### PR TITLE
feat(cli): manifest owns command visibility - uniform registration loop

### DIFF
--- a/apps/axctl/src/agents/cli.ts
+++ b/apps/axctl/src/agents/cli.ts
@@ -125,4 +125,4 @@ export const agentsCommand = Command.make("agents").pipe(
 );
 
 /** Routing declaration consumed by cli/index.ts (Phase 2 command-family split). */
-export const agentsRuntime: RuntimeManifest = { agents: "db" };
+export const agentsRuntime: RuntimeManifest = { agents: { runtime: "db", hidden: true } };

--- a/apps/axctl/src/cli/commands/classifiers.ts
+++ b/apps/axctl/src/cli/commands/classifiers.ts
@@ -633,6 +633,24 @@ export const classifiersPackageOperationsNeedsDb = (args: ReadonlyArray<string>)
         args.includes("--boundary-replay-summary")
     );
 
+// The classifiers family owns its sub-routing (issue #241): dispatch reads
+// this db-conditional declaration via resolveRuntime instead of hard-coding
+// subcommand names. effect-cli.test.ts enforces this table is exhaustive
+// against classifiersCommand's registered subcommands in both directions.
 export const classifiersRuntime: RuntimeManifest = {
-    classifiers: "db",
+    classifiers: {
+        kind: "db-conditional",
+        fallback: "db",
+        subcommands: {
+            list: "none",
+            eval: "none",
+            explain: "db",
+            graph: "db",
+            lifecycle: "db",
+            "package-operations": (args) =>
+                classifiersPackageOperationsNeedsDb(args) ? "db" : "none",
+            "workflow-candidates": "db",
+            "label-mining": "db",
+        },
+    },
 };

