### PR TITLE
feat(site): open-source section redesign + AGPL-3.0 relicense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ site/.content-collections
 
 # generated MDX partial - rebuilt by scripts/extract-stage-rationale.ts on every dev/build
 docs/how-ax-sees-your-work.generated.mdx
+
+# scratch screenshots from landing iteration
+site/.tmp-shots/

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,696 @@
-MIT License
+ax is dual-licensed.
 
-Copyright (c) 2025 Necmettin Karakaya
+================================================================================
+ OPTION 1 — GNU Affero General Public License v3.0 (AGPL-3.0) — default, free
+================================================================================
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+ax is free and open source under the AGPL-3.0 (full text below).
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+In plain terms: you may use, study, modify, and redistribute ax for free.
+But the AGPL is a strong network copyleft license. If you run a modified
+version of ax to provide a service over a network, or distribute it as part
+of your own product, you must release the COMPLETE corresponding source code
+of your work — including your modifications and the surrounding application —
+to your users under the AGPL-3.0.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+================================================================================
+ OPTION 2 — Commercial License — for closed / proprietary use
+================================================================================
+
+If you want to use, embed, host, or resell ax as part of a closed-source or
+proprietary product or service WITHOUT the AGPL's source-disclosure
+obligations, you need a separate commercial license.
+
+Commercial licenses are available from the copyright holder. See
+LICENSE-COMMERCIAL.md or contact:
+
+    Necmettin Karakaya <necmettin.karakaya@gmail.com>
+
+Copyright (c) 2025 Necmettin Karakaya. All rights reserved.
+
+The full text of the AGPL-3.0 follows.
+
+================================================================================
+
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -1,0 +1,49 @@
+# Commercial License for ax
+
+ax is dual-licensed:
+
+1. **AGPL-3.0** (see [`LICENSE`](./LICENSE)) - free and open source. If you build
+   on ax and run it as a network service or ship it inside your product, the
+   AGPL requires you to release the complete corresponding source of your work
+   under the AGPL too.
+
+2. **Commercial License** (this document) - for teams that want to use, embed,
+   host, or resell ax inside a **closed-source or proprietary** product or
+   service, without the AGPL's source-disclosure obligations.
+
+## When you need a commercial license
+
+You need a commercial license if any of these apply and you do **not** want to
+open-source your surrounding code under the AGPL:
+
+- You offer ax (modified or not) to third parties as a hosted/SaaS service.
+- You bundle or embed ax into a proprietary product you distribute or sell.
+- You build a commercial product whose value materially depends on ax and you
+  cannot meet the AGPL's network-copyleft terms.
+
+You do **not** need a commercial license to:
+
+- Use ax internally on your own machines.
+- Self-host, study, modify, and share ax under the AGPL-3.0.
+- Contribute back to the project.
+
+## How it works
+
+A commercial license grants you the right to use ax under proprietary terms
+(no AGPL source-disclosure requirement), with terms negotiated per the size and
+nature of your use. Pricing is typically a flat annual fee or a revenue-based
+arrangement.
+
+## Get a commercial license
+
+Contact the copyright holder:
+
+**Necmettin Karakaya** - <necmettin.karakaya@gmail.com>
+
+Include: your company, intended use, and rough scale (users / deployments /
+revenue). We'll send terms.
+
+---
+
+Copyright (c) 2025 Necmettin Karakaya. All rights reserved. "AGPL-3.0" refers to
+the GNU Affero General Public License version 3.0.

--- a/docs/superpowers/goals/2026-05-30-setfit-session-section-experiments-goal.md
+++ b/docs/superpowers/goals/2026-05-30-setfit-session-section-experiments-goal.md
@@ -818,6 +818,40 @@ Focused CLI tests passed (`26`). Combined classifier package tests passed
 (`111`). Typecheck exited `0` with existing Effect lint messages/warnings. The
 live CLI command reached local SurrealDB and wrote the E501 artifact.
 
+## E502 - Boundary Replay CLI Routing Guard
+
+Question: can the DB-backed package-operations flags be regression-tested so
+future compact graph summary flags do not accidentally run through the no-DB
+CLI path?
+
+Changes:
+
+- Extracted `classifiersPackageOperationsNeedsDb(args)` from the inline CLI
+  routing condition.
+- Added coverage for the DB-backed package-operations flags:
+  `--apply-write-plan`, `--graph-health`, and `--boundary-replay-summary`.
+- Added a negative check that `--quality-status` remains no-DB because it reads
+  a local report file and does not need SurrealDB.
+
+Decision:
+
+- Keep DB routing explicit for package-operations flags that query or mutate the
+  classifier graph.
+- This directly guards the E501 bug where `--boundary-replay-summary` initially
+  reached `SurrealClient.query` through the no-DB sentinel.
+
+Verification:
+
+```sh
+bun test src/cli/effect-cli.test.ts src/cli/classifiers-package-operations.test.ts
+bun test scripts/classifier-package-operations.test.ts src/cli/effect-cli.test.ts src/cli/classifiers-package-operations.test.ts src/classifiers/package-service.test.ts
+bun run typecheck
+```
+
+Focused CLI tests passed (`53`). Combined classifier package and CLI tests
+passed (`138`). Typecheck exited `0` with existing Effect lint
+messages/warnings.
+
 Current recommendation:
 
 - Index continuation: E488 turns the accepted classifier-fixture follow-up into

