### PR TITLE
fix(ingest): finalize run lifecycle on every exit path, honest exit codes

### DIFF
--- a/apps/axctl/src/cli/commands/ingest-verdicts.test.ts
+++ b/apps/axctl/src/cli/commands/ingest-verdicts.test.ts
@@ -1,0 +1,40 @@
+/**
+ * One-line ingest verdicts (#265/#266): exit-path messages for timeout,
+ * failure, and clean-with-skips runs. Pure formatters - the exit-code wiring
+ * itself lives in cmdIngest and is exercised via the ingest-lock outcome
+ * tests (src/ingest/ingest-lock.test.ts).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+    formatIngestFailedVerdict,
+    formatIngestSkipSummary,
+    formatIngestTimeoutVerdict,
+} from "./ingest.ts";
+
+describe("ingest verdict lines", () => {
+    test("timeout verdict names the env knob and the resume command", () => {
+        const line = formatIngestTimeoutVerdict("ingest", 900);
+        expect(line).toBe(
+            "ingest: timed out after 900s (AX_INGEST_TIMEOUT_SECONDS) - " +
+                "progress saved, re-run 'ax ingest' to continue",
+        );
+    });
+
+    test("timeout verdict maps ingest-here to the real CLI spelling", () => {
+        expect(formatIngestTimeoutVerdict("ingest-here", 60)).toContain(
+            "re-run 'ax ingest here' to continue",
+        );
+    });
+
+    test("failed verdict carries session count and first error", () => {
+        expect(formatIngestFailedVerdict(1134, "DbError: connection reset")).toBe(
+            "ingest: FAILED after 1134 sessions - DbError: connection reset",
+        );
+    });
+
+    test("skip summary reports per-file isolation count", () => {
+        expect(formatIngestSkipSummary(3)).toBe(
+            "ingest: ok - 3 file(s) skipped (per-file isolation; retried next run)",
+        );
+    });
+});

--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -25,8 +25,10 @@ import {
     type ProgressReporter,
 } from "../progress.ts";
 import { stderrExit } from "../output.ts";
+import { safeJsonParse } from "@ax/lib/shared/safe-json";
 import {
     buildIngestEventStatement,
+    buildIngestRunFinishStatement,
     buildIngestRunStartStatement,
     buildIngestStageFinishStatement,
     buildIngestStageStartStatement,
@@ -207,6 +209,45 @@ interface IngestCommandOpts {
  */
 const INGEST_LOCK_STALE_GRACE_MS = 60_000;
 
+/** `ax ingest-here` resumes as `ax ingest here`; everything else as-is. */
+const resumeCommand = (command: string): string =>
+    command === "ingest-here" ? "ax ingest here" : `ax ${command}`;
+
+/** One-line verdicts (#265) printed to stderr so the outcome of a run is
+ *  legible without grepping cascade teardown. Exported for tests. */
+export const formatIngestTimeoutVerdict = (command: string, timeoutSeconds: number): string =>
+    `ingest: timed out after ${timeoutSeconds}s (AX_INGEST_TIMEOUT_SECONDS) - ` +
+    `progress saved, re-run '${resumeCommand(command)}' to continue`;
+
+export const formatIngestFailedVerdict = (sessions: number, firstError: string): string =>
+    `ingest: FAILED after ${sessions} sessions - ${firstError}`;
+
+export const formatIngestSkipSummary = (skippedFiles: number): string =>
+    `ingest: ok - ${skippedFiles} file(s) skipped (per-file isolation; retried next run)`;
+
+/**
+ * Sessions persisted by this run so far, summed from the per-stage `counts`
+ * JSON already written to `ingest_stage` rows. Feeds the FAILED verdict
+ * (#265) - the stage stats themselves are lost down the error channel.
+ */
+const completedSessionCount = (
+    db: SurrealClientShape,
+    runId: string,
+): Effect.Effect<number, DbError> =>
+    Effect.gen(function* () {
+        const res = yield* db.query<[Array<{ counts: string | null }>]>(
+            `SELECT counts FROM ingest_stage WHERE run = ingest_run:\`${runId}\`;`,
+        );
+        let sessions = 0;
+        for (const row of res?.[0] ?? []) {
+            if (typeof row.counts !== "string") continue;
+            const parsed = safeJsonParse<Record<string, unknown>>(row.counts);
+            const n = parsed?.["sessions"];
+            if (typeof n === "number" && Number.isFinite(n)) sessions += n;
+        }
+        return sessions;
+    });
+
 // EXCEPTION to the typed-options rule: runIngest({ args }) forwards raw CLI
 // args into the stage pipeline (src/ingest/run.ts does its own --stages/
 // --since/--reset parsing). Until runIngest grows a typed options contract,
@@ -216,9 +257,13 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
     Effect.gen(function* () {
         const commandName = opts.command ?? "ingest";
         const cfg = yield* AxConfig;
+        const db = yield* SurrealClient;
         const path = yield* Path.Path;
         const lockPath = path.join(cfg.paths.dataDir, "ingest.lock");
         const timeoutSeconds = cfg.knobs.ingestTimeoutSeconds;
+        // The runId is minted HERE (not inside runIngest) so the timeout and
+        // failure paths below can address the `ingest_run` row.
+        const runId = runIdFor(commandName);
 
         const work = runIngest({
             command: commandName,
@@ -228,7 +273,8 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
             ...(opts.claudeProject ? { claudeProject: opts.claudeProject } : {}),
             debug: args.includes("--debug"),
             verbose: args.includes("--verbose"),
-        }).pipe(Effect.asVoid);
+            runId: () => runId,
+        });
 
         // Single-flight + hard wall-clock cap, both owned by the lock. While one
         // ingest holds the lock another SKIPS (the watcher re-fires anyway, so a
