### PR TITLE
feat(ingest): per-file failure isolation for Claude + Codex stages

### DIFF
--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -45,6 +45,7 @@ import { safeKeyPart } from "@ax/lib/shared/derive-keys";
 import { tokenQualityLabels } from "./token-quality.ts";
 import { estimateCost } from "./model-pricing.ts";
 import { walkJsonlFilesStrict } from "./walk-jsonl.ts";
+import { makeFileFailureCollector } from "./file-isolation.ts";
 
 const DEFAULT_CODEX_RAW_MAX_BYTES = 5 * 1024 * 1024;
 const DEFAULT_CODEX_PROGRESS_EVERY = 10;
@@ -1406,6 +1407,8 @@ export interface CodexStats {
     planSnapshots: number;
     /** JSONL lines skipped at the decode boundary (unparseable / non-record). */
     malformedLines: number;
+    /** Files whose pipeline failed and was skipped (retried next run). */
+    failedFiles: number;
 }
 
 export const ingestCodex = Effect.fn("codex.ingest")(
@@ -1439,6 +1442,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
         let activeFiles = 0;
         const recordCount = () => turnCount + invCount + toolCallCount + planSnapshotCount;
 
+        const failures = makeFileFailureCollector({ source: "codex" });
         yield* Effect.forEach(files.map((file, index) => ({ file, index })), ({ file, index }) => Effect.gen(function* () {
             // Time-box (dry-run calibration): once the deadline passes, start no
             // new files; in-flight ones finish.
@@ -1446,51 +1450,217 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                 return;
             }
             activeFiles += 1;
-            if (opts.onProgress && (index < 5 || index % 10 === 0)) {
-                yield* opts.onProgress({
-                    currentFile: index + 1,
-                    totalFiles: files.length,
-                    currentFileBytes: file.sizeBytes,
-                    totalBytes,
-                    files: fileCount,
-                    bytes: byteCount,
-                    records: recordCount(),
-                    lines: 0,
-                    activeFiles,
-                    phase: 1,
-                    sessions: sessionCount,
-                    turns: turnCount,
-                    invocations: invCount,
-                    toolCalls: toolCallCount,
-                    planSnapshots: planSnapshotCount,
-                });
-            }
-            const filePath = file.path;
-            const fileStartedAt = Date.now();
-            const sizeBytes = file.sizeBytes;
-            const snapshotRaw = shouldSnapshotCodexRaw(sizeBytes, rawMaxBytes);
-            if (!snapshotRaw) {
-                yield* Effect.logDebug("codex raw snapshot skipped", {
-                    file: fileCount + 1,
-                    totalFiles: files.length,
-                    size: formatBytes(sizeBytes),
-                    max: formatBytes(rawMaxBytes),
-                    path: filePath,
-                });
-            }
+            // Per-file failure isolation: a bad transcript (or a rejected
+            // statement) skips THIS file - it is retried next run - instead of
+            // aborting the whole stage (see file-isolation.ts).
+            yield* failures.isolate(file.path, Effect.gen(function* () {
+                if (opts.onProgress && (index < 5 || index % 10 === 0)) {
+                    yield* opts.onProgress({
+                        currentFile: index + 1,
+                        totalFiles: files.length,
+                        currentFileBytes: file.sizeBytes,
+                        totalBytes,
+                        files: fileCount,
+                        bytes: byteCount,
+                        records: recordCount(),
+                        lines: 0,
+                        activeFiles,
+                        phase: 1,
+                        sessions: sessionCount,
+                        turns: turnCount,
+                        invocations: invCount,
+                        toolCalls: toolCallCount,
+                        planSnapshots: planSnapshotCount,
+                    });
+                }
+                const filePath = file.path;
+                const fileStartedAt = Date.now();
+                const sizeBytes = file.sizeBytes;
+                const snapshotRaw = shouldSnapshotCodexRaw(sizeBytes, rawMaxBytes);
+                if (!snapshotRaw) {
+                    yield* Effect.logDebug("codex raw snapshot skipped", {
+                        file: fileCount + 1,
+                        totalFiles: files.length,
+                        size: formatBytes(sizeBytes),
+                        max: formatBytes(rawMaxBytes),
+                        path: filePath,
+                    });
+                }
 
-            const extractor = createCodexExtractor(filePath, payloadMaxBytes);
-            let lineCount = 0;
-            let currentSession: CodexSession | null = null;
-            let sessionUpserted = false;
-            let fileTurns = 0;
-            let fileInvocations = 0;
-            let fileToolCalls = 0;
-            let filePlanSnapshots = 0;
+                const extractor = createCodexExtractor(filePath, payloadMaxBytes);
+                let lineCount = 0;
+                let currentSession: CodexSession | null = null;
+                let sessionUpserted = false;
+                let fileTurns = 0;
+                let fileInvocations = 0;
+                let fileToolCalls = 0;
+                let filePlanSnapshots = 0;
 
-            const emitProgress = (phase: number) =>
-                opts.onProgress
-                    ? opts.onProgress({
+                const emitProgress = (phase: number) =>
+                    opts.onProgress
+                        ? opts.onProgress({
+                            currentFile: index + 1,
+                            totalFiles: files.length,
+                            currentFileBytes: sizeBytes,
+                            totalBytes,
+                            files: fileCount,
+                            bytes: byteCount,
+                            records: recordCount(),
+                            lines: lineCount,
+                            fileTurns,
+                            fileToolCalls,
+                            activeFiles,
+                            phase,
+                            sessions: sessionCount + (sessionUpserted ? 1 : 0),
+                            turns: turnCount,
+                            invocations: invCount,
+                            toolCalls: toolCallCount,
+                            planSnapshots: planSnapshotCount,
+                        })
+                        : Effect.void;
+
+                const upsertSession = (
+                    session: CodexSession,
+                    rawPointer: string | null,
+                ) =>
+                    db.upsert(new RecordId("session", session.id), {
+                        project: session.cwd ?? undefined,
+                        cwd: session.cwd ?? undefined,
+                        model: concreteCodexModel(session) ?? undefined,
+                        source: "codex",
+                        started_at: new Date(session.started_at),
+                        ended_at: new Date(session.ended_at),
+                        raw_file: rawPointer ?? undefined,
+                    });
+
+                let providerEventsCleared = false;
+                const writeBatch = (batch: MutableCodexExtract) =>
+                    Effect.gen(function* () {
+                        if (!batch.session) return;
+                        currentSession = batch.session;
+                        if (!sessionUpserted) {
+                            yield* upsertSession(batch.session, null);
+                            sessionUpserted = true;
+                        }
+                        // Clear pre-existing agent_event rows once, on the first
+                        // batch for this session. Subsequent streaming batches must
+                        // NOT re-clear or they would wipe this ingest's own events.
+                        const clearExisting = !providerEventsCleared;
+                        providerEventsCleared = true;
+                        yield* queryCodexStatements(buildCodexBatchStatements(batch, payloadMaxBytes, clearExisting));
+                        turnCount += batch.turns.length;
+                        fileTurns += batch.turns.length;
+                        toolCallCount += batch.toolCalls.length;
+                        fileToolCalls += batch.toolCalls.length;
+                        invCount += batch.invocations.length;
+                        fileInvocations += batch.invocations.length;
+                        planSnapshotCount += batch.planSnapshots.length;
+                        filePlanSnapshots += batch.planSnapshots.length;
+                    });
+
+                // Stream the file the SAME way the test seams do, via the shared
+                // `streamCodexFile` body (NOT a node fh): `FileSystem.stream` so a
+                // session that VANISHED between discovery and here (e.g. a cleaned-up
+                // session dir) surfaces as a typed NotFound `PlatformError`. The
+                // flush/progress cadence is threaded INTO the per-line Effect (via
+                // `onFlush`/`onProgress`) so a 30 MB session still drains in bounded
+                // batches at `flushEvery` intervals - identical to before. `onLine`
+                // keeps our outer `lineCount` live mid-stream so the progress emitter
+                // sees the running total AND so the NotFound guard below sees the
+                // real count even when the stream fails before returning.
+                //
+                // NotFound handling is GUARDED: a vanished file is only a benign skip
+                // when NOTHING was persisted yet (no line processed AND no session
+                // upserted). If NotFound strikes AFTER a mid-stream flush already wrote
+                // partial rows (`sessionUpserted`), swallowing it would leave a
+                // partial/incomplete session in the DB while reporting "skipped" - a
+                // silent partial ingest. In that case we let it propagate as a loud
+                // stage-level failure instead. Other PlatformErrors always re-raise.
+                const vanished = yield* streamCodexFile(filePath, extractor, {
+                    flushEvery,
+                    onFlush: writeBatch,
+                    onProgress: emitProgress,
+                    onLine: (count) => {
+                        lineCount = count;
+                    },
+                }).pipe(
+                    Effect.as(false),
+                    Effect.catchTag("PlatformError", (e) =>
+                        isNotFound(e) && lineCount === 0 && !sessionUpserted
+                            ? Effect.succeed(true)
+                            : Effect.fail(e),
+                    ),
+                );
+                if (vanished) {
+                    return;
+                }
+
+                const finalBatch = extractor.drain(true);
+                yield* writeBatch(finalBatch);
+                malformedLineCount += extractor.malformedLines();
+                const completedSession = finalBatch.session ?? currentSession;
+                if (!completedSession) {
+                    return;
+                }
+
+                // Snapshot the raw codex jsonl into the `codex_artifacts` bucket as
+                // best-effort cold storage for modest files. Large Codex sessions
+                // are parsed line-by-line above; reading them again just to copy the
+                // raw transcript can dominate benchmark runs.
+                const bucketPath = `${completedSession.id}.jsonl`;
+                const rawContent = snapshotRaw
+                    ? yield* emitProgress(3).pipe(
+                        Effect.andThen(
+                            // Best-effort cold-storage copy: a file that vanished
+                            // after streaming tolerates to null so the snapshot is
+                            // simply skipped - the parsed rows are already persisted.
+                            // Matches `transcripts.ts`: NotFound recovers to null,
+                            // genuine read faults re-raise rather than being silently
+                            // swallowed.
+                            fs.readFileString(filePath).pipe(
+                                skipNotFound(null as string | null),
+                            ),
+                        ),
+                    )
+                    : null;
+                let rawPointer: string | null = null;
+                if (rawContent !== null) {
+                    rawPointer = yield* db
+                        .putFile("codex_artifacts", bucketPath, rawContent)
+                        .pipe(
+                            Effect.map(() => filePointer("codex_artifacts", bucketPath)),
+                            Effect.catch((err) =>
+                                Effect.logDebug("codex raw snapshot failed", {
+                                    sessionId: completedSession.id,
+                                    message: err.message,
+                                }).pipe(Effect.as(null as string | null)),
+                            ),
+                        );
+                }
+
+                // Final session upsert carries the latest ended_at and raw artifact
+                // pointer after the streaming writes have completed.
+                yield* upsertSession(completedSession, rawPointer);
+                fileCount += 1;
+                byteCount += sizeBytes;
+                sessionCount += 1;
+
+                if (!snapshotRaw) {
+                    yield* Effect.logDebug("codex file ingested", {
+                        file: fileCount,
+                        totalFiles: files.length,
+                        bytes: formatBytes(byteCount),
+                        totalBytes: formatBytes(totalBytes),
+                        sessionId: completedSession.id,
+                        ms: Date.now() - fileStartedAt,
+                        lines: lineCount,
+                        turns: fileTurns,
+                        toolCalls: fileToolCalls,
+                    });
+                }
+
+                if (fileCount % progressEvery === 0) {
+                    const counts = {
                         currentFile: index + 1,
                         totalFiles: files.length,
                         currentFileBytes: sizeBytes,
@@ -1502,180 +1672,17 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                         fileTurns,
                         fileToolCalls,
                         activeFiles,
-                        phase,
-                        sessions: sessionCount + (sessionUpserted ? 1 : 0),
+                        phase: 2,
+                        sessions: sessionCount,
                         turns: turnCount,
                         invocations: invCount,
                         toolCalls: toolCallCount,
                         planSnapshots: planSnapshotCount,
-                    })
-                    : Effect.void;
-
-            const upsertSession = (
-                session: CodexSession,
-                rawPointer: string | null,
-            ) =>
-                db.upsert(new RecordId("session", session.id), {
-                    project: session.cwd ?? undefined,
-                    cwd: session.cwd ?? undefined,
-                    model: concreteCodexModel(session) ?? undefined,
-                    source: "codex",
-                    started_at: new Date(session.started_at),
-                    ended_at: new Date(session.ended_at),
-                    raw_file: rawPointer ?? undefined,
-                });
-
-            let providerEventsCleared = false;
-            const writeBatch = (batch: MutableCodexExtract) =>
-                Effect.gen(function* () {
-                    if (!batch.session) return;
-                    currentSession = batch.session;
-                    if (!sessionUpserted) {
-                        yield* upsertSession(batch.session, null);
-                        sessionUpserted = true;
-                    }
-                    // Clear pre-existing agent_event rows once, on the first
-                    // batch for this session. Subsequent streaming batches must
-                    // NOT re-clear or they would wipe this ingest's own events.
-                    const clearExisting = !providerEventsCleared;
-                    providerEventsCleared = true;
-                    yield* queryCodexStatements(buildCodexBatchStatements(batch, payloadMaxBytes, clearExisting));
-                    turnCount += batch.turns.length;
-                    fileTurns += batch.turns.length;
-                    toolCallCount += batch.toolCalls.length;
-                    fileToolCalls += batch.toolCalls.length;
-                    invCount += batch.invocations.length;
-                    fileInvocations += batch.invocations.length;
-                    planSnapshotCount += batch.planSnapshots.length;
-                    filePlanSnapshots += batch.planSnapshots.length;
-                });
-
-            // Stream the file the SAME way the test seams do, via the shared
-            // `streamCodexFile` body (NOT a node fh): `FileSystem.stream` so a
-            // session that VANISHED between discovery and here (e.g. a cleaned-up
-            // session dir) surfaces as a typed NotFound `PlatformError`. The
-            // flush/progress cadence is threaded INTO the per-line Effect (via
-            // `onFlush`/`onProgress`) so a 30 MB session still drains in bounded
-            // batches at `flushEvery` intervals - identical to before. `onLine`
-            // keeps our outer `lineCount` live mid-stream so the progress emitter
-            // sees the running total AND so the NotFound guard below sees the
-            // real count even when the stream fails before returning.
-            //
-            // NotFound handling is GUARDED: a vanished file is only a benign skip
-            // when NOTHING was persisted yet (no line processed AND no session
-            // upserted). If NotFound strikes AFTER a mid-stream flush already wrote
-            // partial rows (`sessionUpserted`), swallowing it would leave a
-            // partial/incomplete session in the DB while reporting "skipped" - a
-            // silent partial ingest. In that case we let it propagate as a loud
-            // stage-level failure instead. Other PlatformErrors always re-raise.
-            const vanished = yield* streamCodexFile(filePath, extractor, {
-                flushEvery,
-                onFlush: writeBatch,
-                onProgress: emitProgress,
-                onLine: (count) => {
-                    lineCount = count;
-                },
-            }).pipe(
-                Effect.as(false),
-                Effect.catchTag("PlatformError", (e) =>
-                    isNotFound(e) && lineCount === 0 && !sessionUpserted
-                        ? Effect.succeed(true)
-                        : Effect.fail(e),
-                ),
-            );
-            if (vanished) {
-                activeFiles -= 1;
-                return;
-            }
-
-            const finalBatch = extractor.drain(true);
-            yield* writeBatch(finalBatch);
-            malformedLineCount += extractor.malformedLines();
-            const completedSession = finalBatch.session ?? currentSession;
-            if (!completedSession) {
-                activeFiles -= 1;
-                return;
-            }
-
-            // Snapshot the raw codex jsonl into the `codex_artifacts` bucket as
-            // best-effort cold storage for modest files. Large Codex sessions
-            // are parsed line-by-line above; reading them again just to copy the
-            // raw transcript can dominate benchmark runs.
-            const bucketPath = `${completedSession.id}.jsonl`;
-            const rawContent = snapshotRaw
-                ? yield* emitProgress(3).pipe(
-                    Effect.andThen(
-                        // Best-effort cold-storage copy: a file that vanished
-                        // after streaming tolerates to null so the snapshot is
-                        // simply skipped - the parsed rows are already persisted.
-                        // Matches `transcripts.ts`: NotFound recovers to null,
-                        // genuine read faults re-raise rather than being silently
-                        // swallowed.
-                        fs.readFileString(filePath).pipe(
-                            skipNotFound(null as string | null),
-                        ),
-                    ),
-                )
-                : null;
-            let rawPointer: string | null = null;
-            if (rawContent !== null) {
-                rawPointer = yield* db
-                    .putFile("codex_artifacts", bucketPath, rawContent)
-                    .pipe(
-                        Effect.map(() => filePointer("codex_artifacts", bucketPath)),
-                        Effect.catch((err) =>
-                            Effect.logDebug("codex raw snapshot failed", {
-                                sessionId: completedSession.id,
-                                message: err.message,
-                            }).pipe(Effect.as(null as string | null)),
-                        ),
-                    );
-            }
-
-            // Final session upsert carries the latest ended_at and raw artifact
-            // pointer after the streaming writes have completed.
-            yield* upsertSession(completedSession, rawPointer);
-            fileCount += 1;
-            byteCount += sizeBytes;
-            sessionCount += 1;
-
-            if (!snapshotRaw) {
-                yield* Effect.logDebug("codex file ingested", {
-                    file: fileCount,
-                    totalFiles: files.length,
-                    bytes: formatBytes(byteCount),
-                    totalBytes: formatBytes(totalBytes),
-                    sessionId: completedSession.id,
-                    ms: Date.now() - fileStartedAt,
-                    lines: lineCount,
-                    turns: fileTurns,
-                    toolCalls: fileToolCalls,
-                });
-            }
-
-            if (fileCount % progressEvery === 0) {
-                const counts = {
-                    currentFile: index + 1,
-                    totalFiles: files.length,
-                    currentFileBytes: sizeBytes,
-                    totalBytes,
-                    files: fileCount,
-                    bytes: byteCount,
-                    records: recordCount(),
-                    lines: lineCount,
-                    fileTurns,
-                    fileToolCalls,
-                    activeFiles,
-                    phase: 2,
-                    sessions: sessionCount,
-                    turns: turnCount,
-                    invocations: invCount,
-                    toolCalls: toolCallCount,
-                    planSnapshots: planSnapshotCount,
-                };
-                if (opts.onProgress) yield* opts.onProgress(counts);
-                yield* Effect.logDebug("codex ingest progress", counts);
-            }
+                    };
+                    if (opts.onProgress) yield* opts.onProgress(counts);
+                    yield* Effect.logDebug("codex ingest progress", counts);
+                }
+            }));
             activeFiles -= 1;
         }).pipe(Effect.withSpan("codex.file", {
             // Basename only: keeps exported-trace attributes small (the full
@@ -1685,6 +1692,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                 "file.bytes": file.sizeBytes,
             },
         })), { concurrency, discard: true });
