### PR TITLE
feat(og): version og:image URLs so social caches pick up poster changes

### DIFF
--- a/apps/site/functions/_lib/og-meta.test.ts
+++ b/apps/site/functions/_lib/og-meta.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { OG_RENDER_REV, buildOgImageUrl, ogImageVersion } from "./og-meta";
+
+describe("og-meta", () => {
+    test("bare render revision when no manifest text is in hand", () => {
+        expect(buildOgImageUrl("Necmttn", "abc123")).toBe(
+            `https://ax.necmttn.com/og/Necmttn/abc123?v=${OG_RENDER_REV}`,
+        );
+    });
+
+    test("manifest text folds a stable 8-hex-char hash into the version", () => {
+        const text = '{"kind":"manifest","totals":{"turns":12}}';
+        const url = buildOgImageUrl("Necmttn", "abc123", text);
+        expect(url).toMatch(
+            new RegExp(`^https://ax\\.necmttn\\.com/og/Necmttn/abc123\\?v=${OG_RENDER_REV}-[0-9a-f]{8}$`),
+        );
+        // Deterministic: the same manifest always yields the same URL.
+        expect(buildOgImageUrl("Necmttn", "abc123", text)).toBe(url);
+    });
+
+    test("a re-exported share (changed manifest) busts the URL", () => {
+        expect(ogImageVersion('{"totals":{"turns":12}}')).not.toBe(
+            ogImageVersion('{"totals":{"turns":13}}'),
+        );
+    });
+
+    test("empty manifest text still versions with a hash, not bare rev", () => {
+        expect(ogImageVersion("")).toMatch(new RegExp(`^${OG_RENDER_REV}-[0-9a-f]{8}$`));
+    });
+});

--- a/apps/site/functions/_lib/og-meta.ts
+++ b/apps/site/functions/_lib/og-meta.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared OG-poster metadata: the render revision plus the versioned og:image
+ * URL builder. Lives in an underscore dir (not routed by Pages, importable by
+ * route files) so the /s/ meta rewriter can version its og:image URLs without
+ * bundling the poster renderer (workers-og).
+ *
+ * Why version at all: X / Slack / Discord cache card images keyed by the
+ * literal og:image URL, so a poster-template change (e.g. r=5 -> r=6) never
+ * reaches links that were already shared - the platform serves the stale
+ * card forever. Folding the revision - and, when in hand, a hash of the
+ * share's manifest - into a ?v= param gives every template change (and every
+ * re-exported share) a fresh URL the platforms treat as a new image.
+ */
+
+/** Bump when the poster template changes; busts edge + social image caches. */
+export const OG_RENDER_REV = 6;
+
+/** FNV-1a 32-bit as 8 hex chars - tiny, synchronous, stable across runtimes. */
+const fnv1a = (s: string): string => {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < s.length; i++) {
+        h ^= s.charCodeAt(i);
+        h = Math.imul(h, 0x01000193);
+    }
+    return (h >>> 0).toString(16).padStart(8, "0");
+};
+
+/**
+ * Version tag for og:image URLs: `<rev>` alone, or `<rev>-<hash8>` when the
+ * caller already holds the share's manifest text (re-exporting a share
+ * rewrites the gist manifest, so the hash busts social caches for refreshed
+ * shares too - no extra network call, the rewriter fetches it anyway).
+ */
+export const ogImageVersion = (manifestText?: string): string =>
+    manifestText == null ? String(OG_RENDER_REV) : `${OG_RENDER_REV}-${fnv1a(manifestText)}`;
+
+/** Absolute /og/ poster URL with the cache-busting ?v= version param. */
+export const buildOgImageUrl = (owner: string, gistId: string, manifestText?: string): string =>
+    `https://ax.necmttn.com/og/${owner}/${gistId}?v=${ogImageVersion(manifestText)}`;

--- a/apps/site/functions/og/[owner]/[gistId].ts
+++ b/apps/site/functions/og/[owner]/[gistId].ts
@@ -9,6 +9,7 @@
  * html parser drops unknown tags).
  */
 import { ImageResponse } from "workers-og";