@@ -237,7 +283,7 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
         // lock to age into a cooldown - interrupting the fiber doesn't prove
         // SurrealDB stopped server-side, so the next ingest must hold off until
         // the lock goes stale rather than charging a still-busy DB.
-        yield* withIngestLock(
+        const outcome = yield* withIngestLock(
             {
                 lockPath,
                 command: commandName,
@@ -250,16 +296,51 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
                                 `is in progress; skipping.\n`,
                         )
                     ),
+                // The interrupt finalizer (withIngestRunFinish) has already
+                // settled the row as "partial"/interrupted by the time this
+                // runs; overwrite the metrics with the honest timeout reason so
+                // diagnosis doesn't need wall-clock correlation (#266, #269).
+                // Best-effort: a dead DB must not mask the timeout verdict.
                 onTimeout: () =>
-                    Effect.sync(() =>
-                        process.stderr.write(
-                            `axctl ${commandName}: ingest exceeded ${timeoutSeconds}s and was cancelled; ` +
-                                `lock held as cooldown. Raise AX_INGEST_TIMEOUT_SECONDS for a large first backfill.\n`,
-                        )
-                    ),
+                    db.query(buildIngestRunFinishStatement({
+                        runId,
+                        status: "partial",
+                        metrics: { error: `timeout after ${timeoutSeconds}s` },
+                    })).pipe(Effect.ignore),
             },
             work,
+        ).pipe(
+            // Typed failure: print the one-line FAILED verdict (#265) before the
+            // error propagates (BunRuntime.runMain then exits 1).
+            Effect.tapError((error) =>
+                Effect.gen(function* () {
+                    const sessions = yield* completedSessionCount(db, runId).pipe(
+                        Effect.orElseSucceed(() => 0),
+                    );
+                    process.stderr.write(
+                        `${formatIngestFailedVerdict(sessions, errorText(error))}\n`,
+                    );
+                }),
+            ),
         );
