### PR TITLE
perf: kill IN-membership scans + correlated $parent.session derefs on read paths

### DIFF
--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -81,6 +81,7 @@ import { ingestClaudeInsights } from "../ingest/claude-insights.ts";
 import { deriveSignals } from "../ingest/derive-signals.ts";
 import { deriveTurnIntents } from "../ingest/derive-intents.ts";
 import { INSIGHT_VIEWS, insightSqlForView, isInsightView } from "../queries/insights.ts";
+import { enrichInsightRows } from "../queries/insights-enrich.ts";
 import { extractSessionTimeline, SessionTimelineServiceLayer } from "../timeline/service.ts";
 import { formatInsightRows } from "./insights-format.ts";
 import { writeDashboard } from "../dashboard/report.ts";
@@ -606,7 +607,10 @@ const cmdInsights = (args: string[]) =>
         const result = yield* db.query<[Array<Record<string, unknown>>]>(
             insightSqlForView(rawView, limit),
         );
-        console.log(formatInsightRows(rawView, result?.[0] ?? [], { json }));
+        // Classifier views resolve their per-row context here via indexed
+        // lookups (the correlated $parent.session form scanned ~1s/row).
+        const rows = yield* enrichInsightRows(rawView, result?.[0] ?? []);
+        console.log(formatInsightRows(rawView, [...rows], { json }));
     });
 
 const cmdReport = (args: string[]) =>

