### PR TITLE
feat(dashboard): sessions list remakeover - enriched rows + insight accordion

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,9 +30,13 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
 
+  # Artifacts build only on the `release: published` event (or manual dispatch
+  # with a tag). The push run that creates the release via release-please must
+  # NOT also build - when it did, its publish job raced the release-event run's
+  # publish job and --clobber uploads interleaved, leaving a checksums.txt from
+  # one build next to a tarball from the other (v0.24.0 incident).
   build-artifacts:
-    needs: release-please
-    if: ${{ always() && (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '') || needs.release-please.outputs.releases_created == 'true') }}
+    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '') }}
     name: Build ${{ matrix.artifact }}
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -94,9 +98,10 @@ jobs:
           if-no-files-found: error
 
   publish-artifacts:
-    needs: [release-please, build-artifacts]
-    if: ${{ always() && needs.build-artifacts.result == 'success' && (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_name != '') || needs.release-please.outputs.releases_created == 'true') }}
+    needs: build-artifacts
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-assets-${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag_name }}
     permissions:
       contents: write
     steps:
@@ -114,7 +119,8 @@ jobs:
           set -euo pipefail
           cd release-assets
           if [ -z "$TAG_NAME" ]; then
-            TAG_NAME="$(gh release view --repo "$GH_REPO" --json tagName --jq .tagName)"
+            echo "TAG_NAME is empty - refusing to guess the target release" >&2
+            exit 1
           fi
           shasum -a 256 ./*.tar.gz > checksums.txt
           gh release upload "$TAG_NAME" ./*.tar.gz checksums.txt --repo "$GH_REPO" --clobber

--- a/apps/axctl/src/dashboard/router/routes/sessions.ts
+++ b/apps/axctl/src/dashboard/router/routes/sessions.ts
@@ -3,6 +3,7 @@ import { extractSessionTimeline, SessionTimelineServiceLayer } from "../../../ti
 import { fetchSessionCanvas, fetchSessionOrchestration } from "../../session-canvas.ts";
 import { fetchSessionCompare } from "../../session-compare.ts";
 import { fetchSessionDetail } from "../../session-detail.ts";
+import { fetchSessionInsights } from "../../session-insights.ts";
 import { fetchSessionInspect } from "../../session-inspect.ts";
 import { fetchSessionSummary } from "../../session-summary.ts";
 import { fetchSessionChildren, fetchSessionsList, type SessionsListOpts } from "../../sessions-list.ts";
@@ -115,6 +116,11 @@ export const sessionRoutes: ReadonlyArray<AnyRoute> = [
             return decodeOk({ id: id.value, limit: numberParam(input.url, "limit", 500) });
         },
         handler: ({ id, limit }) => fetchSessionChildren(id, { limit }),
+    }),
+    legacyGetRoute({
+        path: "/api/sessions/:id+/insights",
+        decode: requiredSessionId,
+        handler: (id) => fetchSessionInsights(id),
     }),
     legacyGetRoute({
         path: "/api/sessions/:id+/inspect",

--- a/apps/axctl/src/dashboard/session-baselines.test.ts
+++ b/apps/axctl/src/dashboard/session-baselines.test.ts
@@ -71,7 +71,12 @@ describe("fetchSessionBaselines", () => {
         expect(sql).toContain("FROM session_token_usage");
         expect(sql).toContain("FROM session_health");
         expect(sql).toContain("FROM session_metrics");
-        expect(sql).toContain("session.started_at > time::now() - 30d");
+        // session_metrics uses table-own ts field (no per-row deref)
+        expect(sql).toContain("WHERE ts > time::now() - 30d");
+        // zero-token sessions excluded from burn p90
+        expect(sql).toContain("AND estimated_tokens > 0");
+        // guard: no per-row record deref in any baseline statement
+        expect(sql).not.toContain("session.");
         expect(sql).not.toMatch(/FROM turn\b/);
         expect(sql).not.toContain("turn_token_usage");
         expect((sql.match(/SELECT/g) ?? []).length).toBe(4);

--- a/apps/axctl/src/dashboard/session-baselines.test.ts
+++ b/apps/axctl/src/dashboard/session-baselines.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import {
+    _resetBaselineCacheForTests,
+    fetchSessionBaselines,
+    median,
+    p90,
+} from "./session-baselines.ts";
+
+const run = (stub: SurrealClientShape) =>
+    Effect.runPromise(
+        fetchSessionBaselines().pipe(Effect.provideService(SurrealClient, stub)),
+    );
+
+describe("session baseline math", () => {
+    test("median handles odd, even, and empty inputs", () => {
+        expect(median([9, 1, 5])).toBe(5);
+        expect(median([10, 2, 4, 8])).toBe(6);
+        expect(median([])).toBeNull();
+    });
+
+    test("p90 uses nearest-rank and returns null for empty input", () => {
+        expect(p90(Array.from({ length: 100 }, (_, i) => i + 1))).toBe(90);
+        expect(p90([])).toBeNull();
+    });
+});
+
+describe("fetchSessionBaselines", () => {
+    test("computes medians and burn p90 from one aggregate query and caches", async () => {
+        _resetBaselineCacheForTests();
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [[
+                [{ estimated_cost_usd: 3 }, { estimated_cost_usd: 1 }, { estimated_cost_usd: 5 }],
+                [{ friction: 6 }, { friction: 2 }],
+                [{ time_to_land_ms: 1000 }, { time_to_land_ms: 5000 }],
+                [
+                    { estimated_tokens: 1000, turns: 10 },
+                    { estimated_tokens: 9000, turns: 9 },
+                    { estimated_tokens: 1, turns: 0 },
+                ],
+            ]],
+        });
+
+        const first = await run(tc.client);
+        const second = await run(tc.client);
+
+        expect(first).toEqual({
+            median_cost_usd: 3,
+            median_friction: 4,
+            median_time_to_land_ms: 3000,
+            burn_p90: 1000,
+        });
+        expect(second).toEqual(first);
+        expect(tc.captured).toHaveLength(1);
+    });
+
+    test("baseline query is one flat multi-statement query over aggregate tables", async () => {
+        _resetBaselineCacheForTests();
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [[[{ estimated_cost_usd: 1 }], [{ friction: 0 }], [{ time_to_land_ms: 1 }], [{ estimated_tokens: 1, turns: 1 }]]],
+        });
+
+        await run(tc.client);
+
+        expect(tc.captured).toHaveLength(1);
+        const sql = tc.captured[0]!;
+        expect(sql).toContain("FROM session_token_usage");
+        expect(sql).toContain("FROM session_health");
+        expect(sql).toContain("FROM session_metrics");
+        expect(sql).toContain("session.started_at > time::now() - 30d");
+        expect(sql).not.toMatch(/FROM turn\b/);
+        expect(sql).not.toContain("turn_token_usage");
+        expect((sql.match(/SELECT/g) ?? []).length).toBe(4);
+    });
+});

--- a/apps/axctl/src/dashboard/session-baselines.ts
+++ b/apps/axctl/src/dashboard/session-baselines.ts
@@ -76,12 +76,13 @@ export const fetchSessionBaselines = (): Effect.Effect<SessionBaselines, DbError
             WHERE ts > time::now() - 30d;
             SELECT time_to_land_ms
             FROM session_metrics
-            WHERE session.started_at > time::now() - 30d
+            WHERE ts > time::now() - 30d
               AND time_to_land_ms IS NOT NONE;
             SELECT estimated_tokens, turns
             FROM session_health
             WHERE ts > time::now() - 30d
-              AND turns > 0;
+              AND turns > 0
+              AND estimated_tokens > 0;
         `);
 
         const burnRates = burnRows

--- a/apps/axctl/src/dashboard/session-baselines.ts
+++ b/apps/axctl/src/dashboard/session-baselines.ts
@@ -1,0 +1,103 @@
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+
+export interface SessionBaselines {
+    readonly median_cost_usd: number | null;
+    readonly median_friction: number | null;
+    readonly median_time_to_land_ms: number | null;
+    readonly burn_p90: number | null;
+}
+
+interface CostRow {
+    readonly estimated_cost_usd: number | null;
+}
+
+interface FrictionRow {
+    readonly friction: number | null;
+}
+
+interface TimeToLandRow {
+    readonly time_to_land_ms: number | null;
+}
+
+interface BurnRow {
+    readonly estimated_tokens: number | null;
+    readonly turns: number | null;
+}
+
+const CACHE_TTL_MS = 5 * 60_000;
+
+let cachedBaselines: { readonly value: SessionBaselines; readonly expiresAt: number } | null = null;
+
+const finiteNumbers = (xs: ReadonlyArray<number | null | undefined>): number[] =>
+    xs.filter((x): x is number => typeof x === "number" && Number.isFinite(x));
+
+export const median = (xs: ReadonlyArray<number>): number | null => {
+    if (xs.length === 0) return null;
+    const sorted = [...xs].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 1
+        ? sorted[mid]!
+        : (sorted[mid - 1]! + sorted[mid]!) / 2;
+};
+
+export const p90 = (xs: ReadonlyArray<number>): number | null => {
+    if (xs.length === 0) return null;
+    const sorted = [...xs].sort((a, b) => a - b);
+    const index = Math.ceil(sorted.length * 0.9) - 1;
+    return sorted[Math.max(0, index)]!;
+};
+
+export const _resetBaselineCacheForTests = (): void => {
+    cachedBaselines = null;
+};
+
+export const fetchSessionBaselines = (): Effect.Effect<SessionBaselines, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const now = Date.now();
+        if (cachedBaselines && cachedBaselines.expiresAt > now) {
+            return cachedBaselines.value;
+        }
+
+        const db = yield* SurrealClient;
+        const [costRows, frictionRows, timeToLandRows, burnRows] = yield* db.query<[
+            CostRow[],
+            FrictionRow[],
+            TimeToLandRow[],
+            BurnRow[],
+        ]>(`
+            SELECT estimated_cost_usd
+            FROM session_token_usage
+            WHERE ts > time::now() - 30d
+              AND estimated_cost_usd IS NOT NONE;
+            SELECT (user_corrections + tool_errors) AS friction
+            FROM session_health
+            WHERE ts > time::now() - 30d;
+            SELECT time_to_land_ms
+            FROM session_metrics
+            WHERE session.started_at > time::now() - 30d
+              AND time_to_land_ms IS NOT NONE;
+            SELECT estimated_tokens, turns
+            FROM session_health
+            WHERE ts > time::now() - 30d
+              AND turns > 0;
+        `);
+
+        const burnRates = burnRows
+            .map((row) => {
+                const estimatedTokens = Number(row.estimated_tokens);
+                const turns = Number(row.turns);
+                return turns > 0 ? estimatedTokens / turns : Number.NaN;
+            })
+            .filter((x) => Number.isFinite(x));
+
+        const value: SessionBaselines = {
+            median_cost_usd: median(finiteNumbers(costRows.map((row) => row.estimated_cost_usd))),
+            median_friction: median(finiteNumbers(frictionRows.map((row) => row.friction))),
+            median_time_to_land_ms: median(finiteNumbers(timeToLandRows.map((row) => row.time_to_land_ms))),
+            burn_p90: p90(burnRates),
+        };
+        cachedBaselines = { value, expiresAt: now + CACHE_TTL_MS };
+        return value;
+    });

--- a/apps/axctl/src/dashboard/session-insights.test.ts
+++ b/apps/axctl/src/dashboard/session-insights.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { _resetBaselineCacheForTests } from "./session-baselines.ts";
+import { fetchSessionInsights } from "./session-insights.ts";
+
+const BARE = "aaaaaaaa-0000-0000-0000-000000000001";
+const CHILD = "bbbbbbbb-0000-0000-0000-000000000002";
+
+const run = (stub: SurrealClientShape) =>
+    Effect.runPromise(
+        fetchSessionInsights(BARE).pipe(Effect.provideService(SurrealClient, stub)),
+    );
+
+const emptyPrimaryResponse = [[], [], [], [], [], [], [], [], []];
+const emptyBaselineResponse = [[], [], [], []];
+
+beforeEach(() => {
+    _resetBaselineCacheForTests();
+});
+
+describe("fetchSessionInsights", () => {
+    test("assembles full payload and groups diagnostic checks", async () => {
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                [
+                    [{ phase: "plan", start_ts: "2026-06-11T01:00:00Z", end_ts: "2026-06-11T01:12:00Z", duration_ms: 720000 }],
+                    [{ ts: "2026-06-11T01:20:00Z", reaction_type: "correction" }],
+                    [
+                        { ts: "2026-06-11T01:30:00Z", sha: "def456", reverted: false },
+                        { ts: "2026-06-11T01:25:00Z", sha: "abc123", reverted: true },
+                        { ts: "2026-06-11T01:35:00Z", sha: null, reverted: false },
+                    ],
+                    [{ id: `session:\`${CHILD}\``, started_at: "2026-06-11T01:05:00Z", ended_at: "2026-06-11T01:15:00Z" }],
+                    [
+                        { kind: "test", status: "fail", ts: "2026-06-11T01:21:00Z" },
+                        { kind: "test", status: "pass", ts: "2026-06-11T01:25:00Z" },
+                        { kind: "lint", status: "error", ts: "2026-06-11T01:26:00Z" },
+                    ],
+                    [
+                        { skill: "skill:`superpowers__test-driven-development`", ts: "2026-06-11T01:02:00Z" },
+                        { skill: "skill:`github__yeet`", ts: "2026-06-11T01:04:00Z" },
+                    ],
+                    [{ lines_added: 2100, lines_removed: 940, durability_ratio: 0.8, delegation_ratio: 0.38, time_to_land_ms: 200 }],
+                    [{ estimated_cost_usd: 11.2, context_window: 200000, cache_read_input_tokens: 100, estimated_tokens: 350, prompt_tokens: 50 }],
+                    [{ user_corrections: 2, tool_errors: 5 }],
+                ],
+                [[
+                    { seq: 1, prompt_tokens: 1000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, ts: "2026-06-11T01:01:00Z" },
+                    { seq: 2, prompt_tokens: 4000, cache_read_input_tokens: 1000, cache_creation_input_tokens: 500, ts: "2026-06-11T01:06:00Z" },
+                ]],
+                [[{ ts: "2026-06-11T01:40:00Z" }]],
+                [
+                    [{ estimated_cost_usd: 5.6 }],
+                    [{ friction: 7 }],
+                    [{ time_to_land_ms: 400 }],
+                    [{ estimated_tokens: 1000, turns: 10 }],
+                ],
+            ],
+        });
+
+        const payload = await run(tc.client);
+
+        expect(payload).toMatchObject({
+            session: BARE,
+            phases: [{ phase: "plan", start_ts: "2026-06-11T01:00:00Z", end_ts: "2026-06-11T01:12:00Z", duration_ms: 720000 }],
+            friction_ticks: [{ ts: "2026-06-11T01:20:00Z", kind: "correction" }],
+            subagent_spans: [{ id: CHILD, started_at: "2026-06-11T01:05:00Z", ended_at: "2026-06-11T01:15:00Z" }],
+            loc: { added: 2100, removed: 940 },
+            durability: 0.8,
+            delegation_ratio: 0.38,
+            compactions: [{ ts: "2026-06-11T01:40:00Z" }],
+        });
+        expect(payload.commits).toEqual([
+            { ts: "2026-06-11T01:25:00Z", sha: "abc123", reverted: true },
+            { ts: "2026-06-11T01:30:00Z", sha: "def456", reverted: false },
+        ]);
+        expect(payload.checks).toEqual([
+            { kind: "test", runs: [{ ts: "2026-06-11T01:21:00Z", ok: false }, { ts: "2026-06-11T01:25:00Z", ok: true }] },
+            { kind: "lint", runs: [{ ts: "2026-06-11T01:26:00Z", ok: false }] },
+        ]);
+        expect(payload.skills).toEqual([
+            { name: "superpowers:test-driven-development", ts: "2026-06-11T01:02:00Z" },
+            { name: "github:yeet", ts: "2026-06-11T01:04:00Z" },
+        ]);
+        expect(payload.context_curve).toEqual([
+            { t: 0, pct: 0.005 },
+            { t: 300000, pct: 0.0275 },
+        ]);
+        expect(payload.baseline).toEqual({
+            cost_ratio: 2,
+            friction_ratio: 1,
+            land_ratio: 0.5,
+            cache_pct: 100 / 350,
+        });
+    });
+
+    test("empty session returns empty sections and null ratios", async () => {
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                emptyPrimaryResponse,
+                [[]],
+                [[]],
+                emptyBaselineResponse,
+            ],
+        });
+
+        const payload = await run(tc.client);
+
+        expect(payload.session).toBe(BARE);
+        expect(payload.phases).toEqual([]);
+        expect(payload.friction_ticks).toEqual([]);
+        expect(payload.commits).toEqual([]);
+        expect(payload.subagent_spans).toEqual([]);
+        expect(payload.checks).toEqual([]);
+        expect(payload.loc).toBeNull();
+        expect(payload.durability).toBeNull();
+        expect(payload.delegation_ratio).toBeNull();
+        expect(payload.skills).toEqual([]);
+        expect(payload.context_curve).toEqual([]);
+        expect(payload.compactions).toEqual([]);
+        expect(payload.baseline).toEqual({
+            cost_ratio: null,
+            friction_ratio: null,
+            land_ratio: null,
+            cache_pct: null,
+        });
+    });
+
+    test("first query is session-scoped and turn_token_usage only appears in second query", async () => {
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                emptyPrimaryResponse,
+                [[]],
+                [[]],
+                emptyBaselineResponse,
+            ],
+        });
+
+        await run(tc.client);
+
+        expect(tc.captured).toHaveLength(4);
+        const first = tc.captured[0]!;
+        const second = tc.captured[1]!;
+        expect(first).toContain("FROM phase_span WHERE session =");
+        expect(first).toContain("FROM reaction_event WHERE session =");
+        expect(first).toContain("FROM produced WHERE in =");
+        expect(first).toContain("FROM spawned WHERE in =");
+        expect(first).toContain("FROM diagnostic_event WHERE session =");
+        expect(first).toContain("FROM invoked WHERE session =");
+        expect(first).toContain("FROM session_metrics WHERE session =");
+        expect(first).toContain("FROM session_token_usage WHERE session =");
+        expect(first).toContain("FROM session_health WHERE session =");
+        expect(first).not.toMatch(/FROM turn\b/);
+        expect(first).not.toContain("turn_token_usage");
+        expect(second).toContain("FROM turn_token_usage WHERE session =");
+        expect(tc.captured.slice(2).join("\n")).not.toContain("turn_token_usage");
+    });
+
+    test("baseline failure degrades ratios to null while returning the payload", async () => {
+        const failingBaseline = Effect.fail(new Error("baseline unavailable") as DbError);
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                [
+                    [], [], [], [], [],
+                    [],
+                    [{ lines_added: 10, lines_removed: 4, durability_ratio: 0.5, delegation_ratio: 0.25, time_to_land_ms: 100 }],
+                    [{ estimated_cost_usd: 8, context_window: 200000, cache_read_input_tokens: 50, estimated_tokens: 100, prompt_tokens: 50 }],
+                    [{ user_corrections: 1, tool_errors: 1 }],
+                ],
+                [[]],
+                [[]],
+                failingBaseline,
+            ],
+        });
+
+        const payload = await run(tc.client);
+
+        expect(payload.loc).toEqual({ added: 10, removed: 4 });
+        expect(payload.baseline).toEqual({
+            cost_ratio: null,
+            friction_ratio: null,
+            land_ratio: null,
+            cache_pct: 0.5,
+        });
+    });
+
+    test("resetting baselines cache forces a fresh baseline query", async () => {
+        const primaryWithCost = [
+            [], [], [], [], [], [],
+            [{ lines_added: 1, lines_removed: 0, durability_ratio: null, delegation_ratio: null, time_to_land_ms: 100 }],
+            [{ estimated_cost_usd: 10, context_window: 200000, cache_read_input_tokens: 0, estimated_tokens: 100, prompt_tokens: 50 }],
+            [{ user_corrections: 1, tool_errors: 0 }],
+        ];
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                primaryWithCost,
+                [[]],
+                [[]],
+                [[{ estimated_cost_usd: 10 }], [{ friction: 1 }], [{ time_to_land_ms: 100 }], []],
+                primaryWithCost,
+                [[]],
+                [[]],
+                [[{ estimated_cost_usd: 5 }], [{ friction: 1 }], [{ time_to_land_ms: 100 }], []],
+            ],
+        });
+
+        const first = await run(tc.client);
+        _resetBaselineCacheForTests();
+        const second = await run(tc.client);
+
+        expect(first.baseline.cost_ratio).toBe(1);
+        expect(second.baseline.cost_ratio).toBe(2);
+        expect(tc.captured).toHaveLength(8);
+    });
+});

--- a/apps/axctl/src/dashboard/session-insights.test.ts
+++ b/apps/axctl/src/dashboard/session-insights.test.ts
@@ -72,8 +72,12 @@ describe("fetchSessionInsights", () => {
             loc: { added: 2100, removed: 940 },
             durability: 0.8,
             delegation_ratio: 0.38,
-            compactions: [{ ts: "2026-06-11T01:40:00Z" }],
         });
+        // Defect 2: compactions carry a t offset from the same t0 as context_curve.
+        // curve t0 = turn seq=1 ts = 2026-06-11T01:01:00Z
+        // compaction ts = 2026-06-11T01:40:00Z -> t = 39 * 60_000 = 2_340_000
+        // but curve tMax = 300_000 (seq=2 - seq=1), so t is clamped to 300_000.
+        expect(payload.compactions).toEqual([{ ts: "2026-06-11T01:40:00Z", t: 300_000 }]);
         expect(payload.commits).toEqual([
             { ts: "2026-06-11T01:25:00Z", sha: "abc123", reverted: true },
             { ts: "2026-06-11T01:30:00Z", sha: "def456", reverted: false },
@@ -189,6 +193,33 @@ describe("fetchSessionInsights", () => {
             land_ratio: null,
             cache_pct: 0.5,
         });
+    });
+
+    test("context curve always keeps t=0 origin point for >60-turn sessions", async () => {
+        // Build 70 turn-usage rows; the downsampler must keep index 0 (t=0).
+        const base = new Date("2026-06-11T02:00:00Z").getTime();
+        const turnRows = Array.from({ length: 70 }, (_, i) => ({
+            seq: i + 1,
+            prompt_tokens: 1000 + i * 100,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            ts: new Date(base + i * 60_000).toISOString(),
+        }));
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                emptyPrimaryResponse,
+                [turnRows],
+                [[]],
+                emptyBaselineResponse,
+            ],
+        });
+
+        const payload = await run(tc.client);
+
+        expect(payload.context_curve.length).toBeGreaterThan(0);
+        expect(payload.context_curve[0]!.t).toBe(0);
+        expect(payload.context_curve.length).toBeLessThanOrEqual(60);
     });
 
     test("resetting baselines cache forces a fresh baseline query", async () => {

--- a/apps/axctl/src/dashboard/session-insights.ts
+++ b/apps/axctl/src/dashboard/session-insights.ts
@@ -1,0 +1,265 @@
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import type { SessionInsightsPayload } from "@ax/lib/shared/dashboard-types";
+import { toBareSessionId, toSessionRid } from "@ax/lib/shared/session-id";
+import { fetchSessionBaselines } from "./session-baselines.ts";
+
+/**
+ * Insight-panel payload for one expanded sessions-list row.
+ *
+ * Everything here is scoped to one session id and uses aggregate or edge tables:
+ * phase_span, reaction_event, produced, spawned, diagnostic_event, invoked,
+ * session_metrics, session_token_usage, and session_health. The only turn-level
+ * read is the second query over turn_token_usage for the expanded session's
+ * context curve.
+ */
+
+// Live DB recon in Task 6 Step 1:
+// SELECT status, count() AS c FROM diagnostic_event GROUP BY status;
+//   -> only { status: 'error', c: 9436 }
+// SELECT kind, count() AS c FROM diagnostic_event GROUP BY kind;
+//   -> only { kind: 'tool_failure', c: 9436 }
+const OK_STATUSES = new Set(["pass", "passed", "success", "ok"]);
+
+const CURVE_MAX_POINTS = 60;
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+interface PhaseRow {
+    readonly phase: string;
+    readonly start_ts: string;
+    readonly end_ts: string;
+    readonly duration_ms: number;
+}
+
+interface ReactionRow {
+    readonly ts: string;
+    readonly reaction_type: string;
+}
+
+interface CommitRow {
+    readonly ts: string | null;
+    readonly sha: string | null;
+    readonly reverted: boolean | null;
+}
+
+interface SpawnedRow {
+    readonly id: string;
+    readonly started_at: string | null;
+    readonly ended_at: string | null;
+}
+
+interface DiagnosticRow {
+    readonly kind: string;
+    readonly status: string | null;
+    readonly ts: string;
+}
+
+interface InvokedRow {
+    readonly skill: string;
+    readonly ts: string;
+}
+
+interface MetricsRow {
+    readonly lines_added: number;
+    readonly lines_removed: number;
+    readonly durability_ratio: number | null;
+    readonly delegation_ratio: number | null;
+    readonly time_to_land_ms: number | null;
+}
+
+interface UsageRow {
+    readonly estimated_cost_usd: number | null;
+    readonly context_window: number | null;
+    readonly cache_read_input_tokens: number | null;
+    readonly prompt_tokens: number | null;
+    readonly estimated_tokens: number | null;
+}
+
+interface HealthRow {
+    readonly user_corrections: number | null;
+    readonly tool_errors: number | null;
+}
+
+interface TurnUsageRow {
+    readonly seq: number;
+    readonly prompt_tokens: number | null;
+    readonly cache_read_input_tokens: number | null;
+    readonly cache_creation_input_tokens: number | null;
+    readonly ts: string;
+}
+
+interface CompactionRow {
+    readonly ts: string;
+}
+
+const finiteRatio = (
+    numerator: number | null | undefined,
+    denominator: number | null | undefined,
+): number | null =>
+    typeof numerator === "number"
+        && typeof denominator === "number"
+        && Number.isFinite(numerator)
+        && Number.isFinite(denominator)
+        && denominator > 0
+        ? numerator / denominator
+        : null;
+
+const skillNameFromKey = (key: string): string =>
+    key.replace(/^skill:/, "").replace(/`/g, "").replace(/__/g, ":");
+
+const downsampleCurve = (
+    rows: ReadonlyArray<TurnUsageRow>,
+    contextWindow: number | null | undefined,
+): ReadonlyArray<{ readonly t: number; readonly pct: number }> => {
+    const window = typeof contextWindow === "number" && Number.isFinite(contextWindow) && contextWindow > 0
+        ? contextWindow
+        : DEFAULT_CONTEXT_WINDOW;
+    const firstTs = rows[0]?.ts ? new Date(rows[0].ts).getTime() : 0;
+    const points = rows.map((row) => {
+        const ts = row.ts ? new Date(row.ts).getTime() : firstTs;
+        const prompt = row.prompt_tokens ?? 0;
+        const cacheRead = row.cache_read_input_tokens ?? 0;
+        const cacheCreation = row.cache_creation_input_tokens ?? 0;
+        return {
+            t: Number.isFinite(ts) && Number.isFinite(firstTs) ? Math.max(0, ts - firstTs) : 0,
+            pct: Math.min(1, (prompt + cacheRead + cacheCreation) / window),
+        };
+    });
+
+    if (points.length <= CURVE_MAX_POINTS) return points;
+
+    const stride = Math.ceil(points.length / CURVE_MAX_POINTS);
+    const sampled = points.filter((_, index) => index % stride === 0);
+    const last = points.at(-1);
+    if (last && sampled.at(-1) !== last) return [...sampled, last].slice(-CURVE_MAX_POINTS);
+    return sampled;
+};
+
+const groupedChecks = (
+    rows: ReadonlyArray<DiagnosticRow>,
+): SessionInsightsPayload["checks"] => {
+    const byKind = new Map<string, Array<{ readonly ts: string; readonly ok: boolean }>>();
+    for (const row of rows) {
+        const runs = byKind.get(row.kind) ?? [];
+        runs.push({
+            ts: row.ts,
+            ok: row.status !== null && OK_STATUSES.has(row.status.toLowerCase()),
+        });
+        byKind.set(row.kind, runs);
+    }
+    return Array.from(byKind, ([kind, runs]) => ({ kind, runs }));
+};
+
+export const fetchSessionInsights = (
+    bareId: string,
+): Effect.Effect<SessionInsightsPayload, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const session = toBareSessionId(bareId);
+        const rid = toSessionRid(session);
+
+        const [
+            phases,
+            negativeReactions,
+            producedCommits,
+            spawnedChildren,
+            diagnostics,
+            invokedSkills,
+            metricsRows,
+            usageRows,
+            healthRows,
+        ] = yield* db.query<[
+            PhaseRow[],
+            ReactionRow[],
+            CommitRow[],
+            SpawnedRow[],
+            DiagnosticRow[],
+            InvokedRow[],
+            MetricsRow[],
+            UsageRow[],
+            HealthRow[],
+        ]>(`
+            SELECT phase, type::string(start_ts) AS start_ts, type::string(end_ts) AS end_ts, duration_ms
+            FROM phase_span WHERE session = ${rid} ORDER BY start_ts ASC;
+
+            SELECT type::string(ts) AS ts, reaction_type
+            FROM reaction_event WHERE session = ${rid} AND polarity = "negative" ORDER BY ts ASC;
+
+            SELECT type::string(out.ts) AS ts, out.sha AS sha, out.reverted AS reverted
+            FROM produced WHERE in = ${rid};
+
+            SELECT type::string(out) AS id, type::string(out.started_at) AS started_at, type::string(out.ended_at) AS ended_at
+            FROM spawned WHERE in = ${rid};
+
+            SELECT kind, status, type::string(ts) AS ts
+            FROM diagnostic_event WHERE session = ${rid} ORDER BY ts ASC;
+
+            SELECT type::string(out) AS skill, type::string(ts) AS ts
+            FROM invoked WHERE session = ${rid} ORDER BY ts ASC;
+
+            SELECT lines_added, lines_removed, durability_ratio, delegation_ratio, time_to_land_ms
+            FROM session_metrics WHERE session = ${rid};
+
+            SELECT estimated_cost_usd, context_window, cache_read_input_tokens, prompt_tokens, estimated_tokens
+            FROM session_token_usage WHERE session = ${rid};
+
+            SELECT user_corrections, tool_errors
+            FROM session_health WHERE session = ${rid};
+        `);
+
+        const [turnUsage] = yield* db.query<[TurnUsageRow[]]>(`
+            SELECT seq, prompt_tokens, cache_read_input_tokens, cache_creation_input_tokens, type::string(ts) AS ts
+            FROM turn_token_usage WHERE session = ${rid} ORDER BY seq ASC;
+        `);
+
+        const [compactions] = yield* db.query<[CompactionRow[]]>(`
+            SELECT type::string(ts) AS ts
+            FROM compaction WHERE session = ${rid} ORDER BY ts ASC;
+        `);
+
+        const metrics = metricsRows[0] ?? null;
+        const usage = usageRows[0] ?? null;
+        const health = healthRows[0] ?? null;
+        const friction = health
+            ? (Number(health.user_corrections) || 0) + (Number(health.tool_errors) || 0)
+            : null;
+
+        const baselines = yield* fetchSessionBaselines().pipe(
+            Effect.catch(() => Effect.succeed(null)),
+        );
+
+        const cacheRead = usage?.cache_read_input_tokens ?? null;
+        const estimatedTokens = usage?.estimated_tokens ?? null;
+
+        return {
+            session,
+            phases,
+            friction_ticks: negativeReactions.map((row) => ({ ts: row.ts, kind: row.reaction_type })),
+            commits: producedCommits
+                .filter((commit): commit is CommitRow & { readonly ts: string; readonly sha: string } =>
+                    typeof commit.ts === "string" && commit.ts.length > 0
+                    && typeof commit.sha === "string" && commit.sha.length > 0,
+                )
+                .map((commit) => ({ ts: commit.ts, sha: commit.sha, reverted: commit.reverted === true }))
+                .sort((a, b) => a.ts.localeCompare(b.ts)),
+            subagent_spans: spawnedChildren.map((child) => ({
+                id: toBareSessionId(child.id),
+                started_at: child.started_at,
+                ended_at: child.ended_at,
+            })),
+            checks: groupedChecks(diagnostics),
+            loc: metrics ? { added: metrics.lines_added, removed: metrics.lines_removed } : null,
+            durability: metrics?.durability_ratio ?? null,
+            delegation_ratio: metrics?.delegation_ratio ?? null,
+            skills: invokedSkills.map((row) => ({ name: skillNameFromKey(row.skill), ts: row.ts })),
+            context_curve: downsampleCurve(turnUsage, usage?.context_window),
+            compactions,
+            baseline: {
+                cost_ratio: finiteRatio(usage?.estimated_cost_usd, baselines?.median_cost_usd),
+                friction_ratio: finiteRatio(friction, baselines?.median_friction),
+                land_ratio: finiteRatio(metrics?.time_to_land_ms, baselines?.median_time_to_land_ms),
+                cache_pct: finiteRatio(cacheRead, estimatedTokens),
+            },
+        };
+    });

--- a/apps/axctl/src/dashboard/session-insights.ts
+++ b/apps/axctl/src/dashboard/session-insights.ts
@@ -129,10 +129,16 @@ const downsampleCurve = (
 
     if (points.length <= CURVE_MAX_POINTS) return points;
 
-    const stride = Math.ceil(points.length / CURVE_MAX_POINTS);
-    const sampled = points.filter((_, index) => index % stride === 0);
-    const last = points.at(-1);
-    if (last && sampled.at(-1) !== last) return [...sampled, last].slice(-CURVE_MAX_POINTS);
+    // Always keep index 0 (t=0 origin), then stride over the rest to fill
+    // CURVE_MAX_POINTS - 1 slots, then append the last point unconditionally.
+    const target = CURVE_MAX_POINTS - 1;
+    const stride = Math.ceil((points.length - 1) / target);
+    const sampled: Array<{ readonly t: number; readonly pct: number }> = [points[0]!];
+    for (let i = stride; i < points.length - 1; i += stride) {
+        sampled.push(points[i]!);
+    }
+    const last = points.at(-1)!;
+    if (sampled.at(-1) !== last) sampled.push(last);
     return sampled;
 };
 
@@ -232,6 +238,17 @@ export const fetchSessionInsights = (
         const cacheRead = usage?.cache_read_input_tokens ?? null;
         const estimatedTokens = usage?.estimated_tokens ?? null;
 
+        const contextCurve = downsampleCurve(turnUsage, usage?.context_window);
+
+        // Compute t offsets for compaction dots using the same t0 as the curve.
+        const curveT0Ms = turnUsage[0]?.ts ? new Date(turnUsage[0].ts).getTime() : 0;
+        const curveTMax = contextCurve.length > 0 ? Math.max(...contextCurve.map((p) => p.t)) : 0;
+        const compactionsWithT = compactions.map((c) => {
+            const cMs = new Date(c.ts).getTime();
+            const rawT = Number.isFinite(cMs) && Number.isFinite(curveT0Ms) ? Math.max(0, cMs - curveT0Ms) : 0;
+            return { ts: c.ts, t: Math.min(rawT, curveTMax) };
+        });
+
         return {
             session,
             phases,
@@ -253,8 +270,8 @@ export const fetchSessionInsights = (
             durability: metrics?.durability_ratio ?? null,
             delegation_ratio: metrics?.delegation_ratio ?? null,
             skills: invokedSkills.map((row) => ({ name: skillNameFromKey(row.skill), ts: row.ts })),
-            context_curve: downsampleCurve(turnUsage, usage?.context_window),
-            compactions,
+            context_curve: contextCurve,
+            compactions: compactionsWithT,
             baseline: {
                 cost_ratio: finiteRatio(usage?.estimated_cost_usd, baselines?.median_cost_usd),
                 friction_ratio: finiteRatio(friction, baselines?.median_friction),

--- a/apps/axctl/src/dashboard/sessions-list.test.ts
+++ b/apps/axctl/src/dashboard/sessions-list.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { fetchSessionsList } from "./sessions-list.ts";
+
+const RID = "session:`aaaaaaaa-0000-0000-0000-000000000001`";
+const BARE = "aaaaaaaa-0000-0000-0000-000000000001";
+
+const pageRow = {
+    id: RID,
+    project: "ax",
+    source: "claude",
+    cwd: "/Users/x/ax",
+    model: "claude-fable-5",
+    started_at: "2026-06-11T01:00:00.000Z",
+    ended_at: null,
+    has_raw_file: true,
+};
+
+const run = (stub: SurrealClientShape) =>
+    Effect.runPromise(
+        fetchSessionsList({}).pipe(Effect.provideService(SurrealClient, stub)),
+    );
+
+// NOTE on fixture shape: `makeTestSurrealClient`'s `fallback` is a single
+// responder answering EVERY `.query()` call with the same result tuple, so
+// per-call fixtures go through `responses` - one entry per `.query()` call,
+// each entry being that call's full result-set tuple. fetchSessionsList
+// issues 3 calls: page+count (2 sets), spawned counts (1 set), enrichment
+// (3 sets).
+
+describe("fetchSessionsList enrichment", () => {
+    test("joins health/usage/metrics onto rows and computes signal", async () => {
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                // call 1: page select + count (multi-statement -> two result sets)
+                [[pageRow], [{ total: 1 }]],
+                // call 2: spawned counts
+                [[]],
+                // call 3: enrichment (multi-statement -> three result sets)
+                [
+                    [{
+                        session: RID, turns: 58, tool_errors: 5, user_corrections: 2,
+                        context_pressure: "high", ts: new Date().toISOString(),
+                    }],
+                    [{
+                        session: RID, estimated_cost_usd: 11.2, estimated_tokens: 3_400_000,
+                        cache_read_input_tokens: 2_400_000, burn_buckets: "[100,200,300]",
+                    }],
+                    [{
+                        session: RID, produced_commits: 5, reverted_commits: 1,
+                        lines_added: 2100, lines_removed: 940,
+                    }],
+                ],
+            ],
+        }).client;
+
+        const res = await run(stub);
+        const row = res.sessions[0]!;
+        expect(row.id).toBe(BARE);
+        expect(row.turn_count).toBe(58);
+        expect(row.cost_usd).toBe(11.2);
+        expect(row.burn_buckets).toEqual([100, 200, 300]);
+        expect(row.friction).toBe(7);
+        expect(row.signal).toBe("friction");
+        expect(row.produced_commits).toBe(5);
+        expect(row.reverted_commits).toBe(1);
+        expect(row.lines_added).toBe(2100);
+        expect(row.lines_removed).toBe(940);
+        // ended_at null + fresh health ts -> live
+        expect(row.is_live).toBe(true);
+    });
+
+    test("rows without enrichment rows render null fields, signal null, not live", async () => {
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                [[{ ...pageRow, ended_at: "2026-06-11T02:00:00.000Z" }], [{ total: 1 }]],
+                [[]], // spawned
+                [[], [], []], // empty enrichment sets
+            ],
+        }).client;
+        const res = await run(stub);
+        const row = res.sessions[0]!;
+        expect(row.turn_count).toBe(0);
+        expect(row.cost_usd).toBeNull();
+        expect(row.burn_buckets).toBeNull();
+        expect(row.friction).toBeNull();
+        expect(row.signal).toBeNull();
+        expect(row.is_live).toBe(false);
+    });
+
+    test("zero-friction health row -> signal clean", async () => {
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                [[pageRow], [{ total: 1 }]],
+                [[]],
+                [
+                    [{ session: RID, turns: 4, tool_errors: 0, user_corrections: 0, context_pressure: "low", ts: new Date().toISOString() }],
+                    [],
+                    [],
+                ],
+            ],
+        }).client;
+        const res = await run(stub);
+        expect(res.sessions[0]!.signal).toBe("clean");
+        expect(res.sessions[0]!.friction).toBe(0);
+    });
+
+    test("malformed burn_buckets JSON degrades to null", async () => {
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                [[pageRow], [{ total: 1 }]],
+                [[]],
+                [
+                    [],
+                    [{ session: RID, estimated_cost_usd: 1, estimated_tokens: 10, cache_read_input_tokens: 0, burn_buckets: "not json" }],
+                    [],
+                ],
+            ],
+        }).client;
+        const res = await run(stub);
+        expect(res.sessions[0]!.burn_buckets).toBeNull();
+        expect(res.sessions[0]!.cost_usd).toBe(1);
+    });
+});

--- a/apps/axctl/src/dashboard/sessions-list.test.ts
+++ b/apps/axctl/src/dashboard/sessions-list.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { Effect } from "effect";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { DbError } from "@ax/lib/errors";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { _resetBaselineCacheForTests } from "./session-baselines.ts";
 import { fetchSessionsList } from "./sessions-list.ts";
 
 const RID = "session:`aaaaaaaa-0000-0000-0000-000000000001`";
@@ -27,8 +29,14 @@ const run = (stub: SurrealClientShape) =>
 // responder answering EVERY `.query()` call with the same result tuple, so
 // per-call fixtures go through `responses` - one entry per `.query()` call,
 // each entry being that call's full result-set tuple. fetchSessionsList
-// issues 3 calls: page+count (2 sets), spawned counts (1 set), enrichment
-// (3 sets).
+// issues 4 calls: page+count (2 sets), spawned counts (1 set), enrichment
+// (3 sets), baselines (4 sets).
+
+const emptyBaselines = [[], [], [], []];
+
+beforeEach(() => {
+    _resetBaselineCacheForTests();
+});
 
 describe("fetchSessionsList enrichment", () => {
     test("joins health/usage/metrics onto rows and computes signal", async () => {
@@ -54,6 +62,8 @@ describe("fetchSessionsList enrichment", () => {
                         lines_added: 2100, lines_removed: 940,
                     }],
                 ],
+                // call 4: baselines
+                [[{ estimated_cost_usd: 1 }], [{ friction: 1 }], [{ time_to_land_ms: 1 }], [{ estimated_tokens: 900, turns: 3 }]],
             ],
         }).client;
 
@@ -71,6 +81,7 @@ describe("fetchSessionsList enrichment", () => {
         expect(row.lines_removed).toBe(940);
         // ended_at null + fresh health ts -> live
         expect(row.is_live).toBe(true);
+        expect(res.burn_p90).toBe(300);
     });
 
     test("rows without enrichment rows render null fields, signal null, not live", async () => {
@@ -80,6 +91,7 @@ describe("fetchSessionsList enrichment", () => {
                 [[{ ...pageRow, ended_at: "2026-06-11T02:00:00.000Z" }], [{ total: 1 }]],
                 [[]], // spawned
                 [[], [], []], // empty enrichment sets
+                emptyBaselines,
             ],
         }).client;
         const res = await run(stub);
@@ -103,6 +115,7 @@ describe("fetchSessionsList enrichment", () => {
                     [],
                     [],
                 ],
+                emptyBaselines,
             ],
         }).client;
         const res = await run(stub);
@@ -121,10 +134,76 @@ describe("fetchSessionsList enrichment", () => {
                     [{ session: RID, estimated_cost_usd: 1, estimated_tokens: 10, cache_read_input_tokens: 0, burn_buckets: "not json" }],
                     [],
                 ],
+                emptyBaselines,
             ],
         }).client;
         const res = await run(stub);
         expect(res.sessions[0]!.burn_buckets).toBeNull();
         expect(res.sessions[0]!.cost_usd).toBe(1);
+    });
+
+    test("query shape stays on aggregate tables and never scans turns", async () => {
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                [[pageRow], [{ total: 1 }]],
+                [[]],
+                [[], [], []],
+                emptyBaselines,
+            ],
+        });
+
+        await run(tc.client);
+
+        const enrichment = tc.captured[2]!;
+        expect(enrichment).toContain("FROM session_health");
+        expect(enrichment).toContain("FROM session_token_usage");
+        expect(enrichment).toContain("FROM session_metrics");
+        for (const sql of tc.captured) {
+            expect(sql).not.toMatch(/FROM turn\b/);
+            expect(sql).not.toContain("turn_token_usage");
+        }
+    });
+
+    test("stale health ts with open session is not live", async () => {
+        const staleTs = new Date(Date.now() - 11 * 60_000).toISOString();
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                [[pageRow], [{ total: 1 }]],
+                [[]],
+                [
+                    [{ session: RID, turns: 4, tool_errors: 0, user_corrections: 0, context_pressure: "low", ts: staleTs }],
+                    [],
+                    [],
+                ],
+                emptyBaselines,
+            ],
+        }).client;
+
+        const res = await run(stub);
+        expect(res.sessions[0]!.is_live).toBe(false);
+    });
+
+    test("enrichment query failure degrades to bare rows", async () => {
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            responses: [
+                [[pageRow], [{ total: 1 }]],
+                [[]],
+                Effect.fail(new DbError({ operation: "query", message: "enrichment failed" })),
+                emptyBaselines,
+            ],
+        }).client;
+
+        const res = await run(stub);
+        const row = res.sessions[0]!;
+        expect(row.id).toBe(BARE);
+        expect(row.turn_count).toBe(0);
+        expect(row.cost_usd).toBeNull();
+        expect(row.friction).toBeNull();
+        expect(row.signal).toBeNull();
+        expect(row.produced_commits).toBeNull();
+        expect(row.is_live).toBe(false);
     });
 });

--- a/apps/axctl/src/dashboard/sessions-list.ts
+++ b/apps/axctl/src/dashboard/sessions-list.ts
@@ -64,6 +64,45 @@ const safeLiteral = (value: string): string => {
  */
 const formatRecordIdList = (ids: ReadonlyArray<string>): string => ids.join(", ");
 
+/** ended_at-null sessions count as live only when the health derive row was
+ *  written recently - the watcher re-ingests live transcripts within ~1 min,
+ *  so a stale ts means the session is dead, just never closed. */
+const LIVE_HEALTH_TS_WINDOW_MS = 10 * 60_000;
+
+interface HealthRow {
+    readonly session: string;
+    readonly turns: number | null;
+    readonly tool_errors: number | null;
+    readonly user_corrections: number | null;
+    readonly context_pressure: string | null;
+    readonly ts: string | null;
+}
+interface UsageRow {
+    readonly session: string;
+    readonly estimated_cost_usd: number | null;
+    readonly estimated_tokens: number | null;
+    readonly cache_read_input_tokens: number | null;
+    readonly burn_buckets: string | null;
+}
+interface MetricsRow {
+    readonly session: string;
+    readonly produced_commits: number | null;
+    readonly reverted_commits: number | null;
+    readonly lines_added: number | null;
+    readonly lines_removed: number | null;
+}
+
+const parseBurnBuckets = (raw: string | null): number[] | null => {
+    if (!raw) return null;
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return null;
+        return parsed.map((v) => (typeof v === "number" && Number.isFinite(v) ? v : 0));
+    } catch {
+        return null;
+    }
+};
+
 export const fetchSessionsList = (opts: SessionsListOpts = {}): Effect.Effect<SessionListResponse, DbError, SurrealClient> =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
@@ -128,11 +167,11 @@ export const fetchSessionsList = (opts: SessionsListOpts = {}): Effect.Effect<Se
                     started_at: r.started_at,
                     ended_at: r.ended_at,
                     has_raw_file: !!r.has_raw_file,
-                    // turn_count intentionally NOT joined here: the cross-
-                    // session turn table is huge and a batched IN-list count
-                    // still takes ~8 s at the 200-row scale we want. Surface
-                    // 0 in the wire format; per-session detail view fetches
-                    // it on demand.
+                    // turn_count intentionally NOT counted from `turn` here:
+                    // the cross-session turn table is huge and a batched
+                    // IN-list count still takes ~8 s at the 200-row scale we
+                    // want. Filled below from session_health.turns (0 when no
+                    // health row exists).
                     turn_count: 0,
                     parent_session: null,
                     // Filled in below after the spawned-counts query.
@@ -167,11 +206,62 @@ export const fetchSessionsList = (opts: SessionsListOpts = {}): Effect.Effect<Se
                 childCountByRawId.set(r.parent, Number(r.c) || 0);
             }
         }
-        const sessions: SessionListRow[] = paged.items.map((s) => ({
-            ...s,
-            direct_children_count:
-                childCountByRawId.get(rawIdByBare.get(s.id) ?? "") ?? 0,
-        }));
+        // Enrichment: one multi-statement round-trip against the three
+        // per-session aggregate tables. All keyed `session IN [...]` on
+        // UNIQUE session indexes - no turn scans, no graph derefs (the two
+        // documented hang classes for this surface).
+        const healthBySession = new Map<string, HealthRow>();
+        const usageBySession = new Map<string, UsageRow>();
+        const metricsBySession = new Map<string, MetricsRow>();
+        if (rawIds.length > 0) {
+            const inList = formatRecordIdList(rawIds);
+            const [health, usage, metrics] = yield* db.query<[
+                HealthRow[],
+                UsageRow[],
+                MetricsRow[],
+            ]>(`
+                SELECT <string>session AS session, turns, tool_errors,
+                       user_corrections, context_pressure, <string>ts AS ts
+                FROM session_health WHERE session IN [${inList}];
+                SELECT <string>session AS session, estimated_cost_usd,
+                       estimated_tokens, cache_read_input_tokens, burn_buckets
+                FROM session_token_usage WHERE session IN [${inList}];
+                SELECT <string>session AS session, produced_commits,
+                       reverted_commits, lines_added, lines_removed
+                FROM session_metrics WHERE session IN [${inList}];
+            `);
+            for (const h of health) healthBySession.set(h.session, h);
+            for (const u of usage) usageBySession.set(u.session, u);
+            for (const m of metrics) metricsBySession.set(m.session, m);
+        }
+
+        const now = Date.now();
+        const sessions: SessionListRow[] = paged.items.map((s) => {
+            const rawId = rawIdByBare.get(s.id) ?? "";
+            const health = healthBySession.get(rawId);
+            const usage = usageBySession.get(rawId);
+            const metrics = metricsBySession.get(rawId);
+            const friction = health
+                ? (Number(health.user_corrections) || 0) + (Number(health.tool_errors) || 0)
+                : null;
+            const healthTs = health?.ts ? new Date(health.ts).getTime() : Number.NaN;
+            return {
+                ...s,
+                direct_children_count: childCountByRawId.get(rawId) ?? 0,
+                turn_count: health?.turns ?? 0,
+                cost_usd: usage?.estimated_cost_usd ?? null,
+                burn_buckets: parseBurnBuckets(usage?.burn_buckets ?? null),
+                friction,
+                signal: friction === null ? null : friction === 0 ? "clean" : "friction",
+                produced_commits: metrics?.produced_commits ?? null,
+                reverted_commits: metrics?.reverted_commits ?? null,
+                lines_added: metrics?.lines_added ?? null,
+                lines_removed: metrics?.lines_removed ?? null,
+                is_live: s.ended_at === null
+                    && Number.isFinite(healthTs)
+                    && now - healthTs < LIVE_HEALTH_TS_WINDOW_MS,
+            };
+        });
 
         // why: same defence as recall.ts - the count query can legitimately
         // return 0 (empty row, GROUP ALL on empty filter set, or a race with

--- a/apps/axctl/src/dashboard/sessions-list.ts
+++ b/apps/axctl/src/dashboard/sessions-list.ts
@@ -20,6 +20,7 @@ import type {
 import { queryPagedWithCount } from "@ax/lib/shared/graph-query";
 import { clampPagination, type PaginationConfig } from "@ax/lib/shared/pagination";
 import { toBareSessionId, toSessionRid } from "@ax/lib/shared/session-id";
+import { fetchSessionBaselines } from "./session-baselines.ts";
 
 export interface SessionsListOpts {
     readonly offset?: number;
@@ -67,6 +68,8 @@ const formatRecordIdList = (ids: ReadonlyArray<string>): string => ids.join(", "
 /** ended_at-null sessions count as live only when the health derive row was
  *  written recently - the watcher re-ingests live transcripts within ~1 min,
  *  so a stale ts means the session is dead, just never closed. */
+// Wart: deep-backfill can mark old open sessions live/stale by rewriting
+// session_health.ts, but health ts must stay fresh for the dashboard proxy.
 const LIVE_HEALTH_TS_WINDOW_MS = 10 * 60_000;
 
 interface HealthRow {
@@ -215,6 +218,7 @@ export const fetchSessionsList = (opts: SessionsListOpts = {}): Effect.Effect<Se
         const metricsBySession = new Map<string, MetricsRow>();
         if (rawIds.length > 0) {
             const inList = formatRecordIdList(rawIds);
+            // enrichment must never break the base list - degrade to bare rows.
             const [health, usage, metrics] = yield* db.query<[
                 HealthRow[],
                 UsageRow[],
@@ -229,7 +233,9 @@ export const fetchSessionsList = (opts: SessionsListOpts = {}): Effect.Effect<Se
                 SELECT <string>session AS session, produced_commits,
                        reverted_commits, lines_added, lines_removed
                 FROM session_metrics WHERE session IN [${inList}];
-            `);
+            `).pipe(
+                Effect.catch(() => Effect.succeed<[HealthRow[], UsageRow[], MetricsRow[]]>([[], [], []])),
+            );
             for (const h of health) healthBySession.set(h.session, h);
             for (const u of usage) usageBySession.set(u.session, u);
             for (const m of metrics) metricsBySession.set(m.session, m);
@@ -268,8 +274,11 @@ export const fetchSessionsList = (opts: SessionsListOpts = {}): Effect.Effect<Se
         // a concurrent ingest). Falling back to `sessions.length + offset`
         // keeps the UI from claiming fewer rows than it just rendered.
         const total_count = Math.max(paged.total, sessions.length + offset);
+        const baselines = yield* fetchSessionBaselines().pipe(
+            Effect.catch(() => Effect.succeed(null)),
+        );
 
-        return { sessions, total_count, burn_p90: null, window: { offset, limit } };
+        return { sessions, total_count, burn_p90: baselines?.burn_p90 ?? null, window: { offset, limit } };
     });
 
 /**

--- a/apps/axctl/src/dashboard/sessions-list.ts
+++ b/apps/axctl/src/dashboard/sessions-list.ts
@@ -137,6 +137,15 @@ export const fetchSessionsList = (opts: SessionsListOpts = {}): Effect.Effect<Se
                     parent_session: null,
                     // Filled in below after the spawned-counts query.
                     direct_children_count: 0,
+                    cost_usd: null,
+                    burn_buckets: null,
+                    friction: null,
+                    signal: null,
+                    produced_commits: null,
+                    reverted_commits: null,
+                    lines_added: null,
+                    lines_removed: null,
+                    is_live: false,
                 };
             },
             (row) => row.total,
@@ -170,7 +179,7 @@ export const fetchSessionsList = (opts: SessionsListOpts = {}): Effect.Effect<Se
         // keeps the UI from claiming fewer rows than it just rendered.
         const total_count = Math.max(paged.total, sessions.length + offset);
 
-        return { sessions, total_count, window: { offset, limit } };
+        return { sessions, total_count, burn_p90: null, window: { offset, limit } };
     });
 
 /**
@@ -232,6 +241,15 @@ export const fetchSessionChildren = (
             has_raw_file: !!r.has_raw_file,
             turn_count: 0,
             parent_session,
+            cost_usd: null,
+            burn_buckets: null,
+            friction: null,
+            signal: null,
+            produced_commits: null,
+            reverted_commits: null,
+            lines_added: null,
+            lines_removed: null,
+            is_live: false,
         }));
 
         return { parent_session, children };

--- a/apps/axctl/src/ingest/burn-buckets.test.ts
+++ b/apps/axctl/src/ingest/burn-buckets.test.ts
@@ -33,4 +33,8 @@ describe("computeBurnBuckets", () => {
     test("non-finite and negative inputs clamp to 0", () => {
         expect(computeBurnBuckets([Number.NaN, -5, 7])).toEqual([0, 0, 7]);
     });
+
+    test("bucketCount <= 0 -> empty array", () => {
+        expect(computeBurnBuckets([1, 2, 3], 0)).toEqual([]);
+    });
 });

--- a/apps/axctl/src/ingest/burn-buckets.test.ts
+++ b/apps/axctl/src/ingest/burn-buckets.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { computeBurnBuckets } from "./burn-buckets.ts";
+
+describe("computeBurnBuckets", () => {
+    test("empty input -> empty array", () => {
+        expect(computeBurnBuckets([])).toEqual([]);
+    });
+
+    test("fewer turns than buckets -> one bucket per turn, order preserved", () => {
+        expect(computeBurnBuckets([10, 20, 30])).toEqual([10, 20, 30]);
+    });
+
+    test("exactly 20 turns -> identity", () => {
+        const turns = Array.from({ length: 20 }, (_, i) => i + 1);
+        expect(computeBurnBuckets(turns)).toEqual(turns);
+    });
+
+    test("more turns than buckets -> sums per bucket, total preserved", () => {
+        // 40 turns of 1 token -> 20 buckets of 2
+        const turns = Array.from({ length: 40 }, () => 1);
+        const buckets = computeBurnBuckets(turns);
+        expect(buckets).toHaveLength(20);
+        expect(buckets.every((b) => b === 2)).toBe(true);
+    });
+
+    test("uneven split keeps total", () => {
+        const turns = Array.from({ length: 33 }, (_, i) => i);
+        const buckets = computeBurnBuckets(turns);
+        expect(buckets).toHaveLength(20);
+        expect(buckets.reduce((a, b) => a + b, 0)).toBe(turns.reduce((a, b) => a + b, 0));
+    });
+
+    test("non-finite and negative inputs clamp to 0", () => {
+        expect(computeBurnBuckets([Number.NaN, -5, 7])).toEqual([0, 0, 7]);
+    });
+});

--- a/apps/axctl/src/ingest/burn-buckets.ts
+++ b/apps/axctl/src/ingest/burn-buckets.ts
@@ -10,6 +10,7 @@ export const computeBurnBuckets = (
     perTurnTokens: ReadonlyArray<number>,
     bucketCount: number = BURN_BUCKET_COUNT,
 ): number[] => {
+    if (bucketCount <= 0) return [];
     const clean = perTurnTokens.map((t) => (Number.isFinite(t) && t > 0 ? Math.trunc(t) : 0));
     if (clean.length === 0) return [];
     if (clean.length <= bucketCount) return clean;

--- a/apps/axctl/src/ingest/burn-buckets.ts
+++ b/apps/axctl/src/ingest/burn-buckets.ts
@@ -1,0 +1,22 @@
+/**
+ * Downsample per-turn token counts into a fixed-size bucket array for the
+ * sessions-list BURN sparkline. Bucket k sums the contiguous slice of turns
+ * that maps onto it, so the series total is preserved and heavy turns stay
+ * visible. Stored JSON-encoded on `session_token_usage.burn_buckets`.
+ */
+export const BURN_BUCKET_COUNT = 20;
+
+export const computeBurnBuckets = (
+    perTurnTokens: ReadonlyArray<number>,
+    bucketCount: number = BURN_BUCKET_COUNT,
+): number[] => {
+    const clean = perTurnTokens.map((t) => (Number.isFinite(t) && t > 0 ? Math.trunc(t) : 0));
+    if (clean.length === 0) return [];
+    if (clean.length <= bucketCount) return clean;
+    const buckets = new Array<number>(bucketCount).fill(0);
+    for (let i = 0; i < clean.length; i++) {
+        const k = Math.min(bucketCount - 1, Math.floor((i * bucketCount) / clean.length));
+        buckets[k] += clean[i] ?? 0;
+    }
+    return buckets;
+};

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1216,6 +1216,7 @@ const buildCodexTokenUsageStatements = (usage: CodexTokenUsage | null): string[]
         estimatedTokens: usage.estimatedTokens,
     });
     return [
+        // TODO(burn-buckets): codex batching makes per-session series unavailable here; backfill via derive stage
         `UPSERT ${recordRef("session_token_usage", safeKeyPart(usage.session))} MERGE ${surrealObject([
             ["session", recordRef("session", usage.session)],
             ["source", surrealString("codex")],

--- a/apps/axctl/src/ingest/skills.ts
+++ b/apps/axctl/src/ingest/skills.ts
@@ -216,6 +216,15 @@ const collectSkills = (): Effect.Effect<
 > =>
     Effect.gen(function* () {
         const buckets = defaultSkillDirs();
+        const envOverride = (process.env.AX_SKILLS_DIRS ?? "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean).length > 0;
+        if (envOverride) {
+            return yield* Effect.forEach(buckets, ({ dir, scope }) => readSkillDir(dir, scope), {
+                concurrency: "unbounded",
+            }).pipe(Effect.map((xs) => xs.flat()));
+        }
         const [fromBaseDirs, fromPlugins, fromProjects] = yield* Effect.all(
             [
                 Effect.forEach(buckets, ({ dir, scope }) => readSkillDir(dir, scope), {

--- a/apps/axctl/src/ingest/skills.ts
+++ b/apps/axctl/src/ingest/skills.ts
@@ -15,7 +15,7 @@ import { parse as parseYaml } from "yaml";
 import { Effect, FileSystem, Path, Schema } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { SkillName } from "@ax/lib/brands";
-import { defaultSkillDirs } from "@ax/lib/paths";
+import { defaultSkillDirs, skillDirsOverridden } from "@ax/lib/paths";
 import { AppLayer } from "@ax/lib/layers";
 import type { DbError } from "@ax/lib/errors";
 import { upsertSkillByName } from "./skill-upsert.ts";
@@ -216,11 +216,8 @@ const collectSkills = (): Effect.Effect<
 > =>
     Effect.gen(function* () {
         const buckets = defaultSkillDirs();
-        const envOverride = (process.env.AX_SKILLS_DIRS ?? "")
-            .split(",")
-            .map((s) => s.trim())
-            .filter(Boolean).length > 0;
-        if (envOverride) {
+        // AX_SKILLS_DIRS is a full override: when set (tests, sandboxes), plugin + project discovery is skipped so collection stays hermetic.
+        if (skillDirsOverridden()) {
             return yield* Effect.forEach(buckets, ({ dir, scope }) => readSkillDir(dir, scope), {
                 concurrency: "unbounded",
             }).pipe(Effect.map((xs) => xs.flat()));

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -41,6 +41,7 @@ import {
     turnRecordKey,
 } from "./record-keys.ts";
 import { extractToolFileEvidence } from "./tool-file-evidence.ts";
+import { computeBurnBuckets } from "./burn-buckets.ts";
 import {
     buildNormalizedTranscriptStatements,
     buildNormalizedTurnStatements,
@@ -1494,6 +1495,11 @@ export const buildClaudeTokenUsageStatements = (extracted: FileExtract): string[
         estimatedTokens: usage.estimatedTokens,
     });
     const sessionId = extracted.session.id;
+    const burnBuckets = computeBurnBuckets(
+        [...extracted.turnTokenUsages]
+            .sort((a, b) => a.seq - b.seq)
+            .map((t) => t.estimatedTokens),
+    );
     return [
         `UPSERT ${recordRef("session_token_usage", safeKeyPart(sessionId))} MERGE ${surrealObject([
             ["session", recordRef("session", sessionId)],
@@ -1516,6 +1522,7 @@ export const buildClaudeTokenUsageStatements = (extracted: FileExtract): string[
                 source: "claude_transcript",
                 token_source: "transcript_usage",
             })],
+            ["burn_buckets", burnBuckets.length > 0 ? surrealString(JSON.stringify(burnBuckets)) : "NONE"],
             ["ts", surrealDate(usage.ts)],
         ])};`,
     ];

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -14,6 +14,7 @@ import type {
     SessionComparePayload,
     SessionDetailPayload,
     SessionInspectPayload,
+    SessionInsightsPayload,
     SessionListResponse,
     SkillDetailPayload,
     SkillSourcePayload,
@@ -254,6 +255,8 @@ export const api = {
         jsonFetch(`/api/sessions/${encodeURIComponent(sessionId)}`),
     sessionChildren: (parentId: string): Promise<SessionChildrenResponse> =>
         jsonFetch(`/api/sessions/${encodeURIComponent(parentId)}/children`),
+    sessionInsights: (sessionId: string): Promise<SessionInsightsPayload> =>
+        jsonFetch(`/api/sessions/${encodeURIComponent(sessionId)}/insights`),
     sessionInspect: (sessionId: string, params: { turnOffset?: number; turnLimit?: number } = {}): Promise<SessionInspectPayload> => {
         const usp = new URLSearchParams();
         if (params.turnOffset != null) usp.set("turn_offset", String(params.turnOffset));

--- a/apps/studio/src/components/session-insight/BurnSpark.tsx
+++ b/apps/studio/src/components/session-insight/BurnSpark.tsx
@@ -1,16 +1,24 @@
 /** Per-turn token-burn sparkline for a sessions-list row. Bars are neutral
- *  gray; only buckets above the user's 30d p90 (server-provided) go amber -
- *  so amber appearing in the table at all marks an outlier row. */
-export function BurnSpark({ buckets, p90 }: {
+ *  gray; only buckets above the user's 30d p90 go amber - so amber appearing
+ *  in the table at all marks an outlier row.
+ *
+ *  Unit conversion: p90 is a per-turn average; each bucket is a SUM over
+ *  ~(turnCount/buckets.length) turns. We scale the threshold by turns-per-bucket
+ *  so a high-turn session doesn't spuriously amber every bar. */
+export function BurnSpark({ buckets, p90, turnCount }: {
     readonly buckets: ReadonlyArray<number> | null;
     readonly p90: number | null;
+    readonly turnCount: number | null;
 }) {
     if (!buckets || buckets.length === 0) {
         return <span style={{ color: "var(--sx-ink-300)" }}>–</span>;
     }
     const max = Math.max(...buckets, 1);
-    const outliers = p90 === null ? 0 : buckets.filter((b) => b > p90).length;
-    const label = `token burn sparkline, ${buckets.length} buckets, peak ${Math.round(max)} tokens${p90 === null ? "" : `, ${outliers} above 30 day p90`}`;
+    // Scale per-turn p90 up to per-bucket units before comparing to bucket sums.
+    const turnsPerBucket = turnCount && buckets.length > 0 ? Math.max(1, turnCount / buckets.length) : 1;
+    const threshold = p90 !== null ? p90 * turnsPerBucket : null;
+    const outliers = threshold === null ? 0 : buckets.filter((b) => b > threshold).length;
+    const label = `token burn sparkline, ${buckets.length} buckets, peak ${Math.round(max)} tokens${threshold === null ? "" : `, ${outliers} above 30 day p90`}`;
     return (
         <span
             style={{ display: "inline-flex", alignItems: "flex-end", gap: 1, height: 14 }}
@@ -26,7 +34,7 @@ export function BurnSpark({ buckets, p90 }: {
                         width: 3,
                         borderRadius: "1px 1px 0 0",
                         height: Math.max(2, Math.round((b / max) * 14)),
-                        background: p90 !== null && b > p90 ? "var(--sx-amber-500)" : "var(--sx-ink-300)",
+                        background: threshold !== null && b > threshold ? "var(--sx-amber-500)" : "var(--sx-ink-300)",
                     }}
                 />
             ))}

--- a/apps/studio/src/components/session-insight/BurnSpark.tsx
+++ b/apps/studio/src/components/session-insight/BurnSpark.tsx
@@ -9,11 +9,18 @@ export function BurnSpark({ buckets, p90 }: {
         return <span style={{ color: "var(--sx-ink-300)" }}>–</span>;
     }
     const max = Math.max(...buckets, 1);
+    const outliers = p90 === null ? 0 : buckets.filter((b) => b > p90).length;
+    const label = `token burn sparkline, ${buckets.length} buckets, peak ${Math.round(max)} tokens${p90 === null ? "" : `, ${outliers} above 30 day p90`}`;
     return (
-        <span style={{ display: "inline-flex", alignItems: "flex-end", gap: 1, height: 14 }} aria-hidden>
+        <span
+            style={{ display: "inline-flex", alignItems: "flex-end", gap: 1, height: 14 }}
+            role="img"
+            aria-label={label}
+        >
             {buckets.map((b, i) => (
                 <i
                     key={i}
+                    aria-hidden
                     style={{
                         display: "block",
                         width: 3,

--- a/apps/studio/src/components/session-insight/BurnSpark.tsx
+++ b/apps/studio/src/components/session-insight/BurnSpark.tsx
@@ -1,0 +1,28 @@
+/** Per-turn token-burn sparkline for a sessions-list row. Bars are neutral
+ *  gray; only buckets above the user's 30d p90 (server-provided) go amber -
+ *  so amber appearing in the table at all marks an outlier row. */
+export function BurnSpark({ buckets, p90 }: {
+    readonly buckets: ReadonlyArray<number> | null;
+    readonly p90: number | null;
+}) {
+    if (!buckets || buckets.length === 0) {
+        return <span style={{ color: "var(--sx-ink-300)" }}>–</span>;
+    }
+    const max = Math.max(...buckets, 1);
+    return (
+        <span style={{ display: "inline-flex", alignItems: "flex-end", gap: 1, height: 14 }} aria-hidden>
+            {buckets.map((b, i) => (
+                <i
+                    key={i}
+                    style={{
+                        display: "block",
+                        width: 3,
+                        borderRadius: "1px 1px 0 0",
+                        height: Math.max(2, Math.round((b / max) * 14)),
+                        background: p90 !== null && b > p90 ? "var(--sx-amber-500)" : "var(--sx-ink-300)",
+                    }}
+                />
+            ))}
+        </span>
+    );
+}

--- a/apps/studio/src/components/session-insight/InsightPanel.tsx
+++ b/apps/studio/src/components/session-insight/InsightPanel.tsx
@@ -127,8 +127,8 @@ function LocCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
 
 function SkillArcCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
     if (p.skills.length === 0) return null;
-    const arc = p.skills.filter((s, i) => i === 0 || s.name !== p.skills[i - 1]!.name);
     const labelOf = (name: string): string => {
+        // Codex tool patterns: match v\d+: prefix or bare codex_ prefix first.
         const normalized = name.replace(/^v\d+:/, "").toLowerCase();
         if (normalized.includes("spawn_agent")) return "spawn";
         if (normalized.includes("wait_agent")) return "wait";
@@ -138,13 +138,21 @@ function SkillArcCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode 
         if (normalized.includes("view_image")) return "image";
         if (normalized.includes("web_run")) return "web";
         if (normalized.includes("read") || normalized.includes("open")) return "read";
-        return normalized
-            .replace(/^codex_/, "")
-            .replace(/^claude_/, "")
-            .replace(/_/g, " ")
-            .replace(/:.*/, "")
-            .slice(0, 18);
+        // Codex-style names without a simple namespace:slug shape
+        if (!normalized.includes(":") || normalized.replace(/^v\d+:/, "").includes("_")) {
+            return normalized
+                .replace(/^codex_/, "")
+                .replace(/^claude_/, "")
+                .replace(/_/g, " ")
+                .slice(0, 18);
+        }
+        // Simple plugin-namespaced skill id: keep post-colon slug as the label.
+        const colonIdx = name.lastIndexOf(":");
+        return name.slice(colonIdx + 1).replace(/_/g, " ").slice(0, 18);
     };
+    // Dedupe consecutive repeats AFTER labeling (same chip text = same label).
+    const withLabels = p.skills.map((s) => ({ ...s, label: labelOf(s.name) }));
+    const arc = withLabels.filter((s, i) => i === 0 || s.label !== withLabels[i - 1]!.label);
     return (
         <div style={{ minWidth: 0 }}>
             <div style={LBL}>Skill arc</div>
@@ -169,7 +177,7 @@ function SkillArcCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode 
                                     verticalAlign: "bottom",
                                 }}
                             >
-                                {labelOf(s.name)}
+                                {s.label}
                             </span>
                         </span>
                     ))}
@@ -196,9 +204,18 @@ function ContextCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
         .join(" ");
     const peak = Math.max(...points.map((c) => c.pct));
     const last = points[points.length - 1]!.pct;
-    const compactionDots = p.compactions.slice(0, points.length).map((_, i) => {
-        const index = Math.round(((i + 1) / (p.compactions.length + 1)) * (points.length - 1));
-        return points[index]!;
+    // Position each compaction dot at its real t offset, snapped to the nearest
+    // curve point's y. Dots are only rendered when the curve is non-empty.
+    const compactionDots = points.length === 0 ? [] : p.compactions.map((comp) => {
+        const dotT = comp.t;
+        // Find the curve point nearest in t to dotT.
+        let nearest = points[0]!;
+        let minDist = Math.abs(nearest.t - dotT);
+        for (const pt of points) {
+            const d = Math.abs(pt.t - dotT);
+            if (d < minDist) { minDist = d; nearest = pt; }
+        }
+        return { x: (dotT / tMax) * width, y: yOf(nearest.pct) };
     });
 
     return (
@@ -217,7 +234,7 @@ function ContextCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
                     />
                     <path d={path} fill="none" stroke="var(--sx-chart-line)" strokeWidth={1.5} />
                     {compactionDots.map((c, i) => (
-                        <circle key={i} cx={(c.t / tMax) * width} cy={yOf(c.pct)} r={2.4} fill="var(--sx-amber-500)" />
+                        <circle key={i} cx={c.x} cy={c.y} r={2.4} fill="var(--sx-amber-500)" />
                     ))}
                 </svg>
             </div>
@@ -234,6 +251,15 @@ function BaselineFooter({ p }: { readonly p: SessionInsightsPayload }): ReactNod
 
     const delta = (label: string, r: number | null, higherIsWorse: boolean): ReactNode => {
         if (r === null) return null;
+        // When the ratio rounds to 1.0, show a neutral "≈median" instead of "1.0x down/up".
+        if (Math.round(r * 10) === 10) {
+            return (
+                <span>
+                    {" · "}{label}{" "}
+                    <span style={{ color: "var(--sx-ink-500)" }}>≈median</span>
+                </span>
+            );
+        }
         const worse = higherIsWorse ? r > 1 : r < 1;
         return (
             <span>
@@ -331,7 +357,7 @@ export function InsightPanel({ row }: { readonly row: SessionListRow }) {
             {cells.length > 0 ? (
                 <div style={{
                     display: "grid",
-                    gridTemplateColumns: "minmax(150px, 0.85fr) minmax(150px, 0.85fr) minmax(220px, 1.25fr) minmax(220px, 1.15fr)",
+                    gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
                     gap: "12px 28px",
                     marginTop: 12,
                     alignItems: "start",

--- a/apps/studio/src/components/session-insight/InsightPanel.tsx
+++ b/apps/studio/src/components/session-insight/InsightPanel.tsx
@@ -292,12 +292,12 @@ export function InsightPanel({ row }: { readonly row: SessionListRow }) {
         return <div style={{ padding: "12px 16px", fontSize: 10, color: "var(--sx-ink-300)" }}>no insight data for this session</div>;
     }
 
-    const cells = [
-        ["outcome", OutcomeCell({ p })],
-        ["loc", LocCell({ p })],
-        ["skills", SkillArcCell({ p })],
-        ["context", ContextCell({ p })],
-    ].filter((cell): cell is readonly [string, Exclude<ReactNode, null | undefined | false>] => Boolean(cell[1]));
+    const cells: Array<{ readonly key: string; readonly node: ReactNode }> = [
+        { key: "outcome", node: OutcomeCell({ p }) },
+        { key: "loc", node: LocCell({ p }) },
+        { key: "skills", node: SkillArcCell({ p }) },
+        { key: "context", node: ContextCell({ p }) },
+    ].filter((cell) => cell.node !== null && cell.node !== undefined && cell.node !== false);
 
     return (
         <div style={{ padding: "12px 16px 14px 38px", minWidth: 0 }}>
@@ -309,7 +309,7 @@ export function InsightPanel({ row }: { readonly row: SessionListRow }) {
                     gap: "14px 0",
                     marginTop: 16,
                 }}>
-                    {cells.map(([key, cell]) => <div key={key}>{cell}</div>)}
+                    {cells.map((cell) => <div key={cell.key}>{cell.node}</div>)}
                 </div>
             ) : null}
             <BaselineFooter p={p} />

--- a/apps/studio/src/components/session-insight/InsightPanel.tsx
+++ b/apps/studio/src/components/session-insight/InsightPanel.tsx
@@ -5,31 +5,36 @@ import type { SessionInsightsPayload, SessionListRow } from "@ax/lib/shared/dash
 import { StoryBar } from "./StoryBar.tsx";
 
 const LBL: CSSProperties = {
-    fontSize: 10,
+    fontSize: 9,
     color: "var(--sx-ink-500)",
     letterSpacing: "0.06em",
     textTransform: "uppercase",
     fontWeight: 600,
-    marginBottom: 8,
+    marginBottom: 6,
 };
 
 const CAP: CSSProperties = {
     fontSize: 10,
     color: "var(--sx-ink-500)",
-    marginTop: 6,
-    lineHeight: 1.5,
+    marginTop: 5,
+    lineHeight: 1.35,
     whiteSpace: "normal",
     overflowWrap: "anywhere",
 };
 
 const CHART_BAND: CSSProperties = {
-    minHeight: 36,
+    minHeight: 28,
     display: "flex",
     flexDirection: "column",
     justifyContent: "center",
 };
 
 const clamp01 = (n: number): number => Math.min(1, Math.max(0, n));
+
+const compactKind = (kind: string): string => kind
+    .replace(/_/g, " ")
+    .replace(/\btool failure\b/i, "tool fail")
+    .replace(/\buser correction\b/i, "correction");
 
 function OutcomeCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
     const hasChecks = p.checks.length > 0;
@@ -38,8 +43,9 @@ function OutcomeCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
 
     const reverted = p.commits.filter((c) => c.reverted).length;
     const durability = p.durability === null ? null : clamp01(p.durability);
+    const visibleRuns = 12;
     return (
-        <div style={{ padding: "0 14px", minWidth: 0 }}>
+        <div style={{ minWidth: 0 }}>
             <div style={LBL}>Outcome</div>
             <div style={CHART_BAND}>
                 {p.checks.map((c) => (
@@ -48,33 +54,36 @@ function OutcomeCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
                         style={{
                             display: "flex",
                             alignItems: "center",
-                            gap: 5,
+                            gap: 4,
                             fontSize: 10,
                             color: "var(--sx-ink-500)",
-                            height: 13,
+                            height: 12,
                             minWidth: 0,
                         }}
                     >
-                        <span style={{ width: 36, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flexShrink: 0 }}>
-                            {c.kind}
+                        <span title={c.kind} style={{ width: 48, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flexShrink: 0 }}>
+                            {compactKind(c.kind)}
                         </span>
-                        {c.runs.map((r, i) => (
+                        {c.runs.slice(0, visibleRuns).map((r, i) => (
                             <span
                                 key={i}
                                 title={r.ts}
                                 style={{
-                                    width: 6,
-                                    height: 6,
+                                    width: 5,
+                                    height: 5,
                                     borderRadius: "50%",
                                     flexShrink: 0,
                                     background: r.ok ? "var(--sx-green-700)" : "var(--sx-red-700)",
                                 }}
                             />
                         ))}
+                        {c.runs.length > visibleRuns ? (
+                            <span style={{ color: "var(--sx-ink-300)", marginLeft: 2 }}>+{c.runs.length - visibleRuns}</span>
+                        ) : null}
                     </div>
                 ))}
                 {durability !== null ? (
-                    <div style={{ marginTop: 5, maxWidth: 160, height: 6, borderRadius: 2, overflow: "hidden", display: "flex" }}>
+                    <div style={{ marginTop: 5, maxWidth: 130, height: 5, borderRadius: 2, overflow: "hidden", display: "flex" }}>
                         <span style={{ width: `${Math.round(durability * 100)}%`, background: "var(--sx-green-300)" }} />
                         <span style={{ flex: 1, background: "var(--sx-red-300)" }} />
                     </div>
@@ -100,12 +109,12 @@ function LocCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
     const total = Math.max(1, added + removed);
     const fmt = (n: number): string => n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
     return (
-        <div style={{ padding: "0 14px", minWidth: 0 }}>
+        <div style={{ minWidth: 0 }}>
             <div style={LBL}>Delta LOC</div>
             <div style={CHART_BAND}>
-                <div style={{ display: "flex", alignItems: "center", maxWidth: 180, minWidth: 0 }}>
-                    <span style={{ width: `${(added / total) * 100}%`, height: 6, background: "var(--sx-green-300)", borderRadius: 1 }} />
-                    <span style={{ width: `${(removed / total) * 100}%`, height: 6, background: "var(--sx-red-300)", borderRadius: 1, marginLeft: 2 }} />
+                <div style={{ display: "flex", alignItems: "center", maxWidth: 150, minWidth: 0 }}>
+                    <span style={{ width: `${(added / total) * 100}%`, height: 5, background: "var(--sx-green-300)", borderRadius: 1 }} />
+                    <span style={{ width: `${(removed / total) * 100}%`, height: 5, background: "var(--sx-red-300)", borderRadius: 1, marginLeft: 2 }} />
                 </div>
             </div>
             <div style={CAP}>
@@ -119,22 +128,39 @@ function LocCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
 function SkillArcCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
     if (p.skills.length === 0) return null;
     const arc = p.skills.filter((s, i) => i === 0 || s.name !== p.skills[i - 1]!.name);
+    const labelOf = (name: string): string => {
+        const normalized = name.replace(/^v\d+:/, "").toLowerCase();
+        if (normalized.includes("spawn_agent")) return "spawn";
+        if (normalized.includes("wait_agent")) return "wait";
+        if (normalized.includes("exec_command")) return "exec";
+        if (normalized.includes("apply_patch")) return "patch";
+        if (normalized.includes("update_plan")) return "plan";
+        if (normalized.includes("view_image")) return "image";
+        if (normalized.includes("web_run")) return "web";
+        if (normalized.includes("read") || normalized.includes("open")) return "read";
+        return normalized
+            .replace(/^codex_/, "")
+            .replace(/^claude_/, "")
+            .replace(/_/g, " ")
+            .replace(/:.*/, "")
+            .slice(0, 18);
+    };
     return (
-        <div style={{ padding: "0 14px", minWidth: 0 }}>
+        <div style={{ minWidth: 0 }}>
             <div style={LBL}>Skill arc</div>
             <div style={CHART_BAND}>
-                <div style={{ lineHeight: 1.7, minWidth: 0, overflow: "hidden" }}>
-                    {arc.slice(0, 8).map((s, i) => (
+                <div style={{ lineHeight: 1.45, minWidth: 0, overflow: "hidden", whiteSpace: "nowrap", textOverflow: "ellipsis" }}>
+                    {arc.slice(0, 5).map((s, i) => (
                         <span key={`${s.name}-${i}`}>
-                            {i > 0 ? <span style={{ color: "var(--sx-ink-300)" }}> -&gt; </span> : null}
+                            {i > 0 ? <span style={{ color: "var(--sx-ink-300)" }}> → </span> : null}
                             <span
                                 title={s.name}
                                 style={{
                                     display: "inline-block",
-                                    maxWidth: "100%",
+                                    maxWidth: 130,
                                     fontSize: 10,
-                                    padding: "1px 7px",
-                                    borderRadius: 8,
+                                    padding: "1px 5px",
+                                    borderRadius: 3,
                                     background: "var(--sx-line-100)",
                                     color: "var(--sx-ink-600)",
                                     overflow: "hidden",
@@ -143,11 +169,11 @@ function SkillArcCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode 
                                     verticalAlign: "bottom",
                                 }}
                             >
-                                {s.name}
+                                {labelOf(s.name)}
                             </span>
                         </span>
                     ))}
-                    {arc.length > 8 ? <span style={{ color: "var(--sx-ink-300)" }}> +{arc.length - 8}</span> : null}
+                    {arc.length > 5 ? <span style={{ color: "var(--sx-ink-300)" }}> +{arc.length - 5}</span> : null}
                 </div>
             </div>
             <div style={CAP}>{arc.length} skill{arc.length === 1 ? "" : "s"}</div>
@@ -176,10 +202,10 @@ function ContextCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
     });
 
     return (
-        <div style={{ padding: "0 14px", minWidth: 0 }}>
+        <div style={{ minWidth: 0 }}>
             <div style={LBL}>Context</div>
             <div style={CHART_BAND}>
-                <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" aria-hidden>
+                <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" aria-hidden style={{ maxWidth: 260 }}>
                     <line
                         x1={0}
                         y1={yOf(0.9)}
@@ -222,7 +248,7 @@ function BaselineFooter({ p }: { readonly p: SessionInsightsPayload }): ReactNod
     return (
         <div style={{
             marginTop: 14,
-            paddingTop: 8,
+            paddingTop: 7,
             borderTop: "1px dashed var(--sx-line-200)",
             fontSize: 10,
             color: "var(--sx-ink-500)",
@@ -300,14 +326,15 @@ export function InsightPanel({ row }: { readonly row: SessionListRow }) {
     ].filter((cell) => cell.node !== null && cell.node !== undefined && cell.node !== false);
 
     return (
-        <div style={{ padding: "12px 16px 14px 38px", minWidth: 0 }}>
+        <div style={{ padding: "10px 16px 10px 38px", minWidth: 0 }}>
             <StoryBar insights={p} startedAt={row.started_at} endedAt={row.ended_at} />
             {cells.length > 0 ? (
                 <div style={{
                     display: "grid",
-                    gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
-                    gap: "14px 0",
-                    marginTop: 16,
+                    gridTemplateColumns: "minmax(150px, 0.85fr) minmax(150px, 0.85fr) minmax(220px, 1.25fr) minmax(220px, 1.15fr)",
+                    gap: "12px 28px",
+                    marginTop: 12,
+                    alignItems: "start",
                 }}>
                     {cells.map((cell) => <div key={cell.key}>{cell.node}</div>)}
                 </div>

--- a/apps/studio/src/components/session-insight/InsightPanel.tsx
+++ b/apps/studio/src/components/session-insight/InsightPanel.tsx
@@ -1,0 +1,318 @@
+import type { CSSProperties, ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../api.ts";
+import type { SessionInsightsPayload, SessionListRow } from "@ax/lib/shared/dashboard-types";
+import { StoryBar } from "./StoryBar.tsx";
+
+const LBL: CSSProperties = {
+    fontSize: 10,
+    color: "var(--sx-ink-500)",
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    fontWeight: 600,
+    marginBottom: 8,
+};
+
+const CAP: CSSProperties = {
+    fontSize: 10,
+    color: "var(--sx-ink-500)",
+    marginTop: 6,
+    lineHeight: 1.5,
+    whiteSpace: "normal",
+    overflowWrap: "anywhere",
+};
+
+const CHART_BAND: CSSProperties = {
+    minHeight: 36,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+};
+
+const clamp01 = (n: number): number => Math.min(1, Math.max(0, n));
+
+function OutcomeCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
+    const hasChecks = p.checks.length > 0;
+    const hasCommits = p.commits.length > 0;
+    if (!hasChecks && !hasCommits && p.durability === null) return null;
+
+    const reverted = p.commits.filter((c) => c.reverted).length;
+    const durability = p.durability === null ? null : clamp01(p.durability);
+    return (
+        <div style={{ padding: "0 14px", minWidth: 0 }}>
+            <div style={LBL}>Outcome</div>
+            <div style={CHART_BAND}>
+                {p.checks.map((c) => (
+                    <div
+                        key={c.kind}
+                        style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 5,
+                            fontSize: 10,
+                            color: "var(--sx-ink-500)",
+                            height: 13,
+                            minWidth: 0,
+                        }}
+                    >
+                        <span style={{ width: 36, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flexShrink: 0 }}>
+                            {c.kind}
+                        </span>
+                        {c.runs.map((r, i) => (
+                            <span
+                                key={i}
+                                title={r.ts}
+                                style={{
+                                    width: 6,
+                                    height: 6,
+                                    borderRadius: "50%",
+                                    flexShrink: 0,
+                                    background: r.ok ? "var(--sx-green-700)" : "var(--sx-red-700)",
+                                }}
+                            />
+                        ))}
+                    </div>
+                ))}
+                {durability !== null ? (
+                    <div style={{ marginTop: 5, maxWidth: 160, height: 6, borderRadius: 2, overflow: "hidden", display: "flex" }}>
+                        <span style={{ width: `${Math.round(durability * 100)}%`, background: "var(--sx-green-300)" }} />
+                        <span style={{ flex: 1, background: "var(--sx-red-300)" }} />
+                    </div>
+                ) : null}
+            </div>
+            <div style={CAP}>
+                {hasCommits ? (
+                    <>
+                        {p.commits.length} commits
+                        {reverted > 0 ? <span style={{ color: "var(--sx-red-700)" }}> · {reverted} reverted</span> : null}
+                    </>
+                ) : "no commits"}
+                {durability !== null ? <> · durability {durability.toFixed(1)}</> : null}
+            </div>
+        </div>
+    );
+}
+
+function LocCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
+    if (!p.loc || (p.loc.added === 0 && p.loc.removed === 0)) return null;
+    const added = Math.max(0, p.loc.added);
+    const removed = Math.max(0, p.loc.removed);
+    const total = Math.max(1, added + removed);
+    const fmt = (n: number): string => n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+    return (
+        <div style={{ padding: "0 14px", minWidth: 0 }}>
+            <div style={LBL}>Delta LOC</div>
+            <div style={CHART_BAND}>
+                <div style={{ display: "flex", alignItems: "center", maxWidth: 180, minWidth: 0 }}>
+                    <span style={{ width: `${(added / total) * 100}%`, height: 6, background: "var(--sx-green-300)", borderRadius: 1 }} />
+                    <span style={{ width: `${(removed / total) * 100}%`, height: 6, background: "var(--sx-red-300)", borderRadius: 1, marginLeft: 2 }} />
+                </div>
+            </div>
+            <div style={CAP}>
+                <span style={{ color: "var(--sx-green-700)" }}>+{fmt(added)}</span>{" "}
+                <span style={{ color: "var(--sx-red-700)" }}>-{fmt(removed)}</span>
+            </div>
+        </div>
+    );
+}
+
+function SkillArcCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
+    if (p.skills.length === 0) return null;
+    const arc = p.skills.filter((s, i) => i === 0 || s.name !== p.skills[i - 1]!.name);
+    return (
+        <div style={{ padding: "0 14px", minWidth: 0 }}>
+            <div style={LBL}>Skill arc</div>
+            <div style={CHART_BAND}>
+                <div style={{ lineHeight: 1.7, minWidth: 0, overflow: "hidden" }}>
+                    {arc.slice(0, 8).map((s, i) => (
+                        <span key={`${s.name}-${i}`}>
+                            {i > 0 ? <span style={{ color: "var(--sx-ink-300)" }}> -&gt; </span> : null}
+                            <span
+                                title={s.name}
+                                style={{
+                                    display: "inline-block",
+                                    maxWidth: "100%",
+                                    fontSize: 10,
+                                    padding: "1px 7px",
+                                    borderRadius: 8,
+                                    background: "var(--sx-line-100)",
+                                    color: "var(--sx-ink-600)",
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                    whiteSpace: "nowrap",
+                                    verticalAlign: "bottom",
+                                }}
+                            >
+                                {s.name}
+                            </span>
+                        </span>
+                    ))}
+                    {arc.length > 8 ? <span style={{ color: "var(--sx-ink-300)" }}> +{arc.length - 8}</span> : null}
+                </div>
+            </div>
+            <div style={CAP}>{arc.length} skill{arc.length === 1 ? "" : "s"}</div>
+        </div>
+    );
+}
+
+function ContextCell({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
+    const points = p.context_curve
+        .filter((c) => Number.isFinite(c.t) && Number.isFinite(c.pct))
+        .map((c) => ({ t: Math.max(0, c.t), pct: clamp01(c.pct) }));
+    if (points.length < 2) return null;
+
+    const tMax = Math.max(...points.map((c) => c.t), 1);
+    const width = 160;
+    const height = 32;
+    const yOf = (pct: number): number => height - 2 - pct * (height - 6);
+    const path = points
+        .map((c, i) => `${i === 0 ? "M" : "L"}${((c.t / tMax) * width).toFixed(1)},${yOf(c.pct).toFixed(1)}`)
+        .join(" ");
+    const peak = Math.max(...points.map((c) => c.pct));
+    const last = points[points.length - 1]!.pct;
+    const compactionDots = p.compactions.slice(0, points.length).map((_, i) => {
+        const index = Math.round(((i + 1) / (p.compactions.length + 1)) * (points.length - 1));
+        return points[index]!;
+    });
+
+    return (
+        <div style={{ padding: "0 14px", minWidth: 0 }}>
+            <div style={LBL}>Context</div>
+            <div style={CHART_BAND}>
+                <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" aria-hidden>
+                    <line
+                        x1={0}
+                        y1={yOf(0.9)}
+                        x2={width}
+                        y2={yOf(0.9)}
+                        stroke="var(--sx-line-200)"
+                        strokeWidth={1}
+                        strokeDasharray="3,3"
+                    />
+                    <path d={path} fill="none" stroke="var(--sx-chart-line)" strokeWidth={1.5} />
+                    {compactionDots.map((c, i) => (
+                        <circle key={i} cx={(c.t / tMax) * width} cy={yOf(c.pct)} r={2.4} fill="var(--sx-amber-500)" />
+                    ))}
+                </svg>
+            </div>
+            <div style={CAP}>
+                {p.compactions.length} compaction{p.compactions.length === 1 ? "" : "s"} · peak {Math.round(peak * 100)}% · ends {Math.round(last * 100)}%
+            </div>
+        </div>
+    );
+}
+
+function BaselineFooter({ p }: { readonly p: SessionInsightsPayload }): ReactNode {
+    const { cost_ratio, friction_ratio, land_ratio, cache_pct } = p.baseline;
+    if (cost_ratio === null && friction_ratio === null && land_ratio === null && cache_pct === null) return null;
+
+    const delta = (label: string, r: number | null, higherIsWorse: boolean): ReactNode => {
+        if (r === null) return null;
+        const worse = higherIsWorse ? r > 1 : r < 1;
+        return (
+            <span>
+                {" · "}{label}{" "}
+                <span style={{ color: worse ? "var(--sx-red-700)" : "var(--sx-green-700)" }}>
+                    {r.toFixed(1)}x{r > 1 ? " up" : " down"}
+                </span>
+            </span>
+        );
+    };
+
+    return (
+        <div style={{
+            marginTop: 14,
+            paddingTop: 8,
+            borderTop: "1px dashed var(--sx-line-200)",
+            fontSize: 10,
+            color: "var(--sx-ink-500)",
+            textAlign: "right",
+            whiteSpace: "normal",
+            overflowWrap: "anywhere",
+        }}>
+            vs 30d median
+            {delta("cost", cost_ratio, true)}
+            {delta("friction", friction_ratio, true)}
+            {delta("landed", land_ratio, true)}
+            {cache_pct !== null ? <span> · cache {Math.round(clamp01(cache_pct) * 100)}%</span> : null}
+        </div>
+    );
+}
+
+/** Accordion body for an expanded sessions-list row. Fetches lazily on first
+ * expand; TanStack Query caches per session id. */
+export function InsightPanel({ row }: { readonly row: SessionListRow }) {
+    const q = useQuery({
+        queryKey: ["session-insights", row.id],
+        queryFn: () => api.sessionInsights(row.id),
+        staleTime: 5 * 60_000,
+    });
+
+    if (q.isLoading) {
+        return <div style={{ padding: "12px 16px", fontSize: 10, color: "var(--sx-ink-300)" }}>loading insights…</div>;
+    }
+
+    if (q.error || !q.data) {
+        return (
+            <div style={{ padding: "12px 16px", fontSize: 10, color: "var(--sx-ink-300)" }}>
+                failed to load insights ·{" "}
+                <button
+                    onClick={() => void q.refetch()}
+                    style={{
+                        border: "none",
+                        background: "transparent",
+                        color: "var(--sx-ink-500)",
+                        cursor: "pointer",
+                        fontSize: 10,
+                        textDecoration: "underline",
+                        padding: 0,
+                    }}
+                >
+                    retry
+                </button>
+            </div>
+        );
+    }
+
+    const p = q.data;
+    const hasBaseline = Object.values(p.baseline).some((v) => v !== null);
+    const empty = p.phases.length === 0
+        && p.friction_ticks.length === 0
+        && p.commits.length === 0
+        && p.subagent_spans.length === 0
+        && p.checks.length === 0
+        && p.loc === null
+        && p.durability === null
+        && p.delegation_ratio === null
+        && p.skills.length === 0
+        && p.context_curve.length < 2
+        && p.compactions.length === 0
+        && !hasBaseline;
+    if (empty) {
+        return <div style={{ padding: "12px 16px", fontSize: 10, color: "var(--sx-ink-300)" }}>no insight data for this session</div>;
+    }
+
+    const cells = [
+        ["outcome", OutcomeCell({ p })],
+        ["loc", LocCell({ p })],
+        ["skills", SkillArcCell({ p })],
+        ["context", ContextCell({ p })],
+    ].filter((cell): cell is readonly [string, Exclude<ReactNode, null | undefined | false>] => Boolean(cell[1]));
+
+    return (
+        <div style={{ padding: "12px 16px 14px 38px", minWidth: 0 }}>
+            <StoryBar insights={p} startedAt={row.started_at} endedAt={row.ended_at} />
+            {cells.length > 0 ? (
+                <div style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+                    gap: "14px 0",
+                    marginTop: 16,
+                }}>
+                    {cells.map(([key, cell]) => <div key={key}>{cell}</div>)}
+                </div>
+            ) : null}
+            <BaselineFooter p={p} />
+        </div>
+    );
+}

--- a/apps/studio/src/components/session-insight/SignalBadge.tsx
+++ b/apps/studio/src/components/session-insight/SignalBadge.tsx
@@ -1,0 +1,20 @@
+/** Rightmost triage badge: clean (green) / friction N (red) / – (no data). */
+export function SignalBadge({ signal, friction }: {
+    readonly signal: "clean" | "friction" | null;
+    readonly friction: number | null;
+}) {
+    if (signal === null) return <span style={{ color: "var(--sx-ink-300)" }}>–</span>;
+    const warn = signal === "friction";
+    return (
+        <span style={{
+            fontSize: 10,
+            fontWeight: 600,
+            padding: "1px 6px",
+            borderRadius: 2,
+            background: warn ? "var(--sx-red-100)" : "var(--sx-green-100)",
+            color: warn ? "var(--sx-red-700)" : "var(--sx-green-700)",
+        }}>
+            {warn ? `friction ${friction ?? ""}` : "clean"}
+        </span>
+    );
+}

--- a/apps/studio/src/components/session-insight/StoryBar.tsx
+++ b/apps/studio/src/components/session-insight/StoryBar.tsx
@@ -51,26 +51,28 @@ export function StoryBar({ insights, startedAt, endedAt }: {
     const reverted = insights.commits.filter((c) => c.reverted).length;
     const landed = insights.commits.length - reverted;
     const hasLanes = insights.subagent_spans.some((s) => s.started_at !== null);
+    const visibleFriction = insights.friction_ticks.slice(0, 18);
+    const visibleSubagents = insights.subagent_spans.filter((s) => s.started_at !== null).slice(0, 28);
 
     return (
-        <div style={{ maxWidth: 760, minWidth: 0 }}>
+        <div style={{ maxWidth: 720, minWidth: 0 }}>
             <div style={{
-                fontSize: 10,
+                fontSize: 9,
                 color: "var(--sx-ink-500)",
                 letterSpacing: "0.06em",
                 textTransform: "uppercase",
                 fontWeight: 600,
-                marginBottom: 8,
+                marginBottom: 6,
             }}>
                 Story
             </div>
-            <div style={{ position: "relative", width: "100%", height: hasLanes ? 36 : 24 }}>
+            <div style={{ position: "relative", width: "100%", height: hasLanes ? 24 : 18 }}>
                 <span style={{
                     position: "absolute",
-                    top: 1,
+                    top: 0,
                     left: 0,
                     right: 0,
-                    height: 10,
+                    height: 7,
                     background: "var(--sx-phase-idle)",
                 }} />
                 {insights.phases.map((p, i) => {
@@ -83,8 +85,8 @@ export function StoryBar({ insights, startedAt, endedAt }: {
                             title={`${p.phase} ${fmtMs(p.duration_ms)}`}
                             style={{
                                 position: "absolute",
-                                top: 1,
-                                height: 10,
+                                top: 0,
+                                height: 7,
                                 left: `${left}%`,
                                 width: `${Math.max(0.5, right - left)}%`,
                                 background: PHASE_COLOR[p.phase] ?? "var(--sx-phase-exec)",
@@ -92,7 +94,7 @@ export function StoryBar({ insights, startedAt, endedAt }: {
                         />
                     );
                 })}
-                {insights.friction_ticks.map((f, i) => {
+                {visibleFriction.map((f, i) => {
                     const left = pct(f.ts);
                     if (left === null) return null;
                     return (
@@ -101,11 +103,12 @@ export function StoryBar({ insights, startedAt, endedAt }: {
                             title={f.kind}
                             style={{
                                 position: "absolute",
-                                top: -3,
+                                top: -2,
                                 width: 2,
-                                height: 18,
+                                height: 12,
                                 left: `${left}%`,
                                 background: "var(--sx-red-700)",
+                                opacity: 0.82,
                             }}
                         />
                     );
@@ -119,7 +122,7 @@ export function StoryBar({ insights, startedAt, endedAt }: {
                             title={`${c.sha} (reverted)`}
                             style={{
                                 position: "absolute",
-                                top: 13,
+                                top: 8,
                                 left: `${left}%`,
                                 transform: "translateX(-50%)",
                                 color: "var(--sx-red-700)",
@@ -136,9 +139,9 @@ export function StoryBar({ insights, startedAt, endedAt }: {
                             title={c.sha}
                             style={{
                                 position: "absolute",
-                                top: 15,
-                                width: 7,
-                                height: 7,
+                                top: 10,
+                                width: 6,
+                                height: 6,
                                 borderRadius: "50%",
                                 left: `${left}%`,
                                 transform: "translateX(-50%)",
@@ -147,7 +150,7 @@ export function StoryBar({ insights, startedAt, endedAt }: {
                         />
                     );
                 })}
-                {insights.subagent_spans.map((s, i) => {
+                {visibleSubagents.map((s, i) => {
                     const left = pct(s.started_at);
                     if (left === null) return null;
                     const right = pct(s.ended_at) ?? 100;
@@ -157,12 +160,13 @@ export function StoryBar({ insights, startedAt, endedAt }: {
                             title={s.id}
                             style={{
                                 position: "absolute",
-                                top: 27,
-                                height: 5,
+                                top: 19,
+                                height: 4,
                                 borderRadius: 2,
                                 left: `${left}%`,
                                 width: `${Math.max(1, right - left)}%`,
                                 background: "var(--sx-violet-500)",
+                                opacity: 0.72,
                             }}
                         />
                     );
@@ -171,12 +175,12 @@ export function StoryBar({ insights, startedAt, endedAt }: {
             <div style={{
                 fontSize: 10,
                 color: "var(--sx-ink-500)",
-                marginTop: 6,
-                lineHeight: 1.5,
+                marginTop: 4,
+                lineHeight: 1.35,
                 whiteSpace: "normal",
                 overflowWrap: "anywhere",
             }}>
-                {Array.from(phaseTotals.entries()).map(([k, v]) => `${k} ${fmtMs(v)}`).join(" · ")}
+                {Array.from(phaseTotals.entries()).slice(0, 3).map(([k, v]) => `${k} ${fmtMs(v)}`).join(" · ")}
                 {idleMs > 60_000 ? <span style={{ color: "var(--sx-ink-300)" }}> · idle {fmtMs(idleMs)}</span> : null}
                 {insights.friction_ticks.length > 0
                     ? <span style={{ color: "var(--sx-red-700)" }}> · x{insights.friction_ticks.length} corrections</span>

--- a/apps/studio/src/components/session-insight/StoryBar.tsx
+++ b/apps/studio/src/components/session-insight/StoryBar.tsx
@@ -181,6 +181,7 @@ export function StoryBar({ insights, startedAt, endedAt }: {
                 overflowWrap: "anywhere",
             }}>
                 {Array.from(phaseTotals.entries()).slice(0, 3).map(([k, v]) => `${k} ${fmtMs(v)}`).join(" · ")}
+                {phaseTotals.size > 3 ? <span style={{ color: "var(--sx-ink-300)" }}> +{phaseTotals.size - 3} more</span> : null}
                 {idleMs > 60_000 ? <span style={{ color: "var(--sx-ink-300)" }}> · idle {fmtMs(idleMs)}</span> : null}
                 {insights.friction_ticks.length > 0
                     ? <span style={{ color: "var(--sx-red-700)" }}> · x{insights.friction_ticks.length} corrections</span>

--- a/apps/studio/src/components/session-insight/StoryBar.tsx
+++ b/apps/studio/src/components/session-insight/StoryBar.tsx
@@ -1,0 +1,199 @@
+import type { SessionInsightsPayload } from "@ax/lib/shared/dashboard-types";
+
+const PHASE_COLOR: Record<string, string> = {
+    plan: "var(--sx-phase-plan)",
+    execute: "var(--sx-phase-exec)",
+    exec: "var(--sx-phase-exec)",
+    review: "var(--sx-phase-review)",
+};
+
+const fmtMs = (ms: number): string =>
+    ms < 60_000 ? `${Math.round(ms / 1000)}s`
+        : ms < 3_600_000 ? `${Math.round(ms / 60_000)}m`
+            : `${(ms / 3_600_000).toFixed(1)}h`;
+
+const timeOf = (ts: string | null): number | null => {
+    if (!ts) return null;
+    const t = new Date(ts).getTime();
+    return Number.isFinite(t) ? t : null;
+};
+
+const pctOf = (t: number, t0: number, span: number): number =>
+    Math.min(100, Math.max(0, ((t - t0) / span) * 100));
+
+/** Band 1 story strip: phase segments, friction ticks, commit markers, and
+ * subagent lanes on one session-time axis. Idle is the uncovered track. */
+export function StoryBar({ insights, startedAt, endedAt }: {
+    readonly insights: SessionInsightsPayload;
+    readonly startedAt: string | null;
+    readonly endedAt: string | null;
+}) {
+    const phaseStarts = insights.phases.map((p) => timeOf(p.start_ts)).filter((t): t is number => t !== null);
+    const phaseEnds = insights.phases.map((p) => timeOf(p.end_ts)).filter((t): t is number => t !== null);
+    const start = timeOf(startedAt) ?? (phaseStarts.length > 0 ? Math.min(...phaseStarts) : null);
+    const end = timeOf(endedAt) ?? (phaseEnds.length > 0 ? Math.max(...phaseEnds) : null);
+    if (start === null || end === null || end <= start) return null;
+
+    const span = end - start;
+    const pct = (ts: string | null): number | null => {
+        const t = timeOf(ts);
+        return t === null ? null : pctOf(t, start, span);
+    };
+
+    const phaseTotals = new Map<string, number>();
+    for (const p of insights.phases) {
+        if (Number.isFinite(p.duration_ms) && p.duration_ms > 0) {
+            phaseTotals.set(p.phase, (phaseTotals.get(p.phase) ?? 0) + p.duration_ms);
+        }
+    }
+    const covered = Array.from(phaseTotals.values()).reduce((sum, ms) => sum + ms, 0);
+    const idleMs = Math.max(0, span - covered);
+    const reverted = insights.commits.filter((c) => c.reverted).length;
+    const landed = insights.commits.length - reverted;
+    const hasLanes = insights.subagent_spans.some((s) => s.started_at !== null);
+
+    return (
+        <div style={{ maxWidth: 760, minWidth: 0 }}>
+            <div style={{
+                fontSize: 10,
+                color: "var(--sx-ink-500)",
+                letterSpacing: "0.06em",
+                textTransform: "uppercase",
+                fontWeight: 600,
+                marginBottom: 8,
+            }}>
+                Story
+            </div>
+            <div style={{ position: "relative", width: "100%", height: hasLanes ? 36 : 24 }}>
+                <span style={{
+                    position: "absolute",
+                    top: 1,
+                    left: 0,
+                    right: 0,
+                    height: 10,
+                    background: "var(--sx-phase-idle)",
+                }} />
+                {insights.phases.map((p, i) => {
+                    const left = pct(p.start_ts);
+                    const right = pct(p.end_ts);
+                    if (left === null || right === null) return null;
+                    return (
+                        <span
+                            key={`${p.phase}-${i}`}
+                            title={`${p.phase} ${fmtMs(p.duration_ms)}`}
+                            style={{
+                                position: "absolute",
+                                top: 1,
+                                height: 10,
+                                left: `${left}%`,
+                                width: `${Math.max(0.5, right - left)}%`,
+                                background: PHASE_COLOR[p.phase] ?? "var(--sx-phase-exec)",
+                            }}
+                        />
+                    );
+                })}
+                {insights.friction_ticks.map((f, i) => {
+                    const left = pct(f.ts);
+                    if (left === null) return null;
+                    return (
+                        <span
+                            key={`f${i}`}
+                            title={f.kind}
+                            style={{
+                                position: "absolute",
+                                top: -3,
+                                width: 2,
+                                height: 18,
+                                left: `${left}%`,
+                                background: "var(--sx-red-700)",
+                            }}
+                        />
+                    );
+                })}
+                {insights.commits.map((c, i) => {
+                    const left = pct(c.ts);
+                    if (left === null) return null;
+                    return c.reverted ? (
+                        <span
+                            key={`c${i}`}
+                            title={`${c.sha} (reverted)`}
+                            style={{
+                                position: "absolute",
+                                top: 13,
+                                left: `${left}%`,
+                                transform: "translateX(-50%)",
+                                color: "var(--sx-red-700)",
+                                fontSize: 9,
+                                fontWeight: 700,
+                                lineHeight: 1,
+                            }}
+                        >
+                            x
+                        </span>
+                    ) : (
+                        <span
+                            key={`c${i}`}
+                            title={c.sha}
+                            style={{
+                                position: "absolute",
+                                top: 15,
+                                width: 7,
+                                height: 7,
+                                borderRadius: "50%",
+                                left: `${left}%`,
+                                transform: "translateX(-50%)",
+                                background: "var(--sx-green-700)",
+                            }}
+                        />
+                    );
+                })}
+                {insights.subagent_spans.map((s, i) => {
+                    const left = pct(s.started_at);
+                    if (left === null) return null;
+                    const right = pct(s.ended_at) ?? 100;
+                    return (
+                        <span
+                            key={`a${i}`}
+                            title={s.id}
+                            style={{
+                                position: "absolute",
+                                top: 27,
+                                height: 5,
+                                borderRadius: 2,
+                                left: `${left}%`,
+                                width: `${Math.max(1, right - left)}%`,
+                                background: "var(--sx-violet-500)",
+                            }}
+                        />
+                    );
+                })}
+            </div>
+            <div style={{
+                fontSize: 10,
+                color: "var(--sx-ink-500)",
+                marginTop: 6,
+                lineHeight: 1.5,
+                whiteSpace: "normal",
+                overflowWrap: "anywhere",
+            }}>
+                {Array.from(phaseTotals.entries()).map(([k, v]) => `${k} ${fmtMs(v)}`).join(" · ")}
+                {idleMs > 60_000 ? <span style={{ color: "var(--sx-ink-300)" }}> · idle {fmtMs(idleMs)}</span> : null}
+                {insights.friction_ticks.length > 0
+                    ? <span style={{ color: "var(--sx-red-700)" }}> · x{insights.friction_ticks.length} corrections</span>
+                    : null}
+                {insights.commits.length > 0
+                    ? <span style={{ color: "var(--sx-green-700)" }}> · {landed} commits</span>
+                    : null}
+                {reverted > 0 ? <span style={{ color: "var(--sx-red-700)" }}> · x{reverted} reverted</span> : null}
+                {insights.subagent_spans.length > 0
+                    ? (
+                        <span style={{ color: "var(--sx-violet-700)" }}>
+                            {" · "}{insights.subagent_spans.length} subagents
+                            {insights.delegation_ratio !== null ? ` (${Math.round(insights.delegation_ratio * 100)}% delegated)` : ""}
+                        </span>
+                    )
+                    : null}
+            </div>
+        </div>
+    );
+}

--- a/apps/studio/src/components/session-insight/StoryStrip.tsx
+++ b/apps/studio/src/components/session-insight/StoryStrip.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../api.ts";
+import type { SessionInsightsPayload } from "@ax/lib/shared/dashboard-types";
+
+// --- inline IntersectionObserver hook (latch - never goes false after true) ---
+function useInView(rootMargin = "200px"): [boolean, React.RefObject<HTMLSpanElement | null>] {
+    const [inView, setInView] = useState(false);
+    const ref = useRef<HTMLSpanElement | null>(null);
+    useEffect(() => {
+        if (inView) return; // already latched - no observer needed
+        const el = ref.current;
+        if (!el) return;
+        const obs = new IntersectionObserver(
+            (entries) => {
+                for (const e of entries) {
+                    if (e.isIntersecting) {
+                        setInView(true);
+                        obs.disconnect();
+                    }
+                }
+            },
+            { rootMargin },
+        );
+        obs.observe(el);
+        return () => obs.disconnect();
+    }, [inView, rootMargin]);
+    return [inView, ref];
+}
+
+// --- timeline helpers --------------------------------------------------------
+
+const PHASE_COLOR: Record<string, string> = {
+    plan: "var(--sx-phase-plan)",
+    execute: "var(--sx-phase-exec)",
+    exec: "var(--sx-phase-exec)",
+    review: "var(--sx-phase-review)",
+};
+
+const timeOf = (ts: string | null): number | null => {
+    if (!ts) return null;
+    const t = new Date(ts).getTime();
+    return Number.isFinite(t) ? t : null;
+};
+
+const pctOf = (t: number, t0: number, span: number): number =>
+    Math.min(100, Math.max(0, ((t - t0) / span) * 100));
+
+const fmtMs = (ms: number): string =>
+    ms < 60_000
+        ? `${Math.round(ms / 1000)}s`
+        : ms < 3_600_000
+            ? `${Math.round(ms / 60_000)}m`
+            : `${(ms / 3_600_000).toFixed(1)}h`;
+
+function buildTitle(insights: SessionInsightsPayload): string {
+    const phaseTotals = new Map<string, number>();
+    for (const p of insights.phases) {
+        if (Number.isFinite(p.duration_ms) && p.duration_ms > 0) {
+            phaseTotals.set(p.phase, (phaseTotals.get(p.phase) ?? 0) + p.duration_ms);
+        }
+    }
+    const parts: string[] = [];
+    for (const [k, v] of phaseTotals) {
+        parts.push(`${k} ${fmtMs(v)}`);
+    }
+    const reverted = insights.commits.filter((c) => c.reverted).length;
+    const landed = insights.commits.length - reverted;
+    if (reverted > 0) parts.push(`✕${reverted}`);
+    if (landed > 0) parts.push(`●${landed}`);
+    if (insights.subagent_spans.length > 0) parts.push(`${insights.subagent_spans.length} subagents`);
+    return parts.join(" · ") || "no data";
+}
+
+// --- main renderers ----------------------------------------------------------
+
+function renderTimeline(
+    insights: SessionInsightsPayload,
+    startedAt: string | null,
+    endedAt: string | null,
+    variant: "mini" | "underline",
+): React.ReactNode {
+    const phaseStarts = insights.phases.map((p) => timeOf(p.start_ts)).filter((t): t is number => t !== null);
+    const phaseEnds = insights.phases.map((p) => timeOf(p.end_ts)).filter((t): t is number => t !== null);
+    const t0 = timeOf(startedAt) ?? (phaseStarts.length > 0 ? Math.min(...phaseStarts) : null);
+    const t1 = timeOf(endedAt) ?? (phaseEnds.length > 0 ? Math.max(...phaseEnds) : null);
+
+    const noData =
+        insights.phases.length === 0 &&
+        insights.commits.length === 0 &&
+        insights.subagent_spans.length === 0;
+
+    const trackH = variant === "mini" ? 8 : 5;
+    const trackStyle: React.CSSProperties = {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        height: trackH,
+        background: "var(--sx-phase-idle)",
+    };
+
+    if (noData || t0 === null || t1 === null || t1 <= t0) {
+        // fallback: single idle-colored bar or dim dash
+        if (variant === "mini") {
+            return (
+                <span style={{ color: "var(--sx-ink-300)", fontSize: 10 }}>–</span>
+            );
+        }
+        return <span style={trackStyle} />;
+    }
+
+    const span = t1 - t0;
+    const pct = (ts: string | null): number | null => {
+        const t = timeOf(ts);
+        return t === null ? null : pctOf(t, t0, span);
+    };
+
+    const hasLanes = variant === "underline" && insights.subagent_spans.some((s) => s.started_at !== null);
+    const wrapperH = variant === "mini" ? 8 : (hasLanes ? 8 : 5);
+    const maxFriction = 12;
+    const visibleFriction = insights.friction_ticks.slice(0, maxFriction);
+
+    // For underline subagent lane: merge all spans into one
+    let laneLeft: number | null = null;
+    let laneRight: number | null = null;
+    if (hasLanes) {
+        for (const s of insights.subagent_spans) {
+            if (!s.started_at) continue;
+            const l = pct(s.started_at);
+            const r = pct(s.ended_at) ?? 100;
+            if (l !== null) {
+                laneLeft = laneLeft === null ? l : Math.min(laneLeft, l);
+                laneRight = laneRight === null ? r : Math.max(laneRight, r);
+            }
+        }
+    }
+
+    return (
+        <>
+            {/* idle track */}
+            <span style={trackStyle} />
+            {/* phase segments */}
+            {insights.phases.map((p, i) => {
+                const left = pct(p.start_ts);
+                const right = pct(p.end_ts);
+                if (left === null || right === null) return null;
+                return (
+                    <span
+                        key={`ph-${i}`}
+                        title={`${p.phase} ${fmtMs(p.duration_ms)}`}
+                        style={{
+                            position: "absolute",
+                            top: 0,
+                            height: trackH,
+                            left: `${left}%`,
+                            width: `${Math.max(0.5, right - left)}%`,
+                            background: PHASE_COLOR[p.phase] ?? "var(--sx-phase-exec)",
+                        }}
+                    />
+                );
+            })}
+            {/* friction ticks */}
+            {visibleFriction.map((f, i) => {
+                const left = pct(f.ts);
+                if (left === null) return null;
+                return (
+                    <span
+                        key={`fr-${i}`}
+                        title={f.kind}
+                        style={{
+                            position: "absolute",
+                            top: variant === "mini" ? -2 : -1,
+                            width: variant === "mini" ? 2 : 1.5,
+                            height: variant === "mini" ? 12 : 7,
+                            left: `${left}%`,
+                            background: "var(--sx-red-700)",
+                            opacity: 0.82,
+                        }}
+                    />
+                );
+            })}
+            {/* commit dots / reverted marks */}
+            {insights.commits.map((c, i) => {
+                const left = pct(c.ts);
+                if (left === null) return null;
+                return c.reverted ? (
+                    <span
+                        key={`cm-${i}`}
+                        title={`${c.sha} (reverted)`}
+                        style={{
+                            position: "absolute",
+                            top: variant === "mini" ? 0 : -1,
+                            left: `${left}%`,
+                            transform: "translateX(-50%)",
+                            color: "var(--sx-red-700)",
+                            fontSize: variant === "mini" ? 8 : 7,
+                            fontWeight: 700,
+                            lineHeight: 1,
+                        }}
+                    >
+                        ✕
+                    </span>
+                ) : (
+                    <span
+                        key={`cm-${i}`}
+                        title={c.sha}
+                        style={{
+                            position: "absolute",
+                            top: variant === "mini" ? 1 : 0,
+                            width: variant === "mini" ? 6 : 5,
+                            height: variant === "mini" ? 6 : 5,
+                            borderRadius: "50%",
+                            left: `${left}%`,
+                            transform: "translateX(-50%)",
+                            background: "var(--sx-green-700)",
+                        }}
+                    />
+                );
+            })}
+            {/* subagent lane: underline only, merged */}
+            {hasLanes && laneLeft !== null && laneRight !== null ? (
+                <span
+                    title={`${insights.subagent_spans.length} subagents`}
+                    style={{
+                        position: "absolute",
+                        top: 5,
+                        height: 3,
+                        borderRadius: 2,
+                        left: `${laneLeft}%`,
+                        width: `${Math.max(1, laneRight - laneLeft)}%`,
+                        background: "var(--sx-violet-500)",
+                        opacity: 0.72,
+                    }}
+                />
+            ) : null}
+        </>
+    );
+}
+
+// --- public component --------------------------------------------------------
+
+export function StoryStrip({ sessionId, startedAt, endedAt, variant }: {
+    readonly sessionId: string;
+    readonly startedAt: string | null;
+    readonly endedAt: string | null;
+    readonly variant: "mini" | "underline";
+}) {
+    const [inView, wrapRef] = useInView("200px");
+
+    const q = useQuery({
+        queryKey: ["session-insights", sessionId],
+        queryFn: () => api.sessionInsights(sessionId),
+        staleTime: 5 * 60_000,
+        enabled: inView,
+    });
+
+    const isMini = variant === "mini";
+
+    if (isMini) {
+        // 120×8 mini timeline cell
+        return (
+            <span
+                ref={wrapRef}
+                title={q.data ? buildTitle(q.data) : undefined}
+                style={{
+                    display: "inline-block",
+                    position: "relative",
+                    width: 120,
+                    height: 8,
+                    verticalAlign: "middle",
+                    background: "var(--sx-phase-idle)",
+                }}
+            >
+                {q.data ? renderTimeline(q.data, startedAt, endedAt, "mini") : null}
+            </span>
+        );
+    }
+
+    // underline: 100% wide, 5px strip
+    return (
+        <span
+            ref={wrapRef}
+            title={q.data ? buildTitle(q.data) : undefined}
+            style={{
+                display: "block",
+                position: "relative",
+                width: "100%",
+                // 5px strip track + optional 3px subagent lane below = up to 8px
+                height: q.data && q.data.subagent_spans.some((s) => s.started_at !== null)
+                    ? 8
+                    : 5,
+                background: "var(--sx-phase-idle)",
+            }}
+        >
+            {q.data ? renderTimeline(q.data, startedAt, endedAt, "underline") : null}
+        </span>
+    );
+}

--- a/apps/studio/src/components/session-insight/StoryStrip.tsx
+++ b/apps/studio/src/components/session-insight/StoryStrip.tsx
@@ -192,7 +192,6 @@ function renderTimeline(
     insights: SessionInsightsPayload,
     startedAt: string | null,
     endedAt: string | null,
-    variant: "mini" | "underline",
 ): React.ReactNode {
     const phaseStarts = insights.phases.map((p) => timeOf(p.start_ts)).filter((t): t is number => t !== null);
     const phaseEnds = insights.phases.map((p) => timeOf(p.end_ts)).filter((t): t is number => t !== null);
@@ -204,7 +203,7 @@ function renderTimeline(
         insights.commits.length === 0 &&
         insights.subagent_spans.length === 0;
 
-    const trackH = variant === "mini" ? 8 : 5;
+    const trackH = 8;
     const trackStyle: React.CSSProperties = {
         position: "absolute",
         top: 0,
@@ -215,13 +214,9 @@ function renderTimeline(
     };
 
     if (noData || t0 === null || t1 === null || t1 <= t0) {
-        // fallback: single idle-colored bar or dim dash
-        if (variant === "mini") {
-            return (
-                <span style={{ color: "var(--sx-ink-300)", fontSize: 10 }}>–</span>
-            );
-        }
-        return <span style={trackStyle} />;
+        return (
+            <span style={{ color: "var(--sx-ink-300)", fontSize: 10 }}>–</span>
+        );
     }
 
     // Collect all event anchors for time-warp
@@ -254,7 +249,7 @@ function renderTimeline(
         insights.commits.length > 0 ||
         insights.subagent_spans.length > 0;
 
-    const { segments, pct: warpPct, compressedMs } = buildTimeWarp(
+    const { pct: warpPct } = buildTimeWarp(
         hasEvents ? anchors : [],
         t0,
         t1,
@@ -266,42 +261,10 @@ function renderTimeline(
         return t === null ? null : warpPct(t);
     };
 
-    const hasLanes = variant === "underline" && insights.subagent_spans.some((s) => s.started_at !== null);
-    const wrapperH = variant === "mini" ? 8 : (hasLanes ? 8 : 5);
     const maxFriction = 12;
     const visibleFriction = insights.friction_ticks.slice(0, maxFriction);
 
-    // For underline subagent lane: merge all spans into one
-    let laneLeft: number | null = null;
-    let laneRight: number | null = null;
-    if (hasLanes) {
-        for (const s of insights.subagent_spans) {
-            if (!s.started_at) continue;
-            const l = pct(s.started_at);
-            const r = pct(s.ended_at) ?? 100;
-            if (l !== null) {
-                laneLeft = laneLeft === null ? l : Math.min(laneLeft, l);
-                laneRight = laneRight === null ? r : Math.max(laneRight, r);
-            }
-        }
-    }
-
-    // Commit dot positions with de-overlap (underline only)
-    // Compute raw positions then nudge collisions
     const commitPositions = insights.commits.map((c) => pct(c.ts));
-    if (variant === "underline") {
-        // Single-pass de-overlap: if two non-null dots land within 0.8%, nudge the later one
-        for (let i = 1; i < commitPositions.length; i++) {
-            const prev = commitPositions[i - 1];
-            const cur = commitPositions[i];
-            if (prev !== null && cur !== null && cur - prev < 0.8) {
-                commitPositions[i] = Math.min(100, prev + 0.8);
-            }
-        }
-    }
-
-    // Compressed gap markers for underline variant
-    const compressedSegments = variant === "underline" ? segments.filter((s) => s.compressed) : [];
 
     return (
         <>
@@ -327,39 +290,6 @@ function renderTimeline(
                     />
                 );
             })}
-            {/* compression markers (underline variant only) */}
-            {compressedSegments.map((seg, i) => {
-                const midWarp = (seg.warpStart + seg.warpEnd) / 2;
-                return (
-                    <span key={`cmp-${i}`} style={{ position: "absolute", top: 0, left: `${midWarp}%`, transform: "translateX(-50%)" }}>
-                        {/* two 1px white slits */}
-                        <span
-                            style={{
-                                display: "block",
-                                position: "absolute",
-                                top: 0,
-                                left: -1,
-                                width: 1,
-                                height: 5,
-                                background: "white",
-                                opacity: 0.85,
-                            }}
-                        />
-                        <span
-                            style={{
-                                display: "block",
-                                position: "absolute",
-                                top: 0,
-                                left: 1,
-                                width: 1,
-                                height: 5,
-                                background: "white",
-                                opacity: 0.85,
-                            }}
-                        />
-                    </span>
-                );
-            })}
             {/* friction ticks */}
             {visibleFriction.map((f, i) => {
                 const left = pct(f.ts);
@@ -370,9 +300,9 @@ function renderTimeline(
                         title={f.kind}
                         style={{
                             position: "absolute",
-                            top: variant === "mini" ? -2 : -1,
-                            width: variant === "mini" ? 2 : 1.5,
-                            height: variant === "mini" ? 12 : 7,
+                            top: -2,
+                            width: 2,
+                            height: 12,
                             left: `${left}%`,
                             background: "var(--sx-red-700)",
                             opacity: 0.82,
@@ -390,11 +320,11 @@ function renderTimeline(
                         title={`${c.sha} (reverted)`}
                         style={{
                             position: "absolute",
-                            top: variant === "mini" ? 0 : -1,
+                            top: 0,
                             left: `${left}%`,
                             transform: "translateX(-50%)",
                             color: "var(--sx-red-700)",
-                            fontSize: variant === "mini" ? 8 : 7,
+                            fontSize: 8,
                             fontWeight: 700,
                             lineHeight: 1,
                         }}
@@ -407,9 +337,9 @@ function renderTimeline(
                         title={c.sha}
                         style={{
                             position: "absolute",
-                            top: variant === "mini" ? 1 : 0,
-                            width: variant === "mini" ? 6 : 5,
-                            height: variant === "mini" ? 6 : 5,
+                            top: 1,
+                            width: 6,
+                            height: 6,
                             borderRadius: "50%",
                             left: `${left}%`,
                             transform: "translateX(-50%)",
@@ -418,33 +348,16 @@ function renderTimeline(
                     />
                 );
             })}
-            {/* subagent lane: underline only, merged */}
-            {hasLanes && laneLeft !== null && laneRight !== null ? (
-                <span
-                    title={`${insights.subagent_spans.length} subagents`}
-                    style={{
-                        position: "absolute",
-                        top: 5,
-                        height: 3,
-                        borderRadius: 2,
-                        left: `${laneLeft}%`,
-                        width: `${Math.max(1, laneRight - laneLeft)}%`,
-                        background: "var(--sx-violet-500)",
-                        opacity: 0.72,
-                    }}
-                />
-            ) : null}
         </>
     );
 }
 
 // --- public component --------------------------------------------------------
 
-export function StoryStrip({ sessionId, startedAt, endedAt, variant }: {
+export function StoryStrip({ sessionId, startedAt, endedAt }: {
     readonly sessionId: string;
     readonly startedAt: string | null;
     readonly endedAt: string | null;
-    readonly variant: "mini" | "underline";
 }) {
     const [inView, wrapRef] = useInView("200px");
 
@@ -481,45 +394,21 @@ export function StoryStrip({ sessionId, startedAt, endedAt, variant }: {
         }
     }
 
-    const isMini = variant === "mini";
-
-    if (isMini) {
-        // 120×8 mini timeline cell
-        return (
-            <span
-                ref={wrapRef}
-                title={q.data ? buildTitle(q.data, compressedMs) : undefined}
-                style={{
-                    display: "inline-block",
-                    position: "relative",
-                    width: 120,
-                    height: 8,
-                    verticalAlign: "middle",
-                    background: "var(--sx-phase-idle)",
-                }}
-            >
-                {q.data ? renderTimeline(q.data, startedAt, endedAt, "mini") : null}
-            </span>
-        );
-    }
-
-    // underline: 100% wide, 5px strip
+    // 120×8 mini timeline cell
     return (
         <span
             ref={wrapRef}
             title={q.data ? buildTitle(q.data, compressedMs) : undefined}
             style={{
-                display: "block",
+                display: "inline-block",
                 position: "relative",
-                width: "100%",
-                // 5px strip track + optional 3px subagent lane below = up to 8px
-                height: q.data && q.data.subagent_spans.some((s) => s.started_at !== null)
-                    ? 8
-                    : 5,
+                width: 120,
+                height: 8,
+                verticalAlign: "middle",
                 background: "var(--sx-phase-idle)",
             }}
         >
-            {q.data ? renderTimeline(q.data, startedAt, endedAt, "underline") : null}
+            {q.data ? renderTimeline(q.data, startedAt, endedAt) : null}
         </span>
     );
 }

--- a/apps/studio/src/components/session-insight/StoryStrip.tsx
+++ b/apps/studio/src/components/session-insight/StoryStrip.tsx
@@ -28,6 +28,122 @@ function useInView(rootMargin = "200px"): [boolean, React.RefObject<HTMLSpanElem
     return [inView, ref];
 }
 
+// --- piecewise time-warp with idle-gap compression ---------------------------
+
+export interface WarpSegment {
+    realStart: number;
+    realEnd: number;
+    warpStart: number;
+    warpEnd: number;
+    compressed: boolean;
+}
+
+export function buildTimeWarp(
+    anchors: number[],
+    t0: number,
+    t1: number,
+    opts?: { maxGapShare?: number; compressedShare?: number },
+): {
+    segments: WarpSegment[];
+    pct: (ts: number) => number; // 0..100 warped position
+    compressedMs: number;        // total real ms hidden by compression
+} {
+    const maxGapShare = opts?.maxGapShare ?? 0.08;
+    const compressedShare = opts?.compressedShare ?? 0.02;
+
+    // Degenerate: zero-length session
+    if (t1 <= t0) {
+        return {
+            segments: [],
+            pct: () => 0,
+            compressedMs: 0,
+        };
+    }
+
+    const realSpan = t1 - t0;
+
+    // Build sorted, deduped anchor list clamped to [t0, t1], always include t0 + t1
+    const pts = Array.from(new Set([t0, t1, ...anchors.map((a) => Math.min(t1, Math.max(t0, a)))])).sort(
+        (a, b) => a - b,
+    );
+
+    // Build raw segments between adjacent anchor points
+    interface RawSeg {
+        realStart: number;
+        realEnd: number;
+        realDur: number;
+        idle: boolean;
+    }
+    const rawSegs: RawSeg[] = [];
+    for (let i = 0; i < pts.length - 1; i++) {
+        const realStart = pts[i]!;
+        const realEnd = pts[i + 1]!;
+        const realDur = realEnd - realStart;
+        const gapShare = realDur / realSpan;
+        rawSegs.push({ realStart, realEnd, realDur, idle: gapShare > maxGapShare });
+    }
+
+    // If no segments are idle, or only one segment total, no compression needed
+    const idleCount = rawSegs.filter((s) => s.idle).length;
+    if (idleCount === 0 || rawSegs.length <= 1) {
+        // Single identity-mapped segment
+        const seg: WarpSegment = { realStart: t0, realEnd: t1, warpStart: 0, warpEnd: 100, compressed: false };
+        return {
+            segments: [seg],
+            pct: (ts) => Math.min(100, Math.max(0, ((ts - t0) / realSpan) * 100)),
+            compressedMs: 0,
+        };
+    }
+
+    // Assign warp widths:
+    // - idle segments each get compressedShare * 100 (in warp-pct space)
+    // - active segments split the remaining space proportionally to real duration
+    const idleWarpWidth = compressedShare * 100; // warp-pct per idle segment
+    const totalIdleWarp = idleCount * idleWarpWidth;
+    const activeWarpTotal = Math.max(0, 100 - totalIdleWarp);
+
+    const activeTotalRealMs = rawSegs.filter((s) => !s.idle).reduce((sum, s) => sum + s.realDur, 0);
+
+    const segments: WarpSegment[] = [];
+    let warpCursor = 0;
+    for (const raw of rawSegs) {
+        let warpWidth: number;
+        if (raw.idle) {
+            warpWidth = idleWarpWidth;
+        } else {
+            warpWidth = activeTotalRealMs > 0 ? (raw.realDur / activeTotalRealMs) * activeWarpTotal : 0;
+        }
+        segments.push({
+            realStart: raw.realStart,
+            realEnd: raw.realEnd,
+            warpStart: warpCursor,
+            warpEnd: warpCursor + warpWidth,
+            compressed: raw.idle,
+        });
+        warpCursor += warpWidth;
+    }
+
+    const compressedMs = rawSegs.filter((s) => s.idle).reduce((sum, s) => sum + s.realDur, 0);
+
+    function pct(ts: number): number {
+        const clamped = Math.min(t1, Math.max(t0, ts));
+        // Find the segment containing clamped
+        for (const seg of segments) {
+            if (clamped >= seg.realStart && clamped <= seg.realEnd) {
+                const segRealSpan = seg.realEnd - seg.realStart;
+                if (segRealSpan <= 0) return seg.warpStart;
+                const frac = (clamped - seg.realStart) / segRealSpan;
+                return Math.min(100, Math.max(0, seg.warpStart + frac * (seg.warpEnd - seg.warpStart)));
+            }
+        }
+        // Fallback: clamp to edges
+        if (clamped <= t0) return 0;
+        return 100;
+    }
+
+    return { segments, pct, compressedMs };
+}
+
 // --- timeline helpers --------------------------------------------------------
 
 const PHASE_COLOR: Record<string, string> = {
@@ -43,9 +159,6 @@ const timeOf = (ts: string | null): number | null => {
     return Number.isFinite(t) ? t : null;
 };
 
-const pctOf = (t: number, t0: number, span: number): number =>
-    Math.min(100, Math.max(0, ((t - t0) / span) * 100));
-
 const fmtMs = (ms: number): string =>
     ms < 60_000
         ? `${Math.round(ms / 1000)}s`
@@ -53,7 +166,7 @@ const fmtMs = (ms: number): string =>
             ? `${Math.round(ms / 60_000)}m`
             : `${(ms / 3_600_000).toFixed(1)}h`;
 
-function buildTitle(insights: SessionInsightsPayload): string {
+function buildTitle(insights: SessionInsightsPayload, compressedMs = 0): string {
     const phaseTotals = new Map<string, number>();
     for (const p of insights.phases) {
         if (Number.isFinite(p.duration_ms) && p.duration_ms > 0) {
@@ -69,6 +182,7 @@ function buildTitle(insights: SessionInsightsPayload): string {
     if (reverted > 0) parts.push(`✕${reverted}`);
     if (landed > 0) parts.push(`●${landed}`);
     if (insights.subagent_spans.length > 0) parts.push(`${insights.subagent_spans.length} subagents`);
+    if (compressedMs > 60_000) parts.push(`· idle ~${fmtMs(compressedMs)} compressed`);
     return parts.join(" · ") || "no data";
 }
 
@@ -110,10 +224,46 @@ function renderTimeline(
         return <span style={trackStyle} />;
     }
 
-    const span = t1 - t0;
+    // Collect all event anchors for time-warp
+    const anchors: number[] = [];
+    for (const p of insights.phases) {
+        const s = timeOf(p.start_ts);
+        const e = timeOf(p.end_ts);
+        if (s !== null) anchors.push(s);
+        if (e !== null) anchors.push(e);
+    }
+    for (const f of insights.friction_ticks) {
+        const t = timeOf(f.ts);
+        if (t !== null) anchors.push(t);
+    }
+    for (const c of insights.commits) {
+        const t = timeOf(c.ts);
+        if (t !== null) anchors.push(t);
+    }
+    for (const s of insights.subagent_spans) {
+        const sa = timeOf(s.started_at);
+        const ea = timeOf(s.ended_at);
+        if (sa !== null) anchors.push(sa);
+        if (ea !== null) anchors.push(ea);
+    }
+
+    // No event anchors beyond t0/t1 = no compression (just start+end)
+    const hasEvents =
+        insights.phases.length > 0 ||
+        insights.friction_ticks.length > 0 ||
+        insights.commits.length > 0 ||
+        insights.subagent_spans.length > 0;
+
+    const { segments, pct: warpPct, compressedMs } = buildTimeWarp(
+        hasEvents ? anchors : [],
+        t0,
+        t1,
+    );
+
+    // pct helper that handles string timestamps
     const pct = (ts: string | null): number | null => {
         const t = timeOf(ts);
-        return t === null ? null : pctOf(t, t0, span);
+        return t === null ? null : warpPct(t);
     };
 
     const hasLanes = variant === "underline" && insights.subagent_spans.some((s) => s.started_at !== null);
@@ -135,6 +285,23 @@ function renderTimeline(
             }
         }
     }
+
+    // Commit dot positions with de-overlap (underline only)
+    // Compute raw positions then nudge collisions
+    const commitPositions = insights.commits.map((c) => pct(c.ts));
+    if (variant === "underline") {
+        // Single-pass de-overlap: if two non-null dots land within 0.8%, nudge the later one
+        for (let i = 1; i < commitPositions.length; i++) {
+            const prev = commitPositions[i - 1];
+            const cur = commitPositions[i];
+            if (prev !== null && cur !== null && cur - prev < 0.8) {
+                commitPositions[i] = Math.min(100, prev + 0.8);
+            }
+        }
+    }
+
+    // Compressed gap markers for underline variant
+    const compressedSegments = variant === "underline" ? segments.filter((s) => s.compressed) : [];
 
     return (
         <>
@@ -160,6 +327,39 @@ function renderTimeline(
                     />
                 );
             })}
+            {/* compression markers (underline variant only) */}
+            {compressedSegments.map((seg, i) => {
+                const midWarp = (seg.warpStart + seg.warpEnd) / 2;
+                return (
+                    <span key={`cmp-${i}`} style={{ position: "absolute", top: 0, left: `${midWarp}%`, transform: "translateX(-50%)" }}>
+                        {/* two 1px white slits */}
+                        <span
+                            style={{
+                                display: "block",
+                                position: "absolute",
+                                top: 0,
+                                left: -1,
+                                width: 1,
+                                height: 5,
+                                background: "white",
+                                opacity: 0.85,
+                            }}
+                        />
+                        <span
+                            style={{
+                                display: "block",
+                                position: "absolute",
+                                top: 0,
+                                left: 1,
+                                width: 1,
+                                height: 5,
+                                background: "white",
+                                opacity: 0.85,
+                            }}
+                        />
+                    </span>
+                );
+            })}
             {/* friction ticks */}
             {visibleFriction.map((f, i) => {
                 const left = pct(f.ts);
@@ -182,7 +382,7 @@ function renderTimeline(
             })}
             {/* commit dots / reverted marks */}
             {insights.commits.map((c, i) => {
-                const left = pct(c.ts);
+                const left = commitPositions[i];
                 if (left === null) return null;
                 return c.reverted ? (
                     <span
@@ -255,6 +455,32 @@ export function StoryStrip({ sessionId, startedAt, endedAt, variant }: {
         enabled: inView,
     });
 
+    // Compute compressedMs for tooltip - derive anchors same way as renderTimeline
+    let compressedMs = 0;
+    if (q.data && startedAt && endedAt) {
+        const t0 = new Date(startedAt).getTime();
+        const t1 = new Date(endedAt).getTime();
+        if (t1 > t0) {
+            const anchors: number[] = [];
+            const d = q.data;
+            for (const p of d.phases) {
+                const s = timeOf(p.start_ts); const e = timeOf(p.end_ts);
+                if (s !== null) anchors.push(s);
+                if (e !== null) anchors.push(e);
+            }
+            for (const f of d.friction_ticks) { const t = timeOf(f.ts); if (t !== null) anchors.push(t); }
+            for (const c of d.commits) { const t = timeOf(c.ts); if (t !== null) anchors.push(t); }
+            for (const s of d.subagent_spans) {
+                const sa = timeOf(s.started_at); const ea = timeOf(s.ended_at);
+                if (sa !== null) anchors.push(sa);
+                if (ea !== null) anchors.push(ea);
+            }
+            const hasEvents = d.phases.length > 0 || d.friction_ticks.length > 0 || d.commits.length > 0 || d.subagent_spans.length > 0;
+            const warp = buildTimeWarp(hasEvents ? anchors : [], t0, t1);
+            compressedMs = warp.compressedMs;
+        }
+    }
+
     const isMini = variant === "mini";
 
     if (isMini) {
@@ -262,7 +488,7 @@ export function StoryStrip({ sessionId, startedAt, endedAt, variant }: {
         return (
             <span
                 ref={wrapRef}
-                title={q.data ? buildTitle(q.data) : undefined}
+                title={q.data ? buildTitle(q.data, compressedMs) : undefined}
                 style={{
                     display: "inline-block",
                     position: "relative",
@@ -281,7 +507,7 @@ export function StoryStrip({ sessionId, startedAt, endedAt, variant }: {
     return (
         <span
             ref={wrapRef}
-            title={q.data ? buildTitle(q.data) : undefined}
+            title={q.data ? buildTitle(q.data, compressedMs) : undefined}
             style={{
                 display: "block",
                 position: "relative",

--- a/apps/studio/src/components/session-insight/story-strip.test.ts
+++ b/apps/studio/src/components/session-insight/story-strip.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { buildTimeWarp } from "./StoryStrip.tsx";
+
+// Helper: check that pct is monotonically non-decreasing over a set of timestamps
+function isMonotonic(pct: (ts: number) => number, samples: number[]): boolean {
+    let prev = -Infinity;
+    for (const s of samples) {
+        const v = pct(s);
+        if (v < prev - 1e-9) return false;
+        prev = v;
+    }
+    return true;
+}
+
+describe("buildTimeWarp", () => {
+    test("degenerate: t1 <= t0 returns everything at 0", () => {
+        const { segments, pct, compressedMs } = buildTimeWarp([], 1000, 500);
+        expect(segments).toHaveLength(0);
+        expect(pct(750)).toBe(0);
+        expect(pct(1000)).toBe(0);
+        expect(compressedMs).toBe(0);
+
+        // t1 === t0
+        const { pct: pct2 } = buildTimeWarp([1000], 1000, 1000);
+        expect(pct2(1000)).toBe(0);
+    });
+
+    test("no anchors beyond t0/t1: single segment, no compression", () => {
+        const t0 = 0;
+        const t1 = 3_600_000; // 1h
+        const { segments, pct, compressedMs } = buildTimeWarp([], t0, t1);
+        expect(compressedMs).toBe(0);
+        // Single segment spanning full axis
+        expect(segments).toHaveLength(1);
+        expect(segments[0]!.compressed).toBe(false);
+        expect(pct(t0)).toBeCloseTo(0);
+        expect(pct(t1)).toBeCloseTo(100);
+        expect(pct((t0 + t1) / 2)).toBeCloseTo(50);
+    });
+
+    test("single long gap compressed to ~2% warp width", () => {
+        // Session 1 hour, activity at 0 and at 58m, nothing in between
+        const t0 = 0;
+        const t1 = 3_600_000; // 1h
+        const act1 = 0;          // event at t0
+        const act2 = 58 * 60_000; // event at 58m
+        // Gap between act1→act2 is 58m out of 60m = 96.7% > 8% → compressed
+        // Gap between act2→t1 is 2m out of 60m = 3.3% < 8% → active
+
+        const { segments, pct, compressedMs } = buildTimeWarp([act1, act2], t0, t1);
+
+        // Should have compressed segments
+        const compressed = segments.filter((s) => s.compressed);
+        expect(compressed.length).toBeGreaterThan(0);
+
+        // compressedMs should be the 58m gap
+        expect(compressedMs).toBeCloseTo(58 * 60_000, -3);
+
+        // The compressed segment warp width should be ~2% (compressedShare * 100)
+        for (const seg of compressed) {
+            const warpWidth = seg.warpEnd - seg.warpStart;
+            expect(warpWidth).toBeCloseTo(2, 0); // within 1%
+        }
+
+        // pct is monotonic
+        const samples = [t0, act1, act2 / 2, act2, (act2 + t1) / 2, t1];
+        expect(isMonotonic(pct, samples)).toBe(true);
+    });
+
+    test("active segments split remaining space proportionally", () => {
+        const t0 = 0;
+        const t1 = 10_000; // 10 seconds total
+
+        // Two active bursts with a large gap in the middle
+        // burst1: 0..500ms (5% of real time, but small)
+        // gap: 500ms..9000ms (85% → compressed since > 8%)
+        // burst2: 9000ms..10000ms (10% of real time)
+
+        const { segments, pct } = buildTimeWarp([500, 9000], t0, t1);
+
+        const active = segments.filter((s) => !s.compressed);
+        const compressed = segments.filter((s) => s.compressed);
+
+        // One compressed gap
+        expect(compressed.length).toBeGreaterThanOrEqual(1);
+
+        // Active segments should exist
+        expect(active.length).toBeGreaterThanOrEqual(1);
+
+        // Total warp space for active = 100 - 2*numCompressed
+        const totalActiveWarp = active.reduce((sum, s) => sum + (s.warpEnd - s.warpStart), 0);
+        const expectedActiveWarp = 100 - compressed.length * 2;
+        expect(totalActiveWarp).toBeCloseTo(expectedActiveWarp, 1);
+
+        // pct at t0 = 0, pct at t1 = 100
+        expect(pct(t0)).toBeCloseTo(0, 1);
+        expect(pct(t1)).toBeCloseTo(100, 1);
+
+        // pct is monotonic
+        const samples = [0, 250, 500, 4750, 9000, 9500, 10000];
+        expect(isMonotonic(pct, samples)).toBe(true);
+    });
+
+    test("pct is monotonic over many anchors", () => {
+        const t0 = Date.now();
+        const t1 = t0 + 7_200_000; // 2h session
+
+        // Scattered activity: bursts at start and end with long idle in middle
+        const anchors = [
+            t0 + 60_000,
+            t0 + 120_000,
+            t0 + 180_000,
+            // 3h gap (compressed)
+            t0 + 6_900_000,
+            t0 + 6_960_000,
+            t0 + 7_020_000,
+        ];
+
+        const { pct } = buildTimeWarp(anchors, t0, t1);
+
+        const samples: number[] = [];
+        for (let i = 0; i <= 20; i++) {
+            samples.push(t0 + (i / 20) * (t1 - t0));
+        }
+        expect(isMonotonic(pct, samples)).toBe(true);
+    });
+
+    test("compressedMs sums all idle gaps", () => {
+        const t0 = 0;
+        const t1 = 10_000_000; // 10,000 seconds
+
+        // Two large gaps
+        // active: 0..1000 (1% - active, small)
+        // gap1: 1000..5000000 (50% > 8% → compressed)
+        // active: 5000000..5001000 (tiny)
+        // gap2: 5001000..9000000 (40% > 8% → compressed)
+        // active: 9000000..10000000 (10%)
+
+        const anchors = [1000, 5_000_000, 5_001_000, 9_000_000];
+        const { compressedMs, segments } = buildTimeWarp(anchors, t0, t1);
+
+        const compressed = segments.filter((s) => s.compressed);
+        const manualSum = compressed.reduce((sum, s) => sum + (s.realEnd - s.realStart), 0);
+        expect(compressedMs).toBe(manualSum);
+        expect(compressedMs).toBeGreaterThan(0);
+    });
+
+    test("no compression when all gaps are short", () => {
+        const t0 = 0;
+        const t1 = 10_000;
+        // 20 anchors spread every 500ms over 10s → each gap is 500/10000 = 5% < 8%, none compressed
+        const anchors: number[] = [];
+        for (let i = 1; i <= 19; i++) anchors.push(i * 500);
+        const { compressedMs, segments } = buildTimeWarp(anchors, t0, t1);
+        expect(compressedMs).toBe(0);
+        expect(segments.every((s) => !s.compressed)).toBe(true);
+    });
+});

--- a/apps/studio/src/main.tsx
+++ b/apps/studio/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { router } from "./router.tsx";
+import "./styles/session-tokens.css";
 
 // staleTime keeps cached data "fresh" so a tab switch doesn't re-trigger the
 // loading state. We re-fetch on focus so live ingest events are picked up

--- a/apps/studio/src/mock-fixtures.ts
+++ b/apps/studio/src/mock-fixtures.ts
@@ -17,6 +17,7 @@ import type {
     SessionChildrenResponse,
     SessionDetailPayload,
     SessionInspectPayload,
+    SessionInsightsPayload,
     SessionListResponse,
     SkillDetailPayload,
     SkillGraphPayload,
@@ -207,6 +208,26 @@ const EMPTY_SESSION_COMPARE = {
     winners: { fastest: null, cheapest: null, fewest_tokens: null, cleanest: null },
     not_found: [],
 } as never;
+const EMPTY_SESSION_INSIGHTS: SessionInsightsPayload = {
+    session: "mock",
+    phases: [],
+    friction_ticks: [],
+    commits: [],
+    subagent_spans: [],
+    checks: [],
+    loc: null,
+    durability: null,
+    delegation_ratio: null,
+    skills: [],
+    context_curve: [],
+    compactions: [],
+    baseline: {
+        cost_ratio: null,
+        friction_ratio: null,
+        land_ratio: null,
+        cache_pct: null,
+    },
+};
 
 const EMPTY_TOOL_FAILURES: ToolFailuresResponse = { rows: [], total: 0 } as never;
 const EMPTY_GRAPH: GraphExplorerPayload = { mode: "file-attention", limit: 0, nodes: [], edges: [], query: null } as never;
@@ -276,6 +297,7 @@ export async function mockFetch<T>(input: RequestInfo, init?: RequestInit): Prom
 
     // Empties
     if (path.startsWith("/api/sessions/compare")) return EMPTY_SESSION_COMPARE as unknown as T;
+    if (/^\/api\/sessions\/[^/]+\/insights$/.test(path)) return EMPTY_SESSION_INSIGHTS as unknown as T;
     if (path.startsWith("/api/sessions")) return EMPTY_SESSION_LIST as unknown as T;
     if (path === "/api/tool-failures" || path.startsWith("/api/tool-failures/")) return EMPTY_TOOL_FAILURES as unknown as T;
     if (path.startsWith("/api/graph-explorer")) return EMPTY_GRAPH as unknown as T;

--- a/apps/studio/src/routes/sessions.tsx
+++ b/apps/studio/src/routes/sessions.tsx
@@ -179,7 +179,7 @@ function Row({ s, indent, burnP90, expandedToggle, insight, select }: RowProps) 
             <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, color: "var(--muted)", textAlign: "right" }}>{fmtDuration(s.started_at, s.ended_at)}</td>
             <td style={{ textAlign: "right", fontFamily: "ui-monospace, monospace", fontSize: 12, fontVariantNumeric: "tabular-nums", color: s.turn_count > 0 ? "var(--ink)" : "var(--muted-2)" }}>{s.turn_count > 0 ? s.turn_count.toLocaleString() : "-"}</td>
             <td style={{ textAlign: "center", padding: "6px 8px" }}>
-                <BurnSpark buckets={s.burn_buckets} p90={burnP90 ?? null} />
+                <BurnSpark buckets={s.burn_buckets} p90={burnP90 ?? null} turnCount={s.turn_count > 0 ? s.turn_count : null} />
             </td>
             <td style={{ textAlign: "right", fontFamily: "ui-monospace, monospace", fontSize: 12, fontVariantNumeric: "tabular-nums", color: s.cost_usd != null ? "var(--ink)" : "var(--sx-ink-300)" }}>
                 {s.cost_usd != null ? `$${s.cost_usd.toFixed(2)}` : "–"}

--- a/apps/studio/src/routes/sessions.tsx
+++ b/apps/studio/src/routes/sessions.tsx
@@ -122,16 +122,13 @@ function CommitsCell({ produced, reverted }: {
     );
 }
 
-type ViewMode = "viz" | "strip";
-
-// keep in sync with the <th> lists below
-const COL_COUNT_VIZ = 12; // ☐ ID SRC PROJECT STARTED DUR TURNS STORY ΔLOC COMMITS COST SIGNAL → link
-const COL_COUNT_STRIP = 10; // ☐ ID SRC PROJECT STARTED DUR TURNS COST SIGNAL → link
+// keep in sync with the <th> list below
+// ☐ ID SRC PROJECT STARTED DUR TURNS STORY ΔLOC COMMITS COST SIGNAL → link
+const COL_COUNT = 12;
 
 interface RowProps {
     readonly s: SessionListRow;
     readonly indent?: boolean;
-    readonly view: ViewMode;
     readonly maxLoc: number;
     // Expanded-toggle props (root rows with children only)
     readonly childCount?: number;
@@ -146,7 +143,6 @@ interface RowProps {
 const Row = memo(function Row({
     s,
     indent,
-    view,
     maxLoc,
     childCount,
     childLoading,
@@ -172,9 +168,7 @@ const Row = memo(function Row({
 
     const rowStyle: CSSProperties | undefined = indent
         ? { background: "#fafafa" }
-        : view === "strip"
-            ? { borderBottom: "none" } // strip-row pair carries the border
-            : undefined;
+        : undefined;
 
     return (
         <tr
@@ -232,31 +226,26 @@ const Row = memo(function Row({
             <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, color: "var(--muted)" }}>{fmtTs(s.started_at)}</td>
             <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, color: "var(--muted)", textAlign: "right" }}>{fmtDuration(s.started_at, s.ended_at)}</td>
             <td style={{ textAlign: "right", fontFamily: "ui-monospace, monospace", fontSize: 12, fontVariantNumeric: "tabular-nums", color: s.turn_count > 0 ? "var(--ink)" : "var(--muted-2)" }}>{s.turn_count > 0 ? s.turn_count.toLocaleString() : "-"}</td>
-            {view === "viz" ? (
-                <>
-                    <td style={{ textAlign: "center", padding: "6px 8px" }}>
-                        <StoryStrip
-                            sessionId={sid}
-                            startedAt={s.started_at}
-                            endedAt={s.ended_at}
-                            variant="mini"
-                        />
-                    </td>
-                    <td style={{ padding: "4px 8px" }}>
-                        <LocCell
-                            added={s.lines_added}
-                            removed={s.lines_removed}
-                            maxLoc={maxLoc}
-                        />
-                    </td>
-                    <td style={{ padding: "4px 8px" }}>
-                        <CommitsCell
-                            produced={s.produced_commits}
-                            reverted={s.reverted_commits}
-                        />
-                    </td>
-                </>
-            ) : null}
+            <td style={{ textAlign: "center", padding: "6px 8px" }}>
+                <StoryStrip
+                    sessionId={sid}
+                    startedAt={s.started_at}
+                    endedAt={s.ended_at}
+                />
+            </td>
+            <td style={{ padding: "4px 8px" }}>
+                <LocCell
+                    added={s.lines_added}
+                    removed={s.lines_removed}
+                    maxLoc={maxLoc}
+                />
+            </td>
+            <td style={{ padding: "4px 8px" }}>
+                <CommitsCell
+                    produced={s.produced_commits}
+                    reverted={s.reverted_commits}
+                />
+            </td>
             <td style={{ textAlign: "right", fontFamily: "ui-monospace, monospace", fontSize: 12, fontVariantNumeric: "tabular-nums", color: s.cost_usd != null ? "var(--ink)" : "var(--sx-ink-300)" }}>
                 {s.cost_usd != null ? `$${s.cost_usd.toFixed(2)}` : "–"}
             </td>
@@ -286,7 +275,6 @@ export function SessionsRoute() {
     const navigate = useNavigate();
     const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
     const [search, setSearch] = useState("");
-    const [view, setView] = useState<ViewMode>("viz");
     const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
     const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
 
@@ -350,8 +338,6 @@ export function SessionsRoute() {
             setAppendLoading(false);
         }
     };
-
-    const colCount = view === "viz" ? COL_COUNT_VIZ : COL_COUNT_STRIP;
 
     const sentinelRef = useRef<HTMLTableRowElement | null>(null);
     useEffect(() => {
@@ -459,25 +445,6 @@ export function SessionsRoute() {
                         </button>
                     ))}
                 </div>
-                {/* View toggle: viz / strip */}
-                <div style={{ display: "flex", gap: 0, border: "1px solid var(--line)", borderRadius: 4, overflow: "hidden" }}>
-                    {(["viz", "strip"] as const).map((v) => (
-                        <button
-                            key={v}
-                            onClick={() => setView(v)}
-                            style={{
-                                padding: "4px 10px", fontSize: 11, fontWeight: 600,
-                                border: "none",
-                                background: view === v ? "var(--ink)" : "#fff",
-                                color: view === v ? "#fff" : "var(--muted)",
-                                cursor: "pointer",
-                                borderRight: v === "viz" ? "1px solid var(--line)" : "none",
-                            }}
-                        >
-                            {v}
-                        </button>
-                    ))}
-                </div>
                 <input
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
@@ -526,7 +493,7 @@ export function SessionsRoute() {
             {query.isLoading && !query.data ? <div className="loading">Loading…</div> : null}
             {query.data ? (
                 <div style={{ overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
-                <table style={{ width: "100%", minWidth: view === "viz" ? 1280 : 1020, borderCollapse: "collapse" }}>
+                <table style={{ width: "100%", minWidth: 1280, borderCollapse: "collapse" }}>
                     <thead>
                         <tr style={{ background: "var(--page)", fontSize: 11, color: "var(--muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
                             <th style={{ width: 28 }}></th>
@@ -536,13 +503,9 @@ export function SessionsRoute() {
                             <th style={{ textAlign: "left", padding: "6px 8px" }}>started</th>
                             <th style={{ textAlign: "right", padding: "6px 8px" }}>duration</th>
                             <th style={{ textAlign: "right", padding: "6px 8px" }}>turns</th>
-                            {view === "viz" ? (
-                                <>
-                                    <th style={{ textAlign: "center", padding: "6px 8px" }}>story</th>
-                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>δloc</th>
-                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>commits</th>
-                                </>
-                            ) : null}
+                            <th style={{ textAlign: "center", padding: "6px 8px" }}>story</th>
+                            <th style={{ textAlign: "left", padding: "6px 8px" }}>δloc</th>
+                            <th style={{ textAlign: "left", padding: "6px 8px" }}>commits</th>
                             <th style={{ textAlign: "right", padding: "6px 8px" }}>cost</th>
                             <th style={{ textAlign: "left", padding: "6px 8px" }}>signal</th>
                             <th style={{ textAlign: "left", padding: "6px 8px" }}></th>
@@ -557,7 +520,6 @@ export function SessionsRoute() {
                                 <Fragment key={parent.id}>
                                     <Row
                                         s={parent}
-                                        view={view}
                                         maxLoc={maxLoc}
                                         isSelected={selected.has(parent.id)}
                                         onToggleSelect={toggleSelected}
@@ -570,29 +532,12 @@ export function SessionsRoute() {
                                             }
                                             : {})}
                                     />
-                                    {/* strip view: underline strip row follows each root row */}
-                                    {view === "strip" ? (
-                                        <tr className="strip-row" style={{ borderBottom: "1px solid var(--sx-line-200)" }}>
-                                            <td
-                                                colSpan={COL_COUNT_STRIP}
-                                                style={{ padding: 0, height: "auto" }}
-                                            >
-                                                <StoryStrip
-                                                    sessionId={parent.id}
-                                                    startedAt={parent.started_at}
-                                                    endedAt={parent.ended_at}
-                                                    variant="underline"
-                                                />
-                                            </td>
-                                        </tr>
-                                    ) : null}
                                     {isExpanded
                                         ? (kidState?.rows ?? []).map((child) => (
                                             <Row
                                                 key={child.id}
                                                 s={child}
                                                 indent
-                                                view={view}
                                                 maxLoc={maxLoc}
                                                 isSelected={selected.has(child.id)}
                                                 onToggleSelect={toggleSelected}
@@ -604,7 +549,7 @@ export function SessionsRoute() {
                         })}
                         {allRoots.length < totalCount ? (
                             <tr ref={sentinelRef}>
-                                <td colSpan={colCount} style={{
+                                <td colSpan={COL_COUNT} style={{
                                     padding: "12px 24px", color: "var(--muted)", fontSize: 12,
                                     fontFamily: "ui-monospace, monospace",
                                     textAlign: "center", borderTop: "1px dashed var(--line)",

--- a/apps/studio/src/routes/sessions.tsx
+++ b/apps/studio/src/routes/sessions.tsx
@@ -1,7 +1,11 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties, MouseEvent } from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { api } from "../api.ts";
+import { BurnSpark } from "../components/session-insight/BurnSpark.tsx";
+import { InsightPanel } from "../components/session-insight/InsightPanel.tsx";
+import { SignalBadge } from "../components/session-insight/SignalBadge.tsx";
 import { sessionProjectLabel } from "@ax/lib/shared/project-slug";
 import type { SessionListResponse, SessionListRow } from "@ax/lib/shared/dashboard-types";
 import { shortSessionId } from "@ax/lib/shared/session-id";
@@ -46,15 +50,19 @@ function SourceBadge({ source }: { source: string }) {
 interface RowProps {
     readonly s: SessionListRow;
     readonly indent?: boolean;
+    readonly burnP90?: number | null;
     readonly expandedToggle?: { expanded: boolean; childCount: number; loading?: boolean; onToggle: () => void };
+    readonly insight?: { open: boolean; onToggle: () => void };
     readonly select?: { checked: boolean; onToggle: () => void };
 }
 
-function Row({ s, indent, expandedToggle, select }: RowProps) {
+function Row({ s, indent, burnP90, expandedToggle, insight, select }: RowProps) {
     // The wire seam delivers a bare session id (see src/lib/shared/session-id.ts);
     // any backtick/`session:` prefix reaching us would be a server bug.
     const sid = s.id;
     const project = sessionProjectLabel(s.project, s.cwd);
+    const open = insight?.open ?? false;
+    const panelId = `session-insight-${sid}`;
 
     // Warm the inspect-data query on hover/focus - intent-based prefetch
     // avoids stampeding the API when the page has 200 rows.
@@ -68,10 +76,32 @@ function Row({ s, indent, expandedToggle, select }: RowProps) {
         });
     };
 
-    const rowStyle = indent ? { background: "#fafafa" } : undefined;
+    const rowStyle: CSSProperties | undefined = open
+        ? {
+            background: "var(--sx-tint-50)",
+            boxShadow: "inset 3px 0 0 var(--sx-ink-900)",
+            cursor: "pointer",
+        }
+        : indent
+            ? { background: "#fafafa" }
+            : insight
+                ? { cursor: "pointer" }
+                : undefined;
+
+    const onRowClick = (event: MouseEvent<HTMLTableRowElement>) => {
+        if (!insight) return;
+        const target = event.target;
+        if (target instanceof Element && target.closest("a,button,input")) return;
+        insight.onToggle();
+    };
 
     return (
-        <tr style={rowStyle} onMouseEnter={onIntent} onFocus={onIntent}>
+        <tr
+            style={rowStyle}
+            onClick={onRowClick}
+            onMouseEnter={onIntent}
+            onFocus={onIntent}
+        >
             <td style={{ textAlign: "center", width: 28 }}>
                 <input
                     type="checkbox"
@@ -80,7 +110,33 @@ function Row({ s, indent, expandedToggle, select }: RowProps) {
                     aria-label={`Select ${shortSessionId(s.id)} to compare`}
                 />
             </td>
-            <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, paddingLeft: indent ? 32 : 8 }}>
+            <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, paddingLeft: indent ? 32 : 8, whiteSpace: "nowrap" }}>
+                {insight ? (
+                    <button
+                        type="button"
+                        onClick={insight.onToggle}
+                        aria-expanded={open}
+                        aria-controls={panelId}
+                        title={open ? "Collapse insight panel" : "Expand insight panel"}
+                        style={{
+                            border: "none",
+                            background: "transparent",
+                            padding: 0,
+                            cursor: "pointer",
+                            display: "inline-block",
+                            width: 12,
+                            marginRight: 4,
+                            color: "var(--sx-ink-500)",
+                            transform: open ? "rotate(90deg)" : "rotate(0deg)",
+                            transition: "transform 120ms ease",
+                            fontFamily: "inherit",
+                            fontSize: 12,
+                            lineHeight: 1,
+                        }}
+                    >
+                        ▶
+                    </button>
+                ) : null}
                 {expandedToggle ? (
                     <button
                         onClick={expandedToggle.onToggle}
@@ -98,6 +154,23 @@ function Row({ s, indent, expandedToggle, select }: RowProps) {
                 ) : (
                     <span style={{ display: "inline-block", width: 32 }} />
                 )}
+                {s.is_live ? (
+                    <span
+                        title="Live session"
+                        style={{
+                            display: "inline-block",
+                            width: 7,
+                            height: 7,
+                            borderRadius: "50%",
+                            background: "var(--sx-green-700)",
+                            boxShadow: "0 0 0 3px var(--sx-green-100)",
+                            margin: "0 5px 1px 1px",
+                            verticalAlign: "middle",
+                        }}
+                    >
+                        <span className="sr-only">live session</span>
+                    </span>
+                ) : null}
                 <code title={s.id} style={{ marginLeft: 4 }}>{shortSessionId(s.id)}</code>
             </td>
             <td><SourceBadge source={s.source} /></td>
@@ -105,6 +178,15 @@ function Row({ s, indent, expandedToggle, select }: RowProps) {
             <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, color: "var(--muted)" }}>{fmtTs(s.started_at)}</td>
             <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, color: "var(--muted)", textAlign: "right" }}>{fmtDuration(s.started_at, s.ended_at)}</td>
             <td style={{ textAlign: "right", fontFamily: "ui-monospace, monospace", fontSize: 12, fontVariantNumeric: "tabular-nums", color: s.turn_count > 0 ? "var(--ink)" : "var(--muted-2)" }}>{s.turn_count > 0 ? s.turn_count.toLocaleString() : "-"}</td>
+            <td style={{ textAlign: "center", padding: "6px 8px" }}>
+                <BurnSpark buckets={s.burn_buckets} p90={burnP90 ?? null} />
+            </td>
+            <td style={{ textAlign: "right", fontFamily: "ui-monospace, monospace", fontSize: 12, fontVariantNumeric: "tabular-nums", color: s.cost_usd != null ? "var(--ink)" : "var(--sx-ink-300)" }}>
+                {s.cost_usd != null ? `$${s.cost_usd.toFixed(2)}` : "–"}
+            </td>
+            <td style={{ textAlign: "left", padding: "6px 8px" }}>
+                <SignalBadge signal={s.signal} friction={s.friction} />
+            </td>
             <td style={{ display: "flex", gap: 8, alignItems: "center" }}>
                 {s.has_raw_file ? (
                     <Link to="/sessions/$sessionId" params={{ sessionId: sid }} preload="intent" style={{ color: "var(--blue)", fontWeight: 600 }}>
@@ -130,6 +212,7 @@ export function SessionsRoute() {
     const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
     const [search, setSearch] = useState("");
     const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+    const [insightOpen, setInsightOpen] = useState<ReadonlySet<string>>(() => new Set());
     const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
 
     const toggleSelected = (id: string) => {
@@ -272,6 +355,15 @@ export function SessionsRoute() {
         });
     };
 
+    const toggleInsight = (id: string) => {
+        setInsightOpen((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    };
+
     const allExpandableIds = useMemo(
         () => filteredRoots.filter((r) => childCountOf(r) > 0).map((r) => r.id),
         [filteredRoots],
@@ -353,7 +445,8 @@ export function SessionsRoute() {
             </div>
             {query.isLoading && !query.data ? <div className="loading">Loading…</div> : null}
             {query.data ? (
-                <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                <div style={{ overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
+                <table style={{ width: "100%", minWidth: 1120, borderCollapse: "collapse" }}>
                     <thead>
                         <tr style={{ background: "var(--page)", fontSize: 11, color: "var(--muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
                             <th style={{ width: 28 }}></th>
@@ -363,6 +456,9 @@ export function SessionsRoute() {
                             <th style={{ textAlign: "left", padding: "6px 8px" }}>started</th>
                             <th style={{ textAlign: "right", padding: "6px 8px" }}>duration</th>
                             <th style={{ textAlign: "right", padding: "6px 8px" }}>turns</th>
+                            <th style={{ textAlign: "center", padding: "6px 8px" }}>burn</th>
+                            <th style={{ textAlign: "right", padding: "6px 8px" }}>cost</th>
+                            <th style={{ textAlign: "left", padding: "6px 8px" }}>signal</th>
                             <th style={{ textAlign: "left", padding: "6px 8px" }}></th>
                         </tr>
                     </thead>
@@ -375,6 +471,8 @@ export function SessionsRoute() {
                                 <Fragment key={parent.id}>
                                     <Row
                                         s={parent}
+                                        burnP90={query.data?.burn_p90 ?? null}
+                                        insight={{ open: insightOpen.has(parent.id), onToggle: () => toggleInsight(parent.id) }}
                                         select={{ checked: selected.has(parent.id), onToggle: () => toggleSelected(parent.id) }}
                                         {...(childCount > 0
                                             ? {
@@ -387,6 +485,21 @@ export function SessionsRoute() {
                                             }
                                             : {})}
                                     />
+                                    {insightOpen.has(parent.id) ? (
+                                        <tr id={`session-insight-${parent.id}`}>
+                                            <td
+                                                colSpan={11}
+                                                style={{
+                                                    padding: 0,
+                                                    background: "var(--sx-tint-50)",
+                                                    boxShadow: "inset 3px 0 0 var(--sx-ink-900)",
+                                                    borderBottom: "1px solid var(--sx-line-200)",
+                                                }}
+                                            >
+                                                <InsightPanel row={parent} />
+                                            </td>
+                                        </tr>
+                                    ) : null}
                                     {isExpanded
                                         ? (kidState?.rows ?? []).map((child) => (
                                             <Row
@@ -402,7 +515,7 @@ export function SessionsRoute() {
                         })}
                         {allRoots.length < totalCount ? (
                             <tr ref={sentinelRef}>
-                                <td colSpan={8} style={{
+                                <td colSpan={11} style={{
                                     padding: "12px 24px", color: "var(--muted)", fontSize: 12,
                                     fontFamily: "ui-monospace, monospace",
                                     textAlign: "center", borderTop: "1px dashed var(--line)",
@@ -428,6 +541,7 @@ export function SessionsRoute() {
                         ) : null}
                     </tbody>
                 </table>
+                </div>
             ) : null}
         </section>
     );

--- a/apps/studio/src/routes/sessions.tsx
+++ b/apps/studio/src/routes/sessions.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, MouseEvent } from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
@@ -51,18 +51,40 @@ interface RowProps {
     readonly s: SessionListRow;
     readonly indent?: boolean;
     readonly burnP90?: number | null;
-    readonly expandedToggle?: { expanded: boolean; childCount: number; loading?: boolean; onToggle: () => void };
-    readonly insight?: { open: boolean; onToggle: () => void };
-    readonly select?: { checked: boolean; onToggle: () => void };
+    // Expanded-toggle props (root rows with children only)
+    readonly childCount?: number;
+    readonly childLoading?: boolean;
+    readonly expanded?: boolean;
+    readonly onToggleExpanded?: (id: string) => void;
+    // Insight panel props (root rows only)
+    readonly insightOpen?: boolean;
+    readonly onToggleInsight?: (id: string) => void;
+    // Selection props (all rows)
+    readonly isSelected?: boolean;
+    readonly onToggleSelect: (id: string) => void;
 }
 
-function Row({ s, indent, burnP90, expandedToggle, insight, select }: RowProps) {
+const Row = memo(function Row({
+    s,
+    indent,
+    burnP90,
+    childCount,
+    childLoading,
+    expanded,
+    onToggleExpanded,
+    insightOpen,
+    onToggleInsight,
+    isSelected,
+    onToggleSelect,
+}: RowProps) {
     // The wire seam delivers a bare session id (see src/lib/shared/session-id.ts);
     // any backtick/`session:` prefix reaching us would be a server bug.
     const sid = s.id;
     const project = sessionProjectLabel(s.project, s.cwd);
-    const open = insight?.open ?? false;
+    const open = insightOpen ?? false;
     const panelId = `session-insight-${sid}`;
+    const hasInsight = onToggleInsight != null;
+    const hasExpandedToggle = onToggleExpanded != null && childCount != null && childCount > 0;
 
     // Warm the inspect-data query on hover/focus - intent-based prefetch
     // avoids stampeding the API when the page has 200 rows.
@@ -84,15 +106,15 @@ function Row({ s, indent, burnP90, expandedToggle, insight, select }: RowProps) 
         }
         : indent
             ? { background: "#fafafa" }
-            : insight
+            : hasInsight
                 ? { cursor: "pointer" }
                 : undefined;
 
     const onRowClick = (event: MouseEvent<HTMLTableRowElement>) => {
-        if (!insight) return;
+        if (!hasInsight) return;
         const target = event.target;
         if (target instanceof Element && target.closest("a,button,input")) return;
-        insight.onToggle();
+        onToggleInsight(sid);
     };
 
     return (
@@ -105,16 +127,16 @@ function Row({ s, indent, burnP90, expandedToggle, insight, select }: RowProps) 
             <td style={{ textAlign: "center", width: 28 }}>
                 <input
                     type="checkbox"
-                    checked={select?.checked ?? false}
-                    onChange={() => select?.onToggle()}
+                    checked={isSelected ?? false}
+                    onChange={() => onToggleSelect(sid)}
                     aria-label={`Select ${shortSessionId(s.id)} to compare`}
                 />
             </td>
             <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, paddingLeft: indent ? 32 : 8, whiteSpace: "nowrap" }}>
-                {insight ? (
+                {hasInsight ? (
                     <button
                         type="button"
-                        onClick={insight.onToggle}
+                        onClick={() => onToggleInsight(sid)}
                         aria-expanded={open}
                         aria-controls={panelId}
                         title={open ? "Collapse insight panel" : "Expand insight panel"}
@@ -137,17 +159,17 @@ function Row({ s, indent, burnP90, expandedToggle, insight, select }: RowProps) 
                         ▶
                     </button>
                 ) : null}
-                {expandedToggle ? (
+                {hasExpandedToggle ? (
                     <button
-                        onClick={expandedToggle.onToggle}
+                        onClick={() => onToggleExpanded(sid)}
                         style={{
                             border: "none", background: "transparent", cursor: "pointer",
                             padding: "0 6px 0 0", fontFamily: "inherit", fontSize: 12, color: "var(--muted)",
                         }}
-                        title={`${expandedToggle.expanded ? "Collapse" : "Expand"} ${expandedToggle.childCount} subagent${expandedToggle.childCount === 1 ? "" : "s"}`}
+                        title={`${expanded ? "Collapse" : "Expand"} ${childCount} subagent${childCount === 1 ? "" : "s"}`}
                     >
-                        {expandedToggle.expanded ? "▼" : "▶"} {expandedToggle.childCount}
-                        {expandedToggle.loading ? " …" : ""}
+                        {expanded ? "▼" : "▶"} {childCount}
+                        {childLoading ? " …" : ""}
                     </button>
                 ) : indent ? (
                     <span style={{ color: "var(--muted-2)", marginRight: 6 }}>↳</span>
@@ -198,11 +220,14 @@ function Row({ s, indent, burnP90, expandedToggle, insight, select }: RowProps) 
             </td>
         </tr>
     );
-}
+});
 
 /** Number of direct children for a root row. Uses the server-supplied count
  *  (which is always present on `/api/sessions` rows). */
 const childCountOf = (row: SessionListRow): number => row.direct_children_count ?? 0;
+
+// keep in sync with the <th> list below
+const COL_COUNT = 11;
 
 const PAGE_SIZE = 200;
 
@@ -215,14 +240,14 @@ export function SessionsRoute() {
     const [insightOpen, setInsightOpen] = useState<ReadonlySet<string>>(() => new Set());
     const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
 
-    const toggleSelected = (id: string) => {
+    const toggleSelected = useCallback((id: string) => {
         setSelected((prev) => {
             const next = new Set(prev);
             if (next.has(id)) next.delete(id);
             else next.add(id);
             return next;
         });
-    };
+    }, []);
 
     const compareSelected = () => {
         const ids = Array.from(selected);
@@ -346,23 +371,23 @@ export function SessionsRoute() {
         return m;
     }, [expandedIds, childQueries]);
 
-    const toggleExpanded = (id: string) => {
+    const toggleExpanded = useCallback((id: string) => {
         setExpanded((prev) => {
             const next = new Set(prev);
             if (next.has(id)) next.delete(id);
             else next.add(id);
             return next;
         });
-    };
+    }, []);
 
-    const toggleInsight = (id: string) => {
+    const toggleInsight = useCallback((id: string) => {
         setInsightOpen((prev) => {
             const next = new Set(prev);
             if (next.has(id)) next.delete(id);
             else next.add(id);
             return next;
         });
-    };
+    }, []);
 
     const allExpandableIds = useMemo(
         () => filteredRoots.filter((r) => childCountOf(r) > 0).map((r) => r.id),
@@ -472,23 +497,23 @@ export function SessionsRoute() {
                                     <Row
                                         s={parent}
                                         burnP90={query.data?.burn_p90 ?? null}
-                                        insight={{ open: insightOpen.has(parent.id), onToggle: () => toggleInsight(parent.id) }}
-                                        select={{ checked: selected.has(parent.id), onToggle: () => toggleSelected(parent.id) }}
+                                        insightOpen={insightOpen.has(parent.id)}
+                                        onToggleInsight={toggleInsight}
+                                        isSelected={selected.has(parent.id)}
+                                        onToggleSelect={toggleSelected}
                                         {...(childCount > 0
                                             ? {
-                                                expandedToggle: {
-                                                    expanded: isExpanded,
-                                                    childCount,
-                                                    loading: !!kidState?.loading,
-                                                    onToggle: () => toggleExpanded(parent.id),
-                                                },
+                                                childCount,
+                                                childLoading: !!kidState?.loading,
+                                                expanded: isExpanded,
+                                                onToggleExpanded: toggleExpanded,
                                             }
                                             : {})}
                                     />
                                     {insightOpen.has(parent.id) ? (
                                         <tr id={`session-insight-${parent.id}`}>
                                             <td
-                                                colSpan={11}
+                                                colSpan={COL_COUNT}
                                                 style={{
                                                     padding: 0,
                                                     background: "var(--sx-tint-50)",
@@ -506,7 +531,8 @@ export function SessionsRoute() {
                                                 key={child.id}
                                                 s={child}
                                                 indent
-                                                select={{ checked: selected.has(child.id), onToggle: () => toggleSelected(child.id) }}
+                                                isSelected={selected.has(child.id)}
+                                                onToggleSelect={toggleSelected}
                                             />
                                         ))
                                         : null}
@@ -515,7 +541,7 @@ export function SessionsRoute() {
                         })}
                         {allRoots.length < totalCount ? (
                             <tr ref={sentinelRef}>
-                                <td colSpan={11} style={{
+                                <td colSpan={COL_COUNT} style={{
                                     padding: "12px 24px", color: "var(--muted)", fontSize: 12,
                                     fontFamily: "ui-monospace, monospace",
                                     textAlign: "center", borderTop: "1px dashed var(--line)",

--- a/apps/studio/src/routes/sessions.tsx
+++ b/apps/studio/src/routes/sessions.tsx
@@ -3,9 +3,10 @@ import type { CSSProperties, MouseEvent } from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { api } from "../api.ts";
-import { BurnSpark } from "../components/session-insight/BurnSpark.tsx";
-import { InsightPanel } from "../components/session-insight/InsightPanel.tsx";
+// BurnSpark kept on disk; not rendered in viz/strip views (story bar replaces it as the visual)
+// accordion view retired in favor of inline visuals; components kept for the session detail page
 import { SignalBadge } from "../components/session-insight/SignalBadge.tsx";
+import { StoryStrip } from "../components/session-insight/StoryStrip.tsx";
 import { sessionProjectLabel } from "@ax/lib/shared/project-slug";
 import type { SessionListResponse, SessionListRow } from "@ax/lib/shared/dashboard-types";
 import { shortSessionId } from "@ax/lib/shared/session-id";
@@ -47,18 +48,96 @@ function SourceBadge({ source }: { source: string }) {
     );
 }
 
+/** ΔLOC two-bar cell: green (added) + red (removed) proportionally split over
+ *  a fixed 72px total, magnitude encoded via log1p normalisation against maxLoc. */
+function LocCell({ added, removed, maxLoc }: {
+    readonly added: number | null;
+    readonly removed: number | null;
+    readonly maxLoc: number;
+}) {
+    if (added === null && removed === null) {
+        return <span style={{ color: "var(--sx-ink-300)", fontSize: 10 }}>-</span>;
+    }
+    const a = Math.max(0, added ?? 0);
+    const r = Math.max(0, removed ?? 0);
+    const total = a + r;
+    const FIXED_W = 72;
+    const scale = maxLoc > 0 ? Math.log1p(total) / Math.log1p(maxLoc) : 0;
+    const barW = Math.round(FIXED_W * Math.min(1, scale));
+    const greenW = total > 0 ? Math.round(barW * (a / total)) : 0;
+    const redW = barW - greenW;
+
+    const fmt = (n: number): string => n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+    return (
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap" }}>
+            <span style={{ display: "inline-flex", alignItems: "center", width: FIXED_W }}>
+                {greenW > 0
+                    ? <span style={{ display: "inline-block", width: greenW, height: 5, background: "var(--sx-green-700)", borderRadius: "1px 0 0 1px", opacity: 0.8 }} />
+                    : null}
+                {redW > 0
+                    ? <span style={{ display: "inline-block", width: redW, height: 5, background: "var(--sx-red-700)", borderRadius: greenW > 0 ? "0 1px 1px 0" : "1px", opacity: 0.8 }} />
+                    : null}
+            </span>
+            <span style={{ fontSize: 10, fontVariantNumeric: "tabular-nums" }}>
+                <span style={{ color: "var(--sx-green-700)" }}>+{fmt(a)}</span>
+                {" "}
+                <span style={{ color: "var(--sx-red-700)" }}>−{fmt(r)}</span>
+            </span>
+        </span>
+    );
+}
+
+/** COMMITS cell: up to 8 green dots + ✕N reverted + +N overflow. */
+function CommitsCell({ produced, reverted }: {
+    readonly produced: number | null;
+    readonly reverted: number | null;
+}) {
+    if (produced === null && reverted === null) {
+        return <span style={{ color: "var(--sx-ink-300)", fontSize: 10 }}>-</span>;
+    }
+    const p = produced ?? 0;
+    const r = reverted ?? 0;
+    const landed = Math.max(0, p - r);
+    const MAX_DOTS = 8;
+    const shown = Math.min(landed, MAX_DOTS);
+    const overflow = landed - shown;
+    return (
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 3, whiteSpace: "nowrap" }}>
+            {Array.from({ length: shown }, (_, i) => (
+                <span
+                    key={i}
+                    style={{ display: "inline-block", width: 6, height: 6, borderRadius: "50%", background: "var(--sx-green-700)", opacity: 0.85 }}
+                />
+            ))}
+            {overflow > 0
+                ? <span style={{ fontSize: 10, color: "var(--sx-green-700)" }}>+{overflow}</span>
+                : null}
+            {r > 0
+                ? <span style={{ fontSize: 10, color: "var(--sx-red-700)", marginLeft: overflow > 0 ? 0 : 2 }}>✕{r}</span>
+                : null}
+            {p === 0 && r === 0
+                ? <span style={{ color: "var(--sx-ink-300)", fontSize: 10 }}>-</span>
+                : null}
+        </span>
+    );
+}
+
+type ViewMode = "viz" | "strip";
+
+// keep in sync with the <th> lists below
+const COL_COUNT_VIZ = 12; // ☐ ID SRC PROJECT STARTED DUR TURNS STORY ΔLOC COMMITS COST SIGNAL → link
+const COL_COUNT_STRIP = 10; // ☐ ID SRC PROJECT STARTED DUR TURNS COST SIGNAL → link
+
 interface RowProps {
     readonly s: SessionListRow;
     readonly indent?: boolean;
-    readonly burnP90?: number | null;
+    readonly view: ViewMode;
+    readonly maxLoc: number;
     // Expanded-toggle props (root rows with children only)
     readonly childCount?: number;
     readonly childLoading?: boolean;
     readonly expanded?: boolean;
     readonly onToggleExpanded?: (id: string) => void;
-    // Insight panel props (root rows only)
-    readonly insightOpen?: boolean;
-    readonly onToggleInsight?: (id: string) => void;
     // Selection props (all rows)
     readonly isSelected?: boolean;
     readonly onToggleSelect: (id: string) => void;
@@ -67,27 +146,20 @@ interface RowProps {
 const Row = memo(function Row({
     s,
     indent,
-    burnP90,
+    view,
+    maxLoc,
     childCount,
     childLoading,
     expanded,
     onToggleExpanded,
-    insightOpen,
-    onToggleInsight,
     isSelected,
     onToggleSelect,
 }: RowProps) {
-    // The wire seam delivers a bare session id (see src/lib/shared/session-id.ts);
-    // any backtick/`session:` prefix reaching us would be a server bug.
     const sid = s.id;
     const project = sessionProjectLabel(s.project, s.cwd);
-    const open = insightOpen ?? false;
-    const panelId = `session-insight-${sid}`;
-    const hasInsight = onToggleInsight != null;
     const hasExpandedToggle = onToggleExpanded != null && childCount != null && childCount > 0;
 
     // Warm the inspect-data query on hover/focus - intent-based prefetch
-    // avoids stampeding the API when the page has 200 rows.
     const queryClient = useQueryClient();
     const onIntent = () => {
         if (!s.has_raw_file) return;
@@ -98,29 +170,15 @@ const Row = memo(function Row({
         });
     };
 
-    const rowStyle: CSSProperties | undefined = open
-        ? {
-            background: "var(--sx-tint-50)",
-            boxShadow: "inset 3px 0 0 var(--sx-ink-900)",
-            cursor: "pointer",
-        }
-        : indent
-            ? { background: "#fafafa" }
-            : hasInsight
-                ? { cursor: "pointer" }
-                : undefined;
-
-    const onRowClick = (event: MouseEvent<HTMLTableRowElement>) => {
-        if (!hasInsight) return;
-        const target = event.target;
-        if (target instanceof Element && target.closest("a,button,input")) return;
-        onToggleInsight(sid);
-    };
+    const rowStyle: CSSProperties | undefined = indent
+        ? { background: "#fafafa" }
+        : view === "strip"
+            ? { borderBottom: "none" } // strip-row pair carries the border
+            : undefined;
 
     return (
         <tr
             style={rowStyle}
-            onClick={onRowClick}
             onMouseEnter={onIntent}
             onFocus={onIntent}
         >
@@ -133,32 +191,6 @@ const Row = memo(function Row({
                 />
             </td>
             <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, paddingLeft: indent ? 32 : 8, whiteSpace: "nowrap" }}>
-                {hasInsight ? (
-                    <button
-                        type="button"
-                        onClick={() => onToggleInsight(sid)}
-                        aria-expanded={open}
-                        aria-controls={panelId}
-                        title={open ? "Collapse insight panel" : "Expand insight panel"}
-                        style={{
-                            border: "none",
-                            background: "transparent",
-                            padding: 0,
-                            cursor: "pointer",
-                            display: "inline-block",
-                            width: 12,
-                            marginRight: 4,
-                            color: "var(--sx-ink-500)",
-                            transform: open ? "rotate(90deg)" : "rotate(0deg)",
-                            transition: "transform 120ms ease",
-                            fontFamily: "inherit",
-                            fontSize: 12,
-                            lineHeight: 1,
-                        }}
-                    >
-                        ▶
-                    </button>
-                ) : null}
                 {hasExpandedToggle ? (
                     <button
                         onClick={() => onToggleExpanded(sid)}
@@ -200,9 +232,31 @@ const Row = memo(function Row({
             <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, color: "var(--muted)" }}>{fmtTs(s.started_at)}</td>
             <td style={{ fontFamily: "ui-monospace, monospace", fontSize: 12, color: "var(--muted)", textAlign: "right" }}>{fmtDuration(s.started_at, s.ended_at)}</td>
             <td style={{ textAlign: "right", fontFamily: "ui-monospace, monospace", fontSize: 12, fontVariantNumeric: "tabular-nums", color: s.turn_count > 0 ? "var(--ink)" : "var(--muted-2)" }}>{s.turn_count > 0 ? s.turn_count.toLocaleString() : "-"}</td>
-            <td style={{ textAlign: "center", padding: "6px 8px" }}>
-                <BurnSpark buckets={s.burn_buckets} p90={burnP90 ?? null} turnCount={s.turn_count > 0 ? s.turn_count : null} />
-            </td>
+            {view === "viz" ? (
+                <>
+                    <td style={{ textAlign: "center", padding: "6px 8px" }}>
+                        <StoryStrip
+                            sessionId={sid}
+                            startedAt={s.started_at}
+                            endedAt={s.ended_at}
+                            variant="mini"
+                        />
+                    </td>
+                    <td style={{ padding: "4px 8px" }}>
+                        <LocCell
+                            added={s.lines_added}
+                            removed={s.lines_removed}
+                            maxLoc={maxLoc}
+                        />
+                    </td>
+                    <td style={{ padding: "4px 8px" }}>
+                        <CommitsCell
+                            produced={s.produced_commits}
+                            reverted={s.reverted_commits}
+                        />
+                    </td>
+                </>
+            ) : null}
             <td style={{ textAlign: "right", fontFamily: "ui-monospace, monospace", fontSize: 12, fontVariantNumeric: "tabular-nums", color: s.cost_usd != null ? "var(--ink)" : "var(--sx-ink-300)" }}>
                 {s.cost_usd != null ? `$${s.cost_usd.toFixed(2)}` : "–"}
             </td>
@@ -222,12 +276,8 @@ const Row = memo(function Row({
     );
 });
 
-/** Number of direct children for a root row. Uses the server-supplied count
- *  (which is always present on `/api/sessions` rows). */
+/** Number of direct children for a root row. */
 const childCountOf = (row: SessionListRow): number => row.direct_children_count ?? 0;
-
-// keep in sync with the <th> list below
-const COL_COUNT = 11;
 
 const PAGE_SIZE = 200;
 
@@ -236,8 +286,8 @@ export function SessionsRoute() {
     const navigate = useNavigate();
     const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
     const [search, setSearch] = useState("");
+    const [view, setView] = useState<ViewMode>("viz");
     const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
-    const [insightOpen, setInsightOpen] = useState<ReadonlySet<string>>(() => new Set());
     const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
 
     const toggleSelected = useCallback((id: string) => {
@@ -258,8 +308,6 @@ export function SessionsRoute() {
         });
     };
 
-    // Cache by filter set only - appended pages share the same key so
-    // setQueryData accumulates across loadMore() calls (mirrors recall.tsx).
     const baseKey = ["sessions", sourceFilter] as const;
     const query = useQuery({
         queryKey: baseKey,
@@ -274,9 +322,6 @@ export function SessionsRoute() {
     const allRoots = query.data?.sessions ?? [];
     const totalCount = query.data?.total_count ?? 0;
     const [appendLoading, setAppendLoading] = useState(false);
-    // Synchronous re-entrancy guard - mirrors the inspector's loadingRef
-    // pattern so a rapid IntersectionObserver burst can't double-fetch the
-    // same page before React commits `appendLoading`.
     const loadingRef = useRef(false);
 
     const loadMore = async (count: number = PAGE_SIZE) => {
@@ -294,14 +339,6 @@ export function SessionsRoute() {
             );
             queryClient.setQueryData<SessionListResponse>(baseKey, (prev) => {
                 if (!prev) return prev;
-                // why: `window` describes the slice the server returned, not
-                // the cumulative loaded range. Leave it pinned to the first
-                // page so its documented semantic ("server-returned slice")
-                // holds (mirrors recall.tsx fix).
-                // why total_count diverges from recall.tsx (which preserves prev.total_count):
-                // sessions list can grow under concurrent ingest; a stale total misleads the
-                // "X of Y roots" meta line and could keep the IntersectionObserver firing
-                // past the true end.
                 return {
                     ...prev,
                     sessions: [...prev.sessions, ...page.sessions],
@@ -314,8 +351,8 @@ export function SessionsRoute() {
         }
     };
 
-    // Sentinel-driven lazy page load. Same rootMargin as recall.tsx so the
-    // next page kicks in before the user reaches the bottom.
+    const colCount = view === "viz" ? COL_COUNT_VIZ : COL_COUNT_STRIP;
+
     const sentinelRef = useRef<HTMLTableRowElement | null>(null);
     useEffect(() => {
         if (!query.data) return;
@@ -331,6 +368,7 @@ export function SessionsRoute() {
         return () => obs.disconnect();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [query.data?.sessions.length, query.data?.total_count]);
+
     const filteredRoots = useMemo(() => {
         if (!search) return allRoots;
         const needle = search.toLowerCase();
@@ -340,17 +378,21 @@ export function SessionsRoute() {
         });
     }, [allRoots, search]);
 
-    // Count of roots that have at least one direct child. Server tells us
-    // this per-row via direct_children_count - no extra fetch needed.
     const rootsWithChildren = useMemo(
         () => filteredRoots.reduce((n, r) => n + (childCountOf(r) > 0 ? 1 : 0), 0),
         [filteredRoots],
     );
 
-    // Lazy children fetches, one per currently-expanded root. TanStack
-    // Query dedups + caches across re-renders so a row that's collapsed and
-    // re-expanded doesn't refetch within the staleTime window.
-    // TODO: direct_children_count is computed at fetch time. If ingest writes new children mid-session, the displayed count won't refresh until the user reloads the roots query. Acceptable for v0.1.
+    // Precompute maxLoc for the ΔLOC column normalisation (log1p scale).
+    const maxLoc = useMemo(() => {
+        let max = 1;
+        for (const r of filteredRoots) {
+            const total = (r.lines_added ?? 0) + (r.lines_removed ?? 0);
+            if (total > max) max = total;
+        }
+        return max;
+    }, [filteredRoots]);
+
     const expandedIds = useMemo(() => Array.from(expanded), [expanded]);
     const childQueries = useQueries({
         queries: expandedIds.map((id) => ({
@@ -380,19 +422,18 @@ export function SessionsRoute() {
         });
     }, []);
 
-    const toggleInsight = useCallback((id: string) => {
-        setInsightOpen((prev) => {
-            const next = new Set(prev);
-            if (next.has(id)) next.delete(id);
-            else next.add(id);
-            return next;
-        });
-    }, []);
-
     const allExpandableIds = useMemo(
         () => filteredRoots.filter((r) => childCountOf(r) > 0).map((r) => r.id),
         [filteredRoots],
     );
+
+    const filterBtnStyle = (active: boolean): CSSProperties => ({
+        padding: "4px 12px", fontSize: 11, fontWeight: 600,
+        border: "1px solid var(--line)",
+        background: active ? "var(--ink)" : "#fff",
+        color: active ? "#fff" : "var(--muted)",
+        borderRadius: 4, cursor: "pointer",
+    });
 
     return (
         <section className="panel">
@@ -406,20 +447,34 @@ export function SessionsRoute() {
             </header>
             {query.error ? <div className="error">Error: {String(query.error)}</div> : null}
             <div style={{ display: "flex", gap: 12, padding: "8px 0", alignItems: "center", flexWrap: "wrap" }}>
+                {/* Source filter buttons */}
                 <div style={{ display: "flex", gap: 4 }}>
                     {SOURCE_FILTERS.map((f) => (
                         <button
                             key={f}
                             onClick={() => setSourceFilter(f)}
-                            style={{
-                                padding: "4px 12px", fontSize: 11, fontWeight: 600,
-                                border: "1px solid var(--line)",
-                                background: sourceFilter === f ? "var(--ink)" : "#fff",
-                                color: sourceFilter === f ? "#fff" : "var(--muted)",
-                                borderRadius: 4, cursor: "pointer",
-                            }}
+                            style={filterBtnStyle(sourceFilter === f)}
                         >
                             {f}
+                        </button>
+                    ))}
+                </div>
+                {/* View toggle: viz / strip */}
+                <div style={{ display: "flex", gap: 0, border: "1px solid var(--line)", borderRadius: 4, overflow: "hidden" }}>
+                    {(["viz", "strip"] as const).map((v) => (
+                        <button
+                            key={v}
+                            onClick={() => setView(v)}
+                            style={{
+                                padding: "4px 10px", fontSize: 11, fontWeight: 600,
+                                border: "none",
+                                background: view === v ? "var(--ink)" : "#fff",
+                                color: view === v ? "#fff" : "var(--muted)",
+                                cursor: "pointer",
+                                borderRight: v === "viz" ? "1px solid var(--line)" : "none",
+                            }}
+                        >
+                            {v}
                         </button>
                     ))}
                 </div>
@@ -471,7 +526,7 @@ export function SessionsRoute() {
             {query.isLoading && !query.data ? <div className="loading">Loading…</div> : null}
             {query.data ? (
                 <div style={{ overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
-                <table style={{ width: "100%", minWidth: 1120, borderCollapse: "collapse" }}>
+                <table style={{ width: "100%", minWidth: view === "viz" ? 1280 : 1020, borderCollapse: "collapse" }}>
                     <thead>
                         <tr style={{ background: "var(--page)", fontSize: 11, color: "var(--muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>
                             <th style={{ width: 28 }}></th>
@@ -481,7 +536,13 @@ export function SessionsRoute() {
                             <th style={{ textAlign: "left", padding: "6px 8px" }}>started</th>
                             <th style={{ textAlign: "right", padding: "6px 8px" }}>duration</th>
                             <th style={{ textAlign: "right", padding: "6px 8px" }}>turns</th>
-                            <th style={{ textAlign: "center", padding: "6px 8px" }}>burn</th>
+                            {view === "viz" ? (
+                                <>
+                                    <th style={{ textAlign: "center", padding: "6px 8px" }}>story</th>
+                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>δloc</th>
+                                    <th style={{ textAlign: "left", padding: "6px 8px" }}>commits</th>
+                                </>
+                            ) : null}
                             <th style={{ textAlign: "right", padding: "6px 8px" }}>cost</th>
                             <th style={{ textAlign: "left", padding: "6px 8px" }}>signal</th>
                             <th style={{ textAlign: "left", padding: "6px 8px" }}></th>
@@ -496,9 +557,8 @@ export function SessionsRoute() {
                                 <Fragment key={parent.id}>
                                     <Row
                                         s={parent}
-                                        burnP90={query.data?.burn_p90 ?? null}
-                                        insightOpen={insightOpen.has(parent.id)}
-                                        onToggleInsight={toggleInsight}
+                                        view={view}
+                                        maxLoc={maxLoc}
                                         isSelected={selected.has(parent.id)}
                                         onToggleSelect={toggleSelected}
                                         {...(childCount > 0
@@ -510,18 +570,19 @@ export function SessionsRoute() {
                                             }
                                             : {})}
                                     />
-                                    {insightOpen.has(parent.id) ? (
-                                        <tr id={`session-insight-${parent.id}`}>
+                                    {/* strip view: underline strip row follows each root row */}
+                                    {view === "strip" ? (
+                                        <tr className="strip-row" style={{ borderBottom: "1px solid var(--sx-line-200)" }}>
                                             <td
-                                                colSpan={COL_COUNT}
-                                                style={{
-                                                    padding: 0,
-                                                    background: "var(--sx-tint-50)",
-                                                    boxShadow: "inset 3px 0 0 var(--sx-ink-900)",
-                                                    borderBottom: "1px solid var(--sx-line-200)",
-                                                }}
+                                                colSpan={COL_COUNT_STRIP}
+                                                style={{ padding: 0, height: "auto" }}
                                             >
-                                                <InsightPanel row={parent} />
+                                                <StoryStrip
+                                                    sessionId={parent.id}
+                                                    startedAt={parent.started_at}
+                                                    endedAt={parent.ended_at}
+                                                    variant="underline"
+                                                />
                                             </td>
                                         </tr>
                                     ) : null}
@@ -531,6 +592,8 @@ export function SessionsRoute() {
                                                 key={child.id}
                                                 s={child}
                                                 indent
+                                                view={view}
+                                                maxLoc={maxLoc}
                                                 isSelected={selected.has(child.id)}
                                                 onToggleSelect={toggleSelected}
                                             />
@@ -541,7 +604,7 @@ export function SessionsRoute() {
                         })}
                         {allRoots.length < totalCount ? (
                             <tr ref={sentinelRef}>
-                                <td colSpan={COL_COUNT} style={{
+                                <td colSpan={colCount} style={{
                                     padding: "12px 24px", color: "var(--muted)", fontSize: 12,
                                     fontFamily: "ui-monospace, monospace",
                                     textAlign: "center", borderTop: "1px dashed var(--line)",

--- a/apps/studio/src/styles/session-tokens.css
+++ b/apps/studio/src/styles/session-tokens.css
@@ -1,0 +1,32 @@
+/* apps/studio/src/styles/session-tokens.css
+   Sessions-list design system - one hue per meaning (see
+   docs/superpowers/specs/2026-06-11-sessions-list-remakeover-design.md).
+   red = failure/friction/revert/delete ONLY; green = pass/landed/add/live
+   ONLY; amber = elevated-not-failed ONLY; slate ramp = phases; violet =
+   subagents ONLY; source hues = badges ONLY; selection/open state =
+   monochrome ink. */
+:root {
+  --sx-ink-900: #1c2127;
+  --sx-ink-600: #555c66;
+  --sx-ink-500: #6e7681;
+  --sx-ink-300: #b6bcc4;
+  --sx-line-200: #e4e7eb;
+  --sx-line-100: #f0f2f4;
+  --sx-tint-50: #f7f8fa;
+  --sx-red-700: #b13434;
+  --sx-red-300: #e39891;
+  --sx-red-100: #faeceb;
+  --sx-green-700: #1f7a3f;
+  --sx-green-300: #8fc6a0;
+  --sx-green-100: #e8f3ec;
+  --sx-amber-700: #8f6514;
+  --sx-amber-500: #d99a32;
+  --sx-amber-100: #faf1dc;
+  --sx-phase-plan: #c9d4e0;
+  --sx-phase-exec: #8da2b6;
+  --sx-phase-review: #5e7590;
+  --sx-phase-idle: #ececec;
+  --sx-violet-500: #a193cb;
+  --sx-violet-700: #6f5fa3;
+  --sx-chart-line: #9aa7b6;
+}

--- a/docs/superpowers/plans/2026-06-11-sessions-list-remakeover.md
+++ b/docs/superpowers/plans/2026-06-11-sessions-list-remakeover.md
@@ -1,0 +1,1854 @@
+# Sessions List Remakeover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich the dashboard `/sessions` list with per-row signal columns (turns, burn sparkline, cost, friction badge, live dot) and an expandable insight panel (story bar, outcome, ΔLOC, skill arc, context seesaw, baseline footer), per the approved design spec `docs/superpowers/specs/2026-06-11-sessions-list-remakeover-design.md`.
+
+**Architecture:** Row enrichment comes from per-session aggregate tables already written at ingest (`session_health`, `session_token_usage`, `session_metrics`) via batched `session IN [page ids]` queries appended to the existing `fetchSessionsList` flow - never per-row turn scans or stacked graph derefs. The panel is fed by a new `/api/sessions/:id/insights` endpoint fetched lazily on expand. A new `burn_buckets` field on `session_token_usage` is precomputed at ingest from per-turn usage.
+
+**Tech Stack:** bun ≥1.3, TypeScript strict, Effect (beta), SurrealDB 3.0 (`makeTestSurrealClient` for tests), React 19 + TanStack Query/Router (studio SPA), hand-rolled SVG/CSS charts (no chart lib).
+
+**Worktree:** all work happens in `.claude/worktrees/sessions-list-remakeover` (branch `feat/sessions-list-remakeover`). All paths below are relative to that worktree root.
+
+**Conventions that bite:**
+- `bun test` is the runner (`bun:test`); a global hook may block `bun test` - if so, wrap in a tmp script (see memory note "Test runner").
+- SurrealQL: record-id IN-lists are interpolated raw (`formatRecordIdList`), string filters via `safeLiteral`. Datetimes cross the SDK as JS `Date`; over `<string>` casts they arrive as ISO strings.
+- Nested objects in SCHEMAFULL tables are JSON-encoded strings.
+- Effect: consult `effect-solutions show basics services-and-layers testing` before writing Effect code.
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `packages/lib/src/shared/dashboard-types.ts` | modify | wire types: `SessionListRow` additions, `SessionInsightsPayload`, `burn_p90` |
+| `packages/schema/src/schema.surql` | modify | `burn_buckets` field on `session_token_usage` |
+| `apps/axctl/src/ingest/burn-buckets.ts` | create | pure downsampler: per-turn tokens → ≤20 buckets |
+| `apps/axctl/src/ingest/burn-buckets.test.ts` | create | downsampler tests |
+| `apps/axctl/src/ingest/transcripts.ts` | modify | write `burn_buckets` in Claude session_token_usage UPSERT |
+| `apps/axctl/src/ingest/codex.ts` | modify | same for Codex |
+| `apps/axctl/src/dashboard/sessions-list.ts` | modify | enrichment batch queries + signal/is_live computation |
+| `apps/axctl/src/dashboard/sessions-list.test.ts` | create | list enrichment tests |
+| `apps/axctl/src/dashboard/session-baselines.ts` | create | 30d medians + p90, in-process cache |
+| `apps/axctl/src/dashboard/session-baselines.test.ts` | create | baseline math + cache tests |
+| `apps/axctl/src/dashboard/session-insights.ts` | create | panel payload assembly |
+| `apps/axctl/src/dashboard/session-insights.test.ts` | create | payload tests |
+| `apps/axctl/src/dashboard/router/routes/sessions.ts` | modify | register `/api/sessions/:id+/insights` |
+| `apps/studio/src/api.ts` | modify | `sessionInsights()` client fn |
+| `apps/studio/src/styles/session-tokens.css` | create | design-system CSS variables (palette/type) |
+| `apps/studio/src/components/session-insight/BurnSpark.tsx` | create | row sparkline |
+| `apps/studio/src/components/session-insight/SignalBadge.tsx` | create | clean/friction badge |
+| `apps/studio/src/components/session-insight/StoryBar.tsx` | create | band-1 hero bar |
+| `apps/studio/src/components/session-insight/InsightPanel.tsx` | create | accordion panel: bands + footer + cells |
+| `apps/studio/src/routes/sessions.tsx` | modify | new columns, chevron, accordion wiring |
+
+The four `session-insight` components live in one new directory so the panel is testable/replaceable as a unit. `InsightPanel.tsx` holds the four band-2 cells inline (they are small, presentational, and change together); split later only if one grows logic.
+
+---
+
+### Task 1: Wire types
+
+**Files:**
+- Modify: `packages/lib/src/shared/dashboard-types.ts:794-830`
+
+- [ ] **Step 1: Extend `SessionListRow` + `SessionListResponse`**
+
+In `packages/lib/src/shared/dashboard-types.ts`, replace the `SessionListRow` interface (line 794) with:
+
+```ts
+export interface SessionListRow {
+    readonly id: SessionId;
+    readonly project: string | null;
+    readonly source: string;
+    readonly cwd: string | null;
+    readonly model: string | null;
+    readonly started_at: string | null;
+    readonly ended_at: string | null;
+    /** True when a raw transcript pointer exists (session is inspectable). */
+    readonly has_raw_file: boolean;
+    readonly turn_count: number;
+    /** Parent session id when this row was spawned by another session (e.g. a
+     *  Claude subagent / Codex agent). Null for top-level sessions. Always
+     *  null on rows returned from `/api/sessions` (roots-only). Populated on
+     *  rows returned from `/api/sessions/:id/children`. */
+    readonly parent_session: SessionId | null;
+    /** Count of direct children (subagents) this session spawned. Used by the
+     *  SPA to render an expand toggle without first fetching children. Only
+     *  populated on roots returned from `/api/sessions`. */
+    readonly direct_children_count?: number;
+    /** Enrichment block - every field nullable: aggregate rows may not exist
+     *  for a session (pre-backfill ingests, 8s hook-probes, foreign sources).
+     *  Sourced from session_health / session_token_usage / session_metrics
+     *  batch lookups - NEVER from turn-table scans. */
+    readonly cost_usd: number | null;
+    /** Downsampled per-turn estimated tokens (≤20 buckets) for the BURN
+     *  sparkline. Null when the ingest predates burn_buckets backfill. */
+    readonly burn_buckets: ReadonlyArray<number> | null;
+    /** user_corrections + tool_errors. Null when no session_health row. */
+    readonly friction: number | null;
+    /** 'clean' = health row exists and friction is 0. Null = no health data. */
+    readonly signal: "clean" | "friction" | null;
+    readonly produced_commits: number | null;
+    readonly reverted_commits: number | null;
+    readonly lines_added: number | null;
+    readonly lines_removed: number | null;
+    /** ended_at is null AND the latest health derive write is recent - the
+     *  watcher re-ingests live transcripts within ~1 min, so a fresh
+     *  session_health.ts is the cheapest liveness proxy. */
+    readonly is_live: boolean;
+}
+```
+
+`turn_count` semantics change: now populated from `session_health.turns` when available (falls back to 0). Update the doc on the field if you wish, but keep the name/type - children rows and existing consumers rely on it.
+
+In `SessionListResponse` (line 816), add `burn_p90` after `total_count`:
+
+```ts
+export interface SessionListResponse {
+    /** Root sessions only - those with no inbound `spawned` edge. To get a
+     *  root's children, call `/api/sessions/:id/children`. */
+    readonly sessions: ReadonlyArray<SessionListRow>;
+    /** Total root count for the active filter set (independent of window). */
+    readonly total_count: number;
+    /** The user's 30-day p90 per-turn token burn. The SPA colors sparkline
+     *  buckets amber only above this threshold. Null when no usage history. */
+    readonly burn_p90: number | null;
+    /** The slice that was returned. Stays pinned to the first page on the
+     *  SPA side when subsequent pages are appended to the same cache key. */
+    readonly window: { readonly offset: number; readonly limit: number };
+}
+```
+
+- [ ] **Step 2: Add `SessionInsightsPayload`**
+
+Append after `SessionChildrenResponse` (line 830):
+
+```ts
+/** Wire format for `/api/sessions/:id/insights` - the expandable insight
+ *  panel on the sessions list. All sections optional-by-emptiness: a session
+ *  with no data for a section gets an empty array / null, and the SPA hides
+ *  that cell. */
+export interface SessionInsightsPayload {
+    readonly session: SessionId;
+    readonly phases: ReadonlyArray<{
+        readonly phase: string;
+        readonly start_ts: string;
+        readonly end_ts: string;
+        readonly duration_ms: number;
+    }>;
+    readonly friction_ticks: ReadonlyArray<{ readonly ts: string; readonly kind: string }>;
+    readonly commits: ReadonlyArray<{ readonly ts: string; readonly sha: string; readonly reverted: boolean }>;
+    readonly subagent_spans: ReadonlyArray<{
+        readonly id: SessionId;
+        readonly started_at: string | null;
+        readonly ended_at: string | null;
+    }>;
+    readonly checks: ReadonlyArray<{
+        readonly kind: string;
+        readonly runs: ReadonlyArray<{ readonly ts: string; readonly ok: boolean }>;
+    }>;
+    readonly loc: {
+        readonly added: number;
+        readonly removed: number;
+    } | null;
+    readonly durability: number | null;
+    readonly delegation_ratio: number | null;
+    readonly skills: ReadonlyArray<{ readonly name: string; readonly ts: string }>;
+    /** Context-fill curve, ≤60 points; t = ms offset from session start,
+     *  pct = estimated context fill 0..1 (prompt+cache tokens / window). */
+    readonly context_curve: ReadonlyArray<{ readonly t: number; readonly pct: number }>;
+    readonly compactions: ReadonlyArray<{ readonly ts: string }>;
+    readonly baseline: {
+        readonly cost_ratio: number | null;
+        readonly friction_ratio: number | null;
+        readonly land_ratio: number | null;
+        readonly cache_pct: number | null;
+    };
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run typecheck` (from worktree root)
+Expected: FAILS in `apps/axctl/src/dashboard/sessions-list.ts` and `apps/studio` - both construct `SessionListRow` without the new fields. That's the next tasks' work; note the exact error sites. If it fails anywhere ELSE, fix that now.
+
+- [ ] **Step 4: Stub the new fields at both construction sites so typecheck passes**
+
+In `apps/axctl/src/dashboard/sessions-list.ts`, add to BOTH row-construction object literals (the mapper inside `fetchSessionsList` ~line 122, and the `children` mapper in `fetchSessionChildren` ~line 224):
+
+```ts
+                    cost_usd: null,
+                    burn_buckets: null,
+                    friction: null,
+                    signal: null,
+                    produced_commits: null,
+                    reverted_commits: null,
+                    lines_added: null,
+                    lines_removed: null,
+                    is_live: false,
+```
+
+And in the `fetchSessionsList` return statement add `burn_p90: null`:
+
+```ts
+        return { sessions, total_count, burn_p90: null, window: { offset, limit } };
+```
+
+Run: `bun run typecheck`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/lib/src/shared/dashboard-types.ts apps/axctl/src/dashboard/sessions-list.ts
+git commit -m "feat(dashboard): wire types for sessions list enrichment + insights panel"
+```
+
+---
+
+### Task 2: Burn-bucket downsampler (pure)
+
+**Files:**
+- Create: `apps/axctl/src/ingest/burn-buckets.ts`
+- Test: `apps/axctl/src/ingest/burn-buckets.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/axctl/src/ingest/burn-buckets.test.ts
+import { describe, expect, test } from "bun:test";
+import { computeBurnBuckets } from "./burn-buckets.ts";
+
+describe("computeBurnBuckets", () => {
+    test("empty input -> empty array", () => {
+        expect(computeBurnBuckets([])).toEqual([]);
+    });
+
+    test("fewer turns than buckets -> one bucket per turn, order preserved", () => {
+        expect(computeBurnBuckets([10, 20, 30])).toEqual([10, 20, 30]);
+    });
+
+    test("exactly 20 turns -> identity", () => {
+        const turns = Array.from({ length: 20 }, (_, i) => i + 1);
+        expect(computeBurnBuckets(turns)).toEqual(turns);
+    });
+
+    test("more turns than buckets -> sums per bucket, total preserved", () => {
+        // 40 turns of 1 token -> 20 buckets of 2
+        const turns = Array.from({ length: 40 }, () => 1);
+        const buckets = computeBurnBuckets(turns);
+        expect(buckets).toHaveLength(20);
+        expect(buckets.every((b) => b === 2)).toBe(true);
+    });
+
+    test("uneven split keeps total", () => {
+        const turns = Array.from({ length: 33 }, (_, i) => i);
+        const buckets = computeBurnBuckets(turns);
+        expect(buckets).toHaveLength(20);
+        expect(buckets.reduce((a, b) => a + b, 0)).toBe(turns.reduce((a, b) => a + b, 0));
+    });
+
+    test("non-finite and negative inputs clamp to 0", () => {
+        expect(computeBurnBuckets([Number.NaN, -5, 7])).toEqual([0, 0, 7]);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/ingest/burn-buckets.test.ts`
+Expected: FAIL - `Cannot find module './burn-buckets.ts'`
+(If a global hook blocks `bun test`, write a tmp wrapper script `/tmp/run-bun-test.sh` containing `#!/bin/sh\nexec bun test "$@"`, `chmod +x` it, and use it for every test step in this plan.)
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/axctl/src/ingest/burn-buckets.ts
+/**
+ * Downsample per-turn token counts into a fixed-size bucket array for the
+ * sessions-list BURN sparkline. Bucket k sums the contiguous slice of turns
+ * that maps onto it, so the series total is preserved and heavy turns stay
+ * visible. Stored JSON-encoded on `session_token_usage.burn_buckets`.
+ */
+export const BURN_BUCKET_COUNT = 20;
+
+export const computeBurnBuckets = (
+    perTurnTokens: ReadonlyArray<number>,
+    bucketCount: number = BURN_BUCKET_COUNT,
+): number[] => {
+    const clean = perTurnTokens.map((t) => (Number.isFinite(t) && t > 0 ? Math.trunc(t) : 0));
+    if (clean.length === 0) return [];
+    if (clean.length <= bucketCount) return clean;
+    const buckets = new Array<number>(bucketCount).fill(0);
+    for (let i = 0; i < clean.length; i++) {
+        const k = Math.min(bucketCount - 1, Math.floor((i * bucketCount) / clean.length));
+        buckets[k] += clean[i] ?? 0;
+    }
+    return buckets;
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/ingest/burn-buckets.test.ts`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/ingest/burn-buckets.ts apps/axctl/src/ingest/burn-buckets.test.ts
+git commit -m "feat(ingest): burn-bucket downsampler for sessions-list sparkline"
+```
+
+---
+
+### Task 3: `burn_buckets` schema field + ingest writes
+
+**Files:**
+- Modify: `packages/schema/src/schema.surql:849` (session_token_usage block)
+- Modify: `apps/axctl/src/ingest/transcripts.ts:1484-1522` (`buildClaudeTokenUsageStatements`)
+- Modify: `apps/axctl/src/ingest/codex.ts:~1219` (codex session_token_usage UPSERT)
+
+- [ ] **Step 1: Add the schema field**
+
+In `packages/schema/src/schema.surql`, inside the `session_token_usage` block (after the `metrics` field, line ~850), add:
+
+```surql
+DEFINE FIELD burn_buckets ON session_token_usage TYPE option<string>;  -- JSON-encoded number[]; sessions-list BURN sparkline
+```
+
+`option<string>` (not `string`): existing rows predate the field - a non-optional field coerces NONE and crashes ingest (see the `commit.reverted` comment at schema.surql:236 for the precedent).
+
+- [ ] **Step 2: Run the schema test**
+
+Run: `bun test packages/schema`
+Expected: PASS (the schema render/parse tests accept the new field). This is a field add on an existing table - `SCHEMA_TABLES` registration does NOT apply (that's for new tables).
+
+- [ ] **Step 3: Write burn_buckets in the Claude UPSERT**
+
+In `apps/axctl/src/ingest/transcripts.ts`, import at the top of the file alongside the other ingest imports:
+
+```ts
+import { computeBurnBuckets } from "./burn-buckets.ts";
+```
+
+In `buildClaudeTokenUsageStatements` (line 1484), the per-turn series is available as `extracted.turnTokenUsages` (same data `buildClaudeTurnTokenUsageStatements` maps over; each entry has `seq` and `estimatedTokens`). Before the `return [` statement add:
+
+```ts
+    const burnBuckets = computeBurnBuckets(
+        [...extracted.turnTokenUsages]
+            .sort((a, b) => a.seq - b.seq)
+            .map((t) => t.estimatedTokens),
+    );
+```
+
+And add one pair to the `surrealObject([...])` list (after `["metrics", ...]` if present, otherwise after `["labels", ...]`):
+
+```ts
+            ["burn_buckets", burnBuckets.length > 0 ? surrealString(JSON.stringify(burnBuckets)) : "NONE"],
+```
+
+- [ ] **Step 4: Write burn_buckets in the Codex UPSERT**
+
+In `apps/axctl/src/ingest/codex.ts`, the session_token_usage UPSERT is at ~line 1219. Find the builder function containing it and check what per-turn data is in scope: codex batches carry `turnTokenUsages: CodexTurnTokenUsage[]` (declared ~line 461/476). Apply the same pattern - import `computeBurnBuckets` from `./burn-buckets.ts`, compute from the batch's `turnTokenUsages` sorted by `seq` mapping `estimatedTokens`, and add the same `["burn_buckets", ...]` pair to the UPSERT object.
+
+**Caveat the executor must handle:** codex flushes sessions in multiple batches (`drainedTurnTokenUsages` splicing at ~line 785). If the UPSERT site only sees one batch's turns, computing buckets from a partial batch would clobber earlier ones. Inspect the flow: if the usage builder receives cumulative per-session turn usage, wire it directly; if it receives per-batch slices, instead skip codex burn_buckets in this task and leave a `// TODO(burn-buckets): codex batching makes per-session series unavailable here; backfill via derive stage` comment plus `"NONE"` - Claude coverage is the v1 requirement, codex is best-effort.
+
+- [ ] **Step 5: Run ingest test suites**
+
+Run: `bun test apps/axctl/src/ingest/transcripts.test.ts apps/axctl/src/ingest/codex.test.ts`
+Expected: PASS. If a transcripts test snapshot-asserts the UPSERT statement strings, update the expected strings to include `burn_buckets`.
+
+- [ ] **Step 6: Apply schema + verify against live DB (manual, optional but recommended)**
+
+Run: `bun run db:schema` (from worktree root; applies DDL to the local SurrealDB)
+Then: `echo "SELECT burn_buckets FROM session_token_usage LIMIT 1;" | bun scripts/db-query.ts` - if no such script exists, verify via any existing query path; the assertion is just that the field is accepted.
+Expected: no error; existing rows show `burn_buckets: NONE`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/schema/src/schema.surql apps/axctl/src/ingest/transcripts.ts apps/axctl/src/ingest/codex.ts
+git commit -m "feat(ingest): persist burn_buckets on session_token_usage (claude + codex)"
+```
+
+---
+
+### Task 4: Enrich `fetchSessionsList`
+
+**Files:**
+- Modify: `apps/axctl/src/dashboard/sessions-list.ts`
+- Create: `apps/axctl/src/dashboard/sessions-list.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Test pattern follows `apps/axctl/src/dashboard/classifier-explain.test.ts` (`makeTestSurrealClient` + `Effect.provideService`). The stub's `fallback` array answers queries in call order: `fetchSessionsList` issues (1) the page+count multi-statement query → `[rows, [{total}]]`, (2) the spawned-counts query → `[counts]`, (3) the NEW enrichment multi-statement query → `[health[], usage[], metrics[]]`.
+
+```ts
+// apps/axctl/src/dashboard/sessions-list.test.ts
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { fetchSessionsList } from "./sessions-list.ts";
+
+const RID = "session:`aaaaaaaa-0000-0000-0000-000000000001`";
+const BARE = "aaaaaaaa-0000-0000-0000-000000000001";
+
+const pageRow = {
+    id: RID,
+    project: "ax",
+    source: "claude",
+    cwd: "/Users/x/ax",
+    model: "claude-fable-5",
+    started_at: "2026-06-11T01:00:00.000Z",
+    ended_at: null,
+    has_raw_file: true,
+};
+
+const run = (stub: SurrealClientShape) =>
+    Effect.runPromise(
+        fetchSessionsList({}).pipe(Effect.provideService(SurrealClient, stub)),
+    );
+
+describe("fetchSessionsList enrichment", () => {
+    test("joins health/usage/metrics onto rows and computes signal", async () => {
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            fallback: [
+                // query 1: page select + count (multi-statement -> two result sets)
+                [pageRow],
+                [{ total: 1 }],
+                // query 2: spawned counts
+                [],
+                // query 3: enrichment (multi-statement -> three result sets)
+                [{
+                    session: RID, turns: 58, tool_errors: 5, user_corrections: 2,
+                    context_pressure: "high", ts: new Date().toISOString(),
+                }],
+                [{
+                    session: RID, estimated_cost_usd: 11.2, estimated_tokens: 3_400_000,
+                    cache_read_input_tokens: 2_400_000, burn_buckets: "[100,200,300]",
+                }],
+                [{
+                    session: RID, produced_commits: 5, reverted_commits: 1,
+                    lines_added: 2100, lines_removed: 940,
+                }],
+            ],
+        }).client;
+
+        const res = await run(stub);
+        const row = res.sessions[0]!;
+        expect(row.id).toBe(BARE);
+        expect(row.turn_count).toBe(58);
+        expect(row.cost_usd).toBe(11.2);
+        expect(row.burn_buckets).toEqual([100, 200, 300]);
+        expect(row.friction).toBe(7);
+        expect(row.signal).toBe("friction");
+        expect(row.produced_commits).toBe(5);
+        expect(row.reverted_commits).toBe(1);
+        expect(row.lines_added).toBe(2100);
+        expect(row.lines_removed).toBe(940);
+        // ended_at null + fresh health ts -> live
+        expect(row.is_live).toBe(true);
+    });
+
+    test("rows without enrichment rows render null fields, signal null, not live", async () => {
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            fallback: [
+                [{ ...pageRow, ended_at: "2026-06-11T02:00:00.000Z" }],
+                [{ total: 1 }],
+                [], // spawned
+                [], [], [], // empty enrichment sets
+            ],
+        }).client;
+        const res = await run(stub);
+        const row = res.sessions[0]!;
+        expect(row.turn_count).toBe(0);
+        expect(row.cost_usd).toBeNull();
+        expect(row.burn_buckets).toBeNull();
+        expect(row.friction).toBeNull();
+        expect(row.signal).toBeNull();
+        expect(row.is_live).toBe(false);
+    });
+
+    test("zero-friction health row -> signal clean", async () => {
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            fallback: [
+                [pageRow],
+                [{ total: 1 }],
+                [],
+                [{ session: RID, turns: 4, tool_errors: 0, user_corrections: 0, context_pressure: "low", ts: new Date().toISOString() }],
+                [],
+                [],
+            ],
+        }).client;
+        const res = await run(stub);
+        expect(res.sessions[0]!.signal).toBe("clean");
+        expect(res.sessions[0]!.friction).toBe(0);
+    });
+
+    test("malformed burn_buckets JSON degrades to null", async () => {
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            fallback: [
+                [pageRow],
+                [{ total: 1 }],
+                [],
+                [],
+                [{ session: RID, estimated_cost_usd: 1, estimated_tokens: 10, cache_read_input_tokens: 0, burn_buckets: "not json" }],
+                [],
+            ],
+        }).client;
+        const res = await run(stub);
+        expect(res.sessions[0]!.burn_buckets).toBeNull();
+        expect(res.sessions[0]!.cost_usd).toBe(1);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dashboard/sessions-list.test.ts`
+Expected: FAIL - enrichment fields are stubbed null/0 from Task 1.
+
+Note: if `makeTestSurrealClient`'s `fallback` answers *per `.query()` call* (arrays-of-result-sets) rather than per result set, restructure the fallback nesting accordingly - open `packages/lib/src/testing/surreal.ts` and match its actual contract before fighting the test.
+
+- [ ] **Step 3: Implement enrichment in `fetchSessionsList`**
+
+In `apps/axctl/src/dashboard/sessions-list.ts`:
+
+Add near the top (after `formatRecordIdList`):
+
+```ts
+/** ended_at-null sessions count as live only when the health derive row was
+ *  written recently - the watcher re-ingests live transcripts within ~1 min,
+ *  so a stale ts means the session is dead, just never closed. */
+const LIVE_HEALTH_TS_WINDOW_MS = 10 * 60_000;
+
+interface HealthRow {
+    readonly session: string;
+    readonly turns: number | null;
+    readonly tool_errors: number | null;
+    readonly user_corrections: number | null;
+    readonly context_pressure: string | null;
+    readonly ts: string | null;
+}
+interface UsageRow {
+    readonly session: string;
+    readonly estimated_cost_usd: number | null;
+    readonly estimated_tokens: number | null;
+    readonly cache_read_input_tokens: number | null;
+    readonly burn_buckets: string | null;
+}
+interface MetricsRow {
+    readonly session: string;
+    readonly produced_commits: number | null;
+    readonly reverted_commits: number | null;
+    readonly lines_added: number | null;
+    readonly lines_removed: number | null;
+}
+
+const parseBurnBuckets = (raw: string | null): number[] | null => {
+    if (!raw) return null;
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return null;
+        return parsed.map((v) => (typeof v === "number" && Number.isFinite(v) ? v : 0));
+    } catch {
+        return null;
+    }
+};
+```
+
+Then in `fetchSessionsList`, after the spawned-counts query block (line ~160) and BEFORE the `sessions` mapping, add the enrichment fetch (single multi-statement round-trip, same websocket-framing rationale as the page query):
+
+```ts
+        // Enrichment: one multi-statement round-trip against the three
+        // per-session aggregate tables. All keyed `session IN [...]` on
+        // UNIQUE session indexes - no turn scans, no graph derefs (the two
+        // documented hang classes for this surface).
+        const healthBySession = new Map<string, HealthRow>();
+        const usageBySession = new Map<string, UsageRow>();
+        const metricsBySession = new Map<string, MetricsRow>();
+        if (rawIds.length > 0) {
+            const inList = formatRecordIdList(rawIds);
+            const [health, usage, metrics] = yield* db.query<[
+                HealthRow[],
+                UsageRow[],
+                MetricsRow[],
+            ]>(`
+                SELECT <string>session AS session, turns, tool_errors,
+                       user_corrections, context_pressure, <string>ts AS ts
+                FROM session_health WHERE session IN [${inList}];
+                SELECT <string>session AS session, estimated_cost_usd,
+                       estimated_tokens, cache_read_input_tokens, burn_buckets
+                FROM session_token_usage WHERE session IN [${inList}];
+                SELECT <string>session AS session, produced_commits,
+                       reverted_commits, lines_added, lines_removed
+                FROM session_metrics WHERE session IN [${inList}];
+            `);
+            for (const h of health) healthBySession.set(h.session, h);
+            for (const u of usage) usageBySession.set(u.session, u);
+            for (const m of metrics) metricsBySession.set(m.session, m);
+        }
+```
+
+Replace the final `sessions` mapping (currently only fills `direct_children_count`) with:
+
+```ts
+        const now = Date.now();
+        const sessions: SessionListRow[] = paged.items.map((s) => {
+            const rawId = rawIdByBare.get(s.id) ?? "";
+            const health = healthBySession.get(rawId);
+            const usage = usageBySession.get(rawId);
+            const metrics = metricsBySession.get(rawId);
+            const friction = health
+                ? (Number(health.user_corrections) || 0) + (Number(health.tool_errors) || 0)
+                : null;
+            const healthTs = health?.ts ? new Date(health.ts).getTime() : Number.NaN;
+            return {
+                ...s,
+                direct_children_count: childCountByRawId.get(rawId) ?? 0,
+                turn_count: health?.turns ?? 0,
+                cost_usd: usage?.estimated_cost_usd ?? null,
+                burn_buckets: parseBurnBuckets(usage?.burn_buckets ?? null),
+                friction,
+                signal: friction === null ? null : friction === 0 ? "clean" : "friction",
+                produced_commits: metrics?.produced_commits ?? null,
+                reverted_commits: metrics?.reverted_commits ?? null,
+                lines_added: metrics?.lines_added ?? null,
+                lines_removed: metrics?.lines_removed ?? null,
+                is_live: s.ended_at === null
+                    && Number.isFinite(healthTs)
+                    && now - healthTs < LIVE_HEALTH_TS_WINDOW_MS,
+            };
+        });
+```
+
+Leave `burn_p90: null` in the return for now - Task 5 wires it.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test apps/axctl/src/dashboard/sessions-list.test.ts`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Typecheck + full dashboard test sweep**
+
+Run: `bun run typecheck && bun test apps/axctl/src/dashboard`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/axctl/src/dashboard/sessions-list.ts apps/axctl/src/dashboard/sessions-list.test.ts
+git commit -m "feat(dashboard): enrich sessions list rows from per-session aggregates"
+```
+
+---
+
+### Task 5: Baselines module (30d medians + burn p90)
+
+**Files:**
+- Create: `apps/axctl/src/dashboard/session-baselines.ts`
+- Test: `apps/axctl/src/dashboard/session-baselines.test.ts`
+- Modify: `apps/axctl/src/dashboard/sessions-list.ts` (wire `burn_p90`)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/axctl/src/dashboard/session-baselines.test.ts
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { fetchSessionBaselines, median, p90, _resetBaselineCacheForTests } from "./session-baselines.ts";
+
+describe("baseline math", () => {
+    test("median of odd/even/empty", () => {
+        expect(median([3, 1, 2])).toBe(2);
+        expect(median([4, 1, 2, 3])).toBe(2.5);
+        expect(median([])).toBeNull();
+    });
+    test("p90 picks the 90th percentile (nearest-rank)", () => {
+        const xs = Array.from({ length: 100 }, (_, i) => i + 1);
+        expect(p90(xs)).toBe(90);
+        expect(p90([])).toBeNull();
+    });
+});
+
+describe("fetchSessionBaselines", () => {
+    test("computes medians from 30d aggregate rows and caches", async () => {
+        _resetBaselineCacheForTests();
+        let calls = 0;
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            handler: (sql) => {
+                calls++;
+                // one multi-statement query -> three result sets
+                return [
+                    [{ estimated_cost_usd: 2 }, { estimated_cost_usd: 4 }],
+                    [{ friction: 1 }, { friction: 3 }],
+                    [{ time_to_land_ms: 100 }, { time_to_land_ms: 300 }],
+                ];
+            },
+        }).client;
+
+        const a = await Effect.runPromise(
+            fetchSessionBaselines().pipe(Effect.provideService(SurrealClient, stub)),
+        );
+        expect(a.median_cost_usd).toBe(3);
+        expect(a.median_friction).toBe(2);
+        expect(a.median_time_to_land_ms).toBe(200);
+
+        await Effect.runPromise(
+            fetchSessionBaselines().pipe(Effect.provideService(SurrealClient, stub)),
+        );
+        expect(calls).toBe(1); // second call served from cache
+    });
+});
+```
+
+(If `makeTestSurrealClient` has no `handler` option, use `fallback` with the three result sets and assert cache behaviour by checking that a second call with an EMPTY fallback still resolves - read `packages/lib/src/testing/surreal.ts` first and adapt; the assertions stay the same.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dashboard/session-baselines.test.ts`
+Expected: FAIL - module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/axctl/src/dashboard/session-baselines.ts
+/**
+ * 30-day per-user baselines for the sessions-list insight panel footer
+ * ("vs 30d median") and the BURN sparkline amber threshold (p90 per-turn
+ * burn). Computed from the per-session aggregate tables only - bounded by
+ * the 30d window, no turn scans. Cached in-process: the numbers move on
+ * ingest cadence, not request cadence.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+
+export interface SessionBaselines {
+    readonly median_cost_usd: number | null;
+    readonly median_friction: number | null;
+    readonly median_time_to_land_ms: number | null;
+    readonly burn_p90: number | null;
+}
+
+export const median = (xs: ReadonlyArray<number>): number | null => {
+    if (xs.length === 0) return null;
+    const s = [...xs].sort((a, b) => a - b);
+    const mid = Math.floor(s.length / 2);
+    return s.length % 2 === 1 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2;
+};
+
+export const p90 = (xs: ReadonlyArray<number>): number | null => {
+    if (xs.length === 0) return null;
+    const s = [...xs].sort((a, b) => a - b);
+    return s[Math.min(s.length - 1, Math.ceil(s.length * 0.9) - 1)]!;
+};
+
+const CACHE_TTL_MS = 5 * 60_000;
+let cache: { at: number; value: SessionBaselines } | null = null;
+export const _resetBaselineCacheForTests = (): void => { cache = null; };
+
+export const fetchSessionBaselines = (): Effect.Effect<SessionBaselines, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        if (cache && Date.now() - cache.at < CACHE_TTL_MS) return cache.value;
+        const db = yield* SurrealClient;
+        // burn p90 source: average per-turn burn per session
+        // (estimated_tokens / health.turns) is a cheap proxy that avoids
+        // touching turn_token_usage at all; good enough for a color
+        // threshold.
+        const [costs, frictions, lands] = yield* db.query<[
+            Array<{ estimated_cost_usd: number | null }>,
+            Array<{ friction: number | null }>,
+            Array<{ time_to_land_ms: number | null }>,
+        ]>(`
+            SELECT estimated_cost_usd FROM session_token_usage
+                WHERE ts > time::now() - 30d AND estimated_cost_usd IS NOT NONE;
+            SELECT (user_corrections + tool_errors) AS friction FROM session_health
+                WHERE ts > time::now() - 30d;
+            SELECT time_to_land_ms FROM session_metrics
+                WHERE ts > time::now() - 30d AND time_to_land_ms IS NOT NONE;
+        `);
+        const [burns] = yield* db.query<[
+            Array<{ avg_burn: number | null }>,
+        ]>(`
+            SELECT (estimated_tokens / math::max([turns, 1])) AS avg_burn
+            FROM (
+                SELECT estimated_tokens, turns FROM session_health
+                WHERE ts > time::now() - 30d AND turns > 0
+            );
+        `);
+        const value: SessionBaselines = {
+            median_cost_usd: median(costs.map((r) => Number(r.estimated_cost_usd)).filter(Number.isFinite)),
+            median_friction: median(frictions.map((r) => Number(r.friction)).filter(Number.isFinite)),
+            median_time_to_land_ms: median(lands.map((r) => Number(r.time_to_land_ms)).filter(Number.isFinite)),
+            burn_p90: p90(burns.map((r) => Number(r.avg_burn)).filter(Number.isFinite)),
+        };
+        cache = { at: Date.now(), value };
+        return value;
+    });
+```
+
+**SurrealQL caveat for the executor:** the nested-`FROM (SELECT ...)` form and `math::max([..])` must be verified against SurrealDB 3.0.x before trusting - if either misbehaves, fetch `estimated_tokens, turns` rows plainly and do the division in JS (preferred fallback; keep aggregates deref-free per the documented hang class).
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test apps/axctl/src/dashboard/session-baselines.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Wire `burn_p90` into the list response**
+
+In `apps/axctl/src/dashboard/sessions-list.ts` import and call it (degrade to null on failure - enrichment must never break the base list):
+
+```ts
+import { fetchSessionBaselines } from "./session-baselines.ts";
+```
+
+Replace `burn_p90: null` in the return with a guarded fetch placed just before the return:
+
+```ts
+        const baselines = yield* fetchSessionBaselines().pipe(
+            Effect.catchAll(() => Effect.succeed(null)),
+        );
+        return {
+            sessions,
+            total_count,
+            burn_p90: baselines?.burn_p90 ?? null,
+            window: { offset, limit },
+        };
+```
+
+Update `apps/axctl/src/dashboard/sessions-list.test.ts`: the stub now receives one more query (baselines). Add to each test's `fallback` the extra result sets (`[], [], []` and `[]` for the burns query), or call `_resetBaselineCacheForTests()` in a `beforeEach` and append empty sets - match the client contract you established in Task 4 Step 2.
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `bun test apps/axctl/src/dashboard && bun run typecheck`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/axctl/src/dashboard/session-baselines.ts apps/axctl/src/dashboard/session-baselines.test.ts apps/axctl/src/dashboard/sessions-list.ts apps/axctl/src/dashboard/sessions-list.test.ts
+git commit -m "feat(dashboard): 30d session baselines (medians + burn p90) with in-process cache"
+```
+
+---
+
+### Task 6: `/api/sessions/:id/insights` endpoint
+
+**Files:**
+- Create: `apps/axctl/src/dashboard/session-insights.ts`
+- Test: `apps/axctl/src/dashboard/session-insights.test.ts`
+- Modify: `apps/axctl/src/dashboard/router/routes/sessions.ts`
+
+- [ ] **Step 1: Reconnoitre `diagnostic_event.status` values (5 min, informs the ok-mapping)**
+
+Run a one-off query against the live DB (any existing query path, e.g. `ax recall` debug or a scratch bun script):
+
+```surql
+SELECT status, count() AS c FROM diagnostic_event GROUP BY status;
+SELECT kind, count() AS c FROM diagnostic_event GROUP BY kind;
+```
+
+Record the real values in a comment in `session-insights.ts`. The implementation below assumes pass-ish statuses are `pass|passed|success|ok` and everything else is a failure; adjust the `OK_STATUSES` set to the observed values.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// apps/axctl/src/dashboard/session-insights.test.ts
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { fetchSessionInsights } from "./session-insights.ts";
+import { _resetBaselineCacheForTests } from "./session-baselines.ts";
+
+const BARE = "aaaaaaaa-0000-0000-0000-000000000001";
+
+describe("fetchSessionInsights", () => {
+    test("assembles full payload", async () => {
+        _resetBaselineCacheForTests();
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            fallback: [
+                // q1 multi-statement: phases, reactions, produced-commits, spawned, diagnostics, invoked, metrics, usage(+health single)
+                [{ phase: "plan", start_ts: "2026-06-11T01:00:00Z", end_ts: "2026-06-11T01:12:00Z", duration_ms: 720000 }],
+                [{ ts: "2026-06-11T01:20:00Z", reaction_type: "correction" }],
+                [{ ts: "2026-06-11T01:30:00Z", sha: "abc123", reverted: true }],
+                [{ id: "session:`bbbbbbbb-0000-0000-0000-000000000002`", started_at: "2026-06-11T01:05:00Z", ended_at: "2026-06-11T01:15:00Z" }],
+                [{ kind: "test", status: "fail", ts: "2026-06-11T01:21:00Z" }, { kind: "test", status: "pass", ts: "2026-06-11T01:25:00Z" }],
+                [{ skill: "skill:`superpowers__tdd`", ts: "2026-06-11T01:02:00Z" }],
+                [{ lines_added: 2100, lines_removed: 940, durability_ratio: 0.8, delegation_ratio: 0.38, time_to_land_ms: 200 }],
+                [{ estimated_cost_usd: 11.2, context_window: 200000, cache_read_input_tokens: 100, prompt_tokens: 50, estimated_tokens: 150, user_corrections: 2, tool_errors: 5 }],
+                // q2: turn_token_usage curve
+                [{ seq: 1, prompt_tokens: 1000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, ts: "2026-06-11T01:01:00Z" }],
+                // q3: compactions
+                [{ ts: "2026-06-11T01:40:00Z" }],
+                // q4 (baselines, via fetchSessionBaselines): 3 sets + burns
+                [{ estimated_cost_usd: 5.6 }], [{ friction: 7 }], [{ time_to_land_ms: 400 }],
+                [{ avg_burn: 100 }],
+            ],
+        }).client;
+
+        const p = await Effect.runPromise(
+            fetchSessionInsights(BARE).pipe(Effect.provideService(SurrealClient, stub)),
+        );
+        expect(p.session).toBe(BARE);
+        expect(p.phases[0]?.phase).toBe("plan");
+        expect(p.friction_ticks[0]?.kind).toBe("correction");
+        expect(p.commits[0]).toEqual({ ts: "2026-06-11T01:30:00Z", sha: "abc123", reverted: true });
+        expect(p.subagent_spans[0]?.id).toBe("bbbbbbbb-0000-0000-0000-000000000002");
+        expect(p.checks).toEqual([{ kind: "test", runs: [
+            { ts: "2026-06-11T01:21:00Z", ok: false },
+            { ts: "2026-06-11T01:25:00Z", ok: true },
+        ]}]);
+        expect(p.skills[0]?.name).toBe("superpowers:tdd");
+        expect(p.loc).toEqual({ added: 2100, removed: 940 });
+        expect(p.durability).toBe(0.8);
+        expect(p.context_curve.length).toBeGreaterThan(0);
+        expect(p.compactions).toHaveLength(1);
+        expect(p.baseline.cost_ratio).toBe(2); // 11.2 / 5.6
+        expect(p.baseline.friction_ratio).toBe(1); // (2+5)/7
+        expect(p.baseline.land_ratio).toBe(0.5); // 200/400
+    });
+
+    test("empty session -> empty sections, null baseline ratios", async () => {
+        _resetBaselineCacheForTests();
+        const stub = makeTestSurrealClient({
+            denyWrites: true,
+            fallback: [
+                [], [], [], [], [], [], [], [],
+                [],
+                [],
+                [], [], [], [],
+            ],
+        }).client;
+        const p = await Effect.runPromise(
+            fetchSessionInsights(BARE).pipe(Effect.provideService(SurrealClient, stub)),
+        );
+        expect(p.phases).toEqual([]);
+        expect(p.loc).toBeNull();
+        expect(p.baseline.cost_ratio).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dashboard/session-insights.test.ts`
+Expected: FAIL - module not found.
+
+- [ ] **Step 4: Implement**
+
+```ts
+// apps/axctl/src/dashboard/session-insights.ts
+/**
+ * Insight-panel payload for one session - feeds the expandable accordion on
+ * the sessions list (`/api/sessions/:id/insights`). Everything here is
+ * single-session scoped and index-backed: phase_span / reaction_event /
+ * produced / spawned / diagnostic_event / invoked / session_metrics /
+ * session_token_usage+session_health by session id, turn_token_usage via the
+ * (session, seq) index. Single-session edge derefs (produced.out.sha) are
+ * bounded and safe - the documented deref hang was an 87k-edge AGGREGATE,
+ * not a one-session lookup.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import type { SessionInsightsPayload } from "@ax/lib/shared/dashboard-types";
+import { toBareSessionId, toSessionRid } from "@ax/lib/shared/session-id";
+import { fetchSessionBaselines } from "./session-baselines.ts";
+
+/** Verified against live data in Task 6 Step 1 - adjust if the GROUP BY
+ *  showed different status vocabulary. */
+const OK_STATUSES = new Set(["pass", "passed", "success", "ok"]);
+
+const CURVE_MAX_POINTS = 60;
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+/** skill record key -> human name: strip table prefix/backticks, decode the
+ *  `__` plugin-namespace encoding (see packages/lib/src/skill-id.ts). */
+const skillNameFromKey = (key: string): string =>
+    key.replace(/^skill:/, "").replace(/`/g, "").replace(/__/g, ":");
+
+const ratio = (a: number | null | undefined, b: number | null | undefined): number | null =>
+    a !== null && a !== undefined && b !== null && b !== undefined && Number.isFinite(a) && Number.isFinite(b) && b > 0
+        ? a / b
+        : null;
+
+export const fetchSessionInsights = (
+    bareId: string,
+): Effect.Effect<SessionInsightsPayload, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const session = toBareSessionId(bareId);
+        const rid = toSessionRid(session);
+
+        const [phases, reactions, commits, spawnedRows, diagnostics, invokedRows, metricsRows, usageRows] =
+            yield* db.query<[
+                Array<{ phase: string; start_ts: string; end_ts: string; duration_ms: number }>,
+                Array<{ ts: string; reaction_type: string }>,
+                Array<{ ts: string; sha: string; reverted: boolean | null }>,
+                Array<{ id: string; started_at: string | null; ended_at: string | null }>,
+                Array<{ kind: string; status: string | null; ts: string }>,
+                Array<{ skill: string; ts: string }>,
+                Array<{ lines_added: number; lines_removed: number; durability_ratio: number | null; delegation_ratio: number | null; time_to_land_ms: number | null }>,
+                Array<{ estimated_cost_usd: number | null; context_window: number | null; cache_read_input_tokens: number | null; prompt_tokens: number | null; estimated_tokens: number | null; user_corrections: number | null; tool_errors: number | null }>,
+            ]>(`
+                SELECT phase, <string>start_ts AS start_ts, <string>end_ts AS end_ts, duration_ms
+                    FROM phase_span WHERE session = ${rid} ORDER BY start_ts ASC;
+                SELECT <string>ts AS ts, reaction_type
+                    FROM reaction_event WHERE session = ${rid} AND polarity = 'negative' ORDER BY ts ASC;
+                SELECT <string>out.ts AS ts, out.sha AS sha, out.reverted AS reverted
+                    FROM produced WHERE in = ${rid};
+                SELECT <string>out AS id, <string>out.started_at AS started_at, <string>out.ended_at AS ended_at
+                    FROM spawned WHERE in = ${rid};
+                SELECT kind, status, <string>ts AS ts
+                    FROM diagnostic_event WHERE session = ${rid} ORDER BY ts ASC;
+                SELECT <string>out AS skill, <string>ts AS ts
+                    FROM invoked WHERE session = ${rid} ORDER BY ts ASC;
+                SELECT lines_added, lines_removed, durability_ratio, delegation_ratio, time_to_land_ms
+                    FROM session_metrics WHERE session = ${rid};
+                SELECT estimated_cost_usd, context_window, cache_read_input_tokens, prompt_tokens, estimated_tokens,
+                       (SELECT VALUE user_corrections FROM session_health WHERE session = ${rid})[0] AS user_corrections,
+                       (SELECT VALUE tool_errors FROM session_health WHERE session = ${rid})[0] AS tool_errors
+                    FROM session_token_usage WHERE session = ${rid};
+            `);
+
+        const [turnUsage] = yield* db.query<[
+            Array<{ seq: number; prompt_tokens: number | null; cache_read_input_tokens: number | null; cache_creation_input_tokens: number | null; ts: string }>,
+        ]>(`
+            SELECT seq, prompt_tokens, cache_read_input_tokens, cache_creation_input_tokens, <string>ts AS ts
+            FROM turn_token_usage WHERE session = ${rid} ORDER BY seq ASC;
+        `);
+
+        const [compactionRows] = yield* db.query<[Array<{ ts: string }>]>(`
+            SELECT <string>ts AS ts FROM compaction WHERE session = ${rid} ORDER BY ts ASC;
+        `);
+
+        const metrics = metricsRows[0] ?? null;
+        const usage = usageRows[0] ?? null;
+
+        // context curve: per-turn input-side tokens vs window, downsampled
+        const window = usage?.context_window ?? DEFAULT_CONTEXT_WINDOW;
+        const t0 = turnUsage[0]?.ts ? new Date(turnUsage[0].ts).getTime() : 0;
+        const allPoints = turnUsage.map((u) => ({
+            t: u.ts ? Math.max(0, new Date(u.ts).getTime() - t0) : 0,
+            pct: Math.min(1, ((u.prompt_tokens ?? 0) + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0)) / window),
+        }));
+        const stride = Math.max(1, Math.ceil(allPoints.length / CURVE_MAX_POINTS));
+        const context_curve = allPoints.filter((_, i) => i % stride === 0 || i === allPoints.length - 1);
+
+        // checks: group diagnostics by kind, runs in ts order
+        const byKind = new Map<string, Array<{ ts: string; ok: boolean }>>();
+        for (const d of diagnostics) {
+            const runs = byKind.get(d.kind) ?? [];
+            runs.push({ ts: d.ts, ok: d.status !== null && OK_STATUSES.has(d.status.toLowerCase()) });
+            byKind.set(d.kind, runs);
+        }
+
+        const friction = usage && (usage.user_corrections !== null || usage.tool_errors !== null)
+            ? (Number(usage.user_corrections) || 0) + (Number(usage.tool_errors) || 0)
+            : null;
+
+        const baselines = yield* fetchSessionBaselines().pipe(
+            Effect.catchAll(() => Effect.succeed(null)),
+        );
+        const cacheTokens = usage?.cache_read_input_tokens ?? null;
+        const totalTokens = usage?.estimated_tokens ?? null;
+
+        return {
+            session,
+            phases,
+            friction_ticks: reactions.map((r) => ({ ts: r.ts, kind: r.reaction_type })),
+            commits: commits
+                .filter((c) => c.sha && c.ts)
+                .map((c) => ({ ts: c.ts, sha: c.sha, reverted: c.reverted === true }))
+                .sort((a, b) => a.ts.localeCompare(b.ts)),
+            subagent_spans: spawnedRows.map((s) => ({
+                id: toBareSessionId(s.id),
+                started_at: s.started_at,
+                ended_at: s.ended_at,
+            })),
+            checks: Array.from(byKind.entries()).map(([kind, runs]) => ({ kind, runs })),
+            loc: metrics ? { added: metrics.lines_added, removed: metrics.lines_removed } : null,
+            durability: metrics?.durability_ratio ?? null,
+            delegation_ratio: metrics?.delegation_ratio ?? null,
+            skills: invokedRows.map((r) => ({ name: skillNameFromKey(r.skill), ts: r.ts })),
+            context_curve,
+            compactions: compactionRows,
+            baseline: {
+                cost_ratio: ratio(usage?.estimated_cost_usd, baselines?.median_cost_usd),
+                friction_ratio: ratio(friction, baselines?.median_friction),
+                land_ratio: ratio(metrics?.time_to_land_ms, baselines?.median_time_to_land_ms),
+                cache_pct: cacheTokens !== null && totalTokens !== null && totalTokens > 0
+                    ? cacheTokens / totalTokens
+                    : null,
+            },
+        };
+    });
+```
+
+**SurrealQL caveats for the executor:** (a) the inline `(SELECT VALUE ... )[0]` subquery for health counters inside the usage select must be verified on 3.0.x - if it misbehaves, issue it as a 9th plain statement in the same multi-statement query and merge in JS (preferred if in doubt); (b) `out.sha` derefs on `produced`/`spawned` edges of ONE session are bounded (≤ dozens) and fine; do NOT copy this pattern into cross-session aggregates.
+
+- [ ] **Step 5: Run tests**
+
+Run: `bun test apps/axctl/src/dashboard/session-insights.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Register the route**
+
+In `apps/axctl/src/dashboard/router/routes/sessions.ts`, import:
+
+```ts
+import { fetchSessionInsights } from "../../session-insights.ts";
+```
+
+Add to `sessionRoutes` BEFORE the catch-all `/api/sessions/:id+` entry (order matters - the catch-all must stay last; mirror how `/children` sits above it):
+
+```ts
+    legacyGetRoute({
+        path: "/api/sessions/:id+/insights",
+        decode: requiredSessionId,
+        handler: (id) => fetchSessionInsights(id),
+    }),
+```
+
+- [ ] **Step 7: Typecheck + dashboard tests + smoke**
+
+Run: `bun run typecheck && bun test apps/axctl/src/dashboard`
+Expected: PASS
+
+Smoke (optional, needs running DB): `bin/axctl serve` in one shell, then
+`curl -s "http://127.0.0.1:1799/api/sessions?limit=3" | jq '.sessions[0] | {turn_count, cost_usd, signal}'` and
+`curl -s "http://127.0.0.1:1799/api/sessions/<some-id>/insights" | jq 'keys'`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/axctl/src/dashboard/session-insights.ts apps/axctl/src/dashboard/session-insights.test.ts apps/axctl/src/dashboard/router/routes/sessions.ts
+git commit -m "feat(dashboard): /api/sessions/:id/insights panel endpoint"
+```
+
+---
+
+### Task 7: SPA - design tokens + api client
+
+**Files:**
+- Create: `apps/studio/src/styles/session-tokens.css`
+- Modify: `apps/studio/src/api.ts` (add `sessionInsights`)
+
+- [ ] **Step 1: Create the token stylesheet**
+
+```css
+/* apps/studio/src/styles/session-tokens.css
+   Sessions-list design system - one hue per meaning (see
+   docs/superpowers/specs/2026-06-11-sessions-list-remakeover-design.md).
+   red = failure/friction/revert/delete ONLY; green = pass/landed/add/live
+   ONLY; amber = elevated-not-failed ONLY; slate ramp = phases; violet =
+   subagents ONLY; source hues = badges ONLY; selection/open state =
+   monochrome ink. */
+:root {
+  --sx-ink-900: #1c2127;
+  --sx-ink-600: #555c66;
+  --sx-ink-500: #6e7681;
+  --sx-ink-300: #b6bcc4;
+  --sx-line-200: #e4e7eb;
+  --sx-line-100: #f0f2f4;
+  --sx-tint-50: #f7f8fa;
+  --sx-red-700: #b13434;
+  --sx-red-300: #e39891;
+  --sx-red-100: #faeceb;
+  --sx-green-700: #1f7a3f;
+  --sx-green-300: #8fc6a0;
+  --sx-green-100: #e8f3ec;
+  --sx-amber-700: #8f6514;
+  --sx-amber-500: #d99a32;
+  --sx-amber-100: #faf1dc;
+  --sx-phase-plan: #c9d4e0;
+  --sx-phase-exec: #8da2b6;
+  --sx-phase-review: #5e7590;
+  --sx-phase-idle: #ececec;
+  --sx-violet-500: #a193cb;
+  --sx-violet-700: #6f5fa3;
+  --sx-chart-line: #9aa7b6;
+}
+```
+
+Import it where the studio app pulls global styles - find the entry with `rg -n "import.*\.css" apps/studio/src/main.tsx apps/studio/src/root.tsx apps/studio/src/app.tsx 2>/dev/null` and add `import "./styles/session-tokens.css";` next to the existing global CSS import.
+
+- [ ] **Step 2: Add the api client fn**
+
+In `apps/studio/src/api.ts`, import `SessionInsightsPayload` from `@ax/lib/shared/dashboard-types` (extend the existing type-import statement), then add next to `sessionChildren` (~line 255):
+
+```ts
+    sessionInsights: (sessionId: string): Promise<SessionInsightsPayload> =>
+        jsonFetch(`/api/sessions/${encodeURIComponent(sessionId)}/insights`),
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/studio/src/styles/session-tokens.css apps/studio/src/api.ts apps/studio/src/main.tsx
+git commit -m "feat(studio): session design tokens + insights api client"
+```
+
+(Adjust the third path to whichever file got the CSS import.)
+
+---
+
+### Task 8: SPA - BurnSpark + SignalBadge row components
+
+**Files:**
+- Create: `apps/studio/src/components/session-insight/BurnSpark.tsx`
+- Create: `apps/studio/src/components/session-insight/SignalBadge.tsx`
+
+No unit-test harness exists for studio components (no jsdom setup in repo); these are presentational and verified by typecheck + the Task 10 visual pass. Keep them logic-free enough that this is honest.
+
+- [ ] **Step 1: BurnSpark**
+
+```tsx
+// apps/studio/src/components/session-insight/BurnSpark.tsx
+/** Per-turn token-burn sparkline for a sessions-list row. Bars are neutral
+ *  gray; only buckets above the user's 30d p90 (server-provided) go amber -
+ *  so amber appearing in the table at all marks an outlier row. */
+export function BurnSpark({ buckets, p90 }: {
+    readonly buckets: ReadonlyArray<number> | null;
+    readonly p90: number | null;
+}) {
+    if (!buckets || buckets.length === 0) {
+        return <span style={{ color: "var(--sx-ink-300)" }}>–</span>;
+    }
+    const max = Math.max(...buckets, 1);
+    return (
+        <span style={{ display: "inline-flex", alignItems: "flex-end", gap: 1, height: 14 }} aria-hidden>
+            {buckets.map((b, i) => (
+                <i
+                    key={i}
+                    style={{
+                        display: "block",
+                        width: 3,
+                        borderRadius: "1px 1px 0 0",
+                        height: Math.max(2, Math.round((b / max) * 14)),
+                        background: p90 !== null && b > p90 ? "var(--sx-amber-500)" : "var(--sx-ink-300)",
+                    }}
+                />
+            ))}
+        </span>
+    );
+}
+```
+
+- [ ] **Step 2: SignalBadge**
+
+```tsx
+// apps/studio/src/components/session-insight/SignalBadge.tsx
+/** Rightmost triage badge: clean (green) / friction N (red) / – (no data). */
+export function SignalBadge({ signal, friction }: {
+    readonly signal: "clean" | "friction" | null;
+    readonly friction: number | null;
+}) {
+    if (signal === null) return <span style={{ color: "var(--sx-ink-300)" }}>–</span>;
+    const warn = signal === "friction";
+    return (
+        <span style={{
+            fontSize: 10,
+            fontWeight: 600,
+            padding: "1px 6px",
+            borderRadius: 2,
+            background: warn ? "var(--sx-red-100)" : "var(--sx-green-100)",
+            color: warn ? "var(--sx-red-700)" : "var(--sx-green-700)",
+        }}>
+            {warn ? `friction ${friction ?? ""}` : "clean"}
+        </span>
+    );
+}
+```
+
+- [ ] **Step 3: Typecheck + commit**
+
+Run: `bun run typecheck`
+Expected: PASS
+
+```bash
+git add apps/studio/src/components/session-insight/BurnSpark.tsx apps/studio/src/components/session-insight/SignalBadge.tsx
+git commit -m "feat(studio): BurnSpark + SignalBadge row components"
+```
+
+---
+
+### Task 9: SPA - StoryBar + InsightPanel
+
+**Files:**
+- Create: `apps/studio/src/components/session-insight/StoryBar.tsx`
+- Create: `apps/studio/src/components/session-insight/InsightPanel.tsx`
+
+- [ ] **Step 1: StoryBar**
+
+All positioning is percentage-of-session-duration; the session window comes from the row (`started_at`/`ended_at`) with a fallback to the phase extents.
+
+```tsx
+// apps/studio/src/components/session-insight/StoryBar.tsx
+import type { SessionInsightsPayload } from "@ax/lib/shared/dashboard-types";
+
+const PHASE_COLOR: Record<string, string> = {
+    plan: "var(--sx-phase-plan)",
+    execute: "var(--sx-phase-exec)",
+    exec: "var(--sx-phase-exec)",
+    review: "var(--sx-phase-review)",
+};
+
+const fmtMs = (ms: number): string =>
+    ms < 60_000 ? `${Math.round(ms / 1000)}s`
+    : ms < 3_600_000 ? `${Math.round(ms / 60_000)}m`
+    : `${(ms / 3_600_000).toFixed(1)}h`;
+
+/** Band-1 hero: phase segments + friction ticks + commit dots + subagent
+ *  lanes on one session-time axis. Idle = uncovered axis (the track's idle
+ *  color shows through wherever no phase segment sits). */
+export function StoryBar({ insights, startedAt, endedAt }: {
+    readonly insights: SessionInsightsPayload;
+    readonly startedAt: string | null;
+    readonly endedAt: string | null;
+}) {
+    const phases = insights.phases;
+    const tsList = [
+        ...(startedAt ? [new Date(startedAt).getTime()] : []),
+        ...phases.map((p) => new Date(p.start_ts).getTime()),
+    ].filter(Number.isFinite);
+    const endList = [
+        ...(endedAt ? [new Date(endedAt).getTime()] : []),
+        ...phases.map((p) => new Date(p.end_ts).getTime()),
+    ].filter(Number.isFinite);
+    if (tsList.length === 0 || endList.length === 0) return null;
+    const t0 = Math.min(...tsList);
+    const t1 = Math.max(...endList);
+    const span = Math.max(1, t1 - t0);
+    const pct = (ts: string): number =>
+        Math.min(100, Math.max(0, ((new Date(ts).getTime() - t0) / span) * 100));
+
+    const hasLanes = insights.subagent_spans.length > 0;
+    const phaseTotals = new Map<string, number>();
+    for (const p of phases) {
+        phaseTotals.set(p.phase, (phaseTotals.get(p.phase) ?? 0) + p.duration_ms);
+    }
+    const covered = phases.reduce((a, p) => a + p.duration_ms, 0);
+    const idleMs = Math.max(0, span - covered);
+    const reverted = insights.commits.filter((c) => c.reverted).length;
+
+    return (
+        <div style={{ maxWidth: 760 }}>
+            <div style={{
+                fontSize: 10, color: "var(--sx-ink-500)", letterSpacing: "0.06em",
+                textTransform: "uppercase", fontWeight: 600, marginBottom: 8,
+            }}>Story</div>
+            <div style={{ position: "relative", width: "100%", height: hasLanes ? 36 : 24 }}>
+                {/* idle track */}
+                <span style={{ position: "absolute", top: 1, left: 0, right: 0, height: 10, background: "var(--sx-phase-idle)" }} />
+                {phases.map((p, i) => (
+                    <span key={i} style={{
+                        position: "absolute", top: 1, height: 10,
+                        left: `${pct(p.start_ts)}%`,
+                        width: `${Math.max(0.5, pct(p.end_ts) - pct(p.start_ts))}%`,
+                        background: PHASE_COLOR[p.phase] ?? "var(--sx-phase-exec)",
+                    }} />
+                ))}
+                {insights.friction_ticks.map((f, i) => (
+                    <span key={`f${i}`} title={f.kind} style={{
+                        position: "absolute", top: -3, width: 2, height: 18,
+                        left: `${pct(f.ts)}%`, background: "var(--sx-red-700)",
+                    }} />
+                ))}
+                {insights.commits.map((c, i) => c.reverted ? (
+                    <span key={`c${i}`} title={`${c.sha} (reverted)`} style={{
+                        position: "absolute", top: 13, left: `${pct(c.ts)}%`,
+                        color: "var(--sx-red-700)", fontSize: 9, fontWeight: 700, lineHeight: 1,
+                    }}>✕</span>
+                ) : (
+                    <span key={`c${i}`} title={c.sha} style={{
+                        position: "absolute", top: 15, width: 7, height: 7, borderRadius: "50%",
+                        left: `${pct(c.ts)}%`, background: "var(--sx-green-700)",
+                    }} />
+                ))}
+                {insights.subagent_spans.map((s, i) => s.started_at ? (
+                    <span key={`a${i}`} title={s.id} style={{
+                        position: "absolute", top: 27, height: 5, borderRadius: 2,
+                        left: `${pct(s.started_at)}%`,
+                        width: `${Math.max(1, (s.ended_at ? pct(s.ended_at) : 100) - pct(s.started_at))}%`,
+                        background: "var(--sx-violet-500)",
+                    }} />
+                ) : null)}
+            </div>
+            <div style={{ fontSize: 10, color: "var(--sx-ink-500)", marginTop: 6, lineHeight: 1.5 }}>
+                {Array.from(phaseTotals.entries()).map(([k, v]) => `${k} ${fmtMs(v)}`).join(" · ")}
+                {idleMs > 60_000 ? <span style={{ color: "var(--sx-ink-300)" }}> · idle {fmtMs(idleMs)}</span> : null}
+                {insights.friction_ticks.length > 0
+                    ? <span style={{ color: "var(--sx-red-700)" }}> · ✕{insights.friction_ticks.length} corrections</span> : null}
+                {insights.commits.length > 0
+                    ? <span style={{ color: "var(--sx-green-700)" }}> · ●{insights.commits.length - reverted} commits</span> : null}
+                {reverted > 0 ? <span style={{ color: "var(--sx-red-700)" }}> ✕{reverted} reverted</span> : null}
+                {insights.subagent_spans.length > 0
+                    ? <span style={{ color: "var(--sx-violet-700)" }}> · ▬ {insights.subagent_spans.length} subagents
+                        {insights.delegation_ratio !== null ? ` (${Math.round(insights.delegation_ratio * 100)}% delegated)` : ""}</span>
+                    : null}
+            </div>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 2: InsightPanel (fetch + bands + footer + cells)**
+
+```tsx
+// apps/studio/src/components/session-insight/InsightPanel.tsx
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../api.ts";
+import type { SessionInsightsPayload, SessionListRow } from "@ax/lib/shared/dashboard-types";
+import { StoryBar } from "./StoryBar.tsx";
+
+const LBL: React.CSSProperties = {
+    fontSize: 10, color: "var(--sx-ink-500)", letterSpacing: "0.06em",
+    textTransform: "uppercase", fontWeight: 600, marginBottom: 8,
+};
+const CAP: React.CSSProperties = {
+    fontSize: 10, color: "var(--sx-ink-500)", marginTop: 6, lineHeight: 1.5,
+    whiteSpace: "normal", overflowWrap: "anywhere",
+};
+const CHART_BAND: React.CSSProperties = {
+    minHeight: 36, display: "flex", flexDirection: "column", justifyContent: "center",
+};
+
+function OutcomeCell({ p }: { readonly p: SessionInsightsPayload }) {
+    const hasChecks = p.checks.length > 0;
+    const hasCommits = p.commits.length > 0;
+    if (!hasChecks && !hasCommits && p.durability === null) return null;
+    const reverted = p.commits.filter((c) => c.reverted).length;
+    return (
+        <div style={{ padding: "0 14px", minWidth: 0 }}>
+            <div style={LBL}>Outcome</div>
+            <div style={CHART_BAND}>
+                {p.checks.map((c) => (
+                    <div key={c.kind} style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 10, color: "var(--sx-ink-500)", height: 13 }}>
+                        <span style={{ width: 36, overflow: "hidden", textOverflow: "ellipsis" }}>{c.kind}</span>
+                        {c.runs.map((r, i) => (
+                            <span key={i} style={{
+                                width: 6, height: 6, borderRadius: "50%", flexShrink: 0,
+                                background: r.ok ? "var(--sx-green-700)" : "var(--sx-red-700)",
+                            }} />
+                        ))}
+                    </div>
+                ))}
+                {p.durability !== null ? (
+                    <div style={{ marginTop: 5, maxWidth: 160, height: 6, borderRadius: 2, overflow: "hidden", display: "flex" }}>
+                        <span style={{ width: `${Math.round(p.durability * 100)}%`, background: "var(--sx-green-300)" }} />
+                        <span style={{ flex: 1, background: "var(--sx-red-300)" }} />
+                    </div>
+                ) : null}
+            </div>
+            <div style={CAP}>
+                {hasCommits ? <>{p.commits.length} commits{reverted > 0 ? <span style={{ color: "var(--sx-red-700)" }}> · {reverted} reverted</span> : null}</> : "no commits"}
+                {p.durability !== null ? <> · durability {p.durability.toFixed(1)}</> : null}
+            </div>
+        </div>
+    );
+}
+
+function LocCell({ p }: { readonly p: SessionInsightsPayload }) {
+    if (!p.loc || (p.loc.added === 0 && p.loc.removed === 0)) return null;
+    const total = Math.max(1, p.loc.added + p.loc.removed);
+    const fmt = (n: number) => n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+    return (
+        <div style={{ padding: "0 14px", minWidth: 0 }}>
+            <div style={LBL}>ΔLOC</div>
+            <div style={CHART_BAND}>
+                <div style={{ display: "flex", alignItems: "center", maxWidth: 180 }}>
+                    <span style={{ width: `${(p.loc.added / total) * 100}%`, height: 6, background: "var(--sx-green-300)", borderRadius: 1 }} />
+                    <span style={{ width: `${(p.loc.removed / total) * 100}%`, height: 6, background: "var(--sx-red-300)", borderRadius: 1, marginLeft: 2 }} />
+                </div>
+            </div>
+            <div style={CAP}>
+                <span style={{ color: "var(--sx-green-700)" }}>+{fmt(p.loc.added)}</span>{" "}
+                <span style={{ color: "var(--sx-red-700)" }}>−{fmt(p.loc.removed)}</span>
+            </div>
+        </div>
+    );
+}
+
+function SkillArcCell({ p }: { readonly p: SessionInsightsPayload }) {
+    if (p.skills.length === 0) return null;
+    // dedupe consecutive repeats; the arc is the sequence, not the volume
+    const arc = p.skills.filter((s, i) => i === 0 || s.name !== p.skills[i - 1]!.name);
+    return (
+        <div style={{ padding: "0 14px", minWidth: 0 }}>
+            <div style={LBL}>Skill arc</div>
+            <div style={CHART_BAND}>
+                <div style={{ lineHeight: 1.7 }}>
+                    {arc.slice(0, 8).map((s, i) => (
+                        <span key={i}>
+                            {i > 0 ? <span style={{ color: "var(--sx-ink-300)" }}> → </span> : null}
+                            <span style={{
+                                display: "inline-block", fontSize: 10, padding: "1px 7px",
+                                borderRadius: 8, background: "var(--sx-line-100)", color: "var(--sx-ink-600)",
+                            }}>{s.name}</span>
+                        </span>
+                    ))}
+                    {arc.length > 8 ? <span style={{ color: "var(--sx-ink-300)" }}> +{arc.length - 8}</span> : null}
+                </div>
+            </div>
+            <div style={CAP}>{arc.length} skills</div>
+        </div>
+    );
+}
+
+function ContextCell({ p }: { readonly p: SessionInsightsPayload }) {
+    if (p.context_curve.length < 2) return null;
+    const tMax = Math.max(...p.context_curve.map((c) => c.t), 1);
+    const W = 160, H = 32;
+    const path = p.context_curve
+        .map((c, i) => `${i === 0 ? "M" : "L"}${((c.t / tMax) * W).toFixed(1)},${(H - 2 - c.pct * (H - 6)).toFixed(1)}`)
+        .join(" ");
+    const peak = Math.max(...p.context_curve.map((c) => c.pct));
+    const last = p.context_curve[p.context_curve.length - 1]!.pct;
+    return (
+        <div style={{ padding: "0 14px", minWidth: 0 }}>
+            <div style={LBL}>Context</div>
+            <div style={CHART_BAND}>
+                <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none">
+                    <line x1={0} y1={H - 2 - 0.9 * (H - 6)} x2={W} y2={H - 2 - 0.9 * (H - 6)}
+                        stroke="var(--sx-line-200)" strokeWidth={1} strokeDasharray="3,3" />
+                    <path d={path} fill="none" stroke="var(--sx-chart-line)" strokeWidth={1.5} />
+                    {p.compactions.map((c, i) => {
+                        const ct = new Date(c.ts).getTime();
+                        const t0c = p.context_curve[0]!.t;
+                        // compaction ts is absolute; curve t is offset - find nearest point
+                        const nearest = p.context_curve.reduce((best, pt) =>
+                            Math.abs(pt.t - (ct - t0c)) < Math.abs(best.t - (ct - t0c)) ? pt : best);
+                        return <circle key={i} cx={(nearest.t / tMax) * W} cy={H - 2 - nearest.pct * (H - 6)}
+                            r={2.4} fill="var(--sx-amber-500)" />;
+                    })}
+                </svg>
+            </div>
+            <div style={CAP}>
+                {p.compactions.length} compaction{p.compactions.length === 1 ? "" : "s"} · peak {Math.round(peak * 100)}% · ends {Math.round(last * 100)}%
+            </div>
+        </div>
+    );
+}
+
+function BaselineFooter({ p }: { readonly p: SessionInsightsPayload }) {
+    const { cost_ratio, friction_ratio, land_ratio, cache_pct } = p.baseline;
+    if (cost_ratio === null && friction_ratio === null && land_ratio === null) return null;
+    const delta = (label: string, r: number | null, higherIsWorse: boolean) => {
+        if (r === null) return null;
+        const worse = higherIsWorse ? r > 1 : r < 1;
+        return (
+            <span> · {label} <span style={{ color: worse ? "var(--sx-red-700)" : "var(--sx-green-700)" }}>
+                {r.toFixed(1)}×{r > 1 ? "↑" : "↓"}
+            </span></span>
+        );
+    };
+    return (
+        <div style={{
+            marginTop: 14, paddingTop: 8, borderTop: "1px dashed var(--sx-line-200)",
+            fontSize: 10, color: "var(--sx-ink-500)", textAlign: "right",
+        }}>
+            vs 30d median
+            {delta("cost", cost_ratio, true)}
+            {delta("friction", friction_ratio, true)}
+            {delta("landed", land_ratio, true)}
+            {cache_pct !== null ? <span> · cache {Math.round(cache_pct * 100)}%</span> : null}
+        </div>
+    );
+}
+
+/** Accordion body for an expanded sessions-list row. Fetches lazily on first
+ *  expand; TanStack Query caches per session id. */
+export function InsightPanel({ row }: { readonly row: SessionListRow }) {
+    const q = useQuery({
+        queryKey: ["session-insights", row.id],
+        queryFn: () => api.sessionInsights(row.id),
+        staleTime: 5 * 60_000,
+    });
+    if (q.isLoading) {
+        return <div style={{ padding: "12px 16px", fontSize: 10, color: "var(--sx-ink-300)" }}>loading insights…</div>;
+    }
+    if (q.error || !q.data) {
+        return (
+            <div style={{ padding: "12px 16px", fontSize: 10, color: "var(--sx-ink-300)" }}>
+                failed to load insights · <button onClick={() => void q.refetch()} style={{
+                    border: "none", background: "transparent", color: "var(--sx-ink-500)",
+                    cursor: "pointer", fontSize: 10, textDecoration: "underline", padding: 0,
+                }}>retry</button>
+            </div>
+        );
+    }
+    const p = q.data;
+    const cells = [
+        <OutcomeCell key="o" p={p} />, <LocCell key="l" p={p} />,
+        <SkillArcCell key="s" p={p} />, <ContextCell key="c" p={p} />,
+    ];
+    const empty = p.phases.length === 0 && p.commits.length === 0 && p.skills.length === 0
+        && p.context_curve.length < 2 && !p.loc;
+    if (empty) {
+        return <div style={{ padding: "12px 16px", fontSize: 10, color: "var(--sx-ink-300)" }}>no insight data for this session</div>;
+    }
+    return (
+        <div style={{ padding: "12px 16px 14px 38px" }}>
+            <StoryBar insights={p} startedAt={row.started_at} endedAt={row.ended_at} />
+            <div style={{
+                display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+                gap: "14px 0", marginTop: 16,
+            }}>
+                {cells}
+            </div>
+            <BaselineFooter p={p} />
+        </div>
+    );
+}
+```
+
+Note: band-2 cell dividers (`border-right`) are omitted deliberately - with `auto-fit` wrapping, hard-coded dividers leak onto row ends; padding + the grid gap carry the separation. If the executor wants dividers, do it with `box-shadow: 1px 0 0 var(--sx-line-200)` and accept the trailing edge.
+
+- [ ] **Step 3: Typecheck + commit**
+
+Run: `bun run typecheck`
+Expected: PASS
+
+```bash
+git add apps/studio/src/components/session-insight/StoryBar.tsx apps/studio/src/components/session-insight/InsightPanel.tsx
+git commit -m "feat(studio): StoryBar + InsightPanel accordion components"
+```
+
+---
+
+### Task 10: SPA - wire the sessions route
+
+**Files:**
+- Modify: `apps/studio/src/routes/sessions.tsx`
+
+- [ ] **Step 1: Extend the `Row` component**
+
+In `apps/studio/src/routes/sessions.tsx`:
+
+Imports to add:
+
+```tsx
+import { BurnSpark } from "../components/session-insight/BurnSpark.tsx";
+import { SignalBadge } from "../components/session-insight/SignalBadge.tsx";
+import { InsightPanel } from "../components/session-insight/InsightPanel.tsx";
+```
+
+Extend `RowProps`:
+
+```tsx
+interface RowProps {
+    readonly s: SessionListRow;
+    readonly indent?: boolean;
+    readonly expandedToggle?: { expanded: boolean; childCount: number; loading?: boolean; onToggle: () => void };
+    readonly select?: { checked: boolean; onToggle: () => void };
+    readonly burnP90?: number | null;
+    readonly insight?: { open: boolean; onToggle: () => void };
+}
+```
+
+In the `Row` function body, derive the accordion styling and add the new cells. Replace the current `<tr style={rowStyle} ...>` opening and the cells as follows (keep the existing checkbox + id + source + project + started cells; the full new cell order is: checkbox · id (with chevron) · source · project · started · duration · turns · burn · cost · signal · open-link):
+
+```tsx
+    const open = insight?.open ?? false;
+    const rowStyle: React.CSSProperties | undefined = open
+        ? { background: "var(--sx-tint-50)", boxShadow: "inset 3px 0 0 var(--sx-ink-900)", cursor: "pointer" }
+        : indent
+            ? { background: "#fafafa" }
+            : insight ? { cursor: "pointer" } : undefined;
+```
+
+```tsx
+        <tr
+            style={rowStyle}
+            onMouseEnter={onIntent}
+            onFocus={onIntent}
+            onClick={insight ? (e) => {
+                // don't hijack checkbox/button/link clicks
+                const t = e.target as HTMLElement;
+                if (t.closest("a,button,input")) return;
+                insight.onToggle();
+            } : undefined}
+            aria-expanded={insight ? open : undefined}
+        >
+```
+
+In the id cell, render an insight chevron before the existing subagent toggle (live dot precedes the id):
+
+```tsx
+                {insight ? (
+                    <span style={{
+                        display: "inline-block", fontSize: 9, color: "var(--sx-ink-500)",
+                        transition: "transform .15s", transform: open ? "rotate(90deg)" : "none",
+                        width: 12,
+                    }}>▶</span>
+                ) : <span style={{ display: "inline-block", width: 12 }} />}
+                {s.is_live ? (
+                    <span title="live" style={{
+                        display: "inline-block", width: 7, height: 7, borderRadius: "50%",
+                        background: "var(--sx-green-700)", boxShadow: "0 0 0 2px var(--sx-green-100)",
+                        marginRight: 4,
+                    }} />
+                ) : null}
+```
+
+After the existing turns `<td>` (line ~107), add three cells:
+
+```tsx
+            <td style={{ padding: "0 8px" }}>
+                <BurnSpark buckets={s.burn_buckets} p90={burnP90 ?? null} />
+            </td>
+            <td style={{ textAlign: "right", fontFamily: "ui-monospace, monospace", fontSize: 12, fontVariantNumeric: "tabular-nums", color: s.cost_usd !== null ? "var(--ink)" : "var(--muted-2)" }}>
+                {s.cost_usd !== null ? `$${s.cost_usd.toFixed(2)}` : "–"}
+            </td>
+            <td><SignalBadge signal={s.signal} friction={s.friction} /></td>
+```
+
+- [ ] **Step 2: Wire accordion state in `SessionsRoute`**
+
+Add state next to `expanded`:
+
+```tsx
+    const [insightOpen, setInsightOpen] = useState<ReadonlySet<string>>(() => new Set());
+    const toggleInsight = (id: string) => {
+        setInsightOpen((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    };
+```
+
+In the `<thead>` row, add the three new headers after `turns` (and keep the trailing blank th for the open-link column):
+
+```tsx
+                            <th style={{ textAlign: "left", padding: "6px 8px" }}>burn</th>
+                            <th style={{ textAlign: "right", padding: "6px 8px" }}>cost</th>
+                            <th style={{ textAlign: "left", padding: "6px 8px" }}>signal</th>
+```
+
+In the row-render loop, pass the new props to root `Row`s and render the panel row when open (children rows keep the old props - no insight accordion on subagents in v1):
+
+```tsx
+                                    <Row
+                                        s={parent}
+                                        burnP90={query.data?.burn_p90 ?? null}
+                                        insight={{ open: insightOpen.has(parent.id), onToggle: () => toggleInsight(parent.id) }}
+                                        select={{ checked: selected.has(parent.id), onToggle: () => toggleSelected(parent.id) }}
+                                        {...(childCount > 0 ? { expandedToggle: { /* unchanged */ ... } } : {})}
+                                    />
+                                    {insightOpen.has(parent.id) ? (
+                                        <tr>
+                                            <td colSpan={11} style={{
+                                                padding: 0,
+                                                background: "var(--sx-tint-50)",
+                                                boxShadow: "inset 3px 0 0 var(--sx-ink-900)",
+                                                borderBottom: "1px solid var(--sx-line-200)",
+                                            }}>
+                                                <InsightPanel row={parent} />
+                                            </td>
+                                        </tr>
+                                    ) : null}
+```
+
+(`colSpan={11}` = the new column count: checkbox, id, source, project, started, duration, turns, burn, cost, signal, open-link. Recount after your edits and keep the sentinel row's `colSpan` in sync.)
+
+The `{ /* unchanged */ ... }` above means: keep the exact existing `expandedToggle` object - do not retype it.
+
+- [ ] **Step 3: Typecheck + build**
+
+Run: `bun run typecheck && bunx turbo run build --filter=axctl`
+Expected: PASS. (The studio bundle is built/staged by its own script - run `rg -n "stage-studio" package.json scripts/` and run that script if the dashboard serves a prebuilt bundle; per memory, `scripts/stage-studio.ts` builds the web target.)
+
+- [ ] **Step 4: Visual verification (the real gate)**
+
+```bash
+bin/axctl serve
+```
+
+Open `http://127.0.0.1:1799/sessions` and verify against the locked mockup (`.superpowers/brainstorm/81395-1781156096/content/panel-v5.html`):
+
+1. Rows show turns (non-zero where health data exists), burn sparkline, cost, signal badge.
+2. Sparkline amber appears only on outlier rows (roughly 1-in-8, not every row).
+3. Clicking a row opens the accordion: ink left rail + tinted background flowing row → panel; chevron rotates.
+4. Panel: story bar with phase segments/ticks/commit dots; band-2 cells wrap responsively when the window narrows (4 → 2×2 → 1); captions wrap without overlap.
+5. A data-poor session (codex hook-probe) shows `no insight data for this session`.
+6. Subagent expand (`▶ N`) and compare/checkbox flows still work; row-click does NOT hijack checkbox/link clicks.
+7. Several rows open at once stay scannable (rail per group, 1px gray closers, no blue stripes).
+
+Screenshot the expanded state and compare to the mockup.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/studio/src/routes/sessions.tsx
+git commit -m "feat(studio): sessions list remakeover - signal columns + insight accordion"
+```
+
+---
+
+### Task 11: Full verification sweep
+
+- [ ] **Step 1: Repo gates**
+
+```bash
+bun run typecheck
+bun test
+bunx turbo run build
+```
+
+Expected: all PASS. `bun test` is the CI gate - fix anything red before proceeding.
+
+- [ ] **Step 2: Backfill check (manual)**
+
+Run a scoped re-ingest so recent sessions get `burn_buckets`:
+
+```bash
+bin/axctl ingest --since=7
+```
+
+Then reload `/sessions` and confirm sparklines render for recent Claude sessions. (Watcher-race caveat: don't touch live transcripts mid-ingest; see memory "Re-ingest watcher daemon race".)
+
+- [ ] **Step 3: Commit any stragglers + push + PR**
+
+```bash
+git status --short   # review - no unrelated files (never git add -A in this repo)
+git push -u origin feat/sessions-list-remakeover
+gh pr create --title "feat(dashboard): sessions list remakeover - enriched rows + insight accordion" --body "$(cat <<'EOF'
+Implements docs/superpowers/specs/2026-06-11-sessions-list-remakeover-design.md
+
+- Enriched /api/sessions rows: turns, cost, burn sparkline buckets, friction signal, commit/LOC counts, live dot - all from per-session aggregate tables (no turn scans / graph-deref aggregates)
+- New /api/sessions/:id/insights endpoint + accordion insight panel (story bar, outcome, ΔLOC, skill arc, context curve, 30d-baseline footer)
+- New session_token_usage.burn_buckets field, precomputed at ingest (claude + codex)
+- 30d baselines module (medians + burn p90) with in-process cache
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes (already applied)
+
+- Spec coverage: row design → Tasks 1/4/8/10; accordion → 9/10; story bar → 9; band-2 cells → 9; footer → 9; palette/type → 7; API split → 4/6; burn_buckets schema+ingest → 2/3; baselines+p90 → 5; empty/error states → 6/9; testing → per-task. Out-of-scope items from the spec have no tasks (correct).
+- Known judgment calls the executor may revisit: codex burn_buckets batching caveat (Task 3 Step 4), SurrealQL nested-select fallbacks (Tasks 5/6), `top_file` from the spec's ΔLOC caption is NOT implemented (no cheap per-session top-file aggregate exists; the cell ships without it - deviation noted, acceptable), task_label / "≈ classic ship arc" editorial labels deferred.

--- a/docs/superpowers/specs/2026-06-11-sessions-list-remakeover-design.md
+++ b/docs/superpowers/specs/2026-06-11-sessions-list-remakeover-design.md
@@ -267,4 +267,15 @@ fallback turn-scan.
 - Sentiment ribbon, tool-mix/treemap/cadence/hook-lane/plan-burndown/sankey
   charts (gallery items cut in shortlisting - candidates for session detail
   view later).
+
+## Addendum (2026-06-12): accordion retired, inline viz locked
+
+Dogfooding on real data rejected the expandable insight panel ("reads as a
+nested report"). Locked replacement: inline micro-viz columns on every row -
+STORY (120x8 mini timeline with idle-gap time-warp: inter-event gaps >8% of
+the session compress to 2% of the axis), ΔLOC (log-scaled diverging bars),
+COMMITS (dots + reverted ✕). Insights fetched lazily per visible row
+(IntersectionObserver latch, shared TanStack cache). The strip-underline
+variant was prototyped and rejected (unclear). InsightPanel/StoryBar
+components remain on disk for the session detail page.
 - Codex/Pi/OpenCode cwd-filtered ingest (unrelated).

--- a/docs/superpowers/specs/2026-06-11-sessions-list-remakeover-design.md
+++ b/docs/superpowers/specs/2026-06-11-sessions-list-remakeover-design.md
@@ -1,0 +1,270 @@
+# Sessions List Remakeover - Design
+
+Date: 2026-06-11
+Status: approved (brainstorm v5 mockup locked)
+Mockup lineage: `.superpowers/brainstorm/81395-1781156096/content/panel-v2..v5.html` (v5 is canonical)
+
+## Goal
+
+Enrich the dashboard `/sessions` list so it serves three purposes without opening a
+session: **triage/scanning** (which sessions had friction), **outcome ledger** (what
+each session produced), **live monitoring** (what is running / burning now). Recall
+(filters/search) stays as-is.
+
+Direction chosen: **lean table + insight expand** ("Direction C") - single-line rows
+with a few signal columns, row click expands an inline insight panel ("accordion")
+with micro-charts.
+
+## Row design
+
+Column order:
+
+```
+[chevron 18px] [status-dot] ID  SRC  PROJECT  DUR  TURNS  BURN  COST  SIGNAL
+```
+
+- `DUR`, `TURNS`, `COST` right-aligned (mono font column scanning).
+- `chevron` own narrow column; rotates 90° when open; whole row is the click target
+  (`cursor:pointer`, `aria-expanded`).
+- **status-dot**: green + halo = live (`ended_at` null AND last event < 5 min);
+  gray = ended.
+- **BURN**: per-turn token sparkline (~20 buckets). Bars default gray
+  (`--ink-300`); amber (`--amber-500`) only on buckets exceeding the user's p90
+  per-turn burn - outlier rows pop, normal rows stay quiet.
+- **SIGNAL**: rightmost triage badge. Tiers: `clean` (green) when corrections +
+  tool errors = 0 and data present; `friction N` (red) where
+  N = user_corrections + tool_errors; `-` (dim) when no health data.
+- Existing features preserved: source filter tabs, text filter, expand-all,
+  compare checkboxes, subagent child expansion (`▶ N` prefix), open → link.
+
+## Accordion treatment
+
+Open row + panel form one visual group:
+
+- 3px inset left rail in `--ink-900` on row and panel (NOT blue - blue collides
+  with the codex badge).
+- Shared `--tint-50` background flowing row → panel.
+- Panel bottom border `1px solid var(--line-200)` closes the group.
+- Panel left padding aligns the strip's left edge to the ID column text.
+
+## Panel layout - two bands + footer
+
+**Band 1 (hero, full width, fluid up to 760px): Story bar.**
+One horizontal bar = the session narrative:
+
+- Phase segments from `phase_span`: plan/exec/review in the slate ramp
+  (`--phase-plan/exec/review`), idle gaps in `--phase-idle`.
+- Red friction ticks (`--red-700`, 2px) at correction/tool-error timestamps.
+- Commit dots: solid green `--green-700`; reverted commits = red `✕` glyph
+  (hollow dots unreadable at 7px).
+- Subagent lanes: violet (`--violet-500`) bars under the main bar, one per child
+  session, positioned by child start/end. Lane rows render only when children
+  exist.
+- Caption (10px, wraps): `plan 12m · exec 58m · review 18m · idle 16m ·
+  ✕3 corrections · ●2 commits ✕1 reverted · ▬ 2 subagents (38% delegated)` -
+  colored glyphs in the caption ARE the legend; no legend in the label line.
+
+**Band 2: responsive grid, 4 cells.**
+`grid-template-columns: repeat(auto-fit, minmax(200px, 1fr))` - wraps 4 → 2×2 →
+1-col; captions wrap (`white-space:normal`, `overflow-wrap:anywhere`); long file
+paths ellipsis-truncate.
+
+1. **Outcome** - check-run dot rows (typecheck/test attempts, red→green sequence,
+   HTML 10px labels - never SVG text) + durability bar (green/red split) +
+   caption `5 commits · 1 reverted · durability 0.8`.
+2. **ΔLOC · N files** - green/red add/remove bars + caption
+   `+2.1k −940 · top: <file>` (truncated).
+3. **Skill arc** - ordered neutral-gray chips joined by `→` (sequence is the
+   signal, not hue). Caption may carry a derived label styled as editorial:
+   `≈ classic ship arc` (italic, `≈` prefix).
+4. **Context** - seesaw line (`--chart-line` stroke): context fill climbs, drops
+   at compactions; amber dots (`--amber-500`) at compaction peaks (compaction is
+   an event, not a failure - never red); dashed threshold line at 90%.
+   Caption: `2 compactions · peaks 92/96% · ends 71%`.
+
+**Footer (right-aligned typographic line, no chart):**
+`vs 30d median - cost 2.4×↑ · friction 1.3×↑ · landed 0.7×↓ · cache 71%`
+Red deltas = worse than median, green = better. (Replaced bullet-bar chart -
+direction semantics flip per metric; typography is unambiguous.)
+
+**Empty states:** cells render only when their data exists; sessions with no
+insight data (e.g. 8s codex hook-probes) show a single dim line
+`no insight data for this session`. SIGNAL shows `-`.
+
+## Visual system
+
+### Palette (CSS variables; one hue per meaning)
+
+```css
+/* neutrals */
+--ink-900:#1c2127;  /* primary text, accordion rail, median ticks */
+--ink-600:#555c66;  /* secondary text */
+--ink-500:#6e7681;  /* labels + captions (4.6:1 on white) */
+--ink-300:#b6bcc4;  /* default spark bars, dim, done dots */
+--line-200:#e4e7eb; /* borders, dividers, panel bottom */
+--line-100:#f0f2f4; /* row dividers, neutral chip bg */
+--tint-50:#f7f8fa;  /* open-row + panel bg */
+
+/* red = failure/friction/revert/delete ONLY */
+--red-700:#b13434;  --red-300:#e39891;  --red-100:#faeceb;
+/* green = pass/landed/durable/add/live ONLY */
+--green-700:#1f7a3f; --green-300:#8fc6a0; --green-100:#e8f3ec;
+/* amber = elevated-not-failed (hot burn, compactions) ONLY */
+--amber-700:#8f6514; --amber-500:#d99a32; --amber-100:#faf1dc;
+
+/* phases - sequential slate ramp (neutral structure, no judgment) */
+--phase-plan:#c9d4e0; --phase-exec:#8da2b6; --phase-review:#5e7590; --phase-idle:#ececec;
+
+/* categorical */
+--violet-500:#a193cb; --violet-700:#6f5fa3;  /* subagents ONLY */
+--chart-line:#9aa7b6;                        /* neutral chart strokes */
+
+/* source identity - badges ONLY, appears nowhere else */
+--src-claude-bg:#fdf3d7; --src-claude-fg:#8a6d1a;
+--src-codex-bg:#e7eef9;  --src-codex-fg:#2f5fa8;
+```
+
+Rules: no stray hues (`#34a853` etc. banned); accordion/selection state is
+monochrome ink, never a hue; live dot uses `--green-700`.
+
+### Type scale (two sizes)
+
+| token | px   | use |
+|-------|------|-----|
+| base  | 11.5 | row cells, panel values, chips |
+| small | 10   | th, cell labels (uppercase .06em 600 `--ink-500`), captions, badges, chart labels |
+
+10px floor everywhere. Chart axis/series labels are HTML, never scaled SVG
+`<text>`.
+
+### Spacing (4px grid)
+
+- `td { padding:7px 10px }` (~30px rows), `th { padding:6px 10px }`.
+- Panel `padding:12px 16px 14px <ID-column-x>px`.
+- Cells `padding:0 12-14px`, `1px var(--line-200)` right dividers.
+- Fixed bands inside cells: label 14px / chart ≥36px / caption line(s).
+
+## Data & API design
+
+### Constraints (hard-won)
+
+- NO per-row turn-table scans in the list path (`enrichSessions` hang class).
+- NO stacked graph derefs in aggregates (`invoked` 87k-edge hang class).
+- All list enrichment comes from per-session aggregate tables already written at
+  ingest, fetched with `WHERE session IN [page ids]` batch queries.
+
+### `GET /api/sessions` (existing, enriched)
+
+Current 2 queries (session page + spawned counts) grow to **4 batch queries**:
+
+1. session page select (unchanged)
+2. spawned child counts (unchanged)
+3. `session_health` batch: `turns, tool_errors, user_corrections, interruptions,
+   context_pressure, task_label`
+4. `session_token_usage` batch: `estimated_cost_usd, estimated_tokens,
+   cache_read_tokens, burn_buckets` + `session_metrics` batch:
+   `produced_commits, reverted_commits, lines_added, lines_removed,
+   durability_ratio, delegation_ratio`
+   (3 + 4 may run as separate queries; "4 batch queries" is indicative, not a
+   hard cap - the invariant is: all keyed by `session IN [ids]`, no scans.)
+
+List response meta gains `burn_p90: number | null` - the user's 30-day p90
+per-turn token burn (same in-process cache as the baseline medians). The SPA
+colors sparkline buckets amber only above this threshold.
+
+`SessionListRow` additions (all nullable - enrichment may not exist):
+
+```ts
+turn_count: number | null        // session_health.turns (replaces hardcoded 0)
+cost_usd: number | null
+burn_buckets: number[] | null    // sparkline
+friction: number | null          // corrections + tool_errors (server-computed)
+signal: "clean" | "friction" | null
+produced_commits: number | null
+reverted_commits: number | null
+lines_added: number | null
+lines_removed: number | null
+is_live: boolean
+```
+
+### `GET /api/sessions/:id/insights` (new, fetched on expand)
+
+One endpoint returns the full panel payload:
+
+```ts
+interface SessionInsightsPayload {
+  phases: { phase: string; start: string; duration_ms: number }[]
+  friction_ticks: { ts: string; kind: string }[]      // reaction_event + tool errors
+  commits: { ts: string; sha: string; reverted: boolean }[]
+  subagent_spans: { id: string; start: string; end: string | null }[]
+  checks: { kind: "typecheck" | "test" | "build"; runs: { ts: string; ok: boolean }[] }[]
+  loc: { added: number; removed: number; files: number; top_file: string | null }
+  durability: number | null
+  skills: { name: string; ts: string }[]               // ordered invoked edges
+  context_curve: { t: number; pct: number }[]          // downsampled
+  compactions: { ts: string; pct: number }[]
+  baseline: {
+    cost_ratio: number | null      // this / 30d median
+    friction_ratio: number | null
+    land_ratio: number | null
+    cache_pct: number | null
+  }
+}
+```
+
+- Context curve derived from `turn_token_usage.prompt_tokens` per turn vs model
+  context window, downsampled to ≤60 points; compaction events from `compaction`.
+- Check runs derived from `diagnostic_event` (kind/status/ts).
+- Baseline: 30d per-user medians (cost, friction, time-to-land) computed
+  server-side, cached in-process ~5 min.
+- Cells with missing source data return `null`/empty arrays; the SPA hides those
+  cells.
+
+### Schema change: `burn_buckets`
+
+New field on `session_token_usage`: `burn_buckets` - JSON-encoded `number[]`
+(string field per SCHEMAFULL v3 nested-value rule), ~20 buckets, per-turn
+estimated tokens downsampled over turn sequence. Written by the token-usage
+derive stage at ingest; backfill via normal re-ingest/derive run. Register any
+new table in SCHEMA_TABLES - not needed here (field add only), but the schema
+test gate applies.
+
+Sessions without `burn_buckets` (pre-backfill) render an empty BURN cell - no
+fallback turn-scan.
+
+## Component plan (SPA)
+
+- `SessionsTable` - existing list component: new columns, right-alignment,
+  chevron column, signal badge, sparkline (`BurnSpark`, pure SVG/CSS, no chart lib).
+- `SessionInsightPanel` - accordion body; fetches `/insights` on first expand,
+  caches per session id in memory.
+  - `StoryBar` (band 1) - pure-percentage absolute positioning (as mockup).
+  - `OutcomeCell`, `LocCell`, `SkillArcCell`, `ContextCell` (band 2).
+  - `BaselineFooter`.
+- All charts hand-rolled SVG/CSS (no charting dependency) per mockups.
+- Palette/type tokens land as CSS variables in the dashboard stylesheet.
+
+## Error handling
+
+- `/insights` failure → panel shows dim `failed to load insights` + retry link;
+  row data unaffected.
+- Enrichment queries (3/4) failing must not break the base list: wrap in
+  Effect catch → rows render with null enrichment (dim `-`).
+- Mixed-version data (old ingests missing tables) handled by nullable fields.
+
+## Testing
+
+- `fetchSessionsList` unit tests: enrichment join correctness, null paths,
+  query shape (no derefs / no turn scans - assert on SurrealQL strings).
+- `/insights` route test: payload assembly from seeded tables; empty-session path.
+- Derive-stage test: `burn_buckets` downsampling (n turns → 20 buckets edges).
+- Type-level: `SessionListRow`/`SessionInsightsPayload` exported from
+  `@ax/lib/shared/dashboard-types` and consumed by SPA without `any`.
+
+## Out of scope
+
+- Recall/filter changes, compare mode changes.
+- Sentiment ribbon, tool-mix/treemap/cadence/hook-lane/plan-burndown/sankey
+  charts (gallery items cut in shortlisting - candidates for session detail
+  view later).
+- Codex/Pi/OpenCode cwd-filtered ingest (unrelated).

--- a/packages/lib/src/paths.ts
+++ b/packages/lib/src/paths.ts
@@ -10,13 +10,27 @@ export const SKILL_DIRS = (process.env.AX_SKILLS_DIRS ?? "")
     .map((s) => s.trim())
     .filter(Boolean);
 
-export function defaultSkillDirs(): { dir: string; scope: string }[] {
-    // Re-read at call time so tests can override AX_SKILLS_DIRS after module load.
-    const liveSkillDirs = (process.env.AX_SKILLS_DIRS ?? "")
+/**
+ * Returns the parsed list of skill dirs from AX_SKILLS_DIRS, re-read at call
+ * time so tests can override the env var after module load.
+ */
+function liveSkillDirList(): string[] {
+    return (process.env.AX_SKILLS_DIRS ?? "")
         .split(",")
         .map((s) => s.trim())
         .filter(Boolean);
-    const fromEnv = liveSkillDirs.map((dir) => ({ dir, scope: "user" }));
+}
+
+/**
+ * Returns true when AX_SKILLS_DIRS is set and non-empty, indicating that the
+ * env var fully overrides skill discovery (plugin + project dirs are skipped).
+ * Re-read at call time so tests can override the env var after module load.
+ */
+export const skillDirsOverridden = (): boolean => liveSkillDirList().length > 0;
+
+export function defaultSkillDirs(): { dir: string; scope: string }[] {
+    // Re-read at call time so tests can override AX_SKILLS_DIRS after module load.
+    const fromEnv = liveSkillDirList().map((dir) => ({ dir, scope: "user" }));
     if (fromEnv.length > 0) return fromEnv;
     return [
         { dir: posixPath.join(HOME, ".claude", "skills"), scope: "user" },

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -888,7 +888,7 @@ export interface SessionInsightsPayload {
     /** Context-fill curve, ≤60 points; t = ms offset from session start,
      *  pct = estimated context fill 0..1 (prompt+cache tokens / window). */
     readonly context_curve: ReadonlyArray<{ readonly t: number; readonly pct: number }>;
-    readonly compactions: ReadonlyArray<{ readonly ts: string }>;
+    readonly compactions: ReadonlyArray<{ readonly ts: string; readonly t: number }>;
     /** Always present; individual ratios are null when this session or the
      *  30d baseline lacks that metric. All-null ratios ≠ missing baseline. */
     readonly baseline: {

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -801,6 +801,8 @@ export interface SessionListRow {
     readonly ended_at: string | null;
     /** True when a raw transcript pointer exists (session is inspectable). */
     readonly has_raw_file: boolean;
+    /** From session_health.turns when a health row exists; 0 is a sentinel for
+     *  "no health data", not a literal zero-turn session. */
     readonly turn_count: number;
     /** Parent session id when this row was spawned by another session (e.g. a
      *  Claude subagent / Codex agent). Null for top-level sessions. Always
@@ -823,6 +825,7 @@ export interface SessionListRow {
     readonly friction: number | null;
     /** 'clean' = health row exists and friction is 0. Null = no health data. */
     readonly signal: "clean" | "friction" | null;
+    /** Commit/LOC outcome from session_metrics (git-derived at ingest). */
     readonly produced_commits: number | null;
     readonly reverted_commits: number | null;
     readonly lines_added: number | null;
@@ -886,6 +889,8 @@ export interface SessionInsightsPayload {
      *  pct = estimated context fill 0..1 (prompt+cache tokens / window). */
     readonly context_curve: ReadonlyArray<{ readonly t: number; readonly pct: number }>;
     readonly compactions: ReadonlyArray<{ readonly ts: string }>;
+    /** Always present; individual ratios are null when this session or the
+     *  30d baseline lacks that metric. All-null ratios ≠ missing baseline. */
     readonly baseline: {
         readonly cost_ratio: number | null;
         readonly friction_ratio: number | null;

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -811,6 +811,26 @@ export interface SessionListRow {
      *  SPA to render an expand toggle without first fetching children. Only
      *  populated on roots returned from `/api/sessions`. */
     readonly direct_children_count?: number;
+    /** Enrichment block - every field nullable: aggregate rows may not exist
+     *  for a session (pre-backfill ingests, 8s hook-probes, foreign sources).
+     *  Sourced from session_health / session_token_usage / session_metrics
+     *  batch lookups - NEVER from turn-table scans. */
+    readonly cost_usd: number | null;
+    /** Downsampled per-turn estimated tokens (≤20 buckets) for the BURN
+     *  sparkline. Null when the ingest predates burn_buckets backfill. */
+    readonly burn_buckets: ReadonlyArray<number> | null;
+    /** user_corrections + tool_errors. Null when no session_health row. */
+    readonly friction: number | null;
+    /** 'clean' = health row exists and friction is 0. Null = no health data. */
+    readonly signal: "clean" | "friction" | null;
+    readonly produced_commits: number | null;
+    readonly reverted_commits: number | null;
+    readonly lines_added: number | null;
+    readonly lines_removed: number | null;
+    /** ended_at is null AND the latest health derive write is recent - the
+     *  watcher re-ingests live transcripts within ~1 min, so a fresh
+     *  session_health.ts is the cheapest liveness proxy. */
+    readonly is_live: boolean;
 }
 
 export interface SessionListResponse {
@@ -819,6 +839,9 @@ export interface SessionListResponse {
     readonly sessions: ReadonlyArray<SessionListRow>;
     /** Total root count for the active filter set (independent of window). */
     readonly total_count: number;
+    /** The user's 30-day p90 per-turn token burn. The SPA colors sparkline
+     *  buckets amber only above this threshold. Null when no usage history. */
+    readonly burn_p90: number | null;
     /** The slice that was returned. Stays pinned to the first page on the
      *  SPA side when subsequent pages are appended to the same cache key. */
     readonly window: { readonly offset: number; readonly limit: number };
@@ -827,6 +850,48 @@ export interface SessionListResponse {
 export interface SessionChildrenResponse {
     readonly parent_session: SessionId;
     readonly children: ReadonlyArray<SessionListRow>;
+}
+
+/** Wire format for `/api/sessions/:id/insights` - the expandable insight
+ *  panel on the sessions list. All sections optional-by-emptiness: a session
+ *  with no data for a section gets an empty array / null, and the SPA hides
+ *  that cell. */
+export interface SessionInsightsPayload {
+    readonly session: SessionId;
+    readonly phases: ReadonlyArray<{
+        readonly phase: string;
+        readonly start_ts: string;
+        readonly end_ts: string;
+        readonly duration_ms: number;
+    }>;
+    readonly friction_ticks: ReadonlyArray<{ readonly ts: string; readonly kind: string }>;
+    readonly commits: ReadonlyArray<{ readonly ts: string; readonly sha: string; readonly reverted: boolean }>;
+    readonly subagent_spans: ReadonlyArray<{
+        readonly id: SessionId;
+        readonly started_at: string | null;
+        readonly ended_at: string | null;
+    }>;
+    readonly checks: ReadonlyArray<{
+        readonly kind: string;
+        readonly runs: ReadonlyArray<{ readonly ts: string; readonly ok: boolean }>;
+    }>;
+    readonly loc: {
+        readonly added: number;
+        readonly removed: number;
+    } | null;
+    readonly durability: number | null;
+    readonly delegation_ratio: number | null;
+    readonly skills: ReadonlyArray<{ readonly name: string; readonly ts: string }>;
+    /** Context-fill curve, ≤60 points; t = ms offset from session start,
+     *  pct = estimated context fill 0..1 (prompt+cache tokens / window). */
+    readonly context_curve: ReadonlyArray<{ readonly t: number; readonly pct: number }>;
+    readonly compactions: ReadonlyArray<{ readonly ts: string }>;
+    readonly baseline: {
+        readonly cost_ratio: number | null;
+        readonly friction_ratio: number | null;
+        readonly land_ratio: number | null;
+        readonly cache_pct: number | null;
+    };
 }
 
 /** Session inspector: dissected turns with semantic span labels.

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -848,6 +848,7 @@ DEFINE FIELD estimated_cost_usd ON session_token_usage TYPE option<float>;
 DEFINE FIELD pricing_source ON session_token_usage TYPE option<string>;
 DEFINE FIELD labels        ON session_token_usage TYPE option<string>;  -- JSON-encoded
 DEFINE FIELD metrics       ON session_token_usage TYPE option<string>;  -- JSON-encoded
+DEFINE FIELD burn_buckets ON session_token_usage TYPE option<string>;  -- JSON-encoded number[]; sessions-list BURN sparkline
 DEFINE FIELD ts            ON session_token_usage TYPE datetime DEFAULT time::now();
 DEFINE INDEX IF NOT EXISTS session_token_usage_session ON session_token_usage FIELDS session UNIQUE;
 DEFINE INDEX IF NOT EXISTS session_token_usage_epoch ON session_token_usage FIELDS workflow_epoch, source, ts;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,13 +24,7 @@
         "name": "@effect/language-service",
         "ignoreEffectWarningsInTscExitCode": true
       }
-    ],
-    "paths": {
-      "@ax/lib": ["./packages/lib/src/index.ts"],
-      "@ax/lib/*": ["./packages/lib/src/*.ts"],
-      "@ax/schema": ["./packages/schema/src/index.ts"],
-      "@ax/schema/*": ["./packages/schema/src/*.ts"]
-    }
+    ]
   },
   "include": ["apps/axctl/src/**/*.ts", "apps/axctl/src/**/*.tsx", "apps/axctl/src/**/*.d.ts", "packages/**/*.ts"],
   "exclude": ["apps/studio/**"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,13 @@
         "name": "@effect/language-service",
         "ignoreEffectWarningsInTscExitCode": true
       }
-    ]
+    ],
+    "paths": {
+      "@ax/lib": ["./packages/lib/src/index.ts"],
+      "@ax/lib/*": ["./packages/lib/src/*.ts"],
+      "@ax/schema": ["./packages/schema/src/index.ts"],
+      "@ax/schema/*": ["./packages/schema/src/*.ts"]
+    }
   },
   "include": ["apps/axctl/src/**/*.ts", "apps/axctl/src/**/*.tsx", "apps/axctl/src/**/*.d.ts", "packages/**/*.ts"],
   "exclude": ["apps/studio/**"]


### PR DESCRIPTION
Implements docs/superpowers/specs/2026-06-11-sessions-list-remakeover-design.md

- Enriched /api/sessions rows: turns, cost, burn sparkline buckets, friction signal, commit/LOC counts, live dot - all from per-session aggregate tables (no turn scans / graph-deref aggregates)
- New /api/sessions/:id/insights endpoint + accordion insight panel (story bar, outcome, ΔLOC, skill arc, context curve, 30d-baseline footer)
- New session_token_usage.burn_buckets field, precomputed at ingest (claude + codex)
- 30d baselines module (medians + burn p90) with in-process cache

## Riders (not sessions-list scope)

- `.github/workflows/release-please.yml`: asset-upload race fix inherited from the branch base - review separately.
- `AX_SKILLS_DIRS` now fully overrides skill discovery (plugins/projects skipped when set) - shipped for test hermeticity; prod-visible only when the env var is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Design pivot (2026-06-12)

Dogfooding rejected the expandable accordion panel. Locked replacement: **inline micro-viz columns** on every row — STORY (120×8 mini timeline with idle-gap time-warp), ΔLOC (log-scaled bars), COMMITS (dots + reverted ✕). Insights lazy-fetched per visible row. Strip-underline variant prototyped and rejected. InsightPanel/StoryBar components kept on disk for the future session detail page.
