### PR TITLE
feat(share): render tool arguments in shared transcripts

### DIFF
--- a/apps/axctl/src/queries/session-detail.ts
+++ b/apps/axctl/src/queries/session-detail.ts
@@ -286,6 +286,7 @@ SELECT
     name,
     command_norm,
     command_text,
+    input_json,
     output_excerpt,
     has_error
 FROM tool_call
@@ -509,6 +510,8 @@ export interface ShareTurnToolCall {
     readonly seq: number;
     readonly name: string;
     readonly command: string | null;
+    /** JSON-encoded tool input/arguments, as recorded. */
+    readonly input_json: string | null;
     readonly output: string | null;
     readonly has_error: boolean;
 }
@@ -528,6 +531,7 @@ export const sessionShareTurnToolCallsQuery = defineQuery<
             seq: numericField(raw, "seq"),
             name,
             command: stringField(raw, "command_norm") ?? stringField(raw, "command_text"),
+            input_json: stringField(raw, "input_json"),
             output: stringField(raw, "output_excerpt"),
             has_error: raw.has_error === true,
         };

--- a/apps/axctl/src/share/exporter.test.ts
+++ b/apps/axctl/src/share/exporter.test.ts
@@ -13,28 +13,46 @@ describe("attachSynthesizedToolText", () => {
         text,
     });
 
-    it("synthesizes a tool line on text-less turns from tool calls", () => {
+    it("synthesizes a tool line with arguments from input json", () => {
         const [a, b] = attachSynthesizedToolText(
             [turn(12, ""), turn(13, "real assistant text")],
             [
-                { seq: 12, name: "WebFetch", command: "https://x.com", output: "page body", has_error: false },
-                { seq: 13, name: "Bash", command: "ls", output: "files", has_error: false },
+                {
+                    seq: 12,
+                    name: "WebFetch",
+                    command: null,
+                    input_json: JSON.stringify({ url: "https://x.com", prompt: "what is this" }),
+                    output: "page body",
+                    has_error: false,
+                },
+                { seq: 13, name: "Bash", command: "ls", input_json: null, output: "files", has_error: false },
             ],
         );
-        expect(a?.text).toContain("🔧 WebFetch https://x.com");
+        expect(a?.text).toContain("🔧 WebFetch");
+        expect(a?.text).toContain("url: https://x.com");
+        expect(a?.text).toContain("prompt: what is this");
         expect(a?.text).toContain("→ page body");
         expect(a?.has_tool_use).toBe(true);
         // A turn that already has text is left untouched.
         expect(b?.text).toBe("real assistant text");
     });
 
+    it("falls back to the command for shell tools without input json", () => {
+        const [a] = attachSynthesizedToolText(
+            [turn(1, "")],
+            [{ seq: 1, name: "Bash", command: "ls -la", input_json: null, output: "files", has_error: false }],
+        );
+        expect(a?.text).toContain("🔧 Bash");
+        expect(a?.text).toContain("ls -la");
+    });
+
     it("truncates long tool output and flags errors", () => {
         const [a] = attachSynthesizedToolText(
             [turn(1, "")],
-            [{ seq: 1, name: "Bash", command: "x", output: "z".repeat(900), has_error: true }],
+            [{ seq: 1, name: "Bash", command: "x", input_json: null, output: "z".repeat(2000), has_error: true }],
         );
         expect(a?.text).toContain("⚠️");
-        expect(a?.text.length).toBeLessThan(500);
+        expect(a?.text.length).toBeLessThan(800);
         expect(a?.text).toContain("…");
     });
 });

--- a/apps/axctl/src/share/exporter.ts
+++ b/apps/axctl/src/share/exporter.ts
@@ -224,14 +224,45 @@ const attachTurnTokenUsage = (
     });
 };
 
-const TOOL_OUTPUT_MAX = 400;
+const TOOL_OUTPUT_MAX = 600;
+const TOOL_ARG_MAX = 200;
+const TOOL_MAX_ARGS = 6;
+
+const clip = (value: string, max: number): string =>
+    value.length > max ? `${value.slice(0, max - 1)}…` : value;
+
+/**
+ * Render a tool call's arguments from its recorded input JSON as compact
+ * `key: value` lines (whitespace collapsed, each value clipped). Falls back to
+ * the normalized command string for shell tools that have no structured input.
+ */
+const formatToolArgs = (call: ShareTurnToolCall): string[] => {
+    if (call.input_json) {
+        const parsed = (() => {
+            try {
+                return JSON.parse(call.input_json) as unknown;
+            } catch {
+                return null;
+            }
+        })();
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            const lines: string[] = [];
+            for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+                if (value === null || value === undefined || value === "") continue;
+                const rendered = typeof value === "string" ? value : JSON.stringify(value);
+                lines.push(`  ${key}: ${clip(rendered.replace(/\s+/g, " ").trim(), TOOL_ARG_MAX)}`);
+                if (lines.length >= TOOL_MAX_ARGS) break;
+            }
+            if (lines.length > 0) return lines;
+        }
+    }
+    return call.command ? [`  ${clip(call.command, TOOL_ARG_MAX)}`] : [];
+};
 
 const formatToolCall = (call: ShareTurnToolCall): string => {
-    const head = call.command ? `${call.name} ${call.command}` : call.name;
-    const out = call.output
-        ? `\n→ ${call.output.length > TOOL_OUTPUT_MAX ? `${call.output.slice(0, TOOL_OUTPUT_MAX - 1)}…` : call.output}`
-        : "";
-    return `🔧 ${head}${call.has_error ? " ⚠️" : ""}${out}`;
+    const lines = [`🔧 ${call.name}${call.has_error ? "  ⚠️ error" : ""}`, ...formatToolArgs(call)];
+    if (call.output) lines.push(`→ ${clip(call.output, TOOL_OUTPUT_MAX)}`);
+    return lines.join("\n");
 };
 
 /**


### PR DESCRIPTION
Tool-call turns in a shared transcript showed only the tool name + output — you couldn't see *what* the agent called. Now each tool turn renders its arguments.

- Share tool-call query fetches `input_json`.
- The synthesized tool line parses it into compact `key: value` lines (whitespace-collapsed, each clipped to 200 chars, up to 6 keys), falling back to the normalized command for shell tools. Output bumped 400→600 chars.

A WebFetch now reads:
```
🔧 WebFetch
  url: https://paxel.ycombinator.com/
  prompt: What is this product? Describe what it does, its features…
→ # Paxel: AI Coding Analytics Tool …
```

Verified via dry-run on a tool-heavy session. 66 share/query tests pass, typecheck clean.

Follow-ups surfaced (not in this PR):
- **Hook jumps**: the share still doesn't export hook-fire data, so "next hook fire" / "next hook ctx" can't match. Needs hook_fires added to the export + interleaved render.
- **Large fan-out timeout**: exporting a 117-subagent session times out (recursive per-child export). Needs concurrency/cap work for big sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)