### PR TITLE
feat(improve): agent write-path - ax improve propose/analyze + origin badges (PR3)

### DIFF
--- a/apps/axctl/src/cli/commands/improve.ts
+++ b/apps/axctl/src/cli/commands/improve.ts
@@ -639,11 +639,9 @@ const cmdImproveAnalyze = (input: { readonly force: boolean }) =>
             console.log(`already exists: ${path} (re-run with --force to overwrite)`);
             return;
         }
-        yield* Effect.tryPromise(async () => {
-            const { mkdir } = await import("node:fs/promises");
-            await mkdir(dir, { recursive: true });
-            await Bun.write(path, renderAnalyzeBrief({ date }));
-        });
+        // Bun.write creates parent directories itself - no fs import needed
+        // (repo gate: check:no-node-fs).
+        yield* Effect.tryPromise(() => Bun.write(path, renderAnalyzeBrief({ date })));
         console.log(`analysis brief written: ${path}`);
         console.log("hand it to an agent session; findings come back via `ax improve propose`");
     });

--- a/apps/axctl/src/cli/commands/improve.ts
+++ b/apps/axctl/src/cli/commands/improve.ts
@@ -13,6 +13,8 @@ import { lintFiles } from "../../improve/lint.ts";
 import { listProposals, type ProposalRow } from "../../improve/list.ts";
 import { recommend, formatRecommendations, copyToClipboard, selectByIndices, parseIndexInput } from "../../improve/recommend.ts";
 import { showExperiment, formatShow } from "../../improve/show.ts";
+import { renderAnalyzeBrief } from "../../improve/analyze-brief.ts";
+import { runPropose } from "../../improve/propose.ts";
 import { buildImproveProposalsNext } from "../../nav/next-links.ts";
 import { printNextLinks } from "../next-format.ts";
 import type { RuntimeManifest } from "./manifest.ts";
@@ -600,6 +602,60 @@ const improveCheckpointCommand = Command.make(
     ({ force, json }) => cmdImproveCheckpoint({ force, json }),
 ).pipe(Command.withDescription("Compute checkpoint snapshots at +3/+10/+30 sessions for active experiments (session-count windows, not calendar days - see issue #83)"));
 
