### PR TITLE
feat: NavLink next[] follow-ups — self-documenting query surface (HATEOAS for LLMs)

### DIFF
--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -4,6 +4,8 @@ import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import { listSessionsHere, listSessionsAround, listSessionsNear, type SessionRow } from "../dashboard/sessions-query.ts";
+import { buildRecallNext, buildSessionsNext, buildSessionShowNext } from "../nav/next-links.ts";
+import { renderNextFooter } from "./next-format.ts";
 import { findCommitWindow } from "@ax/lib/git-window";
 import { AxConfig } from "@ax/lib/config";
 import { safeJsonParse } from "@ax/lib/shared/safe-json";
@@ -868,8 +870,11 @@ const cmdRecall = (opts: RecallCliOpts) =>
             ...(sources !== null ? { sources } : {}),
             scope,
         });
+        const { hits, next } = buildRecallNext(result, {
+            requestedSources: sources ?? ["turn"],
+        });
         if (opts.json) {
-            console.log(JSON.stringify(result, null, 2));
+            console.log(JSON.stringify({ ...result, hits, next }, null, 2));
             return;
         }
 
@@ -878,6 +883,9 @@ const cmdRecall = (opts: RecallCliOpts) =>
         // --- turns section ---
         if (result.hits.length === 0 && !multiSource) {
             console.log(`no matches for "${opts.query}"`);
+            // Errors-as-teaching: name the broader queries to try next.
+            const footer = renderNextFooter(next);
+            if (footer) console.log(footer);
             return;
         }
         if (result.hits.length > 0) {
@@ -935,6 +943,8 @@ const cmdRecall = (opts: RecallCliOpts) =>
             }
         }
 
+        const footer = renderNextFooter(next);
+        if (footer) console.log(footer);
     });
 
 const cmdSearch = (args: string[]) =>
@@ -3243,9 +3253,10 @@ const cmdSessionsHere = (args: string[]) =>
             : allRows.filter((r) => r.source !== "claude-subagent");
         const hiddenSubagents = allRows.length - visible.length;
         const rows = limit === null ? visible : visible.slice(0, limit);
+        const { sessions, next } = buildSessionsNext(rows);
 
         if (json) {
-            console.log(JSON.stringify(rows, null, 2));
+            console.log(JSON.stringify({ sessions, next }, null, 2));
             return;
         }
         console.log(formatSessionsTable(rows));
@@ -3257,6 +3268,8 @@ const cmdSessionsHere = (args: string[]) =>
             notes.push(`showing ${rows.length} of ${visible.length} - raise --limit`);
         }
         if (notes.length > 0) console.log(`(${notes.join("; ")})`);
+        const footer = renderNextFooter(next);
+        if (footer) console.log(footer);
     });
 
 // --- sessions around ---
@@ -3302,12 +3315,19 @@ const cmdSessionsAround = (args: string[]) =>
         }
 
         const rows = yield* listSessionsAround({ date, days, project });
+        const { sessions, next } = buildSessionsNext(rows, {
+            date: positional,
+            days,
+            project,
+        });
 
         if (json) {
-            console.log(JSON.stringify(rows, null, 2));
+            console.log(JSON.stringify({ sessions, next }, null, 2));
             return;
         }
         console.log(formatSessionsTable(rows));
+        const footer = renderNextFooter(next);
+        if (footer) console.log(footer);
     });
 
 // --- sessions near ---
@@ -3367,12 +3387,15 @@ const cmdSessionsNear = (args: string[]) =>
         }
 
         const rows = yield* listSessionsNear({ from, to, repositoryKey });
+        const { sessions, next } = buildSessionsNext(rows);
 
         if (json) {
-            console.log(JSON.stringify(rows, null, 2));
+            console.log(JSON.stringify({ sessions, next }, null, 2));
             return;
         }
         console.log(formatSessionsTable(rows));
+        const footer = renderNextFooter(next);
+        if (footer) console.log(footer);
     });
 
 // ---------------------------------------------------------------------------
@@ -3437,10 +3460,12 @@ const cmdSessionShow = (args: string[]) =>
             catchDbErrorAndExit("axctl session show"),
         );
 
+        const next = buildSessionShowNext(payload);
+
         if (useJson) {
-            console.log(renderSessionJson(payload, { metrics }));
+            console.log(renderSessionJson(payload, { metrics, next }));
         } else {
-            console.log(renderSessionMarkdown(payload, { metrics }));
+            console.log(renderSessionMarkdown(payload, { metrics, next }));
         }
     });
 
@@ -3468,7 +3493,8 @@ const sessionShowCommand = Command.make(
         "commits that fixed them). " +
         "--expand=<uuid> (repeatable) or --all expands subagent timelines inline. " +
         "--by-role groups the Top skills section by role. " +
-        "Auto markdown on TTY, JSON when piped. --json forces JSON.",
+        "Auto markdown on TTY, JSON when piped. --json forces JSON. " +
+        "Output ends with a `next:` footer of copy-paste follow-up commands (resume in harness, open parent, expand subagents).",
     ),
 );
 
@@ -3507,7 +3533,8 @@ const sessionsHereCommand = Command.make(
 ).pipe(Command.withDescription(
     "List sessions for the current git repository (default: last 14 days). "
     + "Subagent (claude-subagent) sessions are hidden by default - --include-subagents shows them; "
-    + "--limit N caps the rows printed.",
+    + "--limit N caps the rows printed. "
+    + "Output ends with a `next:` footer of copy-paste follow-up commands (drill-in, harness resume); --json carries the same links as a {sessions, next} envelope.",
 ));
 
 const sessionsAroundCommand = Command.make(
@@ -3525,7 +3552,10 @@ const sessionsAroundCommand = Command.make(
             ...stringArg("project", optionValue(project)),
             ...boolArg("json", json),
         ]),
-).pipe(Command.withDescription("List sessions in a ±N-day window around a date (YYYY-MM-DD or ISO8601)"));
+).pipe(Command.withDescription(
+    "List sessions in a ±N-day window around a date (YYYY-MM-DD or ISO8601). "
+    + "Output ends with a `next:` footer of copy-paste follow-up commands (drill-in, harness resume); --json carries the same links as a {sessions, next} envelope.",
+));
 
 const sessionsNearCommand = Command.make(
     "near",
@@ -3540,7 +3570,8 @@ const sessionsNearCommand = Command.make(
 ).pipe(Command.withDescription(
     "List sessions that overlapped with a git commit window (from the predecessor commit's timestamp to this commit's timestamp). " +
     "Pass a full or short SHA. Must be inside the target git repo. " +
-    "See the ax:extract-workflow skill for narrating workflows around a sha.",
+    "See the ax:extract-workflow skill for narrating workflows around a sha. " +
+    "Output ends with a `next:` footer of copy-paste follow-up commands; --json carries the same links as a {sessions, next} envelope.",
 ));
 
 // ---------------------------------------------------------------------------
@@ -4859,7 +4890,8 @@ const recallCommand = Command.make(
         "Cross-session text search (BM25). --sources=turn,commit,skill chooses record types (default turn). " +
         "--scope=here filters to the current repo (auto-detected); --scope=all overrides. " +
         "--project=? / --skill=? opens an interactive picker. " +
-        "See the ax:extract-workflow skill for narrating workflows behind shipped artifacts.",
+        "See the ax:extract-workflow skill for narrating workflows behind shipped artifacts. " +
+        "Output ends with a `next:` footer of copy-paste follow-up commands (drill into a session, resume it in its harness); --json carries the same links in a `next` field.",
     ),
 );
 

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -4,7 +4,16 @@ import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import { listSessionsHere, listSessionsAround, listSessionsNear, type SessionRow } from "../dashboard/sessions-query.ts";
-import { buildRecallNext, buildSessionsNext, buildSessionShowNext } from "../nav/next-links.ts";
+import {
+    buildRecallNext,
+    buildSessionsNext,
+    buildSessionShowNext,
+    buildSkillsWeightedNext,
+    buildSkillsByRoleNext,
+    buildSkillsRolesNext,
+    buildRolesNext,
+    buildImproveProposalsNext,
+} from "../nav/next-links.ts";
 import { renderNextFooter } from "./next-format.ts";
 import { findCommitWindow } from "@ax/lib/git-window";
 import { AxConfig } from "@ax/lib/config";
@@ -1377,6 +1386,8 @@ const cmdSkillsWeighted = (args: string[]) =>
             console.log(renderWeightedJson(result));
         } else {
             console.log(renderWeightedTable(result));
+            const footer = renderNextFooter(buildSkillsWeightedNext(result));
+            if (footer) console.log(footer);
         }
     });
 
@@ -1407,6 +1418,8 @@ const cmdSkillsByRole = (args: string[]) =>
             console.log(renderSkillsByRoleJson(result, role));
         } else {
             console.log(renderSkillsByRoleTable(result, role));
+            const footer = renderNextFooter(buildSkillsByRoleNext(result, role));
+            if (footer) console.log(footer);
         }
     });
 
