### PR TITLE
fix(install): report expected vs actual hash on checksum mismatch instead of silent abort

### DIFF
--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -225,14 +225,24 @@ EOF
       err "checksums.txt did not include ${artifact}"
       exit 1
     }
+    expected_sha="$(printf '%s\n' "$checksum_line" | awk '{print $1}')"
+    actual_sha=""
     if command -v shasum >/dev/null 2>&1; then
-      (cd "$tmp_dir" && printf '%s\n' "$checksum_line" | shasum -a 256 -c - >/dev/null)
-      ok "checksum verified"
+      actual_sha="$(shasum -a 256 "$tmp_dir/$artifact" | awk '{print $1}')"
     elif command -v sha256sum >/dev/null 2>&1; then
-      (cd "$tmp_dir" && printf '%s\n' "$checksum_line" | sha256sum -c - >/dev/null)
+      actual_sha="$(sha256sum "$tmp_dir/$artifact" | awk '{print $1}')"
+    fi
+    if [[ -z "$actual_sha" ]]; then
+      warn "no sha256 checker found, skipping verification"
+    elif [[ "$actual_sha" == "$expected_sha" ]]; then
       ok "checksum verified"
     else
-      warn "no sha256 checker found, skipping verification"
+      err "checksum mismatch for ${C_BOLD}${artifact}${C_RESET}"
+      printf '    %sexpected%s %s\n' "$C_DIM" "$C_RESET" "$expected_sha" >&2
+      printf '    %sactual  %s %s\n' "$C_DIM" "$C_RESET" "$actual_sha" >&2
+      printf '    %sthis usually means a broken release - please report at%s\n' "$C_DIM" "$C_RESET" >&2
+      printf '    %shttps://github.com/%s/issues%s\n' "$C_BOLD" "$REPO" "$C_RESET" >&2
+      exit 1
     fi
   else
     warn "checksums.txt not found, skipping verification"

--- a/install.sh
+++ b/install.sh
@@ -225,14 +225,24 @@ EOF
       err "checksums.txt did not include ${artifact}"
       exit 1
     }
+    expected_sha="$(printf '%s\n' "$checksum_line" | awk '{print $1}')"
+    actual_sha=""
     if command -v shasum >/dev/null 2>&1; then
-      (cd "$tmp_dir" && printf '%s\n' "$checksum_line" | shasum -a 256 -c - >/dev/null)
-      ok "checksum verified"
+      actual_sha="$(shasum -a 256 "$tmp_dir/$artifact" | awk '{print $1}')"
     elif command -v sha256sum >/dev/null 2>&1; then
-      (cd "$tmp_dir" && printf '%s\n' "$checksum_line" | sha256sum -c - >/dev/null)
+      actual_sha="$(sha256sum "$tmp_dir/$artifact" | awk '{print $1}')"
+    fi
+    if [[ -z "$actual_sha" ]]; then
+      warn "no sha256 checker found, skipping verification"
+    elif [[ "$actual_sha" == "$expected_sha" ]]; then
       ok "checksum verified"
     else
-      warn "no sha256 checker found, skipping verification"
+      err "checksum mismatch for ${C_BOLD}${artifact}${C_RESET}"
+      printf '    %sexpected%s %s\n' "$C_DIM" "$C_RESET" "$expected_sha" >&2
+      printf '    %sactual  %s %s\n' "$C_DIM" "$C_RESET" "$actual_sha" >&2
+      printf '    %sthis usually means a broken release - please report at%s\n' "$C_DIM" "$C_RESET" >&2
+      printf '    %shttps://github.com/%s/issues%s\n' "$C_BOLD" "$REPO" "$C_RESET" >&2
+      exit 1
     fi
   else
     warn "checksums.txt not found, skipping verification"


### PR DESCRIPTION
Closes #271

## Bug

`install.sh` aborted **silently** on checksum mismatch: `shasum -a 256 -c` / `sha256sum -c` output was redirected to `/dev/null`, so under `set -euo pipefail` a mismatch killed the script with no message. During the v0.24.0 asset race (fixed by 8534cbea) users saw the installer just stop.

## Fix

The verification block now computes the artifact's sha256 explicitly (`shasum -a 256` / `sha256sum`, first field via awk) and compares it against the `checksums.txt` entry instead of relying on `-c`'s exit code alone. On mismatch it prints to stderr — artifact name, expected hash, actual hash, and a report hint — then keeps the hard `exit 1`. Output uses the script's existing `err`/`printf` + `C_BOLD`/`C_DIM` style. The "no sha256 checker found" and "checksums.txt not found" skip-paths are unchanged.

## `apps/site/public/install`

It is a **build-time copy** of `install.sh` — `apps/site/package.json` runs `cp ../../install.sh public/install` in `predev`/`prebuild`/`build` — but the copy is also checked in. Synced it in this PR so the committed file matches the source until the next site build regenerates it.

## Verification

- `sh -n install.sh` and `bash -n install.sh` pass.
- Functional fixture test: fake tarball + mismatching `checksums.txt` in a tmp dir, ran the exact verification block (lines 221-246) with the script's `err`/`ok`/`warn` helpers:

```
=== MISMATCH CASE ===
  ✗ checksum mismatch for axctl-darwin-arm64.tar.gz
    expected 0000000000000000000000000000000000000000000000000000000000000000
    actual   895c8819dcbb28a45f02f16bcae08a95efa20e79bb3891c02e9c57eef984171b
    this usually means a broken release - please report at
    https://github.com/Necmttn/ax/issues
exit code: 1
=== MATCH CASE ===
  ✓ checksum verified
exit code: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)