### PR TITLE
feat(skills): efficient-dispatch - measured model-routing orchestration

### DIFF
--- a/.claude/workflows/routing-tune.workflow.js
+++ b/.claude/workflows/routing-tune.workflow.js
@@ -1,0 +1,115 @@
+// Routing-class tuning workflow - the anti-staleness loop for ROUTING_CLASSES.
+//
+// The routing table (apps/axctl/src/queries/dispatch-analytics.ts ROUTING_CLASSES,
+// mirrored into the route-dispatch hook and skills/efficient-dispatch) is a
+// hand-written constant. This workflow mines recent dispatch history for
+// class updates, adversarially backtests every proposal against judgment-work
+// false positives, and emits a reviewable brief - it never edits the constant
+// itself. Run it when `ax dispatches --candidates` keeps surfacing unmatched
+// spend, or monthly. Pass args: { days?: number, date: "YYYY-MM-DD" }.
+export const meta = {
+  name: "routing-tune",
+  description: "Mine dispatch history for routing-class updates, backtest against false positives, emit a review brief",
+  whenToUse: "When ax dispatches --candidates shows unmatched expensive dispatches, or as a monthly routing-table refresh",
+  phases: [
+    { title: "Mine", detail: "pull dispatch history, cluster unmatched expensive inherits" },
+    { title: "Backtest", detail: "one adversarial verifier per proposed class" },
+    { title: "Emit", detail: "write .ax/tasks brief with the surviving diff" },
+  ],
+};
+
+const days = (args && args.days) || 30;
+const date = (args && args.date) || "undated";
+
+const PROPOSAL_SCHEMA = {
+  type: "object",
+  required: ["proposals", "retire_candidates", "unmatched_total_cost_usd"],
+  properties: {
+    proposals: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["id", "pattern", "flags", "suggest", "reason", "examples", "est_savings_usd"],
+        properties: {
+          id: { type: "string", description: "kebab-case class id" },
+          pattern: { type: "string", description: "JS regex source matching dispatch descriptions" },
+          flags: { type: "string" },
+          suggest: { type: "string", enum: ["sonnet", "haiku"] },
+          reason: { type: "string" },
+          examples: { type: "array", items: { type: "string" }, description: "3+ real dispatch descriptions this would match" },
+          est_savings_usd: { type: "number" },
+        },
+      },
+    },
+    retire_candidates: {
+      type: "array",
+      items: { type: "string" },
+      description: "existing class ids that matched nothing in the window",
+    },
+    unmatched_total_cost_usd: { type: "number" },
+  },
+};
+
+const VERDICT_SCHEMA = {
+  type: "object",
+  required: ["keep", "false_positive_risk", "rationale"],
+  properties: {
+    keep: { type: "boolean" },
+    false_positive_risk: { type: "string", enum: ["none", "low", "high"] },
+    rationale: { type: "string" },
+  },
+};
+
+phase("Mine");
+const mined = await agent(
+  `In the ax repo (cwd), run \`bun apps/axctl/src/cli/index.ts dispatches --days=${days} --limit=500 --json\` ` +
+  `and \`bun apps/axctl/src/cli/index.ts dispatches --candidates --days=${days} --json\`. ` +
+  `Read ROUTING_CLASSES in apps/axctl/src/queries/dispatch-analytics.ts. ` +
+  `Find dispatches that (a) ran with dispatch_model=inherit on an expensive child model (fable/opus), ` +
+  `(b) match NO current class, and (c) look mechanical (bounded scope, spec'd, search/summarize/convert work - ` +
+  `NOT quality review, PR review, plan synthesis, architecture, or taste-heavy design/copy: those stay on the main model by policy). ` +
+  `Cluster their descriptions and propose at most 5 new routing classes with tight ^-anchored patterns - ` +
+  `prefer missing a few over matching judgment work. Also list existing class ids that matched zero dispatches in the window.`,
+  { label: "mine:unmatched", phase: "Mine", schema: PROPOSAL_SCHEMA, model: "sonnet" },
+);
+
+phase("Backtest");
+const verdicts = await parallel(
+  mined.proposals.map((p) => () =>
+    agent(
+      `Adversarially review this proposed dispatch-routing class for the ax routing table. ` +
+      `Class: ${JSON.stringify(p)}. ` +
+      `In the ax repo (cwd), run \`bun apps/axctl/src/cli/index.ts dispatches --days=${days * 3} --limit=500 --json\` ` +
+      `and test the regex /${p.pattern}/${p.flags} against EVERY description. ` +
+      `Try to REFUTE the class: does it match any quality review, PR review, plan, architecture, design, or copy dispatch ` +
+      `(judgment work that must stay on the main model)? Does it overlap an existing ROUTING_CLASSES pattern ` +
+      `(apps/axctl/src/queries/dispatch-analytics.ts)? Default keep=false when uncertain.`,
+      { label: `backtest:${p.id}`, phase: "Backtest", schema: VERDICT_SCHEMA, model: "sonnet" },
+    ).then((v) => ({ proposal: p, verdict: v })),
+  ),
+);
+
+const surviving = verdicts.filter(Boolean).filter((r) => r.verdict.keep);
+const rejected = verdicts.filter(Boolean).filter((r) => !r.verdict.keep);
+log(`${surviving.length}/${mined.proposals.length} proposed classes survived adversarial backtest`);
+
+phase("Emit");
+const brief = await agent(
+  `Write a routing-tune review brief to .ax/tasks/routing-tune-${date}.md in the ax repo (cwd). Content: ` +
+  `(1) window: last ${days}d, unmatched expensive inherit spend $${mined.unmatched_total_cost_usd}; ` +
+  `(2) SURVIVING class proposals as ready-to-paste ROUTING_CLASSES entries (TypeScript object literals matching the existing style in apps/axctl/src/queries/dispatch-analytics.ts), each with its examples and est savings: ${JSON.stringify(surviving)}; ` +
+  `(3) rejected proposals with refutation rationale: ${JSON.stringify(rejected.map((r) => ({ id: r.proposal.id, rationale: r.verdict.rationale })))}; ` +
+  `(4) retirement candidates (zero matches in window): ${JSON.stringify(mined.retire_candidates)}; ` +
+  `(5) apply checklist: edit ROUTING_CLASSES + the hook DEFAULT_TABLE (packages/hooks-sdk/src/hooks/route-dispatch.ts), run the dispatch-analytics + route-dispatch tests, then \`ax dispatches compile-routing\` and \`ax dispatches compile-routing --skill-md=skills/efficient-dispatch/SKILL.md\`. ` +
+  `Do NOT edit ROUTING_CLASSES or the hook yourself - the brief is the deliverable. Return the file path.`,
+  { label: "emit:brief", phase: "Emit", model: "sonnet" },
+);
+
+return {
+  window_days: days,
+  unmatched_cost_usd: mined.unmatched_total_cost_usd,
+  proposed: mined.proposals.length,
+  survived: surviving.length,
+  retire_candidates: mined.retire_candidates,
+  brief,
+};

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,11 @@ dist/
 # local agent + harness state
 .ax/
 .claude/agents/
