### PR TITLE
feat: first-class compaction signal across harnesses

### DIFF
--- a/apps/axctl/src/cli/session-show-format.test.ts
+++ b/apps/axctl/src/cli/session-show-format.test.ts
@@ -69,6 +69,7 @@ const MINIMAL_PAYLOAD: SessionShowPayload = {
     },
     expanded_subagents: [],
     by_role: null,
+    compactions: [],
 };
 
 // ---------------------------------------------------------------------------
@@ -199,6 +200,44 @@ describe("renderSessionMarkdown - sections", () => {
     });
 });
 
+describe("renderSessionMarkdown - compaction", () => {
+    it("renders a compaction section when compactions present", () => {
+        const payload: SessionShowPayload = {
+            ...MINIMAL_PAYLOAD,
+            compactions: [
+                {
+                    harness: "codex",
+                    ts: "2026-05-14T15:34:42.663Z",
+                    strategy: "history_replacement",
+                    trigger: "auto",
+                    tokens_before: 120000,
+                    kept_count: 83,
+                    summary: null,
+                },
+                {
+                    harness: "pi",
+                    ts: "2026-05-29T06:05:38.132Z",
+                    strategy: "summarize",
+                    trigger: "auto",
+                    tokens_before: 90000,
+                    kept_count: null,
+                    summary: "Goal: ship X",
+                },
+            ],
+        };
+        const md = renderSessionMarkdown(payload);
+        expect(md).toContain("## Compaction");
+        expect(md).toContain("history_replacement");
+        expect(md).toContain("83 kept");
+        expect(md).toContain("Goal: ship X");
+    });
+
+    it("does NOT render a compaction section when compactions empty", () => {
+        const md = renderSessionMarkdown(MINIMAL_PAYLOAD);
+        expect(md).not.toContain("## Compaction");
+    });
+});
+
 describe("renderSessionMarkdown - not found", () => {
     it("emits not-found message when overview is null", () => {
         const payload: SessionShowPayload = {
@@ -213,6 +252,7 @@ describe("renderSessionMarkdown - not found", () => {
             },
             expanded_subagents: [],
             by_role: null,
+            compactions: [],
         };
         const out = renderSessionMarkdown(payload);
         expect(out).toContain("not found");
@@ -298,6 +338,7 @@ describe("renderSessionMarkdown - empty session", () => {
             },
             expanded_subagents: [],
             by_role: null,
+            compactions: [],
         };
         const out = renderSessionMarkdown(payload);
         expect(out).not.toContain("## Top skills");
@@ -316,6 +357,7 @@ describe("renderSessionMarkdown - empty session", () => {
             },
             expanded_subagents: [],
             by_role: null,
+            compactions: [],
         };
         const out = renderSessionMarkdown(payload);
         expect(out).not.toContain("## Subagents");

--- a/apps/axctl/src/cli/session-show-format.ts
+++ b/apps/axctl/src/cli/session-show-format.ts
@@ -110,6 +110,23 @@ function renderTimeline(payload: SessionDetailPayload, prefix = ""): string[] {
 }
 
 /**
+ * Render the `## Compaction` section listing context-compaction boundaries.
+ * Returns "" when there are none, so callers can append unconditionally.
+ */
+function renderCompaction(payload: SessionShowPayload): string[] {
+    const compactions = payload.compactions ?? [];
+    if (compactions.length === 0) return [];
+    const lines: string[] = [`## Compaction (${compactions.length})`, ""];
+    for (const c of compactions) {
+        const toks = c.tokens_before !== null ? ` · ${c.tokens_before} tok before` : "";
+        const kept = c.kept_count !== null ? ` · ${c.kept_count} kept` : "";
+        const sum = c.summary ? ` - ${c.summary.split("\n")[0]!.slice(0, 80)}` : "";
+        lines.push(`- ${c.ts} · ${c.harness} · ${c.strategy}${toks}${kept}${sum}`);
+    }
+    return lines;
+}
+
+/**
  * Render the session show payload as a markdown-flavoured TTY string.
  * Pure function - no I/O.
  */
@@ -207,6 +224,13 @@ export function renderSessionMarkdown(
     }
 
     lines.push("");
+
+    // ── compaction section ───────────────────────────────────────────────────
+    const compactionLines = renderCompaction(payload);
+    if (compactionLines.length > 0) {
+        lines.push(...compactionLines);
+        lines.push("");
+    }
 
     // ── subagents section ────────────────────────────────────────────────────
     if (session.children.length > 0) {

--- a/apps/axctl/src/cli/session-show-format.ts
+++ b/apps/axctl/src/cli/session-show-format.ts
@@ -121,7 +121,7 @@ function renderCompaction(payload: SessionShowPayload): string[] {
         const toks = c.tokens_before !== null ? ` · ${c.tokens_before} tok before` : "";
         const kept = c.kept_count !== null ? ` · ${c.kept_count} kept` : "";
         const sum = c.summary ? ` - ${c.summary.split("\n")[0]!.slice(0, 80)}` : "";
-        lines.push(`- ${c.ts} · ${c.harness} · ${c.strategy}${toks}${kept}${sum}`);
+        lines.push(`- ${fmtTs(c.ts)} · ${c.harness} · ${c.strategy}${toks}${kept}${sum}`);
     }
     return lines;
 }

--- a/apps/axctl/src/dashboard/session-view.ts
+++ b/apps/axctl/src/dashboard/session-view.ts
@@ -7,6 +7,7 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import type {
+    SessionCompaction,
     SessionDetailPayload,
     SessionLink,
     SessionSkillRoleGroup,
@@ -18,7 +19,30 @@ import {
     sessionSkillRolesQuery,
     type SessionSkillRoleEdge,
 } from "../queries/session-view.ts";
+import { sessionCompactionsQuery } from "../queries/session-detail.ts";
 import { fetchSessionDetail } from "./session-detail.ts";
+
+// Accepts both real UUIDs and our synthetic prefixed ids. Mirrors the
+// validation in fetchSessionDetail so we can safely inline the record id.
+const SESSION_ID_RE = /^[A-Za-z0-9_-]{6,80}$/;
+
+const sessionRecordRef = (sessionId: string): string | null => {
+    const uuid = sessionId
+        .replace(/^session:⟨/, "")
+        .replace(/⟩$/, "")
+        .replace(/^session:/, "");
+    return SESSION_ID_RE.test(uuid) ? `session:⟨${uuid}⟩` : null;
+};
+
+const fetchSessionCompactions = (
+    sessionId: string,
+): Effect.Effect<ReadonlyArray<SessionCompaction>, never, SurrealClient> =>
+    Effect.gen(function* () {
+        const recordRef = sessionRecordRef(sessionId);
+        if (!recordRef) return [] as ReadonlyArray<SessionCompaction>;
+        const rows = yield* runQuery(sessionCompactionsQuery, { recordRef });
+        return rows.filter((c): c is SessionCompaction => c !== null);
+    });
 
 export type { SessionViewPayload } from "@ax/lib/shared/dashboard-types";
 
@@ -147,13 +171,17 @@ export const fetchSessionView: (
             ? fetchSessionSkillRoleGroups(primary.top_skills)
             : Effect.succeed(null);
 
-    const [expanded, byRole] = yield* Effect.all([expandedEffect, byRoleEffect], {
-        concurrency: 2,
-    });
+    const compactionsEffect = fetchSessionCompactions(opts.sessionId);
+
+    const [expanded, byRole, compactions] = yield* Effect.all(
+        [expandedEffect, byRoleEffect, compactionsEffect],
+        { concurrency: 3 },
+    );
 
     return {
         session: primary,
         expanded_subagents: expanded,
         by_role: byRole,
+        compactions,
     };
 });

--- a/apps/axctl/src/ingest/codex.test.ts
+++ b/apps/axctl/src/ingest/codex.test.ts
@@ -1034,3 +1034,27 @@ describe("Codex transcript extraction", () => {
         expect(sql).toContain("absolute_path_seen = \"/Users/necmttn/Projects/ax/src/ingest/codex.ts\"");
     });
 });
+
+describe("codex compaction", () => {
+    test("type:compacted produces a compaction row + provider event", () => {
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({ type: "session_meta", timestamp: "2026-05-14T15:00:00.000Z", payload: { id: "cdx-1", timestamp: "2026-05-14T15:00:00.000Z", cwd: "/tmp", originator: "test" } }),
+            JSON.stringify({ type: "event_msg", timestamp: "2026-05-14T15:30:00.000Z", payload: { type: "token_count", info: { total_token_usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120000 }, model_context_window: 200000 } } }),
+            JSON.stringify({ type: "compacted", timestamp: "2026-05-14T15:34:42.663Z", payload: { message: "", replacement_history: [{ type: "message" }, { type: "message" }] } }),
+        ]);
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+        expect(extracted.compactions.length).toBe(1);
+        const c = extracted.compactions[0]!;
+        expect(c.harness).toBe("codex");
+        expect(c.strategy).toBe("history_replacement");
+        expect(c.keptCount).toBe(2);
+        expect(c.tokensBefore).toBe(120000);
+        expect(extracted.providerEvents.some((e) => e.type === "compaction")).toBe(true);
+
+        // The compaction's agentEventKey must match the emitted provider event's key.
+        const compactionEvent = extracted.providerEvents.find((e) => e.type === "compaction");
+        expect(compactionEvent).toBeDefined();
+        expect(c.agentEventKey).toBe(agentEventRecordKey(compactionEvent!));
+    });
+});

