### PR TITLE
feat: skill_pairs + skill_after_error signals (#19, #20)

### DIFF
--- a/schema/schema.surql
+++ b/schema/schema.surql
@@ -86,6 +86,14 @@ DEFINE TABLE touched      TYPE RELATION FROM commit TO file;
 DEFINE FIELD additions    ON touched TYPE option<int>;
 DEFINE FIELD deletions    ON touched TYPE option<int>;
 
+DEFINE TABLE skill_paired TYPE RELATION FROM skill TO skill;  -- skills co-occurring in same session within N turns
+DEFINE FIELD count        ON skill_paired TYPE int DEFAULT 1;
+DEFINE FIELD last_seen    ON skill_paired TYPE datetime;
+
+DEFINE TABLE recovered_by TYPE RELATION FROM turn TO skill;   -- skill invoked after has_error=true turn
+DEFINE FIELD ts            ON recovered_by TYPE datetime;
+DEFINE FIELD error_excerpt ON recovered_by TYPE option<string>;
+
 -- ==== Materialized views (computed at query time) ====
 
 -- Per-skill counts, recent boost

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,8 @@ Usage:
   agentctl recent [--limit=N]
   agentctl unused [--days=N]
   agentctl taste [--limit=N]
+  agentctl pairs <skill> [--limit=N]
+  agentctl recovery [--limit=N]
   agentctl tui
   agentctl install            # one-shot setup: daemon + watcher + symlink
   agentctl uninstall
@@ -251,6 +253,70 @@ LIMIT ${limit};`;
         }
     });
 
+const cmdPairs = (args: string[]) =>
+    Effect.gen(function* () {
+        const name = args.filter((a) => !a.startsWith("--"))[0];
+        if (!name) {
+            console.error("agentctl pairs: missing skill name");
+            process.exit(1);
+        }
+        const limit = parseInt(flag("limit", args) ?? "20", 10);
+        const db = yield* SurrealClient;
+        // Pairs are stored undirected (lexicographically lo->hi). Look the
+        // skill up on either endpoint so callers don't have to know the
+        // canonical direction. Combine both legs into a single ranked list.
+        // Pairs are stored undirected (lexicographically lo->hi), so the
+        // queried skill could be on either endpoint. Use IF/ELSE to pick the
+        // partner regardless of position; SurrealDB lacks UNION on SELECTs.
+        const sql = `
+LET $s = (SELECT id FROM skill WHERE name = $name)[0].id;
+SELECT
+    (IF in = $s THEN out.name ELSE in.name END) AS partner,
+    count,
+    last_seen
+FROM skill_paired
+WHERE in = $s OR out = $s
+ORDER BY count DESC
+LIMIT ${limit};`;
+        const result = yield* db.query<unknown[]>(sql, { name });
+        const arr = Array.isArray(result)
+            ? [...result].reverse().find((r) => Array.isArray(r) && (r as unknown[]).length > 0)
+            : undefined;
+        const rows = (arr as Array<Record<string, unknown>> | undefined) ?? [];
+        if (rows.length === 0) {
+            console.log("(no co-occurring skills)");
+            return;
+        }
+        console.log(`${"partner".padEnd(50)}  count  last_seen`);
+        for (const r of rows) {
+            console.log(
+                `${String(r.partner).padEnd(50)}  ${String(r.count).padStart(5)}  ${r.last_seen ?? "-"}`,
+            );
+        }
+    });
+
+const cmdRecovery = (args: string[]) =>
+    Effect.gen(function* () {
+        const limit = parseInt(flag("limit", args) ?? "20", 10);
+        const db = yield* SurrealClient;
+        const sql = `
+SELECT out.name AS skill, count() AS hits
+FROM recovered_by
+GROUP BY skill
+ORDER BY hits DESC
+LIMIT ${limit};`;
+        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
+        const rows = result?.[0];
+        if (!rows || rows.length === 0) {
+            console.log("(no recovery edges)");
+            return;
+        }
+        console.log(`${"skill".padEnd(50)}  hits`);
+        for (const r of rows) {
+            console.log(`${String(r.skill).padEnd(50)}  ${String(r.hits).padStart(4)}`);
+        }
+    });
+
 const dispatch = (
     cmd: string | undefined,
     rest: string[],
@@ -270,6 +336,10 @@ const dispatch = (
             return cmdUnused(rest);
         case "taste":
             return cmdTaste(rest);
+        case "pairs":
+            return cmdPairs(rest);
+        case "recovery":
+            return cmdRecovery(rest);
         default:
             return null;
     }

--- a/src/ingest/derive-signals.ts
+++ b/src/ingest/derive-signals.ts
@@ -52,12 +52,36 @@ function proposedEdgeId(fromTurnKey: string, skillKey: string): string {
     return `${fromTurnKey}__${skillKey}`;
 }
 
+/**
+ * Deterministic edge id for `skill_paired`. Pair is treated as undirected, so
+ * the lexicographically-smaller skill key always sits in the `in` slot. A
+ * short hash of the joined keys keeps the id stable + length-bounded
+ * regardless of skill-name length (Surreal record-id segment escaping).
+ */
+function skillPairedEdgeId(skillKeyA: string, skillKeyB: string): {
+    edgeId: string;
+    fromKey: string;
+    toKey: string;
+} {
+    const [lo, hi] = skillKeyA < skillKeyB ? [skillKeyA, skillKeyB] : [skillKeyB, skillKeyA];
+    const hash = Bun.hash(`${lo}__${hi}`).toString(16).slice(0, 12);
+    return { edgeId: `${lo.slice(0, 24)}__${hi.slice(0, 24)}__${hash}`, fromKey: lo, toKey: hi };
+}
+
+function recoveredByEdgeId(fromTurnKey: string, skillKey: string): string {
+    return `${fromTurnKey}__${skillKey}`;
+}
+
+const PAIR_WINDOW = 3;
+const RECOVERY_WINDOW = 3;
+
 interface TurnRow {
     id: { tb: string; id: string } | string;
     seq: number;
     role: string;
     text_excerpt: string | null;
     ts: string | Date;
+    has_error: boolean;
     invoked_skills: ReadonlyArray<string>; // skill names this turn already invoked
 }
 
@@ -99,6 +123,7 @@ SELECT
     role,
     text_excerpt,
     ts,
+    has_error,
     ->invoked->skill.name AS invoked_skills
 FROM turn
 ${sinceFilter}
@@ -218,6 +243,108 @@ function deriveProposed(
     return out;
 }
 
+interface SkillPairAccum {
+    fromKey: string;
+    toKey: string;
+    count: number;
+    lastSeen: string; // ISO
+}
+
+interface RecoveryEdge {
+    fromTurnKey: string;
+    skillKey: string;
+    skillName: string;
+    ts: string;
+    errorExcerpt: string | null;
+}
+
+/**
+ * Walk turns in seq order. For every pair of `invoked` skills firing within
+ * `PAIR_WINDOW` turns of each other in the same session, accumulate a
+ * count + max(ts). Pairs are undirected (sorted lexicographically) so
+ * `(a,b)` and `(b,a)` collapse to a single edge. Skills invoked together in
+ * the same turn count too (window includes seq delta = 0).
+ */
+function deriveSkillPairs(
+    bundle: SessionTurns,
+    accum: Map<string, SkillPairAccum>,
+): void {
+    const turns = bundle.turns;
+    // Dedupe invoked_skills per turn: a single assistant turn can fire the
+    // same tool dozens of times (e.g. codex:exec_command 30x in one turn),
+    // and we don't want that to multiply the pair count quadratically.
+    const skillsByTurn = turns.map((t) => [...new Set(t.invoked_skills ?? [])]);
+    for (let i = 0; i < turns.length; i += 1) {
+        const a = turns[i];
+        const aSkills = skillsByTurn[i];
+        if (aSkills.length === 0) continue;
+        for (let j = i; j < turns.length; j += 1) {
+            const b = turns[j];
+            if (b.seq - a.seq > PAIR_WINDOW) break;
+            const bSkills = skillsByTurn[j];
+            if (bSkills.length === 0) continue;
+            for (const sa of aSkills) {
+                for (const sb of bSkills) {
+                    if (sa === sb) continue;
+                    // Same turn pair: avoid double-counting the unordered pair.
+                    if (i === j && sa > sb) continue;
+                    const keyA = skillRecordKey(sa);
+                    const keyB = skillRecordKey(sb);
+                    const { edgeId, fromKey, toKey } = skillPairedEdgeId(keyA, keyB);
+                    const ts = tsToIso(b.ts);
+                    const existing = accum.get(edgeId);
+                    if (existing) {
+                        existing.count += 1;
+                        if (ts > existing.lastSeen) existing.lastSeen = ts;
+                    } else {
+                        accum.set(edgeId, {
+                            fromKey,
+                            toKey,
+                            count: 1,
+                            lastSeen: ts,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * For each turn whose `has_error` flag is true, look forward up to
+ * `RECOVERY_WINDOW` seq steps for the next `invoked` skill in the same
+ * session and emit a `recovered_by` edge from the erroring turn to that
+ * skill. Only the first invocation in the window counts (one recovery per
+ * error).
+ */
+function deriveRecovered(bundle: SessionTurns): RecoveryEdge[] {
+    const out: RecoveryEdge[] = [];
+    const turns = bundle.turns;
+    for (let i = 0; i < turns.length; i += 1) {
+        const t = turns[i];
+        if (!t.has_error) continue;
+        const errorTurnKey = rawTurnKey(t.id);
+        const excerpt = t.text_excerpt;
+        for (let j = i + 1; j < turns.length; j += 1) {
+            const next = turns[j];
+            if (next.seq - t.seq > RECOVERY_WINDOW) break;
+            const skills = next.invoked_skills ?? [];
+            if (skills.length === 0) continue;
+            for (const name of skills) {
+                out.push({
+                    fromTurnKey: errorTurnKey,
+                    skillKey: skillRecordKey(name),
+                    skillName: name,
+                    ts: tsToIso(next.ts),
+                    errorExcerpt: excerpt,
+                });
+            }
+            break; // first invocation window-step wins
+        }
+    }
+    return out;
+}
+
 const fetchSkillNames = (): Effect.Effect<string[], DbError, SurrealClient> =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
@@ -260,11 +387,47 @@ const upsertProposed = (edges: ProposedEdge[]) =>
         }
     });
 
+/**
+ * Idempotent RELATE for `skill_paired`. We aggregate counts in-memory across
+ * all sessions in scope, then RELATE once per unique pair using a
+ * deterministic edge id so re-running `derive-signals` overwrites in place
+ * with identical totals (no count drift from re-fires).
+ */
+const upsertSkillPairs = (pairs: SkillPairAccum[], edgeIds: string[]) =>
+    Effect.gen(function* () {
+        if (pairs.length === 0) return;
+        const db = yield* SurrealClient;
+        const stmts = pairs.map((p, i) => {
+            const edgeId = edgeIds[i];
+            return `RELATE skill:\`${p.fromKey}\` -> skill_paired:\`${edgeId}\` -> skill:\`${p.toKey}\` SET count = ${p.count}, last_seen = d"${p.lastSeen}";`;
+        });
+        for (let i = 0; i < stmts.length; i += 500) {
+            yield* db.query(stmts.slice(i, i + 500).join(""));
+        }
+    });
+
+const upsertRecovered = (edges: RecoveryEdge[]) =>
+    Effect.gen(function* () {
+        if (edges.length === 0) return;
+        const db = yield* SurrealClient;
+        const stmts = edges.map((e) => {
+            const edgeId = recoveredByEdgeId(e.fromTurnKey, e.skillKey);
+            const excerpt =
+                e.errorExcerpt === null ? "NONE" : JSON.stringify(e.errorExcerpt);
+            return `RELATE turn:\`${e.fromTurnKey}\` -> recovered_by:\`${edgeId}\` -> skill:\`${e.skillKey}\` SET ts = d"${e.ts}", error_excerpt = ${excerpt};`;
+        });
+        for (let i = 0; i < stmts.length; i += 500) {
+            yield* db.query(stmts.slice(i, i + 500).join(""));
+        }
+    });
+
 export interface DeriveStats {
     sessions: number;
     turns: number;
     corrections: number;
     proposed: number;
+    skillPairs: number;
+    recoveries: number;
 }
 
 export interface DeriveOpts {
@@ -281,31 +444,51 @@ export const deriveSignals = (
         let corrections = 0;
         let proposed = 0;
         let turnCount = 0;
+        let recoveries = 0;
 
         const correctionBatch: CorrectionEdge[] = [];
         const proposedBatch: ProposedEdge[] = [];
+        const recoveryBatch: RecoveryEdge[] = [];
+        const pairsAccum = new Map<string, SkillPairAccum>();
 
         for (const bundle of bundles) {
             turnCount += bundle.turns.length;
             const c = deriveCorrections(bundle);
             const p = deriveProposed(bundle, skillNames);
+            const r = deriveRecovered(bundle);
             corrections += c.length;
             proposed += p.length;
+            recoveries += r.length;
             correctionBatch.push(...c);
             proposedBatch.push(...p);
+            recoveryBatch.push(...r);
+            deriveSkillPairs(bundle, pairsAccum);
         }
+
+        const pairsList = [...pairsAccum.values()];
+        const pairEdgeIds = [...pairsAccum.keys()];
 
         yield* upsertCorrections(correctionBatch);
         yield* upsertProposed(proposedBatch);
+        yield* upsertSkillPairs(pairsList, pairEdgeIds);
+        yield* upsertRecovered(recoveryBatch);
 
         console.log(
             `[derive-signals] DONE sessions=${bundles.length} turns=${turnCount} corrections=${corrections} proposed=${proposed}`,
+        );
+        console.log(
+            `[skill_pairs] DONE sessions=${bundles.length} pairs=${pairsList.length}`,
+        );
+        console.log(
+            `[recovery] DONE sessions=${bundles.length} edges=${recoveries}`,
         );
         return {
             sessions: bundles.length,
             turns: turnCount,
             corrections,
             proposed,
+            skillPairs: pairsList.length,
+            recoveries,
         };
     });
 