+import { OG_RENDER_REV } from "../../_lib/og-meta";
 
 interface SubagentCard {
     readonly cost_usd: number | null;
@@ -179,11 +180,12 @@ export const onRequestGet: PagesFunction = async (ctx) => {
         return new Response("bad request", { status: 400 });
     }
     const cache = (caches as unknown as { default: Cache }).default;
-    // r= version busts stale cached renders when the poster template changes.
+    // r= version (OG_RENDER_REV, shared with the /s/ meta rewriter's ?v=
+    // og:image param) busts stale cached renders when the template changes.
     // Append variant so watermark and default renders cache independently.
     const u = new URL(ctx.request.url);
     const variant = u.searchParams.get("variant") ?? "default";
-    u.searchParams.set("r", `6-${variant}`);
+    u.searchParams.set("r", `${OG_RENDER_REV}-${variant}`);
     const cacheKey = new Request(u.toString());
     const hit = await cache.match(cacheKey);
     if (hit) return hit;

--- a/apps/site/functions/s/[owner]/[gistId].ts
+++ b/apps/site/functions/s/[owner]/[gistId].ts
@@ -7,6 +7,8 @@
  * (/og/:owner/:gistId) and, when the gist manifest is reachable, its real
  * title and numbers.
  */
+import { buildOgImageUrl } from "../../_lib/og-meta";
+
 interface Env {
     readonly ASSETS: { fetch: (req: Request) => Promise<Response> };
 }
@@ -42,16 +44,20 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
     const shell = await ctx.env.ASSETS.fetch(new Request(shellUrl.toString(), { headers: ctx.request.headers }));
 
     // Best-effort real title/description from the share manifest (edge-cached
-    // upstream by GitHub; a failure falls back to generic copy).
+    // upstream by GitHub; a failure falls back to generic copy). The raw text
+    // is kept: its hash versions the og:image URL so re-exported shares bust
+    // the socials' image caches (X et al. key on the literal URL).
     let title = "Shared ax session";
     let desc = "A recorded AI coding-agent session - every turn, tool call, and dollar.";
+    let manifestText: string | undefined;
     try {
         const res = await fetch(
             `https://gist.githubusercontent.com/${owner}/${gistId}/raw/index.json`,
             { headers: { "user-agent": "ax-share-meta" }, cf: { cacheTtl: 3600, cacheEverything: true } } as RequestInit,
         );
         if (res.ok) {
-            const manifest = (await res.json()) as Manifest;
+            manifestText = await res.text();
+            const manifest = JSON.parse(manifestText) as Manifest;
             title = cleanSummary(manifest.session?.summary) ?? title;
             const t = manifest.totals;
             if (t) {
@@ -67,7 +73,7 @@ export const onRequestGet: PagesFunction<Env> = async (ctx) => {
         // generic copy stands
     }
 
-    const og = `https://ax.necmttn.com/og/${owner}/${gistId}`;
+    const og = buildOgImageUrl(owner, gistId, manifestText);
     const pageUrl = `https://ax.necmttn.com/s/${owner}/${gistId}`;
     const set = (attr: "property" | "name", key: string, content: string) => ({
         selector: `meta[${attr}="${key}"]`,


### PR DESCRIPTION
## Why

X/Twitter, Slack, and Discord cache OG card images keyed by the **literal `og:image` URL**. Our share pages pointed `og:image` at `/og/<owner>/<gistId>` with no version, so poster-template changes (e.g. the r=5→r=6 ASCII logo bump) never propagate to links that were already shared — the platforms serve the stale card forever. Standard fix: put a version/hash param in the URL so a template change mints a URL the platforms treat as a brand-new image.

## What

- **`apps/site/functions/_lib/og-meta.ts`** (new): `OG_RENDER_REV = 6` extracted as the single source of truth for the poster render revision, plus a pure `buildOgImageUrl(owner, gistId, manifestText?)` helper. Underscore dir = not routed by Pages but importable, and it keeps `workers-og` out of the `/s/` bundle (verified: `/s/` bundles to ~3 KB with no wasm).
- **`/og/` renderer**: edge cache key now uses the shared constant (`r=${OG_RENDER_REV}-${variant}`), no behavior change. It ignores the new `?v=` param beyond keying its own edge cache on the full URL — one-time cache fragmentation per new version, which is exactly the desired bust.
- **`/s/` meta rewriter**: `og:image` + `twitter:image` now carry `?v=<rev>-<fnv1a8(manifestText)>`. The hash comes from the gist manifest fetch the rewriter **already does** (`res.text()` instead of `res.json()` — no new network call), so re-exported shares (which rewrite the gist) also bust the social caches. If the manifest fetch fails, the param degrades to `?v=<rev>`.
- **Tests**: `og-meta.test.ts` pins the URL shapes (bare rev, rev+8-hex-hash, determinism, hash changes when the manifest changes). 4 pass.
- Root `functions/og` + `functions/s` mirrors untouched — still pure `onRequestGet` re-exports, and the route files' export surface didn't change.

## Verification

- `bun test` on the new helper: 4/4 pass
- `bun build` of both edge functions resolves the new import; `/s/` bundle contains the versioned URL template
- Site `tsc --noEmit`: no new errors (functions/ isn't in the tsconfig include; pre-existing app/ errors unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)