### PR TITLE
[codex] add setup next-step CTA and filter tool rankings

### DIFF
--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -1383,6 +1383,13 @@ const cmdRoles = (args: string[]) =>
 const cmdTaste = (args: string[]) =>
     Effect.gen(function* () {
         const limit = parsePositiveIntFlag("taste", "limit", args, 30);
+        const includeTools = args.includes("--include-tools");
+        const syntheticFilter = includeTools
+            ? ""
+            : ` AND (skill_id.dir_path IS NONE OR skill_id.dir_path != "(synthetic)")`;
+        const syntheticSkillFilter = includeTools
+            ? ""
+            : ` AND (dir_path IS NONE OR dir_path != "(synthetic)")`;
         const db = yield* SurrealClient;
         // Composite signal: invocations (positive), errors near invocation
         // (negative), corrections within 3 turns of invocation in the same
@@ -1476,7 +1483,10 @@ FROM (
     -- (matches the original cmdTaste behaviour, which started FROM skill and
     -- thus naturally excluded these). Currently happens for a handful of
     -- legacy plugin/built-in tool names that didn't get recorded as skills.
+    -- Drop synthetic provider tools by default too: these are low-level tool
+    -- invocations, not named skills, and otherwise dominate the setup signal.
     WHERE skill_id.name IS NOT NONE
+        ${syntheticFilter}
 );`;
 
         // Skills with proposals but no invocations - the GROUP BY scan
@@ -1495,7 +1505,7 @@ SELECT
     0 AS commits_after,
     -0.5 * array::len(<-proposed) AS taste_score
 FROM skill
-WHERE array::len(<-invoked) = 0 AND array::len(<-proposed) > 0;`;
+WHERE array::len(<-invoked) = 0 AND array::len(<-proposed) > 0${syntheticSkillFilter};`;
 
         // Issue #47: skills with neither invocations nor proposals get
         // dropped entirely from the merged set, so `taste --limit=200`
@@ -1514,7 +1524,7 @@ SELECT
     0 AS commits_after,
     0 AS taste_score
 FROM skill
-WHERE array::len(<-invoked) = 0 AND array::len(<-proposed) = 0;`;
+WHERE array::len(<-invoked) = 0 AND array::len(<-proposed) = 0${syntheticSkillFilter};`;
 
         const [aggResult, propResult, zeroResult] = yield* Effect.all(
             [
@@ -4423,9 +4433,16 @@ const unusedCommand = Command.make(
 
 const tasteCommand = Command.make(
     "taste",
-    { limit: positiveLimit(30) },
-    ({ limit }) => cmdTaste([`--limit=${limit}`]),
-).pipe(Command.withDescription("Rank skills by usage, corrections, proposals, and produced commits"));
+    {
+        limit: positiveLimit(30),
+        includeTools: Flag.boolean("include-tools").pipe(Flag.withDefault(false)),
+    },
+    ({ limit, includeTools }) =>
+        cmdTaste([`--limit=${limit}`, ...boolArg("include-tools", includeTools)]),
+).pipe(Command.withDescription(
+    "Rank named skills by usage, corrections, proposals, and produced commits. " +
+    "Synthetic provider tools are hidden by default; use --include-tools to rank them too.",
+));
 
 const pairsCommand = Command.make(
     "pairs",

--- a/apps/axctl/src/queries/skill-summary.test.ts
+++ b/apps/axctl/src/queries/skill-summary.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import {
+    SKILL_SUMMARY_PROPOSED_ONLY_SQL,
+    SKILL_SUMMARY_SQL,
+} from "./skill-summary.ts";
+
+describe("skill summary SQL", () => {
+    test("excludes synthetic provider tools from invoked skills", () => {
+        expect(SKILL_SUMMARY_SQL).toContain("skill_id.dir_path IS NONE");
+        expect(SKILL_SUMMARY_SQL).toContain('skill_id.dir_path != "(synthetic)"');
+    });
+
+    test("excludes synthetic provider tools from proposed-only skills", () => {
+        expect(SKILL_SUMMARY_PROPOSED_ONLY_SQL).toContain("dir_path IS NONE");
+        expect(SKILL_SUMMARY_PROPOSED_ONLY_SQL).toContain('dir_path != "(synthetic)"');
+    });
+});

--- a/apps/axctl/src/queries/skill-summary.ts
+++ b/apps/axctl/src/queries/skill-summary.ts
@@ -49,6 +49,7 @@ FROM (
         GROUP BY out
     )
     WHERE skill_id.name IS NOT NONE
+        AND (skill_id.dir_path IS NONE OR skill_id.dir_path != "(synthetic)")
 );`;
 
 export const SKILL_LAST_PROJECT_SQL = `
@@ -82,4 +83,6 @@ SELECT
     0 AS commits_after,
     -0.5 * array::len(<-proposed) AS taste_score
 FROM skill
-WHERE array::len(<-invoked) = 0 AND array::len(<-proposed) > 0;`;
+WHERE array::len(<-invoked) = 0
+    AND array::len(<-proposed) > 0
+    AND (dir_path IS NONE OR dir_path != "(synthetic)");`;

--- a/apps/site/app/components/landing-v2/dashboard-preview.tsx
+++ b/apps/site/app/components/landing-v2/dashboard-preview.tsx
@@ -23,7 +23,7 @@ const AGENT_PROMPT = `Set up ax for me, end to end. ax is a local agent-experien
 
 4. SHOW me the result - run \`ax skills weighted\` and \`ax skills config\`. Tell me which skills you labeled and why, and flag anything ax marked orphan or out-of-scope.
 
-Then recommend a couple of skills I under-use that you'd reach for, based on what you saw.`;
+5. GIVE ME A NEXT STEP - recommend 1-2 under-used skills you'd reach for based on what you saw, then end with a concrete CTA: the exact command or prompt I should run next, and what outcome it will produce.`;
 
 export function DashboardPreview() {
   const [copiedPrompt, setCopiedPrompt] = useState(false);

--- a/packages/lib/src/agent-onboarding.ts
+++ b/packages/lib/src/agent-onboarding.ts
@@ -16,7 +16,7 @@ export const AGENT_ONBOARDING_PROMPT = [
     "",
     "3. SHOW me the result - run `ax skills weighted` (usage x role ranking) and `ax skills config` (lifecycle view). Tell me which skills you labeled and why, and flag anything ax marked orphan or out-of-scope.",
     "",
-    "Then recommend a couple of skills I under-use that you'd reach for, based on what you saw.",
+    "4. GIVE ME A NEXT STEP - recommend 1-2 under-used skills you'd reach for based on what you saw, then end with a concrete CTA: the exact command or prompt I should run next, and what outcome it will produce.",
 ].join("\n");
 
 /** Prompt wrapped with a short human-facing header for terminal output. */


### PR DESCRIPTION
## What changed

- Updated the source-of-truth agent onboarding prompt to require a concrete next step at the end of setup.
- Updated the landing page's copied setup prompt to match the same CTA behavior.
- Changed `ax skills taste` to hide synthetic provider tools by default, matching `ax skills weighted` behavior.
- Added `ax skills taste --include-tools` for cases where the low-level provider tool leaderboard is explicitly useful.
- Applied the same synthetic-tool filter to the shared skill-summary SQL used by the TUI/dashboard surfaces.

## Why

User feedback on the setup handoff was that the final response lacked a clear CTA. The setup transcript also showed a second signal problem: when `skills taste` was used as a fallback, the ranking was dominated by low-level tool-call rows like Codex/Cursor/OpenCode tools rather than named skills. Those synthetic rows are useful telemetry, but they should not be the default skill recommendation signal.

## Notes

`ax skills weighted` already had the synthetic-tool exclusion and a non-correlated query path for the historical hang; this patch brings `skills taste` and shared skill-summary surfaces in line with that behavior.

## Validation

- `bun test apps/axctl/src/queries/skill-summary.test.ts apps/axctl/src/dashboard/skills-weighted.test.ts apps/axctl/src/cli/skills-weighted-format.test.ts`
- `bun run typecheck`

Could not live-run `ax skills weighted` / `ax skills taste` locally because the ax DB daemon at `127.0.0.1:8521` was not reachable in this environment.