### PR TITLE
feat(studio): generated HttpApiClient for the version handshake (contract PR B)

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -21,7 +21,8 @@
     "@tanstack/react-router": "^1.169",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "shiki-magic-move": "^1.4.0"
+    "shiki-magic-move": "^1.4.0",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@types/react": "^19.2.0",

--- a/apps/studio/src/api-error.ts
+++ b/apps/studio/src/api-error.ts
@@ -1,0 +1,13 @@
+/**
+ * Fetch error that carries the HTTP status so callers can branch on it
+ * (e.g. 503 from POST /api/ingest = Durable Streams sidecar unavailable on
+ * the compiled binary -> engage the polling fallback). Lives in its own
+ * module so both the legacy jsonFetch transport (api.ts) and the contract
+ * client (contract-client.ts) can throw it without an import cycle.
+ */
+export class ApiError extends Error {
+    constructor(message: string, readonly status: number) {
+        super(message);
+        this.name = "ApiError";
+    }
+}

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -104,15 +104,12 @@ export function imageSrc(absolutePath: string): string {
     return endpoint ? endpoint + path : path;
 }
 
-/** Fetch error that carries the HTTP status so callers can branch on it
- *  (e.g. 503 from POST /api/ingest = Durable Streams sidecar unavailable on
- *  the compiled binary → engage the polling fallback). */
-export class ApiError extends Error {
-    constructor(message: string, readonly status: number) {
-        super(message);
-        this.name = "ApiError";
-    }
-}
+// Moved to its own module so the contract client can throw it without an
+// import cycle; re-exported here so existing importers keep working.
+export { ApiError } from "./api-error.ts";
+import { ApiError } from "./api-error.ts";
+import { contractVersion } from "./contract-client.ts";
+import type { DaemonVersion } from "@ax/lib/shared/api-contract";
 
 async function jsonFetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
     if (STUDIO_MOCK) {
@@ -150,15 +147,9 @@ export interface IngestTriggerResponse {
     readonly streamBaseUrl: string;
 }
 
-export interface DaemonVersion {
-    readonly version: string;
-    readonly api_version: number;
-    readonly capabilities: ReadonlyArray<string>;
-    /** Whether the daemon's Durable Streams sidecar is hosting live ingest.
-     *  `false` on the compiled binary (POST /api/ingest would 503) → the Live
-     *  tab polls counts instead. Optional: older daemons omit it. */
-    readonly live_ingest?: boolean;
-}
+// The version handshake type now comes from the Insights Surface Contract -
+// the same Schema the daemon serves - so the two cannot drift.
+export type { DaemonVersion } from "@ax/lib/shared/api-contract";
 
 // --- session timeline (highlight zoom) -------------------------------------
 
@@ -214,7 +205,20 @@ export interface SessionTimelinePayload {
 }
 
 export const api = {
-    version: (): Promise<DaemonVersion> => jsonFetch("/api/version"),
+    // First contract-client call (ADR-0013): typed end-to-end against the
+    // same Schema the daemon serves. Mock mode without a connected endpoint
+    // keeps the legacy mockFetch behavior (no /api/version fixture -> throws).
+    version: async (): Promise<DaemonVersion> => {
+        if (STUDIO_MOCK) {
+            const endpoint = readEndpoint();
+            if (!endpoint) {
+                const { mockFetch } = await import("./mock-fixtures.ts");
+                return mockFetch("/api/version");
+            }
+            return contractVersion(endpoint);
+        }
+        return contractVersion(null);
+    },
     skills: (): Promise<SkillTriageResponse> => jsonFetch("/api/skills"),
     decide: (
         name: string,

--- a/apps/studio/src/contract-client.test.ts
+++ b/apps/studio/src/contract-client.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { ApiError } from "./api-error.ts";
+import { contractVersion } from "./contract-client.ts";
+
+/** Daemon fixture: configurable /api/version responses per scenario. */
+const responses: Record<string, () => Response> = {
+    "/current": () =>
+        Response.json({
+            version: "0.27.0",
+            api_version: 1,
+            capabilities: ["sessions", "skills"],
+            live_ingest: true,
+        }),
+    // A daemon predating the live_ingest field - the hosted studio must
+    // keep decoding its handshake.
+    "/old": () =>
+        Response.json({
+            version: "0.18.0",
+            api_version: 1,
+            capabilities: ["sessions"],
+        }),
+    // A daemon NEWER than this studio build: extra fields must be ignored.
+    "/future": () =>
+        Response.json({
+            version: "9.9.9",
+            api_version: 1,
+            capabilities: [],
+            live_ingest: false,
+            brand_new_field: { nested: true },
+        }),
+    "/error": () => Response.json({ error: "exploded" }, { status: 500 }),
+};
+
+const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+        const url = new URL(req.url);
+        const scenario = url.pathname.split("/api/version")[0] || "/current";
+        const respond = responses[scenario];
+        return respond ? respond() : new Response("not found", { status: 404 });
+    },
+});
+const base = (scenario: string): string => `http://127.0.0.1:${server.port}${scenario === "/current" ? "" : scenario}`;
+afterAll(() => server.stop());
+
+describe("contractVersion", () => {
+    test("decodes a current daemon handshake", async () => {
+        const v = await contractVersion(base("/current"));
+        expect(v.version).toBe("0.27.0");
+        expect(v.api_version).toBe(1);
+        expect(v.capabilities).toContain("skills");
+        expect(v.live_ingest).toBe(true);
+    });
+
+    test("tolerates an old daemon without live_ingest", async () => {
+        const v = await contractVersion(base("/old"));
+        expect(v.version).toBe("0.18.0");
+        expect(v.live_ingest).toBeUndefined();
+    });
+
+    test("ignores unknown fields from a newer daemon", async () => {
+        const v = await contractVersion(base("/future"));
+        expect(v.version).toBe("9.9.9");
+        expect(v.live_ingest).toBe(false);
+    });
+
+    test("maps an HTTP failure to ApiError with the status", async () => {
+        expect.assertions(2);
+        try {
+            await contractVersion(base("/error"));
+        } catch (err) {
+            expect(err).toBeInstanceOf(ApiError);
+            expect((err as ApiError).status).toBe(500);
+        }
+    });
+
+    test("maps a network failure to ApiError with status 0", async () => {
+        expect.assertions(2);
+        try {
+            // Nothing listens here.
+            await contractVersion("http://127.0.0.1:9");
+        } catch (err) {
+            expect(err).toBeInstanceOf(ApiError);
+            expect((err as ApiError).status).toBe(0);
+        }
+    });
+});

