### PR TITLE
feat: session map strip, OG ASCII logo, stale-usage share warning

### DIFF
--- a/apps/axctl/src/cli/share.test.ts
+++ b/apps/axctl/src/cli/share.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from "bun:test";
 import { minimalShareArtifact, type AxSessionShare } from "../share/artifact.ts";
+import { formatStaleUsageWarning } from "../share/format.ts";
 import { cmdShareWithDeps, parseShareArgs, type ShareCommandDeps } from "./share.ts";
+
+const SESSION_USAGE = {
+    model: "claude-opus-4-5",
+    prompt_tokens: null,
+    completion_tokens: null,
+    cache_creation_input_tokens: null,
+    cache_read_input_tokens: null,
+    estimated_tokens: 5000,
+    estimated_cost_usd: 0.05,
+    pricing_source: "test",
+};
+
+const TURN_USAGE = {
+    ...SESSION_USAGE,
+    seq: 1,
+    fresh_input_tokens: null,
+    usage_source: "api",
+    usage_quality: "exact",
+};
 
 function makeHarness(
     artifact: AxSessionShare | null = minimalShareArtifact({ id: "abc123", source: "codex" }),
@@ -127,16 +147,7 @@ describe("cmdShareWithDeps", () => {
     it("emits stale-usage warning to stderr when session has cost but no per-turn usage", async () => {
         const artifact: AxSessionShare = {
             ...minimalShareArtifact({ id: "abc123", source: "claude" }),
-            token_usage: {
-                model: "claude-opus-4-5",
-                prompt_tokens: null,
-                completion_tokens: null,
-                cache_creation_input_tokens: null,
-                cache_read_input_tokens: null,
-                estimated_tokens: 5000,
-                estimated_cost_usd: 0.05,
-                pricing_source: "test",
-            },
+            token_usage: SESSION_USAGE,
             turns: [
                 { id: "t1", seq: 1, role: "user", text: "hello" },
             ],
@@ -144,38 +155,24 @@ describe("cmdShareWithDeps", () => {
         const harness = makeHarness(artifact);
         await cmdShareWithDeps(["abc123", "--dry-run"], harness.deps);
 
-        expect(harness.stderr()).toContain("axctl share: warning:");
-        expect(harness.stderr()).toContain("session-level cost but no per-turn usage rows");
-        expect(harness.stderr()).toContain("AX_REDERIVE_CLAUDE=1");
+        expect(harness.stderr()).toBe(formatStaleUsageWarning());
+        expect(formatStaleUsageWarning()).toBe(
+            "axctl share: warning: this share has session-level cost but no per-turn usage rows; cost rails may render as $0.\n" +
+            "Re-run ingest with AX_REDERIVE_CLAUDE=1 AX_REDERIVE_SUBAGENTS=1 ax ingest here --stages=claude,subagents --since=N\n",
+        );
     });
 
     it("does not emit stale-usage warning when turns have token_usage", async () => {
-        const sessionUsage = {
-            model: "claude-opus-4-5",
-            prompt_tokens: null,
-            completion_tokens: null,
-            cache_creation_input_tokens: null,
-            cache_read_input_tokens: null,
-            estimated_tokens: 5000,
-            estimated_cost_usd: 0.05,
-            pricing_source: "test",
-        };
         const artifact: AxSessionShare = {
             ...minimalShareArtifact({ id: "abc123", source: "claude" }),
-            token_usage: sessionUsage,
+            token_usage: SESSION_USAGE,
             turns: [
                 {
                     id: "t1",
                     seq: 1,
                     role: "assistant",
                     text: "hello",
-                    token_usage: {
-                        ...sessionUsage,
-                        seq: 1,
-                        fresh_input_tokens: null,
-                        usage_source: "api",
-                        usage_quality: "exact",
-                    },
+                    token_usage: TURN_USAGE,
                 },
             ],
         };

--- a/apps/axctl/src/cli/share.test.ts
+++ b/apps/axctl/src/cli/share.test.ts
@@ -124,6 +124,74 @@ describe("cmdShareWithDeps", () => {
         expect(harness.exitCode()).toBeUndefined();
     });
 
+    it("emits stale-usage warning to stderr when session has cost but no per-turn usage", async () => {
+        const artifact: AxSessionShare = {
+            ...minimalShareArtifact({ id: "abc123", source: "claude" }),
+            token_usage: {
+                model: "claude-opus-4-5",
+                prompt_tokens: null,
+                completion_tokens: null,
+                cache_creation_input_tokens: null,
+                cache_read_input_tokens: null,
+                estimated_tokens: 5000,
+                estimated_cost_usd: 0.05,
+                pricing_source: "test",
+            },
+            turns: [
+                { id: "t1", seq: 1, role: "user", text: "hello" },
+            ],
+        };
+        const harness = makeHarness(artifact);
+        await cmdShareWithDeps(["abc123", "--dry-run"], harness.deps);
+
+        expect(harness.stderr()).toContain("axctl share: warning:");
+        expect(harness.stderr()).toContain("session-level cost but no per-turn usage rows");
+        expect(harness.stderr()).toContain("AX_REDERIVE_CLAUDE=1");
+    });
+
+    it("does not emit stale-usage warning when turns have token_usage", async () => {
+        const sessionUsage = {
+            model: "claude-opus-4-5",
+            prompt_tokens: null,
+            completion_tokens: null,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+            estimated_tokens: 5000,
+            estimated_cost_usd: 0.05,
+            pricing_source: "test",
+        };
+        const artifact: AxSessionShare = {
+            ...minimalShareArtifact({ id: "abc123", source: "claude" }),
+            token_usage: sessionUsage,
+            turns: [
+                {
+                    id: "t1",
+                    seq: 1,
+                    role: "assistant",
+                    text: "hello",
+                    token_usage: {
+                        ...sessionUsage,
+                        seq: 1,
+                        fresh_input_tokens: null,
+                        usage_source: "api",
+                        usage_quality: "exact",
+                    },
+                },
+            ],
+        };
+        const harness = makeHarness(artifact);
+        await cmdShareWithDeps(["abc123", "--dry-run"], harness.deps);
+
+        expect(harness.stderr()).not.toContain("axctl share: warning:");
+    });
+
+    it("does not emit stale-usage warning when there is no session-level usage", async () => {
+        const harness = makeHarness();
+        await cmdShareWithDeps(["abc123", "--dry-run"], harness.deps);
+
+        expect(harness.stderr()).not.toContain("axctl share: warning:");
+    });
+
     it("passes public visibility into preview and publisher", async () => {
         const harness = makeHarness();
         await cmdShareWithDeps(["abc123", "--public", "--yes"], harness.deps);

--- a/apps/axctl/src/cli/share.ts
+++ b/apps/axctl/src/cli/share.ts
@@ -13,6 +13,7 @@ import {
 import {
     formatSharePreview,
     formatShareSuccess,
+    formatStaleUsageWarning,
     hasStaleUsage,
 } from "../share/format.ts";
 import { redactShareArtifact } from "../share/redact.ts";
@@ -109,10 +110,7 @@ export async function cmdShareWithDeps(
     const bundle = buildShareBundle(artifact);
 
     if (hasStaleUsage(artifact)) {
-        deps.writeStderr(
-            "axctl share: warning: this share has session-level cost but no per-turn usage rows; cost rails may render as $0.\n" +
-            "Re-run ingest with AX_REDERIVE_CLAUDE=1 AX_REDERIVE_SUBAGENTS=1 ax ingest here --stages=claude,subagents --since=N\n",
-        );
+        deps.writeStderr(formatStaleUsageWarning());
     }
 
     if (parsed.dryRun) {

--- a/apps/axctl/src/cli/share.ts
+++ b/apps/axctl/src/cli/share.ts
@@ -13,6 +13,7 @@ import {
 import {
     formatSharePreview,
     formatShareSuccess,
+    hasStaleUsage,
 } from "../share/format.ts";
 import { redactShareArtifact } from "../share/redact.ts";
 import { AX_VERSION } from "./version.ts";
@@ -106,6 +107,13 @@ export async function cmdShareWithDeps(
 
     const { artifact } = redactShareArtifact(exported);
     const bundle = buildShareBundle(artifact);
+
+    if (hasStaleUsage(artifact)) {
+        deps.writeStderr(
+            "axctl share: warning: this share has session-level cost but no per-turn usage rows; cost rails may render as $0.\n" +
+            "Re-run ingest with AX_REDERIVE_CLAUDE=1 AX_REDERIVE_SUBAGENTS=1 ax ingest here --stages=claude,subagents --since=N\n",
+        );
+    }
 
     if (parsed.dryRun) {
         // Emit the full multi-file bundle keyed by gist filename so the dry-run

--- a/apps/axctl/src/share/format.test.ts
+++ b/apps/axctl/src/share/format.test.ts
@@ -195,6 +195,31 @@ describe("hasStaleUsage", () => {
         expect(hasStaleUsage(artifact)).toBe(false);
     });
 
+    it("returns true when only a grandchild has session usage and no turn usage exists anywhere", () => {
+        const grandchild: AxSessionShare = {
+            ...minimalShareArtifact({ id: "grandchild1", source: "claude" }),
+            token_usage: SESSION_USAGE,
+            turns: [
+                { id: "gt1", seq: 1, role: "assistant", text: "deep" },
+            ],
+        };
+        const child: AxSessionShare = {
+            ...minimalShareArtifact({ id: "child1", source: "claude" }),
+            turns: [
+                { id: "ct1", seq: 1, role: "assistant", text: "sub" },
+            ],
+            children: [grandchild],
+        };
+        const artifact: AxSessionShare = {
+            ...minimalShareArtifact({ id: "abc123", source: "claude" }),
+            turns: [
+                { id: "t1", seq: 1, role: "user", text: "hello" },
+            ],
+            children: [child],
+        };
+        expect(hasStaleUsage(artifact)).toBe(true);
+    });
+
     it("returns true when session usage uses estimated_tokens only (no cost) and no turns have usage", () => {
         const artifact: AxSessionShare = {
             ...minimalShareArtifact({ id: "abc123", source: "claude" }),

--- a/apps/axctl/src/share/format.test.ts
+++ b/apps/axctl/src/share/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { minimalShareArtifact } from "./artifact.ts";
-import { formatSharePreview, formatShareSuccess } from "./format.ts";
+import { minimalShareArtifact, type AxSessionShare } from "./artifact.ts";
+import { formatSharePreview, formatShareSuccess, hasStaleUsage } from "./format.ts";
 
 describe("share formatter", () => {
     it("prints a concise default private preview", () => {
@@ -92,5 +92,121 @@ describe("share formatter", () => {
 
         expect(text).toContain("Published session share:");
         expect(text).toContain("https://ax.necmttn.com/s/necmttn/abc123");
+    });
+});
+
+const SESSION_USAGE = {
+    model: "claude-opus-4-5",
+    prompt_tokens: null,
+    completion_tokens: null,
+    cache_creation_input_tokens: null,
+    cache_read_input_tokens: null,
+    estimated_tokens: 5000,
+    estimated_cost_usd: 0.05,
+    pricing_source: "test",
+};
+
+const TURN_USAGE = {
+    ...SESSION_USAGE,
+    seq: 2,
+    fresh_input_tokens: null,
+    usage_source: "api",
+    usage_quality: "exact",
+};
+
+describe("hasStaleUsage", () => {
+    it("returns true when session-level usage exists but no turns have token_usage", () => {
+        const artifact: AxSessionShare = {
+            ...minimalShareArtifact({ id: "abc123", source: "claude" }),
+            token_usage: SESSION_USAGE,
+            turns: [
+                { id: "t1", seq: 1, role: "user", text: "hello" },
+                { id: "t2", seq: 2, role: "assistant", text: "world" },
+            ],
+        };
+        expect(hasStaleUsage(artifact)).toBe(true);
+    });
+
+    it("returns false when at least one turn has token_usage", () => {
+        const artifact: AxSessionShare = {
+            ...minimalShareArtifact({ id: "abc123", source: "claude" }),
+            token_usage: SESSION_USAGE,
+            turns: [
+                { id: "t1", seq: 1, role: "user", text: "hello" },
+                {
+                    id: "t2",
+                    seq: 2,
+                    role: "assistant",
+                    text: "world",
+                    token_usage: TURN_USAGE,
+                },
+            ],
+        };
+        expect(hasStaleUsage(artifact)).toBe(false);
+    });
+
+    it("returns false when there is no session-level usage", () => {
+        const artifact: AxSessionShare = {
+            ...minimalShareArtifact({ id: "abc123", source: "claude" }),
+            turns: [
+                { id: "t1", seq: 1, role: "user", text: "hello" },
+            ],
+        };
+        expect(hasStaleUsage(artifact)).toBe(false);
+    });
+
+    it("returns false when session usage values are zero", () => {
+        const artifact: AxSessionShare = {
+            ...minimalShareArtifact({ id: "abc123", source: "claude" }),
+            token_usage: {
+                ...SESSION_USAGE,
+                estimated_tokens: 0,
+                estimated_cost_usd: 0,
+            },
+            turns: [
+                { id: "t1", seq: 1, role: "user", text: "hello" },
+            ],
+        };
+        expect(hasStaleUsage(artifact)).toBe(false);
+    });
+
+    it("returns false when a descendant turn has token_usage", () => {
+        const child: AxSessionShare = {
+            ...minimalShareArtifact({ id: "child1", source: "claude" }),
+            token_usage: SESSION_USAGE,
+            turns: [
+                {
+                    id: "ct1",
+                    seq: 1,
+                    role: "assistant",
+                    text: "sub",
+                    token_usage: { ...TURN_USAGE, seq: 1 },
+                },
+            ],
+        };
+        const artifact: AxSessionShare = {
+            ...minimalShareArtifact({ id: "abc123", source: "claude" }),
+            token_usage: SESSION_USAGE,
+            turns: [
+                { id: "t1", seq: 1, role: "user", text: "hello" },
+            ],
+            children: [child],
+        };
+        expect(hasStaleUsage(artifact)).toBe(false);
+    });
+
+    it("returns true when session usage uses estimated_tokens only (no cost) and no turns have usage", () => {
+        const artifact: AxSessionShare = {
+            ...minimalShareArtifact({ id: "abc123", source: "claude" }),
+            token_usage: {
+                ...SESSION_USAGE,
+                estimated_cost_usd: null,
+                estimated_tokens: 3000,
+            },
+            turns: [
+                { id: "t1", seq: 1, role: "user", text: "hello" },
+            ],
+        };
+        expect(hasStaleUsage(artifact)).toBe(true);
     });
 });

--- a/apps/axctl/src/share/format.ts
+++ b/apps/axctl/src/share/format.ts
@@ -32,6 +32,32 @@ export function totalEstimatedTokens(artifact: AxSessionShare): number | null {
     return sumTrace(artifact, (u) => u.estimated_tokens);
 }
 
+const hasSessionUsage = (artifact: AxSessionShare): boolean => {
+    if (!artifact.token_usage) return false;
+    const { estimated_cost_usd, estimated_tokens } = artifact.token_usage;
+    if (typeof estimated_cost_usd === "number" && estimated_cost_usd > 0) return true;
+    if (typeof estimated_tokens === "number" && estimated_tokens > 0) return true;
+    return false;
+};
+
+const hasTurnUsage = (artifact: AxSessionShare): boolean => {
+    if (artifact.turns.some((turn) => turn.token_usage != null)) return true;
+    return (artifact.children ?? []).some(hasTurnUsage);
+};
+
+/**
+ * Returns true when the exported tree has session-level cost/token usage but
+ * no per-turn usage rows anywhere in the root or descendants. That means the
+ * cost rails will render as $0 on a per-turn basis. Callers should warn the
+ * user to re-ingest with AX_REDERIVE_CLAUDE=1 AX_REDERIVE_SUBAGENTS=1.
+ */
+export function hasStaleUsage(artifact: AxSessionShare): boolean {
+    const anySession = hasSessionUsage(artifact) ||
+        (artifact.children ?? []).some(hasSessionUsage);
+    if (!anySession) return false;
+    return !hasTurnUsage(artifact);
+}
+
 export function formatSharePreview(
     artifact: AxSessionShare,
     options: { readonly public?: boolean } = {},

--- a/apps/axctl/src/share/format.ts
+++ b/apps/axctl/src/share/format.ts
@@ -55,10 +55,21 @@ const hasTurnUsage = (artifact: AxSessionShare): boolean => {
  * no per-turn usage rows anywhere in the root or descendants. That means the
  * cost rails will render as $0 on a per-turn basis. Callers should warn the
  * user to re-ingest with AX_REDERIVE_CLAUDE=1 AX_REDERIVE_SUBAGENTS=1.
+ * Asymmetric by spec: session usage counts only when positive, while turn
+ * usage counts on presence alone (`token_usage != null`).
  */
 export function hasStaleUsage(artifact: AxSessionShare): boolean {
     if (!hasSessionUsage(artifact)) return false;
     return !hasTurnUsage(artifact);
+}
+
+/** The stale-ingest stderr warning `ax share` emits when `hasStaleUsage` is
+ *  true. `N` in `--since=N` is a literal placeholder the user fills in. */
+export function formatStaleUsageWarning(): string {
+    return (
+        "axctl share: warning: this share has session-level cost but no per-turn usage rows; cost rails may render as $0.\n" +
+        "Re-run ingest with AX_REDERIVE_CLAUDE=1 AX_REDERIVE_SUBAGENTS=1 ax ingest here --stages=claude,subagents --since=N\n"
+    );
 }
 
 export function formatSharePreview(

--- a/apps/axctl/src/share/format.ts
+++ b/apps/axctl/src/share/format.ts
@@ -32,12 +32,17 @@ export function totalEstimatedTokens(artifact: AxSessionShare): number | null {
     return sumTrace(artifact, (u) => u.estimated_tokens);
 }
 
-const hasSessionUsage = (artifact: AxSessionShare): boolean => {
+const hasOwnSessionUsage = (artifact: AxSessionShare): boolean => {
     if (!artifact.token_usage) return false;
     const { estimated_cost_usd, estimated_tokens } = artifact.token_usage;
     if (typeof estimated_cost_usd === "number" && estimated_cost_usd > 0) return true;
     if (typeof estimated_tokens === "number" && estimated_tokens > 0) return true;
     return false;
+};
+
+const hasSessionUsage = (artifact: AxSessionShare): boolean => {
+    if (hasOwnSessionUsage(artifact)) return true;
+    return (artifact.children ?? []).some(hasSessionUsage);
 };
 
 const hasTurnUsage = (artifact: AxSessionShare): boolean => {
@@ -52,9 +57,7 @@ const hasTurnUsage = (artifact: AxSessionShare): boolean => {
  * user to re-ingest with AX_REDERIVE_CLAUDE=1 AX_REDERIVE_SUBAGENTS=1.
  */
 export function hasStaleUsage(artifact: AxSessionShare): boolean {
-    const anySession = hasSessionUsage(artifact) ||
-        (artifact.children ?? []).some(hasSessionUsage);
-    if (!anySession) return false;
+    if (!hasSessionUsage(artifact)) return false;
     return !hasTurnUsage(artifact);
 }
 

--- a/apps/site/functions/og/[owner]/[gistId].ts
+++ b/apps/site/functions/og/[owner]/[gistId].ts
@@ -129,53 +129,47 @@ function costBarHtml(m: Manifest): string {
 }
 
 /**
- * ASCII logo for the header wordmark. Three-line line-stack rendered in
- * monospace; each line is a separate div to avoid <pre> fragility in
- * workers-og. Kept small (11px) so it reads as a mark, not a headline.
+ * ASCII AX mark, two lines, monospace column-aligned:
  *
- * A:  /\    X: \/
- *    /--\      /\
- *   /    \    /  \
+ *    col: 0123456
+ *          /\  \/
+ *         /--\ /\
  *
- * Rendered as:
- *   /\  \/
- *  /--\  X
- * /    \/  \
+ * A = ` /\` over `/--\` (cols 0-3), X = `\/` over `/\` (cols 5-6). Shared by
+ * the small header logo and the large ?variant=watermark background; each
+ * line renders as its own div (line-stack) to avoid <pre> fragility in
+ * workers-og.
  */
-const ASCII_LOGO_LINES = ["/\\  \\/", "/--\\  X", "/    \\/  \\"] as const;
+const ASCII_AX_LINES = [" /\\  \\/", "/--\\ /\\"] as const;
 
-/** Small three-line ASCII AX wordmark for the poster header. */
+// Satori collapses runs of regular spaces under its default white-space
+// handling, which destroys column alignment. Swap every space (leading and
+// internal) for a literal non-breaking space, which satori renders as-is.
+const artLine = (line: string): string => esc(line).replace(/ /g, "\u00A0");
+
+/** Small two-line ASCII AX wordmark for the poster header. */
 function asciiLogoHtml(color: string): string {
-    const lines = ASCII_LOGO_LINES.map(
+    const lines = ASCII_AX_LINES.map(
         (line) =>
-            `<div style="display:flex;font-size:11px;line-height:13px;color:${color};letter-spacing:1px;font-weight:700">${esc(line)}</div>`,
+            `<div style="display:flex;font-size:14px;line-height:16px;color:${color};letter-spacing:1px;font-weight:700">${artLine(line)}</div>`,
     ).join("");
     return `<div style="display:flex;flex-direction:column">${lines}</div>`;
 }
 
 /**
- * Large background ASCII watermark for the ?variant=watermark debug variant.
- * Positioned absolutely (satori supports position:absolute on root-level
- * children when the container is position:relative). Low opacity so content
- * stays readable. Significantly larger glyphs than the header mark.
- *
- * Composed as four rows scaled up (font-size:72px).
+ * Large background ASCII watermark for the ?variant=watermark debug variant:
+ * the same AX mark as the header, scaled up. Positioned absolutely (satori
+ * supports position:absolute when the container is position:relative). Low
+ * opacity so content stays readable.
  */
-const ASCII_WATERMARK_LINES = [
-    "/\\\\    \\/\\/",
-    "/--\\\\    X",
-    "/    \\\\  / \\\\",
-    "/ ___  \\\\/   \\\\",
-] as const;
-
 function asciiWatermarkHtml(): string {
-    const lines = ASCII_WATERMARK_LINES.map(
+    const lines = ASCII_AX_LINES.map(
         (line) =>
-            `<div style="display:flex;font-size:72px;line-height:80px;color:${INK};letter-spacing:4px;font-weight:700">${esc(line)}</div>`,
+            `<div style="display:flex;font-size:120px;line-height:132px;color:${INK};letter-spacing:4px;font-weight:700">${artLine(line)}</div>`,
     ).join("");
-    // opacity via hex alpha channel on color (satori supports 8-digit hex).
-    // We use a separate opacity wrapper; satori handles opacity on leaf nodes.
-    return `<div style="display:flex;flex-direction:column;position:absolute;top:120px;left:80px;opacity:0.06">${lines}</div>`;
+    // Faded via an opacity wrapper on the container (not a hex alpha channel
+    // on the color) - satori applies opacity to the whole subtree.
+    return `<div style="display:flex;flex-direction:column;position:absolute;top:160px;left:120px;opacity:0.06">${lines}</div>`;
 }
 
 export const onRequestGet: PagesFunction = async (ctx) => {

--- a/apps/site/functions/og/[owner]/[gistId].ts
+++ b/apps/site/functions/og/[owner]/[gistId].ts
@@ -128,6 +128,56 @@ function costBarHtml(m: Manifest): string {
     return `<div style="display:flex;flex-direction:column"><div style="display:flex">${segs}</div><div style="display:flex;margin-top:12px">${legend}</div></div>`;
 }
 
+/**
+ * ASCII logo for the header wordmark. Three-line line-stack rendered in
+ * monospace; each line is a separate div to avoid <pre> fragility in
+ * workers-og. Kept small (11px) so it reads as a mark, not a headline.
+ *
+ * A:  /\    X: \/
+ *    /--\      /\
+ *   /    \    /  \
+ *
+ * Rendered as:
+ *   /\  \/
+ *  /--\  X
+ * /    \/  \
+ */
+const ASCII_LOGO_LINES = ["/\\  \\/", "/--\\  X", "/    \\/  \\"] as const;
+
+/** Small three-line ASCII AX wordmark for the poster header. */
+function asciiLogoHtml(color: string): string {
+    const lines = ASCII_LOGO_LINES.map(
+        (line) =>
+            `<div style="display:flex;font-size:11px;line-height:13px;color:${color};letter-spacing:1px;font-weight:700">${esc(line)}</div>`,
+    ).join("");
+    return `<div style="display:flex;flex-direction:column">${lines}</div>`;
+}
+
+/**
+ * Large background ASCII watermark for the ?variant=watermark debug variant.
+ * Positioned absolutely (satori supports position:absolute on root-level
+ * children when the container is position:relative). Low opacity so content
+ * stays readable. Significantly larger glyphs than the header mark.
+ *
+ * Composed as four rows scaled up (font-size:72px).
+ */
+const ASCII_WATERMARK_LINES = [
+    "/\\\\    \\/\\/",
+    "/--\\\\    X",
+    "/    \\\\  / \\\\",
+    "/ ___  \\\\/   \\\\",
+] as const;
+
+function asciiWatermarkHtml(): string {
+    const lines = ASCII_WATERMARK_LINES.map(
+        (line) =>
+            `<div style="display:flex;font-size:72px;line-height:80px;color:${INK};letter-spacing:4px;font-weight:700">${esc(line)}</div>`,
+    ).join("");
+    // opacity via hex alpha channel on color (satori supports 8-digit hex).
+    // We use a separate opacity wrapper; satori handles opacity on leaf nodes.
+    return `<div style="display:flex;flex-direction:column;position:absolute;top:120px;left:80px;opacity:0.06">${lines}</div>`;
+}
+
 export const onRequestGet: PagesFunction = async (ctx) => {
     const owner = String(ctx.params.owner ?? "");
     const gistId = String(ctx.params.gistId ?? "").replace(/\.png$/, "");
@@ -136,8 +186,10 @@ export const onRequestGet: PagesFunction = async (ctx) => {
     }
     const cache = (caches as unknown as { default: Cache }).default;
     // r= version busts stale cached renders when the poster template changes.
+    // Append variant so watermark and default renders cache independently.
     const u = new URL(ctx.request.url);
-    u.searchParams.set("r", "5");
+    const variant = u.searchParams.get("variant") ?? "default";
+    u.searchParams.set("r", `6-${variant}`);
     const cacheKey = new Request(u.toString());
     const hit = await cache.match(cacheKey);
     if (hit) return hit;
@@ -169,7 +221,9 @@ export const onRequestGet: PagesFunction = async (ctx) => {
     const stats = `<div style="display:flex;flex-direction:column"><div style="display:flex;margin-bottom:30px">${statList.slice(0, 3).join("")}</div><div style="display:flex">${statList.slice(3).join("")}</div></div>`;
 
     const blocks: Record<string, string> = {
-        header: `<div style="display:flex;justify-content:space-between;align-items:center"><div style="display:flex;align-items:baseline"><span style="font-size:42px;color:${INK};font-weight:700;font-family:'Gelasio'">ax</span><span style="font-size:14px;color:${DIM};margin-left:14px;letter-spacing:3px">AGENT EXPERIENCE</span></div><span style="font-size:17px;color:${DIM}">${esc([model, date].filter(Boolean).join(" · "))}</span></div>`,
+        // ASCII logo replaces the serif "ax" wordmark. The line-stack avoids
+        // <pre> fragility and keeps display:flex on the container intact.
+        header: `<div style="display:flex;justify-content:space-between;align-items:center"><div style="display:flex;align-items:center"><div style="display:flex;margin-right:14px">${asciiLogoHtml(INK)}</div><span style="font-size:14px;color:${DIM};letter-spacing:3px">AGENT EXPERIENCE</span></div><span style="font-size:17px;color:${DIM}">${esc([model, date].filter(Boolean).join(" · "))}</span></div>`,
         title: `<div style="display:flex;font-size:33px;line-height:1.3;color:${INK};margin-top:26px;font-weight:600">${title}</div>`,
         stats: `<div style="display:flex;margin-top:30px">${stats}</div>`,
         fleet: t.subagents > 0 ? `<div style="display:flex;flex-direction:column;align-items:flex-start;margin-top:30px"><div style="display:flex">${fleetHtml(manifest.subagents)}</div><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-top:10px">${t.subagents} SUBAGENTS · BRIGHTER = COSTLIER</span></div>` : "",
@@ -183,11 +237,16 @@ export const onRequestGet: PagesFunction = async (ctx) => {
     const inner = probe
         ? probe.split(",").filter((k) => k in blocks).map((k) => blocks[k]).join("")
         : `${blocks.header}${blocks.title}${mid}${blocks.costbar}${blocks.footer}`;
+    // ?variant=watermark: inject a large low-opacity ASCII background mark for
+    // iterating on the treatment without making it the default social card.
+    // position:relative on the outer container lets the absolute child render
+    // behind the content stack. Never active by default.
+    const watermark = variant === "watermark" ? asciiWatermarkHtml() : "";
     // Full bleed, no border: the platform rendering the preview (X / Slack /
     // Discord) draws its own frame + rounded corners - an inner border reads
     // as a nested double-frame. 64px safe margins keep content clear of the
     // platforms' corner clipping (GitHub-card convention).
-    const html = `<div style="display:flex;flex-direction:column;width:1200px;height:630px;background:${CARD};padding:56px 64px;font-family:'JetBrains Mono'">${inner}</div>`;
+    const html = `<div style="display:flex;flex-direction:column;position:relative;width:1200px;height:630px;background:${CARD};padding:56px 64px;font-family:'JetBrains Mono'">${watermark}${inner}</div>`;
 
     const font = await fetch(
         "https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-400-normal.ttf",

--- a/apps/studio/src/routes/share-inspect.test.ts
+++ b/apps/studio/src/routes/share-inspect.test.ts
@@ -357,6 +357,59 @@ describe("buildSessionMapLanes", () => {
         expect(bad.title).toContain("2 failures");
     });
 
+    test("packs overlapping bars onto separate rows", () => {
+        const model = buildSessionMapLanes(mapManifest([
+            mapCard({ file: "a.json", spawn_turn_seq: 5, duration_ms: 1000 }),
+            mapCard({ file: "b.json", spawn_turn_seq: 5, duration_ms: 1000 }),
+            mapCard({ file: "c.json", spawn_turn_seq: 5, duration_ms: 1000 }),
+        ]));
+        expect(model?.axis).toBe("seq");
+        expect(model?.rows).toBe(3);
+        expect(laneFor(model, "a.json").row).toBe(0);
+        expect(laneFor(model, "b.json").row).toBe(1);
+        expect(laneFor(model, "c.json").row).toBe(2);
+    });
+
+    test("clamps overflow collisions onto the last row instead of growing past the cap", () => {
+        const model = buildSessionMapLanes(mapManifest(
+            ["a", "b", "c", "d", "e", "f"].map((name) =>
+                mapCard({ file: `${name}.json`, spawn_turn_seq: 5, duration_ms: 1000 })),
+        ));
+        expect(model?.rows).toBe(4);
+        expect(model?.lanes.filter((lane) => lane.row === 3)).toHaveLength(3);
+        expect(model?.lanes.every((lane) => lane.row <= 3)).toBe(true);
+    });
+
+    test("rejects the seq axis when any card is nested (spawn seqs are parent-local)", () => {
+        const cards = [
+            mapCard({ file: "a.json", spawn_turn_seq: 3, started_at: "2026-06-01T00:00:00.000Z" }),
+            mapCard({
+                file: "b.json",
+                spawn_turn_seq: 7,
+                depth: 2,
+                parent_id: "claude-subagent-a.json",
+                started_at: "2026-06-01T00:30:00.000Z",
+            }),
+        ];
+        const withWindow = buildSessionMapLanes(mapManifest(
+            cards,
+            { started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T01:00:00.000Z" },
+        ));
+        expect(withWindow?.axis).toBe("time");
+        expect(laneFor(withWindow, "b.json").x).toBeCloseTo(0.5, 5);
+        const withoutWindow = buildSessionMapLanes(mapManifest(cards));
+        expect(withoutWindow?.axis).toBe("order");
+    });
+
+    test("treats an inverted root window (ended_at before started_at) as unusable", () => {
+        const model = buildSessionMapLanes(mapManifest(
+            [mapCard({ file: "a.json" }), mapCard({ file: "b.json" })],
+            { started_at: "2026-06-01T01:00:00.000Z", ended_at: "2026-06-01T00:00:00.000Z" },
+        ));
+        expect(model?.axis).toBe("order");
+        expect(model?.rootDurationMs).toBeNull();
+    });
+
     test("returns null for a manifest with zero subagents", () => {
         expect(buildSessionMapLanes(mapManifest([]))).toBeNull();
     });

--- a/apps/studio/src/routes/share-inspect.test.ts
+++ b/apps/studio/src/routes/share-inspect.test.ts
@@ -243,27 +243,32 @@ const laneFor = (model: ReturnType<typeof buildSessionMapLanes>, file: string) =
 
 describe("buildSessionMapLanes", () => {
     test("places by spawn_turn_seq normalized over the seq range when every card has one", () => {
+        // Wide bars keep the strip covered so gap compression stays out of
+        // this test's way.
         const model = buildSessionMapLanes(mapManifest([
-            mapCard({ file: "a.json", spawn_turn_seq: 10 }),
-            mapCard({ file: "b.json", spawn_turn_seq: 20 }),
-            mapCard({ file: "c.json", spawn_turn_seq: 30 }),
+            mapCard({ file: "a.json", spawn_turn_seq: 0, duration_ms: 1000 }),
+            mapCard({ file: "b.json", spawn_turn_seq: 25, duration_ms: 1000 }),
+            mapCard({ file: "c.json", spawn_turn_seq: 50, duration_ms: 1000 }),
+            mapCard({ file: "d.json", spawn_turn_seq: 75, duration_ms: 1000 }),
+            mapCard({ file: "e.json", spawn_turn_seq: 100, duration_ms: 1000 }),
         ]));
         expect(model?.axis).toBe("seq");
+        expect(model?.gaps).toHaveLength(0);
         const a = laneFor(model, "a.json");
-        const b = laneFor(model, "b.json");
         const c = laneFor(model, "c.json");
+        const e = laneFor(model, "e.json");
         expect(a.x).toBeCloseTo(0, 5);
-        expect(b.x).toBeCloseTo(0.5, 5);
+        expect(c.x).toBeCloseTo(0.5, 5);
         // The last bar is clamped so it stays inside the strip.
-        expect(c.x).toBeCloseTo(1 - c.w, 5);
+        expect(e.x).toBeCloseTo(1 - e.w, 5);
     });
 
     test("falls back to start time over the root window when any seq is missing", () => {
         const model = buildSessionMapLanes(mapManifest(
             [
-                mapCard({ file: "a.json", spawn_turn_seq: 5, started_at: "2026-06-01T00:00:00.000Z" }),
-                mapCard({ file: "b.json", started_at: "2026-06-01T00:30:00.000Z" }),
-                mapCard({ file: "c.json", started_at: "2026-06-01T00:45:00.000Z" }),
+                mapCard({ file: "a.json", spawn_turn_seq: 5, started_at: "2026-06-01T00:00:00.000Z", duration_ms: 1_800_000 }),
+                mapCard({ file: "b.json", started_at: "2026-06-01T00:30:00.000Z", duration_ms: 900_000 }),
+                mapCard({ file: "c.json", started_at: "2026-06-01T00:45:00.000Z", duration_ms: 900_000 }),
             ],
             { started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T01:00:00.000Z" },
         ));
@@ -277,8 +282,8 @@ describe("buildSessionMapLanes", () => {
     test("uses root started_at + totals.duration_ms as the window when ended_at is missing", () => {
         const model = buildSessionMapLanes(mapManifest(
             [
-                mapCard({ file: "a.json", started_at: "2026-06-01T00:00:00.000Z" }),
-                mapCard({ file: "b.json", started_at: "2026-06-01T00:30:00.000Z" }),
+                mapCard({ file: "a.json", started_at: "2026-06-01T00:00:00.000Z", duration_ms: 1_800_000 }),
+                mapCard({ file: "b.json", started_at: "2026-06-01T00:30:00.000Z", duration_ms: 1_800_000 }),
             ],
             { started_at: "2026-06-01T00:00:00.000Z" },
             { duration_ms: 3_600_000 },
@@ -300,14 +305,20 @@ describe("buildSessionMapLanes", () => {
     });
 
     test("applies the minimum bar width for null and tiny durations", () => {
+        // Filler cards keep every uncovered span under the compression
+        // threshold so the raw widths survive untouched.
+        const fillers = Array.from({ length: 7 }, (_, i) =>
+            mapCard({ file: `filler-${i}.json`, spawn_turn_seq: i + 3 }));
         const model = buildSessionMapLanes(mapManifest(
             [
-                mapCard({ file: "null.json", spawn_turn_seq: 1 }),
-                mapCard({ file: "tiny.json", spawn_turn_seq: 2, duration_ms: 1 }),
-                mapCard({ file: "half.json", spawn_turn_seq: 3, duration_ms: 1_800_000 }),
+                mapCard({ file: "half.json", spawn_turn_seq: 0, duration_ms: 1_800_000 }),
+                mapCard({ file: "tiny.json", spawn_turn_seq: 1, duration_ms: 1 }),
+                mapCard({ file: "null.json", spawn_turn_seq: 2 }),
+                ...fillers,
             ],
             { started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T01:00:00.000Z" },
         ));
+        expect(model?.gaps).toHaveLength(0);
         expect(laneFor(model, "null.json").w).toBe(SESSION_MAP_MIN_LANE_W);
         expect(laneFor(model, "tiny.json").w).toBe(SESSION_MAP_MIN_LANE_W);
         expect(laneFor(model, "half.json").w).toBeCloseTo(0.5, 5);
@@ -382,13 +393,14 @@ describe("buildSessionMapLanes", () => {
 
     test("rejects the seq axis when any card is nested (spawn seqs are parent-local)", () => {
         const cards = [
-            mapCard({ file: "a.json", spawn_turn_seq: 3, started_at: "2026-06-01T00:00:00.000Z" }),
+            mapCard({ file: "a.json", spawn_turn_seq: 3, started_at: "2026-06-01T00:00:00.000Z", duration_ms: 1_800_000 }),
             mapCard({
                 file: "b.json",
                 spawn_turn_seq: 7,
                 depth: 2,
                 parent_id: "claude-subagent-a.json",
                 started_at: "2026-06-01T00:30:00.000Z",
+                duration_ms: 1_800_000,
             }),
         ];
         const withWindow = buildSessionMapLanes(mapManifest(
@@ -408,6 +420,100 @@ describe("buildSessionMapLanes", () => {
         ));
         expect(model?.axis).toBe("order");
         expect(model?.rootDurationMs).toBeNull();
+    });
+
+    test("compresses a wide mid-session gap and labels it with the wall-clock span", () => {
+        const model = buildSessionMapLanes(mapManifest(
+            [
+                mapCard({ file: "a.json", started_at: "2026-06-01T00:00:00.000Z", duration_ms: 360_000 }),
+                mapCard({ file: "b.json", started_at: "2026-06-01T00:48:00.000Z", duration_ms: 360_000 }),
+            ],
+            { started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T01:00:00.000Z" },
+        ));
+        expect(model?.axis).toBe("time");
+        expect(model?.gaps).toHaveLength(1);
+        const gap = model!.gaps[0]!;
+        // Domain gap [0.1, 0.8] (42 of 60 minutes) collapses to the fixed
+        // break width; covered segments stretch by (1-0.04)/0.3 = 3.2.
+        expect(gap.label).toBe("42m");
+        expect(gap.w).toBeCloseTo(0.04, 5);
+        expect(gap.x).toBeCloseTo(0.32, 5);
+        const b = laneFor(model, "b.json");
+        expect(b.x).toBeCloseTo(0.36, 5);
+        expect(b.w).toBeCloseTo(0.32, 5);
+    });
+
+    test("leaves gaps below the threshold untouched", () => {
+        const model = buildSessionMapLanes(mapManifest(
+            [
+                mapCard({ file: "a.json", started_at: "2026-06-01T00:00:00.000Z", duration_ms: 1_620_000 }),
+                mapCard({ file: "b.json", started_at: "2026-06-01T00:30:00.000Z", duration_ms: 1_800_000 }),
+            ],
+            { started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T01:00:00.000Z" },
+        ));
+        // Uncovered span is 0.05 of the strip - under the threshold.
+        expect(model?.gaps).toHaveLength(0);
+        expect(laneFor(model, "b.json").x).toBeCloseTo(0.5, 5);
+        expect(laneFor(model, "b.json").w).toBeCloseTo(0.5, 5);
+    });
+
+    test("compresses two separate gaps and keeps bar order", () => {
+        const model = buildSessionMapLanes(mapManifest(
+            [
+                mapCard({ file: "a.json", started_at: "2026-06-01T00:00:00.000Z", duration_ms: 1_800_000 }),
+                mapCard({ file: "b.json", started_at: "2026-06-01T04:00:00.000Z", duration_ms: 1_800_000 }),
+                mapCard({ file: "c.json", started_at: "2026-06-01T08:00:00.000Z", duration_ms: 1_800_000 }),
+            ],
+            { started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T10:00:00.000Z" },
+        ));
+        expect(model?.gaps).toHaveLength(2);
+        const [g0, g1] = model!.gaps;
+        expect(g0!.label).toBe("3h 30m");
+        expect(g1!.label).toBe("3h 30m");
+        expect(g0!.x).toBeLessThan(g1!.x);
+        const a = laneFor(model, "a.json");
+        const b = laneFor(model, "b.json");
+        const c = laneFor(model, "c.json");
+        expect(a.x).toBeLessThan(b.x);
+        expect(b.x).toBeLessThan(c.x);
+        // Bars sit between the breaks they used to be separated by.
+        expect(b.x).toBeCloseTo(g0!.x + g0!.w, 5);
+        expect(c.x).toBeCloseTo(g1!.x + g1!.w, 5);
+    });
+
+    test("labels a seq-axis gap with wall-clock computed from adjacent cards", () => {
+        const model = buildSessionMapLanes(mapManifest([
+            mapCard({ file: "a.json", spawn_turn_seq: 0, started_at: "2026-06-01T00:00:00.000Z" }),
+            mapCard({ file: "b.json", spawn_turn_seq: 10, started_at: "2026-06-01T00:10:00.000Z", duration_ms: 600_000 }),
+            mapCard({ file: "c.json", spawn_turn_seq: 90, started_at: "2026-06-01T03:00:00.000Z" }),
+            mapCard({ file: "d.json", spawn_turn_seq: 100, started_at: "2026-06-01T03:10:00.000Z" }),
+        ]));
+        expect(model?.axis).toBe("seq");
+        expect(model?.gaps).toHaveLength(1);
+        // b ends 00:20 (start + duration), c starts 03:00.
+        expect(model!.gaps[0]!.label).toBe("2h 40m");
+    });
+
+    test("falls back to a turn-count label when seq-axis timestamps are missing", () => {
+        const model = buildSessionMapLanes(mapManifest([
+            mapCard({ file: "a.json", spawn_turn_seq: 0 }),
+            mapCard({ file: "b.json", spawn_turn_seq: 10 }),
+            mapCard({ file: "c.json", spawn_turn_seq: 90 }),
+            mapCard({ file: "d.json", spawn_turn_seq: 100 }),
+        ]));
+        expect(model?.axis).toBe("seq");
+        expect(model?.gaps).toHaveLength(1);
+        expect(model!.gaps[0]!.label).toBe("80 turns");
+    });
+
+    test("never compresses on the order axis (even spacing has no real gaps)", () => {
+        const model = buildSessionMapLanes(mapManifest([
+            mapCard({ file: "a.json" }),
+            mapCard({ file: "b.json" }),
+        ]));
+        expect(model?.axis).toBe("order");
+        expect(model?.gaps).toHaveLength(0);
+        expect(laneFor(model, "b.json").x).toBeCloseTo(0.5, 5);
     });
 
     test("returns null for a manifest with zero subagents", () => {

--- a/apps/studio/src/routes/share-inspect.test.ts
+++ b/apps/studio/src/routes/share-inspect.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+    buildSessionMapLanes,
     fetchShareArtifact,
     fetchShareFile,
     fetchShareManifest,
@@ -7,7 +8,10 @@ import {
     inspectPayloadFromShare,
     isShareManifest,
     rawSessionFileUrl,
+    SESSION_MAP_MIN_LANE_W,
     spanKindForShareTurn,
+    type ShareManifest,
+    type ShareSubagentCard,
 } from "./share-inspect.tsx";
 
 type ShareTurn = Parameters<typeof spanKindForShareTurn>[0];
@@ -179,6 +183,182 @@ describe("fetchShareManifest", () => {
                 expect(artifact.schema_version).toBe(3);
             },
         );
+    });
+});
+
+const mapStats = (failures = 0): ShareSubagentCard["stats"] => ({
+    turns: 1,
+    tool_calls: 0,
+    files_changed: 0,
+    skills_used: 0,
+    failures,
+});
+
+function mapCard(partial: Partial<ShareSubagentCard> & { readonly file: string }): ShareSubagentCard {
+    return {
+        id: `claude-subagent-${partial.file}`,
+        parent_id: "root-1",
+        depth: 1,
+        spawn_turn_seq: null,
+        source: "claude-subagent",
+        duration_ms: null,
+        stats: mapStats(),
+        cost_usd: null,
+        estimated_tokens: null,
+        had_error: false,
+        ...partial,
+    };
+}
+
+function mapManifest(
+    subagents: ReadonlyArray<ShareSubagentCard>,
+    session: Partial<ShareManifest["session"]> = {},
+    totals: Partial<ShareManifest["totals"]> = {},
+): ShareManifest {
+    return {
+        schema_version: 4,
+        kind: "manifest",
+        exported_at: "2026-06-01T02:00:00.000Z",
+        session: { id: "root-1", source: "claude", ...session },
+        stats: mapStats(),
+        root_file: "session.json",
+        totals: {
+            cost_usd: null,
+            duration_ms: null,
+            tool_calls: 0,
+            turns: 0,
+            subagents: subagents.length,
+            failures: 0,
+            ...totals,
+        },
+        subagents,
+    };
+}
+
+const laneFor = (model: ReturnType<typeof buildSessionMapLanes>, file: string) => {
+    const lane = model?.lanes.find((l) => l.file === file);
+    if (!lane) throw new Error(`no lane for ${file}`);
+    return lane;
+};
+
+describe("buildSessionMapLanes", () => {
+    test("places by spawn_turn_seq normalized over the seq range when every card has one", () => {
+        const model = buildSessionMapLanes(mapManifest([
+            mapCard({ file: "a.json", spawn_turn_seq: 10 }),
+            mapCard({ file: "b.json", spawn_turn_seq: 20 }),
+            mapCard({ file: "c.json", spawn_turn_seq: 30 }),
+        ]));
+        expect(model?.axis).toBe("seq");
+        const a = laneFor(model, "a.json");
+        const b = laneFor(model, "b.json");
+        const c = laneFor(model, "c.json");
+        expect(a.x).toBeCloseTo(0, 5);
+        expect(b.x).toBeCloseTo(0.5, 5);
+        // The last bar is clamped so it stays inside the strip.
+        expect(c.x).toBeCloseTo(1 - c.w, 5);
+    });
+
+    test("falls back to start time over the root window when any seq is missing", () => {
+        const model = buildSessionMapLanes(mapManifest(
+            [
+                mapCard({ file: "a.json", spawn_turn_seq: 5, started_at: "2026-06-01T00:00:00.000Z" }),
+                mapCard({ file: "b.json", started_at: "2026-06-01T00:30:00.000Z" }),
+                mapCard({ file: "c.json", started_at: "2026-06-01T00:45:00.000Z" }),
+            ],
+            { started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T01:00:00.000Z" },
+        ));
+        expect(model?.axis).toBe("time");
+        expect(model?.rootDurationMs).toBe(3_600_000);
+        expect(laneFor(model, "a.json").x).toBeCloseTo(0, 5);
+        expect(laneFor(model, "b.json").x).toBeCloseTo(0.5, 5);
+        expect(laneFor(model, "c.json").x).toBeCloseTo(0.75, 5);
+    });
+
+    test("uses root started_at + totals.duration_ms as the window when ended_at is missing", () => {
+        const model = buildSessionMapLanes(mapManifest(
+            [
+                mapCard({ file: "a.json", started_at: "2026-06-01T00:00:00.000Z" }),
+                mapCard({ file: "b.json", started_at: "2026-06-01T00:30:00.000Z" }),
+            ],
+            { started_at: "2026-06-01T00:00:00.000Z" },
+            { duration_ms: 3_600_000 },
+        ));
+        expect(model?.axis).toBe("time");
+        expect(laneFor(model, "b.json").x).toBeCloseTo(0.5, 5);
+    });
+
+    test("falls back to stable even-spaced order when no seqs and no usable root window", () => {
+        const model = buildSessionMapLanes(mapManifest([
+            mapCard({ file: "a.json" }),
+            mapCard({ file: "b.json" }),
+            mapCard({ file: "c.json" }),
+        ]));
+        expect(model?.axis).toBe("order");
+        expect(laneFor(model, "a.json").x).toBeCloseTo(0, 5);
+        expect(laneFor(model, "b.json").x).toBeCloseTo(1 / 3, 5);
+        expect(laneFor(model, "c.json").x).toBeCloseTo(2 / 3, 5);
+    });
+
+    test("applies the minimum bar width for null and tiny durations", () => {
+        const model = buildSessionMapLanes(mapManifest(
+            [
+                mapCard({ file: "null.json", spawn_turn_seq: 1 }),
+                mapCard({ file: "tiny.json", spawn_turn_seq: 2, duration_ms: 1 }),
+                mapCard({ file: "half.json", spawn_turn_seq: 3, duration_ms: 1_800_000 }),
+            ],
+            { started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T01:00:00.000Z" },
+        ));
+        expect(laneFor(model, "null.json").w).toBe(SESSION_MAP_MIN_LANE_W);
+        expect(laneFor(model, "tiny.json").w).toBe(SESSION_MAP_MIN_LANE_W);
+        expect(laneFor(model, "half.json").w).toBeCloseTo(0.5, 5);
+    });
+
+    test("scales cost intensity relative to the max subagent cost", () => {
+        const model = buildSessionMapLanes(mapManifest([
+            mapCard({ file: "a.json", cost_usd: 2 }),
+            mapCard({ file: "b.json", cost_usd: 1 }),
+            mapCard({ file: "c.json", cost_usd: null }),
+        ]));
+        expect(laneFor(model, "a.json").intensity).toBeCloseTo(1, 5);
+        expect(laneFor(model, "b.json").intensity).toBeCloseTo(0.5, 5);
+        expect(laneFor(model, "c.json").intensity).toBeCloseTo(0, 5);
+    });
+
+    test("uses flat neutral coloring (null intensity) when no card has a positive cost", () => {
+        const model = buildSessionMapLanes(mapManifest([
+            mapCard({ file: "a.json", cost_usd: null }),
+            mapCard({ file: "b.json", cost_usd: 0 }),
+        ]));
+        expect(laneFor(model, "a.json").intensity).toBeNull();
+        expect(laneFor(model, "b.json").intensity).toBeNull();
+    });
+
+    test("carries the failure flag and count into the lane and tooltip", () => {
+        const model = buildSessionMapLanes(mapManifest([
+            mapCard({ file: "ok.json" }),
+            mapCard({
+                file: "bad.json",
+                stats: mapStats(2),
+                task_label: "fix the parser",
+                model: "claude-opus-4",
+                cost_usd: 1.25,
+                duration_ms: 120_000,
+            }),
+        ]));
+        const ok = laneFor(model, "ok.json");
+        const bad = laneFor(model, "bad.json");
+        expect(ok.failed).toBe(false);
+        expect(bad.failed).toBe(true);
+        expect(bad.failures).toBe(2);
+        expect(bad.title).toContain("fix the parser");
+        expect(bad.title).toContain("claude-opus-4");
+        expect(bad.title).toContain("$1.25");
+        expect(bad.title).toContain("2m");
+        expect(bad.title).toContain("2 failures");
+    });
+
+    test("returns null for a manifest with zero subagents", () => {
+        expect(buildSessionMapLanes(mapManifest([]))).toBeNull();
     });
 });
 

--- a/apps/studio/src/routes/share-inspect.test.ts
+++ b/apps/studio/src/routes/share-inspect.test.ts
@@ -482,11 +482,13 @@ describe("buildSessionMapLanes", () => {
     });
 
     test("labels a seq-axis gap with wall-clock computed from adjacent cards", () => {
+        // Equal durations widen the bars so only the one big mid-session gap
+        // exists - the iterated compression must not find more.
         const model = buildSessionMapLanes(mapManifest([
-            mapCard({ file: "a.json", spawn_turn_seq: 0, started_at: "2026-06-01T00:00:00.000Z" }),
+            mapCard({ file: "a.json", spawn_turn_seq: 0, started_at: "2026-06-01T00:00:00.000Z", duration_ms: 600_000 }),
             mapCard({ file: "b.json", spawn_turn_seq: 10, started_at: "2026-06-01T00:10:00.000Z", duration_ms: 600_000 }),
-            mapCard({ file: "c.json", spawn_turn_seq: 90, started_at: "2026-06-01T03:00:00.000Z" }),
-            mapCard({ file: "d.json", spawn_turn_seq: 100, started_at: "2026-06-01T03:10:00.000Z" }),
+            mapCard({ file: "c.json", spawn_turn_seq: 90, started_at: "2026-06-01T03:00:00.000Z", duration_ms: 600_000 }),
+            mapCard({ file: "d.json", spawn_turn_seq: 100, started_at: "2026-06-01T03:10:00.000Z", duration_ms: 600_000 }),
         ]));
         expect(model?.axis).toBe("seq");
         expect(model?.gaps).toHaveLength(1);
@@ -496,14 +498,64 @@ describe("buildSessionMapLanes", () => {
 
     test("falls back to a turn-count label when seq-axis timestamps are missing", () => {
         const model = buildSessionMapLanes(mapManifest([
-            mapCard({ file: "a.json", spawn_turn_seq: 0 }),
-            mapCard({ file: "b.json", spawn_turn_seq: 10 }),
-            mapCard({ file: "c.json", spawn_turn_seq: 90 }),
-            mapCard({ file: "d.json", spawn_turn_seq: 100 }),
+            mapCard({ file: "a.json", spawn_turn_seq: 0, duration_ms: 600_000 }),
+            mapCard({ file: "b.json", spawn_turn_seq: 10, duration_ms: 600_000 }),
+            mapCard({ file: "c.json", spawn_turn_seq: 90, duration_ms: 600_000 }),
+            mapCard({ file: "d.json", spawn_turn_seq: 100, duration_ms: 600_000 }),
         ]));
         expect(model?.axis).toBe("seq");
         expect(model?.gaps).toHaveLength(1);
         expect(model!.gaps[0]!.label).toBe("80 turns");
+    });
+
+    test("iterates compression: a medium gap promoted over the threshold by the first stretch also compresses", () => {
+        // Domain gaps: [0.05, 0.65] (0.6, way over) and [0.70, 0.80] (0.10,
+        // UNDER the 0.12 threshold in domain space). Compressing the big gap
+        // stretches segments by 0.96/0.4 = 2.4, lifting the medium gap to
+        // 0.24 of the rendered strip - the circled-white-stretch scenario.
+        const model = buildSessionMapLanes(mapManifest(
+            [
+                mapCard({ file: "a.json", started_at: "2026-06-01T00:00:00.000Z", duration_ms: 180_000 }),
+                mapCard({ file: "b.json", started_at: "2026-06-01T00:39:00.000Z", duration_ms: 180_000 }),
+                mapCard({ file: "c.json", started_at: "2026-06-01T00:48:00.000Z", duration_ms: 720_000 }),
+            ],
+            { started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T01:00:00.000Z" },
+        ));
+        expect(model?.gaps).toHaveLength(2);
+        const [g0, g1] = model!.gaps;
+        // Labels come from DOMAIN quantities: 0.6 and 0.10 of a 60m window.
+        expect(g0!.label).toBe("36m");
+        expect(g1!.label).toBe("6m");
+        // Final stretch with both compressed: (1 - 0.08) / 0.3.
+        const s = 0.92 / 0.3;
+        expect(laneFor(model, "a.json").w).toBeCloseTo(0.05 * s, 5);
+        expect(g0!.x).toBeCloseTo(0.05 * s, 5);
+        expect(laneFor(model, "b.json").x).toBeCloseTo(0.05 * s + 0.04, 5);
+        expect(g1!.x).toBeCloseTo(0.1 * s + 0.04, 5);
+        expect(laneFor(model, "c.json").x).toBeCloseTo(0.1 * s + 0.08, 5);
+    });
+
+    test("caps the number of breaks at the widest gaps", () => {
+        // Six interior gaps (0.20, 0.18, 0.16, 0.14, 0.13, ~0.106) - five
+        // exceed the threshold, but only the four widest may compress.
+        const starts = [
+            "2026-06-01T00:00:00.000Z",
+            "2026-06-01T02:07:12.000Z",
+            "2026-06-01T04:02:24.000Z",
+            "2026-06-01T05:45:36.000Z",
+            "2026-06-01T07:16:48.000Z",
+            "2026-06-01T08:42:00.000Z",
+            "2026-06-01T10:00:00.000Z",
+        ];
+        const model = buildSessionMapLanes(mapManifest(
+            starts.map((started_at, i) => mapCard({ file: `${i}.json`, started_at })),
+            { started_at: "2026-06-01T00:00:00.000Z", ended_at: "2026-06-01T10:00:00.000Z" },
+        ));
+        expect(model?.gaps).toHaveLength(4);
+        expect(model?.gaps.map((g) => g.label)).toEqual(["2h", "1h 48m", "1h 36m", "1h 24m"]);
+        // Output stays sorted by position.
+        const xs = model!.gaps.map((g) => g.x);
+        expect([...xs].sort((a, b) => a - b)).toEqual(xs);
     });
 
     test("never compresses on the order axis (even spacing has no real gaps)", () => {

--- a/apps/studio/src/routes/share-inspect.test.ts
+++ b/apps/studio/src/routes/share-inspect.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
+    buildScrubberGaps,
     buildSessionMapLanes,
+    compressAxisGaps,
     fetchShareArtifact,
     fetchShareFile,
     fetchShareManifest,
@@ -570,6 +572,71 @@ describe("buildSessionMapLanes", () => {
 
     test("returns null for a manifest with zero subagents", () => {
         expect(buildSessionMapLanes(mapManifest([]))).toBeNull();
+    });
+});
+
+describe("compressAxisGaps", () => {
+    test("compresses an interior uncovered span and anchors the axis endpoints", () => {
+        const { remap, gaps } = compressAxisGaps([
+            { start: 0, end: 0.1 },
+            { start: 0.8, end: 0.9 },
+        ]);
+        expect(gaps).toHaveLength(1);
+        expect(gaps[0]!.domainStart).toBeCloseTo(0.1, 5);
+        expect(gaps[0]!.domainEnd).toBeCloseTo(0.8, 5);
+        // Stretch (1-0.04)/0.3 = 3.2: covered [0,0.1] maps to [0, 0.32].
+        expect(gaps[0]!.x).toBeCloseTo(0.32, 5);
+        expect(gaps[0]!.w).toBeCloseTo(0.04, 5);
+        expect(remap(0)).toBeCloseTo(0, 5);
+        expect(remap(1)).toBeCloseTo(1, 5);
+        // Monotonic across the gap boundary.
+        expect(remap(0.1)).toBeLessThan(remap(0.45));
+        expect(remap(0.45)).toBeLessThan(remap(0.8));
+    });
+
+    test("returns the identity when no uncovered span exceeds the threshold", () => {
+        const { remap, gaps } = compressAxisGaps([
+            { start: 0, end: 0.45 },
+            { start: 0.5, end: 1 },
+        ]);
+        expect(gaps).toHaveLength(0);
+        expect(remap(0.7)).toBe(0.7);
+    });
+});
+
+describe("buildScrubberGaps", () => {
+    test("a lone commit tick anchors coverage and splits a dead stretch", () => {
+        const bars = [{ x: 0, w: 0.1 }, { x: 0.9, w: 0.1 }];
+        const without = buildScrubberGaps({ pointXs: [], bars, spanMs: 3_600_000 });
+        expect(without.gaps).toHaveLength(1);
+        expect(without.gaps[0]!.label).toBe("48m");
+        const withTick = buildScrubberGaps({ pointXs: [0.5], bars, spanMs: 3_600_000 });
+        expect(withTick.gaps).toHaveLength(2);
+        expect(withTick.gaps[0]!.label).toBe("23m 49s");
+        expect(withTick.gaps[1]!.label).toBe("23m 49s");
+    });
+
+    test("commit-only stretches are not gaps", () => {
+        const { remap, gaps } = buildScrubberGaps({
+            pointXs: Array.from({ length: 11 }, (_, i) => i / 10),
+            bars: [],
+            spanMs: 3_600_000,
+        });
+        expect(gaps).toHaveLength(0);
+        expect(remap(0.37)).toBe(0.37);
+    });
+
+    test("ticks and bars share the remap - a tick inside a bar stays inside it", () => {
+        const { remap, gaps } = buildScrubberGaps({
+            pointXs: [0.85],
+            bars: [{ x: 0, w: 0.1 }, { x: 0.8, w: 0.1 }],
+            spanMs: 3_600_000,
+        });
+        expect(gaps).toHaveLength(1);
+        expect(remap(0.85)).toBeGreaterThan(remap(0.8));
+        expect(remap(0.85)).toBeLessThan(remap(0.9));
+        expect(remap(0)).toBeCloseTo(0, 5);
+        expect(remap(1)).toBeCloseTo(1, 5);
     });
 });
 

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -323,11 +323,18 @@ const SESSION_MAP_MAX_ROWS = 4;
 /** Bars whose left edges sit closer than this (strip fraction) to an earlier
  *  bar's right edge pack onto the next row instead of overlapping. */
 const SESSION_MAP_PACK_GAP = 0.002;
-/** Uncovered spans between coverage clusters wider than this (strip fraction)
- *  get compressed - long solo-root stretches must not dominate the strip. */
+/** Uncovered spans between coverage clusters wider than this (strip fraction,
+ *  measured in the RENDERED space) get compressed - long solo-root stretches
+ *  must not dominate the strip. */
 const SESSION_MAP_GAP_MIN = 0.12;
 /** Width every compressed gap collapses to (strip fraction). */
 const SESSION_MAP_GAP_W = 0.04;
+/** Fixed-point iteration cap: compressing one gap stretches the rest, which
+ *  can push a previously sub-threshold gap over the visual threshold. */
+const SESSION_MAP_GAP_PASSES = 4;
+/** Max rendered break bands - beyond this, only the widest gaps compress so
+ *  the strip doesn't become a picket fence. */
+const SESSION_MAP_GAP_MAX = 4;
 
 const parseShareTs = (iso: string | null | undefined): number | null => {
     const t = Date.parse(iso ?? "");
@@ -413,17 +420,40 @@ export function buildSessionMapLanes(manifest: ShareManifest): SessionMapModel |
             if (last && p.x <= last.end) last.end = Math.max(last.end, p.x + p.w);
             else covered.push({ start: p.x, end: p.x + p.w });
         }
-        const domainGaps = covered
+        // Candidates: interior uncovered spans, tracked by their DOMAIN
+        // endpoints (labels must come from domain quantities, never remapped
+        // fractions). Spans no wider than the break width are excluded - they
+        // can't shrink, and excluding them keeps the remap stretch-only
+        // (chosen total > chosen count * GAP_W, hence scale > 1).
+        const candidates = covered
             .slice(1)
             .map((seg, i) => ({ start: covered[i]!.end, end: seg.start }))
-            .filter((g) => g.end - g.start > SESSION_MAP_GAP_MIN);
-        if (domainGaps.length > 0) {
-            const gapTotal = domainGaps.reduce((acc, g) => acc + (g.end - g.start), 0);
-            const scale = (1 - domainGaps.length * SESSION_MAP_GAP_W) / (1 - gapTotal);
+            .filter((g) => g.end - g.start > SESSION_MAP_GAP_W);
+        // Fixed-point selection: a gap qualifies when its RENDERED width
+        // (domain width x current stretch) exceeds the threshold, and every
+        // compression raises the stretch - so iterate, widest first, until no
+        // gap qualifies or the pass/band caps stop it.
+        const chosen: Array<{ start: number; end: number }> = [];
+        for (let pass = 0; pass < SESSION_MAP_GAP_PASSES && chosen.length < SESSION_MAP_GAP_MAX; pass++) {
+            const chosenTotal = chosen.reduce((acc, g) => acc + (g.end - g.start), 0);
+            const stretch = (1 - chosen.length * SESSION_MAP_GAP_W) / (1 - chosenTotal);
+            const qualifying = candidates
+                .filter((g) => !chosen.includes(g) && (g.end - g.start) * stretch > SESSION_MAP_GAP_MIN)
+                .sort((a, b) => (b.end - b.start) - (a.end - a.start));
+            if (qualifying.length === 0) break;
+            for (const g of qualifying) {
+                if (chosen.length >= SESSION_MAP_GAP_MAX) break;
+                chosen.push(g);
+            }
+        }
+        if (chosen.length > 0) {
+            chosen.sort((a, b) => a.start - b.start);
+            const gapTotal = chosen.reduce((acc, g) => acc + (g.end - g.start), 0);
+            const scale = (1 - chosen.length * SESSION_MAP_GAP_W) / (1 - gapTotal);
             remap = (v) => {
                 let out = 0;
                 let prev = 0;
-                for (const g of domainGaps) {
+                for (const g of chosen) {
                     if (v <= g.start) return out + (v - prev) * scale;
                     out += (g.start - prev) * scale;
                     if (v <= g.end) return out + ((v - g.start) / (g.end - g.start)) * SESSION_MAP_GAP_W;
@@ -458,7 +488,7 @@ export function buildSessionMapLanes(manifest: ShareManifest): SessionMapModel |
                 const nextSeq = Math.min(...after.map((p) => p.card.spawn_turn_seq ?? 0));
                 return `${Math.max(nextSeq - prevSeq, 0)} turns`;
             };
-            gaps = domainGaps.map((g) => ({ x: remap(g.start), w: SESSION_MAP_GAP_W, label: gapLabel(g) }));
+            gaps = chosen.map((g) => ({ x: remap(g.start), w: SESSION_MAP_GAP_W, label: gapLabel(g) }));
         }
     }
     const remapped = gaps.length === 0 ? placed : placed.map((p) => {

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -301,12 +301,21 @@ export interface SessionMapLane {
     readonly title: string;
 }
 
+/** A compressed empty span between coverage clusters, post-compression
+ *  coordinates. The label is the gap's magnitude (wall-clock or turn delta). */
+export interface SessionMapGap {
+    readonly x: number;
+    readonly w: number;
+    readonly label: string;
+}
+
 export interface SessionMapModel {
     /** One axis semantic per share - never mixed per card. */
     readonly axis: SessionMapAxis;
     readonly rows: number;
     readonly rootDurationMs: number | null;
     readonly lanes: ReadonlyArray<SessionMapLane>;
+    readonly gaps: ReadonlyArray<SessionMapGap>;
 }
 
 export const SESSION_MAP_MIN_LANE_W = 0.012;
@@ -314,6 +323,11 @@ const SESSION_MAP_MAX_ROWS = 4;
 /** Bars whose left edges sit closer than this (strip fraction) to an earlier
  *  bar's right edge pack onto the next row instead of overlapping. */
 const SESSION_MAP_PACK_GAP = 0.002;
+/** Uncovered spans between coverage clusters wider than this (strip fraction)
+ *  get compressed - long solo-root stretches must not dominate the strip. */
+const SESSION_MAP_GAP_MIN = 0.12;
+/** Width every compressed gap collapses to (strip fraction). */
+const SESSION_MAP_GAP_W = 0.04;
 
 const parseShareTs = (iso: string | null | undefined): number | null => {
     const t = Date.parse(iso ?? "");
@@ -385,9 +399,76 @@ export function buildSessionMapLanes(manifest: ShareManifest): SessionMapModel |
         };
     });
 
+    // Gap compression: wide uncovered spans between coverage clusters collapse
+    // to a fixed-width break so a few far-apart dispatches don't leave the
+    // strip mostly blank. Leading/trailing space is kept (axis endpoints stay
+    // anchored at the root window edges), the order axis is already evenly
+    // spaced, and every lane runs through the same monotonic piecewise remap.
+    let remap = (v: number): number => v;
+    let gaps: ReadonlyArray<SessionMapGap> = [];
+    if (axis !== "order") {
+        const covered: Array<{ start: number; end: number }> = [];
+        for (const p of [...placed].sort((a, b) => a.x - b.x)) {
+            const last = covered[covered.length - 1];
+            if (last && p.x <= last.end) last.end = Math.max(last.end, p.x + p.w);
+            else covered.push({ start: p.x, end: p.x + p.w });
+        }
+        const domainGaps = covered
+            .slice(1)
+            .map((seg, i) => ({ start: covered[i]!.end, end: seg.start }))
+            .filter((g) => g.end - g.start > SESSION_MAP_GAP_MIN);
+        if (domainGaps.length > 0) {
+            const gapTotal = domainGaps.reduce((acc, g) => acc + (g.end - g.start), 0);
+            const scale = (1 - domainGaps.length * SESSION_MAP_GAP_W) / (1 - gapTotal);
+            remap = (v) => {
+                let out = 0;
+                let prev = 0;
+                for (const g of domainGaps) {
+                    if (v <= g.start) return out + (v - prev) * scale;
+                    out += (g.start - prev) * scale;
+                    if (v <= g.end) return out + ((v - g.start) / (g.end - g.start)) * SESSION_MAP_GAP_W;
+                    out += SESSION_MAP_GAP_W;
+                    prev = g.end;
+                }
+                return out + (v - prev) * scale;
+            };
+            const gapLabel = (g: { start: number; end: number }): string => {
+                if (axis === "time" && windowMs != null) {
+                    return fmtDuration((g.end - g.start) * windowMs) ?? "";
+                }
+                // Seq axis: prefer wall-clock between the adjacent clusters'
+                // timestamps; fall back to the turn delta when they're missing.
+                const before = placed.filter((p) => p.x + p.w <= g.start + 1e-9);
+                const after = placed.filter((p) => p.x >= g.end - 1e-9);
+                const prevEnds = before
+                    .map((p) => {
+                        const ts = parseShareTs(p.card.started_at);
+                        return ts != null ? ts + (p.card.duration_ms ?? 0) : null;
+                    })
+                    .filter((t): t is number => t != null);
+                const nextStarts = after
+                    .map((p) => parseShareTs(p.card.started_at))
+                    .filter((t): t is number => t != null);
+                if (prevEnds.length > 0 && nextStarts.length > 0) {
+                    const wallClock = Math.min(...nextStarts) - Math.max(...prevEnds);
+                    const label = wallClock > 0 ? fmtDuration(wallClock) : null;
+                    if (label) return label;
+                }
+                const prevSeq = Math.max(...before.map((p) => p.card.spawn_turn_seq ?? 0));
+                const nextSeq = Math.min(...after.map((p) => p.card.spawn_turn_seq ?? 0));
+                return `${Math.max(nextSeq - prevSeq, 0)} turns`;
+            };
+            gaps = domainGaps.map((g) => ({ x: remap(g.start), w: SESSION_MAP_GAP_W, label: gapLabel(g) }));
+        }
+    }
+    const remapped = gaps.length === 0 ? placed : placed.map((p) => {
+        const x = remap(p.x);
+        return { ...p, x, w: remap(p.x + p.w) - x };
+    });
+
     // Greedy row packing on the shared axis - overlapping bars stack downward.
     const laneEnds: number[] = [];
-    const lanes = [...placed]
+    const lanes = [...remapped]
         .sort((p, q) => p.x - q.x || p.order - q.order)
         .map(({ card, order: _order, ...lane }): SessionMapLane => {
             let row = 0;
@@ -402,6 +483,7 @@ export function buildSessionMapLanes(manifest: ShareManifest): SessionMapModel |
         rows: lanes.reduce((acc, lane) => Math.max(acc, lane.row + 1), 1),
         rootDurationMs,
         lanes,
+        gaps,
     };
 }
 
@@ -448,6 +530,32 @@ function ShareSessionMap(props: {
                 <span>{[duration ? `root ${duration}` : null, SESSION_MAP_AXIS_CAPTION[model.axis]].filter(Boolean).join(" · ")}</span>
             </div>
             <div style={{ position: "relative", height: model.rows * SESSION_MAP_ROW_H, marginTop: 8 }}>
+                {model.gaps.map((gap, i) => (
+                    <div
+                        key={`gap-${i}`}
+                        title={`no subagent activity for ${gap.label}`}
+                        style={{
+                            position: "absolute",
+                            left: `${gap.x * 100}%`,
+                            width: `${gap.w * 100}%`,
+                            top: 0,
+                            height: "100%",
+                            borderLeft: "1px dotted var(--muted-2)",
+                            borderRight: "1px dotted var(--muted-2)",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                        }}
+                    >
+                        <span style={{
+                            font: "10px/1.2 ui-monospace, monospace",
+                            color: "var(--muted-2)",
+                            whiteSpace: "nowrap",
+                        }}>
+                            {gap.label}
+                        </span>
+                    </div>
+                ))}
                 {model.lanes.map((lane) => {
                     const selected = lane.file === props.selectedFile;
                     return (

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -280,6 +280,212 @@ function fmtDuration(ms: number | null | undefined): string | null {
     return `${h}h${m % 60 ? ` ${m % 60}m` : ""}`;
 }
 
+// --- F2 session map (manifest-only) -----------------------------------------
+
+export type SessionMapAxis = "seq" | "time" | "order";
+
+export interface SessionMapLane {
+    readonly file: string;
+    readonly id: string;
+    readonly row: number;
+    /** Left edge as a 0..1 fraction of the strip. */
+    readonly x: number;
+    /** Width as a 0..1 fraction of the strip (minimum applied). */
+    readonly w: number;
+    /** 0..1 cost relative to the max subagent cost; null = flat neutral (no
+     *  card in the share has a positive cost, so intensity carries no signal). */
+    readonly intensity: number | null;
+    readonly failed: boolean;
+    readonly failures: number;
+    readonly label: string;
+    readonly title: string;
+}
+
+export interface SessionMapModel {
+    /** One axis semantic per share - never mixed per card. */
+    readonly axis: SessionMapAxis;
+    readonly rows: number;
+    readonly rootDurationMs: number | null;
+    readonly lanes: ReadonlyArray<SessionMapLane>;
+}
+
+export const SESSION_MAP_MIN_LANE_W = 0.012;
+const SESSION_MAP_MAX_ROWS = 4;
+
+const parseShareTs = (iso: string | null | undefined): number | null => {
+    const t = Date.parse(iso ?? "");
+    return Number.isFinite(t) ? t : null;
+};
+
+/**
+ * Pure shaper for the share-page session map: manifest in, positioned lanes
+ * out. Axis is chosen once per share - spawn seq when every card has one,
+ * else start time over the root window, else stable manifest order.
+ */
+export function buildSessionMapLanes(manifest: ShareManifest): SessionMapModel | null {
+    const cards = manifest.subagents;
+    if (cards.length === 0) return null;
+
+    const t0 = parseShareTs(manifest.session.started_at);
+    const tEnd = parseShareTs(manifest.session.ended_at);
+    const totalsDuration =
+        manifest.totals.duration_ms != null && manifest.totals.duration_ms > 0 ? manifest.totals.duration_ms : null;
+    const t1 = tEnd ?? (t0 != null && totalsDuration != null ? t0 + totalsDuration : null);
+    const windowMs = t0 != null && t1 != null && t1 > t0 ? t1 - t0 : null;
+    const rootDurationMs = windowMs ?? totalsDuration;
+
+    const seqs = cards.map((c) => c.spawn_turn_seq);
+    const allSeq = seqs.every((s): s is number => typeof s === "number" && Number.isFinite(s));
+    const axis: SessionMapAxis = allSeq ? "seq" : windowMs != null ? "time" : "order";
+    const minSeq = allSeq ? Math.min(...(seqs as ReadonlyArray<number>)) : 0;
+    const seqRange = allSeq ? Math.max(...(seqs as ReadonlyArray<number>)) - minSeq : 0;
+
+    const maxChildDuration = Math.max(0, ...cards.map((c) => c.duration_ms ?? 0));
+    // No known root duration: scale so the longest child fills a quarter strip.
+    const widthDenom = rootDurationMs ?? (maxChildDuration > 0 ? maxChildDuration * 4 : null);
+
+    const maxCost = Math.max(0, ...cards.map((c) => (c.cost_usd != null && c.cost_usd > 0 ? c.cost_usd : 0)));
+
+    const placed = cards.map((card, i) => {
+        let x = 0;
+        if (axis === "seq") {
+            x = seqRange > 0 ? ((card.spawn_turn_seq as number) - minSeq) / seqRange : 0;
+        } else if (axis === "time") {
+            const ts = parseShareTs(card.started_at);
+            x = ts != null && t0 != null && windowMs != null ? Math.min(1, Math.max(0, (ts - t0) / windowMs)) : 0;
+        } else {
+            x = i / cards.length;
+        }
+        const d = card.duration_ms != null && card.duration_ms > 0 ? card.duration_ms : null;
+        const w = Math.min(1, Math.max(SESSION_MAP_MIN_LANE_W, d != null && widthDenom != null ? d / widthDenom : 0));
+        const failures = card.stats.failures;
+        return {
+            card,
+            order: i,
+            x: Math.min(x, 1 - w),
+            w,
+            intensity: maxCost > 0 ? Math.min(1, Math.max(0, (card.cost_usd ?? 0) / maxCost)) : null,
+            failed: failures > 0,
+            failures,
+            label: subagentChipLabel(card.task_label) ?? `${shortSessionId(card.id)}…`,
+            title: [
+                card.task_label ?? card.id,
+                card.model,
+                fmtDuration(card.duration_ms),
+                fmtUsd(card.cost_usd),
+                failures > 0 ? `${failures} failure${failures === 1 ? "" : "s"}` : null,
+            ].filter(Boolean).join(" · "),
+        };
+    });
+
+    // Greedy row packing on the shared axis - overlapping bars stack downward.
+    const laneEnds: number[] = [];
+    const lanes = [...placed]
+        .sort((p, q) => p.x - q.x || p.order - q.order)
+        .map(({ card, order: _order, ...lane }): SessionMapLane => {
+            let row = 0;
+            while (row < laneEnds.length && (laneEnds[row] ?? 0) > lane.x - 0.002) row++;
+            if (row >= SESSION_MAP_MAX_ROWS) row = SESSION_MAP_MAX_ROWS - 1;
+            laneEnds[row] = Math.max(laneEnds[row] ?? 0, lane.x + lane.w);
+            return { ...lane, file: card.file, id: card.id, row };
+        });
+
+    return {
+        axis,
+        rows: lanes.reduce((acc, lane) => Math.max(acc, lane.row + 1), 1),
+        rootDurationMs,
+        lanes,
+    };
+}
+
+const SESSION_MAP_ROW_H = 18;
+const SESSION_MAP_AXIS_CAPTION: Record<SessionMapAxis, string> = {
+    seq: "placed by spawn turn",
+    time: "placed by start time",
+    order: "in spawn order",
+};
+
+/**
+ * Compact session-map strip near the share hero: the root run's fan-out as
+ * one bar per subagent. Renders from the manifest only; clicking a bar uses
+ * the same `?sub=<file>` selection as the rest of the share viewer.
+ */
+function ShareSessionMap(props: {
+    readonly manifest: ShareManifest;
+    readonly selectedFile: string;
+    readonly onSelect: (file: string) => void;
+    readonly onPrefetch: (file: string) => void;
+}) {
+    const model = useMemo(() => buildSessionMapLanes(props.manifest), [props.manifest]);
+    if (!model) return null;
+    const duration = fmtDuration(model.rootDurationMs);
+    const hasCost = model.lanes.some((lane) => lane.intensity != null);
+    const laneBackground = (lane: SessionMapLane): string => {
+        const pct = lane.intensity == null ? 26 : Math.round(18 + 62 * lane.intensity);
+        if (lane.failed) return `color-mix(in srgb, var(--red) ${Math.max(pct, 26)}%, var(--panel))`;
+        if (lane.intensity == null) return "color-mix(in srgb, var(--muted) 22%, var(--panel))";
+        return `color-mix(in srgb, var(--rose) ${pct}%, var(--panel))`;
+    };
+    return (
+        <div style={SUBAGENT_BAR_STYLE} aria-label="Session map">
+            <div style={{
+                display: "flex",
+                justifyContent: "space-between",
+                gap: 12,
+                font: "700 10px/1.5 ui-monospace, monospace",
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "var(--muted)",
+            }}>
+                <span>Session map · {model.lanes.length} subagent{model.lanes.length === 1 ? "" : "s"}</span>
+                <span>{[duration ? `root ${duration}` : null, SESSION_MAP_AXIS_CAPTION[model.axis]].filter(Boolean).join(" · ")}</span>
+            </div>
+            <div style={{ position: "relative", height: model.rows * SESSION_MAP_ROW_H, marginTop: 8 }}>
+                {model.lanes.map((lane) => {
+                    const selected = lane.file === props.selectedFile;
+                    return (
+                        <button
+                            key={lane.file}
+                            type="button"
+                            title={lane.title}
+                            aria-label={`Open subagent: ${lane.title}`}
+                            aria-pressed={selected}
+                            onClick={() => props.onSelect(lane.file)}
+                            onMouseEnter={() => props.onPrefetch(lane.file)}
+                            onFocus={() => props.onPrefetch(lane.file)}
+                            style={{
+                                position: "absolute",
+                                left: `${lane.x * 100}%`,
+                                width: `${lane.w * 100}%`,
+                                minWidth: 10,
+                                maxWidth: "100%",
+                                top: lane.row * SESSION_MAP_ROW_H,
+                                height: SESSION_MAP_ROW_H - 4,
+                                padding: "0 4px",
+                                border: selected ? "1px solid var(--ink)" : "1px solid transparent",
+                                borderRadius: 2,
+                                cursor: "pointer",
+                                background: laneBackground(lane),
+                                overflow: "hidden",
+                                textAlign: "left",
+                                whiteSpace: "nowrap",
+                                textOverflow: "ellipsis",
+                                font: "9px/1.4 ui-monospace, monospace",
+                                color: lane.failed ? "color-mix(in srgb, var(--red) 60%, var(--ink))" : "var(--ink)",
+                            }}
+                        >
+                            {lane.label}
+                        </button>
+                    );
+                })}
+            </div>
+            <div style={{ marginTop: 6, font: "10px/1.4 ui-monospace, monospace", color: "var(--muted-2)" }}>
+                {[hasCost ? "darker = costlier" : null, "click a bar to open the subagent"].filter(Boolean).join(" · ")}
+            </div>
+        </div>
+    );
+}
+
 /** The transcript body for one session - reused by parent + subagent views. */
 function InspectBody({
     data,
@@ -976,6 +1182,14 @@ function MultiFileShareView(props: {
                     spawnCards={directChildren}
                 />
             )}
+            {manifest.subagents.length > 0 ? (
+                <ShareSessionMap
+                    manifest={manifest}
+                    selectedFile={selectedFile}
+                    onSelect={setSelectedFile}
+                    onPrefetch={prefetch}
+                />
+            ) : null}
             {directChildren.length > 0 ? (
                 <details style={SUBAGENT_BAR_STYLE}>
                     <summary style={{

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -311,6 +311,9 @@ export interface SessionMapModel {
 
 export const SESSION_MAP_MIN_LANE_W = 0.012;
 const SESSION_MAP_MAX_ROWS = 4;
+/** Bars whose left edges sit closer than this (strip fraction) to an earlier
+ *  bar's right edge pack onto the next row instead of overlapping. */
+const SESSION_MAP_PACK_GAP = 0.002;
 
 const parseShareTs = (iso: string | null | undefined): number | null => {
     const t = Date.parse(iso ?? "");
@@ -319,8 +322,10 @@ const parseShareTs = (iso: string | null | undefined): number | null => {
 
 /**
  * Pure shaper for the share-page session map: manifest in, positioned lanes
- * out. Axis is chosen once per share - spawn seq when every card has one,
- * else start time over the root window, else stable manifest order.
+ * out. Axis is chosen once per share - spawn seq when every card has one AND
+ * every card is a direct child of the root (`spawn_turn_seq` is parent-local,
+ * so a nested card's seq has no meaning on the root's turn axis), else start
+ * time over the root window, else stable manifest order.
  */
 export function buildSessionMapLanes(manifest: ShareManifest): SessionMapModel | null {
     const cards = manifest.subagents;
@@ -334,11 +339,13 @@ export function buildSessionMapLanes(manifest: ShareManifest): SessionMapModel |
     const windowMs = t0 != null && t1 != null && t1 > t0 ? t1 - t0 : null;
     const rootDurationMs = windowMs ?? totalsDuration;
 
-    const seqs = cards.map((c) => c.spawn_turn_seq);
-    const allSeq = seqs.every((s): s is number => typeof s === "number" && Number.isFinite(s));
+    const seqValues = cards
+        .map((c) => c.spawn_turn_seq)
+        .filter((s): s is number => typeof s === "number" && Number.isFinite(s));
+    const allSeq = seqValues.length === cards.length && cards.every((c) => c.depth === 1);
     const axis: SessionMapAxis = allSeq ? "seq" : windowMs != null ? "time" : "order";
-    const minSeq = allSeq ? Math.min(...(seqs as ReadonlyArray<number>)) : 0;
-    const seqRange = allSeq ? Math.max(...(seqs as ReadonlyArray<number>)) - minSeq : 0;
+    const minSeq = allSeq ? Math.min(...seqValues) : 0;
+    const seqRange = allSeq ? Math.max(...seqValues) - minSeq : 0;
 
     const maxChildDuration = Math.max(0, ...cards.map((c) => c.duration_ms ?? 0));
     // No known root duration: scale so the longest child fills a quarter strip.
@@ -349,7 +356,7 @@ export function buildSessionMapLanes(manifest: ShareManifest): SessionMapModel |
     const placed = cards.map((card, i) => {
         let x = 0;
         if (axis === "seq") {
-            x = seqRange > 0 ? ((card.spawn_turn_seq as number) - minSeq) / seqRange : 0;
+            x = seqRange > 0 ? ((card.spawn_turn_seq ?? minSeq) - minSeq) / seqRange : 0;
         } else if (axis === "time") {
             const ts = parseShareTs(card.started_at);
             x = ts != null && t0 != null && windowMs != null ? Math.min(1, Math.max(0, (ts - t0) / windowMs)) : 0;
@@ -384,7 +391,7 @@ export function buildSessionMapLanes(manifest: ShareManifest): SessionMapModel |
         .sort((p, q) => p.x - q.x || p.order - q.order)
         .map(({ card, order: _order, ...lane }): SessionMapLane => {
             let row = 0;
-            while (row < laneEnds.length && (laneEnds[row] ?? 0) > lane.x - 0.002) row++;
+            while (row < laneEnds.length && (laneEnds[row] ?? 0) > lane.x - SESSION_MAP_PACK_GAP) row++;
             if (row >= SESSION_MAP_MAX_ROWS) row = SESSION_MAP_MAX_ROWS - 1;
             laneEnds[row] = Math.max(laneEnds[row] ?? 0, lane.x + lane.w);
             return { ...lane, file: card.file, id: card.id, row };
@@ -862,7 +869,8 @@ function SessionScrubber({ timeline, spawnCards }: {
     };
     const fmtClock = (t: number) => new Date(t).toISOString().slice(5, 16).replace("T", " ");
     // Subagent lanes: each dispatch as a bar on the same time axis, greedy
-    // row packing, opacity by cost - the fan-out made visible (the F2 map).
+    // row packing, opacity by cost - a timeline-local preview of the fan-out
+    // (the standalone F2 session map is ShareSessionMap, rendered separately).
     const lanes: Array<Array<{ x: number; w: number; cost: number; failed: boolean; label: string }>> = [];
     const laneEnds: number[] = [];
     const maxCost = Math.max(0.01, ...(spawnCards ?? []).map((c) => c.cost_usd ?? 0));

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -341,6 +341,118 @@ const parseShareTs = (iso: string | null | undefined): number | null => {
     return Number.isFinite(t) ? t : null;
 };
 
+export interface AxisGapBreak {
+    /** Post-compression band position/width (strip fraction). */
+    readonly x: number;
+    readonly w: number;
+    /** Domain endpoints of the compressed span - compute labels from these,
+     *  never from remapped fractions. */
+    readonly domainStart: number;
+    readonly domainEnd: number;
+}
+
+export interface AxisCompression {
+    /** Monotonic piecewise-linear domain -> strip map; identity when nothing
+     *  was compressed. */
+    readonly remap: (v: number) => number;
+    readonly gaps: ReadonlyArray<AxisGapBreak>;
+}
+
+const IDENTITY_AXIS_COMPRESSION: AxisCompression = { remap: (v) => v, gaps: [] };
+
+/**
+ * Shared fixed-point gap compression for a normalized 0..1 axis. Takes the
+ * coverage intervals (anything "active" on the axis), finds interior
+ * uncovered spans, and collapses the ones that would RENDER wider than
+ * SESSION_MAP_GAP_MIN down to SESSION_MAP_GAP_W, stretching everything else
+ * proportionally. Compressing one gap stretches the rest, which can push a
+ * previously sub-threshold gap over the visual threshold - selection iterates
+ * (widest first) until no gap qualifies, bounded by SESSION_MAP_GAP_PASSES
+ * and the SESSION_MAP_GAP_MAX band cap. Candidates no wider than the break
+ * width are excluded, which keeps the remap stretch-only (chosen total >
+ * chosen count * GAP_W, hence scale > 1) and monotonic; axis endpoints stay
+ * anchored (leading/trailing space is not a gap).
+ */
+export function compressAxisGaps(
+    intervals: ReadonlyArray<{ readonly start: number; readonly end: number }>,
+): AxisCompression {
+    const covered: Array<{ start: number; end: number }> = [];
+    for (const p of [...intervals].sort((a, b) => a.start - b.start)) {
+        const last = covered[covered.length - 1];
+        if (last && p.start <= last.end) last.end = Math.max(last.end, p.end);
+        else covered.push({ start: p.start, end: p.end });
+    }
+    const candidates = covered
+        .slice(1)
+        .map((seg, i) => ({ start: covered[i]!.end, end: seg.start }))
+        .filter((g) => g.end - g.start > SESSION_MAP_GAP_W);
+    const chosen: Array<{ start: number; end: number }> = [];
+    for (let pass = 0; pass < SESSION_MAP_GAP_PASSES && chosen.length < SESSION_MAP_GAP_MAX; pass++) {
+        const chosenTotal = chosen.reduce((acc, g) => acc + (g.end - g.start), 0);
+        const stretch = (1 - chosen.length * SESSION_MAP_GAP_W) / (1 - chosenTotal);
+        const qualifying = candidates
+            .filter((g) => !chosen.includes(g) && (g.end - g.start) * stretch > SESSION_MAP_GAP_MIN)
+            .sort((a, b) => (b.end - b.start) - (a.end - a.start));
+        if (qualifying.length === 0) break;
+        for (const g of qualifying) {
+            if (chosen.length >= SESSION_MAP_GAP_MAX) break;
+            chosen.push(g);
+        }
+    }
+    if (chosen.length === 0) return IDENTITY_AXIS_COMPRESSION;
+    chosen.sort((a, b) => a.start - b.start);
+    const gapTotal = chosen.reduce((acc, g) => acc + (g.end - g.start), 0);
+    const scale = (1 - chosen.length * SESSION_MAP_GAP_W) / (1 - gapTotal);
+    const remap = (v: number): number => {
+        let out = 0;
+        let prev = 0;
+        for (const g of chosen) {
+            if (v <= g.start) return out + (v - prev) * scale;
+            out += (g.start - prev) * scale;
+            if (v <= g.end) return out + ((v - g.start) / (g.end - g.start)) * SESSION_MAP_GAP_W;
+            out += SESSION_MAP_GAP_W;
+            prev = g.end;
+        }
+        return out + (v - prev) * scale;
+    };
+    return {
+        remap,
+        gaps: chosen.map((g) => ({ x: remap(g.start), w: SESSION_MAP_GAP_W, domainStart: g.start, domainEnd: g.end })),
+    };
+}
+
+/** Point events (commit/failure ticks) anchor scrubber coverage as a span
+ *  this wide - an isolated commit in a quiet stretch is still activity. */
+const SCRUBBER_POINT_COVER_W = 0.006;
+
+/**
+ * Scrubber-side gap shaping: coverage is the union of ALL activity on the
+ * wall-clock strip - commit ticks, failure ticks (points, inflated a touch so
+ * they anchor coverage), and subagent bars. A stretch with none of those is a
+ * gap candidate. Labels are wall-clock (the scrubber domain is time).
+ */
+export function buildScrubberGaps(args: {
+    readonly pointXs: ReadonlyArray<number>;
+    readonly bars: ReadonlyArray<{ readonly x: number; readonly w: number }>;
+    readonly spanMs: number;
+}): { readonly remap: (v: number) => number; readonly gaps: ReadonlyArray<SessionMapGap> } {
+    const compression = compressAxisGaps([
+        ...args.pointXs.map((x) => ({
+            start: Math.max(0, x - SCRUBBER_POINT_COVER_W / 2),
+            end: Math.min(1, x + SCRUBBER_POINT_COVER_W / 2),
+        })),
+        ...args.bars.map((b) => ({ start: b.x, end: Math.min(1, b.x + b.w) })),
+    ]);
+    return {
+        remap: compression.remap,
+        gaps: compression.gaps.map((g) => ({
+            x: g.x,
+            w: g.w,
+            label: fmtDuration((g.domainEnd - g.domainStart) * args.spanMs) ?? "",
+        })),
+    };
+}
+
 /**
  * Pure shaper for the share-page session map: manifest in, positioned lanes
  * out. Axis is chosen once per share - spawn seq when every card has one AND
@@ -414,82 +526,39 @@ export function buildSessionMapLanes(manifest: ShareManifest): SessionMapModel |
     let remap = (v: number): number => v;
     let gaps: ReadonlyArray<SessionMapGap> = [];
     if (axis !== "order") {
-        const covered: Array<{ start: number; end: number }> = [];
-        for (const p of [...placed].sort((a, b) => a.x - b.x)) {
-            const last = covered[covered.length - 1];
-            if (last && p.x <= last.end) last.end = Math.max(last.end, p.x + p.w);
-            else covered.push({ start: p.x, end: p.x + p.w });
-        }
-        // Candidates: interior uncovered spans, tracked by their DOMAIN
-        // endpoints (labels must come from domain quantities, never remapped
-        // fractions). Spans no wider than the break width are excluded - they
-        // can't shrink, and excluding them keeps the remap stretch-only
-        // (chosen total > chosen count * GAP_W, hence scale > 1).
-        const candidates = covered
-            .slice(1)
-            .map((seg, i) => ({ start: covered[i]!.end, end: seg.start }))
-            .filter((g) => g.end - g.start > SESSION_MAP_GAP_W);
-        // Fixed-point selection: a gap qualifies when its RENDERED width
-        // (domain width x current stretch) exceeds the threshold, and every
-        // compression raises the stretch - so iterate, widest first, until no
-        // gap qualifies or the pass/band caps stop it.
-        const chosen: Array<{ start: number; end: number }> = [];
-        for (let pass = 0; pass < SESSION_MAP_GAP_PASSES && chosen.length < SESSION_MAP_GAP_MAX; pass++) {
-            const chosenTotal = chosen.reduce((acc, g) => acc + (g.end - g.start), 0);
-            const stretch = (1 - chosen.length * SESSION_MAP_GAP_W) / (1 - chosenTotal);
-            const qualifying = candidates
-                .filter((g) => !chosen.includes(g) && (g.end - g.start) * stretch > SESSION_MAP_GAP_MIN)
-                .sort((a, b) => (b.end - b.start) - (a.end - a.start));
-            if (qualifying.length === 0) break;
-            for (const g of qualifying) {
-                if (chosen.length >= SESSION_MAP_GAP_MAX) break;
-                chosen.push(g);
+        const gapLabel = (g: { readonly start: number; readonly end: number }): string => {
+            if (axis === "time" && windowMs != null) {
+                return fmtDuration((g.end - g.start) * windowMs) ?? "";
             }
-        }
-        if (chosen.length > 0) {
-            chosen.sort((a, b) => a.start - b.start);
-            const gapTotal = chosen.reduce((acc, g) => acc + (g.end - g.start), 0);
-            const scale = (1 - chosen.length * SESSION_MAP_GAP_W) / (1 - gapTotal);
-            remap = (v) => {
-                let out = 0;
-                let prev = 0;
-                for (const g of chosen) {
-                    if (v <= g.start) return out + (v - prev) * scale;
-                    out += (g.start - prev) * scale;
-                    if (v <= g.end) return out + ((v - g.start) / (g.end - g.start)) * SESSION_MAP_GAP_W;
-                    out += SESSION_MAP_GAP_W;
-                    prev = g.end;
-                }
-                return out + (v - prev) * scale;
-            };
-            const gapLabel = (g: { start: number; end: number }): string => {
-                if (axis === "time" && windowMs != null) {
-                    return fmtDuration((g.end - g.start) * windowMs) ?? "";
-                }
-                // Seq axis: prefer wall-clock between the adjacent clusters'
-                // timestamps; fall back to the turn delta when they're missing.
-                const before = placed.filter((p) => p.x + p.w <= g.start + 1e-9);
-                const after = placed.filter((p) => p.x >= g.end - 1e-9);
-                const prevEnds = before
-                    .map((p) => {
-                        const ts = parseShareTs(p.card.started_at);
-                        return ts != null ? ts + (p.card.duration_ms ?? 0) : null;
-                    })
-                    .filter((t): t is number => t != null);
-                const nextStarts = after
-                    .map((p) => parseShareTs(p.card.started_at))
-                    .filter((t): t is number => t != null);
-                if (prevEnds.length > 0 && nextStarts.length > 0) {
-                    const wallClock = Math.min(...nextStarts) - Math.max(...prevEnds);
-                    const label = wallClock > 0 ? fmtDuration(wallClock) : null;
-                    if (label) return label;
-                }
-                const prevSeq = Math.max(...before.map((p) => p.card.spawn_turn_seq ?? 0));
-                const nextSeq = Math.min(...after.map((p) => p.card.spawn_turn_seq ?? 0));
-                return `${Math.max(nextSeq - prevSeq, 0)} turns`;
-            };
-            gaps = chosen.map((g) => ({ x: remap(g.start), w: SESSION_MAP_GAP_W, label: gapLabel(g) }));
-        }
+            // Seq axis: prefer wall-clock between the adjacent clusters'
+            // timestamps; fall back to the turn delta when they're missing.
+            const before = placed.filter((p) => p.x + p.w <= g.start + 1e-9);
+            const after = placed.filter((p) => p.x >= g.end - 1e-9);
+            const prevEnds = before
+                .map((p) => {
+                    const ts = parseShareTs(p.card.started_at);
+                    return ts != null ? ts + (p.card.duration_ms ?? 0) : null;
+                })
+                .filter((t): t is number => t != null);
+            const nextStarts = after
+                .map((p) => parseShareTs(p.card.started_at))
+                .filter((t): t is number => t != null);
+            if (prevEnds.length > 0 && nextStarts.length > 0) {
+                const wallClock = Math.min(...nextStarts) - Math.max(...prevEnds);
+                const label = wallClock > 0 ? fmtDuration(wallClock) : null;
+                if (label) return label;
+            }
+            const prevSeq = Math.max(...before.map((p) => p.card.spawn_turn_seq ?? 0));
+            const nextSeq = Math.min(...after.map((p) => p.card.spawn_turn_seq ?? 0));
+            return `${Math.max(nextSeq - prevSeq, 0)} turns`;
+        };
+        const compression = compressAxisGaps(placed.map((p) => ({ start: p.x, end: p.x + p.w })));
+        remap = compression.remap;
+        gaps = compression.gaps.map((g) => ({
+            x: g.x,
+            w: g.w,
+            label: gapLabel({ start: g.domainStart, end: g.domainEnd }),
+        }));
     }
     const remapped = gaps.length === 0 ? placed : placed.map((p) => {
         const x = remap(p.x);
@@ -1006,34 +1075,52 @@ function SessionScrubber({ timeline, spawnCards }: {
         window.location.hash = `turn-${seq}`;
     };
     const fmtClock = (t: number) => new Date(t).toISOString().slice(5, 16).replace("T", " ");
-    // Subagent lanes: each dispatch as a bar on the same time axis, greedy
-    // row packing, opacity by cost - a timeline-local preview of the fan-out
-    // (the standalone F2 session map is ShareSessionMap, rendered separately).
-    const lanes: Array<Array<{ x: number; w: number; cost: number; failed: boolean; label: string }>> = [];
-    const laneEnds: number[] = [];
+    const commitXs = ticks("checkpoint");
+    const failXs = ticks("failure");
+    // Subagent bars in raw domain coords - row packing happens after the remap.
     const maxCost = Math.max(0.01, ...(spawnCards ?? []).map((c) => c.cost_usd ?? 0));
+    const rawBars: Array<{ x: number; w: number; cost: number; failed: boolean; label: string }> = [];
     for (const card of [...(spawnCards ?? [])].sort((p, q) => (p.started_at ?? "").localeCompare(q.started_at ?? ""))) {
         const x = frac(card.started_at);
         if (x == null) continue;
-        const w = Math.max((card.duration_ms ?? 0) / span, 0.004);
-        let r = 0;
-        while (r < laneEnds.length && laneEnds[r] > x - 0.002) r++;
-        if (r >= 4) r = 3;
-        laneEnds[r] = x + w;
-        (lanes[r] ??= []).push({
+        rawBars.push({
             x,
-            w,
+            w: Math.max((card.duration_ms ?? 0) / span, 0.004),
             cost: card.cost_usd ?? 0,
             failed: (card.stats?.failures ?? 0) > 0,
             label: `${card.task_label ?? card.id} - ${fmtUsd(card.cost_usd) ?? ""}`,
         });
     }
+    // Dead stretches (no commits, no failures, no subagents) compress to
+    // labeled breaks, same machinery as the session map. EVERY positional
+    // value below runs through the same remap - segments, label anchors,
+    // ticks, bars - so nothing drifts off its activity.
+    const { remap, gaps } = buildScrubberGaps({
+        pointXs: [...commitXs, ...failXs],
+        bars: rawBars,
+        spanMs: span,
+    });
+    // Subagent lanes: each dispatch as a bar on the shared (remapped) time
+    // axis, greedy row packing, opacity by cost - a timeline-local preview of
+    // the fan-out (the standalone F2 session map is ShareSessionMap).
+    const lanes: Array<Array<{ x: number; w: number; cost: number; failed: boolean; label: string }>> = [];
+    const laneEnds: number[] = [];
+    for (const bar of rawBars) {
+        const x = remap(bar.x);
+        const w = remap(Math.min(bar.x + bar.w, 1)) - x;
+        let r = 0;
+        while (r < laneEnds.length && laneEnds[r] > x - 0.002) r++;
+        if (r >= 4) r = 3;
+        laneEnds[r] = x + w;
+        (lanes[r] ??= []).push({ ...bar, x, w });
+    }
+    const rsegs = segs.map((s) => ({ seg: s.seg, a: remap(s.a), b: remap(s.b) }));
     return (
         <div className="scrub-wrap">
             {/* Labels live in their own deck so the strip below stays pure
                 signal - inside the strip they collided with the ticks. */}
             <div className="scrub-labels">
-                {segs.filter(({ a, b }) => b - a > 0.08).map(({ seg, a, b }) => (
+                {rsegs.filter(({ a, b }) => b - a > 0.08).map(({ seg, a, b }) => (
                     <span
                         key={`l-${seg.id}`}
                         style={{ left: `${a * 100}%`, width: `${(b - a) * 100}%` }}
@@ -1044,7 +1131,7 @@ function SessionScrubber({ timeline, spawnCards }: {
                 ))}
             </div>
             <div className="scrub">
-                {segs.map(({ seg, a, b }) => (
+                {rsegs.map(({ seg, a, b }) => (
                     <button
                         key={seg.id}
                         type="button"
@@ -1054,8 +1141,32 @@ function SessionScrubber({ timeline, spawnCards }: {
                         onClick={() => jump(seg.start_seq)}
                     />
                 ))}
-                {ticks("checkpoint").map((x, i) => <i key={`c${i}`} className="scrub-commit" style={{ left: `${x * 100}%` }} />)}
-                {ticks("failure").map((x, i) => <i key={`f${i}`} className="scrub-fail" style={{ left: `${x * 100}%` }} />)}
+                {gaps.map((gap, i) => (
+                    <span
+                        key={`g${i}`}
+                        title={`no activity for ${gap.label}`}
+                        style={{
+                            position: "absolute",
+                            left: `${gap.x * 100}%`,
+                            width: `${gap.w * 100}%`,
+                            top: 0,
+                            height: "100%",
+                            borderLeft: "1px dotted var(--muted-2)",
+                            borderRight: "1px dotted var(--muted-2)",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            font: "9px/1.2 ui-monospace, monospace",
+                            color: "var(--muted-2)",
+                            whiteSpace: "nowrap",
+                            overflow: "hidden",
+                        }}
+                    >
+                        {gap.label}
+                    </span>
+                ))}
+                {commitXs.map((x, i) => <i key={`c${i}`} className="scrub-commit" style={{ left: `${remap(x) * 100}%` }} />)}
+                {failXs.map((x, i) => <i key={`f${i}`} className="scrub-fail" style={{ left: `${remap(x) * 100}%` }} />)}
             </div>
             {lanes.length > 0 ? (
                 <div className="scrub-lanes" style={{ height: lanes.length * 8 + 2 }}>

--- a/docs/superpowers/specs/2026-06-10-share-map-poster-warning-design.md
+++ b/docs/superpowers/specs/2026-06-10-share-map-poster-warning-design.md
@@ -1,0 +1,131 @@
+# Share Map, ASCII Poster, And Stale Usage Warning Design
+
+Date: 2026-06-10
+Branch: `feat/share-map-poster-warning`
+
+## Goal
+
+Improve public session shares in three focused ways:
+
+1. Add the first production slice of the F2 session map.
+2. Polish the OG poster with an ASCII `AX` logo treatment.
+3. Warn when `ax share` is exporting stale usage data that can make cost rails look empty.
+
+This pass deliberately avoids the larger F2 digest export for commit ticks and chapter bands. The session map must be useful from data already present in the multi-file share manifest.
+
+## User-Facing Behavior
+
+### F2 Session Map
+
+Shared-session Studio pages show a compact `Session map` strip near the existing share hero/header when the manifest has subagents.
+
+The map renders from `index.json` only:
+
+- Root duration from `session.started_at` / `session.ended_at` and `totals.duration_ms`.
+- Subagent cards from `subagents[]`.
+- Horizontal placement from `spawn_turn_seq` when present, falling back to start time relative to the root session window, then stable order as a last fallback.
+- Bar width from `duration_ms` when present, with a minimum visible width.
+- Color intensity from `cost_usd` relative to the highest known subagent cost.
+- Failure state from `stats.failures`.
+- Labels and tooltips from `task_label`, `model`, `cost_usd`, duration, and failure count.
+
+Interaction:
+
+- Clicking a subagent lane selects that subagent using the existing share deep-link behavior (`?sub=<file>`).
+- The map is keyboard reachable through buttons or equivalent focusable controls.
+- Empty space on the map does not change selection.
+- The map is hidden for shares with zero subagents.
+
+The visual language follows the current share viewer: flat, utilitarian, light theme, restrained colors, no decorative grid texture.
+
+### OG Poster
+
+The default poster replaces the current serif `ax` header wordmark with a small ASCII `AX` logo in the top-left header. The poster remains content-first: title, totals, fleet, and cost anatomy still dominate.
+
+A debug/render variant is available with `?variant=watermark`. It renders a larger background ASCII watermark so it can be inspected and iterated without making the louder treatment the default social card.
+
+The OG implementation must keep the known `workers-og` / satori constraints:
+
+- No raw SVG children.
+- Avoid parser-hostile style properties already identified in the handoff.
+- Use hex colors and integer pixel values.
+- Bump the OG cache key when the template changes.
+
+### Stale Ingest Warning
+
+`ax share` emits a non-blocking stderr warning when the exported root or descendant sessions have session-level usage but no turn-level usage rows.
+
+Detection:
+
+- Traverse the redacted exported share tree before building the bundle.
+- Treat session-level usage as present when `token_usage.estimated_cost_usd` or `token_usage.estimated_tokens` is a positive number.
+- Treat turn-level usage as present when any exported turn in the root or descendants has `turn.token_usage`.
+- Warn only when session-level usage is present and turn-level usage is absent everywhere in the exported tree.
+
+Suggested warning text:
+
+```text
+axctl share: warning: this share has session-level cost but no per-turn usage rows; cost rails may render as $0.
+Re-run ingest with AX_REDERIVE_CLAUDE=1 AX_REDERIVE_SUBAGENTS=1 ax ingest here --stages=claude,subagents --since=N
+```
+
+The warning never blocks `--dry-run`, preview, or publish.
+
+## Implementation Shape
+
+### Studio Share Viewer
+
+The hosted Studio share viewer is currently shipped as static assets under `apps/site/public/studio/`. The implementation should first identify whether those assets have an authored source elsewhere in the repo. If they do, edit the source and rebuild. If the static assets are the source of truth for now, keep edits minimal and include a note in the PR.
+
+Add a small map renderer that accepts the manifest object and current selected subagent file. It should be pure enough to test with sample manifest objects.
+
+Expected helpers:
+
+- `buildSessionMapLanes(manifest)` or equivalent pure data shaper.
+- Formatting helpers for cost and duration reused from existing share viewer code when available.
+- DOM/render integration near the existing share hero.
+
+### OG Function
+
+Edit both:
+
+- `apps/site/functions/og/[owner]/[gistId].ts`
+- repo-root `functions/og/[owner]/[gistId].ts` only if the root file needs anything beyond its existing re-export.
+
+The ASCII logo should be a small preformatted block or explicit line stack in the header. Prefer line-stack HTML if `pre` proves fragile in `workers-og`.
+
+Add `variant=watermark` handling inside the same function and include the variant in the cache key alongside the bumped render revision.
+
+### CLI Share Warning
+
+Add a small pure helper in `apps/axctl/src/cli/share.ts` or `apps/axctl/src/share/format.ts`:
+
+- It receives an `AxSessionShare`.
+- It traverses `children`.
+- It returns `true` when the stale condition is met.
+
+`cmdShareWithDeps` writes the warning to stderr after redaction and before dry-run/preview output, so dry-run users see it too.
+
+## Testing
+
+Focused tests:
+
+- `apps/axctl/src/cli/share.test.ts`: warning emitted for session-level usage with no turn usage; no warning when turn usage exists; no warning when there is no session usage.
+- `apps/axctl/src/share/manifest.test.ts` if map support requires additional manifest shaping.
+- Site/Studio test coverage if an authored source test harness exists.
+
+Verification:
+
+- `bun test apps/axctl/src/cli/share.test.ts`
+- Relevant share/manifest tests after edits.
+- Site build/typecheck for Studio/OG edits.
+- Browser verification against a local or deployed share URL.
+- OG verification via `/og/Necmttn/a6d4c2215bbe0998c93b38ad11db2ccb?debug=min` and the default render; also inspect `?variant=watermark`.
+
+## Out Of Scope
+
+- Commit ticks in the session map.
+- Chapter bands derived from classifier/session-section output.
+- Re-exporting the canonical demo gist.
+- Making the watermark poster the default social image.
+- Fixing unrelated known share-viewer bugs such as the docked inspector pinning issue.


### PR DESCRIPTION
## Summary

Implements `docs/superpowers/specs/2026-06-10-share-map-poster-warning-design.md` — three focused share improvements:

- **F2 session map (first slice):** `buildSessionMapLanes` pure shaper + `ShareSessionMap` strip in the Studio share viewer (`apps/studio/src/routes/share-inspect.tsx`). Renders from the share manifest only: per-share axis (seq when all depth-1 cards have `spawn_turn_seq`, else time over root window, else stable order — never mixed), min lane width, cost-intensity coloring with flat-neutral degradation when no positive cost, failure state, greedy 4-row packing. Lanes are real buttons reusing the existing `?sub=` deep-link selection + prefetch; hidden for zero-subagent and legacy single-file shares.
- **OG poster ASCII `AX` logo:** serif header wordmark replaced with a 2-line ASCII mark (div line-stack, nbsp-substituted to survive satori whitespace collapse). New `?variant=watermark` debug render (same mark at 120px, opacity wrapper, behind content). Cache key bumped `r=5` → `r=6-${variant}`. Root `functions/og` mirror untouched (pure re-export, dual-deploy safe).
- **Stale-ingest warning in `ax share`:** `hasStaleUsage` + `formatStaleUsageWarning` in `apps/axctl/src/share/format.ts`; `cmdShareWithDeps` warns on stderr (after redaction, before dry-run/preview/publish) when the exported tree has session-level usage but no per-turn usage rows anywhere — the case where Studio cost rails render $0.

Note: the spec hedged on whether the Studio viewer had an authored source — resolved: it's the `apps/studio` workspace (the `apps/site/public/studio` assets are staged build output and were not touched).

## Test Plan

- [x] `apps/axctl/src/share/format.test.ts` + `apps/axctl/src/cli/share.test.ts` + `apps/studio/src/routes/share-inspect.test.ts`: 52 pass (exact warning text pinned; axis fallbacks, packing, depth guard, neutral degradation covered)
- [x] Neighbor suites: `apps/axctl/src/share/` 58 pass, `apps/studio/` 130 pass
- [x] `tsc --noEmit` clean in `apps/studio`; `apps/axctl` typecheck exit 0
- [ ] Post-deploy: inspect `/og/Necmttn/a6d4c2215bbe0998c93b38ad11db2ccb` default render + `?variant=watermark`
- [ ] Browser check of the session map against a deployed multi-file share

🤖 Generated with [Claude Code](https://claude.com/claude-code)