### PR TITLE
docs(releases): backfill announcements for v0.1.0–v0.21.0

### DIFF
--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,31 @@
+---
+version: "0.1.0"
+date: "2026-05-09"
+title: "The first cut of the local taste graph"
+summary: "ax starts ingesting Claude and Codex transcripts, skills, and git history into a queryable local graph."
+---
+
+0.1.0 is the first working shape of ax: a single-binary CLI that ingests
+Claude Code and Codex transcripts, installed skills, and per-repo git history
+into a local SurrealDB instance, then answers questions about what you
+actually use.
+
+On top of that graph, the release derives its first signals - corrections,
+skill pairs, skill-after-error - and rolls them into a composite taste score.
+A TUI dashboard with live queries and BM25 full-text search make the data
+explorable, and a launchd watcher keeps ingest incremental as new transcripts
+land.
+
+### Highlights
+
+* Transcript ingest for Claude Code and Codex, plus skills and git commits.
+* Composite taste score built from derived correction and usage signals.
+* TUI dashboard with live updates and full-text search over the graph.
+* One-command install that compiles a single binary and auto-installs a pinned SurrealDB.
+* Background watcher re-ingests incrementally when new transcripts appear.
+
+### Why it matters
+
+Agent transcripts pile up on disk and then get ignored. This release turns
+them into a durable local graph you can actually query, and sets up the
+foundation - schema, signals, watcher - that everything after builds on.

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -1,0 +1,14 @@
+---
+version: "0.1.1"
+date: "2026-05-09"
+title: "Install fix for release checksums"
+summary: "A same-day patch so the installer accepts release checksum asset paths."
+---
+
+0.1.1 is a same-day patch to the 0.1.0 install path. The installer now
+accepts the checksum asset paths that releases actually publish, so a fresh
+install verifies and completes cleanly.
+
+### Highlights
+
+* The installer accepts release checksum asset paths during download verification.

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -1,0 +1,26 @@
+---
+version: "0.10.0"
+date: "2026-06-03"
+title: "Setup becomes one command"
+summary: "ax setup installs skills, runs the first ingest, and verifies the install in a single step."
+---
+
+0.10.0 smooths the first five minutes. A new `ax setup` command chains the
+pieces a fresh install needs - skills, the first ingest, and a doctor pass - so
+getting from install to a populated graph is one command instead of three.
+
+Onboarding also gains an agent-instructions prompt with a labeling loop, so ax
+can be wired into your agent files in the style of effect.solutions. And bare
+`ax` now lands on an ascii wordmark instead of a wall of help text.
+
+### Highlights
+
+* `ax setup` runs skills install, first ingest, and doctor in one command.
+* Onboarding offers an agent-instructions prompt with a labeling loop.
+* Running bare `ax` shows a wordmark landing instead of raw help output.
+
+### Why it matters
+
+The graph is only useful once it's populated, and most installs stall before
+that point. Collapsing setup into one verified command gets new users to a
+working graph - and their agents pointed at it - with less friction.

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -1,0 +1,29 @@
+---
+version: "0.11.0"
+date: "2026-06-05"
+title: "Compaction becomes a first-class signal"
+summary: "ax now tracks context compaction across harnesses and survives transcripts that vanish mid-ingest."
+---
+
+0.11.0 promotes context compaction to a first-class signal across harnesses, so
+the graph records when a session's context was squeezed - a key input for
+judging what an agent could actually see at any point in a run.
+
+The rest of the release hardens ingest. Claude and Codex readers move to
+streaming file reads, a transcript that vanishes mid-run is skipped instead of
+aborting the whole ingest, schema apply is idempotent, and `session.project` is
+canonicalized off the repository edge so project scoping stays consistent.
+
+### Highlights
+
+* Compaction events are captured as a first-class signal across harnesses.
+* Vanished transcripts are skipped mid-run instead of aborting ingest.
+* Schema apply is idempotent, so repeated applies no longer trip on indexes.
+* Provider built-in tools are excluded from weighted skill rankings.
+* Fixes for the weighted-skills query hang and `role.weight` crash.
+
+### Why it matters
+
+Compaction is where agents lose the plot, and until now ax couldn't see it
+happen. Recording it alongside sturdier, restart-safe ingest means the graph
+reflects real sessions more faithfully - including the moments context got cut.

