### PR TITLE
feat(site): profile OG cards, crawler meta, visitor CTA

### DIFF
--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -292,6 +292,8 @@ function ProfileDossier({ profile: p }: { profile: ProfileV1 }) {
                 </section>
             )}
 
+            <VisitorCTA />
+
             {/* colophon */}
             <footer className="pf-colophon">
                 <span>compiled by ax from local agent transcripts · nothing leaves the machine unreviewed</span>
@@ -447,6 +449,32 @@ function UnclaimedDossier({ login }: { login: string }) {
                 New to ax? <Link to="/">Start here</Link> - install takes 30 seconds,
                 the first ingest does the rest.
             </p>
+        </section>
+    );
+}
+
+/* ---------- visitor CTA ---------- */
+
+function VisitorCTA() {
+    return (
+        <section className="pf-cta" aria-label="get ax">
+            <h2 className="pf-cta-headline">This dossier compiled itself.</h2>
+            <p className="pf-cta-sub">
+                ax measures your real agent usage locally and publishes only the aggregate
+                - to a gist you own.
+            </p>
+            <div className="pf-cta-cmds">
+                <code className="pf-cta-cmd">curl -fsSL ax.necmttn.com/install | bash</code>
+                <code className="pf-cta-cmd">ax profile publish</code>
+            </div>
+            <a
+                className="pf-cta-repo"
+                href="https://github.com/Necmttn/ax"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                or star the repo →
+            </a>
         </section>
     );
 }

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -9950,3 +9950,54 @@ footer .right {
     .pf-empty { padding: 28px 22px 20px; margin-top: 48px; }
     .pf-empty h1 { padding-right: 0; font-size: 27px; margin-top: 28px; }
 }
+
+/* ----- visitor CTA ----- */
+.pf-cta {
+    margin-top: 72px;
+    border: 1px solid var(--line);
+    border-top: 3px solid var(--ink);
+    background: var(--panel);
+    padding: 40px 40px 32px;
+}
+.pf-cta-headline {
+    font-family: var(--serif);
+    font-size: clamp(24px, 3.5vw, 36px);
+    font-weight: 400;
+    letter-spacing: -0.5px;
+    line-height: 1.15;
+    margin: 0 0 10px;
+}
+.pf-cta-sub {
+    font-size: 14.5px;
+    line-height: 1.55;
+    color: var(--muted);
+    margin: 0 0 24px;
+}
+.pf-cta-cmds {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 20px;
+}
+.pf-cta-cmd {
+    display: block;
+    font-family: var(--mono);
+    font-size: 13.5px;
+    background: var(--ink);
+    color: var(--page);
+    padding: 11px 16px;
+    white-space: pre;
+}
+.pf-cta-cmd::before { content: "$ "; color: var(--green); }
+.pf-cta-repo {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--muted);
+    text-decoration: none;
+    letter-spacing: 0.04em;
+}
+.pf-cta-repo:hover { color: var(--ink); }
+@media (max-width: 560px) {
+    .pf-cta { padding: 28px 22px 22px; }
+    .pf-cta-cmd { white-space: normal; word-break: break-all; }
+}