--- a/apps/axctl/src/ingest/codex.test.ts
+++ b/apps/axctl/src/ingest/codex.test.ts
@@ -1039,7 +1039,7 @@ describe("codex compaction", () => {
     test("type:compacted produces a compaction row + provider event", () => {
         const extracted = __testExtractCodexJsonlLines([
             JSON.stringify({ type: "session_meta", timestamp: "2026-05-14T15:00:00.000Z", payload: { id: "cdx-1", timestamp: "2026-05-14T15:00:00.000Z", cwd: "/tmp", originator: "test" } }),
-            JSON.stringify({ type: "event_msg", timestamp: "2026-05-14T15:30:00.000Z", payload: { type: "token_count", info: { total_token_usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120000 }, model_context_window: 200000 } } }),
+            JSON.stringify({ type: "event_msg", timestamp: "2026-05-14T15:30:00.000Z", payload: { type: "token_count", info: { total_token_usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120000 }, last_token_usage: { input_tokens: 120000, output_tokens: 20, total_tokens: 120020 }, model_context_window: 200000 } } }),
             JSON.stringify({ type: "compacted", timestamp: "2026-05-14T15:34:42.663Z", payload: { message: "", replacement_history: [{ type: "message" }, { type: "message" }] } }),
         ]);
         expect(extracted).not.toBeNull();

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -913,7 +913,7 @@ function createCodexExtractor(
                     if (turnUsage) turnTokenUsages.push(turnUsage);
                     previousTotalTokenUsage = nextUsage.totalTokenUsage;
                     tokenUsage = nextUsage;
-                    lastContextTokens = nextUsage.estimatedTokens ?? lastContextTokens;
+                    lastContextTokens = (nextUsage.lastTokenUsage ? numberField(nextUsage.lastTokenUsage, "input_tokens") : null) ?? lastContextTokens;
                 }
                 return;
             }

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -31,6 +31,7 @@ import {
     parseCodexFunctionOutput,
     toolKindForName,
 } from "./tool-calls.ts";
+import { buildCompactionStatements, extractCodexCompaction, type CompactionWrite } from "./compaction.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
 import { providerDelegationSignalAvailability } from "./delegation.ts";
 import {
@@ -518,6 +519,7 @@ export interface CodexExtract {
     parentEdges: AgentEventParentEdgeWrite[];
     skillRelations: ToolCallSkillRelationWrite[];
     planSnapshots: PlanSnapshotWrite[];
+    compactions: CompactionWrite[];
     tokenUsage: CodexTokenUsage | null;
 }
 
@@ -532,6 +534,7 @@ interface MutableCodexExtract {
     parentEdges: AgentEventParentEdgeWrite[];
     skillRelations: ToolCallSkillRelationWrite[];
     planSnapshots: PlanSnapshotWrite[];
+    compactions: CompactionWrite[];
     tokenUsage: CodexTokenUsage | null;
 }
 
@@ -548,6 +551,8 @@ function createCodexExtractor(
     const parentEdges: AgentEventParentEdgeWrite[] = [];
     const skillRelations: ToolCallSkillRelationWrite[] = [];
     const planSnapshots: PlanSnapshotWrite[] = [];
+    const compactions: CompactionWrite[] = [];
+    let lastContextTokens: number | null = null;
     let tokenUsage: CodexTokenUsage | null = null;
     let tokenCountEvents = 0;
     let previousTotalTokenUsage: Record<string, unknown> | null = null;
@@ -848,6 +853,7 @@ function createCodexExtractor(
         const drainedSnapshots = take(planSnapshots, (snapshot) =>
             snapshot.toolCallKey === null || snapshot.toolCallKey === undefined || flushableToolCallKeys.has(snapshot.toolCallKey),
         );
+        const drainedCompactions = compactions.splice(0, compactions.length);
         return {
             session,
             sourcePath: filePath,
@@ -859,6 +865,7 @@ function createCodexExtractor(
             parentEdges: drainedParentEdges,
             skillRelations: drainedRelations,
             planSnapshots: drainedSnapshots,
+            compactions: drainedCompactions,
             tokenUsage,
         };
     };
@@ -906,7 +913,42 @@ function createCodexExtractor(
                     if (turnUsage) turnTokenUsages.push(turnUsage);
                     previousTotalTokenUsage = nextUsage.totalTokenUsage;
                     tokenUsage = nextUsage;
+                    lastContextTokens = nextUsage.estimatedTokens ?? lastContextTokens;
                 }
+                return;
+            }
+
+            if (type === "compacted" && payload && session) {
+                seq += 1;
+                const compactionEventId = `compacted:${seq}`;
+                const eventKey = agentEventRecordKey({
+                    provider: "codex",
+                    providerSessionId: session.id,
+                    providerEventId: compactionEventId,
+                    seq,
+                });
+                pushProviderEvent({
+                    providerEventId: compactionEventId,
+                    seq,
+                    ts,
+                    type: "compaction",
+                    role: null,
+                    text: null,
+                    textExcerpt: null,
+                    raw: { replacement_count: Array.isArray(payload.replacement_history) ? payload.replacement_history.length : 0 },
+                    labels: { source: "codex_transcript" },
+                    metrics: { strategy: "history_replacement", turnSeq: seq },
+                }, session);
+                const write = extractCodexCompaction(payload, {
+                    sessionId: session.id,
+                    providerSessionId: session.id,
+                    seq,
+                    ts: new Date(ts),
+                    agentEventKey: eventKey,
+                    tokensBefore: lastContextTokens,
+                    boundaryRef: `seq_${seq}`,
+                });
+                if (write) compactions.push(write);
                 return;
             }
 
@@ -979,6 +1021,7 @@ function createCodexExtractor(
                 parentEdges: remaining.parentEdges,
                 skillRelations: remaining.skillRelations,
                 planSnapshots: remaining.planSnapshots,
+                compactions: remaining.compactions,
                 tokenUsage: remaining.tokenUsage,
             };
         },
@@ -1388,6 +1431,7 @@ const buildCodexBatchStatements = (
     ...batch.planSnapshots.flatMap((snapshot) =>
         buildPlanSnapshotStatements(snapshot),
     ),
+    ...buildCompactionStatements(batch.compactions ?? []),
 ];
 
 export const __testBuildCodexBatchStatements = buildCodexBatchStatements;

--- a/apps/axctl/src/ingest/compaction.test.ts
+++ b/apps/axctl/src/ingest/compaction.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import {
+    buildCompactionStatements,
+    compactionRecordKey,
+    extractClaudeCompaction,
+    extractCodexCompaction,
+    extractCursorCompaction,
+    extractPiCompaction,
+    type CompactionWrite,
+} from "./compaction.ts";
+
+describe("compactionRecordKey", () => {
+    test("is deterministic and sanitized", () => {
+        expect(compactionRecordKey("codex", "sess-1:abc", 3)).toBe("codex_sess_1_abc_cmp_3");
+    });
+});
+
+describe("buildCompactionStatements", () => {
+    test("emits one UPSERT with typed fields", () => {
+        const write: CompactionWrite = {
+            compactionKey: "codex_s_cmp_1",
+            sessionId: "s",
+            agentEventKey: "codex_s_seq_000001",
+            harness: "codex",
+            ts: new Date("2026-05-14T15:34:42.663Z"),
+            trigger: "auto",
+            strategy: "history_replacement",
+            sourceConfidence: "explicit",
+            summary: null,
+            tokensBefore: 120000,
+            boundaryRef: "seq_42",
+            keptCount: 83,
+            readFiles: null,
+            modifiedFiles: null,
+            raw: { replacement_count: 83 },
+        };
+        const [stmt] = buildCompactionStatements([write]);
+        expect(stmt).toContain("UPSERT compaction:");
+        expect(stmt).toContain('harness: "codex"');
+        expect(stmt).toContain('strategy: "history_replacement"');
+        expect(stmt).toContain("kept_count: 83");
+        expect(stmt).toContain("tokens_before: 120000");
+        expect(stmt).toContain("summary: NONE");
+        expect(stmt).toContain("session: session:");
+        expect(stmt).toContain("agent_event: agent_event:");
+    });
+
+    test("null kept_count and tokens become NONE", () => {
+        const write: CompactionWrite = {
+            compactionKey: "pi_s_cmp_1",
+            sessionId: "s",
+            agentEventKey: null,
+            harness: "pi",
+            ts: new Date("2026-05-29T06:05:38.132Z"),
+            trigger: "auto",
+            strategy: "summarize",
+            sourceConfidence: "explicit",
+            summary: "Goal: ship X",
+            tokensBefore: 90000,
+            boundaryRef: "entry-7",
+            keptCount: null,
+            readFiles: ["a.ts", "b.ts"],
+            modifiedFiles: null,
+            raw: null,
+        };
+        const [stmt] = buildCompactionStatements([write]);
+        expect(stmt).toContain("kept_count: NONE");
+        expect(stmt).toContain("agent_event: NONE");
+        expect(stmt).toContain('strategy: "summarize"');
+        expect(stmt).toContain("read_files: \"[\\\"a.ts\\\",\\\"b.ts\\\"]\"");
+        expect(stmt).toContain("raw: NONE");
+    });
+});
+
+describe("extractPiCompaction", () => {
+    test("maps a Pi CompactionEntry", () => {
+        const entry = {
+            type: "compaction",
+            id: "c1",
+            summary: "Goal: ship X",
+            firstKeptEntryId: "entry-7",
+            tokensBefore: 90000,
+            fromHook: false,
+            details: { readFiles: ["a.ts"], modifiedFiles: ["b.ts"] },
+        };
+        const w = extractPiCompaction(entry, {
+            sessionId: "s",
+            providerSessionId: "ps",
+            seq: 4,
+            ts: new Date("2026-05-29T06:05:38.132Z"),
+            agentEventKey: "pi_ps_seq_000004",
+        });
+        expect(w).not.toBeNull();
+        expect(w!.strategy).toBe("summarize");
+        expect(w!.summary).toBe("Goal: ship X");
+        expect(w!.tokensBefore).toBe(90000);
+        expect(w!.boundaryRef).toBe("entry-7");
+        expect(w!.trigger).toBe("auto");
+        expect(w!.readFiles).toEqual(["a.ts"]);
+        expect(w!.modifiedFiles).toEqual(["b.ts"]);
+    });
+
+    test("fromHook=true => trigger hook", () => {
+        const w = extractPiCompaction(
+            { type: "compaction", summary: "s", fromHook: true },
+            { sessionId: "s", providerSessionId: "ps", seq: 1, ts: new Date(0), agentEventKey: null },
+        );
+        expect(w!.trigger).toBe("hook");
+    });
+});
+
+describe("extractCodexCompaction", () => {
+    test("history-replacement with kept_count", () => {
+        const payload = {
+            message: "",
+            replacement_history: [{ type: "message" }, { type: "message" }, { type: "message" }],
+        };
+        const w = extractCodexCompaction(payload, {
+            sessionId: "s",
+            providerSessionId: "ps",
+            seq: 10,
+            ts: new Date("2026-05-14T15:34:42.663Z"),
+            agentEventKey: "codex_ps_seq_000010",
+            tokensBefore: 120000,
+            boundaryRef: "seq_10",
+        });
+        expect(w!.strategy).toBe("history_replacement");
+        expect(w!.summary).toBeNull();
+        expect(w!.keptCount).toBe(3);
+        expect(w!.tokensBefore).toBe(120000);
+        expect(w!.trigger).toBe("auto");
+    });
+
+    test("non-empty message => manual trigger + summary", () => {
+        const w = extractCodexCompaction(
+            { message: "focus on auth", replacement_history: [] },
+            { sessionId: "s", providerSessionId: "ps", seq: 1, ts: new Date(0), agentEventKey: null, tokensBefore: null, boundaryRef: "seq_1" },
+        );
+        expect(w!.trigger).toBe("manual");
+        expect(w!.summary).toBe("focus on auth");
+    });
+});
+
+describe("extractCursorCompaction", () => {
+    test("encrypted strategy, null summary", () => {
+        const w = extractCursorCompaction({
+            sessionId: "s",
+            providerSessionId: "ps",
+            seq: 2,
+            ts: new Date("2026-05-29T00:00:00.000Z"),
+            agentEventKey: "cursor_ps_seq_000002",
+            boundaryRef: "bubble-9",
+            summarizedComposers: ["comp-1"],
+        });
+        expect(w.strategy).toBe("encrypted");
+        expect(w.summary).toBeNull();
+        expect(w.boundaryRef).toBe("bubble-9");
+    });
+});
+
+describe("extractClaudeCompaction", () => {
+    test("summarize strategy from ctx.summary", () => {
+        const w = extractClaudeCompaction({
+            sessionId: "s",
+            providerSessionId: "ps",
+            seq: 5,
+            ts: new Date("2026-06-01T10:05:00.000Z"),
+            agentEventKey: "claude_ps_seq_000005",
+            summary: "## Summary\nGoal: ship X",
+            boundaryRef: "u2",
+        });
+        expect(w.strategy).toBe("summarize");
+        expect(w.trigger).toBe("auto");
+        expect(w.summary).toContain("Goal: ship X");
+        expect(w.boundaryRef).toBe("u2");
+        expect(w.sourceConfidence).toBe("explicit");
+    });
+});

--- a/apps/axctl/src/ingest/compaction.ts
+++ b/apps/axctl/src/ingest/compaction.ts
@@ -1,0 +1,198 @@
+import {
+    recordRef,
+    surrealDate,
+    surrealJsonTextOption,
+    surrealObject,
+    surrealOptionInt,
+    surrealOptionRecord,
+    surrealOptionString,
+    surrealString,
+} from "@ax/lib/shared/surql";
+
+export type CompactionStrategy = "summarize" | "history_replacement" | "encrypted";
+export type CompactionTrigger = "auto" | "manual" | "hook";
+export type CompactionConfidence = "explicit" | "derived";
+
+export interface CompactionWrite {
+    readonly compactionKey: string;
+    readonly sessionId: string;
+    readonly agentEventKey?: string | null;
+    readonly harness: string;
+    readonly ts: Date;
+    readonly trigger?: CompactionTrigger | null;
+    readonly strategy: CompactionStrategy;
+    readonly sourceConfidence: CompactionConfidence;
+    readonly summary?: string | null;
+    readonly tokensBefore?: number | null;
+    readonly boundaryRef?: string | null;
+    readonly keptCount?: number | null;
+    readonly readFiles?: readonly string[] | null;
+    readonly modifiedFiles?: readonly string[] | null;
+    readonly raw?: unknown;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+    typeof v === "object" && v !== null && !Array.isArray(v);
+
+const stringArray = (v: unknown): readonly string[] | null =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : null;
+
+export const compactionRecordKey = (
+    harness: string,
+    providerSessionId: string,
+    seq: number,
+): string => `${harness}_${providerSessionId}_cmp_${seq}`.replace(/[^A-Za-z0-9_]/g, "_");
+
+export const buildCompactionStatements = (
+    writes: readonly CompactionWrite[],
+): string[] =>
+    writes.map(
+        (c) =>
+            `UPSERT ${recordRef("compaction", c.compactionKey)} CONTENT ${surrealObject([
+                ["session", recordRef("session", c.sessionId)],
+                ["agent_event", surrealOptionRecord("agent_event", c.agentEventKey ?? null)],
+                ["harness", surrealString(c.harness)],
+                ["ts", surrealDate(c.ts)],
+                ["trigger", surrealOptionString(c.trigger ?? null)],
+                ["strategy", surrealString(c.strategy)],
+                ["source_confidence", surrealString(c.sourceConfidence)],
+                ["summary", surrealOptionString(c.summary ?? null)],
+                ["tokens_before", surrealOptionInt(c.tokensBefore ?? null)],
+                ["boundary_ref", surrealOptionString(c.boundaryRef ?? null)],
+                ["kept_count", surrealOptionInt(c.keptCount ?? null)],
+                ["read_files", surrealJsonTextOption(c.readFiles ?? null)],
+                ["modified_files", surrealJsonTextOption(c.modifiedFiles ?? null)],
+                ["raw", surrealJsonTextOption(c.raw ?? null)],
+            ])};`,
+    );
+
+export interface PiCompactionCtx {
+    readonly sessionId: string;
+    readonly providerSessionId: string;
+    readonly seq: number;
+    readonly ts: Date;
+    readonly agentEventKey?: string | null;
+}
+
+export const extractPiCompaction = (
+    entry: Record<string, unknown>,
+    ctx: PiCompactionCtx,
+): CompactionWrite | null => {
+    if (entry.type !== "compaction") return null;
+    const details = isRecord(entry.details) ? entry.details : null;
+    return {
+        compactionKey: compactionRecordKey("pi", ctx.providerSessionId, ctx.seq),
+        sessionId: ctx.sessionId,
+        agentEventKey: ctx.agentEventKey ?? null,
+        harness: "pi",
+        ts: ctx.ts,
+        trigger: entry.fromHook === true ? "hook" : "auto",
+        strategy: "summarize",
+        sourceConfidence: "explicit",
+        summary: typeof entry.summary === "string" ? entry.summary : null,
+        tokensBefore: typeof entry.tokensBefore === "number" ? entry.tokensBefore : null,
+        boundaryRef:
+            typeof entry.firstKeptEntryId === "string" ? entry.firstKeptEntryId : null,
+        keptCount: null,
+        readFiles: details ? stringArray(details.readFiles) : null,
+        modifiedFiles: details ? stringArray(details.modifiedFiles) : null,
+        raw: { fromHook: entry.fromHook === true },
+    };
+};
+
+export interface CodexCompactionCtx {
+    readonly sessionId: string;
+    readonly providerSessionId: string;
+    readonly seq: number;
+    readonly ts: Date;
+    readonly agentEventKey?: string | null;
+    readonly tokensBefore?: number | null;
+    readonly boundaryRef?: string | null;
+}
+
+export const extractCodexCompaction = (
+    payload: Record<string, unknown>,
+    ctx: CodexCompactionCtx,
+): CompactionWrite | null => {
+    const replacement = Array.isArray(payload.replacement_history)
+        ? payload.replacement_history
+        : [];
+    const message = typeof payload.message === "string" ? payload.message : "";
+    return {
+        compactionKey: compactionRecordKey("codex", ctx.providerSessionId, ctx.seq),
+        sessionId: ctx.sessionId,
+        agentEventKey: ctx.agentEventKey ?? null,
+        harness: "codex",
+        ts: ctx.ts,
+        trigger: message.length > 0 ? "manual" : "auto",
+        strategy: "history_replacement",
+        sourceConfidence: "explicit",
+        summary: message.length > 0 ? message : null,
+        tokensBefore: ctx.tokensBefore ?? null,
+        boundaryRef: ctx.boundaryRef ?? null,
+        keptCount: replacement.length,
+        readFiles: null,
+        modifiedFiles: null,
+        raw: { replacement_count: replacement.length },
+    };
+};
+
+export interface ClaudeCompactionCtx {
+    readonly sessionId: string;
+    readonly providerSessionId: string;
+    readonly seq: number;
+    readonly ts: Date;
+    readonly agentEventKey?: string | null;
+    readonly summary: string | null;
+    readonly boundaryRef?: string | null;
+}
+
+export const extractClaudeCompaction = (
+    ctx: ClaudeCompactionCtx,
+): CompactionWrite => ({
+    compactionKey: compactionRecordKey("claude", ctx.providerSessionId, ctx.seq),
+    sessionId: ctx.sessionId,
+    agentEventKey: ctx.agentEventKey ?? null,
+    harness: "claude",
+    ts: ctx.ts,
+    trigger: "auto",
+    strategy: "summarize",
+    sourceConfidence: "explicit",
+    summary: ctx.summary,
+    tokensBefore: null,
+    boundaryRef: ctx.boundaryRef ?? null,
+    keptCount: null,
+    readFiles: null,
+    modifiedFiles: null,
+    raw: null,
+});
+
+export interface CursorCompactionCtx {
+    readonly sessionId: string;
+    readonly providerSessionId: string;
+    readonly seq: number;
+    readonly ts: Date;
+    readonly agentEventKey?: string | null;
+    readonly boundaryRef?: string | null;
+    readonly summarizedComposers: readonly string[];
+}
+
+export const extractCursorCompaction = (
+    ctx: CursorCompactionCtx,
+): CompactionWrite => ({
+    compactionKey: compactionRecordKey("cursor", ctx.providerSessionId, ctx.seq),
+    sessionId: ctx.sessionId,
+    agentEventKey: ctx.agentEventKey ?? null,
+    harness: "cursor",
+    ts: ctx.ts,
+    trigger: "auto",
+    strategy: "encrypted",
+    sourceConfidence: "explicit",
+    summary: null,
+    tokensBefore: null,
+    boundaryRef: ctx.boundaryRef ?? null,
+    keptCount: null,
+    readFiles: null,
+    modifiedFiles: null,
+    raw: { summarized_composers: ctx.summarizedComposers },
+});

--- a/apps/axctl/src/ingest/cursor.test.ts
+++ b/apps/axctl/src/ingest/cursor.test.ts
@@ -224,6 +224,9 @@ describe("Cursor state.vscdb extraction", () => {
             expect(extract.compactions[0]?.strategy).toBe("encrypted");
             expect(extract.compactions[0]?.summary).toBeNull();
             expect(extract.compactions[0]?.boundaryRef).toBe("b1");
+            expect(extract.providerEvents.filter((e) => e.type === "compaction").length).toBe(1);
+            const compactionEvent = extract.providerEvents.find((e) => e.type === "compaction")!;
+            expect(agentEventRecordKey(compactionEvent)).toBe(extract.compactions[0]?.agentEventKey);
         });
     });
 

--- a/apps/axctl/src/ingest/cursor.test.ts
+++ b/apps/axctl/src/ingest/cursor.test.ts
@@ -192,6 +192,72 @@ describe("Cursor state.vscdb extraction", () => {
         });
     });
 
