### PR TITLE
fix(deploy): functions for the Pages git integration + post-deploy verification

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -11,8 +11,9 @@
     "build": "bun ../../scripts/extract-stage-rationale.ts && cp ../../install.sh public/install && bun ../../scripts/stage-studio.ts && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "deploy": "bun run build && wrangler pages deploy dist/client --project-name=ax --branch=main",
-    "deploy:check": "bun run build && echo 'dist/client/ ready for: wrangler pages deploy dist/client --project-name=ax'"
+    "deploy": "bun run build && wrangler pages deploy dist/client --project-name=ax --branch=main && bun run verify:functions",
+    "deploy:check": "bun run build && echo 'dist/client/ ready for: wrangler pages deploy dist/client --project-name=ax'",
+    "verify:functions": "sleep 3 && curl -s -o /dev/null -w '%{content_type}' 'https://ax.necmttn.com/og/Necmttn/a6d4c2215bbe0998c93b38ad11db2ccb' | grep -q image/png && echo 'functions OK on production' || (echo 'PRODUCTION IS MISSING THE PAGES FUNCTIONS (/og, /s meta)' && exit 1)"
   },
   "dependencies": {
     "@ax/studio": "workspace:*",

--- a/functions/og/[owner]/[gistId].ts
+++ b/functions/og/[owner]/[gistId].ts
@@ -1,0 +1,9 @@
+/**
+ * Repo-root mirror of apps/site/functions/og: the Cloudflare Pages GIT
+ * integration builds with the repository root as its project root, so it only
+ * picks up THIS functions/ directory - every auto-build was shipping without
+ * the OG poster + share-meta functions and silently wiping them from
+ * production (manual `wrangler pages deploy` runs from apps/site and uses
+ * apps/site/functions). Keep both in sync by re-exporting, never duplicating.
+ */
+export { onRequestGet } from "../../../apps/site/functions/og/[owner]/[gistId]";

--- a/functions/s/[owner]/[gistId].ts
+++ b/functions/s/[owner]/[gistId].ts
@@ -1,0 +1,2 @@
+/** Repo-root mirror for the Pages git integration - see functions/og/. */
+export { onRequestGet } from "../../../apps/site/functions/s/[owner]/[gistId]";


### PR DESCRIPTION
Root cause of the OG endpoint dying twice: the **Cloudflare Pages git integration** builds from the repository root, so it never picked up `apps/site/functions` — every auto-build on push replaced production with a deployment that had **no functions**, silently killing `/og` posters and the `/s` crawler-meta rewrite. Manual wrangler deploys (run from `apps/site`) kept re-adding them — hence the on/off behavior.

- Repo-root `functions/` mirrors `apps/site/functions` via re-exports (one source of truth, both deploy paths covered)
- `bun run deploy` now verifies `/og` returns `image/png` on production after deploying and fails loudly otherwise

The proof will be this PR's own merge: the git integration will auto-build main, and that deployment should carry the functions for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)