### PR TITLE
fix(inspect): bound and chunk the direct block/atom ref fan-out on the fast path

### DIFF
--- a/apps/axctl/src/queries/session-turn-content.test.ts
+++ b/apps/axctl/src/queries/session-turn-content.test.ts
@@ -6,12 +6,25 @@
  * (`document = <rid>`), never the `document IN [<all docs>]` membership scan
  * that scanned the whole 430k-block / 1.1M-atom tables (6s + 22s on a 318-doc
  * session). Also verifies blocks + atoms assemble onto the right turn.
+ *
+ * Issue #263 guards (fast inspector path): the speculative direct block/atom
+ * ref fan-out must be chunked so no single SurrealQL query carries more than
+ * DIRECT_REF_BUDGET_PER_QUERY refs, and past
+ * MAX_SPECULATIVE_REFS_PER_REQUEST total refs the resolver must fall back to
+ * the per-document indexed fan-out - asserted via the query-capture seam, not
+ * wall-clock.
  */
 import { describe, expect, test } from "bun:test";
 import { Effect, type Layer } from "effect";
 import { SurrealClient } from "@ax/lib/db";
+import { identityPart } from "@ax/lib/ids";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
-import { resolveTurnContent } from "./session-turn-content.ts";
+import {
+    DIRECT_REF_BUDGET_PER_QUERY,
+    MAX_SPECULATIVE_REFS_PER_REQUEST,
+    resolveTurnContent,
+    resolveTurnContentForSourceRefs,
+} from "./session-turn-content.ts";
 
 const DOC_ID = "content_document:turn__s1_seq_000001__abc";
 
