### PR TITLE
design(studio): spacing scale, palette consolidation, a11y floors, hierarchy

### DIFF
--- a/apps/studio/src/routes/inspector-filter-bar.tsx
+++ b/apps/studio/src/routes/inspector-filter-bar.tsx
@@ -69,9 +69,9 @@ export function FilterBar({
     const quickFilters: ReadonlyArray<QuickFilter> = useMemo(() => [
         { key: "correction",     label: "next correction",  pred: isCorrectionTurn },
         { key: "spawn",          label: "next spawn",       pred: (t) => isSpawnAnchorTurn(t, anchorSeqs) },
-        { key: "tool_use",       label: "next tool_use",    pred: (t) => isRoleTurn(t, "tool_use") },
-        { key: "tool_result",    label: "next tool_result", pred: (t) => isRoleTurn(t, "tool_result") },
-        { key: "hook_injection", label: "next hook ctx",    pred: (t) => isRoleTurn(t, "hook_injection") },
+        { key: "tool_use",       label: "next tool call",    pred: (t) => isRoleTurn(t, "tool_use") },
+        { key: "tool_result",    label: "next tool result", pred: (t) => isRoleTurn(t, "tool_result") },
+        { key: "hook_injection", label: "next hook context",    pred: (t) => isRoleTurn(t, "hook_injection") },
     ], [anchorSeqs]);
 
     // "next hook fire" jumps among the spliced hook_fire markers - those have
@@ -179,12 +179,15 @@ export function FilterBar({
     };
 
     const btnStyle = (enabled: boolean): React.CSSProperties => ({
-        padding: "3px 10px",
-        fontSize: 11,
+        padding: "6px 10px",
+        fontSize: 12,
         fontFamily: "ui-monospace, monospace",
-        border: "1px solid #e2e8f0",
-        background: enabled ? "#fff" : "#f1f5f9",
-        color: enabled ? "#475569" : "#94a3b8",
+        border: "1px solid var(--line)",
+        background: enabled ? "var(--panel)" : "var(--page)",
+        // Disabled buttons still carry content (match counts) - dim with
+        // opacity, keep the text readable.
+        color: "var(--muted)",
+        opacity: enabled ? 1 : 0.55,
         borderRadius: 4,
         cursor: enabled ? "pointer" : "not-allowed",
     });
@@ -193,11 +196,10 @@ export function FilterBar({
         <div className="filter-bar" style={{
             position: "sticky", top: 0, zIndex: 10,
             display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center",
-            padding: "6px 24px", borderTop: "1px solid #e2e8f0", background: "#f8fafc",
-            borderBottom: "1px solid #e2e8f0",
+            padding: "6px var(--strip-x)", borderTop: "1px solid var(--line)", background: "var(--page)",
+            borderBottom: "1px solid var(--line)",
             fontFamily: "ui-monospace, monospace", fontSize: 11,
         }}>
-            <span style={{ color: "#64748b", marginRight: 4 }}>jump:</span>
             {(() => {
                 const hasLoaded = hookFireIdxs.length > 0;
                 const canDiscoverMore = loadedCount < totalCount && totalHookFires > 0;
@@ -214,7 +216,7 @@ export function FilterBar({
                         onClick={() => { void jumpNextHookFire(); }}
                         disabled={!enabled}
                         title={title}
-                        style={{ ...btnStyle(enabled), borderLeft: "3px solid #10b981" }}
+                        style={{ ...btnStyle(enabled), borderLeft: "3px solid var(--green)" }}
                     >
                         next hook fire{count}
                     </button>
@@ -253,10 +255,11 @@ export function FilterBar({
                     onChange={(e) => setSearchInput(e.target.value)}
                     onKeyDown={onSearchKeyDown}
                     placeholder="find in turns (Enter to jump)…"
+                    aria-label="find in turns"
                     style={{
-                        flex: 1, padding: "3px 8px", fontSize: 11, fontFamily: "inherit",
-                        border: "1px solid #e2e8f0", borderRadius: 4, background: "#fff",
-                        color: "#1f2937", minWidth: 0,
+                        flex: 1, padding: "6px 8px", fontSize: 13, fontFamily: "inherit",
+                        border: "1px solid var(--line)", borderRadius: 4, background: "var(--panel)",
+                        color: "var(--ink)", minWidth: 0,
                     }}
                 />
                 <button
@@ -269,7 +272,7 @@ export function FilterBar({
                     next
                 </button>
                 {searchQuery.trim().length > 0 ? (
-                    <span style={{ color: searchSeqs.length > 0 ? "#475569" : "#ef4444" }}>
+                    <span style={{ color: searchSeqs.length > 0 ? "var(--muted)" : "var(--red)" }}>
                         {searchSeqs.length > 0
                             ? `${searchSeqs.length} hit${searchSeqs.length === 1 ? "" : "s"}`
                             : (fullyLoaded ? "no hits" : "no hits in loaded window")}

--- a/apps/studio/src/routes/session-inspect.tsx
+++ b/apps/studio/src/routes/session-inspect.tsx
@@ -17,18 +17,29 @@ import { Transcript } from "./transcript.tsx";
 import type { InspectContentAtomDto, InspectContentBlockDto, InspectTurnContentDto } from "@ax/lib/shared/dashboard-types";
 
 interface KindStyle { bg: string; fg: string; bar: string; label: string }
+
+/** One tone recipe off the calibrated root accents: tinted bg, ink-anchored
+ *  dark fg (always readable on the tint), the raw accent as the bar. Two
+ *  kinds in the same family differ by bg strength (call 14% vs result 7%). */
+const tone = (accent: string, bgPct: number, label: string): KindStyle => ({
+    bg: `color-mix(in srgb, ${accent} ${bgPct}%, var(--panel))`,
+    fg: `color-mix(in srgb, ${accent} 45%, var(--ink))`,
+    bar: accent,
+    label,
+});
+
 export const KIND_STYLE: Record<InspectSpanKind, KindStyle> = {
-    user_input:            { bg: "#fef9c3", fg: "#78350f", bar: "#eab308", label: "user input" },
-    assistant_text:        { bg: "#f3f4f6", fg: "var(--ink)", bar: "var(--ink)", label: "assistant text" },
-    tool_use:              { bg: "#ede9fe", fg: "#4c1d95", bar: "#8b5cf6", label: "tool use" },
-    skill_context:         { bg: "#dbeafe", fg: "#1e3a8a", bar: "var(--blue)", label: "skill" },
-    system_context:        { bg: "#e5e7eb", fg: "#1f2937", bar: "var(--muted)", label: "system" },
-    wrapper_instruction:   { bg: "#fde68a", fg: "#92400e", bar: "#f59e0b", label: "wrapper" },
-    hook_injection:        { bg: "#bbf7d0", fg: "#065f46", bar: "#10b981", label: "hook" },
-    tool_result:           { bg: "#e9d5ff", fg: "#5b21b6", bar: "#a855f7", label: "tool result" },
-    subagent_notification: { bg: "#fed7aa", fg: "#9a3412", bar: "#f97316", label: "subagent notif" },
-    subagent_task:         { bg: "#ffe4e6", fg: "#9f1239", bar: "#e11d48", label: "subagent task" },
-    pasted_reference:      { bg: "#fecaca", fg: "#7f1d1d", bar: "#ef4444", label: "pasted" },
+    user_input:            tone("var(--gold)", 12, "user input"),
+    assistant_text:        { bg: "var(--track)", fg: "var(--ink)", bar: "var(--ink)", label: "assistant text" },
+    tool_use:              tone("var(--violet)", 14, "tool use"),
+    skill_context:         tone("var(--blue)", 12, "skill"),
+    system_context:        { bg: "var(--track)", fg: "var(--ink)", bar: "var(--muted)", label: "system" },
+    wrapper_instruction:   tone("var(--gold)", 26, "wrapper"),
+    hook_injection:        tone("var(--green)", 14, "hook"),
+    tool_result:           tone("var(--violet)", 7, "tool result"),
+    subagent_notification: tone("var(--rose)", 7, "subagent notif"),
+    subagent_task:         tone("var(--rose)", 14, "subagent task"),
+    pasted_reference:      tone("var(--red)", 12, "pasted"),
 };
 
 const JUMP_TARGET_SCROLL_MARGIN = 76;
@@ -114,9 +125,9 @@ function totalBreakdownCost(usage: SessionTokenUsageDetail): number {
 function costBarSegments(usage: SessionTokenUsageDetail): ReadonlyArray<{ label: string; value: number | null; color: string }> {
     return [
         { label: "fresh input", value: numberOrNull(usage.estimated_input_cost_usd), color: "var(--blue)" },
-        { label: "cache write", value: numberOrNull(usage.estimated_cache_creation_cost_usd), color: "#f59e0b" },
-        { label: "cache read", value: numberOrNull(usage.estimated_cache_read_cost_usd), color: "#10b981" },
-        { label: "output", value: numberOrNull(usage.estimated_output_cost_usd), color: "#8b5cf6" },
+        { label: "cache write", value: numberOrNull(usage.estimated_cache_creation_cost_usd), color: "var(--gold)" },
+        { label: "cache read", value: numberOrNull(usage.estimated_cache_read_cost_usd), color: "var(--green)" },
+        { label: "output", value: numberOrNull(usage.estimated_output_cost_usd), color: "var(--violet)" },
     ];
 }
 
@@ -195,7 +206,7 @@ function blockFamily(kind: string): ContentTone {
     if (kind.includes("budget") || kind.includes("metric")) return { bg: "#ffedd5", fg: "#9a3412", bar: "#f97316", label: "budget" };
     if (kind.includes("assistant")) return { bg: "#cffafe", fg: "#155e75", bar: "#06b6d4", label: "assistant" };
     if (kind.includes("tool")) return { bg: "#ede9fe", fg: "#4c1d95", bar: "#8b5cf6", label: "tool" };
-    if (kind.includes("hook")) return { bg: "#bbf7d0", fg: "#065f46", bar: "#10b981", label: "hook" };
+    if (kind.includes("hook")) return { bg: "color-mix(in srgb, var(--green) 14%, var(--panel))", fg: "color-mix(in srgb, var(--green) 45%, var(--ink))", bar: "var(--green)", label: "hook" };
     if (kind.includes("code")) return { bg: "var(--track)", fg: "var(--ink)", bar: "var(--muted)", label: "code" };
     if (kind.includes("heading")) return { bg: "#fee2e2", fg: "#991b1b", bar: "#ef4444", label: "heading" };
     if (kind.includes("paragraph")) return { bg: "#fef9c3", fg: "#78350f", bar: "#eab308", label: "paragraph" };
@@ -310,10 +321,10 @@ function atomDisplayLabel(atom: InspectContentAtomDto): string {
 
 function atomTone(atom: InspectContentAtomDto): ContentTone {
     if (atom.kind === "section_alias") return ALIAS_STYLE[atom.value] ?? ALIAS_STYLE.reference;
-    if (atom.kind.includes("file")) return { bg: "#eff6ff", fg: "#1d4ed8", bar: "var(--blue)", label: "file" };
-    if (atom.kind.includes("url") || atom.kind.includes("citation")) return { bg: "#ecfeff", fg: "#0e7490", bar: "#06b6d4", label: "link" };
-    if (atom.kind.includes("symbol")) return { bg: "#f0fdf4", fg: "#15803d", bar: "#22c55e", label: "symbol" };
-    if (atom.kind.includes("command")) return { bg: "#fef3c7", fg: "#92400e", bar: "#f59e0b", label: "command" };
+    if (atom.kind.includes("file")) return { bg: "color-mix(in srgb, var(--blue) 8%, var(--panel))", fg: "color-mix(in srgb, var(--blue) 55%, var(--ink))", bar: "var(--blue)", label: "file" };
+    if (atom.kind.includes("url") || atom.kind.includes("citation")) return { bg: "color-mix(in srgb, var(--blue) 6%, var(--panel))", fg: "color-mix(in srgb, var(--blue) 45%, var(--ink))", bar: "var(--blue)", label: "link" };
+    if (atom.kind.includes("symbol")) return { bg: "color-mix(in srgb, var(--green) 8%, var(--panel))", fg: "color-mix(in srgb, var(--green) 45%, var(--ink))", bar: "var(--green)", label: "symbol" };
+    if (atom.kind.includes("command")) return { bg: "color-mix(in srgb, var(--gold) 18%, var(--panel))", fg: "color-mix(in srgb, var(--gold) 45%, var(--ink))", bar: "var(--gold)", label: "command" };
     return { bg: "var(--page)", fg: "var(--ink)", bar: "var(--muted-2)", label: blockLabel(atom.kind) };
 }
 
@@ -330,9 +341,10 @@ function AliasMiniMap({
         .map((block) => ({ block, alias: primarySectionAlias(block) }))
         .filter((entry): entry is { block: InspectContentBlockDto; alias: InspectContentAtomDto } => entry.alias !== null);
     const hasStructuralAlias = aliasBlocks.some((entry) => entry.alias.value !== "reference");
-    const blocks = hasStructuralAlias
-        ? aliasBlocks.filter((entry) => entry.alias.value !== "reference")
-        : aliasBlocks;
+    // A reference-only turn would render an all-grey strip that first-time
+    // readers parse as a skeleton loader or redaction - show nothing instead.
+    if (!hasStructuralAlias) return null;
+    const blocks = aliasBlocks.filter((entry) => entry.alias.value !== "reference");
     if (blocks.length === 0) return null;
 
     return (
@@ -360,6 +372,7 @@ function AliasMiniMap({
                         onMouseEnter={() => setActiveTarget(target)}
                         onClick={() => setActiveTarget(target)}
                         title={aliasTitle(alias)}
+                        aria-label={aliasTitle(alias)}
                         style={{
                             flex: `${width} 1 10px`,
                             minWidth: 8,
@@ -452,7 +465,7 @@ export function InspectGuide({ data }: { data: Pick<SessionInspectPayload, "tota
         <div style={{
             margin: "4px 24px 10px",
             padding: "8px 10px",
-            border: "1px solid #cfd8d4",
+            border: "1px solid var(--line)",
             background: "var(--page)",
             display: "grid",
             gap: 7,
@@ -480,8 +493,8 @@ export function InspectGuide({ data }: { data: Pick<SessionInspectPayload, "tota
                 title={`Cost mix by provider billing component. Pricing: ${usage.pricing_source ?? "unknown"}. Per-turn headers below use turn usage when available; inspector block/span cost is character-allocated within the selected turn.`}
                 style={{
                     height: 8,
-                    border: "1px solid #cfd8d4",
-                    background: gradient ? `linear-gradient(90deg, ${gradient})` : "#e5e7eb",
+                    border: "1px solid var(--line)",
+                    background: gradient ? `linear-gradient(90deg, ${gradient})` : "var(--track)",
                 }}
             />
             <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
@@ -490,7 +503,7 @@ export function InspectGuide({ data }: { data: Pick<SessionInspectPayload, "tota
                         key={segment.label}
                         title={`${segment.label}: ${fmtUsd(segment.value)} (${pctOf(segment.value, breakdownTotal || totalCost)} of known cost components)`}
                         style={{
-                            background: "#fff",
+                            background: "var(--panel)",
                             color: "var(--ink)",
                             border: "1px solid var(--line)",
                             borderLeft: `3px solid ${segment.color}`,
@@ -804,7 +817,7 @@ function AnnotatedRawText({
             overflow: "auto",
             whiteSpace: "pre-wrap",
             wordBreak: "break-word",
-            font: "11px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace",
+            font: "12.5px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace",
             background: "#fff",
         }}>
             {rawParts.length > 0 ? rawParts : rawText}
@@ -1075,9 +1088,9 @@ function SpawnMarker({ child }: { child: SpawnChildDto }) {
 
     return (
         <div onMouseEnter={onIntent} onFocus={onIntent} style={{
-            margin: "4px 0", padding: "7px 10px", background: "#fff1f2",
-            border: "1px solid #fecdd3", borderLeft: "4px solid #e11d48", borderRadius: 3, fontSize: 11,
-            fontFamily: "ui-monospace, monospace", color: "#9f1239",
+            margin: "4px 0", padding: "7px 10px", background: "color-mix(in srgb, var(--rose) 8%, var(--panel))",
+            border: "1px solid color-mix(in srgb, var(--rose) 25%, var(--panel))", borderLeft: "4px solid var(--rose)", borderRadius: 3, fontSize: 11,
+            fontFamily: "ui-monospace, monospace", color: "var(--rose)",
         }}>
             <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
                 <span style={{ fontWeight: 700 }}>↳ child session spawned</span>
@@ -1085,13 +1098,13 @@ function SpawnMarker({ child }: { child: SpawnChildDto }) {
                     to="/sessions/$sessionId/inspect"
                     params={{ sessionId: childBare }}
                     preload="intent"
-                    style={{ color: "#9f1239", fontWeight: 600 }}
+                    style={{ color: "var(--rose)", fontWeight: 600 }}
                 >
                     {child.nickname ? `"${child.nickname}"` : `${childBare.slice(0, 12)}…`}
                 </Link>
                 {child.nickname ? <span style={{ opacity: 0.6 }}>{childBare.slice(0, 10)}…</span> : null}
                 {child.tool ? <span style={{ opacity: 0.6 }}>via {child.tool}</span> : null}
-                {m ? <span style={{ background: "#fecdd3", color: "#7f1d1d", padding: "0 6px", borderRadius: 2, fontSize: 10, fontWeight: 600 }}>{m.provider}</span> : null}
+                {m ? <span style={{ background: "color-mix(in srgb, var(--rose) 25%, var(--panel))", color: "color-mix(in srgb, var(--rose) 45%, var(--ink))", padding: "0 6px", borderRadius: 2, fontSize: 10, fontWeight: 600 }}>{m.provider}</span> : null}
                 {chips.map((c) => (
                     <span key={c.label} style={{ background: "#fee2e2", padding: "0 6px", borderRadius: 2, fontSize: 10 }}>
                         {c.label}: <strong>{c.value}</strong>
@@ -1105,7 +1118,7 @@ function SpawnMarker({ child }: { child: SpawnChildDto }) {
                 </div>
             ) : null}
             {brief ? (
-                <div style={{ marginTop: 4, color: "#7f1d1d", opacity: 0.9, fontSize: 11, lineHeight: 1.5, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+                <div style={{ marginTop: 4, color: "color-mix(in srgb, var(--rose) 45%, var(--ink))", opacity: 0.9, fontSize: 11, lineHeight: 1.5, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
                     <span style={{ fontStyle: "italic" }}>
                         “{expanded || !briefIsLong ? brief : `${brief.slice(0, briefClippedLen - 1)}…`}”
                     </span>
@@ -1114,8 +1127,8 @@ function SpawnMarker({ child }: { child: SpawnChildDto }) {
                             onClick={() => setExpanded((v) => !v)}
                             style={{
                                 marginLeft: 6, padding: "0 6px", fontSize: 10, fontFamily: "inherit",
-                                background: "transparent", border: "1px solid #fecdd3", borderRadius: 3,
-                                color: "#9f1239", cursor: "pointer",
+                                background: "transparent", border: "1px solid color-mix(in srgb, var(--rose) 25%, var(--panel))", borderRadius: 3,
+                                color: "var(--rose)", cursor: "pointer",
                             }}
                         >
                             {expanded ? "show less" : `show full (${brief.length.toLocaleString()}c)`}
@@ -1134,8 +1147,8 @@ function SpawnMarker({ child }: { child: SpawnChildDto }) {
  *  that landed in the agent's context window. */
 export function HookFireMarker({ hook }: { hook: HookFireDto }) {
     const ts = hook.ts ? new Date(hook.ts).toISOString().slice(11, 19) : "";
-    const injectBg = hook.inject ? "#bbf7d0" : "var(--line)";
-    const injectFg = hook.inject ? "#065f46" : "var(--muted)";
+    const injectBg = hook.inject ? "color-mix(in srgb, var(--green) 14%, var(--panel))" : "var(--line)";
+    const injectFg = hook.inject ? "color-mix(in srgb, var(--green) 45%, var(--ink))" : "var(--muted)";
     const filePathShort = hook.file_path.length > 60
         ? `…${hook.file_path.slice(-58)}`
         : hook.file_path;
@@ -1147,9 +1160,9 @@ export function HookFireMarker({ hook }: { hook: HookFireDto }) {
                 margin: "4px 24px", padding: "6px 10px",
                 scrollMarginTop: JUMP_TARGET_SCROLL_MARGIN,
                 borderLeft: "3px solid #10b981",
-                background: hook.inject ? "#ecfdf5" : "var(--page)",
+                background: hook.inject ? "color-mix(in srgb, var(--green) 8%, var(--panel))" : "var(--page)",
                 borderRadius: 3, fontSize: 11,
-                fontFamily: "ui-monospace, monospace", color: "#065f46",
+                fontFamily: "ui-monospace, monospace", color: "color-mix(in srgb, var(--green) 45%, var(--ink))",
             }}
         >
             <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
@@ -1157,10 +1170,10 @@ export function HookFireMarker({ hook }: { hook: HookFireDto }) {
                 <span style={{ background: injectBg, color: injectFg, padding: "0 6px", borderRadius: 2, fontSize: 10, fontWeight: 600 }}>
                     inject: {hook.inject ? "yes" : "no"}
                 </span>
-                <span style={{ background: "#e0e7ff", color: "#3730a3", padding: "0 6px", borderRadius: 2, fontSize: 10 }}>
+                <span style={{ background: "color-mix(in srgb, var(--blue) 14%, var(--panel))", color: "color-mix(in srgb, var(--blue) 45%, var(--ink))", padding: "0 6px", borderRadius: 2, fontSize: 10 }}>
                     event: <strong>{hook.event}</strong>
                 </span>
-                <span style={{ background: "#fef3c7", color: "#92400e", padding: "0 6px", borderRadius: 2, fontSize: 10 }}>
+                <span style={{ background: "color-mix(in srgb, var(--gold) 18%, var(--panel))", color: "color-mix(in srgb, var(--gold) 45%, var(--ink))", padding: "0 6px", borderRadius: 2, fontSize: 10 }}>
                     reason: <strong>{hook.reason}</strong>
                 </span>
                 <span style={{ color: "var(--muted)", fontSize: 10 }}>{hook.latency_ms}ms</span>
@@ -1170,7 +1183,7 @@ export function HookFireMarker({ hook }: { hook: HookFireDto }) {
                 {filePathShort}
             </div>
             {hook.inject && hook.injected_titles.length > 0 ? (
-                <div style={{ marginTop: 4, paddingTop: 4, borderTop: "1px dashed #a7f3d0", fontSize: 10, color: "#065f46" }}>
+                <div style={{ marginTop: 4, paddingTop: 4, borderTop: "1px dashed color-mix(in srgb, var(--green) 30%, var(--panel))", fontSize: 10, color: "color-mix(in srgb, var(--green) 45%, var(--ink))" }}>
                     <span style={{ fontWeight: 600 }}>injected memory ({hook.injected_titles.length}):</span>
                     <ul style={{ margin: "2px 0 0 16px", padding: 0 }}>
                         {hook.injected_titles.map((t, i) => (
@@ -1192,8 +1205,8 @@ export function HookFireMarker({ hook }: { hook: HookFireDto }) {
 //     3px      44px     1fr  (header + body align here)
 //
 // Horizontal padding lives on the outer container; the grid sits inside it.
-const TURN_PAD_X = 24;
-const TURN_GUTTER = 44; // fixed seq column width (was: 48 min in full / auto in tool)
+const TURN_PAD_X = 16;
+const TURN_GUTTER = 36; // fixed seq column width (was: 48 min in full / auto in tool)
 const TURN_COL_GAP = 8;
 const turnMono = "ui-monospace, SFMono-Regular, Menlo, monospace";
 
@@ -1224,7 +1237,7 @@ function TurnHeader({
     const usage = turn.token_usage ?? null;
     const cost = numberOrNull(usage?.estimated_cost_usd);
     const tok = usage ? compactTokenCount(usage) : null;
-    const dim = "#9aa3b2";
+    const dim = "var(--muted)";
     const structureTitle =
         `${turn.char_count.toLocaleString()} characters · ${turn.spans.length} classified span${turn.spans.length === 1 ? "" : "s"} from the raw transcript.`;
     return (
@@ -1247,16 +1260,16 @@ function TurnHeader({
                     title={hideRoleLabel ? undefined : `${style.label} turn`}
                     style={{ width: 6, height: 6, borderRadius: 2, background: style.bar, flex: "0 0 auto", transform: "translateY(1px)" }}
                 />
-                {hideRoleLabel ? null : <span style={{ color: style.fg, opacity: 0.85, fontWeight: 600 }}>{style.label}</span>}
+                {hideRoleLabel
+                    ? <span className="sr-only">{style.label} turn</span>
+                    : <span style={{ color: style.fg, opacity: 0.85, fontWeight: 600 }}>{style.label}</span>}
             </span>
             {ts ? <span title="Turn timestamp from the source transcript." style={{ color: dim }}>{ts}</span> : null}
             {cost !== null ? <span title={turnTokenUsageTitle(turn)} style={{ color: dim }}>{fmtUsd(cost)}</span> : null}
-            {tok ? <span title={turnTokenUsageTitle(turn)} style={{ color: dim }}>{tok} tok</span> : null}
-            {turn.char_count > 0 ? (
-                <span title={structureTitle} style={{ color: "#c2c8d2" }}>
-                    {turn.char_count > 1000 ? `${(turn.char_count / 1000).toFixed(1)}k` : turn.char_count}c
-                </span>
-            ) : null}
+            {/* Cumulative context size, not per-turn spend - label it that way.
+                Char-count was pipeline telemetry with no reader value (hover
+                still carries the structural breakdown via turnTokenUsageTitle). */}
+            {tok ? <span title={turnTokenUsageTitle(turn)} style={{ color: dim }}>{tok} ctx</span> : null}
             {extras}
             {rightSlot ? <span style={{ marginLeft: "auto", display: "inline-flex", alignItems: "baseline", gap: 6 }}>{rightSlot}</span> : null}
         </div>
@@ -1302,30 +1315,22 @@ function TurnImpl({
     };
     const s = KIND_STYLE[turn.semantic_role];
     const spawnedChildCount = childrenSpawnedHere?.length ?? 0;
-    // A surviving tool_result turn is an ORPHAN (its preceding call wasn't
-    // matched, or there was none) - paired results are merged into the call
-    // card upstream and never reach this component.
-    const jsonlBadge = turn.role !== turn.semantic_role.replace(/_text$|_input$/, "")
-        ? <span style={{ color: "var(--muted-2)", fontSize: 10 }}>(jsonl: {turn.role})</span>
-        : null;
     const spawnBadge = spawnedChildCount > 0
         ? (
             <span title={`This turn spawned ${spawnedChildCount} sub-agent session${spawnedChildCount === 1 ? "" : "s"}.`}
-                style={{ color: "#9f1239", fontWeight: 700 }}>
+                style={{ color: "var(--rose)", fontWeight: 700 }}>
                 spawn x{spawnedChildCount}
             </span>
         )
         : null;
     const inspectingBadge = turn.content && activeTarget
         ? (
-            <span title="This turn is showing in the docked inspector on the right." style={{ color: "#0f172a", fontWeight: 600 }}>
+            <span title="This turn is showing in the docked inspector on the right." style={{ color: "var(--ink)", fontWeight: 600 }}>
                 inspecting →
             </span>
         )
         : null;
-    const headerExtras = (jsonlBadge || spawnBadge)
-        ? <>{spawnBadge}{jsonlBadge}</>
-        : undefined;
+    const headerExtras = spawnBadge ? <>{spawnBadge}</> : undefined;
 
     // The `#seq` anchor lives in the fixed gutter (column 1) for EVERY turn
     // type so the content column (header + body) starts at one shared left
@@ -1336,7 +1341,7 @@ function TurnImpl({
             style={{
                 gridColumn: "1",
                 gridRow: "1",
-                color: "#aeb5c0",
+                color: "var(--muted)",
                 textDecoration: "none",
                 fontSize: 10.5,
                 lineHeight: 1.6,
@@ -1367,11 +1372,11 @@ function TurnImpl({
         display: "grid",
         gridTemplateColumns: `${TURN_GUTTER}px 1fr`,
         columnGap: TURN_COL_GAP,
-        rowGap: 3,
+        rowGap: 4,
         padding: `8px ${TURN_PAD_X}px`,
         scrollMarginTop: JUMP_TARGET_SCROLL_MARGIN,
         borderLeft: `3px solid ${s.bar}`,
-        background: anchored ? "#fef3c7" : "transparent",
+        background: anchored ? "color-mix(in srgb, var(--blue) 8%, transparent)" : "transparent",
         transition: "background 0.6s",
     };
 
@@ -1380,7 +1385,7 @@ function TurnImpl({
             <div id={`turn-${turn.seq}`} className="turn-row" title={turnTokenUsageTitle(turn)} style={gridStyle}>
                 {seqGutter}
                 <TurnHeader turn={turn} style={s} extras={headerExtras} hideRoleLabel />
-                <div style={{ gridColumn: "2", minWidth: 0 }}>
+                <div style={{ gridColumn: "2", minWidth: 0, maxWidth: "92ch" }}>
                     <ToolRow calls={turn.tool_calls!} resultFor={resultFor} skillContentFor={skillContentFor} />
                     <TurnImages paths={imagePaths} />
                 </div>
@@ -1392,7 +1397,7 @@ function TurnImpl({
         <div id={`turn-${turn.seq}`} className="turn-row" title={turnTokenUsageTitle(turn)} style={gridStyle}>
             {seqGutter}
             <TurnHeader turn={turn} style={s} extras={headerExtras} rightSlot={inspectingBadge} />
-            <div style={{ gridColumn: "2", minWidth: 0 }}>
+            <div style={{ gridColumn: "2", minWidth: 0, maxWidth: "92ch" }}>
                 {childrenSpawnedHere && childrenSpawnedHere.length > 0 ? (
                     <div style={{ padding: "2px 0 4px" }}>
                         {childrenSpawnedHere.map((c) => (
@@ -1418,7 +1423,7 @@ function TurnImpl({
                         />
                     </>
                 ) : (
-                    <pre style={{ margin: 0, padding: "2px 0 0", whiteSpace: "pre-wrap", wordBreak: "break-word", font: "12px/1.55 ui-monospace, monospace", maxHeight: 400, overflow: "auto" }}>
+                    <pre style={{ margin: 0, padding: "2px 0 0", whiteSpace: "pre-wrap", wordBreak: "break-word", font: "12.5px/1.55 ui-monospace, monospace", maxHeight: 400, overflow: "auto" }}>
                         {turn.spans.map((sp, i) => <Span key={i} span={sp} />)}
                     </pre>
                 )}
@@ -1634,14 +1639,14 @@ export function SessionInspectView({ sessionId }: { readonly sessionId: string }
                                 {" · "}
                                 {data.turns.length} turns · {data.total_chars.toLocaleString()} chars
                                 {data.total_hook_fires > 0 ? (
-                                    <> · <span style={{ color: "#065f46" }}>{data.total_hook_fires} hook decision{data.total_hook_fires === 1 ? "" : "s"}</span></>
+                                    <> · <span style={{ color: "color-mix(in srgb, var(--green) 45%, var(--ink))" }}>{data.total_hook_fires} hook decision{data.total_hook_fires === 1 ? "" : "s"}</span></>
                                 ) : null}
                                 {" · source: "}<code>{data.source_path}</code>
                             </div>
                             {data.children.length > 0 ? (
-                                <div style={{ padding: "6px 24px", background: "#ffe4e6", borderTop: "1px solid #fecdd3", borderBottom: "1px solid #fecdd3", fontSize: 12 }}>
-                                    <strong style={{ color: "#9f1239" }}>↓ spawned {data.children.length} subagent{data.children.length === 1 ? "" : "s"}</strong>
-                                    <span style={{ marginLeft: 12, color: "#9f1239", opacity: 0.7 }}>
+                                <div style={{ padding: "6px 24px", background: "color-mix(in srgb, var(--rose) 8%, var(--panel))", borderTop: "1px solid color-mix(in srgb, var(--rose) 25%, var(--panel))", borderBottom: "1px solid color-mix(in srgb, var(--rose) 25%, var(--panel))", fontSize: 12 }}>
+                                    <strong style={{ color: "var(--rose)" }}>↓ spawned {data.children.length} subagent{data.children.length === 1 ? "" : "s"}</strong>
+                                    <span style={{ marginLeft: 12, color: "var(--rose)", opacity: 0.7 }}>
                                         {data.children.slice(0, 6).map((c, i) => {
                                             // Wire seam: c.session_id is already bare.
                                             const bare = c.session_id;
@@ -1651,7 +1656,7 @@ export function SessionInspectView({ sessionId }: { readonly sessionId: string }
                                                     <Link
                                                         to="/sessions/$sessionId/inspect"
                                                         params={{ sessionId: bare }}
-                                                        style={{ color: "#9f1239", fontFamily: "ui-monospace, monospace" }}
+                                                        style={{ color: "var(--rose)", fontFamily: "ui-monospace, monospace" }}
                                                     >
                                                         {c.nickname ? `"${c.nickname}"` : `${bare.slice(0, 10)}…`}
                                                     </Link>
@@ -1663,18 +1668,18 @@ export function SessionInspectView({ sessionId }: { readonly sessionId: string }
                                 </div>
                             ) : null}
                             {data.parent_session ? (
-                                <div style={{ padding: "6px 24px", background: "#ffe4e6", borderTop: "1px solid #fecdd3", borderBottom: "1px solid #fecdd3", fontSize: 12 }}>
-                                    <strong style={{ color: "#9f1239" }}>↑ spawned by</strong>
+                                <div style={{ padding: "6px 24px", background: "color-mix(in srgb, var(--rose) 8%, var(--panel))", borderTop: "1px solid color-mix(in srgb, var(--rose) 25%, var(--panel))", borderBottom: "1px solid color-mix(in srgb, var(--rose) 25%, var(--panel))", fontSize: 12 }}>
+                                    <strong style={{ color: "var(--rose)" }}>↑ spawned by</strong>
                                     {" "}
                                     <Link
                                         to="/sessions/$sessionId/inspect"
                                         params={{ sessionId: data.parent_session }}
-                                        style={{ color: "#9f1239", fontWeight: 600, fontFamily: "ui-monospace, monospace" }}
+                                        style={{ color: "var(--rose)", fontWeight: 600, fontFamily: "ui-monospace, monospace" }}
                                     >
                                         {shortSessionId(data.parent_session)}…
                                     </Link>
-                                    {data.parent_nickname ? <span style={{ color: "#9f1239", marginLeft: 8 }}>· nickname: <strong>{data.parent_nickname}</strong></span> : null}
-                                    <span style={{ color: "#9f1239", marginLeft: 8, opacity: 0.7 }}>This is a subagent session.</span>
+                                    {data.parent_nickname ? <span style={{ color: "var(--rose)", marginLeft: 8 }}>· nickname: <strong>{data.parent_nickname}</strong></span> : null}
+                                    <span style={{ color: "var(--rose)", marginLeft: 8, opacity: 0.7 }}>This is a subagent session.</span>
                                 </div>
                             ) : null}
                         </>

--- a/apps/studio/src/routes/session-inspect.turn.test.tsx
+++ b/apps/studio/src/routes/session-inspect.turn.test.tsx
@@ -63,10 +63,11 @@ test("tool-only turn condenses the chrome (no kind badge / size·span)", () => {
     );
     // The card still renders the tool.
     expect(html).toContain("Bash");
-    // Tool-only turns drop the redundant role label (the card states identity)
-    // and the old structure readout - only the shared dim grid header remains.
+    // Tool-only turns drop the VISIBLE role label (the card states identity)
+    // and the old structure readout - the role survives only as an sr-only
+    // span for screen readers (the accent bar alone is color-only signal).
     expect(html).not.toContain("ASSISTANT TEXT");
-    expect(html).not.toContain("tool use");
+    expect(html).toContain('class="sr-only">tool use turn');
     expect(html).not.toContain("0span");
     // But the anchor is still reachable in the gutter.
     expect(html).toContain('href="#turn-3"');

--- a/apps/studio/src/routes/session-timeline.tsx
+++ b/apps/studio/src/routes/session-timeline.tsx
@@ -40,11 +40,16 @@ function Stat({ n, label }: { n: string; label: string }) {
 
 function EventRow({ e }: { e: TimelineEvent }) {
     const color = KIND_COLOR[e.kind];
+    // Tool/edit rows dominate a segment - repeating their uppercase label per
+    // row is over-labeling (the glyph + color already encode the kind, the
+    // hover carries the word). Keep the text label for the rarer, story-level
+    // kinds where the word IS the signal.
+    const showLabel = e.kind !== "tool_call" && e.kind !== "file_edit";
     return (
         <div style={{ display: "flex", alignItems: "baseline", gap: 8, padding: "3px 0", fontFamily: "ui-monospace, Menlo, monospace", fontSize: 12 }}>
-            <span style={{ color, width: 14, textAlign: "center", flex: "0 0 auto" }}>{KIND_GLYPH[e.kind]}</span>
+            <span title={e.kind.replace("_", " ")} style={{ color, width: 14, textAlign: "center", flex: "0 0 auto" }}>{KIND_GLYPH[e.kind]}</span>
             <span style={{ color: "var(--muted)", textTransform: "uppercase", fontSize: 10, letterSpacing: "0.04em", flex: "0 0 92px" }}>
-                {e.kind.replace("_", " ")}
+                {showLabel ? e.kind.replace("_", " ") : ""}
             </span>
             <span style={{ color: "var(--ink)", minWidth: 0, overflowWrap: "anywhere" }}>
                 {e.title}
@@ -53,7 +58,7 @@ function EventRow({ e }: { e: TimelineEvent }) {
                 ) : null}
             </span>
             {e.seq != null ? (
-                <a href={`#turn-${e.seq}`} style={{ marginLeft: "auto", flex: "0 0 auto", color: "var(--blue)", fontSize: 11, textDecoration: "none" }}>
+                <a href={`#turn-${e.seq}`} style={{ marginLeft: "auto", flex: "0 0 auto", color: "var(--blue)", fontSize: 11, textDecoration: "none", padding: "4px 0 4px 8px" }}>
                     → turn {e.seq}
                 </a>
             ) : null}
@@ -94,7 +99,6 @@ function SegmentBlock({ seg, events }: { seg: TimelineSegment; events: ReadonlyA
 
 function Highlights({ data }: { data: SessionTimelinePayload }) {
     const h = data.highlights;
-    const totalEvents = Object.values(h.event_counts).reduce((a, b) => a + b, 0);
     const sub = [h.model, h.repository, h.started_at?.slice(0, 10)].filter(Boolean).join(" · ");
     return (
         <div style={{ background: "var(--track)", borderLeft: "4px solid var(--green)", padding: "14px 18px", marginBottom: 16 }}>
@@ -107,7 +111,7 @@ function Highlights({ data }: { data: SessionTimelinePayload }) {
                 {h.tool_errors ? <Stat n={String(h.tool_errors)} label="failures" /> : null}
                 {fmtUsd(h.cost_usd) ? <Stat n={fmtUsd(h.cost_usd)} label="cost" /> : null}
                 <Stat n={`${data.segments.length}`} label="segments" />
-                <Stat n={`${data.events.length}/${totalEvents}`} label="key events" />
+                <Stat n={data.events.length.toLocaleString()} label="key events" />
             </div>
         </div>
     );

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -417,9 +417,8 @@ function InspectBody({
                 totalHookFires: data.total_hook_fires + (harnessHooks?.length ?? 0),
             }}
             header={
-                <div style={{ padding: "8px 24px", color: "var(--muted)", fontSize: 12, fontFamily: "ui-monospace, monospace" }}>
-                    {data.turns.length} turns · {data.total_chars.toLocaleString()} chars
-                    {" · source: "}<code>{data.source_path}</code>
+                <div style={{ padding: "8px var(--strip-x)", color: "var(--muted)", fontSize: 12, fontFamily: "ui-monospace, monospace" }}>
+                    {data.turns.length} turns · this session
                 </div>
             }
             renderAfterTurn={(seq) => {
@@ -428,14 +427,14 @@ function InspectBody({
                 return (
                     <>
                         {hooks && hooks.length > 0 ? (
-                            <div style={{ padding: "2px 24px 4px" }}>
+                            <div style={{ padding: "2px var(--strip-x) 4px" }}>
                                 {hooks.map((hook) => (
                                     <HarnessHookMarker key={`hh-${hook.idx}`} hook={hook} />
                                 ))}
                             </div>
                         ) : null}
                         {spawned && spawned.length > 0 ? (
-                            <div style={{ padding: "2px 24px 6px" }}>
+                            <div style={{ padding: "2px var(--strip-x) 6px" }}>
                                 {spawned.map((card) => (
                                     <ShareSpawnMarker
                                         key={card.id}
@@ -451,7 +450,7 @@ function InspectBody({
             }}
             renderAfterTurns={() =>
                 visibleCount < data.turns.length ? (
-                    <div ref={sentinelRef} style={{ padding: "12px 24px", color: "var(--muted-2)", fontSize: 11, fontFamily: "ui-monospace, monospace" }}>
+                    <div ref={sentinelRef} style={{ padding: "12px var(--strip-x)", color: "var(--muted-2)", fontSize: 11, fontFamily: "ui-monospace, monospace" }}>
                         loading {data.turns.length - visibleCount} more turns…
                     </div>
                 ) : null
@@ -461,37 +460,53 @@ function InspectBody({
 }
 
 const SUBAGENT_BAR_STYLE: CSSProperties = {
-    padding: "6px 24px",
-    background: "#fff1f2",
-    borderTop: "1px solid #fecdd3",
-    borderBottom: "1px solid #fecdd3",
+    padding: "8px var(--strip-x)",
+    background: "var(--page)",
+    borderTop: "1px solid var(--line)",
+    borderBottom: "1px solid var(--line)",
     fontSize: 12,
 };
 
+/** Chip-shaped child-session link: a solid scannable unit with a real hit
+ *  area, toned as navigation (the rose family stays on the inline spawn
+ *  markers - an error-red strip read as "something failed", not "browse"). */
 const SUBAGENT_LINK_STYLE: CSSProperties = {
-    background: "transparent",
-    border: "none",
-    padding: 0,
+    display: "inline-flex",
+    alignItems: "center",
+    background: "var(--panel)",
+    border: "1px solid var(--line)",
+    borderRadius: 3,
+    padding: "6px 10px",
     cursor: "pointer",
-    color: "#9f1239",
+    color: "var(--blue)",
     fontFamily: "ui-monospace, monospace",
     fontSize: 12,
-    textDecoration: "underline",
+    textDecoration: "none",
+};
+
+/** Children share a long boilerplate prefix ("You are implementing ...") -
+ *  truncating from the tail kept only the shared part. Strip the prefix so
+ *  the differentiating text survives. */
+const subagentChipLabel = (label: string | null | undefined): string | null => {
+    if (!label) return null;
+    const stripped = label.replace(/^you are\s+(implementing\s+)?/i, "").trim();
+    const text = stripped || label;
+    return text.length > 52 ? `${text.slice(0, 51)}…` : text;
 };
 
 const VIEW_TOGGLE_BAR_STYLE: CSSProperties = {
     display: "flex",
     gap: 6,
-    padding: "8px 24px 0",
+    padding: "8px var(--strip-x) 0",
 };
 
 const VIEW_TOGGLE_BUTTON_STYLE: CSSProperties = {
-    background: "#fff",
-    border: "1px solid var(--line, #d7dbe2)",
+    background: "var(--panel)",
+    border: "1px solid var(--line)",
     borderRadius: 4,
-    padding: "3px 12px",
+    padding: "6px 12px",
     cursor: "pointer",
-    color: "#374151",
+    color: "var(--muted)",
     fontFamily: "ui-monospace, monospace",
     fontSize: 11.5,
     textTransform: "uppercase",
@@ -502,11 +517,16 @@ const VIEW_TOGGLE_BUTTON_STYLE: CSSProperties = {
  *  hook_fire markers (both use `hook-<n>` ids for the shared jump). */
 const HARNESS_HOOK_IDX_BASE = 1_000_000;
 
+const harnessTone = (accent: string): { bg: string; fg: string; bar: string } => ({
+    bg: `color-mix(in srgb, ${accent} 8%, var(--panel))`,
+    fg: `color-mix(in srgb, ${accent} 45%, var(--ink))`,
+    bar: accent,
+});
 const HARNESS_EFFECT_TONE: Record<string, { bg: string; fg: string; bar: string }> = {
-    blocked: { bg: "#fef2f2", fg: "#991b1b", bar: "#ef4444" },
-    modified_input: { bg: "#fffbeb", fg: "#92400e", bar: "#f59e0b" },
-    injected_context: { bg: "#ecfdf5", fg: "#065f46", bar: "#10b981" },
-    notified: { bg: "#eff6ff", fg: "#1e40af", bar: "var(--blue)" },
+    blocked: harnessTone("var(--red)"),
+    modified_input: harnessTone("var(--gold)"),
+    injected_context: harnessTone("var(--green)"),
+    notified: harnessTone("var(--blue)"),
 };
 
 /** Inline marker for a harness hook that did something (blocked / modified /
@@ -563,16 +583,16 @@ export function ShareSpawnMarker(props: {
             style={{
                 display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap",
                 width: "100%", textAlign: "left", cursor: "pointer",
-                margin: "4px 0", padding: "7px 10px", background: "#fff1f2",
-                border: "1px solid #fecdd3", borderLeft: "4px solid #e11d48", borderRadius: 3,
-                fontSize: 11, fontFamily: "ui-monospace, monospace", color: "#9f1239",
+                margin: "4px 0", padding: "10px", background: "color-mix(in srgb, var(--rose) 8%, var(--panel))",
+                border: "1px solid color-mix(in srgb, var(--rose) 25%, var(--panel))", borderLeft: "4px solid var(--rose)", borderRadius: 3,
+                fontSize: 11, fontFamily: "ui-monospace, monospace", color: "var(--rose)",
             }}
         >
             <span style={{ fontWeight: 700 }}>↳ spawned subagent</span>
             <span style={{ fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 420 }}>
                 {card.task_label ? `"${card.task_label}"` : `${card.id.slice(0, 24)}…`}
             </span>
-            <span style={{ background: "#fecdd3", color: "#7f1d1d", padding: "0 6px", borderRadius: 2, fontSize: 10, fontWeight: 600 }}>
+            <span style={{ background: "color-mix(in srgb, var(--rose) 25%, var(--panel))", color: "color-mix(in srgb, var(--rose) 45%, var(--ink))", padding: "0 6px", borderRadius: 2, fontSize: 10, fontWeight: 600 }}>
                 {card.model ?? card.source}
             </span>
             <span style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
@@ -617,23 +637,36 @@ function ShareOutcomeHeader(props: {
     const stat = (n: string, label: string) => (
         <span className="share-hero-stat"><b>{n}</b><span>{label}</span></span>
     );
+    // Hero totals roll up the whole spawn tree; the cost rail below counts
+    // only the session on screen - qualify the labels so the two figures
+    // don't read as a contradiction.
+    const all = props.subagents > 0 ? " (incl. subagents)" : "";
     return (
         <div className="share-hero">
-            <h2 className="share-hero-title">{props.summary ?? "Shared agent session"}</h2>
+            <h2 className="share-hero-title">{cleanShareSummary(props.summary) ?? "Shared agent session"}</h2>
             {sub ? <div className="share-hero-sub">{sub}</div> : null}
             <div className="share-hero-stats">
-                {stat(props.turns.toLocaleString(), "turns")}
+                {stat(props.turns.toLocaleString(), `turns${all}`)}
                 {stat(props.toolCalls.toLocaleString(), "tool calls")}
                 {stat(props.files.toLocaleString(), "files")}
                 {props.subagents > 0 ? stat(props.subagents.toLocaleString(), "subagents") : null}
-                {cost ? stat(cost, "cost") : null}
+                {cost ? stat(cost, `cost${all}`) : null}
                 {duration ? stat(duration, "duration") : null}
                 <span className="share-hero-outcome" style={{ color: props.failures > 0 ? "var(--red)" : "var(--green)" }}>
-                    {props.failures > 0 ? `✗ ${props.failures} failed` : "✓ no failures"}
+                    {props.failures > 0 ? `✗ ${props.failures} failed tool calls` : "✓ no failed tool calls"}
                 </span>
             </div>
         </div>
     );
+}
+
+/** Share summaries are raw first-turn text and can open with harness XML
+ *  (`<local-command-stdout>…`) - strip tags/envelopes so the largest type on
+ *  the page reads as a story, not a debug dump. */
+export function cleanShareSummary(raw: string | null | undefined): string | null {
+    if (!raw) return null;
+    const text = raw.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+    return text.length > 0 ? text : null;
 }
 
 /** v3 multi-file share: manifest-first render + lazy/prefetch session files. */
@@ -777,42 +810,71 @@ function MultiFileShareView(props: {
                     {" · gist share"}
                 </span>
             </header>
-            <ShareOutcomeHeader
-                summary={manifest.session.summary}
-                source={manifest.session.source}
-                model={manifest.session.model}
-                project={manifest.session.project}
-                startedAt={manifest.session.started_at}
-                turns={totals.turns}
-                toolCalls={totals.tool_calls}
-                files={manifest.stats.files_changed}
-                subagents={totals.subagents}
-                failures={totals.failures}
-                costUsd={totals.cost_usd}
-                durationMs={totals.duration_ms}
-            />
+            {/* Hero follows the session ON SCREEN: a subagent view shows the
+                subagent's task + stats, not the parent's (which read as a
+                missing context switch). */}
+            {selectedCard ? (
+                <ShareOutcomeHeader
+                    summary={selectedCard.task_label ?? "Subagent session"}
+                    source={selectedCard.source}
+                    model={selectedCard.model}
+                    project={manifest.session.project}
+                    startedAt={selectedCard.started_at}
+                    turns={selectedCard.stats.turns}
+                    toolCalls={selectedCard.stats.tool_calls}
+                    files={selectedCard.stats.files_changed}
+                    subagents={directChildren.length}
+                    failures={selectedCard.stats.failures}
+                    costUsd={selectedCard.cost_usd}
+                    durationMs={selectedCard.duration_ms}
+                />
+            ) : (
+                <ShareOutcomeHeader
+                    summary={manifest.session.summary}
+                    source={manifest.session.source}
+                    model={manifest.session.model}
+                    project={manifest.session.project}
+                    startedAt={manifest.session.started_at}
+                    turns={totals.turns}
+                    toolCalls={totals.tool_calls}
+                    files={manifest.stats.files_changed}
+                    subagents={totals.subagents}
+                    failures={totals.failures}
+                    costUsd={totals.cost_usd}
+                    durationMs={totals.duration_ms}
+                />
+            )}
             {directChildren.length > 0 ? (
                 <div style={SUBAGENT_BAR_STYLE}>
-                    <strong style={{ color: "#9f1239" }}>
-                        ↓ spawned {directChildren.length} subagent{directChildren.length === 1 ? "" : "s"}
-                    </strong>
-                    <span style={{ marginLeft: 12, color: "#9f1239", opacity: 0.85 }}>
-                        {directChildren.slice(0, 8).map((c, i) => (
-                            <span key={c.id}>
-                                {i > 0 ? " · " : " "}
-                                <button
-                                    type="button"
-                                    onClick={() => setSelectedFile(c.file)}
-                                    onMouseEnter={() => prefetch(c.file)}
-                                    onFocus={() => prefetch(c.file)}
-                                    style={SUBAGENT_LINK_STYLE}
-                                >
-                                    {c.task_label ? `"${c.task_label.slice(0, 40)}${c.task_label.length > 40 ? "…" : ""}"` : `${shortSessionId(c.id)}…`}
-                                    {fmtUsd(c.cost_usd) ? ` (${fmtUsd(c.cost_usd)})` : ""}
-                                </button>
-                            </span>
+                    <span style={{
+                        display: "block",
+                        font: "700 10px/1 ui-monospace, monospace",
+                        textTransform: "uppercase",
+                        letterSpacing: "0.08em",
+                        color: "var(--muted)",
+                        margin: "2px 0 8px",
+                    }}>
+                        ↓ {directChildren.length} subagent session{directChildren.length === 1 ? "" : "s"} - tap to open
+                    </span>
+                    <span style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                        {directChildren.slice(0, 8).map((c) => (
+                            <button
+                                key={c.id}
+                                type="button"
+                                onClick={() => setSelectedFile(c.file)}
+                                onMouseEnter={() => prefetch(c.file)}
+                                onFocus={() => prefetch(c.file)}
+                                style={SUBAGENT_LINK_STYLE}
+                            >
+                                {subagentChipLabel(c.task_label) ?? `${shortSessionId(c.id)}…`}
+                                {fmtUsd(c.cost_usd) ? <span style={{ color: "var(--muted)", marginLeft: 6 }}>{fmtUsd(c.cost_usd)}</span> : null}
+                            </button>
                         ))}
-                        {directChildren.length > 8 ? <span> · …+{directChildren.length - 8}</span> : null}
+                        {directChildren.length > 8 ? (
+                            <span style={{ alignSelf: "center", color: "var(--muted)", fontFamily: "ui-monospace, monospace" }}>
+                                +{directChildren.length - 8} more inline ↓
+                            </span>
+                        ) : null}
                     </span>
                 </div>
             ) : null}
@@ -824,11 +886,8 @@ function MultiFileShareView(props: {
                         onMouseEnter={() => prefetch(parentFile)}
                         style={{ ...SUBAGENT_LINK_STYLE, fontWeight: 700 }}
                     >
-                        ↑ back to {parentLabel}
+                        ↑ back to {subagentChipLabel(parentLabel) ?? parentLabel}
                     </button>
-                    <span style={{ color: "#9f1239", marginLeft: 8, opacity: 0.7 }}>
-                        Viewing subagent{selectedCard.task_label ? `: "${selectedCard.task_label.slice(0, 60)}${selectedCard.task_label.length > 60 ? "…" : ""}"` : ""}.
-                    </span>
                 </div>
             ) : null}
             {fileQuery.error ? <div className="error">Error: {String(fileQuery.error)}</div> : null}
@@ -840,10 +899,11 @@ function MultiFileShareView(props: {
                             key={mode}
                             type="button"
                             onClick={() => setView(mode)}
+                            aria-pressed={view === mode}
                             style={{
                                 ...VIEW_TOGGLE_BUTTON_STYLE,
                                 ...(view === mode
-                                    ? { background: "#1f2937", color: "#fff", borderColor: "#1f2937" }
+                                    ? { background: "var(--ink)", color: "var(--page)", borderColor: "var(--ink)" }
                                     : {}),
                             }}
                         >

--- a/apps/studio/src/routes/tool-row.test.tsx
+++ b/apps/studio/src/routes/tool-row.test.tsx
@@ -66,8 +66,8 @@ describe("ToolCallCard (ToolRowItem / ToolRow)", () => {
         expect(html).toContain('data-testid="tool-card-output"');
         expect(html).toContain("hello world");
         expect(html).not.toContain("local-command-stdout");
-        // terminal styling
-        expect(html).toContain("#1e1e2e");
+        // terminal styling (the named dark-island tokens)
+        expect(html).toContain("var(--term-bg)");
     });
 
     test(">600-char output renders in FULL (no truncation)", () => {

--- a/apps/studio/src/routes/tool-row.tsx
+++ b/apps/studio/src/routes/tool-row.tsx
@@ -1,14 +1,17 @@
 import type { ToolCallDto, ToolCategory } from "@ax/lib/shared/dashboard-types";
 import { stripToolResult } from "./tool-result.tsx";
 
+// Tinted badge tones derived from the calibrated root accents (one recipe,
+// equivalent perceived brightness): blue=net, gold=file, green=edit,
+// violet=search, rose=agent (matches the subagent spawn system), grey=shell.
 const CATEGORY_TONE: Record<ToolCategory, { bg: string; fg: string }> = {
-    net: { bg: "#e4f3ff", fg: "#1f7ac4" },
-    file: { bg: "#fff0db", fg: "#b5730a" },
-    edit: { bg: "#fde7ef", fg: "#b5306a" },
-    sh: { bg: "#eceff3", fg: "#566173" },
-    search: { bg: "#efeaff", fg: "#6b46ff" },
-    agent: { bg: "#ffe9f3", fg: "#c43d7a" },
-    other: { bg: "#eef2f6", fg: "#5a6472" },
+    net: { bg: "color-mix(in srgb, var(--blue) 10%, var(--panel))", fg: "color-mix(in srgb, var(--blue) 45%, var(--ink))" },
+    file: { bg: "color-mix(in srgb, var(--gold) 14%, var(--panel))", fg: "color-mix(in srgb, var(--gold) 45%, var(--ink))" },
+    edit: { bg: "color-mix(in srgb, var(--green) 10%, var(--panel))", fg: "color-mix(in srgb, var(--green) 45%, var(--ink))" },
+    sh: { bg: "var(--track)", fg: "var(--muted)" },
+    search: { bg: "color-mix(in srgb, var(--violet) 10%, var(--panel))", fg: "color-mix(in srgb, var(--violet) 45%, var(--ink))" },
+    agent: { bg: "color-mix(in srgb, var(--rose) 10%, var(--panel))", fg: "color-mix(in srgb, var(--rose) 45%, var(--ink))" },
+    other: { bg: "var(--track)", fg: "var(--muted)" },
 };
 
 const mono = "ui-monospace, SFMono-Regular, Menlo, monospace";
@@ -93,7 +96,7 @@ export function ToolRowItem(
     const hasOutput = output.trim().length > 0;
 
     return (
-        <div style={{ display: "flex", gap: 9, margin: "2px 0 8px" }}>
+        <div style={{ display: "flex", gap: 8, margin: "0 0 8px" }}>
             <div
                 aria-hidden
                 style={{ flex: "0 0 2px", borderRadius: 2, background: tone.fg, opacity: 0.4 }}
@@ -105,13 +108,13 @@ export function ToolRowItem(
                         alignItems: "baseline",
                         gap: 8,
                         font: `12.5px/1.5 ${mono}`,
-                        color: call.has_error ? "#c4361f" : "#2d2840",
-                        padding: "0 0 3px",
+                        color: call.has_error ? "var(--red)" : "var(--ink)",
+                        padding: "0 0 4px",
                     }}
                 >
                     <span
                         style={{
-                            font: `700 9.5px/1.7 ${mono}`,
+                            font: `700 10px/1.6 ${mono}`,
                             letterSpacing: "0.03em",
                             textTransform: "uppercase",
                             borderRadius: 3,
@@ -128,7 +131,7 @@ export function ToolRowItem(
                         ? (
                             <span
                                 style={{
-                                    color: "#8b8398",
+                                    color: "var(--muted)",
                                     minWidth: 0,
                                     overflow: "hidden",
                                     textOverflow: "ellipsis",
@@ -143,14 +146,14 @@ export function ToolRowItem(
                         : null}
                     {call.has_error
                         ? (
-                            <span data-testid="tool-row-error" title="error" style={{ color: "#c4361f", flex: "0 0 auto" }}>
+                            <span data-testid="tool-row-error" title="error" style={{ color: "var(--red)", flex: "0 0 auto" }}>
                                 ⚠
                             </span>
                         )
                         : null}
                     {call.tokens != null
                         ? (
-                            <span style={{ marginLeft: "auto", color: "#b3b8c2", fontSize: 10.5, flex: "0 0 auto" }}>
+                            <span style={{ marginLeft: "auto", color: "var(--muted-2)", fontSize: 10.5, flex: "0 0 auto" }}>
                                 {call.tokens.toLocaleString()}
                             </span>
                         )
@@ -175,16 +178,16 @@ export function ToolRowItem(
                     ? (
                         <pre
                             style={{
-                                margin: "0 0 6px",
+                                margin: "0 0 4px",
                                 font: `11px/1.5 ${mono}`,
-                                color: "#8b8398",
+                                color: "var(--muted)",
                                 whiteSpace: "pre-wrap",
                                 wordBreak: "break-word",
                                 maxHeight: 130,
                                 overflow: "auto",
                             }}
                         >
-                            <span style={{ color: "#c0a3e8", userSelect: "none" }}>$ </span>
+                            <span aria-hidden style={{ color: "#c0a3e8", userSelect: "none" }}>$ </span>
                             {call.command}
                         </pre>
                     )
@@ -192,7 +195,7 @@ export function ToolRowItem(
                     ? (
                         <div
                             style={{
-                                margin: "0 0 6px",
+                                margin: "0 0 4px",
                                 maxHeight: 170,
                                 overflow: "auto",
                                 display: "grid",
@@ -203,8 +206,8 @@ export function ToolRowItem(
                         >
                             {entries.map(([k, v]) => (
                                 <div key={k} style={{ display: "contents" }}>
-                                    <span style={{ color: "#b3b8c2", textAlign: "right" }}>{k}</span>
-                                    <span style={{ color: "#3a3550", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+                                    <span style={{ color: "var(--muted-2)", textAlign: "right" }}>{k}</span>
+                                    <span style={{ color: "var(--ink)", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
                                         {typeof v === "string" ? v : JSON.stringify(v)}
                                     </span>
                                 </div>
@@ -217,9 +220,9 @@ export function ToolRowItem(
                         <div
                             data-testid="skill-launch-line"
                             style={{
-                                margin: "0 0 5px",
+                                margin: "0 0 4px",
                                 font: `11px/1.5 ${mono}`,
-                                color: "#8b8398",
+                                color: "var(--muted)",
                                 whiteSpace: "pre-wrap",
                                 wordBreak: "break-word",
                             }}
@@ -236,9 +239,9 @@ export function ToolRowItem(
                                 margin: 0,
                                 padding: "8px 12px",
                                 borderRadius: 6,
-                                background: "#1e1e2e",
-                                color: "#cdd6f4",
-                                font: `11.5px/1.55 ${mono}`,
+                                background: "var(--term-bg)",
+                                color: "var(--term-fg)",
+                                font: `12.5px/1.55 ${mono}`,
                                 whiteSpace: "pre-wrap",
                                 wordBreak: "break-word",
                                 overflow: "auto",
@@ -268,7 +271,7 @@ export function ToolRow(
 ) {
     if (calls.length === 0) return null;
     return (
-        <div style={{ padding: "2px 0 2px", fontFamily: mono }}>
+        <div style={{ fontFamily: mono }}>
             {calls.map((call, i) => (
                 <ToolRowItem
                     key={`${call.seq}-${call.name}-${i}`}

--- a/apps/studio/src/routes/transcript.tsx
+++ b/apps/studio/src/routes/transcript.tsx
@@ -83,21 +83,40 @@ export function Transcript({
             {header}
             <FilterBar {...filterBar} />
             <InspectGuide data={data} />
-            <div style={{ display: "flex", gap: 4, flexWrap: "wrap", padding: "4px 24px 8px" }}>
-                {(Object.keys(KIND_STYLE) as InspectSpanKind[]).map((kind) => {
-                    const c = KIND_STYLE[kind];
-                    const n = data.totals_by_kind[kind] ?? 0;
-                    const pct = data.total_chars > 0 ? ((n / data.total_chars) * 100).toFixed(1) : "0";
+            <div style={{ display: "flex", gap: 4, flexWrap: "wrap", padding: "4px var(--strip-x) 8px" }}>
+                {(() => {
+                    // Chips at ~0% are dead weight that dilutes the meaningful
+                    // ones - collapse them into a single dim count.
+                    const entries = (Object.keys(KIND_STYLE) as InspectSpanKind[]).map((kind) => {
+                        const n = data.totals_by_kind[kind] ?? 0;
+                        const share = data.total_chars > 0 ? (n / data.total_chars) * 100 : 0;
+                        return { kind, share };
+                    });
+                    const visible = entries.filter((e) => e.share >= 0.05);
+                    const hidden = entries.length - visible.length;
                     return (
-                        <span
-                            key={kind}
-                            title={`${c.label}: ${pct}% of exported characters in this session view. This is not token share or billing share.`}
-                            style={{ background: c.bg, color: c.fg, padding: "2px 10px", borderRadius: 4, fontSize: 11, fontWeight: 600, borderLeft: `3px solid ${c.bar}` }}
-                        >
-                            {c.label} <em style={{ fontStyle: "normal", opacity: 0.7, fontWeight: 400 }}>{pct}%</em>
-                        </span>
+                        <>
+                            {visible.map(({ kind, share }) => {
+                                const c = KIND_STYLE[kind];
+                                const pct = share.toFixed(1);
+                                return (
+                                    <span
+                                        key={kind}
+                                        title={`${c.label}: ${pct}% of exported characters in this session view. This is not token share or billing share.`}
+                                        style={{ background: c.bg, color: c.fg, padding: "2px 10px", borderRadius: 4, fontSize: 11, fontWeight: 600, borderLeft: `3px solid ${c.bar}` }}
+                                    >
+                                        {c.label} <em style={{ fontStyle: "normal", opacity: 0.7, fontWeight: 400 }}>{pct}%</em>
+                                    </span>
+                                );
+                            })}
+                            {hidden > 0 ? (
+                                <span style={{ alignSelf: "center", color: "var(--muted-2)", fontSize: 11 }}>
+                                    +{hidden} at ~0%
+                                </span>
+                            ) : null}
+                        </>
                     );
-                })}
+                })()}
             </div>
             <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
                 <div style={{ minWidth: 0, flex: "1 1 auto" }}>

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -1,8 +1,9 @@
 :root {
     --ink: #141615;
     --muted: #66706b;
-    /* Tertiary text (placeholders, faint counts) - between --muted and --page. */
-    --muted-2: color-mix(in srgb, var(--muted) 55%, var(--page));
+    /* Tertiary text (faint counts). 80% keeps it visibly lighter than --muted
+       while staying near 4:1 on white - the old 55% mix was 2.3:1, illegible. */
+    --muted-2: color-mix(in srgb, var(--muted) 80%, var(--page));
     --page: #f3f6f5;
     --line: #cfd8d4;
     --panel: #ffffff;
@@ -11,7 +12,22 @@
     --blue: #2567a8;
     --red: #bd443b;
     --gold: #a66d10;
+    /* Two more accents, luminance-matched to the four above. */
+    --violet: #6650b8; /* tools / output */
+    --rose: #b32650;   /* subagents */
+    /* The one intentional dark island: tool output terminal blocks. */
+    --term-bg: #1e1e2e;
+    --term-fg: #cdd6f4;
+    /* Shared left inset for transcript chrome strips - the "content spine":
+       turn body text starts at accent 3 + row pad 16 + gutter 36 + gap 8 =
+       63px, so strips indent to match. Overridden to 12px on mobile. */
+    --strip-x: 63px;
     color-scheme: light;
+}
+
+:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
 }
 
 * {
@@ -77,8 +93,8 @@ a {
     border-color: var(--green);
 }
 .studio-banner-warn {
-    background: color-mix(in srgb, var(--orange) 8%, var(--page));
-    border-color: var(--orange);
+    background: color-mix(in srgb, var(--gold) 8%, var(--page));
+    border-color: var(--gold);
 }
 
 .shell {
@@ -189,8 +205,8 @@ a {
     font-weight: 600;
     text-decoration: none;
     color: #fff;
-    background: var(--ink, #0f172a);
-    border: 1px solid var(--ink, #0f172a);
+    background: var(--ink);
+    border: 1px solid var(--ink);
     border-radius: 6px;
     padding: 8px 14px;
     white-space: nowrap;
@@ -1880,23 +1896,23 @@ td.skill-cell .description {
     flex: 0 0 120px;
     height: 6px;
     border-radius: 3px;
-    background: var(--border, #30363d);
+    background: var(--track);
     overflow: hidden;
 }
 
 .ingest-stage-bar-fill {
     display: block;
     height: 100%;
-    background: #2ea043;
+    background: var(--green);
     transition: width 0.2s ease-out;
 }
 
 .ingest-stage.ok .ingest-stage-glyph {
-    color: #2ea043;
+    color: var(--green);
 }
 
 .ingest-stage.error .ingest-stage-glyph {
-    color: #f85149;
+    color: var(--red);
 }
 
 .ingest-stage.running .ingest-stage-glyph {
@@ -2065,20 +2081,20 @@ td.skill-cell .description {
     min-width: 26px;
     font-family: ui-monospace, monospace;
     font-weight: 700;
-    color: #475569;
+    color: var(--muted);
 }
 .compare-table td.win {
     background: rgba(34, 197, 94, 0.12);
 }
 .compare-table td.win strong {
-    color: #15803d;
+    color: var(--green);
 }
 .swimlane-wrap {
     margin-top: 20px;
 }
 .swimlane-wrap h3 {
     font-size: 13px;
-    color: #475569;
+    color: var(--muted);
     margin: 0 0 8px;
 }
 .swimlane {
@@ -2095,14 +2111,14 @@ td.skill-cell .description {
     font-family: ui-monospace, monospace;
     font-weight: 700;
     font-size: 12px;
-    color: #475569;
+    color: var(--muted);
     text-align: center;
     padding-bottom: 4px;
 }
 .turn-cell {
     font-family: ui-monospace, monospace;
     font-size: 10px;
-    color: #0f172a;
+    color: var(--ink);
     text-align: center;
     padding: 2px 4px;
     border-radius: 3px;
@@ -2111,10 +2127,10 @@ td.skill-cell .description {
 }
 .turn-cell.empty {
     background: transparent !important;
-    border: 1px dashed #e2e8f0;
+    border: 1px dashed var(--line);
 }
 .turn-cell.err {
-    border-color: #ef4444;
+    border-color: var(--red);
     box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.4);
 }
 
@@ -2175,7 +2191,19 @@ td.skill-cell .description {
     padding-bottom: 2px;
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .live-indicator.on .live-dot,
+    .ingest-stage.running .ingest-stage-glyph,
+    tr.row-just-saved td {
+        animation: none;
+    }
+}
+
 @media (max-width: 768px) {
+    /* Strips share the 12px mobile spine. */
+    :root {
+        --strip-x: 12px;
+    }
     /* The docked inspector/cost rail is hover-driven - useless on touch and
        it squeezes the transcript to ~110px. Inline styles win specificity,
        hence !important. */
@@ -2183,23 +2211,45 @@ td.skill-cell .description {
         display: none !important;
     }
     /* Jump bar: one horizontally-scrollable row instead of a 5-row sticky
-       block covering a third of the viewport. */
+       block covering a third of the viewport. Buttons get real tap targets. */
     .filter-bar {
         flex-wrap: nowrap !important;
         overflow-x: auto;
-        padding: 6px 12px !important;
         -webkit-overflow-scrolling: touch;
     }
     .filter-bar > * {
         flex: 0 0 auto;
     }
-    /* Turn rows: 100px of gutter+padding per 390px line is too rich. */
+    .filter-bar button {
+        min-height: 40px;
+    }
+    /* Any input under 16px zooms the whole page on iOS focus. */
+    .filter-bar input {
+        font-size: 16px;
+        min-height: 40px;
+    }
+    /* Turn rows: the 26px seq gutter held one 10.5px number then ran empty
+       for the turn's whole height - 20-25% of the screen dead down the left.
+       Drop the grid; the seq anchor (the row's first child) floats into the
+       header line instead. The header is a flex BFC, so it sits beside the
+       float and the body clears it naturally. */
     .turn-row {
-        padding: 8px 10px !important;
-        grid-template-columns: 26px 1fr !important;
+        display: block !important;
+        padding: 8px 12px !important;
+    }
+    .turn-row > a:first-child {
+        float: left;
+        margin-right: 8px;
+    }
+    /* Body text is the page's reading content - keep it >= 13px on phones. */
+    .turn-row pre {
+        font-size: 13px !important;
     }
     .shell {
-        padding: 12px;
+        padding: 12px 8px;
+    }
+    .panel {
+        padding: 12px 8px;
     }
     .masthead .brand-tag {
         display: none;
@@ -2208,7 +2258,7 @@ td.skill-cell .description {
         flex-wrap: wrap;
     }
     .share-cta {
-        font-size: 11px;
-        padding: 6px 10px;
+        font-size: 12px;
+        padding: 8px 12px;
     }
 }


### PR DESCRIPTION
Consolidated output of a **4-lens parallel design critique** (spacing / accessibility / color / UX hierarchy) of the shared-session viewer, each lens grounded in Refactoring UI and run against the live page at 390×844 and 1440×900.

**Spacing** (the reported left-gutter dead space — measured: first glyph at x=76, 19.5% of a phone screen dead): mobile drops the seq-gutter column (the `#seq` anchor floats into the header line), container insets collapse 38→17px, desktop gutter 44→36 sized to content, and every chrome strip moves onto one `--strip-x` content spine (63px desktop / 12px mobile). Tool-card micro-gaps land on a 4/8/16 proximity scale; body capped at 92ch.

**Color**: the page ran ~120 ad-hoc hexes across four competing systems. KIND/category/marker/cost tones now derive from the calibrated root accents via one `color-mix` recipe, with new `--violet`/`--rose` accents and named `--term-bg/fg`. Fixes undefined `var(--orange)`/`var(--border)` refs. Anchor highlight: amber → blue "current item".

**Accessibility**: `--muted-2` 55→80% mix (was 2.3:1), metadata text onto `--muted`, body text 12.5px (13px mobile), global `:focus-visible`, 16px mobile search input (iOS zoom), 40px mobile tap targets, `aria-pressed` toggles, sr-only role labels, `prefers-reduced-motion`.

**Hierarchy**: hero title sanitized of harness XML; hero swaps to the subagent's task+stats when viewing a child; totals labelled "(incl. subagents)"; subagent strip becomes neutral nav chips (boilerplate prefix stripped); skeleton-looking grey minimap strips gone; dead 0% chips collapse; jump bar de-jargoned.

Tests: studio 117 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)