### PR TITLE
feat(profile): activity + insights sections & profile-page redesign

### DIFF
--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -88,11 +88,18 @@ const gatherEnv = Effect.gen(function* () {
 const integer = (n: number): string =>
     Number.isFinite(n) ? Math.trunc(n).toLocaleString("en-US") : "0";
 
+/** Human money: >=1000 -> "~$22.6K", else "$22". */
+const money = (n: number): string => {
+    if (!Number.isFinite(n)) return "$0";
+    if (n >= 1000) return `~$${(n / 1000).toFixed(1)}K`;
+    return `$${n.toFixed(0)}`;
+};
+
 export function formatProfile(p: ProfileV1): string {
     const lines: string[] = [];
     lines.push(`ax profile - @${p.github}  (last ${p.window_days}d)`);
     lines.push("");
-    const cost = p.stats.cost_usd !== undefined ? `  ·  $${p.stats.cost_usd.toFixed(2)} est` : "";
+    const cost = p.stats.cost_usd !== undefined ? `  ·  ${money(p.stats.cost_usd)} est` : "";
     lines.push(
         `${integer(p.stats.sessions)} sessions  ·  ${integer(p.stats.tokens.total)} tokens${cost}`,
     );
@@ -108,13 +115,31 @@ export function formatProfile(p: ProfileV1): string {
         ...topSkills.map((s) => s.name.length),
     );
     for (const m of p.stats.models) {
-        const c = m.cost_usd !== undefined ? `  $${m.cost_usd.toFixed(2)}` : "";
+        const c = m.cost_usd !== undefined ? `  ${money(m.cost_usd)}` : "";
         lines.push(`  ${m.name.padEnd(nameWidth)} ${(m.share * 100).toFixed(0).padStart(3)}%${c}`);
     }
     lines.push("");
     lines.push(`rig: ${p.rig.skills.length} skills · ${p.rig.hooks.length} hooks · routing_table: ${p.rig.routing_table}${p.rig.rules ? ` · ${p.rig.rules.count} rules` : ""}`);
     for (const s of topSkills) {
         lines.push(`  ${s.name.padEnd(nameWidth)} ${integer(s.runs).padStart(6)} runs  (${s.source})`);
+    }
+    if (p.insights) {
+        const ins = p.insights;
+        const deepPct = (ins.deep_session_share * 100).toFixed(0);
+        lines.push("");
+        lines.push("insights:");
+        lines.push(
+            `  ${ins.hours_total.toFixed(1)}h total  ·  longest: ${integer(ins.longest_session_minutes)}min  ·  deep (>=90min): ${deepPct}%`,
+        );
+        lines.push(
+            `  peak hour: ${String(ins.peak_hour_utc).padStart(2, "0")}:00 UTC  ·  max parallel: ${ins.max_parallel_sessions}  ·  spawned: ${integer(ins.subagents_spawned)}  ·  commits: ${integer(ins.commits)}`,
+        );
+        if (ins.tools_top.length > 0) {
+            lines.push("  top tools:");
+            for (const t of ins.tools_top.slice(0, 5)) {
+                lines.push(`    ${t.name.padEnd(20)} ${integer(t.runs).padStart(7)} runs`);
+            }
+        }
     }
     if (p.taste) {
         lines.push("");

--- a/apps/axctl/src/profile/insights.test.ts
+++ b/apps/axctl/src/profile/insights.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+import { deriveInsights } from "./insights.ts";
+import type { DailyActivityRow, SessionDurationRow } from "./queries.ts";
+
+const s = (startIso: string, endIso: string): SessionDurationRow => ({
+    started_at: startIso,
+    ended_at: endIso,
+});
+
+describe("deriveInsights", () => {
+    const baseDailyFull: DailyActivityRow[] = [
+        { date: "2026-06-09", sessions: 31, tokens: 800_000 },
+        { date: "2026-06-10", sessions: 8, tokens: 100_000 },
+        { date: "2026-06-12", sessions: 12, tokens: 120_000_000 },
+    ];
+
+    const baseDurations: SessionDurationRow[] = [
+        s("2026-06-12T10:00:00Z", "2026-06-12T12:30:00Z"), // 2.5h = deep
+        s("2026-06-12T11:00:00Z", "2026-06-12T11:30:00Z"), // 30min = not deep
+        s("2026-06-12T09:00:00Z", "2026-06-12T10:30:00Z"), // 1.5h = deep
+    ];
+
+    test("hours_total sums all durations in hours", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 10,
+            spawned: 5,
+            commits: 20,
+            tools: [{ name: "Bash", runs: 100 }],
+            daily: baseDailyFull,
+        });
+        // 2.5 + 0.5 + 1.5 = 4.5h
+        expect(r!.hours_total).toBeCloseTo(4.5, 1);
+    });
+
+    test("longest_session_minutes finds the longest", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 10,
+            spawned: 5,
+            commits: 20,
+            tools: [],
+            daily: baseDailyFull,
+        });
+        expect(r!.longest_session_minutes).toBe(150);
+    });
+
+    test("deep_session_share = sessions >= 90min / total sessions with duration", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 10,
+            spawned: 5,
+            commits: 20,
+            tools: [],
+            daily: baseDailyFull,
+        });
+        expect(r!.deep_session_share).toBeCloseTo(2 / 3, 3);
+    });
+
+    test("busiest_day = max sessions in daily", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 13,
+            spawned: 5,
+            commits: 20,
+            tools: [],
+            daily: baseDailyFull,
+        });
+        expect(r!.busiest_day.date).toBe("2026-06-09");
+        expect(r!.busiest_day.sessions).toBe(31);
+    });
+
+    test("ties in busiest_day -> earliest date wins", () => {
+        const tied: DailyActivityRow[] = [
+            { date: "2026-06-10", sessions: 10, tokens: 0 },
+            { date: "2026-06-09", sessions: 10, tokens: 0 },
+        ];
+        const r = deriveInsights({
+            durations: [],
+            peakHour: null,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: tied,
+        });
+        expect(r!.busiest_day.date).toBe("2026-06-09");
+    });
+
+    test("max_parallel_sessions: sweep overlapping intervals", () => {
+        const durations: SessionDurationRow[] = [
+            s("2026-06-12T10:00:00Z", "2026-06-12T11:00:00Z"),
+            s("2026-06-12T10:00:00Z", "2026-06-12T10:30:00Z"),
+            s("2026-06-12T10:00:00Z", "2026-06-12T10:20:00Z"),
+            s("2026-06-12T10:35:00Z", "2026-06-12T11:30:00Z"), // only 2 overlap here
+        ];
+        const r = deriveInsights({
+            durations,
+            peakHour: 10,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: [{ date: "2026-06-12", sessions: 4, tokens: 0 }],
+        });
+        expect(r!.max_parallel_sessions).toBe(3);
+    });
+
+    test("max_parallel_sessions: no overlap -> 1", () => {
+        const durations: SessionDurationRow[] = [
+            s("2026-06-12T08:00:00Z", "2026-06-12T09:00:00Z"),
+            s("2026-06-12T10:00:00Z", "2026-06-12T11:00:00Z"),
+        ];
+        const r = deriveInsights({
+            durations,
+            peakHour: 8,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: [{ date: "2026-06-12", sessions: 2, tokens: 0 }],
+        });
+        expect(r!.max_parallel_sessions).toBe(1);
+    });
+
+    test("sessions clamped at 24h each (bad data)", () => {
+        const durations: SessionDurationRow[] = [
+            s("2026-06-01T00:00:00Z", "2026-06-10T00:00:00Z"), // 9 days -> clamped to 24h
+            s("2026-06-12T10:00:00Z", "2026-06-12T12:00:00Z"), // 2h
+        ];
+        const r = deriveInsights({
+            durations,
+            peakHour: 10,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: [{ date: "2026-06-12", sessions: 2, tokens: 0 }],
+        });
+        expect(r!.hours_total).toBeCloseTo(26.0, 1);
+        expect(r!.longest_session_minutes).toBe(1440);
+    });
+
+    test("passthrough fields: peak_hour_utc, spawned, commits, tools_top", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 13,
+            spawned: 420,
+            commits: 1000,
+            tools: [{ name: "Bash", runs: 5000 }],
+            daily: baseDailyFull,
+        });
+        expect(r!.peak_hour_utc).toBe(13);
+        expect(r!.subagents_spawned).toBe(420);
+        expect(r!.commits).toBe(1000);
+        expect(r!.tools_top[0]!.name).toBe("Bash");
+    });
+
+    test("returns null when both durations and daily are empty", () => {
+        const r = deriveInsights({
+            durations: [],
+            peakHour: null,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: [],
+        });
+        expect(r).toBeNull();
+    });
+
+    test("daily non-empty but durations empty: zeros + busiest_day still set", () => {
+        const r = deriveInsights({
+            durations: [],
+            peakHour: 9,
+            spawned: 3,
+            commits: 5,
+            tools: [],
+            daily: [{ date: "2026-06-12", sessions: 5, tokens: 0 }],
+        });
+        expect(r).not.toBeNull();
+        expect(r!.hours_total).toBe(0);
+        expect(r!.deep_session_share).toBe(0);
+        expect(r!.max_parallel_sessions).toBe(0);
+        expect(r!.busiest_day.date).toBe("2026-06-12");
+    });
+
+    test("malformed duration rows are skipped", () => {
+        const durations: SessionDurationRow[] = [
+            s("not-a-date", "2026-06-12T11:00:00Z"),
+            s("2026-06-12T11:00:00Z", "2026-06-12T10:00:00Z"), // end before start
+            s("2026-06-12T10:00:00Z", "2026-06-12T11:00:00Z"), // valid 1h
+        ];
+        const r = deriveInsights({
+            durations,
+            peakHour: 10,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: [{ date: "2026-06-12", sessions: 3, tokens: 0 }],
+        });
+        expect(r!.hours_total).toBeCloseTo(1.0, 1);
+        expect(r!.max_parallel_sessions).toBe(1);
+    });
+});

--- a/apps/axctl/src/profile/insights.ts
+++ b/apps/axctl/src/profile/insights.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure session-analytics derivers for the ProfileV1 `insights` section.
+ * No IO, no Effect, no Date.now() - all inputs injected. Individual session
+ * durations are clamped at 24h to kill bad data (a wedged harness can leave
+ * multi-day "sessions" behind). Returns null when there is no data at all
+ * (both durations and daily empty) so the renderer can omit the section.
+ */
+import type { DailyActivityRow, SessionDurationRow, TopToolRow } from "./queries.ts";
+
+const MAX_SESSION_MS = 24 * 60 * 60 * 1000; // 24h cap per session
+const DEEP_THRESHOLD_MIN = 90;
+
+export interface InsightsInput {
+    readonly durations: ReadonlyArray<SessionDurationRow>;
+    readonly peakHour: number | null;
+    readonly spawned: number;
+    readonly commits: number;
+    readonly tools: ReadonlyArray<TopToolRow>;
+    readonly daily: ReadonlyArray<DailyActivityRow>;
+}
+
+export interface InsightsResult {
+    readonly hours_total: number;
+    readonly longest_session_minutes: number;
+    readonly deep_session_share: number;
+    readonly peak_hour_utc: number;
+    readonly busiest_day: { readonly date: string; readonly sessions: number };
+    readonly max_parallel_sessions: number;
+    readonly subagents_spawned: number;
+    readonly commits: number;
+    readonly tools_top: ReadonlyArray<TopToolRow>;
+}
+
+export function deriveInsights(input: InsightsInput): InsightsResult | null {
+    const { durations, peakHour, spawned, commits, tools, daily } = input;
+    if (durations.length === 0 && daily.length === 0) return null;
+
+    // --- duration stats (clamped at 24h per session) ------------------------
+    let totalMs = 0;
+    let longestMs = 0;
+    let deepCount = 0;
+    let validCount = 0;
+    const events: Array<{ t: number; delta: 1 | -1 }> = [];
+
+    for (const { started_at, ended_at } of durations) {
+        const startMs = Date.parse(started_at);
+        const endMs = Date.parse(ended_at);
+        if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) continue;
+        validCount++;
+        const clampedMs = Math.min(endMs - startMs, MAX_SESSION_MS);
+        totalMs += clampedMs;
+        longestMs = Math.max(longestMs, clampedMs);
+        if (clampedMs / 60_000 >= DEEP_THRESHOLD_MIN) deepCount++;
+        events.push({ t: startMs, delta: 1 });
+        events.push({ t: endMs, delta: -1 });
+    }
+
+    const hours_total = Math.round((totalMs / 3_600_000) * 10) / 10;
+    const longest_session_minutes = Math.round(longestMs / 60_000);
+    const deep_session_share = validCount > 0 ? deepCount / validCount : 0;
+
+    // --- max parallel sessions (classic sweep line) --------------------------
+    // Sort by time; on ties process ends before starts so back-to-back
+    // sessions don't count as overlapping.
+    let max_parallel_sessions = 0;
+    events.sort((a, b) => (a.t !== b.t ? a.t - b.t : a.delta - b.delta));
+    let current = 0;
+    for (const { delta } of events) {
+        current += delta;
+        if (current > max_parallel_sessions) max_parallel_sessions = current;
+    }
+
+    // --- busiest day (max sessions; ties -> earliest date) -------------------
+    let busiestDate = "";
+    let busiestSessions = 0;
+    for (const row of daily) {
+        if (
+            row.sessions > busiestSessions ||
+            (row.sessions === busiestSessions && busiestDate !== "" && row.date < busiestDate)
+        ) {
+            busiestDate = row.date;
+            busiestSessions = row.sessions;
+        }
+    }
+
+    return {
+        hours_total,
+        longest_session_minutes,
+        deep_session_share,
+        peak_hour_utc: peakHour ?? 0,
+        busiest_day: { date: busiestDate, sessions: busiestSessions },
+        max_parallel_sessions,
+        subagents_spawned: spawned,
+        commits,
+        tools_top: tools,
+    };
+}

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, test } from "bun:test";
 import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
 import {
     fetchAcceptedProposals,
+    fetchCommitCount,
     fetchDailyActivity,
+    fetchDailyActivityFull,
     fetchHarnesses,
+    fetchPeakHour,
+    fetchSessionDurations,
     fetchSkillInvocations,
     fetchSkillScopes,
+    fetchSpawnedCount,
     fetchTokenTotals,
+    fetchTopTools,
 } from "./queries.ts";
 
 describe("fetchTokenTotals", () => {
@@ -81,5 +87,127 @@ describe("fetchAcceptedProposals", () => {
         const r = await runWithMock(db, fetchAcceptedProposals());
         expect(r[0]!.title).toBe("Stop edit loops early");
         expect(db.captured[0]).toContain("status = 'accepted'");
+    });
+});
+
+describe("fetchDailyActivityFull", () => {
+    test("returns date+sessions+tokens rows, window applied", async () => {
+        const db = makeMockDb([
+            [[{ date: "2026-06-11", sessions: 5 }, { date: "2026-06-12", sessions: 3 }]],
+            [[{ date: "2026-06-11", tokens: 100_000 }, { date: "2026-06-12", tokens: 80_000 }]],
+        ]);
+        const r = await runWithMock(db, fetchDailyActivityFull({ windowDays: 30 }));
+        expect(r).toHaveLength(2);
+        expect(r[0]).toEqual({ date: "2026-06-11", sessions: 5, tokens: 100_000 });
+        expect(r[1]).toEqual({ date: "2026-06-12", sessions: 3, tokens: 80_000 });
+        expect(db.captured[0]).toContain("time::now() - 30d");
+        expect(db.captured[0]).toContain("array::len(array::distinct(session))");
+    });
+
+    test("day with no tokens entry gets tokens=0", async () => {
+        const db = makeMockDb([
+            [[{ date: "2026-06-11", sessions: 5 }]],
+            [[]],
+        ]);
+        const r = await runWithMock(db, fetchDailyActivityFull({ windowDays: 30 }));
+        expect(r[0]).toEqual({ date: "2026-06-11", sessions: 5, tokens: 0 });
+    });
+
+    test("empty window -> empty array", async () => {
+        const db = makeMockDb([[[]], [[]]]);
+        const r = await runWithMock(db, fetchDailyActivityFull({ windowDays: 30 }));
+        expect(r).toHaveLength(0);
+    });
+});
+
+describe("fetchSessionDurations", () => {
+    test("returns started_at+ended_at as ISO strings, window applied", async () => {
+        const db = makeMockDb([[[
+            { started_at: "2026-06-11T10:00:00Z", ended_at: "2026-06-11T12:30:00Z" },
+            { started_at: "2026-06-12T09:00:00Z", ended_at: "2026-06-12T10:00:00Z" },
+        ]]]);
+        const r = await runWithMock(db, fetchSessionDurations({ windowDays: 30 }));
+        expect(r[0]!.started_at).toBe("2026-06-11T10:00:00Z");
+        expect(r[0]!.ended_at).toBe("2026-06-11T12:30:00Z");
+        expect(db.captured[0]).toContain("ended_at IS NOT NONE");
+        expect(db.captured[0]).toContain("started_at IS NOT NONE");
+        expect(db.captured[0]).toContain("time::now() - 30d");
+    });
+
+    test("empty window -> empty array", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchSessionDurations({ windowDays: 30 }));
+        expect(r).toHaveLength(0);
+    });
+});
+
+describe("fetchPeakHour", () => {
+    test("returns the peak hour as a number", async () => {
+        const db = makeMockDb([[[{ hour: "13", count: 42 }]]]);
+        const r = await runWithMock(db, fetchPeakHour({ windowDays: 30 }));
+        expect(r).toBe(13);
+        expect(db.captured[0]).toContain("time::format(started_at");
+        expect(db.captured[0]).toContain("time::now() - 30d");
+    });
+
+    test("empty window -> null", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchPeakHour({ windowDays: 30 }));
+        expect(r).toBeNull();
+    });
+});
+
+describe("fetchSpawnedCount", () => {
+    test("returns spawned count in window", async () => {
+        const db = makeMockDb([[[{ count: 420 }]]]);
+        const r = await runWithMock(db, fetchSpawnedCount({ windowDays: 30 }));
+        expect(r).toBe(420);
+        expect(db.captured[0]).toContain("FROM spawned");
+        expect(db.captured[0]).toContain("time::now() - 30d");
+    });
+
+    test("empty -> 0", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchSpawnedCount({ windowDays: 30 }));
+        expect(r).toBe(0);
+    });
+});
+
+describe("fetchCommitCount", () => {
+    test("returns commit count using ts field", async () => {
+        const db = makeMockDb([[[{ count: 1000 }]]]);
+        const r = await runWithMock(db, fetchCommitCount({ windowDays: 30 }));
+        expect(r).toBe(1000);
+        expect(db.captured[0]).toContain("FROM commit");
+        expect(db.captured[0]).toContain("ts >");
+        expect(db.captured[0]).toContain("time::now() - 30d");
+    });
+
+    test("empty -> 0", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchCommitCount({ windowDays: 30 }));
+        expect(r).toBe(0);
+    });
+});
+
+describe("fetchTopTools", () => {
+    test("returns top 10 tools by run count, window applied", async () => {
+        const db = makeMockDb([[[
+            { tool: "Bash", count: 5000 },
+            { tool: "Read", count: 3200 },
+        ]]]);
+        const r = await runWithMock(db, fetchTopTools({ windowDays: 30 }));
+        expect(r[0]).toEqual({ name: "Bash", runs: 5000 });
+        expect(r[1]).toEqual({ name: "Read", runs: 3200 });
+        expect(db.captured[0]).toContain("FROM tool_call");
+        expect(db.captured[0]).toContain("command_norm ?? name");
+        expect(db.captured[0]).toContain("LIMIT 10");
+        expect(db.captured[0]).toContain("time::now() - 30d");
+    });
+
+    test("empty -> empty array", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchTopTools({ windowDays: 30 }));
+        expect(r).toHaveLength(0);
     });
 });

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -163,3 +163,178 @@ export const fetchAcceptedProposals = Effect.fn("profile.fetchAcceptedProposals"
         })) satisfies ProposalRow[];
     },
 );
