### PR TITLE
feat: Effect v4 refactor (foundation)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
-import { connect } from "../lib/db.ts";
+import { Effect } from "effect";
+import { SurrealClient } from "../lib/db.ts";
+import { AppLayer } from "../lib/layers.ts";
 import { ingestSkills } from "../ingest/skills.ts";
 import { ingestTranscripts } from "../ingest/transcripts.ts";
 import { ingestCodex } from "../ingest/codex.ts";
@@ -21,28 +23,31 @@ function flag(name: string, args: string[]): string | undefined {
     return found?.split("=")[1];
 }
 
-async function cmdIngest(args: string[]) {
-    const skillsOnly = args.includes("--skills-only");
-    const transcriptsOnly = args.includes("--transcripts-only");
-    const claudeOnly = args.includes("--claude-only");
-    const codexOnly = args.includes("--codex-only");
-    const sinceDays = flag("since", args)
-        ? parseInt(flag("since", args)!, 10)
-        : undefined;
-    if (!transcriptsOnly && !codexOnly) await ingestSkills();
-    if (!skillsOnly && !codexOnly) await ingestTranscripts({ sinceDays });
-    if (!skillsOnly && !claudeOnly) await ingestCodex({ sinceDays });
-}
+const cmdIngest = (args: string[]) =>
+    Effect.gen(function* () {
+        const skillsOnly = args.includes("--skills-only");
+        const transcriptsOnly = args.includes("--transcripts-only");
+        const claudeOnly = args.includes("--claude-only");
+        const codexOnly = args.includes("--codex-only");
+        const sinceArg = flag("since", args);
+        const sinceDays = sinceArg ? parseInt(sinceArg, 10) : undefined;
+        if (!transcriptsOnly && !codexOnly) yield* ingestSkills();
+        if (!skillsOnly && !codexOnly) yield* ingestTranscripts({ sinceDays });
+        if (!skillsOnly && !claudeOnly) yield* ingestCodex({ sinceDays });
+    });
 
-async function cmdSearch(args: string[]) {
-    const query = args.filter((a) => !a.startsWith("--")).join(" ").toLowerCase();
-    const limit = parseInt(flag("limit", args) ?? "10", 10);
-    if (!query) {
-        console.error("agentctl search: missing query");
-        process.exit(1);
-    }
-    const db = await connect();
-    try {
+const cmdSearch = (args: string[]) =>
+    Effect.gen(function* () {
+        const query = args
+            .filter((a) => !a.startsWith("--"))
+            .join(" ")
+            .toLowerCase();
+        const limit = parseInt(flag("limit", args) ?? "10", 10);
+        if (!query) {
+            console.error("agentctl search: missing query");
+            process.exit(1);
+        }
+        const db = yield* SurrealClient;
         // Lexical contains + recent-use boost
         const sql = `
 SELECT
@@ -60,7 +65,8 @@ WHERE
     OR string::lowercase(description ?? '') CONTAINS $q
 ORDER BY name_match DESC, inv_30d DESC, total_inv DESC
 LIMIT ${limit};`;
-        const [rows] = await db.query<[Array<Record<string, unknown>>]>(sql, { q: query });
+        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql, { q: query });
+        const rows = result?.[0];
         if (!rows || rows.length === 0) {
             console.log("(no matches)");
             return;
@@ -72,19 +78,16 @@ LIMIT ${limit};`;
             console.log(`${r.name}  [${r.scope}]  ${usage}`);
             if (truncDesc) console.log(`  ${truncDesc}`);
         }
-    } finally {
-        await db.close();
-    }
-}
+    });
 
-async function cmdStats(args: string[]) {
-    const name = args.filter((a) => !a.startsWith("--"))[0];
-    if (!name) {
-        console.error("agentctl stats: missing skill name");
-        process.exit(1);
-    }
-    const db = await connect();
-    try {
+const cmdStats = (args: string[]) =>
+    Effect.gen(function* () {
+        const name = args.filter((a) => !a.startsWith("--"))[0];
+        if (!name) {
+            console.error("agentctl stats: missing skill name");
+            process.exit(1);
+        }
+        const db = yield* SurrealClient;
         const sql = `
 LET $s = (SELECT * FROM skill WHERE name = $name)[0];
 RETURN {
@@ -104,35 +107,30 @@ RETURN {
         LIMIT 5
     )
 };`;
-        const result = await db.query<[unknown]>(sql, { name });
-        console.log(JSON.stringify(result[0], null, 2));
-    } finally {
-        await db.close();
-    }
-}
+        const result = yield* db.query<[unknown]>(sql, { name });
+        console.log(JSON.stringify(result?.[0], null, 2));
+    });
 
-async function cmdRecent(args: string[]) {
-    const limit = parseInt(flag("limit", args) ?? "20", 10);
-    const db = await connect();
-    try {
+const cmdRecent = (args: string[]) =>
+    Effect.gen(function* () {
+        const limit = parseInt(flag("limit", args) ?? "20", 10);
+        const db = yield* SurrealClient;
         const sql = `
 SELECT ts, out.name AS skill, in.session.project AS project
 FROM invoked
 ORDER BY ts DESC
 LIMIT ${limit};`;
-        const [rows] = await db.query<[Array<Record<string, unknown>>]>(sql);
+        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
+        const rows = result?.[0];
         for (const r of rows ?? []) {
             console.log(`${r.ts}  ${r.skill}  (${r.project ?? "?"})`);
         }
-    } finally {
-        await db.close();
-    }
-}
+    });
 
-async function cmdUnused(args: string[]) {
-    const days = parseInt(flag("days", args) ?? "7", 10);
-    const db = await connect();
-    try {
+const cmdUnused = (args: string[]) =>
+    Effect.gen(function* () {
+        const days = parseInt(flag("days", args) ?? "7", 10);
+        const db = yield* SurrealClient;
         const sql = `
 SELECT
     name,
@@ -142,22 +140,20 @@ SELECT
 FROM skill
 WHERE array::len((SELECT * FROM <-invoked WHERE ts > time::now() - ${days}d)) = 0
 ORDER BY total_inv ASC, name ASC;`;
-        const [rows] = await db.query<[Array<Record<string, unknown>>]>(sql);
+        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
+        const rows = result?.[0];
         for (const r of rows ?? []) {
             console.log(
                 `${r.name}  [${r.scope}]  total=${r.total_inv ?? 0}  last=${r.last_used ?? "never"}`,
             );
         }
         console.log(`\n${rows?.length ?? 0} skills unused in last ${days} days.`);
-    } finally {
-        await db.close();
-    }
-}
+    });
 
-async function cmdTaste(args: string[]) {
-    const limit = parseInt(flag("limit", args) ?? "30", 10);
-    const db = await connect();
-    try {
+const cmdTaste = (args: string[]) =>
+    Effect.gen(function* () {
+        const limit = parseInt(flag("limit", args) ?? "30", 10);
+        const db = yield* SurrealClient;
         // Composite signal: invocations (positive), errors near invocation (negative),
         // edits-following-invocation in same session (positive - work happened).
         const sql = `
@@ -175,7 +171,8 @@ FROM skill
 WHERE array::len(<-invoked) > 0
 ORDER BY inv_30d DESC, clean_inv DESC, inv_total DESC
 LIMIT ${limit};`;
-        const [rows] = await db.query<[Array<Record<string, unknown>>]>(sql);
+        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
+        const rows = result?.[0];
         console.log(
             `${"skill".padEnd(50)}  ${"scope".padEnd(16)}  7d  30d  total  clean`,
         );
@@ -184,13 +181,12 @@ LIMIT ${limit};`;
                 `${String(r.name).padEnd(50)}  ${String(r.scope).padEnd(16)}  ${String(r.inv_7d).padStart(2)}  ${String(r.inv_30d).padStart(3)}  ${String(r.inv_total).padStart(5)}  ${String(r.clean_inv).padStart(5)}`,
             );
         }
-    } finally {
-        await db.close();
-    }
-}
+    });
 