--- a/apps/site/functions/_lib/og-meta.test.ts
+++ b/apps/site/functions/_lib/og-meta.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { OG_RENDER_REV, buildOgImageUrl, ogImageVersion } from "./og-meta";
+import { OG_RENDER_REV, buildOgImageUrl, ogImageVersion, OG_PROFILE_RENDER_REV, buildProfileOgImageUrl } from "./og-meta";
 
 describe("og-meta", () => {
     test("bare render revision when no manifest text is in hand", () => {
@@ -26,5 +26,18 @@ describe("og-meta", () => {
 
     test("empty manifest text still versions with a hash, not bare rev", () => {
         expect(ogImageVersion("")).toMatch(new RegExp(`^${OG_RENDER_REV}-[0-9a-f]{8}$`));
+    });
+});
+
+describe("buildProfileOgImageUrl", () => {
+    test("returns absolute og-profile URL with render revision", () => {
+        expect(buildProfileOgImageUrl("necmttn")).toBe(
+            `https://ax.necmttn.com/og-profile/necmttn?r=${OG_PROFILE_RENDER_REV}`,
+        );
+    });
+
+    test("preserves login casing in URL", () => {
+        const url = buildProfileOgImageUrl("MyUser");
+        expect(url).toContain("/og-profile/MyUser");
     });
 });

--- a/apps/site/functions/_lib/og-meta.ts
+++ b/apps/site/functions/_lib/og-meta.ts
@@ -37,3 +37,10 @@ export const ogImageVersion = (manifestText?: string): string =>
 /** Absolute /og/ poster URL with the cache-busting ?v= version param. */
 export const buildOgImageUrl = (owner: string, gistId: string, manifestText?: string): string =>
     `https://ax.necmttn.com/og/${owner}/${gistId}?v=${ogImageVersion(manifestText)}`;
+
+/** Bump when the profile poster template changes; busts edge + social image caches. */
+export const OG_PROFILE_RENDER_REV = 1;
+
+/** Absolute /og-profile/ poster URL for a profile login with the cache-busting ?r= param. */
+export const buildProfileOgImageUrl = (login: string): string =>
+    `https://ax.necmttn.com/og-profile/${login}?r=${OG_PROFILE_RENDER_REV}`;

--- a/apps/site/functions/og-profile/[login].ts
+++ b/apps/site/functions/og-profile/[login].ts
@@ -1,0 +1,199 @@
+/**
+ * Profile OG poster (1200x630 PNG) for /u/<login> pages.
+ *
+ * Data path: community/users/<login>.json → gist ax-profile.json.
+ * Aesthetic: ax paper/ink editorial (light bg, dark type, green accent).
+ *
+ * Route: /og-profile/<login> (not /og/u/<login>) - avoids the dynamic-segment
+ * collision risk with the existing /og/[owner]/[gistId] function. Cloudflare
+ * Pages prefers static segments over params but the second segment would
+ * still be captured by [gistId] in the existing function if routing is
+ * ambiguous, so we use a non-colliding prefix.
+ *
+ * Satori-safe rules (learned from the /og/ session card):
+ * - No flex-wrap, overflow, gap, max-width, or rgb() commas in style strings.
+ * - No raw <svg> children.
+ * - Use await image.arrayBuffer() - lazy streams produced empty bodies on Pages.
+ * - Hex colors only (commas inside rgb() break the worker's style parser and
+ *   drop display:flex from the same declaration).
+ * - Manual row-chunking instead of flex-wrap.
+ * - Revision r= in cache key; bump OG_PROFILE_RENDER_REV when template changes.
+ */
+import { ImageResponse } from "workers-og";
+import { OG_PROFILE_RENDER_REV } from "../_lib/og-meta";
+
+const LOGIN_RE = /^[A-Za-z0-9-]{1,39}$/;
+const REPO_RAW = "https://raw.githubusercontent.com/Necmttn/ax/main";
+
+// --- color palette (paper/ink editorial, matches site CSS tokens) ---
+const PAGE  = "#f6f5f0";  // --page
+const INK   = "#0a0a0a";  // --ink
+const LINE  = "#d8d6cf";  // --line
+const MUTED = "#6b6b66";  // --muted
+const GREEN = "#2f9e44";  // --green
+
+// --- inline types (no app imports in edge functions) ---
+interface Registration {
+    readonly github: string;
+    readonly gist_id: string;
+}
+
+interface ProfileStats {
+    readonly sessions: number;
+    readonly streak_days: number;
+    readonly tokens: { readonly total: number };
+    readonly cost_usd?: number;
+}
+
+interface ProfileInsights {
+    readonly hours_total?: number;
+}
+
+interface ProfileV1 {
+    readonly v: 1;
+    readonly github: string;
+    readonly window_days: number;
+    readonly stats: ProfileStats;
+    readonly insights?: ProfileInsights;
+}
+
+// --- compact number helpers (no Intl - not reliably available in workers) ---
+function compactNum(n: number): string {
+    if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+    if (n >= 1_000_000)     return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000)         return `${(n / 1_000).toFixed(1)}K`;
+    return String(Math.round(n));
+}
+
+function compactMoney(usd: number): string {
+    if (usd >= 1_000) return `$${(usd / 1_000).toFixed(1)}K`;
+    return `$${usd >= 100 ? usd.toFixed(0) : usd.toFixed(2)}`;
+}
+
+const esc = (s: string): string =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+/** One stat cell: big mono number + small uppercase label below. */
+function statCell(value: string, label: string, accent = false): string {
+    const valueColor = accent ? GREEN : INK;
+    return `<div style="display:flex;flex-direction:column;margin-right:48px">`
+        + `<span style="font-size:52px;font-weight:700;color:${valueColor};line-height:1;letter-spacing:-2px">${esc(value)}</span>`
+        + `<span style="font-size:12px;letter-spacing:0.14em;text-transform:uppercase;color:${MUTED};margin-top:8px">${esc(label)}</span>`
+        + `</div>`;
+}
+
+export const onRequestGet: PagesFunction = async (ctx) => {
+    const login = String(ctx.params.login ?? "").replace(/\.png$/, "");
+    if (!LOGIN_RE.test(login)) {
+        return new Response("bad request", { status: 400 });
+    }
+
+    // Cache key includes the render revision so template bumps bust stale renders.
+    const cache = (caches as unknown as { default: Cache }).default;
+    const u = new URL(ctx.request.url);
+    u.searchParams.set("r", String(OG_PROFILE_RENDER_REV));
+    const cacheKey = new Request(u.toString());
+    const hit = await cache.match(cacheKey);
+    if (hit) return hit;
+
+    // Step 1: resolve registration (login → gist_id)
+    const regRes = await fetch(
+        `${REPO_RAW}/community/users/${login.toLowerCase()}.json`,
+        { headers: { "user-agent": "ax-og-profile" } },
+    );
+    if (!regRes.ok) return new Response("not found", { status: 404 });
+    const reg = (await regRes.json()) as Registration;
+    if (typeof reg.gist_id !== "string" || typeof reg.github !== "string") {
+        return new Response("invalid registration", { status: 404 });
+    }
+
+    // Step 2: fetch the profile gist
+    const profileRes = await fetch(
+        `https://gist.githubusercontent.com/${reg.github}/${reg.gist_id}/raw/ax-profile.json`,
+        { headers: { "user-agent": "ax-og-profile" } },
+    );
+    if (!profileRes.ok) return new Response("not found", { status: 404 });
+    const profile = (await profileRes.json()) as ProfileV1;
+    if (profile.v !== 1) return new Response("invalid profile", { status: 404 });
+
+    const s = profile.stats;
+    const ins = profile.insights;
+
+    // Build stat row: sessions · tokens · cost? · streak · hours?
+    const statCells = [
+        statCell(String(s.sessions), "sessions"),
+        statCell(compactNum(s.tokens.total), "tokens"),
+        s.cost_usd !== undefined ? statCell(`~${compactMoney(s.cost_usd)}`, "est. spend", true) : "",
+        statCell(`${s.streak_days}d`, "streak"),
+        ins?.hours_total !== undefined ? statCell(compactNum(ins.hours_total), "hours") : "",
+    ].filter(Boolean).slice(0, 5).join("");
+
+    // Header: kicker line above big @login
+    const header = `<div style="display:flex;justify-content:space-between;align-items:flex-start">`
+        + `<div style="display:flex;flex-direction:column">`
+        + `<span style="font-size:13px;letter-spacing:0.14em;text-transform:uppercase;color:${MUTED}">`
+        + `agent telemetry dossier · last ${profile.window_days} days`
+        + `</span>`
+        + `<span style="font-size:72px;font-weight:700;letter-spacing:-3px;color:${INK};line-height:1;margin-top:12px">`
+        + `@${esc(login)}`
+        + `</span>`
+        + `</div>`
+        + `<span style="font-size:28px;font-weight:700;color:${GREEN}">ax</span>`
+        + `</div>`;
+
+    // Hairline divider
+    const divider = `<div style="display:flex;height:1px;background:${LINE};margin-top:28px;margin-bottom:40px"></div>`;
+
+    // Stats row
+    const statsRow = `<div style="display:flex;align-items:flex-end">${statCells}</div>`;
+
+    // Footer
+    const footer = `<div style="display:flex;justify-content:space-between;align-items:center;margin-top:48px">`
+        + `<span style="font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:${MUTED}">`
+        + `compiled from local transcripts · ax.necmttn.com`
+        + `</span>`
+        + `</div>`;
+
+    // Full bleed paper card, no inner border (platforms draw their own frame).
+    // 64px safe margins keep content clear of corner clipping.
+    const html = `<div style="display:flex;flex-direction:column;width:1200px;height:630px;background:${PAGE};padding:60px 72px">`
+        + header + divider + statsRow + footer
+        + `</div>`;
+
+    // Fetch fonts in parallel to minimize latency
+    const [font, fontBold] = await Promise.all([
+        fetch("https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-400-normal.ttf")
+            .then(r => r.arrayBuffer()),
+        fetch("https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-700-normal.ttf")
+            .then(r => r.arrayBuffer()),
+    ]);
+
+    let png: ArrayBuffer;
+    try {
+        const image = new ImageResponse(html, {
+            width: 1200,
+            height: 630,
+            fonts: [
+                { name: "JetBrains Mono", data: font,     weight: 400, style: "normal" },
+                { name: "JetBrains Mono", data: fontBold, weight: 700, style: "normal" },
+            ],
+        });
+        // Buffer the render: a lazy stream produced empty bodies on Pages.
+        png = await image.arrayBuffer();
+    } catch (err) {
+        return new Response(
+            `render error: ${err instanceof Error ? `${err.message}\n${err.stack ?? ""}` : String(err)}`,
+            { status: 500 },
+        );
+    }
+    if (png.byteLength === 0) return new Response("render produced 0 bytes", { status: 500 });
+
+    const res = new Response(png, {
+        headers: {
+            "content-type": "image/png",
+            "cache-control": "public, max-age=86400, s-maxage=86400",
+        },
+    });
+    ctx.waitUntil(cache.put(cacheKey, res.clone()));
+    return res;
+};

--- a/apps/site/functions/u/[login].ts
+++ b/apps/site/functions/u/[login].ts
@@ -1,0 +1,124 @@
+/**
+ * Edge head-rewrite for /u/<login> profile pages. The /u/ route is a SPA:
+ * og:image and title are generic by default. This function serves the same
+ * SPA shell with the head rewritten at the edge so crawlers (Slack, X,
+ * Discord) see the real profile poster + a stat-based description instead
+ * of the site's generic card.
+ *
+ * Mirrors the /s/[owner]/[gistId].ts approach:
+ * - Serves SPA shell from /
+ * - Best-effort fetches registration + profile for real stat line
+ * - Falls back to static copy on any failure
+ * - Uses buildProfileOgImageUrl for the og:image value
+ */
+import { buildProfileOgImageUrl } from "../_lib/og-meta";
+
+interface Env {
+    readonly ASSETS: { fetch: (req: Request) => Promise<Response> };
+}
+
+const LOGIN_RE = /^[A-Za-z0-9-]{1,39}$/;
+const REPO_RAW = "https://raw.githubusercontent.com/Necmttn/ax/main";
+
+// Inline types - functions cannot import from app/ code.
+interface Registration {
+    readonly github: string;
+    readonly gist_id: string;
+}
+interface ProfileStats {
+    readonly sessions: number;
+    readonly tokens: { readonly total: number };
+    readonly cost_usd?: number;
+    readonly streak_days: number;
+}
+interface ProfileV1 {
+    readonly v: 1;
+    readonly github: string;
+    readonly window_days: number;
+    readonly stats: ProfileStats;
+}
+
+function compactNum(n: number): string {
+    if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+    if (n >= 1_000_000)     return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000)         return `${(n / 1_000).toFixed(1)}K`;
+    return String(Math.round(n));
+}
+
+export const onRequestGet: PagesFunction<Env> = async (ctx) => {
+    const login = String(ctx.params.login ?? "");
+    if (!LOGIN_RE.test(login)) {
+        return ctx.env.ASSETS.fetch(ctx.request);
+    }
+
+    // Serve the SPA shell (same document the route serves today; only the head changes).
+    const shellUrl = new URL(ctx.request.url);
+    shellUrl.pathname = "/";
+    shellUrl.search = "";
+    const shell = await ctx.env.ASSETS.fetch(new Request(shellUrl.toString(), { headers: ctx.request.headers }));
+
+    const title = `@${login} - ax profile`;
+    let desc = "agent telemetry dossier: sessions, tokens, model split, rig, and taste - measured by ax";
+
+    // Best-effort: fetch registration → profile for a real stat line.
+    // Any error falls back to the generic description.
+    try {
+        const regRes = await fetch(
+            `${REPO_RAW}/community/users/${login.toLowerCase()}.json`,
+            { headers: { "user-agent": "ax-profile-meta" }, cf: { cacheTtl: 3600, cacheEverything: true } } as RequestInit,
+        );
+        if (regRes.ok) {
+            const reg = (await regRes.json()) as Registration;
+            if (typeof reg.gist_id === "string" && typeof reg.github === "string") {
+                const profRes = await fetch(
+                    `https://gist.githubusercontent.com/${reg.github}/${reg.gist_id}/raw/ax-profile.json`,
+                    { headers: { "user-agent": "ax-profile-meta" }, cf: { cacheTtl: 3600, cacheEverything: true } } as RequestInit,
+                );
+                if (profRes.ok) {
+                    const profile = (await profRes.json()) as ProfileV1;
+                    if (profile.v === 1) {
+                        const s = profile.stats;
+                        const bits = [
+                            `${s.sessions} sessions`,
+                            `${compactNum(s.tokens.total)} tokens`,
+                            s.cost_usd !== undefined
+                                ? `~$${s.cost_usd >= 1000 ? `${(s.cost_usd / 1000).toFixed(1)}K` : s.cost_usd.toFixed(0)} spent`
+                                : null,
+                            `${s.streak_days}d streak`,
+                        ].filter(Boolean).join(" · ");
+                        desc = `${bits} - agent telemetry compiled by ax over ${profile.window_days} days`;
+                    }
+                }
+            }
+        }
+    } catch {
+        // generic desc stands
+    }
+
+    const og = buildProfileOgImageUrl(login);
+    const pageUrl = `https://ax.necmttn.com/u/${login}`;
+
+    const set = (attr: "property" | "name", key: string, content: string) => ({
+        selector: `meta[${attr}="${key}"]`,
+        handler: { element: (el: Element) => el.setAttribute("content", content) },
+    });
+
+    const rules = [
+        set("property", "og:image", og),
+        set("name", "twitter:image", og),
+        set("property", "og:image:width", "1200"),
+        set("property", "og:image:height", "630"),
+        set("property", "og:title", title),
+        set("name", "twitter:title", title),
+        set("property", "og:description", desc),
+        set("name", "twitter:description", desc),
+        set("property", "og:url", pageUrl),
+        set("name", "twitter:card", "summary_large_image"),
+    ];
+
+    let rewriter = new HTMLRewriter().on("title", {
+        element: (el) => { el.setInnerContent(`${title} - ax`); },
+    });
+    for (const r of rules) rewriter = rewriter.on(r.selector, r.handler);
+    return rewriter.transform(shell);
+};

--- a/functions/og-profile/[login].ts
+++ b/functions/og-profile/[login].ts
@@ -1,0 +1,9 @@
+/**
+ * Repo-root mirror of apps/site/functions/og-profile: the Cloudflare Pages GIT
+ * integration builds with the repository root as its project root, so it only
+ * picks up THIS functions/ directory - every auto-build was shipping without
+ * the OG poster + share-meta functions and silently wiping them from
+ * production (manual `wrangler pages deploy` runs from apps/site and uses
+ * apps/site/functions). Keep both in sync by re-exporting, never duplicating.
+ */
+export { onRequestGet } from "../../../apps/site/functions/og-profile/[login]";

--- a/functions/u/[login].ts
+++ b/functions/u/[login].ts
@@ -1,0 +1,2 @@
+/** Repo-root mirror for the Pages git integration - see functions/og/. */
+export { onRequestGet } from "../../../apps/site/functions/u/[login]";


### PR DESCRIPTION
## Summary
- **`/og-profile/<login>`** Pages Function — satori-rendered 1200×630 share card from the user's gist (paper/ink aesthetic, @login nameplate, humanized stat row), cached with revision key. Non-colliding path chosen over `/og/u/…` to avoid ambiguity with the existing `/og/[owner]/[gistId]` share-card route.
- **`/u/[login]`** Pages Function — crawler meta rewrite (og:title/description/image + twitter summary_large_image) so shared profile links unfurl with the custom card instead of the generic site shell. Reuses `_lib/og-meta.ts` (new `buildProfileOgImageUrl`, tests green).
- **Visitor CTA band** on the profile page — "This dossier compiled itself." + the real install one-liner + `ax profile publish` + star link, styled in the dossier system.
- Root `functions/` mirrors added for both new functions (re-export convention — CF git integration builds from repo root; PR #214 lesson).

## Test Plan
- [x] 35 site tests green (og-meta + community lib); site build + typecheck clean
- [x] CTA band visually verified in dev against real gist data
- [x] functions mirror structure check
- [ ] Post-merge: verify `/og-profile/necmttn` returns image/png on production and a link unfurl shows the card (functions can't run pre-merge locally without wrangler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)