### PR TITLE
[codex] Normalize provider file evidence

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -56,6 +56,8 @@ session    -> produced     -> commit
 commit     -> touched      -> file
 turn       -> edited       -> file
 turn       -> invoked      -> skill
+tool_call  -> read_file    -> file
+tool_call  -> searched_file -> file
 tool_call  -> concerns     -> skill
 insight    -> concerns     -> session
 ```

--- a/docs/graph-db-taxonomy.md
+++ b/docs/graph-db-taxonomy.md
@@ -1,0 +1,30 @@
+# Graph DB Taxonomy
+
+## File Evidence
+
+File evidence uses shared graph relations regardless of transcript provider:
+
+```text
+turn      -> edited        -> file
+tool_call -> read_file     -> file
+tool_call -> searched_file -> file
+turn      -> mentioned_file -> file
+```
+
+`edited`, `read_file`, and `searched_file` all use local-path file identity
+when the transcript only exposes a checkout path. Writers preserve both the
+raw `path_seen` from tool arguments and the cwd-resolved
+`absolute_path_seen`.
+
+## Provider Parity
+
+| Provider | Edit evidence | Read evidence | Search evidence | Notes |
+| --- | --- | --- | --- | --- |
+| Claude | Implemented from `Edit`, `Write`, `MultiEdit`, `NotebookEdit` tool inputs. | Implemented from `Read` tool inputs. | Implemented from `Grep` and `Glob` tool inputs. | Existing Claude edit extraction is now backed by the shared writer path. |
+| Codex | Implemented for `apply_patch` patch headers when present in function-call arguments. | Shared helper supports structured read paths when present. | Shared helper supports structured search paths when present. | Shell command path parsing beyond structured args is intentionally deferred. |
+| Pi | Implemented from structured tool-call path fields. | Implemented from structured `read` tool-call path fields. | Implemented from structured `grep`/`glob` path fields. | Uses the same `tool_call -> file` relation writer as Codex and Claude. |
+| OpenCode | Pending. | Pending. | Pending. | Concrete tool-call extraction is owned by #88 before this provider can emit reliable file evidence. |
+| Cursor | Pending. | Pending. | Pending. | Concrete tool-call extraction is owned by #89 before this provider can emit reliable file evidence. |
+
+The read side should query these relation tables directly. It should not branch
+on provider names to answer "what did this session edit/read/search?".

--- a/schema/schema.surql
+++ b/schema/schema.surql
@@ -968,6 +968,7 @@ DEFINE INDEX IF NOT EXISTS mentioned_error_out ON mentioned_error FIELDS out;
 DEFINE TABLE read_file TYPE RELATION FROM tool_call TO file;
 DEFINE FIELD evidence    ON read_file TYPE option<string>;      -- 'tool_name' | 'command_norm'
 DEFINE FIELD path_seen   ON read_file TYPE option<string>;
+DEFINE FIELD absolute_path_seen ON read_file TYPE option<string>;
 DEFINE FIELD excerpt     ON read_file TYPE option<string>;
 DEFINE FIELD ts          ON read_file TYPE datetime DEFAULT time::now();
 DEFINE INDEX IF NOT EXISTS read_file_in ON read_file FIELDS in;
@@ -976,6 +977,7 @@ DEFINE INDEX IF NOT EXISTS read_file_out ON read_file FIELDS out;
 DEFINE TABLE searched_file TYPE RELATION FROM tool_call TO file;
 DEFINE FIELD evidence    ON searched_file TYPE option<string>;  -- 'tool_name' | 'command_norm' | 'output_match'
 DEFINE FIELD path_seen   ON searched_file TYPE option<string>;
+DEFINE FIELD absolute_path_seen ON searched_file TYPE option<string>;
 DEFINE FIELD excerpt     ON searched_file TYPE option<string>;
 DEFINE FIELD ts          ON searched_file TYPE datetime DEFAULT time::now();
 DEFINE INDEX IF NOT EXISTS searched_file_in ON searched_file FIELDS in;

--- a/schema/schema.test.ts
+++ b/schema/schema.test.ts
@@ -72,3 +72,12 @@ describe("skill roles schema (P3.1)", () => {
         expect(schema).toContain("DEFINE FIELD is_first     ON invoked TYPE option<bool>");
     });
 });
+
+describe("file evidence schema", () => {
+    test("tool-call file evidence relations store normalized absolute paths", () => {
+        expect(schema).toContain("DEFINE TABLE read_file TYPE RELATION FROM tool_call TO file");
+        expect(schema).toContain("DEFINE TABLE searched_file TYPE RELATION FROM tool_call TO file");
+        expect(schema).toContain("DEFINE FIELD absolute_path_seen ON read_file TYPE option<string>");
+        expect(schema).toContain("DEFINE FIELD absolute_path_seen ON searched_file TYPE option<string>");
+    });
+});

--- a/src/ingest/codex.test.ts
+++ b/src/ingest/codex.test.ts
@@ -774,4 +774,46 @@ describe("Codex transcript extraction", () => {
             extracted.planSnapshots[1]?.items[0]?.key,
         );
     });
+
+    test("writes shared edited file evidence for apply_patch tool calls", () => {
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({
+                type: "session_meta",
+                timestamp: "2026-05-29T06:00:00.000Z",
+                payload: {
+                    id: "codex-file-evidence",
+                    cwd: "/Users/necmttn/Projects/ax",
+                    timestamp: "2026-05-29T06:00:00.000Z",
+                },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-05-29T06:00:01.000Z",
+                payload: {
+                    type: "function_call",
+                    name: "apply_patch",
+                    call_id: "call_patch",
+                    arguments: JSON.stringify({
+                        patch: [
+                            "*** Begin Patch",
+                            "*** Update File: src/ingest/codex.ts",
+                            "@@",
+                            "-old",
+                            "+new",
+                            "*** End Patch",
+                        ].join("\n"),
+                    }),
+                },
+            }),
+        ]);
+
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+
+        const sql = __testBuildCodexBatchStatements(extracted, 1200).join("\n");
+        expect(sql).toContain("->edited:`");
+        expect(sql).toContain("tool = \"apply_patch\"");
+        expect(sql).toContain("path_seen = \"src/ingest/codex.ts\"");
+        expect(sql).toContain("absolute_path_seen = \"/Users/necmttn/Projects/ax/src/ingest/codex.ts\"");
+    });
 });

