### PR TITLE
refactor(queries): consolidate duplicated skill/invocations SQL block

### DIFF
--- a/apps/axctl/src/queries/skill-detail.ts
+++ b/apps/axctl/src/queries/skill-detail.ts
@@ -14,9 +14,33 @@ import type {
     SkillProposalEvidence,
     SkillRecentInvocation,
 } from "@ax/lib/shared/dashboard-types";
+import { skillWithInvocationsSql } from "./skill-invocations-sql.ts";
 
 /**
- * Two variants share this module:
+ * `daily` sparkline buckets - shared verbatim by both variants below.
+ */
+const DAILY_BLOCK = `    daily: (
+        SELECT ts FROM invoked
+        WHERE out = $s.id AND ts > time::now() - 30d
+        ORDER BY ts ASC
+    )`;
+
+/**
+ * 10 most recent invocations. The full variant additionally projects
+ * `turn_has_error` for the dashboard's error badges; the TUI doesn't render
+ * it, so the basic variant keeps the projection minimal.
+ */
+const recentBlock = (extraColumns: string) => `    recent: (
+        SELECT ts, in.session.project AS project${extraColumns}
+        FROM invoked
+        WHERE out = $s.id
+        ORDER BY ts DESC
+        LIMIT 10
+    )`;
+
+/**
+ * Two variants share this module (both compose the canonical
+ * skill+invocations scaffold from `skill-invocations-sql.ts`):
  *
  * - `SKILL_DETAIL_BASIC_SQL` - the TUI hot path. The DetailPane re-queries on
  *   every (debounced) j/k selection change, so it only carries the lightweight
@@ -27,60 +51,24 @@ import type {
  *   both endpoints (no endpoint index), which is fine for an explicit
  *   click-to-expand panel but too heavy for the TUI's per-row selection.
  */
-export const SKILL_DETAIL_BASIC_SQL = `
-LET $s = (SELECT * FROM skill WHERE name = $name)[0];
-RETURN {
-    skill: $s,
-    invocations: {
-        total: array::len((SELECT * FROM invoked WHERE out = $s.id)),
-        d7:    array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 7d)),
-        d30:   array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 30d)),
-        last:  (SELECT ts FROM invoked WHERE out = $s.id ORDER BY ts DESC LIMIT 1)[0].ts,
-    },
-    recent: (
-        SELECT ts, in.session.project AS project
-        FROM invoked
-        WHERE out = $s.id
-        ORDER BY ts DESC
-        LIMIT 10
-    ),
-    daily: (
-        SELECT ts FROM invoked
-        WHERE out = $s.id AND ts > time::now() - 30d
-        ORDER BY ts ASC
-    )
-};`;
+export const SKILL_DETAIL_BASIC_SQL = skillWithInvocationsSql({
+    windows: [7, 30],
+    blocks: [recentBlock(""), DAILY_BLOCK],
+});
 