@@ -1437,6 +1450,8 @@ const cmdRolesForSkill = (args: string[]) =>
             console.log(renderRolesForSkillJson(result, skill));
         } else {
             console.log(renderRolesForSkillTable(result, skill));
+            const footer = renderNextFooter(buildSkillsRolesNext(result, skill));
+            if (footer) console.log(footer);
         }
     });
 
@@ -1456,6 +1471,8 @@ const cmdRoles = (args: string[]) =>
             console.log(renderAllRolesJson(result));
         } else {
             console.log(renderAllRolesTable(result));
+            const footer = renderNextFooter(buildRolesNext(result));
+            if (footer) console.log(footer);
         }
     });
 
@@ -2554,12 +2571,19 @@ const cmdImproveList = (args: string[]) =>
             console.log(prettyPrint(rows));
             return;
         }
+        const improveNext = buildImproveProposalsNext(
+            rows.map((r) => ({ sig: r.dedupe_sig, title: r.title })),
+        );
         if (rows.length === 0) {
             console.log("(no proposals match filter)");
+            const footer = renderNextFooter(improveNext);
+            if (footer) console.log(footer);
             return;
         }
         console.log(`  freq  conf    status      form         dedupe_sig                title`);
         for (const row of rows) console.log(formatProposalLine(row));
+        const footer = renderNextFooter(improveNext);
+        if (footer) console.log(footer);
     });
 
 const cmdImproveShow = (args: string[]) =>
@@ -2653,6 +2677,14 @@ const cmdImproveRecommend = (args: string[]) =>
         }
         const formatted = formatRecommendations(items);
         console.log(formatted);
+        {
+            const footer = renderNextFooter(
+                buildImproveProposalsNext(
+                    items.map((i) => ({ sig: i.shortId, title: i.title })),
+                ),
+            );
+            if (footer) console.log(footer);
+        }
         if (items.length > 0 && !noClipboard) {
             const copied = copyToClipboard(formatted);
             if (copied) console.log("\n[copied to clipboard]");

--- a/apps/axctl/src/cli/next-format.test.ts
+++ b/apps/axctl/src/cli/next-format.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import type { NavLink } from "@ax/lib/shared/nav-link";
+import { renderNextFooter } from "./next-format.ts";
+
+const link = (over: Partial<NavLink>): NavLink => ({
+    description: "do thing",
+    cmd: "ax sessions show abc",
+    ...over,
+});
+
+describe("renderNextFooter", () => {
+    test("renders cmd links with dim description comments", () => {
+        const out = renderNextFooter([
+            link({ cmd: "codex resume abc", description: "resume it" }),
+        ]);
+        expect(out).toContain("next:");
+        expect(out).toContain("codex resume abc");
+        expect(out).toContain("# resume it");
+    });
+
+    test("call-only links are skipped; empty result when none have cmd", () => {
+        const out = renderNextFooter([
+            { description: "mcp only", call: { tool: "recall", arguments: {} } },
+        ]);
+        expect(out).toBe("");
+    });
+
+    test("sorts by priority desc and caps at 4", () => {
+        const links = [1, 2, 3, 4, 5].map((p) =>
+            link({ cmd: `cmd-${p}`, ui: { priority: p } }),
+        );
+        const out = renderNextFooter(links);
+        expect(out).toContain("cmd-5");
+        expect(out).not.toContain("cmd-1");
+        expect(out.indexOf("cmd-5")).toBeLessThan(out.indexOf("cmd-2"));
+    });
+});

--- a/apps/axctl/src/cli/next-format.ts
+++ b/apps/axctl/src/cli/next-format.ts
@@ -1,0 +1,34 @@
+/**
+ * CLI rendering for NavLinks - the `next:` footer.
+ *
+ * Text output shows `cmd` links only (a terminal user can't paste an MCP
+ * call); priority-sorted, capped at 4, with the description as a dim ANSI
+ * comment after the command - matching the inline-ANSI convention used by
+ * cmdRecall / formatSessionsTable. `--json` output carries the full NavLink
+ * objects instead, so agents driving the CLI get both transports.
+ */
+import type { NavLink } from "@ax/lib/shared/nav-link";
+import { sortNavLinks } from "@ax/lib/shared/nav-link";
+
+const MAX_FOOTER_LINKS = 4;
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+
+/**
+ * Render the `next:` footer. Returns "" when no link has a `cmd` - callers
+ * can append unconditionally.
+ */
+export const renderNextFooter = (
+    links: ReadonlyArray<NavLink>,
+): string => {
+    const cmds = sortNavLinks(links)
+        .filter((l): l is NavLink & { cmd: string } => typeof l.cmd === "string")
+        .slice(0, MAX_FOOTER_LINKS);
+    if (cmds.length === 0) return "";
+
+    const width = Math.max(...cmds.map((l) => l.cmd.length));
+    const lines = cmds.map(
+        (l) => `  ${l.cmd.padEnd(width)}   ${DIM}# ${l.description}${RESET}`,
+    );
+    return `\nnext:\n${lines.join("\n")}`;
+};

--- a/apps/axctl/src/cli/session-show-format.ts
+++ b/apps/axctl/src/cli/session-show-format.ts
@@ -17,12 +17,17 @@ import type {
 import type { RevertedCommitDetail, SessionDurabilityDetail } from "../metrics/reverted-commits.ts";
 import { renderByRoleSection } from "./role-format.ts";
 import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
+import type { NavLink } from "@ax/lib/shared/nav-link";
+import { renderNextFooter } from "./next-format.ts";
 
 /** Optional enrichments rendered alongside the base session payload. */
 export interface SessionShowExtras {
     /** Durability drill-down (#176): the commits behind durability_ratio.
      *  Null/undefined → no Metrics section rendered. */
     readonly metrics?: SessionDurabilityDetail | null;
+    /** NavLink follow-ups (resume command, parent, expand-subagents).
+     *  Rendered as a `next:` footer (markdown) / `next` field (JSON). */
+    readonly next?: ReadonlyArray<NavLink>;
 }
 
 /** Last `n` hex chars of a UUID-like string, same pattern as cmdRecall. */
@@ -339,6 +344,12 @@ export function renderSessionMarkdown(
         }
     }
 
+    // ── next: footer (NavLinks - resume / parent / expand) ───────────────────
+    if (extras.next && extras.next.length > 0) {
+        const footer = renderNextFooter(extras.next);
+        if (footer) lines.push(footer);
+    }
+
     return lines.join("\n");
 }
 
@@ -360,6 +371,9 @@ export function renderSessionJson(
                 : {}),
             ...(extras.metrics !== null && extras.metrics !== undefined
                 ? { metrics: extras.metrics }
+                : {}),
+            ...(extras.next !== undefined && extras.next.length > 0
+                ? { next: extras.next }
                 : {}),
         },
         null,

--- a/apps/axctl/src/dashboard/sessions-query.ts
+++ b/apps/axctl/src/dashboard/sessions-query.ts
@@ -20,6 +20,8 @@ export interface SessionRow {
     readonly ended_at: string | null;
     readonly source: string;
     readonly project: string | null;
+    /** Session working directory - feeds the resume-command NavLink. */
+    readonly cwd: string | null;
     readonly repository: string | null;
     readonly turn_count: number;
     readonly first_user_message: string | null;
@@ -40,6 +42,7 @@ const SESSION_SELECT = `
     type::string(ended_at) AS ended_at,
     source,
     project,
+    cwd,
     type::string(repository) AS repository
 FROM session`.trim();
 
@@ -74,6 +77,7 @@ const enrichSessions = (
         readonly ended_at: string | null;
         readonly source: string;
         readonly project: string | null;
+        readonly cwd: string | null;
         readonly repository: string | null;
     }>,
 ): Effect.Effect<SessionRow[], DbError, SurrealClient | AxConfig> =>

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -173,21 +173,93 @@ describe("sessions_around date parsing", () => {
         await expect(tool.run({}, unreachableRt)).rejects.toThrow(/Invalid date/);
     });
 