+
+// --- daily activity full (sessions + tokens per day) ------------------------
+
+export interface DailyActivityRow {
+    readonly date: string;
+    readonly sessions: number;
+    readonly tokens: number;
+}
+
+const DAILY_SESSIONS_SQL = (d: number) => `
+SELECT
+    time::format(ts, "%Y-%m-%d") AS date,
+    array::len(array::distinct(session)) AS sessions
+FROM turn
+WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
+GROUP BY date
+ORDER BY date ASC;`;
+
+const DAILY_TOKENS_SQL = (d: number) => `
+SELECT
+    time::format(ts, "%Y-%m-%d") AS date,
+    math::sum(prompt_tokens ?? 0) + math::sum(completion_tokens ?? 0) AS tokens
+FROM session_token_usage
+WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
+GROUP BY date
+ORDER BY date ASC;`;
+
+export const fetchDailyActivityFull = Effect.fn("profile.fetchDailyActivityFull")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const sessionRows = yield* db
+            .query<[Array<Record<string, unknown>>]>(DAILY_SESSIONS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const tokenRows = yield* db
+            .query<[Array<Record<string, unknown>>]>(DAILY_TOKENS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        // Join tokens onto session rows in JS (two grouped queries; SurrealDB
+        // 3.x grouped aggregates stay deref-free per the hang rule).
+        const tokenMap = new Map(
+            tokenRows
+                .map((r) => [String(r.date), Number(r.tokens ?? 0)] as const)
+                .filter(([day]) => day !== "undefined" && day !== "null"),
+        );
+        return sessionRows
+            .map((r) => {
+                const date = String(r.date);
+                return { date, sessions: Number(r.sessions ?? 0), tokens: tokenMap.get(date) ?? 0 };
+            })
+            .filter((r) => r.date !== "undefined" && r.date !== "null") satisfies DailyActivityRow[];
+    },
+);
+
+// --- session durations -------------------------------------------------------
+
+export interface SessionDurationRow {
+    readonly started_at: string;
+    readonly ended_at: string;
+}
+
+const SESSION_DURATIONS_SQL = (d: number) => `
+SELECT
+    type::string(started_at) AS started_at,
+    type::string(ended_at) AS ended_at
+FROM session
+WHERE started_at > time::now() - ${win(d)}
+  AND started_at IS NOT NONE
+  AND ended_at IS NOT NONE;`;
+
+export const fetchSessionDurations = Effect.fn("profile.fetchSessionDurations")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(SESSION_DURATIONS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return rows
+            .filter((r) => r.started_at != null && r.ended_at != null)
+            .map((r) => ({
+                started_at: String(r.started_at),
+                ended_at: String(r.ended_at),
+            })) satisfies SessionDurationRow[];
+    },
+);
+
+// --- peak hour ---------------------------------------------------------------
+
+const PEAK_HOUR_SQL = (d: number) => `
+SELECT
+    time::format(started_at, "%H") AS hour,
+    count() AS count
+FROM session
+WHERE started_at > time::now() - ${win(d)}
+  AND started_at IS NOT NONE
+GROUP BY hour
+ORDER BY count DESC
+LIMIT 1;`;
+
+export const fetchPeakHour = Effect.fn("profile.fetchPeakHour")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(PEAK_HOUR_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const row = rows[0];
+        if (row == null) return null;
+        return Number(row.hour ?? 0);
+    },
+);
+
+// --- spawned count -----------------------------------------------------------
+
+const SPAWNED_COUNT_SQL = (d: number) => `
+SELECT count() AS count
+FROM spawned
+WHERE ts > time::now() - ${win(d)}
+GROUP ALL;`;
+
+export const fetchSpawnedCount = Effect.fn("profile.fetchSpawnedCount")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(SPAWNED_COUNT_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return Number(rows[0]?.count ?? 0);
+    },
+);
+
+// --- commit count ------------------------------------------------------------
+// commit table uses `ts` (datetime) - confirmed in packages/schema/src/schema.surql.
+
+const COMMIT_COUNT_SQL = (d: number) => `
+SELECT count() AS count
+FROM commit
+WHERE ts > time::now() - ${win(d)}
+GROUP ALL;`;
+
+export const fetchCommitCount = Effect.fn("profile.fetchCommitCount")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(COMMIT_COUNT_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return Number(rows[0]?.count ?? 0);
+    },
+);
+
+// --- top tools ---------------------------------------------------------------
+
+export interface TopToolRow {
+    readonly name: string;
+    readonly runs: number;
+}
+
+const TOP_TOOLS_SQL = (d: number) => `
+SELECT
+    (command_norm ?? name) AS tool,
+    count() AS count
+FROM tool_call
+WHERE ts > time::now() - ${win(d)}
+  AND (command_norm ?? name) IS NOT NONE
+GROUP BY tool
+ORDER BY count DESC
+LIMIT 10;`;
+
+export const fetchTopTools = Effect.fn("profile.fetchTopTools")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(TOP_TOOLS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return rows.map((r) => ({
+            name: String(r.tool),
+            runs: Number(r.count ?? 0),
+        })) satisfies TopToolRow[];
+    },
+);

--- a/apps/axctl/src/profile/render.test.ts
+++ b/apps/axctl/src/profile/render.test.ts
@@ -5,6 +5,8 @@ import { buildProfile } from "./render.ts";
 // Mock result order MUST match the query order in buildProfile:
 // 1 tokenTotals  2 dailyActivity  3 harnesses  4 skillInvocations
 // 5 skillScopes  6 acceptedProposals  7 costModels
+// 8 dailyActivityFull(sessions)  9 dailyActivityFull(tokens)
+// 10 sessionDurations  11 peakHour  12 spawnedCount  13 commitCount  14 topTools
 const mockResults = [
     [[{ prompt_tokens: 31_000_000, completion_tokens: 7_000_000, sessions: 142 }]],
     [[{ date: "2026-06-11" }, { date: "2026-06-12" }]],
@@ -23,6 +25,16 @@ const mockResults = [
         model: "haiku", sessions: 42, prompt_tokens: 1, completion_tokens: 1,
         cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 50,
     }]],
+    [[{ date: "2026-06-11", sessions: 5 }, { date: "2026-06-12", sessions: 12 }]],
+    [[{ date: "2026-06-11", tokens: 100_000 }, { date: "2026-06-12", tokens: 120_000_000 }]],
+    [[
+        { started_at: "2026-06-12T10:00:00Z", ended_at: "2026-06-12T12:30:00Z" },
+        { started_at: "2026-06-12T09:00:00Z", ended_at: "2026-06-12T10:30:00Z" },
+    ]],
+    [[{ hour: "13", count: 42 }]],
+    [[{ count: 420 }]],
+    [[{ count: 1000 }]],
+    [[{ tool: "Bash", count: 5000 }, { tool: "Read", count: 3200 }]],
 ];
 
 const env = {
@@ -54,6 +66,25 @@ describe("buildProfile", () => {
         expect(p.rig.skills).toEqual([{ name: "tdd", source: "superpowers", runs: 88 }]);
         expect(p.rig.rules).toEqual({ count: 2 });
         expect(p.taste!.patterns[0]!.name).toBe("stop-edit-loops-early");
+        // activity
+        expect(p.activity).toBeDefined();
+        expect(p.activity!.daily).toHaveLength(2);
+        expect(p.activity!.daily[0]).toEqual({ date: "2026-06-11", sessions: 5, tokens: 100_000 });
+        expect(p.activity!.daily[1]!.tokens).toBe(120_000_000);
+        // insights
+        expect(p.insights).toBeDefined();
+        expect(p.insights!.hours_total).toBeCloseTo(4, 1); // 2.5h + 1.5h
+        expect(p.insights!.longest_session_minutes).toBe(150);
+        expect(p.insights!.deep_session_share).toBe(1); // both sessions >= 90min
+        expect(p.insights!.peak_hour_utc).toBe(13);
+        expect(p.insights!.busiest_day).toEqual({ date: "2026-06-12", sessions: 12 });
+        expect(p.insights!.max_parallel_sessions).toBe(2);
+        expect(p.insights!.subagents_spawned).toBe(420);
+        expect(p.insights!.commits).toBe(1000);
+        expect(p.insights!.tools_top).toEqual([
+            { name: "Bash", runs: 5000 },
+            { name: "Read", runs: 3200 },
+        ]);
     });
 
     test("includeCost=false strips cost everywhere; share falls back to sessions", async () => {
@@ -68,5 +99,14 @@ describe("buildProfile", () => {
         const db = makeMockDb(noProposals);
         const p = await runWithMock(db, buildProfile({ windowDays: 30, includeCost: true, env }));
         expect(p.taste).toBeUndefined();
+    });
+
+    test("empty daily + durations -> activity and insights omitted", async () => {
+        // Blank out dailyFull(sessions+tokens) and sessionDurations (indices 7, 8, 9).
+        const empty = mockResults.map((r, i) => (i >= 7 && i <= 9 ? [[]] : r));
+        const db = makeMockDb(empty);
+        const p = await runWithMock(db, buildProfile({ windowDays: 30, includeCost: true, env }));
+        expect(p.activity).toBeUndefined();
+        expect(p.insights).toBeUndefined();
     });
 });

--- a/apps/axctl/src/profile/render.ts
+++ b/apps/axctl/src/profile/render.ts
@@ -9,12 +9,19 @@ import { Effect } from "effect";
 import { fetchCostModels } from "../queries/cost-analytics.ts";
 import {
     fetchAcceptedProposals,
+    fetchCommitCount,
     fetchDailyActivity,
+    fetchDailyActivityFull,
     fetchHarnesses,
+    fetchPeakHour,
+    fetchSessionDurations,
     fetchSkillInvocations,
     fetchSkillScopes,
+    fetchSpawnedCount,
     fetchTokenTotals,
+    fetchTopTools,
 } from "./queries.ts";
+import { deriveInsights } from "./insights.ts";
 import { deriveRig } from "./rig.ts";
 import { computeStreak } from "./streak.ts";
 import { deriveTastePatterns } from "./taste.ts";
@@ -39,6 +46,11 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
 
         // Sequential on purpose: makeMockDb replays results in call order,
         // and the local DB answers these in milliseconds anyway.
+        // Order (keep render.test.ts mocks aligned):
+        // 1 tokenTotals  2 dailyActivity  3 harnesses  4 skillInvocations
+        // 5 skillScopes  6 acceptedProposals  7 costModels
+        // 8+9 dailyActivityFull (sessions, tokens)  10 sessionDurations
+        // 11 peakHour  12 spawnedCount  13 commitCount  14 topTools
         const totals = yield* fetchTokenTotals({ windowDays });
         const daily = yield* fetchDailyActivity({ windowDays });
         const harnesses = yield* fetchHarnesses({ windowDays });
@@ -46,6 +58,12 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         const scopes = yield* fetchSkillScopes();
         const proposals = yield* fetchAcceptedProposals();
         const cost = yield* fetchCostModels({ sinceDays: windowDays });
+        const dailyFull = yield* fetchDailyActivityFull({ windowDays });
+        const durations = yield* fetchSessionDurations({ windowDays });
+        const peakHour = yield* fetchPeakHour({ windowDays });
+        const spawnedCount = yield* fetchSpawnedCount({ windowDays });
+        const commitCount = yield* fetchCommitCount({ windowDays });
+        const topTools = yield* fetchTopTools({ windowDays });
 
         const streak = computeStreak(daily, env.today);
 
@@ -64,6 +82,16 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         });
 
         const patterns = deriveTastePatterns(proposals);
+
+        // null when there is no data at all -> section omitted below.
+        const insights = deriveInsights({
+            durations,
+            peakHour,
+            spawned: spawnedCount,
+            commits: commitCount,
+            tools: topTools,
+            daily: dailyFull,
+        });
 
         // decodeProfile throws on invariant breach -> Effect defect (die),
         // intentionally unrecoverable: a malformed profile is a bug here.
@@ -93,6 +121,8 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
                 rulesMarkdown: env.rulesMarkdown,
             }),
             ...(patterns.length > 0 ? { taste: { patterns } } : {}),
+            ...(dailyFull.length > 0 ? { activity: { daily: dailyFull } } : {}),
+            ...(insights !== null ? { insights } : {}),
         });
         return profile;
     },

--- a/apps/axctl/src/profile/schema.test.ts
+++ b/apps/axctl/src/profile/schema.test.ts
@@ -151,3 +151,82 @@ describe("decodeProfile", () => {
         ]);
     });
 });
