### PR TITLE
feat(otel): deep span instrumentation for ingest stages

### DIFF
--- a/apps/axctl/src/ingest/closure.ts
+++ b/apps/axctl/src/ingest/closure.ts
@@ -351,7 +351,7 @@ FROM session_health;`).pipe(Effect.map((rows) => rows?.[0] ?? [])),
             forceRederive
                 ? Effect.succeed<string | undefined>(undefined)
                 : loadClosureWatermark(db),
-        ], { concurrency: 4 });
+        ], { concurrency: 4 }).pipe(Effect.withSpan("closure.fetch"));
         const rows = deriveClosureRows({ commits, touched, sessionHealth });
         const stats: ClosureStats = {
             commitClassifications: rows.classifications.length,
@@ -369,8 +369,10 @@ FROM session_health;`).pipe(Effect.map((rows) => rows?.[0] ?? [])),
             ...rows.fixChains.flatMap(fixChainStatements),
             ...rows.skillCandidates.flatMap(skillCandidateStatements),
         ];
-        yield* db.query("DELETE later_fixed_by;DELETE suggests_skill;DELETE skill_candidate;DELETE commit_classification;");
-        yield* executeStatementsWith(db, statements, { chunkSize: 500 });
+        yield* db.query("DELETE later_fixed_by;DELETE suggests_skill;DELETE skill_candidate;DELETE commit_classification;").pipe(
+            Effect.withSpan("closure.delete"),
+        );
+        yield* executeStatementsWith(db, statements, { chunkSize: 500, label: "closure" });
         yield* upsertClosureWatermark(db, digest);
         return stats;
     });

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1438,7 +1438,7 @@ const buildCodexBatchStatements = (
 export const __testBuildCodexBatchStatements = buildCodexBatchStatements;
 
 const queryCodexStatements = (statements: readonly string[]) =>
-    executeStatements(statements, { chunkSize: 500 });
+    executeStatements(statements, { chunkSize: 500, label: "codex" });
 
 interface CodexIngestOpts {
     sinceDays: number | undefined;
@@ -1730,7 +1730,14 @@ export const ingestCodex = (
                 yield* Effect.logDebug("codex ingest progress", counts);
             }
             activeFiles -= 1;
-        }), { concurrency, discard: true });
+        }).pipe(Effect.withSpan("codex.file", {
+            // Basename only: keeps exported-trace attributes small (the full
+            // session path is reconstructable locally if ever needed).
+            attributes: {
+                "file.name": file.path.slice(file.path.lastIndexOf("/") + 1),
+                "file.bytes": file.sizeBytes,
+            },
+        })), { concurrency, discard: true });
         yield* Effect.logDebug("codex ingest complete", {
             files: fileCount,
             records: recordCount(),

--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -1039,7 +1039,11 @@ export const ingestCursor = (
         for (const dbPath of dbPaths) {
             const extract = yield* Effect.sync(() =>
                 extractCursorStateDb(dbPath, { cursorUserDir: cfg.paths.cursorUserDir })
-            );
+            ).pipe(Effect.withSpan("cursor.db", {
+                // Last two segments (`<workspace-hash>/state.vscdb`) - the
+                // basename alone is always "state.vscdb".
+                attributes: { "file.name": dbPath.split("/").slice(-2).join("/") },
+            }));
             skipped += extract.skipped;
             warnings += extract.warnings.length;
             if (extract.sessions.length === 0) continue;
@@ -1052,7 +1056,7 @@ export const ingestCursor = (
                     raw_file: session.sourcePath,
                 });
             }
-            yield* executeStatements(buildCursorBatchStatements(extract, dbPath), { chunkSize: 500 });
+            yield* executeStatements(buildCursorBatchStatements(extract, dbPath), { chunkSize: 500, label: "cursor" });
             sessionCount += extract.sessions.length;
             turnCount += extract.turns.length;
             toolCallCount += extract.toolCalls.length;

--- a/apps/axctl/src/ingest/derive-metrics.ts
+++ b/apps/axctl/src/ingest/derive-metrics.ts
@@ -53,17 +53,30 @@ export const deriveMetrics = (
         //    needing the read-time `fillEstimatedCost` helper. Independent of
         //    the dirty set - runs before the empty-dirty early return so daemon
         //    `--since=1` ingests heal history incrementally.
-        const costs = yield* deriveCostBackfill();
+        const costs = yield* deriveCostBackfill().pipe(
+            Effect.tap((c) => Effect.annotateCurrentSpan("derive.cost.backfilled", c.backfilled)),
+            Effect.withSpan("derive.cost-backfill"),
+        );
 
         // 1. Freshness backbone - full-history commit.reverted (diff-only writes).
-        const reverted = yield* computeRevertedCommits();
+        const reverted = yield* computeRevertedCommits().pipe(
+            Effect.tap((r) =>
+                Effect.all([
+                    Effect.annotateCurrentSpan("derive.reverted.count", r.revertedCount),
+                    Effect.annotateCurrentSpan("derive.reverted.skipped", r.skipped),
+                ]),
+            ),
+            Effect.withSpan("derive.commit-reverted"),
+        );
 
         // 1b. PR-driven dirty source (issue #172): sessions producing commits
         //     whose pull_request merge_sha/merged_at changed since the last
         //     github-pr ingest. Without this, an OLD session whose PR merges
         //     LATER keeps a stale/NULL time_to_land_ms on the daemon's
         //     `--since=1` path until a full re-derive.
-        const prDirty = yield* computePrMergeDirtySessions();
+        const prDirty = yield* computePrMergeDirtySessions().pipe(
+            Effect.withSpan("derive.pr-merge-dirty"),
+        );
 
         // 2. Dirty set: sessions in the window, PLUS any session that produced a
         //    commit whose `reverted` flag *changed* this run (either direction).
@@ -79,7 +92,7 @@ export const deriveMetrics = (
             : "";
         const dirty = (yield* db.query<[string[]]>(
             `SELECT VALUE type::string(id) FROM session WHERE ${sinceClause}${changedClause};`,
-        ))?.[0] ?? [];
+        ).pipe(Effect.withSpan("derive.dirty-set")))?.[0] ?? [];
         const dirtySet = new Set(
             (dirty as unknown as unknown[]).filter(
                 (s): s is string => typeof s === "string" && s.length > 0,
@@ -93,7 +106,14 @@ export const deriveMetrics = (
             // reverted set itself changed (no new sessions ⇒ no new `edited`
             // edges), so the bounded cascade re-derive runs only on that path -
             // BEFORE the watermarks advance, so a crash re-runs it next time.
-            const cascadeEdges = reverted.skipped ? 0 : yield* deriveFragilityCascade();
+            const cascadeEdges = reverted.skipped
+                ? 0
+                : yield* deriveFragilityCascade().pipe(
+                    Effect.tap((edges) => Effect.annotateCurrentSpan("derive.cascade.edges", edges)),
+                    Effect.withSpan("derive.fragility-cascade", {
+                        attributes: { "derive.cascade.path": "empty-dirty" },
+                    }),
+                );
             if (!reverted.skipped) yield* advanceRevertedWatermark(reverted.fingerprint);
             // Safe here: prDirty.diff only carries PRs whose merge sha RESOLVED
             // locally (unresolved ones are held back to re-diff next run), so
@@ -115,7 +135,9 @@ export const deriveMetrics = (
             const refs = [...frontier].map((id) => recordLiteral("session", recordKeyPart(id, "session") ?? "")).join(", ");
             const parents = (yield* db.query<[string[]]>(
                 `SELECT VALUE type::string(in) FROM spawned WHERE out IN [${refs}];`,
-            ))?.[0] ?? [];
+            ).pipe(Effect.withSpan("derive.spawn-parents", {
+                attributes: { "derive.spawn.depth": depth, "derive.spawn.frontier": frontier.size },
+            })))?.[0] ?? [];
             frontier = new Set();
             for (const p of parents) if (typeof p === "string" && !all.has(p)) { all.add(p); frontier.add(p); }
         }
@@ -132,6 +154,12 @@ export const deriveMetrics = (
                 computeDelegationRatio(expandedIds),
             ],
             { concurrency: 6 },
+        ).pipe(
+            // ONE span for the whole per-session metric computation (NOT per
+            // session - bounded cardinality), carrying the dirty-set size.
+            Effect.withSpan("derive.session-metrics", {
+                attributes: { "derive.sessions": expandedIds.length },
+            }),
         );
 
         // 4. One session_metrics row per dirty session (+ spawn parents).
@@ -149,14 +177,19 @@ export const deriveMetrics = (
                 + `delegation_ratio: ${num(del.get(id) ?? null)}, `
                 + `ts: time::now() };`;
         });