--- a/docs/releases/v0.12.0.md
+++ b/docs/releases/v0.12.0.md
@@ -1,0 +1,29 @@
+---
+version: "0.12.0"
+date: "2026-06-07"
+title: "The session canvas"
+summary: "ax gets a semantic-zoom canvas that maps your sessions as a lineage graph you can pan, zoom, and inspect."
+---
+
+0.12.0 introduces the session canvas: a dashboard view that lays out sessions as
+a zoomable lineage graph instead of a flat list. Sessions sit in swimlanes, with
+subagent orchestration drawn as its own timeline, and node size reflects what
+actually filled the context window - tokens and compaction epochs.
+
+The canvas is built to stay fast at every altitude. Detail cards appear on hover
+backed by a DB-only session summary that dropped from tens of seconds to about
+30 milliseconds, and the time axis now zooms from an 80x cap up to 2000x.
+
+### Highlights
+
+* Sessions render as a semantic-zoom lineage graph with swimlanes and a subagent orchestration timeline.
+* Hovering a session shows an instant detail card; clicking opens inline detail in place or in focus mode.
+* Node size encodes context tokens and compaction epochs, so heavy sessions stand out visually.
+* Time-axis zoom and pan, with progressive pill labels and auto-focus on deep zoom.
+* Detail summaries are computed entirely in the database, cutting load time from 20-58s to ~30ms.
+
+### Why it matters
+
+A list of sessions hides how work actually unfolds: long arcs, forks, subagents,
+and compaction pressure. The canvas makes that structure visible at a glance and
+keeps it explorable without waiting on slow queries.

--- a/docs/releases/v0.12.1.md
+++ b/docs/releases/v0.12.1.md
@@ -1,0 +1,14 @@
+---
+version: "0.12.1"
+date: "2026-06-07"
+title: "Hosted studio reaches the local daemon"
+summary: "A CORS fix lets the hosted studio talk to the ax daemon running on your machine."
+---
+
+0.12.1 is a single fix: `ax serve` now echoes the Allow-Private-Network header,
+so the hosted studio can reach the loopback daemon from the browser instead of
+being blocked by private-network access checks.
+
+### Highlights
+
+* The hosted studio can connect to your local `ax serve` daemon again.

--- a/docs/releases/v0.13.0.md
+++ b/docs/releases/v0.13.0.md
@@ -1,0 +1,26 @@
+---
+version: "0.13.0"
+date: "2026-06-08"
+title: "Subagent transcripts in shares"
+summary: "Shared sessions now include subagent transcripts and pricing for Claude sessions."
+---
+
+0.13.0 makes shared sessions tell the whole story. Exports now carry subagent
+transcripts alongside the main thread, so a share shows the dispatched work and
+not just the orchestrating conversation. Claude sessions are also priced on the
+way out, putting a cost figure on what the share contains.
+
+The release also hardens re-ingest: agent events are now cleared by primary id,
+so SurrealDB index drift can no longer crash a re-ingest run.
+
+### Highlights
+
+* Shared sessions export subagent transcripts, not just the top-level thread.
+* Claude sessions get pricing in exports.
+* Re-ingest no longer crashes when an index has drifted from the underlying rows.
+
+### Why it matters
+
+A share that drops the subagents is an incomplete record of how the work
+happened. Including them - with cost attached - makes shared sessions a faithful
+artifact, and the ingest fix keeps the graph rebuildable without manual repair.