+
+        if (outcome._tag === "timeout") {
+            // Timed-out run must not look like success (#265): honest verdict +
+            // resume hint (#266), then a non-zero exit. The ingest_run row is
+            // already finalized as "partial" by onTimeout above.
+            return yield* stderrExit(
+                `${formatIngestTimeoutVerdict(commandName, timeoutSeconds)}\n`,
+                1,
+            );
+        }
+        if (outcome._tag === "completed") {
+            // Per-file isolation (#257) skips broken files instead of failing
+            // the run; say so instead of a silent exit 0.
+            const skipped = outcome.value.totals["failedFiles"] ?? 0;
+            if (skipped > 0) {
+                process.stderr.write(`${formatIngestSkipSummary(skipped)}\n`);
+            }
+        }
     });
 
 /**

--- a/apps/axctl/src/cli/install.test.ts
+++ b/apps/axctl/src/cli/install.test.ts
@@ -3,6 +3,7 @@ import {
     formatDaemonStatus,
     formatDoctorReport,
     parseDaemonCommand,
+    staleRunningIngestRuns,
     type DaemonStatus,
     type DoctorReport,
 } from "./install.ts";
@@ -88,5 +89,40 @@ describe("cli install operations", () => {
             name: "binary",
             ok: true,
         });
+    });
+});
+
+describe("doctor stale ingest_run detection", () => {
+    const NOW = Date.parse("2026-06-11T12:00:00.000Z");
+    const STALE_AFTER_MS = 960_000; // 900s timeout + 60s grace
+
+    const at = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+    test("flags a running row whose newest heartbeat is older than the threshold", () => {
+        const rows = [
+            { id: "ingest_run:dead", started_at: at(3_600_000) }, // 1h ago, no heartbeat
+        ];
+        expect(staleRunningIngestRuns(rows, NOW, STALE_AFTER_MS)).toEqual(rows);
+    });
+
+    test("a fresh heartbeat keeps an old run out of the stale set", () => {
+        const rows = [
+            {
+                id: "ingest_run:live",
+                started_at: at(3_600_000), // started long ago...
+                last_progress_at: at(30_000), // ...but heartbeat 30s ago
+            },
+        ];
+        expect(staleRunningIngestRuns(rows, NOW, STALE_AFTER_MS)).toEqual([]);
+    });
+
+    test("a recent start without heartbeat is not stale", () => {
+        const rows = [{ id: "ingest_run:young", started_at: at(60_000) }];
+        expect(staleRunningIngestRuns(rows, NOW, STALE_AFTER_MS)).toEqual([]);
+    });
+
+    test("rows with no parseable timestamp are flagged (cannot prove liveness)", () => {
+        const rows = [{ id: "ingest_run:mystery" }];
+        expect(staleRunningIngestRuns(rows, NOW, STALE_AFTER_MS)).toEqual(rows);
     });
 });

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -25,6 +25,7 @@ import { prettyPrint } from "@ax/lib/json";
 import schemaSurql from "@ax/schema/schema.surql" with { type: "text" };
 import { bucketNames, renderBucketBackends } from "@ax/schema/render";
 import { envConfig as readDbEnvConfig } from "@ax/lib/db";
+import { DEFAULT_INGEST_TIMEOUT_SECONDS } from "@ax/lib/config";
 
 /**
  * Tagged failure for install steps (surreal resolution, symlinking). Extends
@@ -672,6 +673,76 @@ async function probeMissingBuckets(endpoint: { host: string; port: number }): Pr
     }
 }
 
+/** A row from `SELECT ... FROM ingest_run WHERE status = 'running'`. */
+export interface RunningIngestRunRow {
+    readonly id?: unknown;
+    readonly command?: unknown;
+    readonly started_at?: unknown;
+    readonly last_progress_at?: unknown;
+}
+
+/**
+ * Ingest wall-clock budget (seconds). Doctor runs on the no-DB code path
+ * (no AxConfig layer), so mirror the `AX_INGEST_TIMEOUT_SECONDS` knob with
+ * the same lenient parse-or-fallback the config layer uses.
+ */
+function ingestTimeoutSecondsFromEnv(): number {
+    const parsed = Number.parseInt(process.env.AX_INGEST_TIMEOUT_SECONDS ?? "", 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_INGEST_TIMEOUT_SECONDS;
+}
+
+/**
+ * Rows whose newest heartbeat (`last_progress_at`, else `started_at`) is older
+ * than `staleAfterMs`. A run still in status "running" past the ingest timeout
+ * was crashed/killed without finalizing - every clean exit path (ok, error,
+ * interrupt, timeout) settles the row, so a stale "running" row is a lie that
+ * misleads diagnosis (issue #269). Exported for tests.
+ */
+export function staleRunningIngestRuns(
+    rows: readonly RunningIngestRunRow[],
+    nowMs: number,
+    staleAfterMs: number,
+): RunningIngestRunRow[] {
+    return rows.filter((row) => {
+        const beat = Date.parse(String(row.last_progress_at ?? row.started_at ?? ""));
+        // No parseable timestamp at all: can't prove it's live, flag it.
+        if (!Number.isFinite(beat)) return true;
+        return nowMs - beat > staleAfterMs;
+    });
+}
+
+/**
+ * ingest_run rows stuck in status "running" longer than `staleAfterMs`, or
+ * null when the daemon could not be queried. Plain HTTP for the same reason
+ * as {@link probeMissingBuckets}: doctor has no SurrealClient layer.
+ */
+async function probeStaleIngestRuns(
+    endpoint: { host: string; port: number },
+    staleAfterMs: number,
+): Promise<RunningIngestRunRow[] | null> {
+    try {
+        const db = readDbEnvConfig();
+        const res = await fetch(`http://${endpoint.host}:${endpoint.port}/sql`, {
+            method: "POST",
+            headers: {
+                Accept: "application/json",
+                Authorization: `Basic ${Buffer.from(`${db.user}:${db.pass}`).toString("base64")}`,
+                "surreal-ns": db.ns,
+                "surreal-db": db.db,
+            },
+            body: "SELECT id, command, started_at, last_progress_at FROM ingest_run WHERE status = 'running';",
+            signal: AbortSignal.timeout(3000),
+        });
+        if (!res.ok) return null;
+        const out = (await res.json()) as Array<{ result?: RunningIngestRunRow[] }>;
+        const rows = out?.[0]?.result;
+        if (!Array.isArray(rows)) return null;
+        return staleRunningIngestRuns(rows, Date.now(), staleAfterMs);
+    } catch {
+        return null;
+    }
+}
+
 export function collectDoctorReport(): Effect.Effect<
     DoctorReport,
     never,
@@ -692,8 +763,17 @@ export function collectDoctorReport(): Effect.Effect<
         const runtimeStateExists = yield* fs
             .exists(daemon.endpoint.runtimeStatePath)
             .pipe(orAbsent(false));
-        const missingBuckets = daemon.dbListening && daemon.endpoint.conflict === null
+        const dbReachable = daemon.dbListening && daemon.endpoint.conflict === null;
+        const missingBuckets = dbReachable
             ? yield* Effect.promise(() => probeMissingBuckets(daemon.endpoint))
+            : null;
+        // Stale "running" runs: anything past the ingest timeout (+grace, same
+        // margin the ingest lock uses) without a heartbeat is a crashed run
+        // that never finalized.
+        const ingestTimeoutSeconds = ingestTimeoutSecondsFromEnv();
+        const staleIngestRuns = dbReachable
+            ? yield* Effect.promise(() =>
+                probeStaleIngestRuns(daemon.endpoint, (ingestTimeoutSeconds + 60) * 1000))
             : null;
         const checks: DoctorCheck[] = [
             {
@@ -748,6 +828,18 @@ export function collectDoctorReport(): Effect.Effect<
                 detail: missingBuckets.length === 0
                     ? `${EXPECTED_BUCKETS.join(", ")} defined`
                     : `missing bucket(s): ${missingBuckets.join(", ")}; re-run 'axctl install' to re-apply the schema`,
+            });
+        }
+        if (staleIngestRuns !== null) {
+            const ids = staleIngestRuns.slice(0, 3).map((row) => String(row.id ?? "?")).join(", ");
+            checks.push({
+                name: "ingest-runs",
+                ok: staleIngestRuns.length === 0,
+                detail: staleIngestRuns.length === 0
+                    ? `no ingest_run rows stuck in status "running"`
+                    : `${staleIngestRuns.length} ingest_run row(s) stuck in status "running" past the ` +
+                        `${ingestTimeoutSeconds}s ingest timeout (${ids}); the run crashed or was killed ` +
+                        `without finalizing - ignore the rows for diagnosis and re-run 'ax ingest'`,
             });
         }
         const onboarding = yield* buildOnboardingReport();

