### PR TITLE
fix(studio): URL-drive subagent selection in share viewer (back/forward)

### DIFF
--- a/apps/studio/src/router.tsx
+++ b/apps/studio/src/router.tsx
@@ -55,9 +55,10 @@ const indexRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/",
     component: StudioIndexRoute,
-    validateSearch: (search): { shareOwner?: string; gistId?: string } => ({
+    validateSearch: (search): { shareOwner?: string; gistId?: string; sub?: string } => ({
         shareOwner: typeof search.shareOwner === "string" ? search.shareOwner : undefined,
         gistId: typeof search.gistId === "string" ? search.gistId : undefined,
+        sub: typeof search.sub === "string" ? search.sub : undefined,
     }),
 });
 
@@ -132,6 +133,9 @@ const shareInspectRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/share/$owner/$gistId",
     component: ShareInspectRoute,
+    validateSearch: (search): { sub?: string } => ({
+        sub: typeof search.sub === "string" ? search.sub : undefined,
+    }),
 });
 
 const episodeRoute = createRoute({

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useParams } from "@tanstack/react-router";
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import type {
     HookFireDto,
     InspectTurnContentDto,
@@ -632,7 +632,29 @@ function MultiFileShareView(props: {
 }) {
     const { owner, gistId, manifest } = props;
     const qc = useQueryClient();
-    const [selectedFile, setSelectedFile] = useState<string>(manifest.root_file);
+    // Selected session is URL-driven (?sub=<file>) so browser back/forward walks
+    // the parent <-> subagent navigation instead of being trapped in local state.
+    const navigate = useNavigate();
+    const search = useSearch({ strict: false }) as { readonly sub?: string };
+    const selectedFile = search.sub && manifest.subagents.some((c) => c.file === search.sub)
+        ? search.sub
+        : manifest.root_file;
+    const setSelectedFile = (file: string) => {
+        const sub = file === manifest.root_file ? undefined : file;
+        // This view mounts on both the studio index ("/studio/?shareOwner&gistId",
+        // the public iframe entry) and the "/share/$owner/$gistId" route, so
+        // navigate()'s search-updater can't resolve a single route type. The call
+        // is valid at runtime on either - it swaps ?sub on the current location and
+        // clears the #turn anchor (it points at the session we're leaving).
+        const navigateLoose = navigate as unknown as (opts: {
+            readonly search: (prev: Record<string, unknown>) => Record<string, unknown>;
+            readonly hash: string;
+        }) => void;
+        navigateLoose({
+            search: (prev) => ({ ...prev, sub }),
+            hash: "",
+        });
+    };
 
     const fileQuery = useQuery({
         queryKey: ["share-file", owner, gistId, selectedFile],


### PR DESCRIPTION
## Problem
In the multi-file share viewer, navigating into a subagent and hitting browser
**back** doesn't return to the main session - subagent selection was local
`useState`, so history had nothing to pop.

## Fix
Drive the selected session from a `?sub=<file>` search param. Each subagent
switch (and the "↑ back to parent" link) is now a real history entry, so
browser back/forward walks parent ↔ subagent. The `#turn` anchor is cleared on
switch (it points at the session being left).

- `router.tsx`: allow `sub` on the index + `/share/$owner/$gistId` routes.
- `share-inspect.tsx`: derive `selectedFile` from the URL via `useSearch`,
  push updates via `useNavigate`. The view mounts on both the studio index
  route (the public iframe entry, `/studio/?shareOwner&gistId`) and `/share`,
  so the navigate search-updater uses a loosened local signature.

## Verify
Open a share with subagents, click into one, hit browser back → returns to main
session; forward → back into the subagent. Deep-link `?sub=<file>` loads
straight into that subagent.

typecheck: clean.