--- a/docs/releases/v0.14.0.md
+++ b/docs/releases/v0.14.0.md
@@ -1,0 +1,27 @@
+---
+version: "0.14.0"
+date: "2026-06-08"
+title: "Multi-file shares and per-turn pricing"
+summary: "Shares split into multi-file gist bundles that load progressively, with cost broken down per turn."
+---
+
+0.14.0 reworks how shared sessions are packaged and read. Exports now go out as
+multi-file gist bundles, and the studio viewer loads them progressively instead
+of waiting for the whole session. Pricing moves from a single session total to
+per-turn figures, so you can see where the cost actually went.
+
+In the studio, the turn inspector docks under the cost rail and follows your
+hover, keeping turn detail in view while you scan the transcript.
+
+### Highlights
+
+* Shared sessions export as multi-file gist bundles instead of one blob.
+* The studio renders shares progressively, so large sessions become readable sooner.
+* Cost is attributed per turn, not just per session.
+* The turn inspector docks under the cost rail and updates as you hover.
+
+### Why it matters
+
+Big sessions were the ones most worth sharing and the hardest to load. Splitting
+the bundle and rendering progressively removes that ceiling, and per-turn pricing
+turns cost from a single opaque number into something you can point at.

--- a/docs/releases/v0.15.0.md
+++ b/docs/releases/v0.15.0.md
@@ -1,0 +1,24 @@
+---
+version: "0.15.0"
+date: "2026-06-08"
+title: "Hook fires and tool arguments in shares"
+summary: "Shared transcripts now show hook fires and the arguments behind synthesized tool turns."
+---
+
+0.15.0 adds more of the underlying record to shared sessions. Hook fires are now
+exported and rendered, so a share shows when harness hooks intervened, not just
+what the agent said. Synthesized tool turns also render their tool arguments,
+making it clear what each call was actually asked to do. Export concurrency is
+bounded so large shares go out without overwhelming the exporter.
+
+### Highlights
+
+* Hook fires are exported and rendered in shared transcripts.
+* Synthesized tool turns show the tool arguments, not just the result.
+* Export concurrency is bounded for more reliable large exports.
+
+### Why it matters
+
+A tool turn without its arguments and a session without its hook fires both hide
+causality. Putting them in the share keeps the published record close to what
+actually ran.

--- a/docs/releases/v0.16.0.md
+++ b/docs/releases/v0.16.0.md
@@ -1,0 +1,29 @@
+---
+version: "0.16.0"
+date: "2026-06-09"
+title: "Studio becomes a standalone app"
+summary: "The studio viewer is extracted into @ax/studio and ships as a standalone Electron desktop app."
+---
+
+0.16.0 promotes the studio from a dashboard bundle to its own product surface.
+The viewer is extracted into the `@ax/studio` package and wrapped as a
+standalone Electron desktop app, so reading sessions no longer requires going
+through the web dashboard.
+
+The viewer itself also gets sharper: the sessions palette and share outcome
+header are unified into one consistent surface, harness hooks now appear in the
+shared transcript, and transcript paint is virtualized with content-visibility
+so long sessions scroll smoothly.
+
+### Highlights
+
+* The studio is extracted into `@ax/studio` and ships as a standalone Electron desktop app.
+* The sessions palette and share outcome header are unified across the studio.
+* Harness hooks are surfaced directly in the shared transcript.
+* Long transcripts paint lazily via content-visibility, keeping scrolling responsive.
+
+### Why it matters
+
+The studio is how shared work gets read, so it deserves to stand on its own.
+Making it a desktop app with a unified surface and virtualized rendering means
+the reading experience scales with the sessions ax now captures.

--- a/docs/releases/v0.17.0.md
+++ b/docs/releases/v0.17.0.md
@@ -1,0 +1,29 @@
+---
+version: "0.17.0"
+date: "2026-06-09"
+title: "Timelines without an LLM"
+summary: "ax can now narrate a session as highlights, segments, and events - computed straight from the graph, no model call required."
+---
+
+0.17.0 is about reading a session, not just storing it. A new timeline service
+derives highlights, segments, and events for any session directly from the
+ingested graph, so studio can show what happened in a run without asking an
+LLM to summarize it.
+
+The studio share view gets a design pass to match: a session-outcome header,
+unified rendering for tool calls in transcripts, and URL-driven subagent
+selection so deep links land on the right view.
+
+### Highlights
+
+* Session timelines (highlights, segments, events) are computed from the graph - no LLM in the loop.
+* Shared sessions open with an outcome header from the studio design pass.
+* Tool calls render through one unified transcript treatment in studio.
+* Subagent selection in the share viewer is driven by the URL.
+* Session inspect paging, session-detail skills, and the workflow dashboard are all faster.
+
+### Why it matters
+
+A telemetry graph is only useful if you can read a run back quickly. Deriving
+the timeline from evidence instead of a model keeps it instant, deterministic,
+and free - and it makes shared sessions legible to people who weren't there.