+
+describe("activity + insights sections", () => {
+    const withSections = {
+        ...validProfile,
+        activity: {
+            daily: [
+                { date: "2026-06-09", sessions: 31, tokens: 800_000 },
+                { date: "2026-06-12", sessions: 12, tokens: 120_000_000 },
+            ],
+        },
+        insights: {
+            hours_total: 307.2,
+            longest_session_minutes: 960,
+            deep_session_share: 0.58,
+            peak_hour_utc: 13,
+            busiest_day: { date: "2026-06-09", sessions: 31 },
+            max_parallel_sessions: 11,
+            subagents_spawned: 420,
+            commits: 1000,
+            tools_top: [
+                { name: "Bash", runs: 5000 },
+                { name: "Read", runs: 3200 },
+            ],
+        },
+    };
+
+    test("accepts valid profile with both sections", () => {
+        const p = decodeProfile(withSections);
+        expect(p.activity!.daily).toHaveLength(2);
+        expect(p.activity!.daily[0]!.sessions).toBe(31);
+        expect(p.insights!.hours_total).toBe(307.2);
+        expect(p.insights!.busiest_day.date).toBe("2026-06-09");
+        expect(p.insights!.tools_top[0]!.name).toBe("Bash");
+    });
+
+    test("activity section is optional - omit it and profile still decodes", () => {
+        const { activity: _a, ...rest } = withSections;
+        const p = decodeProfile(rest);
+        expect(p.activity).toBeUndefined();
+    });
+
+    test("insights section is optional - omit it and profile still decodes", () => {
+        const { insights: _i, ...rest } = withSections;
+        const p = decodeProfile(rest);
+        expect(p.insights).toBeUndefined();
+    });
+
+    test("rejects tools_top row with non-number runs", () => {
+        const bad = {
+            ...withSections,
+            insights: {
+                ...withSections.insights,
+                tools_top: [{ name: "Bash", runs: "five-thousand" }],
+            },
+        };
+        expect(() => decodeProfile(bad)).toThrow();
+    });
+
+    test("rejects tools_top row with non-string name", () => {
+        const bad = {
+            ...withSections,
+            insights: {
+                ...withSections.insights,
+                tools_top: [{ name: 42, runs: 100 }],
+            },
+        };
+        expect(() => decodeProfile(bad)).toThrow();
+    });
+
+    test("rejects activity daily row with missing tokens", () => {
+        const bad = {
+            ...withSections,
+            activity: {
+                daily: [{ date: "2026-06-09", sessions: 31 }],
+            },
+        };
+        expect(() => decodeProfile(bad)).toThrow();
+    });
+});

--- a/apps/axctl/src/profile/schema.ts
+++ b/apps/axctl/src/profile/schema.ts
@@ -98,6 +98,38 @@ const Rig = Schema.Struct({
     ),
 });
 
+const DailyRow = Schema.Struct({
+    date: Schema.String,
+    sessions: Schema.Number,
+    tokens: Schema.Number,
+});
+
+const BusiestDay = Schema.Struct({
+    date: Schema.String,
+    sessions: Schema.Number,
+});
+
+const ToolRun = Schema.Struct({
+    name: Schema.String,
+    runs: Schema.Number,
+});
+
+const Activity = Schema.Struct({
+    daily: Schema.Array(DailyRow),
+});
+
+const Insights = Schema.Struct({
+    hours_total: Schema.Number,
+    longest_session_minutes: Schema.Number,
+    deep_session_share: Schema.Number,
+    peak_hour_utc: Schema.Number,
+    busiest_day: BusiestDay,
+    max_parallel_sessions: Schema.Number,
+    subagents_spawned: Schema.Number,
+    commits: Schema.Number,
+    tools_top: Schema.Array(ToolRun),
+});
+
 export const ProfileV1 = Schema.Struct({
     v: Schema.Literal(1),
     github: Schema.String,
@@ -106,6 +138,8 @@ export const ProfileV1 = Schema.Struct({
     stats: Stats,
     rig: Rig,
     taste: Schema.optional(Schema.Struct({ patterns: Schema.Array(TastePattern) })),
+    activity: Schema.optional(Activity),
+    insights: Schema.optional(Insights),
 });
 export type ProfileV1 = typeof ProfileV1.Type;
 

--- a/apps/site/app/lib/community.test.ts
+++ b/apps/site/app/lib/community.test.ts
@@ -50,6 +50,81 @@ describe("validateProfileV1", () => {
     });
 });
 
