### PR TITLE
feat(timeline): +/− line counts, smart shell titles, subagent landing continuity

### DIFF
--- a/apps/axctl/src/timeline/derive.test.ts
+++ b/apps/axctl/src/timeline/derive.test.ts
@@ -4,8 +4,11 @@ import {
     deriveCheckpointEvents,
     deriveDecisionEvents,
     deriveFailureEvents,
+    deriveFileEvents,
     deriveToolEvents,
+    editDelta,
     pairRecoveries,
+    shellTitle,
     type TimelineInputs,
 } from "./derive.ts";
 import type { ToolCallRow, EditRow } from "./queries.ts";
@@ -50,6 +53,26 @@ describe("deriveToolEvents", () => {
         expect(events).toHaveLength(0); // seq 5 covered by the edge
     });
 
+    it("does not classify claude Bash heredocs/redirects as file edits", () => {
+        const events = deriveToolEvents([
+            tc({ seq: 1, name: "Bash", command_norm: "git add", command_text: '{"command": "git add -A && echo done > /tmp/log"}' }),
+            tc({ seq: 2, name: "Bash", command_norm: "bun run", command_text: '{"command": "bun run x <<\'EOF\'\\n...\\nEOF"}' }),
+        ], "claude", NO_EDGES);
+        expect(events.map((e) => e.kind)).toEqual(["tool_call", "tool_call"]);
+    });
+
+    it("titles wrapper commands (echo) with the real pipeline segment + intent", () => {
+        const events = deriveToolEvents([
+            tc({
+                seq: 3,
+                name: "Bash",
+                command_norm: "echo",
+                command_text: '{"command": "echo ===; bun run typecheck 2>&1", "description": "Typecheck the CLI"}',
+            }),
+        ], "claude", NO_EDGES);
+        expect(events[0]?.title).toBe("bun run typecheck 2>&1 - Typecheck the CLI");
+    });
+
     it("titles Agent dispatches with the description, not the bare tool name", () => {
         const events = deriveToolEvents([
             tc({ seq: 7, name: "Agent", command_text: '{"description": "Implement Task 3: stage registry", "prompt": "You are imp' }),
@@ -61,6 +84,30 @@ describe("deriveToolEvents", () => {
             "Agent: general-purpose",
             "Agent",
         ]);
+    });
+});
+
+describe("editDelta + deriveFileEvents", () => {
+    it("counts +/- lines from Edit and Write inputs", () => {
+        expect(editDelta("Edit", JSON.stringify({ old_string: "a\nb\nc", new_string: "a\nB" })))
+            .toEqual({ added: 2, removed: 3 });
+        expect(editDelta("Write", JSON.stringify({ content: "l1\nl2\nl3\nl4" })))
+            .toEqual({ added: 4, removed: 0 });
+        expect(editDelta("Edit", '{"old_string": "trunc')).toBeNull(); // truncated -> no delta
+    });
+
+    it("appends +/- to file_edit titles when a delta is known", () => {
+        const edits: EditRow[] = [
+            { seq: 4, ts: "2026-06-07T00:00:01Z", path: "src/a.ts", edit_kind: "update", tool: "Edit" },
+            { seq: 9, ts: "2026-06-07T00:00:02Z", path: "src/b.ts", edit_kind: "update", tool: "Edit" },
+        ];
+        const events = deriveFileEvents(edits, new Map([[4, { added: 12, removed: 3 }]]));
+        expect(events[0]?.title).toBe("src/a.ts  +12/-3");
+        expect(events[1]?.title).toBe("src/b.ts");
+    });
+
+    it("shellTitle returns null when there is nothing better", () => {
+        expect(shellTitle('{"command": "echo hello"}')).toBeNull();
     });
 });
 

