### PR TITLE
fix(timeline): title Agent dispatches with their description

### DIFF
--- a/apps/axctl/src/timeline/derive.test.ts
+++ b/apps/axctl/src/timeline/derive.test.ts
@@ -49,6 +49,19 @@ describe("deriveToolEvents", () => {
         ], "claude", new Set([5]));
         expect(events).toHaveLength(0); // seq 5 covered by the edge
     });
+
+    it("titles Agent dispatches with the description, not the bare tool name", () => {
+        const events = deriveToolEvents([
+            tc({ seq: 7, name: "Agent", command_text: '{"description": "Implement Task 3: stage registry", "prompt": "You are imp' }),
+            tc({ seq: 8, name: "Agent", command_text: '{"subagent_type": "general-purpose", "prompt": "Review th' }),
+            tc({ seq: 9, name: "Agent" }), // no input captured -> bare name
+        ], "claude", NO_EDGES);
+        expect(events.map((e) => e.title)).toEqual([
+            "Agent: Implement Task 3: stage registry",
+            "Agent: general-purpose",
+            "Agent",
+        ]);
+    });
 });
 
 describe("deriveFailureEvents", () => {

--- a/apps/axctl/src/timeline/derive.ts
+++ b/apps/axctl/src/timeline/derive.ts
@@ -41,6 +41,25 @@ const tsValue = (ts: string | null): number => {
     return Number.isFinite(t) ? t : Number.POSITIVE_INFINITY;
 };
 
+/** Subagent-dispatch tool names whose bare name says nothing - their event
+ *  title should carry the dispatch description instead of just "Agent". */
+const DISPATCH_TOOLS = new Set(["Agent", "Task"]);
+
+/**
+ * Best-effort label for an Agent/Task dispatch: the `description` (falling
+ * back to `subagent_type`) from the call's input. `command_text` is the first
+ * 400 chars of `input_json`, so it may be TRUNCATED mid-string - regex-extract
+ * instead of JSON.parse.
+ */
+export const dispatchLabel = (commandText: string | null): string | null => {
+    if (!commandText) return null;
+    const pick = (key: string): string | null =>
+        new RegExp(`"${key}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)"`).exec(commandText)?.[1] ?? null;
+    const label = pick("description") ?? pick("subagent_type");
+    if (!label) return null;
+    return label.replace(/\\n/g, " ").replace(/\\"/g, '"').trim() || null;
+};
+
 // --- per-kind derivation ---------------------------------------------------
 
 /**
@@ -74,11 +93,12 @@ export function deriveToolEvents(
             });
             continue;
         }
+        const dispatch = DISPATCH_TOOLS.has(t.name) ? dispatchLabel(t.command_text) : null;
         out.push({
             kind: "tool_call",
             ts: t.ts,
             seq: t.seq,
-            title: clip(t.command_norm ?? t.name, TITLE_MAX),
+            title: clip(dispatch ? `${t.name}: ${dispatch}` : t.command_norm ?? t.name, TITLE_MAX),
             ...(firstLine(t.output_excerpt) ? { detail: clip(firstLine(t.output_excerpt), DETAIL_MAX) } : {}),
             status: "ok",
             refs: [...(t.call_id ? [{ type: "tool" as const, id: t.call_id }] : []), ...turnRef],


### PR DESCRIPTION
Timeline `tool_call` events for `Agent`/`Task` dispatches rendered as a bare **Agent** — `command_norm` is null for them, so the title fell back to the tool name and said nothing about what was dispatched.

Now the title carries the dispatch `description` (fallback `subagent_type`) extracted from `command_text` — regex, not JSON.parse, since that column is the first 400 chars of `input_json` and can be truncated mid-string.

`Agent` → `Agent: Implement Task 3: stage registry`

Tests: timeline suite 18 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)