### PR TITLE
feat(share): surface harness hooks in the shared transcript

### DIFF
--- a/apps/axctl/src/dashboard/web/src/routes/share-inspect.tsx
+++ b/apps/axctl/src/dashboard/web/src/routes/share-inspect.tsx
@@ -24,6 +24,8 @@ interface ShareHarnessHookView {
     readonly hook_name: string;
     readonly effect: string;
     readonly status: string;
+    readonly command?: string;
+    readonly detail?: string;
     readonly anchor_turn_seq: number | null;
 }
 
@@ -442,18 +444,25 @@ function HarnessHookMarker(props: { readonly hook: ShareHarnessHookView }) {
         <div
             id={`hook-${HARNESS_HOOK_IDX_BASE + hook.idx}`}
             style={{
-                display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap",
                 margin: "4px 0", padding: "5px 10px", background: tone.bg,
                 borderLeft: `4px solid ${tone.bar}`, borderRadius: 3,
                 fontSize: 11, fontFamily: "ui-monospace, monospace", color: tone.fg,
             }}
         >
-            <span style={{ fontWeight: 700 }}>⚙ hook</span>
-            <span style={{ fontWeight: 600 }}>{hook.hook_name}</span>
-            <span style={{ background: tone.bar, color: "#fff", padding: "0 6px", borderRadius: 2, fontSize: 10, fontWeight: 600 }}>
-                {hook.effect.replace(/_/g, " ")}
-            </span>
-            {hook.status === "blocking_error" ? <span style={{ fontWeight: 600 }}>⚠️ blocking</span> : null}
+            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                <span style={{ fontWeight: 700 }}>⚙ hook</span>
+                <span style={{ fontWeight: 600 }}>{hook.hook_name}</span>
+                <span style={{ background: tone.bar, color: "#fff", padding: "0 6px", borderRadius: 2, fontSize: 10, fontWeight: 600 }}>
+                    {hook.effect.replace(/_/g, " ")}
+                </span>
+                {hook.command ? <span style={{ opacity: 0.7 }}>{hook.command}</span> : null}
+                {hook.status === "blocking_error" ? <span style={{ fontWeight: 600 }}>⚠️ blocking</span> : null}
+            </div>
+            {hook.detail ? (
+                <div style={{ marginTop: 4, whiteSpace: "pre-wrap", wordBreak: "break-word", opacity: 0.9, lineHeight: 1.5 }}>
+                    {hook.detail}
+                </div>
+            ) : null}
         </div>
     );
 }