### PR DESCRIPTION
## Summary
- Adds two new RELATION tables — `skill_paired` (undirected co-occurrence within 3 turns) and `recovered_by` (next skill after `has_error=true` turn) — plus their derivation passes in `derive-signals.ts`.
- Per-turn invocations are deduped before pair counting so a single assistant turn firing the same tool 30× doesn't quadratically inflate the pair count.
- Adds `agentctl pairs <skill>` and `agentctl recovery` CLI commands.

## Implementation notes
- `skill_paired`: aggregates counts in-memory across all sessions in scope, then RELATEs once per unique (lo→hi) pair using a deterministic edge id (`lo[:24]__hi[:24]__hash`). Re-running `derive-signals` overwrites in place — counts don't drift.
- `recovered_by`: walks turns in seq order; for each `has_error=true` turn, the first `invoked` skill within `seq+1..seq+3` wins. Edge id is `<turnKey>__<skillKey>` so re-runs upsert.
- `pairs` query handles undirected storage by checking `WHERE in = $s OR out = $s` and picking partner via `IF` (SurrealDB lacks UNION).

## Verification
- `bash scripts/apply-schema.sh` — passes
- `bun run typecheck` — passes (exit 0; only pre-existing TS15/TS44 advisories remain)
- `bun run build` — produces single binary `dist/agentctl`
- `bun src/cli/index.ts derive-signals --since=7` — outputs all four lines including `[skill_pairs] DONE` and `[recovery] DONE`
- Re-run produces identical edge counts (idempotent)

## Sample output (local data)
- `skill_paired` total: 13
- `recovered_by` total: 0 (local dataset has no within-3-turn error→invocation patterns)
- Top pair for `codex:exec_command` → `codex:write_stdin` (count=882)

Closes #19, closes #20