### PR TITLE
feat(site): shared og-kit, canonical block AX logo, dense profile card

### DIFF
--- a/apps/site/functions/_lib/og-kit.test.ts
+++ b/apps/site/functions/_lib/og-kit.test.ts
@@ -4,6 +4,7 @@ import {
     artLine,
     fmtUsd,
     compactNumber,
+    compactUsd,
     statHtml,
     footerHtml,
     blockLogoHtml,
@@ -48,14 +49,26 @@ describe("fmtUsd", () => {
 });
 
 describe("compactNumber", () => {
+    test("formats billions", () => {
+        expect(compactNumber(19_620_900_000)).toBe("19.6B");
+    });
     test("formats millions", () => {
         expect(compactNumber(1_500_000)).toBe("1.5M");
     });
     test("formats thousands", () => {
-        expect(compactNumber(2500)).toBe("2.5k");
+        expect(compactNumber(2500)).toBe("2.5K");
     });
     test("leaves small numbers as-is", () => {
         expect(compactNumber(42)).toBe("42");
+    });
+});
+
+describe("compactUsd", () => {
+    test("humanizes big spend with approx marker", () => {
+        expect(compactUsd(22_882)).toBe("~$22.9K");
+    });
+    test("small spend stays exact", () => {
+        expect(compactUsd(42.4)).toBe("$42");
     });
 });
 

--- a/apps/site/functions/_lib/og-kit.test.ts
+++ b/apps/site/functions/_lib/og-kit.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import {
+    esc,
+    artLine,
+    fmtUsd,
+    compactNumber,
+    statHtml,
+    footerHtml,
+    blockLogoHtml,
+    INK,
+    DIM,
+    GREEN,
+} from "./og-kit";
+
+describe("esc", () => {
+    test("escapes html special chars", () => {
+        expect(esc("a&b<c>d")).toBe("a&amp;b&lt;c&gt;d");
+    });
+    test("leaves plain strings unchanged", () => {
+        expect(esc("hello world")).toBe("hello world");
+    });
+});
+
+describe("artLine", () => {
+    test("replaces spaces with non-breaking spaces", () => {
+        // " /\\ " has leading + trailing spaces
+        const result = artLine(" /\\ ");
+        expect(result).not.toContain(" ");
+        expect(result).toContain(" ");
+    });
+    test("escapes html and replaces spaces", () => {
+        const result = artLine("a & b");
+        // spaces become nbsp, & becomes &amp;
+        expect(result).toBe("a &amp; b");
+    });
+});
+
+describe("fmtUsd", () => {
+    test("returns null for null input", () => {
+        expect(fmtUsd(null)).toBeNull();
+    });
+    test("formats cents with two decimals", () => {
+        expect(fmtUsd(1.23)).toBe("$1.23");
+    });
+    test("formats large values with zero decimals", () => {
+        expect(fmtUsd(150.5)).toBe("$151");
+    });
+});
+
+describe("compactNumber", () => {
+    test("formats millions", () => {
+        expect(compactNumber(1_500_000)).toBe("1.5M");
+    });
+    test("formats thousands", () => {
+        expect(compactNumber(2500)).toBe("2.5k");
+    });
+    test("leaves small numbers as-is", () => {
+        expect(compactNumber(42)).toBe("42");
+    });
+});
+
+describe("statHtml", () => {
+    test("contains the label uppercased (caller passes uppercase)", () => {
+        const html = statHtml("42", "TURNS");
+        expect(html).toContain("TURNS");
+    });
+    test("contains the value", () => {
+        const html = statHtml("$1.23", "COST", GREEN);
+        expect(html).toContain("$1.23");
+    });
+    test("uses custom color for value span", () => {
+        const html = statHtml("99", "SESSIONS", GREEN);
+        expect(html).toContain(GREEN);
+    });
+    test("defaults to INK color", () => {
+        const html = statHtml("99", "SESSIONS");
+        expect(html).toContain(INK);
+    });
+});
+
+describe("footerHtml", () => {
+    test("includes the left text", () => {
+        const html = footerHtml("COMPILED FROM LOCAL TRANSCRIPTS");
+        expect(html).toContain("COMPILED FROM LOCAL TRANSCRIPTS");
+    });
+    test("includes AX.NECMTTN.COM", () => {
+        const html = footerHtml("anything");
+        expect(html).toContain("AX.NECMTTN.COM");
+    });
+    test("includes serif ax wordmark", () => {
+        const html = footerHtml("anything");
+        expect(html).toContain("Gelasio");
+        expect(html).toContain(">ax<");
+    });
+});
+
+describe("blockLogoHtml", () => {
+    const opts = { scale: 4, color: INK, dimColor: DIM };
+
+    test("produces 6 row divs", () => {
+        const html = blockLogoHtml(opts);
+        // Each row is a <div style="display:flex"> - count flex rows
+        const rowMatches = [...html.matchAll(/<div style="display:flex">/g)];
+        // 6 rows + 1 outer column container = 7 matches
+        expect(rowMatches.length).toBeGreaterThanOrEqual(6);
+    });
+
+    test("first row has correct pixel count (17 chars → 17 cells)", () => {
+        const html = blockLogoHtml(opts);
+        // Parse out first row - first <div style="display:flex">...</div> block
+        const firstRowMatch = html.match(/<div style="display:flex">(<div style="display:flex;[^"]*"[^>]*><\/div>)+<\/div>/);
+        expect(firstRowMatch).not.toBeNull();
+        // Count cells in first row - each cell has display:flex; (with semicolon, unlike the row wrapper)
+        // The row wrapper uses display:flex" (no semicolon), so matchAll on display:flex; counts only cells.
+        const cellCount = [...(firstRowMatch?.[0] ?? "").matchAll(/<div style="display:flex;/g)].length;
+        // First row " █████╗ ██╗  ██╗" = 16 chars → 16 cells
+        expect(cellCount).toBe(16);
+    });
+
+    test("solid pixels use the ink color", () => {
+        const html = blockLogoHtml({ scale: 4, color: "#ffffff", dimColor: "#888888" });
+        expect(html).toContain("background:#ffffff");
+    });
+
+    test("frame pixels use the dim color", () => {
+        const html = blockLogoHtml({ scale: 4, color: "#ffffff", dimColor: "#888888" });
+        expect(html).toContain("background:#888888");
+    });
+
+    test("scale param controls cell px size", () => {
+        const html8 = blockLogoHtml({ scale: 8, color: INK, dimColor: DIM });
+        expect(html8).toContain("width:8px");
+        expect(html8).toContain("height:8px");
+        const html4 = blockLogoHtml({ scale: 4, color: INK, dimColor: DIM });
+        expect(html4).toContain("width:4px");
+    });
+});

--- a/apps/site/functions/_lib/og-kit.ts
+++ b/apps/site/functions/_lib/og-kit.ts
@@ -42,10 +42,15 @@ export const fmtUsd = (n: number | null): string | null =>
     n == null ? null : `$${n >= 100 ? n.toFixed(0) : n.toFixed(2)}`;
 
 export const compactNumber = (n: number): string => {
-    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-    if (n >= 1_000)     return `${(n / 1_000).toFixed(1)}k`;
+    if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+    if (n >= 1_000_000)     return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000)         return `${(n / 1_000).toFixed(1)}K`;
     return n.toLocaleString("en-US");
 };
+
+/** Humanized money for big stat numerals: 22882 -> "~$22.9K". */
+export const compactUsd = (n: number): string =>
+    n >= 1_000 ? `~$${compactNumber(n)}` : `$${n.toFixed(0)}`;
 
 // ---------------------------------------------------------------------------
 // Stat block - 46px numeral + 14px letter-spaced label (matches share card)

--- a/apps/site/functions/_lib/og-kit.ts
+++ b/apps/site/functions/_lib/og-kit.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared primitives for OG poster rendering (satori / workers-og).
+ *
+ * Satori quirks baked in here so route files don't repeat them:
+ *   - No gap / overflow / border-radius on track containers (breaks display:flex)
+ *   - Use margin-right, not gap, between siblings
+ *   - Replace spaces with &nbsp; in ASCII art (artLine) so satori doesn't collapse them
+ *   - No raw <svg> children (parser drops unknown tags)
+ *   - Commas inside style values break the workers-og style parser; use hex colors not rgb()
+ */
+
+// ---------------------------------------------------------------------------
+// Color palette (same values as share card)
+// ---------------------------------------------------------------------------
+export const INK    = "#e7e9ec";
+export const DIM    = "#8b93a1";
+export const BG     = "#15161d";
+export const CARD   = "#1e1f2a";
+export const LINE   = "#33364a";
+export const GREEN  = "#34d399";
+export const RED    = "#f87171";
+export const ROSE   = "#fb7185";
+export const GOLD   = "#fbbf24";
+export const BLUE   = "#60a5fa";
+export const VIOLET = "#a78bfa";
+
+// ---------------------------------------------------------------------------
+// String escaping
+// ---------------------------------------------------------------------------
+export const esc = (s: string): string =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+// ---------------------------------------------------------------------------
+// ASCII art line - swap every space for NBSP so satori preserves alignment.
+// ---------------------------------------------------------------------------
+export const artLine = (line: string): string => esc(line).replace(/ /g, " ");
+
+// ---------------------------------------------------------------------------
+// Number / currency formatters
+// ---------------------------------------------------------------------------
+export const fmtUsd = (n: number | null): string | null =>
+    n == null ? null : `$${n >= 100 ? n.toFixed(0) : n.toFixed(2)}`;
+
+export const compactNumber = (n: number): string => {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000)     return `${(n / 1_000).toFixed(1)}k`;
+    return n.toLocaleString("en-US");
+};
+
+// ---------------------------------------------------------------------------
+// Stat block - 46px numeral + 14px letter-spaced label (matches share card)
+// ---------------------------------------------------------------------------
+export const statHtml = (
+    value: string,
+    label: string,
+    color: string = INK,
+): string =>
+    `<div style="display:flex;flex-direction:column;margin-right:46px"><span style="font-size:46px;font-weight:700;color:${color}">${esc(value)}</span><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-top:2px">${esc(label)}</span></div>`;
+
+// ---------------------------------------------------------------------------
+// Footer band - serif "ax" wordmark + AX.NECMTTN.COM right side
+// ---------------------------------------------------------------------------
+export const footerHtml = (leftText: string): string =>
+    `<div style="display:flex;justify-content:space-between;align-items:center"><span style="font-size:15px;letter-spacing:2px;color:${DIM}">${esc(leftText)}</span><div style="display:flex;align-items:baseline"><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-right:10px">RECORDED WITH</span><span style="font-size:24px;color:${INK};font-weight:700;font-family:'Gelasio'">ax</span><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-left:12px">· AX.NECMTTN.COM</span></div></div>`;
+
+// ---------------------------------------------------------------------------
+// Block logo - ANSI-shadow pixel grid (font-independent)
+//
+// The 6-line canonical mark from install.sh:
+//
+//    █████╗ ██╗  ██╗
+//   ██╔══██╗╚██╗██╔╝
+//   ███████║ ╚███╔╝
+//   ██╔══██║ ██╔██╗
+//   ██║  ██║██╔╝ ██╗
+//   ╚═╝  ╚═╝╚═╝  ╚═╝
+//
+// Block glyphs (█ ╔ ╗ ╚ ╝ ═ ║) will NOT render in satori (latin-only font
+// subsets). We parse the string character by character and emit one <div>
+// per cell: solid=█ → ink color, frame=╔╗╚╝═║ → dimColor, space → empty.
+// ---------------------------------------------------------------------------
+const LOGO_LINES = [
+    " █████╗ ██╗  ██╗",
+    "██╔══██╗╚██╗██╔╝",
+    "███████║ ╚███╔╝ ",
+    "██╔══██║ ██╔██╗ ",
+    "██║  ██║██╔╝ ██╗",
+    "╚═╝  ╚═╝╚═╝  ╚═╝",
+] as const;
+
+const SOLID_CHARS = new Set(["█"]);
+const FRAME_CHARS = new Set(["╔", "╗", "╚", "╝", "═", "║"]);
+
+export interface BlockLogoOpts {
+    /** px per grid cell (e.g. 4 = small header, 8 = mid, 16 = large) */
+    scale: number;
+    /** Solid pixel color (ink) */
+    color: string;
+    /** Frame/connector pixel color (dim) */
+    dimColor: string;
+}
+
+export const blockLogoHtml = ({ scale, color, dimColor }: BlockLogoOpts): string => {
+    const rows = LOGO_LINES.map((line) => {
+        const cells = [...line].map((ch) => {
+            if (SOLID_CHARS.has(ch)) {
+                return `<div style="display:flex;width:${scale}px;height:${scale}px;background:${color}"></div>`;
+            }
+            if (FRAME_CHARS.has(ch)) {
+                return `<div style="display:flex;width:${scale}px;height:${scale}px;background:${dimColor}"></div>`;
+            }
+            // space → empty cell
+            return `<div style="display:flex;width:${scale}px;height:${scale}px"></div>`;
+        }).join("");
+        return `<div style="display:flex">${cells}</div>`;
+    }).join("");
+    return `<div style="display:flex;flex-direction:column">${rows}</div>`;
+};
+
+// ---------------------------------------------------------------------------
+// Font loading - deduped helper used by both route files
+// ---------------------------------------------------------------------------
+export const loadOgFonts = async (): Promise<{
+    regular: ArrayBuffer;
+    bold: ArrayBuffer;
+    serif: ArrayBuffer;
+}> => {
+    const [regular, bold, serif] = await Promise.all([
+        fetch("https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-400-normal.ttf").then((r) => r.arrayBuffer()),
+        fetch("https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-700-normal.ttf").then((r) => r.arrayBuffer()),
+        fetch("https://cdn.jsdelivr.net/fontsource/fonts/gelasio@latest/latin-700-normal.ttf").then((r) => r.arrayBuffer()),
+    ]);
+    return { regular, bold, serif };
+};

--- a/apps/site/functions/_lib/og-meta.ts
+++ b/apps/site/functions/_lib/og-meta.ts
@@ -13,7 +13,7 @@
  */
 
 /** Bump when the poster template changes; busts edge + social image caches. */
-export const OG_RENDER_REV = 6;
+export const OG_RENDER_REV = 7;
 
 /** FNV-1a 32-bit as 8 hex chars - tiny, synchronous, stable across runtimes. */
 const fnv1a = (s: string): string => {

--- a/apps/site/functions/_lib/og-meta.ts
+++ b/apps/site/functions/_lib/og-meta.ts
@@ -13,7 +13,7 @@
  */
 
 /** Bump when the poster template changes; busts edge + social image caches. */
-export const OG_RENDER_REV = 7;
+export const OG_RENDER_REV = 8;
 
 /** FNV-1a 32-bit as 8 hex chars - tiny, synchronous, stable across runtimes. */
 const fnv1a = (s: string): string => {

--- a/apps/site/functions/og-profile/[login].ts
+++ b/apps/site/functions/og-profile/[login].ts
@@ -16,7 +16,7 @@ import { ImageResponse } from "workers-og";
 import { OG_RENDER_REV } from "../_lib/og-meta";
 import {
     INK, DIM, CARD, GREEN, RED,
-    esc, statHtml, footerHtml, blockLogoHtml, compactNumber, loadOgFonts,
+    esc, statHtml, footerHtml, blockLogoHtml, compactNumber, compactUsd, loadOgFonts,
 } from "../_lib/og-kit";
 
 const LOGIN_RE = /^[A-Za-z0-9_-]{1,39}$/;
@@ -188,16 +188,14 @@ export const onRequestGet: PagesFunction = async (ctx) => {
     // Big @login in Gelasio serif
     const loginHtml = `<div style="display:flex;align-items:baseline;margin-top:12px"><span style="font-size:48px;font-weight:700;color:${DIM};font-family:'Gelasio';margin-right:4px">@</span><span style="font-size:88px;font-weight:700;color:${INK};font-family:'Gelasio';line-height:1">${esc(login)}</span></div>`;
 
-    // Stat band 1
-    const spendStr = spendUsd != null
-        ? (spendUsd >= 100 ? `$${spendUsd.toFixed(0)}` : `$${spendUsd.toFixed(2)}`)
-        : "-";
+    // Stat band 1 - humanized numerals (19.6B, ~$22.9K, 2.3K) per the
+    // profile design language.
     const statBand1 = `<div style="display:flex">${[
         statHtml(sessions != null ? sessions.toLocaleString("en-US") : "-", "SESSIONS"),
         statHtml(tokens  != null ? compactNumber(tokens)             : "-", "TOKENS"),
-        statHtml(spendStr,                                               "EST. SPEND", GREEN),
+        statHtml(spendUsd != null ? compactUsd(spendUsd)             : "-", "EST. SPEND", GREEN),
         statHtml(streakDays  != null ? `${streakDays}d`             : "-", "STREAK"),
-        statHtml(activeHours != null ? `${activeHours}h`            : "-", "HOURS"),
+        statHtml(activeHours != null ? compactNumber(activeHours)   : "-", "HOURS"),
     ].join("")}</div>`;
 
     // Filler: bar chart or second stat row (fills dead space)

--- a/apps/site/functions/og-profile/[login].ts
+++ b/apps/site/functions/og-profile/[login].ts
@@ -1,38 +1,30 @@
 /**
- * Profile OG poster (1200x630 PNG) for /u/<login> pages.
+ * Profile OG card (1200x630 PNG) - dense agent telemetry dossier.
  *
- * Data path: community/users/<login>.json → gist ax-profile.json.
- * Aesthetic: ax paper/ink editorial (light bg, dark type, green accent).
+ * Data path v0: community/users/<login>.json → gist ax-profile.json.
+ * Falls back to ?data=<url-encoded JSON> for local/preview testing without
+ * a published registration.
  *
- * Route: /og-profile/<login> (not /og/u/<login>) - avoids the dynamic-segment
- * collision risk with the existing /og/[owner]/[gistId] function. Cloudflare
- * Pages prefers static segments over params but the second segment would
- * still be captured by [gistId] in the existing function if routing is
- * ambiguous, so we use a non-colliding prefix.
+ * Route: /og-profile/<login> - avoids collision with /og/[owner]/[gistId].
  *
- * Satori-safe rules (learned from the /og/ session card):
- * - No flex-wrap, overflow, gap, max-width, or rgb() commas in style strings.
- * - No raw <svg> children.
- * - Use await image.arrayBuffer() - lazy streams produced empty bodies on Pages.
- * - Hex colors only (commas inside rgb() break the worker's style parser and
- *   drop display:flex from the same declaration).
- * - Manual row-chunking instead of flex-wrap.
- * - Revision r= in cache key; bump OG_PROFILE_RENDER_REV when template changes.
+ * Satori rules (same as share card): display:flex everywhere, integer px,
+ * margin-right not gap, no overflow/border-radius on tracks, no raw svg,
+ * hex colors only (no rgb() - commas break workers-og style parser),
+ * no flex-wrap (takes display:flex down with it).
  */
 import { ImageResponse } from "workers-og";
-import { OG_PROFILE_RENDER_REV } from "../_lib/og-meta";
+import { OG_RENDER_REV } from "../_lib/og-meta";
+import {
+    INK, DIM, CARD, GREEN, RED,
+    esc, statHtml, footerHtml, blockLogoHtml, compactNumber, loadOgFonts,
+} from "../_lib/og-kit";
 
-const LOGIN_RE = /^[A-Za-z0-9-]{1,39}$/;
+const LOGIN_RE = /^[A-Za-z0-9_-]{1,39}$/;
 const REPO_RAW = "https://raw.githubusercontent.com/Necmttn/ax/main";
 
-// --- color palette (paper/ink editorial, matches site CSS tokens) ---
-const PAGE  = "#f6f5f0";  // --page
-const INK   = "#0a0a0a";  // --ink
-const LINE  = "#d8d6cf";  // --line
-const MUTED = "#6b6b66";  // --muted
-const GREEN = "#2f9e44";  // --green
-
-// --- inline types (no app imports in edge functions) ---
+// ---------------------------------------------------------------------------
+// Incoming data shapes - two paths: registered gist or ?data= query stub
+// ---------------------------------------------------------------------------
 interface Registration {
     readonly github: string;
     readonly gist_id: string;
@@ -47,6 +39,15 @@ interface ProfileStats {
 
 interface ProfileInsights {
     readonly hours_total?: number;
+    readonly parallel_sessions?: number;
+    readonly longest_run_hours?: number;
+    readonly commits?: number;
+    readonly subagents_total?: number;
+}
+
+interface DailyActivity {
+    readonly date: string;
+    readonly sessions: number;
 }
 
 interface ProfileV1 {
@@ -55,118 +56,171 @@ interface ProfileV1 {
     readonly window_days: number;
     readonly stats: ProfileStats;
     readonly insights?: ProfileInsights;
+    readonly activity?: { readonly daily?: ReadonlyArray<DailyActivity> };
 }
 
-// --- compact number helpers (no Intl - not reliably available in workers) ---
-function compactNum(n: number): string {
-    if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
-    if (n >= 1_000_000)     return `${(n / 1_000_000).toFixed(1)}M`;
-    if (n >= 1_000)         return `${(n / 1_000).toFixed(1)}K`;
-    return String(Math.round(n));
+// Loose shape for the ?data= stub - all fields optional
+interface ProfileStub {
+    readonly sessions?: number;
+    readonly tokens?: number;
+    readonly estimated_spend_usd?: number | null;
+    readonly streak_days?: number;
+    readonly active_hours?: number;
+    readonly parallel_sessions?: number;
+    readonly longest_run_hours?: number;
+    readonly commits?: number;
+    readonly subagents?: number;
+    readonly activity?: { readonly daily?: ReadonlyArray<DailyActivity> };
 }
 
-function compactMoney(usd: number): string {
-    if (usd >= 1_000) return `$${(usd / 1_000).toFixed(1)}K`;
-    return `$${usd >= 100 ? usd.toFixed(0) : usd.toFixed(2)}`;
+// ---------------------------------------------------------------------------
+// Mini bar chart - 30 bars, satori-safe (margin-right not gap, fixed widths)
+// ---------------------------------------------------------------------------
+function barChartHtml(daily: ReadonlyArray<DailyActivity>): string {
+    const slice = daily.slice(-30);
+    if (slice.length === 0) return "";
+    const maxSessions = Math.max(1, ...slice.map((d) => d.sessions));
+    const busyIdx = slice.reduce((best, d, i) =>
+        d.sessions > (slice[best]?.sessions ?? 0) ? i : best, 0);
+    const BAR_H = 80; // max bar height px
+    const BAR_W = 28; // bar width px
+    const bars = slice.map((d, i) => {
+        const h = Math.max(4, Math.round((d.sessions / maxSessions) * BAR_H));
+        const color = i === busyIdx ? RED : GREEN;
+        return `<div style="display:flex;flex-direction:column;justify-content:flex-end;height:${BAR_H}px;margin-right:4px"><div style="display:flex;width:${BAR_W}px;height:${h}px;background:${color}"></div></div>`;
+    }).join("");
+    return `<div style="display:flex;flex-direction:column"><div style="display:flex;align-items:flex-end">${bars}</div><span style="font-size:13px;letter-spacing:2px;color:${DIM};margin-top:10px">DAILY SESSIONS · 30 DAYS</span></div>`;
 }
 
-const esc = (s: string): string =>
-    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-
-/** One stat cell: big mono number + small uppercase label below. */
-function statCell(value: string, label: string, accent = false): string {
-    const valueColor = accent ? GREEN : INK;
-    return `<div style="display:flex;flex-direction:column;margin-right:48px">`
-        + `<span style="font-size:52px;font-weight:700;color:${valueColor};line-height:1;letter-spacing:-2px">${esc(value)}</span>`
-        + `<span style="font-size:12px;letter-spacing:0.14em;text-transform:uppercase;color:${MUTED};margin-top:8px">${esc(label)}</span>`
-        + `</div>`;
-}
-
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
 export const onRequestGet: PagesFunction = async (ctx) => {
     const login = String(ctx.params.login ?? "").replace(/\.png$/, "");
     if (!LOGIN_RE.test(login)) {
         return new Response("bad request", { status: 400 });
     }
 
-    // Cache key includes the render revision so template bumps bust stale renders.
+    // Cache key includes render revision; bumping OG_RENDER_REV busts old renders.
     const cache = (caches as unknown as { default: Cache }).default;
     const u = new URL(ctx.request.url);
-    u.searchParams.set("r", String(OG_PROFILE_RENDER_REV));
+    u.searchParams.set("r", String(OG_RENDER_REV));
     const cacheKey = new Request(u.toString());
     const hit = await cache.match(cacheKey);
     if (hit) return hit;
 
-    // Step 1: resolve registration (login → gist_id)
-    const regRes = await fetch(
-        `${REPO_RAW}/community/users/${login.toLowerCase()}.json`,
-        { headers: { "user-agent": "ax-og-profile" } },
-    );
-    if (!regRes.ok) return new Response("not found", { status: 404 });
-    const reg = (await regRes.json()) as Registration;
-    if (typeof reg.gist_id !== "string" || typeof reg.github !== "string") {
-        return new Response("invalid registration", { status: 404 });
+    // --- Resolve profile data ---
+    // Path A: ?data= stub (local testing / preview)
+    const rawStub = u.searchParams.get("data");
+    let stub: ProfileStub | null = null;
+    if (rawStub) {
+        try { stub = JSON.parse(rawStub) as ProfileStub; } catch { /* ignore */ }
     }
 
-    // Step 2: fetch the profile gist
-    const profileRes = await fetch(
-        `https://gist.githubusercontent.com/${reg.github}/${reg.gist_id}/raw/ax-profile.json`,
-        { headers: { "user-agent": "ax-og-profile" } },
-    );
-    if (!profileRes.ok) return new Response("not found", { status: 404 });
-    const profile = (await profileRes.json()) as ProfileV1;
-    if (profile.v !== 1) return new Response("invalid profile", { status: 404 });
+    // Path B: registered gist via community/users/<login>.json
+    let gistProfile: ProfileV1 | null = null;
+    if (!stub) {
+        try {
+            const regRes = await fetch(
+                `${REPO_RAW}/community/users/${login.toLowerCase()}.json`,
+                { headers: { "user-agent": "ax-og-profile" } },
+            );
+            if (regRes.ok) {
+                const reg = (await regRes.json()) as Registration;
+                if (typeof reg.gist_id === "string" && typeof reg.github === "string") {
+                    const profileRes = await fetch(
+                        `https://gist.githubusercontent.com/${reg.github}/${reg.gist_id}/raw/ax-profile.json`,
+                        { headers: { "user-agent": "ax-og-profile" } },
+                    );
+                    if (profileRes.ok) {
+                        const p = (await profileRes.json()) as ProfileV1;
+                        if (p.v === 1) gistProfile = p;
+                    }
+                }
+            }
+        } catch { /* fallthrough to placeholder card */ }
+    }
 
-    const s = profile.stats;
-    const ins = profile.insights;
+    // --- Extract normalized fields for layout ---
+    let sessions: number | null    = null;
+    let tokens: number | null      = null;
+    let spendUsd: number | null    = null;
+    let streakDays: number | null  = null;
+    let activeHours: number | null = null;
+    let parallelSessions: number | null  = null;
+    let longestRunHours: number | null   = null;
+    let commits: number | null     = null;
+    let subagents: number | null   = null;
+    let daily: ReadonlyArray<DailyActivity> | null = null;
 
-    // Build stat row: sessions · tokens · cost? · streak · hours?
-    const statCells = [
-        statCell(String(s.sessions), "sessions"),
-        statCell(compactNum(s.tokens.total), "tokens"),
-        s.cost_usd !== undefined ? statCell(`~${compactMoney(s.cost_usd)}`, "est. spend", true) : "",
-        statCell(`${s.streak_days}d`, "streak"),
-        ins?.hours_total !== undefined ? statCell(compactNum(ins.hours_total), "hours") : "",
-    ].filter(Boolean).slice(0, 5).join("");
+    if (stub) {
+        sessions     = stub.sessions ?? null;
+        tokens       = stub.tokens ?? null;
+        spendUsd     = stub.estimated_spend_usd ?? null;
+        streakDays   = stub.streak_days ?? null;
+        activeHours  = stub.active_hours ?? null;
+        parallelSessions = stub.parallel_sessions ?? null;
+        longestRunHours  = stub.longest_run_hours ?? null;
+        commits      = stub.commits ?? null;
+        subagents    = stub.subagents ?? null;
+        daily        = stub.activity?.daily ?? null;
+    } else if (gistProfile) {
+        const s  = gistProfile.stats;
+        const ins = gistProfile.insights;
+        sessions     = s.sessions;
+        tokens       = s.tokens.total;
+        spendUsd     = s.cost_usd ?? null;
+        streakDays   = s.streak_days;
+        activeHours  = ins?.hours_total ?? null;
+        parallelSessions = ins?.parallel_sessions ?? null;
+        longestRunHours  = ins?.longest_run_hours ?? null;
+        commits      = ins?.commits ?? null;
+        subagents    = ins?.subagents_total ?? null;
+        daily        = gistProfile.activity?.daily ?? null;
+    }
 
-    // Header: kicker line above big @login
-    const header = `<div style="display:flex;justify-content:space-between;align-items:flex-start">`
-        + `<div style="display:flex;flex-direction:column">`
-        + `<span style="font-size:13px;letter-spacing:0.14em;text-transform:uppercase;color:${MUTED}">`
-        + `agent telemetry dossier · last ${profile.window_days} days`
-        + `</span>`
-        + `<span style="font-size:72px;font-weight:700;letter-spacing:-3px;color:${INK};line-height:1;margin-top:12px">`
-        + `@${esc(login)}`
-        + `</span>`
-        + `</div>`
-        + `<span style="font-size:28px;font-weight:700;color:${GREEN}">ax</span>`
-        + `</div>`;
+    // --- Build layout sections ---
 
-    // Hairline divider
-    const divider = `<div style="display:flex;height:1px;background:${LINE};margin-top:28px;margin-bottom:40px"></div>`;
+    // Header row: block logo left, kicker right
+    const logo   = blockLogoHtml({ scale: 4, color: INK, dimColor: DIM });
+    const header = `<div style="display:flex;justify-content:space-between;align-items:flex-start"><div style="display:flex">${logo}</div><span style="font-size:13px;letter-spacing:3px;color:${DIM}">AGENT TELEMETRY DOSSIER · LAST 30 DAYS</span></div>`;
 
-    // Stats row
-    const statsRow = `<div style="display:flex;align-items:flex-end">${statCells}</div>`;
+    // Big @login in Gelasio serif
+    const loginHtml = `<div style="display:flex;align-items:baseline;margin-top:12px"><span style="font-size:48px;font-weight:700;color:${DIM};font-family:'Gelasio';margin-right:4px">@</span><span style="font-size:88px;font-weight:700;color:${INK};font-family:'Gelasio';line-height:1">${esc(login)}</span></div>`;
 
-    // Footer
-    const footer = `<div style="display:flex;justify-content:space-between;align-items:center;margin-top:48px">`
-        + `<span style="font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:${MUTED}">`
-        + `compiled from local transcripts · ax.necmttn.com`
-        + `</span>`
-        + `</div>`;
+    // Stat band 1
+    const spendStr = spendUsd != null
+        ? (spendUsd >= 100 ? `$${spendUsd.toFixed(0)}` : `$${spendUsd.toFixed(2)}`)
+        : "-";
+    const statBand1 = `<div style="display:flex">${[
+        statHtml(sessions != null ? sessions.toLocaleString("en-US") : "-", "SESSIONS"),
+        statHtml(tokens  != null ? compactNumber(tokens)             : "-", "TOKENS"),
+        statHtml(spendStr,                                               "EST. SPEND", GREEN),
+        statHtml(streakDays  != null ? `${streakDays}d`             : "-", "STREAK"),
+        statHtml(activeHours != null ? `${activeHours}h`            : "-", "HOURS"),
+    ].join("")}</div>`;
 
-    // Full bleed paper card, no inner border (platforms draw their own frame).
-    // 64px safe margins keep content clear of corner clipping.
-    const html = `<div style="display:flex;flex-direction:column;width:1200px;height:630px;background:${PAGE};padding:60px 72px">`
-        + header + divider + statsRow + footer
-        + `</div>`;
+    // Filler: bar chart or second stat row (fills dead space)
+    let filler: string;
+    if (daily && daily.length > 0) {
+        filler = barChartHtml(daily);
+    } else if (parallelSessions != null || longestRunHours != null || commits != null || subagents != null) {
+        filler = `<div style="display:flex">${[
+            statHtml(parallelSessions != null ? String(parallelSessions)          : "-", "PARALLEL"),
+            statHtml(longestRunHours  != null ? `${longestRunHours}h`             : "-", "LONGEST RUN"),
+            statHtml(commits          != null ? commits.toLocaleString("en-US")   : "-", "COMMITS"),
+            statHtml(subagents        != null ? compactNumber(subagents)          : "-", "SUBAGENTS"),
+        ].join("")}</div>`;
+    } else {
+        filler = "";
+    }
 
-    // Fetch fonts in parallel to minimize latency
-    const [font, fontBold] = await Promise.all([
-        fetch("https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-400-normal.ttf")
-            .then(r => r.arrayBuffer()),
-        fetch("https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-700-normal.ttf")
-            .then(r => r.arrayBuffer()),
-    ]);
+    const footer = footerHtml("COMPILED FROM LOCAL TRANSCRIPTS");
+
+    // justify-content:space-between distributes sections across full 630px
+    const html = `<div style="display:flex;flex-direction:column;justify-content:space-between;width:1200px;height:630px;background:${CARD};padding:56px 64px;font-family:'JetBrains Mono'">${header}${loginHtml}${statBand1}${filler}${footer}</div>`;
+
+    const { regular, bold, serif } = await loadOgFonts();
 
     let png: ArrayBuffer;
     try {
@@ -174,8 +228,9 @@ export const onRequestGet: PagesFunction = async (ctx) => {
             width: 1200,
             height: 630,
             fonts: [
-                { name: "JetBrains Mono", data: font,     weight: 400, style: "normal" },
-                { name: "JetBrains Mono", data: fontBold, weight: 700, style: "normal" },
+                { name: "JetBrains Mono", data: regular, weight: 400, style: "normal" },
+                { name: "JetBrains Mono", data: bold,    weight: 700, style: "normal" },
+                { name: "Gelasio",        data: serif,   weight: 700, style: "normal" },
             ],
         });
         // Buffer the render: a lazy stream produced empty bodies on Pages.
@@ -191,7 +246,7 @@ export const onRequestGet: PagesFunction = async (ctx) => {
     const res = new Response(png, {
         headers: {
             "content-type": "image/png",
-            "cache-control": "public, max-age=86400, s-maxage=86400",
+            "cache-control": "public, max-age=3600, s-maxage=3600",
         },
     });
     ctx.waitUntil(cache.put(cacheKey, res.clone()));

--- a/apps/site/functions/og/[owner]/[gistId].ts
+++ b/apps/site/functions/og/[owner]/[gistId].ts
@@ -10,6 +10,10 @@
  */
 import { ImageResponse } from "workers-og";
 import { OG_RENDER_REV } from "../../_lib/og-meta";
+import {
+    INK, DIM, CARD, GREEN, RED, ROSE, GOLD, BLUE, VIOLET,
+    esc, fmtUsd, statHtml, footerHtml, blockLogoHtml, loadOgFonts,
+} from "../../_lib/og-kit";
 
 interface SubagentCard {
     readonly cost_usd: number | null;
@@ -38,21 +42,6 @@ interface Manifest {
     readonly subagents: ReadonlyArray<SubagentCard>;
 }
 
-const INK = "#e7e9ec";
-const DIM = "#8b93a1";
-const BG = "#15161d";
-const CARD = "#1e1f2a";
-const LINE = "#33364a";
-const GREEN = "#34d399";
-const RED = "#f87171";
-const ROSE = "#fb7185";
-const GOLD = "#fbbf24";
-const BLUE = "#60a5fa";
-const VIOLET = "#a78bfa";
-
-const esc = (s: string): string =>
-    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-
 const cleanSummary = (raw: string | undefined): string => {
     const text = (raw ?? "").replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
     return text.length > 0 ? (text.length > 110 ? `${text.slice(0, 109)}…` : text) : "Shared agent session";
@@ -64,9 +53,6 @@ const fmtDuration = (ms: number | null): string | null => {
     const m = Math.round((ms % 3_600_000) / 60_000);
     return h > 0 ? `${h}h ${m}m` : `${m}m`;
 };
-
-const fmtUsd = (n: number | null): string | null =>
-    n == null ? null : `$${n >= 100 ? n.toFixed(0) : n.toFixed(2)}`;
 
 /** Mix a hex color toward the card background (0 = card, 1 = full color). */
 function shade(hex: string, t: number): string {
@@ -129,50 +115,6 @@ function costBarHtml(m: Manifest): string {
     return `<div style="display:flex;flex-direction:column"><div style="display:flex">${segs}</div><div style="display:flex;margin-top:12px">${legend}</div></div>`;
 }
 
-/**
- * ASCII AX mark, two lines, monospace column-aligned:
- *
- *    col: 0123456
- *          /\  \/
- *         /--\ /\
- *
- * A = ` /\` over `/--\` (cols 0-3), X = `\/` over `/\` (cols 5-6). Shared by
- * the small header logo and the large ?variant=watermark background; each
- * line renders as its own div (line-stack) to avoid <pre> fragility in
- * workers-og.
- */
-const ASCII_AX_LINES = [" /\\  \\/", "/--\\ /\\"] as const;
-
-// Satori collapses runs of regular spaces under its default white-space
-// handling, which destroys column alignment. Swap every space (leading and
-// internal) for a literal non-breaking space, which satori renders as-is.
-const artLine = (line: string): string => esc(line).replace(/ /g, "\u00A0");
-
-/** Small two-line ASCII AX wordmark for the poster header. */
-function asciiLogoHtml(color: string): string {
-    const lines = ASCII_AX_LINES.map(
-        (line) =>
-            `<div style="display:flex;font-size:14px;line-height:16px;color:${color};letter-spacing:1px;font-weight:700">${artLine(line)}</div>`,
-    ).join("");
-    return `<div style="display:flex;flex-direction:column">${lines}</div>`;
-}
-
-/**
- * Large background ASCII watermark for the ?variant=watermark debug variant:
- * the same AX mark as the header, scaled up. Positioned absolutely (satori
- * supports position:absolute when the container is position:relative). Low
- * opacity so content stays readable.
- */
-function asciiWatermarkHtml(): string {
-    const lines = ASCII_AX_LINES.map(
-        (line) =>
-            `<div style="display:flex;font-size:120px;line-height:132px;color:${INK};letter-spacing:4px;font-weight:700">${artLine(line)}</div>`,
-    ).join("");
-    // Faded via an opacity wrapper on the container (not a hex alpha channel
-    // on the color) - satori applies opacity to the whole subtree.
-    return `<div style="display:flex;flex-direction:column;position:absolute;top:160px;left:120px;opacity:0.06">${lines}</div>`;
-}
-
 export const onRequestGet: PagesFunction = async (ctx) => {
     const owner = String(ctx.params.owner ?? "");
     const gistId = String(ctx.params.gistId ?? "").replace(/\.png$/, "");
@@ -203,28 +145,31 @@ export const onRequestGet: PagesFunction = async (ctx) => {
     const model = manifest.session.model ?? "";
     const date = (manifest.session.started_at ?? "").slice(0, 10);
 
-    const stat = (n: string, label: string, color: string = INK) =>
-        `<div style="display:flex;flex-direction:column;margin-right:46px;width:200px"><span style="font-size:46px;font-weight:700;color:${color}">${n}</span><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-top:2px">${label}</span></div>`;
     const statList = [
-        stat(t.turns.toLocaleString("en-US"), "TURNS"),
-        stat(t.tool_calls.toLocaleString("en-US"), "TOOL CALLS"),
-        fmtDuration(t.duration_ms) ? stat(fmtDuration(t.duration_ms)!, "WALL CLOCK") : "",
-        fmtUsd(t.cost_usd) ? stat(fmtUsd(t.cost_usd)!, "TOTAL COST", GREEN) : "",
-        t.failures > 0 ? stat(String(t.failures), "FAILED TOOL CALLS", RED) : "",
+        statHtml(t.turns.toLocaleString("en-US"), "TURNS"),
+        statHtml(t.tool_calls.toLocaleString("en-US"), "TOOL CALLS"),
+        fmtDuration(t.duration_ms) ? statHtml(fmtDuration(t.duration_ms)!, "WALL CLOCK") : "",
+        fmtUsd(t.cost_usd) ? statHtml(fmtUsd(t.cost_usd)!, "TOTAL COST", GREEN) : "",
+        t.failures > 0 ? statHtml(String(t.failures), "FAILED TOOL CALLS", RED) : "",
     ].filter(Boolean);
     // Two rows so the stat column shares the band with the fleet waffle
     // instead of running underneath it.
     const stats = `<div style="display:flex;flex-direction:column"><div style="display:flex;margin-bottom:30px">${statList.slice(0, 3).join("")}</div><div style="display:flex">${statList.slice(3).join("")}</div></div>`;
 
+    // Block logo (pixel grid) replaces the old ASCII two-liner; same header
+    // position, small scale so it fits in the 56px header band.
+    const logo = blockLogoHtml({ scale: 4, color: INK, dimColor: DIM });
+    // Watermark variant: large low-opacity block logo centered behind content.
+    const watermarkLogo = blockLogoHtml({ scale: 10, color: INK, dimColor: DIM });
+
     const blocks: Record<string, string> = {
-        // ASCII logo replaces the serif "ax" wordmark. The line-stack avoids
-        // <pre> fragility and keeps display:flex on the container intact.
-        header: `<div style="display:flex;justify-content:space-between;align-items:center"><div style="display:flex;align-items:center"><div style="display:flex;margin-right:14px">${asciiLogoHtml(INK)}</div><span style="font-size:14px;color:${DIM};letter-spacing:3px">AGENT EXPERIENCE</span></div><span style="font-size:17px;color:${DIM}">${esc([model, date].filter(Boolean).join(" · "))}</span></div>`,
+        // Block logo replaces the ASCII line-stack mark. Same position + kicker.
+        header: `<div style="display:flex;justify-content:space-between;align-items:center"><div style="display:flex;align-items:center"><div style="display:flex;margin-right:14px">${logo}</div><span style="font-size:14px;color:${DIM};letter-spacing:3px">AGENT EXPERIENCE</span></div><span style="font-size:17px;color:${DIM}">${esc([model, date].filter(Boolean).join(" · "))}</span></div>`,
         title: `<div style="display:flex;font-size:33px;line-height:1.3;color:${INK};margin-top:26px;font-weight:600">${title}</div>`,
         stats: `<div style="display:flex;margin-top:30px">${stats}</div>`,
         fleet: t.subagents > 0 ? `<div style="display:flex;flex-direction:column;align-items:flex-start;margin-top:30px"><div style="display:flex">${fleetHtml(manifest.subagents)}</div><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-top:10px">${t.subagents} SUBAGENTS · BRIGHTER = COSTLIER</span></div>` : "",
         costbar: `<div style="display:flex;margin-top:30px">${costBarHtml(manifest)}</div>`,
-        footer: `<div style="display:flex;justify-content:space-between;align-items:center;margin-top:24px"><span style="font-size:15px;letter-spacing:2px;color:${DIM}">EVERY TURN · EVERY TOOL CALL · EVERY DOLLAR</span><div style="display:flex;align-items:baseline"><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-right:10px">RECORDED WITH</span><span style="font-size:24px;color:${INK};font-weight:700;font-family:'Gelasio'">ax</span><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-left:12px">· AX.NECMTTN.COM</span></div></div>`,
+        footer: footerHtml("EVERY TURN · EVERY TOOL CALL · EVERY DOLLAR"),
     };
     const probe = u.searchParams.get("probe");
     // Full layout: stats column left, fleet right, then the cost bar; probe
@@ -233,28 +178,20 @@ export const onRequestGet: PagesFunction = async (ctx) => {
     const inner = probe
         ? probe.split(",").filter((k) => k in blocks).map((k) => blocks[k]).join("")
         : `${blocks.header}${blocks.title}${mid}${blocks.costbar}${blocks.footer}`;
-    // ?variant=watermark: inject a large low-opacity ASCII background mark for
+    // ?variant=watermark: inject a large low-opacity block logo background mark for
     // iterating on the treatment without making it the default social card.
     // position:relative on the outer container lets the absolute child render
     // behind the content stack. Never active by default.
-    const watermark = variant === "watermark" ? asciiWatermarkHtml() : "";
+    const watermark = variant === "watermark"
+        ? `<div style="display:flex;flex-direction:column;position:absolute;top:100px;left:80px;opacity:0.06">${watermarkLogo}</div>`
+        : "";
     // Full bleed, no border: the platform rendering the preview (X / Slack /
     // Discord) draws its own frame + rounded corners - an inner border reads
     // as a nested double-frame. 64px safe margins keep content clear of the
     // platforms' corner clipping (GitHub-card convention).
     const html = `<div style="display:flex;flex-direction:column;position:relative;width:1200px;height:630px;background:${CARD};padding:56px 64px;font-family:'JetBrains Mono'">${watermark}${inner}</div>`;
 
-    const font = await fetch(
-        "https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-400-normal.ttf",
-    ).then((r) => r.arrayBuffer());
-    const fontBold = await fetch(
-        "https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono@latest/latin-700-normal.ttf",
-    ).then((r) => r.arrayBuffer());
-    // Brand wordmark serif - Gelasio is metric-compatible with Georgia (the
-    // site's wordmark face), which is not licensable for embedding.
-    const fontSerif = await fetch(
-        "https://cdn.jsdelivr.net/fontsource/fonts/gelasio@latest/latin-700-normal.ttf",
-    ).then((r) => r.arrayBuffer());
+    const { regular, bold, serif } = await loadOgFonts();
 
     let png: ArrayBuffer;
     try {
@@ -262,9 +199,9 @@ export const onRequestGet: PagesFunction = async (ctx) => {
             width: 1200,
             height: 630,
             fonts: [
-                { name: "JetBrains Mono", data: font, weight: 400, style: "normal" },
-                { name: "JetBrains Mono", data: fontBold, weight: 700, style: "normal" },
-                { name: "Gelasio", data: fontSerif, weight: 700, style: "normal" },
+                { name: "JetBrains Mono", data: regular, weight: 400, style: "normal" },
+                { name: "JetBrains Mono", data: bold, weight: 700, style: "normal" },
+                { name: "Gelasio", data: serif, weight: 700, style: "normal" },
             ],
         });
         // Buffer the render: a lazy stream produced empty bodies on Pages, and


### PR DESCRIPTION
## Summary
- **`_lib/og-kit.ts`** — shared OG component kit extracted from the share card: palette constants, esc/artLine, fmtUsd/compactNumber (now with B tier) /compactUsd (`~$22.9K`), `statHtml`, `footerHtml`, `loadOgFonts`, and **`blockLogoHtml`** — the install-script ANSI-shadow AX mark rendered as a satori-safe div pixel grid (`█` → ink, shadow chars → dim; latin font subsets carry no block glyphs, so text rendering was impossible). 22 unit tests.
- **Share card** refactored onto the kit; the small two-line `/\` mark and watermark both replaced with the canonical block logo — one AX mark everywhere (install script, both OG cards).
- **Profile card redesigned** — dense, fills all 630px, matches the share-card family: dark `#1e1f2a`, block logo + dossier kicker header, 88px serif `@login`, humanized stat band (2,024 / 19.6B / **~$22.9K** / 6d / 2.3K), 30-day activity bar strip with the busiest day in red, standard "RECORDED WITH ax" footer.
- `OG_RENDER_REV` 7→8 busts social caches.

## Test Plan
- [x] 57 site tests green (og-kit 22 + og-meta + community lib)
- [x] `wrangler pages functions build` from repo root: compiled successfully (the PR #335 failure mode)
- [x] Local `wrangler pages dev` render verified against the real gist (screenshot reviewed: dense, humanized, block logo)
- [ ] Post-merge: `/og-profile/necmttn` PNG on production + share-card render spot check

🤖 Generated with [Claude Code](https://claude.com/claude-code)