### PR TITLE
feat: SurrealDB file buckets for transcript snapshots + codex artifacts (#3)

### DIFF
--- a/schema/schema.surql
+++ b/schema/schema.surql
@@ -26,6 +26,18 @@ DEFINE FIELD model          ON session TYPE option<string>;
 DEFINE FIELD source         ON session TYPE string DEFAULT 'claude';  -- 'claude' | 'codex'
 DEFINE FIELD started_at     ON session TYPE option<datetime>;
 DEFINE FIELD ended_at       ON session TYPE option<datetime>;
+DEFINE FIELD raw_file       ON session TYPE option<string>;  -- f"transcripts:/<id>.jsonl" pointer; full original jsonl
+
+-- ==== File buckets (SurrealDB 3.0 experimental) ====
+-- Requires: surreal start --allow-experimental files
+--           SURREAL_BUCKET_FOLDER_ALLOWLIST=$AGENTCTL_DATA_DIR/buckets
+-- Bucket paths are hardcoded because SurrealQL does not interpolate env vars.
+-- apply-schema.sh warns if $AGENTCTL_DATA_DIR differs from the default.
+
+DEFINE BUCKET IF NOT EXISTS transcripts
+    BACKEND "file:/Users/necmttn/.local/share/agentctl/buckets/transcripts";
+DEFINE BUCKET IF NOT EXISTS codex_artifacts
+    BACKEND "file:/Users/necmttn/.local/share/agentctl/buckets/codex_artifacts";
 
 DEFINE TABLE turn SCHEMAFULL;
 DEFINE FIELD session        ON turn TYPE record<session>;

--- a/scripts/apply-schema.sh
+++ b/scripts/apply-schema.sh
@@ -6,6 +6,16 @@ PASS="${AGENTCTL_DB_PASS:-root}"
 NS="${AGENTCTL_DB_NS:-agentctl}"
 DB="${AGENTCTL_DB_DB:-main}"
 SCHEMA="$(dirname "$0")/../schema/schema.surql"
+
+# Bucket paths are hardcoded in schema.surql to /Users/necmttn/.local/share/agentctl/buckets/*
+# because SurrealQL does not expand env vars. Warn if the runtime data dir differs.
+DATA_DIR="${AGENTCTL_DATA_DIR:-$HOME/.local/share/agentctl}"
+HARDCODED_DATA_DIR="/Users/necmttn/.local/share/agentctl"
+if [ "$DATA_DIR" != "$HARDCODED_DATA_DIR" ]; then
+  echo "[agentctl] WARNING: AGENTCTL_DATA_DIR=$DATA_DIR but schema buckets point at $HARDCODED_DATA_DIR" >&2
+  echo "[agentctl] WARNING: edit schema/schema.surql DEFINE BUCKET BACKEND paths to match, or unset AGENTCTL_DATA_DIR" >&2
+fi
+
 surreal import \
   --endpoint "http://127.0.0.1:$PORT" \
   --user "$USER" --pass "$PASS" \

--- a/scripts/db-start.sh
+++ b/scripts/db-start.sh
@@ -4,11 +4,12 @@ set -euo pipefail
 
 DATA_DIR="${AGENTCTL_DATA_DIR:-$HOME/.local/share/agentctl}"
 LOG_DIR="$DATA_DIR/logs"
+BUCKETS_DIR="$DATA_DIR/buckets"
 PORT="${AGENTCTL_DB_PORT:-8521}"
 USER="${AGENTCTL_DB_USER:-root}"
 PASS="${AGENTCTL_DB_PASS:-root}"
 
-mkdir -p "$DATA_DIR" "$LOG_DIR"
+mkdir -p "$DATA_DIR" "$LOG_DIR" "$BUCKETS_DIR/transcripts" "$BUCKETS_DIR/codex_artifacts"
 
 if lsof -iTCP:"$PORT" -sTCP:LISTEN -nP >/dev/null 2>&1; then
   echo "[agentctl] SurrealDB already on port $PORT" >&2
@@ -16,13 +17,17 @@ if lsof -iTCP:"$PORT" -sTCP:LISTEN -nP >/dev/null 2>&1; then
 fi
 
 # rocksdb file backend, daemonized
+# --allow-experimental files: enables DEFINE BUCKET + f"bucket:/path" file syntax (SurrealDB 3.0)
+# SURREAL_BUCKET_FOLDER_ALLOWLIST: required allowlist for file:// backed buckets
+SURREAL_BUCKET_FOLDER_ALLOWLIST="$BUCKETS_DIR" \
 nohup surreal start \
   --user "$USER" --pass "$PASS" \
   --bind "127.0.0.1:$PORT" \
   --log info \
+  --allow-experimental=files \
   "rocksdb://$DATA_DIR/db" \
   >>"$LOG_DIR/surreal.log" 2>&1 &
 
 echo $! > "$DATA_DIR/surreal.pid"
 sleep 1
-echo "[agentctl] SurrealDB pid=$(cat "$DATA_DIR/surreal.pid") port=$PORT data=$DATA_DIR/db"
+echo "[agentctl] SurrealDB pid=$(cat "$DATA_DIR/surreal.pid") port=$PORT data=$DATA_DIR/db buckets=$BUCKETS_DIR"

--- a/scripts/test-getfile.ts
+++ b/scripts/test-getfile.ts
@@ -1,0 +1,17 @@
+import { Effect } from "effect";
+import { SurrealClient } from "../src/lib/db.ts";
+import { AppLayer } from "../src/lib/layers.ts";
+
+const program = Effect.gen(function* () {
+    const db = yield* SurrealClient;
+    const sessionId = process.argv[2] ?? "8a53d7e0-69b9-4b51-8828-7fdccfaf4899";
+    const bucket = process.argv[3] ?? "transcripts";
+    const content = yield* db.getFile(bucket, `${sessionId}.jsonl`);
+    console.log(`bucket=${bucket} session=${sessionId} bytes=${content.length}`);
+    console.log("--- first 300 chars ---");
+    console.log(content.slice(0, 300));
+});
+
+await Effect.runPromise(
+    program.pipe(Effect.provide(AppLayer), Effect.scoped) as Effect.Effect<void>,
+);

--- a/src/ingest/codex.ts
+++ b/src/ingest/codex.ts
@@ -2,7 +2,7 @@ import { readdir, stat, open } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { Effect } from "effect";
-import { RecordId, SurrealClient } from "../lib/db.ts";
+import { RecordId, SurrealClient, filePointer } from "../lib/db.ts";
 import { skillRecordKey } from "../lib/skill-id.ts";
 import { AppLayer } from "../lib/layers.ts";
 import type { DbError } from "../lib/errors.ts";
@@ -187,6 +187,31 @@ export const ingestCodex = (
             if (!extracted) continue;
             fileCount += 1;
 
+            // Snapshot the raw codex jsonl into the `codex_artifacts` bucket as
+            // best-effort cold storage. Failure does not abort ingest.
+            const bucketPath = `${extracted.session.id}.jsonl`;
+            const rawContent = yield* Effect.promise(async () => {
+                try {
+                    return await Bun.file(filePath).text();
+                } catch {
+                    return null;
+                }
+            });
+            let rawPointer: string | null = null;
+            if (rawContent !== null) {
+                rawPointer = yield* db
+                    .putFile("codex_artifacts", bucketPath, rawContent)
+                    .pipe(
+                        Effect.map(() => filePointer("codex_artifacts", bucketPath)),
+                        Effect.catch((err) => {
+                            console.error(
+                                `[codex] putFile failed ${extracted.session.id}: ${err.message}`,
+                            );
+                            return Effect.succeed(null as string | null);
+                        }),
+                    );
+            }
+
             yield* db.upsert(new RecordId("session", extracted.session.id), {
                 project: extracted.session.cwd,
                 cwd: extracted.session.cwd,
@@ -194,6 +219,7 @@ export const ingestCodex = (
                 source: "codex",
                 started_at: new Date(extracted.session.started_at),
                 ended_at: new Date(extracted.session.ended_at),
+                raw_file: rawPointer,
             });
             sessionCount += 1;
 

--- a/src/ingest/transcripts.ts
+++ b/src/ingest/transcripts.ts
@@ -1,7 +1,7 @@
 import { readdir, stat, open } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { Effect } from "effect";
-import { RecordId, SurrealClient } from "../lib/db.ts";
+import { RecordId, SurrealClient, filePointer } from "../lib/db.ts";
 import { TRANSCRIPTS_DIR } from "../lib/paths.ts";
 import { skillRecordKey } from "../lib/skill-id.ts";
 import { AppLayer } from "../lib/layers.ts";
@@ -13,6 +13,7 @@ interface Session {
     cwd: string | null;
     started_at: string | null;
     ended_at: string | null;
+    raw_file: string | null;
 }
 
 interface Turn {
@@ -110,6 +111,7 @@ async function extractFile(filePath: string, projectDir: string): Promise<FileEx
                 cwd,
                 started_at: ts,
                 ended_at: ts,
+                raw_file: null,
             };
         }
         session.ended_at = ts;
@@ -199,11 +201,44 @@ const upsertSessions = (sessions: Session[]) =>
                 db.upsert(new RecordId("session", s.id), {
                     project: s.project,
                     cwd: s.cwd,
+                    source: "claude",
                     started_at: s.started_at ? new Date(s.started_at) : null,
                     ended_at: s.ended_at ? new Date(s.ended_at) : null,
+                    raw_file: s.raw_file,
                 }),
             { concurrency: 4, discard: true },
         );
+    });
+
+/**
+ * Snapshot the original transcript jsonl into the `transcripts` bucket and
+ * return the file pointer string to persist on `session.raw_file`. Failures
+ * are logged but do not abort ingest - the bucket is best-effort cold storage.
+ */
+const snapshotTranscript = (sessionId: string, filePath: string) =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const content = yield* Effect.promise(async () => {
+            try {
+                return await Bun.file(filePath).text();
+            } catch {
+                return null;
+            }
+        });
+        if (content === null) return null;
+        const bucketPath = `${sessionId}.jsonl`;
+        const result = yield* db
+            .putFile("transcripts", bucketPath, content)
+            .pipe(
+                Effect.map(() => filePointer("transcripts", bucketPath)),
+                Effect.catch((err) => {
+                    console.error(
+                        `[transcripts] putFile failed ${sessionId}: ${err.message}`,
+                    );
+                    return Effect.succeed(null as string | null);
+                }),
+            );
+        return result;
     });
 
 const upsertTurns = (turns: Turn[]) =>
