### PR TITLE
feat(dashboard): Insights Surface Contract v1 - system family on Effect HttpApi + Scalar docs

### DIFF
--- a/apps/axctl/src/dashboard/contract/system.test.ts
+++ b/apps/axctl/src/dashboard/contract/system.test.ts
@@ -1,0 +1,140 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { DbError } from "@ax/lib/errors";
+import { AX_VERSION } from "../../cli/version.ts";
+import { API_VERSION } from "../capabilities.ts";
+import { isContractRequest, makeContractWebHandler, type ContractWebHandler } from "./web-handler.ts";
+
+/** Stub DB: SELECT echoes a canned row set; "boom" SQL fails with DbError. */
+const stubDb = Layer.mock(SurrealClient, {
+    query: <T extends unknown[] = unknown[]>(sql: string, _bindings?: Record<string, unknown> | undefined): Effect.Effect<T, DbError, never> =>
+        sql.includes("boom")
+            ? Effect.fail(new DbError({ operation: "query", message: "boom: db exploded" }))
+            : Effect.succeed([[{ ok: true }]] as unknown as T),
+    // `raw` is the only non-effect member, so Layer.mock requires it; the
+    // contract handlers never touch it.
+    raw: null as never,
+});
+
+const handlers: ContractWebHandler[] = [];
+function make(liveIngest = false): ContractWebHandler {
+    const h = makeContractWebHandler({ liveIngest, services: stubDb });
+    handlers.push(h);
+    return h;
+}
+afterAll(async () => {
+    for (const h of handlers) await h.dispose();
+});
+
+const req = (method: string, path: string, body?: unknown): Request =>
+    new Request(`http://127.0.0.1:1738${path}`, {
+        method,
+        ...(body === undefined ? {} : {
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(body),
+        }),
+    });
+
+describe("isContractRequest", () => {
+    test("owns exactly the migrated (method, path) pairs", () => {
+        expect(isContractRequest("GET", "/api/version")).toBe(true);
+        expect(isContractRequest("POST", "/api/query")).toBe(true);
+        expect(isContractRequest("GET", "/docs")).toBe(true);
+        expect(isContractRequest("GET", "/openapi.json")).toBe(true);
+        // Non-GET on a migrated GET path stays with the legacy table (its
+        // method-ANY quirk) until the family is fully cut over.
+        expect(isContractRequest("POST", "/api/version")).toBe(false);
+        expect(isContractRequest("GET", "/api/query")).toBe(false);
+        // Unmigrated families never route here.
+        expect(isContractRequest("GET", "/api/sessions")).toBe(false);
+    });
+});
+
+describe("contract system group", () => {
+    test("GET /api/version matches the legacy response shape", async () => {
+        const { handler } = make(true);
+        const res = await handler(req("GET", "/api/version"));
+        expect(res.status).toBe(200);
+        const body = await res.json() as Record<string, unknown>;
+        expect(body.version).toBe(AX_VERSION);
+        expect(body.api_version).toBe(API_VERSION);
+        expect(body.capabilities).toContain("sessions");
+        expect(body.live_ingest).toBe(true);
+    });
+
+    test("version reports live_ingest false when the sidecar is down", async () => {
+        const { handler } = make(false);
+        const res = await handler(req("GET", "/api/version"));
+        expect(((await res.json()) as { live_ingest: boolean }).live_ingest).toBe(false);
+    });
+
+    test("POST /api/query rejects non-read SQL with 400 (legacy parity)", async () => {
+        const { handler } = make();
+        const res = await handler(req("POST", "/api/query", { sql: "DELETE FROM session" }));
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toMatchObject({
+            error: "Only SELECT, RETURN, and INFO queries are allowed",
+        });
+    });
+
+    test("POST /api/query rejects empty SQL with 400", async () => {
+        const { handler } = make();
+        const res = await handler(req("POST", "/api/query", { sql: "   " }));
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toMatchObject({ error: "SQL is required" });
+    });
+
+    test("POST /api/query returns result + durationMs", async () => {
+        const { handler } = make();
+        const res = await handler(req("POST", "/api/query", { sql: "SELECT * FROM session" }));
+        expect(res.status).toBe(200);
+        const body = await res.json() as { result: unknown; durationMs: number };
+        expect(body.result).toEqual([[{ ok: true }]]);
+        expect(typeof body.durationMs).toBe("number");
+    });
+
+    test("POST /api/query maps DbError to 400 (legacy parity)", async () => {
+        const { handler } = make();
+        const res = await handler(req("POST", "/api/query", { sql: "SELECT boom" }));
+        expect(res.status).toBe(400);
+        const body = await res.json() as { error: string };
+        expect(body.error).toContain("boom");
+    });
+
+    test("GET /api/graph-health passes rows through", async () => {
+        const { handler } = make();
+        const res = await handler(req("GET", "/api/graph-health"));
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toEqual([[{ ok: true }]]);
+    });
+
+    test("GET /api/worktrees returns activity + git", async () => {
+        const { handler } = make();
+        const res = await handler(req("GET", "/api/worktrees"));
+        expect(res.status).toBe(200);
+        const body = await res.json() as Record<string, unknown>;
+        expect(body).toHaveProperty("activity");
+        expect(body).toHaveProperty("git");
+    });
+});
+
+describe("contract docs", () => {
+    test("GET /docs serves the Scalar reference page", async () => {
+        const { handler } = make();
+        const res = await handler(req("GET", "/docs"));
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toContain("text/html");
+        expect(await res.text()).toContain("Scalar");
+    });
+
+    test("GET /openapi.json includes the system endpoints", async () => {
+        const { handler } = make();
+        const res = await handler(req("GET", "/openapi.json"));
+        expect(res.status).toBe(200);
+        const spec = await res.json() as { paths: Record<string, unknown> };
+        expect(Object.keys(spec.paths)).toEqual(expect.arrayContaining([
+            "/api/version", "/api/query", "/api/graph-health", "/api/worktrees", "/api/self-improve",
+        ]));
+    });
+});

