### PR TITLE
feat: live TUI updates via SurrealDB live queries (#22)

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -63,14 +63,14 @@ interface AppProps {
  * in search mode; otherwise the list takes our keystrokes.
  */
 export function App({ client, onQuit }: AppProps) {
-    const liveTick = useLiveInvocations(client);
+    const live = useLiveInvocations(client, true);
     const skills = useSkills(client);
 
     // Re-fetch the list whenever live tick advances.
     useEffect(() => {
-        if (liveTick > 0) skills.refresh();
+        if (live.tick > 0) skills.refresh();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [liveTick]);
+    }, [live.tick]);
 
     const [query, setQuery] = useState("");
     const [mode, setMode] = useState<"list" | "search">("list");
@@ -95,7 +95,7 @@ export function App({ client, onQuit }: AppProps) {
     }, [visibleRows, selectedIndex]);
 
     const selectedSkill = visibleRows[selectedIndex] ?? null;
-    const detail = useSkillDetail(client, selectedSkill?.name ?? null, liveTick);
+    const detail = useSkillDetail(client, selectedSkill?.name ?? null, live.tick);
 
     useKeyboard((key) => {
         // Search mode: only intercept escape; let the input handle everything else.
@@ -198,6 +198,7 @@ export function App({ client, onQuit }: AppProps) {
                 total={skills.data.length}
                 mode={mode}
                 error={errorMessage}
+                lastEvent={live.lastEvent}
             />
         </box>
     );

--- a/src/tui/StatusBar.tsx
+++ b/src/tui/StatusBar.tsx
@@ -3,17 +3,30 @@ interface Props {
     readonly total: number;
     readonly mode: "list" | "search";
     readonly error: string | null;
+    readonly lastEvent?: { readonly skill: string; readonly ts: string } | null;
 }
+
+const formatLiveHint = (
+    lastEvent: { readonly skill: string; readonly ts: string } | null | undefined,
+): string | null => {
+    if (!lastEvent) return null;
+    // `out` is stored as `skill:<id>` - strip the prefix for display.
+    const name = lastEvent.skill.replace(/^skill:⟨?/, "").replace(/⟩$/, "");
+    return `live: ${name}`;
+};
 
 /**
  * Bottom bar: visible-vs-total counts on the left, hotkeys on the right.
  * Errors take precedence over the hotkey hints so they don't get hidden.
+ * When a live invocation has just streamed in, surface a subtle "live: <skill>"
+ * hint so the operator can see the dashboard is reactive without keypresses.
  */
-export function StatusBar({ count, total, mode, error }: Props) {
+export function StatusBar({ count, total, mode, error, lastEvent }: Props) {
     const hints =
         mode === "search"
             ? "type to filter · esc cancel · enter back to list"
             : "↑↓/jk navigate · / search · s sort · r reverse · q quit";
+    const liveHint = formatLiveHint(lastEvent ?? null);
 
     return (
         <box
@@ -28,6 +41,7 @@ export function StatusBar({ count, total, mode, error }: Props) {
         >
             <text fg="#7aa2f7">
                 {error ? "" : `${count}/${total} skills`}
+                {!error && liveHint ? `  ·  ${liveHint}` : ""}
             </text>
             {error ? (
                 <text fg="#f7768e">{error}</text>

--- a/src/tui/hooks/useLiveInvocations.ts
+++ b/src/tui/hooks/useLiveInvocations.ts
@@ -1,61 +1,198 @@
 import { useEffect, useState } from "react";
 import { Effect } from "effect";
 import { flushSync } from "@opentui/react";
+import { Table, type LiveSubscription } from "surrealdb";
 import type { SurrealClientShape } from "../../lib/db.ts";
 
 /**
- * Polling fallback for live invocation updates.
+ * Live state pushed by SurrealDB live queries on the `invoked` relation table.
  *
- * Tries to be a thin wrapper over SurrealDB live queries (`LIVE SELECT * FROM
- * invoked`), but the v2 driver's live API is not exposed through our wrapped
- * `SurrealClient` service yet. Until we extend the wrapper, we just poll a
- * cheap heartbeat query every 5s and bump a tick counter; consumers
- * (`useSkills`, `useSkillDetail`) re-run their queries when the tick advances.
+ * `tick` is bumped on every CREATE event; consumers (`useSkills`,
+ * `useSkillDetail`) re-run their queries when the tick advances, so the
+ * dashboard reflects new invocations within ~1s of arrival.
  *
- * If a new invocation arrives, the next tick will refetch counters and the
- * list re-sorts in place. End-to-end latency is bounded by `intervalMs`.
+ * `lastEvent` carries a low-fidelity hint suitable for status-bar use:
+ * the skill's record id (e.g. `skill:foo`) and the event timestamp.
+ */
+export interface LiveInvocationsState {
+    readonly tick: number;
+    readonly lastEvent: { readonly skill: string; readonly ts: string } | null;
+}
+
+const POLL_FALLBACK_MS = 5000;
+const RECONNECT_DELAY_MS = 1000;
+const MAX_RECONNECTS = 3;
+
+interface InvokedRow {
+    readonly out?: unknown;
+    readonly ts?: unknown;
+}
+
+const extractSkill = (value: InvokedRow | null | undefined): string => {
+    if (!value) return "";
+    const out = (value as { out?: unknown }).out;
+    if (out == null) return "";
+    // RecordId, string, or any value with toString
+    return String(out);
+};
+
+const extractTs = (value: InvokedRow | null | undefined): string => {
+    const ts = value?.ts;
+    if (ts == null) return new Date().toISOString();
+    if (typeof ts === "string") return ts;
+    if (ts instanceof Date) return ts.toISOString();
+    try {
+        return new Date(ts as string).toISOString();
+    } catch {
+        return new Date().toISOString();
+    }
+};
+
+/**
+ * Subscribe to new `invoked` relation rows via a managed SurrealDB live query.
+ *
+ * Failure modes handled:
+ *   1. Server doesn't support live queries → fall back to 5s polling of a
+ *      `count()` heartbeat, matching the pre-live behaviour.
+ *   2. WebSocket drops → the v3 SDK's ManagedLiveSubscription auto-restarts
+ *      itself; we additionally retry up to 3 times on outright `live()`
+ *      failure with a 1s delay before falling back to polling.
+ *
+ * Live queries on relation tables (here `invoked`) work with the bare table
+ * name; the FROM-edge form (e.g. `<-invoked`) is for traversal queries and
+ * cannot be used as a live source.
  */
 export function useLiveInvocations(
     client: SurrealClientShape,
-    intervalMs = 5000,
-): number {
+    enabled = true,
+): LiveInvocationsState {
     const [tick, setTick] = useState(0);
+    const [lastEvent, setLastEvent] = useState<
+        LiveInvocationsState["lastEvent"]
+    >(null);
 
     useEffect(() => {
+        if (!enabled) return;
+
         let cancelled = false;
-        let lastSeen = 0;
+        let activeSub: LiveSubscription | null = null;
+        let unsubscribe: (() => void) | null = null;
+        let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+        let pollTimer: ReturnType<typeof setInterval> | null = null;
+        let attempts = 0;
 
-        const fetchCount = (): Promise<number> =>
-            Effect.runPromise(
-                client.query<[Array<{ c: number }>]>(
-                    "SELECT count() AS c FROM invoked GROUP ALL;",
-                ),
-            )
-                .then((result) => result?.[0]?.[0]?.c ?? 0)
-                .catch(() => lastSeen);
+        const startPolling = (): void => {
+            if (cancelled || pollTimer !== null) return;
+            let lastSeen = 0;
+            const fetchCount = (): Promise<number> =>
+                Effect.runPromise(
+                    client.query<[Array<{ c: number }>]>(
+                        "SELECT count() AS c FROM invoked GROUP ALL;",
+                    ),
+                )
+                    .then((r) => r?.[0]?.[0]?.c ?? lastSeen)
+                    .catch(() => lastSeen);
 
-        // Capture baseline; do not bump tick on first read.
-        void fetchCount().then((c) => {
-            if (!cancelled) lastSeen = c;
-        });
-
-        const handle = setInterval(() => {
+            // Capture baseline without bumping tick.
             void fetchCount().then((c) => {
-                if (cancelled) return;
-                if (c !== lastSeen) {
-                    lastSeen = c;
-                    // Force commit to the OpenTUI renderer; without this the
-                    // tick would not redraw until the next keypress.
-                    flushSync(() => setTick((t) => t + 1));
-                }
+                if (!cancelled) lastSeen = c;
             });
-        }, intervalMs);
+
+            pollTimer = setInterval(() => {
+                void fetchCount().then((c) => {
+                    if (cancelled) return;
+                    if (c !== lastSeen) {
+                        lastSeen = c;
+                        flushSync(() => setTick((t) => t + 1));
+                    }
+                });
+            }, POLL_FALLBACK_MS);
+        };
+
+        const scheduleReconnect = (): void => {
+            if (cancelled) return;
+            if (attempts >= MAX_RECONNECTS) {
+                startPolling();
+                return;
+            }
+            attempts += 1;
+            reconnectTimer = setTimeout(() => {
+                reconnectTimer = null;
+                void connect();
+            }, RECONNECT_DELAY_MS);
+        };
+
+        const connect = async (): Promise<void> => {
+            if (cancelled) return;
+            try {
+                // `live<T>(table)` returns a ManagedLivePromise that resolves
+                // to the active subscription. The ManagedLiveSubscription
+                // restarts itself when the WS reconnects, so we only need
+                // explicit retry handling for the initial dispatch.
+                const sub: LiveSubscription = await client.raw.live<InvokedRow>(
+                    new Table("invoked"),
+                );
+                if (cancelled) {
+                    void sub.kill().catch(() => undefined);
+                    return;
+                }
+                activeSub = sub;
+                attempts = 0; // success resets retry budget
+
+                unsubscribe = sub.subscribe((message) => {
+                    if (cancelled) return;
+                    if (message.action !== "CREATE") return;
+                    const row = message.value as InvokedRow;
+                    const skill = extractSkill(row);
+                    const ts = extractTs(row);
+                    flushSync(() => {
+                        setTick((t) => t + 1);
+                        setLastEvent({ skill, ts });
+                    });
+                });
+            } catch (err) {
+                // Distinguish "server doesn't support live" from transient
+                // disconnects. The SDK throws LiveSubscriptionError with
+                // unsupported=true in the former case; treat anything else as
+                // transient and retry briefly before falling back to polling.
+                const unsupported =
+                    typeof err === "object" &&
+                    err !== null &&
+                    (err as { unsupported?: unknown }).unsupported === true;
+                if (unsupported) {
+                    startPolling();
+                    return;
+                }
+                scheduleReconnect();
+            }
+        };
+
+        void connect();
 
         return () => {
             cancelled = true;
-            clearInterval(handle);
+            if (reconnectTimer !== null) {
+                clearTimeout(reconnectTimer);
+                reconnectTimer = null;
+            }
+            if (pollTimer !== null) {
+                clearInterval(pollTimer);
+                pollTimer = null;
+            }
+            if (unsubscribe) {
+                try {
+                    unsubscribe();
+                } catch {
+                    /* best effort */
+                }
+                unsubscribe = null;
+            }
+            if (activeSub) {
+                void activeSub.kill().catch(() => undefined);
+                activeSub = null;
+            }
         };
-    }, [client, intervalMs]);
+    }, [client, enabled]);
 
-    return tick;
+    return { tick, lastEvent };
 }


### PR DESCRIPTION
Closes #22.

## What

Replace the 5s polling loop in \`useLiveInvocations\` with a managed
SurrealDB live subscription on the \`invoked\` relation table. New
invocations push to the dashboard within ~1s of arrival, no keypresses
or heartbeat polling required.

## API change

Hook now returns:

\`\`\`ts
interface LiveInvocationsState {
    readonly tick: number;
    readonly lastEvent: { skill: string; ts: string } | null;
}
\`\`\`

\`tick\` continues to drive re-fetches in \`useSkills\` and \`useSkillDetail\`
(same wiring as before). \`lastEvent\` feeds a subtle \`live: <skill>\` hint
in the StatusBar so the operator can see reactivity without staring at
the list.

## SurrealDB SDK reality vs spec

The issue body sketches the API as \`db.live(table, callback)\` returning
a query UUID. The installed \`surrealdb@2.0.3\` driver actually exposes
the v3-style managed-live API:

- \`db.live<T>(new Table('invoked'))\` returns a \`ManagedLivePromise\`
- awaiting it yields a \`ManagedLiveSubscription\` with
  \`subscribe(handler)\` (returns unsubscribe), \`kill()\`, \`isAlive\`,
  \`isManaged\`
- callback receives \`{ action, recordId, value, queryId }\` where action
  is \`CREATE | UPDATE | DELETE | KILLED\` (no \`CLOSE\`)

I adapted the hook to this API. Confirmed end-to-end against a local
\`agentctl\` SurrealDB by triggering a \`RELATE turn->invoked->skill\`
while subscribed - the CREATE event arrived in <100ms with the full
edge value (\`{ in, out, ts, args, id }\`).

## Reconnection

Three layers of failure handling:

1. **Server doesn't support live queries** (\`LiveSubscriptionError\`
   with \`unsupported: true\`) -> fall back to the original 5s
   \`count(invoked)\` heartbeat loop, same behaviour as today.
2. **Initial \`live()\` dispatch fails** (e.g. transient WS error) ->
   retry up to 3 times with a 1s delay; if all retries fail, fall back
   to polling.
3. **WS drops after subscription is active** -> handled by the SDK:
   \`ManagedLiveSubscription\` auto-restarts itself on reconnect, no
   work required from the hook.

## Test plan

- [x] \`bun run typecheck\` clean (no new errors)
- [x] \`bun run build\` produces working \`dist/agentctl\`
- [x] Live subscription against \`invoked\` table receives CREATE events
      from triggered RELATE statements
- [ ] \`agentctl tui\` + \`agentctl ingest --since=1\` in a second
      terminal: list updates within ~1s without keypress
- [ ] SIGINT exits cleanly (no hung WS subscription)
- [ ] \`bash scripts/db-stop.sh && bash scripts/db-start.sh\` while TUI
      open: managed sub auto-restarts or falls back to polling