### PR TITLE
feat: derive correction + proposed signals (#5)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,11 +5,13 @@ import { AppLayer } from "../lib/layers.ts";
 import { ingestSkills } from "../ingest/skills.ts";
 import { ingestTranscripts } from "../ingest/transcripts.ts";
 import { ingestCodex } from "../ingest/codex.ts";
+import { deriveSignals } from "../ingest/derive-signals.ts";
 
 const HELP = `agentctl - agent telemetry & taste graph
 
 Usage:
   agentctl ingest [--skills-only|--transcripts-only] [--since=DAYS]
+  agentctl derive-signals [--since=DAYS]
   agentctl search <query> [--limit=N]
   agentctl stats <skill>
   agentctl recent [--limit=N]
@@ -34,6 +36,16 @@ const cmdIngest = (args: string[]) =>
         if (!transcriptsOnly && !codexOnly) yield* ingestSkills();
         if (!skillsOnly && !codexOnly) yield* ingestTranscripts({ sinceDays });
         if (!skillsOnly && !claudeOnly) yield* ingestCodex({ sinceDays });
+        // Auto-derive signals so taste queries always see fresh
+        // corrected_by / proposed edges. Cheap: O(turns) in-memory walk.
+        if (!skillsOnly) yield* deriveSignals({ sinceDays });
+    });
+
+const cmdDeriveSignals = (args: string[]) =>
+    Effect.gen(function* () {
+        const sinceArg = flag("since", args);
+        const sinceDays = sinceArg ? parseInt(sinceArg, 10) : undefined;
+        yield* deriveSignals({ sinceDays });
     });
 
 const cmdSearch = (args: string[]) =>
@@ -154,8 +166,14 @@ const cmdTaste = (args: string[]) =>
     Effect.gen(function* () {
         const limit = parseInt(flag("limit", args) ?? "30", 10);
         const db = yield* SurrealClient;
-        // Composite signal: invocations (positive), errors near invocation (negative),
-        // edits-following-invocation in same session (positive - work happened).
+        // Composite signal: invocations (positive), errors near invocation
+        // (negative), corrections within 3 turns of invocation in the same
+        // session (negative - user pushed back), and proposed-but-not-invoked
+        // (signal of mismatch between assistant suggestions and tool firing).
+        //
+        // `corrections` counts invocations where the next user turn within 3
+        // seq steps in the same session triggered a corrected_by edge.
+        // `proposals` counts proposed edges into this skill.
         const sql = `
 SELECT
     name,
@@ -166,19 +184,29 @@ SELECT
     array::len((
         SELECT * FROM <-invoked
         WHERE in.has_error = false
-    )) AS clean_inv
+    )) AS clean_inv,
+    array::len((
+        SELECT * FROM <-invoked
+        WHERE array::len((
+            SELECT * FROM corrected_by
+            WHERE in.session = $parent.in.session
+              AND in.seq >= $parent.in.seq
+              AND in.seq <= $parent.in.seq + 3
+        )) > 0
+    )) AS corrections,
+    array::len(<-proposed) AS proposals
 FROM skill