--- a/docs/releases/v0.18.0.md
+++ b/docs/releases/v0.18.0.md
@@ -1,0 +1,27 @@
+---
+version: "0.18.0"
+date: "2026-06-09"
+title: "Pull requests join the graph"
+summary: "ax now ingests GitHub PRs - reviews, checks, and deliveries - and links them to the sessions that produced them."
+---
+
+0.18.0 adds a github-pr ingest stage. ax fetches pull requests through the
+`gh` CLI, normalizes them alongside reviews and check runs, writes them into
+the graph, and links each delivery back to the sessions that did the work.
+
+The stage is scoped to the repos ax already knows about, and the writer uses
+content-stable keys so re-ingest stays idempotent. Studio also fixes tool
+calls missing from the graph inspect path.
+
+### Highlights
+
+* GitHub PRs, reviews, and checks are fetched via `gh` and ingested as graph records.
+* Deliveries are linked to the sessions that produced them.
+* The stage only runs against repos in the current ingest scope.
+* Studio's graph inspect path now populates tool calls.
+
+### Why it matters
+
+A PR is where agent work actually lands. Pulling deliveries, reviews, and
+checks into the same graph as sessions and tool calls means ax can connect
+"what the agent did" to "what shipped" - the seam every outcome metric needs.

--- a/docs/releases/v0.19.0.md
+++ b/docs/releases/v0.19.0.md
@@ -1,0 +1,30 @@
+---
+version: "0.19.0"
+date: "2026-06-10"
+title: "Session metrics, derived from the graph"
+summary: "ax sessions metrics and ax signals turn the evidence graph into numbers, and the slowest read paths get unstuck."
+---
+
+0.19.0 starts measuring. New `ax sessions metrics` and `ax signals` commands
+derive session-level metrics straight from the graph, with time-to-land
+anchored on commit timestamps so the numbers reflect when work actually
+landed.
+
+It is also a reliability release for reads. Session queries no longer hang,
+ingest runs are single-flight, and the query layer drops IN-membership scans
+and correlated derefs that made large graphs slow. Studio now shows its build
+version and nags when it doesn't match the daemon.
+
+### Highlights
+
+* `ax sessions metrics` and `ax signals` report graph-derived session metrics.
+* Time-to-land is anchored on the commit timestamp.
+* Session queries no longer hang, and concurrent ingest runs collapse to one.
+* Read paths shed IN-membership scans and correlated derefs for large-graph speed.
+* The live banner shows the studio build version and flags daemon mismatches.
+
+### Why it matters
+
+Metrics are only trustworthy if the queries behind them finish. This release
+pairs the first graph-derived numbers with the performance work that makes
+asking for them routine instead of risky.

--- a/docs/releases/v0.19.1.md
+++ b/docs/releases/v0.19.1.md
@@ -1,0 +1,16 @@
+---
+version: "0.19.1"
+date: "2026-06-10"
+title: "Ingest unwedged"
+summary: "A quadratic clear DELETE could wedge ingest; it no longer does, and ingest can now be profiled over OTLP."
+---
+
+0.19.1 is a small ingest patch. A clear step with quadratic DELETE behavior
+could wedge a run on large tables; ax now avoids it, and ingest gains OTLP
+profiling instrumentation so future stalls show up as spans instead of
+mysteries.
+
+### Highlights
+
+* Ingest no longer wedges on the quadratic clear DELETE.
+* Ingest emits OTLP profiling spans for diagnosing slow runs.

