### PR TITLE
fix(docs): align dashboard port references with serve default 1738

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Set up ax for me, end to end. ax is a local agent-experience graph over my Claud
 
 1. INSTALL - run `curl -fsSL ax.necmttn.com/install | sh` to install the ax CLI. Reference: https://ax.necmttn.com/docs
 
-2. INGEST MY HISTORY - first run `ax ingest --dry-run` and tell me, in plain words, how long a full backfill will take. Then start the ingest in the BACKGROUND so we can keep working: run `ax ingest` as a background job with AX_PROGRESS=plain, and watch its output for progress and completion. Tell me I can watch it fill live in the dashboard - run `ax serve` and open http://127.0.0.1:8520. When the ingest finishes, summarize what landed: total sessions, turns, and the top skills/tools I actually use. Then continue with the steps below.
+2. INGEST MY HISTORY - first run `ax ingest --dry-run` and tell me, in plain words, how long a full backfill will take. Then start the ingest in the BACKGROUND so we can keep working: run `ax ingest` as a background job with AX_PROGRESS=plain, and watch its output for progress and completion. Tell me I can watch it fill live in the dashboard - run `ax serve` and open http://127.0.0.1:1738. When the ingest finishes, summarize what landed: total sessions, turns, and the top skills/tools I actually use. Then continue with the steps below.
 
 3. VERIFY - run `ax doctor`. If anything isn't ok, diagnose and fix it, then re-run until it is.
 
@@ -69,7 +69,7 @@ ax skills taste               # which skills earned their keep
 ax costs for --branch main    # what a branch cost in tokens
 ax sessions metrics           # graph-derived session health
 ax share <session-id>         # publish a session anyone can read
-ax serve                      # live dashboard at http://127.0.0.1:8520
+ax serve                      # live dashboard at http://127.0.0.1:1738
 ```
 
 Requires Bun ≥ 1.3 and SurrealDB ≥ 3.0. macOS-first; Linux works for ingest

--- a/apps/axctl/src/cli/commands/serve.ts
+++ b/apps/axctl/src/cli/commands/serve.ts
@@ -1,4 +1,5 @@
 // Extracted from cli/index.ts (Phase 2 CLI split)
+import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
 import { Effect } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import { serveDashboard } from "../../dashboard/server.ts";
@@ -7,7 +8,7 @@ import type { RuntimeManifest } from "./manifest.ts";
 
 export const serveCommand = Command.make(
     "serve",
-    { port: Flag.integer("port").pipe(Flag.withDefault(1738)) },
+    { port: Flag.integer("port").pipe(Flag.withDefault(DEFAULT_DASHBOARD_PORT)) },
     ({ port }) => Effect.promise(() => serveDashboard([`--port=${port}`])),
 ).pipe(Command.withDescription("Serve the live web dashboard locally"));
 

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
 import { ManagedRuntime } from "effect";
 import { IngestRuntimeLayer } from "../ingest/stage/runtime.ts";
 import { createDurableIngestStream, type DurableIngestStream } from "./ingest-stream-durable.ts";
@@ -7,7 +8,7 @@ import { routeTable } from "./router/table.ts";
 
 export function parseDashboardServeArgs(args: string[]): { port: number } {
     const raw = args.find((arg) => arg.startsWith("--port="))?.split("=")[1];
-    const port = raw === undefined ? 1738 : Number(raw);
+    const port = raw === undefined ? DEFAULT_DASHBOARD_PORT : Number(raw);
     if (!Number.isInteger(port) || port <= 0) throw new Error(`--port must be a positive integer (got ${raw})`);
     return { port };
 }
@@ -17,7 +18,7 @@ export async function handleDashboardRequest(req: Request): Promise<Response> {
     const routed = await dispatch(routeTable, req, url);
     if (routed !== null) return routed;
     if (url.pathname.startsWith("/api/")) return jsonResponse({ error: "not_found" });
-    if (req.method === "GET") return serveRootLanding(url.port || "1738");
+    if (req.method === "GET") return serveRootLanding(url.port || String(DEFAULT_DASHBOARD_PORT));
     return new Response("not found", { status: 404 });
 }
 

--- a/apps/axctl/src/ingest/dry-run.ts
+++ b/apps/axctl/src/ingest/dry-run.ts
@@ -17,6 +17,7 @@
  */
 import { Effect, FileSystem, Option, Path, PlatformError } from "effect";
 import { AxConfig } from "@ax/lib/config";
+import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { ingestTranscripts } from "./transcripts.ts";
@@ -251,6 +252,6 @@ export function formatDryRun(result: DryRunResult, json: boolean): string {
     const eta = result.etaSeconds === null ? "unknown" : `~${formatDuration(result.etaSeconds)}`;
     const roughTag = result.rough ? " (rough)" : "";
     lines.push(`  total: ${s.sessionsTotal.toLocaleString()} sessions   ETA ${eta}${roughTag} on this machine`);
-    lines.push("  run it: ax ingest   (watch live in ax serve → http://127.0.0.1:8520)");
+    lines.push(`  run it: ax ingest   (watch live in ax serve → http://127.0.0.1:${DEFAULT_DASHBOARD_PORT})`);
     return lines.join("\n");
 }

