### PR TITLE
docs(release): announcement for v0.22.0

### DIFF
--- a/docs/releases/v0.22.0.md
+++ b/docs/releases/v0.22.0.md
@@ -1,0 +1,28 @@
+---
+version: "0.22.0"
+date: "2026-06-10"
+title: "Shared sessions get a face"
+summary: "Shared session links now unfurl with a per-session poster image wherever you paste them."
+---
+
+0.22.0 is about how a shared session looks before anyone clicks it. Each share
+now renders a session poster - a generated hero image carrying the session's
+shape - and serves it as a per-session OG image, so links pasted into Slack,
+X, or a PR unfurl with a real preview instead of a generic card.
+
+Getting crawlers to see it took most of the release: the poster render is
+buffered with proper error surfacing, the edge cache key is versioned, and
+head meta is rewritten at the edge so social scrapers - which never run the
+SPA - still get the right tags. The release also folds in NavLink retro fixes
+from 0.21.0's `next[]` follow-ups, keeping them out of stdout pipelines.
+
+### Highlights
+
+* Shared sessions render a poster hero and a per-session OG image.
+* Crawlers see correct preview meta via edge head rewriting and a versioned edge cache.
+* NavLink follow-ups print to stderr with teaching stats and full header ids fixed.
+
+### Why it matters
+
+Shares are how ax sessions travel. A link that unfurls with the session's
+actual shape gets opened; a bare URL gets scrolled past.


### PR DESCRIPTION
Announcement page for v0.22.0 (session poster hero + per-session OG images). First page written under the new coverage lint from #209 — `check:release-announcements --strict` passes with all 27 versions covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)