-export const SKILL_DETAIL_SQL = `
-LET $s = (SELECT * FROM skill WHERE name = $name)[0];
-RETURN {
-    skill: $s,
-    invocations: {
-        total: array::len((SELECT * FROM invoked WHERE out = $s.id)),
-        d7:    array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 7d)),
-        d30:   array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 30d)),
-        last:  (SELECT ts FROM invoked WHERE out = $s.id ORDER BY ts DESC LIMIT 1)[0].ts,
-    },
-    recent: (
-        SELECT ts, in.session.project AS project, turn_has_error
-        FROM invoked
-        WHERE out = $s.id
-        ORDER BY ts DESC
-        LIMIT 10
-    ),
-    daily: (
-        SELECT ts FROM invoked
-        WHERE out = $s.id AND ts > time::now() - 30d
-        ORDER BY ts ASC
-    ),
-    corrections: (
+export const SKILL_DETAIL_SQL = skillWithInvocationsSql({
+    windows: [7, 30],
+    blocks: [
+        recentBlock(", turn_has_error"),
+        DAILY_BLOCK,
+        `    corrections: (
         SELECT ts, in.session.project AS project
         FROM invoked
         WHERE out = $s.id AND was_corrected = true
         ORDER BY ts DESC
         LIMIT 5
-    ),
-    proposals: (
+    )`,
+        `    proposals: (
         -- Some legacy proposed edges have ts = epoch (ingest path used to skip
         -- the field). Fall back to the source turn's ts so the timeline reads
         -- correctly.
@@ -92,8 +80,8 @@ RETURN {
         WHERE out = $s.id
         ORDER BY ts DESC
         LIMIT 5
-    ),
-    paired: (
+    )`,
+        `    paired: (
         -- Skills that co-occurred in the same session within a turn window
         -- (denormalised by derive-signals). The pair is undirected, so we
         -- check both directions and surface the partner's name.
@@ -107,8 +95,9 @@ RETURN {
         WHERE in = $s.id OR out = $s.id
         ORDER BY count DESC
         LIMIT 5
-    )
-};`;
+    )`,
+    ],
+});
 
 export const mapSkillRecentRow = (raw: unknown): SkillRecentInvocation | null => {
     if (!raw || typeof raw !== "object") return null;

--- a/apps/axctl/src/queries/skill-invocations-sql.test.ts
+++ b/apps/axctl/src/queries/skill-invocations-sql.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { skillWithInvocationsSql } from "./skill-invocations-sql.ts";
+
+describe("skillWithInvocationsSql", () => {
+    test("renders the shared skill-lookup + invocations scaffold", () => {
+        const sql = skillWithInvocationsSql({ windows: [7, 30], blocks: [] });
+        expect(sql).toContain("LET $s = (SELECT * FROM skill WHERE name = $name)[0];");
+        expect(sql).toContain("total: array::len((SELECT * FROM invoked WHERE out = $s.id))");
+        expect(sql).toContain(
+            "last:  (SELECT ts FROM invoked WHERE out = $s.id ORDER BY ts DESC LIMIT 1)[0].ts",
+        );
+    });
+
+    test("only the requested day windows are rendered", () => {
+        const sql = skillWithInvocationsSql({ windows: [7, 30], blocks: [] });
+        expect(sql).toContain("time::now() - 7d");
+        expect(sql).toContain("time::now() - 30d");
+        expect(sql).not.toContain("d90:");
+
+        const withD90 = skillWithInvocationsSql({ windows: [7, 30, 90], blocks: [] });
+        expect(withD90).toContain("time::now() - 90d");
+    });
+
+    test("joins extra RETURN blocks with commas inside the RETURN object", () => {
+        const sql = skillWithInvocationsSql({
+            windows: [7],
+            blocks: ["    a: ( SELECT 1 )", "    b: ( SELECT 2 )"],
+        });
+        expect(sql).toContain("    a: ( SELECT 1 ),\n    b: ( SELECT 2 )\n};");
+    });
+});

--- a/apps/axctl/src/queries/skill-invocations-sql.ts
+++ b/apps/axctl/src/queries/skill-invocations-sql.ts
@@ -1,0 +1,54 @@
+/**
+ * Single source of truth for the skill-lookup + invocations SQL scaffold
+ * shared by `SKILL_STATS_SQL` (skill-stats.ts) and the two detail variants
+ * (skill-detail.ts). Issue #247: these three queries used to duplicate the
+ * `LET $s ... RETURN { skill, invocations: {...} }` block side-by-side, so a
+ * change to the `invoked` edge model had to be applied in three places.
+ *
+ * The composer renders the shared scaffold; each query module passes its own
+ * day windows (stats adds d90) and extra RETURN blocks (recent / daily /
+ * evidence / recent_sessions). The basic/full detail split that protects the
+ * TUI hot path stays in skill-detail.ts - this module only owns the shared
+ * fragment.
+ *
+ * Bindings: $name (skill name) - same contract as before.
+ */
+
+export interface SkillInvocationsSqlOptions {
+    /** Rolling-count day windows rendered as `d<N>` keys (e.g. [7, 30, 90]). */
+    readonly windows: ReadonlyArray<number>;
+    /**
+     * Extra top-level RETURN blocks, each pre-rendered with its key and
+     * 4-space indent (e.g. `    recent: (...)`), WITHOUT a trailing comma -
+     * the composer joins them.
+     */
+    readonly blocks: ReadonlyArray<string>;
+}
+
+/**
+ * Compose the skill+invocations query. Rendered text is byte-compatible with
+ * the previous hand-written constants (characterization tests assert on the
+ * exact substrings, incl. the aligned `d7:    array::len(...)` padding).
+ */
+export const skillWithInvocationsSql = ({
+    windows,
+    blocks,
+}: SkillInvocationsSqlOptions): string => {
+    const windowLines = windows
+        .map(
+            (days) =>
+                `        ${`d${days}:`.padEnd(6)} array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - ${days}d)),`,
+        )
+        .join("\n");
+    return `
+LET $s = (SELECT * FROM skill WHERE name = $name)[0];
+RETURN {
+    skill: $s,
+    invocations: {
+        total: array::len((SELECT * FROM invoked WHERE out = $s.id)),
+${windowLines}
+        last:  (SELECT ts FROM invoked WHERE out = $s.id ORDER BY ts DESC LIMIT 1)[0].ts,
+    },
+${blocks.join(",\n")}
+};`;
+};

--- a/apps/axctl/src/queries/skill-stats.ts
+++ b/apps/axctl/src/queries/skill-stats.ts
@@ -13,19 +13,12 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { dateField, numberFieldOrZero } from "@ax/lib/shared/row-fields";
 import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
+import { skillWithInvocationsSql } from "./skill-invocations-sql.ts";
 
-export const SKILL_STATS_SQL = `
-LET $s = (SELECT * FROM skill WHERE name = $name)[0];
-RETURN {
-    skill: $s,
-    invocations: {
-        total: array::len((SELECT * FROM invoked WHERE out = $s.id)),
-        d7:    array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 7d)),
-        d30:   array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 30d)),
-        d90:   array::len((SELECT * FROM invoked WHERE out = $s.id AND ts > time::now() - 90d)),
-        last:  (SELECT ts FROM invoked WHERE out = $s.id ORDER BY ts DESC LIMIT 1)[0].ts,
-    },
-    recent_sessions: (
+export const SKILL_STATS_SQL = skillWithInvocationsSql({
+    windows: [7, 30, 90],
+    blocks: [
+        `    recent_sessions: (
         SELECT
             in.session AS session_id,
             in.session.project AS project_slug,
@@ -35,8 +28,9 @@ RETURN {
         WHERE out = $s.id
         ORDER BY ts DESC
         LIMIT 50
-    )
-};`;
+    )`,
+    ],
+});
 
 export interface SkillStatsInvocations {
     readonly total: number;


### PR DESCRIPTION
Closes #247

## What

`SKILL_STATS_SQL` (skill-stats.ts) and the two detail variants (`SKILL_DETAIL_BASIC_SQL` / `SKILL_DETAIL_SQL` in skill-detail.ts) each hand-wrote the same skill-lookup + invocations scaffold (`LET $s = ... RETURN { skill, invocations: { total/d7/d30/last } }`) - drift risk if the `invoked` edge model changes.

## How

- New `apps/axctl/src/queries/skill-invocations-sql.ts` exporting `skillWithInvocationsSql({ windows, blocks })` - the one source of truth for the shared scaffold.
- `SKILL_STATS_SQL` composes it with `windows: [7, 30, 90]` + its `recent_sessions` block.
- `SKILL_DETAIL_BASIC_SQL` / `SKILL_DETAIL_SQL` compose it with `windows: [7, 30]` plus their own blocks (`recent`/`daily`, full variant adds `corrections`/`proposals`/`paired`). The basic/full split protecting the TUI hot path is unchanged; the TUI keeps re-exporting the basic variant.

## Verification

- Rendered SQL is **byte-identical** to the previous literals for all three constants (compared programmatically against `origin/main`), so payload shapes for CLI stats, dashboard detail, and TUI basic are untouched.
- Existing characterization tests (`skill-stats.test.ts`, `skill-detail.test.ts`, incl. the TUI no-fork + hot-path regression assertions) pass unchanged; added a small test for the new composer seam.
- `bun run typecheck`: clean. `bun test`: 3135 pass, 0 fail (336 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)