### PR TITLE
feat(studio): poll stats when the live stream sidecar is unavailable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ fresh clone.
 
 - `ax serve` → `POST /api/ingest` (or the **Live** tab) forks `runIngest` (same pipeline as CLI) onto the server runtime. Progress flows as `IngestStreamEvent`s through the `IngestStreamBus` seam (`apps/axctl/src/dashboard/ingest-stream.ts`) to a per-run Durable Stream `ingest:<runId>`; the browser subscribes from offset `-1`, so refresh/reconnect mid-run rehydrates. Exactly one terminal `run_finished` event guaranteed. The bus seam lets the Bun backing swap for a hosted backend later untouched.
 - CLI `ax ingest` is unchanged (never passes a `runId`). Progress animates on a TTY by default; non-TTY is silent unless forced with `AX_PROGRESS=on` (or `--progress=plain|pipeline`). `AX_PROGRESS=off` silences. Gated in `withIngest` (`apps/axctl/src/cli/index.ts`).
-- **Live ingest needs ax from source** (the `bin/axctl` shim does this). The compiled `--compile` binary serves the dashboard but returns 503 on `POST /api/ingest` - native lmdb can't bundle, so no sidecar.
+- **Live ingest needs ax from source** (the `bin/axctl` shim does this). The compiled `--compile` binary serves the dashboard but returns 503 on `POST /api/ingest` - native lmdb can't bundle, so no sidecar. `/api/version` advertises this as `live_ingest: false`; the studio Live tab then falls back to polling the count tiles every 5s (`apps/studio/src/poll-fallback.ts`) instead of a dead stream.
 
 ## Workflow extraction commands
 

--- a/apps/axctl/src/dashboard/router/routes/system.test.ts
+++ b/apps/axctl/src/dashboard/router/routes/system.test.ts
@@ -39,4 +39,25 @@ describe("systemRoutes", () => {
     test("POST /api/query remains POST-only", () => {
         expect(matchRoute(systemRoutes, "GET", "/api/query").kind).toBe("method_mismatch");
     });
+
+    test("GET /api/version reports live_ingest=false without a streaming sidecar", async () => {
+        // No serveDashboard boot in tests => no Durable Streams sidecar, the
+        // same shape as the compiled binary. The studio reads this flag to
+        // engage its polling fallback instead of hitting the 503.
+        const matched = matchRoute(systemRoutes, "GET", "/api/version");
+        if (matched.kind !== "matched") throw new Error("expected /api/version to match");
+        const res = await matched.match.route.run(
+            {
+                req: new Request("http://h/api/version"),
+                url: new URL("http://h/api/version"),
+                path: {},
+                body: { kind: "none" },
+            },
+            (() => Promise.reject(new Error("unused"))) as never,
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json() as { live_ingest: boolean; capabilities: string[] };
+        expect(body.live_ingest).toBe(false);
+        expect(body.capabilities).toContain("ingest");
+    });
 });

--- a/apps/axctl/src/dashboard/router/routes/system.ts
+++ b/apps/axctl/src/dashboard/router/routes/system.ts
@@ -9,6 +9,7 @@ import { AX_VERSION } from "../../../cli/version.ts";
 import { graphHealthSql } from "../../../queries/graph-health.ts";
 import { checkoutActivitySql, gitCorrelationSql } from "../../../queries/insights.ts";
 import { API_VERSION, dashboardApiCapabilities } from "../../capabilities.ts";
+import { getServeIngestState } from "../../ingest-state.ts";
 import {
     decodeFail,
     decodeOk,
@@ -43,6 +44,12 @@ export const systemRoutes: ReadonlyArray<AnyRoute> = [
                 version: AX_VERSION,
                 api_version: API_VERSION,
                 capabilities: dashboardApiCapabilities(),
+                // Whether the Durable Streams sidecar is actually hosting live
+                // ingest. False on the compiled binary (native lmdb can't
+                // bundle), where POST /api/ingest would 503 - the studio reads
+                // this to engage its polling fallback up front. Additive
+                // optional field: forward-compatible, no api_version bump.
+                live_ingest: getServeIngestState()?.stream != null,
             }),
     }),
     jsonRoute({

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -103,6 +103,16 @@ export function imageSrc(absolutePath: string): string {
     return endpoint ? endpoint + path : path;
 }
 
+/** Fetch error that carries the HTTP status so callers can branch on it
+ *  (e.g. 503 from POST /api/ingest = Durable Streams sidecar unavailable on
+ *  the compiled binary → engage the polling fallback). */
+export class ApiError extends Error {
+    constructor(message: string, readonly status: number) {
+        super(message);
+        this.name = "ApiError";
+    }
+}
+
 async function jsonFetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
     if (STUDIO_MOCK) {
         const endpoint = readEndpoint();
@@ -126,7 +136,7 @@ async function jsonFetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> 
         } catch {
             /* fall through */
         }
-        throw new Error(detail);
+        throw new ApiError(detail, res.status);
     }
     return (await res.json()) as T;
 }
