### PR TITLE
refactor(cli): db-conditional manifest kind - move classifiers sub-routing out of dispatch

### DIFF
--- a/apps/axctl/src/cli/commands/classifiers.ts
+++ b/apps/axctl/src/cli/commands/classifiers.ts
@@ -633,6 +633,24 @@ export const classifiersPackageOperationsNeedsDb = (args: ReadonlyArray<string>)
         args.includes("--boundary-replay-summary")
     );
 
+// The classifiers family owns its sub-routing (issue #241): dispatch reads
+// this db-conditional declaration via resolveRuntime instead of hard-coding
+// subcommand names. effect-cli.test.ts enforces this table is exhaustive
+// against classifiersCommand's registered subcommands in both directions.
 export const classifiersRuntime: RuntimeManifest = {
-    classifiers: "db",
+    classifiers: {
+        kind: "db-conditional",
+        fallback: "db",
+        subcommands: {
+            list: "none",
+            eval: "none",
+            explain: "db",
+            graph: "db",
+            lifecycle: "db",
+            "package-operations": (args) =>
+                classifiersPackageOperationsNeedsDb(args) ? "db" : "none",
+            "workflow-candidates": "db",
+            "label-mining": "db",
+        },
+    },
 };

--- a/apps/axctl/src/cli/commands/manifest.ts
+++ b/apps/axctl/src/cli/commands/manifest.ts
@@ -14,4 +14,47 @@ export type CommandRuntime =
     /** must never touch the DB - route through withoutDb (Proxy SurrealClient that throws) */
     | "none";
 
-export type RuntimeManifest = Readonly<Record<string, CommandRuntime>>;
+/**
+ * Routing for one subcommand of a db-conditional family: either a static
+ * runtime, or a per-invocation resolver over the raw argv (args[0] is the
+ * family name) for subcommands whose DB usage depends on flags.
+ */
+export type SubcommandRuntime =
+    | CommandRuntime
+    | ((args: ReadonlyArray<string>) => CommandRuntime);
+
+/**
+ * Conditional routing for a family whose subcommands split between runtimes
+ * (e.g. `classifiers eval` is pure compute while `classifiers graph` reads
+ * the DB). The family declares an exhaustive per-subcommand table here so
+ * dispatch never hard-codes subcommand names; effect-cli.test.ts enforces the
+ * table against the registered subcommands in both directions, so a new
+ * subcommand added without a routing declaration fails CI.
+ */
+export interface DbConditionalRuntime {
+    readonly kind: "db-conditional";
+    /** Runtime for the bare family command, `--help`, or an unknown subcommand. */
+    readonly fallback: CommandRuntime;
+    /** Exhaustive per-subcommand routing, keyed by subcommand name (argv[1]). */
+    readonly subcommands: Readonly<Record<string, SubcommandRuntime>>;
+}
+
+/** A family's routing declaration: static runtime or per-subcommand conditional. */
+export type RuntimeDeclaration = CommandRuntime | DbConditionalRuntime;
+
+export type RuntimeManifest = Readonly<Record<string, RuntimeDeclaration>>;
+
+/**
+ * Resolve a declaration to the concrete runtime for one invocation. Static
+ * declarations resolve to themselves; db-conditional ones look up argv[1] in
+ * the family's subcommand table (falling back for bare/--help/unknown).
+ */
+export const resolveRuntime = (
+    declaration: RuntimeDeclaration,
+    args: ReadonlyArray<string>,
+): CommandRuntime => {
+    if (typeof declaration === "string") return declaration;
+    const sub = declaration.subcommands[args[1] ?? ""];
+    if (sub === undefined) return declaration.fallback;
+    return typeof sub === "function" ? sub(args) : sub;
+};

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, test } from "bun:test";
 import {
     DB_COMMANDS,
     RUNTIME_BY_COMMAND,
-    classifiersPackageOperationsNeedsDb,
     detectRemovedIngestFlag,
     insightsOnlyConflicts,
     resolveIngestStages,
     rootCommand,
 } from "./index.ts";
+import { classifiersPackageOperationsNeedsDb } from "./commands/classifiers.ts";
+import { resolveRuntime, type DbConditionalRuntime } from "./commands/manifest.ts";
 import { ALL_STAGES } from "../ingest/stage/registry.ts";
 import type { StageRegistryShape } from "../ingest/stage/registry.ts";
 import type { BaseStageStats, StageDef } from "../ingest/stage/types.ts";
@@ -303,6 +304,78 @@ describe("effect cli", () => {
             "package-operations",
             "--quality-status",
         ])).toBe(false);
