### PR TITLE
fix(dashboard): short-circuit empty-q /api/recall before AppLayer

### DIFF
--- a/apps/axctl/src/dashboard/router/router.ts
+++ b/apps/axctl/src/dashboard/router/router.ts
@@ -6,7 +6,10 @@
  *   - jsonRoute: pure param decoder -> Effect handler -> JSON encode, with
  *     optional respond/errorStatus overrides.
  *   - rawRoute: full Request -> Response escape hatch (SSE /api/events,
- *     binary /api/image, POST /api/ingest - the IngestStreamBus seam).
+ *     binary /api/image, POST /api/ingest - the IngestStreamBus seam - plus
+ *     the pure responses that must never build AppLayer: /api/version and
+ *     empty-q /api/recall, whose eager SurrealClient build would stall ~5s
+ *     without a DB).
  *
  * The Effect runner is injectable so router/route unit tests never build
  * AppLayer (and therefore never touch SurrealDB).
@@ -139,7 +142,7 @@ export interface AnyRoute {
 const toMethods = (m: Method | ReadonlyArray<Method> | "ANY"): ReadonlyArray<Method> =>
     m === "ANY" ? [] : Array.isArray(m) ? m : [m as Method];
 
-const errorMessage = (err: unknown): string => {
+export const errorMessage = (err: unknown): string => {
     if (err instanceof Error) return err.message;
     if (typeof err === "object" && err !== null && "message" in err) {
         return String(err.message);

--- a/apps/axctl/src/dashboard/router/routes/insights.test.ts
+++ b/apps/axctl/src/dashboard/router/routes/insights.test.ts
@@ -64,6 +64,47 @@ describe("decodeGraphExplorerParams", () => {
     });
 });
 
+describe("GET /api/recall", () => {
+    const run = (urlStr: string, runner: (effect: unknown) => Promise<unknown>) => {
+        const matched = matchRoute(insightRoutes, "GET", "/api/recall");
+        if (matched.kind !== "matched") throw new Error("expected /api/recall to match");
+        return matched.match.route.run(input(urlStr), runner as never);
+    };
+
+    test("empty q answers without building AppLayer (runner never invoked)", async () => {
+        // Same DB-less proof as the /api/version route test: a poisoned
+        // runner stands in for appLayerRunner, whose eager SurrealClient
+        // build stalls ~5s without a DB (issue #245).
+        const res = await run(
+            "http://h/api/recall",
+            () => Promise.reject(new Error("AppLayer must not be built for empty q")),
+        );
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toMatchObject({
+            q: "",
+            hits: [],
+            total_count: 0,
+            window: { offset: 0, limit: 50 },
+        });
+    });
+
+    test("non-empty q still runs through the runner", async () => {
+        const sentinel = { q: "hello", hits: [], total_count: 7 };
+        const res = await run("http://h/api/recall?q=hello", () => Promise.resolve(sentinel));
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toEqual(sentinel);
+    });
+
+    test("non-empty q keeps the legacy 500 error mapping", async () => {
+        const res = await run(
+            "http://h/api/recall?q=hello",
+            () => Promise.reject(new Error("db down")),
+        );
+        expect(res.status).toBe(500);
+        await expect(res.json()).resolves.toEqual({ error: "db down" });
+    });
+});
+
 describe("insightRoutes method behavior", () => {
     test("migrated legacy GET-only routes fall through on wrong method", () => {
         expect(matchRoute(insightRoutes, "POST", "/api/recall").kind).toBe("unmatched");

--- a/apps/axctl/src/dashboard/router/routes/insights.ts
+++ b/apps/axctl/src/dashboard/router/routes/insights.ts
@@ -13,8 +13,10 @@ import {
     decodeFail,
     decodeFailWith,
     decodeOk,
+    errorMessage,
     jsonResponse,
     jsonRoute,
+    rawRoute,
     type AnyRoute,
     type Decoded,
     type RouteInput,
@@ -94,15 +96,28 @@ export const insightRoutes: ReadonlyArray<AnyRoute> = [
         decode: decodeSkillGraphParams,
         handler: (params) => fetchSkillGraph(params),
     }),
-    legacyGetRoute({
+    rawRoute({
+        // rawRoute (not jsonRoute) so the empty-q case answers before the
+        // runner: building AppLayer eagerly opens SurrealClient and stalls
+        // ~5s without a DB - same class as /api/version (issue #245).
+        method: "GET",
         path: "/api/recall",
-        decode: decodeRecallParams,
-        handler: (params) =>
-            params.q.trim().length === 0
-                ? Effect.succeed(
+        fallthroughOnMethodMismatch: true,
+        handler: async (input) => {
+            const decoded = decodeRecallParams(input);
+            if (!decoded.ok) return jsonResponse(decoded.body, decoded.status);
+            const params = decoded.value;
+            if (params.q.trim().length === 0) {
+                return jsonResponse(
                     emptyRecallResponse(params.q, params.offset ?? 0, params.limit ?? 50),
-                )
-                : fetchRecall(params),
+                );
+            }
+            try {
+                return jsonResponse(await input.runner(fetchRecall(params)));
+            } catch (err) {
+                return jsonResponse({ error: errorMessage(err) }, 500);
+            }
+        },
     }),
     legacyGetRoute({
         path: "/api/projects/:project+",


### PR DESCRIPTION
## What

Follow-up from the PR #232 post-merge audit (issue #245). `/api/version` was already converted to a `rawRoute` so it never builds AppLayer (whose eager SurrealClient build stalls ~5s without a DB), but `/api/recall` with empty `q` still returned its pure empty payload through `appLayerRunner` - the same latent DB-less stall class.

## Changes

- **`apps/axctl/src/dashboard/router/routes/insights.ts`** - `/api/recall` is now a `rawRoute`: empty/blank `q` answers with `emptyRecallResponse(...)` before the runner; non-empty `q` still goes through `input.runner(fetchRecall(params))` with the identical legacy 500 `{ error }` mapping. `fallthroughOnMethodMismatch` preserved (POST `/api/recall` stays unmatched).
- **`apps/axctl/src/dashboard/router/router.ts`** - exported `errorMessage` for the raw recall handler; updated the escape-hatch doc comment to list the actual `rawRoute` users (SSE `/api/events`, binary `/api/image`, POST `/api/ingest`, `/api/version`, empty-q `/api/recall`).
- **`apps/axctl/src/dashboard/router/routes/insights.test.ts`** - DB-less proof mirroring the `/api/version` route test: a poisoned runner that rejects stands in for `appLayerRunner`; empty-q returns 200 + the canned empty payload without invoking it. Plus regression tests that non-empty `q` still runs through the runner and keeps the legacy 500 error mapping.

## Acceptance criteria

- [x] Empty-q `/api/recall` responds without building AppLayer (DB-less test proves it, like the version-route test)
- [x] Non-empty recall behavior unchanged (runner pass-through + 500 mapping tests)
- [x] Router escape-hatch doc comment lists actual `rawRoute` users

## Verification

- `bun run typecheck` - clean (only pre-existing informational Effect LSP messages)
- `bun test` - 3135 pass, 0 fail (335 files)

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)