### PR TITLE
feat: ax sessions compare — side-by-side run comparison (CLI + dashboard swimlane)

### DIFF
--- a/apps/axctl/src/classifiers/label-mining-service.ts
+++ b/apps/axctl/src/classifiers/label-mining-service.ts
@@ -502,7 +502,7 @@ FROM transcript_label_review;`.trim();
 /** Read persisted vector rows for re-projection. */
 const vectorProjectionSql = `
 SELECT
-    type::string(id) AS id,
+    record::id(id) AS id,
     candidate_id,
     embedding_model,
     embedding_dim,

--- a/apps/axctl/src/classifiers/label-mining.test.ts
+++ b/apps/axctl/src/classifiers/label-mining.test.ts
@@ -87,6 +87,31 @@ describe("mineTranscriptLabelCandidates", () => {
         expect(candidates[0]!.label_family).toBe("direction");
     });
 
+    test("drops agent task-dispatch and slash-command prompts", () => {
+        const candidates = mineTranscriptLabelCandidates({
+            windows: [
+                win({ user: "You are implementing Task 4 from the approved plan in the worktree.", previousAssistant: "# AGENTS.md instructions\n<INSTRUCTIONS>" }),
+                win({ user: "# Simplify: Code Review and Cleanup\n\nReview all changed files.", subjectId: "turn:u2", turnId: "turn:u2" }),
+                win({ user: "Spec compliance review for Task 2. Do not edit files.", subjectId: "turn:u3", turnId: "turn:u3" }),
+            ],
+            limit: 500,
+        });
+        expect(candidates.length).toBe(0);
+    });
+
+    test("an injected AGENTS.md prev does not anchor a correction", () => {
+        const candidates = mineTranscriptLabelCandidates({
+            windows: [
+                win({
+                    user: "no, that's wrong, revert it",
+                    previousAssistant: "# AGENTS.md instructions\n<INSTRUCTIONS> # CLAUDE.md",
+                }),
+            ],
+            limit: 500,
+        });
+        expect(candidates.length).toBe(0);
+    });
+
     test("broadens via intent_kind=correction when text patterns miss", () => {
         const candidates = mineTranscriptLabelCandidates({
             windows: [
@@ -102,6 +127,17 @@ describe("mineTranscriptLabelCandidates", () => {
         const c = candidates[0]!;
         expect(c.label_family).toBe("correction");
         expect(c.weak_sources).toContain("intent:correction");
+    });
+
+    test("does not seed a candidate from a bare affirmation", () => {
+        const candidates = mineTranscriptLabelCandidates({
+            windows: [
+                win({ user: "yes please", userIntentKind: "preference" }),
+                win({ user: "ok lets do it", subjectId: "turn:u2", turnId: "turn:u2", userIntentKind: "preference" }),
+            ],
+            limit: 500,
+        });
+        expect(candidates.length).toBe(0);
     });
 
     test("broadens via intent_kind=preference into a direction candidate", () => {

--- a/apps/axctl/src/classifiers/label-mining.ts
+++ b/apps/axctl/src/classifiers/label-mining.ts
@@ -131,9 +131,17 @@ const matchWeakLabel = (text: string, intentKind?: string | null): WeakMatch | n
         };
     }
 
+    // A bare affirmation ("yes please", "ok lets do it") carries an approval
+    // intent but no substantive direction - it is too vague to seed a useful
+    // label, so the intent_kind fallback must not promote it to a candidate.
+    const isBareAffirmation = /^(yes|yeah|yep|yup|ok|okay|sure|alright|aight)[\s,.!]*(please|lets?\s+do(\s+(it|that|this))?|do\s+it|go(\s+ahead)?)?[\s,.!]*$/i.test(
+        text.trim(),
+    );
+
     // Fallback: broaden organic extraction using the DB-derived `intent_kind`
     // when the high-precision text patterns miss. These remain weak labels
     // (reviewed before any promotion), so a derived-classifier signal is fine.
+    if (isBareAffirmation) return null;
     switch (intentKind) {
         case "correction":
             return {
@@ -169,6 +177,34 @@ const candidateId = (input: {
     ].join("__");
 };
 
+/**
+ * Slash-command bodies and agent task-dispatch prompts the user sends from their
+ * OWN session (e.g. `/simplify`, worktree/issue kickoffs). They carry
+ * `message_kind = 'task'` and live in non-subagent sessions, so the read-layer
+ * filters miss them - but they are not organic corrections/directions, and they
+ * dominate the false positives ("You are implementing Task N...", "# Simplify").
+ */
+const isTaskDispatchOrCommand = (text: string): boolean => {
+    const t = text.trimStart();
+    // Slash-command / harness output markers, and markdown-header command bodies.
+    if (/^<(local-command-stdout|command-name|command-message|skill>)/i.test(t)) return true;
+    if (/^#\s+(simplify|update config|autonomous loop|goal\b|review\b)/i.test(t)) return true;
+    // Agent task-dispatch personas.
+    if (/^you are (a |the )?(implementing|working in repo|final|spec[- ]complian|code reviewer|reviewing\b)/i.test(t)) return true;
+    if (/^implement task\s+\d/i.test(t)) return true;
+    if (/^spec compliance review\b/i.test(t)) return true;
+    if (/^(please\s+)?(final\s+)?re-?review\b/i.test(t)) return true;
+    if (/^review range:/i.test(t)) return true;
+    return false;
+};
+
+/** A "previous assistant" turn that is really injected system/AGENTS context. */
+const isInjectedContextTurn = (text: string | undefined): boolean => {
+    if (!text) return false;
+    const t = text.trimStart();
+    return /^(#\s*AGENTS\.md|<INSTRUCTIONS>|#\s*CLAUDE\.md)/i.test(t);
+};
+
 const isWrapperLike = (window: EventWindowLike, text: string): boolean => {
     if (text.length === 0) return true;
     if (isControlOrContextText(text)) return true;
@@ -177,6 +213,7 @@ const isWrapperLike = (window: EventWindowLike, text: string): boolean => {
     const role = window.userTurn.role;
     if (role !== undefined && role !== "user") return true;
     if (/^(system reminder|<system-reminder>|<subagent_notification>)/i.test(text)) return true;
+    if (isTaskDispatchOrCommand(text)) return true;
     return false;
 };
 
@@ -196,7 +233,10 @@ export function mineTranscriptLabelCandidates(input: {
         if (!match) continue;
 
         const hasPreviousAssistant = !!window.previousAssistantTurn
-            && window.previousAssistantTurn.text.trim().length > 0;
+            && window.previousAssistantTurn.text.trim().length > 0
+            // An injected AGENTS.md/CLAUDE.md "prev" is system context, not a real
+            // prior assistant action - it cannot anchor a correction/direction.
+            && !isInjectedContextTurn(window.previousAssistantTurn.text);
         if (match.requiresPreviousAssistant && !hasPreviousAssistant) continue;
 
         const evidencePaths = collectEvidencePaths(window);
@@ -730,6 +770,14 @@ const surqlString = (value: string): string =>
     `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
 
 /**
+ * Backtick-quoted record-id part. A record id after `:` must be an identifier,
+ * not a single-quoted strand (SurrealDB v3 rejects `table:'id'`); backtick
+ * quoting is the safe form for arbitrary string keys.
+ */
+const surqlRecordId = (value: string): string =>
+    `\`${value.replace(/`/g, "")}\``;
+
+/**
  * Build a single idempotent UPSERT keyed by the row's stable string id. Fields
  * are emitted in a fixed order so re-running over identical input is byte-stable.
  */
@@ -739,7 +787,7 @@ const upsert = (
     fields: readonly (readonly [string, string])[],
 ): string => {
     const set = fields.map(([key, expr]) => `${key} = ${expr}`).join(", ");
-    return `UPSERT ${table}:${surqlString(id)} SET ${set}`;
+    return `UPSERT ${table}:${surqlRecordId(id)} SET ${set}`;
 };
 
 const PROMOTION_SAFE_STATUS = "accepted" as const;

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -82,8 +82,10 @@ import { writeDashboard } from "../dashboard/report.ts";
 import { serveDashboard } from "../dashboard/server.ts";
 import { fetchRecall, type RecallSource, type RecallScope } from "../dashboard/recall.ts";
 import { fetchSessionShow } from "../dashboard/session-show.ts";
+import { fetchSessionCompare } from "../dashboard/session-compare.ts";
 import { fetchCostSummary, type CostSummary } from "../dashboard/cost-query.ts";
 import { renderSessionMarkdown, renderSessionJson } from "./session-show-format.ts";
+import { renderCompareTable, renderCompareJson } from "./session-compare-format.ts";
 import { cmdDaemon, cmdDoctor, cmdInstall, cmdUninstall } from "./install.ts";
 import { resolvePwdRepository } from "../pwd.ts";
 import { detectStaleness } from "@ax/lib/transcript-staleness";
@@ -3332,13 +3334,73 @@ const sessionsNearCommand = Command.make(
     "See the ax:extract-workflow skill for narrating workflows around a sha.",
 ));
 
+// ---------------------------------------------------------------------------
+// ax sessions compare <idA> <idB> [...] - side-by-side run comparison (P0)
+// ---------------------------------------------------------------------------
+
+/**
+ * `ax sessions compare <idA> <idB> [<idC> ...] [--json]`
+ *
+ * Lines up 2+ sessions on headline metrics (duration, tokens, cost, turns,
+ * errors, corrections, commits) and stars the winner per ranked axis. Answers
+ * "same task, which run was faster / cheaper / cleaner?". Auto table on TTY,
+ * --json (or piped) for machine output.
+ *
+ * Duration is wall-clock (ended_at - started_at); transcripts carry no model
+ * latency.
+ */
+const cmdSessionsCompare = (args: string[]) =>
+    Effect.gen(function* () {
+        const ids = args.filter((a) => !a.startsWith("--"));
+        if (ids.length < 2) {
+            console.error("axctl sessions compare: need at least 2 session ids");
+            console.error("  usage: axctl sessions compare <idA> <idB> [<idC> ...] [--json]");
+            process.exit(2);
+        }
+
+        const useJson = wantsJson(args);
+        const payload = yield* fetchSessionCompare(ids).pipe(
+            catchDbErrorAndExit("axctl sessions compare"),
+        );
+
+        if (payload.sessions.length < 2) {
+            process.stderr.write(
+                `axctl sessions compare: resolved only ${payload.sessions.length} session(s); need 2+. ` +
+                    `not found: ${payload.not_found.join(", ") || "(none)"}\n`,
+            );
+            process.exit(1);
+        }
+
+        if (useJson) {
+            console.log(renderCompareJson(payload));
+        } else {
+            console.log(renderCompareTable(payload));
+        }
+    });
+
+const sessionsCompareCommand = Command.make(
+    "compare",
+    {
+        ids: Argument.string("ids").pipe(Argument.variadic({ min: 2 })),
+        json: jsonFlag,
+    },
+    ({ ids, json }) => cmdSessionsCompare([...ids, ...boolArg("json", json)]),
+).pipe(
+    Command.withDescription(
+        "Compare 2+ sessions side by side (duration, tokens, cost, turns, errors, " +
+        "corrections, commits). Stars the winner per axis - answers which run was " +
+        "faster / cheaper / cleaner. Auto table on TTY, --json for machine output.",
+    ),
+);
+
 const sessionsCommand = Command.make("sessions").pipe(
-    Command.withDescription("Windowed session queries: here (pwd-repo), around (date), near (sha), show (detail)"),
+    Command.withDescription("Windowed session queries: here (pwd-repo), around (date), near (sha), show (detail), compare (side-by-side)"),
     Command.withSubcommands([
         sessionsHereCommand,
         sessionsAroundCommand,
         sessionsNearCommand,
         sessionShowCommand,
+        sessionsCompareCommand,
     ]),
 );
 

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -3343,23 +3343,24 @@ const sessionsNearCommand = Command.make(
  *
  * Lines up 2+ sessions on headline metrics (duration, tokens, cost, turns,
  * errors, corrections, commits) and stars the winner per ranked axis. Answers
- * "same task, which run was faster / cheaper / cleaner?". Auto table on TTY,
+ * "same task, which run was faster / cheaper / cleaner?". --turns adds an
+ * index-aligned per-turn appendix (tokens/gap per turn). Auto table on TTY,
  * --json (or piped) for machine output.
  *
- * Duration is wall-clock (ended_at - started_at); transcripts carry no model
- * latency.
+ * Duration / gap are wall-clock; transcripts carry no model latency.
  */
 const cmdSessionsCompare = (args: string[]) =>
     Effect.gen(function* () {
         const ids = args.filter((a) => !a.startsWith("--"));
         if (ids.length < 2) {
             console.error("axctl sessions compare: need at least 2 session ids");
-            console.error("  usage: axctl sessions compare <idA> <idB> [<idC> ...] [--json]");
+            console.error("  usage: axctl sessions compare <idA> <idB> [<idC> ...] [--turns] [--json]");
             process.exit(2);
         }
 
         const useJson = wantsJson(args);
-        const payload = yield* fetchSessionCompare(ids).pipe(
+        const includeTurns = args.includes("--turns");
+        const payload = yield* fetchSessionCompare(ids, { includeTurns }).pipe(
             catchDbErrorAndExit("axctl sessions compare"),
         );
 
@@ -3382,14 +3383,17 @@ const sessionsCompareCommand = Command.make(
     "compare",
     {
         ids: Argument.string("ids").pipe(Argument.variadic({ min: 2 })),
+        turns: Flag.boolean("turns").pipe(Flag.withDefault(false)),
         json: jsonFlag,
     },
-    ({ ids, json }) => cmdSessionsCompare([...ids, ...boolArg("json", json)]),
+    ({ ids, turns, json }) =>
+        cmdSessionsCompare([...ids, ...boolArg("turns", turns), ...boolArg("json", json)]),
 ).pipe(
     Command.withDescription(
         "Compare 2+ sessions side by side (duration, tokens, cost, turns, errors, " +
         "corrections, commits). Stars the winner per axis - answers which run was " +
-        "faster / cheaper / cleaner. Auto table on TTY, --json for machine output.",
+        "faster / cheaper / cleaner. --turns adds a per-turn appendix. " +
+        "Auto table on TTY, --json for machine output.",
     ),
 );
 

--- a/apps/axctl/src/cli/session-compare-format.test.ts
+++ b/apps/axctl/src/cli/session-compare-format.test.ts
@@ -175,6 +175,53 @@ describe("renderCompareTable", () => {
     });
 });
 
+describe("renderCompareTable --turns appendix", () => {
+    const withTurns = (): SessionComparePayload => {
+        const p = payload();
+        return {
+            ...p,
+            sessions: [
+                {
+                    ...p.sessions[0]!,
+                    turns: [
+                        { seq: 0, role: "user", ts: "2026-06-01T10:00:00.000Z", gap_ms: null, est_tokens: null, est_cost_usd: null, has_error: false },
+                        { seq: 1, role: "assistant", ts: "2026-06-01T10:00:08.000Z", gap_ms: 8_000, est_tokens: 12_300, est_cost_usd: 0.04, has_error: true },
+                    ],
+                },
+                {
+                    ...p.sessions[1]!,
+                    turns: [
+                        { seq: 0, role: "user", ts: "2026-06-01T10:00:00.000Z", gap_ms: null, est_tokens: null, est_cost_usd: null, has_error: false },
+                    ],
+                },
+            ],
+        };
+    };
+
+    test("renders a per-turn block with lane headers", () => {
+        const out = renderCompareTable(withTurns());
+        expect(out).toContain("Per-turn");
+        expect(out).toContain("turn");
+    });
+
+    test("flags error turns and shows gap", () => {
+        const out = renderCompareTable(withTurns());
+        expect(out).toContain("12.3k 8s !");
+    });
+
+    test("pads ragged lanes (session [2] has fewer turns)", () => {
+        const out = renderCompareTable(withTurns());
+        const lines = out.split("\n");
+        // 2 turn rows exist even though session [2] has only 1 turn.
+        const turnRows = lines.filter((l) => /^\d+ /.test(l));
+        expect(turnRows.length).toBe(2);
+    });
+
+    test("no per-turn block when turns absent", () => {
+        expect(renderCompareTable(payload())).not.toContain("Per-turn");
+    });
+});
+
 describe("renderCompareJson", () => {
     test("round-trips the payload", () => {
         const p = payload();

--- a/apps/axctl/src/cli/session-compare-format.test.ts
+++ b/apps/axctl/src/cli/session-compare-format.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+import { renderCompareJson, renderCompareTable } from "./session-compare-format.ts";
+import type {
+    SessionCompareEntry,
+    SessionComparePayload,
+    SessionId,
+} from "@ax/lib/shared/dashboard-types";
+
+const sid = (s: string): SessionId => s as unknown as SessionId;
+
+const entry = (over: Partial<SessionCompareEntry> & { session_id: SessionId }): SessionCompareEntry => ({
+    source: "claude",
+    model: "opus-4.8",
+    project: "ax",
+    started_at: "2026-06-01T10:00:00.000Z",
+    ended_at: "2026-06-01T10:10:00.000Z",
+    duration_ms: 600_000,
+    token_usage: null,
+    health: null,
+    commit_count: 0,
+    noise_score: null,
+    ...over,
+});
+
+const A = sid("019e0ad4-c977-7ab8-0000-00000000000a");
+const B = sid("019e0ad4-c977-7ab8-0000-00000000000b");
+
+const payload = (): SessionComparePayload => ({
+    task_label: "wire up compare view",
+    sessions: [
+        entry({
+            session_id: A,
+            duration_ms: 600_000, // 10m - faster
+            token_usage: {
+                model: "opus-4.8",
+                prompt_tokens: null,
+                completion_tokens: null,
+                cache_creation_input_tokens: null,
+                cache_read_input_tokens: null,
+                estimated_tokens: 1_200_000,
+                estimated_cost_usd: 3.4,
+                pricing_source: "table",
+            },
+            health: {
+                turns: 42,
+                tool_calls: 88,
+                tool_errors: 2,
+                user_corrections: 1,
+                interruptions: 0,
+                subagent_dispatches: 3,
+                task_label: "wire up compare view",
+            },
+            commit_count: 4,
+            noise_score: 3,
+        }),
+        entry({
+            session_id: B,
+            source: "codex",
+            model: "gpt-5",
+            duration_ms: 1_082_000, // 18m02s - slower
+            token_usage: {
+                model: "gpt-5",
+                prompt_tokens: null,
+                completion_tokens: null,
+                cache_creation_input_tokens: null,
+                cache_read_input_tokens: null,
+                estimated_tokens: 2_000_000,
+                estimated_cost_usd: 5.1,
+                pricing_source: "table",
+            },
+            health: {
+                turns: 51,
+                tool_calls: 120,
+                tool_errors: 7,
+                user_corrections: 3,
+                interruptions: 1,
+                subagent_dispatches: 0,
+                task_label: "wire up compare view",
+            },
+            commit_count: 2,
+            noise_score: 11,
+        }),
+    ],
+    winners: { fastest: A, cheapest: A, fewest_tokens: A, cleanest: A },
+    not_found: [],
+});
+
+describe("renderCompareTable", () => {
+    test("renders header with session count and shared task label", () => {
+        const out = renderCompareTable(payload());
+        expect(out).toContain("Comparing 2 sessions");
+        expect(out).toContain("task: wire up compare view");
+    });
+
+    test("renders all metric rows", () => {
+        const out = renderCompareTable(payload());
+        for (const label of [
+            "source",
+            "model",
+            "duration",
+            "turns",
+            "tokens",
+            "cost",
+            "tool calls",
+            "tool errors",
+            "corrections",
+            "interruptions",
+            "noise (err+corr+int)",
+            "commits",
+        ]) {
+            expect(out).toContain(label);
+        }
+    });
+
+    test("stars the winning cell on ranked rows", () => {
+        const out = renderCompareTable(payload());
+        const lines = out.split("\n");
+        // session A is the winner on duration/cost/tokens/noise → those rows
+        // carry a single star, in A's column (the first data column).
+        const durationLine = lines.find((l) => l.startsWith("duration"))!;
+        expect(durationLine).toContain("*");
+        const noiseLine = lines.find((l) => l.startsWith("noise"))!;
+        expect(noiseLine).toContain("3 *");
+    });
+
+    test("formats duration / tokens / cost compactly", () => {
+        const out = renderCompareTable(payload());
+        expect(out).toContain("10m 00s");
+        expect(out).toContain("18m 02s");
+        expect(out).toContain("1.2M");
+        expect(out).toContain("2.0M");
+        expect(out).toContain("$3.40");
+        expect(out).toContain("$5.10");
+    });
+
+    test("renders a lane legend mapping [n] to full session ids", () => {
+        const out = renderCompareTable(payload());
+        expect(out).toContain(`[1] ${A}`);
+        expect(out).toContain(`[2] ${B}`);
+    });
+
+    test("summarizes winners line by lane tag", () => {
+        const out = renderCompareTable(payload());
+        expect(out).toContain("Winners:");
+        // session A is lane [1] and wins every ranked axis.
+        expect(out).toContain("fastest [1]");
+        expect(out).toContain("cleanest [1]");
+    });
+
+    test("mixed task labels render as (mixed)", () => {
+        const p = payload();
+        const mixed: SessionComparePayload = { ...p, task_label: null };
+        expect(renderCompareTable(mixed)).toContain("(mixed / unlabeled)");
+    });
+
+    test("missing health/usage degrade to em dash, no winner star", () => {
+        const bare: SessionComparePayload = {
+            task_label: null,
+            sessions: [
+                entry({ session_id: A, token_usage: null, health: null, noise_score: null }),
+                entry({ session_id: B, token_usage: null, health: null, noise_score: null }),
+            ],
+            winners: { fastest: null, cheapest: null, fewest_tokens: null, cleanest: null },
+            not_found: [],
+        };
+        const out = renderCompareTable(bare);
+        expect(out).toContain("-");
+        expect(out).toContain("Winners: (no clear winner)");
+    });
+
+    test("lists not-found ids", () => {
+        const p = payload();
+        const withMissing: SessionComparePayload = { ...p, not_found: ["bogus-id"] };
+        expect(renderCompareTable(withMissing)).toContain("Not found: bogus-id");
+    });
+});
+
+describe("renderCompareJson", () => {
+    test("round-trips the payload", () => {
+        const p = payload();
+        const parsed = JSON.parse(renderCompareJson(p));
+        expect(parsed.sessions.length).toBe(2);
+        expect(parsed.winners.fastest).toBe(A);
+        expect(parsed.task_label).toBe("wire up compare view");
+    });
+});

--- a/apps/axctl/src/cli/session-compare-format.ts
+++ b/apps/axctl/src/cli/session-compare-format.ts
@@ -1,0 +1,189 @@
+/**
+ * Renderers for `ax sessions compare`. Table for humans (TTY), JSON for
+ * machines. Layout: rows = metrics, columns = sessions. The winning cell on
+ * each ranked axis is starred (`*`).
+ */
+import type {
+    SessionCompareEntry,
+    SessionComparePayload,
+    SessionId,
+} from "@ax/lib/shared/dashboard-types";
+
+/** Lane tag for a session column, 1-indexed: [1], [2], … Synthetic subagent
+ *  ids share a long common prefix, so a truncated short-id is ambiguous as a
+ *  column header; the lane tag + legend keeps columns distinct at any N. */
+const laneTag = (index: number): string => `[${index + 1}]`;
+
+export const renderCompareJson = (payload: SessionComparePayload): string =>
+    JSON.stringify(payload, null, 2);
+
+const fmtDuration = (ms: number | null): string => {
+    if (ms === null) return "-";
+    const totalSec = Math.round(ms / 1000);
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    const s = totalSec % 60;
+    if (h > 0) return `${h}h ${String(m).padStart(2, "0")}m`;
+    if (m > 0) return `${m}m ${String(s).padStart(2, "0")}s`;
+    return `${s}s`;
+};
+
+const fmtTokens = (n: number | null | undefined): string => {
+    if (n === null || n === undefined) return "-";
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return String(n);
+};
+
+const fmtCost = (n: number | null | undefined): string =>
+    n === null || n === undefined ? "-" : `$${n.toFixed(2)}`;
+
+const fmtInt = (n: number | null | undefined): string =>
+    n === null || n === undefined ? "-" : String(n);
+
+interface MetricRow {
+    readonly label: string;
+    readonly values: ReadonlyArray<string>;
+    /** Index of the winning session column, or null for unranked rows. */
+    readonly winner: number | null;
+}
+
+const winnerIndex = (
+    entries: ReadonlyArray<SessionCompareEntry>,
+    winnerId: SessionId | null,
+): number | null => {
+    if (winnerId === null) return null;
+    const idx = entries.findIndex((e) => e.session_id === winnerId);
+    return idx >= 0 ? idx : null;
+};
+
+/** Lane tag for a winner id, or null when no winner / not present. */
+const winnerLane = (
+    entries: ReadonlyArray<SessionCompareEntry>,
+    winnerId: SessionId | null,
+): string | null => {
+    const idx = winnerIndex(entries, winnerId);
+    return idx === null ? null : laneTag(idx);
+};
+
+const buildRows = (payload: SessionComparePayload): ReadonlyArray<MetricRow> => {
+    const s = payload.sessions;
+    const col = <T,>(pick: (entry: SessionCompareEntry) => T): ReadonlyArray<T> =>
+        s.map(pick);
+    return [
+        { label: "source", values: col((e) => e.source), winner: null },
+        { label: "model", values: col((e) => e.model ?? "-"), winner: null },
+        {
+            label: "duration",
+            values: col((e) => fmtDuration(e.duration_ms)),
+            winner: winnerIndex(s, payload.winners.fastest),
+        },
+        {
+            label: "turns",
+            values: col((e) => fmtInt(e.health?.turns ?? null)),
+            winner: null,
+        },
+        {
+            label: "tokens",
+            values: col((e) => fmtTokens(e.token_usage?.estimated_tokens ?? null)),
+            winner: winnerIndex(s, payload.winners.fewest_tokens),
+        },
+        {
+            label: "cost",
+            values: col((e) => fmtCost(e.token_usage?.estimated_cost_usd ?? null)),
+            winner: winnerIndex(s, payload.winners.cheapest),
+        },
+        {
+            label: "tool calls",
+            values: col((e) => fmtInt(e.health?.tool_calls ?? null)),
+            winner: null,
+        },
+        {
+            label: "tool errors",
+            values: col((e) => fmtInt(e.health?.tool_errors ?? null)),
+            winner: null,
+        },
+        {
+            label: "corrections",
+            values: col((e) => fmtInt(e.health?.user_corrections ?? null)),
+            winner: null,
+        },
+        {
+            label: "interruptions",
+            values: col((e) => fmtInt(e.health?.interruptions ?? null)),
+            winner: null,
+        },
+        {
+            label: "noise (err+corr+int)",
+            values: col((e) => fmtInt(e.noise_score)),
+            winner: winnerIndex(s, payload.winners.cleanest),
+        },
+        {
+            label: "commits",
+            values: col((e) => fmtInt(e.commit_count)),
+            winner: null,
+        },
+    ];
+};
+
+const pad = (text: string, width: number): string =>
+    text + " ".repeat(Math.max(0, width - text.length));
+
+export const renderCompareTable = (payload: SessionComparePayload): string => {
+    const sessions = payload.sessions;
+    const lines: string[] = [];
+
+    const taskLine = payload.task_label
+        ? `task: ${payload.task_label}`
+        : "task: (mixed / unlabeled)";
+    lines.push(`Comparing ${sessions.length} sessions  ·  ${taskLine}`);
+
+    // Legend maps each lane tag to its full session id (+ project), so the
+    // table can use compact, unambiguous [n] column headers.
+    for (let i = 0; i < sessions.length; i++) {
+        const e = sessions[i]!;
+        const project = e.project ? `  (${e.project})` : "";
+        lines.push(`  ${laneTag(i)} ${e.session_id}${project}`);
+    }
+    lines.push("");
+
+    // Cell text per row, winner star applied.
+    const headers = ["metric", ...sessions.map((_, i) => laneTag(i))];
+    const rows = buildRows(payload);
+    const body: string[][] = rows.map((row) => [
+        row.label,
+        ...row.values.map((v, i) => (row.winner === i ? `${v} *` : v)),
+    ]);
+
+    // Column widths across header + body.
+    const colCount = headers.length;
+    const widths = Array.from({ length: colCount }, (_, c) =>
+        Math.max(headers[c]!.length, ...body.map((r) => r[c]!.length)),
+    );
+
+    const renderLine = (cells: ReadonlyArray<string>): string =>
+        cells.map((cell, c) => pad(cell, widths[c]!)).join(" | ");
+
+    lines.push(renderLine(headers));
+    lines.push(widths.map((w) => "-".repeat(w)).join("-+-"));
+    for (const r of body) lines.push(renderLine(r));
+
+    lines.push("");
+    const w = payload.winners;
+    const winnerBits: string[] = [];
+    const fastest = winnerLane(sessions, w.fastest);
+    const cheapest = winnerLane(sessions, w.cheapest);
+    const fewest = winnerLane(sessions, w.fewest_tokens);
+    const cleanest = winnerLane(sessions, w.cleanest);
+    if (fastest) winnerBits.push(`fastest ${fastest}`);
+    if (cheapest) winnerBits.push(`cheapest ${cheapest}`);
+    if (fewest) winnerBits.push(`fewest tokens ${fewest}`);
+    if (cleanest) winnerBits.push(`cleanest ${cleanest}`);
+    lines.push(winnerBits.length > 0 ? `Winners: ${winnerBits.join(" · ")}` : "Winners: (no clear winner)");
+
+    if (payload.not_found.length > 0) {
+        lines.push(`Not found: ${payload.not_found.join(", ")}`);
+    }
+
+    return lines.join("\n");
+};

--- a/apps/axctl/src/cli/session-compare-format.ts
+++ b/apps/axctl/src/cli/session-compare-format.ts
@@ -6,6 +6,7 @@
 import type {
     SessionCompareEntry,
     SessionComparePayload,
+    SessionCompareTurn,
     SessionId,
 } from "@ax/lib/shared/dashboard-types";
 
@@ -129,6 +130,57 @@ const buildRows = (payload: SessionComparePayload): ReadonlyArray<MetricRow> => 
 const pad = (text: string, width: number): string =>
     text + " ".repeat(Math.max(0, width - text.length));
 
+const fmtTurnGap = (ms: number | null): string => {
+    if (ms === null) return "";
+    const s = Math.round(ms / 1000);
+    if (s >= 60) return `${Math.floor(s / 60)}m${String(s % 60).padStart(2, "0")}`;
+    return `${s}s`;
+};
+
+/** Per-turn appendix: index-aligned lanes (turn N of session [1] vs turn N of
+ *  [2] …). Cell = tokens + optional gap, `!` flags an error turn. Empty cell
+ *  when a session has no turn at that index (ragged → padded). Returns [] when
+ *  no session carries per-turn data. */
+const renderTurnsBlock = (
+    sessions: ReadonlyArray<SessionCompareEntry>,
+): ReadonlyArray<string> => {
+    const lanes = sessions.map((e) => e.turns ?? null);
+    if (!lanes.some((l) => l !== null && l.length > 0)) return [];
+
+    const maxTurns = Math.max(...lanes.map((l) => l?.length ?? 0));
+
+    const cell = (turn: SessionCompareTurn | undefined): string => {
+        if (!turn) return "";
+        const tok = fmtTokens(turn.est_tokens);
+        const gap = fmtTurnGap(turn.gap_ms);
+        const base = gap ? `${tok} ${gap}` : tok;
+        return turn.has_error ? `${base} !` : base;
+    };
+
+    const headers = ["turn", ...sessions.map((_, i) => laneTag(i))];
+    const body: string[][] = [];
+    for (let i = 0; i < maxTurns; i++) {
+        body.push([
+            String(i + 1),
+            ...lanes.map((lane) => cell(lane?.[i])),
+        ]);
+    }
+
+    const widths = headers.map((h, c) =>
+        Math.max(h.length, ...body.map((r) => r[c]!.length)),
+    );
+    const renderLine = (cells: ReadonlyArray<string>): string =>
+        cells.map((c, i) => pad(c, widths[i]!)).join(" | ");
+
+    const lines: string[] = [];
+    lines.push("");
+    lines.push("Per-turn (index-aligned · cell = tokens [gap], ! = error turn)");
+    lines.push(renderLine(headers));
+    lines.push(widths.map((w) => "-".repeat(w)).join("-+-"));
+    for (const r of body) lines.push(renderLine(r));
+    return lines;
+};
+
 export const renderCompareTable = (payload: SessionComparePayload): string => {
     const sessions = payload.sessions;
     const lines: string[] = [];
@@ -184,6 +236,8 @@ export const renderCompareTable = (payload: SessionComparePayload): string => {
     if (payload.not_found.length > 0) {
         lines.push(`Not found: ${payload.not_found.join(", ")}`);
     }
+
+    lines.push(...renderTurnsBlock(sessions));
 
     return lines.join("\n");
 };

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -25,6 +25,7 @@ import {
 } from "./skill-source.ts";
 import { fetchWorkflow } from "./workflow.ts";
 import { fetchSessionDetail } from "./session-detail.ts";
+import { fetchSessionCompare } from "./session-compare.ts";
 import { fetchSessionInspect } from "./session-inspect.ts";
 import { fetchSessionChildren, fetchSessionsList } from "./sessions-list.ts";
 import { fetchEpisodeTimeline } from "./episode-timeline.ts";
@@ -679,6 +680,27 @@ export async function handleDashboardRequest(req: Request): Promise<Response> {
     }
 
     // Specific routes before the catch-all `sessions/(.+)` below.
+    if (url.pathname === "/api/sessions/compare" && req.method === "GET") {
+        const ids = (url.searchParams.get("ids") ?? "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        const includeTurns = url.searchParams.get("turns") === "1";
+        if (ids.length < 2) {
+            return jsonResponse({ error: "need at least 2 session ids (ids=a,b)" }, 400);
+        }
+        try {
+            const payload = await Effect.runPromise(
+                fetchSessionCompare(ids, { includeTurns }).pipe(
+                    Effect.provide(AppLayer),
+                    Effect.scoped,
+                ) as Effect.Effect<unknown>,
+            );
+            return jsonResponse(payload);
+        } catch (err) {
+            return jsonResponse({ error: err instanceof Error ? err.message : String(err) }, 500);
+        }
+    }
     const sessionChildrenMatch = url.pathname.match(/^\/api\/sessions\/(.+)\/children$/);
     if (sessionChildrenMatch && req.method === "GET") {
         const parentId = decodeURIComponent(sessionChildrenMatch[1] ?? "");

--- a/apps/axctl/src/dashboard/session-compare.ts
+++ b/apps/axctl/src/dashboard/session-compare.ts
@@ -1,0 +1,152 @@
+/**
+ * Multi-session compare (swimlane P0 - summary metrics).
+ *
+ * Fetches a handful of sessions and lines up their headline metrics so the
+ * caller can answer "same task, which run was faster / cheaper / cleaner?".
+ * Reuses the per-session detail queries (overview, token usage) plus two
+ * compare-specific reads (session_health, produced-edge count). No per-turn
+ * data yet - that's P1.
+ *
+ * Latency note: `duration_ms` is wall-clock (ended_at - started_at). Raw
+ * transcripts carry no request duration / TTFT, so true per-turn model
+ * latency is not derivable here - see the compare-view plan.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import {
+    sessionHealthQuery,
+    sessionOverviewQuery,
+    sessionProducedCountQuery,
+    sessionTokenUsageQuery,
+} from "../queries/session-detail.ts";
+import type {
+    SessionCompareEntry,
+    SessionComparePayload,
+    SessionCompareWinners,
+    SessionHealthSummary,
+    SessionId,
+    SessionOverview,
+    SessionTokenUsageDetail,
+} from "@ax/lib/shared/dashboard-types";
+import { runSingleQuery } from "@ax/lib/shared/graph-query";
+
+// Mirrors the validation in session-detail.ts: accept real UUIDs and our
+// synthetic prefixed ids, restricted to SurrealDB's unquoted-id charset so the
+// record ref can be safely interpolated.
+const SESSION_ID_RE = /^[A-Za-z0-9_-]{6,80}$/;
+
+const normalizeUuid = (sessionId: string): string =>
+    sessionId
+        .replace(/^session:⟨/, "")
+        .replace(/⟩$/, "")
+        .replace(/^session:/, "");
+
+const durationMs = (overview: SessionOverview): number | null => {
+    if (!overview.started_at || !overview.ended_at) return null;
+    const start = new Date(overview.started_at).getTime();
+    const end = new Date(overview.ended_at).getTime();
+    if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
+    return end - start;
+};
+
+const noiseScore = (health: SessionHealthSummary | null): number | null =>
+    health === null
+        ? null
+        : health.tool_errors + health.user_corrections + health.interruptions;
+
+/**
+ * Pick the session with the unique minimum finite metric. Returns null when no
+ * session has the metric, or when the minimum is shared (a tie is not a clear
+ * winner). Comparing a single session is meaningless, so callers should only
+ * trust winners with 2+ entries.
+ */
+const argMinUnique = (
+    entries: ReadonlyArray<SessionCompareEntry>,
+    pick: (entry: SessionCompareEntry) => number | null,
+): SessionId | null => {
+    const candidates = entries
+        .map((entry) => ({ id: entry.session_id, value: pick(entry) }))
+        .filter((c): c is { id: SessionId; value: number } =>
+            c.value !== null && Number.isFinite(c.value),
+        );
+    if (candidates.length === 0) return null;
+    let best = candidates[0]!;
+    let tied = false;
+    for (const c of candidates.slice(1)) {
+        if (c.value < best.value) {
+            best = c;
+            tied = false;
+        } else if (c.value === best.value) {
+            tied = true;
+        }
+    }
+    return tied ? null : best.id;
+};
+
+const computeWinners = (
+    entries: ReadonlyArray<SessionCompareEntry>,
+): SessionCompareWinners => ({
+    fastest: argMinUnique(entries, (e) => e.duration_ms),
+    cheapest: argMinUnique(entries, (e) => e.token_usage?.estimated_cost_usd ?? null),
+    fewest_tokens: argMinUnique(entries, (e) => e.token_usage?.estimated_tokens ?? null),
+    cleanest: argMinUnique(entries, (e) => e.noise_score),
+});
+
+const sharedTaskLabel = (
+    entries: ReadonlyArray<SessionCompareEntry>,
+): string | null => {
+    const labels = entries.map((e) => e.health?.task_label ?? null);
+    const first = labels[0] ?? null;
+    if (first === null) return null;
+    return labels.every((l) => l === first) ? first : null;
+};
+
+export const fetchSessionCompare = (
+    sessionIds: ReadonlyArray<string>,
+): Effect.Effect<SessionComparePayload, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const notFound: string[] = [];
+        const entries: SessionCompareEntry[] = [];
+
+        for (const sessionId of sessionIds) {
+            const uuid = normalizeUuid(sessionId);
+            if (!SESSION_ID_RE.test(uuid)) {
+                notFound.push(sessionId);
+                continue;
+            }
+            const params = { recordRef: `session:⟨${uuid}⟩` };
+            const [overview, token_usage, health, commit_count] = yield* Effect.all([
+                runSingleQuery(sessionOverviewQuery, params),
+                runSingleQuery(sessionTokenUsageQuery, params),
+                runSingleQuery(sessionHealthQuery, params),
+                runSingleQuery(sessionProducedCountQuery, params),
+            ]);
+
+            if (overview === null) {
+                notFound.push(sessionId);
+                continue;
+            }
+
+            entries.push({
+                session_id: overview.id,
+                source: overview.source,
+                model: overview.model,
+                project: overview.project,
+                started_at: overview.started_at,
+                ended_at: overview.ended_at,
+                duration_ms: durationMs(overview),
+                token_usage: token_usage as SessionTokenUsageDetail | null,
+                health: health as SessionHealthSummary | null,
+                commit_count: commit_count ?? 0,
+                noise_score: noiseScore(health as SessionHealthSummary | null),
+            });
+        }
+
+        return {
+            task_label: sharedTaskLabel(entries),
+            sessions: entries,
+            winners: computeWinners(entries),
+            not_found: notFound,
+        };
+    });

--- a/apps/axctl/src/dashboard/session-compare.ts
+++ b/apps/axctl/src/dashboard/session-compare.ts
@@ -15,21 +15,29 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import {
+    sessionCompareTurnsQuery,
     sessionHealthQuery,
     sessionOverviewQuery,
     sessionProducedCountQuery,
     sessionTokenUsageQuery,
+    sessionTurnTokenUsageQuery,
 } from "../queries/session-detail.ts";
 import type {
     SessionCompareEntry,
     SessionComparePayload,
+    SessionCompareTurn,
     SessionCompareWinners,
     SessionHealthSummary,
     SessionId,
     SessionOverview,
     SessionTokenUsageDetail,
 } from "@ax/lib/shared/dashboard-types";
-import { runSingleQuery } from "@ax/lib/shared/graph-query";
+import { runQuery, runSingleQuery } from "@ax/lib/shared/graph-query";
+
+export interface SessionCompareOptions {
+    /** Attach the per-turn timeline (P1). Off by default - summary only. */
+    readonly includeTurns?: boolean;
+}
 
 // Mirrors the validation in session-detail.ts: accept real UUIDs and our
 // synthetic prefixed ids, restricted to SurrealDB's unquoted-id charset so the
@@ -102,8 +110,50 @@ const sharedTaskLabel = (
     return labels.every((l) => l === first) ? first : null;
 };
 
+/** Build the per-turn timeline: turn spine merged with token usage (by seq),
+ *  with wall-clock gaps derived from consecutive timestamps. */
+const buildTurns = (params: { recordRef: string }) =>
+    Effect.gen(function* () {
+        const [spine, usage] = yield* Effect.all([
+            runQuery(sessionCompareTurnsQuery, params),
+            runQuery(sessionTurnTokenUsageQuery, params),
+        ]);
+        const usageBySeq = new Map<number, { tokens: number | null; cost: number | null }>();
+        for (const u of usage) {
+            if (u === null) continue;
+            usageBySeq.set(u.seq, {
+                tokens: u.estimated_tokens ?? null,
+                cost: u.estimated_cost_usd ?? null,
+            });
+        }
+
+        let prevMs: number | null = null;
+        const turns: SessionCompareTurn[] = [];
+        for (const row of spine) {
+            if (row === null) continue;
+            const ms = row.ts ? new Date(row.ts).getTime() : null;
+            const gap_ms =
+                prevMs !== null && ms !== null && Number.isFinite(ms) && ms >= prevMs
+                    ? ms - prevMs
+                    : null;
+            if (ms !== null && Number.isFinite(ms)) prevMs = ms;
+            const u = usageBySeq.get(row.seq);
+            turns.push({
+                seq: row.seq,
+                role: row.role,
+                ts: row.ts,
+                gap_ms,
+                est_tokens: u?.tokens ?? null,
+                est_cost_usd: u?.cost ?? null,
+                has_error: row.has_error,
+            });
+        }
+        return turns;
+    });
+
 export const fetchSessionCompare = (
     sessionIds: ReadonlyArray<string>,
+    options: SessionCompareOptions = {},
 ): Effect.Effect<SessionComparePayload, DbError, SurrealClient> =>
     Effect.gen(function* () {
         const notFound: string[] = [];
@@ -128,6 +178,8 @@ export const fetchSessionCompare = (
                 continue;
             }
 
+            const turns = options.includeTurns ? yield* buildTurns(params) : undefined;
+
             entries.push({
                 session_id: overview.id,
                 source: overview.source,
@@ -140,6 +192,7 @@ export const fetchSessionCompare = (
                 health: health as SessionHealthSummary | null,
                 commit_count: commit_count ?? 0,
                 noise_score: noiseScore(health as SessionHealthSummary | null),
+                ...(turns ? { turns } : {}),
             });
         }
 

--- a/apps/axctl/src/dashboard/web/src/api.ts
+++ b/apps/axctl/src/dashboard/web/src/api.ts
@@ -8,6 +8,7 @@ import type {
     RecallResponse,
     SkillGraphPayload,
     SessionChildrenResponse,
+    SessionComparePayload,
     SessionDetailPayload,
     SessionInspectPayload,
     SessionListResponse,
@@ -191,6 +192,12 @@ export const api = {
         return jsonFetch(qs
             ? `/api/sessions/${encodeURIComponent(sessionId)}/inspect?${qs}`
             : `/api/sessions/${encodeURIComponent(sessionId)}/inspect`);
+    },
+    sessionCompare: (ids: ReadonlyArray<string>, params: { turns?: boolean } = {}): Promise<SessionComparePayload> => {
+        const usp = new URLSearchParams();
+        usp.set("ids", ids.join(","));
+        if (params.turns) usp.set("turns", "1");
+        return jsonFetch(`/api/sessions/compare?${usp.toString()}`);
     },
     episodeTimeline: (parentId: string): Promise<EpisodeTimelinePayload> =>
         jsonFetch(`/api/episodes/${encodeURIComponent(parentId)}`),

--- a/apps/axctl/src/dashboard/web/src/mock-fixtures.ts
+++ b/apps/axctl/src/dashboard/web/src/mock-fixtures.ts
@@ -201,6 +201,13 @@ const EMPTY_SESSION_LIST: SessionListResponse = {
     limit: 200,
 } as never;
 
+const EMPTY_SESSION_COMPARE = {
+    task_label: null,
+    sessions: [],
+    winners: { fastest: null, cheapest: null, fewest_tokens: null, cleanest: null },
+    not_found: [],
+} as never;
+
 const EMPTY_TOOL_FAILURES: ToolFailuresResponse = { rows: [], total: 0 } as never;
 const EMPTY_GRAPH: GraphExplorerPayload = { mode: "file-attention", limit: 0, nodes: [], edges: [], query: null } as never;
 const EMPTY_SKILL_GRAPH: SkillGraphPayload = { min_count: 0, limit: 0, node_count: 0, edge_count: 0, max_edge_count: 0, nodes: [], edges: [] };
@@ -268,6 +275,7 @@ export async function mockFetch<T>(input: RequestInfo, init?: RequestInit): Prom
     }
 
     // Empties
+    if (path.startsWith("/api/sessions/compare")) return EMPTY_SESSION_COMPARE as unknown as T;
     if (path.startsWith("/api/sessions")) return EMPTY_SESSION_LIST as unknown as T;
     if (path === "/api/tool-failures" || path.startsWith("/api/tool-failures/")) return EMPTY_TOOL_FAILURES as unknown as T;
     if (path.startsWith("/api/graph-explorer")) return EMPTY_GRAPH as unknown as T;

--- a/apps/axctl/src/dashboard/web/src/router.tsx
+++ b/apps/axctl/src/dashboard/web/src/router.tsx
@@ -14,6 +14,7 @@ import { SessionRoute } from "./routes/session.tsx";
 import { SessionInspectRoute } from "./routes/session-inspect.tsx";
 import { ShareInspectRoute } from "./routes/share-inspect.tsx";
 import { SessionsRoute } from "./routes/sessions.tsx";
+import { SessionsCompareRoute } from "./routes/sessions-compare.tsx";
 import { EpisodeRoute } from "./routes/episode.tsx";
 import { ProjectRoute } from "./routes/project.tsx";
 import { RecallRoute } from "./routes/recall.tsx";
@@ -101,6 +102,17 @@ const sessionsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/sessions",
     component: SessionsRoute,
+});
+
+// Static segment - must out-prioritize /sessions/$sessionId below.
+const sessionsCompareRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/sessions/compare",
+    component: SessionsCompareRoute,
+    validateSearch: (search): { ids?: string; turns?: boolean } => ({
+        ids: typeof search.ids === "string" ? search.ids : undefined,
+        turns: search.turns === true || search.turns === "1" || search.turns === "true",
+    }),
 });
 
 const sessionRoute = createRoute({
@@ -217,6 +229,7 @@ const routeTree = rootRoute.addChildren([
     toolsRoute,
     workflowRoute,
     sessionsRoute,
+    sessionsCompareRoute,
     sessionRoute,
     sessionInspectRoute,
     shareInspectRoute,

--- a/apps/axctl/src/dashboard/web/src/routes/sessions-compare.tsx
+++ b/apps/axctl/src/dashboard/web/src/routes/sessions-compare.tsx
@@ -1,0 +1,199 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link, useSearch } from "@tanstack/react-router";
+import { api } from "../api.ts";
+import type {
+    SessionCompareEntry,
+    SessionId,
+} from "@shared/dashboard-types.ts";
+import { shortSessionId } from "@shared/session-id.ts";
+import { prettifyProjectSlug } from "@shared/project-slug.ts";
+
+const fmtDuration = (ms: number | null): string => {
+    if (ms === null) return "-";
+    const s = Math.round(ms / 1000);
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    if (h > 0) return `${h}h ${String(m).padStart(2, "0")}m`;
+    if (m > 0) return `${m}m ${String(s % 60).padStart(2, "0")}s`;
+    return `${s}s`;
+};
+
+const fmtTokens = (n: number | null | undefined): string => {
+    if (n === null || n === undefined) return "-";
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return String(n);
+};
+
+const fmtCost = (n: number | null | undefined): string =>
+    n === null || n === undefined ? "-" : `$${n.toFixed(2)}`;
+
+const fmtInt = (n: number | null | undefined): string =>
+    n === null || n === undefined ? "-" : String(n);
+
+const laneTag = (i: number): string => `[${i + 1}]`;
+
+interface MetricRow {
+    readonly label: string;
+    readonly value: (e: SessionCompareEntry) => string;
+    readonly winner?: SessionId | null;
+    /** Lower-is-better axes get the winner highlight. */
+    readonly ranked?: boolean;
+}
+
+export function SessionsCompareRoute() {
+    const search = useSearch({ from: "/sessions/compare" });
+    const ids = (search.ids ?? "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    const turns = search.turns === true;
+
+    const query = useQuery({
+        queryKey: ["sessions-compare", ids.join(","), turns],
+        queryFn: () => api.sessionCompare(ids, { turns }),
+        enabled: ids.length >= 2,
+    });
+    const data = query.data ?? null;
+    const sessions = data?.sessions ?? [];
+
+    const rows = useMemo<ReadonlyArray<MetricRow>>(() => {
+        if (!data) return [];
+        const w = data.winners;
+        return [
+            { label: "source", value: (e) => e.source },
+            { label: "model", value: (e) => e.model ?? "-" },
+            { label: "duration", value: (e) => fmtDuration(e.duration_ms), winner: w.fastest, ranked: true },
+            { label: "turns", value: (e) => fmtInt(e.health?.turns ?? null) },
+            { label: "tokens", value: (e) => fmtTokens(e.token_usage?.estimated_tokens ?? null), winner: w.fewest_tokens, ranked: true },
+            { label: "cost", value: (e) => fmtCost(e.token_usage?.estimated_cost_usd ?? null), winner: w.cheapest, ranked: true },
+            { label: "tool calls", value: (e) => fmtInt(e.health?.tool_calls ?? null) },
+            { label: "tool errors", value: (e) => fmtInt(e.health?.tool_errors ?? null) },
+            { label: "corrections", value: (e) => fmtInt(e.health?.user_corrections ?? null) },
+            { label: "interruptions", value: (e) => fmtInt(e.health?.interruptions ?? null) },
+            { label: "noise (err+corr+int)", value: (e) => fmtInt(e.noise_score), winner: w.cleanest, ranked: true },
+            { label: "commits", value: (e) => fmtInt(e.commit_count) },
+        ];
+    }, [data]);
+
+    const maxTurnTokens = useMemo(() => {
+        let max = 0;
+        for (const s of sessions) {
+            for (const t of s.turns ?? []) {
+                if (t.est_tokens && t.est_tokens > max) max = t.est_tokens;
+            }
+        }
+        return max;
+    }, [sessions]);
+
+    const hasTurns = sessions.some((s) => (s.turns?.length ?? 0) > 0);
+    const maxTurnCount = Math.max(0, ...sessions.map((s) => s.turns?.length ?? 0));
+
+    return (
+        <section className="panel">
+            <header>
+                <h2>Compare sessions</h2>
+                <span className="meta">
+                    {data
+                        ? `${sessions.length} sessions${data.task_label ? ` · task: ${data.task_label}` : " · task: (mixed)"}`
+                        : ""}
+                </span>
+            </header>
+
+            {ids.length < 2 ? (
+                <div className="empty">
+                    Select 2+ sessions to compare (from the Sessions list), or open
+                    <code> /sessions/compare?ids=a,b</code>.
+                </div>
+            ) : null}
+
+            {query.error ? <div className="error">Error: {String(query.error)}</div> : null}
+            {query.isLoading ? <div className="loading">Loading…</div> : null}
+
+            {data && data.not_found.length > 0 ? (
+                <div className="error">Not found: {data.not_found.join(", ")}</div>
+            ) : null}
+
+            {data && sessions.length >= 2 ? (
+                <>
+                    {/* Lane legend */}
+                    <ul className="compare-legend">
+                        {sessions.map((s, i) => (
+                            <li key={s.session_id}>
+                                <span className="lane-tag">{laneTag(i)}</span>{" "}
+                                <Link to="/sessions/$sessionId" params={{ sessionId: s.session_id }}>
+                                    {shortSessionId(s.session_id)}
+                                </Link>
+                                {s.project ? (
+                                    <small className="meta"> · {prettifyProjectSlug(s.project)}</small>
+                                ) : null}
+                            </li>
+                        ))}
+                    </ul>
+
+                    {/* Summary strip */}
+                    <table className="skills compare-table">
+                        <thead>
+                            <tr>
+                                <th>metric</th>
+                                {sessions.map((s, i) => (
+                                    <th key={s.session_id} className="num">{laneTag(i)}</th>
+                                ))}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {rows.map((row) => (
+                                <tr key={row.label}>
+                                    <td className="skill-cell">{row.label}</td>
+                                    {sessions.map((s) => {
+                                        const isWin = row.ranked && row.winner === s.session_id;
+                                        return (
+                                            <td key={s.session_id} className={`num${isWin ? " win" : ""}`}>
+                                                {isWin ? <strong>{row.value(s)} ★</strong> : row.value(s)}
+                                            </td>
+                                        );
+                                    })}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+
+                    {/* Per-turn swimlane */}
+                    {turns && hasTurns ? (
+                        <div className="swimlane-wrap">
+                            <h3>Per-turn (index-aligned · brightness = tokens · red = error)</h3>
+                            <div
+                                className="swimlane"
+                                style={{ gridTemplateColumns: `repeat(${sessions.length}, minmax(80px, 1fr))` }}
+                            >
+                                {sessions.map((s, i) => (
+                                    <div key={s.session_id} className="swimlane-col">
+                                        <div className="swimlane-head">{laneTag(i)}</div>
+                                        {Array.from({ length: maxTurnCount }, (_, ti) => {
+                                            const t = s.turns?.[ti];
+                                            if (!t) return <div key={ti} className="turn-cell empty" />;
+                                            const intensity = maxTurnTokens > 0 && t.est_tokens
+                                                ? Math.max(0.12, t.est_tokens / maxTurnTokens)
+                                                : 0.06;
+                                            return (
+                                                <div
+                                                    key={ti}
+                                                    className={`turn-cell${t.has_error ? " err" : ""}`}
+                                                    style={{ background: `rgba(56, 189, 248, ${intensity})` }}
+                                                    title={`turn ${t.seq} · ${t.role ?? "?"} · ${fmtTokens(t.est_tokens)} tok${t.gap_ms != null ? ` · gap ${Math.round(t.gap_ms / 1000)}s` : ""}${t.has_error ? " · ERROR" : ""}`}
+                                                >
+                                                    {fmtTokens(t.est_tokens)}
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    ) : null}
+                </>
+            ) : null}
+        </section>
+    );
+}

--- a/apps/axctl/src/dashboard/web/src/routes/sessions.tsx
+++ b/apps/axctl/src/dashboard/web/src/routes/sessions.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { api } from "../api.ts";
 import { prettifyProjectSlug } from "@shared/project-slug.ts";
 import type { SessionListResponse, SessionListRow } from "@shared/dashboard-types.ts";
@@ -47,9 +47,10 @@ interface RowProps {
     readonly s: SessionListRow;
     readonly indent?: boolean;
     readonly expandedToggle?: { expanded: boolean; childCount: number; loading?: boolean; onToggle: () => void };
+    readonly select?: { checked: boolean; onToggle: () => void };
 }
 
-function Row({ s, indent, expandedToggle }: RowProps) {
+function Row({ s, indent, expandedToggle, select }: RowProps) {
     // The wire seam delivers a bare session id (see src/lib/shared/session-id.ts);
     // any backtick/`session:` prefix reaching us would be a server bug.
     const sid = s.id;
@@ -72,6 +73,14 @@ function Row({ s, indent, expandedToggle }: RowProps) {
 
     return (
         <tr style={rowStyle} onMouseEnter={onIntent} onFocus={onIntent}>
+            <td style={{ textAlign: "center", width: 28 }}>
+                <input
+                    type="checkbox"
+                    checked={select?.checked ?? false}
+                    onChange={() => select?.onToggle()}
+                    aria-label={`Select ${shortSessionId(s.id)} to compare`}
+                />
+            </td>
             <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, paddingLeft: indent ? 32 : 8 }}>
                 {expandedToggle ? (
                     <button
@@ -118,9 +127,29 @@ const PAGE_SIZE = 200;
 
 export function SessionsRoute() {
     const queryClient = useQueryClient();
+    const navigate = useNavigate();
     const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
     const [search, setSearch] = useState("");
     const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+    const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
+
+    const toggleSelected = (id: string) => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    };
+
+    const compareSelected = () => {
+        const ids = Array.from(selected);
+        if (ids.length < 2) return;
+        void navigate({
+            to: "/sessions/compare",
+            search: { ids: ids.join(","), turns: true },
+        });
+    };
 
     // Cache by filter set only - appended pages share the same key so
     // setQueryData accumulates across loadMore() calls (mirrors recall.tsx).
@@ -297,12 +326,38 @@ export function SessionsRoute() {
                         {expanded.size === allExpandableIds.length ? "collapse all" : "expand all"}
                     </button>
                 ) : null}
+                <button
+                    onClick={compareSelected}
+                    disabled={selected.size < 2}
+                    title={selected.size < 2 ? "Select 2+ sessions to compare" : `Compare ${selected.size} sessions`}
+                    style={{
+                        padding: "4px 12px", fontSize: 11, fontWeight: 600,
+                        border: "1px solid #e2e8f0", borderRadius: 4,
+                        background: selected.size >= 2 ? "#0f172a" : "#fff",
+                        color: selected.size >= 2 ? "#fff" : "#cbd5e1",
+                        cursor: selected.size >= 2 ? "pointer" : "not-allowed",
+                    }}
+                >
+                    compare{selected.size > 0 ? ` (${selected.size})` : ""}
+                </button>
+                {selected.size > 0 ? (
+                    <button
+                        onClick={() => setSelected(new Set())}
+                        style={{
+                            padding: "4px 8px", fontSize: 11, border: "1px solid #e2e8f0",
+                            background: "#fff", color: "#475569", borderRadius: 4, cursor: "pointer",
+                        }}
+                    >
+                        clear
+                    </button>
+                ) : null}
             </div>
             {query.isLoading && !query.data ? <div className="loading">Loading…</div> : null}
             {query.data ? (
                 <table style={{ width: "100%", borderCollapse: "collapse" }}>
                     <thead>
                         <tr style={{ background: "#f8fafc", fontSize: 11, color: "#475569", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                            <th style={{ width: 28 }}></th>
                             <th style={{ textAlign: "left", padding: "6px 8px" }}>id</th>
                             <th style={{ textAlign: "left", padding: "6px 8px" }}>source</th>
                             <th style={{ textAlign: "left", padding: "6px 8px" }}>project</th>
@@ -321,6 +376,7 @@ export function SessionsRoute() {
                                 <Fragment key={parent.id}>
                                     <Row
                                         s={parent}
+                                        select={{ checked: selected.has(parent.id), onToggle: () => toggleSelected(parent.id) }}
                                         {...(childCount > 0
                                             ? {
                                                 expandedToggle: {
@@ -333,14 +389,21 @@ export function SessionsRoute() {
                                             : {})}
                                     />
                                     {isExpanded
-                                        ? (kidState?.rows ?? []).map((child) => <Row key={child.id} s={child} indent />)
+                                        ? (kidState?.rows ?? []).map((child) => (
+                                            <Row
+                                                key={child.id}
+                                                s={child}
+                                                indent
+                                                select={{ checked: selected.has(child.id), onToggle: () => toggleSelected(child.id) }}
+                                            />
+                                        ))
                                         : null}
                                 </Fragment>
                             );
                         })}
                         {allRoots.length < totalCount ? (
                             <tr ref={sentinelRef}>
-                                <td colSpan={7} style={{
+                                <td colSpan={8} style={{
                                     padding: "12px 24px", color: "#64748b", fontSize: 12,
                                     fontFamily: "ui-monospace, monospace",
                                     textAlign: "center", borderTop: "1px dashed #e2e8f0",

--- a/apps/axctl/src/dashboard/web/src/styles.css
+++ b/apps/axctl/src/dashboard/web/src/styles.css
@@ -1953,3 +1953,71 @@ td.skill-cell .description {
         grid-template-columns: 1fr;
     }
 }
+
+/* ── Session compare (swimlane) ─────────────────────────────────── */
+.compare-legend {
+    list-style: none;
+    margin: 8px 0 12px;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 12px;
+}
+.compare-legend .lane-tag {
+    display: inline-block;
+    min-width: 26px;
+    font-family: ui-monospace, monospace;
+    font-weight: 700;
+    color: #475569;
+}
+.compare-table td.win {
+    background: rgba(34, 197, 94, 0.12);
+}
+.compare-table td.win strong {
+    color: #15803d;
+}
+.swimlane-wrap {
+    margin-top: 20px;
+}
+.swimlane-wrap h3 {
+    font-size: 13px;
+    color: #475569;
+    margin: 0 0 8px;
+}
+.swimlane {
+    display: grid;
+    gap: 8px;
+    align-items: start;
+}
+.swimlane-col {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.swimlane-head {
+    font-family: ui-monospace, monospace;
+    font-weight: 700;
+    font-size: 12px;
+    color: #475569;
+    text-align: center;
+    padding-bottom: 4px;
+}
+.turn-cell {
+    font-family: ui-monospace, monospace;
+    font-size: 10px;
+    color: #0f172a;
+    text-align: center;
+    padding: 2px 4px;
+    border-radius: 3px;
+    border: 1px solid transparent;
+    min-height: 16px;
+}
+.turn-cell.empty {
+    background: transparent !important;
+    border: 1px dashed #e2e8f0;
+}
+.turn-cell.err {
+    border-color: #ef4444;
+    box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.4);
+}

--- a/apps/axctl/src/queries/session-detail.ts
+++ b/apps/axctl/src/queries/session-detail.ts
@@ -16,6 +16,7 @@ import { toBareSessionId } from "@ax/lib/shared/session-id";
 import { decodeJsonOrNull } from "@ax/lib/decode";
 import type {
     SessionAgentDelegation,
+    SessionHealthSummary,
     SessionLink,
     SessionOverview,
     SessionTokenUsageDetail,
@@ -140,6 +141,28 @@ FROM turn_token_usage
 WHERE session = $sessionId
 ORDER BY seq ASC
 LIMIT 2000;`;
+
+/** Per-session health aggregate. One row/session, UNIQUE on session. Powers
+ *  the compare view's turns / errors / corrections / interruptions axes. */
+export const SESSION_HEALTH_SQL = `
+SELECT
+    turns,
+    tool_calls,
+    tool_errors,
+    user_corrections,
+    interruptions,
+    subagent_dispatches,
+    task_label
+FROM session_health
+WHERE session = $sessionId
+LIMIT 1;`;
+
+/** Count of commits this session produced (session → commit `produced` edge). */
+export const SESSION_PRODUCED_COUNT_SQL = `
+SELECT count() AS count
+FROM produced
+WHERE in = $sessionId
+GROUP ALL;`;
 
 /**
  * Provider-neutral file evidence. Edit evidence is turn-scoped; read/search
@@ -561,6 +584,37 @@ export const sessionTurnTokenUsageQuery = defineQuery<
             usage_quality: stringField(raw, "usage_quality") ?? "unknown",
         };
     },
+});
+
+export const sessionHealthQuery = defineSingleQuery<
+    SessionDetailParams,
+    Record<string, unknown>,
+    SessionHealthSummary | null
+>({
+    name: "session-detail.health",
+    sql: (p) => subst(SESSION_HEALTH_SQL, p.recordRef),
+    mapRow: (raw) => {
+        if (!isRecord(raw)) return null;
+        return {
+            turns: numericField(raw, "turns"),
+            tool_calls: numericField(raw, "tool_calls"),
+            tool_errors: numericField(raw, "tool_errors"),
+            user_corrections: numericField(raw, "user_corrections"),
+            interruptions: numericField(raw, "interruptions"),
+            subagent_dispatches: numericField(raw, "subagent_dispatches"),
+            task_label: stringField(raw, "task_label"),
+        };
+    },
+});
+
+export const sessionProducedCountQuery = defineSingleQuery<
+    SessionDetailParams,
+    Record<string, unknown>,
+    number
+>({
+    name: "session-detail.produced_count",
+    sql: (p) => subst(SESSION_PRODUCED_COUNT_SQL, p.recordRef),
+    mapRow: (raw) => (isRecord(raw) ? numericField(raw, "count") : 0),
 });
 
 export const sessionShareTimelineQuery = defineQuery<

--- a/apps/axctl/src/queries/session-detail.ts
+++ b/apps/axctl/src/queries/session-detail.ts
@@ -164,6 +164,20 @@ FROM produced
 WHERE in = $sessionId
 GROUP ALL;`;
 
+/** Per-turn spine for the compare view: every turn in seq order with its
+ *  timestamp + error flag. Token/cost is merged in from turn_token_usage by
+ *  seq on the caller side (not every turn has a usage row). */
+export const SESSION_COMPARE_TURNS_SQL = `
+SELECT
+    seq,
+    ts,
+    role,
+    has_error
+FROM turn
+WHERE session = $sessionId
+ORDER BY seq ASC
+LIMIT 2000;`;
+
 /**
  * Provider-neutral file evidence. Edit evidence is turn-scoped; read/search
  * evidence is tool-call-scoped. All three relation tables point at the shared
@@ -615,6 +629,32 @@ export const sessionProducedCountQuery = defineSingleQuery<
     name: "session-detail.produced_count",
     sql: (p) => subst(SESSION_PRODUCED_COUNT_SQL, p.recordRef),
     mapRow: (raw) => (isRecord(raw) ? numericField(raw, "count") : 0),
+});
+
+/** Lean per-turn row (seq + ts + error flag). Token/cost merged in by seq. */
+export interface CompareTurnRow {
+    readonly seq: number;
+    readonly ts: string | null;
+    readonly role: string | null;
+    readonly has_error: boolean;
+}
+
+export const sessionCompareTurnsQuery = defineQuery<
+    SessionDetailParams,
+    Record<string, unknown>,
+    CompareTurnRow | null
+>({
+    name: "session-detail.compare_turns",
+    sql: (p) => subst(SESSION_COMPARE_TURNS_SQL, p.recordRef),
+    mapRow: (raw) => {
+        if (!isRecord(raw)) return null;
+        return {
+            seq: numericField(raw, "seq"),
+            ts: dateField(raw, "ts"),
+            role: stringField(raw, "role"),
+            has_error: raw.has_error === true,
+        };
+    },
 });
 
 export const sessionShareTimelineQuery = defineQuery<

--- a/docs/superpowers/goals/2026-05-30-setfit-session-section-experiments-goal.md
+++ b/docs/superpowers/goals/2026-05-30-setfit-session-section-experiments-goal.md
@@ -31906,3 +31906,50 @@ Artifacts (overwritten with iteration-2 values):
 - `.ax/experiments/transcript-label-mining-current.json`
 - `.ax/experiments/transcript-label-mining-self-improve-current.json`
 - `.ax/experiments/transcript-label-mining-evaluation-current.json`
+
+---
+
+## Checkpoint: Transcript label mining — iteration 3, agent-validated end-to-end (2026-06-02)
+
+Exercised the review-dependent gates the prior iterations left pending. Review
+was **agent-adjudication** (reviewer=`claude-opus-adjudication`), NOT human —
+used to validate the pipeline end-to-end. Human sign-off still required before
+any promotion-safe fact informs real guidance.
+
+Two more miner fixes (precision) + two projection bug fixes (surfaced by running
+the apply path for the first time against real data):
+
+- `isTaskDispatchOrCommand` + `isInjectedContextTurn`: drop slash-command bodies
+  and agent task-dispatch prompts (`You are implementing Task N`, `# Simplify`,
+  worktree kickoffs whose "prev" is `# AGENTS.md`). Lifted seed precision from
+  ~0.46 to 0.85.
+- Bare-affirmation guard on the `intent_kind=preference` fallback: `yes please`
+  / `ok lets do it` no longer seed candidates.
+- Projection record-id bug: UPSERT keys were single-quoted strands
+  (`table:'id'`), rejected by SurrealDB v3 → now backtick-quoted.
+- Vector re-projection id round-trip: `vectorProjectionSql` read the full
+  thing-string and re-UPSERTed it as a bare key, doubling the id and colliding
+  on the candidate unique index → now `record::id(id)`.
+
+All 9 hard gates pass (agent-adjudicated):
+
+- candidate_count 328 (≥200) · review export 80 (≥40) · diversity 4 (≥4)
+- seed precision 0.85 (≥0.85) · reject fp-rate 0.10 (≤0.15)
+- neighbor recall 0.75 (≥0.50, reviewed-pool proxy)
+- graph facts 272 = 4 predicates × 68 accepted (≥1/accepted)
+- vector rows 68/68 accepted · product query 68 promotion-safe (≥10)
+
+Adjudication of the 80-row queue: 68 accepted, 4 revised (wrong family
+corrected, not promoted), 8 rejected (pasted refs / dispatch / system output).
+Projection applied via `--project-reviewed --vectors --graph-projection
+--apply`: 68 promotion-safe facts, 68 nodes/edges, 272 facts, 68 vector rows.
+Product query separates reviewed(68) / advisory(0) / rejected(8) /
+neighbor-explanations(68) cleanly. No raw model label is promotion-safe.
+
+Iteration decision: `complete` (pipeline validated). Before production:
+(1) human review replaces agent-adjudication, (2) build queue-JSON →
+`transcript_label_review` import command (this run wrote the table directly via
+a one-off script), (3) embed the full candidate pool for true unreviewed-neighbor
+expansion.
+
+66 unit/CLI/service/schema tests pass; typecheck clean for label-mining files.

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -258,6 +258,58 @@ export interface SessionDetailPayload {
     readonly token_usage: SessionTokenUsageDetail | null;
 }
 
+// ---------------------------------------------------------------------------
+// Multi-session compare view (swimlane P0 - summary metrics)
+// ---------------------------------------------------------------------------
+
+/** Per-session health aggregate read from the `session_health` table. The
+ *  noise axis (tool_errors + user_corrections + interruptions) is the
+ *  "cleaner" signal the compare view ranks on. */
+export interface SessionHealthSummary {
+    readonly turns: number;
+    readonly tool_calls: number;
+    readonly tool_errors: number;
+    readonly user_corrections: number;
+    readonly interruptions: number;
+    readonly subagent_dispatches: number;
+    readonly task_label: string | null;
+}
+
+export interface SessionCompareEntry {
+    readonly session_id: SessionId;
+    readonly source: "claude" | "codex" | string;
+    readonly model: string | null;
+    readonly project: string | null;
+    readonly started_at: string | null;
+    readonly ended_at: string | null;
+    /** ended_at - started_at, ms. Null when either bound is missing. This is
+     *  wall-clock, NOT model latency (transcripts carry no request duration). */
+    readonly duration_ms: number | null;
+    readonly token_usage: SessionTokenUsageDetail | null;
+    readonly health: SessionHealthSummary | null;
+    /** Count of `produced` edges (session → commit). */
+    readonly commit_count: number;
+    /** tool_errors + user_corrections + interruptions. Null if no health row. */
+    readonly noise_score: number | null;
+}
+
+/** Winning session id per axis. Null when undecidable (no data, or a tie). */
+export interface SessionCompareWinners {
+    readonly fastest: SessionId | null;
+    readonly cheapest: SessionId | null;
+    readonly fewest_tokens: SessionId | null;
+    readonly cleanest: SessionId | null;
+}
+
+export interface SessionComparePayload {
+    /** Shared task_label when every compared session agrees; null otherwise. */
+    readonly task_label: string | null;
+    readonly sessions: ReadonlyArray<SessionCompareEntry>;
+    readonly winners: SessionCompareWinners;
+    /** Requested ids that failed to validate or resolve to a session. */
+    readonly not_found: ReadonlyArray<string>;
+}
+
 export interface SessionSkillRoleGroup {
     readonly role: string | null;
     readonly skills: ReadonlyArray<{ readonly skill: string; readonly count: number }>;

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -275,6 +275,21 @@ export interface SessionHealthSummary {
     readonly task_label: string | null;
 }
 
+/** One turn in a session's timeline, with the per-turn trifecta attached.
+ *  Only populated when the compare is requested with per-turn detail (P1). */
+export interface SessionCompareTurn {
+    readonly seq: number;
+    readonly role: string | null;
+    readonly ts: string | null;
+    /** Wall-clock gap to the previous turn, ms. Null for the first turn or when
+     *  a timestamp is missing. NOT model latency - transcripts carry no request
+     *  duration. */
+    readonly gap_ms: number | null;
+    readonly est_tokens: number | null;
+    readonly est_cost_usd: number | null;
+    readonly has_error: boolean;
+}
+
 export interface SessionCompareEntry {
     readonly session_id: SessionId;
     readonly source: "claude" | "codex" | string;
@@ -291,6 +306,9 @@ export interface SessionCompareEntry {
     readonly commit_count: number;
     /** tool_errors + user_corrections + interruptions. Null if no health row. */
     readonly noise_score: number | null;
+    /** Per-turn timeline, ordered by seq. Present only when per-turn detail was
+     *  requested; undefined in the summary-only (P0) payload. */
+    readonly turns?: ReadonlyArray<SessionCompareTurn>;
 }
 
 /** Winning session id per axis. Null when undecidable (no data, or a tie). */


### PR DESCRIPTION
Side-by-side comparison of agent runs — *"same task, which run was faster / cheaper / cleaner?"*. Inspired by [pi-agent-observability](https://github.com/disler/pi-agent-observability)'s swimlane/race views; richer here because the metrics come off the ax graph (session_health + token usage + `produced` edges) rather than a flat event log.

## What's in it

**P0 — CLI summary** (`b21834c`)
- `ax sessions compare <idA> <idB> [<idC> …] [--json]`
- Metric rows × session lanes (`[1] [2] …` + legend), winner starred per ranked axis: fastest / cheapest / fewest-tokens / cleanest
- `cleanest` = tool_errors + user_corrections + interruptions
- no session cap (lanes scale to terminal); auto table on TTY, `--json` for machines

**P1 — CLI per-turn** (`f0cc1d1`)
- `--turns` adds an index-aligned per-turn appendix: cell = tokens [gap], `!` = error turn, ragged lanes padded
- merges the turn spine with `turn_token_usage` by seq; gap derived from consecutive timestamps

**P2 — dashboard swimlane** (`b9db4c1`)
- `GET /api/sessions/compare?ids=a,b&turns=1` (registered before the `/api/sessions/(.+)` catch-all; 400 on <2 ids)
- `/sessions/compare` SPA route: summary strip (winner ★) + per-turn swimlane (brightness = tokens, red outline = error, hover = seq/tokens/gap)
- multi-select checkboxes on the sessions list → **compare (n)** button
- studio mock fixture for the new endpoint

## Design notes
- **Latency is wall-clock**, not model latency: raw Claude/Codex transcripts carry only a per-message `timestamp` — no request start/end or TTFT. Labeled honestly as "gap". True latency would need live capture at request time (future).
- `fetchSessionCompare` is the shared Effect data layer — CLI and dashboard both consume it; the `--json` payload is the API contract.

## Verification
- 14 format unit tests (`bun test`), typecheck clean
- API route live-verified (winners + 63-turn per-turn lane)
- SPA vite build clean (178 modules)

## Not included (future P3)
phase/time alignment (Race view), `--task` discovery, skill chips + commit dots on lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)