### PR TITLE
Add provider-neutral plan and delegation extraction

### DIFF
--- a/src/ingest/codex.ts
+++ b/src/ingest/codex.ts
@@ -33,7 +33,12 @@ import {
     toolKindForName,
 } from "./tool-calls.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
-import { normalizeCodexUpdatePlan, type PlanStatus } from "./plans.ts";
+import { providerDelegationSignalAvailability } from "./delegation.ts";
+import {
+    normalizeProviderPlanSnapshot,
+    providerPlanSignalAvailability,
+    toPlanSnapshotWrite,
+} from "./plans.ts";
 import { invokedRelationRecordKey, toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
 import { executeStatements } from "../lib/shared/statement-exec.ts";
 
@@ -151,10 +156,6 @@ function codexMessageKind(role: string, itemType: string | null, textExcerpt: st
     return itemType ?? role;
 }
 
-function stableHash(input: string): string {
-    return Bun.hash(input).toString(16).padStart(16, "0");
-}
-
 export function shouldSnapshotCodexRaw(
     sizeBytes: number,
     maxBytes = DEFAULT_CODEX_RAW_MAX_BYTES,
@@ -252,59 +253,6 @@ function compactCodexFunctionOutputEventRaw(
         call_id: stringField(payload, "call_id"),
         output: compactPayload(payload.output, maxBytes),
     };
-}
-
-function recordKeyPart(input: string, fallback = "_"): string {
-    const sanitized = input
-        .replace(/[^a-zA-Z0-9]/g, "_")
-        .replace(/_+/g, "_")
-        .replace(/^_+|_+$/g, "");
-    return sanitized.length > 0 ? sanitized : fallback;
-}
-
-function planKey(sessionId: string, source: string): string {
-    return [
-        "codex",
-        recordKeyPart(sessionId, "session").slice(0, 80),
-        recordKeyPart(source, "source"),
-        stableHash(`${sessionId}:${source}`).slice(0, 16),
-    ].join("__");
-}
-
-function planSnapshotKey(input: {
-    sessionId: string;
-    source: string;
-    snapshotSeq: number;
-    toolCallKey: string;
-}): string {
-    return [
-        planKey(input.sessionId, input.source),
-        `snapshot_${input.snapshotSeq.toString(10).padStart(6, "0")}`,
-        stableHash(input.toolCallKey).slice(0, 12),
-    ].join("__");
-}
-
-function planItemKey(input: {
-    sessionId: string;
-    source: string;
-    seq: number;
-}): string {
-    return [
-        planKey(input.sessionId, input.source),
-        `item_${input.seq.toString(10).padStart(3, "0")}`,
-    ].join("__");
-}
-
-function planStatus(items: readonly { status: PlanStatus }[]): PlanStatus {
-    if (items.some((item) => item.status === "in_progress")) return "in_progress";
-    if (items.length > 0 && items.every((item) => item.status === "completed")) {
-        return "completed";
-    }
-    if (items.some((item) => item.status === "pending")) return "pending";
-    if (items.length > 0 && items.every((item) => item.status === "abandoned")) {
-        return "abandoned";
-    }
-    return "pending";
 }
 
 type MutableToolCallWrite = {
@@ -596,47 +544,24 @@ function createCodexExtractor(
         });
 
         if (toolName === "update_plan") {
-            const normalized = normalizeCodexUpdatePlan({
+            const normalized = normalizeProviderPlanSnapshot({
+                provider: "codex",
+                toolName,
                 sessionId: currentSession.id,
                 ts,
                 input: payload.arguments,
             });
-            if (normalized.items.length > 0) {
+            if (normalized && normalized.items.length > 0) {
                 const source = normalized.source;
                 const snapshotSeq = nextPlanSnapshotSeq(source);
                 const createdAt = rememberPlanCreatedAt(source, ts);
-                const items = normalized.items.map((item) => ({
-                    key: planItemKey({
-                        sessionId: currentSession.id,
-                        source,
-                        seq: item.seq,
-                    }),
-                    externalId: item.externalId,
-                    seq: item.seq,
-                    content: item.content,
-                    activeForm: item.activeForm,
-                    status: item.status,
-                }));
 
-                planSnapshots.push({
-                    planKey: planKey(currentSession.id, source),
-                    sessionId: currentSession.id,
-                    source,
-                    status: planStatus(normalized.items),
+                planSnapshots.push(toPlanSnapshotWrite({
+                    snapshot: normalized,
+                    snapshotSeq,
                     createdAt,
-                    updatedAt: ts,
-                    snapshotKey: planSnapshotKey({
-                        sessionId: currentSession.id,
-                        source,
-                        snapshotSeq,
-                        toolCallKey,
-                    }),
                     toolCallKey,
-                    itemsJson: normalized.items,
-                    explanation: normalized.explanation,
-                    ts: normalized.ts,
-                    items,
-                });
+                }));
             }
         }
     };
@@ -932,6 +857,8 @@ const buildCodexProviderStatements = (batch: MutableCodexExtract): string[] => {
                 capabilities: {
                     transcripts: true,
                     toolCalls: true,
+                    planSignals: providerPlanSignalAvailability.codex,
+                    delegationSignals: providerDelegationSignalAvailability.codex,
                 },
             },
         ]),

--- a/src/ingest/cursor.ts
+++ b/src/ingest/cursor.ts
@@ -9,7 +9,9 @@ import type { DbError } from "../lib/errors.ts";
 import { executeStatements } from "../lib/shared/statement-exec.ts";
 import { recordRef, surrealDate, surrealString } from "../lib/shared/surql.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
+import { providerDelegationSignalAvailability } from "./delegation.ts";
 import { agentEventRecordKey, buildAgentEventStatements, buildAgentProviderStatements, type AgentEventWrite } from "./provider-events.ts";
+import { providerPlanSignalAvailability } from "./plans.ts";
 import { identityPart, turnRecordKey } from "./record-keys.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
@@ -536,6 +538,8 @@ const buildCursorBatchStatements = (extract: CursorExtract, sourcePath: string):
                 sqlite: true,
                 transcripts: true,
                 providerGraph: true,
+                planSignals: providerPlanSignalAvailability.cursor,
+                delegationSignals: providerDelegationSignalAvailability.cursor,
             },
         },
     ]),

