### PR TITLE
fix(studio): share-view polish — overflow, scroll reset, embedded timeline

### DIFF
--- a/apps/axctl/src/share/artifact.ts
+++ b/apps/axctl/src/share/artifact.ts
@@ -1,4 +1,5 @@
 import type { HookFireDto, InspectTurnContentDto, SessionTokenUsageDetail, ToolCallDto, TurnTokenUsageDetail } from "@ax/lib/shared/dashboard-types";
+import type { SessionTimeline } from "../timeline/types.ts";
 
 export const AX_SESSION_SHARE_SCHEMA_VERSION = 4 as const;
 
@@ -49,6 +50,10 @@ export interface AxSessionShare {
     readonly harness_hooks?: ReadonlyArray<ShareHarnessHook>;
     readonly turns: ReadonlyArray<ShareTurn>;
     readonly timeline: ReadonlyArray<ShareEvent>;
+    /** v4 additive: segmented highlight timeline (L2 phases + L1 key events),
+     *  precomputed at export so the static viewer renders it daemon-free.
+     *  Optional - older bundles simply lack it. */
+    readonly session_timeline?: SessionTimeline | null;
     readonly files: ReadonlyArray<ShareFile>;
     readonly graph: ShareGraph;
     readonly derived: {

--- a/apps/axctl/src/share/exporter.ts
+++ b/apps/axctl/src/share/exporter.ts
@@ -19,6 +19,8 @@ import type {
 import { categoryOf } from "@ax/lib/shared/tool-presentation";
 import { runQuery, runSingleQuery } from "@ax/lib/shared/graph-query";
 import { resolveTurnContent } from "../queries/session-turn-content.ts";
+import { extractSessionTimeline, SessionTimelineServiceLayer } from "../timeline/service.ts";
+import type { SessionTimeline } from "../timeline/types.ts";
 import {
     sessionChildrenQuery,
     sessionOverviewQuery,
@@ -44,6 +46,9 @@ export interface ShareArtifactParts {
     readonly tokenUsage?: SessionTokenUsageDetail | null;
     readonly turns: ReadonlyArray<ShareTurn>;
     readonly timeline: ReadonlyArray<ShareEvent>;
+    /** Segmented highlight timeline (L2 phases + L1 key events), computed at
+     *  export time so the static share viewer can render it without a daemon. */
+    readonly sessionTimeline?: SessionTimeline | null;
     readonly files: ReadonlyArray<ShareFile>;
     readonly children?: ReadonlyArray<AxSessionShare>;
     readonly spawnAnchorTurnSeq?: number | null;
@@ -195,6 +200,7 @@ export function buildShareArtifactFromParts(
             failures,
         },
         token_usage: parts.tokenUsage ?? null,
+        ...(parts.sessionTimeline ? { session_timeline: parts.sessionTimeline } : {}),
         ...(parts.hookFires && parts.hookFires.length > 0 ? { hook_fires: parts.hookFires } : {}),
         ...(parts.harnessHooks && parts.harnessHooks.length > 0 ? { harness_hooks: parts.harnessHooks } : {}),
         turns: parts.turns,
@@ -413,6 +419,14 @@ export const exportSessionShare = (
             turn.text.length > 0 || turn.content != null || (turn.tool_calls?.length ?? 0) > 0
         );
 
+        // Segmented highlight timeline, computed here (where the DB still is)
+        // so the static share viewer can render it daemon-free. Best-effort: a
+        // timeline failure never blocks the export.
+        const sessionTimeline = yield* extractSessionTimeline(recordRef).pipe(
+            Effect.provide(SessionTimelineServiceLayer),
+            Effect.catchDefect(() => Effect.succeed(null)),
+        );
+
         return buildShareArtifactFromParts({
             axVersion,
             exportedAt: new Date().toISOString(),
@@ -422,6 +436,7 @@ export const exportSessionShare = (
             tokenUsage,
             turns,
             timeline: timelineRaw.filter(isPresent),
+            sessionTimeline,
             files: filesRaw.filter(isPresent),
             children,
             hookFires,

--- a/apps/studio/src/routes/session-inspect.tsx
+++ b/apps/studio/src/routes/session-inspect.tsx
@@ -1380,7 +1380,7 @@ function TurnImpl({
             <div id={`turn-${turn.seq}`} title={turnTokenUsageTitle(turn)} style={gridStyle}>
                 {seqGutter}
                 <TurnHeader turn={turn} style={s} extras={headerExtras} hideRoleLabel />
-                <div style={{ gridColumn: "2" }}>
+                <div style={{ gridColumn: "2", minWidth: 0 }}>
                     <ToolRow calls={turn.tool_calls!} resultFor={resultFor} skillContentFor={skillContentFor} />
                     <TurnImages paths={imagePaths} />
                 </div>

--- a/apps/studio/src/routes/session-timeline.tsx
+++ b/apps/studio/src/routes/session-timeline.tsx
@@ -113,31 +113,39 @@ function Highlights({ data }: { data: SessionTimelinePayload }) {
     );
 }
 
+/** Pure presentational timeline (highlights + segments). Shared by the live
+ *  daemon-backed view below and the static share viewer, which reads a
+ *  precomputed `session_timeline` straight off the gist artifact. */
+export function SessionTimelineBody({ data }: { readonly data: SessionTimelinePayload }) {
+    const eventsBySegment = useMemo(() => {
+        const m = new Map<string, TimelineEvent[]>();
+        for (const e of data.events) {
+            const id = e.segment_id ?? "seg-0";
+            (m.get(id) ?? m.set(id, []).get(id)!).push(e);
+        }
+        return m;
+    }, [data]);
+
+    return (
+        <div style={{ padding: "8px 24px 40px" }}>
+            <Highlights data={data} />
+            {data.segments.map((seg) => (
+                <SegmentBlock key={seg.id} seg={seg} events={eventsBySegment.get(seg.id) ?? []} />
+            ))}
+        </div>
+    );
+}
+
 export function SessionTimelineView({ sessionId }: { readonly sessionId: string }) {
     const q = useQuery({
         queryKey: ["session-timeline", sessionId],
         queryFn: () => api.sessionTimeline(sessionId),
         staleTime: 60_000,
     });
-    const eventsBySegment = useMemo(() => {
-        const m = new Map<string, TimelineEvent[]>();
-        for (const e of q.data?.events ?? []) {
-            const id = e.segment_id ?? "seg-0";
-            (m.get(id) ?? m.set(id, []).get(id)!).push(e);
-        }
-        return m;
-    }, [q.data]);
 
     if (q.isLoading) return <div className="loading" style={{ padding: 24 }}>Building timeline…</div>;
     if (q.error) return <div className="error" style={{ padding: 24 }}>Error: {String(q.error)}</div>;
     if (!q.data) return null;
 
-    return (
-        <div style={{ padding: "8px 24px 40px" }}>
-            <Highlights data={q.data} />
-            {q.data.segments.map((seg) => (
-                <SegmentBlock key={seg.id} seg={seg} events={eventsBySegment.get(seg.id) ?? []} />
-            ))}
-        </div>
-    );
+    return <SessionTimelineBody data={q.data} />;
 }

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -12,7 +12,9 @@ import type {
     TurnTokenUsageDetail,
 } from "@ax/lib/shared/dashboard-types";
 import { shortSessionId } from "@ax/lib/shared/session-id";
+import type { SessionTimelinePayload } from "../api.ts";
 import { compactTokens, useInspectSelection, useVisibleTurnSeq } from "./session-inspect.tsx";
+import { SessionTimelineBody } from "./session-timeline.tsx";
 import { Transcript } from "./transcript.tsx";
 
 type ShareSchemaVersion = 1 | 2 | 3 | 4;
@@ -62,6 +64,8 @@ interface ShareArtifact {
         readonly failures: number;
     };
     readonly token_usage?: SessionTokenUsageDetail | null;
+    /** v4 additive: segmented highlight timeline precomputed at export time. */
+    readonly session_timeline?: SessionTimelinePayload | null;
     readonly hook_fires?: ReadonlyArray<HookFireDto>;
     readonly harness_hooks?: ReadonlyArray<ShareHarnessHookView>;
     readonly turns?: ReadonlyArray<{
@@ -456,6 +460,25 @@ const SUBAGENT_LINK_STYLE: CSSProperties = {
     textDecoration: "underline",
 };
 
+const VIEW_TOGGLE_BAR_STYLE: CSSProperties = {
+    display: "flex",
+    gap: 6,
+    padding: "8px 24px 0",
+};
+
+const VIEW_TOGGLE_BUTTON_STYLE: CSSProperties = {
+    background: "#fff",
+    border: "1px solid var(--line, #d7dbe2)",
+    borderRadius: 4,
+    padding: "3px 12px",
+    cursor: "pointer",
+    color: "#374151",
+    fontFamily: "ui-monospace, monospace",
+    fontSize: 11.5,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+};
+
 /** DOM-id offset so harness-hook markers don't collide with file-context
  *  hook_fire markers (both use `hook-<n>` ids for the shared jump). */
 const HARNESS_HOOK_IDX_BASE = 1_000_000;
@@ -605,26 +628,53 @@ function MultiFileShareView(props: {
     // Selected session is URL-driven (?sub=<file>) so browser back/forward walks
     // the parent <-> subagent navigation instead of being trapped in local state.
     const navigate = useNavigate();
-    const search = useSearch({ strict: false }) as { readonly sub?: string };
+    const search = useSearch({ strict: false }) as { readonly sub?: string; readonly view?: string };
     const selectedFile = search.sub && manifest.subagents.some((c) => c.file === search.sub)
         ? search.sub
         : manifest.root_file;
+    const view: "transcript" | "timeline" = search.view === "timeline" ? "timeline" : "transcript";
+    // This view mounts on both the studio index ("/studio/?shareOwner&gistId",
+    // the public iframe entry) and the "/share/$owner/$gistId" route, so
+    // navigate()'s search-updater can't resolve a single route type. The call
+    // is valid at runtime on either - it swaps search params on the current
+    // location and clears the #turn anchor when switching sessions.
+    const navigateLoose = navigate as unknown as (opts: {
+        readonly search: (prev: Record<string, unknown>) => Record<string, unknown>;
+        readonly hash?: string;
+    }) => void;
     const setSelectedFile = (file: string) => {
         const sub = file === manifest.root_file ? undefined : file;
-        // This view mounts on both the studio index ("/studio/?shareOwner&gistId",
-        // the public iframe entry) and the "/share/$owner/$gistId" route, so
-        // navigate()'s search-updater can't resolve a single route type. The call
-        // is valid at runtime on either - it swaps ?sub on the current location and
-        // clears the #turn anchor (it points at the session we're leaving).
-        const navigateLoose = navigate as unknown as (opts: {
-            readonly search: (prev: Record<string, unknown>) => Record<string, unknown>;
-            readonly hash: string;
-        }) => void;
         navigateLoose({
             search: (prev) => ({ ...prev, sub }),
             hash: "",
         });
     };
+    const setView = (next: "transcript" | "timeline") => {
+        navigateLoose({
+            search: (prev) => ({ ...prev, view: next === "transcript" ? undefined : next }),
+        });
+    };
+    // Jumping between sessions keeps the page's scroll offset, which lands the
+    // reader mid-transcript of a session they've never seen - reset to the top.
+    // Skipped on first mount so a deep link's #turn anchor still wins.
+    const mountedRef = useRef(false);
+    useEffect(() => {
+        if (!mountedRef.current) {
+            mountedRef.current = true;
+            return;
+        }
+        window.scrollTo(0, 0);
+    }, [selectedFile]);
+    // Timeline event rows link to `#turn-N` anchors that only exist in the
+    // transcript - a hash jump while on the timeline flips back to it.
+    useEffect(() => {
+        if (view !== "timeline") return;
+        const onHash = () => {
+            if (window.location.hash.startsWith("#turn-")) setView("transcript");
+        };
+        window.addEventListener("hashchange", onHash);
+        return () => window.removeEventListener("hashchange", onHash);
+    }, [view]);
 
     const fileQuery = useQuery({
         queryKey: ["share-file", owner, gistId, selectedFile],
@@ -738,7 +788,28 @@ function MultiFileShareView(props: {
             ) : null}
             {fileQuery.error ? <div className="error">Error: {String(fileQuery.error)}</div> : null}
             {fileQuery.isLoading && !data ? <div className="loading">Loading session…</div> : null}
-            {data ? (
+            {fileQuery.data?.session_timeline ? (
+                <div style={VIEW_TOGGLE_BAR_STYLE}>
+                    {(["transcript", "timeline"] as const).map((mode) => (
+                        <button
+                            key={mode}
+                            type="button"
+                            onClick={() => setView(mode)}
+                            style={{
+                                ...VIEW_TOGGLE_BUTTON_STYLE,
+                                ...(view === mode
+                                    ? { background: "#1f2937", color: "#fff", borderColor: "#1f2937" }
+                                    : {}),
+                            }}
+                        >
+                            {mode}
+                        </button>
+                    ))}
+                </div>
+            ) : null}
+            {view === "timeline" && fileQuery.data?.session_timeline ? (
+                <SessionTimelineBody data={fileQuery.data.session_timeline} />
+            ) : data ? (
                 <InspectBody
                     data={data}
                     subagentsByTurn={subagentsByTurn}


### PR DESCRIPTION
Three share-viewer fixes from dogfooding the published demo share:

1. **Tool-card overflow under the rail** — tool-only turns' grid cell lacked `min-width: 0`, so an unbreakable primary arg (a long node_modules path) expanded the `1fr` track and the card rendered beneath the sticky cost/inspector rail.
2. **Subagent jump keeps scroll offset** — switching parent ↔ subagent landed the reader mid-transcript of a session they'd never seen. Scroll resets to top on session switch (skipped on first mount so `#turn` deep links still win).
3. **No timeline in shares** — the exporter now embeds the segmented highlight timeline (`SessionTimelineService` output) per exported session as `session_timeline` (v4-additive, optional), and the share viewer gains a transcript/timeline toggle reusing the live view's presentational body (`SessionTimelineBody`). `#turn` links from the timeline flip back to the transcript.

Tests: studio 117 pass, axctl share 61 pass; both apps typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)