### PR TITLE
perf(ingest): github-pr fetch cooldown + AX_OTLP_URL passthrough in installed plists

### DIFF
--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -105,6 +105,20 @@ const dbPlist = (
 </plist>
 `;
 
+/**
+ * Optional OTLP passthrough for the background agents: when the user installs
+ * with `AX_OTLP_URL` set (e.g. a local Maple/Jaeger on 127.0.0.1:4318), bake it
+ * into the generated plists so watcher/daily ingests export traces too.
+ * Re-running `axctl install` without the env removes it again.
+ */
+const otlpEnvEntry = (): string => {
+    const url = process.env["AX_OTLP_URL"];
+    if (!url) return "";
+    return `
+    <key>AX_OTLP_URL</key>
+    <string>${url}</string>`;
+};
+
 const watchPlist = (binPath: string): string => `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -133,7 +147,7 @@ const watchPlist = (binPath: string): string => `<?xml version="1.0" encoding="U
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <string>${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>${otlpEnvEntry()}
   </dict>
 </dict>
 </plist>
@@ -168,7 +182,7 @@ const derivePlist = (binPath: string): string => `<?xml version="1.0" encoding="
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <string>${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>${otlpEnvEntry()}
   </dict>
 </dict>
 </plist>

--- a/apps/axctl/src/ingest/github-pr-stage.test.ts
+++ b/apps/axctl/src/ingest/github-pr-stage.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer, Schema } from "effect";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import { GithubPrKey, githubPrStage, ingestGithubPrs } from "./github-pr-stage.ts";
+import { GithubPrKey, githubPrStage, ingestGithubPrs, resolveFetchCooldownMs } from "./github-pr-stage.ts";
 
 /**
  * Build a mock SurrealClient that captures every issued SQL string. The
@@ -10,13 +10,16 @@ import { GithubPrKey, githubPrStage, ingestGithubPrs } from "./github-pr-stage.t
  */
 const makeMockDb = (
     captured: string[],
-    overrides?: { repoRows?: unknown; commitRows?: unknown; producedRows?: unknown },
+    overrides?: { repoRows?: unknown; commitRows?: unknown; producedRows?: unknown; watermarkRows?: unknown },
 ): SurrealClientShape => ({
     query: <T extends unknown[]>(sql: string) =>
         Effect.sync(() => {
             captured.push(sql);
             if (sql.includes("FROM repository")) {
                 return (overrides?.repoRows ?? [[]]) as T;
+            }
+            if (sql.includes("FROM ingest_file_state")) {
+                return (overrides?.watermarkRows ?? [[]]) as T;
             }
             if (sql.includes("FROM commit")) {
                 return (overrides?.commitRows ?? [["commit:`c1`"]]) as T;
@@ -100,6 +103,7 @@ describe("ingestGithubPrs", () => {
         expect(totals).toEqual({
             repositoriesScanned: 0,
             repositoriesDegraded: 0,
+            repositoriesSkippedCooldown: 0,
             pullRequests: 0,
             reviews: 0,
             checks: 0,
@@ -215,5 +219,111 @@ describe("ingestGithubPrs", () => {
         expect(totals.pullRequests).toBe(1); // only the healthy repo wrote
         const prStmts = sql.filter((s) => s.includes("UPSERT pull_request:"));
         expect(prStmts.every((s) => s.includes("repository:`ok`"))).toBe(true);
+    });
+});
+
+describe("fetch cooldown", () => {
+    const repoRows = [
+        [{ id: "repository:`r1`", root_path: "/tmp/x", remote_url: "https://github.com/o/r" }],
+    ];
+    const NOW = 1_750_000_000_000;
+    const COOLDOWN = 15 * 60 * 1000;
+
+    test("skips a repo whose last successful fetch is within the cooldown", async () => {
+        const sql: string[] = [];
+        const db = makeMockDb(sql, {
+            repoRows,
+            watermarkRows: [[{ path: "__github_pr_fetch__//tmp/x", mtime_ms: NOW - 60_000 }]],
+        });
+        let fetchCalls = 0;
+
+        const totals = await run(
+            {
+                fetchCooldownMs: COOLDOWN,
+                now: () => NOW,
+                fetchImpl: () => {
+                    fetchCalls += 1;
+                    return Effect.succeed({ ok: true, prs: [] });
+                },
+            },
+            db,
+        );
+
+        expect(fetchCalls).toBe(0);
+        expect(totals.repositoriesScanned).toBe(1);
+        expect(totals.repositoriesSkippedCooldown).toBe(1);
+    });
+
+    test("fetches when the watermark is older than the cooldown, and advances it", async () => {
+        const sql: string[] = [];
+        const db = makeMockDb(sql, {
+            repoRows,
+            watermarkRows: [[{ path: "__github_pr_fetch__//tmp/x", mtime_ms: NOW - COOLDOWN - 1 }]],
+        });
+        let fetchCalls = 0;
+
+        const totals = await run(
+            {
+                fetchCooldownMs: COOLDOWN,
+                now: () => NOW,
+                fetchImpl: () => {
+                    fetchCalls += 1;
+                    return Effect.succeed({ ok: true, prs: [] });
+                },
+            },
+            db,
+        );
+
+        expect(fetchCalls).toBe(1);
+        expect(totals.repositoriesSkippedCooldown).toBe(0);
+        const wm = sql.find((s) => s.includes("UPSERT ingest_file_state:") && s.includes("github-pr:fetch"));
+        expect(wm).toBeDefined();
+        expect(wm!).toContain(`mtime_ms: ${NOW}`);
+        expect(wm!).toContain('"__github_pr_fetch__//tmp/x"');
+    });
+
+    test("a degraded fetch does NOT advance the watermark (retries next run)", async () => {
+        const sql: string[] = [];
+        const db = makeMockDb(sql, { repoRows });
+
+        const totals = await run(
+            {
+                fetchCooldownMs: COOLDOWN,
+                now: () => NOW,
+                fetchImpl: () => Effect.succeed({ ok: false, prs: [], detail: "gh pr list timed out" }),
+            },
+            db,
+        );
+
+        expect(totals.repositoriesDegraded).toBe(1);
+        const wm = sql.find((s) => s.includes("UPSERT ingest_file_state:"));
+        expect(wm).toBeUndefined();
+    });
+
+    test("cooldown disabled (0/absent) → no watermark read, every repo fetched", async () => {
+        const sql: string[] = [];
+        const db = makeMockDb(sql, { repoRows });
+        let fetchCalls = 0;
+
+        await run(
+            {
+                fetchImpl: () => {
+                    fetchCalls += 1;
+                    return Effect.succeed({ ok: true, prs: [] });
+                },
+            },
+            db,
+        );
+
+        expect(fetchCalls).toBe(1);
+        expect(sql.some((s) => s.includes("SELECT path, mtime_ms FROM ingest_file_state"))).toBe(false);
+    });
+
+    test("resolveFetchCooldownMs: default 15m, env seconds override, 0 disables, junk falls back", () => {
+        expect(resolveFetchCooldownMs({})).toBe(15 * 60 * 1000);
+        expect(resolveFetchCooldownMs({ AX_GITHUB_PR_FETCH_COOLDOWN_SECONDS: "60" })).toBe(60_000);
+        expect(resolveFetchCooldownMs({ AX_GITHUB_PR_FETCH_COOLDOWN_SECONDS: "0" })).toBe(0);
+        expect(resolveFetchCooldownMs({ AX_GITHUB_PR_FETCH_COOLDOWN_SECONDS: "nope" })).toBe(15 * 60 * 1000);
+        expect(resolveFetchCooldownMs({ AX_GITHUB_PR_FETCH_COOLDOWN_SECONDS: "-5" })).toBe(15 * 60 * 1000);
     });
 });

--- a/apps/axctl/src/ingest/github-pr-stage.ts
+++ b/apps/axctl/src/ingest/github-pr-stage.ts
@@ -16,6 +16,7 @@ import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { recordLiteral } from "@ax/lib/ids";
 import { surrealString } from "@ax/lib/shared/surql";
+import { watermarkRecordKey } from "@ax/lib/shared/watermark";
 import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
 import { fetchPullRequests, type PrFetchInput, type PrFetchResult } from "./github-pr-fetch.ts";
@@ -28,10 +29,37 @@ export type GithubPrKey = typeof GithubPrKey.Type;
  *  subprocess + a write batch; serial was the multi-repo stall shape). */
 const FETCH_CONCURRENCY = 4;
 
+/**
+ * Per-repo fetch cooldown for INCREMENTAL runs (the daemon's `--since=1`
+ * path fires on every transcript change; PRs do not move that fast). A repo
+ * whose last successful `gh` fetch is younger than the cooldown is skipped
+ * this run. Degraded fetches never advance the watermark, so failures retry
+ * on the next ingest. Full re-ingests (epoch-zero `since` sentinel) bypass
+ * the cooldown entirely. Tune via `AX_GITHUB_PR_FETCH_COOLDOWN_SECONDS`
+ * (`0` disables).
+ */
+const DEFAULT_FETCH_COOLDOWN_MS = 15 * 60 * 1000;
+const FETCH_COOLDOWN_ENV = "AX_GITHUB_PR_FETCH_COOLDOWN_SECONDS";
+
+/** `ingest_file_state` bookkeeping for the per-repo fetch watermark. The
+ *  `path` column is table-UNIQUE, hence the namespacing prefix (same trick as
+ *  `__pr_merge__/` in metrics/pr-merge-dirty). Last fetch time lives in
+ *  `mtime_ms`. */
+const COOLDOWN_SOURCE = "github-pr:fetch";
+const cooldownPath = (rootPath: string): string => `__github_pr_fetch__/${rootPath}`;
+
+export const resolveFetchCooldownMs = (env: NodeJS.ProcessEnv = process.env): number => {
+    const raw = env[FETCH_COOLDOWN_ENV];
+    if (raw === undefined || raw === "") return DEFAULT_FETCH_COOLDOWN_MS;
+    const secs = Number(raw);
+    return Number.isFinite(secs) && secs >= 0 ? secs * 1000 : DEFAULT_FETCH_COOLDOWN_MS;
+};
+
 /** Stats reported by the github-pr stage. */
 export class GithubPrStageStats extends BaseStageStats.extend<GithubPrStageStats>("GithubPrStageStats")({
     repositoriesScanned: Schema.Number,
     repositoriesDegraded: Schema.Number,
+    repositoriesSkippedCooldown: Schema.Number,
     pullRequestsIngested: Schema.Number,
     reviewsIngested: Schema.Number,
     checksIngested: Schema.Number,
@@ -53,6 +81,14 @@ export interface GithubPrIngestDeps {
      * fetch (forced full re-ingest / epoch-zero sentinel).
      */
     readonly updatedSince?: string;
+    /**
+     * Skip repos whose last successful fetch is younger than this (ms).
+     * `0`/absent → no cooldown. The stage passes a non-zero value only on
+     * incremental runs; tests inject directly.
+     */
+    readonly fetchCooldownMs?: number;
+    /** Injectable clock for cooldown tests. */
+    readonly now?: () => number;
 }
 
 /**
@@ -72,6 +108,9 @@ interface GithubPrTotals {
     /** Repos whose `gh` fetch failed (timeout/auth/network) - logged as a
      *  degraded-stage warning, NOT silently treated as "no PRs". */
     repositoriesDegraded: number;
+    /** Repos skipped this run because their last successful fetch is within
+     *  the cooldown window (incremental runs only). */
+    repositoriesSkippedCooldown: number;
     pullRequests: number;
     reviews: number;
     checks: number;
@@ -114,10 +153,37 @@ export const ingestGithubPrs = (
         >(
             `SELECT type::string(id) AS id, root_path, remote_url FROM repository WHERE remote_url != NONE AND remote_url CONTAINS "github" AND root_path != NONE${repoPathFilter};`,
         );
-        const repos = (repoRows?.[0] ?? []).filter(
+        const allRepos = (repoRows?.[0] ?? []).filter(
             (r): r is typeof r & { root_path: string } =>
                 typeof r.root_path === "string" && r.root_path.length > 0,
         );
+
+        // Cooldown partition: drop repos whose last SUCCESSFUL fetch is
+        // younger than the window. One small indexed-source_kind read; the
+        // watermark advances only after a non-degraded fetch (below), so
+        // degraded repos stay hot and retry next run.
+        const cooldownMs = deps?.fetchCooldownMs ?? 0;
+        const now = deps?.now ?? Date.now;
+        let skippedCooldown = 0;
+        let repos = allRepos;
+        if (cooldownMs > 0 && allRepos.length > 0) {
+            const wmRows = yield* db.query<[Array<{ path: string; mtime_ms: number | null }>]>(
+                `SELECT path, mtime_ms FROM ingest_file_state WHERE source_kind = ${surrealString(COOLDOWN_SOURCE)};`,
+            );
+            const lastFetch = new Map<string, number>();
+            for (const row of wmRows?.[0] ?? []) {
+                if (typeof row.mtime_ms === "number") lastFetch.set(row.path, row.mtime_ms);
+            }
+            const cutoff = now() - cooldownMs;
+            repos = allRepos.filter((r) => {
+                const last = lastFetch.get(cooldownPath(r.root_path));
+                if (last !== undefined && last > cutoff) {
+                    skippedCooldown += 1;
+                    return false;
+                }
+                return true;
+            });
+        }
 
         // Bounded-concurrency per-repo fetch+write. Each fetch is hard-bounded
         // by the fetcher's kill timeout, and (when the caller passed
@@ -143,18 +209,25 @@ export const ingestGithubPrs = (
                         });
                         return { degraded: true as const, pullRequests: 0, reviews: 0, checks: 0, deliveryOutcomes: 0 };
                     }
-                    if (fetched.prs.length === 0) {
-                        return { degraded: false as const, pullRequests: 0, reviews: 0, checks: 0, deliveryOutcomes: 0 };
-                    }
-                    const stats = yield* writePullRequests({ repositoryId, repositoryKey: key, prs: fetched.prs });
+                    const stats =
+                        fetched.prs.length === 0
+                            ? { pullRequests: 0, reviews: 0, checks: 0, deliveryOutcomes: 0 }
+                            : yield* writePullRequests({ repositoryId, repositoryKey: key, prs: fetched.prs });
+                    // Successful fetch (even 0 PRs - gh ran clean): advance the
+                    // per-repo cooldown watermark.
+                    const wmPath = cooldownPath(repo.root_path);
+                    yield* db.query(
+                        `UPSERT ${recordLiteral("ingest_file_state", watermarkRecordKey(COOLDOWN_SOURCE, wmPath))} CONTENT { path: ${surrealString(wmPath)}, source_kind: ${surrealString(COOLDOWN_SOURCE)}, mtime_ms: ${Math.trunc(now())}, ingested_at: time::now() };`,
+                    );
                     return { degraded: false as const, ...stats };
                 }),
             { concurrency: FETCH_CONCURRENCY },
         );
 
         const totals: GithubPrTotals = {
-            repositoriesScanned: repos.length,
+            repositoriesScanned: allRepos.length,
             repositoriesDegraded: 0,
+            repositoriesSkippedCooldown: skippedCooldown,
             pullRequests: 0,
             reviews: 0,
             checks: 0,
@@ -186,16 +259,23 @@ export const githubPrStage: StageDef<GithubPrStageStats, SurrealClient> = {
             // fetch; otherwise bound the gh search to the ingest window (the
             // date floor of `since` is inclusive-safe for `updated:>=`).
             const updatedSince = ctx.since.getTime() > 0 ? ctx.since.toISOString().slice(0, 10) : undefined;
+            // Cooldown only applies to incremental runs - a forced full
+            // re-ingest must always hit the network.
+            const fetchCooldownMs = updatedSince === undefined ? 0 : resolveFetchCooldownMs();
             const result = yield* ingestGithubPrs({
                 ...(ctx.repoPaths === undefined ? {} : { repoPaths: ctx.repoPaths }),
                 ...(updatedSince === undefined ? {} : { updatedSince }),
+                fetchCooldownMs,
             });
             const degraded = result.repositoriesDegraded > 0 ? ` (${result.repositoriesDegraded} degraded)` : "";
+            const cooled =
+                result.repositoriesSkippedCooldown > 0 ? ` (${result.repositoriesSkippedCooldown} on cooldown)` : "";
             return GithubPrStageStats.make({
                 durationMs: Date.now() - t0,
-                summary: `ingested ${result.pullRequests} PRs from ${result.repositoriesScanned} repos${degraded}`,
+                summary: `ingested ${result.pullRequests} PRs from ${result.repositoriesScanned} repos${cooled}${degraded}`,
                 repositoriesScanned: result.repositoriesScanned,
                 repositoriesDegraded: result.repositoriesDegraded,
+                repositoriesSkippedCooldown: result.repositoriesSkippedCooldown,
                 pullRequestsIngested: result.pullRequests,
                 reviewsIngested: result.reviews,
                 checksIngested: result.checks,


### PR DESCRIPTION
## What

Two follow-ups from dogfooding the v0.20.0 metrics ingest in Maple (local OTLP viewer):

1. **github-pr per-repo fetch cooldown** — github-pr was the slowest non-parser stage on the daemon's `--since=1` path (~20s of `gh` spawns per transcript change). Incremental runs now skip repos whose last *successful* fetch is younger than `AX_GITHUB_PR_FETCH_COOLDOWN_SECONDS` (default 15m, `0` disables) via a per-repo `ingest_file_state` watermark (`github-pr:fetch`, `__github_pr_fetch__/<root>` — path-unique-safe). Degraded fetches never advance the watermark (retry next run); full re-ingests (epoch-zero `since` sentinel) bypass the cooldown.

2. **`AX_OTLP_URL` passthrough in `axctl install`** — when set at install time, the generated watcher/derive plists carry it, so background ingests export traces to a local OTLP collector (Maple/Jaeger) without hand-editing plists. Re-install without the env removes it.

## Verification

- 30 stage tests pass (5 new cooldown cases: skip-within-window, fetch+advance, degraded-no-advance, disabled, env parsing); repo-wide 2572 pass / 0 fail; typecheck 0 errors
- Live: first `--since=1` run wrote 13 watermarks + 210 PRs; second run fetched nothing (all repos on cooldown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)