+        yield* failures.report;
         yield* Effect.logDebug("codex ingest complete", {
             files: fileCount,
             records: recordCount(),
@@ -1703,6 +1711,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
             toolCalls: toolCallCount,
             planSnapshots: planSnapshotCount,
             malformedLines: malformedLineCount,
+            failedFiles: failures.count(),
         } satisfies CodexStats;
     },
 );
@@ -1739,6 +1748,8 @@ export class CodexStageStats extends BaseStageStats.extend<CodexStageStats>("Cod
     toolCallsIngested: Schema.Number,
     /** JSONL lines skipped at the decode boundary (unparseable / non-record). */
     malformedLines: Schema.Number,
+    /** Files whose pipeline failed and was skipped (retried next run). */
+    failedFiles: Schema.Number,
 }) {}
 
 export const codexStage: StageDef<CodexStageStats, SurrealClient | AxConfig | FileSystem.FileSystem | Path.Path> = {
@@ -1759,11 +1770,13 @@ export const codexStage: StageDef<CodexStageStats, SurrealClient | AxConfig | Fi
         return CodexStageStats.make({
             durationMs: Date.now() - t0,
             summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls` +
-                (result.malformedLines > 0 ? `, ${result.malformedLines} malformed lines skipped` : ""),
+                (result.malformedLines > 0 ? `, ${result.malformedLines} malformed lines skipped` : "") +
+                (result.failedFiles > 0 ? `, ${result.failedFiles} file(s) failed (retry next run)` : ""),
             sessionsIngested: result.sessions,
             turnsIngested: result.turns,
             toolCallsIngested: result.toolCalls,
             malformedLines: result.malformedLines,
+            failedFiles: result.failedFiles,
         });
     }),
 };

--- a/apps/axctl/src/ingest/file-isolation.test.ts
+++ b/apps/axctl/src/ingest/file-isolation.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Exit } from "effect";
+import { DbError } from "@ax/lib/errors";
+import { makeFileFailureCollector } from "./file-isolation.ts";
+
+const queryError = (message: string) => new DbError({ operation: "query", message });
+const connectError = () => new DbError({ operation: "connect", message: "daemon not reachable" });
+
+const run = <A, E>(eff: Effect.Effect<A, E>) => Effect.runPromiseExit(eff);
+
+describe("makeFileFailureCollector", () => {
+    test("success passes through and records nothing", async () => {
+        const c = makeFileFailureCollector({ source: "test" });
+        const exit = await run(c.isolate("/a.jsonl", Effect.succeed(42)));
+        expect(exit).toEqual(Exit.succeed(42));
+        expect(c.count()).toBe(0);
+        expect(c.failures).toEqual([]);
+    });
+
+    test("a typed failure is swallowed, recorded, and yields undefined", async () => {
+        const c = makeFileFailureCollector({ source: "test" });
+        const exit = await run(c.isolate("/bad.jsonl", Effect.fail(queryError("boom"))));
+        expect(exit).toEqual(Exit.succeed(undefined));
+        expect(c.count()).toBe(1);
+        expect(c.failures).toEqual([{ filePath: "/bad.jsonl", tag: "DbError", message: "boom" }]);
+    });
+
+    test("connection errors propagate (stage must abort)", async () => {
+        const c = makeFileFailureCollector({ source: "test" });
+        const exit = await run(c.isolate("/a.jsonl", Effect.fail(connectError())));
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(c.count()).toBe(0);
+    });
+
+    test("a failure storm aborts after the threshold", async () => {
+        const c = makeFileFailureCollector({ source: "test", stormThreshold: 3 });
+        expect(Exit.isSuccess(await run(c.isolate("/1", Effect.fail(queryError("x")))))).toBe(true);
+        expect(Exit.isSuccess(await run(c.isolate("/2", Effect.fail(queryError("x")))))).toBe(true);
+        const third = await run(c.isolate("/3", Effect.fail(queryError("x"))));
+        expect(Exit.isFailure(third)).toBe(true);
+        if (Exit.isFailure(third)) {
+            expect(String(third.cause)).toContain("3 consecutive files failed");
+        }
+    });
+
+    test("an interleaved success resets the storm counter", async () => {
+        const c = makeFileFailureCollector({ source: "test", stormThreshold: 3 });
+        await run(c.isolate("/1", Effect.fail(queryError("x"))));
+        await run(c.isolate("/2", Effect.fail(queryError("x"))));
+        await run(c.isolate("/ok", Effect.succeed(1)));
+        const next = await run(c.isolate("/3", Effect.fail(queryError("x"))));
+        expect(Exit.isSuccess(next)).toBe(true);
+        expect(c.count()).toBe(3);
+    });
+
+    test("detail list caps but the count keeps growing", async () => {
+        const c = makeFileFailureCollector({ source: "test", stormThreshold: 1000 });
+        for (let i = 0; i < 30; i++) {
+            // alternate success to dodge the storm counter
+            await run(c.isolate("/ok", Effect.succeed(1)));
+            await run(c.isolate(`/f${i}`, Effect.fail(queryError("x"))));
+        }
+        expect(c.count()).toBe(30);
+        expect(c.failures.length).toBe(25);
+    });
+
+    test("defects are not isolated", async () => {
+        const c = makeFileFailureCollector({ source: "test" });
+        const exit = await run(c.isolate("/a", Effect.die(new Error("bug"))));
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(c.count()).toBe(0);
+    });
+
+    test("report is a no-op at zero failures and logs otherwise", async () => {
+        const clean = makeFileFailureCollector({ source: "test" });
+        await Effect.runPromise(clean.report);
+        const dirty = makeFileFailureCollector({ source: "test" });
+        await run(dirty.isolate("/bad", Effect.fail(queryError("boom"))));
+        await Effect.runPromise(dirty.report);
+        expect(dirty.count()).toBe(1);
+    });
+});

--- a/apps/axctl/src/ingest/file-isolation.ts
+++ b/apps/axctl/src/ingest/file-isolation.ts
@@ -1,0 +1,131 @@
+/**
+ * Per-file failure isolation for transcript ingest loops.
+ *
+ * One corrupt transcript (or one statement the daemon rejects) must not abort
+ * the whole provider stage: before this seam existed, the first failing file
+ * froze every session ordered after it on every run (issue #251 was the
+ * deterministic version of that). Each file's pipeline is wrapped in
+ * {@link FileFailureCollector.isolate}: typed failures are recorded and
+ * swallowed - the file's watermark never commits, so the next run retries it
+ * - while the stage keeps going.
+ *
+ * Two classes of failure still abort the stage, on purpose:
+ *
+ *  - connection loss (`DbError` with `operation: "connect"`): nothing after
+ *    it can succeed, and per-file "isolation" would just spray one failure
+ *    per remaining file;
+ *  - a failure storm: `stormThreshold` consecutive failures with no success
+ *    in between means the problem is systemic (wedged daemon, broken session,
+ *    schema drift), not file-local. Counted approximately under concurrency -
+ *    interleaved successes reset it - which is the behavior we want: any
+ *    success proves the pipeline itself still works.
+ *
+ * Defects (Effect.die) are never isolated - they indicate bugs, not bad input.
+ */
+
+import { Effect } from "effect";
+import { DbError } from "@ax/lib/errors";
+
+export interface FileFailure {
+    readonly filePath: string;
+    /** Error tag (`DbError`, `SkillParseError`, ...) or constructor name. */
+    readonly tag: string;
+    readonly message: string;
+}
+
+/** Failures whose detail we keep; beyond this only the count grows. */
+const DETAIL_CAP = 25;
+
+/** Consecutive failures (no success in between) that abort the stage. */
+const DEFAULT_STORM_THRESHOLD = 10;
+
+const failureTag = (err: unknown): string => {
+    if (typeof err === "object" && err !== null && "_tag" in err && typeof err._tag === "string") return err._tag;
+    if (err instanceof Error) return err.name;
+    return "Unknown";
+};
+
+const failureMessage = (err: unknown): string =>
+    err instanceof Error ? err.message : String(err);
+
+const isConnectionError = (err: unknown): boolean =>
+    err instanceof DbError && err.operation === "connect";
+
+export interface FileFailureCollector {
+    /** Recorded failure details, insertion order, capped at {@link DETAIL_CAP}. */
+    readonly failures: ReadonlyArray<FileFailure>;
+    /** Total failed-file count (not capped). */
+    readonly count: () => number;
+    /**
+     * Run one file's pipeline with failures isolated: a typed failure is
+     * recorded + logged and the effect succeeds with `undefined`, except for
+     * connection errors and failure storms, which fail with `DbError` so the
+     * stage aborts. Defects propagate untouched.
+     */
+    readonly isolate: <A, E, R>(
+        filePath: string,
+        eff: Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A | undefined, DbError, R>;
+    /** Log the aggregate (warn) when anything failed. Call once after the loop. */
+    readonly report: Effect.Effect<void>;
+}
+
+export interface FileFailureCollectorOptions {
+    /** Provider label for log lines, e.g. "claude" / "codex". */
+    readonly source: string;
+    readonly stormThreshold?: number;
+}
+
+export const makeFileFailureCollector = (
+    opts: FileFailureCollectorOptions,
+): FileFailureCollector => {
+    const stormThreshold = opts.stormThreshold ?? DEFAULT_STORM_THRESHOLD;
+    const failures: FileFailure[] = [];
+    let total = 0;
+    let consecutive = 0;
+
+    const isolate = <A, E, R>(
+        filePath: string,
+        eff: Effect.Effect<A, E, R>,
+    ): Effect.Effect<A | undefined, DbError, R> =>
+        eff.pipe(
+            Effect.tap(() => Effect.sync(() => { consecutive = 0; })),
+            Effect.catch((err) =>
+                Effect.gen(function* () {
+                    if (isConnectionError(err)) return yield* err as DbError;
+                    total += 1;
+                    consecutive += 1;
+                    if (failures.length < DETAIL_CAP) {
+                        failures.push({ filePath, tag: failureTag(err), message: failureMessage(err) });
+                    }
+                    yield* Effect.logWarning(`${opts.source} ingest: file failed, skipping (will retry next run)`, {
+                        filePath,
+                        tag: failureTag(err),
+                        message: failureMessage(err),
+                    });
+                    if (consecutive >= stormThreshold) {
+                        return yield* new DbError({
+                            operation: "query",
+                            message:
+                                `${opts.source} ingest aborted: ${consecutive} consecutive files failed ` +
+                                `(${total} total) - systemic failure, not bad input. Last: ${filePath}: ${failureMessage(err)}`,
+                        });
+                    }
+                    return undefined;
+                }),
+            ),
+        );
+
+    return {
+        failures,
+        count: () => total,
+        isolate,
+        report: Effect.suspend(() => {
+            if (total === 0) return Effect.void;
+            return Effect.logWarning(`${opts.source} ingest: ${total} file(s) failed and were skipped; they retry next run`, {
+                failures: failures.map((f) => `${f.filePath}: [${f.tag}] ${f.message}`),
+                detailCapped: total > failures.length,
+            });
+        }),
+    };
+};

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -64,6 +64,7 @@ import {
 } from "@ax/lib/shared/surql";
 import { safeKeyPart } from "@ax/lib/shared/derive-keys";
 import { estimateCost, normalizeModelName } from "./model-pricing.ts";
+import { makeFileFailureCollector } from "./file-isolation.ts";
 import {
     extractClaudeCompaction,
     type CompactionWrite,
@@ -1602,6 +1603,8 @@ export interface TranscriptStats {
     hookCommandInvocations: number;
     /** JSONL lines skipped at the decode boundary (unparseable / non-record). */
     malformedLines: number;
+    /** Files whose pipeline failed and was skipped (retried next run). */
+    failedFiles: number;
 }
 
 export const ingestTranscripts = Effect.fn("transcripts.ingest")(
@@ -1734,6 +1737,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
             forceEnv: "AX_REDERIVE_CLAUDE",
         });
 
+        const failures = makeFileFailureCollector({ source: "claude" });
         yield* Effect.forEach(candidates.map((candidate, index) => ({ candidate, index })), ({ candidate, index }) => Effect.gen(function* () {
             // Time-box (dry-run calibration): once the deadline passes, start no
             // new files. In-flight ones finish, so the sample is whatever
@@ -1748,123 +1752,128 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                 return;
             }
             activeFiles += 1;
-            if (opts.onProgress && (index < 5 || index % 10 === 0)) {
-                yield* opts.onProgress({
-                    currentFile: index + 1,
-                    totalFiles: candidates.length,
-                    files,
-                    activeFiles,
-                    records: recordCount(),
-                    sessions,
-                    turns: turnCount,
-                    invocations: invCount,
-                    edits: editCount,
-                    toolCalls: toolCallCount,
-                    planSnapshots: planSnapshotCount,
-                    hookEvents: hookEventCount,
-                    hookCommandInvocations: hookCommandInvocationCount,
-                });
-            }
-            // A transcript that VANISHED between discovery and here (e.g. a
-            // git worktree cleaned up mid-run) surfaces as a typed
-            // PlatformError; NotFound→null SKIPS it. The skip short-circuits
-            // BEFORE `files += 1` / `wm.commit` below, so a vanished file never
-            // advances the watermark. Non-NotFound failures re-raise.
-            const extracted = yield* extractFile(candidate.filePath, candidate.projectDir).pipe(
-                skipNotFound(null),
-                Effect.withSpan("transcripts.parse", {
-                    attributes: { "file.size": candidate.size },
-                }),
-            );
-            if (!extracted) {
-                activeFiles -= 1;
-                return;
-            }
-            files += 1;
-            malformedLineCount += extracted.malformedLines;
-            const pointer = yield* snapshotTranscript(
-                extracted.session.id,
-                candidate.filePath,
-            );
-            extracted.session.raw_file = pointer;
-            yield* upsertSessions([extracted.session]);
-            sessions += 1;
-            yield* writeClaudeTokenUsage(extracted);
-            // Resolve invoked names onto the catalog before writing so the
-            // `invoked` and `concerns` edges land on the real skill row.
-            const resolvedInvocations = extracted.invocations.map((inv) => ({
-                ...inv,
-                skill: resolveSkillName(inv.skill, skillCatalog) ?? inv.skill,
+            // Per-file failure isolation: a bad transcript (or a rejected
+            // statement) skips THIS file - it is retried next run - instead of
+            // aborting the whole stage (see file-isolation.ts).
+            yield* failures.isolate(candidate.filePath, Effect.gen(function* () {
+                if (opts.onProgress && (index < 5 || index % 10 === 0)) {
+                    yield* opts.onProgress({
+                        currentFile: index + 1,
+                        totalFiles: candidates.length,
+                        files,
+                        activeFiles,
+                        records: recordCount(),
+                        sessions,
+                        turns: turnCount,
+                        invocations: invCount,
+                        edits: editCount,
+                        toolCalls: toolCallCount,
+                        planSnapshots: planSnapshotCount,
+                        hookEvents: hookEventCount,
+                        hookCommandInvocations: hookCommandInvocationCount,
+                    });
+                }
+                // A transcript that VANISHED between discovery and here (e.g. a
+                // git worktree cleaned up mid-run) surfaces as a typed
+                // PlatformError; NotFound→null SKIPS it. The skip short-circuits
+                // BEFORE `files += 1` / `wm.commit` below, so a vanished file never
+                // advances the watermark. Non-NotFound failures re-raise.
+                const extracted = yield* extractFile(candidate.filePath, candidate.projectDir).pipe(
+                    skipNotFound(null),
+                    Effect.withSpan("transcripts.parse", {
+                        attributes: { "file.size": candidate.size },
+                    }),
+                );
+                if (!extracted) {
+                    return;
+                }
+                files += 1;
+                malformedLineCount += extracted.malformedLines;
+                const pointer = yield* snapshotTranscript(
+                    extracted.session.id,
+                    candidate.filePath,
+                );
+                extracted.session.raw_file = pointer;
+                yield* upsertSessions([extracted.session]);
+                sessions += 1;
+                yield* writeClaudeTokenUsage(extracted);
+                // Resolve invoked names onto the catalog before writing so the
+                // `invoked` and `concerns` edges land on the real skill row.
+                const resolvedInvocations = extracted.invocations.map((inv) => ({
+                    ...inv,
+                    skill: resolveSkillName(inv.skill, skillCatalog) ?? inv.skill,
+                }));
+                const resolvedSkillRelations = extracted.skillRelations.map((rel) => ({
+                    ...rel,
+                    skillName: resolveSkillName(rel.skillName, skillCatalog) ?? rel.skillName,
+                }));
+                // Seven per-section writes collapsed into ONE normalized-batch
+                // write. transcripts.parity.test.ts keeps golden-shape coverage
+                // for the normalized provider/session/event/turn/tool/plan rows;
+                // token usage above and invoked-edges/hooks below stay separate
+                // per the gap analysis.
+                yield* queryTranscriptStatements(
+                    buildNormalizedTranscriptStatements(
+                        toClaudeNormalizedBatch(extracted, resolvedSkillRelations),
+                    ),
+                    "normalizedBatch",
+                );
+                turnCount += extracted.turns.length;
+                toolCallCount += extracted.toolCalls.length;
+                planSnapshotCount += extracted.planSnapshots.length;
+                yield* relateInvocations(resolvedInvocations);
+                invCount += resolvedInvocations.length;
+                yield* writeHookEvidence(extracted.hookEvents, extracted.hookCommandInvocations);
+                hookEventCount += extracted.hookEvents.length;
+                hookCommandInvocationCount += extracted.hookCommandInvocations.length;
+                editCount += extracted.edits.length;
+                if (opts.onProgress && (files <= 5 || files % 10 === 0)) {
+                    yield* opts.onProgress({
+                        currentFile: index + 1,
+                        totalFiles: candidates.length,
+                        files,
+                        activeFiles,
+                        records: recordCount(),
+                        sessions,
+                        turns: turnCount,
+                        invocations: invCount,
+                        edits: editCount,
+                        toolCalls: toolCallCount,
+                        planSnapshots: planSnapshotCount,
+                        hookEvents: hookEventCount,
+                        hookCommandInvocations: hookCommandInvocationCount,
+                    });
+                }
+                if (files % 50 === 0) {
+                    const counts = {
+                        currentFile: index + 1,
+                        totalFiles: candidates.length,
+                        files,
+                        activeFiles,
+                        records: recordCount(),
+                        sessions,
+                        turns: turnCount,
+                        invocations: invCount,
+                        edits: editCount,
+                        toolCalls: toolCallCount,
+                        planSnapshots: planSnapshotCount,
+                        hookEvents: hookEventCount,
+                        hookCommandInvocations: hookCommandInvocationCount,
+                    };
+                    if (opts.onProgress) yield* opts.onProgress(counts);
+                    yield* Effect.logDebug("transcript ingest progress", {
+                        ...counts,
+                    });
+                }
+                // Record the watermark only after every write for this file
+                // succeeded, so a mid-file failure re-processes next run.
+                yield* wm.commit(candidate.filePath, candidate.mtimeMs, candidate.size);
             }));
-            const resolvedSkillRelations = extracted.skillRelations.map((rel) => ({
-                ...rel,
-                skillName: resolveSkillName(rel.skillName, skillCatalog) ?? rel.skillName,
-            }));
-            // Seven per-section writes collapsed into ONE normalized-batch
-            // write. transcripts.parity.test.ts keeps golden-shape coverage
-            // for the normalized provider/session/event/turn/tool/plan rows;
-            // token usage above and invoked-edges/hooks below stay separate
-            // per the gap analysis.
-            yield* queryTranscriptStatements(
-                buildNormalizedTranscriptStatements(
-                    toClaudeNormalizedBatch(extracted, resolvedSkillRelations),
-                ),
-                "normalizedBatch",
-            );
-            turnCount += extracted.turns.length;
-            toolCallCount += extracted.toolCalls.length;
-            planSnapshotCount += extracted.planSnapshots.length;
-            yield* relateInvocations(resolvedInvocations);
-            invCount += resolvedInvocations.length;
-            yield* writeHookEvidence(extracted.hookEvents, extracted.hookCommandInvocations);
-            hookEventCount += extracted.hookEvents.length;
-            hookCommandInvocationCount += extracted.hookCommandInvocations.length;
-            editCount += extracted.edits.length;
-            if (opts.onProgress && (files <= 5 || files % 10 === 0)) {
-                yield* opts.onProgress({
-                    currentFile: index + 1,
-                    totalFiles: candidates.length,
-                    files,
-                    activeFiles,
-                    records: recordCount(),
-                    sessions,
-                    turns: turnCount,
-                    invocations: invCount,
-                    edits: editCount,
-                    toolCalls: toolCallCount,
-                    planSnapshots: planSnapshotCount,
-                    hookEvents: hookEventCount,
-                    hookCommandInvocations: hookCommandInvocationCount,
-                });
-            }
-            if (files % 50 === 0) {
-                const counts = {
-                    currentFile: index + 1,
-                    totalFiles: candidates.length,
-                    files,
-                    activeFiles,
-                    records: recordCount(),
-                    sessions,
-                    turns: turnCount,
-                    invocations: invCount,
-                    edits: editCount,
-                    toolCalls: toolCallCount,
-                    planSnapshots: planSnapshotCount,
-                    hookEvents: hookEventCount,
-                    hookCommandInvocations: hookCommandInvocationCount,
-                };
-                if (opts.onProgress) yield* opts.onProgress(counts);
-                yield* Effect.logDebug("transcript ingest progress", {
-                    ...counts,
-                });
-            }
-            // Record the watermark only after every write for this file
-            // succeeded, so a mid-file failure re-processes next run.
-            yield* wm.commit(candidate.filePath, candidate.mtimeMs, candidate.size);
             activeFiles -= 1;
         }).pipe(Effect.withSpan("transcripts.file", {
             attributes: { "file.path": candidate.filePath, "file.size": candidate.size },
         })), { concurrency, discard: true });
+        yield* failures.report;
         yield* Effect.logDebug("transcript ingest complete", {
             files,
             records: recordCount(),
@@ -1889,6 +1898,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
             hookEvents: hookEventCount,
             hookCommandInvocations: hookCommandInvocationCount,
             malformedLines: malformedLineCount,
+            failedFiles: failures.count(),
         } satisfies TranscriptStats;
     },
 );
@@ -1924,6 +1934,8 @@ export class ClaudeStats extends BaseStageStats.extend<ClaudeStats>("ClaudeStats
     toolCallsIngested: Schema.Number,
     /** JSONL lines skipped at the decode boundary (unparseable / non-record). */
     malformedLines: Schema.Number,
+    /** Files whose pipeline failed and was skipped (retried next run). */
+    failedFiles: Schema.Number,
 }) {}
 
 export const claudeStage: StageDef<ClaudeStats, SurrealClient | AxConfig | FileSystem.FileSystem | Path.Path> = {
@@ -1944,11 +1956,13 @@ export const claudeStage: StageDef<ClaudeStats, SurrealClient | AxConfig | FileS
         return ClaudeStats.make({
             durationMs: Date.now() - t0,
             summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls` +
-                (result.malformedLines > 0 ? `, ${result.malformedLines} malformed lines skipped` : ""),
+                (result.malformedLines > 0 ? `, ${result.malformedLines} malformed lines skipped` : "") +
+                (result.failedFiles > 0 ? `, ${result.failedFiles} file(s) failed (retry next run)` : ""),
             sessionsIngested: result.sessions,
             turnsIngested: result.turns,
             toolCallsIngested: result.toolCalls,
             malformedLines: result.malformedLines,
+            failedFiles: result.failedFiles,
         });
     }),
 };


