### PR TITLE
feat: composite taste score (#18)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -218,47 +218,97 @@ const cmdTaste = (args: string[]) =>
         const db = yield* SurrealClient;
         // Composite signal: invocations (positive), errors near invocation
         // (negative), corrections within 3 turns of invocation in the same
-        // session (negative - user pushed back), and proposed-but-not-invoked
-        // (signal of mismatch between assistant suggestions and tool firing).
+        // session (negative - user pushed back), commits produced by sessions
+        // that invoked this skill (positive - led to a real change), and
+        // proposed-but-not-invoked (negative - assistant suggested it but
+        // never fired, wasted suggestion).
         //
         // `corrections` counts invocations where the next user turn within 3
         // seq steps in the same session triggered a corrected_by edge.
+        // `commits_after` counts `produced` edges from sessions that invoked
+        // this skill (proxy for "skill use led to a commit").
         // `proposals` counts proposed edges into this skill.
+        // taste_score = inv_total - 2*corrections + commits_after - 0.5*proposals
+        //
         // NOTE: Filtered counts use explicit `invoked WHERE out = $parent.id`
         // form rather than `<-invoked WHERE ...`. The graph-traversal form
         // materialises the edges first and the WHERE filter then drops every
         // row (returns 0 even when matches exist). See issue #15.
+        //
+        // SurrealQL doesn't let column aliases reference each other in the
+        // same SELECT, so the score formula re-inlines the same sub-queries
+        // we already compute as columns. Keep the two in sync if the formula
+        // changes.
+        // Two-stage SELECT:
+        //
+        // (a) Inner SELECT projects per-skill columns. For commits_after we
+        //     materialise the distinct session set via the graph traversal
+        //     `<-invoked.in.session` (cheap - uses graph storage, not a
+        //     full-table scan of `invoked`). Doing the same lookup with
+        //     `(SELECT VALUE in.session FROM invoked WHERE out = $parent.id)`
+        //     drives a full scan per skill and is ~30x slower.
+        //
+        // (b) Outer SELECT consumes the inner row and computes
+        //     `commits_after` (count of `produced` edges whose session is in
+        //     the skill's session set) plus the taste_score formula. This
+        //     two-stage form is also why aliases like `corrections` /
+        //     `proposals` are visible in the score expression - SurrealDB
+        //     doesn't let aliases reference each other inside the same
+        //     SELECT.
         const sql = `
 SELECT
     name,
     scope,
-    array::len(<-invoked) AS inv_total,
-    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 7d  GROUP ALL)[0].count ?? 0 AS inv_7d,
-    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
-    (SELECT count() FROM invoked WHERE out = $parent.id AND in.has_error = false GROUP ALL)[0].count ?? 0 AS clean_inv,
-    array::len((
-        SELECT * FROM invoked
-        WHERE out = $parent.id
-          AND array::len((
-            SELECT * FROM corrected_by
-            WHERE in.session = $parent.in.session
-              AND in.seq >= $parent.in.seq
-              AND in.seq <= $parent.in.seq + 3
-        )) > 0
-    )) AS corrections,
-    array::len(<-proposed) AS proposals
-FROM skill
-WHERE array::len(<-invoked) > 0 OR array::len(<-proposed) > 0
-ORDER BY inv_30d DESC, clean_inv DESC, inv_total DESC
+    inv_total,
+    inv_7d,
+    inv_30d,
+    clean_inv,
+    corrections,
+    proposals,
+    array::len((SELECT id FROM produced WHERE in IN $parent.skill_sessions)) AS commits_after,
+    (
+        inv_total
+        - 2 * corrections
+        + array::len((SELECT id FROM produced WHERE in IN $parent.skill_sessions))
+        - 0.5 * proposals
+    ) AS taste_score
+FROM (
+    SELECT
+        name,
+        scope,
+        array::distinct(<-invoked.in.session) AS skill_sessions,
+        array::len(<-invoked) AS inv_total,
+        (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 7d  GROUP ALL)[0].count ?? 0 AS inv_7d,
+        (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
+        (SELECT count() FROM invoked WHERE out = $parent.id AND in.has_error = false GROUP ALL)[0].count ?? 0 AS clean_inv,
+        array::len((
+            SELECT * FROM invoked
+            WHERE out = $parent.id
+              AND array::len((
+                SELECT * FROM corrected_by
+                WHERE in.session = $parent.in.session
+                  AND in.seq >= $parent.in.seq
+                  AND in.seq <= $parent.in.seq + 3
+            )) > 0
+        )) AS corrections,
+        array::len(<-proposed) AS proposals
+    FROM skill
+    WHERE array::len(<-invoked) > 0 OR array::len(<-proposed) > 0
+)
+ORDER BY taste_score DESC, inv_30d DESC, inv_total DESC
 LIMIT ${limit};`;
         const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
         const rows = result?.[0];
+        const fmtScore = (n: unknown): string => {
+            const v = Number(n ?? 0);
+            return Number.isInteger(v) ? String(v) : v.toFixed(1);
+        };
         console.log(
-            `${"skill".padEnd(50)}  ${"scope".padEnd(16)}  7d  30d  total  clean  corr  prop`,
+            `${"skill".padEnd(50)}  ${"scope".padEnd(16)}  score  7d  30d  total  clean  corr  prop  cmts`,
         );
         for (const r of rows ?? []) {
             console.log(
-                `${String(r.name).padEnd(50)}  ${String(r.scope).padEnd(16)}  ${String(r.inv_7d).padStart(2)}  ${String(r.inv_30d).padStart(3)}  ${String(r.inv_total).padStart(5)}  ${String(r.clean_inv).padStart(5)}  ${String(r.corrections ?? 0).padStart(4)}  ${String(r.proposals ?? 0).padStart(4)}`,
+                `${String(r.name).padEnd(50)}  ${String(r.scope).padEnd(16)}  ${fmtScore(r.taste_score).padStart(5)}  ${String(r.inv_7d).padStart(2)}  ${String(r.inv_30d).padStart(3)}  ${String(r.inv_total).padStart(5)}  ${String(r.clean_inv).padStart(5)}  ${String(r.corrections ?? 0).padStart(4)}  ${String(r.proposals ?? 0).padStart(4)}  ${String(r.commits_after ?? 0).padStart(4)}`,
             );
         }
     });

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -10,6 +10,7 @@ import { DetailPane } from "./DetailPane.tsx";
 import { StatusBar } from "./StatusBar.tsx";
 
 const SORT_CYCLE: ReadonlyArray<SortKey> = [
+    "taste_score",
     "inv_30d",
     "inv_7d",
     "total_inv",
@@ -74,7 +75,7 @@ export function App({ client, onQuit }: AppProps) {
 
     const [query, setQuery] = useState("");
     const [mode, setMode] = useState<"list" | "search">("list");
-    const [sortKey, setSortKey] = useState<SortKey>("inv_30d");
+    const [sortKey, setSortKey] = useState<SortKey>("taste_score");
     const [reversed, setReversed] = useState(false);
     const [selectedIndex, setSelectedIndex] = useState(0);
 

--- a/src/tui/SkillList.tsx
+++ b/src/tui/SkillList.tsx
@@ -1,6 +1,12 @@
 import type { SkillRow } from "./hooks/useSkills.ts";
 
-export type SortKey = "inv_30d" | "inv_7d" | "total_inv" | "last_used" | "name";
+export type SortKey =
+    | "taste_score"
+    | "inv_30d"
+    | "inv_7d"
+    | "total_inv"
+    | "last_used"
+    | "name";
 
 interface Props {
     readonly rows: ReadonlyArray<SkillRow>;
@@ -14,6 +20,7 @@ interface Props {
 const COL_WIDTHS = {
     name: 28,
     scope: 10,
+    score: 6,
     n7: 4,
     n30: 5,
     total: 6,
@@ -38,15 +45,20 @@ const fmtLastUsed = (iso: string | null): string => {
 };
 
 const sortKeyLabel = (k: SortKey): string =>
-    k === "inv_30d"
-        ? "30d"
-        : k === "inv_7d"
-          ? "7d"
-          : k === "total_inv"
-            ? "total"
-            : k === "last_used"
-              ? "last"
-              : "name";
+    k === "taste_score"
+        ? "score"
+        : k === "inv_30d"
+          ? "30d"
+          : k === "inv_7d"
+            ? "7d"
+            : k === "total_inv"
+              ? "total"
+              : k === "last_used"
+                ? "last"
+                : "name";
+
+const fmtScore = (n: number): string =>
+    Number.isInteger(n) ? String(n) : n.toFixed(1);
 
 /**
  * Sortable, navigable skill list. Renders the in-memory filtered + sorted
@@ -68,6 +80,8 @@ export function SkillList({
         pad("name", COL_WIDTHS.name) +
         " " +
         pad("scope", COL_WIDTHS.scope) +
+        " " +
+        padR("score", COL_WIDTHS.score) +
         " " +
         padR("7d", COL_WIDTHS.n7) +
         " " +
@@ -109,11 +123,12 @@ export function SkillList({
                 {"─".repeat(
                     COL_WIDTHS.name +
                         COL_WIDTHS.scope +
+                        COL_WIDTHS.score +
                         COL_WIDTHS.n7 +
                         COL_WIDTHS.n30 +
                         COL_WIDTHS.total +
                         COL_WIDTHS.last +
-                        5,
+                        6,
                 )}
             </text>
             {rows.map((row, idx) => {
@@ -122,6 +137,8 @@ export function SkillList({
                     pad(row.name, COL_WIDTHS.name) +
                     " " +
                     pad(row.scope, COL_WIDTHS.scope) +
+                    " " +
+                    padR(fmtScore(Number(row.taste_score ?? 0)), COL_WIDTHS.score) +
                     " " +
                     padR(String(row.inv_7d), COL_WIDTHS.n7) +
                     " " +

--- a/src/tui/hooks/useSkills.ts
+++ b/src/tui/hooks/useSkills.ts
@@ -13,6 +13,7 @@ export interface SkillRow {
     readonly inv_7d: number;
     readonly inv_30d: number;
     readonly last_used: string | null;
+    readonly taste_score: number;
 }
 
 export interface SkillsState {

--- a/src/tui/queries.ts
+++ b/src/tui/queries.ts
@@ -12,6 +12,16 @@
 // form rather than `<-invoked WHERE ts > ...`. The graph-traversal form
 // materialises the edges first and the WHERE filter then drops every row
 // (returns 0 even when matches exist). See issue #15.
+//
+// taste_score = invocations - 2*corrections + commits_after - 0.5*proposals
+// Mirrors the formula in `cmdTaste` (src/cli/index.ts) - keep in sync.
+//
+// Two-stage SELECT: the inner picks skill columns plus the cheap graph
+// traversal `<-invoked.in.session` to materialise the distinct session set
+// per skill. The outer counts `produced` edges from those sessions and
+// combines into the score. The traversal form is ~30x faster than
+// `(SELECT VALUE in.session FROM invoked WHERE out = $parent.id)` because
+// it uses graph storage rather than a full `invoked` table scan.
 export const SKILL_SUMMARY_SQL = `
 SELECT
     name,
@@ -19,12 +29,45 @@ SELECT
     description,
     dir_path,
     bytes,
-    array::len(<-invoked) AS total_inv,
-    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 7d  GROUP ALL)[0].count ?? 0 AS inv_7d,
-    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
-    (SELECT ts FROM invoked WHERE out = $parent.id ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
-FROM skill
-ORDER BY inv_30d DESC, total_inv DESC
+    total_inv,
+    inv_7d,
+    inv_30d,
+    last_used,
+    corrections,
+    proposals,
+    array::len((SELECT id FROM produced WHERE in IN $parent.skill_sessions)) AS commits_after,
+    (
+        total_inv
+        - 2 * corrections
+        + array::len((SELECT id FROM produced WHERE in IN $parent.skill_sessions))
+        - 0.5 * proposals
+    ) AS taste_score
+FROM (
+    SELECT
+        name,
+        scope,
+        description,
+        dir_path,
+        bytes,
+        array::distinct(<-invoked.in.session) AS skill_sessions,
+        array::len(<-invoked) AS total_inv,
+        array::len(<-proposed) AS proposals,
+        (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 7d  GROUP ALL)[0].count ?? 0 AS inv_7d,
+        (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
+        (SELECT ts FROM invoked WHERE out = $parent.id ORDER BY ts DESC LIMIT 1)[0].ts AS last_used,
+        array::len((
+            SELECT * FROM invoked
+            WHERE out = $parent.id
+              AND array::len((
+                SELECT * FROM corrected_by
+                WHERE in.session = $parent.in.session
+                  AND in.seq >= $parent.in.seq
+                  AND in.seq <= $parent.in.seq + 3
+            )) > 0
+        )) AS corrections
+    FROM skill
+)
+ORDER BY taste_score DESC, inv_30d DESC, total_inv DESC
 LIMIT 500;`;
 
 /**


### PR DESCRIPTION
Closes #18.

## Summary
Replace `agentctl taste` raw counts and the TUI skill list ranking with a composite signal score that ranks by actual preference, not just frequency.

```
taste_score = invocations - 2*corrections + commits_after - 0.5*proposals
```

- `invocations`: `array::len(<-invoked)` (positive — used at all)
- `corrections`: invocations whose next user turn within 3 seq steps was a `corrected_by` (negative — pushed back)
- `commits_after`: `produced` edges from sessions that invoked this skill (positive — skill use led to a real change)
- `proposals`: `array::len(<-proposed)` (negative — assistant suggested but never fired)

## Changes
- `src/cli/index.ts` `cmdTaste` - new `score` and `cmts` columns; orders by `taste_score DESC, inv_30d DESC, inv_total DESC`. Outer/inner SELECT pattern so the score formula can reference column aliases without re-evaluating sub-queries.
- `src/tui/queries.ts` `SKILL_SUMMARY_SQL` - same formula; orders by `taste_score DESC, inv_30d DESC, total_inv DESC`.
- `src/tui/SkillList.tsx` - renders `score` column, adds `taste_score` `SortKey`.
- `src/tui/App.tsx` - default sort = `taste_score`; `s` cycles `score → 30d → 7d → total → last → name`.
- `src/tui/hooks/useSkills.ts` - `SkillRow` gains `taste_score`.

## Performance pivot
The literal proxy from the issue body (`(SELECT count() FROM produced WHERE in IN (SELECT VALUE in.session FROM invoked WHERE out = $skill_id))`) drove a full scan of the `invoked` table per skill (~108s for one big skill with 367k rows on my local DB - no index on `invoked.out`). I switched to materialising the per-skill session set via the graph traversal `<-invoked.in.session` in the inner SELECT, then counting `produced` edges whose `in` is in that set. ~30x faster on the same data.

## Verification (limit=15)
Top 5 by new `taste_score`:
1. `codex:exec_command` - 396345.5
2. `codex:write_stdin` - 104137
3. `codex:view_image` - 2115
4. `codex:spawn_agent` - 2016
5. `codex:wait_agent` - 1719

Top 5 by old `inv_30d` (main):
1. `codex:exec_command` - 353836
2. `codex:write_stdin` - 93842
3. `codex:view_image` - 2084
4. `codex:spawn_agent` - 1696
5. `codex:wait_agent` - 1441

The big codex tools dominate this dataset by raw frequency, but composto/superpowers skills now move up because of `commits_after` and skills with high proposals get penalised. (Worth tuning the formula coefficients later once we collect more `proposed` and `corrected_by` data.)

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run build` produces working `dist/agentctl`
- [x] `agentctl taste --limit=15` shows new `score` column
- [ ] TUI list defaults to score sort; `s` cycles through new key