### PR TITLE
fix(metrics): commit-anchored time-to-land + stale help text (blind-dogfood findings)

### DIFF
--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -3618,7 +3618,8 @@ const sessionsMetricsCommand = Command.make(
         }),
 ).pipe(Command.withDescription(
     "Graph-derived per-session metrics: durability (commits not later reverted), "
-    + "time-to-land (session→PR merge), lines added/removed, sorted by lowest durability. "
+    + "time-to-land (commit→PR merge), lines added/removed, first-edit latency, cold-start reads, "
+    + "delegation. Sorted by produced commits, then most fragile first. "
     + "--here scopes to the pwd repo, --since N days, --json for machine output.",
 ));
 

--- a/apps/axctl/src/metrics/time-to-land.test.ts
+++ b/apps/axctl/src/metrics/time-to-land.test.ts
@@ -14,28 +14,48 @@ const db = (produced: Array<Record<string, unknown>>, prs: Array<Record<string, 
     } as never);
 
 describe("computeTimeToLand", () => {
-    test("ms from session.ended_at to the merged_at of a PR matching a produced sha", async () => {
-        const produced = [{ session: "session:`s1`", ended_at: "2026-01-01T00:00:00Z", sha: "abc" }];
+    test("ms from the commit's ts to the merged_at of the PR matching its sha", async () => {
+        const produced = [{ session: "session:`s1`", commit_ts: "2026-01-01T00:00:00Z", sha: "abc" }];
         const prs = [{ merge_sha: "abc", merged_at: "2026-01-01T01:00:00Z" }];
         const out = await Effect.runPromise(computeTimeToLand(["session:`s1`"]).pipe(Effect.provide(db(produced, prs))));
         expect(out.get("session:`s1`")).toBe(3600000); // 1h
     });
 
-    test("takes the earliest merge across multiple produced commits", async () => {
+    test("takes the fastest commit→merge latency across multiple produced commits", async () => {
         const produced = [
-            { session: "session:`s1`", ended_at: "2026-01-01T00:00:00Z", sha: "early" },
-            { session: "session:`s1`", ended_at: "2026-01-01T00:00:00Z", sha: "late" },
+            { session: "session:`s1`", commit_ts: "2026-01-01T00:00:00Z", sha: "early" },
+            { session: "session:`s1`", commit_ts: "2026-01-01T00:00:00Z", sha: "late" },
         ];
         const prs = [
             { merge_sha: "late", merged_at: "2026-01-01T05:00:00Z" },
             { merge_sha: "early", merged_at: "2026-01-01T02:00:00Z" },
         ];
         const out = await Effect.runPromise(computeTimeToLand(["session:`s1`"]).pipe(Effect.provide(db(produced, prs))));
-        expect(out.get("session:`s1`")).toBe(2 * 3600000); // earliest = 2h
+        expect(out.get("session:`s1`")).toBe(2 * 3600000); // fastest = 2h
+    });
+
+    test("never negative: a merge timestamped before the commit (clock skew) is dropped", async () => {
+        const produced = [
+            { session: "session:`s1`", commit_ts: "2026-01-01T02:00:00Z", sha: "skew" },
+            { session: "session:`s1`", commit_ts: "2026-01-01T00:00:00Z", sha: "ok" },
+        ];
+        const prs = [
+            { merge_sha: "skew", merged_at: "2026-01-01T01:00:00Z" }, // before its commit → dropped
+            { merge_sha: "ok", merged_at: "2026-01-01T03:00:00Z" },
+        ];
+        const out = await Effect.runPromise(computeTimeToLand(["session:`s1`"]).pipe(Effect.provide(db(produced, prs))));
+        expect(out.get("session:`s1`")).toBe(3 * 3600000); // the skewed pair never wins
+    });
+
+    test("only-skewed pairs → null, not a negative", async () => {
+        const produced = [{ session: "session:`s2`", commit_ts: "2026-01-01T02:00:00Z", sha: "skew" }];
+        const prs = [{ merge_sha: "skew", merged_at: "2026-01-01T01:00:00Z" }];
+        const out = await Effect.runPromise(computeTimeToLand(["session:`s2`"]).pipe(Effect.provide(db(produced, prs))));
+        expect(out.get("session:`s2`")).toBe(null);
     });
 
     test("no merged PR matching a produced sha → null", async () => {
-        const produced = [{ session: "session:`s9`", ended_at: "2026-01-01T00:00:00Z", sha: "x" }];
+        const produced = [{ session: "session:`s9`", commit_ts: "2026-01-01T00:00:00Z", sha: "x" }];
         const out = await Effect.runPromise(computeTimeToLand(["session:`s9`"]).pipe(Effect.provide(db(produced, []))));
         expect(out.get("session:`s9`")).toBe(null);
     });

--- a/apps/axctl/src/metrics/time-to-land.ts
+++ b/apps/axctl/src/metrics/time-to-land.ts
@@ -4,9 +4,15 @@ import type { DbError } from "@ax/lib/errors";
 import { isoMs, sessionRefList } from "./util.ts";
 
 /**
- * Latency from a session's end to when its work landed: the earliest
- * `merged_at` over PRs whose `merge_sha` matches a commit the session
- * `produced`, minus `session.ended_at`, in ms. null when nothing merged.
+ * How long the session's work took to LAND: the minimum, across the session's
+ * produced commits that match a merged PR's `merge_sha`, of
+ * `pull_request.merged_at - commit.ts` (ms). null when nothing merged.
+ *
+ * Anchored on the COMMIT timestamp, not `session.ended_at`: long-running
+ * sessions routinely merge PRs while still open, which made the ended_at
+ * anchor negative in ~94% of real rows (blind-dogfood finding). commit→merge
+ * is monotonic (a commit precedes its merge), so the metric is now a real
+ * latency; residual negatives (clock skew across machines) are dropped.
  *
  * Two flat queries joined in JS rather than a correlated subquery - SurrealDB
  * rejects the `FROM pull_request AS pr` table alias used by the inline form, and
@@ -22,9 +28,9 @@ export const computeTimeToLand = (
         for (const id of sessionIds) map.set(id, null);
 
         const refs = sessionRefList(sessionIds);
-        // Produced commits (sha) + the producing session's end time.
+        // Produced commits: sha + the commit's own timestamp.
         const produced = (yield* db.query<[Array<Record<string, unknown>>]>(
-            `SELECT type::string(in) AS session, type::string(in.ended_at) AS ended_at, out.sha AS sha`
+            `SELECT type::string(in) AS session, type::string(out.ts) AS commit_ts, out.sha AS sha`
             + ` FROM produced WHERE in IN [${refs}];`,
         ))?.[0] ?? [];
         // Merged PRs → sha→merged_at lookup (one read over all merged PRs).
@@ -43,13 +49,14 @@ export const computeTimeToLand = (
         for (const r of produced) {
             const session = String(r.session);
             const sha = typeof r.sha === "string" ? r.sha : null;
-            const endedMs = isoMs(r.ended_at);
-            if (sha === null || endedMs === null) continue;
+            const commitMs = isoMs(r.commit_ts);
+            if (sha === null || commitMs === null) continue;
             const mergedAt = mergedAtBySha.get(sha);
             if (mergedAt === undefined) continue;
             const mergedMs = isoMs(mergedAt);
             if (mergedMs === null) continue;
-            const ms = mergedMs - endedMs;
+            const ms = mergedMs - commitMs;
+            if (ms < 0) continue; // clock skew guard - a commit precedes its merge
             const cur = best.get(session);
             if (cur === undefined || ms < cur) best.set(session, ms);
         }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,7 +10,7 @@ Decision record: `docs/adr/0011-session-metrics-thin-slice-over-signal-framework
 |---|---|---|
 | durability_ratio | `durability_ratio` (`option<float>`) | share of the session's produced commits NOT later reverted; **NONE** when the session produced no commits (distinct from 0) |
 | produced / reverted | `produced_commits`, `reverted_commits` | commit counts behind durability |
-| time_to_land_ms | `time_to_land_ms` (`option<int>`) | ms from `session.ended_at` to the earliest merged PR whose `merge_sha` matches a produced commit; NONE when nothing landed |
+| time_to_land_ms | `time_to_land_ms` (`option<int>`) | fastest commit→merge latency: min over produced commits of `pull_request.merged_at − commit.ts` where `merge_sha` matches; NONE when nothing landed. (Anchored on commit ts, not `ended_at` - long sessions merge PRs while still open, which made the old anchor negative.) |
 | lines_added / lines_removed | `lines_added`, `lines_removed` | whole-line counts over the session's Edit/Write tool calls (reuses `ax loc`'s `editDelta`) |
 
 Surfaced by `ax sessions metrics [--here|--project P|--since N|--limit N|--json]`


### PR DESCRIPTION
Two bugs surfaced by a blind agent dogfood of the new metrics surfaces:

1. **`time_to_land_ms` was negative in 48/51 real rows** — long sessions merge PRs while still open, so `merged_at − session.ended_at` went negative, and the table formatter's 1-minute floor masked it. Now anchored on the produced **commit's ts** (commit→merge is monotonic); residual clock-skew negatives dropped. Live values after re-derive: 0…12.8h across 85 landed sessions, none negative.
2. **Stale help text** — `sessions metrics` description still said "sorted by lowest durability" after ordering changed to produced-commits-desc, fragile-first.

82 tests pass · typecheck clean · live re-derive verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)