-async function main() {
-    const [, , cmd, ...rest] = process.argv;
+const dispatch = (
+    cmd: string | undefined,
+    rest: string[],
+): Effect.Effect<void, unknown, SurrealClient> | null => {
     switch (cmd) {
         case "ingest":
             return cmdIngest(rest);
@@ -204,17 +200,26 @@ async function main() {
             return cmdUnused(rest);
         case "taste":
             return cmdTaste(rest);
-        case "help":
-        case "--help":
-        case "-h":
-        case undefined:
-            console.log(HELP);
-            return;
         default:
-            console.error(`agentctl: unknown command "${cmd}"`);
-            console.error(HELP);
-            process.exit(1);
+            return null;
     }
+};
+
+async function main() {
+    const [, , cmd, ...rest] = process.argv;
+    if (cmd === undefined || cmd === "help" || cmd === "--help" || cmd === "-h") {
+        console.log(HELP);
+        return;
+    }
+    const program = dispatch(cmd, rest);
+    if (program === null) {
+        console.error(`agentctl: unknown command "${cmd}"`);
+        console.error(HELP);
+        process.exit(1);
+    }
+    await Effect.runPromise(
+        program.pipe(Effect.provide(AppLayer), Effect.scoped) as Effect.Effect<void>,
+    );
 }
 
 main().catch((err) => {

--- a/src/ingest/codex.ts
+++ b/src/ingest/codex.ts
@@ -1,8 +1,11 @@
 import { readdir, stat, open } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { connect, RecordId } from "../lib/db.ts";
+import { Effect } from "effect";
+import { RecordId, SurrealClient } from "../lib/db.ts";
 import { skillRecordKey } from "../lib/skill-id.ts";
+import { AppLayer } from "../lib/layers.ts";
+import type { DbError } from "../lib/errors.ts";
 
 const CODEX_ROOT = process.env.AGENTCTL_CODEX_DIR ?? join(homedir(), ".codex", "sessions");
 
@@ -62,11 +65,13 @@ async function walkJsonlFiles(root: string, cutoffMs: number): Promise<string[]>
     return out;
 }
 
-async function extractCodexFile(filePath: string): Promise<{
+interface CodexExtract {
     session: CodexSession;
     turns: CodexTurn[];
     invocations: CodexInvocation[];
-} | null> {
+}
+
+async function extractCodexFile(filePath: string): Promise<CodexExtract | null> {
     const fh = await open(filePath, "r");
     let session: CodexSession | null = null;
     const turns: CodexTurn[] = [];
@@ -157,28 +162,32 @@ interface CodexIngestOpts {
     sinceDays: number | undefined;
 }
 
-export async function ingestCodex(
-    opts: Partial<CodexIngestOpts> = {},
-): Promise<{
+export interface CodexStats {
     files: number;
     sessions: number;
     turns: number;
     invocations: number;
-}> {
-    const cutoff = opts.sinceDays ? Date.now() - opts.sinceDays * 86400 * 1000 : 0;
-    const files = await walkJsonlFiles(CODEX_ROOT, cutoff);
-    const db = await connect();
-    let fileCount = 0;
-    let sessionCount = 0;
-    let turnCount = 0;
-    let invCount = 0;
-    try {
+}
+
+export const ingestCodex = (
+    opts: Partial<CodexIngestOpts> = {},
+): Effect.Effect<CodexStats, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const cutoff = opts.sinceDays ? Date.now() - opts.sinceDays * 86400 * 1000 : 0;
+        const files = yield* Effect.promise(() => walkJsonlFiles(CODEX_ROOT, cutoff));
+
+        let fileCount = 0;
+        let sessionCount = 0;
+        let turnCount = 0;
+        let invCount = 0;
+
         for (const filePath of files) {
-            const extracted = await extractCodexFile(filePath);
+            const extracted = yield* Effect.promise(() => extractCodexFile(filePath));
             if (!extracted) continue;
             fileCount += 1;
 
-            await db.upsert(new RecordId("session", extracted.session.id)).content({
+            yield* db.upsert(new RecordId("session", extracted.session.id), {
                 project: extracted.session.cwd,
                 cwd: extracted.session.cwd,
                 model: extracted.session.model_provider,
@@ -194,7 +203,7 @@ export async function ingestCodex(
                     `UPSERT turn:\`${turnRecordKey(t.session, t.seq)}\` CONTENT { session: session:\`${t.session}\`, seq: ${t.seq}, ts: d"${t.ts}", role: ${JSON.stringify(t.role)}, text_excerpt: ${t.text_excerpt === null ? "NONE" : JSON.stringify(t.text_excerpt)}, has_tool_use: ${t.has_tool_use}, has_error: false };`,
             );
             for (let i = 0; i < turnStmts.length; i += 500) {
-                await db.query(turnStmts.slice(i, i + 500).join(""));
+                yield* db.query(turnStmts.slice(i, i + 500).join(""));
             }
             turnCount += extracted.turns.length;
 
@@ -205,7 +214,7 @@ export async function ingestCodex(
                     `UPSERT skill:\`${skillRecordKey(name)}\` MERGE { name: ${JSON.stringify(name)}, scope: "codex-tool", dir_path: "(synthetic)", content_hash: "codex" };`,
             );
             if (skillStmts.length > 0) {
-                await db.query(skillStmts.join(""));
+                yield* db.query(skillStmts.join(""));
             }
 
             const invStmts = extracted.invocations.map(
@@ -213,7 +222,7 @@ export async function ingestCodex(
                     `RELATE turn:\`${turnRecordKey(inv.session, inv.seq)}\`->invoked->skill:\`${skillRecordKey(inv.skill)}\` SET ts = d"${inv.ts}", args = ${JSON.stringify(JSON.stringify(inv.args))};`,
             );
             for (let i = 0; i < invStmts.length; i += 500) {
-                await db.query(invStmts.slice(i, i + 500).join(""));
+                yield* db.query(invStmts.slice(i, i + 500).join(""));
             }
             invCount += extracted.invocations.length;
 
@@ -226,14 +235,21 @@ export async function ingestCodex(
         console.log(
             `[codex] DONE files=${fileCount} sessions=${sessionCount} turns=${turnCount} invocations=${invCount}`,
         );
-        return { files: fileCount, sessions: sessionCount, turns: turnCount, invocations: invCount };
-    } finally {
-        await db.close();
-    }
-}
+        return {
+            files: fileCount,
+            sessions: sessionCount,
+            turns: turnCount,
+            invocations: invCount,
+        };
+    });
 
 if (import.meta.main) {
     const sinceArg = process.argv.find((a) => a.startsWith("--since="));
     const sinceDays = sinceArg ? parseInt(sinceArg.split("=")[1], 10) : undefined;
-    await ingestCodex({ sinceDays });
+    await Effect.runPromise(
+        ingestCodex({ sinceDays }).pipe(
+            Effect.provide(AppLayer),
+            Effect.scoped,
+        ) as Effect.Effect<CodexStats>,
+    );
 }

--- a/src/ingest/skills.ts
+++ b/src/ingest/skills.ts
@@ -2,15 +2,25 @@ import { readFile, readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { parse as parseYaml } from "yaml";
-import { connect, RecordId } from "../lib/db.ts";
+import { Effect } from "effect";
+import { RecordId, SurrealClient } from "../lib/db.ts";
 import { defaultSkillDirs } from "../lib/paths.ts";
 import { skillRecordKey } from "../lib/skill-id.ts";
+import { AppLayer } from "../lib/layers.ts";
+import type { DbError } from "../lib/errors.ts";
 
 interface ParsedSkill {
     name: string;
     description: string | undefined;
     frontmatter: Record<string, unknown>;
     body: string;
+}
+
+interface SkillItem {
+    skill: ParsedSkill;
+    dir_path: string;
+    bytes: number;
+    scope: string;
 }
 
 const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
@@ -48,16 +58,8 @@ function parseSkillFile(content: string, fallbackName: string): ParsedSkill {
     };
 }
 
-async function readSkillDir(
-    dir: string,
-    scope: string,
-): Promise<Array<{ skill: ParsedSkill; dir_path: string; bytes: number; scope: string }>> {
-    const out: Array<{
-        skill: ParsedSkill;
-        dir_path: string;
-        bytes: number;
-        scope: string;
-    }> = [];
+async function readSkillDir(dir: string, scope: string): Promise<SkillItem[]> {
+    const out: SkillItem[] = [];
     let entries: string[];
     try {
         entries = await readdir(dir);
@@ -91,16 +93,9 @@ async function readSkillDir(
     return out;
 }
 
-async function readPluginSkills(): Promise<
-    Array<{ skill: ParsedSkill; dir_path: string; bytes: number; scope: string }>
-> {
+async function readPluginSkills(): Promise<SkillItem[]> {
     const root = join(process.env.HOME!, ".claude", "plugins", "cache");
-    const out: Array<{
-        skill: ParsedSkill;
-        dir_path: string;
-        bytes: number;
-        scope: string;
-    }> = [];
+    const out: SkillItem[] = [];
     let marketplaces: string[];
     try {
         marketplaces = await readdir(root);
@@ -139,9 +134,8 @@ async function readPluginSkills(): Promise<
     return out;
 }
 
-export async function ingestSkills(): Promise<{ count: number }> {
-    const db = await connect();
-    try {
+const collectSkills = (): Effect.Effect<SkillItem[]> =>
+    Effect.promise(async () => {
         const buckets = defaultSkillDirs();
         const fromBaseDirs = (
             await Promise.all(buckets.map(({ dir, scope }) => readSkillDir(dir, scope)))
@@ -150,36 +144,48 @@ export async function ingestSkills(): Promise<{ count: number }> {
         const all = [...fromBaseDirs, ...fromPlugins];
 
         // Dedup by name keeping highest-precedence (user dirs first, plugins last is fine)
-        const byName = new Map<string, (typeof all)[number]>();
+        const byName = new Map<string, SkillItem>();
         for (const item of all) {
             if (!byName.has(item.skill.name)) byName.set(item.skill.name, item);
         }
+        return [...byName.values()];
+    });
 
-        let count = 0;
-        for (const item of byName.values()) {
-            const hash = createHash("sha256")
-                .update(item.skill.body)
-                .digest("hex")
-                .slice(0, 16);
-            const id = new RecordId("skill", skillRecordKey(item.skill.name));
-            await db.upsert(id).content({
-                name: item.skill.name,
-                scope: item.scope,
-                dir_path: item.dir_path,
-                description: item.skill.description ?? null,
-                frontmatter: JSON.stringify(item.skill.frontmatter),
-                content_hash: hash,
-                bytes: item.bytes,
-            });
-            count++;
-        }
+export const ingestSkills = (): Effect.Effect<{ count: number }, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const items = yield* collectSkills();
+
+        yield* Effect.forEach(
+            items,
+            (item) => {
+                const hash = createHash("sha256")
+                    .update(item.skill.body)
+                    .digest("hex")
+                    .slice(0, 16);
+                const id = new RecordId("skill", skillRecordKey(item.skill.name));
+                return db.upsert(id, {
+                    name: item.skill.name,
+                    scope: item.scope,
+                    dir_path: item.dir_path,
+                    description: item.skill.description ?? null,
+                    frontmatter: JSON.stringify(item.skill.frontmatter),
+                    content_hash: hash,
+                    bytes: item.bytes,
+                });
+            },
+            { concurrency: 8, discard: true },
+        );
+
+        const count = items.length;
         console.log(`[skills] upserted ${count}`);
         return { count };
-    } finally {
-        await db.close();
-    }
-}
+    });
 
 if (import.meta.main) {
-    await ingestSkills();
+    await Effect.runPromise(
+        ingestSkills().pipe(Effect.provide(AppLayer), Effect.scoped) as Effect.Effect<
+            { count: number }
+        >,
+    );
 }

--- a/src/ingest/transcripts.ts
+++ b/src/ingest/transcripts.ts
@@ -1,8 +1,11 @@
 import { readdir, stat, open } from "node:fs/promises";
 import { join, basename } from "node:path";
-import { connect, RecordId } from "../lib/db.ts";
+import { Effect } from "effect";
+import { RecordId, SurrealClient } from "../lib/db.ts";
 import { TRANSCRIPTS_DIR } from "../lib/paths.ts";
 import { skillRecordKey } from "../lib/skill-id.ts";
+import { AppLayer } from "../lib/layers.ts";
+import type { DbError } from "../lib/errors.ts";
 
 interface Session {
     id: string;
@@ -187,131 +190,136 @@ async function extractFile(filePath: string, projectDir: string): Promise<FileEx
     return { session, turns, invocations, edits };
 }
 
-async function bulkUpsertSessions(db: Awaited<ReturnType<typeof connect>>, sessions: Session[]) {
-    for (const s of sessions) {
-        const id = new RecordId("session", s.id);
-        await db.upsert(id).content({
-            project: s.project,
-            cwd: s.cwd,
-            started_at: s.started_at ? new Date(s.started_at) : null,
-            ended_at: s.ended_at ? new Date(s.ended_at) : null,
-        });
-    }
-}
-
-async function bulkUpsertTurns(db: Awaited<ReturnType<typeof connect>>, turns: Turn[]) {
-    // Use raw SQL for speed
-    const chunks: string[] = [];
-    for (const t of turns) {
-        const key = turnRecordKey(t.session, t.seq);
-        chunks.push(
-            `UPSERT turn:\`${key}\` CONTENT { session: session:\`${t.session}\`, seq: ${t.seq}, ts: d"${t.ts}", role: "${t.role}", text_excerpt: ${
-                t.text_excerpt === null ? "NONE" : JSON.stringify(t.text_excerpt)
-            }, has_tool_use: ${t.has_tool_use}, has_error: ${t.has_error} };`,
+const upsertSessions = (sessions: Session[]) =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        yield* Effect.forEach(
+            sessions,
+            (s) =>
+                db.upsert(new RecordId("session", s.id), {
+                    project: s.project,
+                    cwd: s.cwd,
+                    started_at: s.started_at ? new Date(s.started_at) : null,
+                    ended_at: s.ended_at ? new Date(s.ended_at) : null,
+                }),
+            { concurrency: 4, discard: true },
         );
-    }
-    if (chunks.length === 0) return;
-    // Send in batches of 500
-    for (let i = 0; i < chunks.length; i += 500) {
-        await db.query(chunks.slice(i, i + 500).join(""));
-    }
-}
+    });
 
-async function bulkRelateInvocations(
-    db: Awaited<ReturnType<typeof connect>>,
-    invocations: Invocation[],
-) {
-    const stmts: string[] = [];
-    for (const inv of invocations) {
-        const turnKey = turnRecordKey(inv.session, inv.seq);
-        const skillKey = skillRecordKey(inv.skill);
-        stmts.push(
-            `RELATE turn:\`${turnKey}\`->invoked->skill:\`${skillKey}\` SET ts = d"${inv.ts}", args = ${JSON.stringify(JSON.stringify(inv.args))};`,
+const upsertTurns = (turns: Turn[]) =>
+    Effect.gen(function* () {
+        if (turns.length === 0) return;
+        const db = yield* SurrealClient;
+        const chunks: string[] = turns.map(
+            (t) =>
+                `UPSERT turn:\`${turnRecordKey(t.session, t.seq)}\` CONTENT { session: session:\`${t.session}\`, seq: ${t.seq}, ts: d"${t.ts}", role: "${t.role}", text_excerpt: ${
+                    t.text_excerpt === null ? "NONE" : JSON.stringify(t.text_excerpt)
+                }, has_tool_use: ${t.has_tool_use}, has_error: ${t.has_error} };`,
         );
-    }
-    for (let i = 0; i < stmts.length; i += 500) {
-        await db.query(stmts.slice(i, i + 500).join(""));
-    }
-}
+        for (let i = 0; i < chunks.length; i += 500) {
+            yield* db.query(chunks.slice(i, i + 500).join(""));
+        }
+    });
 
-async function bulkUpsertEdits(db: Awaited<ReturnType<typeof connect>>, edits: Edit[]) {
-    const fileStmts: string[] = [];
-    const relStmts: string[] = [];
-    const seenFiles = new Set<string>();
-    for (const e of edits) {
-        const fileKey = fileRecordKey(e.repo, e.path);
-        if (!seenFiles.has(fileKey)) {
-            seenFiles.add(fileKey);
-            fileStmts.push(
-                `UPSERT file:\`${fileKey}\` CONTENT { repo: ${e.repo === null ? "NONE" : JSON.stringify(e.repo)}, path: ${JSON.stringify(e.path)} };`,
+const relateInvocations = (invocations: Invocation[]) =>
+    Effect.gen(function* () {
+        if (invocations.length === 0) return;
+        const db = yield* SurrealClient;
+        const stmts = invocations.map(
+            (inv) =>
+                `RELATE turn:\`${turnRecordKey(inv.session, inv.seq)}\`->invoked->skill:\`${skillRecordKey(inv.skill)}\` SET ts = d"${inv.ts}", args = ${JSON.stringify(JSON.stringify(inv.args))};`,
+        );
+        for (let i = 0; i < stmts.length; i += 500) {
+            yield* db.query(stmts.slice(i, i + 500).join(""));
+        }
+    });
+
+const upsertEdits = (edits: Edit[]) =>
+    Effect.gen(function* () {
+        if (edits.length === 0) return;
+        const db = yield* SurrealClient;
+        const fileStmts: string[] = [];
+        const relStmts: string[] = [];
+        const seenFiles = new Set<string>();
+        for (const e of edits) {
+            const fileKey = fileRecordKey(e.repo, e.path);
+            if (!seenFiles.has(fileKey)) {
+                seenFiles.add(fileKey);
+                fileStmts.push(
+                    `UPSERT file:\`${fileKey}\` CONTENT { repo: ${e.repo === null ? "NONE" : JSON.stringify(e.repo)}, path: ${JSON.stringify(e.path)} };`,
+                );
+            }
+            const turnKey = turnRecordKey(e.session, e.seq);
+            relStmts.push(
+                `RELATE turn:\`${turnKey}\`->edited->file:\`${fileKey}\` SET tool = "${e.tool}", ts = d"${e.ts}";`,
             );
         }
-        const turnKey = turnRecordKey(e.session, e.seq);
-        relStmts.push(
-            `RELATE turn:\`${turnKey}\`->edited->file:\`${fileKey}\` SET tool = "${e.tool}", ts = d"${e.ts}";`,
-        );
-    }
-    for (let i = 0; i < fileStmts.length; i += 500) {
-        await db.query(fileStmts.slice(i, i + 500).join(""));
-    }
-    for (let i = 0; i < relStmts.length; i += 500) {
-        await db.query(relStmts.slice(i, i + 500).join(""));
-    }
-}
+        for (let i = 0; i < fileStmts.length; i += 500) {
+            yield* db.query(fileStmts.slice(i, i + 500).join(""));
+        }
+        for (let i = 0; i < relStmts.length; i += 500) {
+            yield* db.query(relStmts.slice(i, i + 500).join(""));
+        }
+    });
 
 interface IngestOpts {
     sinceDays: number | undefined;
     project: string | undefined;
 }
 
-export async function ingestTranscripts(
-    opts: Partial<IngestOpts> = {},
-): Promise<{
+export interface TranscriptStats {
     files: number;
     sessions: number;
     turns: number;
     invocations: number;
     edits: number;
-}> {
-    const cutoff = opts.sinceDays
-        ? Date.now() - opts.sinceDays * 86400 * 1000
-        : 0;
-    const projectDirs = (await readdir(TRANSCRIPTS_DIR)).filter(
-        (d) => !opts.project || d === opts.project,
-    );
+}
 
-    const db = await connect();
-    let files = 0;
-    let sessions = 0;
-    let turnCount = 0;
-    let invCount = 0;
-    let editCount = 0;
-    try {
+export const ingestTranscripts = (
+    opts: Partial<IngestOpts> = {},
+): Effect.Effect<TranscriptStats, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const cutoff = opts.sinceDays
+            ? Date.now() - opts.sinceDays * 86400 * 1000
+            : 0;
+        const projectDirs = (yield* Effect.promise(() => readdir(TRANSCRIPTS_DIR))).filter(
+            (d) => !opts.project || d === opts.project,
+        );
+
+        let files = 0;
+        let sessions = 0;
+        let turnCount = 0;
+        let invCount = 0;
+        let editCount = 0;
+
         for (const projectDir of projectDirs) {
             const fullProject = join(TRANSCRIPTS_DIR, projectDir);
-            let entries: string[];
-            try {
-                entries = await readdir(fullProject);
-            } catch {
-                continue;
-            }
+            const entries = yield* Effect.promise(async () => {
+                try {
+                    return await readdir(fullProject);
+                } catch {
+                    return [] as string[];
+                }
+            });
             for (const entry of entries) {
                 if (!entry.endsWith(".jsonl")) continue;
                 const filePath = join(fullProject, entry);
                 if (cutoff > 0) {
-                    const st = await stat(filePath);
+                    const st = yield* Effect.promise(() => stat(filePath));
                     if (st.mtimeMs < cutoff) continue;
                 }
-                const extracted = await extractFile(filePath, projectDir);
+                const extracted = yield* Effect.promise(() =>
+                    extractFile(filePath, projectDir),
+                );
                 if (!extracted) continue;
                 files += 1;
-                await bulkUpsertSessions(db, [extracted.session]);
+                yield* upsertSessions([extracted.session]);
                 sessions += 1;
-                await bulkUpsertTurns(db, extracted.turns);
+                yield* upsertTurns(extracted.turns);
                 turnCount += extracted.turns.length;
-                await bulkRelateInvocations(db, extracted.invocations);
+                yield* relateInvocations(extracted.invocations);
                 invCount += extracted.invocations.length;
-                await bulkUpsertEdits(db, extracted.edits);
+                yield* upsertEdits(extracted.edits);
                 editCount += extracted.edits.length;
                 if (files % 50 === 0) {
                     console.log(
@@ -324,13 +332,15 @@ export async function ingestTranscripts(
             `[transcripts] DONE files=${files} sessions=${sessions} turns=${turnCount} invocations=${invCount} edits=${editCount}`,
         );
         return { files, sessions, turns: turnCount, invocations: invCount, edits: editCount };
-    } finally {
-        await db.close();
-    }
-}
+    });
 
 if (import.meta.main) {
     const sinceArg = process.argv.find((a) => a.startsWith("--since="));
     const sinceDays = sinceArg ? parseInt(sinceArg.split("=")[1], 10) : undefined;
-    await ingestTranscripts({ sinceDays });
+    await Effect.runPromise(
+        ingestTranscripts({ sinceDays }).pipe(
+            Effect.provide(AppLayer),
+            Effect.scoped,
+        ) as Effect.Effect<TranscriptStats>,
+    );
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,12 @@
-import { Surreal, RecordId, surql } from "surrealdb";
+import {
+    Surreal,
+    RecordId,
+    surql,
+    type AnyRecordId,
+    type Table,
+} from "surrealdb";
+import { Context, Effect, Layer } from "effect";
+import { DbError } from "./errors.ts";
 
 export interface DbConfig {
     url: string;
@@ -18,12 +26,132 @@ export function envConfig(): DbConfig {
     };
 }
 
-export async function connect(cfg: DbConfig = envConfig()): Promise<Surreal> {
-    const db = new Surreal();
-    await db.connect(cfg.url);
-    await db.signin({ username: cfg.user, password: cfg.pass });
-    await db.use({ namespace: cfg.ns, database: cfg.db });
-    return db;
+const sqlExcerpt = (sql: unknown): string | undefined => {
+    if (typeof sql !== "string") return undefined;
+    return sql.length > 200 ? `${sql.slice(0, 200)}…` : sql;
+};
+
+const errorMessage = (err: unknown): string =>
+    err instanceof Error ? err.message : String(err);
+
+/**
+ * Effect-friendly wrapper around the SurrealDB client. Acquired as a Layer so
+ * the underlying connection lifecycle (connect/signin/use → close) is tied to
+ * the surrounding scope.
+ */
+export interface SurrealClientShape {
+    /** Run a raw SurrealQL statement. Returns the array result tuple as-is. */
+    readonly query: <T extends unknown[] = unknown[]>(
+        sql: string,
+        bindings?: Record<string, unknown>,
+    ) => Effect.Effect<T, DbError>;
+
+    /** Upsert a record by id with the given content. */
+    readonly upsert: (
+        id: RecordId,
+        content: Record<string, unknown>,
+    ) => Effect.Effect<unknown, DbError>;
+
+    /** Relate two records via an edge table. */
+    readonly relate: (
+        from: AnyRecordId,
+        edge: Table | RecordId,
+        to: AnyRecordId,
+        data?: Record<string, unknown>,
+    ) => Effect.Effect<unknown, DbError>;
+
+    /** Escape hatch for the raw client when callers need methods we don't wrap. */
+    readonly raw: Surreal;
 }
+
+export class SurrealClient extends Context.Service<
+    SurrealClient,
+    SurrealClientShape
+>()("agentctl/SurrealClient") {}
+
+const acquire = (cfg: DbConfig): Effect.Effect<Surreal, DbError> =>
+    Effect.tryPromise({
+        try: async () => {
+            const db = new Surreal();
+            await db.connect(cfg.url);
+            await db.signin({ username: cfg.user, password: cfg.pass });
+            await db.use({ namespace: cfg.ns, database: cfg.db });
+            return db;
+        },
+        catch: (err) =>
+            new DbError({
+                operation: "connect",
+                message: errorMessage(err),
+            }),
+    });
+
+const release = (db: Surreal): Effect.Effect<void> =>
+    Effect.promise(async () => {
+        try {
+            await db.close();
+        } catch {
+            // best effort
+        }
+    });
+
+const wrap = (db: Surreal): SurrealClientShape => ({
+    query: <T extends unknown[] = unknown[]>(
+        sql: string,
+        bindings?: Record<string, unknown>,
+    ) =>
+        Effect.tryPromise({
+            try: () => db.query<T>(sql, bindings) as Promise<T>,
+            catch: (err) =>
+                new DbError({
+                    operation: "query",
+                    message: errorMessage(err),
+                    sql: sqlExcerpt(sql),
+                }),
+        }),
+
+    upsert: (id: RecordId, content: Record<string, unknown>) =>
+        Effect.tryPromise({
+            try: () => db.upsert(id).content(content) as unknown as Promise<unknown>,
+            catch: (err) =>
+                new DbError({
+                    operation: "upsert",
+                    message: errorMessage(err),
+                    sql: id.toString(),
+                }),
+        }),
+
+    relate: (
+        from: AnyRecordId,
+        edge: Table | RecordId,
+        to: AnyRecordId,
+        data?: Record<string, unknown>,
+    ) =>
+        Effect.tryPromise({
+            try: () =>
+                (data === undefined
+                    ? db.relate(from, edge, to)
+                    : db.relate(from, edge, to, data)) as unknown as Promise<unknown>,
+            catch: (err) =>
+                new DbError({
+                    operation: "relate",
+                    message: errorMessage(err),
+                }),
+        }),
+
+    raw: db,
+});
+
+/**
+ * Layer that connects to SurrealDB on acquisition, exposes a `SurrealClient`
+ * service, and closes the underlying connection on scope close.
+ */
+export const SurrealClientLive: Layer.Layer<SurrealClient, DbError> =
+    Layer.effect(SurrealClient)(
+        Effect.gen(function* () {
+            const cfg = envConfig();
+            const db = yield* Effect.acquireRelease(acquire(cfg), release);
+            return wrap(db);
+        }),
+    );
 
 export { RecordId, surql };

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,34 @@
+import { Schema } from "effect";
+
+/**
+ * Frontmatter parse failure for a SKILL.md file.
+ */
+export class SkillParseError extends Schema.TaggedErrorClass<SkillParseError>(
+    "SkillParseError",
+)("SkillParseError", {
+    file: Schema.String,
+    reason: Schema.String,
+}) {}
+
+/**
+ * SurrealDB query / upsert / relate failure. `sql` is a short excerpt for
+ * debugging; `message` carries the original error string.
+ */
+export class DbError extends Schema.TaggedErrorClass<DbError>("DbError")(
+    "DbError",
+    {
+        operation: Schema.String,
+        message: Schema.String,
+        sql: Schema.optional(Schema.String),
+    },
+) {}
+
+/**
+ * jsonl line parse failure inside a transcript file.
+ */
+export class TranscriptCorruptedError extends Schema.TaggedErrorClass<TranscriptCorruptedError>(
+    "TranscriptCorruptedError",
+)("TranscriptCorruptedError", {
+    file: Schema.String,
+    reason: Schema.String,
+}) {}

--- a/src/lib/layers.ts
+++ b/src/lib/layers.ts
@@ -1,0 +1,8 @@
+import { Layer } from "effect";
+import { SurrealClientLive } from "./db.ts";
+
+/**
+ * Composed application layer. Currently only the SurrealDB client; future
+ * services (config, logger, file system) merge in here.
+ */
+export const AppLayer = Layer.mergeAll(SurrealClientLive);


### PR DESCRIPTION
Refs #1.

## Summary

Refactor the ingest pipelines and CLI to idiomatic Effect v4 beta. External behavior unchanged: same CLI flags, output format, ingest stats, raw SurrealQL statements, and SurrealDB schema (untouched per scope).

## What changed

- **`src/lib/db.ts`** — `SurrealClient` is now a `Context.Service` with `query` / `upsert` / `relate` methods (plus a `raw` escape hatch). Connection lifecycle (`connect` → `signin` → `use` → `close`) is wrapped in `Layer.effect` via `Effect.acquireRelease`, so closing the scope closes the socket. The bare `connect()` helper is gone; `envConfig()` stays as the source of `DbConfig`.
- **`src/lib/errors.ts`** (new) — typed errors via `Schema.TaggedErrorClass`:
  - `SkillParseError { file, reason }`
  - `DbError { operation, message, sql? }` — carries operation kind plus a short SQL excerpt for query / upsert / relate failures
  - `TranscriptCorruptedError { file, reason }`
- **`src/lib/layers.ts`** (new) — `AppLayer = Layer.mergeAll(SurrealClientLive)` for future expansion.
- **`src/ingest/{skills,transcripts,codex}.ts`** — each pipeline now returns `Effect.Effect<Stats, DbError, SurrealClient>` instead of `Promise`. Sequential work uses `Effect.gen`; the skill upsert batch uses `Effect.forEach({ concurrency: 8, discard: true })`. The bulk-SQL chunked upserts in transcripts/codex are preserved verbatim through `db.query` to keep the same wire behavior.
- **`src/cli/index.ts`** — keeps hand-rolled argv parsing (no `@effect/cli` — it has no v4 build). Each command body is an `Effect.gen`; `main()` dispatches and runs via `Effect.runPromise(program.pipe(Effect.provide(AppLayer), Effect.scoped))`. CLI output is identical.

No `@effect/cli` or `@effect/platform` added (no v4 builds yet). No SurrealDB schema bump (Issue #2's territory).

## Verification

- `bun run typecheck` — passes (exit 0). Three remaining `message TS44` lines are advisory `effect(preferSchemaOverJson)` hints from the language-service plugin; they fire on legacy `JSON.parse`/`JSON.stringify` paths that already existed and aren't errors.
- `bun src/ingest/skills.ts` — ingested 126 skills.
- `bun src/cli/index.ts ingest --skills-only` — same.
- `bun src/cli/index.ts ingest --codex-only --since=1` — ingested 41 codex sessions / 6980 turns / 2433 invocations.
- `bun src/cli/index.ts search effect --limit=3` — returns expected ranked rows.
- `bun src/cli/index.ts ingest --transcripts-only --since=1` — fails with a pre-existing schema mismatch (`session.source` expects `string` but is `NONE`). Verified the same error reproduces on `main` before the refactor; not introduced here. Issue #2 owns the schema work.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun src/cli/index.ts ingest --skills-only` runs and reports `[skills] upserted N`
- [x] `bun src/cli/index.ts ingest --codex-only --since=1` runs and reports stats
- [x] `bun src/cli/index.ts search <q>` returns rows
- [ ] (deferred to #2) `--transcripts-only` once `session.source` schema mismatch is fixed