### PR TITLE
fix(ci): stop release publish jobs racing on asset upload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,9 +30,13 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
 
+  # Artifacts build only on the `release: published` event (or manual dispatch
+  # with a tag). The push run that creates the release via release-please must
+  # NOT also build - when it did, its publish job raced the release-event run's
+  # publish job and --clobber uploads interleaved, leaving a checksums.txt from
+  # one build next to a tarball from the other (v0.24.0 incident).
   build-artifacts:
-    needs: release-please
-    if: ${{ always() && (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '') || needs.release-please.outputs.releases_created == 'true') }}
+    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '') }}
     name: Build ${{ matrix.artifact }}
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -94,9 +98,10 @@ jobs:
           if-no-files-found: error
 
   publish-artifacts:
-    needs: [release-please, build-artifacts]
-    if: ${{ always() && needs.build-artifacts.result == 'success' && (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '') || needs.release-please.outputs.releases_created == 'true') }}
+    needs: build-artifacts
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-assets-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag_name }}
     permissions:
       contents: write
     steps:
@@ -114,7 +119,8 @@ jobs:
           set -euo pipefail
           cd release-assets
           if [ -z "$TAG_NAME" ]; then
-            TAG_NAME="$(gh release view --repo "$GH_REPO" --json tagName --jq .tagName)"
+            echo "TAG_NAME is empty - refusing to guess the target release" >&2
+            exit 1
           fi
           shasum -a 256 ./*.tar.gz > checksums.txt
           gh release upload "$TAG_NAME" ./*.tar.gz checksums.txt --repo "$GH_REPO" --clobber


### PR DESCRIPTION
Fixes the v0.24.0 broken-release incident reported in https://github.com/Necmttn/ax/issues/251#issuecomment-4677698545.

## What happened

When release-please created the v0.24.0 release on the push run, the `release: published` event spawned a second workflow run. Both runs built artifacts (bun `--compile` is non-deterministic, so the builds differ byte-for-byte) and both publish jobs ran `gh release upload --clobber` at the same second. The interleaved clobber-deletes/uploads left the release with:

- `checksums.txt` from one build
- `axctl-darwin-arm64.tar.gz` from the **other** build → checksum mismatch, `install.sh` aborts
- `axctl-linux-x64.tar.gz` deleted and never re-uploaded

Both publish jobs failed (422 `ReleaseAsset.name already exists` / 404 on the clobbered asset), confirming the race.

## Fix

- `build-artifacts`/`publish-artifacts` now run **only** on `release: published` or manual dispatch with a tag — the push run is release-please only, so exactly one run publishes per release
- per-tag `concurrency` group on `publish-artifacts` as a backstop
- empty `TAG_NAME` now fails hard instead of falling back to `gh release view` (latest release — wrong target when re-cutting an older tag)

v0.24.0 assets themselves re-cut via `workflow_dispatch` (run 27327799824).

🤖 Generated with [Claude Code](https://claude.com/claude-code)