@@ -313,6 +348,11 @@ export const ingestTranscripts = (
                 );
                 if (!extracted) continue;
                 files += 1;
+                const pointer = yield* snapshotTranscript(
+                    extracted.session.id,
+                    filePath,
+                );
+                extracted.session.raw_file = pointer;
                 yield* upsertSessions([extracted.session]);
                 sessions += 1;
                 yield* upsertTurns(extracted.turns);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -60,9 +60,37 @@ export interface SurrealClientShape {
         data?: Record<string, unknown>,
     ) => Effect.Effect<unknown, DbError>;
 
+    /**
+     * Write content to a SurrealDB v3 file bucket. Path is relative within the
+     * bucket (e.g. `<session-id>.jsonl`). Uses SurrealQL `f"bucket:/path".put($c)`
+     * syntax under the hood. Requires `--allow-experimental files`.
+     */
+    readonly putFile: (
+        bucket: string,
+        path: string,
+        content: string | Uint8Array,
+    ) => Effect.Effect<void, DbError>;
+
+    /**
+     * Read content from a SurrealDB v3 file bucket as a UTF-8 string. Uses
+     * SurrealQL `<string>f"bucket:/path".get()`.
+     */
+    readonly getFile: (
+        bucket: string,
+        path: string,
+    ) => Effect.Effect<string, DbError>;
+
     /** Escape hatch for the raw client when callers need methods we don't wrap. */
     readonly raw: Surreal;
 }
