### PR TITLE
feat(share): session poster hero + per-session OG images

### DIFF
--- a/apps/site/app/routes/s.$owner.$gistId.tsx
+++ b/apps/site/app/routes/s.$owner.$gistId.tsx
@@ -9,12 +9,26 @@ export const Route = createFileRoute("/s/$owner/$gistId")({
     sub: typeof search.sub === "string" && search.sub.length > 0 ? search.sub : undefined,
     view: search.view === "timeline" ? ("timeline" as const) : undefined,
   }),
-  head: ({ params }) => ({
-    meta: [
-      { title: `Shared ax session - ${params.owner}/${params.gistId}` },
-      { name: "description", content: "A shared ax session rendered from a Gist artifact." },
-    ],
-  }),
+  head: ({ params }) => {
+    const og = `https://ax.necmttn.com/og/${params.owner}/${params.gistId}`;
+    const url = `https://ax.necmttn.com/s/${params.owner}/${params.gistId}`;
+    return {
+      meta: [
+        { title: `Shared ax session - ${params.owner}/${params.gistId}` },
+        { name: "description", content: "A recorded AI coding-agent session - every turn, tool call, and dollar." },
+        { property: "og:title", content: "Shared ax session" },
+        { property: "og:description", content: "A recorded AI coding-agent session - every turn, tool call, and dollar." },
+        { property: "og:type", content: "website" },
+        { property: "og:url", content: url },
+        // Poster rendered from the session's own data by /og/:owner/:gistId.
+        { property: "og:image", content: og },
+        { property: "og:image:width", content: "1200" },
+        { property: "og:image:height", content: "630" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:image", content: og },
+      ],
+    };
+  },
   component: SharedSessionFrame,
 });
 