--- a/apps/axctl/src/context/file-context.ts
+++ b/apps/axctl/src/context/file-context.ts
@@ -599,6 +599,9 @@ function durationMs(startedAt: string | null | undefined, endedAt: string | null
  * then issues five batched `IN [sessions]` queries in parallel and aggregates
  * counts client-side. Same shape, ~27 ms instead of ~3500 ms.
  */
+/** Per-session fan-out width for the indexed turn reads in the lean loader. */
+const CONTEXT_TURN_FANOUT = 16;
+
 const loadPriorFileSessionsLean = (fileIds: readonly string[], limit: number) =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
@@ -625,13 +628,23 @@ const loadPriorFileSessionsLean = (fileIds: readonly string[], limit: number) =>
         const sessionIds = Array.from(new Set(aggRows.map((r) => r.session)));
         const sidLiteral = sessionIds.join(", ");
 
-        const [sessionsResult, turnsResult, producedResult, deliveryResult, healthResult, titleResult] =
+        // Per-session INDEXED turn reads. `turn WHERE session IN [<sids>]` is a
+        // membership scan over the 560k-row turn table (~3s for 50 sessions),
+        // the same trap fixed in enrichSessions / share content. `session = <lit>`
+        // hits turn_session_seq (~1ms); fanned out, this is sub-second. The other
+        // reads stay batched: session/produced/delivery_outcome (97 rows) /
+        // session_health (3519) are tiny, so an IN-list there is cheap.
+        const perSessionTurns = <Row>(sqlFor: (sid: string) => string) =>
+            Effect.forEach(
+                sessionIds,
+                (sid) => db.query<[Row[]]>(sqlFor(sid)).pipe(Effect.map(([rows]) => rows ?? [])),
+                { concurrency: CONTEXT_TURN_FANOUT },
+            ).pipe(Effect.map((chunks) => chunks.flat()));
+
+        const [sessionsResult, producedResult, deliveryResult, healthResult] =
             yield* Effect.all([
                 db.query<[Array<{ id: string; project: string | null; source: string | null; started_at: string | null; ended_at: string | null }>]>(
                     `SELECT <string>id AS id, project, source, started_at, ended_at FROM session WHERE id IN [${sidLiteral}];`,
-                ),
-                db.query<[Array<{ session: string; role: string; intent_kind: string | null }>]>(
-                    `SELECT <string>session AS session, role, intent_kind FROM turn WHERE session IN [${sidLiteral}] AND role IN ['user','assistant'];`,
                 ),
                 db.query<[Array<{ in: string }>]>(
                     `SELECT <string>in AS in FROM produced WHERE in IN [${sidLiteral}];`,
@@ -642,17 +655,19 @@ const loadPriorFileSessionsLean = (fileIds: readonly string[], limit: number) =>
                 db.query<[Array<{ session: string; interruptions: number }>]>(
                     `SELECT <string>session AS session, interruptions FROM session_health WHERE session IN [${sidLiteral}];`,
                 ),
-                db.query<[Array<{ session: string; text_excerpt: string; seq: number; intent_kind: string | null }>]>(
-                    `SELECT <string>session AS session, text_excerpt, seq, intent_kind FROM turn WHERE session IN [${sidLiteral}] AND role = 'user' AND message_kind = 'task' AND intent_kind IN ['organic_task','preference','correction'] AND text_excerpt IS NOT NONE ORDER BY seq ASC;`,
-                ),
             ], { concurrency: "unbounded" });
 
+        const turnsRows = yield* perSessionTurns<{ session: string; role: string; intent_kind: string | null }>(
+            (sid) => `SELECT <string>session AS session, role, intent_kind FROM turn WHERE session = ${sid} AND role IN ['user','assistant'];`,
+        );
+        const titleRows = yield* perSessionTurns<{ session: string; text_excerpt: string; seq: number; intent_kind: string | null }>(
+            (sid) => `SELECT <string>session AS session, text_excerpt, seq, intent_kind FROM turn WHERE session = ${sid} AND role = 'user' AND message_kind = 'task' AND intent_kind IN ['organic_task','preference','correction'] AND text_excerpt IS NOT NONE ORDER BY seq ASC;`,
+        );
+
         const [sessionsRows] = sessionsResult;
-        const [turnsRows] = turnsResult;
         const [producedRows] = producedResult;
         const [deliveryRows] = deliveryResult;
         const [healthRows] = healthResult;
-        const [titleRows] = titleResult;
 
         const sessionMeta = new Map<string, { project: string | null; source: string | null; started_at: string | null; ended_at: string | null }>();
         for (const row of sessionsRows) sessionMeta.set(row.id, row);

--- a/apps/axctl/src/dashboard/session-canvas.test.ts
+++ b/apps/axctl/src/dashboard/session-canvas.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for src/dashboard/session-canvas.ts orchestration task fetch.
+ *
+ * Regression guard for the per-child indexed dispatch-task read: the orch task
+ * fetch must hit each child with `session = <ref> ... LIMIT 1` (turn_session_seq),
+ * never `turn WHERE session IN [<all children>]` (a membership scan over the
+ * 560k-row turn table, ~1.3s for 117 children).
+ */
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { fetchSessionOrchestration } from "./session-canvas.ts";
+
+function makeMockDb(): { layer: Layer.Layer<SurrealClient>; captured: string[] } {
+    const captured: string[] = [];
+    const impl: SurrealClientShape = {
+        query: <T extends unknown[] = unknown[]>(sql: string) => {
+            captured.push(sql);
+            if (sql.includes("FROM session WHERE <string>id")) {
+                return Effect.succeed([[
+                    { id: "session:parent", label: "Parent", started_at: "2026-05-01T00:00:00.000Z", ended_at: "2026-05-01T01:00:00.000Z" },
+                ]] as unknown as T);
+            }
+            if (sql.includes("FROM spawned")) {
+                return Effect.succeed([[
+                    { id: "session:`c1`", nickname: "scout", ts: "2026-05-01T00:05:00.000Z", started_at: "2026-05-01T00:05:00.000Z", ended_at: "2026-05-01T00:10:00.000Z" },
+                    { id: "session:`c2`", nickname: null, ts: "2026-05-01T00:06:00.000Z", started_at: "2026-05-01T00:06:00.000Z", ended_at: "2026-05-01T00:12:00.000Z" },
+                ]] as unknown as T);
+            }
+            if (sql.includes("FROM turn WHERE session = session:`c1`")) {
+                return Effect.succeed([[{ s: "session:`c1`", text_excerpt: "do task A", seq: 0 }]] as unknown as T);
+            }
+            if (sql.includes("FROM turn WHERE session = session:`c2`")) {
+                return Effect.succeed([[{ s: "session:`c2`", text_excerpt: "do task B", seq: 1 }]] as unknown as T);
+            }
+            return Effect.succeed([[]] as unknown as T);
+        },
+        upsert: () => Effect.void,
+        relate: () => Effect.void,
+        putFile: () => Effect.void,
+        getFile: () => Effect.succeed(""),
+        raw: {} as never,
+    };
+    return { layer: Layer.succeed(SurrealClient, impl), captured };
+}
+
+describe("fetchSessionOrchestration task fetch", () => {
+    test("reads each child's dispatch task via per-child indexed query, never `session IN`", async () => {
+        const { layer, captured } = makeMockDb();
+
+        const orch = await Effect.runPromise(
+            fetchSessionOrchestration("session:parent").pipe(Effect.provide(layer)),
+        );
+
+        // Regression: no membership scan over the turn table.
+        for (const sql of captured) {
+            if (sql.includes("FROM turn")) {
+                expect(sql).not.toContain("session IN");
+                expect(sql).toContain("LIMIT 1");
+            }
+        }
+        // One indexed per-child read each.
+        expect(captured.some((s) => s.includes("FROM turn WHERE session = session:`c1`"))).toBe(true);
+        expect(captured.some((s) => s.includes("FROM turn WHERE session = session:`c2`"))).toBe(true);
+
+        // Tasks mapped onto the right subagents.
+        const byId = new Map(orch.subagents.map((sub) => [sub.id, sub.task]));
+        expect(byId.get("session:`c1`")).toBe("do task A");
+        expect(byId.get("session:`c2`")).toBe("do task B");
+    });
+});

--- a/apps/axctl/src/dashboard/session-canvas.ts
+++ b/apps/axctl/src/dashboard/session-canvas.ts
@@ -312,13 +312,17 @@ SELECT <string>out AS id, (nickname ?? NONE) AS nickname, ts,
        out.started_at AS started_at, out.ended_at AS ended_at
 FROM spawned WHERE <string>in = $id ORDER BY ts ASC;`;
 
-// First user turn per child session = the subagent's task. ONE query over the
-// child id set (built from `out` refs) instead of a correlated per-child scan
-// (which was the issue-#77 trap - ~10s for 50+ children). Rows arrive seq-ASC,
-// so the first row seen per session is its lowest-seq (= the dispatch prompt).
-const orchTasksSql = (childRefs: ReadonlyArray<string>): string => `
+// First user turn per child session = the subagent's dispatch task. Per-child
+// INDEXED `session = <ref>` LIMIT 1 (hits turn_session_seq) instead of
+// `turn WHERE session IN [<all children>]`, which is a membership scan over the
+// 560k-row turn table (~1.3s for 117 children) - the same trap fixed in
+// enrichSessions. `childRef` is the exact `session:⟨uuid⟩` record-ref literal.
+const orchTaskSql = (childRef: string): string => `
 SELECT <string>session AS s, text_excerpt, seq
-FROM turn WHERE session IN [${childRefs.join(", ")}] AND role = "user" ORDER BY seq ASC;`;
+FROM turn WHERE session = ${childRef} AND role = "user" ORDER BY seq ASC LIMIT 1;`;
+
+/** Per-child fan-out width for the dispatch-task reads. */
+const ORCH_TASK_FANOUT = 16;
 
 const QUICK_SUBAGENT_MS = 60_000;
 
@@ -371,13 +375,21 @@ export const fetchSessionOrchestration = (
         const parent = yield* db.query<[Array<Record<string, unknown>>]>(ORCH_PARENT_SQL, { id: sessionId });
         const children = yield* db.query<[Array<Record<string, unknown>>]>(ORCH_CHILDREN_SQL, { id: sessionId });
         const childRows = children?.[0] ?? [];
-        // batched task fetch: one query over all child ids (the `id` field is the
-        // exact `session:⟨uuid⟩` record-ref literal, safe to inline in the IN set).
+        // Per-child INDEXED task fetch (the `id` field is the exact
+        // `session:⟨uuid⟩` record-ref literal). Fanned out instead of a single
+        // `session IN [<all children>]` membership scan over the turn table.
         const childRefs = childRows.map((r) => str(r, "id")).filter((s): s is string => !!s);
         const tasksById = new Map<string, string>();
         if (childRefs.length > 0) {
-            const taskRows = yield* db.query<[Array<Record<string, unknown>>]>(orchTasksSql(childRefs), {});
-            for (const r of taskRows?.[0] ?? []) {
+            const perChild = yield* Effect.forEach(
+                childRefs,
+                (ref) =>
+                    db.query<[Array<Record<string, unknown>>]>(orchTaskSql(ref), {})
+                        .pipe(Effect.map(([rows]) => rows?.[0])),
+                { concurrency: ORCH_TASK_FANOUT },
+            );
+            for (const r of perChild) {
+                if (!r) continue;
                 const s = str(r, "s");
                 const ex = str(r, "text_excerpt");
                 if (s && ex && !tasksById.has(s)) tasksById.set(s, ex); // first (lowest seq) wins

--- a/apps/axctl/src/queries/insights-enrich.test.ts
+++ b/apps/axctl/src/queries/insights-enrich.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for src/queries/insights-enrich.ts - post-query context enrichment for
+ * the classifier insight views.
+ *
+ * Regression guard: context lookups must use LITERAL session ids
+ * (`session = session:\`...\``, indexed) - never `$parent.session` - and inject
+ * the same field names the old correlated SQL emitted, so formatInsightRows is
+ * unchanged.
+ */
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { enrichInsightRows } from "./insights-enrich.ts";
+
+function makeMockDb(): { layer: Layer.Layer<SurrealClient>; captured: string[] } {
+    const captured: string[] = [];
+    const impl: SurrealClientShape = {
+        query: <T extends unknown[] = unknown[]>(sql: string) => {
+            captured.push(sql);
+            if (sql.includes("FROM turn") && sql.includes('role = "assistant"')) {
+                return Effect.succeed([[{ id: "turn:prev", seq: 4, text: "previous reply" }]] as unknown as T);
+            }
+            if (sql.includes("FROM tool_call") && sql.includes("has_error = true")) {
+                return Effect.succeed([[{ id: "tool_call:f1", name: "Bash", command_norm: "bun", error_text: "boom", output_excerpt: null, ts: "2026-05-01T00:00:00.000Z" }]] as unknown as T);
+            }
+            if (sql.includes("FROM tool_call")) {
+                return Effect.succeed([[{ id: "tool_call:l1", name: "Edit", ts: "2026-05-01T00:10:00.000Z" }]] as unknown as T);
+            }
+            if (sql.includes("FROM command_outcome")) {
+                return Effect.succeed([[{ id: "command_outcome:o1", kind: "expected_feedback", ts: "2026-05-01T00:11:00.000Z" }]] as unknown as T);
+            }
+            if (sql.includes("FROM turn") && sql.includes('role = "user"')) {
+                return Effect.succeed([[{ id: "turn:u6", seq: 6, role: "user", text: "next ask", ts: "2026-05-01T00:12:00.000Z" }]] as unknown as T);
+            }
+            return Effect.succeed([[]] as unknown as T);
+        },
+        upsert: () => Effect.void,
+        relate: () => Effect.void,
+        putFile: () => Effect.void,
+        getFile: () => Effect.succeed(""),
+        raw: {} as never,
+    };
+    return { layer: Layer.succeed(SurrealClient, impl), captured };
+}
+
+const baseRow = {
+    id: "classifier_result:r1",
+    session: "session:`s1`",
+    user_seq: 5,
+    ts: new Date("2026-05-01T00:05:00.000Z"),
+};
+
+describe("enrichInsightRows", () => {
+    test("classifier-facts: injects previous_assistant + recent_tool_failures via literal session ids", async () => {
+        const { layer, captured } = makeMockDb();
+        const rows = await Effect.runPromise(
+            enrichInsightRows("classifier-facts", [baseRow]).pipe(Effect.provide(layer)),
+        );
+        for (const sql of captured) {
+            expect(sql).not.toContain("$parent");
+            expect(sql).toContain("session = session:`s1`");
+        }
+        expect(rows[0]!.previous_assistant).toMatchObject({ id: "turn:prev", text: "previous reply" });
+        expect(rows[0]!.recent_tool_failures).toHaveLength(1);
+        // facts cap failures at 3
+        expect(captured.some((s) => s.includes("LIMIT 3"))).toBe(true);
+    });
+
+    test("correction-contexts: failure lookback is LIMIT 5", async () => {
+        const { layer, captured } = makeMockDb();
+        await Effect.runPromise(
+            enrichInsightRows("correction-contexts", [baseRow]).pipe(Effect.provide(layer)),
+        );
+        expect(captured.some((s) => s.includes("has_error = true") && s.includes("LIMIT 5"))).toBe(true);
+    });
+
+    test("classifier-outcomes: injects later_tool_calls / later_command_outcomes / later_user_turns", async () => {
+        const { layer, captured } = makeMockDb();
+        const rows = await Effect.runPromise(
+            enrichInsightRows("classifier-outcomes", [baseRow]).pipe(Effect.provide(layer)),
+        );
+        for (const sql of captured) expect(sql).not.toContain("$parent");
+        expect(rows[0]!.later_tool_calls).toHaveLength(1);
+        expect(rows[0]!.later_command_outcomes).toHaveLength(1);
+        expect(rows[0]!.later_user_turns).toHaveLength(1);
+    });
+
+    test("non-classifier views pass through with zero queries", async () => {
+        const { layer, captured } = makeMockDb();
+        const rows = await Effect.runPromise(
+            enrichInsightRows("repositories", [baseRow]).pipe(Effect.provide(layer)),
+        );
+        expect(captured).toHaveLength(0);
+        expect(rows[0]).toBe(baseRow);
+    });
+
+    test("a row with no session passes through unenriched (no throw)", async () => {
+        const { layer } = makeMockDb();
+        const rows = await Effect.runPromise(
+            enrichInsightRows("classifier-facts", [{ id: "classifier_result:r2" }]).pipe(Effect.provide(layer)),
+        );
+        expect(rows[0]!.previous_assistant).toBeUndefined();
+    });
+});

--- a/apps/axctl/src/queries/insights-enrich.ts
+++ b/apps/axctl/src/queries/insights-enrich.ts
@@ -1,0 +1,128 @@
+/**
+ * insights-enrich.ts - post-query context enrichment for the classifier
+ * insight views.
+ *
+ * classifier-facts / correction-contexts / classifier-outcomes used to fetch
+ * their per-row context (previous assistant turn, recent tool failures, later
+ * tool calls / command outcomes / user turns) via correlated
+ * `WHERE session = $parent.session` subqueries inside the view SQL. SurrealDB
+ * v3 cannot use index lookups through `$parent.*`, so each subquery partial-
+ * scans the 560k-turn / 150k-tool_call tables: with the default LIMIT 20 that
+ * was ~20s (facts/contexts) and ~38s (outcomes) per view.
+ *
+ * The view SQL now returns just the classifier rows (indexed, fast) and this
+ * module resolves the same context per row with LITERAL session ids - each an
+ * indexed ~1ms lookup (turn_session_seq / tool_call_session_ts) - fanned out
+ * at bounded concurrency. Field names and shapes match what the old SQL
+ * emitted, so `formatInsightRows` is unchanged.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { recordIdString } from "@ax/lib/shared/row-fields";
+import { surrealDate } from "@ax/lib/shared/surql";
+import type { InsightView } from "./insights.ts";
+
+/** Per-row fan-out width for the context lookups. */
+const ENRICH_FANOUT = 8;
+
+type Row = Record<string, unknown>;
+
+const ENRICHED_VIEWS = new Set<InsightView>([
+    "classifier-facts",
+    "correction-contexts",
+    "classifier-outcomes",
+]);
+
+/** `session:⟨uuid⟩`-style literal from a row's raw `session` field (RecordId
+ *  object or string). Null when absent/malformed - the row passes through
+ *  unenriched rather than failing the whole view. */
+const sessionLiteral = (row: Row): string | null => {
+    const raw = recordIdString(row.session);
+    if (!raw || !raw.startsWith("session:")) return null;
+    let key = raw.slice("session:".length);
+    if (key.startsWith("⟨") && key.endsWith("⟩")) key = key.slice(1, -1);
+    else if (key.startsWith("`") && key.endsWith("`")) key = key.slice(1, -1);
+    if (!key) return null;
+    return `session:\`${key.replace(/`/g, "")}\``;
+};
+
+const tsLiteral = (row: Row): string | null => {
+    const ts = row.ts;
+    if (ts instanceof Date) return surrealDate(ts);
+    if (typeof ts === "string" && ts.length > 0) return surrealDate(ts);
+    return null;
+};
+
+const seqOf = (row: Row): number | null =>
+    typeof row.user_seq === "number" && Number.isFinite(row.user_seq) ? row.user_seq : null;
+
+const one = <T>(rows: readonly T[] | undefined): T | null => rows?.[0] ?? null;
+
+const enrichRow = (
+    view: InsightView,
+    row: Row,
+): Effect.Effect<Row, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const sid = sessionLiteral(row);
+        if (sid === null) return row;
+        const seq = seqOf(row);
+        const ts = tsLiteral(row);
+
+        if (view === "classifier-facts" || view === "correction-contexts") {
+            const failureLimit = view === "classifier-facts" ? 3 : 5;
+            const [prevResult, failResult] = yield* Effect.all([
+                seq === null
+                    ? Effect.succeed([[]] as [Row[]])
+                    : db.query<[Row[]]>(
+                        `SELECT id, seq, text_excerpt AS text FROM turn WHERE session = ${sid} AND role = "assistant" AND seq < ${seq} ORDER BY seq DESC LIMIT 1;`,
+                    ),
+                ts === null
+                    ? Effect.succeed([[]] as [Row[]])
+                    : db.query<[Row[]]>(
+                        `SELECT id, name, command_norm, error_text, output_excerpt, ts FROM tool_call WHERE session = ${sid} AND has_error = true AND ts <= ${ts} ORDER BY ts DESC LIMIT ${failureLimit};`,
+                    ),
+            ], { concurrency: 2 });
+            return {
+                ...row,
+                previous_assistant: one(prevResult?.[0]),
+                recent_tool_failures: failResult?.[0] ?? [],
+            };
+        }
+
+        // classifier-outcomes: what happened AFTER the classified turn.
+        const [toolResult, outcomeResult, userResult] = yield* Effect.all([
+            ts === null
+                ? Effect.succeed([[]] as [Row[]])
+                : db.query<[Row[]]>(
+                    `SELECT id, name, command_norm, has_error, status, exit_code, output_excerpt, error_text, ts FROM tool_call WHERE session = ${sid} AND ts > ${ts} ORDER BY ts ASC LIMIT 5;`,
+                ),
+            ts === null
+                ? Effect.succeed([[]] as [Row[]])
+                : db.query<[Row[]]>(
+                    `SELECT id, kind, status, command_norm, command_tool, text, tool_call, ts FROM command_outcome WHERE session = ${sid} AND ts > ${ts} ORDER BY ts ASC LIMIT 5;`,
+                ),
+            seq === null
+                ? Effect.succeed([[]] as [Row[]])
+                : db.query<[Row[]]>(
+                    `SELECT id, seq, role, text_excerpt AS text, ts FROM turn WHERE session = ${sid} AND role = "user" AND seq > ${seq} ORDER BY seq ASC LIMIT 3;`,
+                ),
+        ], { concurrency: 3 });
+        return {
+            ...row,
+            later_tool_calls: toolResult?.[0] ?? [],
+            later_command_outcomes: outcomeResult?.[0] ?? [],
+            later_user_turns: userResult?.[0] ?? [],
+        };
+    });
+
+/** Enrich the rows of a classifier insight view with per-row context via
+ *  indexed lookups. Views outside ENRICHED_VIEWS pass through untouched. */
+export const enrichInsightRows = (
+    view: InsightView,
+    rows: ReadonlyArray<Row>,
+): Effect.Effect<ReadonlyArray<Row>, DbError, SurrealClient> =>
+    ENRICHED_VIEWS.has(view)
+        ? Effect.forEach(rows, (row) => enrichRow(view, row), { concurrency: ENRICH_FANOUT })
+        : Effect.succeed(rows);

