### PR TITLE
fix(studio): guard sessionInsights against old-daemon catch-all payload

### DIFF
--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -269,8 +269,18 @@ export const api = {
         jsonFetch(`/api/sessions/${encodeURIComponent(sessionId)}`),
     sessionChildren: (parentId: string): Promise<SessionChildrenResponse> =>
         jsonFetch(`/api/sessions/${encodeURIComponent(parentId)}/children`),
-    sessionInsights: (sessionId: string): Promise<SessionInsightsPayload> =>
-        jsonFetch(`/api/sessions/${encodeURIComponent(sessionId)}/insights`),
+    sessionInsights: async (sessionId: string): Promise<SessionInsightsPayload> => {
+        const payload = await jsonFetch<SessionInsightsPayload>(
+            `/api/sessions/${encodeURIComponent(sessionId)}/insights`,
+        );
+        // Daemons older than the /insights route answer via the /api/sessions/:id+
+        // catch-all with a 200 + session-detail shape. Reject it here so callers
+        // hit their query error path instead of crashing on `payload.phases`.
+        if (!Array.isArray((payload as { phases?: unknown }).phases)) {
+            throw new ApiError("daemon too old for session insights - update axctl", 404);
+        }
+        return payload;
+    },
     sessionInspect: (sessionId: string, params: { turnOffset?: number; turnLimit?: number } = {}): Promise<SessionInspectPayload> => {
         const usp = new URLSearchParams();
         if (params.turnOffset != null) usp.set("turn_offset", String(params.turnOffset));


### PR DESCRIPTION
## Problem

https://ax.necmttn.com/studio/sessions crashes with `n.phases is not iterable` when hosted studio is connected (`?endpoint=`) to any released daemon.

Root cause chain:
1. `/api/sessions/:id+/insights` shipped in #299 but is **not in any release tag** — released daemons (0.25.0/0.26.0) don't have the route.
2. On those daemons the request falls through to the `/api/sessions/:id+` catch-all (id = `<uuid>/insights`), which answers **200** with a session-detail payload (`{overview:null,...}`) — no `phases`.
3. `StoryStrip` iterates `payload.phases` during render → error boundary takes down the whole sessions page.

Verified against the live local daemon (v0.25.0 on :1738): `/insights` returns the detail shape; `/children` and `/inspect` already exist with correct shapes, so only `/insights` needs the guard.

## Fix

Validate the payload shape in `api.sessionInsights` and throw `ApiError` when `phases` isn't an array. Callers then hit their existing query error paths: StoryStrip renders the blank strip, InsightPanel shows "failed to load insights · retry".

## Testing

- `apps/studio` typecheck clean
- `bun test apps/studio`: 300 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)