### PR TITLE
feat(ingest): extend per-file failure isolation to Pi, OpenCode, and Cursor

### DIFF
--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -13,6 +13,7 @@ import {
     type ToolCallWrite,
 } from "./evidence-writers.ts";
 import { extractCursorCompaction, type CompactionWrite } from "./compaction.ts";
+import { makeFileFailureCollector } from "./file-isolation.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
 import { providerDelegationSignalAvailability } from "./delegation.ts";
 import { agentEventRecordKey, type AgentEventWrite } from "./provider-events.ts";
@@ -32,6 +33,10 @@ export interface CursorStats {
     readonly toolCalls: number;
     readonly skipped: number;
     readonly warnings: number;
+    /** Sessions whose write pipeline failed and was skipped (retried next
+     *  run). Named `failedFiles` to match the cross-provider stage-stats key
+     *  the run totals + CLI skip summary aggregate (#261). */
+    readonly failedFiles: number;
 }
 
 interface CursorSession {
@@ -955,6 +960,37 @@ const buildCursorBatchStatements = (extract: CursorExtract, sourcePath: string):
 
 export const __testBuildCursorBatchStatements = buildCursorBatchStatements;
 
+/**
+ * Narrow a whole-store extract down to ONE session - the unit of isolation
+ * for SQLite-backed providers (#261). The store is re-extracted on every run,
+ * so a session skipped by the isolation seam is naturally retried next run.
+ * `skipped`/`warnings` stay store-level and are NOT attributed to slices.
+ */
+const sliceCursorExtractForSession = (
+    extract: CursorExtract,
+    sessionId: string,
+): CursorExtract => {
+    const toolCalls = extract.toolCalls.filter((call) => call.sessionId === sessionId);
+    // Skill relations carry no session field; correlate through the same
+    // toolCallRecordKey their tool calls were keyed with at extraction time.
+    const toolCallKeys = new Set(toolCalls.map((call) =>
+        toolCallRecordKey({ sessionId, seq: call.seq, callId: call.callId ?? null })
+    ));
+    return {
+        sessions: extract.sessions.filter((session) => session.id === sessionId),
+        turns: extract.turns.filter((turn) => turn.session === sessionId),
+        invocations: extract.invocations.filter((invocation) => invocation.session === sessionId),
+        toolCalls,
+        providerEvents: extract.providerEvents.filter((event) => event.providerSessionId === sessionId),
+        skillRelations: extract.skillRelations.filter((relation) => toolCallKeys.has(relation.toolCallKey)),
+        compactions: extract.compactions.filter((compaction) => compaction.sessionId === sessionId),
+        skipped: 0,
+        warnings: [],
+    };
+};
+
+export const __testSliceCursorExtractForSession = sliceCursorExtractForSession;
+
 // All fs ops below are discovery PROBES: the OLD code guarded every access with
 // `existsSync`/`readdir`-in-try/catch and treated any miss/fault as "absent,
 // skip". `orAbsent` reproduces that exactly (recovers ANY PlatformError to the
@@ -1031,6 +1067,9 @@ export const ingestCursor = Effect.fn("cursor.ingest")(
         let skipped = 0;
         let warnings = 0;
 
+        // One collector across all state DBs: a failure storm spanning stores
+        // is just as systemic as one inside a single store.
+        const failures = makeFileFailureCollector({ source: "cursor", unit: "session" });
         for (const dbPath of dbPaths) {
             const extract = yield* Effect.sync(() =>
                 extractCursorStateDb(dbPath, { cursorUserDir: cfg.paths.cursorUserDir })
@@ -1044,18 +1083,26 @@ export const ingestCursor = Effect.fn("cursor.ingest")(
             if (extract.sessions.length === 0) continue;
 
             for (const session of extract.sessions) {
-                yield* db.upsert(new RecordId("session", session.id), {
-                    source: "cursor",
-                    started_at: new Date(session.started_at),
-                    ended_at: new Date(session.ended_at),
-                    raw_file: session.sourcePath,
-                });
+                const slice = sliceCursorExtractForSession(extract, session.id);
+                // Per-session failure isolation (#261): one undecodable /
+                // rejected session skips THIS session - the store is re-read
+                // next run - instead of aborting the whole stage (see
+                // file-isolation.ts).
+                yield* failures.isolate(`${dbPath}#${session.id}`, Effect.gen(function* () {
+                    yield* db.upsert(new RecordId("session", session.id), {
+                        source: "cursor",
+                        started_at: new Date(session.started_at),
+                        ended_at: new Date(session.ended_at),
+                        raw_file: session.sourcePath,
+                    });
+                    yield* executeStatements(buildCursorBatchStatements(slice, dbPath), { chunkSize: 500, label: "cursor" });
+                    sessionCount += 1;
+                    turnCount += slice.turns.length;
+                    toolCallCount += slice.toolCalls.length;
+                }));
             }
-            yield* executeStatements(buildCursorBatchStatements(extract, dbPath), { chunkSize: 500, label: "cursor" });
-            sessionCount += extract.sessions.length;
-            turnCount += extract.turns.length;
-            toolCallCount += extract.toolCalls.length;
         }
+        yield* failures.report;
 
         return {
             sessions: sessionCount,
@@ -1063,6 +1110,7 @@ export const ingestCursor = Effect.fn("cursor.ingest")(
             toolCalls: toolCallCount,
             skipped,
             warnings,
+            failedFiles: failures.count(),
         } satisfies CursorStats;
     },
 );
@@ -1073,6 +1121,10 @@ export class CursorStageStats extends BaseStageStats.extend<CursorStageStats>("C
     toolCallsIngested: Schema.Number,
     skipped: Schema.Number,
     warnings: Schema.Number,
+    /** Sessions whose write pipeline failed and was skipped (retried next
+     *  run). Named `failedFiles` to match the cross-provider stage-stats key
+     *  the run totals + CLI skip summary aggregate (#261). */
+    failedFiles: Schema.Number,
 }) {}
 
 export const cursorStage: StageDef<CursorStageStats, SurrealClient | AxConfig | FileSystem.FileSystem | Path.Path> = {
@@ -1085,12 +1137,14 @@ export const cursorStage: StageDef<CursorStageStats, SurrealClient | AxConfig | 
         const result = yield* ingestCursor({ sinceDays });
         return CursorStageStats.make({
             durationMs: Date.now() - t0,
-            summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls, skipped ${result.skipped}, warnings ${result.warnings}`,
+            summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls, skipped ${result.skipped}, warnings ${result.warnings}` +
+                (result.failedFiles > 0 ? `, ${result.failedFiles} session(s) failed (retry next run)` : ""),
             sessionsIngested: result.sessions,
             turnsIngested: result.turns,
             toolCallsIngested: result.toolCalls,
             skipped: result.skipped,
             warnings: result.warnings,
+            failedFiles: result.failedFiles,
         });
     }),
 };

