### PR TITLE
feat(timeline): LLM-free session timeline service (highlights + segments + events)

### DIFF
--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -81,6 +81,7 @@ import { ingestClaudeInsights } from "../ingest/claude-insights.ts";
 import { deriveSignals } from "../ingest/derive-signals.ts";
 import { deriveTurnIntents } from "../ingest/derive-intents.ts";
 import { INSIGHT_VIEWS, insightSqlForView, isInsightView } from "../queries/insights.ts";
+import { extractSessionTimeline, SessionTimelineServiceLayer } from "../timeline/service.ts";
 import { formatInsightRows } from "./insights-format.ts";
 import { writeDashboard } from "../dashboard/report.ts";
 import { serveDashboard } from "../dashboard/server.ts";
@@ -4429,6 +4430,37 @@ const statsCommand = Command.make(
     ({ skill }) => cmdStats([skill]),
 ).pipe(Command.withDescription("Show detailed stats for one skill"));
 
+const cmdTimeline = (sessionId: string, json: boolean) =>
+    extractSessionTimeline(sessionId).pipe(
+        Effect.provide(SessionTimelineServiceLayer),
+        Effect.flatMap((tl) =>
+            Effect.sync(() => {
+                if (json) {
+                    console.log(JSON.stringify(tl, null, 2));
+                    return;
+                }
+                const h = tl.highlights;
+                const dur = h.duration_ms != null ? `${(h.duration_ms / 3_600_000).toFixed(1)}h` : "?";
+                const total = Object.values(h.event_counts).reduce((a, b) => a + b, 0);
+                console.log(`${h.model ?? "?"} · ${h.repository ?? ""} · ${dur} · ${h.turns} turns · ${h.tool_calls} tools · ${h.tool_errors} errs · ${h.files_changed} files · $${h.cost_usd?.toFixed(2) ?? "?"}`);
+                console.log(`${tl.segments.length} segments · ${tl.events.length} key events (of ${total})\n`);
+                for (const s of tl.segments) {
+                    const r = s.rollup;
+                    console.log(`  ${s.id} [${s.boundary}] ${s.title}`);
+                    console.log(`     ${s.event_count} evts · ${r.tool_calls} tools · ${r.file_edits} edits · ${r.failures} fail/${r.recovered} rec · ${r.decisions} dec · ${r.checkpoints} chk · ${r.corrections} corr`);
+                }
+            })
+        ),
+    );
+
+const timelineCommand = Command.make(
+    "timeline",
+    { sessionId: Argument.string("session-id"), json: jsonFlag },
+    ({ sessionId, json }) => cmdTimeline(sessionId, json),
+).pipe(Command.withDescription(
+    "Highlight/event timeline for a session (segments + ranked events, LLM-free). --json for the full structure.",
+));
+
 const recentCommand = Command.make(
     "recent",
     { limit: positiveLimit(20) },
@@ -5148,6 +5180,7 @@ export const rootCommand = Command.make("axctl").pipe(
         Command.withHidden(agentsCommand),
         Command.withHidden(projectCommand),
         Command.withHidden(evidenceCommand),
+        Command.withHidden(timelineCommand),
         Command.withHidden(versionCommand),
         Command.withHidden(updateCommand),
         Command.withHidden(daemonCommand),
@@ -5296,6 +5329,7 @@ export const DB_COMMANDS: ReadonlySet<string> = new Set([
     "hooks",
     "agents",
     "evidence",
+    "timeline",
     "tui",
     "dogfood",
 ]);

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -27,6 +27,7 @@ import { fetchWorkflow } from "./workflow.ts";
 import { fetchSessionDetail } from "./session-detail.ts";
 import { fetchSessionCompare } from "./session-compare.ts";
 import { fetchSessionInspect } from "./session-inspect.ts";
+import { extractSessionTimeline, SessionTimelineServiceLayer } from "../timeline/service.ts";
 import { fetchSessionChildren, fetchSessionsList } from "./sessions-list.ts";
 import { fetchEpisodeTimeline } from "./episode-timeline.ts";
 import { fetchProject } from "./project.ts";
@@ -783,6 +784,27 @@ export async function handleDashboardRequest(req: Request): Promise<Response> {
                     turnOffset: Number.isFinite(turnOffset) ? turnOffset : 0,
                     turnLimit: Number.isFinite(turnLimit) ? turnLimit : 100,
                 }).pipe(
+                    Effect.provide(AppLayer),
+                    Effect.scoped,
+                ) as Effect.Effect<unknown>,
+            );
+            return jsonResponse(payload);
+        } catch (err) {
+            return jsonResponse(
+                { error: err instanceof Error ? err.message : String(err) },
+                err instanceof Error && /not found/i.test(err.message) ? 404 : 500,
+            );
+        }
+    }
+
+    const sessionTimelineMatch = url.pathname.match(/^\/api\/sessions\/(.+)\/timeline$/);
+    if (sessionTimelineMatch && req.method === "GET") {
+        const sessionId = decodeURIComponent(sessionTimelineMatch[1] ?? "");
+        if (!sessionId) return jsonResponse({ error: "missing session id" }, 400);
+        try {
+            const payload = await Effect.runPromise(
+                extractSessionTimeline(sessionId).pipe(
+                    Effect.provide(SessionTimelineServiceLayer),
                     Effect.provide(AppLayer),
                     Effect.scoped,
                 ) as Effect.Effect<unknown>,

--- a/apps/axctl/src/timeline/derive.test.ts
+++ b/apps/axctl/src/timeline/derive.test.ts
@@ -12,19 +12,42 @@ import type { ToolCallRow, EditRow } from "./queries.ts";
 
 const tc = (over: Partial<ToolCallRow>): ToolCallRow => ({
     seq: 0, ts: "2026-06-07T00:00:00Z", name: "Bash", command_norm: null,
-    output_excerpt: null, error_text: null, has_error: false, call_id: null, ...over,
+    command_text: null, output_excerpt: null, error_text: null, has_error: false, call_id: null, ...over,
 });
+const NO_EDGES = new Set<number>();
 
 describe("deriveToolEvents", () => {
-    it("keeps notable successes, drops errors and noise", () => {
+    it("keeps notable successes, drops errors and read-noise", () => {
         const events = deriveToolEvents([
             tc({ seq: 1, name: "Bash", command_norm: "bun test" }),
-            tc({ seq: 2, name: "Read", command_norm: null }), // not notable -> dropped
-            tc({ seq: 3, name: "Bash", command_norm: "x", has_error: true }), // error -> dropped (it's a failure)
-        ]);
+            tc({ seq: 2, name: "Read" }), // noise -> dropped
+            tc({ seq: 3, name: "Bash", command_norm: "x", has_error: true }), // error -> failure, not here
+        ], "claude", NO_EDGES);
         expect(events.map((e) => e.title)).toEqual(["bun test"]);
         expect(events[0]?.kind).toBe("tool_call");
         expect(events[0]?.status).toBe("ok");
+    });
+
+    it("surfaces codex exec_command as a tool (provider-aware)", () => {
+        const events = deriveToolEvents([
+            tc({ seq: 1, name: "exec_command", command_norm: "git status" }),
+        ], "codex", NO_EDGES);
+        expect(events[0]?.kind).toBe("tool_call");
+        expect(events[0]?.title).toBe("git status");
+    });
+
+    it("classifies a codex shell edit (sed) as file_edit", () => {
+        const events = deriveToolEvents([
+            tc({ seq: 1, name: "exec_command", command_norm: "sed", command_text: "sed -i s/a/b/ x.ts" }),
+        ], "codex", NO_EDGES);
+        expect(events[0]?.kind).toBe("file_edit");
+    });
+
+    it("lets the edited edge own claude file edits (skips tool_call dupes)", () => {
+        const events = deriveToolEvents([
+            tc({ seq: 5, name: "Edit" }),
+        ], "claude", new Set([5]));
+        expect(events).toHaveLength(0); // seq 5 covered by the edge
     });
 });
 
@@ -96,8 +119,9 @@ describe("deriveCheckpointEvents", () => {
 
 describe("buildTimeline", () => {
     const base: TimelineInputs = {
-        sessionId: "s1", health: null, overview: null, cost: null,
-        toolCalls: [], edits: [], skills: [], corrections: [], plans: [], commits: [], lastAssistant: null,
+        sessionId: "s1", source: "claude", health: null, overview: null, cost: null,
+        toolCalls: [], edits: [], skills: [], corrections: [], plans: [], commits: [],
+        asks: [], compactions: [], lastAssistant: null,
     };
 
     it("orders events by ts and tallies event_counts", () => {

--- a/apps/axctl/src/timeline/derive.test.ts
+++ b/apps/axctl/src/timeline/derive.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "bun:test";
+import {
+    buildTimeline,
+    deriveCheckpointEvents,
+    deriveDecisionEvents,
+    deriveFailureEvents,
+    deriveToolEvents,
+    pairRecoveries,
+    type TimelineInputs,
+} from "./derive.ts";
+import type { ToolCallRow, EditRow } from "./queries.ts";
+
+const tc = (over: Partial<ToolCallRow>): ToolCallRow => ({
+    seq: 0, ts: "2026-06-07T00:00:00Z", name: "Bash", command_norm: null,
+    output_excerpt: null, error_text: null, has_error: false, call_id: null, ...over,
+});
+
+describe("deriveToolEvents", () => {
+    it("keeps notable successes, drops errors and noise", () => {
+        const events = deriveToolEvents([
+            tc({ seq: 1, name: "Bash", command_norm: "bun test" }),
+            tc({ seq: 2, name: "Read", command_norm: null }), // not notable -> dropped
+            tc({ seq: 3, name: "Bash", command_norm: "x", has_error: true }), // error -> dropped (it's a failure)
+        ]);
+        expect(events.map((e) => e.title)).toEqual(["bun test"]);
+        expect(events[0]?.kind).toBe("tool_call");
+        expect(events[0]?.status).toBe("ok");
+    });
+});
+
+describe("deriveFailureEvents", () => {
+    it("surfaces has_error rows with the error's first line", () => {
+        const events = deriveFailureEvents([
+            tc({ seq: 5, name: "Bash", has_error: true, error_text: "Blocked: bad command\nmore" }),
+            tc({ seq: 6, name: "Read" }),
+        ]);
+        expect(events).toHaveLength(1);
+        expect(events[0]?.title).toBe("Bash: Blocked: bad command");
+        expect(events[0]?.status).toBe("error");
+        expect(events[0]?.recovered_by_seq).toBeNull();
+    });
+});
+
+describe("pairRecoveries", () => {
+    it("pairs a failure to the next same-command success within the window", () => {
+        const rows = [
+            tc({ seq: 10, name: "Bash", command_norm: "bun test", has_error: true, error_text: "fail", call_id: "c10" }),
+            tc({ seq: 14, name: "Bash", command_norm: "bun test", has_error: false, call_id: "c14" }),
+        ];
+        const [failure] = pairRecoveries(deriveFailureEvents(rows), rows, []);
+        expect(failure?.recovered_by_seq).toBe(14);
+    });
+
+    it("does not pair beyond the recovery window", () => {
+        const rows = [
+            tc({ seq: 10, name: "Bash", command_norm: "x", has_error: true, call_id: "c10" }),
+            tc({ seq: 100, name: "Bash", command_norm: "x", has_error: false, call_id: "c100" }),
+        ];
+        const [failure] = pairRecoveries(deriveFailureEvents(rows), rows, []);
+        expect(failure?.recovered_by_seq).toBeNull();
+    });
+
+    it("falls back to an edit on a file named in the error text", () => {
+        const rows = [
+            tc({ seq: 10, name: "Edit", has_error: true, error_text: "type error in registry.ts", call_id: "c10" }),
+        ];
+        const edits: EditRow[] = [
+            { seq: 12, ts: "2026-06-07T00:01:00Z", path: "src/ingest/registry.ts", edit_kind: "edit", tool: "Edit" },
+        ];
+        const [failure] = pairRecoveries(deriveFailureEvents(rows), rows, edits);
+        expect(failure?.recovered_by_seq).toBe(12);
+    });
+});
+
+describe("deriveDecisionEvents", () => {
+    it("uses summary, else the first plan item, else a fallback", () => {
+        const events = deriveDecisionEvents([
+            { ts: "2026-06-07T00:00:00Z", summary: "Split into layers", items: null },
+            { ts: "2026-06-07T00:01:00Z", summary: null, items: JSON.stringify([{ content: "step one" }, { content: "step two" }]) },
+            { ts: "2026-06-07T00:02:00Z", summary: null, items: "not json" },
+        ]);
+        expect(events.map((e) => e.title)).toEqual(["Split into layers", "step one", "plan updated"]);
+        expect(events[1]?.detail).toBe("2 steps");
+    });
+});
+
+describe("deriveCheckpointEvents", () => {
+    it("renders a short sha + commit subject", () => {
+        const [e] = deriveCheckpointEvents([
+            { ts: "2026-06-07T00:00:00Z", sha: "0febe0dabcdef", message: "release 0.12.0\n\nbody" },
+        ]);
+        expect(e?.title).toBe("committed 0febe0d · release 0.12.0");
+        expect(e?.refs[0]).toEqual({ type: "commit", id: "0febe0dabcdef" });
+    });
+});
+
+describe("buildTimeline", () => {
+    const base: TimelineInputs = {
+        sessionId: "s1", health: null, overview: null, cost: null,
+        toolCalls: [], edits: [], skills: [], corrections: [], plans: [], commits: [], lastAssistant: null,
+    };
+
+    it("orders events by ts and tallies event_counts", () => {
+        const tl = buildTimeline({
+            ...base,
+            toolCalls: [
+                tc({ seq: 2, ts: "2026-06-07T00:00:02Z", command_norm: "second" }),
+                tc({ seq: 1, ts: "2026-06-07T00:00:01Z", command_norm: "first" }),
+            ],
+            commits: [{ ts: "2026-06-07T00:00:03Z", sha: "abc1234", message: "c" }],
+        });
+        expect(tl.events.map((e) => e.title)).toEqual(["first", "second", "committed abc1234 · c"]);
+        expect(tl.highlights.event_counts.tool_call).toBe(2);
+        expect(tl.highlights.event_counts.checkpoint).toBe(1);
+    });
+
+    it("counts distinct files changed from edits", () => {
+        const tl = buildTimeline({
+            ...base,
+            edits: [
+                { seq: 1, ts: "2026-06-07T00:00:01Z", path: "a.ts", edit_kind: "edit", tool: "Edit" },
+                { seq: 2, ts: "2026-06-07T00:00:02Z", path: "a.ts", edit_kind: "edit", tool: "Edit" },
+                { seq: 3, ts: "2026-06-07T00:00:03Z", path: "b.ts", edit_kind: "write", tool: "Write" },
+            ],
+        });
+        expect(tl.highlights.files_changed).toBe(2);
+    });
+});

--- a/apps/axctl/src/timeline/derive.ts
+++ b/apps/axctl/src/timeline/derive.ts
@@ -1,0 +1,315 @@
+/**
+ * Pure timeline derivation - raw typed rows in, SessionTimeline out. No Effect,
+ * no SurrealDB, no LLM: every event is a deterministic projection of ingested
+ * data, so this whole module is unit-testable with plain fixtures.
+ */
+import type {
+    SessionHighlights,
+    SessionTimeline,
+    TimelineEvent,
+    TimelineEventKind,
+} from "./types.ts";
+import type {
+    CommitRow,
+    CorrectionRow,
+    CostRow,
+    EditRow,
+    HealthRow,
+    LastTurnRow,
+    OverviewRow,
+    PlanRow,
+    SkillRow,
+    ToolCallRow,
+} from "./queries.ts";
+
+const TITLE_MAX = 120;
+const DETAIL_MAX = 280;
+/** Seq distance within which a later success counts as recovering a failure. */
+const RECOVERY_WINDOW = 40;
+/** Tool names that are inherently "notable" even without a normalized command. */
+const NOTABLE_TOOLS = new Set(["Bash", "Task", "Agent"]);
+
+const firstLine = (s: string | null | undefined): string =>
+    (s ?? "").split("\n").find((l) => l.trim().length > 0)?.trim() ?? "";
+const clip = (s: string, n: number): string => (s.length > n ? `${s.slice(0, n - 1)}…` : s);
+const basename = (p: string): string => p.split("/").filter(Boolean).pop() ?? p;
+const tsValue = (ts: string | null): number => {
+    if (!ts) return Number.POSITIVE_INFINITY;
+    const t = new Date(ts).getTime();
+    return Number.isFinite(t) ? t : Number.POSITIVE_INFINITY;
+};
+
+// --- per-kind derivation ---------------------------------------------------
+
+const isNotableTool = (t: ToolCallRow): boolean =>
+    t.command_norm != null || NOTABLE_TOOLS.has(t.name);
+
+export function deriveToolEvents(rows: ReadonlyArray<ToolCallRow>): TimelineEvent[] {
+    return rows
+        .filter((t) => !t.has_error && isNotableTool(t) && t.ts != null)
+        .map((t) => ({
+            kind: "tool_call" as const,
+            ts: t.ts as string,
+            seq: t.seq,
+            title: clip(t.command_norm ?? t.name, TITLE_MAX),
+            ...(firstLine(t.output_excerpt) ? { detail: clip(firstLine(t.output_excerpt), DETAIL_MAX) } : {}),
+            status: "ok" as const,
+            refs: [
+                ...(t.call_id ? [{ type: "tool" as const, id: t.call_id }] : []),
+                ...(t.seq != null ? [{ type: "turn" as const, id: String(t.seq) }] : []),
+            ],
+        }));
+}
+
+export function deriveFailureEvents(rows: ReadonlyArray<ToolCallRow>): TimelineEvent[] {
+    return rows
+        .filter((t) => t.has_error && t.ts != null)
+        .map((t) => {
+            const reason = firstLine(t.error_text) || firstLine(t.output_excerpt) || "error";
+            return {
+                kind: "failure" as const,
+                ts: t.ts as string,
+                seq: t.seq,
+                title: clip(`${t.name}: ${reason}`, TITLE_MAX),
+                ...(t.error_text ? { detail: clip(t.error_text, DETAIL_MAX) } : {}),
+                status: "error" as const,
+                refs: [
+                    ...(t.call_id ? [{ type: "tool" as const, id: t.call_id }] : []),
+                    ...(t.seq != null ? [{ type: "turn" as const, id: String(t.seq) }] : []),
+                ],
+                recovered_by_seq: null as number | null,
+            };
+        });
+}
+
+export function deriveFileEvents(rows: ReadonlyArray<EditRow>): TimelineEvent[] {
+    return rows
+        .filter((e) => e.path != null && e.ts != null)
+        .map((e) => ({
+            kind: "file_edit" as const,
+            ts: e.ts as string,
+            seq: e.seq,
+            title: clip(e.path as string, TITLE_MAX),
+            ...(e.tool || e.edit_kind ? { detail: [e.tool, e.edit_kind].filter(Boolean).join(" · ") } : {}),
+            refs: [
+                { type: "file" as const, id: e.path as string },
+                ...(e.seq != null ? [{ type: "turn" as const, id: String(e.seq) }] : []),
+            ],
+        }));
+}
+
+export function deriveSkillEvents(rows: ReadonlyArray<SkillRow>): TimelineEvent[] {
+    return rows
+        .filter((s) => s.name != null && s.ts != null)
+        .map((s) => ({
+            kind: "skill_invocation" as const,
+            ts: s.ts as string,
+            seq: s.seq,
+            title: clip(s.name as string, TITLE_MAX),
+            refs: [
+                { type: "skill" as const, id: s.name as string },
+                ...(s.seq != null ? [{ type: "turn" as const, id: String(s.seq) }] : []),
+            ],
+        }));
+}
+
+export function deriveCorrectionEvents(rows: ReadonlyArray<CorrectionRow>): TimelineEvent[] {
+    return rows
+        .filter((c) => c.ts != null)
+        .map((c) => ({
+            kind: "correction" as const,
+            ts: c.ts as string,
+            seq: c.seq,
+            title: clip(c.target ? `correction: ${c.target}` : "user correction", TITLE_MAX),
+            ...(firstLine(c.user_text) ? { detail: clip(firstLine(c.user_text), DETAIL_MAX) } : {}),
+            refs: c.seq != null ? [{ type: "turn" as const, id: String(c.seq) }] : [],
+        }));
+}
+
+/** A plan_snapshot is the agent's own stated decision - the first/summary item. */
+export function deriveDecisionEvents(rows: ReadonlyArray<PlanRow>): TimelineEvent[] {
+    return rows
+        .filter((p) => p.ts != null)
+        .map((p) => {
+            let firstItem = "";
+            let count = 0;
+            if (p.items) {
+                try {
+                    const items = JSON.parse(p.items) as Array<{ content?: unknown }>;
+                    if (Array.isArray(items)) {
+                        count = items.length;
+                        const c = items.find((i) => typeof i?.content === "string")?.content;
+                        if (typeof c === "string") firstItem = c;
+                    }
+                } catch {
+                    /* malformed items - fall through to summary */
+                }
+            }
+            const title = p.summary || firstItem || "plan updated";
+            return {
+                kind: "decision" as const,
+                ts: p.ts as string,
+                seq: null,
+                title: clip(title, TITLE_MAX),
+                ...(count > 0 ? { detail: `${count} step${count === 1 ? "" : "s"}` } : {}),
+                refs: [],
+            };
+        });
+}
+
+export function deriveCheckpointEvents(rows: ReadonlyArray<CommitRow>): TimelineEvent[] {
+    return rows
+        .filter((c) => c.ts != null && c.sha != null)
+        .map((c) => ({
+            kind: "checkpoint" as const,
+            ts: c.ts as string,
+            seq: null,
+            title: clip(`committed ${(c.sha as string).slice(0, 7)}${c.message ? ` · ${firstLine(c.message)}` : ""}`, TITLE_MAX),
+            ...(c.message ? { detail: clip(c.message, DETAIL_MAX) } : {}),
+            refs: [{ type: "commit" as const, id: c.sha as string }],
+        }));
+}
+
+/** Raw closing state. Title/detail are last-assistant text - the seam where an
+ *  optional LLM gloss could replace the raw line later. */
+export function deriveOutcomeEvent(row: LastTurnRow | null): TimelineEvent[] {
+    if (!row || row.ts == null) return [];
+    const line = firstLine(row.text_excerpt) || "session ended";
+    return [{
+        kind: "outcome",
+        ts: row.ts,
+        seq: row.seq,
+        title: clip(line, TITLE_MAX),
+        ...(row.text_excerpt ? { detail: clip(row.text_excerpt, DETAIL_MAX) } : {}),
+        refs: row.seq != null ? [{ type: "turn", id: String(row.seq) }] : [],
+    }];
+}
+
+// --- recovery pairing (heuristic, LLM-free) --------------------------------
+
+const sameCommand = (a: ToolCallRow, b: ToolCallRow): boolean =>
+    (a.command_norm != null && a.command_norm === b.command_norm) || a.name === b.name;
+
+/**
+ * Mutates failure events in place, setting `recovered_by_seq` to the seq of the
+ * next success that plausibly fixed it: a later same-command/same-tool success,
+ * else the next edit on a file named in the error text, within RECOVERY_WINDOW.
+ */
+export function pairRecoveries(
+    failures: TimelineEvent[],
+    toolRows: ReadonlyArray<ToolCallRow>,
+    edits: ReadonlyArray<EditRow>,
+): TimelineEvent[] {
+    const byCallId = new Map(toolRows.map((t) => [t.call_id, t] as const));
+    return failures.map((f) => {
+        if (f.kind !== "failure" || f.seq == null) return f;
+        const failedCall = byCallId.get(f.refs.find((r) => r.type === "tool")?.id ?? null);
+        const sf = f.seq;
+        let recovered: number | null = null;
+        const success = toolRows.find(
+            (t) => !t.has_error && t.seq != null && t.seq > sf && t.seq - sf <= RECOVERY_WINDOW &&
+                (failedCall ? sameCommand(t, failedCall) : false),
+        );
+        if (success?.seq != null) recovered = success.seq;
+        if (recovered == null) {
+            const errText = (failedCall?.error_text ?? "").toLowerCase();
+            const fix = edits.find(
+                (e) => e.path != null && e.seq != null && e.seq > sf && e.seq - sf <= RECOVERY_WINDOW &&
+                    errText.includes(basename(e.path).toLowerCase()),
+            );
+            if (fix?.seq != null) recovered = fix.seq;
+        }
+        return { ...f, recovered_by_seq: recovered };
+    });
+}
+
+// --- assembly --------------------------------------------------------------
+
+const byTs = (a: TimelineEvent, b: TimelineEvent): number => {
+    const d = tsValue(a.ts) - tsValue(b.ts);
+    if (d !== 0) return d;
+    return (a.seq ?? Number.POSITIVE_INFINITY) - (b.seq ?? Number.POSITIVE_INFINITY);
+};
+
+const emptyCounts = (): Record<TimelineEventKind, number> => ({
+    decision: 0, tool_call: 0, file_edit: 0, skill_invocation: 0,
+    failure: 0, correction: 0, checkpoint: 0, outcome: 0,
+});
+
+export function deriveHighlights(input: {
+    readonly health: HealthRow | null;
+    readonly overview: OverviewRow | null;
+    readonly cost: CostRow | null;
+    readonly filesChanged: number;
+    readonly skillsUsed: number;
+    readonly events: ReadonlyArray<TimelineEvent>;
+}): SessionHighlights {
+    const h = input.health;
+    const o = input.overview;
+    const started = o?.started_at ?? null;
+    const ended = o?.ended_at ?? null;
+    const duration_ms = started && ended ? new Date(ended).getTime() - new Date(started).getTime() : null;
+    const event_counts = emptyCounts();
+    for (const e of input.events) event_counts[e.kind] += 1;
+    return {
+        started_at: started,
+        ended_at: ended,
+        duration_ms: duration_ms != null && Number.isFinite(duration_ms) ? duration_ms : null,
+        model: o?.model ?? null,
+        project: o?.project ?? null,
+        repository: o?.cwd ?? null,
+        turns: h?.turns ?? 0,
+        user_turns: h?.user_turns ?? 0,
+        assistant_turns: h?.assistant_turns ?? 0,
+        tool_calls: h?.tool_calls ?? 0,
+        tool_errors: h?.tool_errors ?? 0,
+        files_changed: input.filesChanged,
+        skills_used: input.skillsUsed,
+        corrections: h?.user_corrections ?? 0,
+        interruptions: h?.interruptions ?? 0,
+        cost_usd: input.cost?.cost_usd ?? null,
+        estimated_tokens: input.cost?.estimated_tokens ?? h?.estimated_tokens ?? null,
+        event_counts,
+    };
+}
+
+export interface TimelineInputs {
+    readonly sessionId: string;
+    readonly health: HealthRow | null;
+    readonly overview: OverviewRow | null;
+    readonly cost: CostRow | null;
+    readonly toolCalls: ReadonlyArray<ToolCallRow>;
+    readonly edits: ReadonlyArray<EditRow>;
+    readonly skills: ReadonlyArray<SkillRow>;
+    readonly corrections: ReadonlyArray<CorrectionRow>;
+    readonly plans: ReadonlyArray<PlanRow>;
+    readonly commits: ReadonlyArray<CommitRow>;
+    readonly lastAssistant: LastTurnRow | null;
+}
+
+const dedupePaths = (edits: ReadonlyArray<EditRow>): number =>
+    new Set(edits.map((e) => e.path).filter((p): p is string => p != null)).size;
+
+/** Compose all derivations into the final ordered SessionTimeline. Pure. */
+export function buildTimeline(input: TimelineInputs): SessionTimeline {
+    const failures = pairRecoveries(deriveFailureEvents(input.toolCalls), input.toolCalls, input.edits);
+    const events = [
+        ...deriveToolEvents(input.toolCalls),
+        ...failures,
+        ...deriveFileEvents(input.edits),
+        ...deriveSkillEvents(input.skills),
+        ...deriveCorrectionEvents(input.corrections),
+        ...deriveDecisionEvents(input.plans),
+        ...deriveCheckpointEvents(input.commits),
+        ...deriveOutcomeEvent(input.lastAssistant),
+    ].sort(byTs);
+    const highlights = deriveHighlights({
+        health: input.health,
+        overview: input.overview,
+        cost: input.cost,
+        filesChanged: dedupePaths(input.edits),
+        skillsUsed: new Set(input.skills.map((s) => s.name).filter(Boolean)).size,
+        events,
+    });
+    return { session_id: input.sessionId, highlights, events };
+}

--- a/apps/axctl/src/timeline/derive.ts
+++ b/apps/axctl/src/timeline/derive.ts
@@ -10,7 +10,9 @@ import type {
     TimelineEventKind,
 } from "./types.ts";
 import type {
+    AskRow,
     CommitRow,
+    CompactionRow,
     CorrectionRow,
     CostRow,
     EditRow,
@@ -21,13 +23,13 @@ import type {
     SkillRow,
     ToolCallRow,
 } from "./queries.ts";
+import { classifyTool, isRealSkill, type ProviderSource } from "./providers.ts";
+import { segmentize } from "./segment.ts";
 
 const TITLE_MAX = 120;
 const DETAIL_MAX = 280;
 /** Seq distance within which a later success counts as recovering a failure. */
 const RECOVERY_WINDOW = 40;
-/** Tool names that are inherently "notable" even without a normalized command. */
-const NOTABLE_TOOLS = new Set(["Bash", "Task", "Agent"]);
 
 const firstLine = (s: string | null | undefined): string =>
     (s ?? "").split("\n").find((l) => l.trim().length > 0)?.trim() ?? "";
@@ -41,24 +43,48 @@ const tsValue = (ts: string | null): number => {
 
 // --- per-kind derivation ---------------------------------------------------
 
-const isNotableTool = (t: ToolCallRow): boolean =>
-    t.command_norm != null || NOTABLE_TOOLS.has(t.name);
-
-export function deriveToolEvents(rows: ReadonlyArray<ToolCallRow>): TimelineEvent[] {
-    return rows
-        .filter((t) => !t.has_error && isNotableTool(t) && t.ts != null)
-        .map((t) => ({
-            kind: "tool_call" as const,
-            ts: t.ts as string,
+/**
+ * Successful tool calls -> tool_call / file_edit events, provider-aware. Errors
+ * are skipped (they become `failure` events). Noise (reads/searches) and the
+ * fake `<provider>:` skill shadow are dropped. codex/cursor edits (which have no
+ * `edited` edge) are recovered here from the command; claude/pi edits that the
+ * `edited` edge already covers (in `editedSeqs`) are left to deriveFileEvents
+ * so they keep their real path.
+ */
+export function deriveToolEvents(
+    rows: ReadonlyArray<ToolCallRow>,
+    source: ProviderSource,
+    editedSeqs: ReadonlySet<number>,
+): TimelineEvent[] {
+    const out: TimelineEvent[] = [];
+    for (const t of rows) {
+        if (t.has_error || t.ts == null) continue;
+        const c = classifyTool(source, { name: t.name, command_norm: t.command_norm, command_text: t.command_text });
+        if (c.kind === "noise" || c.kind === "skill") continue;
+        const turnRef = t.seq != null ? [{ type: "turn" as const, id: String(t.seq) }] : [];
+        if (c.kind === "file_edit") {
+            if (t.seq != null && editedSeqs.has(t.seq)) continue; // edge covers it with a real path
+            out.push({
+                kind: "file_edit",
+                ts: t.ts,
+                seq: t.seq,
+                title: clip(t.command_norm ?? t.name, TITLE_MAX),
+                ...(t.command_text ? { detail: clip(t.command_text, DETAIL_MAX) } : {}),
+                refs: turnRef,
+            });
+            continue;
+        }
+        out.push({
+            kind: "tool_call",
+            ts: t.ts,
             seq: t.seq,
             title: clip(t.command_norm ?? t.name, TITLE_MAX),
             ...(firstLine(t.output_excerpt) ? { detail: clip(firstLine(t.output_excerpt), DETAIL_MAX) } : {}),
-            status: "ok" as const,
-            refs: [
-                ...(t.call_id ? [{ type: "tool" as const, id: t.call_id }] : []),
-                ...(t.seq != null ? [{ type: "turn" as const, id: String(t.seq) }] : []),
-            ],
-        }));
+            status: "ok",
+            refs: [...(t.call_id ? [{ type: "tool" as const, id: t.call_id }] : []), ...turnRef],
+        });
+    }
+    return out;
 }
 
 export function deriveFailureEvents(rows: ReadonlyArray<ToolCallRow>): TimelineEvent[] {
@@ -98,9 +124,12 @@ export function deriveFileEvents(rows: ReadonlyArray<EditRow>): TimelineEvent[] 
         }));
 }
 
-export function deriveSkillEvents(rows: ReadonlyArray<SkillRow>): TimelineEvent[] {
+export function deriveSkillEvents(
+    rows: ReadonlyArray<SkillRow>,
+    source: ProviderSource,
+): TimelineEvent[] {
     return rows
-        .filter((s) => s.name != null && s.ts != null)
+        .filter((s) => s.name != null && s.ts != null && isRealSkill(source, s.name))
         .map((s) => ({
             kind: "skill_invocation" as const,
             ts: s.ts as string,
@@ -275,6 +304,7 @@ export function deriveHighlights(input: {
 
 export interface TimelineInputs {
     readonly sessionId: string;
+    readonly source: ProviderSource;
     readonly health: HealthRow | null;
     readonly overview: OverviewRow | null;
     readonly cost: CostRow | null;
@@ -284,6 +314,8 @@ export interface TimelineInputs {
     readonly corrections: ReadonlyArray<CorrectionRow>;
     readonly plans: ReadonlyArray<PlanRow>;
     readonly commits: ReadonlyArray<CommitRow>;
+    readonly asks: ReadonlyArray<AskRow>;
+    readonly compactions: ReadonlyArray<CompactionRow>;
     readonly lastAssistant: LastTurnRow | null;
 }
 
@@ -292,12 +324,15 @@ const dedupePaths = (edits: ReadonlyArray<EditRow>): number =>
 
 /** Compose all derivations into the final ordered SessionTimeline. Pure. */
 export function buildTimeline(input: TimelineInputs): SessionTimeline {
+    const editedSeqs = new Set(
+        input.edits.map((e) => e.seq).filter((s): s is number => s != null),
+    );
     const failures = pairRecoveries(deriveFailureEvents(input.toolCalls), input.toolCalls, input.edits);
     const events = [
-        ...deriveToolEvents(input.toolCalls),
+        ...deriveToolEvents(input.toolCalls, input.source, editedSeqs),
         ...failures,
         ...deriveFileEvents(input.edits),
-        ...deriveSkillEvents(input.skills),
+        ...deriveSkillEvents(input.skills, input.source),
         ...deriveCorrectionEvents(input.corrections),
         ...deriveDecisionEvents(input.plans),
         ...deriveCheckpointEvents(input.commits),
@@ -308,8 +343,15 @@ export function buildTimeline(input: TimelineInputs): SessionTimeline {
         overview: input.overview,
         cost: input.cost,
         filesChanged: dedupePaths(input.edits),
-        skillsUsed: new Set(input.skills.map((s) => s.name).filter(Boolean)).size,
-        events,
+        skillsUsed: isRealSkill(input.source, "x")
+            ? new Set(input.skills.map((s) => s.name).filter(Boolean)).size
+            : 0,
+        events, // full counts, before L1 capping
     });
-    return { session_id: input.sessionId, highlights, events };
+    const { segments, events: kept } = segmentize(
+        events,
+        { asks: input.asks, commits: input.commits, compactions: input.compactions },
+        input.overview?.started_at ?? null,
+    );
+    return { session_id: input.sessionId, highlights, segments, events: kept };
 }

--- a/apps/axctl/src/timeline/providers.ts
+++ b/apps/axctl/src/timeline/providers.ts
@@ -1,0 +1,101 @@
+/**
+ * Provider-aware event classification. The normalized `tool_call`/`turn` tables
+ * are shared, but their SEMANTICS differ per harness:
+ *  - claude/claude-subagent: dedicated Edit/Write tools; `Bash` carries
+ *    command_norm; `invoked` is a REAL Skill-tool stream.
+ *  - codex: no edit tool - edits ride inside `exec_command` (sed/tee/heredoc/
+ *    apply_patch); `invoked` is a `codex:<tool>` shadow of every call (fake).
+ *  - pi/opencode/cursor: `invoked` is likewise a `<provider>:<tool>` shadow.
+ * So tool/edit/skill classification must be keyed on the session `source`.
+ * Evidence: docs/design/session-timeline-plan.md.
+ */
+
+export type UnifiedKind = "tool" | "file_edit" | "skill" | "subagent" | "noise";
+export type Importance = "high" | "med" | "low";
+
+export interface ClassifiedTool {
+    readonly kind: UnifiedKind;
+    readonly importance: Importance;
+}
+
+export type ProviderSource =
+    | "claude"
+    | "claude-subagent"
+    | "codex"
+    | "pi"
+    | "opencode"
+    | "cursor"
+    | (string & {});
+
+const isClaudeLike = (source: ProviderSource): boolean =>
+    source === "claude" || source === "claude-subagent";
+
+/** Lowercased tool names that mean "this edited a file" across claude/pi/opencode. */
+const EDIT_TOOL_NAMES = new Set([
+    "edit", "write", "multiedit", "notebookedit", // claude
+    "edit_file", "apply_diff", // cursor
+]);
+const SUBAGENT_TOOL_NAMES = new Set([
+    "task", // claude / opencode
+    "spawn_agent", "wait_agent", "close_agent", "resume_agent", // codex
+]);
+const READ_NOISE_NAMES = new Set([
+    "read", "glob", "grep", "ls", "notebookread",
+    "read_file", "read_file_v2", "glob_file_search", "codebase_search", "list_dir",
+    "view_image",
+]);
+const SHELL_EXEC_NAMES = new Set([
+    "bash", "exec_command", "run_terminal_command", "run_terminal_command_v2",
+]);
+const META_NAMES = new Set([
+    "todowrite", "taskcreate", "taskupdate", "taskstop", "exitplanmode",
+    "update_plan", "get_goal", "update_goal", "create_goal", "write_stdin", "send_input",
+]);
+
+/** Base command (command_norm) of a codex `exec_command` that is really a file edit. */
+const CODEX_EDIT_COMMANDS = new Set(["sed", "tee", "patch", "dd", "apply_patch"]);
+/** Substrings in an exec command that indicate an in-place file write. */
+const CODEX_EDIT_HINTS = ["apply_patch", "<<'eof'", "<<eof", "> /", ">> /", "tee "];
+
+export interface ClassifyInput {
+    readonly name: string;
+    readonly command_norm: string | null;
+    /** Raw command / input text, used only for codex exec edit detection. */
+    readonly command_text: string | null;
+}
+
+/** Map one tool_call to a unified kind + importance, given the session source. */
+export function classifyTool(source: ProviderSource, t: ClassifyInput): ClassifiedTool {
+    const lname = t.name.toLowerCase();
+
+    if (SUBAGENT_TOOL_NAMES.has(lname)) return { kind: "subagent", importance: "high" };
+    if (EDIT_TOOL_NAMES.has(lname)) return { kind: "file_edit", importance: "high" };
+
+    // codex/pi/opencode/cursor edit through the shell - inspect the command.
+    if (SHELL_EXEC_NAMES.has(lname)) {
+        const cmd = (t.command_norm ?? "").toLowerCase();
+        const text = (t.command_text ?? "").toLowerCase();
+        const isEdit =
+            CODEX_EDIT_COMMANDS.has(cmd) ||
+            CODEX_EDIT_HINTS.some((h) => text.includes(h));
+        return isEdit ? { kind: "file_edit", importance: "high" } : { kind: "tool", importance: "high" };
+    }
+
+    if (READ_NOISE_NAMES.has(lname)) return { kind: "noise", importance: "low" };
+    if (lname === "skill") return { kind: "skill", importance: "high" };
+    if (META_NAMES.has(lname)) return { kind: "tool", importance: "med" };
+    if (lname.startsWith("mcp__")) return { kind: "tool", importance: "med" };
+
+    // unknown tool: surface it, but low importance so ranking can drop it.
+    return { kind: "tool", importance: "low" };
+}
+
+/**
+ * Whether an `invoked` skill row is a REAL skill. Only claude/claude-subagent
+ * have genuine Skill-tool invocations; the others emit a `<provider>:<tool>`
+ * shadow 1:1 with every tool call, which must be ignored.
+ */
+export function isRealSkill(source: ProviderSource, skillName: string): boolean {
+    if (!isClaudeLike(source)) return false;
+    return skillName.length > 0;
+}

--- a/apps/axctl/src/timeline/queries.ts
+++ b/apps/axctl/src/timeline/queries.ts
@@ -1,0 +1,200 @@
+/**
+ * Session-scoped SQL + row mappers for timeline extraction. Every query is
+ * bounded by the session record ref so it stays in the session indexes. Mappers
+ * turn raw SurrealDB records into clean typed rows so `derive.ts` can stay pure
+ * (no SurrealDB shapes, fully unit-testable with plain fixtures).
+ */
+import { isRecord, stringField, dateField } from "@ax/lib/shared/row-fields";
+import { toBareSessionId } from "@ax/lib/shared/session-id";
+
+/** `a13f9192-…` -> `session:⟨a13f9192-…⟩` (validated record ref). */
+export function sessionRef(sessionId: string): string {
+    return `session:⟨${toBareSessionId(sessionId)}⟩`;
+}
+
+const numField = (row: Record<string, unknown>, key: string): number | null => {
+    const v = row[key];
+    return typeof v === "number" && Number.isFinite(v) ? v : null;
+};
+const boolField = (row: Record<string, unknown>, key: string): boolean =>
+    row[key] === true;
+const seqField = (row: Record<string, unknown>, key: string): number | null =>
+    numField(row, key);
+
+// --- highlight inputs ------------------------------------------------------
+
+export interface HealthRow {
+    readonly turns: number;
+    readonly user_turns: number;
+    readonly assistant_turns: number;
+    readonly tool_calls: number;
+    readonly tool_errors: number;
+    readonly user_corrections: number;
+    readonly interruptions: number;
+    readonly estimated_tokens: number | null;
+}
+export const healthSql = (ref: string): string =>
+    `SELECT turns, user_turns, assistant_turns, tool_calls, tool_errors, user_corrections, interruptions, estimated_tokens FROM session_health WHERE session = ${ref} LIMIT 1;`;
+export const mapHealth = (raw: unknown): HealthRow | null => {
+    if (!isRecord(raw)) return null;
+    return {
+        turns: numField(raw, "turns") ?? 0,
+        user_turns: numField(raw, "user_turns") ?? 0,
+        assistant_turns: numField(raw, "assistant_turns") ?? 0,
+        tool_calls: numField(raw, "tool_calls") ?? 0,
+        tool_errors: numField(raw, "tool_errors") ?? 0,
+        user_corrections: numField(raw, "user_corrections") ?? 0,
+        interruptions: numField(raw, "interruptions") ?? 0,
+        estimated_tokens: numField(raw, "estimated_tokens"),
+    };
+};
+
+export interface OverviewRow {
+    readonly model: string | null;
+    readonly project: string | null;
+    readonly cwd: string | null;
+    readonly started_at: string | null;
+    readonly ended_at: string | null;
+}
+export const overviewSql = (ref: string): string =>
+    `SELECT model, project, cwd, started_at, ended_at FROM ${ref};`;
+export const mapOverview = (raw: unknown): OverviewRow | null => {
+    if (!isRecord(raw)) return null;
+    return {
+        model: stringField(raw, "model"),
+        project: stringField(raw, "project"),
+        cwd: stringField(raw, "cwd"),
+        started_at: dateField(raw, "started_at"),
+        ended_at: dateField(raw, "ended_at"),
+    };
+};
+
+export interface CostRow {
+    readonly cost_usd: number | null;
+    readonly estimated_tokens: number | null;
+}
+export const costSql = (ref: string): string =>
+    `SELECT estimated_cost_usd, estimated_tokens FROM session_token_usage WHERE session = ${ref} LIMIT 1;`;
+export const mapCost = (raw: unknown): CostRow | null => {
+    if (!isRecord(raw)) return null;
+    return { cost_usd: numField(raw, "estimated_cost_usd"), estimated_tokens: numField(raw, "estimated_tokens") };
+};
+
+// --- event inputs ----------------------------------------------------------
+
+export interface ToolCallRow {
+    readonly seq: number | null;
+    readonly ts: string | null;
+    readonly name: string;
+    readonly command_norm: string | null;
+    readonly output_excerpt: string | null;
+    readonly error_text: string | null;
+    readonly has_error: boolean;
+    readonly call_id: string | null;
+}
+export const toolCallsSql = (ref: string): string =>
+    `SELECT seq, ts, name, command_norm, output_excerpt, error_text, has_error, call_id FROM tool_call WHERE session = ${ref} ORDER BY seq ASC LIMIT 4000;`;
+export const mapToolCall = (raw: unknown): ToolCallRow | null => {
+    if (!isRecord(raw)) return null;
+    const name = stringField(raw, "name");
+    if (!name) return null;
+    return {
+        seq: seqField(raw, "seq"),
+        ts: dateField(raw, "ts"),
+        name,
+        command_norm: stringField(raw, "command_norm"),
+        output_excerpt: stringField(raw, "output_excerpt"),
+        error_text: stringField(raw, "error_text"),
+        has_error: boolField(raw, "has_error"),
+        call_id: stringField(raw, "call_id"),
+    };
+};
+
+export interface EditRow {
+    readonly seq: number | null;
+    readonly ts: string | null;
+    readonly path: string | null;
+    readonly edit_kind: string | null;
+    readonly tool: string | null;
+}
+export const editsSql = (ref: string): string =>
+    `SELECT in.seq AS seq, ts, path_seen AS path, edit_kind, tool FROM edited WHERE in.session = ${ref} ORDER BY seq ASC LIMIT 2000;`;
+export const mapEdit = (raw: unknown): EditRow | null => {
+    if (!isRecord(raw)) return null;
+    return {
+        seq: seqField(raw, "seq"),
+        ts: dateField(raw, "ts"),
+        path: stringField(raw, "path"),
+        edit_kind: stringField(raw, "edit_kind"),
+        tool: stringField(raw, "tool"),
+    };
+};
+
+export interface SkillRow {
+    readonly seq: number | null;
+    readonly ts: string | null;
+    readonly name: string | null;
+}
+export const skillsSql = (ref: string): string =>
+    `SELECT in.seq AS seq, ts, out.name AS name FROM invoked WHERE in.session = ${ref} AND out.name IS NOT NONE ORDER BY seq ASC LIMIT 2000;`;
+export const mapSkill = (raw: unknown): SkillRow | null => {
+    if (!isRecord(raw)) return null;
+    const name = stringField(raw, "name");
+    if (!name) return null;
+    return { seq: seqField(raw, "seq"), ts: dateField(raw, "ts"), name };
+};
+
+export interface CorrectionRow {
+    readonly seq: number | null;
+    readonly ts: string | null;
+    readonly target: string | null;
+    readonly user_text: string | null;
+}
+/** Typed user-redirect signal (classifier), not the noisy `corrected_by` regex. */
+export const correctionsSql = (ref: string): string =>
+    `SELECT user_turn.seq AS seq, ts, target, user_text FROM reaction_event WHERE session = ${ref} AND (polarity = "revise" OR reaction_type = "correction") ORDER BY seq ASC LIMIT 500;`;
+export const mapCorrection = (raw: unknown): CorrectionRow | null => {
+    if (!isRecord(raw)) return null;
+    return {
+        seq: seqField(raw, "seq"),
+        ts: dateField(raw, "ts"),
+        target: stringField(raw, "target"),
+        user_text: stringField(raw, "user_text"),
+    };
+};
+
+export interface PlanRow {
+    readonly ts: string | null;
+    readonly summary: string | null;
+    readonly items: string | null;
+}
+export const plansSql = (ref: string): string =>
+    `SELECT ts, summary, items FROM plan_snapshot WHERE session = ${ref} ORDER BY ts ASC LIMIT 500;`;
+export const mapPlan = (raw: unknown): PlanRow | null => {
+    if (!isRecord(raw)) return null;
+    return { ts: dateField(raw, "ts"), summary: stringField(raw, "summary"), items: stringField(raw, "items") };
+};
+
+export interface CommitRow {
+    readonly ts: string | null;
+    readonly sha: string | null;
+    readonly message: string | null;
+}
+export const commitsSql = (ref: string): string =>
+    `SELECT out.ts AS ts, out.sha AS sha, out.message AS message FROM produced WHERE in = ${ref} AND kind = "commit" ORDER BY ts ASC LIMIT 200;`;
+export const mapCommit = (raw: unknown): CommitRow | null => {
+    if (!isRecord(raw)) return null;
+    return { ts: dateField(raw, "ts"), sha: stringField(raw, "sha"), message: stringField(raw, "message") };
+};
+
+export interface LastTurnRow {
+    readonly seq: number | null;
+    readonly ts: string | null;
+    readonly text_excerpt: string | null;
+}
+export const lastAssistantSql = (ref: string): string =>
+    `SELECT seq, ts, text_excerpt FROM turn WHERE session = ${ref} AND role = "assistant" ORDER BY seq DESC LIMIT 1;`;
+export const mapLastTurn = (raw: unknown): LastTurnRow | null => {
+    if (!isRecord(raw)) return null;
+    return { seq: seqField(raw, "seq"), ts: dateField(raw, "ts"), text_excerpt: stringField(raw, "text_excerpt") };
+};

--- a/apps/axctl/src/timeline/queries.ts
+++ b/apps/axctl/src/timeline/queries.ts
@@ -50,6 +50,7 @@ export const mapHealth = (raw: unknown): HealthRow | null => {
 };
 
 export interface OverviewRow {
+    readonly source: string | null;
     readonly model: string | null;
     readonly project: string | null;
     readonly cwd: string | null;
@@ -57,10 +58,11 @@ export interface OverviewRow {
     readonly ended_at: string | null;
 }
 export const overviewSql = (ref: string): string =>
-    `SELECT model, project, cwd, started_at, ended_at FROM ${ref};`;
+    `SELECT source, model, project, cwd, started_at, ended_at FROM ${ref};`;
 export const mapOverview = (raw: unknown): OverviewRow | null => {
     if (!isRecord(raw)) return null;
     return {
+        source: stringField(raw, "source"),
         model: stringField(raw, "model"),
         project: stringField(raw, "project"),
         cwd: stringField(raw, "cwd"),
@@ -87,13 +89,15 @@ export interface ToolCallRow {
     readonly ts: string | null;
     readonly name: string;
     readonly command_norm: string | null;
+    /** First 400 chars of input_json - codex edit detection peeks at the command. */
+    readonly command_text: string | null;
     readonly output_excerpt: string | null;
     readonly error_text: string | null;
     readonly has_error: boolean;
     readonly call_id: string | null;
 }
 export const toolCallsSql = (ref: string): string =>
-    `SELECT seq, ts, name, command_norm, output_excerpt, error_text, has_error, call_id FROM tool_call WHERE session = ${ref} ORDER BY seq ASC LIMIT 4000;`;
+    `SELECT seq, ts, name, command_norm, string::slice(input_json ?? "", 0, 400) AS command_text, output_excerpt, error_text, has_error, call_id FROM tool_call WHERE session = ${ref} ORDER BY seq ASC LIMIT 6000;`;
 export const mapToolCall = (raw: unknown): ToolCallRow | null => {
     if (!isRecord(raw)) return null;
     const name = stringField(raw, "name");
@@ -103,6 +107,7 @@ export const mapToolCall = (raw: unknown): ToolCallRow | null => {
         ts: dateField(raw, "ts"),
         name,
         command_norm: stringField(raw, "command_norm"),
+        command_text: stringField(raw, "command_text"),
         output_excerpt: stringField(raw, "output_excerpt"),
         error_text: stringField(raw, "error_text"),
         has_error: boolField(raw, "has_error"),
@@ -163,6 +168,15 @@ export const mapCorrection = (raw: unknown): CorrectionRow | null => {
     };
 };
 
+/** Fallback correction source: turns the classifier tagged intent_kind=correction
+ *  (catches redirects the reaction_event table missed). Merged + deduped by seq. */
+export const intentCorrectionsSql = (ref: string): string =>
+    `SELECT seq, ts, text_excerpt AS user_text FROM turn WHERE session = ${ref} AND intent_kind = "correction" ORDER BY seq ASC LIMIT 500;`;
+export const mapIntentCorrection = (raw: unknown): CorrectionRow | null => {
+    if (!isRecord(raw)) return null;
+    return { seq: seqField(raw, "seq"), ts: dateField(raw, "ts"), target: null, user_text: stringField(raw, "user_text") };
+};
+
 export interface PlanRow {
     readonly ts: string | null;
     readonly summary: string | null;
@@ -185,6 +199,31 @@ export const commitsSql = (ref: string): string =>
 export const mapCommit = (raw: unknown): CommitRow | null => {
     if (!isRecord(raw)) return null;
     return { ts: dateField(raw, "ts"), sha: stringField(raw, "sha"), message: stringField(raw, "message") };
+};
+
+export interface AskRow {
+    readonly seq: number | null;
+    readonly ts: string | null;
+    readonly text: string | null;
+}
+/** User "asks" - segment boundaries. message_kind=task is the real prompt
+ *  (skips control/context/tool-result user turns). */
+export const asksSql = (ref: string): string =>
+    `SELECT seq, ts, text_excerpt AS text FROM turn WHERE session = ${ref} AND role = "user" AND message_kind = "task" ORDER BY seq ASC LIMIT 1000;`;
+export const mapAsk = (raw: unknown): AskRow | null => {
+    if (!isRecord(raw)) return null;
+    return { seq: seqField(raw, "seq"), ts: dateField(raw, "ts"), text: stringField(raw, "text") };
+};
+
+export interface CompactionRow {
+    readonly ts: string | null;
+}
+export const compactionsSql = (ref: string): string =>
+    `SELECT ts FROM compaction WHERE session = ${ref} ORDER BY ts ASC LIMIT 200;`;
+export const mapCompaction = (raw: unknown): CompactionRow | null => {
+    if (!isRecord(raw)) return null;
+    const ts = dateField(raw, "ts");
+    return ts ? { ts } : null;
 };
 
 export interface LastTurnRow {

--- a/apps/axctl/src/timeline/segment.test.ts
+++ b/apps/axctl/src/timeline/segment.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { buildBoundaries, segmentize } from "./segment.ts";
+import type { TimelineEvent } from "./types.ts";
+
+const ev = (kind: TimelineEvent["kind"], seq: number, secs: number, over: Partial<TimelineEvent> = {}): TimelineEvent => ({
+    kind, seq, ts: new Date(Date.UTC(2026, 0, 1, 0, 0, secs)).toISOString(), title: `${kind}-${seq}`, refs: [], ...over,
+});
+
+describe("buildBoundaries", () => {
+    it("merges asks/commits/compactions ts-sorted with a session_start anchor", () => {
+        const bs = buildBoundaries(
+            {
+                asks: [{ seq: 1, ts: "2026-01-01T00:00:05Z", text: "do the thing" }],
+                commits: [{ ts: "2026-01-01T00:00:10Z", sha: "abc1234def", message: "ship it" }],
+                compactions: [{ ts: "2026-01-01T00:00:08Z" }],
+            },
+            "2026-01-01T00:00:00Z",
+        );
+        expect(bs.map((b) => b.kind)).toEqual(["session_start", "ask", "compaction", "commit"]);
+        expect(bs[3]?.label).toContain("abc1234");
+    });
+});
+
+describe("segmentize", () => {
+    it("buckets events into segments and keeps FULL rollup counts", () => {
+        const events = [
+            ev("tool_call", 1, 1), ev("file_edit", 2, 2, { refs: [{ type: "file", id: "a.ts" }] }),
+            ev("failure", 3, 11, { recovered_by_seq: 4 }), ev("tool_call", 4, 12),
+        ];
+        const { segments } = segmentize(
+            events,
+            { asks: [{ seq: 3, ts: "2026-01-01T00:00:10Z", text: "fix it" }], commits: [], compactions: [] },
+            "2026-01-01T00:00:00Z",
+        );
+        expect(segments).toHaveLength(2); // session_start + the ask
+        expect(segments[0]?.rollup.tool_calls).toBe(1);
+        expect(segments[0]?.rollup.file_edits).toBe(1);
+        expect(segments[0]?.rollup.files).toBe(1);
+        expect(segments[1]?.rollup.failures).toBe(1);
+        expect(segments[1]?.rollup.recovered).toBe(1);
+        expect(segments[1]?.title).toBe("fix it");
+    });
+
+    it("caps kept events per segment but the rollup still reflects everything", () => {
+        const events = Array.from({ length: 100 }, (_, i) => ev("tool_call", i, i));
+        const { segments, events: kept } = segmentize(
+            events, { asks: [], commits: [], compactions: [] }, "2026-01-01T00:00:00Z",
+            { perSegmentCap: 10, globalBudget: 1000 },
+        );
+        expect(segments[0]?.event_count).toBe(100); // full
+        expect(kept.length).toBe(10); // capped
+        expect(kept.every((e) => e.segment_id === "seg-0")).toBe(true);
+    });
+
+    it("hard-caps total segments by sampling structural boundaries", () => {
+        const commits = Array.from({ length: 200 }, (_, i) => ({
+            ts: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(), sha: `sha${i}`, message: `c${i}`,
+        }));
+        const events = commits.map((c, i) => ev("checkpoint", i, i));
+        const { segments } = segmentize(events, { asks: [], commits, compactions: [] }, "2026-01-01T00:00:00Z", { maxSegments: 30 });
+        expect(segments.length).toBeLessThanOrEqual(30);
+    });
+
+    it("respects the global budget across segments", () => {
+        const asks = Array.from({ length: 5 }, (_, i) => ({ seq: i * 100, ts: new Date(Date.UTC(2026, 0, 1, 0, i, 0)).toISOString(), text: `ask ${i}` }));
+        const events = Array.from({ length: 500 }, (_, i) => ev("tool_call", i, i * 2));
+        const { events: kept } = segmentize(events, { asks, commits: [], compactions: [] }, "2026-01-01T00:00:00Z",
+            { perSegmentCap: 1000, globalBudget: 50 });
+        expect(kept.length).toBe(50);
+    });
+});

--- a/apps/axctl/src/timeline/segment.ts
+++ b/apps/axctl/src/timeline/segment.ts
@@ -1,0 +1,209 @@
+/**
+ * L2 segmentation + L1 importance capping. Turns the flat event stream into
+ * phases (segments) bounded by LLM-free signals - commits, user asks,
+ * compactions, large time-gaps - then ranks events within each segment and caps
+ * them so a 45k-turn loop reads as ~its iterations, each drillable, instead of
+ * thousands of rows. Segment rollups keep the FULL counts so nothing is hidden.
+ * Pure - unit-testable with plain fixtures.
+ */
+import type {
+    SegmentBoundary,
+    TimelineEvent,
+    TimelineEventKind,
+    TimelineSegment,
+} from "./types.ts";
+import type { AskRow, CommitRow, CompactionRow } from "./queries.ts";
+
+export const MAX_SEGMENTS = 30;
+export const PER_SEGMENT_CAP = 25;
+export const GLOBAL_BUDGET = 300;
+const TIME_GAP_MS = 30 * 60 * 1000;
+
+const KIND_WEIGHT: Record<TimelineEventKind, number> = {
+    outcome: 100, failure: 90, decision: 80, checkpoint: 75,
+    correction: 70, skill_invocation: 55, file_edit: 45, tool_call: 30,
+};
+
+const tsValue = (ts: string | null): number => {
+    if (!ts) return Number.POSITIVE_INFINITY;
+    const t = new Date(ts).getTime();
+    return Number.isFinite(t) ? t : Number.POSITIVE_INFINITY;
+};
+const firstLine = (s: string | null | undefined): string =>
+    (s ?? "").split("\n").find((l) => l.trim().length > 0)?.trim() ?? "";
+const clip = (s: string, n: number): string => (s.length > n ? `${s.slice(0, n - 1)}…` : s);
+
+interface Boundary {
+    readonly ts: string;
+    readonly seq: number | null;
+    readonly kind: SegmentBoundary;
+    readonly label: string;
+}
+
+export interface SegmentInputs {
+    readonly asks: ReadonlyArray<AskRow>;
+    readonly commits: ReadonlyArray<CommitRow>;
+    readonly compactions: ReadonlyArray<CompactionRow>;
+}
+
+/** Collect every boundary signal, ts-sorted, with a session_start anchor. */
+export function buildBoundaries(input: SegmentInputs, firstTs: string | null): Boundary[] {
+    const bs: Boundary[] = [];
+    for (const a of input.asks) {
+        if (a.ts) bs.push({ ts: a.ts, seq: a.seq, kind: "ask", label: clip(firstLine(a.text) || "user ask", 100) });
+    }
+    for (const c of input.commits) {
+        if (c.ts) bs.push({ ts: c.ts, seq: null, kind: "commit", label: clip(`committed${c.sha ? ` ${c.sha.slice(0, 7)}` : ""}${c.message ? ` · ${firstLine(c.message)}` : ""}`, 100) });
+    }
+    for (const k of input.compactions) {
+        if (k.ts) bs.push({ ts: k.ts, seq: null, kind: "compaction", label: "context compacted" });
+    }
+    bs.sort((a, b) => tsValue(a.ts) - tsValue(b.ts));
+    const anchorTs = firstTs ?? bs[0]?.ts ?? null;
+    if (anchorTs && (bs.length === 0 || tsValue(bs[0]!.ts) > tsValue(anchorTs))) {
+        bs.unshift({ ts: anchorTs, seq: null, kind: "session_start", label: "session start" });
+    }
+    return bs;
+}
+
+/** Insert time-gap boundaries where events jump > TIME_GAP_MS and no boundary
+ *  already sits in the gap - the universal fallback when asks/commits are sparse. */
+function withTimeGaps(boundaries: Boundary[], events: ReadonlyArray<TimelineEvent>): Boundary[] {
+    if (events.length === 0) return boundaries;
+    const out = [...boundaries];
+    const bset = new Set(boundaries.map((b) => Math.floor(tsValue(b.ts) / 1000)));
+    for (let i = 1; i < events.length; i++) {
+        const prev = tsValue(events[i - 1]!.ts);
+        const cur = tsValue(events[i]!.ts);
+        if (cur - prev > TIME_GAP_MS && !bset.has(Math.floor(cur / 1000))) {
+            out.push({ ts: events[i]!.ts, seq: events[i]!.seq, kind: "time_gap", label: "resumed after a pause" });
+            bset.add(Math.floor(cur / 1000));
+        }
+    }
+    out.sort((a, b) => tsValue(a.ts) - tsValue(b.ts));
+    return out;
+}
+
+const evenSample = <T>(arr: ReadonlyArray<T>, n: number): T[] => {
+    if (n >= arr.length) return [...arr];
+    if (n <= 0) return [];
+    const step = arr.length / n;
+    return Array.from({ length: n }, (_, i) => arr[Math.floor(i * step)]!);
+};
+
+/**
+ * Adaptive collapse to <= max segments. Always keep session_start; prefer
+ * structural boundaries (commit/compaction) over soft ones (ask/time_gap); if
+ * even the structural ones exceed the budget, evenly sample THEM too so a
+ * 200-commit loop still reads as ~max phases (drill-down covers the rest).
+ */
+function selectBoundaries(boundaries: Boundary[], max: number): Boundary[] {
+    if (boundaries.length <= max) return boundaries;
+    const start = boundaries.filter((b) => b.kind === "session_start");
+    const structural = boundaries.filter((b) => b.kind === "commit" || b.kind === "compaction");
+    const soft = boundaries.filter((b) => b.kind === "ask" || b.kind === "time_gap");
+    const slots = Math.max(0, max - start.length);
+    const chosen = structural.length >= slots
+        ? evenSample(structural, slots)
+        : [...structural, ...evenSample(soft, slots - structural.length)];
+    const merged = [...start, ...chosen];
+    merged.sort((a, b) => tsValue(a.ts) - tsValue(b.ts));
+    return merged;
+}
+
+const emptyRollup = () => ({
+    tool_calls: 0, file_edits: 0, files: 0, failures: 0, recovered: 0,
+    skills: 0, decisions: 0, checkpoints: 0, corrections: 0,
+});
+
+function tally(rollup: ReturnType<typeof emptyRollup>, e: TimelineEvent, files: Set<string>): void {
+    switch (e.kind) {
+        case "tool_call": rollup.tool_calls++; break;
+        case "file_edit": {
+            rollup.file_edits++;
+            const f = e.refs.find((r) => r.type === "file")?.id;
+            if (f) files.add(f);
+            break;
+        }
+        case "failure": rollup.failures++; if (e.recovered_by_seq != null) rollup.recovered++; break;
+        case "skill_invocation": rollup.skills++; break;
+        case "decision": rollup.decisions++; break;
+        case "checkpoint": rollup.checkpoints++; break;
+        case "correction": rollup.corrections++; break;
+        default: break;
+    }
+}
+
+export interface Segmented {
+    readonly segments: TimelineSegment[];
+    /** Events, capped per-segment + globally, each tagged with segment_id. */
+    readonly events: TimelineEvent[];
+}
+
+/**
+ * Assign events to segments, compute full rollups, then rank + cap the events.
+ * `allEvents` must already be ts-sorted.
+ */
+export function segmentize(
+    allEvents: ReadonlyArray<TimelineEvent>,
+    input: SegmentInputs,
+    firstTs: string | null,
+    opts: { maxSegments?: number; perSegmentCap?: number; globalBudget?: number } = {},
+): Segmented {
+    const maxSegments = opts.maxSegments ?? MAX_SEGMENTS;
+    const perSegmentCap = opts.perSegmentCap ?? PER_SEGMENT_CAP;
+    const globalBudget = opts.globalBudget ?? GLOBAL_BUDGET;
+
+    let boundaries = withTimeGaps(buildBoundaries(input, firstTs), allEvents);
+    boundaries = selectBoundaries(boundaries, maxSegments);
+    if (boundaries.length === 0) {
+        boundaries = [{ ts: firstTs ?? allEvents[0]?.ts ?? "1970-01-01T00:00:00Z", seq: null, kind: "session_start", label: "session" }];
+    }
+
+    // bucket each event into the last boundary at-or-before its ts
+    const buckets: TimelineEvent[][] = boundaries.map(() => []);
+    const bts = boundaries.map((b) => tsValue(b.ts));
+    for (const e of allEvents) {
+        const et = tsValue(e.ts);
+        let idx = 0;
+        for (let i = 0; i < bts.length; i++) { if (bts[i]! <= et) idx = i; else break; }
+        buckets[idx]!.push(e);
+    }
+
+    // build segment metas (full rollups) + per-segment ranked+capped events
+    const segments: TimelineSegment[] = [];
+    let kept: TimelineEvent[] = [];
+    boundaries.forEach((b, i) => {
+        const evs = buckets[i]!;
+        const id = `seg-${i}`;
+        const rollup = emptyRollup();
+        const files = new Set<string>();
+        for (const e of evs) tally(rollup, e, files);
+        rollup.files = files.size;
+        const seqs = evs.map((e) => e.seq).filter((s): s is number => s != null);
+        const lastTs = evs.length > 0 ? evs[evs.length - 1]!.ts : (boundaries[i + 1]?.ts ?? null);
+        segments.push({
+            id, index: i, title: b.label, boundary: b.kind,
+            start_seq: b.seq ?? (seqs.length ? Math.min(...seqs) : null),
+            end_seq: seqs.length ? Math.max(...seqs) : null,
+            started_at: b.ts, ended_at: lastTs,
+            duration_ms: lastTs ? Math.max(0, tsValue(lastTs) - tsValue(b.ts)) : null,
+            rollup, event_count: evs.length,
+        });
+        const ranked = [...evs]
+            .map((e) => ({ e, w: KIND_WEIGHT[e.kind] ?? 0 }))
+            .sort((a, z) => (z.w - a.w) || (tsValue(a.e.ts) - tsValue(z.e.ts)))
+            .slice(0, perSegmentCap)
+            .map(({ e }) => ({ ...e, segment_id: id }));
+        kept.push(...ranked);
+    });
+
+    // global budget: if still over, keep the highest-weight events overall
+    if (kept.length > globalBudget) {
+        kept = [...kept]
+            .sort((a, b) => (KIND_WEIGHT[b.kind] - KIND_WEIGHT[a.kind]) || (tsValue(a.ts) - tsValue(b.ts)))
+            .slice(0, globalBudget);
+    }
+    kept.sort((a, b) => (tsValue(a.ts) - tsValue(b.ts)) || ((a.seq ?? Infinity) - (b.seq ?? Infinity)));
+    return { segments, events: kept };
+}

--- a/apps/axctl/src/timeline/service.ts
+++ b/apps/axctl/src/timeline/service.ts
@@ -10,14 +10,20 @@ import { SurrealClient } from "@ax/lib/db";
 import { buildTimeline } from "./derive.ts";
 import type { SessionTimeline } from "./types.ts";
 import {
+    asksSql,
     commitsSql,
+    compactionsSql,
     correctionsSql,
     costSql,
     editsSql,
     healthSql,
     lastAssistantSql,
+    mapAsk,
     mapCommit,
+    mapCompaction,
+    intentCorrectionsSql,
     mapCorrection,
+    mapIntentCorrection,
     mapCost,
     mapEdit,
     mapHealth,
@@ -60,7 +66,7 @@ export const SessionTimelineServiceLayer = Layer.effect(SessionTimelineService)(
                 const ref = sessionRef(sessionId);
                 const [
                     healthRaw, overviewRaw, costRaw, toolRaw, editRaw,
-                    skillRaw, correctionRaw, planRaw, commitRaw, lastRaw,
+                    skillRaw, correctionRaw, intentCorrectionRaw, planRaw, commitRaw, askRaw, compactionRaw, lastRaw,
                 ] = yield* Effect.all([
                     oneRow(healthSql(ref)),
                     oneRow(overviewSql(ref)),
@@ -69,22 +75,39 @@ export const SessionTimelineServiceLayer = Layer.effect(SessionTimelineService)(
                     rows(editsSql(ref)),
                     rows(skillsSql(ref)),
                     rows(correctionsSql(ref)),
+                    rows(intentCorrectionsSql(ref)),
                     rows(plansSql(ref)),
                     rows(commitsSql(ref)),
+                    rows(asksSql(ref)),
+                    rows(compactionsSql(ref)),
                     oneRow(lastAssistantSql(ref)),
                 ], { concurrency: "unbounded" });
 
+                const overview = mapOverview(overviewRaw);
+                // Merge both correction sources, dedupe by seq (reaction_event wins - it has a target).
+                const correctionBySeq = new Map<number, ReturnType<typeof mapCorrection>>();
+                for (const c of intentCorrectionRaw.map(mapIntentCorrection).filter(present)) {
+                    if (c.seq != null) correctionBySeq.set(c.seq, c);
+                }
+                for (const c of correctionRaw.map(mapCorrection).filter(present)) {
+                    if (c.seq != null) correctionBySeq.set(c.seq, c);
+                }
+                const corrections = [...correctionBySeq.values()].filter(present).sort((a, b) => (a!.seq ?? 0) - (b!.seq ?? 0));
+
                 return buildTimeline({
                     sessionId,
+                    source: overview?.source ?? "claude",
                     health: mapHealth(healthRaw),
-                    overview: mapOverview(overviewRaw),
+                    overview,
                     cost: mapCost(costRaw),
                     toolCalls: toolRaw.map(mapToolCall).filter(present),
                     edits: editRaw.map(mapEdit).filter(present),
                     skills: skillRaw.map(mapSkill).filter(present),
-                    corrections: correctionRaw.map(mapCorrection).filter(present),
+                    corrections,
                     plans: planRaw.map(mapPlan).filter(present),
                     commits: commitRaw.map(mapCommit).filter(present),
+                    asks: askRaw.map(mapAsk).filter(present),
+                    compactions: compactionRaw.map(mapCompaction).filter(present),
                     lastAssistant: mapLastTurn(lastRaw),
                 });
             });

--- a/apps/axctl/src/timeline/service.ts
+++ b/apps/axctl/src/timeline/service.ts
@@ -1,0 +1,100 @@
+/**
+ * SessionTimelineService - feed a session id, get the highlight/event timeline.
+ * Thin Effect wrapper: runs the session-scoped queries in parallel, maps rows
+ * to clean shapes, and hands them to the pure `buildTimeline` derivation. All
+ * the logic lives in `derive.ts` (testable without a DB); this layer is just
+ * I/O + composition.
+ */
+import { Context, Effect, Layer } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { buildTimeline } from "./derive.ts";
+import type { SessionTimeline } from "./types.ts";
+import {
+    commitsSql,
+    correctionsSql,
+    costSql,
+    editsSql,
+    healthSql,
+    lastAssistantSql,
+    mapCommit,
+    mapCorrection,
+    mapCost,
+    mapEdit,
+    mapHealth,
+    mapLastTurn,
+    mapOverview,
+    mapPlan,
+    mapSkill,
+    mapToolCall,
+    overviewSql,
+    plansSql,
+    sessionRef,
+    skillsSql,
+    toolCallsSql,
+} from "./queries.ts";
+
+const present = <T>(x: T | null): x is T => x !== null;
+
+export interface SessionTimelineShape {
+    readonly extract: (sessionId: string) => Effect.Effect<SessionTimeline>;
+}
+
+export class SessionTimelineService extends Context.Service<
+    SessionTimelineService,
+    SessionTimelineShape
+>()("ax/SessionTimelineService") {}
+
+export const SessionTimelineServiceLayer = Layer.effect(SessionTimelineService)(
+    Effect.gen(function* () {
+            const db = yield* SurrealClient;
+
+            const rows = (sql: string) =>
+                db.query<[Array<Record<string, unknown>>]>(sql).pipe(
+                    Effect.map((r) => r?.[0] ?? []),
+                    Effect.orDie, // a read-only timeline query failing is a defect, not a domain error
+                );
+            const oneRow = (sql: string) =>
+                rows(sql).pipe(Effect.map((rs) => rs[0] ?? null));
+
+            const extract = Effect.fn("SessionTimelineService.extract")(function* (sessionId: string) {
+                const ref = sessionRef(sessionId);
+                const [
+                    healthRaw, overviewRaw, costRaw, toolRaw, editRaw,
+                    skillRaw, correctionRaw, planRaw, commitRaw, lastRaw,
+                ] = yield* Effect.all([
+                    oneRow(healthSql(ref)),
+                    oneRow(overviewSql(ref)),
+                    oneRow(costSql(ref)),
+                    rows(toolCallsSql(ref)),
+                    rows(editsSql(ref)),
+                    rows(skillsSql(ref)),
+                    rows(correctionsSql(ref)),
+                    rows(plansSql(ref)),
+                    rows(commitsSql(ref)),
+                    oneRow(lastAssistantSql(ref)),
+                ], { concurrency: "unbounded" });
+
+                return buildTimeline({
+                    sessionId,
+                    health: mapHealth(healthRaw),
+                    overview: mapOverview(overviewRaw),
+                    cost: mapCost(costRaw),
+                    toolCalls: toolRaw.map(mapToolCall).filter(present),
+                    edits: editRaw.map(mapEdit).filter(present),
+                    skills: skillRaw.map(mapSkill).filter(present),
+                    corrections: correctionRaw.map(mapCorrection).filter(present),
+                    plans: planRaw.map(mapPlan).filter(present),
+                    commits: commitRaw.map(mapCommit).filter(present),
+                    lastAssistant: mapLastTurn(lastRaw),
+                });
+            });
+
+            return { extract } satisfies SessionTimelineShape;
+        }),
+);
+
+/** Convenience: extract a timeline using the ambient SessionTimelineService. */
+export const extractSessionTimeline = (
+    sessionId: string,
+): Effect.Effect<SessionTimeline, never, SessionTimelineService> =>
+    Effect.flatMap(SessionTimelineService, (svc) => svc.extract(sessionId));

--- a/apps/axctl/src/timeline/types.ts
+++ b/apps/axctl/src/timeline/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Session timeline - the "highlight" zoom level between the raw transcript and
+ * the one-line summary. An ordered stream of *important* events (not every
+ * turn) plus session-level highlights, all derived from already-ingested data
+ * with NO LLM inference. See `derive.ts` for the rules and `service.ts` for the
+ * Effect service that feeds a session id and returns this shape.
+ */
+
+export type TimelineEventKind =
+    | "decision" // a plan/choice the agent stated (plan_snapshot)
+    | "tool_call" // a notable tool run
+    | "file_edit" // a file created/modified
+    | "skill_invocation" // a skill was invoked
+    | "failure" // a tool error / something broke
+    | "correction" // the user redirected the agent
+    | "checkpoint" // a milestone (commit, tests green)
+    | "outcome"; // the end result (raw last-assistant text; LLM seam for a gloss)
+
+export type TimelineRefType = "turn" | "file" | "tool" | "skill" | "subagent" | "commit";
+
+export interface TimelineRef {
+    readonly type: TimelineRefType;
+    readonly id: string;
+}
+
+export interface TimelineEvent {
+    readonly kind: TimelineEventKind;
+    /** ISO timestamp; the primary ordering key. */
+    readonly ts: string;
+    /** Anchor turn seq (for `#turn-N` linking); null when not turn-anchored. */
+    readonly seq: number | null;
+    /** One-line, human-readable. Raw data (command/path/error) - never LLM-authored. */
+    readonly title: string;
+    /** Optional secondary line (output excerpt, error text, commit message…). */
+    readonly detail?: string;
+    readonly status?: "ok" | "error";
+    /** Cross-links into the raw transcript / artifacts. */
+    readonly refs: ReadonlyArray<TimelineRef>;
+    /**
+     * For `failure` events: the seq of the event that RESOLVED it (heuristic,
+     * LLM-free). Null when no recovery was found within the window.
+     */
+    readonly recovered_by_seq?: number | null;
+}
+
+export interface SessionHighlights {
+    readonly started_at: string | null;
+    readonly ended_at: string | null;
+    readonly duration_ms: number | null;
+    readonly model: string | null;
+    readonly project: string | null;
+    readonly repository: string | null;
+    readonly turns: number;
+    readonly user_turns: number;
+    readonly assistant_turns: number;
+    readonly tool_calls: number;
+    readonly tool_errors: number;
+    readonly files_changed: number;
+    readonly skills_used: number;
+    readonly corrections: number;
+    readonly interruptions: number;
+    readonly cost_usd: number | null;
+    readonly estimated_tokens: number | null;
+    /** Count of each event kind actually surfaced in `events`. */
+    readonly event_counts: Readonly<Record<TimelineEventKind, number>>;
+}
+
+export interface SessionTimeline {
+    readonly session_id: string;
+    readonly highlights: SessionHighlights;
+    /** Important events, ascending by ts. */
+    readonly events: ReadonlyArray<TimelineEvent>;
+}

--- a/apps/axctl/src/timeline/types.ts
+++ b/apps/axctl/src/timeline/types.ts
@@ -29,6 +29,8 @@ export interface TimelineEvent {
     readonly ts: string;
     /** Anchor turn seq (for `#turn-N` linking); null when not turn-anchored. */
     readonly seq: number | null;
+    /** L2 segment this event belongs to (assigned during assembly). */
+    readonly segment_id?: string;
     /** One-line, human-readable. Raw data (command/path/error) - never LLM-authored. */
     readonly title: string;
     /** Optional secondary line (output excerpt, error text, commit message…). */
@@ -65,9 +67,43 @@ export interface SessionHighlights {
     readonly event_counts: Readonly<Record<TimelineEventKind, number>>;
 }
 
+/** Boundary signal that opened an L2 segment. */
+export type SegmentBoundary = "session_start" | "ask" | "commit" | "compaction" | "time_gap";
+
+/** L2 - a phase/iteration of the session. Carries FULL rollup counts even when
+ *  L1 events were capped, so nothing is silently hidden. */
+export interface TimelineSegment {
+    readonly id: string;
+    readonly index: number;
+    readonly title: string;
+    readonly boundary: SegmentBoundary;
+    readonly start_seq: number | null;
+    readonly end_seq: number | null;
+    readonly started_at: string;
+    readonly ended_at: string | null;
+    readonly duration_ms: number | null;
+    /** Full counts for everything that happened in the span (pre-cap). */
+    readonly rollup: {
+        readonly tool_calls: number;
+        readonly file_edits: number;
+        readonly files: number;
+        readonly failures: number;
+        readonly recovered: number;
+        readonly skills: number;
+        readonly decisions: number;
+        readonly checkpoints: number;
+        readonly corrections: number;
+    };
+    /** Total events in the span before L1 capping. */
+    readonly event_count: number;
+}
+
 export interface SessionTimeline {
     readonly session_id: string;
     readonly highlights: SessionHighlights;
-    /** Important events, ascending by ts. */
+    /** L2 spine - always complete (one per phase/iteration). */
+    readonly segments: ReadonlyArray<TimelineSegment>;
+    /** L1 - the important events, ascending by ts, capped per segment + globally.
+     *  Each carries `segment_id`. Full counts live on the segment rollups. */
     readonly events: ReadonlyArray<TimelineEvent>;
 }

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -131,6 +131,59 @@ export interface DaemonVersion {
     readonly capabilities: ReadonlyArray<string>;
 }
 
+// --- session timeline (highlight zoom) -------------------------------------
+
+export type TimelineEventKind =
+    | "decision" | "tool_call" | "file_edit" | "skill_invocation"
+    | "failure" | "correction" | "checkpoint" | "outcome";
+
+export interface TimelineRef {
+    readonly type: "turn" | "file" | "tool" | "skill" | "subagent" | "commit";
+    readonly id: string;
+}
+export interface TimelineEvent {
+    readonly kind: TimelineEventKind;
+    readonly ts: string;
+    readonly seq: number | null;
+    readonly segment_id?: string;
+    readonly title: string;
+    readonly detail?: string;
+    readonly status?: "ok" | "error";
+    readonly refs: ReadonlyArray<TimelineRef>;
+    readonly recovered_by_seq?: number | null;
+}
+export interface TimelineSegment {
+    readonly id: string;
+    readonly index: number;
+    readonly title: string;
+    readonly boundary: "session_start" | "ask" | "commit" | "compaction" | "time_gap";
+    readonly start_seq: number | null;
+    readonly end_seq: number | null;
+    readonly started_at: string;
+    readonly ended_at: string | null;
+    readonly duration_ms: number | null;
+    readonly rollup: {
+        readonly tool_calls: number; readonly file_edits: number; readonly files: number;
+        readonly failures: number; readonly recovered: number; readonly skills: number;
+        readonly decisions: number; readonly checkpoints: number; readonly corrections: number;
+    };
+    readonly event_count: number;
+}
+export interface SessionTimelinePayload {
+    readonly session_id: string;
+    readonly highlights: {
+        readonly started_at: string | null; readonly ended_at: string | null; readonly duration_ms: number | null;
+        readonly model: string | null; readonly project: string | null; readonly repository: string | null;
+        readonly turns: number; readonly user_turns: number; readonly assistant_turns: number;
+        readonly tool_calls: number; readonly tool_errors: number; readonly files_changed: number;
+        readonly skills_used: number; readonly corrections: number; readonly interruptions: number;
+        readonly cost_usd: number | null; readonly estimated_tokens: number | null;
+        readonly event_counts: Readonly<Record<TimelineEventKind, number>>;
+    };
+    readonly segments: ReadonlyArray<TimelineSegment>;
+    readonly events: ReadonlyArray<TimelineEvent>;
+}
+
 export const api = {
     version: (): Promise<DaemonVersion> => jsonFetch("/api/version"),
     skills: (): Promise<SkillTriageResponse> => jsonFetch("/api/skills"),
@@ -196,6 +249,8 @@ export const api = {
             ? `/api/sessions/${encodeURIComponent(sessionId)}/inspect?${qs}`
             : `/api/sessions/${encodeURIComponent(sessionId)}/inspect`);
     },
+    sessionTimeline: (sessionId: string): Promise<SessionTimelinePayload> =>
+        jsonFetch(`/api/sessions/${encodeURIComponent(sessionId)}/timeline`),
     sessionCompare: (ids: ReadonlyArray<string>, params: { turns?: boolean } = {}): Promise<SessionComparePayload> => {
         const usp = new URLSearchParams();
         usp.set("ids", ids.join(","));

--- a/apps/studio/src/routes/session-inspect.tsx
+++ b/apps/studio/src/routes/session-inspect.tsx
@@ -1341,8 +1341,10 @@ export function SessionInspectView({ sessionId }: { readonly sessionId: string }
         return m ? Number(m[1]) : null;
     };
     const [anchoredSeq, setAnchoredSeq] = useState<number | null>(() => readHashSeq());
-    // Zoom level: raw transcript (default) vs. the highlight/event timeline.
-    const [view, setView] = useState<"transcript" | "timeline">("transcript");
+    // Zoom level. Default to the timeline: it's the fast highlight overview
+    // (~2-3s) and the right entry point; the raw transcript is a slower
+    // (large-query) drill-down loaded on demand.
+    const [view, setView] = useState<"transcript" | "timeline">("timeline");
 
     // The docked right-rail inspector tracks the last block/alias the user
     // hovered, across all turns (seeded to the first parsed turn).

--- a/apps/studio/src/routes/session-inspect.tsx
+++ b/apps/studio/src/routes/session-inspect.tsx
@@ -6,6 +6,7 @@ import type { HookFireDto, InspectSpanDto, InspectSpanKind, InspectTurnDto, Sess
 import { childrenByAnchorTurn, spawnAnchorSet, turnText } from "./inspector-filters.ts";
 import { spliceHookFires } from "@ax/lib/shared/hook-fire-splice";
 import { FilterBar } from "./inspector-filter-bar.tsx";
+import { SessionTimelineView } from "./session-timeline.tsx";
 import { shortSessionId } from "@ax/lib/shared/session-id";
 import { sessionProjectLabel } from "@ax/lib/shared/project-slug";
 import type { InspectContentAtomDto, InspectContentBlockDto, InspectTurnContentDto } from "@ax/lib/shared/dashboard-types";
@@ -1340,6 +1341,8 @@ export function SessionInspectView({ sessionId }: { readonly sessionId: string }
         return m ? Number(m[1]) : null;
     };
     const [anchoredSeq, setAnchoredSeq] = useState<number | null>(() => readHashSeq());
+    // Zoom level: raw transcript (default) vs. the highlight/event timeline.
+    const [view, setView] = useState<"transcript" | "timeline">("transcript");
 
     // The docked right-rail inspector tracks the last block/alias the user
     // hovered, across all turns (seeded to the first parsed turn).
@@ -1442,13 +1445,27 @@ export function SessionInspectView({ sessionId }: { readonly sessionId: string }
         <section className="panel">
             <header>
                 <h2>Session inspect</h2>
-                <span className="meta">
+                <span className="meta" style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                    <span style={{ display: "inline-flex", border: "1px solid var(--line)", borderRadius: 5, overflow: "hidden" }}>
+                        {(["timeline", "transcript"] as const).map((v) => (
+                            <button
+                                key={v}
+                                type="button"
+                                onClick={() => setView(v)}
+                                style={{
+                                    fontFamily: "ui-monospace, monospace", fontSize: 11, padding: "2px 10px", cursor: "pointer",
+                                    border: "none", background: view === v ? "var(--ink)" : "var(--panel)", color: view === v ? "var(--panel)" : "var(--muted)",
+                                }}
+                            >{v}</button>
+                        ))}
+                    </span>
                     <code>{shortSessionId(decoded)}…</code>
                 </span>
             </header>
-            {query.error ? <div className="error">Error: {String(query.error)}</div> : null}
-            {query.isLoading && !data ? <div className="loading">Loading…</div> : null}
-            {data ? (
+            {view === "timeline" ? <SessionTimelineView sessionId={decoded} /> : null}
+            {view === "transcript" && query.error ? <div className="error">Error: {String(query.error)}</div> : null}
+            {view === "transcript" && query.isLoading && !data ? <div className="loading">Loading…</div> : null}
+            {view === "transcript" && data ? (
                 <>
                     <div style={{ padding: "8px 24px", color: "var(--muted)", fontSize: 12, fontFamily: "ui-monospace, monospace" }}>
                         <span>project: </span>

--- a/apps/studio/src/routes/session-timeline.tsx
+++ b/apps/studio/src/routes/session-timeline.tsx
@@ -1,0 +1,143 @@
+/**
+ * The "highlight" zoom level for a session - L2 segments (phases) each with a
+ * rollup, and the L1 important events nested under them. Fed by the LLM-free
+ * SessionTimelineService via /api/sessions/:id/timeline. Sits one level up from
+ * the raw transcript inspector.
+ */
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api, type SessionTimelinePayload, type TimelineEvent, type TimelineEventKind, type TimelineSegment } from "../api.ts";
+
+const KIND_GLYPH: Record<TimelineEventKind, string> = {
+    decision: "◆", tool_call: "⚙", file_edit: "✎", skill_invocation: "↳",
+    failure: "✖", correction: "⟲", checkpoint: "⎉", outcome: "★",
+};
+const KIND_COLOR: Record<TimelineEventKind, string> = {
+    decision: "var(--gold)", tool_call: "var(--blue)", file_edit: "var(--green)",
+    skill_invocation: "var(--blue)", failure: "var(--red)", correction: "var(--gold)",
+    checkpoint: "var(--green)", outcome: "var(--green)",
+};
+const BOUNDARY_LABEL: Record<TimelineSegment["boundary"], string> = {
+    session_start: "start", ask: "ask", commit: "commit", compaction: "compacted", time_gap: "resumed",
+};
+
+const fmtDur = (ms: number | null): string => {
+    if (ms == null) return "";
+    if (ms >= 3_600_000) return `${(ms / 3_600_000).toFixed(1)}h`;
+    if (ms >= 60_000) return `${Math.round(ms / 60_000)}m`;
+    return `${Math.round(ms / 1000)}s`;
+};
+const fmtUsd = (n: number | null): string => (n == null ? "" : `$${n.toFixed(2)}`);
+
+function Stat({ n, label }: { n: string; label: string }) {
+    return (
+        <span style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <b style={{ fontSize: 15, color: "var(--ink)", fontVariantNumeric: "tabular-nums" }}>{n}</b>
+            <span style={{ fontSize: 10, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--muted)" }}>{label}</span>
+        </span>
+    );
+}
+
+function EventRow({ e }: { e: TimelineEvent }) {
+    const color = KIND_COLOR[e.kind];
+    return (
+        <div style={{ display: "flex", alignItems: "baseline", gap: 8, padding: "3px 0", fontFamily: "ui-monospace, Menlo, monospace", fontSize: 12 }}>
+            <span style={{ color, width: 14, textAlign: "center", flex: "0 0 auto" }}>{KIND_GLYPH[e.kind]}</span>
+            <span style={{ color: "var(--muted)", textTransform: "uppercase", fontSize: 10, letterSpacing: "0.04em", flex: "0 0 92px" }}>
+                {e.kind.replace("_", " ")}
+            </span>
+            <span style={{ color: "var(--ink)", minWidth: 0, overflowWrap: "anywhere" }}>
+                {e.title}
+                {e.recovered_by_seq != null ? (
+                    <span style={{ color: "var(--green)", marginLeft: 6 }}>→ fixed #{e.recovered_by_seq}</span>
+                ) : null}
+            </span>
+            {e.seq != null ? (
+                <a href={`#turn-${e.seq}`} style={{ marginLeft: "auto", flex: "0 0 auto", color: "var(--blue)", fontSize: 11, textDecoration: "none" }}>
+                    → turn {e.seq}
+                </a>
+            ) : null}
+        </div>
+    );
+}
+
+function SegmentBlock({ seg, events }: { seg: TimelineSegment; events: ReadonlyArray<TimelineEvent> }) {
+    const r = seg.rollup;
+    const parts = [
+        r.tool_calls ? `${r.tool_calls} tools` : null,
+        r.file_edits ? `${r.file_edits} edits${r.files ? `/${r.files}f` : ""}` : null,
+        r.failures ? `${r.failures} fail${r.recovered ? `·${r.recovered} fixed` : ""}` : null,
+        r.decisions ? `${r.decisions} dec` : null,
+        r.checkpoints ? `${r.checkpoints} commit` : null,
+        r.corrections ? `${r.corrections} corr` : null,
+    ].filter(Boolean);
+    return (
+        <div style={{ borderLeft: "3px solid var(--line)", paddingLeft: 14, marginBottom: 14 }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
+                <span style={{ fontSize: 10, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--muted)", background: "var(--track)", padding: "1px 7px", borderRadius: 3 }}>
+                    {BOUNDARY_LABEL[seg.boundary]}
+                </span>
+                <span style={{ fontFamily: "Georgia, serif", fontSize: 15, color: "var(--ink)", minWidth: 0, overflowWrap: "anywhere" }}>{seg.title}</span>
+                <span style={{ marginLeft: "auto", fontSize: 11, color: "var(--muted)", fontFamily: "ui-monospace, monospace" }}>
+                    {fmtDur(seg.duration_ms)}{seg.event_count ? ` · ${seg.event_count} evts` : ""}
+                </span>
+            </div>
+            {parts.length > 0 ? (
+                <div style={{ fontSize: 11, color: "var(--muted)", fontFamily: "ui-monospace, monospace", margin: "3px 0 6px" }}>
+                    {parts.join("  ·  ")}
+                </div>
+            ) : null}
+            <div>{events.map((e, i) => <EventRow key={`${e.kind}-${e.seq}-${i}`} e={e} />)}</div>
+        </div>
+    );
+}
+
+function Highlights({ data }: { data: SessionTimelinePayload }) {
+    const h = data.highlights;
+    const totalEvents = Object.values(h.event_counts).reduce((a, b) => a + b, 0);
+    const sub = [h.model, h.repository, h.started_at?.slice(0, 10)].filter(Boolean).join(" · ");
+    return (
+        <div style={{ background: "var(--track)", borderLeft: "4px solid var(--green)", padding: "14px 18px", marginBottom: 16 }}>
+            <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--muted)", fontFamily: "ui-monospace, monospace" }}>{sub}</div>
+            <div style={{ display: "flex", gap: 18, flexWrap: "wrap", marginTop: 12, fontFamily: "ui-monospace, monospace" }}>
+                <Stat n={fmtDur(h.duration_ms) || "-"} label="duration" />
+                <Stat n={h.turns.toLocaleString()} label="turns" />
+                <Stat n={h.tool_calls.toLocaleString()} label="tools" />
+                <Stat n={h.files_changed.toLocaleString()} label="files" />
+                {h.tool_errors ? <Stat n={String(h.tool_errors)} label="failures" /> : null}
+                {fmtUsd(h.cost_usd) ? <Stat n={fmtUsd(h.cost_usd)} label="cost" /> : null}
+                <Stat n={`${data.segments.length}`} label="segments" />
+                <Stat n={`${data.events.length}/${totalEvents}`} label="key events" />
+            </div>
+        </div>
+    );
+}
+
+export function SessionTimelineView({ sessionId }: { readonly sessionId: string }) {
+    const q = useQuery({
+        queryKey: ["session-timeline", sessionId],
+        queryFn: () => api.sessionTimeline(sessionId),
+        staleTime: 60_000,
+    });
+    const eventsBySegment = useMemo(() => {
+        const m = new Map<string, TimelineEvent[]>();
+        for (const e of q.data?.events ?? []) {
+            const id = e.segment_id ?? "seg-0";
+            (m.get(id) ?? m.set(id, []).get(id)!).push(e);
+        }
+        return m;
+    }, [q.data]);
+
+    if (q.isLoading) return <div className="loading" style={{ padding: 24 }}>Building timeline…</div>;
+    if (q.error) return <div className="error" style={{ padding: 24 }}>Error: {String(q.error)}</div>;
+    if (!q.data) return null;
+
+    return (
+        <div style={{ padding: "8px 24px 40px" }}>
+            <Highlights data={q.data} />
+            {q.data.segments.map((seg) => (
+                <SegmentBlock key={seg.id} seg={seg} events={eventsBySegment.get(seg.id) ?? []} />
+            ))}
+        </div>
+    );
+}

--- a/docs/design/session-timeline-plan.md
+++ b/docs/design/session-timeline-plan.md
@@ -1,0 +1,116 @@
+# Session Timeline - build plan
+
+The "highlight" zoom level between the raw transcript (L0) and the one-line
+summary. An ordered, **multi-resolution** view of *what happened* in a session,
+derived entirely from already-ingested data - **no LLM**. Built as an Effect
+service (`apps/axctl/src/timeline/`) that takes a session id and outputs a
+`SessionTimeline`; UI comes later.
+
+## Status
+
+- ✅ v0 service shipped (`feat/session-timeline-service`): types + queries +
+  pure `derive` + Effect service + 9 tests. Verified end-to-end on a real
+  685-turn session; all 4 failures auto-paired to their fix.
+- ✅ 10-session stress test (4 → 45,697 turns) - robust, no crashes, ~90%
+  recovery rate. But it surfaced 4 findings (below) that this plan fixes.
+- ✅ Provider-shape investigation across all 6 sources - evidence-backed
+  mapping (below).
+
+## Findings from the 10-session test (what this plan fixes)
+
+1. **Event volume explodes** - a 45k-turn loop session yields **5,918 events**.
+   Not a "highlight". Needs multi-resolution + importance ranking.
+2. **Provider skew** - codex `tool_call` events = 0 (filter was Claude-shaped);
+   codex tools leaked into `skill_invocation` and hit a 2000 cap.
+3. **Correction events miss** - `reaction_event` source too narrow.
+4. **Silent LIMIT caps + sparse cost** on the monsters / old sessions.
+
+## Evidence: the 6 sources behave differently
+
+- **6 sources**: claude (1501), claude-subagent (1213, behaves like claude),
+  codex (731), pi (5), opencode (3), cursor (2).
+- **`invoked` is a fake skill stream** for codex/pi/opencode/cursor - a
+  `<provider>:toolName` shadow 1:1 with every tool call. Only claude /
+  claude-subagent have real skill invocations. → consume `invoked` for claude
+  sources only; drop `^<provider>:` names.
+- **File edits live in 2 channels; 3/5 providers lose them**:
+  - claude/pi → `edited` edge ✓
+  - codex → NO edit tool; edits ride inside `exec_command` (`sed -i`, heredocs,
+    `apply_patch` CLI) → classify inside the command.
+  - opencode → ingest bug: edit input field is `filePath` (camelCase), not in
+    `STRUCTURED_PATH_FIELDS` → no edge.
+  - cursor → `_v2` tool names match no shared set → no file evidence.
+  → derive `file_edit` per-provider at the `tool_call` layer, not the edge.
+- **Segmentation signals** (matrix): time-gaps = only universal boundary;
+  commits (claude+codex), compactions (claude+codex), plans (codex=
+  `plan_snapshot`, claude=`TodoWrite` tool_call), user-turns (all, thin for
+  subagent).
+- **Query gotcha**: `produced.in` IS the session (not `.in.session`); use
+  captured `<string>session` refs; `count(DISTINCT)` unsupported.
+
+## The shape: 3 zoom levels
+
+```
+L0  raw transcript            (exists)            e.g. 45,697 turns
+L1  events (important beats)   importance-ranked   ~top 15–30 per segment
+L2  segments / phases          the loop's spine    ~N iterations / commits
+```
+
+`SessionTimeline` grows a `segments[]`; each `TimelineEvent` keeps `seq` so it
+nests into a segment. Importance ranks *within* a segment, so totals stay
+bounded regardless of 4 or 45k turns.
+
+## Build steps
+
+### Step 1 - ProviderEventMap (provider-aware classification)
+- One provider-keyed classifier `(source, toolCallRow) -> { kind, importance }`.
+- Per-provider tool/edit/skill/subagent/noise tables (from the investigation).
+- codex: inspect `command_norm`/`command_text` of `exec_command` - `sed`/`tee`/
+  `>`/heredoc/`apply_patch` = `file_edit`; else `tool`.
+- `invoked` consumed only for claude/claude-subagent.
+- **Checkpoint**: re-run the 10-session test - codex/pi tools must surface as
+  `tool_call`; `skill_invocation` no longer inflated.
+
+### Step 2 - Segmentation layer (L2)
+- Derive segments bounded by, in priority: commit (`produced`) → user-turn →
+  compaction → large time-gap (per-provider availability from the matrix;
+  time-gap is the universal fallback).
+- Each segment: `{ start_seq, end_seq, ts range, title, rollup, outcome }`.
+  - title = the user ask (first user turn in span) or commit message.
+  - rollup = counts {tools, edits, files, failures, skills} + duration.
+  - outcome = did the span end in a commit / green check?
+- **Checkpoint**: a 45k loop → ~its iterations, each with a readable headline.
+
+### Step 3 - Importance ranking + caps (L1)
+- Rank events within each segment: failures (+recovery) > decisions/plans >
+  commits > file_edits (group consecutive edits to same file as "N×") >
+  notable tools > skills. Cap to top-N per segment; bucket-summarize the long
+  tail ("142 edits across 6 files").
+- Replace the silent SQL `LIMIT`s with explicit, logged caps.
+- **Checkpoint**: L2 ≤ ~30 segments, L1 ≤ ~30 events/segment, any size.
+
+### Step 4 - Correction + cost robustness
+- Correction events: add `intent_kind='correction'` fallback to `reaction_event`.
+- Cost: tolerate missing `session_token_usage` (already nullable; just confirm).
+
+### Step 5 - Re-verify
+- Re-run the 10-session stress test; confirm bounded output + provider coverage.
+- Extend `derive.test.ts` for the provider classifier + segmentation.
+
+## Out of scope (separate)
+- **UI** - fed by this service later (the mockup → real component).
+- **2 ingest bugs found** (opencode `filePath`, cursor `_v2`) - file as issues;
+  they affect the graph broadly, not just timeline.
+- **Optional LLM** - a narrative `outcome`/`decision` gloss; the service leaves
+  a seam (today: raw last-assistant text).
+
+## Open questions
+
+1. Multi-resolution: ship `segments[]` + `events[]` in one artifact, or expose
+   L2 and L1 as separate service methods (lazy L1 per segment)?
+2. Segment granularity for loops: one segment per user-turn, or per commit, or
+   adaptive (collapse when too many)?
+3. Importance cap N - fixed (e.g. 20/segment) or budget-based (total ≤ 300)?
+4. File the 2 ingest bugs now, or fold the codex/opencode/cursor file-edit
+   recovery into Step 1 and fix ingest separately?
+5. Do we want a CLI (`ax timeline <id> --json`) to play with output before UI?


### PR DESCRIPTION
The "highlight" zoom level between the raw transcript and the one-line summary — an ordered, multi-resolution view of *what happened* in a session, derived **entirely from already-ingested data (no LLM)**. Service only; UI is a follow-up.

`SessionTimelineService.extract(sessionId) → SessionTimeline`:
| layer | what | bounded |
|---|---|---|
| `highlights` | duration, model, turns, tools, files, cost, event counts | exact |
| L2 `segments[]` | phases bounded by commits / asks / compactions / time-gaps, full rollups | ≤30 |
| L1 `events[]` | importance-ranked, failure→recovery paired, `segment_id`-tagged | ≤300 |

### How
- **`providers.ts`** — source-keyed classifier `(source, tool_call) → {kind, importance}` across all 6 sources. Fixes the codex skew (exec_command surfaces as tools; shell edits via `sed`/heredoc/`apply_patch` → file_edit) and drops the fake `<provider>:` `invoked` shadow for non-claude sources.
- **`segment.ts`** — L2 segmentation, adaptive collapse to ≤30 (samples structural boundaries on huge loops); each segment keeps FULL rollup counts. L1 importance caps ≤25/segment, ≤300 total.
- **`derive.ts`** — pure derivation incl. heuristic failure→recovery pairing; `queries.ts` session-scoped SQL + mappers; `service.ts` Effect v4 service.
- **CLI**: `ax timeline <id> [--json]`.

### Verified
10 sessions, **4 → 45,697 turns**, claude + codex: bounded to ≤30 segments / ≤300 events every time; codex tools surface; ~90% failure→recovery. **17 timeline tests + 2,142 repo tests pass**; typecheck clean.

### Known v1 gaps (documented in `docs/design/session-timeline-plan.md`)
- codex file *paths* need command parsing (count surfaces, path doesn't).
- narrative `outcome` gloss = the only optional-LLM seam.
- 2 ingest bugs surfaced separately (opencode `filePath`, cursor `_v2`) — filed as issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)