### PR TITLE
Phase 1: extract query seams from CLI

### DIFF
--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -93,6 +93,7 @@ import { deriveSignals } from "../ingest/derive-signals.ts";
 import { deriveTurnIntents } from "../ingest/derive-intents.ts";
 import { INSIGHT_VIEWS, insightSqlForView, isInsightView } from "../queries/insights.ts";
 import { enrichInsightRows } from "../queries/insights-enrich.ts";
+import { fetchSkillStats } from "../queries/skill-stats.ts";
 import { extractSessionTimeline, SessionTimelineServiceLayer } from "../timeline/service.ts";
 import { formatInsightRows } from "./insights-format.ts";
 import { writeDashboard } from "../dashboard/report.ts";
@@ -1096,7 +1097,6 @@ const cmdStats = (args: string[]) =>
             console.error("axctl skills stats: missing skill name");
             process.exit(1);
         }
-        const db = yield* SurrealClient;
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
         const exists = yield* skillExists(name);
@@ -1107,77 +1107,11 @@ const cmdStats = (args: string[]) =>
             );
             process.exit(2);
         }
-        // Issue #43: order recent_sessions by ts DESC (verified server-side),
-        // include the session id so we can de-dup in TS, and capture cwd so
-        // we can render a human-friendly project label rather than the raw
-        // Claude slug.
-        const sql = `
-LET $s = (SELECT * FROM skill WHERE name = $name)[0];
-RETURN {
-    skill: $s,
-    invocations: {
-        total: array::len((SELECT * FROM invoked WHERE out = $s.id)),
-        d7:    array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 7d)),
-        d30:   array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 30d)),
-        d90:   array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 90d)),
-        last:  (SELECT ts FROM invoked WHERE out = $s.id ORDER BY ts DESC LIMIT 1)[0].ts,
-    },
-    recent_sessions: (
-        SELECT
-            in.session AS session_id,
-            in.session.project AS project_slug,
-            in.session.cwd AS cwd,
-            ts
-        FROM invoked
-        WHERE out = $s.id
-        ORDER BY ts DESC
-        LIMIT 50
-    )
-};`;
-        const result = yield* db.query<unknown[]>(sql, { name });
-        const payload = (Array.isArray(result)
-            ? [...result].reverse().find((r) => r != null)
-            : result) as
-            | {
-                  skill?: { dir_path?: string | null } | null;
-                  recent_sessions?: Array<Record<string, unknown>>;
-              }
-            | undefined;
-
-        // Dedupe + cap to the most recent 5 distinct sessions, then prettify.
-        if (payload?.recent_sessions) {
-            const seen = new Set<string>();
-            const clean: Array<{
-                project: string;
-                ts: unknown;
-            }> = [];
-            for (const row of payload.recent_sessions) {
-                const sid = String(row.session_id ?? "");
-                if (sid && seen.has(sid)) continue;
-                if (sid) seen.add(sid);
-                // cwd may come back as an array (per-edge projection) - take
-                // the first scalar for display purposes.
-                const cwdRaw = Array.isArray(row.cwd) ? row.cwd[0] : row.cwd;
-                const slugRaw = Array.isArray(row.project_slug)
-                    ? row.project_slug[0]
-                    : row.project_slug;
-                let project: string;
-                if (typeof cwdRaw === "string" && cwdRaw.length > 0) {
-                    // Mirrors path.basename without pulling node:path here.
-                    const parts = cwdRaw.split("/").filter((p) => p.length > 0);
-                    project = parts.length > 0 ? parts[parts.length - 1] : cwdRaw;
-                } else {
-                    project = prettifyProjectSlug(slugRaw);
-                }
-                clean.push({ project, ts: row.ts });
-                if (clean.length >= 5) break;
-            }
-            (payload as Record<string, unknown>).recent_sessions = clean;
-        }
+        const payload = yield* fetchSkillStats(name);
 
         // Read body lazily from disk via dir_path (DB no longer stores body -
         // multi-file skills + cache-staleness make on-disk the canonical source).
-        const dirPath = payload?.skill?.dir_path;
+        const dirPath = payload.skill?.dir_path;
         // Issue #36: codex-side tools are recorded with a synthetic dir_path
         // sentinel. They have no SKILL.md, so skip the disk read entirely
         // instead of letting Effect.promise(...) crash with ENOENT.

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -94,6 +94,7 @@ import { deriveTurnIntents } from "../ingest/derive-intents.ts";
 import { INSIGHT_VIEWS, insightSqlForView, isInsightView } from "../queries/insights.ts";
 import { enrichInsightRows } from "../queries/insights-enrich.ts";
 import { fetchSkillStats } from "../queries/skill-stats.ts";
+import { fetchUnusedSkills } from "../queries/unused-skills.ts";
 import { extractSessionTimeline, SessionTimelineServiceLayer } from "../timeline/service.ts";
 import { formatInsightRows } from "./insights-format.ts";
 import { writeDashboard } from "../dashboard/report.ts";