--- a/apps/axctl/src/cli/commands/classifiers.ts
+++ b/apps/axctl/src/cli/commands/classifiers.ts
@@ -639,18 +639,21 @@ export const classifiersPackageOperationsNeedsDb = (args: ReadonlyArray<string>)
 // against classifiersCommand's registered subcommands in both directions.
 export const classifiersRuntime: RuntimeManifest = {
     classifiers: {
-        kind: "db-conditional",
-        fallback: "db",
-        subcommands: {
-            list: "none",
-            eval: "none",
-            explain: "db",
-            graph: "db",
-            lifecycle: "db",
-            "package-operations": (args) =>
-                classifiersPackageOperationsNeedsDb(args) ? "db" : "none",
-            "workflow-candidates": "db",
-            "label-mining": "db",
+        hidden: true,
+        runtime: {
+            kind: "db-conditional",
+            fallback: "db",
+            subcommands: {
+                list: "none",
+                eval: "none",
+                explain: "db",
+                graph: "db",
+                lifecycle: "db",
+                "package-operations": (args) =>
+                    classifiersPackageOperationsNeedsDb(args) ? "db" : "none",
+                "workflow-candidates": "db",
+                "label-mining": "db",
+            },
         },
     },
 };

--- a/apps/axctl/src/cli/commands/context.ts
+++ b/apps/axctl/src/cli/commands/context.ts
@@ -36,5 +36,5 @@ export const contextCommand = Command.make("context").pipe(
 );
 
 export const contextRuntime: RuntimeManifest = {
-    context: "db",
+    context: { runtime: "db", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/costs.ts
+++ b/apps/axctl/src/cli/commands/costs.ts
@@ -365,7 +365,7 @@ export const pricingCommand = Command.make(
 ).pipe(Command.withDescription("Inspect imported model pricing rows"));
 
 export const costsRuntime: RuntimeManifest = {
-    costs: "db",
-    loc: "db",
-    pricing: "db",
+    costs: { runtime: "db", hidden: true },
+    loc: { runtime: "db", hidden: true },
+    pricing: { runtime: "db", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/evidence.ts
+++ b/apps/axctl/src/cli/commands/evidence.ts
@@ -46,5 +46,5 @@ export const evidenceCommand = Command.make("evidence").pipe(
 );
 
 export const evidenceRuntime: RuntimeManifest = {
-    evidence: "db",
+    evidence: { runtime: "db", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/hooks.ts
+++ b/apps/axctl/src/cli/commands/hooks.ts
@@ -266,6 +266,7 @@ export const hooksCommand = Command.make("hooks").pipe(
 );
 
 export const hooksRuntime: RuntimeManifest = {
-    hook: "db",
+    // `hook` is harness plumbing (invoked by hook configs), not for humans.
+    hook: { runtime: "db", hidden: true },
     hooks: "db",
 };

--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -635,7 +635,9 @@ export const deriveCommand = Command.make("derive").pipe(
 
 export const ingestRuntime: RuntimeManifest = {
     ingest: "ingest",
-    derive: "db",
-    "derive-signals": "db",
-    "derive-intents": "db",
+    // Hidden maintenance verbs. `derive-signals`/`derive-intents` MUST stay
+    // callable - the installed LaunchAgent plists invoke them by name.
+    derive: { runtime: "db", hidden: true },
+    "derive-signals": { runtime: "db", hidden: true },
+    "derive-intents": { runtime: "db", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/lifecycle.ts
+++ b/apps/axctl/src/cli/commands/lifecycle.ts
@@ -106,11 +106,11 @@ export const uninstallCommand = Command.make(
 );
 
 export const lifecycleRuntime: RuntimeManifest = {
-    version: "none",
-    update: "none",
+    version: { runtime: "none", hidden: true },
+    update: { runtime: "none", hidden: true },
     install: "none",
     setup: "none",
-    daemon: "none",
-    doctor: "none",
-    uninstall: "none",
+    daemon: { runtime: "none", hidden: true },
+    doctor: { runtime: "none", hidden: true },
+    uninstall: { runtime: "none", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/manifest.ts
+++ b/apps/axctl/src/cli/commands/manifest.ts
@@ -42,17 +42,54 @@ export interface DbConditionalRuntime {
 /** A family's routing declaration: static runtime or per-subcommand conditional. */
 export type RuntimeDeclaration = CommandRuntime | DbConditionalRuntime;
 
-export type RuntimeManifest = Readonly<Record<string, RuntimeDeclaration>>;
+/**
+ * Per-command metadata beyond routing. Visibility policy (#173): a hidden
+ * command is omitted from `--help`, shell completions, and "did you mean?"
+ * while staying fully invokable by exact name (agents, plists, and docs use
+ * the names). Read-only insight surfaces MUST stay visible - a hidden command
+ * is invisible to agents discovering the tool via `--help`, so it never gets
+ * used (blind-dogfood finding). Hide only mutating / maintenance / plumbing
+ * verbs.
+ */
+export interface CommandMeta {
+    readonly runtime: RuntimeDeclaration;
+    /** Omit the command from `--help` / completions (still callable by name). */
+    readonly hidden: boolean;
+}
 
 /**
- * Resolve a declaration to the concrete runtime for one invocation. Static
+ * One manifest entry: a bare routing declaration (the command is visible) or
+ * routing wrapped with metadata (`{ runtime, hidden }`). Families fully own
+ * their commands' metadata here; cli/index.ts assembles the root command via
+ * a uniform loop over these entries (issue #248) - no per-command
+ * `withHidden` calls at the assembly site.
+ */
+export type ManifestEntry = RuntimeDeclaration | CommandMeta;
+
+export type RuntimeManifest = Readonly<Record<string, ManifestEntry>>;
+
+/** Discriminate `CommandMeta` from a bare `DbConditionalRuntime` declaration. */
+const isCommandMeta = (entry: ManifestEntry): entry is CommandMeta =>
+    typeof entry !== "string" && !("kind" in entry);
+
+/** The routing declaration of an entry, unwrapping `CommandMeta` if present. */
+export const entryRuntime = (entry: ManifestEntry): RuntimeDeclaration =>
+    isCommandMeta(entry) ? entry.runtime : entry;
+
+/** Whether the entry's command is hidden from `--help` (bare entries are visible). */
+export const entryHidden = (entry: ManifestEntry): boolean =>
+    isCommandMeta(entry) ? entry.hidden : false;
+
+/**
+ * Resolve a manifest entry to the concrete runtime for one invocation. Static
  * declarations resolve to themselves; db-conditional ones look up argv[1] in
  * the family's subcommand table (falling back for bare/--help/unknown).
  */
 export const resolveRuntime = (
-    declaration: RuntimeDeclaration,
+    entry: ManifestEntry,
     args: ReadonlyArray<string>,
 ): CommandRuntime => {
+    const declaration = entryRuntime(entry);
     if (typeof declaration === "string") return declaration;
     const sub = declaration.subcommands[args[1] ?? ""];
     if (sub === undefined) return declaration.fallback;

--- a/apps/axctl/src/cli/commands/manifest.ts
+++ b/apps/axctl/src/cli/commands/manifest.ts
@@ -14,4 +14,47 @@ export type CommandRuntime =
     /** must never touch the DB - route through withoutDb (Proxy SurrealClient that throws) */
     | "none";
 
-export type RuntimeManifest = Readonly<Record<string, CommandRuntime>>;
+/**
+ * Routing for one subcommand of a db-conditional family: either a static
+ * runtime, or a per-invocation resolver over the raw argv (args[0] is the
+ * family name) for subcommands whose DB usage depends on flags.
+ */
+export type SubcommandRuntime =
+    | CommandRuntime
+    | ((args: ReadonlyArray<string>) => CommandRuntime);
+
+/**
+ * Conditional routing for a family whose subcommands split between runtimes
+ * (e.g. `classifiers eval` is pure compute while `classifiers graph` reads
+ * the DB). The family declares an exhaustive per-subcommand table here so
+ * dispatch never hard-codes subcommand names; effect-cli.test.ts enforces the
+ * table against the registered subcommands in both directions, so a new
+ * subcommand added without a routing declaration fails CI.
+ */
+export interface DbConditionalRuntime {
+    readonly kind: "db-conditional";
+    /** Runtime for the bare family command, `--help`, or an unknown subcommand. */
+    readonly fallback: CommandRuntime;
+    /** Exhaustive per-subcommand routing, keyed by subcommand name (argv[1]). */
+    readonly subcommands: Readonly<Record<string, SubcommandRuntime>>;
+}
+
+/** A family's routing declaration: static runtime or per-subcommand conditional. */
+export type RuntimeDeclaration = CommandRuntime | DbConditionalRuntime;
+
+export type RuntimeManifest = Readonly<Record<string, RuntimeDeclaration>>;
+
+/**
+ * Resolve a declaration to the concrete runtime for one invocation. Static
+ * declarations resolve to themselves; db-conditional ones look up argv[1] in
+ * the family's subcommand table (falling back for bare/--help/unknown).
+ */
+export const resolveRuntime = (
+    declaration: RuntimeDeclaration,
+    args: ReadonlyArray<string>,
+): CommandRuntime => {
+    if (typeof declaration === "string") return declaration;
+    const sub = declaration.subcommands[args[1] ?? ""];
+    if (sub === undefined) return declaration.fallback;
+    return typeof sub === "function" ? sub(args) : sub;
+};

--- a/apps/axctl/src/cli/commands/project.ts
+++ b/apps/axctl/src/cli/commands/project.ts
@@ -28,5 +28,5 @@ export const projectCommand = Command.make("project").pipe(
 );
 
 export const projectRuntime: RuntimeManifest = {
-    project: "db",
+    project: { runtime: "db", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/report.ts
+++ b/apps/axctl/src/cli/commands/report.ts
@@ -101,7 +101,7 @@ export const timelineCommand = Command.make(
 ));
 
 export const reportRuntime: RuntimeManifest = {
-    report: "db",
-    insights: "db",
-    timeline: "db",
+    report: { runtime: "db", hidden: true },
+    insights: { runtime: "db", hidden: true },
+    timeline: { runtime: "db", hidden: true },
 };

--- a/apps/axctl/src/cli/commands/star.ts
+++ b/apps/axctl/src/cli/commands/star.ts
@@ -1,0 +1,27 @@
+// Extracted from the cli/index.ts dispatch bypass (issue #242): `star` now
+// routes through the standard manifest path like every other "none" command.
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { cmdStar } from "../star-nudge.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { boolArg } from "./shared.ts";
+
+export const starCommand = Command.make(
+    "star",
+    {
+        done: Flag.boolean("done").pipe(Flag.withDefault(false)),
+        starred: Flag.boolean("starred").pipe(Flag.withDefault(false)),
+    },
+    ({ done, starred }) =>
+        Effect.promise(() =>
+            cmdStar([...boolArg("done", done), ...boolArg("starred", starred)]),
+        ),
+).pipe(
+    Command.withDescription(
+        "Star the ax repo on GitHub via gh (--done / --starred just hides the reminder)",
+    ),
+);
+
+export const starRuntime: RuntimeManifest = {
+    star: "none",
+};

--- a/apps/axctl/src/cli/commands/star.ts
+++ b/apps/axctl/src/cli/commands/star.ts
@@ -23,5 +23,7 @@ export const starCommand = Command.make(
 );
 
 export const starRuntime: RuntimeManifest = {
-    star: "none",
+    // Nudge target (`ax star --done`) - pointed at by the star reminder, not
+    // for the help list.
+    star: { runtime: "none", hidden: true },
 };

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -8,7 +8,7 @@ import {
     rootCommand,
 } from "./index.ts";
 import { classifiersPackageOperationsNeedsDb } from "./commands/classifiers.ts";
-import { resolveRuntime, type DbConditionalRuntime } from "./commands/manifest.ts";
+import { entryHidden, entryRuntime, resolveRuntime, type DbConditionalRuntime } from "./commands/manifest.ts";
 import { ALL_STAGES } from "../ingest/stage/registry.ts";
 import type { StageRegistryShape } from "../ingest/stage/registry.ts";
 import type { BaseStageStats, StageDef } from "../ingest/stage/types.ts";
@@ -89,6 +89,22 @@ describe("effect cli", () => {
                 registered.has(name),
                 `manifest declares "${name}" but no top-level command registers it (ghost RUNTIME_BY_COMMAND/DB_COMMANDS entry)`,
             ).toBe(true);
+        }
+    });
+
+    test("registered visibility mirrors the manifest for every command (uniform loop, #248)", () => {
+        // The root command is assembled by a manifest-driven loop; there must
+        // be no per-command withHidden drift between registration and the
+        // family manifests. Holds for every command, both directions.
+        for (const group of rootCommand.subcommands) {
+            for (const command of group.commands) {
+                const entry = RUNTIME_BY_COMMAND[command.name];
+                expect(entry, `command "${command.name}" missing from a family RuntimeManifest`).toBeDefined();
+                expect(
+                    command.hidden,
+                    `command "${command.name}": registered hidden=${command.hidden} but its manifest declares hidden=${entryHidden(entry!)}`,
+                ).toBe(entryHidden(entry!));
+            }
         }
     });
 
@@ -287,8 +303,8 @@ describe("effect cli", () => {
         const names = topLevelNames();
         expect(names).toContain("share");
         expect(names).toContain("star");
-        expect(RUNTIME_BY_COMMAND["share"]).toBe("none");
-        expect(RUNTIME_BY_COMMAND["star"]).toBe("none");
+        expect(entryRuntime(RUNTIME_BY_COMMAND["share"]!)).toBe("none");
+        expect(entryRuntime(RUNTIME_BY_COMMAND["star"]!)).toBe("none");
         expect(DB_COMMANDS.has("share")).toBe(false);
         expect(DB_COMMANDS.has("star")).toBe(false);
         // star is the nudge target (`ax star --done`), not a discovery surface
@@ -332,8 +348,9 @@ describe("classifiers db-conditional routing (#241)", () => {
     };
 
     const classifiersDeclaration = (): DbConditionalRuntime => {
-        const declared = RUNTIME_BY_COMMAND["classifiers"];
-        expect(declared).toBeDefined();
+        const entry = RUNTIME_BY_COMMAND["classifiers"];
+        expect(entry).toBeDefined();
+        const declared = entryRuntime(entry!);
         expect(typeof declared).toBe("object");
         expect((declared as DbConditionalRuntime).kind).toBe("db-conditional");
         return declared as DbConditionalRuntime;

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, test } from "bun:test";
 import {
     DB_COMMANDS,
     RUNTIME_BY_COMMAND,
-    classifiersPackageOperationsNeedsDb,
     detectRemovedIngestFlag,
     insightsOnlyConflicts,
     resolveIngestStages,
     rootCommand,
 } from "./index.ts";
+import { classifiersPackageOperationsNeedsDb } from "./commands/classifiers.ts";
+import { resolveRuntime, type DbConditionalRuntime } from "./commands/manifest.ts";
 import { ALL_STAGES } from "../ingest/stage/registry.ts";
 import type { StageRegistryShape } from "../ingest/stage/registry.ts";
 import type { BaseStageStats, StageDef } from "../ingest/stage/types.ts";
@@ -303,6 +304,78 @@ describe("effect cli", () => {
             "package-operations",
             "--quality-status",
         ])).toBe(false);
+    });
+});
+
+describe("classifiers db-conditional routing (#241)", () => {
+    const classifiersSubNames = (): string[] => {
+        const classifiers = rootCommand.subcommands
+            .flatMap((g) => g.commands)
+            .find((c) => c.name === "classifiers");
+        expect(classifiers).toBeDefined();
+        return classifiers!.subcommands.flatMap((g) => g.commands.map((c) => c.name));
+    };
+
+    const classifiersDeclaration = (): DbConditionalRuntime => {
+        const declared = RUNTIME_BY_COMMAND["classifiers"];
+        expect(declared).toBeDefined();
+        expect(typeof declared).toBe("object");
+        expect((declared as DbConditionalRuntime).kind).toBe("db-conditional");
+        return declared as DbConditionalRuntime;
+    };
+
+    test("classifiers is declared db-conditional and excluded from DB_COMMANDS (dispatch resolves per-invocation)", () => {
+        classifiersDeclaration();
+        expect(DB_COMMANDS.has("classifiers")).toBe(false);
+    });
+
+    test("every registered classifiers subcommand declares its routing (anti-drift)", () => {
+        const declared = classifiersDeclaration().subcommands;
+        for (const name of classifiersSubNames()) {
+            expect(
+                declared[name],
+                `classifiers subcommand "${name}" missing from the db-conditional routing table in commands/classifiers.ts`,
+            ).toBeDefined();
+        }
+    });
+
+    test("every declared classifiers routing entry maps to a registered subcommand (reverse anti-drift)", () => {
+        const registered = new Set(classifiersSubNames());
+        for (const name of Object.keys(classifiersDeclaration().subcommands)) {
+            expect(
+                registered.has(name),
+                `routing table declares classifiers subcommand "${name}" but classifiersCommand does not register it`,
+            ).toBe(true);
+        }
+    });
+
+    test("resolveRuntime preserves the pre-#241 dispatch behavior byte-for-byte", () => {
+        const declared = classifiersDeclaration();
+        // DB subcommands.
+        expect(resolveRuntime(declared, ["classifiers", "graph"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "lifecycle"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "explain"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "workflow-candidates"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "label-mining"])).toBe("db");
+        // No-DB subcommands.
+        expect(resolveRuntime(declared, ["classifiers", "eval"])).toBe("none");
+        expect(resolveRuntime(declared, ["classifiers", "list"])).toBe("none");
+        // package-operations: DB only with the write-plan/health/replay flags.
+        expect(resolveRuntime(declared, ["classifiers", "package-operations"])).toBe("none");
+        expect(resolveRuntime(declared, ["classifiers", "package-operations", "--quality-status"])).toBe("none");
+        expect(resolveRuntime(declared, ["classifiers", "package-operations", "--apply-write-plan"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "package-operations", "--graph-health"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "package-operations", "--boundary-replay-summary"])).toBe("db");
+        // Bare family / --help / unknown subcommand fall back to db (old
+        // behavior: fell through to DB_COMMANDS which contained "classifiers").
+        expect(resolveRuntime(declared, ["classifiers"])).toBe("db");
+        expect(resolveRuntime(declared, ["classifiers", "--help"])).toBe("db");
+    });
+
+    test("static manifest declarations resolve to themselves", () => {
+        expect(resolveRuntime("db", ["sessions"])).toBe("db");
+        expect(resolveRuntime("ingest", ["ingest"])).toBe("ingest");
+        expect(resolveRuntime("none", ["version"])).toBe("none");
     });
 });
 

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -282,6 +282,21 @@ describe("effect cli", () => {
         expect(DB_COMMANDS.has("pricing")).toBe(true);
     });
 
+    test("share and star route through manifests as no-DB commands - no dispatch bypass (#242)", () => {
+        const names = topLevelNames();
+        expect(names).toContain("share");
+        expect(names).toContain("star");
+        expect(RUNTIME_BY_COMMAND["share"]).toBe("none");
+        expect(RUNTIME_BY_COMMAND["star"]).toBe("none");
+        expect(DB_COMMANDS.has("share")).toBe(false);
+        expect(DB_COMMANDS.has("star")).toBe(false);
+        // star is the nudge target (`ax star --done`), not a discovery surface
+        const byName = new Map(
+            rootCommand.subcommands.flatMap((g) => g.commands.map((c) => [c.name, c] as const)),
+        );
+        expect(byName.get("star")?.hidden).toBe(true);
+    });
+
     test("DB-backed classifier package-operation flags are routed through DB", () => {
         expect(classifiersPackageOperationsNeedsDb([
             "classifiers",

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -30,7 +30,7 @@ import {
     ingestRuntime,
     detectRemovedIngestFlag,
 } from "./commands/ingest.ts";
-import { resolveRuntime, type RuntimeManifest } from "./commands/manifest.ts";
+import { entryHidden, entryRuntime, resolveRuntime, type RuntimeManifest } from "./commands/manifest.ts";
 import {
     versionCommand,
     updateCommand,
@@ -52,59 +52,97 @@ import type { ProgressStage } from "./progress.ts";
 
 const devOnlyCommands = process.env.AX_DEV === "1" ? [dogfoodCommand] : [];
 
+// Spread of every family RuntimeManifest (18 commands/<family>.ts modules +
+// src/agents/cli.ts). effect-cli.test.ts enforces that every registered
+// top-level command appears here, so new families can't silently fall through
+// to the no-DB Proxy at runtime. Each entry carries BOTH facets of the
+// per-command metadata: routing (runtime) and visibility (hidden) - see
+// commands/manifest.ts for the entry shape (#248).
+export const RUNTIME_BY_COMMAND: RuntimeManifest = {
+    ...agentsRuntime,
+    ...reportRuntime,
+    ...signalsRuntime,
+    ...evidenceRuntime,
+    ...contextRuntime,
+    ...projectRuntime,
+    ...serveRuntime,
+    ...shareRuntime,
+    ...starRuntime,
+    ...dogfoodRuntime,
+    ...costsRuntime,
+    ...recallRuntime,
+    ...hooksRuntime,
+    ...retroRuntime,
+    ...improveRuntime,
+    ...sessionsRuntime,
+    ...skillsRuntime,
+    ...classifiersRuntime,
+    ...ingestRuntime,
+    ...lifecycleRuntime,
+};
+
+// Registration order, not metadata: the first block is the common verbs shown
+// in `axctl --help` - keep it short; it is the human's mental map of the tool
+// (full command reference lives in the README). Whether a command is hidden
+// is NOT decided here: visibility lives next to routing in each family's
+// RuntimeManifest (#248) and is applied by the uniform loop below. Visibility
+// policy itself (#173) is documented on `CommandMeta` in commands/manifest.ts.
+const registeredCommands: ReadonlyArray<Command.Command.Any> = [
+    // Common verbs - shown in `axctl --help`.
+    ingestCommand,
+    sessionsCommand,
+    improveCommand,
+    retroCommand,
+    recallCommand,
+    skillsCommand,
+    signalsCommand,
+    rolesCommand,
+    hooksCommand,
+    serveCommand,
+    mcpCommand,
+    tuiCommand,
+    shareCommand,
+    installCommand,
+    setupCommand,
+    // Maintenance / plumbing verbs - hidden via their family manifests.
+    deriveCommand,
+    deriveSignalsCommand,
+    deriveIntentsCommand,
+    insightsCommand,
+    classifiersCommand,
+    reportCommand,
+    costsGroupCommand,
+    locCommand,
+    pricingCommand,
+    contextCommand,
+    hookCommand,
+    agentsCommand,
+    projectCommand,
+    evidenceCommand,
+    timelineCommand,
+    versionCommand,
+    updateCommand,
+    daemonCommand,
+    doctorCommand,
+    uninstallCommand,
+    starCommand,
+    ...devOnlyCommands,
+];
+
+/**
+ * Uniform manifest-driven registration (#248): apply each command's
+ * manifest-declared visibility at assembly time. A command missing from
+ * RUNTIME_BY_COMMAND registers visible - and fails the effect-cli.test.ts
+ * exhaustiveness guard, so it can't ship undeclared.
+ */
+const withManifestVisibility = (command: Command.Command.Any): Command.Command.Any => {
+    const entry = RUNTIME_BY_COMMAND[command.name];
+    return entry !== undefined && entryHidden(entry) ? Command.withHidden(command) : command;
+};
+
 export const rootCommand = Command.make("axctl").pipe(
     Command.withDescription("ax local memory and telemetry for coding agents"),
-    Command.withSubcommands([
-        // Common verbs - shown in `axctl --help`. Keep this list short; it is the
-        // human's mental map of the tool. Everything else is hidden (still fully
-        // invokable by exact name - agents, plists, and docs use the names) so the
-        // default help stays lean. Full command reference lives in the README.
-        ingestCommand,
-        sessionsCommand,
-        improveCommand,
-        retroCommand,
-        recallCommand,
-        skillsCommand,
-        signalsCommand,
-        rolesCommand,
-        hooksCommand,
-        serveCommand,
-        mcpCommand,
-        tuiCommand,
-        shareCommand,
-        installCommand,
-        setupCommand,
-        // Visibility policy (#173): read-only insight surfaces (sessions, recall,
-        // skills, signals, roles, hooks) MUST be visible - a hidden command is
-        // invisible to agents discovering the tool via --help, so it never gets
-        // used (blind-dogfood finding). Hide only mutating / maintenance /
-        // plumbing verbs. `withHidden` omits a command from `--help`, shell
-        // completions, and "did you mean?" while leaving it callable by exact
-        // name. `derive-signals`/`derive-intents` MUST stay callable - the
-        // installed LaunchAgent plists invoke them by name.
-        Command.withHidden(deriveCommand),
-        Command.withHidden(deriveSignalsCommand),
-        Command.withHidden(deriveIntentsCommand),
-        Command.withHidden(insightsCommand),
-        Command.withHidden(classifiersCommand),
-        Command.withHidden(reportCommand),
-        Command.withHidden(costsGroupCommand),
-        Command.withHidden(locCommand),
-        Command.withHidden(pricingCommand),
-        Command.withHidden(contextCommand),
-        Command.withHidden(hookCommand), // harness plumbing (invoked by hook configs), not for humans
-        Command.withHidden(agentsCommand),
-        Command.withHidden(projectCommand),
-        Command.withHidden(evidenceCommand),
-        Command.withHidden(timelineCommand),
-        Command.withHidden(versionCommand),
-        Command.withHidden(updateCommand),
-        Command.withHidden(daemonCommand),
-        Command.withHidden(doctorCommand),
-        Command.withHidden(uninstallCommand),
-        Command.withHidden(starCommand), // nudge target (`ax star --done`) - pointed at by the star reminder, not for the help list
-        ...devOnlyCommands,
-    ]),
+    Command.withSubcommands(registeredCommands.map(withManifestVisibility)),
 );
 
 /**
@@ -221,33 +259,6 @@ const withoutDb = (args: ReadonlyArray<string>): CliProgram => {
     );
 };
 
-// Spread of every family RuntimeManifest (18 commands/<family>.ts modules +
-// src/agents/cli.ts). effect-cli.test.ts enforces that every registered
-// top-level command appears here, so new families can't silently fall through
-// to the no-DB Proxy at runtime.
-export const RUNTIME_BY_COMMAND: RuntimeManifest = {
-    ...agentsRuntime,
-    ...reportRuntime,
-    ...signalsRuntime,
-    ...evidenceRuntime,
-    ...contextRuntime,
-    ...projectRuntime,
-    ...serveRuntime,
-    ...shareRuntime,
-    ...starRuntime,
-    ...dogfoodRuntime,
-    ...costsRuntime,
-    ...recallRuntime,
-    ...hooksRuntime,
-    ...retroRuntime,
-    ...improveRuntime,
-    ...sessionsRuntime,
-    ...skillsRuntime,
-    ...classifiersRuntime,
-    ...ingestRuntime,
-    ...lifecycleRuntime,
-};
-
 // Commands whose handlers reach into SurrealClient via AppLayer (or the
 // ingest superset layer). Anything outside this set runs through `withoutDb`
 // so the user gets fast, honest errors (e.g. "unknown command") instead of a
@@ -256,6 +267,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
 // excluded: dispatch resolves them per-invocation via resolveRuntime.
 export const DB_COMMANDS: ReadonlySet<string> = new Set(
     Object.entries(RUNTIME_BY_COMMAND)
+        .map(([name, entry]) => [name, entryRuntime(entry)] as const)
         .filter(([, runtime]) => runtime === "db" || runtime === "ingest")
         .map(([name]) => name),
 );
@@ -309,20 +321,19 @@ const dispatch = (args: ReadonlyArray<string>): Effect.Effect<void, unknown> => 
         }
         return withIngest(args);
     }
-    // db-conditional families (e.g. classifiers) declare their own
-    // per-subcommand routing in their RuntimeManifest; resolve it here so
-    // dispatch never hard-codes subcommand names or predicates.
+    // Routing is manifest-owned: resolve the family's declared entry (static,
+    // db-conditional, or metadata-wrapped - see commands/manifest.ts) to the
+    // concrete runtime for this invocation, so dispatch never hard-codes
+    // command or subcommand names. Unknown commands / typos fall through to
+    // withoutDb for a fast "unknown command" instead of a DB connect timeout.
     const declared = RUNTIME_BY_COMMAND[args[0]];
-    if (declared !== undefined && typeof declared !== "string") {
+    if (declared !== undefined) {
         const runtime = resolveRuntime(declared, args);
         return runtime === "db"
             ? withDb(args)
             : runtime === "ingest"
                 ? withIngest(args)
                 : withoutDb(args);
-    }
-    if (DB_COMMANDS.has(args[0] ?? "")) {
-        return withDb(args);
     }
     return withoutDb(args);
 };

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -21,7 +21,7 @@ import { retroCommand, retroRuntime } from "./commands/retro.ts";
 import { improveCommand, improveRuntime } from "./commands/improve.ts";
 import { sessionsCommand, sessionsRuntime } from "./commands/sessions.ts";
 import { skillsCommand, rolesCommand, skillsRuntime } from "./commands/skills.ts";
-import { classifiersCommand, classifiersRuntime, classifiersPackageOperationsNeedsDb } from "./commands/classifiers.ts";
+import { classifiersCommand, classifiersRuntime } from "./commands/classifiers.ts";
 import {
     ingestCommand,
     deriveCommand,
@@ -30,7 +30,7 @@ import {
     ingestRuntime,
     detectRemovedIngestFlag,
 } from "./commands/ingest.ts";
-import type { RuntimeManifest } from "./commands/manifest.ts";
+import { resolveRuntime, type RuntimeManifest } from "./commands/manifest.ts";
 import {
     versionCommand,
     updateCommand,
@@ -250,16 +250,13 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
 // ingest superset layer). Anything outside this set runs through `withoutDb`
 // so the user gets fast, honest errors (e.g. "unknown command") instead of a
 // 5s connect timeout. Derived - do not hand-edit; declare runtime in the
-// owning commands/<family>.ts manifest instead.
+// owning commands/<family>.ts manifest instead. db-conditional families are
+// excluded: dispatch resolves them per-invocation via resolveRuntime.
 export const DB_COMMANDS: ReadonlySet<string> = new Set(
     Object.entries(RUNTIME_BY_COMMAND)
         .filter(([, runtime]) => runtime === "db" || runtime === "ingest")
         .map(([name]) => name),
 );
-
-// Moved to commands/classifiers.ts (Phase 2 CLI split); re-exported here for
-// the existing test contract (effect-cli.test.ts imports it from index.ts).
-export { classifiersPackageOperationsNeedsDb } from "./commands/classifiers.ts";
 
 // Moved to commands/ingest.ts (Phase 2 CLI split); re-exported here for the
 // existing test contract (effect-cli.test.ts imports them from index.ts).
@@ -313,16 +310,17 @@ const dispatch = (args: ReadonlyArray<string>): Effect.Effect<void, unknown> => 
         }
         return withIngest(args);
     }
-    if (
-        args[0] === "classifiers" &&
-        (classifiersPackageOperationsNeedsDb(args) ||
-            args[1] === "graph" ||
-            args[1] === "lifecycle")
-    ) {
-        return withDb(args);
-    }
-    if (args[0] === "classifiers" && (args[1] === "eval" || args[1] === "list" || args[1] === "package-operations")) {
-        return withoutDb(args);
+    // db-conditional families (e.g. classifiers) declare their own
+    // per-subcommand routing in their RuntimeManifest; resolve it here so
+    // dispatch never hard-codes subcommand names or predicates.
+    const declared = RUNTIME_BY_COMMAND[args[0]];
+    if (declared !== undefined && typeof declared !== "string") {
+        const runtime = resolveRuntime(declared, args);
+        return runtime === "db"
+            ? withDb(args)
+            : runtime === "ingest"
+                ? withIngest(args)
+                : withoutDb(args);
     }
     if (args[0] === "share") {
         if (args[1] === "--help" || args[1] === "-h") {

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -4,8 +4,7 @@ import { BunFileSystem, BunPath, BunRuntime } from "@effect/platform-bun";
 import { Command } from "effect/unstable/cli";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import { AppLayer } from "@ax/lib/layers";
-import { cmdShare } from "./share.ts";
-import { cmdStar, maybePrintStarNudge } from "./star-nudge.ts";
+import { maybePrintStarNudge } from "./star-nudge.ts";
 import { insightsCommand, reportCommand, timelineCommand, reportRuntime } from "./commands/report.ts";
 import { signalsCommand, signalsRuntime } from "./commands/signals.ts";
 import { evidenceCommand, evidenceRuntime } from "./commands/evidence.ts";
@@ -13,6 +12,7 @@ import { contextCommand, contextRuntime } from "./commands/context.ts";
 import { projectCommand, projectRuntime } from "./commands/project.ts";
 import { serveCommand, mcpCommand, tuiCommand, serveRuntime } from "./commands/serve.ts";
 import { shareCommand, shareRuntime } from "./commands/share.ts";
+import { starCommand, starRuntime } from "./commands/star.ts";
 import { dogfoodCommand, dogfoodRuntime } from "./commands/dogfood.ts";
 import { costsGroupCommand, locCommand, pricingCommand, costsRuntime } from "./commands/costs.ts";
 import { recallCommand, recallRuntime } from "./commands/recall.ts";
@@ -102,6 +102,7 @@ export const rootCommand = Command.make("axctl").pipe(
         Command.withHidden(daemonCommand),
         Command.withHidden(doctorCommand),
         Command.withHidden(uninstallCommand),
+        Command.withHidden(starCommand), // nudge target (`ax star --done`) - pointed at by the star reminder, not for the help list
         ...devOnlyCommands,
     ]),
 );
@@ -233,6 +234,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...projectRuntime,
     ...serveRuntime,
     ...shareRuntime,
+    ...starRuntime,
     ...dogfoodRuntime,
     ...costsRuntime,
     ...recallRuntime,
@@ -274,9 +276,9 @@ export { resolveIngestStages, detectRemovedIngestFlag, insightsOnlyConflicts } f
  * ingest_run finish row + ingest-lock release) instead of hard-killing
  * mid-run and stranding `ingest_run` rows in status "running".
  *
- * Non-Effect legacy commands (version/star/share) are wrapped in
- * `Effect.promise`; a rejection becomes a defect and flows through the same
- * `reportCliFailure` path the old `.catch` handled.
+ * The one remaining non-Effect legacy path (`-V`/`--version` flag printing)
+ * is wrapped in `Effect.promise`; a rejection becomes a defect and flows
+ * through the same `reportCliFailure` path the old `.catch` handled.
  */
 const dispatch = (args: ReadonlyArray<string>): Effect.Effect<void, unknown> => {
     if (args[0] === undefined) {
@@ -295,9 +297,6 @@ const dispatch = (args: ReadonlyArray<string>): Effect.Effect<void, unknown> => 
     }
     if (args[0] === "upgrade") {
         return withoutDb(["update", ...args.slice(1)]);
-    }
-    if (args[0] === "star") {
-        return Effect.promise(() => cmdStar(args.slice(1)));
     }
     if (args[0] === "ingest") {
         // Effect's CLI parser silently ignores unknown flags, so the removed
@@ -323,12 +322,6 @@ const dispatch = (args: ReadonlyArray<string>): Effect.Effect<void, unknown> => 
     }
     if (args[0] === "classifiers" && (args[1] === "eval" || args[1] === "list" || args[1] === "package-operations")) {
         return withoutDb(args);
-    }
-    if (args[0] === "share") {
-        if (args[1] === "--help" || args[1] === "-h") {
-            return withoutDb(args);
-        }
-        return Effect.promise(() => cmdShare(args.slice(1)));
     }
     if (DB_COMMANDS.has(args[0] ?? "")) {
         return withDb(args);


### PR DESCRIPTION
## Stacked PR

**Stacked on #287 and #286** - merge those first; this PR's diff then shrinks to just the #248 change. The branch is `origin/main` + merge of `agent/issue-241-db-conditional-manifest` (#287) + merge of `agent/issue-242-share-star-manifest` (#286) + one commit (`d4a3abef`) for #248 itself.

Closes #248

## What

Command visibility (`Command.withHidden`) was applied inline at the registration site in `cli/index.ts` while routing lived in family `RuntimeManifest`s - two facets of the same per-command metadata in different places. Manifest entries now carry both, and the root command is assembled by a uniform loop.

- **`commands/manifest.ts`**: `ManifestEntry = RuntimeDeclaration | CommandMeta` where `CommandMeta = { runtime, hidden }`; `entryRuntime` / `entryHidden` accessors; `resolveRuntime` widened to accept any `ManifestEntry` (unwraps metadata first). Bare entries stay terse and mean *visible*. The #173 visibility policy doc moved onto `CommandMeta`.
- **Family manifests** (`ingest`, `report`, `classifiers`, `costs`, `context`, `hooks`, `project`, `evidence`, `lifecycle`, `star`, `agents`): declare `hidden: true` for their 21 maintenance / plumbing verbs. `classifiers` shows the combined shape: db-conditional routing *and* hidden, in one entry.
- **`cli/index.ts`**: `registeredCommands` is a pure ordering list; visibility applied by `registeredCommands.map(withManifestVisibility)` - **no per-command `withHidden` calls at the assembly site**. Dispatch now resolves every declared entry through `resolveRuntime` (the `DB_COMMANDS.has` static branch folded in; `DB_COMMANDS` stays exported, derived via `entryRuntime`).
- **`effect-cli.test.ts`**: new bidirectional guard - for every registered command, the registered `hidden` flag must equal the manifest's `entryHidden`; existing classifiers/star guards updated to unwrap entries via `entryRuntime`.

## Acceptance criteria

- [x] `--help` captured before/after on the merged base: **byte-identical** (`diff` clean); visible set = 15 commands, hidden set = 21 commands, same order
- [x] Registration loop driven by manifests; zero `withHidden` calls at the assembly site
- [x] Exhaustiveness guards updated and green

## Verification

- `bun run typecheck`: exit 0
- `bun test` (repo root): 3139 pass, 4 skip, 0 fail (335 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)