### PR TITLE
fix: time-window filter on graph-traversal queries (#15)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -65,6 +65,10 @@ const cmdSearch = (args: string[]) =>
         }
         const db = yield* SurrealClient;
         // Lexical contains + recent-use boost
+        // NOTE: Time-window counts use explicit `invoked WHERE out = $parent.id`
+        // form rather than `<-invoked WHERE ts > ...`. The graph-traversal form
+        // materialises the edges first and the WHERE filter then drops every
+        // row (returns 0 even when matches exist). See issue #15.
         const sql = `
 SELECT
     name,
@@ -73,8 +77,8 @@ SELECT
     (string::lowercase(name) CONTAINS $q) AS name_match,
     (description IS NONE OR string::lowercase(description ?? '') CONTAINS $q) AS desc_match,
     array::len(<-invoked) AS total_inv,
-    array::len((SELECT * FROM <-invoked WHERE ts > time::now() - 30d)) AS inv_30d,
-    (SELECT ts FROM <-invoked ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
+    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
+    (SELECT ts FROM invoked WHERE out = $parent.id ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
 FROM skill
 WHERE
     string::lowercase(name) CONTAINS $q
@@ -174,14 +178,17 @@ const cmdUnused = (args: string[]) =>
     Effect.gen(function* () {
         const days = parseInt(flag("days", args) ?? "7", 10);
         const db = yield* SurrealClient;
+        // See issue #15: `<-invoked WHERE ts > ...` materialises edges first
+        // then the WHERE drops everything, so the count is always 0. Use the
+        // explicit `invoked WHERE out = $parent.id` form instead.
         const sql = `
 SELECT
     name,
     scope,
     array::len(<-invoked) AS total_inv,
-    (SELECT ts FROM <-invoked ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
+    (SELECT ts FROM invoked WHERE out = $parent.id ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
 FROM skill
-WHERE array::len((SELECT * FROM <-invoked WHERE ts > time::now() - ${days}d)) = 0
+WHERE ((SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - ${days}d GROUP ALL)[0].count ?? 0) = 0
 ORDER BY total_inv ASC, name ASC;`;
         const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
         const rows = result?.[0];
@@ -205,20 +212,22 @@ const cmdTaste = (args: string[]) =>
         // `corrections` counts invocations where the next user turn within 3
         // seq steps in the same session triggered a corrected_by edge.
         // `proposals` counts proposed edges into this skill.
+        // NOTE: Filtered counts use explicit `invoked WHERE out = $parent.id`
+        // form rather than `<-invoked WHERE ...`. The graph-traversal form
+        // materialises the edges first and the WHERE filter then drops every
+        // row (returns 0 even when matches exist). See issue #15.
         const sql = `
 SELECT
     name,
     scope,
     array::len(<-invoked) AS inv_total,
-    array::len((SELECT * FROM <-invoked WHERE ts > time::now() - 7d))  AS inv_7d,
-    array::len((SELECT * FROM <-invoked WHERE ts > time::now() - 30d)) AS inv_30d,
+    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 7d  GROUP ALL)[0].count ?? 0 AS inv_7d,
+    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
+    (SELECT count() FROM invoked WHERE out = $parent.id AND in.has_error = false GROUP ALL)[0].count ?? 0 AS clean_inv,
     array::len((
-        SELECT * FROM <-invoked
-        WHERE in.has_error = false
-    )) AS clean_inv,
-    array::len((
-        SELECT * FROM <-invoked
-        WHERE array::len((
+        SELECT * FROM invoked
+        WHERE out = $parent.id
+          AND array::len((
             SELECT * FROM corrected_by
             WHERE in.session = $parent.in.session
               AND in.seq >= $parent.in.seq

--- a/src/tui/queries.ts
+++ b/src/tui/queries.ts
@@ -8,6 +8,10 @@
  * Per-skill summary used by the SkillList. One row per skill, with
  * usage counters that the list sorts on.
  */
+// NOTE: Time-window counts use explicit `invoked WHERE out = $parent.id`
+// form rather than `<-invoked WHERE ts > ...`. The graph-traversal form
+// materialises the edges first and the WHERE filter then drops every row
+// (returns 0 even when matches exist). See issue #15.
 export const SKILL_SUMMARY_SQL = `
 SELECT
     name,
@@ -16,9 +20,9 @@ SELECT
     dir_path,
     bytes,
     array::len(<-invoked) AS total_inv,
-    array::len((SELECT * FROM <-invoked WHERE ts > time::now() - 7d))  AS inv_7d,
-    array::len((SELECT * FROM <-invoked WHERE ts > time::now() - 30d)) AS inv_30d,
-    (SELECT ts FROM <-invoked ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
+    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 7d  GROUP ALL)[0].count ?? 0 AS inv_7d,
+    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
+    (SELECT ts FROM invoked WHERE out = $parent.id ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
 FROM skill
 ORDER BY inv_30d DESC, total_inv DESC
 LIMIT 500;`;


### PR DESCRIPTION
Closes #15

## Summary

`agentctl taste`, `agentctl search`, `agentctl unused`, and the TUI `SKILL_SUMMARY_SQL` all used this pattern for time-window counts:

```surql
array::len((SELECT * FROM <-invoked WHERE ts > time::now() - 7d)) AS inv_7d
```

This always returned `0` even when invocations existed within the window. The graph-traversal `<-invoked` materialises edges first, then the `WHERE` filter drops everything.

`agentctl stats <skill>` already used the working pattern:

```surql
array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 7d))
```

## Fix

Replace every broken pattern with the explicit edge form, using `$parent.id` to bind to the outer skill row when there's no `$s` binding:

```surql
(SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 7d GROUP ALL)[0].count ?? 0 AS inv_7d
```

`$parent.id` works correctly inside `SELECT ... FROM skill` sub-queries (verified against the running DB).

Files touched:
- `src/cli/index.ts` — `cmdTaste` (inv_7d, inv_30d, clean_inv, corrections), `cmdSearch` (inv_30d, last_used), `cmdUnused` (filter + last_used)
- `src/tui/queries.ts` — `SKILL_SUMMARY_SQL` (inv_7d, inv_30d, last_used)

Untouched `array::len(<-invoked)` (no WHERE) and `array::len(<-proposed)` patterns work correctly and are kept for total counts.

## Verification

Before/after for `composto` skill (`agentctl taste --limit=10`):

| Column | Before | After |
|---|---|---|
| 7d | 0 | 632 |
| 30d | 0 | 632 |
| total | 632 | 632 |
| clean | 0 | 632 |

Other validations:

- `bun run typecheck` — clean (only pre-existing TS44/TS15 messages)
- `agentctl unused --days=1` — correctly excludes skills with invocations in the last 24h (e.g. `codex:exec_command` — 278k+ recent invocations — does not appear)
- `agentctl search effect` — still returns matches; `effect-testing` correctly shows `0×30d / 0×total` because it has no recorded invocations

## Test plan

- [x] Reproduce bug against running DB before fix
- [x] Apply fix, re-run `agentctl ingest --skills-only`
- [x] `agentctl taste --limit=10` — non-zero 7d/30d counts for active skills
- [x] `agentctl unused --days=1` — only includes truly stale skills
- [x] `agentctl search effect --limit=5` — returns matches with correct counts
- [x] `bun run typecheck` clean