@@ -105,5 +118,212 @@ describe("resolveTurnContent (full content / share export)", () => {
         // Short-circuits after the document query - no block/atom fan-out.
         expect(tc.captured.some((s) => s.includes("FROM content_block"))).toBe(false);
         expect(tc.captured.some((s) => s.includes("FROM content_atom"))).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Fast inspector path (resolveTurnContentForSourceRefs) - issue #263
+// ---------------------------------------------------------------------------
+
+/** Speculative refs the resolver builds per document / per block (must mirror
+ *  the production constants in session-turn-content.ts). */
+const BLOCK_REFS_PER_DOC = 20;
+const ATOM_REFS_PER_BLOCK = 8 * 5; // 8 fast atom kinds x 5 per kind
+
+const docKeyForSourceRef = (ref: string): string => `turn__${identityPart(ref, "source")}`;
+const BLOCK_ONE_SUFFIX = "__block_000001";
+
+/** Backticked record refs spliced into a record-list source - the speculative
+ *  direct fan-out. Per-document fallback queries interpolate a bare
+ *  (unbackticked) rid instead, so they intentionally count zero here. */
+const directRefCount = (sql: string): number =>
+    (sql.match(/content_(?:document|block|atom):`/g) ?? []).length;
+
+const extractKeys = (sql: string, table: string): string[] =>
+    [...sql.matchAll(new RegExp(`${table}:\`([^\`]+)\``, "g"))].map((m) => m[1]!);
+
+/**
+ * Mock DB for the fast path: every requested document exists (source_ref maps
+ * back to the original input ref), each document has exactly one block (seq 0,
+ * `__block_000001`), and that block has one `symbol_ref` atom. Direct
+ * speculative refs beyond those dereference to nothing (rows omitted), exactly
+ * like the production `.filter(|$o| $o != NONE)` drop.
+ */
+function makeFastPathDb(sourceRefs: readonly string[]): {
+    layer: Layer.Layer<SurrealClient>;
+    captured: string[];
+} {
+    const sourceRefByDocKey = new Map(sourceRefs.map((ref) => [docKeyForSourceRef(ref), ref]));
+    const turnSeqByDocKey = new Map(sourceRefs.map((ref, i) => [docKeyForSourceRef(ref), i + 1]));
+    const docRow = (docKey: string) => ({
+        source_ref: sourceRefByDocKey.get(docKey) ?? null,
+        document_id: `content_document:${docKey}`,
+        parser_id: "p",
+        parser_version: "1",
+        blockset_hash: "h",
+        turn_seq: turnSeqByDocKey.get(docKey) ?? null,
+    });
+    const blockRow = (docKey: string) => ({
+        id: `content_block:${docKey}${BLOCK_ONE_SUFFIX}`,
+        document_id: `content_document:${docKey}`,
+        seq: 0,
+        parent_seq: null,
+        kind: "paragraph",
+        role: "assistant",
+        heading: null,
+        text: "hello",
+        text_excerpt: "hello",
+        start_offset: 0,
+        end_offset: 5,
+        confidence: 1,
+    });
+    const atomRow = (docKey: string) => ({
+        document_id: `content_document:${docKey}`,
+        block_seq: 0,
+        kind: "symbol_ref",
+        value: "foo",
+        normalized: "foo",
+        confidence: 1,
+        raw: null,
+    });
+    const docKeyFromRid = (sql: string): string | null =>
+        sql.match(/document = content_document:([A-Za-z0-9_:-]+)/)?.[1] ?? null;
+    const tc = makeTestSurrealClient({
+        denyWrites: true,
+        fallback: (sql) => {
+            // Direct (record-list) fetches - keys parsed from the spliced refs.
+            if (sql.includes("content_block:`")) {
+                const rows = extractKeys(sql, "content_block")
+                    .filter((key) => key.endsWith(BLOCK_ONE_SUFFIX))
+                    .map((key) => blockRow(key.slice(0, -BLOCK_ONE_SUFFIX.length)));
+                return [rows];
+            }
+            if (sql.includes("content_atom:`")) {
+                const symbolRefPart = identityPart("symbol_ref", "atom");
+                const rows = extractKeys(sql, "content_atom")
+                    .filter((key) => key.endsWith(`__${symbolRefPart}__0001`))
+                    .map((key) => {
+                        const blockKey = key.slice(0, -`__${symbolRefPart}__0001`.length);
+                        return atomRow(blockKey.slice(0, -BLOCK_ONE_SUFFIX.length));
+                    })
+                    .filter((row) => sourceRefByDocKey.has(row.document_id.slice("content_document:".length)));
+                return [rows];
+            }
+            // Per-document indexed fallbacks (`document = <bare rid>`).
+            if (sql.includes("FROM content_block")) {
+                const docKey = docKeyFromRid(sql);
+                return [docKey && sourceRefByDocKey.has(docKey) ? [blockRow(docKey)] : []];
+            }
+            if (sql.includes("FROM content_atom")) {
+                const docKey = docKeyFromRid(sql);
+                return [docKey && sourceRefByDocKey.has(docKey) ? [atomRow(docKey)] : []];
+            }
+            // Direct (record-list) document fetch.
+            if (sql.includes("content_document:`")) {
+                return [extractKeys(sql, "content_document").map(docRow)];
+            }
+            return [[]];
+        },
+    });
+    return { layer: tc.layer, captured: tc.captured };
+}
+
+const runFastPath = (sourceRefs: readonly string[]) => {
+    const { layer, captured } = makeFastPathDb(sourceRefs);
+    return Effect.runPromise(
+        resolveTurnContentForSourceRefs(sourceRefs).pipe(Effect.provide(layer)),
+    ).then((byTurn) => ({ byTurn, captured }));
+};
+
+describe("resolveTurnContentForSourceRefs (fast inspector path)", () => {
+    test("small session: direct record-list fetches, content assembled, no per-document fallback", async () => {
+        const sourceRefs = ["ref-a", "ref-b", "ref-c"];
+        const { byTurn, captured } = await runFastPath(sourceRefs);
+
+        // Direct path used end-to-end: no per-document indexed fallback fired.
+        expect(captured.some((s) => s.includes("document = content_document:"))).toBe(false);
+        // One chunk each for docs (3 refs), blocks (60 refs), atoms (120 refs).
+        expect(captured.filter((s) => s.includes("content_document:`"))).toHaveLength(1);
+        const blockQueries = captured.filter((s) => s.includes("content_block:`"));
+        const atomQueries = captured.filter((s) => s.includes("content_atom:`"));
+        expect(blockQueries).toHaveLength(1);
+        expect(directRefCount(blockQueries[0]!)).toBe(sourceRefs.length * BLOCK_REFS_PER_DOC);
+        expect(atomQueries).toHaveLength(1);
+        expect(directRefCount(atomQueries[0]!)).toBe(sourceRefs.length * ATOM_REFS_PER_BLOCK);
+
+        // Content assembled onto the right turns, atom attached to its block.
+        expect(byTurn.size).toBe(3);
+        for (const seq of [1, 2, 3]) {
+            const content = byTurn.get(seq);
+            expect(content).toBeDefined();
+            expect(content!.blocks).toHaveLength(1);
+            expect(content!.blocks[0]!.text).toBe("hello");
+            expect(content!.blocks[0]!.atoms).toHaveLength(1);
+            expect(content!.blocks[0]!.atoms[0]!.value).toBe("foo");
+        }
+    });
+
+    test("chunking: no single query carries more refs than the budget, all refs covered", async () => {
+        // 30 docs -> 600 speculative block refs -> 3 chunks; 30 blocks -> 1200
+        // atom refs -> 6 chunks. Well under the request ceiling, so the direct
+        // path stays engaged.
+        const sourceRefs = Array.from({ length: 30 }, (_, i) => `ref-${i}`);
+        const { byTurn, captured } = await runFastPath(sourceRefs);
+
+        for (const sql of captured) {
+            expect(directRefCount(sql)).toBeLessThanOrEqual(DIRECT_REF_BUDGET_PER_QUERY);
+        }
+        const blockQueries = captured.filter((s) => s.includes("content_block:`"));
+        const atomQueries = captured.filter((s) => s.includes("content_atom:`"));
+        const totalBlockRefs = sourceRefs.length * BLOCK_REFS_PER_DOC;
+        const totalAtomRefs = sourceRefs.length * ATOM_REFS_PER_BLOCK;
+        expect(blockQueries).toHaveLength(Math.ceil(totalBlockRefs / DIRECT_REF_BUDGET_PER_QUERY));
+        expect(atomQueries).toHaveLength(Math.ceil(totalAtomRefs / DIRECT_REF_BUDGET_PER_QUERY));
+        // Coverage: chunking must not drop refs.
+        expect(blockQueries.reduce((n, s) => n + directRefCount(s), 0)).toBe(totalBlockRefs);
+        expect(atomQueries.reduce((n, s) => n + directRefCount(s), 0)).toBe(totalAtomRefs);
+        // No fallback engaged, full content returned.
+        expect(captured.some((s) => s.includes("document = content_document:"))).toBe(false);
+        expect(byTurn.size).toBe(30);
+    });
+
+    test("at the pagination cap, the speculative fan-out exceeds the ceiling and falls back to per-document indexed fetches", async () => {
+        // Fan-out math at the inspect pagination cap (2000 turns): 2000 docs x
+        // 20 block refs = 40k > MAX_SPECULATIVE_REFS_PER_REQUEST, which
+        // unbounded would have compounded to 40k x 40 = 1.6M atom refs in one
+        // statement. The ceiling must reroute blocks AND atoms to the
+        // per-document indexed path.
+        const sourceRefs = Array.from({ length: 2000 }, (_, i) => `ref-${i}`);
+        expect(sourceRefs.length * BLOCK_REFS_PER_DOC).toBeGreaterThan(MAX_SPECULATIVE_REFS_PER_REQUEST);
+        const { byTurn, captured } = await runFastPath(sourceRefs);
+
+        // No speculative block/atom record-list query at all past the ceiling.
+        expect(captured.some((s) => s.includes("content_block:`"))).toBe(false);
+        expect(captured.some((s) => s.includes("content_atom:`"))).toBe(false);
+        // Per-document indexed fan-out instead - one block + one atom query per doc.
+        const perDocBlocks = captured.filter(
+            (s) => s.includes("FROM content_block") && s.includes("document = content_document:"),
+        );
+        const perDocAtoms = captured.filter(
+            (s) => s.includes("FROM content_atom") && s.includes("document = content_document:"),
+        );
+        expect(perDocBlocks).toHaveLength(2000);
+        expect(perDocAtoms).toHaveLength(2000);
+        // Document resolution itself stays chunked within the budget.
+        for (const sql of captured) {
+            expect(directRefCount(sql)).toBeLessThanOrEqual(DIRECT_REF_BUDGET_PER_QUERY);
+        }
+        expect(captured.filter((s) => s.includes("content_document:`"))).toHaveLength(
+            Math.ceil(sourceRefs.length / DIRECT_REF_BUDGET_PER_QUERY),
+        );
+
+        // Fallback still returns correct content, atoms included.
+        expect(byTurn.size).toBe(2000);
+        const first = byTurn.get(1);
+        const last = byTurn.get(2000);
+        expect(first?.blocks[0]?.text).toBe("hello");
+        expect(first?.blocks[0]?.atoms[0]?.value).toBe("foo");
+        expect(last?.blocks[0]?.text).toBe("hello");
+        expect(last?.blocks[0]?.atoms).toHaveLength(1);
     });
 });

--- a/apps/axctl/src/queries/session-turn-content.ts
+++ b/apps/axctl/src/queries/session-turn-content.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Array as Arr, Effect } from "effect";
 import type { SurrealClient } from "@ax/lib/db";
 import type {
     InspectContentAtomDto,
@@ -81,6 +81,43 @@ const TURN_CONTENT_ATOMS_FOR_DOC_SQL = `
 /** Per-document fan-out width for full content resolution (share export). */
 const CONTENT_FANOUT_CONCURRENCY = 16;
 
+/**
+ * Max record refs a single materialized record-list query may carry on the
+ * fast inspector path. Unbounded, a session at the inspect pagination cap
+ * (2000 turns) packed 2000 x 20 = 40k block refs - and up to 40k x 8 kinds x 5
+ * = 1.6M atom refs - into ONE SurrealQL statement, risking dashboard timeouts
+ * and DB stalls. Exported for the query-capture regression tests.
+ */
+export const DIRECT_REF_BUDGET_PER_QUERY = 200;
+
+/** Bounded concurrency for the chunked direct-ref fetches - same chunked-query
+ *  discipline as the metrics fetchers (see metrics/fragility-cascade.ts). */
+const DIRECT_REF_CONCURRENCY = 8;
+
+/**
+ * Hard ceiling on total speculative direct refs per request (block + atom
+ * stages combined). Past it the speculative fetch degrades to the
+ * per-document indexed fan-out the slow path already uses (~1ms per document
+ * via content_block_document_seq / content_atom_document_kind), which beats
+ * issuing hundreds of record-list chunks that mostly dereference to NONE.
+ * Exported for the fan-out regression tests.
+ */
+export const MAX_SPECULATIVE_REFS_PER_REQUEST = 24_000;
+
+/** Run one bounded record-list query per ref chunk (each query carries at
+ *  most {@link DIRECT_REF_BUDGET_PER_QUERY} refs), flattening the per-chunk
+ *  rows. Callers re-sort in JS - cross-chunk order is not meaningful. */
+const chunkedRefQuery = <Row>(
+    refs: ReadonlyArray<string>,
+    sqlForChunk: (chunk: ReadonlyArray<string>) => string,
+    context: string,
+): Effect.Effect<ReadonlyArray<Row>, never, SurrealClient> =>
+    Effect.forEach(
+        Arr.chunksOf(refs, DIRECT_REF_BUDGET_PER_QUERY),
+        (chunk) => queryMany<Row, Row>(sqlForChunk(chunk), (row) => row, context),
+        { concurrency: DIRECT_REF_CONCURRENCY },
+    ).pipe(Effect.map((results) => results.flat()));
+
 interface TurnContentDocumentRow {
     readonly source_ref: string | null;
     readonly document_id: string;
@@ -115,6 +152,17 @@ interface TurnContentAtomRow {
     readonly raw: unknown;
 }
 
+const compareStrings = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+
+const byDocumentThenSeq = (a: TurnContentBlockRow, b: TurnContentBlockRow): number =>
+    compareStrings(a.document_id, b.document_id) || a.seq - b.seq;
+
+const byDocumentBlockKindValue = (a: TurnContentAtomRow, b: TurnContentAtomRow): number =>
+    compareStrings(a.document_id, b.document_id) ||
+    a.block_seq - b.block_seq ||
+    compareStrings(a.kind, b.kind) ||
+    compareStrings(a.value, b.value);
+
 function contentDocumentRid(value: string): string | null {
     const prefix = "content_document:";
     if (!value.startsWith(prefix)) return null;
@@ -126,9 +174,14 @@ function contentDocumentRid(value: string): string | null {
 
 export const resolveTurnContent = Effect.fn("queries.resolveTurnContent")(
     function* (sessionId: string) {
-        return yield* resolveTurnContentFromDocuments(interpolateRid(TURN_CONTENT_DOCUMENTS_SQL, toBareSessionId(sessionId)), {
-            includeAtoms: true,
-        });
+        return yield* resolveTurnContentFromDocuments(
+            queryMany<TurnContentDocumentRow, TurnContentDocumentRow>(
+                interpolateRid(TURN_CONTENT_DOCUMENTS_SQL, toBareSessionId(sessionId)),
+                (row) => row,
+                "session-turn-content resolveDocuments",
+            ),
+            { includeAtoms: true },
+        );
     },
 );
 
@@ -139,8 +192,12 @@ export const resolveTurnContentForTurnSeqs = Effect.fn("queries.resolveTurnConte
             .sort((a, b) => a - b);
         if (seqs.length === 0) return new Map<number, InspectTurnContentDto>();
         return yield* resolveTurnContentFromDocuments(
-            interpolateRid(TURN_CONTENT_DOCUMENTS_FOR_SEQS_SQL, toBareSessionId(sessionId)),
-            { seqs },
+            queryMany<TurnContentDocumentRow, TurnContentDocumentRow>(
+                interpolateRid(TURN_CONTENT_DOCUMENTS_FOR_SEQS_SQL, toBareSessionId(sessionId)),
+                (row) => row,
+                "session-turn-content resolveDocuments",
+                { seqs },
+            ),
             { includeAtoms: true },
         );
     },
@@ -153,24 +210,32 @@ export const resolveTurnContentForSourceRefs = Effect.fn("queries.resolveTurnCon
     function* (sourceRefs: ReadonlyArray<string>) {
         const refs = [...new Set(sourceRefs)].filter((ref) => ref.length > 0);
         if (refs.length === 0) return new Map<number, InspectTurnContentDto>();
-        const documents = refListSource(
-            refs.map((ref) => recordRef("content_document", contentDocumentKeyForTurnRef(ref))),
-            ["id", "source_ref", "parser_id", "parser_version", "blockset_hash", "turn"],
+        const documentRefs = refs.map((ref) =>
+            recordRef("content_document", contentDocumentKeyForTurnRef(ref)),
         );
         // Fast inspector path: direct document/block/atom record fetches avoid the
         // multi-second `document IN ...` scans seen on large sessions. Atoms are
         // capped per kind/block so the initial inspect response stays sub-second.
-        return yield* resolveTurnContentFromDocuments(`
-        SELECT
-            source_ref,
-            type::string(id) AS document_id,
-            parser_id,
-            parser_version,
-            blockset_hash,
-            turn.seq AS turn_seq
-        FROM ${documents}
-        ORDER BY turn_seq;
-    `, undefined, {
+        // Every record-list fetch is chunked to DIRECT_REF_BUDGET_PER_QUERY refs;
+        // a window at the pagination cap stays a series of small indexed queries
+        // instead of one enormous statement.
+        const fetchDocuments = chunkedRefQuery<TurnContentDocumentRow>(
+            documentRefs,
+            (chunk) => `
+                SELECT
+                    source_ref,
+                    type::string(id) AS document_id,
+                    parser_id,
+                    parser_version,
+                    blockset_hash,
+                    turn.seq AS turn_seq
+                FROM ${refListSource(chunk, ["id", "source_ref", "parser_id", "parser_version", "blockset_hash", "turn"])};
+            `,
+            "session-turn-content resolveDocumentsDirect",
+        ).pipe(
+            Effect.map((rows) => [...rows].sort((a, b) => (a.turn_seq ?? 0) - (b.turn_seq ?? 0))),
+        );
+        return yield* resolveTurnContentFromDocuments(fetchDocuments, {
             includeAtoms: false,
             directBlockLimitPerDocument: 20,
             directAtomLimitPerKind: 5,
@@ -190,8 +255,7 @@ const FAST_TURN_ATOM_KINDS = [
 ] as const;
 
 const resolveTurnContentFromDocuments = (
-    documentsSql: string,
-    bindings?: Record<string, unknown>,
+    fetchDocuments: Effect.Effect<ReadonlyArray<TurnContentDocumentRow>, never, SurrealClient>,
     opts: {
         readonly includeAtoms: boolean;
         readonly directBlockLimitPerDocument?: number;
@@ -199,12 +263,7 @@ const resolveTurnContentFromDocuments = (
     } = { includeAtoms: true },
 ): Effect.Effect<Map<number, InspectTurnContentDto>, never, SurrealClient> =>
     Effect.gen(function* () {
-        const documentRows = yield* queryMany<TurnContentDocumentRow, TurnContentDocumentRow>(
-            documentsSql,
-            (row) => row,
-            "session-turn-content resolveDocuments",
-            bindings,
-        );
+        const documentRows = yield* fetchDocuments;
         if (documentRows.length === 0) return new Map<number, InspectTurnContentDto>();
 
         const documents = documentRows
@@ -224,9 +283,16 @@ const resolveTurnContentFromDocuments = (
                 );
             })
             : [];
-        const blockRows = directBlockRefs.length > 0
-            ? yield* queryMany<TurnContentBlockRow, TurnContentBlockRow>(
-                `
+        // Hard ceiling on the speculative fan-out: past it, fall back to the
+        // per-document indexed path - issuing one ~1ms indexed query per
+        // document beats flooding the DB with speculative refs that mostly
+        // dereference to NONE.
+        const useDirectBlocks =
+            directBlockRefs.length > 0 && directBlockRefs.length <= MAX_SPECULATIVE_REFS_PER_REQUEST;
+        const blockRows = useDirectBlocks
+            ? [...(yield* chunkedRefQuery<TurnContentBlockRow>(
+                directBlockRefs,
+                (chunk) => `
                     SELECT
                         type::string(id) AS id,
                         type::string(document) AS document_id,
@@ -240,12 +306,10 @@ const resolveTurnContentFromDocuments = (
                         start_offset,
                         end_offset,
                         confidence
-                    FROM ${refListSource(directBlockRefs, ["id", "document", "seq", "parent_seq", "kind", "role", "heading", "text", "text_excerpt", "start_offset", "end_offset", "confidence"])}
-                    ORDER BY document_id, seq;
+                    FROM ${refListSource(chunk, ["id", "document", "seq", "parent_seq", "kind", "role", "heading", "text", "text_excerpt", "start_offset", "end_offset", "confidence"])};
                 `,
-                (row) => row,
                 "session-turn-content resolveBlocksDirect",
-            )
+            ))].sort(byDocumentThenSeq)
             // Per-document indexed fan-out instead of a `document IN [<all docs>]`
             // membership scan (see TURN_CONTENT_BLOCKS_FOR_DOC_SQL).
             : (yield* Effect.forEach(
@@ -258,7 +322,9 @@ const resolveTurnContentFromDocuments = (
                     ),
                 { concurrency: CONTENT_FANOUT_CONCURRENCY },
             )).flat();