--- a/docs/releases/v0.20.0.md
+++ b/docs/releases/v0.20.0.md
@@ -1,0 +1,28 @@
+---
+version: "0.20.0"
+date: "2026-06-10"
+title: "Metrics get a dogfood pass"
+summary: "The new metrics surface is reworked from real use - provider parity, fragility cascades, PR freshness, cost, and aggregates."
+---
+
+0.20.0 is the follow-up pass on the metrics introduced in 0.19.0, driven by a
+round of dogfooding. The metrics surface gains provider parity so numbers mean
+the same thing across harnesses, a fragility cascade view, PR freshness,
+cost reporting, and aggregate rollups.
+
+The CLI also gets stricter where silence used to hide mistakes:
+`ax sessions around` now rejects non-date arguments instead of quietly
+returning an empty window, and studio accepts schema_version 4 share
+manifests.
+
+### Highlights
+
+* Metrics cover provider parity, fragility cascade, PR freshness, cost, and aggregates.
+* `ax sessions around` rejects non-date arguments instead of returning an empty window.
+* Studio accepts schema_version 4 share manifests.
+
+### Why it matters
+
+The fastest way to make a metrics surface honest is to use it and fix what
+lies. This release closes the gaps a real dogfood run exposed, so the numbers
+ax reports hold up across providers and over time.

--- a/docs/releases/v0.21.0.md
+++ b/docs/releases/v0.21.0.md
@@ -1,0 +1,31 @@
+---
+version: "0.21.0"
+date: "2026-06-10"
+title: "Query output that points to the next step"
+summary: "ax commands now return NavLink next[] follow-ups - a self-documenting query surface - alongside timeline and share polish."
+---
+
+0.21.0 makes ax's query surface self-documenting. Recall, sessions,
+session-show, skills, roles, and improve output now carry NavLink `next[]`
+follow-ups - HATEOAS for LLMs - so an agent reading one result knows exactly
+which query to run next without consulting docs.
+
+The timeline and share viewer keep maturing: +/- line counts and smart shell
+titles in the timeline, agent dispatches titled with their description, a
+mobile layout for shared sessions, and deep-linkable subagent views. Ingest
+gains deep OTEL span instrumentation per stage and a per-repo cooldown on
+GitHub PR fetches.
+
+### Highlights
+
+* Recall, sessions, session-show, skills, roles, and improve results include `next[]` follow-up links.
+* Timeline entries show +/- line counts, smart shell titles, and description-titled agent dispatches.
+* Shared sessions work on mobile, and subagent views are deep-linkable with isolated nav state.
+* Ingest stages emit deep OTEL spans; GitHub PR fetches respect a per-repo cooldown.
+
+### Why it matters
+
+ax's primary reader is increasingly an agent in-context. Embedding the next
+useful query in every result turns the CLI from a set of commands you have to
+know into a surface you can navigate - the same way links made the web
+explorable.

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,30 @@
+---
+version: "0.4.0"
+date: "2026-05-31"
+title: "Sessions become shareable"
+summary: "ax can publish a session as a gist-backed share link, and the site gets real release pages."
+---
+
+0.4.0 makes a session something you can hand to someone else. Sessions can be
+shared via a gist-backed link, transcript content blocks are parsed and
+stored, and the inspector surfaces subagent lifecycles - so what you share
+reads like the work, not a log dump.
+
+The release also widens the rest of the surface: the site gains a changelog
+page and per-release detail pages, ingest normalizes provider sessions and
+costs, and the classifier experiments get an embedding-helper and graph
+harness with review gates on workflow proposals.
+
+### Highlights
+
+* Gist-backed session sharing produces a link anyone can open.
+* Transcript content blocks are parsed into storage, with subagent lifecycle visible in the inspector.
+* Provider sessions and costs are normalized at ingest.
+* The site ships a changelog page and per-release detail pages.
+* Classifier work gains an embedding helper, a graph harness, and gated proposal review.
+
+### Why it matters
+
+A local graph is only half the story; being able to show a session to someone
+else is the other half. Richer content storage and normalized costs also give
+later inspector and dashboard work a solid base to draw from.

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,27 @@
+---
+version: "0.5.0"
+date: "2026-05-31"
+title: "Shared sessions get their content back"
+summary: "Share links now carry full turn content, and the embedding-helper review loop becomes operable."
+---
+
+0.5.0 tightens the session-sharing path introduced in 0.4.0. Shared sessions
+now include turn content blocks, and the studio viewer loads shared sessions
+from the raw gist correctly - so a share link shows the actual conversation,
+not a skeleton.
+
+The embedding-helper classifier also grows an operable review loop: exports
+can be previewed, review batches dry-run before syncing, and progress is
+reported as you work through them.
+
+### Highlights
+
+* Shared sessions include full turn content blocks.
+* The studio viewer loads shared sessions from the raw gist reliably.
+* Embedding-helper reviews support export previews, dry-run batch sync, and progress reporting.
+
+### Why it matters
+
+Sharing is only useful if the link is faithful to the session. This release
+closes the fidelity gap on shares and makes classifier review something you
+can check before it writes anything.

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,31 @@
+---
+version: "0.6.0"
+date: "2026-06-01"
+title: "A local session inspector with a cost lens"
+summary: "studio gains a unified session inspector with per-turn token costs, and the classifier review loop becomes a guided pipeline."
+---
+
+0.6.0 makes local sessions inspectable in the browser. studio gets a unified
+session inspector with a cost lens, a scrolling token rail, per-turn token
+costs, and a legend - so you can see where a session spent its budget, turn by
+turn. Deep links route to the app shell, so inspector views are addressable.
+
+The classifier review loop also grows from a set of commands into a guided
+pipeline: coverage review briefs with remediations and blockers, lifecycle
+routing, provenance stamping, and apply gates that say exactly what blocks a
+production apply and what to do next.
+
+### Highlights
+
+* Unified local session inspector in studio with cost lens, token rail, and per-turn token costs.
+* Classifier coverage reviews emit briefs, surface blockers with remediations, and gate apply behind explicit checks.
+* Review provenance is recorded and stamped so applied decisions stay auditable.
+* The site relaunches with a minimal landing, a /features deep-dive, and an AGPL-3.0 relicense.
+* `axctl uninstall --purge` wipes the data directory for a clean removal.
+
+### Why it matters
+
+Cost has been in the graph since ingest learned to normalize it; this release
+puts it where you can see it. And by routing every classifier decision
+through reviewable, provenance-stamped gates, the improvement loop stays
+something you can trust rather than something that runs ahead of you.

