### PR TITLE
fix(ingest): add claude-fable-5 + claude-haiku-4-5 pricing entries

### DIFF
--- a/apps/axctl/src/ingest/derive-cost-backfill.test.ts
+++ b/apps/axctl/src/ingest/derive-cost-backfill.test.ts
@@ -60,7 +60,7 @@ describe("deriveCostBackfill", () => {
         // 1M estimated tokens × claude-opus-4-5 input $5/M (byte-estimate rows
         // price the whole count at the input rate - honest lower bound).
         expect(stmt).toContain("estimated_cost_usd = 5.00000000");
-        expect(stmt).toContain('pricing_source = "estimated:built_in_catalog_2026-05-29"');
+        expect(stmt).toContain('pricing_source = "estimated:built_in_catalog_2026-06-10"');
         // Race guard: a concurrently ingest-priced cost wins at write time.
         expect(stmt).toContain("WHERE estimated_cost_usd IS NONE");
     });
@@ -94,8 +94,8 @@ describe("deriveCostBackfill", () => {
         const stats = await Effect.runPromise(
             deriveCostBackfill().pipe(Effect.provide(makeDb([
                 // Should be excluded by the selection - never rewritten even if returned.
-                row({ pricing_source: "estimated:built_in_catalog_2026-05-29" }),
-                row({ id: "session_token_usage:`s2`", estimated_cost_usd: 1.23, pricing_source: "built_in_catalog_2026-05-29" }),
+                row({ pricing_source: "estimated:built_in_catalog_2026-06-10" }),
+                row({ id: "session_token_usage:`s2`", estimated_cost_usd: 1.23, pricing_source: "built_in_catalog_2026-06-10" }),
             ], sink))),
         );
         expect(stats.backfilled).toBe(0);

--- a/apps/axctl/src/ingest/model-pricing.test.ts
+++ b/apps/axctl/src/ingest/model-pricing.test.ts
@@ -159,6 +159,36 @@ describe("model pricing", () => {
         expect(cost.outputUsd).toBeCloseTo(0.001);
     });
 
+    it("prices claude-fable-5 turns instead of leaving them null", () => {
+        const cost = estimateCost({
+            modelKey: "claude-fable-5",
+            promptTokens: 1_000_000,
+            completionTokens: 100_000,
+            cacheCreationInputTokens: 200_000,
+            cacheReadInputTokens: 700_000,
+            estimatedTokens: 1_100_000,
+        });
+
+        expect(cost.inputUsd).toBeCloseTo(1); // 100k fresh @ $10/M
+        expect(cost.outputUsd).toBeCloseTo(5); // 100k @ $50/M
+        expect(cost.cacheCreationUsd).toBeCloseTo(2.5); // 200k @ $12.5/M
+        expect(cost.cacheReadUsd).toBeCloseTo(0.7); // 700k @ $1/M
+        expect(cost.pricingSource).not.toBeNull();
+    });
+
+    it("falls back fable and dated haiku ids to their base entries", () => {
+        const catalog = builtInPricingCatalog();
+
+        expect(pricingForModel("claude-fable-5[1m]", catalog)).toMatchObject({
+            inputPerMillionUsd: 10,
+            outputPerMillionUsd: 50,
+        });
+        expect(pricingForModel("claude-haiku-4-5-20251001", catalog)).toMatchObject({
+            inputPerMillionUsd: 1,
+            outputPerMillionUsd: 5,
+        });
+    });
+
     it("falls back gpt-5 point releases to gpt-5 pricing when no exact row exists", () => {
         const catalog = new Map([["gpt-5", builtInPricingCatalog().get("gpt-5")!]]);
 

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -13,7 +13,7 @@ import type { StageDef } from "./stage/registry.ts";
 const LITELLM_PRICING_URL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 const MODELS_DEV_API_URL = "https://models.dev/api.json";
 
-export const MODEL_PRICING_SOURCE = "built_in_catalog_2026-05-29";
+export const MODEL_PRICING_SOURCE = "built_in_catalog_2026-06-10";
 
 export interface ModelPricing {
     readonly provider: string;
@@ -267,6 +267,24 @@ export const BUILTIN_MODEL_PRICING_CATALOG: Readonly<Record<string, ModelPricing
         fastMultiplier: 1,
         pricingSource: MODEL_PRICING_SOURCE,
     },
+    "claude-fable-5": {
+        provider: "anthropic",
+        inputPerMillionUsd: 10,
+        outputPerMillionUsd: 50,
+        cacheCreationPerMillionUsd: 12.5,
+        cacheReadPerMillionUsd: 1,
+        fastMultiplier: 1,
+        pricingSource: MODEL_PRICING_SOURCE,
+    },
+    "claude-haiku-4-5": {
+        provider: "anthropic",
+        inputPerMillionUsd: 1,
+        outputPerMillionUsd: 5,
+        cacheCreationPerMillionUsd: 1.25,
+        cacheReadPerMillionUsd: 0.1,
+        fastMultiplier: 1,
+        pricingSource: MODEL_PRICING_SOURCE,
+    },
 };
 
 export function normalizeModelName(model: string | null | undefined): string | null {
@@ -392,6 +410,8 @@ export function pricingForModel(
     const exact = catalog.get(modelKey);
     if (exact) return exact;
     if (/^gpt-5(?:\.\d+)?$/i.test(modelKey)) return catalog.get("gpt-5") ?? null;
+    if (modelKey.startsWith("claude-fable-5")) return catalog.get("claude-fable-5") ?? null;
+    if (modelKey.startsWith("claude-haiku-4-5")) return catalog.get("claude-haiku-4-5") ?? null;
     if (modelKey.startsWith("claude-opus-4")) return catalog.get("claude-opus-4") ?? null;
     if (modelKey.startsWith("claude-sonnet-4")) return catalog.get("claude-sonnet-4") ?? null;
     return null;

--- a/apps/axctl/src/metrics/cost-estimate.test.ts
+++ b/apps/axctl/src/metrics/cost-estimate.test.ts
@@ -40,12 +40,12 @@ const catalog = new Map<string, ModelPricing>([
 describe("fillEstimatedCost", () => {
     test("keeps a stored cost untouched (estimated=false, source preserved)", () => {
         const out = fillEstimatedCost(
-            usage({ estimated_cost_usd: 50.5, pricing_source: "built_in_catalog_2026-05-29" }),
+            usage({ estimated_cost_usd: 50.5, pricing_source: "built_in_catalog_2026-06-10" }),
             catalog,
         );
         expect(out).toEqual({
             estimatedCostUsd: 50.5,
-            pricingSource: "built_in_catalog_2026-05-29",
+            pricingSource: "built_in_catalog_2026-06-10",
             estimated: false,
         });
     });


### PR DESCRIPTION
## Bug

Share viewer "COST SO FAR" rail froze at $1.18 from turn ~61 onward on the published NavLink session share, while session total showed $61.77.

## Root cause

`BUILTIN_MODEL_PRICING_CATALOG` had no entry for `claude-fable-5` (or dated haiku ids like `claude-haiku-4-5-20251001`), and `pricingForModel` fallbacks only covered `claude-opus-4*` / `claude-sonnet-4*` / `gpt-5.x`. The session had 314 fable-5 turns (null cost) and 23 opus-4-8 turns (priced = exactly $1.18). The rail sums exact per-turn costs only, so it plateaued at the last priced turn. The viewer was correct; the data was incomplete.

## Fix

- add `claude-fable-5` ($10/$50 per MTok, cache write $12.50 / read $1.00 — standard 1.25×/0.1× ratios) and `claude-haiku-4-5` ($1/$5, cache $1.25/$0.10) builtin entries
- add prefix fallbacks so suffixed ids (`claude-fable-5[1m]`, `claude-haiku-4-5-20251001`) resolve to the base entry
- bump `MODEL_PRICING_SOURCE` to `built_in_catalog_2026-06-10` (also invalidates the pricing watermark so `agent_model` rows rewrite on next ingest)
- regression tests: fable-5 component costs + suffixed-id fallbacks

## Evidence

Repriced the published gist payload with these rates: cumulative cost now climbs monotonically ($24.58 at turn #343, $88.28 session total vs the $61.77 all-at-opus-rates estimate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)