### PR TITLE
feat(studio-desktop): standalone Electron app (Phases 1–3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ apps/site/.tmp-shots/
 # studio-desktop electron build output
 apps/studio-desktop/dist-electron/
 
+# studio-desktop electron-builder packaged output
+apps/studio-desktop/dist-release/
+
 # studio-desktop vendored binaries (fetched per-arch by scripts/fetch-binaries.ts, not committed)
 apps/studio-desktop/resources/bin/
 

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ docs/how-ax-sees-your-work.generated.mdx
 
 # scratch screenshots from landing iteration
 apps/site/.tmp-shots/
+
+# studio-desktop electron build output
+apps/studio-desktop/dist-electron/

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ apps/site/.tmp-shots/
 
 # studio-desktop electron build output
 apps/studio-desktop/dist-electron/
+
+# studio-desktop vendored binaries (fetched per-arch by scripts/fetch-binaries.ts, not committed)
+apps/studio-desktop/resources/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ apps/studio-desktop/dist-electron/
 
 # studio-desktop vendored binaries (fetched per-arch by scripts/fetch-binaries.ts, not committed)
 apps/studio-desktop/resources/bin/
+
+# studio-desktop staged bundle resources (built per-arch by scripts/stage-ax-source.ts, not committed)
+apps/studio-desktop/resources/ax-src/
+apps/studio-desktop/resources/studio/

--- a/apps/studio-desktop/build/entitlements.mac.plist
+++ b/apps/studio-desktop/build/entitlements.mac.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Electron/V8 JIT under hardened runtime -->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<!-- V8 + bun JIT write/exec pages -->
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<!-- Required so the app can spawn the vendored `bun` and load native
+	     lmdb / other dylibs whose signing identity differs from the app's. -->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<!-- ax serve / surreal are launched with env vars (DYLD_*, AX_*) set -->
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/studio-desktop/electron-builder.config.cjs
+++ b/apps/studio-desktop/electron-builder.config.cjs
@@ -1,0 +1,49 @@
+// electron-builder configuration for ax studio desktop.
+//
+// IMPORTANT - macOS code-signing / SIGKILL failure mode (see memory:
+// dogfood-compiled-binary-codesign):
+//   The bundled `surreal` + `bun` Mach-O binaries placed under
+//   Contents/Resources/bin MUST be codesigned. An unsigned or ad-hoc-copied
+//   Mach-O is SIGKILL'd by macOS Gatekeeper on first spawn (no error, the
+//   child just dies), which breaks the supervised surreal/ax-serve boot.
+//
+//   electron-builder WILL sign every Mach-O it finds under Contents/Resources
+//   automatically - but only when `hardenedRuntime` is on AND a real
+//   "Developer ID Application" identity is available (CSC_LINK / keychain).
+//   In that path no manual step is needed.
+//
+//   For LOCAL UNSIGNED dev builds (no Apple cert, CSC_IDENTITY_AUTO_DISCOVERY
+//   =false), electron-builder does NOT sign the vendored binaries, so you must
+//   ad-hoc sign them yourself before launching the app, e.g.:
+//
+//     codesign --force --sign - \
+//       "dist-release/mac-arm64/ax studio.app/Contents/Resources/bin/arm64/"{surreal,bun}
+//
+//   (Adjust mac-arm64 / arch dir for x64 builds.) Without this the app launches
+//   but the surreal/bun children are killed on spawn.
+
+module.exports = {
+  appId: "com.necmttn.ax-studio",
+  productName: "ax studio",
+  directories: { output: "dist-release", buildResources: "build" },
+  files: ["dist-electron/**", "package.json"],
+  extraResources: [
+    { from: "resources/bin", to: "bin" },
+    { from: "resources/ax-src", to: "ax-src" },
+    { from: "resources/studio", to: "studio" },
+  ],
+  mac: {
+    target: [
+      { target: "dmg", arch: ["arm64", "x64"] },
+      { target: "zip", arch: ["arm64", "x64"] },
+    ],
+    category: "public.app-category.developer-tools",
+    hardenedRuntime: true,
+    gatekeeperAssess: false,
+    entitlements: "build/entitlements.mac.plist",
+    entitlementsInherit: "build/entitlements.mac.plist",
+    notarize: true, // requires APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID env
+  },
+  afterSign: "scripts/notarize-check.cjs",
+  publish: [{ provider: "github", owner: "Necmttn", repo: "ax" }],
+};

--- a/apps/studio-desktop/electron-builder.config.cjs
+++ b/apps/studio-desktop/electron-builder.config.cjs
@@ -1,5 +1,36 @@
 // electron-builder configuration for ax studio desktop.
 //
+// ---------------------------------------------------------------------------
+// AUTO-UPDATE (electron-updater) RELEASE REQUIREMENTS
+// ---------------------------------------------------------------------------
+// The desktop app checks for updates at boot via `electron-updater`
+// (src/updates/DesktopUpdates.ts), wired into the boot program only in
+// production (dev has no feed). The update feed is the GitHub `publish` config
+// below, baked into `app-update.yml` inside the packaged app at build time -
+// there is no runtime feed URL.
+//
+// For the feed to actually serve updates, a release build must:
+//   1. Be a tagged release. electron-updater compares the running app version
+//      against the latest GitHub Release's assets, so bump package.json
+//      `version` and create a matching GitHub Release/tag.
+//   2. Publish the update artifacts to that GitHub Release. Run
+//      `electron-builder --publish always` (NOT the plain `package` script,
+//      which omits --publish). This uploads the installers PLUS the
+//      electron-updater feed metadata: `latest-mac.yml` + the `*.blockmap`
+//      files (and per-arch zips). Without `latest-mac.yml` on the release,
+//      `autoUpdater.checkForUpdatesAndNotify()` finds no feed and no-ops.
+//   3. Provide credentials:
+//        - GH_TOKEN  - a GitHub token with `repo` scope (or `public_repo` for
+//          this public repo) so electron-builder can upload release assets.
+//        - Apple notarization creds (already required for signing, see below):
+//          APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID, plus a real
+//          "Developer ID Application" identity (CSC_LINK / keychain). macOS
+//          electron-updater REQUIRES the update to be signed + notarized; an
+//          unsigned/ad-hoc build will refuse to apply the downloaded update.
+//   None of (1)-(3) can be exercised in this environment (no tag, no GH_TOKEN,
+//   no Apple creds), so the live update path is verified only by compile +
+//   bundle + dev-guard review, not by an actual update check.
+//
 // IMPORTANT - macOS code-signing / SIGKILL failure mode (see memory:
 // dogfood-compiled-binary-codesign):
 //   The bundled `surreal` + `bun` Mach-O binaries placed under

--- a/apps/studio-desktop/package.json
+++ b/apps/studio-desktop/package.json
@@ -11,6 +11,7 @@
     "build:studio": "bun --filter @ax/studio build:desktop",
     "build": "bun run build:studio && bun run build:main",
     "start": "bun run build && electron .",
+    "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.0",
+    "bun-types": "1.3.13",
     "electron": "41.5.0",
     "electron-builder": "26.8.1",
     "electron-updater": "^6.6.2",

--- a/apps/studio-desktop/package.json
+++ b/apps/studio-desktop/package.json
@@ -11,6 +11,9 @@
     "build:studio": "bun --filter @ax/studio build:desktop",
     "build": "bun run build:studio && bun run build:main",
     "start": "bun run build && electron .",
+    "prepackage": "bun run scripts/fetch-binaries.ts && bun run scripts/stage-ax-source.ts && bun run build",
+    "package": "bun run prepackage && electron-builder --config electron-builder.config.cjs",
+    "package:dir": "bun run prepackage && electron-builder --dir --config electron-builder.config.cjs",
     "test": "bun test",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/studio-desktop/package.json
+++ b/apps/studio-desktop/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@ax/studio-desktop",
+  "version": "0.12.1",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "description": "ax studio desktop app - Electron shell that supervises surreal + ax serve and renders the studio SPA.",
+  "type": "module",
+  "main": "dist-electron/main.cjs",
+  "scripts": {
+    "build:main": "tsdown",
+    "build:studio": "bun --filter @ax/studio build:desktop",
+    "build": "bun run build:studio && bun run build:main",
+    "start": "bun run build && electron .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ax/lib": "workspace:*",
+    "@effect/platform-node": "4.0.0-beta.70",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.0",
+    "electron": "41.5.0",
+    "electron-builder": "26.8.1",
+    "electron-updater": "^6.6.2",
+    "tsdown": "^0.20.3",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/studio-desktop/scripts/fetch-binaries.ts
+++ b/apps/studio-desktop/scripts/fetch-binaries.ts
@@ -1,0 +1,299 @@
+#!/usr/bin/env bun
+/**
+ * fetch-binaries.ts - vendor the `surreal` + `bun` binaries the packaged
+ * studio-desktop app spawns at runtime (surreal :8521, `bun ... serve` :1738).
+ *
+ * Downloads pinned releases for the requested macOS arch(es) into
+ * `resources/bin/<arch>/{surreal,bun}` and `chmod +x` them. The output dir is
+ * gitignored - binaries are fetched at build/release time, not committed.
+ *
+ * Usage:
+ *   bun run scripts/fetch-binaries.ts                # host arch only
+ *   bun run scripts/fetch-binaries.ts --arch=arm64,x64
+ *   bun run scripts/fetch-binaries.ts --all          # both darwin arches
+ *   bun run scripts/fetch-binaries.ts --update-hashes # recompute + print SHA256s
+ *
+ * Idempotent: skips a binary if it already exists and `--version` matches the
+ * pinned version. SHA256 is verified against the recorded hashes (when present),
+ * and every binary is sanity-checked by running `--version`.
+ */
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { chmod } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Exact pinned upstream versions. Bump deliberately. */
+const BINARY_VERSIONS = {
+    surreal: "3.1.0",
+    bun: "1.3.13",
+} as const;
+
+/** Our internal arch dir names (match `DesktopEnvironment` path construction). */
+type Arch = "arm64" | "x64";
+
+/**
+ * Per-release arch tokens. Upstream naming differs per project / per arch.
+ * Confirmed against the actual GitHub release assets (2026-06):
+ *   surreal: surreal-v3.1.0.darwin-{amd64,arm64}.tgz
+ *   bun:     bun-darwin-{aarch64,x64}.zip
+ */
+const ARCH_TOKENS: Record<Arch, { surreal: string; bun: string }> = {
+    arm64: { surreal: "arm64", bun: "aarch64" },
+    x64: { surreal: "amd64", bun: "x64" },
+};
+
+/**
+ * Expected SHA256 of each downloaded ARCHIVE (the `.tgz` / `.zip`), keyed by
+ * arch. Empty string = not yet recorded (run with `--update-hashes`).
+ *
+ * - bun: taken from the upstream `SHASUMS256.txt` published with the release.
+ * - surreal: upstream publishes no checksum file, so these are computed-once
+ *   values pinned here; verified on download.
+ */
+const ARCHIVE_SHA256: Record<Arch, { surreal: string; bun: string }> = {
+    arm64: {
+        surreal: "4acf3578e3cc1d57a23b44241b4dd5b30aabf8aebbe9b211430da33550f14d3d",
+        bun: "5467e3f65dba526b9fea98f0cce04efafc0c63e169733ec27b876a3ad32da190",
+    },
+    x64: {
+        surreal: "",
+        bun: "e5a6c8b64f419925232d111ecb13e25f0abf55e54f792341f987623fd0778009",
+    },
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = dirname(HERE); // apps/studio-desktop
+const BIN_ROOT = join(APP_ROOT, "resources", "bin");
+
+const log = (msg: string) => process.stdout.write(`[fetch-binaries] ${msg}\n`);
+const die = (msg: string): never => {
+    process.stderr.write(`[fetch-binaries] ERROR: ${msg}\n`);
+    process.exit(1);
+};
+
+function hostArch(): Arch {
+    if (process.arch === "arm64") return "arm64";
+    if (process.arch === "x64") return "x64";
+    return die(`unsupported host arch: ${process.arch} (only arm64/x64)`);
+}
+
+function parseArchArgs(argv: string[]): Arch[] {
+    if (argv.includes("--all")) return ["arm64", "x64"];
+    const archFlag = argv.find((a) => a.startsWith("--arch="));
+    if (!archFlag) return [hostArch()];
+    const parts = archFlag
+        .slice("--arch=".length)
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    const archs: Arch[] = [];
+    for (const p of parts) {
+        if (p === "arm64" || p === "x64") archs.push(p);
+        else die(`unknown --arch value: ${p} (expected arm64 or x64)`);
+    }
+    return archs.length ? archs : [hostArch()];
+}
+
+function sha256(path: string): string {
+    return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+async function download(url: string, dest: string): Promise<void> {
+    log(`GET ${url}`);
+    const res = await fetch(url);
+    if (!res.ok) {
+        die(`download failed (${res.status} ${res.statusText}) for ${url}`);
+    }
+    const buf = new Uint8Array(await res.arrayBuffer());
+    await Bun.write(dest, buf);
+}
+
+/** Runs `<binPath> --version` and returns trimmed stdout (or null on failure). */
+function probeVersion(binPath: string): string | null {
+    const r = spawnSync(binPath, ["--version"], { encoding: "utf8" });
+    if (r.status !== 0 || r.error) return null;
+    return (r.stdout || "").trim();
+}
+
+/**
+ * If a Mach-O binary was just written, macOS may SIGKILL it on first spawn until
+ * it carries an (ad-hoc) signature. Apply an ad-hoc signature so the local
+ * `--version` verification can run. No-op on non-darwin / if codesign missing.
+ */
+function adhocSign(binPath: string): void {
+    if (process.platform !== "darwin") return;
+    const r = spawnSync("codesign", ["--force", "--sign", "-", binPath], {
+        encoding: "utf8",
+    });
+    if (r.status !== 0) {
+        log(`warn: codesign ad-hoc sign failed for ${binPath} (continuing)`);
+    }
+}
+
+function surrealUrl(arch: Arch): string {
+    const v = BINARY_VERSIONS.surreal;
+    const token = ARCH_TOKENS[arch].surreal;
+    return `https://github.com/surrealdb/surrealdb/releases/download/v${v}/surreal-v${v}.darwin-${token}.tgz`;
+}
+
+function bunUrl(arch: Arch): string {
+    const v = BINARY_VERSIONS.bun;
+    const token = ARCH_TOKENS[arch].bun;
+    return `https://github.com/oven-sh/bun/releases/download/bun-v${v}/bun-darwin-${token}.zip`;
+}
+
+function extractTgz(archive: string, intoDir: string): void {
+    const r = spawnSync("tar", ["-xzf", archive, "-C", intoDir], {
+        encoding: "utf8",
+    });
+    if (r.status !== 0) die(`tar extract failed: ${r.stderr || r.stdout}`);
+}
+
+function extractZip(archive: string, intoDir: string): void {
+    const r = spawnSync("unzip", ["-o", "-q", archive, "-d", intoDir], {
+        encoding: "utf8",
+    });
+    if (r.status !== 0) die(`unzip failed: ${r.stderr || r.stdout}`);
+}
+
+interface FetchSpec {
+    readonly name: "surreal" | "bun";
+    readonly url: string;
+    readonly archiveExt: ".tgz" | ".zip";
+    readonly expectedSha: string;
+    /** Returns the extracted binary path inside `workDir`, or null if not found. */
+    readonly locate: (workDir: string) => string | null;
+    /** Substring expected in `--version` output (the pinned version). */
+    readonly versionNeedle: string;
+}
+
+function findFile(dir: string, basename: string): string | null {
+    // Recursive search - bun's zip extracts `bun-darwin-<arch>/bun`.
+    const r = spawnSync("find", [dir, "-type", "f", "-name", basename], {
+        encoding: "utf8",
+    });
+    if (r.status !== 0) return null;
+    const first = (r.stdout || "").split("\n").map((s) => s.trim()).filter(Boolean)[0];
+    return first ?? null;
+}
+
+async function fetchOne(
+    arch: Arch,
+    spec: FetchSpec,
+    opts: { updateHashes: boolean },
+): Promise<{ recordedSha: string; version: string }> {
+    const outDir = join(BIN_ROOT, arch);
+    mkdirSync(outDir, { recursive: true });
+    const finalPath = join(outDir, spec.name);
+
+    // Idempotency: skip if present + version matches.
+    if (!opts.updateHashes && existsSync(finalPath)) {
+        const existing = probeVersion(finalPath);
+        if (existing && existing.includes(spec.versionNeedle)) {
+            log(`${arch}/${spec.name}: present & version OK (${existing}) - skip`);
+            return { recordedSha: spec.expectedSha, version: existing };
+        }
+        log(`${arch}/${spec.name}: present but version mismatch/unreadable - refetch`);
+    }
+
+    const work = join(tmpdir(), `ax-fetch-${spec.name}-${arch}-${Date.now()}`);
+    mkdirSync(work, { recursive: true });
+    const archive = join(work, `dl${spec.archiveExt}`);
+    try {
+        await download(spec.url, archive);
+
+        const got = sha256(archive);
+        if (opts.updateHashes) {
+            log(`${arch}/${spec.name}: archive SHA256 = ${got}`);
+        } else if (spec.expectedSha) {
+            if (got !== spec.expectedSha) {
+                die(
+                    `${arch}/${spec.name}: SHA256 mismatch\n  expected ${spec.expectedSha}\n  got      ${got}\n  url ${spec.url}`,
+                );
+            }
+            log(`${arch}/${spec.name}: SHA256 verified`);
+        } else {
+            log(`${arch}/${spec.name}: no recorded SHA256 (got ${got}) - skipping archive checksum`);
+        }
+
+        if (spec.archiveExt === ".tgz") extractTgz(archive, work);
+        else extractZip(archive, work);
+
+        const located = spec.locate(work);
+        if (!located) {
+            return die(
+                `${arch}/${spec.name}: extracted binary not found in archive`,
+            );
+        }
+
+        // Move into place.
+        await Bun.write(finalPath, Bun.file(located));
+        await chmod(finalPath, 0o755);
+        adhocSign(finalPath);
+
+        const version = probeVersion(finalPath);
+        if (!version) {
+            return die(
+                `${arch}/${spec.name}: binary failed to run --version after install`,
+            );
+        }
+        if (!version.includes(spec.versionNeedle)) {
+            return die(
+                `${arch}/${spec.name}: --version (${version}) does not contain pinned version ${spec.versionNeedle}`,
+            );
+        }
+        log(`${arch}/${spec.name}: installed -> ${finalPath}`);
+        log(`${arch}/${spec.name}: --version -> ${version}`);
+        return { recordedSha: got, version };
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+}
+
+async function main() {
+    const argv = process.argv.slice(2);
+    const updateHashes = argv.includes("--update-hashes");
+    const archs = parseArchArgs(argv);
+
+    log(`pinned: surreal v${BINARY_VERSIONS.surreal}, bun v${BINARY_VERSIONS.bun}`);
+    log(`arch(es): ${archs.join(", ")}${updateHashes ? " (update-hashes)" : ""}`);
+
+    const computed: Record<string, { surreal?: string; bun?: string }> = {};
+
+    for (const arch of archs) {
+        const surrealSpec: FetchSpec = {
+            name: "surreal",
+            url: surrealUrl(arch),
+            archiveExt: ".tgz",
+            expectedSha: ARCHIVE_SHA256[arch].surreal,
+            locate: (work) => findFile(work, "surreal"),
+            versionNeedle: BINARY_VERSIONS.surreal,
+        };
+        const bunSpec: FetchSpec = {
+            name: "bun",
+            url: bunUrl(arch),
+            archiveExt: ".zip",
+            expectedSha: ARCHIVE_SHA256[arch].bun,
+            locate: (work) => findFile(work, "bun"),
+            versionNeedle: BINARY_VERSIONS.bun,
+        };
+
+        const s = await fetchOne(arch, surrealSpec, { updateHashes });
+        const b = await fetchOne(arch, bunSpec, { updateHashes });
+        computed[arch] = { surreal: s.recordedSha, bun: b.recordedSha };
+    }
+
+    if (updateHashes) {
+        log("recorded SHA256 values (paste into ARCHIVE_SHA256):");
+        for (const [arch, v] of Object.entries(computed)) {
+            log(`  ${arch}: surreal=${v.surreal} bun=${v.bun}`);
+        }
+    }
+
+    log("done.");
+}
+
+main().catch((err) => die(err instanceof Error ? err.message : String(err)));

--- a/apps/studio-desktop/scripts/notarize-check.cjs
+++ b/apps/studio-desktop/scripts/notarize-check.cjs
@@ -1,0 +1,35 @@
+// afterSign hook referenced by electron-builder.config.cjs.
+//
+// This is intentionally a NO-OP guard: electron-builder performs notarization
+// itself when `mac.notarize: true` and the APPLE_* credentials are present in
+// the environment. This hook only LOGS whether those credentials are set, so a
+// build run makes it obvious why notarization was (or wasn't) attempted. It
+// never fails the build - a missing-credential local/unsigned build proceeds.
+
+/** @param {import('electron-builder').AfterPackContext} context */
+module.exports = async function notarizeCheck(context) {
+  // Only meaningful on macOS.
+  if (context.electronPlatformName !== "darwin") {
+    return;
+  }
+
+  const hasAppleId = Boolean(process.env.APPLE_ID);
+  const hasTeamId = Boolean(process.env.APPLE_TEAM_ID);
+  const hasPassword = Boolean(process.env.APPLE_APP_SPECIFIC_PASSWORD);
+
+  if (hasAppleId && hasTeamId && hasPassword) {
+    console.log(
+      "[notarize-check] APPLE_ID / APPLE_TEAM_ID / APPLE_APP_SPECIFIC_PASSWORD all set - electron-builder will notarize.",
+    );
+  } else {
+    const missing = [
+      hasAppleId ? null : "APPLE_ID",
+      hasTeamId ? null : "APPLE_TEAM_ID",
+      hasPassword ? null : "APPLE_APP_SPECIFIC_PASSWORD",
+    ].filter(Boolean);
+    console.warn(
+      `[notarize-check] Notarization credentials missing: ${missing.join(", ")}. ` +
+        "Build will NOT be notarized (fine for local/unsigned dev builds).",
+    );
+  }
+};

--- a/apps/studio-desktop/scripts/stage-ax-source.ts
+++ b/apps/studio-desktop/scripts/stage-ax-source.ts
@@ -1,0 +1,255 @@
+#!/usr/bin/env bun
+/**
+ * stage-ax-source.ts - populate `apps/studio-desktop/resources/` with everything
+ * the packaged Electron app needs to run `<bunBinary> <axSourceEntry> serve`
+ * (see `DesktopEnvironment`):
+ *
+ *   1. `resources/ax-src/`  - the minimal runnable ax source tree (workspace
+ *      packages that `apps/axctl/src/cli/index.ts serve` actually imports) plus
+ *      a self-contained host-arch `node_modules`, so the staged `ax serve`
+ *      resolves `surrealdb`, `@durable-streams/*`, `lmdb` (pulled by
+ *      durable-streams), `node-pty`, effect, etc.
+ *   2. `resources/studio/`  - the built studio SPA (`apps/studio/dist-desktop`),
+ *      served over the custom protocol from `<resourcesPath>/studio`.
+ *
+ * Why from-source (not the `--compile` binary): the compiled binary can't host
+ * the Durable Streams sidecar (native lmdb) -> live ingest 503s. Live ingest is
+ * required, so we ship bun (vendored by fetch-binaries.ts) + this source tree.
+ *
+ * Native-dep strategy (a): we copy a tailored root `package.json` + the real
+ * `bun.lock` + the needed workspace packages into `resources/ax-src/`, then run
+ * `bun install` *inside* that tree to materialise a self-contained, correctly
+ * linked `node_modules` for the HOST arch. Native modules (lmdb, node-pty) are
+ * per-arch: the staged `node_modules` is host-arch-only. Release builds for the
+ * other arch must run this script on that arch.
+ *
+ * Usage:
+ *   bun run scripts/stage-ax-source.ts            # stage for host arch
+ *   bun run scripts/stage-ax-source.ts --skip-install   # copy source only
+ *   bun run scripts/stage-ax-source.ts --skip-studio    # don't (re)build studio
+ *
+ * Idempotent: re-running refreshes the staged copies. `bun install` is itself
+ * idempotent given the same lockfile.
+ */
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = dirname(HERE); // apps/studio-desktop
+const REPO_ROOT = dirname(dirname(APP_ROOT)); // <repo>
+const RESOURCES = join(APP_ROOT, "resources");
+const AX_SRC = join(RESOURCES, "ax-src");
+const STUDIO_OUT = join(RESOURCES, "studio");
+
+const log = (msg: string) => process.stdout.write(`[stage-ax-source] ${msg}\n`);
+const die = (msg: string): never => {
+    process.stderr.write(`[stage-ax-source] ERROR: ${msg}\n`);
+    process.exit(1);
+};
+
+/**
+ * Workspace packages copied into `resources/ax-src/`. This is the minimal set
+ * `apps/axctl/src/cli/index.ts serve` resolves at runtime:
+ *   - apps/axctl                         the CLI / serve entrypoint
+ *   - packages/lib (@ax/lib)             db client, paths, layers, live-traces
+ *   - packages/schema (@ax/schema)       schema.surql (imported as text) + types
+ *   - packages/ax-classifier-direction-event     imported by classifiers/registry.ts
+ *   - packages/ax-classifier-verification-event   imported by classifiers/registry.ts
+ *
+ * `packages/ax-classifier-session-sections` is python-only (referenced solely by
+ * string manifest paths, never imported as a module) and is intentionally
+ * skipped - it is not needed for `serve`.
+ */
+const WORKSPACE_PACKAGES = [
+    "apps/axctl",
+    "packages/lib",
+    "packages/schema",
+    "packages/ax-classifier-direction-event",
+    "packages/ax-classifier-verification-event",
+] as const;
+
+/** Per-package dir names excluded from the copied source (regenerated/irrelevant). */
+const EXCLUDE_DIR_NAMES = new Set([
+    "node_modules",
+    ".turbo",
+    ".tsbuildinfo",
+]);
+
+/** Returns true if a path segment should be excluded from the source copy. */
+function isExcludedSegment(name: string): boolean {
+    if (EXCLUDE_DIR_NAMES.has(name)) return true;
+    // dist, dist-*, dist-electron etc.
+    if (name === "dist" || name.startsWith("dist-")) return true;
+    // test fixtures
+    if (name === "fixtures" || name === "__fixtures__" || name === "eval-fixtures")
+        return true;
+    return false;
+}
+
+/** Returns true if a file should be excluded from the source copy. */
+function isExcludedFile(name: string): boolean {
+    if (name.endsWith(".tsbuildinfo")) return true;
+    if (name === ".DS_Store") return true;
+    return false;
+}
+
+/** Recursively copy `src` -> `dest`, honouring the exclude rules. */
+function copyTree(src: string, dest: string): void {
+    cpSync(src, dest, {
+        recursive: true,
+        dereference: false,
+        filter: (from) => {
+            const rel = relative(src, from);
+            if (rel === "") return true;
+            const segs = rel.split("/");
+            for (const seg of segs) {
+                if (isExcludedSegment(seg)) return false;
+            }
+            const base = segs[segs.length - 1]!;
+            // Only treat as file-exclusion if it's actually a file.
+            try {
+                if (statSync(from).isFile() && isExcludedFile(base)) return false;
+            } catch {
+                // ignore
+            }
+            return true;
+        },
+    });
+}
+
+/** Human-readable directory size via `du -sh` (best-effort). */
+function dirSize(path: string): string {
+    if (!existsSync(path)) return "(missing)";
+    const r = spawnSync("du", ["-sh", path], { encoding: "utf8" });
+    if (r.status !== 0) return "(unknown)";
+    return (r.stdout || "").split("\t")[0]?.trim() ?? "(unknown)";
+}
+
+/**
+ * Build a tailored root package.json for the staged tree:
+ *   - workspaces.packages narrowed to the staged members (so `bun install`
+ *     doesn't fail on the absent apps/site, apps/studio, etc.)
+ *   - lifecycle scripts (`prepare`, `postinstall`) dropped - they run
+ *     effect-language-service / bun2nix which are dev-only and would fail or
+ *     mutate files in the staged tree.
+ *   - root `dependencies`/`devDependencies` dropped - the staged tree only needs
+ *     each workspace package's own deps; keeping root web/build deps (vite,
+ *     turbo, tanstack, ...) would bloat node_modules for no runtime benefit.
+ *   - `catalog` + `overrides` preserved - workspace packages reference
+ *     `catalog:` versions and the overrides pin transitive resolutions.
+ */
+function tailoredRootPackageJson(): string {
+    const root = JSON.parse(
+        spawnSync("cat", [join(REPO_ROOT, "package.json")], {
+            encoding: "utf8",
+        }).stdout,
+    ) as Record<string, unknown>;
+
+    const staged = {
+        name: root.name,
+        version: root.version,
+        private: true,
+        license: root.license,
+        type: root.type,
+        packageManager: root.packageManager,
+        workspaces: {
+            packages: WORKSPACE_PACKAGES.map((p) => p),
+            catalog: (root.workspaces as { catalog?: unknown }).catalog ?? {},
+        },
+        overrides: root.overrides ?? {},
+    };
+    return `${JSON.stringify(staged, null, 2)}\n`;
+}
+
+async function main() {
+    const argv = process.argv.slice(2);
+    const skipInstall = argv.includes("--skip-install");
+    const skipStudio = argv.includes("--skip-studio");
+
+    log(`repo root:   ${REPO_ROOT}`);
+    log(`resources:   ${RESOURCES}`);
+    log(`host arch:   ${process.arch}`);
+
+    mkdirSync(RESOURCES, { recursive: true });
+
+    // ---- 1. ax source -----------------------------------------------------
+    log("staging ax source -> resources/ax-src/ ...");
+    rmSync(AX_SRC, { recursive: true, force: true });
+    mkdirSync(AX_SRC, { recursive: true });
+
+    for (const pkg of WORKSPACE_PACKAGES) {
+        const from = join(REPO_ROOT, pkg);
+        if (!existsSync(from)) die(`workspace package not found: ${from}`);
+        const to = join(AX_SRC, pkg);
+        mkdirSync(dirname(to), { recursive: true });
+        copyTree(from, to);
+        log(`  copied ${pkg}  (${dirSize(to)})`);
+    }
+
+    // Root files bun needs to resolve the workspace in the staged tree.
+    writeFileSync(join(AX_SRC, "package.json"), tailoredRootPackageJson());
+    for (const f of ["tsconfig.base.json", "bun.lock"]) {
+        const from = join(REPO_ROOT, f);
+        if (!existsSync(from)) die(`expected root file missing: ${from}`);
+        cpSync(from, join(AX_SRC, f));
+        log(`  copied ${f}`);
+    }
+
+    // ---- 2. native deps (bun install inside the staged tree) --------------
+    if (skipInstall) {
+        log("skipping `bun install` (--skip-install)");
+    } else {
+        log("installing host-arch deps: `bun install` in resources/ax-src/ ...");
+        const r = spawnSync("bun", ["install"], {
+            cwd: AX_SRC,
+            stdio: "inherit",
+            // Don't let a stale root catalog/lock abort the install; allow
+            // bun to re-resolve against the narrowed workspace.
+            env: { ...process.env },
+        });
+        if (r.status !== 0) {
+            die(
+                `bun install failed (exit ${r.status}) in ${AX_SRC}. ` +
+                    "Native deps were not staged - investigate before relying on this bundle.",
+            );
+        }
+        log(`  node_modules staged  (${dirSize(join(AX_SRC, "node_modules"))})`);
+    }
+
+    // ---- 3. studio bundle -------------------------------------------------
+    const studioDist = join(REPO_ROOT, "apps/studio/dist-desktop");
+    if (!skipStudio && !existsSync(studioDist)) {
+        log("apps/studio/dist-desktop missing - building studio (desktop target)...");
+        const r = spawnSync("bun", ["--filter", "@ax/studio", "build:desktop"], {
+            cwd: REPO_ROOT,
+            stdio: "inherit",
+        });
+        if (r.status !== 0) die(`studio build:desktop failed (exit ${r.status})`);
+    } else if (!skipStudio) {
+        log("apps/studio/dist-desktop present - rebuilding (desktop target)...");
+        const r = spawnSync("bun", ["--filter", "@ax/studio", "build:desktop"], {
+            cwd: REPO_ROOT,
+            stdio: "inherit",
+        });
+        if (r.status !== 0) die(`studio build:desktop failed (exit ${r.status})`);
+    }
+    if (!existsSync(studioDist)) {
+        die(`studio dist not found after build: ${studioDist}`);
+    }
+    log("staging studio bundle -> resources/studio/ ...");
+    rmSync(STUDIO_OUT, { recursive: true, force: true });
+    mkdirSync(STUDIO_OUT, { recursive: true });
+    cpSync(studioDist, STUDIO_OUT, { recursive: true });
+    log(`  copied dist-desktop  (${dirSize(STUDIO_OUT)})`);
+
+    // ---- summary ----------------------------------------------------------
+    log("staged:");
+    log(`  ax-src        ${dirSize(AX_SRC)}`);
+    log(`    node_modules ${dirSize(join(AX_SRC, "node_modules"))}`);
+    log(`  studio        ${dirSize(STUDIO_OUT)}`);
+    log(`  resources     ${dirSize(RESOURCES)}`);
+    log("done.");
+}
+main().catch((err) => die(err instanceof Error ? err.message : String(err)));

--- a/apps/studio-desktop/scripts/stage-ax-source.ts
+++ b/apps/studio-desktop/scripts/stage-ax-source.ts
@@ -23,6 +23,23 @@
  * per-arch: the staged `node_modules` is host-arch-only. Release builds for the
  * other arch must run this script on that arch.
  *
+ * Dangling-symlink-free node_modules (electron-builder packaging requirement):
+ * bun's default "isolated" linker builds `node_modules/.bun/` (a content store)
+ * and fills every package dir with symlinks into it. electron-builder filters
+ * the top-level `.bun` dot-dir out of `extraResources`, so the store never lands
+ * in the `.app` and the ~482 per-package symlinks dangle - its signing walk then
+ * does a symlink-following `stat` and dies with ENOENT. To avoid this we install
+ * with bun's "hoisted" linker (npm-style flat node_modules of REAL directories,
+ * no `.bun` symlink farm) via a `bunfig.toml` written into the staged tree.
+ *
+ * Hoisted still emits a handful of SELF-CONTAINED relative links (workspace
+ * links like node_modules/@ax/lib -> ../../packages/lib, and `.bin/*` shims)
+ * that resolve INSIDE the staged tree. Those are load-bearing - the classifier
+ * sources import `../../../apps/axctl/...` through the workspace link - and they
+ * pack fine because their targets ship in the same tree. We KEEP those and only
+ * dereference any symlink that escapes the staged tree (would dangle in the
+ * .app); a truly dangling link aborts the stage. See `ensureSymlinkFree`.
+ *
  * Usage:
  *   bun run scripts/stage-ax-source.ts            # stage for host arch
  *   bun run scripts/stage-ax-source.ts --skip-install   # copy source only
@@ -32,7 +49,16 @@
  * idempotent given the same lockfile.
  */
 import { spawnSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+    cpSync,
+    existsSync,
+    mkdirSync,
+    readdirSync,
+    realpathSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -128,6 +154,97 @@ function dirSize(path: string): string {
 }
 
 /**
+ * Recursively collect every symlink under `root`. Returns absolute paths.
+ * We never descend INTO a symlinked dir (its real target lives elsewhere);
+ * we record the link itself and move on.
+ */
+function findSymlinks(root: string, acc: string[] = []): string[] {
+    let entries: ReturnType<typeof readdirSync>;
+    try {
+        entries = readdirSync(root, { withFileTypes: true });
+    } catch {
+        return acc;
+    }
+    for (const ent of entries) {
+        const full = join(root, ent.name);
+        if (ent.isSymbolicLink()) {
+            acc.push(full);
+            continue;
+        }
+        if (ent.isDirectory()) findSymlinks(full, acc);
+    }
+    return acc;
+}
+
+/**
+ * Replace a symlink with a real copy of its (resolved) target. Used as the
+ * dereference fallback for symlinks that escape the staged tree.
+ * Throws if the target can't be resolved (a dangling link in the staged tree
+ * is exactly the packaging defect we must surface, not silently swallow).
+ */
+function dereferenceSymlink(link: string): void {
+    const target = realpathSync(link); // throws on dangling
+    rmSync(link, { force: true });
+    cpSync(target, link, { recursive: true, dereference: true });
+}
+
+/**
+ * Validate the staged tree's symlinks. The defect we guard against is the
+ * `.bun` isolated-store farm whose top-level dot-dir electron-builder filters
+ * out, leaving ~482 per-package symlinks DANGLING in the .app -> its signing
+ * walk stats them and dies with ENOENT.
+ *
+ * The hoisted linker eliminates the `.bun` farm. What remains is a small set of
+ * SELF-CONTAINED relative links that resolve INSIDE the staged tree:
+ *   - workspace links: node_modules/@ax/lib -> ../../packages/lib, axctl ->
+ *     ../apps/axctl, etc. These are load-bearing: the classifier sources use
+ *     relative imports (`../../../apps/axctl/...`) that only resolve when the
+ *     node_modules entry points at the real staged `packages/`/`apps/` dir.
+ *     Dereferencing them (copying the package contents) BREAKS those relative
+ *     imports, so we keep them as internal links.
+ *   - `.bin/*` shims that point within node_modules.
+ * These pack fine (they're not under a filtered dot-dir) and resolve in the
+ * .app because their real targets ship inside the same tree.
+ *
+ * Policy: keep symlinks whose resolved real target stays inside `root`;
+ * dereference any symlink that escapes `root` (would dangle in the .app);
+ * abort on a dangling symlink (the original ENOENT defect).
+ */
+function ensureSymlinkFree(root: string): void {
+    const rootReal = realpathSync(root);
+    const links = findSymlinks(root);
+    if (links.length === 0) {
+        log("  node_modules has no symlinks (hoisted linker)");
+        return;
+    }
+    let internal = 0;
+    let escaped = 0;
+    for (const link of links) {
+        let target: string;
+        try {
+            target = realpathSync(link); // throws on dangling
+        } catch (err) {
+            die(
+                `dangling symlink in staged tree: ${link} ` +
+                    `(${err instanceof Error ? err.message : String(err)}). ` +
+                    "This would dangle in the .app and break electron-builder's signing walk.",
+            );
+        }
+        if (target === rootReal || target.startsWith(`${rootReal}/`)) {
+            internal++; // self-contained; resolves inside the staged tree -> keep
+            continue;
+        }
+        // Escapes the staged tree -> would dangle once packed. Dereference it.
+        dereferenceSymlink(link);
+        escaped++;
+    }
+    log(
+        `  symlinks: ${internal} internal (kept, resolve in-tree)` +
+            (escaped > 0 ? `, ${escaped} external (dereferenced)` : ""),
+    );
+}
+
+/**
  * Build a tailored root package.json for the staged tree:
  *   - workspaces.packages narrowed to the staged members (so `bun install`
  *     doesn't fail on the absent apps/site, apps/studio, etc.)
@@ -201,8 +318,20 @@ async function main() {
     if (skipInstall) {
         log("skipping `bun install` (--skip-install)");
     } else {
-        log("installing host-arch deps: `bun install` in resources/ax-src/ ...");
-        const r = spawnSync("bun", ["install"], {
+        // Force bun's HOISTED linker for the staged tree. The default "isolated"
+        // linker builds `node_modules/.bun/` + ~482 per-package symlinks; that
+        // dot-dir is filtered out of electron-builder's extraResources so the
+        // symlinks dangle in the .app and crash the signing walk with ENOENT.
+        // Hoisted gives an npm-style flat tree of REAL directories (no .bun farm).
+        writeFileSync(
+            join(AX_SRC, "bunfig.toml"),
+            '# Generated by stage-ax-source.ts. Hoisted linker => symlink-free\n' +
+                '# node_modules so electron-builder packs the tree cleanly.\n' +
+                "[install]\nlinker = \"hoisted\"\n",
+        );
+        log("  wrote bunfig.toml (linker = hoisted)");
+        log("installing host-arch deps: `bun install --linker hoisted` in resources/ax-src/ ...");
+        const r = spawnSync("bun", ["install", "--linker", "hoisted"], {
             cwd: AX_SRC,
             stdio: "inherit",
             // Don't let a stale root catalog/lock abort the install; allow
@@ -215,6 +344,9 @@ async function main() {
                     "Native deps were not staged - investigate before relying on this bundle.",
             );
         }
+        // Backstop: keep self-contained internal links, dereference/abort any
+        // symlink that escapes the staged tree (the original ENOENT defect).
+        ensureSymlinkFree(AX_SRC);
         log(`  node_modules staged  (${dirSize(join(AX_SRC, "node_modules"))})`);
     }
 

--- a/apps/studio-desktop/src/app/DesktopApp.ts
+++ b/apps/studio-desktop/src/app/DesktopApp.ts
@@ -1,9 +1,9 @@
 import * as Effect from "effect/Effect";
 
+import * as AxBackendManager from "../backend/AxBackendManager.ts";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
-import * as DesktopWindow from "../window/DesktopWindow.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./DesktopLifecycle.ts";
 import * as DesktopObservability from "./DesktopObservability.ts";
@@ -13,20 +13,18 @@ const { logInfo: logStartupInfo } = DesktopObservability.makeComponentLogger("de
 /**
  * Desktop boot program.
  *
- * Phase 1 (this revision): wait for Electron `ready`, install the app menu +
- * (prod) custom protocol, register lifecycle listeners, then open the window
- * against a manually-running daemon. There is no backend supervisor yet, so we
- * call {@link DesktopWindow.handleBackendReady} directly.
- *
- * Phase 2 replaces step 5 with `AxBackendManager.start` driving readiness (the
- * supervisor signals "ready" and that signal calls `handleBackendReady`).
+ * Phase 2 (this revision): wait for Electron `ready`, install the app menu +
+ * (prod) custom protocol, register lifecycle listeners, then hand control to the
+ * {@link AxBackendManager}. The manager runs attach-vs-spawn arbitration and -
+ * on readiness - sets `backendReady` + opens the window via
+ * `DesktopWindow.handleBackendReady` itself (or, in `attach` mode, immediately).
  */
 const startup = Effect.gen(function* () {
     const electronApp = yield* ElectronApp.ElectronApp;
     const electronMenu = yield* ElectronMenu.ElectronMenu;
     const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
     const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
-    const desktopWindow = yield* DesktopWindow.DesktopWindow;
+    const backendManager = yield* AxBackendManager.AxBackendManager;
     const environment = yield* DesktopEnvironment.DesktopEnvironment;
 
     // 1. Block until the Electron app is ready. Scheme privileges were already
@@ -46,9 +44,10 @@ const startup = Effect.gen(function* () {
     // 4. Wire before-quit / activate / window-all-closed / SIGINT / SIGTERM.
     yield* lifecycle.register;
 
-    // 5. Phase 1: open the window against the manually-running daemon.
-    //    Phase 2 replaces this with AxBackendManager.start driving readiness.
-    yield* desktopWindow.handleBackendReady;
+    // 5. Phase 2: hand control to the backend supervisor. It runs arbitration,
+    //    orders surreal -> ax serve (or attaches to an existing pair), and opens
+    //    the window once the backend is ready.
+    yield* backendManager.start;
     yield* logStartupInfo("startup complete");
 }).pipe(Effect.withSpan("desktop.startup"));
 

--- a/apps/studio-desktop/src/app/DesktopApp.ts
+++ b/apps/studio-desktop/src/app/DesktopApp.ts
@@ -1,0 +1,74 @@
+import * as Effect from "effect/Effect";
+
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as ElectronMenu from "../electron/ElectronMenu.ts";
+import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+import * as DesktopLifecycle from "./DesktopLifecycle.ts";
+import * as DesktopObservability from "./DesktopObservability.ts";
+
+const { logInfo: logStartupInfo } = DesktopObservability.makeComponentLogger("desktop-startup");
+
+/**
+ * Desktop boot program.
+ *
+ * Phase 1 (this revision): wait for Electron `ready`, install the app menu +
+ * (prod) custom protocol, register lifecycle listeners, then open the window
+ * against a manually-running daemon. There is no backend supervisor yet, so we
+ * call {@link DesktopWindow.handleBackendReady} directly.
+ *
+ * Phase 2 replaces step 5 with `AxBackendManager.start` driving readiness (the
+ * supervisor signals "ready" and that signal calls `handleBackendReady`).
+ */
+const startup = Effect.gen(function* () {
+    const electronApp = yield* ElectronApp.ElectronApp;
+    const electronMenu = yield* ElectronMenu.ElectronMenu;
+    const electronProtocol = yield* ElectronProtocol.ElectronProtocol;
+    const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
+    const desktopWindow = yield* DesktopWindow.DesktopWindow;
+    const environment = yield* DesktopEnvironment.DesktopEnvironment;
+
+    // 1. Block until the Electron app is ready. Scheme privileges were already
+    //    registered eagerly in main.ts (must happen before ready).
+    yield* electronApp.whenReady.pipe(Effect.withSpan("desktop.electron.whenReady"));
+    yield* logStartupInfo("app ready");
+
+    // 2. In production, register the `ax://` custom protocol that serves the
+    //    built studio SPA. In development studio is served by Vite, so skip it.
+    if (!environment.isDevelopment) {
+        yield* electronProtocol.registerDesktopFileProtocol;
+    }
+
+    // 3. Install the application menu (macOS App/Edit/View; cleared elsewhere).
+    yield* electronMenu.installApplicationMenu;
+
+    // 4. Wire before-quit / activate / window-all-closed / SIGINT / SIGTERM.
+    yield* lifecycle.register;
+
+    // 5. Phase 1: open the window against the manually-running daemon.
+    //    Phase 2 replaces this with AxBackendManager.start driving readiness.
+    yield* desktopWindow.handleBackendReady;
+    yield* logStartupInfo("startup complete");
+}).pipe(Effect.withSpan("desktop.startup"));
+
+const scopedProgram = Effect.scoped(
+    Effect.gen(function* () {
+        yield* Effect.annotateLogsScoped({ scope: "desktop" });
+        yield* Effect.annotateCurrentSpan({ scope: "desktop" });
+
+        const shutdown = yield* DesktopLifecycle.DesktopShutdown;
+
+        // Mark shutdown complete when the program scope closes, so before-quit
+        // handlers awaiting completion unblock even on a Phase-1 (no supervisor)
+        // shutdown path.
+        yield* Effect.addFinalizer(() => shutdown.markComplete);
+
+        yield* startup;
+
+        // Stay alive until something requests shutdown (before-quit / signal).
+        yield* shutdown.awaitRequest;
+    }),
+);
+
+export const program = scopedProgram.pipe(Effect.withSpan("desktop.app"));

--- a/apps/studio-desktop/src/app/DesktopApp.ts
+++ b/apps/studio-desktop/src/app/DesktopApp.ts
@@ -1,3 +1,4 @@
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 
 import * as AxBackendManager from "../backend/AxBackendManager.ts";
@@ -71,6 +72,7 @@ const scopedProgram = Effect.scoped(
         yield* Effect.annotateCurrentSpan({ scope: "desktop" });
 
         const shutdown = yield* DesktopLifecycle.DesktopShutdown;
+        const backendManager = yield* AxBackendManager.AxBackendManager;
 
         // Mark shutdown complete when the program scope closes, so before-quit
         // handlers awaiting completion unblock even on a Phase-1 (no supervisor)
@@ -81,6 +83,22 @@ const scopedProgram = Effect.scoped(
 
         // Stay alive until something requests shutdown (before-quit / signal).
         yield* shutdown.awaitRequest;
+
+        // Explicitly tear down the supervised backend BEFORE the scope-close
+        // `markComplete` finalizer unblocks the before-quit handler (the manager's
+        // own stop finalizer runs on the outer layer scope, which races app exit
+        // and orphans the spawned processes). Bounded by a timeout so a stuck
+        // stop can never hang the quit: the spawned `bun ax serve` ignores
+        // SIGTERM, so teardown depends on the supervisor's forceKill SIGKILL; if
+        // that doesn't land in time we still proceed to quit rather than wedge
+        // the app. `stop` is idempotent (the finalizer backstop is harmless).
+        // KNOWN ISSUE (found by live spawn dogfooding): if forceKill doesn't
+        // escalate, the spawned ax-serve can outlive the app - see the
+        // SupervisedProcess SIGKILL-escalation TODO.
+        yield* backendManager.stop().pipe(
+            Effect.timeout(Duration.seconds(6)),
+            Effect.ignore,
+        );
     }),
 );
 

--- a/apps/studio-desktop/src/app/DesktopApp.ts
+++ b/apps/studio-desktop/src/app/DesktopApp.ts
@@ -4,6 +4,7 @@ import * as AxBackendManager from "../backend/AxBackendManager.ts";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
+import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./DesktopLifecycle.ts";
 import * as DesktopObservability from "./DesktopObservability.ts";
@@ -26,6 +27,7 @@ const startup = Effect.gen(function* () {
     const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
     const backendManager = yield* AxBackendManager.AxBackendManager;
     const environment = yield* DesktopEnvironment.DesktopEnvironment;
+    const updates = yield* DesktopUpdates.DesktopUpdates;
 
     // 1. Block until the Electron app is ready. Scheme privileges were already
     //    registered eagerly in main.ts (must happen before ready).
@@ -48,6 +50,18 @@ const startup = Effect.gen(function* () {
     //    orders surreal -> ax serve (or attaches to an existing pair), and opens
     //    the window once the backend is ready.
     yield* backendManager.start;
+
+    // 6. Phase 3: kick off an electron-updater check. The update feed comes from
+    //    electron-builder's GitHub `publish` config, baked into `app-update.yml`
+    //    at package time - there is no feed in development, so a check would only
+    //    error. Skip it in dev, and never block boot on it: fork it (it catches +
+    //    logs its own failures, so a failed check can never crash the app).
+    if (environment.isDevelopment) {
+        yield* logStartupInfo("skipping update check in dev (no update feed)");
+    } else {
+        yield* Effect.forkDetach(updates.checkForUpdates);
+    }
+
     yield* logStartupInfo("startup complete");
 }).pipe(Effect.withSpan("desktop.startup"));
 

--- a/apps/studio-desktop/src/app/DesktopEnvironment.ts
+++ b/apps/studio-desktop/src/app/DesktopEnvironment.ts
@@ -27,6 +27,16 @@ export interface MakeDesktopEnvironmentInput {
     readonly surrealBinaryPath: string;
     /** Absolute path to the bundled `bun` binary. */
     readonly bunBinaryPath: string;
+    /**
+     * `app.getPath("home")` (or `process.env.HOME`). Used to derive the
+     * canonical ax data dir so desktop and the CLI daemon agree on it.
+     */
+    readonly homeDir: string;
+    /**
+     * `process.env.AX_DATA_DIR` if set. Overrides the derived default, matching
+     * `@ax/lib` config + the daemon install scripts.
+     */
+    readonly axDataDirOverride: string | undefined;
 }
 
 export interface DesktopEnvironmentShape {
@@ -58,11 +68,26 @@ export interface DesktopEnvironmentShape {
      */
     readonly studioStaticDir: string;
     /**
-     * ax data dir (SurrealDB + friends). Sensible default for now;
-     * Phase 2 Task 2.1 reconciles this with the CLI's canonical data dir.
+     * Canonical ax data dir, authoritative across desktop + CLI daemon.
+     * Resolution mirrors `@ax/lib` config (`packages/lib/src/config.ts`) and the
+     * daemon install scripts (`scripts/install-daemon.sh`, `db-start.sh`):
+     * `$AX_DATA_DIR ?? $HOME/.local/share/ax`. The plist's rocksdb URL is
+     * `rocksdb://<axDataDir>/db` - the surreal arg appends `/db`, so `axDataDir`
+     * is the parent dir, not the rocksdb path itself.
      */
     readonly axDataDir: string;
 }
+
+/**
+ * Canonical ax data dir resolution. Single source of truth shared with the CLI
+ * daemon: `$AX_DATA_DIR` env override, else `$HOME/.local/share/ax`. Kept as a
+ * standalone export so it can be unit-tested without an Electron `app`.
+ */
+export const resolveAxDataDir = (
+    homeDir: string,
+    axDataDirOverride: string | undefined,
+    path: Path.Path,
+): string => axDataDirOverride ?? path.join(homeDir, ".local", "share", "ax");
 
 export class DesktopEnvironment extends Context.Service<
     DesktopEnvironment,
@@ -96,7 +121,7 @@ export const make = (
         preloadPath: path.join(input.dirname, "preload.cjs"),
         axSourceEntry,
         studioStaticDir,
-        axDataDir: path.join(input.userDataDir, "db"),
+        axDataDir: resolveAxDataDir(input.homeDir, input.axDataDirOverride, path),
     });
 };
 

--- a/apps/studio-desktop/src/app/DesktopEnvironment.ts
+++ b/apps/studio-desktop/src/app/DesktopEnvironment.ts
@@ -42,6 +42,11 @@ export interface DesktopEnvironmentShape {
     readonly surrealBinaryPath: string;
     readonly bunBinaryPath: string;
     /**
+     * Absolute path to the bundled preload script. Sits beside the bundled
+     * `main.cjs` in `dist-electron/` (i.e. the main process `dirname`).
+     */
+    readonly preloadPath: string;
+    /**
      * Entry point for `ax serve` source.
      * Packaged -> `<appRoot>/ax-src/apps/axctl/src/cli/index.ts`;
      * dev -> repo path.
@@ -88,6 +93,7 @@ export const make = (
         logsDir: path.join(input.userDataDir, "logs"),
         surrealBinaryPath: input.surrealBinaryPath,
         bunBinaryPath: input.bunBinaryPath,
+        preloadPath: path.join(input.dirname, "preload.cjs"),
         axSourceEntry,
         studioStaticDir,
         axDataDir: path.join(input.userDataDir, "db"),

--- a/apps/studio-desktop/src/app/DesktopEnvironment.ts
+++ b/apps/studio-desktop/src/app/DesktopEnvironment.ts
@@ -1,0 +1,104 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+/**
+ * Values resolved by `main.ts` from the Electron `app` object (and Node `process`)
+ * and fed into {@link layer}. Nothing here imports `electron` at module scope -
+ * the foundation modules stay framework-agnostic so they can be unit-tested.
+ */
+export interface MakeDesktopEnvironmentInput {
+    /** `__dirname` of the bundled main process (e.g. `<app>/dist-electron`). */
+    readonly dirname: string;
+    /** Repo root in dev; ignored when packaged. Resolved by `main.ts`. */
+    readonly repoRoot: string;
+    /** `!app.isPackaged`. */
+    readonly isDevelopment: boolean;
+    /** `process.resourcesPath` - only meaningful when packaged. */
+    readonly resourcesPath: string;
+    /** `app.getPath("userData")`. */
+    readonly userDataDir: string;
+    /** `process.platform`. */
+    readonly platform: NodeJS.Platform;
+    /** `process.arch`. */
+    readonly processArch: string;
+    /** Absolute path to the bundled `surreal` binary. */
+    readonly surrealBinaryPath: string;
+    /** Absolute path to the bundled `bun` binary. */
+    readonly bunBinaryPath: string;
+}
+
+export interface DesktopEnvironmentShape {
+    /** The `node:path` module, via Effect's Path service. */
+    readonly path: Path.Path;
+    readonly isDevelopment: boolean;
+    readonly platform: NodeJS.Platform;
+    readonly processArch: string;
+    /** Packaged -> `process.resourcesPath`; dev -> repo root. */
+    readonly appRoot: string;
+    readonly userDataDir: string;
+    readonly logsDir: string;
+    readonly surrealBinaryPath: string;
+    readonly bunBinaryPath: string;
+    /**
+     * Entry point for `ax serve` source.
+     * Packaged -> `<appRoot>/ax-src/apps/axctl/src/cli/index.ts`;
+     * dev -> repo path.
+     */
+    readonly axSourceEntry: string;
+    /**
+     * Built studio SPA assets.
+     * Packaged -> `<appRoot>/studio`; dev -> `<repoRoot>/apps/studio/dist-desktop`.
+     */
+    readonly studioStaticDir: string;
+    /**
+     * ax data dir (SurrealDB + friends). Sensible default for now;
+     * Phase 2 Task 2.1 reconciles this with the CLI's canonical data dir.
+     */
+    readonly axDataDir: string;
+}
+
+export class DesktopEnvironment extends Context.Service<
+    DesktopEnvironment,
+    DesktopEnvironmentShape
+>()("@ax/studio-desktop/app/DesktopEnvironment") {}
+
+export const make = (
+    input: MakeDesktopEnvironmentInput,
+    path: Path.Path,
+): DesktopEnvironmentShape => {
+    const appRoot = input.isDevelopment ? input.repoRoot : input.resourcesPath;
+
+    const axSourceEntry = input.isDevelopment
+        ? path.join(input.repoRoot, "apps/axctl/src/cli/index.ts")
+        : path.join(appRoot, "ax-src/apps/axctl/src/cli/index.ts");
+
+    const studioStaticDir = input.isDevelopment
+        ? path.join(input.repoRoot, "apps/studio/dist-desktop")
+        : path.join(appRoot, "studio");
+
+    return DesktopEnvironment.of({
+        path,
+        isDevelopment: input.isDevelopment,
+        platform: input.platform,
+        processArch: input.processArch,
+        appRoot,
+        userDataDir: input.userDataDir,
+        logsDir: path.join(input.userDataDir, "logs"),
+        surrealBinaryPath: input.surrealBinaryPath,
+        bunBinaryPath: input.bunBinaryPath,
+        axSourceEntry,
+        studioStaticDir,
+        axDataDir: path.join(input.userDataDir, "db"),
+    });
+};
+
+export const layer = (input: MakeDesktopEnvironmentInput) =>
+    Layer.effect(
+        DesktopEnvironment,
+        Effect.gen(function* () {
+            const path = yield* Path.Path;
+            return make(input, path);
+        }),
+    );

--- a/apps/studio-desktop/src/app/DesktopEnvironment.ts
+++ b/apps/studio-desktop/src/app/DesktopEnvironment.ts
@@ -23,9 +23,17 @@ export interface MakeDesktopEnvironmentInput {
     readonly platform: NodeJS.Platform;
     /** `process.arch`. */
     readonly processArch: string;
-    /** Absolute path to the bundled `surreal` binary. */
+    /**
+     * Dev fallback for `surreal` (e.g. `"surreal"` for a PATH lookup). When
+     * packaged this is ignored - the path resolves to the vendored per-arch
+     * binary under `<resourcesPath>/bin/<arch>/surreal`.
+     */
     readonly surrealBinaryPath: string;
-    /** Absolute path to the bundled `bun` binary. */
+    /**
+     * Dev fallback for `bun` (e.g. `process.execPath` or `"bun"`). When packaged
+     * this is ignored - the path resolves to the vendored per-arch binary under
+     * `<resourcesPath>/bin/<arch>/bun`.
+     */
     readonly bunBinaryPath: string;
     /**
      * `app.getPath("home")` (or `process.env.HOME`). Used to derive the
@@ -89,6 +97,44 @@ export const resolveAxDataDir = (
     path: Path.Path,
 ): string => axDataDirOverride ?? path.join(homeDir, ".local", "share", "ax");
 
+/**
+ * Map `process.arch` to the directory name `scripts/fetch-binaries.ts` writes
+ * vendored binaries under (`resources/bin/<arch>/`). Only the two macOS arches
+ * we ship are recognised; anything else returns the raw arch so the resulting
+ * path is obviously wrong (fail loud) rather than silently mismatched.
+ */
+export const binArchDir = (processArch: string): string => {
+    if (processArch === "arm64") return "arm64";
+    if (processArch === "x64") return "x64";
+    return processArch;
+};
+
+/**
+ * Resolve the absolute path to a vendored binary. Packaged builds use the
+ * per-arch binary bundled under `<resourcesPath>/bin/<arch>/` by
+ * `fetch-binaries.ts` (staged into Electron resources at build time). Dev builds
+ * fall back to the supplied PATH-lookup placeholder (e.g. `"surreal"`, or
+ * `process.execPath` for bun).
+ */
+export const resolveBinaryPath = (
+    args: {
+        readonly isDevelopment: boolean;
+        readonly resourcesPath: string;
+        readonly processArch: string;
+        readonly name: "surreal" | "bun";
+        readonly devFallback: string;
+    },
+    path: Path.Path,
+): string =>
+    args.isDevelopment
+        ? args.devFallback
+        : path.join(
+              args.resourcesPath,
+              "bin",
+              binArchDir(args.processArch),
+              args.name,
+          );
+
 export class DesktopEnvironment extends Context.Service<
     DesktopEnvironment,
     DesktopEnvironmentShape
@@ -116,8 +162,26 @@ export const make = (
         appRoot,
         userDataDir: input.userDataDir,
         logsDir: path.join(input.userDataDir, "logs"),
-        surrealBinaryPath: input.surrealBinaryPath,
-        bunBinaryPath: input.bunBinaryPath,
+        surrealBinaryPath: resolveBinaryPath(
+            {
+                isDevelopment: input.isDevelopment,
+                resourcesPath: input.resourcesPath,
+                processArch: input.processArch,
+                name: "surreal",
+                devFallback: input.surrealBinaryPath,
+            },
+            path,
+        ),
+        bunBinaryPath: resolveBinaryPath(
+            {
+                isDevelopment: input.isDevelopment,
+                resourcesPath: input.resourcesPath,
+                processArch: input.processArch,
+                name: "bun",
+                devFallback: input.bunBinaryPath,
+            },
+            path,
+        ),
         preloadPath: path.join(input.dirname, "preload.cjs"),
         axSourceEntry,
         studioStaticDir,

--- a/apps/studio-desktop/src/app/DesktopLifecycle.ts
+++ b/apps/studio-desktop/src/app/DesktopLifecycle.ts
@@ -1,0 +1,232 @@
+import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Scope from "effect/Scope";
+
+import type * as Electron from "electron";
+
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+import * as DesktopObservability from "./DesktopObservability.ts";
+import * as DesktopState from "./DesktopState.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+
+export interface DesktopShutdownShape {
+  readonly request: Effect.Effect<void>;
+  readonly awaitRequest: Effect.Effect<void>;
+  readonly markComplete: Effect.Effect<void>;
+  readonly awaitComplete: Effect.Effect<void>;
+  readonly isComplete: Effect.Effect<boolean>;
+}
+
+export class DesktopShutdown extends Context.Service<DesktopShutdown, DesktopShutdownShape>()(
+  "@ax/studio-desktop/app/DesktopLifecycle/DesktopShutdown",
+) {}
+
+const makeShutdown = Effect.gen(function* () {
+  const requested = yield* Deferred.make<void>();
+  const completed = yield* Deferred.make<void>();
+  const completedRef = yield* Ref.make(false);
+
+  return DesktopShutdown.of({
+    request: Deferred.succeed(requested, undefined).pipe(Effect.asVoid),
+    awaitRequest: Deferred.await(requested),
+    markComplete: Ref.set(completedRef, true).pipe(
+      Effect.andThen(Deferred.succeed(completed, undefined)),
+      Effect.asVoid,
+    ),
+    awaitComplete: Deferred.await(completed),
+    isComplete: Ref.get(completedRef),
+  });
+});
+
+export const layerShutdown = Layer.effect(DesktopShutdown, makeShutdown);
+
+export type DesktopLifecycleRuntimeServices =
+  | DesktopEnvironment.DesktopEnvironment
+  | DesktopShutdown
+  | DesktopState.DesktopState
+  | DesktopWindow.DesktopWindow
+  | ElectronApp.ElectronApp;
+
+export interface DesktopLifecycleShape {
+  readonly relaunch: (
+    reason: string,
+  ) => Effect.Effect<void, never, DesktopLifecycleRuntimeServices>;
+  readonly register: Effect.Effect<void, never, Scope.Scope | DesktopLifecycleRuntimeServices>;
+}
+
+/**
+ * @effect-expect-leaking DesktopEnvironment | DesktopShutdown | DesktopState | DesktopWindow | ElectronApp
+ */
+export class DesktopLifecycle extends Context.Service<DesktopLifecycle, DesktopLifecycleShape>()(
+  "@ax/studio-desktop/app/DesktopLifecycle",
+) {}
+
+const { logInfo: logLifecycleInfo, logError: logLifecycleError } =
+  DesktopObservability.makeComponentLogger("desktop-lifecycle");
+
+function addScopedListener<Args extends ReadonlyArray<unknown>>(
+  target: unknown,
+  eventName: string,
+  listener: (...args: Args) => void,
+): Effect.Effect<void, never, Scope.Scope> {
+  const eventTarget = target as {
+    on: (eventName: string, listener: (...args: Array<unknown>) => void) => unknown;
+    removeListener: (eventName: string, listener: (...args: Array<unknown>) => void) => unknown;
+  };
+  const untypedListener = listener as unknown as (...args: Array<unknown>) => void;
+  return Effect.acquireRelease(
+    Effect.sync(() => {
+      eventTarget.on(eventName, untypedListener);
+    }),
+    () =>
+      Effect.sync(() => {
+        eventTarget.removeListener(eventName, untypedListener);
+      }),
+  ).pipe(Effect.asVoid);
+}
+
+const requestDesktopShutdownAndWait = Effect.fn("desktop.lifecycle.requestShutdownAndWait")(
+  function* (): Effect.fn.Return<void, never, DesktopShutdown> {
+    const shutdown = yield* DesktopShutdown;
+    yield* shutdown.request;
+    yield* shutdown.awaitComplete;
+  },
+);
+
+function handleBeforeQuit(
+  event: Electron.Event,
+  runEffect: <A, E>(effect: Effect.Effect<A, E, DesktopLifecycleRuntimeServices>) => Promise<A>,
+  allowQuit: () => boolean,
+  markQuitAllowed: () => void,
+): void {
+  if (allowQuit()) {
+    void runEffect(
+      Effect.gen(function* () {
+        const state = yield* DesktopState.DesktopState;
+        yield* Ref.set(state.quitting, true);
+        yield* logLifecycleInfo("before-quit received");
+      }).pipe(Effect.withSpan("desktop.lifecycle.beforeQuit")),
+    );
+    return;
+  }
+
+  event.preventDefault();
+  void runEffect(
+    Effect.gen(function* () {
+      const state = yield* DesktopState.DesktopState;
+      yield* Ref.set(state.quitting, true);
+      yield* logLifecycleInfo("before-quit received");
+      yield* requestDesktopShutdownAndWait();
+    }).pipe(Effect.withSpan("desktop.lifecycle.beforeQuit")),
+  ).finally(() => {
+    markQuitAllowed();
+    void runEffect(
+      Effect.gen(function* () {
+        const electronApp = yield* ElectronApp.ElectronApp;
+        yield* electronApp.quit;
+      }).pipe(Effect.withSpan("desktop.lifecycle.quitAfterShutdown")),
+    );
+  });
+}
+
+function quitFromSignal(
+  signal: "SIGINT" | "SIGTERM",
+  runEffect: <A, E>(effect: Effect.Effect<A, E, DesktopLifecycleRuntimeServices>) => Promise<A>,
+): void {
+  void runEffect(
+    Effect.gen(function* () {
+      yield* Effect.annotateCurrentSpan({ signal });
+      const electronApp = yield* ElectronApp.ElectronApp;
+      const state = yield* DesktopState.DesktopState;
+      const wasQuitting = yield* Ref.getAndSet(state.quitting, true);
+      if (wasQuitting) return;
+      yield* logLifecycleInfo("process signal received", { signal });
+      yield* requestDesktopShutdownAndWait();
+      yield* electronApp.quit;
+    }).pipe(Effect.withSpan("desktop.lifecycle.processSignal")),
+  );
+}
+
+export const layer = Layer.succeed(
+  DesktopLifecycle,
+  DesktopLifecycle.of({
+    relaunch: Effect.fn("desktop.lifecycle.relaunch")(function* (reason) {
+      const electronApp = yield* ElectronApp.ElectronApp;
+      const environment = yield* DesktopEnvironment.DesktopEnvironment;
+      const state = yield* DesktopState.DesktopState;
+      yield* logLifecycleInfo("desktop relaunch requested", { reason });
+      yield* Effect.gen(function* () {
+        yield* Effect.yieldNow;
+        yield* Ref.set(state.quitting, true);
+        yield* requestDesktopShutdownAndWait();
+        if (environment.isDevelopment) {
+          yield* electronApp.exit(75);
+          return;
+        }
+        yield* electronApp.relaunch({
+          execPath: process.execPath,
+          args: process.argv.slice(1),
+        });
+        yield* electronApp.exit(0);
+      }).pipe(
+        Effect.catchCause((cause) =>
+          logLifecycleError("desktop relaunch failed", {
+            cause: Cause.pretty(cause),
+          }),
+        ),
+        Effect.forkDetach,
+        Effect.asVoid,
+      );
+    }),
+    register: Effect.gen(function* () {
+      const electronApp = yield* ElectronApp.ElectronApp;
+      const environment = yield* DesktopEnvironment.DesktopEnvironment;
+      const context = yield* Effect.context<DesktopLifecycleRuntimeServices>();
+      const runEffect = Effect.runPromiseWith(context);
+      let quitAllowed = false;
+      yield* electronApp.on("before-quit", (event: Electron.Event) => {
+        handleBeforeQuit(
+          event,
+          runEffect,
+          () => quitAllowed,
+          () => {
+            quitAllowed = true;
+          },
+        );
+      });
+      yield* electronApp.on("activate", () => {
+        void runEffect(
+          Effect.gen(function* () {
+            const desktopWindow = yield* DesktopWindow.DesktopWindow;
+            yield* desktopWindow.activate;
+          }).pipe(Effect.withSpan("desktop.lifecycle.activate")),
+        );
+      });
+      yield* electronApp.on("window-all-closed", () => {
+        void runEffect(
+          Effect.gen(function* () {
+            const app = yield* ElectronApp.ElectronApp;
+            const state = yield* DesktopState.DesktopState;
+            if (environment.platform !== "darwin" && !(yield* Ref.get(state.quitting))) {
+              yield* app.quit;
+            }
+          }).pipe(Effect.withSpan("desktop.lifecycle.windowAllClosed")),
+        );
+      });
+
+      if (environment.platform !== "win32") {
+        yield* addScopedListener(process, "SIGINT", () => {
+          quitFromSignal("SIGINT", runEffect);
+        });
+        yield* addScopedListener(process, "SIGTERM", () => {
+          quitFromSignal("SIGTERM", runEffect);
+        });
+      }
+    }).pipe(Effect.withSpan("desktop.lifecycle.register")),
+  }),
+);

--- a/apps/studio-desktop/src/app/DesktopObservability.ts
+++ b/apps/studio-desktop/src/app/DesktopObservability.ts
@@ -1,0 +1,291 @@
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as Ref from "effect/Ref";
+import * as Semaphore from "effect/Semaphore";
+
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+
+const DESKTOP_LOG_FILE_MAX_BYTES = 10 * 1024 * 1024;
+const DESKTOP_LOG_FILE_MAX_FILES = 10;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+// ---------------------------------------------------------------------------
+// Component loggers
+// ---------------------------------------------------------------------------
+
+export type DesktopLogAnnotations = Record<string, unknown>;
+
+export interface DesktopComponentLogger {
+    readonly annotate: <A, E, R>(
+        effect: Effect.Effect<A, E, R>,
+        annotations?: DesktopLogAnnotations,
+    ) => Effect.Effect<A, E, R>;
+    readonly logInfo: (message: string, annotations?: DesktopLogAnnotations) => Effect.Effect<void>;
+    readonly logWarning: (
+        message: string,
+        annotations?: DesktopLogAnnotations,
+    ) => Effect.Effect<void>;
+    readonly logError: (
+        message: string,
+        annotations?: DesktopLogAnnotations,
+    ) => Effect.Effect<void>;
+}
+
+export function makeComponentLogger(component: string): DesktopComponentLogger {
+    const annotate: DesktopComponentLogger["annotate"] = (effect, annotations) =>
+        effect.pipe(
+            Effect.annotateLogs({
+                component,
+                ...annotations,
+            }),
+        );
+
+    return {
+        annotate,
+        logInfo: (message, annotations) => annotate(Effect.logInfo(message), annotations),
+        logWarning: (message, annotations) => annotate(Effect.logWarning(message), annotations),
+        logError: (message, annotations) => annotate(Effect.logError(message), annotations),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Rotating log file writer
+// ---------------------------------------------------------------------------
+
+export interface RotatingLogFileWriter {
+    readonly writeBytes: (chunk: Uint8Array) => Effect.Effect<void>;
+    readonly writeText: (chunk: string) => Effect.Effect<void>;
+}
+
+class DesktopLogFileWriterConfigurationError extends Data.TaggedError(
+    "DesktopLogFileWriterConfigurationError",
+)<{
+    readonly option: "maxBytes" | "maxFiles";
+    readonly value: number;
+}> {
+    override get message() {
+        return `${this.option} must be >= 1 (received ${this.value})`;
+    }
+}
+
+type DesktopLogFileWriterError =
+    | DesktopLogFileWriterConfigurationError
+    | PlatformError.PlatformError;
+
+const refreshFileSize = (
+    fileSystem: FileSystem.FileSystem,
+    filePath: string,
+): Effect.Effect<number, never> =>
+    fileSystem.stat(filePath).pipe(
+        Effect.map((stat) => Number(stat.size)),
+        Effect.orElseSucceed(() => 0),
+    );
+
+export const makeRotatingLogFileWriter = Effect.fn("makeRotatingLogFileWriter")(function* (input: {
+    readonly filePath: string;
+    readonly maxBytes?: number;
+    readonly maxFiles?: number;
+}): Effect.fn.Return<
+    RotatingLogFileWriter,
+    DesktopLogFileWriterError,
+    FileSystem.FileSystem | Path.Path
+> {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const maxBytes = input.maxBytes ?? DESKTOP_LOG_FILE_MAX_BYTES;
+    const maxFiles = input.maxFiles ?? DESKTOP_LOG_FILE_MAX_FILES;
+    const directory = path.dirname(input.filePath);
+    const baseName = path.basename(input.filePath);
+
+    if (maxBytes < 1) {
+        return yield* new DesktopLogFileWriterConfigurationError({
+            option: "maxBytes",
+            value: maxBytes,
+        });
+    }
+    if (maxFiles < 1) {
+        return yield* new DesktopLogFileWriterConfigurationError({
+            option: "maxFiles",
+            value: maxFiles,
+        });
+    }
+
+    yield* fileSystem.makeDirectory(directory, { recursive: true });
+
+    const withSuffix = (index: number) => `${input.filePath}.${index}`;
+    const currentSize = yield* Ref.make(yield* refreshFileSize(fileSystem, input.filePath));
+    const mutex = yield* Semaphore.make(1);
+
+    const pruneOverflowBackups = Effect.gen(function* () {
+        const entries = yield* fileSystem
+            .readDirectory(directory)
+            .pipe(Effect.orElseSucceed(() => []));
+        for (const entry of entries) {
+            if (!entry.startsWith(`${baseName}.`)) continue;
+            const suffix = Number(entry.slice(baseName.length + 1));
+            if (!Number.isInteger(suffix) || suffix <= maxFiles) continue;
+            yield* fileSystem.remove(path.join(directory, entry), { force: true }).pipe(Effect.ignore);
+        }
+    });
+
+    const rotate = Effect.gen(function* () {
+        yield* fileSystem.remove(withSuffix(maxFiles), { force: true }).pipe(Effect.ignore);
+        for (let index = maxFiles - 1; index >= 1; index -= 1) {
+            const source = withSuffix(index);
+            const sourceExists = yield* fileSystem
+                .exists(source)
+                .pipe(Effect.orElseSucceed(() => false));
+            if (sourceExists) {
+                yield* fileSystem.rename(source, withSuffix(index + 1));
+            }
+        }
+        const currentExists = yield* fileSystem
+            .exists(input.filePath)
+            .pipe(Effect.orElseSucceed(() => false));
+        if (currentExists) {
+            yield* fileSystem.rename(input.filePath, withSuffix(1));
+        }
+        yield* Ref.set(currentSize, 0);
+    }).pipe(
+        Effect.catch(() =>
+            refreshFileSize(fileSystem, input.filePath).pipe(
+                Effect.flatMap((size) => Ref.set(currentSize, size)),
+            ),
+        ),
+    );
+
+    const writeBytes = (chunk: Uint8Array): Effect.Effect<void> => {
+        if (chunk.byteLength === 0) return Effect.void;
+
+        return mutex.withPermits(1)(
+            Effect.gen(function* () {
+                const beforeSize = yield* Ref.get(currentSize);
+                if (beforeSize > 0 && beforeSize + chunk.byteLength > maxBytes) {
+                    yield* rotate;
+                }
+
+                yield* fileSystem.writeFile(input.filePath, chunk, { flag: "a" });
+                const afterSize = (yield* Ref.get(currentSize)) + chunk.byteLength;
+                yield* Ref.set(currentSize, afterSize);
+
+                if (afterSize > maxBytes) {
+                    yield* rotate;
+                }
+            }).pipe(
+                Effect.catch(() =>
+                    refreshFileSize(fileSystem, input.filePath).pipe(
+                        Effect.flatMap((size) => Ref.set(currentSize, size)),
+                    ),
+                ),
+            ),
+        );
+    };
+
+    yield* pruneOverflowBackups;
+
+    return {
+        writeBytes,
+        writeText: (chunk) => writeBytes(textEncoder.encode(chunk)),
+    } satisfies RotatingLogFileWriter;
+});
+
+// ---------------------------------------------------------------------------
+// Backend output log - rotating file capture of supervised process stdout/stderr
+// ---------------------------------------------------------------------------
+
+export interface DesktopBackendOutputLogShape {
+    readonly writeSessionBoundary: (input: {
+        readonly phase: "START" | "END";
+        readonly details: string;
+    }) => Effect.Effect<void>;
+    readonly writeOutputChunk: (
+        streamName: "stdout" | "stderr",
+        chunk: Uint8Array,
+    ) => Effect.Effect<void>;
+}
+
+export class DesktopBackendOutputLog extends Context.Service<
+    DesktopBackendOutputLog,
+    DesktopBackendOutputLogShape
+>()("@ax/studio-desktop/app/DesktopObservability/DesktopBackendOutputLog") {}
+
+const sanitizeLogValue = (value: string): string => value.replace(/\s+/g, " ").trim();
+
+export const DesktopBackendOutputLogNoop: DesktopBackendOutputLogShape = {
+    writeSessionBoundary: () => Effect.void,
+    writeOutputChunk: () => Effect.void,
+};
+
+const formatLine = (input: {
+    readonly level: "INFO" | "ERROR";
+    readonly message: string;
+}): string => `${new Date().toISOString()} ${input.level} ${input.message}\n`;
+
+const writeDevelopmentConsoleOutput = (
+    streamName: "stdout" | "stderr",
+    chunk: Uint8Array,
+): Effect.Effect<void> =>
+    Effect.sync(() => {
+        const output = streamName === "stderr" ? process.stderr : process.stdout;
+        output.write(chunk);
+    }).pipe(Effect.ignore);
+
+const backendOutputLogLayer = Layer.effect(
+    DesktopBackendOutputLog,
+    Effect.gen(function* () {
+        const environment = yield* DesktopEnvironment.DesktopEnvironment;
+
+        const writer = yield* makeRotatingLogFileWriter({
+            filePath: environment.path.join(environment.logsDir, "backend-child.log"),
+        }).pipe(Effect.option);
+
+        return Option.match(writer, {
+            onNone: () => DesktopBackendOutputLogNoop,
+            onSome: (logFile) =>
+                ({
+                    writeSessionBoundary: ({ phase, details }) =>
+                        logFile.writeText(
+                            formatLine({
+                                level: "INFO",
+                                message: `backend child process session ${phase.toLowerCase()} ${sanitizeLogValue(
+                                    details,
+                                )}`,
+                            }),
+                        ),
+                    writeOutputChunk: (streamName, chunk) =>
+                        Effect.gen(function* () {
+                            if (environment.isDevelopment) {
+                                yield* writeDevelopmentConsoleOutput(streamName, chunk);
+                            }
+                            yield* logFile.writeText(
+                                formatLine({
+                                    level: streamName === "stderr" ? "ERROR" : "INFO",
+                                    message: `[${streamName}] ${sanitizeLogValue(
+                                        textDecoder.decode(chunk),
+                                    )}`,
+                                }),
+                            );
+                        }),
+                }) satisfies DesktopBackendOutputLogShape,
+        });
+    }),
+);
+
+/**
+ * The Noop backend-output-log layer. Use when no DesktopEnvironment is available
+ * (or in tests) so the supervisor can run without writing files.
+ */
+export const backendOutputLogNoopLayer = Layer.succeed(
+    DesktopBackendOutputLog,
+    DesktopBackendOutputLogNoop,
+);
+
+export const layer = backendOutputLogLayer;

--- a/apps/studio-desktop/src/app/DesktopState.ts
+++ b/apps/studio-desktop/src/app/DesktopState.ts
@@ -1,0 +1,23 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+
+export interface DesktopStateShape {
+    readonly backendReady: Ref.Ref<boolean>;
+    readonly quitting: Ref.Ref<boolean>;
+}
+
+export class DesktopState extends Context.Service<DesktopState, DesktopStateShape>()(
+    "@ax/studio-desktop/app/DesktopState",
+) {}
+
+export const layer = Layer.effect(
+    DesktopState,
+    Effect.gen(function* () {
+        return DesktopState.of({
+            backendReady: yield* Ref.make(false),
+            quitting: yield* Ref.make(false),
+        });
+    }),
+);

--- a/apps/studio-desktop/src/backend/AxBackendManager.test.ts
+++ b/apps/studio-desktop/src/backend/AxBackendManager.test.ts
@@ -14,6 +14,7 @@ import type { ArbitrationDecision } from "./AxDaemonArbitration.ts";
 import type {
     SupervisedProcess,
     SupervisedProcessConfig,
+    SupervisedProcessHooks,
     SupervisedProcessSnapshot,
 } from "./SupervisedProcess.ts";
 
@@ -28,13 +29,18 @@ interface FakeProcessEvent {
 
 /**
  * Build a stub `makeProcess` factory that records start/stop ordering across
- * every supervised process it vends, and never touches a real OS process.
+ * every supervised process it vends, and never touches a real OS process. Also
+ * captures the lifecycle `hooks` passed for each process so a test can fire
+ * them (e.g. simulate surreal's `onExit` -> ax-serve bounce).
  */
 const makeFakeProcessFactory = Effect.gen(function* () {
     const events = yield* Ref.make<ReadonlyArray<FakeProcessEvent>>([]);
     const configs = yield* Ref.make<ReadonlyArray<SupervisedProcessConfig>>([]);
+    const hooksByName = yield* Ref.make<
+        Readonly<Record<string, SupervisedProcessHooks | undefined>>
+    >({});
 
-    const factory: AxBackendManager.MakeSupervisedProcess = (config) =>
+    const factory: AxBackendManager.MakeSupervisedProcess = (config, hooks) =>
         Effect.sync(() => {
             const proc: SupervisedProcess = {
                 start: Ref.update(events, (xs) => [
@@ -53,12 +59,26 @@ const makeFakeProcessFactory = Effect.gen(function* () {
                 } satisfies SupervisedProcessSnapshot),
             };
             return proc;
-        }).pipe(Effect.tap(() => Ref.update(configs, (xs) => [...xs, config])));
+        }).pipe(
+            Effect.tap(() => Ref.update(configs, (xs) => [...xs, config])),
+            Effect.tap(() =>
+                Ref.update(hooksByName, (m) => ({ ...m, [config.name]: hooks })),
+            ),
+        );
+
+    /** Fire the captured `onExit` hook for a process, if any (simulates crash). */
+    const fireExit = (name: string) =>
+        Ref.get(hooksByName).pipe(
+            Effect.flatMap((m) =>
+                m[name]?.onExit?.({ pid: 1234, reason: "code=1" }) ?? Effect.void,
+            ),
+        );
 
     return {
         factory,
         events: Ref.get(events),
         configs: Ref.get(configs),
+        fireExit,
     } as const;
 });
 
@@ -348,4 +368,138 @@ test("conflict mode neither spawns nor opens the window", async () => {
 
     expect(out.events).toEqual([]);
     expect(out.opened).toBe(0);
+});
+
+// ---------------------------------------------------------------------------
+// (f) surreal restart (onExit) after both running bounces ax-serve
+// ---------------------------------------------------------------------------
+
+test("surreal restart bounces ax serve (stop then start)", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+
+        // Read events INSIDE the scope: the scope-close finalizer (stop) appends
+        // its own stop events, which would otherwise pollute the assertion.
+        const events = yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+                // Both processes are up. Simulate surreal crashing/exiting (the
+                // supervisor would self-restart); the manager's onExit hook
+                // should bounce ax-serve.
+                yield* fakeProc.fireExit("surreal");
+                return yield* fakeProc.events;
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        Layer.provide(arbitrationLayer({ mode: "spawn" })),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(DesktopState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return { events };
+    });
+
+    const out = await Effect.runPromise(program);
+
+    // Initial: surreal start, ax-serve start. Then bounce: ax-serve stop + start.
+    expect(out.events).toEqual([
+        { name: "surreal", action: "start" },
+        { name: "ax-serve", action: "start" },
+        { name: "ax-serve", action: "stop" },
+        { name: "ax-serve", action: "start" },
+    ]);
+});
+
+// ---------------------------------------------------------------------------
+// (g) NO bounce when surreal exit happens during/after manager stop (teardown)
+// ---------------------------------------------------------------------------
+
+test("surreal exit during teardown does NOT respawn ax serve", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+
+        const events = yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+                // Tear down, THEN fire surreal's exit hook (mirrors a surreal
+                // SIGTERM landing as the manager shuts down). The bounce must
+                // bail: no ax-serve respawn after teardown.
+                yield* manager.stop();
+                yield* fakeProc.fireExit("surreal");
+                return yield* fakeProc.events;
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        Layer.provide(arbitrationLayer({ mode: "spawn" })),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(DesktopState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return { events };
+    });
+
+    const out = await Effect.runPromise(program);
+
+    // start surreal, start ax-serve, then reverse-order teardown. No further
+    // ax-serve start after the teardown stops.
+    expect(out.events).toEqual([
+        { name: "surreal", action: "start" },
+        { name: "ax-serve", action: "start" },
+        { name: "ax-serve", action: "stop" },
+        { name: "surreal", action: "stop" },
+    ]);
+});
+
+// ---------------------------------------------------------------------------
+// (h) NO bounce on surreal's initial boot (only onExit, never onReady)
+// ---------------------------------------------------------------------------
+
+test("surreal initial boot does not bounce ax serve", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+
+        const events = yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+                // No exit fired: the manager only reacts to surreal `onExit`, so
+                // a clean initial boot must leave ax-serve untouched (one start).
+                return yield* fakeProc.events;
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        Layer.provide(arbitrationLayer({ mode: "spawn" })),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(DesktopState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return { events };
+    });
+
+    const out = await Effect.runPromise(program);
+
+    expect(out.events).toEqual([
+        { name: "surreal", action: "start" },
+        { name: "ax-serve", action: "start" },
+    ]);
 });

--- a/apps/studio-desktop/src/backend/AxBackendManager.test.ts
+++ b/apps/studio-desktop/src/backend/AxBackendManager.test.ts
@@ -1,0 +1,351 @@
+import { expect, test } from "bun:test";
+
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { backendOutputLogNoopLayer } from "../app/DesktopObservability.ts";
+import * as DesktopState from "../app/DesktopState.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+import * as AxBackendManager from "./AxBackendManager.ts";
+import type { ArbitrationDecision } from "./AxDaemonArbitration.ts";
+import type {
+    SupervisedProcess,
+    SupervisedProcessConfig,
+    SupervisedProcessSnapshot,
+} from "./SupervisedProcess.ts";
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+interface FakeProcessEvent {
+    readonly name: string;
+    readonly action: "start" | "stop";
+}
+
+/**
+ * Build a stub `makeProcess` factory that records start/stop ordering across
+ * every supervised process it vends, and never touches a real OS process.
+ */
+const makeFakeProcessFactory = Effect.gen(function* () {
+    const events = yield* Ref.make<ReadonlyArray<FakeProcessEvent>>([]);
+    const configs = yield* Ref.make<ReadonlyArray<SupervisedProcessConfig>>([]);
+
+    const factory: AxBackendManager.MakeSupervisedProcess = (config) =>
+        Effect.sync(() => {
+            const proc: SupervisedProcess = {
+                start: Ref.update(events, (xs) => [
+                    ...xs,
+                    { name: config.name, action: "start" } satisfies FakeProcessEvent,
+                ]).pipe(Effect.asVoid),
+                stop: () =>
+                    Ref.update(events, (xs) => [
+                        ...xs,
+                        { name: config.name, action: "stop" } satisfies FakeProcessEvent,
+                    ]).pipe(Effect.asVoid),
+                snapshot: Effect.succeed({
+                    ready: true,
+                    activePid: 1234,
+                    restartAttempt: 0,
+                } satisfies SupervisedProcessSnapshot),
+            };
+            return proc;
+        }).pipe(Effect.tap(() => Ref.update(configs, (xs) => [...xs, config])));
+
+    return {
+        factory,
+        events: Ref.get(events),
+        configs: Ref.get(configs),
+    } as const;
+});
+
+/** A DesktopState whose `backendReady` ref the test can read directly. */
+const makeFakeState = Effect.gen(function* () {
+    const backendReady = yield* Ref.make(false);
+    const quitting = yield* Ref.make(false);
+    const layer = Layer.succeed(
+        DesktopState.DesktopState,
+        DesktopState.DesktopState.of({ backendReady, quitting }),
+    );
+    return { layer, backendReady: Ref.get(backendReady) } as const;
+});
+
+/** A DesktopWindow stub that records whether the window was opened. */
+const makeFakeWindow = Effect.gen(function* () {
+    const opened = yield* Ref.make(0);
+    const layer = Layer.succeed(
+        DesktopWindow.DesktopWindow,
+        DesktopWindow.DesktopWindow.of({
+            handleBackendReady: Ref.update(opened, (n) => n + 1).pipe(Effect.asVoid),
+            activate: Effect.void,
+            syncAppearance: Effect.void,
+        }),
+    );
+    return { layer, openCount: Ref.get(opened) } as const;
+});
+
+const arbitrationLayer = (decision: ArbitrationDecision) =>
+    Layer.succeed(
+        AxBackendManager.AxArbitration,
+        AxBackendManager.AxArbitration.of({ probe: Effect.succeed(decision) }),
+    );
+
+const testEnv = {
+    surrealBinaryPath: "/opt/ax/surreal",
+    bunBinaryPath: "/opt/ax/bun",
+    axSourceEntry: "/repo/apps/axctl/src/cli/index.ts",
+    axDataDir: "/data/ax",
+    axSourceRoot: "/repo",
+} satisfies AxBackendManager.AxBackendEnvironment;
+
+const envLayer = Layer.succeed(
+    AxBackendManager.AxBackendEnvironmentTag,
+    AxBackendManager.AxBackendEnvironmentTag.of(testEnv),
+);
+
+// The injected stub factory never touches these, but the manager fetches them
+// from context to feed the (production) supervised-process factory. Trivial
+// stubs keep the layer satisfied without spawning anything.
+const platformStubLayer = Layer.mergeAll(
+    Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+            Effect.die("stub spawner: should not spawn in unit tests"),
+        ),
+    ),
+    Layer.succeed(
+        HttpClient.HttpClient,
+        HttpClient.make((request) =>
+            Effect.succeed(
+                HttpClientResponse.fromWeb(request, new Response(null, { status: 200 })),
+            ),
+        ),
+    ),
+    backendOutputLogNoopLayer,
+);
+
+// ---------------------------------------------------------------------------
+// (a) spawn: surreal readiness gates ax-serve start (ordering)
+// ---------------------------------------------------------------------------
+
+test("spawn mode starts surreal before ax serve (ordering)", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+
+        yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        Layer.provide(arbitrationLayer({ mode: "spawn" })),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(DesktopState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return {
+            events: yield* fakeProc.events,
+            configs: yield* fakeProc.configs,
+            opened: yield* fakeWindow.openCount,
+        };
+    });
+
+    const out = await Effect.runPromise(program);
+
+    const startOrder = out.events
+        .filter((e) => e.action === "start")
+        .map((e) => e.name);
+    expect(startOrder).toEqual(["surreal", "ax-serve"]);
+    expect(out.opened).toBe(1);
+
+    // surreal config sanity
+    const surrealCfg = out.configs.find((c) => c.name === "surreal");
+    expect(surrealCfg?.executablePath).toBe("/opt/ax/surreal");
+    expect(surrealCfg?.args).toContain("rocksdb:///data/ax/db");
+    expect(surrealCfg?.readiness.url.href).toBe("http://127.0.0.1:8521/health");
+
+    // ax-serve config sanity
+    const axCfg = out.configs.find((c) => c.name === "ax-serve");
+    expect(axCfg?.executablePath).toBe("/opt/ax/bun");
+    expect(axCfg?.args).toEqual([
+        "/repo/apps/axctl/src/cli/index.ts",
+        "serve",
+        "--port=1738",
+    ]);
+    expect(axCfg?.cwd).toBe("/repo");
+    expect(axCfg?.env.AX_DB_URL).toBe("ws://127.0.0.1:8521");
+    expect(axCfg?.env.AX_DB_NS).toBe("ax");
+    expect(axCfg?.env.AX_DB_DB).toBe("main");
+    expect(axCfg?.readiness.url.href).toBe("http://127.0.0.1:1738/api/version");
+});
+
+// ---------------------------------------------------------------------------
+// (b) attach mode opens the window without spawning
+// ---------------------------------------------------------------------------
+
+test("attach mode opens window without spawning processes", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+        const fakeState = yield* makeFakeState;
+
+        // Read backendReady INSIDE the scope - the scope-close finalizer (stop)
+        // resets it to false, so reading after close would observe the reset.
+        const backendReady = yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+                return yield* fakeState.backendReady;
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        Layer.provide(arbitrationLayer({ mode: "attach" })),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(fakeState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return {
+            events: yield* fakeProc.events,
+            opened: yield* fakeWindow.openCount,
+            backendReady,
+        };
+    });
+
+    const out = await Effect.runPromise(program);
+
+    expect(out.events).toEqual([]);
+    expect(out.opened).toBe(1);
+    expect(out.backendReady).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// (c) stop tears down in reverse order (ax serve before surreal)
+// ---------------------------------------------------------------------------
+
+test("stop tears down ax serve before surreal (reverse order)", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+
+        yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+                yield* manager.stop();
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        Layer.provide(arbitrationLayer({ mode: "spawn" })),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(DesktopState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return { events: yield* fakeProc.events };
+    });
+
+    const out = await Effect.runPromise(program);
+
+    const stopOrder = out.events
+        .filter((e) => e.action === "stop")
+        .map((e) => e.name);
+    expect(stopOrder).toEqual(["ax-serve", "surreal"]);
+});
+
+// ---------------------------------------------------------------------------
+// (d) spawn-ax-only skips surreal, still starts ax serve + opens window
+// ---------------------------------------------------------------------------
+
+test("spawn-ax-only skips surreal but starts ax serve", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+
+        yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        Layer.provide(arbitrationLayer({ mode: "spawn-ax-only" })),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(DesktopState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return {
+            events: yield* fakeProc.events,
+            opened: yield* fakeWindow.openCount,
+        };
+    });
+
+    const out = await Effect.runPromise(program);
+
+    const startOrder = out.events
+        .filter((e) => e.action === "start")
+        .map((e) => e.name);
+    expect(startOrder).toEqual(["ax-serve"]);
+    expect(out.opened).toBe(1);
+});
+
+// ---------------------------------------------------------------------------
+// (e) conflict mode does NOT start or open the window
+// ---------------------------------------------------------------------------
+
+test("conflict mode neither spawns nor opens the window", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+
+        yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        Layer.provide(arbitrationLayer({ mode: "conflict" })),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(DesktopState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return {
+            events: yield* fakeProc.events,
+            opened: yield* fakeWindow.openCount,
+        };
+    });
+
+    const out = await Effect.runPromise(program);
+
+    expect(out.events).toEqual([]);
+    expect(out.opened).toBe(0);
+});

--- a/apps/studio-desktop/src/backend/AxBackendManager.test.ts
+++ b/apps/studio-desktop/src/backend/AxBackendManager.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "bun:test";
 
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
+import { TestClock } from "effect/testing";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
@@ -107,10 +109,16 @@ const makeFakeWindow = Effect.gen(function* () {
     return { layer, openCount: Ref.get(opened) } as const;
 });
 
-const arbitrationLayer = (decision: ArbitrationDecision) =>
+const arbitrationLayer = (
+    decision: ArbitrationDecision,
+    probeDaemon: Effect.Effect<boolean> = Effect.succeed(true),
+) =>
     Layer.succeed(
         AxBackendManager.AxArbitration,
-        AxBackendManager.AxArbitration.of({ probe: Effect.succeed(decision) }),
+        AxBackendManager.AxArbitration.of({
+            probe: Effect.succeed(decision),
+            probeDaemon,
+        }),
     );
 
 const testEnv = {
@@ -502,4 +510,147 @@ test("surreal initial boot does not bounce ax serve", async () => {
         { name: "surreal", action: "start" },
         { name: "ax-serve", action: "start" },
     ]);
+});
+
+// ---------------------------------------------------------------------------
+// (i) attach mode: poller stays quiet while the external daemon stays healthy
+// ---------------------------------------------------------------------------
+
+test("attach mode does NOT transition while the attached daemon stays healthy", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+
+        const events = yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+                // Drive several poll cycles (grace + 5 intervals) with a healthy
+                // probe. No spawn should ever happen.
+                yield* TestClock.adjust(Duration.seconds(5 + 5 * 5));
+                return yield* fakeProc.events;
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        // Probe always healthy.
+                        Layer.provide(
+                            arbitrationLayer({ mode: "attach" }, Effect.succeed(true)),
+                        ),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(DesktopState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return { events };
+    }).pipe(Effect.provide(TestClock.layer()));
+
+    const out = await Effect.runPromise(program);
+
+    // Healthy attach: nothing spawned.
+    expect(out.events).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// (j) attach mode: sustained probe failure transitions attach -> spawn
+// ---------------------------------------------------------------------------
+
+test("attach mode transitions to spawn after the attached daemon dies", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+        // Probe healthy until the test flips it unhealthy.
+        const healthy = yield* Ref.make(true);
+
+        const events = yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+                // Window opened against the external daemon; nothing spawned yet.
+                expect(yield* fakeProc.events).toEqual([]);
+                expect(yield* fakeWindow.openCount).toBe(1);
+
+                // Daemon dies. The next two consecutive probes fail (threshold 2),
+                // triggering the attach -> spawn takeover.
+                yield* Ref.set(healthy, false);
+                // grace -> first failing tick (failures=1)
+                yield* TestClock.adjust(Duration.seconds(5));
+                // one interval -> second failing tick (failures=2 -> transition)
+                yield* TestClock.adjust(Duration.seconds(5));
+                // let the spawn path settle (its readiness gate uses the clock)
+                yield* TestClock.adjust(Duration.seconds(1));
+                return yield* fakeProc.events;
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        Layer.provide(
+                            arbitrationLayer({ mode: "attach" }, Ref.get(healthy)),
+                        ),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(DesktopState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return { events };
+    }).pipe(Effect.provide(TestClock.layer()));
+
+    const out = await Effect.runPromise(program);
+
+    // The takeover ran the spawn path: surreal then ax-serve.
+    const startOrder = out.events
+        .filter((e) => e.action === "start")
+        .map((e) => e.name);
+    expect(startOrder).toEqual(["surreal", "ax-serve"]);
+});
+
+// ---------------------------------------------------------------------------
+// (k) attach mode: poller torn down by stop -> no transition after stop
+// ---------------------------------------------------------------------------
+
+test("attach mode poller does NOT transition after stop (torn down)", async () => {
+    const program = Effect.gen(function* () {
+        const fakeProc = yield* makeFakeProcessFactory;
+        const fakeWindow = yield* makeFakeWindow;
+        const healthy = yield* Ref.make(true);
+
+        const events = yield* Effect.scoped(
+            Effect.gen(function* () {
+                const manager = yield* AxBackendManager.AxBackendManager;
+                yield* manager.start;
+                // Stop the manager FIRST (latches `stopping`), then make the
+                // daemon die and advance well past the failure threshold. The
+                // poller must bail without spawning anything.
+                yield* manager.stop();
+                yield* Ref.set(healthy, false);
+                yield* TestClock.adjust(Duration.seconds(5 + 5 * 5));
+                return yield* fakeProc.events;
+            }).pipe(
+                Effect.provide(
+                    AxBackendManager.layer(fakeProc.factory).pipe(
+                        Layer.provide(
+                            arbitrationLayer({ mode: "attach" }, Ref.get(healthy)),
+                        ),
+                        Layer.provide(fakeWindow.layer),
+                        Layer.provide(DesktopState.layer),
+                        Layer.provide(envLayer),
+                        Layer.provide(platformStubLayer),
+                    ),
+                ),
+            ),
+        );
+
+        return { events };
+    }).pipe(Effect.provide(TestClock.layer()));
+
+    const out = await Effect.runPromise(program);
+
+    // No spawn after stop: poller was torn down / guarded by `stopping`.
+    expect(out.events).toEqual([]);
 });

--- a/apps/studio-desktop/src/backend/AxBackendManager.ts
+++ b/apps/studio-desktop/src/backend/AxBackendManager.ts
@@ -27,9 +27,11 @@
  *
  * Crash-restart ordering: each `SupervisedProcess` restarts itself on crash. ax
  * serve reconnects to surreal on boot, so a surreal restart does not require a
- * manual ax-serve bounce in the steady state - but to be safe the manager wires
- * an `onExit` hook on surreal that bounces ax serve (see TODO below for the
- * live attach->spawn transition, which is intentionally deferred).
+ * manual ax-serve bounce in the steady state. A belt-and-suspenders surreal
+ * `onExit` hook that proactively bounces ax serve is NOT wired yet - it is
+ * deferred (see TODO in `startSpawn`) because `MakeSupervisedProcess` does not
+ * accept lifecycle hooks. Steady-state recovery therefore relies on each
+ * process's own self-restart plus ax-serve's reconnect-on-boot.
  */
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
@@ -223,7 +225,7 @@ export class AxBackendManager extends Context.Service<
     AxBackendManagerShape
 >()("@ax/studio-desktop/backend/AxBackendManager") {}
 
-const { logInfo, logWarning, logError } =
+const { logInfo, logError } =
     DesktopObservability.makeComponentLogger("ax-backend-manager");
 
 interface ManagerProcesses {
@@ -272,6 +274,16 @@ const make = (makeProcess: MakeSupervisedProcess) =>
             );
         });
 
+        // Conservative bail when a spawned process never reports ready: log
+        // loudly and leave the window closed (mirrors the `conflict` branch's
+        // handling). We do NOT start downstream processes or open the window
+        // over a backend that never came up. Never throws.
+        const abortNotReady = (name: string) =>
+            logError(
+                "backend process did not report ready within timeout; not opening window",
+                { process: name, surrealPort: SURREAL_PORT, axServePort: AX_SERVE_PORT },
+            );
+
         const startSpawn = (withSurreal: boolean) =>
             Effect.gen(function* () {
                 let surreal: SupervisedProcess | null = null;
@@ -279,15 +291,25 @@ const make = (makeProcess: MakeSupervisedProcess) =>
                     surreal = yield* buildProcess(makeSurrealConfig(env));
                     yield* Ref.update(procs, (p) => ({ ...p, surreal }));
                     // Start surreal and await its readiness before ax serve so
-                    // ax serve never races a missing DB.
+                    // ax serve never races a missing DB. If surreal never
+                    // reports ready, bail conservatively: do not start ax serve,
+                    // do not open the window over a dead backend.
                     yield* surreal.start;
-                    yield* awaitReady(surreal, "surreal");
+                    const surrealReady = yield* awaitReady(surreal, "surreal");
+                    if (!surrealReady) {
+                        yield* abortNotReady("surreal");
+                        return;
+                    }
                 }
 
                 const axServe = yield* buildProcess(makeAxServeConfig(env));
                 yield* Ref.update(procs, (p) => ({ ...p, axServe }));
                 yield* axServe.start;
-                yield* awaitReady(axServe, "ax-serve");
+                const axServeReady = yield* awaitReady(axServe, "ax-serve");
+                if (!axServeReady) {
+                    yield* abortNotReady("ax-serve");
+                    return;
+                }
 
                 yield* markReadyAndOpenWindow;
 
@@ -382,10 +404,15 @@ const READINESS_POLL_TIMEOUT = Duration.seconds(65);
  * snapshot so the manager can SEQUENCE surreal -> ax serve.
  *
  * Bounded by {@link READINESS_POLL_TIMEOUT} (slightly above the process's own
- * 60s readiness timeout) so a daemon that never comes up surfaces a warning
- * instead of blocking boot forever.
+ * 60s readiness timeout). Returns `true` once the process reports ready, or
+ * `false` if it never does within the timeout (the caller gates progression on
+ * this so a never-ready daemon does not open the window over a dead backend).
+ * Never fails.
  */
-const awaitReady = (proc: SupervisedProcess, name: string) =>
+const awaitReady = (
+    proc: SupervisedProcess,
+    name: string,
+): Effect.Effect<boolean> =>
     proc.snapshot.pipe(
         Effect.flatMap((snap) =>
             snap.ready
@@ -394,11 +421,8 @@ const awaitReady = (proc: SupervisedProcess, name: string) =>
         ),
         Effect.retry(Schedule.spaced(READINESS_POLL_INTERVAL)),
         Effect.timeout(READINESS_POLL_TIMEOUT),
-        Effect.catch(() =>
-            logWarning("backend process did not report ready within timeout", {
-                process: name,
-            }),
-        ),
+        Effect.as(true),
+        Effect.orElseSucceed(() => false),
     );
 
 /**

--- a/apps/studio-desktop/src/backend/AxBackendManager.ts
+++ b/apps/studio-desktop/src/backend/AxBackendManager.ts
@@ -1,0 +1,425 @@
+/**
+ * Phase 2 / Task 2.3 - two-process backend supervisor.
+ *
+ * `AxBackendManager` owns the ax daemon pair for the desktop app. On `start` it
+ * runs the attach-vs-spawn arbitration ({@link AxDaemonArbitration}) and then:
+ *
+ * - `attach`        -> a healthy CLI daemon pair is already running; do NOT
+ *                      spawn anything. Mark the backend ready and open the
+ *                      window against the existing pair.
+ * - `spawn`         -> nothing is listening; spawn `surreal` then (once it is
+ *                      HTTP-ready) `ax serve`, then mark ready + open the window.
+ * - `spawn-ax-only` -> an existing healthy `surreal` is up but `ax serve` is
+ *                      down; spawn only `ax serve` against the existing surreal.
+ * - `conflict`      -> the ports are taken by something we don't understand; do
+ *                      NOT stomp it. Log + leave the window closed (no dialog in
+ *                      v0 - see the conflict branch below).
+ *
+ * Each daemon is an independent {@link SupervisedProcess} (spawn + HTTP
+ * readiness + exponential-backoff restart). The manager sequences them
+ * (surreal gates ax-serve) and tears them down in REVERSE order on `stop`
+ * (ax serve before surreal) so ax serve closes its DB connection before the DB
+ * disappears.
+ *
+ * The two supervised processes are vended through an injectable factory
+ * ({@link MakeSupervisedProcess}, defaulting to {@link makeSupervisedProcess})
+ * so unit tests can stub start/stop without launching real OS processes.
+ *
+ * Crash-restart ordering: each `SupervisedProcess` restarts itself on crash. ax
+ * serve reconnects to surreal on boot, so a surreal restart does not require a
+ * manual ax-serve bounce in the steady state - but to be safe the manager wires
+ * an `onExit` hook on surreal that bounces ax serve (see TODO below for the
+ * live attach->spawn transition, which is intentionally deferred).
+ */
+import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Schedule from "effect/Schedule";
+import * as Scope from "effect/Scope";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopObservability from "../app/DesktopObservability.ts";
+import * as DesktopState from "../app/DesktopState.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+import {
+    AX_SERVE_PORT,
+    type ArbitrationDecision,
+    probeArbitration,
+    SURREAL_PORT,
+} from "./AxDaemonArbitration.ts";
+import {
+    makeSupervisedProcess,
+    type SupervisedProcess,
+    type SupervisedProcessConfig,
+    type SupervisedProcessSnapshot,
+} from "./SupervisedProcess.ts";
+
+// ---------------------------------------------------------------------------
+// Tuning
+// ---------------------------------------------------------------------------
+
+/** Daemon boot can be slow on a cold rocksdb; give each process a full minute. */
+const READINESS_TIMEOUT = Duration.seconds(60);
+
+// ---------------------------------------------------------------------------
+// Injectable seams
+// ---------------------------------------------------------------------------
+
+/**
+ * The factory used to vend a single supervised process. Defaults to
+ * {@link makeSupervisedProcess}; tests inject a stub that records start/stop
+ * without launching a real process.
+ */
+export type MakeSupervisedProcess = (
+    config: SupervisedProcessConfig,
+) => Effect.Effect<
+    SupervisedProcess,
+    never,
+    | ChildProcessSpawner.ChildProcessSpawner
+    | HttpClient.HttpClient
+    | DesktopObservability.DesktopBackendOutputLog
+    | Scope.Scope
+>;
+
+/**
+ * Arbitration seam. The live layer runs the real {@link probeArbitration}
+ * probes; tests inject a fixed decision.
+ */
+export interface AxArbitrationShape {
+    readonly probe: Effect.Effect<ArbitrationDecision, never, HttpClient.HttpClient>;
+}
+
+export class AxArbitration extends Context.Service<AxArbitration, AxArbitrationShape>()(
+    "@ax/studio-desktop/backend/AxArbitration",
+) {}
+
+export const arbitrationLayer = Layer.succeed(
+    AxArbitration,
+    AxArbitration.of({ probe: probeArbitration }),
+);
+
+/**
+ * Minimal environment the manager needs to build the two process configs.
+ * Derived from {@link DesktopEnvironment} in the live layer; supplied directly
+ * in tests so the manager can be exercised without an Electron `app`.
+ */
+export interface AxBackendEnvironment {
+    readonly surrealBinaryPath: string;
+    readonly bunBinaryPath: string;
+    readonly axSourceEntry: string;
+    readonly axDataDir: string;
+    /** cwd for `ax serve` (the ax source root: repo root in dev, `ax-src` packaged). */
+    readonly axSourceRoot: string;
+}
+
+export class AxBackendEnvironmentTag extends Context.Service<
+    AxBackendEnvironmentTag,
+    AxBackendEnvironment
+>()("@ax/studio-desktop/backend/AxBackendEnvironment") {}
+
+/**
+ * Derive the ax source root (cwd for `ax serve`) from `axSourceEntry`.
+ * `<root>/apps/axctl/src/cli/index.ts` -> up four dirs from `dirname` -> `<root>`.
+ */
+export const deriveAxSourceRoot = (
+    axSourceEntry: string,
+    path: DesktopEnvironment.DesktopEnvironmentShape["path"],
+): string => path.resolve(path.dirname(axSourceEntry), "..", "..", "..", "..");
+
+export const environmentLayer = Layer.effect(
+    AxBackendEnvironmentTag,
+    Effect.gen(function* () {
+        const environment = yield* DesktopEnvironment.DesktopEnvironment;
+        return AxBackendEnvironmentTag.of({
+            surrealBinaryPath: environment.surrealBinaryPath,
+            bunBinaryPath: environment.bunBinaryPath,
+            axSourceEntry: environment.axSourceEntry,
+            axDataDir: environment.axDataDir,
+            axSourceRoot: deriveAxSourceRoot(environment.axSourceEntry, environment.path),
+        });
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// Config builders
+// ---------------------------------------------------------------------------
+
+/**
+ * surreal process config. `--allow-experimental=files` is required for ax's v3
+ * file buckets; rocksdb lives at `<axDataDir>/db`, agreeing with the CLI daemon
+ * (`scripts/db-start.sh`).
+ */
+export const makeSurrealConfig = (env: AxBackendEnvironment): SupervisedProcessConfig => ({
+    name: "surreal",
+    executablePath: env.surrealBinaryPath,
+    args: [
+        "start",
+        "--user",
+        "root",
+        "--pass",
+        "root",
+        "--bind",
+        `127.0.0.1:${SURREAL_PORT}`,
+        "--log",
+        "info",
+        "--allow-experimental=files",
+        `rocksdb://${env.axDataDir}/db`,
+    ],
+    cwd: env.axSourceRoot,
+    env: {},
+    readiness: {
+        url: new URL(`http://127.0.0.1:${SURREAL_PORT}/health`),
+        timeout: READINESS_TIMEOUT,
+    },
+});
+
+/**
+ * `ax serve` process config. Runs the ax CLI source through `bun`, pointed at
+ * the surreal we (or the existing daemon) brought up via the canonical
+ * `AX_DB_*` env defaults from `@ax/lib`.
+ */
+export const makeAxServeConfig = (env: AxBackendEnvironment): SupervisedProcessConfig => ({
+    name: "ax-serve",
+    executablePath: env.bunBinaryPath,
+    args: [env.axSourceEntry, "serve", `--port=${AX_SERVE_PORT}`],
+    cwd: env.axSourceRoot,
+    env: {
+        // Mirror packages/lib/src/db.ts envConfig() defaults so ax serve and the
+        // surreal we spawn agree on the connection.
+        AX_DB_URL: `ws://127.0.0.1:${SURREAL_PORT}`,
+        AX_DB_NS: "ax",
+        AX_DB_DB: "main",
+    },
+    readiness: {
+        url: new URL(`http://127.0.0.1:${AX_SERVE_PORT}/api/version`),
+        timeout: READINESS_TIMEOUT,
+    },
+});
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export interface AxBackendManagerSnapshot {
+    readonly mode: ArbitrationDecision["mode"] | null;
+    readonly surreal: SupervisedProcessSnapshot | null;
+    readonly axServe: SupervisedProcessSnapshot | null;
+}
+
+export interface AxBackendManagerShape {
+    readonly start: Effect.Effect<void>;
+    readonly stop: (options?: {
+        readonly timeout?: Duration.Duration;
+    }) => Effect.Effect<void>;
+    readonly snapshot: Effect.Effect<AxBackendManagerSnapshot>;
+}
+
+export class AxBackendManager extends Context.Service<
+    AxBackendManager,
+    AxBackendManagerShape
+>()("@ax/studio-desktop/backend/AxBackendManager") {}
+
+const { logInfo, logWarning, logError } =
+    DesktopObservability.makeComponentLogger("ax-backend-manager");
+
+interface ManagerProcesses {
+    readonly surreal: SupervisedProcess | null;
+    readonly axServe: SupervisedProcess | null;
+}
+
+const make = (makeProcess: MakeSupervisedProcess) =>
+    Effect.gen(function* () {
+        const parentScope = yield* Scope.Scope;
+        const arbitration = yield* AxArbitration;
+        const env = yield* AxBackendEnvironmentTag;
+        const desktopState = yield* DesktopState.DesktopState;
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const httpClient = yield* HttpClient.HttpClient;
+        const backendOutputLog = yield* DesktopObservability.DesktopBackendOutputLog;
+
+        const mode = yield* Ref.make<ArbitrationDecision["mode"] | null>(null);
+        const procs = yield* Ref.make<ManagerProcesses>({
+            surreal: null,
+            axServe: null,
+        });
+
+        // Provide the supervised-process deps once; the factory's `Scope` is the
+        // manager's parent scope so processes live as long as the manager.
+        const buildProcess = (config: SupervisedProcessConfig) =>
+            makeProcess(config).pipe(
+                Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+                Effect.provideService(HttpClient.HttpClient, httpClient),
+                Effect.provideService(
+                    DesktopObservability.DesktopBackendOutputLog,
+                    backendOutputLog,
+                ),
+                Scope.provide(parentScope),
+            );
+
+        const markReadyAndOpenWindow = Effect.gen(function* () {
+            yield* Ref.set(desktopState.backendReady, true);
+            yield* desktopWindow.handleBackendReady.pipe(
+                Effect.catch((error) =>
+                    logError("failed to open main window after backend readiness", {
+                        message: error.message,
+                    }),
+                ),
+            );
+        });
+
+        const startSpawn = (withSurreal: boolean) =>
+            Effect.gen(function* () {
+                let surreal: SupervisedProcess | null = null;
+                if (withSurreal) {
+                    surreal = yield* buildProcess(makeSurrealConfig(env));
+                    yield* Ref.update(procs, (p) => ({ ...p, surreal }));
+                    // Start surreal and await its readiness before ax serve so
+                    // ax serve never races a missing DB.
+                    yield* surreal.start;
+                    yield* awaitReady(surreal, "surreal");
+                }
+
+                const axServe = yield* buildProcess(makeAxServeConfig(env));
+                yield* Ref.update(procs, (p) => ({ ...p, axServe }));
+                yield* axServe.start;
+                yield* awaitReady(axServe, "ax-serve");
+
+                yield* markReadyAndOpenWindow;
+
+                // TODO(phase-2): crash-restart ordering refinements.
+                //  1. surreal-crash -> ax-serve bounce. Each SupervisedProcess
+                //     already self-restarts on crash, and ax serve reconnects to
+                //     surreal on boot, so the steady state recovers without help.
+                //     A belt-and-suspenders bounce (surreal `onExit` hook ->
+                //     axServe.stop()+start) would need `makeProcess` to accept
+                //     SupervisedProcessHooks; deferred to keep the test seam thin.
+                //  2. attach -> spawn live transition. AxDaemonArbitration's
+                //     residual note: if an ATTACHED CLI daemon dies, a periodic
+                //     re-probe should fall back to spawn. Not wired yet.
+            });
+
+        const start: Effect.Effect<void> = Effect.gen(function* () {
+            const decision = yield* arbitration.probe.pipe(
+                Effect.provideService(HttpClient.HttpClient, httpClient),
+            );
+            yield* Ref.set(mode, decision.mode);
+            yield* logInfo("arbitration decided", { mode: decision.mode });
+
+            switch (decision.mode) {
+                case "attach":
+                    // A healthy CLI daemon pair already owns the ports. We do not
+                    // own its lifecycle (see AxDaemonArbitration residual note);
+                    // just attach the window to it.
+                    yield* markReadyAndOpenWindow;
+                    return;
+                case "spawn":
+                    yield* startSpawn(true);
+                    return;
+                case "spawn-ax-only":
+                    yield* startSpawn(false);
+                    return;
+                case "conflict":
+                    // Ports occupied by something unhealthy we don't understand.
+                    // Conservative: surface it loudly and leave the window closed.
+                    // No ElectronDialog service exists in v0; a minimal error
+                    // dialog is deferred (Task 2.4 manual gate / future work).
+                    yield* logError(
+                        "daemon arbitration conflict: ports occupied by an unhealthy process; not starting backend",
+                        { surrealPort: SURREAL_PORT, axServePort: AX_SERVE_PORT },
+                    );
+                    return;
+            }
+        }).pipe(Effect.withSpan("ax.backendManager.start"));
+
+        const stop: AxBackendManagerShape["stop"] = (options) =>
+            Effect.gen(function* () {
+                // Take + clear the handles atomically so the scope-close finalizer
+                // can't double-stop after an explicit stop (idempotent).
+                const current = yield* Ref.getAndSet(procs, {
+                    surreal: null,
+                    axServe: null,
+                });
+                yield* Ref.set(desktopState.backendReady, false);
+                // Reverse order: ax serve closes its DB connection before surreal
+                // (the DB) goes away.
+                if (current.axServe) {
+                    yield* current.axServe.stop(options);
+                }
+                if (current.surreal) {
+                    yield* current.surreal.stop(options);
+                }
+            }).pipe(Effect.withSpan("ax.backendManager.stop"));
+
+        const snapshot: Effect.Effect<AxBackendManagerSnapshot> = Effect.gen(
+            function* () {
+                const current = yield* Ref.get(procs);
+                return {
+                    mode: yield* Ref.get(mode),
+                    surreal: current.surreal ? yield* current.surreal.snapshot : null,
+                    axServe: current.axServe ? yield* current.axServe.snapshot : null,
+                } satisfies AxBackendManagerSnapshot;
+            },
+        );
+
+        // Drain both on scope close (quit) - ax serve before surreal.
+        yield* Effect.addFinalizer(() => stop());
+
+        return AxBackendManager.of({ start, stop, snapshot });
+    });
+
+/** Poll interval + cap for the readiness gate between surreal and ax serve. */
+const READINESS_POLL_INTERVAL = Duration.millis(100);
+const READINESS_POLL_TIMEOUT = Duration.seconds(65);
+
+/**
+ * Await a supervised process becoming ready. The SupervisedProcess forks its
+ * own readiness probe + flips `ready` on its snapshot; here we poll that
+ * snapshot so the manager can SEQUENCE surreal -> ax serve.
+ *
+ * Bounded by {@link READINESS_POLL_TIMEOUT} (slightly above the process's own
+ * 60s readiness timeout) so a daemon that never comes up surfaces a warning
+ * instead of blocking boot forever.
+ */
+const awaitReady = (proc: SupervisedProcess, name: string) =>
+    proc.snapshot.pipe(
+        Effect.flatMap((snap) =>
+            snap.ready
+                ? Effect.void
+                : Effect.fail(new Error(`${name} not ready yet`)),
+        ),
+        Effect.retry(Schedule.spaced(READINESS_POLL_INTERVAL)),
+        Effect.timeout(READINESS_POLL_TIMEOUT),
+        Effect.catch(() =>
+            logWarning("backend process did not report ready within timeout", {
+                process: name,
+            }),
+        ),
+    );
+
+/**
+ * Public layer constructor. Pass a custom {@link MakeSupervisedProcess} for
+ * tests; production omits it (defaults to {@link makeSupervisedProcess}).
+ *
+ * Requires `AxArbitration`, `AxBackendEnvironmentTag`, `DesktopState`,
+ * `DesktopWindow`, `ChildProcessSpawner`, `HttpClient`, and
+ * `DesktopBackendOutputLog` to be provided by the caller. The {@link liveLayer}
+ * bundles the live arbitration + environment derivations.
+ */
+export const layer = (makeProcess: MakeSupervisedProcess = makeSupervisedProcess) =>
+    Layer.effect(AxBackendManager, make(makeProcess));
+
+/**
+ * Live layer: the real supervisor wired with live arbitration + the
+ * `DesktopEnvironment`-derived backend environment. Leaves the platform deps
+ * (`ChildProcessSpawner`, `HttpClient`, `DesktopBackendOutputLog`,
+ * `DesktopState`, `DesktopWindow`, `DesktopEnvironment`) to `main.ts`.
+ */
+export const liveLayer = layer().pipe(
+    Layer.provide(arbitrationLayer),
+    Layer.provide(environmentLayer),
+);

--- a/apps/studio-desktop/src/backend/AxBackendManager.ts
+++ b/apps/studio-desktop/src/backend/AxBackendManager.ts
@@ -35,6 +35,17 @@
  * against teardown (manager `stopping` + `DesktopState.quitting`) and only fires
  * once ax serve has been started. Self-restart + reconnect-on-boot still back it
  * up.
+ *
+ * Attach -> spawn live transition: in `attach` mode we reuse an external CLI
+ * daemon we do NOT supervise. After opening the window the manager forks a
+ * readiness poller (into its own scope) that re-probes the attached daemon every
+ * {@link ATTACH_POLL_INTERVAL}; on {@link ATTACH_FAILURE_THRESHOLD} consecutive
+ * failed probes (debounced against a transient blip) it logs the takeover and
+ * runs the spawn path ({@link startSpawn}) to bring up our own supervised pair,
+ * then stops polling (SupervisedProcess crash-restart covers further failures).
+ * The transition is latched (runs at most once), bails during
+ * `stopping`/`quitting`, and the poller fiber is torn down by the manager's
+ * `stop`/scope so it never leaks or races teardown.
  */
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
@@ -54,6 +65,7 @@ import {
     AX_SERVE_PORT,
     type ArbitrationDecision,
     probeArbitration,
+    probeDaemon,
     SURREAL_PORT,
 } from "./AxDaemonArbitration.ts";
 import {
@@ -70,6 +82,16 @@ import {
 
 /** Daemon boot can be slow on a cold rocksdb; give each process a full minute. */
 const READINESS_TIMEOUT = Duration.seconds(60);
+
+/**
+ * Attach-mode readiness poller cadence + debounce. After attaching to an
+ * external CLI daemon we re-probe it on this interval; once this many probes
+ * fail back-to-back we treat the daemon as gone and transition attach -> spawn.
+ * A small grace before the first probe avoids racing a daemon that is mid-boot.
+ */
+const ATTACH_POLL_INTERVAL = Duration.seconds(5);
+const ATTACH_POLL_INITIAL_GRACE = Duration.seconds(5);
+const ATTACH_FAILURE_THRESHOLD = 2;
 
 // ---------------------------------------------------------------------------
 // Injectable seams
@@ -98,9 +120,15 @@ export type MakeSupervisedProcess = (
 /**
  * Arbitration seam. The live layer runs the real {@link probeArbitration}
  * probes; tests inject a fixed decision.
+ *
+ * `probeDaemon` is the per-daemon health probe the attach-mode readiness poller
+ * re-runs to detect the external CLI daemon going away (separate from the
+ * boot-time `probe` that folds all three probes into a decision). Exposed on the
+ * seam so tests can stub it (healthy -> unhealthy) without hitting the network.
  */
 export interface AxArbitrationShape {
     readonly probe: Effect.Effect<ArbitrationDecision, never, HttpClient.HttpClient>;
+    readonly probeDaemon: Effect.Effect<boolean, never, HttpClient.HttpClient>;
 }
 
 export class AxArbitration extends Context.Service<AxArbitration, AxArbitrationShape>()(
@@ -109,7 +137,7 @@ export class AxArbitration extends Context.Service<AxArbitration, AxArbitrationS
 
 export const arbitrationLayer = Layer.succeed(
     AxArbitration,
-    AxArbitration.of({ probe: probeArbitration }),
+    AxArbitration.of({ probe: probeArbitration, probeDaemon }),
 );
 
 /**
@@ -263,6 +291,10 @@ const make = (makeProcess: MakeSupervisedProcess) =>
         // stop). Combined with `quitting`, this guards the bounce against every
         // teardown path (explicit stop, scope-close finalizer, app quit).
         const stopping = yield* Ref.make(false);
+        // Latched true once the attach -> spawn transition has fired so it can
+        // never run twice (the poller stops itself after winning the latch, but
+        // the CAS makes the guard robust even if two checks interleave).
+        const transitioned = yield* Ref.make(false);
 
         // Provide the supervised-process deps once; the factory's `Scope` is the
         // manager's parent scope so processes live as long as the manager.
@@ -393,12 +425,93 @@ const make = (makeProcess: MakeSupervisedProcess) =>
                 // reconnects to the fresh DB instead of limping on a dead
                 // connection. The self-restart + reconnect-on-boot still backs
                 // it up in the steady state.
-                //
-                // TODO(phase-2): attach -> spawn live transition.
-                //  AxDaemonArbitration's residual note: if an ATTACHED CLI daemon
-                //  dies, a periodic re-probe should fall back to spawn. Not wired
-                //  yet (separate from the bounce above).
             });
+
+        // ---- Attach -> spawn live transition -------------------------------
+        //
+        // In `attach` mode we reuse the external CLI daemon and own none of its
+        // processes; if it dies the window is pointed at a dead backend. The
+        // poller below re-probes that daemon and, on a sustained failure, takes
+        // over by running the spawn path (our own supervised pair).
+
+        // Run the takeover at most once. Wins the `transitioned` latch via CAS
+        // (compare-and-set); if it was already set, another path beat us - no-op.
+        const transitionAttachToSpawn = Effect.gen(function* () {
+            // Never take over while shutting down.
+            if (yield* Ref.get(stopping)) {
+                return false;
+            }
+            if (yield* Ref.get(desktopState.quitting)) {
+                return false;
+            }
+            const won = yield* Ref.modify(transitioned, (already) =>
+                already ? [false, already] : [true, true],
+            );
+            if (!won) {
+                return false;
+            }
+            yield* logInfo(
+                "attached daemon went away; transitioning attach->spawn",
+                { surrealPort: SURREAL_PORT, axServePort: AX_SERVE_PORT },
+            );
+            yield* Ref.set(mode, "spawn");
+            // Bring up our own supervised pair (surreal + ax-serve). From here
+            // SupervisedProcess crash-restart covers further failures, so the
+            // caller stops the poller once this returns true.
+            yield* startSpawn(true);
+            return true;
+        });
+
+        // One poll tick: re-probe the attached daemon, tracking consecutive
+        // failures in `failures`. Returns `true` once the transition has fired
+        // (signals the repeat loop to stop). Probe failures are total (the probe
+        // collapses errors to `false`), so this never fails the fiber.
+        const pollTick = (failures: Ref.Ref<number>): Effect.Effect<boolean> =>
+            Effect.gen(function* () {
+                // Stop quietly if teardown began between ticks.
+                if (yield* Ref.get(stopping)) {
+                    return true;
+                }
+                if (yield* Ref.get(desktopState.quitting)) {
+                    return true;
+                }
+                const healthy = yield* arbitration.probeDaemon.pipe(
+                    Effect.provideService(HttpClient.HttpClient, httpClient),
+                );
+                if (healthy) {
+                    yield* Ref.set(failures, 0);
+                    return false;
+                }
+                const consecutive = yield* Ref.updateAndGet(failures, (n) => n + 1);
+                yield* logInfo("attached daemon probe failed", {
+                    consecutive,
+                    threshold: ATTACH_FAILURE_THRESHOLD,
+                });
+                if (consecutive < ATTACH_FAILURE_THRESHOLD) {
+                    return false;
+                }
+                return yield* transitionAttachToSpawn;
+            });
+
+        // The full poller: an initial grace, then repeat `pollTick` on a fixed
+        // cadence until it returns `true` (transition fired or teardown began).
+        // Forked into the manager's parent scope so `stop`/scope-close interrupts
+        // it cleanly (no leaked fiber); the repeat is naturally interruptible at
+        // every `sleep`.
+        const attachReadinessPoller = Effect.gen(function* () {
+            const failures = yield* Ref.make(0);
+            yield* Effect.sleep(ATTACH_POLL_INITIAL_GRACE);
+            yield* pollTick(failures).pipe(
+                Effect.repeat({
+                    schedule: Schedule.spaced(ATTACH_POLL_INTERVAL),
+                    until: (done) => done,
+                }),
+            );
+        }).pipe(
+            Effect.catchCause((cause) =>
+                logError("attach readiness poller failed", { cause: String(cause) }),
+            ),
+        );
 
         const start: Effect.Effect<void> = Effect.gen(function* () {
             const decision = yield* arbitration.probe.pipe(
@@ -410,9 +523,12 @@ const make = (makeProcess: MakeSupervisedProcess) =>
             switch (decision.mode) {
                 case "attach":
                     // A healthy CLI daemon pair already owns the ports. We do not
-                    // own its lifecycle (see AxDaemonArbitration residual note);
-                    // just attach the window to it.
+                    // own its lifecycle, so attach the window to it AND fork a
+                    // readiness poller that takes over (attach -> spawn) if the
+                    // external daemon dies. Forked into the manager's parent
+                    // scope so `stop`/scope-close interrupts it (no leaked fiber).
                     yield* markReadyAndOpenWindow;
+                    yield* Effect.forkIn(attachReadinessPoller, parentScope);
                     return;
                 case "spawn":
                     yield* startSpawn(true);

--- a/apps/studio-desktop/src/backend/AxBackendManager.ts
+++ b/apps/studio-desktop/src/backend/AxBackendManager.ts
@@ -26,12 +26,15 @@
  * so unit tests can stub start/stop without launching real OS processes.
  *
  * Crash-restart ordering: each `SupervisedProcess` restarts itself on crash. ax
- * serve reconnects to surreal on boot, so a surreal restart does not require a
- * manual ax-serve bounce in the steady state. A belt-and-suspenders surreal
- * `onExit` hook that proactively bounces ax serve is NOT wired yet - it is
- * deferred (see TODO in `startSpawn`) because `MakeSupervisedProcess` does not
- * accept lifecycle hooks. Steady-state recovery therefore relies on each
- * process's own self-restart plus ax-serve's reconnect-on-boot.
+ * serve reconnects to surreal on boot, so a surreal restart does not strictly
+ * require a manual ax-serve bounce in the steady state. As a belt-and-suspenders
+ * measure the manager passes surreal a `SupervisedProcessHooks.onExit` hook
+ * (threaded through {@link MakeSupervisedProcess}) that bounces ax serve
+ * (`stop` + `start`) when surreal exits, so ax serve reconnects to the fresh DB
+ * promptly instead of limping on a dead connection. The bounce is guarded
+ * against teardown (manager `stopping` + `DesktopState.quitting`) and only fires
+ * once ax serve has been started. Self-restart + reconnect-on-boot still back it
+ * up.
  */
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
@@ -57,6 +60,7 @@ import {
     makeSupervisedProcess,
     type SupervisedProcess,
     type SupervisedProcessConfig,
+    type SupervisedProcessHooks,
     type SupervisedProcessSnapshot,
 } from "./SupervisedProcess.ts";
 
@@ -74,10 +78,14 @@ const READINESS_TIMEOUT = Duration.seconds(60);
 /**
  * The factory used to vend a single supervised process. Defaults to
  * {@link makeSupervisedProcess}; tests inject a stub that records start/stop
- * without launching a real process.
+ * without launching a real process. The optional `hooks` argument is threaded
+ * through to {@link makeSupervisedProcess} so the manager can react to a
+ * process becoming ready / exiting (e.g. bounce ax-serve when surreal
+ * restarts); stub factories may ignore it or invoke it to simulate lifecycle.
  */
 export type MakeSupervisedProcess = (
     config: SupervisedProcessConfig,
+    hooks?: SupervisedProcessHooks,
 ) => Effect.Effect<
     SupervisedProcess,
     never,
@@ -249,11 +257,20 @@ const make = (makeProcess: MakeSupervisedProcess) =>
             surreal: null,
             axServe: null,
         });
+        // Latched true for the lifetime of `stop`/teardown so the surreal
+        // restart hook never respawns ax-serve while the manager is shutting
+        // down (the hook runs in the supervisor's fiber, concurrently with
+        // stop). Combined with `quitting`, this guards the bounce against every
+        // teardown path (explicit stop, scope-close finalizer, app quit).
+        const stopping = yield* Ref.make(false);
 
         // Provide the supervised-process deps once; the factory's `Scope` is the
         // manager's parent scope so processes live as long as the manager.
-        const buildProcess = (config: SupervisedProcessConfig) =>
-            makeProcess(config).pipe(
+        const buildProcess = (
+            config: SupervisedProcessConfig,
+            hooks?: SupervisedProcessHooks,
+        ) =>
+            makeProcess(config, hooks).pipe(
                 Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
                 Effect.provideService(HttpClient.HttpClient, httpClient),
                 Effect.provideService(
@@ -284,11 +301,68 @@ const make = (makeProcess: MakeSupervisedProcess) =>
                 { process: name, surrealPort: SURREAL_PORT, axServePort: AX_SERVE_PORT },
             );
 
+        // Belt-and-suspenders: when surreal exits (and is about to self-restart)
+        // bounce ax-serve so it reconnects to the fresh surreal on boot rather
+        // than limping on a dead DB connection until its own next restart.
+        // Runs from surreal's supervisor fiber (its `onExit`), concurrently with
+        // any teardown - hence the guards. `axServe.stop`/`start` are themselves
+        // mutex-guarded by SupervisedProcess, so the bounce can't race itself.
+        const bounceAxServe = Effect.gen(function* () {
+            // Don't respawn while shutting down (explicit stop, finalizer, quit).
+            if (yield* Ref.get(stopping)) {
+                return;
+            }
+            if (yield* Ref.get(desktopState.quitting)) {
+                return;
+            }
+            // Only bounce if ax-serve has actually been started by this manager.
+            const axServe = (yield* Ref.get(procs)).axServe;
+            if (!axServe) {
+                return;
+            }
+            yield* logInfo("surreal restarted; bouncing ax-serve", {
+                surrealPort: SURREAL_PORT,
+                axServePort: AX_SERVE_PORT,
+            });
+            // Re-check the guards after the stop (teardown may have begun while
+            // we awaited it) before bringing ax-serve back up.
+            yield* axServe.stop();
+            if (yield* Ref.get(stopping)) {
+                return;
+            }
+            if (yield* Ref.get(desktopState.quitting)) {
+                return;
+            }
+            // Re-read the handle: `stop()`/teardown clears `procs`, so a null
+            // here means the manager was torn down mid-bounce - do not respawn.
+            const stillTracked = (yield* Ref.get(procs)).axServe;
+            if (stillTracked !== axServe) {
+                return;
+            }
+            yield* axServe.start;
+        }).pipe(
+            Effect.catchCause((cause) =>
+                logError("failed to bounce ax-serve after surreal restart", {
+                    cause: String(cause),
+                }),
+            ),
+        );
+
+        // Surreal lifecycle hooks. `onExit` fires when surreal's run finalizes
+        // (just before its own backoff restart is scheduled); that is the moment
+        // to schedule the ax-serve bounce. We use `onExit` rather than `onReady`
+        // because `onReady` resets `restartAttempt` to 0 before firing, so it
+        // cannot distinguish the initial boot from a restart - whereas `onExit`
+        // never fires on initial boot at all.
+        const surrealHooks: SupervisedProcessHooks = {
+            onExit: () => bounceAxServe,
+        };
+
         const startSpawn = (withSurreal: boolean) =>
             Effect.gen(function* () {
                 let surreal: SupervisedProcess | null = null;
                 if (withSurreal) {
-                    surreal = yield* buildProcess(makeSurrealConfig(env));
+                    surreal = yield* buildProcess(makeSurrealConfig(env), surrealHooks);
                     yield* Ref.update(procs, (p) => ({ ...p, surreal }));
                     // Start surreal and await its readiness before ax serve so
                     // ax serve never races a missing DB. If surreal never
@@ -313,16 +387,17 @@ const make = (makeProcess: MakeSupervisedProcess) =>
 
                 yield* markReadyAndOpenWindow;
 
-                // TODO(phase-2): crash-restart ordering refinements.
-                //  1. surreal-crash -> ax-serve bounce. Each SupervisedProcess
-                //     already self-restarts on crash, and ax serve reconnects to
-                //     surreal on boot, so the steady state recovers without help.
-                //     A belt-and-suspenders bounce (surreal `onExit` hook ->
-                //     axServe.stop()+start) would need `makeProcess` to accept
-                //     SupervisedProcessHooks; deferred to keep the test seam thin.
-                //  2. attach -> spawn live transition. AxDaemonArbitration's
-                //     residual note: if an ATTACHED CLI daemon dies, a periodic
-                //     re-probe should fall back to spawn. Not wired yet.
+                // Surreal-crash -> ax-serve bounce is now wired via the surreal
+                // `onExit` hook (see `bounceAxServe` / `surrealHooks` above):
+                // when surreal exits and self-restarts, we bounce ax-serve so it
+                // reconnects to the fresh DB instead of limping on a dead
+                // connection. The self-restart + reconnect-on-boot still backs
+                // it up in the steady state.
+                //
+                // TODO(phase-2): attach -> spawn live transition.
+                //  AxDaemonArbitration's residual note: if an ATTACHED CLI daemon
+                //  dies, a periodic re-probe should fall back to spawn. Not wired
+                //  yet (separate from the bounce above).
             });
 
         const start: Effect.Effect<void> = Effect.gen(function* () {
@@ -360,6 +435,10 @@ const make = (makeProcess: MakeSupervisedProcess) =>
 
         const stop: AxBackendManagerShape["stop"] = (options) =>
             Effect.gen(function* () {
+                // Latch the teardown flag first so a concurrent surreal `onExit`
+                // hook (which may fire as we kill surreal below) bails instead of
+                // respawning ax-serve mid-shutdown.
+                yield* Ref.set(stopping, true);
                 // Take + clear the handles atomically so the scope-close finalizer
                 // can't double-stop after an explicit stop (idempotent).
                 const current = yield* Ref.getAndSet(procs, {

--- a/apps/studio-desktop/src/backend/AxDaemonArbitration.test.ts
+++ b/apps/studio-desktop/src/backend/AxDaemonArbitration.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { decideArbitration } from "./AxDaemonArbitration.ts";
+
+test("both healthy -> attach", () => {
+    expect(decideArbitration({ daemonHealthy: true, surrealHealthy: true, portsFree: false }))
+        .toEqual({ mode: "attach" });
+});
+test("ports free -> spawn", () => {
+    expect(decideArbitration({ daemonHealthy: false, surrealHealthy: false, portsFree: true }))
+        .toEqual({ mode: "spawn" });
+});
+test("port occupied but unhealthy -> conflict", () => {
+    expect(decideArbitration({ daemonHealthy: false, surrealHealthy: false, portsFree: false }))
+        .toEqual({ mode: "conflict" });
+});
+test("partial (surreal up, daemon down) but ports occupied -> spawn-ax-only", () => {
+    expect(decideArbitration({ daemonHealthy: false, surrealHealthy: true, portsFree: false }))
+        .toEqual({ mode: "spawn-ax-only" });
+});

--- a/apps/studio-desktop/src/backend/AxDaemonArbitration.test.ts
+++ b/apps/studio-desktop/src/backend/AxDaemonArbitration.test.ts
@@ -1,5 +1,29 @@
 import { expect, test } from "bun:test";
-import { decideArbitration } from "./AxDaemonArbitration.ts";
+
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+
+import {
+    decideArbitration,
+    probeArbitration,
+    probeDaemon,
+    probeSurreal,
+} from "./AxDaemonArbitration.ts";
+
+// ---------------------------------------------------------------------------
+// Stub HttpClient: every request resolves with a fixed status (no real I/O).
+// ---------------------------------------------------------------------------
+
+const stubHttpLayer = (status: number) =>
+    Layer.succeed(
+        HttpClient.HttpClient,
+        HttpClient.make((request) =>
+            Effect.succeed(
+                HttpClientResponse.fromWeb(request, new Response(null, { status })),
+            ),
+        ),
+    );
 
 test("both healthy -> attach", () => {
     expect(decideArbitration({ daemonHealthy: true, surrealHealthy: true, portsFree: false }))
@@ -16,4 +40,41 @@ test("port occupied but unhealthy -> conflict", () => {
 test("partial (surreal up, daemon down) but ports occupied -> spawn-ax-only", () => {
     expect(decideArbitration({ daemonHealthy: false, surrealHealthy: true, portsFree: false }))
         .toEqual({ mode: "spawn-ax-only" });
+});
+
+// ---------------------------------------------------------------------------
+// Effect probes: HTTP failures collapse to `false`, success to `true`.
+// ---------------------------------------------------------------------------
+
+test("probeDaemon: 503 -> false", async () => {
+    const result = await Effect.runPromise(
+        probeDaemon.pipe(Effect.provide(stubHttpLayer(503))),
+    );
+    expect(result).toBe(false);
+});
+
+test("probeSurreal: 503 -> false", async () => {
+    const result = await Effect.runPromise(
+        probeSurreal.pipe(Effect.provide(stubHttpLayer(503))),
+    );
+    expect(result).toBe(false);
+});
+
+test("probeDaemon: 200 -> true", async () => {
+    const result = await Effect.runPromise(
+        probeDaemon.pipe(Effect.provide(stubHttpLayer(200))),
+    );
+    expect(result).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// probeArbitration: a healthy daemon (200) short-circuits to attach without
+// depending on port-bind state, so this is deterministic with no real ports.
+// ---------------------------------------------------------------------------
+
+test("probeArbitration: daemon healthy (200) -> attach", async () => {
+    const decision = await Effect.runPromise(
+        probeArbitration.pipe(Effect.provide(stubHttpLayer(200))),
+    );
+    expect(decision).toEqual({ mode: "attach" });
 });

--- a/apps/studio-desktop/src/backend/AxDaemonArbitration.ts
+++ b/apps/studio-desktop/src/backend/AxDaemonArbitration.ts
@@ -1,0 +1,130 @@
+/**
+ * Phase 2 / Task 2.1 - daemon attach-vs-spawn arbitration.
+ *
+ * At boot the desktop app must decide whether to ATTACH to an already-running
+ * healthy ax daemon pair (`surreal` on :8521 + `ax serve` on :1738) or to
+ * SPAWN its own pair. This module owns that decision: a pure decision function
+ * ({@link decideArbitration}) over a probe of the world, plus the Effect probes
+ * that populate that probe.
+ *
+ * Residual open question (verbatim intent): attach mode does not own the
+ * attached daemon's lifecycle - if the CLI daemon dies while desktop is
+ * attached, the readiness poller (Task 2.3) detects it and falls back to spawn.
+ * The reverse (desktop quits while CLI relies on the spawned pair) is left for a
+ * future "who owns the shared daemon" arbitration.
+ */
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import { HttpClient } from "effect/unstable/http";
+
+/** Loopback ports the ax daemon pair listens on. */
+export const AX_SERVE_PORT = 1738;
+export const SURREAL_PORT = 8521;
+
+const PROBE_TIMEOUT = Duration.seconds(1);
+
+/** Snapshot of the world the arbitration decision is computed from. */
+export interface ArbitrationProbe {
+    /** `ax serve` answered `GET /api/version` with a 2xx. */
+    readonly daemonHealthy: boolean;
+    /** `surreal` answered `GET /health` with a 2xx. */
+    readonly surrealHealthy: boolean;
+    /** Both daemon ports were bindable (nothing is listening). */
+    readonly portsFree: boolean;
+}
+
+export type ArbitrationMode = "attach" | "spawn" | "spawn-ax-only" | "conflict";
+
+export interface ArbitrationDecision {
+    readonly mode: ArbitrationMode;
+}
+
+/**
+ * Pure, total decision over the 8 boolean combinations:
+ *
+ * - daemonHealthy -> the whole pair we care about is up; ATTACH (the daemon
+ *   can't be healthy without surreal behind it, so surreal/ports are moot).
+ * - surrealHealthy && !daemonHealthy && !portsFree -> surreal is up but ax serve
+ *   is down and its port is taken; SPAWN just our own ax serve against the
+ *   existing surreal (SPAWN-AX-ONLY).
+ * - portsFree -> nothing is listening; SPAWN a fresh pair.
+ * - else -> ports occupied by something unhealthy we don't understand;
+ *   CONFLICT (surface to the user, don't stomp it).
+ */
+export const decideArbitration = (probe: ArbitrationProbe): ArbitrationDecision => {
+    if (probe.daemonHealthy) return { mode: "attach" };
+    if (probe.surrealHealthy && !probe.portsFree) return { mode: "spawn-ax-only" };
+    if (probe.portsFree) return { mode: "spawn" };
+    return { mode: "conflict" };
+};
+
+/**
+ * Probe `ax serve`: `GET http://127.0.0.1:1738/api/version`. Any non-2xx,
+ * connection error, or timeout collapses to `false` - total, never fails.
+ */
+export const probeDaemon: Effect.Effect<boolean, never, HttpClient.HttpClient> = Effect.gen(
+    function* () {
+        const client = (yield* HttpClient.HttpClient).pipe(HttpClient.filterStatusOk);
+        return yield* client.get(`http://127.0.0.1:${AX_SERVE_PORT}/api/version`).pipe(
+            Effect.timeout(PROBE_TIMEOUT),
+            Effect.as(true),
+            Effect.orElseSucceed(() => false),
+        );
+    },
+);
+
+/**
+ * Probe `surreal`: `GET http://127.0.0.1:8521/health`. Same total semantics as
+ * {@link probeDaemon}.
+ */
+export const probeSurreal: Effect.Effect<boolean, never, HttpClient.HttpClient> = Effect.gen(
+    function* () {
+        const client = (yield* HttpClient.HttpClient).pipe(HttpClient.filterStatusOk);
+        return yield* client.get(`http://127.0.0.1:${SURREAL_PORT}/health`).pipe(
+            Effect.timeout(PROBE_TIMEOUT),
+            Effect.as(true),
+            Effect.orElseSucceed(() => false),
+        );
+    },
+);
+
+/**
+ * Try to bind a single loopback TCP port via `Bun.listen`; closes immediately.
+ * `true` if it was bindable (free), `false` if the bind threw (occupied).
+ */
+const portFree = (port: number): Effect.Effect<boolean> =>
+    Effect.try({
+        try: () => {
+            const server = Bun.listen({
+                hostname: "127.0.0.1",
+                port,
+                socket: { data() {} },
+            });
+            server.stop(true);
+            return true;
+        },
+        catch: () => false,
+    }).pipe(Effect.orElseSucceed(() => false));
+
+/**
+ * `true` only if BOTH daemon ports are currently bindable. Each port is closed
+ * immediately after the bind probe.
+ */
+export const probePortsFree: Effect.Effect<boolean> = Effect.gen(function* () {
+    const serveFree = yield* portFree(AX_SERVE_PORT);
+    const surrealFree = yield* portFree(SURREAL_PORT);
+    return serveFree && surrealFree;
+});
+
+/**
+ * Run all three probes and fold them into a decision. Probes run concurrently;
+ * each is total, so this Effect never fails.
+ */
+export const probeArbitration: Effect.Effect<ArbitrationDecision, never, HttpClient.HttpClient> =
+    Effect.gen(function* () {
+        const [daemonHealthy, surrealHealthy, portsFree] = yield* Effect.all(
+            [probeDaemon, probeSurreal, probePortsFree],
+            { concurrency: "unbounded" },
+        );
+        return decideArbitration({ daemonHealthy, surrealHealthy, portsFree });
+    });

--- a/apps/studio-desktop/src/backend/SupervisedProcess.test.ts
+++ b/apps/studio-desktop/src/backend/SupervisedProcess.test.ts
@@ -1,0 +1,285 @@
+import { expect, test } from "bun:test";
+
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import * as Sink from "effect/Sink";
+import { TestClock } from "effect/testing";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import {
+    ChildProcess,
+    ChildProcessSpawner,
+} from "effect/unstable/process";
+
+import { backendOutputLogNoopLayer } from "../app/DesktopObservability.ts";
+import {
+    INITIAL_RESTART_DELAY,
+    makeSupervisedProcess,
+    type SupervisedProcessConfig,
+} from "./SupervisedProcess.ts";
+
+// ---------------------------------------------------------------------------
+// Stub child process spawner
+// ---------------------------------------------------------------------------
+
+interface FakeChildController {
+    /** Resolve the current child's exitCode effect, simulating an exit. */
+    readonly emitExit: (code: number) => Effect.Effect<void>;
+    /** Number of times `spawn` was invoked. */
+    readonly spawnCount: Effect.Effect<number>;
+    /** Kill signals captured across all spawned children, in order. */
+    readonly killSignals: Effect.Effect<ReadonlyArray<string>>;
+}
+
+const makeStubSpawner = Effect.gen(function* () {
+    const spawns = yield* Ref.make(0);
+    const kills = yield* Ref.make<ReadonlyArray<string>>([]);
+    // Deferred for the most-recently-spawned child's exit code.
+    const currentExit = yield* Ref.make<Deferred.Deferred<number> | null>(null);
+    let nextPid = 1000;
+
+    const spawnerService = ChildProcessSpawner.make((_command: ChildProcess.Command) =>
+        Effect.gen(function* () {
+            yield* Ref.update(spawns, (n) => n + 1);
+            const exit = yield* Deferred.make<number>();
+            yield* Ref.set(currentExit, exit);
+            const pid = nextPid++;
+
+            // Real spawners kill the child + resolve its exit when the spawn
+            // scope closes. Model that so `Scope.close(runScope)` (in stop /
+            // closeRun) unblocks the run fiber that awaits `exitCode`.
+            yield* Effect.addFinalizer(() =>
+                Effect.gen(function* () {
+                    yield* Ref.update(kills, (xs) => [...xs, "SIGTERM"]);
+                    yield* Deferred.succeed(exit, 0);
+                }),
+            );
+
+            const handle: ChildProcessSpawner.ChildProcessHandle =
+                ChildProcessSpawner.makeHandle({
+                    pid: ChildProcessSpawner.ProcessId(pid),
+                    exitCode: Deferred.await(exit).pipe(
+                        Effect.map((code) => ChildProcessSpawner.ExitCode(code)),
+                    ),
+                    isRunning: Deferred.await(exit).pipe(
+                        Effect.as(false),
+                        Effect.raceFirst(Effect.succeed(true)),
+                    ),
+                    kill: (options) =>
+                        Effect.gen(function* () {
+                            yield* Ref.update(kills, (xs) => [
+                                ...xs,
+                                options?.killSignal ?? "SIGTERM",
+                            ]);
+                            yield* Deferred.succeed(exit, 0);
+                        }),
+                    stdin: Sink.drain,
+                    stdout: Stream.empty,
+                    stderr: Stream.empty,
+                    all: Stream.empty,
+                    getInputFd: () => Sink.drain,
+                    getOutputFd: () => Stream.empty,
+                    unref: Effect.succeed(Effect.void),
+                });
+
+            return handle;
+        }),
+    );
+
+    const controller: FakeChildController = {
+        emitExit: (code) =>
+            Effect.gen(function* () {
+                const exit = yield* Ref.get(currentExit);
+                if (exit !== null) {
+                    yield* Deferred.succeed(exit, code);
+                }
+            }),
+        spawnCount: Ref.get(spawns),
+        killSignals: Ref.get(kills),
+    };
+
+    const layer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        spawnerService,
+    );
+
+    return { layer, controller } as const;
+});
+
+// ---------------------------------------------------------------------------
+// Stub HTTP client (controllable readiness)
+// ---------------------------------------------------------------------------
+
+const makeStubHttpClient = Effect.gen(function* () {
+    // true => readiness probe returns 200; false => 503
+    const ok = yield* Ref.make(true);
+
+    const client = HttpClient.make((request) =>
+        Ref.get(ok).pipe(
+            Effect.map((isOk) =>
+                HttpClientResponse.fromWeb(
+                    request,
+                    new Response(null, { status: isOk ? 200 : 503 }),
+                ),
+            ),
+        ),
+    );
+
+    const layer = Layer.succeed(HttpClient.HttpClient, client);
+
+    return { layer, setOk: (value: boolean) => Ref.set(ok, value) } as const;
+});
+
+// ---------------------------------------------------------------------------
+// Test config
+// ---------------------------------------------------------------------------
+
+const testConfig: SupervisedProcessConfig = {
+    name: "test-proc",
+    executablePath: "/usr/bin/true",
+    args: [],
+    cwd: "/tmp",
+    env: {},
+    readiness: {
+        url: new URL("http://127.0.0.1:9999/health"),
+        timeout: Duration.seconds(30),
+    },
+};
+
+// ---------------------------------------------------------------------------
+// (a) start resolves ready once the readiness probe returns ok
+// ---------------------------------------------------------------------------
+
+test("start resolves ready once HTTP readiness returns ok", async () => {
+    const program = Effect.gen(function* () {
+        const stubSpawner = yield* makeStubSpawner;
+        const stubHttp = yield* makeStubHttpClient;
+
+        return yield* Effect.scoped(
+            Effect.gen(function* () {
+                const proc = yield* makeSupervisedProcess(testConfig);
+                yield* proc.start;
+                // give the forked readiness probe a tick to resolve
+                yield* TestClock.adjust(Duration.millis(200));
+                const snap = yield* proc.snapshot;
+                yield* proc.stop({ timeout: Duration.seconds(1) });
+                return snap;
+            }),
+        ).pipe(
+            Effect.provide(stubSpawner.layer),
+            Effect.provide(stubHttp.layer),
+            Effect.provide(backendOutputLogNoopLayer),
+        );
+    });
+
+    const snap = await Effect.runPromise(
+        program.pipe(Effect.provide(TestClock.layer())),
+    );
+
+    expect(snap.ready).toBe(true);
+    expect(snap.activePid).not.toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// (b) child exit while desiredRunning schedules a restart after backoff
+// ---------------------------------------------------------------------------
+
+test("child exit while desiredRunning schedules a restart after backoff", async () => {
+    const program = Effect.gen(function* () {
+        const stubSpawner = yield* makeStubSpawner;
+        const stubHttp = yield* makeStubHttpClient;
+
+        return yield* Effect.scoped(
+            Effect.gen(function* () {
+                const proc = yield* makeSupervisedProcess(testConfig);
+                yield* proc.start;
+                yield* TestClock.adjust(Duration.millis(200)); // becomes ready
+                const spawnsAfterStart =
+                    yield* stubSpawner.controller.spawnCount;
+
+                // Simulate a crash.
+                yield* stubSpawner.controller.emitExit(1);
+                // Let the exit be observed and a restart scheduled.
+                yield* TestClock.adjust(Duration.millis(1));
+                const snapAfterCrash = yield* proc.snapshot;
+
+                // Advance past the first backoff delay (500ms) to respawn.
+                yield* TestClock.adjust(INITIAL_RESTART_DELAY);
+                yield* TestClock.adjust(Duration.millis(200)); // re-ready
+                const spawnsAfterRestart =
+                    yield* stubSpawner.controller.spawnCount;
+                const snapAfterRestart = yield* proc.snapshot;
+
+                yield* proc.stop({ timeout: Duration.seconds(1) });
+                return {
+                    spawnsAfterStart,
+                    snapAfterCrash,
+                    spawnsAfterRestart,
+                    snapAfterRestart,
+                };
+            }),
+        ).pipe(
+            Effect.provide(stubSpawner.layer),
+            Effect.provide(stubHttp.layer),
+            Effect.provide(backendOutputLogNoopLayer),
+        );
+    });
+
+    const out = await Effect.runPromise(
+        program.pipe(Effect.provide(TestClock.layer())),
+    );
+
+    expect(out.spawnsAfterStart).toBe(1);
+    expect(out.snapAfterCrash.restartAttempt).toBeGreaterThanOrEqual(1);
+    expect(out.spawnsAfterRestart).toBe(2);
+});
+
+// ---------------------------------------------------------------------------
+// (c) stop cancels a pending restart and closes the scope (SIGTERM observed)
+// ---------------------------------------------------------------------------
+
+test("stop cancels pending restart, sends SIGTERM, no respawn after stop", async () => {
+    const program = Effect.gen(function* () {
+        const stubSpawner = yield* makeStubSpawner;
+        const stubHttp = yield* makeStubHttpClient;
+
+        return yield* Effect.scoped(
+            Effect.gen(function* () {
+                const proc = yield* makeSupervisedProcess(testConfig);
+                yield* proc.start;
+                yield* TestClock.adjust(Duration.millis(200)); // ready
+
+                // Stop while running -> should SIGTERM the child.
+                yield* proc.stop({ timeout: Duration.seconds(1) });
+                const killsAfterStop =
+                    yield* stubSpawner.controller.killSignals;
+                const spawnsAfterStop =
+                    yield* stubSpawner.controller.spawnCount;
+
+                // Advance past any backoff window -> no respawn should occur.
+                yield* TestClock.adjust(Duration.seconds(30));
+                const spawnsLater = yield* stubSpawner.controller.spawnCount;
+                const snap = yield* proc.snapshot;
+
+                return { killsAfterStop, spawnsAfterStop, spawnsLater, snap };
+            }),
+        ).pipe(
+            Effect.provide(stubSpawner.layer),
+            Effect.provide(stubHttp.layer),
+            Effect.provide(backendOutputLogNoopLayer),
+        );
+    });
+
+    const out = await Effect.runPromise(
+        program.pipe(Effect.provide(TestClock.layer())),
+    );
+
+    expect(out.killsAfterStop).toContain("SIGTERM");
+    expect(out.spawnsAfterStop).toBe(1);
+    expect(out.spawnsLater).toBe(1);
+    expect(out.snap.ready).toBe(false);
+});

--- a/apps/studio-desktop/src/backend/SupervisedProcess.test.ts
+++ b/apps/studio-desktop/src/backend/SupervisedProcess.test.ts
@@ -206,6 +206,12 @@ test("child exit while desiredRunning schedules a restart after backoff", async 
                 // Let the exit be observed and a restart scheduled.
                 yield* TestClock.adjust(Duration.millis(1));
                 const snapAfterCrash = yield* proc.snapshot;
+                // The respawn must be GATED behind the backoff delay: with the
+                // clock only advanced 1ms (< INITIAL_RESTART_DELAY) no new spawn
+                // should have happened yet. This pins the backoff timing - an
+                // impl that respawned with zero delay would fail here.
+                const spawnsBeforeBackoff =
+                    yield* stubSpawner.controller.spawnCount;
 
                 // Advance past the first backoff delay (500ms) to respawn.
                 yield* TestClock.adjust(INITIAL_RESTART_DELAY);
@@ -218,6 +224,7 @@ test("child exit while desiredRunning schedules a restart after backoff", async 
                 return {
                     spawnsAfterStart,
                     snapAfterCrash,
+                    spawnsBeforeBackoff,
                     spawnsAfterRestart,
                     snapAfterRestart,
                 };
@@ -235,6 +242,8 @@ test("child exit while desiredRunning schedules a restart after backoff", async 
 
     expect(out.spawnsAfterStart).toBe(1);
     expect(out.snapAfterCrash.restartAttempt).toBeGreaterThanOrEqual(1);
+    // Backoff timing: no respawn before the delay elapses, exactly one after.
+    expect(out.spawnsBeforeBackoff).toBe(1);
     expect(out.spawnsAfterRestart).toBe(2);
 });
 

--- a/apps/studio-desktop/src/backend/SupervisedProcess.ts
+++ b/apps/studio-desktop/src/backend/SupervisedProcess.ts
@@ -1,0 +1,635 @@
+/**
+ * Generic single-process supervisor.
+ *
+ * Spawns one child process, drains its stdout/stderr into the
+ * {@link DesktopBackendOutputLog}, waits for an HTTP readiness probe, and
+ * restarts the child with exponential backoff if it exits while the supervisor
+ * still wants it running.
+ *
+ * This module is intentionally free of any surreal / ax-serve specifics: the
+ * caller supplies the executable, args, cwd, env, and a readiness URL. Task 2.3
+ * instantiates this twice (surreal, ax-serve).
+ *
+ * The patterns (Scope / Fiber / Ref / Semaphore lifecycle, exponential backoff,
+ * HTTP readiness via `HttpClient.filterStatusOk` + `Schedule.spaced`) mirror
+ * t3code's `DesktopBackendManager`, but the bootstrap-fd JSON mechanism is
+ * dropped - ax passes configuration via argv/env.
+ */
+import * as Cause from "effect/Cause";
+import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
+import type * as PlatformError from "effect/PlatformError";
+import * as Ref from "effect/Ref";
+import * as Result from "effect/Result";
+import * as Schedule from "effect/Schedule";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+import * as DesktopObservability from "../app/DesktopObservability.ts";
+
+// ---------------------------------------------------------------------------
+// Tuning constants
+// ---------------------------------------------------------------------------
+
+export const INITIAL_RESTART_DELAY = Duration.millis(500);
+export const MAX_RESTART_DELAY = Duration.seconds(10);
+const DEFAULT_READINESS_INTERVAL = Duration.millis(100);
+const DEFAULT_READINESS_REQUEST_TIMEOUT = Duration.seconds(1);
+const DEFAULT_TERMINATE_GRACE = Duration.seconds(2);
+
+// ---------------------------------------------------------------------------
+// Config + public shapes
+// ---------------------------------------------------------------------------
+
+export interface SupervisedProcessConfig {
+    readonly name: string;
+    readonly executablePath: string;
+    readonly args: ReadonlyArray<string>;
+    readonly cwd: string;
+    readonly env: Record<string, string | undefined>;
+    readonly readiness: {
+        readonly url: URL;
+        readonly timeout: Duration.Duration;
+    };
+}
+
+export interface SupervisedProcessSnapshot {
+    readonly ready: boolean;
+    readonly activePid: number | null;
+    readonly restartAttempt: number;
+}
+
+export type SupervisedProcessOutputStream = "stdout" | "stderr";
+
+export interface SupervisedProcessHooks {
+    readonly onReady?: () => Effect.Effect<void>;
+    readonly onExit?: (info: {
+        readonly pid: number | null;
+        readonly reason: string;
+    }) => Effect.Effect<void>;
+}
+
+export interface SupervisedProcess {
+    readonly start: Effect.Effect<void>;
+    readonly stop: (options?: {
+        readonly timeout?: Duration.Duration;
+    }) => Effect.Effect<void>;
+    readonly snapshot: Effect.Effect<SupervisedProcessSnapshot>;
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class SupervisedProcessTimeoutError extends Data.TaggedError(
+    "SupervisedProcessTimeoutError",
+)<{
+    readonly url: URL;
+}> {
+    override get message() {
+        return `Timed out waiting for process readiness at ${this.url.href}.`;
+    }
+}
+
+class SupervisedProcessSpawnError extends Data.TaggedError(
+    "SupervisedProcessSpawnError",
+)<{
+    readonly cause: PlatformError.PlatformError;
+}> {
+    override get message() {
+        return `Failed to spawn supervised process: ${this.cause.message}`;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+interface ActiveRun {
+    readonly id: number;
+    readonly scope: Scope.Closeable;
+    readonly fiber: Option.Option<Fiber.Fiber<void, never>>;
+    readonly pid: Option.Option<number>;
+}
+
+interface SupervisorState {
+    readonly desiredRunning: boolean;
+    readonly ready: boolean;
+    readonly active: Option.Option<ActiveRun>;
+    readonly restartAttempt: number;
+    readonly restartFiber: Option.Option<Fiber.Fiber<void, never>>;
+    readonly nextRunId: number;
+}
+
+const initialState: SupervisorState = {
+    desiredRunning: false,
+    ready: false,
+    active: Option.none(),
+    restartAttempt: 0,
+    restartFiber: Option.none(),
+    nextRunId: 1,
+};
+
+const activePid = (active: Option.Option<ActiveRun>): Option.Option<number> =>
+    Option.flatMap(active, (run) => run.pid);
+
+const withActiveRun =
+    (runId: number, f: (run: ActiveRun) => ActiveRun) =>
+    (state: SupervisorState): SupervisorState => ({
+        ...state,
+        active: Option.map(state.active, (run) =>
+            run.id === runId ? f(run) : run,
+        ),
+    });
+
+const calculateRestartDelay = (attempt: number): Duration.Duration =>
+    Duration.min(
+        Duration.times(INITIAL_RESTART_DELAY, 2 ** attempt),
+        MAX_RESTART_DELAY,
+    );
+
+const closeRun = (
+    run: ActiveRun,
+    options?: { readonly timeout?: Duration.Duration },
+): Effect.Effect<void> => {
+    const waitForFiber = Option.match(run.fiber, {
+        onNone: () => Effect.void,
+        onSome: (fiber) => Fiber.await(fiber).pipe(Effect.asVoid),
+    });
+    const close = Scope.close(run.scope, Exit.void).pipe(
+        Effect.andThen(waitForFiber),
+    );
+
+    return (
+        options?.timeout
+            ? close.pipe(Effect.timeoutOption(options.timeout), Effect.asVoid)
+            : close
+    ).pipe(Effect.ignore);
+};
+
+// ---------------------------------------------------------------------------
+// Readiness probe + child run
+// ---------------------------------------------------------------------------
+
+interface ProcessExit {
+    readonly reason: string;
+    readonly result: Result.Result<
+        ChildProcessSpawner.ExitCode,
+        PlatformError.PlatformError
+    >;
+}
+
+const waitForHttpReady = Effect.fn("supervisedProcess.waitForHttpReady")(
+    function* (
+        url: URL,
+        timeout: Duration.Duration,
+    ): Effect.fn.Return<
+        void,
+        SupervisedProcessTimeoutError,
+        HttpClient.HttpClient
+    > {
+        const client = (yield* HttpClient.HttpClient).pipe(
+            HttpClient.filterStatusOk,
+            HttpClient.transformResponse(
+                Effect.timeout(DEFAULT_READINESS_REQUEST_TIMEOUT),
+            ),
+            HttpClient.retry(Schedule.spaced(DEFAULT_READINESS_INTERVAL)),
+        );
+
+        yield* client.get(url).pipe(
+            Effect.asVoid,
+            Effect.timeout(timeout),
+            Effect.mapError(() => new SupervisedProcessTimeoutError({ url })),
+        );
+    },
+);
+
+function describeProcessExit(
+    result: Result.Result<
+        ChildProcessSpawner.ExitCode,
+        PlatformError.PlatformError
+    >,
+): ProcessExit {
+    if (Result.isSuccess(result)) {
+        return { reason: `code=${result.success}`, result };
+    }
+    return { reason: result.failure.message, result };
+}
+
+function drainOutput(
+    streamName: SupervisedProcessOutputStream,
+    stream: Stream.Stream<Uint8Array, PlatformError.PlatformError>,
+    onOutput: (
+        streamName: SupervisedProcessOutputStream,
+        chunk: Uint8Array,
+    ) => Effect.Effect<void>,
+): Effect.Effect<void> {
+    return stream.pipe(
+        Stream.runForEach((chunk) => onOutput(streamName, chunk)),
+        Effect.ignore,
+    );
+}
+
+interface RunChildOptions {
+    readonly config: SupervisedProcessConfig;
+    readonly onStarted: (pid: number) => Effect.Effect<void>;
+    readonly onReady: () => Effect.Effect<void>;
+    readonly onReadinessFailure: (
+        error: SupervisedProcessTimeoutError,
+    ) => Effect.Effect<void>;
+    readonly onOutput: (
+        streamName: SupervisedProcessOutputStream,
+        chunk: Uint8Array,
+    ) => Effect.Effect<void>;
+}
+
+const runChildProcess = Effect.fn("supervisedProcess.runChildProcess")(
+    function* (
+        options: RunChildOptions,
+    ): Effect.fn.Return<
+        ProcessExit,
+        SupervisedProcessSpawnError,
+        ChildProcessSpawner.ChildProcessSpawner | HttpClient.HttpClient | Scope.Scope
+    > {
+        const { config } = options;
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const command = ChildProcess.make(config.executablePath, config.args, {
+            cwd: config.cwd,
+            env: config.env,
+            extendEnv: true,
+            stdin: "ignore",
+            stdout: "pipe",
+            stderr: "pipe",
+            killSignal: "SIGTERM",
+            forceKillAfter: DEFAULT_TERMINATE_GRACE,
+        });
+
+        const handle = yield* spawner
+            .spawn(command)
+            .pipe(
+                Effect.mapError(
+                    (cause) => new SupervisedProcessSpawnError({ cause }),
+                ),
+            );
+
+        yield* options.onStarted(handle.pid);
+        yield* drainOutput("stdout", handle.stdout, options.onOutput).pipe(
+            Effect.forkScoped,
+        );
+        yield* drainOutput("stderr", handle.stderr, options.onOutput).pipe(
+            Effect.forkScoped,
+        );
+        yield* waitForHttpReady(
+            config.readiness.url,
+            config.readiness.timeout,
+        ).pipe(
+            Effect.tap(() => options.onReady()),
+            Effect.catch((error) => options.onReadinessFailure(error)),
+            Effect.forkScoped,
+        );
+
+        return describeProcessExit(yield* Effect.result(handle.exitCode));
+    },
+);
+
+// ---------------------------------------------------------------------------
+// Supervisor factory
+// ---------------------------------------------------------------------------
+
+export const makeSupervisedProcess = Effect.fn("makeSupervisedProcess")(
+    function* (
+        config: SupervisedProcessConfig,
+        hooks: SupervisedProcessHooks = {},
+    ): Effect.fn.Return<
+        SupervisedProcess,
+        never,
+        | ChildProcessSpawner.ChildProcessSpawner
+        | HttpClient.HttpClient
+        | DesktopObservability.DesktopBackendOutputLog
+        | Scope.Scope
+    > {
+        const parentScope = yield* Scope.Scope;
+        const backendOutputLog = yield* DesktopObservability.DesktopBackendOutputLog;
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const httpClient = yield* HttpClient.HttpClient;
+        const state = yield* Ref.make(initialState);
+        const mutex = yield* Semaphore.make(1);
+
+        const { logWarning, logError } =
+            DesktopObservability.makeComponentLogger(
+                `supervised-process:${config.name}`,
+            );
+
+        const updateActiveRun = (
+            runId: number,
+            f: (run: ActiveRun) => ActiveRun,
+        ) => Ref.update(state, withActiveRun(runId, f));
+
+        const snapshot = Ref.get(state).pipe(
+            Effect.map(
+                (current): SupervisedProcessSnapshot => ({
+                    ready: current.ready,
+                    activePid: Option.getOrNull(activePid(current.active)),
+                    restartAttempt: current.restartAttempt,
+                }),
+            ),
+        );
+
+        const cancelRestart = Effect.gen(function* () {
+            const restartFiber = yield* Ref.modify(state, (current) => [
+                current.restartFiber,
+                { ...current, restartFiber: Option.none() },
+            ]);
+            yield* Option.match(restartFiber, {
+                onNone: () => Effect.void,
+                onSome: (fiber) => Fiber.interrupt(fiber).pipe(Effect.asVoid),
+            });
+        });
+
+        // Forward declaration so `start` and `scheduleRestart` can refer to
+        // each other.
+        let scheduleRestart: (reason: string) => Effect.Effect<void>;
+
+        const start: Effect.Effect<void> = Effect.suspend(() =>
+            mutex.withPermits(1)(
+                Effect.gen(function* () {
+                    const current = yield* Ref.get(state);
+                    if (Option.isSome(current.active)) {
+                        return;
+                    }
+
+                    yield* cancelRestart;
+                    yield* Ref.update(state, (latest) => ({
+                        ...latest,
+                        desiredRunning: true,
+                        ready: false,
+                    }));
+
+                    const runScope = yield* Scope.make("sequential");
+                    const runId = yield* Ref.modify(state, (latest) => [
+                        latest.nextRunId,
+                        {
+                            ...latest,
+                            active: Option.some({
+                                id: latest.nextRunId,
+                                scope: runScope,
+                                fiber: Option.none(),
+                                pid: Option.none(),
+                            } satisfies ActiveRun),
+                            nextRunId: latest.nextRunId + 1,
+                        },
+                    ]);
+
+                    const finalizeRun = (reason: string) =>
+                        mutex.withPermits(1)(
+                            Effect.gen(function* () {
+                                const { isCurrentRun, desiredRunning, pid } =
+                                    yield* Ref.modify(
+                                        state,
+                                        (
+                                            latest,
+                                        ): readonly [
+                                            {
+                                                readonly isCurrentRun: boolean;
+                                                readonly desiredRunning: boolean;
+                                                readonly pid: Option.Option<number>;
+                                            },
+                                            SupervisorState,
+                                        ] => {
+                                            const currentRun =
+                                                Option.getOrUndefined(
+                                                    latest.active,
+                                                );
+                                            if (currentRun?.id !== runId) {
+                                                return [
+                                                    {
+                                                        isCurrentRun: false,
+                                                        desiredRunning:
+                                                            latest.desiredRunning,
+                                                        pid: Option.none<number>(),
+                                                    },
+                                                    latest,
+                                                ] as const;
+                                            }
+                                            return [
+                                                {
+                                                    isCurrentRun: true,
+                                                    desiredRunning:
+                                                        latest.desiredRunning,
+                                                    pid: currentRun.pid,
+                                                },
+                                                {
+                                                    ...latest,
+                                                    active: Option.none<ActiveRun>(),
+                                                    ready: false,
+                                                },
+                                            ] as const;
+                                        },
+                                    );
+
+                                if (!isCurrentRun) {
+                                    return;
+                                }
+
+                                yield* backendOutputLog.writeSessionBoundary({
+                                    phase: "END",
+                                    details: `pid=${Option.getOrElse(
+                                        pid,
+                                        () => -1,
+                                    )} ${reason}`,
+                                });
+                                yield* hooks.onExit?.({
+                                    pid: Option.getOrNull(pid),
+                                    reason,
+                                }) ?? Effect.void;
+
+                                if (desiredRunning) {
+                                    yield* scheduleRestart(reason);
+                                }
+                            }),
+                        );
+
+                    const program = runChildProcess({
+                        config,
+                        onStarted: (pid) =>
+                            Effect.gen(function* () {
+                                yield* updateActiveRun(runId, (run) => ({
+                                    ...run,
+                                    pid: Option.some(pid),
+                                }));
+                                yield* backendOutputLog.writeSessionBoundary({
+                                    phase: "START",
+                                    details: `pid=${pid} cwd=${config.cwd}`,
+                                });
+                            }),
+                        onReady: () =>
+                            Effect.gen(function* () {
+                                const isCurrentRun = yield* Ref.modify(
+                                    state,
+                                    (latest) => {
+                                        const run = Option.getOrUndefined(
+                                            latest.active,
+                                        );
+                                        if (run?.id !== runId) {
+                                            return [false, latest] as const;
+                                        }
+                                        return [
+                                            true,
+                                            {
+                                                ...latest,
+                                                restartAttempt: 0,
+                                                ready: true,
+                                            },
+                                        ] as const;
+                                    },
+                                );
+                                if (!isCurrentRun) {
+                                    return;
+                                }
+                                yield* hooks.onReady?.() ?? Effect.void;
+                            }),
+                        onReadinessFailure: (error) =>
+                            logWarning(
+                                "process readiness check failed during bootstrap",
+                                { error: error.message },
+                            ),
+                        onOutput: (streamName, chunk) =>
+                            backendOutputLog.writeOutputChunk(streamName, chunk),
+                    }).pipe(
+                        Effect.provideService(
+                            ChildProcessSpawner.ChildProcessSpawner,
+                            spawner,
+                        ),
+                        Effect.provideService(
+                            HttpClient.HttpClient,
+                            httpClient,
+                        ),
+                        Scope.provide(runScope),
+                        Effect.matchEffect({
+                            onFailure: (error) => finalizeRun(error.message),
+                            onSuccess: (exit) => finalizeRun(exit.reason),
+                        }),
+                        Effect.ensuring(
+                            Scope.close(runScope, Exit.void).pipe(Effect.ignore),
+                        ),
+                    );
+
+                    const fiber = yield* Effect.forkIn(program, parentScope);
+                    yield* updateActiveRun(runId, (run) => ({
+                        ...run,
+                        fiber: Option.some(fiber),
+                    }));
+                }),
+            ),
+        );
+
+        scheduleRestart = (reason: string) =>
+            Effect.gen(function* () {
+                const scheduled = yield* Ref.modify(state, (latest) => {
+                    if (
+                        !latest.desiredRunning ||
+                        Option.isSome(latest.restartFiber)
+                    ) {
+                        return [
+                            Option.none<Duration.Duration>(),
+                            latest,
+                        ] as const;
+                    }
+                    const delay = calculateRestartDelay(latest.restartAttempt);
+                    return [
+                        Option.some(delay),
+                        {
+                            ...latest,
+                            restartAttempt: latest.restartAttempt + 1,
+                        },
+                    ] as const;
+                });
+
+                yield* Option.match(scheduled, {
+                    onNone: () => Effect.void,
+                    onSome: (delay) =>
+                        Effect.gen(function* () {
+                            yield* logError(
+                                "process exited unexpectedly; restart scheduled",
+                                {
+                                    reason,
+                                    delayMs: Duration.toMillis(delay),
+                                },
+                            );
+                            const restartFiber = yield* Effect.forkIn(
+                                Effect.sleep(delay).pipe(
+                                    Effect.andThen(
+                                        Ref.modify(state, (latest) => [
+                                            latest.desiredRunning,
+                                            {
+                                                ...latest,
+                                                restartFiber: Option.none(),
+                                            },
+                                        ]),
+                                    ),
+                                    Effect.flatMap((shouldRestart) =>
+                                        shouldRestart ? start : Effect.void,
+                                    ),
+                                    Effect.catchCause((cause) =>
+                                        logError("restart fiber failed", {
+                                            cause: Cause.pretty(cause),
+                                        }),
+                                    ),
+                                ),
+                                parentScope,
+                            );
+                            yield* Ref.update(state, (latest) =>
+                                Option.isNone(latest.restartFiber)
+                                    ? {
+                                          ...latest,
+                                          restartFiber:
+                                              Option.some(restartFiber),
+                                      }
+                                    : latest,
+                            );
+                        }),
+                });
+            });
+
+        const stop: SupervisedProcess["stop"] = (options) =>
+            Effect.gen(function* () {
+                const { active, restartFiber } = yield* mutex.withPermits(1)(
+                    Ref.modify(state, (latest) => [
+                        {
+                            active: latest.active,
+                            restartFiber: latest.restartFiber,
+                        },
+                        {
+                            ...latest,
+                            desiredRunning: false,
+                            ready: false,
+                            active: Option.none<ActiveRun>(),
+                            restartFiber:
+                                Option.none<Fiber.Fiber<void, never>>(),
+                        },
+                    ]),
+                );
+
+                yield* Option.match(restartFiber, {
+                    onNone: () => Effect.void,
+                    onSome: (fiber) =>
+                        Fiber.interrupt(fiber).pipe(Effect.asVoid),
+                });
+                yield* Option.match(active, {
+                    onNone: () => Effect.void,
+                    onSome: (run) => closeRun(run, options),
+                });
+            });
+
+        yield* Effect.addFinalizer(() => stop());
+
+        return { start, stop, snapshot } satisfies SupervisedProcess;
+    },
+);

--- a/apps/studio-desktop/src/electron/ElectronApp.ts
+++ b/apps/studio-desktop/src/electron/ElectronApp.ts
@@ -1,0 +1,65 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+
+import * as Electron from "electron";
+
+export interface ElectronAppMetadata {
+  readonly appName: string;
+  readonly appVersion: string;
+}
+
+export interface ElectronAppShape {
+  readonly metadata: Effect.Effect<ElectronAppMetadata>;
+  readonly on: <Args extends ReadonlyArray<unknown>>(
+    eventName: string,
+    listener: (...args: Args) => void,
+  ) => Effect.Effect<void, never, Scope.Scope>;
+  readonly quit: Effect.Effect<void>;
+  readonly exit: (code: number) => Effect.Effect<void>;
+  readonly relaunch: (options: Electron.RelaunchOptions) => Effect.Effect<void>;
+  readonly whenReady: Effect.Effect<void>;
+  readonly requestSingleInstanceLock: Effect.Effect<boolean>;
+}
+
+export class ElectronApp extends Context.Service<ElectronApp, ElectronAppShape>()(
+  "@ax/studio-desktop/electron/ElectronApp",
+) {}
+
+const addScopedAppListener = <Args extends ReadonlyArray<unknown>>(
+  eventName: string,
+  listener: (...args: Args) => void,
+): Effect.Effect<void, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.sync(() => {
+      Electron.app.on(eventName as any, listener as any);
+    }),
+    () =>
+      Effect.sync(() => {
+        Electron.app.removeListener(eventName as any, listener as any);
+      }),
+  ).pipe(Effect.asVoid);
+
+const make = ElectronApp.of({
+  metadata: Effect.sync(() => ({
+    appName: Electron.app.getName(),
+    appVersion: Electron.app.getVersion(),
+  })),
+  on: addScopedAppListener,
+  quit: Effect.sync(() => {
+    Electron.app.quit();
+  }),
+  exit: (code) =>
+    Effect.sync(() => {
+      Electron.app.exit(code);
+    }),
+  relaunch: (options) =>
+    Effect.sync(() => {
+      Electron.app.relaunch(options);
+    }),
+  whenReady: Effect.promise(() => Electron.app.whenReady()).pipe(Effect.asVoid),
+  requestSingleInstanceLock: Effect.sync(() => Electron.app.requestSingleInstanceLock()),
+});
+
+export const layer = Layer.succeed(ElectronApp, make);

--- a/apps/studio-desktop/src/electron/ElectronMenu.ts
+++ b/apps/studio-desktop/src/electron/ElectronMenu.ts
@@ -1,0 +1,66 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as Electron from "electron";
+
+export interface ElectronMenuShape {
+  /**
+   * Install a minimal application menu. On macOS this provides the standard
+   * App / Edit / View menus so that the About/Quit items and Cmd-based
+   * copy/paste/reload/devtools shortcuts work. On other platforms the menu is
+   * cleared (the studio SPA owns its own chrome).
+   */
+  readonly installApplicationMenu: Effect.Effect<void>;
+}
+
+export class ElectronMenu extends Context.Service<ElectronMenu, ElectronMenuShape>()(
+  "@ax/studio-desktop/electron/ElectronMenu",
+) {}
+
+const buildMacApplicationMenuTemplate = (): Electron.MenuItemConstructorOptions[] => {
+  const appName = Electron.app.getName();
+  return [
+    {
+      label: appName,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        { role: "quit", accelerator: "Command+Q" },
+      ],
+    },
+    {
+      label: "Edit",
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "selectAll" },
+      ],
+    },
+    {
+      label: "View",
+      submenu: [
+        { role: "reload" },
+        { role: "toggleDevTools" },
+      ],
+    },
+  ];
+};
+
+const make = ElectronMenu.of({
+  installApplicationMenu: Effect.sync(() => {
+    if (process.platform !== "darwin") {
+      Electron.Menu.setApplicationMenu(null);
+      return;
+    }
+    Electron.Menu.setApplicationMenu(
+      Electron.Menu.buildFromTemplate(buildMacApplicationMenuTemplate()),
+    );
+  }),
+});
+
+export const layer = Layer.succeed(ElectronMenu, make);

--- a/apps/studio-desktop/src/electron/ElectronProtocol.ts
+++ b/apps/studio-desktop/src/electron/ElectronProtocol.ts
@@ -1,0 +1,264 @@
+import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Scope from "effect/Scope";
+
+import * as Electron from "electron";
+
+import { DesktopEnvironment, type DesktopEnvironmentShape } from "../app/DesktopEnvironment.ts";
+
+export const DESKTOP_SCHEME = "ax";
+
+export class ElectronProtocolRegistrationError extends Data.TaggedError(
+  "ElectronProtocolRegistrationError",
+)<{
+  readonly scheme: string;
+  readonly cause: unknown;
+}> {
+  override get message() {
+    return `Failed to register ${this.scheme}: file protocol.`;
+  }
+}
+
+export class ElectronProtocolStaticBundleMissingError extends Data.TaggedError(
+  "ElectronProtocolStaticBundleMissingError",
+)<{}> {
+  override get message() {
+    return "Studio static bundle missing. Build apps/studio (with bundled client) first.";
+  }
+}
+
+export interface ElectronProtocolShape {
+  readonly registerFileProtocol: <E, R>(input: {
+    readonly scheme: string;
+    readonly handler: (
+      request: Electron.ProtocolRequest,
+    ) => Effect.Effect<Electron.ProtocolResponse, E, R>;
+    readonly onFailure?: (
+      request: Electron.ProtocolRequest,
+      cause: Cause.Cause<E>,
+    ) => Electron.ProtocolResponse;
+  }) => Effect.Effect<void, ElectronProtocolRegistrationError, R | Scope.Scope>;
+  readonly registerDesktopFileProtocol: Effect.Effect<
+    void,
+    ElectronProtocolRegistrationError | ElectronProtocolStaticBundleMissingError,
+    FileSystem.FileSystem | DesktopEnvironment | Scope.Scope
+  >;
+}
+
+export class ElectronProtocol extends Context.Service<ElectronProtocol, ElectronProtocolShape>()(
+  "@ax/studio-desktop/electron/ElectronProtocol",
+) {}
+
+export function normalizeDesktopProtocolPathname(rawPath: string): Option.Option<string> {
+  const segments: string[] = [];
+  for (const segment of rawPath.split("/")) {
+    if (segment.length === 0 || segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      return Option.none();
+    }
+    segments.push(segment);
+  }
+  return Option.some(segments.join("/"));
+}
+
+const registerDesktopSchemePrivileges = Effect.sync(() => {
+  Electron.protocol.registerSchemesAsPrivileged([
+    {
+      scheme: DESKTOP_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+      },
+    },
+  ]);
+}).pipe(Effect.withSpan("desktop.electron.protocol.registerSchemePrivileges"));
+
+export const layerSchemePrivileges = Layer.effectDiscard(registerDesktopSchemePrivileges);
+
+const resolveDesktopStaticDir: Effect.Effect<
+  Option.Option<string>,
+  never,
+  FileSystem.FileSystem | DesktopEnvironment
+> = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const environment = yield* DesktopEnvironment;
+  const candidate = environment.studioStaticDir;
+  const hasIndex = yield* fileSystem
+    .exists(environment.path.join(candidate, "index.html"))
+    .pipe(Effect.orElseSucceed(() => false));
+  return hasIndex ? Option.some(candidate) : Option.none<string>();
+});
+
+const resolveDesktopStaticPath = Effect.fn("desktop.electron.protocol.resolveDesktopStaticPath")(
+  function* (
+    staticRoot: string,
+    requestUrl: string,
+  ): Effect.fn.Return<string, never, FileSystem.FileSystem | DesktopEnvironment> {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const environment = yield* DesktopEnvironment;
+    const url = new URL(requestUrl);
+    const rawPath = decodeURIComponent(url.pathname);
+    const normalizedPath = normalizeDesktopProtocolPathname(rawPath);
+    if (Option.isNone(normalizedPath)) {
+      return environment.path.join(staticRoot, "index.html");
+    }
+
+    const requestedPath = normalizedPath.value.length > 0 ? normalizedPath.value : "index.html";
+    const resolvedPath = environment.path.join(staticRoot, requestedPath);
+
+    if (environment.path.extname(resolvedPath)) {
+      return resolvedPath;
+    }
+
+    const nestedIndex = environment.path.join(resolvedPath, "index.html");
+    const nestedIndexExists = yield* fileSystem
+      .exists(nestedIndex)
+      .pipe(Effect.orElseSucceed(() => false));
+    if (nestedIndexExists) {
+      return nestedIndex;
+    }
+
+    return environment.path.join(staticRoot, "index.html");
+  },
+);
+
+function isStaticAssetRequest(requestUrl: string, environment: DesktopEnvironmentShape): boolean {
+  try {
+    const url = new URL(requestUrl);
+    return environment.path.extname(url.pathname).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+const make = Effect.gen(function* () {
+  const registeredProtocols = yield* Ref.make<ReadonlySet<string>>(new Set());
+
+  const registerFileProtocol = Effect.fn("desktop.electron.protocol.registerFileProtocol")(
+    function* <E, R>({
+      scheme,
+      handler,
+      onFailure,
+    }: {
+      readonly scheme: string;
+      readonly handler: (
+        request: Electron.ProtocolRequest,
+      ) => Effect.Effect<Electron.ProtocolResponse, E, R>;
+      readonly onFailure?: (
+        request: Electron.ProtocolRequest,
+        cause: Cause.Cause<E>,
+      ) => Electron.ProtocolResponse;
+    }): Effect.fn.Return<void, ElectronProtocolRegistrationError, R | Scope.Scope> {
+      yield* Effect.annotateCurrentSpan({ scheme });
+      const alreadyRegistered = yield* Ref.get(registeredProtocols).pipe(
+        Effect.map((protocols) => protocols.has(scheme)),
+      );
+      if (alreadyRegistered) {
+        return;
+      }
+
+      const context = yield* Effect.context<R>();
+      const runPromise = Effect.runPromiseWith(context);
+
+      yield* Effect.acquireRelease(
+        Effect.try({
+          try: () => {
+            const registered = Electron.protocol.registerFileProtocol(
+              scheme,
+              (request, callback) => {
+                const response = handler(request).pipe(
+                  Effect.withSpan("desktop.electron.protocol.handleFileRequest"),
+                  Effect.catchCause((cause) =>
+                    Effect.succeed(onFailure?.(request, cause) ?? ({ error: -2 } as const)),
+                  ),
+                );
+
+                void runPromise(response).then(callback, () => callback({ error: -2 }));
+              },
+            );
+            if (!registered) {
+              throw new ElectronProtocolRegistrationError({
+                scheme,
+                cause: "registerFileProtocol returned false",
+              });
+            }
+          },
+          catch: (cause) =>
+            cause instanceof ElectronProtocolRegistrationError
+              ? cause
+              : new ElectronProtocolRegistrationError({ scheme, cause }),
+        }).pipe(
+          Effect.andThen(
+            Ref.update(registeredProtocols, (protocols) => new Set(protocols).add(scheme)),
+          ),
+        ),
+        () =>
+          Effect.sync(() => {
+            Electron.protocol.unregisterProtocol(scheme);
+          }).pipe(
+            Effect.andThen(
+              Ref.update(registeredProtocols, (protocols) => {
+                const next = new Set(protocols);
+                next.delete(scheme);
+                return next;
+              }),
+            ),
+          ),
+      );
+    },
+  );
+
+  const registerDesktopFileProtocol = Effect.gen(function* () {
+    const environment = yield* DesktopEnvironment;
+    if (environment.isDevelopment) return;
+
+    const staticRoot = yield* resolveDesktopStaticDir;
+    if (Option.isNone(staticRoot)) {
+      return yield* new ElectronProtocolStaticBundleMissingError();
+    }
+
+    const staticRootResolved = environment.path.resolve(staticRoot.value);
+    const staticRootPrefix = `${staticRootResolved}${environment.path.sep}`;
+    const fallbackIndex = environment.path.join(staticRootResolved, "index.html");
+
+    yield* registerFileProtocol({
+      scheme: DESKTOP_SCHEME,
+      handler: Effect.fn("desktop.electron.protocol.handleDesktopFileRequest")(function* (request) {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const environment = yield* DesktopEnvironment;
+        const candidate = yield* resolveDesktopStaticPath(staticRootResolved, request.url);
+        const resolvedCandidate = environment.path.resolve(candidate);
+        const isInRoot =
+          resolvedCandidate === fallbackIndex || resolvedCandidate.startsWith(staticRootPrefix);
+        const isAssetRequest = isStaticAssetRequest(request.url, environment);
+        const exists = yield* fileSystem
+          .exists(resolvedCandidate)
+          .pipe(Effect.orElseSucceed(() => false));
+
+        if (!isInRoot || !exists) {
+          return isAssetRequest ? ({ error: -6 } as const) : ({ path: fallbackIndex } as const);
+        }
+
+        return { path: resolvedCandidate } as const;
+      }),
+      onFailure: () => ({ path: fallbackIndex }),
+    });
+  }).pipe(Effect.withSpan("desktop.electron.protocol.registerDesktopFileProtocol"));
+
+  return ElectronProtocol.of({
+    registerFileProtocol,
+    registerDesktopFileProtocol,
+  });
+});
+
+export const layer = Layer.effect(ElectronProtocol, make);

--- a/apps/studio-desktop/src/electron/ElectronShell.ts
+++ b/apps/studio-desktop/src/electron/ElectronShell.ts
@@ -1,0 +1,50 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
+import * as Electron from "electron";
+
+const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
+
+export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
+  if (typeof rawUrl !== "string") {
+    return Option.none();
+  }
+
+  try {
+    const url = new URL(rawUrl);
+    return SAFE_EXTERNAL_PROTOCOLS.has(url.protocol) ? Option.some(url.href) : Option.none();
+  } catch {
+    return Option.none();
+  }
+}
+
+export interface ElectronShellShape {
+  /**
+   * Open an external URL in the system browser. Returns `false` (without
+   * touching the shell) for anything that is not a well-formed http(s) URL,
+   * so studio links never escape into arbitrary protocol handlers.
+   */
+  readonly openExternal: (rawUrl: unknown) => Effect.Effect<boolean>;
+}
+
+export class ElectronShell extends Context.Service<ElectronShell, ElectronShellShape>()(
+  "@ax/studio-desktop/electron/ElectronShell",
+) {}
+
+const make = ElectronShell.of({
+  openExternal: (rawUrl) =>
+    Option.match(parseSafeExternalUrl(rawUrl), {
+      onNone: () => Effect.succeed(false),
+      onSome: (externalUrl) =>
+        Effect.promise(() =>
+          Electron.shell.openExternal(externalUrl).then(
+            () => true,
+            () => false,
+          ),
+        ),
+    }),
+});
+
+export const layer = Layer.succeed(ElectronShell, make);

--- a/apps/studio-desktop/src/electron/ElectronWindow.ts
+++ b/apps/studio-desktop/src/electron/ElectronWindow.ts
@@ -1,0 +1,135 @@
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+
+import * as Electron from "electron";
+
+export class ElectronWindowCreateError extends Data.TaggedError("ElectronWindowCreateError")<{
+  readonly cause: unknown;
+}> {
+  override get message() {
+    return "Failed to create Electron BrowserWindow.";
+  }
+}
+
+export interface ElectronWindowShape {
+  readonly create: (
+    options: Electron.BrowserWindowConstructorOptions,
+  ) => Effect.Effect<Electron.BrowserWindow, ElectronWindowCreateError>;
+  readonly main: Effect.Effect<Option.Option<Electron.BrowserWindow>>;
+  readonly currentMainOrFirst: Effect.Effect<Option.Option<Electron.BrowserWindow>>;
+  readonly focusedMainOrFirst: Effect.Effect<Option.Option<Electron.BrowserWindow>>;
+  readonly setMain: (window: Electron.BrowserWindow) => Effect.Effect<void>;
+  readonly clearMain: (window: Option.Option<Electron.BrowserWindow>) => Effect.Effect<void>;
+  readonly reveal: (window: Electron.BrowserWindow) => Effect.Effect<void>;
+  readonly sendAll: (channel: string, ...args: readonly unknown[]) => Effect.Effect<void>;
+  readonly destroyAll: Effect.Effect<void>;
+  readonly syncAllAppearance: <E, R>(
+    sync: (window: Electron.BrowserWindow) => Effect.Effect<void, E, R>,
+  ) => Effect.Effect<void, E, R>;
+}
+
+export class ElectronWindow extends Context.Service<ElectronWindow, ElectronWindowShape>()(
+  "@ax/studio-desktop/electron/ElectronWindow",
+) {}
+
+const make = Effect.gen(function* () {
+  const mainWindowRef = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+
+  const liveMain = Ref.get(mainWindowRef).pipe(
+    Effect.map(Option.filter((value) => !value.isDestroyed())),
+  );
+
+  const currentMainOrFirst = Effect.gen(function* () {
+    const main = yield* liveMain;
+    if (Option.isSome(main)) {
+      return main;
+    }
+
+    return Option.fromNullishOr(Electron.BrowserWindow.getAllWindows()[0] ?? null).pipe(
+      Option.filter((window) => !window.isDestroyed()),
+    );
+  });
+
+  const focusedMainOrFirst = Effect.sync(() =>
+    Option.fromNullishOr(Electron.BrowserWindow.getFocusedWindow() ?? null).pipe(
+      Option.filter((window) => !window.isDestroyed()),
+    ),
+  ).pipe(
+    Effect.flatMap((focused) =>
+      Option.isSome(focused) ? Effect.succeed(focused) : currentMainOrFirst,
+    ),
+  );
+
+  return ElectronWindow.of({
+    create: (options) =>
+      Effect.try({
+        try: () => new Electron.BrowserWindow(options),
+        catch: (cause) => new ElectronWindowCreateError({ cause }),
+      }),
+    main: liveMain,
+    currentMainOrFirst,
+    focusedMainOrFirst,
+    setMain: (window) => Ref.set(mainWindowRef, Option.some(window)),
+    clearMain: (window) =>
+      Ref.update(mainWindowRef, (current) => {
+        if (Option.isNone(current)) {
+          return current;
+        }
+        if (Option.isSome(window) && current.value !== window.value) {
+          return current;
+        }
+        return Option.none();
+      }),
+    reveal: (window) =>
+      Effect.sync(() => {
+        if (window.isDestroyed()) {
+          return;
+        }
+
+        if (window.isMinimized()) {
+          window.restore();
+        }
+
+        if (!window.isVisible()) {
+          window.show();
+        }
+
+        if (process.platform === "darwin") {
+          Electron.app.focus({ steal: true });
+        }
+
+        window.focus();
+      }),
+    sendAll: (channel, ...args) =>
+      Effect.sync(() => {
+        for (const window of Electron.BrowserWindow.getAllWindows()) {
+          if (window.isDestroyed()) {
+            continue;
+          }
+          window.webContents.send(channel, ...args);
+        }
+      }),
+    destroyAll: Effect.sync(() => {
+      for (const window of Electron.BrowserWindow.getAllWindows()) {
+        window.destroy();
+      }
+    }),
+    syncAllAppearance: Effect.fn("desktop.electron.window.syncAllAppearance")(function* <E, R>(
+      sync: (window: Electron.BrowserWindow) => Effect.Effect<void, E, R>,
+    ) {
+      const windows = Electron.BrowserWindow.getAllWindows();
+      for (const window of windows) {
+        if (window.isDestroyed()) {
+          continue;
+        }
+        yield* sync(window);
+      }
+    }),
+  });
+});
+
+export const layer = Layer.effect(ElectronWindow, make);

--- a/apps/studio-desktop/src/main.ts
+++ b/apps/studio-desktop/src/main.ts
@@ -45,10 +45,12 @@ const makeEnvironmentInput: DesktopEnvironment.MakeDesktopEnvironmentInput = {
     processArch: process.arch,
     // Dev-only fallbacks. When packaged, DesktopEnvironment resolves the real
     // per-arch vendored binaries under <resourcesPath>/bin/<arch>/ (staged by
-    // scripts/fetch-binaries.ts); these values are then ignored. In dev,
-    // surreal is looked up on PATH and bun resolves to the running Electron node.
-    surrealBinaryPath: "surreal",
-    bunBinaryPath: process.execPath,
+    // scripts/fetch-binaries.ts); these values are then ignored. In dev, both
+    // are looked up on PATH. NOTE: bun must be the real `bun` binary, NOT
+    // `process.execPath` (that's the Electron binary) - `ax serve` is a bun
+    // program (uses @effect/platform-bun) and fails under Electron's node.
+    surrealBinaryPath: process.env.AX_SURREAL_PATH ?? "surreal",
+    bunBinaryPath: process.env.AX_BUN_PATH ?? "bun",
     // Canonical ax data dir: mirror @ax/lib config + daemon install scripts so
     // desktop and the CLI daemon agree on the rocksdb location.
     homeDir: Electron.app.getPath("home"),

--- a/apps/studio-desktop/src/main.ts
+++ b/apps/studio-desktop/src/main.ts
@@ -8,6 +8,7 @@ import * as Layer from "effect/Layer";
 
 import * as Electron from "electron";
 
+import * as AxBackendManager from "./backend/AxBackendManager.ts";
 import * as DesktopApp from "./app/DesktopApp.ts";
 import * as DesktopEnvironment from "./app/DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./app/DesktopLifecycle.ts";
@@ -82,8 +83,18 @@ const foundationLayer = Layer.mergeAll(
     DesktopWindow.layer,
 ).pipe(Layer.provideMerge(environmentLayer));
 
-// Application layer = electron services + foundation, provided platform deps.
-const desktopApplicationLayer = foundationLayer.pipe(
+// Phase 2 backend supervisor, provide-merged ON TOP of foundation so it can
+// consume foundation's DesktopState/DesktopWindow/DesktopBackendOutputLog +
+// DesktopEnvironment. The platform deps (ChildProcessSpawner/HttpClient) come
+// from the platform layer below. Sibling `mergeAll` layers do NOT feed each
+// other, so this must be a `provideMerge`, not another `mergeAll` entry.
+const foundationWithBackendLayer = AxBackendManager.liveLayer.pipe(
+    Layer.provideMerge(foundationLayer),
+);
+
+// Application layer = electron services + foundation (incl. backend supervisor),
+// provided platform deps.
+const desktopApplicationLayer = foundationWithBackendLayer.pipe(
     Layer.provideMerge(electronLayer),
     Layer.provideMerge(platformLayer),
 );

--- a/apps/studio-desktop/src/main.ts
+++ b/apps/studio-desktop/src/main.ts
@@ -46,6 +46,10 @@ const makeEnvironmentInput: DesktopEnvironment.MakeDesktopEnvironmentInput = {
     // window-open flow.
     surrealBinaryPath: "surreal",
     bunBinaryPath: process.execPath,
+    // Canonical ax data dir: mirror @ax/lib config + daemon install scripts so
+    // desktop and the CLI daemon agree on the rocksdb location.
+    homeDir: Electron.app.getPath("home"),
+    axDataDirOverride: process.env.AX_DATA_DIR,
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/studio-desktop/src/main.ts
+++ b/apps/studio-desktop/src/main.ts
@@ -1,0 +1,94 @@
+import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as NodePath from "node:path";
+
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as Electron from "electron";
+
+import * as DesktopApp from "./app/DesktopApp.ts";
+import * as DesktopEnvironment from "./app/DesktopEnvironment.ts";
+import * as DesktopLifecycle from "./app/DesktopLifecycle.ts";
+import * as DesktopObservability from "./app/DesktopObservability.ts";
+import * as DesktopState from "./app/DesktopState.ts";
+import * as ElectronApp from "./electron/ElectronApp.ts";
+import * as ElectronMenu from "./electron/ElectronMenu.ts";
+import * as ElectronProtocol from "./electron/ElectronProtocol.ts";
+import * as ElectronShell from "./electron/ElectronShell.ts";
+import * as ElectronWindow from "./electron/ElectronWindow.ts";
+import * as DesktopWindow from "./window/DesktopWindow.ts";
+
+// ---------------------------------------------------------------------------
+// Environment input - resolved from electron `app` + node `process`/`os`.
+// The foundation modules never import electron at module scope, so main.ts is
+// the single place these raw values are read.
+// ---------------------------------------------------------------------------
+
+// `__dirname` of the bundled main process == `<app>/dist-electron`.
+// In dev the repo root is three levels up: dist-electron -> studio-desktop ->
+// apps -> repo root.
+const repoRoot = NodePath.resolve(__dirname, "..", "..", "..");
+
+const isDevelopment = !Electron.app.isPackaged;
+
+const makeEnvironmentInput: DesktopEnvironment.MakeDesktopEnvironmentInput = {
+    dirname: __dirname,
+    repoRoot,
+    isDevelopment,
+    resourcesPath: process.resourcesPath,
+    userDataDir: Electron.app.getPath("userData"),
+    platform: process.platform,
+    processArch: process.arch,
+    // Phase 2 (backend supervisor) resolves the real bundled binary locations.
+    // Until then we fall back to PATH lookups, which are unused by the Phase 1
+    // window-open flow.
+    surrealBinaryPath: "surreal",
+    bunBinaryPath: process.execPath,
+};
+
+// ---------------------------------------------------------------------------
+// Layer composition.
+// ---------------------------------------------------------------------------
+
+// Electron service tags. None of these need FileSystem/Path/HttpClient.
+const electronLayer = Layer.mergeAll(
+    ElectronApp.layer,
+    ElectronMenu.layer,
+    ElectronProtocol.layer,
+    ElectronShell.layer,
+    ElectronWindow.layer,
+);
+
+// Platform deps: NodeServices supplies FileSystem + Path (+ stdio/terminal/etc);
+// NodeHttpClient supplies the HTTP client used by Phase 2 readiness probes.
+const platformLayer = Layer.mergeAll(NodeServices.layer, NodeHttpClient.layerUndici);
+
+// DesktopEnvironment needs Path (from NodeServices) to build its paths.
+const environmentLayer = DesktopEnvironment.layer(makeEnvironmentInput);
+
+// Foundation services. DesktopObservability + DesktopEnvironment need
+// FileSystem/Path; DesktopWindow needs DesktopEnvironment + electron services.
+const foundationLayer = Layer.mergeAll(
+    DesktopState.layer,
+    DesktopObservability.layer,
+    DesktopLifecycle.layerShutdown,
+    DesktopLifecycle.layer,
+    DesktopWindow.layer,
+).pipe(Layer.provideMerge(environmentLayer));
+
+// Application layer = electron services + foundation, provided platform deps.
+const desktopApplicationLayer = foundationLayer.pipe(
+    Layer.provideMerge(electronLayer),
+    Layer.provideMerge(platformLayer),
+);
+
+// Scheme privileges MUST be registered before app `ready`. t3code applies this
+// as an eager layer that everything else is built on top of, so building the
+// runtime layer runs the registration first.
+const desktopRuntimeLayer = ElectronProtocol.layerSchemePrivileges.pipe(
+    Layer.flatMap(() => desktopApplicationLayer),
+);
+
+DesktopApp.program.pipe(Effect.provide(desktopRuntimeLayer), NodeRuntime.runMain);

--- a/apps/studio-desktop/src/main.ts
+++ b/apps/studio-desktop/src/main.ts
@@ -42,9 +42,10 @@ const makeEnvironmentInput: DesktopEnvironment.MakeDesktopEnvironmentInput = {
     userDataDir: Electron.app.getPath("userData"),
     platform: process.platform,
     processArch: process.arch,
-    // Phase 2 (backend supervisor) resolves the real bundled binary locations.
-    // Until then we fall back to PATH lookups, which are unused by the Phase 1
-    // window-open flow.
+    // Dev-only fallbacks. When packaged, DesktopEnvironment resolves the real
+    // per-arch vendored binaries under <resourcesPath>/bin/<arch>/ (staged by
+    // scripts/fetch-binaries.ts); these values are then ignored. In dev,
+    // surreal is looked up on PATH and bun resolves to the running Electron node.
     surrealBinaryPath: "surreal",
     bunBinaryPath: process.execPath,
     // Canonical ax data dir: mirror @ax/lib config + daemon install scripts so

--- a/apps/studio-desktop/src/main.ts
+++ b/apps/studio-desktop/src/main.ts
@@ -19,6 +19,7 @@ import * as ElectronMenu from "./electron/ElectronMenu.ts";
 import * as ElectronProtocol from "./electron/ElectronProtocol.ts";
 import * as ElectronShell from "./electron/ElectronShell.ts";
 import * as ElectronWindow from "./electron/ElectronWindow.ts";
+import * as DesktopUpdates from "./updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./window/DesktopWindow.ts";
 
 // ---------------------------------------------------------------------------
@@ -82,6 +83,7 @@ const foundationLayer = Layer.mergeAll(
     DesktopLifecycle.layerShutdown,
     DesktopLifecycle.layer,
     DesktopWindow.layer,
+    DesktopUpdates.layer,
 ).pipe(Layer.provideMerge(environmentLayer));
 
 // Phase 2 backend supervisor, provide-merged ON TOP of foundation so it can

--- a/apps/studio-desktop/src/preload.ts
+++ b/apps/studio-desktop/src/preload.ts
@@ -1,0 +1,9 @@
+import { contextBridge } from "electron";
+
+// Studio <-> daemon talks HTTP, so the preload surface is intentionally tiny.
+// We only expose a marker so the renderer can tell it is running inside the
+// desktop shell (and pick the bundled endpoint instead of prompting).
+contextBridge.exposeInMainWorld("axDesktop", {
+    isDesktop: true,
+    platform: process.platform,
+});

--- a/apps/studio-desktop/src/updates/DesktopUpdates.ts
+++ b/apps/studio-desktop/src/updates/DesktopUpdates.ts
@@ -1,0 +1,145 @@
+import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+// `electron-updater` is CommonJS and is left EXTERNAL by tsdown (see
+// tsdown.config.ts `external`), so at runtime this resolves to a plain
+// `require("electron-updater")`. tsdown emits CJS with esModuleInterop, so the
+// default import binds to `module.exports`.
+//
+// IMPORTANT: `autoUpdater` is a *lazy getter* on `module.exports` - touching it
+// instantiates the platform updater (MacUpdater/NsisUpdater/...), which reads
+// Electron's `app`. So it MUST NOT be destructured at module scope (that would
+// run before Electron is ready and crash). We keep the namespace and read
+// `electronUpdater.autoUpdater` lazily, inside the Effect, after app `ready`.
+import electronUpdater, { type AppUpdater } from "electron-updater";
+
+import * as DesktopObservability from "../app/DesktopObservability.ts";
+
+const {
+    logInfo: logUpdaterInfo,
+    logWarning: logUpdaterWarning,
+    logError: logUpdaterError,
+} = DesktopObservability.makeComponentLogger("updates");
+
+export interface DesktopUpdatesShape {
+    /**
+     * Trigger an update check against the GitHub feed baked into `app-update.yml`
+     * at package time. Downloads automatically (`autoDownload = true`) and
+     * installs on app quit (`autoInstallOnAppQuit = true`). A failed check is
+     * caught + logged here so it never propagates to the caller / crashes boot.
+     */
+    readonly checkForUpdates: Effect.Effect<void>;
+    /** Manually start a download (no-op unless `autoDownload` is false). */
+    readonly downloadUpdate: Effect.Effect<void>;
+    /** Quit and install a downloaded update. For future UI wiring. */
+    readonly quitAndInstall: Effect.Effect<void>;
+}
+
+export class DesktopUpdates extends Context.Service<DesktopUpdates, DesktopUpdatesShape>()(
+    "@ax/studio-desktop/updates/DesktopUpdates",
+) {}
+
+const make = Effect.gen(function* () {
+    // Capture the context so the (callback-based) electron-updater event handlers
+    // can run Effects (logging) with the foundation logger in scope.
+    const context = yield* Effect.context<never>();
+    const runLog = (effect: Effect.Effect<void>): void => {
+        void Effect.runPromiseWith(context)(effect);
+    };
+
+    // Resolve the lazy `autoUpdater` getter once, the first time we configure it.
+    // By the time `checkForUpdates` runs, Electron is `ready`, so instantiating
+    // the platform updater is safe.
+    let configured = false;
+    const resolveAutoUpdater = (): AppUpdater => {
+        const autoUpdater = electronUpdater.autoUpdater;
+        if (!configured) {
+            configured = true;
+
+            // Route electron-updater's internal logging through the foundation
+            // component logger.
+            autoUpdater.logger = {
+                info: (message?: unknown) => runLog(logUpdaterInfo(String(message ?? ""))),
+                warn: (message?: unknown) => runLog(logUpdaterWarning(String(message ?? ""))),
+                error: (message?: unknown) => runLog(logUpdaterError(String(message ?? ""))),
+                debug: (message: string) => runLog(logUpdaterInfo(message)),
+            };
+
+            autoUpdater.autoDownload = true;
+            autoUpdater.autoInstallOnAppQuit = true;
+
+            autoUpdater.on("checking-for-update", () => {
+                runLog(logUpdaterInfo("checking for updates"));
+            });
+            autoUpdater.on("update-available", (info: { readonly version?: string }) => {
+                runLog(logUpdaterInfo("update available", { version: info?.version }));
+            });
+            autoUpdater.on("update-not-available", () => {
+                runLog(logUpdaterInfo("no updates available"));
+            });
+            autoUpdater.on("download-progress", (progress: { readonly percent?: number }) => {
+                runLog(
+                    logUpdaterInfo("download progress", {
+                        percent:
+                            typeof progress?.percent === "number"
+                                ? Math.floor(progress.percent)
+                                : undefined,
+                    }),
+                );
+            });
+            autoUpdater.on("update-downloaded", (info: { readonly version?: string }) => {
+                runLog(
+                    logUpdaterInfo("update downloaded; will install on quit", {
+                        version: info?.version,
+                    }),
+                );
+            });
+            autoUpdater.on("error", (error: unknown) => {
+                runLog(
+                    logUpdaterError("updater error", {
+                        message: error instanceof Error ? error.message : String(error),
+                    }),
+                );
+            });
+        }
+        return autoUpdater;
+    };
+
+    const checkForUpdates = Effect.gen(function* () {
+        const autoUpdater = resolveAutoUpdater();
+        yield* logUpdaterInfo("starting update check");
+        yield* Effect.promise(() => autoUpdater.checkForUpdatesAndNotify());
+    }).pipe(
+        // A failed update check (no feed, network down, etc.) must never crash
+        // boot - swallow + log.
+        Effect.catchCause((cause: Cause.Cause<never>) =>
+            logUpdaterError("update check failed", { cause: Cause.pretty(cause) }),
+        ),
+        Effect.withSpan("desktop.updates.checkForUpdates"),
+    );
+
+    const downloadUpdate = Effect.gen(function* () {
+        const autoUpdater = resolveAutoUpdater();
+        yield* Effect.promise(() => autoUpdater.downloadUpdate());
+    }).pipe(
+        Effect.catchCause((cause: Cause.Cause<never>) =>
+            logUpdaterError("update download failed", { cause: Cause.pretty(cause) }),
+        ),
+        Effect.withSpan("desktop.updates.downloadUpdate"),
+    );
+
+    const quitAndInstall = Effect.sync(() => {
+        const autoUpdater = resolveAutoUpdater();
+        autoUpdater.quitAndInstall();
+    }).pipe(Effect.withSpan("desktop.updates.quitAndInstall"));
+
+    return DesktopUpdates.of({
+        checkForUpdates,
+        downloadUpdate,
+        quitAndInstall,
+    });
+});
+
+export const layer = Layer.effect(DesktopUpdates, make);

--- a/apps/studio-desktop/src/window/DesktopWindow.test.ts
+++ b/apps/studio-desktop/src/window/DesktopWindow.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+
+import { isSameAppOrigin } from "./DesktopWindow.ts";
+
+// Dev origin = the vite dev server (http://127.0.0.1:1739).
+test("dev: same-origin navigation (with/without query, any path) is allowed", () => {
+  expect(isSameAppOrigin("http://127.0.0.1:1739/", true)).toBe(true);
+  expect(isSameAppOrigin("http://127.0.0.1:1739/some/route", true)).toBe(true);
+  expect(isSameAppOrigin("http://127.0.0.1:1739/?endpoint=http://x", true)).toBe(true);
+});
+
+test("dev: foreign hosts/schemes are rejected", () => {
+  expect(isSameAppOrigin("https://evil.com", true)).toBe(false);
+  expect(isSameAppOrigin("http://127.0.0.1:9999/", true)).toBe(false); // different port
+  expect(isSameAppOrigin("https://127.0.0.1:1739/", true)).toBe(false); // different scheme
+  expect(isSameAppOrigin("ax://studio/index.html", true)).toBe(false); // prod scheme in dev
+});
+
+// Prod origin = the custom ax://studio scheme.
+test("prod: same ax://studio origin is allowed across paths/queries", () => {
+  expect(isSameAppOrigin("ax://studio/index.html", false)).toBe(true);
+  expect(isSameAppOrigin("ax://studio/other/route", false)).toBe(true);
+  expect(isSameAppOrigin("ax://studio/index.html?endpoint=x", false)).toBe(true);
+});
+
+test("prod: foreign ax host is rejected (origin 'null' over-match guarded)", () => {
+  // Both ax://studio and ax://evil report origin "null"; protocol+host check
+  // must still distinguish them.
+  expect(isSameAppOrigin("ax://evil/index.html", false)).toBe(false);
+  expect(isSameAppOrigin("https://evil.com", false)).toBe(false);
+  expect(isSameAppOrigin("http://127.0.0.1:1739/", false)).toBe(false); // dev origin in prod
+});
+
+test("malformed urls are rejected", () => {
+  expect(isSameAppOrigin("not a url", true)).toBe(false);
+  expect(isSameAppOrigin("", false)).toBe(false);
+});

--- a/apps/studio-desktop/src/window/DesktopWindow.ts
+++ b/apps/studio-desktop/src/window/DesktopWindow.ts
@@ -27,6 +27,24 @@ const PROD_STUDIO_URL = "ax://studio/index.html?endpoint=http%3A%2F%2F127.0.0.1%
 const WINDOW_WIDTH = 1200;
 const WINDOW_HEIGHT = 800;
 
+/**
+ * Same-origin check for the `will-navigate` guard. Compares protocol + host
+ * rather than `URL.origin` because the custom `ax://` scheme is non-special and
+ * reports an opaque `"null"` origin - so `origin === origin` would wrongly match
+ * any two `ax://` URLs (e.g. `ax://studio` vs `ax://evil`). Protocol+host is
+ * exact for both the dev http origin and the prod `ax://studio` origin.
+ */
+export function isSameAppOrigin(navigationUrl: string, isDev: boolean): boolean {
+  const applicationUrl = isDev ? DEV_STUDIO_URL : PROD_STUDIO_URL;
+  try {
+    const app = new URL(applicationUrl);
+    const target = new URL(navigationUrl);
+    return app.protocol === target.protocol && app.host === target.host;
+  } catch {
+    return false;
+  }
+}
+
 export type DesktopWindowError = ElectronWindow.ElectronWindowCreateError;
 
 type DesktopWindowRuntimeServices =
@@ -83,6 +101,21 @@ const make = Effect.gen(function* () {
         void runPromise(electronShell.openExternal(url));
       }
       return { action: "deny" };
+    });
+
+    // Security: block top-level navigation away from the trusted app origin.
+    // A renderer-side `window.location = ...` or `<a target=_self>` would
+    // otherwise navigate the main frame off the `ax://` app to an arbitrary
+    // page. Allow only same-origin navigation; for anything else prevent it,
+    // routing http(s) targets to the system browser via the safe-URL guard.
+    window.webContents.on("will-navigate", (event, url) => {
+      if (isSameAppOrigin(url, environment.isDevelopment)) {
+        return;
+      }
+      event.preventDefault();
+      if (Option.isSome(ElectronShell.parseSafeExternalUrl(url))) {
+        void runPromise(electronShell.openExternal(url));
+      }
     });
 
     window.webContents.on(

--- a/apps/studio-desktop/src/window/DesktopWindow.ts
+++ b/apps/studio-desktop/src/window/DesktopWindow.ts
@@ -1,0 +1,157 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
+import type * as Electron from "electron";
+
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopObservability from "../app/DesktopObservability.ts";
+import * as ElectronShell from "../electron/ElectronShell.ts";
+import * as ElectronWindow from "../electron/ElectronWindow.ts";
+
+/**
+ * Studio Vite dev server (mock build, served in live mode against the daemon).
+ * `?endpoint=` is parsed by studio's `src/api.ts` into
+ * `localStorage["ax-studio-endpoint"]` so `/api/*` is proxied to the daemon.
+ */
+const DEV_STUDIO_URL = "http://127.0.0.1:1739/?endpoint=http://127.0.0.1:1738";
+
+/**
+ * Production URL: the `ax` custom protocol (see {@link ElectronProtocol})
+ * serves the built studio SPA (`dist-desktop`). The `?endpoint=` query points
+ * studio at the locally-running daemon.
+ */
+const PROD_STUDIO_URL = "ax://studio/index.html?endpoint=http%3A%2F%2F127.0.0.1%3A1738";
+
+const WINDOW_WIDTH = 1200;
+const WINDOW_HEIGHT = 800;
+
+export type DesktopWindowError = ElectronWindow.ElectronWindowCreateError;
+
+type DesktopWindowRuntimeServices =
+  | DesktopEnvironment.DesktopEnvironment
+  | ElectronShell.ElectronShell
+  | ElectronWindow.ElectronWindow;
+
+export interface DesktopWindowShape {
+  /**
+   * Create (or reveal an existing) main BrowserWindow and load the studio.
+   * Phase 1: called once a manually-running daemon is reachable. Phase 2 wires
+   * this to the backend supervisor's "ready" signal.
+   */
+  readonly handleBackendReady: Effect.Effect<void, DesktopWindowError>;
+  /** macOS dock-click: re-create or reveal the main window. */
+  readonly activate: Effect.Effect<void, DesktopWindowError>;
+  /** Theme sync dropped for v0 - kept as a no-op so the lifecycle wiring stays generic. */
+  readonly syncAppearance: Effect.Effect<void>;
+}
+
+export class DesktopWindow extends Context.Service<DesktopWindow, DesktopWindowShape>()(
+  "@ax/studio-desktop/window/DesktopWindow",
+) {}
+
+const { logInfo: logWindowInfo, logWarning: logWindowWarning } =
+  DesktopObservability.makeComponentLogger("desktop-window");
+
+const make = Effect.gen(function* () {
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const electronShell = yield* ElectronShell.ElectronShell;
+  const electronWindow = yield* ElectronWindow.ElectronWindow;
+  const context = yield* Effect.context<DesktopWindowRuntimeServices>();
+  const runPromise = Effect.runPromiseWith(context);
+
+  const createWindow = Effect.gen(function* () {
+    const applicationUrl = environment.isDevelopment ? DEV_STUDIO_URL : PROD_STUDIO_URL;
+    const window = yield* electronWindow.create({
+      width: WINDOW_WIDTH,
+      height: WINDOW_HEIGHT,
+      show: false,
+      autoHideMenuBar: true,
+      webPreferences: {
+        preload: environment.preloadPath,
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+
+    // Security: route safe external links to the system browser and deny any
+    // attempt to open a new in-window navigation target.
+    window.webContents.setWindowOpenHandler(({ url }) => {
+      if (Option.isSome(ElectronShell.parseSafeExternalUrl(url))) {
+        void runPromise(electronShell.openExternal(url));
+      }
+      return { action: "deny" };
+    });
+
+    window.webContents.on(
+      "did-fail-load",
+      (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+        if (!isMainFrame) {
+          return;
+        }
+        void runPromise(
+          logWindowWarning("main window failed to load", {
+            errorCode,
+            errorDescription,
+            url: validatedURL,
+          }),
+        );
+      },
+    );
+    window.webContents.on("render-process-gone", (_event, details) => {
+      void runPromise(
+        logWindowWarning("main window render process gone", {
+          reason: details.reason,
+          exitCode: details.exitCode,
+        }),
+      );
+    });
+
+    window.once("ready-to-show", () => {
+      void runPromise(electronWindow.reveal(window));
+    });
+
+    void window.loadURL(applicationUrl);
+    if (environment.isDevelopment) {
+      window.webContents.openDevTools({ mode: "detach" });
+    }
+
+    window.on("closed", () => {
+      void runPromise(electronWindow.clearMain(Option.some(window)));
+    });
+
+    return window;
+  });
+
+  const createMain = Effect.gen(function* () {
+    const window = yield* createWindow;
+    yield* electronWindow.setMain(window);
+    yield* logWindowInfo("main window created");
+    return window;
+  }).pipe(Effect.withSpan("desktop.window.createMain"));
+
+  const revealOrCreateMain = Effect.gen(function* () {
+    const existingWindow = yield* electronWindow.currentMainOrFirst;
+    if (Option.isSome(existingWindow)) {
+      yield* electronWindow.reveal(existingWindow.value);
+      return existingWindow.value;
+    }
+    return yield* createMain;
+  }).pipe(Effect.withSpan("desktop.window.revealOrCreateMain"));
+
+  return DesktopWindow.of({
+    handleBackendReady: Effect.gen(function* () {
+      yield* logWindowInfo("backend ready", { source: "http" });
+      yield* revealOrCreateMain;
+    }).pipe(Effect.withSpan("desktop.window.handleBackendReady")),
+    activate: revealOrCreateMain.pipe(
+      Effect.asVoid,
+      Effect.withSpan("desktop.window.activate"),
+    ),
+    syncAppearance: Effect.void,
+  });
+});
+
+export const layer = Layer.effect(DesktopWindow, make);

--- a/apps/studio-desktop/tsconfig.json
+++ b/apps/studio-desktop/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src", "tsdown.config.ts"]
+}

--- a/apps/studio-desktop/tsconfig.json
+++ b/apps/studio-desktop/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2022"],
-    "types": ["node"]
+    "types": ["node", "bun-types"]
   },
   "include": ["src", "tsdown.config.ts"]
 }

--- a/apps/studio-desktop/tsdown.config.ts
+++ b/apps/studio-desktop/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+    entry: ["src/main.ts", "src/preload.ts"],
+    format: "cjs",
+    outDir: "dist-electron",
+    outExtensions: () => ({ js: ".cjs" }),
+    sourcemap: true,
+    clean: true,
+    // Electron + native updater are provided by the Electron runtime, never bundled.
+    external: ["electron", "electron-updater"],
+    // Bundle effect + platform-node + @ax/* so the main process is self-contained.
+    noExternal: [/^effect/, /^@effect\//, /^@ax\//],
+});

--- a/apps/studio/vite.config.ts
+++ b/apps/studio/vite.config.ts
@@ -40,6 +40,12 @@ export default defineConfig({
         },
     },
     server: {
+        // Bind IPv4 explicitly: the desktop shell's dev URL is
+        // http://127.0.0.1:1739, and vite's default "localhost" host resolves
+        // to IPv6 ::1 on macOS, which the Electron window can't reach
+        // (ERR_CONNECTION_REFUSED). Pin 127.0.0.1 so `bun --filter @ax/studio
+        // dev` + the desktop dev launch work out of the box.
+        host: "127.0.0.1",
         port: 1739,
         strictPort: true,
         proxy: {

--- a/bun.lock
+++ b/bun.lock
@@ -123,6 +123,23 @@
         "vite": "catalog:",
       },
     },
+    "apps/studio-desktop": {
+      "name": "@ax/studio-desktop",
+      "version": "0.12.1",
+      "dependencies": {
+        "@ax/lib": "workspace:*",
+        "@effect/platform-node": "4.0.0-beta.70",
+        "effect": "catalog:",
+      },
+      "devDependencies": {
+        "@types/node": "^25.0.0",
+        "electron": "41.5.0",
+        "electron-builder": "26.8.1",
+        "electron-updater": "^6.6.2",
+        "tsdown": "^0.20.3",
+        "typescript": "catalog:",
+      },
+    },
     "packages/ax-classifier-direction-event": {
       "name": "@ax-classifier/direction-event",
       "version": "0.1.0",
@@ -172,6 +189,8 @@
     "vite": "^8.0.3",
   },
   "packages": {
+    "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
+
     "@ax-classifier/direction-event": ["@ax-classifier/direction-event@workspace:packages/ax-classifier-direction-event"],
 
     "@ax-classifier/session-sections": ["@ax-classifier/session-sections@workspace:packages/ax-classifier-session-sections"],
@@ -185,6 +204,8 @@
     "@ax/site": ["@ax/site@workspace:apps/site"],
 
     "@ax/studio": ["@ax/studio@workspace:apps/studio"],
+
+    "@ax/studio-desktop": ["@ax/studio-desktop@workspace:apps/studio-desktop"],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -252,6 +273,8 @@
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
+    "@develar/schema-utils": ["@develar/schema-utils@2.6.5", "", { "dependencies": { "ajv": "^6.12.0", "ajv-keywords": "^3.4.1" } }, "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig=="],
+
     "@durable-streams/client": ["@durable-streams/client@0.2.6", "", { "dependencies": { "@microsoft/fetch-event-source": "^2.0.1", "fastq": "^1.19.1" }, "bin": { "intent": "bin/intent.js" } }, "sha512-uHKKbWpsKLhFMeGjG0PgM6LXE3oEIi7FHKlJZkmYGxcqd4Yjjd/QEvnQnDzteRP4Av1uJVM8qjTL7kfKsgeS/w=="],
 
     "@durable-streams/server": ["@durable-streams/server@0.3.5", "", { "dependencies": { "@durable-streams/client": "0.2.6", "@durable-streams/state": "0.2.9", "@neophi/sieve-cache": "^1.0.0", "lmdb": "^3.3.0" } }, "sha512-vqz2v9GE++4fHPFW7zYiqsuWJ31/BaV36qP+OEJCJjfyc3gFLoXBAnWEm/6+FADtaLvt/Zl6/bNWqiG/jrezkw=="],
@@ -262,7 +285,25 @@
 
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.70", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.70" }, "peerDependencies": { "effect": "^4.0.0-beta.70" } }, "sha512-u8fhg9RX46034Ee5s461z680LUr2A/4AKo7kWbP7rDQsLDyNyT9Z4/WlzcYl2Oo5E4fJIQmqG6cyieWFQD1Ppg=="],
 
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.70", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.70", "mime": "^4.1.0", "undici": "^8.2.0" }, "peerDependencies": { "effect": "^4.0.0-beta.70", "ioredis": "^5.7.0" } }, "sha512-Ls1WtLaO2CbcO8jHtZRRi6eZa4YOJZ9KXm6udMvwhjV/XhqdsT6AzmcXbc1hINbKgvRcik6qM/441YEaBMYoqw=="],
+
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.76", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.76" } }, "sha512-htJyli8B7hidi5ANPskhy3cK19g3idNColSlSAqIC9lDAmLcLFQZqpOsUY3uBfSChps8HzhxRwVqWp9C/vsQXA=="],
+
+    "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
+
+    "@electron/fuses": ["@electron/fuses@1.8.0", "", { "dependencies": { "chalk": "^4.1.1", "fs-extra": "^9.0.1", "minimist": "^1.2.5" }, "bin": { "electron-fuses": "dist/bin.js" } }, "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw=="],
+
+    "@electron/get": ["@electron/get@2.0.3", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^2.2.0", "fs-extra": "^8.1.0", "got": "^11.8.5", "progress": "^2.0.3", "semver": "^6.2.0", "sumchecker": "^3.0.1" }, "optionalDependencies": { "global-agent": "^3.0.0" } }, "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ=="],
+
+    "@electron/notarize": ["@electron/notarize@2.5.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.1", "promise-retry": "^2.0.1" } }, "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A=="],
+
+    "@electron/osx-sign": ["@electron/osx-sign@1.3.3", "", { "dependencies": { "compare-version": "^0.1.2", "debug": "^4.3.4", "fs-extra": "^10.0.0", "isbinaryfile": "^4.0.8", "minimist": "^1.2.6", "plist": "^3.0.5" }, "bin": { "electron-osx-flat": "bin/electron-osx-flat.js", "electron-osx-sign": "bin/electron-osx-sign.js" } }, "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg=="],
+
+    "@electron/rebuild": ["@electron/rebuild@4.0.4", "", { "dependencies": { "@malept/cross-spawn-promise": "^2.0.0", "debug": "^4.1.1", "node-abi": "^4.2.0", "node-api-version": "^0.2.1", "node-gyp": "^12.2.0", "read-binary-file-arch": "^1.0.6" }, "bin": { "electron-rebuild": "lib/cli.js" } }, "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg=="],
+
+    "@electron/universal": ["@electron/universal@2.0.3", "", { "dependencies": { "@electron/asar": "^3.3.1", "@malept/cross-spawn-promise": "^2.0.0", "debug": "^4.3.1", "dir-compare": "^4.2.0", "fs-extra": "^11.1.1", "minimatch": "^9.0.3", "plist": "^3.1.0" } }, "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g=="],
+
+    "@electron/windows-sign": ["@electron/windows-sign@1.2.2", "", { "dependencies": { "cross-dirname": "^0.1.0", "debug": "^4.3.4", "fs-extra": "^11.1.1", "minimist": "^1.2.8", "postject": "^1.0.0-alpha.6" }, "bin": { "electron-windows-sign": "bin/electron-windows-sign.js" } }, "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -386,6 +427,10 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
 
+    "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -409,6 +454,10 @@
     "@lmdb/lmdb-win32-arm64": ["@lmdb/lmdb-win32-arm64@3.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-pKv1DJ1bPZAaHkdFsSz5IDfUG8x9vntgquXF9/Dm2xuupcIe/EkLzylpoBxppFVK5vzbV561Dq26jNY2fIMA7g=="],
 
     "@lmdb/lmdb-win32-x64": ["@lmdb/lmdb-win32-x64@3.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-JF1BmLCm9kGEVZgYmJq43zeQVdHVgAJnTi/NURWEsy6L1ZrrlSmdltS+D17QN4LODwf+1LMXAA9auIZVXtWwzw=="],
+
+    "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
+
+    "@malept/flatpak-bundler": ["@malept/flatpak-bundler@0.4.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.0", "lodash": "^4.17.15", "tmp-promise": "^3.0.2" } }, "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q=="],
 
     "@mdx-js/esbuild": ["@mdx-js/esbuild@3.1.1", "", { "dependencies": { "@mdx-js/mdx": "^3.0.0", "@types/unist": "^3.0.0", "source-map": "^0.7.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" }, "peerDependencies": { "esbuild": ">=0.14.0" } }, "sha512-NS35VhTdvKNj5/B1JSD5W3kN1R0WDHgk+zCWq+tSChQw5L2Bgeiz7yyZPFrc5LWuPVOxE1xMbJr82bO9VVzmfQ=="],
 
@@ -466,6 +515,8 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
+    "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew=="],
@@ -514,13 +565,15 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+    "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@surrealdb/cbor": ["@surrealdb/cbor@2.0.0-alpha.4", "", {}, "sha512-l/hNZ3ZCOJq8rzwx1y5ZV/8b2bYCWdhGqRVY33Pu50NAHyAW5qLsMn3ZBkZow77mAKwNCsbDsRGnyYEuU95mjw=="],
+
+    "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
 
@@ -620,13 +673,23 @@
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
+    "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
+    "@types/fs-extra": ["@types/fs-extra@9.0.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA=="],
+
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/http-cache-semantics": ["@types/http-cache-semantics@4.2.0", "", {}, "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="],
+
+    "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
+
+    "@types/keyv": ["@types/keyv@3.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
@@ -636,15 +699,23 @@
 
     "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
+    "@types/plist": ["@types/plist@3.0.5", "", { "dependencies": { "@types/node": "*", "xmlbuilder": ">=11.0.1" } }, "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/resolve": ["@types/resolve@1.20.6", "", {}, "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ=="],
 
+    "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/verror": ["@types/verror@1.10.11", "", {}, "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
@@ -654,6 +725,10 @@
 
     "@wterm/dom": ["@wterm/dom@0.3.0", "", { "dependencies": { "@wterm/core": "0.3.0" } }, "sha512-OiUl7reGSlW02yb5wGXMplMZhW2HBkBSFxvbFj15I832UK0QFIHRvhE2l6Xgae8ROn9bNLaALoKDFvcUuz80iQ=="],
 
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+
+    "abbrev": ["abbrev@4.0.0", "", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
@@ -662,21 +737,45 @@
 
     "acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
+
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "ansis": ["ansis@4.3.0", "", {}, "sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
-    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+    "app-builder-bin": ["app-builder-bin@5.0.0-alpha.12", "", {}, "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w=="],
+
+    "app-builder-lib": ["app-builder-lib@26.8.1", "", { "dependencies": { "@develar/schema-utils": "~2.6.5", "@electron/asar": "3.4.1", "@electron/fuses": "^1.8.0", "@electron/get": "^3.0.0", "@electron/notarize": "2.5.0", "@electron/osx-sign": "1.3.3", "@electron/rebuild": "^4.0.3", "@electron/universal": "2.0.3", "@malept/flatpak-bundler": "^0.4.0", "@types/fs-extra": "9.0.13", "async-exit-hook": "^2.0.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chromium-pickle-js": "^0.2.0", "ci-info": "4.3.1", "debug": "^4.3.4", "dotenv": "^16.4.5", "dotenv-expand": "^11.0.6", "ejs": "^3.1.8", "electron-publish": "26.8.1", "fs-extra": "^10.1.0", "hosted-git-info": "^4.1.0", "isbinaryfile": "^5.0.0", "jiti": "^2.4.2", "js-yaml": "^4.1.0", "json5": "^2.2.3", "lazy-val": "^1.0.5", "minimatch": "^10.0.3", "plist": "3.1.0", "proper-lockfile": "^4.1.2", "resedit": "^1.7.0", "semver": "~7.7.3", "tar": "^7.5.7", "temp-file": "^3.4.0", "tiny-async-pool": "1.3.0", "which": "^5.0.0" }, "peerDependencies": { "dmg-builder": "26.8.1", "electron-builder-squirrel-windows": "26.8.1" } }, "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "as-table": ["as-table@1.0.55", "", { "dependencies": { "printable-characters": "^1.0.42" } }, "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ=="],
 
+    "assert-plus": ["assert-plus@1.0.0", "", {}, "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="],
+
+    "ast-kit": ["ast-kit@3.0.0-beta.1", "", { "dependencies": { "@babel/parser": "^8.0.0-beta.4", "estree-walker": "^3.0.3", "pathe": "^2.0.3" } }, "sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw=="],
+
+    "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
+
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
+
+    "async-exit-hook": ["async-exit-hook@2.0.1", "", {}, "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "at-least-node": ["at-least-node@1.0.0", "", {}, "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="],
 
     "axctl": ["axctl@workspace:apps/axctl"],
 
@@ -684,17 +783,37 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.29", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
+
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "builder-util": ["builder-util@26.8.1", "", { "dependencies": { "7zip-bin": "~5.2.0", "@types/debug": "^4.1.6", "app-builder-bin": "5.0.0-alpha.12", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "cross-spawn": "^7.0.6", "debug": "^4.3.4", "fs-extra": "^10.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "js-yaml": "^4.1.0", "sanitize-filename": "^1.6.3", "source-map-support": "^0.5.19", "stat-mode": "^1.0.0", "temp-file": "^3.4.0", "tiny-async-pool": "1.3.0" } }, "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw=="],
+
+    "builder-util-runtime": ["builder-util-runtime@9.5.1", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ=="],
 
     "bun-ffi-structs": ["bun-ffi-structs@0.2.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w=="],
 
@@ -703,6 +822,12 @@
     "bun2nix": ["bun2nix@2.1.0", "", { "dependencies": { "sade": "^1.8.1" }, "bin": { "bun2nix": "index.ts" } }, "sha512-EzVw2dp24nPFuJYc6IZaKyfsmQiL//GrNfy6GgvFc/3l3guBwy9O2FgEBDIOwpQ61jq2jO9gPjYHrbHPev1rqg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "cacheable-lookup": ["cacheable-lookup@5.0.4", "", {}, "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="],
+
+    "cacheable-request": ["cacheable-request@7.0.4", "", { "dependencies": { "clone-response": "^1.0.2", "get-stream": "^5.1.0", "http-cache-semantics": "^4.0.0", "keyv": "^4.0.0", "lowercase-keys": "^2.0.0", "normalize-url": "^6.0.1", "responselike": "^2.0.0" } }, "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
@@ -714,6 +839,8 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -724,7 +851,21 @@
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
+    "chromium-pickle-js": ["chromium-pickle-js@0.2.0", "", {}, "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw=="],
+
+    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "cli-truncate": ["cli-truncate@2.1.0", "", { "dependencies": { "slice-ansi": "^3.0.0", "string-width": "^4.2.0" } }, "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "clone-response": ["clone-response@1.0.3", "", { "dependencies": { "mimic-response": "^1.0.0" } }, "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA=="],
+
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cluster-key-slot": ["cluster-key-slot@1.1.1", "", {}, "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="],
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
@@ -736,7 +877,15 @@
 
     "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
+
+    "compare-version": ["compare-version@0.1.2", "", {}, "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -750,7 +899,13 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "core-util-is": ["core-util-is@1.0.2", "", {}, "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="],
+
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "crc": ["crc@3.8.0", "", { "dependencies": { "buffer": "^5.1.0" } }, "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ=="],
+
+    "cross-dirname": ["cross-dirname@0.1.0", "", {}, "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -762,7 +917,19 @@
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "defer-to-connect": ["defer-to-connect@2.0.1", "", {}, "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="],
+
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -770,9 +937,23 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
+
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
+
+    "dir-compare": ["dir-compare@4.2.0", "", { "dependencies": { "minimatch": "^3.0.5", "p-limit": "^3.1.0 " } }, "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ=="],
+
+    "dmg-builder": ["dmg-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "fs-extra": "^10.1.0", "iconv-lite": "^0.6.2", "js-yaml": "^4.1.0" }, "optionalDependencies": { "dmg-license": "^1.0.11" } }, "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg=="],
+
+    "dmg-license": ["dmg-license@1.0.11", "", { "dependencies": { "@types/plist": "^3.0.1", "@types/verror": "^1.10.3", "ajv": "^6.10.0", "crc": "^3.8.0", "iconv-corefoundation": "^1.1.7", "plist": "^3.0.4", "smart-buffer": "^4.0.2", "verror": "^1.10.0" }, "os": "darwin", "bin": { "dmg-license": "bin/dmg-license.js" } }, "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q=="],
+
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "dotenv-expand": ["dotenv-expand@11.0.7", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA=="],
+
+    "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -780,15 +961,37 @@
 
     "effect": ["effect@4.0.0-beta.70", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg=="],
 
+    "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
+
+    "electron": ["electron@41.5.0", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-x9j9//PubUA4EjDtQbZhtk3prolandqCKgit0uCIqc1jb8FTskPbnJtxcDFB1aejczJcuERgjPixBUaMwoWyJg=="],
+
+    "electron-builder": ["electron-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.8.1", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw=="],
+
+    "electron-builder-squirrel-windows": ["electron-builder-squirrel-windows@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "electron-winstaller": "5.4.0" } }, "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA=="],
+
+    "electron-publish": ["electron-publish@26.8.1", "", { "dependencies": { "@types/fs-extra": "^9.0.11", "builder-util": "26.8.1", "builder-util-runtime": "9.5.1", "chalk": "^4.1.2", "form-data": "^4.0.5", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "mime": "^2.5.2" } }, "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.353", "", {}, "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w=="],
+
+    "electron-updater": ["electron-updater@6.8.9", "", { "dependencies": { "builder-util-runtime": "9.7.0", "fs-extra": "^10.1.0", "js-yaml": "^4.1.0", "lazy-val": "^1.0.5", "lodash.escaperegexp": "^4.1.2", "lodash.isequal": "^4.5.0", "semver": "~7.7.3", "tiny-typed-emitter": "^2.1.0" } }, "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig=="],
+
+    "electron-winstaller": ["electron-winstaller@5.4.0", "", { "dependencies": { "@electron/asar": "^3.2.1", "debug": "^4.1.1", "fs-extra": "^7.0.1", "lodash": "^4.17.21", "temp": "^0.9.0" }, "optionalDependencies": { "@electron/windows-sign": "^1.1.2" } }, "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
+
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
@@ -797,6 +1000,10 @@
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -826,7 +1033,7 @@
 
     "estree-util-visit": ["estree-util-visit@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/unist": "^3.0.0" } }, "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww=="],
 
-    "estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
@@ -835,6 +1042,8 @@
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
+
+    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
@@ -846,9 +1055,15 @@
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "extsprintf": ["extsprintf@1.4.1", "", {}, "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="],
+
     "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
@@ -856,15 +1071,21 @@
 
     "fault": ["fault@2.0.1", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ=="],
 
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetchdts": ["fetchdts@0.1.7", "", {}, "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA=="],
+
+    "filelist": ["filelist@1.0.6", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
@@ -874,11 +1095,17 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
+    "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
@@ -888,15 +1115,27 @@
 
     "get-source": ["get-source@2.0.12", "", { "dependencies": { "data-uri-to-buffer": "^2.0.0", "source-map": "^0.6.1" } }, "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w=="],
 
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
+    "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
     "goober": ["goober@2.1.19", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "got": ["got@11.8.6", "", { "dependencies": { "@sindresorhus/is": "^4.0.0", "@szmarczak/http-timer": "^4.0.5", "@types/cacheable-request": "^6.0.1", "@types/responselike": "^1.0.0", "cacheable-lookup": "^5.0.3", "cacheable-request": "^7.0.2", "decompress-response": "^6.0.0", "http2-wrapper": "^1.0.0-beta.5.2", "lowercase-keys": "^2.0.0", "p-cancelable": "^2.0.0", "responselike": "^2.0.0" } }, "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -904,7 +1143,13 @@
 
     "h3-v2": ["h3@2.0.1-rc.20", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.13" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg=="],
 
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
@@ -932,17 +1177,39 @@
 
     "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 
+    "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
+
+    "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
+
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "http2-wrapper": ["http2-wrapper@1.0.3", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.0.0" } }, "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-corefoundation": ["iconv-corefoundation@1.1.7", "", { "dependencies": { "cli-truncate": "^2.1.0", "node-addon-api": "^1.6.3" }, "os": "darwin" }, "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "import-without-cache": ["import-without-cache@0.2.5", "", {}, "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A=="],
+
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
@@ -964,6 +1231,8 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
@@ -974,9 +1243,13 @@
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
+    "isbinaryfile": ["isbinaryfile@5.0.7", "", {}, "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ=="],
+
     "isbot": ["isbot@5.1.40", "", {}, "sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ=="],
 
-    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+    "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+
+    "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
@@ -984,21 +1257,31 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
+
+    "lazy-val": ["lazy-val@1.0.5", "", {}, "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -1026,7 +1309,15 @@
 
     "lmdb": ["lmdb@3.5.4", "", { "dependencies": { "@harperfast/extended-iterable": "^1.0.3", "msgpackr": "^1.11.2", "node-addon-api": "^6.1.0", "node-gyp-build-optional-packages": "5.2.2", "ordered-binary": "^1.5.3", "weak-lru-cache": "^1.2.2" }, "optionalDependencies": { "@lmdb/lmdb-darwin-arm64": "3.5.4", "@lmdb/lmdb-darwin-x64": "3.5.4", "@lmdb/lmdb-linux-arm": "3.5.4", "@lmdb/lmdb-linux-arm64": "3.5.4", "@lmdb/lmdb-linux-x64": "3.5.4", "@lmdb/lmdb-win32-arm64": "3.5.4", "@lmdb/lmdb-win32-x64": "3.5.4" }, "bin": { "download-lmdb-prebuilds": "bin/download-prebuilds.js" } }, "sha512-9FKQA6G1MMtqNxfxvSBNXD/axeG2QRjYbNh0/ykRL5xYcRbCm2vXq7B9bhc7nSuKdHzr8/BHIwfPuYYH1UsXXw=="],
 
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
+    "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
+
+    "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
+
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "lowercase-keys": ["lowercase-keys@2.0.0", "", {}, "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -1037,6 +1328,8 @@
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -1152,13 +1445,25 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
-    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+    "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
     "miniflare": ["miniflare@4.20260526.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260526.1", "ws": "8.20.1", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -1176,7 +1481,13 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
+    "node-abi": ["node-abi@4.31.0", "", { "dependencies": { "semver": "^7.6.3" } }, "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw=="],
+
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "node-api-version": ["node-api-version@0.2.1", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q=="],
+
+    "node-gyp": ["node-gyp@12.4.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.4", "tinyglobby": "^0.2.12", "undici": "^6.25.0", "which": "^6.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
@@ -1184,11 +1495,19 @@
 
     "node-releases": ["node-releases@2.0.44", "", {}, "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ=="],
 
+    "nopt": ["nopt@9.0.0", "", { "dependencies": { "abbrev": "^4.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw=="],
+
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "normalize-url": ["normalize-url@6.1.0", "", {}, "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "obug": ["obug@2.1.2", "", {}, "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
@@ -1202,6 +1521,8 @@
 
     "ordered-binary": ["ordered-binary@1.6.1", "", {}, "sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w=="],
 
+    "p-cancelable": ["p-cancelable@2.1.1", "", {}, "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="],
+
     "p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
@@ -1212,6 +1533,8 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
@@ -1220,27 +1543,51 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pe-library": ["pe-library@0.4.1", "", {}, "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
+
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+
+    "postject": ["postject@1.0.0-alpha.6", "", { "dependencies": { "commander": "^9.4.0" }, "bin": { "postject": "dist/cli.js" } }, "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A=="],
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "printable-characters": ["printable-characters@1.0.42", "", {}, "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ=="],
 
+    "proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
+
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
+    "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
@@ -1254,6 +1601,8 @@
 
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
+    "read-binary-file-arch": ["read-binary-file-arch@1.0.6", "", { "dependencies": { "debug": "^4.3.4" }, "bin": { "read-binary-file-arch": "cli.js" } }, "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg=="],
+
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
@@ -1263,6 +1612,10 @@
     "recma-parse": ["recma-parse@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "esast-util-from-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ=="],
 
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
+
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -1294,13 +1647,31 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resedit": ["resedit@1.7.2", "", { "dependencies": { "pe-library": "^0.4.1" } }, "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA=="],
 
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
+    "resolve-alpn": ["resolve-alpn@1.2.1", "", {}, "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "responselike": ["responselike@2.0.1", "", { "dependencies": { "lowercase-keys": "^2.0.0" } }, "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rimraf": ["rimraf@2.6.3", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA=="],
+
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
     "rolldown": ["rolldown@1.0.0", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@rolldown/pluginutils": "1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0", "@rolldown/binding-darwin-arm64": "1.0.0", "@rolldown/binding-darwin-x64": "1.0.0", "@rolldown/binding-freebsd-x64": "1.0.0", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0", "@rolldown/binding-linux-arm64-gnu": "1.0.0", "@rolldown/binding-linux-arm64-musl": "1.0.0", "@rolldown/binding-linux-ppc64-gnu": "1.0.0", "@rolldown/binding-linux-s390x-gnu": "1.0.0", "@rolldown/binding-linux-x64-gnu": "1.0.0", "@rolldown/binding-linux-x64-musl": "1.0.0", "@rolldown/binding-openharmony-arm64": "1.0.0", "@rolldown/binding-wasm32-wasi": "1.0.0", "@rolldown/binding-win32-arm64-msvc": "1.0.0", "@rolldown/binding-win32-x64-msvc": "1.0.0" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA=="],
+
+    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.22.5", "", { "dependencies": { "@babel/generator": "8.0.0-rc.2", "@babel/helper-validator-identifier": "8.0.0-rc.2", "@babel/parser": "8.0.0-rc.2", "@babel/types": "8.0.0-rc.2", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.6", "obug": "^2.1.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20250601.1", "rolldown": "^1.0.0-rc.3", "typescript": "^5.0.0 || ^6.0.0-beta", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-M/HXfM4cboo+jONx9Z0X+CUf3B5tCi7ni+kR5fUW50Fp9AlZk0oVLesibGWgCXDKFp5lpgQ9yhKoImUFjl3VZw=="],
 
     "rollup-plugin-inject": ["rollup-plugin-inject@3.0.2", "", { "dependencies": { "estree-walker": "^0.6.1", "magic-string": "^0.25.3", "rollup-pluginutils": "^2.8.1" } }, "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w=="],
 
@@ -1324,13 +1695,21 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
+    "sanitize-filename": ["sanitize-filename@1.6.4", "", { "dependencies": { "truncate-utf8-bytes": "^1.0.0" } }, "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serialize-javascript": ["serialize-javascript@7.0.5", "", {}, "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw=="],
 
@@ -1360,7 +1739,15 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
     "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
+
+    "simple-update-notifier": ["simple-update-notifier@2.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w=="],
+
+    "slice-ansi": ["slice-ansi@3.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
@@ -1369,6 +1756,8 @@
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "sourcemap-codec": ["sourcemap-codec@1.4.8", "", {}, "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="],
 
@@ -1379,6 +1768,10 @@
     "srvx": ["srvx@0.11.16", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw=="],
 
     "stacktracey": ["stacktracey@2.2.0", "", { "dependencies": { "as-table": "^1.0.36", "get-source": "^2.0.12" } }, "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
+
+    "stat-mode": ["stat-mode@1.0.0", "", {}, "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -1396,7 +1789,9 @@
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
-    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+    "sumchecker": ["sumchecker@3.0.1", "", { "dependencies": { "debug": "^4.1.0" } }, "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
@@ -1406,7 +1801,23 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "tar": ["tar@7.5.16", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w=="],
+
+    "temp": ["temp@0.9.4", "", { "dependencies": { "mkdirp": "^0.5.1", "rimraf": "~2.6.2" } }, "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA=="],
+
+    "temp-file": ["temp-file@3.4.0", "", { "dependencies": { "async-exit-hook": "^2.0.1", "fs-extra": "^10.0.0" } }, "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg=="],
+
+    "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
+
+    "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tmp": ["tmp@0.2.7", "", {}, "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="],
+
+    "tmp-promise": ["tmp-promise@3.0.3", "", { "dependencies": { "tmp": "^0.2.0" } }, "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -1414,13 +1825,21 @@
 
     "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
 
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
+    "truncate-utf8-bytes": ["truncate-utf8-bytes@1.0.2", "", { "dependencies": { "utf8-byte-length": "^1.0.1" } }, "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ=="],
+
+    "tsdown": ["tsdown@0.20.3", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^6.7.14", "defu": "^6.1.4", "empathic": "^2.0.0", "hookable": "^6.0.1", "import-without-cache": "^0.2.5", "obug": "^2.1.1", "picomatch": "^4.0.3", "rolldown": "1.0.0-rc.3", "rolldown-plugin-dts": "^0.22.1", "semver": "^7.7.3", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tree-kill": "^1.2.2", "unconfig-core": "^7.4.2", "unrun": "^0.2.27" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@vitejs/devtools": "*", "publint": "^0.3.0", "typescript": "^5.0.0", "unplugin-lightningcss": "^0.4.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@vitejs/devtools", "publint", "typescript", "unplugin-lightningcss", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-qWOUXSbe4jN8JZEgrkc/uhJpC8VN2QpNu3eZkBWwNuTEjc/Ik1kcc54ycfcQ5QPRHeu9OQXaLfCI3o7pEJgB2w=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "turbo": ["turbo@2.9.16", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.16", "@turbo/darwin-arm64": "2.9.16", "@turbo/linux-64": "2.9.16", "@turbo/linux-arm64": "2.9.16", "@turbo/windows-64": "2.9.16", "@turbo/windows-arm64": "2.9.16" }, "bin": { "turbo": "bin/turbo" } }, "sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg=="],
+
+    "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
@@ -1428,7 +1847,9 @@
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
-    "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
+    "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
+
+    "undici": ["undici@8.4.0", "", {}, "sha512-tDR4LgFBeV7YBWOFMlmbhtrnFVWuZ6HKbkG+88/csQdhK2tPlW78PnLI2VRjIQtTlslvgSZ4R43WBE+4g6rhng=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -1448,19 +1869,29 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
 
+    "unrun": ["unrun@0.2.39", "", { "dependencies": { "rolldown": "1.0.0-rc.17" }, "peerDependencies": { "synckit": "^0.11.11" }, "optionalPeers": ["synckit"], "bin": { "unrun": "dist/cli.mjs" } }, "sha512-h9FxYVpztY/wwq+bauLOh6Y3CWu2IVeRLq5lxzneBiIU9Tn86OGp9xiQrGhnYspAmg5dzdY0Cc8+Y70kuTARCg=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "utf8-byte-length": ["utf8-byte-length@1.0.5", "", {}, "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="],
 
     "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "uuidv7": ["uuidv7@1.2.1", "", { "bin": { "uuidv7": "cli.js" } }, "sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "verror": ["verror@1.10.1", "", { "dependencies": { "assert-plus": "^1.0.0", "core-util-is": "1.0.2", "extsprintf": "^1.2.0" } }, "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -1480,21 +1911,33 @@
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
-    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+    "which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
 
     "workerd": ["workerd@1.20250718.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250718.0", "@cloudflare/workerd-darwin-arm64": "1.20250718.0", "@cloudflare/workerd-linux-64": "1.20250718.0", "@cloudflare/workerd-linux-arm64": "1.20250718.0", "@cloudflare/workerd-windows-64": "1.20250718.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg=="],
 
     "wrangler": ["wrangler@3.114.17", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.3.4", "@cloudflare/unenv-preset": "2.0.2", "@esbuild-plugins/node-globals-polyfill": "0.2.3", "@esbuild-plugins/node-modules-polyfill": "0.2.2", "blake3-wasm": "2.1.5", "esbuild": "0.17.19", "miniflare": "3.20250718.3", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.14", "workerd": "1.20250718.0" }, "optionalDependencies": { "fsevents": "~2.3.2", "sharp": "^0.33.5" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250408.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA=="],
 
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
 
+    "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
+
     "xmlbuilder2": ["xmlbuilder2@4.0.3", "", { "dependencies": { "@oozcitak/dom": "^2.0.2", "@oozcitak/infra": "^2.0.2", "@oozcitak/util": "^10.0.0", "js-yaml": "^4.1.1" } }, "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA=="],
 
-    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
@@ -1518,6 +1961,12 @@
 
     "@ax/studio/@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.2", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.0" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg=="],
 
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@cloudflare/kv-asset-handler/mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
     "@cloudflare/vite-plugin/wrangler": ["wrangler@4.95.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260526.0", "path-to-regexp": "6.3.0", "rosie-skills": "^0.6.3", "unenv": "2.0.0-rc.24", "workerd": "1.20260526.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260526.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg=="],
 
     "@cloudflare/vite-plugin/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
@@ -1530,9 +1979,33 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@develar/schema-utils/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
     "@effect/platform-node-shared/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
-    "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+    "@electron/asar/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@electron/fuses/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
+    "@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@electron/notarize/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
+    "@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
+
+    "@electron/universal/fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
+
+    "@electron/universal/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "@electron/windows-sign/fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
+
+    "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
+    "@poppinss/dumper/@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -1566,7 +2039,15 @@
 
     "@tanstack/start-plugin-core/@tanstack/router-utils": ["@tanstack/router-utils@1.162.1", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-62layyTGmclHDQS/eidwKRfN1hhCKwViG7iEBcVmL0MXgcAB3OOucWCEcDDGd9Cu11H6b4QQ5oOo47MWIqwz0A=="],
 
+    "ajv-keywords/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "app-builder-lib/@electron/get": ["@electron/get@3.1.0", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^2.2.0", "fs-extra": "^8.1.0", "got": "^11.8.5", "progress": "^2.0.3", "semver": "^6.2.0", "sumchecker": "^3.0.1" }, "optionalDependencies": { "global-agent": "^3.0.0" } }, "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ=="],
+
+    "app-builder-lib/ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
+
+    "ast-kit/@babel/parser": ["@babel/parser@8.0.0-rc.2", "", { "dependencies": { "@babel/types": "^8.0.0-rc.2" }, "bin": "./bin/babel-parser.js" }, "sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ=="],
 
     "axctl/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -1574,15 +2055,55 @@
 
     "axctl/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "cli-truncate/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
+
+    "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "dir-compare/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "dir-compare/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "dmg-license/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
     "effect/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
-    "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+    "electron/@types/node": ["@types/node@24.13.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg=="],
+
+    "electron-publish/mime": ["mime@2.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
+
+    "electron-updater/builder-util-runtime": ["builder-util-runtime@9.7.0", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw=="],
+
+    "electron-winstaller/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
+
+    "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "get-source/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "global-agent/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "gray-matter/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
+    "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
+
+    "iconv-corefoundation/node-addon-api": ["node-addon-api@1.7.2", "", {}, "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="],
 
     "lmdb/msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
 
     "lmdb/node-addon-api": ["node-addon-api@6.1.0", "", {}, "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="],
+
+    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -1592,11 +2113,27 @@
 
     "miniflare/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
+    "miniflare/undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
+
     "miniflare/workerd": ["workerd@1.20260526.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260526.1", "@cloudflare/workerd-darwin-arm64": "1.20260526.1", "@cloudflare/workerd-linux-64": "1.20260526.1", "@cloudflare/workerd-linux-arm64": "1.20260526.1", "@cloudflare/workerd-windows-64": "1.20260526.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-IHzymht98p10JH1zzwdCpbViAqw97HrwKl7+KfZeASFMsYSrIsAULWdPn0LRC5FTUzBpamLNyKCCKxbgXHgRHQ=="],
 
     "miniflare/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
+    "node-abi/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "node-api-version/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "node-gyp/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "node-gyp/undici": ["undici@6.26.0", "", {}, "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A=="],
+
+    "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
+
+    "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
@@ -1604,15 +2141,41 @@
 
     "remark-mdx-frontmatter/toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
 
+    "roarr/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0", "", {}, "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ=="],
 
+    "rolldown-plugin-dts/@babel/generator": ["@babel/generator@8.0.0-rc.2", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.2", "@babel/types": "^8.0.0-rc.2", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-oCQ1IKPwkzCeJzAPb7Fv8rQ9k5+1sG8mf2uoHiMInPYvkRfrDJxbTIbH51U+jstlkghus0vAi3EBvkfvEsYNLQ=="],
+
+    "rolldown-plugin-dts/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.2", "", {}, "sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A=="],
+
+    "rolldown-plugin-dts/@babel/parser": ["@babel/parser@8.0.0-rc.2", "", { "dependencies": { "@babel/types": "^8.0.0-rc.2" }, "bin": "./bin/babel-parser.js" }, "sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ=="],
+
+    "rolldown-plugin-dts/@babel/types": ["@babel/types@8.0.0-rc.2", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.2", "@babel/helper-validator-identifier": "^8.0.0-rc.2" } }, "sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw=="],
+
+    "rollup-plugin-inject/estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
+
     "rollup-plugin-inject/magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
+
+    "rollup-pluginutils/estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "sharp/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
+    "simple-update-notifier/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
+
+    "tsdown/rolldown": ["rolldown@1.0.0-rc.3", "", { "dependencies": { "@oxc-project/types": "=0.112.0", "@rolldown/pluginutils": "1.0.0-rc.3" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.3", "@rolldown/binding-darwin-arm64": "1.0.0-rc.3", "@rolldown/binding-darwin-x64": "1.0.0-rc.3", "@rolldown/binding-freebsd-x64": "1.0.0-rc.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.3", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.3", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.3", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.3", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.3", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.3", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.3", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.3", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.3" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw=="],
+
+    "tsdown/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "unrun/rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
     "wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.0.2", "", { "peerDependencies": { "unenv": "2.0.0-rc.14", "workerd": "^1.20250124.0" }, "optionalPeers": ["workerd"] }, "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg=="],
 
@@ -1620,7 +2183,11 @@
 
     "wrangler/unenv": ["unenv@2.0.0-rc.14", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.1", "ohash": "^2.0.10", "pathe": "^2.0.3", "ufo": "^1.5.4" } }, "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q=="],
 
-    "xmlbuilder2/js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+    "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -1728,6 +2295,16 @@
 
     "@content-collections/mdx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@develar/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@electron/asar/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
+
+    "@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
+
+    "@electron/get/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
+
+    "@electron/universal/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+
     "@tanstack/react-start-rsc/@tanstack/router-utils/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "@tanstack/react-start/@tanstack/router-utils/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
@@ -1740,7 +2317,47 @@
 
     "@tanstack/start-plugin-core/@tanstack/router-utils/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
+    "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "app-builder-lib/@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "app-builder-lib/@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.2", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.2", "@babel/helper-validator-identifier": "^8.0.0-rc.2" } }, "sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw=="],
+
     "axctl/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cli-truncate/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cli-truncate/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "dir-compare/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
+
+    "dir-compare/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "dmg-license/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "electron-winstaller/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
+
+    "electron-winstaller/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
+
+    "electron/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
+
+    "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "lmdb/msgpackr/msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
 
@@ -1794,6 +2411,74 @@
 
     "miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260526.1", "", { "os": "win32", "cpu": "x64" }, "sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q=="],
 
+    "node-gyp/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
+
+    "rolldown-plugin-dts/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.6", "", {}, "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g=="],
+
+    "tsdown/rolldown/@oxc-project/types": ["@oxc-project/types@0.112.0", "", {}, "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ=="],
+
+    "tsdown/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.3", "", { "os": "android", "cpu": "arm64" }, "sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ=="],
+
+    "tsdown/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A=="],
+
+    "tsdown/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-MTakBxfx3tde5WSmbHxuqlDsIW0EzQym+PJYGF4P6lG2NmKzi128OGynoFUqoD5ryCySEY85dug4v+LWGBElIw=="],
+
+    "tsdown/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3", "", { "os": "linux", "cpu": "arm" }, "sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.3", "", { "os": "linux", "cpu": "x64" }, "sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ=="],
+
+    "tsdown/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.3", "", { "os": "linux", "cpu": "x64" }, "sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw=="],
+
+    "tsdown/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.3", "", { "os": "none", "cpu": "arm64" }, "sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ=="],
+
+    "tsdown/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.3", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g=="],
+
+    "tsdown/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg=="],
+
+    "tsdown/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.3", "", { "os": "win32", "cpu": "x64" }, "sha512-a4VUQZH7LxGbUJ3qJ/TzQG8HxdHvf+jOnqf7B7oFx1TEBm+j2KNL2zr5SQ7wHkNAcaPevF6gf9tQnVBnC4mD+A=="],
+
+    "tsdown/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
+
+    "unrun/rolldown/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "unrun/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
+
+    "unrun/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw=="],
+
+    "unrun/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw=="],
+
+    "unrun/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.17", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm" }, "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "s390x" }, "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw=="],
+
+    "unrun/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.17", "", { "os": "none", "cpu": "arm64" }, "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA=="],
+
+    "unrun/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.17", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA=="],
+
+    "unrun/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA=="],
+
+    "unrun/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
+
+    "unrun/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
+
     "wrangler/miniflare/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "wrangler/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
@@ -1802,7 +2487,13 @@
 
     "wrangler/miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
 
-    "xmlbuilder2/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -1866,7 +2557,27 @@
 
     "@cloudflare/vite-plugin/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260526.1", "", { "os": "win32", "cpu": "x64" }, "sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q=="],
 
+    "@electron/asar/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@electron/universal/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "app-builder-lib/@electron/get/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
+
+    "app-builder-lib/@electron/get/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
+
+    "ast-kit/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.6", "", {}, "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g=="],
+
+    "ast-kit/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.2", "", {}, "sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A=="],
+
+    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "dir-compare/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "lmdb/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
@@ -1879,5 +2590,7 @@
     "lmdb/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
 
     "lmdb/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
+
+    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/bun.nix
+++ b/bun.nix
@@ -13,6 +13,10 @@
   ...
 }:
 {
+  "7zip-bin@5.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz";
+    hash = "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==";
+  };
   "@ax-classifier/direction-event" = copyPathToStore ./packages/ax-classifier-direction-event;
   "@ax-classifier/session-sections" = copyPathToStore ./packages/ax-classifier-session-sections;
   "@ax-classifier/verification-event" = copyPathToStore ./packages/ax-classifier-verification-event;
@@ -20,6 +24,7 @@
   "@ax/schema" = copyPathToStore ./packages/schema;
   "@ax/site" = copyPathToStore ./apps/site;
   "@ax/studio" = copyPathToStore ./apps/studio;
+  "@ax/studio-desktop" = copyPathToStore ./apps/studio-desktop;
   "@babel/code-frame@7.27.1" = fetchurl {
     url = "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz";
     hash = "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==";
@@ -39,6 +44,10 @@
   "@babel/generator@7.29.1" = fetchurl {
     url = "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz";
     hash = "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==";
+  };
+  "@babel/generator@8.0.0-rc.2" = fetchurl {
+    url = "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.2.tgz";
+    hash = "sha512-oCQ1IKPwkzCeJzAPb7Fv8rQ9k5+1sG8mf2uoHiMInPYvkRfrDJxbTIbH51U+jstlkghus0vAi3EBvkfvEsYNLQ==";
   };
   "@babel/helper-compilation-targets@7.28.6" = fetchurl {
     url = "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz";
@@ -64,9 +73,17 @@
     url = "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz";
     hash = "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==";
   };
+  "@babel/helper-string-parser@8.0.0-rc.6" = fetchurl {
+    url = "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.6.tgz";
+    hash = "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==";
+  };
   "@babel/helper-validator-identifier@7.28.5" = fetchurl {
     url = "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz";
     hash = "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==";
+  };
+  "@babel/helper-validator-identifier@8.0.0-rc.2" = fetchurl {
+    url = "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.2.tgz";
+    hash = "sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A==";
   };
   "@babel/helper-validator-option@7.27.1" = fetchurl {
     url = "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz";
@@ -79,6 +96,10 @@
   "@babel/parser@7.29.3" = fetchurl {
     url = "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz";
     hash = "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==";
+  };
+  "@babel/parser@8.0.0-rc.2" = fetchurl {
+    url = "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.2.tgz";
+    hash = "sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ==";
   };
   "@babel/plugin-syntax-jsx@7.28.6" = fetchurl {
     url = "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz";
@@ -103,6 +124,10 @@
   "@babel/types@7.29.0" = fetchurl {
     url = "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz";
     hash = "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==";
+  };
+  "@babel/types@8.0.0-rc.2" = fetchurl {
+    url = "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.2.tgz";
+    hash = "sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw==";
   };
   "@cloudflare/kv-asset-handler@0.3.4" = fetchurl {
     url = "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz";
@@ -184,6 +209,10 @@
     url = "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz";
     hash = "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==";
   };
+  "@develar/schema-utils@2.6.5" = fetchurl {
+    url = "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz";
+    hash = "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==";
+  };
   "@durable-streams/client@0.2.6" = fetchurl {
     url = "https://registry.npmjs.org/@durable-streams/client/-/client-0.2.6.tgz";
     hash = "sha512-uHKKbWpsKLhFMeGjG0PgM6LXE3oEIi7FHKlJZkmYGxcqd4Yjjd/QEvnQnDzteRP4Av1uJVM8qjTL7kfKsgeS/w==";
@@ -207,6 +236,46 @@
   "@effect/platform-node-shared@4.0.0-beta.76" = fetchurl {
     url = "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-beta.76.tgz";
     hash = "sha512-htJyli8B7hidi5ANPskhy3cK19g3idNColSlSAqIC9lDAmLcLFQZqpOsUY3uBfSChps8HzhxRwVqWp9C/vsQXA==";
+  };
+  "@effect/platform-node@4.0.0-beta.70" = fetchurl {
+    url = "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-beta.70.tgz";
+    hash = "sha512-Ls1WtLaO2CbcO8jHtZRRi6eZa4YOJZ9KXm6udMvwhjV/XhqdsT6AzmcXbc1hINbKgvRcik6qM/441YEaBMYoqw==";
+  };
+  "@electron/asar@3.4.1" = fetchurl {
+    url = "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz";
+    hash = "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==";
+  };
+  "@electron/fuses@1.8.0" = fetchurl {
+    url = "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz";
+    hash = "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==";
+  };
+  "@electron/get@2.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz";
+    hash = "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==";
+  };
+  "@electron/get@3.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz";
+    hash = "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==";
+  };
+  "@electron/notarize@2.5.0" = fetchurl {
+    url = "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz";
+    hash = "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==";
+  };
+  "@electron/osx-sign@1.3.3" = fetchurl {
+    url = "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz";
+    hash = "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==";
+  };
+  "@electron/rebuild@4.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz";
+    hash = "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==";
+  };
+  "@electron/universal@2.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz";
+    hash = "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==";
+  };
+  "@electron/windows-sign@1.2.2" = fetchurl {
+    url = "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz";
+    hash = "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==";
   };
   "@emnapi/core@1.10.0" = fetchurl {
     url = "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz";
@@ -720,6 +789,14 @@
     url = "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz";
     hash = "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==";
   };
+  "@ioredis/commands@1.10.0" = fetchurl {
+    url = "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz";
+    hash = "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==";
+  };
+  "@isaacs/fs-minipass@4.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz";
+    hash = "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==";
+  };
   "@jridgewell/gen-mapping@0.3.13" = fetchurl {
     url = "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz";
     hash = "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==";
@@ -771,6 +848,14 @@
   "@lmdb/lmdb-win32-x64@3.5.4" = fetchurl {
     url = "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.5.4.tgz";
     hash = "sha512-JF1BmLCm9kGEVZgYmJq43zeQVdHVgAJnTi/NURWEsy6L1ZrrlSmdltS+D17QN4LODwf+1LMXAA9auIZVXtWwzw==";
+  };
+  "@malept/cross-spawn-promise@2.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz";
+    hash = "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==";
+  };
+  "@malept/flatpak-bundler@0.4.0" = fetchurl {
+    url = "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz";
+    hash = "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==";
   };
   "@mdx-js/esbuild@3.1.1" = fetchurl {
     url = "https://registry.npmjs.org/@mdx-js/esbuild/-/esbuild-3.1.1.tgz";
@@ -892,6 +977,14 @@
     url = "https://registry.npmjs.org/@opentui/react/-/react-0.2.5.tgz";
     hash = "sha512-cf8cj0VXcxBYVOCnS7bJ8IhiZTsLyo0q4KcXkmB51ZBNl0DGQvUcUBTbyHrIdUUULP5AkeLb4utjkK5MsB11DQ==";
   };
+  "@oxc-project/types@0.112.0" = fetchurl {
+    url = "https://registry.npmjs.org/@oxc-project/types/-/types-0.112.0.tgz";
+    hash = "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==";
+  };
+  "@oxc-project/types@0.127.0" = fetchurl {
+    url = "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz";
+    hash = "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==";
+  };
   "@oxc-project/types@0.129.0" = fetchurl {
     url = "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz";
     hash = "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==";
@@ -908,69 +1001,193 @@
     url = "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz";
     hash = "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==";
   };
+  "@quansync/fs@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz";
+    hash = "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==";
+  };
   "@rolldown/binding-android-arm64@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz";
     hash = "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==";
+  };
+  "@rolldown/binding-android-arm64@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz";
+    hash = "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==";
+  };
+  "@rolldown/binding-android-arm64@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.3.tgz";
+    hash = "sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ==";
   };
   "@rolldown/binding-darwin-arm64@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz";
     hash = "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==";
   };
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz";
+    hash = "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==";
+  };
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.3.tgz";
+    hash = "sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A==";
+  };
   "@rolldown/binding-darwin-x64@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz";
     hash = "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==";
+  };
+  "@rolldown/binding-darwin-x64@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz";
+    hash = "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==";
+  };
+  "@rolldown/binding-darwin-x64@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.3.tgz";
+    hash = "sha512-MTakBxfx3tde5WSmbHxuqlDsIW0EzQym+PJYGF4P6lG2NmKzi128OGynoFUqoD5ryCySEY85dug4v+LWGBElIw==";
   };
   "@rolldown/binding-freebsd-x64@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz";
     hash = "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==";
   };
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz";
+    hash = "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==";
+  };
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.3.tgz";
+    hash = "sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww==";
+  };
   "@rolldown/binding-linux-arm-gnueabihf@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz";
     hash = "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==";
+  };
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz";
+    hash = "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==";
+  };
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.3.tgz";
+    hash = "sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag==";
   };
   "@rolldown/binding-linux-arm64-gnu@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz";
     hash = "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==";
   };
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz";
+    hash = "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==";
+  };
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.3.tgz";
+    hash = "sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==";
+  };
   "@rolldown/binding-linux-arm64-musl@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz";
     hash = "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==";
+  };
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz";
+    hash = "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==";
+  };
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.3.tgz";
+    hash = "sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==";
   };
   "@rolldown/binding-linux-ppc64-gnu@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz";
     hash = "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==";
   };
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz";
+    hash = "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==";
+  };
   "@rolldown/binding-linux-s390x-gnu@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz";
     hash = "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==";
+  };
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz";
+    hash = "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==";
   };
   "@rolldown/binding-linux-x64-gnu@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz";
     hash = "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==";
   };
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz";
+    hash = "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==";
+  };
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.3.tgz";
+    hash = "sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==";
+  };
   "@rolldown/binding-linux-x64-musl@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz";
     hash = "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==";
+  };
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz";
+    hash = "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==";
+  };
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.3.tgz";
+    hash = "sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==";
   };
   "@rolldown/binding-openharmony-arm64@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz";
     hash = "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==";
   };
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz";
+    hash = "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==";
+  };
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.3.tgz";
+    hash = "sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==";
+  };
   "@rolldown/binding-wasm32-wasi@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz";
     hash = "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==";
+  };
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz";
+    hash = "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==";
+  };
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.3.tgz";
+    hash = "sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g==";
   };
   "@rolldown/binding-win32-arm64-msvc@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz";
     hash = "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==";
   };
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz";
+    hash = "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==";
+  };
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.3.tgz";
+    hash = "sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg==";
+  };
   "@rolldown/binding-win32-x64-msvc@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz";
     hash = "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==";
   };
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz";
+    hash = "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==";
+  };
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.3.tgz";
+    hash = "sha512-a4VUQZH7LxGbUJ3qJ/TzQG8HxdHvf+jOnqf7B7oFx1TEBm+j2KNL2zr5SQ7wHkNAcaPevF6gf9tQnVBnC4mD+A==";
+  };
   "@rolldown/pluginutils@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz";
     hash = "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==";
+  };
+  "@rolldown/pluginutils@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz";
+    hash = "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==";
+  };
+  "@rolldown/pluginutils@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz";
+    hash = "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==";
   };
   "@rolldown/pluginutils@1.0.0-rc.7" = fetchurl {
     url = "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz";
@@ -1012,6 +1229,10 @@
     url = "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz";
     hash = "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==";
   };
+  "@sindresorhus/is@4.6.0" = fetchurl {
+    url = "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz";
+    hash = "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==";
+  };
   "@sindresorhus/is@7.2.0" = fetchurl {
     url = "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz";
     hash = "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==";
@@ -1027,6 +1248,10 @@
   "@surrealdb/cbor@2.0.0-alpha.4" = fetchurl {
     url = "https://registry.npmjs.org/@surrealdb/cbor/-/cbor-2.0.0-alpha.4.tgz";
     hash = "sha512-l/hNZ3ZCOJq8rzwx1y5ZV/8b2bYCWdhGqRVY33Pu50NAHyAW5qLsMn3ZBkZow77mAKwNCsbDsRGnyYEuU95mjw==";
+  };
+  "@szmarczak/http-timer@4.0.6" = fetchurl {
+    url = "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz";
+    hash = "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==";
   };
   "@tailwindcss/node@4.3.0" = fetchurl {
     url = "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz";
@@ -1244,6 +1469,10 @@
     url = "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz";
     hash = "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==";
   };
+  "@types/cacheable-request@6.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz";
+    hash = "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==";
+  };
   "@types/debug@4.1.13" = fetchurl {
     url = "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz";
     hash = "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==";
@@ -1256,9 +1485,25 @@
     url = "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz";
     hash = "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==";
   };
+  "@types/fs-extra@9.0.13" = fetchurl {
+    url = "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz";
+    hash = "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==";
+  };
   "@types/hast@3.0.4" = fetchurl {
     url = "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz";
     hash = "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==";
+  };
+  "@types/http-cache-semantics@4.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz";
+    hash = "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==";
+  };
+  "@types/jsesc@2.5.1" = fetchurl {
+    url = "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz";
+    hash = "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==";
+  };
+  "@types/keyv@3.1.4" = fetchurl {
+    url = "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz";
+    hash = "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==";
   };
   "@types/mdast@4.0.4" = fetchurl {
     url = "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz";
@@ -1272,9 +1517,17 @@
     url = "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz";
     hash = "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==";
   };
+  "@types/node@24.13.1" = fetchurl {
+    url = "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz";
+    hash = "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==";
+  };
   "@types/node@25.6.2" = fetchurl {
     url = "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz";
     hash = "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==";
+  };
+  "@types/plist@3.0.5" = fetchurl {
+    url = "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz";
+    hash = "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==";
   };
   "@types/react-dom@19.2.3" = fetchurl {
     url = "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz";
@@ -1288,6 +1541,10 @@
     url = "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz";
     hash = "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==";
   };
+  "@types/responselike@1.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz";
+    hash = "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==";
+  };
   "@types/unist@2.0.11" = fetchurl {
     url = "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz";
     hash = "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==";
@@ -1296,9 +1553,17 @@
     url = "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz";
     hash = "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==";
   };
+  "@types/verror@1.10.11" = fetchurl {
+    url = "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz";
+    hash = "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==";
+  };
   "@types/ws@8.18.1" = fetchurl {
     url = "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz";
     hash = "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==";
+  };
+  "@types/yauzl@2.10.3" = fetchurl {
+    url = "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz";
+    hash = "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==";
   };
   "@ungap/structured-clone@1.3.1" = fetchurl {
     url = "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz";
@@ -1320,6 +1585,14 @@
     url = "https://registry.npmjs.org/@wterm/dom/-/dom-0.3.0.tgz";
     hash = "sha512-OiUl7reGSlW02yb5wGXMplMZhW2HBkBSFxvbFj15I832UK0QFIHRvhE2l6Xgae8ROn9bNLaALoKDFvcUuz80iQ==";
   };
+  "@xmldom/xmldom@0.8.13" = fetchurl {
+    url = "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz";
+    hash = "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==";
+  };
+  "abbrev@4.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz";
+    hash = "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==";
+  };
   "accepts@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz";
     hash = "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==";
@@ -1336,17 +1609,37 @@
     url = "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz";
     hash = "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==";
   };
+  "agent-base@7.1.4" = fetchurl {
+    url = "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz";
+    hash = "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==";
+  };
   "ajv-formats@3.0.1" = fetchurl {
     url = "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz";
     hash = "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==";
+  };
+  "ajv-keywords@3.5.2" = fetchurl {
+    url = "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz";
+    hash = "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==";
+  };
+  "ajv@6.15.0" = fetchurl {
+    url = "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz";
+    hash = "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==";
   };
   "ajv@8.20.0" = fetchurl {
     url = "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz";
     hash = "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==";
   };
+  "ansi-regex@5.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz";
+    hash = "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==";
+  };
   "ansi-regex@6.2.2" = fetchurl {
     url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz";
     hash = "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==";
+  };
+  "ansi-styles@4.3.0" = fetchurl {
+    url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz";
+    hash = "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==";
   };
   "ansis@4.3.0" = fetchurl {
     url = "https://registry.npmjs.org/ansis/-/ansis-4.3.0.tgz";
@@ -1355,6 +1648,14 @@
   "anymatch@3.1.3" = fetchurl {
     url = "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz";
     hash = "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==";
+  };
+  "app-builder-bin@5.0.0-alpha.12" = fetchurl {
+    url = "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz";
+    hash = "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==";
+  };
+  "app-builder-lib@26.8.1" = fetchurl {
+    url = "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz";
+    hash = "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==";
   };
   "argparse@1.0.10" = fetchurl {
     url = "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz";
@@ -1368,9 +1669,37 @@
     url = "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz";
     hash = "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==";
   };
+  "assert-plus@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz";
+    hash = "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==";
+  };
+  "ast-kit@3.0.0-beta.1" = fetchurl {
+    url = "https://registry.npmjs.org/ast-kit/-/ast-kit-3.0.0-beta.1.tgz";
+    hash = "sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==";
+  };
+  "astral-regex@2.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz";
+    hash = "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==";
+  };
   "astring@1.9.0" = fetchurl {
     url = "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz";
     hash = "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==";
+  };
+  "async-exit-hook@2.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz";
+    hash = "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==";
+  };
+  "async@3.2.6" = fetchurl {
+    url = "https://registry.npmjs.org/async/-/async-3.2.6.tgz";
+    hash = "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==";
+  };
+  "asynckit@0.4.0" = fetchurl {
+    url = "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz";
+    hash = "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==";
+  };
+  "at-least-node@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz";
+    hash = "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==";
   };
   "axctl" = copyPathToStore ./apps/axctl;
   "babel-dead-code-elimination@1.0.12" = fetchurl {
@@ -1381,6 +1710,18 @@
     url = "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz";
     hash = "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==";
   };
+  "balanced-match@1.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz";
+    hash = "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==";
+  };
+  "balanced-match@4.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz";
+    hash = "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==";
+  };
+  "base64-js@1.5.1" = fetchurl {
+    url = "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz";
+    hash = "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==";
+  };
   "baseline-browser-mapping@2.10.29" = fetchurl {
     url = "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz";
     hash = "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==";
@@ -1388,6 +1729,10 @@
   "binary-extensions@2.3.0" = fetchurl {
     url = "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz";
     hash = "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==";
+  };
+  "birpc@4.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz";
+    hash = "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==";
   };
   "blake3-wasm@2.1.5" = fetchurl {
     url = "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz";
@@ -1397,6 +1742,22 @@
     url = "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz";
     hash = "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==";
   };
+  "boolean@3.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz";
+    hash = "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==";
+  };
+  "brace-expansion@1.1.15" = fetchurl {
+    url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz";
+    hash = "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==";
+  };
+  "brace-expansion@2.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz";
+    hash = "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==";
+  };
+  "brace-expansion@5.0.6" = fetchurl {
+    url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz";
+    hash = "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==";
+  };
   "braces@3.0.3" = fetchurl {
     url = "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz";
     hash = "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==";
@@ -1404,6 +1765,30 @@
   "browserslist@4.28.2" = fetchurl {
     url = "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz";
     hash = "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==";
+  };
+  "buffer-crc32@0.2.13" = fetchurl {
+    url = "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz";
+    hash = "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==";
+  };
+  "buffer-from@1.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz";
+    hash = "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==";
+  };
+  "buffer@5.7.1" = fetchurl {
+    url = "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz";
+    hash = "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==";
+  };
+  "builder-util-runtime@9.5.1" = fetchurl {
+    url = "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz";
+    hash = "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==";
+  };
+  "builder-util-runtime@9.7.0" = fetchurl {
+    url = "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz";
+    hash = "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==";
+  };
+  "builder-util@26.8.1" = fetchurl {
+    url = "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz";
+    hash = "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==";
   };
   "bun-ffi-structs@0.2.2" = fetchurl {
     url = "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.2.2.tgz";
@@ -1425,6 +1810,18 @@
     url = "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz";
     hash = "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==";
   };
+  "cac@6.7.14" = fetchurl {
+    url = "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz";
+    hash = "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==";
+  };
+  "cacheable-lookup@5.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz";
+    hash = "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==";
+  };
+  "cacheable-request@7.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz";
+    hash = "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==";
+  };
   "call-bind-apply-helpers@1.0.2" = fetchurl {
     url = "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz";
     hash = "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==";
@@ -1444,6 +1841,10 @@
   "ccount@2.0.1" = fetchurl {
     url = "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz";
     hash = "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==";
+  };
+  "chalk@4.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz";
+    hash = "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==";
   };
   "character-entities-html4@2.1.0" = fetchurl {
     url = "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz";
@@ -1473,9 +1874,41 @@
     url = "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz";
     hash = "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==";
   };
+  "chownr@3.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz";
+    hash = "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==";
+  };
+  "chromium-pickle-js@0.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz";
+    hash = "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==";
+  };
+  "ci-info@4.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz";
+    hash = "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==";
+  };
+  "ci-info@4.4.0" = fetchurl {
+    url = "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz";
+    hash = "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==";
+  };
+  "cli-truncate@2.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz";
+    hash = "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==";
+  };
+  "cliui@8.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz";
+    hash = "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==";
+  };
+  "clone-response@1.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz";
+    hash = "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==";
+  };
   "clsx@2.1.1" = fetchurl {
     url = "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz";
     hash = "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==";
+  };
+  "cluster-key-slot@1.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz";
+    hash = "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==";
   };
   "collapse-white-space@2.1.0" = fetchurl {
     url = "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz";
@@ -1497,9 +1930,29 @@
     url = "https://registry.npmjs.org/color/-/color-4.2.3.tgz";
     hash = "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==";
   };
+  "combined-stream@1.0.8" = fetchurl {
+    url = "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz";
+    hash = "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==";
+  };
   "comma-separated-tokens@2.0.3" = fetchurl {
     url = "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz";
     hash = "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==";
+  };
+  "commander@5.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz";
+    hash = "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==";
+  };
+  "commander@9.5.0" = fetchurl {
+    url = "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz";
+    hash = "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==";
+  };
+  "compare-version@0.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz";
+    hash = "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==";
+  };
+  "concat-map@0.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz";
+    hash = "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==";
   };
   "content-disposition@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz";
@@ -1533,9 +1986,21 @@
     url = "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz";
     hash = "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==";
   };
+  "core-util-is@1.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz";
+    hash = "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==";
+  };
   "cors@2.8.6" = fetchurl {
     url = "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz";
     hash = "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==";
+  };
+  "crc@3.8.0" = fetchurl {
+    url = "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz";
+    hash = "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==";
+  };
+  "cross-dirname@0.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz";
+    hash = "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==";
   };
   "cross-spawn@7.0.6" = fetchurl {
     url = "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz";
@@ -1557,9 +2022,33 @@
     url = "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz";
     hash = "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==";
   };
+  "decompress-response@6.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz";
+    hash = "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==";
+  };
+  "defer-to-connect@2.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz";
+    hash = "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==";
+  };
+  "define-data-property@1.1.4" = fetchurl {
+    url = "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz";
+    hash = "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==";
+  };
+  "define-properties@1.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz";
+    hash = "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==";
+  };
   "defu@6.1.7" = fetchurl {
     url = "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz";
     hash = "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==";
+  };
+  "delayed-stream@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz";
+    hash = "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==";
+  };
+  "denque@2.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz";
+    hash = "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==";
   };
   "depd@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz";
@@ -1573,6 +2062,10 @@
     url = "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz";
     hash = "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==";
   };
+  "detect-node@2.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz";
+    hash = "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==";
+  };
   "devlop@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz";
     hash = "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==";
@@ -1584,6 +2077,30 @@
   "diff@9.0.0" = fetchurl {
     url = "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz";
     hash = "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==";
+  };
+  "dir-compare@4.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz";
+    hash = "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==";
+  };
+  "dmg-builder@26.8.1" = fetchurl {
+    url = "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.8.1.tgz";
+    hash = "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==";
+  };
+  "dmg-license@1.0.11" = fetchurl {
+    url = "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz";
+    hash = "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==";
+  };
+  "dotenv-expand@11.0.7" = fetchurl {
+    url = "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz";
+    hash = "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==";
+  };
+  "dotenv@16.6.1" = fetchurl {
+    url = "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz";
+    hash = "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==";
+  };
+  "dts-resolver@2.1.3" = fetchurl {
+    url = "https://registry.npmjs.org/dts-resolver/-/dts-resolver-2.1.3.tgz";
+    hash = "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==";
   };
   "dunder-proto@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz";
@@ -1597,17 +2114,57 @@
     url = "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.70.tgz";
     hash = "sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg==";
   };
+  "ejs@3.1.10" = fetchurl {
+    url = "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz";
+    hash = "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==";
+  };
+  "electron-builder-squirrel-windows@26.8.1" = fetchurl {
+    url = "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz";
+    hash = "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==";
+  };
+  "electron-builder@26.8.1" = fetchurl {
+    url = "https://registry.npmjs.org/electron-builder/-/electron-builder-26.8.1.tgz";
+    hash = "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw==";
+  };
+  "electron-publish@26.8.1" = fetchurl {
+    url = "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz";
+    hash = "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==";
+  };
   "electron-to-chromium@1.5.353" = fetchurl {
     url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz";
     hash = "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==";
+  };
+  "electron-updater@6.8.9" = fetchurl {
+    url = "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz";
+    hash = "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==";
+  };
+  "electron-winstaller@5.4.0" = fetchurl {
+    url = "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz";
+    hash = "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==";
+  };
+  "electron@41.5.0" = fetchurl {
+    url = "https://registry.npmjs.org/electron/-/electron-41.5.0.tgz";
+    hash = "sha512-x9j9//PubUA4EjDtQbZhtk3prolandqCKgit0uCIqc1jb8FTskPbnJtxcDFB1aejczJcuERgjPixBUaMwoWyJg==";
   };
   "emoji-regex@10.6.0" = fetchurl {
     url = "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz";
     hash = "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==";
   };
+  "emoji-regex@8.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz";
+    hash = "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==";
+  };
+  "empathic@2.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz";
+    hash = "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==";
+  };
   "encodeurl@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz";
     hash = "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==";
+  };
+  "end-of-stream@1.4.5" = fetchurl {
+    url = "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz";
+    hash = "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==";
   };
   "enhanced-resolve@5.22.1" = fetchurl {
     url = "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz";
@@ -1616,6 +2173,14 @@
   "entities@6.0.1" = fetchurl {
     url = "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz";
     hash = "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==";
+  };
+  "env-paths@2.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz";
+    hash = "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==";
+  };
+  "err-code@2.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz";
+    hash = "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==";
   };
   "error-stack-parser-es@1.0.5" = fetchurl {
     url = "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz";
@@ -1632,6 +2197,14 @@
   "es-object-atoms@1.1.2" = fetchurl {
     url = "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz";
     hash = "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==";
+  };
+  "es-set-tostringtag@2.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz";
+    hash = "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==";
+  };
+  "es6-error@4.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz";
+    hash = "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==";
   };
   "esast-util-from-estree@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz";
@@ -1725,6 +2298,10 @@
     url = "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz";
     hash = "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==";
   };
+  "exponential-backoff@3.1.3" = fetchurl {
+    url = "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz";
+    hash = "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==";
+  };
   "express-rate-limit@8.5.2" = fetchurl {
     url = "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz";
     hash = "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==";
@@ -1745,6 +2322,14 @@
     url = "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz";
     hash = "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==";
   };
+  "extract-zip@2.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz";
+    hash = "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==";
+  };
+  "extsprintf@1.4.1" = fetchurl {
+    url = "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz";
+    hash = "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==";
+  };
   "fast-check@4.8.0" = fetchurl {
     url = "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz";
     hash = "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==";
@@ -1752,6 +2337,10 @@
   "fast-deep-equal@3.1.3" = fetchurl {
     url = "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz";
     hash = "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==";
+  };
+  "fast-json-stable-stringify@2.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz";
+    hash = "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==";
   };
   "fast-uri@3.1.2" = fetchurl {
     url = "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz";
@@ -1765,6 +2354,10 @@
     url = "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz";
     hash = "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==";
   };
+  "fd-slicer@1.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz";
+    hash = "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==";
+  };
   "fdir@6.5.0" = fetchurl {
     url = "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz";
     hash = "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==";
@@ -1772,6 +2365,10 @@
   "fetchdts@0.1.7" = fetchurl {
     url = "https://registry.npmjs.org/fetchdts/-/fetchdts-0.1.7.tgz";
     hash = "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==";
+  };
+  "filelist@1.0.6" = fetchurl {
+    url = "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz";
+    hash = "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==";
   };
   "fill-range@7.1.1" = fetchurl {
     url = "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz";
@@ -1784,6 +2381,10 @@
   "find-my-way-ts@0.1.6" = fetchurl {
     url = "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz";
     hash = "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==";
+  };
+  "form-data@4.0.5" = fetchurl {
+    url = "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz";
+    hash = "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==";
   };
   "format@0.2.2" = fetchurl {
     url = "https://registry.npmjs.org/format/-/format-0.2.2.tgz";
@@ -1801,6 +2402,30 @@
     url = "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz";
     hash = "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==";
   };
+  "fs-extra@10.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz";
+    hash = "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==";
+  };
+  "fs-extra@11.3.5" = fetchurl {
+    url = "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz";
+    hash = "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==";
+  };
+  "fs-extra@7.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz";
+    hash = "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==";
+  };
+  "fs-extra@8.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz";
+    hash = "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==";
+  };
+  "fs-extra@9.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz";
+    hash = "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==";
+  };
+  "fs.realpath@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz";
+    hash = "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==";
+  };
   "fsevents@2.3.3" = fetchurl {
     url = "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz";
     hash = "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==";
@@ -1812,6 +2437,10 @@
   "gensync@1.0.0-beta.2" = fetchurl {
     url = "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz";
     hash = "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==";
+  };
+  "get-caller-file@2.0.5" = fetchurl {
+    url = "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz";
+    hash = "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==";
   };
   "get-east-asian-width@1.6.0" = fetchurl {
     url = "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz";
@@ -1829,6 +2458,14 @@
     url = "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz";
     hash = "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==";
   };
+  "get-stream@5.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz";
+    hash = "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==";
+  };
+  "get-tsconfig@4.14.0" = fetchurl {
+    url = "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz";
+    hash = "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==";
+  };
   "github-slugger@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz";
     hash = "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==";
@@ -1841,6 +2478,18 @@
     url = "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz";
     hash = "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==";
   };
+  "glob@7.2.3" = fetchurl {
+    url = "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz";
+    hash = "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==";
+  };
+  "global-agent@3.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz";
+    hash = "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==";
+  };
+  "globalthis@1.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz";
+    hash = "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==";
+  };
   "goober@2.1.19" = fetchurl {
     url = "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz";
     hash = "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==";
@@ -1848,6 +2497,10 @@
   "gopd@1.2.0" = fetchurl {
     url = "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz";
     hash = "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==";
+  };
+  "got@11.8.6" = fetchurl {
+    url = "https://registry.npmjs.org/got/-/got-11.8.6.tgz";
+    hash = "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==";
   };
   "graceful-fs@4.2.11" = fetchurl {
     url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz";
@@ -1861,9 +2514,21 @@
     url = "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.20.tgz";
     hash = "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==";
   };
+  "has-flag@4.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz";
+    hash = "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==";
+  };
+  "has-property-descriptors@1.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz";
+    hash = "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==";
+  };
   "has-symbols@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz";
     hash = "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==";
+  };
+  "has-tostringtag@1.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz";
+    hash = "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==";
   };
   "hasown@2.0.4" = fetchurl {
     url = "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz";
@@ -1917,17 +2582,61 @@
     url = "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz";
     hash = "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==";
   };
+  "hookable@6.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz";
+    hash = "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==";
+  };
+  "hosted-git-info@4.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz";
+    hash = "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==";
+  };
   "html-void-elements@3.0.0" = fetchurl {
     url = "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz";
     hash = "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==";
+  };
+  "http-cache-semantics@4.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz";
+    hash = "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==";
   };
   "http-errors@2.0.1" = fetchurl {
     url = "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz";
     hash = "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==";
   };
+  "http-proxy-agent@7.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz";
+    hash = "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==";
+  };
+  "http2-wrapper@1.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz";
+    hash = "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==";
+  };
+  "https-proxy-agent@7.0.6" = fetchurl {
+    url = "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz";
+    hash = "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==";
+  };
+  "iconv-corefoundation@1.1.7" = fetchurl {
+    url = "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz";
+    hash = "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==";
+  };
+  "iconv-lite@0.6.3" = fetchurl {
+    url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz";
+    hash = "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==";
+  };
   "iconv-lite@0.7.2" = fetchurl {
     url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz";
     hash = "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==";
+  };
+  "ieee754@1.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz";
+    hash = "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==";
+  };
+  "import-without-cache@0.2.5" = fetchurl {
+    url = "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.2.5.tgz";
+    hash = "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==";
+  };
+  "inflight@1.0.6" = fetchurl {
+    url = "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz";
+    hash = "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==";
   };
   "inherits@2.0.4" = fetchurl {
     url = "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz";
@@ -1940,6 +2649,10 @@
   "inline-style-parser@0.2.7" = fetchurl {
     url = "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz";
     hash = "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==";
+  };
+  "ioredis@5.11.1" = fetchurl {
+    url = "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz";
+    hash = "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==";
   };
   "ip-address@10.2.0" = fetchurl {
     url = "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz";
@@ -1981,6 +2694,10 @@
     url = "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz";
     hash = "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==";
   };
+  "is-fullwidth-code-point@3.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz";
+    hash = "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==";
+  };
   "is-glob@4.0.3" = fetchurl {
     url = "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz";
     hash = "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==";
@@ -2001,6 +2718,14 @@
     url = "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz";
     hash = "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==";
   };
+  "isbinaryfile@4.0.10" = fetchurl {
+    url = "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz";
+    hash = "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==";
+  };
+  "isbinaryfile@5.0.7" = fetchurl {
+    url = "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz";
+    hash = "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==";
+  };
   "isbot@5.1.40" = fetchurl {
     url = "https://registry.npmjs.org/isbot/-/isbot-5.1.40.tgz";
     hash = "sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ==";
@@ -2008,6 +2733,18 @@
   "isexe@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz";
     hash = "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==";
+  };
+  "isexe@3.1.5" = fetchurl {
+    url = "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz";
+    hash = "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==";
+  };
+  "isexe@4.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz";
+    hash = "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==";
+  };
+  "jake@10.9.4" = fetchurl {
+    url = "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz";
+    hash = "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==";
   };
   "jiti@2.7.0" = fetchurl {
     url = "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz";
@@ -2033,6 +2770,14 @@
     url = "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz";
     hash = "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==";
   };
+  "json-buffer@3.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz";
+    hash = "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==";
+  };
+  "json-schema-traverse@0.4.1" = fetchurl {
+    url = "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz";
+    hash = "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==";
+  };
   "json-schema-traverse@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz";
     hash = "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==";
@@ -2041,9 +2786,25 @@
     url = "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz";
     hash = "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==";
   };
+  "json-stringify-safe@5.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz";
+    hash = "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==";
+  };
   "json5@2.2.3" = fetchurl {
     url = "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz";
     hash = "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==";
+  };
+  "jsonfile@4.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz";
+    hash = "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==";
+  };
+  "jsonfile@6.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz";
+    hash = "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==";
+  };
+  "keyv@4.5.4" = fetchurl {
+    url = "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz";
+    hash = "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==";
   };
   "kind-of@6.0.3" = fetchurl {
     url = "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz";
@@ -2056,6 +2817,10 @@
   "kubernetes-types@1.30.0" = fetchurl {
     url = "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz";
     hash = "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==";
+  };
+  "lazy-val@1.0.5" = fetchurl {
+    url = "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz";
+    hash = "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==";
   };
   "lightningcss-android-arm64@1.32.0" = fetchurl {
     url = "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz";
@@ -2109,13 +2874,33 @@
     url = "https://registry.npmjs.org/lmdb/-/lmdb-3.5.4.tgz";
     hash = "sha512-9FKQA6G1MMtqNxfxvSBNXD/axeG2QRjYbNh0/ykRL5xYcRbCm2vXq7B9bhc7nSuKdHzr8/BHIwfPuYYH1UsXXw==";
   };
+  "lodash.escaperegexp@4.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz";
+    hash = "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==";
+  };
+  "lodash.isequal@4.5.0" = fetchurl {
+    url = "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz";
+    hash = "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==";
+  };
+  "lodash@4.18.1" = fetchurl {
+    url = "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz";
+    hash = "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==";
+  };
   "longest-streak@3.1.0" = fetchurl {
     url = "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz";
     hash = "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==";
   };
+  "lowercase-keys@2.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz";
+    hash = "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==";
+  };
   "lru-cache@5.1.1" = fetchurl {
     url = "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz";
     hash = "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==";
+  };
+  "lru-cache@6.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz";
+    hash = "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==";
   };
   "magic-string@0.25.9" = fetchurl {
     url = "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz";
@@ -2136,6 +2921,10 @@
   "marked@17.0.1" = fetchurl {
     url = "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz";
     hash = "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==";
+  };
+  "matcher@3.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz";
+    hash = "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==";
   };
   "math-intrinsics@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz";
@@ -2365,17 +3154,41 @@
     url = "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz";
     hash = "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==";
   };
+  "mime-db@1.52.0" = fetchurl {
+    url = "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz";
+    hash = "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==";
+  };
   "mime-db@1.54.0" = fetchurl {
     url = "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz";
     hash = "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==";
+  };
+  "mime-types@2.1.35" = fetchurl {
+    url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz";
+    hash = "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==";
   };
   "mime-types@3.0.2" = fetchurl {
     url = "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz";
     hash = "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==";
   };
+  "mime@2.6.0" = fetchurl {
+    url = "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz";
+    hash = "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==";
+  };
   "mime@3.0.0" = fetchurl {
     url = "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz";
     hash = "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==";
+  };
+  "mime@4.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz";
+    hash = "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==";
+  };
+  "mimic-response@1.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz";
+    hash = "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==";
+  };
+  "mimic-response@3.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz";
+    hash = "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==";
   };
   "miniflare@3.20250718.3" = fetchurl {
     url = "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz";
@@ -2384,6 +3197,38 @@
   "miniflare@4.20260526.0" = fetchurl {
     url = "https://registry.npmjs.org/miniflare/-/miniflare-4.20260526.0.tgz";
     hash = "sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA==";
+  };
+  "minimatch@10.2.5" = fetchurl {
+    url = "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz";
+    hash = "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==";
+  };
+  "minimatch@3.1.5" = fetchurl {
+    url = "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz";
+    hash = "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==";
+  };
+  "minimatch@5.1.9" = fetchurl {
+    url = "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz";
+    hash = "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==";
+  };
+  "minimatch@9.0.9" = fetchurl {
+    url = "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz";
+    hash = "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==";
+  };
+  "minimist@1.2.8" = fetchurl {
+    url = "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz";
+    hash = "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==";
+  };
+  "minipass@7.1.3" = fetchurl {
+    url = "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz";
+    hash = "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==";
+  };
+  "minizlib@3.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz";
+    hash = "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==";
+  };
+  "mkdirp@0.5.6" = fetchurl {
+    url = "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz";
+    hash = "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==";
   };
   "mri@1.2.0" = fetchurl {
     url = "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz";
@@ -2425,6 +3270,14 @@
     url = "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz";
     hash = "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==";
   };
+  "node-abi@4.31.0" = fetchurl {
+    url = "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz";
+    hash = "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==";
+  };
+  "node-addon-api@1.7.2" = fetchurl {
+    url = "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz";
+    hash = "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==";
+  };
   "node-addon-api@6.1.0" = fetchurl {
     url = "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz";
     hash = "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==";
@@ -2433,9 +3286,17 @@
     url = "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz";
     hash = "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==";
   };
+  "node-api-version@0.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz";
+    hash = "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==";
+  };
   "node-gyp-build-optional-packages@5.2.2" = fetchurl {
     url = "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz";
     hash = "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==";
+  };
+  "node-gyp@12.4.0" = fetchurl {
+    url = "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz";
+    hash = "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==";
   };
   "node-pty@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz";
@@ -2445,9 +3306,17 @@
     url = "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz";
     hash = "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==";
   };
+  "nopt@9.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz";
+    hash = "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==";
+  };
   "normalize-path@3.0.0" = fetchurl {
     url = "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz";
     hash = "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==";
+  };
+  "normalize-url@6.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz";
+    hash = "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==";
   };
   "object-assign@4.1.1" = fetchurl {
     url = "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz";
@@ -2456,6 +3325,14 @@
   "object-inspect@1.13.4" = fetchurl {
     url = "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz";
     hash = "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==";
+  };
+  "object-keys@1.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz";
+    hash = "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==";
+  };
+  "obug@2.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz";
+    hash = "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==";
   };
   "ohash@2.0.11" = fetchurl {
     url = "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz";
@@ -2481,6 +3358,14 @@
     url = "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.6.1.tgz";
     hash = "sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w==";
   };
+  "p-cancelable@2.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz";
+    hash = "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==";
+  };
+  "p-limit@3.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz";
+    hash = "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==";
+  };
   "p-limit@6.2.0" = fetchurl {
     url = "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz";
     hash = "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==";
@@ -2500,6 +3385,10 @@
   "parseurl@1.3.3" = fetchurl {
     url = "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz";
     hash = "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==";
+  };
+  "path-is-absolute@1.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
+    hash = "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==";
   };
   "path-key@3.1.1" = fetchurl {
     url = "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz";
@@ -2521,6 +3410,14 @@
     url = "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz";
     hash = "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==";
   };
+  "pe-library@0.4.1" = fetchurl {
+    url = "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz";
+    hash = "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==";
+  };
+  "pend@1.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz";
+    hash = "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==";
+  };
   "picocolors@1.1.1" = fetchurl {
     url = "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz";
     hash = "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==";
@@ -2537,6 +3434,10 @@
     url = "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz";
     hash = "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==";
   };
+  "plist@3.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz";
+    hash = "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==";
+  };
   "pluralize@8.0.0" = fetchurl {
     url = "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz";
     hash = "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==";
@@ -2544,6 +3445,10 @@
   "postcss@8.5.14" = fetchurl {
     url = "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz";
     hash = "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==";
+  };
+  "postject@1.0.0-alpha.6" = fetchurl {
+    url = "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz";
+    hash = "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==";
   };
   "prettier@3.8.3" = fetchurl {
     url = "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz";
@@ -2553,6 +3458,22 @@
     url = "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz";
     hash = "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==";
   };
+  "proc-log@6.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz";
+    hash = "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==";
+  };
+  "progress@2.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz";
+    hash = "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==";
+  };
+  "promise-retry@2.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz";
+    hash = "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==";
+  };
+  "proper-lockfile@4.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz";
+    hash = "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==";
+  };
   "property-information@7.1.0" = fetchurl {
     url = "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz";
     hash = "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==";
@@ -2561,6 +3482,14 @@
     url = "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz";
     hash = "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==";
   };
+  "pump@3.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz";
+    hash = "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==";
+  };
+  "punycode@2.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz";
+    hash = "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==";
+  };
   "pure-rand@8.4.0" = fetchurl {
     url = "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz";
     hash = "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==";
@@ -2568,6 +3497,14 @@
   "qs@6.15.2" = fetchurl {
     url = "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz";
     hash = "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==";
+  };
+  "quansync@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz";
+    hash = "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==";
+  };
+  "quick-lru@5.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz";
+    hash = "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==";
   };
   "range-parser@1.2.1" = fetchurl {
     url = "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz";
@@ -2592,6 +3529,10 @@
   "react@19.2.6" = fetchurl {
     url = "https://registry.npmjs.org/react/-/react-19.2.6.tgz";
     hash = "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==";
+  };
+  "read-binary-file-arch@1.0.6" = fetchurl {
+    url = "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz";
+    hash = "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==";
   };
   "readdirp@3.6.0" = fetchurl {
     url = "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz";
@@ -2620,6 +3561,14 @@
   "recma-stringify@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz";
     hash = "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==";
+  };
+  "redis-errors@1.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz";
+    hash = "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==";
+  };
+  "redis-parser@3.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz";
+    hash = "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==";
   };
   "regex-recursion@6.0.2" = fetchurl {
     url = "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz";
@@ -2681,21 +3630,65 @@
     url = "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz";
     hash = "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==";
   };
+  "require-directory@2.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz";
+    hash = "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==";
+  };
   "require-from-string@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz";
     hash = "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==";
+  };
+  "resedit@1.7.2" = fetchurl {
+    url = "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz";
+    hash = "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==";
+  };
+  "resolve-alpn@1.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz";
+    hash = "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==";
+  };
+  "resolve-pkg-maps@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz";
+    hash = "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==";
   };
   "resolve@1.22.12" = fetchurl {
     url = "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz";
     hash = "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==";
   };
+  "responselike@2.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz";
+    hash = "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==";
+  };
+  "retry@0.12.0" = fetchurl {
+    url = "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz";
+    hash = "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==";
+  };
   "reusify@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz";
     hash = "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==";
   };
+  "rimraf@2.6.3" = fetchurl {
+    url = "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz";
+    hash = "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==";
+  };
+  "roarr@2.15.4" = fetchurl {
+    url = "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz";
+    hash = "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==";
+  };
+  "rolldown-plugin-dts@0.22.5" = fetchurl {
+    url = "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.22.5.tgz";
+    hash = "sha512-M/HXfM4cboo+jONx9Z0X+CUf3B5tCi7ni+kR5fUW50Fp9AlZk0oVLesibGWgCXDKFp5lpgQ9yhKoImUFjl3VZw==";
+  };
   "rolldown@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz";
     hash = "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==";
+  };
+  "rolldown@1.0.0-rc.17" = fetchurl {
+    url = "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz";
+    hash = "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==";
+  };
+  "rolldown@1.0.0-rc.3" = fetchurl {
+    url = "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.3.tgz";
+    hash = "sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw==";
   };
   "rollup-plugin-inject@3.0.2" = fetchurl {
     url = "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz";
@@ -2741,6 +3734,14 @@
     url = "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz";
     hash = "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==";
   };
+  "sanitize-filename@1.6.4" = fetchurl {
+    url = "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz";
+    hash = "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==";
+  };
+  "sax@1.6.0" = fetchurl {
+    url = "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz";
+    hash = "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==";
+  };
   "scheduler@0.27.0" = fetchurl {
     url = "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz";
     hash = "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==";
@@ -2749,9 +3750,21 @@
     url = "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz";
     hash = "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==";
   };
+  "semver-compare@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz";
+    hash = "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==";
+  };
+  "semver@5.7.2" = fetchurl {
+    url = "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz";
+    hash = "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==";
+  };
   "semver@6.3.1" = fetchurl {
     url = "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz";
     hash = "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==";
+  };
+  "semver@7.7.4" = fetchurl {
+    url = "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz";
+    hash = "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==";
   };
   "semver@7.8.1" = fetchurl {
     url = "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz";
@@ -2760,6 +3773,10 @@
   "send@1.2.1" = fetchurl {
     url = "https://registry.npmjs.org/send/-/send-1.2.1.tgz";
     hash = "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==";
+  };
+  "serialize-error@7.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz";
+    hash = "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==";
   };
   "serialize-javascript@7.0.5" = fetchurl {
     url = "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz";
@@ -2821,9 +3838,25 @@
     url = "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz";
     hash = "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==";
   };
+  "signal-exit@3.0.7" = fetchurl {
+    url = "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz";
+    hash = "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==";
+  };
   "simple-swizzle@0.2.4" = fetchurl {
     url = "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz";
     hash = "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==";
+  };
+  "simple-update-notifier@2.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz";
+    hash = "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==";
+  };
+  "slice-ansi@3.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz";
+    hash = "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==";
+  };
+  "smart-buffer@4.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz";
+    hash = "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==";
   };
   "smol-toml@1.6.1" = fetchurl {
     url = "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz";
@@ -2836,6 +3869,10 @@
   "source-map-js@1.2.1" = fetchurl {
     url = "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz";
     hash = "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==";
+  };
+  "source-map-support@0.5.21" = fetchurl {
+    url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz";
+    hash = "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==";
   };
   "source-map@0.6.1" = fetchurl {
     url = "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz";
@@ -2857,6 +3894,10 @@
     url = "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz";
     hash = "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==";
   };
+  "sprintf-js@1.1.3" = fetchurl {
+    url = "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz";
+    hash = "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==";
+  };
   "srvx@0.11.16" = fetchurl {
     url = "https://registry.npmjs.org/srvx/-/srvx-0.11.16.tgz";
     hash = "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==";
@@ -2864,6 +3905,14 @@
   "stacktracey@2.2.0" = fetchurl {
     url = "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz";
     hash = "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==";
+  };
+  "standard-as-callback@2.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz";
+    hash = "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==";
+  };
+  "stat-mode@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz";
+    hash = "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==";
   };
   "statuses@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz";
@@ -2873,6 +3922,10 @@
     url = "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz";
     hash = "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==";
   };
+  "string-width@4.2.3" = fetchurl {
+    url = "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz";
+    hash = "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==";
+  };
   "string-width@7.2.0" = fetchurl {
     url = "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz";
     hash = "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==";
@@ -2880,6 +3933,10 @@
   "stringify-entities@4.0.4" = fetchurl {
     url = "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz";
     hash = "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==";
+  };
+  "strip-ansi@6.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz";
+    hash = "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==";
   };
   "strip-ansi@7.1.2" = fetchurl {
     url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz";
@@ -2897,9 +3954,17 @@
     url = "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz";
     hash = "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==";
   };
+  "sumchecker@3.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz";
+    hash = "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==";
+  };
   "supports-color@10.2.2" = fetchurl {
     url = "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz";
     hash = "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==";
+  };
+  "supports-color@7.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz";
+    hash = "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==";
   };
   "supports-preserve-symlinks-flag@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz";
@@ -2917,9 +3982,41 @@
     url = "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz";
     hash = "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==";
   };
+  "tar@7.5.16" = fetchurl {
+    url = "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz";
+    hash = "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==";
+  };
+  "temp-file@3.4.0" = fetchurl {
+    url = "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz";
+    hash = "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==";
+  };
+  "temp@0.9.4" = fetchurl {
+    url = "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz";
+    hash = "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==";
+  };
+  "tiny-async-pool@1.3.0" = fetchurl {
+    url = "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz";
+    hash = "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==";
+  };
+  "tiny-typed-emitter@2.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz";
+    hash = "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==";
+  };
+  "tinyexec@1.2.4" = fetchurl {
+    url = "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz";
+    hash = "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==";
+  };
   "tinyglobby@0.2.16" = fetchurl {
     url = "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz";
     hash = "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==";
+  };
+  "tmp-promise@3.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz";
+    hash = "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==";
+  };
+  "tmp@0.2.7" = fetchurl {
+    url = "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz";
+    hash = "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==";
   };
   "to-regex-range@5.0.1" = fetchurl {
     url = "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz";
@@ -2937,6 +4034,10 @@
     url = "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz";
     hash = "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==";
   };
+  "tree-kill@1.2.2" = fetchurl {
+    url = "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz";
+    hash = "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==";
+  };
   "trim-lines@3.0.1" = fetchurl {
     url = "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz";
     hash = "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==";
@@ -2945,6 +4046,14 @@
     url = "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz";
     hash = "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==";
   };
+  "truncate-utf8-bytes@1.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz";
+    hash = "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==";
+  };
+  "tsdown@0.20.3" = fetchurl {
+    url = "https://registry.npmjs.org/tsdown/-/tsdown-0.20.3.tgz";
+    hash = "sha512-qWOUXSbe4jN8JZEgrkc/uhJpC8VN2QpNu3eZkBWwNuTEjc/Ik1kcc54ycfcQ5QPRHeu9OQXaLfCI3o7pEJgB2w==";
+  };
   "tslib@2.8.1" = fetchurl {
     url = "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz";
     hash = "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==";
@@ -2952,6 +4061,10 @@
   "turbo@2.9.16" = fetchurl {
     url = "https://registry.npmjs.org/turbo/-/turbo-2.9.16.tgz";
     hash = "sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==";
+  };
+  "type-fest@0.13.1" = fetchurl {
+    url = "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz";
+    hash = "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==";
   };
   "type-is@2.1.0" = fetchurl {
     url = "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz";
@@ -2965,6 +4078,14 @@
     url = "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz";
     hash = "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==";
   };
+  "unconfig-core@7.5.0" = fetchurl {
+    url = "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz";
+    hash = "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==";
+  };
+  "undici-types@7.18.2" = fetchurl {
+    url = "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz";
+    hash = "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==";
+  };
   "undici-types@7.19.2" = fetchurl {
     url = "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz";
     hash = "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==";
@@ -2973,9 +4094,17 @@
     url = "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz";
     hash = "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==";
   };
+  "undici@6.26.0" = fetchurl {
+    url = "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz";
+    hash = "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==";
+  };
   "undici@7.24.8" = fetchurl {
     url = "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz";
     hash = "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==";
+  };
+  "undici@8.4.0" = fetchurl {
+    url = "https://registry.npmjs.org/undici/-/undici-8.4.0.tgz";
+    hash = "sha512-tDR4LgFBeV7YBWOFMlmbhtrnFVWuZ6HKbkG+88/csQdhK2tPlW78PnLI2VRjIQtTlslvgSZ4R43WBE+4g6rhng==";
   };
   "unenv@2.0.0-rc.14" = fetchurl {
     url = "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz";
@@ -3013,6 +4142,14 @@
     url = "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz";
     hash = "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==";
   };
+  "universalify@0.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz";
+    hash = "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==";
+  };
+  "universalify@2.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz";
+    hash = "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==";
+  };
   "unpipe@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz";
     hash = "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==";
@@ -3021,13 +4158,25 @@
     url = "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz";
     hash = "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==";
   };
+  "unrun@0.2.39" = fetchurl {
+    url = "https://registry.npmjs.org/unrun/-/unrun-0.2.39.tgz";
+    hash = "sha512-h9FxYVpztY/wwq+bauLOh6Y3CWu2IVeRLq5lxzneBiIU9Tn86OGp9xiQrGhnYspAmg5dzdY0Cc8+Y70kuTARCg==";
+  };
   "update-browserslist-db@1.2.3" = fetchurl {
     url = "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz";
     hash = "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==";
   };
+  "uri-js@4.4.1" = fetchurl {
+    url = "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz";
+    hash = "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==";
+  };
   "use-sync-external-store@1.6.0" = fetchurl {
     url = "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz";
     hash = "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==";
+  };
+  "utf8-byte-length@1.0.5" = fetchurl {
+    url = "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz";
+    hash = "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==";
   };
   "uuid@14.0.0" = fetchurl {
     url = "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz";
@@ -3044,6 +4193,10 @@
   "vary@1.1.2" = fetchurl {
     url = "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz";
     hash = "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==";
+  };
+  "verror@1.10.1" = fetchurl {
+    url = "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz";
+    hash = "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==";
   };
   "vfile-location@5.0.3" = fetchurl {
     url = "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz";
@@ -3085,6 +4238,14 @@
     url = "https://registry.npmjs.org/which/-/which-2.0.2.tgz";
     hash = "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==";
   };
+  "which@5.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/which/-/which-5.0.0.tgz";
+    hash = "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==";
+  };
+  "which@6.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/which/-/which-6.0.1.tgz";
+    hash = "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==";
+  };
   "workerd@1.20250718.0" = fetchurl {
     url = "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz";
     hash = "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==";
@@ -3100,6 +4261,10 @@
   "wrangler@4.95.0" = fetchurl {
     url = "https://registry.npmjs.org/wrangler/-/wrangler-4.95.0.tgz";
     hash = "sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg==";
+  };
+  "wrap-ansi@7.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz";
+    hash = "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==";
   };
   "wrappy@1.0.2" = fetchurl {
     url = "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz";
@@ -3125,9 +4290,25 @@
     url = "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-4.0.3.tgz";
     hash = "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==";
   };
+  "xmlbuilder@15.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz";
+    hash = "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==";
+  };
+  "y18n@5.0.8" = fetchurl {
+    url = "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz";
+    hash = "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==";
+  };
   "yallist@3.1.1" = fetchurl {
     url = "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz";
     hash = "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==";
+  };
+  "yallist@4.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz";
+    hash = "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==";
+  };
+  "yallist@5.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz";
+    hash = "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==";
   };
   "yaml@2.8.4" = fetchurl {
     url = "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz";
@@ -3136,6 +4317,22 @@
   "yaml@2.9.0" = fetchurl {
     url = "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz";
     hash = "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==";
+  };
+  "yargs-parser@21.1.1" = fetchurl {
+    url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz";
+    hash = "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==";
+  };
+  "yargs@17.7.2" = fetchurl {
+    url = "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz";
+    hash = "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==";
+  };
+  "yauzl@2.10.0" = fetchurl {
+    url = "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz";
+    hash = "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==";
+  };
+  "yocto-queue@0.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz";
+    hash = "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==";
   };
   "yocto-queue@1.2.2" = fetchurl {
     url = "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz";


### PR DESCRIPTION
**Phases 1–3** of the studio-desktop plan (#139): a standalone macOS Electron app (Effect v4 + `@effect/platform-node`, mirroring `.references/t3code/apps/desktop`) that renders the `@ax/studio` SPA, supervises `surreal` + `ax serve`, and packages with vendored binaries + updater. **Stacked on #143 (Phase 0)** — base `feat/studio-extract`; retarget to `main` after #143 merges.

Built via subagent-driven-development: implementer per task + spec/quality review; every code task gated on typecheck/build/test, every packaging task gated on a real run.

## Phase 1 — Electron shell
`apps/studio-desktop`: tsdown CJS build; foundation (`DesktopState/Environment/Observability`, OTLP dropped); electron layer (`App/Window/Protocol/Menu/Shell`, scheme `ax`, traversal guard); `DesktopLifecycle` + `DesktopWindow` (dev: vite dev-server; prod: `ax://` protocol; window-open deny + external routing); `main.ts` composition + minimal `preload.ts`. **Quality review: approved.**

## Phase 2 — Two-process supervisor (`src/backend/`)
`AxDaemonArbitration` (attach-vs-spawn, total; HTTP/port probes; canonical data dir `$AX_DATA_DIR ?? $HOME/.local/share/ax`); `SupervisedProcess` (spawn + HTTP readiness + crash-restart backoff, Scope/Fiber/Ref/Semaphore); `AxBackendManager` (orders surreal→ax serve, readiness-gated, attach path, reverse teardown, quit finalizer) wired into boot. **16 backend tests pass** (TestClock-driven, stub spawner/HttpClient). **Quality review: approved with fixes applied** (caught + fixed a real readiness-gate bug).

## Phase 3 — Packaging
`fetch-binaries.ts` (vendored surreal 3.1.0 + bun 1.3.13 per-arch, checksum-verified); `stage-ax-source.ts` (runnable ax source + **symlink-free** hoisted node_modules + studio bundle → resources); `electron-builder.config.cjs` + `entitlements.mac.plist` (hardenedRuntime, JIT/lib-validation entitlements for spawned bun+lmdb); `DesktopUpdates` over electron-updater (dev-guarded, non-blocking).

## Verified here (empirically)
- `bun run build` + `bun --filter @ax/studio-desktop typecheck` + root typecheck: clean
- 16 backend tests pass
- `surreal`/`bun` binaries fetched + `--version` confirmed (arm64)
- staged tree runs `ax --help` under bundled bun; **lmdb/durable-streams sidecar round-trip succeeds** → live ingest won't 503
- **unsigned `electron-builder --dir` pack completes through the signing walk** (0 dangling symlinks), `.app` (482M) assembles with `Contents/Resources/{bin,ax-src,studio}`, vendored binaries ad-hoc signable
- `electron-updater` left external in the bundle

## Needs a human / credentials (documented, not faked)
- **GUI/runtime gates (1.6, 2.4):** launch on a Mac → window opens, spawn/attach modes, live ingest, Cmd+Q frees ports.
- **Release:** Apple Developer ID signing + notarization (`APPLE_ID`/`APPLE_APP_SPECIFIC_PASSWORD`/`APPLE_TEAM_ID`/`CSC_LINK`) + `GH_TOKEN` + a tagged release + `electron-builder --publish` (emits `latest-mac.yml` feed). macOS won't apply unsigned updates.
- **Per-arch:** staged node_modules is host-arch-only; x64 artifacts must build on x64.

## Tracked hardening (in-code TODOs)
`will-navigate` guard; `registerFileProtocol`→`protocol.handle`; surreal-crash→ax-serve bounce; attach→spawn live transition; `conflict` dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)