### PR TITLE
perf: cmdTaste subquery rewrite (FETCH or graph-WHERE) (#31)

### DIFF
--- a/schema/schema.surql
+++ b/schema/schema.surql
@@ -84,6 +84,18 @@ DEFINE INDEX commit_sha_uq  ON commit FIELDS repo, sha UNIQUE;
 DEFINE TABLE invoked      TYPE RELATION FROM turn TO skill;     -- explicit Skill tool call
 DEFINE FIELD args         ON invoked TYPE option<string>;       -- JSON-encoded
 DEFINE FIELD ts           ON invoked TYPE datetime;
+-- Denormalised copies of the source turn's `has_error` and "was corrected
+-- within 3 user turns" flags. cmdTaste's `clean_inv` / `corrections`
+-- subqueries previously dereferenced `in.has_error` / walked `corrected_by`
+-- per row, which forced a per-edge record fetch (~1-2s on the largest skill
+-- × 137 skills). With these flags on the edge, the same counts collapse to a
+-- single full-scan GROUP BY out aggregate (see issue #31). Default `false`
+-- so freshly-relate'd edges never carry NONE (which would break the
+-- `WHERE turn_has_error = false` predicate). Populated at ingest
+-- (transcripts.ts, codex.ts) and updated by derive-signals when a
+-- corrected_by edge is emitted.
+DEFINE FIELD turn_has_error ON invoked TYPE bool DEFAULT false;
+DEFINE FIELD was_corrected  ON invoked TYPE bool DEFAULT false;
 -- Most cmdTaste/cmdSearch/cmdUnused subqueries filter
 -- `WHERE out = $skill_id AND ts > time::now() - Nd`. Composite index
 -- covers both predicates from one seek.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -88,40 +88,49 @@ const cmdSearch = (args: string[]) =>
         // form rather than `<-invoked WHERE ts > ...`. The graph-traversal
         // form materialises edges first then the WHERE drops every row
         // (returns 0 even when matches exist). See issue #15.
+        // PERF (issue #31): The per-row `(SELECT count() FROM invoked
+        // WHERE out = $parent.id AND ts > 30d ...)` subquery costs ~1.5s
+        // per matched skill that happens to be one of the high-volume
+        // ones (e.g. codex:exec_command @ ~500k edges). For a search hit
+        // that includes them, total runtime jumps to 30s+. The fix is the
+        // same as cmdTaste: do the per-skill recent counters in one
+        // GROUP BY scan, then merge with the FTS-ranked result list.
         const ftsSql = `
 SELECT
+    id,
     name,
     scope,
     description,
-    (math::max([search::score(0), 0.0]) + math::max([search::score(1), 0.0])) AS score,
-    array::len(<-invoked) AS total_inv,
-    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
-    (SELECT ts FROM invoked WHERE out = $parent.id ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
+    (math::max([search::score(0), 0.0]) + math::max([search::score(1), 0.0])) AS score
 FROM skill
 WHERE name @0@ $q OR description @1@ $q
-ORDER BY score DESC, inv_30d DESC, total_inv DESC
+ORDER BY score DESC
 LIMIT ${limit};`;
-        // Fallback: legacy CONTAINS query for DBs that haven't had
-        // schema/schema.surql re-applied since this change landed (FTS
-        // index missing). Mirrors the pre-FTS behaviour with a synthetic
-        // score column so the downstream rendering loop is uniform.
         const legacySql = `
 SELECT
+    id,
     name,
     scope,
     description,
     (IF string::lowercase(name) CONTAINS $q THEN 2.0 ELSE 0.0 END
-     + IF string::lowercase(description ?? '') CONTAINS $q THEN 1.0 ELSE 0.0 END) AS score,
-    array::len(<-invoked) AS total_inv,
-    (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
-    (SELECT ts FROM invoked WHERE out = $parent.id ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
+     + IF string::lowercase(description ?? '') CONTAINS $q THEN 1.0 ELSE 0.0 END) AS score
 FROM skill
 WHERE
     string::lowercase(name) CONTAINS $q
     OR string::lowercase(description ?? '') CONTAINS $q
-ORDER BY score DESC, inv_30d DESC, total_inv DESC
+ORDER BY score DESC
 LIMIT ${limit};`;
-        const result = yield* db
+        // Per-skill aggregates over `invoked` in one full scan
+        // (~1-2s) - cheap relative to repeating it per matched skill.
+        const aggSql = `
+SELECT
+    out AS skill_id,
+    count() AS total_inv,
+    math::sum(IF ts > time::now() - 30d THEN 1 ELSE 0 END) AS inv_30d,
+    math::max(ts) AS last_used
+FROM invoked
+GROUP BY out;`;
+        const matchResult = yield* db
             .query<[Array<Record<string, unknown>>]>(ftsSql, { q: query })
             .pipe(
                 Effect.catch(() =>
@@ -130,7 +139,32 @@ LIMIT ${limit};`;
                     }),
                 ),
             );
-        const rows = result?.[0];
+        const aggResult = yield* db.query<[Array<Record<string, unknown>>]>(aggSql);
+        const matched = (matchResult?.[0] ?? []) as Array<Record<string, unknown>>;
+        const aggMap = new Map<string, Record<string, unknown>>();
+        for (const a of (aggResult?.[0] ?? []) as Array<Record<string, unknown>>) {
+            aggMap.set(String(a.skill_id ?? ""), a);
+        }
+        const rows = matched
+            .map((m) => {
+                const agg = aggMap.get(String(m.id ?? ""));
+                return {
+                    name: m.name,
+                    scope: m.scope,
+                    description: m.description,
+                    score: m.score,
+                    total_inv: agg ? Number(agg.total_inv ?? 0) : 0,
+                    inv_30d: agg ? Number(agg.inv_30d ?? 0) : 0,
+                    last_used: agg?.last_used ?? null,
+                };
+            })
+            .sort((a, b) => {
+                const ds = Number(b.score ?? 0) - Number(a.score ?? 0);
+                if (ds !== 0) return ds;
+                const d30 = b.inv_30d - a.inv_30d;
+                if (d30 !== 0) return d30;
+                return b.total_inv - a.total_inv;
+            });
         if (!rows || rows.length === 0) {
             console.log("(no matches)");
             return;
@@ -224,26 +258,88 @@ const cmdUnused = (args: string[]) =>
     Effect.gen(function* () {
         const days = parseInt(flag("days", args) ?? "7", 10);
         const db = yield* SurrealClient;
-        // See issue #15: `<-invoked WHERE ts > ...` materialises edges first
-        // then the WHERE drops everything, so the count is always 0. Use the
-        // explicit `invoked WHERE out = $parent.id` form instead.
-        const sql = `
+        // PERF (issue #31): Previous form ran a correlated subquery per skill
+        // (`SELECT count() FROM invoked WHERE out = $parent.id AND ts > N`).
+        // On the largest skill (~500k invoked edges) the index walk took
+        // ~1.5s × 137 skills = enough to make this multi-minute.
+        //
+        // Now we (a) compute the recent-active set in one full-scan
+        // GROUP BY over `invoked`, (b) compute total_inv + last_used in
+        // bulk, (c) anti-join in TS. Net round-trip: ~2 cheap queries.
+        const recentSql = `
+SELECT out AS skill_id, count() AS recent
+FROM invoked
+WHERE ts > time::now() - ${days}d
+GROUP BY out;`;
+        const summarySql = `
 SELECT
-    name,
-    scope,
-    array::len(<-invoked) AS total_inv,
-    (SELECT ts FROM invoked WHERE out = $parent.id ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
-FROM skill
-WHERE ((SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - ${days}d GROUP ALL)[0].count ?? 0) = 0
-ORDER BY total_inv ASC, name ASC;`;
-        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
-        const rows = result?.[0];
-        for (const r of rows ?? []) {
+    out AS skill_id,
+    out.name AS name,
+    out.scope AS scope,
+    count() AS total_inv,
+    math::max(ts) AS last_used
+FROM invoked
+GROUP BY out;`;
+        // Skills with literally zero invocations don't show up in the
+        // GROUP BY scan; pull them straight from the skill table so the
+        // "never used" rows still appear.
+        const noInvSql = `
+SELECT name, scope FROM skill WHERE array::len(<-invoked) = 0;`;
+        const [recentRes, summaryRes, noInvRes] = yield* Effect.all(
+            [
+                db.query<[Array<Record<string, unknown>>]>(recentSql),
+                db.query<[Array<Record<string, unknown>>]>(summarySql),
+                db.query<[Array<Record<string, unknown>>]>(noInvSql),
+            ],
+            { concurrency: 3 },
+        );
+        const recent = new Set<string>(
+            (recentRes?.[0] ?? []).map((r) => String(r.skill_id ?? "")),
+        );
+        const summary = (summaryRes?.[0] ?? []) as Array<Record<string, unknown>>;
+        const fmtTs = (v: unknown): string => {
+            if (v == null) return "never";
+            if (typeof v === "string") return v;
+            if (v instanceof Date) return v.toISOString();
+            return String(v);
+        };
+        const unused: Array<{
+            name: string;
+            scope: string;
+            total_inv: number;
+            last_used: string;
+        }> = [];
+        for (const r of summary) {
+            const id = String(r.skill_id ?? "");
+            if (recent.has(id)) continue;
+            // Drop orphans (invoked.out points at a skill record that was
+            // never UPSERTed - matches the original FROM-skill behaviour).
+            if (r.name == null) continue;
+            unused.push({
+                name: String(r.name),
+                scope: String(r.scope ?? ""),
+                total_inv: Number(r.total_inv ?? 0),
+                last_used: fmtTs(r.last_used),
+            });
+        }
+        for (const r of (noInvRes?.[0] ?? []) as Array<Record<string, unknown>>) {
+            unused.push({
+                name: String(r.name ?? ""),
+                scope: String(r.scope ?? ""),
+                total_inv: 0,
+                last_used: "never",
+            });
+        }
+        unused.sort(
+            (a, b) =>
+                a.total_inv - b.total_inv || a.name.localeCompare(b.name),
+        );
+        for (const r of unused) {
             console.log(
-                `${r.name}  [${r.scope}]  total=${r.total_inv ?? 0}  last=${r.last_used ?? "never"}`,
+                `${r.name}  [${r.scope}]  total=${r.total_inv}  last=${r.last_used}`,
             );
         }
-        console.log(`\n${rows?.length ?? 0} skills unused in last ${days} days.`);
+        console.log(`\n${unused.length} skills unused in last ${days} days.`);
     });
 
 const cmdTaste = (args: string[]) =>
@@ -264,32 +360,37 @@ const cmdTaste = (args: string[]) =>
         // `proposals` counts proposed edges into this skill.
         // taste_score = inv_total - 2*corrections + commits_after - 0.5*proposals
         //
-        // NOTE: Filtered counts use explicit `invoked WHERE out = $parent.id`
-        // form rather than `<-invoked WHERE ...`. The graph-traversal form
-        // materialises the edges first and the WHERE filter then drops every
-        // row (returns 0 even when matches exist). See issue #15.
+        // PERF (issue #31): The previous form ran 4-5 correlated subqueries
+        // per skill (`WHERE out = $parent.id AND <pred>`), each forcing the
+        // index scan to walk every edge for that skill. On the largest skill
+        // (codex:exec_command, ~500k edges) every subquery cost ~1.5-2s,
+        // putting the total at ~167s for 137 skills. SurrealDB's optimiser
+        // doesn't push graph traversal `<-invoked WHERE ...` past the edge
+        // materialisation either, so neither FETCH nor inline graph-WHERE
+        // helped meaningfully (~90s).
         //
-        // SurrealQL doesn't let column aliases reference each other in the
-        // same SELECT, so the score formula re-inlines the same sub-queries
-        // we already compute as columns. Keep the two in sync if the formula
-        // changes.
-        // Two-stage SELECT:
+        // Current form does the heavy aggregation in ONE pass over the
+        // `invoked` table via `GROUP BY out` with conditional `math::sum`.
+        // This requires two new denormalised fields on the edge:
+        //   - `turn_has_error` (set at ingest from the source turn)
+        //   - `was_corrected`  (set by derive-signals when a corrected_by
+        //                       edge falls within +3 seq of the invocation)
+        // so that the `clean_inv` / `corrections` predicates become pure
+        // edge-field filters. End-to-end taste runtime drops to ~13s.
         //
-        // (a) Inner SELECT projects per-skill columns. For commits_after we
-        //     materialise the distinct session set via the graph traversal
-        //     `<-invoked.in.session` (cheap - uses graph storage, not a
-        //     full-table scan of `invoked`). Doing the same lookup with
-        //     `(SELECT VALUE in.session FROM invoked WHERE out = $parent.id)`
-        //     drives a full scan per skill and is ~30x slower.
-        //
-        // (b) Outer SELECT consumes the inner row and computes
-        //     `commits_after` (count of `produced` edges whose session is in
-        //     the skill's session set) plus the taste_score formula. This
-        //     two-stage form is also why aliases like `corrections` /
-        //     `proposals` are visible in the score expression - SurrealDB
-        //     doesn't let aliases reference each other inside the same
-        //     SELECT.
-        const sql = `
+        // The query runs in two server-side stages plus a client-side merge
+        // of the proposed-only skills (which have no `invoked` edges and
+        // therefore wouldn't appear in the GROUP BY result):
+        //   (a) AGGREGATES_SQL  - per-skill counters from the invoked scan,
+        //                         then enriches with `<-proposed` /
+        //                         `<-invoked.in.session` traversals and
+        //                         `produced` join.
+        //   (b) PROPOSED_ONLY_SQL - skills with no invocations but with
+        //                           proposals, contributing the negative
+        //                           taste_score floor (-0.5 * proposals).
+        // Results are concatenated and sorted in TS to mirror the original
+        // ORDER BY taste_score DESC, inv_30d DESC, inv_total DESC.
+        const aggregatesSql = `
 SELECT
     name,
     scope,
@@ -299,7 +400,9 @@ SELECT
     clean_inv,
     corrections,
     proposals,
-    array::len((SELECT id FROM produced WHERE in IN $parent.skill_sessions)) AS commits_after,
+    array::len((
+        SELECT id FROM produced WHERE in IN $parent.skill_sessions
+    )) AS commits_after,
     (
         inv_total
         - 2 * corrections
@@ -308,31 +411,66 @@ SELECT
     ) AS taste_score
 FROM (
     SELECT
-        name,
-        scope,
-        array::distinct(<-invoked.in.session) AS skill_sessions,
-        array::len(<-invoked) AS inv_total,
-        (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 7d  GROUP ALL)[0].count ?? 0 AS inv_7d,
-        (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
-        (SELECT count() FROM invoked WHERE out = $parent.id AND in.has_error = false GROUP ALL)[0].count ?? 0 AS clean_inv,
-        array::len((
-            SELECT * FROM invoked
-            WHERE out = $parent.id
-              AND array::len((
-                SELECT * FROM corrected_by
-                WHERE in.session = $parent.in.session
-                  AND in.seq >= $parent.in.seq
-                  AND in.seq <= $parent.in.seq + 3
-            )) > 0
-        )) AS corrections,
-        array::len(<-proposed) AS proposals
-    FROM skill
-    WHERE array::len(<-invoked) > 0 OR array::len(<-proposed) > 0
-)
-ORDER BY taste_score DESC, inv_30d DESC, inv_total DESC
-LIMIT ${limit};`;
-        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
-        const rows = result?.[0];
+        skill_id.name AS name,
+        skill_id.scope AS scope,
+        inv_total,
+        inv_7d,
+        inv_30d,
+        clean_inv,
+        corrections,
+        array::len(skill_id<-proposed) AS proposals,
+        array::distinct(skill_id<-invoked.in.session ?? []) AS skill_sessions
+    FROM (
+        SELECT
+            out AS skill_id,
+            count() AS inv_total,
+            math::sum(IF ts > time::now() - 7d  THEN 1 ELSE 0 END) AS inv_7d,
+            math::sum(IF ts > time::now() - 30d THEN 1 ELSE 0 END) AS inv_30d,
+            math::sum(IF turn_has_error = false THEN 1 ELSE 0 END) AS clean_inv,
+            math::sum(IF was_corrected   = true  THEN 1 ELSE 0 END) AS corrections
+        FROM invoked
+        GROUP BY out
+    )
+    -- Drop orphan invocations whose target skill never had its row UPSERTed
+    -- (matches the original cmdTaste behaviour, which started FROM skill and
+    -- thus naturally excluded these). Currently happens for a handful of
+    -- legacy plugin/built-in tool names that didn't get recorded as skills.
+    WHERE skill_id.name IS NOT NONE
+);`;
+
+        // Skills with proposals but no invocations - the GROUP BY scan
+        // doesn't see them. Cheap: 137-skill count + per-skill proposal
+        // count, all via graph traversal.
+        const proposedOnlySql = `
+SELECT
+    name,
+    scope,
+    0 AS inv_total,
+    0 AS inv_7d,
+    0 AS inv_30d,
+    0 AS clean_inv,
+    0 AS corrections,
+    array::len(<-proposed) AS proposals,
+    0 AS commits_after,
+    -0.5 * array::len(<-proposed) AS taste_score
+FROM skill
+WHERE array::len(<-invoked) = 0 AND array::len(<-proposed) > 0;`;
+
+        const aggResult = yield* db.query<[Array<Record<string, unknown>>]>(aggregatesSql);
+        const propResult = yield* db.query<[Array<Record<string, unknown>>]>(proposedOnlySql);
+        const aggRows = aggResult?.[0] ?? [];
+        const propRows = propResult?.[0] ?? [];
+        // Merge + sort to mirror original ORDER BY (server-side ORDER BY
+        // would force a second pass over the merged set, simpler in TS).
+        const score = (r: Record<string, unknown>) => Number(r.taste_score ?? 0);
+        const merged = [...aggRows, ...propRows].sort((a, b) => {
+            const ds = score(b) - score(a);
+            if (ds !== 0) return ds;
+            const d30 = Number(b.inv_30d ?? 0) - Number(a.inv_30d ?? 0);
+            if (d30 !== 0) return d30;
+            return Number(b.inv_total ?? 0) - Number(a.inv_total ?? 0);
+        });
+        const rows = merged.slice(0, limit);
         const fmtScore = (n: unknown): string => {
             const v = Number(n ?? 0);
             return Number.isInteger(v) ? String(v) : v.toFixed(1);

--- a/src/ingest/codex.ts
+++ b/src/ingest/codex.ts
@@ -243,9 +243,14 @@ export const ingestCodex = (
                 yield* db.query(skillStmts.join(""));
             }
 
+            // Codex transcripts don't surface tool errors at the turn level
+            // (errors live inside `function_call_output` payloads we don't
+            // currently parse), so `turn_has_error` is always false here.
+            // The field is set explicitly anyway so the edge has the same
+            // shape as Claude-source edges (see issue #31).
             const invStmts = extracted.invocations.map(
                 (inv) =>
-                    `RELATE turn:\`${turnRecordKey(inv.session, inv.seq)}\`->invoked->skill:\`${skillRecordKey(inv.skill)}\` SET ts = d"${inv.ts}", args = ${JSON.stringify(JSON.stringify(inv.args))};`,
+                    `RELATE turn:\`${turnRecordKey(inv.session, inv.seq)}\`->invoked->skill:\`${skillRecordKey(inv.skill)}\` SET ts = d"${inv.ts}", args = ${JSON.stringify(JSON.stringify(inv.args))}, turn_has_error = false;`,
             );
             for (let i = 0; i < invStmts.length; i += 500) {
                 yield* db.query(invStmts.slice(i, i + 500).join(""));

--- a/src/ingest/derive-signals.ts
+++ b/src/ingest/derive-signals.ts
@@ -155,6 +155,12 @@ interface CorrectionEdge {
     toTurnKey: string;
     pattern: string;
     ts: string;
+    // Session + seq of the corrected (assistant) turn. Used to mark
+    // invoked edges as `was_corrected = true` for any invocation whose
+    // turn falls in [correctedSeq - 3, correctedSeq] (matches the
+    // pre-denormalisation cmdTaste +3 seq window). See issue #31.
+    correctedSession: string;
+    correctedSeq: number;
 }
 
 interface ProposedEdge {
@@ -197,6 +203,8 @@ function deriveCorrections(bundle: SessionTurns): CorrectionEdge[] {
                 toTurnKey: rawTurnKey(t.id),
                 pattern: matched,
                 ts: tsToIso(t.ts),
+                correctedSession: bundle.sessionId,
+                correctedSeq: prev.seq,
             });
         }
         // After a user turn fires, reset the anchor so the next correction
@@ -374,6 +382,48 @@ const upsertCorrections = (edges: CorrectionEdge[]) =>
         }
     });
 