--- a/apps/axctl/src/ingest/file-isolation.test.ts
+++ b/apps/axctl/src/ingest/file-isolation.test.ts
@@ -71,6 +71,18 @@ describe("makeFileFailureCollector", () => {
         expect(c.count()).toBe(0);
     });
 
+    test("a custom unit noun labels the storm abort message", async () => {
+        // SQLite-store providers (opencode/cursor) isolate per SESSION, not
+        // per file (#261); the abort message must say so.
+        const c = makeFileFailureCollector({ source: "test", unit: "session", stormThreshold: 2 });
+        await run(c.isolate("/store.db#s1", Effect.fail(queryError("x"))));
+        const second = await run(c.isolate("/store.db#s2", Effect.fail(queryError("x"))));
+        expect(Exit.isFailure(second)).toBe(true);
+        if (Exit.isFailure(second)) {
+            expect(String(second.cause)).toContain("2 consecutive sessions failed");
+        }
+    });
+
     test("report is a no-op at zero failures and logs otherwise", async () => {
         const clean = makeFileFailureCollector({ source: "test" });
         await Effect.runPromise(clean.report);

--- a/apps/axctl/src/ingest/file-isolation.ts
+++ b/apps/axctl/src/ingest/file-isolation.ts
@@ -9,6 +9,14 @@
  * swallowed - the file's watermark never commits, so the next run retries it
  * - while the stage keeps going.
  *
+ * The "file" is really a *unit of isolation*: for transcript providers
+ * (claude/codex/pi) it is a session file, for SQLite-store providers
+ * (opencode/cursor) it is one session within the store - re-extracted on the
+ * next run either way, so skip-and-retry semantics carry over unchanged
+ * (#261). `filePath` then holds a source locator (`<store path>#<session id>`)
+ * rather than a literal path, and {@link FileFailureCollectorOptions.unit}
+ * relabels the log lines.
+ *
  * Two classes of failure still abort the stage, on purpose:
  *
  *  - connection loss (`DbError` with `operation: "connect"`): nothing after
@@ -27,6 +35,8 @@ import { Effect } from "effect";
 import { DbError } from "@ax/lib/errors";
 
 export interface FileFailure {
+    /** Source locator: a transcript file path, or `<store path>#<session id>`
+     *  for SQLite-store providers where the unit of isolation is a session. */
     readonly filePath: string;
     /** Error tag (`DbError`, `SkillParseError`, ...) or constructor name. */
     readonly tag: string;
@@ -71,8 +81,11 @@ export interface FileFailureCollector {
 }
 
 export interface FileFailureCollectorOptions {
-    /** Provider label for log lines, e.g. "claude" / "codex". */
+    /** Provider label for log lines, e.g. "claude" / "codex" / "pi". */
     readonly source: string;
+    /** Isolation-unit noun for log lines: "file" (transcript providers) or
+     *  "session" (SQLite-store providers). Defaults to "file". */
+    readonly unit?: string;
     readonly stormThreshold?: number;
 }
 
@@ -80,6 +93,7 @@ export const makeFileFailureCollector = (
     opts: FileFailureCollectorOptions,
 ): FileFailureCollector => {
     const stormThreshold = opts.stormThreshold ?? DEFAULT_STORM_THRESHOLD;
+    const unit = opts.unit ?? "file";
     const failures: FileFailure[] = [];
     let total = 0;
     let consecutive = 0;
@@ -98,7 +112,7 @@ export const makeFileFailureCollector = (
                     if (failures.length < DETAIL_CAP) {
                         failures.push({ filePath, tag: failureTag(err), message: failureMessage(err) });
                     }
-                    yield* Effect.logWarning(`${opts.source} ingest: file failed, skipping (will retry next run)`, {
+                    yield* Effect.logWarning(`${opts.source} ingest: ${unit} failed, skipping (will retry next run)`, {
                         filePath,
                         tag: failureTag(err),
                         message: failureMessage(err),
@@ -107,7 +121,7 @@ export const makeFileFailureCollector = (
                         return yield* new DbError({
                             operation: "query",
                             message:
-                                `${opts.source} ingest aborted: ${consecutive} consecutive files failed ` +
+                                `${opts.source} ingest aborted: ${consecutive} consecutive ${unit}s failed ` +
                                 `(${total} total) - systemic failure, not bad input. Last: ${filePath}: ${failureMessage(err)}`,
                         });
                     }
@@ -122,7 +136,7 @@ export const makeFileFailureCollector = (
         isolate,
         report: Effect.suspend(() => {
             if (total === 0) return Effect.void;
-            return Effect.logWarning(`${opts.source} ingest: ${total} file(s) failed and were skipped; they retry next run`, {
+            return Effect.logWarning(`${opts.source} ingest: ${total} ${unit}(s) failed and were skipped; they retry next run`, {
                 failures: failures.map((f) => `${f.filePath}: [${f.tag}] ${f.message}`),
                 detailCapped: total > failures.length,
             });

--- a/apps/axctl/src/ingest/opencode.ts
+++ b/apps/axctl/src/ingest/opencode.ts
@@ -10,6 +10,7 @@ import {
     type ToolCallSkillRelationWrite,
     type ToolCallWrite,
 } from "./evidence-writers.ts";
+import { makeFileFailureCollector } from "./file-isolation.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
 import { providerDelegationSignalAvailability } from "./delegation.ts";
 import { buildNormalizedTranscriptStatements } from "./normalized/transcripts.ts";
@@ -71,6 +72,10 @@ export interface OpenCodeStats {
     readonly toolCalls: number;
     readonly skipped: number;
     readonly warnings: number;
+    /** Sessions whose write pipeline failed and was skipped (retried next
+     *  run). Named `failedFiles` to match the cross-provider stage-stats key
+     *  the run totals + CLI skip summary aggregate (#261). */
+    readonly failedFiles: number;
 }
 
 const SAFE_FALLBACK_TS = "1970-01-01T00:00:00.000Z";
@@ -809,6 +814,36 @@ export function extractOpenCodeDatabase(dbPath: string): OpenCodeExtract {
     }
 }
 
+/**
+ * Narrow a whole-store extract down to ONE session - the unit of isolation
+ * for SQLite-backed providers (#261). The store is re-extracted on every run,
+ * so a session skipped by the isolation seam is naturally retried next run.
+ * `skipped`/`warnings` stay store-level and are NOT attributed to slices.
+ */
+const sliceOpenCodeExtractForSession = (
+    extract: OpenCodeExtract,
+    sessionId: string,
+): OpenCodeExtract => {
+    const toolCalls = extract.toolCalls.filter((call) => call.sessionId === sessionId);
+    // Skill relations carry no session field; correlate through the same
+    // toolCallRecordKey their tool calls were keyed with at extraction time.
+    const toolCallKeys = new Set(toolCalls.map((call) =>
+        toolCallRecordKey({ sessionId, seq: call.seq, callId: call.callId ?? null })
+    ));
+    return {
+        sessions: extract.sessions.filter((session) => session.id === sessionId),
+        turns: extract.turns.filter((turn) => turn.session === sessionId),
+        providerEvents: extract.providerEvents.filter((event) => event.providerSessionId === sessionId),
+        toolCalls,
+        invocations: extract.invocations.filter((invocation) => invocation.session === sessionId),
+        skillRelations: extract.skillRelations.filter((relation) => toolCallKeys.has(relation.toolCallKey)),
+        skipped: 0,
+        warnings: [],
+    };
+};
+
+export const __testSliceOpenCodeExtractForSession = sliceOpenCodeExtractForSession;
+
 const buildOpenCodeBatchStatements = (
     extract: OpenCodeExtract,
     sourcePath: string,
@@ -937,6 +972,7 @@ export const ingestOpenCode = Effect.fn("opencode.ingest")(
                 toolCalls: 0,
                 skipped: 0,
                 warnings: 0,
+                failedFiles: 0,
             };
         }
 
@@ -958,28 +994,44 @@ export const ingestOpenCode = Effect.fn("opencode.ingest")(
                 toolCalls: 0,
                 skipped: extract.skipped,
                 warnings: extract.warnings.length,
+                failedFiles: 0,
             };
         }
 
+        const failures = makeFileFailureCollector({ source: "opencode", unit: "session" });
+        let sessionCount = 0;
+        let turnCount = 0;
+        let toolCallCount = 0;
         for (const session of extract.sessions) {
-            yield* db.upsert(new RecordId("session", session.id), {
-                project: session.cwd ?? undefined,
-                cwd: session.cwd ?? undefined,
-                model: session.model ?? undefined,
-                source: "opencode",
-                started_at: new Date(session.started_at),
-                ended_at: new Date(session.ended_at),
-                raw_file: dbPath,
-            });
+            const slice = sliceOpenCodeExtractForSession(extract, session.id);
+            // Per-session failure isolation (#261): one undecodable / rejected
+            // session skips THIS session - the store is re-read next run -
+            // instead of aborting the whole stage (see file-isolation.ts).
+            yield* failures.isolate(`${dbPath}#${session.id}`, Effect.gen(function* () {
+                yield* db.upsert(new RecordId("session", session.id), {
+                    project: session.cwd ?? undefined,
+                    cwd: session.cwd ?? undefined,
+                    model: session.model ?? undefined,
+                    source: "opencode",
+                    started_at: new Date(session.started_at),
+                    ended_at: new Date(session.ended_at),
+                    raw_file: dbPath,
+                });
+                yield* executeStatements(buildOpenCodeBatchStatements(slice, dbPath), { chunkSize: 500, label: "opencode" });
+                sessionCount += 1;
+                turnCount += slice.turns.length;
+                toolCallCount += slice.toolCalls.length;
+            }));
         }
-        yield* executeStatements(buildOpenCodeBatchStatements(extract, dbPath), { chunkSize: 500, label: "opencode" });
+        yield* failures.report;
 
         return {
-            sessions: extract.sessions.length,
-            turns: extract.turns.length,
-            toolCalls: extract.toolCalls.length,
+            sessions: sessionCount,
+            turns: turnCount,
+            toolCalls: toolCallCount,
             skipped: extract.skipped,
             warnings: extract.warnings.length,
+            failedFiles: failures.count(),
         } satisfies OpenCodeStats;
     },
 );
@@ -990,6 +1042,10 @@ export class OpenCodeStageStats extends BaseStageStats.extend<OpenCodeStageStats
     toolCallsIngested: Schema.Number,
     skipped: Schema.Number,
     warnings: Schema.Number,
+    /** Sessions whose write pipeline failed and was skipped (retried next
+     *  run). Named `failedFiles` to match the cross-provider stage-stats key
+     *  the run totals + CLI skip summary aggregate (#261). */
+    failedFiles: Schema.Number,
 }) {}
 
 export const opencodeStage: StageDef<OpenCodeStageStats, SurrealClient | AxConfig | FileSystem.FileSystem | Path.Path> = {
@@ -1002,12 +1058,14 @@ export const opencodeStage: StageDef<OpenCodeStageStats, SurrealClient | AxConfi
         const result = yield* ingestOpenCode({ sinceDays });
         return OpenCodeStageStats.make({
             durationMs: Date.now() - t0,
-            summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls, skipped ${result.skipped}, warnings ${result.warnings}`,
+            summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls, skipped ${result.skipped}, warnings ${result.warnings}` +
+                (result.failedFiles > 0 ? `, ${result.failedFiles} session(s) failed (retry next run)` : ""),
             sessionsIngested: result.sessions,
             turnsIngested: result.turns,
             toolCallsIngested: result.toolCalls,
             skipped: result.skipped,
             warnings: result.warnings,
+            failedFiles: result.failedFiles,
         });
     }),
 };

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -29,6 +29,7 @@ import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./st
 import type { StageDef } from "./stage/registry.ts";
 import { extractCommandTool, normalizeCommand, toolKindForName } from "./tool-calls.ts";
 import { extractToolFileEvidence } from "./tool-file-evidence.ts";
+import { makeFileFailureCollector } from "./file-isolation.ts";
 import { decodePiTranscriptLine } from "./line-schemas.ts";
 import { tokenQualityLabels } from "./token-quality.ts";
 import { walkJsonlFilesLenient } from "./walk-jsonl.ts";
@@ -98,6 +99,8 @@ export interface PiStats {
     readonly toolCalls: number;
     readonly skipped: number;
     readonly warnings: number;
+    /** Files whose pipeline failed and was skipped (retried next run). */
+    readonly failedFiles: number;
 }
 
 const SAFE_FALLBACK_TS = "1970-01-01T00:00:00.000Z";
@@ -744,41 +747,51 @@ export const ingestPi = Effect.fn("pi.ingest")(
         let skipped = 0;
         let warningCount = 0;
 
+        const failures = makeFileFailureCollector({ source: "pi" });
         for (const file of files) {
-            fileCount += 1;
-            // OLD: `Bun.file(path).text()` under `Effect.promise` - a read
-            // rejection became an unrecoverable defect. `readFileString`
-            // surfaces a typed PlatformError that the stage boundary dies on,
-            // preserving "no tolerance for a read fault here".
-            const text = yield* fs.readFileString(file.path);
-            const extractor = createPiExtractor(file.path);
-            for (const line of text.split(/\r?\n/)) {
-                extractor.processLine(line);
-            }
-            const extracted = extractor.finish();
-            if (!extracted) {
-                skipped += 1;
-                warningCount += 1;
-                continue;
-            }
+            // Per-file failure isolation (#261): a bad session file (read
+            // fault or a rejected statement) skips THIS file - it is retried
+            // next run - instead of aborting the whole stage (see
+            // file-isolation.ts). `files` counts only completed files, like
+            // claude/codex.
+            yield* failures.isolate(file.path, Effect.gen(function* () {
+                // OLD: `Bun.file(path).text()` under `Effect.promise` - a read
+                // rejection became an unrecoverable defect. `readFileString`
+                // surfaces a typed PlatformError that the isolation seam
+                // records + skips like any other per-file failure.
+                const text = yield* fs.readFileString(file.path);
+                const extractor = createPiExtractor(file.path);
+                for (const line of text.split(/\r?\n/)) {
+                    extractor.processLine(line);
+                }
+                const extracted = extractor.finish();
+                if (!extracted) {
+                    fileCount += 1;
+                    skipped += 1;
+                    warningCount += 1;
+                    return;
+                }
 
-            skipped += extracted.skipped;
-            warningCount += extracted.warnings.length;
-            yield* db.upsert(new RecordId("session", extracted.session.id), {
-                project: extracted.session.cwd ?? undefined,
-                cwd: extracted.session.cwd ?? undefined,
-                model: extracted.session.model ?? undefined,
-                source: "pi",
-                started_at: new Date(extracted.session.started_at),
-                ended_at: new Date(extracted.session.ended_at),
-                raw_file: extracted.sourcePath ?? undefined,
-            });
-            yield* executeStatements(buildPiBatchStatements(extracted), { chunkSize: 500, label: "pi" });
-            sessionCount += 1;
-            eventCount += extracted.providerEvents.length;
-            turnCount += extracted.turns.length;
-            toolCallCount += extracted.toolCalls.length;
+                skipped += extracted.skipped;
+                warningCount += extracted.warnings.length;
+                yield* db.upsert(new RecordId("session", extracted.session.id), {
+                    project: extracted.session.cwd ?? undefined,
+                    cwd: extracted.session.cwd ?? undefined,
+                    model: extracted.session.model ?? undefined,
+                    source: "pi",
+                    started_at: new Date(extracted.session.started_at),
+                    ended_at: new Date(extracted.session.ended_at),
+                    raw_file: extracted.sourcePath ?? undefined,
+                });
+                yield* executeStatements(buildPiBatchStatements(extracted), { chunkSize: 500, label: "pi" });
+                fileCount += 1;
+                sessionCount += 1;
+                eventCount += extracted.providerEvents.length;
+                turnCount += extracted.turns.length;
+                toolCallCount += extracted.toolCalls.length;
+            }));
         }
+        yield* failures.report;
 
         return {
             files: fileCount,
@@ -788,6 +801,7 @@ export const ingestPi = Effect.fn("pi.ingest")(
             toolCalls: toolCallCount,
             skipped,
             warnings: warningCount,
+            failedFiles: failures.count(),
         } satisfies PiStats;
     },
 );
@@ -800,6 +814,8 @@ export class PiStageStats extends BaseStageStats.extend<PiStageStats>("PiStageSt
     toolCallsIngested: Schema.Number,
     skipped: Schema.Number,
     warnings: Schema.Number,
+    /** Files whose pipeline failed and was skipped (retried next run). */
+    failedFiles: Schema.Number,
 }) {}
 
 export const piStage: StageDef<PiStageStats, SurrealClient | AxConfig | FileSystem.FileSystem | Path.Path> = {
@@ -809,16 +825,16 @@ export const piStage: StageDef<PiStageStats, SurrealClient | AxConfig | FileSyst
     run: Effect.fn(function* (ctx: IngestContext) {
         const t0 = Date.now();
         const sinceDays = sinceDaysFromCtx(ctx);
-        // The directory walk recovers every PlatformError internally; the
-        // only PlatformError that can escape `ingestPi` is a per-file
-        // `readFileString` fault, which (like claude/codex) dies as a defect
-        // rather than masquerading as a recoverable DbError.
-        const result = yield* ingestPi({ sinceDays }).pipe(
-            Effect.catchTag("PlatformError", (e) => Effect.die(e)),
-        );
+        // The directory walk recovers every PlatformError internally, and a
+        // per-file `readFileString` fault is now recorded + skipped by the
+        // per-file isolation seam (#261, see file-isolation.ts), so no
+        // PlatformError escapes `ingestPi`. Only connection loss and failure
+        // storms abort the stage, as a DbError.
+        const result = yield* ingestPi({ sinceDays });
         return PiStageStats.make({
             durationMs: Date.now() - t0,
-            summary: `ingested ${result.files} files, ${result.sessions} sessions, ${result.events} events, ${result.turns} turns, ${result.toolCalls} tool calls, skipped ${result.skipped}, warnings ${result.warnings}`,
+            summary: `ingested ${result.files} files, ${result.sessions} sessions, ${result.events} events, ${result.turns} turns, ${result.toolCalls} tool calls, skipped ${result.skipped}, warnings ${result.warnings}` +
+                (result.failedFiles > 0 ? `, ${result.failedFiles} file(s) failed (retry next run)` : ""),
             filesIngested: result.files,
             sessionsIngested: result.sessions,
             eventsIngested: result.events,
@@ -826,6 +842,7 @@ export const piStage: StageDef<PiStageStats, SurrealClient | AxConfig | FileSyst
             toolCallsIngested: result.toolCalls,
             skipped: result.skipped,
             warnings: result.warnings,
+            failedFiles: result.failedFiles,
         });
     }),
 };

--- a/apps/axctl/src/ingest/provider-isolation.test.ts
+++ b/apps/axctl/src/ingest/provider-isolation.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Per-unit failure isolation for the Pi / OpenCode / Cursor stages (#261).
+ *
+ * Mirrors the file-isolation contract proven for Claude + Codex in #257:
+ *  - one failing unit (a Pi session FILE, an OpenCode/Cursor SESSION inside a
+ *    SQLite store) is recorded + skipped while the rest of the stage completes;
+ *  - connection-level DbErrors still abort the stage;
+ *  - failure storms (consecutive failures, no success between) still abort;
+ *  - stats surface the skipped count as `failedFiles`.
+ *
+ * The DB seam is the shared in-memory SurrealClient double: routes inject a
+ * DbError when the issued SQL mentions the bad unit's session id. Fixtures
+ * live on the real filesystem (bun:sqlite needs real files), so the layers
+ * are BunFileSystem + Path + a test AxConfig pointing at a temp dir.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { Effect, Exit, Layer, Path } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { AxConfigTest } from "@ax/lib/config";
+import { DbError } from "@ax/lib/errors";
+import { makeTestSurrealClient, type TestSurrealRoutes } from "@ax/lib/testing/surreal";
+import { ingestCursor, type CursorStats } from "./cursor.ts";
+import { ingestOpenCode, type OpenCodeStats } from "./opencode.ts";
+import { ingestPi, type PiStats } from "./pi.ts";
+
+const queryError = (message: string) => new DbError({ operation: "query", message });
+const connectError = () => new DbError({ operation: "connect", message: "daemon not reachable" });
+
+const layersFor = (
+    paths: Partial<{ piDir: string; opencodeDir: string; cursorUserDir: string }>,
+    routes: TestSurrealRoutes,
+) => {
+    const tc = makeTestSurrealClient({ routes });
+    const layer = Layer.mergeAll(
+        tc.layer,
+        AxConfigTest({ paths }).pipe(Layer.provide(BunFileSystem.layer)),
+        BunFileSystem.layer,
+        Path.layer,
+    );
+    return { tc, layer };
+};
+
+// ---------------------------------------------------------------------------
+// Pi: unit of isolation is a session FILE (same as codex)
+// ---------------------------------------------------------------------------
+
+const piSessionLines = (sessionId: string): string =>
+    [
+        JSON.stringify({
+            type: "session",
+            version: 3,
+            id: sessionId,
+            timestamp: "2026-06-01T10:00:00.000Z",
+            cwd: "/Users/necmttn/Projects/ax",
+        }),
+        JSON.stringify({
+            type: "message",
+            id: `${sessionId}msg1`,
+            parentId: null,
+            timestamp: "2026-06-01T10:00:01.000Z",
+            message: {
+                role: "user",
+                content: [{ type: "text", text: "hello pi" }],
+            },
+        }),
+    ].join("\n");
+
+describe("pi per-file failure isolation", () => {
+    let piDir: string;
+
+    beforeAll(async () => {
+        piDir = await mkdtemp(join(tmpdir(), "ax-pi-isolation-"));
+        await writeFile(join(piDir, "good.jsonl"), piSessionLines("pigood"));
+        await writeFile(join(piDir, "bad.jsonl"), piSessionLines("pibad"));
+    });
+    afterAll(async () => {
+        await rm(piDir, { recursive: true, force: true });
+    });
+
+    test("a failing session file is skipped and reported; the rest completes", async () => {
+        const { tc, layer } = layersFor({ piDir }, [
+            { match: "pibad", rows: Effect.fail(queryError("statement rejected")) },
+        ]);
+        const stats = await Effect.runPromise(
+            ingestPi({}).pipe(Effect.provide(layer)) as Effect.Effect<PiStats>,
+        );
+
+        expect(stats.sessions).toBe(1);
+        expect(stats.files).toBe(1);
+        expect(stats.failedFiles).toBe(1);
+        // The good session's statements went through.
+        expect(tc.captured.some((sql) => sql.includes("pigood"))).toBe(true);
+    });
+
+    test("a connection-level DbError aborts the stage", async () => {
+        const { layer } = layersFor({ piDir }, [
+            { match: "UPSERT", rows: Effect.fail(connectError()) },
+        ]);
+        const exit = await Effect.runPromiseExit(
+            ingestPi({}).pipe(Effect.provide(layer)) as Effect.Effect<unknown, DbError>,
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+    });
+});
+
+describe("pi failure storm aborts the stage", () => {
+    let piDir: string;
+
+    beforeAll(async () => {
+        piDir = await mkdtemp(join(tmpdir(), "ax-pi-storm-"));
+        // Default storm threshold is 10 consecutive failures.
+        for (let i = 0; i < 10; i++) {
+            await writeFile(join(piDir, `storm-${i}.jsonl`), piSessionLines(`pistorm${i}`));
+        }
+    });
+    afterAll(async () => {
+        await rm(piDir, { recursive: true, force: true });
+    });
+
+    test("10 consecutive failing files fail the stage with a storm DbError", async () => {
+        const { layer } = layersFor({ piDir }, [
+            { match: "pistorm", rows: Effect.fail(queryError("statement rejected")) },
+        ]);
+        const exit = await Effect.runPromiseExit(
+            ingestPi({}).pipe(Effect.provide(layer)) as Effect.Effect<unknown, DbError>,
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+            expect(String(exit.cause)).toContain("consecutive");
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// OpenCode: unit of isolation is a SESSION inside the SQLite store
+// ---------------------------------------------------------------------------
+
+const seedOpenCodeStore = (dbPath: string): void => {
+    const db = new Database(dbPath);
+    try {
+        db.run("CREATE TABLE session (id TEXT PRIMARY KEY, cwd TEXT, title TEXT, created_at TEXT, updated_at TEXT)");
+        db.run("CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, role TEXT, content TEXT, created_at TEXT)");
+        db.run(
+            "INSERT INTO session VALUES ('ocgood', '/tmp/p', 'good', '2026-06-01T10:00:00.000Z', '2026-06-01T10:05:00.000Z')",
+        );
+        db.run(
+            "INSERT INTO session VALUES ('ocbad', '/tmp/p', 'bad', '2026-06-01T11:00:00.000Z', '2026-06-01T11:05:00.000Z')",
+        );
+        db.run("INSERT INTO message VALUES ('m1', 'ocgood', 'user', 'hello good', '2026-06-01T10:00:01.000Z')");
+        db.run("INSERT INTO message VALUES ('m2', 'ocbad', 'user', 'hello bad', '2026-06-01T11:00:01.000Z')");
+    } finally {
+        db.close();
+    }
+};
+
+describe("opencode per-session failure isolation", () => {
+    let opencodeDir: string;
+
+    beforeAll(async () => {
+        opencodeDir = await mkdtemp(join(tmpdir(), "ax-opencode-isolation-"));
+        seedOpenCodeStore(join(opencodeDir, "opencode.db"));
+    });
+    afterAll(async () => {
+        await rm(opencodeDir, { recursive: true, force: true });
+    });
+
+    test("a failing session is skipped and reported; the rest completes", async () => {
+        const { tc, layer } = layersFor({ opencodeDir }, [
+            { match: "ocbad", rows: Effect.fail(queryError("statement rejected")) },
+        ]);
+        const stats = await Effect.runPromise(
+            ingestOpenCode({}).pipe(Effect.provide(layer)) as Effect.Effect<OpenCodeStats>,
+        );
+
+        expect(stats.sessions).toBe(1);
+        expect(stats.turns).toBe(1);
+        expect(stats.failedFiles).toBe(1);
+        expect(tc.captured.some((sql) => sql.includes("ocgood"))).toBe(true);
+    });
+
+    test("a connection-level DbError aborts the stage", async () => {
+        const { layer } = layersFor({ opencodeDir }, [
+            { match: "UPSERT", rows: Effect.fail(connectError()) },
+        ]);
+        const exit = await Effect.runPromiseExit(
+            ingestOpenCode({}).pipe(Effect.provide(layer)) as Effect.Effect<unknown, DbError>,
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Cursor: unit of isolation is a SESSION inside the state.vscdb store
+// ---------------------------------------------------------------------------
+
+const seedCursorStore = (dbPath: string): void => {
+    const db = new Database(dbPath);
+    try {
+        db.run("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)");
+        const payload = JSON.stringify({
+            conversations: [
+                {
+                    id: "convgood",
+                    title: "good",
+                    messages: [
+                        { id: "b1", role: "user", text: "hello good", timestamp: "2026-06-01T10:00:00.000Z" },
+                    ],
+                },
+                {
+                    id: "convbad",
+                    title: "bad",
+                    messages: [
+                        { id: "b2", role: "user", text: "hello bad", timestamp: "2026-06-01T11:00:00.000Z" },
+                    ],
+                },
+            ],
+        });
+        db.query("INSERT INTO ItemTable VALUES ('composer.composerData', ?)").run(payload);
+    } finally {
+        db.close();
+    }
+};
+
+describe("cursor per-session failure isolation", () => {
+    let cursorUserDir: string;
+
+    beforeAll(async () => {
+        cursorUserDir = await mkdtemp(join(tmpdir(), "ax-cursor-isolation-"));
+        await mkdir(join(cursorUserDir, "globalStorage"), { recursive: true });
+        seedCursorStore(join(cursorUserDir, "globalStorage", "state.vscdb"));
+    });
+    afterAll(async () => {
+        await rm(cursorUserDir, { recursive: true, force: true });
+    });
+
+    test("a failing session is skipped and reported; the rest completes", async () => {
+        const { tc, layer } = layersFor({ cursorUserDir }, [
+            { match: "convbad", rows: Effect.fail(queryError("statement rejected")) },
+        ]);
+        const stats = await Effect.runPromise(
+            ingestCursor({}).pipe(Effect.provide(layer)) as Effect.Effect<CursorStats>,
+        );
+
+        expect(stats.sessions).toBe(1);
+        expect(stats.turns).toBe(1);
+        expect(stats.failedFiles).toBe(1);
+        expect(tc.captured.some((sql) => sql.includes("convgood"))).toBe(true);
+    });
+
+    test("a connection-level DbError aborts the stage", async () => {
+        const { layer } = layersFor({ cursorUserDir }, [
+            { match: "UPSERT", rows: Effect.fail(connectError()) },
+        ]);
+        const exit = await Effect.runPromiseExit(
+            ingestCursor({}).pipe(Effect.provide(layer)) as Effect.Effect<unknown, DbError>,
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes #261

Follow-up to #257: the `makeFileFailureCollector` seam (`apps/axctl/src/ingest/file-isolation.ts`) now guards all five provider stages instead of just Claude + Codex. One bad Pi session file or one undecodable OpenCode/Cursor session no longer aborts its whole provider stage.

## What changed

**Pi** (`pi.ts`) - per-file isolation, same as Codex:
- Each session file's read → extract → upsert → statement batch runs inside `failures.isolate(file.path, ...)`; a read fault or rejected statement records + skips that file (retried next run) while the rest of the stage completes.
- The stage-level `catchTag("PlatformError", die)` is removed: the directory walk recovers internally and per-file read faults are now isolated, so no PlatformError escapes `ingestPi`.
- `files` now counts completed files only, mirroring claude/codex.

**OpenCode / Cursor** (`opencode.ts`, `cursor.ts`) - per-session isolation:
- The unit of isolation is a session inside the SQLite store. New `sliceOpenCodeExtractForSession` / `sliceCursorExtractForSession` helpers narrow the whole-store extract to one session (skill relations correlate via `toolCallRecordKey`; cursor compactions filter by session id).
- Each session's `db.upsert` + `executeStatements` batch runs inside `failures.isolate("<store path>#<session id>", ...)`. Stores are re-extracted every run, so a skipped session retries naturally.
- Cursor uses ONE collector across all state DBs, so a failure storm spanning stores still aborts.

**Collector** (`file-isolation.ts`):
- `FileFailure.filePath` is documented as a source locator (file path, or `<store path>#<session id>`).
- New `unit` option ("file" default, "session" for the SQLite providers) labels the per-failure log, the aggregate report, and the storm-abort message. Connection-error passthrough (`DbError` with `operation: "connect"`) and the consecutive-failure storm threshold are unchanged.

**Stats / summaries**:
- All three providers add `failedFiles` to their stats + stage stats (the cross-provider key `runIngest` totals and the CLI skip summary already aggregate), and append `N file(s)/session(s) failed (retry next run)` to the stage summary - same as Claude/Codex.

## Acceptance criteria

- [x] A failing Pi session file is skipped and reported; the rest of the Pi stage completes
- [x] A failing OpenCode/Cursor session is skipped and reported; the rest of that stage completes
- [x] Connection-level DB errors and failure storms still abort the stage
- [x] Provider stats + stage summaries surface the skipped count
- [x] Unit tests cover the new isolation points

## Tests

New `provider-isolation.test.ts` exercises each provider end-to-end through the in-memory SurrealClient double with route-injected `DbError`s over real temp fixtures (jsonl for Pi, `bun:sqlite` stores for OpenCode/Cursor): failing-unit-skipped, connection-abort, and a 10-file Pi failure storm. `file-isolation.test.ts` gains a unit-noun test ("2 consecutive sessions failed").

- `bun test`: 3140 pass / 0 fail (3144 across 336 files)
- `bun run typecheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)