--- a/docs/superpowers/goals/2026-05-30-setfit-session-section-experiments-goal.md
+++ b/docs/superpowers/goals/2026-05-30-setfit-session-section-experiments-goal.md
@@ -763,6 +763,61 @@ bun run typecheck
 Passed: `27` focused service tests, then `109` combined classifier package
 tests. Typecheck exited `0` with the existing Effect lint messages/warnings.
 
+## E501 - Boundary Replay Package CLI Summary
+
+Question: can agents call the reviewed deterministic replay posture through a
+single package-operations CLI flag, without recreating the graph query or using
+the lower-level graph command?
+
+Changes:
+
+- Added `classifiers package-operations --boundary-replay-summary`.
+- The flag routes through `ClassifierPackageService.boundaryReplaySummaryReport`
+  and `writeBoundaryReplaySummaryReport`.
+- Text output renders the compact promotion posture, subject counts,
+  classifiers, targets, subjects, and recommended argv.
+- The CLI keeps optional graph filters for debug narrowing while the service
+  owns the default boundary replay query.
+- Fixed the top-level CLI DB routing so this DB-backed package-operations flag
+  gets `AppLayer` instead of the no-DB sentinel.
+
+Command:
+
+```sh
+bun src/cli/index.ts classifiers package-operations \
+  --boundary-replay-summary \
+  --out=.ax/experiments/boundary-replay-package-summary-e501.json \
+  --json
+```
+
+Artifact:
+
+- `.ax/experiments/boundary-replay-package-summary-e501.json`
+
+Result:
+
+- `status=reviewed_deterministic_facts_available`
+- `production_posture=deterministic_and_reviewed_graph_facts_only`
+- `next_action=use_reviewed_deterministic_graph_facts`
+- `covered_subject_count=1`
+- `deterministic_label_subject_count=1`
+- `evidence_path_count=1`
+- classifier key: `correction-event`
+- target: `workflow_state`
+
+Verification:
+
+```sh
+bun test src/cli/classifiers-package-operations.test.ts
+bun test scripts/classifier-package-operations.test.ts src/cli/classifiers-package-operations.test.ts src/classifiers/package-service.test.ts
+bun run typecheck
+bun src/cli/index.ts classifiers package-operations --boundary-replay-summary --out=.ax/experiments/boundary-replay-package-summary-e501.json --json
+```
+
+Focused CLI tests passed (`26`). Combined classifier package tests passed
+(`111`). Typecheck exited `0` with existing Effect lint messages/warnings. The
+live CLI command reached local SurrealDB and wrote the E501 artifact.
+
 Current recommendation:
 
 - Index continuation: E488 turns the accepted classifier-fixture follow-up into

--- a/docs/superpowers/plans/2026-06-01-landing-open-source-section.md
+++ b/docs/superpowers/plans/2026-06-01-landing-open-source-section.md
@@ -1,0 +1,70 @@
+# Landing Open Source Section Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an open-source and local-first proof section to the landing page.
+
+**Architecture:** Create one focused React component for the section, export it through the existing landing-v2 barrel, and render it between the lineage flow and footer cards. Add scoped `.landing-v2` CSS for desktop and mobile layout.
+
+**Tech Stack:** React 19, TanStack Start route components, TypeScript, global CSS scoped by `.landing-v2`.
+
+---
+
+### Task 1: Add Section Component
+
+**Files:**
+- Create: `site/app/components/landing-v2/open-source-section.tsx`
+- Modify: `site/app/components/landing-v2/index.tsx`
+
+- [x] **Step 1: Create the component**
+
+Create `site/app/components/landing-v2/open-source-section.tsx` with a terminal proof block, four trust cards, and action links.
+
+- [x] **Step 2: Export the component**
+
+Add `export { OpenSourceSection } from "./open-source-section";` to `site/app/components/landing-v2/index.tsx`.
+
+### Task 2: Render Section
+
+**Files:**
+- Modify: `site/app/routes/index.tsx`
+
+- [x] **Step 1: Import through the existing barrel**
+
+Add `OpenSourceSection` to the existing `~/components/landing-v2` import.
+
+- [x] **Step 2: Place the section**
+
+Render `<OpenSourceSection />` after `<LineageFlow />` and before `<FooterCards />`.
+
+### Task 3: Style Section
+
+**Files:**
+- Modify: `site/app/styles/globals.css`
+
+- [x] **Step 1: Add scoped desktop styles**
+
+Add `.landing-v2 section.open-source`, `.open-source-grid`, `.oss-terminal`, `.oss-proof-grid`, `.oss-proof-card`, and `.oss-actions` rules near the existing landing-v2 section styles.
+
+- [x] **Step 2: Add mobile rules**
+
+Extend existing `@media (max-width: 860px)` and `@media (max-width: 520px)` landing-v2 rules so the two-column layout collapses to one column and action links wrap cleanly.
+
+### Task 4: Verify
+
+**Files:**
+- Inspect: `site/app/components/landing-v2/open-source-section.tsx`
+- Inspect: `site/app/routes/index.tsx`
+- Inspect: `site/app/styles/globals.css`
+
+- [x] **Step 1: Search for expected strings**
+
+Run: `rg -n "If it shapes your agent|Local SurrealDB|OpenSourceSection|open-source" site/app`
+
+- [x] **Step 2: Typecheck**
+
+Run: `bun run typecheck` from `site/`. Existing unrelated TypeScript failures may remain; record whether any new failure points to the new component.
+
+- [x] **Step 3: Browser smoke if dependencies allow**
+
+Run the site dev server and inspect the landing page if practical. Confirm the section appears between the lineage flow and footer cards.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "axctl",
   "version": "0.5.0",
