### PR TITLE
perf: relation table indexes (#29)

### DIFF
--- a/schema/schema.surql
+++ b/schema/schema.surql
@@ -84,18 +84,29 @@ DEFINE INDEX commit_sha_uq  ON commit FIELDS repo, sha UNIQUE;
 DEFINE TABLE invoked      TYPE RELATION FROM turn TO skill;     -- explicit Skill tool call
 DEFINE FIELD args         ON invoked TYPE option<string>;       -- JSON-encoded
 DEFINE FIELD ts           ON invoked TYPE datetime;
+-- Most cmdTaste/cmdSearch/cmdUnused subqueries filter
+-- `WHERE out = $skill_id AND ts > time::now() - Nd`. Composite index
+-- covers both predicates from one seek.
+DEFINE INDEX IF NOT EXISTS invoked_out_ts ON invoked FIELDS out, ts;
 
 DEFINE TABLE proposed     TYPE RELATION FROM turn TO skill;     -- assistant text mentioned skill, never invoked
 DEFINE FIELD ts           ON proposed TYPE datetime;
 DEFINE FIELD context_excerpt ON proposed TYPE option<string>;
+-- `<-proposed` traversal counts (proposed-but-never-invoked) hit `out`.
+DEFINE INDEX IF NOT EXISTS proposed_out ON proposed FIELDS out;
 
 DEFINE TABLE edited       TYPE RELATION FROM turn TO file;      -- Edit/Write tool fired
 DEFINE FIELD tool         ON edited TYPE string;                -- 'Edit'|'Write'|'NotebookEdit'
 DEFINE FIELD ts           ON edited TYPE datetime;
+-- `edited` lookups by source turn (e.g., 'which files did this session edit').
+DEFINE INDEX IF NOT EXISTS edited_in ON edited FIELDS in;
 
 DEFINE TABLE corrected_by TYPE RELATION FROM turn TO turn;      -- assistant turn → next user turn that pushed back
 DEFINE FIELD pattern      ON corrected_by TYPE option<string>;  -- which negation pattern matched
 DEFINE FIELD ts           ON corrected_by TYPE datetime;
+-- `corrected_by` lookups in cmdTaste's correction-rate subquery walk via `in`
+-- (the assistant turn that was corrected).
+DEFINE INDEX IF NOT EXISTS corrected_by_in ON corrected_by FIELDS in;
 
 DEFINE TABLE produced     TYPE RELATION FROM session TO commit;
 DEFINE TABLE touched      TYPE RELATION FROM commit TO file;


### PR DESCRIPTION
Closes #29

## Summary

Relation tables (`invoked`, `proposed`, `corrected_by`, `edited`) had **zero** indexes. Every per-skill subquery in `cmdTaste`/`cmdSearch`/`cmdUnused` and the TUI summary forced a full table scan over `invoked` (~574k rows locally).

## Indexes added

| Index | Table | Fields | Used by |
|---|---|---|---|
| `invoked_out_ts` | `invoked` | `out, ts` | `WHERE out = $skill AND ts > time::now() - Nd` (cmdTaste 7d/30d, cmdSearch 30d, cmdUnused) |
| `proposed_out` | `proposed` | `out` | `<-proposed` count (cmdTaste `proposals`) |
| `edited_in` | `edited` | `in` | reverse turn -> files lookup |
| `corrected_by_in` | `corrected_by` | `in` | corrections subquery in cmdTaste |

## Verification

`EXPLAIN` confirms all four indexes are picked up:
```
Aggregate [mode: GROUP ALL]
  IndexScan [index: invoked_out_ts, access: [skill:...] MoreThan d'...']

IndexCountScan [source: proposed, condition: out = skill:...]
IndexScan [index: corrected_by_in, access: = turn:...]
IndexScan [index: edited_in, access: = turn:...]
```

`bun run typecheck` clean (no errors; only pre-existing Effect-lint info messages).
`bun run build` produces a working `dist/agentctl` with the new schema embedded via the bun text loader (verified: `strings dist/agentctl | rg invoked_out_ts` hits).
Smoke-tested `taste`, `unused`, `search` against the local DB — all return correct results.

## Wall-time benchmark (`agentctl taste --limit=80`)

| | Wall time |
|---|---|
| Before | **157.04 s** |
| After  | **153.58 s** |

Modest improvement on the dominant query, **not the seconds-scale drop the issue predicted**. The indexes themselves are correctly seeked (verified above), but `cmdTaste`'s remaining cost is dominated by per-row field-deref against the indexed result set, not the index lookup. Specifically, for the hottest skill `codex:exec_command` (~448k invocations):

- `clean_inv`: `SELECT count() FROM invoked WHERE out = $sk AND in.has_error = false GROUP ALL` -> 2.6 s. Plan: `IndexScan` then `Filter [predicate: in.has_error = false]` -> 448k turn-record dereferences.
- `corrections`: nested `SELECT * FROM invoked WHERE out = $sk AND array::len((SELECT * FROM corrected_by WHERE in.session = $parent.in.session AND in.seq >= ... AND in.seq <= ... + 3)) > 0` -> **20.3 s** for that one skill alone. Per-invocation correlated subquery + chained field deref through `in.session`/`in.seq`.
- `<-invoked.in.session`: 2.5 s. Graph-storage traversal of 448k edges, then per-edge `.in.session` fetch.

The index changes shipped here are still correct and worth landing — they're the foundation any further optimization needs. **Issue #29 as scoped (relation-table indexes) is delivered.** The remaining wall-time gap needs CLI-side query restructuring (out of scope here, since the issue prohibits touching `src/cli/*`):

- Materialise per-skill aggregates so 448k-row skills don't dominate
- Replace `in.has_error = false` filter with a `clean_inv` boolean stored on the `invoked` edge at ingest time
- Pre-compute `corrections` as an `invoked.was_corrected: bool` field at ingest time

Recommend opening a follow-up issue for the CLI/ingest side.

## Index storage cost

`INFO FOR DB` after applying:

```
indexes: { invoked_out_ts: 'DEFINE INDEX invoked_out_ts ON invoked FIELDS out, ts' }
indexes: { proposed_out: 'DEFINE INDEX proposed_out ON proposed FIELDS out' }
indexes: { edited_in: 'DEFINE INDEX edited_in ON edited FIELDS in' }
indexes: { corrected_by_in: 'DEFINE INDEX corrected_by_in ON corrected_by FIELDS in' }
```

Row counts: `invoked` 573,990, `proposed` 155, `edited` 62,549, `corrected_by` 10. SurrealDB index sizes are not directly exposed through `INFO`; index build was instantaneous and no bucket pressure observed.

## Test plan

- [x] `bash scripts/apply-schema.sh` succeeds idempotently
- [x] `INFO FOR TABLE invoked|proposed|edited|corrected_by` shows new indexes
- [x] `EXPLAIN` against each rewritten subquery shows IndexScan / IndexCountScan
- [x] `bun run typecheck` clean
- [x] `bun run build` produces working `dist/agentctl`
- [x] `agentctl taste`, `agentctl unused`, `agentctl search` return correct results
- [x] `dist/agentctl` binary embeds the four new index definitions