@@ -143,6 +153,10 @@ export interface DaemonVersion {
     readonly version: string;
     readonly api_version: number;
     readonly capabilities: ReadonlyArray<string>;
+    /** Whether the daemon's Durable Streams sidecar is hosting live ingest.
+     *  `false` on the compiled binary (POST /api/ingest would 503) → the Live
+     *  tab polls counts instead. Optional: older daemons omit it. */
+    readonly live_ingest?: boolean;
 }
 
 // --- session timeline (highlight zoom) -------------------------------------

--- a/apps/studio/src/poll-fallback.test.ts
+++ b/apps/studio/src/poll-fallback.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { POLL_INTERVAL_MS, shouldPollFallback } from "./poll-fallback.ts";
+
+describe("shouldPollFallback (compiled-binary live-stream gap)", () => {
+    test("daemon reports live_ingest=false (compiled binary) → poll", () => {
+        expect(shouldPollFallback({ liveIngest: false, triggerStatus: undefined })).toBe(true);
+    });
+
+    test("daemon reports live_ingest=true (source) → stream, no polling", () => {
+        expect(shouldPollFallback({ liveIngest: true, triggerStatus: undefined })).toBe(false);
+    });
+
+    test("flag unknown (older daemon / probe in flight) → prefer streaming", () => {
+        expect(shouldPollFallback({ liveIngest: undefined, triggerStatus: undefined })).toBe(false);
+    });
+
+    test("flag unknown but POST /api/ingest 503'd → poll", () => {
+        expect(shouldPollFallback({ liveIngest: undefined, triggerStatus: 503 })).toBe(true);
+    });
+
+    test("non-503 trigger failure (e.g. 500 mid-run error) → no polling", () => {
+        expect(shouldPollFallback({ liveIngest: undefined, triggerStatus: 500 })).toBe(false);
+    });
+
+    test("flag says streaming works → a stray 503 still wins (sidecar died)", () => {
+        // live_ingest=true was probed earlier; if the trigger later 503s the
+        // sidecar is gone - fall back rather than dead-end.
+        expect(shouldPollFallback({ liveIngest: true, triggerStatus: 503 })).toBe(true);
+    });
+
+    test("poll interval is ~5s", () => {
+        expect(POLL_INTERVAL_MS).toBe(5000);
+    });
+});

--- a/apps/studio/src/poll-fallback.ts
+++ b/apps/studio/src/poll-fallback.ts
@@ -1,0 +1,29 @@
+/**
+ * Polling fallback decision for the Live Ingest tab.
+ *
+ * On the compiled axctl binary the Durable Streams sidecar can't load (no
+ * native lmdb in a single-file build), so the live stream path is dead:
+ * POST /api/ingest 503s and nothing ever auto-refreshes. Instead of a dead
+ * state, the Live tab drops to polling the count endpoints every
+ * `POLL_INTERVAL_MS` so a CLI-driven `ax ingest` backfill is still visible.
+ *
+ * The streaming path stays preferred: polling engages ONLY when
+ *   (a) the daemon says so up front (`live_ingest === false` on
+ *       GET /api/version), or
+ *   (b) POST /api/ingest came back 503 (older daemon without the flag).
+ */
+
+export const POLL_INTERVAL_MS = 5000;
+
+export interface PollFallbackInput {
+    /** `live_ingest` from GET /api/version; `undefined` = older daemon or
+     *  version probe still in flight (assume streaming works). */
+    readonly liveIngest: boolean | undefined;
+    /** HTTP status of the last failed POST /api/ingest, if any. */
+    readonly triggerStatus: number | undefined;
+}
+
+export function shouldPollFallback({ liveIngest, triggerStatus }: PollFallbackInput): boolean {
+    if (liveIngest === false) return true;
+    return triggerStatus === 503;
+}