+
+/**
+ * Format a stored file-pointer string for record fields. We persist the bare
+ * `bucket:/path` form (without the SurrealQL `f"..."` literal wrapper) so
+ * downstream code can split on `:/` without parsing.
+ */
+export const filePointer = (bucket: string, path: string): string =>
+    `${bucket}:/${path}`;
 
 export class SurrealClient extends Context.Service<
     SurrealClient,
@@ -135,6 +163,40 @@ const wrap = (db: Surreal): SurrealClientShape => ({
                 new DbError({
                     operation: "relate",
                     message: errorMessage(err),
+                }),
+        }),
+
+    putFile: (bucket: string, path: string, content: string | Uint8Array) =>
+        Effect.tryPromise({
+            try: async () => {
+                // SurrealQL: f"<bucket>:/<path>".put($content)
+                // Bucket + path are interpolated (validated by caller); content
+                // is parameterized to handle binary + arbitrary text safely.
+                const sql = `f"${bucket}:/${path}".put($content); RETURN true;`;
+                await db.query(sql, { content });
+            },
+            catch: (err) =>
+                new DbError({
+                    operation: "putFile",
+                    message: errorMessage(err),
+                    sql: `${bucket}:/${path}`,
+                }),
+        }),
+
+    getFile: (bucket: string, path: string) =>
+        Effect.tryPromise({
+            try: async () => {
+                // <string> cast forces bytes -> UTF-8 string per SurrealDB 3.0 docs.
+                const sql = `RETURN <string>f"${bucket}:/${path}".get();`;
+                const result = (await db.query(sql)) as unknown[];
+                const first = result?.[0];
+                return typeof first === "string" ? first : String(first ?? "");
+            },
+            catch: (err) =>
+                new DbError({
+                    operation: "getFile",
+                    message: errorMessage(err),
+                    sql: `${bucket}:/${path}`,
                 }),
         }),
 