--- a/src/ingest/codex.ts
+++ b/src/ingest/codex.ts
@@ -13,6 +13,7 @@ import type { StageDef } from "./stage/registry.ts";
 import {
     buildPlanSnapshotStatements,
     buildRelateToolCallSkillStatements,
+    buildToolFileEvidenceStatements,
     buildToolCallStatements,
     type PlanSnapshotWrite,
     type ToolCallSkillRelationWrite,
@@ -35,6 +36,7 @@ import {
 import { classifyTurnIntent } from "./intent-kind.ts";
 import { normalizeCodexUpdatePlan, type PlanStatus } from "./plans.ts";
 import { invokedRelationRecordKey, toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
+import { extractToolFileEvidence } from "./tool-file-evidence.ts";
 import { executeStatements } from "../lib/shared/statement-exec.ts";
 
 const DEFAULT_CODEX_RAW_MAX_BYTES = 5 * 1024 * 1024;
@@ -976,6 +978,7 @@ const buildCodexBatchStatements = (
     ...buildToolCallStatements(batch.toolCalls.map((call) =>
         compactCodexToolCall(call, payloadMaxBytes),
     )),
+    ...buildToolFileEvidenceStatements(extractToolFileEvidence(batch.toolCalls)),
     ...batch.parentEdges.map((edge) =>
         buildAgentEventParentEdgeStatement(edge),
     ),

--- a/src/ingest/derive-claude-subagents.ts
+++ b/src/ingest/derive-claude-subagents.ts
@@ -12,9 +12,9 @@ import {
     extractFileWithSessionId,
     upsertTurnsForSubagents,
     writeToolCallStatementsForSubagents,
+    writeToolFileEvidenceForSubagents,
     relateInvocationsForSubagents,
     relateToolCallSkillsForSubagents,
-    upsertEditsForSubagents,
     writePlanSnapshotsForSubagents,
 } from "./transcripts.ts";
 import { resolveSkillName } from "../lib/skill-id.ts";
@@ -270,6 +270,7 @@ export const deriveClaudeSubagents = (
 
                 yield* upsertTurnsForSubagents(extracted.turns);
                 yield* writeToolCallStatementsForSubagents(extracted.toolCalls);
+                yield* writeToolFileEvidenceForSubagents(extracted.toolCalls);
                 const resolvedInvocations = extracted.invocations.map((inv) => ({
                     ...inv,
                     skill: resolveSkillName(inv.skill, skillCatalog) ?? inv.skill,
@@ -281,7 +282,6 @@ export const deriveClaudeSubagents = (
                 }));
                 yield* relateToolCallSkillsForSubagents(resolvedSkillRelations);
                 yield* writePlanSnapshotsForSubagents(extracted.planSnapshots);
-                yield* upsertEditsForSubagents(extracted.edits);
 
                 turnsTotal += extracted.turns.length;
                 invocationsTotal += extracted.invocations.length;

--- a/src/ingest/evidence-writers.test.ts
+++ b/src/ingest/evidence-writers.test.ts
@@ -6,6 +6,7 @@ import {
     buildPlanSnapshotStatements,
     buildRelateToolCallSkillStatements,
     buildSkillPlaceholderStatements,
+    buildToolFileEvidenceStatements,
     buildToolCallStatements,
     recordRef,
     relateToolCallSkill,
@@ -150,6 +151,59 @@ describe("evidence writer statement builders", () => {
         expect(sql).not.toContain("UPSERT skill:");
         expect(sql).not.toContain("scope: \"unknown\"");
         expect(sql).not.toContain("->invoked->");
+    });
+
+    test("tool file evidence statements share local file identity across edit read and search edges", () => {
+        const statements = buildToolFileEvidenceStatements([
+            {
+                kind: "edited",
+                sessionId: "session-1",
+                turnKey: "turn-key",
+                toolCallKey: "tool-call-edit",
+                toolName: "apply_patch",
+                ts: "2026-05-29T06:00:00.000Z",
+                path: "/repo/src/a.ts",
+                pathSeen: "src/a.ts",
+                evidence: "tool_name:apply_patch",
+            },
+            {
+                kind: "read_file",
+                sessionId: "session-1",
+                turnKey: "turn-key",
+                toolCallKey: "tool-call-read",
+                toolName: "Read",
+                ts: "2026-05-29T06:00:01.000Z",
+                path: "/repo/src/a.ts",
+                pathSeen: "src/a.ts",
+                evidence: "tool_name:Read",
+                excerpt: "export const a = 1;",
+            },
+            {
+                kind: "searched_file",
+                sessionId: "session-1",
+                turnKey: "turn-key",
+                toolCallKey: "tool-call-grep",
+                toolName: "Grep",
+                ts: "2026-05-29T06:00:02.000Z",
+                path: "/repo/src",
+                pathSeen: "src",
+                evidence: "tool_name:Grep",
+            },
+        ]);
+
+        const sql = statements.join("\n");
+
+        expect(sql.match(/UPSERT file:`/g)).toHaveLength(2);
+        expect(sql).toContain('identity_scope: "local_path"');
+        expect(sql).toContain("->edited:`");
+        expect(sql).toContain("tool = \"apply_patch\"");
+        expect(sql).toContain("path_seen = \"src/a.ts\"");
+        expect(sql).toContain("absolute_path_seen = \"/repo/src/a.ts\"");
+        expect(sql).toContain("->read_file:`");
+        expect(sql).toContain("evidence = \"tool_name:Read\"");
+        expect(sql).toContain("excerpt = \"export const a = 1;\"");
+        expect(sql).toContain("->searched_file:`");
+        expect(sql).toContain("evidence = \"tool_name:Grep\"");
     });
 
     test("placeholder skill statements are separate from relation statements", () => {

--- a/src/ingest/evidence-writers.ts
+++ b/src/ingest/evidence-writers.ts
@@ -3,7 +3,13 @@ import { SurrealClient, type SurrealClientShape } from "../lib/db.ts";
 import type { DbError } from "../lib/errors.ts";
 import { skillRecordKey } from "../lib/skill-id.ts";
 import { executeStatements, executeStatementsWith } from "../lib/shared/statement-exec.ts";
-import { toolCallRecordKey, toolRecordKey } from "./record-keys.ts";
+import {
+    editedRelationRecordKey,
+    fileRecordKey,
+    toolCallRecordKey,
+    toolFileRelationRecordKey,
+    toolRecordKey,
+} from "./record-keys.ts";
 import {
     surrealString,
     surrealDate,
@@ -18,6 +24,7 @@ import {
     recordRef,
 } from "../lib/shared/surql.ts";
 import { nonEmptyString } from "../lib/shared/derive-keys.ts";
+import type { ToolFileEvidence } from "./tool-file-evidence.ts";
 
 export { recordRef } from "../lib/shared/surql.ts";
 
@@ -80,6 +87,8 @@ export interface PlanSnapshotWrite {
     readonly ts: TimestampInput;
     readonly items: readonly PlanSnapshotItemWrite[];
 }
+
+export type ToolFileEvidenceWrite = ToolFileEvidence;
 
 const toolIdentity = (provider: string, kind: string, name: string): string =>
     `${provider}:${kind}:${name}`;
@@ -198,6 +207,67 @@ export function buildRelateToolCallSkillStatements(
             ["reason", surrealOptionString(input.reason)],
         ])};`,
     ];
+}
+
+export function toolEvidenceFileRecordKey(path: string): string {
+    return fileRecordKey("_", path);
+}
+
+export function buildToolFileEvidenceStatements(
+    evidence: readonly ToolFileEvidenceWrite[],
+): string[] {
+    const statements: string[] = [];
+    const seenFiles = new Set<string>();
+
+    for (const item of evidence) {
+        const fileKey = toolEvidenceFileRecordKey(item.path);
+        if (!seenFiles.has(fileKey)) {
+            seenFiles.add(fileKey);
+            statements.push(
+                `UPSERT ${recordRef("file", fileKey)} CONTENT ${surrealObject([
+                    ["repo", "NONE"],
+                    ["path", surrealString(item.path)],
+                    ["identity_scope", surrealString("local_path")],
+                ])};`,
+            );
+        }
+
+        if (item.kind === "edited") {
+            if (!item.turnKey) continue;
+            const edgeKey = editedRelationRecordKey({
+                turnKey: item.turnKey,
+                fileKey,
+                tool: item.toolName,
+            });
+            statements.push(
+                `RELATE ${recordRef("turn", item.turnKey)}->edited:\`${edgeKey}\`->${recordRef("file", fileKey)} SET ${surrealSet([
+                    ["tool", surrealString(item.toolName)],
+                    ["ts", surrealDate(item.ts)],
+                    ["path_seen", surrealOptionString(item.pathSeen)],
+                    ["absolute_path_seen", surrealOptionString(item.path)],
+                    ["edit_kind", surrealOptionString(item.editKind)],
+                ])};`,
+            );
+            continue;
+        }
+
+        const edgeKey = toolFileRelationRecordKey({
+            toolCallKey: item.toolCallKey,
+            fileKey,
+            kind: item.kind,
+        });
+        statements.push(
+            `RELATE ${recordRef("tool_call", item.toolCallKey)}->${item.kind}:\`${edgeKey}\`->${recordRef("file", fileKey)} SET ${surrealSet([
+                ["evidence", surrealOptionString(item.evidence)],
+                ["path_seen", surrealOptionString(item.pathSeen)],
+                ["absolute_path_seen", surrealOptionString(item.path)],
+                ["excerpt", surrealOptionString(item.excerpt)],
+                ["ts", surrealDate(item.ts)],
+            ])};`,
+        );
+    }
+
+    return statements;
 }
 
 export function buildSkillPlaceholderStatements(skillName: string): string[] {

--- a/src/ingest/pi.test.ts
+++ b/src/ingest/pi.test.ts
@@ -522,6 +522,54 @@ describe("Pi JSONL extraction", () => {
         expect(firstEvents.map((event) => event.seq).sort((a, b) => a - b)).toEqual([1, 2, 1000001001]);
     });
 
+    test("writes shared read and search file evidence for Pi tool calls", () => {
+        const extracted = __testExtractPiJsonlLines([
+            JSON.stringify({
+                type: "session",
+                version: 3,
+                id: "pi-file-evidence",
+                timestamp: "2026-05-29T06:00:00.000Z",
+                cwd: "/Users/necmttn/Projects/ax",
+            }),
+            JSON.stringify({
+                type: "message",
+                id: "assistant-file-evidence",
+                parentId: null,
+                timestamp: "2026-05-29T06:00:01.000Z",
+                message: {
+                    role: "assistant",
+                    content: [
+                        {
+                            type: "toolCall",
+                            id: "call-read",
+                            name: "read",
+                            input: { path: "src/ingest/pi.ts" },
+                        },
+                        {
+                            type: "toolCall",
+                            id: "call-grep",
+                            name: "grep",
+                            input: { pattern: "needle", path: "src/ingest" },
+                        },
+                    ],
+                },
+            }),
+        ]);
+
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+
+        const sql = __testBuildPiBatchStatements(extracted).join("\n");
+        expect(sql).toContain("->read_file:`");
+        expect(sql).toContain("path_seen = \"src/ingest/pi.ts\"");
+        expect(sql).toContain("absolute_path_seen = \"/Users/necmttn/Projects/ax/src/ingest/pi.ts\"");
+        expect(sql).toContain("evidence = \"tool_name:read\"");
+        expect(sql).toContain("->searched_file:`");
+        expect(sql).toContain("path_seen = \"src/ingest\"");
+        expect(sql).toContain("absolute_path_seen = \"/Users/necmttn/Projects/ax/src/ingest\"");
+        expect(sql).toContain("evidence = \"tool_name:grep\"");
+    });
+
     test("turn statements escape session ids and timestamps through shared Surreal helpers", () => {
         const extracted = __testExtractPiJsonlLines([
             JSON.stringify({

--- a/src/ingest/pi.ts
+++ b/src/ingest/pi.ts
@@ -19,6 +19,7 @@ import {
 import { skillRecordKey } from "../lib/skill-id.ts";
 import {
     buildRelateToolCallSkillStatements,
+    buildToolFileEvidenceStatements,
     buildToolCallStatements,
     type ToolCallSkillRelationWrite,
     type ToolCallWrite,
@@ -29,6 +30,7 @@ import { invokedRelationRecordKey, toolCallRecordKey, turnRecordKey } from "./re
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
 import { extractCommandTool, normalizeCommand, toolKindForName } from "./tool-calls.ts";
+import { extractToolFileEvidence } from "./tool-file-evidence.ts";
 
 export const PiKey = Schema.Literal("pi");
 export type PiKey = typeof PiKey.Type;
@@ -710,6 +712,7 @@ const buildPiBatchStatements = (extract: PiExtract): string[] => [
     }),
     ...buildTurnStatements(extract.turns),
     ...buildToolCallStatements(extract.toolCalls),
+    ...buildToolFileEvidenceStatements(extractToolFileEvidence(extract.toolCalls)),
     ...buildSyntheticSkillAndInvocationStatements(extract.invocations),
     ...extract.skillRelations.flatMap((relation) =>
         buildRelateToolCallSkillStatements(relation),

--- a/src/ingest/tool-file-evidence.test.ts
+++ b/src/ingest/tool-file-evidence.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { classifyToolFileEvidence, evidenceReason } from "./tool-file-evidence.ts";
+import {
+    classifyToolFileEvidence,
+    evidenceReason,
+    extractToolFileEvidence,
+} from "./tool-file-evidence.ts";
+import { toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
 
 describe("tool file evidence classification", () => {
     test("classifies file read tools and shell readers", () => {
@@ -16,5 +21,95 @@ describe("tool file evidence classification", () => {
 
     test("ignores unrelated commands", () => {
         expect(classifyToolFileEvidence({ name: "exec_command", commandNorm: "git status" })).toEqual([]);
+    });
+
+    test("extracts edit/read/search paths from structured tool calls", () => {
+        const readKey = toolCallRecordKey({
+            sessionId: "session-1",
+            seq: 1,
+            callId: "call-read",
+        });
+        const grepKey = toolCallRecordKey({
+            sessionId: "session-1",
+            seq: 2,
+            callId: "call-grep",
+        });
+        const editKey = toolCallRecordKey({
+            sessionId: "session-1",
+            seq: 3,
+            callId: "call-edit",
+        });
+
+        expect(extractToolFileEvidence([
+            {
+                provider: "pi",
+                toolName: "Read",
+                toolKind: "builtin",
+                sessionId: "session-1",
+                seq: 1,
+                turnKey: turnRecordKey("session-1", 1),
+                callId: "call-read",
+                ts: "2026-05-29T06:00:00.000Z",
+                cwd: "/repo",
+                inputJson: { file_path: "src/read.ts" },
+                hasError: false,
+            },
+            {
+                provider: "pi",
+                toolName: "Grep",
+                toolKind: "builtin",
+                sessionId: "session-1",
+                seq: 2,
+                turnKey: turnRecordKey("session-1", 2),
+                callId: "call-grep",
+                ts: "2026-05-29T06:00:01.000Z",
+                cwd: "/repo",
+                inputJson: { pattern: "needle", path: "src" },
+                hasError: false,
+            },
+            {
+                provider: "codex",
+                toolName: "apply_patch",
+                toolKind: "builtin",
+                sessionId: "session-1",
+                seq: 3,
+                turnKey: turnRecordKey("session-1", 3),
+                callId: "call-edit",
+                ts: "2026-05-29T06:00:02.000Z",
+                cwd: "/repo",
+                inputJson: {
+                    patch: "*** Begin Patch\n*** Update File: src/edit.ts\n@@\n-old\n+new\n*** End Patch",
+                },
+                hasError: false,
+            },
+        ]).map((item) => ({
+            kind: item.kind,
+            toolCallKey: item.toolCallKey,
+            path: item.path,
+            pathSeen: item.pathSeen,
+            evidence: item.evidence,
+        }))).toEqual([
+            {
+                kind: "read_file",
+                toolCallKey: readKey,
+                path: "/repo/src/read.ts",
+                pathSeen: "src/read.ts",
+                evidence: "tool_name:Read",
+            },
+            {
+                kind: "searched_file",
+                toolCallKey: grepKey,
+                path: "/repo/src",
+                pathSeen: "src",
+                evidence: "tool_name:Grep",
+            },
+            {
+                kind: "edited",
+                toolCallKey: editKey,
+                path: "/repo/src/edit.ts",
+                pathSeen: "src/edit.ts",
+                evidence: "tool_name:apply_patch",
+            },
+        ]);
     });
 });

--- a/src/ingest/tool-file-evidence.ts
+++ b/src/ingest/tool-file-evidence.ts
@@ -1,13 +1,34 @@
+import { isAbsolute, resolve } from "node:path";
+import type { ToolCallWrite } from "./evidence-writers.ts";
+import { toolCallRecordKey } from "./record-keys.ts";
+
 export type ToolFileEvidenceKind = "read_file" | "searched_file";
+export type ToolFileRelationKind = "edited" | ToolFileEvidenceKind;
 
 const READ_TOOLS = new Set(["read"]);
 const SEARCH_TOOLS = new Set(["grep", "glob"]);
+const EDIT_TOOLS = new Set(["edit", "write", "multiedit", "notebookedit", "apply_patch"]);
 const READ_COMMANDS = new Set(["cat", "sed", "nl", "head", "tail", "less"]);
 const SEARCH_COMMANDS = new Set(["rg", "grep", "git grep", "fd", "find"]);
+const STRUCTURED_PATH_FIELDS = ["file_path", "path", "notebook_path", "file"] as const;
 
 export interface ToolFileEvidenceInput {
     readonly name: string;
     readonly commandNorm?: string | null;
+}
+
+export interface ToolFileEvidence {
+    readonly kind: ToolFileRelationKind;
+    readonly sessionId: string;
+    readonly turnKey?: string | null;
+    readonly toolCallKey: string;
+    readonly toolName: string;
+    readonly ts: Date | string;
+    readonly path: string;
+    readonly pathSeen: string;
+    readonly evidence: string;
+    readonly excerpt?: string | null;
+    readonly editKind?: string | null;
 }
 
 export function classifyToolFileEvidence(input: ToolFileEvidenceInput): readonly ToolFileEvidenceKind[] {
@@ -27,4 +48,138 @@ export function evidenceReason(input: ToolFileEvidenceInput, kind: ToolFileEvide
         return `command_norm:${command}`;
     }
     return `tool_name:${input.name}`;
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+    return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+
+function stringField(input: Record<string, unknown>, field: string): string | null {
+    const value = input[field];
+    return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function arrayStringField(input: Record<string, unknown>, field: string): readonly string[] {
+    const value = input[field];
+    if (!Array.isArray(value)) return [];
+    return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function normalizeEvidencePath(path: string, cwd?: string | null): string {
+    if (isAbsolute(path) || !cwd) return path;
+    return resolve(cwd, path);
+}
+
+function unique(values: Iterable<string>): string[] {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const value of values) {
+        const trimmed = value.trim();
+        if (trimmed.length === 0 || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        out.push(trimmed);
+    }
+    return out;
+}
+
+function structuredPaths(input: unknown): string[] {
+    if (!isRecord(input)) return [];
+    const paths: string[] = [];
+    for (const field of STRUCTURED_PATH_FIELDS) {
+        const path = stringField(input, field);
+        if (path) paths.push(path);
+    }
+    paths.push(...arrayStringField(input, "paths"));
+    paths.push(...arrayStringField(input, "files"));
+    return unique(paths);
+}
+
+function patchPaths(input: unknown): string[] {
+    if (!isRecord(input)) return [];
+    const patch =
+        stringField(input, "patch") ??
+        stringField(input, "diff") ??
+        stringField(input, "input");
+    if (!patch) return [];
+
+    const paths: string[] = [];
+    for (const line of patch.split(/\r?\n/)) {
+        const explicit = line.match(/^\*\*\* (?:Add|Update|Delete) File: (.+)$/) ??
+            line.match(/^\*\*\* Move to: (.+)$/);
+        if (explicit?.[1]) {
+            paths.push(explicit[1]);
+            continue;
+        }
+
+        const diffPath = line.match(/^\+\+\+ b\/(.+)$/);
+        if (diffPath?.[1] && diffPath[1] !== "/dev/null") paths.push(diffPath[1]);
+    }
+    return unique(paths);
+}
+
+function pathsForKind(call: ToolCallWrite, kind: ToolFileRelationKind): string[] {
+    const structured = structuredPaths(call.inputJson);
+    if (kind !== "edited") return structured;
+
+    const name = call.toolName.trim().toLowerCase();
+    if (name === "apply_patch") return unique([...structured, ...patchPaths(call.inputJson)]);
+    return structured;
+}
+
+function editKindForTool(toolName: string): string | null {
+    const name = toolName.trim().toLowerCase();
+    if (name === "write") return "write";
+    if (name === "apply_patch" || name === "edit" || name === "multiedit" || name === "notebookedit") {
+        return "edit";
+    }
+    return null;
+}
+
+export function extractToolFileEvidence(
+    calls: readonly ToolCallWrite[],
+): ToolFileEvidence[] {
+    const evidence: ToolFileEvidence[] = [];
+
+    for (const call of calls) {
+        const name = call.toolName.trim().toLowerCase();
+        const kinds: ToolFileRelationKind[] = [
+            ...(EDIT_TOOLS.has(name) ? ["edited" as const] : []),
+            ...classifyToolFileEvidence({
+                name: call.toolName,
+                commandNorm: call.commandNorm ?? null,
+            }),
+        ];
+        if (kinds.length === 0) continue;
+
+        const toolCallKey = toolCallRecordKey({
+            sessionId: call.sessionId,
+            seq: call.seq,
+            callId: call.callId ?? null,
+        });
+
+        for (const kind of kinds) {
+            for (const pathSeen of pathsForKind(call, kind)) {
+                evidence.push({
+                    kind,
+                    sessionId: call.sessionId,
+                    turnKey: call.turnKey ?? null,
+                    toolCallKey,
+                    toolName: call.toolName,
+                    ts: call.ts,
+                    path: normalizeEvidencePath(pathSeen, call.cwd),
+                    pathSeen,
+                    evidence: kind === "edited"
+                        ? `tool_name:${call.toolName}`
+                        : evidenceReason({
+                            name: call.toolName,
+                            commandNorm: call.commandNorm ?? null,
+                        }, kind),
+                    excerpt: call.outputExcerpt ?? null,
+                    editKind: kind === "edited" ? editKindForTool(call.toolName) : null,
+                });
+            }
+        }
+    }
+
+    return evidence;
 }

--- a/src/ingest/transcripts.test.ts
+++ b/src/ingest/transcripts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { agentEventRecordKey } from "./provider-events.ts";
 import { fileRecordKey, toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
+import { extractToolFileEvidence } from "./tool-file-evidence.ts";
 import {
     __testExtractClaudeJsonlLines,
     claudeConcurrency,
@@ -747,6 +748,71 @@ describe("Claude transcript extraction", () => {
         expect(extracted.edits).toHaveLength(1);
         const edit = extracted.edits[0];
         expect(transcriptEditFileRecordKey(edit?.path ?? "")).toBe(expectedFileKey);
+    });
+
+    test("Claude tool calls project shared edit read and search file evidence", () => {
+        const extracted = __testExtractClaudeJsonlLines(
+            [
+                JSON.stringify({
+                    type: "assistant",
+                    timestamp: "2026-05-09T10:00:00.000Z",
+                    cwd: "/Users/necmttn/Projects/ax",
+                    message: {
+                        content: [
+                            {
+                                type: "tool_use",
+                                id: "toolu_edit",
+                                name: "Edit",
+                                input: { file_path: "src/edit.ts" },
+                            },
+                            {
+                                type: "tool_use",
+                                id: "toolu_read",
+                                name: "Read",
+                                input: { file_path: "src/read.ts" },
+                            },
+                            {
+                                type: "tool_use",
+                                id: "toolu_grep",
+                                name: "Grep",
+                                input: { pattern: "needle", path: "src" },
+                            },
+                        ],
+                    },
+                }),
+            ],
+            "-Users-necmttn-Projects-ax",
+            "session-shared-file-evidence",
+        );
+
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+
+        expect(extractToolFileEvidence(extracted.toolCalls).map((item) => ({
+            kind: item.kind,
+            toolName: item.toolName,
+            path: item.path,
+            pathSeen: item.pathSeen,
+        }))).toEqual([
+            {
+                kind: "edited",
+                toolName: "Edit",
+                path: "/Users/necmttn/Projects/ax/src/edit.ts",
+                pathSeen: "src/edit.ts",
+            },
+            {
+                kind: "read_file",
+                toolName: "Read",
+                path: "/Users/necmttn/Projects/ax/src/read.ts",
+                pathSeen: "src/read.ts",
+            },
+            {
+                kind: "searched_file",
+                toolName: "Grep",
+                path: "/Users/necmttn/Projects/ax/src",
+                pathSeen: "src",
+            },
+        ]);
     });
 
     test("edited-file IDs merge the same local file across cwd-derived repo labels", () => {

--- a/src/ingest/transcripts.ts
+++ b/src/ingest/transcripts.ts
@@ -13,6 +13,7 @@ import type { StageDef } from "./stage/registry.ts";
 import {
     buildPlanSnapshotStatements,
     buildRelateToolCallSkillStatements,
+    buildToolFileEvidenceStatements,
     buildToolCallStatements,
     type PlanSnapshotWrite,
     type ToolCallSkillRelationWrite,
@@ -32,12 +33,12 @@ import {
 import { classifyTurnIntent } from "./intent-kind.ts";
 import { normalizeClaudeTodoWrite, type PlanStatus } from "./plans.ts";
 import {
-    editedRelationRecordKey,
     fileRecordKey,
     invokedRelationRecordKey,
     toolCallRecordKey,
     turnRecordKey,
 } from "./record-keys.ts";
+import { extractToolFileEvidence } from "./tool-file-evidence.ts";
 
 import { executeStatements, executeStatementsWith } from "../lib/shared/statement-exec.ts";
 
@@ -1068,10 +1069,10 @@ export {
     upsertSessions as upsertSessionsForSubagents,
     upsertTurns as upsertTurnsForSubagents,
     writeToolCallStatements as writeToolCallStatementsForSubagents,
+    writeToolFileEvidence as writeToolFileEvidenceForSubagents,
     relateInvocations as relateInvocationsForSubagents,
     relateToolCallSkills as relateToolCallSkillsForSubagents,
     writePlanSnapshots as writePlanSnapshotsForSubagents,
-    upsertEdits as upsertEditsForSubagents,
 };
 
 const upsertSessions = (sessions: Session[]) =>
@@ -1231,30 +1232,10 @@ const relateInvocations = (invocations: Invocation[]) =>
         yield* executeStatementsWith(db, stmts, { chunkSize: 500 });
     });
 
-const upsertEdits = (edits: Edit[]) =>
-    Effect.gen(function* () {
-        if (edits.length === 0) return;
-        const db = yield* SurrealClient;
-        const fileStmts: string[] = [];
-        const relStmts: string[] = [];
-        const seenFiles = new Set<string>();
-        for (const e of edits) {
-            const fileKey = transcriptEditFileRecordKey(e.path);
-            if (!seenFiles.has(fileKey)) {
-                seenFiles.add(fileKey);
-                fileStmts.push(
-                    `UPSERT file:\`${fileKey}\` CONTENT { repo: NONE, path: ${surrealLiteral(e.path)}, identity_scope: "local_path" };`,
-                );
-            }
-            const turnKey = turnRecordKey(e.session, e.seq);
-            const edgeKey = editedRelationRecordKey({ turnKey, fileKey, tool: e.tool });
-            relStmts.push(
-                `RELATE turn:\`${turnKey}\`->edited:\`${edgeKey}\`->file:\`${fileKey}\` SET tool = "${e.tool}", ts = d"${e.ts}";`,
-            );
-        }
-        yield* executeStatementsWith(db, fileStmts, { chunkSize: 500 });
-        yield* executeStatementsWith(db, relStmts, { chunkSize: 500 });
-    });
+const writeToolFileEvidence = (toolCalls: readonly ToolCallWrite[]) =>
+    queryTranscriptStatements(buildToolFileEvidenceStatements(
+        extractToolFileEvidence(toolCalls),
+    ));
 
 const relateToolCallSkills = (relations: ToolCallSkillRelationWrite[]) =>
     Effect.gen(function* () {
@@ -1459,6 +1440,7 @@ export const ingestTranscripts = (
             yield* writeProviderEvidence(extracted);
             yield* writeToolCallStatements(extracted.toolCalls);
             toolCallCount += extracted.toolCalls.length;
+            yield* writeToolFileEvidence(extracted.toolCalls);
             // Resolve invoked names onto the catalog before writing so the
             // `invoked` and `concerns` edges land on the real skill row.
             const resolvedInvocations = extracted.invocations.map((inv) => ({
@@ -1477,7 +1459,6 @@ export const ingestTranscripts = (
             yield* writeHookEvidence(extracted.hookEvents, extracted.hookCommandInvocations);
             hookEventCount += extracted.hookEvents.length;
             hookCommandInvocationCount += extracted.hookCommandInvocations.length;
-            yield* upsertEdits(extracted.edits);
             editCount += extracted.edits.length;
             if (opts.onProgress && (files <= 5 || files % 10 === 0)) {
                 yield* opts.onProgress({

--- a/src/queries/session-detail.test.ts
+++ b/src/queries/session-detail.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { SESSION_FILE_EVIDENCE_SQL } from "./session-detail.ts";
+
+describe("session detail queries", () => {
+    test("file evidence reads shared relation tables without provider branches", () => {
+        expect(SESSION_FILE_EVIDENCE_SQL).toContain("FROM edited");
+        expect(SESSION_FILE_EVIDENCE_SQL).toContain("FROM read_file");
+        expect(SESSION_FILE_EVIDENCE_SQL).toContain("FROM searched_file");
+        expect(SESSION_FILE_EVIDENCE_SQL).toContain("WHERE in.session = $sessionId");
+        expect(SESSION_FILE_EVIDENCE_SQL).not.toContain("provider =");
+        expect(SESSION_FILE_EVIDENCE_SQL).not.toContain("source = \"claude\"");
+        expect(SESSION_FILE_EVIDENCE_SQL).not.toContain("source = \"codex\"");
+        expect(SESSION_FILE_EVIDENCE_SQL).not.toContain("source = \"pi\"");
+    });
+});

--- a/src/queries/session-detail.ts
+++ b/src/queries/session-detail.ts
@@ -97,6 +97,55 @@ WHERE session = $sessionId AND name = "Agent"
 ORDER BY ts ASC
 LIMIT 50;`;
 
+/**
+ * Provider-neutral file evidence. Edit evidence is turn-scoped; read/search
+ * evidence is tool-call-scoped. All three relation tables point at the shared
+ * `file` records, so callers should not branch on Claude/Codex/Pi.
+ */
+export const SESSION_FILE_EVIDENCE_SQL = `
+SELECT
+    "edited" AS relation,
+    out AS file,
+    out.path AS path,
+    tool AS tool,
+    path_seen,
+    absolute_path_seen,
+    ts
+FROM edited
+WHERE in.session = $sessionId
+ORDER BY ts DESC
+LIMIT 100;
+
+SELECT
+    "read_file" AS relation,
+    out AS file,
+    out.path AS path,
+    in.name AS tool,
+    path_seen,
+    absolute_path_seen,
+    evidence,
+    excerpt,
+    ts
+FROM read_file
+WHERE in.session = $sessionId
+ORDER BY ts DESC
+LIMIT 100;
+
+SELECT
+    "searched_file" AS relation,
+    out AS file,
+    out.path AS path,
+    in.name AS tool,
+    path_seen,
+    absolute_path_seen,
+    evidence,
+    excerpt,
+    ts
+FROM searched_file
+WHERE in.session = $sessionId
+ORDER BY ts DESC
+LIMIT 100;`;
+
 // ---------------------------------------------------------------------------
 // Typed Query seam
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #90

## Summary
- Add provider-neutral tool file evidence extraction for edited/read/searched file paths from structured tool-call args.
- Add shared writers for `edited`, `read_file`, and `searched_file` relations with local-path file identity plus `path_seen` and `absolute_path_seen`.
- Wire Claude, Codex, Pi, and Claude subagent ingest paths through the shared writer.
- Add provider parity docs and a provider-neutral session-detail file evidence query surface.

## Validation
- `bun test src/ingest/tool-file-evidence.test.ts src/ingest/evidence-writers.test.ts src/ingest/transcripts.test.ts src/ingest/codex.test.ts src/ingest/pi.test.ts src/queries/session-detail.test.ts schema/schema.test.ts`
- `bun scripts/check-table-coverage.ts`
- `bun run typecheck 2>&1 | rg 'src/(ingest/tool-file-evidence|ingest/transcripts|ingest/derive-claude-subagents|ingest/codex|ingest/pi|queries/session-detail|ingest/evidence-writers)'`
- `bun test` was also run; it has 3 unrelated failures currently: `ingestGit repoPaths bypass` missing `.claude/worktrees/workflow-extraction-frictions/.git`, plus `src/cli/lint.test.ts` and `src/cli/recommend.test.ts` help subprocess timeouts with empty output.
- Full `bun run typecheck` still fails on unrelated existing errors in `src/cli`, `src/improve`, and `src/ingest/git.ts`; the filtered touched-file check above is clean.

## Blocked / follow-up
- OpenCode concrete file evidence remains dependent on #88 tool-call extraction.
- Cursor concrete file evidence remains dependent on #89 tool-call extraction.
- Shell command path parsing beyond structured args is intentionally deferred to avoid duplicating extractor work.