+describe("validateProfileV1 - activity + insights sections", () => {
+    const profileWithSections = {
+        ...validProfile,
+        activity: {
+            daily: [
+                { date: "2026-06-09", sessions: 31, tokens: 800_000 },
+            ],
+        },
+        insights: {
+            hours_total: 307.2,
+            longest_session_minutes: 960,
+            deep_session_share: 0.58,
+            peak_hour_utc: 13,
+            busiest_day: { date: "2026-06-09", sessions: 31 },
+            max_parallel_sessions: 11,
+            subagents_spawned: 420,
+            commits: 1000,
+            tools_top: [
+                { name: "Bash", runs: 5000 },
+            ],
+        },
+    };
+
+    test("accepts profile with valid activity + insights", () => {
+        const p = validateProfileV1(profileWithSections);
+        expect(p.activity!.daily[0]!.sessions).toBe(31);
+        expect(p.insights!.peak_hour_utc).toBe(13);
+        expect(p.insights!.busiest_day.date).toBe("2026-06-09");
+        expect(p.insights!.tools_top[0]!.name).toBe("Bash");
+    });
+
+    test("rejects non-number in tools_top.runs", () => {
+        const bad = {
+            ...profileWithSections,
+            insights: {
+                ...profileWithSections.insights,
+                tools_top: [{ name: "Bash", runs: "five-thousand" }],
+            },
+        };
+        expect(() => validateProfileV1(bad)).toThrow();
+    });
+
+    test("rejects non-string in tools_top.name", () => {
+        const bad = {
+            ...profileWithSections,
+            insights: {
+                ...profileWithSections.insights,
+                tools_top: [{ name: 42, runs: 100 }],
+            },
+        };
+        expect(() => validateProfileV1(bad)).toThrow();
+    });
+
+    test("rejects non-number hours_total", () => {
+        const bad = {
+            ...profileWithSections,
+            insights: {
+                ...profileWithSections.insights,
+                hours_total: "307.2",
+            },
+        };
+        expect(() => validateProfileV1(bad)).toThrow();
+    });
+
+    test("rejects daily row with non-number sessions", () => {
+        const bad = {
+            ...profileWithSections,
+            activity: {
+                daily: [{ date: "2026-06-09", sessions: "31", tokens: 800_000 }],
+            },
+        };
+        expect(() => validateProfileV1(bad)).toThrow();
+    });
+});
+
 describe("validateRegistration", () => {
     test("accepts {github, gist_id, joined}; rejects junk", () => {
         expect(validateRegistration({ github: "a", gist_id: "f00", joined: "2026-06-12" }).gist_id).toBe("f00");

--- a/apps/site/app/lib/community.ts
+++ b/apps/site/app/lib/community.ts
@@ -43,6 +43,26 @@ export interface TastePattern {
     readonly context?: string;
     readonly evidence: { readonly sessions: number; readonly confidence: number; readonly last_reinforced?: string; readonly trend?: string };
 }
+export interface ProfileDailyRow {
+    readonly date: string;
+    readonly sessions: number;
+    readonly tokens: number;
+}
+export interface ProfileToolRun {
+    readonly name: string;
+    readonly runs: number;
+}
+export interface ProfileInsights {
+    readonly hours_total: number;
+    readonly longest_session_minutes: number;
+    readonly deep_session_share: number;
+    readonly peak_hour_utc: number;
+    readonly busiest_day: { readonly date: string; readonly sessions: number };
+    readonly max_parallel_sessions: number;
+    readonly subagents_spawned: number;
+    readonly commits: number;
+    readonly tools_top: readonly ProfileToolRun[];
+}
 export interface ProfileV1 {
     readonly v: 1;
     readonly github: string;
@@ -64,6 +84,8 @@ export interface ProfileV1 {
         readonly rules?: { readonly count: number };
     };
     readonly taste?: { readonly patterns: readonly TastePattern[] };
+    readonly activity?: { readonly daily: readonly ProfileDailyRow[] };
+    readonly insights?: ProfileInsights;
 }
 
 const optNum = (v: unknown, what: string): void => {
@@ -124,6 +146,37 @@ export function validateProfileV1(value: unknown): ProfileV1 {
             num(p.evidence.sessions, "evidence.sessions");
             num(p.evidence.confidence, "evidence.confidence");
             optStr(p.evidence.trend, "evidence.trend");
+        }
+    }
+    if (value.activity !== undefined) {
+        if (!isRecord(value.activity) || !Array.isArray(value.activity.daily)) {
+            throw new Error("invalid activity");
+        }
+        for (const d of value.activity.daily) {
+            if (!isRecord(d)) throw new Error("invalid activity.daily row");
+            str(d.date, "activity.daily.date");
+            num(d.sessions, "activity.daily.sessions");
+            num(d.tokens, "activity.daily.tokens");
+        }
+    }
+    if (value.insights !== undefined) {
+        const ins = value.insights;
+        if (!isRecord(ins)) throw new Error("invalid insights");
+        num(ins.hours_total, "insights.hours_total");
+        num(ins.longest_session_minutes, "insights.longest_session_minutes");
+        num(ins.deep_session_share, "insights.deep_session_share");
+        num(ins.peak_hour_utc, "insights.peak_hour_utc");
+        if (!isRecord(ins.busiest_day)) throw new Error("invalid insights.busiest_day");
+        str(ins.busiest_day.date, "insights.busiest_day.date");
+        num(ins.busiest_day.sessions, "insights.busiest_day.sessions");
+        num(ins.max_parallel_sessions, "insights.max_parallel_sessions");
+        num(ins.subagents_spawned, "insights.subagents_spawned");
+        num(ins.commits, "insights.commits");
+        if (!Array.isArray(ins.tools_top)) throw new Error("invalid insights.tools_top");
+        for (const t of ins.tools_top) {
+            if (!isRecord(t)) throw new Error("invalid tools_top row");
+            str(t.name, "tools_top.name");
+            num(t.runs, "tools_top.runs");
         }
     }
     return value as unknown as ProfileV1;

--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -1,9 +1,15 @@
 // apps/site/app/routes/u.$login.tsx
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { SiteHeader } from "~/components/landing-sections/site-header";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
-import { fetchProfile, type ProfileV1 } from "~/lib/community";
+import {
+    fetchProfile,
+    type ProfileV1,
+    type ProfileDailyRow,
+    type ProfileInsights,
+    type ProfileSkill,
+} from "~/lib/community";
 
 export const Route = createFileRoute("/u/$login")({
     head: ({ params }) => ({
@@ -54,89 +60,393 @@ function ProfilePage() {
         <>
             <SiteHeader />
             <main className="profile-page">
-                {state.kind === "loading" && <p className="muted">loading @{login}…</p>}
-                {state.kind === "not-found" && (
-                    <section>
-                        <h1>@{login} isn't on ax yet</h1>
-                        <p>Publish your own profile: <code>ax profile publish</code></p>
-                    </section>
-                )}
-                {state.kind === "error" && <p className="muted">couldn't load profile: {state.message}</p>}
-                {state.kind === "ready" && <ProfileCard profile={state.profile} />}
+                {state.kind === "loading" && <p className="pf-loading">pulling the dossier on @{login}…</p>}
+                {state.kind === "not-found" && <UnclaimedDossier login={login} />}
+                {state.kind === "error" && <p className="pf-loading">couldn't load profile: {state.message}</p>}
+                {state.kind === "ready" && <ProfileDossier profile={state.profile} />}
             </main>
             <SiteFooter />
         </>
     );
 }
 
-const fmt = (n: number): string => Intl.NumberFormat("en-US", { notation: "compact" }).format(n);
+/* ---------- formatting (one helper set, everything humanized) ---------- */
 
-function ProfileCard({ profile: p }: { profile: ProfileV1 }) {
+const COMPACT = new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 });
+const PLAIN = new Intl.NumberFormat("en-US");
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/** 19_600_000_000 -> "19.6B", 13185 -> "13.2K" */
+const fmtCompact = (n: number): string => COMPACT.format(n);
+/** 2021 -> "2,021" */
+const fmtInt = (n: number): string => PLAIN.format(Math.round(n));
+/** 22900 -> "$22.9K" */
+const fmtMoney = (n: number): string => `$${COMPACT.format(n)}`;
+/** 0.078 -> "7.8%" */
+const fmtPct = (share: number): string => {
+    const pct = Math.min(100, Math.max(0, share * 100));
+    return `${pct >= 10 ? Math.round(pct) : Math.round(pct * 10) / 10}%`;
+};
+/** 1440 -> "24h", 105 -> "1h 45m", 45 -> "45m" */
+const fmtDuration = (minutes: number): string => {
+    const m = Math.max(0, Math.round(minutes));
+    if (m < 60) return `${m}m`;
+    const h = Math.floor(m / 60);
+    const rem = m % 60;
+    return rem === 0 ? `${h}h` : `${h}h ${rem}m`;
+};
+/** 3 -> "03:00" */
+const fmtHour = (h: number): string => `${String(Math.min(23, Math.max(0, Math.round(h)))).padStart(2, "0")}:00`;
+/** "2026-06-10" -> "Jun 10"; anything else falls back to the raw string (safe: text node). */
+const fmtDay = (iso: string): string => {
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+    if (!m) return iso;
+    const month = MONTHS[Number(m[2]) - 1];
+    return month ? `${month} ${Number(m[3])}` : iso;
+};
+const clampPct = (x: number): number => (Number.isFinite(x) ? Math.min(100, Math.max(0, x)) : 0);
+
+/* ---------- the dossier ---------- */
+
+function ProfileDossier({ profile: p }: { profile: ProfileV1 }) {
+    const daily = p.activity && p.activity.daily.length > 0
+        ? [...p.activity.daily].sort((a, b) => (a.date < b.date ? -1 : 1))
+        : [];
+    const ins = p.insights;
+    const models = [...p.stats.models].sort((a, b) => b.share - a.share);
+    const tools = ins && ins.tools_top.length > 0 ? ins.tools_top.slice(0, 10) : [];
+    let section = 0;
+    const nextSection = (): string => String(++section).padStart(2, "0");
+
     return (
-        <article>
-            <header>
-                <h1>@{p.github}</h1>
-                <p className="muted">last {p.window_days} days · updated {p.generated_at.slice(0, 10)} · powered by <Link to="/">ax</Link></p>
+        <article className="pf-dossier">
+            {/* nameplate */}
+            <header className="pf-mast">
+                <div className="pf-mast-kicker">
+                    <span>agent telemetry dossier</span>
+                    <span>{p.window_days}-day window · compiled {p.generated_at.slice(0, 10)}</span>
+                </div>
+                <h1 className="pf-name"><span className="pf-at">@</span>{p.github}</h1>
+                <div className="pf-mast-sub">
+                    <span className="pf-harness-list">
+                        {p.stats.harnesses.map((h) => <span className="pf-harness" key={h}>{h}</span>)}
+                    </span>
+                    <span className="pf-mast-via">compiled from local transcripts by <Link to="/">ax</Link></span>
+                </div>
             </header>
 
-            <section className="stat-row">
-                <Stat label="sessions" value={fmt(p.stats.sessions)} />
-                <Stat label="tokens" value={fmt(p.stats.tokens.total)} />
-                {p.stats.cost_usd !== undefined && <Stat label="est. spend" value={`$${p.stats.cost_usd.toFixed(0)}`} />}
-                <Stat label="streak" value={`${p.stats.streak_days}d`} />
-                <Stat label="active days" value={String(p.stats.active_days)} />
+            {/* vitals ledger */}
+            <section className="pf-ledger" aria-label="vitals">
+                <Vital num={fmtInt(p.stats.sessions)} label="sessions" />
+                <Vital num={fmtCompact(p.stats.tokens.total)} label="tokens" />
+                {p.stats.cost_usd !== undefined && <Vital num={`~${fmtMoney(p.stats.cost_usd)}`} label="est. spend" />}
+                {ins && <Vital num={fmtCompact(ins.hours_total)} unit="hrs" label="in the loop" />}
+                <Vital num={`${fmtInt(p.stats.active_days)}/${fmtInt(p.window_days)}`} label="days active" />
+                <Vital num={`${fmtInt(p.stats.streak_days)}d`} label="streak" />
             </section>
 
-            <section>
-                <h2>models</h2>
-                {p.stats.models.map((m, i) => (
-                    <div className="bar-row" key={`${m.name}-${i}`}>
-                        <span className="bar-label">{m.name}</span>
-                        <span className="bar-track"><span className="bar-fill" style={{ width: `${Math.min(100, Math.max(0, m.share * 100))}%` }} /></span>
-                        <span className="bar-value">{(m.share * 100).toFixed(0)}%{m.cost_usd !== undefined ? ` · $${m.cost_usd.toFixed(0)}` : ""}</span>
-                    </div>
-                ))}
-                <p className="muted">harnesses: {p.stats.harnesses.join(", ")}</p>
-            </section>
-
-            <section>
-                <h2>rig</h2>
-                <p className="muted">
-                    {p.rig.skills.length} skills · {p.rig.hooks.length} hooks · routing table: {p.rig.routing_table ? "yes" : "no"}
-                    {p.rig.rules ? ` · ${p.rig.rules.count} rules` : ""}
-                </p>
-                <ul>
-                    {p.rig.skills.slice(0, 15).map((s) => (
-                        <li key={`${s.source}:${s.name}`}>
-                            {s.name} <span className="muted">({s.source}, {fmt(s.runs)} runs)</span>
-                        </li>
-                    ))}
-                </ul>
-            </section>
-
-            {p.taste && p.taste.patterns.length > 0 && (
-                <section>
-                    <h2>taste</h2>
-                    <ul>
-                        {p.taste.patterns.map((t) => (
-                            <li key={`${t.category}/${t.name}`}>
-                                <strong>{t.category === "stack-choice" && t.slot ? `${t.slot}: ${t.name}` : t.name}</strong>
-                                {t.summary ? <> - {t.summary}</> : null}
-                                <span className="muted"> (confidence {t.evidence.confidence}, {t.evidence.sessions} sessions{t.evidence.trend ? `, ${t.evidence.trend}` : ""})</span>
-                            </li>
+            {/* the window: activity timeline + model split, one story */}
+            <section className="pf-section">
+                <Kicker n={nextSection()} title="The window" note={`last ${p.window_days} days`} />
+                <div className={daily.length > 0 ? "pf-window" : "pf-window pf-window--solo"}>
+                    {daily.length > 0 && <ActivityTimeline daily={daily} busiest={ins?.busiest_day.date} />}
+                    <div className="pf-models">
+                        <div className="pf-models-head">
+                            model split · {fmtInt(p.stats.sessions)} sessions over {p.window_days} days
+                        </div>
+                        {models.map((m, i) => (
+                            <div className="pf-model" key={`${m.name}-${i}`}>
+                                <div className="pf-model-top">
+                                    <span className="pf-model-name">{m.name}</span>
+                                    <span className="pf-model-meta">
+                                        <strong>{fmtPct(m.share)}</strong>
+                                        {m.cost_usd !== undefined ? ` · ~${fmtMoney(m.cost_usd)}` : ""}
+                                    </span>
+                                </div>
+                                <span className="pf-model-track">
+                                    <span
+                                        className={i === 0 ? "pf-model-fill pf-model-fill--lead" : "pf-model-fill"}
+                                        style={{ width: `${clampPct(m.share * 100)}%` }}
+                                    />
+                                </span>
+                            </div>
                         ))}
-                    </ul>
+                        {models.length === 0 && <p className="pf-quiet">no model data in this window.</p>}
+                    </div>
+                </div>
+            </section>
+
+            {/* wrapped-style insight cards */}
+            {ins && (
+                <section className="pf-section">
+                    <Kicker n={nextSection()} title="The shape of the work" note="derived from session telemetry" />
+                    <div className="pf-cards">
+                        {buildInsightCards(ins).map((c) => (
+                            <div className="pf-card" key={c.q}>
+                                <span className="pf-card-q">{c.q}</span>
+                                <span className="pf-card-a">{c.a}</span>
+                                <span className="pf-card-s">{c.s}</span>
+                            </div>
+                        ))}
+                    </div>
                 </section>
             )}
+
+            {/* tool taste */}
+            {tools.length > 0 && (
+                <section className="pf-section">
+                    <Kicker n={nextSection()} title="Tool taste" note="what the hands actually reach for" />
+                    <div className="pf-tools">
+                        {tools.map((t, i) => {
+                            const max = tools[0]?.runs ?? 0;
+                            const w = max > 0 ? clampPct((t.runs / max) * 100) : 0;
+                            return (
+                                <div className="pf-tool" key={`${t.name}-${i}`}>
+                                    <span className="pf-tool-rank">{String(i + 1).padStart(2, "0")}</span>
+                                    <span className="pf-tool-name">{t.name}</span>
+                                    <span className="pf-tool-track" aria-hidden="true">
+                                        <span
+                                            className={i === 0 ? "pf-tool-bar pf-tool-bar--lead" : "pf-tool-bar"}
+                                            style={{ width: `${w}%` }}
+                                        />
+                                    </span>
+                                    <span className="pf-tool-runs">{fmtCompact(t.runs)}</span>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </section>
+            )}
+
+            {/* the rig: skills grouped by source + guardrails */}
+            <section className="pf-section">
+                <Kicker n={nextSection()} title="The rig" note={`${fmtInt(p.rig.skills.length)} skills · ${fmtInt(p.rig.hooks.length)} hooks`} />
+                <div className="pf-rig">
+                    <div className="pf-rig-skills">
+                        {groupSkills(p.rig.skills).map((g) => (
+                            <div className="pf-rig-group" key={g.source}>
+                                <div className="pf-rig-group-head">
+                                    <span>{g.source}</span>
+                                    <span>{fmtInt(g.skills.length)} skills · {fmtCompact(g.runs)} runs</span>
+                                </div>
+                                {g.skills.slice(0, 10).map((s) => (
+                                    <div className="pf-skill" key={s.name}>
+                                        <span className="pf-skill-name">{s.name}</span>
+                                        <span className="pf-skill-runs">{fmtCompact(s.runs)} runs</span>
+                                    </div>
+                                ))}
+                                {g.skills.length > 10 && (
+                                    <div className="pf-rig-more">+ {fmtInt(g.skills.length - 10)} more</div>
+                                )}
+                            </div>
+                        ))}
+                        {p.rig.skills.length === 0 && <p className="pf-quiet">no skills recorded in this window.</p>}
+                    </div>
+                    <aside className="pf-guardrails">
+                        <h3>Guardrails</h3>
+                        <p>The deterministic half of the rig - what fires on every tool call, before taste gets a vote.</p>
+                        <div className="pf-guard-row">
+                            <span>hooks</span>
+                            <span className={p.rig.hooks.length > 0 ? "pf-guard-on" : "pf-guard-off"}>
+                                {p.rig.hooks.length > 0 ? `${fmtInt(p.rig.hooks.length)} installed` : "none"}
+                            </span>
+                        </div>
+                        {p.rig.hooks.length > 0 && (
+                            <div className="pf-hook-list">
+                                {p.rig.hooks.map((h) => <span className="pf-hook" key={h}>{h}</span>)}
+                            </div>
+                        )}
+                        <div className="pf-guard-row">
+                            <span>routing table</span>
+                            <span className={p.rig.routing_table ? "pf-guard-on" : "pf-guard-off"}>
+                                {p.rig.routing_table ? "compiled" : "not compiled"}
+                            </span>
+                        </div>
+                        <div className="pf-guard-row">
+                            <span>rules</span>
+                            <span className={p.rig.rules && p.rig.rules.count > 0 ? "pf-guard-on" : "pf-guard-off"}>
+                                {p.rig.rules ? fmtInt(p.rig.rules.count) : "-"}
+                            </span>
+                        </div>
+                    </aside>
+                </div>
+            </section>
+
+            {/* taste patterns */}
+            {p.taste && p.taste.patterns.length > 0 && (
+                <section className="pf-section">
+                    <Kicker n={nextSection()} title="Taste" note="patterns ax keeps seeing" />
+                    <div className="pf-taste">
+                        {p.taste.patterns.map((t) => (
+                            <div className="pf-pattern" key={`${t.category}/${t.name}`}>
+                                <span className="pf-pattern-cat">{t.category}{t.slot ? ` · ${t.slot}` : ""}</span>
+                                <div className="pf-pattern-name">{t.name}</div>
+                                {t.summary && <p className="pf-pattern-sum">{t.summary}</p>}
+                                <div className="pf-pattern-ev">
+                                    {fmtInt(t.evidence.sessions)} sessions · confidence {fmtPct(t.evidence.confidence)}
+                                    {t.evidence.trend ? ` · ${t.evidence.trend}` : ""}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+            )}
+
+            {/* colophon */}
+            <footer className="pf-colophon">
+                <span>compiled by ax from local agent transcripts · nothing leaves the machine unreviewed</span>
+                <span>publish yours → <code>ax profile publish</code></span>
+            </footer>
         </article>
     );
 }
 
-function Stat({ label, value }: { label: string; value: string }) {
+/* ---------- pieces ---------- */
+
+function Vital({ num, unit, label }: { num: string; unit?: string; label: string }) {
     return (
-        <div className="stat">
-            <div className="stat-value">{value}</div>
-            <div className="stat-label muted">{label}</div>
+        <div className="pf-vital">
+            <span className="pf-vital-num">{num}{unit ? <small> {unit}</small> : null}</span>
+            <span className="pf-vital-label">{label}</span>
         </div>
+    );
+}
+
+function Kicker({ n, title, note }: { n: string; title: string; note?: string }) {
+    return (
+        <div className="pf-kicker">
+            <span className="pf-kicker-n">{n}</span>
+            <h2>{title}</h2>
+            <span className="pf-kicker-rule" aria-hidden="true" />
+            {note && <span className="pf-kicker-note">{note}</span>}
+        </div>
+    );
+}
+
+function ActivityTimeline({ daily, busiest }: { daily: readonly ProfileDailyRow[]; busiest?: string }) {
+    const maxSessions = daily.reduce((m, d) => Math.max(m, d.sessions), 0);
+    const maxTokens = daily.reduce((m, d) => Math.max(m, d.tokens), 0);
+    const totalSessions = daily.reduce((s, d) => s + d.sessions, 0);
+    const avg = daily.length > 0 ? totalSessions / daily.length : 0;
+    const first = daily[0];
+    const last = daily[daily.length - 1];
+    return (
+        <div className="pf-activity">
+            <div
+                className="pf-chart"
+                role="img"
+                aria-label={`daily sessions over ${daily.length} days, peaking at ${fmtInt(maxSessions)}`}
+            >
+                {daily.map((d) => {
+                    const h = maxSessions > 0 ? clampPct((d.sessions / maxSessions) * 100) : 0;
+                    const q = maxTokens > 0 ? Math.min(4, Math.max(1, Math.ceil((d.tokens / maxTokens) * 4))) : 1;
+                    const peak = busiest !== undefined && d.date === busiest;
+                    return (
+                        <span
+                            className="pf-chart-day"
+                            key={d.date}
+                            title={`${d.date} · ${fmtInt(d.sessions)} sessions · ${fmtCompact(d.tokens)} tokens`}
+                        >
+                            <span
+                                className={`pf-chart-fill pf-q${q}${peak ? " is-peak" : ""}`}
+                                style={{ height: `${Math.max(h, d.sessions > 0 ? 3 : 0)}%` }}
+                            />
+                        </span>
+                    );
+                })}
+            </div>
+            <div className="pf-chart-axis">
+                <span>{first ? fmtDay(first.date) : ""}</span>
+                <span className="pf-chart-axis-mid">~{fmtInt(avg)} sessions/day · darker = heavier token days{busiest !== undefined ? " · peak in red" : ""}</span>
+                <span>{last ? fmtDay(last.date) : ""}</span>
+            </div>
+        </div>
+    );
+}
+
+interface InsightCard { readonly q: string; readonly a: ReactNode; readonly s: string }
+
+function buildInsightCards(ins: ProfileInsights): InsightCard[] {
+    return [
+        {
+            q: "How deep do you go?",
+            a: fmtPct(ins.deep_session_share),
+            s: "of sessions ran 90+ minutes - deliberate, not drive-by",
+        },
+        {
+            q: "How many agents at once?",
+            a: fmtInt(ins.max_parallel_sessions),
+            s: "sessions running in parallel at peak",
+        },
+        {
+            q: "Longest single run?",
+            a: fmtDuration(ins.longest_session_minutes),
+            s: "one session, end to end, without letting go",
+        },
+        {
+            q: "When are you most alive?",
+            a: <>{fmtHour(ins.peak_hour_utc)}<small> UTC</small></>,
+            s: "the hour the graph lights up",
+        },
+        {
+            q: "Busiest day?",
+            a: fmtDay(ins.busiest_day.date),
+            s: `${fmtInt(ins.busiest_day.sessions)} sessions in a single day`,
+        },
+        {
+            q: "How many hands?",
+            a: fmtCompact(ins.subagents_spawned),
+            s: "subagents dispatched to do the legwork",
+        },
+        {
+            q: "What actually shipped?",
+            a: fmtCompact(ins.commits),
+            s: "commits landed across the window",
+        },
+        {
+            q: "Time in the loop?",
+            a: <>{fmtCompact(ins.hours_total)}<small> hrs</small></>,
+            s: "of recorded agent time on the clock",
+        },
+    ];
+}
+
+interface SkillGroup { readonly source: string; readonly skills: ProfileSkill[]; readonly runs: number }
+
+function groupSkills(skills: readonly ProfileSkill[]): SkillGroup[] {
+    const by = new Map<string, ProfileSkill[]>();
+    for (const s of skills) {
+        const list = by.get(s.source);
+        if (list) list.push(s);
+        else by.set(s.source, [s]);
+    }
+    return [...by.entries()]
+        .map(([source, list]) => ({
+            source,
+            skills: [...list].sort((a, b) => b.runs - a.runs),
+            runs: list.reduce((sum, s) => sum + s.runs, 0),
+        }))
+        .sort((a, b) => b.runs - a.runs);
+}
+
+/* ---------- not-found doubles as the join CTA ---------- */
+
+function UnclaimedDossier({ login }: { login: string }) {
+    return (
+        <section className="pf-empty">
+            <span className="pf-empty-stamp" aria-hidden="true">unclaimed</span>
+            <h1>No dossier on file for @{login}.</h1>
+            <p>
+                ax compiles a public profile from your local agent telemetry - sessions,
+                tokens, model split, the rig you've built, the patterns in how you work.
+                One command. Your transcripts never leave your machine; only the
+                aggregate ships, to a gist you own.
+            </p>
+            <code className="pf-empty-cmd">ax profile publish</code>
+            <p>
+                New to ax? <Link to="/">Start here</Link> - install takes 30 seconds,
+                the first ingest does the rest.
+            </p>
+        </section>
     );
 }

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -9461,22 +9461,492 @@ footer .right {
 .prose pre::-webkit-scrollbar { height: 6px; }
 .prose pre::-webkit-scrollbar-thumb { background: #3a3a3a; border-radius: 3px; }
 
-/* --- profile + leaders pages --- */
+/* ============================================================
+   profile dossier (/u/$login) + leaders page
+   - profile is a typeset "telemetry dossier": serif nameplate,
+     mono numerals, hairline rules, paper/ink. No SaaS chrome.
+   ============================================================ */
+
 .profile-page, .leaders-page {
     max-width: var(--shell-max);
     margin: 0 auto;
-    padding: 32px var(--shell-pad) 64px;
+    padding: 32px var(--shell-pad) 96px;
 }
-.stat-row { display: flex; gap: 28px; flex-wrap: wrap; margin: 20px 0; }
-.stat-value { font-size: 1.6rem; font-family: var(--mono); }
-.bar-row { display: flex; align-items: center; gap: 10px; margin: 4px 0; font-family: var(--mono); font-size: 0.85rem; }
-.bar-label { width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.bar-track { flex: 1; height: 8px; background: var(--line); border-radius: 4px; overflow: hidden; }
-.bar-fill { display: block; height: 100%; background: var(--green); }
-.bar-value { width: 110px; text-align: right; }
+@media (max-width: 640px) {
+    .profile-page, .leaders-page { padding-left: 20px; padding-right: 20px; }
+}
+
+/* ----- leaders (unchanged behavior, /leaders depends on these) ----- */
 .leaders-tabs { display: flex; gap: 8px; margin: 16px 0; flex-wrap: wrap; }
 .leaders-tabs button { font: inherit; padding: 6px 14px; border: 1px solid var(--line); background: var(--panel); cursor: pointer; border-radius: 6px; }
 .leaders-tabs button[aria-selected="true"] { background: var(--ink); color: var(--page); }
 .leaders-table { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 0.9rem; }
 .leaders-table td, .leaders-table th { padding: 8px 10px; border-bottom: 1px solid var(--line); text-align: left; }
 .leaders-table td:last-child, .leaders-table th:last-child { text-align: right; }
+
+/* ----- states ----- */
+.pf-loading {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--muted);
+    padding: 96px 0;
+}
+.pf-quiet { font-size: 13.5px; color: var(--muted); margin: 8px 0; }
+
+/* ----- nameplate ----- */
+.pf-mast { padding-top: 40px; }
+.pf-mast-kicker {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px 24px;
+    flex-wrap: wrap;
+    font-family: var(--mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--muted);
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--line);
+}
+.pf-name {
+    font-family: var(--serif);
+    font-size: clamp(46px, 7.5vw, 76px);
+    font-weight: 400;
+    letter-spacing: -2px;
+    line-height: 1.02;
+    margin: 26px 0 14px;
+    overflow-wrap: anywhere;
+}
+.pf-name .pf-at {
+    color: var(--muted);
+    font-size: 0.58em;
+    vertical-align: 0.22em;
+    letter-spacing: 0;
+    margin-right: 2px;
+}
+.pf-mast-sub {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 10px 24px;
+    flex-wrap: wrap;
+    padding-bottom: 22px;
+    border-bottom: 3px double var(--ink);
+}
+.pf-harness-list { display: inline-flex; flex-wrap: wrap; gap: 6px; }
+.pf-harness {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    padding: 3px 9px;
+}
+.pf-mast-via { font-family: var(--mono); font-size: 12px; color: var(--muted); }
+.pf-mast-via a { color: var(--ink); text-decoration-color: var(--green); text-underline-offset: 3px; }
+
+/* ----- vitals ledger ----- */
+.pf-ledger {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(148px, 1fr));
+    border-bottom: 1px solid var(--line);
+}
+.pf-vital {
+    padding: 20px 18px 16px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    min-width: 0;
+}
+.pf-vital + .pf-vital { padding-left: 18px; border-left: 1px solid var(--line); }
+.pf-vital-num {
+    font-family: var(--mono);
+    font-size: 29px;
+    line-height: 1.05;
+    letter-spacing: -0.5px;
+    white-space: nowrap;
+}
+.pf-vital-num small {
+    font-size: 14px;
+    color: var(--muted);
+    letter-spacing: 0;
+}
+.pf-vital-label {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.13em;
+    color: var(--muted);
+}
+@media (max-width: 720px) {
+    .pf-ledger { grid-template-columns: repeat(2, 1fr); }
+    .pf-vital { border-top: 1px solid var(--line); }
+    .pf-vital:nth-child(odd) { padding-left: 0; border-left: none; }
+    .pf-vital:nth-child(-n+2) { border-top: none; }
+    .pf-vital-num { font-size: 25px; }
+}
+
+/* ----- section kicker ----- */
+.pf-section { margin-top: 60px; }
+.pf-kicker {
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+    margin-bottom: 24px;
+}
+.pf-kicker-n {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--green);
+    letter-spacing: 0.1em;
+}
+.pf-kicker h2 {
+    font-family: var(--serif);
+    font-size: 27px;
+    font-weight: 400;
+    letter-spacing: -0.5px;
+    line-height: 1.1;
+    margin: 0;
+    white-space: nowrap;
+}
+.pf-kicker-rule { flex: 1; border-top: 1px solid var(--line); transform: translateY(-5px); min-width: 24px; }
+.pf-kicker-note {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted);
+    text-align: right;
+}
+@media (max-width: 560px) {
+    .pf-kicker { flex-wrap: wrap; }
+    .pf-kicker h2 { white-space: normal; }
+    .pf-kicker-note { width: 100%; text-align: left; }
+    .pf-kicker-rule { display: none; }
+}
+
+/* ----- 01 the window: timeline + models ----- */
+.pf-window {
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    gap: 44px;
+    align-items: start;
+}
+.pf-window--solo { grid-template-columns: minmax(0, 1fr); max-width: 640px; }
+@media (max-width: 880px) {
+    .pf-window { grid-template-columns: minmax(0, 1fr); gap: 36px; }
+}
+
+.pf-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 132px;
+    border-bottom: 2px solid var(--ink);
+}
+.pf-chart-day {
+    flex: 1 1 0;
+    min-width: 0;
+    height: 100%;
+    display: flex;
+    align-items: flex-end;
+}
+.pf-chart-fill { width: 100%; display: block; }
+.pf-chart-fill.pf-q1 { background: color-mix(in srgb, var(--green) 28%, var(--page)); }
+.pf-chart-fill.pf-q2 { background: color-mix(in srgb, var(--green) 52%, var(--page)); }
+.pf-chart-fill.pf-q3 { background: color-mix(in srgb, var(--green) 78%, var(--page)); }
+.pf-chart-fill.pf-q4 { background: var(--green); }
+.pf-chart-fill.is-peak { background: var(--red); }
+.pf-chart-day:hover .pf-chart-fill { background: var(--ink); }
+.pf-chart-axis {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+    padding-top: 9px;
+}
+.pf-chart-axis-mid { text-align: center; }
+@media (max-width: 560px) {
+    .pf-chart { gap: 2px; height: 96px; }
+    .pf-chart-axis-mid { display: none; }
+}
+
+.pf-models { min-width: 0; }
+.pf-models-head {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.13em;
+    color: var(--muted);
+    padding-bottom: 9px;
+    margin-bottom: 16px;
+    border-bottom: 1px solid var(--line);
+}
+.pf-model { margin-bottom: 15px; }
+.pf-model-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 14px;
+    font-family: var(--mono);
+    font-size: 13px;
+}
+.pf-model-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.pf-model-meta { color: var(--muted); white-space: nowrap; font-size: 12px; }
+.pf-model-meta strong { color: var(--ink); font-weight: 600; font-size: 13px; }
+.pf-model-track {
+    display: block;
+    height: 6px;
+    background: color-mix(in srgb, var(--line) 55%, var(--page));
+    margin-top: 6px;
+}
+.pf-model-fill { display: block; height: 100%; background: var(--ink); }
+.pf-model-fill--lead { background: var(--green); }
+
+/* ----- 02 insight cards (wrapped-style) ----- */
+.pf-cards {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px;
+    background: var(--line);
+    border: 1px solid var(--line);
+}
+.pf-card {
+    background: var(--panel);
+    padding: 18px 20px 20px;
+    min-height: 158px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+}
+.pf-card-q {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.13em;
+    color: var(--green);
+    line-height: 1.45;
+}
+.pf-card-a {
+    font-family: var(--serif);
+    font-size: 36px;
+    letter-spacing: -1px;
+    line-height: 1.02;
+    margin-top: auto;
+    overflow-wrap: anywhere;
+}
+.pf-card-a small {
+    font-size: 0.42em;
+    font-family: var(--mono);
+    letter-spacing: 0.04em;
+    color: var(--muted);
+}
+.pf-card-s { font-size: 12.5px; line-height: 1.45; color: var(--muted); }
+@media (max-width: 980px) { .pf-cards { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 460px) {
+    .pf-cards { grid-template-columns: minmax(0, 1fr); }
+    .pf-card { min-height: 0; }
+    .pf-card-a { font-size: 32px; }
+}
+
+/* ----- 03 tool taste ----- */
+.pf-tools { max-width: 760px; }
+.pf-tool {
+    display: grid;
+    grid-template-columns: 26px minmax(96px, 168px) minmax(0, 1fr) 64px;
+    gap: 14px;
+    align-items: center;
+    font-family: var(--mono);
+    font-size: 13px;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--line);
+}
+.pf-tool-rank { color: var(--muted); font-size: 11px; }
+.pf-tool-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pf-tool-track { display: block; min-width: 0; }
+.pf-tool-bar { display: block; height: 9px; background: var(--ink); }
+.pf-tool-bar--lead { background: var(--green); }
+.pf-tool-runs { text-align: right; color: var(--muted); font-size: 12px; }
+@media (max-width: 560px) {
+    .pf-tool { grid-template-columns: 22px minmax(72px, 110px) minmax(0, 1fr) 52px; gap: 10px; font-size: 12px; }
+}
+
+/* ----- 04 the rig ----- */
+.pf-rig {
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    gap: 44px;
+    align-items: start;
+}
+@media (max-width: 880px) { .pf-rig { grid-template-columns: minmax(0, 1fr); gap: 32px; } }
+.pf-rig-group { margin-bottom: 28px; }
+.pf-rig-group:last-child { margin-bottom: 0; }
+.pf-rig-group-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 14px;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.13em;
+    color: var(--muted);
+    border-bottom: 1px solid var(--ink);
+    padding-bottom: 6px;
+    margin-bottom: 4px;
+}
+.pf-rig-group-head span:first-child { color: var(--ink); }
+.pf-skill {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 16px;
+    padding: 6px 0;
+    border-bottom: 1px solid var(--line);
+    font-family: var(--mono);
+    font-size: 13px;
+}
+.pf-skill-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.pf-skill-runs { color: var(--muted); font-size: 11.5px; white-space: nowrap; }
+.pf-rig-more {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+    padding-top: 7px;
+}
+.pf-guardrails {
+    border: 1px solid var(--ink);
+    background: var(--panel);
+    padding: 22px 22px 18px;
+    box-shadow: 4px 4px 0 color-mix(in srgb, var(--ink) 8%, transparent);
+}
+.pf-guardrails h3 {
+    font-family: var(--serif);
+    font-size: 20px;
+    font-weight: 400;
+    letter-spacing: -0.3px;
+    margin: 0 0 6px;
+}
+.pf-guardrails > p { font-size: 13px; line-height: 1.5; color: var(--muted); margin: 0 0 14px; }
+.pf-guard-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 14px;
+    font-family: var(--mono);
+    font-size: 12.5px;
+    padding: 9px 0;
+    border-top: 1px solid var(--line);
+}
+.pf-guard-on { color: var(--green); }
+.pf-guard-off { color: var(--muted); }
+.pf-hook-list { display: flex; flex-wrap: wrap; gap: 6px; padding-bottom: 10px; }
+.pf-hook {
+    font-family: var(--mono);
+    font-size: 11px;
+    border: 1px solid var(--line);
+    background: var(--page);
+    padding: 2px 8px;
+    overflow-wrap: anywhere;
+}
+
+/* ----- 05 taste patterns ----- */
+.pf-taste {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0 52px;
+}
+@media (max-width: 760px) { .pf-taste { grid-template-columns: minmax(0, 1fr); } }
+.pf-pattern { padding: 16px 0; border-bottom: 1px solid var(--line); }
+.pf-pattern-cat {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.13em;
+    color: var(--green);
+}
+.pf-pattern-name {
+    font-family: var(--serif);
+    font-size: 19px;
+    letter-spacing: -0.3px;
+    line-height: 1.2;
+    margin: 3px 0 2px;
+}
+.pf-pattern-sum { font-size: 13.5px; line-height: 1.5; margin: 2px 0 4px; }
+.pf-pattern-ev { font-family: var(--mono); font-size: 11px; color: var(--muted); }
+
+/* ----- colophon ----- */
+.pf-colophon {
+    margin-top: 72px;
+    border-top: 2px solid var(--ink);
+    padding-top: 14px;
+    display: flex;
+    justify-content: space-between;
+    gap: 10px 28px;
+    flex-wrap: wrap;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--muted);
+}
+.pf-colophon code {
+    font-family: var(--mono);
+    background: var(--panel);
+    border: 1px solid var(--line);
+    color: var(--ink);
+    padding: 2px 8px;
+}
+
+/* ----- not-found / join CTA ----- */
+.pf-empty {
+    max-width: 560px;
+    margin: 72px auto 48px;
+    border: 1px solid var(--ink);
+    background: var(--panel);
+    padding: 38px 38px 28px;
+    position: relative;
+    box-shadow: 5px 5px 0 color-mix(in srgb, var(--ink) 8%, transparent);
+}
+.pf-empty-stamp {
+    position: absolute;
+    top: 20px;
+    right: 22px;
+    font-family: var(--mono);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--red);
+    border: 1.5px solid var(--red);
+    padding: 4px 9px 3px;
+    transform: rotate(5deg);
+    opacity: 0.85;
+}
+.pf-empty h1 {
+    font-family: var(--serif);
+    font-size: 31px;
+    font-weight: 400;
+    letter-spacing: -0.5px;
+    line-height: 1.15;
+    margin: 0 0 14px;
+    padding-right: 96px;
+    overflow-wrap: anywhere;
+}
+.pf-empty p { font-size: 14.5px; line-height: 1.55; color: var(--muted); margin: 0 0 12px; }
+.pf-empty p a { color: var(--ink); text-decoration-color: var(--green); text-underline-offset: 3px; }
+.pf-empty-cmd {
+    display: block;
+    font-family: var(--mono);
+    font-size: 14px;
+    background: var(--ink);
+    color: var(--page);
+    padding: 13px 16px;
+    margin: 20px 0 18px;
+}
+.pf-empty-cmd::before { content: "$ "; color: var(--green); }
+@media (max-width: 560px) {
+    .pf-empty { padding: 28px 22px 20px; margin-top: 48px; }
+    .pf-empty h1 { padding-right: 0; font-size: 27px; margin-top: 28px; }
+}

--- a/docs/superpowers/plans/2026-06-12-profile-activity-insights.md
+++ b/docs/superpowers/plans/2026-06-12-profile-activity-insights.md
@@ -1,0 +1,1372 @@
+# Profile Activity + Insights Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend ProfileV1 with optional `activity` (daily sessions+tokens) and `insights` (session depth, parallelism, spawns, commits, top tools) sections, wired from new windowed SurrealDB queries through pure derivers to the CLI formatter and site validator.
+
+**Architecture:** Each piece is independently tested - new SurrealDB queries mirror existing ones in `profile/queries.ts`, pure interval math lives in a new `profile/insights.ts`, `buildProfile` in `render.ts` appends the new query calls at the end (preserving mock order for existing tests), and the site validator's manual type-check is extended inline. The `activity` section reuses query data already needed by `insights`. TDD throughout: write the failing test, then the implementation.
+
+**Tech Stack:** Bun ≥1.3, TypeScript strict, Effect v4 beta, SurrealDB 3.x (no stacked in/out derefs in grouped aggregates), `@ax/lib/testing/surreal` mock helpers.
+
+---
+
+## File Map
+
+| File | Status | Responsibility |
+|---|---|---|
+| `apps/axctl/src/profile/schema.ts` | Modify | Add `activity` + `insights` optional sections to ProfileV1 |
+| `apps/axctl/src/profile/schema.test.ts` | Modify | Tests for new sections decode/reject correctly |
+| `apps/axctl/src/profile/queries.ts` | Modify | Add 6 new windowed fetchers |
+| `apps/axctl/src/profile/queries.test.ts` | Modify | Tests for each new fetcher |
+| `apps/axctl/src/profile/insights.ts` | **Create** | Pure `deriveInsights()` + `deriveDailyFull()` functions |
+| `apps/axctl/src/profile/insights.test.ts` | **Create** | Unit tests for all pure math |
+| `apps/axctl/src/profile/render.ts` | Modify | Append new query calls + wire insights into decodeProfile |
+| `apps/axctl/src/profile/render.test.ts` | Modify | Extend mockResults (8 new slots) + assert new fields |
+| `apps/axctl/src/cli/commands/profile.ts` | Modify | `money()` helper + insights block in `formatProfile` |
+| `apps/site/app/lib/community.ts` | Modify | Extend ProfileV1 interface + validateProfileV1 for new sections |
+| `apps/site/app/lib/community.test.ts` | Modify | Accept+reject tests for new sections |
+
+---
+
+## Task 1: Schema - add activity + insights to ProfileV1
+
+**Files:**
+- Modify: `apps/axctl/src/profile/schema.ts`
+- Modify: `apps/axctl/src/profile/schema.test.ts`
+
+### Step 1.1 - Write failing schema tests
+
+- [ ] Open `apps/axctl/src/profile/schema.test.ts` and add these tests **after** the existing `describe` block (do not alter existing tests):
+
+```typescript
+describe("activity + insights sections", () => {
+    const withSections = {
+        ...validProfile,
+        activity: {
+            daily: [
+                { date: "2026-06-09", sessions: 31, tokens: 800_000 },
+                { date: "2026-06-12", sessions: 12, tokens: 120_000_000 },
+            ],
+        },
+        insights: {
+            hours_total: 307.2,
+            longest_session_minutes: 960,
+            deep_session_share: 0.58,
+            peak_hour_utc: 13,
+            busiest_day: { date: "2026-06-09", sessions: 31 },
+            max_parallel_sessions: 11,
+            subagents_spawned: 420,
+            commits: 1000,
+            tools_top: [
+                { name: "Bash", runs: 5000 },
+                { name: "Read", runs: 3200 },
+            ],
+        },
+    };
+
+    test("accepts valid profile with both sections", () => {
+        const p = decodeProfile(withSections);
+        expect(p.activity!.daily).toHaveLength(2);
+        expect(p.activity!.daily[0]!.sessions).toBe(31);
+        expect(p.insights!.hours_total).toBe(307.2);
+        expect(p.insights!.busiest_day.date).toBe("2026-06-09");
+        expect(p.insights!.tools_top[0]!.name).toBe("Bash");
+    });
+
+    test("activity section is optional - omit it and profile still decodes", () => {
+        const { activity: _a, ...rest } = withSections;
+        const p = decodeProfile(rest);
+        expect(p.activity).toBeUndefined();
+    });
+
+    test("insights section is optional - omit it and profile still decodes", () => {
+        const { insights: _i, ...rest } = withSections;
+        const p = decodeProfile(rest);
+        expect(p.insights).toBeUndefined();
+    });
+
+    test("rejects tools_top row with non-number runs", () => {
+        const bad = {
+            ...withSections,
+            insights: {
+                ...withSections.insights,
+                tools_top: [{ name: "Bash", runs: "five-thousand" }],
+            },
+        };
+        expect(() => decodeProfile(bad)).toThrow();
+    });
+
+    test("rejects tools_top row with non-string name", () => {
+        const bad = {
+            ...withSections,
+            insights: {
+                ...withSections.insights,
+                tools_top: [{ name: 42, runs: 100 }],
+            },
+        };
+        expect(() => decodeProfile(bad)).toThrow();
+    });
+
+    test("rejects activity daily row with missing tokens", () => {
+        const bad = {
+            ...withSections,
+            activity: {
+                daily: [{ date: "2026-06-09", sessions: 31 }],  // tokens missing
+            },
+        };
+        expect(() => decodeProfile(bad)).toThrow();
+    });
+});
+```
+
+- [ ] Run failing tests:
+
+```bash
+/tmp/run-ax-tests.sh apps/axctl/src/profile/schema.test.ts
+```
+
+Expected: 6 new tests FAIL with decode/type errors.
+
+### Step 1.2 - Implement schema additions
+
+- [ ] Open `apps/axctl/src/profile/schema.ts`. After the `Rig` const, add:
+
+```typescript
+const DailyRow = Schema.Struct({
+    date: Schema.String,
+    sessions: Schema.Number,
+    tokens: Schema.Number,
+});
+
+const BusiestDay = Schema.Struct({
+    date: Schema.String,
+    sessions: Schema.Number,
+});
+
+const ToolRun = Schema.Struct({
+    name: Schema.String,
+    runs: Schema.Number,
+});
+
+const Activity = Schema.Struct({
+    daily: Schema.Array(DailyRow),
+});
+
+const Insights = Schema.Struct({
+    hours_total: Schema.Number,
+    longest_session_minutes: Schema.Number,
+    deep_session_share: Schema.Number,
+    peak_hour_utc: Schema.Number,
+    busiest_day: BusiestDay,
+    max_parallel_sessions: Schema.Number,
+    subagents_spawned: Schema.Number,
+    commits: Schema.Number,
+    tools_top: Schema.Array(ToolRun),
+});
+```
+
+Then in the `ProfileV1` struct, add two optional fields after `taste`:
+
+```typescript
+    activity: Schema.optional(Activity),
+    insights: Schema.optional(Insights),
+```
+
+- [ ] Run tests again:
+
+```bash
+/tmp/run-ax-tests.sh apps/axctl/src/profile/schema.test.ts
+```
+
+Expected: all tests PASS (including the original set).
+
+### Step 1.3 - Commit
+
+```bash
+git add apps/axctl/src/profile/schema.ts apps/axctl/src/profile/schema.test.ts
+git commit -m "feat(profile): add activity + insights sections to ProfileV1 schema"
+```
+
+---
+
+## Task 2: Queries - add 6 windowed fetchers
+
+**Files:**
+- Modify: `apps/axctl/src/profile/queries.ts`
+- Modify: `apps/axctl/src/profile/queries.test.ts`
+
+The commit table has a `ts` field of type `datetime` (confirmed in schema.surql). Use `ts > time::now() - ${win(d)}`.
+
+### Step 2.1 - Write failing query tests
+
+- [ ] Open `apps/axctl/src/profile/queries.test.ts`. Add these describe blocks after the existing ones:
+
+```typescript
+import {
+    fetchDailyActivityFull,
+    fetchSessionDurations,
+    fetchPeakHour,
+    fetchSpawnedCount,
+    fetchCommitCount,
+    fetchTopTools,
+} from "./queries.ts";
+
+describe("fetchDailyActivityFull", () => {
+    test("returns date+sessions+tokens rows, window applied", async () => {
+        const db = makeMockDb([
+            // sessions-per-day from turn (query 1)
+            [[{ date: "2026-06-11", sessions: 5 }, { date: "2026-06-12", sessions: 3 }]],
+            // tokens-per-day from session_token_usage (query 2)
+            [[{ date: "2026-06-11", tokens: 100_000 }, { date: "2026-06-12", tokens: 80_000 }]],
+        ]);
+        const r = await runWithMock(db, fetchDailyActivityFull({ windowDays: 30 }));
+        expect(r).toHaveLength(2);
+        expect(r[0]).toEqual({ date: "2026-06-11", sessions: 5, tokens: 100_000 });
+        expect(r[1]).toEqual({ date: "2026-06-12", sessions: 3, tokens: 80_000 });
+        expect(db.captured[0]).toContain("time::now() - 30d");
+        expect(db.captured[0]).toContain("array::len(array::distinct(session))");
+    });
+
+    test("day with no tokens entry gets tokens=0", async () => {
+        const db = makeMockDb([
+            [[{ date: "2026-06-11", sessions: 5 }]],
+            [[]], // no token rows
+        ]);
+        const r = await runWithMock(db, fetchDailyActivityFull({ windowDays: 30 }));
+        expect(r[0]).toEqual({ date: "2026-06-11", sessions: 5, tokens: 0 });
+    });
+
+    test("empty window -> empty array", async () => {
+        const db = makeMockDb([[[]], [[]]]);
+        const r = await runWithMock(db, fetchDailyActivityFull({ windowDays: 30 }));
+        expect(r).toHaveLength(0);
+    });
+});
+
+describe("fetchSessionDurations", () => {
+    test("returns started_at+ended_at as ISO strings, window applied", async () => {
+        const db = makeMockDb([[[
+            { started_at: "2026-06-11T10:00:00Z", ended_at: "2026-06-11T12:30:00Z" },
+            { started_at: "2026-06-12T09:00:00Z", ended_at: "2026-06-12T10:00:00Z" },
+        ]]]);
+        const r = await runWithMock(db, fetchSessionDurations({ windowDays: 30 }));
+        expect(r[0]!.started_at).toBe("2026-06-11T10:00:00Z");
+        expect(r[0]!.ended_at).toBe("2026-06-11T12:30:00Z");
+        expect(db.captured[0]).toContain("ended_at IS NOT NONE");
+        expect(db.captured[0]).toContain("started_at IS NOT NONE");
+        expect(db.captured[0]).toContain("time::now() - 30d");
+    });
+
+    test("empty window -> empty array", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchSessionDurations({ windowDays: 30 }));
+        expect(r).toHaveLength(0);
+    });
+});
+
+describe("fetchPeakHour", () => {
+    test("returns the peak hour as a number", async () => {
+        const db = makeMockDb([[[{ hour: "13", count: 42 }]]]);
+        const r = await runWithMock(db, fetchPeakHour({ windowDays: 30 }));
+        expect(r).toBe(13);
+        expect(db.captured[0]).toContain("time::format(started_at");
+        expect(db.captured[0]).toContain("time::now() - 30d");
+    });
+
+    test("empty window -> null", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchPeakHour({ windowDays: 30 }));
+        expect(r).toBeNull();
+    });
+});
+
+describe("fetchSpawnedCount", () => {
+    test("returns spawned count in window", async () => {
+        const db = makeMockDb([[[{ count: 420 }]]]);
+        const r = await runWithMock(db, fetchSpawnedCount({ windowDays: 30 }));
+        expect(r).toBe(420);
+        expect(db.captured[0]).toContain("FROM spawned");
+        expect(db.captured[0]).toContain("time::now() - 30d");
+    });
+
+    test("empty -> 0", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchSpawnedCount({ windowDays: 30 }));
+        expect(r).toBe(0);
+    });
+});
+
+describe("fetchCommitCount", () => {
+    test("returns commit count using ts field", async () => {
+        const db = makeMockDb([[[{ count: 1000 }]]]);
+        const r = await runWithMock(db, fetchCommitCount({ windowDays: 30 }));
+        expect(r).toBe(1000);
+        expect(db.captured[0]).toContain("FROM commit");
+        expect(db.captured[0]).toContain("ts >"); // uses ts field
+        expect(db.captured[0]).toContain("time::now() - 30d");
+    });
+
+    test("empty -> 0", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchCommitCount({ windowDays: 30 }));
+        expect(r).toBe(0);
+    });
+});
+
+describe("fetchTopTools", () => {
+    test("returns top 10 tools by run count, window applied", async () => {
+        const db = makeMockDb([[[
+            { tool: "Bash", count: 5000 },
+            { tool: "Read", count: 3200 },
+        ]]]);
+        const r = await runWithMock(db, fetchTopTools({ windowDays: 30 }));
+        expect(r[0]).toEqual({ name: "Bash", runs: 5000 });
+        expect(r[1]).toEqual({ name: "Read", runs: 3200 });
+        expect(db.captured[0]).toContain("FROM tool_call");
+        expect(db.captured[0]).toContain("command_norm ?? name");
+        expect(db.captured[0]).toContain("LIMIT 10");
+        expect(db.captured[0]).toContain("time::now() - 30d");
+    });
+
+    test("empty -> empty array", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchTopTools({ windowDays: 30 }));
+        expect(r).toHaveLength(0);
+    });
+});
+```
+
+- [ ] Run failing tests:
+
+```bash
+/tmp/run-ax-tests.sh apps/axctl/src/profile/queries.test.ts
+```
+
+Expected: all 12 new tests FAIL (functions not found).
+
+### Step 2.2 - Implement the 6 new fetchers
+
+- [ ] Open `apps/axctl/src/profile/queries.ts`. Append the following after `fetchAcceptedProposals`:
+
+```typescript
+// --- daily activity full (sessions + tokens per day) -----------------------
+
+export interface DailyActivityRow {
+    readonly date: string;
+    readonly sessions: number;
+    readonly tokens: number;
+}
+
+const DAILY_SESSIONS_SQL = (d: number) => `
+SELECT
+    time::format(ts, "%Y-%m-%d") AS date,
+    array::len(array::distinct(session)) AS sessions
+FROM turn
+WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
+GROUP BY date
+ORDER BY date ASC;`;
+
+const DAILY_TOKENS_SQL = (d: number) => `
+SELECT
+    time::format(ts, "%Y-%m-%d") AS date,
+    math::sum(prompt_tokens ?? 0) + math::sum(completion_tokens ?? 0) AS tokens
+FROM session_token_usage
+WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
+GROUP BY date
+ORDER BY date ASC;`;
+
+export const fetchDailyActivityFull = Effect.fn("profile.fetchDailyActivityFull")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const sessionRows = yield* db
+            .query<[Array<Record<string, unknown>>]>(DAILY_SESSIONS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const tokenRows = yield* db
+            .query<[Array<Record<string, unknown>>]>(DAILY_TOKENS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        // Join tokens onto session rows in JS (SurrealDB 3.x: no cross-query joins)
+        const tokenMap = new Map(
+            tokenRows
+                .map((r) => [String(r.date), Number(r.tokens ?? 0)] as const)
+                .filter(([d]) => d !== "undefined" && d !== "null"),
+        );
+        return sessionRows
+            .map((r) => {
+                const date = String(r.date);
+                return { date, sessions: Number(r.sessions ?? 0), tokens: tokenMap.get(date) ?? 0 };
+            })
+            .filter((r) => r.date !== "undefined" && r.date !== "null") satisfies DailyActivityRow[];
+    },
+);
+
+// --- session durations -------------------------------------------------------
+
+export interface SessionDurationRow {
+    readonly started_at: string;
+    readonly ended_at: string;
+}
+
+const SESSION_DURATIONS_SQL = (d: number) => `
+SELECT
+    type::string(started_at) AS started_at,
+    type::string(ended_at) AS ended_at
+FROM session
+WHERE started_at > time::now() - ${win(d)}
+  AND started_at IS NOT NONE
+  AND ended_at IS NOT NONE;`;
+
+export const fetchSessionDurations = Effect.fn("profile.fetchSessionDurations")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(SESSION_DURATIONS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return rows
+            .filter((r) => r.started_at != null && r.ended_at != null)
+            .map((r) => ({
+                started_at: String(r.started_at),
+                ended_at: String(r.ended_at),
+            })) satisfies SessionDurationRow[];
+    },
+);
+
+// --- peak hour ---------------------------------------------------------------
+
+const PEAK_HOUR_SQL = (d: number) => `
+SELECT
+    time::format(started_at, "%H") AS hour,
+    count() AS count
+FROM session
+WHERE started_at > time::now() - ${win(d)}
+  AND started_at IS NOT NONE
+GROUP BY hour
+ORDER BY count DESC
+LIMIT 1;`;
+
+export const fetchPeakHour = Effect.fn("profile.fetchPeakHour")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(PEAK_HOUR_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const row = rows[0];
+        if (row == null) return null;
+        return Number(row.hour ?? 0);
+    },
+);
+
+// --- spawned count -----------------------------------------------------------
+
+const SPAWNED_COUNT_SQL = (d: number) => `
+SELECT count() AS count
+FROM spawned
+WHERE ts > time::now() - ${win(d)}
+GROUP ALL;`;
+
+export const fetchSpawnedCount = Effect.fn("profile.fetchSpawnedCount")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(SPAWNED_COUNT_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return Number(rows[0]?.count ?? 0);
+    },
+);
+
+// --- commit count ------------------------------------------------------------
+// commit table uses `ts` (datetime) field - confirmed in schema.surql.
+
+const COMMIT_COUNT_SQL = (d: number) => `
+SELECT count() AS count
+FROM commit
+WHERE ts > time::now() - ${win(d)}
+GROUP ALL;`;
+
+export const fetchCommitCount = Effect.fn("profile.fetchCommitCount")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(COMMIT_COUNT_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return Number(rows[0]?.count ?? 0);
+    },
+);
+
+// --- top tools ---------------------------------------------------------------
+
+export interface TopToolRow {
+    readonly name: string;
+    readonly runs: number;
+}
+
+const TOP_TOOLS_SQL = (d: number) => `
+SELECT
+    (command_norm ?? name) AS tool,
+    count() AS count
+FROM tool_call
+WHERE ts > time::now() - ${win(d)}
+  AND (command_norm ?? name) IS NOT NONE
+GROUP BY tool
+ORDER BY count DESC
+LIMIT 10;`;
+
+export const fetchTopTools = Effect.fn("profile.fetchTopTools")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(TOP_TOOLS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return rows.map((r) => ({
+            name: String(r.tool),
+            runs: Number(r.count ?? 0),
+        })) satisfies TopToolRow[];
+    },
+);
+```
+
+- [ ] Run tests:
+
+```bash
+/tmp/run-ax-tests.sh apps/axctl/src/profile/queries.test.ts
+```
+
+Expected: all tests PASS.
+
+### Step 2.3 - Commit
+
+```bash
+git add apps/axctl/src/profile/queries.ts apps/axctl/src/profile/queries.test.ts
+git commit -m "feat(profile): add 6 windowed fetchers for activity + insights data"
+```
+
+---
+
+## Task 3: Pure deriver - insights.ts (new file)
+
+**Files:**
+- Create: `apps/axctl/src/profile/insights.ts`
+- Create: `apps/axctl/src/profile/insights.test.ts`
+
+### Step 3.1 - Write failing insights tests
+
+- [ ] Create `apps/axctl/src/profile/insights.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { deriveInsights } from "./insights.ts";
+import type { DailyActivityRow, SessionDurationRow } from "./queries.ts";
+
+// 90 minutes = 5400 seconds; deep session threshold
+const s = (startIso: string, endIso: string): SessionDurationRow => ({
+    started_at: startIso,
+    ended_at: endIso,
+});
+
+describe("deriveInsights", () => {
+    const baseDailyFull: DailyActivityRow[] = [
+        { date: "2026-06-09", sessions: 31, tokens: 800_000 },
+        { date: "2026-06-10", sessions: 8, tokens: 100_000 },
+        { date: "2026-06-12", sessions: 12, tokens: 120_000_000 },
+    ];
+
+    const baseDurations: SessionDurationRow[] = [
+        s("2026-06-12T10:00:00Z", "2026-06-12T12:30:00Z"),  // 2.5h = deep
+        s("2026-06-12T11:00:00Z", "2026-06-12T11:30:00Z"),  // 30min = not deep
+        s("2026-06-12T09:00:00Z", "2026-06-12T10:30:00Z"),  // 1.5h = deep
+    ];
+
+    test("hours_total sums all durations in hours", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 10,
+            spawned: 5,
+            commits: 20,
+            tools: [{ name: "Bash", runs: 100 }],
+            daily: baseDailyFull,
+        });
+        // 2.5 + 0.5 + 1.5 = 4.5h
+        expect(r!.hours_total).toBeCloseTo(4.5, 1);
+    });
+
+    test("longest_session_minutes finds the longest", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 10,
+            spawned: 5,
+            commits: 20,
+            tools: [],
+            daily: baseDailyFull,
+        });
+        // 2.5h = 150min
+        expect(r!.longest_session_minutes).toBe(150);
+    });
+
+    test("deep_session_share = sessions >= 90min / total sessions with duration", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 10,
+            spawned: 5,
+            commits: 20,
+            tools: [],
+            daily: baseDailyFull,
+        });
+        // 2 deep out of 3 = 0.667
+        expect(r!.deep_session_share).toBeCloseTo(2 / 3, 3);
+    });
+
+    test("busiest_day = max sessions in daily; ties pick earliest", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 13,
+            spawned: 5,
+            commits: 20,
+            tools: [],
+            daily: baseDailyFull,
+        });
+        expect(r!.busiest_day.date).toBe("2026-06-09");
+        expect(r!.busiest_day.sessions).toBe(31);
+    });
+
+    test("ties in busiest_day -> earliest date wins", () => {
+        const tied: DailyActivityRow[] = [
+            { date: "2026-06-10", sessions: 10, tokens: 0 },
+            { date: "2026-06-09", sessions: 10, tokens: 0 },
+        ];
+        const r = deriveInsights({
+            durations: [],
+            peakHour: null,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: tied,
+        });
+        expect(r!.busiest_day.date).toBe("2026-06-09");
+    });
+
+    test("max_parallel_sessions: sweep overlapping intervals", () => {
+        // Three sessions overlapping at 10:15: [10:00-11:00], [10:00-10:30], [10:00-10:20]
+        const durations: SessionDurationRow[] = [
+            s("2026-06-12T10:00:00Z", "2026-06-12T11:00:00Z"),
+            s("2026-06-12T10:00:00Z", "2026-06-12T10:30:00Z"),
+            s("2026-06-12T10:00:00Z", "2026-06-12T10:20:00Z"),
+            s("2026-06-12T10:35:00Z", "2026-06-12T11:30:00Z"),  // only 2 overlap here
+        ];
+        const r = deriveInsights({
+            durations,
+            peakHour: 10,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: [{ date: "2026-06-12", sessions: 4, tokens: 0 }],
+        });
+        expect(r!.max_parallel_sessions).toBe(3);
+    });
+
+    test("max_parallel_sessions: no overlap -> 1", () => {
+        const durations: SessionDurationRow[] = [
+            s("2026-06-12T08:00:00Z", "2026-06-12T09:00:00Z"),
+            s("2026-06-12T10:00:00Z", "2026-06-12T11:00:00Z"),
+        ];
+        const r = deriveInsights({
+            durations,
+            peakHour: 8,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: [{ date: "2026-06-12", sessions: 2, tokens: 0 }],
+        });
+        expect(r!.max_parallel_sessions).toBe(1);
+    });
+
+    test("sessions clamped at 24h each (bad data)", () => {
+        const durations: SessionDurationRow[] = [
+            s("2026-06-01T00:00:00Z", "2026-06-10T00:00:00Z"), // 9 days → clamped to 24h
+            s("2026-06-12T10:00:00Z", "2026-06-12T12:00:00Z"),  // 2h
+        ];
+        const r = deriveInsights({
+            durations,
+            peakHour: 10,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: [{ date: "2026-06-12", sessions: 2, tokens: 0 }],
+        });
+        // clamped: 24h + 2h = 26h
+        expect(r!.hours_total).toBeCloseTo(26.0, 1);
+        // longest after clamp is 24h = 1440 min
+        expect(r!.longest_session_minutes).toBe(1440);
+    });
+
+    test("peak_hour_utc mirrors input peakHour", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 13,
+            spawned: 420,
+            commits: 1000,
+            tools: [{ name: "Bash", runs: 5000 }],
+            daily: baseDailyFull,
+        });
+        expect(r!.peak_hour_utc).toBe(13);
+        expect(r!.subagents_spawned).toBe(420);
+        expect(r!.commits).toBe(1000);
+        expect(r!.tools_top[0]!.name).toBe("Bash");
+    });
+
+    test("returns null when both durations and daily are empty", () => {
+        const r = deriveInsights({
+            durations: [],
+            peakHour: null,
+            spawned: 0,
+            commits: 0,
+            tools: [],
+            daily: [],
+        });
+        expect(r).toBeNull();
+    });
+
+    test("daily non-empty but durations empty: hours_total=0, deep_share=0, max_parallel=0", () => {
+        const r = deriveInsights({
+            durations: [],
+            peakHour: 9,
+            spawned: 3,
+            commits: 5,
+            tools: [],
+            daily: [{ date: "2026-06-12", sessions: 5, tokens: 0 }],
+        });
+        expect(r).not.toBeNull();
+        expect(r!.hours_total).toBe(0);
+        expect(r!.deep_session_share).toBe(0);
+        expect(r!.max_parallel_sessions).toBe(0);
+        expect(r!.busiest_day.date).toBe("2026-06-12");
+    });
+});
+```
+
+- [ ] Run failing tests:
+
+```bash
+/tmp/run-ax-tests.sh apps/axctl/src/profile/insights.test.ts
+```
+
+Expected: all tests FAIL (module not found).
+
+### Step 3.2 - Implement insights.ts
+
+- [ ] Create `apps/axctl/src/profile/insights.ts`:
+
+```typescript
+/**
+ * Pure session-analytics derivers for the ProfileV1 `insights` section.
+ * No IO, no Effect, no Date.now() - all inputs injected.
+ * Clamps individual session duration at 24h to kill bad data.
+ */
+import type { DailyActivityRow, SessionDurationRow, TopToolRow } from "./queries.ts";
+
+const MAX_SESSION_MS = 24 * 60 * 60 * 1000; // 24h cap per session
+const DEEP_THRESHOLD_MIN = 90;
+
+export interface InsightsInput {
+    readonly durations: ReadonlyArray<SessionDurationRow>;
+    readonly peakHour: number | null;
+    readonly spawned: number;
+    readonly commits: number;
+    readonly tools: ReadonlyArray<TopToolRow>;
+    readonly daily: ReadonlyArray<DailyActivityRow>;
+}
+
+export interface InsightsResult {
+    readonly hours_total: number;
+    readonly longest_session_minutes: number;
+    readonly deep_session_share: number;
+    readonly peak_hour_utc: number;
+    readonly busiest_day: { readonly date: string; readonly sessions: number };
+    readonly max_parallel_sessions: number;
+    readonly subagents_spawned: number;
+    readonly commits: number;
+    readonly tools_top: ReadonlyArray<TopToolRow>;
+}
+
+/**
+ * Returns null when both durations and daily are empty (no data → renderer omits section).
+ */
+export function deriveInsights(input: InsightsInput): InsightsResult | null {
+    const { durations, peakHour, spawned, commits, tools, daily } = input;
+    if (durations.length === 0 && daily.length === 0) return null;
+
+    // --- duration stats -------------------------------------------------------
+    let totalMs = 0;
+    let longestMs = 0;
+    let deepCount = 0;
+
+    const events: Array<{ t: number; delta: 1 | -1 }> = [];
+
+    for (const { started_at, ended_at } of durations) {
+        const startMs = Date.parse(started_at);
+        const endMs = Date.parse(ended_at);
+        if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) continue;
+        const rawMs = endMs - startMs;
+        const clampedMs = Math.min(rawMs, MAX_SESSION_MS);
+        totalMs += clampedMs;
+        longestMs = Math.max(longestMs, clampedMs);
+        const clampedMinutes = clampedMs / 60_000;
+        if (clampedMinutes >= DEEP_THRESHOLD_MIN) deepCount++;
+        events.push({ t: startMs, delta: 1 });
+        events.push({ t: endMs, delta: -1 });
+    }
+
+    const hours_total = Math.round((totalMs / 3_600_000) * 10) / 10;
+    const longest_session_minutes = Math.round(longestMs / 60_000);
+    const deep_session_share = durations.length > 0
+        ? deepCount / durations.length
+        : 0;
+
+    // --- max parallel sessions (sweep line) -----------------------------------
+    let max_parallel_sessions = 0;
+    if (events.length > 0) {
+        events.sort((a, b) => a.t !== b.t ? a.t - b.t : a.delta - b.delta); // ends before starts on tie
+        let current = 0;
+        for (const { delta } of events) {
+            current += delta;
+            if (current > max_parallel_sessions) max_parallel_sessions = current;
+        }
+    }
+
+    // --- busiest day (from daily rows) ----------------------------------------
+    let busiestDate = "";
+    let busiestSessions = 0;
+    for (const row of daily) {
+        if (
+            row.sessions > busiestSessions ||
+            (row.sessions === busiestSessions && busiestDate !== "" && row.date < busiestDate)
+        ) {
+            busiestDate = row.date;
+            busiestSessions = row.sessions;
+        }
+    }
+    // Fallback if daily is empty but durations are not (shouldn't happen in practice)
+    if (busiestDate === "" && daily.length === 0) {
+        busiestDate = "";
+        busiestSessions = 0;
+    }
+
+    return {
+        hours_total,
+        longest_session_minutes,
+        deep_session_share,
+        peak_hour_utc: peakHour ?? 0,
+        busiest_day: { date: busiestDate, sessions: busiestSessions },
+        max_parallel_sessions,
+        subagents_spawned: spawned,
+        commits,
+        tools_top: tools,
+    };
+}
+```
+
+- [ ] Run tests:
+
+```bash
+/tmp/run-ax-tests.sh apps/axctl/src/profile/insights.test.ts
+```
+
+Expected: all tests PASS.
+
+### Step 3.3 - Commit
+
+```bash
+git add apps/axctl/src/profile/insights.ts apps/axctl/src/profile/insights.test.ts
+git commit -m "feat(profile): pure deriveInsights with sweep-line parallelism + depth math"
+```
+
+---
+
+## Task 4: Renderer - wire new data into buildProfile
+
+**Files:**
+- Modify: `apps/axctl/src/profile/render.ts`
+- Modify: `apps/axctl/src/profile/render.test.ts`
+
+The key constraint: `makeMockDb` replays results in call order. The existing tests expect mocks 1-7 in the current order. New fetchers must be **appended** (calls 8-15 in order).
+
+### Step 4.1 - Write failing render tests
+
+- [ ] Open `apps/axctl/src/profile/render.test.ts`. The existing `mockResults` array has 7 entries (indices 0-6). Add 8 more entries for the new queries:
+
+```typescript
+// Extended mockResults: append new results for new fetchers (calls 8-15)
+// 8  fetchDailyActivityFull (sessions query)
+// 9  fetchDailyActivityFull (tokens query)
+// 10 fetchSessionDurations
+// 11 fetchPeakHour
+// 12 fetchSpawnedCount
+// 13 fetchCommitCount
+// 14 fetchTopTools
+```
+
+Replace the `mockResults` const in the file with:
+
+```typescript
+const mockResults = [
+    // --- existing 7 ---
+    [[{ prompt_tokens: 31_000_000, completion_tokens: 7_000_000, sessions: 142 }]],
+    [[{ date: "2026-06-11" }, { date: "2026-06-12" }]],
+    [[{ source: "claude" }, { source: "codex" }]],
+    [[{ skill: "tdd", count: 88 }]],
+    [[{ name: "tdd", scope: "plugin:superpowers" }]],
+    [[{
+        form: "guidance", title: "Stop edit loops early",
+        hypothesis: "3+ edits means drift", confidence: "high", frequency: 12,
+        updated_at: "2026-06-10T00:00:00Z", created_at: "2026-06-01T00:00:00Z",
+    }]],
+    [[{
+        model: "fable", sessions: 100, prompt_tokens: 1, completion_tokens: 1,
+        cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 150,
+    }, {
+        model: "haiku", sessions: 42, prompt_tokens: 1, completion_tokens: 1,
+        cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 50,
+    }]],
+    // --- new: fetchDailyActivityFull (2 queries) ---
+    [[{ date: "2026-06-11", sessions: 5 }, { date: "2026-06-12", sessions: 12 }]],
+    [[{ date: "2026-06-11", tokens: 100_000 }, { date: "2026-06-12", tokens: 120_000_000 }]],
+    // --- new: fetchSessionDurations ---
+    [[
+        { started_at: "2026-06-12T10:00:00Z", ended_at: "2026-06-12T12:30:00Z" },
+        { started_at: "2026-06-12T09:00:00Z", ended_at: "2026-06-12T10:30:00Z" },
+    ]],
+    // --- new: fetchPeakHour ---
+    [[{ hour: "13", count: 42 }]],
+    // --- new: fetchSpawnedCount ---
+    [[{ count: 420 }]],
+    // --- new: fetchCommitCount ---
+    [[{ count: 1000 }]],
+    // --- new: fetchTopTools ---
+    [[{ tool: "Bash", count: 5000 }, { tool: "Read", count: 3200 }]],
+];
+```
+
+- [ ] Add new assertions at the end of the "assembles a valid ProfileV1" test (before closing `})`):
+
+```typescript
+        // activity
+        expect(p.activity).toBeDefined();
+        expect(p.activity!.daily).toHaveLength(2);
+        expect(p.activity!.daily[0]!.date).toBe("2026-06-11");
+        expect(p.activity!.daily[0]!.sessions).toBe(5);
+        expect(p.activity!.daily[1]!.tokens).toBe(120_000_000);
+        // insights
+        expect(p.insights).toBeDefined();
+        expect(p.insights!.peak_hour_utc).toBe(13);
+        expect(p.insights!.subagents_spawned).toBe(420);
+        expect(p.insights!.commits).toBe(1000);
+        expect(p.insights!.tools_top[0]!.name).toBe("Bash");
+        expect(p.insights!.busiest_day.date).toBe("2026-06-12");
+```
+
+- [ ] Run failing tests:
+
+```bash
+/tmp/run-ax-tests.sh apps/axctl/src/profile/render.test.ts
+```
+
+Expected: "assembles a valid ProfileV1" test FAILS on activity/insights assertions; other tests may error due to mock count mismatch (that's fine for now).
+
+### Step 4.2 - Implement in render.ts
+
+- [ ] Open `apps/axctl/src/profile/render.ts`. Add imports for new fetchers and the deriver:
+
+```typescript
+import {
+    fetchCommitCount,
+    fetchDailyActivityFull,
+    fetchPeakHour,
+    fetchSessionDurations,
+    fetchSpawnedCount,
+    fetchTopTools,
+} from "./queries.ts";
+import { deriveInsights } from "./insights.ts";
+```
+
+- [ ] Inside `buildProfile`, after the existing `const cost = yield* fetchCostModels(...)` call, append (update the sequential-order comment too):
+
+```typescript
+        // --- activity + insights (appended in order; keep mocks aligned) -------
+        // 8 fetchDailyActivityFull (sessions)  9 fetchDailyActivityFull (tokens)
+        // 10 fetchSessionDurations  11 fetchPeakHour  12 fetchSpawnedCount
+        // 13 fetchCommitCount  14 fetchTopTools
+        const dailyFull = yield* fetchDailyActivityFull({ windowDays });
+        const durations = yield* fetchSessionDurations({ windowDays });
+        const peakHour = yield* fetchPeakHour({ windowDays });
+        const spawnedCount = yield* fetchSpawnedCount({ windowDays });
+        const commitCount = yield* fetchCommitCount({ windowDays });
+        const topTools = yield* fetchTopTools({ windowDays });
+
+        const insights = deriveInsights({
+            durations,
+            peakHour,
+            spawned: spawnedCount,
+            commits: commitCount,
+            tools: topTools,
+            daily: dailyFull,
+        });
+```
+
+- [ ] In the `decodeProfile({...})` call, add the two new optional sections after `...(patterns.length > 0 ? { taste: { patterns } } : {})`:
+
+```typescript
+            ...(dailyFull.length > 0 ? { activity: { daily: dailyFull } } : {}),
+            ...(insights !== null ? { insights } : {}),
+```
+
+- [ ] Run tests:
+
+```bash
+/tmp/run-ax-tests.sh apps/axctl/src/profile/render.test.ts
+```
+
+Expected: all tests PASS (the existing three tests still pass because the mocks now have 15 entries and the new calls are fulfilled by entries 8-14).
+
+**Note:** The existing tests for `includeCost=false` and `no proposals -> taste omitted` will now consume all 15 mock entries when run via `makeMockDb(mockResults)`. Verify they still pass - if they use the same `mockResults`, the mock db will just have extra buffered results which is harmless.
+
+### Step 4.3 - Commit
+
+```bash
+git add apps/axctl/src/profile/render.ts apps/axctl/src/profile/render.test.ts
+git commit -m "feat(profile): wire activity + insights into buildProfile"
+```
+
+---
+
+## Task 5: CLI formatter - money() helper + insights block
+
+**Files:**
+- Modify: `apps/axctl/src/cli/commands/profile.ts`
+
+### Step 5.1 - Add money() helper and update formatProfile
+
+- [ ] Open `apps/axctl/src/cli/commands/profile.ts`. After the `integer` helper, add:
+
+```typescript
+/** Formats a USD amount: >=1000 -> "~$22.6K", else "$22" */
+const money = (n: number): string => {
+    if (!Number.isFinite(n)) return "$0";
+    if (n >= 1000) return `~$${(n / 1000).toFixed(1)}K`;
+    return `$${n.toFixed(0)}`;
+};
+```
+
+- [ ] In `formatProfile`, replace the cost rendering on the stats line:
+
+```typescript
+    const cost = p.stats.cost_usd !== undefined ? `  ·  ${money(p.stats.cost_usd)} est` : "";
+```
+
+- [ ] Replace the per-model cost rendering in the models loop:
+
+```typescript
+        const c = m.cost_usd !== undefined ? `  ${money(m.cost_usd)}` : "";
+```
+
+- [ ] After the `if (p.taste)` block at the end of `formatProfile`, add the insights block:
+
+```typescript
+    if (p.insights) {
+        const ins = p.insights;
+        const deepPct = (ins.deep_session_share * 100).toFixed(0);
+        lines.push("");
+        lines.push("insights:");
+        lines.push(
+            `  ${ins.hours_total.toFixed(1)}h total  ·  longest: ${ins.longest_session_minutes}min  ·  deep (≥90min): ${deepPct}%`,
+        );
+        lines.push(
+            `  peak hour: ${ins.peak_hour_utc.toString().padStart(2, "0")}:00 UTC  ·  max parallel: ${ins.max_parallel_sessions}  ·  spawned: ${integer(ins.subagents_spawned)}  ·  commits: ${integer(ins.commits)}`,
+        );
+        if (ins.tools_top.length > 0) {
+            lines.push("  top tools:");
+            for (const t of ins.tools_top.slice(0, 5)) {
+                lines.push(`    ${t.name.padEnd(20)} ${integer(t.runs).padStart(7)} runs`);
+            }
+        }
+    }
+```
+
+- [ ] Run typecheck to verify:
+
+```bash
+cd /Users/necmttn/Projects/ax/.claude/worktrees/ax-profiles-spec && bun run typecheck 2>&1 | grep -E "profile|community" | head -20
+```
+
+Expected: no errors in profile.ts.
+
+### Step 5.2 - Commit
+
+```bash
+git add apps/axctl/src/cli/commands/profile.ts
+git commit -m "feat(profile): money() helper + insights block in formatProfile"
+```
+
+---
+
+## Task 6: Site validator - extend community.ts + tests
+
+**Files:**
+- Modify: `apps/site/app/lib/community.ts`
+- Modify: `apps/site/app/lib/community.test.ts`
+
+### Step 6.1 - Write failing site validator tests
+
+- [ ] Open `apps/site/app/lib/community.test.ts`. After the existing `validateProfileV1` describe block, add:
+
+```typescript
+describe("validateProfileV1 - activity + insights sections", () => {
+    const profileWithSections = {
+        ...validProfile,
+        activity: {
+            daily: [
+                { date: "2026-06-09", sessions: 31, tokens: 800_000 },
+            ],
+        },
+        insights: {
+            hours_total: 307.2,
+            longest_session_minutes: 960,
+            deep_session_share: 0.58,
+            peak_hour_utc: 13,
+            busiest_day: { date: "2026-06-09", sessions: 31 },
+            max_parallel_sessions: 11,
+            subagents_spawned: 420,
+            commits: 1000,
+            tools_top: [
+                { name: "Bash", runs: 5000 },
+            ],
+        },
+    };
+
+    test("accepts profile with valid activity + insights", () => {
+        const p = validateProfileV1(profileWithSections);
+        expect((p as unknown as typeof profileWithSections).activity!.daily[0]!.sessions).toBe(31);
+        expect((p as unknown as typeof profileWithSections).insights!.peak_hour_utc).toBe(13);
+        expect((p as unknown as typeof profileWithSections).insights!.busiest_day.date).toBe("2026-06-09");
+        expect((p as unknown as typeof profileWithSections).insights!.tools_top[0]!.name).toBe("Bash");
+    });
+
+    test("rejects non-number in tools_top.runs", () => {
+        const bad = {
+            ...profileWithSections,
+            insights: {
+                ...profileWithSections.insights,
+                tools_top: [{ name: "Bash", runs: "five-thousand" }],
+            },
+        };
+        expect(() => validateProfileV1(bad)).toThrow();
+    });
+
+    test("rejects non-string in tools_top.name", () => {
+        const bad = {
+            ...profileWithSections,
+            insights: {
+                ...profileWithSections.insights,
+                tools_top: [{ name: 42, runs: 100 }],
+            },
+        };
+        expect(() => validateProfileV1(bad)).toThrow();
+    });
+
+    test("rejects non-number hours_total", () => {
+        const bad = {
+            ...profileWithSections,
+            insights: {
+                ...profileWithSections.insights,
+                hours_total: "307.2",
+            },
+        };
+        expect(() => validateProfileV1(bad)).toThrow();
+    });
+
+    test("rejects daily row with non-number sessions", () => {
+        const bad = {
+            ...profileWithSections,
+            activity: {
+                daily: [{ date: "2026-06-09", sessions: "31", tokens: 800_000 }],
+            },
+        };
+        expect(() => validateProfileV1(bad)).toThrow();
+    });
+});
+```
+
+- [ ] Run failing tests:
+
+```bash
+/tmp/run-ax-tests.sh apps/site/app/lib/community.test.ts
+```
+
+Expected: 5 new tests FAIL.
+
+### Step 6.2 - Implement validator extensions in community.ts
+
+- [ ] Open `apps/site/app/lib/community.ts`. Extend the `ProfileV1` TypeScript interface to include the new optional sections:
+
+```typescript
+export interface ProfileDailyRow {
+    readonly date: string;
+    readonly sessions: number;
+    readonly tokens: number;
+}
+export interface ProfileToolRun {
+    readonly name: string;
+    readonly runs: number;
+}
+export interface ProfileInsights {
+    readonly hours_total: number;
+    readonly longest_session_minutes: number;
+    readonly deep_session_share: number;
+    readonly peak_hour_utc: number;
+    readonly busiest_day: { readonly date: string; readonly sessions: number };
+    readonly max_parallel_sessions: number;
+    readonly subagents_spawned: number;
+    readonly commits: number;
+    readonly tools_top: readonly ProfileToolRun[];
+}
+```
+
+Add these to the `ProfileV1` interface after `taste?`:
+
+```typescript
+    readonly activity?: { readonly daily: readonly ProfileDailyRow[] };
+    readonly insights?: ProfileInsights;
+```
+
+- [ ] In `validateProfileV1`, add the new section validation after the `if (value.taste !== undefined)` block:
+
+```typescript
+    if (value.activity !== undefined) {
+        if (!isRecord(value.activity) || !Array.isArray(value.activity.daily)) {
+            throw new Error("invalid activity");
+        }
+        for (const d of value.activity.daily) {
+            if (!isRecord(d)) throw new Error("invalid activity.daily row");
+            str(d.date, "activity.daily.date");
+            num(d.sessions, "activity.daily.sessions");
+            num(d.tokens, "activity.daily.tokens");
+        }
+    }
+    if (value.insights !== undefined) {
+        const ins = value.insights;
+        if (!isRecord(ins)) throw new Error("invalid insights");
+        num(ins.hours_total, "insights.hours_total");
+        num(ins.longest_session_minutes, "insights.longest_session_minutes");
+        num(ins.deep_session_share, "insights.deep_session_share");
+        num(ins.peak_hour_utc, "insights.peak_hour_utc");
+        if (!isRecord(ins.busiest_day)) throw new Error("invalid insights.busiest_day");
+        str(ins.busiest_day.date, "insights.busiest_day.date");
+        num(ins.busiest_day.sessions, "insights.busiest_day.sessions");
+        num(ins.max_parallel_sessions, "insights.max_parallel_sessions");
+        num(ins.subagents_spawned, "insights.subagents_spawned");
+        num(ins.commits, "insights.commits");
+        if (!Array.isArray(ins.tools_top)) throw new Error("invalid insights.tools_top");
+        for (const t of ins.tools_top) {
+            if (!isRecord(t)) throw new Error("invalid tools_top row");
+            str(t.name, "tools_top.name");
+            num(t.runs, "tools_top.runs");
+        }
+    }
+```
+
+- [ ] Run tests:
+
+```bash
+/tmp/run-ax-tests.sh apps/site/app/lib/community.test.ts
+```
+
+Expected: all tests PASS.
+
+### Step 6.3 - Commit
+
+```bash
+git add apps/site/app/lib/community.ts apps/site/app/lib/community.test.ts
+git commit -m "feat(profile): extend site validator for activity + insights sections"
+```
+
+---
+
+## Task 7: Gates + smoke test
+
+**Files:** No new files. Read-only verification.
+
+### Step 7.1 - Run full test suite
+
+- [ ] Run all gated paths:
+
+```bash
+/tmp/run-ax-tests.sh apps/axctl/src/profile/ apps/axctl/src/cli/effect-cli.test.ts apps/site/app/lib/
+```
+
+Expected: All tests pass. Note the total count.
+
+### Step 7.2 - Typecheck
+
+- [ ] Run typecheck from worktree root:
+
+```bash
+cd /Users/necmttn/Projects/ax/.claude/worktrees/ax-profiles-spec && bun run typecheck 2>&1 | tail -20
+```
+
+Expected: No errors.
+
+### Step 7.3 - check:no-node-fs
+
+- [ ] Verify no node:fs usage in new/modified files:
+
+```bash
+cd /Users/necmttn/Projects/ax/.claude/worktrees/ax-profiles-spec && bun run check:no-node-fs 2>&1 | tail -10
+```
+
+Expected: passes.
+
+### Step 7.4 - Smoke test against live DB
+
+- [ ] Run the smoke query:
+
+```bash
+bun /Users/necmttn/Projects/ax/.claude/worktrees/ax-profiles-spec/apps/axctl/src/cli/index.ts profile show --json | jq '{activity: (.activity.daily | length), insights: .insights}'
+```
+
+Expected: JSON output with `activity` count > 0 and `insights` object with numeric fields. If DB lacks session durations, insights may be null (acceptable - note it).
+
+### Step 7.5 - Final commit (if any loose ends)
+
+If the smoke test revealed any issues, fix and commit:
+
+```bash
+git add -p  # stage only profile + site files
+git commit -m "fix(profile): smoke test fixups"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✅ `activity.daily` schema (DailyRow with date/sessions/tokens)
+- ✅ `insights` schema (all 9 numeric fields + busiest_day struct + tools_top array)
+- ✅ Both sections optional at profile level, all fields required within
+- ✅ `fetchDailyActivityFull` - sessions from turn + tokens from session_token_usage, joined in JS
+- ✅ `fetchSessionDurations` - WHERE both NOT NONE, type::string
+- ✅ `fetchPeakHour` - windowed PEAK_HOUR_SQL
+- ✅ `fetchSpawnedCount` - windowed SPAWNED_SQL
+- ✅ `fetchCommitCount` - uses `ts` field (confirmed in schema.surql)
+- ✅ `fetchTopTools` - top 10, no failures col
+- ✅ `deriveInsights` - hours_total clamped, sweep-line parallelism, deep share, busiest_day ties
+- ✅ Returns null when durations AND daily both empty
+- ✅ `render.ts` - appended after existing 7 queries (mock order preserved)
+- ✅ `render.test.ts` - mockResults extended 7→15 entries
+- ✅ `formatProfile` - money() helper, insights block, top 5 tools
+- ✅ `community.ts` - ProfileV1 interface + validateProfileV1 extended
+- ✅ `community.test.ts` - accept + reject cases for new sections
+- ✅ Gates: test suite, typecheck, check:no-node-fs, smoke
+
+**Type consistency:**
+- `DailyActivityRow` / `SessionDurationRow` / `TopToolRow` defined in `queries.ts`, imported by `insights.ts`
+- `InsightsInput` / `InsightsResult` defined in `insights.ts`
+- `buildProfile` spreads `insights` (null-checked) and `dailyFull` (length-checked) into decodeProfile
+
+**Commit table note:** The `commit` table uses `ts` (datetime) - confirmed via `rg "DEFINE TABLE commit" -A 10` in schema.surql. `fetchCommitCount` uses `WHERE ts > time::now() - ${win(d)}`.


### PR DESCRIPTION
## Summary
- **ProfileV1 gains two optional sections** (backward compatible): `activity.daily[]` (date/sessions/tokens) and `insights` (hours_total, longest_session, deep_session_share, peak_hour, busiest_day, max_parallel_sessions, subagents_spawned, commits, tools_top). Six new windowed fetchers + pure `deriveInsights` (sweep-line parallelism, 24h duration clamp); all privacy-safe aggregates.
- **CLI**: `money()` humanizer (`~$22.9K`), insights block + top tools in `formatProfile`.
- **Site `/u/<login>` redesign** — editorial telemetry-dossier: serif nameplate, vitals ledger with humanized numbers, activity timeline paired with the model split (models now have temporal context), wrapped-style insight cards, ranked tool-taste section, rig grouped by source with a guardrails aside, unclaimed-dossier join CTA. Site validator extended for the new sections (every rendered field type-checked).

Addresses review feedback: models lacked timespan, rig lacked workflow context, tool taste missing, raw `$22648`, missing interesting metrics.

## Test Plan
- [x] 161 tests green (schema +6, queries +13, insights +12, render, site lib +5); typecheck, no-node-fs clean
- [x] Live smoke: gist republished with activity (30 days) + insights; real-data render verified in dev server (screenshot reviewed)
- [x] Old gists without the new sections still validate/render (sections optional end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)