--- a/apps/axctl/src/dashboard/contract/system.ts
+++ b/apps/axctl/src/dashboard/contract/system.ts
@@ -1,0 +1,89 @@
+/**
+ * Handlers for the system group of the Insights Surface Contract
+ * (@ax/lib/shared/api-contract). Behavior parity with the legacy
+ * router/routes/system.ts rows is the contract here: same payloads, same
+ * status mapping (query failures -> 400, read failures -> { error } 500).
+ */
+import { Context, Effect } from "effect";
+import { HttpApiBuilder } from "effect/unstable/httpapi";
+import {
+    AxApi,
+    DaemonVersion,
+    InternalError,
+    QueryRejected,
+    QueryResult,
+    WorktreesResult,
+} from "@ax/lib/shared/api-contract";
+import { SurrealClient } from "@ax/lib/db";
+import { AX_VERSION } from "../../cli/version.ts";
+import { graphHealthSql } from "../../queries/graph-health.ts";
+import { checkoutActivitySql, gitCorrelationSql } from "../../queries/insights.ts";
+import { API_VERSION, dashboardApiCapabilities } from "../capabilities.ts";
+
+/**
+ * Boot-time facts the contract handlers need from `serveDashboard` (whether
+ * the Durable Streams sidecar came up). Provided as a layer when the web
+ * handler is built - the contract module itself must stay daemon-agnostic.
+ */
+export class ContractServeInfo extends Context.Service<
+    ContractServeInfo,
+    { readonly liveIngest: boolean }
+>()("axctl/dashboard/ContractServeInfo") {}
+
+const errorText = (err: unknown): string =>
+    err instanceof Error ? err.message : String(err);
+
+const internal = (err: unknown) => new InternalError({ error: errorText(err) });
+
+export const SystemGroupLive = HttpApiBuilder.group(AxApi, "system", (handlers) =>
+    handlers
+        .handle("version", () =>
+            Effect.gen(function* () {
+                const info = yield* ContractServeInfo;
+                return new DaemonVersion({
+                    version: AX_VERSION,
+                    api_version: API_VERSION,
+                    capabilities: dashboardApiCapabilities(),
+                    live_ingest: info.liveIngest,
+                });
+            }))
+        .handle("query", ({ payload }) =>
+            Effect.gen(function* () {
+                const sql = payload.sql.trim();
+                if (!sql) return yield* new QueryRejected({ error: "SQL is required" });
+                if (!/^(SELECT|RETURN|INFO)\b/i.test(sql)) {
+                    return yield* new QueryRejected({
+                        error: "Only SELECT, RETURN, and INFO queries are allowed",
+                    });
+                }
+                const started = performance.now();
+                const db = yield* SurrealClient;
+                const result = yield* db.query(sql).pipe(
+                    Effect.mapError((err) => new QueryRejected({ error: errorText(err) })),
+                );
+                return new QueryResult({
+                    result,
+                    durationMs: Math.round(performance.now() - started),
+                });
+            }))
+        .handle("graphHealth", () =>
+            Effect.gen(function* () {
+                const db = yield* SurrealClient;
+                return yield* db.query(graphHealthSql(25)).pipe(Effect.mapError(internal));
+            }))
+        .handle("worktrees", () =>
+            Effect.gen(function* () {
+                const db = yield* SurrealClient;
+                const activity = yield* db.query(checkoutActivitySql(50)).pipe(Effect.mapError(internal));
+                const git = yield* db.query(gitCorrelationSql(50)).pipe(Effect.mapError(internal));
+                return new WorktreesResult({ activity, git });
+            }))
+        .handle("selfImprove", () =>
+            Effect.gen(function* () {
+                const db = yield* SurrealClient;
+                return yield* db.query(`
+SELECT id, guidance, version, text, status, scope, risk, evidence, metrics_before, metrics_after, created_at
+FROM guidance_version
+ORDER BY created_at DESC
+LIMIT 50;`).pipe(Effect.mapError(internal));
+            })));

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -1,0 +1,74 @@
+/**
+ * Mounts the Insights Surface Contract onto a fetch-compatible web handler.
+ *
+ * Strangler seam (ADR-0013): `serveDashboard` consults `isContractRequest`
+ * FIRST - migrated (method, path) pairs route into the v4 HttpRouter built
+ * here; everything else falls through to the legacy route table untouched.
+ * The explicit pair table (rather than letting the v4 router 404) keeps the
+ * legacy table's quirks - e.g. method-ANY routes - intact until each family
+ * is fully cut over.
+ *
+ * The `memoMap` option is shared with the server's ManagedRuntime
+ * (serve-runtime.ts), so AppLayer's services - the SurrealDB connection,
+ * trace sink - are built ONCE and reused by both the contract routes and
+ * the legacy routes' runner.
+ */
+import { Layer } from "effect";
+import { BunFileSystem, BunHttpPlatform, BunPath } from "@effect/platform-bun";
+import { Etag, HttpRouter } from "effect/unstable/http";
+import { HttpApiBuilder, HttpApiScalar } from "effect/unstable/httpapi";
+import type { SurrealClient } from "@ax/lib/db";
+import { AppLayer } from "@ax/lib/layers";
+import { AxApi } from "@ax/lib/shared/api-contract";
+import { ContractServeInfo, SystemGroupLive } from "./system.ts";
+
+/** Everything the contract handlers reach for; widens as families join. */
+export type ContractServices = SurrealClient;
+
+/** Migrated (method, path) pairs the contract router owns. */
+const CONTRACT_ROUTES: ReadonlySet<string> = new Set([
+    "GET /api/version",
+    "POST /api/query",
+    "GET /api/graph-health",
+    "GET /api/worktrees",
+    "GET /api/self-improve",
+    "GET /docs",
+    "GET /openapi.json",
+]);
+
+export const isContractRequest = (method: string, pathname: string): boolean =>
+    CONTRACT_ROUTES.has(`${method} ${pathname}`);
+
+export interface ContractWebHandler {
+    readonly handler: (request: Request) => Promise<Response>;
+    readonly dispose: () => Promise<void>;
+}
+
+export interface MakeContractWebHandlerOptions {
+    /** Whether the Durable Streams sidecar is hosting live ingest. */
+    readonly liveIngest: boolean;
+    /** Share with the server runtime so AppLayer builds once (see above). */
+    readonly memoMap?: Layer.MemoMap;
+    /** Test seam: services the handlers need (default: production AppLayer). */
+    readonly services?: Layer.Layer<ContractServices, unknown>;
+}
+
+export function makeContractWebHandler(opts: MakeContractWebHandlerOptions): ContractWebHandler {
+    // Handler services (SurrealClient, ContractServeInfo) must be part of the
+    // app layer's OUTPUT: route handlers declare them through the router's
+    // `Requires` channel, which `toWebHandler` satisfies from the built
+    // context at request time - `Layer.provide` into the group does not.
+    const appLayer = Layer.mergeAll(
+        HttpApiBuilder.layer(AxApi, { openapiPath: "/openapi.json" }),
+        HttpApiScalar.layer(AxApi, { path: "/docs" }),
+        Layer.succeed(ContractServeInfo)({ liveIngest: opts.liveIngest }),
+        opts.services ?? AppLayer,
+    ).pipe(
+        Layer.provide(SystemGroupLive),
+        Layer.provide([BunHttpPlatform.layer, BunFileSystem.layer, BunPath.layer, Etag.layer]),
+    );
+    return HttpRouter.toWebHandler(appLayer, {
+        memoMap: opts.memoMap,
+        disableLogger: true,
+    });
+}

