### PR TITLE
feat(cli): ax dispatches + --candidates + compile-routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,12 @@ fresh clone.
 `ax cost sessions [--days=N] [--model=<name>] [--limit=N]` - top sessions by cost with id, project, model, started_at (default 14d/20 rows).
 `ax cost split [--days=N]` - origin (main vs subagent) × model matrix with cost and share-of-total; totals row. MCP: `cost_models`, `cost_split`.
 
+### Dispatch routing
+
+`ax dispatches [--days=N] [--limit=N]` - subagent dispatch table sorted by child cost (default 14d/30 rows). Shows ts, agent_type, description, dispatch_model ("inherit" when no explicit model), child_model, child_cost_usd. Summary: count, % inherit, total subagent cost. MCP: `dispatches`.
+`ax dispatches --candidates [--days=N]` - inherit + expensive (fable/opus) + routing-class match filter. Shows suggested model + est savings per dispatch. Footer: total est savings, top 3 classes by savings.
+`ax dispatches compile-routing [--out=PATH]` - write `~/.ax/hooks/routing-table.json` from ROUTING_CLASSES constant (mirrors route-dispatch.ts hook defaults; a unify step is deferred). Idempotent regenerate. --out overrides path (tests use tmp dirs).
+
 ## Recommend + apply guidance to your own agent files
 
 `axctl improve recommend / accept / lint / show` ship the v0 grounded-files

