### PR TITLE
fix(ingest): SurrealDB 3.0.x record-list select abort + per-machine bucket paths

### DIFF
--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -23,7 +23,8 @@ import {
 import { prettyPrint } from "@ax/lib/json";
 // Schema is embedded at build time so the compiled binary is self-contained.
 import schemaSurql from "@ax/schema/schema.surql" with { type: "text" };
-import { renderBucketBackends } from "@ax/schema/render";
+import { bucketNames, renderBucketBackends } from "@ax/schema/render";
+import { envConfig as readDbEnvConfig } from "@ax/lib/db";
 
 /**
  * Tagged failure for install steps (surreal resolution, symlinking). Extends
@@ -639,22 +640,24 @@ export function formatDaemonStatus(status: DaemonStatus, json = false): string {
  * back partway - historically a bucket BACKEND path outside the daemon's
  * allowlist (issue #251) - and transcript snapshots silently no-op.
  */
-const EXPECTED_BUCKETS = ["transcripts", "codex_artifacts"];
+const EXPECTED_BUCKETS = bucketNames(schemaSurql);
 
 /**
- * Names from EXPECTED_BUCKETS that are NOT defined on ns=ax/db=main, or null
- * when the daemon could not be queried (down, auth, non-JSON). Plain HTTP so
- * doctor needs no SurrealClient layer.
+ * Names from EXPECTED_BUCKETS that are NOT defined on the configured ns/db,
+ * or null when the daemon could not be queried (down, auth, non-JSON). Plain
+ * HTTP so doctor needs no SurrealClient layer; creds/ns/db come from the same
+ * AX_DB_* env config the rest of ax uses.
  */
 async function probeMissingBuckets(endpoint: { host: string; port: number }): Promise<string[] | null> {
     try {
+        const db = readDbEnvConfig();
         const res = await fetch(`http://${endpoint.host}:${endpoint.port}/sql`, {
             method: "POST",
             headers: {
                 Accept: "application/json",
-                Authorization: `Basic ${Buffer.from("root:root").toString("base64")}`,
-                "surreal-ns": "ax",
-                "surreal-db": "main",
+                Authorization: `Basic ${Buffer.from(`${db.user}:${db.pass}`).toString("base64")}`,
+                "surreal-ns": db.ns,
+                "surreal-db": db.db,
             },
             body: "INFO FOR DB;",
             signal: AbortSignal.timeout(3000),
@@ -732,21 +735,21 @@ export function collectDoctorReport(): Effect.Effect<
                 ok: runtimeStateExists,
                 detail: daemon.endpoint.runtimeStatePath,
             },
-            ...(missingBuckets === null
-                ? []
-                : [{
-                    name: "db-buckets",
-                    ok: missingBuckets.length === 0,
-                    detail: missingBuckets.length === 0
-                        ? `${EXPECTED_BUCKETS.join(", ")} defined`
-                        : `missing bucket(s): ${missingBuckets.join(", ")}; re-run 'axctl install' to re-apply the schema`,
-                }]),
             ...daemon.agents.map((agent): DoctorCheck => ({
                 name: agent.label,
                 ok: !isMacos() || (agent.plistExists && agent.loaded),
                 detail: `${agent.loaded ? "loaded" : "not loaded"}; plist=${agent.plistExists ? "present" : "absent"}`,
             })),
         ];
+        if (missingBuckets !== null) {
+            checks.push({
+                name: "db-buckets",
+                ok: missingBuckets.length === 0,
+                detail: missingBuckets.length === 0
+                    ? `${EXPECTED_BUCKETS.join(", ")} defined`
+                    : `missing bucket(s): ${missingBuckets.join(", ")}; re-run 'axctl install' to re-apply the schema`,
+            });
+        }
         const onboarding = yield* buildOnboardingReport();
         const onboardingChecks: DoctorCheck[] = onboarding.checks.map((c) => ({
             name: `onboarding:${c.id}`,

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -23,6 +23,7 @@ import {
 import { prettyPrint } from "@ax/lib/json";
 // Schema is embedded at build time so the compiled binary is self-contained.
 import schemaSurql from "@ax/schema/schema.surql" with { type: "text" };
+import { renderBucketBackends } from "@ax/schema/render";
 
 /**
  * Tagged failure for install steps (surreal resolution, symlinking). Extends
@@ -44,7 +45,10 @@ const BIN_DIR = posixPath.join(HOME, ".local", "bin");
 const VENDOR_BIN_DIR = posixPath.join(DATA_DIR, "bin");
 
 // Pin to a known-good SurrealDB. Override via env to test newer versions.
-const SURREAL_VERSION = process.env.AXCTL_SURREAL_VERSION ?? "3.0.5";
+// 3.0.x is NOT acceptable for new downloads: `SELECT ... FROM [recordid]`
+// throws "Specify a database to use" (issue #251). The query shape is now
+// version-portable (see @ax/lib/shared/record-select), but pin past the bug.
+const SURREAL_VERSION = process.env.AXCTL_SURREAL_VERSION ?? "3.1.0";
 
 const DB_LABEL = "com.necmttn.ax-db";
 const WATCH_LABEL = "com.necmttn.ax-watch";
@@ -630,6 +634,41 @@ export function formatDaemonStatus(status: DaemonStatus, json = false): string {
     return lines.join("\n");
 }
 
+/**
+ * Buckets schema.surql defines. A missing one means the schema import rolled
+ * back partway - historically a bucket BACKEND path outside the daemon's
+ * allowlist (issue #251) - and transcript snapshots silently no-op.
+ */
+const EXPECTED_BUCKETS = ["transcripts", "codex_artifacts"];
+
+/**
+ * Names from EXPECTED_BUCKETS that are NOT defined on ns=ax/db=main, or null
+ * when the daemon could not be queried (down, auth, non-JSON). Plain HTTP so
+ * doctor needs no SurrealClient layer.
+ */
+async function probeMissingBuckets(endpoint: { host: string; port: number }): Promise<string[] | null> {
+    try {
+        const res = await fetch(`http://${endpoint.host}:${endpoint.port}/sql`, {
+            method: "POST",
+            headers: {
+                Accept: "application/json",
+                Authorization: `Basic ${Buffer.from("root:root").toString("base64")}`,
+                "surreal-ns": "ax",
+                "surreal-db": "main",
+            },
+            body: "INFO FOR DB;",
+            signal: AbortSignal.timeout(3000),
+        });
+        if (!res.ok) return null;
+        const out = (await res.json()) as Array<{ result?: { buckets?: Record<string, unknown> } }>;
+        const buckets = out?.[0]?.result?.buckets;
+        if (buckets === undefined) return null;
+        return EXPECTED_BUCKETS.filter((name) => !(name in buckets));
+    } catch {
+        return null;
+    }
+}
+
 export function collectDoctorReport(): Effect.Effect<
     DoctorReport,
     never,
@@ -650,6 +689,9 @@ export function collectDoctorReport(): Effect.Effect<
         const runtimeStateExists = yield* fs
             .exists(daemon.endpoint.runtimeStatePath)
             .pipe(orAbsent(false));
+        const missingBuckets = daemon.dbListening && daemon.endpoint.conflict === null
+            ? yield* Effect.promise(() => probeMissingBuckets(daemon.endpoint))
+            : null;
         const checks: DoctorCheck[] = [
             {
                 name: "platform",
@@ -690,6 +732,15 @@ export function collectDoctorReport(): Effect.Effect<
                 ok: runtimeStateExists,
                 detail: daemon.endpoint.runtimeStatePath,
             },
+            ...(missingBuckets === null
+                ? []
+                : [{
+                    name: "db-buckets",
+                    ok: missingBuckets.length === 0,
+                    detail: missingBuckets.length === 0
+                        ? `${EXPECTED_BUCKETS.join(", ")} defined`
+                        : `missing bucket(s): ${missingBuckets.join(", ")}; re-run 'axctl install' to re-apply the schema`,
+                }]),
             ...daemon.agents.map((agent): DoctorCheck => ({
                 name: agent.label,
                 ok: !isMacos() || (agent.plistExists && agent.loaded),
@@ -780,9 +831,13 @@ export function cmdInstall(): Effect.Effect<
         console.log(`  wrote:  ${DERIVE_PLIST}`);
         yield* Effect.promise(() => loadAgent(DERIVE_PLIST));
 
-        // Apply schema from embedded resource via surreal import.
+        // Apply schema from embedded resource via surreal import. Bucket
+        // BACKEND paths are rewritten to THIS machine's buckets dir - the
+        // committed schema.surql carries the committing machine's absolute
+        // path, which the daemon's bucket allowlist would deny here,
+        // rolling back the entire import transaction (issue #251).
         const schemaPath = path.join(DATA_DIR, ".schema-cache.surql");
-        yield* fs.writeFileString(schemaPath, schemaSurql);
+        yield* fs.writeFileString(schemaPath, renderBucketBackends(schemaSurql, BUCKETS_DIR));
         const r = spawnSync(
             surrealPath,
             [

--- a/apps/axctl/src/dashboard/session-inspect.ts
+++ b/apps/axctl/src/dashboard/session-inspect.ts
@@ -39,6 +39,7 @@ import { safeKeyPart } from "@ax/lib/shared/derive-keys";
 import { clampPagination, type PaginationConfig } from "@ax/lib/shared/pagination";
 import { toBareSessionId, toSessionRid } from "@ax/lib/shared/session-id";
 import { recordRef } from "@ax/lib/shared/surql";
+import { refListSource } from "@ax/lib/shared/record-select";
 
 const INSPECT_TURNS_PAGINATION: PaginationConfig = { defaultLimit: 2000, maxLimit: 2000 };
 
@@ -660,7 +661,9 @@ const resolveTurnTokenUsageForSourceRefs = (
     const refs = sourceRefs.map((key) => recordRef("turn_token_usage", key));
     if (refs.length === 0) return Effect.succeed(new Map<number, TurnTokenUsageDetail>());
     return queryMany<TurnTokenUsageRow, TurnTokenUsageDetail>(
-        TURN_TOKEN_USAGE_FOR_REFS_SQL.split("$refs").join(`[${refs.join(", ")}]`),
+        // Materialized record-list source - bare `FROM [refs]` throws on
+        // SurrealDB 3.0.x (see @ax/lib/shared/record-select, issue #251).
+        TURN_TOKEN_USAGE_FOR_REFS_SQL.split("$refs").join(refListSource(refs)),
         mapTurnTokenUsageRow,
         "session-inspect resolveTurnTokenUsageForSourceRefs",
     ).pipe(
@@ -687,11 +690,16 @@ const resolveGraphTurnWindow = (
 ): Effect.Effect<ReadonlyArray<GraphTurnRow>, never, SurrealClient> => {
     const turnRefs = turnSourceRefsForWindow(sessionId, turnOffset, turnLimit);
     if (turnRefs.length === 0) return Effect.succeed([]);
-    const from = turnRefs.map((key) => recordRef("turn", key)).join(", ");
+    // pick: turn rows carry full message text in several fields; materialize
+    // only what the projection + WHERE touch (text itself is selected).
+    const from = refListSource(
+        turnRefs.map((key) => recordRef("turn", key)),
+        ["seq", "role", "ts", "text", "has_tool_use"],
+    );
     return queryMany<GraphTurnRow, GraphTurnRow>(
         `
             SELECT seq, role, type::string(ts) AS ts, text
-            FROM [${from}]
+            FROM ${from}
             WHERE text IS NOT NONE OR has_tool_use = true
             ORDER BY seq ASC;
         `,

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1328,14 +1328,14 @@ const relateInvocations = (invocations: Invocation[]) =>
             // the proper scope/dir_path/description on known skills with
             // our 'unknown' placeholder. Idempotent re-runs of ingest stay
             // a no-op for everything that has a real on-disk source.
-            // Record-list selection (`FROM [refs]`), NEVER `FROM skill WHERE
-            // id IN [...]`: the id IN-list form silently matches NOTHING on
-            // the skill table (verified live on SurrealDB 3.1.0 - invariant
-            // documented in @ax/lib/shared/record-select), which made this
-            // lookup return empty and clobbered real skill rows with the
-            // 'unknown' placeholder MERGE below. (The previous comment here
-            // claimed the opposite - that `FROM [...]` returns DatabaseEmpty -
-            // which does not reproduce on 3.1.0: missing records are skipped.)
+            // Materialized record-list selection via selectByIds, NEVER
+            // `FROM skill WHERE id IN [...]` (silently matches NOTHING on the
+            // skill table, which made this lookup return empty and clobbered
+            // real skill rows with the 'unknown' placeholder MERGE below) and
+            // NEVER bare `FROM [refs]` (throws "Specify a database to use" on
+            // SurrealDB 3.0.x - issue #251, aborted every Claude/Codex ingest
+            // on fresh installs). Both invariants are documented + verified
+            // in @ax/lib/shared/record-select.
             const existing = (yield* db.query<[Array<{ name?: string }>]>(
                 selectByIds("name", "skill", [...uniqueSkills].map(skillRecordKey)),
             )) as [Array<{ name?: string }>];

--- a/apps/axctl/src/metrics/cost-estimate.ts
+++ b/apps/axctl/src/metrics/cost-estimate.ts
@@ -19,6 +19,7 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { recordLiteral } from "@ax/lib/ids";
+import { refListSource } from "@ax/lib/shared/record-select";
 import {
     builtInPricingCatalog,
     estimateCost,
@@ -112,14 +113,14 @@ export const loadPricingCatalogForModels = (
             // recordLiteral throws on `/newline/NUL keys - skip rather than defect.
             if (key && !/[`\n\u0000]/.test(key)) keys.add(key);
         }
-        const refs = [...keys].map((k) => recordLiteral("agent_model", k)).join(", ");
+        const refs = refListSource([...keys].map((k) => recordLiteral("agent_model", k)));
         const rows = (yield* db.query<[AgentModelPricingRow[]]>(
             `SELECT name, provider, input_per_million_usd, output_per_million_usd,`
             + ` cache_creation_per_million_usd, cache_read_per_million_usd,`
             + ` input_above_200k_per_million_usd, output_above_200k_per_million_usd,`
             + ` cache_creation_above_200k_per_million_usd, cache_read_above_200k_per_million_usd,`
             + ` fast_multiplier, context_window, pricing_source`
-            + ` FROM [${refs}];`,
+            + ` FROM ${refs};`,
         ))?.[0] ?? [];
         return mergePricingCatalogs(builtInPricingCatalog(), pricingRowsToCatalog(rows));
     });

--- a/apps/axctl/src/metrics/fragility-cascade.ts
+++ b/apps/axctl/src/metrics/fragility-cascade.ts
@@ -234,7 +234,7 @@ export const computeFragilityCascade = (
         //    verification: @ax/lib/shared/record-select).
         const fileInfo = new Map<string, { path: string; repository: string | null }>();
         const fileRows = yield* chunkedQuery(db, [...fragileFiles], limits.chunkSize, (chunk) =>
-            selectByIds("type::string(id) AS id, path, type::string(repository) AS repository", "file", chunk));
+            selectByIds("type::string(id) AS id, path, type::string(repository) AS repository", "file", chunk, ["id", "path", "repository"]));
         for (const r of fileRows) {
             const key = recordKeyPart(r.id, "file");
             const path = str(r.path);
@@ -295,7 +295,9 @@ export const computeFragilityCascade = (
             rawEdits.map((e) => recordKeyPart(e.turn, "turn")).filter((k): k is string => k !== null),
         )];
         const turnRows = yield* chunkedQuery(db, turnKeys, limits.chunkSize, (chunk) =>
-            selectByIds("type::string(id) AS id, type::string(session) AS session", "turn", chunk));
+            // pick: turn rows carry full message text - materialize only the
+            // two fields this projection reads.
+            selectByIds("type::string(id) AS id, type::string(session) AS session", "turn", chunk, ["id", "session"]));
         for (const r of turnRows) {
             const id = str(r.id);
             const session = str(r.session);

--- a/apps/axctl/src/queries/session-turn-content.ts
+++ b/apps/axctl/src/queries/session-turn-content.ts
@@ -7,6 +7,7 @@ import type {
 } from "@ax/lib/shared/dashboard-types";
 import { identityPart } from "@ax/lib/ids";
 import { recordKeyPart } from "@ax/lib/shared/derive-keys";
+import { refListSource } from "@ax/lib/shared/record-select";
 import { interpolateRid, queryMany } from "@ax/lib/shared/graph-query";
 import { toBareSessionId } from "@ax/lib/shared/session-id";
 import { recordRef } from "@ax/lib/shared/surql";
@@ -152,9 +153,9 @@ export const resolveTurnContentForSourceRefs = Effect.fn("queries.resolveTurnCon
     function* (sourceRefs: ReadonlyArray<string>) {
         const refs = [...new Set(sourceRefs)].filter((ref) => ref.length > 0);
         if (refs.length === 0) return new Map<number, InspectTurnContentDto>();
-        const documents = refs
-            .map((ref) => recordRef("content_document", contentDocumentKeyForTurnRef(ref)))
-            .join(", ");
+        const documents = refListSource(
+            refs.map((ref) => recordRef("content_document", contentDocumentKeyForTurnRef(ref))),
+        );
         // Fast inspector path: direct document/block/atom record fetches avoid the
         // multi-second `document IN ...` scans seen on large sessions. Atoms are
         // capped per kind/block so the initial inspect response stays sub-second.
@@ -166,7 +167,7 @@ export const resolveTurnContentForSourceRefs = Effect.fn("queries.resolveTurnCon
             parser_version,
             blockset_hash,
             turn.seq AS turn_seq
-        FROM [${documents}]
+        FROM ${documents}
         ORDER BY turn_seq;
     `, undefined, {
             includeAtoms: false,
@@ -238,7 +239,7 @@ const resolveTurnContentFromDocuments = (
                         start_offset,
                         end_offset,
                         confidence
-                    FROM [${directBlockRefs.join(", ")}]
+                    FROM ${refListSource(directBlockRefs)}
                     ORDER BY document_id, seq;
                 `,
                 (row) => row,
@@ -281,7 +282,7 @@ const resolveTurnContentFromDocuments = (
                         normalized,
                         confidence,
                         raw
-                    FROM [${directAtomRefs.join(", ")}]
+                    FROM ${refListSource(directAtomRefs)}
                     ORDER BY document_id, block_seq, kind, value;
                 `,
                 (row) => row,

--- a/apps/axctl/src/queries/session-turn-content.ts
+++ b/apps/axctl/src/queries/session-turn-content.ts
@@ -155,6 +155,7 @@ export const resolveTurnContentForSourceRefs = Effect.fn("queries.resolveTurnCon
         if (refs.length === 0) return new Map<number, InspectTurnContentDto>();
         const documents = refListSource(
             refs.map((ref) => recordRef("content_document", contentDocumentKeyForTurnRef(ref))),
+            ["id", "source_ref", "parser_id", "parser_version", "blockset_hash", "turn"],
         );
         // Fast inspector path: direct document/block/atom record fetches avoid the
         // multi-second `document IN ...` scans seen on large sessions. Atoms are
@@ -239,7 +240,7 @@ const resolveTurnContentFromDocuments = (
                         start_offset,
                         end_offset,
                         confidence
-                    FROM ${refListSource(directBlockRefs)}
+                    FROM ${refListSource(directBlockRefs, ["id", "document", "seq", "parent_seq", "kind", "role", "heading", "text", "text_excerpt", "start_offset", "end_offset", "confidence"])}
                     ORDER BY document_id, seq;
                 `,
                 (row) => row,
@@ -282,7 +283,7 @@ const resolveTurnContentFromDocuments = (
                         normalized,
                         confidence,
                         raw
-                    FROM ${refListSource(directAtomRefs)}
+                    FROM ${refListSource(directAtomRefs, ["document", "block", "kind", "value", "normalized", "confidence", "raw"])}
                     ORDER BY document_id, block_seq, kind, value;
                 `,
                 (row) => row,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "check:cli-reference": "bun scripts/check-cli-reference.ts",
     "check:release-announcements": "bun scripts/check-release-announcements.ts",
     "check:no-node-fs": "bun scripts/check-no-node-fs.ts",
+    "check:record-select": "bun scripts/check-record-select.ts",
     "check:table-coverage": "bun scripts/check-table-coverage.ts",
     "dashboard:dev": "vite --config apps/axctl/src/dashboard/web/vite.config.ts",
     "dashboard:build": "vite build --config apps/axctl/src/dashboard/web/vite.config.ts",

--- a/packages/lib/src/shared/record-select.test.ts
+++ b/packages/lib/src/shared/record-select.test.ts
@@ -31,3 +31,19 @@ describe("selectByIds", () => {
         expect(sql).not.toContain("WHERE id IN");
     });
 });
+
+describe("pick projection", () => {
+    test("narrows materialization to a destructured field subset", () => {
+        expect(recordListSource("turn", ["t1"], ["id", "session"]))
+            .toBe("[turn:`t1`].map(|$r| $r.{id, session}).filter(|$o| $o != NONE)");
+        expect(refListSource(["turn:`t1`"], ["seq", "text"]))
+            .toBe("[turn:`t1`].map(|$r| $r.{seq, text}).filter(|$o| $o != NONE)");
+        expect(selectByIds("session", "turn", ["t1"], ["id", "session"]))
+            .toBe("SELECT session FROM [turn:`t1`].map(|$r| $r.{id, session}).filter(|$o| $o != NONE);");
+    });
+    test("rejects empty and non-identifier pick fields", () => {
+        expect(() => recordListSource("turn", ["t1"], [])).toThrow(/empty pick/);
+        expect(() => recordListSource("turn", ["t1"], ["a b"])).toThrow(/invalid pick field/);
+        expect(() => refListSource(["turn:`t1`"], ["x;DROP"])).toThrow(/invalid pick field/);
+    });
+});

--- a/packages/lib/src/shared/record-select.test.ts
+++ b/packages/lib/src/shared/record-select.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { recordListSource, refListSource, selectByIds } from "./record-select.ts";
 
+// The `.map(|$r| $r.*).filter(|$o| $o != NONE)` suffix materializes the
+// records before SELECT iterates them - bare `FROM [refs]` throws "Specify a
+// database to use" on SurrealDB 3.0.x (issue #251). See record-select.ts.
+const MATERIALIZE = ".map(|$r| $r.*).filter(|$o| $o != NONE)";
+
 describe("recordListSource", () => {
-    test("backtick-quotes bare keys into a record-list source", () => {
-        expect(recordListSource("file", ["a", "b_c"])).toBe("[file:`a`, file:`b_c`]");
+    test("backtick-quotes bare keys into a materialized record-list source", () => {
+        expect(recordListSource("file", ["a", "b_c"])).toBe(`[file:\`a\`, file:\`b_c\`]${MATERIALIZE}`);
     });
     test("single key", () => {
-        expect(recordListSource("skill", ["v2__x"])).toBe("[skill:`v2__x`]");
+        expect(recordListSource("skill", ["v2__x"])).toBe(`[skill:\`v2__x\`]${MATERIALIZE}`);
     });
     test("throws on an empty key (recordLiteral contract)", () => {
         expect(() => recordListSource("session", [""])).toThrow(/invalid record key/);
@@ -15,14 +20,14 @@ describe("recordListSource", () => {
 
 describe("refListSource", () => {
     test("joins pre-formatted record literals verbatim", () => {
-        expect(refListSource(["session:⟨u-1⟩", "session:`u-2`"])).toBe("[session:⟨u-1⟩, session:`u-2`]");
+        expect(refListSource(["session:⟨u-1⟩", "session:`u-2`"])).toBe(`[session:⟨u-1⟩, session:\`u-2\`]${MATERIALIZE}`);
     });
 });
 
 describe("selectByIds", () => {
-    test("emits the record-list selection statement (NEVER `WHERE id IN`)", () => {
+    test("emits the materialized record-list statement (NEVER `WHERE id IN`)", () => {
         const sql = selectByIds("name", "skill", ["a", "b"]);
-        expect(sql).toBe("SELECT name FROM [skill:`a`, skill:`b`];");
+        expect(sql).toBe(`SELECT name FROM [skill:\`a\`, skill:\`b\`]${MATERIALIZE};`);
         expect(sql).not.toContain("WHERE id IN");
     });
 });

--- a/packages/lib/src/shared/record-select.ts
+++ b/packages/lib/src/shared/record-select.ts
@@ -2,16 +2,23 @@
  * record-select: the ONE reliable shape for bulk fetch-by-record-id, and the
  * single home of the SurrealDB id-IN-list quirk documentation.
  *
- * INVARIANT (verified live against SurrealDB 3.1.0 on 127.0.0.1:8521,
- * 2026-06-10, scratch script run against real rows of every table below):
+ * INVARIANT (verified live against SurrealDB 3.0.5 AND 3.1.0 in-memory
+ * instances, 2026-06-11, plus 3.1.0 on 127.0.0.1:8521 against real rows on
+ * 2026-06-10):
  *
- *   - `SELECT ... FROM [table:`k1`, table:`k2`]` (record-list selection)
- *     resolved every existing record on EVERY table tested: session, turn,
- *     skill, file, commit, tool_call, pull_request. Missing records are
- *     silently skipped (1 real + 1 missing → 1 row; all missing → 0 rows,
- *     no error). The historical claim that `FROM [...]` returns
- *     `DatabaseEmpty` (old transcripts.ts comment) does NOT reproduce on
- *     3.1.0 - it was either version- or context-specific and is gone.
+ *   - Bare record-list selection `SELECT ... FROM [table:`k1`, table:`k2`]`
+ *     works on 3.1.0 but THROWS "Specify a database to use" on 3.0.x even
+ *     with the session namespace/database set (issue #251 - it aborted every
+ *     Claude/Codex ingest on fresh installs, which pinned SurrealDB 3.0.5).
+ *     Parameterized `FROM $ids` fails identically on 3.0.x.
+ *
+ *   - Materializing the records first - `FROM [refs].map(|$r| $r.*)` -
+ *     resolves every existing record on BOTH 3.0.5 and 3.1.0. Missing
+ *     records dereference to NONE; the appended `.filter(|$o| $o != NONE)`
+ *     drops them explicitly (1 real + 1 missing → 1 row; all missing → 0
+ *     rows, no error). Field expressions over the materialized objects -
+ *     aliases, `type::string(id)`, `<string>id` casts - behave exactly as
+ *     they do over a table source. This is the shape both helpers below emit.
  *
  *   - `SELECT ... FROM <table> WHERE id IN [refs]` is UNRELIABLE: with the
  *     exact same refs it matched 0 rows on skill, file, commit, tool_call and
@@ -34,26 +41,34 @@
 import { recordLiteral } from "../ids.ts";
 
 /**
- * A record-list FROM source from bare record keys:
- * `` [table:`k1`, table:`k2`] ``.
+ * Dereference a record-id list into plain objects so the SELECT source is
+ * version-portable (see the 3.0.x invariant above), dropping missing records.
+ */
+const materialized = (refList: string): string =>
+    `${refList}.map(|$r| $r.*).filter(|$o| $o != NONE)`;
+
+/**
+ * A materialized FROM source from bare record keys:
+ * `` [table:`k1`, table:`k2`].map(|$r| $r.*).filter(|$o| $o != NONE) ``.
  *
  * @throws {Error} when any key is empty or contains a backtick/newline/null
  *   byte (see `recordLiteral`). Filter/normalize keys before calling.
  */
 export const recordListSource = (table: string, keys: readonly string[]): string =>
-    `[${keys.map((k) => recordLiteral(table, k)).join(", ")}]`;
+    materialized(`[${keys.map((k) => recordLiteral(table, k)).join(", ")}]`);
 
 /**
- * A record-list FROM source from refs that are ALREADY valid record literals
+ * A materialized FROM source from refs that are ALREADY valid record literals
  * (e.g. strings produced by `type::string(id)` / `<string>id`, which come back
  * as `` table:`key` `` or `table:⟨key⟩`). No escaping is applied - never pass
  * user input through this form.
  */
 export const refListSource = (refs: readonly string[]): string =>
-    `[${refs.join(", ")}]`;
+    materialized(`[${refs.join(", ")}]`);
 
 /**
- * The full bulk fetch-by-id statement: `SELECT <fields> FROM [refs];`.
+ * The full bulk fetch-by-id statement:
+ * `SELECT <fields> FROM [refs].map(|$r| $r.*).filter(|$o| $o != NONE);`.
  * Missing records are skipped; an all-missing list yields zero rows.
  */
 export const selectByIds = (fields: string, table: string, keys: readonly string[]): string =>

--- a/packages/lib/src/shared/record-select.ts
+++ b/packages/lib/src/shared/record-select.ts
@@ -40,12 +40,29 @@
 
 import { recordLiteral } from "../ids.ts";
 
+const IDENT_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 /**
  * Dereference a record-id list into plain objects so the SELECT source is
  * version-portable (see the 3.0.x invariant above), dropping missing records.
+ *
+ * `pick` narrows the materialization to a destructured field subset
+ * (`$r.{a, b}`) - use it on tables with heavy payload fields (e.g. `turn.text`,
+ * `content_block.search_text`) so the server doesn't copy the full record just
+ * to project two columns. It must include EVERY field the surrounding
+ * statement touches: SELECT expressions (`type::string(id)` needs `id`,
+ * `turn.seq` needs `turn`), WHERE, and ORDER BY.
  */
-const materialized = (refList: string): string =>
-    `${refList}.map(|$r| $r.*).filter(|$o| $o != NONE)`;
+const materialized = (refList: string, pick?: readonly string[]): string => {
+    if (pick !== undefined) {
+        if (pick.length === 0) throw new Error("record-select: empty pick");
+        for (const field of pick) {
+            if (!IDENT_RE.test(field)) throw new Error(`record-select: invalid pick field ${JSON.stringify(field)}`);
+        }
+    }
+    const shape = pick === undefined ? "*" : `{${pick.join(", ")}}`;
+    return `${refList}.map(|$r| $r.${shape}).filter(|$o| $o != NONE)`;
+};
 
 /**
  * A materialized FROM source from bare record keys:
@@ -54,8 +71,8 @@ const materialized = (refList: string): string =>
  * @throws {Error} when any key is empty or contains a backtick/newline/null
  *   byte (see `recordLiteral`). Filter/normalize keys before calling.
  */
-export const recordListSource = (table: string, keys: readonly string[]): string =>
-    materialized(`[${keys.map((k) => recordLiteral(table, k)).join(", ")}]`);
+export const recordListSource = (table: string, keys: readonly string[], pick?: readonly string[]): string =>
+    materialized(`[${keys.map((k) => recordLiteral(table, k)).join(", ")}]`, pick);
 
 /**
  * A materialized FROM source from refs that are ALREADY valid record literals
@@ -63,13 +80,13 @@ export const recordListSource = (table: string, keys: readonly string[]): string
  * as `` table:`key` `` or `table:⟨key⟩`). No escaping is applied - never pass
  * user input through this form.
  */
-export const refListSource = (refs: readonly string[]): string =>
-    materialized(`[${refs.join(", ")}]`);
+export const refListSource = (refs: readonly string[], pick?: readonly string[]): string =>
+    materialized(`[${refs.join(", ")}]`, pick);
 
 /**
  * The full bulk fetch-by-id statement:
  * `SELECT <fields> FROM [refs].map(|$r| $r.*).filter(|$o| $o != NONE);`.
  * Missing records are skipped; an all-missing list yields zero rows.
  */
-export const selectByIds = (fields: string, table: string, keys: readonly string[]): string =>
-    `SELECT ${fields} FROM ${recordListSource(table, keys)};`;
+export const selectByIds = (fields: string, table: string, keys: readonly string[], pick?: readonly string[]): string =>
+    `SELECT ${fields} FROM ${recordListSource(table, keys, pick)};`;

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -8,7 +8,11 @@
       "types": "./src/types.ts",
       "import": "./src/types.ts"
     },
-    "./schema.surql": "./src/schema.surql"
+    "./schema.surql": "./src/schema.surql",
+    "./render": {
+      "types": "./src/render.ts",
+      "import": "./src/render.ts"
+    }
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/schema/src/render.test.ts
+++ b/packages/schema/src/render.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import schemaSurql from "./schema.surql" with { type: "text" };
-import { renderBucketBackends } from "./render.ts";
+import { bucketNames, renderBucketBackends } from "./render.ts";
 
 describe("renderBucketBackends", () => {
     test("rewrites every DEFINE BUCKET backend to the given buckets dir", () => {
@@ -23,6 +23,10 @@ describe("renderBucketBackends", () => {
         const rendered = renderBucketBackends(schemaSurql, "/tmp/ax-buckets");
         const rewritten = (rendered.match(/BACKEND "file:\/tmp\/ax-buckets\//g) ?? []).length;
         expect(rewritten).toBe(bucketCount);
+    });
+
+    test("bucketNames lists the shipped buckets in declaration order", () => {
+        expect(bucketNames(schemaSurql)).toEqual(["transcripts", "codex_artifacts"]);
     });
 
     test("leaves non-bucket content untouched", () => {

--- a/packages/schema/src/render.test.ts
+++ b/packages/schema/src/render.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import schemaSurql from "./schema.surql" with { type: "text" };
+import { renderBucketBackends } from "./render.ts";
+
+describe("renderBucketBackends", () => {
+    test("rewrites every DEFINE BUCKET backend to the given buckets dir", () => {
+        const rendered = renderBucketBackends(schemaSurql, "/Users/alice/.local/share/ax/buckets");
+        expect(rendered).toContain(
+            `DEFINE BUCKET IF NOT EXISTS transcripts\n    BACKEND "file:/Users/alice/.local/share/ax/buckets/transcripts";`,
+        );
+        expect(rendered).toContain(
+            `DEFINE BUCKET IF NOT EXISTS codex_artifacts\n    BACKEND "file:/Users/alice/.local/share/ax/buckets/codex_artifacts";`,
+        );
+        // no committed-machine path survives in any bucket backend
+        for (const line of rendered.split("\n")) {
+            if (line.includes('BACKEND "file:')) expect(line).toContain("/Users/alice/");
+        }
+    });
+
+    test("rewrites all DEFINE BUCKET statements in the shipped schema", () => {
+        const bucketCount = (schemaSurql.match(/DEFINE BUCKET IF NOT EXISTS/g) ?? []).length;
+        expect(bucketCount).toBeGreaterThanOrEqual(2);
+        const rendered = renderBucketBackends(schemaSurql, "/tmp/ax-buckets");
+        const rewritten = (rendered.match(/BACKEND "file:\/tmp\/ax-buckets\//g) ?? []).length;
+        expect(rewritten).toBe(bucketCount);
+    });
+
+    test("leaves non-bucket content untouched", () => {
+        const rendered = renderBucketBackends(schemaSurql, "/tmp/ax-buckets");
+        expect(rendered.split("\n").length).toBe(schemaSurql.split("\n").length);
+        expect(rendered).toContain("DEFINE TABLE turn SCHEMAFULL;");
+    });
+});

--- a/packages/schema/src/render.ts
+++ b/packages/schema/src/render.ts
@@ -1,0 +1,26 @@
+/**
+ * Render-time substitutions for schema.surql.
+ *
+ * SurrealQL cannot interpolate env vars, so `DEFINE BUCKET ... BACKEND
+ * "file:<abs path>"` is written with a literal path in schema.surql. That
+ * literal is whatever the committing machine used - shipping it verbatim
+ * pointed fresh installs at the package author's home directory, which the
+ * daemon's `SURREAL_BUCKET_FOLDER_ALLOWLIST` (always the installing user's
+ * data dir) then denied, rolling back the whole schema import transaction
+ * (issue #251). Every apply path must rewrite the bucket paths to the
+ * resolved local buckets dir first.
+ */
+
+const BUCKET_BACKEND_RE = /(DEFINE BUCKET IF NOT EXISTS (\w+)\s+BACKEND\s+")file:[^"]*(")/g;
+
+/**
+ * Rewrite every `DEFINE BUCKET ... BACKEND "file:..."` in `schema` so the
+ * bucket lives at `<bucketsDir>/<bucket name>`. All other content is
+ * untouched. `bucketsDir` must be an absolute path without a trailing slash.
+ */
+export const renderBucketBackends = (schema: string, bucketsDir: string): string =>
+    schema.replace(
+        BUCKET_BACKEND_RE,
+        (_m, prefix: string, name: string, suffix: string) =>
+            `${prefix}file:${bucketsDir}/${name}${suffix}`,
+    );

--- a/packages/schema/src/render.ts
+++ b/packages/schema/src/render.ts
@@ -11,7 +11,7 @@
  * resolved local buckets dir first.
  */
 
-const BUCKET_BACKEND_RE = /(DEFINE BUCKET IF NOT EXISTS (\w+)\s+BACKEND\s+")file:[^"]*(")/g;
+const BUCKET_BACKEND_RE = /(DEFINE BUCKET IF NOT EXISTS (\w+)\s+BACKEND\s+")file:[^"]*"/g;
 
 /**
  * Rewrite every `DEFINE BUCKET ... BACKEND "file:..."` in `schema` so the
@@ -21,6 +21,13 @@ const BUCKET_BACKEND_RE = /(DEFINE BUCKET IF NOT EXISTS (\w+)\s+BACKEND\s+")file
 export const renderBucketBackends = (schema: string, bucketsDir: string): string =>
     schema.replace(
         BUCKET_BACKEND_RE,
-        (_m, prefix: string, name: string, suffix: string) =>
-            `${prefix}file:${bucketsDir}/${name}${suffix}`,
+        (_m, prefix: string, name: string) => `${prefix}file:${bucketsDir}/${name}"`,
     );
+
+/**
+ * Bucket names the schema defines, in declaration order. The single source of
+ * truth for "which buckets must exist" - doctor checks etc. derive from this
+ * instead of hand-maintaining a list that drifts when schema.surql changes.
+ */
+export const bucketNames = (schema: string): string[] =>
+    [...schema.matchAll(/DEFINE BUCKET IF NOT EXISTS (\w+)/g)].map((m) => m[1] as string);

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -148,8 +148,8 @@ DEFINE INDEX IF NOT EXISTS agent_event_session_ts ON agent_event FIELDS agent_se
 -- env vars) and reflect the committing machine. NEVER import this file
 -- verbatim on another machine: every apply path must rewrite the paths to
 -- the local $AX_DATA_DIR/buckets first (issue #251) - axctl install uses
--- renderBucketBackends (packages/schema/src/render.ts); apply-schema.sh
--- and dev-db.sh sed-substitute.
+-- renderBucketBackends (packages/schema/src/render.ts); shell paths go
+-- through apply-schema.sh's sed (dev-db.sh delegates to it).
 
 DEFINE BUCKET IF NOT EXISTS transcripts
     BACKEND "file:/Users/necmttn/.local/share/ax/buckets/transcripts";

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -144,8 +144,12 @@ DEFINE INDEX IF NOT EXISTS agent_event_session_ts ON agent_event FIELDS agent_se
 -- ==== File buckets (SurrealDB 3.0 experimental) ====
 -- Requires: surreal start --allow-experimental files
 --           SURREAL_BUCKET_FOLDER_ALLOWLIST=$AX_DATA_DIR/buckets
--- Bucket paths are hardcoded because SurrealQL does not interpolate env vars.
--- apply-schema.sh warns if $AX_DATA_DIR differs from the default.
+-- Bucket BACKEND paths below are literals (SurrealQL does not interpolate
+-- env vars) and reflect the committing machine. NEVER import this file
+-- verbatim on another machine: every apply path must rewrite the paths to
+-- the local $AX_DATA_DIR/buckets first (issue #251) - axctl install uses
+-- renderBucketBackends (packages/schema/src/render.ts); apply-schema.sh
+-- and dev-db.sh sed-substitute.
 
 DEFINE BUCKET IF NOT EXISTS transcripts
     BACKEND "file:/Users/necmttn/.local/share/ax/buckets/transcripts";

--- a/scripts/apply-schema.sh
+++ b/scripts/apply-schema.sh
@@ -6,6 +6,7 @@ PASS="${AX_DB_PASS:-root}"
 NS="${AX_DB_NS:-ax}"
 DB="${AX_DB_DB:-main}"
 SCHEMA="$(dirname "$0")/../packages/schema/src/schema.surql"
+SURREAL_BIN="${AX_SURREAL_BIN:-surreal}"
 
 # Bucket BACKEND paths in schema.surql carry the committing machine's absolute
 # path (SurrealQL cannot expand env vars). Rewrite them to THIS machine's
@@ -19,7 +20,7 @@ trap 'rm -f "$RENDERED"' EXIT
 sed -E "s|BACKEND \"file:[^\"]*/buckets/([a-zA-Z0-9_]+)\"|BACKEND \"file:$BUCKETS_DIR/\1\"|" \
   "$SCHEMA" > "$RENDERED"
 
-surreal import \
+"$SURREAL_BIN" import \
   --endpoint "http://127.0.0.1:$PORT" \
   --user "$USER" --pass "$PASS" \
   --ns "$NS" --db "$DB" \

--- a/scripts/apply-schema.sh
+++ b/scripts/apply-schema.sh
@@ -7,18 +7,21 @@ NS="${AX_DB_NS:-ax}"
 DB="${AX_DB_DB:-main}"
 SCHEMA="$(dirname "$0")/../packages/schema/src/schema.surql"
 
-# Bucket paths are hardcoded in schema.surql to /Users/necmttn/.local/share/ax/buckets/*
-# because SurrealQL does not expand env vars. Warn if the runtime data dir differs.
+# Bucket BACKEND paths in schema.surql carry the committing machine's absolute
+# path (SurrealQL cannot expand env vars). Rewrite them to THIS machine's
+# buckets dir before import - a mismatched path is denied by the daemon's
+# SURREAL_BUCKET_FOLDER_ALLOWLIST and rolls back the whole import (issue #251).
+# Mirrors renderBucketBackends in packages/schema/src/render.ts.
 DATA_DIR="${AX_DATA_DIR:-$HOME/.local/share/ax}"
-HARDCODED_DATA_DIR="/Users/necmttn/.local/share/ax"
-if [ "$DATA_DIR" != "$HARDCODED_DATA_DIR" ]; then
-  echo "[axctl] WARNING: AX_DATA_DIR=$DATA_DIR but schema buckets point at $HARDCODED_DATA_DIR" >&2
-  echo "[axctl] WARNING: edit packages/schema/src/schema.surql DEFINE BUCKET BACKEND paths to match, or unset AX_DATA_DIR" >&2
-fi
+BUCKETS_DIR="$DATA_DIR/buckets"
+RENDERED="$(mktemp -t ax-schema.XXXXXX.surql)"
+trap 'rm -f "$RENDERED"' EXIT
+sed -E "s|BACKEND \"file:[^\"]*/buckets/([a-zA-Z0-9_]+)\"|BACKEND \"file:$BUCKETS_DIR/\1\"|" \
+  "$SCHEMA" > "$RENDERED"
 
 surreal import \
   --endpoint "http://127.0.0.1:$PORT" \
   --user "$USER" --pass "$PASS" \
   --ns "$NS" --db "$DB" \
-  "$SCHEMA"
-echo "[axctl] schema applied to $NS/$DB"
+  "$RENDERED"
+echo "[axctl] schema applied to $NS/$DB (buckets at $BUCKETS_DIR)"

--- a/scripts/check-record-select.test.ts
+++ b/scripts/check-record-select.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import { isBareRecordListFromLine } from "./check-record-select.ts";
+
+describe("isBareRecordListFromLine", () => {
+    test("flags a bare record-list FROM source", () => {
+        expect(isBareRecordListFromLine("            FROM [${from}]")).toBe(true);
+        expect(isBareRecordListFromLine("`SELECT name FROM [skill:`a`];`")).toBe(true);
+        expect(isBareRecordListFromLine('TURN_SQL.split("$refs").join(`[${refs.join(", ")}]`) + " FROM [x]"')).toBe(true);
+    });
+
+    test("does NOT flag the materialized shape", () => {
+        expect(isBareRecordListFromLine("FROM [skill:`a`].map(|$r| $r.*).filter(|$o| $o != NONE);")).toBe(false);
+    });
+
+    test("does NOT flag helper interpolations", () => {
+        expect(isBareRecordListFromLine("FROM ${refListSource(directBlockRefs)}")).toBe(false);
+        expect(isBareRecordListFromLine("`SELECT name FROM ${recordListSource(\"skill\", keys)};`")).toBe(false);
+    });
+
+    test("does NOT flag comments or non-FROM brackets", () => {
+        expect(isBareRecordListFromLine("// NEVER bare `FROM [refs]` (throws on 3.0.x)")).toBe(false);
+        expect(isBareRecordListFromLine(" * `SELECT ... FROM [table:`k1`]` works on 3.1.0")).toBe(false);
+        expect(isBareRecordListFromLine("WHERE session IN [${sidLiteral}]")).toBe(false);
+    });
+});
+
+test("runtime tree is clean of bare record-list FROM sources", async () => {
+    const proc = Bun.spawn(["bun", "scripts/check-record-select.ts"], {
+        cwd: new URL("..", import.meta.url).pathname,
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+});

--- a/scripts/check-record-select.ts
+++ b/scripts/check-record-select.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+/**
+ * Guard: ban bare record-list FROM sources (`FROM [table:..., ...]`) in
+ * runtime SurrealQL.
+ *
+ * SurrealDB 3.0.x throws "Specify a database to use" on bare record-list
+ * selection even with the session database set (issue #251 - it aborted every
+ * Claude/Codex ingest on fresh installs). The version-portable shape
+ * materializes the records first; @ax/lib/shared/record-select is the only
+ * place allowed to emit it. Any other `FROM [` in a query string is a
+ * regression waiting for a 3.0.x daemon.
+ *
+ * Scope: .ts/.tsx under apps/axctl/src and packages/-star-/src, excluding
+ * test files and record-select.ts itself. Comment lines are skipped so the
+ * invariant docs don't trip the guard.
+ */
+
+import { Glob } from "bun";
+
+const SCAN_GLOBS = [
+    "apps/axctl/src/**/*.ts",
+    "apps/axctl/src/**/*.tsx",
+    "packages/*/src/**/*.ts",
+    "packages/*/src/**/*.tsx",
+];
+
+/** Files allowed to contain `FROM [`. Each entry must carry a reason. */
+const EXCLUDED_FILES: readonly string[] = [
+    // The materialized-shape helpers + the invariant documentation live here.
+    "packages/lib/src/shared/record-select.ts",
+];
+
+const COMMENT_LINE_RE = /^\s*(?:\/\/|\*|\/\*|--)/;
+const BARE_RECORD_LIST_FROM_RE = /\bFROM\s+\[/;
+
+/** True when `line` contains a bare record-list FROM source (not a comment,
+ *  not already materialized on the same line). Exported for tests. */
+export function isBareRecordListFromLine(line: string): boolean {
+    if (COMMENT_LINE_RE.test(line)) return false;
+    if (!BARE_RECORD_LIST_FROM_RE.test(line)) return false;
+    // The helpers append `.map(|$r| ...)` to the list source; a line that
+    // carries the materializer (directly or via refListSource/recordListSource
+    // interpolation) is fine.
+    return !/\.map\(\|\$r\|/.test(line) && !/refListSource|recordListSource|selectByIds/.test(line);
+}
+
+interface Offender {
+    readonly file: string;
+    readonly line: number;
+    readonly text: string;
+}
+
+async function main(): Promise<void> {
+    const excluded = new Set(EXCLUDED_FILES);
+    const seen = new Set<string>();
+    const files: string[] = [];
+    for (const pattern of SCAN_GLOBS) {
+        const glob = new Glob(pattern);
+        for await (const file of glob.scan({ cwd: process.cwd(), onlyFiles: true })) {
+            if (seen.has(file)) continue;
+            seen.add(file);
+            if (file.endsWith(".test.ts") || file.endsWith(".test.tsx")) continue;
+            if (excluded.has(file)) continue;
+            files.push(file);
+        }
+    }
+
+    const offenders: Offender[] = [];
+    for (const file of files.sort()) {
+        const content = await Bun.file(file).text();
+        const lines = content.split("\n");
+        for (let i = 0; i < lines.length; i++) {
+            const text = lines[i] as string;
+            if (isBareRecordListFromLine(text)) {
+                offenders.push({ file, line: i + 1, text: text.trim() });
+            }
+        }
+    }
+
+    if (offenders.length > 0) {
+        console.error("Bare record-list FROM source(s) found (throws on SurrealDB 3.0.x - issue #251):");
+        for (const o of offenders) {
+            console.error(`${o.file}:${o.line}: ${o.text}`);
+        }
+        console.error(
+            `\n${offenders.length} offender(s). Build the source with refListSource/recordListSource/selectByIds from @ax/lib/shared/record-select.`,
+        );
+        process.exit(1);
+    }
+
+    console.log(`check-record-select: clean (${files.length} files scanned, 0 bare record-list FROM sources).`);
+}
+
+if (import.meta.main) {
+    await main();
+}

--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -29,12 +29,13 @@ SURREAL_BIN="${AX_SURREAL_BIN:-$(command -v surreal || true)}"
 healthy() { curl -fsS "http://127.0.0.1:$AX_DB_PORT/health" >/dev/null 2>&1; }
 
 apply_schema() {
-    # schema.surql hardcodes DEFINE BUCKET paths at the STABLE data dir (SurrealQL
-    # cannot expand env vars). Rewrite them to the dev data dir so dev buckets land
-    # under AX_DATA_DIR and match the dev SurrealDB's bucket allowlist.
+    # schema.surql hardcodes DEFINE BUCKET paths at the COMMITTING machine's
+    # data dir (SurrealQL cannot expand env vars). Rewrite whatever path is
+    # committed to the dev data dir so dev buckets land under AX_DATA_DIR and
+    # match the dev SurrealDB's bucket allowlist (issue #251).
     local tmp
     tmp="$(mktemp)"
-    sed "s#$HOME/.local/share/ax/buckets#$AX_DATA_DIR/buckets#g" \
+    sed -E "s|BACKEND \"file:[^\"]*/buckets/([a-zA-Z0-9_]+)\"|BACKEND \"file:$AX_DATA_DIR/buckets/\1\"|" \
         "$ROOT/packages/schema/src/schema.surql" >"$tmp"
     "$SURREAL_BIN" import \
         --endpoint "http://127.0.0.1:$AX_DB_PORT" \

--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -29,21 +29,13 @@ SURREAL_BIN="${AX_SURREAL_BIN:-$(command -v surreal || true)}"
 healthy() { curl -fsS "http://127.0.0.1:$AX_DB_PORT/health" >/dev/null 2>&1; }
 
 apply_schema() {
-    # schema.surql hardcodes DEFINE BUCKET paths at the COMMITTING machine's
-    # data dir (SurrealQL cannot expand env vars). Rewrite whatever path is
-    # committed to the dev data dir so dev buckets land under AX_DATA_DIR and
-    # match the dev SurrealDB's bucket allowlist (issue #251).
-    local tmp
-    tmp="$(mktemp)"
-    sed -E "s|BACKEND \"file:[^\"]*/buckets/([a-zA-Z0-9_]+)\"|BACKEND \"file:$AX_DATA_DIR/buckets/\1\"|" \
-        "$ROOT/packages/schema/src/schema.surql" >"$tmp"
-    "$SURREAL_BIN" import \
-        --endpoint "http://127.0.0.1:$AX_DB_PORT" \
-        --user "$DB_USER" --pass "$DB_PASS" \
-        --ns "$NS" --db "$DB" \
-        "$tmp"
-    rm -f "$tmp"
-    echo "[ax-dev] schema applied to $NS/$DB on :$AX_DB_PORT"
+    # Delegates to apply-schema.sh, which rewrites the committed DEFINE BUCKET
+    # paths to $AX_DATA_DIR/buckets before import (issue #251) - one rewrite
+    # implementation instead of a drifting copy here. AX_DATA_DIR/AX_DB_PORT
+    # are already exported above; pass the rest explicitly.
+    AX_SURREAL_BIN="$SURREAL_BIN" AX_DB_USER="$DB_USER" AX_DB_PASS="$DB_PASS" \
+        AX_DB_NS="$NS" AX_DB_DB="$DB" \
+        "$ROOT/scripts/apply-schema.sh"
 }
 
 stop_db() {


### PR DESCRIPTION
Fixes #251.

## Bug 1 — `DbError: "Specify a database to use"` aborting Claude/Codex ingest

Root cause is **not** a connection losing its `USE` (great forensics in the issue, but the single shared WS connection is fine): SurrealDB **3.0.x has a server-side bug** where record-list selection — `SELECT ... FROM [skill:`...`]` — throws `Specify a database to use` even with the session ns/db set. Parameterized `FROM $ids` fails identically. Fixed upstream in 3.1.0. Reproduced deterministically against in-memory 3.0.5 vs 3.1.0:

```
3.0.5  SELECT name FROM [skill:`v2__finish__fdc1e806fc80ba9c`];  → ERROR Specify a database to use
3.1.0  same                                                      → [{name: 'v2:finish'}]
```

Fresh installs pinned SurrealDB **3.0.5** (`install.ts`), so the first ingested session that invoked a skill hit the `relateInvocations` catalog lookup and the whole Claude/Codex stage aborted — same skill id, frozen session counts, exactly as reported.

Fix:
- All record-list FROM sources now **materialize records first**: `[refs].map(|$r| $r.*).filter(|$o| $o != NONE)` — verified live on both 3.0.5 and 3.1.0, including alias/`type::string(id)`/`<string>id` casts, record-link derefs (`turn.seq`), ORDER BY, and empty lists. Centralized in `@ax/lib/shared/record-select`; the three bare `FROM [...]` sites outside it (`session-turn-content.ts` ×3, `cost-estimate.ts`) now route through `refListSource`.
- Download pin bumped **3.0.5 → 3.1.0** (existing vendored/system 3.0.x stays accepted — the new query shape works there too).

## Bug 2 — bucket schema bakes the author's home path

`schema.surql` `DEFINE BUCKET ... BACKEND "file:/Users/necmttn/..."` shipped verbatim; on any other machine the daemon's `SURREAL_BUCKET_FOLDER_ALLOWLIST` denies it and **rolls back the entire schema import transaction**, leaving no `transcripts`/`codex_artifacts` buckets.

Fix:
- New `@ax/schema/render` → `renderBucketBackends(schema, bucketsDir)`; `axctl install` rewrites bucket paths to the resolved `$AX_DATA_DIR/buckets` before `surreal import`.
- `apply-schema.sh` + `dev-db.sh` do the equivalent sed (dev-db's old sed only matched the author's `$HOME`).
- `axctl doctor` gains a **db-buckets** check (plain HTTP `INFO FOR DB`) that flags missing buckets with a remediation hint — the issue called out that doctor stayed silent.

## Validation

- `bun test` repo-wide: 2899 pass / 0 fail; new `render.test.ts` + updated `record-select.test.ts`.
- `bun run typecheck` clean.
- E2E script ran the real `selectByIds`/`refListSource` output against live 3.0.5 **and** 3.1.0 in-memory instances — identical correct results, missing records skipped.
- `INFO FOR DB` bucket probe shape verified over HTTP on 3.0.5.

## Follow-up (not in this PR)

A single failing file in `transcripts.file` still fails the provider stage rather than skipping the one session; with the deterministic thrower gone this no longer freezes ingest, but per-file isolation would be a good resilience follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)