-WHERE array::len(<-invoked) > 0
+WHERE array::len(<-invoked) > 0 OR array::len(<-proposed) > 0
 ORDER BY inv_30d DESC, clean_inv DESC, inv_total DESC
 LIMIT ${limit};`;
         const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
         const rows = result?.[0];
         console.log(
-            `${"skill".padEnd(50)}  ${"scope".padEnd(16)}  7d  30d  total  clean`,
+            `${"skill".padEnd(50)}  ${"scope".padEnd(16)}  7d  30d  total  clean  corr  prop`,
         );
         for (const r of rows ?? []) {
             console.log(
-                `${String(r.name).padEnd(50)}  ${String(r.scope).padEnd(16)}  ${String(r.inv_7d).padStart(2)}  ${String(r.inv_30d).padStart(3)}  ${String(r.inv_total).padStart(5)}  ${String(r.clean_inv).padStart(5)}`,
+                `${String(r.name).padEnd(50)}  ${String(r.scope).padEnd(16)}  ${String(r.inv_7d).padStart(2)}  ${String(r.inv_30d).padStart(3)}  ${String(r.inv_total).padStart(5)}  ${String(r.clean_inv).padStart(5)}  ${String(r.corrections ?? 0).padStart(4)}  ${String(r.proposals ?? 0).padStart(4)}`,
             );
         }
     });
@@ -190,6 +218,8 @@ const dispatch = (
     switch (cmd) {
         case "ingest":
             return cmdIngest(rest);
+        case "derive-signals":
+            return cmdDeriveSignals(rest);
         case "search":
             return cmdSearch(rest);
         case "stats":

--- a/src/ingest/derive-signals.ts
+++ b/src/ingest/derive-signals.ts
@@ -1,0 +1,321 @@
+import { Effect } from "effect";
+import { SurrealClient } from "../lib/db.ts";
+import { skillRecordKey } from "../lib/skill-id.ts";
+import { AppLayer } from "../lib/layers.ts";
+import type { DbError } from "../lib/errors.ts";
+
+/**
+ * Negation patterns that signal a user pushed back on the previous assistant
+ * turn. Each entry is `[regex, label]` - the label is what we persist on the
+ * `corrected_by.pattern` field so downstream queries can group by phrase.
+ *
+ * Patterns are matched against the first ~200 chars of the user turn text,
+ * lowercased. Word boundaries keep us from firing on "actually" inside a URL
+ * or "no" inside "node".
+ */
+const NEGATION_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+    // Hard interrupts logged by Claude Code itself - strongest correction
+    // signal we have, since the user literally cancelled mid-tool-use.
+    [/\[request interrupted by user/i, "interrupted"],
+    [/\bno\b/, "no"],
+    [/\bstop\b/, "stop"],
+    [/\bwrong\b/, "wrong"],
+    [/\bnot that\b/, "not that"],
+    [/\bactually\b/, "actually"],
+    [/\binstead\b/, "instead"],
+    [/\bwait\b/, "wait"],
+    [/\bhold on\b/, "hold on"],
+    [/\byou missed\b/, "you missed"],
+    [/\byou forgot\b/, "you forgot"],
+] as const;
+
+const CORRECTION_WINDOW_CHARS = 200;
+
+function matchNegation(text: string): string | null {
+    const head = text.slice(0, CORRECTION_WINDOW_CHARS).toLowerCase();
+    for (const [re, label] of NEGATION_PATTERNS) {
+        if (re.test(head)) return label;
+    }
+    return null;
+}
+
+/**
+ * Build a deterministic edge record-id so re-runs upsert instead of
+ * duplicating. Surreal record-ids escape via backticks, so we strip out the
+ * `turn:` prefix and join the two raw keys.
+ */
+function correctedByEdgeId(fromTurnKey: string, toTurnKey: string): string {
+    return `${fromTurnKey}__${toTurnKey}`;
+}
+
+function proposedEdgeId(fromTurnKey: string, skillKey: string): string {
+    return `${fromTurnKey}__${skillKey}`;
+}
+
+interface TurnRow {
+    id: { tb: string; id: string } | string;
+    seq: number;
+    role: string;
+    text_excerpt: string | null;
+    ts: string | Date;
+    invoked_skills: ReadonlyArray<string>; // skill names this turn already invoked
+}
+
+interface SessionTurns {
+    sessionId: string;
+    turns: TurnRow[];
+}
+
+/** Extract the raw `id` portion of a turn record-id (`turn:⟨xyz⟩` → `xyz`). */
+function rawTurnKey(id: TurnRow["id"]): string {
+    if (typeof id === "string") {
+        const colon = id.indexOf(":");
+        return colon === -1 ? id : id.slice(colon + 1);
+    }
+    return id.id;
+}
+
+function tsToIso(ts: TurnRow["ts"]): string {
+    return ts instanceof Date ? ts.toISOString() : String(ts);
+}
+
+/**
+ * Fetch every (session → turns) bundle in one round-trip. Each turn carries
+ * its outgoing `->invoked->skill.name` array so we can detect "proposed but
+ * not invoked" without a second query.
+ */
+const fetchSessionTurns = (
+    sinceDays: number | undefined,
+): Effect.Effect<SessionTurns[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const sinceFilter =
+            sinceDays && sinceDays > 0 ? `WHERE ts > time::now() - ${sinceDays}d` : "";
+        const sql = `
+SELECT
+    id,
+    session,
+    seq,
+    role,
+    text_excerpt,
+    ts,
+    ->invoked->skill.name AS invoked_skills
+FROM turn
+${sinceFilter}
+ORDER BY session ASC, seq ASC;`;
+        const result = yield* db.query<[TurnRow[] & { session: unknown }[]]>(sql);
+        const rows = (result?.[0] ?? []) as Array<TurnRow & { session: unknown }>;
+
+        const bySession = new Map<string, TurnRow[]>();
+        for (const row of rows) {
+            const sess = row.session;
+            const sessionId =
+                typeof sess === "string"
+                    ? sess.replace(/^session:/, "").replace(/[`⟨⟩]/g, "")
+                    : sess && typeof sess === "object" && "id" in sess
+                      ? String((sess as { id: unknown }).id)
+                      : String(sess);
+            const list = bySession.get(sessionId) ?? [];
+            list.push(row);
+            bySession.set(sessionId, list);
+        }
+        return [...bySession.entries()].map(([sessionId, turns]) => ({
+            sessionId,
+            turns,
+        }));
+    });
+
+interface CorrectionEdge {
+    fromTurnKey: string;
+    toTurnKey: string;
+    pattern: string;
+    ts: string;
+}
+
+interface ProposedEdge {
+    fromTurnKey: string;
+    skillKey: string;
+    skillName: string;
+    ts: string;
+    contextExcerpt: string;
+}
+
+/**
+ * Walk turns in order. Whenever a user turn arrives, look back for the most
+ * recent assistant turn (skipping tool_call / reasoning / function_call_output
+ * noise that interleaves between assistant generations and user replies). If
+ * the user text starts with a negation pattern, emit a correction edge from
+ * that assistant turn to the user turn.
+ */
+function deriveCorrections(bundle: SessionTurns): CorrectionEdge[] {
+    const out: CorrectionEdge[] = [];
+    const turns = bundle.turns;
+    let lastAssistantIdx: number | null = null;
+    for (let i = 0; i < turns.length; i += 1) {
+        const t = turns[i];
+        if (t.role === "assistant") {
+            lastAssistantIdx = i;
+            continue;
+        }
+        if (t.role !== "user") continue;
+        const text = t.text_excerpt;
+        // Tool-result user turns carry no text excerpt - skip without
+        // disturbing the anchor (this is what was masking interrupted-by-user
+        // turns, which sit immediately after a tool_result user turn).
+        if (!text) continue;
+        if (lastAssistantIdx === null) continue;
+        const matched = matchNegation(text);
+        if (matched) {
+            const prev = turns[lastAssistantIdx];
+            out.push({
+                fromTurnKey: rawTurnKey(prev.id),
+                toTurnKey: rawTurnKey(t.id),
+                pattern: matched,
+                ts: tsToIso(t.ts),
+            });
+        }
+        // After a user turn fires, reset the anchor so the next correction
+        // must follow a fresh assistant turn.
+        lastAssistantIdx = null;
+    }
+    return out;
+}
+
+/**
+ * For each assistant turn whose excerpt mentions a known skill name but did
+ * NOT outgoing-invoke that skill, emit a `proposed` edge. Substring match is
+ * case-sensitive on the canonical skill name to avoid `gsd:plan-phase`
+ * matching the word "plan" everywhere.
+ */
+function deriveProposed(
+    bundle: SessionTurns,
+    skillNames: ReadonlyArray<string>,
+): ProposedEdge[] {
+    if (skillNames.length === 0) return [];
+    const out: ProposedEdge[] = [];
+    for (const turn of bundle.turns) {
+        if (turn.role !== "assistant") continue;
+        const text = turn.text_excerpt;
+        if (!text) continue;
+        const invokedSet = new Set(turn.invoked_skills ?? []);
+        for (const name of skillNames) {
+            if (invokedSet.has(name)) continue;
+            if (!text.includes(name)) continue;
+            // Skip trivially-short names that would create noise (e.g. "ci").
+            if (name.length < 4) continue;
+            const idx = text.indexOf(name);
+            const start = Math.max(0, idx - 40);
+            const end = Math.min(text.length, idx + name.length + 40);
+            out.push({
+                fromTurnKey: rawTurnKey(turn.id),
+                skillKey: skillRecordKey(name),
+                skillName: name,
+                ts: tsToIso(turn.ts),
+                contextExcerpt: text.slice(start, end),
+            });
+        }
+    }
+    return out;
+}
+
+const fetchSkillNames = (): Effect.Effect<string[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const result = yield* db.query<[Array<{ name: string }>]>(
+            `SELECT name FROM skill;`,
+        );
+        return (result?.[0] ?? []).map((r) => r.name).filter((n): n is string => Boolean(n));
+    });
+
+/**
+ * Idempotent RELATE on the `corrected_by` relation. SurrealDB rejects raw
+ * `UPSERT` against a RELATION-typed table ("is not a relation"), but
+ * `RELATE in -> table:⟨id⟩ -> out` overwrites in place when the same edge
+ * record-id is reused. Building the id deterministically from both endpoint
+ * keys keeps re-runs side-effect-free.
+ */
+const upsertCorrections = (edges: CorrectionEdge[]) =>
+    Effect.gen(function* () {
+        if (edges.length === 0) return;
+        const db = yield* SurrealClient;
+        const stmts = edges.map((e) => {
+            const edgeId = correctedByEdgeId(e.fromTurnKey, e.toTurnKey);
+            return `RELATE turn:\`${e.fromTurnKey}\` -> corrected_by:\`${edgeId}\` -> turn:\`${e.toTurnKey}\` SET pattern = ${JSON.stringify(e.pattern)}, ts = d"${e.ts}";`;
+        });
+        for (let i = 0; i < stmts.length; i += 500) {
+            yield* db.query(stmts.slice(i, i + 500).join(""));
+        }
+    });
+
+const upsertProposed = (edges: ProposedEdge[]) =>
+    Effect.gen(function* () {
+        if (edges.length === 0) return;
+        const db = yield* SurrealClient;
+        const stmts = edges.map((e) => {
+            const edgeId = proposedEdgeId(e.fromTurnKey, e.skillKey);
+            return `RELATE turn:\`${e.fromTurnKey}\` -> proposed:\`${edgeId}\` -> skill:\`${e.skillKey}\` SET ts = d"${e.ts}", context_excerpt = ${JSON.stringify(e.contextExcerpt)};`;
+        });
+        for (let i = 0; i < stmts.length; i += 500) {
+            yield* db.query(stmts.slice(i, i + 500).join(""));
+        }
+    });
+
+export interface DeriveStats {
+    sessions: number;
+    turns: number;
+    corrections: number;
+    proposed: number;
+}
+
+export interface DeriveOpts {
+    sinceDays: number | undefined;
+}
+
+export const deriveSignals = (
+    opts: Partial<DeriveOpts> = {},
+): Effect.Effect<DeriveStats, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const skillNames = yield* fetchSkillNames();
+        const bundles = yield* fetchSessionTurns(opts.sinceDays);
+
+        let corrections = 0;
+        let proposed = 0;
+        let turnCount = 0;
+
+        const correctionBatch: CorrectionEdge[] = [];
+        const proposedBatch: ProposedEdge[] = [];
+
+        for (const bundle of bundles) {
+            turnCount += bundle.turns.length;
+            const c = deriveCorrections(bundle);
+            const p = deriveProposed(bundle, skillNames);
+            corrections += c.length;
+            proposed += p.length;
+            correctionBatch.push(...c);
+            proposedBatch.push(...p);
+        }
+
+        yield* upsertCorrections(correctionBatch);
+        yield* upsertProposed(proposedBatch);
+
+        console.log(
+            `[derive-signals] DONE sessions=${bundles.length} turns=${turnCount} corrections=${corrections} proposed=${proposed}`,
+        );
+        return {
+            sessions: bundles.length,
+            turns: turnCount,
+            corrections,
+            proposed,
+        };
+    });
+
+if (import.meta.main) {
+    const sinceArg = process.argv.find((a) => a.startsWith("--since="));
+    const sinceDays = sinceArg ? parseInt(sinceArg.split("=")[1], 10) : undefined;
+    await Effect.runPromise(
+        deriveSignals({ sinceDays }).pipe(
+            Effect.provide(AppLayer),
+            Effect.scoped,
+        ) as Effect.Effect<DeriveStats>,
+    );
+}


