### PR TITLE
fix(ingest): unwedge ingest (quadratic clear DELETE) + OTLP profiling instrumentation

### DIFF
--- a/apps/axctl/src/ingest/provider-events.test.ts
+++ b/apps/axctl/src/ingest/provider-events.test.ts
@@ -86,15 +86,17 @@ describe("provider event writer statement builders", () => {
         // the existing rows hold the same (agent_session, seq) under a different
         // record id (seq drift across ingests).
         //
-        // They MUST delete by primary id via an `id IN (SELECT VALUE id ...)`
-        // subquery, NOT a bare `WHERE agent_session = ...`. The latter is planned
+        // They MUST delete the subquery RESULT by primary id
+        // (`DELETE (SELECT VALUE id ...)`), NOT a bare `WHERE agent_session =
+        // ...` and NOT `WHERE id IN (SELECT ...)`. The bare WHERE is planned
         // through the `agent_event_session_seq` secondary index, which can hold
         // stale/ghost entries in a long-lived DB - an index-driven DELETE then
         // silently skips drifted rows while their entries still block the fresh
-        // INSERT, crashing the next ingest. Deleting by primary id sidesteps the
-        // corruptible index entirely.
-        const clearEventStmt = `DELETE agent_event WHERE id IN (SELECT VALUE id FROM agent_event WHERE agent_session = agent_session:\`${sessionKey}\`);`;
-        const clearEdgeStmt = `DELETE agent_event_child WHERE id IN (SELECT VALUE id FROM agent_event_child WHERE agent_session = agent_session:\`${sessionKey}\`);`;
+        // INSERT, crashing the next ingest. The id-IN-subquery form re-evaluates
+        // the inner full-table scan per candidate row - quadratic in table size,
+        // it wedged every ingest once agent_event_child grew to ~460k rows.
+        const clearEventStmt = `DELETE (SELECT VALUE id FROM agent_event WHERE agent_session = agent_session:\`${sessionKey}\`);`;
+        const clearEdgeStmt = `DELETE (SELECT VALUE id FROM agent_event_child WHERE agent_session = agent_session:\`${sessionKey}\`);`;
 
         const clearEventIdx = statements.indexOf(clearEventStmt);
         const clearEdgeIdx = statements.indexOf(clearEdgeStmt);
@@ -109,6 +111,10 @@ describe("provider event writer statement builders", () => {
         // Guard against regressing to the index-driven bare-WHERE delete.
         expect(
             statements.some((s) => /^DELETE agent_event WHERE agent_session =/.test(s)),
+        ).toBe(false);
+        // Guard against regressing to the quadratic id-IN-subquery delete.
+        expect(
+            statements.some((s) => s.includes("WHERE id IN (SELECT")),
         ).toBe(false);
     });
 

--- a/apps/axctl/src/ingest/provider-events.ts
+++ b/apps/axctl/src/ingest/provider-events.ts
@@ -170,9 +170,17 @@ export function buildAgentProviderStatements(
  *   fresh `(agent_session, seq)` INSERT, so the next ingest crashes with
  *   "Database index agent_event_session_seq already contains [...]". An inner
  *   `SELECT VALUE id ... WHERE agent_session = ...` reliably enumerates every
- *   row (full-table predicate); the outer `DELETE ... WHERE id IN (...)` removes
- *   them by primary id, which never consults the corruptible secondary index.
+ *   row (full-table predicate); deleting that result set removes rows by
+ *   primary id, which never consults the corruptible secondary index.
  *   `ax doctor` surfaces residual duplicates so the index can be rebuilt.
+ *
+ *   The delete targets the subquery RESULT (`DELETE (SELECT VALUE id ...)`),
+ *   NOT `DELETE ... WHERE id IN (SELECT ...)`. The id-IN-subquery form is
+ *   planned as a per-row membership test - the inner full-table scan
+ *   re-evaluates for every candidate row, going quadratic in table size
+ *   (measured: never completes at ~460k rows, pegging surreal at >100% CPU;
+ *   the result-set form finishes in ~2-5s). That quadratic DELETE is what
+ *   wedged every ingest pass once agent_event_child grew large enough.
  */
 export function buildAgentSessionEventClearStatements(
     sessions: readonly AgentSessionWrite[],
@@ -185,11 +193,10 @@ export function buildAgentSessionEventClearStatements(
         seen.add(sessionKey);
         const sessionRef = recordRef("agent_session", sessionKey);
         // Child edges first so no edge transiently references a deleted event.
-        // Delete by primary id (via an `id IN (SELECT VALUE id ...)` subquery) so
-        // a corrupt/stale `agent_event_session_seq` index can't silently leave
-        // rows behind - see the doc comment above.
-        statements.push(`DELETE agent_event_child WHERE id IN (SELECT VALUE id FROM agent_event_child WHERE agent_session = ${sessionRef});`);
-        statements.push(`DELETE agent_event WHERE id IN (SELECT VALUE id FROM agent_event WHERE agent_session = ${sessionRef});`);
+        // Delete the subquery RESULT by primary id - never `WHERE id IN
+        // (SELECT ...)`, which goes quadratic - see the doc comment above.
+        statements.push(`DELETE (SELECT VALUE id FROM agent_event_child WHERE agent_session = ${sessionRef});`);
+        statements.push(`DELETE (SELECT VALUE id FROM agent_event WHERE agent_session = ${sessionRef});`);
     }
     return statements;
 }

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1186,7 +1186,9 @@ const upsertSessions = (sessions: Session[]) =>
                 }),
             { concurrency: 4, discard: true },
         );
