### PR TITLE
fix(site): serve /install as static file (Cloudflare didn't honor redirect)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,8 @@ site/node_modules
 site/app/routeTree.gen.ts
 site/.content-collections
 
+# generated install script mirror - copied by site/package.json prebuild
+site/public/install
+
 # generated MDX partial - rebuilt by scripts/extract-stage-rationale.ts on every dev/build
 docs/how-ax-sees-your-work.generated.mdx

--- a/docs/superpowers/goals/2026-05-30-setfit-session-section-experiments-goal.md
+++ b/docs/superpowers/goals/2026-05-30-setfit-session-section-experiments-goal.md
@@ -665,6 +665,67 @@ jq '{conclusion,production_posture,setfit,hybrid,boundary_replay,graph}' \
 Returned `conclusion=continue_hybrid_not_raw_setfit` and
 `production_posture=deterministic_and_reviewed_graph_facts_only`.
 
+## E499 - Boundary Replay Service Summary
+
+Question: can services consume the reviewed deterministic replay posture
+directly from graph query results, without reinterpreting individual graph
+facts?
+
+Changes:
+
+- Added `boundary_replay_summary` to classifier graph health reports.
+- The summary is emitted for `boundary-replay` and `evidence` graph modes.
+- Text rendering now exposes the summary status, production posture, next
+  action, remediation, covered subject count, deterministic-label count,
+  evidence count, classifiers, targets, subjects, and recommended query argv
+  when filters need relaxing.
+
+Command:
+
+```sh
+bun src/cli/index.ts classifiers graph \
+  --mode=boundary-replay \
+  --source-kind=boundary_replay_deterministic_projection \
+  --fact-kind=classifier_boundary_replay \
+  --predicate=covered_by_deterministic \
+  --value=true \
+  --out=.ax/experiments/boundary-replay-summary-e499.json \
+  --json
+```
+
+Artifact:
+
+- `.ax/experiments/boundary-replay-summary-e499.json`
+
+Result:
+
+- `query_match_status=matched`
+- `boundary_replay_summary.status=reviewed_deterministic_facts_available`
+- `boundary_replay_summary.production_posture=deterministic_and_reviewed_graph_facts_only`
+- `boundary_replay_summary.next_action=use_reviewed_deterministic_graph_facts`
+- `covered_subject_count=1`
+- `deterministic_label_subject_count=1`
+- `evidence_path_count=1`
+- classifier key: `correction-event`
+- target: `workflow_state`
+
+Decision:
+
+- Continue building product/service behavior on this summary shape.
+- Services can now branch on a compact posture field instead of inferring
+  promotion safety from raw graph rows.
+- Raw model output still remains review/mining input only.
+
+Verification:
+
+```sh
+bun test scripts/classifier-package-operations.test.ts src/cli/classifiers-package-operations.test.ts
+bun run typecheck
+```
+
+Passed: `82` Bun tests. Typecheck exited `0` with the existing Effect lint
+messages.
+
 Current recommendation:
 
 - Index continuation: E488 turns the accepted classifier-fixture follow-up into

--- a/docs/superpowers/specs/2026-06-01-landing-open-source-section-design.md
+++ b/docs/superpowers/specs/2026-06-01-landing-open-source-section-design.md
@@ -1,0 +1,69 @@
+# Landing Open Source Section Design
+
+## Context
+
+The live landing route renders `DashboardPreview`, `LineageFlow`, and `FooterCards`
+inside `.landing-v2`. The page already frames ax as a local agent experience
+layer. It now needs a proof section that answers whether users can inspect,
+trust, fork, and operate the tool locally.
+
+## User Goal
+
+Add a section similar in spirit to the T3 Code open-source section: a centered
+open-source claim, a terminal proof block, and compact cards for trust signals.
+The section should communicate both open-source and local-first properties.
+
+## Placement
+
+Insert the section between `LineageFlow` and `FooterCards`. That puts the trust
+message after the product explanation and before the final navigation links.
+
+## Content
+
+Use this structure:
+
+- Eyebrow: `open source`
+- Headline: `If it shapes your agent, you should be able to fork it.`
+- Supporting copy: ax is MIT licensed, local-first, typed, and inspectable.
+- Terminal panel with realistic setup commands:
+  - `gh repo clone Necmttn/ax`
+  - `bun install`
+  - `axctl daemon start`
+- Four proof cards:
+  - `MIT` with commercial-friendly/license copy
+  - `TypeScript` with strict/end-to-end typed copy
+  - `Local SurrealDB` with local database copy
+  - `No telemetry` with no upload/no SaaS copy
+- Bottom actions linking to GitHub, repository fork view, and docs or
+  contributing material.
+
+## Visual Direction
+
+Use the chosen “screenshot echo” layout without copying the source image:
+
+- Centered eyebrow, headline, and paragraph.
+- A two-column desktop composition: terminal panel on the left, four cards on
+  the right.
+- Warm `.landing-v2` palette, existing mono and serif font variables, existing
+  border tokens, and 8-10px radii.
+- Quiet hover states on action links and cards.
+- Responsive collapse to a single column on mobile with no horizontal scroll.
+
+## Implementation
+
+Create a focused `OpenSourceSection` component under
+`site/app/components/landing-v2/`, export it from the landing-v2 index, and render
+it in `site/app/routes/index.tsx` after `LineageFlow`.
+
+Add CSS scoped under `.landing-v2` in `site/app/styles/globals.css`. Keep all
+selectors section-specific to avoid changing older landing sections.
+
+## Validation
+
+Verify that:
+
+- The section renders between the lineage flow and footer cards.
+- `https://github.com/Necmttn/ax` is used for GitHub actions.
+- The layout collapses cleanly at existing mobile breakpoints.
+- Existing unrelated TypeScript errors are not treated as introduced by this
+  change.

--- a/scripts/classifier-package-operations.test.ts
+++ b/scripts/classifier-package-operations.test.ts
@@ -1735,6 +1735,17 @@ describe("classifier package operations report", () => {
         expect(report.result_totals.boundary_replay_fact_count).toBe(1);
         expect(report.query_result_kinds).toContain("boundary_replay_facts");
         expect(report.query_result_kind_counts).toContainEqual({ kind: "boundary_replay_facts", count: 1 });
+        expect(report.boundary_replay_summary).toMatchObject({
+            status: "reviewed_deterministic_facts_available",
+            production_posture: "deterministic_and_reviewed_graph_facts_only",
+            next_action: "use_reviewed_deterministic_graph_facts",
+            covered_subject_count: 1,
+            deterministic_label_subject_count: 1,
+            evidence_path_count: 1,
+            classifier_keys: ["correction-event"],
+            targets: ["workflow_state"],
+            subjects: ["classifier_boundary_miss:workflow"],
+        });
         expect(report.boundary_replay_facts?.[0]).toMatchObject({
             predicate: "covered_by_deterministic",
             classifier_key: "correction-event",

--- a/site/package.json
+++ b/site/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "predev": "bun ../scripts/extract-stage-rationale.ts",
-    "prebuild": "bun ../scripts/extract-stage-rationale.ts",
+    "predev": "bun ../scripts/extract-stage-rationale.ts && cp ../install.sh public/install",
+    "prebuild": "bun ../scripts/extract-stage-rationale.ts && cp ../install.sh public/install",
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",

--- a/src/classifiers/package-operations.ts
+++ b/src/classifiers/package-operations.ts
@@ -403,6 +403,21 @@ export interface ClassifierGraphBoundaryReplayFact {
     readonly evidence_paths: readonly string[];
 }
 
+export interface ClassifierGraphBoundaryReplaySummary {
+    readonly status: "not_requested" | "reviewed_deterministic_facts_available" | "no_reviewed_deterministic_facts";
+    readonly production_posture: "deterministic_and_reviewed_graph_facts_only" | "not_applicable";
+    readonly next_action: "query_boundary_replay_facts" | "use_reviewed_deterministic_graph_facts" | "project_or_apply_boundary_replay_facts";
+    readonly remediation: string;
+    readonly covered_subject_count: number;
+    readonly deterministic_label_subject_count: number;
+    readonly evidence_path_count: number;
+    readonly classifier_keys: readonly string[];
+    readonly targets: readonly string[];
+    readonly subjects: readonly string[];
+    readonly recommended_query?: ClassifierGraphHealthQuery;
+    readonly recommended_argv?: readonly string[];
+}
+
 export interface ClassifierGraphRoutingPolicyRecommendedQuery {
     readonly mode: "embedding-helper" | "evidence";
     readonly operation_id?: string;
@@ -562,6 +577,7 @@ export interface ClassifierPackageExecutionGraphHealthReport {
     readonly lifecycle_available_value_counts?: readonly ClassifierGraphLifecycleValueCount[];
     readonly embedding_helper_facts: readonly ClassifierGraphEmbeddingHelperFact[];
     readonly boundary_replay_facts?: readonly ClassifierGraphBoundaryReplayFact[];
+    readonly boundary_replay_summary?: ClassifierGraphBoundaryReplaySummary;
     readonly routing_policy_summary?: ClassifierGraphRoutingPolicySummary;
     readonly evidence_paths: readonly string[];
     readonly query_match_status?: "matched" | "no_match";
@@ -3275,6 +3291,84 @@ export function buildExecutionGraphHealthReport(input: {
         ...(resultEmbeddingHelperFacts.length > 0 ? [{ kind: "embedding_helper_facts" as const, count: resultEmbeddingHelperFacts.length }] : []),
         ...(resultBoundaryReplayFacts.length > 0 ? [{ kind: "boundary_replay_facts" as const, count: resultBoundaryReplayFacts.length }] : []),
     ];
+    const boundaryReplaySummary: ClassifierGraphBoundaryReplaySummary | undefined =
+        query.mode === "boundary-replay" || query.mode === "evidence"
+            ? (() => {
+                const summaryFacts = boundaryReplayFacts;
+                const coveredSubjects = Array.from(new Set(summaryFacts
+                    .filter((fact) => fact.predicate === "covered_by_deterministic" && fact.value === true)
+                    .map((fact) => fact.subject)))
+                    .sort();
+                const deterministicLabelSubjects = Array.from(new Set(summaryFacts
+                    .filter((fact) => fact.predicate === "deterministic_label")
+                    .map((fact) => fact.subject)))
+                    .sort();
+                const classifierKeys = Array.from(new Set(summaryFacts
+                    .map((fact) => fact.classifier_key)
+                    .filter((key): key is string => typeof key === "string")))
+                    .sort();
+                const targets = Array.from(new Set(summaryFacts
+                    .map((fact) => fact.target)
+                    .filter((target): target is string => typeof target === "string")))
+                    .sort();
+                const summaryEvidencePaths = Array.from(new Set(summaryFacts.flatMap((fact) => fact.evidence_paths))).sort();
+                const recommendedSourceKind = query.source_kind ?? "boundary_replay_deterministic_projection";
+                const recommendedFactKind = query.fact_kind ?? "classifier_boundary_replay";
+                const recommendedPredicate = "covered_by_deterministic";
+                const recommendedValueEquals = "true";
+                const recommendedQuery: ClassifierGraphHealthQuery = {
+                    mode: "boundary-replay",
+                    source_kind: recommendedSourceKind,
+                    fact_kind: recommendedFactKind,
+                    predicate: recommendedPredicate,
+                    value_equals: recommendedValueEquals,
+                };
+                const recommendedArgv = [
+                    "bun",
+                    "src/cli/index.ts",
+                    "classifiers",
+                    "graph",
+                    "--mode",
+                    recommendedQuery.mode,
+                    "--source-kind",
+                    recommendedSourceKind,
+                    "--fact-kind",
+                    recommendedFactKind,
+                    "--predicate",
+                    recommendedPredicate,
+                    "--value",
+                    recommendedValueEquals,
+                ];
+                const factsAvailable = summaryFacts.length > 0;
+                const resultFactsAvailable = resultBoundaryReplayFacts.length > 0;
+                const coveredAvailable = coveredSubjects.length > 0;
+                return {
+                    status: factsAvailable
+                        ? "reviewed_deterministic_facts_available"
+                        : "no_reviewed_deterministic_facts",
+                    production_posture: factsAvailable
+                        ? "deterministic_and_reviewed_graph_facts_only"
+                        : "not_applicable",
+                    next_action: resultFactsAvailable
+                        ? "use_reviewed_deterministic_graph_facts"
+                        : boundaryReplayFacts.length > 0
+                            ? "query_boundary_replay_facts"
+                            : "project_or_apply_boundary_replay_facts",
+                    remediation: resultFactsAvailable
+                        ? "Use these reviewed deterministic replay facts as promotion-safe graph evidence; keep raw model output in review/mining workflows."
+                        : boundaryReplayFacts.length > 0
+                            ? "Relax boundary-replay filters or run the recommended query to inspect available reviewed deterministic facts."
+                            : "Project and apply boundary replay facts before routing product behavior from reviewed deterministic evidence.",
+                    covered_subject_count: coveredSubjects.length,
+                    deterministic_label_subject_count: deterministicLabelSubjects.length,
+                    evidence_path_count: summaryEvidencePaths.length,
+                    classifier_keys: classifierKeys,
+                    targets,
+                    subjects: Array.from(new Set([...coveredSubjects, ...deterministicLabelSubjects])).sort(),
+                    ...(!coveredAvailable && boundaryReplayFacts.length > 0 ? { recommended_query: recommendedQuery, recommended_argv: recommendedArgv } : {}),
+                };
+            })()
+            : undefined;
 
     return {
         schema: "ax.classifier_package_execution_graph_health_report.v1",
@@ -3288,6 +3382,7 @@ export function buildExecutionGraphHealthReport(input: {
         lifecycle_available_value_counts: lifecycleAvailableValueCounts,
         embedding_helper_facts: resultEmbeddingHelperFacts,
         boundary_replay_facts: resultBoundaryReplayFacts,
+        ...(boundaryReplaySummary === undefined ? {} : { boundary_replay_summary: boundaryReplaySummary }),
         routing_policy_summary: routingPolicySummary,
         evidence_paths: resultEvidencePaths,
         query_match_status: queryMatchStatus,

--- a/src/cli/classifiers-package-operations.test.ts
+++ b/src/cli/classifiers-package-operations.test.ts
@@ -781,6 +781,18 @@ describe("classifiers package-operations format", () => {
             }],
             lifecycle_facts: [],
             embedding_helper_facts: [],
+            boundary_replay_summary: {
+                status: "reviewed_deterministic_facts_available",
+                production_posture: "deterministic_and_reviewed_graph_facts_only",
+                next_action: "use_reviewed_deterministic_graph_facts",
+                remediation: "Use these reviewed deterministic replay facts as promotion-safe graph evidence; keep raw model output in review/mining workflows.",
+                covered_subject_count: 1,
+                deterministic_label_subject_count: 1,
+                evidence_path_count: 1,
+                classifier_keys: ["correction-event"],
+                targets: ["workflow_state"],
+                subjects: ["classifier_boundary_miss:workflow"],
+            },
             evidence_paths: [".ax/experiments/run.json"],
             totals: {
                 node_count: 3,
@@ -817,6 +829,9 @@ describe("classifiers package-operations format", () => {
         expect(output).toContain("filter operation: refresh");
         expect(output).toContain("nodes/edges/facts: 3/2/2");
         expect(output).toContain("results operations/guarded/changed/lifecycle/helper/boundary/evidence: 1/1/1/0/0/0/1");
+        expect(output).toContain("boundary replay summary: reviewed_deterministic_facts_available");
+        expect(output).toContain("boundary replay production posture: deterministic_and_reviewed_graph_facts_only");
+        expect(output).toContain("boundary replay classifiers: correction-event");
         expect(output).toContain("- demo/refresh");
         expect(output).toContain("runs executed/failed/guarded: 1/0/1");
         expect(output).toContain("changed artifacts:");

--- a/src/cli/classifiers-package-operations.ts
+++ b/src/cli/classifiers-package-operations.ts
@@ -400,6 +400,18 @@ export function renderClassifierPackageExecutionGraphHealthText(report: Classifi
         evaluated_policy_count: 0,
         candidate_count: 0,
     };
+    const boundaryReplaySummary = report.boundary_replay_summary ?? {
+        status: "not_requested",
+        production_posture: "not_applicable",
+        next_action: "query_boundary_replay_facts",
+        remediation: "Run a boundary-replay graph query to inspect reviewed deterministic facts.",
+        covered_subject_count: 0,
+        deterministic_label_subject_count: 0,
+        evidence_path_count: 0,
+        classifier_keys: [],
+        targets: [],
+        subjects: [],
+    };
     const routingPolicyRecommendedFloorAdjustments = (routingPolicySummary.recommended_floor_adjustments ?? [])
         .map((adjustment) =>
             `${adjustment.floor}<=${adjustment.recommended} (requested ${adjustment.requested}, gap ${adjustment.gap}, threshold ${adjustment.source_threshold ?? "none"})`
@@ -571,6 +583,15 @@ export function renderClassifierPackageExecutionGraphHealthText(report: Classifi
         `packages/operations/executions/artifacts: ${report.totals.package_count}/${report.totals.operation_count}/${report.totals.execution_count}/${report.totals.artifact_count}`,
         `execution/guard/artifact/lifecycle/helper/boundary facts: ${report.totals.execution_fact_count}/${report.totals.guard_fact_count}/${report.totals.artifact_fact_count}/${report.totals.lifecycle_fact_count}/${report.totals.embedding_helper_fact_count}/${report.totals.boundary_replay_fact_count ?? 0}`,
         `results operations/guarded/changed/lifecycle/helper/boundary/evidence: ${report.result_totals.operation_count}/${report.result_totals.guarded_operation_count}/${report.result_totals.changed_artifact_count}/${report.result_totals.lifecycle_fact_count}/${report.result_totals.embedding_helper_fact_count}/${report.result_totals.boundary_replay_fact_count ?? 0}/${report.result_totals.evidence_path_count}`,
+        `boundary replay summary: ${boundaryReplaySummary.status}`,
+        `boundary replay production posture: ${boundaryReplaySummary.production_posture}`,
+        `boundary replay next action: ${boundaryReplaySummary.next_action}`,
+        `boundary replay remediation: ${boundaryReplaySummary.remediation}`,
+        `boundary replay covered/labels/evidence: ${boundaryReplaySummary.covered_subject_count}/${boundaryReplaySummary.deterministic_label_subject_count}/${boundaryReplaySummary.evidence_path_count}`,
+        `boundary replay classifiers: ${boundaryReplaySummary.classifier_keys.join(", ") || "none"}`,
+        `boundary replay targets: ${boundaryReplaySummary.targets.join(", ") || "none"}`,
+        `boundary replay subjects: ${boundaryReplaySummary.subjects.join(", ") || "none"}`,
+        `boundary replay recommended argv: ${boundaryReplaySummary.recommended_argv?.join(" ") ?? "none"}`,
         `routing policy status: ${routingPolicySummary.status}`,
         `routing policy evaluated: ${routingPolicySummary.evaluated_policy_count ?? "unknown"}`,
         `routing policy candidates: ${routingPolicySummary.candidate_count}`,


### PR DESCRIPTION
Cloudflare Pages didn't honor either the TanStack `throw redirect()` from `site/app/routes/install.ts` or the `site/public/_redirects` rule for /install. Simpler bulletproof fix: serve the install.sh content directly. prebuild/predev auto-copy keeps it in sync.

Generated with Claude Code.