### PR TITLE
fix(share): bucket turn usage onto kept turns so cost-so-far accumulates

### DIFF
--- a/apps/axctl/src/share/exporter.test.ts
+++ b/apps/axctl/src/share/exporter.test.ts
@@ -1,12 +1,104 @@
 import { describe, expect, it, test } from "bun:test";
 import {
     attachStructuredToolCalls,
+    attachTurnTokenUsage,
     buildShareArtifactFromParts,
     normalizeSessionRecordRef,
 } from "./exporter.ts";
 import type { ShareTurn } from "./artifact.ts";
+import type { TurnTokenUsageDetail } from "@ax/lib/shared/dashboard-types";
 
 const turn = (seq: number, text: string): ShareTurn => ({ id: `t${seq}`, seq, role: "assistant", text });
+
+const usage = (seq: number, over: Partial<TurnTokenUsageDetail> = {}): TurnTokenUsageDetail => ({
+    seq,
+    model: "gpt-5.5",
+    prompt_tokens: 100,
+    completion_tokens: 10,
+    cache_creation_input_tokens: null,
+    cache_read_input_tokens: 50,
+    fresh_input_tokens: 50,
+    estimated_tokens: 110,
+    estimated_input_cost_usd: 0.001,
+    estimated_output_cost_usd: 0.0005,
+    estimated_cache_creation_cost_usd: null,
+    estimated_cache_read_cost_usd: 0.0001,
+    estimated_cost_usd: 0.0016,
+    pricing_source: "built_in",
+    usage_source: "provider",
+    usage_quality: "exact",
+    ...over,
+});
+
+describe("attachTurnTokenUsage", () => {
+    test("exact seq match attaches unchanged", () => {
+        const out = attachTurnTokenUsage([turn(0, "a"), turn(1, "b")], [usage(1)]);
+        expect(out[0]!.token_usage).toBeUndefined();
+        expect(out[1]!.token_usage?.seq).toBe(1);
+        expect(out[1]!.token_usage?.estimated_cost_usd).toBe(0.0016);
+    });
+
+    test("usage on a dropped seq buckets to the nearest preceding kept turn", () => {
+        // Provider event rows (codex token_count) are filtered out of the share
+        // transcript; their usage must land on the preceding kept turn.
+        const out = attachTurnTokenUsage([turn(1, "a"), turn(5, "b"), turn(9, "c")], [usage(7)]);
+        expect(out[0]!.token_usage).toBeUndefined();
+        expect(out[1]!.token_usage?.seq).toBe(5);
+        expect(out[2]!.token_usage).toBeUndefined();
+    });
+
+    test("usage before the first kept turn buckets to the first turn", () => {
+        const out = attachTurnTokenUsage([turn(4, "a"), turn(8, "b")], [usage(2)]);
+        expect(out[0]!.token_usage?.seq).toBe(4);
+    });
+
+    test("several usages in one bucket sum tokens and costs null-aware", () => {
+        const out = attachTurnTokenUsage(
+            [turn(1, "a"), turn(10, "b")],
+            [
+                usage(3, { estimated_cost_usd: 0.5, cache_creation_input_tokens: null }),
+                usage(6, { estimated_cost_usd: 0.25, cache_creation_input_tokens: 30, model: null }),
+            ],
+        );
+        const merged = out[0]!.token_usage!;
+        expect(merged.seq).toBe(1);
+        expect(merged.prompt_tokens).toBe(200);
+        expect(merged.completion_tokens).toBe(20);
+        expect(merged.estimated_tokens).toBe(220);
+        expect(merged.estimated_cost_usd).toBe(0.75);
+        // null + 30 sums to 30; null + null stays null
+        expect(merged.cache_creation_input_tokens).toBe(30);
+        expect(merged.estimated_cache_creation_cost_usd).toBeNull();
+        // first non-null wins for identity fields
+        expect(merged.model).toBe("gpt-5.5");
+    });
+
+    test("pi subagent fixture: every usage row survives and the rail total matches", () => {
+        // Real layout from session 019e729a (codex, gpt-5.5): the DB held 37
+        // usage rows but only 2 seqs intersected the kept share turns, freezing
+        // the viewer's cost-so-far rail. Bucketing must preserve all 37.
+        const keptSeqs = [
+            1, 2, 3, 5, 6, 9, 11, 12, 15, 17, 18, 19, 20, 26, 27, 28, 29, 30, 36, 37, 38, 39,
+            45, 46, 47, 51, 54, 55, 56, 61, 62, 67, 68, 71, 75, 76, 79, 82, 85, 86, 89, 90,
+            91, 92, 97, 100, 103, 104, 105, 109, 110, 114, 115, 118, 119, 120, 121, 126, 127,
+            129, 130, 131, 135, 136, 137, 138, 139, 145, 148, 149, 152, 156, 159, 162, 165,
+            166, 167, 168, 173, 175, 176, 178, 179, 180, 184,
+        ];
+        const usageSeqs = [
+            8, 14, 24, 34, 43, 50, 52, 59, 63, 66, 69, 73, 77, 81, 83, 87, 95, 98, 101, 107,
+            112, 116, 124, 126, 134, 143, 147, 150, 154, 157, 161, 163, 171, 174, 177, 183, 184,
+        ];
+        const out = attachTurnTokenUsage(
+            keptSeqs.map((seq) => turn(seq, "x")),
+            usageSeqs.map((seq) => usage(seq, { estimated_cost_usd: 0.1 })),
+        );
+        const attached = out.filter((t) => t.token_usage != null);
+        const totalCost = attached.reduce((sum, t) => sum + (t.token_usage!.estimated_cost_usd ?? 0), 0);
+        expect(totalCost).toBeCloseTo(0.1 * usageSeqs.length, 10);
+        // cost accumulates across the transcript, not frozen at two turns
+        expect(attached.length).toBeGreaterThan(20);
+    });
+});
 
 describe("attachStructuredToolCalls", () => {
     test("attaches typed tool_calls to the matching empty-text turn", () => {

--- a/apps/axctl/src/share/exporter.ts
+++ b/apps/axctl/src/share/exporter.ts
@@ -251,13 +251,67 @@ const attachTurnContent = (
         return content ? { ...turn, content } : turn;
     });
 
-const attachTurnTokenUsage = (
+type ShareTurnUsage = NonNullable<ShareTurn["token_usage"]>;
+
+const addNullable = (a: number | null | undefined, b: number | null | undefined): number | null =>
+    a == null && b == null ? null : (a ?? 0) + (b ?? 0);
+
+const mergeTurnUsage = (a: ShareTurnUsage, b: ShareTurnUsage, seq: number): ShareTurnUsage => ({
+    seq,
+    model: a.model ?? b.model,
+    prompt_tokens: addNullable(a.prompt_tokens, b.prompt_tokens),
+    completion_tokens: addNullable(a.completion_tokens, b.completion_tokens),
+    cache_creation_input_tokens: addNullable(a.cache_creation_input_tokens, b.cache_creation_input_tokens),
+    cache_read_input_tokens: addNullable(a.cache_read_input_tokens, b.cache_read_input_tokens),
+    fresh_input_tokens: addNullable(a.fresh_input_tokens, b.fresh_input_tokens),
+    estimated_tokens: a.estimated_tokens + b.estimated_tokens,
+    estimated_input_cost_usd: addNullable(a.estimated_input_cost_usd, b.estimated_input_cost_usd),
+    estimated_output_cost_usd: addNullable(a.estimated_output_cost_usd, b.estimated_output_cost_usd),
+    estimated_cache_creation_cost_usd: addNullable(a.estimated_cache_creation_cost_usd, b.estimated_cache_creation_cost_usd),
+    estimated_cache_read_cost_usd: addNullable(a.estimated_cache_read_cost_usd, b.estimated_cache_read_cost_usd),
+    estimated_cost_usd: addNullable(a.estimated_cost_usd, b.estimated_cost_usd),
+    pricing_source: a.pricing_source ?? b.pricing_source,
+    usage_source: a.usage_source,
+    usage_quality: a.usage_quality,
+});
+
+/**
+ * Usage rows are keyed by provider-event seq, but the share transcript keeps
+ * only renderable turns (codex event rows like token_count are filtered out),
+ * so an exact seq join drops most usage and freezes the viewer's cost-so-far
+ * rail. Bucket each usage row onto the nearest kept turn at or before its seq
+ * (the first turn when none precedes it) and sum buckets that collect several
+ * rows, so the cumulative cost over the transcript is preserved.
+ */
+export const attachTurnTokenUsage = (
     turns: ReadonlyArray<ShareTurn>,
     usages: ReadonlyArray<NonNullable<ShareTurn["token_usage"]>>,
 ): ReadonlyArray<ShareTurn> => {
-    const bySeq = new Map(usages.map((usage) => [usage.seq, usage]));
+    if (turns.length === 0 || usages.length === 0) return turns;
+    const keptSeqs = turns.map((turn) => turn.seq).sort((a, b) => a - b);
+    const bucketOf = (seq: number): number => {
+        let lo = 0;
+        let hi = keptSeqs.length - 1;
+        let found = keptSeqs[0]!;
+        while (lo <= hi) {
+            const mid = (lo + hi) >> 1;
+            if (keptSeqs[mid]! <= seq) {
+                found = keptSeqs[mid]!;
+                lo = mid + 1;
+            } else {
+                hi = mid - 1;
+            }
+        }
+        return found;
+    };
+    const buckets = new Map<number, ShareTurnUsage>();
+    for (const usage of usages) {
+        const seq = bucketOf(usage.seq);
+        const prev = buckets.get(seq);
+        buckets.set(seq, prev ? mergeTurnUsage(prev, usage, seq) : { ...usage, seq });
+    }
     return turns.map((turn) => {
-        const tokenUsage = bySeq.get(turn.seq);
+        const tokenUsage = buckets.get(turn.seq);
         return tokenUsage ? { ...turn, token_usage: tokenUsage } : turn;
     });
 };
@@ -400,17 +454,19 @@ export const exportSessionShare = (
             )
         ).filter(isPresent);
 
-        // Build turns: attach structured tool calls, usage + content, then drop
-        // turns that ended up with no text, no content, and no tool calls (empty
-        // assistant / thinking shells) so the shared transcript has no blank rows.
-        const turns = attachTurnContent(
-            attachTurnTokenUsage(
+        // Build turns: attach structured tool calls + content, drop turns that
+        // ended up with no text, no content, and no tool calls (empty assistant
+        // / thinking shells), then attach usage. Usage goes last so it buckets
+        // onto the turns that actually survive into the artifact - attaching
+        // before the filter loses rows whose turn gets dropped.
+        const turns = attachTurnTokenUsage(
+            attachTurnContent(
                 attachStructuredToolCalls(shareTurns, turnToolCallsRaw.filter(isPresent)),
-                turnTokenUsageRaw.filter(isPresent),
+                turnContent,
+            ).filter((turn) =>
+                turn.text.length > 0 || turn.content != null || (turn.tool_calls?.length ?? 0) > 0
             ),
-            turnContent,
-        ).filter((turn) =>
-            turn.text.length > 0 || turn.content != null || (turn.tool_calls?.length ?? 0) > 0
+            turnTokenUsageRaw.filter(isPresent),
         );
 
         // Segmented highlight timeline, computed here (where the DB still is)


### PR DESCRIPTION
## Problem

In the share viewer, the "cost so far" rail freezes while scrolling subagent sessions. On the pi-implementation share (`019e729a`, codex/gpt-5.5) the DB holds **37** `turn_token_usage` rows, but the published artifact carried only **2**.

Root cause: `attachTurnTokenUsage` joins usage→turn by exact seq, but usage rows key off provider-event seqs (codex `token_count` rows) that the exporter filters out of the share transcript. Only seqs that happen to collide survive. A second leak: usage attached *before* the empty-shell turn filter, so usage on a dropped shell vanished too.

## Fix

- Bucket each usage row onto the nearest kept turn with `seq ≤ usage.seq` (first turn when none precedes), binary search over kept seqs.
- Sum multi-row buckets null-aware (`null+null → null`, `null+x → x`); first non-null wins for identity fields (model, pricing_source).
- Attach usage **after** the empty-shell filter so it lands on turns that actually ship.

## Tests

5 new cases in `exporter.test.ts`, including a fixture with the real seq layout from session `019e729a` (85 kept turns vs 37 usage seqs) asserting all 37 rows survive and the cumulative rail total matches. `bun test` on the share suite: 18 pass.

Note: `packages/lib/src/transcript-staleness.test.ts` typecheck error is pre-existing on main (adf4ad2e), untouched here.

Follow-up candidate: the live dashboard DB path (`dashboard/session-inspect.ts:964`) does the same exact-seq join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)