--- a/apps/studio/src/routes/ingest-live.tsx
+++ b/apps/studio/src/routes/ingest-live.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "../api.ts";
+import { api, ApiError } from "../api.ts";
+import { POLL_INTERVAL_MS, shouldPollFallback } from "../poll-fallback.ts";
 import { useIngestStream, type StageStatus } from "../use-ingest-stream.ts";
 
 /**
@@ -10,6 +11,13 @@ import { useIngestStream, type StageStatus } from "../use-ingest-stream.ts";
  * stages tick green as they finish + dashboard count tiles climb live. A
  * refresh mid-run rehydrates from the persisted stream URL (the hook replays
  * the stream from the start, so finished stages show as done).
+ *
+ * Polling fallback: on the compiled binary the Durable Streams sidecar can't
+ * load, so the stream path is dead. The daemon advertises that via
+ * `live_ingest: false` on GET /api/version (older daemons: we catch the 503
+ * from POST /api/ingest instead) and this view drops to refetching the count
+ * tiles every 5s so a CLI-driven backfill is still visible. See
+ * poll-fallback.ts; the streaming path stays preferred and untouched.
  */
 
 const STREAM_URL_KEY = "ax-ingest-live-stream-url";
@@ -46,8 +54,24 @@ export function IngestLiveRoute() {
     const [streamUrl, setStreamUrl] = useState<string | null>(() => readPersistedStreamUrl());
     const [busy, setBusy] = useState(false);
     const [triggerError, setTriggerError] = useState<string | null>(null);
+    /** HTTP status of the last failed POST /api/ingest (503 = sidecar gone). */
+    const [triggerStatus, setTriggerStatus] = useState<number | undefined>(undefined);
 
     const run = useIngestStream(streamUrl);
+
+    // Capability probe: the daemon says up front whether the Durable Streams
+    // sidecar is hosting live ingest (false on the compiled binary). Older
+    // daemons omit the flag - then the 503 catch in start() is the trigger.
+    const versionQuery = useQuery({
+        queryKey: ["daemon-version"],
+        queryFn: () => api.version(),
+        staleTime: 60_000,
+        retry: false,
+    });
+    const polling = shouldPollFallback({
+        liveIngest: versionQuery.data?.live_ingest,
+        triggerStatus,
+    });
 
     // While a run is live, invalidate the count-tile query keys on each new
     // delta so the numbers refetch and visibly climb. These are the same keys
@@ -95,7 +119,13 @@ export function IngestLiveRoute() {
             persistStreamUrl(res.stream);
             setStreamUrl(res.stream);
         } catch (err) {
-            setTriggerError(err instanceof Error ? err.message : String(err));
+            if (err instanceof ApiError && err.status === 503) {
+                // Sidecar unavailable (compiled binary) - switch to the
+                // polling fallback instead of dead-ending on the error.
+                setTriggerStatus(err.status);
+            } else {
+                setTriggerError(err instanceof Error ? err.message : String(err));
+            }
         } finally {
             setBusy(false);
         }
@@ -111,7 +141,7 @@ export function IngestLiveRoute() {
                 <span className="meta">
                     {run.label ? `${run.label} · ` : ""}
                     {idle
-                        ? "idle"
+                        ? polling ? "polling" : "idle"
                         : run.finished
                         ? run.runStatus === "completed"
                             ? "completed"
@@ -125,7 +155,8 @@ export function IngestLiveRoute() {
                     type="button"
                     className="badge keep"
                     onClick={start}
-                    disabled={busy || Boolean(live)}
+                    disabled={busy || Boolean(live) || polling}
+                    title={polling ? "Live ingest needs ax running from source" : undefined}
                 >
                     {busy ? "Starting…" : live ? "Running…" : "Run ingest"}
                 </button>
@@ -143,15 +174,29 @@ export function IngestLiveRoute() {
                     session restarted - try Run ingest again.
                 </div>
             ) : null}
+            {polling ? (
+                <div className="empty" role="status">
+                    Live stream unavailable - polling every {POLL_INTERVAL_MS / 1000}s.
+                </div>
+            ) : null}
 
-            <CountTiles />
+            <CountTiles pollMs={polling ? POLL_INTERVAL_MS : false} />
 
             {idle ? (
-                <div className="empty">
-                    No active run. Hit <strong>Run ingest</strong> to stream a live
-                    ingest pass - stages tick green and the counts above climb as data
-                    lands.
-                </div>
+                polling ? (
+                    <div className="empty">
+                        Live streaming needs ax running from source (the compiled binary
+                        can't host the Durable Streams sidecar). Run{" "}
+                        <strong>ax ingest</strong> in a terminal - the counts above
+                        refresh automatically while it fills.
+                    </div>
+                ) : (
+                    <div className="empty">
+                        No active run. Hit <strong>Run ingest</strong> to stream a live
+                        ingest pass - stages tick green and the counts above climb as data
+                        lands.
+                    </div>
+                )
             ) : (
                 <StageChecklist run={run} />
             )}
@@ -201,19 +246,24 @@ function formatEtaLeft(ms: number): string {
 }
 
 /** Count tiles reusing the same React Query keys the live SSE hook invalidates,
- *  so they refetch and climb as the run progresses. */
-function CountTiles() {
+ *  so they refetch and climb as the run progresses. `pollMs` is the polling
+ *  fallback: when the live stream can't run (compiled binary) the tiles
+ *  refetch on an interval instead of waiting for stream-driven invalidation. */
+function CountTiles({ pollMs = false }: { pollMs?: number | false }) {
     const skillsQuery = useQuery({
         queryKey: ["skills"],
         queryFn: () => api.skills(),
+        refetchInterval: pollMs,
     });
     const sessionsQuery = useQuery({
         queryKey: ["sessions", "all"],
         queryFn: () => api.sessions({ limit: 1 }),
+        refetchInterval: pollMs,
     });
     const failuresQuery = useQuery({
         queryKey: ["tool-failures"],
         queryFn: () => api.toolFailures(),
+        refetchInterval: pollMs,
     });
 
     const skills = skillsQuery.data?.skills.length ?? null;


### PR DESCRIPTION
## Gap

On the compiled binary the Durable Streams native sidecar can't load (no darwin-arm64 build / native lmdb won't bundle), so the dashboard serves but never live-updates during ingest: `POST /api/ingest` returns 503 and the stream subscription path is dead. Users had to hammer reload to watch a backfill fill.

## Fix (interim, client-side polling fallback)

- **Capability flag**: `GET /api/version` now reports `live_ingest: boolean`, derived from whether the Durable Streams sidecar actually started (`getServeIngestState()?.stream != null`). Additive optional field, no `api_version` bump.
- **Studio Live tab** (`apps/studio/src/routes/ingest-live.tsx`): probes the flag on mount; when `live_ingest === false` (compiled binary) — or when `POST /api/ingest` comes back 503 on an older daemon that doesn't have the flag — it engages a polling fallback:
  - count tiles (skills / sessions / tool failures) refetch every 5s via React Query `refetchInterval`
  - a visible "Live stream unavailable - polling every 5s." notice replaces the dead state, plus a hint to run `ax ingest` from a terminal
  - the Run ingest button is disabled (it would just 503)
- **`ApiError`**: `jsonFetch` errors now carry the HTTP status so the 503 is detectable without string-matching.
- Decision logic isolated in `apps/studio/src/poll-fallback.ts` (pure, unit-tested). The streaming path (IngestStreamBus seam, `useIngestStream`) is untouched and stays preferred — the fallback engages only on stream unavailability.

## Tests

- `apps/studio/src/poll-fallback.test.ts`: fallback decision matrix (flag false → poll; flag true/unknown → stream; 503 → poll; non-503 failure → no poll).
- `apps/axctl/src/dashboard/router/routes/system.test.ts`: `/api/version` reports `live_ingest: false` when no sidecar is up (the compiled-binary shape).
- Full repo suite green (3055 pass), `bun run typecheck` clean (root + apps/studio).

## Manual verification

Compiled-binary behavior is environment-dependent (sidecar load failure); simulated by the no-serve-state test above. To verify by hand: run the compiled `dist/axctl serve`, open the Live tab — it should show the polling notice and counts should climb while `ax ingest` runs in a terminal, instead of requiring manual reloads.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)