+  "license": "AGPL-3.0-only",
   "description": "ax is local memory and telemetry for coding agents. axctl ingests transcripts, skills, and git history into SurrealDB; surfaces what skills are worth keeping and what the user actually does on demand.",
   "type": "module",
   "workspaces": [

--- a/packages/ax-classifier-direction-event/package.json
+++ b/packages/ax-classifier-direction-event/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ax-classifier/direction-event",
   "version": "0.1.0",
+  "license": "AGPL-3.0-only",
   "type": "module",
   "private": true,
   "exports": {

--- a/packages/ax-classifier-session-sections/package.json
+++ b/packages/ax-classifier-session-sections/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ax-classifier/session-sections",
   "version": "0.1.0",
+  "license": "AGPL-3.0-only",
   "type": "module",
   "private": true
 }

--- a/packages/ax-classifier-verification-event/package.json
+++ b/packages/ax-classifier-verification-event/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ax-classifier/verification-event",
   "version": "0.1.0",
+  "license": "AGPL-3.0-only",
   "type": "module",
   "private": true,
   "exports": {

--- a/site/app/components/landing-v2/index.tsx
+++ b/site/app/components/landing-v2/index.tsx
@@ -1,4 +1,5 @@
 export { DashboardPreview } from "./dashboard-preview";
 export { LineageFlow } from "./lineage-flow";
+export { OpenSourceSection } from "./open-source-section";
 export { FooterCards } from "./footer-cards";
 export { SupportsStrip } from "./supports-strip";

--- a/site/app/components/landing-v2/open-source-section.tsx
+++ b/site/app/components/landing-v2/open-source-section.tsx
@@ -1,0 +1,175 @@
+type IconProps = { className?: string };
+
+function LicenseIcon({ className }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 14a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z" />
+      <path d="M9.5 13.2 8 21l4-2 4 2-1.5-7.8" />
+    </svg>
+  );
+}
+
+function TypeIcon({ className }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M4 7V5h16v2" />
+      <path d="M12 5v14" />
+      <path d="M9 19h6" />
+    </svg>
+  );
+}
+
+function LocalIcon({ className }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <ellipse cx="12" cy="5.5" rx="7" ry="2.5" />
+      <path d="M5 5.5v13c0 1.4 3.1 2.5 7 2.5s7-1.1 7-2.5v-13" />
+      <path d="M5 12c0 1.4 3.1 2.5 7 2.5s7-1.1 7-2.5" />
+    </svg>
+  );
+}
+
+function ForkIcon({ className }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="6" cy="5" r="2.5" />
+      <circle cx="18" cy="5" r="2.5" />
+      <circle cx="12" cy="19" r="2.5" />
+      <path d="M6 7.5v3c0 1.7 1.3 3 3 3h6c1.7 0 3-1.3 3-3v-3" />
+      <path d="M12 13.5v3" />
+    </svg>
+  );
+}
+
+function GitHubIcon({ className }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49 0-.24-.01-.88-.01-1.73-2.78.62-3.37-1.37-3.37-1.37-.46-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.05 1.53 1.05.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.55-1.14-4.55-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.36 9.36 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.32.68.94.68 1.9 0 1.37-.01 2.48-.01 2.82 0 .27.18.6.69.49A10.02 10.02 0 0 0 22 12.25C22 6.58 17.52 2 12 2Z" />
+    </svg>
+  );
+}
+
+function DocsIcon({ className }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M5 4.5A1.5 1.5 0 0 1 6.5 3H17a2 2 0 0 1 2 2v15.5a.5.5 0 0 1-.74.44A4 4 0 0 0 16.5 20H6.5A1.5 1.5 0 0 1 5 18.5Z" />
+      <path d="M5 17.5A1.5 1.5 0 0 1 6.5 16H19" />
+      <path d="M9 7.5h6M9 11h4" />
+    </svg>
+  );
+}
+
+const proofCards = [
+  {
+    title: "AGPL-3.0",
+    detail: "Free & open · commercial license available",
+    accent: "ink" as const,
+    Icon: LicenseIcon,
+  },
+  {
+    title: "TypeScript",
+    detail: "End-to-end, strictly typed",
+    accent: "blue" as const,
+    Icon: TypeIcon,
+  },
+  {
+    title: "Local-first",
+    detail: "SurrealDB on 127.0.0.1",
+    accent: "green" as const,
+    Icon: LocalIcon,
+  },
+  {
+    title: "Forkable",
+    detail: "Hack the loop, ship a PR",
+    accent: "ink" as const,
+    Icon: ForkIcon,
+  },
+];
+
+export function OpenSourceSection() {
+  return (
+    <section className="open-source" aria-labelledby="open-source-title">
+      <div className="open-source-head">
+        <span className="eyebrow">open source</span>
+        <h2 id="open-source-title">
+          If it shapes your agent, you should be able to fork it.
+        </h2>
+        <p>
+          ax is AGPL-3.0, local-first, and end-to-end typed. The whole feedback
+          loop lives in files and a database on your machine&nbsp;&mdash; inspect
+          it, bend it, fork it. Commercial license available if you need it.
+        </p>
+      </div>
+
+      <div className="open-source-grid">
+        <div className="oss-terminal" aria-label="Repository setup commands">
+          <div className="oss-terminal-bar">
+            <div className="browser-dots" aria-hidden="true">
+              <span></span>
+              <span></span>
+              <span></span>
+            </div>
+            <span>~/code</span>
+          </div>
+          <div className="oss-terminal-body">
+            <div className="oss-line">
+              <span className="prompt">$</span>
+              <code>gh repo clone Necmttn/ax</code>
+            </div>
+            <div className="oss-line muted">
+              <span></span>
+              <code>Cloned ax into ./ax</code>
+            </div>
+            <div className="oss-line">
+              <span className="prompt">$</span>
+              <code>cd ax &amp;&amp; bun install</code>
+            </div>
+            <div className="oss-line muted">
+              <span></span>
+              <code>1 284 packages installed in 4.2s</code>
+            </div>
+            <div className="oss-line">
+              <span className="prompt">$</span>
+              <code>axctl daemon start</code>
+            </div>
+            <div className="oss-line muted">
+              <span></span>
+              <code>ax dashboard &rarr; http://127.0.0.1:8520</code>
+            </div>
+            <div className="oss-line">
+              <span className="prompt">$</span>
+              <span className="oss-caret" aria-hidden="true"></span>
+            </div>
+          </div>
+        </div>
+
+        <div className="oss-proof-grid" aria-label="Open source proof points">
+          {proofCards.map(({ title, detail, accent, Icon }) => (
+            <div className={`oss-proof-card accent-${accent}`} key={title}>
+              <span className="oss-proof-icon" aria-hidden="true">
+                <Icon />
+              </span>
+              <h3>{title}</h3>
+              <p>{detail}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="oss-actions" aria-label="Open source links">
+        <a className="oss-action primary" href="https://github.com/Necmttn/ax" target="_blank" rel="noopener noreferrer">
+          <GitHubIcon className="oss-action-glyph" />
+          Star on GitHub <span className="oss-action-arrow" aria-hidden="true">&rarr;</span>
+        </a>
+        <a className="oss-action" href="https://github.com/Necmttn/ax/fork" target="_blank" rel="noopener noreferrer">
+          <ForkIcon className="oss-action-glyph" />
+          Fork the repo <span className="oss-action-arrow" aria-hidden="true">&rarr;</span>
+        </a>
+        <a className="oss-action" href="/docs">
+          <DocsIcon className="oss-action-glyph" />
+          Read the docs <span className="oss-action-arrow" aria-hidden="true">&rarr;</span>
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/site/app/routes/index.tsx
+++ b/site/app/routes/index.tsx
@@ -4,6 +4,7 @@ import { SiteFooter } from "~/components/landing-sections/site-footer";
 import {
   DashboardPreview,
   LineageFlow,
+  OpenSourceSection,
   FooterCards,
 } from "~/components/landing-v2";
 
@@ -18,6 +19,7 @@ function Landing() {
       <main className="landing-v2">
         <DashboardPreview />
         <LineageFlow />
+        <OpenSourceSection />
         <FooterCards />
       </main>
       <SiteFooter />

--- a/site/app/styles/globals.css
+++ b/site/app/styles/globals.css
@@ -7821,6 +7821,244 @@ footer .right {
   .landing-v2 .event-chip { transition: none !important; }
 }
 
+/* ---------- open source proof ---------- */
+.landing-v2 section.open-source {
+  padding: 88px 0 80px;
+  border-bottom: 1px solid var(--line);
+}
+.landing-v2 .open-source-head {
+  text-align: center;
+  margin: 0 auto 46px;
+}
+.landing-v2 .open-source-head h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 56px;
+  line-height: 1.02;
+  letter-spacing: -1.4px;
+  margin: 22px auto 18px;
+  max-width: 17ch;
+}
+.landing-v2 .open-source-head p {
+  font-family: var(--serif);
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--muted);
+  margin: 0 auto;
+  max-width: 50ch;
+}
+.landing-v2 .open-source-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.95fr);
+  gap: 24px;
+  align-items: stretch;
+}
+.landing-v2 .oss-terminal,
+.landing-v2 .oss-proof-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+}
+.landing-v2 .oss-terminal {
+  overflow: hidden;
+  min-height: 280px;
+}
+.landing-v2 .oss-terminal-bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 14px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--line);
+  background: #efede5;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+.landing-v2 .oss-terminal-bar .browser-dots {
+  justify-self: start;
+}
+.landing-v2 .oss-terminal-body {
+  padding: 30px 28px 28px;
+  font-family: var(--mono);
+  font-size: 14px;
+  line-height: 1.75;
+}
+.landing-v2 .oss-line {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 10px;
+  align-items: baseline;
+  color: var(--ink);
+}
+.landing-v2 .oss-line code {
+  color: inherit;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.landing-v2 .oss-line .prompt {
+  color: var(--blue);
+  user-select: none;
+}
+.landing-v2 .oss-line.muted {
+  color: var(--muted);
+}
+.landing-v2 .oss-caret {
+  display: inline-block;
+  width: 8px;
+  height: 1.05em;
+  transform: translateY(2px);
+  background: var(--blue);
+  animation: oss-blink 1.1s steps(1) infinite;
+}
+@keyframes oss-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .landing-v2 .oss-caret { animation: none; }
+}
+.landing-v2 .oss-proof-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+.landing-v2 .oss-proof-card {
+  position: relative;
+  min-height: 132px;
+  padding: 22px 22px 24px;
+  overflow: hidden;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+}
+.landing-v2 .oss-proof-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 2px;
+  background: var(--accent, var(--ink));
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+.landing-v2 .oss-proof-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent, var(--ink));
+  background: #fff;
+  box-shadow: 0 8px 24px -16px rgba(10, 10, 10, 0.35);
+}
+.landing-v2 .oss-proof-card:hover::before {
+  opacity: 0.85;
+}
+.landing-v2 .oss-proof-card.accent-ink { --accent: var(--ink); }
+.landing-v2 .oss-proof-card.accent-blue { --accent: var(--blue); }
+.landing-v2 .oss-proof-card.accent-green { --accent: var(--green); }
+.landing-v2 .oss-proof-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  margin-bottom: 16px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  color: var(--accent, var(--ink));
+  background: var(--panel);
+  transition: border-color 0.18s ease, transform 0.18s ease;
+}
+.landing-v2 .oss-proof-icon svg {
+  width: 18px;
+  height: 18px;
+}
+.landing-v2 .oss-proof-card:hover .oss-proof-icon {
+  border-color: var(--accent, var(--ink));
+  transform: translateY(-1px);
+}
+.landing-v2 .oss-proof-card h3 {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 26px;
+  font-weight: 400;
+  line-height: 1.1;
+  letter-spacing: -0.4px;
+}
+.landing-v2 .oss-proof-card p {
+  margin: 9px 0 0;
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.55;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+}
+.landing-v2 .oss-actions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 40px auto 0;
+}
+.landing-v2 .oss-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 46px;
+  padding: 0 18px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+}
+.landing-v2 .oss-action.primary {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: var(--page);
+}
+.landing-v2 .oss-action-glyph {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--muted);
+  transition: color 0.15s ease;
+}
+.landing-v2 .oss-action.primary .oss-action-glyph {
+  color: var(--page);
+}
+.landing-v2 .oss-action:hover {
+  transform: translateY(-1px);
+  border-color: var(--ink);
+  background: #fff;
+  color: var(--ink);
+  box-shadow: 0 8px 20px -14px rgba(10, 10, 10, 0.5);
+}
+.landing-v2 .oss-action.primary:hover {
+  background: #000;
+  color: var(--page);
+}
+.landing-v2 .oss-action.primary:hover .oss-action-glyph {
+  color: var(--page);
+}
+.landing-v2 .oss-action:hover .oss-action-glyph {
+  color: var(--ink);
+}
+.landing-v2 .oss-action-arrow {
+  color: var(--muted);
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+.landing-v2 .oss-action.primary .oss-action-arrow {
+  color: var(--page);
+}
+.landing-v2 .oss-action:hover .oss-action-arrow {
+  color: var(--ink);
+  transform: translateX(2px);
+}
+.landing-v2 .oss-action.primary:hover .oss-action-arrow {
+  color: var(--page);
+}
+
 /* ---------- footer cards ---------- */
 .landing-v2 section.cards {
   padding: 64px 0 80px;
@@ -7906,6 +8144,13 @@ footer .right {
   .landing-v2 .browser-url { min-width: 0; font-size: 10.5px; }
   .landing-v2 .cards-grid { grid-template-columns: repeat(2, 1fr); }
   .landing-v2 section.lineage { padding: 56px 0 64px; }
+  .landing-v2 section.open-source { padding: 56px 0 64px; }
+  .landing-v2 .open-source-head { margin-bottom: 32px; }
+  .landing-v2 .open-source-head h2 { font-size: 40px; letter-spacing: -0.7px; }
+  .landing-v2 .open-source-head p { font-size: 16px; }
+  .landing-v2 .open-source-grid { grid-template-columns: 1fr; }
+  .landing-v2 .oss-terminal { min-height: 0; }
+  .landing-v2 .oss-terminal-body { padding: 24px 20px; font-size: 12px; }
   .landing-v2 .lineage-grid {
     grid-template-columns: 1fr;
     gap: 18px;
@@ -7919,6 +8164,12 @@ footer .right {
   .landing-v2 section.hero h1 { font-size: 36px; }
   .landing-v2 .score-number .n { font-size: 96px; letter-spacing: -2px; }
   .landing-v2 .ministats { grid-template-columns: 1fr; }
+  .landing-v2 .oss-proof-grid { grid-template-columns: 1fr; }
+  .landing-v2 .oss-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .landing-v2 .oss-action { justify-content: center; }
   .landing-v2 .mini {
     border-left: none !important;
     padding: 20px 4px !important;

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ax-site",
   "version": "0.0.0",
+  "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/cli/classifiers-package-operations.test.ts
+++ b/src/cli/classifiers-package-operations.test.ts
@@ -9,6 +9,7 @@ import {
     renderClassifierLifecycleRouteBindingPreviewText,
     renderClassifierLifecycleInsightText,
     renderClassifierLifecycleRoutingSummaryText,
+    renderClassifierGraphBoundaryReplaySummaryText,
     renderClassifierPackageExecutionFactsText,
     renderClassifierPackageExecutionGraphHealthText,
     renderClassifierPackageExecutionHistoryText,
@@ -31,6 +32,7 @@ import type {
     ClassifierLifecycleRouteBindingPreviewReport,
     ClassifierLifecycleInsightReport,
     ClassifierLifecycleRoutingSummaryReport,
+    ClassifierGraphBoundaryReplaySummary,
     ClassifierPackageExecutionFactProjectionReport,
     ClassifierPackageExecutionGraphHealthReport,
     ClassifierPackageExecutionHistoryReport,
@@ -318,6 +320,84 @@ describe("classifiers package-operations format", () => {
                 mode: "lifecycle",
                 predicate: "review_pipeline_recommended_action_execution_phase",
                 value_equals: "execute",
+            },
+        });
+    });
+
+    test("renders boundary replay summaries", () => {
+        const summary: ClassifierGraphBoundaryReplaySummary = {
+            status: "reviewed_deterministic_facts_available",
+            production_posture: "deterministic_and_reviewed_graph_facts_only",
+            next_action: "use_reviewed_deterministic_graph_facts",
+            remediation: "Use reviewed deterministic graph facts for promotion-safe behavior.",
+            covered_subject_count: 1,
+            deterministic_label_subject_count: 1,
+            evidence_path_count: 1,
+            classifier_keys: ["correction-event"],
+            targets: ["workflow_state"],
+            subjects: ["classifier_boundary_miss:workflow"],
+            recommended_argv: ["bun", "src/cli/index.ts", "classifiers", "graph", "--mode=boundary-replay"],
+        };
+
+        const output = renderClassifierGraphBoundaryReplaySummaryText(summary);
+
+        expect(output).toContain("classifier boundary replay summary");
+        expect(output).toContain("status: reviewed_deterministic_facts_available");
+        expect(output).toContain("production posture: deterministic_and_reviewed_graph_facts_only");
+        expect(output).toContain("classifiers: correction-event");
+        expect(output).toContain("targets: workflow_state");
+        expect(output).toContain("recommended argv: bun src/cli/index.ts classifiers graph --mode=boundary-replay");
+    });
+
+    test("routes boundary replay summaries to the compact writer", async () => {
+        const summary: ClassifierGraphBoundaryReplaySummary = {
+            status: "reviewed_deterministic_facts_available",
+            production_posture: "deterministic_and_reviewed_graph_facts_only",
+            next_action: "use_reviewed_deterministic_graph_facts",
+            remediation: "Use reviewed deterministic graph facts for promotion-safe behavior.",
+            covered_subject_count: 1,
+            deterministic_label_subject_count: 1,
+            evidence_path_count: 1,
+            classifier_keys: ["correction-event"],
+            targets: ["workflow_state"],
+            subjects: ["classifier_boundary_miss:workflow"],
+        };
+        let calledWith: unknown;
+        const previousExitCode = process.exitCode;
+        const service = ClassifierPackageService.of({
+            writeBoundaryReplaySummaryReport: (input: unknown) => Effect.sync(() => {
+                calledWith = input;
+                return summary;
+            }),
+        } as never);
+
+        try {
+            await Effect.runPromise(
+                runClassifiersPackageOperations({
+                    manifestPath: "packages/ax-classifier-session-sections/ax.classifier.json",
+                    boundaryReplaySummary: true,
+                    sourceKind: "boundary_replay_deterministic_projection",
+                    factKind: "classifier_boundary_replay",
+                    predicate: "covered_by_deterministic",
+                    valueEquals: "true",
+                    out: ".ax/experiments/boundary-replay-summary.json",
+                    json: false,
+                } as never).pipe(
+                    Effect.provideService(ClassifierPackageService, service),
+                    Effect.provideService(SurrealClient, {} as SurrealClientShape),
+                ),
+            );
+        } finally {
+            process.exitCode = previousExitCode ?? 0;
+        }
+
+        expect(calledWith).toEqual({
+            out: ".ax/experiments/boundary-replay-summary.json",
+            query: {
+                source_kind: "boundary_replay_deterministic_projection",
+                fact_kind: "classifier_boundary_replay",
+                predicate: "covered_by_deterministic",
+                value_equals: "true",
             },
         });
     });

--- a/src/cli/classifiers-package-operations.ts
+++ b/src/cli/classifiers-package-operations.ts
@@ -29,6 +29,7 @@ import type {
     ClassifierLifecycleRouteBindingPreviewReport,
     ClassifierLifecycleInsightReport,
     ClassifierLifecycleRoutingSummaryReport,
+    ClassifierGraphBoundaryReplaySummary,
     ClassifierGraphQuerySuggestionRoutingSummary,
     ClassifierGraphHealthMode,
     ClassifierGraphHealthQuery,
@@ -53,6 +54,7 @@ export interface ClassifierPackageOperationsCommandInput extends ClassifierPacka
     readonly applyWritePlan?: boolean;
     readonly graphHealth?: boolean;
     readonly querySuggestionRouting?: boolean;
+    readonly boundaryReplaySummary?: boolean;
     readonly qualityStatus?: boolean;
     readonly sourceReportPath?: string;
     readonly graphMode?: ClassifierGraphHealthMode;
@@ -390,6 +392,25 @@ export function renderClassifierGraphQuerySuggestionRoutingSummaryText(
     lines.push(`verification expected query match: ${suggestion.verification.expected_query_match_status}`);
     lines.push(`verification expected result count: ${suggestion.verification.expected_result_count ?? "none"}`);
     return lines.join("\n");
+}
+
+export function renderClassifierGraphBoundaryReplaySummaryText(
+    summary: ClassifierGraphBoundaryReplaySummary,
+): string {
+    return [
+        "classifier boundary replay summary",
+        `status: ${summary.status}`,
+        `production posture: ${summary.production_posture}`,
+        `next action: ${summary.next_action}`,
+        `remediation: ${summary.remediation}`,
+        `covered subjects: ${summary.covered_subject_count}`,
+        `deterministic label subjects: ${summary.deterministic_label_subject_count}`,
+        `evidence paths: ${summary.evidence_path_count}`,
+        `classifiers: ${summary.classifier_keys.join(", ") || "none"}`,
+        `targets: ${summary.targets.join(", ") || "none"}`,
+        `subjects: ${summary.subjects.join(", ") || "none"}`,
+        `recommended argv: ${summary.recommended_argv?.join(" ") ?? "none"}`,
+    ].join("\n");
 }
 
 export function renderClassifierPackageExecutionGraphHealthText(report: ClassifierPackageExecutionGraphHealthReport): string {
@@ -1162,6 +1183,40 @@ export const runClassifiersPackageOperations = (
                 console.log(renderClassifierQualityStatusText(report));
             }
             if (!report.quality_gate_passed) {
+                process.exitCode = 1;
+            }
+            return;
+        }
+        if (input.boundaryReplaySummary) {
+            const query = {
+                ...(input.graphMode ? { mode: input.graphMode } : {}),
+                ...(input.operationId ? { operation_id: input.operationId } : {}),
+                ...(input.artifact ? { artifact_path: input.artifact } : {}),
+                ...(input.sourceKind ? { source_kind: input.sourceKind } : {}),
+                ...(input.factKind ? { fact_kind: input.factKind } : {}),
+                ...(input.status ? { status: input.status } : {}),
+                ...(input.sourceFixture ? { source_fixture_id: input.sourceFixture } : {}),
+                ...(input.proposedLabel ? { proposed_label: input.proposedLabel } : {}),
+                ...(input.threshold ? { threshold: input.threshold } : {}),
+                ...(input.minSeedCount === undefined ? {} : { min_seed_count: input.minSeedCount }),
+                ...(input.minPositiveRecall === undefined ? {} : { min_positive_recall: input.minPositiveRecall }),
+                ...(input.minCallReduction === undefined ? {} : { min_call_reduction: input.minCallReduction }),
+                ...(input.minNearestSimilarity === undefined ? {} : { min_nearest_similarity: input.minNearestSimilarity }),
+                ...(input.nearestFixture ? { nearest_fixture_id: input.nearestFixture } : {}),
+                ...(input.predicate ? { predicate: input.predicate } : {}),
+                ...(input.subject ? { subject: input.subject } : {}),
+                ...(input.valueContains ? { value_contains: input.valueContains } : {}),
+                ...(input.valueEquals !== undefined ? { value_equals: input.valueEquals } : {}),
+            } as const;
+            const report = input.out
+                ? yield* packages.writeBoundaryReplaySummaryReport({ out: input.out, query })
+                : yield* packages.boundaryReplaySummaryReport({ query });
+            if (input.json) {
+                console.log(JSON.stringify(report, null, 2));
+            } else if (!input.out) {
+                console.log(renderClassifierGraphBoundaryReplaySummaryText(report));
+            }
+            if (report.status !== "reviewed_deterministic_facts_available") {
                 process.exitCode = 1;
             }
             return;

--- a/src/cli/effect-cli.test.ts
+++ b/src/cli/effect-cli.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { DB_COMMANDS, detectRemovedIngestFlag, insightsOnlyConflicts, resolveIngestStages, rootCommand } from "./index.ts";
+import {
+    DB_COMMANDS,
+    classifiersPackageOperationsNeedsDb,
+    detectRemovedIngestFlag,
+    insightsOnlyConflicts,
+    resolveIngestStages,
+    rootCommand,
+} from "./index.ts";
 import { ALL_STAGES } from "../ingest/stage/registry.ts";
 import type { StageRegistryShape } from "../ingest/stage/registry.ts";
 import type { BaseStageStats, StageDef } from "../ingest/stage/types.ts";
@@ -232,6 +239,29 @@ describe("effect cli", () => {
         expect(subNames).toEqual(expect.arrayContaining(["summary", "for"]));
         expect(DB_COMMANDS.has("costs")).toBe(true);
         expect(DB_COMMANDS.has("pricing")).toBe(true);
+    });
+
+    test("DB-backed classifier package-operation flags are routed through DB", () => {
+        expect(classifiersPackageOperationsNeedsDb([
+            "classifiers",
+            "package-operations",
+            "--apply-write-plan",
+        ])).toBe(true);
+        expect(classifiersPackageOperationsNeedsDb([
+            "classifiers",
+            "package-operations",
+            "--graph-health",
+        ])).toBe(true);
+        expect(classifiersPackageOperationsNeedsDb([
+            "classifiers",
+            "package-operations",
+            "--boundary-replay-summary",
+        ])).toBe(true);
+        expect(classifiersPackageOperationsNeedsDb([
+            "classifiers",
+            "package-operations",
+            "--quality-status",
+        ])).toBe(false);
     });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4947,6 +4947,15 @@ export const DB_COMMANDS: ReadonlySet<string> = new Set([
     "dogfood",
 ]);
 
+export const classifiersPackageOperationsNeedsDb = (args: ReadonlyArray<string>): boolean =>
+    args[0] === "classifiers" &&
+    args[1] === "package-operations" &&
+    (
+        args.includes("--apply-write-plan") ||
+        args.includes("--graph-health") ||
+        args.includes("--boundary-replay-summary")
+    );
+
 async function main() {
     const [, , ...args] = process.argv;
     if (args[0] === undefined || args[0] === "help" || args[0] === "--help" || args[0] === "-h") {
@@ -4977,11 +4986,7 @@ async function main() {
     }
     if (
         args[0] === "classifiers" &&
-        ((args[1] === "package-operations" && (
-            args.includes("--apply-write-plan") ||
-            args.includes("--graph-health") ||
-            args.includes("--boundary-replay-summary")
-        )) ||
+        (classifiersPackageOperationsNeedsDb(args) ||
             args[1] === "graph" ||
             args[1] === "lifecycle")
     ) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1847,11 +1847,12 @@ const classifiersPackageOperationsCommand = Command.make(
         workflowStatus: Flag.string("workflow-status").pipe(Flag.optional),
         writePlan: Flag.boolean("write-plan").pipe(Flag.withDefault(false)),
         querySuggestionRouting: Flag.boolean("query-suggestion-routing").pipe(Flag.withDefault(false)),
+        boundaryReplaySummary: Flag.boolean("boundary-replay-summary").pipe(Flag.withDefault(false)),
         qualityStatus: Flag.boolean("quality-status").pipe(Flag.withDefault(false)),
         sourceReport: Flag.string("source-report").pipe(Flag.optional),
         json: jsonFlag,
     },
-    ({ allowExpensive, applyWritePlan, all, dryRun, execute, facts, graphHealth, graphMode, history, manifest, operation, artifact, sourceKind, factKind, status, sourceFixture, proposedLabel, threshold, minSeedCount, minPositiveRecall, minCallReduction, minNearestSimilarity, nearestFixture, predicate, subject, valueContains, valueEquals, out, preflight, root, workflowStatus, writePlan, querySuggestionRouting, qualityStatus, sourceReport, json }) => {
+    ({ allowExpensive, applyWritePlan, all, dryRun, execute, facts, graphHealth, graphMode, history, manifest, operation, artifact, sourceKind, factKind, status, sourceFixture, proposedLabel, threshold, minSeedCount, minPositiveRecall, minCallReduction, minNearestSimilarity, nearestFixture, predicate, subject, valueContains, valueEquals, out, preflight, root, workflowStatus, writePlan, querySuggestionRouting, boundaryReplaySummary, qualityStatus, sourceReport, json }) => {
         const operationId = optionValue(operation);
         const artifactPath = optionValue(artifact);
         const sourceKindName = optionValue(sourceKind);
@@ -1890,8 +1891,9 @@ const classifiersPackageOperationsCommand = Command.make(
             execute,
             facts,
             graphHealth,
-            graphMode,
+            ...(boundaryReplaySummary && graphMode === "summary" ? {} : { graphMode }),
             querySuggestionRouting,
+            boundaryReplaySummary,
             qualityStatus,
             ...(sourceReportPath === undefined ? {} : { sourceReportPath }),
             history,
@@ -4975,7 +4977,11 @@ async function main() {
     }
     if (
         args[0] === "classifiers" &&
-        ((args[1] === "package-operations" && (args.includes("--apply-write-plan") || args.includes("--graph-health"))) ||
+        ((args[1] === "package-operations" && (
+            args.includes("--apply-write-plan") ||
+            args.includes("--graph-health") ||
+            args.includes("--boundary-replay-summary")
+        )) ||
             args[1] === "graph" ||
             args[1] === "lifecycle")
     ) {


### PR DESCRIPTION
## What

Two things ship together:

### 1. Landing open-source section redesign
- Real SVG icons: per-card glyphs (license/type/db/fork) + GitHub mark, git-branch, docs icons on action buttons
- Per-card accent colors (ink/blue/green) — left rail + border + soft shadow on hover
- Pill action buttons; primary "Star on GitHub" inverted
- Blinking blue terminal caret
- Tightened serif typography (h2 56px, -1.4px tracking)
- Dropped "No telemetry" card → **Forkable**

### 2. Relicense MIT → AGPL-3.0 (dual license)
Goal: stay genuinely open source, but monetize commercial/closed use.

- `LICENSE` → AGPL-3.0 full text + dual-license header
- `LICENSE-COMMERCIAL.md` → paid path for closed/proprietary embedding or SaaS
- `"license": "AGPL-3.0-only"` set across root, site, and all 3 `@ax-classifier/*` workspace packages
- Landing card + copy updated MIT → AGPL-3.0

**Why it monetizes:** AGPL network copyleft forces anyone running ax as a service or shipping it closed to open their full stack — or buy a commercial license. Self-hosters/contributors stay free.

## Dependency license audit
Scanned 527 installed packages. **No AGPL-incompatible licenses.**

| Pkg | License | Verdict |
|---|---|---|
| sharp libvips binary | LGPL-3.0 | ✅ compatible, native binary |
| lightningcss | MPL-2.0 | ✅ compatible, build-time only |
| @content-collections/mdx | MIT | ✅ |
| bun2nix | MIT | ✅ dev-only |
| @ax-classifier/* | own packages | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)