--- a/src/ingest/delegation.test.ts
+++ b/src/ingest/delegation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+    normalizeDelegationToolCall,
+    providerDelegationSignalAvailability,
+} from "./delegation.ts";
+
+describe("provider delegation signal contract", () => {
+    test("normalizes Codex spawn_agent output into a shared spawned source", () => {
+        const spawn = normalizeDelegationToolCall({
+            provider: "codex",
+            toolCallId: "tool_call:⟨spawn-call⟩",
+            parentSessionId: "session:⟨parent-session⟩",
+            ts: "2026-05-09T10:00:00.000Z",
+            toolName: "spawn_agent",
+            outputExcerpt: JSON.stringify({
+                agent_id: "child-session",
+                nickname: "Babbage",
+            }),
+        });
+
+        expect(spawn).toEqual({
+            provider: "codex",
+            toolCallId: "tool_call:⟨spawn-call⟩",
+            parentSessionId: "session:⟨parent-session⟩",
+            ts: "2026-05-09T10:00:00.000Z",
+            childSessionId: "child-session",
+            nickname: "Babbage",
+            toolName: "spawn_agent",
+        });
+    });
+
+    test("keeps unresolved delegation sources explicit", () => {
+        const spawn = normalizeDelegationToolCall({
+            provider: "claude",
+            toolCallId: "tool_call:⟨task-call⟩",
+            parentSessionId: "session:⟨parent-session⟩",
+            ts: "2026-05-09T10:00:00.000Z",
+            toolName: "Task",
+            outputExcerpt: "not json",
+        });
+
+        expect(spawn).toMatchObject({
+            provider: "claude",
+            childSessionId: null,
+            nickname: null,
+            toolName: "Task",
+        });
+    });
+
+    test("marks provider availability from observed raw signals", () => {
+        expect(providerDelegationSignalAvailability.claude).toMatchObject({
+            status: "available",
+            sharedRecords: ["spawned"],
+        });
+        expect(providerDelegationSignalAvailability.codex).toMatchObject({
+            status: "available",
+            rawSignals: ["spawn_agent tool output"],
+        });
+
+        for (const provider of ["pi", "opencode", "cursor"] as const) {
+            expect(providerDelegationSignalAvailability[provider].status).toBe("unavailable");
+            expect(providerDelegationSignalAvailability[provider].rawSignals).toEqual([]);
+        }
+    });
+});