--- a/apps/axctl/src/queries/insights.test.ts
+++ b/apps/axctl/src/queries/insights.test.ts
@@ -234,8 +234,12 @@ describe("insights query builders", () => {
 
         expect(sql).toContain("FROM edited");
         expect(sql).toContain("GROUP BY session");
-        expect(sql).toContain("FROM command_outcome WHERE session = $parent.session");
-        expect(sql).toContain("verification_commands = 0");
+        // Anti-join against the verified-session set (computed once), not a
+        // per-row correlated `session = $parent.session` subquery.
+        expect(sql).not.toContain("$parent.session");
+        expect(sql).toContain("session NOT IN");
+        expect(sql).toContain("FROM command_outcome");
+        expect(sql).toContain("0 AS verification_commands");
     });
 
     test("userLanguageSql reads user-message ngrams", () => {

--- a/apps/axctl/src/queries/insights.test.ts
+++ b/apps/axctl/src/queries/insights.test.ts
@@ -330,46 +330,35 @@ describe("insights query builders", () => {
         expect(sql).toContain("ORDER BY ts DESC");
     });
 
-    test("classifierFactsSql joins facts to user turn, prior assistant, and tool failures", () => {
+    // The per-row context (previous assistant / failures / later activity) is
+    // resolved post-query by enrichInsightRows with literal session ids; the
+    // view SQL itself must stay free of correlated $parent.* subqueries.
+    test("classifierFactsSql selects classifier rows without correlated context subqueries", () => {
         const sql = classifierFactsSql(10);
 
         expect(sql).toContain("FROM classifier_result");
         expect(sql).toContain("turn.text_excerpt AS user_text");
-        expect(sql).toContain("AS previous_assistant");
-        expect(sql).toContain('role = "assistant"');
-        expect(sql).toContain("seq < $parent.turn.seq");
-        expect(sql).toContain("FROM tool_call");
-        expect(sql).toContain("has_error = true");
-        expect(sql).toContain("AS recent_tool_failures");
         expect(sql).toContain("WHERE turn IS NOT NONE");
         expect(sql).toContain("ORDER BY ts DESC");
+        expect(sql).not.toContain("$parent");
     });
 
-    test("correctionContextsSql focuses correction facts with causal context", () => {
+    test("correctionContextsSql focuses correction facts without correlated subqueries", () => {
         const sql = correctionContextsSql(10);
 
         expect(sql).toContain("FROM classifier_result");
         expect(sql).toContain('classifier_key = "correction-event" OR label = "correction"');
         expect(sql).toContain("turn.text_excerpt AS user_text");
-        expect(sql).toContain("AS previous_assistant");
-        expect(sql).toContain("FROM tool_call");
-        expect(sql).toContain("has_error = true");
-        expect(sql).toContain("LIMIT 5");
+        expect(sql).not.toContain("$parent");
     });
 
-    test("classifierOutcomesSql connects facts to later tools, outcomes, and user turns", () => {
+    test("classifierOutcomesSql selects classifier rows without correlated subqueries", () => {
         const sql = classifierOutcomesSql(10);
 
         expect(sql).toContain("FROM classifier_result");
         expect(sql).toContain("turn.text_excerpt AS user_text");
-        expect(sql).toContain("AS later_tool_calls");
-        expect(sql).toContain("FROM tool_call");
-        expect(sql).toContain("ts > $parent.ts");
-        expect(sql).toContain("AS later_command_outcomes");
-        expect(sql).toContain("FROM command_outcome");
-        expect(sql).toContain("AS later_user_turns");
-        expect(sql).toContain('role = "user"');
-        expect(sql).toContain("seq > $parent.turn.seq");
+        expect(sql).toContain("WHERE turn IS NOT NONE");
+        expect(sql).not.toContain("$parent");
     });
 
     test("harnessCandidatesSql groups repeated facts into suggested harness actions", () => {

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -380,25 +380,40 @@ LIMIT ${safeLimit};`.trim();
 
 export function verificationGapsSql(limit: number): string {
     const safeLimit = checkedLimit(limit);
+    // "Sessions that edited but never verified." The old form ran a correlated
+    // `command_outcome WHERE session = $parent.session` subquery per edited
+    // session (thousands) - $parent.session can't use an index, so ~16s. This
+    // instead: (1) anti-join against the verified-session set computed ONCE
+    // (`session NOT IN (... GROUP BY session)`); (2) filter + limit on the cheap
+    // (session, edits) projection, deref session meta only for the final N rows.
+    // verification_commands is 0 by construction of the filter. ~16s -> ~6s; the
+    // residual is the `in.session` deref over the edited edge table.
     return `
-SELECT * FROM (
-    SELECT
-        session AS id,
-        session.project AS project,
-        session.cwd AS cwd,
-        session.started_at AS started_at,
-        session.ended_at AS ended_at,
-        edits,
-        array::len((SELECT id FROM command_outcome WHERE session = $parent.session AND kind IN ["expected_feedback", "product_bug_signal", "guardrail"])) AS verification_commands
+SELECT
+    id,
+    id.project AS project,
+    id.cwd AS cwd,
+    id.started_at AS started_at,
+    id.ended_at AS ended_at,
+    edits,
+    0 AS verification_commands
+FROM (
+    SELECT session AS id, edits
     FROM (
         SELECT in.session AS session, count() AS edits
         FROM edited
         GROUP BY session
     )
+    WHERE edits > 0
+      AND session NOT IN (
+        SELECT VALUE session FROM command_outcome
+        WHERE kind IN ["expected_feedback", "product_bug_signal", "guardrail"]
+        GROUP BY session
+      )
+    ORDER BY edits DESC
+    LIMIT ${safeLimit}
 )
-WHERE edits > 0 AND verification_commands = 0
-ORDER BY edits DESC, ended_at DESC
-LIMIT ${safeLimit};`.trim();
+ORDER BY edits DESC, ended_at DESC;`.trim();
 }
 
 export function userLanguageSql(limit: number): string {

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -617,6 +617,12 @@ ORDER BY ts DESC
 LIMIT ${safeLimit};`.trim();
 }
 
+// NOTE (classifier-facts / correction-contexts / classifier-outcomes): the
+// per-row context (previous assistant turn, recent failures, later activity)
+// is resolved AFTER this query by `enrichInsightRows` (insights-enrich.ts)
+// using literal session ids. The correlated `$parent.session` subqueries that
+// used to live here could not use index lookups (SurrealDB v3), so each row
+// cost ~1s of partial scans (~20-38s per view at LIMIT 20).
 export function classifierFactsSql(limit: number): string {
     const safeLimit = checkedLimit(limit);
     return `
@@ -639,34 +645,7 @@ SELECT
     session.cwd AS cwd,
     evidence_json,
     signals,
-    ts,
-    (
-        SELECT
-            id,
-            seq,
-            text_excerpt AS text
-        FROM turn
-        WHERE session = $parent.session
-          AND role = "assistant"
-          AND seq < $parent.turn.seq
-        ORDER BY seq DESC
-        LIMIT 1
-    )[0] AS previous_assistant,
-    (
-        SELECT
-            id,
-            name,
-            command_norm,
-            error_text,
-            output_excerpt,
-            ts
-        FROM tool_call
-        WHERE session = $parent.session
-          AND has_error = true
-          AND ts <= $parent.ts
-        ORDER BY ts DESC
-        LIMIT 3
-    ) AS recent_tool_failures
+    ts
 FROM classifier_result
 WHERE turn IS NOT NONE
 ORDER BY ts DESC
@@ -693,34 +672,7 @@ SELECT
     session.cwd AS cwd,
     evidence_json,
     signals,
-    ts,
-    (
-        SELECT
-            id,
-            seq,
-            text_excerpt AS text
-        FROM turn
-        WHERE session = $parent.session
-          AND role = "assistant"
-          AND seq < $parent.turn.seq
-        ORDER BY seq DESC
-        LIMIT 1
-    )[0] AS previous_assistant,
-    (
-        SELECT
-            id,
-            name,
-            command_norm,
-            error_text,
-            output_excerpt,
-            ts
-        FROM tool_call
-        WHERE session = $parent.session
-          AND has_error = true
-          AND ts <= $parent.ts
-        ORDER BY ts DESC
-        LIMIT 5
-    ) AS recent_tool_failures
+    ts
 FROM classifier_result
 WHERE classifier_key = "correction-event" OR label = "correction"
 ORDER BY ts DESC
@@ -745,54 +697,7 @@ SELECT
     session,
     session.project AS project,
     session.cwd AS cwd,
-    ts,
-    (
-        SELECT
-            id,
-            name,
-            command_norm,
-            has_error,
-            status,
-            exit_code,
-            output_excerpt,
-            error_text,
-            ts
-        FROM tool_call
-        WHERE session = $parent.session
-          AND ts > $parent.ts
-        ORDER BY ts ASC
-        LIMIT 5
-    ) AS later_tool_calls,
-    (
-        SELECT
-            id,
-            kind,
-            status,
-            command_norm,
-            command_tool,
-            text,
-            tool_call,
-            ts
-        FROM command_outcome
-        WHERE session = $parent.session
-          AND ts > $parent.ts
-        ORDER BY ts ASC
-        LIMIT 5
-    ) AS later_command_outcomes,
-    (
-        SELECT
-            id,
-            seq,
-            role,
-            text_excerpt AS text,
-            ts
-        FROM turn
-        WHERE session = $parent.session
-          AND role = "user"
-          AND seq > $parent.turn.seq
-        ORDER BY seq ASC
-        LIMIT 3
-    ) AS later_user_turns
+    ts
 FROM classifier_result
 WHERE turn IS NOT NONE
 ORDER BY ts DESC

--- a/docs/proud-session-seed-loop-log.md
+++ b/docs/proud-session-seed-loop-log.md
@@ -457,3 +457,38 @@ go-ahead, not autonomous:**
 4. ingest write batching (per-row UPSERT → per-file transaction) — write path.
 
 Pausing the autonomous loop here and reporting for direction.
+
+---
+
+## Iteration 11 — classifier views: correlated context → enrichment pass (2026-06-10 ~09:20 WITA)
+
+**Context.** User said continue past convergence — taking the remaining backlog
+item #1 (the other $parent.session views).
+
+**Tried.** classifier-facts / correction-contexts / classifier-outcomes
+(20s / 20s / 38s): outer LIMIT already bounds rows, but each row ran 2-3
+correlated `$parent.session` subqueries (~1s partial scan each). Pure SQL can't
+fix this ($parent defeats the index), so: slimmed the view SQL to just the
+classifier rows and added `insights-enrich.ts` — a post-query pass that resolves
+the same context per row with LITERAL session ids (indexed) at concurrency 8.
+Field names/shapes preserved → formatInsightRows untouched; non-classifier
+views pass through.
+
+**Worked.** **20.3s → 0.44s / 20.2s → 0.49s / 37.7s → 0.49s** (~40-77x).
+Differential parity proven: literal vs correlated lookup on a failure-heavy
+session returns identical rows/order. Tests 32/32 (insights SQL-shape +
+5 new enrich tests). typecheck + effect-lint clean. Committed `bd19bac`.
+
+**Failed / friction.**
+- First sanity check looked alarming (failures/later_tool_calls all 0) — turned
+  out GENUINE (recent classifier rows come from clean sessions, incl. this
+  loop's own); proven by manual queries + the differential check.
+- SurrealDB 3.1 parse rule bit my ad-hoc test query: ORDER BY fields must
+  appear in the SELECT projection ("Missing order idiom") — production queries
+  all comply.
+
+**Next.** Remaining deep backlog: (a) verification-gaps residual ~4s = in.session
+deref over `edited` (needs edge denormalization, write-path); (b)
+buildFileContextPack → lean swap (title-priority behavior decision); (c) ingest
+write batching. All write-path/behavioral — propose PR'ing the branch first
+(4 perf commits accumulated), then tackle with fresh review.

--- a/docs/proud-session-seed-loop-log.md
+++ b/docs/proud-session-seed-loop-log.md
@@ -378,3 +378,38 @@ held; profiled before changing, real test isolation).
 - 7. `reaction_event.session` backfill+index (drop the `user_turn.session` deref).
 - Then the risky/test-coupled ones (1b buildFileContextPack swap, 2 insights
   $parent.session, 3 ingest write batching) — each its own time-boxed iteration.
+
+---
+
+## Iteration 9 — profile recall / loc-query / content_atom index (2026-06-10 08:15 WITA)
+
+**Tried.** Profiled the next three backlog candidates before touching anything.
+
+**Worked — all non-actionable (valid negative findings):**
+- **recall** (`session IN [ids]` skill path + `session.repository` deref): 0.92s
+  scope=here (2005 hits), 0.57s scope=all (2302), 1.35s --skill. The BM25 FTS
+  index narrows first, so the session filters apply to a small set. Healthy.
+- **content_atom session index**: `content_atom WHERE session=X AND
+  source_kind='turn'` IS 12.5s (the `(session,kind)` index is defeated by the
+  source_kind filter). BUT the only `FROM content_atom` query (session-turn-
+  content.ts) was made per-document in iter-2, so NOTHING queries atoms by
+  session. Adding `(session,source_kind)` would be a speculative index (ingest
+  + DB cost, no consumer) — skipped per profile-first discipline.
+- **loc-query** `tool_call name IN [edit tools]`: 0.54s over 150k rows, and in
+  practice gated by `session = X` (indexed) or an FTS subquery + LIMIT. Fine.
+
+**Conclusion.** The clean, low-risk read hotspots are exhausted — the big wins
+(enrichSessions, share content, file-context lean, session-canvas orch) are
+shipped; the remaining IN-patterns are over small/medium tables or gated by
+index/FTS/LIMIT and run <1s. What's left is the RISKY set, each its own
+time-boxed iteration:
+- 2. `insights.ts` `$parent.session` correlated derefs (633-774) — profile first
+  (is it used + slow on `ax signals`/wrapped/health?); expect test coupling.
+- 1b. `buildFileContextPack` → lean swap (mock rewrite + title-priority).
+- 3. ingest write batching (per-row UPSERT → per-file txn) — write path.
+
+**Next (iter 10).** Profile `insights.ts` queries on a real invocation; if a
+`$parent.session` query is genuinely slow AND has test isolation, fix it
+(time-boxed, ship-safe-subset rule). Otherwise document and consider the loop
+converged on safe read wins — report status and pause for direction on the
+risky/write-path targets.

--- a/docs/proud-session-seed-loop-log.md
+++ b/docs/proud-session-seed-loop-log.md
@@ -353,3 +353,28 @@ hole, ship the safe subset and split the rest into its own iteration.**
 - 5. recall.ts session-IN scope filter. 6. schema diff-apply on install.
 - 7. reaction_event.session backfill+index. 8. loc-query name-IN.
 - 9. content_atom(session,source_kind) index. 10. DB retention/compaction.
+
+---
+
+## Iteration 8 — optimization target #4: session-canvas orch IN-scan (2026-06-10 07:55 WITA)
+
+**Tried.** Profiled `session-canvas.ts` `orchTasksSql` on the worst-case
+orchestration (`72f97b36`, **117 spawned children**): `turn WHERE session IN
+[117] AND role='user' ORDER BY seq` = **1.33s** (fetches 3106 rows just to keep
+the first per child). Per-child `session = X ... LIMIT 1` = 0.016s.
+
+**Worked.** Replaced with per-child indexed `LIMIT 1` fan-out (concurrency 16) —
+117 rows instead of 3106, and indexed. The view only needs each child's first
+user turn (dispatch prompt), so the result is identical. Added
+`session-canvas.test.ts` (regression guard: per-child `session =`, never
+`session IN`, + task→subagent mapping). typecheck 0, test 1/1, effect-lint clean.
+Committed `f544637`. Clean, isolated target — no rabbit hole (the time-box rule
+held; profiled before changing, real test isolation).
+
+**Next.**
+- 5. `recall.ts:116` `AND session IN [ids]` scope filter — profile with a large
+  `--scope=here` (many sessions) before changing; fix only if slow.
+- 9. `content_atom(session, source_kind)` index (defeated `(session,kind)` today).
+- 7. `reaction_event.session` backfill+index (drop the `user_turn.session` deref).
+- Then the risky/test-coupled ones (1b buildFileContextPack swap, 2 insights
+  $parent.session, 3 ingest write batching) — each its own time-boxed iteration.

--- a/docs/proud-session-seed-loop-log.md
+++ b/docs/proud-session-seed-loop-log.md
@@ -314,3 +314,42 @@ PR summary ready, branch green. Remaining: the final wind-down within ~30min of
 08:30 — re-enable `com.necmttn.ax-watch`, one catch-up `ax ingest --since=1`
 (lock-protected), confirm `sessions here` + `share --dry-run` still fast, then
 mark the loop complete. Interim wakes are just health pings.
+
+---
+
+## Iteration 7 — optimization loop target #1: file-context turn IN-scans (2026-06-10 07:10 WITA)
+
+Branch `opt/read-hotspots` off the merged main (#167 + #166). Working the
+10-target optimization backlog from the post-merge review.
+
+**Tried.** Target #1 = `context/file-context.ts` `session IN [...]` cluster.
+Found two layers:
+- `loadPriorFileSessionsLean` (hook limit-5 path): `turn WHERE session IN [≤50]`
+  for user/assistant counts + task titles = ~3s membership scan over 560k turns.
+- `loadPriorFileSessions` (the `$parent.session` correlated version `ax context
+  file` actually uses): ~12 partial scans/row, ~3.2s.
+
+**Worked.** Fixed the lean loader: both turn reads → per-session `session = <lit>`
+indexed fan-out (concurrency 16); small-table reads stay batched. typecheck 0,
+file-context + hook tests 26/26, effect-lint clean. Committed `76df58f`.
+
+**Failed / friction (important lesson).** Tried to also swap
+`buildFileContextPack` onto the lean loader + delete the slow correlated one —
+but (a) the unit test mocks the slow query's single fat response, so it needs a
+full per-session mock rewrite, and (b) the lean loader prioritizes `pr_title`
+for the session title while the slow one prioritizes the first user-turn text —
+a real BEHAVIORAL difference, not just perf. Reverted the swap to pristine and
+shipped only the safe, tested lean-loader fix. **Loop rule going forward:
+time-box each target; if it turns into a test-coupling / behavior-change rabbit
+hole, ship the safe subset and split the rest into its own iteration.**
+
+**Next (optimization backlog, re-ordered for low-risk-first).**
+- 1b. `buildFileContextPack` → lean loader swap (needs mock rewrite + title-
+  priority decision). Its own iteration.
+- 2. `insights.ts` `$parent.session` correlated subqueries (633-774) — same
+  pattern; likely same test coupling, time-box it.
+- 3. ingest write batching (`transcripts.ts` per-row UPSERTs → per-file txn).
+- 4. session-canvas orch `session IN [childRefs]` (small, self-contained).
+- 5. recall.ts session-IN scope filter. 6. schema diff-apply on install.
+- 7. reaction_event.session backfill+index. 8. loc-query name-IN.
+- 9. content_atom(session,source_kind) index. 10. DB retention/compaction.

--- a/docs/proud-session-seed-loop-log.md
+++ b/docs/proud-session-seed-loop-log.md
@@ -413,3 +413,47 @@ time-boxed iteration:
 (time-boxed, ship-safe-subset rule). Otherwise document and consider the loop
 converged on safe read wins — report status and pause for direction on the
 risky/write-path targets.
+
+---
+
+## Iteration 10 — insights $parent.session (verification-gaps) + convergence (2026-06-10 08:40 WITA)
+
+**Tried.** Profiled the `ax insights` views that use `$parent.session`:
+verification-gaps **16s**, classifier-facts **20s**, correction-contexts **20s**
+— genuinely slow. Tests assert SQL *strings* (good isolation, no DB mock).
+
+**Worked.** Fixed verification-gaps with a contained single-query rewrite (kept
+the string-builder architecture): correlated `command_outcome WHERE session =
+$parent.session` per edited session → one-shot anti-join `session NOT IN (SELECT
+... GROUP BY session)`, plus deferring the session-meta derefs to after
+filter+limit. **16s → 4.1s.** Output identical; insights tests 27/27 (assertions
+updated to the anti-join shape); typecheck + effect-lint clean. Committed
+`0f2acad`.
+
+**Failed / friction.** The residual ~4s is the `in.session` 2-hop deref over the
+`edited` edge table — flooring it needs denormalizing session onto the edge
+(ingest/schema = write-path). The sibling views classifier-facts /
+correction-contexts (~20s) have the SAME pattern but with multiple
+$parent.session subqueries each — bigger per-view rewrites.
+
+## Loop status: CONVERGED on safe read wins
+
+**`opt/read-hotspots` (post-merge of #167), 6 commits:**
+- `76df58f` file-context lean loader: turn `session IN` → per-session indexed.
+- `f544637` session-canvas orch: `session IN [117]` 1.33s → per-child indexed.
+- `0f2acad` insights verification-gaps: correlated `$parent.session` 16s → 4.1s.
+- + iter logs `97b9746`, `43cf4dd`, `f9e14f9`, and this entry.
+Profiled-healthy (no change): recall, loc-query, content_atom session index
+(no consumer), cost-query, sessions show.
+
+**Remaining backlog = risky / deeper / write-path — each needs explicit
+go-ahead, not autonomous:**
+1. classifier-facts / correction-contexts (~20s) — same anti-join treatment,
+   multiple subqueries per view.
+2. `edited`/`tool_call` session denormalization — floors the insights derefs but
+   is an ingest/schema change (re-ingest cost).
+3. `buildFileContextPack` → lean loader swap (mock rewrite + title-priority
+   behavior change).
+4. ingest write batching (per-row UPSERT → per-file transaction) — write path.
+
+Pausing the autonomous loop here and reporting for direction.


### PR DESCRIPTION
Follow-up to #167 — works the remaining read-hotspot backlog from the post-merge review. Every fix was profiled against the live DB before changing, and verified after.

## Wins

| Path | Before | After |
|------|--------|-------|
| `ax insights classifier-facts` | 20.3s | **0.44s** |
| `ax insights correction-contexts` | 20.2s | **0.49s** |
| `ax insights classifier-outcomes` | 37.7s | **0.49s** |
| `ax insights verification-gaps` | 16.0s | **4.1s** |
| session-canvas orchestration (117 children) | 1.33s | indexed per-child |
| file-context lean loader (hot file, ~50 sessions) | ~3s | per-session indexed |

## What changed

- **insights classifier views** — the view SQL returns just the classifier rows; a new `queries/insights-enrich.ts` pass resolves per-row context (previous assistant turn, recent failures, later activity) with **literal session ids** (indexed ~1ms via `turn_session_seq` / `tool_call_session_ts`) instead of correlated `WHERE session = $parent.session` subqueries, which can't use indexes in SurrealDB v3 (~1s partial scan per row). Field names/shapes unchanged → `formatInsightRows` untouched. Differential parity check: literal vs correlated on a failure-heavy session returns identical rows/order.
- **verification-gaps** — correlated per-session `command_outcome` subquery → one-shot anti-join (`session NOT IN (… GROUP BY session)`) + session-meta derefs deferred to after filter/limit.
- **session-canvas orch** — `turn WHERE session IN [<all children>]` (membership scan, 3106 rows fetched to keep firsts) → per-child `session = X … LIMIT 1` indexed fan-out.
- **file-context lean loader** — turn count/title reads `session IN [≤50]` → per-session indexed fan-out; small-table IN-batches kept (they're cheap).

Profiled-healthy, intentionally unchanged (documented in the loop log): recall, loc-query, cost-query, sessions show, `content_atom` session index (no consumer).

## Tests
insights 27/27 (SQL-shape: no `$parent`), insights-enrich 5/5 (new), session-canvas 1/1 (new), file-context + hook 26/26. typecheck clean; effect-lint (`@effect/language-service`) clean on all changed code.

Per-iteration trail: `docs/proud-session-seed-loop-log.md` (iterations 7–11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)