-        yield* executeStatementsWith(db, stmts, { chunkSize: 500 });
+        yield* executeStatementsWith(db, stmts, { chunkSize: 500, label: "sessionMetrics" });
 
         // 5. Fragility-cascade precompute (issue #171): bounded full rewrite of
         //    the `fragility_cascade` table so `ax signals show fragility_cascade`
         //    reads stored rows instead of doing live edge derefs. Runs whenever
         //    sessions were dirty (new `edited` edges can add downstream fixers)
         //    and on reverted-set changes (handled above for the empty dirty set).
-        const cascadeEdges = yield* deriveFragilityCascade();
+        const cascadeEdges = yield* deriveFragilityCascade().pipe(
+            Effect.tap((edges) => Effect.annotateCurrentSpan("derive.cascade.edges", edges)),
+            Effect.withSpan("derive.fragility-cascade", {
+                attributes: { "derive.cascade.path": "dirty" },
+            }),
+        );
 
         // Advance the commit-reverted + PR-merge watermarks ONLY now that the
         // dependent session_metrics rows are persisted - a crash before this

--- a/apps/axctl/src/ingest/derive-signals.ts
+++ b/apps/axctl/src/ingest/derive-signals.ts
@@ -860,8 +860,13 @@ export const deriveSignals = (
     opts: Partial<DeriveOpts> = {},
 ): Effect.Effect<DeriveStats, DbError, SurrealClient> =>
     Effect.gen(function* () {
-        const skillNames = yield* fetchSkillNames();
-        const bundles = yield* fetchSessionTurns(opts.sinceDays);
+        const skillNames = yield* fetchSkillNames().pipe(
+            Effect.withSpan("signals.fetch-skills"),
+        );
+        const bundles = yield* fetchSessionTurns(opts.sinceDays).pipe(
+            Effect.tap((b) => Effect.annotateCurrentSpan("signals.sessions", b.length)),
+            Effect.withSpan("signals.fetch-turns"),
+        );
         if (opts.onProgress) yield* opts.onProgress({ sessions: bundles.length });
 
         let corrections = 0;
@@ -913,7 +918,10 @@ export const deriveSignals = (
                 skillPairs: pairsList.length,
             });
         }
