### PR TITLE
docs: cost-routing design doc + dogfood report

### DIFF
--- a/docs/design/cost-routing.md
+++ b/docs/design/cost-routing.md
@@ -1,0 +1,131 @@
+# Cost routing: model spend visibility + dispatch routing loop
+
+How ax answers "where does my model spend go, and which subagent dispatches
+should run on cheaper models" - and how that answer feeds back into the
+harness automatically.
+
+Shipped across PRs #300-#304 (2026-06-12).
+
+## The problem this solves
+
+A 3-day window of Claude Code work on this machine showed:
+
+- **Main-loop fable: ~$4.2k (49%)** - dominated by cache reads (~250k context
+  re-read on every tool-call turn; grunt loops like Bash/Edit/browser QA run
+  IN the expensive main context)
+- **Subagent fable: ~$1.3k (16%)** - 77% of Agent dispatches carry no explicit
+  `model`, inheriting the parent's expensive model for mechanical work
+- **Cheap models: <1%** - sonnet/haiku barely used despite being 3-10x cheaper
+
+None of this was visible: subagent token-usage rows had `model = null` (two
+compounding ingest bugs), and no query surface existed over the cost data.
+
+## Data layer (fixed in #300)
+
+- Subagent transcripts (`<session>/subagents/agent-*.jsonl`) were already
+  ingested, but `derive-claude-subagents` dropped the extracted model on the
+  session upsert, AND `session-health`'s token-usage UPSERT clobbered the
+  correct `model` with `session.model` (null) on every pass. `model_ref`
+  survived, which is how the bug was diagnosed.
+- `writeTokenUsageForSubagents` now writes `source = "claude-subagent"` so
+  origin rollups don't depend on writer order.
+- `spawned` edges (parent -> subagent) carry `agent_type`, `description`,
+  `agent_name`, `tool_use_id` from `agent-<id>.meta.json`. `tool_use_id` joins
+  the parent's `tool_call.call_id`, which exposes the dispatch-time `model`
+  override without parsing input JSON blobs at query time.
+- Backfill: `AX_REDERIVE_SUBAGENTS=1 ax ingest --stages=subagents`.
+
+## Read surface (#301, #303)
+
+```
+ax cost models   [--days=N]                  # per-model rollup
+ax cost sessions [--days=N] [--model=X]      # top sessions by cost
+ax cost split    [--days=N]                  # main vs subagent x model matrix
+ax dispatches    [--days=N] [--limit=N]      # dispatch table, % inherit
+ax dispatches --candidates [--days=N]        # downgrade candidates + est savings
+```
+
+MCP tools `cost_models`, `cost_split`, `dispatches` expose the same queries
+read-only, so an agent can ask "where is the spend" mid-session without the
+user prompting it.
+
+Query discipline: GROUP BY stays on scalar fields of the scanned table;
+derived dimensions (origin) and all joins happen in JS after flat scans.
+Record derefs inside aggregates hang SurrealDB 3.x at this table size.
+
+Candidate repricing delegates to the ingest's `estimateCost` with the
+`agent_model` table as pricing catalog. `prompt_tokens` on usage rows is
+TOTAL billed input (fresh + both cache buckets); naive per-bucket math
+double-counts cache and zeroes the savings.
+
+## Routing policy
+
+One typed constant - `ROUTING_CLASSES` in
+`apps/axctl/src/queries/dispatch-analytics.ts`, mirrored as the built-in
+defaults of the `route-dispatch` hook:
+
+| class | pattern | suggest |
+|---|---|---|
+| spec-review | `^spec review` | sonnet |
+| search-locate | `^(pattern-find\|locate\|find\|map\|sweep\|grep)` | haiku |
+| research | `^(research\|investigate docs\|study)` | sonnet |
+| well-specified-impl | `^implement ` | sonnet |
+| bulk-mechanical | `^(write announcements\|regenerate\|standardize\|merge main)` | sonnet |
+| agent types | Explore, codebase-locator, codebase-pattern-finder → haiku; codebase-analyzer → sonnet | |
+
+**Deliberately unrouted:** quality reviews, PR reviews, plan synthesis,
+design/copy taste work. The main model is the orchestrator and Q&A reviewer
+in this workflow; only mechanical work routes down.
+
+`ax dispatches compile-routing` regenerates `~/.ax/hooks/routing-table.json`
+from the constant. The hook reads that file at fire time and falls back to
+its built-in copy of the same defaults.
+
+## Apply surface (#302, #304)
+
+`route-dispatch` hook (hooks-sdk, PreToolUse on the Agent tool, Claude-only):
+a dispatch with no explicit `model` whose description/agent-type matches a
+routing class gets a `warn` verdict -
+
+> ax routing: "Spec review Task 2" looks like spec-compliance checklist
+> review work - consider model: "sonnet" on this dispatch (est ~2-3x
+> cheaper). Explicit model silences this.
+
+`warn` (not `block`): the suggestion reaches the model so it can re-dispatch
+with `model:` pinned; the call is never prevented. Every failure path fails
+open. Install:
+
+```
+ax hooks init                                                  # scaffolds it
+ax hooks install ~/.ax/hooks/route-dispatch.ts --providers=claude
+ax hooks backtest ~/.ax/hooks/route-dispatch.ts --days=7       # replay history
+```
+
+Backtest on this machine: 396 dispatches replayed, 156 would-warn (39%),
+0 would-block.
+
+## The loop
+
+```
+ingest (model attribution, spawned metadata)
+  -> read     ax cost split / ax dispatches --candidates  (CLI + MCP)
+  -> apply    route-dispatch hook warns at dispatch time
+  -> compile  ax dispatches compile-routing regenerates the table
+  -> verify   ax cost split before/after; workflow_epoch stamps (planned)
+```
+
+Planned next: a `deriveRoutingProposalRows` rule in the proposals derive
+stage (form=hook) so accumulated candidate savings surface in
+`ax improve recommend`, and epoch stamping on accept for before/after deltas.
+
+## Workflow guidance (the human side)
+
+- Fable/opus main loop orchestrates, plans, and reviews diffs.
+- Well-specified implementation, spec reviews, searches, research, bulk copy
+  -> dispatch with `model: "sonnet"` (or haiku for pure search).
+- Keep tool-heavy loops (build/test cycles, browser QA) OUT of the expensive
+  main context - the dominant cost is the main loop re-reading ~250k context
+  on every tool call, not subagent output tokens.
+- Measured ceiling on this machine: ~$275/3d redirectable via dispatch
+  routing alone; several times that from moving grunt loops out of the main
+  context.