--- a/apps/axctl/src/dashboard/serve-runtime.ts
+++ b/apps/axctl/src/dashboard/serve-runtime.ts
@@ -17,7 +17,7 @@
  * fresh one is swapped in for the next request. A rejection AFTER a
  * successful build is a handler error and never triggers a swap.
  */
-import { Effect, ManagedRuntime } from "effect";
+import { Effect, ManagedRuntime, type Layer } from "effect";
 import { IngestRuntimeLayer } from "../ingest/stage/runtime.ts";
 import type { DashboardEnv, EffectRunner } from "./router/router.ts";
 
@@ -47,9 +47,18 @@ export interface ServeRuntimeHandle {
     readonly dispose: () => Promise<void>;
 }
 
-const makeDefault = (): RuntimeLike => ManagedRuntime.make(IngestRuntimeLayer);
+/**
+ * Production runtime factory. Pass a `memoMap` to share layer builds with
+ * other consumers of the same layer objects - `serveDashboard` shares one
+ * memoMap between this runtime and the contract web handler
+ * (contract/web-handler.ts) so AppLayer's SurrealDB connection is built once.
+ */
+export const defaultRuntimeFactory = (
+    options?: { readonly memoMap?: Layer.MemoMap },
+): (() => RuntimeLike) =>
+() => ManagedRuntime.make(IngestRuntimeLayer, options?.memoMap ? { memoMap: options.memoMap } : undefined);
 
