### PR TITLE
perf(studio): virtualize shared transcript paint via content-visibility

### DIFF
--- a/apps/axctl/src/dashboard/web/src/routes/share-inspect.tsx
+++ b/apps/axctl/src/dashboard/web/src/routes/share-inspect.tsx
@@ -364,7 +364,14 @@ function InspectBody({
                         const spawned = subagentsByTurn?.get(turn.seq);
                         const hooks = harnessByTurn.get(turn.seq);
                         return (
-                            <div key={`turn-${turn.seq}`}>
+                            // content-visibility virtualizes paint/layout for
+                            // off-screen turns while keeping every turn in the
+                            // DOM, so #turn-N anchors, jumps, find, and the cost
+                            // rail keep working on huge (100k+ px) transcripts.
+                            <div
+                                key={`turn-${turn.seq}`}
+                                style={{ contentVisibility: "auto", containIntrinsicSize: "auto 200px" }}
+                            >
                                 <Turn
                                     turn={turn}
                                     anchored={anchoredSeq === turn.seq}


### PR DESCRIPTION
A long shared session renders as one huge page — a 679-turn session is ~140k px of DOM — so scrolling/paint got heavy.

Wrap each turn in `content-visibility: auto` + `contain-intrinsic-size: auto 200px`. The browser skips layout/paint for off-screen turns, but **every turn stays in the DOM** — so `#turn-N` anchors, the jump buttons, find, hook/spawn markers, and the cost rail all keep working. (JS windowing / react-virtual would evict offscreen turns and break all of that.)

## Verified
On a 679-turn / ~136k-px share (via in-page JS): all 679 turn wrappers get `content-visibility: auto`, the `#turn-1350` jump lands correctly (scrollY 97k, turn at top), and content paints on approach (`elementFromPoint` returns the real turn at viewport center). 10 share tests pass; typecheck clean.

Note: this also explains the "blank deep-scroll screenshot" from before — that was a CDP screenshot artifact on the very tall page, not an app bug; content always painted for real users. This change keeps the page light regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)