+    });
+});
+
+describe("classifiers db-conditional routing (#241)", () => {
+    const classifiersSubNames = (): string[] => {
+        const classifiers = rootCommand.subcommands
+            .flatMap((g) => g.commands)
+            .find((c) => c.name === "classifiers");
+        expect(classifiers).toBeDefined();
+        return classifiers!.subcommands.flatMap((g) => g.commands.map((c) => c.name));
+    };
+
+    const classifiersDeclaration = (): DbConditionalRuntime => {
+        const declared = RUNTIME_BY_COMMAND["classifiers"];
+        expect(declared).toBeDefined();
+        expect(typeof declared).toBe("object");
+        expect((declared as DbConditionalRuntime).kind).toBe("db-conditional");
+        return declared as DbConditionalRuntime;
+    };
+
+    test("classifiers is declared db-conditional and excluded from DB_COMMANDS (dispatch resolves per-invocation)", () => {
+        classifiersDeclaration();
+        expect(DB_COMMANDS.has("classifiers")).toBe(false);
+    });
+
+    test("every registered classifiers subcommand declares its routing (anti-drift)", () => {
+        const declared = classifiersDeclaration().subcommands;
+        for (const name of classifiersSubNames()) {
+            expect(
+                declared[name],
+                `classifiers subcommand "${name}" missing from the db-conditional routing table in commands/classifiers.ts`,
+            ).toBeDefined();
+        }
+    });
+
+    test("every declared classifiers routing entry maps to a registered subcommand (reverse anti-drift)", () => {
+        const registered = new Set(classifiersSubNames());
+        for (const name of Object.keys(classifiersDeclaration().subcommands)) {
+            expect(
+                registered.has(name),
+                `routing table declares classifiers subcommand "${name}" but classifiersCommand does not register it`,
+            ).toBe(true);
+        }
+    });
+
+    test("resolveRuntime preserves the pre-#241 dispatch behavior byte-for-byte", () => {
+        const declared = classifiersDeclaration();
+        // DB subcommands.
+        expect(resolveRuntime(declared, ["classifiers", "graph"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "lifecycle"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "explain"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "workflow-candidates"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "label-mining"])).toBe("db");
+        // No-DB subcommands.
+        expect(resolveRuntime(declared, ["classifiers", "eval"])).toBe("none");
+        expect(resolveRuntime(declared, ["classifiers", "list"])).toBe("none");
+        // package-operations: DB only with the write-plan/health/replay flags.
+        expect(resolveRuntime(declared, ["classifiers", "package-operations"])).toBe("none");
+        expect(resolveRuntime(declared, ["classifiers", "package-operations", "--quality-status"])).toBe("none");
+        expect(resolveRuntime(declared, ["classifiers", "package-operations", "--apply-write-plan"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "package-operations", "--graph-health"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "package-operations", "--boundary-replay-summary"])).toBe("db");
+        // Bare family / --help / unknown subcommand fall back to db (old
+        // behavior: fell through to DB_COMMANDS which contained "classifiers").
+        expect(resolveRuntime(declared, ["classifiers"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "--help"])).toBe("db");
+    });
+
+    test("static manifest declarations resolve to themselves", () => {
+        expect(resolveRuntime("db", ["sessions"])).toBe("db");
+        expect(resolveRuntime("ingest", ["ingest"])).toBe("ingest");
+        expect(resolveRuntime("none", ["version"])).toBe("none");
     });
 });
 

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -21,7 +21,7 @@ import { retroCommand, retroRuntime } from "./commands/retro.ts";
 import { improveCommand, improveRuntime } from "./commands/improve.ts";
 import { sessionsCommand, sessionsRuntime } from "./commands/sessions.ts";
 import { skillsCommand, rolesCommand, skillsRuntime } from "./commands/skills.ts";
-import { classifiersCommand, classifiersRuntime, classifiersPackageOperationsNeedsDb } from "./commands/classifiers.ts";
+import { classifiersCommand, classifiersRuntime } from "./commands/classifiers.ts";
 import {
     ingestCommand,
     deriveCommand,
@@ -30,7 +30,7 @@ import {
     ingestRuntime,
     detectRemovedIngestFlag,
 } from "./commands/ingest.ts";
-import type { RuntimeManifest } from "./commands/manifest.ts";
+import { resolveRuntime, type RuntimeManifest } from "./commands/manifest.ts";
 import {
     versionCommand,
     updateCommand,
@@ -250,16 +250,13 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
 // ingest superset layer). Anything outside this set runs through `withoutDb`
 // so the user gets fast, honest errors (e.g. "unknown command") instead of a
 // 5s connect timeout. Derived - do not hand-edit; declare runtime in the
-// owning commands/<family>.ts manifest instead.
+// owning commands/<family>.ts manifest instead. db-conditional families are
+// excluded: dispatch resolves them per-invocation via resolveRuntime.
 export const DB_COMMANDS: ReadonlySet<string> = new Set(
     Object.entries(RUNTIME_BY_COMMAND)
         .filter(([, runtime]) => runtime === "db" || runtime === "ingest")
         .map(([name]) => name),
 );
-
-// Moved to commands/classifiers.ts (Phase 2 CLI split); re-exported here for
-// the existing test contract (effect-cli.test.ts imports it from index.ts).
-export { classifiersPackageOperationsNeedsDb } from "./commands/classifiers.ts";
 
 // Moved to commands/ingest.ts (Phase 2 CLI split); re-exported here for the
 // existing test contract (effect-cli.test.ts imports them from index.ts).
@@ -313,16 +310,17 @@ const dispatch = (args: ReadonlyArray<string>): Effect.Effect<void, unknown> => 
         }
         return withIngest(args);
     }