--- a/apps/site/app/components/features/features-page.tsx
+++ b/apps/site/app/components/features/features-page.tsx
@@ -616,7 +616,7 @@ export function FeaturesPage() {
           <div className="cli-row">
             <span className="cmd">ax serve</span>
             <span className="desc">
-              Local web dashboard at <code className="inline">127.0.0.1:8520</code> with the same data the TUI sees.
+              Local web dashboard at <code className="inline">127.0.0.1:1738</code> with the same data the TUI sees.
             </span>
           </div>
           <div className="cli-row">
@@ -662,7 +662,7 @@ export function FeaturesPage() {
           </div>
           <div className="local-card">
             <span className="lc-eye">dashboard</span>
-            <span className="lc-val">127.0.0.1:8520</span>
+            <span className="lc-val">127.0.0.1:1738</span>
             <span className="lc-desc">Web UI for the graph, findings, and intervention queue. No auth - it&apos;s your loopback.</span>
           </div>
           <div className="local-card">

--- a/apps/site/app/components/landing-v2/dashboard-preview.tsx
+++ b/apps/site/app/components/landing-v2/dashboard-preview.tsx
@@ -17,7 +17,7 @@ const AGENT_PROMPT = `Set up ax for me, end to end. ax is a local agent-experien
 
 1. INSTALL - run \`${INSTALL_CMD}\` to install the ax CLI. Reference: ${DOCS_URL}
 
-2. INGEST MY HISTORY - first run \`ax ingest --dry-run\` and tell me, in plain words, how long a full backfill will take. Then start the ingest in the BACKGROUND so we can keep working: run \`ax ingest\` as a background job with AX_PROGRESS=plain, and watch its output for progress and completion. Tell me I can watch it fill live in the dashboard - run \`ax serve\` and open http://127.0.0.1:8520. When the ingest finishes, summarize what landed: total sessions, turns, and the top skills/tools I actually use. Then continue with the steps below.
+2. INGEST MY HISTORY - first run \`ax ingest --dry-run\` and tell me, in plain words, how long a full backfill will take. Then start the ingest in the BACKGROUND so we can keep working: run \`ax ingest\` as a background job with AX_PROGRESS=plain, and watch its output for progress and completion. Tell me I can watch it fill live in the dashboard - run \`ax serve\` and open http://127.0.0.1:1738. When the ingest finishes, summarize what landed: total sessions, turns, and the top skills/tools I actually use. Then continue with the steps below.
 
 3. VERIFY - run \`ax doctor\`. If anything isn't ok, diagnose and fix it, then re-run until it is.
 
@@ -143,7 +143,7 @@ export function DashboardPreview() {
         <div
           className="browser"
           role="img"
-          aria-label="ax dashboard preview at 127.0.0.1:8520"
+          aria-label="ax dashboard preview at 127.0.0.1:1738"
         >
           <div className="browser-bar">
             <div className="browser-dots">
@@ -151,7 +151,7 @@ export function DashboardPreview() {
               <span></span>
               <span></span>
             </div>
-            <div className="browser-url">127.0.0.1:8520</div>
+            <div className="browser-url">127.0.0.1:1738</div>
             <div className="browser-spacer"></div>
           </div>
 

--- a/apps/site/app/components/landing-v2/open-source-section.tsx
+++ b/apps/site/app/components/landing-v2/open-source-section.tsx
@@ -144,7 +144,7 @@ export function OpenSourceSection() {
             </div>
             <div className="oss-line muted">
               <span></span>
-              <code>ax dashboard &rarr; http://127.0.0.1:8520</code>
+              <code>ax dashboard &rarr; http://127.0.0.1:1738</code>
             </div>
             <div className="oss-line">
               <span className="prompt">$</span>

--- a/apps/site/public/install
+++ b/apps/site/public/install
@@ -288,7 +288,7 @@ else
   printf '    %sax setup%s     %sinstall the agent skills + first ingest%s\n' "$C_BOLD" "$C_RESET" "$C_DIM" "$C_RESET"
 fi
 printf '    %sax doctor%s    %scheck your setup%s\n' "$C_BOLD" "$C_RESET" "$C_DIM" "$C_RESET"
-printf '    %sax serve%s     %sopen the dashboard → http://127.0.0.1:8520%s\n' "$C_BOLD" "$C_RESET" "$C_DIM" "$C_RESET"
+printf '    %sax serve%s     %sopen the dashboard → http://127.0.0.1:1738%s\n' "$C_BOLD" "$C_RESET" "$C_DIM" "$C_RESET"
 printf '    %sax recall%s    %ssearch what your agents actually did%s\n' "$C_BOLD" "$C_RESET" "$C_DIM" "$C_RESET"
 printf '\n'
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,7 +33,7 @@ CI runs both - failing either blocks merge.
 While developing, skip the compiled binary and run the TypeScript directly:
 
 ```bash
-bun src/cli/index.ts serve --port=8520
+bun src/cli/index.ts serve --port=1738
 bun src/cli/index.ts insights friction --limit=10
 bun src/cli/index.ts recall "auth middleware"
 ```

--- a/docs/language.md
+++ b/docs/language.md
@@ -45,8 +45,8 @@ The CLI binary. Use when the technical layer matters. `axctl install`,
 ### ax studio
 
 The live dashboard at `axctl serve`. Use the studio name in prose
-("open ax studio at `127.0.0.1:8520`"), use the command name in
-instructions (`axctl serve --port=8520`).
+("open ax studio at `127.0.0.1:1738`"), use the command name in
+instructions (`axctl serve --port=1738`).
 
 ### ax pilot
 

--- a/install.sh
+++ b/install.sh
@@ -288,7 +288,7 @@ else
   printf '    %sax setup%s     %sinstall the agent skills + first ingest%s\n' "$C_BOLD" "$C_RESET" "$C_DIM" "$C_RESET"
 fi
 printf '    %sax doctor%s    %scheck your setup%s\n' "$C_BOLD" "$C_RESET" "$C_DIM" "$C_RESET"
-printf '    %sax serve%s     %sopen the dashboard → http://127.0.0.1:8520%s\n' "$C_BOLD" "$C_RESET" "$C_DIM" "$C_RESET"
+printf '    %sax serve%s     %sopen the dashboard → http://127.0.0.1:1738%s\n' "$C_BOLD" "$C_RESET" "$C_DIM" "$C_RESET"
 printf '    %sax recall%s    %ssearch what your agents actually did%s\n' "$C_BOLD" "$C_RESET" "$C_DIM" "$C_RESET"
 printf '\n'
 

--- a/packages/lib/src/agent-onboarding.test.ts
+++ b/packages/lib/src/agent-onboarding.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { AGENT_ONBOARDING_PROMPT, renderAgentOnboarding } from "./agent-onboarding.ts";
+import { DEFAULT_DASHBOARD_PORT } from "./dashboard-port.ts";
+
+describe("agent-onboarding dashboard port", () => {
+    test("onboarding prompt points at the serve default port", () => {
+        // Anti-drift guard for issue #268: the prompt agents paste verbatim
+        // must reference the same port `ax serve` actually binds by default.
+        expect(AGENT_ONBOARDING_PROMPT).toContain(`http://127.0.0.1:${DEFAULT_DASHBOARD_PORT}`);
+    });
+
+    test("no stale port references survive in the rendered onboarding", () => {
+        expect(renderAgentOnboarding()).not.toContain("8520");
+    });
+});

