### PR TITLE
feat(hooks-sdk): route-dispatch hook - model-routing suggestions on Agent dispatches

### DIFF
--- a/apps/axctl/src/hooks/sdk-workspace.test.ts
+++ b/apps/axctl/src/hooks/sdk-workspace.test.ts
@@ -29,15 +29,17 @@ describe("scaffoldWorkspace", () => {
         expect(pkgRaw.endsWith("\n")).toBe(true);
     });
 
-    test("writes both starter hook files", async () => {
+    test("writes all starter hook files", async () => {
         const dir = mk();
         const sdkPath = "/abs/packages/hooks-sdk";
         const written = await run(scaffoldWorkspace({ dir, sdkPath, install: false }));
 
         const ewPath = join(dir, "enforce-worktree.ts");
         const ewwPath = join(dir, "enforce-worktree-write.ts");
+        const rdPath = join(dir, "route-dispatch.ts");
         expect(existsSync(ewPath)).toBe(true);
         expect(existsSync(ewwPath)).toBe(true);
+        expect(existsSync(rdPath)).toBe(true);
 
         const ewContent = readFileSync(ewPath, "utf8");
         expect(ewContent).toContain('@ax/hooks-sdk/hooks/enforce-worktree');
@@ -48,9 +50,13 @@ describe("scaffoldWorkspace", () => {
         const ewwContent = readFileSync(ewwPath, "utf8");
         expect(ewwContent).toContain('@ax/hooks-sdk/hooks/enforce-worktree-write');
 
-        // Both hook files should be in the written list
+        const rdContent = readFileSync(rdPath, "utf8");
+        expect(rdContent).toContain('@ax/hooks-sdk/hooks/route-dispatch');
+
+        // All hook files should be in the written list
         expect(written).toContain(ewPath);
         expect(written).toContain(ewwPath);
+        expect(written).toContain(rdPath);
     });
 
     test("does not overwrite an existing hook file (preserves user edits)", async () => {
@@ -100,7 +106,8 @@ describe("scaffoldWorkspace", () => {
         expect(written).toContain(join(dir, "package.json"));
         expect(written).toContain(join(dir, "enforce-worktree.ts"));
         expect(written).toContain(join(dir, "enforce-worktree-write.ts"));
-        expect(written.length).toBe(3);
+        expect(written).toContain(join(dir, "route-dispatch.ts"));
+        expect(written.length).toBe(4);
     });
 
     test("creates dir if it does not exist", async () => {

--- a/apps/axctl/src/hooks/sdk-workspace.ts
+++ b/apps/axctl/src/hooks/sdk-workspace.ts
@@ -66,7 +66,13 @@ export interface ScaffoldOptions {
     readonly install: boolean;
 }
 
-const GUARD_NAMES = ["enforce-worktree", "enforce-worktree-write"] as const;
+const GUARD_NAMES = [
+    "enforce-worktree",
+    "enforce-worktree-write",
+    // Claude-only: suggests cheaper model when Agent dispatch has no explicit model set.
+    // Codex has no Agent-tool dispatch equivalent; this hook is a no-op there.
+    "route-dispatch",
+] as const;
 
 const packageJsonContent = (sdkPath: string): string =>
     `${JSON.stringify(

--- a/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import routeDispatch from "./route-dispatch.ts";
+import { GitEnvTest } from "../git-env.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const layer = GitEnvTest({});
+
+type AgentInput = {
+  subagent_type?: string;
+  model?: string;
+  description?: string;
+  prompt?: string;
+};
+
+const run = (input: AgentInput) =>
+  Effect.runPromise(
+    routeDispatch
+      .run({
+        harness: "claude",
+        event: "PreToolUse",
+        sessionId: null,
+        cwd: "/repo",
+        tool: { name: "Agent", input: input as Record<string, unknown> },
+        raw: {},
+      })
+      .pipe(Effect.provide(layer)),
+  );
+
+// ---------------------------------------------------------------------------
+// Explicit model → always allow
+// ---------------------------------------------------------------------------
+
+describe("explicit model set", () => {
+  test("model='sonnet' → Allow (user made a deliberate choice)", async () => {
+    const v = await run({ description: "locate all usages", model: "sonnet" });
+    expect(v._tag).toBe("Allow");
+  });
+
+  test("model='haiku' → Allow", async () => {
+    const v = await run({ description: "spec review of PR #42", model: "haiku" });
+    expect(v._tag).toBe("Allow");
+  });
+
+  test("model='' (empty string) is treated as unset → may warn", async () => {
+    // Empty string is falsy - we treat it the same as absent
+    const v = await run({ description: "locate symbols", model: "" });
+    // Should warn (matches search-locate) rather than allow
+    expect(v._tag).toBe("Warn");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Description-based matches (default routing table)
+// ---------------------------------------------------------------------------
+
+describe("description matches default routing table", () => {
+  test("'spec review of PR' → Warn with sonnet suggestion", async () => {
+    const v = await run({ description: "spec review of PR #42" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("sonnet");
+      expect(v.message).toContain("checklist compliance review");
+    }
+  });
+
+  test("'Locate all TODO comments' → Warn with haiku suggestion (case-insensitive)", async () => {
+    const v = await run({ description: "Locate all TODO comments" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("haiku");
+    }
+  });
+
+  test("'find usages of Foo' → Warn with haiku", async () => {
+    const v = await run({ description: "find usages of Foo" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("haiku");
+    }
+  });
+
+  test("'research the Effect v4 API' → Warn with sonnet", async () => {
+    const v = await run({ description: "research the Effect v4 API" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("sonnet");
+      expect(v.message).toContain("web/docs research");
+    }
+  });
+
+  test("'implement task: add route-dispatch hook' → Warn with sonnet", async () => {
+    const v = await run({ description: "implement task: add route-dispatch hook" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("sonnet");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agent-type rules (default routing table)
+// ---------------------------------------------------------------------------
+
+describe("agentType rules", () => {
+  test("subagent_type='Explore' → Warn with haiku", async () => {
+    const v = await run({ subagent_type: "Explore", description: "some task" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("haiku");
+      expect(v.message).toContain("Explore");
+    }
+  });
+
+  test("subagent_type='codebase-locator' → Warn with haiku", async () => {
+    const v = await run({ subagent_type: "codebase-locator" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("haiku");
+    }
+  });
+
+  test("subagent_type='codebase-analyzer' → Warn with sonnet", async () => {
+    const v = await run({ subagent_type: "codebase-analyzer" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("sonnet");
+    }
+  });
+
+  test("agentType wins over description pattern when both match", async () => {
+    // 'Explore' agent type → haiku; description 'research ...' → sonnet.
+    // Agent type should win (more specific).
+    const v = await run({ subagent_type: "Explore", description: "research the docs" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("haiku");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No match → allow
+// ---------------------------------------------------------------------------
+
+describe("no match", () => {
+  test("unknown description → Allow", async () => {
+    const v = await run({ description: "write a comprehensive e2e test suite" });
+    expect(v._tag).toBe("Allow");
+  });
+
+  test("unknown subagent_type + unmatched description → Allow", async () => {
+    const v = await run({ subagent_type: "general-purpose", description: "do the thing" });
+    expect(v._tag).toBe("Allow");
+  });
+
+  test("no input fields → Allow", async () => {
+    const v = await run({});
+    expect(v._tag).toBe("Allow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt fallback (first 120 chars used when description absent)
+// ---------------------------------------------------------------------------
+
+describe("prompt fallback", () => {
+  test("no description but prompt starts with 'locate' → Warn (haiku)", async () => {
+    const v = await run({ prompt: "locate all files that import Effect" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("haiku");
+    }
+  });
+
+  test("prompt longer than 120 chars - only first 120 chars matched", async () => {
+    // Pad with characters that would not match, then put a pattern at end
+    const padding = "x".repeat(130);
+    const v = await run({ prompt: `${padding} spec review of PR` });
+    // The pattern won't be in the first 120 chars - should allow
+    expect(v._tag).toBe("Allow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warn message contains key fields
+// ---------------------------------------------------------------------------
+
+describe("warn message format", () => {
+  test("message includes description label, model suggestion, and cost hint", async () => {
+    const v = await run({ description: "spec review of PR #42" });
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("ax routing:");
+      expect(v.message).toContain('"spec review of PR #42"');
+      expect(v.message).toContain("sonnet");
+      expect(v.message).toContain("cheaper");
+      expect(v.message).toContain("Explicit model silences this");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Routing table fallback: corrupt file → defaults still fire
+// ---------------------------------------------------------------------------
+
+describe("routing table loading", () => {
+  test("corrupt/absent routing table falls back to defaults and still warns on known pattern", async () => {
+    // We cannot easily mock the fs call here without dependency injection,
+    // but the real path (~/.ax/hooks/routing-table.json) likely does not exist
+    // in CI. The default table is embedded, so the hook should still work.
+    // This test verifies the default table is active when the file is absent.
+    const v = await run({ description: "locate things" });
+    // 'locate' matches the default search-locate pattern → Warn
+    expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("haiku");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defect → fail open
+// ---------------------------------------------------------------------------
+
+describe("defect handling", () => {
+  test("predicate defect → Allow (fail open via runHook contract)", async () => {
+    // The define.ts runHook wrapper catches defects and returns allow.
+    // We test this via runHook directly.
+    const { runHook } = await import("../define.ts");
+    const boom = {
+      name: "boom",
+      events: ["PreToolUse"] as const,
+      matcher: { tools: ["Agent"] },
+      run: () => Effect.sync((): never => { throw new Error("simulated defect"); }),
+    };
+    const result = await Effect.runPromise(
+      runHook(
+        boom,
+        JSON.stringify({
+          hook_event_name: "PreToolUse",
+          tool_name: "Agent",
+          tool_input: { description: "spec review" },
+          cwd: "/repo",
+        }),
+        {},
+      ).pipe(Effect.provide(layer)),
+    );
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-Agent tool → does not match (matcher guard)
+// ---------------------------------------------------------------------------
+
+describe("matcher guard", () => {
+  test("Bash tool → does not fire (matcher filters it out)", async () => {
+    const { runHook } = await import("../define.ts");
+    const result = await Effect.runPromise(
+      runHook(
+        routeDispatch,
+        JSON.stringify({
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "echo hi" },
+          cwd: "/repo",
+        }),
+        {},
+      ).pipe(Effect.provide(layer)),
+    );
+    expect(result.exitCode).toBe(0);
+    // No systemMessage in stdout (warn would produce it)
+    expect(result.stdout).toBeUndefined();
+  });
+});

--- a/packages/hooks-sdk/src/hooks/route-dispatch.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.ts
@@ -1,0 +1,244 @@
+/**
+ * route-dispatch hook
+ *
+ * Fires on PreToolUse for the `Agent` tool. When a subagent dispatch has no
+ * explicit `model`, matches the dispatch description (or first 120 chars of
+ * prompt) against a routing table and emits a `warn` verdict suggesting a
+ * cheaper model to the calling model.
+ *
+ * Verdict choice - warn vs inject:
+ *   - `warn` encodes as `{ systemMessage: "..." }` on stdout (exit 0).
+ *     Claude Code injects this into the model's context for the CURRENT turn,
+ *     so the model can re-read the suggestion and re-dispatch with `model:`
+ *     pinned.  `inject` (plain stdout) is for SessionStart/UserPromptSubmit
+ *     context augmentation, not PreToolUse feedback; `block` (exit 2) would
+ *     prevent the dispatch entirely, which is too aggressive.  `warn` is the
+ *     right fit: it reaches the model without stopping the call.
+ *   - Codex has no Agent-tool dispatch equivalent; this hook is Claude-only
+ *     but the SDK fires it for any harness - it will just never match on Codex
+ *     because Codex never emits an `Agent` tool name.
+ */
+
+import { Effect, Result, Schema } from "effect";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { defineHook, runMain } from "../define.ts";
+import { GitEnv } from "../git-env.ts";
+import { Verdict } from "../verdict.ts";
+
+// ---------------------------------------------------------------------------
+// Routing table schema
+// ---------------------------------------------------------------------------
+
+const RoutingClass = Schema.Struct({
+  id: Schema.String,
+  pattern: Schema.String,
+  flags: Schema.optional(Schema.String),
+  suggest: Schema.String,
+  reason: Schema.String,
+});
+
+const RoutingTable = Schema.Struct({
+  version: Schema.Literal(1),
+  classes: Schema.Array(RoutingClass),
+  agentTypes: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+});
+
+type RoutingTableType = Schema.Schema.Type<typeof RoutingTable>;
+
+// ---------------------------------------------------------------------------
+// Built-in defaults (used when ~/.ax/hooks/routing-table.json is absent /
+// unparseable - the hook must work before any compile-routing step exists)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TABLE: RoutingTableType = {
+  version: 1,
+  classes: [
+    {
+      id: "mechanical-review",
+      pattern: "^(spec review|quality review|review pr)",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "checklist compliance review",
+    },
+    {
+      id: "search-locate",
+      pattern: "^(pattern-find|locate|find|map|sweep|grep)",
+      flags: "i",
+      suggest: "haiku",
+      reason: "code search/sweep",
+    },
+    {
+      id: "research",
+      pattern: "^(research|investigate docs|study)",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "web/docs research",
+    },
+    {
+      id: "well-specified-impl",
+      pattern: "^(implement task|implement p[0-9]|regenerate|standardize)",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "spec'd implementation",
+    },
+  ],
+  agentTypes: {
+    Explore: "haiku",
+    "codebase-locator": "haiku",
+    "codebase-pattern-finder": "haiku",
+    "codebase-analyzer": "sonnet",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Load routing table (synchronous; fails open on any error)
+// ---------------------------------------------------------------------------
+
+const ROUTING_TABLE_PATH = `${homedir()}/.ax/hooks/routing-table.json`;
+
+const decodeRoutingTable = Schema.decodeUnknownResult(RoutingTable);
+
+/**
+ * Load and validate the routing table from disk.
+ * Returns DEFAULT_TABLE on any error (missing file, bad JSON, schema mismatch).
+ */
+const loadRoutingTable = (): RoutingTableType => {
+  try {
+    const text = readFileSync(ROUTING_TABLE_PATH, "utf8");
+    const parsed: unknown = JSON.parse(text);
+    const result = decodeRoutingTable(parsed);
+    if (Result.isSuccess(result)) return result.success;
+    // Schema validation failed - fall back to defaults (fail open)
+    return DEFAULT_TABLE;
+  } catch {
+    // File absent, unreadable, or non-JSON - fall back to defaults
+    return DEFAULT_TABLE;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Match logic (pure, synchronous)
+// ---------------------------------------------------------------------------
+
+interface MatchResult {
+  readonly classId: string;
+  readonly suggest: string;
+  readonly reason: string;
+  readonly source: "agentType" | "description";
+}
+
+const matchTable = (
+  table: RoutingTableType,
+  description: string | undefined,
+  subagentType: string | undefined,
+): MatchResult | null => {
+  // 1. Agent-type rules win first (more specific)
+  if (subagentType && table.agentTypes) {
+    const suggest = table.agentTypes[subagentType];
+    if (suggest) {
+      return {
+        classId: `agent-type:${subagentType}`,
+        suggest,
+        reason: `agent type ${subagentType}`,
+        source: "agentType",
+      };
+    }
+  }
+
+  // 2. Description/prompt pattern matching
+  if (description) {
+    for (const cls of table.classes) {
+      try {
+        const flags = cls.flags ?? "";
+        const re = new RegExp(cls.pattern, flags);
+        if (re.test(description)) {
+          return {
+            classId: cls.id,
+            suggest: cls.suggest,
+            reason: cls.reason,
+            source: "description",
+          };
+        }
+      } catch {
+        // Malformed regex in routing table entry - skip this entry
+        continue;
+      }
+    }
+  }
+
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Cost multiplier hint (rough guidance - not exact)
+// ---------------------------------------------------------------------------
+
+const costHint = (suggest: string): string => {
+  // Multipliers vs the expensive tiers (fable/opus) per current agent_model
+  // pricing: fable->haiku 10x, opus->haiku 5x; fable->sonnet ~3x.
+  switch (suggest) {
+    case "haiku":
+      return "~5-10x";
+    case "sonnet":
+      return "~2-3x";
+    default:
+      return "significantly";
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Hook definition
+// ---------------------------------------------------------------------------
+
+const hook = defineHook({
+  name: "route-dispatch",
+  events: ["PreToolUse"],
+  // Only fire for Agent-tool dispatches.
+  matcher: { tools: ["Agent"] },
+  run: (event) =>
+    // GitEnv is required by the HookDefinition interface signature, but this
+    // hook does not need git state. We yield* it to satisfy the type, but
+    // never call any of its methods.
+    Effect.gen(function* () {
+      void (yield* GitEnv); // satisfy R=GitEnv; unused
+
+      const input = event.tool?.input ?? {};
+      const model = input.model;
+      const subagentType =
+        typeof input.subagent_type === "string" ? input.subagent_type : undefined;
+      const rawDescription =
+        typeof input.description === "string" ? input.description : undefined;
+      const rawPrompt =
+        typeof input.prompt === "string" ? input.prompt.slice(0, 120) : undefined;
+
+      // Explicit model set - the caller has already made a deliberate choice.
+      if (model !== undefined && model !== null && model !== "") {
+        return Verdict.allow;
+      }
+
+      const description = rawDescription ?? rawPrompt;
+
+      const table = loadRoutingTable();
+      const match = matchTable(table, description, subagentType);
+
+      if (match === null) return Verdict.allow;
+
+      const label = rawDescription
+        ? `"${rawDescription}"`
+        : subagentType
+          ? `agent-type "${subagentType}"`
+          : `"${description ?? "(unknown)"}"`;
+
+      const msg =
+        `ax routing: ${label} looks like ${match.reason} work - ` +
+        `consider model: "${match.suggest}" on this dispatch ` +
+        `(est ${costHint(match.suggest)} cheaper). ` +
+        `Explicit model silences this.`;
+
+      return Verdict.warn(msg);
+    }),
+});
+
+export default hook;
+if (import.meta.main) void runMain(hook);

--- a/scripts/check-no-node-fs.ts
+++ b/scripts/check-no-node-fs.ts
@@ -39,6 +39,9 @@ const EXCLUDED_FILES: readonly string[] = [
     // realPath is async - a sync realpath needs node:fs. Runs under plain
     // bun in ~/.ax/hooks workspaces, not the axctl platform runtime.
     "packages/hooks-sdk/src/git-env.ts",
+    // Same fire-path constraint: routing-table.json is read synchronously so
+    // the hook's error channel stays `never` under plain bun (~70ms budget).
+    "packages/hooks-sdk/src/hooks/route-dispatch.ts",
 ];
 
 const BANNED_SPECIFIERS = [


### PR DESCRIPTION
## What

The apply-side of the model-routing loop. A `route-dispatch` hook (PreToolUse, Agent tool, Claude-only) that fires when a subagent dispatch has **no explicit `model`** and its description or agent-type matches a mechanical-work class — and emits a `warn` verdict suggesting the cheaper model:

> ax routing: "Spec review Task 2" looks like checklist compliance review work - consider model: "sonnet" on this dispatch (est ~2-3x cheaper). Explicit model silences this.

- Routing table: `~/.ax/hooks/routing-table.json` (Effect Schema-validated), typed built-in defaults when absent/corrupt — works before any compile-routing step exists
- Default classes: mechanical-review→sonnet, search-locate→haiku, research→sonnet, well-specified-impl→sonnet; agent-type rules (Explore/locator/pattern-finder→haiku)
- Every failure path fails open (missing file, bad JSON, schema mismatch, malformed regex)
- `warn` over `block`: the suggestion reaches the model so it can re-dispatch with `model:` pinned; never prevents the call
- Scaffolds via `ax hooks init`; install: `ax hooks install ~/.ax/hooks/route-dispatch.ts --providers=claude`

## Why

`ax cost split` (#301) shows subagent spend on fable/opus that pattern-matches mechanical work (spec reviews, locates, sweeps) — directly redirectable at ~2-10x multipliers. This hook closes read→apply; `ax dispatches compile-routing` (follow-up) regenerates the table from graph evidence.

## Notes

- `route-dispatch.ts` allowlisted in `check:no-node-fs` (same fire-path-sync justification as `git-env.ts`)
- Codex unaffected: never emits an `Agent` tool name

## Tests

21 new hook tests; 94 pass across hooks-sdk + sdk-workspace; no-node-fs gate clean; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)