### PR DESCRIPTION
Closes #5

## What

Post-pass deriver that mines existing transcript turns for two new edge types (already in schema, no schema change):

- `corrected_by` (turn -> turn): assistant turn followed by a user turn whose first 200 chars match a negation regex. Patterns: `no`, `stop`, `wrong`, `not that`, `actually`, `instead`, `wait`, `hold on`, `you missed`, `you forgot`, plus the strongest signal we have - `[Request interrupted by user...]`.
- `proposed` (turn -> skill): assistant turn whose `text_excerpt` mentions a known skill name without firing the Skill tool in that turn.

## How

`src/ingest/derive-signals.ts`:
- Single SurrealQL pass loads all turns + their outgoing `->invoked->skill.name`, grouped by session, ordered by seq.
- In-memory walker per session emits correction/proposed edges with deterministic record-ids (`fromKey__toKey` / `fromKey__skillKey`). `RELATE in -> table:<id> -> out` overwrites in place so re-runs never duplicate.
- Walker subtlety: tool-result-bearing user turns have `text_excerpt=null`. The original implementation cleared the assistant anchor on those, which masked `[Request interrupted]` replies that always come right after a tool_result. Fix: only consume the anchor when the user turn has authored text.

## CLI

- New `agentctl derive-signals [--since=DAYS]` command.
- `agentctl ingest` auto-runs the deriver after the skill/claude/codex passes.
- `agentctl taste` grew two columns (`corr`, `prop`):
  - `corr` = invocations of this skill where a correction landed within 3 seq in the same session.
  - `prop` = proposed-but-not-invoked edges into this skill.

## Numbers

Sample run on local DB (92 sessions, 26442 turns):

```
[derive-signals] DONE sessions=92 turns=26442 corrections=9 proposed=126
```

1-day window:

```
[derive-signals] DONE sessions=59 turns=13396 corrections=5 proposed=69
```

Wall time ~0.4-0.5s for both. Re-running keeps counts steady (idempotent verified).

Top proposed-but-not-invoked skill: `multica-pull` with 12 mentions across the corpus.

Correction patterns observed: `no`, `wait`, `interrupted`.

## Test plan

- [x] `bun run typecheck` clean (only pre-existing JSON-message diagnostics in unrelated files)
- [x] First run: 9 corrections / 126 proposed against full corpus
- [x] Second run: identical counts (RELATE with explicit edge id overwrites instead of duplicating)
- [x] `agentctl taste` renders new columns without errors
- [x] Auto-run wired into `ingest` (verified by running `agentctl ingest --since=1`)