--- a/packages/lib/src/agent-onboarding.ts
+++ b/packages/lib/src/agent-onboarding.ts
@@ -6,11 +6,13 @@
  * (the classify/lint loop) -> explore.
  */
 
+import { DEFAULT_DASHBOARD_PORT } from "./dashboard-port.ts";
+
 /** The raw prompt text the user pastes into Claude Code / Codex. */
 export const AGENT_ONBOARDING_PROMPT = [
     "Set up ax for me. ax is my local agent-experience graph over my Claude Code + Codex history. Do this end to end:",
     "",
-    "1. INGEST MY HISTORY - first run `ax ingest --dry-run` and tell me, in plain words, how long a full backfill will take. Then start the ingest in the BACKGROUND so we can keep working: run `ax ingest` as a background job with AX_PROGRESS=plain, and watch its output for progress and completion. Tell me I can watch it fill live in the dashboard - run `ax serve` and open http://127.0.0.1:8520. When the ingest finishes, summarize what landed: total sessions, turns, and the top skills/tools I actually use. Then continue with the steps below.",
+    `1. INGEST MY HISTORY - first run \`ax ingest --dry-run\` and tell me, in plain words, how long a full backfill will take. Then start the ingest in the BACKGROUND so we can keep working: run \`ax ingest\` as a background job with AX_PROGRESS=plain, and watch its output for progress and completion. Tell me I can watch it fill live in the dashboard - run \`ax serve\` and open http://127.0.0.1:${DEFAULT_DASHBOARD_PORT}. When the ingest finishes, summarize what landed: total sessions, turns, and the top skills/tools I actually use. Then continue with the steps below.`,
     "",
     "2. VERIFY - run `ax doctor`. If anything isn't ok, diagnose and fix it, then re-run until it is.",
     "",

--- a/packages/lib/src/dashboard-port.ts
+++ b/packages/lib/src/dashboard-port.ts
@@ -1,0 +1,10 @@
+/**
+ * Default port for `ax serve` (the local dashboard daemon).
+ *
+ * Single source of truth so user-facing copy (the agent onboarding prompt,
+ * ingest dry-run hint, CLI flag default) can't drift from the actual serve
+ * default again. README.md, install.sh, and the landing site mirror this
+ * value as plain text - if you change it, sweep those too
+ * (`rg -n "1738" README.md install.sh apps/site`).
+ */
+export const DEFAULT_DASHBOARD_PORT = 1738;


### PR DESCRIPTION
Closes #268

`ax serve` defaults to port **1738** (`apps/axctl/src/cli/commands/serve.ts`), but every user-facing surface still said **8520**, sending users (and the onboarding prompt agents paste verbatim) to a dead URL. The code's port is canonical; this sweeps all stale text to 1738 and adds an anti-drift seam.

## Anti-drift seam

- New `DEFAULT_DASHBOARD_PORT = 1738` constant in `packages/lib/src/dashboard-port.ts`, now consumed by:
  - `apps/axctl/src/cli/commands/serve.ts` (`--port` flag default)
  - `apps/axctl/src/dashboard/server.ts` (arg-parse default + root-landing port fallback)
  - `packages/lib/src/agent-onboarding.ts` (onboarding prompt, now a template literal)
  - `apps/axctl/src/ingest/dry-run.ts` ("watch live in ax serve" hint)
- New test `packages/lib/src/agent-onboarding.test.ts` asserts the prompt renders `http://127.0.0.1:${DEFAULT_DASHBOARD_PORT}` and contains no stale `8520`.

## Surfaces updated (text)

- `README.md` ×2 (canonical setup prompt + quick-start command block)
- `install.sh` final-output line
- `apps/site/public/install` - verified byte-identical mirror of `install.sh` (no generation script exists; it's hand-mirrored, CI only runs `bash -n install.sh`). Updated both; they remain identical.
- `apps/site/app/components/landing-v2/open-source-section.tsx`
- `apps/site/app/components/landing-v2/dashboard-preview.tsx` (prompt copy, aria-label, browser-chrome URL)
- `apps/site/app/components/features/features-page.tsx` (CLI row + local-card)
- `docs/language.md` (describes current studio behavior)
- `docs/development.md` (run-from-source example)

## Intentionally skipped (historical specs/prototypes)

- `docs/prototypes/*.html` (landing-page prototypes)
- `docs/superpowers/**` (dated specs/plans)
- `packages/ax-classifier-session-sections/uv.lock` (hash coincidences, not ports)

## Verification

- `bun run typecheck` exit 0 (repo root)
- Test run over `apps/axctl/src/dashboard` + `packages/lib/src`: 586 pass / 0 fail (includes new anti-drift test)
- `rg -n "8520"` outside skipped dirs: only the new test's negative assertion remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)