-    if (
-        args[0] === "classifiers" &&
-        (classifiersPackageOperationsNeedsDb(args) ||
-            args[1] === "graph" ||
-            args[1] === "lifecycle")
-    ) {
-        return withDb(args);
-    }
-    if (args[0] === "classifiers" && (args[1] === "eval" || args[1] === "list" || args[1] === "package-operations")) {
-        return withoutDb(args);
+    // db-conditional families (e.g. classifiers) declare their own
+    // per-subcommand routing in their RuntimeManifest; resolve it here so
+    // dispatch never hard-codes subcommand names or predicates.
+    const declared = RUNTIME_BY_COMMAND[args[0]];
+    if (declared !== undefined && typeof declared !== "string") {
+        const runtime = resolveRuntime(declared, args);
+        return runtime === "db"
+            ? withDb(args)
+            : runtime === "ingest"
+                ? withIngest(args)
+                : withoutDb(args);
     }
     if (args[0] === "share") {
         if (args[1] === "--help" || args[1] === "-h") {


### PR DESCRIPTION
Closes #241

## What

`dispatch()` in `apps/axctl/src/cli/index.ts` hard-coded classifiers subcommand names (`graph`/`lifecycle`/`eval`/`list`/`package-operations`) plus the `classifiersPackageOperationsNeedsDb` predicate — the only command whose sub-routing lived outside its family `RuntimeManifest`. This adds a `db-conditional` manifest kind so the classifiers family declares its own routing and dispatch reads `RUNTIME_BY_COMMAND` uniformly.

## Changes

- **`commands/manifest.ts`** — new `DbConditionalRuntime` declaration kind: `{ kind: "db-conditional", fallback, subcommands }` where each subcommand maps to a static `CommandRuntime` or a per-invocation argv resolver; plus a `resolveRuntime` helper that resolves any declaration to a concrete runtime.
- **`commands/classifiers.ts`** — `classifiersRuntime` now declares the full per-subcommand routing table (`list`/`eval` → none, `explain`/`graph`/`lifecycle`/`workflow-candidates`/`label-mining` → db, `package-operations` → resolver over the write-plan/health/replay flags, fallback db for bare/`--help`/unknown).
- **`index.ts`** — dispatch resolves db-conditional declarations generically via `resolveRuntime`; no classifiers subcommand names or predicates remain. `DB_COMMANDS` derivation keeps only static `db`/`ingest` entries (conditional families are resolved per-invocation, never via the set). Dropped the `classifiersPackageOperationsNeedsDb` re-export; the test imports it from its owning module.
- **`effect-cli.test.ts`** — new `classifiers db-conditional routing (#241)` suite:
  - both-direction exhaustiveness: every registered classifiers subcommand must appear in the routing table, and every table entry must map to a registered subcommand — **a new classifiers subcommand added without a routing declaration fails CI**
  - byte-for-byte behavior assertions for every subcommand + the package-operations flag matrix + bare/`--help` fallback, matching the pre-#241 dispatch rules exactly

## Behavior

Routing is byte-identical: `eval`/`list` and flagless `package-operations` stay on the no-DB path; `graph`/`lifecycle` and `package-operations` with `--apply-write-plan`/`--graph-health`/`--boundary-replay-summary` stay on the DB path; everything else (explain, workflow-candidates, label-mining, bare `classifiers`, `--help`) keeps the old `DB_COMMANDS` fallback → db.

## Verification

- `bun run typecheck` — clean (only pre-existing Effect LSP info diagnostics)
- `bun test` — 3137 pass, 0 fail (335 files); effect-cli.test.ts: 35 pass
- Smoke: `axctl classifiers list` runs instantly on the no-DB path

🤖 Generated with [Claude Code](https://claude.com/claude-code)