### PR DESCRIPTION
Closes #3

## Summary
- Enables SurrealDB 3.0 experimental file buckets via `--allow-experimental=files` + `SURREAL_BUCKET_FOLDER_ALLOWLIST`
- Defines `transcripts` and `codex_artifacts` buckets backed by `~/.local/share/agentctl/buckets/*`
- Snapshots the original jsonl per session into the bucket; persists `f"bucket:/path"` style pointer on `session.raw_file`
- Adds `putFile` / `getFile` to `SurrealClient` (Effect v4)
- Fixes a latent v3 SCHEMAFULL bug where `session.source` DEFAULT was missed by CONTENT-replace upserts

## Schema diff
- `DEFINE FIELD raw_file ON session TYPE option<string>`
- `DEFINE BUCKET transcripts BACKEND "file:/Users/necmttn/.local/share/agentctl/buckets/transcripts"`
- `DEFINE BUCKET codex_artifacts BACKEND "file:/Users/necmttn/.local/share/agentctl/buckets/codex_artifacts"`

Bucket paths are hardcoded because SurrealQL does not interpolate env vars; `apply-schema.sh` warns if `AGENTCTL_DATA_DIR` differs.

## API surface
```ts
db.putFile(bucket: string, path: string, content: string | Uint8Array): Effect<void, DbError>
db.getFile(bucket: string, path: string): Effect<string, DbError>
filePointer(bucket: string, path: string): string  // returns "bucket:/path"
```

## Test plan
- [x] `bash scripts/db-stop.sh && bash scripts/db-start.sh && bash scripts/apply-schema.sh`
- [x] `bun src/cli/index.ts ingest --since=1` - 59/92 sessions populated `raw_file`
- [x] `bun scripts/test-getfile.ts <session-id> transcripts` - 11479 bytes round-tripped identically vs file on disk
- [x] `bun run typecheck` - exit 0 (only pre-existing JSON.parse messages)

## Pivots from spec
- `--allow-experimental files` (space form) eats the positional db path; corrected to `--allow-experimental=files`
- Bucket file backend additionally requires `SURREAL_BUCKET_FOLDER_ALLOWLIST` env var (per [the v3 blog post](https://surrealdb.com/blog/file-support-in-surrealdb-3-0))
- `filePointer()` returns the bare `bucket:/path` (no `f"..."` wrapper) so downstream code can split without parsing SurrealQL literal syntax; the wrapper is added at query time inside `putFile`/`getFile`
- `Effect.catchAll` does not exist in Effect v4 - used `Effect.catch` (the v4 rename per `.references/effect-smol`)