@@ -1167,109 +1168,14 @@ const cmdUnused = (args: string[]) =>
     Effect.gen(function* () {
         const days = parsePositiveIntFlag("unused", "days", args, 7);
         const includeScoped = args.includes("--include-scoped");
-        const db = yield* SurrealClient;
         // Skills declared in a subagent's `skills:` frontmatter load only when
         // that agent is spawned - they're not global dead weight. Recover the
         // skill → agent(s) map from disk so they can be hidden/tagged here.
         const agentScope = yield* loadAgentScopeMap();
-        // PERF (issue #31): Previous form ran a correlated subquery per skill
-        // (`SELECT count() FROM invoked WHERE out = $parent.id AND ts > N`).
-        // On the largest skill (~500k invoked edges) the index walk took
-        // ~1.5s × 137 skills = enough to make this multi-minute.
-        //
-        // Now we (a) compute the recent-active set in one full-scan
-        // GROUP BY over `invoked`, (b) compute total_inv + last_used in
-        // bulk, (c) anti-join in TS. Net round-trip: ~2 cheap queries.
-        const recentSql = `
-SELECT out AS skill_id, count() AS recent
-FROM invoked
-WHERE ts > time::now() - ${days}d
-GROUP BY out;`;
-        // Issue #34: `out.name AS name` over a GROUP BY scan returns the
-        // per-edge name array (e.g. ~500k entries for codex:exec_command).
-        // String() of that is a 17 MB single line. Aggregate over the edge
-        // table only, then look up the skill row by id in a separate cheap
-        // query and merge in TS.
-        const summarySql = `
-SELECT
-    out AS skill_id,
-    count() AS total_inv,
-    math::max(ts) AS last_used
-FROM invoked
-GROUP BY out;`;
-        const skillSql = `SELECT id, name, scope FROM skill;`;
-        // Skills with literally zero invocations don't show up in the
-        // GROUP BY scan; pull them straight from the skill table so the
-        // "never used" rows still appear.
-        const noInvSql = `
-SELECT name, scope FROM skill WHERE array::len(<-invoked) = 0 AND deleted_at IS NONE;`;
-        const [recentRes, summaryRes, skillRes, noInvRes] = yield* Effect.all(
-            [
-                db.query<[Array<Record<string, unknown>>]>(recentSql),
-                db.query<[Array<Record<string, unknown>>]>(summarySql),
-                db.query<[Array<Record<string, unknown>>]>(skillSql),
-                db.query<[Array<Record<string, unknown>>]>(noInvSql),
-            ],
-            { concurrency: 4 },
-        );
-        const recent = new Set<string>(
-            (recentRes?.[0] ?? []).map((r) => String(r.skill_id ?? "")),
-        );
-        const skillById = new Map<
-            string,
-            { name: string; scope: string }
-        >();
-        for (const s of (skillRes?.[0] ?? []) as Array<Record<string, unknown>>) {
-            skillById.set(String(s.id ?? ""), {
-                name: String(s.name ?? ""),
-                scope: String(s.scope ?? ""),
-            });
-        }
-        const summary = (summaryRes?.[0] ?? []) as Array<Record<string, unknown>>;
-        const fmtTs = (v: unknown): string => {
-            if (v == null) return "never";
-            // SurrealDB's math::max returns -Infinity for empty groups; surface
-            // it as "never" rather than the literal "-Infinity" string.
-            if (typeof v === "number" && !Number.isFinite(v)) return "never";
-            if (typeof v === "string") return v;
-            if (v instanceof Date) return v.toISOString();
-            return String(v);
-        };
-        const unused: Array<{
-            name: string;
-            scope: string;
-            total_inv: number;
-            last_used: string;
-        }> = [];
-        for (const r of summary) {
-            const id = String(r.skill_id ?? "");
-            if (recent.has(id)) continue;
-            const meta = skillById.get(id);
-            // Drop orphan invocations whose target skill never had a row
-            // UPSERTed (matches the original FROM-skill behaviour, which
-            // started from skill rows and naturally excluded these).
-            if (!meta || !meta.name) continue;
-            unused.push({
-                name: meta.name,
-                scope: meta.scope,
-                total_inv: Number(r.total_inv ?? 0),
-                last_used: fmtTs(r.last_used),
-            });
-        }
-        for (const r of (noInvRes?.[0] ?? []) as Array<Record<string, unknown>>) {
-            unused.push({
-                name: String(r.name ?? ""),
-                scope: String(r.scope ?? ""),
-                total_inv: 0,
-                last_used: "never",
-            });
-        }
-        unused.sort(
-            (a, b) =>
-                a.total_inv - b.total_inv || a.name.localeCompare(b.name),
-        );
+        const unused = yield* fetchUnusedSkills({ days });
         let hiddenScoped = 0;
         for (const r of unused) {
+            const last = r.last_used ?? "never";
             const agents = agentScope.get(r.name);
             if (agents && agents.length > 0) {
                 // Agent-scoped: not global dead weight. Hide unless asked,
@@ -1279,12 +1185,12 @@ SELECT name, scope FROM skill WHERE array::len(<-invoked) = 0 AND deleted_at IS 
                     continue;
                 }
                 console.log(
-                    `${r.name}  [agent:${agents.join(",")}]  total=${fmtCount(r.total_inv)}  last=${r.last_used}`,
+                    `${r.name}  [agent:${agents.join(",")}]  total=${fmtCount(r.total_inv)}  last=${last}`,
                 );
                 continue;
             }
             console.log(
-                `${r.name}  [${r.scope}]  total=${fmtCount(r.total_inv)}  last=${r.last_used}`,
+                `${r.name}  [${r.scope}]  total=${fmtCount(r.total_inv)}  last=${last}`,
             );
         }
         const shown = unused.length - (includeScoped ? 0 : hiddenScoped);

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -10,13 +10,13 @@ import { checkoutActivitySql, gitCorrelationSql } from "../queries/insights.ts";
 import { addIngestEventSubscriber, removeIngestEventSubscriber } from "./telemetry.ts";
 import {
     clearSkillDecision,
-    fetchSkillDetail,
     fetchSkillTriage,
     isTriageDecision,
     listSkillDecisions,
     setSkillDecision,
     setSkillDecisionsBulk,
 } from "./triage.ts";
+import { fetchSkillDetail } from "../queries/skill-detail.ts";
 import { fetchToolFailureDetail, fetchToolFailures } from "./tool-failures.ts";
 import {
     applySkillDecisionToDisk,

--- a/apps/axctl/src/dashboard/triage.ts
+++ b/apps/axctl/src/dashboard/triage.ts
@@ -9,6 +9,7 @@ import {
     SKILL_SUMMARY_PROPOSED_ONLY_SQL,
 } from "../queries/skill-summary.ts";
 import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
+import { numericField } from "@ax/lib/shared/row-fields";
 import type {
     SkillRow,
     SkillTriageEntry,
@@ -24,11 +25,6 @@ const STAPLE_INV_30D = 10;                 // workhorse threshold (frequent use)
 const STAPLE_CORRECTION_RATIO = 0.10;      // staple must have <10% correction
 const STALE_DAYS = 45;
 const HIGH_CORRECTION_RATIO = 0.20;        // >=20% of recent invocations corrected
-
-const numericField = (row: Record<string, unknown>, key: string): number => {
-    const value = Number(row[key] ?? 0);
-    return Number.isFinite(value) ? value : 0;
-};
 
 const stringField = (row: Record<string, unknown>, key: string): string | null => {
     const value = row[key];

--- a/apps/axctl/src/dashboard/triage.ts
+++ b/apps/axctl/src/dashboard/triage.ts
@@ -8,13 +8,8 @@ import {
     SKILL_SUMMARY_SQL,
     SKILL_SUMMARY_PROPOSED_ONLY_SQL,
 } from "../queries/skill-summary.ts";
-import { SKILL_DETAIL_SQL } from "../queries/skill-detail.ts";
 import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
 import type {
-    SkillDetailPayload,
-    SkillPair,
-    SkillProposalEvidence,
-    SkillRecentInvocation,
     SkillRow,
     SkillTriageEntry,
     SkillTriageNote,
@@ -449,89 +444,6 @@ export const setSkillDecisionsBulk = (
             if (parsed) out.push(parsed);
         }
         return out;
-    });
-
-const tsField = (raw: Record<string, unknown>, key: string): string => {
-    const date = dateField(raw, key);
-    return date ?? "";
-};
-
-const parseRecent = (raw: unknown): SkillRecentInvocation | null => {
-    if (!raw || typeof raw !== "object") return null;
-    const row = raw as Record<string, unknown>;
-    const ts = tsField(row, "ts");
-    if (!ts) return null;
-    return {
-        ts,
-        project: stringField(row, "project"),
-        ...(typeof row.turn_has_error === "boolean"
-            ? { turn_has_error: row.turn_has_error }
-            : {}),
-    };
-};
-
-const parsePair = (raw: unknown): SkillPair | null => {
-    if (!raw || typeof raw !== "object") return null;
-    const row = raw as Record<string, unknown>;
-    const partner = stringField(row, "partner");
-    if (!partner) return null;
-    return {
-        partner,
-        count: numericField(row, "count"),
-        last_seen: dateField(row, "last_seen"),
-    };
-};
-
-const parseProposal = (raw: unknown): SkillProposalEvidence | null => {
-    if (!raw || typeof raw !== "object") return null;
-    const row = raw as Record<string, unknown>;
-    const ts = tsField(row, "ts");
-    if (!ts) return null;
-    return {
-        ts,
-        project: stringField(row, "project"),
-        context_excerpt: stringField(row, "context_excerpt"),
-    };
-};
-
-export const fetchSkillDetail = (
-    name: string,
-): Effect.Effect<SkillDetailPayload, DbError, SurrealClient> =>
-    Effect.gen(function* () {
-        const db = yield* SurrealClient;
-        const result = yield* db.query<unknown[]>(SKILL_DETAIL_SQL, { name });
-        // RETURN { ... } gives us [block] where block is the object.
-        const payload = Array.isArray(result)
-            ? ([...result].reverse().find((r) => r != null) as Record<string, unknown> | undefined)
-            : (result as Record<string, unknown> | undefined);
-        const skill = (payload?.skill ?? null) as Record<string, unknown> | null;
-        const invocations = (payload?.invocations ?? {}) as Record<string, unknown>;
-        const recent = Array.isArray(payload?.recent) ? payload.recent : [];
-        const corrections = Array.isArray(payload?.corrections) ? payload.corrections : [];
-        const proposals = Array.isArray(payload?.proposals) ? payload.proposals : [];
-        const paired = Array.isArray(payload?.paired) ? payload.paired : [];
-        return {
-            name,
-            scope: skill ? stringField(skill, "scope") : null,
-            description: skill ? stringField(skill, "description") : null,
-            dir_path: skill ? stringField(skill, "dir_path") : null,
-            invocations: {
-                total: numericField(invocations, "total"),
-                d7: numericField(invocations, "d7"),
-                d30: numericField(invocations, "d30"),
-                last: dateField(invocations, "last"),
-            },
-            recent: recent.map(parseRecent).filter((r): r is SkillRecentInvocation => r !== null),
-            corrections: corrections
-                .map(parseRecent)
-                .filter((r): r is SkillRecentInvocation => r !== null),
-            proposals: proposals
-                .map(parseProposal)
-                .filter((r): r is SkillProposalEvidence => r !== null),
-            paired: paired
-                .map(parsePair)
-                .filter((r): r is SkillPair => r !== null),
-        };
     });
 
 export const isTriageDecision = (value: unknown): value is TriageDecision =>

--- a/apps/axctl/src/queries/episode-timeline.test.ts
+++ b/apps/axctl/src/queries/episode-timeline.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+    EPISODE_PARENT_SQL,
+    EPISODE_CHILDREN_SQL,
+    EPISODE_PARENT_INVOCATIONS_SQL,
+    EPISODE_CHILD_INVOCATIONS_SQL,
+} from "./episode-timeline.ts";
+
+const PARENT = "session:⟨019e0ad4-c977-7e36-a8b5-0a1b2c3d4e5f⟩";
+
+describe("episode-timeline SQL builders", () => {
+    test("parent select interpolates the validated record ref", () => {
+        const sql = EPISODE_PARENT_SQL(PARENT);
+        expect(sql).toContain(`FROM ${PARENT};`);
+        expect(sql).toContain("started_at");
+        expect(sql).toContain("ended_at");
+    });
+
+    test("children scan is bounded and ordered by spawn time", () => {
+        const sql = EPISODE_CHILDREN_SQL(PARENT);
+        expect(sql).toContain(`WHERE in = ${PARENT}`);
+        expect(sql).toContain("ORDER BY out.started_at ASC");
+        expect(sql).toContain("LIMIT 500");
+    });
+
+    test("parent invocations walk the in.session index and bound the scan", () => {
+        const sql = EPISODE_PARENT_INVOCATIONS_SQL(PARENT);
+        expect(sql).toContain(`WHERE in.session = ${PARENT}`);
+        expect(sql).toContain("out.name IS NOT NONE");
+        expect(sql).toContain("LIMIT 5000");
+    });
+
+    test("child invocations take a pre-materialised id array literal (no IN-subquery)", () => {
+        const literal = `[${PARENT}]`;
+        const sql = EPISODE_CHILD_INVOCATIONS_SQL(literal);
+        expect(sql).toContain(`WHERE in.session IN ${literal}`);
+        expect(sql).not.toContain("SELECT out FROM spawned"); // no subquery regression
+        expect(sql).toContain("LIMIT 20000");
+    });
+});

--- a/apps/axctl/src/queries/skill-detail.test.ts
+++ b/apps/axctl/src/queries/skill-detail.test.ts
@@ -1,6 +1,42 @@
 import { describe, expect, test } from "bun:test";
-import { SKILL_DETAIL_SQL } from "./skill-detail.ts";
+import { Effect } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import {
+    SKILL_DETAIL_SQL,
+    fetchSkillDetail,
+    mapSkillPairRow,
+    mapSkillProposalRow,
+    mapSkillRecentRow,
+} from "./skill-detail.ts";
 import { SKILL_DETAIL_SQL as TUI_SKILL_DETAIL_SQL } from "../tui/queries.ts";
+
+/** Mock SurrealClientShape returning canned responses per query() call,
+ *  copied from dashboard/skills-weighted.test.ts. */
+function makeMockDb(responses: Array<unknown>): SurrealClientShape {
+    let callIndex = 0;
+    return {
+        query: <T extends unknown[] = unknown[]>(
+            _sql: string,
+            _bindings?: Record<string, unknown>,
+        ): Effect.Effect<T, DbError> => {
+            const resp = responses[callIndex] ?? [[]];
+            callIndex++;
+            return Effect.succeed(resp as unknown as T);
+        },
+        upsert: () => Effect.void,
+        relate: () => Effect.void,
+        putFile: () => Effect.void,
+        getFile: () => Effect.succeed(""),
+        raw: {} as never,
+    } as unknown as SurrealClientShape;
+}
+
+const runWithMock = <A>(
+    db: SurrealClientShape,
+    effect: Effect.Effect<A, unknown, SurrealClient>,
+): Promise<A> =>
+    Effect.runPromise(effect.pipe(Effect.provideService(SurrealClient, db)));
 
 describe("SKILL_DETAIL_SQL", () => {
     test("binds the skill by $name", () => {
@@ -23,5 +59,70 @@ describe("SKILL_DETAIL_SQL", () => {
 
     test("TUI re-exports the canonical SQL (no fork)", () => {
         expect(TUI_SKILL_DETAIL_SQL).toBe(SKILL_DETAIL_SQL);
+    });
+});
+
+describe("skill-detail row mappers", () => {
+    test("mapSkillRecentRow keeps ts/project and optional turn_has_error", () => {
+        expect(
+            mapSkillRecentRow({
+                ts: "2026-06-01T00:00:00.000Z",
+                project: "-Users-necmttn-Projects-ax",
+                turn_has_error: true,
+            }),
+        ).toEqual({
+            ts: "2026-06-01T00:00:00.000Z",
+            project: "-Users-necmttn-Projects-ax",
+            turn_has_error: true,
+        });
+        expect(mapSkillRecentRow({ project: "x" })).toBeNull(); // no ts
+        expect(mapSkillRecentRow(null)).toBeNull();
+    });
+
+    test("mapSkillPairRow requires a partner", () => {
+        expect(
+            mapSkillPairRow({ partner: "tdd", count: 4, last_seen: "2026-06-01T00:00:00.000Z" }),
+        ).toEqual({ partner: "tdd", count: 4, last_seen: "2026-06-01T00:00:00.000Z" });
+        expect(mapSkillPairRow({ count: 4 })).toBeNull();
+    });
+
+    test("mapSkillProposalRow requires ts", () => {
+        expect(
+            mapSkillProposalRow({ ts: "2026-06-01T00:00:00.000Z", project: null, context_excerpt: "..." }),
+        ).toEqual({ ts: "2026-06-01T00:00:00.000Z", project: null, context_excerpt: "..." });
+        expect(mapSkillProposalRow({ project: "x" })).toBeNull();
+    });
+});
+
+describe("fetchSkillDetail", () => {
+    test("parses the RETURN block (last non-null statement result)", async () => {
+        // db.query returns one entry per statement: LET → null, RETURN → payload.
+        const payload = {
+            skill: { name: "tdd", scope: "plugin", description: "d", dir_path: "/tmp/tdd" },
+            invocations: { total: 12, d7: 2, d30: 9, last: "2026-06-09T00:00:00.000Z" },
+            recent: [{ ts: "2026-06-09T00:00:00.000Z", project: "p", turn_has_error: false }],
+            corrections: [],
+            proposals: [{ ts: "2026-06-01T00:00:00.000Z", project: "p", context_excerpt: "e" }],
+            paired: [{ partner: "caveman", count: 3, last_seen: "2026-06-08T00:00:00.000Z" }],
+        };
+        const db = makeMockDb([[null, payload]]);
+        const result = await runWithMock(db, fetchSkillDetail("tdd"));
+
+        expect(result.name).toBe("tdd");
+        expect(result.scope).toBe("plugin");
+        expect(result.invocations).toEqual({
+            total: 12, d7: 2, d30: 9, last: "2026-06-09T00:00:00.000Z",
+        });
+        expect(result.recent).toHaveLength(1);
+        expect(result.proposals).toHaveLength(1);
+        expect(result.paired[0]!.partner).toBe("caveman");
+    });
+
+    test("degrades to empty payload when the skill row is missing", async () => {
+        const db = makeMockDb([[null, { skill: null, invocations: {}, recent: [], corrections: [], proposals: [], paired: [] }]]);
+        const result = await runWithMock(db, fetchSkillDetail("ghost"));
+        expect(result.scope).toBeNull();
+        expect(result.invocations.total).toBe(0);
+        expect(result.recent).toEqual([]);
     });
 });

--- a/apps/axctl/src/queries/skill-detail.test.ts
+++ b/apps/axctl/src/queries/skill-detail.test.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import {
+    SKILL_DETAIL_BASIC_SQL,
     SKILL_DETAIL_SQL,
     fetchSkillDetail,
     mapSkillPairRow,
@@ -57,8 +58,31 @@ describe("SKILL_DETAIL_SQL", () => {
         expect(SKILL_DETAIL_SQL).toContain("turn_has_error");
     });
 
-    test("TUI re-exports the canonical SQL (no fork)", () => {
-        expect(TUI_SKILL_DETAIL_SQL).toBe(SKILL_DETAIL_SQL);
+    test("TUI re-exports the canonical basic SQL (no fork)", () => {
+        expect(TUI_SKILL_DETAIL_SQL).toBe(SKILL_DETAIL_BASIC_SQL);
+    });
+});
+
+describe("SKILL_DETAIL_BASIC_SQL", () => {
+    test("binds the skill by $name", () => {
+        expect(SKILL_DETAIL_BASIC_SQL).toContain("WHERE name = $name");
+    });
+
+    test("includes the TUI daily buckets (last 30 days, ascending)", () => {
+        expect(SKILL_DETAIL_BASIC_SQL).toContain("daily:");
+        expect(SKILL_DETAIL_BASIC_SQL).toMatch(
+            /daily:\s*\(\s*SELECT ts FROM invoked\s*WHERE out = \$s\.id AND ts > time::now\(\) - 30d\s*ORDER BY ts ASC\s*\)/,
+        );
+    });
+
+    test("excludes the dashboard evidence blocks (TUI hot-path regression)", () => {
+        // The TUI DetailPane queries per row selection; the evidence blocks
+        // (esp. `paired`, an unindexed skill_paired endpoint scan) must never
+        // leak back into the basic variant.
+        expect(SKILL_DETAIL_BASIC_SQL).not.toContain("corrections:");
+        expect(SKILL_DETAIL_BASIC_SQL).not.toContain("proposals:");
+        expect(SKILL_DETAIL_BASIC_SQL).not.toContain("paired:");
+        expect(SKILL_DETAIL_BASIC_SQL).not.toContain("skill_paired");
     });
 });
 

--- a/apps/axctl/src/queries/skill-detail.test.ts
+++ b/apps/axctl/src/queries/skill-detail.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { SKILL_DETAIL_SQL } from "./skill-detail.ts";
+import { SKILL_DETAIL_SQL as TUI_SKILL_DETAIL_SQL } from "../tui/queries.ts";
+
+describe("SKILL_DETAIL_SQL", () => {
+    test("binds the skill by $name", () => {
+        expect(SKILL_DETAIL_SQL).toContain("WHERE name = $name");
+    });
+
+    test("includes the TUI daily buckets (last 30 days, ascending)", () => {
+        expect(SKILL_DETAIL_SQL).toContain("daily:");
+        expect(SKILL_DETAIL_SQL).toMatch(
+            /daily:\s*\(\s*SELECT ts FROM invoked\s*WHERE out = \$s\.id AND ts > time::now\(\) - 30d\s*ORDER BY ts ASC\s*\)/,
+        );
+    });
+
+    test("includes the dashboard evidence blocks", () => {
+        expect(SKILL_DETAIL_SQL).toContain("corrections:");
+        expect(SKILL_DETAIL_SQL).toContain("proposals:");
+        expect(SKILL_DETAIL_SQL).toContain("paired:");
+        expect(SKILL_DETAIL_SQL).toContain("turn_has_error");
+    });
+
+    test("TUI re-exports the canonical SQL (no fork)", () => {
+        expect(TUI_SKILL_DETAIL_SQL).toBe(SKILL_DETAIL_SQL);
+    });
+});

--- a/apps/axctl/src/queries/skill-detail.ts
+++ b/apps/axctl/src/queries/skill-detail.ts
@@ -5,6 +5,17 @@
  *
  * Bindings: $name (skill name).
  */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { dateField, numericField, stringField } from "@ax/lib/shared/row-fields";
+import type {
+    SkillDetailPayload,
+    SkillPair,
+    SkillProposalEvidence,
+    SkillRecentInvocation,
+} from "@ax/lib/shared/dashboard-types";
+
 export const SKILL_DETAIL_SQL = `
 LET $s = (SELECT * FROM skill WHERE name = $name)[0];
 RETURN {
@@ -63,3 +74,85 @@ RETURN {
         LIMIT 5
     )
 };`;
+
+/** Empty-string fallback so mapper guards can test truthiness. */
+const tsField = (raw: Record<string, unknown>, key: string): string =>
+    dateField(raw, key) ?? "";
+
+export const mapSkillRecentRow = (raw: unknown): SkillRecentInvocation | null => {
+    if (!raw || typeof raw !== "object") return null;
+    const row = raw as Record<string, unknown>;
+    const ts = tsField(row, "ts");
+    if (!ts) return null;
+    return {
+        ts,
+        project: stringField(row, "project"),
+        ...(typeof row.turn_has_error === "boolean"
+            ? { turn_has_error: row.turn_has_error }
+            : {}),
+    };
+};
+
+export const mapSkillPairRow = (raw: unknown): SkillPair | null => {
+    if (!raw || typeof raw !== "object") return null;
+    const row = raw as Record<string, unknown>;
+    const partner = stringField(row, "partner");
+    if (!partner) return null;
+    return {
+        partner,
+        count: numericField(row, "count"),
+        last_seen: dateField(row, "last_seen"),
+    };
+};
+
+export const mapSkillProposalRow = (raw: unknown): SkillProposalEvidence | null => {
+    if (!raw || typeof raw !== "object") return null;
+    const row = raw as Record<string, unknown>;
+    const ts = tsField(row, "ts");
+    if (!ts) return null;
+    return {
+        ts,
+        project: stringField(row, "project"),
+        context_excerpt: stringField(row, "context_excerpt"),
+    };
+};
+
+export const fetchSkillDetail = (
+    name: string,
+): Effect.Effect<SkillDetailPayload, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const result = yield* db.query<unknown[]>(SKILL_DETAIL_SQL, { name });
+        // RETURN { ... } gives us [block] where block is the object.
+        const payload = Array.isArray(result)
+            ? ([...result].reverse().find((r) => r != null) as Record<string, unknown> | undefined)
+            : (result as Record<string, unknown> | undefined);
+        const skill = (payload?.skill ?? null) as Record<string, unknown> | null;
+        const invocations = (payload?.invocations ?? {}) as Record<string, unknown>;
+        const recent = Array.isArray(payload?.recent) ? payload.recent : [];
+        const corrections = Array.isArray(payload?.corrections) ? payload.corrections : [];
+        const proposals = Array.isArray(payload?.proposals) ? payload.proposals : [];
+        const paired = Array.isArray(payload?.paired) ? payload.paired : [];
+        return {
+            name,
+            scope: skill ? stringField(skill, "scope") : null,
+            description: skill ? stringField(skill, "description") : null,
+            dir_path: skill ? stringField(skill, "dir_path") : null,
+            invocations: {
+                total: numericField(invocations, "total"),
+                d7: numericField(invocations, "d7"),
+                d30: numericField(invocations, "d30"),
+                last: dateField(invocations, "last"),
+            },
+            recent: recent.map(mapSkillRecentRow).filter((r): r is SkillRecentInvocation => r !== null),
+            corrections: corrections
+                .map(mapSkillRecentRow)
+                .filter((r): r is SkillRecentInvocation => r !== null),
+            proposals: proposals
+                .map(mapSkillProposalRow)
+                .filter((r): r is SkillProposalEvidence => r !== null),
+            paired: paired
+                .map(mapSkillPairRow)
+                .filter((r): r is SkillPair => r !== null),
+        };
+    });

--- a/apps/axctl/src/queries/skill-detail.ts
+++ b/apps/axctl/src/queries/skill-detail.ts
@@ -1,6 +1,7 @@
 /**
- * Per-skill detail payload powering both the TUI DetailPane and the web
- * dashboard's "click recommendation reason → see evidence" expand panel.
+ * Per-skill detail payload powering the TUI DetailPane (incl. the 30-day
+ * `daily` sparkline buckets), the web dashboard's "click recommendation
+ * reason → see evidence" expand panel, and `GET /api/skills/:name/detail`.
  *
  * Bindings: $name (skill name).
  */
@@ -20,6 +21,11 @@ RETURN {
         WHERE out = $s.id
         ORDER BY ts DESC
         LIMIT 10
+    ),
+    daily: (
+        SELECT ts FROM invoked
+        WHERE out = $s.id AND ts > time::now() - 30d
+        ORDER BY ts ASC
     ),
     corrections: (
         SELECT ts, in.session.project AS project

--- a/apps/axctl/src/queries/skill-detail.ts
+++ b/apps/axctl/src/queries/skill-detail.ts
@@ -16,6 +16,42 @@ import type {
     SkillRecentInvocation,
 } from "@ax/lib/shared/dashboard-types";
 
+/**
+ * Two variants share this module:
+ *
+ * - `SKILL_DETAIL_BASIC_SQL` - the TUI hot path. The DetailPane re-queries on
+ *   every (debounced) j/k selection change, so it only carries the lightweight
+ *   blocks it renders: skill row, invocation counts, recent list, daily
+ *   sparkline buckets. All filtered by the indexed `invoked.out`.
+ * - `SKILL_DETAIL_SQL` - the full dashboard payload. Adds the evidence blocks
+ *   (`corrections`, `proposals`, `paired`); `paired` scans `skill_paired` by
+ *   both endpoints (no endpoint index), which is fine for an explicit
+ *   click-to-expand panel but too heavy for the TUI's per-row selection.
+ */
+export const SKILL_DETAIL_BASIC_SQL = `
+LET $s = (SELECT * FROM skill WHERE name = $name)[0];
+RETURN {
+    skill: $s,
+    invocations: {
+        total: array::len((SELECT * FROM invoked WHERE out = $s.id)),
+        d7:    array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 7d)),
+        d30:   array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 30d)),
+        last:  (SELECT ts FROM invoked WHERE out = $s.id ORDER BY ts DESC LIMIT 1)[0].ts,
+    },
+    recent: (
+        SELECT ts, in.session.project AS project
+        FROM invoked
+        WHERE out = $s.id
+        ORDER BY ts DESC
+        LIMIT 10
+    ),
+    daily: (
+        SELECT ts FROM invoked
+        WHERE out = $s.id AND ts > time::now() - 30d
+        ORDER BY ts ASC
+    )
+};`;
+
 export const SKILL_DETAIL_SQL = `
 LET $s = (SELECT * FROM skill WHERE name = $name)[0];
 RETURN {
@@ -75,14 +111,10 @@ RETURN {
     )
 };`;
 
-/** Empty-string fallback so mapper guards can test truthiness. */
-const tsField = (raw: Record<string, unknown>, key: string): string =>
-    dateField(raw, key) ?? "";
-
 export const mapSkillRecentRow = (raw: unknown): SkillRecentInvocation | null => {
     if (!raw || typeof raw !== "object") return null;
     const row = raw as Record<string, unknown>;
-    const ts = tsField(row, "ts");
+    const ts = dateField(row, "ts") ?? "";
     if (!ts) return null;
     return {
         ts,
@@ -108,7 +140,7 @@ export const mapSkillPairRow = (raw: unknown): SkillPair | null => {
 export const mapSkillProposalRow = (raw: unknown): SkillProposalEvidence | null => {
     if (!raw || typeof raw !== "object") return null;
     const row = raw as Record<string, unknown>;
-    const ts = tsField(row, "ts");
+    const ts = dateField(row, "ts") ?? "";
     if (!ts) return null;
     return {
         ts,

--- a/apps/axctl/src/queries/skill-stats.test.ts
+++ b/apps/axctl/src/queries/skill-stats.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import {
+    SKILL_STATS_SQL,
+    dedupeRecentSessions,
+    fetchSkillStats,
+} from "./skill-stats.ts";
+
+function makeMockDb(responses: Array<unknown>): SurrealClientShape {
+    let callIndex = 0;
+    return {
+        query: <T extends unknown[] = unknown[]>(
+            _sql: string,
+            _bindings?: Record<string, unknown>,
+        ): Effect.Effect<T, DbError> => {
+            const resp = responses[callIndex] ?? [[]];
+            callIndex++;
+            return Effect.succeed(resp as unknown as T);
+        },
+        upsert: () => Effect.void,
+        relate: () => Effect.void,
+        putFile: () => Effect.void,
+        getFile: () => Effect.succeed(""),
+        raw: {} as never,
+    } as unknown as SurrealClientShape;
+}
+
+const runWithMock = <A>(
+    db: SurrealClientShape,
+    effect: Effect.Effect<A, unknown, SurrealClient>,
+): Promise<A> =>
+    Effect.runPromise(effect.pipe(Effect.provideService(SurrealClient, db)));
+
+describe("SKILL_STATS_SQL", () => {
+    test("binds by $name and covers 7/30/90d windows", () => {
+        expect(SKILL_STATS_SQL).toContain("WHERE name = $name");
+        expect(SKILL_STATS_SQL).toContain("time::now() - 7d");
+        expect(SKILL_STATS_SQL).toContain("time::now() - 30d");
+        expect(SKILL_STATS_SQL).toContain("time::now() - 90d");
+    });
+
+    test("recent sessions are ordered server-side and bounded", () => {
+        expect(SKILL_STATS_SQL).toContain("ORDER BY ts DESC");
+        expect(SKILL_STATS_SQL).toContain("LIMIT 50");
+        expect(SKILL_STATS_SQL).toContain("in.session AS session_id");
+        expect(SKILL_STATS_SQL).toContain("in.session.cwd AS cwd");
+    });
+});
+
+describe("dedupeRecentSessions", () => {
+    test("dedupes by session id and caps at 5", () => {
+        const rows = Array.from({ length: 8 }, (_, i) => ({
+            session_id: `session:s${i % 6}`, // s0..s5, s0/s1 repeat
+            project_slug: "-Users-necmttn-Projects-ax",
+            cwd: null,
+            ts: `2026-06-0${(i % 6) + 1}T00:00:00.000Z`,
+        }));
+        const clean = dedupeRecentSessions(rows);
+        expect(clean).toHaveLength(5);
+        expect(new Set(clean.map((c) => c.ts)).size).toBe(5);
+    });
+
+    test("prefers cwd basename over project slug", () => {
+        const clean = dedupeRecentSessions([
+            {
+                session_id: "session:a",
+                project_slug: "-Users-necmttn-Projects-ax",
+                cwd: "/Users/necmttn/Projects/ax",
+                ts: "2026-06-01T00:00:00.000Z",
+            },
+        ]);
+        expect(clean[0]!.project).toBe("ax");
+    });
+
+    test("unwraps array-valued cwd/slug projections", () => {
+        const clean = dedupeRecentSessions([
+            {
+                session_id: "session:a",
+                project_slug: ["-Users-necmttn-Projects-ax"],
+                cwd: ["/Users/necmttn/Projects/ax"],
+                ts: "2026-06-01T00:00:00.000Z",
+            },
+        ]);
+        expect(clean[0]!.project).toBe("ax");
+    });
+});
+
+describe("fetchSkillStats", () => {
+    test("parses payload from the last non-null statement result", async () => {
+        const payload = {
+            skill: { name: "tdd", scope: "plugin", dir_path: "/tmp/tdd" },
+            invocations: { total: 100, d7: 3, d30: 20, d90: 60, last: "2026-06-09T00:00:00.000Z" },
+            recent_sessions: [
+                { session_id: "session:a", project_slug: "-p-ax", cwd: "/p/ax", ts: "2026-06-09T00:00:00.000Z" },
+                { session_id: "session:a", project_slug: "-p-ax", cwd: "/p/ax", ts: "2026-06-08T00:00:00.000Z" },
+            ],
+        };
+        const db = makeMockDb([[null, payload]]);
+        const result = await runWithMock(db, fetchSkillStats("tdd"));
+
+        expect(result.skill?.name).toBe("tdd");
+        expect(result.invocations).toEqual({
+            total: 100, d7: 3, d30: 20, d90: 60, last: "2026-06-09T00:00:00.000Z",
+        });
+        expect(result.recent_sessions).toEqual([
+            { project: "ax", ts: "2026-06-09T00:00:00.000Z" },
+        ]);
+    });
+
+    test("missing skill yields null skill and zeroed invocations", async () => {
+        const db = makeMockDb([[null, { skill: null, invocations: {}, recent_sessions: [] }]]);
+        const result = await runWithMock(db, fetchSkillStats("ghost"));
+        expect(result.skill).toBeNull();
+        expect(result.invocations.total).toBe(0);
+        expect(result.recent_sessions).toEqual([]);
+    });
+});

--- a/apps/axctl/src/queries/skill-stats.ts
+++ b/apps/axctl/src/queries/skill-stats.ts
@@ -13,7 +13,7 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { dateField, numericField } from "@ax/lib/shared/row-fields";
-import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
+import { sessionProjectLabel } from "@ax/lib/shared/project-slug";
 
 export const SKILL_STATS_SQL = `
 LET $s = (SELECT * FROM skill WHERE name = $name)[0];
@@ -61,10 +61,10 @@ export interface SkillStatsPayload {
 }
 
 /**
- * Dedupe + cap to the most recent `cap` distinct sessions, then prettify the
- * project label (cwd basename when available, else the prettified slug).
- * cwd/project_slug may come back as arrays (per-edge projection) - take the
- * first scalar for display purposes.
+ * Dedupe + cap to the most recent `cap` distinct sessions, then label the
+ * project via the shared `sessionProjectLabel` (prettified slug, falling back
+ * to the cwd basename). cwd/project_slug may come back as arrays (per-edge
+ * projection) - take the first scalar for display purposes.
  */
 export const dedupeRecentSessions = (
     rows: ReadonlyArray<Record<string, unknown>>,
@@ -80,14 +80,10 @@ export const dedupeRecentSessions = (
         const slugRaw = Array.isArray(row.project_slug)
             ? row.project_slug[0]
             : row.project_slug;
-        let project: string;
-        if (typeof cwdRaw === "string" && cwdRaw.length > 0) {
-            // Mirrors path.basename without pulling node:path here.
-            const parts = cwdRaw.split("/").filter((p) => p.length > 0);
-            project = parts.length > 0 ? parts[parts.length - 1] : cwdRaw;
-        } else {
-            project = prettifyProjectSlug(slugRaw);
-        }
+        const project = sessionProjectLabel(
+            typeof slugRaw === "string" ? slugRaw : null,
+            typeof cwdRaw === "string" ? cwdRaw : null,
+        );
         clean.push({ project, ts: dateField(row, "ts") });
         if (clean.length >= cap) break;
     }

--- a/apps/axctl/src/queries/skill-stats.ts
+++ b/apps/axctl/src/queries/skill-stats.ts
@@ -13,7 +13,7 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { dateField, numericField } from "@ax/lib/shared/row-fields";
-import { sessionProjectLabel } from "@ax/lib/shared/project-slug";
+import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
 
 export const SKILL_STATS_SQL = `
 LET $s = (SELECT * FROM skill WHERE name = $name)[0];
@@ -61,10 +61,10 @@ export interface SkillStatsPayload {
 }
 
 /**
- * Dedupe + cap to the most recent `cap` distinct sessions, then label the
- * project via the shared `sessionProjectLabel` (prettified slug, falling back
- * to the cwd basename). cwd/project_slug may come back as arrays (per-edge
- * projection) - take the first scalar for display purposes.
+ * Dedupe + cap to the most recent `cap` distinct sessions, then prettify the
+ * project label (cwd basename when available, else the prettified slug).
+ * cwd/project_slug may come back as arrays (per-edge projection) - take the
+ * first scalar for display purposes.
  */
 export const dedupeRecentSessions = (
     rows: ReadonlyArray<Record<string, unknown>>,
@@ -80,10 +80,14 @@ export const dedupeRecentSessions = (
         const slugRaw = Array.isArray(row.project_slug)
             ? row.project_slug[0]
             : row.project_slug;
-        const project = sessionProjectLabel(
-            typeof slugRaw === "string" ? slugRaw : null,
-            typeof cwdRaw === "string" ? cwdRaw : null,
-        );
+        let project: string;
+        if (typeof cwdRaw === "string" && cwdRaw.length > 0) {
+            // Mirrors path.basename without pulling node:path here.
+            const parts = cwdRaw.split("/").filter((p) => p.length > 0);
+            project = parts.length > 0 ? parts[parts.length - 1] : cwdRaw;
+        } else {
+            project = prettifyProjectSlug(slugRaw);
+        }
         clean.push({ project, ts: dateField(row, "ts") });
         if (clean.length >= cap) break;
     }

--- a/apps/axctl/src/queries/skill-stats.ts
+++ b/apps/axctl/src/queries/skill-stats.ts
@@ -1,0 +1,123 @@
+/**
+ * `ax skills stats <name>`: one-skill stats payload - invocation counts at
+ * 7/30/90 days + the 5 most recent distinct sessions. The CLI formats and
+ * prints; this module owns the SQL, the types, and the dedupe transform.
+ *
+ * Issue #43 history: recent_sessions are ordered by ts DESC server-side,
+ * include the session id so we can de-dup in TS, and capture cwd so we can
+ * render a human-friendly project label rather than the raw Claude slug.
+ *
+ * Bindings: $name (skill name).
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { dateField, numericField } from "@ax/lib/shared/row-fields";
+import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
+
+export const SKILL_STATS_SQL = `
+LET $s = (SELECT * FROM skill WHERE name = $name)[0];
+RETURN {
+    skill: $s,
+    invocations: {
+        total: array::len((SELECT * FROM invoked WHERE out = $s.id)),
+        d7:    array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 7d)),
+        d30:   array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 30d)),
+        d90:   array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 90d)),
+        last:  (SELECT ts FROM invoked WHERE out = $s.id ORDER BY ts DESC LIMIT 1)[0].ts,
+    },
+    recent_sessions: (
+        SELECT
+            in.session AS session_id,
+            in.session.project AS project_slug,
+            in.session.cwd AS cwd,
+            ts
+        FROM invoked
+        WHERE out = $s.id
+        ORDER BY ts DESC
+        LIMIT 50
+    )
+};`;
+
+export interface SkillStatsInvocations {
+    readonly total: number;
+    readonly d7: number;
+    readonly d30: number;
+    readonly d90: number;
+    readonly last: string | null;
+}
+
+export interface SkillStatsRecentSession {
+    readonly project: string;
+    readonly ts: string | null;
+}
+
+export interface SkillStatsPayload {
+    /** Full raw skill row (`$s`) - the CLI prettyPrints it verbatim, so we
+     *  keep every column rather than projecting. */
+    readonly skill: Record<string, unknown> | null;
+    readonly invocations: SkillStatsInvocations;
+    readonly recent_sessions: ReadonlyArray<SkillStatsRecentSession>;
+}
+
+/**
+ * Dedupe + cap to the most recent `cap` distinct sessions, then prettify the
+ * project label (cwd basename when available, else the prettified slug).
+ * cwd/project_slug may come back as arrays (per-edge projection) - take the
+ * first scalar for display purposes.
+ */
+export const dedupeRecentSessions = (
+    rows: ReadonlyArray<Record<string, unknown>>,
+    cap = 5,
+): SkillStatsRecentSession[] => {
+    const seen = new Set<string>();
+    const clean: SkillStatsRecentSession[] = [];
+    for (const row of rows) {
+        const sid = String(row.session_id ?? "");
+        if (sid && seen.has(sid)) continue;
+        if (sid) seen.add(sid);
+        const cwdRaw = Array.isArray(row.cwd) ? row.cwd[0] : row.cwd;
+        const slugRaw = Array.isArray(row.project_slug)
+            ? row.project_slug[0]
+            : row.project_slug;
+        let project: string;
+        if (typeof cwdRaw === "string" && cwdRaw.length > 0) {
+            // Mirrors path.basename without pulling node:path here.
+            const parts = cwdRaw.split("/").filter((p) => p.length > 0);
+            project = parts.length > 0 ? parts[parts.length - 1] : cwdRaw;
+        } else {
+            project = prettifyProjectSlug(slugRaw);
+        }
+        clean.push({ project, ts: dateField(row, "ts") });
+        if (clean.length >= cap) break;
+    }
+    return clean;
+};
+
+export const fetchSkillStats = (
+    name: string,
+): Effect.Effect<SkillStatsPayload, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const result = yield* db.query<unknown[]>(SKILL_STATS_SQL, { name });
+        // LET → null, RETURN → payload: take the last non-null statement result.
+        const payload = (Array.isArray(result)
+            ? [...result].reverse().find((r) => r != null)
+            : result) as Record<string, unknown> | undefined;
+        const skill = (payload?.skill ?? null) as Record<string, unknown> | null;
+        const invocations = (payload?.invocations ?? {}) as Record<string, unknown>;
+        const recentRaw = Array.isArray(payload?.recent_sessions)
+            ? (payload.recent_sessions as Array<Record<string, unknown>>)
+            : [];
+        return {
+            skill,
+            invocations: {
+                total: numericField(invocations, "total"),
+                d7: numericField(invocations, "d7"),
+                d30: numericField(invocations, "d30"),
+                d90: numericField(invocations, "d90"),
+                last: dateField(invocations, "last"),
+            },
+            recent_sessions: dedupeRecentSessions(recentRaw),
+        };
+    });

--- a/apps/axctl/src/queries/unused-skills.test.ts
+++ b/apps/axctl/src/queries/unused-skills.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import {
+    UNUSED_RECENT_SQL,
+    UNUSED_SUMMARY_SQL,
+    UNUSED_SKILL_ROWS_SQL,
+    UNUSED_NEVER_INVOKED_SQL,
+    normalizeLastUsed,
+    mergeUnusedRows,
+    fetchUnusedSkills,
+} from "./unused-skills.ts";
+
+function makeMockDb(responses: Array<unknown>): SurrealClientShape {
+    let callIndex = 0;
+    return {
+        query: <T extends unknown[] = unknown[]>(
+            _sql: string,
+            _bindings?: Record<string, unknown>,
+        ): Effect.Effect<T, DbError> => {
+            const resp = responses[callIndex] ?? [[]];
+            callIndex++;
+            return Effect.succeed(resp as unknown as T);
+        },
+        upsert: () => Effect.void,
+        relate: () => Effect.void,
+        putFile: () => Effect.void,
+        getFile: () => Effect.succeed(""),
+        raw: {} as never,
+    } as unknown as SurrealClientShape;
+}
+
+const runWithMock = <A>(
+    db: SurrealClientShape,
+    effect: Effect.Effect<A, unknown, SurrealClient>,
+): Promise<A> =>
+    Effect.runPromise(effect.pipe(Effect.provideService(SurrealClient, db)));
+
+describe("unused-skills SQL", () => {
+    test("recent scan splices a validated day window and groups by out", () => {
+        const sql = UNUSED_RECENT_SQL(7);
+        expect(sql).toContain("time::now() - 7d");
+        expect(sql).toContain("GROUP BY out");
+        expect(sql).toContain("FROM invoked");
+    });
+
+    test("recent scan rejects non-positive / non-integer day windows", () => {
+        expect(() => UNUSED_RECENT_SQL(0)).toThrow(RangeError);
+        expect(() => UNUSED_RECENT_SQL(-3)).toThrow(RangeError);
+        expect(() => UNUSED_RECENT_SQL(1.5)).toThrow(RangeError);
+    });
+
+    test("summary aggregates over the edge table only (issue #34)", () => {
+        expect(UNUSED_SUMMARY_SQL).toContain("GROUP BY out");
+        expect(UNUSED_SUMMARY_SQL).not.toContain("out.name");
+    });
+
+    test("never-invoked scan excludes tombstoned skills", () => {
+        expect(UNUSED_NEVER_INVOKED_SQL).toContain("array::len(<-invoked) = 0");
+        expect(UNUSED_NEVER_INVOKED_SQL).toContain("deleted_at IS NONE");
+    });
+
+    test("skill rows query is a cheap projection", () => {
+        expect(UNUSED_SKILL_ROWS_SQL).toContain("SELECT id, name, scope FROM skill");
+    });
+});
+
+describe("normalizeLastUsed", () => {
+    test("null / -Infinity (empty math::max group) → null", () => {
+        expect(normalizeLastUsed(null)).toBeNull();
+        expect(normalizeLastUsed(undefined)).toBeNull();
+        expect(normalizeLastUsed(Number.NEGATIVE_INFINITY)).toBeNull();
+    });
+    test("string passthrough, Date → ISO", () => {
+        expect(normalizeLastUsed("2026-06-01T00:00:00.000Z")).toBe("2026-06-01T00:00:00.000Z");
+        expect(normalizeLastUsed(new Date("2026-06-01T00:00:00.000Z"))).toBe("2026-06-01T00:00:00.000Z");
+    });
+    test("toJSON objects (SurrealDB DateTime) → ISO", () => {
+        expect(normalizeLastUsed({ toJSON: () => "2026-06-01T00:00:00.000Z" })).toBe(
+            "2026-06-01T00:00:00.000Z",
+        );
+    });
+});
+
+describe("mergeUnusedRows", () => {
+    const skills = [
+        { id: "skill:a", name: "alpha", scope: "user" },
+        { id: "skill:b", name: "beta", scope: "plugin" },
+        { id: "skill:c", name: "gamma", scope: "user" },
+    ];
+
+    test("anti-joins recent-active skills out and sorts by total then name", () => {
+        const rows = mergeUnusedRows({
+            recent: [{ skill_id: "skill:a" }],
+            summary: [
+                { skill_id: "skill:a", total_inv: 50, last_used: "2026-06-09T00:00:00.000Z" },
+                { skill_id: "skill:b", total_inv: 9, last_used: "2026-04-01T00:00:00.000Z" },
+                { skill_id: "skill:c", total_inv: 2, last_used: "2026-03-01T00:00:00.000Z" },
+            ],
+            skills,
+            neverInvoked: [],
+        });
+        expect(rows.map((r) => r.name)).toEqual(["gamma", "beta"]);
+        expect(rows[0]!.last_used).toBe("2026-03-01T00:00:00.000Z");
+    });
+
+    test("drops orphan invocation groups whose skill row is missing", () => {
+        const rows = mergeUnusedRows({
+            recent: [],
+            summary: [{ skill_id: "skill:ghost", total_inv: 4, last_used: null }],
+            skills,
+            neverInvoked: [],
+        });
+        expect(rows).toEqual([]);
+    });
+
+    test("appends never-invoked skills with zero totals and null last_used", () => {
+        const rows = mergeUnusedRows({
+            recent: [],
+            summary: [],
+            skills,
+            neverInvoked: [{ name: "delta", scope: "user" }],
+        });
+        expect(rows).toEqual([
+            { name: "delta", scope: "user", total_inv: 0, last_used: null },
+        ]);
+    });
+});
+
+describe("fetchUnusedSkills", () => {
+    test("runs the 4 scans and merges", async () => {
+        const db = makeMockDb([
+            [[{ skill_id: "skill:a", recent: 3 }]],                                            // recent
+            [[
+                { skill_id: "skill:a", total_inv: 50, last_used: "2026-06-09T00:00:00.000Z" },
+                { skill_id: "skill:b", total_inv: 9, last_used: "2026-04-01T00:00:00.000Z" },
+            ]],                                                                                 // summary
+            [[
+                { id: "skill:a", name: "alpha", scope: "user" },
+                { id: "skill:b", name: "beta", scope: "plugin" },
+            ]],                                                                                 // skill rows
+            [[{ name: "delta", scope: "user" }]],                                               // never invoked
+        ]);
+        const rows = await runWithMock(db, fetchUnusedSkills({ days: 7 }));
+        expect(rows.map((r) => r.name)).toEqual(["delta", "beta"]);
+        expect(rows[0]).toEqual({ name: "delta", scope: "user", total_inv: 0, last_used: null });
+    });
+});

--- a/apps/axctl/src/queries/unused-skills.test.ts
+++ b/apps/axctl/src/queries/unused-skills.test.ts
@@ -81,6 +81,13 @@ describe("normalizeLastUsed", () => {
             "2026-06-01T00:00:00.000Z",
         );
     });
+    test("junk objects / non-datetime values → null (never '[object Object]')", () => {
+        expect(normalizeLastUsed({})).toBeNull();
+        expect(normalizeLastUsed({ foo: 1 })).toBeNull();
+        expect(normalizeLastUsed({ toJSON: () => 42 })).toBeNull();
+        expect(normalizeLastUsed(12345)).toBeNull();
+        expect(normalizeLastUsed(true)).toBeNull();
+    });
 });
 
 describe("mergeUnusedRows", () => {

--- a/apps/axctl/src/queries/unused-skills.ts
+++ b/apps/axctl/src/queries/unused-skills.ts
@@ -65,10 +65,7 @@ export interface UnusedSkillRow {
  * `dateField` extractor (string passthrough, Date/`{toJSON}` → ISO, anything
  * else → null).
  */
-export const normalizeLastUsed = (v: unknown): string | null => {
-    if (typeof v === "number" && !Number.isFinite(v)) return null;
-    return dateField({ v }, "v");
-};
+export const normalizeLastUsed = (v: unknown): string | null => dateField({ v }, "v");
 
 export interface UnusedScanRows {
     readonly recent: ReadonlyArray<Record<string, unknown>>;

--- a/apps/axctl/src/queries/unused-skills.ts
+++ b/apps/axctl/src/queries/unused-skills.ts
@@ -1,0 +1,149 @@
+/**
+ * `ax skills unused`: skills with no invocations inside a recency window.
+ *
+ * PERF (issue #31): an earlier form ran a correlated subquery per skill
+ * (`SELECT count() FROM invoked WHERE out = $parent.id AND ts > N`). On the
+ * largest skill (~500k invoked edges) the index walk took ~1.5s × 137 skills.
+ * Now we (a) compute the recent-active set in one full-scan GROUP BY over
+ * `invoked`, (b) compute total_inv + last_used in bulk, (c) anti-join in TS.
+ * Net round-trip: ~2 cheap queries.
+ *
+ * Issue #34: `out.name AS name` over a GROUP BY scan returns the per-edge
+ * name array (~500k entries for codex:exec_command); String() of that is a
+ * 17 MB single line. So we aggregate over the edge table only and look up
+ * skill rows by id in a separate cheap query, merging in TS.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+
+const checkedDays = (days: number): number => {
+    if (!Number.isInteger(days) || days <= 0) {
+        throw new RangeError(`days must be a positive integer (got ${days})`);
+    }
+    return days;
+};
+
+/** Skills with ≥1 invocation inside the window - the "still active" set. */
+export const UNUSED_RECENT_SQL = (days: number): string => `
+SELECT out AS skill_id, count() AS recent
+FROM invoked
+WHERE ts > time::now() - ${checkedDays(days)}d
+GROUP BY out;`;
+
+/** Bulk per-skill totals + last_used over the whole edge table. */
+export const UNUSED_SUMMARY_SQL = `
+SELECT
+    out AS skill_id,
+    count() AS total_inv,
+    math::max(ts) AS last_used
+FROM invoked
+GROUP BY out;`;
+
+/** Cheap id → (name, scope) lookup, merged in TS. */
+export const UNUSED_SKILL_ROWS_SQL = `SELECT id, name, scope FROM skill;`;
+
+/** Skills with literally zero invocations don't show up in the GROUP BY
+ *  scan; pull them straight from the skill table so the "never used" rows
+ *  still appear. */
+export const UNUSED_NEVER_INVOKED_SQL = `
+SELECT name, scope FROM skill WHERE array::len(<-invoked) = 0 AND deleted_at IS NONE;`;
+
+export interface UnusedSkillRow {
+    readonly name: string;
+    readonly scope: string;
+    readonly total_inv: number;
+    /** ISO timestamp of last use; `null` = never used. */
+    readonly last_used: string | null;
+}
+
+/**
+ * SurrealDB's math::max returns -Infinity for empty groups; normalise that
+ * (and null/undefined) to `null`. Datetimes arrive as string, Date, or a
+ * DateTime-like `{toJSON}` object depending on path.
+ */
+export const normalizeLastUsed = (v: unknown): string | null => {
+    if (v == null) return null;
+    if (typeof v === "number" && !Number.isFinite(v)) return null;
+    if (typeof v === "string") return v;
+    if (v instanceof Date) return v.toISOString();
+    if (typeof v === "object" && "toJSON" in v) {
+        const j = (v as { toJSON: () => unknown }).toJSON();
+        if (typeof j === "string" && j.length > 0) return j;
+    }
+    return String(v);
+};
+
+export interface UnusedScanRows {
+    readonly recent: ReadonlyArray<Record<string, unknown>>;
+    readonly summary: ReadonlyArray<Record<string, unknown>>;
+    readonly skills: ReadonlyArray<Record<string, unknown>>;
+    readonly neverInvoked: ReadonlyArray<Record<string, unknown>>;
+}
+
+/** Anti-join the recent-active set out of the bulk summary, drop orphan
+ *  invocation groups (no skill row - matches the original FROM-skill
+ *  behaviour), append never-invoked skills, sort by total then name. */
+export const mergeUnusedRows = (input: UnusedScanRows): UnusedSkillRow[] => {
+    const recentIds = new Set<string>(
+        input.recent.map((r) => String(r.skill_id ?? "")),
+    );
+    const skillById = new Map<string, { name: string; scope: string }>();
+    for (const s of input.skills) {
+        skillById.set(String(s.id ?? ""), {
+            name: String(s.name ?? ""),
+            scope: String(s.scope ?? ""),
+        });
+    }
+    const unused: UnusedSkillRow[] = [];
+    for (const r of input.summary) {
+        const id = String(r.skill_id ?? "");
+        if (recentIds.has(id)) continue;
+        const meta = skillById.get(id);
+        if (!meta || !meta.name) continue;
+        unused.push({
+            name: meta.name,
+            scope: meta.scope,
+            total_inv: Number(r.total_inv ?? 0),
+            last_used: normalizeLastUsed(r.last_used),
+        });
+    }
+    for (const r of input.neverInvoked) {
+        unused.push({
+            name: String(r.name ?? ""),
+            scope: String(r.scope ?? ""),
+            total_inv: 0,
+            last_used: null,
+        });
+    }
+    unused.sort(
+        (a, b) => a.total_inv - b.total_inv || a.name.localeCompare(b.name),
+    );
+    return unused;
+};
+
+export interface UnusedSkillsParams {
+    readonly days: number;
+}
+
+export const fetchUnusedSkills = (
+    params: UnusedSkillsParams,
+): Effect.Effect<ReadonlyArray<UnusedSkillRow>, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const [recentRes, summaryRes, skillRes, noInvRes] = yield* Effect.all(
+            [
+                db.query<[Array<Record<string, unknown>>]>(UNUSED_RECENT_SQL(params.days)),
+                db.query<[Array<Record<string, unknown>>]>(UNUSED_SUMMARY_SQL),
+                db.query<[Array<Record<string, unknown>>]>(UNUSED_SKILL_ROWS_SQL),
+                db.query<[Array<Record<string, unknown>>]>(UNUSED_NEVER_INVOKED_SQL),
+            ],
+            { concurrency: 4 },
+        );
+        return mergeUnusedRows({
+            recent: recentRes?.[0] ?? [],
+            summary: summaryRes?.[0] ?? [],
+            skills: skillRes?.[0] ?? [],
+            neverInvoked: noInvRes?.[0] ?? [],
+        });
+    });

--- a/apps/axctl/src/queries/unused-skills.ts
+++ b/apps/axctl/src/queries/unused-skills.ts
@@ -16,6 +16,7 @@
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
+import { dateField } from "@ax/lib/shared/row-fields";
 
 const checkedDays = (days: number): number => {
     if (!Number.isInteger(days) || days <= 0) {
@@ -60,18 +61,13 @@ export interface UnusedSkillRow {
 /**
  * SurrealDB's math::max returns -Infinity for empty groups; normalise that
  * (and null/undefined) to `null`. Datetimes arrive as string, Date, or a
- * DateTime-like `{toJSON}` object depending on path.
+ * DateTime-like `{toJSON}` object depending on path - delegated to the shared
+ * `dateField` extractor (string passthrough, Date/`{toJSON}` → ISO, anything
+ * else → null).
  */
 export const normalizeLastUsed = (v: unknown): string | null => {
-    if (v == null) return null;
     if (typeof v === "number" && !Number.isFinite(v)) return null;
-    if (typeof v === "string") return v;
-    if (v instanceof Date) return v.toISOString();
-    if (typeof v === "object" && "toJSON" in v) {
-        const j = (v as { toJSON: () => unknown }).toJSON();
-        if (typeof j === "string" && j.length > 0) return j;
-    }
-    return String(v);
+    return dateField({ v }, "v");
 };
 
 export interface UnusedScanRows {

--- a/apps/axctl/src/tui/queries.ts
+++ b/apps/axctl/src/tui/queries.ts
@@ -12,4 +12,8 @@ export {
     SKILL_SUMMARY_SQL,
 } from "../queries/skill-summary.ts";
 
-export { SKILL_DETAIL_SQL } from "../queries/skill-detail.ts";
+// The TUI DetailPane re-queries per (debounced) row selection, so it gets the
+// lightweight variant - the full SKILL_DETAIL_SQL adds dashboard evidence
+// blocks (corrections/proposals/paired) the TUI never renders, and `paired`
+// scans skill_paired by both endpoints (unindexed).
+export { SKILL_DETAIL_BASIC_SQL as SKILL_DETAIL_SQL } from "../queries/skill-detail.ts";

--- a/apps/axctl/src/tui/queries.ts
+++ b/apps/axctl/src/tui/queries.ts
@@ -1,8 +1,8 @@
 /**
  * SurrealQL query strings used by the TUI dashboard.
  *
- * Skill summary SQL moved to `src/queries/skill-summary.ts` so the dashboard
- * server can reuse it. Re-exported here for backward compatibility.
+ * All SQL now lives in `src/queries/` so every surface shares one variant.
+ * Re-exported here for backward compatibility with the TUI hooks.
  */
 
 export {
@@ -12,33 +12,4 @@ export {
     SKILL_SUMMARY_SQL,
 } from "../queries/skill-summary.ts";
 
-/**
- * Detail payload for a single skill: skill metadata (no body - read from
- * dir_path on the JS side) + per-day invocation buckets for the last 30 days
- * + recent invocation list.
- *
- * Bindings: $name (skill name).
- */
-export const SKILL_DETAIL_SQL = `
-LET $s = (SELECT * FROM skill WHERE name = $name)[0];
-RETURN {
-    skill: $s,
-    invocations: {
-        total: array::len((SELECT * FROM invoked WHERE out = $s.id)),
-        d7:    array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 7d)),
-        d30:   array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 30d)),
-        last:  (SELECT ts FROM invoked WHERE out = $s.id ORDER BY ts DESC LIMIT 1)[0].ts,
-    },
-    recent: (
-        SELECT ts, in.session.project AS project
-        FROM invoked
-        WHERE out = $s.id
-        ORDER BY ts DESC
-        LIMIT 10
-    ),
-    daily: (
-        SELECT ts FROM invoked
-        WHERE out = $s.id AND ts > time::now() - 30d
-        ORDER BY ts ASC
-    )
-};`;
+export { SKILL_DETAIL_SQL } from "../queries/skill-detail.ts";

--- a/packages/lib/src/shared/row-fields.test.ts
+++ b/packages/lib/src/shared/row-fields.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isRecord, stringField, dateField, numberField, recordIdString } from "./row-fields.ts";
+import { isRecord, stringField, dateField, numberField, numericField, recordIdString } from "./row-fields.ts";
 
 describe("isRecord", () => {
     test("true for plain object, false for array/null", () => {
@@ -37,6 +37,16 @@ describe("numberField", () => {
     test("finite number passthrough, else null", () => {
         expect(numberField({ n: 3 }, "n")).toBe(3);
         expect(numberField({ n: "3" }, "n")).toBe(null);
+    });
+});
+
+describe("numericField", () => {
+    test("coerces numeric-ish values, defaults to 0", () => {
+        expect(numericField({ n: 3 }, "n")).toBe(3);
+        expect(numericField({ n: "3" }, "n")).toBe(3);
+        expect(numericField({}, "n")).toBe(0);
+        expect(numericField({ n: Number.NEGATIVE_INFINITY }, "n")).toBe(0);
+        expect(numericField({ n: "junk" }, "n")).toBe(0);
     });
 });
 

--- a/packages/lib/src/shared/row-fields.ts
+++ b/packages/lib/src/shared/row-fields.ts
@@ -44,6 +44,17 @@ export const numberField = (
     return typeof v === "number" && Number.isFinite(v) ? v : null;
 };
 
+/** Number at `key` coerced from any numeric-ish value (string counts, Date
+ *  no); non-finite or missing → `0`. Use for aggregate counts where a
+ *  missing column means zero. */
+export const numericField = (
+    row: Record<string, unknown>,
+    key: string,
+): number => {
+    const v = Number(row[key] ?? 0);
+    return Number.isFinite(v) ? v : 0;
+};
+
 /** A record id rendered as a string - accepts a string or a `RecordId`-like
  *  object with a meaningful `toString`. */
 export const recordIdString = (v: unknown): string | null => {


### PR DESCRIPTION
## Summary

- Extract skill stats, unused skill scanning, skill detail, role, and episode timeline query behavior out of the CLI/dashboard surfaces into query modules.
- Preserve existing CLI/TUI behavior while adding focused characterization coverage for the extracted query builders and row mappers.
- Apply review-gate cleanups, including the TUI basic skill-detail SQL split and preserving cwd-basename-first labels for recent sessions.

## Verification

- `/tmp/p1-test.sh` -> `2647 pass`, `4 skip`, `0 fail`
- `bun run typecheck` -> exit 0; existing Effect-LSP advisory diagnostics only

## Notes

Live DB / `ax ingest` checks intentionally skipped per the phase execution convention.
