### PR TITLE
design(studio): flat linear desktop — kill the graph-paper grid

### DIFF
--- a/apps/studio/src/Shell.tsx
+++ b/apps/studio/src/Shell.tsx
@@ -49,7 +49,7 @@ export function Shell({ children }: { children: ReactNode }) {
 /** Slim chrome for a standalone shared-session gist view. */
 function ShareChrome({ children }: { children: ReactNode }) {
     return (
-        <div className="shell">
+        <div className="shell shell-share">
             <header className="masthead masthead-share">
                 <div className="brand">
                     <h1>ax</h1>

--- a/apps/studio/src/routes/inspector-filter-bar.tsx
+++ b/apps/studio/src/routes/inspector-filter-bar.tsx
@@ -196,7 +196,7 @@ export function FilterBar({
         <div className="filter-bar" style={{
             position: "sticky", top: 0, zIndex: 10,
             display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center",
-            padding: "6px var(--strip-x)", borderTop: "1px solid var(--line)", background: "var(--page)",
+            padding: "8px var(--strip-x)", background: "var(--page)",
             borderBottom: "1px solid var(--line)",
             fontFamily: "ui-monospace, monospace", fontSize: 11,
         }}>

--- a/apps/studio/src/routes/session-inspect.tsx
+++ b/apps/studio/src/routes/session-inspect.tsx
@@ -463,10 +463,9 @@ export function InspectGuide({ data }: { data: Pick<SessionInspectPayload, "tota
 
     return (
         <div style={{
-            margin: "4px 24px 10px",
-            padding: "8px 10px",
-            border: "1px solid var(--line)",
-            background: "var(--page)",
+            margin: 0,
+            padding: "10px var(--strip-x) 12px",
+            borderBottom: "1px solid var(--line)",
             display: "grid",
             gap: 7,
         }}>
@@ -474,7 +473,7 @@ export function InspectGuide({ data }: { data: Pick<SessionInspectPayload, "tota
                 <div style={{ display: "flex", gap: 12, alignItems: "baseline", flexWrap: "wrap" }}>
                     <strong
                         title="Estimated total provider cost for this session from stored token usage and the model pricing catalog."
-                        style={{ color: "#141615", font: "700 15px/1 ui-monospace, monospace" }}
+                        style={{ color: "var(--ink)", font: "700 15px/1 ui-monospace, monospace" }}
                     >
                         {fmtUsd(totalCost)}
                     </strong>

--- a/apps/studio/src/routes/session-timeline.tsx
+++ b/apps/studio/src/routes/session-timeline.tsx
@@ -101,7 +101,7 @@ function Highlights({ data }: { data: SessionTimelinePayload }) {
     const h = data.highlights;
     const sub = [h.model, h.repository, h.started_at?.slice(0, 10)].filter(Boolean).join(" · ");
     return (
-        <div style={{ background: "var(--track)", borderLeft: "4px solid var(--green)", padding: "14px 18px", marginBottom: 16 }}>
+        <div style={{ background: "var(--panel)", borderBottom: "1px solid var(--line)", padding: "4px 0 14px", marginBottom: 16 }}>
             <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--muted)", fontFamily: "ui-monospace, monospace" }}>{sub}</div>
             <div style={{ display: "flex", gap: 18, flexWrap: "wrap", marginTop: 12, fontFamily: "ui-monospace, monospace" }}>
                 <Stat n={fmtDur(h.duration_ms) || "-"} label="duration" />
@@ -131,7 +131,7 @@ export function SessionTimelineBody({ data }: { readonly data: SessionTimelinePa
     }, [data]);
 
     return (
-        <div style={{ padding: "8px 24px 40px" }}>
+        <div style={{ padding: "8px var(--strip-x) 40px" }}>
             <Highlights data={data} />
             {data.segments.map((seg) => (
                 <SegmentBlock key={seg.id} seg={seg} events={eventsBySegment.get(seg.id) ?? []} />

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -460,9 +460,8 @@ function InspectBody({
 }
 
 const SUBAGENT_BAR_STYLE: CSSProperties = {
-    padding: "8px var(--strip-x)",
-    background: "var(--page)",
-    borderTop: "1px solid var(--line)",
+    padding: "10px var(--strip-x)",
+    background: "var(--panel)",
     borderBottom: "1px solid var(--line)",
     fontSize: 12,
 };

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -43,11 +43,9 @@ body,
 body {
     margin: 0;
     color: var(--ink);
-    background:
-        linear-gradient(90deg, rgba(20, 22, 21, 0.045) 1px, transparent 1px),
-        linear-gradient(180deg, rgba(20, 22, 21, 0.045) 1px, transparent 1px),
-        var(--page);
-    background-size: 22px 22px;
+    /* Flat surface. The old 22px graph-paper grid dated the whole app and
+       added texture noise between every panel - linear and quiet wins. */
+    background: var(--page);
     font-family:
         "Avenir Next",
         ui-sans-serif,
@@ -143,17 +141,25 @@ a {
     align-items: center;
 }
 
-/* Shared-session outcome header: what the session did, before the transcript. */
+/* The share view reads as a document - hold a tighter measure than the
+   full dashboard so wide monitors get margin, not stretch. */
+.shell-share {
+    max-width: 1240px;
+}
+
+/* Shared-session outcome header: what the session did, before the transcript.
+   Flat: same white surface as the panel, separated by one hairline - no tinted
+   block, no accent bar. Linear and quiet. */
 .share-hero {
-    background: var(--track);
-    border-left: 4px solid var(--green);
-    padding: 16px 20px;
-    margin: 0 0 4px;
+    background: var(--panel);
+    border-bottom: 1px solid var(--line);
+    padding: 20px var(--strip-x) 16px;
+    margin: 0;
 }
 .share-hero .share-hero-title {
     margin: 0;
     font-family: Georgia, serif;
-    font-size: 22px;
+    font-size: 21px;
     line-height: 1.3;
     color: var(--ink);
     overflow-wrap: anywhere;


### PR DESCRIPTION
Desktop reads dated and busy: the 22px graph-paper body texture shows through between every panel, the hero is a tinted block with an accent bar, and stacked strips each draw their own borders/backgrounds.

- Flat `--page` body — grid texture gone
- Share view holds a 1240px document measure (was 1480px stretch)
- Hero: white + one hairline, no tint/accent bar
- Subagent strip / jump bar / cost strip: tinted backgrounds and double borders removed; sections separate by single hairlines on the `--strip-x` spine
- Timeline highlights block flattened to match

Tests: studio 117 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)