### PR TITLE
fix(ingest): clear agent_event by primary id so index drift can't crash re-ingest

### DIFF
--- a/apps/axctl/src/ingest/provider-events.test.ts
+++ b/apps/axctl/src/ingest/provider-events.test.ts
@@ -85,8 +85,16 @@ describe("provider event writer statement builders", () => {
         // The clears must come FIRST so the fresh batch inserts cleanly even if
         // the existing rows hold the same (agent_session, seq) under a different
         // record id (seq drift across ingests).
-        const clearEventStmt = `DELETE agent_event WHERE agent_session = agent_session:\`${sessionKey}\`;`;
-        const clearEdgeStmt = `DELETE agent_event_child WHERE agent_session = agent_session:\`${sessionKey}\`;`;
+        //
+        // They MUST delete by primary id via an `id IN (SELECT VALUE id ...)`
+        // subquery, NOT a bare `WHERE agent_session = ...`. The latter is planned
+        // through the `agent_event_session_seq` secondary index, which can hold
+        // stale/ghost entries in a long-lived DB - an index-driven DELETE then
+        // silently skips drifted rows while their entries still block the fresh
+        // INSERT, crashing the next ingest. Deleting by primary id sidesteps the
+        // corruptible index entirely.
+        const clearEventStmt = `DELETE agent_event WHERE id IN (SELECT VALUE id FROM agent_event WHERE agent_session = agent_session:\`${sessionKey}\`);`;
+        const clearEdgeStmt = `DELETE agent_event_child WHERE id IN (SELECT VALUE id FROM agent_event_child WHERE agent_session = agent_session:\`${sessionKey}\`);`;
 
         const clearEventIdx = statements.indexOf(clearEventStmt);
         const clearEdgeIdx = statements.indexOf(clearEdgeStmt);
@@ -97,6 +105,11 @@ describe("provider event writer statement builders", () => {
         expect(firstUpsertIdx).toBeGreaterThanOrEqual(0);
         expect(clearEdgeIdx).toBeLessThan(firstUpsertIdx);
         expect(clearEventIdx).toBeLessThan(firstUpsertIdx);
+
+        // Guard against regressing to the index-driven bare-WHERE delete.
+        expect(
+            statements.some((s) => /^DELETE agent_event WHERE agent_session =/.test(s)),
+        ).toBe(false);
     });
 
     test("clearExisting:false suppresses the per-session clear (streaming follow-up batches)", () => {

--- a/apps/axctl/src/ingest/provider-events.ts
+++ b/apps/axctl/src/ingest/provider-events.ts
@@ -152,14 +152,27 @@ export function buildAgentProviderStatements(
  *   re-ingest a fresh event can be assigned a `seq` already occupied by a
  *   *different* record id, and the per-UPSERT UNIQUE check throws mid-batch.
  *
- *   Deleting the session's events first (scoped via the `agent_event_session_ts`
- *   index on `agent_session`) makes the fresh batch insert cleanly regardless of
- *   seq drift OR record-id drift. Because record ids are derived from stable
- *   identifiers, the re-inserted rows reuse the same ids, so `turn.agent_event`,
- *   `tool_call.agent_event`, `plan_snapshot.agent_event` and `content_document`
- *   references continue to resolve. Clearing the `agent_event_child` edges in the
- *   same write avoids leaving edges that point at deleted rows; the batch re-emits
- *   them via the parent-edge statements.
+ *   Deleting the session's events first makes the fresh batch insert cleanly
+ *   regardless of seq drift OR record-id drift. Because record ids are derived
+ *   from stable identifiers, the re-inserted rows reuse the same ids, so
+ *   `turn.agent_event`, `tool_call.agent_event`, `plan_snapshot.agent_event` and
+ *   `content_document` references continue to resolve. Clearing the
+ *   `agent_event_child` edges in the same write avoids leaving edges that point
+ *   at deleted rows; the batch re-emits them via the parent-edge statements.
+ *
+ *   The delete MUST route through the PRIMARY id, not the `(agent_session, seq)`
+ *   secondary index. A long-lived DB can accumulate stale/ghost entries in the
+ *   `agent_event_session_seq` UNIQUE index (observed across a SurrealDB version
+ *   change / prior partial ingests: 27 codex sessions held ~19k duplicate
+ *   `(agent_session, seq)` rows the index let in). A bare
+ *   `DELETE ... WHERE agent_session = ...` is planned through that index and
+ *   SILENTLY SKIPS the drifted rows - yet their index entries still block the
+ *   fresh `(agent_session, seq)` INSERT, so the next ingest crashes with
+ *   "Database index agent_event_session_seq already contains [...]". An inner
+ *   `SELECT VALUE id ... WHERE agent_session = ...` reliably enumerates every
+ *   row (full-table predicate); the outer `DELETE ... WHERE id IN (...)` removes
+ *   them by primary id, which never consults the corruptible secondary index.
+ *   `ax doctor` surfaces residual duplicates so the index can be rebuilt.
  */
 export function buildAgentSessionEventClearStatements(
     sessions: readonly AgentSessionWrite[],
@@ -172,8 +185,11 @@ export function buildAgentSessionEventClearStatements(
         seen.add(sessionKey);
         const sessionRef = recordRef("agent_session", sessionKey);
         // Child edges first so no edge transiently references a deleted event.
-        statements.push(`DELETE agent_event_child WHERE agent_session = ${sessionRef};`);
-        statements.push(`DELETE agent_event WHERE agent_session = ${sessionRef};`);
+        // Delete by primary id (via an `id IN (SELECT VALUE id ...)` subquery) so
+        // a corrupt/stale `agent_event_session_seq` index can't silently leave
+        // rows behind - see the doc comment above.
+        statements.push(`DELETE agent_event_child WHERE id IN (SELECT VALUE id FROM agent_event_child WHERE agent_session = ${sessionRef});`);
+        statements.push(`DELETE agent_event WHERE id IN (SELECT VALUE id FROM agent_event WHERE agent_session = ${sessionRef});`);
     }
     return statements;
 }

--- a/scripts/repair-agent-event-index.test.ts
+++ b/scripts/repair-agent-event-index.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { planSessionDedup } from "./repair-agent-event-index.ts";
+
+describe("planSessionDedup", () => {
+    test("keeps the first row at each seq and drops the rest", () => {
+        const drop = planSessionDedup([
+            { id: "agent_event:a", seq: 1 },
+            { id: "agent_event:b", seq: 2 },
+            { id: "agent_event:c", seq: 2 }, // dup of seq 2 -> drop
+            { id: "agent_event:d", seq: 3 },
+            { id: "agent_event:e", seq: 3 }, // dup of seq 3 -> drop
+            { id: "agent_event:f", seq: 3 }, // dup of seq 3 -> drop
+        ]);
+        expect(drop).toEqual(["agent_event:c", "agent_event:e", "agent_event:f"]);
+    });
+
+    test("a clean session drops nothing", () => {
+        const drop = planSessionDedup([
+            { id: "agent_event:a", seq: 1 },
+            { id: "agent_event:b", seq: 2 },
+            { id: "agent_event:c", seq: 3 },
+        ]);
+        expect(drop).toEqual([]);
+    });
+
+    test("empty input drops nothing", () => {
+        expect(planSessionDedup([])).toEqual([]);
+    });
+});

--- a/scripts/repair-agent-event-index.ts
+++ b/scripts/repair-agent-event-index.ts
@@ -1,0 +1,142 @@
+/**
+ * repair-agent-event-index: reconcile the `agent_event_session_seq` UNIQUE index
+ * with the actual `agent_event` rows.
+ *
+ * Why this exists
+ * ---------------
+ * `agent_event` carries `DEFINE INDEX agent_event_session_seq ... (agent_session,
+ * seq) UNIQUE`. A long-lived DB (observed across a SurrealDB version change and
+ * prior partial ingests) can drift into an inconsistent state where the table
+ * holds DUPLICATE `(agent_session, seq)` rows the index let in, AND a bare
+ * `DELETE agent_event WHERE agent_session = ...` - which the planner routes
+ * through that index - silently skips the drifted rows. Their ghost index
+ * entries still block a fresh `(agent_session, seq)` INSERT, so the next ingest
+ * crashes:
+ *
+ *   Database index `agent_event_session_seq` already contains
+ *     [agent_session:<id>, <seq>], with record `agent_event:<id>__...`
+ *
+ * The ingest-time fix (see `buildAgentSessionEventClearStatements` in
+ * apps/axctl/src/ingest/provider-events.ts) deletes by PRIMARY id so it can't be
+ * defeated by index drift, and self-heals a session on its next re-ingest. This
+ * script is the GLOBAL one-shot repair for a DB that is already corrupt: it
+ * dedupes every affected session by primary id, then rebuilds the index clean.
+ *
+ * Usage
+ * -----
+ *   bun scripts/repair-agent-event-index.ts            # apply the repair
+ *   bun scripts/repair-agent-event-index.ts --dry-run  # report only, no writes
+ *
+ * Safe to re-run: a clean DB reports 0 duplicates and rebuilds the index as a
+ * no-op. `agent_event` is derived data (transcripts are the source of truth), so
+ * a repaired session fully reconstructs on its next ingest.
+ */
+
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { AppLayer } from "@ax/lib/layers";
+
+const INDEX_NAME = "agent_event_session_seq";
+const DRY_RUN = process.argv.includes("--dry-run");
+
+interface DupGroup {
+    readonly agent_session: string;
+    readonly seq: number;
+    readonly c: number;
+}
+
+/** Excess record ids to delete for one session: keep the first row at each seq,
+ *  drop the rest. Pure so it can be reasoned about / unit-tested in isolation. */
+export const planSessionDedup = (
+    rows: ReadonlyArray<{ readonly id: string; readonly seq: number }>,
+): string[] => {
+    const seen = new Set<number>();
+    const drop: string[] = [];
+    for (const row of rows) {
+        if (seen.has(row.seq)) drop.push(row.id);
+        else seen.add(row.seq);
+    }
+    return drop;
+};
+
+const repair = Effect.gen(function* () {
+    const db = yield* SurrealClient;
+
+    // 1) Enumerate duplicate (agent_session, seq) groups via a full-table GROUP
+    //    BY (index-independent), then collapse to the affected sessions.
+    const groups = yield* db
+        .query<[DupGroup[]]>(
+            `SELECT agent_session, seq, count() AS c FROM agent_event GROUP BY agent_session, seq;`,
+        )
+        .pipe(Effect.map((r) => (r?.[0] ?? []).filter((g) => g.c > 1)));
+    const sessions = [...new Set(groups.map((g) => String(g.agent_session)))];
+    const excess = groups.reduce((n, g) => n + (g.c - 1), 0);
+
+    console.log(`[repair] duplicate (agent_session, seq) groups: ${groups.length}`);
+    console.log(`[repair] affected sessions: ${sessions.length}`);
+    console.log(`[repair] excess rows to remove: ${excess}`);
+
+    if (DRY_RUN) {
+        console.log("[repair] --dry-run: no writes performed");
+        return;
+    }
+
+    if (groups.length === 0) {
+        // Still rebuild the index to drop any ghost entries that have no
+        // surviving duplicate row to flag them.
+        yield* db.query(`REMOVE INDEX IF EXISTS ${INDEX_NAME} ON agent_event;`);
+        yield* db.query(
+            `DEFINE INDEX ${INDEX_NAME} ON agent_event FIELDS agent_session, seq UNIQUE;`,
+        );
+        console.log("[repair] no duplicates; index rebuilt clean");
+        return;
+    }
+
+    // 2) Drop the corrupt index so deletes scan the table and nothing blocks.
+    yield* db.query(`REMOVE INDEX IF EXISTS ${INDEX_NAME} ON agent_event;`);
+    console.log("[repair] index removed");
+
+    // 3) Dedupe each affected session: delete excess rows by PRIMARY id (never
+    //    the corruptible secondary index), batched to stay under parser limits.
+    let removed = 0;
+    for (const sess of sessions) {
+        const sk = sess.replace(/^agent_session:/, "").replace(/^`|`$/g, "");
+        const rows = yield* db
+            .query<[Array<{ id: string; seq: number }>]>(
+                `SELECT id, seq FROM agent_event WHERE agent_session = agent_session:\`${sk}\`;`,
+            )
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const drop = planSessionDedup(rows.map((row) => ({ id: String(row.id), seq: row.seq })));
+        for (let i = 0; i < drop.length; i += 200) {
+            const batch = drop.slice(i, i + 200);
+            yield* db.query(batch.map((id) => `DELETE ${id};`).join(""));
+        }
+        removed += drop.length;
+    }
+    console.log(`[repair] excess rows removed: ${removed}`);
+
+    // 4) Verify no duplicates survive before re-asserting UNIQUE.
+    const after = yield* db
+        .query<[DupGroup[]]>(
+            `SELECT agent_session, seq, count() AS c FROM agent_event GROUP BY agent_session, seq;`,
+        )
+        .pipe(Effect.map((r) => (r?.[0] ?? []).filter((g) => g.c > 1)));
+    if (after.length > 0) {
+        console.error(`[repair] ABORT: ${after.length} duplicate groups remain; index NOT rebuilt`);
+        return;
+    }
+
+    // 5) Rebuild the UNIQUE index against the now-clean table.
+    yield* db.query(
+        `DEFINE INDEX ${INDEX_NAME} ON agent_event FIELDS agent_session, seq UNIQUE;`,
+    );
+    console.log("[repair] index rebuilt UNIQUE - done");
+});
+
+// Only run the repair when invoked directly (`bun scripts/repair-...ts`), so
+// importing `planSessionDedup` for tests never touches the live DB.
+if (import.meta.main) {
+    await Effect.runPromise(
+        repair.pipe(Effect.provide(AppLayer)) as Effect.Effect<void, unknown, never>,
+    );
+}


### PR DESCRIPTION
## Problem

`ax update` / `ax ingest` crashed mid-pipeline with:

```
Database index `agent_event_session_seq` already contains
  [agent_session:codex__019df150…, 181],
  with record `agent_event:…__compacted_181__…`
```

## Root cause

The per-session clear ran `DELETE agent_event WHERE agent_session = X`. SurrealDB plans that through the `agent_event_session_seq` `(agent_session, seq)` **UNIQUE** index. A long-lived DB had drifted: it held **genuine duplicate `(agent_session, seq)` rows** the index let in, and the index-driven DELETE **silently skipped** the drifted rows — yet their ghost entries still blocked the fresh `(agent_session, seq)` INSERT, crashing the next ingest.

Verified live:
- `DELETE … WHERE agent_session=X` took one session 190→10 rows (10 ghosts survived **with the correct `agent_session` link**).
- `SELECT … WHERE agent_session=X` and `DELETE agent_event:<id>` (by primary id) both saw/removed every row.
- Scope: **18,936 dup `(session, seq)` groups, ~19,089 excess rows, 27 codex sessions.**

## Fix

Delete via `id IN (SELECT VALUE id FROM agent_event WHERE agent_session = X)` — the inner SELECT reliably enumerates every row; the outer DELETE removes them by **primary id**, never consulting the corruptible secondary index. This also **self-heals** a corrupt session on its next re-ingest.

Plus `scripts/repair-agent-event-index.ts` (+ unit-tested `planSessionDedup`) to globally dedupe + rebuild the index for an already-corrupt DB (`--dry-run` supported), and a strengthened builder test that forbids regressing to the bare-WHERE delete.

## Verification

- Local DB repaired (19,089 rows removed, index rebuilt UNIQUE), then full `ax ingest` ran end-to-end `EXIT=0`.
- Re-ran the exact failing file's 925-statement batch: applies cleanly.
- `bun test` provider-events + repair script: 9 pass.
- Repair `--dry-run` against repaired DB: 0 duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)