+/**
+ * For each correction edge, mark every `invoked` edge whose source turn falls
+ * in `[correctedSeq - 3, correctedSeq]` of the same session as
+ * `was_corrected = true`. This denormalises the +3-seq-window check that
+ * cmdTaste's `corrections` subquery used to do per row (~6s on the largest
+ * skill); after this, the same count becomes a single GROUP BY scan with no
+ * record fetch. See issue #31.
+ *
+ * The window is inclusive on both ends: an invocation IS considered
+ * corrected if its turn is the one that got pushed back, OR if a later turn
+ * within 3 steps got pushed back. Mirrors the original SurrealQL predicate
+ * `in.seq >= $parent.in.seq AND in.seq <= $parent.in.seq + 3`.
+ */
+const markWasCorrected = (edges: CorrectionEdge[]) =>
+    Effect.gen(function* () {
+        if (edges.length === 0) return;
+        const db = yield* SurrealClient;
+        // Build the universe of (session, seq) tuples that should be marked.
+        // Multiple correction edges may overlap; dedupe via a Set keyed by
+        // the deterministic turn record-key so we issue exactly one UPDATE
+        // per turn regardless of overlap.
+        const turnsToMark = new Set<string>();
+        for (const e of edges) {
+            const lo = Math.max(1, e.correctedSeq - 3);
+            const hi = e.correctedSeq;
+            for (let seq = lo; seq <= hi; seq += 1) {
+                // turnRecordKey strips `-` from session id; replicate inline
+                // (separate file so we can't import the private helper).
+                const sess = e.correctedSession.replace(/-/g, "");
+                turnsToMark.add(`${sess}_${seq}`);
+            }
+        }
+        if (turnsToMark.size === 0) return;
+        const stmts = [...turnsToMark].map(
+            (turnKey) =>
+                `UPDATE invoked SET was_corrected = true WHERE in = turn:\`${turnKey}\` RETURN NONE;`,
+        );
+        for (let i = 0; i < stmts.length; i += 500) {
+            yield* db.query(stmts.slice(i, i + 500).join(""));
+        }
+    });
+
 const upsertProposed = (edges: ProposedEdge[]) =>
     Effect.gen(function* () {
         if (edges.length === 0) return;
@@ -469,6 +519,9 @@ export const deriveSignals = (
         const pairEdgeIds = [...pairsAccum.keys()];
 
         yield* upsertCorrections(correctionBatch);
+        // Denormalise was_corrected onto invoked edges so cmdTaste's
+        // corrections subquery becomes a pure index/scan filter (issue #31).
+        yield* markWasCorrected(correctionBatch);
         yield* upsertProposed(proposedBatch);
         yield* upsertSkillPairs(pairsList, pairEdgeIds);
         yield* upsertRecovered(recoveryBatch);

--- a/src/ingest/transcripts.ts
+++ b/src/ingest/transcripts.ts
@@ -32,6 +32,11 @@ interface Invocation {
     ts: string;
     skill: string;
     args: unknown;
+    // Snapshot of the source turn's `has_error` at relate time. Denormalised
+    // onto the edge so cmdTaste's `clean_inv` count can hit a single
+    // GROUP BY scan instead of dereferencing `in.has_error` per row (~30x
+    // slower on the largest skills). See issue #31.
+    turn_has_error: boolean;
 }
 
 interface Edit {
@@ -130,6 +135,11 @@ async function extractFile(filePath: string, projectDir: string): Promise<FileEx
         let textExcerpt: string | null = null;
         let hasToolUse = false;
         let hasError = false;
+        // Track invocation indices added this iteration so we can backfill
+        // `turn_has_error` once `hasError` is finalised below (a tool_result
+        // block later in the same content array can flip it after the
+        // tool_use that emitted the invocation).
+        const turnInvStart = invocations.length;
 
         for (const block of content) {
             if (block.type === "text" && typeof block.text === "string" && !textExcerpt) {
@@ -149,6 +159,11 @@ async function extractFile(filePath: string, projectDir: string): Promise<FileEx
                             ts,
                             skill: skillName,
                             args: block.input,
+                            // Backfilled after the content loop below; assistant
+                            // turns essentially never carry has_error in current
+                            // data (it lives on tool_result turns) but we set
+                            // the field correctly in case future capture changes.
+                            turn_has_error: false,
                         });
                     }
                 } else if (
@@ -173,6 +188,15 @@ async function extractFile(filePath: string, projectDir: string): Promise<FileEx
             }
             if (block.type === "tool_result" && (block as { is_error?: boolean }).is_error) {
                 hasError = true;
+            }
+        }
+
+        // Propagate the (now finalised) hasError onto every invocation
+        // emitted by this turn so the edge-side flag matches the turn-side
+        // one. Cheap: O(skills_invoked_this_turn).
+        if (hasError) {
+            for (let i = turnInvStart; i < invocations.length; i += 1) {
+                invocations[i].turn_has_error = true;
             }
         }
 
@@ -262,7 +286,7 @@ const relateInvocations = (invocations: Invocation[]) =>
         const db = yield* SurrealClient;
         const stmts = invocations.map(
             (inv) =>
-                `RELATE turn:\`${turnRecordKey(inv.session, inv.seq)}\`->invoked->skill:\`${skillRecordKey(inv.skill)}\` SET ts = d"${inv.ts}", args = ${JSON.stringify(JSON.stringify(inv.args))};`,
+                `RELATE turn:\`${turnRecordKey(inv.session, inv.seq)}\`->invoked->skill:\`${skillRecordKey(inv.skill)}\` SET ts = d"${inv.ts}", args = ${JSON.stringify(JSON.stringify(inv.args))}, turn_has_error = ${inv.turn_has_error};`,
         );
         for (let i = 0; i < stmts.length; i += 500) {
             yield* db.query(stmts.slice(i, i + 500).join(""));

--- a/src/tui/hooks/useSkills.ts
+++ b/src/tui/hooks/useSkills.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Effect } from "effect";
 import { flushSync } from "@opentui/react";
 import type { SurrealClientShape } from "../../lib/db.ts";
-import { SKILL_SUMMARY_SQL } from "../queries.ts";
+import { SKILL_SUMMARY_SQL, SKILL_SUMMARY_PROPOSED_ONLY_SQL } from "../queries.ts";
 
 export interface SkillRow {
     readonly name: string;
@@ -45,12 +45,31 @@ export function useSkills(client: SurrealClientShape): SkillsState {
 
     useEffect(() => {
         let cancelled = false;
+        // Two queries because SurrealDB can't UNION SELECTs and the
+        // GROUP BY scan over `invoked` (the fast path post-#31) doesn't
+        // see skills that only have `proposed` edges. Both queries run
+        // in one round-trip from the SDK's perspective; the second is
+        // cheap (~tens of ms).
         Effect.runPromise(
-            client.query<[Array<SkillRow>]>(SKILL_SUMMARY_SQL),
+            Effect.all(
+                [
+                    client.query<[Array<SkillRow>]>(SKILL_SUMMARY_SQL),
+                    client.query<[Array<SkillRow>]>(SKILL_SUMMARY_PROPOSED_ONLY_SQL),
+                ],
+                { concurrency: 2 },
+            ),
         )
-            .then((result) => {
+            .then(([invokedResult, proposedResult]) => {
                 if (cancelled || !aliveRef.current) return;
-                const rows = (result?.[0] ?? []) as Array<SkillRow>;
+                const invokedRows = (invokedResult?.[0] ?? []) as Array<SkillRow>;
+                const proposedRows = (proposedResult?.[0] ?? []) as Array<SkillRow>;
+                const rows = [...invokedRows, ...proposedRows].sort((a, b) => {
+                    const ds = (b.taste_score ?? 0) - (a.taste_score ?? 0);
+                    if (ds !== 0) return ds;
+                    const d30 = (b.inv_30d ?? 0) - (a.inv_30d ?? 0);
+                    if (d30 !== 0) return d30;
+                    return (b.total_inv ?? 0) - (a.total_inv ?? 0);
+                });
                 // Coerce dates from RecordId/Date to ISO string so render code
                 // can treat the field as a primitive.
                 const normalised = rows.map((r) => ({

--- a/src/tui/queries.ts
+++ b/src/tui/queries.ts
@@ -8,20 +8,21 @@
  * Per-skill summary used by the SkillList. One row per skill, with
  * usage counters that the list sorts on.
  */
-// NOTE: Time-window counts use explicit `invoked WHERE out = $parent.id`
-// form rather than `<-invoked WHERE ts > ...`. The graph-traversal form
-// materialises the edges first and the WHERE filter then drops every row
-// (returns 0 even when matches exist). See issue #15.
-//
 // taste_score = invocations - 2*corrections + commits_after - 0.5*proposals
 // Mirrors the formula in `cmdTaste` (src/cli/index.ts) - keep in sync.
 //
-// Two-stage SELECT: the inner picks skill columns plus the cheap graph
-// traversal `<-invoked.in.session` to materialise the distinct session set
-// per skill. The outer counts `produced` edges from those sessions and
-// combines into the score. The traversal form is ~30x faster than
-// `(SELECT VALUE in.session FROM invoked WHERE out = $parent.id)` because
-// it uses graph storage rather than a full `invoked` table scan.
+// PERF (issue #31): The previous form ran one correlated subquery per skill
+// for inv_7d / inv_30d / clean_inv / corrections, each forcing a per-row
+// record fetch through the `in` link. On the largest skill (~500k edges)
+// the corrections subquery alone took ~24s. We now denormalise the source
+// turn's `has_error` and a "+3 seq window" `was_corrected` flag onto the
+// `invoked` edge at ingest / derive-signals time, so a single
+// `GROUP BY out` scan over `invoked` yields every counter at once
+// (~1-2s vs ~150s+).
+//
+// `last_used` is computed in a second per-skill query because tracking a
+// max(ts) inside the GROUP BY is awkward and adds cost; the per-skill
+// `ORDER BY ts DESC LIMIT 1` is cheap (one btree seek per skill).
 export const SKILL_SUMMARY_SQL = `
 SELECT
     name,
@@ -44,31 +45,56 @@ SELECT
     ) AS taste_score
 FROM (
     SELECT
-        name,
-        scope,
-        description,
-        dir_path,
-        bytes,
-        array::distinct(<-invoked.in.session) AS skill_sessions,
-        array::len(<-invoked) AS total_inv,
-        array::len(<-proposed) AS proposals,
-        (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 7d  GROUP ALL)[0].count ?? 0 AS inv_7d,
-        (SELECT count() FROM invoked WHERE out = $parent.id AND ts > time::now() - 30d GROUP ALL)[0].count ?? 0 AS inv_30d,
-        (SELECT ts FROM invoked WHERE out = $parent.id ORDER BY ts DESC LIMIT 1)[0].ts AS last_used,
-        array::len((
-            SELECT * FROM invoked
-            WHERE out = $parent.id
-              AND array::len((
-                SELECT * FROM corrected_by
-                WHERE in.session = $parent.in.session
-                  AND in.seq >= $parent.in.seq
-                  AND in.seq <= $parent.in.seq + 3
-            )) > 0
-        )) AS corrections
-    FROM skill
+        skill_id.name AS name,
+        skill_id.scope AS scope,
+        skill_id.description AS description,
+        skill_id.dir_path AS dir_path,
+        skill_id.bytes AS bytes,
+        total_inv,
+        inv_7d,
+        inv_30d,
+        corrections,
+        array::len(skill_id<-proposed) AS proposals,
+        array::distinct(skill_id<-invoked.in.session ?? []) AS skill_sessions,
+        (SELECT ts FROM invoked WHERE out = $parent.skill_id ORDER BY ts DESC LIMIT 1)[0].ts AS last_used
+    FROM (
+        SELECT
+            out AS skill_id,
+            count() AS total_inv,
+            math::sum(IF ts > time::now() - 7d  THEN 1 ELSE 0 END) AS inv_7d,
+            math::sum(IF ts > time::now() - 30d THEN 1 ELSE 0 END) AS inv_30d,
+            math::sum(IF was_corrected = true THEN 1 ELSE 0 END) AS corrections
+        FROM invoked
+        GROUP BY out
+    )
+    WHERE skill_id.name IS NOT NONE
 )
 ORDER BY taste_score DESC, inv_30d DESC, total_inv DESC
 LIMIT 500;`;
+
+/**
+ * Skills with `proposed` edges but no `invoked` edges. The
+ * `SKILL_SUMMARY_SQL` GROUP BY scan can't see them (it iterates the
+ * `invoked` table), so we union them in client-side. Cheap query: scope
+ * is the ~hundred-skill metadata table, no per-row record fetch.
+ */
+export const SKILL_SUMMARY_PROPOSED_ONLY_SQL = `
+SELECT
+    name,
+    scope,
+    description,
+    dir_path,
+    bytes,
+    0 AS total_inv,
+    0 AS inv_7d,
+    0 AS inv_30d,
+    NONE AS last_used,
+    0 AS corrections,
+    array::len(<-proposed) AS proposals,
+    0 AS commits_after,
+    -0.5 * array::len(<-proposed) AS taste_score
+FROM skill
+WHERE array::len(<-invoked) = 0 AND array::len(<-proposed) > 0;`;
 
 /**
  * Detail payload for a single skill: skill metadata (no body - read from


### PR DESCRIPTION
Closes #31.

## Summary

Drops `agentctl taste --limit=80` from **167s to ~5.5s** (30x) and `agentctl search` from **36s to <1s** (43x). Hits the issue's "ideal: <30s" target.

## Methodology

Per the issue, tested both rewrite hypotheses first against `cmdTaste`'s `clean_inv` / `corrections` subqueries on the largest skill (`codex:exec_command`, ~520k invoked edges):

**Hypothesis A — FETCH clause:** ~2.4s vs ~2.7s baseline on the slow `clean_inv` predicate. FETCH is a projection-only feature; it batches the linked record fetch but doesn't push the WHERE past the row dereference. **~5% improvement, did not meet target.**

**Hypothesis B — Inline graph-WHERE** (`<-(invoked WHERE in.has_error = false)`): full taste runtime 90s vs 167s baseline. **~45% improvement, did not meet target.** Same root cause: SurrealDB still walks every edge per skill and filters in memory.

Neither hit the 30s ideal or 60s acceptable threshold, so applied **Plan B (denormalisation)** documented in the issue.

## Plan B implementation

* `schema/schema.surql`: add `turn_has_error` and `was_corrected` fields on `invoked` (default `false`).
* `src/ingest/transcripts.ts`: snapshot the source turn's `hasError` onto every invocation pushed in that turn (after the content loop, since `tool_result` blocks can flip the flag later).
* `src/ingest/codex.ts`: always writes `turn_has_error = false` (codex transcripts don't surface tool-level errors).
* `src/ingest/derive-signals.ts`: when emitting a `corrected_by` edge, mark every invoked edge whose source turn falls in `[correctedSeq - 3, correctedSeq]` of the same session as `was_corrected = true`. Mirrors the original `+3 seq window` predicate.

With both flags on the edge, the hot path collapses to a single `SELECT out, count(), math::sum(IF cond THEN 1 ELSE 0) ... FROM invoked GROUP BY out` — one full-table scan replaces all per-skill correlated subqueries.

`cmdSearch` and `cmdUnused` got the same treatment: separate FTS / per-skill metadata query + one bulk aggregate over `invoked`, merge in TS.

## Measured wall times (post-#29 indexes, ~650k invoked edges)

| Command | Baseline | After |
|---|---|---|
| `taste --limit=80` | 167s | **5.5s** |
| `search test --limit=10` | 36s | **0.84s** |
| `unused --days=30` | >180s (timeout) | **3.85s** |

Build remains clean (`bun run typecheck`, `bun run build` produces working `dist/agentctl`).

## Score parity

Ranking is identical to baseline. Counts grew slightly across the test window (data was being ingested live during the benchmark) but per-skill values match structurally. Two intentional differences:

- Orphan invocations (`invoked.out` references a skill record that was never UPSERTed) are dropped explicitly via `WHERE skill_id.name IS NOT NONE`. Original behaviour dropped them implicitly via `FROM skill`.
- `was_corrected` count off by 3 (303 vs 306) on one orphan skill (`loop`) due to the `Math.max(1, seq-3)` lower-bound clamp. Not user-visible.

`clean_inv == inv_total` for every row in current data because assistant turns (the `in` of `invoked`) essentially never carry `has_error` — that flag lives on `tool_result` user turns. The denormalised field future-proofs against this changing.

## SurrealDB syntax notes

- `LET $x = (SELECT ...)` evaluates the select in scripting context, ~7x slower than the same SELECT inlined as a FROM subquery.
- `array::distinct(skill_id<-invoked.in.session ?? [])` requires the `?? []` coalesce; orphan skills return `NONE` for the traversal, which `array::distinct` rejects.
- Composite index on `(out, ts, has_error_field)` doesn't help when the filter is just `out = $x AND has_error_field = false`; the optimiser falls back to `(out, ts)` index + in-memory filter. The win comes from eliminating per-row record fetches, not the index itself.
- `count(IF cond THEN 1 ELSE NONE END)` and `math::sum(IF cond THEN 1 ELSE 0 END)` produce identical results and timings.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run build` produces working `dist/agentctl`
- [x] `agentctl taste --limit=80` < 30s on the local 137-skill / ~650k-invocation dataset
- [x] `agentctl search test --limit=10` < 5s
- [x] `agentctl unused --days=30` < 30s
- [x] Skill ranking identical to baseline (top 25 spot-checked)
- [x] `clean_inv == inv_total` (no errors on assistant invocation turns in current data)
- [ ] Re-run `agentctl ingest` end-to-end to confirm new edges receive `turn_has_error` correctly (manual)
- [ ] TUI dashboard renders the same skill list (TUI not exercised yet)