--- a/apps/axctl/src/cli/commands/ax-dispatches.ts
+++ b/apps/axctl/src/cli/commands/ax-dispatches.ts
@@ -1,0 +1,226 @@
+/**
+ * `ax dispatches` - subagent dispatch analytics.
+ *
+ * Subcommands:
+ *   ax dispatches [--days=N] [--limit=N] [--json]
+ *     Table of dispatches sorted by child cost desc. Summary: count, % inherit,
+ *     total subagent cost.
+ *
+ *   ax dispatches --candidates [--days=N] [--json]
+ *     Dispatches where model=inherit, child model is expensive (fable/opus),
+ *     and description/agentType matches a routing class. Shows suggested model
+ *     + est savings. Footer: total est savings, top 3 classes by savings.
+ *
+ *   ax dispatches compile-routing [--out=PATH] [--json]
+ *     Write ~/.ax/hooks/routing-table.json from ROUTING_CLASSES. Idempotent
+ *     regenerate. --out overrides the default path (tests use tmp dirs).
+ *     ONLY write operation - to filesystem, not DB.
+ */
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { prettyPrint } from "@ax/lib/json";
+import { printNextLinks } from "../next-format.ts";
+import {
+    fetchDispatches,
+    fetchDispatchCandidates,
+    compileRouting,
+} from "../../queries/dispatch-analytics.ts";
+import { buildDispatchesNext, buildCandidatesNext } from "../../nav/next-links.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { fail, jsonFlag, optionValue, positiveLimit } from "./shared.ts";
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+const usd = (n: number): string =>
+    Number.isFinite(n) ? `$${n.toFixed(4)}` : "$0.0000";
+
+const pct = (n: number): string =>
+    Number.isFinite(n) ? `${n.toFixed(1)}%` : "0.0%";
+
+const truncate = (s: string | null, len: number): string => {
+    if (!s) return "";
+    return s.length <= len ? s : `${s.slice(0, len - 1)}…`;
+};
+
+// ---------------------------------------------------------------------------
+// ax dispatches [--days=N] [--limit=N] [--candidates] [--json]
+// ---------------------------------------------------------------------------
+
+const cmdDispatches = (input: {
+    readonly sinceDays: number;
+    readonly limit: number;
+    readonly candidates: boolean;
+    readonly json: boolean;
+}) =>
+    Effect.gen(function* () {
+        if (input.candidates) {
+            const result = yield* fetchDispatchCandidates({ sinceDays: input.sinceDays });
+
+            if (input.json) {
+                console.log(prettyPrint(result));
+                return;
+            }
+
+            if (result.candidates.length === 0) {
+                console.log("(no routing candidates in the requested window)");
+                return;
+            }
+
+            printNextLinks(buildCandidatesNext(result));
+
+            // Header
+            const descW = 48;
+            const modelW = 28;
+            console.log(
+                `${"ts".padEnd(19)}  ${"agent_type".padEnd(24)}  ${"description".padEnd(descW)}  ` +
+                `${"suggest".padEnd(modelW)}  ${"child_cost".padStart(10)}  ${"est_savings".padStart(11)}`,
+            );
+
+            for (const row of result.candidates) {
+                const ts = row.ts.slice(0, 19);
+                const at = truncate(row.agent_type, 24);
+                const desc = truncate(row.description, descW);
+                const suggest = row.suggested_model.slice(0, modelW);
+                console.log(
+                    `${ts.padEnd(19)}  ${at.padEnd(24)}  ${desc.padEnd(descW)}  ` +
+                    `${suggest.padEnd(modelW)}  ${usd(row.child_cost_usd).padStart(10)}  ` +
+                    `${usd(row.est_savings_usd).padStart(11)}`,
+                );
+            }
+
+            console.log(`\ntotal est savings: ${usd(result.total_est_savings_usd)}`);
+            if (result.top_classes.length > 0) {
+                const classLine = result.top_classes
+                    .map((c) => `${c.classId} (${usd(c.savings_usd)})`)
+                    .join(", ");
+                console.log(`top classes: ${classLine}`);
+            }
+            return;
+        }
+
+        // Default: full dispatch table
+        const result = yield* fetchDispatches({ sinceDays: input.sinceDays, limit: input.limit });
+
+        if (input.json) {
+            console.log(prettyPrint(result));
+            return;
+        }
+
+        if (result.rows.length === 0) {
+            console.log("(no dispatches in the requested window)");
+            return;
+        }
+
+        printNextLinks(buildDispatchesNext(result));
+
+        const descW = 48;
+        const dmW = 16; // dispatch model column
+        const cmW = 28; // child model column
+
+        console.log(
+            `${"ts".padEnd(19)}  ${"agent_type".padEnd(24)}  ${"description".padEnd(descW)}  ` +
+            `${"dispatch_model".padEnd(dmW)}  ${"child_model".padEnd(cmW)}  ${"child_cost".padStart(10)}`,
+        );
+
+        for (const row of result.rows) {
+            const ts = row.ts.slice(0, 19);
+            const at = truncate(row.agent_type, 24);
+            const desc = truncate(row.description, descW);
+            const dm = row.dispatch_model.slice(0, dmW);
+            const cm = (row.child_model ?? "?").slice(0, cmW);
+            console.log(
+                `${ts.padEnd(19)}  ${at.padEnd(24)}  ${desc.padEnd(descW)}  ` +
+                `${dm.padEnd(dmW)}  ${cm.padEnd(cmW)}  ${usd(row.child_cost_usd).padStart(10)}`,
+            );
+        }
+
+        console.log(
+            `\n${result.total_dispatches} dispatches  ${pct(result.inherit_pct)} inherit  ` +
+            `total subagent cost: ${usd(result.total_child_cost_usd)}  (${input.sinceDays} days)`,
+        );
+    });
+
+const dispatchesMainCommand = Command.make(
+    "dispatches",
+    {
+        days: Flag.integer("days").pipe(Flag.withDefault(14)),
+        limit: positiveLimit(30),
+        candidates: Flag.boolean("candidates").pipe(Flag.withDefault(false)),
+        json: jsonFlag,
+    },
+    ({ days, limit, candidates, json }) => {
+        if (!Number.isInteger(days) || days <= 0) {
+            fail(`ax dispatches: --days must be a positive integer (got "${days}")`);
+        }
+        return cmdDispatches({ sinceDays: days, limit, candidates, json });
+    },
+).pipe(
+    Command.withDescription(
+        "Subagent dispatch analytics: table of dispatches sorted by child cost, with dispatch model, child model, cost. " +
+        "--days=N (default 14)  --limit=N (default 30)  --candidates (inherit + expensive + routing match)  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax dispatches compile-routing [--out=PATH] [--json]
+// ---------------------------------------------------------------------------
+
+const compileRoutingCommand = Command.make(
+    "compile-routing",
+    {
+        out: Flag.string("out").pipe(Flag.optional),
+        json: jsonFlag,
+    },
+    ({ out, json }) => Effect.gen(function* () {
+        const outPath = optionValue(out);
+        const result = yield* compileRouting(outPath);
+        if (json) {
+            console.log(prettyPrint(result));
+        } else {
+            console.log(`routing-table written: ${result.path}`);
+        }
+    }),
+).pipe(
+    Command.withDescription(
+        "Write ~/.ax/hooks/routing-table.json from the built-in ROUTING_CLASSES constant. " +
+        "Idempotent regenerate. --out=PATH overrides default path. --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax dispatches (group)
+// ---------------------------------------------------------------------------
+
+export const dispatchesCommand = Command.make("dispatches").pipe(
+    Command.withDescription(
+        "Subagent dispatch analytics + routing optimisation. Sub-commands: compile-routing",
+    ),
+    Command.withSubcommands([compileRoutingCommand]),
+);
+
+// Attach flags directly to the group command so `ax dispatches` works without
+// a subcommand. We re-declare the main handler on the group command itself
+// via Command.make with flags, then add subcommands.
+//
+// Effect CLI v4 groups need a parent command to hold subcommands. The actual
+// dispatch table view lives on the parent command itself (not a subcommand).
+// We achieve this by making `dispatchesMainCommand` the parent and hanging
+// `compile-routing` off it.
+export const dispatchesRootCommand = dispatchesMainCommand.pipe(
+    Command.withSubcommands([compileRoutingCommand]),
+);
+
+export const axDispatchesRuntime: RuntimeManifest = {
+    dispatches: {
+        runtime: {
+            kind: "db-conditional",
+            fallback: "db",
+            subcommands: {
+                "compile-routing": "none",
+            },
+        },
+        hidden: false,
+    },
+};

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -16,6 +16,7 @@ import { starCommand, starRuntime } from "./commands/star.ts";
 import { dogfoodCommand, dogfoodRuntime } from "./commands/dogfood.ts";
 import { costsGroupCommand, locCommand, pricingCommand, costsRuntime } from "./commands/costs.ts";
 import { costCommand, axCostRuntime } from "./commands/ax-cost.ts";
+import { dispatchesRootCommand, axDispatchesRuntime } from "./commands/ax-dispatches.ts";
 import { recallCommand, recallRuntime } from "./commands/recall.ts";
 import { hookCommand, hooksCommand, hooksRuntime } from "./commands/hooks.ts";
 import { retroCommand, retroRuntime } from "./commands/retro.ts";
@@ -73,6 +74,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...dogfoodRuntime,
     ...costsRuntime,
     ...axCostRuntime,
+    ...axDispatchesRuntime,
     ...recallRuntime,
     ...hooksRuntime,
     ...retroRuntime,
@@ -108,6 +110,7 @@ const registeredCommands: ReadonlyArray<Command.Command.Any> = [
     installCommand,
     setupCommand,
     costCommand,
+    dispatchesRootCommand,
     // Maintenance / plumbing verbs - hidden via their family manifests.
     deriveCommand,
     deriveSignalsCommand,

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_TOOLS = [
     "signal_show",
     "cost_models",
     "cost_split",
+    "dispatches",
 ] as const;
 
 describe("axMcpTools registry", () => {
@@ -40,7 +41,7 @@ describe("axMcpTools registry", () => {
         expect(recall!.inputSchema).toHaveProperty("q");
     });
 
-    it("registers all 14 read-only tools, each well-formed", () => {
+    it("registers all 15 read-only tools, each well-formed", () => {
         expect(axMcpTools.map((t) => t.name).sort()).toEqual(
             [...EXPECTED_TOOLS].sort(),
         );

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -58,6 +58,8 @@ import {
     buildCostSplitNext,
 } from "../nav/next-links.ts";
 import { fetchCostModels, fetchCostSplit } from "../queries/cost-analytics.ts";
+import { fetchDispatches, fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
+import { buildDispatchesNext, buildCandidatesNext } from "../nav/next-links.ts";
 
 /**
  * The long-lived MCP runtime, built from `AppLayer` (SurrealClient + config +
@@ -520,6 +522,41 @@ const costSplitTool: AxMcpTool = {
     },
 };
 
+const dispatchesTool: AxMcpTool = {
+    name: "dispatches",
+    description:
+        `Subagent dispatch analytics over the spawned relation. Without candidates: table of dispatches sorted by child cost (ts, agent_type, description, dispatch_model, child_model, child_cost_usd) + summary (count, inherit%, total cost). With candidates=true: only inherit dispatches on expensive models (fable/opus) that match a routing class, with suggested model + est savings. ${NEXT_PROTOCOL_HINT}`,
+    inputSchema: {
+        days: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Window in days (default 14)."),
+        limit: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Max dispatch rows to return (default 30). Ignored when candidates=true."),
+        candidates: z
+            .boolean()
+            .optional()
+            .describe("When true, return only routing-optimisation candidates with est savings."),
+    },
+    run: async (args, rt) => {
+        const days = typeof args.days === "number" ? args.days : 14;
+        const candidates = args.candidates === true;
+        if (candidates) {
+            const result = await rt.runPromise(fetchDispatchCandidates({ sinceDays: days }));
+            return { ...result, next: buildCandidatesNext(result) };
+        }
+        const limit = typeof args.limit === "number" ? args.limit : 30;
+        const result = await rt.runPromise(fetchDispatches({ sinceDays: days, limit }));
+        return { ...result, next: buildDispatchesNext(result) };
+    },
+};
+
 /**
  * All registered MCP tools. `server.ts` iterates this array to register +
  * wrap each one.
@@ -544,4 +581,5 @@ export const axMcpTools: ReadonlyArray<AxMcpTool> = [
     signalShowTool,
     costModelsTool,
     costSplitTool,
+    dispatchesTool,
 ];

--- a/apps/axctl/src/nav/next-links.ts
+++ b/apps/axctl/src/nav/next-links.ts
@@ -35,6 +35,7 @@ import type {
     FetchAllRolesResult,
 } from "../dashboard/role-queries.ts";
 import type { CostModelsResult, CostSplitResult } from "../queries/cost-analytics.ts";
+import type { DispatchesResult, CandidatesResult } from "../queries/dispatch-analytics.ts";
 
 // ---------------------------------------------------------------------------
 // Protocol hint - appended to tool/CLI descriptions
@@ -531,6 +532,64 @@ export const buildImproveProposalsNext = (
         description: "Accept the top proposal (emits a .ax/tasks brief; CLI-only, mutating)",
         cmd: `ax improve accept ${first.sig}`,
         ui: { priority: 5, group: "act" },
+    });
+    return sortNavLinks(top);
+};
+
+// ---------------------------------------------------------------------------
+// dispatches / dispatch candidates
+// ---------------------------------------------------------------------------
+
+/** Top-level links for dispatch analytics. */
+export const buildDispatchesNext = (
+    result: DispatchesResult,
+): ReadonlyArray<NavLink> => {
+    const top: NavLink[] = [];
+    if (result.total_dispatches === 0) {
+        top.push({
+            description: "No dispatches - widen the window",
+            cmd: "ax dispatches --days=30",
+            ui: { priority: 8, group: "search" },
+        });
+        return top;
+    }
+    top.push({
+        description: "Show only routing candidates (inherit + expensive + matching class)",
+        call: { tool: "dispatches", arguments: { days: 14, candidates: true } },
+        cmd: "ax dispatches --candidates",
+        ui: { priority: 7, group: "read" },
+    });
+    top.push({
+        description: "Split cost by origin (main vs subagent) × model",
+        call: { tool: "cost_split", arguments: {} },
+        cmd: "ax cost split",
+        ui: { priority: 6, group: "read" },
+    });
+    return sortNavLinks(top);
+};
+
+/** Top-level links for dispatch candidates. */
+export const buildCandidatesNext = (
+    result: CandidatesResult,
+): ReadonlyArray<NavLink> => {
+    const top: NavLink[] = [];
+    if (result.candidates.length === 0) {
+        top.push({
+            description: "No candidates - see full dispatch table",
+            cmd: "ax dispatches --days=30",
+            ui: { priority: 8, group: "search" },
+        });
+        return top;
+    }
+    top.push({
+        description: "Write routing table to ~/.ax/hooks/routing-table.json",
+        cmd: "ax dispatches compile-routing",
+        ui: { priority: 7, group: "act" },
+    });
+    top.push({
+        description: "Full dispatch table (all dispatches, not just candidates)",
+        cmd: "ax dispatches",
+        ui: { priority: 6, group: "read" },
     });
     return sortNavLinks(top);
 };

--- a/apps/axctl/src/queries/dispatch-analytics.test.ts
+++ b/apps/axctl/src/queries/dispatch-analytics.test.ts
@@ -1,0 +1,520 @@
+/**
+ * Tests for dispatch-analytics.ts
+ *
+ * Uses makeMockDb (canned spawned / tool_call / usage rows) to exercise:
+ *   - inherit vs explicit model resolution
+ *   - candidate matching (expensive + routing-class filter)
+ *   - repricing math
+ *   - compile-routing JSON shape via tmp dir
+ */
+import { describe, expect, it } from "bun:test";
+import { Effect, Layer } from "effect";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+
+import {
+    fetchDispatches,
+    fetchDispatchCandidates,
+    compileRouting,
+    ROUTING_CLASSES,
+    matchRouting,
+} from "./dispatch-analytics.ts";
+
+const fsLayers = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+const runCompileRouting = (outPath: string) =>
+    Effect.runPromise(compileRouting(outPath).pipe(Effect.provide(fsLayers)));
+
+// ---------------------------------------------------------------------------
+// Mock DB helper
+// ---------------------------------------------------------------------------
+
+type QueryResult = Array<Record<string, unknown>>;
+
+/**
+ * Build a mock SurrealClient Layer from canned per-query results.
+ * The implementation returns results[0..n] in the order the SQL queries arrive
+ * (multi-statement query returns multiple result arrays).
+ */
+const makeMockDb = (results: QueryResult[]): Layer.Layer<SurrealClient> => {
+    const stub: SurrealClientShape = {
+        query: (_sql: string) => {
+            return Effect.succeed(results as [QueryResult, ...QueryResult[]]);
+        },
+        // biome-ignore lint: other methods not needed
+    } as unknown as SurrealClientShape;
+    return Layer.succeed(SurrealClient, stub);
+};
+
+const run = <A>(eff: Effect.Effect<A, unknown, SurrealClient>, layer: Layer.Layer<SurrealClient>) =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer)));
+
+// ---------------------------------------------------------------------------
+// ROUTING_CLASSES
+// ---------------------------------------------------------------------------
+
+describe("ROUTING_CLASSES", () => {
+    it("has version 1", () => {
+        expect(ROUTING_CLASSES.version).toBe(1);
+    });
+
+    it("has 5 classes", () => {
+        expect(ROUTING_CLASSES.classes).toHaveLength(5);
+    });
+
+    it("has agentTypes for Explore, codebase-locator, codebase-pattern-finder, codebase-analyzer", () => {
+        expect(ROUTING_CLASSES.agentTypes).toHaveProperty("Explore", "haiku");
+        expect(ROUTING_CLASSES.agentTypes).toHaveProperty("codebase-locator", "haiku");
+        expect(ROUTING_CLASSES.agentTypes).toHaveProperty("codebase-pattern-finder", "haiku");
+        expect(ROUTING_CLASSES.agentTypes).toHaveProperty("codebase-analyzer", "sonnet");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// matchRouting
+// ---------------------------------------------------------------------------
+
+describe("matchRouting", () => {
+    it("matches agent-type Explore to haiku", () => {
+        const m = matchRouting(null, "Explore");
+        expect(m).not.toBeNull();
+        expect(m!.suggest).toBe("haiku");
+        expect(m!.source).toBe("agentType");
+    });
+
+    it("agent-type wins over description", () => {
+        const m = matchRouting("spec review of the PR", "Explore");
+        expect(m).not.toBeNull();
+        expect(m!.suggest).toBe("haiku"); // agent-type wins
+    });
+
+    it("matches description 'spec review' to sonnet (spec-review)", () => {
+        const m = matchRouting("spec review the implementation", null);
+        expect(m).not.toBeNull();
+        expect(m!.suggest).toBe("sonnet");
+        expect(m!.classId).toBe("spec-review");
+    });
+
+    it("matches description 'locate all uses' to haiku (search-locate)", () => {
+        const m = matchRouting("locate all uses of X", null);
+        expect(m).not.toBeNull();
+        expect(m!.suggest).toBe("haiku");
+        expect(m!.classId).toBe("search-locate");
+    });
+
+    it("returns null for unmatched description and no agent type", () => {
+        const m = matchRouting("do some analysis", null);
+        expect(m).toBeNull();
+    });
+
+    it("returns null for null inputs", () => {
+        const m = matchRouting(null, null);
+        expect(m).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchDispatches - inherit vs explicit model
+// ---------------------------------------------------------------------------
+
+describe("fetchDispatches", () => {
+    it("returns empty when no spawned rows", async () => {
+        const layer = makeMockDb([[], [], [], []]);
+        const result = await run(fetchDispatches({ sinceDays: 14, limit: 30 }), layer);
+        expect(result.total_dispatches).toBe(0);
+        expect(result.rows).toHaveLength(0);
+        expect(result.inherit_pct).toBe(0);
+        expect(result.total_child_cost_usd).toBe(0);
+    });
+
+    it("resolves dispatch_model='inherit' when no tool_use_id", async () => {
+        const spawnedRows = [
+            {
+                parent_id: "session:parent-1",
+                child_id: "session:claude-subagent-abc",
+                ts: "2026-06-10T10:00:00Z",
+                agent_type: "Explore",
+                description: "find all usages",
+                tool_use_id: null,
+            },
+        ];
+        const usageRows = [
+            {
+                session_id: "session:claude-subagent-abc",
+                model: "claude-fable-5",
+                prompt_tokens: 1000,
+                completion_tokens: 500,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 0.05,
+            },
+        ];
+        const layer = makeMockDb([spawnedRows, usageRows, [], []]);
+        const result = await run(fetchDispatches({ sinceDays: 14, limit: 30 }), layer);
+
+        expect(result.total_dispatches).toBe(1);
+        expect(result.rows[0]?.dispatch_model).toBe("inherit");
+        expect(result.rows[0]?.child_model).toBe("claude-fable-5");
+        expect(result.rows[0]?.child_cost_usd).toBe(0.05);
+        expect(result.inherit_pct).toBe(100);
+    });
+
+    it("resolves dispatch_model from Agent tool_call input_json when tool_use_id matches", async () => {
+        const spawnedRows = [
+            {
+                parent_id: "session:parent-1",
+                child_id: "session:claude-subagent-def",
+                ts: "2026-06-10T11:00:00Z",
+                agent_type: "general-purpose",
+                description: "implement task X",
+                tool_use_id: "toolu_xyz123",
+            },
+        ];
+        const usageRows = [
+            {
+                session_id: "session:claude-subagent-def",
+                model: "claude-sonnet-4-6",
+                prompt_tokens: 2000,
+                completion_tokens: 800,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 0.02,
+            },
+        ];
+        const toolCallRows = [
+            {
+                session_id: "session:parent-1",
+                call_id: "toolu_xyz123",
+                input_json: JSON.stringify({ model: "sonnet", description: "implement task X" }),
+            },
+        ];
+        const layer = makeMockDb([spawnedRows, usageRows, toolCallRows, []]);
+        const result = await run(fetchDispatches({ sinceDays: 14, limit: 30 }), layer);
+
+        expect(result.rows[0]?.dispatch_model).toBe("sonnet");
+        expect(result.inherit_pct).toBe(0);
+    });
+
+    it("sorts by child_cost_usd desc", async () => {
+        const spawnedRows = [
+            {
+                parent_id: "session:parent-1",
+                child_id: "session:claude-subagent-cheap",
+                ts: "2026-06-10T10:00:00Z",
+                agent_type: "Explore",
+                description: "locate X",
+                tool_use_id: null,
+            },
+            {
+                parent_id: "session:parent-1",
+                child_id: "session:claude-subagent-expensive",
+                ts: "2026-06-10T10:01:00Z",
+                agent_type: "general-purpose",
+                description: "big task",
+                tool_use_id: null,
+            },
+        ];
+        const usageRows = [
+            {
+                session_id: "session:claude-subagent-cheap",
+                model: "claude-haiku-4-5",
+                prompt_tokens: 100,
+                completion_tokens: 50,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 0.001,
+            },
+            {
+                session_id: "session:claude-subagent-expensive",
+                model: "claude-fable-5",
+                prompt_tokens: 5000,
+                completion_tokens: 2000,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 0.50,
+            },
+        ];
+        const layer = makeMockDb([spawnedRows, usageRows, [], []]);
+        const result = await run(fetchDispatches({ sinceDays: 14, limit: 30 }), layer);
+
+        expect(result.rows[0]?.child_id).toBe("claude-subagent-expensive");
+        expect(result.rows[1]?.child_id).toBe("claude-subagent-cheap");
+        expect(result.total_child_cost_usd).toBeCloseTo(0.501, 3);
+    });
+
+    it("respects limit", async () => {
+        const spawnedRows = Array.from({ length: 5 }, (_, i) => ({
+            parent_id: "session:parent-1",
+            child_id: `session:claude-subagent-${i}`,
+            ts: "2026-06-10T10:00:00Z",
+            agent_type: "Explore",
+            description: "locate X",
+            tool_use_id: null,
+        }));
+        const layer = makeMockDb([spawnedRows, [], [], []]);
+        const result = await run(fetchDispatches({ sinceDays: 14, limit: 2 }), layer);
+
+        expect(result.total_dispatches).toBe(5);
+        expect(result.rows).toHaveLength(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchDispatchCandidates - filtering and repricing
+// ---------------------------------------------------------------------------
+
+describe("fetchDispatchCandidates", () => {
+    it("returns empty when no spawned rows", async () => {
+        const layer = makeMockDb([[], [], [], [], []]);
+        const result = await run(fetchDispatchCandidates({ sinceDays: 14 }), layer);
+        expect(result.candidates).toHaveLength(0);
+        expect(result.total_est_savings_usd).toBe(0);
+    });
+
+    it("excludes dispatches with an explicit model (non-inherit)", async () => {
+        const spawnedRows = [
+            {
+                parent_id: "session:parent-1",
+                child_id: "session:claude-subagent-abc",
+                ts: "2026-06-10T10:00:00Z",
+                agent_type: "Explore",
+                description: "find stuff",
+                tool_use_id: "tool-1",
+            },
+        ];
+        const usageRows = [
+            {
+                session_id: "session:claude-subagent-abc",
+                model: "claude-fable-5",
+                prompt_tokens: 1000,
+                completion_tokens: 500,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 0.05,
+            },
+        ];
+        const toolCallRows = [
+            {
+                session_id: "session:parent-1",
+                call_id: "tool-1",
+                input_json: JSON.stringify({ model: "fable", description: "find stuff" }),
+            },
+        ];
+        const layer = makeMockDb([spawnedRows, usageRows, toolCallRows, [], []]);
+        const result = await run(fetchDispatchCandidates({ sinceDays: 14 }), layer);
+
+        // dispatch_model is "fable" (not inherit) - excluded
+        expect(result.candidates).toHaveLength(0);
+    });
+
+    it("excludes dispatches where child model is NOT expensive (no fable/opus)", async () => {
+        const spawnedRows = [
+            {
+                parent_id: "session:parent-1",
+                child_id: "session:claude-subagent-cheap",
+                ts: "2026-06-10T10:00:00Z",
+                agent_type: "Explore",
+                description: "locate something",
+                tool_use_id: null,
+            },
+        ];
+        const usageRows = [
+            {
+                session_id: "session:claude-subagent-cheap",
+                model: "claude-haiku-4-5",  // not expensive
+                prompt_tokens: 1000,
+                completion_tokens: 500,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 0.001,
+            },
+        ];
+        const layer = makeMockDb([spawnedRows, usageRows, [], [], []]);
+        const result = await run(fetchDispatchCandidates({ sinceDays: 14 }), layer);
+
+        expect(result.candidates).toHaveLength(0);
+    });
+
+    it("excludes dispatches that don't match any routing class", async () => {
+        const spawnedRows = [
+            {
+                parent_id: "session:parent-1",
+                child_id: "session:claude-subagent-unmatched",
+                ts: "2026-06-10T10:00:00Z",
+                agent_type: "general-purpose",  // not in agentTypes table
+                description: "do some random work",  // no pattern match
+                tool_use_id: null,
+            },
+        ];
+        const usageRows = [
+            {
+                session_id: "session:claude-subagent-unmatched",
+                model: "claude-fable-5",
+                prompt_tokens: 1000,
+                completion_tokens: 500,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 0.10,
+            },
+        ];
+        const layer = makeMockDb([spawnedRows, usageRows, [], [], []]);
+        const result = await run(fetchDispatchCandidates({ sinceDays: 14 }), layer);
+
+        expect(result.candidates).toHaveLength(0);
+    });
+
+    it("includes candidates that match all three criteria and reprices correctly", async () => {
+        const spawnedRows = [
+            {
+                parent_id: "session:parent-1",
+                child_id: "session:claude-subagent-explore",
+                ts: "2026-06-10T10:00:00Z",
+                agent_type: "Explore",  // -> haiku
+                description: "locate all usages of function X",
+                tool_use_id: null,
+            },
+        ];
+        const usageRows = [
+            {
+                session_id: "session:claude-subagent-explore",
+                model: "claude-fable-5",  // expensive
+                prompt_tokens: 1_000_000,   // 1M tokens -> easy math
+                completion_tokens: 0,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 15.0,  // actual fable cost
+            },
+        ];
+        // agent_model pricing: haiku at $0.80/M input
+        const agentModels = [
+            {
+                name: "claude-haiku-4-5-20251001",
+                input_per_million_usd: 0.80,
+                output_per_million_usd: 4.0,
+                cache_read_per_million_usd: 0.08,
+                cache_creation_per_million_usd: 1.0,
+            },
+        ];
+        const layer = makeMockDb([spawnedRows, usageRows, [], [], agentModels]);
+        const result = await run(fetchDispatchCandidates({ sinceDays: 14 }), layer);
+
+        expect(result.candidates).toHaveLength(1);
+        const cand = result.candidates[0]!;
+        expect(cand.routing_match.suggest).toBe("haiku");
+        expect(cand.suggested_model).toBe("claude-haiku-4-5-20251001");
+        // repriced = 1M * 0.80/M = $0.80; savings = $15.0 - $0.80 = $14.20
+        expect(cand.est_savings_usd).toBeCloseTo(14.20, 2);
+        expect(result.total_est_savings_usd).toBeCloseTo(14.20, 2);
+    });
+
+    it("computes top_classes sorted by savings desc", async () => {
+        const spawnedRows = [
+            {
+                parent_id: "session:p1",
+                child_id: "session:claude-subagent-s1",
+                ts: "2026-06-10T10:00:00Z",
+                agent_type: "Explore",  // haiku -> big savings
+                description: "locate large code",
+                tool_use_id: null,
+            },
+            {
+                parent_id: "session:p1",
+                child_id: "session:claude-subagent-s2",
+                ts: "2026-06-10T10:01:00Z",
+                agent_type: null,
+                description: "spec review the PR",  // -> spec-review -> sonnet
+                tool_use_id: null,
+            },
+        ];
+        const usageRows = [
+            {
+                session_id: "session:claude-subagent-s1",
+                model: "claude-fable-5",
+                prompt_tokens: 1_000_000,
+                completion_tokens: 0,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 15.0,
+            },
+            {
+                session_id: "session:claude-subagent-s2",
+                model: "claude-opus-4",
+                prompt_tokens: 500_000,
+                completion_tokens: 0,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 7.5,
+            },
+        ];
+        const agentModels = [
+            {
+                name: "claude-haiku-4-5-20251001",
+                input_per_million_usd: 0.80,
+                output_per_million_usd: 4.0,
+                cache_read_per_million_usd: 0.08,
+                cache_creation_per_million_usd: 1.0,
+            },
+            {
+                name: "claude-sonnet-4-6",
+                input_per_million_usd: 3.0,
+                output_per_million_usd: 15.0,
+                cache_read_per_million_usd: 0.30,
+                cache_creation_per_million_usd: 3.75,
+            },
+        ];
+        const layer = makeMockDb([spawnedRows, usageRows, [], [], agentModels]);
+        const result = await run(fetchDispatchCandidates({ sinceDays: 14 }), layer);
+
+        expect(result.candidates).toHaveLength(2);
+        // top_classes: agent-type:Explore has bigger savings (~14.20) vs spec-review (~6.0)
+        expect(result.top_classes[0]?.classId).toBe("agent-type:Explore");
+        expect(result.top_classes.length).toBeLessThanOrEqual(3);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// compile-routing
+// ---------------------------------------------------------------------------
+
+describe("compileRouting", () => {
+    it("writes valid JSON to the specified tmp path", async () => {
+        const outPath = join(tmpdir(), `routing-table-test-${Date.now()}.json`);
+        const res = await runCompileRouting(outPath);
+        expect(res.written).toBe(true);
+        expect(res.path).toBe(outPath);
+        const content = readFileSync(outPath, "utf8");
+        const parsed = JSON.parse(content);
+        expect(parsed.version).toBe(1);
+        expect(Array.isArray(parsed.classes)).toBe(true);
+        expect(typeof parsed.agentTypes).toBe("object");
+    });
+
+    it("written JSON has the correct class IDs", async () => {
+        const outPath = join(tmpdir(), `routing-table-ids-test-${Date.now()}.json`);
+        await runCompileRouting(outPath);
+        const parsed = JSON.parse(readFileSync(outPath, "utf8"));
+        const ids = (parsed.classes as Array<{ id: string }>).map((c) => c.id);
+        expect(ids).toContain("spec-review");
+        expect(ids).toContain("search-locate");
+        expect(ids).toContain("research");
+        expect(ids).toContain("well-specified-impl");
+    });
+
+    it("is idempotent - overwriting with same content succeeds", async () => {
+        const outPath = join(tmpdir(), `routing-table-idempotent-test-${Date.now()}.json`);
+        await runCompileRouting(outPath);
+        const first = readFileSync(outPath, "utf8");
+        await runCompileRouting(outPath); // second write
+        const second = readFileSync(outPath, "utf8");
+        expect(first).toBe(second);
+    });
+
+    it("agentTypes match ROUTING_CLASSES", async () => {
+        const outPath = join(tmpdir(), `routing-table-agent-types-test-${Date.now()}.json`);
+        await runCompileRouting(outPath);
+        const parsed = JSON.parse(readFileSync(outPath, "utf8"));
+        expect(parsed.agentTypes).toMatchObject(ROUTING_CLASSES.agentTypes);
+    });
+});

--- a/apps/axctl/src/queries/dispatch-analytics.ts
+++ b/apps/axctl/src/queries/dispatch-analytics.ts
@@ -1,0 +1,680 @@
+/**
+ * `ax dispatches` queries: subagent dispatch analytics.
+ *
+ * Three flat queries, joined in JS by record-id string (hang-avoidance: NO
+ * record derefs inside aggregates, NO graph traversal in SELECT projections
+ * over large tables):
+ *   (1) SELECT from spawned with ts, agent_type, description, tool_use_id,
+ *       and stringified in/out IDs.
+ *   (2) session_token_usage rows for claude-subagent sessions (child cost).
+ *   (3) Agent tool_call rows in window: session, call_id, input_json.
+ *   (4) Parent session models: SELECT id, model FROM session (non-subagent).
+ *
+ * Routing classes mirror packages/hooks-sdk/src/hooks/route-dispatch.ts
+ * (feat/route-dispatch-hook branch). NOT imported from there - duplicated with
+ * a comment. A compile-routing step will unify later.
+ */
+import { Effect, FileSystem, Path } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { homedir } from "node:os";
+import { estimateCost, type ModelPricing } from "../ingest/model-pricing.ts";
+
+// ---------------------------------------------------------------------------
+// Routing classes
+// (mirrors packages/hooks-sdk/src/hooks/route-dispatch.ts DEFAULT_TABLE)
+// ---------------------------------------------------------------------------
+
+export interface RoutingClass {
+    readonly id: string;
+    readonly pattern: string;
+    readonly flags: string;
+    readonly suggest: string; // "sonnet" | "haiku"
+    readonly reason: string;
+}
+
+export interface RoutingTable {
+    readonly version: 1;
+    readonly classes: ReadonlyArray<RoutingClass>;
+    readonly agentTypes: Readonly<Record<string, string>>;
+}
+
+/**
+ * ROUTING_CLASSES - exported typed constant.
+ * Mirrors route-dispatch.ts DEFAULT_TABLE. Do NOT import from there;
+ * a compile-routing step will unify them later.
+ */
+export const ROUTING_CLASSES: RoutingTable = {
+    version: 1,
+    classes: [
+        // Quality reviews and PR reviews deliberately have NO class: the main
+        // model is the Q&A reviewer in this workflow, so only the mechanical
+        // spec-compliance pass routes down.
+        {
+            id: "spec-review",
+            pattern: "^spec review",
+            flags: "i",
+            suggest: "sonnet",
+            reason: "spec-compliance checklist review",
+        },
+        {
+            id: "search-locate",
+            pattern: "^(pattern-find|locate|find|map|sweep|grep)",
+            flags: "i",
+            suggest: "haiku",
+            reason: "code search/sweep",
+        },
+        {
+            id: "research",
+            pattern: "^(research|investigate docs|study)",
+            flags: "i",
+            suggest: "sonnet",
+            reason: "web/docs research",
+        },
+        {
+            id: "well-specified-impl",
+            pattern: "^implement ",
+            flags: "i",
+            suggest: "sonnet",
+            reason: "spec'd implementation",
+        },
+        {
+            id: "bulk-mechanical",
+            pattern: "^(write announcements|regenerate|standardize|merge main)",
+            flags: "i",
+            suggest: "sonnet",
+            reason: "bulk mechanical work",
+        },
+    ],
+    agentTypes: {
+        Explore: "haiku",
+        "codebase-locator": "haiku",
+        "codebase-pattern-finder": "haiku",
+        "codebase-analyzer": "sonnet",
+    },
+};
+
+// Model name resolution for repricing suggestions
+const MODEL_ALIASES: Record<string, string> = {
+    sonnet: "claude-sonnet-4-6",
+    haiku: "claude-haiku-4-5-20251001",
+};
+
+// Expensive model tiers (candidate filter)
+const EXPENSIVE_TIER_RE = /fable|opus/i;
+
+// ---------------------------------------------------------------------------
+// Routing match
+// ---------------------------------------------------------------------------
+
+export interface RoutingMatch {
+    readonly classId: string;
+    readonly suggest: string;
+    readonly reason: string;
+    readonly source: "agentType" | "description";
+}
+
+export const matchRouting = (
+    description: string | null,
+    agentType: string | null,
+): RoutingMatch | null => {
+    // Agent-type rules win first (more specific)
+    if (agentType) {
+        const suggest = ROUTING_CLASSES.agentTypes[agentType];
+        if (suggest) {
+            return {
+                classId: `agent-type:${agentType}`,
+                suggest,
+                reason: `agent type ${agentType}`,
+                source: "agentType",
+            };
+        }
+    }
+    if (description) {
+        for (const cls of ROUTING_CLASSES.classes) {
+            try {
+                const re = new RegExp(cls.pattern, cls.flags);
+                if (re.test(description)) {
+                    return {
+                        classId: cls.id,
+                        suggest: cls.suggest,
+                        reason: cls.reason,
+                        source: "description",
+                    };
+                }
+            } catch {
+                continue;
+            }
+        }
+    }
+    return null;
+};
+
+// ---------------------------------------------------------------------------
+// Raw DB row interfaces (query results before joining)
+// ---------------------------------------------------------------------------
+
+interface SpawnedRow {
+    parent_id: string;
+    child_id: string;
+    ts: string;
+    agent_type: string | null;
+    description: string | null;
+    tool_use_id: string | null;
+}
+
+interface UsageRow {
+    session_id: string;
+    model: string | null;
+    prompt_tokens: number;
+    completion_tokens: number;
+    cache_read_tokens: number;
+    cache_create_tokens: number;
+    cost_usd: number;
+}
+
+interface ToolCallRow {
+    session_id: string;
+    call_id: string;
+    input_json: string | null;
+}
+
+interface ParentSessionRow {
+    session_id: string;
+    model: string | null;
+}
+
+interface AgentModelRow {
+    name: string;
+    input_per_million_usd: number | null;
+    output_per_million_usd: number | null;
+    cache_read_per_million_usd: number | null;
+    cache_creation_per_million_usd: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch row (post-join)
+// ---------------------------------------------------------------------------
+
+export interface DispatchRow {
+    readonly ts: string;
+    readonly parent_id: string;
+    readonly child_id: string;
+    readonly agent_type: string | null;
+    readonly description: string | null;
+    /** "inherit" when no explicit model in Agent tool input */
+    readonly dispatch_model: string;
+    /** Model the child actually ran on (from usage or session.model) */
+    readonly child_model: string | null;
+    readonly child_cost_usd: number;
+    /** Prompt tokens (for repricing) */
+    readonly prompt_tokens: number;
+    /** Completion tokens (for repricing) */
+    readonly completion_tokens: number;
+    /** Cache read tokens (for repricing) */
+    readonly cache_read_tokens: number;
+    /** Cache creation tokens (for repricing) */
+    readonly cache_create_tokens: number;
+}
+
+export interface DispatchesResult {
+    readonly rows: ReadonlyArray<DispatchRow>;
+    readonly total_dispatches: number;
+    readonly inherit_pct: number;
+    readonly total_child_cost_usd: number;
+}
+
+// ---------------------------------------------------------------------------
+// Candidate row (candidates subcommand)
+// ---------------------------------------------------------------------------
+
+export interface CandidateRow extends DispatchRow {
+    readonly routing_match: RoutingMatch;
+    readonly suggested_model: string; // resolved full model name
+    readonly est_savings_usd: number; // child_cost - repriced cost
+}
+
+export interface CandidatesResult {
+    readonly candidates: ReadonlyArray<CandidateRow>;
+    readonly total_est_savings_usd: number;
+    readonly top_classes: ReadonlyArray<{ classId: string; savings_usd: number }>;
+}
+
+// ---------------------------------------------------------------------------
+// SQL queries (flat, no derefs in aggregates)
+// ---------------------------------------------------------------------------
+
+const SPAWNED_SQL = (sinceDays: number) => `
+SELECT
+    type::string(in)  AS parent_id,
+    type::string(out) AS child_id,
+    type::string(ts)  AS ts,
+    agent_type,
+    description,
+    tool_use_id
+FROM spawned
+WHERE ts > time::now() - ${Math.max(1, Math.trunc(sinceDays))}d
+  AND agent_type != NONE;
+`;
+
+const USAGE_SQL = (sinceDays: number) => `
+SELECT
+    type::string(session) AS session_id,
+    model,
+    prompt_tokens,
+    completion_tokens,
+    cache_read_input_tokens  AS cache_read_tokens,
+    cache_creation_input_tokens AS cache_create_tokens,
+    estimated_cost_usd AS cost_usd
+FROM session_token_usage
+WHERE ts > time::now() - ${Math.max(1, Math.trunc(sinceDays))}d
+  AND source = 'claude-subagent';
+`;
+
+const TOOL_CALLS_SQL = (sinceDays: number) => `
+SELECT
+    type::string(session) AS session_id,
+    call_id,
+    input_json
+FROM tool_call
+WHERE ts > time::now() - ${Math.max(1, Math.trunc(sinceDays))}d
+  AND name = 'Agent';
+`;
+
+const PARENT_SESSIONS_SQL = (sinceDays: number) => `
+SELECT
+    type::string(id) AS session_id,
+    model
+FROM session
+WHERE source != 'claude-subagent'
+  AND started_at > time::now() - ${Math.max(1, Math.trunc(sinceDays))}d;
+`;
+
+const AGENT_MODELS_SQL = `
+SELECT
+    name,
+    input_per_million_usd,
+    output_per_million_usd,
+    cache_read_per_million_usd,
+    cache_creation_per_million_usd
+FROM agent_model;
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const cleanSessionId = (id: string): string =>
+    id.replace(/^session:/, "").replace(/^`(.*)`$/, "$1");
+
+const parseInputJson = (raw: string | null): Record<string, unknown> => {
+    if (!raw) return {};
+    try {
+        return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+        return {};
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Core fetch: build joined DispatchRow array
+// ---------------------------------------------------------------------------
+
+export const fetchDispatches = Effect.fn("queries.fetchDispatches")(
+    function* (opts: { readonly sinceDays: number; readonly limit: number }) {
+        const db = yield* SurrealClient;
+
+        const [spawnedResult, usageResult, toolCallsResult, parentSessionsResult] =
+            yield* db.query<[
+                Array<Record<string, unknown>>,
+                Array<Record<string, unknown>>,
+                Array<Record<string, unknown>>,
+                Array<Record<string, unknown>>,
+            ]>(
+                SPAWNED_SQL(opts.sinceDays) +
+                USAGE_SQL(opts.sinceDays) +
+                TOOL_CALLS_SQL(opts.sinceDays) +
+                PARENT_SESSIONS_SQL(opts.sinceDays),
+            );
+
+        const spawnedRows: SpawnedRow[] = (spawnedResult ?? []).map((r) => ({
+            parent_id: String(r.parent_id ?? ""),
+            child_id: String(r.child_id ?? ""),
+            ts: String(r.ts ?? ""),
+            agent_type: r.agent_type == null ? null : String(r.agent_type),
+            description: r.description == null ? null : String(r.description),
+            tool_use_id: r.tool_use_id == null ? null : String(r.tool_use_id),
+        }));
+
+        const usageRows: UsageRow[] = (usageResult ?? []).map((r) => ({
+            session_id: String(r.session_id ?? ""),
+            model: r.model == null ? null : String(r.model),
+            prompt_tokens: Number(r.prompt_tokens ?? 0),
+            completion_tokens: Number(r.completion_tokens ?? 0),
+            cache_read_tokens: Number(r.cache_read_tokens ?? 0),
+            cache_create_tokens: Number(r.cache_create_tokens ?? 0),
+            cost_usd: Number(r.cost_usd ?? 0),
+        }));
+
+        const toolCallRows: ToolCallRow[] = (toolCallsResult ?? []).map((r) => ({
+            session_id: String(r.session_id ?? ""),
+            call_id: String(r.call_id ?? ""),
+            input_json: r.input_json == null ? null : String(r.input_json),
+        }));
+
+        const parentSessionRows: ParentSessionRow[] = (parentSessionsResult ?? []).map((r) => ({
+            session_id: String(r.session_id ?? ""),
+            model: r.model == null ? null : String(r.model),
+        }));
+
+        // Build lookup maps
+        const usageByChildId = new Map<string, UsageRow>();
+        for (const u of usageRows) {
+            const bare = cleanSessionId(u.session_id);
+            usageByChildId.set(u.session_id, u);
+            usageByChildId.set(bare, u);
+            usageByChildId.set(`session:${bare}`, u);
+        }
+
+        // tool_call lookup: call_id -> input_json
+        const toolCallByCallId = new Map<string, ToolCallRow>();
+        for (const tc of toolCallRows) {
+            if (tc.call_id) toolCallByCallId.set(tc.call_id, tc);
+        }
+
+        // parent session model lookup: bare session id -> model
+        const parentModelById = new Map<string, string | null>();
+        for (const ps of parentSessionRows) {
+            const bare = cleanSessionId(ps.session_id);
+            parentModelById.set(bare, ps.model);
+            parentModelById.set(ps.session_id, ps.model);
+        }
+
+        // Join rows
+        const rows: DispatchRow[] = [];
+        for (const sp of spawnedRows) {
+            const bareChild = cleanSessionId(sp.child_id);
+            const bareParent = cleanSessionId(sp.parent_id);
+
+            // Get dispatch model from Agent tool_call input
+            let dispatchModel = "inherit";
+            if (sp.tool_use_id) {
+                const tc = toolCallByCallId.get(sp.tool_use_id);
+                if (tc) {
+                    const inp = parseInputJson(tc.input_json);
+                    const m = inp.model;
+                    if (typeof m === "string" && m.trim().length > 0) {
+                        dispatchModel = m.trim();
+                    }
+                }
+            }
+
+            // Get child usage
+            const usage = usageByChildId.get(bareChild) ??
+                usageByChildId.get(`session:${bareChild}`) ??
+                usageByChildId.get(sp.child_id);
+
+            // Resolve child model: prefer usage, fall back to parent session model
+            let childModel: string | null = usage?.model ?? null;
+            if (!childModel) {
+                childModel = parentModelById.get(bareParent) ?? parentModelById.get(sp.parent_id) ?? null;
+            }
+
+            rows.push({
+                ts: sp.ts,
+                parent_id: bareParent,
+                child_id: bareChild,
+                agent_type: sp.agent_type,
+                description: sp.description,
+                dispatch_model: dispatchModel,
+                child_model: childModel,
+                child_cost_usd: usage?.cost_usd ?? 0,
+                prompt_tokens: usage?.prompt_tokens ?? 0,
+                completion_tokens: usage?.completion_tokens ?? 0,
+                cache_read_tokens: usage?.cache_read_tokens ?? 0,
+                cache_create_tokens: usage?.cache_create_tokens ?? 0,
+            });
+        }
+
+        // Sort by cost desc, then apply limit
+        rows.sort((a, b) => b.child_cost_usd - a.child_cost_usd);
+        const limited = rows.slice(0, opts.limit);
+
+        const total_dispatches = rows.length;
+        const inheritCount = rows.filter((r) => r.dispatch_model === "inherit").length;
+        const inherit_pct = total_dispatches > 0 ? (inheritCount / total_dispatches) * 100 : 0;
+        const total_child_cost_usd = rows.reduce((s, r) => s + r.child_cost_usd, 0);
+
+        return {
+            rows: limited,
+            total_dispatches,
+            inherit_pct,
+            total_child_cost_usd,
+        } satisfies DispatchesResult;
+    },
+);
+
+// ---------------------------------------------------------------------------
+// Candidates fetch: inherit + expensive + routing-match
+// ---------------------------------------------------------------------------
+
+export const fetchDispatchCandidates = Effect.fn("queries.fetchDispatchCandidates")(
+    function* (opts: { readonly sinceDays: number }) {
+        const db = yield* SurrealClient;
+
+        const [spawnedResult, usageResult, toolCallsResult, parentSessionsResult, agentModelsResult] =
+            yield* db.query<[
+                Array<Record<string, unknown>>,
+                Array<Record<string, unknown>>,
+                Array<Record<string, unknown>>,
+                Array<Record<string, unknown>>,
+                Array<Record<string, unknown>>,
+            ]>(
+                SPAWNED_SQL(opts.sinceDays) +
+                USAGE_SQL(opts.sinceDays) +
+                TOOL_CALLS_SQL(opts.sinceDays) +
+                PARENT_SESSIONS_SQL(opts.sinceDays) +
+                AGENT_MODELS_SQL,
+            );
+
+        const spawnedRows: SpawnedRow[] = (spawnedResult ?? []).map((r) => ({
+            parent_id: String(r.parent_id ?? ""),
+            child_id: String(r.child_id ?? ""),
+            ts: String(r.ts ?? ""),
+            agent_type: r.agent_type == null ? null : String(r.agent_type),
+            description: r.description == null ? null : String(r.description),
+            tool_use_id: r.tool_use_id == null ? null : String(r.tool_use_id),
+        }));
+
+        const usageRows: UsageRow[] = (usageResult ?? []).map((r) => ({
+            session_id: String(r.session_id ?? ""),
+            model: r.model == null ? null : String(r.model),
+            prompt_tokens: Number(r.prompt_tokens ?? 0),
+            completion_tokens: Number(r.completion_tokens ?? 0),
+            cache_read_tokens: Number(r.cache_read_tokens ?? 0),
+            cache_create_tokens: Number(r.cache_create_tokens ?? 0),
+            cost_usd: Number(r.cost_usd ?? 0),
+        }));
+
+        const toolCallRows: ToolCallRow[] = (toolCallsResult ?? []).map((r) => ({
+            session_id: String(r.session_id ?? ""),
+            call_id: String(r.call_id ?? ""),
+            input_json: r.input_json == null ? null : String(r.input_json),
+        }));
+
+        const parentSessionRows: ParentSessionRow[] = (parentSessionsResult ?? []).map((r) => ({
+            session_id: String(r.session_id ?? ""),
+            model: r.model == null ? null : String(r.model),
+        }));
+
+        const agentModels: AgentModelRow[] = (agentModelsResult ?? []).map((r) => ({
+            name: String(r.name ?? ""),
+            input_per_million_usd: r.input_per_million_usd == null ? null : Number(r.input_per_million_usd),
+            output_per_million_usd: r.output_per_million_usd == null ? null : Number(r.output_per_million_usd),
+            cache_read_per_million_usd: r.cache_read_per_million_usd == null ? null : Number(r.cache_read_per_million_usd),
+            cache_creation_per_million_usd: r.cache_creation_per_million_usd == null ? null : Number(r.cache_creation_per_million_usd),
+        }));
+
+        // Build lookup maps
+        const usageByChildId = new Map<string, UsageRow>();
+        for (const u of usageRows) {
+            const bare = cleanSessionId(u.session_id);
+            usageByChildId.set(u.session_id, u);
+            usageByChildId.set(bare, u);
+            usageByChildId.set(`session:${bare}`, u);
+        }
+
+        const toolCallByCallId = new Map<string, ToolCallRow>();
+        for (const tc of toolCallRows) {
+            if (tc.call_id) toolCallByCallId.set(tc.call_id, tc);
+        }
+
+        const parentModelById = new Map<string, string | null>();
+        for (const ps of parentSessionRows) {
+            const bare = cleanSessionId(ps.session_id);
+            parentModelById.set(bare, ps.model);
+            parentModelById.set(ps.session_id, ps.model);
+        }
+
+        // agent_model rows -> estimateCost catalog, so repricing uses the SAME
+        // DB pricing that priced the actual costs at ingest.
+        const pricingCatalog = new Map<string, ModelPricing>();
+        for (const am of agentModels) {
+            pricingCatalog.set(am.name, {
+                provider: "anthropic",
+                inputPerMillionUsd: am.input_per_million_usd ?? null,
+                outputPerMillionUsd: am.output_per_million_usd ?? null,
+                cacheCreationPerMillionUsd: am.cache_creation_per_million_usd ?? null,
+                cacheReadPerMillionUsd: am.cache_read_per_million_usd ?? null,
+                fastMultiplier: 1,
+                pricingSource: "agent_model",
+            });
+        }
+
+        // Helper: reprice token buckets at a given model's rates. Delegates to
+        // the ingest's estimateCost - prompt_tokens here is TOTAL billed input
+        // (fresh + both cache buckets), and estimateCost recovers fresh input
+        // by subtracting the cache buckets before applying the input rate.
+        const reprice = (usage: UsageRow, targetModelName: string): number => {
+            const cost = estimateCost({
+                modelKey: targetModelName,
+                promptTokens: usage.prompt_tokens,
+                completionTokens: usage.completion_tokens,
+                cacheCreationInputTokens: usage.cache_create_tokens,
+                cacheReadInputTokens: usage.cache_read_tokens,
+                estimatedTokens: usage.prompt_tokens + usage.completion_tokens,
+                ...(pricingCatalog.size > 0 ? { pricingCatalog } : {}),
+            });
+            return cost.totalUsd ?? usage.cost_usd;
+        };
+
+        const candidates: CandidateRow[] = [];
+
+        for (const sp of spawnedRows) {
+            const bareChild = cleanSessionId(sp.child_id);
+            const bareParent = cleanSessionId(sp.parent_id);
+
+            // Tool call lookup for dispatch model
+            let dispatchModel = "inherit";
+            if (sp.tool_use_id) {
+                const tc = toolCallByCallId.get(sp.tool_use_id);
+                if (tc) {
+                    const inp = parseInputJson(tc.input_json);
+                    const m = inp.model;
+                    if (typeof m === "string" && m.trim().length > 0) {
+                        dispatchModel = m.trim();
+                    }
+                }
+            }
+
+            // Candidate criterion (a): dispatch_model must be "inherit"
+            if (dispatchModel !== "inherit") continue;
+
+            const usage = usageByChildId.get(bareChild) ??
+                usageByChildId.get(`session:${bareChild}`) ??
+                usageByChildId.get(sp.child_id);
+
+            let childModel: string | null = usage?.model ?? null;
+            if (!childModel) {
+                childModel = parentModelById.get(bareParent) ?? parentModelById.get(sp.parent_id) ?? null;
+            }
+
+            // Candidate criterion (b): child model is expensive tier (fable/opus)
+            if (!childModel || !EXPENSIVE_TIER_RE.test(childModel)) continue;
+
+            // Candidate criterion (c): description or agent_type matches a routing class
+            const routingMatch = matchRouting(sp.description, sp.agent_type);
+            if (!routingMatch) continue;
+
+            // Resolve suggested model name
+            const suggestedAlias = routingMatch.suggest;
+            const suggestedModelName = MODEL_ALIASES[suggestedAlias] ?? suggestedAlias;
+
+            // Reprice
+            const childCostUsd = usage?.cost_usd ?? 0;
+            const repricedCost = usage ? reprice(usage, suggestedModelName) : 0;
+            const estSavings = Math.max(0, childCostUsd - repricedCost);
+
+            candidates.push({
+                ts: sp.ts,
+                parent_id: bareParent,
+                child_id: bareChild,
+                agent_type: sp.agent_type,
+                description: sp.description,
+                dispatch_model: dispatchModel,
+                child_model: childModel,
+                child_cost_usd: childCostUsd,
+                prompt_tokens: usage?.prompt_tokens ?? 0,
+                completion_tokens: usage?.completion_tokens ?? 0,
+                cache_read_tokens: usage?.cache_read_tokens ?? 0,
+                cache_create_tokens: usage?.cache_create_tokens ?? 0,
+                routing_match: routingMatch,
+                suggested_model: suggestedModelName,
+                est_savings_usd: estSavings,
+            });
+        }
+
+        // Sort by est savings desc
+        candidates.sort((a, b) => b.est_savings_usd - a.est_savings_usd);
+
+        const total_est_savings_usd = candidates.reduce((s, c) => s + c.est_savings_usd, 0);
+
+        // Top 3 routing classes by savings
+        const classSavings = new Map<string, number>();
+        for (const c of candidates) {
+            const existing = classSavings.get(c.routing_match.classId) ?? 0;
+            classSavings.set(c.routing_match.classId, existing + c.est_savings_usd);
+        }
+        const top_classes = [...classSavings.entries()]
+            .sort(([, a], [, b]) => b - a)
+            .slice(0, 3)
+            .map(([classId, savings_usd]) => ({ classId, savings_usd }));
+
+        return {
+            candidates,
+            total_est_savings_usd,
+            top_classes,
+        } satisfies CandidatesResult;
+    },
+);
+
+// ---------------------------------------------------------------------------
+// compile-routing: write routing table JSON to disk
+// ---------------------------------------------------------------------------
+
+export interface CompileRoutingResult {
+    readonly path: string;
+    readonly written: boolean;
+}
+
+export const compileRouting = (
+    outPath?: string,
+): Effect.Effect<CompileRoutingResult, never, FileSystem.FileSystem | Path.Path> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const resolvedPath = outPath ?? path.join(homedir(), ".ax", "hooks", "routing-table.json");
+        const json = JSON.stringify(ROUTING_CLASSES, null, 2);
+        yield* fs.makeDirectory(path.dirname(resolvedPath), { recursive: true }).pipe(Effect.orDie);
+        yield* fs.writeFileString(resolvedPath, json).pipe(Effect.orDie);
+        return { path: resolvedPath, written: true };
+    });

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,9 @@ axctl costs for --query <text> [--limit=N]  # cost for sessions matching turn te
 axctl costs for --terms <a,b,c> [--since=N] # cost for sessions matching any term
 axctl costs for --commit <sha>              # cost for sessions that produced a commit
 axctl costs for --branch <name>             # cost for sessions linked to a branch
+axctl cost <models|sessions|split>          # model/cost analytics incl. main-vs-subagent split
+axctl dispatches [--candidates]             # subagent dispatch routing analytics + est savings
+axctl dispatches compile-routing            # regenerate ~/.ax/hooks/routing-table.json
 axctl pricing [--query <model>]             # inspect imported model pricing rows
 axctl share <session-id>                    # publish a sanitized session share via GitHub Gist
 axctl roles                                 # list role labels with skill counts


### PR DESCRIPTION
## What

The read+apply bridge of the model-routing loop, over the `spawned` edges enriched in #300:

- `ax dispatches [--days] [--limit]` — dispatch table: agent_type × description × dispatch model ("inherit" = no explicit model) × child model × child cost. Summary: count, % inherit, total subagent cost
- `ax dispatches --candidates` — dispatches that are (a) inherit, (b) on an expensive tier (fable/opus), (c) matching a routing class → suggested model + est savings (repriced via the ingest's `estimateCost`, optionally with `agent_model` DB pricing as catalog)
- `ax dispatches compile-routing [--out]` — regenerates `~/.ax/hooks/routing-table.json` from `ROUTING_CLASSES` (feeds the route-dispatch hook from #302)
- MCP: read-only `dispatches` tool

## Real data (3 days)

```
364 dispatches, 77.2% inherit, total subagent cost $1,517
candidates: total est savings $275.18
top classes: well-specified-impl ($181.13), spec-review ($43.77), bulk-mechanical ($15.75)
```

## Review fixes applied on top of the base implementation

- **Repricing bug**: `prompt_tokens` on usage rows is TOTAL billed input (fresh + both cache buckets); naive per-bucket math charged cache reads at full input rate AND double-counted, driving every big row's savings to $0 (total showed $12). Now delegates to `estimateCost`, which recovers fresh input correctly → $275
- **Routing classes tuned**: quality review + PR review deliberately have NO class — the main model stays the Q&A reviewer; only mechanical spec reviews route to sonnet. `^implement ` broadened, `bulk-mechanical` class added
- **compile-routing migrated to Effect FileSystem** (was node:fs — `check:no-node-fs` gate would have failed CI)

Follow-up: align the hook's DEFAULT_TABLE (#302) with the tuned classes — separate small PR.

## Tests

24 query tests incl. repricing math + compile-routing via tmp dir; smoke-test EXPECTED_TOOLS updated (15); 80 pass across dispatch/mcp/cli; no-node-fs gate clean; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)