### PR TITLE
feat(dashboard+studio): insights family on the contract + DB-down hardening

### DIFF
--- a/apps/axctl/src/dashboard/contract/common.ts
+++ b/apps/axctl/src/dashboard/contract/common.ts
@@ -1,0 +1,13 @@
+/** Shared helpers for contract group handlers. */
+import { Effect } from "effect";
+import { InternalError } from "@ax/lib/shared/api-contract";
+
+export const errorText = (err: unknown): string =>
+    err instanceof Error ? err.message : String(err);
+
+/** Legacy read-endpoint failure parity: `{ error }` body with HTTP 500. */
+export const internal = (err: unknown): InternalError => new InternalError({ error: errorText(err) });
+
+/** Map an effect's failures to the 500 InternalError contract. */
+export const orInternal = <A, R>(effect: Effect.Effect<A, unknown, R>): Effect.Effect<A, InternalError, R> =>
+    effect.pipe(Effect.mapError(internal));

--- a/apps/axctl/src/dashboard/contract/insights.test.ts
+++ b/apps/axctl/src/dashboard/contract/insights.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { isContractRequest, makeContractWebHandler, type ContractWebHandler } from "./web-handler.ts";
+
+/** Stub DB returning empty result tuples - enough for null/empty paths. */
+const emptyDb = Layer.mock(SurrealClient, {
+    query: <T extends unknown[] = unknown[]>(_sql: string, _bindings?: Record<string, unknown> | undefined) =>
+        Effect.succeed([[]] as unknown as T),
+    raw: null as never,
+});
+
+const handlers: ContractWebHandler[] = [];
+function make(services: Parameters<typeof makeContractWebHandler>[0]["services"] = emptyDb): ContractWebHandler {
+    const h = makeContractWebHandler({ liveIngest: false, services });
+    handlers.push(h);
+    return h;
+}
+afterAll(async () => {
+    for (const h of handlers) await h.dispose();
+});
+
+const get = (path: string): Request => new Request(`http://127.0.0.1:1738${path}`);
+
+describe("isContractRequest - insights + hardening", () => {
+    test("GET /api/version is NOT contract-routed (DB-free legacy row serves it)", () => {
+        expect(isContractRequest("GET", "/api/version")).toBe(false);
+    });
+
+    test("insights exact paths route to the contract", () => {
+        for (const p of [
+            "/api/recall", "/api/skill-graph", "/api/wrapped",
+            "/api/wrapped/public-preview", "/api/workflow", "/api/tool-failures",
+        ]) expect(isContractRequest("GET", p)).toBe(true);
+    });
+
+    test("single-segment param paths route; multi-segment falls to legacy greedy rows", () => {
+        expect(isContractRequest("GET", "/api/episodes/abc-123")).toBe(true);
+        expect(isContractRequest("GET", "/api/episodes/a/b")).toBe(false);
+        expect(isContractRequest("GET", "/api/projects/my-repo")).toBe(true);
+        expect(isContractRequest("GET", "/api/projects/a/b")).toBe(false);
+        expect(isContractRequest("GET", "/api/tool-failures/Bash/detail")).toBe(true);
+        expect(isContractRequest("GET", "/api/tool-failures/a/b/detail")).toBe(false);
+    });
+
+    test("graph-explorer stays legacy (env-gated experimental)", () => {
+        expect(isContractRequest("GET", "/api/graph-explorer")).toBe(false);
+    });
+});
+
+describe("insights handlers", () => {
+    test("recall with empty q answers the canned empty page without touching the DB", async () => {
+        const poisoned = Layer.mock(SurrealClient, {
+            query: () => Effect.die(new Error("DB must not be touched for empty q")),
+            raw: null as never,
+        });
+        const { handler } = make(poisoned);
+        const res = await handler(get("/api/recall?q=%20"));
+        expect(res.status).toBe(200);
+        const body = await res.json() as { hits: unknown[]; total_count: number };
+        expect(body.hits).toEqual([]);
+        expect(body.total_count).toBe(0);
+    });
+
+    test("project lookup miss maps to 404 { error } (legacy respond parity)", async () => {
+        const { handler } = make();
+        const res = await handler(get("/api/projects/nope"));
+        expect(res.status).toBe(404);
+        await expect(res.json()).resolves.toMatchObject({ error: "project not found" });
+    });
+
+    test("garbage numeric query param is a 400, not a silent default", async () => {
+        const { handler } = make();
+        const res = await handler(get("/api/skill-graph?limit=abc"));
+        expect(res.status).toBe(400);
+    });
+});
+
+describe("contract handler self-healing", () => {
+    test("a failed layer build answers 500 and recovers on the next request", async () => {
+        let attempts = 0;
+        const flaky = Layer.effect(SurrealClient)(Effect.suspend(() => {
+            attempts += 1;
+            if (attempts === 1) return Effect.fail(new Error("db down at boot"));
+            return Effect.succeed({
+                query: () => Effect.succeed([[]]),
+                raw: null,
+            } as unknown as SurrealClientShape);
+        }));
+        const { handler } = make(flaky);
+
+        const first = await handler(get("/api/wrapped"));
+        expect(first.status).toBe(500);
+        await expect(first.json()).resolves.toMatchObject({ error: expect.stringContaining("db down") });
+
+        // The wrapper swapped in a fresh handler; the rebuilt layer succeeds.
+        const second = await handler(get("/api/tool-failures"));
+        expect(second.status).toBe(200);
+    });
+});