--- a/docs/releases/v0.6.1.md
+++ b/docs/releases/v0.6.1.md
@@ -1,0 +1,14 @@
+---
+version: "0.6.1"
+date: "2026-06-01"
+title: "Smoother concurrent ingest"
+summary: "A patch that stops concurrent ingests from retrying in lockstep on transaction conflicts."
+---
+
+0.6.1 is a single database fix: the transaction-conflict retry is now
+jittered, so two ingests hitting the same rows - say, a manual run and the
+background watcher - stop colliding on every retry and make progress instead.
+
+### Highlights
+
+* Transaction-conflict retries are jittered to break concurrent-ingest lockstep.

--- a/docs/releases/v0.6.2.md
+++ b/docs/releases/v0.6.2.md
@@ -1,0 +1,15 @@
+---
+version: "0.6.2"
+date: "2026-06-01"
+title: "Incremental ingest heals itself"
+summary: "Incremental ingest now recovers from reaction-event conflicts instead of failing."
+---
+
+0.6.2 is a small reliability patch for incremental ingest. When an
+`ax ingest --since` run hits a conflicting `reaction_event` record left behind
+by an earlier run, ax now resolves the conflict itself instead of surfacing an
+error.
+
+### Highlights
+
+* Incremental `--since` ingest self-heals `reaction_event` conflicts.

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,21 @@
+---
+version: "0.7.0"
+date: "2026-06-01"
+title: "Ingest shows its work"
+summary: "Interactive ax ingest now animates step-by-step progress instead of running silently."
+---
+
+0.7.0 is a focused release with one change: running `ax ingest` in an
+interactive terminal now shows animated step progress. Instead of waiting on a
+quiet command, you can see which stage of the pipeline is running as it
+happens.
+
+### Highlights
+
+* `ax ingest` renders animated per-step progress on an interactive terminal.
+
+### Why it matters
+
+Ingest is the command you run most, and it does a lot of work across harnesses.
+Seeing the steps as they run makes long ingests legible and makes it obvious
+where time goes.

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,0 +1,32 @@
+---
+version: "0.8.0"
+date: "2026-06-03"
+title: "The graph opens up: MCP, live ingest, faster re-ingest"
+summary: "Agents can now query the ax graph in-context over MCP, the dashboard streams ingest live, and warm re-ingests get dramatically faster."
+---
+
+0.8.0 makes the evidence graph available where the work happens. `ax mcp` runs
+a stdio MCP server that exposes the read-only queries - recall, sessions,
+weighted skills, roles, improve recommendations - so an agent can ask ax
+questions mid-session instead of you shelling out.
+
+The same release wires ingest into the dashboard: a Live view streams progress
+over Durable Streams, survives refresh and reconnect mid-run, and the CLI gains
+per-stage row counts and speed columns. Underneath, a series of skip-unchanged
+and incremental passes cut warm re-ingest time from roughly 50 seconds to a few
+seconds.
+
+### Highlights
+
+* `ax mcp` exposes the graph's read-only queries as MCP tools for in-context use.
+* The dashboard gets a Live ingest view that resumes cleanly across refreshes.
+* Warm re-ingests skip unchanged sources, dropping from ~50s to a few seconds.
+* `ax sessions compare` puts two runs side by side, with a dashboard swimlane view.
+* `ax -v` reports git provenance (tag, sha, branch, dirty state).
+
+### Why it matters
+
+ax stops being a tool you context-switch into. Agents query the graph from
+inside their own session, ingest is visible while it runs, and re-running it
+costs seconds instead of a coffee break - which makes keeping the graph fresh
+the default rather than a chore.

