### PR TITLE
fix(share): subagent nav state isolation + deep-linkable sub/view + timeline turn jumps

### DIFF
--- a/apps/site/app/lib/session-share.test.ts
+++ b/apps/site/app/lib/session-share.test.ts
@@ -62,6 +62,12 @@ describe("site session share helpers", () => {
     );
   });
 
+  it("forwards subagent + view selection into the Studio embed URL", () => {
+    expect(studioShareUrl("Necmttn", "abc123", { sub: "subagent-a1.json", view: "timeline" })).toBe(
+      "/studio/?shareOwner=Necmttn&gistId=abc123&sub=subagent-a1.json&view=timeline",
+    );
+  });
+
   it("selects ax-session.json raw URL from a Gist response", () => {
     const raw = rawSessionFileUrlFromGist({
       owner: { login: "necmttn" },

--- a/apps/site/app/lib/session-share.ts
+++ b/apps/site/app/lib/session-share.ts
@@ -77,8 +77,15 @@ export function gistApiUrl(gistId: string): string {
   return `https://api.github.com/gists/${encodeURIComponent(gistId)}`;
 }
 
-export function studioShareUrl(owner: string, gistId: string): string {
-  return `/studio/?shareOwner=${encodeURIComponent(owner)}&gistId=${encodeURIComponent(gistId)}`;
+export function studioShareUrl(
+  owner: string,
+  gistId: string,
+  extra?: { readonly sub?: string; readonly view?: string },
+): string {
+  let url = `/studio/?shareOwner=${encodeURIComponent(owner)}&gistId=${encodeURIComponent(gistId)}`;
+  if (extra?.sub) url += `&sub=${encodeURIComponent(extra.sub)}`;
+  if (extra?.view) url += `&view=${encodeURIComponent(extra.view)}`;
+  return url;
 }
 
 export function gistOwnerMatches(value: unknown, owner: string): boolean {

--- a/apps/site/app/routes/s.$owner.$gistId.tsx
+++ b/apps/site/app/routes/s.$owner.$gistId.tsx
@@ -1,7 +1,14 @@
+import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { studioShareUrl } from "~/lib/session-share";
 
 export const Route = createFileRoute("/s/$owner/$gistId")({
+  // `sub` selects a subagent session file, `view` the transcript/timeline tab.
+  // Forwarded into the studio iframe so deep links open exactly what was shared.
+  validateSearch: (search: Record<string, unknown>) => ({
+    sub: typeof search.sub === "string" && search.sub.length > 0 ? search.sub : undefined,
+    view: search.view === "timeline" ? ("timeline" as const) : undefined,
+  }),
   head: ({ params }) => ({
     meta: [
       { title: `Shared ax session - ${params.owner}/${params.gistId}` },
@@ -13,7 +20,11 @@ export const Route = createFileRoute("/s/$owner/$gistId")({
 
 function SharedSessionFrame() {
   const { owner, gistId } = Route.useParams();
-  const src = studioShareUrl(owner, gistId);
+  const search = Route.useSearch();
+  // Frozen at mount: the embedded studio mirrors its own navigation back onto
+  // THIS page's URL (history.replaceState from the same-origin iframe), and a
+  // reactive src would reload the iframe on every mirrored change.
+  const [src] = useState(() => studioShareUrl(owner, gistId, { sub: search.sub, view: search.view }));
 
   return (
     <main className="share-embed-shell">

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -644,6 +644,12 @@ function MultiFileShareView(props: {
     }) => void;
     const setSelectedFile = (file: string) => {
         const sub = file === manifest.root_file ? undefined : file;
+        // Drop the #turn anchor BEFORE the navigate re-renders: the freshly
+        // keyed InspectBody reads location.hash at mount, and a stale anchor
+        // would scroll the new session to the old session's turn number.
+        if (window.location.hash) {
+            window.history.replaceState(null, "", window.location.pathname + window.location.search);
+        }
         navigateLoose({
             search: (prev) => ({ ...prev, sub }),
             hash: "",
@@ -652,6 +658,10 @@ function MultiFileShareView(props: {
     const setView = (next: "transcript" | "timeline") => {
         navigateLoose({
             search: (prev) => ({ ...prev, view: next === "transcript" ? undefined : next }),
+            // Preserve the #turn anchor across the toggle: a timeline event's
+            // "→ turn N" link sets the hash first, then flips the view, and the
+            // mounting transcript scrolls to it.
+            hash: window.location.hash.replace(/^#/, ""),
         });
     };
     // Jumping between sessions keeps the page's scroll offset, which lands the
@@ -675,6 +685,24 @@ function MultiFileShareView(props: {
         window.addEventListener("hashchange", onHash);
         return () => window.removeEventListener("hashchange", onHash);
     }, [view]);
+    // Mirror the selected subagent + view onto the embedding page's URL (the
+    // public /s/<owner>/<gistId> shell iframes this same-origin), so copying
+    // the address bar shares exactly what is on screen. replaceState bypasses
+    // the parent's router, so the iframe src stays stable - no reload loop.
+    const subParam = selectedFile === manifest.root_file ? undefined : selectedFile;
+    useEffect(() => {
+        if (window.parent === window) return;
+        try {
+            const url = new URL(window.parent.location.href);
+            if (subParam) url.searchParams.set("sub", subParam);
+            else url.searchParams.delete("sub");
+            if (view === "timeline") url.searchParams.set("view", view);
+            else url.searchParams.delete("view");
+            window.parent.history.replaceState(null, "", url.toString());
+        } catch {
+            // Cross-origin embed: leave the parent URL alone.
+        }
+    }, [subParam, view]);
 
     const fileQuery = useQuery({
         queryKey: ["share-file", owner, gistId, selectedFile],
@@ -811,6 +839,9 @@ function MultiFileShareView(props: {
                 <SessionTimelineBody data={fileQuery.data.session_timeline} />
             ) : data ? (
                 <InspectBody
+                    // Keyed by file: jump-cursor/anchor state must not leak from
+                    // one session's transcript into another's.
+                    key={selectedFile}
                     data={data}
                     subagentsByTurn={subagentsByTurn}
                     harnessHooks={fileQuery.data?.harness_hooks}


### PR DESCRIPTION
Three navigation fixes for the public share viewer, from live dogfooding:

1. **Subagent opened at the parent's turn number** — `InspectBody` kept its jump-cursor/anchor state across session switches. Now keyed by selected file (clean remount) and the stale `#turn` anchor is dropped before the switch.
2. **Timeline → "turn N" links now land on the turn** — the hash is preserved across the timeline→transcript flip, so the mounting transcript grows its window to the target and scrolls to it.
3. **Deep-linkable subagent + view** — the embedded studio mirrors `?sub` and `?view` onto the public `/s/<owner>/<gistId>` URL via same-origin `replaceState`, and the `/s/` route forwards them back into the iframe src. Copying the address bar now shares exactly what's on screen.

Tests: studio 117 pass, site session-share 18 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)