--- a/src/ingest/delegation.ts
+++ b/src/ingest/delegation.ts
@@ -1,0 +1,94 @@
+import { decodeJsonOrNull } from "../lib/decode.ts";
+import type { AgentProviderName } from "./provider-events.ts";
+
+export type ProviderDelegationSignalStatus = "available" | "unavailable";
+
+export type ProviderDelegationSignalAvailability = {
+    readonly provider: AgentProviderName;
+    readonly status: ProviderDelegationSignalStatus;
+    readonly rawSignals: readonly string[];
+    readonly sharedRecords: readonly "spawned"[];
+    readonly evidence: string;
+};
+
+export type DelegationToolCallInput = {
+    readonly provider: AgentProviderName;
+    readonly toolCallId: string;
+    readonly parentSessionId: string;
+    readonly ts: string;
+    readonly toolName: string;
+    readonly outputExcerpt: string | null;
+};
+
+export type NormalizedDelegationSpawn = {
+    readonly provider: AgentProviderName;
+    readonly toolCallId: string;
+    readonly parentSessionId: string;
+    readonly ts: string;
+    readonly childSessionId: string | null;
+    readonly nickname: string | null;
+    readonly toolName: string;
+};
+
+export const providerDelegationSignalAvailability: Readonly<Record<AgentProviderName, ProviderDelegationSignalAvailability>> = {
+    claude: {
+        provider: "claude",
+        status: "available",
+        rawSignals: ["subagents/agent-*.jsonl manifest"],
+        sharedRecords: ["spawned"],
+        evidence: "Claude subagent transcript manifests include parent session id and agent id; derive-claude-subagents writes spawned edges.",
+    },
+    codex: {
+        provider: "codex",
+        status: "available",
+        rawSignals: ["spawn_agent tool output"],
+        sharedRecords: ["spawned"],
+        evidence: "Codex spawn_agent output includes agent_id and nickname; derive-spawned writes spawned edges after the child session exists.",
+    },
+    pi: {
+        provider: "pi",
+        status: "unavailable",
+        rawSignals: [],
+        sharedRecords: ["spawned"],
+        evidence: "Current Pi JSONL fixtures expose generic toolCall blocks but no child-session id or delegation relation payload.",
+    },
+    opencode: {
+        provider: "opencode",
+        status: "unavailable",
+        rawSignals: [],
+        sharedRecords: ["spawned"],
+        evidence: "Current OpenCode SQLite fixtures expose messages/parts only; no child-session id or delegation relation payload is ingested.",
+    },
+    cursor: {
+        provider: "cursor",
+        status: "unavailable",
+        rawSignals: [],
+        sharedRecords: ["spawned"],
+        evidence: "Current Cursor state.vscdb fixtures expose composer messages/bubbles only; no child-session id or delegation relation payload is present.",
+    },
+};
+
+const isRecord = (input: unknown): input is Record<string, unknown> =>
+    typeof input === "object" && input !== null && !Array.isArray(input);
+
+const stringField = (input: Record<string, unknown>, field: string): string | null => {
+    const value = input[field];
+    return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+export function normalizeDelegationToolCall(
+    input: DelegationToolCallInput,
+): NormalizedDelegationSpawn {
+    const parsed = input.outputExcerpt ? decodeJsonOrNull(input.outputExcerpt) : null;
+    const payload = isRecord(parsed) ? parsed : null;
+
+    return {
+        provider: input.provider,
+        toolCallId: input.toolCallId,
+        parentSessionId: input.parentSessionId,
+        ts: input.ts,
+        childSessionId: payload ? stringField(payload, "agent_id") : null,
+        nickname: payload ? stringField(payload, "nickname") : null,
+        toolName: input.toolName,
+    };
+}

--- a/src/ingest/derive-spawned.ts
+++ b/src/ingest/derive-spawned.ts
@@ -4,16 +4,10 @@ import type { DbError } from "../lib/errors.ts";
 import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
 import { surrealLiteral } from "../lib/json.ts";
-import { decodeJsonOrNull } from "../lib/decode.ts";
+import { normalizeDelegationToolCall, type NormalizedDelegationSpawn } from "./delegation.ts";
+import type { AgentProviderName } from "./provider-events.ts";
 
-interface SpawnSource {
-    readonly tool_call_id: string;
-    readonly parent_session_id: string;
-    readonly ts: string;
-    readonly child_id: string | null;
-    readonly nickname: string | null;
-    readonly tool_name: string;
-}
+type SpawnSource = NormalizedDelegationSpawn;
 
 const SPAWN_SOURCES_SQL = `
 SELECT
@@ -25,9 +19,6 @@ SELECT
 FROM tool_call
 WHERE name = "spawn_agent" OR name = "Task"
 ORDER BY ts ASC;`;
-
-const isRecord = (v: unknown): v is Record<string, unknown> =>
-    typeof v === "object" && v !== null && !Array.isArray(v);
 
 const stringField = (row: Record<string, unknown>, key: string): string | null => {
     const v = row[key];
@@ -54,6 +45,9 @@ const recordIdToString = (v: unknown): string | null => {
     return null;
 };
 
+const providerForSpawnTool = (toolName: string): AgentProviderName =>
+    toolName === "Task" ? "claude" : "codex";
+
 /**
  * Pull spawn-like tool calls and extract (parent, child) session pairs.
  * Codex `spawn_agent`: output_excerpt = `{"agent_id":"<uuid>","nickname":"..."}`.
@@ -72,29 +66,14 @@ const collectSources = (
         const ts = dateField(raw, "ts");
         const output = stringField(raw, "output_excerpt");
         if (!id || !session || !name || !ts) continue;
-        const parsed = output ? decodeJsonOrNull(output) : null;
-        if (!isRecord(parsed)) {
-            out.push({
-                tool_call_id: id,
-                parent_session_id: session,
-                ts,
-                child_id: null,
-                nickname: null,
-                tool_name: name,
-            });
-            continue;
-        }
-        // codex spawn_agent: agent_id is the child session id
-        const child = stringField(parsed, "agent_id");
-        const nickname = stringField(parsed, "nickname");
-        out.push({
-            tool_call_id: id,
-            parent_session_id: session,
+        out.push(normalizeDelegationToolCall({
+            provider: providerForSpawnTool(name),
+            toolCallId: id,
+            parentSessionId: session,
             ts,
-            child_id: child,
-            nickname,
-            tool_name: name,
-        });
+            toolName: name,
+            outputExcerpt: output,
+        }));
     }
     return out;
 };
@@ -123,7 +102,7 @@ export const deriveSpawned = (): Effect.Effect<
             SPAWN_SOURCES_SQL,
         );
         const sources = collectSources(rows?.[0] ?? []);
-        const resolved = sources.filter((s) => s.child_id !== null);
+        const resolved = sources.filter((s) => s.childSessionId !== null);
         const unresolved = sources.length - resolved.length;
 
         // Verify each child session record exists. Codex stores subagent
@@ -133,11 +112,11 @@ export const deriveSpawned = (): Effect.Effect<
         let written = 0;
         let missing = 0;
         for (const src of resolved) {
-            if (!src.child_id) continue;
+            if (!src.childSessionId) continue;
             // `parent_session_id` already comes back from SurrealDB as the
             // serialised record id `session:⟨…⟩`. Use it raw, NOT quoted.
-            const parentId = src.parent_session_id;
-            const childId = `session:⟨${src.child_id}⟩`;
+            const parentId = src.parentSessionId;
+            const childId = `session:⟨${src.childSessionId}⟩`;
             // Check existence before RELATE - SurrealDB strict mode rejects
             // edges that point at non-existent records.
             const check = yield* db.query<[Array<Record<string, unknown>>]>(
@@ -148,8 +127,8 @@ export const deriveSpawned = (): Effect.Effect<
                 missing += 1;
                 continue;
             }
-            const callId = src.tool_call_id; // already in tool_call:⟨…⟩ form
-            const toolLit = surrealLiteral(src.tool_name);
+            const callId = src.toolCallId; // already in tool_call:⟨…⟩ form
+            const toolLit = surrealLiteral(src.toolName);
             const nickLit =
                 src.nickname === null ? "NONE" : surrealLiteral(src.nickname);
             // Idempotent: dedupe by (in,out,tool_call) before inserting.

--- a/src/ingest/opencode.ts
+++ b/src/ingest/opencode.ts
@@ -9,7 +9,9 @@ import type { DbError } from "../lib/errors.ts";
 import { executeStatements } from "../lib/shared/statement-exec.ts";
 import { recordRef, surrealDate, surrealString } from "../lib/shared/surql.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
+import { providerDelegationSignalAvailability } from "./delegation.ts";
 import { agentEventRecordKey, buildAgentEventStatements, buildAgentProviderStatements, type AgentEventWrite } from "./provider-events.ts";
+import { providerPlanSignalAvailability } from "./plans.ts";
 import { turnRecordKey } from "./record-keys.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
@@ -556,6 +558,8 @@ const buildOpenCodeBatchStatements = (
                 sqlite: true,
                 transcripts: true,
                 providerGraph: true,
+                planSignals: providerPlanSignalAvailability.opencode,
+                delegationSignals: providerDelegationSignalAvailability.opencode,
             },
         },
     ]),

--- a/src/ingest/pi.ts
+++ b/src/ingest/pi.ts
@@ -24,7 +24,9 @@ import {
     type ToolCallWrite,
 } from "./evidence-writers.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
+import { providerDelegationSignalAvailability } from "./delegation.ts";
 import { agentEventRecordKey, buildAgentEventStatements, buildAgentProviderStatements, type AgentEventWrite } from "./provider-events.ts";
+import { providerPlanSignalAvailability } from "./plans.ts";
 import { invokedRelationRecordKey, toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
@@ -675,6 +677,8 @@ const buildPiBatchStatements = (extract: PiExtract): string[] => [
             capabilities: {
                 transcripts: true,
                 providerGraph: true,
+                planSignals: providerPlanSignalAvailability.pi,
+                delegationSignals: providerDelegationSignalAvailability.pi,
             },
         },
     ]),

--- a/src/ingest/plans.test.ts
+++ b/src/ingest/plans.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
     normalizeClaudeTodoWrite,
     normalizeCodexUpdatePlan,
+    normalizeProviderPlanSnapshot,
+    providerPlanSignalAvailability,
+    toPlanSnapshotWrite,
 } from "./plans.ts";
 
 describe("plan normalization", () => {
@@ -18,6 +21,7 @@ describe("plan normalization", () => {
         });
 
         expect(snapshot.source).toBe("claude_todowrite");
+        expect(snapshot.provider).toBe("claude");
         expect(snapshot.items).toEqual([
             { externalId: null, seq: 1, content: "Inspect schema", activeForm: "Inspecting schema", status: "completed" },
             { externalId: null, seq: 2, content: "Add tests", activeForm: "Adding tests", status: "in_progress" },
@@ -38,6 +42,7 @@ describe("plan normalization", () => {
         });
 
         expect(snapshot.source).toBe("codex_update_plan");
+        expect(snapshot.provider).toBe("codex");
         expect(snapshot.explanation).toBe("Following the plan gate.");
         expect(snapshot.items[1]).toEqual({
             externalId: null,
@@ -78,6 +83,74 @@ describe("plan normalization", () => {
                 status: "in_progress",
             },
         ]);
+    });
+
+    test("provider-neutral detector dispatches Claude and Codex plan tools", () => {
+        expect(
+            normalizeProviderPlanSnapshot({
+                provider: "claude",
+                toolName: "TodoWrite",
+                sessionId: "s1",
+                ts: "2026-05-09T10:00:00.000Z",
+                input: { todos: [{ content: "Use shared contract", status: "in_progress" }] },
+            }),
+        ).toMatchObject({
+            provider: "claude",
+            source: "claude_todowrite",
+            items: [{ content: "Use shared contract", status: "in_progress" }],
+        });
+
+        expect(
+            normalizeProviderPlanSnapshot({
+                provider: "codex",
+                toolName: "update_plan",
+                sessionId: "s1",
+                ts: "2026-05-09T10:00:00.000Z",
+                input: { plan: [{ step: "Use shared contract", status: "completed" }] },
+            }),
+        ).toMatchObject({
+            provider: "codex",
+            source: "codex_update_plan",
+            items: [{ content: "Use shared contract", status: "completed" }],
+        });
+    });
+
+    test("does not invent plan snapshots for unavailable providers", () => {
+        for (const provider of ["pi", "opencode", "cursor"] as const) {
+            expect(providerPlanSignalAvailability[provider].status).toBe("unavailable");
+            expect(providerPlanSignalAvailability[provider].planSources).toEqual([]);
+            expect(
+                normalizeProviderPlanSnapshot({
+                    provider,
+                    toolName: "TodoWrite",
+                    sessionId: "s1",
+                    ts: "2026-05-09T10:00:00.000Z",
+                    input: { todos: [{ content: "looks plan-like", status: "completed" }] },
+                }),
+            ).toBeNull();
+        }
+    });
+
+    test("builds provider-scoped plan snapshot writes from normalized plans", () => {
+        const normalized = normalizeCodexUpdatePlan({
+            sessionId: "codex-plan-session",
+            ts: "2026-05-09T10:00:00.000Z",
+            input: {
+                plan: [{ step: "Write once", status: "in_progress" }],
+            },
+        });
+
+        const write = toPlanSnapshotWrite({
+            snapshot: normalized,
+            snapshotSeq: 1,
+            createdAt: normalized.ts,
+            toolCallKey: "codex-plan-session__tool__call_plan",
+        });
+
+        expect(write.planKey).toMatch(/^codex__codex_plan_session__codex_update_plan__/);
+        expect(write.snapshotKey).toContain("__snapshot_000001__");
+        expect(write.items[0]?.key).toMatch(/__item_001$/);
+        expect(write.status).toBe("in_progress");
     });
 
     test("handles malformed unknown payloads without throwing", () => {

--- a/src/ingest/plans.ts
+++ b/src/ingest/plans.ts
@@ -1,9 +1,28 @@
 import { decodeJsonOrNull } from "../lib/decode.ts";
 import { nonEmptyString } from "../lib/shared/derive-keys.ts";
+import type { PlanSnapshotWrite } from "./evidence-writers.ts";
+import type { AgentProviderName } from "./provider-events.ts";
 
 export type PlanStatus = "pending" | "in_progress" | "completed" | "abandoned";
 
 export type PlanSource = "claude_todowrite" | "claude_task" | "codex_update_plan";
+
+export type ProviderPlanSignalStatus = "available" | "unavailable";
+
+export type ProviderPlanSignalAvailability = {
+    readonly provider: AgentProviderName;
+    readonly status: ProviderPlanSignalStatus;
+    readonly planSources: readonly PlanSource[];
+    readonly toolNames: readonly string[];
+    readonly evidence: string;
+};
+
+export type ProviderPlanDetector = {
+    readonly provider: AgentProviderName;
+    readonly source: PlanSource;
+    readonly toolName: string;
+    readonly normalize: (input: NormalizeProviderPlanInput) => NormalizedPlanSnapshot;
+};
 
 export type NormalizedPlanItem = {
     readonly externalId: string | null;
@@ -14,6 +33,7 @@ export type NormalizedPlanItem = {
 };
 
 export type NormalizedPlanSnapshot = {
+    readonly provider: AgentProviderName;
     readonly sessionId: string;
     readonly source: PlanSource;
     readonly ts: string;
@@ -53,6 +73,33 @@ type NormalizeCodexUpdatePlanInput = {
     readonly input: unknown;
 };
 
+export type NormalizeProviderPlanInput = {
+    readonly provider: AgentProviderName;
+    readonly toolName: string;
+    readonly sessionId: string;
+    readonly ts: string;
+    readonly input: unknown;
+};
+
+export type PlanSnapshotWriteInput = {
+    readonly snapshot: NormalizedPlanSnapshot;
+    readonly snapshotSeq: number;
+    readonly createdAt: string;
+    readonly toolCallKey: string;
+};
+
+function stableHash(input: string): string {
+    return Bun.hash(input).toString(16).padStart(16, "0");
+}
+
+function recordKeyPart(input: string, fallback = "_"): string {
+    const sanitized = input
+        .replace(/[^a-zA-Z0-9]/g, "_")
+        .replace(/_+/g, "_")
+        .replace(/^_+|_+$/g, "");
+    return sanitized.length > 0 ? sanitized : fallback;
+}
+
 function normalizeStatus(status: string | null | undefined): PlanStatus {
     if (status === "in_progress" || status === "completed" || status === "abandoned") {
         return status;
@@ -77,7 +124,7 @@ function asRecordArray(input: unknown): Record<string, unknown>[] {
     return input.filter(isRecord);
 }
 
-export function normalizeClaudeTodoWrite({
+function normalizeClaudeTodoWritePayload({
     sessionId,
     ts,
     input,
@@ -101,6 +148,7 @@ export function normalizeClaudeTodoWrite({
     }
 
     return {
+        provider: "claude",
         sessionId,
         source: "claude_todowrite",
         ts,
@@ -109,7 +157,7 @@ export function normalizeClaudeTodoWrite({
     };
 }
 
-export function normalizeCodexUpdatePlan({
+function normalizeCodexUpdatePlanPayload({
     sessionId,
     ts,
     input,
@@ -131,10 +179,192 @@ export function normalizeCodexUpdatePlan({
     }
 
     return {
+        provider: "codex",
         sessionId,
         source: "codex_update_plan",
         ts,
         explanation: nonEmptyString(typeof raw.explanation === "string" ? raw.explanation : null),
+        items,
+    };
+}
+
+export const providerPlanDetectors: readonly ProviderPlanDetector[] = [
+    {
+        provider: "claude",
+        source: "claude_todowrite",
+        toolName: "TodoWrite",
+        normalize: ({ sessionId, ts, input }) =>
+            normalizeClaudeTodoWritePayload({ sessionId, ts, input }),
+    },
+    {
+        provider: "codex",
+        source: "codex_update_plan",
+        toolName: "update_plan",
+        normalize: ({ sessionId, ts, input }) =>
+            normalizeCodexUpdatePlanPayload({ sessionId, ts, input }),
+    },
+];
+
+export const providerPlanSignalAvailability: Readonly<Record<AgentProviderName, ProviderPlanSignalAvailability>> = {
+    claude: {
+        provider: "claude",
+        status: "available",
+        planSources: ["claude_todowrite"],
+        toolNames: ["TodoWrite"],
+        evidence: "Claude transcript tool_use blocks expose TodoWrite todos.",
+    },
+    codex: {
+        provider: "codex",
+        status: "available",
+        planSources: ["codex_update_plan"],
+        toolNames: ["update_plan"],
+        evidence: "Codex session JSONL exposes update_plan function call arguments.",
+    },
+    pi: {
+        provider: "pi",
+        status: "unavailable",
+        planSources: [],
+        toolNames: [],
+        evidence: "Current Pi JSONL fixtures expose message, custom, and generic toolCall blocks; no raw plan snapshot payload equivalent is present.",
+    },
+    opencode: {
+        provider: "opencode",
+        status: "unavailable",
+        planSources: [],
+        toolNames: [],
+        evidence: "Current OpenCode SQLite fixtures expose sessions/messages/parts only; no tool-call or plan snapshot rows are ingested yet.",
+    },
+    cursor: {
+        provider: "cursor",
+        status: "unavailable",
+        planSources: [],
+        toolNames: [],
+        evidence: "Current Cursor state.vscdb fixtures expose composer messages/bubbles only; no raw plan snapshot payload equivalent is present.",
+    },
+};
+
+export function normalizeProviderPlanSnapshot(
+    input: NormalizeProviderPlanInput,
+): NormalizedPlanSnapshot | null {
+    const detector = providerPlanDetectors.find((candidate) =>
+        candidate.provider === input.provider && candidate.toolName === input.toolName
+    );
+    return detector?.normalize(input) ?? null;
+}
+
+export function normalizeClaudeTodoWrite(
+    input: NormalizeClaudeTodoWriteInput,
+): NormalizedPlanSnapshot {
+    const normalized = normalizeProviderPlanSnapshot({
+        provider: "claude",
+        toolName: "TodoWrite",
+        ...input,
+    });
+    if (normalized === null) {
+        throw new Error("missing Claude TodoWrite plan detector");
+    }
+    return normalized;
+}
+
+export function normalizeCodexUpdatePlan(
+    input: NormalizeCodexUpdatePlanInput,
+): NormalizedPlanSnapshot {
+    const normalized = normalizeProviderPlanSnapshot({
+        provider: "codex",
+        toolName: "update_plan",
+        ...input,
+    });
+    if (normalized === null) {
+        throw new Error("missing Codex update_plan detector");
+    }
+    return normalized;
+}
+
+export function planKey(sessionId: string, provider: AgentProviderName, source: string): string {
+    return [
+        provider,
+        recordKeyPart(sessionId, "session").slice(0, 80),
+        recordKeyPart(source, "source"),
+        stableHash(`${sessionId}:${source}`).slice(0, 16),
+    ].join("__");
+}
+
+export function planSnapshotKey(input: {
+    readonly provider: AgentProviderName;
+    readonly sessionId: string;
+    readonly source: string;
+    readonly snapshotSeq: number;
+    readonly toolCallKey: string;
+}): string {
+    return [
+        planKey(input.sessionId, input.provider, input.source),
+        `snapshot_${input.snapshotSeq.toString(10).padStart(6, "0")}`,
+        stableHash(input.toolCallKey).slice(0, 12),
+    ].join("__");
+}
+
+export function planItemKey(input: {
+    readonly provider: AgentProviderName;
+    readonly sessionId: string;
+    readonly source: string;
+    readonly seq: number;
+}): string {
+    return [
+        planKey(input.sessionId, input.provider, input.source),
+        `item_${input.seq.toString(10).padStart(3, "0")}`,
+    ].join("__");
+}
+
+export function planStatus(items: readonly { status: PlanStatus }[]): PlanStatus {
+    if (items.some((item) => item.status === "in_progress")) return "in_progress";
+    if (items.length > 0 && items.every((item) => item.status === "completed")) {
+        return "completed";
+    }
+    if (items.some((item) => item.status === "pending")) return "pending";
+    if (items.length > 0 && items.every((item) => item.status === "abandoned")) {
+        return "abandoned";
+    }
+    return "pending";
+}
+
+export function toPlanSnapshotWrite({
+    snapshot,
+    snapshotSeq,
+    createdAt,
+    toolCallKey,
+}: PlanSnapshotWriteInput): PlanSnapshotWrite {
+    const items = snapshot.items.map((item) => ({
+        key: planItemKey({
+            provider: snapshot.provider,
+            sessionId: snapshot.sessionId,
+            source: snapshot.source,
+            seq: item.seq,
+        }),
+        externalId: item.externalId,
+        seq: item.seq,
+        content: item.content,
+        activeForm: item.activeForm,
+        status: item.status,
+    }));
+
+    return {
+        planKey: planKey(snapshot.sessionId, snapshot.provider, snapshot.source),
+        sessionId: snapshot.sessionId,
+        source: snapshot.source,
+        status: planStatus(snapshot.items),
+        createdAt,
+        updatedAt: snapshot.ts,
+        snapshotKey: planSnapshotKey({
+            provider: snapshot.provider,
+            sessionId: snapshot.sessionId,
+            source: snapshot.source,
+            snapshotSeq,
+            toolCallKey,
+        }),
+        toolCallKey,
+        itemsJson: snapshot.items,
+        explanation: snapshot.explanation,
+        ts: snapshot.ts,
         items,
     };
 }

--- a/src/ingest/transcripts.ts
+++ b/src/ingest/transcripts.ts
@@ -30,7 +30,12 @@ import {
     toolKindForName,
 } from "./tool-calls.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
-import { normalizeClaudeTodoWrite, type PlanStatus } from "./plans.ts";
+import { providerDelegationSignalAvailability } from "./delegation.ts";
+import {
+    normalizeProviderPlanSnapshot,
+    providerPlanSignalAvailability,
+    toPlanSnapshotWrite,
+} from "./plans.ts";
 import {
     editedRelationRecordKey,
     fileRecordKey,
@@ -208,59 +213,6 @@ function stringField(input: Record<string, unknown>, field: string): string | nu
 
 function stableHash(input: string): string {
     return Bun.hash(input).toString(16).padStart(16, "0");
-}
-
-function recordKeyPart(input: string, fallback = "_"): string {
-    const sanitized = input
-        .replace(/[^a-zA-Z0-9]/g, "_")
-        .replace(/_+/g, "_")
-        .replace(/^_+|_+$/g, "");
-    return sanitized.length > 0 ? sanitized : fallback;
-}
-
-function planKey(sessionId: string, source: string): string {
-    return [
-        "claude",
-        recordKeyPart(sessionId, "session").slice(0, 80),
-        recordKeyPart(source, "source"),
-        stableHash(`${sessionId}:${source}`).slice(0, 16),
-    ].join("__");
-}
-
-function planSnapshotKey(input: {
-    sessionId: string;
-    source: string;
-    snapshotSeq: number;
-    toolCallKey: string;
-}): string {
-    return [
-        planKey(input.sessionId, input.source),
-        `snapshot_${input.snapshotSeq.toString(10).padStart(6, "0")}`,
-        stableHash(input.toolCallKey).slice(0, 12),
-    ].join("__");
-}
-
-function planItemKey(input: {
-    sessionId: string;
-    source: string;
-    seq: number;
-}): string {
-    return [
-        planKey(input.sessionId, input.source),
-        `item_${input.seq.toString(10).padStart(3, "0")}`,
-    ].join("__");
-}
-
-function planStatus(items: readonly { status: PlanStatus }[]): PlanStatus {
-    if (items.some((item) => item.status === "in_progress")) return "in_progress";
-    if (items.length > 0 && items.every((item) => item.status === "completed")) {
-        return "completed";
-    }
-    if (items.some((item) => item.status === "pending")) return "pending";
-    if (items.length > 0 && items.every((item) => item.status === "abandoned")) {
-        return "abandoned";
-    }
-    return "pending";
 }
 
 function boundedExcerpt(input: string): string {
@@ -556,48 +508,24 @@ function createClaudeExtractor(projectDir: string, sessionId: string) {
         }
 
         if (name === "TodoWrite" && input) {
-            const normalized = normalizeClaudeTodoWrite({
+            const normalized = normalizeProviderPlanSnapshot({
+                provider: "claude",
+                toolName: name,
                 sessionId,
                 ts,
                 input,
             });
-            if (normalized.items.length > 0) {
+            if (normalized && normalized.items.length > 0) {
                 const source = normalized.source;
                 const snapshotSeq = nextPlanSnapshotSeq(source);
                 const createdAt = rememberPlanCreatedAt(source, ts);
-                const currentPlanKey = planKey(sessionId, source);
-                const items = normalized.items.map((item) => ({
-                    key: planItemKey({
-                        sessionId,
-                        source,
-                        seq: item.seq,
-                    }),
-                    externalId: item.externalId,
-                    seq: item.seq,
-                    content: item.content,
-                    activeForm: item.activeForm,
-                    status: item.status,
-                }));
 
-                planSnapshots.push({
-                    planKey: currentPlanKey,
-                    sessionId,
-                    source,
-                    status: planStatus(normalized.items),
+                planSnapshots.push(toPlanSnapshotWrite({
+                    snapshot: normalized,
+                    snapshotSeq,
                     createdAt,
-                    updatedAt: ts,
-                    snapshotKey: planSnapshotKey({
-                        sessionId,
-                        source,
-                        snapshotSeq,
-                        toolCallKey,
-                    }),
                     toolCallKey,
-                    itemsJson: normalized.items,
-                    explanation: normalized.explanation,
-                    ts: normalized.ts,
-                    items,
-                });
+                }));
             }
         }
     };
@@ -1292,6 +1220,8 @@ const buildClaudeProviderStatements = (extracted: FileExtract): string[] => [
             capabilities: {
                 transcripts: true,
                 toolCalls: true,
+                planSignals: providerPlanSignalAvailability.claude,
+                delegationSignals: providerDelegationSignalAvailability.claude,
             },
         },
     ]),


### PR DESCRIPTION
## Summary

- Adds provider-neutral plan detector contracts plus shared plan key/status/write mapping for existing Claude TodoWrite and Codex update_plan snapshots.
- Adds provider-neutral delegation signal availability plus Codex spawn_agent normalization used by the spawned derivation.
- Records explicit plan/delegation availability in provider capabilities; Pi/OpenCode/Cursor are marked unavailable with fixture-backed tests rather than inferred data.

## Validation

- bun test src/ingest/plans.test.ts src/ingest/delegation.test.ts src/ingest/transcripts.test.ts src/ingest/codex.test.ts src/ingest/pi.test.ts src/ingest/opencode.test.ts src/ingest/cursor.test.ts src/ingest/derive-spawned.stage.test.ts src/dashboard/session-show.test.ts src/cli/session-show-format.test.ts
- bun test src/queries/session-detail.ts src/dashboard/session-show.test.ts src/queries/episode-timeline.ts src/dashboard/workflow.ts src/ingest/derive-spawned.stage.test.ts
- bunx tsc --noEmit --skipLibCheck --strict --module preserve --moduleResolution bundler --target ES2022 --allowImportingTsExtensions --types bun src/ingest/plans.ts src/ingest/delegation.ts src/ingest/derive-spawned.ts
- bunx tsc --noEmit --skipLibCheck --strict --module preserve --moduleResolution bundler --target ES2022 --allowImportingTsExtensions --types bun src/ingest/transcripts.ts src/ingest/codex.ts src/ingest/pi.ts src/ingest/opencode.ts src/ingest/cursor.ts src/ingest/plans.test.ts src/ingest/delegation.test.ts

Note: full `bun run typecheck` currently fails on unrelated pre-existing errors in src/cli and src/improve.

Closes #91