-    });
+    }).pipe(Effect.withSpan("transcripts.upsertSessions", {
+        attributes: { "sessions.count": sessions.length },
+    }));
 
 /**
  * Snapshot the original transcript jsonl into the `transcripts` bucket and
@@ -1215,6 +1217,9 @@ const snapshotTranscript = (sessionId: string, filePath: string) =>
                         message: err.message,
                     }).pipe(Effect.as(null as string | null)),
                 ),
+                Effect.withSpan("transcripts.snapshot", {
+                    attributes: { "snapshot.bytes": content.length, "snapshot.session": sessionId },
+                }),
             );
         return result;
     });
@@ -1222,7 +1227,7 @@ const snapshotTranscript = (sessionId: string, filePath: string) =>
 const upsertTurns = (turns: Turn[]) =>
     Effect.gen(function* () {
         if (turns.length === 0) return;
-        yield* queryTranscriptStatements(buildTurnStatements(turns));
+        yield* queryTranscriptStatements(buildTurnStatements(turns), "upsertTurns");
     });
 
 const buildTurnStatements = (turns: readonly Turn[]): string[] =>
@@ -1265,8 +1270,8 @@ const buildHookCommandInvocationStatements = (invocations: readonly HookCommandI
         `UPSERT ${recordRef("hook_command_invocation", invocation.key)} CONTENT { hook_event: ${recordRef("harness_hook_event", invocation.hook_event_key)}, session: ${recordRef("session", invocation.session)}, ts: d"${invocation.ts}", harness: ${surrealLiteral(invocation.harness)}, event_name: ${surrealLiteral(invocation.event_name)}, hook_name: ${surrealLiteral(invocation.hook_name)}, tool_call_id: ${optionString(invocation.tool_call_id)}, tool_call: ${optionRecordRef("tool_call", invocation.tool_call_key)}, command: ${surrealLiteral(invocation.command)}, command_hash: ${surrealLiteral(invocation.command_hash)}, provider_status: ${surrealLiteral(invocation.provider_status)}, effect: ${surrealLiteral(invocation.effect)}, exit_code: ${optionInt(invocation.exit_code)}, duration_ms: ${optionInt(invocation.duration_ms)}, stdout_excerpt: ${optionString(invocation.stdout_excerpt)}, stderr_excerpt: ${optionString(invocation.stderr_excerpt)}, content_excerpt: ${optionString(invocation.content_excerpt)}, blocking_error_excerpt: ${optionString(invocation.blocking_error_excerpt)} };`,
     );
 
-const queryTranscriptStatements = (statements: readonly string[]) =>
-    executeStatements(statements, { chunkSize: 500 });
+const queryTranscriptStatements = (statements: readonly string[], label?: string) =>
+    executeStatements(statements, { chunkSize: 500, ...(label === undefined ? {} : { label }) });
 
 const relateInvocations = (invocations: Invocation[]) =>
     Effect.gen(function* () {
@@ -1308,7 +1313,7 @@ const relateInvocations = (invocations: Invocation[]) =>
                     (n) =>
                         `UPSERT skill:\`${skillRecordKey(n)}\` MERGE { name: ${surrealLiteral(n)}, scope: "unknown", dir_path: "(unknown)", content_hash: "unknown" };`,
                 );
-                yield* executeStatementsWith(db, placeholders, { chunkSize: 500 });
+                yield* executeStatementsWith(db, placeholders, { chunkSize: 500, label: "skillPlaceholders" });
             }
         }
 
@@ -1321,20 +1326,20 @@ const relateInvocations = (invocations: Invocation[]) =>
                 `RELATE turn:\`${turnKey}\`->invoked:\`${edgeKey}\`->skill:\`${skillKey}\` SET session = ${recordRef("session", inv.session)}, ts = d"${inv.ts}", args = ${surrealLiteral(args)}, turn_has_error = ${inv.turn_has_error}, turn_index = ${inv.seq};`,
             ];
         });
-        yield* executeStatementsWith(db, stmts, { chunkSize: 500 });
+        yield* executeStatementsWith(db, stmts, { chunkSize: 500, label: "invokedEdges" });
     });
 
 const writeToolFileEvidence = (toolCalls: readonly ToolCallWrite[]) =>
     queryTranscriptStatements(buildToolFileEvidenceStatements(
         extractToolFileEvidence(toolCalls),
-    ));
+    ), "toolFileEvidence");
 
 const relateToolCallSkills = (relations: ToolCallSkillRelationWrite[]) =>
     Effect.gen(function* () {
         if (relations.length === 0) return;
         yield* queryTranscriptStatements(relations.flatMap((relation) =>
             buildRelateToolCallSkillStatements(relation),
-        ));
+        ), "toolCallSkills");
     });
 
 const writePlanSnapshots = (snapshots: PlanSnapshotWrite[]) =>
@@ -1342,14 +1347,14 @@ const writePlanSnapshots = (snapshots: PlanSnapshotWrite[]) =>
         if (snapshots.length === 0) return;
         yield* queryTranscriptStatements(snapshots.flatMap((snapshot) =>
             buildPlanSnapshotStatements(snapshot),
-        ));
+        ), "planSnapshots");
     });
 
 const writeToolCallStatements = (toolCalls: readonly ToolCallWrite[]) =>
-    queryTranscriptStatements(buildToolCallStatements(toolCalls));
+    queryTranscriptStatements(buildToolCallStatements(toolCalls), "toolCalls");
 
 const writeCompactions = (compactions: readonly CompactionWrite[]) =>
-    queryTranscriptStatements(buildCompactionStatements(compactions));
+    queryTranscriptStatements(buildCompactionStatements(compactions), "compactions");
 
 const writeHookEvidence = (
     events: readonly HarnessHookEventWrite[],
@@ -1358,7 +1363,7 @@ const writeHookEvidence = (
     queryTranscriptStatements([
         ...buildHarnessHookEventStatements(events),
         ...buildHookCommandInvocationStatements(invocations),
-    ]);
+    ], "hookEvidence");
 
 const buildClaudeProviderStatements = (extracted: FileExtract): string[] => [
     ...buildAgentProviderStatements([
@@ -1405,7 +1410,7 @@ const buildClaudeProviderStatements = (extracted: FileExtract): string[] => [
 ];
 
 const writeProviderEvidence = (extracted: FileExtract) =>
-    queryTranscriptStatements(buildClaudeProviderStatements(extracted));
+    queryTranscriptStatements(buildClaudeProviderStatements(extracted), "providerEvidence");
 
 const surrealOptionFloat = (value: number | null | undefined): string =>
     value === null || value === undefined || !Number.isFinite(value)
@@ -1706,6 +1711,9 @@ export const ingestTranscripts = (
             // advances the watermark. Non-NotFound failures re-raise.
             const extracted = yield* extractFile(candidate.filePath, candidate.projectDir).pipe(
                 skipNotFound(null),
+                Effect.withSpan("transcripts.parse", {
+                    attributes: { "file.size": candidate.size },
+                }),
             );
             if (!extracted) {
                 activeFiles -= 1;
@@ -1788,7 +1796,9 @@ export const ingestTranscripts = (
             // succeeded, so a mid-file failure re-processes next run.
             yield* wm.commit(candidate.filePath, candidate.mtimeMs, candidate.size);
             activeFiles -= 1;
-        }), { concurrency, discard: true });
+        }).pipe(Effect.withSpan("transcripts.file", {
+            attributes: { "file.path": candidate.filePath, "file.size": candidate.size },
+        })), { concurrency, discard: true });
         yield* Effect.logDebug("transcript ingest complete", {
             files,
             records: recordCount(),

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -1,0 +1,63 @@
+# Profiling ingest with OTLP traces
+
+ax exports every Effect span (and log/metric) over OTLP/HTTP when
+`AX_OTLP_URL` is set. Unset, the exporter layer is `Layer.empty` - zero
+overhead, no behavior change. The seam is
+`packages/lib/src/otel.ts` (`otlpTelemetryFromEnv`), wired beneath
+`LiveTraceLayer` in `packages/lib/src/layers.ts` so the existing LiveTrace
+progress spans and the OTLP exporter both see the same span tree.
+
+## Quick start (Maple local)
+
+```bash
+brew install Makisuo/tap/maple
+scripts/trace-ingest.sh --since=1 --stages=claude   # starts maple if needed
+maple traces --format table                          # or the UI at local.maple.dev
+```
+
+Any axctl invocation works, not just ingest:
+
+```bash
+AX_OTLP_URL=http://127.0.0.1:4318 bun apps/axctl/src/cli/index.ts sessions metrics --here
+```
+
+Maple listens for OTLP/HTTP on `127.0.0.1:4318`; ax appends `/v1/traces`
+etc. itself. Any OTLP collector works (Jaeger, otel-desktop-viewer, ...) -
+point `AX_OTLP_URL` at it.
+
+## What is instrumented
+
+Span hierarchy for an ingest run (names you can filter on):
+
+- `<stage key>` - one span per pipeline stage (`LiveTrace.step` in
+  `apps/axctl/src/ingest/stage/runner.ts`), tagged `ingest.stage.tags`.
+  - `transcripts.file` - one span per Claude transcript candidate
+    (attrs: `file.path`, `file.size`). Watermark-skipped files show as
+    sub-millisecond spans.
+    - `transcripts.parse` - JSONL parse/extract (attr: `file.size`)
+    - `transcripts.snapshot` - raw-transcript blob upload
+      (attr: `snapshot.bytes`)
+    - `transcripts.upsertSessions` - session row upsert
+    - `db.exec:<label>` - one span per write-helper batch
+      (`upsertTurns`, `providerEvidence`, `toolCalls`, `hookEvidence`,
+      `invokedEdges`, ...), attrs: `db.exec.statements`, `db.exec.chunks`.
+      - `db.chunk` - one span per `db.query()` roundtrip
+        (attrs: `db.chunk.index`, `db.chunk.statements`)
+
+Every write that routes through the shared
+`packages/lib/src/shared/statement-exec.ts` seam gets `db.exec`/`db.chunk`
+spans automatically; pass `{ label }` in `ExecuteOptions` to attribute a
+call site.
+
+## Sampling methodology
+
+Profile against a quiet DB or the numbers lie:
+
+1. `launchctl bootout gui/$UID/com.necmttn.ax-watch` - stop watcher re-fires
+2. wait for `surreal` CPU to settle (`ps aux | rg surreal`)
+3. run progressively bigger samples: one stage (`--stages=claude`) →
+   source stages (`--stages=claude,codex,git,opencode`) → full default set
+4. `AX_REDERIVE_CLAUDE=1` forces re-parse of watermark-skipped transcripts
+   when you need a repeatable workload
+5. restore:
+   `launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.necmttn.ax-watch.plist`

--- a/packages/lib/src/db.ts
+++ b/packages/lib/src/db.ts
@@ -177,20 +177,23 @@ const release = (db: Surreal): Effect.Effect<void> =>
 
 // Debug seam (AX_DB_QUERY_LOG=<path>): append a line before and after every
 // db.query() so a wedged statement is identifiable post-mortem - the last
-// "start" without a matching "done" is the in-flight SQL. Sync appends keep
-// ordering exact; the env gate keeps production paths allocation-free.
+// "start" without a matching "done" is the in-flight SQL. A single buffered
+// Bun FileSink (flushed per line) keeps ordering exact without node:fs; the
+// env gate keeps production paths allocation-free.
 const queryLogPath = process.env["AX_DB_QUERY_LOG"];
 let queryLogSeq = 0;
+let queryLogSink: ReturnType<ReturnType<typeof Bun.file>["writer"]> | null = null;
 const logQuery = (phase: "start" | "done", seq: number, ms: number, sql?: string): void => {
     if (!queryLogPath) return;
     try {
-        require("node:fs").appendFileSync(
-            queryLogPath,
+        queryLogSink ??= Bun.file(queryLogPath).writer();
+        queryLogSink.write(
             `${new Date().toISOString()} q${seq} ${phase}${phase === "done" ? ` +${ms.toFixed(0)}ms` : ""}${sql === undefined ? "" : ` ${sql.slice(0, 300).replaceAll("\n", " ")}`}\n`,
         );
+        void queryLogSink.flush();
         // Full-statement capture for replay: one file per query start.
         if (phase === "start" && sql !== undefined && process.env["AX_DB_QUERY_LOG_FULL"] === "1") {
-            require("node:fs").writeFileSync(`${queryLogPath}.q${seq}.sql`, sql);
+            void Bun.write(`${queryLogPath}.q${seq}.sql`, sql);
         }
     } catch {
         // diagnostics only - never fail the query path

--- a/packages/lib/src/db.ts
+++ b/packages/lib/src/db.ts
@@ -188,6 +188,10 @@ const logQuery = (phase: "start" | "done", seq: number, ms: number, sql?: string
             queryLogPath,
             `${new Date().toISOString()} q${seq} ${phase}${phase === "done" ? ` +${ms.toFixed(0)}ms` : ""}${sql === undefined ? "" : ` ${sql.slice(0, 300).replaceAll("\n", " ")}`}\n`,
         );
+        // Full-statement capture for replay: one file per query start.
+        if (phase === "start" && sql !== undefined && process.env["AX_DB_QUERY_LOG_FULL"] === "1") {
+            require("node:fs").writeFileSync(`${queryLogPath}.q${seq}.sql`, sql);
+        }
     } catch {
         // diagnostics only - never fail the query path
     }

--- a/packages/lib/src/db.ts
+++ b/packages/lib/src/db.ts
@@ -175,13 +175,39 @@ const release = (db: Surreal): Effect.Effect<void> =>
         }
     });
 
+// Debug seam (AX_DB_QUERY_LOG=<path>): append a line before and after every
+// db.query() so a wedged statement is identifiable post-mortem - the last
+// "start" without a matching "done" is the in-flight SQL. Sync appends keep
+// ordering exact; the env gate keeps production paths allocation-free.
+const queryLogPath = process.env["AX_DB_QUERY_LOG"];
+let queryLogSeq = 0;
+const logQuery = (phase: "start" | "done", seq: number, ms: number, sql?: string): void => {
+    if (!queryLogPath) return;
+    try {
+        require("node:fs").appendFileSync(
+            queryLogPath,
+            `${new Date().toISOString()} q${seq} ${phase}${phase === "done" ? ` +${ms.toFixed(0)}ms` : ""}${sql === undefined ? "" : ` ${sql.slice(0, 300).replaceAll("\n", " ")}`}\n`,
+        );
+    } catch {
+        // diagnostics only - never fail the query path
+    }
+};
+
 const wrap = (db: Surreal): SurrealClientShape => ({
     query: <T extends unknown[] = unknown[]>(
         sql: string,
         bindings?: Record<string, unknown>,
     ) =>
         Effect.tryPromise({
-            try: () => db.query<T>(sql, bindings) as Promise<T>,
+            try: async () => {
+                if (!queryLogPath) return await (db.query<T>(sql, bindings) as Promise<T>);
+                const seq = ++queryLogSeq;
+                const t0 = performance.now();
+                logQuery("start", seq, 0, sql);
+                const out = await (db.query<T>(sql, bindings) as Promise<T>);
+                logQuery("done", seq, performance.now() - t0);
+                return out;
+            },
             catch: (err) =>
                 new DbError({
                     operation: "query",

--- a/packages/lib/src/layers.ts
+++ b/packages/lib/src/layers.ts
@@ -6,6 +6,7 @@ import { ProcessServiceLive } from "./process.ts";
 import { LiveTraceLayer } from "./live-traces/Tracer.ts";
 import { TraceSinkLive, TraceTransportTag } from "./live-traces/Sink.ts";
 import { NoopTransportLayer } from "./live-traces/transports/console.ts";
+import { otlpTelemetryFromEnv } from "./otel.ts";
 
 /**
  * Library-level composed application layer.
@@ -47,6 +48,9 @@ const AppLayerSansTransport = SurrealClientLive.pipe(
     Layer.merge(ProcessServiceLive),
     Layer.provideMerge(LiveTraceLayer),
     Layer.provideMerge(TraceSinkLive({ flushIntervalMs: 200 })),
+    // OTLP export (AX_OTLP_URL): provided BENEATH LiveTraceLayer so its build
+    // sees the OTLP tracer as the base it decorates - both sinks get every span.
+    Layer.provideMerge(otlpTelemetryFromEnv()),
 );
 
 /** Default app layer: trace events are dropped (NoopTransport), keeping stdout

--- a/packages/lib/src/otel.ts
+++ b/packages/lib/src/otel.ts
@@ -1,0 +1,54 @@
+/**
+ * otel.ts - env-gated OTLP/HTTP telemetry export for axctl.
+ *
+ * Set `AX_OTLP_URL` (e.g. `http://127.0.0.1:4318`, the default endpoint of a
+ * local Maple `maple start` - https://maple.dev/local/) and every Effect span,
+ * log, and metric flows to that collector. Unset, this layer is `Layer.empty`
+ * and the binary behaves exactly as before - zero overhead, no network.
+ *
+ * Wired beneath `LiveTraceLayer` in `layers.ts`: LiveTrace DECORATES whatever
+ * base tracer is in context at its build time, so providing the OTLP tracer
+ * below it means both systems see every span (LiveTrace for the progress
+ * UI/dashboard, OTLP for flame-graph inspection in Maple).
+ */
+import { Layer } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { Otlp } from "effect/unstable/observability";
+
+/** Env var holding the OTLP/HTTP base URL. `/v1/traces` etc. are appended by Otlp. */
+export const AX_OTLP_URL_ENV = "AX_OTLP_URL";
+
+export interface OtlpTelemetryOptions {
+    readonly baseUrl: string;
+    /** Resource service.name shown in the collector UI. Default "axctl". */
+    readonly serviceName?: string;
+}
+
+/**
+ * Unconditional OTLP layer: logs + metrics + traces over OTLP/HTTP (JSON),
+ * self-contained (brings its own fetch-backed HttpClient).
+ *
+ * Short export interval + shutdown flush matter here: axctl is a CLI, so most
+ * runs exit within seconds of the last span - a server-tuned batching window
+ * would drop the tail of the trace.
+ */
+export const otlpTelemetryLayer = (opts: OtlpTelemetryOptions): Layer.Layer<never> =>
+    Otlp.layerJson({
+        baseUrl: opts.baseUrl,
+        resource: { serviceName: opts.serviceName ?? "axctl" },
+        tracerExportInterval: "500 millis",
+        loggerExportInterval: "1 second",
+        metricsExportInterval: "2 seconds",
+        shutdownTimeout: "3 seconds",
+    }).pipe(Layer.provide(FetchHttpClient.layer));
+
+/**
+ * Env-gated variant: real exporter when `AX_OTLP_URL` is set, `Layer.empty`
+ * otherwise. Read once at layer build (config snapshot, not reactive).
+ */
+export const otlpTelemetryFromEnv = (serviceName?: string): Layer.Layer<never> => {
+    const baseUrl = process.env[AX_OTLP_URL_ENV];
+    return baseUrl && baseUrl.length > 0
+        ? otlpTelemetryLayer(serviceName === undefined ? { baseUrl } : { baseUrl, serviceName })
+        : Layer.empty;
+};