### PR DESCRIPTION
Follow-up to #253 / #251: with the deterministic thrower fixed, make the stage shape itself resilient — one bad file should cost one file, not the provider.

## What

New seam `apps/axctl/src/ingest/file-isolation.ts`: each file's pipeline in the Claude (`transcripts.file`) and Codex (`codex.file`) loops runs inside `failures.isolate(filePath, ...)`.

| failure | behavior |
|---|---|
| typed per-file failure (DbError on a statement, parse error) | recorded + warned, file skipped, watermark uncommitted → retried next run |
| `DbError operation=connect` | propagates — stage aborts (nothing after it can succeed) |
| 10 consecutive failures, zero successes between | propagates aggregated DbError — systemic breakage (wedged daemon, schema drift), not bad input |
| defect (`Effect.die`) | propagates untouched — bugs are not bad input |

Stats: `TranscriptStats`/`CodexStats` + both stage schemas gain `failedFiles`; stage summary appends `N file(s) failed (retry next run)`. Failure details (capped at 25, total uncapped) logged as one aggregate warning after the loop.

The inner early-exit `activeFiles -= 1` decrements moved to a single decrement after `isolate()`, so the progress gauge balances on every path (success, early return, swallowed failure).

## Why the storm threshold

Pre-#253, the record-list bug failed *every* skill-invoking file. Pure isolation would have reported "2,990 files failed" as a successful run. Ten consecutive failures with no interleaved success means the pipeline itself is broken — abort loudly. Any single success resets the counter (the count is approximate under concurrency, which is the desired semantics: a success proves the pipeline works).

## Validation

- 8 new unit tests on the collector (passthrough, swallow+record, connect propagation, storm abort, reset-on-success, detail cap, defect passthrough, report).
- Full suite: 2915 pass / 0 fail; typecheck clean.

## Not in scope

- Pi/OpenCode/Cursor loops (different iteration shapes) — same seam applies, follow-up.
- Surfacing failed-file details in the dashboard Live tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)