### PR TITLE
test: shared makeMockDb helper — replace verbatim copies (#244)

### DIFF
--- a/apps/axctl/src/dashboard/recall.commit.test.ts
+++ b/apps/axctl/src/dashboard/recall.commit.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
-import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { makeMockDb } from "@ax/lib/testing/surreal";
 import {
     RECALL_COMMITS_SQL,
     RECALL_SKILLS_SQL,
@@ -14,18 +14,6 @@ import {
     RECALL_SKILLS_COUNT_SQL,
 } from "../queries/recall.ts";
 import { fetchRecall } from "./recall.ts";
-
-// ---------------------------------------------------------------------------
-// Mock DB helper (mirrors derive-claude-subagents.test.ts pattern)
-// ---------------------------------------------------------------------------
-
-function makeMockDb(queryResponses: Map<string, unknown[][]> = new Map()) {
-    const tc = makeTestSurrealClient({
-        denyWrites: true,
-        routes: [...queryResponses].map(([match, rows]) => ({ match, rows: rows as unknown[] })),
-    });
-    return { calls: tc.calls, layer: tc.layer };
-}
 
 // ---------------------------------------------------------------------------
 // SQL shape tests (unit - no DB mock needed)

--- a/apps/axctl/src/dashboard/recall.test.ts
+++ b/apps/axctl/src/dashboard/recall.test.ts
@@ -1,19 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
-import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { makeMockDb } from "@ax/lib/testing/surreal";
 import { RECALL_COUNT_SQL, RECALL_TURNS_SQL } from "../queries/recall.ts";
 import { fetchRecall } from "./recall.ts";
-
-// ---------------------------------------------------------------------------
-// Minimal mock DB (mirrors recall.commit.test.ts pattern)
-// ---------------------------------------------------------------------------
-
-function makeMockDb(queryResponses: Map<string, unknown[][]> = new Map()) {
-    return makeTestSurrealClient({
-        denyWrites: true,
-        routes: [...queryResponses].map(([match, rows]) => ({ match, rows: rows as unknown[] })),
-    }).layer;
-}
 
 describe("recall pagination", () => {
     test("RECALL_TURNS_SQL uses parameterised offset/limit", () => {
@@ -40,7 +29,7 @@ describe("recall back-compat: sources=turn (default)", () => {
         const responses = new Map<string, unknown[][]>([
             ["count() AS total", [[{ total: 7 }]]],
         ]);
-        const layer = makeMockDb(responses);
+        const { layer } = makeMockDb(responses);
 
         const result = await Effect.runPromise(
             // No sources specified - defaults to ["turn"]

--- a/apps/axctl/src/dashboard/skills-weighted.test.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.test.ts
@@ -7,25 +7,8 @@
  * - Doctor count and advice trigger at the threshold.
  */
 import { describe, it, expect } from "bun:test";
-import { Effect } from "effect";
-import { SurrealClient } from "@ax/lib/db";
-import { makeTestSurrealClient, type TestSurrealClient } from "@ax/lib/testing/surreal";
+import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
 import { fetchSkillsWeighted } from "./skills-weighted.ts";
-
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
-/** Mock SurrealClient answering query() calls with `responses` in call order. */
-const makeMockDb = (responses: Array<unknown>): TestSurrealClient =>
-    makeTestSurrealClient({ denyWrites: true, responses: responses as Array<unknown[]> });
-
-/** Run an Effect with the mock SurrealClient. */
-const runWithMock = <A>(
-    db: TestSurrealClient,
-    effect: Effect.Effect<A, unknown, SurrealClient>,
-): Promise<A> =>
-    Effect.runPromise(effect.pipe(Effect.provide(db.layer)));
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -141,14 +124,14 @@ describe("fetchSkillsWeighted", () => {
     });
 
     it("doctor SQL excludes synthetics by default", async () => {
-        const db = makeTestSurrealClient({ denyWrites: true });
+        const db = makeMockDb();
 
         await runWithMock(db, fetchSkillsWeighted());
         expect(db.captured[2]).toContain('dir_path = "(synthetic)"');
     });
 
     it("includes window clause when windowDays is set", async () => {
-        const db = makeTestSurrealClient({ denyWrites: true });
+        const db = makeMockDb();
 
         await runWithMock(db, fetchSkillsWeighted({ windowDays: 30 }));
         // First SQL is the invocation query
@@ -156,7 +139,7 @@ describe("fetchSkillsWeighted", () => {
     });
 
     it("omits window clause when windowDays is not set", async () => {
-        const db = makeTestSurrealClient({ denyWrites: true });
+        const db = makeMockDb();
 
         await runWithMock(db, fetchSkillsWeighted());
         expect(db.captured[0]).not.toContain("ts >= time::now()");

--- a/apps/axctl/src/ingest/derive-claude-subagents.test.ts
+++ b/apps/axctl/src/ingest/derive-claude-subagents.test.ts
@@ -13,26 +13,13 @@ import { Effect, Layer } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { RecordId } from "surrealdb";
 import { SurrealClient } from "@ax/lib/db";
-import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { makeMockDb } from "@ax/lib/testing/surreal";
 import { AxConfig, makeTestConfig } from "@ax/lib/config";
 import { deriveClaudeSubagents } from "./derive-claude-subagents.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Build a mock SurrealClient layer. The `queryResponses` map lets callers
- * drive what each SELECT returns; unrecognised queries return [[]].
- * All calls are recorded in `calls` / `upserts`.
- */
-function makeMockDb(queryResponses: Map<string, unknown[][]> = new Map()) {
-    const tc = makeTestSurrealClient({
-        // Find first matching key that the sql CONTAINS
-        routes: [...queryResponses].map(([match, rows]) => ({ match, rows: rows as unknown[] })),
-    });
-    return { calls: tc.calls, upserts: tc.upserts, layer: tc.layer };
-}
 
 /**
  * Minimal AxConfig layer that provides a transcripts dir that doesn't exist
@@ -105,7 +92,7 @@ describe("repository backfill (F7)", () => {
             },
         ]]);
 
-        const { calls, layer } = makeMockDb(responses);
+        const { calls, layer } = makeMockDb(responses, { denyWrites: false });
         await runWith(layer);
 
         // Should have issued the backfill SELECT query
@@ -139,7 +126,7 @@ describe("repository backfill (F7)", () => {
         // Backfill query returns empty - no subagents need repair
         responses.set('source = "claude-subagent" AND repository IS NONE', [[]]);
 
-        const { calls, layer } = makeMockDb(responses);
+        const { calls, layer } = makeMockDb(responses, { denyWrites: false });
         await runWith(layer);
 
         // No UPDATE query for backfill
@@ -171,7 +158,7 @@ describe("repository backfill (F7)", () => {
             },
         ]]);
 
-        const { layer } = makeMockDb(responses);
+        const { layer } = makeMockDb(responses, { denyWrites: false });
         const stats = await runWith(layer);
 
         expect(stats.repositoryBackfilled).toBe(2);
@@ -182,7 +169,7 @@ describe("repository backfill (F7)", () => {
         responses.set("SELECT name FROM skill", [[]]);
         responses.set('source = "claude-subagent" AND repository IS NONE', [[]]);
 
-        const { layer } = makeMockDb(responses);
+        const { layer } = makeMockDb(responses, { denyWrites: false });
         const stats = await runWith(layer);
 
         expect(stats.repositoryInherited).toBe(0);
@@ -307,7 +294,7 @@ describe("repository inheritance on new subagents (F7)", () => {
         // Backfill: no rows need repair
         responses.set('source = "claude-subagent" AND repository IS NONE', [[]]);
 
-        const { upserts, layer } = makeMockDb(responses);
+        const { upserts, layer } = makeMockDb(responses, { denyWrites: false });
         const stats = await runWith(layer, makeFixtureConfig(fixture.root));
 
         // Stage should have discovered 1 subagent and written it
@@ -351,7 +338,7 @@ describe("repository inheritance on new subagents (F7)", () => {
         ]]);
         responses.set('source = "claude-subagent" AND repository IS NONE', [[]]);
 
-        const { upserts, layer } = makeMockDb(responses);
+        const { upserts, layer } = makeMockDb(responses, { denyWrites: false });
         const stats = await runWith(layer, makeFixtureConfig(fixture.root));
 
         expect(stats.discovered).toBe(1);

--- a/apps/axctl/src/ingest/skills.test.ts
+++ b/apps/axctl/src/ingest/skills.test.ts
@@ -11,7 +11,7 @@ import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { makeMockDb } from "@ax/lib/testing/surreal";
 import { ingestSkills } from "./skills.ts";
 
 // ingestSkills now reads the on-disk fixtures through the @effect/platform
@@ -37,17 +37,6 @@ function extractRoles(fm: Record<string, unknown>): string[] {
         if (norm) result.push(norm);
     }
     return result;
-}
-
-// ---------------------------------------------------------------------------
-// Mock DB helpers
-// ---------------------------------------------------------------------------
-
-function makeMockDb(queryResponses: Map<string, unknown[][]> = new Map()) {
-    const tc = makeTestSurrealClient({
-        routes: [...queryResponses].map(([match, rows]) => ({ match, rows: rows as unknown[] })),
-    });
-    return { calls: tc.calls, layer: tc.layer };
 }
 
 // ---------------------------------------------------------------------------
@@ -130,7 +119,7 @@ describe("looseLineParse list-format fallback", () => {
                 "utf8",
             );
 
-            const { layer } = makeMockDb();
+            const { layer } = makeMockDb(undefined, { denyWrites: false });
             const stats = await Effect.runPromise(
                 ingestSkills().pipe(Effect.provide(Layer.mergeAll(layer, PlatformLayer))),
             );
@@ -164,7 +153,7 @@ describe("ingestSkills end-to-end role wiring", () => {
                 "utf8",
             );
 
-            const { calls, layer } = makeMockDb();
+            const { calls, layer } = makeMockDb(undefined, { denyWrites: false });
             await Effect.runPromise(
                 ingestSkills().pipe(Effect.provide(Layer.mergeAll(layer, PlatformLayer))),
             );
@@ -200,7 +189,7 @@ describe("ingestSkills end-to-end role wiring", () => {
                 "utf8",
             );
 
-            const { layer } = makeMockDb();
+            const { layer } = makeMockDb(undefined, { denyWrites: false });
             const stats = await Effect.runPromise(
                 ingestSkills().pipe(Effect.provide(Layer.mergeAll(layer, PlatformLayer))),
             );
@@ -228,7 +217,7 @@ describe("ingestSkills end-to-end role wiring", () => {
                 "utf8",
             );
 
-            const { calls, layer } = makeMockDb();
+            const { calls, layer } = makeMockDb(undefined, { denyWrites: false });
             const stats = await Effect.runPromise(
                 ingestSkills().pipe(Effect.provide(Layer.mergeAll(layer, PlatformLayer))),
             );

--- a/apps/axctl/src/queries/skill-detail.test.ts
+++ b/apps/axctl/src/queries/skill-detail.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Effect } from "effect";
-import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import { makeTestSurrealClient, type TestSurrealRows } from "@ax/lib/testing/surreal";
+import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
 import {
     SKILL_DETAIL_BASIC_SQL,
     SKILL_DETAIL_SQL,
@@ -11,20 +9,6 @@ import {
     mapSkillRecentRow,
 } from "./skill-detail.ts";
 import { SKILL_DETAIL_SQL as TUI_SKILL_DETAIL_SQL } from "../tui/queries.ts";
-
-/** Mock SurrealClientShape returning canned responses per query() call. */
-function makeMockDb(responses: Array<unknown>): SurrealClientShape {
-    return makeTestSurrealClient({
-        denyWrites: true,
-        responses: responses as ReadonlyArray<TestSurrealRows>,
-    }).client;
-}
-
-const runWithMock = <A>(
-    db: SurrealClientShape,
-    effect: Effect.Effect<A, unknown, SurrealClient>,
-): Promise<A> =>
-    Effect.runPromise(effect.pipe(Effect.provideService(SurrealClient, db)));
 
 describe("SKILL_DETAIL_SQL", () => {
     test("binds the skill by $name", () => {

--- a/apps/axctl/src/queries/skill-stats.test.ts
+++ b/apps/axctl/src/queries/skill-stats.test.ts
@@ -1,25 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { Effect } from "effect";
-import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import { makeTestSurrealClient, type TestSurrealRows } from "@ax/lib/testing/surreal";
+import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
 import {
     SKILL_STATS_SQL,
     dedupeRecentSessions,
     fetchSkillStats,
 } from "./skill-stats.ts";
-
-function makeMockDb(responses: Array<unknown>): SurrealClientShape {
-    return makeTestSurrealClient({
-        denyWrites: true,
-        responses: responses as ReadonlyArray<TestSurrealRows>,
-    }).client;
-}
-
-const runWithMock = <A>(
-    db: SurrealClientShape,
-    effect: Effect.Effect<A, unknown, SurrealClient>,
-): Promise<A> =>
-    Effect.runPromise(effect.pipe(Effect.provideService(SurrealClient, db)));
 
 describe("SKILL_STATS_SQL", () => {
     test("binds by $name and covers 7/30/90d windows", () => {

--- a/apps/axctl/src/queries/unused-skills.test.ts
+++ b/apps/axctl/src/queries/unused-skills.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Effect } from "effect";
-import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import { makeTestSurrealClient, type TestSurrealRows } from "@ax/lib/testing/surreal";
+import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
 import {
     UNUSED_RECENT_SQL,
     UNUSED_SUMMARY_SQL,
@@ -11,19 +9,6 @@ import {
     mergeUnusedRows,
     fetchUnusedSkills,
 } from "./unused-skills.ts";
-
-function makeMockDb(responses: Array<unknown>): SurrealClientShape {
-    return makeTestSurrealClient({
-        denyWrites: true,
-        responses: responses as ReadonlyArray<TestSurrealRows>,
-    }).client;
-}
-
-const runWithMock = <A>(
-    db: SurrealClientShape,
-    effect: Effect.Effect<A, unknown, SurrealClient>,
-): Promise<A> =>
-    Effect.runPromise(effect.pipe(Effect.provideService(SurrealClient, db)));
 
 describe("unused-skills SQL", () => {
     test("recent scan splices a validated day window and groups by out", () => {

--- a/packages/lib/src/testing/surreal.ts
+++ b/packages/lib/src/testing/surreal.ts
@@ -199,3 +199,65 @@ export const makeTestSurrealClient = (
         files,
     };
 };
+
+// ---------------------------------------------------------------------------
+// makeMockDb / runWithMock - the canonical query-test pattern
+// ---------------------------------------------------------------------------
+
+/**
+ * Responses for {@link makeMockDb}:
+ * - an **array** answers `query` calls positionally (`responses[i]` answers
+ *   the i-th call), or
+ * - a **Map** routes by SQL substring → rows (insertion order, first match
+ *   wins; unmatched queries resolve `[[]]`).
+ */
+export type MockDbResponses =
+    | ReadonlyArray<TestSurrealRows>
+    | ReadonlyMap<string, TestSurrealResponder>;
+
+export interface MockDbOptions {
+    /**
+     * Mock DBs are read-only by default: any `upsert`/`relate`/`putFile`
+     * fails loudly. Pass `false` for write-path tests (writes are then
+     * recorded in `upserts`/`relates`/`files`).
+     */
+    readonly denyWrites?: boolean;
+}
+
+/**
+ * Canonical mock `SurrealClient` for query tests - use this instead of
+ * hand-rolling a `SurrealClientShape` or a local `makeMockDb` in new test
+ * modules (issue #244).
+ *
+ * ```ts
+ * import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
+ *
+ * // Positional: responses[i] answers the i-th query() call.
+ * const db = makeMockDb([[[{ total: 7 }]]]);
+ * const result = await runWithMock(db, fetchRecall({ q: "auth" }));
+ *
+ * // Routed: SQL-substring → rows.
+ * const { calls, layer } = makeMockDb(new Map([["count() AS total", [[{ total: 7 }]]]]));
+ * ```
+ *
+ * Returns the full {@link TestSurrealClient}, so call sites can destructure
+ * whatever they need (`layer`, `client`, `calls`, `captured`, `upserts`, ...).
+ * Anything fancier (dynamic responders, fallbacks, raw escape hatch) should
+ * call {@link makeTestSurrealClient} directly.
+ */
+export const makeMockDb = (
+    responses: MockDbResponses = [],
+    opts: MockDbOptions = {},
+): TestSurrealClient =>
+    makeTestSurrealClient({
+        denyWrites: opts.denyWrites ?? true,
+        ...(responses instanceof Map
+            ? { routes: [...responses].map(([match, rows]) => ({ match, rows })) }
+            : { responses: responses as ReadonlyArray<TestSurrealRows> }),
+    });
+
+/** Run an Effect against a {@link makeMockDb} mock's `SurrealClient` layer. */
+export const runWithMock = <A, E>(
+    db: TestSurrealClient,
+    effect: Effect.Effect<A, E, SurrealClient>,
+): Promise<A> => Effect.runPromise(effect.pipe(Effect.provide(db.layer)));


### PR DESCRIPTION
Closes #244

## What

Hoists one canonical `makeMockDb` (+ `runWithMock`) into `@ax/lib/testing/surreal` and deletes the local copies that were verbatim (or near-verbatim) wrappers around `makeTestSurrealClient`.

### Canonical helper (`packages/lib/src/testing/surreal.ts`)

- `makeMockDb(responses?, opts?)` — accepts either a **positional responses array** (`responses[i]` answers the i-th `query()` call) or a **`Map` of SQL-substring → rows** routes; returns the full `TestSurrealClient` so call sites destructure whatever they need (`layer`, `client`, `calls`, `captured`, `upserts`, ...). Read-only by default (`denyWrites: true`); write-path tests pass `{ denyWrites: false }`.
- `runWithMock(db, effect)` — runs an Effect against the mock's `SurrealClient` layer.
- Doc comment marks this as the pattern for new query test modules.

### Migrated (local copies deleted)

- `apps/axctl/src/queries/skill-detail.test.ts`, `skill-stats.test.ts`, `unused-skills.test.ts` — 3 byte-identical responses-array copies + identical `runWithMock`s
- `apps/axctl/src/dashboard/skills-weighted.test.ts` — near-verbatim responses-array copy (also converted three inline `makeTestSurrealClient({ denyWrites: true })` calls)
- `apps/axctl/src/dashboard/recall.test.ts`, `recall.commit.test.ts` — Map-route copies (read-only)
- `apps/axctl/src/ingest/skills.test.ts`, `derive-claude-subagents.test.ts` — Map-route copies (write-path, now `{ denyWrites: false }`)

### Left local (genuine variants, by design)

Domain-fixture builders that parameterise `makeTestSurrealClient` with bespoke routes/fallbacks rather than duplicating the generic stub: `pwd`, `skill-role`, `skills-lint`, `github-pr-stage`, `github-pr-write`, `sessions-query`, `session-canvas`, `session-turn-content`, `insights-enrich`, `transcript-staleness`.

## Verification

- `bun run typecheck` — exit 0
- `bun test` before (origin/main) and after — **identical counts**: 3132 pass, 4 skip, 0 fail, 10097 expect() calls, 3136 tests across 335 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)