### PR TITLE
fix(skills): emit classify briefs as top-of-file frontmatter so lint can parse them

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Set up ax for me, end to end. ax is a local agent-experience graph over my Claud
 
 3. VERIFY - run `ax doctor`. If anything isn't ok, diagnose and fix it, then re-run until it is.
 
-4. LABEL what ax can't classify - run `ax skills classify`. It writes one `.ax/tasks/classify-<skill>.md` brief per skill I use but ax can't role-tag. For each brief: read the skill, decide its role(s), and fill the YAML at the bottom (`primary_role:` is required; `secondary_roles`, `confidence`, `rationale` are optional). Run `ax roles` to see labels already in use. Then run `ax skills lint` to apply them. If it says "no unclassified skills", that's fine.
+4. LABEL what ax can't classify - run `ax skills classify`. It writes one `.ax/tasks/classify-<skill>.md` brief per skill I use but ax can't role-tag. For each brief: read the skill, decide its role(s), and fill the YAML frontmatter at the top (`primary_role:` is required; `secondary`, `confidence`, `rationale` are optional). Run `ax roles` to see labels already in use. Then run `ax skills lint` to apply them. If it says "no unclassified skills", that's fine.
 
 5. SHOW me the result - run `ax skills weighted` and `ax skills config`. Tell me which skills you labeled and why, and flag anything ax marked orphan or out-of-scope.
 

