### PR TITLE
feat(site): four showcase routes (hook backtest, recall, token economy, verdict timeline)

### DIFF
--- a/site/app/components/landing-sections/site-header.tsx
+++ b/site/app/components/landing-sections/site-header.tsx
@@ -12,6 +12,7 @@ export function SiteHeader() {
         <a href="#change">Change</a>
         <a href="#demo">Demo</a>
         <a href="#install">Install</a>
+        <a href="/showcases">Showcases</a>
         {/* /origin route lands in Task 5; plain <a> for now */}
         <a href="/origin">Origin</a>
         <a className="primary" href="https://github.com/Necmttn/ax" target="_blank" rel="noopener noreferrer">GitHub →</a>

--- a/site/app/components/showcases/hook-backtest.tsx
+++ b/site/app/components/showcases/hook-backtest.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+export function HookBacktestShowcase() {
+  return (
+    <section id="hook-backtest" className="showcase-hook-backtest">
+      <main className="wrap">
+        <p className="eyebrow">before-you-ship · backtest</p>
+        <h2>
+          Ask the graph what your hook <em>would have</em> caught.
+        </h2>
+        <p className="lede">
+          You write a guardrail. You don&apos;t know if it&apos;ll catch real mistakes or
+          just become noise. ax replays your last week of actual sessions against
+          the hook before you install it, so the decision to ship is evidence,
+          not vibes.
+        </p>
+
+        <div className="split">
+          {/* hook source */}
+          <article className="hook-card" aria-label="proposed hook">
+            <header className="hook-head">
+              <span className="filename">
+                ~/.claude/hooks/
+                <b style={{ color: "var(--ink)", fontWeight: 500 }}>
+                  pre-tool-main-branch-guard.ts
+                </b>
+              </span>
+              <span className="badge">candidate</span>
+            </header>
+            <pre className="hook-source">
+<span className="c-com">{"// fires on Bash tool_call before execution"}</span>{"\n"}
+<span className="c-key">export const</span>{" hook = {\n  "}
+<span className="c-key">on</span>{": "}
+<span className="c-str">{"\"pre_tool\""}</span>{",\n  "}
+<span className="c-key">tool</span>{": "}
+<span className="c-str">{"\"Bash\""}</span>{",\n  "}
+<span className="c-fn">match</span>{"(call) {\n    "}
+<span className="c-key">const</span>{" cmd = call.input.command ?? "}
+<span className="c-str">{"\"\""}</span>{";\n    "}
+<span className="c-key">if</span>{" (!"}
+<span className="c-str">{"/^\\s*git\\s+(push|commit)\\b/"}</span>{".test(cmd)) "}
+<span className="c-key">return false</span>{";\n    "}
+<span className="c-key">const</span>{" branch = call.context.git?.branch ?? "}
+<span className="c-str">{"\"\""}</span>{";\n    "}
+<span className="c-key">return</span>{" "}
+<span className="c-str">{"/^(main|master|production)$/"}</span>{".test(branch);\n  },\n  "}
+<span className="c-fn">action</span>{": "}
+<span className="c-str">{"\"block\""}</span>{",\n  "}
+<span className="c-key">reason</span>{": "}
+<span className="c-str">{"\"direct write to protected branch\""}</span>{",\n};"}
+            </pre>
+            <footer className="hook-foot">
+              <span>pre-tool · Bash</span>
+              <span className="gut">12 lines · gut-check before backtest</span>
+            </footer>
+          </article>
+
+          {/* terminal mock */}
+          <section className="term-frame" aria-label="backtest run">
+            <header className="term-chrome">
+              <span className="term-dot term-dot-r" />
+              <span className="term-dot term-dot-y" />
+              <span className="term-dot term-dot-g" />
+              <span className="term-title">
+                ax <span className="seg">·</span> hooks backtest{" "}
+                <span className="seg">·</span> ~/Projects/ax
+              </span>
+            </header>
+            <pre className="term-body">
+<span className="term-line"><span className="t-prompt">~/.claude $</span> <span className="t-cmd">axctl hooks backtest</span> pre-tool-main-branch-guard <span className="t-flag">--since=</span><span className="t-num">7d</span></span>{"\n"}
+<span className="term-line"><span className="t-muted">  ↳ replay window  </span> 2026-05-21 → 2026-05-28  <span className="t-muted">(7d)</span></span>{"\n"}
+<span className="term-line"><span className="t-muted">  ↳ sessions       </span> <span className="t-num">14</span> claude_code, <span className="t-num">3</span> codex  <span className="t-muted">(17 total)</span></span>{"\n"}
+<span className="term-line"><span className="t-muted">  ↳ tool_calls     </span> <span className="t-num">1,247</span> bash invocations indexed</span>{"\n"}
+<span className="term-line"> </span>{"\n"}
+<span className="term-line"><span className="t-muted">  replaying…</span> <span className="t-ok">████████████████████</span> <span className="t-muted">1247/1247  4.2s</span></span>{"\n"}
+<span className="term-line"> </span>{"\n"}
+<span className="term-line rule">  ───────────────────────────────────────────────────────────</span>{"\n"}
+<span className="term-line">  <span className="t-strong">verdict</span>          <span className="rec-badge">SHIP · HIGH-CONFIDENCE</span></span>{"\n"}
+<span className="term-line rule">  ───────────────────────────────────────────────────────────</span>{"\n"}
+<span className="term-line"><span className="t-muted">  fires            </span> <span className="t-num">12</span> / 1,247 calls  <span className="t-muted">(0.96%)</span></span>{"\n"}
+<span className="term-line"><span className="t-muted">  ├─ </span><span className="t-bad">true positives </span> <span className="t-num">11</span>  <span className="t-muted">would have blocked actual main-branch pushes</span></span>{"\n"}
+<span className="term-line"><span className="t-muted">  └─ </span><span className="t-warn">false positives</span> <span className="t-num"> 1</span>  <span className="t-muted">legitimate hotfix → production · 2026-05-24</span></span>{"\n"}
+<span className="term-line"> </span>{"\n"}
+<span className="term-line"><span className="t-muted">  precision        </span> <span className="t-ok">0.917</span>   <span className="t-muted">recall</span> <span className="t-ok">0.917</span>   <span className="t-muted">F1</span> <span className="t-ok">0.917</span></span>{"\n"}
+<span className="term-line"><span className="t-muted">  prevented rollbacks </span> <span className="t-num">5</span>     <span className="t-muted">(traced via post-event reverts)</span></span>{"\n"}
+<span className="term-line"> </span>{"\n"}
+<span className="term-line"><span className="t-muted">  by repo</span></span>{"\n"}
+<span className="term-line"><span className="t-muted">    </span><span className="t-file">~/Projects/ax</span>        <span className="t-num"> 8</span>  <span className="t-bad">▮▮▮▮▮▮▮▮</span></span>{"\n"}
+<span className="term-line"><span className="t-muted">    </span><span className="t-file">~/Projects/quera</span>     <span className="t-num"> 3</span>  <span className="t-bad">▮▮▮</span></span>{"\n"}
+<span className="term-line"><span className="t-muted">    </span><span className="t-file">~/Projects/dotfiles</span>  <span className="t-num"> 1</span>  <span className="t-warn">▮</span> <span className="t-muted">← false positive lives here</span></span>{"\n"}
+<span className="term-line"> </span>{"\n"}
+<span className="term-line"><span className="t-muted">  one to review:</span></span>{"\n"}
+<span className="term-line"><span className="t-muted">    </span><span className="t-id">sess_8af3·turn-42</span>  <span className="t-warn">hotfix/prod-token-leak</span>  <span className="t-muted">→ allow-list?</span></span>{"\n"}
+<span className="term-line"> </span>{"\n"}
+<span className="term-line"><span className="t-ok">  install with:</span> <span className="t-cmd">axctl hooks install</span> pre-tool-main-branch-guard <span className="t-flag">--allow=hotfix/*</span></span>{"\n"}
+<span className="term-line"><span className="t-prompt">~/.claude $</span> <span className="term-caret" aria-hidden="true" /></span>
+            </pre>
+          </section>
+        </div>
+
+        {/* week strip */}
+        <section className="week" aria-label="7-day session distribution">
+          <header className="week-head">
+            <span className="label">
+              replay window · 17 sessions · 1,247 bash calls
+            </span>
+            <span className="meta">
+              2026-05-21 → 2026-05-28 · <b>12 fires</b> ·{" "}
+              <b>5 rollbacks prevented</b>
+            </span>
+          </header>
+
+          <div className="week-grid">
+            <div className="day-label">
+              <b>Thu 21</b>3 sessions
+            </div>
+            <div className="day-row">
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick tp" title="true positive · ~/Projects/ax" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="day-count">163 calls</span>
+            </div>
+
+            <div className="day-label">
+              <b>Fri 22</b>2 sessions
+            </div>
+            <div className="day-row">
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick tp" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick saved" title="prevented rollback" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="day-count">131 calls</span>
+            </div>
+
+            <div className="day-label">
+              <b>Sat 23</b>1 session
+            </div>
+            <div className="day-row">
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="day-count">86 calls</span>
+            </div>
+
+            <div className="day-label">
+              <b>Sun 24</b>2 sessions
+            </div>
+            <div className="day-row">
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span
+                className="tick fp"
+                title="false positive · hotfix on production"
+              />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="day-count">112 calls</span>
+            </div>
+
+            <div className="day-label">
+              <b>Mon 25</b>3 sessions
+            </div>
+            <div className="day-row">
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick tp" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick saved" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick tp" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="day-count">221 calls</span>
+            </div>
+
+            <div className="day-label">
+              <b>Tue 26</b>3 sessions
+            </div>
+            <div className="day-row">
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick saved" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick tp" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick tp" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="day-count">248 calls</span>
+            </div>
+
+            <div className="day-label">
+              <b>Wed 27</b>2 sessions
+            </div>
+            <div className="day-row">
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick saved" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick tp" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="day-count">177 calls</span>
+            </div>
+
+            <div className="day-label">
+              <b>Thu 28</b>1 session · today
+            </div>
+            <div className="day-row">
+              <span className="tick pass" />
+              <span className="tick tp" />
+              <span className="tick pass" />
+              <span className="tick pass" />
+              <span className="tick saved" />
+              <span className="tick pass" />
+              <span className="tick tp" />
+              <span className="tick pass" />
+              <span className="tick tp" />
+              <span className="tick pass" />
+              <span className="day-count">109 calls</span>
+            </div>
+          </div>
+
+          <div className="legend">
+            <span>
+              <span className="sw pass" /> pass · normal traffic
+            </span>
+            <span>
+              <span className="sw tp" /> would have blocked · true positive
+            </span>
+            <span>
+              <span className="sw saved" /> traced to a later rollback
+            </span>
+            <span>
+              <span className="sw fp" /> false positive · review
+            </span>
+          </div>
+        </section>
+
+        {/* caption */}
+        <aside className="caption">
+          <span className="tag">the move</span>
+          <p>
+            Before you install a guardrail, ax replays your last seven days of
+            sessions against it. You see exactly what it would have blocked,
+            what it would have broken, and which calls it traced to a later
+            rollback - so a hook ships with a precision number attached, not a
+            hunch.{" "}
+            <em>
+              No other agent tooling can do this; no one else has the typed
+              session graph.
+            </em>
+          </p>
+        </aside>
+      </main>
+    </section>
+  );
+}