-        const directAtomRefs = opts.directAtomLimitPerKind
+        // Speculative atom refs only make sense while the request is still in
+        // direct mode; once blocks fell back per-document, atoms follow.
+        const directAtomRefs = useDirectBlocks && opts.directAtomLimitPerKind
             ? blockRows.flatMap((block) => {
                 const blockKey = recordKeyPart(block.id, "content_block");
                 if (!blockKey) return [];
@@ -272,9 +338,18 @@ const resolveTurnContentFromDocuments = (
                 );
             })
             : [];
-        const atomRows = directAtomRefs.length > 0
-            ? yield* queryMany<TurnContentAtomRow, TurnContentAtomRow>(
-                `
+        const useDirectAtoms =
+            directAtomRefs.length > 0 &&
+            directBlockRefs.length + directAtomRefs.length <= MAX_SPECULATIVE_REFS_PER_REQUEST;
+        // On the fast path, atoms past the ceiling degrade to the per-document
+        // indexed fetch too (still correct - just no longer capped per kind).
+        const wantsAtomFallback =
+            opts.includeAtoms ||
+            (opts.directAtomLimitPerKind !== undefined && !useDirectAtoms && blockRows.length > 0);
+        const atomRows = useDirectAtoms
+            ? [...(yield* chunkedRefQuery<TurnContentAtomRow>(
+                directAtomRefs,
+                (chunk) => `
                     SELECT
                         type::string(document) AS document_id,
                         block.seq AS block_seq,
@@ -283,13 +358,11 @@ const resolveTurnContentFromDocuments = (
                         normalized,
                         confidence,
                         raw
-                    FROM ${refListSource(directAtomRefs, ["document", "block", "kind", "value", "normalized", "confidence", "raw"])}
-                    ORDER BY document_id, block_seq, kind, value;
+                    FROM ${refListSource(chunk, ["document", "block", "kind", "value", "normalized", "confidence", "raw"])};
                 `,
-                (row) => row,
                 "session-turn-content resolveAtomsDirect",
-            )
-            : opts.includeAtoms
+            ))].sort(byDocumentBlockKindValue)
+            : wantsAtomFallback
               // Per-document indexed fan-out instead of a `document IN [...]` scan.
               ? (yield* Effect.forEach(
                   documents,


### PR DESCRIPTION
Closes #263

## Problem

The session-inspect fast path (`resolveTurnContentForSourceRefs`) builds speculative direct record refs instead of scanning by membership: up to 20 block refs per document, then up to 5 atom refs per kind per block across 8 kinds. At the inspect pagination cap (2000 turns) this compounds to 40k block refs and a worst case of ~1.6M atom refs sent to SurrealDB as a **single** record-list source - one enormous query per API request.

## Change

`apps/axctl/src/queries/session-turn-content.ts`:

- **Chunked record-list fetches** - documents, blocks, and atoms on the fast path now go through `chunkedRefQuery`, which caps each materialized record-list query at `DIRECT_REF_BUDGET_PER_QUERY` (200) refs and runs chunks at bounded concurrency (8) - the same chunked-query discipline as `metrics/fragility-cascade.ts`. Cross-chunk ordering is restored with deterministic JS sorts (the per-chunk SQL `ORDER BY` was meaningless across chunks).
- **Hard ceiling + fallback** - `MAX_SPECULATIVE_REFS_PER_REQUEST` (24k) bounds the total speculative refs per request (block + atom stages cumulative). Past it, the resolver falls back to the per-document indexed fan-out the slow path already implements (`document = <rid>` hits `content_block_document_seq` / `content_atom_document_kind`, ~1ms per doc); once blocks fall back, atoms follow. Fallback atoms lose only the per-kind cap, never content.
- **#253 pattern preserved** - every record-list source still goes through `refListSource` (materialized `.map(|$r| $r.*)` + `pick` projection), so SurrealDB 3.0.x compatibility and the row-width trim are untouched.
- `resolveTurnContentFromDocuments` now takes a document-fetch *effect* instead of raw SQL, so the fast path's document lookup is chunked too while the slow paths (`resolveTurnContent`, `resolveTurnContentForTurnSeqs`) keep their exact existing queries.

## Acceptance criteria

- **No single query over the ref budget**: asserted via the `makeTestSurrealClient` query-capture seam - every captured SQL is checked against `DIRECT_REF_BUDGET_PER_QUERY`.
- **Pagination-cap regression test (fan-out math, not wall-clock)**: a 2000-ref window (40k speculative block refs > ceiling) must emit zero speculative block/atom record-list queries and reroute to 2000 + 2000 per-document indexed fetches, still returning correct blocks + atoms for all 2000 turns.
- **Chunking coverage**: 30 docs -> 3 block chunks / 6 atom chunks, with the union of chunked refs exactly covering the speculative set.
- **Small sessions unchanged**: direct path end-to-end, no fallback queries; existing `resolveTurnContent` slow-path tests untouched and green.

## Verification

- `bun run typecheck` - exit 0
- `bun test` - 3135 pass / 0 fail (335 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)