### PR TITLE
feat(profile): ax profile publish/unpublish - profiles spec, plan 2 (gist + fork rails)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,9 +125,16 @@ fresh clone.
 ### Profile
 
 `ax profile show [--window=N] [--no-cost] [--json]` - render your local ax
-profile (ProfileV1: stats + rig + taste patterns) from the graph. Local-only
-preview; publish/gist/leaderboard land in later plans
-(docs/superpowers/specs/2026-06-12-ax-profiles-design.md).
+profile (ProfileV1: stats + rig + taste patterns) from the graph.
+`ax profile publish [--window=N] [--no-cost] [--if-stale=H] [--yes] [--skip-registration]` -
+publish to a public gist (create once, PATCH in place). First run: consent
+prompt showing the exact JSON, then fork + community/users/<login>.json
+registration PR into Necmttn/ax (git-data API, no local clone). The watcher
+runs `--if-stale=6` after ingest - silent no-op until first consent.
+`--no-cost` is sticky across republishes; `ax profile unpublish` (delete
+gist + local state) resets it. State: `~/.ax/profile-publish.json`. Spec:
+docs/superpowers/specs/2026-06-12-ax-profiles-design.md; leaderboard/site
+land in plans 3-4.
 
 ### Dispatch routing
 

--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -1,7 +1,8 @@
 /**
  * `ax profile show` - render the local profile (ProfileV1) from the graph.
- * Local-only preview; publish (gist + fork registration) lands in a later
- * plan. Mirrors the commands/ax-cost.ts pattern: read-only, `db` runtime.
+ * `ax profile publish` - publish ProfileV1 to a public gist (create once, PATCH in place);
+ *   first run shows the exact JSON, asks for consent, then opens a community registration PR.
+ * `ax profile unpublish` - delete the published gist and local publish state.
  */
 import { Effect } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
@@ -9,7 +10,20 @@ import { prettyPrint } from "@ax/lib/json";
 import { buildProfile, type ProfileEnv } from "../../profile/render.ts";
 import type { ProfileV1 } from "../../profile/schema.ts";
 import type { RuntimeManifest } from "./manifest.ts";
-import { fail, jsonFlag } from "./shared.ts";
+import { fail, jsonFlag, optionValue } from "./shared.ts";
+import { GitHubEnvLive } from "../../profile/github-env.ts";
+import {
+    createProfileGist,
+    deleteProfileGist,
+    ensureRegistration,
+    isStale,
+    patchProfileGist,
+} from "../../profile/publish.ts";
+import {
+    defaultPublishStatePath,
+    loadPublishState,
+    savePublishState,
+} from "../../profile/publish-state.ts";
 
 // ---------------------------------------------------------------------------
 // Environment gathering (the only IO in this file)
@@ -147,11 +161,142 @@ const profileShowCommand = Command.make(
     ),
 );
 