--- a/docs/releases/v0.9.0.md
+++ b/docs/releases/v0.9.0.md
@@ -1,0 +1,30 @@
+---
+version: "0.9.0"
+date: "2026-06-03"
+title: "One front door for hooks, skills, and agents"
+summary: "ax gains a unified config surface so hooks, skills, and agent definitions are managed and reconciled through one consistent path."
+---
+
+0.9.0 builds a config front door. Hooks, skills, and agent definitions now
+share a common spine: one set of domain modules, one CLI wiring, and one path
+into the graph, so what's installed in your harness config and what ax knows
+about stay in sync.
+
+Reconcile is now scope-partitioned - it only touches the scopes it owns, so a
+project-level sync can't clobber global or other-repo entries. Agent scoping
+also gets sharper, with repo-qualified project scope and agent-scoped skills
+hidden from `ax skills unused`.
+
+### Highlights
+
+* Hooks, skills, and agent config flow through one shared front door into the graph.
+* Reconcile is scope-partitioned and only modifies the scopes it owns.
+* Project scope is repo-qualified, so per-repo agents resolve unambiguously.
+* The config view distinguishes out-of-scope rows from true orphans.
+* Editing a hook preserves its ax marker, keeping hook identity stable.
+
+### Why it matters
+
+Config drift is how guidance quietly stops applying. With one front door and
+ownership-aware reconcile, ax can tell you what's actually wired up - and fix
+it - without stepping on configuration it doesn't own.


### PR DESCRIPTION
Backfills concise release announcement pages for the 24 versions that shipped without one (everything except v0.2.0 and v0.3.0, which already exist).

- Grounded in the matching CHANGELOG.md sections + commit ranges; no invented motivation, thin releases kept narrow
- Matches the v0.3.0 voice: theme paragraph, ≤5 highlights, "Why it matters"; patch releases extra short
- Frontmatter dates = original release dates, so /changelog ordering is correct
- Site build verified locally: all 26 /changelog/$version pages prerender

Going forward, the Codex CI job from #196 generates these automatically per release (pending OPENAI_API_KEY, #206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)