-    it("maps a valid ISO date to a Date and calls the runtime", async () => {
-        let captured: { date?: Date } | undefined;
+    it("maps a valid ISO date to a Date and returns the {sessions, next} envelope", async () => {
         const rt = {
-            runPromise: (_eff: unknown) => {
-                // listSessionsAround was already invoked with the parsed opts by
-                // the time we get here; we can't see opts directly, so instead
-                // re-run the mapping check via a spy on Date construction below.
-                return Promise.resolve([]);
-            },
+            runPromise: (_eff: unknown) => Promise.resolve([]),
         } as never;
-        const result = await tool.run({ date: "2026-01-15" }, rt);
-        expect(result).toEqual([]);
+        const result = (await tool.run({ date: "2026-01-15" }, rt)) as {
+            sessions: ReadonlyArray<unknown>;
+            next: ReadonlyArray<{ description: string }>;
+        };
+        expect(result.sessions).toEqual([]);
+        // empty window + date → errors-as-teaching widen link
+        expect(result.next.length).toBeGreaterThan(0);
         // sanity: the same valid string parses to a valid Date
-        captured = { date: new Date("2026-01-15") };
-        expect(Number.isNaN(captured.date!.getTime())).toBe(false);
+        expect(Number.isNaN(new Date("2026-01-15").getTime())).toBe(false);
+    });
+});
+
+describe("NavLink next[] wiring", () => {
+    const byName = (n: string) => axMcpTools.find((t) => t.name === n)!;
+
+    it("recall / sessions_around / session_show descriptions teach the next protocol", () => {
+        for (const name of ["recall", "sessions_around", "session_show"]) {
+            expect(byName(name).description).toContain("`next`");
+        }
+    });
+
+    it("recall result carries per-hit and top-level next links", async () => {
+        const stub = {
+            q: "timeline",
+            hits: [
+                {
+                    turn_id: "turn:1",
+                    session_id: "019e2531-b552-7b53-a029-c780adbb6560",
+                    project: null,
+                    source: "codex",
+                    cwd: null,
+                    role: "user",
+                    ts: "2026-06-09T02:00:00.000Z",
+                    snippet: "x",
+                },
+            ],
+            commits: [],
+            skills: [],
+            truncated: false,
+            total_count: 5,
+            total_counts: { turn: 5, commit: 0, skill: 0 },
+            window: { offset: 0, limit: 50 },
+        };
+        const rt = { runPromise: () => Promise.resolve(stub) } as never;
+        const result = (await byName("recall").run({ q: "timeline" }, rt)) as {
+            hits: ReadonlyArray<{ next?: ReadonlyArray<unknown> }>;
+            next: ReadonlyArray<{ cmd?: string }>;
+        };
+        expect(result.hits[0]?.next).toHaveLength(1);
+        expect(
+            result.next.some((l) => l.cmd === "codex resume 019e2531-b552-7b53-a029-c780adbb6560"),
+        ).toBe(true);
+    });
+
+    it("session_show result carries next with a resume link", async () => {
+        const stub = {
+            session: {
+                overview: {
+                    id: "019e2531-b552-7b53-a029-c780adbb6560",
+                    project: null,
+                    cwd: "/tmp/p",
+                    model: null,
+                    source: "claude",
+                    started_at: null,
+                    ended_at: null,
+                },
+                top_skills: [],
+                tool_calls: [],
+                children: [],
+                parent: null,
+                agent_delegations: [],
+                token_usage: null,
+            },
+            expanded_subagents: [],
+            by_role: null,
+            compactions: [],
+        };
+        const rt = { runPromise: () => Promise.resolve(stub) } as never;
+        const result = (await byName("session_show").run(
+            { sessionId: "019e2531-b552-7b53-a029-c780adbb6560" },
+            rt,
+        )) as { next: ReadonlyArray<{ cmd?: string }> };
+        expect(result.next.some((l) => l.cmd?.includes("claude --resume"))).toBe(true);
     });
 });
 

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -49,6 +49,11 @@ import {
     buildRecallNext,
     buildSessionsNext,
     buildSessionShowNext,
+    buildSkillsWeightedNext,
+    buildSkillsByRoleNext,
+    buildSkillsRolesNext,
+    buildRolesNext,
+    buildImproveProposalsNext,
 } from "../nav/next-links.ts";
 
 /**
@@ -202,7 +207,7 @@ const sessionShowTool: AxMcpTool = {
 const skillsWeightedTool: AxMcpTool = {
     name: "skills_weighted",
     description:
-        "Rank skills by usage x role-weight (score = invocations x role-weight). Returns ranked rows plus a doctor summary of unclassified skills. Use to see which skills actually carry weight in recent work.",
+        `Rank skills by usage x role-weight (score = invocations x role-weight). Returns ranked rows plus a doctor summary of unclassified skills. Use to see which skills actually carry weight in recent work. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {
         windowDays: z
             .number()
@@ -224,14 +229,15 @@ const skillsWeightedTool: AxMcpTool = {
             ...(windowDays !== undefined ? { windowDays } : {}),
             ...(limit !== undefined ? { limit } : {}),
         };
-        return await rt.runPromise(fetchSkillsWeighted(params));
+        const result = await rt.runPromise(fetchSkillsWeighted(params));
+        return { ...result, next: buildSkillsWeightedNext(result) };
     },
 };
 
 const skillsByRoleTool: AxMcpTool = {
     name: "skills_by_role",
     description:
-        "List skills tagged with a given role, ranked by invocation count. Returns rows with source/confidence/rationale and whether any skill matched the role.",
+        `List skills tagged with a given role, ranked by invocation count. Returns rows with source/confidence/rationale and whether any skill matched the role. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {
         role: z
             .string()
@@ -250,14 +256,15 @@ const skillsByRoleTool: AxMcpTool = {
             role,
             ...(limit !== undefined ? { limit } : {}),
         };
-        return await rt.runPromise(fetchSkillsByRole(params));
+        const result = await rt.runPromise(fetchSkillsByRole(params));
+        return { ...result, next: buildSkillsByRoleNext(result, role) };
     },
 };
 
 const skillsRolesTool: AxMcpTool = {
     name: "skills_roles",
     description:
-        "List the roles a given skill plays, with weights, source, confidence and rationale. Returns whether the skill exists. The inverse of skills_by_role.",
+        `List the roles a given skill plays, with weights, source, confidence and rationale. Returns whether the skill exists. The inverse of skills_by_role. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {
         skill: z
             .string()
@@ -265,17 +272,19 @@ const skillsRolesTool: AxMcpTool = {
     },
     run: async (args, rt) => {
         const skill = String(args.skill ?? "");
-        return await rt.runPromise(fetchRolesForSkill({ skill }));
+        const result = await rt.runPromise(fetchRolesForSkill({ skill }));
+        return { ...result, next: buildSkillsRolesNext(result, skill) };
     },
 };
 
 const rolesTool: AxMcpTool = {
     name: "roles",
     description:
-        "List the full role vocabulary with each role's weight and the number of skills classified into it. Use to discover valid role labels for skills_by_role.",
+        `List the full role vocabulary with each role's weight and the number of skills classified into it. Use to discover valid role labels for skills_by_role. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {},
     run: async (_args, rt) => {
-        return await rt.runPromise(fetchAllRoles());
+        const result = await rt.runPromise(fetchAllRoles());
+        return { ...result, next: buildRolesNext(result) };
     },
 };
 
@@ -284,7 +293,7 @@ const RECOMMEND_AGENTS = ["claude", "codex"] as const;
 const improveRecommendTool: AxMcpTool = {
     name: "improve_recommend",
     description:
-        "Rank open self-improvement proposals by confidence x recency x frequency. Returns the shortlist of grounded suggestions the agent could accept. Use to surface what to improve next.",
+        `Rank open self-improvement proposals by confidence x recency x frequency. Returns an envelope { proposals, next } - the shortlist of grounded suggestions the agent could accept. Use to surface what to improve next. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {
         limit: z
             .number()
@@ -324,7 +333,11 @@ const improveRecommendTool: AxMcpTool = {
             ...(agent !== undefined ? { agent } : {}),
             ...(sinceDays !== undefined ? { sinceDays } : {}),
         };
-        return await rt.runPromise(recommend(input));
+        const items = await rt.runPromise(recommend(input));
+        const next = buildImproveProposalsNext(
+            items.map((i) => ({ sig: i.shortId, title: i.title })),
+        );
+        return { proposals: items, next };
     },
 };
 
@@ -347,7 +360,7 @@ const improveShowTool: AxMcpTool = {
 const improveListTool: AxMcpTool = {
     name: "improve_list",
     description:
-        "List the experiment-loop proposal shortlist, filterable by status and form. Returns proposal rows ordered by frequency. Use to browse proposals beyond the ranked improve_recommend view.",
+        `List the experiment-loop proposal shortlist, filterable by status and form. Returns an envelope { proposals, next } - proposal rows ordered by frequency. Use to browse proposals beyond the ranked improve_recommend view. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {
         status: z
             .string()
@@ -373,7 +386,11 @@ const improveListTool: AxMcpTool = {
             ...(form !== undefined ? { form } : {}),
             ...(limit !== undefined ? { limit } : {}),
         };
-        return await rt.runPromise(listProposals(input));
+        const rows = await rt.runPromise(listProposals(input));
+        const next = buildImproveProposalsNext(
+            rows.map((r) => ({ sig: r.dedupe_sig, title: r.title })),
+        );
+        return { proposals: rows, next };
     },
 };
 

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -44,6 +44,12 @@ import { showExperiment } from "../improve/show.ts";
 import { listProposals, type ListProposalsInput } from "../improve/list.ts";
 import { fetchSessionMetrics } from "../metrics/session-metrics-query.ts";
 import { SIGNAL_CATALOG, findSignal, runRelationSignal } from "../metrics/catalog.ts";
+import {
+    NEXT_PROTOCOL_HINT,
+    buildRecallNext,
+    buildSessionsNext,
+    buildSessionShowNext,
+} from "../nav/next-links.ts";
 
 /**
  * The long-lived MCP runtime, built from `AppLayer` (SurrealClient + config +
@@ -73,7 +79,7 @@ const RECALL_SOURCES = ["turn", "commit", "skill"] as const;
 const recallTool: AxMcpTool = {
     name: "recall",
     description:
-        "Full-text recall across the ax graph: search turns (conversation excerpts), git commits, and skills. Returns scored hits with source, excerpt, and provenance.",
+        `Full-text recall across the ax graph: search turns (conversation excerpts), git commits, and skills. Returns scored hits with source, excerpt, and provenance. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {
         q: z.string().describe("Search query (required). Matched against turn text, commit messages, and skill metadata."),
         limit: z
@@ -105,14 +111,18 @@ const recallTool: AxMcpTool = {
             ...(sources && sources.length > 0 ? { sources } : {}),
         };
 
-        return await rt.runPromise(fetchRecall(params));
+        const result = await rt.runPromise(fetchRecall(params));
+        const { hits, next } = buildRecallNext(result, {
+            requestedSources: params.sources ?? ["turn"],
+        });
+        return { ...result, hits, next };
     },
 };
 
 const sessionsAroundTool: AxMcpTool = {
     name: "sessions_around",
     description:
-        "List agent sessions in a time window centred on a date (default +/-3 days). Returns session rows with turn counts and the first user message. Use to find what work happened around a given day.",
+        `List agent sessions in a time window centred on a date (default +/-3 days). Returns an envelope { sessions, next } - session rows with turn counts and the first user message. Use to find what work happened around a given day. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {
         date: z
             .string()
@@ -141,14 +151,19 @@ const sessionsAroundTool: AxMcpTool = {
             ...(days !== undefined ? { days } : {}),
             ...(project !== undefined ? { project } : {}),
         };
-        return await rt.runPromise(listSessionsAround(opts));
+        const rows = await rt.runPromise(listSessionsAround(opts));
+        return buildSessionsNext(rows, {
+            date: dateStr,
+            ...(days !== undefined ? { days } : {}),
+            ...(project !== undefined ? { project } : {}),
+        });
     },
 };
 
 const sessionShowTool: AxMcpTool = {
     name: "session_show",
     description:
-        "Show one session in detail: base facts, optionally expanded subagent children, and optional skill-by-role grouping. Use after sessions_around / recall to drill into a specific session id.",
+        `Show one session in detail: base facts, optionally expanded subagent children, and optional skill-by-role grouping. Use after sessions_around / recall to drill into a specific session id. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {
         sessionId: z
             .string()
@@ -179,7 +194,8 @@ const sessionShowTool: AxMcpTool = {
             expandAll,
             ...(byRole !== undefined ? { byRole } : {}),
         };
-        return await rt.runPromise(fetchSessionShow(opts));
+        const payload = await rt.runPromise(fetchSessionShow(opts));
+        return { ...payload, next: buildSessionShowNext(payload) };
     },
 };
 

--- a/apps/axctl/src/nav/next-links.test.ts
+++ b/apps/axctl/src/nav/next-links.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from "bun:test";
+import type {
+    RecallResponse,
+    RecallHit,
+    SessionViewPayload,
+    SessionDetailPayload,
+} from "@ax/lib/shared/dashboard-types";
+import type { SessionRow } from "../dashboard/sessions-query.ts";
+import {
+    buildRecallNext,
+    buildSessionsNext,
+    buildSessionShowNext,
+} from "./next-links.ts";
+
+const UUID_A = "019e2531-b552-7b53-a029-c780adbb6560";
+const UUID_B = "019e9999-aaaa-7b53-a029-c780adbb6560";
+
+const hit = (over: Partial<RecallHit>): RecallHit => ({
+    turn_id: "turn:1",
+    session_id: UUID_A,
+    project: "-Users-x-proj",
+    source: "claude",
+    cwd: "/Users/x/proj",
+    role: "user",
+    ts: "2026-06-09T02:00:00.000Z",
+    snippet: "timeline vision",
+    ...over,
+});
+
+const recallResponse = (
+    hits: ReadonlyArray<RecallHit>,
+    total = hits.length,
+): RecallResponse => ({
+    q: "timeline",
+    hits,
+    commits: [],
+    skills: [],
+    truncated: false,
+    total_count: total,
+    total_counts: { turn: total, commit: 0, skill: 0 },
+    window: { offset: 0, limit: 50 },
+});
+
+const row = (over: Partial<SessionRow>): SessionRow => ({
+    id: UUID_A,
+    started_at: "2026-06-09T02:00:00.000Z",
+    ended_at: null,
+    source: "claude",
+    project: "-Users-x-proj",
+    cwd: "/Users/x/proj",
+    repository: null,
+    turn_count: 5,
+    first_user_message: "hello",
+    ...over,
+});
+
+const detail = (over: Partial<SessionDetailPayload>): SessionDetailPayload => ({
+    overview: {
+        id: UUID_A,
+        project: "-Users-x-proj",
+        cwd: "/Users/x/proj",
+        model: null,
+        source: "claude",
+        started_at: "2026-06-09T02:00:00.000Z",
+        ended_at: null,
+    },
+    top_skills: [],
+    tool_calls: [],
+    children: [],
+    parent: null,
+    agent_delegations: [],
+    token_usage: null,
+    ...over,
+});
+
+const view = (session: SessionDetailPayload): SessionViewPayload => ({
+    session,
+    expanded_subagents: [],
+    by_role: null,
+    compactions: [],
+});
+
+describe("buildRecallNext", () => {
+    test("per-hit next is exactly one session drill-in", () => {
+        const { hits } = buildRecallNext(recallResponse([hit({})]), {
+            requestedSources: ["turn"],
+        });
+        expect(hits[0]?.next).toHaveLength(1);
+        expect(hits[0]?.next?.[0]?.call?.tool).toBe("session_show");
+        expect(hits[0]?.next?.[0]?.call?.arguments).toEqual({ sessionId: UUID_A });
+        expect(hits[0]?.next?.[0]?.cmd).toBe(`ax sessions show ${UUID_A}`);
+    });
+
+    test("top-level next carries resume cmd for claude hit with cwd", () => {
+        const { next } = buildRecallNext(recallResponse([hit({})]), {
+            requestedSources: ["turn"],
+        });
+        const resume = next.find((l) => l.ui?.group === "resume");
+        expect(resume?.cmd).toBe(`cd /Users/x/proj && claude --resume ${UUID_A}`);
+    });
+
+    test("codex hit → codex resume cmd", () => {
+        const { next } = buildRecallNext(
+            recallResponse([hit({ source: "codex", session_id: UUID_B })]),
+            { requestedSources: ["turn"] },
+        );
+        const resume = next.find((l) => l.ui?.group === "resume");
+        expect(resume?.cmd).toBe(`codex resume ${UUID_B}`);
+    });
+
+    test("subagent hit → no resume link", () => {
+        const { next } = buildRecallNext(
+            recallResponse([
+                hit({ source: "claude-subagent", session_id: "claude-subagent-abc" }),
+            ]),
+            { requestedSources: ["turn"] },
+        );
+        expect(next.find((l) => l.ui?.group === "resume")).toBeUndefined();
+    });
+
+    test("resume links dedupe by session and cap at 2 distinct sessions", () => {
+        const { next } = buildRecallNext(
+            recallResponse([
+                hit({}),
+                hit({}),
+                hit({ session_id: UUID_B }),
+                hit({ session_id: "019e3333-b552-7b53-a029-c780adbb6560" }),
+            ]),
+            { requestedSources: ["turn"] },
+        );
+        expect(next.filter((l) => l.ui?.group === "resume")).toHaveLength(2);
+    });
+
+    test("empty result teaches broaden + sessions_around", () => {
+        const { next } = buildRecallNext(recallResponse([], 0), {
+            requestedSources: ["turn"],
+        });
+        expect(next.length).toBeGreaterThanOrEqual(2);
+        const tools = next.map((l) => l.call?.tool);
+        expect(tools).toContain("recall");
+        expect(tools).toContain("sessions_around");
+    });
+
+    test("thin results from subset sources suggest broadening", () => {
+        const { next } = buildRecallNext(recallResponse([hit({})], 1), {
+            requestedSources: ["turn"],
+        });
+        const broaden = next.find((l) => l.call?.tool === "recall");
+        expect(broaden?.call?.arguments).toEqual({
+            q: "timeline",
+            sources: ["turn", "commit", "skill"],
+        });
+    });
+
+    test("all sources requested + results → no broaden link", () => {
+        const { next } = buildRecallNext(recallResponse([hit({})], 5), {
+            requestedSources: ["turn", "commit", "skill"],
+        });
+        expect(next.find((l) => l.call?.tool === "recall")).toBeUndefined();
+    });
+});
+
+describe("buildSessionsNext", () => {
+    test("per-row drill-in + top resume", () => {
+        const { sessions, next } = buildSessionsNext([row({})]);
+        expect(sessions[0]?.next?.[0]?.call?.tool).toBe("session_show");
+        const resume = next.find((l) => l.ui?.group === "resume");
+        expect(resume?.cmd).toBe(`cd /Users/x/proj && claude --resume ${UUID_A}`);
+    });
+
+    test("pi/opencode/cursor rows get no resume link", () => {
+        const { next } = buildSessionsNext([
+            row({ source: "pi" }),
+            row({ source: "opencode", id: UUID_B }),
+        ]);
+        expect(next.filter((l) => l.ui?.group === "resume")).toHaveLength(0);
+    });
+
+    test("empty window with date teaches widening", () => {
+        const { next } = buildSessionsNext([], { date: "2026-06-09", days: 3 });
+        const widen = next.find((l) => l.call?.tool === "sessions_around");
+        expect(widen?.call?.arguments).toEqual({ date: "2026-06-09", days: 6 });
+    });
+
+    test("empty window with project filter teaches dropping it", () => {
+        const { next } = buildSessionsNext([], {
+            date: "2026-06-09",
+            days: 3,
+            project: "-Users-x-proj",
+        });
+        expect(next).toHaveLength(2);
+    });
+});
+
+describe("buildSessionShowNext", () => {
+    test("claude session → resume link first", () => {
+        const next = buildSessionShowNext(view(detail({})));
+        expect(next[0]?.cmd).toBe(`cd /Users/x/proj && claude --resume ${UUID_A}`);
+    });
+
+    test("subagent session → parent link, no resume", () => {
+        const next = buildSessionShowNext(
+            view(
+                detail({
+                    overview: {
+                        id: "claude-subagent-abc",
+                        project: null,
+                        cwd: null,
+                        model: null,
+                        source: "claude-subagent",
+                        started_at: null,
+                        ended_at: null,
+                    },
+                    parent: {
+                        session_id: UUID_A,
+                        project: null,
+                        started_at: null,
+                        nickname: null,
+                        tool: null,
+                        ts: null,
+                    },
+                }),
+            ),
+        );
+        expect(next.find((l) => l.ui?.group === "resume")).toBeUndefined();
+        expect(next[0]?.call?.arguments).toEqual({ sessionId: UUID_A });
+        expect(next[0]?.description).toContain("parent");
+    });
+
+    test("children unexpanded → expand-all link", () => {
+        const next = buildSessionShowNext(
+            view(
+                detail({
+                    children: [
+                        {
+                            session_id: "claude-subagent-x",
+                            project: null,
+                            started_at: null,
+                            nickname: null,
+                            tool: null,
+                            ts: null,
+                        },
+                    ],
+                }),
+            ),
+        );
+        const expand = next.find((l) => l.call?.arguments.expandAll === true);
+        expect(expand?.cmd).toBe(`ax sessions show ${UUID_A} --all`);
+    });
+
+    test("no overview → empty next", () => {
+        const next = buildSessionShowNext(view(detail({ overview: null })));
+        expect(next).toHaveLength(0);
+    });
+});

--- a/apps/axctl/src/nav/next-links.test.ts
+++ b/apps/axctl/src/nav/next-links.test.ts
@@ -10,6 +10,11 @@ import {
     buildRecallNext,
     buildSessionsNext,
     buildSessionShowNext,
+    buildSkillsWeightedNext,
+    buildSkillsByRoleNext,
+    buildSkillsRolesNext,
+    buildRolesNext,
+    buildImproveProposalsNext,
 } from "./next-links.ts";
 
 const UUID_A = "019e2531-b552-7b53-a029-c780adbb6560";
@@ -251,5 +256,122 @@ describe("buildSessionShowNext", () => {
     test("no overview → empty next", () => {
         const next = buildSessionShowNext(view(detail({ overview: null })));
         expect(next).toHaveLength(0);
+    });
+});
+
+describe("buildSkillsWeightedNext", () => {
+    const wrow = {
+        skill_id: "skill:tdd",
+        skill_name: "tdd",
+        invocations: 10,
+        session_count: 4,
+        roles: [],
+        weight: 1,
+        score: 10,
+    };
+
+    test("unclassified skills → classify cmd; top row → roles link", () => {
+        const next = buildSkillsWeightedNext({
+            rows: [wrow],
+            doctor: { unclassified_count: 7, threshold: 5, advice: "classify" },
+        });
+        expect(next[0]?.cmd).toBe("ax skills classify");
+        expect(next[1]?.call?.tool).toBe("skills_roles");
+        expect(next[1]?.call?.arguments).toEqual({ skill: "tdd" });
+    });
+
+    test("clean doctor + no rows → empty next", () => {
+        const next = buildSkillsWeightedNext({
+            rows: [],
+            doctor: { unclassified_count: 0, threshold: 5, advice: null },
+        });
+        expect(next).toHaveLength(0);
+    });
+});
+
+describe("buildSkillsByRoleNext", () => {
+    test("role not found → roles teaching link", () => {
+        const next = buildSkillsByRoleNext({ rows: [], found: false }, "nope");
+        expect(next[0]?.call?.tool).toBe("roles");
+        expect(next[0]?.cmd).toBe("ax roles");
+    });
+
+    test("rows → roles-of-top-skill link", () => {
+        const next = buildSkillsByRoleNext(
+            {
+                rows: [
+                    {
+                        skill_id: "skill:tdd",
+                        skill_name: "tdd",
+                        source: "manual",
+                        confidence: 1,
+                        rationale: null,
+                        invocations: 9,
+                    },
+                ],
+                found: true,
+            },
+            "verifier",
+        );
+        expect(next[0]?.call?.arguments).toEqual({ skill: "tdd" });
+    });
+});
+
+describe("buildSkillsRolesNext", () => {
+    test("unknown skill → recall-the-catalog teaching link", () => {
+        const next = buildSkillsRolesNext({ rows: [], skillExists: false }, "tdx");
+        expect(next[0]?.call?.tool).toBe("recall");
+        expect(next[0]?.call?.arguments).toEqual({ q: "tdx", sources: ["skill"] });
+    });
+
+    test("top role → skills_by_role link", () => {
+        const next = buildSkillsRolesNext(
+            {
+                rows: [
+                    {
+                        role_name: "verifier",
+                        role_weight: 2,
+                        source: "manual",
+                        confidence: 1,
+                        edge_weight_override: null,
+                        rationale: null,
+                        since: null,
+                    },
+                ],
+                skillExists: true,
+            },
+            "tdd",
+        );
+        expect(next[0]?.call?.tool).toBe("skills_by_role");
+        expect(next[0]?.cmd).toBe("ax skills by-role verifier");
+    });
+});
+
+describe("buildRolesNext", () => {
+    test("links into the largest role", () => {
+        const next = buildRolesNext({
+            rows: [
+                { name: "verifier", weight: 2, skill_count: 3 },
+                { name: "scout", weight: 1, skill_count: 9 },
+            ],
+        });
+        expect(next[0]?.call?.arguments).toEqual({ role: "scout" });
+    });
+});
+
+describe("buildImproveProposalsNext", () => {
+    test("first proposal → show link + cmd-only accept", () => {
+        const next = buildImproveProposalsNext([
+            { sig: "abc123", title: "Add a guard hook" },
+        ]);
+        const show = next.find((l) => l.call?.tool === "improve_show");
+        expect(show?.call?.arguments).toEqual({ sigOrId: "abc123" });
+        const accept = next.find((l) => l.cmd === "ax improve accept abc123");
+        expect(accept?.call).toBeUndefined(); // mutating - cmd-only, never MCP
+    });
+
+    test("empty shortlist → widen-status teaching link", () => {
+        const next = buildImproveProposalsNext([]);
+        expect(next[0]?.call?.arguments).toEqual({ status: "all" });
     });
 });

--- a/apps/axctl/src/nav/next-links.ts
+++ b/apps/axctl/src/nav/next-links.ts
@@ -28,6 +28,12 @@ import type {
 import type { WithNext } from "@ax/lib/shared/nav-link";
 import type { SessionRow } from "../dashboard/sessions-query.ts";
 import type { RecallSource } from "../dashboard/recall.ts";
+import type { SkillsWeightedResult } from "../dashboard/skills-weighted.ts";
+import type {
+    FetchSkillsByRoleResult,
+    FetchRolesForSkillResult,
+    FetchAllRolesResult,
+} from "../dashboard/role-queries.ts";
 
 // ---------------------------------------------------------------------------
 // Protocol hint - appended to tool/CLI descriptions
@@ -308,5 +314,159 @@ export const buildSessionShowNext = (
         });
     }
 
+    return sortNavLinks(top);
+};
+
+// ---------------------------------------------------------------------------
+// skills weighted / by-role / roles
+// ---------------------------------------------------------------------------
+
+/** skills_by_role link - dual transport. */
+const skillsByRoleLink = (
+    role: string,
+    description: string,
+    priority = 6,
+): NavLink => ({
+    description,
+    call: { tool: "skills_by_role", arguments: { role } },
+    cmd: `ax skills by-role ${role}`,
+    ui: { priority, group: "read" },
+});
+
+/** Top-level links for the weighted skill ranking. */
+export const buildSkillsWeightedNext = (
+    result: SkillsWeightedResult,
+): ReadonlyArray<NavLink> => {
+    const top: NavLink[] = [];
+    if (result.doctor.unclassified_count > 0) {
+        top.push({
+            description: `${result.doctor.unclassified_count} skills are unclassified - emit classify briefs to improve the ranking`,
+            cmd: "ax skills classify",
+            ui: { priority: 9, group: "classify" },
+        });
+    }
+    const topRow = result.rows[0];
+    if (topRow) {
+        top.push(
+            skillRolesLink(
+                topRow.skill_name,
+                "Inspect the roles behind the top-ranked skill",
+                6,
+            ),
+        );
+    }
+    return sortNavLinks(top);
+};
+
+/** Top-level links for a skills-by-role listing. */
+export const buildSkillsByRoleNext = (
+    result: FetchSkillsByRoleResult,
+    _role: string,
+): ReadonlyArray<NavLink> => {
+    const top: NavLink[] = [];
+    if (!result.found || result.rows.length === 0) {
+        // Errors-as-teaching: name the tool that lists valid role labels.
+        top.push({
+            description: "No skills matched this role - list the valid role labels",
+            call: { tool: "roles", arguments: {} },
+            cmd: "ax roles",
+            ui: { priority: 9, group: "search" },
+        });
+        return top;
+    }
+    const topSkill = result.rows[0];
+    if (topSkill) {
+        top.push(
+            skillRolesLink(
+                topSkill.skill_name,
+                "See all roles the top skill plays",
+                6,
+            ),
+        );
+    }
+    return sortNavLinks(top);
+};
+
+/** Top-level links for a roles-of-skill listing. */
+export const buildSkillsRolesNext = (
+    result: FetchRolesForSkillResult,
+    skill: string,
+): ReadonlyArray<NavLink> => {
+    const top: NavLink[] = [];
+    if (!result.skillExists) {
+        // Errors-as-teaching: find the right skill name via recall.
+        top.push({
+            description: `Unknown skill "${skill}" - search the skill catalog for the right name`,
+            call: { tool: "recall", arguments: { q: skill, sources: ["skill"] } },
+            cmd: `ax recall ${JSON.stringify(skill)} --sources=skill`,
+            ui: { priority: 9, group: "search" },
+        });
+        return top;
+    }
+    const topRole = result.rows[0];
+    if (topRole) {
+        top.push(
+            skillsByRoleLink(
+                topRole.role_name,
+                "List the other skills that play this skill's top role",
+                6,
+            ),
+        );
+    }
+    return sortNavLinks(top);
+};
+
+/** Top-level links for the role vocabulary listing. */
+export const buildRolesNext = (
+    result: FetchAllRolesResult,
+): ReadonlyArray<NavLink> => {
+    const top: NavLink[] = [];
+    const biggest = [...result.rows].sort((a, b) => b.skill_count - a.skill_count)[0];
+    if (biggest) {
+        top.push(
+            skillsByRoleLink(
+                biggest.name,
+                `Drill into the largest role (${biggest.skill_count} skills)`,
+                6,
+            ),
+        );
+    }
+    return sortNavLinks(top);
+};
+
+// ---------------------------------------------------------------------------
+// improve (recommend / list)
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level links for proposal shortlists. `sig` is the dedupe signature /
+ * short id accepted by improve_show and `ax improve accept`. The accept
+ * link is cmd-only: mutating ops are deliberately not exposed over MCP.
+ */
+export const buildImproveProposalsNext = (
+    proposals: ReadonlyArray<{ readonly sig: string; readonly title: string }>,
+): ReadonlyArray<NavLink> => {
+    const top: NavLink[] = [];
+    const first = proposals[0];
+    if (!first) {
+        top.push({
+            description: "No proposals - widen the filter to all statuses",
+            call: { tool: "improve_list", arguments: { status: "all" } },
+            cmd: "ax improve list --status=all",
+            ui: { priority: 8, group: "search" },
+        });
+        return top;
+    }
+    top.push({
+        description: `Inspect the evidence trail behind the top proposal ("${first.title.slice(0, 60)}")`,
+        call: { tool: "improve_show", arguments: { sigOrId: first.sig } },
+        cmd: `ax improve show ${first.sig}`,
+        ui: { priority: 7, group: "read" },
+    });
+    top.push({
+        description: "Accept the top proposal (emits a .ax/tasks brief; CLI-only, mutating)",
+        cmd: `ax improve accept ${first.sig}`,
+        ui: { priority: 5, group: "act" },
+    });
     return sortNavLinks(top);
 };

