### PR TITLE
feat: body column on skill (#2)

### DIFF
--- a/schema/schema.surql
+++ b/schema/schema.surql
@@ -13,6 +13,7 @@ DEFINE FIELD scope          ON skill TYPE string;          -- 'user' | 'project'
 DEFINE FIELD dir_path       ON skill TYPE string;
 DEFINE FIELD description    ON skill TYPE option<string>;
 DEFINE FIELD frontmatter    ON skill TYPE option<string>;   -- JSON-encoded
+DEFINE FIELD body           ON skill TYPE option<string>;   -- SKILL.md body content (post-frontmatter), powers FTS + TUI preview
 DEFINE FIELD content_hash   ON skill TYPE string;
 DEFINE FIELD bytes          ON skill TYPE option<int>;
 DEFINE FIELD ingested_at    ON skill TYPE datetime VALUE time::now();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -107,8 +107,22 @@ RETURN {
         LIMIT 5
     )
 };`;
-        const result = yield* db.query<[unknown]>(sql, { name });
-        console.log(JSON.stringify(result?.[0], null, 2));
+        const result = yield* db.query<unknown[]>(sql, { name });
+        // SurrealDB returns one entry per statement; the LET yields null,
+        // the RETURN yields the payload. Pick the last non-null result.
+        const payload = (Array.isArray(result)
+            ? [...result].reverse().find((r) => r != null)
+            : result) as
+            | { skill?: { body?: string | null } | null }
+            | undefined;
+        const body = payload?.skill?.body;
+        if (typeof body === "string" && body.length > 0) {
+            const excerpt = body.length > 500 ? body.slice(0, 500) + "…" : body;
+            console.log("--- body excerpt ---");
+            console.log(excerpt);
+            console.log("--- end body ---\n");
+        }
+        console.log(JSON.stringify(payload, null, 2));
     });
 
 const cmdRecent = (args: string[]) =>

--- a/src/ingest/skills.ts
+++ b/src/ingest/skills.ts
@@ -170,6 +170,7 @@ export const ingestSkills = (): Effect.Effect<{ count: number }, DbError, Surrea
                     dir_path: item.dir_path,
                     description: item.skill.description ?? null,
                     frontmatter: JSON.stringify(item.skill.frontmatter),
+                    body: item.skill.body,
                     content_hash: hash,
                     bytes: item.bytes,
                 });


### PR DESCRIPTION
Closes #2

## Summary
- Add `DEFINE FIELD body ON skill TYPE option<string>` to `schema/schema.surql`
- Skills ingest now stores the SKILL.md body (post-frontmatter) on each upsert
- `agentctl stats <skill>` prints first 500 chars of body when present, then the JSON payload
- Drive-by fix: `cmdStats` was reading `result[0]` (the LET null result) instead of the RETURN payload; now picks the last non-null statement result

## Test plan
- [x] `bun run typecheck` passes (only pre-existing info-level diagnostics for JSON.stringify)
- [x] `bash scripts/apply-schema.sh` applies cleanly to local SurrealDB
- [x] `bun src/cli/index.ts ingest --skills-only` upserts 126 skills
- [x] `bun src/cli/index.ts stats <skill>` shows body excerpt + invocation stats