### PR TITLE
chore(license): make LICENSE pure AGPL-3.0 so GitHub detects it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,38 +1,3 @@
-ax is dual-licensed.
-
-================================================================================
- OPTION 1 — GNU Affero General Public License v3.0 (AGPL-3.0) — default, free
-================================================================================
-
-ax is free and open source under the AGPL-3.0 (full text below).
-
-In plain terms: you may use, study, modify, and redistribute ax for free.
-But the AGPL is a strong network copyleft license. If you run a modified
-version of ax to provide a service over a network, or distribute it as part
-of your own product, you must release the COMPLETE corresponding source code
-of your work — including your modifications and the surrounding application —
-to your users under the AGPL-3.0.
-
-================================================================================
- OPTION 2 — Commercial License — for closed / proprietary use
-================================================================================
-
-If you want to use, embed, host, or resell ax as part of a closed-source or
-proprietary product or service WITHOUT the AGPL's source-disclosure
-obligations, you need a separate commercial license.
-
-Commercial licenses are available from the copyright holder. See
-LICENSE-COMMERCIAL.md or contact:
-
-    Necmettin Karakaya <necmettin.karakaya@gmail.com>
-
-Copyright (c) 2025 Necmettin Karakaya. All rights reserved.
-
-The full text of the AGPL-3.0 follows.
-
-================================================================================
-
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/README.md
+++ b/README.md
@@ -390,5 +390,6 @@ Questions, feedback, or want to shape where ax goes next? Join the Discord:
 
 ## License
 
-[AGPL-3.0-only](LICENSE) © 2025 Necmettin Karakaya. A commercial license is
-available for use that the AGPL doesn't permit - reach out via the Discord above.
+[AGPL-3.0-only](LICENSE) © 2025 Necmettin Karakaya. A
+[commercial license](docs/COMMERCIAL-LICENSE.md) is available for use that the
+AGPL doesn't permit - reach out via the Discord above.

--- a/docs/COMMERCIAL-LICENSE.md
+++ b/docs/COMMERCIAL-LICENSE.md
@@ -2,7 +2,7 @@
 
 ax is dual-licensed:
 
-1. **AGPL-3.0** (see [`LICENSE`](./LICENSE)) - free and open source. If you build
+1. **AGPL-3.0** (see [`LICENSE`](../LICENSE)) - free and open source. If you build
    on ax and run it as a network service or ship it inside your product, the
    AGPL requires you to release the complete corresponding source of your work
    under the AGPL too.


### PR DESCRIPTION
GitHub showed **Unknown, Unknown** for licenses because `LICENSE` carried a custom dual-licensing preamble before the AGPL text — `licensee` needs a near-exact match.

- Strip the preamble; `LICENSE` is now the canonical AGPL-3.0 text → GitHub badge becomes **AGPL-3.0**
- Move `LICENSE-COMMERCIAL.md` → `docs/COMMERCIAL-LICENSE.md` so licensee stops flagging a second "Unknown" root license file
- README license section now links the commercial doc (the dual-license story lives there + README, unchanged in substance)

`package.json` license fields already say `AGPL-3.0-only` everywhere — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)