### PR TITLE
fix(cli): route share/star through family manifests, remove pre-dispatch bypass

### DIFF
--- a/apps/axctl/src/cli/commands/star.ts
+++ b/apps/axctl/src/cli/commands/star.ts
@@ -1,0 +1,27 @@
+// Extracted from the cli/index.ts dispatch bypass (issue #242): `star` now
+// routes through the standard manifest path like every other "none" command.
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { cmdStar } from "../star-nudge.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { boolArg } from "./shared.ts";
+
+export const starCommand = Command.make(
+    "star",
+    {
+        done: Flag.boolean("done").pipe(Flag.withDefault(false)),
+        starred: Flag.boolean("starred").pipe(Flag.withDefault(false)),
+    },
+    ({ done, starred }) =>
+        Effect.promise(() =>
+            cmdStar([...boolArg("done", done), ...boolArg("starred", starred)]),
+        ),
+).pipe(
+    Command.withDescription(
+        "Star the ax repo on GitHub via gh (--done / --starred just hides the reminder)",
+    ),
+);
+
+export const starRuntime: RuntimeManifest = {
+    star: "none",
+};

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -282,6 +282,21 @@ describe("effect cli", () => {
         expect(DB_COMMANDS.has("pricing")).toBe(true);
     });
 
+    test("share and star route through manifests as no-DB commands - no dispatch bypass (#242)", () => {
+        const names = topLevelNames();
+        expect(names).toContain("share");
+        expect(names).toContain("star");
+        expect(RUNTIME_BY_COMMAND["share"]).toBe("none");
+        expect(RUNTIME_BY_COMMAND["star"]).toBe("none");
+        expect(DB_COMMANDS.has("share")).toBe(false);
+        expect(DB_COMMANDS.has("star")).toBe(false);
+        // star is the nudge target (`ax star --done`), not a discovery surface
+        const byName = new Map(
+            rootCommand.subcommands.flatMap((g) => g.commands.map((c) => [c.name, c] as const)),
+        );
+        expect(byName.get("star")?.hidden).toBe(true);
+    });
+
     test("DB-backed classifier package-operation flags are routed through DB", () => {
         expect(classifiersPackageOperationsNeedsDb([
             "classifiers",

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -4,8 +4,7 @@ import { BunFileSystem, BunPath, BunRuntime } from "@effect/platform-bun";
 import { Command } from "effect/unstable/cli";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import { AppLayer } from "@ax/lib/layers";
-import { cmdShare } from "./share.ts";
-import { cmdStar, maybePrintStarNudge } from "./star-nudge.ts";
+import { maybePrintStarNudge } from "./star-nudge.ts";
 import { insightsCommand, reportCommand, timelineCommand, reportRuntime } from "./commands/report.ts";
 import { signalsCommand, signalsRuntime } from "./commands/signals.ts";
 import { evidenceCommand, evidenceRuntime } from "./commands/evidence.ts";
@@ -13,6 +12,7 @@ import { contextCommand, contextRuntime } from "./commands/context.ts";
 import { projectCommand, projectRuntime } from "./commands/project.ts";
 import { serveCommand, mcpCommand, tuiCommand, serveRuntime } from "./commands/serve.ts";
 import { shareCommand, shareRuntime } from "./commands/share.ts";
+import { starCommand, starRuntime } from "./commands/star.ts";
 import { dogfoodCommand, dogfoodRuntime } from "./commands/dogfood.ts";
 import { costsGroupCommand, locCommand, pricingCommand, costsRuntime } from "./commands/costs.ts";
 import { recallCommand, recallRuntime } from "./commands/recall.ts";
@@ -102,6 +102,7 @@ export const rootCommand = Command.make("axctl").pipe(
         Command.withHidden(daemonCommand),
         Command.withHidden(doctorCommand),
         Command.withHidden(uninstallCommand),
+        Command.withHidden(starCommand), // nudge target (`ax star --done`) - pointed at by the star reminder, not for the help list
         ...devOnlyCommands,
     ]),
 );
@@ -233,6 +234,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...projectRuntime,
     ...serveRuntime,
     ...shareRuntime,
+    ...starRuntime,
     ...dogfoodRuntime,
     ...costsRuntime,
     ...recallRuntime,
@@ -274,9 +276,9 @@ export { resolveIngestStages, detectRemovedIngestFlag, insightsOnlyConflicts } f
  * ingest_run finish row + ingest-lock release) instead of hard-killing
  * mid-run and stranding `ingest_run` rows in status "running".
  *
- * Non-Effect legacy commands (version/star/share) are wrapped in
- * `Effect.promise`; a rejection becomes a defect and flows through the same
- * `reportCliFailure` path the old `.catch` handled.
+ * The one remaining non-Effect legacy path (`-V`/`--version` flag printing)
+ * is wrapped in `Effect.promise`; a rejection becomes a defect and flows
+ * through the same `reportCliFailure` path the old `.catch` handled.
  */
 const dispatch = (args: ReadonlyArray<string>): Effect.Effect<void, unknown> => {
     if (args[0] === undefined) {
@@ -295,9 +297,6 @@ const dispatch = (args: ReadonlyArray<string>): Effect.Effect<void, unknown> => 
     }
     if (args[0] === "upgrade") {
         return withoutDb(["update", ...args.slice(1)]);
-    }
-    if (args[0] === "star") {
-        return Effect.promise(() => cmdStar(args.slice(1)));
     }
     if (args[0] === "ingest") {
         // Effect's CLI parser silently ignores unknown flags, so the removed
@@ -323,12 +322,6 @@ const dispatch = (args: ReadonlyArray<string>): Effect.Effect<void, unknown> => 
     }
     if (args[0] === "classifiers" && (args[1] === "eval" || args[1] === "list" || args[1] === "package-operations")) {
         return withoutDb(args);
-    }
-    if (args[0] === "share") {
-        if (args[1] === "--help" || args[1] === "-h") {
-            return withoutDb(args);
-        }
-        return Effect.promise(() => cmdShare(args.slice(1)));
     }
     if (DB_COMMANDS.has(args[0] ?? "")) {
         return withDb(args);


### PR DESCRIPTION
Closes #242

## What

`share` had a full Effect-CLI registration + manifest entry, yet `dispatch` (apps/axctl/src/cli/index.ts) still short-circuited to `Effect.promise(() => cmdShare(...))` before manifest routing; `star` bypassed with no manifest entry at all. Both now route through the standard `withoutDb` path like every other `"none"` command, so the two code paths can't diverge.

## Changes

- **`apps/axctl/src/cli/commands/star.ts` (new)** - `starCommand` (`--done` / `--starred` flags forwarding to `cmdStar`) + `starRuntime: { star: "none" }` manifest, mirroring the existing family-module pattern.
- **`apps/axctl/src/cli/index.ts`** - deleted both early-return branches; registered `starCommand` hidden (it's the nudge target `ax star --done`, not a discovery surface, matching the "Hidden command" note in star-nudge.ts); spread `starRuntime` into `RUNTIME_BY_COMMAND`; updated the stale "Non-Effect legacy commands (version/star/share)" dispatch comment.
- **`apps/axctl/src/cli/effect-cli.test.ts`** - regression test pinning share/star as registered, manifest-declared `"none"` commands outside `DB_COMMANDS`, with star hidden. The existing forward/reverse exhaustiveness guards now cover `star` automatically since it's a registered top-level command.

## Behavior parity

| Invocation | Before | After |
|---|---|---|
| `ax share --help` | Effect-CLI help, exit 0 | byte-identical |
| `ax share` (no args) | `missing <session-id>` + usage, exit 2 | identical (variadic min 0 keeps `cmdShare`'s own arg validation live) |
| `ax share <id> [--dry-run/--open/--public/--yes]` | `cmdShare` | same `cmdShare`, now via the registered handler |
| `ax star --done` | marks nudge state, exit 0 | identical (verified against sandboxed `AX_DATA_DIR`) |
| `ax star --help` | fell through to the gh star flow | proper help, exit 0 |
| root `ax --help` | no `star` listed | unchanged (hidden) |

Only divergence: unknown-flag errors (`ax share --bogus`) now produce the standard Effect-CLI `Unrecognized flag` + exit 1 instead of the hand-rolled usage + exit 2 - i.e. the same behavior as every other command, which is the unification this issue asks for.

## Verification

- `bun run typecheck` - clean (exit 0, only pre-existing effect-lsp info messages)
- `bun test` - 3133 pass / 0 fail (3137 across 335 files)
- Before/after smoke runs of `share --help`, `share`, `share --bogus-flag`, `star --help`, `star --done`

🤖 Generated with [Claude Code](https://claude.com/claude-code)