### PR TITLE
fix(site): repo-root functions mirror import depth (Pages build)

### DIFF
--- a/functions/og-profile/[login].ts
+++ b/functions/og-profile/[login].ts
@@ -6,4 +6,4 @@
  * production (manual `wrangler pages deploy` runs from apps/site and uses
  * apps/site/functions). Keep both in sync by re-exporting, never duplicating.
  */
-export { onRequestGet } from "../../../apps/site/functions/og-profile/[login]";
+export { onRequestGet } from "../../apps/site/functions/og-profile/[login]";

--- a/functions/u/[login].ts
+++ b/functions/u/[login].ts
@@ -1,2 +1,2 @@
 /** Repo-root mirror for the Pages git integration - see functions/og/. */
-export { onRequestGet } from "../../../apps/site/functions/u/[login]";
+export { onRequestGet } from "../../apps/site/functions/u/[login]";


### PR DESCRIPTION
## Summary
PR #333's root-mirror functions sit two path segments deep (`u/[login].ts`, `og-profile/[login].ts`) but used the three-deep `../../../` re-export path copied from `og/[owner]/[gistId].ts` — esbuild couldn't resolve them and the Cloudflare Pages git build failed (production kept serving the previous deploy). Corrected to `../../`; `wrangler pages functions build` from repo root now compiles.

## Test Plan
- [x] `wrangler pages functions build` from repo root: "Compiled Worker successfully" (was: 2 resolve errors)
- [ ] Post-merge: Pages build green; `/og-profile/necmttn` serves image/png in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)