--- a/apps/axctl/src/cli/skills-classify-template.test.ts
+++ b/apps/axctl/src/cli/skills-classify-template.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { renderClassifyBrief, skillNameToSlug } from "./skills-classify-template.ts";
+import { parseBrief } from "./skills-lint.ts";
 
 describe("skillNameToSlug", () => {
     test("replaces colons with double underscore", () => {
@@ -90,8 +91,79 @@ describe("renderClassifyBrief", () => {
         expect(out).toContain("ax_classify: pre-bash-guard");
     });
 
-    test("output is valid markdown (starts with heading)", () => {
+    test("output starts with top-of-file YAML frontmatter", () => {
         const out = renderClassifyBrief(base);
-        expect(out.trimStart()).toMatch(/^# ax classify:/);
+        expect(out.startsWith("---\n")).toBe(true);
+        expect(out).toMatch(/^---\nax_classify: /);
+        // The frontmatter block is closed before the markdown body starts
+        expect(out).toContain("---\n\n# ax classify:");
+    });
+
+    test("does not scaffold the YAML inside a fenced code block", () => {
+        const out = renderClassifyBrief(base);
+        expect(out).not.toContain("```yaml");
+    });
+});
+
+describe("renderClassifyBrief -> skills lint round-trip", () => {
+    const base = {
+        skillName: "superpowers:subagent-driven-development",
+        invocations: 42,
+        sessions: 7,
+    };
+
+    test("freshly emitted brief parses as pending (no primary_role yet)", () => {
+        const out = renderClassifyBrief(base);
+        // null = pending, not an error - lint leaves the file alone
+        expect(parseBrief(out, "classify-test.md")).toBeNull();
+    });
+
+    test("filling primary_role makes the brief lint-applicable as scaffolded", () => {
+        const out = renderClassifyBrief(base);
+        const filled = out.replace(
+            "primary_role:           # required, single string",
+            "primary_role: execution # required, single string",
+        );
+        expect(filled).not.toBe(out);
+
+        const parsed = parseBrief(filled, "classify-test.md");
+        expect(parsed).not.toBeNull();
+        if (parsed === null || "error" in parsed) {
+            throw new Error(`expected filled brief to parse, got: ${JSON.stringify(parsed)}`);
+        }
+        expect(parsed.ax_classify).toBe("superpowers:subagent-driven-development");
+        expect(parsed.primary_role).toBe("execution");
+        expect(parsed.secondary).toEqual([]);
+        expect(parsed.confidence).toBe(1.0);
+    });
+
+    test("filled brief round-trips with secondary roles and rationale", () => {
+        const out = renderClassifyBrief({
+            skillName: "pre-bash-guard",
+            invocations: 10,
+            sessions: 3,
+        });
+        const filled = out
+            .replace(
+                "primary_role:           # required, single string",
+                "primary_role: verification",
+            )
+            .replace(
+                "secondary: []           # optional, list of strings",
+                "secondary: [framing, repair]",
+            )
+            .replace(
+                "  Explain why you picked these roles.",
+                "  Guards bash preconditions before execution.",
+            );
+
+        const parsed = parseBrief(filled, "classify-pre-bash-guard.md");
+        if (parsed === null || "error" in parsed) {
+            throw new Error(`expected filled brief to parse, got: ${JSON.stringify(parsed)}`);
+        }
+        expect(parsed.ax_classify).toBe("pre-bash-guard");
+        expect(parsed.primary_role).toBe("verification");
+        expect(parsed.secondary).toEqual(["framing", "repair"]);
+        expect(parsed.rationale).toBe("Guards bash preconditions before execution.");
     });
 });

--- a/apps/axctl/src/cli/skills-classify-template.ts
+++ b/apps/axctl/src/cli/skills-classify-template.ts
@@ -23,10 +23,19 @@ export function skillNameToSlug(name: string): string {
 
 export function renderClassifyBrief(input: ClassifyBriefInput): string {
     const { skillName, invocations, sessions } = input;
-    return `# ax classify: ${skillName}
+    return `---
+ax_classify: ${skillName}
+primary_role:           # required, single string
+secondary: []           # optional, list of strings
+confidence: 1.0         # optional, float 0-1, defaults to 1.0
+rationale: |            # optional, free-form text
+  Explain why you picked these roles.
+---
+
+# ax classify: ${skillName}
 
 **Action:** classify skill's primary + secondary roles for \`ax skills weighted\` (P3.6)
-**Target:** edit this file, fill the fields below, then run \`axctl skills lint\`
+**Target:** edit this file, fill the frontmatter at the top, then run \`axctl skills lint\`
 **Provenance:** YAML frontmatter \`ax_classify: ${skillName}\`
 
 ## Why
@@ -46,9 +55,10 @@ Run these to understand the skill's actual use before deciding:
 Or: \`axctl skills tag ${skillName} <role>\` for a one-line override.
 
 ## Decide
-Fill the YAML at the bottom. Valid \`primary_role\` values are anything you
-choose - common ones: framing, execution, execution-mode, producer,
-verification, repair. Add as many \`secondary\` roles as you like (or none).
+Fill the YAML frontmatter at the top of this file. Valid \`primary_role\`
+values are anything you choose - common ones: framing, execution,
+execution-mode, producer, verification, repair. Add as many \`secondary\`
+roles as you like (or none).
 
 When done:
 
@@ -56,18 +66,5 @@ When done:
 
 …will read this file, upsert \`plays_role\` edges with \`source="brief"\`,
 and remove this task file.
-
-## Fill in
-
-\`\`\`yaml
----
-ax_classify: ${skillName}
-primary_role:           # required, single string
-secondary: []           # optional, list of strings
-confidence: 1.0         # optional, float 0-1, defaults to 1.0
-rationale: |            # optional, free-form text
-  Explain why you picked these roles.
----
-\`\`\`
 `;
 }

--- a/apps/axctl/src/cli/skills-lint.test.ts
+++ b/apps/axctl/src/cli/skills-lint.test.ts
@@ -21,8 +21,8 @@ import { cmdSkillsLint, type LintReport } from "./skills-lint.ts";
 // ---------------------------------------------------------------------------
 // Test fixtures
 // Briefs have YAML frontmatter at the very top (--- block), matching the
-// classify brief spec. The rendering template wraps the YAML in a fenced
-// code block for readability, but filled briefs have the frontmatter at top.
+// classify brief spec. The rendering template scaffolds the frontmatter at
+// the top of the file, so filled briefs keep it there.
 // ---------------------------------------------------------------------------
 
 const FILLED_BRIEF = `---

--- a/apps/axctl/src/cli/skills-lint.ts
+++ b/apps/axctl/src/cli/skills-lint.ts
@@ -21,7 +21,7 @@ import { surrealString } from "@ax/lib/shared/surql";
 // ---------------------------------------------------------------------------
 
 /** Parsed frontmatter from a classify brief. */
-interface BriefFrontmatter {
+export interface BriefFrontmatter {
     readonly ax_classify: string;
     readonly primary_role: string;
     readonly secondary: string[];
@@ -74,8 +74,10 @@ function extractFrontmatter(content: string): string | null {
  * Returns null when the brief is pending (no primary_role) so the caller can
  * skip it silently.
  * Throws a descriptive string error when the brief is malformed.
+ *
+ * Exported for the template round-trip test (skills-classify-template.test.ts).
  */
-function parseBrief(
+export function parseBrief(
     content: string,
     filePath: string,
 ): BriefFrontmatter | null | { error: string } {

--- a/apps/site/app/components/landing-v2/dashboard-preview.tsx
+++ b/apps/site/app/components/landing-v2/dashboard-preview.tsx
@@ -21,7 +21,7 @@ const AGENT_PROMPT = `Set up ax for me, end to end. ax is a local agent-experien
 
 3. VERIFY - run \`ax doctor\`. If anything isn't ok, diagnose and fix it, then re-run until it is.
 
-4. LABEL what ax can't classify - run \`ax skills classify\`. It writes one \`.ax/tasks/classify-<skill>.md\` brief per skill I use but ax can't role-tag. For each brief: read the skill, decide its role(s), and fill the YAML at the bottom (\`primary_role:\` is required; \`secondary_roles\`, \`confidence\`, \`rationale\` are optional). Run \`ax roles\` to see labels already in use. Then run \`ax skills lint\` to apply them. If it says "no unclassified skills", that's fine.
+4. LABEL what ax can't classify - run \`ax skills classify\`. It writes one \`.ax/tasks/classify-<skill>.md\` brief per skill I use but ax can't role-tag. For each brief: read the skill, decide its role(s), and fill the YAML frontmatter at the top (\`primary_role:\` is required; \`secondary\`, \`confidence\`, \`rationale\` are optional). Run \`ax roles\` to see labels already in use. Then run \`ax skills lint\` to apply them. If it says "no unclassified skills", that's fine.
 
 5. SHOW me the result - run \`ax skills weighted\` and \`ax skills config\`. Tell me which skills you labeled and why, and flag anything ax marked orphan or out-of-scope.
 

--- a/packages/lib/src/agent-onboarding.ts
+++ b/packages/lib/src/agent-onboarding.ts
@@ -14,7 +14,7 @@ export const AGENT_ONBOARDING_PROMPT = [
     "",
     "2. VERIFY - run `ax doctor`. If anything isn't ok, diagnose and fix it, then re-run until it is.",
     "",
-    "3. LABEL what ax can't classify - run `ax skills classify`. It writes one `.ax/tasks/classify-<skill>.md` brief per skill I use but ax can't role-tag. For each brief: read the skill, decide its role(s), and fill the YAML at the bottom (`primary_role:` is required; `secondary_roles`, `confidence`, `rationale` are optional). Run `ax roles` to see labels already in use. Then run `ax skills lint` to apply them. If it says \"no unclassified skills\", that's fine - nothing to label yet.",
+    "3. LABEL what ax can't classify - run `ax skills classify`. It writes one `.ax/tasks/classify-<skill>.md` brief per skill I use but ax can't role-tag. For each brief: read the skill, decide its role(s), and fill the YAML frontmatter at the top (`primary_role:` is required; `secondary`, `confidence`, `rationale` are optional). Run `ax roles` to see labels already in use. Then run `ax skills lint` to apply them. If it says \"no unclassified skills\", that's fine - nothing to label yet.",
     "",
     "4. SHOW me the result - run `ax skills weighted` (usage x role ranking) and `ax skills config` (lifecycle view). Tell me which skills you labeled and why, and flag anything ax marked orphan or out-of-scope.",
     "",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -74,8 +74,8 @@ ax skills classify        # writes .ax/tasks/classify-<skill>.md per unclassifie
 
 For each brief written:
 1. Read the skill (its SKILL.md / what it does) and the brief's evidence.
-2. Fill the YAML at the bottom of the brief: `primary_role:` (required, one
-   label), plus optional `secondary_roles:`, `confidence:` (0–1), `rationale:`.
+2. Fill the YAML frontmatter at the top of the brief: `primary_role:` (required,
+   one label), plus optional `secondary:`, `confidence:` (0–1), `rationale:`.
    Run `ax roles` to see labels already in use; reuse them when they fit.
 3. Apply + check:
 


### PR DESCRIPTION
## Bug

`ax skills classify` scaffolded the fill-in YAML inside a ```` ```yaml ```` fence at the **bottom** of each brief (`apps/axctl/src/cli/skills-classify-template.ts`), but `ax skills lint` only extracts `---` frontmatter anchored to the **top** of the file (`apps/axctl/src/cli/skills-lint.ts`, regex `/^(?:﻿)?\s*---\n([\s\S]*?)\n---/`). Every brief filled exactly as scaffolded failed lint until the user manually moved the YAML to the top (first-run session in #264 burned ~6 turns restructuring 7 briefs by hand).

## Fix

- The template now emits real top-of-file frontmatter (`ax_classify`, `primary_role`, `secondary`, `confidence`, `rationale`) as the first thing in the file, with the human-readable brief body below it. The fenced `## Fill in` section is removed and the body guidance ("Fill the YAML frontmatter at the top", **Target** line) points at the frontmatter.
- `parseBrief` is exported from `skills-lint.ts` so the template tests can round-trip through the real lint parser.
- Doc mentions of the old shape updated: `README.md`, `skills/setup/SKILL.md`, `packages/lib/src/agent-onboarding.ts`, `apps/site/app/components/landing-v2/dashboard-preview.tsx` — including the incorrect `secondary_roles` field name (the parser reads `secondary`).

## Tests

New round-trip coverage in `skills-classify-template.test.ts`:

- freshly emitted brief parses as **pending** (no `primary_role`) — lint leaves it alone
- filling `primary_role` in the exact scaffolded line makes the brief lint-applicable, with `ax_classify` preserved for plugin-namespaced names (`superpowers:subagent-driven-development`)
- filled brief round-trips `secondary: [framing, repair]` and a rewritten `rationale` block scalar

Evidence:

- `bun test` (template + lint + classify suites): 44 pass, 0 fail
- `bun run typecheck`: exit 0

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)