--- a/packages/lib/src/shared/statement-exec.ts
+++ b/packages/lib/src/shared/statement-exec.ts
@@ -21,6 +21,9 @@ export const DEFAULT_CHUNK_SIZE = 250;
 export interface ExecuteOptions {
     /** Statements per `db.query()` call. Defaults to {@link DEFAULT_CHUNK_SIZE}. */
     readonly chunkSize?: number;
+    /** Span label identifying the caller (e.g. "upsertTurns") so DB time is
+     *  attributable per write-helper in a trace viewer. Default "statements". */
+    readonly label?: string;
 }
 
 /** Execute pre-built statements against an already-resolved client. Use when
@@ -30,12 +33,28 @@ export const executeStatementsWith = (
     db: SurrealClientShape,
     statements: readonly string[],
     options?: ExecuteOptions,
-): Effect.Effect<void, DbError> =>
-    Effect.forEach(
-        Arr.chunksOf(statements, options?.chunkSize ?? DEFAULT_CHUNK_SIZE),
-        (chunk) => db.query(chunk.join("")),
+): Effect.Effect<void, DbError> => {
+    if (statements.length === 0) return Effect.void;
+    const chunks = Arr.chunksOf(statements, options?.chunkSize ?? DEFAULT_CHUNK_SIZE);
+    return Effect.forEach(
+        chunks,
+        (chunk, i) =>
+            db.query(chunk.join("")).pipe(
+                Effect.asVoid,
+                Effect.withSpan("db.chunk", {
+                    attributes: { "db.chunk.index": i, "db.chunk.statements": chunk.length },
+                }),
+            ),
         { discard: true },
+    ).pipe(
+        Effect.withSpan(`db.exec:${options?.label ?? "statements"}`, {
+            attributes: {
+                "db.exec.statements": statements.length,
+                "db.exec.chunks": chunks.length,
+            },
+        }),
     );
+};
 
 /** Execute pre-built statements, resolving `SurrealClient` from context. */
 export const executeStatements = (

--- a/scripts/trace-ingest.sh
+++ b/scripts/trace-ingest.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# trace-ingest.sh - run an instrumented ingest with spans exported to a local
+# Maple collector (https://maple.dev/local/), for flame-graph profiling.
+#
+#   scripts/trace-ingest.sh [--stages=claude] [--since=1] [...any ax ingest args]
+#
+# Requires: `brew install Makisuo/tap/maple`. Starts maple detached if the
+# OTLP port is not already listening. Inspect with `maple traces` or the UI
+# the startup banner prints (local.maple.dev).
+#
+# Tip: pause the watcher first so samples are not contended:
+#   launchctl bootout gui/$UID/com.necmttn.ax-watch
+#   ... profile ...
+#   launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.necmttn.ax-watch.plist
+set -euo pipefail
+
+OTLP_URL="${AX_OTLP_URL:-http://127.0.0.1:4318}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v maple >/dev/null 2>&1; then
+    echo "maple not installed: brew install Makisuo/tap/maple" >&2
+    exit 1
+fi
+
+if ! curl -sf -o /dev/null --max-time 1 "${OTLP_URL}/v1/traces" -X POST -H 'content-type: application/json' -d '{}'; then
+    echo "starting maple (detached, logs ~/.maple/maple.log)..." >&2
+    maple start -d
+    sleep 1
+fi
+
+echo "exporting to ${OTLP_URL} (service: axctl)" >&2
+exec env AX_OTLP_URL="${OTLP_URL}" AX_PROGRESS="${AX_PROGRESS:-off}" \
+    bun "${REPO_ROOT}/apps/axctl/src/cli/index.ts" ingest "$@"


### PR DESCRIPTION
## The wedge

Since `agent_event_child` crossed ~460k rows, **every ingest pass wedged forever**: `claude/transcripts`, `codex/sessions`, `git/history`, `opencode/sessions` never completed; the watcher re-fired endlessly; SurrealDB sat pegged >100% CPU for hours; timed-out/killed runs left orphaned server-side queries holding locks, so subsequent runs blocked at 0% CPU.

Root cause: the per-session clear from #141

```sql
DELETE agent_event_child WHERE id IN (SELECT VALUE id FROM agent_event_child WHERE agent_session = ...);
```

is planned as a **per-row membership test** — the inner full-table scan re-evaluates for every candidate row (461k rows × ~450ms = never). Measured: never completes at current table size.

## The fix

```sql
DELETE (SELECT VALUE id FROM agent_event_child WHERE agent_session = ...);
```

Same #141 semantics (enumerate via full predicate, delete by primary id, never trust the corruptible `agent_event_session_seq` index), finishes in ~2–5s. Regression guard added to the test.

**Before/after:** `ingest --since=2` (all stages): 4× consecutive 900s timeouts, never converged → **1m46s, exit 0**. `--stages=claude`: never completes → **54s**.

## Instrumentation (how it was found, kept in-repo)

- `AX_OTLP_URL=http://127.0.0.1:4318` exports every Effect span/log/metric over OTLP/HTTP (`packages/lib/src/otel.ts`, wired beneath `LiveTraceLayer`; `Layer.empty` when unset — zero overhead). Works with Maple local (`maple start`) or any OTLP collector.
- Fine-grained ingest spans: per-transcript-file, parse, snapshot, per-write-helper (`db.exec:<label>`), per-chunk `db.query` roundtrips (`statement-exec.ts` `ExecuteOptions.label`).
- `AX_DB_QUERY_LOG=<path>` (+`AX_DB_QUERY_LOG_FULL=1`) logs start/done per `db.query` — the wedged statement is the last start without a done; full capture enabled offline replay + statement bisection.
- `scripts/trace-ingest.sh` + `docs/instrumentation.md` document the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)