-        const failedToolCalls = yield* fetchFailedToolCalls(opts.sinceDays);
+        const failedToolCalls = yield* fetchFailedToolCalls(opts.sinceDays).pipe(
+            Effect.tap((calls) => Effect.annotateCurrentSpan("signals.failed_tool_calls", calls.length)),
+            Effect.withSpan("signals.fetch-failed-tools"),
+        );
         const toolFrictionBatch = deriveFrictionFromToolCalls(failedToolCalls);
         const correctionFrictionBatch = deriveFrictionFromCorrections(correctionBatch);
         const frictionBatch = [...toolFrictionBatch, ...correctionFrictionBatch];
@@ -931,17 +939,45 @@ export const deriveSignals = (
             });
         }
 
-        yield* upsertCorrections(correctionBatch);
+        yield* upsertCorrections(correctionBatch).pipe(
+            Effect.withSpan("signals.write.corrections", {
+                attributes: { "signals.count": correctionBatch.length },
+            }),
+        );
         // Denormalise was_corrected onto invoked edges so cmdTaste's
         // corrections subquery becomes a pure index/scan filter (issue #31).
-        yield* markWasCorrected(correctionBatch);
-        yield* upsertProposed(proposedBatch);
+        yield* markWasCorrected(correctionBatch).pipe(
+            Effect.withSpan("signals.write.was-corrected", {
+                attributes: { "signals.count": correctionBatch.length },
+            }),
+        );
+        yield* upsertProposed(proposedBatch).pipe(
+            Effect.withSpan("signals.write.proposed", {
+                attributes: { "signals.count": proposedBatch.length },
+            }),
+        );
         if (shouldWriteSkillPairs) {
-            yield* upsertSkillPairs(pairsList, pairEdgeIds);
+            yield* upsertSkillPairs(pairsList, pairEdgeIds).pipe(
+                Effect.withSpan("signals.write.skill-pairs", {
+                    attributes: { "signals.count": pairsList.length },
+                }),
+            );
         }