--- a/apps/axctl/src/dashboard/telemetry.test.ts
+++ b/apps/axctl/src/dashboard/telemetry.test.ts
@@ -4,6 +4,7 @@ import {
     buildIngestEventStatement,
     buildIngestStageFinishStatement,
     buildIngestStageStartStatement,
+    buildIngestRunFinishStatement,
     buildIngestRunStartStatement,
     makeIngestEvent,
     publishIngestEvent,
@@ -25,9 +26,33 @@ describe("dashboard telemetry", () => {
         expect(event.counts).toEqual({ commits: 2 });
     });
 
-    test("buildIngestRunStartStatement writes run record", () => {
-        expect(buildIngestRunStartStatement({ runId: "r1", command: "ingest", sinceDays: 1 }))
-            .toContain("UPSERT ingest_run:`r1`");
+    test("buildIngestRunStartStatement writes run record with an initial heartbeat", () => {
+        const sql = buildIngestRunStartStatement({ runId: "r1", command: "ingest", sinceDays: 1 });
+        expect(sql).toContain("UPSERT ingest_run:`r1`");
+        expect(sql).toContain("last_progress_at: time::now()");
+    });
+
+    test("buildIngestRunFinishStatement supports the partial status (timeout/interrupt)", () => {
+        const sql = buildIngestRunFinishStatement({
+            runId: "r1",
+            status: "partial",
+            metrics: { error: "timeout after 900s" },
+        });
+        expect(sql).toContain("UPDATE ingest_run:`r1`");
+        expect(sql).toContain('status = "partial"');
+        expect(sql).toContain("timeout after 900s");
+    });
+
+    test("stage start/finish statements bump the run heartbeat", () => {
+        expect(buildIngestStageStartStatement({ runId: "r1", source: "git", stage: "fetch" }))
+            .toContain("UPDATE ingest_run:`r1` SET last_progress_at = time::now()");
+        expect(buildIngestStageFinishStatement({
+            runId: "r1",
+            source: "git",
+            stage: "fetch",
+            status: "ok",
+            counts: {},
+        })).toContain("UPDATE ingest_run:`r1` SET last_progress_at = time::now()");
     });
 
     test("buildIngestEventStatement stores JSON counts", () => {

--- a/apps/axctl/src/dashboard/telemetry.ts
+++ b/apps/axctl/src/dashboard/telemetry.ts
@@ -29,15 +29,28 @@ export function buildIngestRunStartStatement(input: {
     readonly sinceDays?: number | null;
 }): string {
     const since = input.sinceDays === null || input.sinceDays === undefined ? "NONE" : String(input.sinceDays);
-    return `UPSERT ingest_run:\`${input.runId}\` MERGE { command: ${surrealString(input.command)}, status: "running", since_days: ${since}, started_at: time::now() };`;
+    return `UPSERT ingest_run:\`${input.runId}\` MERGE { command: ${surrealString(input.command)}, status: "running", since_days: ${since}, started_at: time::now(), last_progress_at: time::now() };`;
 }
+
+/** Terminal `ingest_run` statuses: "ok" = clean finish, "error" = the run
+ *  failed, "partial" = interrupted/timed out with progress saved (re-running
+ *  `ax ingest` continues incrementally). "running" is never terminal - a row
+ *  stuck there means the process died without finalizing (doctor warns). */
+export type IngestRunFinishStatus = "ok" | "error" | "partial";
 
 export function buildIngestRunFinishStatement(input: {
     readonly runId: string;
-    readonly status: "ok" | "error";
+    readonly status: IngestRunFinishStatus;
     readonly metrics?: unknown;
 }): string {
     return `UPDATE ingest_run:\`${input.runId}\` SET status = ${surrealString(input.status)}, ended_at = time::now(), metrics = ${surrealJson(input.metrics ?? {})} RETURN NONE;`;
+}
+
+/** Heartbeat on the parent run row: stage start/finish bumps
+ *  `last_progress_at` so a genuinely-live "running" run is distinguishable
+ *  from one stranded by a crash (doctor's stale-run check, issue #269). */
+function ingestRunHeartbeatStatement(runId: string): string {
+    return `UPDATE ingest_run:\`${runId}\` SET last_progress_at = time::now() RETURN NONE;`;
 }
 
 export function buildIngestStageStartStatement(input: {
@@ -46,7 +59,7 @@ export function buildIngestStageStartStatement(input: {
     readonly stage: string;
 }): string {
     const id = `${sqlIdPart(input.runId)}__${sqlIdPart(input.source)}__${sqlIdPart(input.stage)}`;
-    return `UPSERT ingest_stage:\`${id}\` MERGE { run: ingest_run:\`${input.runId}\`, source: ${surrealString(input.source)}, stage: ${surrealString(input.stage)}, status: "running", started_at: time::now() };`;
+    return `UPSERT ingest_stage:\`${id}\` MERGE { run: ingest_run:\`${input.runId}\`, source: ${surrealString(input.source)}, stage: ${surrealString(input.stage)}, status: "running", started_at: time::now() }; ${ingestRunHeartbeatStatement(input.runId)}`;
 }
 
 export function buildIngestStageFinishStatement(input: {
@@ -59,7 +72,7 @@ export function buildIngestStageFinishStatement(input: {
 }): string {
     const id = `${sqlIdPart(input.runId)}__${sqlIdPart(input.source)}__${sqlIdPart(input.stage)}`;
     const errorText = input.errorText === undefined ? "NONE" : surrealString(input.errorText);
-    return `UPDATE ingest_stage:\`${id}\` SET status = ${surrealString(input.status)}, ended_at = time::now(), counts = ${surrealJson(input.counts ?? {})}, error_text = ${errorText} RETURN NONE;`;
+    return `UPDATE ingest_stage:\`${id}\` SET status = ${surrealString(input.status)}, ended_at = time::now(), counts = ${surrealJson(input.counts ?? {})}, error_text = ${errorText} RETURN NONE; ${ingestRunHeartbeatStatement(input.runId)}`;
 }
 
 export function buildIngestEventStatement(event: IngestEvent): string {

--- a/apps/axctl/src/ingest/ingest-lock.test.ts
+++ b/apps/axctl/src/ingest/ingest-lock.test.ts
@@ -48,7 +48,7 @@ describe("withIngestLock", () => {
             ),
         );
         expect(ran).toBe(true);
-        expect(result).toBe("ran");
+        expect(result).toEqual({ _tag: "completed", value: "ran" });
         // released after work completes
         expect(existsSync(lockPath)).toBe(false);
     });
@@ -67,7 +67,7 @@ describe("withIngestLock", () => {
             ),
         );
         expect(ran).toBe(false);
-        expect(result).toBe(`busy:${process.pid}`);
+        expect(result).toEqual({ _tag: "busy", value: `busy:${process.pid}` });
     });
 
     test("steals a stale lock (older than staleMs) and runs work", async () => {
@@ -115,7 +115,7 @@ describe("withIngestLock", () => {
         expect(existsSync(lockPath)).toBe(false);
     });
 
-    test("on timeout: KEEPS the lock (cooldown) and runs onTimeout", async () => {
+    test("on timeout: KEEPS the lock (cooldown), runs onTimeout, returns a distinguishable timeout outcome", async () => {
         let timedOut = false;
         const result = await run(
             withIngestLock(
@@ -133,9 +133,33 @@ describe("withIngestLock", () => {
             ),
         );
         expect(timedOut).toBe(true);
-        expect(result).toBeUndefined();
+        // NOT a success value: callers must be able to exit non-zero (#265)
+        expect(result).toEqual({ _tag: "timeout" });
         // lock deliberately left in place so the DB gets a cooldown window
         expect(existsSync(lockPath)).toBe(true);
+    });
+
+    test("onTimeout runs AFTER the interrupted work's finalizers complete", async () => {
+        const order: string[] = [];
+        await run(
+            withIngestLock(
+                {
+                    lockPath,
+                    command: "ingest",
+                    staleMs: STALE_MS,
+                    timeoutSeconds: 1,
+                    now: () => T0,
+                    onBusy: () => Effect.succeed("busy" as const),
+                    onTimeout: () => Effect.sync(() => { order.push("onTimeout"); }),
+                },
+                // work's own finalizer (e.g. withIngestRunFinish settling the
+                // ingest_run row) must have run before onTimeout overwrites it.
+                Effect.never.pipe(
+                    Effect.ensuring(Effect.sync(() => { order.push("work-finalizer"); })),
+                ),
+            ),
+        );
+        expect(order).toEqual(["work-finalizer", "onTimeout"]);
     });
 
     test("atomic acquire: a fresh live holder is never overwritten", async () => {

--- a/apps/axctl/src/ingest/ingest-lock.ts
+++ b/apps/axctl/src/ingest/ingest-lock.ts
@@ -35,6 +35,18 @@ export interface IngestLockInfo {
 }
 
 /**
+ * Discriminated result of {@link withIngestLock}, so callers can tell a
+ * timed-out run apart from a busy skip or a completed run. The distinction is
+ * load-bearing: `ax ingest` must exit non-zero on timeout (#265) while a busy
+ * skip stays exit 0 (the watcher re-fires anyway). An earlier version
+ * collapsed timeout into `undefined`, which read as success.
+ */
+export type IngestLockOutcome<A, A2> =
+    | { readonly _tag: "completed"; readonly value: A }
+    | { readonly _tag: "busy"; readonly value: A2 }
+    | { readonly _tag: "timeout" };
+
+/**
  * Is `pid` a live process this user could signal? `kill(pid, 0)` sends no
  * signal; it only probes existence. ESRCH => gone; EPERM => alive but owned by
  * another user (still "alive" for our purposes).
@@ -67,8 +79,10 @@ const readHolder = (
  * Run `work` while holding the ingest lock. If a fresh lock owned by a live
  * process is already held, run `onBusy(holder)` instead and skip `work`.
  *
- * Returns the work's value on success, the `onBusy` value when busy, or
- * `undefined` when `work` timed out (the lock is then left to age out).
+ * Returns `{ _tag: "completed", value }` with the work's value on success,
+ * `{ _tag: "busy", value }` with the `onBusy` value when skipped, or
+ * `{ _tag: "timeout" }` when `work` timed out (the lock is then left to age
+ * out as a cooldown).
  */
 export const withIngestLock = <A, E, R, A2, E2, R2>(
     opts: {
@@ -80,12 +94,15 @@ export const withIngestLock = <A, E, R, A2, E2, R2>(
         readonly timeoutSeconds?: number;
         readonly now?: () => number;
         readonly onBusy: (holder: IngestLockInfo) => Effect.Effect<A2, E2, R2>;
-        /** logged when `work` exceeds `timeoutSeconds` (lock left to age) */
+        /** run when `work` exceeds `timeoutSeconds` (lock left to age) - e.g.
+         *  finalize the run row + tell the user; runs AFTER the interrupted
+         *  work's own finalizers have completed */
         readonly onTimeout?: () => Effect.Effect<void, never, never>;
     },
     work: Effect.Effect<A, E, R>,
-): Effect.Effect<A | A2 | undefined, E | E2, R | R2 | FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<IngestLockOutcome<A, A2>, E | E2, R | R2 | FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
+        const busy = (value: A2): IngestLockOutcome<A, A2> => ({ _tag: "busy", value });
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
         const now = opts.now ?? (() => Date.now());
@@ -110,7 +127,7 @@ export const withIngestLock = <A, E, R, A2, E2, R2>(
             if (Option.isSome(holder)) {
                 const h = holder.value;
                 if (now() - h.startedAt < opts.staleMs && isProcessAlive(h.pid)) {
-                    return yield* opts.onBusy(h);
+                    return busy(yield* opts.onBusy(h));
                 }
             }
             // Stale / dead / unreadable: steal it, then re-create atomically. If
@@ -119,9 +136,9 @@ export const withIngestLock = <A, E, R, A2, E2, R2>(
             owned = yield* tryCreate();
             if (!owned) {
                 const h2 = yield* readHolder(opts.lockPath);
-                return yield* opts.onBusy(
+                return busy(yield* opts.onBusy(
                     Option.getOrElse(h2, () => ({ pid: -1, startedAt: now(), command: "unknown" })),
-                );
+                ));
             }
         }
 
@@ -152,7 +169,7 @@ export const withIngestLock = <A, E, R, A2, E2, R2>(
 
         if (Option.isNone(result)) {
             if (opts.onTimeout) yield* opts.onTimeout();
-            return undefined;
+            return { _tag: "timeout" } as IngestLockOutcome<A, A2>;
         }
-        return result.value;
+        return { _tag: "completed", value: result.value } as IngestLockOutcome<A, A2>;
     });

--- a/apps/axctl/src/ingest/run.test.ts
+++ b/apps/axctl/src/ingest/run.test.ts
@@ -75,7 +75,7 @@ describe("withIngestRunFinish", () => {
         expect(writes[0]).toContain("boom");
     });
 
-    it("writes status error + interrupted on fiber interruption", async () => {
+    it("writes status partial + interrupted on fiber interruption (progress is saved)", async () => {
         const db = fakeDb();
         const fiber = Effect.runFork(
             withIngestRunFinish(db.client, "r1")(Effect.never),
@@ -85,8 +85,20 @@ describe("withIngestRunFinish", () => {
         await Effect.runPromise(Fiber.interrupt(fiber));
         const writes = finishWrites(db.queries);
         expect(writes).toHaveLength(1);
-        expect(writes[0]).toContain('status = "error"');
+        expect(writes[0]).toContain('status = "partial"');
         expect(writes[0]).toContain("interrupted");
+    });
+
+    it("writes status error on a defect so the row never stays running", async () => {
+        const db = fakeDb();
+        const exit = await Effect.runPromiseExit(
+            withIngestRunFinish(db.client, "r1")(Effect.die(new Error("kaboom"))),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        const writes = finishWrites(db.queries);
+        expect(writes).toHaveLength(1);
+        expect(writes[0]).toContain('status = "error"');
+        expect(writes[0]).toContain("kaboom");
     });
 });
 
@@ -108,12 +120,42 @@ describe("runIngest", () => {
             runId: "test_run",
             selectedStages: ["skills", "commands"],
             status: "ok",
+            // BaseStageStats carries only durationMs (excluded) + summary, so
+            // the numeric totals are empty here.
+            totals: {},
         });
         const sql = db.queries.join("\n");
         expect(sql).toContain("UPSERT ingest_run:`test_run`");
         expect(sql).toContain("UPSERT ingest_stage:`test_run__skills__upsert`");
         expect(sql).toContain("UPSERT ingest_stage:`test_run__commands__upsert`");
         expect(sql).toContain("status = \"ok\"");
+    });
+
+    it("sums numeric stage stats into totals (excluding durationMs)", async () => {
+        const db = fakeDb();
+        const statStage: StageDef = {
+            meta: StageMeta.make({ key: "skills", deps: [], tags: ["ingest"] }),
+            run: () =>
+                Effect.succeed({
+                    ...BaseStageStats.make({ durationMs: 5, summary: "skills done" }),
+                    sessions: 3,
+                    failedFiles: 2,
+                }),
+        };
+        const registry = StageRegistryLive([statStage]);
+        const program = runIngest({
+            command: "ingest",
+            args: [],
+            cwd: "/tmp/ax",
+            now: () => new Date("2026-05-29T00:00:00.000Z"),
+            runId: () => "test_run",
+        }).pipe(Effect.provide(Layer.mergeAll(db.layer, registry, traceLayer())));
+
+        const result = await Effect.runPromise(
+            program as Effect.Effect<unknown, never, never>,
+        ) as { totals: Record<string, number> };
+
+        expect(result.totals).toEqual({ sessions: 3, failedFiles: 2 });
     });
 
     it("rejects reset with stage filters before deleting graph rows", async () => {

--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -80,15 +80,23 @@ const errorText = (error: unknown): string =>
  *  - success       -> status "ok"
  *  - typed failure -> status "error" + `{ error: <message> }`; the original
  *                     failure still propagates
- *  - interruption  -> status "error" + `{ error: "interrupted" }` (best
- *                     effort - the write itself is `Effect.ignore`d)
+ *  - interruption  -> status "partial" + `{ error: "interrupted" }` (best
+ *                     effort - the write itself is `Effect.ignore`d).
+ *                     "partial", not "error": ingest is incremental, so a
+ *                     Ctrl-C/timeout keeps everything persisted so far and a
+ *                     re-run continues (#266). The timeout path in
+ *                     cmdIngest's `onTimeout` then overwrites the metrics
+ *                     with the honest timeout reason.
+ *  - defect        -> status "error" + the squashed defect text (best
+ *                     effort) - a crash must never strand the row in
+ *                     "running" (#269); the defect still propagates
  *
- * Pure defects write nothing, mirroring the old trio (tap/catch never saw
- * them). The finalizer runs while the SurrealClient scope is still open
- * (inner scope unwinds before the layer closes the connection), so the last
- * write has a live connection. The interruption arm requires the process
- * main fiber to actually be interrupted on SIGINT - see BunRuntime.runMain
- * in cli/index.ts.
+ * The finalizer runs while the SurrealClient scope is still open (inner
+ * scope unwinds before the layer closes the connection), so the last write
+ * has a live connection. The interruption arm requires the process main
+ * fiber to actually be interrupted on SIGINT - see BunRuntime.runMain in
+ * cli/index.ts. A hard kill (SIGKILL/power loss) runs no finalizer at all;
+ * `ax doctor`'s stale-run check catches those rows.
  */
 export const withIngestRunFinish = (db: SurrealClientShape, runId: string) =>
     <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | DbError, R> =>
@@ -103,18 +111,25 @@ export const withIngestRunFinish = (db: SurrealClientShape, runId: string) =>
             if (Exit.hasInterrupts(exit)) {
                 return db.query(buildIngestRunFinishStatement({
                     runId,
-                    status: "error",
+                    status: "partial",
                     metrics: { error: "interrupted" },
                 })).pipe(Effect.ignore);
             }
             const failure = Cause.findErrorOption(cause);
-            return Option.isSome(failure)
-                ? db.query(buildIngestRunFinishStatement({
+            if (Option.isSome(failure)) {
+                return db.query(buildIngestRunFinishStatement({
                     runId,
                     status: "error",
                     metrics: { error: errorText(failure.value) },
-                })).pipe(Effect.asVoid)
-                : Effect.void;
+                })).pipe(Effect.asVoid);
+            }
+            // Defect: still settle the row (never leave "running"), best
+            // effort; the defect itself propagates past this finalizer.
+            return db.query(buildIngestRunFinishStatement({
+                runId,
+                status: "error",
+                metrics: { error: errorText(Cause.squash(cause)) },
+            })).pipe(Effect.ignore);
         });
 
 const numericCounts = (value: unknown): Record<string, number> => {
@@ -246,6 +261,10 @@ export interface RunIngestResult {
     readonly runId: string;
     readonly selectedStages: readonly string[];
     readonly status: "ok";
+    /** Numeric stage stats summed across all stages (e.g. `sessions`,
+     *  `failedFiles` from the per-file isolation guards). `durationMs` is
+     *  excluded - summing wall-clocks across concurrent stages is noise. */
+    readonly totals: Record<string, number>;
 }
 
 const defaultRunId = (command: string): string =>
@@ -293,7 +312,7 @@ export const runIngest = (
             )
         );
 
-        yield* runPipeline(wrappedStages, ctx).pipe(
+        const stageStats = yield* runPipeline(wrappedStages, ctx).pipe(
             LiveTrace.withTrace({
                 traceId: `ingest:${runId}`,
                 label: `ingest ${selectedStages.map((s) => s.meta.key).join(",")}`,
@@ -303,9 +322,18 @@ export const runIngest = (
             Effect.provideService(References.MinimumLogLevel, opts.verbose ? "Debug" : "Info"),
         );
 
+        const totals: Record<string, number> = {};
+        for (const stats of stageStats) {
+            for (const [key, value] of Object.entries(stats)) {
+                if (key === "durationMs" || typeof value !== "number" || !Number.isFinite(value)) continue;
+                totals[key] = (totals[key] ?? 0) + value;
+            }
+        }
+
         return {
             runId,
             selectedStages: selectedStages.map((s) => s.meta.key),
             status: "ok" as const,
+            totals,
         };
     });

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -60,6 +60,11 @@ const DEFAULTS = {
     sessionsEnrichConcurrency: 16,
 } as const;
 
+/** Default hard wall-clock cap on a single CLI ingest (seconds). Exported for
+ *  code paths that run without AxConfig (e.g. `ax doctor` on the no-DB-layer
+ *  route) but must mirror the `AX_INGEST_TIMEOUT_SECONDS` knob's default. */
+export const DEFAULT_INGEST_TIMEOUT_SECONDS = DEFAULTS.ingestTimeoutSeconds;
+
 /** Legacy-faithful int knob parsing, byte-identical to the old hand-rolled
  *  env readers: `Number.parseInt(raw, 10)` prefix-parses (`" 5"` -> 5,
  *  `"5abc"` -> 5, `"5.5"` -> 5, `"1e2"` -> 1); a missing var, empty string,

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1082,6 +1082,9 @@ DEFINE FIELD command       ON ingest_run TYPE string;
 DEFINE FIELD status        ON ingest_run TYPE string DEFAULT 'running';
 DEFINE FIELD since_days    ON ingest_run TYPE option<int>;
 DEFINE FIELD started_at    ON ingest_run TYPE datetime DEFAULT time::now();
+-- Heartbeat: bumped on every stage start/finish so a genuinely-live "running"
+-- run is distinguishable from one stranded by a crash (doctor stale-run check).
+DEFINE FIELD last_progress_at ON ingest_run TYPE option<datetime>;
 DEFINE FIELD ended_at      ON ingest_run TYPE option<datetime>;
 DEFINE FIELD metrics       ON ingest_run TYPE option<string>;
 DEFINE INDEX IF NOT EXISTS ingest_run_status_started ON ingest_run FIELDS status, started_at;

--- a/packages/schema/src/schema.test.ts
+++ b/packages/schema/src/schema.test.ts
@@ -214,3 +214,9 @@ describe("content block artifact schema", () => {
         expect(schema).toContain("DEFINE INDEX IF NOT EXISTS mentions_file_document ON mentions_file FIELDS document");
     });
 });
+
+describe("ingest_run lifecycle schema", () => {
+    test("last_progress_at heartbeat field on ingest_run is present", () => {
+        expect(schema).toContain("DEFINE FIELD last_progress_at ON ingest_run TYPE option<datetime>");
+    });
+});


### PR DESCRIPTION
Fixes three bugs observed in the same real first-run session (gist [fe8661f9](https://gist.github.com/supnim/fe8661f9328645f5f132667698c4a426), same session as #251), all in the ingest run lifecycle.

## #265 - exit codes

`ax ingest` exited 0 on errored and timed-out runs. Root cause: `withIngestLock` mapped a timeout (`Effect.timeoutOption` -> `Option.none`) to a plain `undefined` success, and `onTimeout` only logged.

- `withIngestLock` now returns a discriminated `completed | busy | timeout` outcome (`apps/axctl/src/ingest/ingest-lock.ts`), so a timeout is structurally distinguishable from success.
- `cmdIngest` exits **1** on timeout via `stderrExit`, printing `ingest: timed out after Ns (AX_INGEST_TIMEOUT_SECONDS) - progress saved, re-run 'ax ingest' to continue`.
- Typed failures print `ingest: FAILED after N sessions - <first error>` (session count summed from the `ingest_stage` counts already persisted for the run) before the error propagates to `BunRuntime.runMain`'s exit-1 teardown.
- Clean runs with per-file skips (#257 isolation) stay exit 0 but report `ingest: ok - N file(s) skipped (per-file isolation; retried next run)`, fed by a new `totals` aggregate on `RunIngestResult`.

## #266 - timeout UX

The 900s default wall-clock killed a 3,827-session first backfill with `{"error":"interrupted"}` and no resume hint.

- On timeout, `onTimeout` now finalizes the `ingest_run` row as status **"partial"** with `{ error: "timeout after Ns" }` (it runs after the interrupted work's own finalizers, verified by a new ordering test), and the user gets the honest message + resume hint above instead of a teardown cascade.
- Backlog-aware timeout scaling was considered but not included: the dry-run source count requires its own scan, which is not cheap enough to run before every ingest. The honest message + partial status + non-zero exit is the core fix.

## #269 - stale "running" rows

`ingest_run` rows stayed `status: "running"` forever on crash/interrupt/timeout, which actively misled diagnosis in #251.

- `withIngestRunFinish` (already an `onExit` finalizer around the pipeline) now settles the row on **all** exits: success -> `ok`, typed failure -> `error`, interrupt -> `partial` + `interrupted`, and defects -> `error` + squashed defect text (previously defects wrote nothing).
- New `last_progress_at` heartbeat field on `ingest_run` (`packages/schema/src/schema.surql`), bumped by every stage start/finish statement, so a genuinely-live run is distinguishable from a stranded one.
- New `ax doctor` check `ingest-runs` (follows the existing `db-buckets` plain-HTTP probe pattern in `apps/axctl/src/cli/install.ts`) warns on "running" rows whose newest heartbeat is older than the ingest timeout + 60s grace. Hard kills (SIGKILL/power loss) run no finalizer, so doctor is the backstop.

No new table, so no `SCHEMA_TABLES` registration needed; the new field is `option<datetime>` (safe for existing DBs) and covered by a schema presence test.

## Verification

- `bun run typecheck` clean
- full repo suite: 3061 pass / 0 fail (330 files)
- new/extended tests: lock timeout outcome + onTimeout-after-finalizers ordering, run finalization on interrupt (partial) and defect (error), totals aggregation, heartbeat statements, partial finish statement, verdict formatting, doctor stale-run detection (heartbeat fresh/stale/missing), schema field presence

Closes #265
Closes #266
Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)