--- a/site/app/components/showcases/recall.tsx
+++ b/site/app/components/showcases/recall.tsx
@@ -1,0 +1,274 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+export function RecallShowcase() {
+  const argRef = useRef<HTMLSpanElement | null>(null);
+
+  useEffect(() => {
+    const el = argRef.current;
+    if (!el) return;
+
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    if (reduce) return;
+
+    const full = '"auth middleware oauth refresh token"';
+    let i = full.length;
+    let phase: "idle" | "erase" | "type" = "idle";
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    function tick() {
+      if (!el) return;
+      if (phase === "idle") {
+        timer = setTimeout(() => { phase = "erase"; tick(); }, 3500);
+        return;
+      }
+      if (phase === "erase") {
+        i = Math.max(0, i - 1);
+        el.textContent = full.slice(0, i);
+        if (i === 0) {
+          phase = "type";
+          timer = setTimeout(tick, 350);
+          return;
+        }
+        timer = setTimeout(tick, 22);
+        return;
+      }
+      if (phase === "type") {
+        i = Math.min(full.length, i + 1);
+        el.textContent = full.slice(0, i);
+        if (i === full.length) {
+          phase = "idle";
+          timer = setTimeout(tick, 200);
+          return;
+        }
+        timer = setTimeout(tick, 38);
+        return;
+      }
+    }
+
+    timer = setTimeout(tick, 1800);
+
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  const inlineCode: React.CSSProperties = {
+    fontFamily: "var(--mono)",
+    fontSize: "15px",
+  };
+
+  return (
+    <section id="recall" className="showcase-recall">
+      <p className="eyebrow">search the graph</p>
+      <h2>
+        Find what you shipped <em>last time you did this.</em>
+      </h2>
+      <p className="lede">
+        <span>
+          Every transcript ax has ever ingested is full-text searchable -
+          Claude Code, Codex, every turn, every tool call, every reasoning text.
+        </span>
+        <span className="soft">
+          {" "}Ranked excerpts come back with the session, the file,
+          the commit, and whether it stuck.
+        </span>
+      </p>
+
+      {/* CLI shape */}
+      <div className="cli" aria-hidden="true">
+        <span className="dots">
+          <i className="dot r" />
+          <i className="dot y" />
+          <i className="dot g" />
+        </span>
+        <span className="prompt">~/Projects/ax</span>
+        <span className="prompt">&gt;</span>
+        <span className="cmd">axctl recall</span>
+        <span className="arg" ref={argRef}>"auth middleware oauth refresh token"</span>
+        <span className="caret" />
+      </div>
+
+      {/* search widget */}
+      <div className="search" role="search">
+        <span className="glyph" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="11" cy="11" r="7" />
+            <line x1="20" y1="20" x2="16.5" y2="16.5" />
+          </svg>
+        </span>
+        <input
+          id="q"
+          type="text"
+          defaultValue="auth middleware oauth refresh token"
+          spellCheck={false}
+          autoComplete="off"
+        />
+        <span className="kbd">
+          <span>search</span> <b>⏎</b>
+        </span>
+      </div>
+
+      <div className="meta-row">
+        <div className="scope">
+          <span className="chip">14,832 turns</span>
+          <span className="chip">412 sessions</span>
+          <span className="chip">claude + codex</span>
+        </div>
+        <div>4 matches · 38 ms</div>
+      </div>
+
+      {/* results */}
+      <div className="results">
+        {/* 1 */}
+        <article className="result">
+          <div className="rank">
+            01
+            <span className="score">0.94</span>
+          </div>
+          <div className="body">
+            <p className="excerpt">
+              Built the <mark>OAuth refresh token</mark> rotation. The
+              {" "}<mark>middleware</mark> now checks expiry with <code style={inlineCode}>&lt;=</code>
+              {" "}not <code style={inlineCode}>&lt;</code> after the bug we hit last quarter -
+              tests cover the boundary tick and the clock-skew window.
+            </p>
+            <div className="prov">
+              <span className="src">claude code</span>
+              <span className="sep">·</span>
+              <span className="sid">session 5a8e9c</span>
+              <span className="sep">·</span>
+              <span className="date">2026-05-21 · 14:02</span>
+              <span className="sep">·</span>
+              <span>~/Projects/ax</span>
+              <span className="sep">·</span>
+              <span className="path">src/auth/middleware.ts</span>
+            </div>
+            <div className="outcome adopted">
+              <span className="arrow">→ shipped in</span>
+              <span className="commit">8b3d1f4</span>
+              <span className="verdict">adopted</span>
+              <span className="t-since">t + 7d</span>
+            </div>
+          </div>
+        </article>
+
+        {/* 2 */}
+        <article className="result">
+          <div className="rank">
+            02
+            <span className="score">0.81</span>
+          </div>
+          <div className="body">
+            <p className="excerpt">
+              PR #847 - <mark>OAuth refresh</mark> path. Tests cover both expiry edge cases;
+              the <mark>middleware</mark> guards against double-refresh by holding a
+              per-tenant lock for the duration of the rotation.
+            </p>
+            <div className="prov">
+              <span className="src">claude code</span>
+              <span className="sep">·</span>
+              <span className="sid">session 3c1d22</span>
+              <span className="sep">·</span>
+              <span className="date">2026-04-14 · 09:48</span>
+              <span className="sep">·</span>
+              <span>~/Projects/ax</span>
+              <span className="sep">·</span>
+              <span className="path">src/auth/refresh.ts</span>
+            </div>
+            <div className="outcome adopted">
+              <span className="arrow">→ shipped in</span>
+              <span className="commit">2e0a5cc</span>
+              <span className="verdict">adopted</span>
+              <span className="t-since">t + 30d</span>
+            </div>
+          </div>
+        </article>
+
+        {/* 3 */}
+        <article className="result">
+          <div className="rank">
+            03
+            <span className="score">0.72</span>
+          </div>
+          <div className="body">
+            <p className="excerpt">
+              Initial <mark>OAuth</mark> wiring. Note for future me: don't reuse the access
+              {" "}<mark>token</mark> endpoint for <mark>refresh</mark> - separate route, separate
+              rate limit, separate audit log.
+            </p>
+            <div className="prov">
+              <span className="src codex">codex</span>
+              <span className="sep">·</span>
+              <span className="sid">session 7f4b88</span>
+              <span className="sep">·</span>
+              <span className="date">2026-03-02 · 22:11</span>
+              <span className="sep">·</span>
+              <span>~/Projects/ax</span>
+              <span className="sep">·</span>
+              <span className="path">src/auth/routes.ts</span>
+            </div>
+            <div className="outcome adopted-locked">
+              <span className="arrow">→ shipped in</span>
+              <span className="commit">9d1e0a2</span>
+              <span className="verdict">adopted · locked</span>
+              <span className="t-since">t + 90d</span>
+            </div>
+          </div>
+        </article>
+
+        {/* 4 (dim - rejected) */}
+        <article className="result dim">
+          <div className="rank">
+            04
+            <span className="score">0.41</span>
+          </div>
+          <div className="body">
+            <p className="excerpt">
+              Spike on <mark>OAuth</mark> session-binding inside the <mark>middleware</mark> -
+              rejected, returned to the PR #420 approach. Leaving the diff in
+              {" "}<code style={inlineCode}>scratch/</code> in case the threat
+              model changes.
+            </p>
+            <div className="prov">
+              <span className="src">claude code</span>
+              <span className="sep">·</span>
+              <span className="sid">session 1a2b33</span>
+              <span className="sep">·</span>
+              <span className="date">2025-12-08 · 16:30</span>
+              <span className="sep">·</span>
+              <span>~/Projects/ax</span>
+              <span className="sep">·</span>
+              <span className="path">scratch/oauth-bind.ts</span>
+            </div>
+            <div className="outcome rejected">
+              <span className="arrow">→ rolled back</span>
+              <span className="verdict">rejected</span>
+              <span className="t-since">t + 2d</span>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      {/* caption */}
+      <aside className="caption">
+        <div className="label">how it works</div>
+        <div>
+          <p>
+            Every Claude Code and Codex session ax ingests becomes a row in the unified
+            graph - turn text, tool calls, reasoning, file edits, commit refs.
+            {" "}<code>axctl recall</code> runs full-text search over that graph and ranks by
+            {" "}<em>recency × relevance × outcome</em>.
+          </p>
+          <p>
+            "Outcome" is the part no other agent layer has: whether the change shipped,
+            was rolled back, or got locked in as a permanent pattern. You're not just
+            searching what you wrote - you're searching what worked.
+          </p>
+        </div>
+      </aside>
+
+      <p className="foot">ax · local taste &amp; telemetry graph · prototype</p>
+    </section>
+  );
+}

--- a/site/app/components/showcases/token-economy.tsx
+++ b/site/app/components/showcases/token-economy.tsx
@@ -1,0 +1,310 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+export function TokenEconomyShowcase() {
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    if (reduce) return;
+
+    const bars = Array.from(
+      root.querySelectorAll<HTMLElement>(
+        ".epoch-row .bar > div, .session .cache-mini > div, .target .fill, .provider-strip > div",
+      ),
+    );
+
+    const original: Array<{ el: HTMLElement; width: string }> = [];
+    bars.forEach((b) => {
+      original.push({ el: b, width: b.style.width });
+      b.style.width = "0%";
+    });
+
+    const raf = requestAnimationFrame(() => {
+      original.forEach(({ el, width }) => {
+        el.style.transition = "width 700ms cubic-bezier(.2,.7,.2,1)";
+        el.style.width = width;
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return (
+    <section
+      id="token-economy"
+      className="showcase-token-economy"
+      ref={rootRef}
+      aria-label="Token economy diagnostic showcase"
+    >
+      <p className="eyebrow">see the bleed · token-impact</p>
+      <h2>
+        Where your agent <em>context</em> goes.
+      </h2>
+      <p className="lede">
+        Every agent user is bleeding money on cache misses they can&apos;t see.{" "}
+        <span className="cmd">axctl insights token-impact --since=7d</span> joins your local
+        claude + codex transcripts, reconciles provider metadata against transcript bytes,
+        and shows the spend, the hit rate, and the workflows burning the budget.
+      </p>
+
+      {/* ============ HERO STATS ============ */}
+      <section className="stats" aria-label="hero stats">
+        <div className="stat" data-kind="tokens">
+          <div className="label">tokens · 7d</div>
+          <div className="big">
+            14.2<span className="unit">M</span>
+          </div>
+          <div className="delta">
+            <span className="up">▲ +20%</span> &nbsp;vs 11.8M last week
+          </div>
+          <div className="submeta">claude 8.5M · codex 5.7M</div>
+        </div>
+
+        <div className="stat" data-kind="spend">
+          <div className="label">spend · 7d</div>
+          <div className="big">
+            $42<span className="unit">.18</span>
+          </div>
+          <div className="provider-strip" aria-hidden="true">
+            <div className="seg-claude" style={{ width: "57.3%" }} />
+            <div className="seg-codex" style={{ width: "42.7%" }} />
+          </div>
+          <div className="provider-legend">
+            <span>
+              <span className="swatch" style={{ background: "#d77757" }} />
+              claude $24.18
+            </span>
+            <span>
+              <span className="swatch" style={{ background: "var(--blue)" }} />
+              codex $18.00
+            </span>
+          </div>
+        </div>
+
+        <div className="stat" data-kind="cache">
+          <div className="label">cache hit · 7d</div>
+          <div className="big">
+            67<span className="unit">%</span>
+          </div>
+          <div className="target" aria-hidden="true">
+            <div className="fill" />
+            <div className="tick" title="target 80%" />
+          </div>
+          <div className="target-legend">
+            <span className="up">▼ -4pp WoW</span>
+            <span>target 80%</span>
+          </div>
+        </div>
+      </section>
+
+      {/* ============ BREAKDOWN ============ */}
+      <div className="section-head">
+        <h3>By workflow epoch &amp; expensive sessions</h3>
+        <div className="meta">join: session_token_usage ⋈ session_health</div>
+      </div>
+
+      <section className="breakdown">
+        {/* LEFT: workflow_epoch stacked bars */}
+        <div>
+          <div className="epoch-row" title="gsd: 5.96M tokens, 71% cached">
+            <div className="name">
+              <span className="badge" style={{ background: "var(--ink)" }} />
+              gsd
+            </div>
+            <div className="bar">
+              <div className="cached" style={{ width: "29.8%" }} />
+              <div className="miss" style={{ width: "12.2%" }} />
+            </div>
+            <div className="pct">42%</div>
+          </div>
+          <div className="epoch-row" title="superpowers: 4.40M tokens, 78% cached">
+            <div className="name">
+              <span className="badge" style={{ background: "#5b5b56" }} />
+              superpowers
+            </div>
+            <div className="bar">
+              <div className="cached" style={{ width: "24.2%" }} />
+              <div className="miss" style={{ width: "6.8%" }} />
+            </div>
+            <div className="pct">31%</div>
+          </div>
+          <div className="epoch-row" title="ad-hoc: 3.83M tokens, 48% cached">
+            <div className="name">
+              <span className="badge" style={{ background: "#aeaca3" }} />
+              ad-hoc
+            </div>
+            <div className="bar">
+              <div className="cached" style={{ width: "13.0%" }} />
+              <div className="miss" style={{ width: "14.0%" }} />
+            </div>
+            <div className="pct">27%</div>
+          </div>
+
+          <div className="epoch-key">
+            <span>
+              <span className="sw" style={{ background: "var(--green)" }} />
+              cached
+            </span>
+            <span>
+              <span className="sw" style={{ background: "var(--red)" }} />
+              cache miss (paid)
+            </span>
+          </div>
+
+          <p className="epoch-note">
+            Bar length = share of total tokens. Color split inside each bar = cached vs.
+            paid for the same workload.{" "}
+            <strong>ad-hoc is half the tokens of gsd but burns more dollars</strong> -
+            fewer rituals, lower cache hit.
+          </p>
+        </div>
+
+        {/* RIGHT: top expensive sessions */}
+        <div>
+          <div className="sessions">
+            <div className="session">
+              <div className="sid">session 9c2e44 · claude</div>
+              <div className="right">
+                <span className="tk">2.40M</span> tk
+              </div>
+              <div className="path">
+                ~/Projects/ax <span className="arrow">›</span> src/ingest/transcripts.ts
+                refactor
+              </div>
+              <div className="cache-mini">
+                <div className="c" style={{ width: "41%" }} />
+                <div className="m" style={{ width: "59%" }} />
+              </div>
+              <div className="ratio">
+                <span>
+                  cache hit <span className="bad">41%</span>
+                </span>
+                <span>$7.81 · 14 turns</span>
+              </div>
+            </div>
+
+            <div className="session">
+              <div className="sid">session 4f1ab0 · codex</div>
+              <div className="right">
+                <span className="tk">1.85M</span> tk
+              </div>
+              <div className="path">
+                ~/Projects/ax <span className="arrow">›</span> insights CLI scaffold
+              </div>
+              <div className="cache-mini">
+                <div className="c" style={{ width: "58%" }} />
+                <div className="m" style={{ width: "42%" }} />
+              </div>
+              <div className="ratio">
+                <span>
+                  cache hit <span className="mid">58%</span>
+                </span>
+                <span>$5.94 · 22 turns</span>
+              </div>
+            </div>
+
+            <div className="session">
+              <div className="sid">session a07e91 · claude</div>
+              <div className="right">
+                <span className="tk">1.31M</span> tk
+              </div>
+              <div className="path">
+                ~/Projects/ax <span className="arrow">›</span> schema v3 migration
+              </div>
+              <div className="cache-mini">
+                <div className="c" style={{ width: "79%" }} />
+                <div className="m" style={{ width: "21%" }} />
+              </div>
+              <div className="ratio">
+                <span>
+                  cache hit <span className="ok">79%</span>
+                </span>
+                <span>$3.12 · 9 turns</span>
+              </div>
+            </div>
+
+            <div className="session">
+              <div className="sid">session 2bf330 · codex</div>
+              <div className="right">
+                <span className="tk">1.07M</span> tk
+              </div>
+              <div className="path">
+                ~/Projects/ax <span className="arrow">›</span> docs/landing rewrite
+              </div>
+              <div className="cache-mini">
+                <div className="c" style={{ width: "36%" }} />
+                <div className="m" style={{ width: "64%" }} />
+              </div>
+              <div className="ratio">
+                <span>
+                  cache hit <span className="bad">36%</span>
+                </span>
+                <span>$3.78 · 31 turns</span>
+              </div>
+            </div>
+
+            <div className="session">
+              <div className="sid">session 7d4c12 · claude</div>
+              <div className="right">
+                <span className="tk">0.92M</span> tk
+              </div>
+              <div className="path">
+                ~/Projects/quera <span className="arrow">›</span> live-traces vendor
+              </div>
+              <div className="cache-mini">
+                <div className="c" style={{ width: "74%" }} />
+                <div className="m" style={{ width: "26%" }} />
+              </div>
+              <div className="ratio">
+                <span>
+                  cache hit <span className="ok">74%</span>
+                </span>
+                <span>$2.34 · 11 turns</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ============ INSIGHT ============ */}
+      <section className="insight">
+        <div className="ratio-num">
+          3.2<span className="x">×</span>
+        </div>
+        <div className="body">
+          <strong>codex burns 3.2× the context of claude code</strong> for equivalent
+          work - same workflow_epoch, same repo, same outcome. Most of that is restated
+          history per turn.
+          <span className="src">
+            workflow-impact says the gsd → superpowers migration is paying off · run{" "}
+            <code>axctl insights workflow-impact</code> for the cohort comparison
+          </span>
+        </div>
+      </section>
+
+      {/* ============ CAPTION ============ */}
+      <section className="caption">
+        <div className="col">
+          <div className="h">where the numbers come from</div>
+          ax reads provider metadata - <code>cache_creation_input_tokens</code>,{" "}
+          <code>cache_read_input_tokens</code>, <code>input_tokens</code>,{" "}
+          <code>output_tokens</code> - and falls back to transcript-byte estimates when a
+          turn predates cache reporting.
+        </div>
+        <div className="col">
+          <div className="h">runs on your machine</div>
+          Local SurrealDB instance. Typed Effect pipeline. No outbound calls, no upload.
+          Sibling diagnostics: <span className="pill">cache-health</span>
+          <span className="pill">workflow-impact</span>
+          <span className="pill">skill-impact</span>
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/site/app/components/showcases/verdict-timeline.tsx
+++ b/site/app/components/showcases/verdict-timeline.tsx
@@ -1,0 +1,564 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+/**
+ * Showcase 4 - Verdict Timeline.
+ *
+ * Ported from `docs/prototypes/showcase-4-verdict-timeline.html`.
+ *
+ * Animation lives in a single useEffect: a token rides the SVG track
+ * from accept → +3 sess → +10 sess → +30 sess (locked verdict). Each
+ * checkpoint lights its node + halo + chip and rewrites the inspector
+ * panel below. Plays once on first scroll-into-view, replay pill resets.
+ *
+ * Query-string flags (client-only, headless screenshots):
+ *   ?autoplay - kick the animation immediately
+ *   ?final    - skip to locked state, no animation
+ */
+
+type Color = "green" | "red" | "blue";
+type EvidenceClass = "ok" | "err" | "ref" | "lk";
+
+type Checkpoint = {
+  id: number;
+  x: number;
+  dur: number;
+  ease: (t: number) => number;
+  chipId: string;
+  haloId: string;
+  nodeId: string;
+  color: Color;
+  inspect: {
+    name: string;
+    sub: string;
+    evidence: Array<[string, string, EvidenceClass]>;
+    state: string;
+    stateCls: string;
+  };
+};
+
+const TRACK_X0 = 60;
+const TRACK_X1 = 840;
+
+function easeOutCubic(t: number) { return 1 - Math.pow(1 - t, 3); }
+function easeInCubic(t: number)  { return t * t * t; }
+function linear(t: number)       { return t; }
+
+const CP: Checkpoint[] = [
+  {
+    id: 3, x: 320, dur: 1400, ease: easeOutCubic,
+    chipId: "chip-7", haloId: "halo-7", nodeId: "node-7",
+    color: "green",
+    inspect: {
+      name: "+3 sessions", sub: "early signal",
+      evidence: [
+        ["marker",  "src/cli/run.ts:42 · still landed", "ok"],
+        ["file",    "no fixes across 3 sessions",       "ok"],
+        ["pattern", "target failure: 0 hits",           "ok"],
+        ["tests",   "0 regressions in adjacent suite",  "ok"],
+      ],
+      state: "on-track", stateCls: "is-green",
+    },
+  },
+  {
+    id: 10, x: 580, dur: 1600, ease: linear,
+    chipId: "chip-30", haloId: "halo-30", nodeId: "node-30",
+    color: "green",
+    inspect: {
+      name: "+10 sessions", sub: "real-world settled",
+      evidence: [
+        ["marker",     "still landed · 0 rollbacks",          "ok"],
+        ["dependents", "1 downstream skill fired against it", "ref"],
+        ["pattern",    "target failure: 0 hits over 10 sess", "ok"],
+        ["tests",      "6 runs · all green",                  "ok"],
+      ],
+      state: "holding", stateCls: "is-green",
+    },
+  },
+  {
+    id: 30, x: 840, dur: 1800, ease: easeInCubic,
+    chipId: "chip-90", haloId: "halo-90", nodeId: "node-90",
+    color: "green",
+    inspect: {
+      name: "+30 sessions", sub: "locked verdict",
+      evidence: [
+        ["verdict",  "ADOPTED",                                    "ok"],
+        ["evidence", "marker · file · pattern · tests joined",     "lk"],
+        ["feeds",    "dedupe graph · future proposals",            "ref"],
+        ["locked",   "session 30 reached · cannot be re-proposed", "lk"],
+      ],
+      state: "adopted", stateCls: "is-green",
+    },
+  },
+];
+
+export function VerdictTimelineShowcase() {
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const stageRef   = useRef<HTMLDivElement | null>(null);
+  const tokenRef   = useRef<SVGCircleElement | null>(null);
+  const tokenShRef = useRef<SVGCircleElement | null>(null);
+  const fillRef    = useRef<SVGLineElement | null>(null);
+  const pillRef    = useRef<HTMLButtonElement | null>(null);
+  const pillTxtRef = useRef<HTMLSpanElement | null>(null);
+  const inspCpRef  = useRef<HTMLSpanElement | null>(null);
+  const inspSubRef = useRef<HTMLSpanElement | null>(null);
+  const inspBodyRef= useRef<HTMLDivElement | null>(null);
+  const inspStRef  = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const section = sectionRef.current;
+    const stage   = stageRef.current;
+    if (!section || !stage) return;
+
+    let rafId: number | null = null;
+    let running = false;
+    let played  = false;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    function setPill(state: string, text?: string) {
+      const pill = pillRef.current;
+      if (!pill) return;
+      pill.setAttribute("data-state", state);
+      if (text && pillTxtRef.current) pillTxtRef.current.textContent = text;
+    }
+
+    function setTokenX(x: number) {
+      tokenRef.current?.setAttribute("cx",   String(x));
+      tokenShRef.current?.setAttribute("cx", String(x));
+      fillRef.current?.setAttribute("x2",    String(x));
+    }
+
+    function clearTimers() {
+      timers.forEach((t) => clearTimeout(t));
+      timers.length = 0;
+    }
+
+    function clearVisualState() {
+      if (rafId != null) cancelAnimationFrame(rafId);
+      clearTimers();
+      setTokenX(TRACK_X0);
+      section!.querySelectorAll(".tl-chip").forEach((c) =>
+        c.classList.remove("is-shown")
+      );
+      [7, 30, 90].forEach((id) => {
+        const n = section!.querySelector("#node-" + id);
+        const h = section!.querySelector("#halo-" + id);
+        n?.classList.remove("is-reached", "is-green", "is-red", "is-blue");
+        h?.classList.remove("is-shown", "is-red", "is-blue");
+      });
+      if (inspCpRef.current)  inspCpRef.current.textContent  = "accept";
+      if (inspSubRef.current) inspSubRef.current.textContent = "experiment opened";
+      if (inspBodyRef.current) {
+        inspBodyRef.current.innerHTML = `
+          <div class="ev is-shown"><span class="lk">exp_id</span> <span>post-feature-verify · t0</span></div>
+          <div class="ev is-shown"><span class="lk">marker</span> <span>added · src/cli/run.ts:42</span></div>
+          <div class="ev is-shown"><span class="lk">watching</span> <span>marker · file · pattern · tests</span></div>
+        `;
+      }
+      if (inspStRef.current) {
+        inspStRef.current.className = "insp-state";
+        inspStRef.current.textContent = "pending";
+      }
+    }
+
+    function updateInspector(cp: Checkpoint) {
+      if (inspCpRef.current)  inspCpRef.current.textContent  = cp.inspect.name;
+      if (inspSubRef.current) inspSubRef.current.textContent = cp.inspect.sub;
+      const body = inspBodyRef.current;
+      if (body) {
+        body.innerHTML = "";
+        cp.inspect.evidence.forEach((row, i) => {
+          const [label, val, cls] = row;
+          const div = document.createElement("div");
+          div.className = "ev";
+          div.innerHTML = `<span class="lk">${label}</span> <span class="${cls}">${val}</span>`;
+          body.appendChild(div);
+          const tid = setTimeout(() => div.classList.add("is-shown"), 80 + i * 90);
+          timers.push(tid);
+        });
+      }
+      if (inspStRef.current) {
+        inspStRef.current.className = "insp-state " + cp.inspect.stateCls;
+        inspStRef.current.textContent = cp.inspect.state;
+      }
+    }
+
+    function animateLeg(fromX: number, toX: number, durMs: number, easeFn: (t: number) => number) {
+      return new Promise<void>((resolve) => {
+        const start = performance.now();
+        function step(now: number) {
+          const t = Math.min(1, (now - start) / durMs);
+          const e = easeFn(t);
+          const x = fromX + (toX - fromX) * e;
+          setTokenX(x);
+          if (t < 1) {
+            rafId = requestAnimationFrame(step);
+          } else {
+            resolve();
+          }
+        }
+        rafId = requestAnimationFrame(step);
+      });
+    }
+
+    function wait(ms: number) {
+      return new Promise<void>((r) => {
+        const tid = setTimeout(r, ms);
+        timers.push(tid);
+      });
+    }
+
+    async function play() {
+      if (running) return;
+      running = true;
+      setPill("playing", "playing");
+      clearVisualState();
+
+      let prevX = TRACK_X0;
+      for (let i = 0; i < CP.length; i++) {
+        const cp = CP[i]!;
+        await animateLeg(prevX, cp.x, cp.dur, cp.ease);
+        prevX = cp.x;
+
+        const node = section!.querySelector("#" + cp.nodeId);
+        const halo = section!.querySelector("#" + cp.haloId);
+        const chip = section!.querySelector("#" + cp.chipId);
+        node?.classList.add("is-reached", "is-" + cp.color);
+        halo?.classList.add("is-shown");
+        if (cp.color !== "green") halo?.classList.add("is-" + cp.color);
+        chip?.classList.add("is-shown");
+        updateInspector(cp);
+
+        if (i < CP.length - 1) await wait(420);
+      }
+
+      running = false;
+      played  = true;
+      setPill("done", "replay");
+    }
+
+    function jumpToFinal() {
+      setTokenX(TRACK_X1);
+      CP.forEach((cp) => {
+        section!.querySelector("#" + cp.nodeId)?.classList.add("is-reached", "is-" + cp.color);
+        section!.querySelector("#" + cp.haloId)?.classList.add("is-shown");
+        section!.querySelector("#" + cp.chipId)?.classList.add("is-shown");
+      });
+      updateInspector(CP[CP.length - 1]!);
+      // skip per-row stagger
+      section!.querySelectorAll(".insp-body .ev").forEach((el) =>
+        el.classList.add("is-shown")
+      );
+      setPill("done", "replay");
+      played = true;
+    }
+
+    // intersection-observer: play once on first scroll-into-view
+    let io: IntersectionObserver | null = null;
+    if ("IntersectionObserver" in window) {
+      io = new IntersectionObserver(
+        (entries) => {
+          for (const e of entries) {
+            if (e.isIntersecting && !played && !running) {
+              const tid = setTimeout(play, 280);
+              timers.push(tid);
+            }
+          }
+        },
+        { threshold: 0.45 }
+      );
+      io.observe(stage);
+    }
+
+    // query-string affordances (client-only)
+    if (typeof window !== "undefined") {
+      const qs = new URLSearchParams(window.location.search);
+      if (qs.has("autoplay")) {
+        const tid = setTimeout(play, 80);
+        timers.push(tid);
+      }
+      if (qs.has("final")) {
+        io?.disconnect();
+        io = null;
+        jumpToFinal();
+      }
+    }
+
+    // replay pill
+    const pill = pillRef.current;
+    const onPillClick = () => {
+      if (running) return;
+      play();
+    };
+    pill?.addEventListener("click", onPillClick);
+
+    // reduce-motion: skip to end state
+    const prefersReduced =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReduced) {
+      io?.disconnect();
+      io = null;
+      jumpToFinal();
+    }
+
+    return () => {
+      if (rafId != null) cancelAnimationFrame(rafId);
+      clearTimers();
+      io?.disconnect();
+      pill?.removeEventListener("click", onPillClick);
+    };
+  }, []);
+
+  return (
+    <section
+      id="verdict-timeline"
+      ref={sectionRef}
+      className="showcase-verdict-timeline"
+    >
+      <p className="eyebrow">the compounding part</p>
+      <h2>
+        Every change earns its place by{" "}
+        <em style={{ fontStyle: "italic", color: "var(--muted)" }}>session 30</em>.
+      </h2>
+      <p className="lede">
+        Accepting a proposal doesn&apos;t make it true. ax turns each acceptance into an
+        experiment with three forward-looking checkpoints &mdash; t+3, t+10, t+30{" "}
+        <em style={{ fontStyle: "italic", color: "var(--muted)" }}>sessions</em> &mdash;
+        and watches the next runs to see if the change actually held. Days are the wrong
+        unit when an agent ships eight sessions a day. The verdict at t+30 sessions is
+        locked. Future proposals know.
+      </p>
+
+      <figure className="figure fig-timeline" aria-label="ax verdict timeline showcase">
+        <div className="fig-head">
+          <span className="fig-id">Fig · S-04</span>
+          <span>verdict timeline · post-feature-verify</span>
+          <button
+            className="auto-pill"
+            type="button"
+            data-state="idle"
+            id="replay"
+            ref={pillRef}
+          >
+            <span className="auto-dot" />
+            <span className="auto-text" ref={pillTxtRef}>play</span>
+          </button>
+        </div>
+
+        <div className="tl-stage" id="stage" ref={stageRef}>
+          <svg
+            className="tl-svg"
+            viewBox="0 0 900 180"
+            preserveAspectRatio="none"
+            aria-hidden="true"
+          >
+            {/* track baseline */}
+            <line className="tl-track-bg" x1="60" y1="90" x2="840" y2="90" />
+            <line
+              className="tl-track-fill"
+              id="track-fill"
+              x1="60"
+              y1="90"
+              x2="60"
+              y2="90"
+              ref={fillRef}
+            />
+
+            {/* end labels */}
+            <text className="tl-end left"  x="60"  y="62">accept</text>
+            <text className="tl-end right" x="840" y="62">lock</text>
+
+            {/* shadow + token */}
+            <circle
+              className="tl-token-shadow"
+              id="token-shadow"
+              cx="60"
+              cy="98"
+              r="9"
+              ref={tokenShRef}
+            />
+            <g id="token-group">
+              <circle
+                className="tl-token"
+                id="token"
+                cx="60"
+                cy="90"
+                r="9"
+                ref={tokenRef}
+              />
+            </g>
+
+            {/* +3 sessions @ x=320 */}
+            <circle className="tl-node-halo" id="halo-7" cx="320" cy="90" r="18" />
+            <circle className="tl-node"      id="node-7" cx="320" cy="90" r="7" />
+            <text className="tl-label is-cp" x="320" y="120" textAnchor="middle">+3 sess</text>
+            <text className="tl-cp-title"    x="320" y="138" textAnchor="middle">early signal</text>
+
+            {/* +10 sessions @ x=580 */}
+            <circle className="tl-node-halo" id="halo-30" cx="580" cy="90" r="18" />
+            <circle className="tl-node"      id="node-30" cx="580" cy="90" r="7" />
+            <text className="tl-label is-cp" x="580" y="120" textAnchor="middle">+10 sess</text>
+            <text className="tl-cp-title"    x="580" y="138" textAnchor="middle">real-world settled</text>
+
+            {/* +30 sessions @ x=840 */}
+            <circle className="tl-node-halo" id="halo-90" cx="840" cy="90" r="22" />
+            <circle className="tl-node"      id="node-90" cx="840" cy="90" r="9" />
+            <text className="tl-label is-cp" x="840" y="120" textAnchor="middle">+30 sess</text>
+            <text className="tl-cp-title"    x="840" y="138" textAnchor="middle">locked verdict</text>
+
+            {/* evidence chips */}
+            <g className="tl-chip is-green" id="chip-7" transform="translate(220,18)">
+              <g className="tl-chip-inner">
+                <rect className="tl-chip-box" x="0" y="0" width="200" height="38" rx="2" />
+                <text className="tl-chip-text"          x="12" y="16">marker still landed</text>
+                <text className="tl-chip-text is-muted" x="12" y="30">0 fixes across 3 sessions</text>
+              </g>
+            </g>
+
+            <g className="tl-chip is-green" id="chip-30" transform="translate(480,18)">
+              <g className="tl-chip-inner">
+                <rect className="tl-chip-box" x="0" y="0" width="200" height="38" rx="2" />
+                <text className="tl-chip-text"          x="12" y="16">0 rollbacks · 10 sess held</text>
+                <text className="tl-chip-text is-muted" x="12" y="30">1 dependent skill fired</text>
+              </g>
+            </g>
+
+            {/* t+90: bigger emphasis as the locked verdict */}
+            <g className="tl-chip is-green" id="chip-90" transform="translate(700,4)">
+              <g className="tl-chip-inner">
+                <rect
+                  className="tl-chip-box"
+                  x="0"
+                  y="0"
+                  width="200"
+                  height="52"
+                  rx="2"
+                  style={{ fill: "var(--green)", stroke: "var(--green)" }}
+                />
+                <text
+                  className="tl-chip-text"
+                  x="14"
+                  y="22"
+                  style={{
+                    fill: "var(--page)",
+                    fontWeight: 500,
+                    letterSpacing: "0.14em",
+                    fontSize: "12px",
+                  }}
+                >
+                  VERDICT: ADOPTED
+                </text>
+                <text
+                  className="tl-chip-text"
+                  x="14"
+                  y="40"
+                  style={{
+                    fill: "color-mix(in srgb, var(--page) 78%, transparent)",
+                    fontSize: "10.5px",
+                  }}
+                >
+                  feeds dedupe graph
+                </text>
+              </g>
+            </g>
+          </svg>
+        </div>
+
+        {/* inspector panel */}
+        <div className="inspector" id="inspector" aria-live="polite">
+          <div className="insp-cp">
+            <span id="insp-cp-name" ref={inspCpRef}>accept</span>
+            <span className="insp-cp-sub" id="insp-cp-sub" ref={inspSubRef}>
+              experiment opened
+            </span>
+          </div>
+          <div className="insp-body" id="insp-body" ref={inspBodyRef}>
+            <div className="ev is-shown">
+              <span className="lk">exp_id</span> <span>post-feature-verify · t0</span>
+            </div>
+            <div className="ev is-shown">
+              <span className="lk">marker</span> <span>added · src/cli/run.ts:42</span>
+            </div>
+            <div className="ev is-shown">
+              <span className="lk">watching</span>{" "}
+              <span>marker · file · pattern · tests</span>
+            </div>
+          </div>
+          <div className="insp-state" id="insp-state" ref={inspStRef}>pending</div>
+        </div>
+
+        <p className="cap">
+          <strong>ax doesn&apos;t trust the moment you accept</strong> &mdash; it earns
+          the verdict by watching what happens across the next 30 sessions. Marker still
+          landed? File still healthy? Pattern not recurring? Tests still green? Each
+          checkpoint joins evidence from the same graph that generated the proposal.
+          Sessions, not days &mdash; a weekend doesn&apos;t artificially delay; a
+          productive afternoon doesn&apos;t artificially rush. The verdict at +30
+          sessions is locked and feeds the next round.
+        </p>
+      </figure>
+
+      {/* past experiments strip */}
+      <section className="exp-strip" aria-label="five past experiments">
+        <p className="exp-strip-head">
+          <span>recent experiments</span>
+          <span className="right">5 of 47</span>
+        </p>
+
+        <ul className="exp-list">
+          <li>
+            <span className="exp-name">post-feature-verify</span>
+            <span className="exp-cp-tag">+30 sess</span>
+            <span className="exp-reason">
+              <span className="ok">marker landed</span> ·{" "}
+              <span className="ok">0 rollbacks</span> ·{" "}
+              <span className="ref">1 dependent</span>
+            </span>
+            <span className="vchip is-adopted">adopted</span>
+          </li>
+          <li>
+            <span className="exp-name">main-branch-guardrail</span>
+            <span className="exp-cp-tag">+10 sess</span>
+            <span className="exp-reason">
+              marker landed · <span className="err">2 of 4 callsites bypassed</span>
+            </span>
+            <span className="vchip is-partial">partial</span>
+          </li>
+          <li>
+            <span className="exp-name">skill-ts-default</span>
+            <span className="exp-cp-tag">+3 sess</span>
+            <span className="exp-reason">awaiting first signal · 1 session remaining</span>
+            <span className="vchip is-pending">pending</span>
+          </li>
+          <li>
+            <span className="exp-name">ingest-regression</span>
+            <span className="exp-cp-tag">+30 sess</span>
+            <span className="exp-reason">
+              <span className="ok">pattern not recurred over 30 sessions</span> ·{" "}
+              <span className="ok">tests green</span>
+            </span>
+            <span className="vchip is-adopted">adopted</span>
+          </li>
+          <li>
+            <span className="exp-name">cache-warm-on-start</span>
+            <span className="exp-cp-tag">+10 sess</span>
+            <span className="exp-reason">
+              <span className="err">added 800ms cold start</span> · reverted at session 6
+            </span>
+            <span className="vchip is-regressed">regressed</span>
+          </li>
+        </ul>
+
+        <div className="verdict-legend" role="list">
+          <span className="vleg-label">verdict states ›</span>
+          <span className="vchip is-adopted" role="listitem">adopted</span>
+          <span className="vchip is-regressed" role="listitem">regressed</span>
+          <span className="vchip is-partial" role="listitem">partial</span>
+          <span className="vchip is-ignored" role="listitem">ignored</span>
+          <span className="vchip is-no-longer-needed" role="listitem">no_longer_needed</span>
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/site/app/routes/showcases.tsx
+++ b/site/app/routes/showcases.tsx
@@ -1,0 +1,45 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SiteHeader } from "~/components/landing-sections/site-header";
+import { SiteFooter } from "~/components/landing-sections/site-footer";
+import { HookBacktestShowcase } from "~/components/showcases/hook-backtest";
+import { RecallShowcase } from "~/components/showcases/recall";
+import { TokenEconomyShowcase } from "~/components/showcases/token-economy";
+import { VerdictTimelineShowcase } from "~/components/showcases/verdict-timeline";
+
+export const Route = createFileRoute("/showcases")({
+  component: Showcases,
+});
+
+function Showcases() {
+  return (
+    <>
+      <SiteHeader />
+      <main>
+        <section className="showcases-intro">
+          <p className="eyebrow">what ax actually does</p>
+          <h1>
+            Four scenarios, <em>one graph</em>.
+          </h1>
+          <p className="lede">
+            Concrete demos of what your local ax instance already exposes -
+            backtest a hook against history, search every session you've ever
+            had, see where your tokens go, watch a verdict earn its place at
+            +30 sessions. Each one is something you can run today.
+          </p>
+          <nav className="showcases-nav" aria-label="showcase jump links">
+            <a href="#hook-backtest">hook backtest</a>
+            <a href="#recall">recall</a>
+            <a href="#token-economy">token economy</a>
+            <a href="#verdict-timeline">verdict timeline</a>
+          </nav>
+        </section>
+
+        <HookBacktestShowcase />
+        <RecallShowcase />
+        <TokenEconomyShowcase />
+        <VerdictTimelineShowcase />
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/site/app/styles/globals.css
+++ b/site/app/styles/globals.css
@@ -4020,3 +4020,1688 @@ footer .right {
   .fig-curve .ax-marker-sub   { font-size: 20px; }
 }
 
+/* ----- showcase 2: recall ----- */
+
+.showcase-recall {
+  /* local scoped tokens (not in global :root) */
+  --soft: #8a8780;
+  --hi: #fff3a8;
+  --hi-stroke: #d4b800;
+
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 80px 32px 120px;
+  background: var(--page);
+  color: var(--ink);
+  font-family: var(--sans);
+}
+
+.showcase-recall .eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin: 0 0 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.showcase-recall .eyebrow::before {
+  content: "";
+  width: 18px;
+  height: 1px;
+  background: var(--ink);
+  opacity: 0.5;
+}
+
+.showcase-recall h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 44px;
+  line-height: 1.08;
+  letter-spacing: -0.6px;
+  margin: 0 0 18px;
+  max-width: 22ch;
+}
+.showcase-recall h2 em {
+  font-style: italic;
+  color: var(--muted);
+}
+.showcase-recall .lede {
+  font-family: var(--serif);
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink);
+  max-width: 60ch;
+  margin: 0 0 40px;
+}
+.showcase-recall .lede .soft { color: var(--muted); }
+
+/* CLI strip */
+.showcase-recall .cli {
+  background: var(--term-bg);
+  color: var(--term-fg);
+  border-radius: 8px;
+  padding: 14px 18px;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 0 0 22px;
+  box-shadow: 0 8px 24px -16px rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--term-line);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  overflow: hidden;
+}
+.showcase-recall .cli .dots {
+  display: inline-flex;
+  gap: 6px;
+  margin-right: 8px;
+}
+.showcase-recall .cli .dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.showcase-recall .cli .dot.r { background: #ec6a5e; }
+.showcase-recall .cli .dot.y { background: #f4be4f; }
+.showcase-recall .cli .dot.g { background: #61c554; }
+.showcase-recall .cli .prompt { color: var(--term-muted); }
+.showcase-recall .cli .cmd { color: var(--term-fg); }
+.showcase-recall .cli .arg { color: #c5b35b; }
+.showcase-recall .cli .caret {
+  display: inline-block;
+  width: 7px;
+  height: 14px;
+  background: var(--term-fg);
+  margin-left: 2px;
+  transform: translateY(2px);
+  animation: showcase-recall-blink 1s steps(2) infinite;
+}
+@keyframes showcase-recall-blink {
+  50% { opacity: 0; }
+}
+
+/* search panel */
+.showcase-recall .search {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 18px 20px;
+  display: grid;
+  grid-template-columns: 24px 1fr auto;
+  align-items: center;
+  gap: 14px;
+  box-shadow: 0 1px 0 #ece9df, 0 24px 60px -40px rgba(20, 20, 15, 0.25);
+  margin: 0 0 14px;
+  position: relative;
+}
+.showcase-recall .search:focus-within {
+  border-color: var(--ink);
+}
+.showcase-recall .search .glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+}
+.showcase-recall .search input {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  font-family: var(--serif);
+  font-size: 22px;
+  color: var(--ink);
+  outline: none;
+  width: 100%;
+  padding: 4px 0;
+  letter-spacing: -0.2px;
+}
+.showcase-recall .search input::placeholder { color: #b3b1a8; }
+.showcase-recall .search .kbd {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.showcase-recall .search .kbd b {
+  font-weight: 500;
+  background: #efece1;
+  border: 1px solid var(--line);
+  border-bottom-width: 2px;
+  padding: 2px 7px;
+  border-radius: 4px;
+  color: var(--ink);
+}
+
+.showcase-recall .meta-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0 4px;
+  margin: 0 0 26px;
+}
+.showcase-recall .meta-row .scope {
+  display: inline-flex;
+  gap: 14px;
+}
+.showcase-recall .meta-row .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.showcase-recall .meta-row .chip::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  background: var(--ink);
+  border-radius: 50%;
+  opacity: 0.6;
+}
+
+/* results */
+.showcase-recall .results {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border-top: 1px solid var(--line);
+}
+
+.showcase-recall .result {
+  padding: 26px 4px 22px;
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 18px;
+  transition: background 0.2s;
+}
+.showcase-recall .result:hover {
+  background: color-mix(in srgb, var(--panel) 60%, transparent);
+}
+.showcase-recall .result.dim { opacity: 0.55; }
+
+.showcase-recall .rank {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  padding-top: 4px;
+}
+.showcase-recall .rank .score {
+  display: block;
+  margin-top: 6px;
+  font-size: 10px;
+  color: var(--soft);
+}
+
+.showcase-recall .body .excerpt {
+  font-family: var(--serif);
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink);
+  margin: 0 0 14px;
+  max-width: 64ch;
+}
+.showcase-recall .body .excerpt mark {
+  background: var(--hi);
+  color: var(--ink);
+  padding: 1px 3px;
+  border-radius: 2px;
+  box-shadow: inset 0 -1px 0 var(--hi-stroke);
+}
+
+.showcase-recall .prov {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  line-height: 1.7;
+}
+.showcase-recall .prov .sep { color: #c8c6bd; }
+.showcase-recall .prov .path { color: var(--ink); }
+.showcase-recall .prov .sid { color: var(--blue); }
+.showcase-recall .prov .date { color: var(--ink); }
+.showcase-recall .prov .src {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.showcase-recall .prov .src::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+}
+.showcase-recall .prov .src.codex::before {
+  background: var(--blue);
+}
+
+.showcase-recall .outcome {
+  margin-top: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  padding: 6px 12px 6px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #fcfbf6;
+}
+.showcase-recall .outcome .arrow { color: var(--muted); }
+.showcase-recall .outcome .commit {
+  font-weight: 500;
+  color: var(--ink);
+  background: #eee9d6;
+  padding: 1px 6px;
+  border-radius: 3px;
+  border: 1px solid #d8d2bb;
+}
+.showcase-recall .outcome .verdict {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 10px;
+}
+.showcase-recall .outcome.adopted .verdict { color: var(--green); }
+.showcase-recall .outcome.adopted-locked .verdict { color: var(--green); font-weight: 600; }
+.showcase-recall .outcome.rolled .verdict { color: var(--red); }
+.showcase-recall .outcome.rejected .verdict { color: var(--red); }
+
+.showcase-recall .outcome .t-since {
+  color: var(--soft);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+}
+
+/* caption */
+.showcase-recall .caption {
+  margin-top: 48px;
+  padding: 28px 30px;
+  border: 1px dashed var(--line);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--panel) 60%, transparent);
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 22px;
+  align-items: start;
+}
+.showcase-recall .caption .label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  padding-top: 4px;
+}
+.showcase-recall .caption p {
+  margin: 0 0 10px;
+  font-family: var(--serif);
+  font-size: 16.5px;
+  line-height: 1.6;
+  color: var(--ink);
+  max-width: 60ch;
+}
+.showcase-recall .caption p:last-child { margin-bottom: 0; }
+.showcase-recall .caption code {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  background: #efece1;
+  padding: 1px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--line);
+}
+
+.showcase-recall .foot {
+  margin-top: 28px;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--soft);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 720px) {
+  .showcase-recall h2 { font-size: 32px; }
+  .showcase-recall .lede { font-size: 17px; }
+  .showcase-recall .search input { font-size: 18px; }
+  .showcase-recall .search { padding: 14px 16px; }
+  .showcase-recall .result { grid-template-columns: 1fr; gap: 8px; }
+  .showcase-recall .rank { padding-top: 0; }
+  .showcase-recall .caption { grid-template-columns: 1fr; gap: 10px; }
+}
+
+/* ----- showcase 1: hook backtest ----- */
+.showcase-hook-backtest {
+  --cc-orange: #d77757;
+  background: var(--page);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+.showcase-hook-backtest * { box-sizing: border-box; }
+
+.showcase-hook-backtest .wrap {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 88px 32px 96px;
+}
+
+/* header */
+.showcase-hook-backtest .eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin: 0 0 16px;
+}
+.showcase-hook-backtest h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(30px, 4.4vw, 44px);
+  line-height: 1.08;
+  letter-spacing: -0.6px;
+  margin: 0 0 24px;
+  max-width: 24ch;
+}
+.showcase-hook-backtest h2 em {
+  font-style: italic;
+  color: var(--muted);
+}
+.showcase-hook-backtest p.lede {
+  font-family: var(--serif);
+  font-size: 19px;
+  line-height: 1.6;
+  margin: 0 0 40px;
+  max-width: 62ch;
+  color: var(--ink);
+}
+
+/* split layout */
+.showcase-hook-backtest .split {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  gap: 18px;
+  align-items: stretch;
+}
+@media (max-width: 820px) {
+  .showcase-hook-backtest .split { grid-template-columns: 1fr; }
+}
+
+/* hook source card */
+.showcase-hook-backtest .hook-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.showcase-hook-backtest .hook-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+.showcase-hook-backtest .hook-head .filename {
+  color: var(--ink);
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 12px;
+}
+.showcase-hook-backtest .hook-head .badge {
+  color: var(--cc-orange);
+  border: 1px solid color-mix(in srgb, var(--cc-orange) 35%, var(--line));
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+}
+.showcase-hook-backtest .hook-source {
+  margin: 0;
+  padding: 18px 18px 20px;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.65;
+  color: var(--ink);
+  white-space: pre;
+  overflow-x: auto;
+  flex: 1;
+}
+.showcase-hook-backtest .hook-source .c-key { color: var(--blue); }
+.showcase-hook-backtest .hook-source .c-str { color: var(--green); }
+.showcase-hook-backtest .hook-source .c-com { color: var(--muted); font-style: italic; }
+.showcase-hook-backtest .hook-source .c-fn  { color: #8a3ffc; }
+.showcase-hook-backtest .hook-source .c-num { color: var(--red); }
+.showcase-hook-backtest .hook-foot {
+  border-top: 1px solid var(--line);
+  padding: 10px 16px;
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+.showcase-hook-backtest .hook-foot .gut { color: var(--ink); }
+
+/* terminal */
+.showcase-hook-backtest .term-frame {
+  background: var(--term-bg);
+  border: 1px solid var(--term-line);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 24px -12px rgba(0,0,0,0.18);
+}
+.showcase-hook-backtest .term-chrome {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+  height: 34px;
+  border-bottom: 1px solid var(--term-line);
+  background: linear-gradient(to bottom, #1c1c16, #14140f);
+}
+.showcase-hook-backtest .term-dot {
+  width: 11px; height: 11px; border-radius: 50%;
+  box-shadow: inset 0 0 0 0.5px rgba(0,0,0,0.25);
+}
+.showcase-hook-backtest .term-dot-r { background: #ec6a5e; }
+.showcase-hook-backtest .term-dot-y { background: #f4be4f; }
+.showcase-hook-backtest .term-dot-g { background: #61c554; }
+.showcase-hook-backtest .term-title {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--term-muted);
+  margin-left: 14px;
+}
+.showcase-hook-backtest .term-title .seg { color: var(--term-fg); }
+.showcase-hook-backtest .term-body {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--term-fg);
+  padding: 16px 18px 18px;
+  white-space: pre;
+  overflow-x: auto;
+  min-height: 360px;
+}
+.showcase-hook-backtest .term-line { padding: 1px 0; }
+.showcase-hook-backtest .t-prompt { color: var(--term-violet); }
+.showcase-hook-backtest .t-cmd    { color: var(--term-yellow); }
+.showcase-hook-backtest .t-flag   { color: var(--term-blue); }
+.showcase-hook-backtest .t-muted  { color: var(--term-muted); }
+.showcase-hook-backtest .t-ok     { color: var(--term-green); }
+.showcase-hook-backtest .t-bad    { color: var(--term-red); }
+.showcase-hook-backtest .t-warn   { color: var(--term-yellow); }
+.showcase-hook-backtest .t-id     { color: var(--term-violet); }
+.showcase-hook-backtest .t-num    { color: var(--term-blue); }
+.showcase-hook-backtest .t-file   { color: var(--term-blue); }
+.showcase-hook-backtest .t-strong { color: var(--term-fg); font-weight: 600; }
+.showcase-hook-backtest .t-rule   { color: var(--term-line); }
+.showcase-hook-backtest .term-body .rule {
+  color: #3a3830;
+  letter-spacing: -1px;
+}
+.showcase-hook-backtest .rec-badge {
+  background: color-mix(in srgb, var(--term-green) 22%, transparent);
+  color: var(--term-green);
+  padding: 0 8px;
+  border-radius: 3px;
+  border: 1px solid color-mix(in srgb, var(--term-green) 38%, transparent);
+}
+.showcase-hook-backtest .term-caret {
+  display: inline-block;
+  width: 8px;
+  height: 14px;
+  background: var(--term-fg);
+  vertical-align: -2px;
+  animation: showcase-hook-backtest-blink 1.1s steps(1) infinite;
+}
+@keyframes showcase-hook-backtest-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+/* week strip */
+.showcase-hook-backtest .week {
+  margin-top: 28px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 20px 22px 22px;
+}
+.showcase-hook-backtest .week-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+.showcase-hook-backtest .week-head .label {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+.showcase-hook-backtest .week-head .meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+.showcase-hook-backtest .week-head .meta b { color: var(--ink); font-weight: 500; }
+.showcase-hook-backtest .week-grid {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 10px 18px;
+  align-items: center;
+}
+.showcase-hook-backtest .day-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  text-align: right;
+  line-height: 1.2;
+}
+.showcase-hook-backtest .day-label b {
+  display: block;
+  color: var(--ink);
+  font-weight: 500;
+  font-size: 11.5px;
+  margin-bottom: 2px;
+}
+.showcase-hook-backtest .day-row {
+  display: flex;
+  gap: 3px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.showcase-hook-backtest .tick {
+  width: 14px;
+  height: 22px;
+  border-radius: 2px;
+  background: #ece9df;
+  border: 1px solid #dedacd;
+  position: relative;
+}
+.showcase-hook-backtest .tick.pass  { background: #ece9df; border-color: #dedacd; }
+.showcase-hook-backtest .tick.tp    { background: var(--cc-orange); border-color: #b95f3f; }
+.showcase-hook-backtest .tick.fp    { background: #f0d36b; border-color: #c9a93b; }
+.showcase-hook-backtest .tick.saved { background: #2f9e44; border-color: #237a32; }
+.showcase-hook-backtest .day-row .sep {
+  flex: 1;
+  height: 1px;
+  background: transparent;
+}
+.showcase-hook-backtest .day-count {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  margin-left: auto;
+  padding-left: 10px;
+  min-width: 70px;
+  text-align: right;
+}
+.showcase-hook-backtest .legend {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--line);
+  display: flex;
+  gap: 22px;
+  flex-wrap: wrap;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+.showcase-hook-backtest .legend .sw {
+  display: inline-block;
+  width: 10px; height: 10px;
+  border-radius: 2px;
+  margin-right: 6px;
+  vertical-align: -1px;
+}
+.showcase-hook-backtest .legend .sw.pass  { background: #ece9df; border: 1px solid #dedacd; }
+.showcase-hook-backtest .legend .sw.tp    { background: var(--cc-orange); border: 1px solid #b95f3f; }
+.showcase-hook-backtest .legend .sw.fp    { background: #f0d36b; border: 1px solid #c9a93b; }
+.showcase-hook-backtest .legend .sw.saved { background: var(--green); border: 1px solid #237a32; }
+
+/* caption */
+.showcase-hook-backtest .caption {
+  margin-top: 30px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 28px;
+}
+.showcase-hook-backtest .caption .tag {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  padding-top: 4px;
+}
+.showcase-hook-backtest .caption p {
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.6;
+  margin: 0;
+  max-width: 60ch;
+}
+.showcase-hook-backtest .caption p em { color: var(--muted); font-style: italic; }
+
+@media (max-width: 640px) {
+  .showcase-hook-backtest .caption { grid-template-columns: 1fr; gap: 8px; }
+  .showcase-hook-backtest .week-grid { grid-template-columns: 90px 1fr; }
+}
+
+
+/* ----- showcase 4: verdict timeline ----- */
+/* Ported from docs/prototypes/showcase-4-verdict-timeline.html.
+   All selectors scoped under .showcase-verdict-timeline. Tokens
+   --page --ink --muted --line --green --red --blue --panel
+   --serif --mono --sans are reused from :root above. */
+
+.showcase-verdict-timeline { color: var(--ink); font-family: var(--sans); }
+.showcase-verdict-timeline *, .showcase-verdict-timeline *::before, .showcase-verdict-timeline *::after { box-sizing: border-box; }
+
+/* ---------- type ---------- */
+.showcase-verdict-timeline .eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin: 0 0 16px;
+}
+.showcase-verdict-timeline h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 36px;
+  line-height: 1.12;
+  letter-spacing: -0.5px;
+  margin: 0 0 18px;
+  max-width: 22ch;
+}
+.showcase-verdict-timeline p.lede {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink);
+  max-width: 64ch;
+  margin: 0 0 36px;
+}
+.showcase-verdict-timeline p.cap {
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--muted);
+  max-width: 64ch;
+  margin: 28px 0 0;
+}
+.showcase-verdict-timeline p.cap strong { color: var(--ink); font-weight: 500; }
+
+/* ---------- figure shell ---------- */
+.showcase-verdict-timeline .figure {
+  width: 100%;
+  margin: 28px 0 8px;
+  padding: 0;
+}
+.showcase-verdict-timeline .fig-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 18px;
+  padding-bottom: 14px;
+  margin-bottom: 22px;
+  border-bottom: 1px solid var(--ink);
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+.showcase-verdict-timeline .fig-head .fig-id { color: var(--ink); }
+.showcase-verdict-timeline .fig-head .auto-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid var(--line);
+  padding: 4px 9px;
+  cursor: pointer;
+  line-height: 1;
+  margin-left: auto;
+}
+.showcase-verdict-timeline .fig-head .auto-pill[data-state="playing"] {
+  color: var(--ink);
+  border-color: var(--ink);
+}
+.showcase-verdict-timeline .fig-head .auto-pill[data-state="done"],
+.showcase-verdict-timeline .fig-head .auto-pill[data-state="idle"] { cursor: pointer; }
+.showcase-verdict-timeline .fig-head .auto-pill .auto-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--green) 30%, transparent);
+  display: inline-block;
+}
+.showcase-verdict-timeline .fig-head .auto-pill[data-state="playing"] .auto-dot {
+  animation: svtl-pulse 1.6s ease-in-out infinite;
+}
+.showcase-verdict-timeline .fig-head .auto-pill[data-state="done"] .auto-dot,
+.showcase-verdict-timeline .fig-head .auto-pill[data-state="idle"] .auto-dot { display: none; }
+.showcase-verdict-timeline .fig-head .auto-pill[data-state="done"]::before {
+  content: "↻";
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+@keyframes svtl-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+/* ---------- timeline stage ---------- */
+.showcase-verdict-timeline .tl-stage {
+  position: relative;
+  padding: 36px 0 28px;
+}
+.showcase-verdict-timeline .tl-svg {
+  width: 100%;
+  height: 180px;
+  display: block;
+  overflow: visible;
+}
+.showcase-verdict-timeline .tl-svg .tl-chip { overflow: visible; }
+
+.showcase-verdict-timeline .tl-track-bg { stroke: var(--line); stroke-width: 2; }
+.showcase-verdict-timeline .tl-track-fill {
+  stroke: var(--ink);
+  stroke-width: 2;
+  stroke-linecap: butt;
+  transition: none;
+}
+
+.showcase-verdict-timeline .tl-node {
+  fill: var(--page);
+  stroke: var(--ink);
+  stroke-width: 1.5;
+  transition: fill 360ms ease, stroke 360ms ease;
+}
+.showcase-verdict-timeline .tl-node.is-reached { fill: var(--ink); }
+.showcase-verdict-timeline .tl-node.is-reached.is-green { fill: var(--green); stroke: var(--green); }
+.showcase-verdict-timeline .tl-node.is-reached.is-red   { fill: var(--red);   stroke: var(--red); }
+.showcase-verdict-timeline .tl-node.is-reached.is-blue  { fill: var(--blue);  stroke: var(--blue); }
+
+.showcase-verdict-timeline .tl-node-halo {
+  fill: var(--green);
+  opacity: 0;
+  transition: opacity 360ms ease;
+}
+.showcase-verdict-timeline .tl-node-halo.is-shown { opacity: 0.18; }
+.showcase-verdict-timeline .tl-node-halo.is-red  { fill: var(--red); }
+.showcase-verdict-timeline .tl-node-halo.is-blue { fill: var(--blue); }
+
+.showcase-verdict-timeline .tl-token {
+  fill: var(--ink);
+  stroke: var(--page);
+  stroke-width: 3;
+}
+.showcase-verdict-timeline .tl-token-shadow {
+  fill: var(--ink);
+  opacity: 0.10;
+}
+
+.showcase-verdict-timeline .tl-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  fill: var(--muted);
+}
+.showcase-verdict-timeline .tl-label.is-cp { fill: var(--ink); }
+.showcase-verdict-timeline .tl-end {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 15px;
+  fill: var(--muted);
+}
+.showcase-verdict-timeline .tl-end.left  { text-anchor: start; }
+.showcase-verdict-timeline .tl-end.right { text-anchor: end; }
+
+.showcase-verdict-timeline .tl-cp-title {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  fill: var(--ink);
+}
+
+/* evidence chips: opacity-only CSS transform on outer <g>, translateY on inner */
+.showcase-verdict-timeline .tl-chip {
+  opacity: 0;
+  transition: opacity 320ms ease-out;
+}
+.showcase-verdict-timeline .tl-chip.is-shown { opacity: 1; }
+.showcase-verdict-timeline .tl-chip .tl-chip-inner {
+  transform: translateY(-6px);
+  transform-box: fill-box;
+  transform-origin: 0 0;
+  transition: transform 320ms ease-out;
+}
+.showcase-verdict-timeline .tl-chip.is-shown .tl-chip-inner {
+  transform: translateY(0);
+}
+
+.showcase-verdict-timeline .tl-chip-box {
+  fill: var(--panel);
+  stroke: var(--line);
+  stroke-width: 1;
+}
+.showcase-verdict-timeline .tl-chip.is-green .tl-chip-box { stroke: var(--green); }
+.showcase-verdict-timeline .tl-chip.is-red   .tl-chip-box { stroke: var(--red); }
+.showcase-verdict-timeline .tl-chip.is-blue  .tl-chip-box { stroke: var(--blue); }
+
+.showcase-verdict-timeline .tl-chip-text {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  fill: var(--ink);
+  letter-spacing: 0.02em;
+}
+.showcase-verdict-timeline .tl-chip-text.is-muted { fill: var(--muted); }
+
+/* optional html verdict overlay (kept for parity, currently unused in markup) */
+.showcase-verdict-timeline .tl-verdict {
+  position: absolute;
+  right: 0;
+  top: 0;
+  transform: translateY(8px);
+  opacity: 0;
+  transition: opacity 360ms ease-out, transform 360ms ease-out;
+  pointer-events: none;
+}
+.showcase-verdict-timeline .tl-verdict.is-shown { opacity: 1; transform: translateY(0); }
+.showcase-verdict-timeline .tl-verdict .v-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  padding: 8px 14px;
+  background: var(--green);
+  color: var(--page);
+  border: 1px solid var(--green);
+  line-height: 1;
+}
+.showcase-verdict-timeline .tl-verdict .v-pill::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  background: var(--page);
+  border-radius: 50%;
+}
+
+/* ---------- inspector ---------- */
+.showcase-verdict-timeline .inspector {
+  display: grid;
+  grid-template-columns: 88px 1fr auto;
+  gap: 20px;
+  align-items: start;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--line);
+  padding: 18px 4px 20px;
+  margin-top: 12px;
+}
+.showcase-verdict-timeline .insp-cp {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.showcase-verdict-timeline .insp-cp .insp-cp-sub {
+  display: block;
+  color: var(--muted);
+  margin-top: 4px;
+  letter-spacing: 0.08em;
+}
+.showcase-verdict-timeline .insp-body {
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.65;
+  color: var(--ink);
+  min-height: 56px;
+  display: grid;
+  gap: 4px;
+}
+.showcase-verdict-timeline .insp-body .ev {
+  opacity: 0;
+  transform: translateY(-2px);
+  transition: opacity 320ms ease-out, transform 320ms ease-out;
+}
+.showcase-verdict-timeline .insp-body .ev.is-shown { opacity: 1; transform: translateY(0); }
+.showcase-verdict-timeline .insp-body .ev .lk  { color: var(--muted); }
+.showcase-verdict-timeline .insp-body .ev .ok  { color: var(--green); }
+.showcase-verdict-timeline .insp-body .ev .err { color: var(--red); }
+.showcase-verdict-timeline .insp-body .ev .ref { color: var(--blue); }
+
+.showcase-verdict-timeline .insp-state {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  align-self: start;
+  white-space: nowrap;
+}
+.showcase-verdict-timeline .insp-state.is-green { border-color: var(--green); color: var(--green); }
+.showcase-verdict-timeline .insp-state.is-red   { border-color: var(--red);   color: var(--red); }
+.showcase-verdict-timeline .insp-state.is-blue  { border-color: var(--blue);  color: var(--blue); }
+
+/* ---------- past-experiments strip ---------- */
+.showcase-verdict-timeline .exp-strip {
+  margin-top: 44px;
+  border-top: 1px solid var(--ink);
+  padding-top: 18px;
+}
+.showcase-verdict-timeline .exp-strip-head {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 14px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+.showcase-verdict-timeline .exp-strip-head .right { color: var(--muted); }
+
+.showcase-verdict-timeline .exp-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--line);
+}
+.showcase-verdict-timeline .exp-list li {
+  display: grid;
+  grid-template-columns: 1fr 64px 1fr auto;
+  gap: 18px;
+  align-items: center;
+  padding: 12px 4px;
+  border-bottom: 1px solid var(--line);
+}
+
+.showcase-verdict-timeline .exp-name {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+.showcase-verdict-timeline .exp-cp-tag {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  text-align: center;
+}
+.showcase-verdict-timeline .exp-reason {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.showcase-verdict-timeline .exp-reason .ok  { color: var(--green); }
+.showcase-verdict-timeline .exp-reason .err { color: var(--red); }
+.showcase-verdict-timeline .exp-reason .ref { color: var(--blue); }
+
+/* verdict chips for the strip */
+.showcase-verdict-timeline .vchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+  background: transparent;
+  line-height: 1;
+  white-space: nowrap;
+}
+.showcase-verdict-timeline .vchip.is-adopted {
+  background: var(--green);
+  border-color: var(--green);
+  color: var(--page);
+}
+.showcase-verdict-timeline .vchip.is-regressed {
+  background: var(--red);
+  border-color: var(--red);
+  color: var(--page);
+}
+.showcase-verdict-timeline .vchip.is-partial {
+  background: linear-gradient(90deg, var(--blue) 50%, var(--page) 50%);
+  border-color: var(--blue);
+  color: var(--ink);
+}
+.showcase-verdict-timeline .vchip.is-ignored {
+  background: transparent;
+  border-color: var(--line);
+  color: var(--muted);
+}
+.showcase-verdict-timeline .vchip.is-pending {
+  background: transparent;
+  border-color: var(--line);
+  color: var(--muted);
+  font-style: italic;
+}
+.showcase-verdict-timeline .vchip.is-pending::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+  animation: svtl-pulse 1.6s ease-in-out infinite;
+}
+.showcase-verdict-timeline .vchip.is-no-longer-needed {
+  text-decoration: line-through;
+  text-decoration-color: var(--muted);
+  color: var(--muted);
+  border-color: var(--line);
+}
+
+.showcase-verdict-timeline .verdict-legend {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+.showcase-verdict-timeline .verdict-legend .vchip {
+  font-size: 9.5px;
+  padding: 4px 8px;
+  letter-spacing: 0.14em;
+}
+.showcase-verdict-timeline .verdict-legend .vleg-label { color: var(--muted); }
+
+/* ---------- responsive ---------- */
+@media (max-width: 720px) {
+  .showcase-verdict-timeline h2 { font-size: 28px; }
+  .showcase-verdict-timeline p.lede { font-size: 17px; }
+  .showcase-verdict-timeline .inspector {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .showcase-verdict-timeline .exp-list li {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "name verdict"
+      "cp   verdict"
+      "reason reason";
+    gap: 6px 12px;
+  }
+  .showcase-verdict-timeline .exp-name    { grid-area: name; }
+  .showcase-verdict-timeline .exp-cp-tag  { grid-area: cp; text-align: left; }
+  .showcase-verdict-timeline .exp-reason  { grid-area: reason; }
+  .showcase-verdict-timeline .exp-list li > .vchip { grid-area: verdict; }
+  .showcase-verdict-timeline .tl-svg { height: 220px; }
+}
+
+/* ----- showcase 3: token economy ----- */
+.showcase-token-economy {
+  --te-amber: #b8860b;
+  --te-soft: #ece9df;
+  --te-soft-2: #ebe9e0;
+  --te-insight-bg: #f0ece1;
+  --te-claude: #d77757;
+
+  display: block;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 64px 32px 96px;
+  background: var(--page);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+.showcase-token-economy * { box-sizing: border-box; }
+
+.showcase-token-economy .eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin: 0 0 14px;
+}
+.showcase-token-economy h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 40px;
+  line-height: 1.1;
+  letter-spacing: -0.6px;
+  margin: 0 0 18px;
+}
+.showcase-token-economy h2 em {
+  font-style: italic;
+  color: var(--muted);
+}
+.showcase-token-economy p.lede {
+  margin: 0 0 36px;
+  font-size: 19px;
+  line-height: 1.5;
+  max-width: 60ch;
+  color: #2c2c28;
+}
+.showcase-token-economy p.lede .cmd {
+  font-family: var(--mono);
+  font-size: 14px;
+  padding: 1px 6px;
+  background: var(--te-soft-2);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+/* hero stats */
+.showcase-token-economy .stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  margin-bottom: 56px;
+}
+.showcase-token-economy .stat {
+  padding: 24px 24px 22px;
+  border-right: 1px solid var(--line);
+  position: relative;
+}
+.showcase-token-economy .stat:last-child { border-right: none; }
+.showcase-token-economy .stat .label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 14px;
+}
+.showcase-token-economy .stat .big {
+  font-family: var(--mono);
+  font-size: 44px;
+  letter-spacing: -1px;
+  line-height: 1;
+  font-weight: 500;
+}
+.showcase-token-economy .stat .big .unit {
+  font-size: 14px;
+  color: var(--muted);
+  letter-spacing: 0;
+  margin-left: 4px;
+  font-weight: 400;
+}
+.showcase-token-economy .stat .delta {
+  font-family: var(--mono);
+  font-size: 12px;
+  margin-top: 12px;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+.showcase-token-economy .delta .up,
+.showcase-token-economy .delta .down { color: var(--red); }
+.showcase-token-economy .delta .good { color: var(--green); }
+.showcase-token-economy .stat .submeta {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--muted);
+  margin-top: 4px;
+  letter-spacing: 0.01em;
+}
+.showcase-token-economy .stat[data-kind="tokens"] .big { color: var(--ink); }
+.showcase-token-economy .stat[data-kind="spend"]  .big { color: var(--blue); }
+.showcase-token-economy .stat[data-kind="cache"]  .big { color: var(--red); }
+
+.showcase-token-economy .provider-strip {
+  display: flex;
+  height: 6px;
+  margin-top: 14px;
+  background: var(--te-soft);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.showcase-token-economy .provider-strip .seg-claude { background: var(--te-claude); }
+.showcase-token-economy .provider-strip .seg-codex  { background: var(--blue); }
+.showcase-token-economy .provider-legend {
+  display: flex;
+  gap: 14px;
+  margin-top: 8px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+.showcase-token-economy .provider-legend .swatch {
+  display: inline-block;
+  width: 8px; height: 8px;
+  margin-right: 5px;
+  vertical-align: 1px;
+  border-radius: 1px;
+}
+
+.showcase-token-economy .target {
+  margin-top: 14px;
+  height: 6px;
+  background: var(--te-soft);
+  border-radius: 1px;
+  position: relative;
+  overflow: visible;
+}
+.showcase-token-economy .target .fill {
+  height: 100%;
+  width: 67%;
+  background: var(--red);
+  border-radius: 1px;
+}
+.showcase-token-economy .target .tick {
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: 80%;
+  width: 1.5px;
+  background: var(--ink);
+}
+.showcase-token-economy .target-legend {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  margin-top: 8px;
+  display: flex;
+  justify-content: space-between;
+  letter-spacing: 0.04em;
+}
+
+/* breakdown */
+.showcase-token-economy .section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0 0 22px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 10px;
+}
+.showcase-token-economy .section-head h3 {
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 400;
+  margin: 0;
+  letter-spacing: -0.2px;
+}
+.showcase-token-economy .section-head .meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+.showcase-token-economy .breakdown {
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: 48px;
+  margin-bottom: 56px;
+}
+
+.showcase-token-economy .epoch-row {
+  display: grid;
+  grid-template-columns: 110px 1fr 64px;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+.showcase-token-economy .epoch-row .name {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+.showcase-token-economy .epoch-row .name .badge {
+  display: inline-block;
+  width: 8px; height: 8px;
+  margin-right: 7px;
+  vertical-align: 1px;
+  border-radius: 1px;
+}
+.showcase-token-economy .epoch-row .bar {
+  height: 22px;
+  background: var(--te-soft);
+  border-radius: 1px;
+  overflow: hidden;
+  display: flex;
+  position: relative;
+}
+.showcase-token-economy .epoch-row .bar .cached {
+  background: var(--green);
+  opacity: 0.85;
+  transition: opacity .2s ease;
+}
+.showcase-token-economy .epoch-row .bar .miss {
+  background: var(--red);
+  opacity: 0.78;
+  transition: opacity .2s ease;
+}
+.showcase-token-economy .epoch-row:hover .bar .cached,
+.showcase-token-economy .epoch-row:hover .bar .miss { opacity: 1; }
+.showcase-token-economy .epoch-row .pct {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--muted);
+  text-align: right;
+  letter-spacing: 0.02em;
+}
+.showcase-token-economy .epoch-key {
+  display: flex;
+  gap: 18px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  margin-top: 10px;
+  letter-spacing: 0.04em;
+}
+.showcase-token-economy .epoch-key .sw {
+  display: inline-block;
+  width: 8px; height: 8px;
+  margin-right: 6px;
+  vertical-align: 1px;
+  border-radius: 1px;
+}
+.showcase-token-economy .epoch-note {
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 22px;
+  line-height: 1.5;
+  max-width: 42ch;
+}
+.showcase-token-economy .epoch-note strong {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+/* sessions */
+.showcase-token-economy .sessions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.showcase-token-economy .session {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 6px 12px;
+  padding: 12px 14px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+}
+.showcase-token-economy .session .sid {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+.showcase-token-economy .session .path {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--ink);
+  letter-spacing: 0;
+  grid-column: 1 / span 2;
+  margin-top: 1px;
+}
+.showcase-token-economy .session .path .arrow {
+  color: var(--muted);
+  margin: 0 6px;
+}
+.showcase-token-economy .session .right {
+  font-family: var(--mono);
+  font-size: 12px;
+  text-align: right;
+  color: var(--muted);
+}
+.showcase-token-economy .session .right .tk {
+  color: var(--ink);
+  font-weight: 500;
+}
+.showcase-token-economy .session .cache-mini {
+  grid-column: 1 / span 2;
+  height: 4px;
+  background: var(--te-soft);
+  border-radius: 1px;
+  overflow: hidden;
+  display: flex;
+  margin-top: 4px;
+}
+.showcase-token-economy .session .cache-mini .c { background: var(--green); opacity: 0.85; }
+.showcase-token-economy .session .cache-mini .m { background: var(--red); opacity: 0.78; }
+.showcase-token-economy .session .ratio {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  grid-column: 1 / span 2;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2px;
+}
+.showcase-token-economy .session .ratio .bad { color: var(--red); }
+.showcase-token-economy .session .ratio .ok  { color: var(--green); }
+.showcase-token-economy .session .ratio .mid { color: var(--te-amber); }
+
+/* insight */
+.showcase-token-economy .insight {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  padding: 22px 26px;
+  border-left: 3px solid var(--red);
+  background: var(--te-insight-bg);
+  margin-bottom: 56px;
+  align-items: center;
+}
+.showcase-token-economy .insight .ratio-num {
+  font-family: var(--mono);
+  font-size: 40px;
+  line-height: 1;
+  color: var(--red);
+  font-weight: 500;
+  letter-spacing: -1px;
+}
+.showcase-token-economy .insight .ratio-num .x {
+  font-size: 22px;
+  color: var(--muted);
+  letter-spacing: 0;
+  margin-left: 2px;
+}
+.showcase-token-economy .insight .body {
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.45;
+}
+.showcase-token-economy .insight .body strong { font-weight: 600; }
+.showcase-token-economy .insight .body .src {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  margin-top: 8px;
+  text-transform: uppercase;
+}
+.showcase-token-economy .insight .body code {
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+/* caption */
+.showcase-token-economy .caption {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line);
+}
+.showcase-token-economy .caption .col {
+  font-size: 14px;
+  line-height: 1.55;
+  color: #3a3a35;
+}
+.showcase-token-economy .caption .col .h {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.showcase-token-economy .caption code {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  background: var(--te-soft-2);
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--line);
+}
+.showcase-token-economy .caption .pill {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 2px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  margin-right: 4px;
+  margin-top: 6px;
+}
+
+@media (max-width: 760px) {
+  .showcase-token-economy { padding: 48px 20px 72px; }
+  .showcase-token-economy .stats { grid-template-columns: 1fr; }
+  .showcase-token-economy .stat { border-right: none; border-bottom: 1px solid var(--line); }
+  .showcase-token-economy .stat:last-child { border-bottom: none; }
+  .showcase-token-economy .breakdown { grid-template-columns: 1fr; gap: 40px; }
+  .showcase-token-economy .caption { grid-template-columns: 1fr; }
+  .showcase-token-economy h2 { font-size: 32px; }
+}
+
+/* ----- /showcases route — intro panel + jump nav ----- */
+.showcases-intro {
+  max-width: 760px;
+  margin: 80px auto 24px;
+  padding: 0 24px;
+  text-align: left;
+}
+.showcases-intro .eyebrow {
+  margin-bottom: 20px;
+}
+.showcases-intro h1 {
+  font-family: var(--serif);
+  font-size: 56px;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 24px;
+  color: var(--ink);
+}
+.showcases-intro h1 em {
+  font-style: italic;
+  color: var(--muted);
+}
+.showcases-intro .lede {
+  font-size: 18px;
+  line-height: 1.6;
+  color: var(--ink);
+  margin: 0 0 28px;
+}
+.showcases-intro .showcases-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  border-top: 1px solid var(--line);
+  padding-top: 16px;
+}
+.showcases-intro .showcases-nav a {
+  padding: 6px 12px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+  text-decoration: none;
+  transition: color .15s ease, border-color .15s ease;
+}
+.showcases-intro .showcases-nav a:hover {
+  color: var(--ink);
+  border-color: var(--ink);
+}
+
+@media (max-width: 640px) {
+  .showcases-intro {
+    margin-top: 48px;
+  }
+  .showcases-intro h1 {
+    font-size: 38px;
+  }
+  .showcases-intro .lede {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## Summary

Concrete UI demos of features ax already ships but the site doesn't yet surface. Each component is a self-contained React port of a prototype HTML file from `docs/prototypes/`, mounted on a single `/showcases` route with a jump nav between them.

Components under `site/app/components/showcases/`:
- **hook-backtest**: would-this-hook-have-caught widget. Hook source panel + terminal mock with precision/recall + 7-day session strip.
- **recall**: cross-session BM25 FTS search bar with ranked turn excerpts, provenance line, outcome chip joined against the verdict graph.
- **token-economy**: token-impact diagnostic — hero stat block (tokens / spend / cache hit + WoW deltas), workflow-epoch stacked bars (cached vs paid), top-5 expensive sessions panel.
- **verdict-timeline**: animated +3/+10/+30 session timeline (matches the new session-based windows from #83) with token movement, evidence chips, inspector, and a 5-experiment strip covering ADOPTED/REGRESSED/PARTIAL/PENDING states.

Wiring:
- `site/app/routes/showcases.tsx` mounts all four with an intro panel + jump nav anchors (`#hook-backtest`, `#recall`, `#token-economy`, `#verdict-timeline`).
- `site-header.tsx` adds a top-nav `Showcases` link.
- `globals.css` gains ~1,800 lines of scoped CSS, each block prefixed with `.showcase-<name>` so styles don't leak across showcases or back into the landing.

Animation conventions:
- All four respect `prefers-reduced-motion`.
- Verdict-timeline uses `IntersectionObserver` to play once on first scroll-into-view and exposes `?autoplay` / `?final` query flags + a replay pill.
- Recall has an idle CLI typewriter; hook-backtest a CSS-keyframe blinking caret; token-economy a one-shot entrance bar fill.

## Test plan
- [x] Typecheck clean for every new file (pre-existing errors in landing-sections/ + origin-sections/ untouched)
- [x] `/showcases` SSR returns 200 with all four section classes present
- [ ] After merge: visual review of each showcase + tab interactions in dev server
- [ ] After merge: nav link routes correctly from landing

Generated with Claude Code.