### PR TITLE
feat(dashboard): surface skipped-file failures from ingest in the Live tab

### DIFF
--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -6,7 +6,7 @@ import { decodeJsonOrNull } from "@ax/lib/decode";
 import { recordRef, surrealDate, surrealJsonOption, surrealObject, surrealOptionInt, surrealOptionString, surrealString } from "@ax/lib/shared/surql";
 import { AppLayer } from "@ax/lib/layers";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
-import { annotateStageProgress } from "./stage/runner.ts";
+import { annotateStageProgress, stageFileFailureAnnotator } from "./stage/runner.ts";
 import type { StageDef } from "./stage/registry.ts";
 import {
     type PlanSnapshotWrite,
@@ -45,7 +45,7 @@ import { safeKeyPart } from "@ax/lib/shared/derive-keys";
 import { tokenQualityLabels } from "./token-quality.ts";
 import { estimateCost } from "./model-pricing.ts";
 import { walkJsonlFilesStrict } from "./walk-jsonl.ts";
-import { makeFileFailureCollector } from "./file-isolation.ts";
+import { type FileFailureSnapshot, makeFileFailureCollector } from "./file-isolation.ts";
 
 const DEFAULT_CODEX_RAW_MAX_BYTES = 5 * 1024 * 1024;
 const DEFAULT_CODEX_PROGRESS_EVERY = 10;
@@ -1389,6 +1389,10 @@ const queryCodexStatements = (statements: readonly string[]) =>
 interface CodexIngestOpts {
     sinceDays: number | undefined;
     onProgress: (counts: Record<string, number>) => Effect.Effect<void>;
+    /** Cumulative skipped-file snapshots from the failure collector (see
+     *  file-isolation.ts). The stage wires `stageFileFailureAnnotator` here so
+     *  the dashboard Live tab can list which files were skipped and why. */
+    onFileFailures: (snapshot: FileFailureSnapshot) => Effect.Effect<void>;
     /** Hard cap on session files processed - a backstop for `ingest --dry-run`
      *  calibration (paired with `deadlineMs`). */
     limit: number | undefined;
@@ -1442,7 +1446,10 @@ export const ingestCodex = Effect.fn("codex.ingest")(
         let activeFiles = 0;
         const recordCount = () => turnCount + invCount + toolCallCount + planSnapshotCount;
 
-        const failures = makeFileFailureCollector({ source: "codex" });
+        const failures = makeFileFailureCollector({
+            source: "codex",
+            ...(opts.onFileFailures ? { onFailure: opts.onFileFailures } : {}),
+        });
         yield* Effect.forEach(files.map((file, index) => ({ file, index })), ({ file, index }) => Effect.gen(function* () {
             // Time-box (dry-run calibration): once the deadline passes, start no
             // new files; in-flight ones finish.
@@ -1759,12 +1766,16 @@ export const codexStage: StageDef<CodexStageStats, SurrealClient | AxConfig | Fi
     run: Effect.fn(function* (ctx: IngestContext) {
         const t0 = Date.now();
         const sinceDays = sinceDaysFromCtx(ctx);
+        // Capture the stage span HERE (current span = the runner's
+        // LiveTrace.step span) so failure snapshots emitted from deep inside
+        // per-file child spans still key to this stage on the live stream.
+        const onFileFailures = yield* stageFileFailureAnnotator;
         // A vanished session file is caught + skipped inside `ingestCodex`;
         // any PlatformError that escapes here is a genuine FS fault (e.g. an
         // unreadable sessions root or a non-NotFound stat/stream error), so
         // it dies as a defect rather than masquerading as a recoverable
         // DbError - mirroring `claudeStage`.
-        const result = yield* ingestCodex({ sinceDays, onProgress: annotateStageProgress }).pipe(
+        const result = yield* ingestCodex({ sinceDays, onProgress: annotateStageProgress, onFileFailures }).pipe(
             Effect.catchTag("PlatformError", (e) => Effect.die(e)),
         );
         return CodexStageStats.make({

--- a/apps/axctl/src/ingest/file-isolation.test.ts
+++ b/apps/axctl/src/ingest/file-isolation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Exit } from "effect";
 import { DbError } from "@ax/lib/errors";
-import { makeFileFailureCollector } from "./file-isolation.ts";
+import { type FileFailureSnapshot, makeFileFailureCollector } from "./file-isolation.ts";
 
 const queryError = (message: string) => new DbError({ operation: "query", message });
 const connectError = () => new DbError({ operation: "connect", message: "daemon not reachable" });
@@ -69,6 +69,47 @@ describe("makeFileFailureCollector", () => {
         const exit = await run(c.isolate("/a", Effect.die(new Error("bug"))));
         expect(Exit.isFailure(exit)).toBe(true);
         expect(c.count()).toBe(0);
+    });
+
+    test("onFailure receives a cumulative snapshot per recorded failure, never on success", async () => {
+        const snapshots: FileFailureSnapshot[] = [];
+        const c = makeFileFailureCollector({
+            source: "test",
+            onFailure: (snapshot) => Effect.sync(() => snapshots.push(snapshot)),
+        });
+        await run(c.isolate("/ok", Effect.succeed(1)));
+        expect(snapshots).toEqual([]);
+        await run(c.isolate("/a.jsonl", Effect.fail(queryError("boom"))));
+        await run(c.isolate("/b.jsonl", Effect.fail(queryError("crash"))));
+        expect(snapshots).toEqual([
+            { total: 1, failures: [{ filePath: "/a.jsonl", tag: "DbError", message: "boom" }] },
+            {
+                total: 2,
+                failures: [
+                    { filePath: "/a.jsonl", tag: "DbError", message: "boom" },
+                    { filePath: "/b.jsonl", tag: "DbError", message: "crash" },
+                ],
+            },
+        ]);
+        // Snapshots are independent copies - later failures must not mutate
+        // an earlier snapshot a consumer already holds.
+        expect(snapshots[0].failures.length).toBe(1);
+    });
+
+    test("onFailure keeps reporting the uncapped total past the detail cap", async () => {
+        const snapshots: FileFailureSnapshot[] = [];
+        const c = makeFileFailureCollector({
+            source: "test",
+            stormThreshold: 1000,
+            onFailure: (snapshot) => Effect.sync(() => snapshots.push(snapshot)),
+        });
+        for (let i = 0; i < 30; i++) {
+            await run(c.isolate("/ok", Effect.succeed(1)));
+            await run(c.isolate(`/f${i}`, Effect.fail(queryError("x"))));
+        }
+        const last = snapshots.at(-1);
+        expect(last?.total).toBe(30);
+        expect(last?.failures.length).toBe(25);
     });
 
     test("report is a no-op at zero failures and logs otherwise", async () => {

--- a/apps/axctl/src/ingest/file-isolation.ts
+++ b/apps/axctl/src/ingest/file-isolation.ts
@@ -33,6 +33,15 @@ export interface FileFailure {
     readonly message: string;
 }
 
+/** Cumulative failure state passed to {@link FileFailureCollectorOptions.onFailure}
+ *  after each recorded failure: `total` is uncapped, `failures` is the detail
+ *  list capped at {@link DETAIL_CAP}. Each snapshot supersedes the previous
+ *  one, so consumers can simply keep the latest. */
+export interface FileFailureSnapshot {
+    readonly total: number;
+    readonly failures: ReadonlyArray<FileFailure>;
+}
+
 /** Failures whose detail we keep; beyond this only the count grows. */
 const DETAIL_CAP = 25;
 
@@ -74,6 +83,13 @@ export interface FileFailureCollectorOptions {
     /** Provider label for log lines, e.g. "claude" / "codex". */
     readonly source: string;
     readonly stormThreshold?: number;
+    /**
+     * Invoked after each recorded failure with the cumulative snapshot
+     * (count + capped detail list). The ingest stages use this to publish the
+     * skipped-file list onto the live progress stream while the stage runs;
+     * leaving it unset keeps the collector log-only (CLI behavior unchanged).
+     */
+    readonly onFailure?: (snapshot: FileFailureSnapshot) => Effect.Effect<void>;
 }
 
 export const makeFileFailureCollector = (
@@ -103,6 +119,9 @@ export const makeFileFailureCollector = (
                         tag: failureTag(err),
                         message: failureMessage(err),
                     });
+                    if (opts.onFailure) {
+                        yield* opts.onFailure({ total, failures: [...failures] });
+                    }
                     if (consecutive >= stormThreshold) {
                         return yield* new DbError({
                             operation: "query",

--- a/apps/axctl/src/ingest/stage/runner.test.ts
+++ b/apps/axctl/src/ingest/stage/runner.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@ax/lib/live-traces/Sink";
 import type { TraceEvent } from "@ax/lib/live-traces/types";
 import { LiveTrace } from "@ax/lib/live-traces/index";
-import { annotateStageProgress, PIPELINE_CONCURRENCY, runPipeline, topoLayers } from "./runner.ts";
+import { annotateStageProgress, PIPELINE_CONCURRENCY, runPipeline, stageFileFailureAnnotator, topoLayers } from "./runner.ts";
 import { BaseStageStats, IngestContext, StageMeta, type StageDef } from "./types.ts";
 
 const stage = (key: string, deps: string[]): StageDef => ({
@@ -224,5 +224,98 @@ describe("annotateStageProgress", () => {
         const recordsValue =
             recordsEvent && "attributes" in recordsEvent ? recordsEvent.attributes?.value : null;
         expect(recordsValue).toBe(42);
+    });
+});
+
+// The failure collector fires its onFailure hook deep inside per-file child
+// spans (transcripts.file etc.). `stageFileFailureAnnotator` must pin the
+// snapshot to the STAGE span captured at StageDef.run entry, not whatever
+// span happens to be current at emission time - otherwise the Live tab keys
+// the skipped-file list to a phantom stage name.
+describe("stageFileFailureAnnotator", () => {
+    it("emits the snapshot on the stage span even when invoked inside a nested child span", async () => {
+        const events: TraceEvent[] = [];
+        const ctx = IngestContext.make({ cwd: "/tmp/ax", since: new Date(0), debug: false });
+        const snapshot = {
+            total: 3,
+            failures: [{ filePath: "/p/a.jsonl", tag: "DbError", message: "boom" }],
+        };
+
+        const demo: StageDef = {
+            meta: StageMeta.make({ key: "demo", deps: [], tags: ["ingest"] }),
+            run: () =>
+                Effect.gen(function* () {
+                    const onFileFailures = yield* stageFileFailureAnnotator;
+                    // Emit from inside a child span, like the per-file loops do.
+                    yield* Effect.withSpan(onFileFailures(snapshot), "demo.file");
+                    return BaseStageStats.make({ durationMs: 1, summary: "demo done" });
+                }),
+        };
+
+        await Effect.runPromise(
+            runPipeline([demo], ctx).pipe(
+                LiveTrace.withTrace({
+                    traceId: "ingest:test",
+                    label: "ingest demo",
+                    scope: { type: "user", id: "test" },
+                }),
+                Effect.provide(traceLayer(events)),
+            ) as Effect.Effect<unknown, never, never>,
+        );
+
+        const failureEvent = events.find(
+            (e) => e._tag === "SpanEvent" && e.name === "attribute:ingest.fileFailures",
+        );
+        expect(failureEvent).toBeDefined();
+        const value = failureEvent && "attributes" in failureEvent ? failureEvent.attributes?.value : null;
+        expect(JSON.parse(String(value))).toEqual(snapshot);
+
+        // Keyed to the stage span: the SpanEvent's spanId must be the span
+        // whose SpanStart carries the stage name, not the nested child span.
+        const stageStart = events.find(
+            (e) => e._tag === "SpanStart" && e.name === "demo",
+        );
+        const childStart = events.find(
+            (e) => e._tag === "SpanStart" && e.name === "demo.file",
+        );
+        expect(stageStart).toBeDefined();
+        expect(childStart).toBeDefined();
+        if (failureEvent?._tag === "SpanEvent" && stageStart?._tag === "SpanStart" && childStart?._tag === "SpanStart") {
+            expect(failureEvent.spanId).toBe(stageStart.spanId);
+            expect(failureEvent.spanId).not.toBe(childStart.spanId);
+        }
+    });
+
+    it("emits nothing for an empty snapshot or outside any span", async () => {
+        const events: TraceEvent[] = [];
+        const ctx = IngestContext.make({ cwd: "/tmp/ax", since: new Date(0), debug: false });
+
+        const demo: StageDef = {
+            meta: StageMeta.make({ key: "demo", deps: [], tags: ["ingest"] }),
+            run: () =>
+                Effect.gen(function* () {
+                    const onFileFailures = yield* stageFileFailureAnnotator;
+                    yield* onFileFailures({ total: 0, failures: [] });
+                    return BaseStageStats.make({ durationMs: 1, summary: "clean" });
+                }),
+        };
+
+        await Effect.runPromise(
+            runPipeline([demo], ctx).pipe(
+                LiveTrace.withTrace({
+                    traceId: "ingest:test",
+                    label: "ingest demo",
+                    scope: { type: "user", id: "test" },
+                }),
+                Effect.provide(traceLayer(events)),
+            ) as Effect.Effect<unknown, never, never>,
+        );
+        expect(
+            events.some((e) => e._tag === "SpanEvent" && e.name === "attribute:ingest.fileFailures"),
+        ).toBe(false);
+
+        // Outside any span (plain CLI/test context): the hook is a no-op, not a crash.
+        const hook = await Effect.runPromise(stageFileFailureAnnotator);
+        await Effect.runPromise(hook({ total: 5, failures: [] }));
     });
 });

--- a/apps/axctl/src/ingest/stage/runner.ts
+++ b/apps/axctl/src/ingest/stage/runner.ts
@@ -1,6 +1,8 @@
-import { Deferred, Effect, Semaphore } from "effect";
+import { Deferred, Effect, Option, Semaphore } from "effect";
 import type { DbError } from "@ax/lib/errors";
 import { LiveTrace } from "@ax/lib/live-traces/index";
+import type { FileFailureSnapshot } from "../file-isolation.ts";
+import { INGEST_FILE_FAILURES_KEY } from "../stream-events.ts";
 import type { BaseStageStats, IngestContext, StageDef } from "./types.ts";
 
 /** Max stages running their `run` Effect concurrently. Each stage has its own
@@ -51,6 +53,36 @@ export const annotateStageProgress = (
             }
         }
     });
+
+/**
+ * Build a hook that publishes a stage's cumulative skipped-file snapshot onto
+ * the STAGE span as a JSON `ingest.fileFailures` attribute (emitted immediately
+ * as an `attribute:*` SpanEvent - see `WrappedSpan.attribute` - which
+ * `ingestStreamEventFromTrace` turns into a `stage_file_failures` stream
+ * event for the dashboard Live tab).
+ *
+ * Unlike {@link annotateStageProgress}, this can NOT use
+ * `Effect.annotateCurrentSpan` at emission time: the failure collector invokes
+ * its `onFailure` hook deep inside per-file child spans (`transcripts.file`,
+ * `codex.ingest`, ...), so the *current* span there is not the stage span and
+ * the snapshot would be keyed to the wrong stage name. Instead, run this
+ * effect at the top of `StageDef.run` - where the current span IS the stage's
+ * `LiveTrace.step` span - to capture that span once, and pass the returned
+ * hook into the stage's ingest function. Outside a live trace (plain CLI run,
+ * tests) the attribute lands on a regular span (or nowhere when no span
+ * exists) and nothing else changes: the CLI keeps its aggregate warn log.
+ */
+export const stageFileFailureAnnotator: Effect.Effect<
+    (snapshot: FileFailureSnapshot) => Effect.Effect<void>
+> = Effect.gen(function* () {
+    const span = yield* Effect.option(Effect.currentSpan);
+    return (snapshot) =>
+        Effect.sync(() => {
+            if (Option.isSome(span) && snapshot.total > 0) {
+                span.value.attribute(INGEST_FILE_FAILURES_KEY, JSON.stringify(snapshot));
+            }
+        });
+});
 
 /** Kahn's algorithm; throws on cycle. Layers are useful for diagnostics, but
  *  `runPipeline` uses Deferreds for tighter scheduling (no layer barriers). */

--- a/apps/axctl/src/ingest/stream-events.test.ts
+++ b/apps/axctl/src/ingest/stream-events.test.ts
@@ -31,6 +31,55 @@ describe("ingest stream events", () => {
         expect(ingestStreamEventFromTrace({ _tag: "SpanEvent", traceId: "ingest:x", spanId: "s", name: "n" } as never, { spanNames: new Map() })).toBeNull();
     });
 
+    test("maps an attribute:ingest.fileFailures SpanEvent to stage_file_failures, keyed to the stage span", () => {
+        const names = new Map([["s1", "claude"]]);
+        const snapshot = {
+            total: 27,
+            failures: [{ filePath: "/p/a.jsonl", tag: "DbError", message: "boom" }],
+        };
+        const ev = ingestStreamEventFromTrace(
+            {
+                _tag: "SpanEvent",
+                traceId: "ingest:run123",
+                spanId: "s1",
+                name: "attribute:ingest.fileFailures",
+                attributes: { value: JSON.stringify(snapshot) },
+            } as never,
+            { spanNames: names },
+        );
+        expect(ev).toEqual({
+            kind: "stage_file_failures",
+            runId: "run123",
+            stage: "claude",
+            total: 27,
+            failures: [{ filePath: "/p/a.jsonl", tag: "DbError", message: "boom" }],
+        } as IngestStreamEvent);
+    });
+
+    test("drops malformed or empty fileFailures payloads instead of crashing", () => {
+        const cases: unknown[] = [
+            undefined,
+            42,
+            "not json",
+            JSON.stringify({ total: 0, failures: [] }),
+            JSON.stringify({ total: 2 }),
+            JSON.stringify({ total: 2, failures: [{ filePath: 1, tag: "x", message: "y" }] }),
+        ];
+        for (const value of cases) {
+            const ev = ingestStreamEventFromTrace(
+                {
+                    _tag: "SpanEvent",
+                    traceId: "ingest:run123",
+                    spanId: "s1",
+                    name: "attribute:ingest.fileFailures",
+                    attributes: { value },
+                } as never,
+                { spanNames: new Map([["s1", "claude"]]) },
+            );
+            expect(ev).toBeNull();
+        }
+    });
+
     test("emits stage_progress once current + total are both known, with rate + eta", () => {
         const ctx = {
             spanNames: new Map<string, string>(),

--- a/apps/axctl/src/ingest/stream-events.ts
+++ b/apps/axctl/src/ingest/stream-events.ts
@@ -1,9 +1,16 @@
 import type { TraceEvent } from "@ax/lib/live-traces/types";
-import type { IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
+import type { IngestFileFailure, IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
 
 // Re-export so existing axctl importers (`from ".../ingest/stream-events.ts"`)
 // keep resolving the type unchanged after the contract moved to @ax/lib/shared.
 export type { IngestStreamEvent };
+
+/** Span-attribute key carrying a stage's cumulative skipped-file snapshot
+ *  (JSON-encoded {@link IngestFileFailure} list + uncapped total). Producer:
+ *  `stageFileFailureAnnotator` (stage/runner.ts); consumer: the
+ *  `attribute:<key>` SpanEvent branch below. Non-numeric, so the CLI progress
+ *  transports' count parsers ignore it by construction. */
+export const INGEST_FILE_FAILURES_KEY = "ingest.fileFailures";
 
 const runIdOf = (traceId: string): string => traceId.replace(/^ingest:/, "");
 
@@ -34,6 +41,33 @@ const firstFinite = (...vs: Array<number | undefined>): number | undefined => {
     return undefined;
 };
 
+/** Decode the JSON snapshot from an `attribute:ingest.fileFailures` SpanEvent.
+ *  Defensive: a malformed payload yields null (the event is dropped) rather
+ *  than crashing the transport. */
+const readFileFailures = (
+    attributes: Record<string, unknown> | undefined,
+): { total: number; failures: IngestFileFailure[] } | null => {
+    const raw = attributes?.value;
+    if (typeof raw !== "string") return null;
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (typeof parsed !== "object" || parsed === null) return null;
+        const { total, failures } = parsed as { total?: unknown; failures?: unknown };
+        if (typeof total !== "number" || !Number.isFinite(total) || total <= 0) return null;
+        if (!Array.isArray(failures)) return null;
+        const details: IngestFileFailure[] = [];
+        for (const f of failures) {
+            if (typeof f !== "object" || f === null) return null;
+            const { filePath, tag, message } = f as Record<string, unknown>;
+            if (typeof filePath !== "string" || typeof tag !== "string" || typeof message !== "string") return null;
+            details.push({ filePath, tag, message });
+        }
+        return { total, failures: details };
+    } catch {
+        return null;
+    }
+};
+
 /** Translate a live-trace event into an ingest progress event, or null. */
 export function ingestStreamEventFromTrace(
     event: TraceEvent,
@@ -49,6 +83,20 @@ export function ingestStreamEventFromTrace(
             return { kind: "stage_started", runId: runIdOf(event.traceId), stage: event.name };
         }
         case "SpanEvent": {
+            // Skipped-file snapshot: forward as its own event so the Live tab
+            // can render the per-stage failure list (count climbs live; replay
+            // reconverges on the final cumulative snapshot).
+            if (event.name === `attribute:${INGEST_FILE_FAILURES_KEY}`) {
+                const snapshot = readFileFailures(event.attributes);
+                if (!snapshot) return null;
+                return {
+                    kind: "stage_file_failures",
+                    runId: runIdOf(event.traceId),
+                    stage: ctx.spanNames.get(event.spanId) ?? event.spanId,
+                    total: snapshot.total,
+                    failures: snapshot.failures,
+                };
+            }
             // Accumulate counts; emit a stage_progress only once current + total
             // are both known (a determinate bar), otherwise stay silent.
             const parsed = readCount(event.name, event.attributes);

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -7,7 +7,7 @@ import { SkillName } from "@ax/lib/brands";
 import { resolveSkillName, skillRecordKey } from "@ax/lib/skill-id";
 import { AppLayer } from "@ax/lib/layers";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
-import { annotateStageProgress } from "./stage/runner.ts";
+import { annotateStageProgress, stageFileFailureAnnotator } from "./stage/runner.ts";
 import type { StageDef } from "./stage/registry.ts";
 import {
     buildPlanSnapshotStatements,
@@ -64,7 +64,7 @@ import {
 } from "@ax/lib/shared/surql";
 import { safeKeyPart } from "@ax/lib/shared/derive-keys";
 import { estimateCost, normalizeModelName } from "./model-pricing.ts";
-import { makeFileFailureCollector } from "./file-isolation.ts";
+import { type FileFailureSnapshot, makeFileFailureCollector } from "./file-isolation.ts";
 import {
     extractClaudeCompaction,
     type CompactionWrite,
@@ -1581,6 +1581,10 @@ interface IngestOpts {
     sinceDays: number | undefined;
     project: string | undefined;
     onProgress: (counts: Record<string, number>) => Effect.Effect<void>;
+    /** Cumulative skipped-file snapshots from the failure collector (see
+     *  file-isolation.ts). The stage wires `stageFileFailureAnnotator` here so
+     *  the dashboard Live tab can list which files were skipped and why. */
+    onFileFailures: (snapshot: FileFailureSnapshot) => Effect.Effect<void>;
     /** Hard cap on transcript files processed - a backstop for `ingest --dry-run`
      *  calibration (paired with `deadlineMs`). */
     limit: number | undefined;
@@ -1737,7 +1741,10 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
             forceEnv: "AX_REDERIVE_CLAUDE",
         });
 
-        const failures = makeFileFailureCollector({ source: "claude" });
+        const failures = makeFileFailureCollector({
+            source: "claude",
+            ...(opts.onFileFailures ? { onFailure: opts.onFileFailures } : {}),
+        });
         yield* Effect.forEach(candidates.map((candidate, index) => ({ candidate, index })), ({ candidate, index }) => Effect.gen(function* () {
             // Time-box (dry-run calibration): once the deadline passes, start no
             // new files. In-flight ones finish, so the sample is whatever
@@ -1945,12 +1952,16 @@ export const claudeStage: StageDef<ClaudeStats, SurrealClient | AxConfig | FileS
     run: Effect.fn(function* (ctx: IngestContext) {
         const t0 = Date.now();
         const sinceDays = sinceDaysFromCtx(ctx);
+        // Capture the stage span HERE (current span = the runner's
+        // LiveTrace.step span) so failure snapshots emitted from deep inside
+        // per-file child spans still key to this stage on the live stream.
+        const onFileFailures = yield* stageFileFailureAnnotator;
         // The vanished-transcript case is caught + skipped inside
         // `ingestTranscripts`; any PlatformError that escapes here is a
         // genuine FS failure (e.g. an unreadable transcripts root or a
         // non-NotFound stat/stream error) so it dies as a defect rather
         // than masquerading as a recoverable DbError.
-        const result = yield* ingestTranscripts({ sinceDays, project: ctx.claudeProject, onProgress: annotateStageProgress }).pipe(
+        const result = yield* ingestTranscripts({ sinceDays, project: ctx.claudeProject, onProgress: annotateStageProgress, onFileFailures }).pipe(
             Effect.catchTag("PlatformError", (e) => Effect.die(e)),
         );
         return ClaudeStats.make({

--- a/apps/studio/src/routes/ingest-live.tsx
+++ b/apps/studio/src/routes/ingest-live.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError } from "../api.ts";
 import { POLL_INTERVAL_MS, shouldPollFallback } from "../poll-fallback.ts";
-import { useIngestStream, type StageStatus } from "../use-ingest-stream.ts";
+import { useIngestStream, type StageFileFailures, type StageStatus } from "../use-ingest-stream.ts";
 
 /**
  * Live ingest view over Durable Streams.
@@ -214,26 +214,59 @@ function StageChecklist({ run }: { run: ReturnType<typeof useIngestStream> }) {
                 const status = run.stages[stage] ?? "running";
                 const p = run.progress[stage];
                 const pct = p && p.total > 0 ? Math.min(100, Math.round((p.current / p.total) * 100)) : null;
+                const skipped = run.fileFailures[stage];
                 return (
                     <li key={stage} className={`ingest-stage ${status}`}>
-                        <span className="ingest-stage-glyph">{STAGE_GLYPH[status]}</span>
-                        <span className="ingest-stage-name">{stage}</span>
-                        {status === "running" && p && pct !== null ? (
-                            <span className="ingest-stage-bar" aria-label={`${pct}%`}>
-                                <span className="ingest-stage-bar-fill" style={{ width: `${pct}%` }} />
+                        <div className="ingest-stage-row">
+                            <span className="ingest-stage-glyph">{STAGE_GLYPH[status]}</span>
+                            <span className="ingest-stage-name">{stage}</span>
+                            {status === "running" && p && pct !== null ? (
+                                <span className="ingest-stage-bar" aria-label={`${pct}%`}>
+                                    <span className="ingest-stage-bar-fill" style={{ width: `${pct}%` }} />
+                                </span>
+                            ) : null}
+                            <span className="ingest-stage-status">
+                                {status === "running" && p && pct !== null
+                                    ? `${p.current.toLocaleString()}/${p.total.toLocaleString()} · ${pct}%${
+                                        p.ratePerSec > 0 ? ` · ${p.ratePerSec.toFixed(1)}/s` : ""
+                                    }${p.etaLeftMs !== null ? ` · ~${formatEtaLeft(p.etaLeftMs)} left` : ""}`
+                                    : status}
                             </span>
-                        ) : null}
-                        <span className="ingest-stage-status">
-                            {status === "running" && p && pct !== null
-                                ? `${p.current.toLocaleString()}/${p.total.toLocaleString()} · ${pct}%${
-                                    p.ratePerSec > 0 ? ` · ${p.ratePerSec.toFixed(1)}/s` : ""
-                                }${p.etaLeftMs !== null ? ` · ~${formatEtaLeft(p.etaLeftMs)} left` : ""}`
-                                : status}
-                        </span>
+                        </div>
+                        {skipped && skipped.total > 0 ? <SkippedFiles skipped={skipped} /> : null}
                     </li>
                 );
             })}
         </ul>
+    );
+}
+
+/** Collapsed "N files skipped" row under a stage; expands to the failure
+ *  detail list (path + error). The detail list is capped upstream (25), so a
+ *  larger total gets an "and N more" overflow line. Skipped files retry on
+ *  the next ingest run - they are warnings, not stage errors. */
+function SkippedFiles({ skipped }: { skipped: StageFileFailures }) {
+    const overflow = skipped.total - skipped.failures.length;
+    return (
+        <details className="ingest-stage-skipped">
+            <summary>
+                {skipped.total.toLocaleString()} file{skipped.total === 1 ? "" : "s"} skipped
+                (retry next run)
+            </summary>
+            <ul className="ingest-stage-skipped-list">
+                {skipped.failures.map((f) => (
+                    <li key={f.filePath}>
+                        <code className="ingest-stage-skipped-path">{f.filePath}</code>
+                        <span className="ingest-stage-skipped-error">
+                            [{f.tag}] {f.message}
+                        </span>
+                    </li>
+                ))}
+                {overflow > 0 ? (
+                    <li className="ingest-stage-skipped-overflow">…and {overflow.toLocaleString()} more</li>
+                ) : null}
+            </ul>
+        </details>
     );
 }
 

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2005,12 +2005,63 @@ td.skill-cell .description {
 
 .ingest-stage {
     display: flex;
-    align-items: center;
-    gap: 10px;
+    flex-direction: column;
+    gap: 4px;
     padding: 6px 10px;
     border: 1px solid var(--line);
     background: var(--panel);
     font-size: 13px;
+}
+
+.ingest-stage-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+/* Skipped-file failures under a stage row (per-file isolation, issue #257):
+   collapsed count summary, expands to the capped detail list. */
+.ingest-stage-skipped {
+    margin: 0 0 2px 26px;
+    font-size: 12px;
+}
+
+.ingest-stage-skipped > summary {
+    cursor: pointer;
+    color: var(--gold);
+    width: fit-content;
+}
+
+.ingest-stage-skipped-list {
+    list-style: none;
+    margin: 4px 0 2px;
+    padding: 0 0 0 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    border-left: 2px solid var(--line);
+}
+
+.ingest-stage-skipped-list > li {
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: 8px;
+    min-width: 0;
+}
+
+.ingest-stage-skipped-path {
+    font-family: inherit;
+    overflow-wrap: anywhere;
+}
+
+.ingest-stage-skipped-error {
+    color: var(--muted);
+    overflow-wrap: anywhere;
+}
+
+.ingest-stage-skipped-overflow {
+    color: var(--muted);
+    font-style: italic;
 }
 
 .ingest-stage-glyph {

--- a/apps/studio/src/use-ingest-stream.test.ts
+++ b/apps/studio/src/use-ingest-stream.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import type { IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
+import { applyEvent, type IngestStreamState } from "./use-ingest-stream.ts";
+
+const IDLE: IngestStreamState = {
+    stages: {},
+    progress: {},
+    fileFailures: {},
+    order: [],
+    finished: false,
+    runStatus: "running",
+};
+
+const fold = (events: ReadonlyArray<IngestStreamEvent>): IngestStreamState =>
+    events.reduce(applyEvent, IDLE);
+
+const failure = (filePath: string): { filePath: string; tag: string; message: string } => ({
+    filePath,
+    tag: "DbError",
+    message: "boom",
+});
+
+describe("applyEvent: stage_file_failures", () => {
+    test("latest cumulative snapshot wins per stage, keyed by stage name", () => {
+        const state = fold([
+            { kind: "run_started", runId: "r", label: "ingest" },
+            { kind: "stage_started", runId: "r", stage: "claude" },
+            { kind: "stage_file_failures", runId: "r", stage: "claude", total: 1, failures: [failure("/a.jsonl")] },
+            {
+                kind: "stage_file_failures",
+                runId: "r",
+                stage: "claude",
+                total: 2,
+                failures: [failure("/a.jsonl"), failure("/b.jsonl")],
+            },
+            { kind: "stage_file_failures", runId: "r", stage: "codex", total: 1, failures: [failure("/c.jsonl")] },
+        ]);
+        expect(state.fileFailures.claude).toEqual({
+            total: 2,
+            failures: [failure("/a.jsonl"), failure("/b.jsonl")],
+        });
+        expect(state.fileFailures.codex).toEqual({ total: 1, failures: [failure("/c.jsonl")] });
+    });
+
+    test("failures survive stage and run completion (post-run report)", () => {
+        const state = fold([
+            { kind: "stage_started", runId: "r", stage: "claude" },
+            { kind: "stage_file_failures", runId: "r", stage: "claude", total: 1, failures: [failure("/a.jsonl")] },
+            { kind: "stage_finished", runId: "r", stage: "claude", status: "ok", durationMs: 10 },
+            { kind: "run_finished", runId: "r", status: "completed", durationMs: 20 },
+        ]);
+        expect(state.finished).toBe(true);
+        expect(state.fileFailures.claude?.total).toBe(1);
+    });
+
+    test("Durable Stream replay reconverges on the same final state", () => {
+        const events: IngestStreamEvent[] = [
+            { kind: "run_started", runId: "r", label: "ingest" },
+            { kind: "stage_started", runId: "r", stage: "claude" },
+            { kind: "stage_file_failures", runId: "r", stage: "claude", total: 1, failures: [failure("/a.jsonl")] },
+            {
+                kind: "stage_file_failures",
+                runId: "r",
+                stage: "claude",
+                total: 2,
+                failures: [failure("/a.jsonl"), failure("/b.jsonl")],
+            },
+            { kind: "stage_finished", runId: "r", stage: "claude", status: "ok", durationMs: 10 },
+            { kind: "run_finished", runId: "r", status: "completed", durationMs: 20 },
+        ];
+        const live = fold(events);
+        // Refresh mid-run = full replay from offset -1 into fresh IDLE state.
+        const replayed = fold(events);
+        expect(replayed).toEqual(live);
+        expect(replayed.fileFailures.claude?.total).toBe(2);
+    });
+
+    test("a clean run records no fileFailures and a zero-total snapshot is ignored", () => {
+        const clean = fold([
+            { kind: "stage_started", runId: "r", stage: "claude" },
+            { kind: "stage_finished", runId: "r", stage: "claude", status: "ok", durationMs: 10 },
+        ]);
+        expect(clean.fileFailures).toEqual({});
+        const zero = fold([
+            { kind: "stage_started", runId: "r", stage: "claude" },
+            { kind: "stage_file_failures", runId: "r", stage: "claude", total: 0, failures: [] },
+        ]);
+        expect(zero.fileFailures).toEqual({});
+    });
+});

--- a/apps/studio/src/use-ingest-stream.ts
+++ b/apps/studio/src/use-ingest-stream.ts
@@ -1,6 +1,6 @@
 import { useEffect, useReducer } from "react";
 import { stream, type StreamResponse } from "@durable-streams/client";
-import type { IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
+import type { IngestFileFailure, IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
 
 /**
  * Live ingest view over Durable Streams.
@@ -29,10 +29,20 @@ export interface StageProgress {
     readonly etaLeftMs: number | null;
 }
 
+/** Per-stage skipped-file state folded from `stage_file_failures` events.
+ *  Each event carries the cumulative snapshot, so the latest one wins -
+ *  `failures` is the capped detail list (25), `total` the uncapped count. */
+export interface StageFileFailures {
+    readonly total: number;
+    readonly failures: ReadonlyArray<IngestFileFailure>;
+}
+
 export interface IngestStreamState {
     readonly stages: Record<string, StageStatus>;
     /** Per-stage live progress (current/total/rate/eta), keyed by stage name. */
     readonly progress: Record<string, StageProgress>;
+    /** Per-stage skipped-file failures, keyed by stage name. Empty on a clean run. */
+    readonly fileFailures: Record<string, StageFileFailures>;
     readonly order: ReadonlyArray<string>;
     readonly finished: boolean;
     readonly runStatus: RunStatus;
@@ -47,6 +57,7 @@ export interface IngestStreamState {
 const IDLE: IngestStreamState = {
     stages: {},
     progress: {},
+    fileFailures: {},
     order: [],
     finished: false,
     runStatus: "running",
@@ -58,8 +69,8 @@ type Action =
     | { readonly type: "error"; readonly message: string };
 
 /** Fold one ingest event into state. Idempotent: re-applying a finished stage
- *  (or a duplicate run_started) leaves state unchanged. */
-function applyEvent(state: IngestStreamState, event: IngestStreamEvent): IngestStreamState {
+ *  (or a duplicate run_started) leaves state unchanged. Exported for tests. */
+export function applyEvent(state: IngestStreamState, event: IngestStreamEvent): IngestStreamState {
     switch (event.kind) {
         case "run_started":
             return { ...state, label: event.label, runStatus: "running" };
@@ -93,6 +104,21 @@ function applyEvent(state: IngestStreamState, event: IngestStreamEvent): IngestS
                     },
                 },
                 order: known ? state.order : [...state.order, event.stage],
+            };
+        }
+        case "stage_file_failures": {
+            // Snapshots are cumulative; the latest one supersedes. Replaying a
+            // finished run re-applies the same snapshots in order, converging
+            // on the identical final state (idempotent rehydrate). Unlike
+            // progress bars, the failure list stays visible after the stage
+            // (and run) finishes - it's the post-run report.
+            if (event.total <= 0) return state;
+            return {
+                ...state,
+                fileFailures: {
+                    ...state.fileFailures,
+                    [event.stage]: { total: event.total, failures: event.failures },
+                },
             };
         }
         case "stage_finished": {

--- a/packages/lib/src/shared/ingest-stream-events.ts
+++ b/packages/lib/src/shared/ingest-stream-events.ts
@@ -5,6 +5,15 @@
  * (consumer, apps/studio/src/use-ingest-stream.ts) can import it without
  * reaching across workspace boundaries.
  */
+/** One skipped file's failure detail, as recorded by the ingest stage's
+ *  per-file failure collector (apps/axctl/src/ingest/file-isolation.ts). */
+export interface IngestFileFailure {
+    readonly filePath: string;
+    /** Error tag (`DbError`, `SkillParseError`, ...) or constructor name. */
+    readonly tag: string;
+    readonly message: string;
+}
+
 export type IngestStreamEvent =
     | { readonly kind: "run_started"; readonly runId: string; readonly label: string }
     | { readonly kind: "stage_started"; readonly runId: string; readonly stage: string }
@@ -18,6 +27,20 @@ export type IngestStreamEvent =
         readonly etaLeftMs: number | null;
         /** 1-based index of this stage among those started so far. */
         readonly stageIndex: number;
+    }
+    | {
+        /**
+         * Cumulative skipped-file snapshot for one stage. Re-published on each
+         * new failure (each snapshot supersedes the previous one for the same
+         * stage), so the Live tab shows the count climb while the stage runs
+         * AND a Durable Stream replay reconverges on the final list. `failures`
+         * is capped by the collector (25 details); `total` is not.
+         */
+        readonly kind: "stage_file_failures";
+        readonly runId: string;
+        readonly stage: string;
+        readonly total: number;
+        readonly failures: ReadonlyArray<IngestFileFailure>;
     }
     | { readonly kind: "stage_finished"; readonly runId: string; readonly stage: string; readonly status: "ok" | "error"; readonly durationMs: number }
     | { readonly kind: "run_finished"; readonly runId: string; readonly status: "completed" | "failed"; readonly durationMs: number };


### PR DESCRIPTION
Closes #262

Follow-up to #257 (per-file failure isolation). The failure collector already records which files a stage skipped (path, error tag, message - capped at 25), but a Live-tab user only saw the `failedFiles` count in the stage summary at best. This carries the details through the ingest stream so the dashboard renders them per stage.

## How it flows

```
collector.onFailure (cumulative snapshot, per recorded failure)
  → stageFileFailureAnnotator pins it on the STAGE span as a JSON attribute
    → WrappedSpan emits attribute:ingest.fileFailures SpanEvent immediately
      → ingestStreamEventFromTrace → stage_file_failures IngestStreamEvent
        → IngestStreamBus → Durable Stream ingest:<runId>
          → studio fold (latest snapshot wins) → Live tab row
```

- **`file-isolation.ts`**: optional `onFailure` hook on the collector - invoked after each recorded failure with the cumulative snapshot (`total` uncapped, `failures` capped at 25). Unset = log-only, exactly as before.
- **`stage/runner.ts`**: `stageFileFailureAnnotator` captures the stage span at `StageDef.run` entry. The collector fires deep inside per-file child spans (`transcripts.file`, ...), so `Effect.annotateCurrentSpan` at emission time would key the snapshot to the wrong span - a runner test locks the stage-span pinning in.
- **`stream-events.ts`**: new `stage_file_failures` event decoded defensively from the JSON attribute; malformed payloads are dropped, not crashed on.
- **studio Live tab**: a collapsed "N files skipped (retry next run)" row under the stage that expands (`<details>`) to the path + `[tag] message` list, with an "…and N more" overflow line past the cap. Clean runs render nothing new.

## Acceptance criteria

- ✅ Count per stage visible while running and after completion - snapshots emit live on each failure and the fold keeps them after `stage_finished`/`run_finished`
- ✅ Expanding shows file path + error message, capped list with "and N more" overflow
- ✅ Clean run renders nothing new (zero-total snapshots never emit; empty state unchanged)
- ✅ Stream replay reproduces the failure rows - events go through the Durable Stream, and the cumulative-snapshot fold reconverges on refresh (covered by `use-ingest-stream.test.ts`)
- ✅ CLI unchanged: aggregate warn log stays; the non-numeric attribute is invisible to the terminal transports' count parsers

## Verification

- `bun run typecheck` - exit 0
- `bun test` - 3142 pass / 0 fail (336 files), incl. new tests for the collector hook, the translator, stage-span pinning, and the studio fold

🤖 Generated with [Claude Code](https://claude.com/claude-code)