### PR TITLE
fix(share): adapt recover to discriminated ingest-lock outcome

### DIFF
--- a/apps/axctl/src/share/recover.ts
+++ b/apps/axctl/src/share/recover.ts
@@ -126,13 +126,15 @@ export const ingestShareTranscript = (
             work,
         );
 
-        // undefined = timed out; the lock is deliberately left as a cooldown
-        // (see ingest-lock.ts header).
-        const timedOut: ShareIngestOutcome = {
-            kind: "failed",
-            message: `ingest exceeded ${timeoutSeconds}s and was cancelled; retry shortly`,
-        };
-        return outcome ?? timedOut;
+        // On timeout the lock is deliberately left as a cooldown (see
+        // ingest-lock.ts header); completed/busy both carry a ShareIngestOutcome.
+        if (outcome._tag === "timeout") {
+            return {
+                kind: "failed",
+                message: `ingest exceeded ${timeoutSeconds}s and was cancelled; retry shortly`,
+            } satisfies ShareIngestOutcome;
+        }
+        return outcome.value;
     }).pipe(
         Effect.catch((error) =>
             Effect.succeed<ShareIngestOutcome>({


### PR DESCRIPTION
Main typecheck broke after merging #277 and #279 together: each was CI-green alone, but #279 changed `withIngestLock` to return a discriminated `completed | busy | timeout` outcome while #277's `share/recover.ts` consumed the old direct-value API (`outcome ?? timedOut`).

Fix: handle the discriminated union — `timeout` maps to the existing `failed` outcome with the retry hint, `completed`/`busy` unwrap `.value` (both already carry a `ShareIngestOutcome`).

Verified: full `tsc --noEmit` exit 0 (was failing on main with TS2375 at `recover.ts:85`); recover + share + ingest-lock suites 30 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