--- a/apps/axctl/src/nav/next-links.ts
+++ b/apps/axctl/src/nav/next-links.ts
@@ -1,0 +1,312 @@
+/**
+ * NavLink builders - "HATEOAS for LLMs" assembly layer.
+ *
+ * Pure functions of query payloads (no DB, no Effect) consumed by BOTH the
+ * MCP tools and the CLI handlers. Query functions in `dashboard/` stay pure
+ * data (they also serve the SPA); turning results into agent affordances is
+ * a presentation-protocol concern that lives here.
+ *
+ * Two-tier policy (ported from quera's unified-search):
+ *   - per-hit `next`: exactly one drill-in link.
+ *   - top-level `next`: cross-cutting follow-ups, priority-ordered. The
+ *     flagship link is the harness resume command for a session result.
+ *   - errors-as-teaching: empty results return links that name the broader
+ *     query to try next instead of a bare empty array.
+ *
+ * Every link carries both transports when possible: `call` (MCP tool payload,
+ * copy verbatim) and `cmd` (literal shell command, run as-is).
+ */
+import type { NavLink } from "@ax/lib/shared/nav-link";
+import { sortNavLinks } from "@ax/lib/shared/nav-link";
+import { buildResumeAction } from "@ax/lib/shared/resume-command";
+import { toBareSessionId } from "@ax/lib/shared/session-id";
+import type {
+    RecallResponse,
+    RecallHit,
+    SessionViewPayload,
+} from "@ax/lib/shared/dashboard-types";
+import type { WithNext } from "@ax/lib/shared/nav-link";
+import type { SessionRow } from "../dashboard/sessions-query.ts";
+import type { RecallSource } from "../dashboard/recall.ts";
+
+// ---------------------------------------------------------------------------
+// Protocol hint - appended to tool/CLI descriptions
+// ---------------------------------------------------------------------------
+
+export const NEXT_PROTOCOL_HINT =
+    "Results include a `next` array of ready-to-run follow-up actions: copy `call` payloads verbatim into the named tool, or run `cmd` strings as-is (e.g. the exact harness resume command for a session). Empty results return `next` suggestions for broader queries.";
+
+// ---------------------------------------------------------------------------
+// Shared link constructors
+// ---------------------------------------------------------------------------
+
+/** Drill-in link for a session id - dual transport. */
+export const sessionShowLink = (
+    sessionId: string,
+    description = "Drill into this session",
+    priority = 8,
+): NavLink => {
+    const id = toBareSessionId(sessionId);
+    return {
+        description,
+        call: { tool: "session_show", arguments: { sessionId: id } },
+        cmd: `ax sessions show ${id}`,
+        ui: { priority, group: "read" },
+    };
+};
+
+/** Roles-of-skill link - dual transport. */
+export const skillRolesLink = (
+    skill: string,
+    description = "List the roles this skill plays",
+    priority = 6,
+): NavLink => ({
+    description,
+    call: { tool: "skills_roles", arguments: { skill } },
+    cmd: `ax skills roles ${skill}`,
+    ui: { priority, group: "read" },
+});
+
+/**
+ * Resume link for a session, or null when the source has no verified resume
+ * path (subagent → handled by caller via parent link; pi/opencode/cursor →
+ * deliberately omitted).
+ */
+export const sessionResumeLink = (input: {
+    readonly sessionId: string;
+    readonly source: string;
+    readonly cwd?: string | null;
+    readonly priority?: number;
+}): NavLink | null => {
+    const action = buildResumeAction({
+        sessionId: input.sessionId,
+        source: input.source,
+        cwd: input.cwd ?? null,
+    });
+    if (action.kind !== "resume" || action.command === null) return null;
+    const caveat = action.note ? ` (${action.note})` : "";
+    return {
+        description: `Resume this session in its harness (${input.source})${caveat}`,
+        cmd: action.command,
+        ui: { priority: input.priority ?? 10, group: "resume" },
+    };
+};
+
+/** sessions_around link centred on a timestamp - dual transport. */
+const sessionsAroundLink = (
+    ts: string,
+    days: number,
+    description: string,
+    priority = 5,
+): NavLink => {
+    const date = ts.slice(0, 10); // YYYY-MM-DD
+    return {
+        description,
+        call: { tool: "sessions_around", arguments: { date, days } },
+        cmd: `ax sessions around ${date} --days=${days}`,
+        ui: { priority, group: "search" },
+    };
+};
+
+// ---------------------------------------------------------------------------
+// recall
+// ---------------------------------------------------------------------------
+
+const ALL_SOURCES: ReadonlyArray<RecallSource> = ["turn", "commit", "skill"];
+
+export interface RecallNextOptions {
+    readonly requestedSources: ReadonlyArray<RecallSource>;
+}
+
+export interface RecallWithNext {
+    readonly hits: ReadonlyArray<WithNext<RecallHit>>;
+    readonly next: ReadonlyArray<NavLink>;
+}
+
+/**
+ * Decorate a RecallResponse: per-hit drill-ins + top-level cross-cutting
+ * links (resume for the most recent resumable sessions, browse-the-day,
+ * broaden-sources when results are thin or absent).
+ */
+export const buildRecallNext = (
+    r: RecallResponse,
+    opts: RecallNextOptions,
+): RecallWithNext => {
+    const hits: Array<WithNext<RecallHit>> = r.hits.map((h) => ({
+        ...h,
+        next: [sessionShowLink(h.session_id, "Read the session this turn belongs to")],
+    }));
+
+    const top: NavLink[] = [];
+
+    // ① Resume the most recent resumable sessions (hits are ts DESC; dedupe
+    //    by session id, cap at 2 distinct sessions).
+    const seen = new Set<string>();
+    for (const h of r.hits) {
+        if (seen.size >= 2) break;
+        const id = toBareSessionId(h.session_id);
+        if (seen.has(id)) continue;
+        seen.add(id);
+        const link = sessionResumeLink({
+            sessionId: id,
+            source: h.source ?? "",
+            cwd: h.cwd,
+        });
+        if (link) top.push(link);
+    }
+
+    // ② Browse what else happened around the top hit.
+    const topTs = r.hits[0]?.ts;
+    if (topTs) {
+        top.push(
+            sessionsAroundLink(topTs, 1, "See what else happened around the top hit", 5),
+        );
+    }
+
+    const broaden: NavLink = {
+        description: "Broaden the search to all sources (turns, commits, skills)",
+        call: { tool: "recall", arguments: { q: r.q, sources: [...ALL_SOURCES] } },
+        cmd: `ax recall ${JSON.stringify(r.q)} --sources=turn,commit,skill`,
+        ui: { priority: 4, group: "search" },
+    };
+    const subsetRequested = opts.requestedSources.length < ALL_SOURCES.length;
+
+    if (r.total_count === 0) {
+        // Errors-as-teaching: nothing matched - name the broader queries.
+        if (subsetRequested) top.push({ ...broaden, ui: { ...broaden.ui, priority: 9 } });
+        top.push({
+            description:
+                "No text match - browse sessions near a known date instead",
+            call: { tool: "sessions_around", arguments: { date: "<YYYY-MM-DD>", days: 3 } },
+            cmd: "ax sessions around <YYYY-MM-DD> --days=3",
+            ui: { priority: 8, group: "search" },
+        });
+    } else if (subsetRequested && r.total_count < 3) {
+        // ④ Thin results from a subset of sources - suggest widening.
+        top.push(broaden);
+    }
+
+    return { hits, next: sortNavLinks(top) };
+};
+
+// ---------------------------------------------------------------------------
+// sessions (here / around / near)
+// ---------------------------------------------------------------------------
+
+export interface SessionsNextOptions {
+    readonly date?: string | undefined;
+    readonly days?: number | undefined;
+    readonly project?: string | null | undefined;
+}
+
+export interface SessionsWithNext {
+    readonly sessions: ReadonlyArray<WithNext<SessionRow>>;
+    readonly next: ReadonlyArray<NavLink>;
+}
+
+/**
+ * Decorate session rows: per-row drill-in + top-level resume links for the
+ * most recent resumable sessions. Empty windows teach widening.
+ */
+export const buildSessionsNext = (
+    rows: ReadonlyArray<SessionRow>,
+    opts: SessionsNextOptions = {},
+): SessionsWithNext => {
+    const sessions: Array<WithNext<SessionRow>> = rows.map((row) => ({
+        ...row,
+        next: [sessionShowLink(row.id)],
+    }));
+
+    const top: NavLink[] = [];
+
+    // ① Resume links for the most recent resumable sessions (rows arrive
+    //    newest-first from the queries; cap at 2).
+    let resumes = 0;
+    for (const row of rows) {
+        if (resumes >= 2) break;
+        const link = sessionResumeLink({
+            sessionId: row.id,
+            source: row.source,
+            cwd: row.cwd,
+        });
+        if (link) {
+            top.push(link);
+            resumes += 1;
+        }
+    }
+
+    // ⑤ Empty window - teach widening / dropping the filter.
+    if (rows.length === 0 && opts.date) {
+        const widened = (opts.days ?? 3) * 2;
+        top.push(
+            sessionsAroundLink(
+                opts.date,
+                widened,
+                `No sessions in the window - widen to ±${widened} days`,
+                9,
+            ),
+        );
+        if (opts.project) {
+            top.push({
+                description: "Drop the project filter and search all projects",
+                call: {
+                    tool: "sessions_around",
+                    arguments: { date: opts.date.slice(0, 10), days: opts.days ?? 3 },
+                },
+                cmd: `ax sessions around ${opts.date.slice(0, 10)} --days=${opts.days ?? 3}`,
+                ui: { priority: 8, group: "search" },
+            });
+        }
+    }
+
+    return { sessions, next: sortNavLinks(top) };
+};
+
+// ---------------------------------------------------------------------------
+// session show
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level links for a session detail view: resume (or parent for
+ * subagents), expand-subagents when children exist but none are expanded.
+ */
+export const buildSessionShowNext = (
+    p: SessionViewPayload,
+): ReadonlyArray<NavLink> => {
+    const top: NavLink[] = [];
+    const overview = p.session.overview;
+    if (!overview) return top;
+    const id = toBareSessionId(overview.id);
+
+    // ① Resume - or ② the parent link when this is a subagent session.
+    const resume = sessionResumeLink({
+        sessionId: id,
+        source: overview.source,
+        cwd: overview.cwd,
+    });
+    if (resume) top.push(resume);
+
+    if (p.session.parent) {
+        top.push(
+            sessionShowLink(
+                p.session.parent.session_id,
+                overview.source === "claude-subagent"
+                    ? "Subagent sessions are not resumable - open the parent session"
+                    : "Open the parent session",
+                9,
+            ),
+        );
+    }
+
+    // ⑥ Expand subagents when children exist and nothing is expanded yet.
+    if (p.session.children.length > 0 && p.expanded_subagents.length === 0) {
+        top.push({
+            description: `Expand all ${p.session.children.length} subagent children inline`,
+            call: { tool: "session_show", arguments: { sessionId: id, expandAll: true } },
+            cmd: `ax sessions show ${id} --all`,
+            ui: { priority: 7, group: "read" },
+        });
+    }
+
+    return sortNavLinks(top);
+};

