### PR TITLE
feat(cli): ax cost models/sessions/split + MCP cost tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,12 @@ fresh clone.
 
 `ax roles` - list known role labels.
 
+### Cost analytics
+
+`ax cost models [--days=N]` - per-model rollup: sessions, prompt/completion/cache tokens, estimated cost USD (default 14d).
+`ax cost sessions [--days=N] [--model=<name>] [--limit=N]` - top sessions by cost with id, project, model, started_at (default 14d/20 rows).
+`ax cost split [--days=N]` - origin (main vs subagent) × model matrix with cost and share-of-total; totals row. MCP: `cost_models`, `cost_split`.
+
 ## Recommend + apply guidance to your own agent files
 
 `axctl improve recommend / accept / lint / show` ship the v0 grounded-files

--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -1,0 +1,271 @@
+/**
+ * `ax cost models / sessions / split` - model/cost analytics.
+ *
+ * All three subcommands are read-only, use the `db` runtime, and mirror
+ * the pattern from commands/costs.ts and commands/skills.ts.
+ */
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { prettyPrint } from "@ax/lib/json";
+import { printNextLinks } from "../next-format.ts";
+import {
+    fetchCostModels,
+    fetchCostSessions,
+    fetchCostSplit,
+} from "../../queries/cost-analytics.ts";
+import {
+    buildCostModelsNext,
+    buildCostSplitNext,
+} from "../../nav/next-links.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { fail, jsonFlag, optionValue, positiveLimit } from "./shared.ts";
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+const usd = (n: number): string =>
+    Number.isFinite(n) ? `$${n.toFixed(4)}` : "$0.0000";
+
+const integer = (n: number): string =>
+    Number.isFinite(n) ? Math.trunc(n).toLocaleString("en-US") : "0";
+
+const pct = (n: number): string =>
+    Number.isFinite(n) ? `${n.toFixed(1)}%` : "0.0%";
+
+// ---------------------------------------------------------------------------
+// ax cost models [--days=N] [--json]
+// ---------------------------------------------------------------------------
+
+const cmdCostModels = (input: {
+    readonly sinceDays: number;
+    readonly json: boolean;
+}) =>
+    Effect.gen(function* () {
+        const result = yield* fetchCostModels({ sinceDays: input.sinceDays });
+
+        if (input.json) {
+            console.log(prettyPrint(result));
+            return;
+        }
+
+        if (result.rows.length === 0) {
+            console.log("(no session token usage in the requested window)");
+            return;
+        }
+
+        printNextLinks(buildCostModelsNext(result));
+
+        const colWidths = {
+            model: Math.max(20, ...result.rows.map((r) => r.model.length)),
+        };
+
+        console.log(
+            `${"model".padEnd(colWidths.model)}  ${"sessions".padStart(8)}  ${"prompt".padStart(14)}  ${"completion".padStart(14)}  ${"cache_read".padStart(12)}  ${"cache_create".padStart(12)}  ${"cost".padStart(10)}`,
+        );
+        for (const row of result.rows) {
+            console.log(
+                `${row.model.padEnd(colWidths.model)}  ` +
+                `${integer(row.sessions).padStart(8)}  ` +
+                `${integer(row.prompt_tokens).padStart(14)}  ` +
+                `${integer(row.completion_tokens).padStart(14)}  ` +
+                `${integer(row.cache_read_tokens).padStart(12)}  ` +
+                `${integer(row.cache_create_tokens).padStart(12)}  ` +
+                `${usd(row.cost_usd).padStart(10)}`,
+            );
+        }
+        console.log(`\ntotal: ${usd(result.total_cost_usd)}  (${input.sinceDays} days)`);
+    });
+
+const costModelsCommand = Command.make(
+    "models",
+    {
+        days: Flag.integer("days").pipe(Flag.withDefault(14)),
+        json: jsonFlag,
+    },
+    ({ days, json }) => {
+        if (!Number.isInteger(days) || days <= 0) {
+            fail(`ax cost models: --days must be a positive integer (got "${days}")`);
+        }
+        return cmdCostModels({ sinceDays: days, json });
+    },
+).pipe(
+    Command.withDescription(
+        "Per-model rollup: sessions, prompt/completion/cache tokens, estimated cost. " +
+        "--days=N (default 14)  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax cost sessions [--days=N] [--model=<name>] [--limit=N] [--json]
+// ---------------------------------------------------------------------------
+
+const cmdCostSessions = (input: {
+    readonly sinceDays: number;
+    readonly limit: number;
+    readonly model: string | null;
+    readonly json: boolean;
+}) =>
+    Effect.gen(function* () {
+        const result = yield* fetchCostSessions({
+            sinceDays: input.sinceDays,
+            limit: input.limit,
+            model: input.model,
+        });
+
+        if (input.json) {
+            console.log(prettyPrint(result));
+            return;
+        }
+
+        if (result.rows.length === 0) {
+            console.log("(no priced sessions in the requested window)");
+            return;
+        }
+
+        console.log(
+            `${"session".padEnd(36)}  ${"project".padEnd(24)}  ${"model".padEnd(28)}  ${"started".padEnd(19)}  ${"cost".padStart(10)}  ${"completion".padStart(12)}  ${"cache_read".padStart(12)}`,
+        );
+        for (const row of result.rows) {
+            // Strip "session:" prefix and optional SurrealDB backtick wrapping (`uuid`)
+            const sid = row.session_id.replace(/^session:/, "").replace(/^`(.*)`$/, "$1").slice(0, 36);
+            const proj = (row.project ?? "").slice(0, 24);
+            const mdl = (row.model ?? "?").slice(0, 28);
+            const ts = (row.started_at ?? "").slice(0, 19);
+            console.log(
+                `${sid.padEnd(36)}  ` +
+                `${proj.padEnd(24)}  ` +
+                `${mdl.padEnd(28)}  ` +
+                `${ts.padEnd(19)}  ` +
+                `${usd(row.cost_usd).padStart(10)}  ` +
+                `${integer(row.completion_tokens).padStart(12)}  ` +
+                `${integer(row.cache_read_tokens).padStart(12)}`,
+            );
+        }
+    });
+
+const costSessionsCommand = Command.make(
+    "sessions",
+    {
+        days: Flag.integer("days").pipe(Flag.withDefault(14)),
+        model: Flag.string("model").pipe(Flag.optional),
+        limit: positiveLimit(20),
+        json: jsonFlag,
+    },
+    ({ days, model, limit, json }) => {
+        if (!Number.isInteger(days) || days <= 0) {
+            fail(`ax cost sessions: --days must be a positive integer (got "${days}")`);
+        }
+        return cmdCostSessions({
+            sinceDays: days,
+            limit,
+            model: optionValue(model) ?? null,
+            json,
+        });
+    },
+).pipe(
+    Command.withDescription(
+        "Top sessions by estimated cost: id, project, model, started_at, cost, completion tokens, cache-read tokens. " +
+        "--days=N (default 14)  --model=<name>  --limit=N (default 20)  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax cost split [--days=N] [--json]
+// ---------------------------------------------------------------------------
+
+const cmdCostSplit = (input: {
+    readonly sinceDays: number;
+    readonly json: boolean;
+}) =>
+    Effect.gen(function* () {
+        const result = yield* fetchCostSplit({ sinceDays: input.sinceDays });
+
+        if (input.json) {
+            console.log(prettyPrint(result));
+            return;
+        }
+
+        if (result.totals.cost_usd === 0) {
+            console.log("(no cost data in the requested window)");
+            return;
+        }
+
+        printNextLinks(buildCostSplitNext(result));
+
+        const colWidths = {
+            origin: 8,
+            model: Math.max(20, ...result.rows.map((r) => r.model.length)),
+        };
+
+        console.log(
+            `${"origin".padEnd(colWidths.origin)}  ${"model".padEnd(colWidths.model)}  ${"sessions".padStart(8)}  ${"prompt".padStart(14)}  ${"completion".padStart(14)}  ${"cost".padStart(10)}  ${"share".padStart(7)}`,
+        );
+        for (const row of result.rows) {
+            console.log(
+                `${row.origin.padEnd(colWidths.origin)}  ` +
+                `${row.model.padEnd(colWidths.model)}  ` +
+                `${integer(row.sessions).padStart(8)}  ` +
+                `${integer(row.prompt_tokens).padStart(14)}  ` +
+                `${integer(row.completion_tokens).padStart(14)}  ` +
+                `${usd(row.cost_usd).padStart(10)}  ` +
+                `${pct(row.share_pct).padStart(7)}`,
+        );
+        }
+
+        // Totals row
+        const t = result.totals;
+        const totalLabel = "TOTAL";
+        console.log(
+            `\n${"".padEnd(colWidths.origin)}  ${"".padEnd(colWidths.model)}  ` +
+            `${"".padStart(8)}  ${"".padStart(14)}  ${"".padStart(14)}  ` +
+            `${"─".repeat(10)}  ${"─".repeat(7)}`,
+        );
+        console.log(
+            `${totalLabel.padEnd(colWidths.origin)}  ${"".padEnd(colWidths.model)}  ` +
+            `${integer(t.sessions).padStart(8)}  ` +
+            `${integer(t.prompt_tokens).padStart(14)}  ` +
+            `${integer(t.completion_tokens).padStart(14)}  ` +
+            `${usd(t.cost_usd).padStart(10)}  ` +
+            `${"100.0%".padStart(7)}`,
+        );
+        console.log(`\n(${input.sinceDays} days)`);
+    });
+
+const costSplitCommand = Command.make(
+    "split",
+    {
+        days: Flag.integer("days").pipe(Flag.withDefault(14)),
+        json: jsonFlag,
+    },
+    ({ days, json }) => {
+        if (!Number.isInteger(days) || days <= 0) {
+            fail(`ax cost split: --days must be a positive integer (got "${days}")`);
+        }
+        return cmdCostSplit({ sinceDays: days, json });
+    },
+).pipe(
+    Command.withDescription(
+        "Cost matrix: origin (main vs subagent) x model with cost, tokens, and share-of-total. " +
+        "--days=N (default 14)  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax cost (group command)
+// ---------------------------------------------------------------------------
+
+export const costCommand = Command.make("cost").pipe(
+    Command.withDescription(
+        "Model/cost analytics: per-model rollup, top sessions, main-vs-subagent split",
+    ),
+    Command.withSubcommands([
+        costModelsCommand,
+        costSessionsCommand,
+        costSplitCommand,
+    ]),
+);
+
+export const axCostRuntime: RuntimeManifest = {
+    cost: "db",
+};

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -15,6 +15,7 @@ import { shareCommand, shareRuntime } from "./commands/share.ts";
 import { starCommand, starRuntime } from "./commands/star.ts";
 import { dogfoodCommand, dogfoodRuntime } from "./commands/dogfood.ts";
 import { costsGroupCommand, locCommand, pricingCommand, costsRuntime } from "./commands/costs.ts";
+import { costCommand, axCostRuntime } from "./commands/ax-cost.ts";
 import { recallCommand, recallRuntime } from "./commands/recall.ts";
 import { hookCommand, hooksCommand, hooksRuntime } from "./commands/hooks.ts";
 import { retroCommand, retroRuntime } from "./commands/retro.ts";
@@ -71,6 +72,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...starRuntime,
     ...dogfoodRuntime,
     ...costsRuntime,
+    ...axCostRuntime,
     ...recallRuntime,
     ...hooksRuntime,
     ...retroRuntime,
@@ -105,6 +107,7 @@ const registeredCommands: ReadonlyArray<Command.Command.Any> = [
     shareCommand,
     installCommand,
     setupCommand,
+    costCommand,
     // Maintenance / plumbing verbs - hidden via their family manifests.
     deriveCommand,
     deriveSignalsCommand,

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -25,6 +25,8 @@ const EXPECTED_TOOLS = [
     "improve_list",
     "session_metrics",
     "signal_show",
+    "cost_models",
+    "cost_split",
 ] as const;
 
 describe("axMcpTools registry", () => {
@@ -38,7 +40,7 @@ describe("axMcpTools registry", () => {
         expect(recall!.inputSchema).toHaveProperty("q");
     });
 
-    it("registers all 12 read-only tools, each well-formed", () => {
+    it("registers all 14 read-only tools, each well-formed", () => {
         expect(axMcpTools.map((t) => t.name).sort()).toEqual(
             [...EXPECTED_TOOLS].sort(),
         );

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -54,7 +54,10 @@ import {
     buildSkillsRolesNext,
     buildRolesNext,
     buildImproveProposalsNext,
+    buildCostModelsNext,
+    buildCostSplitNext,
 } from "../nav/next-links.ts";
+import { fetchCostModels, fetchCostSplit } from "../queries/cost-analytics.ts";
 
 /**
  * The long-lived MCP runtime, built from `AppLayer` (SurrealClient + config +
@@ -479,6 +482,44 @@ const signalShowTool: AxMcpTool = {
     },
 };
 
+const costModelsTool: AxMcpTool = {
+    name: "cost_models",
+    description:
+        `Per-model cost rollup over session_token_usage: sessions count, prompt/completion/cache tokens, estimated cost USD, sorted by cost desc. Includes an "(unattributed)" row for sessions with no model recorded. ${NEXT_PROTOCOL_HINT}`,
+    inputSchema: {
+        days: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Window in days (default 14)."),
+    },
+    run: async (args, rt) => {
+        const days = typeof args.days === "number" ? args.days : 14;
+        const result = await rt.runPromise(fetchCostModels({ sinceDays: days }));
+        return { ...result, next: buildCostModelsNext(result) };
+    },
+};
+
+const costSplitTool: AxMcpTool = {
+    name: "cost_split",
+    description:
+        `Cost matrix split by origin (main = non-subagent, subagent = claude-subagent) x model. Returns rows with cost, token sums, and share-of-total percent, plus a totals row. Use to understand how much subagent dispatch costs relative to top-level sessions. ${NEXT_PROTOCOL_HINT}`,
+    inputSchema: {
+        days: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Window in days (default 14)."),
+    },
+    run: async (args, rt) => {
+        const days = typeof args.days === "number" ? args.days : 14;
+        const result = await rt.runPromise(fetchCostSplit({ sinceDays: days }));
+        return { ...result, next: buildCostSplitNext(result) };
+    },
+};
+
 /**
  * All registered MCP tools. `server.ts` iterates this array to register +
  * wrap each one.
@@ -501,4 +542,6 @@ export const axMcpTools: ReadonlyArray<AxMcpTool> = [
     improveListTool,
     sessionMetricsTool,
     signalShowTool,
+    costModelsTool,
+    costSplitTool,
 ];

--- a/apps/axctl/src/nav/next-links.ts
+++ b/apps/axctl/src/nav/next-links.ts
@@ -34,6 +34,7 @@ import type {
     FetchRolesForSkillResult,
     FetchAllRolesResult,
 } from "../dashboard/role-queries.ts";
+import type { CostModelsResult, CostSplitResult } from "../queries/cost-analytics.ts";
 
 // ---------------------------------------------------------------------------
 // Protocol hint - appended to tool/CLI descriptions
@@ -431,6 +432,69 @@ export const buildRolesNext = (
             ),
         );
     }
+    return sortNavLinks(top);
+};
+
+// ---------------------------------------------------------------------------
+// improve (recommend / list)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// cost models / split
+// ---------------------------------------------------------------------------
+
+/** Top-level links for cost models rollup. */
+export const buildCostModelsNext = (
+    result: CostModelsResult,
+): ReadonlyArray<NavLink> => {
+    const top: NavLink[] = [];
+    if (result.rows.length === 0) {
+        top.push({
+            description: "No cost data - widen the window",
+            cmd: "ax cost models --days=30",
+            ui: { priority: 8, group: "search" },
+        });
+        return top;
+    }
+    top.push({
+        description: "Show top sessions by cost",
+        call: { tool: "cost_models", arguments: { days: 14 } },
+        cmd: "ax cost sessions",
+        ui: { priority: 7, group: "read" },
+    });
+    top.push({
+        description: "Split cost by origin (main vs subagent) × model",
+        call: { tool: "cost_split", arguments: {} },
+        cmd: "ax cost split",
+        ui: { priority: 6, group: "read" },
+    });
+    return sortNavLinks(top);
+};
+
+/** Top-level links for cost split matrix. */
+export const buildCostSplitNext = (
+    result: CostSplitResult,
+): ReadonlyArray<NavLink> => {
+    const top: NavLink[] = [];
+    if (result.totals.cost_usd === 0) {
+        top.push({
+            description: "No cost data - widen the window",
+            cmd: "ax cost split --days=30",
+            ui: { priority: 8, group: "search" },
+        });
+        return top;
+    }
+    top.push({
+        description: "Per-model rollup with session counts",
+        call: { tool: "cost_models", arguments: {} },
+        cmd: "ax cost models",
+        ui: { priority: 7, group: "read" },
+    });
+    top.push({
+        description: "Top sessions by cost",
+        cmd: "ax cost sessions",
+        ui: { priority: 6, group: "read" },
+    });
     return sortNavLinks(top);
 };
 

--- a/apps/axctl/src/queries/cost-analytics.test.ts
+++ b/apps/axctl/src/queries/cost-analytics.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
+import {
+    fetchCostModels,
+    fetchCostSessions,
+    fetchCostSplit,
+} from "./cost-analytics.ts";
+
+// ---------------------------------------------------------------------------
+// fetchCostModels
+// ---------------------------------------------------------------------------
+
+describe("fetchCostModels", () => {
+    test("aggregates per-model rows and sorts by cost desc", async () => {
+        const dbRows = [
+            { model: "claude-opus-4-8", sessions: 10, prompt_tokens: 1000, completion_tokens: 200,
+              cache_read_tokens: 50, cache_create_tokens: 20, cost_usd: 5.0 },
+            { model: "gpt-5.5", sessions: 5, prompt_tokens: 500, completion_tokens: 100,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 2.0 },
+        ];
+        const db = makeMockDb([[dbRows]]);
+        const result = await runWithMock(db, fetchCostModels({ sinceDays: 14 }));
+
+        expect(result.rows).toHaveLength(2);
+        expect(result.rows[0]!.model).toBe("claude-opus-4-8");
+        expect(result.rows[0]!.cost_usd).toBe(5.0);
+        expect(result.rows[1]!.model).toBe("gpt-5.5");
+        expect(result.total_cost_usd).toBeCloseTo(7.0);
+    });
+
+    test("maps null model to (unattributed)", async () => {
+        const dbRows = [
+            { model: null, sessions: 3, prompt_tokens: 100, completion_tokens: 50,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 1.0 },
+        ];
+        const db = makeMockDb([[dbRows]]);
+        const result = await runWithMock(db, fetchCostModels({ sinceDays: 14 }));
+
+        expect(result.rows[0]!.model).toBe("(unattributed)");
+    });
+
+    test("handles empty result", async () => {
+        const db = makeMockDb([[[]]] );
+        const result = await runWithMock(db, fetchCostModels({ sinceDays: 14 }));
+
+        expect(result.rows).toHaveLength(0);
+        expect(result.total_cost_usd).toBe(0);
+    });
+
+    test("SQL includes the since window", async () => {
+        const db = makeMockDb([[[]]] );
+        await runWithMock(db, fetchCostModels({ sinceDays: 7 }));
+        expect(db.captured[0]).toContain("time::now() - 7d");
+    });
+
+    test("SQL groups by model and orders by cost_usd", async () => {
+        const db = makeMockDb([[[]]] );
+        await runWithMock(db, fetchCostModels({ sinceDays: 14 }));
+        expect(db.captured[0]).toContain("GROUP BY model");
+        expect(db.captured[0]).toContain("ORDER BY cost_usd DESC");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchCostSessions
+// ---------------------------------------------------------------------------
+
+describe("fetchCostSessions", () => {
+    test("returns sessions sorted by cost desc", async () => {
+        const dbRows = [
+            {
+                session_id: "session:abc123",
+                project: "ax",
+                model: "claude-opus-4-8",
+                started_at: "2026-06-10T00:00:00.000Z",
+                cost_usd: 3.5,
+                completion_tokens: 1000,
+                cache_read_tokens: 500,
+            },
+        ];
+        const db = makeMockDb([[dbRows]]);
+        const result = await runWithMock(db, fetchCostSessions({ sinceDays: 14, limit: 20, model: null }));
+
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0]!.session_id).toBe("session:abc123");
+        expect(result.rows[0]!.cost_usd).toBe(3.5);
+        expect(result.rows[0]!.model).toBe("claude-opus-4-8");
+    });
+
+    test("null fields are preserved as null", async () => {
+        const dbRows = [
+            {
+                session_id: "session:x",
+                project: null,
+                model: null,
+                started_at: null,
+                cost_usd: 0.5,
+                completion_tokens: 0,
+                cache_read_tokens: 0,
+            },
+        ];
+        const db = makeMockDb([[dbRows]]);
+        const result = await runWithMock(db, fetchCostSessions({ sinceDays: 14, limit: 20, model: null }));
+
+        expect(result.rows[0]!.project).toBeNull();
+        expect(result.rows[0]!.model).toBeNull();
+        expect(result.rows[0]!.started_at).toBeNull();
+    });
+
+    test("SQL includes model filter when provided", async () => {
+        const db = makeMockDb([[[]]] );
+        await runWithMock(db, fetchCostSessions({ sinceDays: 14, limit: 20, model: "claude-opus-4-8" }));
+        expect(db.captured[0]).toContain("claude-opus-4-8");
+    });
+
+    test("SQL does not include model filter when null", async () => {
+        const db = makeMockDb([[[]]] );
+        await runWithMock(db, fetchCostSessions({ sinceDays: 14, limit: 20, model: null }));
+        expect(db.captured[0]).not.toContain("model =");
+    });
+
+    test("SQL limits results", async () => {
+        const db = makeMockDb([[[]]] );
+        await runWithMock(db, fetchCostSessions({ sinceDays: 14, limit: 5, model: null }));
+        expect(db.captured[0]).toContain("LIMIT 5");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchCostSplit
+// ---------------------------------------------------------------------------
+
+describe("fetchCostSplit", () => {
+    test("partitions source=claude-subagent into subagent origin", async () => {
+        const dbRows = [
+            { source: "claude", model: "claude-opus-4-8", sessions: 5,
+              prompt_tokens: 1000, completion_tokens: 200,
+              cache_read_tokens: 50, cache_create_tokens: 10, cost_usd: 4.0 },
+            { source: "claude-subagent", model: null, sessions: 2,
+              prompt_tokens: 300, completion_tokens: 60,
+              cache_read_tokens: 10, cache_create_tokens: 5, cost_usd: 1.0 },
+        ];
+        const db = makeMockDb([[dbRows]]);
+        const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+
+        const mainRow = result.rows.find((r) => r.origin === "main");
+        const subRow = result.rows.find((r) => r.origin === "subagent");
+
+        expect(mainRow).toBeDefined();
+        expect(subRow).toBeDefined();
+        expect(mainRow!.model).toBe("claude-opus-4-8");
+        expect(subRow!.model).toBe("(unattributed)");
+    });
+
+    test("computes share_pct relative to total", async () => {
+        const dbRows = [
+            { source: "claude", model: "A", sessions: 1,
+              prompt_tokens: 100, completion_tokens: 10,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 3.0 },
+            { source: "codex", model: "B", sessions: 1,
+              prompt_tokens: 50, completion_tokens: 5,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 1.0 },
+        ];
+        const db = makeMockDb([[dbRows]]);
+        const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+
+        const a = result.rows.find((r) => r.model === "A")!;
+        const b = result.rows.find((r) => r.model === "B")!;
+        expect(a.share_pct).toBeCloseTo(75);
+        expect(b.share_pct).toBeCloseTo(25);
+    });
+
+    test("totals aggregate across all rows", async () => {
+        const dbRows = [
+            { source: "claude", model: "X", sessions: 3,
+              prompt_tokens: 100, completion_tokens: 20,
+              cache_read_tokens: 5, cache_create_tokens: 2, cost_usd: 2.0 },
+            { source: "claude-subagent", model: null, sessions: 7,
+              prompt_tokens: 200, completion_tokens: 40,
+              cache_read_tokens: 10, cache_create_tokens: 4, cost_usd: 1.5 },
+        ];
+        const db = makeMockDb([[dbRows]]);
+        const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+
+        expect(result.totals.sessions).toBe(10);
+        expect(result.totals.prompt_tokens).toBe(300);
+        expect(result.totals.cost_usd).toBeCloseTo(3.5);
+    });
+
+    test("handles zero total cost without NaN share_pct", async () => {
+        const dbRows = [
+            { source: "claude", model: "X", sessions: 1,
+              prompt_tokens: 100, completion_tokens: 10,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0 },
+        ];
+        const db = makeMockDb([[dbRows]]);
+        const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+
+        expect(result.rows[0]!.share_pct).toBe(0);
+    });
+
+    test("SQL groups by source and model", async () => {
+        const db = makeMockDb([[[]]] );
+        await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+        expect(db.captured[0]).toContain("GROUP BY source, model");
+    });
+});

--- a/apps/axctl/src/queries/cost-analytics.ts
+++ b/apps/axctl/src/queries/cost-analytics.ts
@@ -1,0 +1,285 @@
+/**
+ * `ax cost models / sessions / split`: model/cost analytics over
+ * `session_token_usage`. GROUP BY stays on scalar fields of the scanned table
+ * only - record derefs inside aggregates over large tables hang SurrealDB 3.x -
+ * so any grouping that needs a derived dimension (origin) happens in JS after
+ * a single scan.
+ *
+ * Tables used (read-only):
+ *   session_token_usage: source, model, prompt_tokens, completion_tokens,
+ *     cache_creation_input_tokens, cache_read_input_tokens,
+ *     estimated_cost_usd, ts
+ *   session: id, source, project, started_at, model
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { surrealLiteral } from "@ax/lib/json";
+
+// ---------------------------------------------------------------------------
+// cost models
+// ---------------------------------------------------------------------------
+
+export interface CostModelsRow {
+    readonly model: string;
+    readonly sessions: number;
+    readonly prompt_tokens: number;
+    readonly completion_tokens: number;
+    readonly cache_read_tokens: number;
+    readonly cache_create_tokens: number;
+    readonly cost_usd: number;
+}
+
+export interface CostModelsResult {
+    readonly rows: ReadonlyArray<CostModelsRow>;
+    readonly total_cost_usd: number;
+}
+
+/**
+ * Fetch raw session_token_usage rows for the cost-models rollup. Avoids
+ * GROUP BY + deref inside aggregates; aggregation is done in JS.
+ */
+const COST_MODELS_SQL = (sinceDays: number) => `
+SELECT
+    model,
+    count() AS sessions,
+    math::sum(prompt_tokens) AS prompt_tokens,
+    math::sum(completion_tokens) AS completion_tokens,
+    math::sum(cache_read_input_tokens) AS cache_read_tokens,
+    math::sum(cache_creation_input_tokens) AS cache_create_tokens,
+    math::sum(estimated_cost_usd) AS cost_usd
+FROM session_token_usage
+WHERE ts > time::now() - ${Math.max(1, Math.trunc(sinceDays))}d
+GROUP BY model
+ORDER BY cost_usd DESC;
+`;
+
+export const fetchCostModels = Effect.fn("queries.fetchCostModels")(
+    function* (opts: { readonly sinceDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db.query<[Array<Record<string, unknown>>]>(
+            COST_MODELS_SQL(opts.sinceDays),
+        ).pipe(Effect.map((r) => r?.[0] ?? []));
+
+        const parsed: CostModelsRow[] = rows.map((row) => ({
+            model: row.model == null ? "(unattributed)" : String(row.model),
+            sessions: Number(row.sessions ?? 0),
+            prompt_tokens: Number(row.prompt_tokens ?? 0),
+            completion_tokens: Number(row.completion_tokens ?? 0),
+            cache_read_tokens: Number(row.cache_read_tokens ?? 0),
+            cache_create_tokens: Number(row.cache_create_tokens ?? 0),
+            cost_usd: Number(row.cost_usd ?? 0),
+        }));
+
+        // Sort by cost desc
+        parsed.sort((a, b) => b.cost_usd - a.cost_usd);
+
+        const total_cost_usd = parsed.reduce((sum, r) => sum + r.cost_usd, 0);
+        return { rows: parsed, total_cost_usd } satisfies CostModelsResult;
+    },
+);
+
+// ---------------------------------------------------------------------------
+// cost sessions
+// ---------------------------------------------------------------------------
+
+export interface CostSessionsRow {
+    readonly session_id: string;
+    readonly project: string | null;
+    readonly model: string | null;
+    readonly started_at: string | null;
+    readonly cost_usd: number;
+    readonly completion_tokens: number;
+    readonly cache_read_tokens: number;
+}
+
+export interface CostSessionsResult {
+    readonly rows: ReadonlyArray<CostSessionsRow>;
+}
+
+const COST_SESSIONS_SQL = (sinceDays: number, limit: number, modelFilter: string | null) => {
+    const whereFragments = [
+        `ts > time::now() - ${Math.max(1, Math.trunc(sinceDays))}d`,
+        "estimated_cost_usd != NONE",
+    ];
+    if (modelFilter) {
+        whereFragments.push(`model = ${surrealLiteral(modelFilter)}`);
+    }
+    const where = whereFragments.join(" AND ");
+    return `
+SELECT
+    type::string(session) AS session_id,
+    session.project AS project,
+    model,
+    type::string(session.started_at) AS started_at,
+    estimated_cost_usd AS cost_usd,
+    completion_tokens,
+    cache_read_input_tokens AS cache_read_tokens
+FROM session_token_usage
+WHERE ${where}
+ORDER BY estimated_cost_usd DESC
+LIMIT ${Math.min(Math.max(1, Math.trunc(limit)), 500)};
+`;
+};
+
+export const fetchCostSessions = Effect.fn("queries.fetchCostSessions")(
+    function* (opts: {
+        readonly sinceDays: number;
+        readonly limit: number;
+        readonly model: string | null;
+    }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db.query<[Array<Record<string, unknown>>]>(
+            COST_SESSIONS_SQL(opts.sinceDays, opts.limit, opts.model),
+        ).pipe(Effect.map((r) => r?.[0] ?? []));
+
+        const parsed: CostSessionsRow[] = rows.map((row) => ({
+            session_id: String(row.session_id ?? ""),
+            project: row.project == null ? null : String(row.project),
+            model: row.model == null ? null : String(row.model),
+            started_at: row.started_at == null ? null : String(row.started_at),
+            cost_usd: Number(row.cost_usd ?? 0),
+            completion_tokens: Number(row.completion_tokens ?? 0),
+            cache_read_tokens: Number(row.cache_read_tokens ?? 0),
+        }));
+
+        return { rows: parsed } satisfies CostSessionsResult;
+    },
+);
+
+// ---------------------------------------------------------------------------
+// cost split
+// ---------------------------------------------------------------------------
+
+export interface CostSplitRow {
+    readonly origin: "main" | "subagent";
+    readonly model: string;
+    readonly sessions: number;
+    readonly prompt_tokens: number;
+    readonly completion_tokens: number;
+    readonly cache_read_tokens: number;
+    readonly cache_create_tokens: number;
+    readonly cost_usd: number;
+    readonly share_pct: number;
+}
+
+export interface CostSplitTotals {
+    readonly sessions: number;
+    readonly prompt_tokens: number;
+    readonly completion_tokens: number;
+    readonly cache_read_tokens: number;
+    readonly cache_create_tokens: number;
+    readonly cost_usd: number;
+}
+
+export interface CostSplitResult {
+    readonly rows: ReadonlyArray<CostSplitRow>;
+    readonly totals: CostSplitTotals;
+}
+
+const COST_SPLIT_SQL = (sinceDays: number) => `
+SELECT
+    source,
+    model,
+    count() AS sessions,
+    math::sum(prompt_tokens) AS prompt_tokens,
+    math::sum(completion_tokens) AS completion_tokens,
+    math::sum(cache_read_input_tokens) AS cache_read_tokens,
+    math::sum(cache_creation_input_tokens) AS cache_create_tokens,
+    math::sum(estimated_cost_usd) AS cost_usd
+FROM session_token_usage
+WHERE ts > time::now() - ${Math.max(1, Math.trunc(sinceDays))}d
+GROUP BY source, model
+ORDER BY cost_usd DESC;
+`;
+
+/**
+ * Aggregate into (origin × model) cells where origin is "main" (source !=
+ * 'claude-subagent') or "subagent" (source == 'claude-subagent').
+ * Aggregation + share computation run in JS after a single DB scan.
+ */
+export const fetchCostSplit = Effect.fn("queries.fetchCostSplit")(
+    function* (opts: { readonly sinceDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db.query<[Array<Record<string, unknown>>]>(
+            COST_SPLIT_SQL(opts.sinceDays),
+        ).pipe(Effect.map((r) => r?.[0] ?? []));
+
+        // Aggregate per (origin × model)
+        const cellMap = new Map<string, {
+            origin: "main" | "subagent";
+            model: string;
+            sessions: number;
+            prompt_tokens: number;
+            completion_tokens: number;
+            cache_read_tokens: number;
+            cache_create_tokens: number;
+            cost_usd: number;
+        }>();
+
+        let totalCost = 0;
+        let totalSessions = 0;
+        let totalPrompt = 0;
+        let totalCompletion = 0;
+        let totalCacheRead = 0;
+        let totalCacheCreate = 0;
+
+        for (const row of rows) {
+            const origin: "main" | "subagent" =
+                String(row.source ?? "") === "claude-subagent" ? "subagent" : "main";
+            const model = row.model == null ? "(unattributed)" : String(row.model);
+            const key = `${origin}\x00${model}`;
+
+            const sessions = Number(row.sessions ?? 0);
+            const prompt = Number(row.prompt_tokens ?? 0);
+            const completion = Number(row.completion_tokens ?? 0);
+            const cacheRead = Number(row.cache_read_tokens ?? 0);
+            const cacheCreate = Number(row.cache_create_tokens ?? 0);
+            const cost = Number(row.cost_usd ?? 0);
+
+            const existing = cellMap.get(key);
+            if (existing) {
+                existing.sessions += sessions;
+                existing.prompt_tokens += prompt;
+                existing.completion_tokens += completion;
+                existing.cache_read_tokens += cacheRead;
+                existing.cache_create_tokens += cacheCreate;
+                existing.cost_usd += cost;
+            } else {
+                cellMap.set(key, {
+                    origin,
+                    model,
+                    sessions,
+                    prompt_tokens: prompt,
+                    completion_tokens: completion,
+                    cache_read_tokens: cacheRead,
+                    cache_create_tokens: cacheCreate,
+                    cost_usd: cost,
+                });
+            }
+
+            totalCost += cost;
+            totalSessions += sessions;
+            totalPrompt += prompt;
+            totalCompletion += completion;
+            totalCacheRead += cacheRead;
+            totalCacheCreate += cacheCreate;
+        }
+
+        const cells = [...cellMap.values()].sort((a, b) => b.cost_usd - a.cost_usd);
+        const splitRows: CostSplitRow[] = cells.map((cell) => ({
+            ...cell,
+            share_pct: totalCost > 0 ? (cell.cost_usd / totalCost) * 100 : 0,
+        }));
+
+        const totals: CostSplitTotals = {
+            sessions: totalSessions,
+            prompt_tokens: totalPrompt,
+            completion_tokens: totalCompletion,
+            cache_read_tokens: totalCacheRead,
+            cache_create_tokens: totalCacheCreate,
+            cost_usd: totalCost,
+        };
+
+        return { rows: splitRows, totals } satisfies CostSplitResult;
+    },
+);


### PR DESCRIPTION
## What

Read-only cost analytics command family over `session_token_usage`:

- `ax cost models [--days=N]` — per-model rollup (sessions, tokens, est cost)
- `ax cost sessions [--days=N] [--model] [--limit]` — top sessions by cost
- `ax cost split [--days=N]` — the headline: origin (main loop vs subagent) × model matrix with share-of-total

MCP: `cost_models` + `cost_split` registered (same query functions, read-only), so agents can ask "where is the spend" in-context.

## Sample (real data, post-#300 backfill)

```
origin    model                      sessions     cost    share
main      claude-fable-5                   30  $4211.22    48.7%
main      claude-opus-4-8                  11  $2057.32    23.8%
subagent  claude-fable-5                  187  $1340.55    15.5%
subagent  claude-sonnet-4-6                72    $50.39     0.6%
subagent  claude-haiku-4-5                 23    $10.94     0.1%
```

This view is the read surface of the model-routing loop: subagent fable spend ($1.3k here) is directly redirectable to sonnet/haiku via dispatch model pins; `ax dispatches --candidates` (next PR) names the dispatches.

## Notes

- Query layer keeps GROUP BY on scalar fields only; derived-dimension grouping (origin) in JS — record derefs inside aggregates hang SurrealDB 3.x at this scale
- Depends on #300 for subagent rows to carry model + `source=claude-subagent` (commands work either way; rows show "(unattributed)" pre-backfill)
- Legacy hidden `ax costs` left untouched; fold into `cost` later

## Tests

15 new query tests (makeMockDb); 159 pass incl. manifest exhaustiveness; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)