### PR TITLE
perf(schema): add skill_paired endpoint indexes

### DIFF
--- a/apps/axctl/src/queries/skill-detail.test.ts
+++ b/apps/axctl/src/queries/skill-detail.test.ts
@@ -63,9 +63,8 @@ describe("SKILL_DETAIL_BASIC_SQL", () => {
     });
 
     test("excludes the dashboard evidence blocks (TUI hot-path regression)", () => {
-        // The TUI DetailPane queries per row selection; the evidence blocks
-        // (esp. `paired`, an unindexed skill_paired endpoint scan) must never
-        // leak back into the basic variant.
+        // The TUI DetailPane queries per row selection; the dashboard-only
+        // evidence blocks must never leak back into the basic variant.
         expect(SKILL_DETAIL_BASIC_SQL).not.toContain("corrections:");
         expect(SKILL_DETAIL_BASIC_SQL).not.toContain("proposals:");
         expect(SKILL_DETAIL_BASIC_SQL).not.toContain("paired:");

--- a/apps/axctl/src/queries/skill-detail.ts
+++ b/apps/axctl/src/queries/skill-detail.ts
@@ -23,9 +23,9 @@ import type {
  *   blocks it renders: skill row, invocation counts, recent list, daily
  *   sparkline buckets. All filtered by the indexed `invoked.out`.
  * - `SKILL_DETAIL_SQL` - the full dashboard payload. Adds the evidence blocks
- *   (`corrections`, `proposals`, `paired`); `paired` scans `skill_paired` by
- *   both endpoints (no endpoint index), which is fine for an explicit
- *   click-to-expand panel but too heavy for the TUI's per-row selection.
+ *   (`corrections`, `proposals`, `paired`); `paired` looks up `skill_paired`
+ *   by both endpoints (indexed: `skill_paired_in`/`skill_paired_out`). Still
+ *   dashboard-only - the TUI's per-row selection keeps the lighter variant.
  */
 export const SKILL_DETAIL_BASIC_SQL = `
 LET $s = (SELECT * FROM skill WHERE name = $name)[0];

--- a/apps/axctl/src/tui/queries.ts
+++ b/apps/axctl/src/tui/queries.ts
@@ -14,6 +14,5 @@ export {
 
 // The TUI DetailPane re-queries per (debounced) row selection, so it gets the
 // lightweight variant - the full SKILL_DETAIL_SQL adds dashboard evidence
-// blocks (corrections/proposals/paired) the TUI never renders, and `paired`
-// scans skill_paired by both endpoints (unindexed).
+// blocks (corrections/proposals/paired) the TUI never renders.
 export { SKILL_DETAIL_BASIC_SQL as SKILL_DETAIL_SQL } from "../queries/skill-detail.ts";

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1400,6 +1400,10 @@ DEFINE INDEX IF NOT EXISTS derived_from_out ON derived_from FIELDS out;
 DEFINE TABLE skill_paired TYPE RELATION FROM skill TO skill;  -- skills co-occurring in same session within N turns
 DEFINE FIELD count        ON skill_paired TYPE int DEFAULT 1;
 DEFINE FIELD last_seen    ON skill_paired TYPE datetime;
+-- Endpoint indexes: the dashboard skill-detail `paired` block filters by
+-- `in = $s.id OR out = $s.id` (apps/axctl/src/queries/skill-detail.ts).
+DEFINE INDEX IF NOT EXISTS skill_paired_in  ON skill_paired FIELDS in;
+DEFINE INDEX IF NOT EXISTS skill_paired_out ON skill_paired FIELDS out;
 
 DEFINE TABLE recovered_by TYPE RELATION FROM turn TO skill;   -- skill invoked after has_error=true turn
 DEFINE FIELD ts            ON recovered_by TYPE datetime;


### PR DESCRIPTION
Closes #246

## What

The dashboard `SKILL_DETAIL_SQL` `paired` block filters `skill_paired WHERE in = $s.id OR out = $s.id` with no endpoint index — a full relation scan on every skill-detail request. This adds `skill_paired_in` / `skill_paired_out` indexes in `packages/schema/src/schema.surql`, following the existing relation-endpoint convention (`spawned_in/out`, `supersedes_in/out`, `produced_artifact_in/out`, ...).

Comment-only follow-ups in `apps/axctl/src/queries/skill-detail.ts`, `apps/axctl/src/tui/queries.ts`, and `apps/axctl/src/queries/skill-detail.test.ts`, which all described the scan as unindexed.

## Verification

Local SurrealDB at `127.0.0.1:8521` ns=`ax` db=`main` was reachable; indexes applied via the same `DEFINE INDEX IF NOT EXISTS` statements (idempotent with `bun run db:schema`).

**EXPLAIN before** (filter pushed into a full table scan):

```json
{"operator":"TableScan","attributes":{"table":"skill_paired","pre_decode_filter":"yes","predicate":"in = skill:... OR out = skill:..."}}
```

**EXPLAIN after** (union of the two new endpoint indexes):

```json
{"operator":"UnionIndexScan","attributes":{"table":"skill_paired","branches":"2"},"children":[
  {"operator":"IndexScan","attributes":{"index":"skill_paired_in","access":"= skill:..."}},
  {"operator":"IndexScan","attributes":{"index":"skill_paired_out","access":"= skill:..."}}]}
```

Correctness spot-check: the full `paired` block (partner/count/last_seen, `ORDER BY count DESC LIMIT 5`) returns identical, correct rows through the indexed path (verified against `codex:close_agent`, top partner `codex:spawn_agent` count 507).

Volume note: this local graph has only 112 `skill_paired` rows, so latency delta is noise — the plan change (TableScan → UnionIndexScan) is the verified improvement, per the issue's "measurement documented if volume is trivial" clause.

## Guardrails

- `SCHEMA_TABLES` mirror needs no change — `skill_paired` is already registered (`apps/axctl/src/queries/insights.ts:161`); the mirror guard test tracks `DEFINE TABLE` statements only, and it passes.
- No `DELETE ... WHERE` on the newly indexed fields introduced (the only existing delete is a whole-table `DELETE skill_paired;` in `ingest/run.ts`, which is unaffected by the ghost-index pitfall).

## Tests

- `bun run typecheck` — pass (Effect-lint informational messages only)
- `bun test` — 3132 pass, 4 skip, 0 fail (335 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)