+const cmdImprovePropose = (input: { readonly file: string | undefined; readonly json: boolean }) =>
+    Effect.gen(function* () {
+        const raw = input.file !== undefined
+            ? yield* Effect.tryPromise(() => Bun.file(input.file as string).text())
+            : yield* Effect.tryPromise(() => Bun.stdin.text());
+        const parsed = yield* Effect.try({
+            try: () => JSON.parse(raw) as unknown,
+            catch: (err) => new Error(`invalid JSON on ${input.file ? input.file : "stdin"}: ${err instanceof Error ? err.message : String(err)}`),
+        });
+        const result = yield* runPropose(parsed);
+        if (input.json) {
+            console.log(JSON.stringify(result));
+        } else {
+            console.log(`${result.status}: ${result.form} proposal "${result.title}" (sig=${result.sig})`);
+            console.log("next: ax improve list - or review it in the dashboard Improve tab");
+        }
+    });
+
+const improveProposeCommand = Command.make(
+    "propose",
+    {
+        file: Flag.string("file").pipe(Flag.optional),
+        json: jsonFlag,
+    },
+    ({ file, json }) => cmdImprovePropose({ file: optionValue(file), json }),
+).pipe(Command.withDescription("Agent write-path: read one proposal as JSON (stdin or --file), validate, and insert it with origin 'agent'. Same title bumps frequency instead of duplicating."));
+
+const cmdImproveAnalyze = (input: { readonly force: boolean }) =>
+    Effect.gen(function* () {
+        const date = new Date().toISOString().slice(0, 10);
+        const dir = ".ax/tasks";
+        const path = `${dir}/analyze-improve-${date}.md`;
+        const exists = yield* Effect.tryPromise(() => Bun.file(path).exists());
+        if (exists && !input.force) {
+            console.log(`already exists: ${path} (re-run with --force to overwrite)`);
+            return;
+        }
+        yield* Effect.tryPromise(async () => {
+            const { mkdir } = await import("node:fs/promises");
+            await mkdir(dir, { recursive: true });
+            await Bun.write(path, renderAnalyzeBrief({ date }));
+        });
+        console.log(`analysis brief written: ${path}`);
+        console.log("hand it to an agent session; findings come back via `ax improve propose`");
+    });
+
+const improveAnalyzeCommand = Command.make(
+    "analyze",
+    {
+        force: Flag.boolean("force").pipe(Flag.withDefault(false)),
+    },
+    ({ force }) => cmdImproveAnalyze({ force }),
+).pipe(Command.withDescription("Emit .ax/tasks/analyze-improve-<date>.md - a deep-analysis brief instructing an agent to mine the graph and write proposals back via `ax improve propose`."));
+
 export const improveCommand = Command.make("improve").pipe(
     Command.withDescription("Experiment loop: rank proposals (recommend), accept (emit task brief or scaffold + dispatch subagent), lint grounded agent files, track verdicts at +3/+10/+30 sessions after accept."),
     Command.withSubcommands([
@@ -612,6 +668,8 @@ export const improveCommand = Command.make("improve").pipe(
         improveCheckpointCommand,
         improveVerdictCommand,
         improveResetCommand,
+        improveProposeCommand,
+        improveAnalyzeCommand,
     ]),
 );
 

--- a/apps/axctl/src/dashboard/capabilities.ts
+++ b/apps/axctl/src/dashboard/capabilities.ts
@@ -26,6 +26,7 @@ export const baseApiCapabilities = [
     "wrapped",     // /api/wrapped + public-preview
     "improve",     // /api/improve + accept/reject/verdict
     "next-actions", // /api/next-actions ranked action cards + agent briefs
+    "improve-analyze", // GET /api/improve/analyze-brief - deep-analysis brief for agents
     "events",      // /api/events (SSE)
     "ingest",      // POST /api/ingest -> { runId, stream } + Durable Streams sidecar
     "image",       // GET /api/image?path= -> local on-disk image bytes

--- a/apps/axctl/src/dashboard/contract/improve.ts
+++ b/apps/axctl/src/dashboard/contract/improve.ts
@@ -19,6 +19,7 @@ import {
 } from "@ax/lib/shared/api-contract";
 import { fetchImproveProposals } from "../improve-proposals.ts";
 import { fetchNextActionsCached, invalidateNextActionsCache } from "../read-caches.ts";
+import { renderAnalyzeBrief } from "../../improve/analyze-brief.ts";
 import { asJsonValue, internal, orInternal } from "./common.ts";
 
 interface ImproveActionResult { readonly status: string; readonly message?: string }
@@ -51,6 +52,10 @@ export const ImproveGroupLive = HttpApiBuilder.group(AxApi, "improve", (handlers
                 Effect.map((proposals) => asJsonValue({ proposals })),
             )))
         .handle("nextActions", () => orInternal(fetchNextActionsCached()))
+        .handle("analyzeBrief", () =>
+            Effect.sync(() => ({
+                brief: renderAnalyzeBrief({ date: new Date().toISOString().slice(0, 10) }),
+            })))
         .handle("improveAction", ({ params, payload }) =>
             Effect.gen(function* () {
                 if (params.action !== "accept" && params.action !== "reject" && params.action !== "verdict") {

--- a/apps/axctl/src/dashboard/contract/skills-improve.test.ts
+++ b/apps/axctl/src/dashboard/contract/skills-improve.test.ts
@@ -34,6 +34,7 @@ describe("isContractRequest - skills/improve/live routing", () => {
         expect(isContractRequest("GET", "/api/skills")).toBe(true);
         expect(isContractRequest("POST", "/api/skills/decide-bulk")).toBe(true);
         expect(isContractRequest("GET", "/api/improve")).toBe(true);
+        expect(isContractRequest("GET", "/api/improve/analyze-brief")).toBe(true);
         expect(isContractRequest("POST", "/api/ingest")).toBe(true);
     });
 

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -68,6 +68,7 @@ const CONTRACT_ROUTES: ReadonlySet<string> = new Set([
     // improve
     "GET /api/improve",
     "GET /api/next-actions",
+    "GET /api/improve/analyze-brief",
     // live (SSE /api/events + binary /api/image stay raw legacy routes)
     "POST /api/ingest",
     // docs

--- a/apps/axctl/src/dashboard/improve-proposals.test.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.test.ts
@@ -93,6 +93,16 @@ describe("fetchImproveProposals - brief attachment", () => {
         expect(brief).not.toContain("ax improve accept");
     });
 
+    it("coalesces missing origin to mined; preserves explicit agent", async () => {
+        const rows = await run(
+            fetchImproveProposals(),
+            makeMockDb([[openRow, { ...openRow, dedupe_sig: "sig-agent", origin: "agent" }]]),
+        ) as ReadonlyArray<ProposalDto>;
+
+        expect(rows[0]?.origin).toBe("mined");
+        expect(rows[1]?.origin).toBe("agent");
+    });
+
     it("returns empty array for empty DB result", async () => {
         const rows = await run(
             fetchImproveProposals(),

--- a/apps/axctl/src/dashboard/improve-proposals.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.ts
@@ -8,7 +8,7 @@ import { renderAgentBrief } from "./agent-brief.ts";
 // See docs/superpowers/plans/2026-05-25-experiment-loop-cleanup-and-rebuild.md
 // (Phase C10). Moved verbatim from server.ts queryApi (166-182).
 const PROPOSALS_SQL = `
-SELECT id, form, title, hypothesis, dedupe_sig, frequency, confidence, status, reject_reason,
+SELECT id, form, title, hypothesis, dedupe_sig, frequency, confidence, status, origin, reject_reason,
     type::string(created_at) AS created_at,
     (SELECT trigger_pattern, suspected_gap, proposed_behavior, expected_impact FROM skill_proposal      WHERE proposal = $parent.id LIMIT 1)[0] AS skill_payload,
     (SELECT bounded_role, delegation_trigger, example_task_patterns FROM subagent_proposal   WHERE proposal = $parent.id LIMIT 1)[0] AS subagent_payload,
@@ -36,6 +36,8 @@ export const proposalReviewBrief = (p: ProposalDto): string =>
 
 const withBrief = (p: ProposalDto): ProposalDto => ({
     ...p,
+    // Rows created before the origin field exist read NONE.
+    origin: p.origin ?? "mined",
     brief:
         p.status === "open"
             ? proposalReviewBrief(p)

--- a/apps/axctl/src/dashboard/next-actions.ts
+++ b/apps/axctl/src/dashboard/next-actions.ts
@@ -77,7 +77,8 @@ export const proposalCards = (
                     kind: "proposal",
                     title: `Decide proposal: ${p.title}`,
                     evidence: `${p.form} proposal, confidence ${p.confidence}, seen ${p.frequency}x`,
-                    impact: KIND_WEIGHT.proposal + bonus(cw * Math.log2(p.frequency + 1)),
+                    // agent-origin proposals outrank mined ones at equal confidence x frequency
+                    impact: KIND_WEIGHT.proposal + bonus(cw * Math.log2(p.frequency + 1) + ((p.origin ?? "mined") === "agent" ? 1 : 0)),
                     brief: proposalReviewBrief(p),
                     link: null,
                     inline_action: {

--- a/apps/axctl/src/improve/analyze-brief.test.ts
+++ b/apps/axctl/src/improve/analyze-brief.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { renderAnalyzeBrief } from "./analyze-brief.ts";
+
+describe("renderAnalyzeBrief", () => {
+    const brief = renderAnalyzeBrief({ date: "2026-06-12" });
+
+    test("teaches the write-back command", () => {
+        expect(brief).toContain("ax improve propose");
+        expect(brief).toContain("echo '<json>'");
+    });
+
+    test("documents all five forms and their payloads", () => {
+        for (const form of ["guidance", "skill", "hook", "subagent", "automation"]) {
+            expect(brief).toContain(`**${form}**`);
+        }
+        expect(brief).toContain("trigger_pattern");
+        expect(brief).toContain("file_target");
+        expect(brief).toContain("bounded_role");
+        expect(brief).toContain("event_name");
+        expect(brief).toContain("trigger_signal");
+    });
+
+    test("requires evidence and names the mining commands", () => {
+        expect(brief).toContain("MUST carry evidence");
+        expect(brief).toContain("ax sessions churn");
+        expect(brief).toContain("ax dispatches --candidates");
+        expect(brief).toContain("ax recall");
+        expect(brief).toContain("ax improve list");
+    });
+
+    test("stamps the date", () => {
+        expect(brief).toContain("2026-06-12");
+    });
+});

--- a/apps/axctl/src/improve/analyze-brief.ts
+++ b/apps/axctl/src/improve/analyze-brief.ts
@@ -1,0 +1,68 @@
+/**
+ * The deep-analysis brief - `ax improve analyze` writes it to
+ * `.ax/tasks/`, the dashboard's "Copy analysis brief" button serves it via
+ * GET /api/improve/analyze-brief. An agent session works the brief and
+ * writes its findings back through `ax improve propose`, which lands them
+ * in the improve loop with `origin: "agent"`.
+ */
+
+export interface AnalyzeBriefInput {
+    /** ISO date stamp for the brief heading (YYYY-MM-DD). */
+    readonly date: string;
+}
+
+export const renderAnalyzeBrief = ({ date }: AnalyzeBriefInput): string =>
+    `## Task: Deep-analysis pass over the ax graph (${date})
+
+You are an analysis agent with access to the \`ax\` CLI. Mine the telemetry
+graph for durable improvement opportunities and write each one back as a
+proposal. Mechanical signal-mining already exists - your value is depth:
+connect evidence across sources, name root causes, propose the smallest
+durable fix.
+
+**Mine (read-only):**
+- \`ax sessions churn --since=30\` - repair-heavy sessions, failed checks, episodes
+- \`ax dispatches --candidates --days=30\` - misrouted expensive dispatches
+- \`ax recall <query>\` - cross-source search when you need context on a pattern
+- \`ax skills weighted\` / \`ax skills classify --dry-run\` - skill usage vs hygiene
+- \`ax improve list\` - what the loop already knows (do NOT duplicate open proposals)
+- the ax MCP tools (recall, sessions_around, session_show, ...) if connected
+
+**Write back - one proposal per durable pattern:**
+
+\`\`\`bash
+echo '<json>' | ax improve propose
+\`\`\`
+
+JSON shape (\`form\` selects the payload):
+
+\`\`\`json
+{
+  "form": "guidance | skill | hook | subagent | automation",
+  "title": "imperative, specific",
+  "hypothesis": "what keeps happening + why this fixes it",
+  "confidence": "high | medium | low",
+  "frequency": 3,
+  "evidence": "session ids, sigs, $ amounts - concrete refs",
+  "payload": { ... }
+}
+\`\`\`
+
+Payloads:
+- **guidance**: { "file_target": "CLAUDE.md", "section"?, "suggested_text" }
+- **skill**: { "trigger_pattern", "suspected_gap", "proposed_behavior", "expected_impact"? }
+- **hook**: { "event_name", "target_tool"?, "hook_command", "recovery_path"?, "smoke_test_command"?, "disable_command"?, "failure_mode"? ("fail_open"|"fail_closed") }
+- **subagent**: { "bounded_role", "delegation_trigger", "example_task_patterns"? }
+- **automation**: { "trigger_signal", "schedule"?, "action", ...same safety fields as hook }
+
+**Rules:**
+- Every proposal MUST carry evidence refs (session ids / dedupe sigs / failure counts / $).
+- Re-proposing an existing pattern is fine - same title bumps its frequency instead of duplicating.
+- Prefer guidance/skill forms unless a deterministic guard is clearly needed (then hook).
+- 3-7 strong proposals beat 20 weak ones.
+
+**Verify:** \`ax improve list\` shows your proposals; the dashboard Improve tab
+ranks them with an "agent" badge.
+
+_source: ax improve analyze ${date}_
+`;

--- a/apps/axctl/src/improve/propose.test.ts
+++ b/apps/axctl/src/improve/propose.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import {
+    buildProposeStatements,
+    decodeProposeInput,
+    runPropose,
+    type ProposeInput,
+} from "./propose.ts";
+
+const guidanceInput: ProposeInput = {
+    form: "guidance",
+    title: "Always run typecheck before commit",
+    hypothesis: "5 sessions repaired type errors post-commit",
+    confidence: "high",
+    evidence: "sessions: 01ja, 01jb",
+    payload: {
+        file_target: "CLAUDE.md",
+        suggested_text: "Run `bun run typecheck` before every commit.",
+    },
+};
+
+describe("decodeProposeInput", () => {
+    test("accepts a valid guidance proposal", async () => {
+        const decoded = await Effect.runPromise(decodeProposeInput(guidanceInput));
+        expect(decoded.form).toBe("guidance");
+    });
+
+    test("rejects unknown form", async () => {
+        const bad = { ...guidanceInput, form: "wish" };
+        await expect(Effect.runPromise(decodeProposeInput(bad))).rejects.toThrow();
+    });
+
+    test("rejects missing payload field", async () => {
+        const bad = {
+            ...guidanceInput,
+            payload: { file_target: "CLAUDE.md" },
+        };
+        await expect(Effect.runPromise(decodeProposeInput(bad))).rejects.toThrow();
+    });
+
+    test("rejects bad confidence", async () => {
+        const bad = { ...guidanceInput, confidence: "certain" };
+        await expect(Effect.runPromise(decodeProposeInput(bad))).rejects.toThrow();
+    });
+});
+
+describe("buildProposeStatements", () => {
+    test("fresh sig: CREATE with origin agent + payload UPSERT", () => {
+        const stmts = buildProposeStatements(guidanceInput, "guidance__abc123", true);
+        expect(stmts).toHaveLength(2);
+        expect(stmts[0]).toContain("CREATE proposal:");
+        expect(stmts[0]).toContain('origin: "agent"');
+        expect(stmts[0]).toContain('status: "open"');
+        expect(stmts[0]).toContain('dedupe_sig: "guidance__abc123"');
+        expect(stmts[1]).toContain("UPSERT guidance_proposal:");
+        expect(stmts[1]).toContain("suggested_text:");
+    });
+
+    test("existing sig: frequency bump, no CREATE, payload still upserted", () => {
+        const stmts = buildProposeStatements(guidanceInput, "guidance__abc123", false);
+        expect(stmts).toHaveLength(2);
+        expect(stmts[0]).toContain("UPDATE proposal SET");
+        expect(stmts[0]).toContain("frequency = frequency + 1");
+        expect(stmts[0]).toContain('WHERE dedupe_sig = "guidance__abc123"');
+        expect(stmts[0]).not.toContain("CREATE");
+        expect(stmts[1]).toContain("UPSERT guidance_proposal:");
+    });
+
+    test("skill form writes skill_proposal payload", () => {
+        const input: ProposeInput = {
+            form: "skill",
+            title: "Batch reads",
+            hypothesis: "h",
+            confidence: "medium",
+            payload: {
+                trigger_pattern: "multi-file feature work",
+                suspected_gap: "sequential reads",
+                proposed_behavior: "batch upfront",
+            },
+        };
+        const stmts = buildProposeStatements(input, "skill__def", true);
+        expect(stmts[1]).toContain("UPSERT skill_proposal:");
+        expect(stmts[1]).toContain('trigger_pattern: "multi-file feature work"');
+    });
+});
+
+describe("runPropose", () => {
+    const makeDb = (existingRows: Array<{ id: string }>, log: string[]) => {
+        const stub: SurrealClientShape = {
+            query: (sql: string) => {
+                log.push(sql);
+                return Effect.succeed(
+                    sql.startsWith("SELECT id FROM proposal")
+                        ? [existingRows]
+                        : [[]],
+                );
+            },
+        } as unknown as SurrealClientShape;
+        return Layer.succeed(SurrealClient, stub);
+    };
+
+    test("fresh proposal: status created, CREATE executed", async () => {
+        const log: string[] = [];
+        const res = await Effect.runPromise(
+            runPropose(guidanceInput).pipe(Effect.provide(makeDb([], log))),
+        );
+        expect(res.status).toBe("created");
+        expect(res.sig.startsWith("guidance__")).toBe(true);
+        expect(log.some((s) => s.startsWith("CREATE proposal:"))).toBe(true);
+    });
+
+    test("existing sig: status bumped, UPDATE executed", async () => {
+        const log: string[] = [];
+        const res = await Effect.runPromise(
+            runPropose(guidanceInput).pipe(
+                Effect.provide(makeDb([{ id: "proposal:x" }], log)),
+            ),
+        );
+        expect(res.status).toBe("bumped");
+        expect(log.some((s) => s.startsWith("UPDATE proposal SET"))).toBe(true);
+        expect(log.some((s) => s.startsWith("CREATE proposal:"))).toBe(false);
+    });
+});

--- a/apps/axctl/src/improve/propose.ts
+++ b/apps/axctl/src/improve/propose.ts
@@ -1,0 +1,221 @@
+import { Effect, Schema } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import {
+    recordRef,
+    surrealObject,
+    surrealOptionString,
+    surrealString,
+} from "@ax/lib/shared/surql";
+import { dedupeSig, normalizeTitle } from "../ingest/derive-proposals.ts";
+
+/**
+ * `ax improve propose` - the agent write-path into the improve loop.
+ *
+ * An analysis agent (see analyze-brief.ts) mines the graph and emits one
+ * JSON proposal per durable pattern; this module validates it, dedupes by
+ * `dedupe_sig(form, normalized title)`, and writes:
+ *   - fresh sig    -> CREATE proposal with origin 'agent' + status 'open'
+ *   - existing sig -> frequency bump + hypothesis/confidence refresh
+ * The per-form payload row is UPSERT-ed in both paths (mirrors the retro
+ * derivation writer in ingest/derive-retro-proposals.ts).
+ */
+
+const common = {
+    title: Schema.String,
+    hypothesis: Schema.String,
+    confidence: Schema.Literals(["high", "medium", "low"]),
+    frequency: Schema.optional(Schema.Int),
+    evidence: Schema.optional(Schema.String),
+};
+
+const SkillPayload = Schema.Struct({
+    trigger_pattern: Schema.String,
+    suspected_gap: Schema.String,
+    proposed_behavior: Schema.String,
+    expected_impact: Schema.optional(Schema.String),
+});
+
+const SubagentPayload = Schema.Struct({
+    bounded_role: Schema.String,
+    delegation_trigger: Schema.String,
+    example_task_patterns: Schema.optional(Schema.Array(Schema.String)),
+});
+
+const safety = {
+    recovery_path: Schema.optional(Schema.String),
+    smoke_test_command: Schema.optional(Schema.String),
+    disable_command: Schema.optional(Schema.String),
+    failure_mode: Schema.optional(Schema.Literals(["fail_open", "fail_closed"])),
+};
+
+const HookPayload = Schema.Struct({
+    event_name: Schema.String,
+    target_tool: Schema.optional(Schema.String),
+    hook_command: Schema.String,
+    ...safety,
+});
+
+const GuidancePayload = Schema.Struct({
+    file_target: Schema.String,
+    section: Schema.optional(Schema.String),
+    suggested_text: Schema.String,
+});
+
+const AutomationPayload = Schema.Struct({
+    trigger_signal: Schema.String,
+    schedule: Schema.optional(Schema.String),
+    action: Schema.String,
+    ...safety,
+});
+
+export const ProposeInputSchema = Schema.Union([
+    Schema.Struct({ form: Schema.Literal("skill"), ...common, payload: SkillPayload }),
+    Schema.Struct({ form: Schema.Literal("subagent"), ...common, payload: SubagentPayload }),
+    Schema.Struct({ form: Schema.Literal("hook"), ...common, payload: HookPayload }),
+    Schema.Struct({ form: Schema.Literal("guidance"), ...common, payload: GuidancePayload }),
+    Schema.Struct({ form: Schema.Literal("automation"), ...common, payload: AutomationPayload }),
+]);
+
+export type ProposeInput = typeof ProposeInputSchema.Type;
+
+export interface ProposeResult {
+    readonly status: "created" | "bumped";
+    readonly sig: string;
+    readonly form: ProposeInput["form"];
+    readonly title: string;
+}
+
+/** Stable record key derived from the sig - same row on re-propose. */
+const proposalKey = (sig: string): string => `agent__${sig}`;
+
+const PAYLOAD_TABLE: Record<ProposeInput["form"], string> = {
+    skill: "skill_proposal",
+    subagent: "subagent_proposal",
+    hook: "hook_proposal",
+    guidance: "guidance_proposal",
+    automation: "automation_proposal",
+};
+
+const opt = (v: string | undefined): string => surrealOptionString(v ?? null);
+
+const payloadFields = (input: ProposeInput): ReadonlyArray<readonly [string, string]> => {
+    switch (input.form) {
+        case "skill":
+            return [
+                ["trigger_pattern", surrealString(input.payload.trigger_pattern)],
+                ["suspected_gap", surrealString(input.payload.suspected_gap)],
+                ["proposed_behavior", surrealString(input.payload.proposed_behavior)],
+                ["expected_impact", opt(input.payload.expected_impact)],
+            ];
+        case "subagent":
+            return [
+                ["bounded_role", surrealString(input.payload.bounded_role)],
+                ["delegation_trigger", surrealString(input.payload.delegation_trigger)],
+                [
+                    "example_task_patterns",
+                    `[${(input.payload.example_task_patterns ?? []).map(surrealString).join(", ")}]`,
+                ],
+            ];
+        case "hook":
+            return [
+                ["event_name", surrealString(input.payload.event_name)],
+                ["target_tool", opt(input.payload.target_tool)],
+                ["hook_command", surrealString(input.payload.hook_command)],
+                ["recovery_path", opt(input.payload.recovery_path)],
+                ["smoke_test_command", opt(input.payload.smoke_test_command)],
+                ["disable_command", opt(input.payload.disable_command)],
+                ["failure_mode", opt(input.payload.failure_mode)],
+            ];
+        case "guidance":
+            return [
+                ["file_target", surrealString(input.payload.file_target)],
+                ["section", opt(input.payload.section)],
+                ["suggested_text", surrealString(input.payload.suggested_text)],
+            ];
+        case "automation":
+            return [
+                ["trigger_signal", surrealString(input.payload.trigger_signal)],
+                ["schedule", opt(input.payload.schedule)],
+                ["action", surrealString(input.payload.action)],
+                ["recovery_path", opt(input.payload.recovery_path)],
+                ["smoke_test_command", opt(input.payload.smoke_test_command)],
+                ["disable_command", opt(input.payload.disable_command)],
+                ["failure_mode", opt(input.payload.failure_mode)],
+            ];
+    }
+};
+
+/** Pure statement builder - testable without a DB. */
+export const buildProposeStatements = (
+    input: ProposeInput,
+    sig: string,
+    isNew: boolean,
+): string[] => {
+    const key = proposalKey(sig);
+    const proposalRef = recordRef("proposal", key);
+    const payloadRef = recordRef(PAYLOAD_TABLE[input.form], key);
+    const frequency = input.frequency ?? 1;
+    const baseline = JSON.stringify({
+        origin: "agent",
+        evidence: input.evidence ?? null,
+        frequency,
+    });
+
+    const stmts: string[] = [];
+    if (isNew) {
+        stmts.push(
+            `CREATE ${proposalRef} CONTENT ${surrealObject([
+                ["form", surrealString(input.form)],
+                ["title", surrealString(input.title)],
+                ["hypothesis", surrealString(input.hypothesis)],
+                ["dedupe_sig", surrealString(sig)],
+                ["frequency", String(frequency)],
+                ["confidence", surrealString(input.confidence)],
+                ["status", surrealString("open")],
+                ["origin", surrealString("agent")],
+                ["baseline", surrealOptionString(baseline)],
+                ["updated_at", "time::now()"],
+            ])};`,
+        );
+    } else {
+        stmts.push(
+            `UPDATE proposal SET ${[
+                ["hypothesis", surrealString(input.hypothesis)],
+                ["frequency", "frequency + 1"],
+                ["confidence", surrealString(input.confidence)],
+                ["updated_at", "time::now()"],
+            ]
+                .map(([name, value]) => `${name} = ${value}`)
+                .join(", ")} WHERE dedupe_sig = ${surrealString(sig)};`,
+        );
+    }
+    stmts.push(
+        `UPSERT ${payloadRef} MERGE ${surrealObject([
+            ["proposal", proposalRef],
+            ...payloadFields(input),
+        ])};`,
+    );
+    return stmts;
+};
+
+export const decodeProposeInput = (raw: unknown) =>
+    Schema.decodeUnknownEffect(ProposeInputSchema)(raw);
+
+export const runPropose = Effect.fn("improve.runPropose")(function* (raw: unknown) {
+    const input = yield* decodeProposeInput(raw);
+    const sig = dedupeSig(input.form, normalizeTitle(input.title));
+    const db = yield* SurrealClient;
+    const existing = yield* db.query<[Array<{ id: unknown }>]>(
+        `SELECT id FROM proposal WHERE dedupe_sig = ${surrealString(sig)} LIMIT 1;`,
+    );
+    const isNew = (existing[0] ?? []).length === 0;
+    for (const stmt of buildProposeStatements(input, sig, isNew)) {
+        yield* db.query(stmt);
+    }
+    return {
+        status: isNew ? "created" : "bumped",
+        sig,
+        form: input.form,
+        title: input.title,
+    } satisfies ProposeResult;
+});

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -433,6 +433,9 @@ export const api = {
     nextActions: (): Promise<NextActionsPayload> =>
         viaContract("/api/next-actions", (c) => c.improve.nextActions()),
 
+    improveAnalyzeBrief: (): Promise<{ brief: string }> =>
+        jsonFetch("/api/improve/analyze-brief"),
+
     /** Read-only SQL console (Lab) - daemon accepts SELECT/RETURN/INFO only. */
     query: (sql: string): Promise<{ result: unknown; durationMs: number }> =>
         viaContract(

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -434,7 +434,7 @@ export const api = {
         viaContract("/api/next-actions", (c) => c.improve.nextActions()),
 
     improveAnalyzeBrief: (): Promise<{ brief: string }> =>
-        jsonFetch("/api/improve/analyze-brief"),
+        viaContract("/api/improve/analyze-brief", (c) => c.improve.analyzeBrief()),
 
     /** Read-only SQL console (Lab) - daemon accepts SELECT/RETURN/INFO only. */
     query: (sql: string): Promise<{ result: unknown; durationMs: number }> =>

--- a/apps/studio/src/mock-fixtures.ts
+++ b/apps/studio/src/mock-fixtures.ts
@@ -364,6 +364,10 @@ export async function mockFetch<T>(input: RequestInfo, init?: RequestInit): Prom
     if (path.startsWith("/api/recall")) return EMPTY_RECALL as unknown as T;
     if (path === "/api/wrapped" || path === "/api/wrapped/public-preview") return EMPTY_WRAPPED as unknown as T;
 
+    if (path === "/api/improve/analyze-brief") {
+        return { brief: "## Task: Deep-analysis pass (mock)\n\nConnect a local daemon for the real brief." } as unknown as T;
+    }
+
     // Lab SQL console
     if (path === "/api/query" && method === "POST") {
         return {

--- a/apps/studio/src/routes/improve.tsx
+++ b/apps/studio/src/routes/improve.tsx
@@ -23,7 +23,10 @@ const VERDICTS: ReadonlyArray<string> = [
     "adopted", "ignored", "regressed", "partial", "no_longer_needed",
 ];
 const CONF_W: Record<string, number> = { high: 3, medium: 2, low: 1 };
-const score = (p: ProposalDto) => (CONF_W[p.confidence] ?? 1) * Math.log2(p.frequency + 1);
+const score = (p: ProposalDto) =>
+    (CONF_W[p.confidence] ?? 1) * Math.log2(p.frequency + 1) +
+    // agent-origin tiebreak above mined at equal confidence x frequency
+    ((p.origin ?? "mined") === "agent" ? 0.5 : 0);
 
 export function ImproveRoute() {
     const queryClient = useQueryClient();
@@ -95,6 +98,7 @@ export function ImproveRoute() {
                 <span className="meta">
                     {proposals.length} proposals · {filtered.length} shown
                 </span>
+                <AnalysisBriefButton />
             </header>
 
             <NextActionsPanel handlers={{
@@ -168,7 +172,12 @@ export function ImproveRoute() {
                                         : <span className="meta">-</span>}
                                     </td>
                                     <td>{verdict}</td>
-                                    <td>{p.title}</td>
+                                    <td>
+                                        {(p.origin ?? "mined") === "agent"
+                                            ? <span className="badge keep" style={{ marginRight: 6 }}>agent</span>
+                                            : null}
+                                        {p.title}
+                                    </td>
                                 </tr>
                             );
                         })}
@@ -240,7 +249,7 @@ function ProposalDetail({
         <>
             <header>
                 <h3 style={{ margin: 0 }}>{proposal.title}</h3>
-                <span className="meta">{proposal.dedupe_sig}</span>
+                <span className="meta">{proposal.dedupe_sig} · {proposal.origin ?? "mined"}</span>
             </header>
             <dl className="kv">
                 <dt>Form</dt><dd>{proposal.form}</dd>
@@ -422,4 +431,16 @@ function SafetyFields({
             <dt>Failure mode</dt><dd>{payload.failure_mode ?? "-"}</dd>
         </>
     );
+}
+
+/** Fetches the deep-analysis brief once and offers it as a copy action -
+ *  paste into an agent session; findings return via `ax improve propose`. */
+function AnalysisBriefButton() {
+    const query = useQuery({
+        queryKey: ["improve", "analyze-brief"],
+        queryFn: () => api.improveAnalyzeBrief(),
+        staleTime: Infinity,
+    });
+    if (!query.data) return null;
+    return <CopyButton text={query.data.brief} label="Copy analysis brief" />;
 }

--- a/docs/superpowers/plans/2026-06-12-agent-writepath-pr3.md
+++ b/docs/superpowers/plans/2026-06-12-agent-writepath-pr3.md
@@ -1,0 +1,56 @@
+# Agent Write-Path (PR3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Agents can write rich proposals into the improve loop: `ax improve analyze` emits a mining brief, `ax improve propose` inserts validated proposals with `origin: "agent"`, and the dashboard surfaces origin + a "Run deep analysis" copy button.
+
+**Architecture:** `origin` is an additive SCHEMAFULL field (DEFAULT 'mined'; old rows read NONE → coalesce in JS). `propose` mirrors the retro derivation pattern (fresh `dedupe_sig` → CREATE proposal; existing → frequency bump; per-form payload UPSERT) via pure statement builders + one Effect runner. The analyze brief is one template module shared by the CLI (writes `.ax/tasks/`) and a new GET endpoint (dashboard copies it to clipboard).
+
+**Tech Stack:** Effect 4 beta, effect Schema for input validation, bun:test. Studio: React/TanStack.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-improve-first-dashboard-design.md` (PR4 section covers wrapped; this is PR3 scope).
+
+**Hard-won rules:** new endpoint ⇒ register in `baseApiCapabilities` AND `mock-fixtures.ts`. `/api/improve` is legacy-only (not contract) - single wiring point `improve-proposals.ts`. No new table ⇒ no SCHEMA_TABLES change.
+
+---
+
+### Task 1: `origin` field end-to-end (read side)
+
+- [ ] `packages/schema/src/schema.surql` proposal block: `DEFINE FIELD origin ON proposal TYPE string DEFAULT 'mined';`
+- [ ] `ProposalDto` gains `readonly origin?: string` (dashboard-types).
+- [ ] `apps/axctl/src/dashboard/improve-proposals.ts`: PROPOSALS_SQL selects `origin`; `withBrief` mapper coalesces `origin: p.origin ?? "mined"` (old rows = NONE).
+- [ ] Test: improve-proposals.test.ts asserts coalesce for a row without origin.
+- [ ] Gate: dashboard tests + typecheck. Commit `feat(improve): proposal origin field, mined default`.
+
+### Task 2: propose core (TDD)
+
+**Files:** Create `apps/axctl/src/improve/propose.ts` + `propose.test.ts`.
+
+- [ ] `ProposeInput` Schema: `{ form: Literals(skill|subagent|hook|guidance|automation), title, hypothesis, confidence: Literals(high|medium|low), frequency?: int>=1 (default 1), evidence?: string, payload: per-form struct }` - payload field shapes copied from schema.surql payload tables (skill: trigger_pattern/suspected_gap/proposed_behavior/expected_impact?; subagent: bounded_role/delegation_trigger/example_task_patterns?; hook: event_name/target_tool?/hook_command + safety fields?; guidance: file_target/section?/suggested_text; automation: trigger_signal/schedule?/action + safety fields?).
+- [ ] `buildProposeStatements(input, sig)` pure: mirrors `buildRetroSkillProposalStatements` (apps/axctl/src/ingest/derive-retro-proposals.ts:390 - CREATE-if-fresh with `origin: 'agent'`, else frequency bump + updated_at; payload UPSERT both paths). Reuse `dedupeSig`/`normalizeTitle` from `apps/axctl/src/ingest/derive-proposals.ts:283-286` and the `surrealString/surrealObject` helpers the retro builder uses.
+- [ ] `runPropose(input)` Effect: validate → sig → statements → db.query → return `{ status: "created" | "bumped", sig }` (detect via SELECT before, like retro does).
+- [ ] Tests: schema rejects bad form/missing payload field; statement builder snapshot for skill + guidance forms (origin 'agent' present, payload UPSERT); bump path.
+- [ ] Commit `feat(improve): propose core - validated agent proposal insert`.
+
+### Task 3: CLI subcommands
+
+- [ ] `apps/axctl/src/improve/analyze-brief.ts`: `renderAnalyzeBrief({ date, repoHint })` pure template - instructs the agent to mine `ax sessions churn`, `ax dispatches --candidates`, `ax recall`, tool failures + MCP read tools; one proposal per durable pattern with evidence refs (session ids, sigs, $); emit each via `echo '<json>' | ax improve propose`; documents the ProposeInput JSON shape per form. Test: contains the propose command, all 5 forms, evidence requirement.
+- [ ] `cli/commands/improve.ts`: subcommand `propose` (reads stdin, `--file=` override) → runPropose, prints JSON result; subcommand `analyze` → writes `.ax/tasks/analyze-improve-<YYYY-MM-DD>.md` (mkdir -p, no overwrite without `--force`), prints path. Follow the existing subcommand registration style in that file.
+- [ ] Commit `feat(cli): ax improve propose + analyze`.
+
+### Task 4: analyze-brief endpoint
+
+- [ ] GET `/api/improve/analyze-brief` (improve routes family, static path BEFORE `/:sig/:action` - method differs but keep above it) → `{ brief: string }` via `renderAnalyzeBrief`.
+- [ ] `baseApiCapabilities` += `"improve-analyze"`; mock fixture for the path; `api.improveAnalyzeBrief()` client method.
+- [ ] Route-match test. Commit `feat(dashboard): analyze-brief endpoint`.
+
+### Task 5: studio surfacing
+
+- [ ] Improve route header: "Run deep analysis" `CopyButton`-style button fetching the brief once (useQuery, staleTime Infinity) and copying on click - label "Copy analysis brief".
+- [ ] Proposals table + detail: `agent` badge when `origin === "agent"` (badge keep styling); table rank score: agent gets +0.5 tiebreak above mined at equal confidence×frequency (and same tweak in `proposalCards` bonus server-side: `+ bonus(... + (origin === "agent" ? 1 : 0))`).
+- [ ] Build + studio typecheck. Commit `feat(studio): agent origin badge + run deep analysis`.
+
+### Task 6: gate + live smoke + PR
+
+- [ ] `bun test` + typecheck + build. Live: side-port daemon; `echo '{"form":"guidance",...}' | ./apps/axctl/bin/axctl improve propose` → /api/improve shows it with origin agent; re-propose bumps frequency; `ax improve analyze` writes the brief; GET analyze-brief returns it. Schema field on live DB: ensure `ax ingest`-applied schema or manual DEFINE on the dev DB (schema.surql applies via db lifecycle scripts - check scripts/ for schema apply command and run it).
+- [ ] Push + PR; merge only at CLEAN.

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -333,6 +333,10 @@ export const ImproveGroup = HttpApiGroup.make("improve")
             success: Schema.Unknown,
             error: InternalError,
         }),
+        HttpApiEndpoint.get("analyzeBrief", "/api/improve/analyze-brief", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
         HttpApiEndpoint.post("improveAction", "/api/improve/:sig/:action", {
             params: {
                 sig: Schema.String,

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -1188,6 +1188,8 @@ export interface ProposalDto {
     readonly guidance_payload?: GuidanceProposalPayload | null;
     readonly automation_payload?: AutomationProposalPayload | null;
     readonly experiment?: ExperimentDto | null;
+    /** "mined" (signal-derived) or "agent" (ax improve propose); served coalesced. */
+    readonly origin?: string;
     /** server-rendered markdown agent brief */
     readonly brief?: string;
 }

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1605,6 +1605,9 @@ DEFINE FIELD confidence    ON proposal TYPE string;
     -- low | medium | high
 DEFINE FIELD status        ON proposal TYPE string DEFAULT 'open';
     -- open | accepted | rejected | superseded
+DEFINE FIELD origin        ON proposal TYPE string DEFAULT 'mined';
+    -- mined (signal-derived) | agent (written via `ax improve propose`)
+    -- old rows read NONE - consumers coalesce to 'mined'
 DEFINE FIELD reject_reason ON proposal TYPE option<string>;
 DEFINE FIELD baseline      ON proposal TYPE option<string>;
 DEFINE FIELD created_at    ON proposal TYPE datetime DEFAULT time::now();


### PR DESCRIPTION
PR3 of docs/superpowers/specs/2026-06-12-improve-first-dashboard-design.md.

Agents can now write rich proposals into the improve loop instead of only mechanical signal-mining:

- **`ax improve analyze`** emits `.ax/tasks/analyze-improve-<date>.md` — a deep-analysis brief teaching an agent to mine the graph (`sessions churn`, `dispatches --candidates`, `recall`, MCP tools) and write one proposal per durable pattern, with mandatory evidence refs.
- **`ax improve propose`** — JSON on stdin (or `--file`), Schema-validated per form (skill/subagent/hook/guidance/automation), deduped by sig: fresh → `CREATE` with `origin: "agent"`, repeat title → frequency bump. Mirrors the retro-derivation writer.
- **`origin` field** on `proposal` (additive, DEFAULT `'mined'`; old rows coalesced in JS).
- **Dashboard**: agent badge in the proposals table + detail, agent-origin outranks mined at equal confidence×frequency (server card builder + client table), "Copy analysis brief" header button backed by `GET /api/improve/analyze-brief` (capability `improve-analyze`, mock fixture included).

**Verified:** 3709 tests pass, typecheck + build green. Live e2e: propose → created → re-propose bumps → `/api/improve` serves `origin: "agent"` → analyze-brief endpoint + capability advertised → bad input rejected by schema. Smoke rows cleaned up.

Next: PR4 wrapped remake (Paxel-style cards, `ax wrapped generate/publish`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)