+    test("flags compaction when a composer has a non-empty summarizedComposers array", async () => {
+        await withTempCursorStateDb((db, dbPath) => {
+            db.run("CREATE TABLE cursorDiskKV (key text primary key, value blob)");
+            db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+                "composerData:comp-1",
+                JSON.stringify({
+                    composerId: "comp-1",
+                    name: "t",
+                    createdAt: 1748000000000,
+                    summarizedComposers: ["prev-comp"],
+                    fullConversationHeadersOnly: [
+                        { bubbleId: "b1", type: 1, grouping: { hasText: true } },
+                    ],
+                }),
+            );
+            db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+                "bubbleId:comp-1:b1",
+                JSON.stringify({
+                    bubbleId: "b1",
+                    type: 2,
+                    text: "hi",
+                    createdAt: "2026-05-29T10:49:48.611Z",
+                }),
+            );
+
+            const extract = extractCursorStateDb(dbPath);
+
+            expect(extract.compactions.length).toBe(1);
+            expect(extract.compactions[0]?.harness).toBe("cursor");
+            expect(extract.compactions[0]?.strategy).toBe("encrypted");
+            expect(extract.compactions[0]?.summary).toBeNull();
+            expect(extract.compactions[0]?.boundaryRef).toBe("b1");
+        });
+    });
+
+    test("does not flag compaction when summarizedComposers is empty", async () => {
+        await withTempCursorStateDb((db, dbPath) => {
+            db.run("CREATE TABLE cursorDiskKV (key text primary key, value blob)");
+            db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+                "composerData:comp-2",
+                JSON.stringify({
+                    composerId: "comp-2",
+                    name: "t",
+                    createdAt: 1748000000000,
+                    summarizedComposers: [],
+                    fullConversationHeadersOnly: [
+                        { bubbleId: "b1", type: 1, grouping: { hasText: true } },
+                    ],
+                }),
+            );
+            db.query("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(
+                "bubbleId:comp-2:b1",
+                JSON.stringify({
+                    bubbleId: "b1",
+                    type: 2,
+                    text: "hi",
+                    createdAt: "2026-05-29T10:49:48.611Z",
+                }),
+            );
+
+            const extract = extractCursorStateDb(dbPath);
+
+            expect(extract.compactions.length).toBe(0);
+        });
+    });
+
     test("extracts Cursor toolFormerData into shared tool calls and invocation edges", async () => {
         await withTempCursorStateDb((db, dbPath) => {
             db.run("CREATE TABLE cursorDiskKV (key text primary key, value blob)");

--- a/apps/axctl/src/ingest/cursor.test.ts
+++ b/apps/axctl/src/ingest/cursor.test.ts
@@ -226,7 +226,7 @@ describe("Cursor state.vscdb extraction", () => {
             expect(extract.compactions[0]?.boundaryRef).toBe("b1");
             expect(extract.providerEvents.filter((e) => e.type === "compaction").length).toBe(1);
             const compactionEvent = extract.providerEvents.find((e) => e.type === "compaction")!;
-            expect(agentEventRecordKey(compactionEvent)).toBe(extract.compactions[0]?.agentEventKey);
+            expect(extract.compactions[0]?.agentEventKey).toBe(agentEventRecordKey(compactionEvent));
         });
     });
 

--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -15,6 +15,7 @@ import {
     type ToolCallSkillRelationWrite,
     type ToolCallWrite,
 } from "./evidence-writers.ts";
+import { buildCompactionStatements, extractCursorCompaction, type CompactionWrite } from "./compaction.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
 import { providerDelegationSignalAvailability } from "./delegation.ts";
 import { agentEventRecordKey, buildAgentEventStatements, buildAgentProviderStatements, type AgentEventWrite } from "./provider-events.ts";
@@ -74,6 +75,7 @@ export interface CursorExtract {
     toolCalls: ToolCallWrite[];
     providerEvents: AgentEventWrite[];
     skillRelations: ToolCallSkillRelationWrite[];
+    compactions: CompactionWrite[];
     skipped: number;
     warnings: string[];
 }
@@ -157,6 +159,7 @@ function emptyExtract(warnings: string[] = [], skipped = 0): CursorExtract {
         toolCalls: [],
         providerEvents: [],
         skillRelations: [],
+        compactions: [],
         skipped,
         warnings,
     };
@@ -601,11 +604,12 @@ function extractComposerData(
     const toolCalls: ToolCallWrite[] = [];
     const providerEvents: AgentEventWrite[] = [];
     const skillRelations: ToolCallSkillRelationWrite[] = [];
+    const compactions: CompactionWrite[] = [];
     let skipped = 0;
     const conversations = Array.isArray(data.conversations) ? data.conversations : [];
     if (!Array.isArray(data.conversations)) {
         warnings.push(`${sourceKey}: missing conversations array`);
-        return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, skipped: 1 };
+        return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, compactions, skipped: 1 };
     }
 
     for (const conversation of conversations) {
@@ -655,7 +659,7 @@ function extractComposerData(
         if (seq > 0) sessions.push(session);
     }
 
-    return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, skipped };
+    return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, compactions, skipped };
 }
 
 function extractComposerDiskKvData(
@@ -673,16 +677,17 @@ function extractComposerDiskKvData(
     const toolCalls: ToolCallWrite[] = [];
     const providerEvents: AgentEventWrite[] = [];
     const skillRelations: ToolCallSkillRelationWrite[] = [];
+    const compactions: CompactionWrite[] = [];
     let skipped = 0;
     const composerId = stringField(data, "composerId") ?? sourceKey.slice(CURSOR_COMPOSER_DATA_PREFIX.length);
     if (composerId.length === 0) {
         warnings.push(`${sourceKey}: missing composerId`);
-        return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, skipped: 1 };
+        return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, compactions, skipped: 1 };
     }
     const headers = Array.isArray(data.fullConversationHeadersOnly) ? data.fullConversationHeadersOnly : [];
     if (!Array.isArray(data.fullConversationHeadersOnly)) {
         warnings.push(`${sourceKey}: missing fullConversationHeadersOnly array`);
-        return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, skipped: 1 };
+        return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, compactions, skipped: 1 };
     }
 
     const session: CursorSession = {
@@ -748,7 +753,50 @@ function extractComposerDiskKvData(
     }
     if (seq > 0) sessions.push(session);
 
-    return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, skipped };
+    const summarizedComposers = Array.isArray((data as Record<string, unknown>).summarizedComposers)
+        ? ((data as Record<string, unknown>).summarizedComposers as unknown[]).filter(
+              (x): x is string => typeof x === "string",
+          )
+        : [];
+    if (summarizedComposers.length > 0) {
+        const compactionSeq = seq + 1;
+        const firstHeader = headers.find((header): header is Record<string, unknown> => isRecord(header));
+        const firstBubbleId =
+            (firstHeader ? stringField(firstHeader, "bubbleId") : null) ?? composerId;
+        const compactionTs = validTimestamp(data.createdAt, session.ended_at).ts;
+        const compactionEventId = `compaction:${composerId}`;
+        const eventKey = agentEventRecordKey({
+            provider: "cursor",
+            providerSessionId: session.id,
+            providerEventId: compactionEventId,
+            seq: compactionSeq,
+        });
+        providerEvents.push({
+            provider: "cursor",
+            providerSessionId: session.id,
+            axSessionId: session.id,
+            providerEventId: compactionEventId,
+            seq: compactionSeq,
+            ts: compactionTs,
+            type: "compaction",
+            role: null,
+            text: null,
+            metrics: { strategy: "encrypted" },
+        });
+        compactions.push(
+            extractCursorCompaction({
+                sessionId: session.id,
+                providerSessionId: composerId,
+                seq: compactionSeq,
+                ts: new Date(compactionTs),
+                agentEventKey: eventKey,
+                boundaryRef: firstBubbleId,
+                summarizedComposers,
+            }),
+        );
+    }
+
+    return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, compactions, skipped };
 }
 
 export function extractCursorStateDb(dbPath: string, options: CursorExtractOptions = {}): CursorExtract {
@@ -770,6 +818,7 @@ export function extractCursorStateDb(dbPath: string, options: CursorExtractOptio
         const toolCalls: ToolCallWrite[] = [];
         const providerEvents: AgentEventWrite[] = [];
         const skillRelations: ToolCallSkillRelationWrite[] = [];
+        const compactions: CompactionWrite[] = [];
         const warnings: string[] = [];
         let skipped = 0;
 
@@ -799,6 +848,7 @@ export function extractCursorStateDb(dbPath: string, options: CursorExtractOptio
                     toolCalls.push(...extracted.toolCalls);
                     providerEvents.push(...extracted.providerEvents);
                     skillRelations.push(...extracted.skillRelations);
+                    compactions.push(...extracted.compactions);
                     skipped += extracted.skipped;
                 } else if (row.key.startsWith(CURSOR_COMPOSER_DATA_PREFIX)) {
                     const extracted = extractComposerDiskKvData(payload, row.key, dbPath, dbIdentity, db, table, warnings);
@@ -808,12 +858,13 @@ export function extractCursorStateDb(dbPath: string, options: CursorExtractOptio
                     toolCalls.push(...extracted.toolCalls);
                     providerEvents.push(...extracted.providerEvents);
                     skillRelations.push(...extracted.skillRelations);
+                    compactions.push(...extracted.compactions);
                     skipped += extracted.skipped;
                 }
             }
         }
 
-        return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, skipped, warnings };
+        return { sessions, turns, invocations, toolCalls, providerEvents, skillRelations, compactions, skipped, warnings };
     } catch (error) {
         return emptyExtract(
             [`failed to extract Cursor state database ${dbPath}: ${error instanceof Error ? error.message : String(error)}`],
@@ -902,6 +953,7 @@ const buildCursorBatchStatements = (extract: CursorExtract, sourcePath: string):
     ...extract.skillRelations.flatMap((relation) =>
         buildRelateToolCallSkillStatements(relation),
     ),
+    ...buildCompactionStatements(extract.compactions),
 ];
 
 export const __testBuildCursorBatchStatements = buildCursorBatchStatements;

--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -786,7 +786,7 @@ function extractComposerDiskKvData(
         compactions.push(
             extractCursorCompaction({
                 sessionId: session.id,
-                providerSessionId: composerId,
+                providerSessionId: session.id,
                 seq: compactionSeq,
                 ts: new Date(compactionTs),
                 agentEventKey: eventKey,

--- a/apps/axctl/src/ingest/pi.test.ts
+++ b/apps/axctl/src/ingest/pi.test.ts
@@ -677,6 +677,8 @@ describe("pi compaction", () => {
         expect(c.summary).toBe("Goal: ship X");
         expect(c.boundaryRef).toBe("entry-7");
         expect(c.tokensBefore).toBe(90000);
+        expect(c.readFiles).toEqual(["a.ts"]);
+        expect(c.modifiedFiles).toEqual([]);
         expect(extracted!.providerEvents.filter((e) => e.type === "compaction").length).toBe(1);
 
         const eventKey = agentEventRecordKey({

--- a/apps/axctl/src/ingest/pi.test.ts
+++ b/apps/axctl/src/ingest/pi.test.ts
@@ -663,3 +663,28 @@ describe("Pi JSONL directory walk (no-follow symlink semantics)", () => {
         expect(found).toEqual([join(sub, "ok.jsonl")]);
     });
 });
+
+describe("pi compaction", () => {
+    test("type:compaction produces a compaction row (no duplicate provider event)", () => {
+        const extracted = __testExtractPiJsonlLines([
+            JSON.stringify({ type: "session", id: "pi-1", timestamp: 1748498738132, cwd: "/tmp" }),
+            JSON.stringify({ type: "compaction", id: "c1", parentId: "p0", timestamp: 1748498800000, summary: "Goal: ship X", firstKeptEntryId: "entry-7", tokensBefore: 90000, fromHook: false, details: { readFiles: ["a.ts"], modifiedFiles: [] } }),
+        ]);
+        expect(extracted).not.toBeNull();
+        expect(extracted!.compactions.length).toBe(1);
+        const c = extracted!.compactions[0];
+        expect(c.strategy).toBe("summarize");
+        expect(c.summary).toBe("Goal: ship X");
+        expect(c.boundaryRef).toBe("entry-7");
+        expect(c.tokensBefore).toBe(90000);
+        expect(extracted!.providerEvents.filter((e) => e.type === "compaction").length).toBe(1);
+
+        const eventKey = agentEventRecordKey({
+            provider: "pi",
+            providerSessionId: "pi-1",
+            providerEventId: "c1",
+            seq: 1,
+        });
+        expect(c.agentEventKey).toBe(eventKey);
+    });
+});

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -24,6 +24,7 @@ import {
     type ToolCallSkillRelationWrite,
     type ToolCallWrite,
 } from "./evidence-writers.ts";
+import { buildCompactionStatements, extractPiCompaction, type CompactionWrite } from "./compaction.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
 import { providerDelegationSignalAvailability } from "./delegation.ts";
 import { agentEventRecordKey, buildAgentEventStatements, buildAgentProviderStatements, type AgentEventWrite } from "./provider-events.ts";
@@ -85,6 +86,7 @@ interface PiExtract {
     invocations: PiInvocation[];
     toolCalls: ToolCallWrite[];
     providerEvents: AgentEventWrite[];
+    compactions: CompactionWrite[];
     skillRelations: ToolCallSkillRelationWrite[];
     usage: PiUsage;
     skipped: number;
@@ -292,6 +294,7 @@ function createPiExtractor(filePath: string) {
     const invocations: PiInvocation[] = [];
     const toolCalls: MutableToolCallWrite[] = [];
     const providerEvents: AgentEventWrite[] = [];
+    const compactions: CompactionWrite[] = [];
     const skillRelations: ToolCallSkillRelationWrite[] = [];
     const toolCallsByCallId = new Map<string, MutableToolCallWrite>();
     const pendingToolResultsByCallId = new Map<string, ToolResultFields>();
@@ -543,6 +546,27 @@ function createPiExtractor(filePath: string) {
                 },
             }, session);
 
+            if (type === "compaction") {
+                // The universal pushProviderEvent above already emitted the
+                // `compaction` agent_event keyed on (provider, session, providerEventId,
+                // seq). Reproduce that exact key here to link the compaction row; do
+                // NOT push a second provider event.
+                const eventKey = agentEventRecordKey({
+                    provider: "pi",
+                    providerSessionId: session.id,
+                    providerEventId,
+                    seq,
+                });
+                const write = extractPiCompaction(entry, {
+                    sessionId: session.id,
+                    providerSessionId: session.id,
+                    seq,
+                    ts: new Date(ts),
+                    agentEventKey: eventKey,
+                });
+                if (write) compactions.push(write);
+            }
+
             if (message && role === "assistant" && Array.isArray(message.content)) {
                 let toolCallOrdinal = 0;
                 for (const block of message.content) {
@@ -567,6 +591,7 @@ function createPiExtractor(filePath: string) {
                 invocations,
                 toolCalls,
                 providerEvents,
+                compactions,
                 skillRelations,
                 usage,
                 skipped,
@@ -751,6 +776,7 @@ const buildPiBatchStatements = (extract: PiExtract): string[] => [
     ...extract.skillRelations.flatMap((relation) =>
         buildRelateToolCallSkillStatements(relation),
     ),
+    ...buildCompactionStatements(extract.compactions),
     ...buildPiTokenUsageStatements(extract),
 ];
 

--- a/apps/axctl/src/ingest/transcripts.test.ts
+++ b/apps/axctl/src/ingest/transcripts.test.ts
@@ -1084,3 +1084,64 @@ describe("Claude transcript extraction", () => {
         ]);
     });
 });
+
+describe("claude compaction", () => {
+    test("isCompactSummary message becomes a compaction row, not a user turn", () => {
+        const extracted = __testExtractClaudeJsonlLines(
+            [
+                JSON.stringify({
+                    type: "user",
+                    uuid: "u1",
+                    timestamp: "2026-06-01T10:00:00.000Z",
+                    sessionId: "cl-1",
+                    cwd: "/tmp",
+                    message: { role: "user", content: "real question" },
+                }),
+                JSON.stringify({
+                    type: "user",
+                    uuid: "u2",
+                    timestamp: "2026-06-01T10:05:00.000Z",
+                    sessionId: "cl-1",
+                    cwd: "/tmp",
+                    isCompactSummary: true,
+                    isVisibleInTranscriptOnly: true,
+                    message: { role: "user", content: "## Summary\nGoal: ship X" },
+                }),
+            ],
+            "-tmp",
+            "cl-1",
+        );
+
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+
+        expect(extracted.compactions.length).toBe(1);
+        expect(extracted.compactions[0].strategy).toBe("summarize");
+        expect(extracted.compactions[0].summary).toContain("Goal: ship X");
+        expect(extracted.compactions[0].boundaryRef).toBe("u2");
+
+        const userTurnTexts = extracted.turns
+            .filter((t) => t.role === "user")
+            .map((t) => t.text);
+        expect(userTurnTexts).toContain("real question");
+        expect(userTurnTexts.some((t) => t?.includes("Goal: ship X"))).toBe(false);
+
+        // No duplicate type:"user" provider event for the compaction entry,
+        // and exactly one compaction provider event whose key matches the row.
+        const compactionEvents = extracted.providerEvents.filter(
+            (e) => e.type === "compaction",
+        );
+        expect(compactionEvents.length).toBe(1);
+        const userEventsForU2 = extracted.providerEvents.filter(
+            (e) => e.providerEventId === "u2" && e.type === "user",
+        );
+        expect(userEventsForU2.length).toBe(0);
+        const eventKey = agentEventRecordKey({
+            provider: "claude",
+            providerSessionId: "cl-1",
+            providerEventId: "u2",
+            seq: compactionEvents[0].seq,
+        });
+        expect(extracted.compactions[0].agentEventKey).toBe(eventKey);
+    });
+});

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -47,6 +47,11 @@ import { executeStatements, executeStatementsWith } from "@ax/lib/shared/stateme
 import { fileWatermark } from "@ax/lib/shared/watermark";
 import { skipNotFound } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
+import {
+    buildCompactionStatements,
+    extractClaudeCompaction,
+    type CompactionWrite,
+} from "./compaction.ts";
 
 const MAX_OUTPUT_EXCERPT_CHARS = 1200;
 const DEFAULT_CLAUDE_CONCURRENCY = 4;
@@ -299,11 +304,13 @@ interface FileExtract {
     planSnapshots: PlanSnapshotWrite[];
     hookEvents: HarnessHookEventWrite[];
     hookCommandInvocations: HookCommandInvocationWrite[];
+    compactions: CompactionWrite[];
 }
 
 function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: string) {
     let session: Session | null = null;
     const turns: Turn[] = [];
+    const compactions: CompactionWrite[] = [];
     const invocations: Invocation[] = [];
     const edits: Edit[] = [];
     const toolCalls: MutableToolCallWrite[] = [];
@@ -872,6 +879,57 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
             const providerEventId = stringField(entry, "uuid");
             const kind = messageKind(role, messageContent, textExcerpt);
             const intentKind = classifyTurnIntent({ role, messageKind: kind, source: "claude", text });
+
+            // Context-compaction artifact: a synthetic `type:"user"` entry with
+            // `isCompactSummary:true` carrying the summary text. Capture it as a
+            // `compaction` row + a `compaction` provider event, and SKIP the
+            // normal user turn + the unconditional provider push so it never
+            // pollutes turn/recall data (it is transcript-only, not a real turn).
+            const isCompactSummary =
+                entry.isCompactSummary === true ||
+                (isRecord(entry.message) &&
+                    (entry.message as Record<string, unknown>).isCompactSummary === true);
+            if (isCompactSummary) {
+                const compactionSeq = nextProviderSeq();
+                const eventKey = agentEventRecordKey({
+                    provider: "claude",
+                    providerSessionId: sessionId,
+                    providerEventId,
+                    seq: compactionSeq,
+                });
+                pushProviderEvent({
+                    providerEventId,
+                    seq: compactionSeq,
+                    ts,
+                    type: "compaction",
+                    role: null,
+                    text,
+                    textExcerpt,
+                    raw: entry,
+                    labels: {
+                        source: "claude_transcript",
+                        messageKind: kind,
+                        intentKind,
+                    },
+                    metrics: {
+                        turnSeq: seq,
+                        contentBlocks: content.length,
+                    },
+                });
+                compactions.push(
+                    extractClaudeCompaction({
+                        sessionId,
+                        providerSessionId: sessionId,
+                        seq: compactionSeq,
+                        ts: new Date(ts),
+                        agentEventKey: eventKey,
+                        summary: text ?? null,
+                        boundaryRef: providerEventId ?? null,
+                    }),
+                );
+                return;
+            }
+
             pushProviderEvent({
                 providerEventId,
                 seq: nextProviderSeq(),
@@ -947,6 +1005,7 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
                 planSnapshots,
                 hookEvents,
                 hookCommandInvocations,
+                compactions,
             };
         },
     };
@@ -1195,6 +1254,9 @@ const writePlanSnapshots = (snapshots: PlanSnapshotWrite[]) =>
 const writeToolCallStatements = (toolCalls: readonly ToolCallWrite[]) =>
     queryTranscriptStatements(buildToolCallStatements(toolCalls));
 
+const writeCompactions = (compactions: readonly CompactionWrite[]) =>
+    queryTranscriptStatements(buildCompactionStatements(compactions));
+
 const writeHookEvidence = (
     events: readonly HarnessHookEventWrite[],
     invocations: readonly HookCommandInvocationWrite[],
@@ -1438,6 +1500,7 @@ export const ingestTranscripts = (
             yield* upsertTurns(extracted.turns);
             turnCount += extracted.turns.length;
             yield* writeProviderEvidence(extracted);
+            yield* writeCompactions(extracted.compactions);
             yield* writeToolCallStatements(extracted.toolCalls);
             toolCallCount += extracted.toolCalls.length;
             yield* writeToolFileEvidence(extracted.toolCalls);

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -70,6 +70,7 @@ export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "content_block", stage: "active", note: "Searchable markdown block chunks with source offsets." },
     { table: "content_atom", stage: "active", note: "Fine-grained parsed document facts and evidence atoms." },
     { table: "plan_snapshot", stage: "active", note: "Point-in-time TodoWrite/update_plan snapshots." },
+    { table: "compaction", stage: "active", note: "Context-compaction events per harness (summarize/history-replacement/encrypted)." },
     { table: "insight", stage: "active", note: "Imported Claude usage-data insight facets." },
     { table: "friction_event", stage: "active", note: "Tool failures, imported insight friction, and derived friction." },
     { table: "turn_analysis", stage: "active", note: "Per-turn message analysis for sparse user feedback and assistant behavior." },

--- a/apps/axctl/src/queries/session-detail.ts
+++ b/apps/axctl/src/queries/session-detail.ts
@@ -16,6 +16,7 @@ import { toBareSessionId } from "@ax/lib/shared/session-id";
 import { decodeJsonOrNull } from "@ax/lib/decode";
 import type {
     SessionAgentDelegation,
+    SessionCompaction,
     SessionHealthSummary,
     SessionLink,
     SessionOverview,
@@ -100,6 +101,21 @@ FROM tool_call
 WHERE session = $sessionId AND name = "Agent"
 ORDER BY ts ASC
 LIMIT 50;`;
+
+/** Context-compaction boundaries recorded for this session, oldest first. */
+export const SESSION_COMPACTIONS_SQL = `
+SELECT
+    harness,
+    type::string(ts) AS ts,
+    strategy,
+    trigger,
+    tokens_before,
+    kept_count,
+    summary
+FROM compaction
+WHERE session = $sessionId
+ORDER BY ts ASC
+LIMIT 100;`;
 
 export const SESSION_TOKEN_USAGE_SQL = `
 SELECT
@@ -566,6 +582,31 @@ export const sessionTokenUsageQuery = defineSingleQuery<
             estimated_cache_read_cost_usd: nullableNumberField(raw, "estimated_cache_read_cost_usd"),
             estimated_cost_usd: nullableNumberField(raw, "estimated_cost_usd"),
             pricing_source: stringField(raw, "pricing_source"),
+        };
+    },
+});
+
+export const sessionCompactionsQuery = defineQuery<
+    SessionDetailParams,
+    Record<string, unknown>,
+    SessionCompaction | null
+>({
+    name: "session-detail.compactions",
+    sql: (p) => subst(SESSION_COMPACTIONS_SQL, p.recordRef),
+    mapRow: (raw) => {
+        if (!isRecord(raw)) return null;
+        const harness = stringField(raw, "harness");
+        const ts = dateField(raw, "ts");
+        const strategy = stringField(raw, "strategy");
+        if (!harness || !ts || !strategy) return null;
+        return {
+            harness,
+            ts,
+            strategy,
+            trigger: stringField(raw, "trigger"),
+            tokens_before: nullableNumberField(raw, "tokens_before"),
+            kept_count: nullableNumberField(raw, "kept_count"),
+            summary: stringField(raw, "summary"),
         };
     },
 });

--- a/docs/superpowers/plans/2026-06-04-compaction-signal.md
+++ b/docs/superpowers/plans/2026-06-04-compaction-signal.md
@@ -1,0 +1,1142 @@
+# Compaction Signal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make context compaction a first-class, queryable event across the Pi, Codex, Claude, and Cursor harness parsers in the ax ingest pipeline.
+
+**Architecture:** A new SCHEMAFULL `compaction` projection table (mirroring `plan_snapshot`) plus a shared `compaction.ts` module holding the typed `CompactionWrite` shape, its SurrealDB statement builder, and four pure per-harness extractors. Each parser detects its native compaction marker, builds a `CompactionWrite`, threads it through the existing `*Extract` accumulator, and appends `buildCompactionStatements(...)` to its batch write. The Claude parser additionally stops mis-ingesting the `isCompactSummary` continuation message as a normal turn. Two compaction models (summarize-to-text vs history-replacement) are unified via a `strategy` discriminant. OpenCode is out of scope (gets the schema field, stays null).
+
+**Tech Stack:** TypeScript (strict), bun ≥ 1.3, SurrealDB 3.0+, `bun:test`. SurrealDB statement helpers from `@ax/lib/shared/surql`. Provider-event substrate in `apps/axctl/src/ingest/provider-events.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-compaction-signal-design.md`
+
+**Working tree:** worktree `feat/compaction-signal` (branch `feat/compaction-signal`). All commits land here; integrate via PR.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `packages/schema/src/schema.surql` | DDL - add `compaction` table | Modify (after `plan_snapshot`, ~line 501) |
+| `apps/axctl/src/ingest/compaction.ts` | `CompactionWrite` type, `compactionRecordKey`, `buildCompactionStatements`, 4 pure extractors | Create |
+| `apps/axctl/src/ingest/compaction.test.ts` | Unit tests for builder + extractors | Create |
+| `apps/axctl/src/ingest/codex.ts` | Detect `type:"compacted"`, thread compactions | Modify |
+| `apps/axctl/src/ingest/codex.test.ts` | Codex compaction test | Modify |
+| `apps/axctl/src/ingest/pi.ts` | Detect `type:"compaction"`, thread compactions | Modify |
+| `apps/axctl/src/ingest/pi.test.ts` | Pi compaction test | Modify |
+| `apps/axctl/src/ingest/transcripts.ts` | Detect `isCompactSummary`, skip turn, thread compactions | Modify |
+| `apps/axctl/src/ingest/transcripts.test.ts` | Claude compaction + turn-skip regression | Modify/Create |
+| `apps/axctl/src/ingest/cursor.ts` | Detect non-empty `summarizedComposers`, thread compactions | Modify |
+| `apps/axctl/src/ingest/cursor.test.ts` | Cursor compaction test | Modify |
+| `apps/axctl/src/dashboard/session-show.ts` | Add `compactions` to `SessionViewPayload` + query | Modify |
+| `apps/axctl/src/cli/session-show-format.ts` | Render compaction boundaries | Modify |
+| `apps/axctl/src/cli/session-show-format.test.ts` | Renderer test | Modify |
+
+**Control-flow flags (from codebase analysis):**
+- **Pi already emits a generic provider event for every entry** (`pi.ts:517` unconditional `pushProviderEvent` with `type` passed through). So a `type:"compaction"` entry *already* produces an `agent_event` with `type:"compaction"`. Do **NOT** add a second `pushProviderEvent` in the Pi arm - only extract the projection row. Capture the emitted event's key via `agentEventRecordKey(...)` for the `agent_event` link.
+- **Codex drops unknown top-level types** - `type:"compacted"` falls through the whole switch and emits nothing today. The Codex arm MUST both `pushProviderEvent` and extract the projection row.
+- **`agent_event.type` is an unconstrained string** - `"compaction"` needs no DDL change for the event. Only the new `compaction` projection table is new DDL.
+- **No codegen** - `packages/schema/src/types.ts` is a hand-written stub; no derived-type update is required.
+
+---
+
+## Task 1: Schema - `compaction` table
+
+**Files:**
+- Modify: `packages/schema/src/schema.surql` (insert after `plan_snapshot` block, which ends at line 501)
+- Test: `packages/schema/src/schema.test.ts` (already applies the full schema; no new test needed - it validates the DDL parses/applies)
+
+- [ ] **Step 1: Add the table DDL**
+
+Insert immediately after the `plan_snapshot` index lines (after `schema.surql:501`):
+
+```surql
+
+DEFINE TABLE compaction SCHEMAFULL;
+DEFINE FIELD session           ON compaction TYPE record<session>;
+DEFINE FIELD agent_event       ON compaction TYPE option<record<agent_event>>;
+DEFINE FIELD harness           ON compaction TYPE string;          -- provider name: claude|codex|pi|cursor|opencode
+DEFINE FIELD ts                ON compaction TYPE datetime;
+DEFINE FIELD trigger           ON compaction TYPE option<string>;  -- auto|manual|hook
+DEFINE FIELD strategy          ON compaction TYPE string;          -- summarize|history_replacement|encrypted
+DEFINE FIELD source_confidence ON compaction TYPE string;          -- explicit|derived
+DEFINE FIELD summary           ON compaction TYPE option<string>;  -- Pi/Claude; null for Codex/Cursor
+DEFINE FIELD tokens_before     ON compaction TYPE option<int>;
+DEFINE FIELD boundary_ref      ON compaction TYPE option<string>;  -- where post-compaction history resumes
+DEFINE FIELD kept_count        ON compaction TYPE option<int>;     -- Codex replacement_history length
+DEFINE FIELD read_files        ON compaction TYPE option<string>;  -- JSON-encoded array; Pi details
+DEFINE FIELD modified_files    ON compaction TYPE option<string>;  -- JSON-encoded array; Pi details
+DEFINE FIELD raw               ON compaction TYPE option<string>;  -- JSON-encoded
+DEFINE INDEX compaction_session_ts  ON compaction FIELDS session, ts;
+DEFINE INDEX compaction_agent_event ON compaction FIELDS agent_event;
+```
+
+- [ ] **Step 2: Run the schema test to verify the DDL applies**
+
+Run: `bun test packages/schema/src/schema.test.ts`
+Expected: PASS (schema applies cleanly; a malformed DDL would fail to parse).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C .claude/worktrees/compaction-signal add packages/schema/src/schema.surql
+git -C .claude/worktrees/compaction-signal commit -m "feat(schema): add compaction projection table"
+```
+
+---
+
+## Task 2: Shared `compaction.ts` module
+
+**Files:**
+- Create: `apps/axctl/src/ingest/compaction.ts`
+- Test: `apps/axctl/src/ingest/compaction.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/axctl/src/ingest/compaction.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+    buildCompactionStatements,
+    compactionRecordKey,
+    extractCodexCompaction,
+    extractCursorCompaction,
+    extractPiCompaction,
+    type CompactionWrite,
+} from "./compaction.ts";
+
+describe("compactionRecordKey", () => {
+    test("is deterministic and sanitized", () => {
+        expect(compactionRecordKey("codex", "sess-1:abc", 3)).toBe("codex_sess_1_abc_cmp_3");
+    });
+});
+
+describe("buildCompactionStatements", () => {
+    test("emits one UPSERT with typed fields", () => {
+        const write: CompactionWrite = {
+            compactionKey: "codex_s_cmp_1",
+            sessionId: "s",
+            agentEventKey: "codex_s_seq_000001",
+            harness: "codex",
+            ts: new Date("2026-05-14T15:34:42.663Z"),
+            trigger: "auto",
+            strategy: "history_replacement",
+            sourceConfidence: "explicit",
+            summary: null,
+            tokensBefore: 120000,
+            boundaryRef: "seq_42",
+            keptCount: 83,
+            readFiles: null,
+            modifiedFiles: null,
+            raw: { replacement_count: 83 },
+        };
+        const [stmt] = buildCompactionStatements([write]);
+        expect(stmt).toContain("UPSERT compaction:");
+        expect(stmt).toContain("harness: 'codex'");
+        expect(stmt).toContain("strategy: 'history_replacement'");
+        expect(stmt).toContain("kept_count: 83");
+        expect(stmt).toContain("tokens_before: 120000");
+        expect(stmt).toContain("summary: NONE");
+        expect(stmt).toContain("session: session:");
+        expect(stmt).toContain("agent_event: agent_event:");
+    });
+
+    test("null kept_count and tokens become NONE", () => {
+        const write: CompactionWrite = {
+            compactionKey: "pi_s_cmp_1",
+            sessionId: "s",
+            agentEventKey: null,
+            harness: "pi",
+            ts: new Date("2026-05-29T06:05:38.132Z"),
+            trigger: "auto",
+            strategy: "summarize",
+            sourceConfidence: "explicit",
+            summary: "Goal: ship X",
+            tokensBefore: 90000,
+            boundaryRef: "entry-7",
+            keptCount: null,
+            readFiles: ["a.ts", "b.ts"],
+            modifiedFiles: null,
+            raw: null,
+        };
+        const [stmt] = buildCompactionStatements([write]);
+        expect(stmt).toContain("kept_count: NONE");
+        expect(stmt).toContain("agent_event: NONE");
+        expect(stmt).toContain("strategy: 'summarize'");
+        expect(stmt).toContain("read_files: '[\"a.ts\",\"b.ts\"]'");
+        expect(stmt).toContain("raw: NONE");
+    });
+});
+
+describe("extractPiCompaction", () => {
+    test("maps a Pi CompactionEntry", () => {
+        const entry = {
+            type: "compaction",
+            id: "c1",
+            summary: "Goal: ship X",
+            firstKeptEntryId: "entry-7",
+            tokensBefore: 90000,
+            fromHook: false,
+            details: { readFiles: ["a.ts"], modifiedFiles: ["b.ts"] },
+        };
+        const w = extractPiCompaction(entry, {
+            sessionId: "s",
+            providerSessionId: "ps",
+            seq: 4,
+            ts: new Date("2026-05-29T06:05:38.132Z"),
+            agentEventKey: "pi_ps_seq_000004",
+        });
+        expect(w).not.toBeNull();
+        expect(w!.strategy).toBe("summarize");
+        expect(w!.summary).toBe("Goal: ship X");
+        expect(w!.tokensBefore).toBe(90000);
+        expect(w!.boundaryRef).toBe("entry-7");
+        expect(w!.trigger).toBe("auto");
+        expect(w!.readFiles).toEqual(["a.ts"]);
+        expect(w!.modifiedFiles).toEqual(["b.ts"]);
+    });
+
+    test("fromHook=true => trigger hook", () => {
+        const w = extractPiCompaction(
+            { type: "compaction", summary: "s", fromHook: true },
+            { sessionId: "s", providerSessionId: "ps", seq: 1, ts: new Date(0), agentEventKey: null },
+        );
+        expect(w!.trigger).toBe("hook");
+    });
+});
+
+describe("extractCodexCompaction", () => {
+    test("history-replacement with kept_count", () => {
+        const payload = {
+            message: "",
+            replacement_history: [{ type: "message" }, { type: "message" }, { type: "message" }],
+        };
+        const w = extractCodexCompaction(payload, {
+            sessionId: "s",
+            providerSessionId: "ps",
+            seq: 10,
+            ts: new Date("2026-05-14T15:34:42.663Z"),
+            agentEventKey: "codex_ps_seq_000010",
+            tokensBefore: 120000,
+            boundaryRef: "seq_10",
+        });
+        expect(w!.strategy).toBe("history_replacement");
+        expect(w!.summary).toBeNull();
+        expect(w!.keptCount).toBe(3);
+        expect(w!.tokensBefore).toBe(120000);
+        expect(w!.trigger).toBe("auto");
+    });
+
+    test("non-empty message => manual trigger + summary", () => {
+        const w = extractCodexCompaction(
+            { message: "focus on auth", replacement_history: [] },
+            { sessionId: "s", providerSessionId: "ps", seq: 1, ts: new Date(0), agentEventKey: null, tokensBefore: null, boundaryRef: "seq_1" },
+        );
+        expect(w!.trigger).toBe("manual");
+        expect(w!.summary).toBe("focus on auth");
+    });
+});
+
+describe("extractCursorCompaction", () => {
+    test("encrypted strategy, null summary", () => {
+        const w = extractCursorCompaction({
+            sessionId: "s",
+            providerSessionId: "ps",
+            seq: 2,
+            ts: new Date("2026-05-29T00:00:00.000Z"),
+            agentEventKey: "cursor_ps_seq_000002",
+            boundaryRef: "bubble-9",
+            summarizedComposers: ["comp-1"],
+        });
+        expect(w.strategy).toBe("encrypted");
+        expect(w.summary).toBeNull();
+        expect(w.boundaryRef).toBe("bubble-9");
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test apps/axctl/src/ingest/compaction.test.ts`
+Expected: FAIL - `Cannot find module './compaction.ts'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `apps/axctl/src/ingest/compaction.ts`:
+
+```ts
+import {
+    recordRef,
+    surrealDate,
+    surrealJsonTextOption,
+    surrealObject,
+    surrealOptionInt,
+    surrealOptionRecord,
+    surrealOptionString,
+    surrealString,
+} from "@ax/lib/shared/surql";
+
+export type CompactionStrategy = "summarize" | "history_replacement" | "encrypted";
+export type CompactionTrigger = "auto" | "manual" | "hook";
+export type CompactionConfidence = "explicit" | "derived";
+
+export interface CompactionWrite {
+    readonly compactionKey: string;
+    readonly sessionId: string;
+    readonly agentEventKey?: string | null;
+    readonly harness: string;
+    readonly ts: Date;
+    readonly trigger?: CompactionTrigger | null;
+    readonly strategy: CompactionStrategy;
+    readonly sourceConfidence: CompactionConfidence;
+    readonly summary?: string | null;
+    readonly tokensBefore?: number | null;
+    readonly boundaryRef?: string | null;
+    readonly keptCount?: number | null;
+    readonly readFiles?: readonly string[] | null;
+    readonly modifiedFiles?: readonly string[] | null;
+    readonly raw?: unknown;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+    typeof v === "object" && v !== null && !Array.isArray(v);
+
+const stringArray = (v: unknown): readonly string[] | null =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : null;
+
+export const compactionRecordKey = (
+    harness: string,
+    providerSessionId: string,
+    seq: number,
+): string => `${harness}_${providerSessionId}_cmp_${seq}`.replace(/[^A-Za-z0-9_]/g, "_");
+
+export const buildCompactionStatements = (
+    writes: readonly CompactionWrite[],
+): string[] =>
+    writes.map(
+        (c) =>
+            `UPSERT ${recordRef("compaction", c.compactionKey)} CONTENT ${surrealObject([
+                ["session", recordRef("session", c.sessionId)],
+                ["agent_event", surrealOptionRecord("agent_event", c.agentEventKey ?? null)],
+                ["harness", surrealString(c.harness)],
+                ["ts", surrealDate(c.ts)],
+                ["trigger", surrealOptionString(c.trigger ?? null)],
+                ["strategy", surrealString(c.strategy)],
+                ["source_confidence", surrealString(c.sourceConfidence)],
+                ["summary", surrealOptionString(c.summary ?? null)],
+                ["tokens_before", surrealOptionInt(c.tokensBefore ?? null)],
+                ["boundary_ref", surrealOptionString(c.boundaryRef ?? null)],
+                ["kept_count", surrealOptionInt(c.keptCount ?? null)],
+                ["read_files", surrealJsonTextOption(c.readFiles ?? null)],
+                ["modified_files", surrealJsonTextOption(c.modifiedFiles ?? null)],
+                ["raw", surrealJsonTextOption(c.raw ?? null)],
+            ])};`,
+    );
+
+export interface PiCompactionCtx {
+    readonly sessionId: string;
+    readonly providerSessionId: string;
+    readonly seq: number;
+    readonly ts: Date;
+    readonly agentEventKey?: string | null;
+}
+
+export const extractPiCompaction = (
+    entry: Record<string, unknown>,
+    ctx: PiCompactionCtx,
+): CompactionWrite | null => {
+    if (entry.type !== "compaction") return null;
+    const details = isRecord(entry.details) ? entry.details : null;
+    return {
+        compactionKey: compactionRecordKey("pi", ctx.providerSessionId, ctx.seq),
+        sessionId: ctx.sessionId,
+        agentEventKey: ctx.agentEventKey ?? null,
+        harness: "pi",
+        ts: ctx.ts,
+        trigger: entry.fromHook === true ? "hook" : "auto",
+        strategy: "summarize",
+        sourceConfidence: "explicit",
+        summary: typeof entry.summary === "string" ? entry.summary : null,
+        tokensBefore: typeof entry.tokensBefore === "number" ? entry.tokensBefore : null,
+        boundaryRef:
+            typeof entry.firstKeptEntryId === "string" ? entry.firstKeptEntryId : null,
+        keptCount: null,
+        readFiles: details ? stringArray(details.readFiles) : null,
+        modifiedFiles: details ? stringArray(details.modifiedFiles) : null,
+        raw: { fromHook: entry.fromHook === true },
+    };
+};
+
+export interface CodexCompactionCtx {
+    readonly sessionId: string;
+    readonly providerSessionId: string;
+    readonly seq: number;
+    readonly ts: Date;
+    readonly agentEventKey?: string | null;
+    readonly tokensBefore?: number | null;
+    readonly boundaryRef?: string | null;
+}
+
+export const extractCodexCompaction = (
+    payload: Record<string, unknown>,
+    ctx: CodexCompactionCtx,
+): CompactionWrite | null => {
+    const replacement = Array.isArray(payload.replacement_history)
+        ? payload.replacement_history
+        : [];
+    const message = typeof payload.message === "string" ? payload.message : "";
+    return {
+        compactionKey: compactionRecordKey("codex", ctx.providerSessionId, ctx.seq),
+        sessionId: ctx.sessionId,
+        agentEventKey: ctx.agentEventKey ?? null,
+        harness: "codex",
+        ts: ctx.ts,
+        trigger: message.length > 0 ? "manual" : "auto",
+        strategy: "history_replacement",
+        sourceConfidence: "explicit",
+        summary: message.length > 0 ? message : null,
+        tokensBefore: ctx.tokensBefore ?? null,
+        boundaryRef: ctx.boundaryRef ?? null,
+        keptCount: replacement.length,
+        readFiles: null,
+        modifiedFiles: null,
+        raw: { replacement_count: replacement.length },
+    };
+};
+
+export interface ClaudeCompactionCtx {
+    readonly sessionId: string;
+    readonly providerSessionId: string;
+    readonly seq: number;
+    readonly ts: Date;
+    readonly agentEventKey?: string | null;
+    readonly summary: string | null;
+    readonly boundaryRef?: string | null;
+}
+
+export const extractClaudeCompaction = (
+    ctx: ClaudeCompactionCtx,
+): CompactionWrite => ({
+    compactionKey: compactionRecordKey("claude", ctx.providerSessionId, ctx.seq),
+    sessionId: ctx.sessionId,
+    agentEventKey: ctx.agentEventKey ?? null,
+    harness: "claude",
+    ts: ctx.ts,
+    trigger: "auto",
+    strategy: "summarize",
+    sourceConfidence: "explicit",
+    summary: ctx.summary,
+    tokensBefore: null,
+    boundaryRef: ctx.boundaryRef ?? null,
+    keptCount: null,
+    readFiles: null,
+    modifiedFiles: null,
+    raw: null,
+});
+
+export interface CursorCompactionCtx {
+    readonly sessionId: string;
+    readonly providerSessionId: string;
+    readonly seq: number;
+    readonly ts: Date;
+    readonly agentEventKey?: string | null;
+    readonly boundaryRef?: string | null;
+    readonly summarizedComposers: readonly string[];
+}
+
+export const extractCursorCompaction = (
+    ctx: CursorCompactionCtx,
+): CompactionWrite => ({
+    compactionKey: compactionRecordKey("cursor", ctx.providerSessionId, ctx.seq),
+    sessionId: ctx.sessionId,
+    agentEventKey: ctx.agentEventKey ?? null,
+    harness: "cursor",
+    ts: ctx.ts,
+    trigger: "auto",
+    strategy: "encrypted",
+    sourceConfidence: "explicit",
+    summary: null,
+    tokensBefore: null,
+    boundaryRef: ctx.boundaryRef ?? null,
+    keptCount: null,
+    readFiles: null,
+    modifiedFiles: null,
+    raw: { summarized_composers: ctx.summarizedComposers },
+});
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun test apps/axctl/src/ingest/compaction.test.ts`
+Expected: PASS (all assertions). If `read_files` assertion fails, confirm `surrealJsonTextOption` emits compact JSON (no spaces) - `JSON.stringify(["a.ts","b.ts"])` => `["a.ts","b.ts"]`.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C .claude/worktrees/compaction-signal add apps/axctl/src/ingest/compaction.ts apps/axctl/src/ingest/compaction.test.ts
+git -C .claude/worktrees/compaction-signal commit -m "feat(ingest): shared compaction write type, statement builder, extractors"
+```
+
+---
+
+## Task 3: Codex parser - detect `type:"compacted"`
+
+**Files:**
+- Modify: `apps/axctl/src/ingest/codex.ts`
+- Test: `apps/axctl/src/ingest/codex.test.ts`
+
+Context (from analysis): `processLine` switch is at `codex.ts:867-967`; the `token_count` block is at `:901-911`; the `response_item` block starts at `:913`. The `*Extract` accumulators are closure arrays drained via `.splice(...)` at `:833` and returned in the drain object at `:852`; `planSnapshots` is an existing projection accumulator threaded the same way you'll thread `compactions`. The provider statement builder `buildCodexProviderStatements` is at `:1230-1280`. `pushProviderEvent` is at `:566` and `agentEventRecordKey` is imported from `./provider-events.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/axctl/src/ingest/codex.test.ts`:
+
+```ts
+import { extractCodexCompaction } from "./compaction.ts"; // (add if not already imported)
+
+describe("codex compaction", () => {
+    test("type:compacted produces a compaction row + provider event", () => {
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({ type: "session_meta", payload: { id: "cdx-1", timestamp: "2026-05-14T15:00:00.000Z", cwd: "/tmp", originator: "test" } }),
+            JSON.stringify({ type: "event_msg", timestamp: "2026-05-14T15:30:00.000Z", payload: { type: "token_count", info: { total_token_usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120000 }, model_context_window: 200000 } } }),
+            JSON.stringify({ type: "compacted", timestamp: "2026-05-14T15:34:42.663Z", payload: { message: "", replacement_history: [{ type: "message" }, { type: "message" }] } }),
+        ]);
+        expect(extracted.compactions.length).toBe(1);
+        const c = extracted.compactions[0];
+        expect(c.harness).toBe("codex");
+        expect(c.strategy).toBe("history_replacement");
+        expect(c.keptCount).toBe(2);
+        expect(c.tokensBefore).toBe(120000);
+        // provider event emitted with type "compaction"
+        expect(extracted.providerEvents.some((e) => e.type === "compaction")).toBe(true);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test apps/axctl/src/ingest/codex.test.ts`
+Expected: FAIL - `extracted.compactions` is undefined.
+
+- [ ] **Step 3: Add the `compactions` accumulator + import**
+
+In `codex.ts`, add to the imports near the existing `./compaction.ts`-adjacent imports:
+
+```ts
+import { buildCompactionStatements, extractCodexCompaction, type CompactionWrite } from "./compaction.ts";
+```
+
+Near the other closure accumulators (where `providerEvents`/`planSnapshots` are declared, around `codex.ts:551`), add:
+
+```ts
+const compactions: CompactionWrite[] = [];
+let lastContextTokens: number | null = null;
+```
+
+In the `token_count` block (`codex.ts:901-911`), after the existing usage advance, capture the running context size. Add this line inside that block:
+
+```ts
+lastContextTokens = tokenUsage?.totalTokens ?? lastContextTokens;
+```
+
+(If the local field is named differently, use the `total_tokens` value just parsed by `codexTokenUsageFromPayload`. Confirm the property name on `CodexTokenUsage` by reading `codex.ts:90-98`.)
+
+- [ ] **Step 4: Add the `compacted` arm**
+
+Insert between the `token_count` block (ends `:911`) and the `response_item` block (starts `:913`):
+
+```ts
+if (type === "compacted" && payload && session) {
+    seq += 1;
+    const eventKey = agentEventRecordKey({
+        provider: "codex",
+        providerSessionId: session.id,
+        seq,
+        ts,
+        type: "compaction",
+    });
+    pushProviderEvent(
+        {
+            seq,
+            ts,
+            type: "compaction",
+            role: null,
+            text: null,
+            metrics: { strategy: "history_replacement" },
+            raw: { replacement_count: Array.isArray(payload.replacement_history) ? payload.replacement_history.length : 0 },
+        },
+        session,
+    );
+    const write = extractCodexCompaction(payload, {
+        sessionId: session.id,
+        providerSessionId: session.id,
+        seq,
+        ts: new Date(ts),
+        agentEventKey: eventKey,
+        tokensBefore: lastContextTokens,
+        boundaryRef: `seq_${seq}`,
+    });
+    if (write) compactions.push(write);
+    return;
+}
+```
+
+Notes:
+- `pushProviderEvent`'s exact argument shape must match its definition at `codex.ts:566` - read it and align field names (`seq`, `ts`, `type`, `role`, `text`, `metrics`, `raw`). The example above assumes the same shape used by the `response_item` pushes.
+- `session.id` is the provider session id used elsewhere in this file as the session key - confirm against the `session_meta` block at `:876-887`.
+- `agentEventRecordKey` is already imported in this file (used in tests); if not imported in the module, add it from `./provider-events.ts`.
+
+- [ ] **Step 5: Thread `compactions` through drain + finish + remaining**
+
+At the drain site (`codex.ts:833`), add alongside the other `.splice(...)` drains:
+
+```ts
+const drainedCompactions = compactions.splice(0, compactions.length);
+```
+
+In the drain return object (`codex.ts:852`), add:
+
+```ts
+compactions: drainedCompactions,
+```
+
+In the `finish()` remaining-return (`codex.ts:864`), add `compactions: remaining.compactions,` to the returned object, and add `compactions: CompactionWrite[]` to the `*Extract` interface for codex (find it near the top of the file - search `interface` with a `providerEvents` field; add the field there).
+
+- [ ] **Step 6: Emit compaction statements in the builder**
+
+In `buildCodexProviderStatements` (`codex.ts:1230-1280`), where it returns the array of statements (it calls `buildAgentEventStatements(...)`), append the compaction statements. Change the returned array to include:
+
+```ts
+...buildCompactionStatements(batch.compactions ?? []),
+```
+
+`batch` here is the drained/extracted object - confirm it carries `compactions` (it does after Step 5). If the builder's parameter type doesn't include `compactions`, add it to that type.
+
+- [ ] **Step 7: Run tests + typecheck**
+
+Run: `bun test apps/axctl/src/ingest/codex.test.ts && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C .claude/worktrees/compaction-signal add apps/axctl/src/ingest/codex.ts apps/axctl/src/ingest/codex.test.ts
+git -C .claude/worktrees/compaction-signal commit -m "feat(ingest): emit compaction events from codex transcripts"
+```
+
+---
+
+## Task 4: Pi parser - detect `type:"compaction"`
+
+**Files:**
+- Modify: `apps/axctl/src/ingest/pi.ts`
+- Test: `apps/axctl/src/ingest/pi.test.ts`
+
+Context: `PiExtract` interface at `pi.ts:81` (has `providerEvents`). The `type` chain is at `pi.ts:440-556`; the **universal** `pushProviderEvent` is at `:517-544` (so a `compaction` entry already emits an `agent_event` with `type:"compaction"` - do NOT add a second push). `finish()` returns the extract at `:558-570`. Statements assembled around `:717` via `buildAgentEventStatements`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/axctl/src/ingest/pi.test.ts`:
+
+```ts
+describe("pi compaction", () => {
+    test("type:compaction produces a compaction row (no duplicate provider event)", () => {
+        const extracted = __testExtractPiJsonlLines([
+            JSON.stringify({ type: "session", id: "pi-1", timestamp: 1748498738132, cwd: "/tmp" }),
+            JSON.stringify({ type: "compaction", id: "c1", parentId: "p0", timestamp: 1748498800000, summary: "Goal: ship X", firstKeptEntryId: "entry-7", tokensBefore: 90000, fromHook: false, details: { readFiles: ["a.ts"], modifiedFiles: [] } }),
+        ]);
+        expect(extracted.compactions.length).toBe(1);
+        const c = extracted.compactions[0];
+        expect(c.strategy).toBe("summarize");
+        expect(c.summary).toBe("Goal: ship X");
+        expect(c.boundaryRef).toBe("entry-7");
+        expect(c.tokensBefore).toBe(90000);
+        // exactly one provider event for the compaction entry (no double-push)
+        expect(extracted.providerEvents.filter((e) => e.type === "compaction").length).toBe(1);
+    });
+});
+```
+
+(If Pi timestamps are epoch-ms, the test uses numbers; confirm the session header field names against `pi.ts:441-459` and adjust the `session` line if needed.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test apps/axctl/src/ingest/pi.test.ts`
+Expected: FAIL - `extracted.compactions` is undefined.
+
+- [ ] **Step 3: Add accumulator + interface field + import**
+
+Import in `pi.ts`:
+
+```ts
+import { buildCompactionStatements, extractPiCompaction, type CompactionWrite } from "./compaction.ts";
+```
+
+Add `compactions: CompactionWrite[];` to the `PiExtract` interface (`pi.ts:81`). Declare the accumulator near `const providerEvents: AgentEventWrite[] = [];` (`pi.ts:294`):
+
+```ts
+const compactions: CompactionWrite[] = [];
+```
+
+- [ ] **Step 4: Add the compaction extraction (after the universal provider-event push)**
+
+The universal `pushProviderEvent` at `pi.ts:517-544` already emits the `agent_event`. Immediately AFTER that push (so the event key matches), add:
+
+```ts
+if (type === "compaction") {
+    const eventKey = agentEventRecordKey({
+        provider: "pi",
+        providerSessionId: session.id,
+        seq,
+        ts: iso,
+        type: "compaction",
+    });
+    const write = extractPiCompaction(entry, {
+        sessionId: session.id,
+        providerSessionId: session.id,
+        seq,
+        ts: new Date(iso),
+        agentEventKey: eventKey,
+    });
+    if (write) compactions.push(write);
+}
+```
+
+Notes:
+- `entry`, `session.id`, `seq`, and the resolved timestamp (`iso`) are the locals already in scope in this loop - confirm their exact names by reading `pi.ts:466-544` (the timestamp local may be named `iso`, `ts`, or come from the `{ ts }` returned by Pi's timestamp resolver at `:466`). Use whatever the universal push at `:517` passes as `ts` so the `agentEventRecordKey` matches the emitted event.
+- `agentEventRecordKey` is already imported (`pi.ts:29`).
+
+- [ ] **Step 5: Return compactions from finish()**
+
+In `finish()` (`pi.ts:558-570`), add to the returned object:
+
+```ts
+compactions,
+```
+
+- [ ] **Step 6: Emit compaction statements**
+
+Where Pi assembles write statements (around `pi.ts:717`, the block that spreads `buildAgentEventStatements({...})`), append:
+
+```ts
+...buildCompactionStatements(extract.compactions),
+```
+
+(Use the same `extract`/batch variable name in scope at that site - read `:710-750`.)
+
+- [ ] **Step 7: Run tests + typecheck**
+
+Run: `bun test apps/axctl/src/ingest/pi.test.ts && bun run typecheck`
+Expected: PASS - and the "no double-push" assertion confirms exactly one `compaction` provider event.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C .claude/worktrees/compaction-signal add apps/axctl/src/ingest/pi.ts apps/axctl/src/ingest/pi.test.ts
+git -C .claude/worktrees/compaction-signal commit -m "feat(ingest): emit compaction events from pi transcripts"
+```
+
+---
+
+## Task 5: Claude parser - `isCompactSummary` detect + turn skip
+
+**Files:**
+- Modify: `apps/axctl/src/ingest/transcripts.ts`
+- Test: `apps/axctl/src/ingest/transcripts.test.ts` (create if absent; the `__testExtractClaudeJsonlLines` re-export is at `transcripts.ts:955`)
+
+Context: `processLine` at `transcripts.ts:814`; `if (type === "summary") return;` at `:818-819` (this is a DIFFERENT marker - leaf title summaries - leave it); `role` derived at `:851`; unconditional `pushProviderEvent` at `:875-893`; normal turn constructed at `:915-926`; `FileExtract` interface at `:290` (has `turns`, `providerEvents`); `finish()` returns at `:938-945`.
+
+The compaction marker is a `type:"user"` entry with `isCompactSummary: true` (and `isVisibleInTranscriptOnly: true`). Goal: emit a `compaction` row, emit the provider event as `type:"compaction"` (not a user turn), and **do not** push a normal user `turn`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend `apps/axctl/src/ingest/transcripts.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { __testExtractClaudeJsonlLines } from "./transcripts.ts";
+
+describe("claude compaction", () => {
+    test("isCompactSummary message becomes a compaction row, not a user turn", () => {
+        const extracted = __testExtractClaudeJsonlLines([
+            JSON.stringify({ type: "user", uuid: "u1", timestamp: "2026-06-01T10:00:00.000Z", sessionId: "cl-1", cwd: "/tmp", message: { role: "user", content: "real question" } }),
+            JSON.stringify({ type: "user", uuid: "u2", timestamp: "2026-06-01T10:05:00.000Z", sessionId: "cl-1", cwd: "/tmp", isCompactSummary: true, isVisibleInTranscriptOnly: true, message: { role: "user", content: "## Summary\nGoal: ship X" } }),
+        ]);
+        // compaction row captured
+        expect(extracted.compactions.length).toBe(1);
+        expect(extracted.compactions[0].strategy).toBe("summarize");
+        expect(extracted.compactions[0].summary).toContain("Goal: ship X");
+        expect(extracted.compactions[0].boundaryRef).toBe("u2");
+        // the isCompactSummary entry did NOT create a normal user turn
+        const userTurnTexts = extracted.turns.filter((t) => t.role === "user").map((t) => t.text);
+        expect(userTurnTexts).toContain("real question");
+        expect(userTurnTexts.some((t) => t?.includes("Goal: ship X"))).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test apps/axctl/src/ingest/transcripts.test.ts`
+Expected: FAIL - `extracted.compactions` undefined and/or the summary text leaks into a user turn.
+
+- [ ] **Step 3: Add accumulator + interface field + import**
+
+Import in `transcripts.ts`:
+
+```ts
+import { buildCompactionStatements, extractClaudeCompaction, type CompactionWrite } from "./compaction.ts";
+```
+
+Add `compactions: CompactionWrite[];` to `FileExtract` (`transcripts.ts:290`). Declare near `const turns: Turn[] = [];` (`:306`):
+
+```ts
+const compactions: CompactionWrite[] = [];
+```
+
+- [ ] **Step 4: Detect `isCompactSummary` and branch**
+
+After `ts`/`role` are resolved (around `:851`) and BEFORE the normal turn push at `:915`, add a guard. Determine the flag and summary text using the same text-extraction the parser already uses for a user turn (the local that holds the turn `text` - read `:895-915` to find its name; call it `text` below):
+
+```ts
+const isCompactSummary =
+    entry.isCompactSummary === true ||
+    (isRecord(entry.message) && (entry.message as Record<string, unknown>).isCompactSummary === true);
+if (isCompactSummary) {
+    const eventKey = agentEventRecordKey({
+        provider: "claude",
+        providerSessionId: sessionId,
+        seq,
+        ts,
+        type: "compaction",
+    });
+    providerEvents.push({
+        provider: "claude",
+        providerSessionId: sessionId,
+        seq,
+        ts,
+        type: "compaction",
+        role: null,
+        text,
+        metrics: { strategy: "summarize" },
+    });
+    compactions.push(
+        extractClaudeCompaction({
+            sessionId,
+            providerSessionId: sessionId,
+            seq,
+            ts: new Date(ts),
+            agentEventKey: eventKey,
+            summary: text ?? null,
+            boundaryRef: typeof entry.uuid === "string" ? entry.uuid : null,
+        }),
+    );
+    return; // skip the normal user turn + the unconditional provider push below
+}
+```
+
+Notes:
+- This `return` must come BEFORE both the unconditional `pushProviderEvent` (`:875`) and the `turns.push` (`:915`) so the entry does not also become a normal turn or a `type:"user"` event. If the unconditional provider push happens earlier than the turn push, place this guard above the provider push (just after `role`/`ts`/`text` are available).
+- `sessionId`, `seq`, `ts`, and `text` are locals already in scope - confirm exact names against `:843-915`. `isRecord` and `agentEventRecordKey` are already used in this file (imports at top).
+- The `AgentEventWrite` push shape must match how `providerEvents.push({...})` is called at `:875-893` - copy that call's field set, swapping `type` to `"compaction"`, `role` to `null`, and keeping `text`.
+
+- [ ] **Step 5: Return compactions from finish() + emit statements**
+
+In `finish()` (`:938-945`) add `compactions,` to the returned object. Then find where Claude assembles write statements (the upsert pipeline; `upsertTurns` is at `:1069`, and provider events are written via `buildAgentEventStatements` - search the file for `buildAgentEventStatements(`). At that assembly site, append:
+
+```ts
+...buildCompactionStatements(extracted.compactions),
+```
+
+(Match the variable name in scope - likely `extracted` per `:1002`.)
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `bun test apps/axctl/src/ingest/transcripts.test.ts && bun run typecheck`
+Expected: PASS - compaction captured, no summary leak into user turns.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C .claude/worktrees/compaction-signal add apps/axctl/src/ingest/transcripts.ts apps/axctl/src/ingest/transcripts.test.ts
+git -C .claude/worktrees/compaction-signal commit -m "feat(ingest): capture claude compaction summary, stop mis-ingesting it as a turn"
+```
+
+---
+
+## Task 6: Cursor parser - `summarizedComposers`
+
+**Files:**
+- Modify: `apps/axctl/src/ingest/cursor.ts`
+- Test: `apps/axctl/src/ingest/cursor.test.ts`
+
+Context: `CursorExtract` interface at `cursor.ts:70` (has `providerEvents`). The disk-KV path `extractComposerDiskKvData` is at `:661-752`; the composer record `data` is read at `:677-685` (where `fullConversationHeadersOnly`, `name`, `createdAt` are read - read `summarizedComposers` here); per-bubble loop at `:702-748`. Cursor tests use a real temporary SQLite `Database` (see existing `cursor.test.ts`).
+
+For v1: detect a **session-level** compaction when `data.summarizedComposers` is a non-empty array. Emit one `compaction` row per composer that has it (boundary = composerId or first bubble id). This is coarse but matches the encrypted-content constraint (we can flag that compaction happened, not its content).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/axctl/src/ingest/cursor.test.ts`, following the existing temp-SQLite setup pattern in that file (reuse its helper that seeds `cursorDiskKV` rows - read the file's existing tests for the exact seeding helper name and DB-open boilerplate). Seed a composer whose `data` has a non-empty `summarizedComposers`:
+
+```ts
+test("non-empty summarizedComposers yields a compaction row", async () => {
+    // ... open temp Database + seed using the SAME helper the other cursor tests use ...
+    // composerData row:
+    //   key: "composerData:comp-1"
+    //   value: JSON.stringify({ composerId: "comp-1", fullConversationHeadersOnly: [{ bubbleId: "b1" }], summarizedComposers: ["prev-comp"], name: "t", createdAt: 1748000000000 })
+    // bubbleId:comp-1:b1 row: { type: 2, text: "hi", ... }
+    const extract = await /* the same extract entrypoint the existing tests call */;
+    expect(extract.compactions.length).toBe(1);
+    expect(extract.compactions[0].harness).toBe("cursor");
+    expect(extract.compactions[0].strategy).toBe("encrypted");
+    expect(extract.compactions[0].summary).toBeNull();
+});
+```
+
+(Author the seeding/DB boilerplate by copying an existing passing test in `cursor.test.ts` - do not invent a new harness.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test apps/axctl/src/ingest/cursor.test.ts`
+Expected: FAIL - `extract.compactions` undefined.
+
+- [ ] **Step 3: Add accumulator + interface field + import**
+
+Import:
+
+```ts
+import { buildCompactionStatements, extractCursorCompaction, type CompactionWrite } from "./compaction.ts";
+```
+
+Add `compactions: CompactionWrite[];` to `CursorExtract` (`cursor.ts:70`). Initialize it in BOTH return paths that build a `CursorExtract` (the empty/early return at `:153-159` and the main return at `:583`/`:650`) - set `compactions: []` in the empty path and `compactions` (the accumulator) in the main path. Declare the accumulator near `const providerEvents: AgentEventWrite[] = [];` (`:602`):
+
+```ts
+const compactions: CompactionWrite[] = [];
+```
+
+- [ ] **Step 4: Detect summarizedComposers in the disk-KV composer read**
+
+In `extractComposerDiskKvData` where `data` is read (`:677-685`), after resolving `composerId` and the bubble list, add:
+
+```ts
+const summarizedComposers = Array.isArray((data as Record<string, unknown>).summarizedComposers)
+    ? ((data as Record<string, unknown>).summarizedComposers as unknown[]).filter(
+          (x): x is string => typeof x === "string",
+      )
+    : [];
+if (summarizedComposers.length > 0) {
+    const seq = /* next seq for this composer - reuse the loop's seq counter or bubble index */ 0;
+    const firstBubbleId = /* first bubble id from fullConversationHeadersOnly, else composerId */ composerId;
+    const eventKey = agentEventRecordKey({
+        provider: "cursor",
+        providerSessionId: composerId,
+        seq,
+        ts: createdIso,
+        type: "compaction",
+    });
+    input.providerEvents.push({
+        provider: "cursor",
+        providerSessionId: composerId,
+        seq,
+        ts: createdIso,
+        type: "compaction",
+        role: null,
+        text: null,
+        metrics: { strategy: "encrypted" },
+    });
+    compactions.push(
+        extractCursorCompaction({
+            sessionId: composerId,
+            providerSessionId: composerId,
+            seq,
+            ts: new Date(createdIso),
+            agentEventKey: eventKey,
+            boundaryRef: firstBubbleId,
+            summarizedComposers,
+        }),
+    );
+}
+```
+
+Notes:
+- `composerId`, the `providerEvents` array reference, and the resolved composer timestamp (`createdIso` - derive from `data.createdAt`) are locals/fields already in scope - confirm exact names against `:661-700`. `agentEventRecordKey` is imported (`:20`).
+- `seq`: pick a stable per-composer seq that won't collide with bubble events. Simplest: use a dedicated value like `the bubble count` or `0` prefixed into the record key via `compactionRecordKey` (which already namespaces by composer). Since `compactionRecordKey("cursor", composerId, seq)` is unique per composer, `seq = 0` is fine for one compaction row per composer in v1. Use the same `seq` for the matching `agent_event` key.
+
+- [ ] **Step 5: Emit compaction statements**
+
+Find where Cursor assembles statements (search `buildAgentEventStatements(` in `cursor.ts`). Append:
+
+```ts
+...buildCompactionStatements(extract.compactions),
+```
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `bun test apps/axctl/src/ingest/cursor.test.ts && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C .claude/worktrees/compaction-signal add apps/axctl/src/ingest/cursor.ts apps/axctl/src/ingest/cursor.test.ts
+git -C .claude/worktrees/compaction-signal commit -m "feat(ingest): flag cursor compaction from summarizedComposers"
+```
+
+---
+
+## Task 7: `ax sessions show` - annotate compaction boundaries
+
+**Files:**
+- Modify: `apps/axctl/src/dashboard/session-show.ts` (extend `SessionViewPayload` + query)
+- Modify: `apps/axctl/src/cli/session-show-format.ts` (render)
+- Test: `apps/axctl/src/cli/session-show-format.test.ts`
+
+Context: `fetchSessionView`/`SessionViewPayload` in `session-show.ts`; pure renderer `renderSessionMarkdown` at `session-show-format.ts:116-232`; `renderTimeline` at `:86-109`. Because `renderTimeline` truncates tool_calls to 8 (`:96`), render compaction in a dedicated section, not inside the truncated timeline.
+
+- [ ] **Step 1: Write the failing renderer test**
+
+Add to `apps/axctl/src/cli/session-show-format.test.ts` (mirror the existing payload-construction pattern in that file):
+
+```ts
+test("renders a compaction section when compactions present", () => {
+    const payload = {
+        // ...spread a minimal valid SessionViewPayload as the other tests build it...
+        compactions: [
+            { harness: "codex", ts: "2026-05-14T15:34:42.663Z", strategy: "history_replacement", tokens_before: 120000, kept_count: 83, summary: null },
+            { harness: "pi", ts: "2026-05-29T06:05:38.132Z", strategy: "summarize", tokens_before: 90000, kept_count: null, summary: "Goal: ship X" },
+        ],
+    } as unknown as Parameters<typeof renderSessionMarkdown>[0];
+    const md = renderSessionMarkdown(payload);
+    expect(md).toContain("## Compaction");
+    expect(md).toContain("history_replacement");
+    expect(md).toContain("83 kept");
+    expect(md).toContain("Goal: ship X");
+});
+```
+
+(Read `session-show-format.test.ts` first and reuse however it constructs the base payload so the non-compaction fields are valid.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test apps/axctl/src/cli/session-show-format.test.ts`
+Expected: FAIL - no `## Compaction` section.
+
+- [ ] **Step 3: Extend the payload type + query**
+
+In `session-show.ts`, add to `SessionViewPayload` (the interface/type returned by `fetchSessionView`):
+
+```ts
+readonly compactions: ReadonlyArray<{
+    readonly harness: string;
+    readonly ts: string;
+    readonly strategy: string;
+    readonly trigger: string | null;
+    readonly tokens_before: number | null;
+    readonly kept_count: number | null;
+    readonly summary: string | null;
+}>;
+```
+
+In the query that assembles the payload, add a SELECT against the `compaction` table for the session, ordered by `ts`:
+
+```ts
+const compactions = await db.query(
+    `SELECT harness, type::string(ts) AS ts, strategy, trigger, tokens_before, kept_count, summary
+     FROM compaction WHERE session = $session ORDER BY ts ASC`,
+    { session: sessionRecordRef },
+);
+```
+
+(Match the existing query style/`db` accessor in this file - read how `tool_calls`/`agent_delegations` are fetched and follow it exactly, including how the session record reference is passed. Include `compactions` in the returned payload object, defaulting to `[]` when none.)
+
+- [ ] **Step 4: Render the section**
+
+In `session-show-format.ts`, add a `renderCompaction(payload)` helper near `renderTimeline` (`:86`):
+
+```ts
+const renderCompaction = (payload: SessionViewPayload): string => {
+    if (!payload.compactions || payload.compactions.length === 0) return "";
+    const lines = payload.compactions.map((c) => {
+        const kept = c.kept_count !== null ? ` · ${c.kept_count} kept` : "";
+        const toks = c.tokens_before !== null ? ` · ${c.tokens_before} tok before` : "";
+        const sum = c.summary ? ` - ${c.summary.split("\n")[0].slice(0, 80)}` : "";
+        return `- ${c.ts} · ${c.harness} · ${c.strategy}${toks}${kept}${sum}`;
+    });
+    return `\n## Compaction (${payload.compactions.length})\n\n${lines.join("\n")}\n`;
+};
+```
+
+Then call it inside `renderSessionMarkdown` (`:116-232`), appending its output near the Timeline section (`:185-191`):
+
+```ts
+out += renderCompaction(payload);
+```
+
+(Use the actual string-accumulation idiom in `renderSessionMarkdown` - read `:116-232`; it may push to an array rather than `+=`. Match it.)
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run: `bun test apps/axctl/src/cli/session-show-format.test.ts && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C .claude/worktrees/compaction-signal add apps/axctl/src/dashboard/session-show.ts apps/axctl/src/cli/session-show-format.ts apps/axctl/src/cli/session-show-format.test.ts
+git -C .claude/worktrees/compaction-signal commit -m "feat(cli): show compaction boundaries in ax sessions show"
+```
+
+---
+
+## Task 8: Full-suite verification + integration check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full ingest test suite**
+
+Run: `bun test apps/axctl/src/ingest`
+Expected: PASS (all parser tests including the 4 new compaction tests).
+
+- [ ] **Step 2: Repo-wide test + typecheck**
+
+Run: `bun test && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Real-data smoke test (manual, optional but recommended)**
+
+Run a scoped ingest over real Codex sessions known to contain compaction, then query:
+
+```bash
+.claude/worktrees/compaction-signal/apps/axctl/bin/axctl ingest --since=30 --stages=codex
+# then in the DB:
+#   SELECT harness, count() FROM compaction GROUP BY harness;
+# Expect codex rows > 0 (55 sessions / 351 events exist in ~/.codex/sessions).
+```
+
+Expected: non-zero `compaction` rows for codex; spot-check `kept_count` is populated and `strategy = "history_replacement"`.
+
+- [ ] **Step 4: Push branch + open PR**
+
+```bash
+git -C .claude/worktrees/compaction-signal push -u origin feat/compaction-signal
+gh pr create --repo Necmttn/ax --base main --head feat/compaction-signal \
+  --title "feat: first-class compaction signal across harnesses" \
+  --body "Implements docs/superpowers/specs/2026-06-04-compaction-signal-design.md - see plan docs/superpowers/plans/2026-06-04-compaction-signal.md"
+```
+
+---
+
+## Notes for the implementer
+
+- **Read before editing each parser.** Every parser task gives exact line numbers from analysis, but the load-bearing locals (`seq`, `ts`/`iso`, `text`, `session.id`, the `*Extract` variable name at the statement-assembly site) must be confirmed by reading the surrounding 30–40 lines first. The plan flags every such spot.
+- **The `agent_event` key must match the emitted event.** Always derive `agentEventKey` with the SAME `agentEventRecordKey({provider, providerSessionId, seq, ts, type})` args used by the corresponding `pushProviderEvent`/`providerEvents.push`, or the `compaction.agent_event` link will dangle.
+- **Pi is the one harness that must NOT push a second provider event** (its universal push at `pi.ts:517` already emits the `type:"compaction"` event). Codex, Claude, and Cursor DO push (Codex/Cursor because the entry is otherwise unhandled; Claude because it replaces the user-turn push it's suppressing).
+- **OpenCode is intentionally untouched** - it has no explicit marker; deriving boundaries from `step-finish.tokens` saturation is a separate follow-up with `source_confidence: "derived"`.
+- **Worktree-write hook:** all edits happen inside `.claude/worktrees/compaction-signal`, so the enforce-worktree-on-main hook stays satisfied. Run `bun` commands from the repo root but `git` via `git -C .claude/worktrees/compaction-signal`.

--- a/docs/superpowers/specs/2026-06-04-compaction-signal-design.md
+++ b/docs/superpowers/specs/2026-06-04-compaction-signal-design.md
@@ -1,0 +1,148 @@
+# Compaction Signal - Design
+
+**Date:** 2026-06-04
+**Status:** Approved (design), pending implementation plan
+**Scope:** v1 - make context compaction a first-class signal in the ax ingest pipeline.
+
+## Problem
+
+ax ingests transcripts from 5 harnesses (Claude Code, Codex, Pi, OpenCode, Cursor).
+Every harness performs **context compaction** when it nears its context window -
+summarizing or replacing prior history so the conversation can continue. This is a
+high-value agent-experience signal ("how often did this session hit the wall, and
+what survived"), yet **all 5 parsers currently drop it**:
+
+- **Claude** - additionally *mis-ingests* the post-`/compact` continuation message
+  (`isCompactSummary:true`) as a normal user turn, polluting turn/recall data.
+- **Codex** - `type:"compacted"` + `event_msg/context_compacted` both fall through
+  the parser's switch.
+- **Pi** - `type:"compaction"` entry has no case in `pi.ts`.
+- **Cursor** - per-bubble `summarizedComposers[]` marker never read.
+- **OpenCode** - no explicit marker; only `step-finish.tokens` (also dropped).
+
+### Evidence (verified against on-disk data, 2026-06-04)
+
+| Harness | Marker | Real-data confirmation |
+|---|---|---|
+| Pi | `type:"compaction"` | docs (`pi.dev/docs/latest/compaction`) - `CompactionEntry{ summary, firstKeptEntryId, tokensBefore, details.{readFiles,modifiedFiles}, fromHook }`. Trigger: auto when `contextTokens > contextWindow - reserveTokens` (reserve 16384) or manual `/compact`. |
+| Codex | `type:"compacted"` + `event_msg/context_compacted` | 55 sessions, 351 events in `~/.codex/sessions`. Paired records (same ts). `payload.{message, replacement_history[]}`. `message` empty on auto-compaction; `replacement_history` 80–186 msgs. |
+| Claude | `isCompactSummary:true` user message | 14 sessions in `~/.claude/projects`. `type:"user"` msg carrying summary text in `message.content`. (NB: `type:"summary"` entries, dropped at `transcripts.ts:819`, are leaf conversation-title summaries - a *different* thing, correctly skipped.) |
+| Cursor | non-empty `summarizedComposers[]` per bubble | `state.vscdb` - every bubble has `summarizedComposers` array (empty when no compaction). Composer flags `isContinuationInProgress`, `speculativeSummarizationEncryptionKey`. Summary content is **encrypted** (`blobEncryptionKey`). |
+| OpenCode | none → `step-finish.tokens` | `opencode.db` - no structural compaction part-type; `step-finish` parts carry `tokens.{total,input,output,cache}`. Boundary only *derivable* by saturation. |
+
+## Goal
+
+Persist compaction as a queryable, typed event for the **4 explicit harnesses**
+(Pi, Codex, Claude, Cursor). OpenCode gets the schema field but stays null until a
+later derived-inference pass. Fix the Claude continuation-message pollution bug in
+the same pass.
+
+## The core abstraction: one event, two models
+
+Compaction takes two fundamentally different shapes. The schema unifies them with a
+`strategy` discriminant rather than forcing one model onto the other:
+
+- **summarize-to-text** (Pi, Claude, Cursor) - produces a summary string. Cursor's is
+  encrypted, so stored as null with `strategy:"encrypted"`.
+- **history-replacement** (Codex) - swaps the whole prior history for a retained
+  message set. No summary text; instead a `kept_count`.
+
+## Schema
+
+`packages/schema/src/schema.surql` - new normalized projection table, mirroring the
+existing `plan_snapshot` pattern (FK to `session`/`agent_event`, option fields,
+JSON-encoded nested data, indexes).
+
+```surql
+DEFINE TABLE compaction SCHEMAFULL;
+DEFINE FIELD session           ON compaction TYPE record<session>;
+DEFINE FIELD agent_event       ON compaction TYPE option<record<agent_event>>;
+DEFINE FIELD harness           ON compaction TYPE string;          -- provider name
+DEFINE FIELD ts                ON compaction TYPE datetime;
+DEFINE FIELD trigger           ON compaction TYPE option<string>;  -- auto|manual|hook
+DEFINE FIELD strategy          ON compaction TYPE string;          -- summarize|history_replacement|encrypted
+DEFINE FIELD source_confidence ON compaction TYPE string;          -- explicit|derived
+DEFINE FIELD summary           ON compaction TYPE option<string>;  -- Pi/Claude; null Codex/Cursor
+DEFINE FIELD tokens_before     ON compaction TYPE option<int>;     -- Pi explicit; others derivable
+DEFINE FIELD boundary_ref      ON compaction TYPE option<string>;  -- where post-compaction resumes
+DEFINE FIELD kept_count        ON compaction TYPE option<int>;     -- Codex replacement_history length
+DEFINE FIELD read_files        ON compaction TYPE option<string>;  -- JSON-encoded; Pi details
+DEFINE FIELD modified_files    ON compaction TYPE option<string>;  -- JSON-encoded; Pi details
+DEFINE FIELD raw               ON compaction TYPE option<string>;  -- JSON-encoded
+DEFINE INDEX compaction_session_ts  ON compaction FIELDS session, ts;
+DEFINE INDEX compaction_agent_event ON compaction FIELDS agent_event;
+```
+
+Each parser also emits a provider event via the existing dual-write substrate:
+`AgentEventWrite{ type: "compaction", ts, role: null, text: <summary|null>, metrics: <structured>, raw: <raw> }`.
+The `compaction` projection row links back via `agent_event`.
+
+## Per-harness mapping (v1)
+
+All v1 rows: `source_confidence = "explicit"`.
+
+| Harness | Detect | strategy | summary | tokens_before | boundary_ref | kept_count | trigger |
+|---|---|---|---|---|---|---|---|
+| **Pi** | `type:"compaction"` | summarize | `summary` | `tokensBefore` | `firstKeptEntryId` | - | `fromHook ? hook : (message ? manual : auto)` |
+| **Codex** | `type:"compacted"` (+`context_compacted` as corroborating signal) | history_replacement | null | derive from preceding `token_count` event | compacted-entry seq/id | `replacement_history.length` | `payload.message ? manual : auto` |
+| **Claude** | `isCompactSummary:true` user msg | summarize | `message.content` | - | msg `uuid` | - | auto (manual `/compact` indistinguishable in transcript) |
+| **Cursor** | non-empty `summarizedComposers[]` | encrypted | null (encrypted) | - | bubble id | - | auto |
+| OpenCode | *(deferred)* | - | - | - | - | - | - |
+
+Pi's `details.{readFiles,modifiedFiles}` → `read_files`/`modified_files` (JSON-encoded).
+
+## Claude continuation bug fix (in scope)
+
+The `isCompactSummary:true` message is currently ingested as a normal user `turn`.
+Change the Claude parser to:
+1. Detect `isCompactSummary === true` on a user entry.
+2. Route it into a `compaction` event (summary = `message.content`).
+3. Exclude it from normal turn ingestion (do not create a user `turn` for it), OR tag
+   the turn `message_kind: "compaction_summary"` and skip it from recall/turn-text
+   surfaces. **Decision: skip the turn entirely** - it is a synthetic system artifact,
+   not a user utterance, and `isVisibleInTranscriptOnly` confirms it is not a real turn.
+
+This removes the recall/turn pollution and is naturally in scope since the Claude
+parser is already being modified for compaction.
+
+## Consuming surface (v1)
+
+One CLI read surface to prove the data end-to-end: `ax sessions show <id>` annotates
+compaction boundaries inline - where the session compacted, the strategy, and a
+summary excerpt (or "history replaced, N kept" for Codex) - plus a per-session
+compaction count line. No dashboard timeline or recall integration in v1.
+
+## Parser shape (modular, typed)
+
+Per the project's typed/modular/Effect default, each parser gets a small pure
+extractor:
+
+```
+extractCompaction(entry, ctx) => CompactionWrite | null
+```
+
+`CompactionWrite` is a shared typed shape (in `@ax/lib` or alongside
+`provider-events.ts`). Keeps the parser switch-arms thin and each harness's mapping
+independently unit-testable.
+
+## Testing
+
+- **Per-harness extractor unit tests** with fixtures captured from real on-disk data
+  (Pi/Codex/Claude have live samples; Cursor needs a synthetic fixture with a populated
+  `summarizedComposers`). Fixtures committed under each parser's test dir.
+- **Integration test**: ingest a multi-compaction Codex session → assert N `compaction`
+  rows with correct `kept_count` and `strategy:"history_replacement"`.
+- **Claude regression**: assert the `isCompactSummary` message produces a `compaction`
+  row and **no** corresponding user `turn`.
+
+## Out of scope (v1)
+
+- OpenCode derived (saturation-inference) boundaries - `source_confidence:"derived"`,
+  separate follow-up.
+- Reading Cursor's encrypted summary content.
+- Dashboard compaction timeline; `ax recall` integration.
+
+## Open questions
+
+None - all design decisions resolved during brainstorming (scope, storage shape,
+Claude bug inclusion, v1 surface).

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -333,10 +333,23 @@ export interface SessionSkillRoleGroup {
     readonly skills: ReadonlyArray<{ readonly skill: string; readonly count: number }>;
 }
 
+/** One context-compaction boundary recorded for a session. Sourced from the
+ *  `compaction` table; one row per compaction event across all harnesses. */
+export interface SessionCompaction {
+    readonly harness: string;
+    readonly ts: string;
+    readonly strategy: string;
+    readonly trigger: string | null;
+    readonly tokens_before: number | null;
+    readonly kept_count: number | null;
+    readonly summary: string | null;
+}
+
 export interface SessionViewPayload {
     readonly session: SessionDetailPayload;
     readonly expanded_subagents: ReadonlyArray<SessionDetailPayload>;
     readonly by_role: ReadonlyArray<SessionSkillRoleGroup> | null;
+    readonly compactions: ReadonlyArray<SessionCompaction>;
 }
 
 export interface WorkflowEpisode {

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -500,6 +500,24 @@ DEFINE FIELD ts             ON plan_snapshot TYPE datetime DEFAULT time::now();
 DEFINE INDEX plan_snapshot_plan_ts ON plan_snapshot FIELDS plan, ts;
 DEFINE INDEX plan_snapshot_agent_event ON plan_snapshot FIELDS agent_event;
 
+DEFINE TABLE compaction SCHEMAFULL;
+DEFINE FIELD session           ON compaction TYPE record<session>;
+DEFINE FIELD agent_event       ON compaction TYPE option<record<agent_event>>;
+DEFINE FIELD harness           ON compaction TYPE string;          -- provider name: claude|codex|pi|cursor|opencode
+DEFINE FIELD ts                ON compaction TYPE datetime;
+DEFINE FIELD trigger           ON compaction TYPE option<string>;  -- auto|manual|hook
+DEFINE FIELD strategy          ON compaction TYPE string;          -- summarize|history_replacement|encrypted
+DEFINE FIELD source_confidence ON compaction TYPE string;          -- explicit|derived
+DEFINE FIELD summary           ON compaction TYPE option<string>;  -- Pi/Claude; null for Codex/Cursor
+DEFINE FIELD tokens_before     ON compaction TYPE option<int>;
+DEFINE FIELD boundary_ref      ON compaction TYPE option<string>;  -- where post-compaction history resumes
+DEFINE FIELD kept_count        ON compaction TYPE option<int>;     -- Codex replacement_history length
+DEFINE FIELD read_files        ON compaction TYPE option<string>;  -- JSON-encoded array; Pi details
+DEFINE FIELD modified_files    ON compaction TYPE option<string>;  -- JSON-encoded array; Pi details
+DEFINE FIELD raw               ON compaction TYPE option<string>;  -- JSON-encoded
+DEFINE INDEX compaction_session_ts  ON compaction FIELDS session, ts;
+DEFINE INDEX compaction_agent_event ON compaction FIELDS agent_event;
+
 DEFINE TABLE insight SCHEMAFULL;
 DEFINE FIELD subject_type   ON insight TYPE string;
 DEFINE FIELD subject_id     ON insight TYPE option<string>;


### PR DESCRIPTION
## What

Makes context **compaction** a first-class, queryable signal in the ax ingest pipeline. Previously all 5 harness parsers dropped compaction events (and Claude *mis-ingested* its compaction-summary as a normal user turn). This adds a typed `compaction` table + provider events for the 4 harnesses with explicit markers.

Implements `docs/superpowers/specs/2026-06-04-compaction-signal-design.md` (plan: `docs/superpowers/plans/2026-06-04-compaction-signal.md`).

## How

- **New `compaction` SCHEMAFULL table** (mirrors `plan_snapshot`): session/agent_event FKs, `harness`, `ts`, `trigger`, `strategy`, `source_confidence`, `summary`, `tokens_before`, `boundary_ref`, `kept_count`, `read_files`/`modified_files`, `raw`.
- **Shared `apps/axctl/src/ingest/compaction.ts`**: `CompactionWrite` type, `buildCompactionStatements` (clones `buildPlanSnapshotStatements`), and 4 pure per-harness extractors.
- **Two compaction models unified via `strategy`**: summarize-to-text (Pi/Claude) vs history-replacement (Codex) vs encrypted (Cursor).

### Per-harness markers (verified against real on-disk data)

| Harness | Marker | strategy | Notes |
|---|---|---|---|
| **Codex** | `type:"compacted"` | `history_replacement` | `kept_count` = `replacement_history.length`; `tokens_before` = `last_token_usage.input_tokens` (context occupancy) |
| **Pi** | `type:"compaction"` | `summarize` | `summary`, `firstKeptEntryId`, `tokensBefore`, file lists. No double provider-event push (Pi already emits one per entry). |
| **Claude** | `isCompactSummary:true` user msg | `summarize` | **Also fixes a bug**: this message is no longer mis-ingested as a normal user turn. |
| **Cursor** | non-empty `summarizedComposers[]` | `encrypted` | Flag-only — summary content is encrypted at rest. |

- **`ax sessions show <id>`** renders a `## Compaction` section (separate from the truncated timeline).

## Validation

- **551 ingest tests pass**, 47 compaction+CLI tests, **0 typecheck errors**.
- Each parser test asserts: correct row fields, exactly-one `type:"compaction"` provider event (no double-emit), and `agent_event` FK matches the emitted event.
- **Live smoke test**: ingested real `~/.codex/sessions` → 91 compaction rows, FKs resolve, `tokens_before` avg **232,679** / max **250,249** (just under the ~256k window), 0 implausible values. The smoke test caught (and we fixed) a `tokens_before` bug where it had used cumulative session tokens instead of context occupancy.

## Out of scope (v1)

- **OpenCode** — no explicit marker; gets the schema field but stays null (derive-from-`step-finish.tokens` saturation is a follow-up, `source_confidence:"derived"`).
- Reading Cursor's encrypted summary content.
- Known minor limitation: a Cursor composer with non-empty `summarizedComposers` but zero retrievable bubbles is dropped by `ingestCursor`'s empty-session guard (safe — no dangling FK — but the signal is lost; rare, content's encrypted anyway).
- `ax recall` / dashboard timeline integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)