### PR TITLE
refactor(cli): shared fail() + parseCsvFlag helpers, sweep ad-hoc exit-2 sites

### DIFF
--- a/apps/axctl/src/cli/commands/classifiers.ts
+++ b/apps/axctl/src/cli/commands/classifiers.ts
@@ -38,6 +38,7 @@ import {
     boolArg,
     jsonFlag,
     optionValue,
+    parseCsvFlag,
     positiveLimit,
     stringArg,
 } from "./shared.ts";
@@ -282,15 +283,12 @@ const parseRouteInputValues = (value: Option.Option<string>): Readonly<Record<st
         return undefined;
     }
     return Object.fromEntries(
-        text.split(",")
-            .map((entry) => entry.trim())
-            .filter((entry) => entry.length > 0)
-            .map((entry) => {
-                const separator = entry.indexOf("=");
-                return separator === -1
-                    ? [entry, ""]
-                    : [entry.slice(0, separator), entry.slice(separator + 1)];
-            }),
+        parseCsvFlag(text).map((entry) => {
+            const separator = entry.indexOf("=");
+            return separator === -1
+                ? [entry, ""]
+                : [entry.slice(0, separator), entry.slice(separator + 1)];
+        }),
     );
 };
 

--- a/apps/axctl/src/cli/commands/costs.ts
+++ b/apps/axctl/src/cli/commands/costs.ts
@@ -8,7 +8,7 @@ import { fetchLocSummary, type LocSummary, type LocSelector } from "../../dashbo
 import { resolvePwdRepository } from "../../pwd.ts";
 import { stderrExit } from "../output.ts";
 import type { RuntimeManifest } from "./manifest.ts";
