### PR TITLE
feat(share): target-ingest the session when it isn't in the graph yet

### DIFF
--- a/apps/axctl/src/cli/share.test.ts
+++ b/apps/axctl/src/cli/share.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { minimalShareArtifact, type AxSessionShare } from "../share/artifact.ts";
 import { formatStaleUsageWarning } from "../share/format.ts";
+import type { ShareTranscriptHit } from "../share/recover.ts";
 import { cmdShareWithDeps, parseShareArgs, type ShareCommandDeps } from "./share.ts";
 
 const SESSION_USAGE = {
@@ -24,13 +25,24 @@ const TURN_USAGE = {
 
 function makeHarness(
     artifact: AxSessionShare | null = minimalShareArtifact({ id: "abc123", source: "codex" }),
+    overrides: Partial<ShareCommandDeps> = {},
 ) {
     let stdout = "";
     let stderr = "";
     let exitCode: number | undefined;
     const published: Parameters<ShareCommandDeps["publish"]>[0][] = [];
+    const locateCalls: string[] = [];
+    const ingestCalls: ShareTranscriptHit[] = [];
     const deps: ShareCommandDeps = {
         exportArtifact: async () => artifact,
+        locateTranscript: async (sessionId) => {
+            locateCalls.push(sessionId);
+            return null;
+        },
+        ingestSession: async (hit) => {
+            ingestCalls.push(hit);
+            return { kind: "ingested" };
+        },
         publish: async (input) => {
             published.push(input);
             return { owner: "necmttn", gistId: "gist123" };
@@ -48,11 +60,14 @@ function makeHarness(
         clearExitCode: () => {
             exitCode = undefined;
         },
+        ...overrides,
     };
 
     return {
         deps,
         published,
+        locateCalls,
+        ingestCalls,
         exitCode: () => exitCode,
         setStaleExitCode: (code: number) => {
             exitCode = code;
@@ -61,6 +76,11 @@ function makeHarness(
         stderr: () => stderr,
     };
 }
+
+const CLAUDE_HIT: ShareTranscriptHit = {
+    path: "/home/u/.claude/projects/-Users-u-Projects-ax/abc123.jsonl",
+    harness: "claude",
+};
 
 describe("parseShareArgs", () => {
     it("parses dry-run share args", () => {
@@ -117,12 +137,98 @@ describe("cmdShareWithDeps", () => {
         expect(harness.published).toHaveLength(0);
     });
 
-    it("sets exitCode 1 when the session is missing", async () => {
+    it("sets exitCode 1 when the session is missing and no transcript exists on disk", async () => {
         const harness = makeHarness(null);
         await cmdShareWithDeps(["missing123"], harness.deps);
 
         expect(harness.exitCode()).toBe(1);
         expect(harness.stderr()).toContain("axctl share: session missing123 not found");
+        expect(harness.locateCalls).toEqual(["missing123"]);
+        expect(harness.ingestCalls).toHaveLength(0);
+        expect(harness.published).toHaveLength(0);
+    });
+
+    it("does not touch the disk fallback when the export succeeds first try", async () => {
+        const harness = makeHarness();
+        await cmdShareWithDeps(["abc123", "--dry-run"], harness.deps);
+
+        expect(harness.locateCalls).toHaveLength(0);
+        expect(harness.ingestCalls).toHaveLength(0);
+    });
+
+    it("ingests the on-disk transcript and retries the export on a graph miss", async () => {
+        const artifact = minimalShareArtifact({ id: "abc123", source: "claude" });
+        const exports: Array<AxSessionShare | null> = [null, artifact];
+        const harness = makeHarness(null, {
+            exportArtifact: async () => exports.shift() ?? null,
+            locateTranscript: async () => CLAUDE_HIT,
+        });
+        await cmdShareWithDeps(["abc123", "--dry-run"], harness.deps);
+
+        expect(harness.stderr()).toContain(
+            "axctl share: session abc123 not in graph - ingesting it now…",
+        );
+        expect(harness.ingestCalls).toEqual([CLAUDE_HIT]);
+        expect(harness.exitCode()).toBeUndefined();
+        // --dry-run semantics intact after the recovery: bundle on stdout, no publish.
+        const bundle = JSON.parse(harness.stdout());
+        expect(bundle["index.json"].session.id).toBe("abc123");
+        expect(harness.published).toHaveLength(0);
+    });
+
+    it("publishes after a successful miss->ingest->retry with --yes", async () => {
+        const artifact = minimalShareArtifact({ id: "abc123", source: "claude" });
+        const exports: Array<AxSessionShare | null> = [null, artifact];
+        const harness = makeHarness(null, {
+            exportArtifact: async () => exports.shift() ?? null,
+            locateTranscript: async () => CLAUDE_HIT,
+        });
+        await cmdShareWithDeps(["abc123", "--yes"], harness.deps);
+
+        expect(harness.exitCode()).toBeUndefined();
+        expect(harness.published).toHaveLength(1);
+        expect(harness.stdout()).toContain("https://ax.necmttn.com/s/necmttn/gist123");
+    });
+
+    it("reports a busy ingest lock instead of deadlocking", async () => {
+        const harness = makeHarness(null, {
+            locateTranscript: async () => CLAUDE_HIT,
+            ingestSession: async () => ({ kind: "busy", pid: 4242, command: "ingest" }),
+        });
+        await cmdShareWithDeps(["abc123"], harness.deps);
+
+        expect(harness.exitCode()).toBe(1);
+        expect(harness.stderr()).toContain(
+            "another ingest (pid 4242, ingest) is in progress",
+        );
+        expect(harness.published).toHaveLength(0);
+    });
+
+    it("reports a failed targeted ingest with what was attempted", async () => {
+        const harness = makeHarness(null, {
+            locateTranscript: async () => CLAUDE_HIT,
+            ingestSession: async () => ({ kind: "failed", message: "db exploded" }),
+        });
+        await cmdShareWithDeps(["abc123"], harness.deps);
+
+        expect(harness.exitCode()).toBe(1);
+        expect(harness.stderr()).toContain(
+            `targeted ingest of ${CLAUDE_HIT.path} failed: db exploded`,
+        );
+        expect(harness.published).toHaveLength(0);
+    });
+
+    it("fails with what was attempted when the session is still missing after ingest", async () => {
+        const harness = makeHarness(null, {
+            locateTranscript: async () => CLAUDE_HIT,
+        });
+        await cmdShareWithDeps(["abc123"], harness.deps);
+
+        expect(harness.ingestCalls).toEqual([CLAUDE_HIT]);
+        expect(harness.exitCode()).toBe(1);
+        expect(harness.stderr()).toContain(
+            `ingested ${CLAUDE_HIT.path}, but the session still did not appear in the graph`,
+        );
         expect(harness.published).toHaveLength(0);
     });
 

--- a/apps/axctl/src/cli/share.ts
+++ b/apps/axctl/src/cli/share.ts
@@ -17,6 +17,13 @@ import {
     hasStaleUsage,
 } from "../share/format.ts";
 import { redactShareArtifact } from "../share/redact.ts";
+import {
+    ingestShareTranscript,
+    locateShareTranscript,
+    type ShareIngestOutcome,
+    type ShareTranscriptHit,
+} from "../share/recover.ts";
+import { IngestRuntimeLayer } from "../ingest/stage/runtime.ts";
 import { AX_VERSION } from "./version.ts";
 import { catchDbErrorAndExit } from "./output.ts";
 
@@ -33,6 +40,14 @@ export interface ShareCommandDeps {
         sessionId: string,
         axVersion: string,
     ) => Promise<AxSessionShare | null>;
+    /** Find the session's on-disk transcript when it isn't in the graph. */
+    readonly locateTranscript: (
+        sessionId: string,
+    ) => Promise<ShareTranscriptHit | null>;
+    /** Targeted ingest of a located transcript (single-flight locked). */
+    readonly ingestSession: (
+        hit: ShareTranscriptHit,
+    ) => Promise<ShareIngestOutcome>;
     readonly publish: (input: {
         readonly bundle: ShareBundle;
         readonly public: boolean;
@@ -84,6 +99,57 @@ const openShareUrl = async (ref: GistRef): Promise<void> => {
     });
 };
 
+/**
+ * Export-miss fallback: find the transcript on disk, run a targeted ingest
+ * for it (claude: scoped to its project dir; codex: --since window), then
+ * retry the export once. Every failure mode writes its own stderr message and
+ * sets exit code 1; returns the recovered artifact or null.
+ */
+async function recoverMissingSession(
+    sessionId: string,
+    deps: ShareCommandDeps,
+): Promise<AxSessionShare | null> {
+    const hit = await deps.locateTranscript(sessionId);
+    if (hit === null) {
+        deps.writeStderr(`axctl share: session ${sessionId} not found\n`);
+        deps.setExitCode(1);
+        return null;
+    }
+
+    deps.writeStderr(
+        `axctl share: session ${sessionId} not in graph - ingesting it now…\n`,
+    );
+    const outcome = await deps.ingestSession(hit);
+    if (outcome.kind === "busy") {
+        deps.writeStderr(
+            `axctl share: session ${sessionId} not in graph and another ingest ` +
+                `(pid ${outcome.pid}, ${outcome.command}) is in progress; ` +
+                `re-run ax share once it finishes\n`,
+        );
+        deps.setExitCode(1);
+        return null;
+    }
+    if (outcome.kind === "failed") {
+        deps.writeStderr(
+            `axctl share: session ${sessionId} not found ` +
+                `(targeted ingest of ${hit.path} failed: ${outcome.message})\n`,
+        );
+        deps.setExitCode(1);
+        return null;
+    }
+
+    const exported = await deps.exportArtifact(sessionId, AX_VERSION);
+    if (exported === null) {
+        deps.writeStderr(
+            `axctl share: session ${sessionId} not found ` +
+                `(ingested ${hit.path}, but the session still did not appear in the graph)\n`,
+        );
+        deps.setExitCode(1);
+        return null;
+    }
+    return exported;
+}
+
 export async function cmdShareWithDeps(
     args: string[],
     deps: ShareCommandDeps,
@@ -99,11 +165,13 @@ export async function cmdShareWithDeps(
     }
     deps.clearExitCode();
 
-    const exported = await deps.exportArtifact(parsed.sessionId, AX_VERSION);
+    let exported = await deps.exportArtifact(parsed.sessionId, AX_VERSION);
     if (exported === null) {
-        deps.writeStderr(`axctl share: session ${parsed.sessionId} not found\n`);
-        deps.setExitCode(1);
-        return;
+        // Export miss (#270): the session a user most wants to share - the
+        // live one - is by definition not yet ingested. Locate its transcript
+        // on disk, run a targeted ingest, then retry the export once.
+        exported = await recoverMissingSession(parsed.sessionId, deps);
+        if (exported === null) return; // recoverMissingSession wrote the error + exit code
     }
 
     const { artifact } = redactShareArtifact(exported);
@@ -153,6 +221,22 @@ const liveShareDeps: ShareCommandDeps = {
             exportSessionShare(sessionId, axVersion).pipe(
                 catchDbErrorAndExit("axctl share"),
                 Effect.provide(AppLayer),
+                Effect.scoped,
+            ),
+        ),
+    locateTranscript: (sessionId) =>
+        Effect.runPromise(
+            locateShareTranscript(sessionId).pipe(
+                Effect.provide(AppLayer),
+                Effect.scoped,
+            ),
+        ),
+    ingestSession: (hit) =>
+        Effect.runPromise(
+            ingestShareTranscript(hit).pipe(
+                // The ingest pipeline needs the stage registry on top of the
+                // app services - same runtime layer `ax ingest` runs under.
+                Effect.provide(IngestRuntimeLayer),
                 Effect.scoped,
             ),
         ),

--- a/apps/axctl/src/share/recover.test.ts
+++ b/apps/axctl/src/share/recover.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { sinceDaysForMtime } from "./recover.ts";
+
+const DAY_MS = 86_400_000;
+
+describe("sinceDaysForMtime", () => {
+    it("uses the 1-day minimum for a transcript modified just now (live session)", () => {
+        const now = Date.now();
+        expect(sinceDaysForMtime(now, now)).toBe(1);
+    });
+
+    it("adds a day of margin past the mtime so the cutoff cannot exclude the file", () => {
+        const now = Date.now();
+        expect(sinceDaysForMtime(now - 3 * DAY_MS, now)).toBe(4);
+    });
+
+    it("never returns less than 1 even for a future mtime (clock skew)", () => {
+        const now = Date.now();
+        expect(sinceDaysForMtime(now + DAY_MS, now)).toBe(1);
+    });
+});

--- a/apps/axctl/src/share/recover.ts
+++ b/apps/axctl/src/share/recover.ts
@@ -1,0 +1,149 @@
+/**
+ * recover.ts - locate + targeted-ingest fallback for `ax share` when the
+ * session isn't in the graph yet (#270).
+ *
+ * The session a user most wants to share - the live one they're in - is by
+ * definition not ingested yet. On an export miss the share command uses this
+ * module to (1) find the transcript on disk via the canonical
+ * TranscriptLocator, (2) run the narrowest existing ingest for it (claude:
+ * the stage's per-project filter, the same one `ax ingest here` uses; codex:
+ * the date-bucketed --since walk - there is no per-file filter), then the
+ * caller retries the export once.
+ *
+ * The ingest runs under the same single-flight lock as every other CLI
+ * ingest (see ingest-lock.ts): if the watcher or a manual ingest holds it,
+ * we surface "busy" instead of piling a second ingest onto the DB.
+ */
+import { Effect, FileSystem, Option, Path } from "effect";
+import { AxConfig } from "@ax/lib/config";
+import { SurrealClient } from "@ax/lib/db";
+import { ProcessService } from "@ax/lib/process";
+import { TraceSink } from "@ax/lib/live-traces/Sink";
+import { toBareSessionId } from "@ax/lib/shared/session-id";
+import { locateTranscript, type Harness } from "@ax/lib/transcript-locator";
+import { runIngest } from "../ingest/run.ts";
+import { withIngestLock } from "../ingest/ingest-lock.ts";
+import { StageRegistry } from "../ingest/stage/registry.ts";
+
+/** A transcript found on disk for a session that isn't in the graph. */
+export interface ShareTranscriptHit {
+    readonly path: string;
+    readonly harness: Harness;
+}
+
+export type ShareIngestOutcome =
+    | { readonly kind: "ingested" }
+    | { readonly kind: "busy"; readonly pid: number; readonly command: string }
+    | { readonly kind: "failed"; readonly message: string };
+
+/** Mirrors cli/commands/ingest.ts: extra grace beyond the hard ingest timeout
+ *  before a held lock is deemed stale and stolen. */
+const INGEST_LOCK_STALE_GRACE_MS = 60_000;
+
+/**
+ * --since window for the targeted ingest: just wide enough to include the
+ * transcript's mtime (min 1 day), so the project-scoped claude stage / codex
+ * date walk picks the file up without backfilling unrelated history.
+ */
+export const sinceDaysForMtime = (mtimeMs: number, nowMs: number): number =>
+    Math.max(1, Math.ceil((nowMs - mtimeMs) / 86_400_000) + 1);
+
+/**
+ * Find the on-disk transcript for `sessionId` (claude then codex), or null.
+ * Uses the canonical TranscriptLocator - DB `raw_file` hint first (a no-op
+ * here since the session isn't ingested), then filesystem search.
+ */
+export const locateShareTranscript = (
+    sessionId: string,
+): Effect.Effect<
+    ShareTranscriptHit | null,
+    never,
+    SurrealClient | FileSystem.FileSystem | Path.Path
+> =>
+    locateTranscript(toBareSessionId(sessionId)).pipe(
+        Effect.map((found): ShareTranscriptHit | null => ({
+            path: found.path,
+            harness: found.harness,
+        })),
+        // TranscriptNotFoundError -> null: the caller renders "not found".
+        Effect.orElseSucceed(() => null),
+    );
+
+/**
+ * Run the narrowest existing ingest that covers `hit`, under the
+ * single-flight ingest lock. Never fails: every error (DB, stage, defect)
+ * degrades to `{ kind: "failed" }` so the share command can report what was
+ * attempted instead of crashing.
+ */
+export const ingestShareTranscript = (
+    hit: ShareTranscriptHit,
+): Effect.Effect<
+    ShareIngestOutcome,
+    never,
+    SurrealClient | AxConfig | ProcessService | StageRegistry | TraceSink | FileSystem.FileSystem | Path.Path
+> =>
+    Effect.gen(function* () {
+        const cfg = yield* AxConfig;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        const mtimeMs = yield* fs.stat(hit.path).pipe(
+            Effect.map((info) => Option.getOrElse(info.mtime, () => new Date()).getTime()),
+            Effect.orElseSucceed(() => Date.now()),
+        );
+        const sinceDays = sinceDaysForMtime(mtimeMs, Date.now());
+
+        // Claude transcripts: scope the stage to the single
+        // ~/.claude/projects/<slug>/ dir the file lives in (the same
+        // `claudeProject` filter `ax ingest here` passes). Codex has no
+        // per-project filter; the --since window is the narrowest scope.
+        const relative = path.relative(cfg.paths.transcriptsDir, hit.path);
+        const claudeProject = hit.harness === "claude" && !relative.startsWith("..")
+            ? relative.split(path.sep)[0]
+            : undefined;
+
+        const timeoutSeconds = cfg.knobs.ingestTimeoutSeconds;
+        const work = runIngest({
+            command: "share-ingest",
+            args: [`--stages=${hit.harness}`, `--since=${sinceDays}`],
+            cwd: process.cwd(),
+            ...(claudeProject ? { claudeProject } : {}),
+        }).pipe(Effect.as<ShareIngestOutcome>({ kind: "ingested" }));
+
+        const outcome = yield* withIngestLock(
+            {
+                lockPath: path.join(cfg.paths.dataDir, "ingest.lock"),
+                command: "share-ingest",
+                staleMs: timeoutSeconds * 1000 + INGEST_LOCK_STALE_GRACE_MS,
+                timeoutSeconds,
+                onBusy: (holder) =>
+                    Effect.succeed<ShareIngestOutcome>({
+                        kind: "busy",
+                        pid: holder.pid,
+                        command: holder.command,
+                    }),
+            },
+            work,
+        );
+
+        // undefined = timed out; the lock is deliberately left as a cooldown
+        // (see ingest-lock.ts header).
+        const timedOut: ShareIngestOutcome = {
+            kind: "failed",
+            message: `ingest exceeded ${timeoutSeconds}s and was cancelled; retry shortly`,
+        };
+        return outcome ?? timedOut;
+    }).pipe(
+        Effect.catch((error) =>
+            Effect.succeed<ShareIngestOutcome>({
+                kind: "failed",
+                message: error instanceof Error ? error.message : String(error),
+            })
+        ),
+        Effect.catchDefect((defect) =>
+            Effect.succeed<ShareIngestOutcome>({
+                kind: "failed",
+                message: defect instanceof Error ? defect.message : String(defect),
+            })
+        ),
+    );


### PR DESCRIPTION
Closes #270

## Problem

`ax share <session-id>` required the session to already be in the graph (`exportSessionShare` returns null on an overview miss → "session not found", exit 1). The session a user most wants to share — the live one they're in — is by definition not yet ingested. During #251 this was a hard chicken-and-egg: ingest was broken, so the bug-repro session itself couldn't be shared.

## Fix

On an export miss, before failing (`apps/axctl/src/share/recover.ts` + the deps seam in `apps/axctl/src/cli/share.ts`):

1. **Locate the transcript on disk** via the canonical `TranscriptLocator` (`@ax/lib/transcript-locator`) — no new path logic; it already searches `~/.claude/projects/<slug>/<id>.jsonl` and `~/.codex/sessions/YYYY/MM/DD/rollout-*-<id>.jsonl`.
2. **If found**, print `session <id> not in graph — ingesting it now…` and run a targeted ingest through the existing `runIngest` pipeline:
   - **claude**: `--stages=claude` scoped to the one project dir via the same `claudeProject` filter `ax ingest here` uses (slug derived from the located file's path), with a `--since` window computed from the file's mtime (+1 day margin, min 1).
   - **codex**: `--stages=codex` with the `--since` window only — the codex stage has no per-project/per-file filter, so the date-bucketed walk is the narrowest existing scope. (Pi/OpenCode/Cursor aren't covered; the locator only resolves claude + codex. v1 is claude+codex.)
   - The ingest runs under the existing single-flight ingest lock (`ingest-lock.ts`). A held lock surfaces `another ingest (pid N, cmd) is in progress; re-run ax share once it finishes` instead of piling a second ingest onto the DB; a timeout leaves the lock as cooldown (same semantics as `ax ingest`) and reports failure.
3. **Retry the export once.** If the session still isn't in the graph, fail with the original message plus what was attempted (transcript path + outcome).

`--dry-run` semantics are intact: after a successful recovery the multi-file bundle still prints to stdout and nothing publishes.

### Notes / limitations (v1)

- Only `--stages=claude` / `--stages=codex` run — derive enrichments (subagents, turn-content-blocks, signals) are not part of the targeted ingest, so a freshly recovered share may have less enrichment than one from a full ingest. The `subagents` stage walks every project dir unscoped, so it was deliberately left out of the narrow path.
- Every recovery failure mode degrades to a clear stderr message + exit 1; the recovery effect never throws (errors and defects are caught into a `failed` outcome).

## Tests

- `apps/axctl/src/cli/share.test.ts`: miss→locate→ingest→retry happy path (dry-run and `--yes` publish), transcript-missing, busy lock, failed ingest, still-missing-after-ingest, and no-disk-touch when export succeeds first try — all through the `cmdShareWithDeps` seam.
- `apps/axctl/src/share/recover.test.ts`: `--since` window math.
- `bun run typecheck` clean; full repo suite: 3056 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)