### PR TITLE
feat(cli): ax sessions churn - verification churn insight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ fresh clone.
 `ax sessions around <date> [--days=N] [--project=PATH]` - date window, default ±3d.
 `ax sessions near <sha>` - predecessor→commit window (adaptive); falls back to ±3d for orphan commits.
 `ax sessions show <id> [--expand=<uuid>|--all] [--by-role] [--json]` - drill into one session.
+`ax sessions churn [--here|--project=PATH] [--source=S] [--since=N]` - verification churn by session/source: landed vs edit vs repair LOC, failed checks, episodes (failure opens, same-family pass closes, 30min expiry). Default 30d window.
 
 ### Cross-source recall
 

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -746,9 +746,10 @@ export const cmdSessionsChurn = (input: {
             project = pwd.repoRoot;
         }
 
-        const since = input.sinceDays === null
-            ? null
-            : new Date(Date.now() - Math.min(Math.max(Math.trunc(input.sinceDays), 1), 3650) * 86400 * 1000);
+        // Default window keeps the all-session fan-out bounded on mature DBs;
+        // pass a larger --since (up to 3650) for deeper history.
+        const sinceDays = input.sinceDays ?? 30;
+        const since = new Date(Date.now() - Math.min(Math.max(Math.trunc(sinceDays), 1), 3650) * 86400 * 1000);
 
         const summary = yield* fetchSessionChurnSummary({
             since,
@@ -786,7 +787,7 @@ export const sessionsChurnCommand = Command.make(
     "Summarize verification churn by session/source: edit LOC, landed LOC, failed/passed checks, "
     + "episodes opened by failures after edits, and repair LOC before passes. "
     + "--here scopes to the pwd repo, --project filters session.project/cwd, --source filters provider, "
-    + "--since N days, --limit caps hot sessions, --json for machine output.",
+    + "--since N days (default 30, max 3650), --limit caps hot sessions, --json for machine output.",
 ));
 
 export const sessionsCommand = Command.make("sessions").pipe(

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -33,6 +33,7 @@ import {
     type GroupByKey,
 } from "../../metrics/aggregates.ts";
 import { fetchSessionDurabilityDetail } from "../../metrics/reverted-commits.ts";
+import { fetchSessionChurnSummary, formatSessionChurnSummary } from "../../metrics/session-churn.ts";
 import { fetchSessionMetrics } from "../../metrics/session-metrics-query.ts";
 import { formatSessionMetrics, SESSION_METRICS_LEGEND } from "../../metrics/util.ts";
 import { buildSessionsNext, buildSessionShowNext } from "../../nav/next-links.ts";
@@ -722,8 +723,74 @@ const sessionsMetricsCommand = Command.make(
     + "See `ax signals` for cross-session relation signals (e.g. fragility cascades).",
 ));
 
+// ---------------------------------------------------------------------------
+// ax sessions churn - verification failures plus repair/edit churn
+// ---------------------------------------------------------------------------
+
+export const cmdSessionsChurn = (input: {
+    readonly sinceDays: number | null;
+    readonly project: string | null;
+    readonly here: boolean;
+    readonly source: string | null;
+    readonly limit: number;
+    readonly json: boolean;
+}) =>
+    Effect.gen(function* () {
+        let project = input.project;
+        if (input.here) {
+            const pwd = yield* resolvePwdRepository().pipe(
+                Effect.catchTag("NotAGitRepoError", (err) =>
+                    stderrExit(`axctl sessions churn: --here requires a git repository (cwd=${err.cwd})\n`, 2),
+                ),
+            );
+            project = pwd.repoRoot;
+        }
+
+        const since = input.sinceDays === null
+            ? null
+            : new Date(Date.now() - Math.min(Math.max(Math.trunc(input.sinceDays), 1), 3650) * 86400 * 1000);
+
+        const summary = yield* fetchSessionChurnSummary({
+            since,
+            project,
+            source: input.source,
+            limit: input.limit,
+        });
+        if (input.json) {
+            console.log(prettyPrint(summary));
+            return;
+        }
+        console.log(formatSessionChurnSummary(summary));
+    });
+
+export const sessionsChurnCommand = Command.make(
+    "churn",
+    {
+        since: optionalSince,
+        project: Flag.string("project").pipe(Flag.optional),
+        here: Flag.boolean("here").pipe(Flag.withDefault(false)),
+        source: Flag.string("source").pipe(Flag.optional),
+        limit: positiveLimit(20),
+        json: jsonFlag,
+    },
+    ({ since, project, here, source, limit, json }) =>
+        cmdSessionsChurn({
+            sinceDays: optionValue(since) ?? null,
+            project: optionValue(project) ?? null,
+            here,
+            source: optionValue(source) ?? null,
+            limit,
+            json,
+        }),
+).pipe(Command.withDescription(
+    "Summarize verification churn by session/source: edit LOC, landed LOC, failed/passed checks, "
+    + "episodes opened by failures after edits, and repair LOC before passes. "
+    + "--here scopes to the pwd repo, --project filters session.project/cwd, --source filters provider, "
+    + "--since N days, --limit caps hot sessions, --json for machine output.",
+));
+
 export const sessionsCommand = Command.make("sessions").pipe(
-    Command.withDescription("Windowed session queries: here (pwd-repo), around (date), near (sha), show (detail), compare (side-by-side), metrics (graph-derived)"),
+    Command.withDescription("Windowed session queries: here (pwd-repo), around (date), near (sha), show (detail), compare (side-by-side), metrics (graph-derived), churn (verification repair churn)"),
     Command.withSubcommands([
         sessionsHereCommand,
         sessionsAroundCommand,
@@ -731,6 +798,7 @@ export const sessionsCommand = Command.make("sessions").pipe(
         sessionShowCommand,
         sessionsCompareCommand,
         sessionsMetricsCommand,
+        sessionsChurnCommand,
     ]),
 );
 

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -417,13 +417,13 @@ describe("sessions command", () => {
         expect(names).toContain("sessions");
     });
 
-    test("sessions exposes here, around, near subcommands", () => {
+    test("sessions exposes here, around, near, churn subcommands", () => {
         const sessions = rootCommand.subcommands
             .flatMap((g) => g.commands)
             .find((c) => c.name === "sessions");
         expect(sessions).toBeDefined();
         const subNames = sessions!.subcommands.flatMap((g) => g.commands.map((c) => c.name));
-        expect(subNames).toEqual(expect.arrayContaining(["here", "around", "near"]));
+        expect(subNames).toEqual(expect.arrayContaining(["here", "around", "near", "churn"]));
     });
 
     test("sessions is routed as a DB command", () => {

--- a/apps/axctl/src/dashboard/cost-query.ts
+++ b/apps/axctl/src/dashboard/cost-query.ts
@@ -3,6 +3,7 @@ import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { recordLiteral } from "@ax/lib/ids";
 import { surrealDate, surrealString } from "@ax/lib/shared/surql";
+import { sessionProjectClause } from "../metrics/session-filter.ts";
 
 export interface CostSessionRow {
     readonly session: string;
@@ -171,10 +172,7 @@ const emptySummary = (selector: string, evidence: string): CostSummary => summar
 const querySessionClauses = (selector: Extract<CostSelector, { kind: "query" }>): string[] => {
     const clauses: string[] = [];
     if (selector.since) clauses.push(`session.started_at >= ${surrealDate(selector.since)}`);
-    if (selector.project) {
-        const project = surrealString(selector.project);
-        clauses.push(`(session.cwd = ${project} OR session.project = ${project})`);
-    }
+    if (selector.project) clauses.push(sessionProjectClause(selector.project, "session."));
     if (selector.repositoryKey) {
         clauses.push(`session.repository = ${recordLiteral("repository", selector.repositoryKey)}`);
     }

--- a/apps/axctl/src/dashboard/loc-query.ts
+++ b/apps/axctl/src/dashboard/loc-query.ts
@@ -4,6 +4,7 @@ import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { recordLiteral } from "@ax/lib/ids";
 import { surrealDate, surrealString } from "@ax/lib/shared/surql";
+import { sessionProjectClause } from "../metrics/session-filter.ts";
 
 // ---------------------------------------------------------------------------
 // Lines-of-code metric (analog of Claude Code OTEL `claude_code.lines_of_code.count`).
@@ -192,10 +193,7 @@ const mapRows = (rows: ReadonlyArray<Record<string, unknown>>): RawEditRow[] =>
 const querySessionClauses = (selector: Extract<LocSelector, { kind: "query" }>): string[] => {
     const clauses: string[] = [];
     if (selector.since) clauses.push(`session.started_at >= ${surrealDate(selector.since)}`);
-    if (selector.project) {
-        const project = surrealString(selector.project);
-        clauses.push(`(session.cwd = ${project} OR session.project = ${project})`);
-    }
+    if (selector.project) clauses.push(sessionProjectClause(selector.project, "session."));
     if (selector.repositoryKey) {
         clauses.push(`session.repository = ${recordLiteral("repository", selector.repositoryKey)}`);
     }

--- a/apps/axctl/src/ingest/check-family.test.ts
+++ b/apps/axctl/src/ingest/check-family.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { checkFamilyFromCommand } from "./check-family.ts";
+
+describe("checkFamilyFromCommand", () => {
+    test("classifies direct check binaries", () => {
+        expect(checkFamilyFromCommand("tsc --noEmit")).toBe("typecheck");
+        expect(checkFamilyFromCommand("tsgo")).toBe("typecheck");
+        expect(checkFamilyFromCommand("vitest run")).toBe("test");
+        expect(checkFamilyFromCommand("jest")).toBe("test");
+        expect(checkFamilyFromCommand("pytest -x")).toBe("test");
+        expect(checkFamilyFromCommand("playwright test")).toBe("test");
+        expect(checkFamilyFromCommand("eslint src")).toBe("eslint");
+        expect(checkFamilyFromCommand("oxlint --fix")).toBe("oxlint");
+        expect(checkFamilyFromCommand("oxc")).toBe("oxlint");
+    });
+
+    test("classifies runner subcommands and run-scripts", () => {
+        expect(checkFamilyFromCommand("bun test apps/foo.test.ts")).toBe("test");
+        expect(checkFamilyFromCommand("npm test")).toBe("test");
+        expect(checkFamilyFromCommand("bun run typecheck")).toBe("typecheck");
+        expect(checkFamilyFromCommand("bun run lint")).toBe("lint");
+        expect(checkFamilyFromCommand("pnpm lint")).toBe("lint");
+        expect(checkFamilyFromCommand("npm run lint:fix")).toBe("lint");
+        expect(checkFamilyFromCommand("bun run build")).toBe("build");
+        expect(checkFamilyFromCommand("bun run check:no-node-fs")).toBe("check");
+        expect(checkFamilyFromCommand("cargo test")).toBe("test");
+        expect(checkFamilyFromCommand("cargo check")).toBe("check");
+        expect(checkFamilyFromCommand("cargo build")).toBe("build");
+        expect(checkFamilyFromCommand("cargo clippy")).toBe("lint");
+        expect(checkFamilyFromCommand("go test ./...")).toBe("test");
+        expect(checkFamilyFromCommand("go vet ./...")).toBe("lint");
+        expect(checkFamilyFromCommand("make build")).toBe("build");
+    });
+
+    test("classifies bare script tokens except shell-builtin test", () => {
+        expect(checkFamilyFromCommand("lint")).toBe("lint");
+        expect(checkFamilyFromCommand("typecheck")).toBe("typecheck");
+        expect(checkFamilyFromCommand("test -f foo")).toBeNull();
+    });
+
+    test("looks past leading env assignments, cd prefixes, and earlier segments", () => {
+        expect(checkFamilyFromCommand("CI=1 bun test")).toBe("test");
+        expect(checkFamilyFromCommand("cd apps/axctl && bun test")).toBe("test");
+        expect(checkFamilyFromCommand("echo done && bun run typecheck")).toBe("typecheck");
+        expect(checkFamilyFromCommand("bun test || true")).toBe("test");
+    });
+
+    test("does not classify commands that merely mention check keywords", () => {
+        expect(checkFamilyFromCommand(null)).toBeNull();
+        expect(checkFamilyFromCommand("")).toBeNull();
+        expect(checkFamilyFromCommand("date")).toBeNull();
+        expect(checkFamilyFromCommand("ls test/")).toBeNull();
+        expect(checkFamilyFromCommand("rg foo test/ -l")).toBeNull();
+        expect(checkFamilyFromCommand("cat build.log")).toBeNull();
+        expect(checkFamilyFromCommand("git push")).toBeNull();
+        expect(checkFamilyFromCommand("git checkout build")).toBeNull();
+        expect(checkFamilyFromCommand("bun install")).toBeNull();
+        expect(checkFamilyFromCommand("bun ~/.ax/hooks/enforce-worktree.ts")).toBeNull();
+        expect(checkFamilyFromCommand("echo test")).toBeNull();
+        expect(checkFamilyFromCommand("bash scripts/test.sh")).toBeNull();
+    });
+});

--- a/apps/axctl/src/ingest/check-family.ts
+++ b/apps/axctl/src/ingest/check-family.ts
@@ -109,6 +109,15 @@ const segmentFamily = (segment: readonly string[]): CheckFamily | null => {
     return null;
 };
 
+/**
+ * A normalized command ("bun run", "npx") that cannot classify on its own but
+ * may resolve to a check family once the full command text is known.
+ */
+const RUNNER_AMBIGUOUS_NORM = /^(?:bun|npm|pnpm|yarn|deno|npx|bunx|pnpx)(?:\s+(?:run|x|exec))?$/;
+
+export const commandNormNeedsText = (norm: string | null | undefined): boolean =>
+    norm !== null && norm !== undefined && RUNNER_AMBIGUOUS_NORM.test(norm.trim().toLowerCase());
+
 const scriptFamily = (script: string | null | undefined): CheckFamily | null => {
     if (script === null || script === undefined) return null;
     const head = script.split(":")[0] ?? "";

--- a/apps/axctl/src/ingest/check-family.ts
+++ b/apps/axctl/src/ingest/check-family.ts
@@ -1,0 +1,118 @@
+import { commandTokenSegments } from "./tool-calls.ts";
+
+/**
+ * Single source of truth for "is this command a verification check, and which
+ * family?" - consumed by the ingest outcome classifier and the churn metric.
+ *
+ * Classification is anchored to command position: a family is only assigned
+ * when the check is the command being run (`bun test`, `tsc --noEmit`), never
+ * because a keyword appears somewhere in the text (`ls test/`, `cat build.log`).
+ */
+export type CheckFamily =
+    | "test"
+    | "typecheck"
+    | "lint"
+    | "eslint"
+    | "oxlint"
+    | "build"
+    | "check";
+
+const DIRECT_BINARIES = new Map<string, CheckFamily>([
+    ["vitest", "test"],
+    ["jest", "test"],
+    ["pytest", "test"],
+    ["tsc", "typecheck"],
+    ["tsgo", "typecheck"],
+    ["eslint", "eslint"],
+    ["oxlint", "oxlint"],
+    ["oxc", "oxlint"],
+    ["golangci-lint", "lint"],
+]);
+
+/** Script/target names as run via `bun run X`, `pnpm X`, `make X`, or bare. */
+const SCRIPT_FAMILIES = new Map<string, CheckFamily>([
+    ["test", "test"],
+    ["tsc", "typecheck"],
+    ["typecheck", "typecheck"],
+    ["lint", "lint"],
+    ["eslint", "eslint"],
+    ["oxlint", "oxlint"],
+    ["build", "build"],
+    ["check", "check"],
+]);
+
+/** Bare script tokens classify too, except `test` (shell builtin). */
+const BARE_SCRIPT_TOKENS = new Set(["typecheck", "lint", "build", "check"]);
+
+const PACKAGE_RUNNERS = new Set(["bun", "npm", "pnpm", "yarn", "deno", "npx", "bunx", "pnpx"]);
+const RUN_ALIASES = new Set(["run", "x", "exec"]);
+const TARGET_RUNNERS = new Set(["make", "just"]);
+
+const CARGO_FAMILIES = new Map<string, CheckFamily>([
+    ["test", "test"],
+    ["check", "check"],
+    ["build", "build"],
+    ["clippy", "lint"],
+]);
+
+const GO_FAMILIES = new Map<string, CheckFamily>([
+    ["test", "test"],
+    ["build", "build"],
+    ["vet", "lint"],
+]);
+
+const ALL_FAMILIES: ReadonlySet<string> = new Set<CheckFamily>([
+    "test", "typecheck", "lint", "eslint", "oxlint", "build", "check",
+]);
+
+export const isCheckFamily = (value: string | null | undefined): value is CheckFamily =>
+    value !== null && value !== undefined && ALL_FAMILIES.has(value);
+
+/** Accept an already-canonical family verbatim, else classify as a command. */
+export const coerceCheckFamily = (raw: string | null | undefined): CheckFamily | null =>
+    isCheckFamily(raw) ? raw : checkFamilyFromCommand(raw);
+
+export const checkFamilyFromCommand = (raw: string | null | undefined): CheckFamily | null => {
+    if (raw === null || raw === undefined || raw.trim().length === 0) return null;
+
+    for (const segment of commandTokenSegments(raw)) {
+        const family = segmentFamily(segment);
+        if (family !== null) return family;
+    }
+    return null;
+};
+
+const segmentFamily = (segment: readonly string[]): CheckFamily | null => {
+    const tool = basename(segment[0] ?? "").toLowerCase();
+    if (tool.length === 0) return null;
+
+    const direct = DIRECT_BINARIES.get(tool);
+    if (direct !== undefined) return direct;
+
+    const args = segment.slice(1).filter((token) => !token.startsWith("-"));
+    const arg0 = args[0]?.toLowerCase() ?? null;
+
+    if (tool === "playwright") return arg0 === "test" ? "test" : null;
+    if (tool === "cargo") return arg0 === null ? null : CARGO_FAMILIES.get(arg0) ?? null;
+    if (tool === "go") return arg0 === null ? null : GO_FAMILIES.get(arg0) ?? null;
+    if (TARGET_RUNNERS.has(tool)) return scriptFamily(arg0);
+
+    if (PACKAGE_RUNNERS.has(tool)) {
+        if (arg0 === "test") return "test";
+        const script = arg0 !== null && RUN_ALIASES.has(arg0) ? args[1]?.toLowerCase() ?? null : arg0;
+        return scriptFamily(script);
+    }
+
+    if (segment.length === 1 || BARE_SCRIPT_TOKENS.has(tool)) {
+        return BARE_SCRIPT_TOKENS.has(tool) ? SCRIPT_FAMILIES.get(tool) ?? null : null;
+    }
+    return null;
+};
+
+const scriptFamily = (script: string | null | undefined): CheckFamily | null => {
+    if (script === null || script === undefined) return null;
+    const head = script.split(":")[0] ?? "";
+    return SCRIPT_FAMILIES.get(head) ?? null;
+};
+
+const basename = (token: string): string => token.split("/").pop() ?? token;

--- a/apps/axctl/src/ingest/codex.test.ts
+++ b/apps/axctl/src/ingest/codex.test.ts
@@ -501,6 +501,53 @@ describe("Codex transcript extraction", () => {
         ]);
     });
 
+    test("extracts custom_tool_call apply_patch items as edit tool calls", () => {
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({
+                type: "session_meta",
+                timestamp: "2026-05-09T13:00:00.000Z",
+                payload: {
+                    id: "codex-patch",
+                    cwd: "/Users/necmttn/Projects/ax",
+                    timestamp: "2026-05-09T13:00:00.000Z",
+                },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-05-09T13:00:01.000Z",
+                payload: {
+                    type: "custom_tool_call",
+                    status: "completed",
+                    name: "apply_patch",
+                    call_id: "call-patch",
+                    input: "*** Begin Patch\n*** Update File: a.ts\n+added line\n-removed line\n*** End Patch\n",
+                },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-05-09T13:00:02.000Z",
+                payload: {
+                    type: "custom_tool_call_output",
+                    call_id: "call-patch",
+                    output: "Exit code: 0\nWall time: 0 seconds\nOutput:\nSuccess. Updated the following files:\nM a.ts",
+                },
+            }),
+        ]);
+
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+
+        expect(extracted.toolCalls).toHaveLength(1);
+        const call = extracted.toolCalls[0]!;
+        expect(call.toolName).toBe("apply_patch");
+        expect(call.callId).toBe("call-patch");
+        expect(call.inputJson).toEqual({ patch: expect.stringContaining("*** Begin Patch") });
+        expect(call.outputExcerpt ?? "").toContain("Success.");
+
+        const toolTurn = extracted.turns.find((turn) => turn.has_tool_use);
+        expect(toolTurn).toMatchObject({ role: "tool_call" });
+    });
+
     test("extracts function calls, matched outputs, synthetic skill relations, and update_plan snapshots", () => {
         const execOutput =
             "Chunk ID: abc\nWall time: 0.2000 seconds\nProcess exited with code 1\nOriginal token count: 30\nOutput:\nfatal: not a git repository\n";

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -597,7 +597,11 @@ function createCodexExtractor(
 
         const transcriptCallId = stringField(payload, "call_id");
         const callId = transcriptCallId ?? nextAnonymousFunctionCallId();
-        const inputJson = parseCodexArguments(payload.arguments);
+        // function_call carries JSON `arguments`; custom_tool_call (apply_patch)
+        // carries the raw patch text in `input` - wrap it so apply-patch LOC
+        // consumers find their `patch` field.
+        const customInput = payload.arguments === undefined ? stringField(payload, "input") : null;
+        const inputJson = customInput !== null ? { patch: customInput } : parseCodexArguments(payload.arguments);
         const turnKey = turnRecordKey(currentSession.id, seq);
         const toolCallKey = toolCallRecordKey({
             sessionId: currentSession.id,
@@ -914,8 +918,12 @@ function createCodexExtractor(
                 seq += 1;
                 const itemType = stringField(payload, "type");
                 const message = codexMessageRecord(payload);
+                // apply_patch arrives as custom_tool_call (a freeform tool),
+                // not function_call - treat both as tool calls or codex edits
+                // never reach the tool_call table.
+                const isToolCall = itemType === "function_call" || itemType === "custom_tool_call";
                 const role =
-                    itemType === "function_call"
+                    isToolCall
                         ? "tool_call"
                         : itemType === "message"
                           ? (stringField(message ?? {}, "role") ?? "assistant")
@@ -923,8 +931,6 @@ function createCodexExtractor(
 
                 const text = textFromCodexContent(message?.content);
                 const textExcerpt = text === null ? null : text.slice(0, 500);
-
-                const isToolCall = itemType === "function_call";
                 const kind = codexMessageKind(role, itemType, textExcerpt);
                 turns.push({
                     session: session.id,
@@ -940,7 +946,7 @@ function createCodexExtractor(
 
                 if (isToolCall) {
                     processFunctionCall(payload, ts, session);
-                } else if (itemType === "function_call_output") {
+                } else if (itemType === "function_call_output" || itemType === "custom_tool_call_output") {
                     processFunctionOutput(payload, ts, session);
                 } else {
                     pushProviderEvent({

--- a/apps/axctl/src/ingest/outcomes.test.ts
+++ b/apps/axctl/src/ingest/outcomes.test.ts
@@ -15,6 +15,30 @@ describe("classifyCommandOutcome", () => {
         })).toBe("expected_feedback");
     });
 
+    test("verification gate is anchored to command position, not keywords", () => {
+        expect(classifyCommandOutcome({
+            command_norm: "ls",
+            command_text: "ls test/",
+            has_error: true,
+            exit_code: 2,
+            output_excerpt: "ls: cannot access",
+        })).toBe("unknown");
+        expect(classifyCommandOutcome({
+            command_norm: "bun run",
+            command_text: "bun run typecheck",
+            has_error: true,
+            exit_code: 1,
+            output_excerpt: "error TS2322: type mismatch",
+        })).toBe("expected_feedback");
+        expect(classifyCommandOutcome({
+            command_norm: "oxlint",
+            command_text: "oxlint --deny-warnings",
+            has_error: true,
+            exit_code: 1,
+            output_excerpt: "lint warnings found",
+        })).toBe("expected_feedback");
+    });
+
     test("classifies search misses and environment blockers", () => {
         expect(classifyCommandOutcome({ command_norm: "rg", has_error: true, exit_code: 1, output_excerpt: "no matches" })).toBe("search_miss");
         expect(classifyCommandOutcome({ command_norm: "surreal", has_error: true, error_text: "connection refused" })).toBe("environment_blocker");

--- a/apps/axctl/src/ingest/outcomes.ts
+++ b/apps/axctl/src/ingest/outcomes.ts
@@ -6,6 +6,7 @@ import { recordRef } from "./evidence-writers.ts";
 import { surrealDate, surrealJsonOption, surrealObject, surrealOptionDate, surrealOptionString, surrealString } from "@ax/lib/shared/surql";
 import { executeStatementsWith } from "@ax/lib/shared/statement-exec";
 import { isoTimestamp, recordKeyPart, safeKeyPart, type TimestampInput } from "@ax/lib/shared/derive-keys";
+import { checkFamilyFromCommand } from "./check-family.ts";
 
 export type CommandOutcomeKind =
     | "success"
@@ -87,7 +88,7 @@ export function classifyCommandOutcome(row: ToolCallOutcomeRow): CommandOutcomeK
     if (/\b(rg|grep|find|fd)\b/.test(command) && (row.exit_code === 1 || /no matches|not found|0 results/.test(text))) return "search_miss";
     if (/--exit-code|git diff|git status --porcelain|guardrail|preflight/.test(command)) return "guardrail";
     if (/command not found|enoent|econnrefused|connection refused|auth|permission denied|network|port|daemon|database/.test(text)) return "environment_blocker";
-    if (/\b(test|typecheck|tsc|tsgo|lint|oxc|build|check)\b/.test(command)) {
+    if (checkFamilyFromCommand(row.command_text) !== null || checkFamilyFromCommand(row.command_norm) !== null) {
         if (/fail|error|expected|assert|type|lint|diagnostic|compile/.test(text)) return "expected_feedback";
         return "product_bug_signal";
     }

--- a/apps/axctl/src/ingest/tool-calls.ts
+++ b/apps/axctl/src/ingest/tool-calls.ts
@@ -201,6 +201,16 @@ function extractCommandTokens(command: string | null | undefined): string[] | nu
     return null;
 }
 
+/** All shell segments of a command, each stripped of env/cd/wrapper prefixes. */
+export function commandTokenSegments(command: string | null | undefined): string[][] {
+    const tokens = tokenizeShell(command ?? "");
+    if (tokens.length === 0) return [];
+
+    return commandSegments(tokens)
+        .map((segment) => stripCommandPrefixes(segment))
+        .filter((segment) => segment.length > 0);
+}
+
 function tokenizeShell(command: string): string[] {
     const tokens: string[] = [];
     let current = "";

--- a/apps/axctl/src/metrics/aggregates.ts
+++ b/apps/axctl/src/metrics/aggregates.ts
@@ -26,7 +26,7 @@ import type { DbError } from "@ax/lib/errors";
 import { recordLiteral } from "@ax/lib/ids";
 import { skillRecordLookupKeys } from "@ax/lib/skill-id";
 import { dateField } from "@ax/lib/shared/row-fields";
-import { surrealDate, surrealString } from "@ax/lib/shared/surql";
+import { surrealDate } from "@ax/lib/shared/surql";
 import { fetchSessionCostMap } from "./cost-estimate.ts";
 import { fetchSessionHealthMap } from "./session-metrics-query.ts";
 import { cleanSessionId, isoMs, metricPct, numOrNull, numOrZero, strOrNull } from "./util.ts";

--- a/apps/axctl/src/metrics/aggregates.ts
+++ b/apps/axctl/src/metrics/aggregates.ts
@@ -30,6 +30,7 @@ import { surrealDate, surrealString } from "@ax/lib/shared/surql";
 import { fetchSessionCostMap } from "./cost-estimate.ts";
 import { fetchSessionHealthMap } from "./session-metrics-query.ts";
 import { cleanSessionId, isoMs, metricPct, numOrNull, numOrZero, strOrNull } from "./util.ts";
+import { sessionProjectClause } from "./session-filter.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -354,10 +355,7 @@ export const fetchAggregateRows = (
         const db = yield* SurrealClient;
         const clauses: string[] = [];
         if (input.since) clauses.push(`session.started_at >= ${surrealDate(input.since)}`);
-        if (input.project) {
-            const project = surrealString(input.project);
-            clauses.push(`(session.project = ${project} OR session.cwd = ${project})`);
-        }
+        if (input.project) clauses.push(sessionProjectClause(input.project, "session."));
         const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
         const metrics = (yield* db.query<[Array<Record<string, unknown>>]>(`
 SELECT

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -54,6 +54,7 @@ const db = (input: {
     outcomes?: Array<Record<string, unknown>>;
     hooks?: Array<Record<string, unknown>>;
     seenSql?: string[];
+    respectBaseLimit?: boolean;
 }) =>
     Layer.succeed(SurrealClient, {
         query: <T>(sql: string) => {
@@ -64,7 +65,9 @@ const db = (input: {
             if (sql.includes("FROM tool_call")) return Effect.succeed([input.edits ?? []] as unknown as T);
             if (sql.includes("FROM command_outcome")) return Effect.succeed([input.outcomes ?? []] as unknown as T);
             if (sql.includes("FROM hook_command_invocation")) return Effect.succeed([input.hooks ?? []] as unknown as T);
-            return Effect.succeed([input.base] as unknown as T);
+            const limit = input.respectBaseLimit ? Number(sql.match(/\bLIMIT\s+(\d+)/)?.[1] ?? NaN) : NaN;
+            const base = Number.isFinite(limit) ? input.base.slice(0, limit) : input.base;
+            return Effect.succeed([base] as unknown as T);
         },
     } as never);
 
@@ -302,6 +305,41 @@ describe("fetchSessionChurnSummary", () => {
         expect(seenSql[0]).toContain("FROM session_metrics");
     });
 
+    test("limit only caps hot sessions after ranking, not the base session scan", async () => {
+        const seenSql: string[] = [];
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 1,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            respectBaseLimit: true,
+            seenSql,
+            base: [
+                { session: "session:`newer-quiet`", source: "codex" },
+                { session: "session:`older-hot`", source: "codex" },
+                { session: "session:`older-warm`", source: "codex" },
+            ],
+            edits: [
+                { session: "session:`older-hot`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+                { session: "session:`older-warm`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+            ],
+            outcomes: [
+                { session: "session:`older-hot`", ts: "2026-06-11T00:02:00.000Z", status: "error", command_norm: "tsc" },
+                { session: "session:`older-hot`", ts: "2026-06-11T00:03:00.000Z", status: "error", command_norm: "eslint" },
+                { session: "session:`older-warm`", ts: "2026-06-11T00:02:00.000Z", status: "error", command_norm: "tsc" },
+            ],
+        }))));
+
+        const baseSql = seenSql.find((s) => s.includes("FROM session_metrics"))!;
+        expect(baseSql).not.toContain("LIMIT 1");
+        expect(summary.hotSessions.map((row) => row.session)).toEqual(["older-hot"]);
+        expect(summary.aggregates).toHaveLength(1);
+        expect(summary.aggregates[0]).toMatchObject({
+            sessions: 2,
+            verificationFailures: 3,
+        });
+    });
+
     test("landed LOC joins produced commits to touched files in JS", async () => {
         const summary = await Effect.runPromise(fetchSessionChurnSummary({
             since: null,
@@ -382,6 +420,60 @@ describe("fetchSessionChurnSummary", () => {
             passedEpisodes: 2,
         });
         expect(summary.hotSessions[0].topCheck).toBe("eslint");
+    });
+
+    test("successful command_outcome text does not classify or close verification episodes", async () => {
+        const seenSql: string[] = [];
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            seenSql,
+            base: [{ session: "session:`s1`", source: "codex" }],
+            edits: [
+                { session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+                { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "b", new_string: "b\nc" }) },
+            ],
+            outcomes: [
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "expected_feedback", status: "error", command_norm: "tsc" },
+                { session: "session:`s1`", ts: "2026-06-11T00:04:00.000Z", kind: "success", status: "ok", command_norm: "cat", text: "README mentions bun test and build" },
+                { session: "session:`s1`", ts: "2026-06-11T00:05:00.000Z", kind: "success", status: "ok", command_norm: "bun test" },
+            ],
+        }))));
+
+        const outcomeSql = seenSql.find((s) => s.includes("FROM command_outcome"))!;
+        expect(outcomeSql).toContain('AND (kind = "expected_feedback" OR status = "ok")');
+        expect(summary.hotSessions[0]).toMatchObject({
+            session: "s1",
+            verificationFailures: 1,
+            verificationPasses: 1,
+            episodes: 1,
+            passedEpisodes: 0,
+            repairLinesAdded: 2,
+        });
+    });
+
+    test("command_text takes precedence over command_norm and tool names", async () => {
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            base: [{ session: "session:`s1`", source: "codex" }],
+            edits: [{ session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) }],
+            outcomes: [
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "expected_feedback", status: "error", command_text: "bun run typecheck", command_norm: "bun", command_tool: "test" },
+                { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", kind: "success", status: "ok", command_text: "bun run typecheck", command_norm: "bun", command_tool: "test" },
+            ],
+        }))));
+
+        expect(summary.hotSessions[0]).toMatchObject({
+            topCheck: "typecheck",
+            verificationFailures: 1,
+            verificationPasses: 1,
+            passedEpisodes: 1,
+        });
     });
 });
 

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -189,6 +189,44 @@ describe("computeSessionChurn", () => {
         });
     });
 
+    test("open episodes expire after 30 minutes and stop tainting edits", () => {
+        const M = 60_000;
+        const summary = computeSessionChurn([
+            edit("s1", 1 * M, 2),
+            fail("s1", 2 * M, "typecheck"),
+            edit("s1", 5 * M, 3, 1),
+            edit("s1", 40 * M, 50, 10),
+            pass("s1", 41 * M, "typecheck"),
+        ], landed([]), health([]));
+
+        expect(summary.hotSessions[0]).toMatchObject({
+            episodes: 1,
+            passedEpisodes: 0,
+            repairLinesAdded: 3,
+            repairLinesRemoved: 1,
+            verificationPasses: 1,
+        });
+    });
+
+    test("repeated failures refresh the episode expiry window", () => {
+        const M = 60_000;
+        const summary = computeSessionChurn([
+            edit("s1", 1 * M, 2),
+            fail("s1", 2 * M, "typecheck"),
+            fail("s1", 25 * M, "typecheck"),
+            edit("s1", 50 * M, 7, 2),
+            pass("s1", 51 * M, "typecheck"),
+        ], landed([]), health([]));
+
+        expect(summary.hotSessions[0]).toMatchObject({
+            episodes: 1,
+            passedEpisodes: 1,
+            verificationFailures: 2,
+            repairLinesAdded: 7,
+            repairLinesRemoved: 2,
+        });
+    });
+
     test("source aggregate includes top check and passed episode totals", () => {
         const summary = computeSessionChurn([
             edit("s1", 1, 2, 0, "codex"),

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -260,6 +260,29 @@ describe("computeSessionChurn", () => {
         }]);
     });
 
+    test("source aggregates count multi-session commits once", () => {
+        const summary = computeSessionChurn([
+            edit("s1", 1, 1),
+            fail("s1", 2, "test"),
+            edit("s2", 1, 1),
+            fail("s2", 2, "test"),
+        ], landed([
+            ["s1", { added: 500, removed: 100 }],
+            ["s2", { added: 500, removed: 100 }],
+        ]), health([]), {
+            landedCommits: [{ commit: "c1", sessions: ["s1", "s2"], added: 500, removed: 100 }],
+        });
+
+        expect(summary.hotSessions.map((row) => [row.session, row.landedLinesAdded, row.landedLinesRemoved]))
+            .toEqual([["s1", 500, 100], ["s2", 500, 100]]);
+        expect(summary.aggregates).toHaveLength(1);
+        expect(summary.aggregates[0]).toMatchObject({
+            sessions: 2,
+            landedLinesAdded: 500,
+            landedLinesRemoved: 100,
+        });
+    });
+
     test("filters edit-only, pass-only, and metadata-only sessions from output rows", () => {
         const summary = computeSessionChurn([
             edit("quiet-edit", 1, 5, 1),
@@ -412,6 +435,41 @@ describe("fetchSessionChurnSummary", () => {
             landedLinesAdded: 13,
             landedLinesRemoved: 3,
             verificationFailures: 1,
+        });
+    });
+
+    test("multi-session commits land once per source aggregate when fetched", async () => {
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            base: [
+                { session: "session:`s1`", source: "codex" },
+                { session: "session:`s2`", source: "codex" },
+            ],
+            produced: [
+                { session: "session:`s1`", commit: "commit:`c1`" },
+                { session: "session:`s2`", commit: "commit:`c1`" },
+            ],
+            touched: [
+                { commit: "commit:`c1`", file: "file:`f1`", path: "src/a.ts", additions: 10, deletions: 2 },
+            ],
+            edits: [
+                { session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+                { session: "session:`s2`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+            ],
+            outcomes: [
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", status: "error", command_norm: "tsc" },
+                { session: "session:`s2`", ts: "2026-06-11T00:02:00.000Z", status: "error", command_norm: "tsc" },
+            ],
+        }))));
+
+        expect(summary.hotSessions.map((row) => row.landedLinesAdded)).toEqual([10, 10]);
+        expect(summary.aggregates[0]).toMatchObject({
+            sessions: 2,
+            landedLinesAdded: 10,
+            landedLinesRemoved: 2,
         });
     });
 

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient } from "@ax/lib/db";
 import {
     computeSessionChurn,
+    fetchSessionChurnSummary,
     formatSessionChurnSummary,
     normalizeCheckFamily,
     type ChurnEvent,
@@ -41,6 +44,29 @@ const landed = (entries: Array<readonly [string, { readonly added: number; reado
 
 const health = (entries: Array<readonly [string, string | null]>) =>
     new Map(entries);
+
+const db = (input: {
+    base: Array<Record<string, unknown>>;
+    health?: Array<Record<string, unknown>>;
+    produced?: Array<Record<string, unknown>>;
+    touched?: Array<Record<string, unknown>>;
+    edits?: Array<Record<string, unknown>>;
+    outcomes?: Array<Record<string, unknown>>;
+    hooks?: Array<Record<string, unknown>>;
+    seenSql?: string[];
+}) =>
+    Layer.succeed(SurrealClient, {
+        query: <T>(sql: string) => {
+            input.seenSql?.push(sql);
+            if (sql.includes("FROM session_health")) return Effect.succeed([input.health ?? []] as unknown as T);
+            if (sql.includes("FROM produced")) return Effect.succeed([input.produced ?? []] as unknown as T);
+            if (sql.includes("FROM touched")) return Effect.succeed([input.touched ?? []] as unknown as T);
+            if (sql.includes("FROM tool_call")) return Effect.succeed([input.edits ?? []] as unknown as T);
+            if (sql.includes("FROM command_outcome")) return Effect.succeed([input.outcomes ?? []] as unknown as T);
+            if (sql.includes("FROM hook_command_invocation")) return Effect.succeed([input.hooks ?? []] as unknown as T);
+            return Effect.succeed([input.base] as unknown as T);
+        },
+    } as never);
 
 describe("normalizeCheckFamily", () => {
     test("normalizes known verification families", () => {
@@ -242,6 +268,120 @@ describe("computeSessionChurn", () => {
             repairLinesRemoved: 1,
             verificationFailures: 1,
         });
+    });
+});
+
+describe("fetchSessionChurnSummary", () => {
+    test("base query includes since, project, and source filters", async () => {
+        const seenSql: string[] = [];
+        await Effect.runPromise(fetchSessionChurnSummary({
+            since: new Date("2026-06-01T00:00:00.000Z"),
+            project: "/repo/ax",
+            source: "codex",
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({ base: [], seenSql }))));
+
+        const baseSql = seenSql.find((s) => s.includes("FROM session_metrics"))!;
+        expect(baseSql).toContain('session.started_at >= d"2026-06-01T00:00:00.000Z"');
+        expect(baseSql).toContain('(session.project = "/repo/ax" OR session.cwd = "/repo/ax")');
+        expect(baseSql).toContain('session.source = "codex"');
+    });
+
+    test("empty base sessions skip secondary scans", async () => {
+        const seenSql: string[] = [];
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({ base: [], seenSql }))));
+
+        expect(summary.hotSessions).toEqual([]);
+        expect(summary.aggregates).toEqual([]);
+        expect(seenSql).toHaveLength(1);
+        expect(seenSql[0]).toContain("FROM session_metrics");
+    });
+
+    test("landed LOC joins produced commits to touched files in JS", async () => {
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            base: [{ session: "session:`s1`", source: "codex" }],
+            health: [{ session: "session:`s1`", task_label: "landed loc" }],
+            produced: [{ session: "session:`s1`", commit: "commit:`c1`" }],
+            touched: [
+                { commit: "commit:`c1`", file: "file:`f1`", path: "src/a.ts", additions: 10, deletions: 2 },
+                { commit: "commit:`c1`", file: "file:`f1`", path: "src/a.ts", additions: 10, deletions: 2 },
+                { commit: "commit:`c1`", file: "file:`f2`", path: "src/b.ts", additions: 3, deletions: 1 },
+            ],
+            edits: [{ session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) }],
+            outcomes: [{ session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", status: "error", command_norm: "tsc" }],
+        }))));
+
+        expect(summary.hotSessions[0]).toMatchObject({
+            session: "s1",
+            taskLabel: "landed loc",
+            landedLinesAdded: 13,
+            landedLinesRemoved: 3,
+            verificationFailures: 1,
+        });
+    });
+
+    test("edit tool rows produce line-delta edit events", async () => {
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            base: [{ session: "session:`s1`", source: "claude" }],
+            edits: [
+                { session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Write", input_json: JSON.stringify({ content: "a\nb\nc" }) },
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", name: "exec_command", command_norm: "apply_patch", input_json: JSON.stringify({ patch: "+new\n-old\n+++ b/file\n--- a/file" }) },
+            ],
+            outcomes: [{ session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", status: "error", command_norm: "bun test" }],
+        }))));
+
+        expect(summary.hotSessions[0]).toMatchObject({
+            session: "s1",
+            editEvents: 2,
+            editLinesAdded: 4,
+            editLinesRemoved: 1,
+            repairLinesAdded: 0,
+            repairLinesRemoved: 0,
+            verificationFailures: 1,
+            topCheck: "test",
+        });
+    });
+
+    test("command_outcome and hook rows produce verification fail/pass events", async () => {
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            base: [{ session: "session:`s1`", source: "codex" }],
+            edits: [{ session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) }],
+            outcomes: [
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "expected_feedback", status: "ok", command_norm: "eslint" },
+                { session: "session:`s1`", ts: "2026-06-11T00:04:00.000Z", kind: "check", status: "ok", command_norm: "eslint" },
+                { session: "session:`s1`", ts: "2026-06-11T00:05:00.000Z", kind: "check", status: "ok", command_norm: "deploy" },
+            ],
+            hooks: [
+                { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", provider_status: "blocking_error", effect: "blocked", exit_code: 1, command: "bun test" },
+                { session: "session:`s1`", ts: "2026-06-11T00:06:00.000Z", provider_status: "success", effect: "allowed", exit_code: null, command: "bun test" },
+            ],
+        }))));
+
+        expect(summary.hotSessions[0]).toMatchObject({
+            session: "s1",
+            verificationFailures: 2,
+            verificationPasses: 2,
+            episodes: 2,
+            passedEpisodes: 2,
+        });
+        expect(summary.hotSessions[0].topCheck).toBe("eslint");
     });
 });
 

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -95,6 +95,13 @@ describe("normalizeCheckFamily", () => {
         expect(normalizeCheckFamily("")).toBeNull();
         expect(normalizeCheckFamily("date")).toBeNull();
     });
+
+    test("does not classify commands that merely mention check keywords", () => {
+        expect(normalizeCheckFamily("ls test/")).toBeNull();
+        expect(normalizeCheckFamily("rg foo test/ -l")).toBeNull();
+        expect(normalizeCheckFamily("cat build.log")).toBeNull();
+        expect(normalizeCheckFamily("git checkout build")).toBeNull();
+    });
 });
 
 describe("computeSessionChurn", () => {
@@ -454,6 +461,49 @@ describe("fetchSessionChurnSummary", () => {
             passedEpisodes: 0,
             repairLinesAdded: 2,
         });
+    });
+
+    test("incidental keyword successes and hook names do not close episodes", async () => {
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            base: [{ session: "session:`s1`", source: "claude" }],
+            edits: [{ session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) }],
+            outcomes: [
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "expected_feedback", status: "error", command_text: "bun test" },
+                { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", kind: "success", status: "ok", command_text: "ls test/" },
+            ],
+            hooks: [
+                { session: "session:`s1`", ts: "2026-06-11T00:04:00.000Z", provider_status: "success", effect: "allowed", exit_code: 0, command: "bun /Users/x/.ax/hooks/guard.ts", hook_name: "bun-test-blocking" },
+            ],
+        }))));
+
+        expect(summary.hotSessions[0]).toMatchObject({
+            session: "s1",
+            verificationFailures: 1,
+            verificationPasses: 0,
+            episodes: 1,
+            passedEpisodes: 0,
+        });
+    });
+
+    test("fail-side output text never infers a check family", async () => {
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            base: [{ session: "session:`s1`", source: "claude" }],
+            edits: [{ session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) }],
+            outcomes: [
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "unknown", status: "error", command_text: "git push", text: "remote: check your credentials" },
+            ],
+        }))));
+
+        expect(summary.hotSessions).toEqual([]);
+        expect(summary.aggregates).toEqual([]);
     });
 
     test("command_text takes precedence over command_norm and tool names", async () => {

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -444,6 +444,7 @@ describe("fetchSessionChurnSummary", () => {
         }))));
 
         const outcomeSql = seenSql.find((s) => s.includes("FROM command_outcome"))!;
+        expect(outcomeSql).toContain("tool_call.command_text AS command_text");
         expect(outcomeSql).toContain('AND (kind = "expected_feedback" OR status = "ok")');
         expect(summary.hotSessions[0]).toMatchObject({
             session: "s1",

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -53,6 +53,7 @@ const db = (input: {
     edits?: Array<Record<string, unknown>>;
     outcomes?: Array<Record<string, unknown>>;
     hooks?: Array<Record<string, unknown>>;
+    toolTexts?: Array<Record<string, unknown>>;
     seenSql?: string[];
     respectBaseLimit?: boolean;
 }) =>
@@ -62,6 +63,7 @@ const db = (input: {
             if (sql.includes("FROM session_health")) return Effect.succeed([input.health ?? []] as unknown as T);
             if (sql.includes("FROM produced")) return Effect.succeed([input.produced ?? []] as unknown as T);
             if (sql.includes("FROM touched")) return Effect.succeed([input.touched ?? []] as unknown as T);
+            if (sql.includes("FROM tool_call") && sql.includes("WHERE id IN")) return Effect.succeed([input.toolTexts ?? []] as unknown as T);
             if (sql.includes("FROM tool_call")) return Effect.succeed([input.edits ?? []] as unknown as T);
             if (sql.includes("FROM command_outcome")) return Effect.succeed([input.outcomes ?? []] as unknown as T);
             if (sql.includes("FROM hook_command_invocation")) return Effect.succeed([input.hooks ?? []] as unknown as T);
@@ -451,8 +453,8 @@ describe("fetchSessionChurnSummary", () => {
         }))));
 
         const outcomeSql = seenSql.find((s) => s.includes("FROM command_outcome"))!;
-        expect(outcomeSql).toContain("tool_call.command_text AS command_text");
-        expect(outcomeSql).toContain('AND (kind = "expected_feedback" OR status = "ok")');
+        expect(outcomeSql).not.toContain("tool_call.command_text");
+        expect(outcomeSql).not.toContain('kind = "expected_feedback"');
         expect(summary.hotSessions[0]).toMatchObject({
             session: "s1",
             verificationFailures: 1,
@@ -472,8 +474,8 @@ describe("fetchSessionChurnSummary", () => {
             base: [{ session: "session:`s1`", source: "claude" }],
             edits: [{ session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) }],
             outcomes: [
-                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "expected_feedback", status: "error", command_text: "bun test" },
-                { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", kind: "success", status: "ok", command_text: "ls test/" },
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "expected_feedback", status: "error", command_norm: "bun test" },
+                { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", kind: "success", status: "ok", command_norm: "ls" },
             ],
             hooks: [
                 { session: "session:`s1`", ts: "2026-06-11T00:04:00.000Z", provider_status: "success", effect: "allowed", exit_code: 0, command: "bun /Users/x/.ax/hooks/guard.ts", hook_name: "bun-test-blocking" },
@@ -506,7 +508,7 @@ describe("fetchSessionChurnSummary", () => {
         expect(summary.aggregates).toEqual([]);
     });
 
-    test("command_text takes precedence over command_norm and tool names", async () => {
+    test("error rows of any outcome kind count as verification failures", async () => {
         const summary = await Effect.runPromise(fetchSessionChurnSummary({
             since: null,
             limit: 20,
@@ -515,11 +517,43 @@ describe("fetchSessionChurnSummary", () => {
             base: [{ session: "session:`s1`", source: "codex" }],
             edits: [{ session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) }],
             outcomes: [
-                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "expected_feedback", status: "error", command_text: "bun run typecheck", command_norm: "bun", command_tool: "test" },
-                { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", kind: "success", status: "ok", command_text: "bun run typecheck", command_norm: "bun", command_tool: "test" },
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "product_bug_signal", status: "error", command_norm: "bun test" },
+                { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", kind: "environment_blocker", status: "error", command_norm: "tsc" },
+                { session: "session:`s1`", ts: "2026-06-11T00:04:00.000Z", kind: "unknown", status: "error", command_norm: "git push" },
             ],
         }))));
 
+        expect(summary.hotSessions[0]).toMatchObject({
+            session: "s1",
+            verificationFailures: 2,
+            episodes: 2,
+        });
+    });
+
+    test("ambiguous runner norms resolve via batched tool_call text lookup", async () => {
+        const seenSql: string[] = [];
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            seenSql,
+            base: [{ session: "session:`s1`", source: "codex" }],
+            edits: [{ session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) }],
+            outcomes: [
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", kind: "product_bug_signal", status: "error", command_norm: "bun run", tool_call_ref: "tool_call:`tc1`" },
+                { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", kind: "success", status: "ok", command_norm: "bun run", tool_call_ref: "tool_call:`tc2`" },
+                { session: "session:`s1`", ts: "2026-06-11T00:04:00.000Z", kind: "success", status: "ok", command_norm: "bun run", tool_call_ref: "tool_call:`tc3`" },
+            ],
+            toolTexts: [
+                { id: "tool_call:`tc1`", command_text: "bun run typecheck" },
+                { id: "tool_call:`tc2`", command_text: "bun run typecheck" },
+                { id: "tool_call:`tc3`", command_text: "bun run dev" },
+            ],
+        }))));
+
+        const lookupSql = seenSql.find((s) => s.includes("WHERE id IN"))!;
+        expect(lookupSql).toContain("FROM tool_call");
         expect(summary.hotSessions[0]).toMatchObject({
             topCheck: "typecheck",
             verificationFailures: 1,

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -355,11 +355,13 @@ describe("fetchSessionChurnSummary", () => {
             generatedAt: new Date("2026-06-11T00:00:00.000Z"),
         }).pipe(Effect.provide(db({ base: [], seenSql }))));
 
-        const baseSql = seenSql.find((s) => s.includes("FROM session_metrics"))!;
-        expect(baseSql).toContain("session.started_at AS started_at");
-        expect(baseSql).toContain('session.started_at >= d"2026-06-01T00:00:00.000Z"');
-        expect(baseSql).toContain('(session.project = "/repo/ax" OR session.cwd = "/repo/ax")');
-        expect(baseSql).toContain('session.source = "codex"');
+        const baseSql = seenSql[0]!;
+        expect(baseSql).toContain("FROM session");
+        expect(baseSql).not.toContain("session_metrics");
+        expect(baseSql).not.toContain("ORDER BY");
+        expect(baseSql).toContain('started_at >= d"2026-06-01T00:00:00.000Z"');
+        expect(baseSql).toContain('cwd = "/repo/ax"');
+        expect(baseSql).toContain('source = "codex"');
     });
 
     test("empty base sessions skip secondary scans", async () => {
@@ -373,7 +375,8 @@ describe("fetchSessionChurnSummary", () => {
         expect(summary.hotSessions).toEqual([]);
         expect(summary.aggregates).toEqual([]);
         expect(seenSql).toHaveLength(1);
-        expect(seenSql[0]).toContain("FROM session_metrics");
+        expect(seenSql[0]).toContain("FROM session");
+        expect(seenSql[0]).not.toContain("session_metrics");
     });
 
     test("limit only caps hot sessions after ranking, not the base session scan", async () => {
@@ -401,7 +404,8 @@ describe("fetchSessionChurnSummary", () => {
             ],
         }))));
 
-        const baseSql = seenSql.find((s) => s.includes("FROM session_metrics"))!;
+        const baseSql = seenSql[0]!;
+        expect(baseSql).toContain("FROM session");
         expect(baseSql).not.toContain("LIMIT 1");
         expect(summary.hotSessions.map((row) => row.session)).toEqual(["older-hot"]);
         expect(summary.aggregates).toHaveLength(1);

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import {
+    computeSessionChurn,
+    formatSessionChurnSummary,
+    normalizeCheckFamily,
+    type ChurnEvent,
+} from "./session-churn.ts";
+
+const edit = (session: string, tsMs: number, linesAdded: number, linesRemoved = 0, source = "codex"): ChurnEvent => ({
+    session,
+    source,
+    tsMs,
+    kind: "edit",
+    check: null,
+    linesAdded,
+    linesRemoved,
+});
+
+const fail = (session: string, tsMs: number, check: string, source = "codex"): ChurnEvent => ({
+    session,
+    source,
+    tsMs,
+    kind: "verification_fail",
+    check,
+    linesAdded: 0,
+    linesRemoved: 0,
+});
+
+const pass = (session: string, tsMs: number, check: string, source = "codex"): ChurnEvent => ({
+    session,
+    source,
+    tsMs,
+    kind: "verification_pass",
+    check,
+    linesAdded: 0,
+    linesRemoved: 0,
+});
+
+const landed = (entries: Array<readonly [string, { readonly added: number; readonly removed: number }]>) =>
+    new Map(entries);
+
+const health = (entries: Array<readonly [string, string | null]>) =>
+    new Map(entries);
+
+describe("normalizeCheckFamily", () => {
+    test("normalizes known verification families", () => {
+        expect(normalizeCheckFamily("bun test apps/foo.test.ts")).toBe("test");
+        expect(normalizeCheckFamily("vitest run")).toBe("test");
+        expect(normalizeCheckFamily("jest")).toBe("test");
+        expect(normalizeCheckFamily("playwright test")).toBe("test");
+        expect(normalizeCheckFamily("bun run typecheck")).toBe("typecheck");
+        expect(normalizeCheckFamily("tsc --noEmit")).toBe("typecheck");
+        expect(normalizeCheckFamily("tsgo")).toBe("typecheck");
+        expect(normalizeCheckFamily("oxlint --fix")).toBe("oxlint");
+        expect(normalizeCheckFamily("eslint src")).toBe("eslint");
+        expect(normalizeCheckFamily("bun run build")).toBe("build");
+        expect(normalizeCheckFamily("cargo check")).toBe("check");
+    });
+
+    test("returns null for unknown or empty checks", () => {
+        expect(normalizeCheckFamily(null)).toBeNull();
+        expect(normalizeCheckFamily("")).toBeNull();
+        expect(normalizeCheckFamily("date")).toBeNull();
+    });
+});
+
+describe("computeSessionChurn", () => {
+    test("failure before any edit does not start an episode", () => {
+        const summary = computeSessionChurn([
+            fail("s1", 1, "typecheck"),
+            edit("s1", 2, 5, 1),
+        ], landed([]), health([]));
+
+        expect(summary.hotSessions).toHaveLength(1);
+        expect(summary.hotSessions[0]).toMatchObject({
+            session: "s1",
+            verificationFailures: 1,
+            episodes: 0,
+            repairLinesAdded: 0,
+            repairLinesRemoved: 0,
+        });
+    });
+
+    test("counts repair churn after failure and before same-check pass", () => {
+        const summary = computeSessionChurn([
+            edit("s1", 1, 10, 1),
+            fail("s1", 2, "tsc --noEmit"),
+            edit("s1", 3, 4, 2),
+            pass("s1", 4, "typecheck"),
+            edit("s1", 5, 20, 8),
+        ], landed([["s1", { added: 7, removed: 3 }]]), health([["s1", "fix type errors"]]));
+
+        expect(summary.hotSessions[0]).toMatchObject({
+            session: "s1",
+            taskLabel: "fix type errors",
+            landedLinesAdded: 7,
+            landedLinesRemoved: 3,
+            editLinesAdded: 34,
+            editLinesRemoved: 11,
+            repairLinesAdded: 4,
+            repairLinesRemoved: 2,
+            editEvents: 3,
+            verificationFailures: 1,
+            verificationPasses: 1,
+            episodes: 1,
+            passedEpisodes: 1,
+            topCheck: "typecheck",
+        });
+    });
+
+    test("repeated same-check failure increments failures but does not double-count repair edits", () => {
+        const summary = computeSessionChurn([
+            edit("s1", 1, 3),
+            fail("s1", 2, "oxlint"),
+            edit("s1", 3, 5, 2),
+            fail("s1", 4, "oxlint"),
+            edit("s1", 5, 7, 1),
+            pass("s1", 6, "oxlint"),
+        ], landed([]), health([]));
+
+        expect(summary.hotSessions[0]).toMatchObject({
+            verificationFailures: 2,
+            episodes: 1,
+            passedEpisodes: 1,
+            repairLinesAdded: 12,
+            repairLinesRemoved: 3,
+            topCheck: "oxlint",
+        });
+    });
+
+    test("multiple open checks do not double-count one repair edit in headline repair LOC", () => {
+        const summary = computeSessionChurn([
+            edit("s1", 1, 1),
+            fail("s1", 2, "typecheck"),
+            fail("s1", 3, "eslint"),
+            edit("s1", 4, 9, 4),
+            pass("s1", 5, "typecheck"),
+            pass("s1", 6, "eslint"),
+        ], landed([]), health([]));
+
+        expect(summary.hotSessions[0]).toMatchObject({
+            verificationFailures: 2,
+            episodes: 2,
+            passedEpisodes: 2,
+            repairLinesAdded: 9,
+            repairLinesRemoved: 4,
+        });
+    });
+
+    test("source aggregate includes top check and passed episode totals", () => {
+        const summary = computeSessionChurn([
+            edit("s1", 1, 2, 0, "codex"),
+            fail("s1", 2, "typecheck", "codex"),
+            edit("s1", 3, 3, 1, "codex"),
+            pass("s1", 4, "typecheck", "codex"),
+            edit("s2", 1, 1, 0, "codex"),
+            fail("s2", 2, "typecheck", "codex"),
+            edit("s2", 3, 4, 2, "codex"),
+            fail("s2", 4, "eslint", "codex"),
+            edit("s2", 5, 6, 3, "codex"),
+        ], landed([
+            ["s1", { added: 5, removed: 1 }],
+            ["s2", { added: 8, removed: 2 }],
+        ]), health([]));
+
+        expect(summary.aggregates).toEqual([{
+            source: "codex",
+            sessions: 2,
+            sessionsWithFailures: 2,
+            landedLinesAdded: 13,
+            landedLinesRemoved: 3,
+            editLinesAdded: 16,
+            editLinesRemoved: 6,
+            repairLinesAdded: 13,
+            repairLinesRemoved: 6,
+            verificationFailures: 3,
+            episodes: 3,
+            passedEpisodes: 1,
+            topCheck: "typecheck",
+        }]);
+    });
+});
+
+describe("formatSessionChurnSummary", () => {
+    test("renders the empty formatter hint", () => {
+        const summary = computeSessionChurn([], landed([]), health([]));
+
+        expect(formatSessionChurnSummary(summary)).toBe(
+            "no verification churn rows matched (run `ax ingest`, or loosen --since/--source/--here).",
+        );
+    });
+});

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -286,6 +286,7 @@ describe("fetchSessionChurnSummary", () => {
         }).pipe(Effect.provide(db({ base: [], seenSql }))));
 
         const baseSql = seenSql.find((s) => s.includes("FROM session_metrics"))!;
+        expect(baseSql).toContain("session.started_at AS started_at");
         expect(baseSql).toContain('session.started_at >= d"2026-06-01T00:00:00.000Z"');
         expect(baseSql).toContain('(session.project = "/repo/ax" OR session.cwd = "/repo/ax")');
         expect(baseSql).toContain('session.source = "codex"');

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -664,6 +664,19 @@ describe("fetchSessionChurnSummary", () => {
 });
 
 describe("formatSessionChurnSummary", () => {
+    test("flattens and truncates multi-line task labels in the table", () => {
+        const summary = computeSessionChurn([
+            edit("s1", 1, 1),
+            fail("s1", 2, "test"),
+        ], landed([]), health([["s1", "<goal_context>\nContinue working toward the active thread goal.\nMore lines here that go on and on beyond any reasonable width."]]));
+
+        const rendered = formatSessionChurnSummary(summary);
+        const taskLines = rendered.split("\n").filter((line) => line.includes("<goal_context>"));
+        expect(taskLines).toHaveLength(1);
+        expect(taskLines[0]!.length).toBeLessThanOrEqual(160);
+        expect(rendered).not.toContain("Continue working");
+    });
+
     test("renders the empty formatter hint", () => {
         const summary = computeSessionChurn([], landed([]), health([]));
 

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -53,6 +53,10 @@ describe("normalizeCheckFamily", () => {
         expect(normalizeCheckFamily("tsgo")).toBe("typecheck");
         expect(normalizeCheckFamily("oxlint --fix")).toBe("oxlint");
         expect(normalizeCheckFamily("eslint src")).toBe("eslint");
+        expect(normalizeCheckFamily("bun run lint")).toBe("lint");
+        expect(normalizeCheckFamily("pnpm lint")).toBe("lint");
+        expect(normalizeCheckFamily("npm run lint")).toBe("lint");
+        expect(normalizeCheckFamily("lint")).toBe("lint");
         expect(normalizeCheckFamily("bun run build")).toBe("build");
         expect(normalizeCheckFamily("cargo check")).toBe("check");
     });
@@ -178,6 +182,66 @@ describe("computeSessionChurn", () => {
             passedEpisodes: 1,
             topCheck: "typecheck",
         }]);
+    });
+
+    test("filters edit-only, pass-only, and metadata-only sessions from output rows", () => {
+        const summary = computeSessionChurn([
+            edit("quiet-edit", 1, 5, 1),
+            pass("quiet-pass", 1, "typecheck"),
+            edit("noisy", 1, 1),
+            fail("noisy", 2, "typecheck"),
+        ], landed([
+            ["metadata-only", { added: 20, removed: 4 }],
+            ["noisy", { added: 3, removed: 1 }],
+        ]), health([
+            ["metadata-only", "quiet metadata"],
+            ["quiet-edit", "quiet edit"],
+            ["quiet-pass", "quiet pass"],
+            ["noisy", "has verification signal"],
+        ]));
+
+        expect(summary.hotSessions.map((row) => row.session)).toEqual(["noisy"]);
+        expect(summary.aggregates).toHaveLength(1);
+        expect(summary.aggregates[0]).toMatchObject({
+            sessions: 1,
+            landedLinesAdded: 3,
+            editLinesAdded: 1,
+            verificationFailures: 1,
+        });
+    });
+
+    test("returns empty output when all sessions are quiet", () => {
+        const summary = computeSessionChurn([
+            edit("quiet-edit", 1, 5, 1),
+            pass("quiet-pass", 1, "typecheck"),
+        ], landed([["metadata-only", { added: 20, removed: 4 }]]), health([["metadata-only", "quiet metadata"]]));
+
+        expect(summary.hotSessions).toEqual([]);
+        expect(summary.aggregates).toEqual([]);
+        expect(formatSessionChurnSummary(summary)).toBe(
+            "no verification churn rows matched (run `ax ingest`, or loosen --since/--source/--here).",
+        );
+    });
+
+    test("normalizes DB-shaped and bare session ids across events and metadata maps", () => {
+        const summary = computeSessionChurn([
+            edit("session:`mixed-1`", 1, 6, 2),
+            fail("session:`mixed-1`", 2, "typecheck"),
+            edit("session:`mixed-1`", 3, 4, 1),
+        ], landed([["mixed-1", { added: 9, removed: 3 }]]), health([["session:⟨mixed-1⟩", "mixed task"]]));
+
+        expect(summary.hotSessions).toHaveLength(1);
+        expect(summary.hotSessions[0]).toMatchObject({
+            session: "mixed-1",
+            taskLabel: "mixed task",
+            landedLinesAdded: 9,
+            landedLinesRemoved: 3,
+            editLinesAdded: 10,
+            editLinesRemoved: 3,
+            repairLinesAdded: 4,
+            repairLinesRemoved: 1,
+            verificationFailures: 1,
+        });
     });
 });
 

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -12,6 +12,7 @@ import {
     toolClassInputOf,
 } from "@ax/lib/shared/tool-classes";
 import { editDelta } from "../dashboard/loc-query.ts";
+import { coerceCheckFamily } from "../ingest/check-family.ts";
 import { applyPatchDelta } from "./session-loc.ts";
 import { fetchSessionHealthMap } from "./session-metrics-query.ts";
 import { cleanSessionId } from "./util.ts";
@@ -140,20 +141,10 @@ interface MutableAggregateState {
 const DEFAULT_LIMIT = 10;
 const IN_CHUNK = 500;
 
-export const normalizeCheckFamily = (raw: string | null): string | null => {
-    if (raw === null) return null;
-    const text = raw.trim().toLowerCase();
-    if (text.length === 0) return null;
-
-    if (/\boxlint\b/.test(text) || /\boxc\b/.test(text)) return "oxlint";
-    if (/\beslint\b/.test(text)) return "eslint";
-    if (/\blint\b/.test(text)) return "lint";
-    if (/\b(tsc|typecheck|tsgo)\b/.test(text)) return "typecheck";
-    if (/\b(bun\s+test|vitest|jest|playwright|test)\b/.test(text)) return "test";
-    if (/\bbuild\b/.test(text)) return "build";
-    if (/\bcheck\b/.test(text)) return "check";
-    return null;
-};
+// Accepts an already-canonical family ("test") or a raw command ("bun test");
+// raw commands classify only when the check is in command position.
+export const normalizeCheckFamily = (raw: string | null): string | null =>
+    coerceCheckFamily(raw);
 
 export const computeSessionChurn = (
     events: readonly ChurnEvent[],
@@ -432,7 +423,7 @@ const fetchCommandOutcomeEvents = (
                     ? "verification_pass"
                     : null;
             if (eventKind === null) continue;
-            const check = commandOutcomeCheck(row, eventKind);
+            const check = commandOutcomeCheck(row);
             if (session.length === 0 || tsMs === null || check === null) continue;
             events.push({
                 session,
@@ -468,7 +459,9 @@ const fetchHookEvents = (
         for (const row of rows) {
             const session = cleanSessionId(String(row.session ?? ""));
             const tsMs = msOrNull(row.ts);
-            const check = normalizedCheckFrom(row.command, row.hook_name);
+            // Classify by the hook's command only - hook_name keywords (e.g.
+            // "bun-test-blocking") must not register as verification events.
+            const check = normalizedCheckFrom(row.command);
             if (session.length === 0 || tsMs === null || check === null) continue;
             const providerStatus = strOrNull(row.provider_status);
             const effect = strOrNull(row.effect);
@@ -725,13 +718,11 @@ const normalizedCheckFrom = (...values: readonly unknown[]): string | null => {
     return null;
 };
 
-const commandOutcomeCheck = (
-    row: Record<string, unknown>,
-    eventKind: "verification_fail" | "verification_pass",
-): string | null =>
-    eventKind === "verification_fail"
-        ? normalizedCheckFrom(row.command_text, row.command_norm, row.command_tool, row.text)
-        : normalizedCheckFrom(row.command_text, row.command_norm, row.command_tool);
+// Classify strictly from the command itself (text, then normalized form).
+// Output text and the provider tool name (command_tool) are never consulted -
+// "remote: check your credentials" is not a check run.
+const commandOutcomeCheck = (row: Record<string, unknown>): string | null =>
+    normalizedCheckFrom(row.command_text, row.command_norm);
 
 const exitCodeOf = (value: unknown): number | null => {
     if (value === null || value === undefined) return null;

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -14,6 +14,7 @@ import {
 import { editDelta } from "../dashboard/loc-query.ts";
 import { checkFamilyFromCommand, coerceCheckFamily, commandNormNeedsText } from "../ingest/check-family.ts";
 import { applyPatchDelta } from "./session-loc.ts";
+import { sessionProjectClause } from "./session-filter.ts";
 import { fetchSessionHealthMap } from "./session-metrics-query.ts";
 import { cleanSessionId } from "./util.ts";
 import { chunked, numOrZero, sessionRefList, strOrNull } from "./util.ts";
@@ -272,10 +273,7 @@ export const fetchSessionChurnSummary = (
         // irrelevant here - ids feed a Set and events are re-sorted in JS.
         const clauses: string[] = [];
         if (input.since) clauses.push(`started_at >= ${surrealDate(input.since)}`);
-        if (project !== null) {
-            const projectSql = surrealString(project);
-            clauses.push(`(project = ${projectSql} OR cwd = ${projectSql})`);
-        }
+        if (project !== null) clauses.push(sessionProjectClause(project));
         if (source !== null) clauses.push(`source = ${surrealString(source)}`);
         const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
         const baseRows = (yield* db.query<[Array<Record<string, unknown>>]>(`

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -262,7 +262,7 @@ export const fetchSessionChurnSummary = (
         if (source !== null) clauses.push(`session.source = ${surrealString(source)}`);
         const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
         const baseRows = (yield* db.query<[Array<Record<string, unknown>>]>(`
-SELECT type::string(session) AS session, session.source AS source
+SELECT type::string(session) AS session, session.source AS source, session.started_at AS started_at
 FROM session_metrics
 ${where}
 ORDER BY session.started_at DESC;`))?.[0] ?? [];

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -412,7 +412,7 @@ const fetchCommandOutcomeEvents = (
         const rows = (yield* Effect.all(
             chunked(sessionIds, IN_CHUNK).map((ids) =>
                 db.query<[Array<Record<string, unknown>>]>(
-                    `SELECT type::string(session) AS session, type::string(ts) AS ts, kind, status, command_text, command_norm, command_tool, text`
+                    `SELECT type::string(session) AS session, type::string(ts) AS ts, kind, status, tool_call.command_text AS command_text, command_norm, command_tool, text`
                     + ` FROM command_outcome WHERE session IN [${sessionRefList(ids)}]`
                     + ` AND (kind = "expected_feedback" OR status = "ok") ORDER BY ts ASC;`,
                 ),

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -268,19 +268,20 @@ export const fetchSessionChurnSummary = (
         const limit = Math.min(Math.max(Math.trunc(input.limit), 1), 1000);
         const project = input.project ?? null;
         const source = input.source ?? null;
+        // Deref-free scan over session's own (indexed) columns; ordering is
+        // irrelevant here - ids feed a Set and events are re-sorted in JS.
         const clauses: string[] = [];
-        if (input.since) clauses.push(`session.started_at >= ${surrealDate(input.since)}`);
+        if (input.since) clauses.push(`started_at >= ${surrealDate(input.since)}`);
         if (project !== null) {
             const projectSql = surrealString(project);
-            clauses.push(`(session.project = ${projectSql} OR session.cwd = ${projectSql})`);
+            clauses.push(`(project = ${projectSql} OR cwd = ${projectSql})`);
         }
-        if (source !== null) clauses.push(`session.source = ${surrealString(source)}`);
+        if (source !== null) clauses.push(`source = ${surrealString(source)}`);
         const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
         const baseRows = (yield* db.query<[Array<Record<string, unknown>>]>(`
-SELECT type::string(session) AS session, session.source AS source, session.started_at AS started_at
-FROM session_metrics
-${where}
-ORDER BY session.started_at DESC;`))?.[0] ?? [];
+SELECT type::string(id) AS session, source
+FROM session
+${where};`))?.[0] ?? [];
 
         const sessionIds = uniqueCleanSessionIds(baseRows.map((row) => String(row.session ?? "")));
         const sourceBySession = new Map<string, string | null>();

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -1,0 +1,405 @@
+export interface ChurnEvent {
+    readonly session: string;
+    readonly source: string | null;
+    readonly tsMs: number;
+    readonly kind: "edit" | "verification_fail" | "verification_pass";
+    readonly check: string | null;
+    readonly linesAdded: number;
+    readonly linesRemoved: number;
+}
+
+export interface SessionChurnRow {
+    readonly session: string;
+    readonly source: string | null;
+    readonly taskLabel: string | null;
+    readonly landedLinesAdded: number;
+    readonly landedLinesRemoved: number;
+    readonly editLinesAdded: number;
+    readonly editLinesRemoved: number;
+    readonly repairLinesAdded: number;
+    readonly repairLinesRemoved: number;
+    readonly editEvents: number;
+    readonly verificationFailures: number;
+    readonly verificationPasses: number;
+    readonly episodes: number;
+    readonly passedEpisodes: number;
+    readonly topCheck: string | null;
+}
+
+export interface SourceChurnAggregate {
+    readonly source: string;
+    readonly sessions: number;
+    readonly sessionsWithFailures: number;
+    readonly landedLinesAdded: number;
+    readonly landedLinesRemoved: number;
+    readonly editLinesAdded: number;
+    readonly editLinesRemoved: number;
+    readonly repairLinesAdded: number;
+    readonly repairLinesRemoved: number;
+    readonly verificationFailures: number;
+    readonly episodes: number;
+    readonly passedEpisodes: number;
+    readonly topCheck: string | null;
+}
+
+export interface SessionChurnSummary {
+    readonly generatedAt: string;
+    readonly filters: {
+        readonly since: string | null;
+        readonly project: string | null;
+        readonly source: string | null;
+        readonly limit: number;
+    };
+    readonly aggregates: SourceChurnAggregate[];
+    readonly hotSessions: SessionChurnRow[];
+}
+
+export interface ChurnLines {
+    readonly added: number;
+    readonly removed: number;
+}
+
+export interface SessionHealthChurnInput {
+    readonly taskLabel?: string | null;
+}
+
+export interface ComputeSessionChurnOptions {
+    readonly generatedAt?: Date | string;
+    readonly since?: Date | string | null;
+    readonly project?: string | null;
+    readonly source?: string | null;
+    readonly limit?: number;
+}
+
+interface IndexedChurnEvent extends ChurnEvent {
+    readonly index: number;
+}
+
+interface MutableSessionState {
+    session: string;
+    source: string | null;
+    taskLabel: string | null;
+    landedLinesAdded: number;
+    landedLinesRemoved: number;
+    editLinesAdded: number;
+    editLinesRemoved: number;
+    repairLinesAdded: number;
+    repairLinesRemoved: number;
+    editEvents: number;
+    verificationFailures: number;
+    verificationPasses: number;
+    episodes: number;
+    passedEpisodes: number;
+    hasPriorEdit: boolean;
+    openChecks: Set<string>;
+    checkFailures: Map<string, number>;
+}
+
+interface MutableAggregateState {
+    source: string;
+    sessions: number;
+    sessionsWithFailures: number;
+    landedLinesAdded: number;
+    landedLinesRemoved: number;
+    editLinesAdded: number;
+    editLinesRemoved: number;
+    repairLinesAdded: number;
+    repairLinesRemoved: number;
+    verificationFailures: number;
+    episodes: number;
+    passedEpisodes: number;
+}
+
+const DEFAULT_LIMIT = 10;
+
+export const normalizeCheckFamily = (raw: string | null): string | null => {
+    if (raw === null) return null;
+    const text = raw.trim().toLowerCase();
+    if (text.length === 0) return null;
+
+    if (/\boxlint\b/.test(text) || /\boxc\b/.test(text)) return "oxlint";
+    if (/\beslint\b/.test(text)) return "eslint";
+    if (/\b(tsc|typecheck|tsgo)\b/.test(text)) return "typecheck";
+    if (/\b(bun\s+test|vitest|jest|playwright|test)\b/.test(text)) return "test";
+    if (/\bbuild\b/.test(text)) return "build";
+    if (/\bcheck\b/.test(text)) return "check";
+    return null;
+};
+
+export const computeSessionChurn = (
+    events: readonly ChurnEvent[],
+    landedBySession: ReadonlyMap<string, ChurnLines>,
+    healthBySession: ReadonlyMap<string, string | null | SessionHealthChurnInput>,
+    options: ComputeSessionChurnOptions = {},
+): SessionChurnSummary => {
+    const sourceFilter = options.source ?? null;
+    const limit = Math.max(0, Math.trunc(options.limit ?? DEFAULT_LIMIT));
+    const generatedAt = dateishToIso(options.generatedAt ?? new Date());
+    const states = new Map<string, MutableSessionState>();
+    const countedRepairEditKeys = new Set<string>();
+
+    for (const session of landedBySession.keys()) {
+        getState(states, session, null, landedBySession, healthBySession);
+    }
+    for (const session of healthBySession.keys()) {
+        getState(states, session, null, landedBySession, healthBySession);
+    }
+
+    const sorted = events
+        .map((event, index): IndexedChurnEvent => ({ ...event, index }))
+        .filter((event) => sourceFilter === null || event.source === sourceFilter)
+        .sort((a, b) => a.session.localeCompare(b.session) || a.tsMs - b.tsMs || a.index - b.index);
+
+    for (const event of sorted) {
+        const state = getState(states, event.session, event.source, landedBySession, healthBySession);
+        if (state.source === null && event.source !== null) state.source = event.source;
+
+        if (event.kind === "edit") {
+            state.editEvents += 1;
+            state.editLinesAdded += nonNegative(event.linesAdded);
+            state.editLinesRemoved += nonNegative(event.linesRemoved);
+            state.hasPriorEdit = true;
+
+            if (state.openChecks.size > 0) {
+                const repairKey = `${event.session}:${event.index}`;
+                if (!countedRepairEditKeys.has(repairKey)) {
+                    countedRepairEditKeys.add(repairKey);
+                    state.repairLinesAdded += nonNegative(event.linesAdded);
+                    state.repairLinesRemoved += nonNegative(event.linesRemoved);
+                }
+            }
+            continue;
+        }
+
+        const check = normalizeCheckFamily(event.check);
+        if (check === null) continue;
+
+        if (event.kind === "verification_fail") {
+            state.verificationFailures += 1;
+            increment(state.checkFailures, check, 1);
+            if (state.hasPriorEdit && !state.openChecks.has(check)) {
+                state.openChecks.add(check);
+                state.episodes += 1;
+            }
+            continue;
+        }
+
+        state.verificationPasses += 1;
+        if (state.openChecks.delete(check)) {
+            state.passedEpisodes += 1;
+        }
+    }
+
+    const rowsWithChecks = [...states.values()]
+        .map((state) => ({ row: freezeRow(state), checkFailures: state.checkFailures }))
+        .filter(({ row }) => sourceFilter === null || row.source === sourceFilter);
+
+    const aggregates = buildAggregates(rowsWithChecks);
+    const hotSessions = rowsWithChecks
+        .map(({ row }) => row)
+        .sort(compareHotSessions)
+        .slice(0, limit);
+
+    return {
+        generatedAt,
+        filters: {
+            since: dateishToIsoOrNull(options.since ?? null),
+            project: options.project ?? null,
+            source: sourceFilter,
+            limit,
+        },
+        aggregates,
+        hotSessions,
+    };
+};
+
+export const formatSessionChurnSummary = (summary: SessionChurnSummary): string => {
+    if (summary.aggregates.length === 0) {
+        return "no verification churn rows matched (run `ax ingest`, or loosen --since/--source/--here).";
+    }
+
+    const sourceRows = summary.aggregates.map((row) => [
+        row.source,
+        String(row.sessions),
+        String(row.sessionsWithFailures),
+        String(row.verificationFailures),
+        String(row.episodes),
+        String(row.passedEpisodes),
+        loc(row.landedLinesAdded, row.landedLinesRemoved),
+        loc(row.editLinesAdded, row.editLinesRemoved),
+        loc(row.repairLinesAdded, row.repairLinesRemoved),
+        row.topCheck ?? "-",
+    ]);
+
+    const sessionRows = summary.hotSessions.map((row) => [
+        truncate(row.session, 20),
+        row.source ?? "unknown",
+        String(row.verificationFailures),
+        String(row.episodes),
+        String(row.passedEpisodes),
+        loc(row.landedLinesAdded, row.landedLinesRemoved),
+        loc(row.editLinesAdded, row.editLinesRemoved),
+        loc(row.repairLinesAdded, row.repairLinesRemoved),
+        row.topCheck ?? "-",
+        row.taskLabel ?? "-",
+    ]);
+
+    return [
+        "verification churn by source",
+        table(["source", "sess", "fail-sess", "fails", "episodes", "pass", "landed", "edits", "repair", "top"], sourceRows),
+        "",
+        "hot sessions",
+        table(["session", "source", "fails", "episodes", "pass", "landed", "edits", "repair", "top", "task"], sessionRows),
+    ].join("\n");
+};
+
+const getState = (
+    states: Map<string, MutableSessionState>,
+    session: string,
+    source: string | null,
+    landedBySession: ReadonlyMap<string, ChurnLines>,
+    healthBySession: ReadonlyMap<string, string | null | SessionHealthChurnInput>,
+): MutableSessionState => {
+    const existing = states.get(session);
+    if (existing !== undefined) return existing;
+
+    const landed = landedBySession.get(session);
+    const state: MutableSessionState = {
+        session,
+        source,
+        taskLabel: taskLabelOf(healthBySession.get(session)),
+        landedLinesAdded: landed?.added ?? 0,
+        landedLinesRemoved: landed?.removed ?? 0,
+        editLinesAdded: 0,
+        editLinesRemoved: 0,
+        repairLinesAdded: 0,
+        repairLinesRemoved: 0,
+        editEvents: 0,
+        verificationFailures: 0,
+        verificationPasses: 0,
+        episodes: 0,
+        passedEpisodes: 0,
+        hasPriorEdit: false,
+        openChecks: new Set(),
+        checkFailures: new Map(),
+    };
+    states.set(session, state);
+    return state;
+};
+
+const freezeRow = (state: MutableSessionState): SessionChurnRow => ({
+    session: state.session,
+    source: state.source,
+    taskLabel: state.taskLabel,
+    landedLinesAdded: state.landedLinesAdded,
+    landedLinesRemoved: state.landedLinesRemoved,
+    editLinesAdded: state.editLinesAdded,
+    editLinesRemoved: state.editLinesRemoved,
+    repairLinesAdded: state.repairLinesAdded,
+    repairLinesRemoved: state.repairLinesRemoved,
+    editEvents: state.editEvents,
+    verificationFailures: state.verificationFailures,
+    verificationPasses: state.verificationPasses,
+    episodes: state.episodes,
+    passedEpisodes: state.passedEpisodes,
+    topCheck: topCheck(state.checkFailures),
+});
+
+const buildAggregates = (
+    rows: Array<{ readonly row: SessionChurnRow; readonly checkFailures: ReadonlyMap<string, number> }>,
+): SourceChurnAggregate[] => {
+    const aggregates = new Map<string, {
+        row: MutableAggregateState;
+        checkFailures: Map<string, number>;
+    }>();
+
+    for (const { row, checkFailures } of rows) {
+        const source = row.source ?? "unknown";
+        let aggregate = aggregates.get(source);
+        if (aggregate === undefined) {
+            aggregate = {
+                row: {
+                    source,
+                    sessions: 0,
+                    sessionsWithFailures: 0,
+                    landedLinesAdded: 0,
+                    landedLinesRemoved: 0,
+                    editLinesAdded: 0,
+                    editLinesRemoved: 0,
+                    repairLinesAdded: 0,
+                    repairLinesRemoved: 0,
+                    verificationFailures: 0,
+                    episodes: 0,
+                    passedEpisodes: 0,
+                },
+                checkFailures: new Map(),
+            };
+            aggregates.set(source, aggregate);
+        }
+
+        aggregate.row.sessions += 1;
+        aggregate.row.sessionsWithFailures += row.verificationFailures > 0 ? 1 : 0;
+        aggregate.row.landedLinesAdded += row.landedLinesAdded;
+        aggregate.row.landedLinesRemoved += row.landedLinesRemoved;
+        aggregate.row.editLinesAdded += row.editLinesAdded;
+        aggregate.row.editLinesRemoved += row.editLinesRemoved;
+        aggregate.row.repairLinesAdded += row.repairLinesAdded;
+        aggregate.row.repairLinesRemoved += row.repairLinesRemoved;
+        aggregate.row.verificationFailures += row.verificationFailures;
+        aggregate.row.episodes += row.episodes;
+        aggregate.row.passedEpisodes += row.passedEpisodes;
+        for (const [check, count] of checkFailures) {
+            increment(aggregate.checkFailures, check, count);
+        }
+    }
+
+    return [...aggregates.values()]
+        .map(({ row, checkFailures }) => ({ ...row, topCheck: topCheck(checkFailures) }))
+        .sort((a, b) => b.verificationFailures - a.verificationFailures || b.repairLinesAdded + b.repairLinesRemoved - (a.repairLinesAdded + a.repairLinesRemoved) || a.source.localeCompare(b.source));
+};
+
+const compareHotSessions = (a: SessionChurnRow, b: SessionChurnRow): number =>
+    b.verificationFailures - a.verificationFailures
+    || (b.repairLinesAdded + b.repairLinesRemoved) - (a.repairLinesAdded + a.repairLinesRemoved)
+    || b.episodes - a.episodes
+    || a.session.localeCompare(b.session);
+
+const topCheck = (counts: ReadonlyMap<string, number>): string | null => {
+    const [top] = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+    return top?.[0] ?? null;
+};
+
+const increment = (counts: Map<string, number>, key: string, amount: number): void => {
+    counts.set(key, (counts.get(key) ?? 0) + amount);
+};
+
+const taskLabelOf = (input: string | null | SessionHealthChurnInput | undefined): string | null => {
+    if (typeof input === "string") return input;
+    if (input === null || input === undefined) return null;
+    return input.taskLabel ?? null;
+};
+
+const nonNegative = (n: number): number => Number.isFinite(n) && n > 0 ? n : 0;
+
+const dateishToIso = (value: Date | string): string =>
+    value instanceof Date ? value.toISOString() : value;
+
+const dateishToIsoOrNull = (value: Date | string | null): string | null =>
+    value === null ? null : dateishToIso(value);
+
+const loc = (added: number, removed: number): string => `+${added}/-${removed}`;
+
+const truncate = (text: string, max: number): string =>
+    text.length <= max ? text : `${text.slice(0, Math.max(0, max - 3))}...`;
+
+const table = (header: readonly string[], rows: readonly string[][]): string => {
+    const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i]?.length ?? 0)));
+    const render = (cells: readonly string[]) => cells
+        .map((cell, i) => isNumericColumn(header[i] ?? "") ? cell.padStart(widths[i] ?? cell.length) : cell.padEnd(widths[i] ?? cell.length))
+        .join("  ")
+        .trimEnd();
+    return [render(header), ...rows.map(render)].join("\n");
+};
+
+const isNumericColumn = (name: string): boolean =>
+    ["sess", "fail-sess", "fails", "episodes", "pass"].includes(name);

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -1,3 +1,5 @@
+import { cleanSessionId } from "./util.ts";
+
 export interface ChurnEvent {
     readonly session: string;
     readonly source: string | null;
@@ -119,6 +121,7 @@ export const normalizeCheckFamily = (raw: string | null): string | null => {
 
     if (/\boxlint\b/.test(text) || /\boxc\b/.test(text)) return "oxlint";
     if (/\beslint\b/.test(text)) return "eslint";
+    if (/\blint\b/.test(text)) return "lint";
     if (/\b(tsc|typecheck|tsgo)\b/.test(text)) return "typecheck";
     if (/\b(bun\s+test|vitest|jest|playwright|test)\b/.test(text)) return "test";
     if (/\bbuild\b/.test(text)) return "build";
@@ -137,21 +140,23 @@ export const computeSessionChurn = (
     const generatedAt = dateishToIso(options.generatedAt ?? new Date());
     const states = new Map<string, MutableSessionState>();
     const countedRepairEditKeys = new Set<string>();
+    const normalizedLanded = normalizeLandedMap(landedBySession);
+    const normalizedHealth = normalizeHealthMap(healthBySession);
 
-    for (const session of landedBySession.keys()) {
-        getState(states, session, null, landedBySession, healthBySession);
+    for (const session of normalizedLanded.keys()) {
+        getState(states, session, null, normalizedLanded, normalizedHealth);
     }
-    for (const session of healthBySession.keys()) {
-        getState(states, session, null, landedBySession, healthBySession);
+    for (const session of normalizedHealth.keys()) {
+        getState(states, session, null, normalizedLanded, normalizedHealth);
     }
 
     const sorted = events
-        .map((event, index): IndexedChurnEvent => ({ ...event, index }))
+        .map((event, index): IndexedChurnEvent => ({ ...event, session: normalizeSessionKey(event.session), index }))
         .filter((event) => sourceFilter === null || event.source === sourceFilter)
         .sort((a, b) => a.session.localeCompare(b.session) || a.tsMs - b.tsMs || a.index - b.index);
 
     for (const event of sorted) {
-        const state = getState(states, event.session, event.source, landedBySession, healthBySession);
+        const state = getState(states, event.session, event.source, normalizedLanded, normalizedHealth);
         if (state.source === null && event.source !== null) state.source = event.source;
 
         if (event.kind === "edit") {
@@ -192,6 +197,7 @@ export const computeSessionChurn = (
 
     const rowsWithChecks = [...states.values()]
         .map((state) => ({ row: freezeRow(state), checkFailures: state.checkFailures }))
+        .filter(({ row }) => hasVerificationSignal(row))
         .filter(({ row }) => sourceFilter === null || row.source === sourceFilter);
 
     const aggregates = buildAggregates(rowsWithChecks);
@@ -286,6 +292,41 @@ const getState = (
     states.set(session, state);
     return state;
 };
+
+const normalizeLandedMap = (input: ReadonlyMap<string, ChurnLines>): Map<string, ChurnLines> => {
+    const out = new Map<string, ChurnLines>();
+    for (const [session, lines] of input) {
+        const key = normalizeSessionKey(session);
+        const cur = out.get(key) ?? { added: 0, removed: 0 };
+        out.set(key, {
+            added: cur.added + nonNegative(lines.added),
+            removed: cur.removed + nonNegative(lines.removed),
+        });
+    }
+    return out;
+};
+
+const normalizeHealthMap = (
+    input: ReadonlyMap<string, string | null | SessionHealthChurnInput>,
+): Map<string, string | null | SessionHealthChurnInput> => {
+    const out = new Map<string, string | null | SessionHealthChurnInput>();
+    for (const [session, health] of input) {
+        const key = normalizeSessionKey(session);
+        const existing = out.get(key);
+        if (existing === undefined || taskLabelOf(existing) === null) {
+            out.set(key, health);
+        }
+    }
+    return out;
+};
+
+const normalizeSessionKey = (session: string): string => cleanSessionId(session);
+
+const hasVerificationSignal = (row: SessionChurnRow): boolean =>
+    row.verificationFailures > 0
+    || row.episodes > 0
+    || row.repairLinesAdded > 0
+    || row.repairLinesRemoved > 0;
 
 const freezeRow = (state: MutableSessionState): SessionChurnRow => ({
     session: state.session,

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -12,7 +12,7 @@ import {
     toolClassInputOf,
 } from "@ax/lib/shared/tool-classes";
 import { editDelta } from "../dashboard/loc-query.ts";
-import { coerceCheckFamily } from "../ingest/check-family.ts";
+import { checkFamilyFromCommand, coerceCheckFamily, commandNormNeedsText } from "../ingest/check-family.ts";
 import { applyPatchDelta } from "./session-loc.ts";
 import { fetchSessionHealthMap } from "./session-metrics-query.ts";
 import { cleanSessionId } from "./util.ts";
@@ -400,31 +400,28 @@ const fetchCommandOutcomeEvents = (
     Effect.gen(function* () {
         const db = yield* SurrealClient;
         if (sessionIds.length === 0) return [];
+        // Deref-free: command_text lives on tool_call only and is batch-joined
+        // below for the few rows whose normalized command is ambiguous.
         const rows = (yield* Effect.all(
             chunked(sessionIds, IN_CHUNK).map((ids) =>
                 db.query<[Array<Record<string, unknown>>]>(
-                    `SELECT type::string(session) AS session, type::string(ts) AS ts, kind, status, tool_call.command_text AS command_text, command_norm, command_tool, text`
-                    + ` FROM command_outcome WHERE session IN [${sessionRefList(ids)}]`
-                    + ` AND (kind = "expected_feedback" OR status = "ok") ORDER BY ts ASC;`,
+                    `SELECT type::string(session) AS session, type::string(ts) AS ts, kind, status, command_norm, type::string(tool_call) AS tool_call_ref`
+                    + ` FROM command_outcome WHERE session IN [${sessionRefList(ids)}];`,
                 ),
             ),
             { concurrency: 4 },
         )).flatMap((batch) => batch?.[0] ?? []);
 
+        interface PendingOutcome {
+            readonly session: string;
+            readonly tsMs: number;
+            readonly eventKind: "verification_fail" | "verification_pass";
+            readonly toolCallKey: string;
+        }
+
         const events: ChurnEvent[] = [];
-        for (const row of rows) {
-            const session = cleanSessionId(String(row.session ?? ""));
-            const tsMs = msOrNull(row.ts);
-            const status = strOrNull(row.status);
-            const kind = strOrNull(row.kind);
-            const eventKind = kind === "expected_feedback" || status === "error"
-                ? "verification_fail"
-                : status === "ok"
-                    ? "verification_pass"
-                    : null;
-            if (eventKind === null) continue;
-            const check = commandOutcomeCheck(row);
-            if (session.length === 0 || tsMs === null || check === null) continue;
+        const pending: PendingOutcome[] = [];
+        const pushEvent = (session: string, tsMs: number, eventKind: PendingOutcome["eventKind"], check: string) => {
             events.push({
                 session,
                 source: sourceBySession.get(session) ?? null,
@@ -434,6 +431,53 @@ const fetchCommandOutcomeEvents = (
                 linesAdded: 0,
                 linesRemoved: 0,
             });
+        };
+
+        for (const row of rows) {
+            const session = cleanSessionId(String(row.session ?? ""));
+            const tsMs = msOrNull(row.ts);
+            const status = strOrNull(row.status);
+            const kind = strOrNull(row.kind);
+            const eventKind = kind === "expected_feedback" || status === "error"
+                ? "verification_fail" as const
+                : status === "ok"
+                    ? "verification_pass" as const
+                    : null;
+            if (eventKind === null || session.length === 0 || tsMs === null) continue;
+
+            const norm = strOrNull(row.command_norm);
+            const check = checkFamilyFromCommand(norm);
+            if (check !== null) {
+                pushEvent(session, tsMs, eventKind, check);
+                continue;
+            }
+            if (!commandNormNeedsText(norm)) continue;
+            const toolCallKey = recordKeyPart(strOrNull(row.tool_call_ref), "tool_call");
+            if (toolCallKey === null || toolCallKey.length === 0) continue;
+            pending.push({ session, tsMs, eventKind, toolCallKey });
+        }
+
+        if (pending.length > 0) {
+            const keys = [...new Set(pending.map((item) => item.toolCallKey))];
+            const textRows = (yield* Effect.all(
+                chunked(keys, IN_CHUNK).map((ids) =>
+                    db.query<[Array<Record<string, unknown>>]>(
+                        `SELECT type::string(id) AS id, command_text FROM tool_call WHERE id IN [${recordRefList("tool_call", ids)}];`,
+                    ),
+                ),
+                { concurrency: 4 },
+            )).flatMap((batch) => batch?.[0] ?? []);
+
+            const textByKey = new Map<string, string | null>();
+            for (const row of textRows) {
+                const key = recordKeyPart(strOrNull(row.id), "tool_call");
+                if (key !== null && key.length > 0) textByKey.set(key, strOrNull(row.command_text));
+            }
+            for (const item of pending) {
+                const check = checkFamilyFromCommand(textByKey.get(item.toolCallKey) ?? null);
+                if (check === null) continue;
+                pushEvent(item.session, item.tsMs, item.eventKind, check);
+            }
         }
         return events;
     });
@@ -717,12 +761,6 @@ const normalizedCheckFrom = (...values: readonly unknown[]): string | null => {
     }
     return null;
 };
-
-// Classify strictly from the command itself (text, then normalized form).
-// Output text and the provider tool name (command_tool) are never consulted -
-// "remote: check your credentials" is not a check run.
-const commandOutcomeCheck = (row: Record<string, unknown>): string | null =>
-    normalizedCheckFrom(row.command_text, row.command_norm);
 
 const exitCodeOf = (value: unknown): number | null => {
     if (value === null || value === undefined) return null;

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -594,7 +594,7 @@ export const formatSessionChurnSummary = (summary: SessionChurnSummary): string 
         loc(row.editLinesAdded, row.editLinesRemoved),
         loc(row.repairLinesAdded, row.repairLinesRemoved),
         row.topCheck ?? "-",
-        row.taskLabel ?? "-",
+        row.taskLabel === null ? "-" : truncate(singleLine(row.taskLabel), 48),
     ]);
 
     return [
@@ -854,6 +854,8 @@ const dateishToIsoOrNull = (value: Date | string | null): string | null =>
     value === null ? null : dateishToIso(value);
 
 const loc = (added: number, removed: number): string => `+${added}/-${removed}`;
+
+const singleLine = (text: string): string => text.split(/\r?\n/, 1)[0]?.trim() ?? text;
 
 const truncate = (text: string, max: number): string =>
     text.length <= max ? text : `${text.slice(0, Math.max(0, max - 3))}...`;

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -87,6 +87,19 @@ export interface ChurnLines {
     readonly removed: number;
 }
 
+/** Commit-level landed LOC with every producing session, for aggregate dedupe. */
+export interface LandedCommit {
+    readonly commit: string;
+    readonly sessions: readonly string[];
+    readonly added: number;
+    readonly removed: number;
+}
+
+export interface LandedLoc {
+    readonly bySession: ReadonlyMap<string, ChurnLines>;
+    readonly commits: readonly LandedCommit[];
+}
+
 export interface SessionHealthChurnInput {
     readonly taskLabel?: string | null;
 }
@@ -97,6 +110,13 @@ export interface ComputeSessionChurnOptions {
     readonly project?: string | null;
     readonly source?: string | null;
     readonly limit?: number;
+    /**
+     * When provided, source aggregates compute landed LOC from these commits
+     * (each counted once per source) instead of summing per-session rows -
+     * a commit produced by several sessions keeps full per-session credit
+     * without inflating the source totals.
+     */
+    readonly landedCommits?: readonly LandedCommit[];
 }
 
 interface IndexedChurnEvent extends ChurnEvent {
@@ -221,7 +241,7 @@ export const computeSessionChurn = (
         .filter(({ row }) => hasVerificationSignal(row))
         .filter(({ row }) => sourceFilter === null || row.source === sourceFilter);
 
-    const aggregates = buildAggregates(rowsWithChecks);
+    const aggregates = buildAggregates(rowsWithChecks, options.landedCommits ?? null);
     const hotSessions = rowsWithChecks
         .map(({ row }) => row)
         .sort(compareHotSessions)
@@ -283,16 +303,20 @@ ORDER BY session.started_at DESC;`))?.[0] ?? [];
             fetchHookEvents(sessionIds, sourceBySession),
         ], { concurrency: 5 });
 
-        return computeSessionChurn([...edits, ...commandEvents, ...hookEvents], landed, health, options);
+        return computeSessionChurn([...edits, ...commandEvents, ...hookEvents], landed.bySession, health, {
+            ...options,
+            landedCommits: landed.commits,
+        });
     });
 
 const fetchLandedLocBySession = (
     sessionIds: readonly string[],
-): Effect.Effect<Map<string, ChurnLines>, DbError, SurrealClient> =>
+): Effect.Effect<LandedLoc, DbError, SurrealClient> =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
         const out = new Map<string, ChurnLines>();
-        if (sessionIds.length === 0) return out;
+        const commitTotals = new Map<string, { added: number; removed: number }>();
+        if (sessionIds.length === 0) return { bySession: out, commits: [] };
 
         const producedRows = (yield* Effect.all(
             chunked(sessionIds, IN_CHUNK).map((ids) =>
@@ -316,7 +340,7 @@ const fetchLandedLocBySession = (
             }
             sessions.add(session);
         }
-        if (sessionsByCommit.size === 0) return out;
+        if (sessionsByCommit.size === 0) return { bySession: out, commits: [] };
 
         const commitIds = [...sessionsByCommit.keys()];
         const touchedRows = (yield* Effect.all(
@@ -344,6 +368,10 @@ const fetchLandedLocBySession = (
 
             const added = numOrZero(row.additions);
             const removed = numOrZero(row.deletions);
+            const commitTotal = commitTotals.get(commit) ?? { added: 0, removed: 0 };
+            commitTotal.added += added;
+            commitTotal.removed += removed;
+            commitTotals.set(commit, commitTotal);
             for (const session of sessions) {
                 const cur = out.get(session) ?? { added: 0, removed: 0 };
                 out.set(session, {
@@ -353,7 +381,13 @@ const fetchLandedLocBySession = (
             }
         }
 
-        return out;
+        const commits: LandedCommit[] = [...commitTotals.entries()].map(([commit, lines]) => ({
+            commit,
+            sessions: [...(sessionsByCommit.get(commit) ?? [])],
+            added: lines.added,
+            removed: lines.removed,
+        }));
+        return { bySession: out, commits };
     });
 
 const fetchEditEvents = (
@@ -668,6 +702,7 @@ const freezeRow = (state: MutableSessionState): SessionChurnRow => ({
 
 const buildAggregates = (
     rows: Array<{ readonly row: SessionChurnRow; readonly checkFailures: ReadonlyMap<string, number> }>,
+    landedCommits: readonly LandedCommit[] | null,
 ): SourceChurnAggregate[] => {
     const aggregates = new Map<string, {
         row: MutableAggregateState;
@@ -700,8 +735,10 @@ const buildAggregates = (
 
         aggregate.row.sessions += 1;
         aggregate.row.sessionsWithFailures += row.verificationFailures > 0 ? 1 : 0;
-        aggregate.row.landedLinesAdded += row.landedLinesAdded;
-        aggregate.row.landedLinesRemoved += row.landedLinesRemoved;
+        if (landedCommits === null) {
+            aggregate.row.landedLinesAdded += row.landedLinesAdded;
+            aggregate.row.landedLinesRemoved += row.landedLinesRemoved;
+        }
         aggregate.row.editLinesAdded += row.editLinesAdded;
         aggregate.row.editLinesRemoved += row.editLinesRemoved;
         aggregate.row.repairLinesAdded += row.repairLinesAdded;
@@ -711,6 +748,23 @@ const buildAggregates = (
         aggregate.row.passedEpisodes += row.passedEpisodes;
         for (const [check, count] of checkFailures) {
             increment(aggregate.checkFailures, check, count);
+        }
+    }
+
+    if (landedCommits !== null) {
+        const sourceBySession = new Map(rows.map(({ row }) => [row.session, row.source ?? "unknown"]));
+        for (const commit of landedCommits) {
+            const sources = new Set<string>();
+            for (const session of commit.sessions) {
+                const source = sourceBySession.get(normalizeSessionKey(session));
+                if (source !== undefined) sources.add(source);
+            }
+            for (const source of sources) {
+                const aggregate = aggregates.get(source);
+                if (aggregate === undefined) continue;
+                aggregate.row.landedLinesAdded += nonNegative(commit.added);
+                aggregate.row.landedLinesRemoved += nonNegative(commit.removed);
+            }
         }
     }
 

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -265,8 +265,7 @@ export const fetchSessionChurnSummary = (
 SELECT type::string(session) AS session, session.source AS source
 FROM session_metrics
 ${where}
-ORDER BY session.started_at DESC
-LIMIT ${limit};`))?.[0] ?? [];
+ORDER BY session.started_at DESC;`))?.[0] ?? [];
 
         const sessionIds = uniqueCleanSessionIds(baseRows.map((row) => String(row.session ?? "")));
         const sourceBySession = new Map<string, string | null>();
@@ -413,8 +412,9 @@ const fetchCommandOutcomeEvents = (
         const rows = (yield* Effect.all(
             chunked(sessionIds, IN_CHUNK).map((ids) =>
                 db.query<[Array<Record<string, unknown>>]>(
-                    `SELECT type::string(session) AS session, type::string(ts) AS ts, kind, status, command_norm, command_tool, text`
-                    + ` FROM command_outcome WHERE session IN [${sessionRefList(ids)}] ORDER BY ts ASC;`,
+                    `SELECT type::string(session) AS session, type::string(ts) AS ts, kind, status, command_text, command_norm, command_tool, text`
+                    + ` FROM command_outcome WHERE session IN [${sessionRefList(ids)}]`
+                    + ` AND (kind = "expected_feedback" OR status = "ok") ORDER BY ts ASC;`,
                 ),
             ),
             { concurrency: 4 },
@@ -424,8 +424,6 @@ const fetchCommandOutcomeEvents = (
         for (const row of rows) {
             const session = cleanSessionId(String(row.session ?? ""));
             const tsMs = msOrNull(row.ts);
-            const check = normalizedCheckFrom(row.command_norm, row.command_tool, row.text);
-            if (session.length === 0 || tsMs === null || check === null) continue;
             const status = strOrNull(row.status);
             const kind = strOrNull(row.kind);
             const eventKind = kind === "expected_feedback" || status === "error"
@@ -434,6 +432,8 @@ const fetchCommandOutcomeEvents = (
                     ? "verification_pass"
                     : null;
             if (eventKind === null) continue;
+            const check = commandOutcomeCheck(row, eventKind);
+            if (session.length === 0 || tsMs === null || check === null) continue;
             events.push({
                 session,
                 source: sourceBySession.get(session) ?? null,
@@ -724,6 +724,14 @@ const normalizedCheckFrom = (...values: readonly unknown[]): string | null => {
     }
     return null;
 };
+
+const commandOutcomeCheck = (
+    row: Record<string, unknown>,
+    eventKind: "verification_fail" | "verification_pass",
+): string | null =>
+    eventKind === "verification_fail"
+        ? normalizedCheckFrom(row.command_text, row.command_norm, row.command_tool, row.text)
+        : normalizedCheckFrom(row.command_text, row.command_norm, row.command_tool);
 
 const exitCodeOf = (value: unknown): number | null => {
     if (value === null || value === undefined) return null;

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -1,4 +1,21 @@
+import { Effect } from "effect";
+import { recordLiteral } from "@ax/lib/ids";
+import { recordKeyPart } from "@ax/lib/shared/derive-keys";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { surrealDate, surrealString } from "@ax/lib/shared/surql";
+import {
+    canonicalEditToolName,
+    editToolSqlFilter,
+    isApplyPatchCall,
+    isEditTool,
+    toolClassInputOf,
+} from "@ax/lib/shared/tool-classes";
+import { editDelta } from "../dashboard/loc-query.ts";
+import { applyPatchDelta } from "./session-loc.ts";
+import { fetchSessionHealthMap } from "./session-metrics-query.ts";
 import { cleanSessionId } from "./util.ts";
+import { chunked, numOrZero, sessionRefList, strOrNull } from "./util.ts";
 
 export interface ChurnEvent {
     readonly session: string;
@@ -54,6 +71,14 @@ export interface SessionChurnSummary {
     };
     readonly aggregates: SourceChurnAggregate[];
     readonly hotSessions: SessionChurnRow[];
+}
+
+export interface FetchSessionChurnInput {
+    readonly since: Date | null;
+    readonly project?: string | null;
+    readonly source?: string | null;
+    readonly limit: number;
+    readonly generatedAt?: Date | string;
 }
 
 export interface ChurnLines {
@@ -113,6 +138,7 @@ interface MutableAggregateState {
 }
 
 const DEFAULT_LIMIT = 10;
+const IN_CHUNK = 500;
 
 export const normalizeCheckFamily = (raw: string | null): string | null => {
     if (raw === null) return null;
@@ -218,6 +244,253 @@ export const computeSessionChurn = (
         hotSessions,
     };
 };
+
+export const fetchSessionChurnSummary = (
+    input: FetchSessionChurnInput,
+): Effect.Effect<SessionChurnSummary, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const limit = Math.min(Math.max(Math.trunc(input.limit), 1), 1000);
+        const project = input.project ?? null;
+        const source = input.source ?? null;
+        const clauses: string[] = [];
+        if (input.since) clauses.push(`session.started_at >= ${surrealDate(input.since)}`);
+        if (project !== null) {
+            const projectSql = surrealString(project);
+            clauses.push(`(session.project = ${projectSql} OR session.cwd = ${projectSql})`);
+        }
+        if (source !== null) clauses.push(`session.source = ${surrealString(source)}`);
+        const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+        const baseRows = (yield* db.query<[Array<Record<string, unknown>>]>(`
+SELECT type::string(session) AS session, session.source AS source
+FROM session_metrics
+${where}
+ORDER BY session.started_at DESC
+LIMIT ${limit};`))?.[0] ?? [];
+
+        const sessionIds = uniqueCleanSessionIds(baseRows.map((row) => String(row.session ?? "")));
+        const sourceBySession = new Map<string, string | null>();
+        for (const row of baseRows) {
+            const session = cleanSessionId(String(row.session ?? ""));
+            if (session.length === 0) continue;
+            sourceBySession.set(session, strOrNull(row.source));
+        }
+        const options = churnOptions(input, project, source, limit);
+
+        if (sessionIds.length === 0) {
+            return computeSessionChurn([], new Map(), new Map(), options);
+        }
+
+        const [health, landed, edits, commandEvents, hookEvents] = yield* Effect.all([
+            fetchSessionHealthMap(sessionIds),
+            fetchLandedLocBySession(sessionIds),
+            fetchEditEvents(sessionIds, sourceBySession),
+            fetchCommandOutcomeEvents(sessionIds, sourceBySession),
+            fetchHookEvents(sessionIds, sourceBySession),
+        ], { concurrency: 5 });
+
+        return computeSessionChurn([...edits, ...commandEvents, ...hookEvents], landed, health, options);
+    });
+
+const fetchLandedLocBySession = (
+    sessionIds: readonly string[],
+): Effect.Effect<Map<string, ChurnLines>, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const out = new Map<string, ChurnLines>();
+        if (sessionIds.length === 0) return out;
+
+        const producedRows = (yield* Effect.all(
+            chunked(sessionIds, IN_CHUNK).map((ids) =>
+                db.query<[Array<Record<string, unknown>>]>(
+                    `SELECT type::string(in) AS session, type::string(out) AS commit`
+                    + ` FROM produced WHERE in IN [${sessionRefList(ids)}];`,
+                ),
+            ),
+            { concurrency: 4 },
+        )).flatMap((batch) => batch?.[0] ?? []);
+
+        const sessionsByCommit = new Map<string, Set<string>>();
+        for (const row of producedRows) {
+            const session = cleanSessionId(String(row.session ?? ""));
+            const commit = String(row.commit ?? "");
+            if (session.length === 0 || commit.length === 0) continue;
+            let sessions = sessionsByCommit.get(commit);
+            if (sessions === undefined) {
+                sessions = new Set();
+                sessionsByCommit.set(commit, sessions);
+            }
+            sessions.add(session);
+        }
+        if (sessionsByCommit.size === 0) return out;
+
+        const commitIds = [...sessionsByCommit.keys()];
+        const touchedRows = (yield* Effect.all(
+            chunked(commitIds, IN_CHUNK).map((ids) =>
+                db.query<[Array<Record<string, unknown>>]>(
+                    `SELECT type::string(in) AS commit, type::string(out) AS file, out.path AS path, old_path, new_path, additions, deletions`
+                    + ` FROM touched WHERE in IN [${recordRefList("commit", ids)}];`,
+                ),
+            ),
+            { concurrency: 4 },
+        )).flatMap((batch) => batch?.[0] ?? []);
+
+        const seenTouched = new Set<string>();
+        for (const row of touchedRows) {
+            const commit = String(row.commit ?? "");
+            const sessions = sessionsByCommit.get(commit);
+            if (sessions === undefined) continue;
+
+            const identity = touchedIdentity(row);
+            if (identity !== null) {
+                const key = `${commit}:${identity}`;
+                if (seenTouched.has(key)) continue;
+                seenTouched.add(key);
+            }
+
+            const added = numOrZero(row.additions);
+            const removed = numOrZero(row.deletions);
+            for (const session of sessions) {
+                const cur = out.get(session) ?? { added: 0, removed: 0 };
+                out.set(session, {
+                    added: cur.added + added,
+                    removed: cur.removed + removed,
+                });
+            }
+        }
+
+        return out;
+    });
+
+const fetchEditEvents = (
+    sessionIds: readonly string[],
+    sourceBySession: ReadonlyMap<string, string | null>,
+): Effect.Effect<ChurnEvent[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        if (sessionIds.length === 0) return [];
+        const rows = (yield* Effect.all(
+            chunked(sessionIds, IN_CHUNK).map((ids) =>
+                db.query<[Array<Record<string, unknown>>]>(
+                    `SELECT type::string(session) AS session, type::string(ts) AS ts, name, command_norm, input_json`
+                    + ` FROM tool_call WHERE session IN [${sessionRefList(ids)}] AND ${editToolSqlFilter} ORDER BY ts ASC;`,
+                ),
+            ),
+            { concurrency: 4 },
+        )).flatMap((batch) => batch?.[0] ?? []);
+
+        const events: ChurnEvent[] = [];
+        for (const row of rows) {
+            const call = toolClassInputOf(row);
+            if (!isEditTool(call)) continue;
+            const session = cleanSessionId(String(row.session ?? ""));
+            const tsMs = msOrNull(row.ts);
+            if (session.length === 0 || tsMs === null) continue;
+            const inputJson = strOrNull(row.input_json);
+            const delta = isApplyPatchCall(call)
+                ? applyPatchDelta(inputJson)
+                : editDelta(canonicalEditToolName(call.name), inputJson);
+            events.push({
+                session,
+                source: sourceBySession.get(session) ?? null,
+                tsMs,
+                kind: "edit",
+                check: null,
+                linesAdded: delta.added,
+                linesRemoved: delta.removed,
+            });
+        }
+        return events;
+    });
+
+const fetchCommandOutcomeEvents = (
+    sessionIds: readonly string[],
+    sourceBySession: ReadonlyMap<string, string | null>,
+): Effect.Effect<ChurnEvent[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        if (sessionIds.length === 0) return [];
+        const rows = (yield* Effect.all(
+            chunked(sessionIds, IN_CHUNK).map((ids) =>
+                db.query<[Array<Record<string, unknown>>]>(
+                    `SELECT type::string(session) AS session, type::string(ts) AS ts, kind, status, command_norm, command_tool, text`
+                    + ` FROM command_outcome WHERE session IN [${sessionRefList(ids)}] ORDER BY ts ASC;`,
+                ),
+            ),
+            { concurrency: 4 },
+        )).flatMap((batch) => batch?.[0] ?? []);
+
+        const events: ChurnEvent[] = [];
+        for (const row of rows) {
+            const session = cleanSessionId(String(row.session ?? ""));
+            const tsMs = msOrNull(row.ts);
+            const check = normalizedCheckFrom(row.command_norm, row.command_tool, row.text);
+            if (session.length === 0 || tsMs === null || check === null) continue;
+            const status = strOrNull(row.status);
+            const kind = strOrNull(row.kind);
+            const eventKind = kind === "expected_feedback" || status === "error"
+                ? "verification_fail"
+                : status === "ok"
+                    ? "verification_pass"
+                    : null;
+            if (eventKind === null) continue;
+            events.push({
+                session,
+                source: sourceBySession.get(session) ?? null,
+                tsMs,
+                kind: eventKind,
+                check,
+                linesAdded: 0,
+                linesRemoved: 0,
+            });
+        }
+        return events;
+    });
+
+const fetchHookEvents = (
+    sessionIds: readonly string[],
+    sourceBySession: ReadonlyMap<string, string | null>,
+): Effect.Effect<ChurnEvent[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        if (sessionIds.length === 0) return [];
+        const rows = (yield* Effect.all(
+            chunked(sessionIds, IN_CHUNK).map((ids) =>
+                db.query<[Array<Record<string, unknown>>]>(
+                    `SELECT type::string(session) AS session, type::string(ts) AS ts, provider_status, effect, exit_code, command, hook_name`
+                    + ` FROM hook_command_invocation WHERE session IN [${sessionRefList(ids)}] ORDER BY ts ASC;`,
+                ),
+            ),
+            { concurrency: 4 },
+        )).flatMap((batch) => batch?.[0] ?? []);
+
+        const events: ChurnEvent[] = [];
+        for (const row of rows) {
+            const session = cleanSessionId(String(row.session ?? ""));
+            const tsMs = msOrNull(row.ts);
+            const check = normalizedCheckFrom(row.command, row.hook_name);
+            if (session.length === 0 || tsMs === null || check === null) continue;
+            const providerStatus = strOrNull(row.provider_status);
+            const effect = strOrNull(row.effect);
+            const exitCode = exitCodeOf(row.exit_code);
+            const eventKind = providerStatus === "blocking_error" || effect === "blocked" || (exitCode !== null && exitCode !== 0)
+                ? "verification_fail"
+                : providerStatus === "success" && effect !== "blocked" && (exitCode === null || exitCode === 0)
+                    ? "verification_pass"
+                    : null;
+            if (eventKind === null) continue;
+            events.push({
+                session,
+                source: sourceBySession.get(session) ?? null,
+                tsMs,
+                kind: eventKind,
+                check,
+                linesAdded: 0,
+                linesRemoved: 0,
+            });
+        }
+        return events;
+    });
 
 export const formatSessionChurnSummary = (summary: SessionChurnSummary): string => {
     if (summary.aggregates.length === 0) {
@@ -412,6 +685,58 @@ const topCheck = (counts: ReadonlyMap<string, number>): string | null => {
 
 const increment = (counts: Map<string, number>, key: string, amount: number): void => {
     counts.set(key, (counts.get(key) ?? 0) + amount);
+};
+
+const uniqueCleanSessionIds = (ids: readonly string[]): string[] =>
+    [...new Set(ids.map((id) => cleanSessionId(id)).filter((id) => id.length > 0))];
+
+const churnOptions = (
+    input: FetchSessionChurnInput,
+    project: string | null,
+    source: string | null,
+    limit: number,
+): ComputeSessionChurnOptions => ({
+    since: input.since,
+    project,
+    source,
+    limit,
+    ...(input.generatedAt !== undefined ? { generatedAt: input.generatedAt } : {}),
+});
+
+const recordRefList = (table: string, ids: readonly string[]): string =>
+    ids
+        .map((id) => recordKeyPart(id, table))
+        .filter((id): id is string => id !== null && id.length > 0)
+        .map((id) => recordLiteral(table, id))
+        .join(", ");
+
+const touchedIdentity = (row: Record<string, unknown>): string | null => {
+    const file = strOrNull(row.file);
+    if (file !== null) return file;
+    const path = strOrNull(row.path) ?? strOrNull(row.new_path) ?? strOrNull(row.old_path);
+    return path;
+};
+
+const normalizedCheckFrom = (...values: readonly unknown[]): string | null => {
+    for (const value of values) {
+        const check = normalizeCheckFamily(strOrNull(value));
+        if (check !== null) return check;
+    }
+    return null;
+};
+
+const exitCodeOf = (value: unknown): number | null => {
+    if (value === null || value === undefined) return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+};
+
+const msOrNull = (value: unknown): number | null => {
+    if (value instanceof Date) return value.getTime();
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value !== "string" || value.length === 0) return null;
+    const ms = new Date(value).getTime();
+    return Number.isFinite(ms) ? ms : null;
 };
 
 const taskLabelOf = (input: string | null | SessionHealthChurnInput | undefined): string | null => {

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -119,7 +119,8 @@ interface MutableSessionState {
     episodes: number;
     passedEpisodes: number;
     hasPriorEdit: boolean;
-    openChecks: Set<string>;
+    /** check family -> tsMs of the failure that opened/refreshed the episode */
+    openChecks: Map<string, number>;
     checkFailures: Map<string, number>;
 }
 
@@ -141,6 +142,13 @@ interface MutableAggregateState {
 const DEFAULT_LIMIT = 10;
 const IN_CHUNK = 500;
 
+/**
+ * An open episode whose failure saw no same-family verification event for
+ * this long stops attributing edits as repair churn - one uncaptured pass
+ * must not taint the rest of the session.
+ */
+export const EPISODE_EXPIRY_MS = 30 * 60_000;
+
 // Accepts an already-canonical family ("test") or a raw command ("bun test");
 // raw commands classify only when the check is in command position.
 export const normalizeCheckFamily = (raw: string | null): string | null =>
@@ -156,7 +164,6 @@ export const computeSessionChurn = (
     const limit = Math.max(0, Math.trunc(options.limit ?? DEFAULT_LIMIT));
     const generatedAt = dateishToIso(options.generatedAt ?? new Date());
     const states = new Map<string, MutableSessionState>();
-    const countedRepairEditKeys = new Set<string>();
     const normalizedLanded = normalizeLandedMap(landedBySession);
     const normalizedHealth = normalizeHealthMap(healthBySession);
 
@@ -175,6 +182,7 @@ export const computeSessionChurn = (
     for (const event of sorted) {
         const state = getState(states, event.session, event.source, normalizedLanded, normalizedHealth);
         if (state.source === null && event.source !== null) state.source = event.source;
+        expireOpenChecks(state, event.tsMs);
 
         if (event.kind === "edit") {
             state.editEvents += 1;
@@ -183,12 +191,8 @@ export const computeSessionChurn = (
             state.hasPriorEdit = true;
 
             if (state.openChecks.size > 0) {
-                const repairKey = `${event.session}:${event.index}`;
-                if (!countedRepairEditKeys.has(repairKey)) {
-                    countedRepairEditKeys.add(repairKey);
-                    state.repairLinesAdded += nonNegative(event.linesAdded);
-                    state.repairLinesRemoved += nonNegative(event.linesRemoved);
-                }
+                state.repairLinesAdded += nonNegative(event.linesAdded);
+                state.repairLinesRemoved += nonNegative(event.linesRemoved);
             }
             continue;
         }
@@ -199,9 +203,9 @@ export const computeSessionChurn = (
         if (event.kind === "verification_fail") {
             state.verificationFailures += 1;
             increment(state.checkFailures, check, 1);
-            if (state.hasPriorEdit && !state.openChecks.has(check)) {
-                state.openChecks.add(check);
-                state.episodes += 1;
+            if (state.hasPriorEdit) {
+                if (!state.openChecks.has(check)) state.episodes += 1;
+                state.openChecks.set(check, event.tsMs);
             }
             continue;
         }
@@ -596,7 +600,7 @@ const getState = (
         episodes: 0,
         passedEpisodes: 0,
         hasPriorEdit: false,
-        openChecks: new Set(),
+        openChecks: new Map(),
         checkFailures: new Map(),
     };
     states.set(session, state);
@@ -631,6 +635,12 @@ const normalizeHealthMap = (
 };
 
 const normalizeSessionKey = (session: string): string => cleanSessionId(session);
+
+const expireOpenChecks = (state: MutableSessionState, tsMs: number): void => {
+    for (const [check, openedAt] of state.openChecks) {
+        if (tsMs - openedAt > EPISODE_EXPIRY_MS) state.openChecks.delete(check);
+    }
+};
 
 const hasVerificationSignal = (row: SessionChurnRow): boolean =>
     row.verificationFailures > 0

--- a/apps/axctl/src/metrics/session-filter.test.ts
+++ b/apps/axctl/src/metrics/session-filter.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { sessionProjectClause } from "./session-filter.ts";
+
+describe("sessionProjectClause", () => {
+    test("matches root path, claude slug, exact cwd, and subdirectory cwd", () => {
+        const clause = sessionProjectClause("/Users/n/Projects/ax");
+        expect(clause).toBe(
+            '(project = "/Users/n/Projects/ax" OR project = "-Users-n-Projects-ax"'
+            + ' OR cwd = "/Users/n/Projects/ax" OR string::starts_with(cwd ?? "", "/Users/n/Projects/ax/"))',
+        );
+    });
+
+    test("prefixes columns for record-deref queries", () => {
+        const clause = sessionProjectClause("/repo", "session.");
+        expect(clause).toContain('session.project = "/repo"');
+        expect(clause).toContain('session.project = "-repo"');
+        expect(clause).toContain('string::starts_with(session.cwd ?? "", "/repo/")');
+    });
+});

--- a/apps/axctl/src/metrics/session-filter.ts
+++ b/apps/axctl/src/metrics/session-filter.ts
@@ -1,0 +1,24 @@
+import { pathToProjectSlug } from "@ax/lib/shared/project-slug";
+import { surrealString } from "@ax/lib/shared/surql";
+
+/**
+ * One SQL clause for "session belongs to this project root", shared by the
+ * sessions metrics / aggregates / churn and dashboard cost / loc queries.
+ *
+ * Matches all the ways a session can carry its project identity:
+ * - `project = <root>`          providers that store the raw cwd as project
+ * - `project = <claude-slug>`   Claude stores `~/.claude/projects` dir slugs
+ * - `cwd = <root>`              exact checkout root
+ * - `cwd` inside `<root>/`      subdirectory and worktree sessions
+ *
+ * `fieldPrefix` lets record-deref queries pass `"session."`; queries on the
+ * session table itself use the default bare columns.
+ */
+export const sessionProjectClause = (projectRoot: string, fieldPrefix = ""): string => {
+    const root = surrealString(projectRoot);
+    const slug = surrealString(pathToProjectSlug(projectRoot));
+    const prefix = surrealString(projectRoot.endsWith("/") ? projectRoot : `${projectRoot}/`);
+    const col = (name: string) => `${fieldPrefix}${name}`;
+    return `(${col("project")} = ${root} OR ${col("project")} = ${slug}`
+        + ` OR ${col("cwd")} = ${root} OR string::starts_with(${col("cwd")} ?? "", ${prefix}))`;
+};

--- a/apps/axctl/src/metrics/session-metrics-query.ts
+++ b/apps/axctl/src/metrics/session-metrics-query.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
-import { surrealDate, surrealString } from "@ax/lib/shared/surql";
+import { surrealDate } from "@ax/lib/shared/surql";
 import { nonEmptyString } from "@ax/lib/shared/derive-keys";
 import { fetchSessionCostMap } from "./cost-estimate.ts";
 import { chunked, cleanSessionId, numOrNull, numOrZero, sessionRefList, strOrNull } from "./util.ts";

--- a/apps/axctl/src/metrics/session-metrics-query.ts
+++ b/apps/axctl/src/metrics/session-metrics-query.ts
@@ -5,6 +5,7 @@ import { surrealDate, surrealString } from "@ax/lib/shared/surql";
 import { nonEmptyString } from "@ax/lib/shared/derive-keys";
 import { fetchSessionCostMap } from "./cost-estimate.ts";
 import { chunked, cleanSessionId, numOrNull, numOrZero, sessionRefList, strOrNull } from "./util.ts";
+import { sessionProjectClause } from "./session-filter.ts";
 
 export interface SessionMetricsRow {
     readonly session: string;
@@ -80,10 +81,7 @@ export const fetchSessionMetrics = (
         const limit = Math.min(Math.max(input.limit, 1), 500);
         const clauses: string[] = [];
         if (input.since) clauses.push(`session.started_at >= ${surrealDate(input.since)}`);
-        if (input.project) {
-            const project = surrealString(input.project);
-            clauses.push(`(session.project = ${project} OR session.cwd = ${project})`);
-        }
+        if (input.project) clauses.push(sessionProjectClause(input.project, "session."));
         const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
         const rows = (yield* db.query<[Array<Record<string, unknown>>]>(`
 SELECT

--- a/apps/axctl/src/nav/next-links.test.ts
+++ b/apps/axctl/src/nav/next-links.test.ts
@@ -181,6 +181,23 @@ describe("buildSessionsNext", () => {
         expect(next.filter((l) => l.ui?.group === "resume")).toHaveLength(0);
     });
 
+    test("non-empty window suggests the churn rollup", () => {
+        const { next } = buildSessionsNext([row({})], { project: "/Users/x/proj" });
+        const churn = next.find((l) => l.cmd?.includes("sessions churn"));
+        expect(churn?.cmd).toBe('ax sessions churn --project="/Users/x/proj"');
+    });
+
+    test("non-empty window without project suggests bare churn", () => {
+        const { next } = buildSessionsNext([row({})]);
+        const churn = next.find((l) => l.cmd?.includes("sessions churn"));
+        expect(churn?.cmd).toBe("ax sessions churn");
+    });
+
+    test("empty window has no churn link", () => {
+        const { next } = buildSessionsNext([], { date: "2026-06-09", days: 3 });
+        expect(next.find((l) => l.cmd?.includes("sessions churn"))).toBeUndefined();
+    });
+
     test("empty window with date teaches widening", () => {
         const { next } = buildSessionsNext([], { date: "2026-06-09", days: 3 });
         const widen = next.find((l) => l.call?.tool === "sessions_around");

--- a/apps/axctl/src/nav/next-links.ts
+++ b/apps/axctl/src/nav/next-links.ts
@@ -243,6 +243,18 @@ export const buildSessionsNext = (
         }
     }
 
+    // ③ Churn rollup over the same scope - cmd-only until an MCP
+    //    sessions_churn tool exists.
+    if (rows.length > 0) {
+        top.push({
+            description: "Aggregate verification churn (edit vs repair LOC, failed checks) for this scope",
+            cmd: opts.project
+                ? `ax sessions churn --project="${opts.project}"`
+                : "ax sessions churn",
+            ui: { priority: 5, group: "read" },
+        });
+    }
+
     // ⑤ Empty window - teach widening / dropping the filter.
     if (rows.length === 0 && opts.date) {
         const widened = (opts.days ?? 3) * 2;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,8 +21,10 @@ axctl skills <search|taste|unused|pairs|recovery|stats|recent|classify|tag|lint|
 axctl agents <config|reconcile|scope|park|unpark|rm>   # agent-file registry + overrides
 axctl insights <view>                       # 31 read-only graph views
 axctl classifiers <list|eval|explain|...>   # classifier coverage, graph, lifecycle, label-mining
-axctl sessions <here|around <date>|near <sha>|show <id>|compare|metrics>
+axctl sessions <here|around <date>|near <sha>|show <id>|compare|metrics|churn>
                                             # windowed session queries + graph-derived metrics
+axctl sessions churn [--here|--project=P] [--source=S] [--since=N] [--json]
+                                            # verification churn: landed vs edit vs repair LOC, failed checks, episodes
 axctl signals <list|show <id>>              # relation-signal catalog (fragility cascade, ...)
 axctl costs summary [--since=N]             # estimated token cost by provider/model
 axctl costs for --session <id>              # cost for one session

--- a/docs/insights-cli-reference.md
+++ b/docs/insights-cli-reference.md
@@ -225,6 +225,19 @@ plan snapshots, estimated tokens, cache ratios, and a coarse context-pressure
 bucket. These rows power `token-impact`, `cache-health`, `workflow-impact`, and
 `codex-health`.
 
+## Verification Churn (`ax sessions churn`)
+
+`ax sessions churn [--here|--project=P] [--source=S] [--since=N] [--json]`
+rolls verification churn up by session and source: landed LOC (commits via
+`produced`/`touched`), edit LOC (edit-class tool calls), and repair LOC -
+edits made while a verification episode is open. An episode opens when a
+check command (test / typecheck / lint / build) fails after prior edits and
+closes when a same-family check passes; open episodes expire after 30
+minutes. Check classification is anchored to command position (`bun test`
+counts, `ls test/` does not). Default window is 30 days; `--here` scopes to
+the current repo (project slug, cwd, and worktree/subdirectory sessions all
+match).
+
 ## Closure Quality And Skill Candidate Tables
 
 The closure-quality slice adds:

--- a/docs/superpowers/plans/2026-06-11-session-verification-churn.md
+++ b/docs/superpowers/plans/2026-06-11-session-verification-churn.md
@@ -1,0 +1,364 @@
+# Session Verification Churn Insight Implementation Plan
+
+> Required execution mode: `superpowers:subagent-driven-development`. Implement task-by-task, with a worker per implementation slice and reviewer passes after each slice.
+
+## Goal
+
+Ship a first aggregate signal for "agent wrote code, verification complained, agent repaired it" using data ax already ingests.
+
+User-facing command:
+
+```bash
+ax sessions churn --here --since=30
+ax sessions churn --source=claude --since=7
+ax sessions churn --json
+```
+
+The command reports:
+
+- aggregate rows by provider source;
+- a bounded "hot sessions" list ranked by verification failures and repair churn;
+- separate landed LOC, edit churn LOC, and repair churn LOC so attempted edits are not mislabeled as git-landed diff.
+
+## Non-Goals
+
+- No schema migration in v1.
+- No tokei language/comment classification in v1.
+- No dashboard UI in v1.
+- No per-file repair attribution in v1.
+
+## Existing Data Sources
+
+- `session_metrics.lines_added` / `session_metrics.lines_removed`: edit-class tool-call churn already derived by ingest.
+- `produced -> touched`: landed git diff line counts (`touched.additions`, `touched.deletions`) by session.
+- `command_outcome`: derived shell command outcomes. Failed test/typecheck/lint/build/check commands are `kind = "expected_feedback"` with `status = "error"`; successful commands are `kind = "success"` with `status = "ok"`.
+- `hook_command_invocation`: provider hook commands. Blocked/nonzero invocations are verification failures; successful/nonblocking invocations can close an episode.
+- `tool_call`: edit events with timestamps and input JSON. Use the existing edit-tool classification helpers and `applyPatchDelta`/`editDelta` logic.
+
+## Files
+
+Create:
+
+- `apps/axctl/src/metrics/session-churn.ts`
+- `apps/axctl/src/metrics/session-churn.test.ts`
+
+Modify:
+
+- `apps/axctl/src/cli/commands/sessions.ts`
+- `apps/axctl/src/cli/effect-cli.test.ts`
+
+## Semantics
+
+### Check Family Normalization
+
+`normalizeCheckFamily(raw: string | null): string | null`
+
+Rules:
+
+- `oxlint`, `oxc`, hook names/commands containing `oxlint` -> `oxlint`
+- `eslint` -> `eslint`
+- `tsc`, `typecheck`, `tsgo` -> `typecheck`
+- `bun test`, `vitest`, `jest`, `playwright`, `test` -> `test`
+- `build` -> `build`
+- `check` -> `check`
+- otherwise `null`
+
+Use the command text first when available, then command norm/tool/hook name.
+
+### Event Model
+
+Use a pure event stream before any aggregation:
+
+```ts
+export interface ChurnEvent {
+    readonly session: string;
+    readonly source: string | null;
+    readonly tsMs: number;
+    readonly kind: "edit" | "verification_fail" | "verification_pass";
+    readonly check: string | null;
+    readonly linesAdded: number;
+    readonly linesRemoved: number;
+}
+```
+
+Edit events carry line deltas and `check = null`.
+
+Verification events carry `check != null` and zero line deltas.
+
+### Episode Rules
+
+`computeSessionChurn(events, landedBySession, healthBySession)`
+
+- Sort events by `(session, tsMs)`.
+- A repair episode starts at a verification failure only if the same session has at least one prior edit event.
+- Subsequent edit events count as repair churn until:
+  - a verification pass for the same check family closes the episode; or
+  - the session ends.
+- A later pass marks the episode `passed = true`; no later pass keeps the episode and `passed = false`.
+- Repeated failures of the same check while an episode is open increment failure count but do not double-count already-counted edits.
+- Multiple open check families may exist; one edit after failures can count toward each open episode only if the checks are distinct. The session-level `repairLinesAdded/Removed` must dedupe edit event ids or timestamps so one edit is not counted twice in the headline totals.
+
+### Output Rows
+
+Session row:
+
+```ts
+export interface SessionChurnRow {
+    readonly session: string;
+    readonly source: string | null;
+    readonly taskLabel: string | null;
+    readonly landedLinesAdded: number;
+    readonly landedLinesRemoved: number;
+    readonly editLinesAdded: number;
+    readonly editLinesRemoved: number;
+    readonly repairLinesAdded: number;
+    readonly repairLinesRemoved: number;
+    readonly editEvents: number;
+    readonly verificationFailures: number;
+    readonly verificationPasses: number;
+    readonly episodes: number;
+    readonly passedEpisodes: number;
+    readonly topCheck: string | null;
+}
+```
+
+Aggregate row:
+
+```ts
+export interface SourceChurnAggregate {
+    readonly source: string;
+    readonly sessions: number;
+    readonly sessionsWithFailures: number;
+    readonly landedLinesAdded: number;
+    readonly landedLinesRemoved: number;
+    readonly editLinesAdded: number;
+    readonly editLinesRemoved: number;
+    readonly repairLinesAdded: number;
+    readonly repairLinesRemoved: number;
+    readonly verificationFailures: number;
+    readonly episodes: number;
+    readonly passedEpisodes: number;
+    readonly topCheck: string | null;
+}
+```
+
+Payload:
+
+```ts
+export interface SessionChurnSummary {
+    readonly generatedAt: string;
+    readonly filters: {
+        readonly since: string | null;
+        readonly project: string | null;
+        readonly source: string | null;
+        readonly limit: number;
+    };
+    readonly aggregates: SourceChurnAggregate[];
+    readonly hotSessions: SessionChurnRow[];
+}
+```
+
+### Formatting
+
+Plain output:
+
+```text
+verification churn by source
+source  sess  fail-sess  fails  episodes  pass  landed    edits      repair    top
+codex     32         11     44        18    12  +120/-8  +980/-210  +310/-90  typecheck
+
+hot sessions
+session               source  fails  episodes  pass  landed   edits      repair    top        task
+abc123...             codex      12         4     3  +10/-2  +220/-80  +90/-40   oxlint     ...
+```
+
+Empty output should say:
+
+```text
+no verification churn rows matched (run `ax ingest`, or loosen --since/--source/--here).
+```
+
+JSON output should be `prettyPrint(summary)`.
+
+## Fetcher Shape
+
+`fetchSessionChurnSummary(input)` in `session-churn.ts`.
+
+Input:
+
+```ts
+export interface FetchSessionChurnInput {
+    readonly since: Date | null;
+    readonly project: string | null;
+    readonly source: string | null;
+    readonly limit: number;
+}
+```
+
+Queries:
+
+1. Base sessions from `session_metrics`, filtered by `session.started_at`, `session.project/cwd`, and `session.source`.
+
+```sql
+SELECT
+  type::string(session) AS session,
+  session.source AS source,
+  session.project AS project,
+  session.cwd AS cwd,
+  lines_added, lines_removed
+FROM session_metrics
+WHERE ...
+```
+
+2. Health map with `fetchSessionHealthMap(sessionIds)` for task labels.
+
+3. Landed diff:
+
+```sql
+SELECT type::string(in) AS session, type::string(out) AS commit
+FROM produced
+WHERE in IN [session:`...`];
+```
+
+Then:
+
+```sql
+SELECT type::string(in) AS commit, additions, deletions
+FROM touched
+WHERE in IN [commit:`...`];
+```
+
+Join in JS: session -> commit(s) -> touched rows.
+
+4. Edit events:
+
+```sql
+SELECT type::string(session) AS session, type::string(ts) AS ts, name, command_norm, input_json
+FROM tool_call
+WHERE session IN [...] AND <editToolSqlFilter>
+ORDER BY ts ASC;
+```
+
+Use `toolClassInputOf`, `isEditTool`, `isApplyPatchCall`, `canonicalEditToolName`, `applyPatchDelta`, and `editDelta`.
+
+5. Command verification events:
+
+```sql
+SELECT type::string(session) AS session, type::string(ts) AS ts,
+       command_norm, command_tool, kind, status, text
+FROM command_outcome
+WHERE session IN [...] AND (kind = "expected_feedback" OR status = "ok")
+ORDER BY ts ASC;
+```
+
+Filter to known check families in JS. Failure when `kind = "expected_feedback"` or `status = "error"`; pass when `status = "ok"`.
+
+6. Hook verification events:
+
+```sql
+SELECT type::string(session) AS session, type::string(ts) AS ts,
+       hook_name, command, provider_status, effect, exit_code
+FROM hook_command_invocation
+WHERE session IN [...]
+ORDER BY ts ASC;
+```
+
+Filter to known check families in JS. Failure when `provider_status = "blocking_error"` or `effect = "blocked"` or `exit_code != 0`; pass when `provider_status = "success"` and `effect != "blocked"` and `exit_code` is `0` or `NONE`.
+
+Batch `IN` lists with existing `chunked`/`sessionRefList`. Do not use correlated edge derefs over `produced`, `touched`, or `tool_call`.
+
+## Task 1: Pure Model and Formatting
+
+Worker owns:
+
+- `apps/axctl/src/metrics/session-churn.ts`
+- `apps/axctl/src/metrics/session-churn.test.ts`
+
+Steps:
+
+1. Create the event/row/aggregate/payload interfaces.
+2. Implement `normalizeCheckFamily`.
+3. Implement `computeSessionChurn`.
+4. Implement `formatSessionChurnSummary`.
+5. Add tests for:
+   - check normalization;
+   - failure starts only after a prior edit;
+   - repair churn after a failure and before a pass;
+   - repeated failure does not double-count already-counted edits;
+   - aggregate top check and pass ratio;
+   - empty formatter hint.
+6. Run:
+
+```bash
+bun test apps/axctl/src/metrics/session-churn.test.ts
+```
+
+Expected: pass.
+
+## Task 2: Fetcher and CLI
+
+Worker owns:
+
+- `apps/axctl/src/metrics/session-churn.ts`
+- `apps/axctl/src/metrics/session-churn.test.ts`
+- `apps/axctl/src/cli/commands/sessions.ts`
+- `apps/axctl/src/cli/effect-cli.test.ts`
+
+Steps:
+
+1. Add `fetchSessionChurnSummary`.
+2. Add mocked-db tests proving:
+   - base query filters `session.started_at`, `session.project/cwd`, and `session.source`;
+   - empty base sessions skip secondary scans;
+   - landed LOC joins `produced` to `touched` in JS;
+   - edit tool rows become edit events with line deltas;
+   - command and hook rows become verification fail/pass events.
+3. Add `cmdSessionsChurn` in `apps/axctl/src/cli/commands/sessions.ts`.
+4. Add `sessionsChurnCommand` with flags:
+
+```ts
+since: optionalSince,
+project: Flag.string("project").pipe(Flag.optional),
+here: Flag.boolean("here").pipe(Flag.withDefault(false)),
+source: Flag.string("source").pipe(Flag.optional),
+limit: positiveLimit(20),
+json: jsonFlag,
+```
+
+5. Wire it into `sessionsCommand` subcommands and update the command description.
+6. Update `effect-cli.test.ts` so the sessions subcommand exposure test includes `churn`.
+7. Run:
+
+```bash
+bun test apps/axctl/src/metrics/session-churn.test.ts apps/axctl/src/cli/effect-cli.test.ts
+```
+
+Expected: pass.
+
+## Verification
+
+Final verification after both tasks:
+
+```bash
+bun test apps/axctl/src/metrics/session-churn.test.ts apps/axctl/src/cli/effect-cli.test.ts
+bun run typecheck
+apps/axctl/bin/axctl sessions churn --here --since=30 --limit=10
+apps/axctl/bin/axctl sessions churn --here --since=30 --limit=3 --json
+```
+
+If full `bun run typecheck` fails from unrelated repository errors, capture the relevant filtered command:
+
+```bash
+bun run typecheck 2>&1 | rg "session-churn|cli/commands/sessions|effect-cli"
+```
+
+Expected: empty.
+
+## Review Gates
+
+After each implementation task:
+
+1. Run a spec compliance review against this plan.
+2. Run a code quality review focused on correctness, DB query shape, type safety, and test coverage.
+3. Fix blocking findings before moving to the next task.
+


### PR DESCRIPTION
## Summary

New `ax sessions churn` command: per-session/source rollup of verification churn - landed LOC vs edit LOC vs repair LOC after failed checks, with episode tracking (failure opens, same-family pass closes, 30-min expiry).

Closes #297, closes #298.

Beyond the base feature, a 10-finding review pass was applied on the branch:

- **Anchored check-family classification** (`ingest/check-family.ts`, shared by ingest outcome gate + churn): `ls test/`, `cat build.log`, hook names like `bun-test-blocking` no longer open/close episodes; fail-side output text never infers a check.
- **All error outcome kinds count as failures** - previously `product_bug_signal`/`environment_blocker`/`unknown` rows (the majority of real failing checks) were silently excluded (~10x undercount measured live).
- **Codex edits existed**: codex `apply_patch` arrives as `custom_tool_call`, which ingest dropped entirely - codex sessions showed 0 edit/repair LOC. Now parsed into `tool_call` rows. **Historical sessions need a re-ingest** (`ax ingest --since=N`).
- **Deref-free, bounded queries**: base scan moved off `session_metrics` per-row `session.*` derefs onto indexed `session` columns; `tool_call.command_text` deref replaced with a batched id lookup; CLI defaults `--since=30` (the unbounded shape previously hung `skills weighted`).
- **Aggregate correctness**: multi-session commits counted once per source (no more double-counted landed LOC); open episodes expire after 30min so one uncaptured pass can't taint a whole session as repair.
- **Shared `sessionProjectClause`** (churn/metrics/aggregates/cost/loc): `--here`/`--project` now match Claude project slugs and subdirectory/worktree cwds.

## Test Plan

- [x] `bun test` repo-wide green (3335 pass), `bun run typecheck` clean
- [x] Live smoke after 7d re-ingest: codex went from `edits +0/-0, episodes 0` to `+286/-142, 23 episodes`
- [x] `ax sessions churn --here` matches claude + worktree sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)