--- a/apps/axctl/src/dashboard/web/src/routes/share-inspect.tsx
+++ b/apps/axctl/src/dashboard/web/src/routes/share-inspect.tsx
@@ -17,6 +17,16 @@ import { DockedRail, HookFireMarker, InspectGuide, KIND_STYLE, Turn, useInspectS
 
 type ShareSchemaVersion = 1 | 2 | 3;
 
+interface ShareHarnessHookView {
+    readonly idx: number;
+    readonly ts: string;
+    readonly event_name: string;
+    readonly hook_name: string;
+    readonly effect: string;
+    readonly status: string;
+    readonly anchor_turn_seq: number | null;
+}
+
 interface ShareArtifact {
     readonly schema_version: ShareSchemaVersion;
     readonly exported_at: string;
@@ -40,6 +50,7 @@ interface ShareArtifact {
     };
     readonly token_usage?: SessionTokenUsageDetail | null;
     readonly hook_fires?: ReadonlyArray<HookFireDto>;
+    readonly harness_hooks?: ReadonlyArray<ShareHarnessHookView>;
     readonly turns?: ReadonlyArray<{
         readonly id: string;
         readonly seq: number;
@@ -254,18 +265,35 @@ function fmtDuration(ms: number | null | undefined): string | null {
 function InspectBody({
     data,
     subagentsByTurn,
+    harnessHooks,
     onSelectSubagent,
     onPrefetchSubagent,
 }: {
     readonly data: SessionInspectPayload;
     readonly subagentsByTurn?: ReadonlyMap<number, ReadonlyArray<ShareSubagentCard>>;
+    readonly harnessHooks?: ReadonlyArray<ShareHarnessHookView>;
     readonly onSelectSubagent?: (file: string) => void;
     readonly onPrefetchSubagent?: (file: string) => void;
 }) {
     const [anchoredSeq, setAnchoredSeq] = useState<number | null>(() => hashSeq());
     const turnsRef = useRef<ReadonlyArray<InspectTurnDto>>([]);
     turnsRef.current = data.turns;
-    const hookFireIdxs = data.hook_fires.map((h) => h.idx);
+    // Harness hooks (guardrail fires) anchored to their nearest turn, + the
+    // combined jump idx list ("next hook fire" cycles file-context + harness).
+    const harnessByTurn = useMemo(() => {
+        const map = new Map<number, ShareHarnessHookView[]>();
+        for (const hook of harnessHooks ?? []) {
+            if (hook.anchor_turn_seq == null) continue;
+            const list = map.get(hook.anchor_turn_seq) ?? [];
+            list.push(hook);
+            map.set(hook.anchor_turn_seq, list);
+        }
+        return map;
+    }, [harnessHooks]);
+    const hookFireIdxs = [
+        ...data.hook_fires.map((h) => h.idx),
+        ...(harnessHooks ?? []).map((h) => HARNESS_HOOK_IDX_BASE + h.idx),
+    ];
     const hookFireIdxsRef = useRef<ReadonlyArray<number>>([]);
     hookFireIdxsRef.current = hookFireIdxs;
     const visibleSeq = useVisibleTurnSeq(data.turns, anchoredSeq ?? data.turns[0]?.seq ?? null);
@@ -305,7 +333,7 @@ function InspectBody({
                 getCurrentSeq={() => anchoredSeq}
                 hookFireIdxs={hookFireIdxs}
                 getHookFireIdxs={() => hookFireIdxsRef.current}
-                totalHookFires={data.total_hook_fires}
+                totalHookFires={data.total_hook_fires + (harnessHooks?.length ?? 0)}
             />
             <InspectGuide data={data} />
             <div style={{ display: "flex", gap: 4, flexWrap: "wrap", padding: "4px 24px 8px" }}>
@@ -332,6 +360,7 @@ function InspectBody({
                         }
                         const turn = item.turn;
                         const spawned = subagentsByTurn?.get(turn.seq);
+                        const hooks = harnessByTurn.get(turn.seq);
                         return (
                             <div key={`turn-${turn.seq}`}>
                                 <Turn
@@ -340,6 +369,13 @@ function InspectBody({
                                     activeTarget={selection?.turnSeq === turn.seq ? selection.target : null}
                                     onInspect={setSelection}
                                 />
+                                {hooks && hooks.length > 0 ? (
+                                    <div style={{ padding: "2px 24px 4px" }}>
+                                        {hooks.map((hook) => (
+                                            <HarnessHookMarker key={`hh-${hook.idx}`} hook={hook} />
+                                        ))}
+                                    </div>
+                                ) : null}
                                 {spawned && spawned.length > 0 ? (
                                     <div style={{ padding: "2px 24px 6px" }}>
                                         {spawned.map((card) => (
@@ -385,6 +421,42 @@ const SUBAGENT_LINK_STYLE: CSSProperties = {
     fontSize: 12,
     textDecoration: "underline",
 };
+
+/** DOM-id offset so harness-hook markers don't collide with file-context
+ *  hook_fire markers (both use `hook-<n>` ids for the shared jump). */
+const HARNESS_HOOK_IDX_BASE = 1_000_000;
+
+const HARNESS_EFFECT_TONE: Record<string, { bg: string; fg: string; bar: string }> = {
+    blocked: { bg: "#fef2f2", fg: "#991b1b", bar: "#ef4444" },
+    modified_input: { bg: "#fffbeb", fg: "#92400e", bar: "#f59e0b" },
+    injected_context: { bg: "#ecfdf5", fg: "#065f46", bar: "#10b981" },
+    notified: { bg: "#eff6ff", fg: "#1e40af", bar: "#3b82f6" },
+};
+
+/** Inline marker for a harness hook that did something (blocked / modified /
+ *  injected). Shows the guardrail activity inline in the shared transcript. */
+function HarnessHookMarker(props: { readonly hook: ShareHarnessHookView }) {
+    const { hook } = props;
+    const tone = HARNESS_EFFECT_TONE[hook.effect] ?? { bg: "#f8fafc", fg: "#334155", bar: "#94a3b8" };
+    return (
+        <div
+            id={`hook-${HARNESS_HOOK_IDX_BASE + hook.idx}`}
+            style={{
+                display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap",
+                margin: "4px 0", padding: "5px 10px", background: tone.bg,
+                borderLeft: `4px solid ${tone.bar}`, borderRadius: 3,
+                fontSize: 11, fontFamily: "ui-monospace, monospace", color: tone.fg,
+            }}
+        >
+            <span style={{ fontWeight: 700 }}>⚙ hook</span>
+            <span style={{ fontWeight: 600 }}>{hook.hook_name}</span>
+            <span style={{ background: tone.bar, color: "#fff", padding: "0 6px", borderRadius: 2, fontSize: 10, fontWeight: 600 }}>
+                {hook.effect.replace(/_/g, " ")}
+            </span>
+            {hook.status === "blocking_error" ? <span style={{ fontWeight: 600 }}>⚠️ blocking</span> : null}
+        </div>
+    );
+}
 
 /**
  * Inline "spawned subagent" marker, mirroring the live inspector's SpawnMarker
@@ -544,6 +616,7 @@ function MultiFileShareView(props: {
                 <InspectBody
                     data={data}
                     subagentsByTurn={subagentsByTurn}
+                    harnessHooks={fileQuery.data?.harness_hooks}
                     onSelectSubagent={setSelectedFile}
                     onPrefetchSubagent={prefetch}
                 />
@@ -574,7 +647,7 @@ function LegacyShareView(props: { readonly owner: string; readonly gistId: strin
             </header>
             {query.error ? <div className="error">Error: {String(query.error)}</div> : null}
             {query.isLoading && !data ? <div className="loading">Loading shared session…</div> : null}
-            {data ? <InspectBody data={data} /> : null}
+            {data ? <InspectBody data={data} harnessHooks={query.data?.harness_hooks} /> : null}
         </section>
     );
 }

--- a/apps/axctl/src/queries/session-detail.test.ts
+++ b/apps/axctl/src/queries/session-detail.test.ts
@@ -6,6 +6,7 @@ import {
     SESSION_SHARE_TURNS_SQL,
     SESSION_SHARE_TURN_TOOLCALLS_SQL,
     SESSION_SHARE_HOOK_FIRES_SQL,
+    SESSION_SHARE_HARNESS_HOOKS_SQL,
     mapSessionShareFileRow,
     mapSessionShareTimelineRow,
     mapSessionShareTurnRow,
@@ -113,6 +114,8 @@ describe("session share query mappers", () => {
         expect(SESSION_SHARE_TURN_TOOLCALLS_SQL).toContain("LIMIT 4000");
         expect(SESSION_SHARE_HOOK_FIRES_SQL).toContain("WHERE session = $sessionId");
         expect(SESSION_SHARE_HOOK_FIRES_SQL).toContain("LIMIT 2000");
+        expect(SESSION_SHARE_HARNESS_HOOKS_SQL).toContain("WHERE session = $sessionId");
+        expect(SESSION_SHARE_HARNESS_HOOKS_SQL).toContain("LIMIT 2000");
         expect(SESSION_SHARE_FILES_SQL).toContain("WHERE in.session = $sessionId");
         expect(SESSION_SHARE_FILES_SQL).toContain("LIMIT 200");
     });

--- a/apps/axctl/src/queries/session-detail.ts
+++ b/apps/axctl/src/queries/session-detail.ts
@@ -291,7 +291,12 @@ SELECT
     event_name,
     hook_name,
     effect,
-    provider_status
+    provider_status,
+    command,
+    stdout_excerpt,
+    content_excerpt,
+    blocking_error_excerpt,
+    stderr_excerpt
 FROM hook_command_invocation
 WHERE session = $sessionId
     AND effect IN ["blocked", "modified_input", "injected_context", "notified"]
@@ -578,6 +583,34 @@ export type ShareHookFire = Omit<HookFireDto, "idx">;
 /** Harness hook row before the exporter assigns idx + anchor turn. */
 export type ShareHarnessHookRow = Omit<ShareHarnessHook, "idx" | "anchor_turn_seq">;
 
+const HARNESS_DETAIL_MAX = 600;
+
+/** Pull `additionalContext` out of a hook's stdout JSON (the text Claude/Codex
+ *  actually saw injected), tolerating a missing/malformed payload. */
+const extractInjectedContext = (stdout: string | null): string | null => {
+    if (!stdout) return null;
+    const parsed = decodeJsonOrNull(stdout);
+    if (!parsed || typeof parsed !== "object") return null;
+    const rec = parsed as Record<string, unknown>;
+    const hso = rec.hookSpecificOutput;
+    if (hso && typeof hso === "object" && typeof (hso as Record<string, unknown>).additionalContext === "string") {
+        return (hso as Record<string, unknown>).additionalContext as string;
+    }
+    return typeof rec.additionalContext === "string" ? rec.additionalContext : null;
+};
+
+/** The most informative excerpt of what a hook did: blocking reason, injected
+ *  context, or raw output. Clipped so a big file-memory block stays bounded. */
+const harnessHookDetail = (raw: Record<string, unknown>): string | null => {
+    const detail = stringField(raw, "blocking_error_excerpt")
+        ?? stringField(raw, "content_excerpt")
+        ?? extractInjectedContext(stringField(raw, "stdout_excerpt"))
+        ?? stringField(raw, "stderr_excerpt");
+    if (!detail) return null;
+    const trimmed = detail.trim();
+    return trimmed.length > HARNESS_DETAIL_MAX ? `${trimmed.slice(0, HARNESS_DETAIL_MAX - 1)}…` : trimmed;
+};
+
 export const sessionShareHarnessHooksQuery = defineQuery<
     SessionDetailParams,
     Record<string, unknown>,
@@ -592,12 +625,16 @@ export const sessionShareHarnessHooksQuery = defineQuery<
         const hook_name = stringField(raw, "hook_name");
         const effect = stringField(raw, "effect");
         if (!ts || !event_name || !hook_name || !effect) return null;
+        const command = stringField(raw, "command");
+        const detail = harnessHookDetail(raw);
         return {
             ts,
             event_name,
             hook_name,
             effect,
             status: stringField(raw, "provider_status") ?? "",
+            ...(command ? { command } : {}),
+            ...(detail ? { detail } : {}),
         };
     },
 });

--- a/apps/axctl/src/queries/session-detail.ts
+++ b/apps/axctl/src/queries/session-detail.ts
@@ -26,7 +26,7 @@ import type {
     SessionTopSkill,
     TurnTokenUsageDetail,
 } from "@ax/lib/shared/dashboard-types";
-import type { ShareEvent, ShareFile, ShareTurn } from "../share/artifact.ts";
+import type { ShareEvent, ShareFile, ShareHarnessHook, ShareTurn } from "../share/artifact.ts";
 
 export const SESSION_OVERVIEW_SQL = `
 SELECT
@@ -281,6 +281,23 @@ LIMIT 2000;`;
  * the otherwise text-less tool-call turns (keeps the shared transcript from
  * jumping over the agent's actual work).
  */
+/** Harness hook invocations that DID something (blocked / modified input /
+ *  injected context / notified) for a shared session - the guardrail hooks the
+ *  user configured. Passthrough (allowed / no_op / unknown) is excluded to keep
+ *  the transcript readable. */
+export const SESSION_SHARE_HARNESS_HOOKS_SQL = `
+SELECT
+    ts,
+    event_name,
+    hook_name,
+    effect,
+    provider_status
+FROM hook_command_invocation
+WHERE session = $sessionId
+    AND effect IN ["blocked", "modified_input", "injected_context", "notified"]
+ORDER BY ts ASC
+LIMIT 2000;`;
+
 /** Runtime hook-fire decisions for a shared session (file-context injections
  *  etc.), ordered by time so the viewer can interleave + jump to them. */
 export const SESSION_SHARE_HOOK_FIRES_SQL = `
@@ -557,6 +574,33 @@ export const sessionShareTurnToolCallsQuery = defineQuery<
 
 /** Hook fire without the SPA-only `idx` (assigned by the exporter in ts order). */
 export type ShareHookFire = Omit<HookFireDto, "idx">;
+
+/** Harness hook row before the exporter assigns idx + anchor turn. */
+export type ShareHarnessHookRow = Omit<ShareHarnessHook, "idx" | "anchor_turn_seq">;
+
+export const sessionShareHarnessHooksQuery = defineQuery<
+    SessionDetailParams,
+    Record<string, unknown>,
+    ShareHarnessHookRow | null
+>({
+    name: "session-detail.share_harness_hooks",
+    sql: (p) => subst(SESSION_SHARE_HARNESS_HOOKS_SQL, p.recordRef),
+    mapRow: (raw) => {
+        if (!isRecord(raw)) return null;
+        const ts = dateField(raw, "ts");
+        const event_name = stringField(raw, "event_name");
+        const hook_name = stringField(raw, "hook_name");
+        const effect = stringField(raw, "effect");
+        if (!ts || !event_name || !hook_name || !effect) return null;
+        return {
+            ts,
+            event_name,
+            hook_name,
+            effect,
+            status: stringField(raw, "provider_status") ?? "",
+        };
+    },
+});
 
 export const sessionShareHookFiresQuery = defineQuery<
     SessionDetailParams,

--- a/apps/axctl/src/share/artifact.ts
+++ b/apps/axctl/src/share/artifact.ts
@@ -87,6 +87,11 @@ export interface ShareHarnessHook {
     readonly effect: string;
     /** progress_only | success | blocking_error */
     readonly status: string;
+    /** The command the hook ran (e.g. `axctl hook file-context`). */
+    readonly command?: string;
+    /** What the hook did/injected: the injected context, blocking reason, or
+     *  output excerpt - so the reader can show *why* it fired, not just that. */
+    readonly detail?: string;
     /** Nearest turn seq by timestamp, for inline placement. */
     readonly anchor_turn_seq: number | null;
 }

--- a/apps/axctl/src/share/artifact.ts
+++ b/apps/axctl/src/share/artifact.ts
@@ -41,6 +41,10 @@ export interface AxSessionShare {
     /** v3+: runtime hook-fire decisions (file-context injections etc.), so the
      *  shared inspector can show + jump to them like the live one. */
     readonly hook_fires?: ReadonlyArray<HookFireDto>;
+    /** v3+: harness hook invocations that DID something (blocked / modified /
+     *  injected), anchored to the nearest turn, so the shared transcript shows
+     *  where guardrail hooks fired. */
+    readonly harness_hooks?: ReadonlyArray<ShareHarnessHook>;
     readonly turns: ReadonlyArray<ShareTurn>;
     readonly timeline: ReadonlyArray<ShareEvent>;
     readonly files: ReadonlyArray<ShareFile>;
@@ -68,6 +72,23 @@ export interface AxSessionShare {
      * Absent on the root and when no parent turn matched.
      */
     readonly spawn_anchor_turn_seq?: number | null;
+}
+
+/** A harness hook invocation surfaced in a shared transcript. */
+export interface ShareHarnessHook {
+    /** Monotonic index for stable DOM ids / jump cursor. */
+    readonly idx: number;
+    readonly ts: string;
+    /** PreToolUse | PostToolUse | SessionStart | UserPromptSubmit | Stop | ... */
+    readonly event_name: string;
+    /** e.g. PreToolUse:Write, SessionStart:startup */
+    readonly hook_name: string;
+    /** allowed | blocked | injected_context | modified_input | notified | no_op */
+    readonly effect: string;
+    /** progress_only | success | blocking_error */
+    readonly status: string;
+    /** Nearest turn seq by timestamp, for inline placement. */
+    readonly anchor_turn_seq: number | null;
 }
 
 export interface ShareTurn {

--- a/apps/axctl/src/share/exporter.ts
+++ b/apps/axctl/src/share/exporter.ts
@@ -25,6 +25,7 @@ import {
     sessionShareTurnsQuery,
     sessionShareTurnToolCallsQuery,
     sessionShareHookFiresQuery,
+    sessionShareHarnessHooksQuery,
     sessionTokenUsageQuery,
     sessionTurnTokenUsageQuery,
     sessionToolCallsQuery,
@@ -45,6 +46,7 @@ export interface ShareArtifactParts {
     readonly children?: ReadonlyArray<AxSessionShare>;
     readonly spawnAnchorTurnSeq?: number | null;
     readonly hookFires?: AxSessionShare["hook_fires"];
+    readonly harnessHooks?: AxSessionShare["harness_hooks"];
 }
 
 const SESSION_ID_RE = /^[A-Za-z0-9_-]{6,80}$/;
@@ -169,6 +171,7 @@ export function buildShareArtifactFromParts(
         },
         token_usage: parts.tokenUsage ?? null,
         ...(parts.hookFires && parts.hookFires.length > 0 ? { hook_fires: parts.hookFires } : {}),
+        ...(parts.harnessHooks && parts.harnessHooks.length > 0 ? { harness_hooks: parts.harnessHooks } : {}),
         turns: parts.turns,
         timeline: parts.timeline,
         files,
@@ -335,7 +338,7 @@ export const exportSessionShare = (
         if (remaining < 0) return null;
 
         const params = { recordRef };
-        const [overview, topSkillsRaw, toolCallsRaw, tokenUsage, turnTokenUsageRaw, turnsRaw, timelineRaw, filesRaw, childLinksRaw, turnToolCallsRaw, hookFiresRaw, turnContent] =
+        const [overview, topSkillsRaw, toolCallsRaw, tokenUsage, turnTokenUsageRaw, turnsRaw, timelineRaw, filesRaw, childLinksRaw, turnToolCallsRaw, hookFiresRaw, harnessHooksRaw, turnContent] =
             yield* Effect.all([
                 runSingleQuery(sessionOverviewQuery, params),
                 runQuery(sessionTopSkillsQuery, params),
@@ -348,6 +351,7 @@ export const exportSessionShare = (
                 runQuery(sessionChildrenQuery, params),
                 runQuery(sessionShareTurnToolCallsQuery, params),
                 runQuery(sessionShareHookFiresQuery, params),
+                runQuery(sessionShareHarnessHooksQuery, params),
                 resolveTurnContent(sessionId),
             ]);
 
@@ -363,6 +367,14 @@ export const exportSessionShare = (
         // Each child's spawn-edge ts is anchored to the nearest parent turn so
         // the viewer can mark where it was launched.
         const shareTurns = turnsRaw.filter(isPresent);
+        // Harness hooks: assign idx + anchor each to the nearest turn by ts.
+        const harnessHooks = harnessHooksRaw
+            .filter(isPresent)
+            .map((hook, idx) => ({
+                idx,
+                ...hook,
+                anchor_turn_seq: anchorChildToTurn(shareTurns, hook.ts),
+            }));
         const nextVisited = new Set(visited).add(recordRef);
         const childLinks = childLinksRaw.filter(isPresent);
         const children = (
@@ -402,6 +414,7 @@ export const exportSessionShare = (
             files: filesRaw.filter(isPresent),
             children,
             hookFires,
+            harnessHooks,
             ...(options.spawnAnchorTurnSeq != null
                 ? { spawnAnchorTurnSeq: options.spawnAnchorTurnSeq }
                 : {}),


### PR DESCRIPTION
The session view never showed the user's actual harness hooks — `SessionStart` (caveman/superpowers injection), `PreToolUse:Write/Edit` (enforce-worktree), etc. They live in `hook_command_invocation`; the empty `hook_fire` table is a separate ax-only file-context feature. Now shares surface them.

- New session-scoped, bounded query over `hook_command_invocation`, filtered to effects that *did* something (`blocked` / `modified_input` / `injected_context` / `notified`) so passthrough noise stays out.
- Exporter assigns an `idx` + anchors each hook to its nearest turn by ts, adds `harness_hooks` to the artifact.
- Reader renders an inline `HarnessHookMarker` (`⊙ hook PreToolUse:Write · modified input`, colour-coded by effect) at the anchored turn, and feeds the idxs into the existing "next hook fire" jump (DOM ids offset so they never collide with file-context `hook_fire` markers).

## Verified in-browser
On a real share: a green `SessionStart:clear → injected context` marker renders inline after turn #4, and **"next hook fire (90)"** jumps between guardrail fires. (90 meaningful hooks: 44 injected_context, 46 modified_input.)

2098 tests pass; typecheck clean (axctl + studio SPA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)