### PR TITLE
[codex] Add typed JSON boundary helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ axctl recall <query> [--sources=turn,commit,skill] [--scope=here|all]
                                             # cross-session BM25 full-text search
 axctl context [file] [<query>]              # file/agent-context grounding
 axctl skills <search|taste|unused|pairs|recovery|classify|tag|lint|weighted|by-role|roles>
-axctl insights <view>                       # 16 read-only graph views
+axctl insights <view>                       # 19 read-only graph views
 axctl costs <summary>                       # token/cost usage by provider/model quality
 axctl sessions <here|around <date>|near <sha>|show <id>>
                                             # windowed session queries

--- a/docs/effect-json-boundaries.md
+++ b/docs/effect-json-boundaries.md
@@ -1,0 +1,27 @@
+# Effect JSON Boundaries
+
+JSON that crosses an IO boundary should decode through Effect Schema before the
+rest of the code reads it. Use the helpers in `src/lib/decode.ts`:
+
+- `decodeJsonOrNull` for best-effort unknown JSON from JSONL/file payloads.
+- `decodeJsonOrNullAs(schema, text)` when the caller knows the payload shape.
+- `decodeJsonRecordOrNull` for JSON object maps such as DB `labels`.
+- `encodeJsonOrNull` for machine-boundary JSON strings.
+
+Direct `JSON.parse` remains acceptable only inside a central boundary helper or
+legacy adapter that immediately normalizes and validates the value. Direct
+`JSON.stringify` remains acceptable for human pretty printing, test fixtures,
+and SurrealQL string-literal helpers where the value is already in-process and
+not an external payload.
+
+The remaining Effect language-service advisories are intentionally split this
+way:
+
+- `Effect.void` in fake `SurrealClient` test doubles: concise no-op service
+  methods, not production control flow.
+- `JSON.stringify` in `src/lib/json.ts` pretty printing: human CLI output.
+- `JSON.stringify` in `src/lib/shared/surql.ts`: SurrealQL literal escaping.
+- JSON fixture construction in tests: test data, not runtime IO.
+
+New runtime JSON readers should not add raw `JSON.parse` call sites. Add a
+schema and route through `src/lib/decode.ts` instead.

--- a/docs/insights-cli-reference.md
+++ b/docs/insights-cli-reference.md
@@ -15,6 +15,7 @@ axctl insights git --limit=25
 axctl insights friction --limit=50
 axctl insights tools --limit=20
 axctl insights sessions --limit=20
+axctl insights file-evidence --limit=20
 axctl insights feedback-loops --limit=20
 axctl insights verification-gaps --limit=20
 axctl insights user-language --limit=20
@@ -44,6 +45,9 @@ The builders target the current schema fields directly:
 - `toolFailuresSql` groups `tool_call` rows with `WHERE has_error = true`.
 - `sessionEvidenceSql` summarizes session-linked tool calls, failures,
   friction events, and plan snapshots.
+- `fileEvidenceSql` summarizes provider-neutral edit, read, and search file
+  relations so Claude/Codex/Pi evidence can be compared without provider
+  branches.
 - `feedbackLoopsSql` groups persisted `command_outcome` rows so expected test
   feedback, guardrails, search misses, and real blockers can be separated.
 - `verificationGapsSql` finds sessions with edits but no verification-shaped

--- a/src/dashboard/cost-query.ts
+++ b/src/dashboard/cost-query.ts
@@ -1,7 +1,8 @@
 import { Effect } from "effect";
 import { SurrealClient } from "../lib/db.ts";
-import { decodeJsonOrNull } from "../lib/decode.ts";
+import { decodeJsonRecordOrNull } from "../lib/decode.ts";
 import type { DbError } from "../lib/errors.ts";