--- a/apps/axctl/src/dashboard/contract/insights.ts
+++ b/apps/axctl/src/dashboard/contract/insights.ts
@@ -1,0 +1,58 @@
+/**
+ * Handlers for the insights group of the Insights Surface Contract.
+ * Thin delegations to the existing fetch* effects; parity notes:
+ *   - recall keeps the empty-q fast path (no DB touch, canned empty page),
+ *   - project maps a null lookup to the 404 NotFoundError the legacy
+ *     respond-override produced,
+ *   - everything else is fetch* + the 500 InternalError mapping.
+ */
+import { Effect } from "effect";
+import { HttpApiBuilder } from "effect/unstable/httpapi";
+import { AxApi, NotFoundError } from "@ax/lib/shared/api-contract";
+import { fetchEpisodeTimeline } from "../episode-timeline.ts";
+import { fetchProject } from "../project.ts";
+import { emptyRecallResponse, fetchRecall, type RecallParams } from "../recall.ts";
+import { fetchSkillGraph } from "../skill-graph.ts";
+import { fetchToolFailureDetail, fetchToolFailures } from "../tool-failures.ts";
+import { fetchWorkflow } from "../workflow.ts";
+import { fetchWrapped, sanitizeWrappedProfile } from "../wrapped.ts";
+import { orInternal } from "./common.ts";
+
+export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handlers) =>
+    handlers
+        .handle("recall", ({ query }) => {
+            const params: RecallParams = {
+                q: query.q ?? "",
+                project: query.project ?? null,
+                skill: query.skill ?? null,
+                since: query.since ?? null,
+                offset: query.offset ?? 0,
+                limit: query.limit ?? 50,
+            };
+            if (params.q.trim().length === 0) {
+                return Effect.succeed(
+                    emptyRecallResponse(params.q, params.offset ?? 0, params.limit ?? 50),
+                );
+            }
+            return orInternal(fetchRecall(params));
+        })
+        .handle("episodeTimeline", ({ params }) => orInternal(fetchEpisodeTimeline(params.parentId)))
+        .handle("skillGraph", ({ query }) =>
+            orInternal(fetchSkillGraph({
+                ...(query.minCount === undefined ? {} : { minCount: query.minCount }),
+                ...(query.limit === undefined ? {} : { limit: query.limit }),
+            })))
+        .handle("project", ({ params }) =>
+            orInternal(fetchProject(params.project)).pipe(
+                Effect.flatMap((payload) =>
+                    payload === null
+                        ? Effect.fail(new NotFoundError({ error: "project not found" }))
+                        : Effect.succeed(payload)
+                ),
+            ))
+        .handle("wrapped", () => orInternal(fetchWrapped()))
+        .handle("wrappedPublicPreview", () =>
+            orInternal(fetchWrapped().pipe(Effect.map(sanitizeWrappedProfile))))
+        .handle("workflow", () => orInternal(fetchWorkflow()))
+        .handle("toolFailures", () => orInternal(fetchToolFailures()))
+        .handle("toolFailureDetail", ({ params }) => orInternal(fetchToolFailureDetail(params.label))));

