### PR TITLE
docs+workflow: honest candidate-savings semantics, routing-tune hardening

### DIFF
--- a/.claude/workflows/routing-tune.workflow.js
+++ b/.claude/workflows/routing-tune.workflow.js
@@ -18,8 +18,19 @@ export const meta = {
   ],
 };
 
-const days = (args && args.days) || 30;
-const date = (args && args.date) || "undated";
+// Tolerate stringified args - some callers pass args as a JSON string, which
+// would otherwise silently fall through to defaults (first live run produced
+// routing-tune-undated.md this way).
+let parsedArgs = args;
+if (typeof parsedArgs === "string") {
+  try {
+    parsedArgs = JSON.parse(parsedArgs);
+  } catch {
+    parsedArgs = undefined;
+  }
+}
+const days = (parsedArgs && parsedArgs.days) || 30;
+const date = (parsedArgs && parsedArgs.date) || "undated";
 
 const PROPOSAL_SCHEMA = {
   type: "object",
@@ -69,7 +80,10 @@ const mined = await agent(
   `(b) match NO current class, and (c) look mechanical (bounded scope, spec'd, search/summarize/convert work - ` +
   `NOT quality review, PR review, plan synthesis, architecture, or taste-heavy design/copy: those stay on the main model by policy). ` +
   `Cluster their descriptions and propose at most 5 new routing classes with tight ^-anchored patterns - ` +
-  `prefer missing a few over matching judgment work. Also list existing class ids that matched zero dispatches in the window.`,
+  `prefer missing a few over matching judgment work. Also list existing class ids that matched zero dispatches in the window - ` +
+  `but BEWARE sample bias: --limit truncates the cost-sorted list, so cheap dispatches (Explore/locator children) fall off it. ` +
+  `Before claiming a class matched zero dispatches, verify against the UNTRUNCATED window (raise --limit or query the spawned ` +
+  `agent_type distribution directly); when you cannot rule out truncation, do not propose the retirement.`,
   { label: "mine:unmatched", phase: "Mine", schema: PROPOSAL_SCHEMA, model: "sonnet" },
 );
 

--- a/docs/design/cost-routing.md
+++ b/docs/design/cost-routing.md
@@ -126,6 +126,23 @@ stage (form=hook) so accumulated candidate savings surface in
 - Keep tool-heavy loops (build/test cycles, browser QA) OUT of the expensive
   main context - the dominant cost is the main loop re-reading ~250k context
   on every tool call, not subagent output tokens.
-- Measured ceiling on this machine: ~$275/3d redirectable via dispatch
-  routing alone; several times that from moving grunt loops out of the main
-  context.
+- Measured on this machine (30d window): ~$404 of identified redirectable
+  dispatch spend with the hand-written classes, ~$573 after `/routing-tune`
+  mined three more (+42% detector coverage). Several times that is available
+  from moving grunt loops out of the main context.
+
+## Reading the numbers honestly
+
+`--candidates` totals are **identified redirectable spend** - a retrospective,
+hypothetical repricing of past dispatches, NOT realized savings and NOT a
+spend change. Growing the number means the detector got better at naming the
+leak; no dollars moved. Realized savings only appear go-forward, as the hook
+and skill change dispatch behavior - measure them as the inherit rate
+dropping (`ax dispatches`) and subagent spend shifting toward cheap models
+(`ax cost split`) across an adoption boundary. And compare like windows:
+a 3-day figure and a 30-day figure are different questions.
+
+Scope note vs billing tools (ccusage etc.): ax prices from `agent_model`
+list rates and counts subagent transcripts as separate rows; billing tools
+see plan-level accounting and usually only main session files. Use ax for
+"where inside the work did it go", billing data for "what did I pay".


### PR DESCRIPTION
Polish pass after the user caught two real issues:

1. **The headline delta was apples-to-oranges** — "$275 → $573" compared a 3-day pre-tune figure with a 30-day post-tune figure. True same-window numbers (30d, computed by filtering candidates by class id): **$403.61 with the hand-written classes → $573.21 with the mined classes (+42% detector coverage)**. Design doc updated.
2. **The semantics were easy to misread as savings.** New "Reading the numbers honestly" section: `--candidates` totals are *identified redirectable spend* (retrospective repricing of past dispatches), not realized savings; realized savings are measured go-forward via inherit rate + `cost split` across an adoption boundary; plus the ax-vs-billing-tools scope note (list rates + subagent transcripts vs plan accounting + main sessions only).

Workflow hardening from the first live run's dogfood findings:
- tolerate stringified `args` (the run wrote `routing-tune-undated.md` because args arrived JSON-encoded)
- miner is warned about cost-sorted `--limit` truncation before proposing class retirements (the bogus "Explore: zero matches" claim was exactly this bias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)