### PR TITLE
fix(community): live-test findings - lowercase registration, raw gist fetch

### DIFF
--- a/apps/axctl/src/profile/publish.test.ts
+++ b/apps/axctl/src/profile/publish.test.ts
@@ -134,6 +134,36 @@ describe("ensureRegistration", () => {
         });
     });
 
+    test("uppercase login registers under the lowercase filename and branch", async () => {
+        // Live finding: "Necmttn" produced Necmttn.json, which the registry
+        // validator scope regex rejects and the site lookup (lowercased) 404s.
+        const fork = "Necmttn/ax";
+        const t = GitHubEnvTest({
+            responses: {
+                [`POST /repos/${REGISTRY_REPO}/forks`]: { full_name: fork },
+                [`GET /repos/${fork}/git/ref/heads/main`]: { object: { sha: "base" } },
+                [`POST /repos/${fork}/git/blobs`]: { sha: "blob1" },
+                [`GET /repos/${fork}/git/commits/base`]: { tree: { sha: "tree0" } },
+                [`POST /repos/${fork}/git/trees`]: { sha: "tree1" },
+                [`POST /repos/${fork}/git/commits`]: { sha: "commit1" },
+                [`POST /repos/${fork}/git/refs`]: { ref: "refs/heads/ax-profile-necmttn" },
+                [`POST /repos/${REGISTRY_REPO}/pulls`]: { html_url: "https://github.com/Necmttn/ax/pull/1000" },
+            },
+        });
+        await run(
+            ensureRegistration({ login: "Necmttn", gistId: "g1", joined: "2026-06-12" })
+                .pipe(Effect.provide(t.layer)),
+        );
+        const contentsCheck = t.calls.find((c) => c.method === "GET" && c.path.includes("/contents/"));
+        expect(contentsCheck?.path).toBe(`/repos/${REGISTRY_REPO}/contents/community/users/necmttn.json`);
+        const trees = t.calls.find((c) => c.path === `/repos/${fork}/git/trees`)?.body as {
+            tree: Array<{ path: string }>;
+        };
+        expect(trees.tree[0]!.path).toBe("community/users/necmttn.json");
+        const refs = t.calls.find((c) => c.path === `/repos/${fork}/git/refs`)?.body as { ref: string };
+        expect(refs.ref).toBe("refs/heads/ax-profile-necmttn");
+    });
+
     test("non-404 error on contents check fails registration without forking", async () => {
         const t = GitHubEnvTest({
             responses: {

--- a/apps/axctl/src/profile/publish.ts
+++ b/apps/axctl/src/profile/publish.ts
@@ -78,7 +78,9 @@ export const ensureRegistration = Effect.fn("profile.ensureRegistration")(
     function* (input: { readonly login: string; readonly gistId: string; readonly joined: string }) {
         const gh = yield* GitHubEnv;
         const { login, gistId, joined } = input;
-        const filePath = `community/users/${login}.json`;
+        // Filename is ALWAYS the lowercase login - the registry validator and
+        // the site lookup both require it (GitHub logins are case-insensitive).
+        const filePath = `community/users/${login.toLowerCase()}.json`;
 
         const exists = yield* gh.api("GET", `/repos/${REGISTRY_REPO}/contents/${filePath}`).pipe(
             Effect.map(() => true),
@@ -120,7 +122,7 @@ export const ensureRegistration = Effect.fn("profile.ensureRegistration")(
             }),
         );
 
-        const branch = `ax-profile-${login}`;
+        const branch = `ax-profile-${login.toLowerCase()}`;
         yield* gh.api("POST", `/repos/${forkFullName}/git/refs`, {
             ref: `refs/heads/${branch}`,
             sha: commit.sha,

--- a/scripts/compile-community.ts
+++ b/scripts/compile-community.ts
@@ -21,6 +21,7 @@ export interface RegisteredUser {
 
 export type GistFetcher = (
     gistId: string,
+    owner: string,
 ) => Promise<{ profile: unknown; etag: string | null } | null>;
 
 export interface BoardRow {
@@ -69,7 +70,7 @@ export async function compileCommunity(
     const dropped: CompiledOutput["dropped"] = [];
 
     for (const user of [...users].sort((a, b) => a.github.localeCompare(b.github))) {
-        const fetched = await fetchGist(user.gist_id);
+        const fetched = await fetchGist(user.gist_id, user.github);
         if (fetched === null) {
             dropped.push({ login: user.github, reason: "fetch-failed" });
             continue;
@@ -152,26 +153,24 @@ export async function compileCommunity(
 // CLI entry: read users dir, fetch via HTTP with ETag cache, write outputs.
 // ---------------------------------------------------------------------------
 
+/**
+ * Fetch the gist's ax-profile.json via the PUBLIC raw URL, unauthenticated.
+ * Deliberately NOT api.github.com: the Actions GITHUB_TOKEN is an
+ * installation token with no gist scope, so authenticated /gists/:id calls
+ * 404 in CI (live finding, first compile run). The raw CDN endpoint needs
+ * no auth, has no meaningful rate limit, and never truncates.
+ */
 const liveFetcher = (cache: Record<string, { etag: string; profile: unknown }>): GistFetcher =>
-    async (gistId) => {
+    async (gistId, owner) => {
         try {
             const cached = cache[gistId];
-            const res = await fetch(`https://api.github.com/gists/${gistId}`, {
-                headers: {
-                    accept: "application/vnd.github+json",
-                    ...(process.env.GITHUB_TOKEN ? { authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
-                    ...(cached ? { "if-none-match": cached.etag } : {}),
-                },
-            });
+            const res = await fetch(
+                `https://gist.githubusercontent.com/${owner}/${gistId}/raw/ax-profile.json`,
+                { headers: { ...(cached ? { "if-none-match": cached.etag } : {}) } },
+            );
             if (res.status === 304 && cached) return { profile: cached.profile, etag: cached.etag };
             if (!res.ok) return null;
-            const body = (await res.json()) as {
-                files?: Record<string, { content?: string; truncated?: boolean }>;
-            };
-            const f = body.files?.["ax-profile.json"];
-            if (!f || f.truncated === true || typeof f.content !== "string") return null;
-            const content = f.content;
-            const profile: unknown = JSON.parse(content);
+            const profile: unknown = await res.json();
             const etag = res.headers.get("etag");
             if (etag) cache[gistId] = { etag, profile };
             return { profile, etag };


### PR DESCRIPTION
## Summary
First real `ax profile publish` (registration PR #323) surfaced two bugs:
- **Uppercase registration filename** — `Necmttn.json` slipped past the lowercase-only workflow scope (taking the human-review path, so validation never ran) and 404s the site's lowercased lookup. `ensureRegistration` now lowercases the filename + branch.
- **Compile fetch-failed on every gist** — Actions' `GITHUB_TOKEN` is an installation token without gist scope, so authenticated `/gists/:id` returns 404 in CI. The fetcher now uses the public raw gist URL (unauthenticated, no truncation).

Companion data fix (separate, on main): rename `community/users/Necmttn.json` → `necmttn.json`.

## Test Plan
- [x] New regression test: uppercase login → lowercase filename/branch (publish.test.ts)
- [x] 18 affected tests green; typecheck clean
- [ ] Post-merge: re-dispatch community-nightly, confirm leaderboard populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)