-export function makeServeRuntime(make: () => RuntimeLike = makeDefault): ServeRuntimeHandle {
+export function makeServeRuntime(make: () => RuntimeLike = defaultRuntimeFactory()): ServeRuntimeHandle {
     let runtime = make();
     let disposed = false;
 

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -1,4 +1,10 @@
 import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
+import { Layer } from "effect";
+import {
+    isContractRequest,
+    makeContractWebHandler,
+    type ContractWebHandler,
+} from "./contract/web-handler.ts";
 import { createDurableIngestStream, type DurableIngestStream } from "./ingest-stream-durable.ts";
 import { dispatch, jsonResponse, type EffectRunner, type ServeContext } from "./router/router.ts";
 import { routeTable } from "./router/table.ts";
@@ -11,7 +17,7 @@ import {
     removeServePidfile,
     writeServePidfile,
 } from "./serve-instance.ts";
-import { makeServeRuntime } from "./serve-runtime.ts";
+import { defaultRuntimeFactory, makeServeRuntime } from "./serve-runtime.ts";
 
 export function parseDashboardServeArgs(args: string[]): { port: number } {
     const raw = args.find((arg) => arg.startsWith("--port="))?.split("=")[1];
@@ -33,8 +39,15 @@ export async function handleDashboardRequest(
     req: Request,
     runner: EffectRunner = unavailableRunner,
     serve: ServeContext | null = null,
+    contract: ContractWebHandler | null = null,
 ): Promise<Response> {
     const url = new URL(req.url);
+    // Strangler seam (ADR-0013): (method, path) pairs the Insights Surface
+    // Contract owns route into the v4 HttpRouter; everything else falls
+    // through to the legacy route table untouched.
+    if (contract !== null && isContractRequest(req.method, url.pathname)) {
+        return contract.handler(req);
+    }
     const routed = await dispatch(routeTable, req, url, runner, serve);
     if (routed !== null) return routed;
     if (url.pathname.startsWith("/api/")) return jsonResponse({ error: "not_found" });
@@ -124,6 +137,7 @@ export async function handleDashboardRequestWithCors(
     req: Request,
     runner?: EffectRunner,
     serve: ServeContext | null = null,
+    contract: ContractWebHandler | null = null,
 ): Promise<Response> {
     const origin = req.headers.get("origin");
     const cors = corsHeadersFor(origin);
@@ -145,7 +159,7 @@ export async function handleDashboardRequestWithCors(
         return new Response(null, { status: 204, headers });
     }
 
-    const response = await handleDashboardRequest(req, runner, serve);
+    const response = await handleDashboardRequest(req, runner, serve, contract);
     for (const [k, v] of Object.entries(cors)) response.headers.set(k, v);
     return response;
 }
@@ -196,7 +210,12 @@ export async function serveDashboard(args: string[]): Promise<void> {
     // can still land here despite the pre-flight (race, or a non-HTTP
     // listener the probe can't identify) - report it cleanly instead of
     // rethrowing into the `axctl error:` stack dump; everything else rethrows.
-    const handle = makeServeRuntime();
+    // One memoMap shared between the server runtime and the contract web
+    // handler: both compose the same AppLayer object, so its services (the
+    // SurrealDB connection, trace sink) build once and are reused by both.
+    const memoMap = Layer.makeMemoMapUnsafe();
+    const handle = makeServeRuntime(defaultRuntimeFactory({ memoMap }));
+    const contract = makeContractWebHandler({ liveIngest: stream !== null, memoMap });
     const serve: ServeContext = { ingestStream: stream };
     let server: ReturnType<typeof Bun.serve>;
     try {
@@ -212,11 +231,12 @@ export async function serveDashboard(args: string[]): Promise<void> {
         // (no full-text index yet) and can take 5-15s on a year-old graph.
         server = Bun.serve({
             port,
-            fetch: (req) => handleDashboardRequestWithCors(req, handle.runner, serve),
+            fetch: (req) => handleDashboardRequestWithCors(req, handle.runner, serve, contract),
             idleTimeout: 60,
         });
     } catch (err) {
         if (stream) await stream.stop().catch(() => undefined);
+        await contract.dispose().catch(() => undefined);
         await handle.dispose().catch(() => undefined);
         if (isAddrInUse(err)) {
             const { formatServePortBusy } = await import("../cli/banner.ts");
@@ -253,6 +273,7 @@ export async function serveDashboard(args: string[]): Promise<void> {
         if (pidfile?.pid === process.pid) await removeServePidfile();
         await server.stop();
         if (stream) await stream.stop().catch(() => undefined);
+        await contract.dispose().catch(() => undefined);
         await handle.dispose().catch(() => undefined);
         process.removeListener("SIGINT", onSigint);
         process.removeListener("SIGTERM", onSigterm);

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -1,0 +1,93 @@
+/**
+ * The Insights Surface Contract (ADR-0013): the schema-typed HTTP API the
+ * daemon serves and the studio consumes - the single source of truth for
+ * routes, params, payloads, responses, and errors. The daemon registers it
+ * into the v4 HttpRouter via HttpApiBuilder (apps/axctl/src/dashboard/
+ * contract/), Scalar docs render it at /docs, and the studio derives its
+ * client from it.
+ *
+ * Migration is strangler-style, one route family at a time; endpoints not
+ * yet listed here are still served by the legacy route table. SSE
+ * /api/events and binary /api/image stay OUTSIDE the contract permanently
+ * (streaming/binary shapes that don't fit HttpApi).
+ *
+ * This module must stay daemon-agnostic: no imports from apps/* (the studio
+ * bundles it for the browser).
+ */
+import { Schema } from "effect";
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi";
+
+// ---------------------------------------------------------------- system
+
+/** GET /api/version - the studio's handshake + capability probe. */
+export class DaemonVersion extends Schema.Class<DaemonVersion>("ax/DaemonVersion")({
+    version: Schema.String,
+    api_version: Schema.Number,
+    capabilities: Schema.Array(Schema.String),
+    /** Whether the Durable Streams sidecar is hosting live ingest. False on
+     *  the compiled binary (native lmdb can't bundle), where POST /api/ingest
+     *  503s - the studio reads this to engage its polling fallback. */
+    live_ingest: Schema.Boolean,
+}) {}
+
+/** POST /api/query rejection: non-read SQL or a database error. Legacy
+ *  behavior mapped every failure on this endpoint to HTTP 400. */
+export class QueryRejected extends Schema.ErrorClass<QueryRejected>("ax/QueryRejected")({
+    error: Schema.String,
+}, { httpApiStatus: 400 }) {}
+
+/** Database/internal failure on a read endpoint - the legacy route table
+ *  rendered these as `{ error }` with HTTP 500; the contract keeps that. */
+export class InternalError extends Schema.ErrorClass<InternalError>("ax/InternalError")({
+    error: Schema.String,
+}, { httpApiStatus: 500 }) {}
+
+/** POST /api/query - the read-only SQL console (SELECT/RETURN/INFO only). */
+export class QueryResult extends Schema.Class<QueryResult>("ax/QueryResult")({
+    result: Schema.Unknown,
+    durationMs: Schema.Number,
+}) {}
+
+export class WorktreesResult extends Schema.Class<WorktreesResult>("ax/WorktreesResult")({
+    activity: Schema.Unknown,
+    git: Schema.Unknown,
+}) {}
+
+/**
+ * The system family: version/capability metadata, the read-only SQL console,
+ * and the legacy raw-row insight queries. The raw-row endpoints are
+ * deliberately `Schema.Unknown` payloads - they pass SurrealDB rows through
+ * untyped today; tightening them is contract work for a later pass, not a
+ * blocker for the strangler migration.
+ */
+export const SystemGroup = HttpApiGroup.make("system")
+    .add(
+        HttpApiEndpoint.get("version", "/api/version", {
+            success: DaemonVersion,
+        }),
+        HttpApiEndpoint.post("query", "/api/query", {
+            // A real Schema (not bare fields) so the payload codec is JSON -
+            // bare field maps are interpreted as form-urlencoded by HttpApi.
+            payload: Schema.Struct({ sql: Schema.String }),
+            success: QueryResult,
+            error: QueryRejected,
+        }),
+        HttpApiEndpoint.get("graphHealth", "/api/graph-health", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("worktrees", "/api/worktrees", {
+            success: WorktreesResult,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("selfImprove", "/api/self-improve", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+    );
+
+/** The Insights Surface Contract. Families join as they migrate (ADR-0013). */
+export const AxApi = HttpApi.make("ax")
+    .add(SystemGroup)
+    .annotate(OpenApi.Title, "ax daemon API")
+    .annotate(OpenApi.Version, "1");


### PR DESCRIPTION
## What

First strangler slice of ADR-0013 — the system route family served from the Effect v4 HTTP stack, behind a contract both daemon and studio will share.

- **`@ax/lib/shared/api-contract`** — the Insights Surface Contract: `HttpApi` + Schemas for the system family (`version`, `query`, `graph-health`, `worktrees`, `self-improve`). Daemon-agnostic (no `apps/*` imports) so the studio can bundle it.
- **`dashboard/contract/`** — handlers (`HttpApiBuilder.group`) + `makeContractWebHandler`: mounts the contract on the v4 layer-collected `HttpRouter` via `HttpRouter.toWebHandler`, with **Scalar docs at `/docs`** and the OpenAPI spec at `/openapi.json`.
- **Strangler seam** — `serveDashboard` consults an explicit `(method, path)` table first; migrated pairs hit the v4 handler, everything else (including non-GET hits on legacy method-ANY routes) falls through to the legacy table untouched. Zero removed routes, zero behavior change outside the migrated pairs.
- **One connection** — the contract handler shares a `Layer.MemoMap` with the server runtime (`defaultRuntimeFactory({memoMap})`), so AppLayer's SurrealDB connection builds once and serves both worlds.

## Status parity

`POST /api/query` failures (non-read SQL, DbError) → 400 with `{error}` exactly as the legacy route; read-endpoint DB failures → typed `InternalError` 500 `{error}`.

## Out of scope (next PR)

Studio `HttpApiClient` swap; removing legacy system rows after cutover.

## Verification

- 11 new contract tests (stub `SurrealClient` via `Layer.mock`): version shape/live_ingest parity, query 400 mappings, Scalar 200, OpenAPI path inventory. Full suite 3485 pass / typecheck clean.
- Live smoke from the worktree: contract GET `/api/version` + legacy POST `/api/version` (ANY quirk) both answer; `/api/query` 5ms on the shared connection; `/docs` renders; CORS headers present on contract responses; `/api/sessions` (unmigrated) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)