### PR TITLE
feat(share): hook-fire export + render; bound export concurrency

### DIFF
--- a/apps/axctl/src/dashboard/web/src/routes/session-inspect.tsx
+++ b/apps/axctl/src/dashboard/web/src/routes/session-inspect.tsx
@@ -1093,7 +1093,7 @@ function SpawnMarker({ child }: { child: SpawnChildDto }) {
  *  visual language is consistent. Chips surface inject/reason/event; when
  *  inject=true we also show the clipped titles of the prior-session memory
  *  that landed in the agent's context window. */
-function HookFireMarker({ hook }: { hook: HookFireDto }) {
+export function HookFireMarker({ hook }: { hook: HookFireDto }) {
     const ts = hook.ts ? new Date(hook.ts).toISOString().slice(11, 19) : "";
     const injectBg = hook.inject ? "#bbf7d0" : "#e2e8f0";
     const injectFg = hook.inject ? "#065f46" : "#475569";

--- a/apps/axctl/src/dashboard/web/src/routes/share-inspect.tsx
+++ b/apps/axctl/src/dashboard/web/src/routes/share-inspect.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import type {
+    HookFireDto,
     InspectTurnContentDto,
     InspectSpanKind,
     InspectTurnDto,
@@ -10,8 +11,9 @@ import type {
     TurnTokenUsageDetail,
 } from "@shared/dashboard-types.ts";
 import { shortSessionId } from "@shared/session-id.ts";
+import { spliceHookFires } from "@shared/hook-fire-splice.ts";
 import { FilterBar } from "./inspector-filter-bar.tsx";
-import { DockedRail, InspectGuide, KIND_STYLE, Turn, useInspectSelection, useVisibleTurnSeq } from "./session-inspect.tsx";
+import { DockedRail, HookFireMarker, InspectGuide, KIND_STYLE, Turn, useInspectSelection, useVisibleTurnSeq } from "./session-inspect.tsx";
 
 type ShareSchemaVersion = 1 | 2 | 3;
 
@@ -37,6 +39,7 @@ interface ShareArtifact {
         readonly failures: number;
     };
     readonly token_usage?: SessionTokenUsageDetail | null;
+    readonly hook_fires?: ReadonlyArray<HookFireDto>;
     readonly turns?: ReadonlyArray<{
         readonly id: string;
         readonly seq: number;
@@ -216,8 +219,8 @@ export function inspectPayloadFromShare(artifact: ShareArtifact, sourcePath: str
         parent_session: null,
         parent_nickname: null,
         children: [],
-        hook_fires: [],
-        total_hook_fires: 0,
+        hook_fires: artifact.hook_fires ?? [],
+        total_hook_fires: artifact.hook_fires?.length ?? 0,
     };
 }
 
@@ -262,6 +265,9 @@ function InspectBody({
     const [anchoredSeq, setAnchoredSeq] = useState<number | null>(() => hashSeq());
     const turnsRef = useRef<ReadonlyArray<InspectTurnDto>>([]);
     turnsRef.current = data.turns;
+    const hookFireIdxs = data.hook_fires.map((h) => h.idx);
+    const hookFireIdxsRef = useRef<ReadonlyArray<number>>([]);
+    hookFireIdxsRef.current = hookFireIdxs;
     const visibleSeq = useVisibleTurnSeq(data.turns, anchoredSeq ?? data.turns[0]?.seq ?? null);
     const [selection, setSelection] = useInspectSelection(data);
     // Spawn-turn seqs power the "next spawn" jump button + match the inline
@@ -297,9 +303,9 @@ function InspectBody({
                 loadMore={() => Promise.resolve()}
                 getTurns={() => turnsRef.current}
                 getCurrentSeq={() => anchoredSeq}
-                hookFireIdxs={[]}
-                getHookFireIdxs={() => []}
-                totalHookFires={0}
+                hookFireIdxs={hookFireIdxs}
+                getHookFireIdxs={() => hookFireIdxsRef.current}
+                totalHookFires={data.total_hook_fires}
             />
             <InspectGuide data={data} />
             <div style={{ display: "flex", gap: 4, flexWrap: "wrap", padding: "4px 24px 8px" }}>
@@ -320,10 +326,14 @@ function InspectBody({
             </div>
             <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
                 <div style={{ minWidth: 0, flex: "1 1 auto" }}>
-                    {data.turns.map((turn) => {
+                    {spliceHookFires(data.turns, data.hook_fires).map((item) => {
+                        if (item.kind === "hook_fire") {
+                            return <HookFireMarker key={`hook-${item.hook.idx}`} hook={item.hook} />;
+                        }
+                        const turn = item.turn;
                         const spawned = subagentsByTurn?.get(turn.seq);
                         return (
-                            <div key={turn.seq}>
+                            <div key={`turn-${turn.seq}`}>
                                 <Turn
                                     turn={turn}
                                     anchored={anchoredSeq === turn.seq}

--- a/apps/axctl/src/queries/session-detail.test.ts
+++ b/apps/axctl/src/queries/session-detail.test.ts
@@ -5,6 +5,7 @@ import {
     SESSION_SHARE_TIMELINE_SQL,
     SESSION_SHARE_TURNS_SQL,
     SESSION_SHARE_TURN_TOOLCALLS_SQL,
+    SESSION_SHARE_HOOK_FIRES_SQL,
     mapSessionShareFileRow,
     mapSessionShareTimelineRow,
     mapSessionShareTurnRow,
@@ -110,6 +111,8 @@ describe("session share query mappers", () => {
         expect(SESSION_SHARE_TURNS_SQL).toContain("LIMIT 2000");
         expect(SESSION_SHARE_TURN_TOOLCALLS_SQL).toContain("WHERE session = $sessionId");
         expect(SESSION_SHARE_TURN_TOOLCALLS_SQL).toContain("LIMIT 4000");
+        expect(SESSION_SHARE_HOOK_FIRES_SQL).toContain("WHERE session = $sessionId");
+        expect(SESSION_SHARE_HOOK_FIRES_SQL).toContain("LIMIT 2000");
         expect(SESSION_SHARE_FILES_SQL).toContain("WHERE in.session = $sessionId");
         expect(SESSION_SHARE_FILES_SQL).toContain("LIMIT 200");
     });

--- a/apps/axctl/src/queries/session-detail.ts
+++ b/apps/axctl/src/queries/session-detail.ts
@@ -15,6 +15,7 @@ import {
 import { toBareSessionId } from "@ax/lib/shared/session-id";
 import { decodeJsonOrNull } from "@ax/lib/decode";
 import type {
+    HookFireDto,
     SessionAgentDelegation,
     SessionCompaction,
     SessionHealthSummary,
@@ -280,6 +281,22 @@ LIMIT 2000;`;
  * the otherwise text-less tool-call turns (keeps the shared transcript from
  * jumping over the agent's actual work).
  */
+/** Runtime hook-fire decisions for a shared session (file-context injections
+ *  etc.), ordered by time so the viewer can interleave + jump to them. */
+export const SESSION_SHARE_HOOK_FIRES_SQL = `
+SELECT
+    ts,
+    event,
+    file_path,
+    inject,
+    reason,
+    latency_ms,
+    injected_titles
+FROM hook_fire
+WHERE session = $sessionId
+ORDER BY ts ASC
+LIMIT 2000;`;
+
 export const SESSION_SHARE_TURN_TOOLCALLS_SQL = `
 SELECT
     seq,
@@ -534,6 +551,35 @@ export const sessionShareTurnToolCallsQuery = defineQuery<
             input_json: stringField(raw, "input_json"),
             output: stringField(raw, "output_excerpt"),
             has_error: raw.has_error === true,
+        };
+    },
+});
+
+/** Hook fire without the SPA-only `idx` (assigned by the exporter in ts order). */
+export type ShareHookFire = Omit<HookFireDto, "idx">;
+
+export const sessionShareHookFiresQuery = defineQuery<
+    SessionDetailParams,
+    Record<string, unknown>,
+    ShareHookFire | null
+>({
+    name: "session-detail.share_hook_fires",
+    sql: (p) => subst(SESSION_SHARE_HOOK_FIRES_SQL, p.recordRef),
+    mapRow: (raw) => {
+        if (!isRecord(raw)) return null;
+        const ts = dateField(raw, "ts");
+        const event = stringField(raw, "event");
+        if (!ts || !event) return null;
+        return {
+            ts,
+            event,
+            file_path: stringField(raw, "file_path") ?? "",
+            inject: raw.inject === true,
+            reason: stringField(raw, "reason") ?? "",
+            latency_ms: numericField(raw, "latency_ms"),
+            injected_titles: Array.isArray(raw.injected_titles)
+                ? (raw.injected_titles as unknown[]).filter((t): t is string => typeof t === "string")
+                : [],
         };
     },
 });

--- a/apps/axctl/src/share/artifact.ts
+++ b/apps/axctl/src/share/artifact.ts
@@ -1,4 +1,4 @@
-import type { InspectTurnContentDto, SessionTokenUsageDetail, TurnTokenUsageDetail } from "@ax/lib/shared/dashboard-types";
+import type { HookFireDto, InspectTurnContentDto, SessionTokenUsageDetail, TurnTokenUsageDetail } from "@ax/lib/shared/dashboard-types";
 
 export const AX_SESSION_SHARE_SCHEMA_VERSION = 3 as const;
 
@@ -38,6 +38,9 @@ export interface AxSessionShare {
         readonly failures: number;
     };
     readonly token_usage?: SessionTokenUsageDetail | null;
+    /** v3+: runtime hook-fire decisions (file-context injections etc.), so the
+     *  shared inspector can show + jump to them like the live one. */
+    readonly hook_fires?: ReadonlyArray<HookFireDto>;
     readonly turns: ReadonlyArray<ShareTurn>;
     readonly timeline: ReadonlyArray<ShareEvent>;
     readonly files: ReadonlyArray<ShareFile>;

--- a/apps/axctl/src/share/exporter.test.ts
+++ b/apps/axctl/src/share/exporter.test.ts
@@ -195,6 +195,22 @@ describe("buildShareArtifactFromParts", () => {
         expect(artifact.schema_version).toBe(3);
     });
 
+    it("carries hook fires when present, omits the field when empty", () => {
+        const hook = {
+            idx: 0,
+            ts: "2026-05-29T00:01:00.000Z",
+            event: "pre-edit",
+            file_path: "src/a.ts",
+            inject: true,
+            reason: "high_signal",
+            latency_ms: 12,
+            injected_titles: ["prior session"],
+        };
+        expect(buildShareArtifactFromParts({ ...baseParts, hookFires: [hook] }).hook_fires).toHaveLength(1);
+        expect(buildShareArtifactFromParts({ ...baseParts, hookFires: [] }).hook_fires).toBeUndefined();
+        expect(buildShareArtifactFromParts(baseParts).hook_fires).toBeUndefined();
+    });
+
     it("attaches child subagent shares when provided", () => {
         const child = minimalShareArtifact({ id: "child1", source: "codex" });
         const artifact = buildShareArtifactFromParts({

--- a/apps/axctl/src/share/exporter.ts
+++ b/apps/axctl/src/share/exporter.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Ref } from "effect";
 import {
     AX_SESSION_SHARE_SCHEMA_VERSION,
     type AxSessionShare,
@@ -24,6 +24,7 @@ import {
     sessionShareTimelineQuery,
     sessionShareTurnsQuery,
     sessionShareTurnToolCallsQuery,
+    sessionShareHookFiresQuery,
     sessionTokenUsageQuery,
     sessionTurnTokenUsageQuery,
     sessionToolCallsQuery,
@@ -43,6 +44,7 @@ export interface ShareArtifactParts {
     readonly files: ReadonlyArray<ShareFile>;
     readonly children?: ReadonlyArray<AxSessionShare>;
     readonly spawnAnchorTurnSeq?: number | null;
+    readonly hookFires?: AxSessionShare["hook_fires"];
 }
 
 const SESSION_ID_RE = /^[A-Za-z0-9_-]{6,80}$/;
@@ -166,6 +168,7 @@ export function buildShareArtifactFromParts(
             failures,
         },
         token_usage: parts.tokenUsage ?? null,
+        ...(parts.hookFires && parts.hookFires.length > 0 ? { hook_fires: parts.hookFires } : {}),
         turns: parts.turns,
         timeline: parts.timeline,
         files,
@@ -292,6 +295,14 @@ export const attachSynthesizedToolText = (
     });
 };
 
+/** Subagents exported concurrently at each level of the spawn tree. Bounds DB
+ *  load so a wide fan-out (100+ subagents) can't stampede the daemon into a
+ *  timeout (unbounded recursion previously hung the export). */
+const EXPORT_CONCURRENCY = 8;
+/** Hard cap on sessions fully exported in one share (root + descendants), so a
+ *  pathological orchestration can't produce an unbounded gist or hang. */
+const MAX_EXPORTED_SESSIONS = 400;
+
 export interface ExportSessionShareOptions {
     /**
      * Record refs already materialised on the current export path. Guards
@@ -301,6 +312,8 @@ export interface ExportSessionShareOptions {
     readonly visited?: ReadonlySet<string>;
     /** Internal: the parent turn seq this session was spawned at, if any. */
     readonly spawnAnchorTurnSeq?: number | null;
+    /** Internal: shared remaining-session budget (cycle/size backstop). */
+    readonly budget?: Ref.Ref<number>;
 }
 
 export const exportSessionShare = (
@@ -315,8 +328,14 @@ export const exportSessionShare = (
         const visited = options.visited ?? new Set<string>();
         if (visited.has(recordRef)) return null;
 
+        // Shared budget across the whole recursion (created once at the root)
+        // caps total sessions exported - a cycle/size backstop.
+        const budget = options.budget ?? (yield* Ref.make(MAX_EXPORTED_SESSIONS));
+        const remaining = yield* Ref.updateAndGet(budget, (n) => n - 1);
+        if (remaining < 0) return null;
+
         const params = { recordRef };
-        const [overview, topSkillsRaw, toolCallsRaw, tokenUsage, turnTokenUsageRaw, turnsRaw, timelineRaw, filesRaw, childLinksRaw, turnToolCallsRaw, turnContent] =
+        const [overview, topSkillsRaw, toolCallsRaw, tokenUsage, turnTokenUsageRaw, turnsRaw, timelineRaw, filesRaw, childLinksRaw, turnToolCallsRaw, hookFiresRaw, turnContent] =
             yield* Effect.all([
                 runSingleQuery(sessionOverviewQuery, params),
                 runQuery(sessionTopSkillsQuery, params),
@@ -328,10 +347,16 @@ export const exportSessionShare = (
                 runQuery(sessionShareFilesQuery, params),
                 runQuery(sessionChildrenQuery, params),
                 runQuery(sessionShareTurnToolCallsQuery, params),
+                runQuery(sessionShareHookFiresQuery, params),
                 resolveTurnContent(sessionId),
             ]);
 
         if (overview === null) return null;
+
+        // Assign the SPA-only monotonic idx (used for stable DOM ids + jumps).
+        const hookFires = hookFiresRaw
+            .filter(isPresent)
+            .map((fire, idx) => ({ idx, ...fire }));
 
         // Recurse into spawned subagents. The visited set carries this session
         // so a child that points back never re-expands; leaves return [].
@@ -346,9 +371,11 @@ export const exportSessionShare = (
                     exportSessionShare(String(link.session_id), axVersion, {
                         visited: nextVisited,
                         spawnAnchorTurnSeq: anchorChildToTurn(shareTurns, link.ts ?? null),
+                        budget,
                     }),
                 ),
-                { concurrency: "unbounded" },
+                // Bounded so a wide fan-out can't stampede the daemon.
+                { concurrency: EXPORT_CONCURRENCY },
             )
         ).filter(isPresent);
 
@@ -374,6 +401,7 @@ export const exportSessionShare = (
             timeline: timelineRaw.filter(isPresent),
             files: filesRaw.filter(isPresent),
             children,
+            hookFires,
             ...(options.spawnAnchorTurnSeq != null
                 ? { spawnAnchorTurnSeq: options.spawnAnchorTurnSeq }
                 : {}),


### PR DESCRIPTION
Two follow-ups from "make all the jumps work" + robustness.

## Hook fires (next hook fire / hook-context jumps)
The share never exported hook-fire data, so those jumps had nothing to match. Now:
- A session-scoped, bounded `hook_fire` query; the exporter fetches it, assigns the SPA `idx`, and adds `hook_fires` to the share artifact.
- The reader maps `hook_fires` into the inspect payload, feeds the FilterBar's `hookFireIdxs`, and interleaves `HookFireMarker` among turns via the shared `spliceHookFires` (now-exported marker). Fully gated on data — empty `hook_fires` renders exactly as before.

## Export concurrency + budget guard
Recursive subagent export was unbounded — a wide fan-out could stampede the daemon (a 117-subagent session hung). Children now export at bounded concurrency, with a shared session budget as a cycle/size backstop.

## Honest caveats
- **No hook_fire data locally** — the file-context hook feature has zero rows in this DB, so hook jumps can't be *visually* demoed. The plumbing mirrors the live inspector exactly and is unit-tested; data-backed jumps (**tool_use / spawn / correction**) work.
- **Large fan-out still slow** — the bound stops the stampede, but the cost is per-session (heavy content resolution) × count, so 100+ subagent sessions need a deeper per-session perf pass (separate). Normal sessions (a13f9192, 2 subagents) export fine.

2098 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)