### PR TITLE
feat(routing): apply /routing-tune mined classes

### DIFF
--- a/apps/axctl/src/queries/dispatch-analytics.test.ts
+++ b/apps/axctl/src/queries/dispatch-analytics.test.ts
@@ -62,8 +62,8 @@ describe("ROUTING_CLASSES", () => {
         expect(ROUTING_CLASSES.version).toBe(1);
     });
 
-    it("has 5 classes", () => {
-        expect(ROUTING_CLASSES.classes).toHaveLength(5);
+    it("has 8 classes", () => {
+        expect(ROUTING_CLASSES.classes).toHaveLength(8);
     });
 
     it("has agentTypes for Explore, codebase-locator, codebase-pattern-finder, codebase-analyzer", () => {

--- a/apps/axctl/src/queries/dispatch-analytics.ts
+++ b/apps/axctl/src/queries/dispatch-analytics.ts
@@ -84,6 +84,31 @@ export const ROUTING_CLASSES: RoutingTable = {
             suggest: "sonnet",
             reason: "bulk mechanical work",
         },
+        // Mined by /routing-tune 2026-06-12 (adversarially backtested over 90d;
+        // brief: .ax/tasks/routing-tune-undated.md). The colon in task-N-impl
+        // is load-bearing: "Task 4 spec compliance review" (no colon) must NOT
+        // match - reviews stay on the main model.
+        {
+            id: "task-N-impl",
+            pattern: "^Task \\d+:",
+            flags: "i",
+            suggest: "sonnet",
+            reason: "numbered plan-task implementation",
+        },
+        {
+            id: "bug-fix",
+            pattern: "^Fix\\s",
+            flags: "i",
+            suggest: "sonnet",
+            reason: "bounded bug-fix remediation",
+        },
+        {
+            id: "feature-add",
+            pattern: "^Add\\s",
+            flags: "i",
+            suggest: "sonnet",
+            reason: "additive feature with a clear target",
+        },
     ],
     agentTypes: {
         Explore: "haiku",

--- a/packages/hooks-sdk/src/hooks/route-dispatch.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.ts
@@ -93,6 +93,28 @@ const DEFAULT_TABLE: RoutingTableType = {
       suggest: "sonnet",
       reason: "bulk mechanical work",
     },
+    // Mined by /routing-tune 2026-06-12; mirrors dispatch-analytics.ts.
+    {
+      id: "task-N-impl",
+      pattern: "^Task \\d+:",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "numbered plan-task implementation",
+    },
+    {
+      id: "bug-fix",
+      pattern: "^Fix\\s",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "bounded bug-fix remediation",
+    },
+    {
+      id: "feature-add",
+      pattern: "^Add\\s",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "additive feature with a clear target",
+    },
   ],
   agentTypes: {
     Explore: "haiku",

--- a/skills/efficient-dispatch/SKILL.md
+++ b/skills/efficient-dispatch/SKILL.md
@@ -32,6 +32,9 @@ mirror it:
 | research | `^(research\|investigate docs\|study)` | sonnet |
 | well-specified-impl | `^implement ` | sonnet |
 | bulk-mechanical | `^(write announcements\|regenerate\|standardize\|merge main)` | sonnet |
+| task-N-impl | `^Task \d+:` | sonnet |
+| bug-fix | `^Fix\s` | sonnet |
+| feature-add | `^Add\s` | sonnet |
 | agent types | Explore, codebase-locator, codebase-pattern-finder → haiku; codebase-analyzer → sonnet | |
 <!-- /ax:routing-table -->
 


### PR DESCRIPTION
First live run of `/routing-tune` (the committed workflow from #307), reviewed and applied.

## What the run found (30d window, 7 agents, ~250k tokens)

- **$1,127** unmatched expensive-inherit dispatch spend
- 5 proposed classes → **3 survived** adversarial backtest:
  - `task-N-impl` (`^Task \d+:`) — colon anchor is load-bearing: excludes "Task 4 spec compliance review" (judgment, stays on main). 0 FPs / 90d
  - `bug-fix` (`^Fix\s`) — "Fix X review feedback" *applies* fixes, doesn't review; verb anchors semantic direction. 0 FPs / 30 matches
  - `feature-add` (`^Add\s`) — additive "Add X to Y" shape. 0 FPs / 9 matches
- 2 rejected with structural reasoning (`^Issue \d+` would silently match "Issue 5 design the schema"; `^Verify\s` unconstrained) — each with a condition-to-unblock
- 1 retirement proposal (**rejected in review**: "Explore: zero matches" contradicts this week's observed Explore dispatches — cost-sorted sample bias)

## Effect

30d candidate savings: **$275 → $573**. Both copies updated (ROUTING_CLASSES + hook DEFAULT_TABLE), skill table regenerated via `compile-routing --skill-md`, sync test green. 49 tests pass.

Brief: `.ax/tasks/routing-tune-undated.md` (the `-undated` name is a known workflow-args quirk — args arrived stringified; tolerated by defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)