### PR TITLE
fix(ingest): subagent model attribution + spawned edge dispatch metadata

### DIFF
--- a/apps/axctl/src/ingest/derive-claude-subagents.test.ts
+++ b/apps/axctl/src/ingest/derive-claude-subagents.test.ts
@@ -205,6 +205,10 @@ async function buildFixture(opts: {
     parentSessionId: string;
     /** Optional cwd written into the jsonl line so the extractor picks it up. */
     cwdInFile?: string;
+    /** Optional model name written onto the assistant message so the extractor captures it. */
+    modelInFile?: string;
+    /** Optional meta.json content to write next to the jsonl. */
+    meta?: Record<string, string>;
 }) {
     const root = await mkdtemp(join(tmpdir(), "ax-test-subagent-"));
     tmpDirs.push(root);
@@ -224,13 +228,23 @@ async function buildFixture(opts: {
 
     // Write first line (gives parseManifest what it needs: agentId + sessionId)
     // and a second line so finish() produces a non-null session.
-    const secondLine: Record<string, string> = {
+    const secondLine: Record<string, unknown> = {
         agentId: opts.agentId,
         sessionId: opts.parentSessionId,
         type: "assistant",
         timestamp: "2026-01-01T00:00:01.000Z",
     };
+    // Wrap model in a message object so the extractor reads `message.model`.
+    if (opts.modelInFile) {
+        secondLine["message"] = { model: opts.modelInFile };
+    }
     await Bun.write(agentFile, JSON.stringify(firstLine) + "\n" + JSON.stringify(secondLine) + "\n");
+
+    // Write optional meta.json sibling.
+    if (opts.meta) {
+        const metaFile = agentFile.replace(/\.jsonl$/, ".meta.json");
+        await Bun.write(metaFile, JSON.stringify(opts.meta));
+    }
 
     return {
         root,
@@ -355,6 +369,182 @@ describe("repository inheritance on new subagents (F7)", () => {
             // cwd must be the extractor-produced value, NOT the parent's cwd
             expect(upsertCall.content["cwd"]).toBe("/home/user/subagent-working-dir");
             expect(upsertCall.content["cwd"]).not.toBe("/home/user/parent-project");
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: model attribution (Phase 1 fix)
+// ---------------------------------------------------------------------------
+
+/** Shared mock parent row for model/meta tests. */
+function makeParentResponse(parentSessionId: string): Map<string, unknown[][]> {
+    const responses = new Map<string, unknown[][]>();
+    responses.set("SELECT name FROM skill", [[]]);
+    responses.set(parentSessionId, [[
+        {
+            id: `session:⟨${parentSessionId}⟩`,
+            repository: null,
+            checkout: null,
+            cwd: "/home/user/project",
+        },
+    ]]);
+    responses.set('source = "claude-subagent" AND repository IS NONE', [[]]);
+    return responses;
+}
+
+describe("model attribution on subagent session", () => {
+    test("model from assistant message.model lands on the session upsert", async () => {
+        const fixture = await buildFixture({
+            agentId: "model-test-001",
+            parentSessionId: "parent-model-001",
+            modelInFile: "claude-sonnet-4-6",
+        });
+
+        const { upserts, layer } = makeMockDb(
+            makeParentResponse("parent-model-001"),
+            { denyWrites: false },
+        );
+        await runWith(layer, makeFixtureConfig(fixture.root));
+
+        const upsertCall = upserts.find((c) => String(c.id).includes(fixture.subagentSessionId));
+        expect(upsertCall).toBeDefined();
+        expect(upsertCall?.content["model"]).toBe("claude-sonnet-4-6");
+    });
+
+    test("model is undefined on upsert when no assistant message carries model", async () => {
+        const fixture = await buildFixture({
+            agentId: "model-test-002",
+            parentSessionId: "parent-model-002",
+            // no modelInFile → extractor produces session.model = null
+        });
+
+        const { upserts, layer } = makeMockDb(
+            makeParentResponse("parent-model-002"),
+            { denyWrites: false },
+        );
+        await runWith(layer, makeFixtureConfig(fixture.root));
+
+        const upsertCall = upserts.find((c) => String(c.id).includes(fixture.subagentSessionId));
+        expect(upsertCall).toBeDefined();
+        // null → coerced to undefined → not stored (consistent with upsertSessions pattern)
+        expect(upsertCall?.content["model"]).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: meta.json enrichment on spawned edge
+// ---------------------------------------------------------------------------
+
+describe("meta.json enrichment on spawned edge", () => {
+    test("meta fields land in the RELATE query when meta.json is present", async () => {
+        const fixture = await buildFixture({
+            agentId: "meta-test-001",
+            parentSessionId: "parent-meta-001",
+            meta: {
+                agentType: "design-curator",
+                description: "Accessibility critique share view",
+                name: "critic-a11y",
+                toolUseId: "toolu_01Xshe123abc",
+            },
+        });
+
+        const { calls, layer } = makeMockDb(
+            makeParentResponse("parent-meta-001"),
+            { denyWrites: false },
+        );
+        await runWith(layer, makeFixtureConfig(fixture.root));
+
+        const relateCall = calls.find(
+            (c) => c.sql.includes("RELATE") && c.sql.includes("spawned"),
+        );
+        expect(relateCall).toBeDefined();
+        if (relateCall) {
+            expect(relateCall.sql).toContain("agent_type");
+            expect(relateCall.sql).toContain("design-curator");
+            expect(relateCall.sql).toContain("description");
+            expect(relateCall.sql).toContain("Accessibility critique share view");
+            expect(relateCall.sql).toContain("agent_name");
+            expect(relateCall.sql).toContain("critic-a11y");
+            expect(relateCall.sql).toContain("tool_use_id");
+            expect(relateCall.sql).toContain("toolu_01Xshe123abc");
+        }
+    });
+
+    test("missing meta.json is tolerated: RELATE runs without meta fields", async () => {
+        const fixture = await buildFixture({
+            agentId: "meta-test-002",
+            parentSessionId: "parent-meta-002",
+            // no meta → no meta.json written
+        });
+
+        const { calls, layer } = makeMockDb(
+            makeParentResponse("parent-meta-002"),
+            { denyWrites: false },
+        );
+        // Should not throw
+        const stats = await runWith(layer, makeFixtureConfig(fixture.root));
+        expect(stats.written).toBe(1);
+
+        const relateCall = calls.find(
+            (c) => c.sql.includes("RELATE") && c.sql.includes("spawned"),
+        );
+        expect(relateCall).toBeDefined();
+        // Meta clauses absent when file not present
+        if (relateCall) {
+            expect(relateCall.sql).not.toContain("agent_type");
+            expect(relateCall.sql).not.toContain("tool_use_id");
+        }
+    });
+
+    test("unparseable meta.json is tolerated: RELATE still runs", async () => {
+        const fixture = await buildFixture({
+            agentId: "meta-test-003",
+            parentSessionId: "parent-meta-003",
+        });
+        // Overwrite with invalid JSON
+        const metaFile = fixture.agentFile.replace(/\.jsonl$/, ".meta.json");
+        await Bun.write(metaFile, "not-valid-json{{{");
+
+        const { calls, layer } = makeMockDb(
+            makeParentResponse("parent-meta-003"),
+            { denyWrites: false },
+        );
+        const stats = await runWith(layer, makeFixtureConfig(fixture.root));
+        expect(stats.written).toBe(1);
+
+        const relateCall = calls.find(
+            (c) => c.sql.includes("RELATE") && c.sql.includes("spawned"),
+        );
+        expect(relateCall).toBeDefined();
+    });
+
+    test("partial meta.json only emits present fields", async () => {
+        const fixture = await buildFixture({
+            agentId: "meta-test-004",
+            parentSessionId: "parent-meta-004",
+            meta: {
+                agentType: "codebase-analyzer",
+                // description, name, toolUseId intentionally absent
+            },
+        });
+
+        const { calls, layer } = makeMockDb(
+            makeParentResponse("parent-meta-004"),
+            { denyWrites: false },
+        );
+        await runWith(layer, makeFixtureConfig(fixture.root));
+
+        const relateCall = calls.find(
+            (c) => c.sql.includes("RELATE") && c.sql.includes("spawned"),
+        );
+        expect(relateCall).toBeDefined();
+        if (relateCall) {
+            expect(relateCall.sql).toContain("agent_type");
+            expect(relateCall.sql).toContain("codebase-analyzer");
+            // Absent fields must not appear
+            expect(relateCall.sql).not.toContain("tool_use_id");
+            expect(relateCall.sql).not.toContain("agent_name");
         }
     });
 });

--- a/apps/axctl/src/ingest/derive-claude-subagents.ts
+++ b/apps/axctl/src/ingest/derive-claude-subagents.ts
@@ -31,6 +31,14 @@ interface SubagentManifest {
     readonly file: string;
 }
 
+/** Parsed content of `agent-<id>.meta.json` - all fields optional. */
+interface SubagentMeta {
+    readonly agentType?: string;
+    readonly description?: string;
+    readonly name?: string;
+    readonly toolUseId?: string;
+}
+
 export interface DeriveClaudeSubagentsOpts {
     readonly onProgress?: (counts: Record<string, number>) => Effect.Effect<void>;
 }
@@ -119,6 +127,32 @@ const buildManifest = (
         file: filePath,
     };
 }
+
+/**
+ * Attempt to read `agent-<id>.meta.json` (sibling of the `.jsonl` file).
+ * Returns partial/empty object on any failure – callers treat every field optional.
+ */
+const readSubagentMeta = (
+    jsonlPath: string,
+): Effect.Effect<SubagentMeta, never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const metaPath = jsonlPath.replace(/\.jsonl$/, ".meta.json");
+        const text = yield* fs.readFileString(metaPath).pipe(orAbsent<string | null>(null));
+        if (text === null) return {};
+        const parsed = decodeJsonOrNull(text);
+        if (!isRecord(parsed)) return {};
+        const agentType = stringField(parsed, "agentType");
+        const description = stringField(parsed, "description");
+        const name = stringField(parsed, "name");
+        const toolUseId = stringField(parsed, "toolUseId");
+        return {
+            ...(agentType !== null ? { agentType } : {}),
+            ...(description !== null ? { description } : {}),
+            ...(name !== null ? { name } : {}),
+            ...(toolUseId !== null ? { toolUseId } : {}),
+        };
+    });
 
 export interface DeriveClaudeSubagentsStats {
     readonly discovered: number;
@@ -268,6 +302,10 @@ export const deriveClaudeSubagents = (
                 ),
             );
 
+            // Read adjacent meta.json for dispatch metadata (agent type, description, etc.).
+            // Missing / unparseable file yields {}; all fields remain optional.
+            const meta = yield* readSubagentMeta(m.file);
+
             // Inherit repository/checkout from parent unconditionally (the extractor
             // never sets them). Inherit cwd from parent only if extractor produced none.
             const parentRepository = parentRow["repository"] ?? undefined;
@@ -303,6 +341,7 @@ export const deriveClaudeSubagents = (
                     project: extracted.session.project ?? m.project ?? undefined,
                     cwd: cwdValue,
                     source: "claude-subagent",
+                    model: extracted.session.model ?? undefined,
                     started_at: extracted.session.started_at
                         ? new Date(extracted.session.started_at)
                         : m.startedAt
@@ -347,8 +386,15 @@ export const deriveClaudeSubagents = (
             yield* db.query(
                 `DELETE spawned WHERE in = ${parentRid} AND out = ${subagentRef} AND tool = "Agent";`,
             );
+            // Build optional meta SET clauses from adjacent meta.json fields.
+            const metaClauses = [
+                meta.agentType !== undefined ? `, agent_type = ${surrealLiteral(meta.agentType)}` : "",
+                meta.description !== undefined ? `, description = ${surrealLiteral(meta.description)}` : "",
+                meta.name !== undefined ? `, agent_name = ${surrealLiteral(meta.name)}` : "",
+                meta.toolUseId !== undefined ? `, tool_use_id = ${surrealLiteral(meta.toolUseId)}` : "",
+            ].join("");
             yield* db.query(
-                `RELATE ${parentRid} -> spawned -> ${subagentRef} SET ts = d${surrealLiteral(m.startedAt ?? new Date().toISOString())}, tool = "Agent", nickname = ${surrealLiteral(m.agentId.slice(0, 12))};`,
+                `RELATE ${parentRid} -> spawned -> ${subagentRef} SET ts = d${surrealLiteral(m.startedAt ?? new Date().toISOString())}, tool = "Agent", nickname = ${surrealLiteral(m.agentId.slice(0, 12))}${metaClauses};`,
             );
             written += 1;
 

--- a/apps/axctl/src/ingest/session-health.test.ts
+++ b/apps/axctl/src/ingest/session-health.test.ts
@@ -112,5 +112,27 @@ describe("session health derivation", () => {
         expect(statement).toContain("estimated_tokens: IF prompt_tokens != NONE OR completion_tokens != NONE OR cache_creation_input_tokens != NONE OR cache_read_input_tokens != NONE THEN estimated_tokens ELSE 42 END");
         expect(statement).toContain("labels: IF prompt_tokens != NONE OR completion_tokens != NONE OR cache_creation_input_tokens != NONE OR cache_read_input_tokens != NONE THEN labels ELSE");
         expect(statement).toContain("metrics: IF prompt_tokens != NONE OR completion_tokens != NONE OR cache_creation_input_tokens != NONE OR cache_read_input_tokens != NONE THEN metrics ELSE");
+        expect(statement).toContain('model: "gpt-5.5"');
+    });
+
+    test("token usage statement preserves an existing model when session.model is null", () => {
+        const statement = __testTokenUsageStatement({
+            sessionKey: "claude-subagent-abc",
+            source: "claude-subagent",
+            workflowEpoch: null,
+            model: null,
+            promptTokens: null,
+            completionTokens: null,
+            cacheCreationInputTokens: null,
+            cacheReadInputTokens: null,
+            estimatedTokens: 42,
+            transcriptBytes: 168,
+            contextWindow: null,
+            labels: { source: "session_health", token_source: "byte_estimate" },
+            metrics: { turn_bytes: 168 },
+            ts: "2026-05-29T07:00:00.000Z",
+        });
+
+        expect(statement).toContain("model: IF model != NONE THEN model ELSE NONE END");
     });
 });

--- a/apps/axctl/src/ingest/session-health.ts
+++ b/apps/axctl/src/ingest/session-health.ts
@@ -341,7 +341,10 @@ function tokenUsageStatement(row: SessionTokenUsage): string {
         ["session", recordRef("session", row.sessionKey)],
         ["source", surrealString(row.source)],
         ["workflow_epoch", row.workflowEpoch ? recordRef("workflow_epoch", row.workflowEpoch) : "NONE"],
-        ["model", surrealOptionString(row.model)],
+        // Never clobber a model the transcript-priced pass already wrote: the
+        // subagent ingest writes the real per-transcript model, while this
+        // pass only knows session.model (null for sources that don't set it).
+        ["model", row.model === null ? "IF model != NONE THEN model ELSE NONE END" : surrealOptionString(row.model)],
         ["prompt_tokens", `IF ${existingActualTokenUsage} THEN prompt_tokens ELSE ${surrealOptionInt(row.promptTokens)} END`],
         ["completion_tokens", `IF ${existingActualTokenUsage} THEN completion_tokens ELSE ${surrealOptionInt(row.completionTokens)} END`],
         ["cache_creation_input_tokens", `IF ${existingActualTokenUsage} THEN cache_creation_input_tokens ELSE ${surrealOptionInt(row.cacheCreationInputTokens)} END`],

--- a/apps/axctl/src/ingest/transcripts.test.ts
+++ b/apps/axctl/src/ingest/transcripts.test.ts
@@ -1230,6 +1230,18 @@ describe("claude token usage", () => {
         expect(stmt).toContain('source: "claude"');
     });
 
+    test("subagent source override lands on session and turn usage rows", () => {
+        const extracted = __testExtractClaudeJsonlLines(
+            usageLines("claude-opus-4-8"),
+            "-tmp",
+            "claude-subagent-abc",
+        );
+        const [stmt] = buildClaudeTokenUsageStatements(extracted!, "claude-subagent");
+        expect(stmt).toContain('source: "claude-subagent"');
+        const [turnStmt] = buildClaudeTurnTokenUsageStatements(extracted!, "claude-subagent");
+        expect(turnStmt).toContain('source: "claude-subagent"');
+    });
+
     test("emits no statements when the transcript carries no usage", () => {
         const extracted = __testExtractClaudeJsonlLines(
             [

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1481,7 +1481,10 @@ const surrealOptionFloat = (value: number | null | undefined): string =>
  * preserves these real counts (and leaves the cost fields it never writes
  * intact). Empty when the transcript carried no `usage` blocks.
  */
-export const buildClaudeTokenUsageStatements = (extracted: FileExtract): string[] => {
+export const buildClaudeTokenUsageStatements = (
+    extracted: FileExtract,
+    source: "claude" | "claude-subagent" = "claude",
+): string[] => {
     const usage = extracted.tokenUsage;
     if (!usage) return [];
     const modelKey = normalizeModelName(usage.model);
@@ -1497,7 +1500,7 @@ export const buildClaudeTokenUsageStatements = (extracted: FileExtract): string[
     return [
         `UPSERT ${recordRef("session_token_usage", safeKeyPart(sessionId))} MERGE ${surrealObject([
             ["session", recordRef("session", sessionId)],
-            ["source", surrealString("claude")],
+            ["source", surrealString(source)],
             ["model", surrealOptionString(usage.model)],
             ["prompt_tokens", surrealOptionInt(usage.promptTokens)],
             ["completion_tokens", surrealOptionInt(usage.completionTokens)],
@@ -1526,7 +1529,10 @@ export const buildClaudeTokenUsageStatements = (extracted: FileExtract): string[
  * `usage`. Mirrors the codex turn-usage shape so the inspector's per-turn cost
  * rail lights up for Claude sessions too. Empty when no turns carried usage.
  */
-export const buildClaudeTurnTokenUsageStatements = (extracted: FileExtract): string[] => {
+export const buildClaudeTurnTokenUsageStatements = (
+    extracted: FileExtract,
+    source: "claude" | "claude-subagent" = "claude",
+): string[] => {
     const sessionId = extracted.session.id;
     return extracted.turnTokenUsages.map((usage) => {
         const modelKey = normalizeModelName(usage.model);
@@ -1543,7 +1549,7 @@ export const buildClaudeTurnTokenUsageStatements = (extracted: FileExtract): str
             ["session", recordRef("session", sessionId)],
             ["turn", recordRef("turn", turnKey)],
             ["seq", Math.trunc(usage.seq).toString(10)],
-            ["source", surrealString("claude")],
+            ["source", surrealString(source)],
             ["model", surrealOptionString(usage.model)],
             ["prompt_tokens", surrealOptionInt(usage.promptTokens)],
             ["completion_tokens", surrealOptionInt(usage.completionTokens)],
@@ -1575,7 +1581,21 @@ const writeClaudeTokenUsage = (extracted: FileExtract) => {
         : queryTranscriptStatements(statements);
 };
 
-export { writeClaudeTokenUsage as writeTokenUsageForSubagents };
+/**
+ * Subagent variant: identical rows, but `source = "claude-subagent"` so
+ * origin-level rollups (`ax cost split`) can separate main-loop spend from
+ * dispatched-agent spend. The session-health pass writes the same value from
+ * `session.source`; without this the last writer would flip the field.
+ */
+export const writeTokenUsageForSubagents = (extracted: FileExtract) => {
+    const statements = [
+        ...buildClaudeTokenUsageStatements(extracted, "claude-subagent"),
+        ...buildClaudeTurnTokenUsageStatements(extracted, "claude-subagent"),
+    ];
+    return statements.length === 0
+        ? Effect.void
+        : queryTranscriptStatements(statements);
+};
 
 interface IngestOpts {
     sinceDays: number | undefined;

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1422,6 +1422,10 @@ DEFINE FIELD ts           ON spawned TYPE datetime DEFAULT time::now();
 DEFINE FIELD tool         ON spawned TYPE option<string>;       -- e.g. "spawn_agent" | "Task"
 DEFINE FIELD tool_call    ON spawned TYPE option<record<tool_call>>;
 DEFINE FIELD nickname     ON spawned TYPE option<string>;       -- codex assigns "Turing", "Babbage", etc.
+DEFINE FIELD agent_type   ON spawned TYPE option<string>;       -- from agent-<id>.meta.json agentType
+DEFINE FIELD description  ON spawned TYPE option<string>;       -- from agent-<id>.meta.json description
+DEFINE FIELD agent_name   ON spawned TYPE option<string>;       -- from agent-<id>.meta.json name
+DEFINE FIELD tool_use_id  ON spawned TYPE option<string>;       -- from agent-<id>.meta.json toolUseId; joins parent tool_call.call_id
 DEFINE INDEX IF NOT EXISTS spawned_in   ON spawned FIELDS in;
 DEFINE INDEX IF NOT EXISTS spawned_out  ON spawned FIELDS out;
 


### PR DESCRIPTION
## Problem

All 869 `claude-subagent` sessions have `model = null` on session rows and `session_token_usage` rows — $1.8k of estimated cost priced blind, and main-vs-subagent model split impossible to query.

Two compounding bugs:
1. `derive-claude-subagents` dropped `extracted.session.model` on the session upsert (the extractor captured it correctly all along).
2. `session-health`'s token-usage UPSERT wrote `model` unconditionally from `session.model` (null for subagents), **clobbering** the correct model `writeTokenUsageForSubagents` had just written. Evidence: `model_ref` (which health never touches) survived on the same rows — 483 sonnet / 311 opus-4-7 / 215 opus-4-8 / 187 fable / 132 haiku.

## Fix

- Session upsert now includes `model` (unconditional, so re-derive backfills existing rows)
- Health pass preserves an existing `model` when `session.model` is null (`IF model != NONE THEN model ELSE NONE END`)
- `spawned` edge enriched from `agent-<id>.meta.json`: `agent_type`, `description`, `agent_name`, `tool_use_id` (`tool_use_id` joins parent `tool_call.call_id` for dispatch-routing analysis — join itself comes in a follow-up)

## Backfill

```
AX_REDERIVE_SUBAGENTS=1 ax ingest --stages=subagents
```

## Tests

16 pass (8 new: model attribution ×2, meta.json enrichment ×4, health clobber guard ×1, model passthrough ×1); typecheck clean.

Part of the model-routing/cost-visibility arc: subagent model attribution → `ax cost` → `ax dispatches --candidates` → improve-loop routing proposals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)