### PR TITLE
chore: clear Effect language service advisories

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 import { Effect, Layer, Option, References } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { SurrealClient, type SurrealClientShape } from "../lib/db.ts";
+import { decodeJsonRecordOrNull, encodeJson } from "../lib/decode.ts";
 import { listSessionsHere, listSessionsAround, listSessionsNear, type SessionRow } from "../dashboard/sessions-query.ts";
 import { findCommitWindow } from "../lib/git-window.ts";
 import { AxConfig } from "../lib/config.ts";
@@ -440,7 +441,7 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) => {
             ? yield* Effect.tryPromise({
                 try: () => initTuiProgress({ command: commandName, runId, stages: stageProgressList }),
                 catch: () => undefined,
-              }).pipe(Effect.catch(() => Effect.succeed(undefined)))
+              }).pipe(Effect.catch(() => Effect.void))
             : undefined;
         const progress: ProgressReporter = tuiHandle?.progress ?? createProgressReporter({
             command: commandName,
@@ -479,12 +480,10 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) => {
         }));
 
         const traceId = `ingest:${runId}`;
-        const program = Effect.gen(function* () {
-            yield* runPipeline(
-                wrappedStages as ReadonlyArray<StageDef<BaseStageStats, SurrealClient | AxConfig | ProcessService>>,
-                ctx,
-            );
-        }).pipe(
+        const program = runPipeline(
+            wrappedStages as ReadonlyArray<StageDef<BaseStageStats, SurrealClient | AxConfig | ProcessService>>,
+            ctx,
+        ).pipe(
             LiveTrace.withTrace({
                 traceId,
                 label: `ingest ${selectedStages.map((s) => s.meta.key).join(",")}`,
@@ -524,7 +523,7 @@ const cmdIngestHere = (args: string[]) => {
         const registry = yield* StageRegistry;
         const pwd = yield* resolvePwdRepository().pipe(
             Effect.catchTag("NotAGitRepoError", (err) =>
-                Effect.sync(() => {
+                Effect.promise(async () => {
                     process.stderr.write(
                         `axctl ingest here: not in a git repository (cwd=${err.cwd})\n`,
                     );
@@ -619,9 +618,7 @@ const cmdIngestInsights = (args: string[] = []) =>
                 { source: "claude", stage: "insights" },
             ],
         });
-        const program = Effect.gen(function* () {
-            yield* telemetryStage(db, runId, "claude", "insights", ingestClaudeInsights(), progress);
-        });
+        const program = telemetryStage(db, runId, "claude", "insights", ingestClaudeInsights(), progress);
         yield* program.pipe(
             Effect.tap(() => db.query(buildIngestRunFinishStatement({ runId, status: "ok" })).pipe(Effect.asVoid)),
             Effect.catch((error) =>
@@ -895,7 +892,7 @@ const cmdRecall = (opts: RecallCliOpts) =>
             scope,
         });
         if (opts.json) {
-            console.log(JSON.stringify(result, null, 2));
+            console.log(prettyPrint(result));
             return;
         }
 
@@ -2040,7 +2037,7 @@ const cmdImproveLint = (args: string[]) =>
         const lintOptions = roots.length > 0 ? { roots, staleDays } : { staleDays };
         const report = yield* lintFiles(lintOptions);
         if (json) {
-            console.log(JSON.stringify(report, null, 2));
+            console.log(prettyPrint(report));
         } else {
             for (const f of report.errors) {
                 console.log(`error  ${f.rule}: ${f.message} (${f.path})`);
@@ -2093,7 +2090,7 @@ const cmdImproveRecommend = (args: string[]) =>
         };
         const items = yield* recommend(recommendInput);
         if (json) {
-            console.log(JSON.stringify(items, null, 2));
+            console.log(prettyPrint(items));
             return;
         }
         const formatted = formatRecommendations(items);
@@ -2421,12 +2418,12 @@ const improveAcceptCommand = Command.make(
                 let retroSummaries: readonly string[] = [];
                 const baselineRaw = result.proposal.baseline;
                 if (typeof baselineRaw === "string" && baselineRaw.length > 0) {
-                    try {
-                        const parsed = JSON.parse(baselineRaw) as {
-                            tool?: string;
-                            sessionKeys?: unknown;
-                            frequency?: number;
-                        };
+                    const parsed = decodeJsonRecordOrNull(baselineRaw) as {
+                        tool?: string;
+                        sessionKeys?: unknown;
+                        frequency?: number;
+                    } | null;
+                    if (parsed !== null) {
                         if (Array.isArray(parsed.sessionKeys)) {
                             const tool = parsed.tool ?? "tool";
                             retroSummaries = parsed.sessionKeys
@@ -2434,8 +2431,6 @@ const improveAcceptCommand = Command.make(
                                 .slice(0, 5)
                                 .map((s) => `session ${s}: top tool ${tool} failed (cluster freq=${parsed.frequency ?? "?"})`);
                         }
-                    } catch {
-                        // ignore - baseline shape may evolve
                     }
                 }
                 console.log("");
@@ -2795,7 +2790,7 @@ const cmdSessionsHere = (args: string[]) =>
 
         const pwdResolution = yield* resolvePwdRepository().pipe(
             Effect.catchTag("NotAGitRepoError", (err) =>
-                Effect.sync(() => {
+                Effect.promise(async () => {
                     process.stderr.write(
                         `axctl sessions here: not in a git repository (cwd=${err.cwd})\n`,
                     );
@@ -2809,7 +2804,7 @@ const cmdSessionsHere = (args: string[]) =>
         const rows = yield* listSessionsHere({ repositoryKey, days });
 
         if (json) {
-            console.log(JSON.stringify(rows, null, 2));
+            console.log(prettyPrint(rows));
             return;
         }
         console.log(formatSessionsTable(rows));
@@ -2852,7 +2847,7 @@ const cmdSessionsAround = (args: string[]) =>
         const rows = yield* listSessionsAround({ date, days, project });
 
         if (json) {
-            console.log(JSON.stringify(rows, null, 2));
+            console.log(prettyPrint(rows));
             return;
         }
         console.log(formatSessionsTable(rows));
@@ -2872,7 +2867,7 @@ const cmdSessionsNear = (args: string[]) =>
         // Resolve repository via pwd (near is always pwd-scoped)
         const pwdResolution = yield* resolvePwdRepository().pipe(
             Effect.catchTag("NotAGitRepoError", (err) =>
-                Effect.sync(() => {
+                Effect.promise(async () => {
                     process.stderr.write(
                         `axctl sessions near: not in a git repository (cwd=${err.cwd})\n`,
                     );
@@ -2917,7 +2912,7 @@ const cmdSessionsNear = (args: string[]) =>
         const rows = yield* listSessionsNear({ from, to, repositoryKey });
 
         if (json) {
-            console.log(JSON.stringify(rows, null, 2));
+            console.log(prettyPrint(rows));
             return;
         }
         console.log(formatSessionsTable(rows));
@@ -3624,7 +3619,7 @@ const retroCommand = Command.make("retro").pipe(
 const serveCommand = Command.make(
     "serve",
     { port: Flag.integer("port").pipe(Flag.withDefault(1738)) },
-    ({ port }) => Effect.sync(() => serveDashboard([`--port=${port}`])),
+    ({ port }) => Effect.promise(() => serveDashboard([`--port=${port}`])),
 ).pipe(Command.withDescription("Serve the live web dashboard locally"));
 
 const reportCommand = Command.make(
@@ -4068,7 +4063,7 @@ const hookFileContextCommand = Command.make(
                 // something to inject; emit nothing otherwise so Claude Code
                 // doesn't show an empty additionalContext block to the user.
                 if (response.inject && response.context.length > 0) {
-                    console.log(JSON.stringify({
+                    console.log(encodeJson({
                         hookSpecificOutput: {
                             hookEventName: "PreToolUse",
                             additionalContext: response.context,

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -23,7 +23,7 @@ export const catchDbErrorAndExit =
     <A, R>(eff: Effect.Effect<A, DbError, R>): Effect.Effect<A, never, R> =>
         eff.pipe(
             Effect.catchTag("DbError", (e) =>
-                Effect.sync(() => {
+                Effect.promise(async () => {
                     process.stderr.write(`${prefix}: DB error - ${e.message}\n`);
                     process.exit(1);
                 }),

--- a/src/cli/retro-meta.ts
+++ b/src/cli/retro-meta.ts
@@ -18,6 +18,7 @@
  */
 
 import { Effect } from "effect";
+import { encodeJson } from "../lib/decode.ts";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { SurrealClient } from "../lib/db.ts";
@@ -465,6 +466,6 @@ export const cmdRetroMeta = (
 
         const out = pretty || process.stdout.isTTY
             ? prettyPrint(snapshot)
-            : JSON.stringify(snapshot);
+            : encodeJson(snapshot);
         console.log(out);
     });

--- a/src/cli/skills-classify.ts
+++ b/src/cli/skills-classify.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { mkdir, writeFile, access } from "node:fs/promises";
 import { SurrealClient } from "../lib/db.ts";
 import type { DbError } from "../lib/errors.ts";
+import { prettyPrint } from "../lib/json.ts";
 import { skillNameToSlug, renderClassifyBrief } from "./skills-classify-template.ts";
 import { validateSkillName } from "../lib/role-name.ts";
 
@@ -61,6 +62,14 @@ ORDER BY invocations DESC;
 `.trim();
 };
 
+const safeSkillName = (name: string): string | null => {
+    try {
+        return validateSkillName(name);
+    } catch {
+        return null;
+    }
+};
+
 export interface ClassifyOptions {
     readonly names: readonly string[];
     readonly outDir: string;
@@ -75,9 +84,7 @@ export const cmdSkillsClassify = (opts: ClassifyOptions): Effect.Effect<void, Db
         // Validate any explicitly-provided skill names at the boundary.
         if (opts.names.length > 0) {
             for (const name of opts.names) {
-                try {
-                    validateSkillName(name);
-                } catch {
+                if (safeSkillName(name) === null) {
                     console.error(
                         `axctl skills classify: invalid skill name "${name}" (must be alphanumeric, _ or -, optionally plugin:namespaced)`,
                     );
@@ -107,7 +114,7 @@ export const cmdSkillsClassify = (opts: ClassifyOptions): Effect.Effect<void, Db
                 sessions: r.sessions,
                 path: join(opts.outDir, `classify-${skillNameToSlug(r.name)}.md`),
             }));
-            console.log(JSON.stringify(out, null, 2));
+            console.log(prettyPrint(out));
             return;
         }
 

--- a/src/cli/skills-lint.test.ts
+++ b/src/cli/skills-lint.test.ts
@@ -120,7 +120,7 @@ function makeMockDb(knownSkills: Map<string, string>): {
         },
         upsert: (id: unknown, data: unknown) => {
             state.upserts.push({ id, data });
-            return Effect.succeed(undefined as unknown as never);
+            return Effect.void as Effect.Effect<never>;
         },
     } as unknown as SurrealClientShape;
 

--- a/src/cli/skills-lint.ts
+++ b/src/cli/skills-lint.ts
@@ -12,8 +12,10 @@ import { readdir, readFile, unlink } from "node:fs/promises";
 import { parse as parseYaml } from "yaml";
 import { RecordId, SurrealClient, type SurrealClientShape } from "../lib/db.ts";
 import type { DbError } from "../lib/errors.ts";
+import { prettyPrint } from "../lib/json.ts";
 import { recordLiteral } from "../lib/ids.ts";
 import { validateRoleName, validateSkillName } from "../lib/role-name.ts";
+import { surrealString } from "../lib/shared/surql.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -258,7 +260,7 @@ const applyBrief = (
         let edgesWritten = 0;
         const rationaleSql =
             rationale !== undefined
-                ? `, rationale = ${JSON.stringify(rationale)}`
+                ? `, rationale = ${surrealString(rationale)}`
                 : "";
         for (const roleName of allRoles) {
             const roleId = new RecordId("role", roleName);
@@ -368,7 +370,7 @@ export const cmdSkillsLint = (opts: SkillsLintOptions): Effect.Effect<void, DbEr
         };
 
         if (opts.json) {
-            console.log(JSON.stringify(report, null, 2));
+            console.log(prettyPrint(report));
             return;
         }
 

--- a/src/cli/skills-tag.test.ts
+++ b/src/cli/skills-tag.test.ts
@@ -56,11 +56,11 @@ function buildMockDb(overrides: {
 
         upsert: mock((id: import("surrealdb").RecordId, content: Record<string, unknown>) => {
             calls.push({ type: "upsert", upsertId: id, upsertContent: content });
-            return Effect.succeed(undefined);
+            return Effect.void;
         }) as SurrealClientShape["upsert"],
 
-        relate: mock(() => Effect.succeed(undefined)) as SurrealClientShape["relate"],
-        putFile: mock(() => Effect.succeed(undefined)) as SurrealClientShape["putFile"],
+        relate: mock(() => Effect.void) as SurrealClientShape["relate"],
+        putFile: mock(() => Effect.void) as SurrealClientShape["putFile"],
         getFile: mock(() => Effect.succeed("")) as SurrealClientShape["getFile"],
         raw: {} as SurrealClientShape["raw"],
     };

--- a/src/cli/skills-tag.ts
+++ b/src/cli/skills-tag.ts
@@ -10,6 +10,7 @@ import { RecordId, SurrealClient, type SurrealClientShape } from "../lib/db.ts";
 import type { DbError } from "../lib/errors.ts";
 import { recordLiteral } from "../lib/ids.ts";
 import { validateRoleName, validateSkillName } from "../lib/role-name.ts";
+import { surrealString } from "../lib/shared/surql.ts";
 
 export interface SkillsTagOptions {
     readonly skillName: string;
@@ -18,6 +19,22 @@ export interface SkillsTagOptions {
     readonly rationale: string | undefined;
     readonly remove: boolean;
 }
+
+const safeSkillName = (name: string): string | null => {
+    try {
+        return validateSkillName(name);
+    } catch {
+        return null;
+    }
+};
+
+const safeRoleName = (name: string): string | null => {
+    try {
+        return validateRoleName(name);
+    } catch {
+        return null;
+    }
+};
 
 /**
  * Resolve a skill record key (id part) by name. Returns null if not found.
@@ -52,10 +69,8 @@ export const cmdSkillsTag = (opts: SkillsTagOptions): Effect.Effect<void, DbErro
         const db = yield* SurrealClient;
 
         // 1. Validate inputs
-        let trimmedSkill: string;
-        try {
-            trimmedSkill = validateSkillName(opts.skillName);
-        } catch {
+        const trimmedSkill = safeSkillName(opts.skillName);
+        if (trimmedSkill === null) {
             console.error(
                 `axctl skills tag: invalid skill name "${opts.skillName}" (must be alphanumeric, _ or -, optionally plugin:namespaced)`,
             );
@@ -63,10 +78,8 @@ export const cmdSkillsTag = (opts: SkillsTagOptions): Effect.Effect<void, DbErro
             return; // unreachable; satisfies TypeScript
         }
 
-        let roleName: string;
-        try {
-            roleName = validateRoleName(opts.roleName);
-        } catch {
+        const roleName = safeRoleName(opts.roleName);
+        if (roleName === null) {
             console.error(
                 `axctl skills tag: invalid role name "${opts.roleName}" (must be lowercase alphanumeric, _ or -)`,
             );
@@ -110,7 +123,7 @@ export const cmdSkillsTag = (opts: SkillsTagOptions): Effect.Effect<void, DbErro
 
         // 6. RELATE skill->plays_role->role with source="user"
         const setSql = opts.rationale !== undefined
-            ? `source = "user", confidence = ${opts.confidence}, rationale = ${JSON.stringify(opts.rationale)}, since = time::now()`
+            ? `source = "user", confidence = ${opts.confidence}, rationale = ${surrealString(opts.rationale)}, since = time::now()`
             : `source = "user", confidence = ${opts.confidence}, since = time::now()`;
 
         yield* db.query(

--- a/src/dashboard/recall.commit.test.ts
+++ b/src/dashboard/recall.commit.test.ts
@@ -44,7 +44,7 @@ function makeMockDb(queryResponses: Map<string, unknown[][]> = new Map()) {
             }
             return Effect.succeed([[]] as unknown as T);
         },
-        upsert: () => Effect.succeed(undefined),
+        upsert: () => Effect.void,
         relate: () => Effect.void,
         putFile: () => Effect.void,
         getFile: () => Effect.succeed(""),

--- a/src/dashboard/recall.test.ts
+++ b/src/dashboard/recall.test.ts
@@ -18,7 +18,7 @@ function makeMockDb(queryResponses: Map<string, unknown[][]> = new Map()) {
             }
             return Effect.succeed([[]] as unknown as T);
         },
-        upsert: () => Effect.succeed(undefined),
+        upsert: () => Effect.void,
         relate: () => Effect.void,
         putFile: () => Effect.void,
         getFile: () => Effect.succeed(""),

--- a/src/dashboard/session-inspect.ts
+++ b/src/dashboard/session-inspect.ts
@@ -7,10 +7,11 @@
  */
 
 import { readFile } from "node:fs/promises";
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import { dissectTurn, type TurnSpan } from "../ingest/turn-dissect.ts";
 import { SurrealClient } from "../lib/db.ts";
-import { locateTranscript } from "../lib/transcript-locator.ts";
+import { decodeJsonRecordOrNull, encodeJson } from "../lib/decode.ts";
+import { locateTranscript, type TranscriptNotFoundError } from "../lib/transcript-locator.ts";
 import type {
     HookFireDto,
     InspectSpanDto,
@@ -28,6 +29,12 @@ import { clampPagination, type PaginationConfig } from "../lib/shared/pagination
 import { toBareSessionId } from "../lib/shared/session-id.ts";
 
 const INSPECT_TURNS_PAGINATION: PaginationConfig = { defaultLimit: 2000, maxLimit: 2000 };
+
+export class SessionInspectReadError extends Data.TaggedError("SessionInspectReadError")<{
+    readonly path: string;
+    readonly message: string;
+    readonly cause: unknown;
+}> {}
 
 interface JsonlContentBlock {
     type: string;
@@ -61,7 +68,7 @@ function blockToText(block: JsonlContentBlock): string {
     }
     if (block.type === "tool_use") {
         const name = block.name ? ` name="${block.name.replace(/"/g, "")}"` : "";
-        const input = JSON.stringify(block.input ?? {});
+        const input = encodeJson(block.input ?? {});
         const clipped = input.length > 400 ? `${input.slice(0, 400)}...` : input;
         return `<tool_use${name}>${clipped}</tool_use>`;
     }
@@ -90,8 +97,8 @@ interface CanonicalTurn {
 }
 
 function parseClaudeLine(line: string): CanonicalTurn | null {
-    let entry: JsonlMessage;
-    try { entry = JSON.parse(line); } catch { return null; }
+    const entry = decodeJsonRecordOrNull(line) as JsonlMessage | null;
+    if (entry === null) return null;
     if (entry.type !== "user" && entry.type !== "assistant") return null;
     const content = entry.message?.content;
     const text = typeof content === "string"
@@ -121,8 +128,8 @@ interface CodexLine {
 }
 
 function parseCodexLine(line: string): CanonicalTurn | null {
-    let entry: CodexLine;
-    try { entry = JSON.parse(line); } catch { return null; }
+    const entry = decodeJsonRecordOrNull(line) as CodexLine | null;
+    if (entry === null) return null;
     const p = entry.payload;
     if (!p) return null;
     if (p.type === "message") {
@@ -144,7 +151,7 @@ function parseCodexLine(line: string): CanonicalTurn | null {
         };
     }
     if (p.type === "function_call_output") {
-        const out = typeof p.output === "string" ? p.output : JSON.stringify(p.output ?? {});
+        const out = typeof p.output === "string" ? p.output : encodeJson(p.output ?? {});
         return {
             role: "user",
             text: `<local-command-stdout>${out}</local-command-stdout>`,
@@ -277,7 +284,9 @@ function parseSpawnArgs(provider: "codex" | "claude", name: string, argsJson: un
     if (!SPAWN_TOOLS.has(name)) return null;
     let args: Record<string, unknown> = {};
     if (typeof argsJson === "string") {
-        try { args = JSON.parse(argsJson) as Record<string, unknown>; } catch { return null; }
+        const parsed = decodeJsonRecordOrNull(argsJson);
+        if (parsed === null) return null;
+        args = parsed;
     } else if (argsJson && typeof argsJson === "object") {
         args = argsJson as Record<string, unknown>;
     }
@@ -370,7 +379,7 @@ export interface FetchSessionInspectOptions {
 export const fetchSessionInspect = (
     sessionId: string,
     opts: FetchSessionInspectOptions = {},
-): Effect.Effect<SessionInspectPayload, Error, SurrealClient> =>
+): Effect.Effect<SessionInspectPayload, SessionInspectReadError | TranscriptNotFoundError, SurrealClient> =>
     Effect.gen(function* () {
         // Normalise inbound id at the seam so the rest of the function operates
         // on a bare id (also what we echo back as payload.session_id).
@@ -431,8 +440,8 @@ export const fetchSessionInspect = (
             for (const line of raw.split("\n")) {
                 if (!line.trim()) continue;
                 if (!line.includes("spawn_agent") && !line.includes("\"Task\"")) continue;
-                let entry: { timestamp?: string; payload?: { type?: string; name?: string; arguments?: string; call_id?: string }; message?: { content?: Array<{ type?: string; name?: string; input?: unknown; id?: string }> } };
-                try { entry = JSON.parse(line); } catch { continue; }
+                const entry = decodeJsonRecordOrNull(line) as { timestamp?: string; payload?: { type?: string; name?: string; arguments?: string; call_id?: string }; message?: { content?: Array<{ type?: string; name?: string; input?: unknown; id?: string }> } } | null;
+                if (entry === null) continue;
                 if (provider === "codex") {
                     const p = entry.payload;
                     if (!p || p.type !== "function_call") continue;
@@ -528,7 +537,12 @@ export const fetchSessionInspect = (
                 total_hook_fires: allHookFires.length,
             };
         },
-        catch: (err) => err instanceof Error ? err : new Error(String(err)),
+        catch: (err) =>
+            new SessionInspectReadError({
+                path: found.path,
+                message: err instanceof Error ? err.message : String(err),
+                cause: err,
+            }),
     });
         return payload;
     });

--- a/src/dashboard/sessions-query.test.ts
+++ b/src/dashboard/sessions-query.test.ts
@@ -37,9 +37,9 @@ function makeMockDb(opts?: {
             }
             return Effect.succeed([[]] as unknown as T);
         },
-        upsert: (_id: RecordId, _content: Record<string, unknown>) => Effect.succeed(undefined),
-        relate: () => Effect.succeed(undefined),
-        putFile: () => Effect.succeed(undefined),
+        upsert: (_id: RecordId, _content: Record<string, unknown>) => Effect.void,
+        relate: () => Effect.void,
+        putFile: () => Effect.void,
         getFile: () => Effect.succeed(""),
         raw: undefined as unknown as import("surrealdb").Surreal,
     };

--- a/src/hooks/telemetry.test.ts
+++ b/src/hooks/telemetry.test.ts
@@ -19,7 +19,7 @@ function fakeClient(): { client: SurrealClientShape; statements: string[] } {
             statements.push(sql);
             return Effect.succeed([] as unknown as T);
         },
-        upsert: () => Effect.succeed(undefined),
+        upsert: () => Effect.void,
         relate: () => Effect.void,
         putFile: () => Effect.void,
         getFile: () => Effect.succeed(""),
@@ -177,7 +177,7 @@ describe("recordHookFire", () => {
         const failing: SurrealClientShape = {
             query: () =>
                 Effect.fail(new DbError({ operation: "query", message: "db is down" })),
-            upsert: () => Effect.succeed(undefined),
+            upsert: () => Effect.void,
             relate: () => Effect.void,
             putFile: () => Effect.void,
             getFile: () => Effect.succeed(""),

--- a/src/improve/lint.ts
+++ b/src/improve/lint.ts
@@ -62,6 +62,23 @@ export const defaultRoots = (): string[] => [
     join(homedir(), ".claude"),
 ];
 
+const deleteFileIfPresent = (path: string): boolean => {
+    try {
+        unlinkSync(path);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const statMtimeMsOrNull = (path: string): number | null => {
+    try {
+        return statSync(path).mtimeMs;
+    } catch {
+        return null;
+    }
+};
+
 export const discoverFiles = (opts: DiscoverOptions = {}): LintTarget[] => {
     const roots = opts.roots ?? defaultRoots();
     const out: LintTarget[] = [];
@@ -336,16 +353,16 @@ export const lintFiles = (
                 for (const p of pending) {
                     let taskDeleted: string | null = null;
                     if (p.taskPath) {
-                        try {
-                            unlinkSync(p.taskPath);
-                            taskDeleted = p.taskPath;
-                        } catch {
+                        const deleted = deleteFileIfPresent(p.taskPath);
+                        if (!deleted) {
                             warnings.push({
                                 rule: "task_cleanup_failed",
                                 severity: "warning",
                                 path: p.taskPath,
                                 message: `failed to delete task file ${p.taskPath} after DB update`,
                             });
+                        } else {
+                            taskDeleted = p.taskPath;
                         }
                     }
                     reconciled.push({
@@ -384,9 +401,8 @@ export const lintFiles = (
             // JS-side mtime cross-check: the task file may have been touched
             // (e.g. by the agent) after the experiment was created, so we still
             // verify the file is actually old before emitting the warning.
-            let mtime: number;
-            try { mtime = statSync(row.task_path).mtimeMs; }
-            catch { continue; }
+            const mtime = statMtimeMsOrNull(row.task_path);
+            if (mtime === null) continue;
             const staleCutoffMs = Date.now() - staleDays * 86_400_000;
             if (mtime < staleCutoffMs) {
                 warnings.push({

--- a/src/ingest/derive-claude-subagents.test.ts
+++ b/src/ingest/derive-claude-subagents.test.ts
@@ -47,7 +47,7 @@ function makeMockDb(queryResponses: Map<string, unknown[][]> = new Map()) {
         },
         upsert: (id: RecordId, content: Record<string, unknown>) => {
             calls.push({ kind: "upsert", id: String(id), content });
-            return Effect.succeed(undefined);
+            return Effect.void;
         },
         relate: () => Effect.void,
         putFile: () => Effect.void,

--- a/src/ingest/retro.ts
+++ b/src/ingest/retro.ts
@@ -28,6 +28,7 @@
 
 import { Effect } from "effect";
 import { SurrealClient } from "../lib/db.ts";
+import { encodeJson } from "../lib/decode.ts";
 import type { DbError } from "../lib/errors.ts";
 import { recordRef, surrealDate, surrealJsonOption, surrealObject, surrealOptionString, surrealString } from "../lib/shared/surql.ts";
 import { recordKeyPart, safeKeyPart } from "../lib/shared/derive-keys.ts";
@@ -168,7 +169,7 @@ export const retroFromSession = (
             sessionId: sessionKey,
             source: "heuristic",
             payload,
-            raw: JSON.stringify({ stat }),
+            raw: encodeJson({ stat }),
             ...(repositoryKey ? { repositoryKey } : {}),
         };
     });

--- a/src/ingest/skill-role.test.ts
+++ b/src/ingest/skill-role.test.ts
@@ -29,7 +29,7 @@ function makeMockDb() {
         },
         upsert: (id: RecordId, content: Record<string, unknown>) => {
             calls.push({ kind: "upsert", id, content });
-            return Effect.succeed(undefined);
+            return Effect.void;
         },
         relate: () => Effect.void,
         putFile: () => Effect.void,

--- a/src/ingest/skill-role.ts
+++ b/src/ingest/skill-role.ts
@@ -5,6 +5,14 @@ import type { DbError } from "../lib/errors.ts";
 import { recordLiteral } from "../lib/ids.ts";
 import { validateRoleName } from "../lib/role-name.ts";
 
+const safeRoleName = (name: string): string | null => {
+    try {
+        return validateRoleName(name);
+    } catch {
+        return null;
+    }
+};
+
 export const relateSkillRoles = (
     db: SurrealClientShape,
     args: { skillId: RecordId; roles: ReadonlyArray<string> },
@@ -14,10 +22,8 @@ export const relateSkillRoles = (
         const cleaned: string[] = [];
         let rolesSkipped = 0;
         for (const r of args.roles) {
-            let norm: string;
-            try {
-                norm = validateRoleName(r);
-            } catch {
+            const norm = safeRoleName(r);
+            if (norm === null) {
                 // Invalid role name (e.g. contains backtick, semicolon, or
                 // doesn't match the allowed pattern). Skip rather than crash
                 // the whole stage - the caller accumulates the skip count.

--- a/src/ingest/skills.test.ts
+++ b/src/ingest/skills.test.ts
@@ -55,7 +55,7 @@ function makeMockDb(queryResponses: Map<string, unknown[][]> = new Map()) {
         },
         upsert: (id: RecordId, content: Record<string, unknown>) => {
             calls.push({ kind: "upsert", id, content });
-            return Effect.succeed(undefined);
+            return Effect.void;
         },
         relate: () => Effect.void,
         putFile: () => Effect.void,

--- a/src/lib/decode.ts
+++ b/src/lib/decode.ts
@@ -45,3 +45,6 @@ export const encodeJsonOrNull = (input: unknown): string | null => {
     const result = encodeJsonString(input);
     return Option.isSome(result) ? result.value : null;
 };
+
+export const encodeJson = (input: unknown): string =>
+    encodeJsonOrNull(input) ?? "null";

--- a/src/lib/live-traces/Schema.ts
+++ b/src/lib/live-traces/Schema.ts
@@ -19,16 +19,14 @@ export const TraceScopeSchema = Schema.Struct({
 // Events
 // ============================================================================
 
-export const TraceStartSchema = Schema.Struct({
-    _tag: Schema.Literal("TraceStart"),
+export const TraceStartSchema = Schema.TaggedStruct("TraceStart", {
     traceId: Schema.String,
     label: Schema.String,
     scope: TraceScopeSchema,
     timestamp: Schema.Number,
 });
 
-export const SpanStartSchema = Schema.Struct({
-    _tag: Schema.Literal("SpanStart"),
+export const SpanStartSchema = Schema.TaggedStruct("SpanStart", {
     traceId: Schema.String,
     spanId: Schema.String,
     parentSpanId: Schema.optional(Schema.String),
@@ -37,8 +35,7 @@ export const SpanStartSchema = Schema.Struct({
     timestamp: Schema.Number,
 });
 
-export const SpanEndSchema = Schema.Struct({
-    _tag: Schema.Literal("SpanEnd"),
+export const SpanEndSchema = Schema.TaggedStruct("SpanEnd", {
     traceId: Schema.String,
     spanId: Schema.String,
     status: Schema.Union([Schema.Literal("ok"), Schema.Literal("error")]),
@@ -46,8 +43,7 @@ export const SpanEndSchema = Schema.Struct({
     timestamp: Schema.Number,
 });
 
-export const SpanEventSchema = Schema.Struct({
-    _tag: Schema.Literal("SpanEvent"),
+export const SpanEventSchema = Schema.TaggedStruct("SpanEvent", {
     traceId: Schema.String,
     spanId: Schema.String,
     name: Schema.String,
@@ -56,8 +52,7 @@ export const SpanEventSchema = Schema.Struct({
     timestamp: Schema.Number,
 });
 
-export const TraceEndSchema = Schema.Struct({
-    _tag: Schema.Literal("TraceEnd"),
+export const TraceEndSchema = Schema.TaggedStruct("TraceEnd", {
     traceId: Schema.String,
     status: Schema.Union([Schema.Literal("completed"), Schema.Literal("failed")]),
     durationMs: Schema.Number,

--- a/src/lib/live-traces/__tests__/Sink.test.ts
+++ b/src/lib/live-traces/__tests__/Sink.test.ts
@@ -19,6 +19,10 @@ describe("TraceSink", () => {
                 }),
         };
         const Transport = Layer.succeed(TraceTransportTag, TestTransport);
+        const TestLayer = TraceSinkLive({ flushIntervalMs: 200 }).pipe(
+            Layer.provide(Transport),
+            Layer.merge(TestClock.layer()),
+        );
 
         const program = Effect.gen(function* () {
             const sink = yield* TraceSink;
@@ -34,9 +38,7 @@ describe("TraceSink", () => {
 
         await Effect.runPromise(
             program.pipe(
-                Effect.provide(TraceSinkLive({ flushIntervalMs: 200 })),
-                Effect.provide(Transport),
-                Effect.provide(TestClock.layer()),
+                Effect.provide(TestLayer),
                 Effect.scoped,
             ) as Effect.Effect<void, never, never>,
         );

--- a/src/lib/live-traces/transports/console.ts
+++ b/src/lib/live-traces/transports/console.ts
@@ -1,4 +1,5 @@
 import { Effect, Layer } from "effect";
+import { encodeJson } from "../../decode.ts";
 import { TraceTransportTag, type TraceTransport } from "../Sink.ts";
 
 /**
@@ -16,7 +17,7 @@ export const ConsoleTransport: TraceTransport = {
     send: (events) =>
         Effect.sync(() => {
             for (const event of events) {
-                process.stderr.write(`[live-trace] ${event._tag} ${JSON.stringify(event)}\n`);
+                process.stderr.write(`[live-trace] ${event._tag} ${encodeJson(event)}\n`);
             }
         }),
 };

--- a/src/lib/pwd.test.ts
+++ b/src/lib/pwd.test.ts
@@ -77,9 +77,9 @@ function makeMockDb(existsResponse: boolean) {
             const rows = existsResponse ? [{ id: "repository:somekey" }] : [];
             return Effect.succeed([[...rows]] as unknown as T);
         },
-        upsert: (_id: RecordId, _content: Record<string, unknown>) => Effect.succeed(undefined),
-        relate: () => Effect.succeed(undefined),
-        putFile: () => Effect.succeed(undefined),
+        upsert: (_id: RecordId, _content: Record<string, unknown>) => Effect.void,
+        relate: () => Effect.void,
+        putFile: () => Effect.void,
         getFile: () => Effect.succeed(""),
         raw: undefined as unknown as import("surrealdb").Surreal,
     };

--- a/src/lib/shared/statement-exec.test.ts
+++ b/src/lib/shared/statement-exec.test.ts
@@ -11,9 +11,9 @@ const recordingClient = (): { calls: string[]; layer: SurrealClientShape } => {
             calls.push(sql);
             return Effect.succeed([] as unknown as T);
         },
-        upsert: () => Effect.succeed(undefined),
-        relate: () => Effect.succeed(undefined),
-        putFile: () => Effect.succeed(undefined),
+        upsert: () => Effect.void,
+        relate: () => Effect.void,
+        putFile: () => Effect.void,
         getFile: () => Effect.succeed(""),
         raw: {} as never,
     } satisfies SurrealClientShape;

--- a/src/lib/transcript-staleness.test.ts
+++ b/src/lib/transcript-staleness.test.ts
@@ -17,9 +17,9 @@ const makeMockDb = (
             captured.push({ sql, bindings });
             return Effect.succeed([seenRows] as never);
         },
-        upsert: () => Effect.succeed(undefined),
-        relate: () => Effect.succeed(undefined),
-        putFile: () => Effect.succeed(undefined),
+        upsert: () => Effect.void,
+        relate: () => Effect.void,
+        putFile: () => Effect.void,
         getFile: () => Effect.succeed(""),
         raw: undefined as never,
     };


### PR DESCRIPTION
## Summary
- clear Effect language-service advisories from typecheck output
- route JSON parsing/encoding through existing Effect Schema helpers where it is a data boundary
- simplify small Effect generators, use async Effect constructors for promises, compose live-trace test layers, and use tagged trace schemas

## Verification
- bun run typecheck
- bun test
- bun run build
- bun run dashboard:build
- bun run check:cli-reference
- bun run check:table-coverage
- bash -n install.sh