--- a/docs/dogfood/2026-06-12-cost-routing/report.md
+++ b/docs/dogfood/2026-06-12-cost-routing/report.md
@@ -1,0 +1,93 @@
+# Dogfood: cost-routing loop (2026-06-12)
+
+Goal set the evening before: "ax should answer 'what's my fable workflow and
+where can cheaper models run' in one command" - then build it, dogfood it,
+and verify against the manually-computed ground truth.
+
+## Ground truth (manual, locked before any code)
+
+Computed by raw-SQL on SurrealDB + jq over raw transcripts, Jun 9-11 window,
+the 26 fable-parent sessions only:
+
+| slice | value |
+|---|---|
+| main-loop fable | $2,748 (70%) |
+| subagent fable (inherited) | $565 (14%) |
+| main-loop opus (mid-session switches) | $541 |
+| subagents on sonnet/opus/haiku | $60 |
+| Agent dispatches inheriting parent model | 180 of 272 (66%) |
+
+## What ax says now (one command each, 3-day window, ALL sessions)
+
+`ax cost split --days=3`:
+
+| origin | model | cost | share |
+|---|---|---|---|
+| main | claude-fable-5 | $4,211 | 48.7% |
+| main | claude-opus-4-8 | $2,057 | 23.8% |
+| subagent | claude-fable-5 | $1,341 | 15.5% |
+| main | gpt-5.5 | $679 | 7.9% |
+| subagent | claude-opus-4-8 | $175 | 2.0% |
+| subagent | claude-sonnet-4-6 | $50 | 0.6% |
+| subagent | claude-haiku-4-5 | $11 | 0.1% |
+| **total** | | **$8,645** | |
+
+`ax dispatches --days=3`: 364 dispatches, **77.2% inherit**, subagent cost $1,518.
+
+`ax dispatches --candidates --days=3`: **est savings $275.18** - top classes
+well-specified-impl ($181), spec-review ($44), bulk-mechanical ($16).
+
+## Ground-truth reconciliation
+
+The windows differ deliberately: ground truth = 26 fable-parent sessions
+Jun 9-11; ax = ALL sessions Jun 9-12 (including the overnight build itself,
+which ran heavy fable main-loop + a fleet of sonnet subagents).
+
+- Inherit rate: 66% (ground truth, fable parents) vs 77.2% (all parents) -
+  consistent, the broader set inherits more.
+- Subagent fable: $565 (fable parents, 21d-scoped estimate) vs $1,341
+  (all parents incl. the build night) - direction and order match; the delta
+  is the added day + opus/other parents' fable children.
+- Main-loop fable cache-read dominance: confirmed by `ax cost models`
+  (3.47B cache-read tokens on fable = $3.5k of the $5.5k fable total).
+
+Verdict: ax now reproduces the manual analysis in one command, with the
+expected window/scope deltas explained.
+
+## Bugs found BY dogfooding (each found by trusting the data and tracing)
+
+1. **model=null on all 869 subagent usage rows** - two compounding writers:
+   session upsert dropped the extracted model; session-health clobbered the
+   priced row's model with null. `model_ref` survived = smoking gun. (#300)
+2. **source flip-flop** - `writeTokenUsageForSubagents` hardcoded
+   `source="claude"`, so origin split depended on which writer ran last. (#300)
+3. **MCP smoke test hardcodes tool list** - cost tools broke CI. (#301 fix)
+4. **node:fs in axctl runtime code** - `check:no-node-fs` gate caught both the
+   hook (allowlisted, fire-path sync justification) and compile-routing
+   (migrated to Effect FileSystem). (#302/#303)
+5. **Repricing double-count** - `prompt_tokens` is total billed input;
+   per-bucket math charged cache reads at full input rate, zeroing savings
+   ($12 -> $275 after delegating to `estimateCost`). (#303)
+6. **Routing-policy misalignment** - v1 classes routed quality/PR reviews to
+   sonnet, contradicting "main model is the Q&A reviewer". Both copies
+   tuned. (#304)
+
+## Hook validation
+
+- `ax hooks backtest route-dispatch.ts --days=7`: 396 dispatches replayed,
+  156 would-warn (39.4%), 0 would-block.
+- Installed live (`~/.claude/settings.json`, PreToolUse/Agent matcher);
+  next mechanical model-less dispatch gets the nudge in-context.
+- 21 unit tests: explicit-model allow, class/agent-type matching, corrupt
+  routing table -> defaults, defects fail open.
+
+## Build-night meta (the workflow being built, applied to building it)
+
+Every implementation phase ran as a sonnet subagent in an isolated worktree;
+fable (main loop) wrote briefs, reviewed diffs, and fixed what review caught.
+Review caught one real bug per phase on average (see list above) - the
+fable-reviews-cheap-implementation pattern earned its keep on its own
+construction.
+
+PRs: #300 (ingest attribution) -> #301 (ax cost) -> #302 (hook) ->
+#303 (ax dispatches) -> #304 (routing alignment). All squash-merged on CLEAN.


### PR DESCRIPTION
Closes the documentation loop on the #300-#304 arc:

- `docs/design/cost-routing.md` — data layer, read surface, routing policy (incl. what's deliberately unrouted and why), hook semantics, the full read→apply→compile→verify loop, human-side workflow guidance
- `docs/dogfood/2026-06-12-cost-routing/report.md` — ground-truth reconciliation (manual analysis vs `ax cost split`), the six bugs dogfooding caught, hook backtest numbers (396 replayed / 156 warn / 0 block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)