### PR TITLE
fix(hooks-sdk): align route-dispatch defaults with tuned ROUTING_CLASSES

### DIFF
--- a/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
@@ -63,7 +63,7 @@ describe("description matches default routing table", () => {
     expect(v._tag).toBe("Warn");
     if (v._tag === "Warn") {
       expect(v.message).toContain("sonnet");
-      expect(v.message).toContain("checklist compliance review");
+      expect(v.message).toContain("spec-compliance checklist review");
     }
   });
 

--- a/packages/hooks-sdk/src/hooks/route-dispatch.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.ts
@@ -54,12 +54,16 @@ type RoutingTableType = Schema.Schema.Type<typeof RoutingTable>;
 const DEFAULT_TABLE: RoutingTableType = {
   version: 1,
   classes: [
+    // Quality reviews and PR reviews deliberately have NO class: the main
+    // model is the Q&A reviewer in this workflow, so only the mechanical
+    // spec-compliance pass routes down. Mirrors ROUTING_CLASSES in
+    // apps/axctl/src/queries/dispatch-analytics.ts (compile-routing unifies).
     {
-      id: "mechanical-review",
-      pattern: "^(spec review|quality review|review pr)",
+      id: "spec-review",
+      pattern: "^spec review",
       flags: "i",
       suggest: "sonnet",
-      reason: "checklist compliance review",
+      reason: "spec-compliance checklist review",
     },
     {
       id: "search-locate",
@@ -77,10 +81,17 @@ const DEFAULT_TABLE: RoutingTableType = {
     },
     {
       id: "well-specified-impl",
-      pattern: "^(implement task|implement p[0-9]|regenerate|standardize)",
+      pattern: "^implement ",
       flags: "i",
       suggest: "sonnet",
       reason: "spec'd implementation",
+    },
+    {
+      id: "bulk-mechanical",
+      pattern: "^(write announcements|regenerate|standardize|merge main)",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "bulk mechanical work",
     },
   ],
   agentTypes: {


### PR DESCRIPTION
Follow-up to #302/#303: the hook's built-in DEFAULT_TABLE now matches the tuned `ROUTING_CLASSES` — quality/PR reviews deliberately unrouted (main model stays the Q&A reviewer), spec reviews → sonnet, `^implement ` broadened, `bulk-mechanical` added.

21 hook tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)