--- a/apps/axctl/src/queries/recall.ts
+++ b/apps/axctl/src/queries/recall.ts
@@ -31,6 +31,7 @@ SELECT
     session,
     session.project AS project,
     session.source AS source,
+    session.cwd AS cwd,
     role,
     ts,
     text_excerpt
@@ -158,6 +159,7 @@ export const recallTurnsQuery = defineQuery<
             session_id: toBareSessionId(session),
             project: stringField(raw, "project"),
             source: stringField(raw, "source"),
+            cwd: stringField(raw, "cwd"),
             role: stringField(raw, "role"),
             ts: dateField(raw, "ts"),
             snippet: truncate(text, 240),

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -645,6 +645,8 @@ export interface RecallHit {
     readonly session_id: SessionId;
     readonly project: string | null;
     readonly source: string | null;
+    /** Session working directory - feeds the resume-command NavLink. */
+    readonly cwd: string | null;
     readonly role: string | null;
     readonly ts: string | null;
     readonly snippet: string;

--- a/packages/lib/src/shared/nav-link.ts
+++ b/packages/lib/src/shared/nav-link.ts
@@ -1,0 +1,44 @@
+/**
+ * NavLink - "HATEOAS for LLMs".
+ *
+ * Instead of teaching the whole tool/CLI grammar upfront in descriptions,
+ * responses carry `next` links that describe valid follow-up actions with
+ * ready-to-run payloads. An agent copies `call.arguments` verbatim into the
+ * named MCP tool, or runs `cmd` as-is in a shell. Two transports because ax
+ * is driven both ways: MCP tool calls and CLI/Bash. Some affordances (e.g.
+ * the harness resume command) only exist as shell commands.
+ */
+
+/** An MCP follow-up call. Copy `arguments` verbatim - do not edit. */
+export interface NavLinkCall {
+	/** Tool name to invoke. */
+	readonly tool: string;
+	/** Arguments object to pass. Copy verbatim. */
+	readonly arguments: Record<string, unknown>;
+}
+
+/**
+ * A ready-to-run follow-up action. At least one of `call` / `cmd` is set.
+ * `call` = MCP follow-up; `cmd` = literal shell command (copy-paste as-is).
+ */
+export interface NavLink {
+	/** Human/LLM-readable hint for when to use this link. */
+	readonly description: string;
+	readonly call?: NavLinkCall;
+	readonly cmd?: string;
+	readonly ui?: {
+		/** Higher sorts first. */
+		readonly priority?: number;
+		/** Grouping hint, e.g. "resume" | "read" | "search" | "navigate". */
+		readonly group?: string;
+	};
+}
+
+/** A payload extended with navigation links. */
+export type WithNext<T> = T & { readonly next?: ReadonlyArray<NavLink> };
+
+/** Sort links by `ui.priority` descending (missing priority = 0). */
+export const sortNavLinks = (
+	links: ReadonlyArray<NavLink>,
+): ReadonlyArray<NavLink> =>
+	[...links].sort((a, b) => (b.ui?.priority ?? 0) - (a.ui?.priority ?? 0));

--- a/packages/lib/src/shared/resume-command.test.ts
+++ b/packages/lib/src/shared/resume-command.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { buildResumeAction } from "./resume-command.ts";
+
+const UUID = "019e2531-b552-7b53-a029-c780adbb6560";
+
+describe("buildResumeAction", () => {
+	test("claude with cwd → cd-prefixed claude --resume", () => {
+		const a = buildResumeAction({
+			sessionId: UUID,
+			source: "claude",
+			cwd: "/Users/x/proj",
+		});
+		expect(a.kind).toBe("resume");
+		expect(a.command).toBe(`cd /Users/x/proj && claude --resume ${UUID}`);
+	});
+
+	test("claude without cwd → bare claude --resume with note", () => {
+		const a = buildResumeAction({ sessionId: UUID, source: "claude" });
+		expect(a.kind).toBe("resume");
+		expect(a.command).toBe(`claude --resume ${UUID}`);
+		expect(a.note).toContain("project directory");
+	});
+
+	test("claude cwd with shell-unsafe chars is quoted", () => {
+		const a = buildResumeAction({
+			sessionId: UUID,
+			source: "claude",
+			cwd: "/Users/x/my proj",
+		});
+		expect(a.command).toBe(`cd '/Users/x/my proj' && claude --resume ${UUID}`);
+	});
+
+	test("codex → codex resume, no cd prefix", () => {
+		const a = buildResumeAction({
+			sessionId: UUID,
+			source: "codex",
+			cwd: "/Users/x/proj",
+		});
+		expect(a.kind).toBe("resume");
+		expect(a.command).toBe(`codex resume ${UUID}`);
+	});
+
+	test("claude-subagent → parent kind, no command", () => {
+		const a = buildResumeAction({
+			sessionId: "claude-subagent-abc123",
+			source: "claude-subagent",
+			parentSessionId: UUID,
+		});
+		expect(a.kind).toBe("parent");
+		expect(a.command).toBeNull();
+		expect(a.note).toContain("parent");
+	});
+
+	test("pi / opencode / cursor / unknown → unsupported, no command", () => {
+		for (const source of ["pi", "opencode", "cursor", "mystery"]) {
+			const a = buildResumeAction({ sessionId: UUID, source });
+			expect(a.kind).toBe("unsupported");
+			expect(a.command).toBeNull();
+		}
+	});
+
+	test("session id is sanitized to bare form", () => {
+		const a = buildResumeAction({
+			sessionId: `session:⟨${UUID}⟩`,
+			source: "codex",
+		});
+		expect(a.command).toBe(`codex resume ${UUID}`);
+	});
+});

--- a/packages/lib/src/shared/resume-command.ts
+++ b/packages/lib/src/shared/resume-command.ts
@@ -1,0 +1,83 @@
+/**
+ * Resume-command builder - maps a session's `source` harness to the literal
+ * shell command that resumes it. The single source of truth for "how do I
+ * continue this session", consumed by the NavLink builders (MCP + CLI).
+ *
+ * Verified facts (2026-06-10):
+ *   - codex: ax session id == provider rollout UUID (ingest/codex.ts), and
+ *     `codex resume <SESSION_ID>` accepts it directly - no cwd needed, codex
+ *     resolves rollouts from ~/.codex/sessions.
+ *   - claude: session id == claude UUID v7. `claude --resume <uuid>` is
+ *     project-dir scoped (transcripts live under ~/.claude/projects/<slug>/),
+ *     so the `cd <cwd> && ` prefix is load-bearing when cwd is known.
+ *   - claude-subagent: synthetic ids, not resumable - point at the parent.
+ *   - pi / opencode / cursor: resume syntax unverified - deliberately emit
+ *     nothing rather than teach an agent a command we haven't tested.
+ */
+
+import { type SessionId, toBareSessionId } from "./session-id.ts";
+
+export type ResumeKind = "resume" | "parent" | "unsupported";
+
+export interface ResumeAction {
+	readonly kind: ResumeKind;
+	/** Literal shell command, e.g. "cd /p && claude --resume <uuid>". Null unless kind="resume". */
+	readonly command: string | null;
+	/** Caveat or why-not, e.g. "subagent sessions are not resumable; open the parent". */
+	readonly note: string | null;
+}
+
+export interface ResumeInput {
+	/** Session id in any form - record-id decoration is stripped. */
+	readonly sessionId: SessionId;
+	/** Provider source: 'claude' | 'codex' | 'claude-subagent' | 'pi' | 'opencode' | 'cursor' | ... */
+	readonly source: string;
+	readonly cwd?: string | null;
+	readonly parentSessionId?: SessionId | null;
+}
+
+/** Command templates - one constant each so a syntax fix is a one-line change. */
+const CLAUDE_RESUME = (id: string): string => `claude --resume ${id}`;
+const CODEX_RESUME = (id: string): string => `codex resume ${id}`;
+
+const SHELL_SAFE_RE = /^[A-Za-z0-9_\-./~]+$/;
+
+/** Single-quote a path for shell interpolation unless it's already safe. */
+const shellPath = (p: string): string =>
+	SHELL_SAFE_RE.test(p) ? p : `'${p.replace(/'/g, "'\\''")}'`;
+
+export const buildResumeAction = (input: ResumeInput): ResumeAction => {
+	const id = toBareSessionId(input.sessionId);
+	switch (input.source) {
+		case "claude": {
+			if (input.cwd) {
+				return {
+					kind: "resume",
+					command: `cd ${shellPath(input.cwd)} && ${CLAUDE_RESUME(id)}`,
+					note: null,
+				};
+			}
+			return {
+				kind: "resume",
+				command: CLAUDE_RESUME(id),
+				note: "run from the session's project directory - claude resume is project-dir scoped",
+			};
+		}
+		case "codex":
+			return { kind: "resume", command: CODEX_RESUME(id), note: null };
+		case "claude-subagent":
+			return {
+				kind: "parent",
+				command: null,
+				note: input.parentSessionId
+					? `subagent sessions are not resumable - open the parent session ${toBareSessionId(input.parentSessionId)}`
+					: "subagent sessions are not resumable - open the parent session",
+			};
+		default:
+			return {
+				kind: "unsupported",
+				command: null,
+				note: `resume not supported for source '${input.source}' yet`,
+			};
+	}
+};


### PR DESCRIPTION
## What

Query responses now carry a `next` array of ready-to-run follow-up actions — MCP `call` payloads to copy verbatim and literal shell `cmd` strings. Flagship affordance: any session result includes the exact harness resume command (`claude --resume <uuid>`, `codex resume <uuid>`), so finding a lost session and continuing it is one query + one copy-paste.

## Surfaces

**Wave 1:** `recall`, `sessions here/around/near`, `sessions show` (CLI footer + `--json` + MCP)
**Wave 2:** `skills weighted/by-role/roles`, `roles`, `improve recommend/list`

## Design

- `packages/lib/src/shared/nav-link.ts` — NavLink types, dual transport
- `packages/lib/src/shared/resume-command.ts` — source → resume-command map (claude cd-prefixed, codex bare, subagent → parent link, pi/opencode/cursor deliberately omitted until verified)
- `apps/axctl/src/nav/next-links.ts` — pure builders shared by MCP + CLI; errors-as-teaching on empty results
- Mutating ops (`improve accept`) are cmd-only links — read-only MCP invariant preserved

## Breaking

`ax sessions * --json` now emits `{sessions, next}` instead of a bare array. improve/skills CLI `--json` unchanged (retro skill compat).

## Tests

2610 pass / 0 fail; live-smoked: recall footer w/ resume cmds, codex resume, subagent→parent, teaching footers on empty results, MCP envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)