+// ---------------------------------------------------------------------------
+// ax profile publish [--window=N] [--no-cost] [--if-stale=H] [--yes] [--skip-registration]
+// ---------------------------------------------------------------------------
+
+const cmdProfilePublish = (input: {
+    readonly window: number;
+    readonly noCost: boolean;
+    readonly ifStaleHours: number | null;
+    readonly yes: boolean;
+    readonly skipRegistration: boolean;
+}) =>
+    Effect.gen(function* () {
+        const statePath = defaultPublishStatePath();
+        const state = yield* Effect.promise(() => loadPublishState(statePath));
+        const nowIso = new Date().toISOString();
+
+        if (input.ifStaleHours !== null) {
+            // --if-stale is the watcher path: no state file -> silent no-op (never prompts).
+            if (state === null) return;
+            if (!isStale(state.published_at, input.ifStaleHours, nowIso)) return;
+        }
+
+        const env = yield* gatherEnv;
+        const noCost = input.noCost || (state?.no_cost ?? false);
+        const profile = yield* buildProfile({
+            windowDays: input.window,
+            includeCost: !noCost,
+            env,
+        });
+
+        if (state === null) {
+            // First publish: consent gate. Show EXACTLY what leaves the machine
+            // (incl. taste summaries - see profile/taste.ts PUBLISH GATE).
+            console.log(prettyPrint(profile));
+            console.log("\nThis exact JSON will be published as a PUBLIC gist under your GitHub account.");
+            if (!input.yes) {
+                const ans = (globalThis.prompt?.("Publish? [y/N]") ?? "").trim().toLowerCase();
+                if (ans !== "y" && ans !== "yes") {
+                    console.log("Aborted. Nothing was published.");
+                    return;
+                }
+            }
+            const ref = yield* createProfileGist(profile);
+            yield* Effect.promise(() =>
+                savePublishState(statePath, {
+                    v: 1,
+                    gist_id: ref.gistId,
+                    owner: ref.owner,
+                    consented_at: nowIso,
+                    published_at: nowIso,
+                    no_cost: noCost,
+                }),
+            );
+            console.log(`\npublished: https://gist.github.com/${ref.owner}/${ref.gistId}`);
+
+            if (!input.skipRegistration) {
+                const result = yield* ensureRegistration({
+                    login: ref.owner,
+                    gistId: ref.gistId,
+                    joined: nowIso.slice(0, 10),
+                });
+                console.log(
+                    result.status === "pr-opened"
+                        ? `registration PR: ${result.prUrl}`
+                        : "already registered in the community directory.",
+                );
+            }
+            return;
+        }
+
+        // Subsequent publish: PATCH gist, update state.
+        yield* patchProfileGist(state.gist_id, profile);
+        yield* Effect.promise(() =>
+            savePublishState(statePath, { ...state, published_at: nowIso, no_cost: noCost }),
+        );
+        console.log(`updated: https://gist.github.com/${state.owner}/${state.gist_id}`);
+    }).pipe(Effect.provide(GitHubEnvLive));
+
+const profilePublishCommand = Command.make(
+    "publish",
+    {
+        window: Flag.integer("window").pipe(Flag.withDefault(30)),
+        noCost: Flag.boolean("no-cost").pipe(Flag.withDefault(false)),
+        ifStale: Flag.integer("if-stale").pipe(Flag.optional),
+        yes: Flag.boolean("yes").pipe(Flag.withDefault(false)),
+        skipRegistration: Flag.boolean("skip-registration").pipe(Flag.withDefault(false)),
+    },
+    ({ window, noCost, ifStale, yes, skipRegistration }) => {
+        if (!Number.isInteger(window) || window <= 0) {
+            fail(`ax profile publish: --window must be a positive integer (got "${window}")`);
+        }
+        const ifStaleHours = optionValue(ifStale) ?? null;
+        if (ifStaleHours !== null && (!Number.isInteger(ifStaleHours) || ifStaleHours <= 0)) {
+            fail(`ax profile publish: --if-stale must be positive hours (got "${ifStaleHours}")`);
+        }
+        return cmdProfilePublish({ window, noCost, ifStaleHours, yes, skipRegistration });
+    },
+).pipe(
+    Command.withDescription(
+        "Publish your profile to a public gist (create once, update in place); " +
+        "first run asks for consent and opens the community registration PR. " +
+        "--window=N  --no-cost  --if-stale=<hours>  --yes  --skip-registration",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax profile unpublish
+// ---------------------------------------------------------------------------
+
+const cmdProfileUnpublish = () =>
+    Effect.gen(function* () {
+        const statePath = defaultPublishStatePath();
+        const state = yield* Effect.promise(() => loadPublishState(statePath));
+        if (state === null) {
+            console.log("not published (no local publish state).");
+            return;
+        }
+        yield* deleteProfileGist(state.gist_id);
+        yield* Effect.promise(async () => {
+            await Bun.$`rm -f ${statePath}`.quiet().nothrow();
+        });
+        console.log(`deleted gist ${state.gist_id} and local publish state.`);
+        console.log(
+            `If you registered, open a removal PR for community/users/${state.owner}.json in Necmttn/ax.`,
+        );
+    }).pipe(Effect.provide(GitHubEnvLive));
+
+const profileUnpublishCommand = Command.make("unpublish", {}, () => cmdProfileUnpublish()).pipe(
+    Command.withDescription("Delete the published profile gist and local publish state."),
+);
+
 export const profileCommand = Command.make("profile").pipe(
     Command.withDescription(
         "Your ax profile: stats, rig, and taste rendered from the local graph",
     ),
-    Command.withSubcommands([profileShowCommand]),
+    Command.withSubcommands([profileShowCommand, profilePublishCommand, profileUnpublishCommand]),
 );
 
 export const axProfileRuntime: RuntimeManifest = {

--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -195,7 +195,11 @@ const cmdProfilePublish = (input: {
             // First publish: consent gate. Show EXACTLY what leaves the machine
             // (incl. taste summaries - see profile/taste.ts PUBLISH GATE).
             console.log(prettyPrint(profile));
-            console.log("\nThis exact JSON will be published as a PUBLIC gist under your GitHub account.");
+            console.log(
+                "\nThis exact JSON will be published as a PUBLIC gist under your GitHub account,\n" +
+                "and kept fresh automatically (the watcher republishes future data, including new\n" +
+                "taste patterns) until you run `ax profile unpublish`.",
+            );
             if (!input.yes) {
                 const ans = (globalThis.prompt?.("Publish? [y/N]") ?? "").trim().toLowerCase();
                 if (ans !== "y" && ans !== "yes") {
@@ -278,7 +282,15 @@ const cmdProfileUnpublish = () =>
             console.log("not published (no local publish state).");
             return;
         }
-        yield* deleteProfileGist(state.gist_id);
+        // Tolerate an already-deleted gist (404): local state cleanup must
+        // never be blocked by remote state drift.
+        yield* deleteProfileGist(state.gist_id).pipe(
+            Effect.catchTag("GitHubApiError", (e) =>
+                e.status === 404
+                    ? Effect.sync(() => console.log("gist already deleted remotely."))
+                    : Effect.fail(e),
+            ),
+        );
         yield* Effect.promise(async () => {
             await Bun.$`rm -f ${statePath}`.quiet().nothrow();
         });

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -147,7 +147,7 @@ const watchPlist = (binPath: string): string => `<?xml version="1.0" encoding="U
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>${binPath} ingest --since=1 >>${LOG_DIR}/watcher.log 2>&amp;1 &amp;&amp; ${binPath} derive-signals --since=1 >>${LOG_DIR}/watcher.log 2>&amp;1</string>
+    <string>${binPath} ingest --since=1 >>${LOG_DIR}/watcher.log 2>&amp;1 &amp;&amp; ${binPath} derive-signals --since=1 >>${LOG_DIR}/watcher.log 2>&amp;1; ${binPath} profile publish --if-stale=6 >>${LOG_DIR}/watcher.log 2>&amp;1 || true</string>
   </array>
   <key>WatchPaths</key>
   <array>

--- a/apps/axctl/src/profile/github-env.test.ts
+++ b/apps/axctl/src/profile/github-env.test.ts
@@ -39,4 +39,16 @@ describe("GitHubEnvTest", () => {
         );
         expect(result).toBe("err:404");
     });
+
+    test("login defaults to null when not canned", async () => {
+        const t = GitHubEnvTest({ responses: {} });
+        const login = await run(
+            Effect.gen(function* () {
+                const gh = yield* GitHubEnv;
+                return yield* gh.login();
+            }),
+            t,
+        );
+        expect(login).toBeNull();
+    });
 });

--- a/apps/axctl/src/profile/github-env.test.ts
+++ b/apps/axctl/src/profile/github-env.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { GitHubEnv, GitHubEnvTest } from "./github-env.ts";
+
+const run = <A, E>(eff: Effect.Effect<A, E, GitHubEnv>, layer: ReturnType<typeof GitHubEnvTest>) =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer.layer)) as Effect.Effect<A, E>);
+
+describe("GitHubEnvTest", () => {
+    test("replays canned responses per METHOD path key and records calls", async () => {
+        const t = GitHubEnvTest({
+            responses: { "POST /gists": { id: "abc123", owner: { login: "necmttn" } } },
+            login: "necmttn",
+        });
+        const out = await run(
+            Effect.gen(function* () {
+                const gh = yield* GitHubEnv;
+                const created = yield* gh.api("POST", "/gists", { files: {} });
+                const login = yield* gh.login();
+                return { created, login };
+            }),
+            t,
+        );
+        expect((out.created as { id: string }).id).toBe("abc123");
+        expect(out.login).toBe("necmttn");
+        expect(t.calls).toEqual([{ method: "POST", path: "/gists", body: { files: {} } }]);
+    });
+
+    test("missing canned response fails with GitHubApiError", async () => {
+        const t = GitHubEnvTest({ responses: {} });
+        const result = await run(
+            Effect.gen(function* () {
+                const gh = yield* GitHubEnv;
+                return yield* gh.api("GET", "/user").pipe(
+                    Effect.map(() => "ok" as const),
+                    Effect.catchTag("GitHubApiError", (e) => Effect.succeed(`err:${e.status}`)),
+                );
+            }),
+            t,
+        );
+        expect(result).toBe("err:404");
+    });
+});

--- a/apps/axctl/src/profile/github-env.ts
+++ b/apps/axctl/src/profile/github-env.ts
@@ -1,0 +1,107 @@
+/**
+ * GitHubEnv - the single seam through which profile publish talks to
+ * GitHub. Live layer shells out to `gh api` (auth handled by gh); the test
+ * layer replays canned responses and records calls, so every publish
+ * operation is testable without network. Mirrors hooks-sdk GitEnv.
+ */
+import { Context, Effect, Layer, Schema } from "effect";
+
+export class GitHubApiError extends Schema.TaggedErrorClass<GitHubApiError>(
+    "GitHubApiError",
+)("GitHubApiError", {
+    status: Schema.Number,
+    message: Schema.String,
+}) {}
+
+export type GhMethod = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+
+export interface GitHubEnvService {
+    /** `gh api --method <method> <path>` with optional JSON body on stdin. */
+    readonly api: (
+        method: GhMethod,
+        path: string,
+        body?: unknown,
+    ) => Effect.Effect<unknown, GitHubApiError>;
+    /** authenticated login, null when gh is missing/unauthenticated. */
+    readonly login: () => Effect.Effect<string | null>;
+}
+
+export class GitHubEnv extends Context.Service<GitHubEnv, GitHubEnvService>()(
+    "axctl/profile/GitHubEnv",
+) {}
+
+const ghApi = async (method: GhMethod, path: string, body?: unknown): Promise<unknown> => {
+    const args = ["gh", "api", "--method", method, path, ...(body !== undefined ? ["--input", "-"] : [])];
+    const proc = Bun.spawn(args, {
+        stdin: body !== undefined ? "pipe" : "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    if (body !== undefined && proc.stdin) {
+        proc.stdin.write(JSON.stringify(body));
+        proc.stdin.end();
+    }
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    if (exitCode !== 0) {
+        // gh prints "gh: Not Found (HTTP 404)" style messages on stderr.
+        const m = /HTTP (\d{3})/.exec(stderr);
+        throw new GitHubApiError({
+            status: m ? Number(m[1]) : 1,
+            message: stderr.trim() || stdout.trim() || `gh api ${path} exited ${exitCode}`,
+        });
+    }
+    return stdout.trim() === "" ? null : JSON.parse(stdout);
+};
+
+const liveShape: GitHubEnvService = {
+    api: (method, path, body) =>
+        Effect.tryPromise({
+            try: () => ghApi(method, path, body),
+            catch: (e) =>
+                e instanceof GitHubApiError
+                    ? e
+                    : new GitHubApiError({ status: 0, message: e instanceof Error ? e.message : String(e) }),
+        }),
+    login: () =>
+        Effect.tryPromise({
+            try: async () => {
+                const proc = Bun.spawn(["gh", "api", "user", "--jq", ".login"], {
+                    stdout: "pipe",
+                    stderr: "ignore",
+                });
+                const out = await new Response(proc.stdout).text();
+                return (await proc.exited) === 0 && out.trim() !== "" ? out.trim() : null;
+            },
+            catch: () => null,
+        }).pipe(Effect.orElseSucceed(() => null)),
+};
+
+export const GitHubEnvLive: Layer.Layer<GitHubEnv> = Layer.succeed(GitHubEnv, liveShape);
+
+export interface RecordedCall {
+    readonly method: GhMethod;
+    readonly path: string;
+    readonly body?: unknown;
+}
+
+/** Test layer: canned responses keyed "METHOD path"; records every call. */
+export const GitHubEnvTest = (config: {
+    responses: Record<string, unknown>;
+    login?: string | null;
+}): { layer: Layer.Layer<GitHubEnv>; calls: RecordedCall[] } => {
+    const calls: RecordedCall[] = [];
+    const layer = Layer.succeed(GitHubEnv, {
+        api: (method, path, body) => {
+            calls.push(body !== undefined ? { method, path, body } : { method, path });
+            const key = `${method} ${path}`;
+            if (key in config.responses) return Effect.succeed(config.responses[key]);
+            return Effect.fail(new GitHubApiError({ status: 404, message: `no canned response for ${key}` }));
+        },
+        login: () => Effect.succeed(config.login ?? null),
+    });
+    return { layer, calls };
+};

--- a/apps/axctl/src/profile/github-env.ts
+++ b/apps/axctl/src/profile/github-env.ts
@@ -61,6 +61,8 @@ const liveShape: GitHubEnvService = {
     api: (method, path, body) =>
         Effect.tryPromise({
             try: () => ghApi(method, path, body),
+            // status 0 = spawn/JSON-parse failure (not an HTTP status);
+            // status 1 = gh exited non-zero without an HTTP code on stderr.
             catch: (e) =>
                 e instanceof GitHubApiError
                     ? e

--- a/apps/axctl/src/profile/github-env.ts
+++ b/apps/axctl/src/profile/github-env.ts
@@ -90,7 +90,21 @@ export interface RecordedCall {
     readonly body?: unknown;
 }
 
-/** Test layer: canned responses keyed "METHOD path"; records every call. */
+/** Canned error marker: `{ __error: { status, message } }` makes api() fail. */
+const asInjectedError = (value: unknown): GitHubApiError | null => {
+    if (typeof value !== "object" || value === null || !("__error" in value)) return null;
+    const e = (value as { __error: unknown }).__error;
+    if (typeof e !== "object" || e === null) return null;
+    const { status, message } = e as { status?: unknown; message?: unknown };
+    if (typeof status !== "number" || typeof message !== "string") return null;
+    return new GitHubApiError({ status, message });
+};
+
+/**
+ * Test layer: canned responses keyed "METHOD path"; records every call.
+ * Missing key → GitHubApiError 404. A canned value of
+ * `{ __error: { status, message } }` injects a failure with that status.
+ */
 export const GitHubEnvTest = (config: {
     responses: Record<string, unknown>;
     login?: string | null;
@@ -100,7 +114,12 @@ export const GitHubEnvTest = (config: {
         api: (method, path, body) => {
             calls.push(body !== undefined ? { method, path, body } : { method, path });
             const key = `${method} ${path}`;
-            if (key in config.responses) return Effect.succeed(config.responses[key]);
+            if (key in config.responses) {
+                const value = config.responses[key];
+                const injected = asInjectedError(value);
+                if (injected !== null) return Effect.fail(injected);
+                return Effect.succeed(value);
+            }
             return Effect.fail(new GitHubApiError({ status: 404, message: `no canned response for ${key}` }));
         },
         login: () => Effect.succeed(config.login ?? null),

--- a/apps/axctl/src/profile/publish-state.test.ts
+++ b/apps/axctl/src/profile/publish-state.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { loadPublishState, savePublishState, type PublishState } from "./publish-state.ts";
+
+const dir = `/tmp/ax-publish-state-test-${process.pid}`;
+const path = `${dir}/profile-publish.json`;
+
+afterEach(async () => {
+    await Bun.$`rm -rf ${dir}`.quiet().nothrow();
+});
+
+const state: PublishState = {
+    v: 1,
+    gist_id: "abc123",
+    owner: "necmttn",
+    consented_at: "2026-06-12T19:00:00Z",
+    published_at: "2026-06-12T19:00:00Z",
+    no_cost: false,
+};
+
+describe("publish state", () => {
+    test("round-trips", async () => {
+        await savePublishState(path, state);
+        expect(await loadPublishState(path)).toEqual(state);
+    });
+
+    test("missing file -> null", async () => {
+        expect(await loadPublishState(`${dir}/nope.json`)).toBeNull();
+    });
+
+    test("corrupt file -> null (never throws)", async () => {
+        await Bun.write(path, "{not json");
+        expect(await loadPublishState(path)).toBeNull();
+    });
+
+    test("wrong shape -> null", async () => {
+        await Bun.write(path, JSON.stringify({ v: 99 }));
+        expect(await loadPublishState(path)).toBeNull();
+    });
+});

--- a/apps/axctl/src/profile/publish-state.ts
+++ b/apps/axctl/src/profile/publish-state.ts
@@ -1,0 +1,68 @@
+/**
+ * Local publish state: consent + gist pointer + freshness. One JSON at
+ * ~/.ax/profile-publish.json. Deleting the file revokes consent (the
+ * watcher step no-ops without it). Reads never throw - any corruption
+ * degrades to "not published yet".
+ *
+ * Atomic write: Bun.write(tmp) + mv rename keeps the reader from ever
+ * seeing a partial file. node:fs is banned by CI gate check:no-node-fs,
+ * so we use Bun.spawnSync(["mv", ...]) for the rename step.
+ */
+
+export interface PublishState {
+    readonly v: 1;
+    readonly gist_id: string;
+    readonly owner: string;
+    readonly consented_at: string;
+    readonly published_at: string;
+    readonly no_cost: boolean;
+}
+
+export const defaultPublishStatePath = (): string =>
+    `${process.env.HOME}/.ax/profile-publish.json`;
+
+export async function loadPublishState(path: string): Promise<PublishState | null> {
+    try {
+        const file = Bun.file(path);
+        if (!(await file.exists())) return null;
+        const raw: unknown = JSON.parse(await file.text());
+        if (typeof raw !== "object" || raw === null) return null;
+        const r = raw as Record<string, unknown>;
+        if (
+            r.v !== 1 ||
+            typeof r.gist_id !== "string" ||
+            typeof r.owner !== "string" ||
+            typeof r.consented_at !== "string" ||
+            typeof r.published_at !== "string" ||
+            typeof r.no_cost !== "boolean"
+        ) {
+            return null;
+        }
+        return {
+            v: 1,
+            gist_id: r.gist_id,
+            owner: r.owner,
+            consented_at: r.consented_at,
+            published_at: r.published_at,
+            no_cost: r.no_cost,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export async function savePublishState(path: string, state: PublishState): Promise<void> {
+    // Atomic: write to a sibling tmp file, then rename into place.
+    // Same-directory rename is atomic on POSIX. node:fs is banned by the
+    // check:no-node-fs CI gate, so we use Bun.spawnSync(["mv", ...]).
+    const tmp = `${path}.${process.pid}.tmp`;
+    await Bun.write(tmp, `${JSON.stringify(state, null, 2)}\n`, { createPath: true });
+    const result = Bun.spawnSync(["mv", tmp, path]);
+    if (result.exitCode !== 0) {
+        // Clean up the tmp file and surface the error
+        Bun.spawnSync(["rm", "-f", tmp]);
+        throw new Error(
+            `savePublishState: mv ${tmp} → ${path} failed (exit ${result.exitCode})`,
+        );
+    }
+}

--- a/apps/axctl/src/profile/publish.test.ts
+++ b/apps/axctl/src/profile/publish.test.ts
@@ -1,0 +1,106 @@
+// apps/axctl/src/profile/publish.test.ts
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { GitHubEnvTest } from "./github-env.ts";
+import {
+    createProfileGist,
+    ensureRegistration,
+    isStale,
+    patchProfileGist,
+    profileGistPayload,
+    REGISTRY_REPO,
+} from "./publish.ts";
+import type { ProfileV1 } from "./schema.ts";
+
+const profile = {
+    v: 1, github: "necmttn", generated_at: "2026-06-12T19:00:00Z", window_days: 30,
+    stats: {
+        sessions: 1, active_days: 1, streak_days: 1,
+        tokens: { prompt: 1, completion: 1, total: 2 },
+        models: [], harnesses: ["claude"],
+    },
+    rig: { skills: [], hooks: [], routing_table: false },
+} as unknown as ProfileV1;
+
+const run = <A, E>(eff: Effect.Effect<A, E, never>) => Effect.runPromise(eff);
+
+describe("profileGistPayload", () => {
+    test("one file, public, stable filename", () => {
+        const p = profileGistPayload(profile);
+        expect(p.public).toBe(true);
+        expect(Object.keys(p.files)).toEqual(["ax-profile.json"]);
+        expect(JSON.parse(p.files["ax-profile.json"]!.content).github).toBe("necmttn");
+    });
+});
+
+describe("isStale", () => {
+    test("fresh within ttl", () => {
+        expect(isStale("2026-06-12T18:00:00Z", 6, "2026-06-12T19:00:00Z")).toBe(false);
+    });
+    test("stale past ttl", () => {
+        expect(isStale("2026-06-12T10:00:00Z", 6, "2026-06-12T19:00:00Z")).toBe(true);
+    });
+    test("garbage timestamp counts as stale", () => {
+        expect(isStale("nope", 6, "2026-06-12T19:00:00Z")).toBe(true);
+    });
+});
+
+describe("createProfileGist / patchProfileGist", () => {
+    test("create POSTs /gists and returns ref", async () => {
+        const t = GitHubEnvTest({
+            responses: { "POST /gists": { id: "g1", owner: { login: "necmttn" } } },
+        });
+        const ref = await run(createProfileGist(profile).pipe(Effect.provide(t.layer)));
+        expect(ref).toEqual({ gistId: "g1", owner: "necmttn" });
+        expect(t.calls[0]!.method).toBe("POST");
+    });
+
+    test("patch PATCHes /gists/:id", async () => {
+        const t = GitHubEnvTest({ responses: { "PATCH /gists/g1": { id: "g1" } } });
+        await run(patchProfileGist("g1", profile).pipe(Effect.provide(t.layer)));
+        expect(t.calls[0]).toMatchObject({ method: "PATCH", path: "/gists/g1" });
+    });
+});
+
+describe("ensureRegistration", () => {
+    test("skips when registration file already exists upstream", async () => {
+        const t = GitHubEnvTest({
+            responses: {
+                [`GET /repos/${REGISTRY_REPO}/contents/community/users/necmttn.json`]: { sha: "x" },
+            },
+        });
+        const r = await run(
+            ensureRegistration({ login: "necmttn", gistId: "g1", joined: "2026-06-12" })
+                .pipe(Effect.provide(t.layer)),
+        );
+        expect(r).toEqual({ status: "already-registered" });
+        expect(t.calls).toHaveLength(1);
+    });
+
+    test("full flow: fork, branch ref, blob/tree/commit, ref, PR", async () => {
+        const login = "necmttn";
+        const fork = `${login}/ax`;
+        const t = GitHubEnvTest({
+            responses: {
+                // No GET contents key - test layer 404s missing keys = "not registered"
+                [`POST /repos/${REGISTRY_REPO}/forks`]: { full_name: fork },
+                [`GET /repos/${fork}/git/ref/heads/main`]: { object: { sha: "base" } },
+                [`POST /repos/${fork}/git/blobs`]: { sha: "blob1" },
+                [`GET /repos/${fork}/git/commits/base`]: { tree: { sha: "tree0" } },
+                [`POST /repos/${fork}/git/trees`]: { sha: "tree1" },
+                [`POST /repos/${fork}/git/commits`]: { sha: "commit1" },
+                [`POST /repos/${fork}/git/refs`]: { ref: "refs/heads/ax-profile-necmttn" },
+                [`POST /repos/${REGISTRY_REPO}/pulls`]: { html_url: "https://github.com/Necmttn/ax/pull/999" },
+            },
+        });
+        const r = await run(
+            ensureRegistration({ login, gistId: "g1", joined: "2026-06-12" })
+                .pipe(Effect.provide(t.layer)),
+        );
+        expect(r).toEqual({ status: "pr-opened", prUrl: "https://github.com/Necmttn/ax/pull/999" });
+        const paths = t.calls.map((c) => `${c.method} ${c.path}`);
+        expect(paths).toContain(`POST /repos/${REGISTRY_REPO}/forks`);
+        expect(paths).toContain(`POST /repos/${login}/ax/git/blobs`);
+        expect(paths).toContain(`POST /repos/${REGISTRY_REPO}/pulls`);
+    });
+});

--- a/apps/axctl/src/profile/publish.test.ts
+++ b/apps/axctl/src/profile/publish.test.ts
@@ -53,6 +53,9 @@ describe("createProfileGist / patchProfileGist", () => {
         const ref = await run(createProfileGist(profile).pipe(Effect.provide(t.layer)));
         expect(ref).toEqual({ gistId: "g1", owner: "necmttn" });
         expect(t.calls[0]!.method).toBe("POST");
+        const body = t.calls[0]!.body as { public: boolean; files: Record<string, unknown> };
+        expect(body.public).toBe(true);
+        expect(Object.keys(body.files)).toContain("ax-profile.json");
     });
 
     test("patch PATCHes /gists/:id", async () => {
@@ -102,5 +105,52 @@ describe("ensureRegistration", () => {
         expect(paths).toContain(`POST /repos/${REGISTRY_REPO}/forks`);
         expect(paths).toContain(`POST /repos/${login}/ax/git/blobs`);
         expect(paths).toContain(`POST /repos/${REGISTRY_REPO}/pulls`);
+
+        const callBody = (path: string): unknown =>
+            t.calls.find((c) => c.path === path)?.body;
+        const expectedContent = `${JSON.stringify(
+            { github: login, gist_id: "g1", joined: "2026-06-12" },
+            null,
+            2,
+        )}\n`;
+        expect(callBody(`/repos/${fork}/git/blobs`)).toEqual({
+            content: expectedContent,
+            encoding: "utf-8",
+        });
+        expect(callBody(`/repos/${fork}/git/trees`)).toMatchObject({
+            tree: [
+                {
+                    path: "community/users/necmttn.json",
+                    mode: "100644",
+                    type: "blob",
+                    sha: "blob1",
+                },
+            ],
+        });
+        expect(callBody(`/repos/${fork}/git/commits`)).toMatchObject({ parents: ["base"] });
+        expect(callBody(`/repos/${REGISTRY_REPO}/pulls`)).toMatchObject({
+            head: "necmttn:ax-profile-necmttn",
+            base: "main",
+        });
+    });
+
+    test("non-404 error on contents check fails registration without forking", async () => {
+        const t = GitHubEnvTest({
+            responses: {
+                [`GET /repos/${REGISTRY_REPO}/contents/community/users/necmttn.json`]: {
+                    __error: { status: 500, message: "boom" },
+                },
+            },
+        });
+        const outcome = await run(
+            ensureRegistration({ login: "necmttn", gistId: "g1", joined: "2026-06-12" }).pipe(
+                Effect.map(() => "ok" as const),
+                Effect.catchTag("GitHubApiError", (e) => Effect.succeed(`err:${e.status}`)),
+                Effect.provide(t.layer),
+            ),
+        );
+        expect(outcome).toBe("err:500");
+        const paths = t.calls.map((c) => `${c.method} ${c.path}`);
+        expect(paths).not.toContain(`POST /repos/${REGISTRY_REPO}/forks`);
     });
 });

--- a/apps/axctl/src/profile/publish.ts
+++ b/apps/axctl/src/profile/publish.ts
@@ -1,0 +1,140 @@
+/**
+ * Publish operations: gist payload + create/patch, staleness, and the
+ * one-time fork -> remote commit -> PR registration into the main repo
+ * (community/users/<login>.json). Everything goes through GitHubEnv; no
+ * local clone is ever made (git-data API: blob -> tree -> commit -> ref).
+ */
+import { Effect } from "effect";
+import { GitHubApiError, GitHubEnv } from "./github-env.ts";
+import type { ProfileV1 } from "./schema.ts";
+
+export const REGISTRY_REPO = "Necmttn/ax";
+
+export interface GistRef {
+    readonly gistId: string;
+    readonly owner: string;
+}
+
+export function profileGistPayload(profile: ProfileV1): {
+    readonly description: string;
+    readonly public: boolean;
+    readonly files: Record<string, { readonly content: string }>;
+} {
+    return {
+        description: `ax profile - ${profile.github}`,
+        public: true,
+        files: { "ax-profile.json": { content: `${JSON.stringify(profile, null, 2)}\n` } },
+    };
+}
+
+/** hoursTtl staleness vs an injected `now` (no Date.now in logic). */
+export function isStale(publishedAt: string, hoursTtl: number, now: string): boolean {
+    const pub = Date.parse(publishedAt);
+    const ref = Date.parse(now);
+    if (!Number.isFinite(pub) || !Number.isFinite(ref)) return true;
+    return ref - pub > hoursTtl * 3_600_000;
+}
+
+const asRecord = (u: unknown): Record<string, unknown> =>
+    typeof u === "object" && u !== null ? (u as Record<string, unknown>) : {};
+
+export const createProfileGist = Effect.fn("profile.createProfileGist")(
+    function* (profile: ProfileV1) {
+        const gh = yield* GitHubEnv;
+        const out = asRecord(yield* gh.api("POST", "/gists", profileGistPayload(profile)));
+        const owner = asRecord(out.owner);
+        return {
+            gistId: String(out.id ?? ""),
+            owner: typeof owner.login === "string" ? owner.login : "",
+        } satisfies GistRef;
+    },
+);
+
+export const patchProfileGist = Effect.fn("profile.patchProfileGist")(
+    function* (gistId: string, profile: ProfileV1) {
+        const gh = yield* GitHubEnv;
+        yield* gh.api("PATCH", `/gists/${gistId}`, profileGistPayload(profile));
+    },
+);
+
+export const deleteProfileGist = Effect.fn("profile.deleteProfileGist")(
+    function* (gistId: string) {
+        const gh = yield* GitHubEnv;
+        yield* gh.api("DELETE", `/gists/${gistId}`);
+    },
+);
+
+export type RegistrationResult =
+    | { readonly status: "already-registered" }
+    | { readonly status: "pr-opened"; readonly prUrl: string };
+
+/**
+ * One-time registration: community/users/<login>.json via the user's fork.
+ * Idempotent: skips when the file already exists upstream. The branch is
+ * deterministic (ax-profile-<login>) so re-runs collide loudly instead of
+ * spamming PRs.
+ */
+export const ensureRegistration = Effect.fn("profile.ensureRegistration")(
+    function* (input: { readonly login: string; readonly gistId: string; readonly joined: string }) {
+        const gh = yield* GitHubEnv;
+        const { login, gistId, joined } = input;
+        const filePath = `community/users/${login}.json`;
+
+        const exists = yield* gh.api("GET", `/repos/${REGISTRY_REPO}/contents/${filePath}`).pipe(
+            Effect.map(() => true),
+            Effect.catchTag("GitHubApiError", (e: GitHubApiError) =>
+                e.status === 404 ? Effect.succeed(false) : Effect.fail(e),
+            ),
+        );
+        if (exists) return { status: "already-registered" } as const;
+
+        const fork = asRecord(yield* gh.api("POST", `/repos/${REGISTRY_REPO}/forks`, {}));
+        const forkFullName = typeof fork.full_name === "string" ? fork.full_name : `${login}/ax`;
+
+        const baseRef = asRecord(yield* gh.api("GET", `/repos/${forkFullName}/git/ref/heads/main`));
+        const baseSha = String(asRecord(baseRef.object).sha ?? "");
+
+        const content = `${JSON.stringify({ github: login, gist_id: gistId, joined }, null, 2)}\n`;
+        const blob = asRecord(
+            yield* gh.api("POST", `/repos/${forkFullName}/git/blobs`, {
+                content,
+                encoding: "utf-8",
+            }),
+        );
+
+        const baseCommit = asRecord(yield* gh.api("GET", `/repos/${forkFullName}/git/commits/${baseSha}`));
+        const baseTreeSha = String(asRecord(baseCommit.tree).sha ?? "");
+
+        const tree = asRecord(
+            yield* gh.api("POST", `/repos/${forkFullName}/git/trees`, {
+                base_tree: baseTreeSha,
+                tree: [{ path: filePath, mode: "100644", type: "blob", sha: blob.sha }],
+            }),
+        );
+
+        const commit = asRecord(
+            yield* gh.api("POST", `/repos/${forkFullName}/git/commits`, {
+                message: `community: register ax profile for @${login}`,
+                tree: tree.sha,
+                parents: [baseSha],
+            }),
+        );
+
+        const branch = `ax-profile-${login}`;
+        yield* gh.api("POST", `/repos/${forkFullName}/git/refs`, {
+            ref: `refs/heads/${branch}`,
+            sha: commit.sha,
+        });
+
+        const pr = asRecord(
+            yield* gh.api("POST", `/repos/${REGISTRY_REPO}/pulls`, {
+                title: `community: register ax profile for @${login}`,
+                head: `${login}:${branch}`,
+                base: "main",
+                body: `One-time ax profile registration. Gist: https://gist.github.com/${login}/${gistId}\n\nOpened by \`ax profile publish\`.`,
+            }),
+        );
+
+        return { status: "pr-opened", prUrl: String(pr.html_url ?? "") } as const;
+    },
+);

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -34,6 +34,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 
 ### Profile
 - `ax profile show [--window=N] [--no-cost]` - your local agent profile rendered from the graph: usage stats, rig (skills/hooks/rules), and evidence-grounded taste patterns
+- `ax profile publish` - share it: consent-gated public gist (updated in place by the watcher) + one-time community registration PR; `ax profile unpublish` reverses it
 
 ### Self-improvement loop
 - `ax improve recommend / accept / lint / show` - evidence-backed proposals (guidance, skills, hooks, automations) derived from the graph; accept emits a task brief, lint reconciles applied guidance

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,6 +36,9 @@ axctl cost <models|sessions|split>          # model/cost analytics incl. main-vs
 axctl dispatches [--candidates]             # subagent dispatch routing analytics + est savings
 axctl dispatches compile-routing            # regenerate ~/.ax/hooks/routing-table.json
 axctl profile show [--window=N] [--no-cost] # local profile: stats + rig + taste from the graph
+axctl profile publish [--if-stale=H] [--yes] [--skip-registration]
+                                            # publish profile gist + one-time community registration PR
+axctl profile unpublish                     # delete the published gist + local consent
 axctl pricing [--query <model>]             # inspect imported model pricing rows
 axctl share <session-id>                    # publish a sanitized session share via GitHub Gist
 axctl roles                                 # list role labels with skill counts

--- a/docs/superpowers/plans/2026-06-12-community-repo-rails.md
+++ b/docs/superpowers/plans/2026-06-12-community-repo-rails.md
@@ -1,0 +1,744 @@
+# Community Repo Rails (Plan 3 of 4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The `Necmttn/ax` repo accepts profile registrations safely (schema-validated, identity-checked, auto-merged) and compiles all registered gists nightly into leaderboard / skill-stats / hook-stats / state-distribution JSON the site (Plan 4) reads.
+
+**Architecture:** Two bun scripts (testable, no Action-only logic) + two thin workflows. `scripts/validate-community-users.ts` enforces the registration contract on PRs; `community-users.yml` runs it, verifies PR author == filename == json.github and that nothing else is touched, then auto-merges. `scripts/compile-community.ts` walks `community/users/*.json`, fetches each gist's `ax-profile.json` (injectable fetcher; ETag cache), validates rows through the canonical `ProfileV1` decoder (single source of truth from Plan 1), drops absurd values, and emits deterministic compiled JSON; `community-nightly.yml` runs it on cron and commits only on change.
+
+**Tech Stack:** bun scripts, GitHub Actions (mirror `.github/workflows/ci.yml` conventions: ubuntu-24.04, `oven-sh/setup-bun@v2` bun 1.3.10, `bun install --frozen-lockfile`), bun:test.
+
+**Conventions that bite:**
+- Scripts live in `scripts/`, run via `bun scripts/<name>.ts`, and exit non-zero with printed reasons (see `scripts/check-cli-reference.ts` for tone). Note: `scripts/` is NOT under the `check:no-node-fs` source gate the same way app code is - but verify with `bun run check:no-node-fs` after writing; if scripts are gated, use Bun APIs.
+- `bun test` may be hook-blocked locally → `/tmp/run-ax-tests.sh` wrapper.
+- Workflows: least-privilege `permissions:` per job; auto-merge needs `contents: write` + `pull-requests: write`.
+- Importing app code from scripts works by relative path (bun monorepo, no build step): `import { decodeProfile } from "../apps/axctl/src/profile/schema.ts"`.
+- Determinism: compiled JSON must be byte-stable for identical inputs (sorted keys/rows) or the nightly commit-on-change will churn.
+
+**File structure:**
+
+```
+community/
+├── README.md                          # what this dir is, registration contract
+└── users/                             # one <login>.json per registered user (starts empty)
+scripts/
+├── validate-community-users.ts        # PR gate: schema + identity + filename
+├── validate-community-users.test.ts
+├── compile-community.ts               # nightly: gists -> leaderboard/skill-stats/hook-stats/state
+└── compile-community.test.ts
+.github/workflows/
+├── community-users.yml                # validate + auto-merge registrations
+└── community-nightly.yml              # cron compile + commit-on-change
+```
+
+---
+
+### Task 1: Registration validator script
+
+**Files:**
+- Create: `scripts/validate-community-users.ts`
+- Test: `scripts/validate-community-users.test.ts`
+
+Contract (spec §3a): each `community/users/<login>.json` is exactly `{ github, gist_id, joined }`; `github` matches filename (case-insensitive login, file lowercase); `joined` is `YYYY-MM-DD`; unknown fields rejected. The script takes file paths as argv (the workflow passes changed files) plus `--author=<login>` and exits 1 on any violation.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// scripts/validate-community-users.test.ts
+import { afterEach, describe, expect, test } from "bun:test";
+import { validateUserFile } from "./validate-community-users.ts";
+
+const dir = `/tmp/ax-community-validate-${process.pid}`;
+
+afterEach(async () => {
+    await Bun.$`rm -rf ${dir}`.quiet().nothrow();
+});
+
+const write = async (name: string, content: unknown): Promise<string> => {
+    const path = `${dir}/community/users/${name}`;
+    await Bun.write(path, typeof content === "string" ? content : JSON.stringify(content));
+    return path;
+};
+
+describe("validateUserFile", () => {
+    test("accepts a valid registration matching the author", async () => {
+        const p = await write("necmttn.json", { github: "necmttn", gist_id: "abc123", joined: "2026-06-12" });
+        expect(await validateUserFile(p, "necmttn")).toEqual([]);
+    });
+
+    test("author mismatch rejected", async () => {
+        const p = await write("necmttn.json", { github: "necmttn", gist_id: "abc", joined: "2026-06-12" });
+        const errs = await validateUserFile(p, "someone-else");
+        expect(errs.some((e) => e.includes("author"))).toBe(true);
+    });
+
+    test("filename / github mismatch rejected", async () => {
+        const p = await write("other.json", { github: "necmttn", gist_id: "abc", joined: "2026-06-12" });
+        const errs = await validateUserFile(p, "necmttn");
+        expect(errs.some((e) => e.includes("filename"))).toBe(true);
+    });
+
+    test("unknown fields rejected", async () => {
+        const p = await write("necmttn.json", { github: "necmttn", gist_id: "abc", joined: "2026-06-12", admin: true });
+        const errs = await validateUserFile(p, "necmttn");
+        expect(errs.some((e) => e.includes("unknown field"))).toBe(true);
+    });
+
+    test("bad joined date rejected", async () => {
+        const p = await write("necmttn.json", { github: "necmttn", gist_id: "abc", joined: "yesterday" });
+        const errs = await validateUserFile(p, "necmttn");
+        expect(errs.some((e) => e.includes("joined"))).toBe(true);
+    });
+
+    test("malformed json rejected without throwing", async () => {
+        const p = await write("necmttn.json", "{nope");
+        const errs = await validateUserFile(p, "necmttn");
+        expect(errs.length).toBeGreaterThan(0);
+    });
+
+    test("uppercase login normalizes: file lowercase, github field case-insensitive", async () => {
+        const p = await write("necmttn.json", { github: "Necmttn", gist_id: "abc", joined: "2026-06-12" });
+        expect(await validateUserFile(p, "Necmttn")).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run (`/tmp/run-ax-tests.sh scripts/validate-community-users.test.ts`), verify FAIL**
+
+- [ ] **Step 3: Implement**
+
+```ts
+// scripts/validate-community-users.ts
+/**
+ * PR gate for community/users/<login>.json registrations (profiles spec
+ * §3a). Strict by construction: exactly {github, gist_id, joined}, filename
+ * == github == PR author (case-insensitive; filename lowercase), joined is
+ * YYYY-MM-DD. Used by .github/workflows/community-users.yml; also runnable
+ * locally: bun scripts/validate-community-users.ts --author=me community/users/me.json
+ */
+
+const ALLOWED_KEYS = new Set(["github", "gist_id", "joined"]);
+
+export async function validateUserFile(path: string, author: string): Promise<string[]> {
+    const errors: string[] = [];
+    const fileName = path.split("/").pop() ?? "";
+    const stem = fileName.replace(/\.json$/, "");
+
+    let raw: unknown;
+    try {
+        raw = JSON.parse(await Bun.file(path).text());
+    } catch (e) {
+        return [`${fileName}: not valid JSON (${e instanceof Error ? e.message : String(e)})`];
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+        return [`${fileName}: must be a JSON object`];
+    }
+    const r = raw as Record<string, unknown>;
+
+    for (const key of Object.keys(r)) {
+        if (!ALLOWED_KEYS.has(key)) errors.push(`${fileName}: unknown field "${key}"`);
+    }
+    const github = typeof r.github === "string" ? r.github : "";
+    if (github === "") errors.push(`${fileName}: "github" must be a non-empty string`);
+    if (typeof r.gist_id !== "string" || r.gist_id === "" || !/^[a-f0-9]+$/i.test(r.gist_id)) {
+        errors.push(`${fileName}: "gist_id" must be a hex gist id`);
+    }
+    if (typeof r.joined !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(r.joined)) {
+        errors.push(`${fileName}: "joined" must be YYYY-MM-DD`);
+    }
+    if (github !== "" && stem !== github.toLowerCase()) {
+        errors.push(`${fileName}: filename must be the lowercase github login ("${github.toLowerCase()}.json")`);
+    }
+    if (github !== "" && github.toLowerCase() !== author.toLowerCase()) {
+        errors.push(`${fileName}: "github" (${github}) must match the PR author (${author})`);
+    }
+    return errors;
+}
+
+if (import.meta.main) {
+    const args = process.argv.slice(2);
+    const authorArg = args.find((a) => a.startsWith("--author="));
+    const files = args.filter((a) => !a.startsWith("--"));
+    if (!authorArg || files.length === 0) {
+        console.error("usage: bun scripts/validate-community-users.ts --author=<login> <file>...");
+        process.exit(2);
+    }
+    const author = authorArg.slice("--author=".length);
+    let failed = false;
+    for (const file of files) {
+        const errors = await validateUserFile(file, author);
+        for (const e of errors) {
+            console.error(e);
+            failed = true;
+        }
+    }
+    if (failed) process.exit(1);
+    console.log(`${files.length} registration file(s) valid for @${author}.`);
+}
+```
+
+- [ ] **Step 4: Run, verify PASS (7 tests)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/validate-community-users.ts scripts/validate-community-users.test.ts
+git commit -m "feat(community): registration validator for community/users PRs"
+```
+
+---
+
+### Task 2: Community directory scaffolding
+
+**Files:**
+- Create: `community/README.md`, `community/users/.gitkeep`
+
+- [ ] **Step 1: Write community/README.md**
+
+```markdown
+# ax community
+
+Profiles, leaderboards, and (soon) shared patterns/skills/hooks for ax users.
+Spec: docs/superpowers/specs/2026-06-12-ax-profiles-design.md
+
+## users/
+
+One file per registered user: `users/<login>.json`
+
+```json
+{ "github": "<login>", "gist_id": "<hex>", "joined": "YYYY-MM-DD" }
+```
+
+Registration is opened automatically by `ax profile publish` (fork + PR).
+PRs touching only your own `users/<login>.json` are schema-checked and
+auto-merged by CI; the profile data itself lives in your gist and updates
+without further PRs.
+
+## Compiled outputs (nightly)
+
+`leaderboard.json`, `skill-stats.json`, `hook-stats.json`,
+`state/<year>.json` are generated by `scripts/compile-community.ts` - do not
+edit by hand.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add community/README.md community/users/.gitkeep
+git commit -m "feat(community): directory scaffolding + registration contract"
+```
+
+---
+
+### Task 3: Compile script (gists → boards/stats/state)
+
+**Files:**
+- Create: `scripts/compile-community.ts`
+- Test: `scripts/compile-community.test.ts`
+
+Injectable fetcher so tests run without network. Validation through `decodeProfile` (Plan 1). Absurd-row guard: `tokens.total > 100e9` or `sessions > 50_000` over the profile window → excluded (logged). Output is deterministic (rows sorted by value desc then login asc; stable key order via explicit object building).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// scripts/compile-community.test.ts
+import { describe, expect, test } from "bun:test";
+import { compileCommunity, type GistFetcher } from "./compile-community.ts";
+
+const profile = (login: string, over: Record<string, unknown> = {}) => ({
+    v: 1,
+    github: login,
+    generated_at: "2026-06-12T00:00:00Z",
+    window_days: 30,
+    stats: {
+        sessions: 100, active_days: 20, streak_days: 5,
+        tokens: { prompt: 900, completion: 100, total: 1000 },
+        cost_usd: 42, models: [], harnesses: ["claude"],
+        ...((over.stats as object) ?? {}),
+    },
+    rig: {
+        skills: [{ name: "tdd", source: "superpowers", runs: 10 }],
+        hooks: ["enforce-worktree"],
+        routing_table: true,
+        ...((over.rig as object) ?? {}),
+    },
+});
+
+const fetcher = (gists: Record<string, unknown>): GistFetcher => async (gistId) =>
+    gistId in gists ? { profile: gists[gistId], etag: null } : null;
+
+const users = [
+    { github: "alice", gist_id: "g1", joined: "2026-06-01" },
+    { github: "bob", gist_id: "g2", joined: "2026-06-02" },
+];
+
+describe("compileCommunity", () => {
+    test("builds boards sorted by value desc", async () => {
+        const out = await compileCommunity(users, fetcher({
+            g1: profile("alice", { stats: { tokens: { prompt: 1, completion: 1, total: 2000 } } }),
+            g2: profile("bob"),
+        }), { now: "2026-06-12T03:00:00Z" });
+
+        expect(out.leaderboard.boards.tokens.map((r) => r.login)).toEqual(["alice", "bob"]);
+        expect(out.leaderboard.boards.cost[0]).toEqual({ login: "alice", value: 42 });
+        expect(out.leaderboard.compiled_at).toBe("2026-06-12T03:00:00Z");
+    });
+
+    test("skill/hook stats aggregate by source+name across users", async () => {
+        const out = await compileCommunity(users, fetcher({
+            g1: profile("alice"),
+            g2: profile("bob"),
+        }), { now: "2026-06-12T03:00:00Z" });
+
+        expect(out.skillStats["superpowers:tdd"]).toEqual({ users: 2, runs: 20 });
+        expect(out.hookStats["enforce-worktree"]).toEqual({ users: 2 });
+    });
+
+    test("invalid profile rows are dropped and reported", async () => {
+        const out = await compileCommunity(users, fetcher({
+            g1: profile("alice"),
+            g2: { v: 99, garbage: true },
+        }), { now: "2026-06-12T03:00:00Z" });
+
+        expect(out.leaderboard.boards.tokens).toHaveLength(1);
+        expect(out.dropped).toEqual([{ login: "bob", reason: "invalid-profile" }]);
+    });
+
+    test("absurd values excluded from boards", async () => {
+        const out = await compileCommunity(users, fetcher({
+            g1: profile("alice", { stats: { tokens: { prompt: 0, completion: 0, total: 200e9 } } }),
+            g2: profile("bob"),
+        }), { now: "2026-06-12T03:00:00Z" });
+
+        expect(out.leaderboard.boards.tokens.map((r) => r.login)).toEqual(["bob"]);
+        expect(out.dropped).toEqual([{ login: "alice", reason: "absurd-values" }]);
+    });
+
+    test("unreachable gist dropped, compile continues", async () => {
+        const out = await compileCommunity(users, fetcher({ g1: profile("alice") }), { now: "2026-06-12T03:00:00Z" });
+        expect(out.leaderboard.boards.tokens).toHaveLength(1);
+        expect(out.dropped).toEqual([{ login: "bob", reason: "fetch-failed" }]);
+    });
+
+    test("state distributions: model share + harness mix histograms exist", async () => {
+        const out = await compileCommunity(users, fetcher({ g1: profile("alice"), g2: profile("bob") }), {
+            now: "2026-06-12T03:00:00Z",
+        });
+        expect(out.state.year).toBe(2026);
+        expect(out.state.users).toBe(2);
+        expect(out.state.harness_mix.claude).toBe(2);
+        expect(out.state.skill_adoption["superpowers:tdd"]).toBe(2);
+    });
+
+    test("output is deterministic for identical input", async () => {
+        const f = fetcher({ g1: profile("alice"), g2: profile("bob") });
+        const a = await compileCommunity(users, f, { now: "2026-06-12T03:00:00Z" });
+        const b = await compileCommunity(users, f, { now: "2026-06-12T03:00:00Z" });
+        expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    });
+});
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+- [ ] **Step 3: Implement**
+
+```ts
+// scripts/compile-community.ts
+/**
+ * Nightly community compile (profiles spec §3b): walk community/users/,
+ * fetch each registered gist's ax-profile.json, validate through the
+ * canonical ProfileV1 decoder, drop invalid/absurd rows (reported, never
+ * silent), and emit deterministic compiled JSON:
+ *   community/leaderboard.json   - boards: tokens, sessions, streak, cost
+ *   community/skill-stats.json   - { "<source>:<name>": { users, runs } }
+ *   community/hook-stats.json    - { "<hook>": { users } }
+ *   community/state/<year>.json  - anonymized distributions
+ * Fetcher is injectable for tests; the CLI entry uses fetch() with an ETag
+ * cache so unchanged gists cost a 304.
+ */
+import { decodeProfile, type ProfileV1 } from "../apps/axctl/src/profile/schema.ts";
+
+export interface RegisteredUser {
+    readonly github: string;
+    readonly gist_id: string;
+    readonly joined: string;
+}
+
+export type GistFetcher = (
+    gistId: string,
+) => Promise<{ profile: unknown; etag: string | null } | null>;
+
+export interface BoardRow {
+    readonly login: string;
+    readonly value: number;
+}
+
+export interface CompiledOutput {
+    readonly leaderboard: {
+        readonly compiled_at: string;
+        readonly window_days: number;
+        readonly boards: {
+            readonly tokens: BoardRow[];
+            readonly sessions: BoardRow[];
+            readonly streak: BoardRow[];
+            readonly cost: BoardRow[];
+        };
+    };
+    readonly skillStats: Record<string, { users: number; runs: number }>;
+    readonly hookStats: Record<string, { users: number }>;
+    readonly state: {
+        readonly year: number;
+        readonly users: number;
+        readonly harness_mix: Record<string, number>;
+        readonly skill_adoption: Record<string, number>;
+        readonly model_share: Record<string, number>;
+    };
+    readonly dropped: Array<{ login: string; reason: "fetch-failed" | "invalid-profile" | "absurd-values" }>;
+}
+
+const MAX_TOKENS = 100e9;
+const MAX_SESSIONS = 50_000;
+
+const sortBoard = (rows: BoardRow[]): BoardRow[] =>
+    [...rows].sort((a, b) => b.value - a.value || a.login.localeCompare(b.login));
+
+const sortedRecord = <V>(entries: Array<[string, V]>): Record<string, V> =>
+    Object.fromEntries(entries.sort(([a], [b]) => a.localeCompare(b)));
+
+export async function compileCommunity(
+    users: ReadonlyArray<RegisteredUser>,
+    fetchGist: GistFetcher,
+    opts: { readonly now: string },
+): Promise<CompiledOutput> {
+    const profiles: Array<{ login: string; p: ProfileV1 }> = [];
+    const dropped: CompiledOutput["dropped"] = [];
+
+    for (const user of [...users].sort((a, b) => a.github.localeCompare(b.github))) {
+        const fetched = await fetchGist(user.gist_id);
+        if (fetched === null) {
+            dropped.push({ login: user.github, reason: "fetch-failed" });
+            continue;
+        }
+        let p: ProfileV1;
+        try {
+            p = decodeProfile(fetched.profile);
+        } catch {
+            dropped.push({ login: user.github, reason: "invalid-profile" });
+            continue;
+        }
+        if (p.stats.tokens.total > MAX_TOKENS || p.stats.sessions > MAX_SESSIONS) {
+            dropped.push({ login: user.github, reason: "absurd-values" });
+            continue;
+        }
+        profiles.push({ login: user.github, p });
+    }
+
+    const board = (value: (p: ProfileV1) => number | undefined): BoardRow[] =>
+        sortBoard(
+            profiles.flatMap(({ login, p }) => {
+                const v = value(p);
+                return v === undefined ? [] : [{ login, value: v }];
+            }),
+        );
+
+    const skillAgg = new Map<string, { users: number; runs: number }>();
+    const hookAgg = new Map<string, { users: number }>();
+    const harnessMix = new Map<string, number>();
+    const modelUsers = new Map<string, number>();
+    for (const { p } of profiles) {
+        for (const s of p.rig.skills) {
+            const key = `${s.source}:${s.name}`;
+            const cur = skillAgg.get(key) ?? { users: 0, runs: 0 };
+            skillAgg.set(key, { users: cur.users + 1, runs: cur.runs + s.runs });
+        }
+        for (const h of p.rig.hooks) {
+            const cur = hookAgg.get(h) ?? { users: 0 };
+            hookAgg.set(h, { users: cur.users + 1 });
+        }
+        for (const h of p.stats.harnesses) {
+            harnessMix.set(h, (harnessMix.get(h) ?? 0) + 1);
+        }
+        for (const m of p.stats.models) {
+            modelUsers.set(m.name, (modelUsers.get(m.name) ?? 0) + 1);
+        }
+    }
+
+    return {
+        leaderboard: {
+            compiled_at: opts.now,
+            window_days: 30,
+            boards: {
+                tokens: board((p) => p.stats.tokens.total),
+                sessions: board((p) => p.stats.sessions),
+                streak: board((p) => p.stats.streak_days),
+                cost: board((p) => p.stats.cost_usd),
+            },
+        },
+        skillStats: sortedRecord([...skillAgg.entries()]),
+        hookStats: sortedRecord([...hookAgg.entries()]),
+        state: {
+            year: Number(opts.now.slice(0, 4)),
+            users: profiles.length,
+            harness_mix: sortedRecord([...harnessMix.entries()]),
+            skill_adoption: sortedRecord([...skillAgg.entries()].map(([k, v]) => [k, v.users])),
+            model_share: sortedRecord([...modelUsers.entries()]),
+        },
+        dropped,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry: read users dir, fetch via HTTP with ETag cache, write outputs.
+// ---------------------------------------------------------------------------
+
+const liveFetcher = (cache: Record<string, { etag: string; profile: unknown }>): GistFetcher =>
+    async (gistId) => {
+        try {
+            const cached = cache[gistId];
+            const res = await fetch(`https://api.github.com/gists/${gistId}`, {
+                headers: {
+                    accept: "application/vnd.github+json",
+                    ...(process.env.GITHUB_TOKEN ? { authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
+                    ...(cached ? { "if-none-match": cached.etag } : {}),
+                },
+            });
+            if (res.status === 304 && cached) return { profile: cached.profile, etag: cached.etag };
+            if (!res.ok) return null;
+            const body = (await res.json()) as {
+                files?: Record<string, { content?: string }>;
+            };
+            const content = body.files?.["ax-profile.json"]?.content;
+            if (typeof content !== "string") return null;
+            const profile: unknown = JSON.parse(content);
+            const etag = res.headers.get("etag");
+            if (etag) cache[gistId] = { etag, profile };
+            return { profile, etag };
+        } catch {
+            return null;
+        }
+    };
+
+if (import.meta.main) {
+    const usersDir = "community/users";
+    const glob = new Bun.Glob("*.json");
+    const users: RegisteredUser[] = [];
+    for await (const name of glob.scan({ cwd: usersDir })) {
+        const raw: unknown = JSON.parse(await Bun.file(`${usersDir}/${name}`).text());
+        const r = raw as Record<string, unknown>;
+        users.push({ github: String(r.github), gist_id: String(r.gist_id), joined: String(r.joined) });
+    }
+
+    const cachePath = "community/.gist-etag-cache.json";
+    let cache: Record<string, { etag: string; profile: unknown }> = {};
+    try {
+        cache = JSON.parse(await Bun.file(cachePath).text());
+    } catch {
+        // first run / corrupt cache: full fetch
+    }
+
+    const out = await compileCommunity(users, liveFetcher(cache), { now: new Date().toISOString() });
+
+    const year = new Date().getUTCFullYear();
+    await Bun.write("community/leaderboard.json", `${JSON.stringify(out.leaderboard, null, 2)}\n`);
+    await Bun.write("community/skill-stats.json", `${JSON.stringify(out.skillStats, null, 2)}\n`);
+    await Bun.write("community/hook-stats.json", `${JSON.stringify(out.hookStats, null, 2)}\n`);
+    await Bun.write(`community/state/${year}.json`, `${JSON.stringify(out.state, null, 2)}\n`);
+    await Bun.write(cachePath, `${JSON.stringify(cache, null, 2)}\n`);
+
+    console.log(`compiled ${users.length - out.dropped.length}/${users.length} profiles.`);
+    for (const d of out.dropped) console.log(`  dropped ${d.login}: ${d.reason}`);
+}
+```
+
+NOTE: `compiled_at` makes output non-byte-stable across runs even with identical inputs - the nightly workflow's commit-on-change must therefore diff IGNORING `compiled_at`, or simpler: only update `compiled_at` when something else changed. Resolve in Task 4 with the simple approach: workflow does `git diff --ignore-matching-lines='"compiled_at"' --quiet` - verify the flag exists (it's `-I` in git diff) and works; fallback: write compiled_at into a separate tiny `community/compiled-meta.json` excluded from the diff check.
+
+- [ ] **Step 4: Run, verify PASS (7 tests)**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/compile-community.ts scripts/compile-community.test.ts
+git commit -m "feat(community): nightly gist compile - leaderboard/skill-stats/state"
+```
+
+---
+
+### Task 4: Workflows
+
+**Files:**
+- Create: `.github/workflows/community-users.yml`, `.github/workflows/community-nightly.yml`
+
+- [ ] **Step 1: community-users.yml**
+
+```yaml
+name: community-users
+
+on:
+  pull_request_target:
+    paths:
+      - "community/users/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # pull_request_target runs with base-repo secrets; check out the PR
+      # head EXPLICITLY and never execute its code - we only read JSON files
+      # and run OUR validator from the base ref.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      - name: Only community/users files changed
+        id: scope
+        run: |
+          set -euo pipefail
+          changed=$(git -C pr-head diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+          echo "$changed"
+          if echo "$changed" | grep -v '^community/users/[a-z0-9-]*\.json$' | grep -q .; then
+            echo "outside=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "outside=false" >> "$GITHUB_OUTPUT"
+            echo "files<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$changed" | sed 's|^|pr-head/|' >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate registrations
+        if: steps.scope.outputs.outside == 'false'
+        run: |
+          bun install --frozen-lockfile
+          bun scripts/validate-community-users.ts \
+            --author="${{ github.event.pull_request.user.login }}" \
+            ${{ steps.scope.outputs.files }}
+
+      - name: Auto-merge
+        if: steps.scope.outputs.outside == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ github.event.pull_request.number }} --squash --auto --repo ${{ github.repository }}
+
+      - name: Comment when human review needed
+        if: steps.scope.outputs.outside == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} \
+            --body "This PR touches files outside community/users/, so it needs normal human review (no auto-merge)."
+```
+
+SECURITY NOTE (implementer must verify, not skip): `pull_request_target` + checking out PR head is the classic foot-gun. The mitigations here: PR head is checked out into `pr-head/` and ONLY read as data (the validator runs from the base checkout; nothing in `pr-head/` is executed or installed). Keep it that way. Also confirm branch protection on main doesn't block `--auto` squash merges from GITHUB_TOKEN; if it does, document that a repo setting change ("Allow auto-merge") is required - that's a settings change, not a code change.
+
+- [ ] **Step 2: community-nightly.yml**
+
+```yaml
+name: community-nightly
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  compile:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      - run: bun install --frozen-lockfile
+
+      - name: Compile community outputs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun scripts/compile-community.ts
+
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          git add community/
+          # -I ignores compiled_at-only churn; if everything else is identical, skip.
+          if git diff --cached --quiet -I '"compiled_at"'; then
+            echo "no changes"
+            exit 0
+          fi
+          git config user.name "ax-community-bot"
+          git config user.email "actions@github.com"
+          git commit -m "chore(community): nightly compile"
+          git push
+```
+
+(Verify `git diff -I` behaves with `--cached`; if not, fall back to the compiled-meta split from Task 3's NOTE.)
+
+- [ ] **Step 3: Lint workflows**
+
+```bash
+bunx yaml-lint .github/workflows/community-users.yml .github/workflows/community-nightly.yml 2>/dev/null || bun -e 'const y=await import("js-yaml").catch(()=>null); console.log("manual review: ensure valid yaml")'
+actionlint 2>/dev/null || echo "actionlint not installed - visual review"
+```
+
+(Best-effort: at minimum `bun -e 'JSON.stringify'`-style parse via a yaml lib if present, plus careful visual review.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/community-users.yml .github/workflows/community-nightly.yml
+git commit -m "ci(community): registration auto-merge + nightly compile workflows"
+```
+
+---
+
+### Task 5: Docs
+
+**Files:**
+- Modify: `CLAUDE.md` (Profile section gains a community paragraph)
+
+- [ ] **Step 1: Append to the CLAUDE.md Profile section**
+
+```markdown
+Community rails: `community/users/<login>.json` registrations are validated
+(schema + author==filename) and auto-merged by `community-users.yml`;
+`community-nightly.yml` compiles registered gists into
+`community/{leaderboard,skill-stats,hook-stats,state/<year>}.json`
+(`scripts/compile-community.ts`, ETag-cached, absurd rows dropped). Compiled
+files are generated - never hand-edit.
+```
+
+- [ ] **Step 2: Gates + commit**
+
+```bash
+bun run check:cli-reference   # unchanged commands - must still pass
+/tmp/run-ax-tests.sh scripts/
+git add CLAUDE.md
+git commit -m "docs: community rails in CLAUDE.md"
+```
+
+---
+
+## Self-review
+
+1. **Spec coverage (Plan-3 slice):** §3a validation + identity + auto-merge → Tasks 1+4; scope guard (other paths → human review) → Task 4 workflow; §3b nightly compile, ETag, absurd-row drop, all four outputs incl. `state/<year>.json` → Tasks 3+4; `community/` scaffolding + contract docs → Task 2. Pattern/skill/hook contribution dirs (3c) are NOT in this plan - they ship with `ax contribute` later (post-Plan-4), noted in spec.
+2. **Placeholder scan:** two explicit verify-at-implementation notes (git diff -I semantics; pull_request_target security + auto-merge repo setting), each with concrete fallback.
+3. **Type consistency:** `RegisteredUser`/`GistFetcher`/`CompiledOutput` defined once in compile-community.ts; `decodeProfile`/`ProfileV1` imported from the canonical schema; `runs` field name matches Plan 1's rename (not `runs_30d`).

--- a/scripts/com.necmttn.ax-watch.plist
+++ b/scripts/com.necmttn.ax-watch.plist
@@ -8,7 +8,7 @@
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>cd __AX_DIR__ &amp;&amp; bun src/cli/index.ts ingest --since=1 &gt;&gt;__LOG_DIR__/watcher.log 2&gt;&amp;1</string>
+    <string>cd __AX_DIR__ &amp;&amp; bun src/cli/index.ts ingest --since=1 &gt;&gt;__LOG_DIR__/watcher.log 2&gt;&amp;1; bun src/cli/index.ts profile publish --if-stale=6 &gt;&gt;__LOG_DIR__/watcher.log 2&gt;&amp;1 || true</string>
   </array>
   <key>WatchPaths</key>
   <array>


### PR DESCRIPTION
## Summary
- **`GitHubEnv` Effect service** — single layer-testable seam for every `gh api` call (Live = gh spawn; Test = canned responses + recorded calls + error injection). All publish logic tested without network.
- **`ax profile publish`** — consent-gated public gist (create once, `PATCH` in place). First run prints the exact JSON (including taste summaries — the Plan-1 publish gate) and discloses recurring auto-republish before anything leaves the machine; then opens the one-time `community/users/<login>.json` registration PR via fork + git-data API (no local clone). `--if-stale=H` is the watcher path: silent no-op without prior consent. `--no-cost` sticky; `ax profile unpublish` deletes gist + state (404-tolerant).
- **Watcher freshness** — `axctl install`'s generated plist now appends `profile publish --if-stale=6` after ingest (the scripts/ template was also updated, though final review found it's a dead artifact — the install.ts generator is the real one).
- Plan 3 doc (community repo rails) included.

## Test Plan
- [x] 99 tests pass (profile module 62 + CLI gate 37); typecheck, check:no-node-fs, check:cli-reference, plutil all green
- [x] Security paths pinned: non-404 contents-check failure never forks; request bodies (blob/tree/commit/PR) asserted
- [x] Live smokes (no real publish): `--if-stale` silent no-op without state; `echo n |` preview + abort path; unpublish no-state message
- [x] Consent invariant traced end-to-end in final review: no path reaches gist create/patch without explicit or persisted consent

🤖 Generated with [Claude Code](https://claude.com/claude-code)