-import { jsonFlag, optionalSince, optionValue, positiveLimit } from "./shared.ts";
+import { fail, jsonFlag, optionalSince, optionValue, parseCsvFlag, positiveLimit } from "./shared.ts";
 
 const usd = (value: unknown): string => {
     const n = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
@@ -129,13 +129,8 @@ const formatCostSummary = (summary: CostSummary): string => {
     return lines.join("\n");
 };
 
-const splitCostTerms = (value: string | null): string[] =>
-    value === null
-        ? []
-        : value.split(",").map((term) => term.trim()).filter((term) => term.length > 0);
-
-const costQueryTerms = (query: string | null, terms: string | null): string[] => {
-    const parsedTerms = splitCostTerms(terms);
+const costQueryTerms = (query: string | null, terms: string | null): readonly string[] => {
+    const parsedTerms = parseCsvFlag(terms);
     if (parsedTerms.length > 0) return parsedTerms;
     return query === null ? [] : [query];
 };
@@ -180,8 +175,7 @@ const cmdCostsFor = (input: {
             input.branch ? { kind: "branch" as const, branch: input.branch, repositoryKey, limit: input.limit } :
             null;
         if (!selected) {
-            console.error("axctl costs for: pass one of --session, --query, --terms, --commit, --branch");
-            process.exit(2);
+            fail("axctl costs for: pass one of --session, --query, --terms, --commit, --branch");
         }
         const summary = yield* fetchCostSummary(selected);
         if (input.json) {

--- a/apps/axctl/src/cli/commands/improve.ts
+++ b/apps/axctl/src/cli/commands/improve.ts
@@ -16,7 +16,7 @@ import { showExperiment, formatShow } from "../../improve/show.ts";
 import { buildImproveProposalsNext } from "../../nav/next-links.ts";
 import { printNextLinks } from "../next-format.ts";
 import type { RuntimeManifest } from "./manifest.ts";
-import { jsonFlag, optionValue, parseFileHints, positiveLimit, requireOptionalPositiveInt, requirePositiveInt } from "./shared.ts";
+import { fail, jsonFlag, optionValue, parseFileHints, positiveLimit, requireOptionalPositiveInt, requirePositiveInt } from "./shared.ts";
 
 /**
  * axctl improve - surface the experiment-loop proposal shortlist.
@@ -80,8 +80,7 @@ const cmdImproveShow = (input: {
             return;
         }
         if (result === null) {
-            process.stderr.write(`no proposal matched ${positional}\n`);
-            process.exit(2);
+            fail(`no proposal matched ${positional}`);
         }
         console.log(formatShow(result));
     });
@@ -274,8 +273,7 @@ const improveAcceptCommand = Command.make(
             const result = yield* acceptProposal({ sigOrId: id, force, autoScaffold });
 
             if (result.status === "not_found") {
-                console.error(result.message ?? `no proposal matched ${id}`);
-                process.exit(2);
+                fail(result.message ?? `no proposal matched ${id}`);
             }
             if (result.status === "wrong_status") {
                 console.error(result.message ?? "proposal already processed");
@@ -289,16 +287,13 @@ const improveAcceptCommand = Command.make(
                 process.exit(2);
             }
             if (result.status === "unsupported_form") {
-                console.error(result.message ?? "unsupported form");
-                process.exit(2);
+                fail(result.message ?? "unsupported form");
             }
             if (result.status === "missing_payload") {
-                console.error(result.message ?? "missing payload");
-                process.exit(2);
+                fail(result.message ?? "missing payload");
             }
             if (result.status === "scaffold_exists") {
-                console.error(result.message ?? "scaffold already exists (use --force to overwrite)");
-                process.exit(2);
+                fail(result.message ?? "scaffold already exists (use --force to overwrite)");
             }
 
             // status === "ok"
@@ -367,8 +362,7 @@ const cmdImproveReject = (input: {
         const reason = input.reason ?? "not_worth_packaging";
         const result = yield* rejectProposal({ sigOrId: positional, reason });
         if (result.status !== "ok") {
-            console.error(result.message ?? `failed to reject proposal ${positional}`);
-            process.exit(2);
+            fail(result.message ?? `failed to reject proposal ${positional}`);
         }
         console.log(`proposal status -> rejected (reason: ${result.reason})`);
     });
@@ -461,19 +455,16 @@ const cmdImproveVerdict = (input: {
         );
         const row = (sel?.[0] ?? [])[0];
         if (!row) {
-            console.error(`no experiment matched ${positional} (check \`axctl improve list --status=accepted\`)`);
-            process.exit(2);
+            fail(`no experiment matched ${positional} (check \`axctl improve list --status=accepted\`)`);
         }
         const checkpoints = (row.checkpoints as Array<Record<string, unknown>> | undefined) ?? [];
 
         if (setValue !== undefined) {
             if (!ALLOWED_VERDICTS.has(setValue)) {
-                console.error(`--set must be one of: ${[...ALLOWED_VERDICTS].sort().join(", ")}`);
-                process.exit(2);
+                fail(`--set must be one of: ${[...ALLOWED_VERDICTS].sort().join(", ")}`);
             }
             if (row.locked_verdict) {
-                console.error(`experiment already locked: ${String(row.locked_verdict)}`);
-                process.exit(2);
+                fail(`experiment already locked: ${String(row.locked_verdict)}`);
             }
             const experimentId = String(row.id ?? "");
             const latestCp = checkpoints[0];
@@ -543,11 +534,12 @@ const improveVerdictCommand = Command.make(
 const cmdImproveReset = (input: { readonly yes: boolean }) =>
     Effect.gen(function* () {
         if (!input.yes) {
-            console.error("axctl improve reset: refusing to wipe without --yes");
-            console.error("  drops: checkpoint, opportunity, experiment, cites_evidence,");
-            console.error("         skill_proposal, subagent_proposal, hook_proposal,");
-            console.error("         guidance_proposal, automation_proposal, proposal");
-            process.exit(2);
+            fail(
+                "axctl improve reset: refusing to wipe without --yes\n" +
+                "  drops: checkpoint, opportunity, experiment, cites_evidence,\n" +
+                "         skill_proposal, subagent_proposal, hook_proposal,\n" +
+                "         guidance_proposal, automation_proposal, proposal",
+            );
         }
         const db = yield* SurrealClient;
         // Dependency order: checkpoint -> opportunity -> experiment ->

--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -38,10 +38,12 @@ import {
 import type { RuntimeManifest } from "./manifest.ts";
 import {
     boolArg,
+    fail,
     intArg,
     jsonFlag,
     optionValue,
     optionalSince,
+    parseCsvFlag,
     requireOptionalPositiveInt,
     stringArg,
 } from "./shared.ts";
@@ -156,16 +158,11 @@ export const resolveIngestStages = (
 ): ReadonlyArray<StageDef<BaseStageStats, unknown>> => {
     const stagesArg = args.find((a) => a.startsWith("--stages="));
     if (stagesArg) {
-        const raw = stagesArg
-            .slice("--stages=".length)
-            .split(",")
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
+        const raw = parseCsvFlag(stagesArg.slice("--stages=".length));
         try {
             return selectByKeys(registry, raw);
         } catch (err) {
-            process.stderr.write(`axctl ingest: ${(err as Error).message}\n`);
-            process.exit(2);
+            fail(`axctl ingest: ${(err as Error).message}`);
         }
     }
     if (args.includes("--derive-only")) return selectByTag(registry, "derive");
@@ -536,17 +533,13 @@ export const ingestCommand = Command.make(
         }
         if (insightsOnly) {
             if (reset) {
-                console.error("axctl ingest: --reset cannot be combined with --insights-only");
-                process.exit(2);
+                fail("axctl ingest: --reset cannot be combined with --insights-only");
             }
             const conflicts = insightsOnlyConflicts({
                 hasSince: Option.isSome(since),
             });
             if (conflicts.length > 0) {
-                console.error(
-                    `axctl ingest: --insights-only is mutually exclusive with ${conflicts.join(", ")}`,
-                );
-                process.exit(2);
+                fail(`axctl ingest: --insights-only is mutually exclusive with ${conflicts.join(", ")}`);
             }
             return cmdIngestInsights({ progress, verbose });
         }

--- a/apps/axctl/src/cli/commands/recall.ts
+++ b/apps/axctl/src/cli/commands/recall.ts
@@ -13,21 +13,18 @@ import { printNextLinks } from "../next-format.ts";
 import { fetchRecall, type RecallSource, type RecallScope } from "../../dashboard/recall.ts";
 import { resolvePwdRepository } from "../../pwd.ts";
 import type { RuntimeManifest } from "./manifest.ts";
-import { jsonFlag } from "./shared.ts";
+import { fail, jsonFlag, parseCsvFlag } from "./shared.ts";
 
 const VALID_SOURCES: ReadonlySet<string> = new Set(["turn", "commit", "skill"]);
 
 function parseSourcesFlag(raw: string | null): ReadonlyArray<RecallSource> | null {
     if (!raw) return null;
-    const parts = raw.split(",").map((s) => s.trim()).filter(Boolean);
+    const parts = parseCsvFlag(raw);
     const invalid = parts.filter((p) => !VALID_SOURCES.has(p));
     if (invalid.length > 0) {
-        console.error(
-            `axctl recall: unknown source(s): ${invalid.join(", ")}. Valid: turn, commit, skill`,
-        );
-        process.exit(2);
+        fail(`axctl recall: unknown source(s): ${invalid.join(", ")}. Valid: turn, commit, skill`);
     }
-    return parts as RecallSource[];
+    return parts as ReadonlyArray<RecallSource>;
 }
 
 interface RecallCliOpts {
@@ -63,8 +60,7 @@ const resolveScope = (
                 Effect.catchTag("NotAGitRepoError", (err) => {
                     if (scopeFlag === "here") {
                         // explicit --scope=here outside a git repo → error
-                        process.stderr.write(`axctl recall: --scope=here requires a git repo (cwd=${err.cwd})\n`);
-                        process.exit(2);
+                        fail(`axctl recall: --scope=here requires a git repo (cwd=${err.cwd})`);
                     }
                     // auto-detect: not a git repo → silent fall-through to all
                     return Effect.succeed(null as import("../../pwd.ts").PwdResolution | null);
@@ -77,8 +73,7 @@ const resolveScope = (
             } as RecallScope;
         }
 
-        console.error(`axctl recall: unknown --scope value "${scopeFlag}". Valid: here, all`);
-        process.exit(2);
+        fail(`axctl recall: unknown --scope value "${scopeFlag}". Valid: here, all`);
     });
 
 /**
@@ -93,14 +88,10 @@ async function pickFromList(
     candidates: ReadonlyArray<{ readonly value: string; readonly hint: string }>,
 ): Promise<string | null> {
     if (!process.stdin.isTTY) {
-        console.error(
-            `axctl recall: --${label} requires a value (stdin is not a TTY)`,
-        );
-        process.exit(2);
+        fail(`axctl recall: --${label} requires a value (stdin is not a TTY)`);
     }
     if (candidates.length === 0) {
-        console.error(`no ${label}s found`);
-        process.exit(2);
+        fail(`no ${label}s found`);
     }
     process.stderr.write(`\nPick a ${label}:\n`);
     candidates.forEach((c, i) => {
@@ -118,8 +109,7 @@ async function pickFromList(
     if (!answer) return null;
     const n = Number(answer);
     if (!Number.isInteger(n) || n < 1 || n > candidates.length) {
-        console.error(`invalid selection: ${answer}`);
-        process.exit(2);
+        fail(`invalid selection: ${answer}`);
     }
     return candidates[n - 1]!.value;
 }
@@ -161,10 +151,7 @@ const resolveProject = (input: string | null) =>
         );
         if (matches.length === 1) return matches[0]!.slug;
         if (matches.length === 0) {
-            console.error(
-                `axctl recall: no project matches "${trimmed}". Try: axctl recall ... --project=?`,
-            );
-            process.exit(2);
+            fail(`axctl recall: no project matches "${trimmed}". Try: axctl recall ... --project=?`);
         }
         return yield* Effect.promise(() =>
             pickFromList(
@@ -207,10 +194,7 @@ const resolveSkill = (input: string | null) =>
         const matches = all.filter((r) => r.name.toLowerCase().includes(lower));
         if (matches.length === 1) return matches[0]!.name;
         if (matches.length === 0) {
-            console.error(
-                `axctl recall: no skill matches "${trimmed}". Try: axctl recall ... --skill=?`,
-            );
-            process.exit(2);
+            fail(`axctl recall: no skill matches "${trimmed}". Try: axctl recall ... --skill=?`);
         }
         return yield* Effect.promise(() =>
             pickFromList(

--- a/apps/axctl/src/cli/commands/retro.ts
+++ b/apps/axctl/src/cli/commands/retro.ts
@@ -11,7 +11,7 @@ import { cmdRetroReflect } from "../retro-reflect.ts";
 import { cmdRetroMeta } from "../retro-meta.ts";
 import { cmdRetroPlan } from "../retro-plan.ts";
 import type { RuntimeManifest } from "./manifest.ts";
-import { boolArg, jsonFlag, optionValue, positiveLimit, requirePositiveInt, stringArg } from "./shared.ts";
+import { boolArg, fail, jsonFlag, optionValue, positiveLimit, requirePositiveInt, stringArg } from "./shared.ts";
 
 /**
  * `ax retro emit` - create/update a retro node + `session -> reviewed -> retro`.
@@ -45,8 +45,7 @@ const cmdRetroEmit = (input: {
             );
             const row = (latest?.[0] ?? [])[0];
             if (!row) {
-                console.error("ax retro emit: no session to retro on (no --session and no rows in DB)");
-                process.exit(2);
+                fail("ax retro emit: no session to retro on (no --session and no rows in DB)");
             }
             const idStr = typeof row.id === "string" ? row.id : `session:${row.id.id}`;
             sessionRecordId = idStr;
@@ -55,19 +54,15 @@ const cmdRetroEmit = (input: {
 
         if (fromFile) {
             const raw = yield* Effect.promise(() => Bun.file(fromFile).text().catch((e) => {
-                console.error(`ax retro emit: could not read --from-file=${fromFile}: ${e}`);
-                process.exit(2);
+                fail(`ax retro emit: could not read --from-file=${fromFile}: ${e}`);
                 return "";
             }));
             const parsed = safeJsonParse<{ tried?: string; worked?: string; failed?: string; next?: string }>(raw);
             if (!parsed) {
-                console.error(`ax retro emit: --from-file is not valid JSON`);
-                process.exit(2);
-                return;
+                fail(`ax retro emit: --from-file is not valid JSON`);
             }
             if (!parsed.tried) {
-                console.error("ax retro emit: payload missing required `tried` field");
-                process.exit(2);
+                fail("ax retro emit: payload missing required `tried` field");
             }
             const sessionKey = sessionRecordId.split(":").slice(1).join(":").replace(/`/g, "");
             yield* upsertRetro({
@@ -91,8 +86,7 @@ const cmdRetroEmit = (input: {
 
         const retroInput = yield* retroFromSession(sessionRecordId);
         if (!retroInput) {
-            console.error(`ax retro emit: session ${sessionRecordId} not found`);
-            process.exit(2);
+            fail(`ax retro emit: session ${sessionRecordId} not found`);
         }
         yield* upsertRetro(retroInput);
         if (json) {
@@ -403,8 +397,7 @@ const cmdRetroBrief = (input: {
         `);
         const row = (rows?.[0] ?? [])[0];
         if (!row) {
-            console.error(`ax retro brief: session ${sessionRecordId} not found`);
-            process.exit(2);
+            fail(`ax retro brief: session ${sessionRecordId} not found`);
         }
         const idStr = typeof row.id === "string" ? row.id : `session:${row.id.id}`;
         const key = idStr.startsWith("session:") ? idStr.slice("session:".length).replace(/`/g, "") : idStr;

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -43,6 +43,7 @@ import { renderCompareTable, renderCompareJson } from "../session-compare-format
 import { renderSessionMarkdown, renderSessionJson } from "../session-show-format.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import {
+    fail,
     jsonFlag,
     optionalSince,
     optionValue,
@@ -243,16 +244,10 @@ const cmdSessionsAround = (input: {
         } else if (/^\d{4}-\d{2}-\d{2}[T ]/.test(positional)) {
             date = new Date(positional);
         } else {
-            console.error(
-                `axctl sessions around: invalid date "${positional}" (expected YYYY-MM-DD or ISO8601)`,
-            );
-            process.exit(2);
+            fail(`axctl sessions around: invalid date "${positional}" (expected YYYY-MM-DD or ISO8601)`);
         }
         if (isNaN(date.getTime())) {
-            console.error(
-                `axctl sessions around: invalid date "${positional}" (expected YYYY-MM-DD or ISO8601)`,
-            );
-            process.exit(2);
+            fail(`axctl sessions around: invalid date "${positional}" (expected YYYY-MM-DD or ISO8601)`);
         }
 
         const days = requirePositiveInt("sessions around", "days", input.days);
@@ -309,17 +304,14 @@ const cmdSessionsNear = (input: {
         const window = yield* findCommitWindow(repoRoot, sha).pipe(
             Effect.catchTag("ProcessError", () =>
                 Effect.sync(() => {
-                    console.error(`axctl sessions near: unknown sha ${sha}`);
-                    process.exit(2);
+                    fail(`axctl sessions near: unknown sha ${sha}`);
                     return { kind: "not_found" as const };
                 }),
             ),
         );
 
         if (window.kind === "not_found") {
-            console.error(`axctl sessions near: unknown sha ${sha}`);
-            process.exit(2);
-            return;
+            fail(`axctl sessions near: unknown sha ${sha}`);
         }
 
         let from: Date;
@@ -624,18 +616,14 @@ const cmdSessionsMetrics = (input: {
     readonly minCost: number | null;
 }) =>
     Effect.gen(function* () {
-        const fail = (msg: string): never => {
-            process.stderr.write(`axctl sessions metrics: ${msg}\n`);
-            process.exit(2);
-        };
         // --group-by values are validated by Flag.choice (GROUP_BY_KEYS).
         const groupBy = input.groupBy;
         if (groupBy !== null && input.skill !== null) {
-            fail("--group-by and --skill are exclusive (--skill is its own with/without comparison).");
+            fail("axctl sessions metrics: --group-by and --skill are exclusive (--skill is its own with/without comparison).");
         }
         const aggregateMode = groupBy !== null || input.skill !== null;
         if (!aggregateMode && (input.source !== null || input.minCost !== null)) {
-            fail("--source/--min-cost filter the aggregate scan; combine them with --group-by or --skill.");
+            fail("axctl sessions metrics: --source/--min-cost filter the aggregate scan; combine them with --group-by or --skill.");
         }
         let project = input.project;
         if (input.here) {

--- a/apps/axctl/src/cli/commands/shared.test.ts
+++ b/apps/axctl/src/cli/commands/shared.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Option } from "effect";
+import { fail, parseCsvFlag, parseFileHints, requirePositiveInt } from "./shared.ts";
+
+// ---------------------------------------------------------------------------
+// fail
+// ---------------------------------------------------------------------------
+
+describe("fail", () => {
+    let errorOutput: string[] = [];
+    let exitCode: number | undefined;
+    let originalConsoleError: typeof console.error;
+    let originalExit: typeof process.exit;
+
+    beforeEach(() => {
+        errorOutput = [];
+        exitCode = undefined;
+        originalConsoleError = console.error;
+        originalExit = process.exit.bind(process);
+        console.error = (...args: unknown[]) => {
+            errorOutput.push(args.map(String).join(" "));
+        };
+        (process as NodeJS.Process).exit = ((code?: number) => {
+            exitCode = code;
+            // Don't actually exit - throw to stop execution flow in tests
+            throw new Error(`process.exit(${code})`);
+        }) as typeof process.exit;
+    });
+
+    afterEach(() => {
+        console.error = originalConsoleError;
+        (process as NodeJS.Process).exit = originalExit;
+    });
+
+    it("prints the message verbatim to stderr and exits with code 2", () => {
+        expect(() => fail("axctl example: something went wrong")).toThrow("process.exit(2)");
+        expect(errorOutput).toEqual(["axctl example: something went wrong"]);
+        expect(exitCode).toBe(2);
+    });
+
+    it("requirePositiveInt delegates to fail with exact legacy wording", () => {
+        expect(() => requirePositiveInt("sessions around", "days", 0)).toThrow("process.exit(2)");
+        expect(errorOutput).toEqual([
+            'axctl sessions around: --days must be a positive integer (got "0")',
+        ]);
+        expect(exitCode).toBe(2);
+    });
+
+    it("requirePositiveInt passes valid values through untouched", () => {
+        expect(requirePositiveInt("sessions around", "days", 14)).toBe(14);
+        expect(errorOutput).toEqual([]);
+        expect(exitCode).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parseCsvFlag / parseFileHints
+// ---------------------------------------------------------------------------
+
+describe("parseCsvFlag", () => {
+    it("splits on commas and trims entries", () => {
+        expect(parseCsvFlag("a, b ,c")).toEqual(["a", "b", "c"]);
+    });
+
+    it("drops empty entries (leading/trailing/double commas)", () => {
+        expect(parseCsvFlag(",a,,b,")).toEqual(["a", "b"]);
+    });
+
+    it("returns [] for null, undefined, and empty string", () => {
+        expect(parseCsvFlag(null)).toEqual([]);
+        expect(parseCsvFlag(undefined)).toEqual([]);
+        expect(parseCsvFlag("")).toEqual([]);
+    });
+
+    it("keeps = inside entries intact (route-input style values)", () => {
+        expect(parseCsvFlag("key=value, flag")).toEqual(["key=value", "flag"]);
+    });
+});
+
+describe("parseFileHints", () => {
+    it("None → []", () => {
+        expect(parseFileHints(Option.none())).toEqual([]);
+    });
+
+    it("Some csv → trimmed non-empty entries", () => {
+        expect(parseFileHints(Option.some(" a.md , b.md "))).toEqual(["a.md", "b.md"]);
+    });
+});

--- a/apps/axctl/src/cli/commands/shared.ts
+++ b/apps/axctl/src/cli/commands/shared.ts
@@ -30,6 +30,18 @@ export const optionalSince = Flag.integer("since").pipe(Flag.optional);
 export const jsonFlag = Flag.boolean("json").pipe(Flag.withDefault(false));
 
 /**
+ * Print `message` to stderr and terminate with exit code 2 (usage error).
+ * Owns the `console.error` + `process.exit(2)` pattern that was re-rolled
+ * ad-hoc across the command-family modules (issue #243). Returns `never` so
+ * it composes in expression positions and TypeScript control-flow narrows
+ * after a call, same as a bare `process.exit(2)`.
+ */
+export function fail(message: string): never {
+    console.error(message);
+    process.exit(2);
+}
+
+/**
  * Typed replacement for the old string-based parsePositiveIntFlag: the Effect
  * CLI parser already guarantees an integer; this preserves the positivity
  * check (and exact error wording + exit 2) that used to run on the rebuilt
@@ -37,10 +49,7 @@ export const jsonFlag = Flag.boolean("json").pipe(Flag.withDefault(false));
  */
 export function requirePositiveInt(cmd: string, flagName: string, n: number): number {
     if (!Number.isInteger(n) || n <= 0) {
-        console.error(
-            `axctl ${cmd}: --${flagName} must be a positive integer (got "${n}")`,
-        );
-        process.exit(2);
+        fail(`axctl ${cmd}: --${flagName} must be a positive integer (got "${n}")`);
     }
     return n;
 }
@@ -64,9 +73,13 @@ export function requireOptionalPositiveInt(
 export const fmtCount = (v: unknown): string =>
     fmtCountLib(v as number | null | undefined);
 
-/** Split a comma-separated flag value (file hints, agent ids, forms) into trimmed non-empty entries. */
-export const parseFileHints = (value: Option.Option<string>): readonly string[] =>
-    (Option.getOrUndefined(value) ?? "")
+/** Split a comma-separated flag value into trimmed non-empty entries. */
+export const parseCsvFlag = (value: string | null | undefined): readonly string[] =>
+    (value ?? "")
         .split(",")
-        .map((file) => file.trim())
-        .filter((file) => file.length > 0);
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+
+/** Option-flag variant of {@link parseCsvFlag} (file hints, agent ids, forms). */
+export const parseFileHints = (value: Option.Option<string>): readonly string[] =>
+    parseCsvFlag(Option.getOrUndefined(value));

--- a/apps/axctl/src/cli/commands/signals.ts
+++ b/apps/axctl/src/cli/commands/signals.ts
@@ -6,7 +6,7 @@ import { SIGNAL_CATALOG, findSignal, runRelationSignal } from "../../metrics/cat
 import { cleanSessionId } from "../../metrics/util.ts";
 import type { CascadeEdge } from "../../metrics/fragility-cascade.ts";
 import type { RuntimeManifest } from "./manifest.ts";
-import { jsonFlag, positiveLimit } from "./shared.ts";
+import { fail, jsonFlag, positiveLimit } from "./shared.ts";
 
 const formatCascadeEdges = (edges: readonly CascadeEdge[], descriptor: { label: string }): string => {
     if (edges.length === 0) return `${descriptor.label}: no edges (no reverted-commit files have downstream fixers).`;
@@ -30,9 +30,7 @@ const cmdSignalsShow = (input: { readonly id: string; readonly limit: number; re
         const descriptor = findSignal(input.id);
         if (descriptor === undefined) {
             const ids = SIGNAL_CATALOG.map((s) => s.id).join(", ");
-            process.stderr.write(`axctl signals show: unknown signal "${input.id}". Valid ids: ${ids}\n`);
-            process.exit(2);
-            return;
+            fail(`axctl signals show: unknown signal "${input.id}". Valid ids: ${ids}`);
         }
         if (descriptor.kind === "aggregate") {
             console.log("aggregate rendering is a later wave");

--- a/apps/axctl/src/cli/commands/skills.ts
+++ b/apps/axctl/src/cli/commands/skills.ts
@@ -37,6 +37,7 @@ import { cmdSkillsTag } from "../skills-tag.ts";
 import { renderWeightedTable, renderWeightedJson } from "../skills-weighted-format.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import {
+    fail,
     fmtCount,
     jsonFlag,
     optionValue,
@@ -206,10 +207,7 @@ const cmdStats = (input: StatsInput) =>
         const exists = yield* skillExists(name);
         if (!exists) {
             const hint = name.length > 20 ? name.slice(0, 20) : name;
-            console.error(
-                `axctl: no skill named "${name}". try: axctl skills search "${hint}"`,
-            );
-            process.exit(2);
+            fail(`axctl: no skill named "${name}". try: axctl skills search "${hint}"`);
         }
         const payload = yield* fetchSkillStats(name);
 
@@ -405,8 +403,7 @@ const cmdRolesForSkill = (input: RolesForSkillInput) =>
         );
 
         if (!result.skillExists) {
-            process.stderr.write(`axctl skills roles: unknown skill "${skill}"\n`);
-            process.exit(2);
+            fail(`axctl skills roles: unknown skill "${skill}"`);
         }
 
         if (json) {
@@ -663,10 +660,7 @@ const cmdPairs = (input: PairsInput) =>
         const exists = yield* skillExists(name);
         if (!exists) {
             const hint = name.length > 20 ? name.slice(0, 20) : name;
-            console.error(
-                `axctl: no skill named "${name}". try: axctl skills search "${hint}"`,
-            );
-            process.exit(2);
+            fail(`axctl: no skill named "${name}". try: axctl skills search "${hint}"`);
         }
         // Pairs are stored undirected (lexicographically lo->hi). Look the
         // skill up on either endpoint so callers don't have to know the

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -31,6 +31,7 @@ import {
     detectRemovedIngestFlag,
 } from "./commands/ingest.ts";
 import type { RuntimeManifest } from "./commands/manifest.ts";
+import { parseCsvFlag } from "./commands/shared.ts";
 import {
     versionCommand,
     updateCommand,
@@ -146,7 +147,7 @@ const withDb = (args: ReadonlyArray<string>): CliProgram =>
 const resolveProgressStages = (args: ReadonlyArray<string>): ProgressStage[] => {
     const stagesArg = args.find((a) => a.startsWith("--stages="));
     const keys = stagesArg
-        ? stagesArg.slice("--stages=".length).split(",").map((s) => s.trim()).filter(Boolean)
+        ? parseCsvFlag(stagesArg.slice("--stages=".length))
         : args.includes("--derive-only")
             ? ALL_STAGES.filter((s) => s.meta.tags.includes("derive")).map((s) => s.meta.key)
             : ALL_STAGES.map((s) => s.meta.key);

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -5,6 +5,7 @@ import { orAbsent } from "@ax/lib/shared/fs-error";
 import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
 import { posixPath } from "@ax/lib/shared/path";
 import { buildOnboardingReport, formatInstallOnboardingGuidance } from "./onboarding.ts";
+import { fail } from "./commands/shared.ts";
 import {
     candidatePorts,
     pickFreePort,
@@ -1113,8 +1114,7 @@ export function cmdDaemon(
         if (!isMacos()) {
             console.log(formatDaemonStatus(yield* collectDaemonStatus(), parsed.json));
             if (parsed.command !== "status") {
-                console.error("axctl daemon: start/stop/restart use launchd and are macOS-only");
-                process.exit(2);
+                fail("axctl daemon: start/stop/restart use launchd and are macOS-only");
             }
             return;
         }

--- a/apps/axctl/src/cli/retro-plan.ts
+++ b/apps/axctl/src/cli/retro-plan.ts
@@ -35,6 +35,7 @@ import {
     surrealString,
 } from "@ax/lib/shared/surql";
 import { safeKeyPart } from "@ax/lib/shared/derive-keys";
+import { fail as sharedFail, parseCsvFlag } from "./commands/shared.ts";
 import { dedupeSig, normalizeTitle } from "../ingest/derive-proposals.ts";
 import {
     type InterventionSafetyContract,
@@ -81,10 +82,7 @@ const flagValue = (args: string[], name: string): string | undefined => {
     return hit?.split("=").slice(1).join("=");
 };
 
-const fail = (message: string): never => {
-    console.error(`ax retro plan: ${message}`);
-    process.exit(2);
-};
+const fail = (message: string): never => sharedFail(`ax retro plan: ${message}`);
 
 /**
  * Parse the CLI argv into a validated RetroPlanArgs. Throws (via
@@ -136,10 +134,7 @@ export const parseRetroPlanArgs = (
     if (!Number.isFinite(frequency) || frequency <= 0) {
         fail(`--frequency must be a positive integer (got ${frequencyRaw})`);
     }
-    const evidenceRetros = evidenceRaw
-        .split(",")
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
+    const evidenceRetros = parseCsvFlag(evidenceRaw);
 
     return {
         slug: slug as string,

--- a/apps/axctl/src/cli/skills-classify.ts
+++ b/apps/axctl/src/cli/skills-classify.ts
@@ -12,6 +12,7 @@ import { orAbsent } from "@ax/lib/shared/fs-error";
 import { prettyPrint } from "@ax/lib/json";
 import { skillNameToSlug, renderClassifyBrief } from "./skills-classify-template.ts";
 import { validateSkillName } from "@ax/lib/role-name";
+import { fail } from "./commands/shared.ts";
 
 export interface ClassifyRow {
     readonly name: string;
@@ -88,11 +89,9 @@ export const cmdSkillsClassify = (
         if (opts.names.length > 0) {
             for (const name of opts.names) {
                 if (safeSkillName(name) === null) {
-                    console.error(
+                    fail(
                         `axctl skills classify: invalid skill name "${name}" (must be alphanumeric, _ or -, optionally plugin:namespaced)`,
                     );
-                    process.exit(2);
-                    return; // unreachable; satisfies TypeScript
                 }
             }
         }

--- a/apps/axctl/src/cli/skills-tag.ts
+++ b/apps/axctl/src/cli/skills-tag.ts
@@ -11,6 +11,7 @@ import type { DbError } from "@ax/lib/errors";
 import { recordLiteral } from "@ax/lib/ids";
 import { validateRoleName, validateSkillName } from "@ax/lib/role-name";
 import { surrealString } from "@ax/lib/shared/surql";
+import { fail } from "./commands/shared.ts";
 
 export interface SkillsTagOptions {
     readonly skillName: string;
@@ -71,32 +72,25 @@ export const cmdSkillsTag = (opts: SkillsTagOptions): Effect.Effect<void, DbErro
         // 1. Validate inputs
         const trimmedSkill = safeSkillName(opts.skillName);
         if (trimmedSkill === null) {
-            console.error(
+            fail(
                 `axctl skills tag: invalid skill name "${opts.skillName}" (must be alphanumeric, _ or -, optionally plugin:namespaced)`,
             );
-            process.exit(2);
-            return; // unreachable; satisfies TypeScript
         }
 
         const roleName = safeRoleName(opts.roleName);
         if (roleName === null) {
-            console.error(
+            fail(
                 `axctl skills tag: invalid role name "${opts.roleName}" (must be lowercase alphanumeric, _ or -)`,
             );
-            process.exit(2);
-            return; // unreachable; satisfies TypeScript
         }
         if (opts.confidence < 0 || opts.confidence > 1) {
-            console.error(`axctl skills tag: --confidence must be between 0 and 1 (got ${opts.confidence})`);
-            process.exit(2);
+            fail(`axctl skills tag: --confidence must be between 0 and 1 (got ${opts.confidence})`);
         }
 
         // 2. Resolve skill record id by name
         const skillKey = yield* lookupSkillKey(db, trimmedSkill);
         if (skillKey === null) {
-            console.error(`axctl skills tag: unknown skill "${trimmedSkill}"`);
-            process.exit(2);
-            return; // unreachable but satisfies TypeScript
+            fail(`axctl skills tag: unknown skill "${trimmedSkill}"`);
         }
 
         // Inline record id literal - bypasses SDK RecordId binding which


### PR DESCRIPTION
Closes #243

## What

~30 ad-hoc `console.error` + `process.exit(2)` sites across the CLI command-family modules now route through one shared helper, and the re-rolled comma-split flag parsing is consolidated.

- **`fail(message): never`** in `apps/axctl/src/cli/commands/shared.ts` owns the message + exit-2 usage-error pattern. Returns `never`, so it composes in expression positions and TypeScript control-flow narrows after a call - the unreachable `return; // satisfies TypeScript` lines could go too.
- **`parseCsvFlag(value)`** is the generic trim/split/drop-empties CSV helper; `parseFileHints` becomes a thin `Option`-flag wrapper over it.

## Sweep

- `fail()` adopted in: `recall`, `sessions` (incl. the metrics-local `fail` wrapper, now inlined), `retro`, `improve`, `skills`, `ingest`, `costs`, `signals`, `skills-tag`, `skills-classify`, `retro-plan` (prefixing wrapper kept, delegates to shared), `install` (daemon macOS guard), and `requirePositiveInt` itself.
- `parseCsvFlag()` adopted in: costs' `splitCostTerms` (deleted), classifiers' `parseRouteInputValues`, ingest's `--stages` resolution, retro-plan's `--evidence-retros`, index.ts progress-stage resolution. recall's `parseSourcesFlag` stays as a thin validation layer on top, per the issue.

## Byte-identical guarantee

- Every message string is carried over verbatim; `console.error(msg)` emits the same stderr bytes as the replaced `process.stderr.write(`${msg}\n`)` sites.
- New `shared.test.ts` locks the helper contract (message verbatim, exit code 2, `requirePositiveInt` legacy wording).
- Existing exit-2 tests (`skills-tag.test.ts` tests 3/7/8/9/10) pass unchanged.
- Manual smokes: `sessions around banana`, `recall foo --sources=bogus`, `costs for` → exit 2 with identical wording.

Intentionally left: `improve lint`'s message-less `process.exit(2)` and the multi-line conditional `wrong_status` block in `improve accept` (not the simple message+exit shape).

## Verification

- `bun run typecheck` → exit 0
- `bun test` → 3141 pass, 0 fail (336 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)