### PR TITLE
fix(studio): accept schema_version 4 share manifests

### DIFF
--- a/apps/studio/src/routes/share-inspect.test.ts
+++ b/apps/studio/src/routes/share-inspect.test.ts
@@ -100,6 +100,18 @@ describe("isShareManifest", () => {
         })).toBe(true);
         expect(isShareManifest({ schema_version: 3, session: { id: "s1" }, turns: [] })).toBe(false);
     });
+
+    test("accepts a v4 manifest (current CLI export version)", () => {
+        expect(isShareManifest({
+            schema_version: 4,
+            kind: "manifest",
+            session: { id: "s1", source: "claude" },
+            totals: { cost_usd: null, duration_ms: null, tool_calls: 0, turns: 0, subagents: 0, failures: 0 },
+            root_file: "session.json",
+            subagents: [],
+        })).toBe(true);
+        expect(isShareManifest({ schema_version: 5, kind: "manifest", session: { id: "s1" }, totals: {}, root_file: "session.json", subagents: [] })).toBe(false);
+    });
 });
 
 describe("fetchShareManifest", () => {

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -139,7 +139,7 @@ export interface ShareSubagentCard {
 }
 
 export interface ShareManifest {
-    readonly schema_version: 3;
+    readonly schema_version: 3 | 4;
     readonly kind: "manifest";
     readonly exported_at: string;
     readonly ax_version?: string;
@@ -162,7 +162,7 @@ export function isShareManifest(value: unknown): value is ShareManifest {
     return (
         isRecord(value) &&
         value.kind === "manifest" &&
-        value.schema_version === 3 &&
+        (value.schema_version === 3 || value.schema_version === 4) &&
         isRecord(value.session) &&
         typeof value.session.id === "string" &&
         isRecord(value.totals) &&


### PR DESCRIPTION
Fresh `ax share` bundles emit manifest `schema_version: 4`, but the studio share viewer's `isShareManifest` guard hard-pinned `=== 3`. Every new share therefore fell back to the legacy single-file `ax-session.json` path and died with **"Could not fetch ax-session.json"**.

- Accept `schema_version: 3 | 4` in `ShareManifest` + guard
- Test: v4 manifest accepted, v5 rejected

Verified against live gist `Necmttn/a6d4c2215bbe0998c93b38ad11db2ccb` (34-subagent bundle, manifest v4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)