-        yield* upsertRecovered(recoveryBatch);
-        yield* upsertFrictionEvents(frictionBatch);
-        yield* upsertDiagnosticEvents(diagnosticBatch);
+        yield* upsertRecovered(recoveryBatch).pipe(
+            Effect.withSpan("signals.write.recovered", {
+                attributes: { "signals.count": recoveryBatch.length },
+            }),
+        );
+        yield* upsertFrictionEvents(frictionBatch).pipe(
+            Effect.withSpan("signals.write.friction", {
+                attributes: { "signals.count": frictionBatch.length },
+            }),
+        );
+        yield* upsertDiagnosticEvents(diagnosticBatch).pipe(
+            Effect.withSpan("signals.write.diagnostics", {
+                attributes: { "signals.count": diagnosticBatch.length },
+            }),
+        );
 
         yield* Effect.logDebug("signals derived", {
             sessions: bundles.length,

--- a/apps/axctl/src/ingest/github-pr-stage.ts
+++ b/apps/axctl/src/ingest/github-pr-stage.ts
@@ -220,7 +220,23 @@ export const ingestGithubPrs = (
                         `UPSERT ${recordLiteral("ingest_file_state", watermarkRecordKey(COOLDOWN_SOURCE, wmPath))} CONTENT { path: ${surrealString(wmPath)}, source_kind: ${surrealString(COOLDOWN_SOURCE)}, mtime_ms: ${Math.trunc(now())}, ingested_at: time::now() };`,
                     );
                     return { degraded: false as const, ...stats };
-                }),
+                }).pipe(
+                    // Annotate INSIDE the span (tap runs before withSpan closes
+                    // it) so each parallel repo bar carries its own PR count +
+                    // degraded flag in the trace waterfall.
+                    Effect.tap((r) =>
+                        Effect.all([
+                            Effect.annotateCurrentSpan("github_pr.prs", r.pullRequests),
+                            Effect.annotateCurrentSpan("github_pr.degraded", r.degraded),
+                        ]),
+                    ),
+                    Effect.withSpan("github-pr.repo", {
+                        attributes: {
+                            // Basename only - privacy-light attribute for exported traces.
+                            "repo.name": repo.root_path.slice(repo.root_path.lastIndexOf("/") + 1),
+                        },
+                    }),
+                ),
             { concurrency: FETCH_CONCURRENCY },
         );
 

--- a/apps/axctl/src/ingest/opencode.ts
+++ b/apps/axctl/src/ingest/opencode.ts
@@ -944,7 +944,9 @@ export const ingestOpenCode = (
             } catch (error) {
                 return failedExtract(dbPath, error);
             }
-        });
+        }).pipe(Effect.withSpan("opencode.extract", {
+            attributes: { "file.name": dbPath.slice(dbPath.lastIndexOf("/") + 1) },
+        }));
 
         if (extract.sessions.length === 0) {
             return {
@@ -967,7 +969,7 @@ export const ingestOpenCode = (
                 raw_file: dbPath,
             });
         }
