### PR TITLE
fix(share): mobile layout + 'recorded with ax' CTA

### DIFF
--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -52,6 +52,7 @@ main, header, footer {
   width: 100vw;
   max-width: none;
   min-height: 100vh;
+  min-height: 100dvh; /* iOS Safari: don't clip behind the toolbar */
   margin: 0;
   padding: 0;
   background: #f3f6f5;
@@ -61,6 +62,7 @@ main, header, footer {
   display: block;
   width: 100%;
   height: 100vh;
+  height: 100dvh; /* iOS Safari: don't clip behind the toolbar */
   border: 0;
 }
 

--- a/apps/studio/src/Shell.tsx
+++ b/apps/studio/src/Shell.tsx
@@ -32,11 +32,16 @@ interface Tab {
 
 export function Shell({ children }: { children: ReactNode }) {
     const state = useRouterState();
-    // A shared session (/share/...) is a standalone, read-only gist view: the
-    // local-graph nav + live/offline chrome don't apply (those routes need a
-    // running daemon). Render slim branded chrome with a CTA instead. Branching
-    // on which component renders keeps each one's hooks unconditional.
-    return state.location.pathname.startsWith("/share")
+    // A shared session is a standalone, read-only gist view: the local-graph
+    // nav + live/offline chrome don't apply (those routes need a running
+    // daemon). It arrives two ways - the /share/... route AND the public-embed
+    // index entry /studio/?shareOwner=...&gistId=... - both get the slim
+    // branded chrome with a CTA. Branching on which component renders keeps
+    // each one's hooks unconditional.
+    const search = state.location.search as { shareOwner?: unknown; gistId?: unknown };
+    const isShare = state.location.pathname.startsWith("/share")
+        || (typeof search.shareOwner === "string" && typeof search.gistId === "string");
+    return isShare
         ? <ShareChrome>{children}</ShareChrome>
         : <FullChrome>{children}</FullChrome>;
 }
@@ -56,10 +61,25 @@ function ShareChrome({ children }: { children: ReactNode }) {
                     target="_blank"
                     rel="noopener noreferrer"
                 >
-                    Map your own agent sessions → Get ax
+                    Get ax →
                 </a>
             </header>
             {children}
+            <footer className="share-footer">
+                <span className="share-footer-label">recorded with ax</span>
+                <p className="share-footer-copy">
+                    Trace your own agent sessions - every turn, tool call, and dollar, on your machine.
+                </p>
+                <code className="share-footer-install">curl -fsSL https://ax.necmttn.com/install | sh</code>
+                <a
+                    className="share-footer-link"
+                    href="https://ax.necmttn.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    ax.necmttn.com →
+                </a>
+            </footer>
         </div>
     );
 }

--- a/apps/studio/src/routes/inspector-filter-bar.tsx
+++ b/apps/studio/src/routes/inspector-filter-bar.tsx
@@ -190,7 +190,7 @@ export function FilterBar({
     });
 
     return (
-        <div style={{
+        <div className="filter-bar" style={{
             position: "sticky", top: 0, zIndex: 10,
             display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center",
             padding: "6px 24px", borderTop: "1px solid #e2e8f0", background: "#f8fafc",

--- a/apps/studio/src/routes/session-inspect.tsx
+++ b/apps/studio/src/routes/session-inspect.tsx
@@ -688,7 +688,7 @@ export function DockedRail({
     setSelection: (selection: InspectSelection | null) => void;
 }) {
     return (
-        <div style={{
+        <div className="docked-rail" style={{
             flex: "0 0 320px",
             alignSelf: "flex-start",
             position: "sticky",
@@ -1377,7 +1377,7 @@ function TurnImpl({
 
     if (toolOnly) {
         return (
-            <div id={`turn-${turn.seq}`} title={turnTokenUsageTitle(turn)} style={gridStyle}>
+            <div id={`turn-${turn.seq}`} className="turn-row" title={turnTokenUsageTitle(turn)} style={gridStyle}>
                 {seqGutter}
                 <TurnHeader turn={turn} style={s} extras={headerExtras} hideRoleLabel />
                 <div style={{ gridColumn: "2", minWidth: 0 }}>
@@ -1389,7 +1389,7 @@ function TurnImpl({
     }
 
     return (
-        <div id={`turn-${turn.seq}`} title={turnTokenUsageTitle(turn)} style={gridStyle}>
+        <div id={`turn-${turn.seq}`} className="turn-row" title={turnTokenUsageTitle(turn)} style={gridStyle}>
             {seqGutter}
             <TurnHeader turn={turn} style={s} extras={headerExtras} rightSlot={inspectingBadge} />
             <div style={{ gridColumn: "2", minWidth: 0 }}>

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2117,3 +2117,98 @@ td.skill-cell .description {
     border-color: #ef4444;
     box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.4);
 }
+
+/* --- shared-session view: mobile + CTA footer ----------------------------- */
+
+/* Unbroken code strings (gist source paths) must never widen the page. */
+.panel code {
+    overflow-wrap: anywhere;
+    word-break: break-all;
+}
+
+/* Raw share summaries can be many lines of payload at 22px serif - clamp. */
+.share-hero .share-hero-title {
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+/* "Recorded with ax" CTA card at the end of a shared transcript. */
+.share-footer {
+    border: 1px solid var(--line);
+    background: #fff;
+    padding: 16px 20px 18px;
+    margin-top: 16px;
+    display: grid;
+    gap: 8px;
+    justify-items: start;
+}
+.share-footer-label {
+    font: 700 10px/1 ui-monospace, Menlo, monospace;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--muted);
+}
+.share-footer-copy {
+    margin: 0;
+    font-size: 13px;
+    color: var(--ink);
+    max-width: 52ch;
+}
+.share-footer-install {
+    font: 12px/1.4 ui-monospace, Menlo, monospace;
+    background: var(--page);
+    border: 1px solid var(--line);
+    padding: 8px 12px;
+    white-space: nowrap;
+    overflow-x: auto;
+    max-width: 100%;
+}
+.share-footer-link {
+    font: 600 11px/1 ui-monospace, Menlo, monospace;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink);
+    text-decoration: none;
+    border-bottom: 1px solid var(--ink);
+    padding-bottom: 2px;
+}
+
+@media (max-width: 768px) {
+    /* The docked inspector/cost rail is hover-driven - useless on touch and
+       it squeezes the transcript to ~110px. Inline styles win specificity,
+       hence !important. */
+    .docked-rail {
+        display: none !important;
+    }
+    /* Jump bar: one horizontally-scrollable row instead of a 5-row sticky
+       block covering a third of the viewport. */
+    .filter-bar {
+        flex-wrap: nowrap !important;
+        overflow-x: auto;
+        padding: 6px 12px !important;
+        -webkit-overflow-scrolling: touch;
+    }
+    .filter-bar > * {
+        flex: 0 0 auto;
+    }
+    /* Turn rows: 100px of gutter+padding per 390px line is too rich. */
+    .turn-row {
+        padding: 8px 10px !important;
+        grid-template-columns: 26px 1fr !important;
+    }
+    .shell {
+        padding: 12px;
+    }
+    .masthead .brand-tag {
+        display: none;
+    }
+    .masthead-share {
+        flex-wrap: wrap;
+    }
+    .share-cta {
+        font-size: 11px;
+        padding: 6px 10px;
+    }
+}


### PR DESCRIPTION
Design-critique pass at 390×844 found: 475px scrollWidth vs 390px viewport (whole page panned sideways), transcript squeezed to ~110px beside the fixed 320px inspector rail, and the entire first viewport spent on the mock banner + 10 dashboard tabs.

- **ShareChrome on the public embed** — `/studio/?shareOwner&gistId` fell into FullChrome, so shares showed the mock-mode banner + dashboard nav and the header CTA never rendered. Now detected as a share view.
- **Inspector rail hidden ≤768px** — hover-driven, useless on touch, and the cause of the squeezed column.
- **Jump bar** — one horizontally-scrollable row instead of a 5-row sticky block.
- **Turn gutter/padding tightened on mobile** (+~46px of text per line); unbroken `<code>` gist paths wrap (killed the horizontal overflow); hero title clamped; `100dvh` iframe for iOS.
- **CTA** — slim `Get ax →` header pill + a "recorded with ax" footer card with the install one-liner, in the page's monospace/1px-border grammar.

Tests: studio 117 pass, typecheck clean. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)