--- a/apps/studio/src/contract-client.ts
+++ b/apps/studio/src/contract-client.ts
@@ -1,0 +1,61 @@
+/**
+ * Studio-side client for the Insights Surface Contract
+ * (@ax/lib/shared/api-contract): `HttpApiClient` derived from the same
+ * HttpApi the daemon serves, so paths, params, and response types cannot
+ * drift between the two codebases.
+ *
+ * This module owns ONLY the contract -> Promise bridge. The studio-specific
+ * transport behaviors stay where they were:
+ *   - mock-fixtures interception happens in api.ts BEFORE calling here
+ *     (mock mode without a connected endpoint never reaches the network),
+ *   - the daemon endpoint (localStorage `?endpoint=` connect flow) arrives
+ *     as `baseUrl`, re-resolved per call because the user can connect or
+ *     disconnect at runtime,
+ *   - failures are normalized to `ApiError` with an HTTP status (0 = network
+ *     or decode failure), preserving the status-branching the UI relies on.
+ */
+import { Cause, Effect, Exit, ManagedRuntime } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { HttpApiClient } from "effect/unstable/httpapi";
+import { AxApi } from "@ax/lib/shared/api-contract";
+import { ApiError } from "./api-error.ts";
+
+/** One browser-lifetime runtime over the fetch-backed HttpClient. */
+const runtime = ManagedRuntime.make(FetchHttpClient.layer);
+
+const makeClient = (baseUrl: string | null) =>
+    HttpApiClient.make(AxApi, baseUrl === null ? {} : { baseUrl });
+
+type AxClient = Effect.Success<ReturnType<typeof makeClient>>;
+
+/** Map a squashed client failure to the ApiError contract the UI branches on. */
+function toApiError(err: unknown): ApiError {
+    const status =
+        typeof err === "object" && err !== null && "response" in err &&
+        typeof (err as { response?: { status?: unknown } }).response?.status === "number"
+            ? (err as { response: { status: number } }).response.status
+            : 0;
+    const message = err instanceof Error ? err.message : String(err);
+    return new ApiError(message, status);
+}
+
+/**
+ * Run one contract call: build the per-call client against `baseUrl`
+ * (null = same-origin relative URLs) and normalize failures to ApiError.
+ */
+async function runContract<A, E>(
+    baseUrl: string | null,
+    call: (client: AxClient) => Effect.Effect<A, E>,
+): Promise<A> {
+    const exit = await runtime.runPromiseExit(
+        Effect.flatMap(makeClient(baseUrl), call),
+    );
+    if (Exit.isSuccess(exit)) return exit.value;
+    throw toApiError(Cause.squash(exit.cause));
+}
+
+// ---------------------------------------------------------------- calls
+
+/** GET /api/version through the contract. */
+export const contractVersion = (baseUrl: string | null) =>
+    runContract(baseUrl, (client) => client.system.version());

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "apps/axctl": {
       "name": "axctl",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "bin": {
         "axctl": "./bin/axctl",
       },
@@ -119,6 +119,7 @@
         "@pierre/trees": "^1.0.0-beta.4",
         "@tanstack/react-query": "^5",
         "@tanstack/react-router": "^1.169",
+        "effect": "catalog:",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "shiki-magic-move": "^1.4.0",

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -26,8 +26,10 @@ export class DaemonVersion extends Schema.Class<DaemonVersion>("ax/DaemonVersion
     capabilities: Schema.Array(Schema.String),
     /** Whether the Durable Streams sidecar is hosting live ingest. False on
      *  the compiled binary (native lmdb can't bundle), where POST /api/ingest
-     *  503s - the studio reads this to engage its polling fallback. */
-    live_ingest: Schema.Boolean,
+     *  503s - the studio reads this to engage its polling fallback. Optional
+     *  on the wire: daemons older than the field omit it, and the hosted
+     *  studio must keep decoding their responses. */
+    live_ingest: Schema.optionalKey(Schema.Boolean),
 }) {}
 
 /** POST /api/query rejection: non-read SQL or a database error. Legacy


### PR DESCRIPTION
## What

PR B of the ADR-0013 system-family migration (daemon side landed in #322): the studio's first generated-client call.

- **`contract-client.ts`** — `HttpApiClient.make(AxApi)` over `FetchHttpClient`, one browser-lifetime `ManagedRuntime`. `api.version()` now goes through it; the response type is the contract's `DaemonVersion` Schema, so daemon and studio cannot drift.
- **Version-skew tolerance** — `live_ingest` becomes `optionalKey` in the contract: daemons older than the field still decode, and unknown fields from newer daemons are ignored (both tested).
- **Transport seams preserved** — mock-fixtures interception stays in `api.ts` before the client; the `?endpoint=` localStorage connect flow arrives as `baseUrl` per call; failures normalize to `ApiError` with HTTP status (0 = network/decode), which the UI branches on. `ApiError` moved to `api-error.ts` (re-exported) to break the import cycle.

## Cost

Studio entry chunk: 327.45 → 348.80 kB gzip (**+21.4 kB**) for effect core + Schema + HttpApiClient. Measured against main with the same build.

## Verification

- 5 new tests against a live `Bun.serve` fixture: current/old/future daemon handshakes, 500 → `ApiError(500)`, refused connection → `ApiError(0)`.
- Real round-trip: `contractVersion()` against a daemon booted from this branch returns the typed handshake (`live_ingest: true`, 14 capabilities).
- Full suite 3496 pass / repo + studio typecheck clean / `build:web` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)