-        yield* executeStatements(buildOpenCodeBatchStatements(extract, dbPath), { chunkSize: 500 });
+        yield* executeStatements(buildOpenCodeBatchStatements(extract, dbPath), { chunkSize: 500, label: "opencode" });
 
         return {
             sessions: extract.sessions.length,

--- a/apps/axctl/src/ingest/outcomes.ts
+++ b/apps/axctl/src/ingest/outcomes.ts
@@ -249,7 +249,10 @@ export const deriveOutcomes = (opts: { sinceDays: number | undefined } = { since
     Effect.gen(function* () {
         const db = yield* SurrealClient;
         const [toolCalls, userTurns] = yield* Effect.all(
-            [fetchToolCalls(opts.sinceDays), fetchUserTurns(opts.sinceDays)],
+            [
+                fetchToolCalls(opts.sinceDays).pipe(Effect.withSpan("outcomes.fetch-tool-calls")),
+                fetchUserTurns(opts.sinceDays).pipe(Effect.withSpan("outcomes.fetch-user-turns")),
+            ],
             { concurrency: 2 },
         );
         const outcomes = deriveCommandOutcomes(toolCalls);
@@ -258,8 +261,10 @@ export const deriveOutcomes = (opts: { sinceDays: number | undefined } = { since
             ...outcomes.map(commandOutcomeStatement),
             ...ngrams.map(ngramStatement),
         ];
-        yield* db.query("DELETE user_message_ngram;");
-        yield* executeStatementsWith(db, statements, { chunkSize: 500 });
+        yield* db.query("DELETE user_message_ngram;").pipe(
+            Effect.withSpan("outcomes.delete-ngrams"),
+        );
+        yield* executeStatementsWith(db, statements, { chunkSize: 500, label: "outcomes" });
         return {
             commandOutcomes: outcomes.length,
             userMessageNgrams: ngrams.length,

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -832,7 +832,7 @@ export const ingestPi = (
                 ended_at: new Date(extracted.session.ended_at),
                 raw_file: extracted.sourcePath ?? undefined,
             });
-            yield* executeStatements(buildPiBatchStatements(extracted), { chunkSize: 500 });
+            yield* executeStatements(buildPiBatchStatements(extracted), { chunkSize: 500, label: "pi" });
             sessionCount += 1;
             eventCount += extracted.providerEvents.length;
             turnCount += extracted.turns.length;


### PR DESCRIPTION
## What

Stage spans in OTLP traces (Maple/Jaeger via `AX_OTLP_URL`) were monoliths — only stage + `db.exec`/`db.chunk` showed. This decomposes them with purely additive `Effect.withSpan` (same pattern as the existing db.exec spans; zero overhead with no exporter attached):

- **parsers**: `codex.file` (name+bytes, parallel bars), `opencode.extract`, `cursor.db`; claude already had `transcripts.file/parse/snapshot` on main
- **github-pr**: `github-pr.repo` per repo (pr count + degraded attrs) — the 13 concurrent gh fetches become visible bars
- **derive-metrics**: `derive.{cost-backfill,commit-reverted,pr-merge-dirty,dirty-set,spawn-parents,session-metrics,fragility-cascade}` with counts/skip-path attrs
- **signals**: per-fetch + per-writer spans (`signals.write.corrections` etc., each with `signals.count`)
- **outcomes / closure**: fetch/delete/write sub-spans
- labeled writes: `db.exec:codex|pi|opencode|cursor|sessionMetrics|outcomes|closure`

Cardinality bounded: per-file/per-repo only, no per-row spans; exporter batches (500ms).

## Verification

- typecheck exit 0; full suite 2572 pass / 0 fail
- live: `AX_OTLP_URL=http://127.0.0.1:4318 ... ingest --since=1` exit 0 against running Maple collector

🤖 Generated with [Claude Code](https://claude.com/claude-code)