### PR TITLE
feat(share): export subagent transcripts + price Claude sessions (#145)

### DIFF
--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -5028,23 +5028,21 @@ const setupCommand = Command.make(
     "setup",
     {
         agents: Flag.string("agents").pipe(Flag.optional),
-        noIngest: Flag.boolean("no-ingest").pipe(Flag.withDefault(false)),
         yes: Flag.boolean("yes").pipe(Flag.withDefault(false)),
         agentPrompt: Flag.boolean("agent-prompt").pipe(Flag.withDefault(false)),
     },
-    ({ agents, noIngest, yes, agentPrompt }) =>
+    ({ agents, yes, agentPrompt }) =>
         cmdSetup({
             ...(agents._tag === "Some"
                 ? { agents: agents.value.split(",").map((s) => s.trim()).filter(Boolean) }
                 : {}),
-            skipIngest: noIngest,
             yes,
             agentPromptOnly: agentPrompt,
         }),
 ).pipe(
     Command.withDescription(
-        "Install the agent skills, run the first ingest, and verify. " +
-        "--agents=claude-code,codex  --no-ingest  --yes  --agent-prompt (print just the paste-to-agent block)",
+        "Install the agent skills and verify; hands ingest to your agent via the onboarding brief. " +
+        "--agents=claude-code,codex  --yes  --agent-prompt (print just the paste-to-agent block)",
     ),
 );
 

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -95,6 +95,7 @@ import { cmdDaemon, cmdDoctor, cmdInstall, cmdSetup, cmdUninstall } from "./inst
 import { resolvePwdRepository } from "../pwd.ts";
 import { detectStaleness } from "@ax/lib/transcript-staleness";
 import { ingestTranscripts } from "../ingest/transcripts.ts";
+import { estimateIngest, formatDryRun } from "../ingest/dry-run.ts";
 import { encodeClaudeProjectSlug } from "@ax/lib/transcript-locator";
 import {
     createProgressReporter,
@@ -1723,12 +1724,28 @@ const ingestCommand = Command.make(
         deriveOnly: Flag.boolean("derive-only").pipe(Flag.withDefault(false)),
         // Wipe the skill graph before a full re-ingest so it rebuilds clean.
         reset: Flag.boolean("reset").pipe(Flag.withDefault(false)),
+        // Estimate how long a full backfill takes (counts sources + times a
+        // small sample) and exit without running the full ingest.
+        dryRun: Flag.boolean("dry-run").pipe(Flag.withDefault(false)),
+        json: Flag.boolean("json").pipe(Flag.withDefault(false)),
         since: optionalSince,
         progress: progressFlag,
         verbose: verboseFlag,
         debug: debugFlag,
     },
-    ({ insightsOnly, stages, deriveOnly, reset, since, progress, verbose, debug }) => {
+    ({ insightsOnly, stages, deriveOnly, reset, dryRun, json, since, progress, verbose, debug }) => {
+        if (dryRun) {
+            // Same runtime layer (IngestRuntimeLayer via withIngest) provides
+            // estimateIngest's services (AxConfig/FS/Path/SurrealClient); the cast
+            // aligns this branch's requirement set with the other ingest branches
+            // so Command.make infers one handler return type.
+            return Effect.gen(function* () {
+                const result = yield* estimateIngest({
+                    sinceDays: Option.getOrUndefined(since),
+                });
+                console.log(formatDryRun(result, json));
+            }) as ReturnType<typeof cmdIngest>;
+        }
         if (insightsOnly) {
             if (reset) {
                 console.error("axctl ingest: --reset cannot be combined with --insights-only");
@@ -1762,6 +1779,7 @@ const ingestCommand = Command.make(
 ).pipe(
     Command.withDescription(
         "Ingest skills, local agent transcripts, git history, and insight artifacts. " +
+            "Use --dry-run [--json] to estimate how long a full backfill will take (and exit). " +
             "Use --stages=<a,b,c> for a custom subset, or --derive-only to run every stage tagged `derive` " +
             "(see ADR-0009; canonical list lives in src/ingest/stage/registry.ts). " +
             "Use --reset to wipe the skill graph first and rebuild it clean.",

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -5234,11 +5234,11 @@ const withIngest = (args: ReadonlyArray<string>): CliProgram => {
         : mode === "off"
             ? undefined
             : wantPlain
-                ? pipelineTraceTransportLayer("plain")
+                ? pipelineTraceTransportLayer("plain", resolveProgressStages(args))
                 : tuiCapable
                     ? tuiTraceTransportLayer(resolveProgressStages(args))
                     : interactive || force
-                        ? pipelineTraceTransportLayer("plain")
+                        ? pipelineTraceTransportLayer("plain", resolveProgressStages(args))
                         : undefined;
     // The transport must be wired BENEATH TraceSinkLive (via ingestRuntimeLayerWith),
     // not merged on top of the already-built AppLayer - otherwise the sink keeps

--- a/apps/axctl/src/cli/ingest-trace-progress.ts
+++ b/apps/axctl/src/cli/ingest-trace-progress.ts
@@ -40,6 +40,7 @@ const readCountAttribute = (
  */
 export const pipelineTraceTransportLayer = (
     mode: ProgressMode = "pipeline",
+    stages: readonly ProgressStage[] = [],
 ): Layer.Layer<TraceTransportTag> => Layer.sync(
     TraceTransportTag,
     () => {
@@ -58,9 +59,10 @@ export const pipelineTraceTransportLayer = (
                                     command: "ingest",
                                     runId: event.traceId.replace(/^ingest:/, ""),
                                     mode,
-                                    // PipelineProgress/PlainProgress auto-add a row per
-                                    // stage as its span starts, so start empty.
-                                    stages: [],
+                                    // Pass the known stage list so plain-mode [n/N]
+                                    // step indices are stable; PipelineProgress still
+                                    // auto-adds rows as spans start.
+                                    stages,
                                 });
                                 break;
                             }

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -835,8 +835,6 @@ const SETUP_AGENTS: ReadonlyArray<{ id: string; label: string; dir: string }> = 
 export interface SetupOptions {
     /** Explicit agent ids; skips detection/prompt when set. */
     readonly agents?: ReadonlyArray<string>;
-    /** Skip the initial `ax ingest`. */
-    readonly skipIngest?: boolean;
     /** Non-interactive: take detected defaults, no prompts. */
     readonly yes?: boolean;
     /** Internal: invoked from `cmdInstall` (tweaks headers). */
@@ -844,15 +842,6 @@ export interface SetupOptions {
     /** Print ONLY the paste-into-your-agent prompt and exit (for copy / install.sh). */
     readonly agentPromptOnly?: boolean;
 }
-
-/** Resolve the real binary to re-invoke for the first ingest. */
-const selfBin = (): Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =>
-    Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const path = yield* Path.Path;
-        const vendored = path.join(VENDOR_BIN_DIR, "axctl");
-        return (yield* fs.exists(vendored).pipe(orAbsent(false))) ? vendored : process.execPath;
-    });
 
 /** Choose which agents to install skills for. Interactive on a TTY, else the
  *  detected (present-on-disk) set, falling back to claude-code + codex. */
@@ -893,7 +882,7 @@ export function cmdSetup(
             console.log(AGENT_ONBOARDING_PROMPT);
             return;
         }
-        console.log(opts.fromInstall ? "[axctl] setup (skills + first ingest)" : "[axctl] setup");
+        console.log(opts.fromInstall ? "[axctl] setup (skills + onboarding)" : "[axctl] setup");
 
         const agents = yield* resolveSetupAgents(opts);
 
@@ -911,21 +900,22 @@ export function cmdSetup(
             else console.log(`  skills: npx exited ${r.status ?? "?"} (re-run 'ax setup' or the npx command above)`);
         }
 
-        // 2. first ingest so the graph is populated immediately.
-        if (opts.skipIngest) {
-            console.log("  ingest: skipped (--no-ingest)");
-        } else {
-            console.log("  ingest: running initial backfill...");
-            const bin = yield* selfBin();
-            const r = spawnSync(bin, ["ingest"], { stdio: "inherit" });
-            if (r.status !== 0) console.log(`  ingest: exited ${r.status ?? "?"} (run 'ax ingest' manually)`);
-        }
+        // 2. ingest is NOT run here. A full backfill can take minutes; blocking
+        // setup on it makes install feel frozen, and re-running it on every
+        // `ax update` is pure waste (the watcher + daily ETL keep the graph
+        // fresh). The onboarding brief hands ingest to the agent as a narrated
+        // step (dry-run ETA -> background run -> dashboard -> takeaways). Users
+        // without an agent get the explicit next-step below.
+        console.log("  ingest: not run yet (kept out of setup so it never blocks). populate the graph:");
+        console.log("          ax ingest --dry-run   # see how long a full backfill will take");
+        console.log("          ax ingest             # full backfill (watch live in ax serve)");
+        console.log("          ...or the daily 04:00 sync fills it overnight.");
 
         // 3. verify.
         console.log();
         yield* cmdDoctor([]);
 
-        // 4. hand off to the agent for the labeling loop (classify -> fill -> lint).
+        // 4. hand off to the agent for ingest + the labeling loop (classify -> fill -> lint).
         console.log();
         console.log(renderAgentOnboarding());
     });

--- a/apps/axctl/src/cli/progress-tui.tsx
+++ b/apps/axctl/src/cli/progress-tui.tsx
@@ -13,6 +13,7 @@ import { useSyncExternalStore } from "react";
 import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
 import type { ProgressReporter, ProgressStage } from "./progress.ts";
+import { computeStageMetrics } from "./progress.ts";
 
 type Status = "pending" | "running" | "done" | "failed";
 
@@ -219,7 +220,7 @@ function IngestProgressView({ store, command, runId }: ViewProps) {
     const eta = done > 0 && done < total ? formatDuration((elapsed / done) * (total - done)) : "--";
     const labelW = Math.max(12, ...stages.map((s) => stageKey(s).length));
 
-    const headerLine = `axctl ${command}  run=${runId.slice(0, 8)}  elapsed=${formatDuration(elapsed)}  eta=${eta}`;
+    const headerLine = `axctl ${command}  run=${runId.slice(0, 8)}  [${done}/${total}]  elapsed=${formatDuration(elapsed)}  eta=${eta}`;
     const speedLine = `speed ${speed > 0 ? `${formatCount(speed)}/s` : "--"}  current=${currentLabel}`;
     const colHeader = `  ${"stage".padEnd(labelW)}  progress              ${"rows".padStart(8)}  ${"speed".padStart(10)}  ${"time".padStart(7)}`;
 
@@ -276,11 +277,13 @@ function StageRow({ s, labelW, frame, now }: {
         : "--";
     const speedText = speed > 0 ? `${formatCount(speed)}/s` : "--";
     const timeText = s.startedAt ? formatDuration(elapsed) : "--";
+    const etaLeftMs = s.status === "running" ? computeStageMetrics(s.counts, elapsed).etaLeftMs : undefined;
+    const etaText = etaLeftMs !== undefined ? `  ~${formatDuration(etaLeftMs)} left` : "";
     const color = s.status === "done" ? "#9ece6a"
         : s.status === "failed" ? "#f7768e"
         : s.status === "running" ? "#7dcfff"
         : "#414868";
-    const line = `${icon} ${label}  ${bar}  ${rowText.padStart(8)}  ${speedText.padStart(10)}  ${timeText.padStart(7)}${s.error ? `  ${s.error}` : ""}`;
+    const line = `${icon} ${label}  ${bar}  ${rowText.padStart(8)}  ${speedText.padStart(10)}  ${timeText.padStart(7)}${s.error ? `  ${s.error}` : etaText}`;
     return (
         <box style={{ height: 1, flexShrink: 0 }}>
             <text fg={color}>{line}</text>

--- a/apps/axctl/src/cli/progress.test.ts
+++ b/apps/axctl/src/cli/progress.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createProgressReporter, parseProgressMode, type ProgressSink } from "./progress.ts";
+import { computeStageMetrics, createProgressReporter, parseProgressMode, type ProgressSink } from "./progress.ts";
 
 function memorySink(isTTY = false, columns = 120): ProgressSink & { chunks: string[] } {
     const chunks: string[] = [];
@@ -38,6 +38,75 @@ describe("cli progress", () => {
 
         expect(sink.chunks.join("")).toContain("[axctl] skills/upsert started");
         expect(sink.chunks.join("")).toContain("skills=205");
+    });
+
+    test("computeStageMetrics derives it/s, ratio, and eta-left", () => {
+        // 50/200 files in 5s => 10 it/s; 150 left => 15s.
+        const m = computeStageMetrics(
+            { currentFile: 50, totalFiles: 200, records: 1000 },
+            5000,
+        );
+        expect(m.current).toBe(50);
+        expect(m.total).toBe(200);
+        expect(m.ratio).toBeCloseTo(0.25, 5);
+        expect(m.itemsPerSec).toBeCloseTo(10, 5);
+        expect(m.etaLeftMs).toBeCloseTo(15000, 0);
+        expect(m.rowsPerSec).toBeCloseTo(200, 5);
+    });
+
+    test("computeStageMetrics suppresses rates for sub-100ms elapsed", () => {
+        const m = computeStageMetrics({ currentFile: 5, totalFiles: 200 }, 1);
+        expect(m.itemsPerSec).toBe(0);
+        expect(m.etaLeftMs).toBeUndefined();
+    });
+
+    test("plain mode emits live [n/N] progress lines with it/s and eta-left", () => {
+        const sink = memorySink();
+        let now = 1_000;
+        const progress = createProgressReporter({
+            command: "ingest",
+            mode: "plain",
+            runId: "abc123",
+            stages: [
+                { source: "claude", stage: "transcripts" },
+                { source: "codex", stage: "sessions" },
+            ],
+            sink,
+            now: () => now,
+        });
+
+        progress.start({ source: "claude", stage: "transcripts" });
+        now = 6_000; // 5s elapsed
+        progress.update({ source: "claude", stage: "transcripts" }, {
+            currentFile: 50,
+            totalFiles: 200,
+            records: 1000,
+        });
+        progress.stop();
+
+        const out = sink.chunks.join("");
+        expect(out).toContain("[1/2] claude/transcripts  50/200");
+        expect(out).toContain("it/s");
+        expect(out).toContain("25%");
+        expect(out).toContain("left");
+    });
+
+    test("plain mode stays quiet on total-less discovery ticks", () => {
+        const sink = memorySink();
+        const progress = createProgressReporter({
+            command: "ingest",
+            mode: "plain",
+            runId: "abc123",
+            stages: [{ source: "signals", stage: "derive" }],
+            sink,
+            now: () => 1_000,
+        });
+        progress.start({ source: "signals", stage: "derive" });
+        progress.update({ source: "signals", stage: "derive" }, { signals: 12 }); // no current/total
+        progress.stop();
+        const out = sink.chunks.join("");
+        expect(out).toContain("signals/derive started");
+        expect(out).not.toContain("[1/1]"); // no live line without a determinate total
     });
 
     test("json mode emits structured progress events", () => {

--- a/apps/axctl/src/cli/progress.ts
+++ b/apps/axctl/src/cli/progress.ts
@@ -141,6 +141,44 @@ function totalRows(counts: Record<string, number>): number {
     return 0;
 }
 
+const firstFinite = (...values: Array<number | undefined>): number | undefined => {
+    for (const v of values) if (typeof v === "number" && Number.isFinite(v)) return v;
+    return undefined;
+};
+
+/** Per-stage live metrics shared by every renderer (plain log, pipeline board,
+ *  TUI, dashboard) so the Paxel-style line is identical everywhere. `current`/
+ *  `total` come from the `currentFile`/`totalFiles` (or subagent) convention
+ *  keys; `itemsPerSec` is item throughput (files/s, what Paxel shows); `rowsPerSec`
+ *  is record throughput; `etaLeftMs` projects the remaining items at the current
+ *  item rate. Sub-100ms elapsed suppresses rates to avoid noise-inflated speeds. */
+export interface StageMetrics {
+    readonly current: number | undefined;
+    readonly total: number | undefined;
+    readonly ratio: number | undefined;
+    readonly rows: number;
+    readonly itemsPerSec: number;
+    readonly rowsPerSec: number;
+    readonly etaLeftMs: number | undefined;
+}
+
+export function computeStageMetrics(counts: Record<string, number>, elapsedMs: number): StageMetrics {
+    const current = firstFinite(counts.currentFile, counts.currentSubagent);
+    const total = firstFinite(counts.totalFiles, counts.totalSubagents);
+    const ratio = current !== undefined && total !== undefined && total > 0
+        ? Math.min(1, current / total)
+        : undefined;
+    const rows = totalRows(counts);
+    const secs = elapsedMs / 1000;
+    const measurable = elapsedMs >= minSpeedElapsedMs && secs > 0;
+    const itemsPerSec = measurable && current !== undefined && current > 0 ? current / secs : 0;
+    const rowsPerSec = measurable && rows > 0 ? rows / secs : 0;
+    const etaLeftMs = itemsPerSec > 0 && total !== undefined && current !== undefined && total > current
+        ? ((total - current) / itemsPerSec) * 1000
+        : undefined;
+    return { current, total, ratio, rows, itemsPerSec, rowsPerSec, etaLeftMs };
+}
+
 function summarizeCounts(counts: Record<string, number>): string {
     const phase = typeof counts.phase === "number"
         ? counts.phase === 1 ? "reading" : counts.phase === 2 ? "writing" : counts.phase === 3 ? "snapshotting" : "working"
@@ -242,13 +280,50 @@ class JsonProgress implements ProgressReporter {
 class PlainProgress implements ProgressReporter {
     readonly live = false;
 
-    constructor(private readonly sink: ProgressSink, private readonly now: () => number) {}
+    // Per-stage start time + ordered keys so update() lines carry a [n/N] step
+    // index and an item rate. `lastLine` de-dupes identical consecutive lines so
+    // an agent tailing the log isn't flooded when counts haven't changed.
+    private readonly startedAt = new Map<string, number>();
+    private readonly order: string[] = [];
+    private readonly lastLine = new Map<string, string>();
 
-    start(stage: ProgressStage): void {
-        this.sink.write(`[axctl] ${stageKey(stage)} started\n`);
+    constructor(
+        private readonly sink: ProgressSink,
+        private readonly now: () => number,
+        private readonly stageCount = 0,
+    ) {}
+
+    private track(key: string): void {
+        if (!this.startedAt.has(key)) {
+            this.startedAt.set(key, this.now());
+            this.order.push(key);
+        }
     }
 
-    update(): void {}
+    start(stage: ProgressStage): void {
+        const key = stageKey(stage);
+        this.track(key);
+        this.sink.write(`[axctl] ${key} started\n`);
+    }
+
+    update(stage: ProgressStage, counts: Record<string, number>): void {
+        const key = stageKey(stage);
+        this.track(key);
+        const m = computeStageMetrics(counts, this.now() - (this.startedAt.get(key) ?? this.now()));
+        // Only emit a live line once we have a determinate current/total; pure
+        // discovery ticks (totals only) and total-less stages stay quiet here and
+        // surface their result on finish().
+        if (m.current === undefined || m.total === undefined) return;
+        const idx = this.order.indexOf(key) + 1;
+        const n = Math.max(this.stageCount, this.order.length);
+        const pct = m.ratio !== undefined ? `  ${Math.round(m.ratio * 100)}%` : "";
+        const rate = m.itemsPerSec > 0 ? `  ${m.itemsPerSec.toFixed(1)} it/s` : "";
+        const eta = m.etaLeftMs !== undefined ? `  ~${formatDuration(m.etaLeftMs)} left` : "";
+        const line = `[axctl] [${idx}/${n}] ${key}  ${formatCount(m.current)}/${formatCount(m.total)}${rate}${pct}${eta}`;
+        if (this.lastLine.get(key) === line) return;
+        this.lastLine.set(key, line);
+        this.sink.write(line + "\n");
+    }
 
     finish(stage: ProgressStage, counts: Record<string, number>): void {
         const summary = summarizeCounts(counts);
@@ -372,7 +447,7 @@ class PipelineProgress implements ProgressReporter {
         const labelW = this.labelWidth();
         const header = `  ${"stage".padEnd(labelW)}  progress              ${"rows".padStart(8)}  ${"speed".padStart(10)}  ${"time".padStart(7)}`;
         const rows = [
-            `axctl ${this.options.command}  run=${this.options.runId.slice(0, 8)}  elapsed=${formatDuration(elapsed)}  eta=${eta}`,
+            `axctl ${this.options.command}  run=${this.options.runId.slice(0, 8)}  [${done}/${total}]  elapsed=${formatDuration(elapsed)}  eta=${eta}`,
             `speed ${speed > 0 ? `${formatCount(speed)}/s` : "--"}  current=${currentLabel}`,
             "",
             header,
@@ -416,7 +491,11 @@ class PipelineProgress implements ProgressReporter {
                 : "--";
         const speedText = speed > 0 ? `${formatCount(speed)}/s` : "--";
         const timeText = state.startedAt ? formatDuration(elapsed) : "--";
-        const suffix = state.error ? `  ${state.error}` : "";
+        const etaLeftMs = state.status === "running"
+            ? computeStageMetrics(state.counts, elapsed).etaLeftMs
+            : undefined;
+        const etaText = etaLeftMs !== undefined ? `  ~${formatDuration(etaLeftMs)} left` : "";
+        const suffix = state.error ? `  ${state.error}` : etaText;
         return `${icon} ${label}  ${bar}  ${rowText.padStart(8)}  ${speedText.padStart(10)}  ${timeText.padStart(7)}${suffix}`;
     }
 
@@ -446,7 +525,7 @@ export function createProgressReporter(options: ProgressOptions): ProgressReport
     };
     if (options.mode === "off") return new NoopProgress();
     if (options.mode === "json") return new JsonProgress({ ...base, sink });
-    if (options.mode === "plain") return new PlainProgress(sink, now);
+    if (options.mode === "plain") return new PlainProgress(sink, now, options.stages.length);
     if (shouldUsePipeline(options.mode, sink, env)) {
         return new PipelineProgress({
             ...base,
@@ -455,5 +534,5 @@ export function createProgressReporter(options: ProgressOptions): ProgressReport
         }, options.stages);
     }
     if (options.mode === "auto") return new JsonProgress({ ...base, sink });
-    return new PlainProgress(sink, now);
+    return new PlainProgress(sink, now, options.stages.length);
 }

--- a/apps/axctl/src/dashboard/ingest-workflow.ts
+++ b/apps/axctl/src/dashboard/ingest-workflow.ts
@@ -54,12 +54,17 @@ interface TerminalState {
 
 /** A live-trace transport that forwards ingest spans to the stream bus. */
 function busTransportLayer(bus: IngestStreamBus, state: TerminalState): Layer.Layer<TraceTransportTag> {
-    const spanNames = new Map<string, string>();
+    const ctx = {
+        spanNames: new Map<string, string>(),
+        spanStartedAt: new Map<string, number>(),
+        spanCounts: new Map<string, Record<string, number>>(),
+        index: { started: 0 },
+    };
     const transport: TraceTransport = {
         send: (events) =>
             Effect.promise(async () => {
                 for (const event of events) {
-                    const mapped = ingestStreamEventFromTrace(event, { spanNames });
+                    const mapped = ingestStreamEventFromTrace(event, ctx);
                     if (mapped) {
                         if (mapped.kind === "run_finished") state.finished = true;
                         await bus.publish(mapped.runId, mapped);

--- a/apps/axctl/src/dashboard/web/src/routes/ingest-live.tsx
+++ b/apps/axctl/src/dashboard/web/src/routes/ingest-live.tsx
@@ -167,16 +167,37 @@ function StageChecklist({ run }: { run: ReturnType<typeof useIngestStream> }) {
         <ul className="ingest-stages">
             {run.order.map((stage) => {
                 const status = run.stages[stage] ?? "running";
+                const p = run.progress[stage];
+                const pct = p && p.total > 0 ? Math.min(100, Math.round((p.current / p.total) * 100)) : null;
                 return (
                     <li key={stage} className={`ingest-stage ${status}`}>
                         <span className="ingest-stage-glyph">{STAGE_GLYPH[status]}</span>
                         <span className="ingest-stage-name">{stage}</span>
-                        <span className="ingest-stage-status">{status}</span>
+                        {status === "running" && p && pct !== null ? (
+                            <span className="ingest-stage-bar" aria-label={`${pct}%`}>
+                                <span className="ingest-stage-bar-fill" style={{ width: `${pct}%` }} />
+                            </span>
+                        ) : null}
+                        <span className="ingest-stage-status">
+                            {status === "running" && p && pct !== null
+                                ? `${p.current.toLocaleString()}/${p.total.toLocaleString()} · ${pct}%${
+                                    p.ratePerSec > 0 ? ` · ${p.ratePerSec.toFixed(1)}/s` : ""
+                                }${p.etaLeftMs !== null ? ` · ~${formatEtaLeft(p.etaLeftMs)} left` : ""}`
+                                : status}
+                        </span>
                     </li>
                 );
             })}
         </ul>
     );
+}
+
+/** Compact remaining-time label for the live progress bar ("3m30s", "45s"). */
+function formatEtaLeft(ms: number): string {
+    const s = Math.max(0, Math.round(ms / 1000));
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    return `${m}m${(s % 60).toString().padStart(2, "0")}s`;
 }
 
 /** Count tiles reusing the same React Query keys the live SSE hook invalidates,

--- a/apps/axctl/src/dashboard/web/src/styles.css
+++ b/apps/axctl/src/dashboard/web/src/styles.css
@@ -1790,9 +1790,25 @@ td.skill-cell .description {
 
 .ingest-stage-status {
     font-size: 11px;
-    text-transform: uppercase;
     letter-spacing: 0.05em;
     color: var(--muted);
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.ingest-stage-bar {
+    flex: 0 0 120px;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--border, #30363d);
+    overflow: hidden;
+}
+
+.ingest-stage-bar-fill {
+    display: block;
+    height: 100%;
+    background: #2ea043;
+    transition: width 0.2s ease-out;
 }
 
 .ingest-stage.ok .ingest-stage-glyph {

--- a/apps/axctl/src/dashboard/web/src/use-ingest-stream.ts
+++ b/apps/axctl/src/dashboard/web/src/use-ingest-stream.ts
@@ -21,8 +21,18 @@ import type { IngestStreamEvent } from "../../../ingest/stream-events.ts";
 export type StageStatus = "running" | "ok" | "error";
 export type RunStatus = "running" | "completed" | "failed";
 
+/** Live per-stage metering folded from `stage_progress` events. */
+export interface StageProgress {
+    readonly current: number;
+    readonly total: number;
+    readonly ratePerSec: number;
+    readonly etaLeftMs: number | null;
+}
+
 export interface IngestStreamState {
     readonly stages: Record<string, StageStatus>;
+    /** Per-stage live progress (current/total/rate/eta), keyed by stage name. */
+    readonly progress: Record<string, StageProgress>;
     readonly order: ReadonlyArray<string>;
     readonly finished: boolean;
     readonly runStatus: RunStatus;
@@ -36,6 +46,7 @@ export interface IngestStreamState {
 
 const IDLE: IngestStreamState = {
     stages: {},
+    progress: {},
     order: [],
     finished: false,
     runStatus: "running",
@@ -61,6 +72,26 @@ function applyEvent(state: IngestStreamState, event: IngestStreamEvent): IngestS
             return {
                 ...state,
                 stages: { ...state.stages, [event.stage]: "running" },
+                order: known ? state.order : [...state.order, event.stage],
+            };
+        }
+        case "stage_progress": {
+            const known = event.stage in state.stages;
+            const current = state.stages[event.stage];
+            // Don't resurrect a finished stage's bar on replay.
+            if (current === "ok" || current === "error") return state;
+            return {
+                ...state,
+                stages: { ...state.stages, [event.stage]: "running" },
+                progress: {
+                    ...state.progress,
+                    [event.stage]: {
+                        current: event.current,
+                        total: event.total,
+                        ratePerSec: event.ratePerSec,
+                        etaLeftMs: event.etaLeftMs,
+                    },
+                },
                 order: known ? state.order : [...state.order, event.stage],
             };
         }

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1443,9 +1443,12 @@ const queryCodexStatements = (statements: readonly string[]) =>
 interface CodexIngestOpts {
     sinceDays: number | undefined;
     onProgress: (counts: Record<string, number>) => Effect.Effect<void>;
-    /** Cap the number of session files processed. Used by `ingest --dry-run` to
-     *  time a small representative slice for ETA calibration. */
+    /** Hard cap on session files processed - a backstop for `ingest --dry-run`
+     *  calibration (paired with `deadlineMs`). */
     limit: number | undefined;
+    /** Absolute wall-clock deadline (ms epoch). Once reached, no NEW file is
+     *  started; in-flight files finish. Lets `--dry-run` time-box calibration. */
+    deadlineMs: number | undefined;
 }
 
 export interface CodexStats {
@@ -1491,6 +1494,11 @@ export const ingestCodex = (
         const recordCount = () => turnCount + invCount + toolCallCount + planSnapshotCount;
 
         yield* Effect.forEach(files.map((file, index) => ({ file, index })), ({ file, index }) => Effect.gen(function* () {
+            // Time-box (dry-run calibration): once the deadline passes, start no
+            // new files; in-flight ones finish.
+            if (opts.deadlineMs !== undefined && Date.now() >= opts.deadlineMs) {
+                return;
+            }
             activeFiles += 1;
             if (opts.onProgress && (index < 5 || index % 10 === 0)) {
                 yield* opts.onProgress({

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1443,6 +1443,9 @@ const queryCodexStatements = (statements: readonly string[]) =>
 interface CodexIngestOpts {
     sinceDays: number | undefined;
     onProgress: (counts: Record<string, number>) => Effect.Effect<void>;
+    /** Cap the number of session files processed. Used by `ingest --dry-run` to
+     *  time a small representative slice for ETA calibration. */
+    limit: number | undefined;
 }
 
 export interface CodexStats {
@@ -1464,6 +1467,11 @@ export const ingestCodex = (
         const fs = yield* FileSystem.FileSystem;
         const cutoff = opts.sinceDays ? Date.now() - opts.sinceDays * 86400 * 1000 : 0;
         const files = yield* walkJsonlFiles(cfg.paths.codexDir, cutoff);
+        // `--dry-run` calibration: cap to a small representative slice so we can
+        // time real parse+write throughput without processing everything.
+        if (typeof opts.limit === "number" && files.length > opts.limit) {
+            files.length = opts.limit;
+        }
         const totalBytes = files.reduce((sum, file) => sum + file.sizeBytes, 0);
         if (opts.onProgress) yield* opts.onProgress({ totalFiles: files.length, totalBytes });
         const rawMaxBytes = cfg.knobs.codexRawMaxBytes;

--- a/apps/axctl/src/ingest/derive-claude-subagents.ts
+++ b/apps/axctl/src/ingest/derive-claude-subagents.ts
@@ -16,6 +16,7 @@ import {
     relateInvocationsForSubagents,
     relateToolCallSkillsForSubagents,
     writePlanSnapshotsForSubagents,
+    writeTokenUsageForSubagents,
 } from "./transcripts.ts";
 import { resolveSkillName } from "@ax/lib/skill-id";
 import { recordLiteral } from "@ax/lib/ids";
@@ -318,6 +319,7 @@ export const deriveClaudeSubagents = (
                 });
                 if (parentRepository !== undefined) repositoryInherited += 1;
 
+                yield* writeTokenUsageForSubagents(extracted);
                 yield* upsertTurnsForSubagents(extracted.turns);
                 yield* writeToolCallStatementsForSubagents(extracted.toolCalls);
                 yield* writeToolFileEvidenceForSubagents(extracted.toolCalls);

--- a/apps/axctl/src/ingest/dry-run.test.ts
+++ b/apps/axctl/src/ingest/dry-run.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { computeEstimate, formatDuration, formatDryRun, type DryRunResult } from "./dry-run.ts";
+
+describe("computeEstimate", () => {
+    test("projects ETA from a sampled rate", () => {
+        // 30 sessions in 2s => 15/s; 1200 total => 80s.
+        const { ratePerSec, etaSeconds } = computeEstimate(1200, 30, 2);
+        expect(ratePerSec).toBeCloseTo(15, 5);
+        expect(etaSeconds).toBe(80);
+    });
+
+    test("returns null when nothing was sampled (populated DB / watermark skip)", () => {
+        expect(computeEstimate(1200, 0, 0)).toEqual({ ratePerSec: null, etaSeconds: null });
+    });
+
+    test("guards against a sub-10ms sample yielding an absurd rate", () => {
+        expect(computeEstimate(1200, 30, 0.005)).toEqual({ ratePerSec: null, etaSeconds: null });
+    });
+
+    test("rounds ETA to whole seconds", () => {
+        const { etaSeconds } = computeEstimate(100, 3, 1); // 3/s -> 33.33s
+        expect(etaSeconds).toBe(33);
+    });
+});
+
+describe("formatDuration", () => {
+    test("seconds under a minute", () => {
+        expect(formatDuration(45)).toBe("45s");
+        expect(formatDuration(0)).toBe("0s");
+    });
+    test("minutes with zero-padded seconds", () => {
+        expect(formatDuration(210)).toBe("3m30s");
+        expect(formatDuration(65)).toBe("1m05s");
+    });
+    test("hours with zero-padded minutes", () => {
+        expect(formatDuration(3720)).toBe("1h02m");
+    });
+});
+
+const baseResult = (over: Partial<DryRunResult> = {}): DryRunResult => ({
+    sources: { claude: 1180, codex: 60, pi: 0, opencodeStore: false, cursorStore: false, sessionsTotal: 1240 },
+    sampled: { items: 30, seconds: 2.1 },
+    ratePerSec: 14.3,
+    etaSeconds: 210,
+    ...over,
+});
+
+describe("formatDryRun", () => {
+    test("json emits the machine-readable shape", () => {
+        const out = JSON.parse(formatDryRun(baseResult(), true));
+        expect(out.sources.sessionsTotal).toBe(1240);
+        expect(out.etaSeconds).toBe(210);
+        expect(out.ratePerSec).toBe(14.3);
+        expect(out.sampled.items).toBe(30);
+    });
+
+    test("human output shows per-source counts, total, and ETA", () => {
+        const out = formatDryRun(baseResult(), false);
+        expect(out).toContain("claude   1,180 sessions");
+        expect(out).toContain("codex    60 sessions");
+        expect(out).not.toContain("pi "); // zero-count sources omitted
+        expect(out).toContain("ETA ~3m30s");
+        expect(out).toContain("ax serve");
+    });
+
+    test("human output handles an empty source set", () => {
+        const out = formatDryRun(
+            baseResult({
+                sources: { claude: 0, codex: 0, pi: 0, opencodeStore: false, cursorStore: false, sessionsTotal: 0 },
+                sampled: { items: 0, seconds: 0 },
+                ratePerSec: null,
+                etaSeconds: null,
+            }),
+            false,
+        );
+        expect(out).toContain("nothing to ingest yet");
+    });
+
+    test("human output handles an already-populated DB (no measurable rate)", () => {
+        const out = formatDryRun(baseResult({ ratePerSec: null, etaSeconds: null }), false);
+        expect(out).toContain("already has data");
+        expect(out).toContain("ax ingest");
+    });
+});

--- a/apps/axctl/src/ingest/dry-run.test.ts
+++ b/apps/axctl/src/ingest/dry-run.test.ts
@@ -42,6 +42,8 @@ const baseResult = (over: Partial<DryRunResult> = {}): DryRunResult => ({
     sampled: { items: 30, seconds: 2.1 },
     ratePerSec: 14.3,
     etaSeconds: 210,
+    rough: false,
+    populated: false,
     ...over,
 });
 
@@ -76,9 +78,16 @@ describe("formatDryRun", () => {
         expect(out).toContain("nothing to ingest yet");
     });
 
-    test("human output handles an already-populated DB (no measurable rate)", () => {
-        const out = formatDryRun(baseResult({ ratePerSec: null, etaSeconds: null }), false);
-        expect(out).toContain("already has data");
+    test("human output tags a small (time-boxed) sample as rough", () => {
+        const out = formatDryRun(baseResult({ sampled: { items: 5, seconds: 8 }, ratePerSec: 0.6, etaSeconds: 3300, rough: true }), false);
+        expect(out).toContain("(rough)");
+    });
+
+    test("human output reports an already-populated DB as incremental", () => {
+        const out = formatDryRun(baseResult({ ratePerSec: null, etaSeconds: null, populated: true }), false);
+        expect(out).toContain("already populated");
+        expect(out).toContain("incremental");
         expect(out).toContain("ax ingest");
+        expect(out).not.toContain("ETA ~"); // no misleading full-total ETA
     });
 });

--- a/apps/axctl/src/ingest/dry-run.ts
+++ b/apps/axctl/src/ingest/dry-run.ts
@@ -22,8 +22,15 @@ import type { DbError } from "@ax/lib/errors";
 import { ingestTranscripts } from "./transcripts.ts";
 import { ingestCodex } from "./codex.ts";
 
-/** How many sessions to push through the pipeline to measure throughput. */
-export const DEFAULT_SAMPLE_SIZE = 30;
+/** Wall-clock budget for the calibration sample. Keeps the dry-run snappy even
+ *  when individual transcripts are large (one fat session can take seconds). */
+export const DEFAULT_SAMPLE_BUDGET_MS = 8_000;
+/** Hard backstop on files sampled, so a corpus of tiny files doesn't run the
+ *  whole budget for no extra signal. */
+export const DEFAULT_SAMPLE_CAP = 60;
+/** Below this many sampled items the ETA is flagged "rough" - a small sample is
+ *  noisy, especially when transcript sizes vary widely. */
+export const ROUGH_SAMPLE_THRESHOLD = 10;
 
 export interface SourceCounts {
     /** claude `.jsonl` transcript files (~one per session). */
@@ -48,6 +55,12 @@ export interface DryRunResult {
     readonly ratePerSec: number | null;
     /** projected full-backfill seconds, or null when no rate could be measured. */
     readonly etaSeconds: number | null;
+    /** true when the sample was small (time-boxed early), so the ETA is noisy. */
+    readonly rough: boolean;
+    /** true when the graph already has sessions. A full-total ETA would be
+     *  misleading (the watermark skips already-ingested files), so we report the
+     *  run as incremental instead. */
+    readonly populated: boolean;
 }
 
 /** Pure ETA math. Returns null rate/eta when the sample measured nothing
@@ -105,6 +118,23 @@ const countJsonl = (
         return count;
     });
 
+/** Cheap "is the graph already populated?" probe. One existence check, not a
+ *  full count. Drives the ETA branch: an empty graph means every on-disk file is
+ *  pending (so total == pending and the ETA is exact); a populated graph means
+ *  the watermark will skip most files, so extrapolating over the full total would
+ *  wildly over-estimate - we report incremental instead. */
+const dbHasSessions = (): Effect.Effect<boolean, never, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const rows = (yield* db.query<[Array<{ id: unknown }>]>("SELECT id FROM session LIMIT 1;"))?.[0] ?? [];
+        return rows.length > 0;
+    }).pipe(
+        // A missing `session` table (schema not applied yet) or any query failure
+        // means we can't confirm population - treat as empty (first run) rather
+        // than crashing the dry-run.
+        Effect.orElseSucceed(() => false),
+    );
+
 const pathExists = (p: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
@@ -113,7 +143,10 @@ const pathExists = (p: string): Effect.Effect<boolean, never, FileSystem.FileSys
 
 export interface EstimateOptions {
     readonly sinceDays?: number | undefined;
-    readonly sampleSize?: number | undefined;
+    /** Wall-clock budget for the calibration sample (ms). */
+    readonly sampleBudgetMs?: number | undefined;
+    /** Hard file-count backstop for the sample. */
+    readonly sampleCap?: number | undefined;
     /** Injectable clock (ms) for deterministic tests. */
     readonly now?: (() => number) | undefined;
 }
@@ -130,7 +163,8 @@ export const estimateIngest = (
         const cfg = yield* AxConfig;
         const path = yield* Path.Path;
         const now = opts.now ?? (() => Date.now());
-        const sample = opts.sampleSize ?? DEFAULT_SAMPLE_SIZE;
+        const cap = opts.sampleCap ?? DEFAULT_SAMPLE_CAP;
+        const budgetMs = opts.sampleBudgetMs ?? DEFAULT_SAMPLE_BUDGET_MS;
         const cutoff = opts.sinceDays ? now() - opts.sinceDays * 86400 * 1000 : 0;
 
         const claude = yield* countJsonl(cfg.paths.transcriptsDir, cutoff);
@@ -141,17 +175,29 @@ export const estimateIngest = (
         const sessionsTotal = claude + codex + pi;
         const sources: SourceCounts = { claude, codex, pi, opencodeStore, cursorStore, sessionsTotal };
 
-        // Calibrate on whichever jsonl harness has the most pending work, so the
-        // measured rate is representative.
+        // On a populated graph the watermark skips already-ingested files, so a
+        // full-total ETA is meaningless (and sampling would only re-touch a
+        // handful of new files). Report incremental and skip calibration.
+        const populated = yield* dbHasSessions();
+        if (populated) {
+            return { sources, sampled: { items: 0, seconds: 0 }, ratePerSec: null, etaSeconds: null, rough: false, populated };
+        }
+
+        // First run: every on-disk file is pending, so total == pending and the
+        // ETA is exact. Calibrate on whichever jsonl harness has the most work.
+        // Time-boxed: process real files until the budget elapses (or the cap is
+        // hit), then extrapolate.
         const useCodex = codex > claude;
         const t0 = now();
+        const deadlineMs = t0 + budgetMs;
         const items = useCodex
-            ? (yield* ingestCodex({ sinceDays: opts.sinceDays, limit: sample })).sessions
-            : (yield* ingestTranscripts({ sinceDays: opts.sinceDays, limit: sample })).sessions;
+            ? (yield* ingestCodex({ sinceDays: opts.sinceDays, limit: cap, deadlineMs })).sessions
+            : (yield* ingestTranscripts({ sinceDays: opts.sinceDays, limit: cap, deadlineMs })).sessions;
         const seconds = (now() - t0) / 1000;
 
         const { ratePerSec, etaSeconds } = computeEstimate(sessionsTotal, items, seconds);
-        return { sources, sampled: { items, seconds }, ratePerSec, etaSeconds };
+        const rough = ratePerSec !== null && items < ROUGH_SAMPLE_THRESHOLD;
+        return { sources, sampled: { items, seconds }, ratePerSec, etaSeconds, rough, populated };
     });
 
 /** Render the dry-run result for humans (Paxel-style) or as JSON for the agent. */
@@ -163,6 +209,8 @@ export function formatDryRun(result: DryRunResult, json: boolean): string {
                 sampled: result.sampled,
                 ratePerSec: result.ratePerSec,
                 etaSeconds: result.etaSeconds,
+                rough: result.rough,
+                populated: result.populated,
             },
             null,
             2,
@@ -181,10 +229,18 @@ export function formatDryRun(result: DryRunResult, json: boolean): string {
         return lines.join("\n");
     }
 
+    if (result.populated) {
+        // Graph already has sessions: runs are incremental (the watermark skips
+        // already-ingested files), so a full-total ETA would be meaningless.
+        lines.push("  graph already populated - the next run is incremental (only new/changed files), so it'll be quick.");
+        lines.push("  run it: ax ingest");
+        return lines.join("\n");
+    }
+
     if (result.ratePerSec === null) {
-        // Nothing measurable - usually the graph is already populated, so the
-        // sample slice was skipped by the watermark.
-        lines.push("  graph already has data - a fresh run will be quick (only new files).");
+        // Empty graph but the sample measured nothing usable (e.g. all candidate
+        // files were too short to produce a session). Can't project a rate.
+        lines.push("  couldn't measure a rate from the sample; just run it:");
         lines.push("  run it: ax ingest");
         return lines.join("\n");
     }
@@ -193,7 +249,8 @@ export function formatDryRun(result: DryRunResult, json: boolean): string {
         `  calibrating... sampled ${result.sampled.items} in ${result.sampled.seconds.toFixed(1)}s (${result.ratePerSec.toFixed(1)}/s)`,
     );
     const eta = result.etaSeconds === null ? "unknown" : `~${formatDuration(result.etaSeconds)}`;
-    lines.push(`  total: ${s.sessionsTotal.toLocaleString()} sessions   ETA ${eta} on this machine`);
+    const roughTag = result.rough ? " (rough)" : "";
+    lines.push(`  total: ${s.sessionsTotal.toLocaleString()} sessions   ETA ${eta}${roughTag} on this machine`);
     lines.push("  run it: ax ingest   (watch live in ax serve → http://127.0.0.1:8520)");
     return lines.join("\n");
 }

--- a/apps/axctl/src/ingest/dry-run.ts
+++ b/apps/axctl/src/ingest/dry-run.ts
@@ -1,0 +1,199 @@
+/**
+ * `ax ingest --dry-run` - estimate how long a full backfill will take BEFORE
+ * running it, so the onboarding agent (and a human) can decide and narrate.
+ *
+ * Two parts:
+ *   1. Count pending source sessions cheaply (recursive `.jsonl` walks for the
+ *      claude/codex/pi harnesses; a presence probe for the opencode/cursor
+ *      sqlite stores). On a fresh DB - the case that matters most, the first
+ *      run - every file is pending, so the raw count is exact. On a populated
+ *      DB it is an upper bound (the watermark skips unchanged files at run time).
+ *   2. Calibrate throughput on THIS machine by timing a small real slice (the
+ *      sample) through the normal pipeline. Upserts are idempotent, so the
+ *      sampled sessions are reused by the subsequent real run - no wasted work.
+ *
+ * The pure ETA math (`computeEstimate`, `formatDuration`) is separated from the
+ * effectful counting/sampling so it can be unit-tested without a DB or disk.
+ */
+import { Effect, FileSystem, Option, Path, PlatformError } from "effect";
+import { AxConfig } from "@ax/lib/config";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { ingestTranscripts } from "./transcripts.ts";
+import { ingestCodex } from "./codex.ts";
+
+/** How many sessions to push through the pipeline to measure throughput. */
+export const DEFAULT_SAMPLE_SIZE = 30;
+
+export interface SourceCounts {
+    /** claude `.jsonl` transcript files (~one per session). */
+    readonly claude: number;
+    /** codex `.jsonl` session files. */
+    readonly codex: number;
+    /** pi `.jsonl` session files. */
+    readonly pi: number;
+    /** opencode sqlite store present (sessions counted at run time). */
+    readonly opencodeStore: boolean;
+    /** cursor user dir present (conversations counted at run time). */
+    readonly cursorStore: boolean;
+    /** claude + codex + pi - the jsonl harnesses that drive the ETA. */
+    readonly sessionsTotal: number;
+}
+
+export interface DryRunResult {
+    readonly sources: SourceCounts;
+    readonly sampled: { readonly items: number; readonly seconds: number };
+    /** sessions/sec measured from the sample, or null when nothing was sampled
+     *  (e.g. the graph is already populated so the slice was skipped). */
+    readonly ratePerSec: number | null;
+    /** projected full-backfill seconds, or null when no rate could be measured. */
+    readonly etaSeconds: number | null;
+}
+
+/** Pure ETA math. Returns null rate/eta when the sample measured nothing
+ *  usable (too few items, or a sub-millisecond elapsed that would yield an
+ *  absurd rate). */
+export function computeEstimate(
+    sessionsTotal: number,
+    sampledItems: number,
+    sampledSeconds: number,
+): { ratePerSec: number | null; etaSeconds: number | null } {
+    if (sampledItems < 1 || sampledSeconds <= 0.01) {
+        return { ratePerSec: null, etaSeconds: null };
+    }
+    const ratePerSec = sampledItems / sampledSeconds;
+    const etaSeconds = sessionsTotal / ratePerSec;
+    return { ratePerSec, etaSeconds: Math.round(etaSeconds) };
+}
+
+/** Human-friendly duration: "3m30s", "45s", "1h02m". */
+export function formatDuration(seconds: number): string {
+    const s = Math.max(0, Math.round(seconds));
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    const rem = s % 60;
+    if (m < 60) return `${m}m${rem.toString().padStart(2, "0")}s`;
+    const h = Math.floor(m / 60);
+    return `${h}h${(m % 60).toString().padStart(2, "0")}m`;
+}
+
+/** Recursively count `.jsonl` files under `dir` whose mtime passes the cutoff.
+ *  Stat-only - never opens a file. Missing/unreadable dirs count as 0. */
+const countJsonl = (
+    dir: string,
+    cutoffMs: number,
+): Effect.Effect<number, never, FileSystem.FileSystem | Path.Path> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const exists = yield* fs.exists(dir).pipe(Effect.orElseSucceed(() => false));
+        if (!exists) return 0;
+        const entries = yield* fs.readDirectory(dir).pipe(Effect.orElseSucceed(() => [] as string[]));
+        let count = 0;
+        for (const name of entries) {
+            const full = path.join(dir, name);
+            const info = yield* fs.stat(full).pipe(Effect.option);
+            if (Option.isNone(info)) continue;
+            const st = info.value;
+            if (st.type === "Directory") {
+                count += yield* countJsonl(full, cutoffMs);
+            } else if (name.endsWith(".jsonl")) {
+                const mtime = Option.getOrElse(st.mtime, () => new Date(0)).getTime();
+                if (cutoffMs <= 0 || mtime >= cutoffMs) count += 1;
+            }
+        }
+        return count;
+    });
+
+const pathExists = (p: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        return yield* fs.exists(p).pipe(Effect.orElseSucceed(() => false));
+    });
+
+export interface EstimateOptions {
+    readonly sinceDays?: number | undefined;
+    readonly sampleSize?: number | undefined;
+    /** Injectable clock (ms) for deterministic tests. */
+    readonly now?: (() => number) | undefined;
+}
+
+/** Count sources, then time a small real slice to project the full ETA. */
+export const estimateIngest = (
+    opts: EstimateOptions = {},
+): Effect.Effect<
+    DryRunResult,
+    DbError | PlatformError.PlatformError,
+    AxConfig | FileSystem.FileSystem | Path.Path | SurrealClient
+> =>
+    Effect.gen(function* () {
+        const cfg = yield* AxConfig;
+        const path = yield* Path.Path;
+        const now = opts.now ?? (() => Date.now());
+        const sample = opts.sampleSize ?? DEFAULT_SAMPLE_SIZE;
+        const cutoff = opts.sinceDays ? now() - opts.sinceDays * 86400 * 1000 : 0;
+
+        const claude = yield* countJsonl(cfg.paths.transcriptsDir, cutoff);
+        const codex = yield* countJsonl(cfg.paths.codexDir, cutoff);
+        const pi = yield* countJsonl(cfg.paths.piDir, cutoff);
+        const opencodeStore = yield* pathExists(path.join(cfg.paths.opencodeDir, "opencode.db"));
+        const cursorStore = yield* pathExists(cfg.paths.cursorUserDir);
+        const sessionsTotal = claude + codex + pi;
+        const sources: SourceCounts = { claude, codex, pi, opencodeStore, cursorStore, sessionsTotal };
+
+        // Calibrate on whichever jsonl harness has the most pending work, so the
+        // measured rate is representative.
+        const useCodex = codex > claude;
+        const t0 = now();
+        const items = useCodex
+            ? (yield* ingestCodex({ sinceDays: opts.sinceDays, limit: sample })).sessions
+            : (yield* ingestTranscripts({ sinceDays: opts.sinceDays, limit: sample })).sessions;
+        const seconds = (now() - t0) / 1000;
+
+        const { ratePerSec, etaSeconds } = computeEstimate(sessionsTotal, items, seconds);
+        return { sources, sampled: { items, seconds }, ratePerSec, etaSeconds };
+    });
+
+/** Render the dry-run result for humans (Paxel-style) or as JSON for the agent. */
+export function formatDryRun(result: DryRunResult, json: boolean): string {
+    if (json) {
+        return JSON.stringify(
+            {
+                sources: result.sources,
+                sampled: result.sampled,
+                ratePerSec: result.ratePerSec,
+                etaSeconds: result.etaSeconds,
+            },
+            null,
+            2,
+        );
+    }
+    const { sources: s } = result;
+    const lines: string[] = ["ax ingest --dry-run", "  counting sources..."];
+    if (s.claude > 0) lines.push(`    claude   ${s.claude.toLocaleString()} sessions`);
+    if (s.codex > 0) lines.push(`    codex    ${s.codex.toLocaleString()} sessions`);
+    if (s.pi > 0) lines.push(`    pi       ${s.pi.toLocaleString()} sessions`);
+    if (s.opencodeStore) lines.push("    opencode store present (counted at run time)");
+    if (s.cursorStore) lines.push("    cursor store present (counted at run time)");
+
+    if (s.sessionsTotal === 0 && !s.opencodeStore && !s.cursorStore) {
+        lines.push("  nothing to ingest yet.");
+        return lines.join("\n");
+    }
+
+    if (result.ratePerSec === null) {
+        // Nothing measurable - usually the graph is already populated, so the
+        // sample slice was skipped by the watermark.
+        lines.push("  graph already has data - a fresh run will be quick (only new files).");
+        lines.push("  run it: ax ingest");
+        return lines.join("\n");
+    }
+
+    lines.push(
+        `  calibrating... sampled ${result.sampled.items} in ${result.sampled.seconds.toFixed(1)}s (${result.ratePerSec.toFixed(1)}/s)`,
+    );
+    const eta = result.etaSeconds === null ? "unknown" : `~${formatDuration(result.etaSeconds)}`;
+    lines.push(`  total: ${s.sessionsTotal.toLocaleString()} sessions   ETA ${eta} on this machine`);
+    lines.push("  run it: ax ingest   (watch live in ax serve → http://127.0.0.1:8520)");
+    return lines.join("\n");
+}

--- a/apps/axctl/src/ingest/stream-events.test.ts
+++ b/apps/axctl/src/ingest/stream-events.test.ts
@@ -30,4 +30,31 @@ describe("ingest stream events", () => {
     test("returns null for unrelated events", () => {
         expect(ingestStreamEventFromTrace({ _tag: "SpanEvent", traceId: "ingest:x", spanId: "s", name: "n" } as never, { spanNames: new Map() })).toBeNull();
     });
+
+    test("emits stage_progress once current + total are both known, with rate + eta", () => {
+        const ctx = {
+            spanNames: new Map<string, string>(),
+            spanStartedAt: new Map<string, number>(),
+            spanCounts: new Map<string, Record<string, number>>(),
+            index: { started: 0 },
+        };
+        ingestStreamEventFromTrace(
+            { _tag: "SpanStart", traceId: "ingest:r", spanId: "s1", name: "claude/transcripts", timestamp: 1000 } as never,
+            ctx,
+        );
+        // Total only -> not yet determinate -> null.
+        const partial = ingestStreamEventFromTrace(
+            { _tag: "SpanEvent", traceId: "ingest:r", spanId: "s1", name: "attribute:ingest.count.totalFiles", attributes: { value: 200 }, timestamp: 1000 } as never,
+            ctx,
+        );
+        expect(partial).toBeNull();
+        // Now current arrives 5s in -> 50/200 @ 10/s, 150 left -> 15s.
+        const ev = ingestStreamEventFromTrace(
+            { _tag: "SpanEvent", traceId: "ingest:r", spanId: "s1", name: "attribute:ingest.count.currentFile", attributes: { value: 50 }, timestamp: 6000 } as never,
+            ctx,
+        );
+        expect(ev).toMatchObject({ kind: "stage_progress", stage: "claude/transcripts", current: 50, total: 200, stageIndex: 1 });
+        expect((ev as { ratePerSec: number }).ratePerSec).toBeCloseTo(10, 5);
+        expect((ev as { etaLeftMs: number }).etaLeftMs).toBeCloseTo(15000, 0);
+    });
 });

--- a/apps/axctl/src/ingest/stream-events.ts
+++ b/apps/axctl/src/ingest/stream-events.ts
@@ -3,25 +3,94 @@ import type { TraceEvent } from "@ax/lib/live-traces/types";
 export type IngestStreamEvent =
     | { readonly kind: "run_started"; readonly runId: string; readonly label: string }
     | { readonly kind: "stage_started"; readonly runId: string; readonly stage: string }
+    | {
+        readonly kind: "stage_progress";
+        readonly runId: string;
+        readonly stage: string;
+        readonly current: number;
+        readonly total: number;
+        readonly ratePerSec: number;
+        readonly etaLeftMs: number | null;
+        /** 1-based index of this stage among those started so far. */
+        readonly stageIndex: number;
+    }
     | { readonly kind: "stage_finished"; readonly runId: string; readonly stage: string; readonly status: "ok" | "error"; readonly durationMs: number }
     | { readonly kind: "run_finished"; readonly runId: string; readonly status: "completed" | "failed"; readonly durationMs: number };
 
 const runIdOf = (traceId: string): string => traceId.replace(/^ingest:/, "");
 
-/** Translate a live-trace event into a coarse ingest progress event, or null. */
+/** Mutable per-trace state the translator threads across events: span id ->
+ *  stage name, start time, and accumulated counts, plus a started-stage counter
+ *  for the [n] index. Callers create one and reuse it for the whole trace. */
+export interface TraceStreamCtx {
+    readonly spanNames: Map<string, string>;
+    readonly spanStartedAt?: Map<string, number>;
+    readonly spanCounts?: Map<string, Record<string, number>>;
+    readonly index?: { started: number };
+}
+
+/** Parse an `ingest.*` count SpanEvent into `[key, value]`, mirroring the
+ *  terminal renderer. `ingest.records` is the primary count; `ingest.count.<f>`
+ *  carries each stat field (incl. currentFile/totalFiles). */
+const readCount = (name: string, attributes: Record<string, unknown> | undefined): readonly [string, number] | null => {
+    if (!name.startsWith("attribute:ingest.")) return null;
+    const value = attributes?.value;
+    if (typeof value !== "number" || !Number.isFinite(value)) return null;
+    if (name === "attribute:ingest.records") return ["records", value];
+    if (name.startsWith("attribute:ingest.count.")) return [name.slice("attribute:ingest.count.".length), value];
+    return null;
+};
+
+const firstFinite = (...vs: Array<number | undefined>): number | undefined => {
+    for (const v of vs) if (typeof v === "number" && Number.isFinite(v)) return v;
+    return undefined;
+};
+
+/** Translate a live-trace event into an ingest progress event, or null. */
 export function ingestStreamEventFromTrace(
     event: TraceEvent,
-    ctx: { readonly spanNames: Map<string, string> },
+    ctx: TraceStreamCtx,
 ): IngestStreamEvent | null {
     switch (event._tag) {
         case "TraceStart":
             return { kind: "run_started", runId: runIdOf(event.traceId), label: event.label };
-        case "SpanStart":
+        case "SpanStart": {
             ctx.spanNames.set(event.spanId, event.name);
+            ctx.spanStartedAt?.set(event.spanId, event.timestamp);
+            if (ctx.index) ctx.index.started += 1;
             return { kind: "stage_started", runId: runIdOf(event.traceId), stage: event.name };
+        }
+        case "SpanEvent": {
+            // Accumulate counts; emit a stage_progress only once current + total
+            // are both known (a determinate bar), otherwise stay silent.
+            const parsed = readCount(event.name, event.attributes);
+            if (!parsed || !ctx.spanCounts) return null;
+            const counts = ctx.spanCounts.get(event.spanId) ?? {};
+            counts[parsed[0]] = parsed[1];
+            ctx.spanCounts.set(event.spanId, counts);
+            const current = firstFinite(counts.currentFile, counts.currentSubagent);
+            const total = firstFinite(counts.totalFiles, counts.totalSubagents);
+            if (current === undefined || total === undefined || total <= 0) return null;
+            const startedAt = ctx.spanStartedAt?.get(event.spanId) ?? event.timestamp;
+            const secs = Math.max(0, event.timestamp - startedAt) / 1000;
+            const ratePerSec = secs > 0 && current > 0 ? current / secs : 0;
+            const etaLeftMs = ratePerSec > 0 && total > current ? ((total - current) / ratePerSec) * 1000 : null;
+            return {
+                kind: "stage_progress",
+                runId: runIdOf(event.traceId),
+                stage: ctx.spanNames.get(event.spanId) ?? event.spanId,
+                current,
+                total,
+                ratePerSec,
+                etaLeftMs,
+                stageIndex: ctx.index?.started ?? 0,
+            };
+        }
         case "SpanEnd": {
             const stage = ctx.spanNames.get(event.spanId) ?? event.spanId;
             ctx.spanNames.delete(event.spanId);
+            ctx.spanStartedAt?.delete(event.spanId);
+            ctx.spanCounts?.delete(event.spanId);
             return { kind: "stage_finished", runId: runIdOf(event.traceId), stage, status: event.status, durationMs: event.durationMs };
         }
         case "TraceEnd":

--- a/apps/axctl/src/ingest/transcripts.test.ts
+++ b/apps/axctl/src/ingest/transcripts.test.ts
@@ -4,6 +4,7 @@ import { fileRecordKey, toolCallRecordKey, turnRecordKey } from "./record-keys.t
 import { extractToolFileEvidence } from "./tool-file-evidence.ts";
 import {
     __testExtractClaudeJsonlLines,
+    buildClaudeTokenUsageStatements,
     claudeConcurrency,
     transcriptEditFileRecordKey,
 } from "./transcripts.ts";
@@ -1143,5 +1144,115 @@ describe("claude compaction", () => {
             seq: compactionEvents[0].seq,
         });
         expect(extracted.compactions[0].agentEventKey).toBe(eventKey);
+    });
+});
+
+describe("claude token usage", () => {
+    const usageLines = (model: string) => [
+        JSON.stringify({
+            type: "user",
+            uuid: "u1",
+            timestamp: "2026-06-01T10:00:00.000Z",
+            sessionId: "cl-tok",
+            cwd: "/tmp",
+            message: { role: "user", content: "do a thing" },
+        }),
+        JSON.stringify({
+            type: "assistant",
+            uuid: "a1",
+            timestamp: "2026-06-01T10:00:01.000Z",
+            sessionId: "cl-tok",
+            message: {
+                role: "assistant",
+                model,
+                content: "ok",
+                usage: {
+                    input_tokens: 100,
+                    output_tokens: 50,
+                    cache_creation_input_tokens: 200,
+                    cache_read_input_tokens: 1000,
+                },
+            },
+        }),
+        JSON.stringify({
+            type: "assistant",
+            uuid: "a2",
+            timestamp: "2026-06-01T10:00:02.000Z",
+            sessionId: "cl-tok",
+            message: {
+                role: "assistant",
+                model,
+                content: "done",
+                usage: {
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 2000,
+                },
+            },
+        }),
+    ];
+
+    test("sums per-message usage with cache-inclusive prompt totals", () => {
+        const extracted = __testExtractClaudeJsonlLines(
+            usageLines("claude-opus-4-8"),
+            "-tmp",
+            "cl-tok",
+        );
+        expect(extracted?.tokenUsage).not.toBeNull();
+        const u = extracted!.tokenUsage!;
+        // prompt = fresh(110) + cacheCreation(200) + cacheRead(3000) = 3310
+        expect(u.promptTokens).toBe(3310);
+        expect(u.completionTokens).toBe(55);
+        expect(u.cacheCreationInputTokens).toBe(200);
+        expect(u.cacheReadInputTokens).toBe(3000);
+        expect(u.estimatedTokens).toBe(3365);
+        expect(u.model).toBe("claude-opus-4-8");
+    });
+
+    test("prices the session via the built-in catalog", () => {
+        const extracted = __testExtractClaudeJsonlLines(
+            usageLines("claude-opus-4-8"),
+            "-tmp",
+            "cl-tok",
+        );
+        const [stmt] = buildClaudeTokenUsageStatements(extracted!);
+        expect(stmt).toContain("UPSERT session_token_usage:");
+        expect(stmt).toContain("pricing_source:");
+        // fresh 110 @ $5/M + output 55 @ $25/M + cacheCreate 200 @ $6.25/M
+        // + cacheRead 3000 @ $0.5/M = 0.00055 + 0.001375 + 0.00125 + 0.0015
+        expect(stmt).toContain("estimated_cost_usd: 0.004675");
+        expect(stmt).toContain('source: "claude"');
+    });
+
+    test("emits no statements when the transcript carries no usage", () => {
+        const extracted = __testExtractClaudeJsonlLines(
+            [
+                JSON.stringify({
+                    type: "user",
+                    uuid: "u1",
+                    timestamp: "2026-06-01T10:00:00.000Z",
+                    sessionId: "cl-none",
+                    cwd: "/tmp",
+                    message: { role: "user", content: "hi" },
+                }),
+            ],
+            "-tmp",
+            "cl-none",
+        );
+        expect(extracted?.tokenUsage).toBeNull();
+        expect(buildClaudeTokenUsageStatements(extracted!)).toEqual([]);
+    });
+
+    test("leaves cost null for an unknown model but still records tokens", () => {
+        const extracted = __testExtractClaudeJsonlLines(
+            usageLines("some-unpriced-model"),
+            "-tmp",
+            "cl-tok",
+        );
+        const [stmt] = buildClaudeTokenUsageStatements(extracted!);
+        expect(stmt).toContain("estimated_cost_usd: NONE");
+        expect(stmt).toContain("pricing_source: NONE");
+        expect(stmt).toContain("prompt_tokens: 3310");
     });
 });

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1318,6 +1318,9 @@ interface IngestOpts {
     sinceDays: number | undefined;
     project: string | undefined;
     onProgress: (counts: Record<string, number>) => Effect.Effect<void>;
+    /** Cap the number of transcript files processed. Used by `ingest --dry-run`
+     *  to time a small representative slice for ETA calibration. */
+    limit: number | undefined;
 }
 
 export interface TranscriptStats {
@@ -1422,6 +1425,12 @@ export const ingestTranscripts = (
                     size,
                 });
             }
+        }
+
+        // `--dry-run` calibration: cap to a small representative slice so we can
+        // time real parse+write throughput without processing everything.
+        if (typeof opts.limit === "number" && candidates.length > opts.limit) {
+            candidates.length = opts.limit;
         }
 
         if (opts.onProgress) yield* opts.onProgress({ totalFiles: candidates.length });

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1318,9 +1318,13 @@ interface IngestOpts {
     sinceDays: number | undefined;
     project: string | undefined;
     onProgress: (counts: Record<string, number>) => Effect.Effect<void>;
-    /** Cap the number of transcript files processed. Used by `ingest --dry-run`
-     *  to time a small representative slice for ETA calibration. */
+    /** Hard cap on transcript files processed - a backstop for `ingest --dry-run`
+     *  calibration (paired with `deadlineMs`). */
     limit: number | undefined;
+    /** Absolute wall-clock deadline (ms epoch). Once reached, no NEW file is
+     *  started; in-flight files finish. Lets `--dry-run` time-box calibration so
+     *  it stays snappy even when individual transcripts are large. */
+    deadlineMs: number | undefined;
 }
 
 export interface TranscriptStats {
@@ -1463,6 +1467,12 @@ export const ingestTranscripts = (
         });
 
         yield* Effect.forEach(candidates.map((candidate, index) => ({ candidate, index })), ({ candidate, index }) => Effect.gen(function* () {
+            // Time-box (dry-run calibration): once the deadline passes, start no
+            // new files. In-flight ones finish, so the sample is whatever
+            // completed within the budget.
+            if (opts.deadlineMs !== undefined && Date.now() >= opts.deadlineMs) {
+                return;
+            }
             // Skip-unchanged: a candidate whose on-disk (mtime,size) still
             // matches its persisted watermark has already been ingested in a
             // prior run; its rows persist, so skipping is output-equivalent.

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -49,6 +49,16 @@ import { fileWatermark } from "@ax/lib/shared/watermark";
 import { skipNotFound } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
 import {
+    surrealDate,
+    surrealJsonOption,
+    surrealObject,
+    surrealOptionInt,
+    surrealOptionString,
+    surrealString,
+} from "@ax/lib/shared/surql";
+import { safeKeyPart } from "@ax/lib/shared/derive-keys";
+import { estimateCost, normalizeModelName } from "./model-pricing.ts";
+import {
     buildCompactionStatements,
     extractClaudeCompaction,
     type CompactionWrite,
@@ -293,6 +303,23 @@ function applyToolResult(call: MutableToolCallWrite, result: ToolResultFields): 
     call.hasError = result.hasError;
 }
 
+/**
+ * Per-session token usage summed from the Claude transcript's own
+ * `message.usage` blocks. Anthropic reports `input_tokens` EXCLUSIVE of cache
+ * tokens, so `promptTokens` here is the total billed input
+ * (fresh + cache-creation + cache-read) to match the convention `estimateCost`
+ * expects (it subtracts cache from prompt to recover fresh input).
+ */
+interface ClaudeTokenUsage {
+    promptTokens: number;
+    completionTokens: number;
+    cacheCreationInputTokens: number;
+    cacheReadInputTokens: number;
+    estimatedTokens: number;
+    model: string | null;
+    ts: string;
+}
+
 interface FileExtract {
     session: Session;
     sourcePath: string | null;
@@ -306,6 +333,7 @@ interface FileExtract {
     hookEvents: HarnessHookEventWrite[];
     hookCommandInvocations: HookCommandInvocationWrite[];
     compactions: CompactionWrite[];
+    tokenUsage: ClaudeTokenUsage | null;
 }
 
 function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: string) {
@@ -330,6 +358,14 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
     let cwd: string | null = null;
     let model: string | null = null;
     let lastProviderEventId: string | null = null;
+    // Token usage accumulated from per-message `usage` blocks. `freshInput` is
+    // Anthropic's cache-exclusive `input_tokens`; cache totals are tracked
+    // separately so we can both store the breakdown and price it correctly.
+    let usageFreshInput = 0;
+    let usageCompletion = 0;
+    let usageCacheCreation = 0;
+    let usageCacheRead = 0;
+    let sawUsage = false;
 
     const nextProviderSeq = (): number => {
         providerSeq += 1;
@@ -865,6 +901,17 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
                 model = entryModel;
                 if (session) session.model = entryModel;
             }
+            // Anthropic emits `usage` on each assistant message. Sum across the
+            // session; subagent transcripts live in separate files, so this
+            // never double-counts a child's tokens into its parent.
+            const usage = message && isRecord(message.usage) ? message.usage : null;
+            if (usage) {
+                sawUsage = true;
+                usageFreshInput += numberField(usage, "input_tokens") ?? 0;
+                usageCompletion += numberField(usage, "output_tokens") ?? 0;
+                usageCacheCreation += numberField(usage, "cache_creation_input_tokens") ?? 0;
+                usageCacheRead += numberField(usage, "cache_read_input_tokens") ?? 0;
+            }
             const messageContent = message?.content;
             const content = asContentBlocks(messageContent);
 
@@ -1007,6 +1054,20 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
                 hookEvents,
                 hookCommandInvocations,
                 compactions,
+                tokenUsage: sawUsage
+                    ? {
+                          // Total billed input = fresh + both cache buckets, so
+                          // estimateCost recovers fresh input by subtracting cache.
+                          promptTokens: usageFreshInput + usageCacheCreation + usageCacheRead,
+                          completionTokens: usageCompletion,
+                          cacheCreationInputTokens: usageCacheCreation,
+                          cacheReadInputTokens: usageCacheRead,
+                          estimatedTokens:
+                              usageFreshInput + usageCacheCreation + usageCacheRead + usageCompletion,
+                          model: session.model,
+                          ts: session.ended_at ?? session.started_at ?? new Date(0).toISOString(),
+                      }
+                    : null,
             };
         },
     };
@@ -1314,6 +1375,68 @@ const buildClaudeProviderStatements = (extracted: FileExtract): string[] => [
 const writeProviderEvidence = (extracted: FileExtract) =>
     queryTranscriptStatements(buildClaudeProviderStatements(extracted));
 
+const surrealOptionFloat = (value: number | null | undefined): string =>
+    value === null || value === undefined || !Number.isFinite(value)
+        ? "NONE"
+        : Number(value.toFixed(8)).toString();
+
+/**
+ * Build the `session_token_usage` UPSERT for a Claude session, priced from the
+ * transcript's own usage totals. Targets the SAME record id the session-health
+ * stage uses (`safeKeyPart(sessionId)`) so this priced row and the later
+ * health pass converge on one row - health's `IF prompt_tokens != NONE` guard
+ * preserves these real counts (and leaves the cost fields it never writes
+ * intact). Empty when the transcript carried no `usage` blocks.
+ */
+export const buildClaudeTokenUsageStatements = (extracted: FileExtract): string[] => {
+    const usage = extracted.tokenUsage;
+    if (!usage) return [];
+    const modelKey = normalizeModelName(usage.model);
+    const cost = estimateCost({
+        modelKey,
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+        cacheCreationInputTokens: usage.cacheCreationInputTokens,
+        cacheReadInputTokens: usage.cacheReadInputTokens,
+        estimatedTokens: usage.estimatedTokens,
+    });
+    const sessionId = extracted.session.id;
+    return [
+        `UPSERT ${recordRef("session_token_usage", safeKeyPart(sessionId))} MERGE ${surrealObject([
+            ["session", recordRef("session", sessionId)],
+            ["source", surrealString("claude")],
+            ["model", surrealOptionString(usage.model)],
+            ["prompt_tokens", surrealOptionInt(usage.promptTokens)],
+            ["completion_tokens", surrealOptionInt(usage.completionTokens)],
+            ["cache_creation_input_tokens", surrealOptionInt(usage.cacheCreationInputTokens)],
+            ["cache_read_input_tokens", surrealOptionInt(usage.cacheReadInputTokens)],
+            ["estimated_tokens", Math.trunc(usage.estimatedTokens).toString(10)],
+            ["transcript_bytes", "0"],
+            ["model_ref", modelKey ? recordRef("agent_model", modelKey) : "NONE"],
+            ["estimated_input_cost_usd", surrealOptionFloat(cost.inputUsd)],
+            ["estimated_output_cost_usd", surrealOptionFloat(cost.outputUsd)],
+            ["estimated_cache_creation_cost_usd", surrealOptionFloat(cost.cacheCreationUsd)],
+            ["estimated_cache_read_cost_usd", surrealOptionFloat(cost.cacheReadUsd)],
+            ["estimated_cost_usd", surrealOptionFloat(cost.totalUsd)],
+            ["pricing_source", surrealOptionString(cost.pricingSource)],
+            ["labels", surrealJsonOption({
+                source: "claude_transcript",
+                token_source: "transcript_usage",
+            })],
+            ["ts", surrealDate(usage.ts)],
+        ])};`,
+    ];
+};
+
+const writeClaudeTokenUsage = (extracted: FileExtract) => {
+    const statements = buildClaudeTokenUsageStatements(extracted);
+    return statements.length === 0
+        ? Effect.void
+        : queryTranscriptStatements(statements);
+};
+
+export { writeClaudeTokenUsage as writeTokenUsageForSubagents };
+
 interface IngestOpts {
     sinceDays: number | undefined;
     project: string | undefined;
@@ -1517,6 +1640,7 @@ export const ingestTranscripts = (
             extracted.session.raw_file = pointer;
             yield* upsertSessions([extracted.session]);
             sessions += 1;
+            yield* writeClaudeTokenUsage(extracted);
             yield* upsertTurns(extracted.turns);
             turnCount += extracted.turns.length;
             yield* writeProviderEvidence(extracted);

--- a/apps/axctl/src/share/artifact.test.ts
+++ b/apps/axctl/src/share/artifact.test.ts
@@ -36,6 +36,10 @@ describe("share artifact", () => {
         expect(isAxSessionShare(artifact)).toBe(true);
     });
 
+    it("defaults to schema v2", () => {
+        expect(AX_SESSION_SHARE_SCHEMA_VERSION).toBe(2);
+    });
+
     it("rejects unsupported schema versions", () => {
         const artifact = minimalShareArtifact({
             id: "abc123",
@@ -43,6 +47,30 @@ describe("share artifact", () => {
         });
 
         expect(isAxSessionShare({ ...artifact, schema_version: 999 })).toBe(false);
+    });
+
+    it("still accepts legacy v1 artifacts (no children field)", () => {
+        const artifact = minimalShareArtifact({ id: "abc123", source: "codex" });
+        expect(isAxSessionShare({ ...artifact, schema_version: 1 })).toBe(true);
+    });
+
+    it("accepts a v2 artifact carrying nested child shares", () => {
+        const child = minimalShareArtifact({ id: "child1", source: "codex" });
+        const parent = {
+            ...minimalShareArtifact({ id: "parent1", source: "codex" }),
+            children: [child],
+        };
+        expect(isAxSessionShare(parent)).toBe(true);
+    });
+
+    it("rejects a non-array children field", () => {
+        const artifact = minimalShareArtifact({ id: "abc123", source: "codex" });
+        expect(isAxSessionShare({ ...artifact, children: "nope" })).toBe(false);
+    });
+
+    it("rejects children that are not valid shares", () => {
+        const artifact = minimalShareArtifact({ id: "abc123", source: "codex" });
+        expect(isAxSessionShare({ ...artifact, children: [{ bogus: true }] })).toBe(false);
     });
 
     it("rejects artifacts missing derived data", () => {

--- a/apps/axctl/src/share/artifact.ts
+++ b/apps/axctl/src/share/artifact.ts
@@ -1,12 +1,16 @@
 import type { InspectTurnContentDto, SessionTokenUsageDetail, TurnTokenUsageDetail } from "@ax/lib/shared/dashboard-types";
 
-export const AX_SESSION_SHARE_SCHEMA_VERSION = 1 as const;
+export const AX_SESSION_SHARE_SCHEMA_VERSION = 2 as const;
+
+/** Schema versions a reader still accepts. v1 lacked `children`. */
+export const SUPPORTED_SHARE_SCHEMA_VERSIONS = [1, 2] as const;
+export type ShareSchemaVersion = (typeof SUPPORTED_SHARE_SCHEMA_VERSIONS)[number];
 
 export type KnownShareSource = "claude" | "codex" | "pi" | "opencode" | "cursor";
 export type ShareSource = KnownShareSource | (string & {});
 
 export interface AxSessionShare {
-    readonly schema_version: typeof AX_SESSION_SHARE_SCHEMA_VERSION;
+    readonly schema_version: ShareSchemaVersion;
     readonly exported_at: string;
     readonly ax_version: string;
     readonly session: {
@@ -41,6 +45,12 @@ export interface AxSessionShare {
         readonly applied: boolean;
         readonly rules: ReadonlyArray<string>;
     };
+    /**
+     * v2+: child subagent sessions spawned by this session, each a full
+     * (recursively redacted) share artifact. Absent/empty when the session
+     * delegated no subagents. Recursion terminates at leaf sessions.
+     */
+    readonly children?: ReadonlyArray<AxSessionShare>;
 }
 
 export interface ShareTurn {
@@ -109,7 +119,12 @@ const hasNumericStats = (value: Record<string, unknown>): boolean =>
 
 export function isAxSessionShare(value: unknown): value is AxSessionShare {
     if (!isRecord(value)) return false;
-    if (value.schema_version !== AX_SESSION_SHARE_SCHEMA_VERSION) return false;
+    if (
+        typeof value.schema_version !== "number" ||
+        !(SUPPORTED_SHARE_SCHEMA_VERSIONS as ReadonlyArray<number>).includes(value.schema_version)
+    ) {
+        return false;
+    }
     if (typeof value.exported_at !== "string") return false;
     if (typeof value.ax_version !== "string") return false;
     if (!isRecord(value.session)) return false;
@@ -126,6 +141,10 @@ export function isAxSessionShare(value: unknown): value is AxSessionShare {
     if (!isRecord(value.redactions)) return false;
     if (typeof value.redactions.applied !== "boolean") return false;
     if (!Array.isArray(value.redactions.rules)) return false;
+    if (value.children !== undefined) {
+        if (!Array.isArray(value.children)) return false;
+        if (!value.children.every((child) => isAxSessionShare(child))) return false;
+    }
     return true;
 }
 

--- a/apps/axctl/src/share/exporter.test.ts
+++ b/apps/axctl/src/share/exporter.test.ts
@@ -3,6 +3,7 @@ import {
     buildShareArtifactFromParts,
     normalizeSessionRecordRef,
 } from "./exporter.ts";
+import { minimalShareArtifact } from "./artifact.ts";
 
 describe("buildShareArtifactFromParts", () => {
     it("builds a V1 artifact from session rows", () => {
@@ -115,6 +116,49 @@ describe("buildShareArtifactFromParts", () => {
             { from: "session:abc123", to: "file:src/a.ts", label: "changed" },
             { from: "session:abc123", to: "file:src/b.ts", label: "changed" },
         ]);
+    });
+
+    const baseParts = {
+        axVersion: "0.2.0",
+        exportedAt: "2026-05-29T00:00:00.000Z",
+        overview: {
+            id: "parent1",
+            project: "ax",
+            cwd: "/Users/necmttn/Projects/ax",
+            model: "gpt-5",
+            source: "codex" as const,
+            started_at: "2026-05-29T00:00:00.000Z",
+            ended_at: "2026-05-29T00:10:00.000Z",
+        },
+        topSkills: [],
+        toolCalls: [],
+        turns: [],
+        timeline: [],
+        files: [],
+    };
+
+    it("emits a schema v2 artifact", () => {
+        const artifact = buildShareArtifactFromParts(baseParts);
+        expect(artifact.schema_version).toBe(2);
+    });
+
+    it("attaches child subagent shares when provided", () => {
+        const child = minimalShareArtifact({ id: "child1", source: "codex" });
+        const artifact = buildShareArtifactFromParts({
+            ...baseParts,
+            children: [child],
+        });
+
+        expect(artifact.children).toHaveLength(1);
+        expect(artifact.children?.[0]?.session.id).toBe("child1");
+    });
+
+    it("omits children when none were spawned", () => {
+        const artifact = buildShareArtifactFromParts(baseParts);
+        expect(artifact.children).toBeUndefined();
+
+        const empty = buildShareArtifactFromParts({ ...baseParts, children: [] });
+        expect(empty.children).toBeUndefined();
     });
 });
 

--- a/apps/axctl/src/share/exporter.ts
+++ b/apps/axctl/src/share/exporter.ts
@@ -18,6 +18,7 @@ import type {
 import { runQuery, runSingleQuery } from "@ax/lib/shared/graph-query";
 import { resolveTurnContent } from "../queries/session-turn-content.ts";
 import {
+    sessionChildrenQuery,
     sessionOverviewQuery,
     sessionShareFilesQuery,
     sessionShareTimelineQuery,
@@ -38,6 +39,7 @@ export interface ShareArtifactParts {
     readonly turns: ReadonlyArray<ShareTurn>;
     readonly timeline: ReadonlyArray<ShareEvent>;
     readonly files: ReadonlyArray<ShareFile>;
+    readonly children?: ReadonlyArray<AxSessionShare>;
 }
 
 const SESSION_ID_RE = /^[A-Za-z0-9_-]{6,80}$/;
@@ -147,6 +149,9 @@ export function buildShareArtifactFromParts(
             applied: false,
             rules: [],
         },
+        ...(parts.children && parts.children.length > 0
+            ? { children: parts.children }
+            : {}),
     };
 }
 
@@ -183,16 +188,29 @@ const attachTurnTokenUsage = (
     });
 };
 
+export interface ExportSessionShareOptions {
+    /**
+     * Record refs already materialised on the current export path. Guards
+     * against re-exporting (or cycling on) a session that appears more than
+     * once in the spawn graph. Internal - callers pass nothing.
+     */
+    readonly visited?: ReadonlySet<string>;
+}
+
 export const exportSessionShare = (
     sessionId: string,
     axVersion: string,
+    options: ExportSessionShareOptions = {},
 ): Effect.Effect<AxSessionShare | null, DbError, SurrealClient> =>
     Effect.gen(function* () {
         const recordRef = normalizeSessionRecordRef(sessionId);
         if (recordRef === null) return null;
 
+        const visited = options.visited ?? new Set<string>();
+        if (visited.has(recordRef)) return null;
+
         const params = { recordRef };
-        const [overview, topSkillsRaw, toolCallsRaw, tokenUsage, turnTokenUsageRaw, turnsRaw, timelineRaw, filesRaw, turnContent] =
+        const [overview, topSkillsRaw, toolCallsRaw, tokenUsage, turnTokenUsageRaw, turnsRaw, timelineRaw, filesRaw, childLinksRaw, turnContent] =
             yield* Effect.all([
                 runSingleQuery(sessionOverviewQuery, params),
                 runQuery(sessionTopSkillsQuery, params),
@@ -202,10 +220,26 @@ export const exportSessionShare = (
                 runQuery(sessionShareTurnsQuery, params),
                 runQuery(sessionShareTimelineQuery, params),
                 runQuery(sessionShareFilesQuery, params),
+                runQuery(sessionChildrenQuery, params),
                 resolveTurnContent(sessionId),
             ]);
 
         if (overview === null) return null;
+
+        // Recurse into spawned subagents. The visited set carries this session
+        // so a child that points back never re-expands; leaves return [].
+        const nextVisited = new Set(visited).add(recordRef);
+        const childLinks = childLinksRaw.filter(isPresent);
+        const children = (
+            yield* Effect.all(
+                childLinks.map((link) =>
+                    exportSessionShare(String(link.session_id), axVersion, {
+                        visited: nextVisited,
+                    }),
+                ),
+                { concurrency: "unbounded" },
+            )
+        ).filter(isPresent);
 
         return buildShareArtifactFromParts({
             axVersion,
@@ -220,5 +254,6 @@ export const exportSessionShare = (
             ),
             timeline: timelineRaw.filter(isPresent),
             files: filesRaw.filter(isPresent),
+            children,
         });
     });

--- a/apps/axctl/src/share/format.test.ts
+++ b/apps/axctl/src/share/format.test.ts
@@ -25,6 +25,68 @@ describe("share formatter", () => {
         expect(text).not.toContain("secret/unlisted Gist");
     });
 
+    it("renders whole-trace cost and subagent count when present", () => {
+        const child = {
+            ...minimalShareArtifact({ id: "child1", source: "codex" }),
+            token_usage: {
+                model: "gpt-5",
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                estimated_tokens: 0,
+                estimated_cost_usd: 0.5,
+                pricing_source: "test",
+            },
+        };
+        const artifact = {
+            ...minimalShareArtifact({ id: "abc123", source: "codex" }),
+            token_usage: {
+                model: "gpt-5",
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                estimated_tokens: 0,
+                estimated_cost_usd: 1.25,
+                pricing_source: "test",
+            },
+            children: [child],
+        };
+
+        const text = formatSharePreview(artifact);
+        expect(text).toContain("subagents: 1");
+        expect(text).toContain("cost: $1.75");
+    });
+
+    it("falls back to estimated tokens when cost is unavailable", () => {
+        const artifact = {
+            ...minimalShareArtifact({ id: "abc123", source: "claude" }),
+            token_usage: {
+                model: "claude-opus-4-8",
+                prompt_tokens: null,
+                completion_tokens: null,
+                cache_creation_input_tokens: null,
+                cache_read_input_tokens: null,
+                estimated_tokens: 921199,
+                estimated_cost_usd: null,
+                pricing_source: null,
+            },
+        };
+
+        const text = formatSharePreview(artifact);
+        expect(text).toContain("tokens: ~921,199 (cost unavailable)");
+        expect(text).not.toContain("cost:");
+    });
+
+    it("omits cost and subagents lines when absent", () => {
+        const text = formatSharePreview(
+            minimalShareArtifact({ id: "abc123", source: "codex" }),
+        );
+        expect(text).not.toContain("cost:");
+        expect(text).not.toContain("subagents:");
+    });
+
     it("prints the share URL after publishing", () => {
         const text = formatShareSuccess({ owner: "necmttn", gistId: "abc123" });
 

--- a/apps/axctl/src/share/format.ts
+++ b/apps/axctl/src/share/format.ts
@@ -1,6 +1,37 @@
 import type { AxSessionShare } from "./artifact.ts";
 import { type GistRef, shareUrlForGist } from "./gist.ts";
 
+const formatUsd = (value: number): string =>
+    value >= 0.01 ? `$${value.toFixed(2)}` : `$${value.toFixed(4)}`;
+
+/**
+ * Sum a per-session token_usage field across this session and every spawned
+ * subagent, recursively. Returns null when no session in the tree carries it.
+ */
+const sumTrace = (
+    artifact: AxSessionShare,
+    read: (usage: NonNullable<AxSessionShare["token_usage"]>) => number | null | undefined,
+): number | null => {
+    const own = artifact.token_usage ? read(artifact.token_usage) ?? null : null;
+    const childValues = (artifact.children ?? []).map((child) => sumTrace(child, read));
+    const values = [own, ...childValues].filter((v): v is number => v !== null);
+    if (values.length === 0) return null;
+    return values.reduce((sum, v) => sum + v, 0);
+};
+
+/**
+ * Whole-trace estimated cost: this session plus every spawned subagent,
+ * recursively. Returns null when no session in the tree carries a cost.
+ */
+export function totalCostUsd(artifact: AxSessionShare): number | null {
+    return sumTrace(artifact, (u) => u.estimated_cost_usd);
+}
+
+/** Whole-trace estimated token count (cost-independent usage fallback). */
+export function totalEstimatedTokens(artifact: AxSessionShare): number | null {
+    return sumTrace(artifact, (u) => u.estimated_tokens);
+}
+
 export function formatSharePreview(
     artifact: AxSessionShare,
     options: { readonly public?: boolean } = {},
@@ -21,6 +52,21 @@ export function formatSharePreview(
     lines.push(
         `stats: turns: ${artifact.stats.turns}, tool_calls: ${artifact.stats.tool_calls}, files_changed: ${artifact.stats.files_changed}, skills_used: ${artifact.stats.skills_used}, failures: ${artifact.stats.failures}`,
     );
+
+    const subagentCount = artifact.children?.length ?? 0;
+    if (subagentCount > 0) {
+        lines.push(`subagents: ${subagentCount}`);
+    }
+
+    const cost = totalCostUsd(artifact);
+    if (cost !== null) {
+        lines.push(`cost: ${formatUsd(cost)}`);
+    } else {
+        const tokens = totalEstimatedTokens(artifact);
+        if (tokens !== null) {
+            lines.push(`tokens: ~${tokens.toLocaleString("en-US")} (cost unavailable)`);
+        }
+    }
 
     lines.push(
         artifact.redactions.applied

--- a/apps/site/app/components/landing-v2/dashboard-preview.tsx
+++ b/apps/site/app/components/landing-v2/dashboard-preview.tsx
@@ -17,13 +17,15 @@ const AGENT_PROMPT = `Set up ax for me, end to end. ax is a local agent-experien
 
 1. INSTALL - run \`${INSTALL_CMD}\` to install the ax CLI. Reference: ${DOCS_URL}
 
-2. VERIFY - run \`ax doctor\`. If anything isn't ok, diagnose and fix it, then re-run until it is.
+2. INGEST MY HISTORY - first run \`ax ingest --dry-run\` and tell me, in plain words, how long a full backfill will take. Then start the ingest in the BACKGROUND so we can keep working: run \`ax ingest\` as a background job with AX_PROGRESS=plain, and watch its output for progress and completion. Tell me I can watch it fill live in the dashboard - run \`ax serve\` and open http://127.0.0.1:8520. When the ingest finishes, summarize what landed: total sessions, turns, and the top skills/tools I actually use. Then continue with the steps below.
 
-3. LABEL what ax can't classify - run \`ax skills classify\`. It writes one \`.ax/tasks/classify-<skill>.md\` brief per skill I use but ax can't role-tag. For each brief: read the skill, decide its role(s), and fill the YAML at the bottom (\`primary_role:\` is required; \`secondary_roles\`, \`confidence\`, \`rationale\` are optional). Run \`ax roles\` to see labels already in use. Then run \`ax skills lint\` to apply them. If it says "no unclassified skills", that's fine.
+3. VERIFY - run \`ax doctor\`. If anything isn't ok, diagnose and fix it, then re-run until it is.
 
-4. SHOW me the result - run \`ax skills weighted\` and \`ax skills config\`. Tell me which skills you labeled and why, and flag anything ax marked orphan or out-of-scope.
+4. LABEL what ax can't classify - run \`ax skills classify\`. It writes one \`.ax/tasks/classify-<skill>.md\` brief per skill I use but ax can't role-tag. For each brief: read the skill, decide its role(s), and fill the YAML at the bottom (\`primary_role:\` is required; \`secondary_roles\`, \`confidence\`, \`rationale\` are optional). Run \`ax roles\` to see labels already in use. Then run \`ax skills lint\` to apply them. If it says "no unclassified skills", that's fine.
 
-5. GIVE ME A NEXT STEP - recommend 1-2 under-used skills you'd reach for based on what you saw, then end with a concrete CTA: the exact command or prompt I should run next, and what outcome it will produce.`;
+5. SHOW me the result - run \`ax skills weighted\` and \`ax skills config\`. Tell me which skills you labeled and why, and flag anything ax marked orphan or out-of-scope.
+
+6. GIVE ME A NEXT STEP - recommend 1-2 under-used skills you'd reach for based on what you saw, then end with a concrete CTA: the exact command or prompt I should run next, and what outcome it will produce.`;
 
 export function DashboardPreview() {
   const [copiedPrompt, setCopiedPrompt] = useState(false);

--- a/docs/superpowers/specs/2026-06-07-agent-driven-first-ingest-design.md
+++ b/docs/superpowers/specs/2026-06-07-agent-driven-first-ingest-design.md
@@ -1,4 +1,4 @@
-# Agent-driven first ingest
+# Agent-driven first ingest + Paxel-grade progress
 
 **Date:** 2026-06-07
 **Status:** design, pending review
@@ -19,29 +19,43 @@ multi-minute full scan.
 
 Two deeper issues this exposes:
 
-1. **Install blocks on a long process.** First-run ingest can take minutes with
-   no ETA and no escape. Users drop off staring at a frozen terminal.
-2. **No onboarding narration.** The long step has no "here's how long, go look at
-   the dashboard, here's what we found" arc.
+1. **Install blocks on a long, opaque process.** First-run ingest takes minutes
+   with no ETA and no escape. Users drop off staring at a frozen terminal.
+2. **The progress we do show is coarse.** Compared to the reference (YC Paxel's
+   first-run analysis), ax lacks an up-front ETA, per-item metering, throughput
+   (it/s), time-remaining, and a dashboard-mirrored live view.
+
+### Reference: YC Paxel first run (the bar to clear)
+
+- Counts sources first, prints **per-source + total ETA**, gates on `Continue?`
+- Numbered pipeline steps `[7/17]`
+- Live bar: `⠧ [7/17] Summarizing 115/287  1.8 it/s  ██▊░ 11%  01:17 elapsed · ~10:04 left`
+- Local cache → reruns skip completed work
 
 ## Goal
 
 Install/setup finishes fast. The onboarding **agent** drives ingest as a narrated
-step: show an ETA, run it in the background, point the user at the live dashboard,
-then summarize takeaways. `ax update` stops ingesting entirely (schema still
-re-applies, which is correct).
+step: show an ETA, run it in the background, point the user at a **live dashboard
+that renders a Paxel-grade progress bar**, then summarize takeaways. `ax update`
+stops ingesting (schema still re-applies, which is correct). The same rich
+progress renders in every context - foreground TUI, plain log (agent-tailed), and
+the dashboard.
 
 ## Decisions
 
-- **Orchestration: agent-driven via the brief.** The CLI provides primitives; the
+- **Orchestration: agent-driven via the brief.** CLI provides primitives; the
   pasted onboarding prompt sequences them and narrates.
 - **ETA: quick sample calibration, always.** No prior-run data exists on the run
   that matters most (first run), so estimate on *this machine* by sampling.
 - **Background: the agent's own backgrounding.** No new `--background` flag, no
   status file. The agent launches `ax ingest` with `Bash(run_in_background)`,
   tails the log for progress + exit, and summarizes via existing queries.
-- **Remove inline ingest from `cmdSetup` entirely** (not gate it). Absence of the
-  call fixes the update bug directly; no runtime DB check needed.
+- **Remove inline ingest from `cmdSetup` entirely** (not gate it). Revert the
+  `dbHasSessions` probe added earlier in this branch - dead code once the call is
+  gone.
+- **Upgrade progress to Paxel-grade and mirror it everywhere** - item-level
+  metering (current/total), it/s, ETA-remaining, numbered steps; rendered by the
+  TTY TUI, the plain log, and the `ax serve` dashboard from one shared model.
 
 ## Components
 
@@ -52,72 +66,115 @@ re-applies, which is correct).
 Setup becomes: agent-skills install → (schema/daemon already done by `cmdInstall`)
 → `cmdDoctor` → render brief. The step-2 ingest block is removed.
 
-Safety net for users who never paste the brief into an agent: print a one-line
-next-step instead of running ingest -
+Safety net for users who never paste the brief into an agent - print, don't run:
 
 ```
   ingest: not run yet. populate the graph with:
-          ax ingest            # full backfill (see ETA: ax ingest --dry-run)
-          ...or the 04:00 daily sync will fill it overnight.
+          ax ingest --dry-run   # see ETA
+          ax ingest             # full backfill (watch live in ax serve)
+          ...or the 04:00 daily sync fills it overnight.
 ```
 
-The watcher (`--since=1` deltas) and the daily full ETL cron already exist as the
-non-agent fallbacks; no new daemon work.
+Watcher (`--since=1` deltas) + daily full ETL cron are the non-agent fallbacks;
+no new daemon work. **Revert** `dbHasSessions` + the populated-DB gate.
 
-**Revert** the `dbHasSessions` probe + populated-DB gate added earlier in this
-branch - dead once the inline ingest call is gone.
+### 2. Progress model upgrade (shared core)
 
-### 2. `ax ingest --dry-run [--json]` - ETA via sample calibration
+`apps/axctl/src/cli/progress.ts` (+ `progress-tui.tsx`), `ingest/stage/*`
 
-New flag on the existing `ingest` command (`apps/axctl/src/cli/index.ts` +
-`apps/axctl/src/ingest/run.ts`).
+Today `ProgressReporter` carries `update(stage, counts)` with arbitrary counts and
+already guards against throughput noise on sub-threshold stages. Extend the model
+so every render target can show the Paxel line:
 
-Behaviour:
+- **Per-stage total + current.** Stages declare a `total` when known (source
+  stages: counted files; derive stages: a cheap `count()` at stage start) and
+  report `current` via `update`. Stages with no meaningful total degrade to the
+  current spinner (no fake %).
+- **Throughput + ETA-remaining.** Reporter derives `it/s` from Δcurrent/Δt
+  (reusing the existing noise floor) and `etaLeftMs` from
+  `(total − current) / rate`, aggregated across remaining stages weighted by their
+  declared totals. Overall `[n/N]` from stage index / stage count.
+- **One snapshot type** consumed by all three renderers (below), so the bar is
+  identical everywhere: `⠧ [7/17] Summarizing 115/287  1.8 it/s  ██▊ 11%  01:17 · ~10:04 left`.
 
-1. **Count pending sources** cheaply by globbing the per-harness session stores
+Render targets:
+- **TTY TUI** (`progress-tui.tsx`) - foreground bar.
+- **Plain mode** (`AX_PROGRESS=plain`) - same fields, one line per tick/stage,
+  newline-delimited so an agent tailing the log parses progress + completion.
+- **Dashboard** - see §4.
+
+### 3. `ax ingest --dry-run [--json]` - ETA via sample calibration
+
+New flag on the `ingest` command (`apps/axctl/src/cli/index.ts` + `ingest/run.ts`).
+
+1. **Count pending sources** cheaply by globbing per-harness stores
    (`~/.claude/projects/`, `~/.codex/sessions/`, `~/.pi/agent/sessions/`,
-   OpenCode + Cursor SQLite). No DB writes, no parsing - file/row counts only.
+   OpenCode + Cursor SQLite row counts). No DB writes, no transcript parsing.
 2. **Sample-calibrate (always):** ingest a small real slice (~30 sessions) through
-   the normal pipeline, timed. Upserts are idempotent, so the slice is reused by
-   the subsequent real run - no wasted work. Derive items/sec.
+   the normal pipeline, timed. Idempotent upserts → the slice is reused by the
+   real run, no wasted work. Derive items/sec.
 3. **Extrapolate** to the full counted total → `etaSeconds`.
-4. Print a human summary; `--json` emits:
+4. Human output mirrors Paxel's up-front estimate (per-source + total):
+   ```
+   ax ingest --dry-run
+     counting sources...
+       claude   1,180 sessions
+       codex      60 sessions
+       cursor      0
+     calibrating... sampled 30 in 2.1s  (14.3/s)
+     total: 1,240 sessions, ~38k turns   ETA ~3m30s on this machine
+     run it: ax ingest   (watch live in ax serve → http://127.0.0.1:8520)
+   ```
+   `--json`:
    ```json
-   { "sources": { "sessions": 1240, "turns": 38000, "...": 0 },
-     "sampled": { "items": 30, "seconds": 2.1 },
-     "ratePerSec": 14.3, "etaSeconds": 210 }
+   { "sources": { "claude": 1180, "codex": 60, "cursor": 0, "sessionsTotal": 1240, "turnsTotal": 38000 },
+     "sampled": { "items": 30, "seconds": 2.1 }, "ratePerSec": 14.3, "etaSeconds": 210 }
    ```
    The agent reads `--json` to narrate ETA and to compute live progress while
-   polling (current DB session count ÷ `sources.sessions`).
+   polling (current DB session count ÷ `sources.sessionsTotal`).
 
-Human output:
+### 4. Dashboard mirror - `stage_progress` stream event
 
+`apps/axctl/src/ingest/stream-events.ts`, `dashboard/ingest-stream.ts`, web UI
+
+Stream events are currently coarse (`run_started`, `stage_started`,
+`stage_finished`, `run_finished`). Add:
+
+```ts
+| { kind: "stage_progress"; runId: string; stage: string;
+    current: number; total: number; ratePerSec: number;
+    stageIndex: number; stageCount: number; etaLeftMs: number }
 ```
-ax ingest --dry-run
-  counting sources... 1,240 sessions, 38k turns
-  calibrating... sampled 30 in 2.1s
-  ETA: ~3m30s on this machine
-  run it: ax ingest   (watch live in ax serve → http://127.0.0.1:8520)
-```
 
-### 3. Onboarding brief - new leading step
+The progress reporter publishes it through the existing `IngestStreamBus` →
+durable stream `ingest:<runId>`; the Live tab renders the same bar from the same
+fields. Subscribe-from-`-1` rehydration is unchanged.
+
+**Caveat (documented, not solved here):** server-forked ingest (POST /api/ingest)
+only works running from source; the compiled binary returns 503 (native lmdb).
+For installed/compiled users the agent backgrounds the **CLI** ingest, which does
+*not* publish to the serve process's in-memory bus - so the dashboard reflects the
+**growing graph** (session counts climbing), while the rich live bar appears in
+the agent-tailed terminal log. Unifying CLI→dashboard progress for compiled builds
+is out of scope (would need a file/IPC progress sink).
+
+### 5. Onboarding brief - new leading step
 
 `packages/lib/src/agent-onboarding.ts` (`AGENT_ONBOARDING_PROMPT`). Prepend:
 
 ```
 1. INGEST MY HISTORY -
    - Run `ax ingest --dry-run` and tell me the ETA in plain words.
-   - Then start the ingest in the BACKGROUND (so we can keep talking):
-     run `ax ingest` (set AX_PROGRESS=plain) as a background job.
+   - Start the ingest in the BACKGROUND (so we can keep talking):
+     run `ax ingest` with AX_PROGRESS=plain as a background job.
    - Tell me to watch it fill live: `ax serve` → http://127.0.0.1:8520
-   - Poll the background job's progress; when it finishes, summarize what
-     landed: total sessions, turns, and the top skills/tools I actually use.
+   - Poll the background job; report milestones; when it finishes, summarize
+     what landed: total sessions, turns, and the top skills/tools I use.
    - THEN continue with verify / label / show below.
 ```
 
-Existing steps (verify → label → show → next-step) renumber after it. The brief
-stays the single source of truth (CLI `ax setup --agent-prompt`, install.sh, site
-copy button all consume it).
+Existing steps renumber after it. The brief stays the single source of truth
+(`ax setup --agent-prompt`, install.sh, site copy button).
 
 ## Data flow
 
@@ -125,47 +182,47 @@ copy button all consume it).
 ax update / ax setup
   └─ cmdSetup: skills + doctor + render brief   (fast, no ingest)
        └─ user pastes brief into Claude Code / Codex
-            └─ agent: ax ingest --dry-run --json   → ETA + counts
+            └─ agent: ax ingest --dry-run --json     → ETA + per-source counts
                agent: Bash(run_in_background) AX_PROGRESS=plain ax ingest
-               agent: "watch ax serve → :8520"
-               agent: poll log / session count vs total
+                  → plain log: ⠧ [7/17] Summarizing 115/287 1.8 it/s … ~10:04 left
+               agent: "watch ax serve → :8520"  (graph fills; bar if source-run)
+               agent: poll log / session count vs total → milestones
                agent (on exit): ax skills weighted → takeaways summary
                  → proceeds to verify / label / show
 ```
 
-`ax serve`'s dashboard reflects the **growing graph** (session counts climbing as
-the detached CLI commits rows) - not a live progress bar from that process. The
-agent owns the numeric progress via the dry-run total + log tail.
-
 ## Error handling
 
-- **Dry-run, no sources:** print "nothing to ingest yet" and ETA 0; agent skips
-  the background run.
-- **Sample fails** (e.g. one bad transcript): catch, fall back to a coarse band
-  ("a few minutes") rather than aborting the dry-run; real ingest surfaces the
-  per-item error as today.
-- **Background ingest exits non-zero:** the agent sees it in the tailed log /
-  task exit and reports "ingest exited N - run `ax ingest` manually", then still
-  continues onboarding.
-- **`ax update` path:** unchanged except no ingest. `cmdInstall` still re-applies
-  schema (correct - migrations land on update).
+- **Dry-run, no sources:** "nothing to ingest yet", ETA 0; agent skips the run.
+- **Sample fails** (one bad transcript): catch, fall back to a coarse band
+  ("a few minutes"); real ingest surfaces per-item errors as today.
+- **Stage with unknown total:** spinner only, no fabricated %/ETA.
+- **Background ingest exits non-zero:** agent sees it in the tailed log / task
+  exit, reports "ingest exited N - run `ax ingest` manually", continues onboarding.
+- **`ax update`:** unchanged except no ingest; `cmdInstall` still re-applies schema.
 
 ## Testing
 
-- `cmdSetup` no longer spawns `ingest` (assert no ingest spawn; brief rendered;
-  next-step line present). Update existing `install.test.ts`.
-- `ax ingest --dry-run --json` shape: counts present, `etaSeconds` finite,
-  `ratePerSec > 0` given a sampled slice; ETA 0 with empty sources.
-- Source-counting helpers unit-tested per harness against fixture dirs (cheap
-  globs / row counts, no DB).
-- Sample calibration: with a fixture of N sessions and a stubbed clock, rate and
-  extrapolation math are deterministic.
+- `cmdSetup` no longer spawns `ingest` (assert no spawn; brief + next-step line
+  present). Update `install.test.ts`.
+- Progress model: given stage totals + a stubbed clock, `it/s`, `%`, `etaLeftMs`,
+  `[n/N]` are deterministic; sub-threshold stages emit no fake throughput.
+- One snapshot → identical fields across TUI / plain / `stage_progress` event
+  (assert the serializer, not three renderers).
+- `ax ingest --dry-run --json` shape: per-source counts, finite `etaSeconds`,
+  `ratePerSec > 0` after a sampled slice; ETA 0 on empty sources.
+- Source-counting helpers per harness against fixture dirs (cheap globs / row
+  counts, no DB).
 
 ## Out of scope
 
-- `ax ingest --background` / status-file / `ax ingest status` (agent backgrounds
-  it instead).
-- Server-forked live-progress onboarding (`ax serve` POST /api/ingest) - excluded
-  because the compiled binary returns 503 (native lmdb can't bundle).
-- Persisting throughput across runs - the chosen flow re-samples each dry-run;
-  the case that matters (first run) has no history anyway.
+- **Source/repo selection menu** + `Continue? [Y/n]` gate (Paxel has them) - the
+  agent narrates the ETA and proceeds; `ingest here` already scopes. Defer.
+- `ax ingest --background` / status file / `ax ingest status` - agent backgrounds
+  it instead.
+- Unifying compiled-binary CLI ingest progress into the dashboard (needs a
+  file/IPC progress sink; §4 caveat).
+- Persisting throughput across runs - re-sample each dry-run; the case that
+  matters (first run) has no history.
+- Cache/"skipped N completed" surfacing - idempotent upserts already no-op;
+  surfacing them as skips is a later polish.

--- a/docs/superpowers/specs/2026-06-07-agent-driven-first-ingest-design.md
+++ b/docs/superpowers/specs/2026-06-07-agent-driven-first-ingest-design.md
@@ -1,0 +1,171 @@
+# Agent-driven first ingest
+
+**Date:** 2026-06-07
+**Status:** design, pending review
+
+## Problem
+
+`ax update` re-runs a full backfill ingest. Flow:
+
+```
+ax update → install.sh (AXCTL_VERSION=latest)
+  → axctl install → cmdSetup({fromInstall}) → spawnSync("ingest")  # full, no --since
+```
+
+`cmdSetup` always runs a **full** `ax ingest` inline. Correct on a fresh install,
+wrong on update: the DB is already populated, the watcher keeps it incremental,
+and the daily 04:00 ETL cron does full backfills. Update fires a redundant
+multi-minute full scan.
+
+Two deeper issues this exposes:
+
+1. **Install blocks on a long process.** First-run ingest can take minutes with
+   no ETA and no escape. Users drop off staring at a frozen terminal.
+2. **No onboarding narration.** The long step has no "here's how long, go look at
+   the dashboard, here's what we found" arc.
+
+## Goal
+
+Install/setup finishes fast. The onboarding **agent** drives ingest as a narrated
+step: show an ETA, run it in the background, point the user at the live dashboard,
+then summarize takeaways. `ax update` stops ingesting entirely (schema still
+re-applies, which is correct).
+
+## Decisions
+
+- **Orchestration: agent-driven via the brief.** The CLI provides primitives; the
+  pasted onboarding prompt sequences them and narrates.
+- **ETA: quick sample calibration, always.** No prior-run data exists on the run
+  that matters most (first run), so estimate on *this machine* by sampling.
+- **Background: the agent's own backgrounding.** No new `--background` flag, no
+  status file. The agent launches `ax ingest` with `Bash(run_in_background)`,
+  tails the log for progress + exit, and summarizes via existing queries.
+- **Remove inline ingest from `cmdSetup` entirely** (not gate it). Absence of the
+  call fixes the update bug directly; no runtime DB check needed.
+
+## Components
+
+### 1. `cmdSetup` - drop inline ingest
+
+`apps/axctl/src/cli/install.ts`
+
+Setup becomes: agent-skills install → (schema/daemon already done by `cmdInstall`)
+→ `cmdDoctor` → render brief. The step-2 ingest block is removed.
+
+Safety net for users who never paste the brief into an agent: print a one-line
+next-step instead of running ingest -
+
+```
+  ingest: not run yet. populate the graph with:
+          ax ingest            # full backfill (see ETA: ax ingest --dry-run)
+          ...or the 04:00 daily sync will fill it overnight.
+```
+
+The watcher (`--since=1` deltas) and the daily full ETL cron already exist as the
+non-agent fallbacks; no new daemon work.
+
+**Revert** the `dbHasSessions` probe + populated-DB gate added earlier in this
+branch - dead once the inline ingest call is gone.
+
+### 2. `ax ingest --dry-run [--json]` - ETA via sample calibration
+
+New flag on the existing `ingest` command (`apps/axctl/src/cli/index.ts` +
+`apps/axctl/src/ingest/run.ts`).
+
+Behaviour:
+
+1. **Count pending sources** cheaply by globbing the per-harness session stores
+   (`~/.claude/projects/`, `~/.codex/sessions/`, `~/.pi/agent/sessions/`,
+   OpenCode + Cursor SQLite). No DB writes, no parsing - file/row counts only.
+2. **Sample-calibrate (always):** ingest a small real slice (~30 sessions) through
+   the normal pipeline, timed. Upserts are idempotent, so the slice is reused by
+   the subsequent real run - no wasted work. Derive items/sec.
+3. **Extrapolate** to the full counted total → `etaSeconds`.
+4. Print a human summary; `--json` emits:
+   ```json
+   { "sources": { "sessions": 1240, "turns": 38000, "...": 0 },
+     "sampled": { "items": 30, "seconds": 2.1 },
+     "ratePerSec": 14.3, "etaSeconds": 210 }
+   ```
+   The agent reads `--json` to narrate ETA and to compute live progress while
+   polling (current DB session count ÷ `sources.sessions`).
+
+Human output:
+
+```
+ax ingest --dry-run
+  counting sources... 1,240 sessions, 38k turns
+  calibrating... sampled 30 in 2.1s
+  ETA: ~3m30s on this machine
+  run it: ax ingest   (watch live in ax serve → http://127.0.0.1:8520)
+```
+
+### 3. Onboarding brief - new leading step
+
+`packages/lib/src/agent-onboarding.ts` (`AGENT_ONBOARDING_PROMPT`). Prepend:
+
+```
+1. INGEST MY HISTORY -
+   - Run `ax ingest --dry-run` and tell me the ETA in plain words.
+   - Then start the ingest in the BACKGROUND (so we can keep talking):
+     run `ax ingest` (set AX_PROGRESS=plain) as a background job.
+   - Tell me to watch it fill live: `ax serve` → http://127.0.0.1:8520
+   - Poll the background job's progress; when it finishes, summarize what
+     landed: total sessions, turns, and the top skills/tools I actually use.
+   - THEN continue with verify / label / show below.
+```
+
+Existing steps (verify → label → show → next-step) renumber after it. The brief
+stays the single source of truth (CLI `ax setup --agent-prompt`, install.sh, site
+copy button all consume it).
+
+## Data flow
+
+```
+ax update / ax setup
+  └─ cmdSetup: skills + doctor + render brief   (fast, no ingest)
+       └─ user pastes brief into Claude Code / Codex
+            └─ agent: ax ingest --dry-run --json   → ETA + counts
+               agent: Bash(run_in_background) AX_PROGRESS=plain ax ingest
+               agent: "watch ax serve → :8520"
+               agent: poll log / session count vs total
+               agent (on exit): ax skills weighted → takeaways summary
+                 → proceeds to verify / label / show
+```
+
+`ax serve`'s dashboard reflects the **growing graph** (session counts climbing as
+the detached CLI commits rows) - not a live progress bar from that process. The
+agent owns the numeric progress via the dry-run total + log tail.
+
+## Error handling
+
+- **Dry-run, no sources:** print "nothing to ingest yet" and ETA 0; agent skips
+  the background run.
+- **Sample fails** (e.g. one bad transcript): catch, fall back to a coarse band
+  ("a few minutes") rather than aborting the dry-run; real ingest surfaces the
+  per-item error as today.
+- **Background ingest exits non-zero:** the agent sees it in the tailed log /
+  task exit and reports "ingest exited N - run `ax ingest` manually", then still
+  continues onboarding.
+- **`ax update` path:** unchanged except no ingest. `cmdInstall` still re-applies
+  schema (correct - migrations land on update).
+
+## Testing
+
+- `cmdSetup` no longer spawns `ingest` (assert no ingest spawn; brief rendered;
+  next-step line present). Update existing `install.test.ts`.
+- `ax ingest --dry-run --json` shape: counts present, `etaSeconds` finite,
+  `ratePerSec > 0` given a sampled slice; ETA 0 with empty sources.
+- Source-counting helpers unit-tested per harness against fixture dirs (cheap
+  globs / row counts, no DB).
+- Sample calibration: with a fixture of N sessions and a stubbed clock, rate and
+  extrapolation math are deterministic.
+
+## Out of scope
+
+- `ax ingest --background` / status-file / `ax ingest status` (agent backgrounds
+  it instead).
+- Server-forked live-progress onboarding (`ax serve` POST /api/ingest) - excluded
+  because the compiled binary returns 503 (native lmdb can't bundle).
+- Persisting throughput across runs - the chosen flow re-samples each dry-run;
+  the case that matters (first run) has no history anyway.

--- a/packages/lib/src/agent-onboarding.ts
+++ b/packages/lib/src/agent-onboarding.ts
@@ -2,21 +2,23 @@
  * The "give this to your agent" onboarding prompt - ax's parallel to
  * effect.solutions' "Copy Agent Instructions". Single source of truth consumed
  * by the CLI (`ax setup [--agent-prompt]`), install.sh (via the binary), and the
- * landing site's copy button. Drives the agent through verify -> LABEL (the
- * classify/lint loop) -> explore.
+ * landing site's copy button. Drives the agent through ingest -> verify -> LABEL
+ * (the classify/lint loop) -> explore.
  */
 
 /** The raw prompt text the user pastes into Claude Code / Codex. */
 export const AGENT_ONBOARDING_PROMPT = [
     "Set up ax for me. ax is my local agent-experience graph over my Claude Code + Codex history. Do this end to end:",
     "",
-    "1. VERIFY - run `ax doctor`. If anything isn't ok, diagnose and fix it, then re-run until it is.",
+    "1. INGEST MY HISTORY - first run `ax ingest --dry-run` and tell me, in plain words, how long a full backfill will take. Then start the ingest in the BACKGROUND so we can keep working: run `ax ingest` as a background job with AX_PROGRESS=plain, and watch its output for progress and completion. Tell me I can watch it fill live in the dashboard - run `ax serve` and open http://127.0.0.1:8520. When the ingest finishes, summarize what landed: total sessions, turns, and the top skills/tools I actually use. Then continue with the steps below.",
     "",
-    "2. LABEL what ax can't classify - run `ax skills classify`. It writes one `.ax/tasks/classify-<skill>.md` brief per skill I use but ax can't role-tag. For each brief: read the skill, decide its role(s), and fill the YAML at the bottom (`primary_role:` is required; `secondary_roles`, `confidence`, `rationale` are optional). Run `ax roles` to see labels already in use. Then run `ax skills lint` to apply them. If it says \"no unclassified skills\", that's fine - nothing to label yet.",
+    "2. VERIFY - run `ax doctor`. If anything isn't ok, diagnose and fix it, then re-run until it is.",
     "",
-    "3. SHOW me the result - run `ax skills weighted` (usage x role ranking) and `ax skills config` (lifecycle view). Tell me which skills you labeled and why, and flag anything ax marked orphan or out-of-scope.",
+    "3. LABEL what ax can't classify - run `ax skills classify`. It writes one `.ax/tasks/classify-<skill>.md` brief per skill I use but ax can't role-tag. For each brief: read the skill, decide its role(s), and fill the YAML at the bottom (`primary_role:` is required; `secondary_roles`, `confidence`, `rationale` are optional). Run `ax roles` to see labels already in use. Then run `ax skills lint` to apply them. If it says \"no unclassified skills\", that's fine - nothing to label yet.",
     "",
-    "4. GIVE ME A NEXT STEP - recommend 1-2 under-used skills you'd reach for based on what you saw, then end with a concrete CTA: the exact command or prompt I should run next, and what outcome it will produce.",
+    "4. SHOW me the result - run `ax skills weighted` (usage x role ranking) and `ax skills config` (lifecycle view). Tell me which skills you labeled and why, and flag anything ax marked orphan or out-of-scope.",
+    "",
+    "5. GIVE ME A NEXT STEP - recommend 1-2 under-used skills you'd reach for based on what you saw, then end with a concrete CTA: the exact command or prompt I should run next, and what outcome it will produce.",
 ].join("\n");
 
 /** Prompt wrapped with a short human-facing header for terminal output. */


### PR DESCRIPTION
Fixes #145.

## Problem
`ax share` flattened subagent-driven sessions (schema v1 had no `children`) and the preview never rendered cost. Investigating the cost gap surfaced a second root cause: **Claude sessions were never priced at all**.

## Changes

### Schema v2 — subagent children
- `AxSessionShare` gains a recursive `children` field. `isAxSessionShare` accepts v1 **and** v2, so previously-published gists still validate.
- `exportSessionShare` fetches the `spawned` children edge and recurses per child (cycle-guarded via a `visited` set). Redaction's deep-walk already scrubs nested child turns.

### Cost rendering
- `formatSharePreview` now shows **whole-trace cost** (session + all subagents, recursive) and a `subagents:` count. Falls back to `tokens: ~N (cost unavailable)` when no price exists.

### Claude pricing (the data gap behind the missing cost)
- Codex/Pi wrote their own priced `session_token_usage`; Claude relied on `session-health.ts`, which **never computed cost** and only got token counts from the usually-absent `~/.claude/usage-data` files.
- Every Claude assistant message carries `message.usage`. The transcript extractor now sums it (cache-inclusive prompt total to match `estimateCost`), prices via the built-in catalog, and writes `session_token_usage` at the **same record id** `session-health` uses — whose `IF prompt_tokens != NONE` guard preserves the real counts and leaves cost intact.
- Same writer wired into the subagent ingest path.

## Verification
End-to-end on session `a13f9192`:
- parent **\$39.34**, children **\$0.28** / **\$0.13**, preview **cost: \$39.76**, `pricing_source: built_in_catalog_2026-05-29`
- cost persists across a `session-health` re-run
- unknown models → `cost: NONE` but tokens still recorded

**Tests:** 570 ingest + 34 share pass; typecheck clean. New tests cover usage summation, cache-inclusive prompt totals, priced/unpriced/no-usage statement builds, schema-v2 validation, recursive children export, and whole-trace cost rendering.

## Migration
New transcripts price automatically. Existing rows backfill once with `AX_REDERIVE_CLAUDE=1` (parents) / `AX_REDERIVE_SUBAGENTS=1` (children).

🤖 Generated with [Claude Code](https://claude.com/claude-code)