### PR TITLE
feat: self-improve weekly ingest + deprecate hook (#7)

### DIFF
--- a/integrations/self-improve/README.md
+++ b/integrations/self-improve/README.md
@@ -1,0 +1,88 @@
+# self-improve integration
+
+Hooks for `~/.claude/self-improve/` (the user's weekly skill self-improvement
+pipeline) that consume `agentctl`'s telemetry DB.
+
+Two scripts:
+
+- **`agentctl-ingest.ts`** - runs `agentctl ingest --since=14` to refresh the
+  SurrealDB. Logs to `<RUN_DIR>/agentctl-ingest.log`. Designed to slot into
+  `run.sh` as the `agentctl-ingest` step, immediately before `extract`.
+
+- **`deprecate-helper.ts`** - runs `agentctl unused --days=90`, parses its
+  output, filters out anything in `~/.claude/self-improve/keep.txt`, and writes
+  `<RUN_DIR>/deprecation-candidates.json`. Intended to be called from the
+  `deprecate` step (or run on demand).
+
+Both scripts are **graceful**: if `agentctl` isn't on `PATH`, they write a
+"skipped" / "unavailable" record and exit 0, so an absent `agentctl` won't
+break the self-improve cron.
+
+## Install
+
+The self-improve runner expects step scripts at `~/.claude/self-improve/lib/`.
+Symlink or copy these scripts in:
+
+```bash
+SELF_IMPROVE_HOME="$HOME/.claude/self-improve"
+AGENTCTL_REPO="$HOME/Projects/agentctl"
+
+# Symlink the ingest step (preferred - picks up upstream fixes automatically)
+ln -sf "$AGENTCTL_REPO/integrations/self-improve/agentctl-ingest.ts" \
+       "$SELF_IMPROVE_HOME/lib/agentctl-ingest.ts"
+
+# deprecate-helper is invoked by lib/deprecate.ts; symlink alongside lib/
+ln -sf "$AGENTCTL_REPO/integrations/self-improve/deprecate-helper.ts" \
+       "$SELF_IMPROVE_HOME/lib/agentctl-deprecate-helper.ts"
+```
+
+Then add the step to `run.sh` immediately before `extract`:
+
+```bash
+run_step agentctl-ingest
+print_budget
+run_step extract
+# ...
+```
+
+The `deprecate` step should call the helper and merge its output with the
+existing `deprecations.json`. See `lib/deprecate.ts` in the self-improve repo.
+
+## Configuration
+
+Environment variables read by `agentctl-ingest.ts`:
+
+| Var                              | Default | Meaning                          |
+| -------------------------------- | ------- | -------------------------------- |
+| `AGENTCTL_INGEST_SINCE_DAYS`     | `14`    | Days back for `--since=N`        |
+
+`deprecate-helper.ts` accepts `--days=N` (default `90`).
+
+## Output schemas
+
+### `<RUN_DIR>/agentctl-ingest.log`
+
+Plain text; combined stdout/stderr of `agentctl ingest`, prefixed with
+`[agentctl-ingest]` lifecycle markers.
+
+### `<RUN_DIR>/deprecation-candidates.json`
+
+```json
+{
+  "generated_at": "2026-05-08T12:00:00.000Z",
+  "days": 90,
+  "source": "agentctl",
+  "candidates": [
+    {
+      "slug": "old-skill-name",
+      "scope": "project",
+      "total_invocations": 3,
+      "last_used": "2025-11-15T03:21:55.000Z"
+    }
+  ],
+  "kept": ["protected-skill"]
+}
+```
+
+When `agentctl` is missing, `source` is `"unavailable"` and both arrays are
+empty.

--- a/integrations/self-improve/agentctl-ingest.ts
+++ b/integrations/self-improve/agentctl-ingest.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+/**
+ * agentctl-ingest step for ~/.claude/self-improve/ pipeline.
+ *
+ * Refreshes the agentctl SurrealDB by running `agentctl ingest --since=14`
+ * (14 days = past 2 weeks for safety / catching any missed runs).
+ *
+ * Usage from run.sh:
+ *   bun lib/agentctl-ingest.ts <RUN_DIR> <HOME_DIR>
+ *
+ * Behavior:
+ * - Logs progress to <RUN_DIR>/agentctl-ingest.log
+ * - Exits 0 if `agentctl` is not on PATH (graceful fallback - integration is optional)
+ * - Exits 0 on successful ingest
+ * - Exits non-zero only if `agentctl` exists AND fails
+ */
+
+import { spawn } from "node:child_process";
+import { mkdir, writeFile, appendFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const SINCE_DAYS = Number(process.env.AGENTCTL_INGEST_SINCE_DAYS ?? 14);
+
+async function which(cmd: string): Promise<string | null> {
+    return new Promise((resolve) => {
+        const child = spawn("which", [cmd], { stdio: ["ignore", "pipe", "ignore"] });
+        let out = "";
+        child.stdout.on("data", (d) => { out += d.toString(); });
+        child.on("close", (code) => {
+            if (code === 0 && out.trim()) resolve(out.trim());
+            else resolve(null);
+        });
+        child.on("error", () => resolve(null));
+    });
+}
+
+async function runIngest(logPath: string, agentctlPath: string): Promise<number> {
+    return new Promise((resolve) => {
+        const child = spawn(agentctlPath, ["ingest", `--since=${SINCE_DAYS}`], {
+            stdio: ["ignore", "pipe", "pipe"],
+            env: process.env,
+        });
+        const tee = async (chunk: Buffer) => {
+            const s = chunk.toString();
+            process.stdout.write(s);
+            await appendFile(logPath, s);
+        };
+        child.stdout.on("data", tee);
+        child.stderr.on("data", tee);
+        child.on("close", (code) => resolve(code ?? 1));
+        child.on("error", async (err) => {
+            await appendFile(logPath, `\n[error] ${err.message}\n`);
+            resolve(1);
+        });
+    });
+}
+
+async function main(): Promise<void> {
+    const [, , runDirArg] = process.argv;
+    if (!runDirArg) {
+        console.error("usage: bun agentctl-ingest.ts <runDir> [homeDir]");
+        process.exit(2);
+    }
+    await mkdir(runDirArg, { recursive: true });
+    const logPath = join(runDirArg, "agentctl-ingest.log");
+
+    const startedAt = new Date().toISOString();
+    await writeFile(logPath, `[agentctl-ingest] started_at=${startedAt} since_days=${SINCE_DAYS}\n`);
+
+    const agentctlPath = await which("agentctl");
+    if (!agentctlPath) {
+        const msg = "[agentctl-ingest] 'agentctl' not on PATH; skipping (integration is optional)\n";
+        await appendFile(logPath, msg);
+        console.log(msg.trim());
+        process.exit(0);
+    }
+    await appendFile(logPath, `[agentctl-ingest] using ${agentctlPath}\n`);
+
+    const code = await runIngest(logPath, agentctlPath);
+    const finishedAt = new Date().toISOString();
+    await appendFile(logPath, `\n[agentctl-ingest] finished_at=${finishedAt} exit_code=${code}\n`);
+
+    if (code !== 0) {
+        console.error(`[agentctl-ingest] failed with exit code ${code}; see ${logPath}`);
+        process.exit(code);
+    }
+    console.log(`[agentctl-ingest] done; log at ${logPath}`);
+}
+
+if (import.meta.main) {
+    await main();
+}

--- a/integrations/self-improve/deprecate-helper.ts
+++ b/integrations/self-improve/deprecate-helper.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env bun
+/**
+ * Deprecation candidate generator for ~/.claude/self-improve/ pipeline.
+ *
+ * Calls `agentctl unused --days=90`, parses the human-readable output, then
+ * cross-references against ~/.claude/self-improve/keep.txt to filter the
+ * always-keep list out. Writes structured JSON to:
+ *   <RUN_DIR>/deprecation-candidates.json
+ *
+ * Usage:
+ *   bun deprecate-helper.ts <RUN_DIR> <HOME_DIR> [--days=90]
+ *
+ * Output schema:
+ *   {
+ *     generated_at: string (ISO),
+ *     days: number,
+ *     source: "agentctl",
+ *     candidates: Array<{ slug: string; scope: string; total_invocations: number; last_used: string | null }>,
+ *     kept: string[]   // slugs that would be candidates but are protected by keep.txt
+ *   }
+ *
+ * Graceful fallback: if `agentctl` is not on PATH, writes an empty result
+ * with source: "unavailable" and exits 0.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+interface Candidate {
+    slug: string;
+    scope: string;
+    total_invocations: number;
+    last_used: string | null;
+}
+
+interface Result {
+    generated_at: string;
+    days: number;
+    source: "agentctl" | "unavailable";
+    candidates: Candidate[];
+    kept: string[];
+}
+
+function parseFlag(name: string, args: string[], fallback: string): string {
+    const found = args.find((a) => a.startsWith(`--${name}=`));
+    if (!found) return fallback;
+    return found.slice(name.length + 3);
+}
+
+async function which(cmd: string): Promise<string | null> {
+    return new Promise((resolve) => {
+        const child = spawn("which", [cmd], { stdio: ["ignore", "pipe", "ignore"] });
+        let out = "";
+        child.stdout.on("data", (d) => { out += d.toString(); });
+        child.on("close", (code) => {
+            if (code === 0 && out.trim()) resolve(out.trim());
+            else resolve(null);
+        });
+        child.on("error", () => resolve(null));
+    });
+}
+
+async function runUnused(agentctlPath: string, days: number): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(agentctlPath, ["unused", `--days=${days}`], {
+            stdio: ["ignore", "pipe", "pipe"],
+            env: process.env,
+        });
+        let stdout = "";
+        let stderr = "";
+        child.stdout.on("data", (d) => { stdout += d.toString(); });
+        child.stderr.on("data", (d) => { stderr += d.toString(); });
+        child.on("close", (code) => {
+            if (code !== 0) reject(new Error(`agentctl unused exited ${code}: ${stderr}`));
+            else resolve(stdout);
+        });
+        child.on("error", (err) => reject(err));
+    });
+}
+
+/**
+ * Parse the human output of `agentctl unused`. Each row looks like:
+ *   "<name>  [<scope>]  total=<n>  last=<iso|never>"
+ * The trailing summary line ("N skills unused in last D days.") is ignored.
+ */
+function parseUnusedOutput(stdout: string): Candidate[] {
+    const out: Candidate[] = [];
+    const rowRe = /^(.+?)\s+\[([^\]]+)\]\s+total=(\d+)\s+last=(\S+)\s*$/;
+    for (const line of stdout.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        if (/skills unused in last/i.test(trimmed)) continue;
+        const m = rowRe.exec(trimmed);
+        if (!m) continue;
+        const [, name, scope, total, last] = m;
+        out.push({
+            slug: name!.trim(),
+            scope: scope!.trim(),
+            total_invocations: Number(total),
+            last_used: last === "never" ? null : last!,
+        });
+    }
+    return out;
+}
+
+async function loadKeepList(homeDir: string): Promise<Set<string>> {
+    const keepPath = join(homeDir, "keep.txt");
+    try {
+        const raw = await readFile(keepPath, "utf8");
+        return new Set(
+            raw
+                .split("\n")
+                .map((l) => l.trim())
+                .filter((l) => l && !l.startsWith("#")),
+        );
+    } catch {
+        return new Set();
+    }
+}
+
+async function main(): Promise<void> {
+    const [, , runDirArg, homeDirArg, ...rest] = process.argv;
+    if (!runDirArg || !homeDirArg) {
+        console.error("usage: bun deprecate-helper.ts <runDir> <homeDir> [--days=90]");
+        process.exit(2);
+    }
+    const days = Number(parseFlag("days", rest, "90"));
+    await mkdir(runDirArg, { recursive: true });
+    const outPath = join(runDirArg, "deprecation-candidates.json");
+
+    const keep = await loadKeepList(homeDirArg);
+    const generated_at = new Date().toISOString();
+
+    const agentctlPath = await which("agentctl");
+    if (!agentctlPath) {
+        const empty: Result = {
+            generated_at,
+            days,
+            source: "unavailable",
+            candidates: [],
+            kept: [],
+        };
+        await writeFile(outPath, JSON.stringify(empty, null, 2));
+        console.log(`[deprecate-helper] agentctl not on PATH; wrote empty result to ${outPath}`);
+        return;
+    }
+
+    let stdout: string;
+    try {
+        stdout = await runUnused(agentctlPath, days);
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[deprecate-helper] agentctl unused failed: ${msg}`);
+        process.exit(1);
+    }
+
+    const all = parseUnusedOutput(stdout);
+    const kept: string[] = [];
+    const candidates: Candidate[] = [];
+    for (const row of all) {
+        if (keep.has(row.slug)) kept.push(row.slug);
+        else candidates.push(row);
+    }
+    const result: Result = { generated_at, days, source: "agentctl", candidates, kept };
+    await writeFile(outPath, JSON.stringify(result, null, 2));
+    console.log(
+        `[deprecate-helper] wrote ${outPath}: ${candidates.length} candidate(s), ${kept.length} kept (days=${days})`,
+    );
+}
+
+if (import.meta.main) {
+    await main();
+}


### PR DESCRIPTION
Closes #7

## Summary

Wires `agentctl` into the user's existing `~/.claude/self-improve/` weekly cron via two bun scripts under `integrations/self-improve/`:

- **`agentctl-ingest.ts`** — refreshes the SurrealDB by running `agentctl ingest --since=14` (14 days = past 2 weeks for safety). Logs combined stdout/stderr to `<RUN_DIR>/agentctl-ingest.log`. Slots into `run.sh` as the `agentctl_ingest` step immediately before `extract`.
- **`deprecate-helper.ts`** — runs `agentctl unused --days=90`, parses the human output, cross-references `~/.claude/self-improve/keep.txt`, and writes `<RUN_DIR>/deprecation-candidates.json`. Consumed by the existing `deprecate` step.

Both scripts are **graceful**: if `agentctl` isn't on `PATH`, they write a "skipped" / "unavailable" record and exit 0, so a missing binary won't break the self-improve cron.

## Files

- `integrations/self-improve/agentctl-ingest.ts` (new)
- `integrations/self-improve/deprecate-helper.ts` (new)
- `integrations/self-improve/README.md` (new) — install / config / output schema docs

No changes to `src/`, `schema/`, or `scripts/db-*.sh`.

## Self-improve side (outside this repo)

Modifications under `~/.claude/self-improve/`:

- `lib/agentctl_ingest.ts` — symlink to `integrations/self-improve/agentctl-ingest.ts`
- `lib/agentctl_deprecate_helper.ts` — symlink to `integrations/self-improve/deprecate-helper.ts`
- `lib/types.ts` — added `agentctl_ingest` to the `StepName` enum
- `lib/status.ts` — added `agentctl_ingest` to the `STEPS` array
- `lib/deprecate.ts` — invokes the helper, merges output into `deprecations.json` under `agentctl_candidates` / `agentctl_kept`
- `run.sh` — added `run_step agentctl_ingest` between `ingest` and `extract`

(Step name uses underscores to keep `jq -r ".steps.$step"` and the bash-derived script path `lib/$step.ts` clean.)

## Test plan

- [x] `bun run typecheck` passes (no new errors)
- [x] `agentctl-ingest.ts` smoke test (no agentctl on PATH) — exits 0, writes `skipped` log
- [x] `agentctl-ingest.ts` smoke test (agentctl on PATH) — runs ingest, propagates exit code, log captured
- [x] `deprecate-helper.ts` produces valid JSON with 135 candidates from current local DB
- [x] `bash -n run.sh` syntax-check passes
- [x] `initStatus` seeds the new `agentctl_ingest` step as `pending`
- [x] `lib/deprecate.ts` compiles (`bun -e "import './lib/deprecate'"`)