+import { surrealString } from "../lib/shared/surql.ts";
 import {
     modelQualityFromLabels,
     tokenQualityFromLabels,
@@ -69,10 +70,7 @@ const stringOrNull = (value: unknown): string | null =>
 
 const labelsRecord = (value: unknown): Record<string, unknown> => {
     if (typeof value !== "string") return {};
-    const decoded = decodeJsonOrNull(value);
-    return typeof decoded === "object" && decoded !== null && !Array.isArray(decoded)
-        ? decoded as Record<string, unknown>
-        : {};
+    return decodeJsonRecordOrNull(value) ?? {};
 };
 
 export const mapCostRows = (rows: ReadonlyArray<Record<string, unknown>>): CostSessionRow[] =>
@@ -166,7 +164,7 @@ export const fetchCostSummary = (
     Effect.gen(function* () {
         const db = yield* SurrealClient;
         const where: string[] = [];
-        if (input.source) where.push(`source = ${JSON.stringify(input.source)}`);
+        if (input.source) where.push(`source = ${surrealString(input.source)}`);
         if (input.sinceDays !== null) {
             const since = Math.min(Math.max(Math.trunc(input.sinceDays), 1), 3650);
             where.push(`ts > time::now() - ${since}d`);

--- a/src/hooks/file-context-hook.ts
+++ b/src/hooks/file-context-hook.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import type { DbError } from "../lib/errors.ts";
 import { SurrealClient } from "../lib/db.ts";
+import { decodeJsonRecordOrNull } from "../lib/decode.ts";
 import {
     buildFileContextHookEvidence,
     type FileContextPack,
@@ -183,13 +184,8 @@ function adaptClaudePayload(payload: Record<string, unknown>): FileContextHookFl
 }
 
 export function parseFileContextHookStdin(text: string): FileContextHookInput {
-    let payload: Record<string, unknown> = {};
-    try {
-        const parsed = JSON.parse(text);
-        if (parsed && typeof parsed === "object") payload = parsed as Record<string, unknown>;
-    } catch {
-        return parseFileContextHookFlags({});
-    }
+    const payload = decodeJsonRecordOrNull(text);
+    if (!payload) return parseFileContextHookFlags({});
 
     if (typeof payload.hook_event_name === "string") {
         return parseFileContextHookFlags(adaptClaudePayload(payload));

--- a/src/lib/decode.test.ts
+++ b/src/lib/decode.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { decodeJsonOrNull } from "./decode.ts";
+import { Schema } from "effect";
+import {
+    decodeJsonOrNull,
+    decodeJsonOrNullAs,
+    decodeJsonRecordOrNull,
+    encodeJsonOrNull,
+} from "./decode.ts";
 
 describe("decodeJsonOrNull", () => {
     test("decodes valid JSON to its parsed value", () => {
@@ -16,5 +22,29 @@ describe("decodeJsonOrNull", () => {
         expect(decodeJsonOrNull("not json")).toBeNull();
         expect(decodeJsonOrNull("{a:1}")).toBeNull();
         expect(decodeJsonOrNull("{")).toBeNull();
+    });
+
+    test("validates decoded JSON against a typed Schema", () => {
+        const HookPayload = Schema.Struct({
+            event: Schema.String,
+            files: Schema.Array(Schema.String),
+        });
+
+        expect(decodeJsonOrNullAs(HookPayload, '{"event":"read","files":["src/a.ts"]}')).toEqual({
+            event: "read",
+            files: ["src/a.ts"],
+        });
+        expect(decodeJsonOrNullAs(HookPayload, '{"event":"read","files":[1]}')).toBeNull();
+    });
+
+    test("decodes only JSON object records for record boundaries", () => {
+        expect(decodeJsonRecordOrNull('{"a":1}')).toEqual({ a: 1 });
+        expect(decodeJsonRecordOrNull("[1,2,3]")).toBeNull();
+        expect(decodeJsonRecordOrNull("null")).toBeNull();
+    });
+
+    test("encodes machine-boundary JSON through Schema", () => {
+        expect(encodeJsonOrNull({ a: 1 })).toBe('{"a":1}');
+        expect(encodeJsonOrNull(["x", true])).toBe('["x",true]');
     });
 });

--- a/src/lib/decode.ts
+++ b/src/lib/decode.ts
@@ -1,6 +1,10 @@
 import { Option, Schema } from "effect";
 
 const decodeJsonString = Schema.decodeUnknownOption(Schema.UnknownFromJsonString);
+const encodeJsonString = Schema.encodeUnknownOption(Schema.UnknownFromJsonString);
+
+export const JsonRecordSchema = Schema.Record(Schema.String, Schema.Unknown);
+export type JsonRecord = typeof JsonRecordSchema.Type;
 
 /**
  * Best-effort JSON decode at an IO boundary (jsonl lines, file payloads).
@@ -11,5 +15,33 @@ const decodeJsonString = Schema.decodeUnknownOption(Schema.UnknownFromJsonString
  */
 export const decodeJsonOrNull = (input: string): unknown | null => {
     const result = decodeJsonString(input);
+    return Option.isSome(result) ? result.value : null;
+};
+
+/**
+ * Decode a JSON string and validate the parsed payload against an Effect
+ * Schema. This is the preferred boundary helper when callers know the shape
+ * they expect from stdin, JSONL, DB labels, or file payloads.
+ */
+export const decodeJsonOrNullAs = <T>(
+    schema: Schema.Decoder<T, never>,
+    input: string,
+): T | null => {
+    const decoded = decodeJsonOrNull(input);
+    if (decoded === null) return null;
+    const result = Schema.decodeUnknownOption(schema)(decoded);
+    return Option.isSome(result) ? result.value : null;
+};
+
+export const decodeJsonRecordOrNull = (input: string): JsonRecord | null =>
+    decodeJsonOrNullAs(JsonRecordSchema, input);
+
+/**
+ * Encode a value as a JSON string through Effect Schema's JSON-string
+ * transformation. This keeps machine-boundary serialization centralized;
+ * human pretty-printing can still use `prettyPrint` from `lib/json.ts`.
+ */
+export const encodeJsonOrNull = (input: unknown): string | null => {
+    const result = encodeJsonString(input);
     return Option.isSome(result) ? result.value : null;
 };

--- a/src/lib/json.ts
+++ b/src/lib/json.ts
@@ -14,7 +14,7 @@
  *
  * Real decode boundaries (`JSON.parse` on jsonl lines / file payloads) live in
  * `src/ingest/*` and should use Effect Schema decoders directly - those are
- * tracked in issue #71 ("Add boundary schemas for JSON IO").
+ * tracked in issue #86 ("Effect JSON-boundary Schema decoders").
  */
 
 import { surrealString } from "./shared/surql.ts";

--- a/src/queries/insights.test.ts
+++ b/src/queries/insights.test.ts
@@ -7,6 +7,7 @@ import {
     repositoryOverviewSql,
     schemaCoverageSql,
     sessionEvidenceSql,
+    fileEvidenceSql,
     feedbackLoopsSql,
     userLanguageSql,
     verificationGapsSql,
@@ -130,6 +131,24 @@ describe("insights query builders", () => {
         expect(sql).toContain("ORDER BY last_seen DESC");
         expect(sql).toContain("LIMIT 9");
         expectNoStaleFields(sql);
+    });
+
+    test("fileEvidenceSql summarizes provider-neutral edit/read/search relations", () => {
+        const sql = fileEvidenceSql(4);
+
+        expect(sql).toContain("RETURN [");
+        expect(sql).toContain('relation: "edited"');
+        expect(sql).toContain("FROM edited");
+        expect(sql).toContain("session.source AS source");
+        expect(sql).toContain('relation: "read_file"');
+        expect(sql).toContain("FROM read_file");
+        expect(sql).toContain("in.session.source AS source");
+        expect(sql).toContain('relation: "searched_file"');
+        expect(sql).toContain("FROM searched_file");
+        expect(sql).toContain("GROUP BY source, tool, evidence");
+        expect(sql).toContain("LIMIT 4");
+        expect(sql).not.toContain("raw_kind");
+        expect(sql).not.toContain("identity_kind");
     });
 
     test("schemaCoverageSql returns scalar counts for active and staged tables", () => {

--- a/src/queries/insights.ts
+++ b/src/queries/insights.ts
@@ -6,6 +6,7 @@ export const INSIGHT_VIEWS = [
     "friction",
     "tools",
     "sessions",
+    "file-evidence",
     "feedback-loops",
     "verification-gaps",
     "user-language",
@@ -235,6 +236,60 @@ ORDER BY last_seen DESC
 LIMIT ${safeLimit};`.trim();
 }
 
+export function fileEvidenceSql(limit: number): string {
+    const safeLimit = checkedLimit(limit);
+    return `
+RETURN [
+    {
+        relation: "edited",
+        rows: (
+            SELECT
+                "edited" AS relation,
+                session.source AS source,
+                tool,
+                count() AS edge_count,
+                time::max(ts) AS last_seen
+            FROM edited
+            GROUP BY source, tool
+            ORDER BY edge_count DESC, last_seen DESC
+            LIMIT ${safeLimit}
+        )
+    },
+    {
+        relation: "read_file",
+        rows: (
+            SELECT
+                "read_file" AS relation,
+                in.session.source AS source,
+                in.name AS tool,
+                evidence,
+                count() AS edge_count,
+                time::max(ts) AS last_seen
+            FROM read_file
+            GROUP BY source, tool, evidence
+            ORDER BY edge_count DESC, last_seen DESC
+            LIMIT ${safeLimit}
+        )
+    },
+    {
+        relation: "searched_file",
+        rows: (
+            SELECT
+                "searched_file" AS relation,
+                in.session.source AS source,
+                in.name AS tool,
+                evidence,
+                count() AS edge_count,
+                time::max(ts) AS last_seen
+            FROM searched_file
+            GROUP BY source, tool, evidence
+            ORDER BY edge_count DESC, last_seen DESC
+            LIMIT ${safeLimit}
+        )
+    }
+];`.trim();
+}
+
 export function feedbackLoopsSql(limit: number): string {
     const safeLimit = checkedLimit(limit);
     return `
@@ -460,6 +515,8 @@ export function insightSqlForView(view: InsightView, limit: number): string {
             return toolFailuresSql(limit);
         case "sessions":
             return sessionEvidenceSql(limit);
+        case "file-evidence":
+            return fileEvidenceSql(limit);
         case "feedback-loops":
             return feedbackLoopsSql(limit);
         case "verification-gaps":


### PR DESCRIPTION
Closes #86.

## What changed
- Added Effect Schema-backed JSON boundary helpers in `src/lib/decode.ts`, including typed decode and record decode helpers.
- Migrated hook stdin parsing and cost label decoding to the shared JSON boundary helpers.
- Replaced a cost-query SQL string literal `JSON.stringify` with the shared SurrealQL string helper.
- Added `axctl insights file-evidence` so provider-neutral edit/read/search file evidence can be inspected from the CLI.
- Documented the JSON-boundary policy and which remaining Effect language-service advisories are intentional.

## Verification
- `bun test src/lib/decode.test.ts src/hooks/file-context-hook.test.ts src/dashboard/cost-query.test.ts src/queries/insights.test.ts`
- `bun run typecheck`
- `bun run check:cli-reference`
