### PR TITLE
feat: launchd WatchPaths plist for incremental ingest (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,41 @@ agentctl ingest [--since=DAYS]      # refresh (skills + transcripts + codex)
 Three layers, no daemon:
 
 1. **Stop hook** (`~/.claude/settings.json`) fires `agentctl ingest --since=1` after every Claude Code session ends.
-2. **launchd WatchPaths** (planned) - fallback for non-Claude tools writing into `~/.claude/projects/` or `~/.codex/sessions/`.
+2. **launchd WatchPaths** (macOS) - fallback for non-Claude tools writing into `~/.claude/projects/` or `~/.codex/sessions/`.
 3. **Weekly cron** via your existing self-improve runs full ingest as deep-scan backfill.
 
 Stop hook is enough for ~99% of cases. The other two are insurance.
+
+### launchd watcher (macOS)
+
+Belt-and-suspenders fallback to the Stop hook. A `LaunchAgent` watches
+`~/.claude/projects/` and `~/.codex/sessions/`; whenever those paths change
+it runs `agentctl ingest --since=1`. `ThrottleInterval=60` coalesces bursts
+so a flurry of writes triggers a single ingest at most once per minute.
+
+```bash
+bun run watcher:install      # renders + loads ~/Library/LaunchAgents/com.necmttn.agentctl-watch.plist
+bun run watcher:uninstall    # unloads + removes it
+```
+
+What `watcher:install` does:
+
+- renders `scripts/com.necmttn.agentctl-watch.plist` (a template) into
+  `~/Library/LaunchAgents/com.necmttn.agentctl-watch.plist`, substituting
+  absolute paths for `$HOME`, the repo, and the log dir
+- `launchctl unload`s any previous version (idempotent)
+- `launchctl load -w`s the fresh plist
+
+Logs land in `~/.local/share/agentctl/logs/`:
+
+- `watcher.log` - stdout/stderr of each `bun ... ingest --since=1` invocation
+- `watcher.out` / `watcher.err` - launchd's own pipes
+
+Verify it's loaded:
+
+```bash
+launchctl list | grep com.necmttn.agentctl-watch
+```
 
 ## Schema
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "db:start": "scripts/db-start.sh",
     "db:stop": "scripts/db-stop.sh",
     "db:schema": "scripts/apply-schema.sh",
-    "refs:setup": "scripts/setup-references.sh"
+    "refs:setup": "scripts/setup-references.sh",
+    "watcher:install": "bash scripts/install-watcher.sh",
+    "watcher:uninstall": "bash scripts/uninstall-watcher.sh"
   },
   "dependencies": {
     "effect": "^4.0.0-beta.64",

--- a/scripts/com.necmttn.agentctl-watch.plist
+++ b/scripts/com.necmttn.agentctl-watch.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.necmttn.agentctl-watch</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>cd __AGENTCTL_DIR__ &amp;&amp; bun src/cli/index.ts ingest --since=1 &gt;&gt;__LOG_DIR__/watcher.log 2&gt;&amp;1</string>
+  </array>
+  <key>WatchPaths</key>
+  <array>
+    <string>__HOME__/.claude/projects</string>
+    <string>__HOME__/.codex/sessions</string>
+  </array>
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>__LOG_DIR__/watcher.out</string>
+  <key>StandardErrorPath</key>
+  <string>__LOG_DIR__/watcher.err</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+</dict>
+</plist>

--- a/scripts/install-watcher.sh
+++ b/scripts/install-watcher.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install the launchd WatchPaths agent that runs `agentctl ingest --since=1`
+# whenever ~/.claude/projects/ or ~/.codex/sessions/ change. macOS only.
+#
+# Idempotent: unloads any existing agent before reloading.
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "install-watcher.sh: macOS only (launchd). Detected: $(uname -s)" >&2
+  exit 1
+fi
+
+LABEL="com.necmttn.agentctl-watch"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$SCRIPT_DIR/$LABEL.plist"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+TARGET="$LAUNCH_AGENTS_DIR/$LABEL.plist"
+LOG_DIR="$HOME/.local/share/agentctl/logs"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "install-watcher.sh: template not found: $TEMPLATE" >&2
+  exit 1
+fi
+
+mkdir -p "$LAUNCH_AGENTS_DIR" "$LOG_DIR"
+
+# Render template (substitute __HOME__, __AGENTCTL_DIR__, __LOG_DIR__).
+sed \
+  -e "s|__HOME__|$HOME|g" \
+  -e "s|__AGENTCTL_DIR__|$REPO_DIR|g" \
+  -e "s|__LOG_DIR__|$LOG_DIR|g" \
+  "$TEMPLATE" > "$TARGET"
+
+# Unload first if already loaded (idempotent reload).
+if launchctl list | grep -q "$LABEL"; then
+  echo "Unloading existing $LABEL..."
+  launchctl unload -w "$TARGET" 2>/dev/null || true
+fi
+
+echo "Loading $LABEL from $TARGET..."
+launchctl load -w "$TARGET"
+
+echo
+echo "Installed: $TARGET"
+echo "Logs:      $LOG_DIR/{watcher.log,watcher.out,watcher.err}"
+echo "Verify:    launchctl list | grep $LABEL"
+echo "Uninstall: bash $SCRIPT_DIR/uninstall-watcher.sh"

--- a/scripts/uninstall-watcher.sh
+++ b/scripts/uninstall-watcher.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Uninstall the agentctl launchd WatchPaths agent.
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "uninstall-watcher.sh: macOS only (launchd). Detected: $(uname -s)" >&2
+  exit 1
+fi
+
+LABEL="com.necmttn.agentctl-watch"
+TARGET="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+if launchctl list | grep -q "$LABEL"; then
+  echo "Unloading $LABEL..."
+  launchctl unload -w "$TARGET" 2>/dev/null || true
+fi
+
+if [[ -f "$TARGET" ]]; then
+  rm -f "$TARGET"
+  echo "Removed: $TARGET"
+else
+  echo "No plist at $TARGET (already uninstalled)."
+fi


### PR DESCRIPTION
Closes #6

## What

Belt-and-suspenders fallback to the existing Stop hook. macOS LaunchAgent watches `~/.claude/projects/` + `~/.codex/sessions/` and runs `agentctl ingest --since=1` on path changes. `ThrottleInterval=60` coalesces bursts to at most one ingest per minute.

## Files

- `scripts/com.necmttn.agentctl-watch.plist` — plist template with `__HOME__`, `__AGENTCTL_DIR__`, `__LOG_DIR__` placeholders
- `scripts/install-watcher.sh` — renders template into `~/Library/LaunchAgents/`, idempotent (`launchctl unload` then `load -w`)
- `scripts/uninstall-watcher.sh` — unloads + removes the plist
- `package.json` — `watcher:install` / `watcher:uninstall` npm scripts
- `README.md` — install/uninstall + verification section

Pure infra additions. No changes to `src/`, `schema/`, `db-*.sh`, `setup-references.sh`, or `apply-schema.sh`.

## Verification

- `bun run typecheck` passes (only pre-existing message-level warnings, no errors)
- `bash -n` clean on both shell scripts
- Rendered plist preview verified (paths interpolate correctly, ProgramArguments + WatchPaths + ThrottleInterval=60 + RunAtLoad=false + log paths under `~/.local/share/agentctl/logs/`)

## Install

```bash
bun run watcher:install      # render + load
bun run watcher:uninstall    # unload + remove
launchctl list | grep com.necmttn.agentctl-watch   # verify
```

Logs land at `~/.local/share/agentctl/logs/{watcher.log,watcher.out,watcher.err}`.