--- a/apps/axctl/src/dashboard/contract/system.test.ts
+++ b/apps/axctl/src/dashboard/contract/system.test.ts
@@ -38,7 +38,10 @@ const req = (method: string, path: string, body?: unknown): Request =>
 
 describe("isContractRequest", () => {
     test("owns exactly the migrated (method, path) pairs", () => {
-        expect(isContractRequest("GET", "/api/version")).toBe(true);
+        // /api/version is in the contract (docs, generated client) but is
+        // ROUTED to the DB-free legacy row so the daemon's identity probe
+        // keeps answering when SurrealDB is down - see web-handler.ts.
+        expect(isContractRequest("GET", "/api/version")).toBe(false);
         expect(isContractRequest("POST", "/api/query")).toBe(true);
         expect(isContractRequest("GET", "/docs")).toBe(true);
         expect(isContractRequest("GET", "/openapi.json")).toBe(true);

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -5,8 +5,16 @@
  * FIRST - migrated (method, path) pairs route into the v4 HttpRouter built
  * here; everything else falls through to the legacy route table untouched.
  * The explicit pair table (rather than letting the v4 router 404) keeps the
- * legacy table's quirks - e.g. method-ANY routes - intact until each family
- * is fully cut over.
+ * legacy table's quirks - e.g. method-ANY routes and greedy `:param+` ids
+ * with raw slashes - intact until each family is fully cut over.
+ *
+ * GET /api/version is in the CONTRACT (docs, OpenAPI, generated client) but
+ * NOT in the routing table: it is the daemon's identity probe and must keep
+ * answering when SurrealDB is down, so the DB-free legacy rawRoute serves
+ * it. The v4 web handler builds its layer stack on first request and
+ * `toWebHandlerLayerWith` caches a FAILED build forever - the self-healing
+ * wrapper below rebuilds the handler after a rejected request so contract
+ * routes recover once the DB comes up (mirrors serve-runtime.ts).
  *
  * The `memoMap` option is shared with the server's ManagedRuntime
  * (serve-runtime.ts), so AppLayer's services - the SurrealDB connection,
@@ -20,24 +28,44 @@ import { HttpApiBuilder, HttpApiScalar } from "effect/unstable/httpapi";
 import type { SurrealClient } from "@ax/lib/db";
 import { AppLayer } from "@ax/lib/layers";
 import { AxApi } from "@ax/lib/shared/api-contract";
+import { jsonResponse } from "../router/router.ts";
+import { errorText } from "./common.ts";
+import { InsightsGroupLive } from "./insights.ts";
 import { ContractServeInfo, SystemGroupLive } from "./system.ts";
 
 /** Everything the contract handlers reach for; widens as families join. */
 export type ContractServices = SurrealClient;
 
-/** Migrated (method, path) pairs the contract router owns. */
+/** Migrated exact (method, path) pairs the contract router owns. */
 const CONTRACT_ROUTES: ReadonlySet<string> = new Set([
-    "GET /api/version",
+    // system (GET /api/version deliberately absent - see module doc)
     "POST /api/query",
     "GET /api/graph-health",
     "GET /api/worktrees",
     "GET /api/self-improve",
+    // insights
+    "GET /api/recall",
+    "GET /api/skill-graph",
+    "GET /api/wrapped",
+    "GET /api/wrapped/public-preview",
+    "GET /api/workflow",
+    "GET /api/tool-failures",
+    // docs
     "GET /docs",
     "GET /openapi.json",
 ]);
 
+/** Migrated single-segment param routes. Multi-segment ids (raw slashes in
+ *  a greedy `:param+`) fall through to the legacy rows by construction. */
+const CONTRACT_PATTERNS: ReadonlyArray<{ readonly method: string; readonly pattern: RegExp }> = [
+    { method: "GET", pattern: /^\/api\/episodes\/[^/]+$/ },
+    { method: "GET", pattern: /^\/api\/projects\/[^/]+$/ },
+    { method: "GET", pattern: /^\/api\/tool-failures\/[^/]+\/detail$/ },
+];
+
 export const isContractRequest = (method: string, pathname: string): boolean =>
-    CONTRACT_ROUTES.has(`${method} ${pathname}`);
+    CONTRACT_ROUTES.has(`${method} ${pathname}`) ||
+    CONTRACT_PATTERNS.some((p) => p.method === method && p.pattern.test(pathname));
 
 export interface ContractWebHandler {
     readonly handler: (request: Request) => Promise<Response>;
@@ -64,11 +92,33 @@ export function makeContractWebHandler(opts: MakeContractWebHandlerOptions): Con
         Layer.succeed(ContractServeInfo)({ liveIngest: opts.liveIngest }),
         opts.services ?? AppLayer,
     ).pipe(
-        Layer.provide(SystemGroupLive),
+        Layer.provide([SystemGroupLive, InsightsGroupLive]),
         Layer.provide([BunHttpPlatform.layer, BunFileSystem.layer, BunPath.layer, Etag.layer]),
     );
-    return HttpRouter.toWebHandler(appLayer, {
-        memoMap: opts.memoMap,
-        disableLogger: true,
-    });
+    const build = (): ContractWebHandler =>
+        HttpRouter.toWebHandler(appLayer, {
+            memoMap: opts.memoMap,
+            disableLogger: true,
+        });
+
+    // Self-heal: a handler REJECTION (as opposed to an error response) means
+    // the lazy layer build failed - e.g. SurrealDB down at boot - and
+    // toWebHandlerLayerWith caches that failure forever. Swap in a fresh
+    // handler so the next request retries, and answer this one with a 500.
+    let current = build();
+    return {
+        handler: async (request) => {
+            const active = current;
+            try {
+                return await active.handler(request);
+            } catch (err) {
+                if (current === active) {
+                    current = build();
+                    void active.dispose().catch(() => undefined);
+                }
+                return jsonResponse({ error: errorText(err) }, 500);
+            }
+        },
+        dispose: () => current.dispose(),
+    };
 }

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -108,7 +108,8 @@ export function imageSrc(absolutePath: string): string {
 // import cycle; re-exported here so existing importers keep working.
 export { ApiError } from "./api-error.ts";
 import { ApiError } from "./api-error.ts";
-import { contractVersion } from "./contract-client.ts";
+import { runContract, type AxClient } from "./contract-client.ts";
+import type { Effect } from "effect";
 import type { DaemonVersion } from "@ax/lib/shared/api-contract";
 
 async function jsonFetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
@@ -137,6 +138,29 @@ async function jsonFetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> 
         throw new ApiError(detail, res.status);
     }
     return (await res.json()) as T;
+}
+
+/**
+ * Route a call through the Insights Surface Contract client (ADR-0013).
+ * Mock mode without a connected endpoint keeps the legacy mock-fixtures
+ * behavior, keyed by the same bare path jsonFetch used; otherwise the
+ * generated client runs against the connected endpoint (or same-origin).
+ * The `T` cast preserves the dashboard-types interfaces the UI was already
+ * trusting under jsonFetch<T> - contract payloads tighten in a later pass.
+ */
+async function viaContract<T>(
+    mockPath: string,
+    call: (client: AxClient) => Effect.Effect<unknown, unknown>,
+): Promise<T> {
+    if (STUDIO_MOCK) {
+        const endpoint = readEndpoint();
+        if (!endpoint) {
+            const { mockFetch } = await import("./mock-fixtures.ts");
+            return mockFetch<T>(mockPath);
+        }
+        return await runContract(endpoint, call) as T;
+    }
+    return await runContract(null, call) as T;
 }
 
 export interface IngestTriggerResponse {
@@ -205,20 +229,8 @@ export interface SessionTimelinePayload {
 }
 
 export const api = {
-    // First contract-client call (ADR-0013): typed end-to-end against the
-    // same Schema the daemon serves. Mock mode without a connected endpoint
-    // keeps the legacy mockFetch behavior (no /api/version fixture -> throws).
-    version: async (): Promise<DaemonVersion> => {
-        if (STUDIO_MOCK) {
-            const endpoint = readEndpoint();
-            if (!endpoint) {
-                const { mockFetch } = await import("./mock-fixtures.ts");
-                return mockFetch("/api/version");
-            }
-            return contractVersion(endpoint);
-        }
-        return contractVersion(null);
-    },
+    version: (): Promise<DaemonVersion> =>
+        viaContract("/api/version", (c) => c.system.version()),
     skills: (): Promise<SkillTriageResponse> => jsonFetch("/api/skills"),
     decide: (
         name: string,
@@ -259,7 +271,8 @@ export const api = {
         }),
     decisions: (): Promise<{ decisions: ReadonlyArray<SkillTriageNote> }> =>
         jsonFetch("/api/decisions"),
-    workflow: (): Promise<WorkflowResponse> => jsonFetch("/api/workflow"),
+    workflow: (): Promise<WorkflowResponse> =>
+        viaContract("/api/workflow", (c) => c.insights.workflow()),
     sessions: (params: { offset?: number; limit?: number; source?: string; project?: string } = {}): Promise<SessionListResponse> => {
         const usp = new URLSearchParams();
         if (params.offset != null) usp.set("offset", String(params.offset));
@@ -303,9 +316,15 @@ export const api = {
         return jsonFetch(`/api/sessions/compare?${usp.toString()}`);
     },
     episodeTimeline: (parentId: string): Promise<EpisodeTimelinePayload> =>
-        jsonFetch(`/api/episodes/${encodeURIComponent(parentId)}`),
+        viaContract(
+            `/api/episodes/${encodeURIComponent(parentId)}`,
+            (c) => c.insights.episodeTimeline({ params: { parentId } }),
+        ),
     project: (slug: string): Promise<ProjectPagePayload> =>
-        jsonFetch(`/api/projects/${encodeURIComponent(slug)}`),
+        viaContract(
+            `/api/projects/${encodeURIComponent(slug)}`,
+            (c) => c.insights.project({ params: { project: slug } }),
+        ),
     graphExplorer: (params: {
         mode?: GraphExplorerMode;
         q?: string | null;
@@ -328,13 +347,14 @@ export const api = {
         jsonFetch(`/api/session-orchestration?id=${encodeURIComponent(id)}`),
     sessionSummary: (id: string): Promise<SessionSummary> =>
         jsonFetch(`/api/session-summary?id=${encodeURIComponent(id)}`),
-    skillGraph: (params: { minCount?: number; limit?: number } = {}): Promise<SkillGraphPayload> => {
-        const usp = new URLSearchParams();
-        if (params.minCount != null) usp.set("minCount", String(params.minCount));
-        if (params.limit != null) usp.set("limit", String(params.limit));
-        const qs = usp.toString();
-        return jsonFetch(qs ? `/api/skill-graph?${qs}` : "/api/skill-graph");
-    },
+    skillGraph: (params: { minCount?: number; limit?: number } = {}): Promise<SkillGraphPayload> =>
+        viaContract("/api/skill-graph", (c) =>
+            c.insights.skillGraph({
+                query: {
+                    ...(params.minCount != null ? { minCount: params.minCount } : {}),
+                    ...(params.limit != null ? { limit: params.limit } : {}),
+                },
+            })),
     recall: (params: {
         q: string;
         project?: string | null;
@@ -342,16 +362,18 @@ export const api = {
         since?: string | null;
         offset?: number;
         limit?: number;
-    }): Promise<RecallResponse> => {
-        const usp = new URLSearchParams();
-        usp.set("q", params.q);
-        if (params.project) usp.set("project", params.project);
-        if (params.skill) usp.set("skill", params.skill);
-        if (params.since) usp.set("since", params.since);
-        if (params.offset != null) usp.set("offset", String(params.offset));
-        if (params.limit != null) usp.set("limit", String(params.limit));
-        return jsonFetch(`/api/recall?${usp.toString()}`);
-    },
+    }): Promise<RecallResponse> =>
+        viaContract("/api/recall", (c) =>
+            c.insights.recall({
+                query: {
+                    q: params.q,
+                    ...(params.project ? { project: params.project } : {}),
+                    ...(params.skill ? { skill: params.skill } : {}),
+                    ...(params.since ? { since: params.since } : {}),
+                    ...(params.offset != null ? { offset: params.offset } : {}),
+                    ...(params.limit != null ? { limit: params.limit } : {}),
+                },
+            })),
     /** Trigger a live ingest run. Returns the full Durable Streams sidecar URL
      *  the browser subscribes to directly (the sidecar has permissive CORS and
      *  runs on its own localhost port). */
@@ -361,12 +383,17 @@ export const api = {
             headers: { "content-type": "application/json" },
             body: JSON.stringify(params.since != null ? { since: params.since } : {}),
         }),
-    toolFailures: (): Promise<ToolFailuresResponse> => jsonFetch("/api/tool-failures"),
+    toolFailures: (): Promise<ToolFailuresResponse> =>
+        viaContract("/api/tool-failures", (c) => c.insights.toolFailures()),
     toolFailureDetail: (label: string): Promise<ToolFailureDetailPayload> =>
-        jsonFetch(`/api/tool-failures/${encodeURIComponent(label)}/detail`),
-    wrapped: (): Promise<WrappedProfile> => jsonFetch("/api/wrapped"),
+        viaContract(
+            `/api/tool-failures/${encodeURIComponent(label)}/detail`,
+            (c) => c.insights.toolFailureDetail({ params: { label } }),
+        ),
+    wrapped: (): Promise<WrappedProfile> =>
+        viaContract("/api/wrapped", (c) => c.insights.wrapped()),
     wrappedPublicPreview: (): Promise<WrappedProfile> =>
-        jsonFetch("/api/wrapped/public-preview"),
+        viaContract("/api/wrapped/public-preview", (c) => c.insights.wrappedPublicPreview()),
 
     // Experiment loop - see
     // docs/superpowers/plans/2026-05-25-experiment-loop-cleanup-and-rebuild.md

--- a/apps/studio/src/contract-client.ts
+++ b/apps/studio/src/contract-client.ts
@@ -39,11 +39,15 @@ function toApiError(err: unknown): ApiError {
     return new ApiError(message, status);
 }
 
+export type { AxClient };
+
 /**
  * Run one contract call: build the per-call client against `baseUrl`
  * (null = same-origin relative URLs) and normalize failures to ApiError.
+ * The generic seam every api.ts method migrated to the contract goes
+ * through (via api.ts's viaContract, which owns the mock-mode branch).
  */
-async function runContract<A, E>(
+export async function runContract<A, E>(
     baseUrl: string | null,
     call: (client: AxClient) => Effect.Effect<A, E>,
 ): Promise<A> {

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -44,6 +44,11 @@ export class InternalError extends Schema.ErrorClass<InternalError>("ax/Internal
     error: Schema.String,
 }, { httpApiStatus: 500 }) {}
 
+/** A looked-up entity does not exist - `{ error }` with HTTP 404. */
+export class NotFoundError extends Schema.ErrorClass<NotFoundError>("ax/NotFoundError")({
+    error: Schema.String,
+}, { httpApiStatus: 404 }) {}
+
 /** POST /api/query - the read-only SQL console (SELECT/RETURN/INFO only). */
 export class QueryResult extends Schema.Class<QueryResult>("ax/QueryResult")({
     result: Schema.Unknown,
@@ -88,8 +93,73 @@ export const SystemGroup = HttpApiGroup.make("system")
         }),
     );
 
+/**
+ * The insights family: cross-source recall, project pages, episode
+ * timelines, the skill graph, wrapped profiles, workflow rollups, and tool
+ * failures. Payloads are `Schema.Unknown` for now (same later-pass deal as
+ * the system raw rows); paths, params, and status mapping are the contract.
+ *
+ * Path params are single-segment: every client URL-encodes ids, and the
+ * legacy greedy `:param+` rows remain mounted for raw-slash ids.
+ */
+export const InsightsGroup = HttpApiGroup.make("insights")
+    .add(
+        HttpApiEndpoint.get("recall", "/api/recall", {
+            query: {
+                q: Schema.optionalKey(Schema.String),
+                project: Schema.optionalKey(Schema.String),
+                skill: Schema.optionalKey(Schema.String),
+                since: Schema.optionalKey(Schema.String),
+                offset: Schema.optionalKey(Schema.Number),
+                limit: Schema.optionalKey(Schema.Number),
+            },
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("episodeTimeline", "/api/episodes/:parentId", {
+            params: { parentId: Schema.String },
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("skillGraph", "/api/skill-graph", {
+            query: {
+                minCount: Schema.optionalKey(Schema.Number),
+                limit: Schema.optionalKey(Schema.Number),
+            },
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("project", "/api/projects/:project", {
+            params: { project: Schema.String },
+            success: Schema.Unknown,
+            error: [NotFoundError, InternalError],
+        }),
+        HttpApiEndpoint.get("wrapped", "/api/wrapped", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("wrappedPublicPreview", "/api/wrapped/public-preview", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("workflow", "/api/workflow", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("toolFailures", "/api/tool-failures", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("toolFailureDetail", "/api/tool-failures/:label/detail", {
+            params: { label: Schema.String },
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+    );
+
 /** The Insights Surface Contract. Families join as they migrate (ADR-0013). */
 export const AxApi = HttpApi.make("ax")
     .add(SystemGroup)
+    .add(InsightsGroup)
     .annotate(OpenApi.Title, "ax daemon API")
     .annotate(OpenApi.Version, "1");


### PR DESCRIPTION
## What

PR C of ADR-0013 — the insights family migrates to the contract, plus two hardening fixes for the DB-down case.

**Insights family** (`recall`, `episodes/:id`, `skill-graph`, `projects/:slug`, `wrapped` ×2, `workflow`, `tool-failures` ×2):
- Contract endpoints with typed query/params; payloads `Schema.Unknown` (tightening = later pass, per the system-family precedent). `NotFoundError` (404) added for the project-miss parity.
- Handlers are thin delegations to the existing `fetch*` effects; recall keeps its empty-q fast path (canned page, DB never touched — tested with a poisoned stub).
- Matcher gains single-segment param patterns; multi-segment ids (raw slashes) still fall to the legacy greedy `:param+` rows. `graph-explorer` stays legacy (env-gated experimental).
- Studio: all nine calls go through the generated client via a `viaContract` helper that preserves mock-fixtures interception and `ApiError` mapping. Behavior change (intentional): garbage numeric query params are now 400s instead of silently defaulted.

**Hardening** — `toWebHandlerLayerWith` caches a rejected lazy build forever (`handlerPromise ??=`), so SurrealDB down at boot would have bricked every contract route permanently:
1. `GET /api/version` is no longer contract-*routed* — the DB-free legacy row keeps the daemon identity probe (used by `ax serve` pre-flight, studio connect, desktop arbitration) answering with the DB down. It stays in the contract for Scalar/OpenAPI/client.
2. `makeContractWebHandler` self-heals: a rejected request answers 500, disposes the bricked handler, rebuilds for the next request (tested with a first-build-fails layer).

## Verification

- 9 new tests (matcher patterns, empty-q recall with poisoned DB stub, project 404, 400-on-garbage-param, self-healing recover). Full suite 3505 pass, typecheck clean, `build:web` green.
- Live smoke: contract recall (empty + real q), skill-graph, wrapped 200s; project miss 404; `/api/version` still served DB-free; OpenAPI grows to 14 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)