--- a/apps/site/functions/og/[owner]/[gistId].ts
+++ b/apps/site/functions/og/[owner]/[gistId].ts
@@ -1,0 +1,152 @@
+/**
+ * Per-session OG image: a poster derived from the share's gist manifest
+ * (`index.json`) - verdict, title, headline numbers, and the subagent
+ * fan-out as cost-shaded lane bars on a shared time axis. The same visual
+ * language as the share page's hero, so the link preview IS the product.
+ *
+ * Served at /og/<owner>/<gistId> (PNG, 1200x630). Cached aggressively:
+ * a given gist's manifest is immutable enough for a day.
+ */
+import { ImageResponse } from "workers-og";
+
+interface SubagentCard {
+    readonly started_at?: string;
+    readonly ended_at?: string;
+    readonly duration_ms: number | null;
+    readonly cost_usd: number | null;
+    readonly stats?: { readonly failures?: number };
+}
+
+interface Manifest {
+    readonly kind: string;
+    readonly session: { readonly summary?: string; readonly model?: string; readonly started_at?: string };
+    readonly stats: { readonly files_changed: number };
+    readonly totals: {
+        readonly cost_usd: number | null;
+        readonly duration_ms: number | null;
+        readonly tool_calls: number;
+        readonly turns: number;
+        readonly subagents: number;
+        readonly failures: number;
+    };
+    readonly subagents: ReadonlyArray<SubagentCard>;
+}
+
+const esc = (s: string): string =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+const cleanSummary = (raw: string | undefined): string => {
+    const text = (raw ?? "").replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+    return text.length > 0 ? (text.length > 120 ? `${text.slice(0, 119)}…` : text) : "Shared agent session";
+};
+
+const fmtDuration = (ms: number | null): string | null => {
+    if (ms == null || ms <= 0) return null;
+    const h = Math.floor(ms / 3_600_000);
+    const m = Math.round((ms % 3_600_000) / 60_000);
+    return h > 0 ? `${h}h ${m}m` : `${m}m`;
+};
+
+const fmtUsd = (n: number | null): string | null =>
+    n == null ? null : `$${n >= 100 ? n.toFixed(0) : n.toFixed(2)}`;
+
+/** Greedy-packed subagent lanes as absolutely-positioned divs. */
+function laneHtml(cards: ReadonlyArray<SubagentCard>): string {
+    const times = cards
+        .map((c) => ({ t: Date.parse(c.started_at ?? ""), d: c.duration_ms ?? 0, cost: c.cost_usd ?? 0, failed: (c.stats?.failures ?? 0) > 0 }))
+        .filter((c) => Number.isFinite(c.t));
+    if (times.length === 0) return "";
+    const t0 = Math.min(...times.map((c) => c.t));
+    const t1 = Math.max(...times.map((c) => c.t + Math.max(c.d, 60_000)));
+    const span = Math.max(t1 - t0, 60_000);
+    const maxCost = Math.max(0.01, ...times.map((c) => c.cost));
+    const laneEnds: number[] = [];
+    let bars = "";
+    for (const c of times.sort((p, q) => p.t - q.t)) {
+        const x = (c.t - t0) / span;
+        const w = Math.max(c.d / span, 0.008);
+        let r = 0;
+        while (r < laneEnds.length && laneEnds[r] > x - 0.004) r++;
+        if (r >= 5) r = 4;
+        laneEnds[r] = x + w;
+        const opacity = (0.35 + 0.6 * (c.cost / maxCost)).toFixed(2);
+        bars += `<div style="position:absolute;left:${(x * 100).toFixed(2)}%;top:${r * 22}px;width:${Math.max(w * 100, 0.8).toFixed(2)}%;height:16px;border-radius:3px;background:${c.failed ? "#bd443b" : "#b32650"};opacity:${opacity}"></div>`;
+    }
+    return `<div style="display:flex;position:relative;width:100%;height:${laneEnds.length * 22}px">${bars}</div>`;
+}
+
+export const onRequestGet: PagesFunction = async (ctx) => {
+    const owner = String(ctx.params.owner ?? "");
+    const gistId = String(ctx.params.gistId ?? "").replace(/\.png$/, "");
+    if (!/^[A-Za-z0-9-]+$/.test(owner) || !/^[a-f0-9]+$/.test(gistId)) {
+        return new Response("bad request", { status: 400 });
+    }
+    const cache = (caches as unknown as { default: Cache }).default;
+    const cacheKey = new Request(ctx.request.url);
+    const hit = await cache.match(cacheKey);
+    if (hit) return hit;
+
+    const manifestRes = await fetch(
+        `https://gist.githubusercontent.com/${owner}/${gistId}/raw/index.json`,
+        { headers: { "user-agent": "ax-og" } },
+    );
+    if (!manifestRes.ok) return new Response("not found", { status: 404 });
+    const manifest = (await manifestRes.json()) as Manifest;
+    if (manifest.kind !== "manifest") return new Response("not a share", { status: 404 });
+
+    const t = manifest.totals;
+    const title = esc(cleanSummary(manifest.session.summary));
+    const date = (manifest.session.started_at ?? "").slice(0, 10);
+    const right = [fmtUsd(t.cost_usd), fmtDuration(t.duration_ms), date].filter(Boolean).join(" · ");
+    const stat = (n: string, label: string) =>
+        `<div style="display:flex;flex-direction:column"><span style="font-size:40px;font-weight:700;color:#141615">${n}</span><span style="font-size:15px;letter-spacing:1px;color:#66706b">${label.toUpperCase()}</span></div>`;
+    const stats = [
+        stat(t.turns.toLocaleString("en-US"), "turns"),
+        stat(t.tool_calls.toLocaleString("en-US"), "tool calls"),
+        t.subagents > 0 ? stat(String(t.subagents), "subagents") : "",
+        stat(String(manifest.stats.files_changed), "files"),
+        t.failures > 0 ? `<div style="display:flex;flex-direction:column"><span style="font-size:40px;font-weight:700;color:#bd443b">${t.failures}</span><span style="font-size:15px;letter-spacing:1px;color:#66706b">FAILURES</span></div>` : "",
+    ].filter(Boolean).join("");
+
+    const html = `
+<div style="display:flex;flex-direction:column;width:1200px;height:630px;background:#f3f6f5;padding:28px;font-family:'JetBrains Mono'">
+  <div style="display:flex;flex-direction:column;flex:1;background:#ffffff;border:2px solid #cfd8d4;padding:44px 52px">
+    <div style="display:flex;justify-content:space-between;align-items:center">
+      <span style="font-size:30px;color:#141615;font-weight:700">ax<span style="font-size:15px;color:#66706b;margin-left:12px;letter-spacing:2px">AGENT EXPERIENCE</span></span>
+      <span style="font-size:20px;color:#66706b">${esc(right)}</span>
+    </div>
+    <div style="display:flex;font-size:38px;line-height:1.25;color:#141615;margin-top:34px;font-weight:600">${title}</div>
+    <div style="display:flex;gap:56px;margin-top:36px">${stats}</div>
+    <div style="display:flex;margin-top:38px">${laneHtml(manifest.subagents)}</div>
+    <div style="display:flex;flex:1"></div>
+    <div style="display:flex;justify-content:space-between;font-size:16px;letter-spacing:1px;color:#66706b">
+      <span>${t.subagents > 0 ? `BARS = ${t.subagents} SUBAGENTS · DARKER = COSTLIER` : ""}</span>
+      <span>RECORDED WITH AX · AX.NECMTTN.COM</span>
+    </div>
+  </div>
+</div>`;
+
+    const font = await fetch(
+        "https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-400-normal.ttf",
+    ).then((r) => r.arrayBuffer());
+    const fontBold = await fetch(
+        "https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-700-normal.ttf",
+    ).then((r) => r.arrayBuffer());
+
+    const image = new ImageResponse(html, {
+        width: 1200,
+        height: 630,
+        fonts: [
+            { name: "JetBrains Mono", data: font, weight: 400, style: "normal" },
+            { name: "JetBrains Mono", data: fontBold, weight: 700, style: "normal" },
+        ],
+    });
+    const res = new Response(image.body, {
+        headers: {
+            "content-type": "image/png",
+            "cache-control": "public, max-age=86400, s-maxage=86400",
+        },
+    });
+    ctx.waitUntil(cache.put(cacheKey, res.clone()));
+    return res;
+};

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -30,6 +30,7 @@
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.1.0",
+    "workers-og": "^0.0.27",
     "zod": "^4.1.11"
   },
   "devDependencies": {

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -625,9 +625,9 @@ const segmentLabel = (title: string): string =>
  * phase jumps the transcript to its first turn (the hash flip also leaves
  * the timeline view if that's where the reader is).
  */
-function SessionScrubber({ timeline, spawnTimes }: {
+function SessionScrubber({ timeline, spawnCards }: {
     readonly timeline: SessionTimelinePayload;
-    readonly spawnTimes?: ReadonlyArray<string>;
+    readonly spawnCards?: ReadonlyArray<ShareSubagentCard>;
 }) {
     const h = timeline.highlights;
     const t0 = Date.parse(h.started_at ?? "");
@@ -655,8 +655,42 @@ function SessionScrubber({ timeline, spawnTimes }: {
         window.location.hash = `turn-${seq}`;
     };
     const fmtClock = (t: number) => new Date(t).toISOString().slice(5, 16).replace("T", " ");
+    // Subagent lanes: each dispatch as a bar on the same time axis, greedy
+    // row packing, opacity by cost - the fan-out made visible (the F2 map).
+    const lanes: Array<Array<{ x: number; w: number; cost: number; failed: boolean; label: string }>> = [];
+    const laneEnds: number[] = [];
+    const maxCost = Math.max(0.01, ...(spawnCards ?? []).map((c) => c.cost_usd ?? 0));
+    for (const card of [...(spawnCards ?? [])].sort((p, q) => (p.started_at ?? "").localeCompare(q.started_at ?? ""))) {
+        const x = frac(card.started_at);
+        if (x == null) continue;
+        const w = Math.max((card.duration_ms ?? 0) / span, 0.004);
+        let r = 0;
+        while (r < laneEnds.length && laneEnds[r] > x - 0.002) r++;
+        if (r >= 4) r = 3;
+        laneEnds[r] = x + w;
+        (lanes[r] ??= []).push({
+            x,
+            w,
+            cost: card.cost_usd ?? 0,
+            failed: (card.stats?.failures ?? 0) > 0,
+            label: `${card.task_label ?? card.id} - ${fmtUsd(card.cost_usd) ?? ""}`,
+        });
+    }
     return (
         <div className="scrub-wrap">
+            {/* Labels live in their own deck so the strip below stays pure
+                signal - inside the strip they collided with the ticks. */}
+            <div className="scrub-labels">
+                {segs.filter(({ a, b }) => b - a > 0.08).map(({ seg, a, b }) => (
+                    <span
+                        key={`l-${seg.id}`}
+                        style={{ left: `${a * 100}%`, width: `${(b - a) * 100}%` }}
+                        onClick={() => jump(seg.start_seq)}
+                    >
+                        {segmentLabel(seg.title)}
+                    </span>
+                ))}
+            </div>
             <div className="scrub">
                 {segs.map(({ seg, a, b }) => (
                     <button
@@ -666,20 +700,32 @@ function SessionScrubber({ timeline, spawnTimes }: {
                         style={{ left: `${a * 100}%`, width: `${(b - a) * 100}%` }}
                         title={`${segmentLabel(seg.title)} - ${fmtDuration(seg.duration_ms) ?? ""} · ${seg.rollup.tool_calls} tools${seg.rollup.failures ? ` · ${seg.rollup.failures} failures` : ""}`}
                         onClick={() => jump(seg.start_seq)}
-                    >
-                        {(b - a) > 0.08 ? <span>{segmentLabel(seg.title)}</span> : null}
-                    </button>
+                    />
                 ))}
                 {ticks("checkpoint").map((x, i) => <i key={`c${i}`} className="scrub-commit" style={{ left: `${x * 100}%` }} />)}
                 {ticks("failure").map((x, i) => <i key={`f${i}`} className="scrub-fail" style={{ left: `${x * 100}%` }} />)}
-                {(spawnTimes ?? []).map((iso, i) => {
-                    const x = frac(iso);
-                    return x == null ? null : <i key={`s${i}`} className="scrub-spawn" style={{ left: `${x * 100}%` }} />;
-                })}
             </div>
+            {lanes.length > 0 ? (
+                <div className="scrub-lanes" style={{ height: lanes.length * 8 + 2 }}>
+                    {lanes.map((row, r) =>
+                        row.map((b, i) => (
+                            <i
+                                key={`${r}-${i}`}
+                                className={b.failed ? "lane-bar failed" : "lane-bar"}
+                                style={{
+                                    left: `${b.x * 100}%`,
+                                    width: `${Math.max(b.w * 100, 0.4)}%`,
+                                    top: r * 8,
+                                    opacity: 0.35 + 0.6 * (b.cost / maxCost),
+                                }}
+                                title={b.label}
+                            />
+                        )))}
+                </div>
+            ) : null}
             <div className="scrub-axis">
                 <span>{fmtClock(t0)}</span>
-                <span>commits ↓ · failures ↑ · subagents ◦ - click a phase to jump</span>
+                <span>commits ↓ · failures ↑{lanes.length > 0 ? " · bars = subagents (darker = costlier)" : ""} - click a phase to jump</span>
                 <span>{fmtClock(t1)}</span>
             </div>
         </div>
@@ -703,7 +749,7 @@ function ShareOutcomeHeader(props: {
     readonly costUsd: number | null;
     readonly durationMs: number | null;
     readonly timeline?: SessionTimelinePayload | null;
-    readonly spawnTimes?: ReadonlyArray<string>;
+    readonly spawnCards?: ReadonlyArray<ShareSubagentCard>;
 }) {
     const cost = fmtUsd(props.costUsd);
     const duration = fmtDuration(props.durationMs);
@@ -733,7 +779,11 @@ function ShareOutcomeHeader(props: {
                 {props.files > 0 ? <>, <b>{props.files}</b> files</> : null}
                 {failPhrase ? <>, <span className="share-hero-fail">{failPhrase}</span></> : null}.
             </p>
-            {tl ? <SessionScrubber timeline={tl} spawnTimes={props.spawnTimes} /> : null}
+            {tl ? <SessionScrubber timeline={tl} spawnCards={props.spawnCards} /> : null}
+            <div className="share-hero-brand">
+                <span>{[props.project, fmtShareDate(props.startedAt)].filter(Boolean).join(" · ")}</span>
+                <span>recorded with <b>ax</b> · ax.necmttn.com</span>
+            </div>
         </div>
     );
 }
@@ -906,7 +956,7 @@ function MultiFileShareView(props: {
                     costUsd={selectedCard.cost_usd}
                     durationMs={selectedCard.duration_ms}
                     timeline={fileQuery.data?.session_timeline ?? null}
-                    spawnTimes={directChildren.map((c) => c.started_at).filter((t): t is string => !!t)}
+                    spawnCards={directChildren}
                 />
             ) : (
                 <ShareOutcomeHeader
@@ -923,23 +973,22 @@ function MultiFileShareView(props: {
                     costUsd={totals.cost_usd}
                     durationMs={totals.duration_ms}
                     timeline={fileQuery.data?.session_timeline ?? null}
-                    spawnTimes={directChildren.map((c) => c.started_at).filter((t): t is string => !!t)}
+                    spawnCards={directChildren}
                 />
             )}
             {directChildren.length > 0 ? (
-                <div style={SUBAGENT_BAR_STYLE}>
-                    <span style={{
-                        display: "block",
-                        font: "700 10px/1 ui-monospace, monospace",
+                <details style={SUBAGENT_BAR_STYLE}>
+                    <summary style={{
+                        font: "700 10px/1.5 ui-monospace, monospace",
                         textTransform: "uppercase",
                         letterSpacing: "0.08em",
                         color: "var(--muted)",
-                        margin: "2px 0 8px",
+                        cursor: "pointer",
                     }}>
-                        ↓ {directChildren.length} subagent session{directChildren.length === 1 ? "" : "s"} - tap to open
-                    </span>
-                    <span style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-                        {directChildren.slice(0, 8).map((c) => (
+                        {directChildren.length} subagent session{directChildren.length === 1 ? "" : "s"} · {fmtUsd(directChildren.reduce((acc, c) => acc + (c.cost_usd ?? 0), 0)) ?? ""} - browse all, or open them inline at their spawn points ↓
+                    </summary>
+                    <span style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 10 }}>
+                        {directChildren.map((c) => (
                             <button
                                 key={c.id}
                                 type="button"
@@ -952,13 +1001,8 @@ function MultiFileShareView(props: {
                                 {fmtUsd(c.cost_usd) ? <span style={{ color: "var(--muted)", marginLeft: 6 }}>{fmtUsd(c.cost_usd)}</span> : null}
                             </button>
                         ))}
-                        {directChildren.length > 8 ? (
-                            <span style={{ alignSelf: "center", color: "var(--muted)", fontFamily: "ui-monospace, monospace" }}>
-                                +{directChildren.length - 8} more inline ↓
-                            </span>
-                        ) : null}
                     </span>
-                </div>
+                </details>
             ) : null}
             {selectedCard ? (
                 <div style={SUBAGENT_BAR_STYLE}>

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -243,9 +243,58 @@ a {
 .scrub-wrap {
     margin-top: 14px;
 }
+.scrub-labels {
+    position: relative;
+    height: 15px;
+    margin-bottom: 2px;
+}
+.scrub-labels span {
+    position: absolute;
+    top: 0;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+    border-left: 1px solid var(--line);
+    padding-left: 5px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+}
+.scrub-labels span:hover {
+    color: var(--ink);
+}
+.scrub-lanes {
+    position: relative;
+    margin-top: 3px;
+}
+.lane-bar {
+    position: absolute;
+    height: 6px;
+    border-radius: 1.5px;
+    background: var(--rose);
+}
+.lane-bar.failed {
+    background: var(--red);
+}
+.share-hero-brand {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 14px;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 9.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted-2);
+}
+.share-hero-brand b {
+    color: var(--muted);
+}
 .scrub {
     position: relative;
-    height: 32px;
+    height: 26px;
     border: 1px solid var(--line);
     border-radius: 4px;
     overflow: hidden;
@@ -266,19 +315,6 @@ a {
 .scrub-seg:hover {
     background: color-mix(in srgb, var(--blue) 7%, var(--panel));
 }
-.scrub-seg span {
-    position: absolute;
-    left: 6px;
-    top: 50%;
-    transform: translateY(-50%);
-    font-family: ui-monospace, Menlo, monospace;
-    font-size: 9px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--muted);
-    white-space: nowrap;
-    pointer-events: none;
-}
 .scrub i {
     position: absolute;
     pointer-events: none;
@@ -294,14 +330,6 @@ a {
     width: 2px;
     height: 7px;
     background: var(--red);
-}
-.scrub-spawn {
-    top: 50%;
-    width: 3px;
-    height: 3px;
-    margin-top: -1.5px;
-    border-radius: 50%;
-    background: var(--rose);
 }
 .scrub-axis {
     display: flex;


### PR DESCRIPTION
The share header becomes a **poster** — screenshottable, chart-heavy, branded — and the same visual drives **per-session OG images**.

**Poster hero (studio)**
- Scrubber phase labels get their own deck above the strip (they collided with tick marks inside it)
- Subagent fan-out as cost-shaded lane bars on the same wall-clock axis (darker = costlier, red = had failures) — the F2 map lanes, computed from manifest cards client-side
- The subagent chip wall collapses to one `<details>` summary line
- `recorded with ax · ax.necmttn.com` attribution inside the card, so screenshots carry the brand

**OG images (site)**
- `/og/:owner/:gistId` Cloudflare Pages Function (`workers-og`/Satori): 1200×630 poster rendered from the share's gist `index.json` — title, headline numbers, subagent lanes, branding; edge-cached 24h
- `/s/` route head: `og:image`, `og:url`, `twitter:card=summary_large_image` → pasting a share link into Slack/X/Discord unfurls into the session's own poster

Tests: studio 117 pass, site 18 pass; studio typecheck clean (site tsc pre-build errors are the documented codegen ones, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)