-.claude/workflows/
+# committed named workflows (Bun-repo pattern) - keep *.workflow.js versioned,
+# ignore everything else in the dir (gitignore can't re-include inside an
+# excluded DIRECTORY, so exclude contents with /* instead)
+.claude/workflows/*
+!.claude/workflows/*.workflow.js
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,26 @@ ax costs for --branch feat/share        # cost of a whole feature branch
 
 So "what did that refactor cost" has an answer with a dollar sign on it.
 
+## Route the expensive model where it earns its keep
+
+Your frontier model burns 3-10x cheaper-model rates on mechanical subagent
+work unless you route it. ax measures the leak, nudges at dispatch time, and
+proves whether the routing worked:
+
+```bash
+ax cost split --days=7              # main loop vs subagents, by model
+ax dispatches --candidates          # model-less dispatches + est savings
+ax dispatches compile-routing       # regenerate the routing table
+ax hooks install ~/.ax/hooks/route-dispatch.ts --providers=claude
+```
+
+The `route-dispatch` hook warns when a mechanical dispatch forgets an explicit
+model; the `efficient-dispatch` skill (via `npx skills add Necmttn/ax`) teaches
+the orchestration pattern; `ax improve recommend` surfaces a proposal when
+missed savings accumulate; `/routing-tune` (committed workflow) re-mines the
+routing classes from your own dispatch history. One source of truth, measured
+end to end - see [docs/design/cost-routing.md](docs/design/cost-routing.md).
+
 ## Share a session like a gist
 
 ```bash

--- a/apps/axctl/src/cli/commands/ax-dispatches.ts
+++ b/apps/axctl/src/cli/commands/ax-dispatches.ts
@@ -24,6 +24,7 @@ import {
     fetchDispatches,
     fetchDispatchCandidates,
     compileRouting,
+    compileRoutingSkillMd,
 } from "../../queries/dispatch-analytics.ts";
 import { buildDispatchesNext, buildCandidatesNext } from "../../nav/next-links.ts";
 import type { RuntimeManifest } from "./manifest.ts";
@@ -171,9 +172,25 @@ const compileRoutingCommand = Command.make(
     "compile-routing",
     {
         out: Flag.string("out").pipe(Flag.optional),
+        skillMd: Flag.string("skill-md").pipe(Flag.optional),
         json: jsonFlag,
     },
-    ({ out, json }) => Effect.gen(function* () {
+    ({ out, skillMd, json }) => Effect.gen(function* () {
+        const skillPath = optionValue(skillMd);
+        if (skillPath !== undefined) {
+            const result = yield* compileRoutingSkillMd(skillPath);
+            if (result.error) {
+                fail(`compile-routing --skill-md: ${result.error} in ${result.path}`);
+            }
+            if (json) {
+                console.log(prettyPrint(result));
+            } else {
+                console.log(result.written
+                    ? `skill routing table regenerated: ${result.path}`
+                    : `skill routing table already current: ${result.path}`);
+            }
+            return;
+        }
         const outPath = optionValue(out);
         const result = yield* compileRouting(outPath);
         if (json) {
@@ -185,7 +202,8 @@ const compileRoutingCommand = Command.make(
 ).pipe(
     Command.withDescription(
         "Write ~/.ax/hooks/routing-table.json from the built-in ROUTING_CLASSES constant. " +
-        "Idempotent regenerate. --out=PATH overrides default path. --json",
+        "Idempotent regenerate. --out=PATH overrides default path. " +
+        "--skill-md=PATH instead regenerates the ax:routing-table section of a skill markdown. --json",
     ),
 );
 

--- a/apps/axctl/src/queries/dispatch-analytics.test.ts
+++ b/apps/axctl/src/queries/dispatch-analytics.test.ts
@@ -19,6 +19,8 @@ import {
     fetchDispatches,
     fetchDispatchCandidates,
     compileRouting,
+    renderRoutingTableMarkdown,
+    replaceSkillRoutingSection,
     ROUTING_CLASSES,
     matchRouting,
 } from "./dispatch-analytics.ts";
@@ -516,5 +518,53 @@ describe("compileRouting", () => {
         await runCompileRouting(outPath);
         const parsed = JSON.parse(readFileSync(outPath, "utf8"));
         expect(parsed.agentTypes).toMatchObject(ROUTING_CLASSES.agentTypes);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// skill-md routing section
+// ---------------------------------------------------------------------------
+
+describe("renderRoutingTableMarkdown / replaceSkillRoutingSection", () => {
+    it("renders one row per class plus an agent-types row, pipes escaped", () => {
+        const md = renderRoutingTableMarkdown();
+        for (const cls of ROUTING_CLASSES.classes) {
+            expect(md).toContain(`| ${cls.id} |`);
+        }
+        expect(md).toContain("agent types");
+        // Alternation pipes inside patterns must be escaped for the table.
+        expect(md).toContain("\\|");
+    });
+
+    it("replaces only the marked section and is idempotent", () => {
+        const doc = [
+            "# heading",
+            "",
+            "<!-- ax:routing-table -->",
+            "stale table",
+            "<!-- /ax:routing-table -->",
+            "",
+            "tail text",
+        ].join("\n");
+        const once = replaceSkillRoutingSection(doc);
+        expect(once).not.toBeNull();
+        expect(once!).toContain("# heading");
+        expect(once!).toContain("tail text");
+        expect(once!).not.toContain("stale table");
+        expect(once!).toContain("| spec-review |");
+        const twice = replaceSkillRoutingSection(once!);
+        expect(twice).toBe(once!);
+    });
+
+    it("returns null when markers are missing", () => {
+        expect(replaceSkillRoutingSection("no markers here")).toBeNull();
+    });
+
+    it("the shipped efficient-dispatch skill is in sync with ROUTING_CLASSES", () => {
+        const skillPath = join(import.meta.dir, "../../../../skills/efficient-dispatch/SKILL.md");
+        const content = readFileSync(skillPath, "utf8");
+        const regenerated = replaceSkillRoutingSection(content);
+        expect(regenerated).not.toBeNull();
+        expect(regenerated!).toBe(content);
     });
 });

--- a/apps/axctl/src/queries/dispatch-analytics.ts
+++ b/apps/axctl/src/queries/dispatch-analytics.ts
@@ -678,3 +678,76 @@ export const compileRouting = (
         yield* fs.writeFileString(resolvedPath, json).pipe(Effect.orDie);
         return { path: resolvedPath, written: true };
     });
+
+// ---------------------------------------------------------------------------
+// compile-routing --skill-md: regenerate the routing table inside a skill doc
+// ---------------------------------------------------------------------------
+
+const SKILL_TABLE_OPEN = "<!-- ax:routing-table -->";
+const SKILL_TABLE_CLOSE = "<!-- /ax:routing-table -->";
+
+/** Render ROUTING_CLASSES as the markdown table embedded in skill docs. */
+export const renderRoutingTableMarkdown = (): string => {
+    const lines = [
+        "| class | description pattern | model |",
+        "|---|---|---|",
+    ];
+    for (const cls of ROUTING_CLASSES.classes) {
+        // Escape pipes so regex alternations don't break the table.
+        const pattern = cls.pattern.replace(/\|/g, "\\|");
+        lines.push(`| ${cls.id} | \`${pattern}\` | ${cls.suggest} |`);
+    }
+    const byModel = new Map<string, string[]>();
+    for (const [agentType, model] of Object.entries(ROUTING_CLASSES.agentTypes ?? {})) {
+        const list = byModel.get(model) ?? [];
+        list.push(agentType);
+        byModel.set(model, list);
+    }
+    const agentTypes = [...byModel.entries()]
+        .map(([model, types]) => `${types.join(", ")} → ${model}`)
+        .join("; ");
+    if (agentTypes) lines.push(`| agent types | ${agentTypes} | |`);
+    return lines.join("\n");
+};
+
+/**
+ * Replace the marked routing-table section in a skill markdown body.
+ * Returns null when the markers are missing (caller surfaces the error).
+ */
+export const replaceSkillRoutingSection = (content: string): string | null => {
+    const open = content.indexOf(SKILL_TABLE_OPEN);
+    const close = content.indexOf(SKILL_TABLE_CLOSE);
+    if (open === -1 || close === -1 || close < open) return null;
+    return (
+        content.slice(0, open + SKILL_TABLE_OPEN.length) +
+        "\n" + renderRoutingTableMarkdown() + "\n" +
+        content.slice(close)
+    );
+};
+
+export interface CompileSkillMdResult {
+    readonly path: string;
+    readonly written: boolean;
+    readonly error?: string;
+}
+
+/** Regenerate the `ax:routing-table` section of a skill markdown file in place. */
+export const compileRoutingSkillMd = (
+    skillPath: string,
+): Effect.Effect<CompileSkillMdResult, never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const content = yield* fs.readFileString(skillPath).pipe(Effect.orDie);
+        const updated = replaceSkillRoutingSection(content);
+        if (updated === null) {
+            return {
+                path: skillPath,
+                written: false,
+                error: `missing ${SKILL_TABLE_OPEN} ... ${SKILL_TABLE_CLOSE} markers`,
+            };
+        }
+        if (updated !== content) {
+            yield* fs.writeFileString(skillPath, updated).pipe(Effect.orDie);
+        }
+        return { path: skillPath, written: updated !== content };
+    });

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -1,0 +1,63 @@
+# ax - the agent experience layer
+
+> ax is a local taste & telemetry graph for AI coding agents. It ingests
+> transcripts from Claude Code, Codex, Pi, OpenCode, and Cursor into a local
+> SurrealDB, then turns that history into evidence: which skills earn their
+> keep, what work actually cost, where expensive models burn tokens on
+> mechanical work, and which guardrails measurably help. Everything runs on
+> the user's machine; nothing leaves it unless they share a session.
+
+Site: https://ax.necmttn.com
+Repo: https://github.com/Necmttn/ax
+Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills add Necmttn/ax`
+
+## What users can do
+
+### Recall and reconstruct
+- `ax recall <query>` - full-text search across turns, commits, and skills
+- `ax sessions here | around <date> | near <sha> | show <id>` - windowed session queries; drill into any session turn by turn
+- `ax:extract-workflow` skill - reconstruct the workflow behind a shipped artifact ("what made X work")
+- `ax share <session-id>` - publish a sanitized session share via GitHub Gist, viewable in the hosted studio
+
+### Skills intelligence
+- `ax skills search | taste | unused | pairs | recovery | stats | weighted` - which installed skills actually get used, and what they pair with
+- `ax skills classify / tag / lint / by-role / roles` - role-tag skills via review briefs; usage x role-weight ranking
+- `ax skills config` - skill lifecycle (live / orphan / out-of-scope / parked)
+
+### Cost and model routing
+- `ax cost models | sessions | split` - spend by model; the split shows main-loop vs subagent spend so users see what their frontier model burns on mechanical work
+- `ax dispatches [--candidates]` - subagent dispatches that inherited an expensive model + estimated savings at cheaper-model pricing
+- `ax dispatches compile-routing` - regenerate the routing table that drives the route-dispatch hook and the efficient-dispatch skill
+- `efficient-dispatch` skill - orchestration pattern: the main model keeps judgment and review, mechanical dispatches carry an explicit cheaper model
+- `route-dispatch` hook - deterministic dispatch-time nudge when a mechanical dispatch forgets an explicit model
+- `ax costs summary | for --session/--query/--commit/--branch` - what any session, feature, or branch cost in tokens and USD
+
+### Self-improvement loop
+- `ax improve recommend / accept / lint / show` - evidence-backed proposals (guidance, skills, hooks, automations) derived from the graph; accept emits a task brief, lint reconciles applied guidance
+- `ax retro emit / pending / brief` + `ax:retro` skill - guided experiment-loop retrospective: triage proposals, lock verdicts, review hook effectiveness
+- `ax hooks init / install / backtest / cases` - author typed TypeScript hooks once, run them on Claude Code + Codex; replay history through a hook before installing it
+
+### Graph insights
+- `ax insights <view>` - 31 read-only graph views
+- `ax signals list | show` - relation-signal catalog (fragility cascades, etc.)
+- `ax sessions metrics`, `ax evidence weekly` - session health and weekly evidence rollups
+- `ax serve` - local dashboard with live ingest, session browser, and health views
+- `ax tui` - terminal skills browser
+
+### Setup and ingest
+- `ax setup` / `ax install` - first-time install: CLI, local SurrealDB, transcript watcher
+- `ax ingest [here] [--since=Nd]` - ingest transcripts, skills, and git history; `here` scopes to the current repo; the watcher does this automatically on new transcripts
+- `ax roles` - list role labels used for skill classification
+- `ax doctor` - validate the install (db, watcher, skills)
+
+### For agents (MCP)
+- `ax mcp` - stdio MCP server exposing read-only graph queries as tools: recall, sessions_around, session_show, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, session_metrics, signal_show, cost_models, cost_split, dispatches
+
+## Pages
+- [How it works](https://ax.necmttn.com/how-it-works): ingest -> graph -> evidence loop
+- [Features](https://ax.necmttn.com/features): feature tour
+- [CLI reference](https://ax.necmttn.com/docs/cli-reference): every command
+- [Docs](https://ax.necmttn.com/docs): concepts and language
+- [Manifesto](https://ax.necmttn.com/manifesto): why the agent experience layer exists
+- [Changelog](https://ax.necmttn.com/changelog): release narratives
+- [Registry](https://ax.necmttn.com/registry): community registry direction

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -106,6 +106,35 @@ A: Say "let's do an ax retro" - proposal triage + verdict review against your re
 **Q: Is my install healthy / why is nothing ingesting?**
 A: `ax doctor` - validates DB, watcher, and skills. The watcher ingests new transcripts automatically; `ax ingest here --since=1` forces a scoped pass.
 
+## Q&A - multi-hop graph questions (where the graph beats grep)
+
+These need relations chained across sessions, commits, files, and verdicts -
+derived at ingest, queryable in one command.
+
+**Q: Which of my past mistakes are still costing OTHER work?**
+A: `ax signals show fragility_cascade` - sessions whose reverted commits' files later forced edits by *other* sessions. Three hops: origin session -> reverted commit -> touched files -> downstream sessions that had to fix them, weighted by distinct downstream fixers.
+
+**Q: Which features needed fixes after shipping?**
+A: `ax insights post-feature-fixes` - feature commits joined to the fix commits that followed them. Pair with `ax costs for --commit` to price the cleanup.
+
+**Q: What do I correct my agent about most often?**
+A: `ax insights friction` for the correction/interruption hotspots; `ax insights reaction-themes` clusters classified user reactions into recurring themes - the raw material the improve loop mines.
+
+**Q: Where does my agent claim "done" without verifying?**
+A: `ax insights verification-gaps` - completion claims with no verification evidence behind them.
+
+**Q: Which sessions burned tokens without producing anything?**
+A: `ax insights token-impact` and `ax insights cache-health` - token spend joined to outcome evidence, cache-read ratios flagging context-thrash sessions.
+
+**Q: Which skills rescue sessions that go wrong?**
+A: `ax skills recovery` - failure -> recovery arcs: what got invoked after things broke, and whether the session recovered.
+
+**Q: How does ax decide WHAT to propose improving?**
+A: The derive pipeline chains hops at ingest: classified reactions + correction contexts + skill candidates + dispatch analytics flow into `proposal` rows with evidence refs. `ax improve recommend` ranks them (confidence x recency x frequency); accepting stamps the moment; `ax:retro` verdicts close the loop. Improvement is graph-derived, not vibes.
+
+**Q: My question isn't on this list - can I ask the graph directly?**
+A: Yes. The whole graph is local SurrealDB (`127.0.0.1:8521`, schema in the repo); `ax insights <view>` covers 31 prebuilt traversals, and via `ax mcp` an agent can chain recall -> sessions_around -> session_show hops itself to answer novel multi-hop questions in-context.
+
 ## Pages
 - [How it works](https://ax.necmttn.com/how-it-works): ingest -> graph -> evidence loop
 - [Features](https://ax.necmttn.com/features): feature tour

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -53,6 +53,59 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 ### For agents (MCP)
 - `ax mcp` - stdio MCP server exposing read-only graph queries as tools: recall, sessions_around, session_show, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, session_metrics, signal_show, cost_models, cost_split, dispatches
 
+## Q&A - "how do I..." mapped to the ax answer
+
+**Q: What was I working on last week?**
+A: `ax sessions here --days=7` - sessions scoped to the current repo. `ax sessions around 2026-06-01` for a date window anywhere.
+
+**Q: How did we ship feature X? I need to reconstruct what actually happened.**
+A: `ax sessions near <sha>` finds the sessions behind a commit; the `ax:extract-workflow` skill narrates the ordered steps that produced the artifact.
+
+**Q: Where did we discuss/decide Y? I remember it but can't find it.**
+A: `ax recall "Y"` - full-text search across every turn, commit, and skill, across all five harnesses.
+
+**Q: What did that refactor / branch / PR cost?**
+A: `ax costs for --branch <name>` or `--commit <sha>` or `--query "<text>"` - tokens and USD, priced per model with cache buckets.
+
+**Q: Where does my model spend actually go?**
+A: `ax cost split --days=7` - main loop vs subagents, by model. Usually reveals the frontier model burning cache reads on mechanical work.
+
+**Q: My frontier-model bill is high. What can run on cheaper models?**
+A: `ax dispatches --candidates` - every subagent dispatch that inherited an expensive model while doing mechanical work, with estimated savings repriced from real token buckets.
+
+**Q: How do I make my agent pick cheaper models automatically?**
+A: Three layers: the `efficient-dispatch` skill (orchestration pattern), the `route-dispatch` hook (`ax hooks install ~/.ax/hooks/route-dispatch.ts --providers=claude` - warns at dispatch time), and `ax dispatches compile-routing` (regenerates the routing table both read).
+
+**Q: I installed 100 skills. Which ones actually earn their keep?**
+A: `ax skills weighted` - usage x role-weight ranking. `ax skills unused` for the dead weight; `ax skills config` to park or retire.
+
+**Q: Which skills work well together?**
+A: `ax skills pairs` - co-occurrence across real sessions.
+
+**Q: Did that hook / guardrail / guidance actually help, or does it just feel like it did?**
+A: The experiment loop: `ax improve recommend` proposes changes with evidence, accepting stamps the moment, and `ax:retro` walks verdicts - worked, didn't, no-longer-needed. Hook effectiveness has its own signal.
+
+**Q: Can I test a hook against history before trusting it?**
+A: `ax hooks backtest <file> --days=14` - replays your real tool-call history through the hook in-process and reports would-block/would-warn rates.
+
+**Q: How do I write one guard that runs on both Claude Code and Codex?**
+A: `ax hooks init` scaffolds `~/.ax/hooks` (typed Effect TypeScript, `defineHook`); `ax hooks install <file> --providers=claude,codex` fans it out to both configs.
+
+**Q: Can my agent query its own history mid-session, without me prompting it?**
+A: `ax mcp` - a stdio MCP server exposing the read-only graph queries as 15 tools. The agent asks "where is the spend" or "what did we try before" itself.
+
+**Q: How do I show a session to a teammate?**
+A: `ax share <session-id>` - sanitized share via GitHub Gist, rendered in the hosted studio viewer.
+
+**Q: I'd rather click than type.**
+A: `ax serve` - local dashboard: live ingest, session browser, health views. `ax tui` for the terminal skills browser.
+
+**Q: What should I improve in my setup right now?**
+A: Say "let's do an ax retro" - proposal triage + verdict review against your recent work. `ax improve recommend` for the raw shortlist.
+
+**Q: Is my install healthy / why is nothing ingesting?**
+A: `ax doctor` - validates DB, watcher, and skills. The watcher ingests new transcripts automatically; `ax ingest here --since=1` forces a scoped pass.
+
 ## Pages
 - [How it works](https://ax.necmttn.com/how-it-works): ingest -> graph -> evidence loop
 - [Features](https://ax.necmttn.com/features): feature tour

--- a/scripts/check-cli-reference.ts
+++ b/scripts/check-cli-reference.ts
@@ -33,4 +33,18 @@ if (missing.length > 0) {
     process.exit(1);
 }
 
-console.log(`README.md + docs/cli.md cover ${subcommands.length} CLI subcommands.`);
+// llms.txt is the machine-readable feature index served at the site root.
+// Unlike the human docs (where one of README/cli.md suffices), it must cover
+// EVERY visible subcommand itself - an LLM reading it gets no second source.
+const llms = readFileSync("apps/site/public/llms.txt", "utf8");
+const missingLlms = subcommands.filter(
+    (command) => !llms.includes(`axctl ${command}`) && !llms.includes(`ax ${command}`),
+);
+
+if (missingLlms.length > 0) {
+    console.error("apps/site/public/llms.txt is missing CLI subcommands:");
+    for (const command of missingLlms) console.error(`  ${command}`);
+    process.exit(1);
+}
+
+console.log(`README.md + docs/cli.md + llms.txt cover ${subcommands.length} CLI subcommands.`);

--- a/skills/efficient-dispatch/SKILL.md
+++ b/skills/efficient-dispatch/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: efficient-dispatch
+description: Model-routing orchestration for any expensive frontier model (Fable, Opus, GPT-5.x) - the main model keeps judgment and Q&A review, mechanical subagent dispatches carry an explicit cheaper model, and ax measures whether the routing actually worked. Use when orchestrating codebase-heavy or token-heavy work with subagents, when dispatching Agent tasks without a model, when the user says "route to cheaper models", "efficient dispatch", "optimize model spend", or asks where their token spend goes. Pairs with the route-dispatch hook (deterministic backstop) and `ax dispatches` (evidence). Do NOT fire on single-shot questions or tiny tasks with no dispatching.
+---
+
+# efficient-dispatch - routed, measured, verified
+
+The main model is the orchestrator and Q&A reviewer. Mechanical work runs on
+cheaper models - and unlike guidance-only approaches, every claim here is
+checkable against your own ax graph.
+
+## The split
+
+**Main model keeps** (never route down): decomposition, architecture and
+product tradeoffs, plan synthesis, quality review, PR review, judging
+conflicting subagent reports, final integration, taste-heavy design/copy.
+
+**Cheaper models take** mechanical work - dispatch with an explicit
+`model:` per the routing table below.
+
+## Routing table
+
+Source of truth: `~/.ax/hooks/routing-table.json` (regenerate with
+`ax dispatches compile-routing`). Consult it when present; these built-ins
+mirror it:
+
+<!-- ax:routing-table -->
+| class | description pattern | model |
+|---|---|---|
+| spec-review | `^spec review` | sonnet |
+| search-locate | `^(pattern-find\|locate\|find\|map\|sweep\|grep)` | haiku |
+| research | `^(research\|investigate docs\|study)` | sonnet |
+| well-specified-impl | `^implement ` | sonnet |
+| bulk-mechanical | `^(write announcements\|regenerate\|standardize\|merge main)` | sonnet |
+| agent types | Explore, codebase-locator, codebase-pattern-finder → haiku; codebase-analyzer → sonnet | |
+<!-- /ax:routing-table -->
+
+Anything unmatched: leave the model unset only if the work genuinely needs
+main-model judgment - otherwise pick sonnet.
+
+## Dispatch discipline
+
+1. Decompose into independent slices BEFORE reading everything yourself;
+   run slices as parallel subagents in isolated worktrees when they edit files.
+2. Every brief is self-contained: repo path, exact objective, in/out of scope,
+   evidence format to return (files, line refs, commands, diffs, failures),
+   verification commands, stop conditions.
+3. Set `model:` explicitly on every mechanical dispatch. The route-dispatch
+   hook warns when you forget - treat the warning as a re-dispatch signal,
+   not noise.
+4. Treat subagent reports as leads. Before acting on a high-impact finding or
+   declaring done, reopen the cited files and re-run the key verification
+   yourself. Expect to find one real bug per delegated phase.
+
+## Measure (what guidance-only skills can't do)
+
+- `ax dispatches --days=7` - your inherit rate (target: explicit model on all
+  mechanical classes)
+- `ax dispatches --candidates` - missed routings + est savings, repriced from
+  real token buckets
+- `ax cost split --days=7` - main vs subagent spend by model; the dominant
+  cost is usually main-loop cache reads, so move tool-heavy loops (build/test
+  cycles, browser QA) into subagents entirely
+- `ax improve recommend` - surfaces a routing proposal automatically when
+  missed savings accumulate
+
+## Verify
+
+After adopting this skill, compare windows: `ax cost split` + inherit rate
+before vs after. If the inherit rate doesn't drop, the routing isn't
+happening - check `ax hooks backtest ~/.ax/hooks/route-dispatch.ts --days=7`
+and whether dispatches are bypassing the table.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -94,6 +94,20 @@ Also surface the config front door when relevant:
 - `ax hooks init` - scaffold `~/.ax/hooks` for authoring custom TypeScript guards (`defineHook` from `@ax/hooks-sdk`); validate with `ax hooks backtest` before `ax hooks install`.
 - `ax agents config` - agent definitions and the skills they scope.
 
+After the first ingest completes, show the user where their model spend goes -
+this is the fastest "aha" in the product:
+
+```bash
+ax cost split --days=7       # main loop vs subagents, by model
+ax dispatches --candidates   # dispatches that could run on cheaper models
+```
+
+If the candidates list is non-empty, point at the routing loop: the
+`efficient-dispatch` skill (installed with the others), the `route-dispatch`
+hook (`ax hooks init` scaffolds it; install with
+`ax hooks install ~/.ax/hooks/route-dispatch.ts --providers=claude`), and
+`docs/design/cost-routing.md` for the full picture.
+
 ## What's installed
 
 | Component | Where | Owner |


### PR DESCRIPTION
## What

`skills/efficient-dispatch` — the intent-layer companion to the #300-#306 routing loop, prompted by BuilderIO's `efficient-fable`/`efficient-frontier` skills shipping the same thesis as prose. Ours differs in one structural way: **every claim is checkable against the user's own ax graph.**

- Main model keeps judgment: decomposition, tradeoffs, synthesis, quality/PR review (deliberately unrouted, matching the hook policy)
- Mechanical dispatches carry explicit `model:` per the routing table
- Measure section: `ax dispatches --candidates`, `ax cost split` — inherit rate as the adoption metric
- Verify section: before/after windows + hook backtest

## Anti-staleness, two layers

1. **Copy drift** — the routing table in SKILL.md sits between `<!-- ax:routing-table -->` markers; `ax dispatches compile-routing --skill-md=PATH` regenerates it from `ROUTING_CLASSES`, and a unit test asserts the shipped skill is byte-identical to the regenerated output. Skill prose, hook defaults, and `routing-table.json` share one source of truth.
2. **Class staleness** — `ROUTING_CLASSES` itself is hand-written, so it goes stale as dispatch vocabulary shifts. `.claude/workflows/routing-tune.workflow.js` (committed, Bun-repo pattern; runs as `/routing-tune`) closes that: mines the window for unmatched expensive inherits, proposes tight new classes, adversarially backtests each against judgment-work false positives (default reject when uncertain), and emits a `.ax/tasks` review brief. Human applies; compile-routing propagates. Workflow stages route to sonnet per the skill's own policy. gitignore updated to version `*.workflow.js` (contents-exclusion so negation works).

## Status

**Draft — under live testing today** (installed to ~/.claude/skills + ~/.codex/skills alongside BuilderIO's efficient-fable, epoch marker `efficient-fable-skill` stamped for before/after comparison). Publish tonight after the testing window.

## Tests

4 new (markdown render, marker replacement, missing-marker error, shipped-skill sync); 65 pass across dispatch + cli; gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)