### PR TITLE
test: restore baseline CI

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -120,7 +120,7 @@ const stringArg = (name: string, value: string | undefined): string[] =>
 const optionValue = <A>(value: Option.Option<A>): A | undefined =>
     Option.getOrUndefined(value);
 
-function flag(name: string, args: string[]): string | undefined {
+function flag(name: string, args: readonly string[]): string | undefined {
     const found = args.find((a) => a.startsWith(`--${name}=`));
     return found?.split("=")[1];
 }
@@ -134,7 +134,7 @@ function flag(name: string, args: string[]): string | undefined {
 function parsePositiveIntFlag(
     cmd: string,
     flagName: string,
-    args: string[],
+    args: readonly string[],
     fallback?: number,
 ): number {
     const raw = flag(flagName, args);
@@ -162,7 +162,7 @@ function parsePositiveIntFlag(
 function parseOptionalPositiveIntFlag(
     cmd: string,
     flagName: string,
-    args: string[],
+    args: readonly string[],
 ): number | undefined {
     const raw = flag(flagName, args);
     if (raw === undefined) return undefined;
@@ -1896,13 +1896,6 @@ interface ProposalRow {
     readonly created_at?: string;
 }
 
-interface SkillProposalRow {
-    readonly trigger_pattern: string;
-    readonly suspected_gap: string;
-    readonly proposed_behavior: string;
-    readonly expected_impact: string | null;
-}
-
 const formatProposalLine = (row: ProposalRow): string => {
     const freq = String(row.frequency).padStart(6);
     const conf = (row.confidence ?? "").padEnd(6);
@@ -1971,10 +1964,8 @@ const cmdImproveLint = (args: string[]) =>
         for (const a of args) {
             if (a.startsWith("--root=")) roots.push(a.slice("--root=".length));
         }
-        const report = yield* lintFiles({
-            roots: roots.length > 0 ? roots : undefined,
-            staleDays,
-        });
+        const lintOptions = roots.length > 0 ? { roots, staleDays } : { staleDays };
+        const report = yield* lintFiles(lintOptions);
         if (json) {
             console.log(JSON.stringify(report, null, 2));
         } else {
@@ -2022,11 +2013,12 @@ const cmdImproveRecommend = (args: string[]) =>
                 }
             }
         }
-        const items = yield* recommend({
+        const recommendInput = {
             limit,
-            forms: forms.length > 0 ? forms : undefined,
-            sinceDays,
-        });
+            ...(forms.length > 0 ? { forms } : {}),
+            ...(sinceDays === undefined ? {} : { sinceDays }),
+        };
+        const items = yield* recommend(recommendInput);
         if (json) {
             console.log(JSON.stringify(items, null, 2));
             return;
@@ -2128,7 +2120,7 @@ const improveShowCommand = Command.make(
     ({ id, json }) => cmdImproveShow([id, ...boolArg("json", json)]),
 ).pipe(Command.withDescription("Show experiment evidence + status for one proposal id"));
 
-const cmdImproveAccept = (args: string[]) =>
+export const cmdImproveAccept = (args: string[]) =>
     Effect.gen(function* () {
         const positional = args.filter((a) => !a.startsWith("--"))[0];
         if (positional === undefined) {
@@ -4404,6 +4396,10 @@ async function main() {
     const [, , ...args] = process.argv;
     if (args[0] === undefined || args[0] === "help" || args[0] === "--help" || args[0] === "-h") {
         await Effect.runPromise(withoutDb(["--help"]));
+        return;
+    }
+    if (args.includes("--help") || args.includes("-h")) {
+        await Effect.runPromise(withoutDb(args));
         return;
     }
     if (args[0] === "-V" || args[0] === "-v" || args[0] === "--version") {

--- a/src/improve/actions.ts
+++ b/src/improve/actions.ts
@@ -135,7 +135,6 @@ const defaultTaskDir = (): string =>
  * Map a full proposal row + experimentId to a TaskInput for renderTaskFile.
  */
 const buildTaskInput = (row: FullProposalRow, experimentId: string): TaskInput => {
-    const form = row.form as TaskInput["form"];
     const shortId = row.dedupe_sig;
     if (row.form === "guidance") {
         return {
@@ -287,8 +286,8 @@ export const acceptProposal = (
                     hypothesis: row.hypothesis,
                     triggerPattern: payload.trigger_pattern == null ? null : String(payload.trigger_pattern),
                     proposedBehavior: String(payload.proposed_behavior ?? ""),
-                    baseline: typeof (row as Record<string, unknown>).baseline === "string"
-                        ? String((row as Record<string, unknown>).baseline)
+                    baseline: typeof (row as unknown as Record<string, unknown>).baseline === "string"
+                        ? String((row as unknown as Record<string, unknown>).baseline)
                         : null,
                 },
             };

--- a/src/improve/grounded-files.e2e.test.ts
+++ b/src/improve/grounded-files.e2e.test.ts
@@ -66,7 +66,7 @@ const cleanupProposal = (sig: string) =>
             DELETE experiment WHERE proposal = proposal:e2e_${sig};
             DELETE guidance_proposal WHERE proposal = proposal:e2e_${sig};
             DELETE proposal:e2e_${sig};
-        `).pipe(Effect.orElse(() => Effect.void));
+        `).pipe(Effect.catch(() => Effect.void));
     });
 
 // ---------------------------------------------------------------------------

--- a/src/improve/lint.test.ts
+++ b/src/improve/lint.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { Effect, Layer } from "effect";
 import { SurrealClient } from "../lib/db.ts";
 import { DbError } from "../lib/errors.ts";
-import { discoverFiles, lintFiles, type LintTarget, type LintReport } from "./lint.ts";
+import { discoverFiles, lintFiles, type LintTarget } from "./lint.ts";
 
 const make = () => {
     const root = mkdtempSync(join(tmpdir(), "ax-lint-"));

--- a/src/improve/lint.ts
+++ b/src/improve/lint.ts
@@ -147,7 +147,14 @@ const collectIds = (target: LintTarget, errors: LintFinding[]): Map<string, IdTa
         // Skill and subagent files use frontmatter; may carry ax_experiment.
         // (subagent experiments don't exist yet in v0 but the path is identical.)
         const fm = parseFrontmatterMarker(content);
-        if (fm) found.set(fm.id, { path: target.path, experiment: fm.experiment });
+        if (fm) {
+            found.set(
+                fm.id,
+                fm.experiment === undefined
+                    ? { path: target.path }
+                    : { path: target.path, experiment: fm.experiment },
+            );
+        }
     }
     return found;
 };

--- a/src/improve/recommend.test.ts
+++ b/src/improve/recommend.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
-import { recommend, formatRecommendations, selectByIndices, parseIndexInput, type RecommendInput, type RecommendItem } from "./recommend.ts";
+import { recommend, formatRecommendations, selectByIndices, parseIndexInput, type RecommendItem } from "./recommend.ts";
 import { SurrealClient } from "../lib/db.ts";
 
 const layerWith = (rows: ReadonlyArray<unknown>) =>

--- a/src/ingest/git.test.ts
+++ b/src/ingest/git.test.ts
@@ -233,9 +233,10 @@ describe("ingestGit repoPaths bypass", () => {
             raw: {} as never,
         };
 
-        // Use the current worktree's own repo root as the target - it's a real
-        // git repo so buildRepoInfo succeeds.
-        const repoRoot = "/Users/necmttn/Projects/ax/.claude/worktrees/workflow-extraction-frictions";
+        // Use this test checkout as the target - it is a real git repo in CI
+        // and in local worktrees, so buildRepoInfo succeeds without depending
+        // on a developer-specific path.
+        const repoRoot = process.cwd();
 
         const result = await Effect.runPromise(
             ingestGit({ repoPaths: [repoRoot], sinceDays: 1 }).pipe(

--- a/src/ingest/git.ts
+++ b/src/ingest/git.ts
@@ -836,7 +836,10 @@ export const gitStage: StageDef<GitStageStats, SurrealClient> = {
         Effect.gen(function* () {
             const t0 = Date.now();
             const sinceDays = sinceDaysFromCtx(ctx);
-            const result = yield* ingestGit({ sinceDays, repoPaths: ctx.repoPaths });
+            const result = yield* ingestGit({
+                ...(sinceDays === undefined ? {} : { sinceDays }),
+                ...(ctx.repoPaths === undefined ? {} : { repoPaths: ctx.repoPaths }),
+            });
             return GitStageStats.make({
                 durationMs: Date.now() - t0,
                 summary: `ingested ${result.commits} commits from ${result.repos} repos`,


### PR DESCRIPTION
## Summary
- route nested --help through no-DB CLI parsing so help tests do not wait on SurrealDB
- make git repoPaths test use the current checkout instead of a developer-specific worktree path
- clean exactOptionalPropertyTypes/no-unused typecheck failures in improve/git paths

## Test Plan
- bun test
- bun run typecheck
- bash -n install.sh
- bun run check:cli-reference
- bun run check:table-coverage
- bun run build
- ./dist/axctl --version
- ./dist/axctl help
- ./dist/axctl daemon status --json
- ./dist/axctl doctor --json