--- a/apps/axctl/src/timeline/derive.ts
+++ b/apps/axctl/src/timeline/derive.ts
@@ -16,6 +16,7 @@ import type {
     CorrectionRow,
     CostRow,
     EditRow,
+    EditStatRow,
     HealthRow,
     LastTurnRow,
     OverviewRow,
@@ -53,11 +54,71 @@ const DISPATCH_TOOLS = new Set(["Agent", "Task"]);
  */
 export const dispatchLabel = (commandText: string | null): string | null => {
     if (!commandText) return null;
-    const pick = (key: string): string | null =>
-        new RegExp(`"${key}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)"`).exec(commandText)?.[1] ?? null;
-    const label = pick("description") ?? pick("subagent_type");
+    const label = jsonStringField(commandText, "description") ?? jsonStringField(commandText, "subagent_type");
     if (!label) return null;
-    return label.replace(/\\n/g, " ").replace(/\\"/g, '"').trim() || null;
+    return unescapeJson(label) || null;
+};
+
+/** Regex-extract one string field from (possibly truncated) raw JSON text. */
+const jsonStringField = (text: string | null, key: string): string | null =>
+    text ? new RegExp(`"${key}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)"`).exec(text)?.[1] ?? null : null;
+
+const unescapeJson = (s: string): string =>
+    s.replace(/\\n/g, " ").replace(/\\t/g, " ").replace(/\\"/g, '"').replace(/\\\\/g, "\\").trim();
+
+/** Shell wrappers whose bare name says nothing about what actually ran. */
+const WRAPPER_NORMS = new Set(["echo", "printf", "cd", "true", "set", "export", "eval"]);
+
+/**
+ * Better title for a shell call whose normalized command is a wrapper (`echo`
+ * piggybacking a compound command, `cd x && bun test`, heredoc logging, ...).
+ * Splits the raw command on `&&`/`||`/`;`/`|`/newlines, surfaces the first
+ * segment that is NOT a wrapper, and appends the agent's stated `description`
+ * when present. Returns null when there is nothing better than the norm.
+ */
+export const shellTitle = (commandText: string | null): string | null => {
+    const rawCmd = jsonStringField(commandText, "command");
+    const desc = jsonStringField(commandText, "description");
+    const segments = rawCmd
+        ? unescapeJson(rawCmd).split(/&&|\|\||[;|\n]/).map((s) => s.trim()).filter((s) => s.length > 0)
+        : [];
+    const meaningful = segments.find((s) => !WRAPPER_NORMS.has((s.split(/\s+/)[0] ?? "").toLowerCase()));
+    const cmdLabel = meaningful ? clip(meaningful, 48) : null;
+    const descLabel = desc ? unescapeJson(desc) : null;
+    if (cmdLabel && descLabel) return `${cmdLabel} - ${descLabel}`;
+    return cmdLabel ?? descLabel;
+};
+
+export interface EditDelta {
+    readonly added: number;
+    readonly removed: number;
+}
+
+const countLines = (s: unknown): number =>
+    typeof s === "string" && s.length > 0 ? s.split("\n").length : 0;
+
+/**
+ * +/- line counts for one Edit/Write/NotebookEdit call from its full input.
+ * Best-effort: the input is sliced at 32k chars, so a giant Write may not
+ * parse - return null and the event title stays as-is.
+ */
+export const editDelta = (name: string, inputJson: string | null): EditDelta | null => {
+    if (!inputJson) return null;
+    try {
+        const input = JSON.parse(inputJson) as Record<string, unknown>;
+        if (name === "Edit") {
+            return { added: countLines(input.new_string), removed: countLines(input.old_string) };
+        }
+        if (name === "Write") {
+            return { added: countLines(input.content), removed: 0 };
+        }
+        if (name === "NotebookEdit") {
+            return { added: countLines(input.new_source), removed: 0 };
+        }
+        return null;
+    } catch {
+        return null;
+    }
 };
 
 // --- per-kind derivation ---------------------------------------------------
@@ -94,11 +155,16 @@ export function deriveToolEvents(
             continue;
         }
         const dispatch = DISPATCH_TOOLS.has(t.name) ? dispatchLabel(t.command_text) : null;
+        // A wrapper norm (`echo`, `cd`, ...) hides the real work - pull the
+        // meaningful pipeline segment + the agent's intent out of the input.
+        const smart = !dispatch && t.command_norm && WRAPPER_NORMS.has(t.command_norm.toLowerCase())
+            ? shellTitle(t.command_text)
+            : null;
         out.push({
             kind: "tool_call",
             ts: t.ts,
             seq: t.seq,
-            title: clip(dispatch ? `${t.name}: ${dispatch}` : t.command_norm ?? t.name, TITLE_MAX),
+            title: clip(dispatch ? `${t.name}: ${dispatch}` : smart ?? t.command_norm ?? t.name, TITLE_MAX),
             ...(firstLine(t.output_excerpt) ? { detail: clip(firstLine(t.output_excerpt), DETAIL_MAX) } : {}),
             status: "ok",
             refs: [...(t.call_id ? [{ type: "tool" as const, id: t.call_id }] : []), ...turnRef],
@@ -128,20 +194,29 @@ export function deriveFailureEvents(rows: ReadonlyArray<ToolCallRow>): TimelineE
         });
 }
 
-export function deriveFileEvents(rows: ReadonlyArray<EditRow>): TimelineEvent[] {
+export function deriveFileEvents(
+    rows: ReadonlyArray<EditRow>,
+    deltaBySeq: ReadonlyMap<number, EditDelta> = new Map(),
+): TimelineEvent[] {
     return rows
         .filter((e) => e.path != null && e.ts != null)
-        .map((e) => ({
-            kind: "file_edit" as const,
-            ts: e.ts as string,
-            seq: e.seq,
-            title: clip(e.path as string, TITLE_MAX),
-            ...(e.tool || e.edit_kind ? { detail: [e.tool, e.edit_kind].filter(Boolean).join(" · ") } : {}),
-            refs: [
-                { type: "file" as const, id: e.path as string },
-                ...(e.seq != null ? [{ type: "turn" as const, id: String(e.seq) }] : []),
-            ],
-        }));
+        .map((e) => {
+            const delta = e.seq != null ? deltaBySeq.get(e.seq) : undefined;
+            const suffix = delta && (delta.added > 0 || delta.removed > 0)
+                ? `  +${delta.added}/-${delta.removed}`
+                : "";
+            return {
+                kind: "file_edit" as const,
+                ts: e.ts as string,
+                seq: e.seq,
+                title: clip(`${e.path as string}${suffix}`, TITLE_MAX),
+                ...(e.tool || e.edit_kind ? { detail: [e.tool, e.edit_kind].filter(Boolean).join(" · ") } : {}),
+                refs: [
+                    { type: "file" as const, id: e.path as string },
+                    ...(e.seq != null ? [{ type: "turn" as const, id: String(e.seq) }] : []),
+                ],
+            };
+        });
 }
 
 export function deriveSkillEvents(
@@ -330,6 +405,8 @@ export interface TimelineInputs {
     readonly cost: CostRow | null;
     readonly toolCalls: ReadonlyArray<ToolCallRow>;
     readonly edits: ReadonlyArray<EditRow>;
+    /** Full Edit/Write inputs for +/- line counts; optional (older callers). */
+    readonly editStats?: ReadonlyArray<EditStatRow>;
     readonly skills: ReadonlyArray<SkillRow>;
     readonly corrections: ReadonlyArray<CorrectionRow>;
     readonly plans: ReadonlyArray<PlanRow>;
@@ -348,10 +425,21 @@ export function buildTimeline(input: TimelineInputs): SessionTimeline {
         input.edits.map((e) => e.seq).filter((s): s is number => s != null),
     );
     const failures = pairRecoveries(deriveFailureEvents(input.toolCalls), input.toolCalls, input.edits);
+    // +/- per turn seq, summed when one turn carries several edit calls.
+    const deltaBySeq = new Map<number, EditDelta>();
+    for (const stat of input.editStats ?? []) {
+        if (stat.seq == null) continue;
+        const delta = editDelta(stat.name, stat.input_json);
+        if (!delta) continue;
+        const prev = deltaBySeq.get(stat.seq);
+        deltaBySeq.set(stat.seq, prev
+            ? { added: prev.added + delta.added, removed: prev.removed + delta.removed }
+            : delta);
+    }
     const events = [
         ...deriveToolEvents(input.toolCalls, input.source, editedSeqs),
         ...failures,
-        ...deriveFileEvents(input.edits),
+        ...deriveFileEvents(input.edits, deltaBySeq),
         ...deriveSkillEvents(input.skills, input.source),
         ...deriveCorrectionEvents(input.corrections),
         ...deriveDecisionEvents(input.plans),

--- a/apps/axctl/src/timeline/providers.ts
+++ b/apps/axctl/src/timeline/providers.ts
@@ -76,7 +76,12 @@ export function classifyTool(source: ProviderSource, t: ClassifyInput): Classifi
     if (EDIT_TOOL_NAMES.has(lname)) return { kind: "file_edit", importance: "high" };
 
     // codex/pi/opencode/cursor edit through the shell - inspect the command.
+    // Claude-like harnesses edit through dedicated tools (the `edited` edge
+    // covers those); their Bash heredocs/redirects are pipelines and logging,
+    // so the shell-edit heuristic only produces false "FILE EDIT git add"
+    // rows there - skip it.
     if (SHELL_EXEC_NAMES.has(lname)) {
+        if (isClaudeLike(source)) return { kind: "tool", importance: "high" };
         const cmd = (t.command_norm ?? "").toLowerCase();
         const text = (t.command_text ?? "").toLowerCase();
         const isEdit =

--- a/apps/axctl/src/timeline/queries.ts
+++ b/apps/axctl/src/timeline/queries.ts
@@ -135,6 +135,28 @@ export const mapEdit = (raw: unknown): EditRow | null => {
     };
 };
 
+/** Full edit-tool inputs, fetched separately so the lean tool_call query stays
+ *  cheap: counting +/- lines needs old_string/new_string/content, which the
+ *  400-char command_text slice cannot carry. 32k slice bounds Write payloads;
+ *  a truncated JSON simply yields no delta (best-effort). */
+export interface EditStatRow {
+    readonly seq: number | null;
+    readonly name: string;
+    readonly input_json: string | null;
+}
+export const editStatsSql = (ref: string): string =>
+    `SELECT seq, name, string::slice(input_json ?? "", 0, 32000) AS input_json FROM tool_call WHERE session = ${ref} AND name IN ['Edit', 'Write', 'NotebookEdit'] ORDER BY seq ASC LIMIT 2000;`;
+export const mapEditStat = (raw: unknown): EditStatRow | null => {
+    if (!isRecord(raw)) return null;
+    const name = stringField(raw, "name");
+    if (!name) return null;
+    return {
+        seq: seqField(raw, "seq"),
+        name,
+        input_json: stringField(raw, "input_json"),
+    };
+};
+
 export interface SkillRow {
     readonly seq: number | null;
     readonly ts: string | null;

--- a/apps/axctl/src/timeline/service.ts
+++ b/apps/axctl/src/timeline/service.ts
@@ -16,6 +16,7 @@ import {
     correctionsSql,
     costSql,
     editsSql,
+    editStatsSql,
     healthSql,
     lastAssistantSql,
     mapAsk,
@@ -26,6 +27,7 @@ import {
     mapIntentCorrection,
     mapCost,
     mapEdit,
+    mapEditStat,
     mapHealth,
     mapLastTurn,
     mapOverview,
@@ -65,7 +67,7 @@ export const SessionTimelineServiceLayer = Layer.effect(SessionTimelineService)(
             const extract = Effect.fn("SessionTimelineService.extract")(function* (sessionId: string) {
                 const ref = sessionRef(sessionId);
                 const [
-                    healthRaw, overviewRaw, costRaw, toolRaw, editRaw,
+                    healthRaw, overviewRaw, costRaw, toolRaw, editRaw, editStatRaw,
                     skillRaw, correctionRaw, intentCorrectionRaw, planRaw, commitRaw, askRaw, compactionRaw, lastRaw,
                 ] = yield* Effect.all([
                     oneRow(healthSql(ref)),
@@ -73,6 +75,7 @@ export const SessionTimelineServiceLayer = Layer.effect(SessionTimelineService)(
                     oneRow(costSql(ref)),
                     rows(toolCallsSql(ref)),
                     rows(editsSql(ref)),
+                    rows(editStatsSql(ref)),
                     rows(skillsSql(ref)),
                     rows(correctionsSql(ref)),
                     rows(intentCorrectionsSql(ref)),
@@ -102,6 +105,7 @@ export const SessionTimelineServiceLayer = Layer.effect(SessionTimelineService)(
                     cost: mapCost(costRaw),
                     toolCalls: toolRaw.map(mapToolCall).filter(present),
                     edits: editRaw.map(mapEdit).filter(present),
+                    editStats: editStatRaw.map(mapEditStat).filter(present),
                     skills: skillRaw.map(mapSkill).filter(present),
                     corrections,
                     plans: planRaw.map(mapPlan).filter(present),

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -287,16 +287,35 @@ function InspectBody({
     harnessHooks,
     onSelectSubagent,
     onPrefetchSubagent,
+    landOnFirstTurn = false,
 }: {
     readonly data: SessionInspectPayload;
     readonly subagentsByTurn?: ReadonlyMap<number, ReadonlyArray<ShareSubagentCard>>;
     readonly harnessHooks?: ReadonlyArray<ShareHarnessHookView>;
     readonly onSelectSubagent?: (file: string) => void;
     readonly onPrefetchSubagent?: (file: string) => void;
+    /** Land on the first message instead of page top (subagent continuity:
+     *  the reader just clicked this session's task in the parent transcript). */
+    readonly landOnFirstTurn?: boolean;
 }) {
     const [anchoredSeq, setAnchoredSeq] = useState<number | null>(() => hashSeq());
     const turnsRef = useRef<ReadonlyArray<InspectTurnDto>>([]);
     turnsRef.current = data.turns;
+
+    // Landing on mount (the component is keyed per session file): a #turn
+    // anchor wins via the anchoredSeq effect below; otherwise a subagent
+    // continues at its first message; otherwise reset to the page top.
+    useEffect(() => {
+        if (hashSeq() != null) return;
+        const first = turnsRef.current[0];
+        if (landOnFirstTurn && first) {
+            document.getElementById(`turn-${first.seq}`)?.scrollIntoView({ behavior: "auto", block: "start" });
+            return;
+        }
+        window.scrollTo(0, 0);
+        // Mount-only: landing is a one-shot decision per keyed session view.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // Mount-windowing: render the first N turns, grow on scroll / on a jump that
     // targets a turn past the window. The full list stays in `data.turns` so
@@ -642,18 +661,25 @@ function MultiFileShareView(props: {
         readonly search: (prev: Record<string, unknown>) => Record<string, unknown>;
         readonly hash?: string;
     }) => void;
-    const setSelectedFile = (file: string) => {
+    const setSelectedFile = (file: string, anchorSeq?: number | null) => {
         const sub = file === manifest.root_file ? undefined : file;
         // Drop the #turn anchor BEFORE the navigate re-renders: the freshly
         // keyed InspectBody reads location.hash at mount, and a stale anchor
         // would scroll the new session to the old session's turn number.
+        // `anchorSeq` re-anchors deliberately (back-nav returns to the spawn turn).
         if (window.location.hash) {
             window.history.replaceState(null, "", window.location.pathname + window.location.search);
         }
-        navigateLoose({
-            search: (prev) => ({ ...prev, sub }),
-            hash: "",
-        });
+        const go = () =>
+            navigateLoose({
+                search: (prev) => ({ ...prev, sub }),
+                hash: anchorSeq != null ? `turn-${anchorSeq}` : "",
+            });
+        // Crossfade the session switch where the View Transitions API exists.
+        const startViewTransition = (document as { startViewTransition?: (cb: () => unknown) => unknown })
+            .startViewTransition?.bind(document);
+        if (startViewTransition) startViewTransition(go);
+        else go();
     };
     const setView = (next: "transcript" | "timeline") => {
         navigateLoose({
@@ -664,17 +690,8 @@ function MultiFileShareView(props: {
             hash: window.location.hash.replace(/^#/, ""),
         });
     };
-    // Jumping between sessions keeps the page's scroll offset, which lands the
-    // reader mid-transcript of a session they've never seen - reset to the top.
-    // Skipped on first mount so a deep link's #turn anchor still wins.
-    const mountedRef = useRef(false);
-    useEffect(() => {
-        if (!mountedRef.current) {
-            mountedRef.current = true;
-            return;
-        }
-        window.scrollTo(0, 0);
-    }, [selectedFile]);
+    // Landing position on session switch lives in InspectBody's mount effect
+    // (anchor > first turn > top), so nothing scrolls here.
     // Timeline event rows link to `#turn-N` anchors that only exist in the
     // transcript - a hash jump while on the timeline flips back to it.
     useEffect(() => {
@@ -803,7 +820,7 @@ function MultiFileShareView(props: {
                 <div style={SUBAGENT_BAR_STYLE}>
                     <button
                         type="button"
-                        onClick={() => setSelectedFile(parentFile)}
+                        onClick={() => setSelectedFile(parentFile, selectedCard.spawn_turn_seq)}
                         onMouseEnter={() => prefetch(parentFile)}
                         style={{ ...SUBAGENT_LINK_STYLE, fontWeight: 700 }}
                     >
@@ -847,6 +864,7 @@ function MultiFileShareView(props: {
                     harnessHooks={fileQuery.data?.harness_hooks}
                     onSelectSubagent={setSelectedFile}
                     onPrefetchSubagent={prefetch}
+                    landOnFirstTurn={selectedFile !== manifest.root_file}
                 />
             ) : null}
         </section>


### PR DESCRIPTION
Timeline skim-quality + share navigation continuity:

**Timeline events**
- `file_edit` events now show `+N/-M` line counts (full Edit/Write/NotebookEdit inputs fetched via a separate bounded query; deltas summed per turn)
- wrapper shell commands (`echo`, `cd`, …) title with the real pipeline segment plus the agent's stated `description`: `echo` → `bun run typecheck 2>&1 — Typecheck the CLI`
- claude Bash heredocs/redirects no longer misclassify as FILE EDIT (`FILE EDIT git add`, `FILE EDIT bun run`) — the codex shell-edit heuristic is now gated to non-claude sources

**Share viewer**
- opening a subagent lands on its **first message** (continuity with the task you just read in the parent), not the page top; `↑ back` returns to the spawn turn in the parent
- session switches crossfade via the View Transitions API where supported

Tests: timeline 23 pass, studio 117 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)