### PR TITLE
docs(release): announcement for v0.22.1

### DIFF
--- a/docs/releases/v0.22.1.md
+++ b/docs/releases/v0.22.1.md
@@ -1,0 +1,58 @@
+---
+version: "0.22.1"
+date: "2026-06-10"
+title: "Ctrl-C stops lying to the graph"
+summary: "Interrupting an ingest now closes its run row and kills its children - plus an Effect-wide canon pass and deploy/studio fixes."
+---
+
+0.22.1 is a hardening release built around one question: what happens when
+you interrupt ax mid-work? Before this release, Ctrl-C during an ingest
+hard-killed the process - the SurrealDB connection never closed, the OTLP
+trace buffer never flushed, child `git`/`gh` processes kept running, and the
+`ingest_run` row stayed `running` forever, lying to every surface that reads
+it.
+
+The fix came out of an Effect-TS canon audit: four parallel reviewers compared
+ax's codebase against the Effect v4 reference source and canonical guides, and
+the top finding was that the CLI entrypoint never adopted `BunRuntime.runMain`
+- so SIGINT never became fiber interruption, and none of the carefully
+written finalizers ever ran. 0.22.1 lands that audit as eight changes in one
+pass (#215):
+
+* The CLI runs under `runMain`: SIGINT → interrupt → finalizers. Interrupted
+  ingests exit 130 and close their run row with an `interrupted` marker -
+  verified live by SIGINT-ing a real ingest mid-run.
+* Subprocess spawns moved to one scoped helper: interruption and timeouts
+  now kill the child instead of leaking it.
+* Env reading moved to Effect `Config` - with parsing kept byte-identical to
+  the old behavior. An adversarial review pass caught that the naive
+  conversion would have silently dropped operational knob values like
+  `AX_INGEST_TIMEOUT_SECONDS=30s` to defaults; the shipped version pins the
+  old parsing semantics with regression tests against the original helpers
+  as oracles.
+* Transcript parsers validate each line against tolerant schemas and count
+  `malformedLines` instead of silently producing partial rows.
+* JSON-encoded nested fields, typed errors, branded ids, ~40 traced
+  entry-point spans, and an effect 4.0.0-beta.78 bump round out the pass.
+
+### Also in this release
+
+* **Deploys verify themselves** (#214): the Pages git integration ships its
+  functions correctly and the pipeline checks the deployed site after merge
+  instead of assuming.
+* **Studio**: the cost rail's sticky offset clears the jump bar (#212), and
+  NavLink follow-ups got their third round of fixes - next-block ordering,
+  session-id prefix resolution, summary floor (#216).
+* **Share posters**: the OG image got a brand lockup and full-bleed layout
+  (#211, #217).
+* **Release hygiene**: the flaky Codex CI announcement job was replaced with
+  a local coverage lint (#209) - the same lint that nudged this page into
+  existence.
+
+### Why it matters
+
+A telemetry graph you trust is the whole product. A run row stuck in
+`running` because you pressed Ctrl-C is a small lie that compounds - into
+wrong session metrics, wrong durability ratios, wrong conclusions. 0.22.1
+makes interruption a first-class, finalized exit path, so the graph records
+what actually happened.


### PR DESCRIPTION
Release page for v0.22.1 (`/changelog/v0.22.1`): Effect canon pass (#215) as the headline — runMain SIGINT shutdown, subprocess lifecycle, Config with parsing oracles — plus deploy verification (#214), studio/NavLink fixes (#212, #216), OG poster (#211, #217), and the announcement-lint swap (#209) that demanded this page.

Verified: typecheck clean, site build prerenders the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)