### PR TITLE
feat(og): design-review polish - unified mark, named peak, full-bleed grid

### DIFF
--- a/apps/site/functions/_lib/og-kit.test.ts
+++ b/apps/site/functions/_lib/og-kit.test.ts
@@ -100,10 +100,12 @@ describe("footerHtml", () => {
         const html = footerHtml("anything");
         expect(html).toContain("AX.NECMTTN.COM");
     });
-    test("includes serif ax wordmark", () => {
+    test("carries the block mark, not a serif wordmark (one logo, two scales)", () => {
         const html = footerHtml("anything");
-        expect(html).toContain("Gelasio");
-        expect(html).toContain(">ax<");
+        expect(html).not.toContain("Gelasio");
+        expect(html).toContain("AX.NECMTTN.COM");
+        // pixel cells from the embedded block logo at scale 3
+        expect(html).toContain("width:3px;height:3px");
     });
 });
 

--- a/apps/site/functions/_lib/og-kit.ts
+++ b/apps/site/functions/_lib/og-kit.ts
@@ -13,6 +13,7 @@
 // Color palette (same values as share card)
 // ---------------------------------------------------------------------------
 export const INK    = "#e7e9ec";
+export const PAPER  = "#f6f5f0";
 export const DIM    = "#8b93a1";
 export const BG     = "#15161d";
 export const CARD   = "#1e1f2a";
@@ -59,14 +60,22 @@ export const statHtml = (
     value: string,
     label: string,
     color: string = INK,
-): string =>
-    `<div style="display:flex;flex-direction:column;margin-right:46px"><span style="font-size:46px;font-weight:700;color:${color}">${esc(value)}</span><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-top:2px">${esc(label)}</span></div>`;
+    opts: { size?: number; marginRight?: number } = {},
+): string => {
+    const size = opts.size ?? 46;
+    const mr = opts.marginRight ?? 46;
+    // Labels: 16px / 1px tracking - 14px/2px is unreadable at the ~500px
+    // social-unfurl render size.
+    return `<div style="display:flex;flex-direction:column;margin-right:${mr}px"><span style="font-size:${size}px;font-weight:700;color:${color}">${esc(value)}</span><span style="font-size:16px;letter-spacing:1px;color:${DIM};margin-top:2px">${esc(label)}</span></div>`;
+};
 
 // ---------------------------------------------------------------------------
-// Footer band - serif "ax" wordmark + AX.NECMTTN.COM right side
+// Footer band - the SAME block mark at small scale (one logo, two scales;
+// the serif "ax" wordmark was a third typeface and read invisible at 24px).
+// align-items:center because the pixel mark has no text baseline.
 // ---------------------------------------------------------------------------
 export const footerHtml = (leftText: string): string =>
-    `<div style="display:flex;justify-content:space-between;align-items:center"><span style="font-size:15px;letter-spacing:2px;color:${DIM}">${esc(leftText)}</span><div style="display:flex;align-items:baseline"><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-right:10px">RECORDED WITH</span><span style="font-size:24px;color:${INK};font-weight:700;font-family:'Gelasio'">ax</span><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-left:12px">· AX.NECMTTN.COM</span></div></div>`;
+    `<div style="display:flex;justify-content:space-between;align-items:center"><span style="font-size:15px;letter-spacing:2px;color:${DIM}">${esc(leftText)}</span><div style="display:flex;align-items:center"><span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-right:12px">RECORDED WITH</span>${blockLogoHtml({ scale: 3, color: PAPER, dimColor: "transparent" })}<span style="font-size:14px;letter-spacing:2px;color:${DIM};margin-left:12px">· AX.NECMTTN.COM</span></div></div>`;
 
 // ---------------------------------------------------------------------------
 // Block logo - ANSI-shadow pixel grid (font-independent)
@@ -111,10 +120,13 @@ export const blockLogoHtml = ({ scale, color, dimColor }: BlockLogoOpts): string
             if (SOLID_CHARS.has(ch)) {
                 return `<div style="display:flex;width:${scale}px;height:${scale}px;background:${color}"></div>`;
             }
-            if (FRAME_CHARS.has(ch)) {
+            // At small scales the ANSI drop-shadow blurs into the letterform
+            // and reads as mud - "transparent" skips painting it entirely so
+            // the mark renders single-color and crisp.
+            if (FRAME_CHARS.has(ch) && dimColor !== "transparent") {
                 return `<div style="display:flex;width:${scale}px;height:${scale}px;background:${dimColor}"></div>`;
             }
-            // space → empty cell
+            // space / skipped shadow → empty cell
             return `<div style="display:flex;width:${scale}px;height:${scale}px"></div>`;
         }).join("");
         return `<div style="display:flex">${cells}</div>`;

--- a/apps/site/functions/_lib/og-meta.ts
+++ b/apps/site/functions/_lib/og-meta.ts
@@ -13,7 +13,7 @@
  */
 
 /** Bump when the poster template changes; busts edge + social image caches. */
-export const OG_RENDER_REV = 8;
+export const OG_RENDER_REV = 9;
 
 /** FNV-1a 32-bit as 8 hex chars - tiny, synchronous, stable across runtimes. */
 const fnv1a = (s: string): string => {

--- a/apps/site/functions/og-profile/[login].ts
+++ b/apps/site/functions/og-profile/[login].ts
@@ -15,7 +15,7 @@
 import { ImageResponse } from "workers-og";
 import { OG_RENDER_REV } from "../_lib/og-meta";
 import {
-    INK, DIM, CARD, GREEN, RED,
+    INK, PAPER, DIM, CARD, GREEN, RED,
     esc, statHtml, footerHtml, blockLogoHtml, compactNumber, compactUsd, loadOgFonts,
 } from "../_lib/og-kit";
 
@@ -35,6 +35,7 @@ interface ProfileStats {
     readonly streak_days: number;
     readonly tokens: { readonly total: number };
     readonly cost_usd?: number;
+    readonly harnesses?: ReadonlyArray<string>;
 }
 
 interface ProfileInsights {
@@ -70,6 +71,7 @@ interface ProfileStub {
     readonly longest_run_hours?: number;
     readonly commits?: number;
     readonly subagents?: number;
+    readonly harnesses?: ReadonlyArray<string>;
     readonly activity?: { readonly daily?: ReadonlyArray<DailyActivity> };
 }
 
@@ -83,13 +85,31 @@ function barChartHtml(daily: ReadonlyArray<DailyActivity>): string {
     const busyIdx = slice.reduce((best, d, i) =>
         d.sessions > (slice[best]?.sessions ?? 0) ? i : best, 0);
     const BAR_H = 80; // max bar height px
-    const BAR_W = 28; // bar width px
+    const BAR_W = 32; // bar width px
     const bars = slice.map((d, i) => {
         const h = Math.max(4, Math.round((d.sessions / maxSessions) * BAR_H));
         const color = i === busyIdx ? RED : GREEN;
-        return `<div style="display:flex;flex-direction:column;justify-content:flex-end;height:${BAR_H}px;margin-right:4px"><div style="display:flex;width:${BAR_W}px;height:${h}px;background:${color}"></div></div>`;
+        return `<div style="display:flex;flex-direction:column;justify-content:flex-end;height:${BAR_H}px"><div style="display:flex;width:${BAR_W}px;height:${h}px;background:${color}"></div></div>`;
     }).join("");
-    return `<div style="display:flex;flex-direction:column"><div style="display:flex;align-items:flex-end">${bars}</div><span style="font-size:13px;letter-spacing:2px;color:${DIM};margin-top:10px">DAILY SESSIONS · 30 DAYS</span></div>`;
+    // Full-bleed: fixed-width bars on a space-between 1072px track distribute
+    // the slack as even gaps - exact edge-to-edge without fractional margins.
+    // The caption NAMES the red bar: unexplained red reads as "error", named
+    // red reads as "peak".
+    const busy = slice[busyIdx];
+    const peakLabel = busy
+        ? ` · PEAK ${fmtDayLabel(busy.date)} · ${busy.sessions.toLocaleString("en-US")} SESSIONS`
+        : "";
+    return `<div style="display:flex;flex-direction:column"><div style="display:flex;align-items:flex-end;justify-content:space-between;width:1072px">${bars}</div><span style="font-size:13px;letter-spacing:2px;color:${DIM};margin-top:10px">DAILY SESSIONS · 30 DAYS${esc(peakLabel)}</span></div>`;
+}
+
+const MONTHS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"] as const;
+
+/** "2026-06-10" -> "JUN 10"; falls back to the raw string. */
+function fmtDayLabel(iso: string): string {
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+    if (!m) return iso;
+    const month = MONTHS[Number(m[2]) - 1];
+    return month ? `${month} ${Number(m[3])}` : iso;
 }
 
 // ---------------------------------------------------------------------------
@@ -151,6 +171,7 @@ export const onRequestGet: PagesFunction = async (ctx) => {
     let longestRunHours: number | null   = null;
     let commits: number | null     = null;
     let subagents: number | null   = null;
+    let harnesses: ReadonlyArray<string> | null = null;
     let daily: ReadonlyArray<DailyActivity> | null = null;
 
     if (stub) {
@@ -163,6 +184,7 @@ export const onRequestGet: PagesFunction = async (ctx) => {
         longestRunHours  = stub.longest_run_hours ?? null;
         commits      = stub.commits ?? null;
         subagents    = stub.subagents ?? null;
+        harnesses    = stub.harnesses ?? null;
         daily        = stub.activity?.daily ?? null;
     } else if (gistProfile) {
         const s  = gistProfile.stats;
@@ -176,38 +198,50 @@ export const onRequestGet: PagesFunction = async (ctx) => {
         longestRunHours  = ins?.longest_run_hours ?? null;
         commits      = ins?.commits ?? null;
         subagents    = ins?.subagents_total ?? null;
+        harnesses    = s.harnesses ?? null;
         daily        = gistProfile.activity?.daily ?? null;
     }
 
     // --- Build layout sections ---
 
-    // Header row: block logo left, kicker right
-    const logo   = blockLogoHtml({ scale: 4, color: INK, dimColor: DIM });
-    const header = `<div style="display:flex;justify-content:space-between;align-items:flex-start"><div style="display:flex">${logo}</div><span style="font-size:13px;letter-spacing:3px;color:${DIM}">AGENT TELEMETRY DOSSIER · LAST 30 DAYS</span></div>`;
+    // Header row: block logo left (single-color paper, no shadow - the
+    // two-tone treatment reads as mud below ~scale 8), kicker right.
+    const logo   = blockLogoHtml({ scale: 5, color: PAPER, dimColor: "transparent" });
+    const header = `<div style="display:flex;justify-content:space-between;align-items:center"><div style="display:flex">${logo}</div><span style="font-size:13px;letter-spacing:2px;color:${DIM}">AGENT TELEMETRY DOSSIER · LAST 30 DAYS</span></div>`;
 
-    // Big @login in Gelasio serif
-    const loginHtml = `<div style="display:flex;align-items:baseline;margin-top:12px"><span style="font-size:48px;font-weight:700;color:${DIM};font-family:'Gelasio';margin-right:4px">@</span><span style="font-size:88px;font-weight:700;color:${INK};font-family:'Gelasio';line-height:1">${esc(login)}</span></div>`;
+    // Name row: serif @login left (green @ = live handle), harness chips
+    // right - the chips claim the dead right half of the row.
+    const chipNames = (harnesses ?? [])
+        .filter((h) => !h.endsWith("-subagent"))
+        .slice(0, 4);
+    const chips = chipNames.length > 0
+        ? `<div style="display:flex;align-items:center">${chipNames.map((h) =>
+            `<div style="display:flex;padding:8px 16px;background:#262735;color:${DIM};font-size:14px;letter-spacing:2px;margin-left:10px">${esc(h.toUpperCase())}</div>`,
+        ).join("")}</div>`
+        : "";
+    const loginHtml = `<div style="display:flex;justify-content:space-between;align-items:center;margin-top:40px"><div style="display:flex;align-items:baseline"><span style="font-size:64px;font-weight:700;color:${GREEN};font-family:'Gelasio';margin-right:2px">@</span><span style="font-size:88px;font-weight:700;color:${INK};font-family:'Gelasio';line-height:1">${esc(login)}</span></div>${chips}</div>`;
 
-    // Stat band 1 - humanized numerals (19.6B, ~$22.9K, 2.3K) per the
-    // profile design language.
-    const statBand1 = `<div style="display:flex">${[
-        statHtml(sessions != null ? sessions.toLocaleString("en-US") : "-", "SESSIONS"),
-        statHtml(tokens  != null ? compactNumber(tokens)             : "-", "TOKENS"),
-        statHtml(spendUsd != null ? compactUsd(spendUsd)             : "-", "EST. SPEND", GREEN),
-        statHtml(streakDays  != null ? `${streakDays}d`             : "-", "STREAK"),
-        statHtml(activeHours != null ? compactNumber(activeHours)   : "-", "HOURS"),
+    // Stat band - full-bleed via space-between (no trailing margins); the
+    // green spend numeral is the hero and wins by SIZE, not just color.
+    const noMr = { marginRight: 0 };
+    const statBand1 = `<div style="display:flex;justify-content:space-between;align-items:flex-end;margin-top:36px">${[
+        statHtml(sessions != null ? sessions.toLocaleString("en-US") : "-", "SESSIONS", INK, noMr),
+        statHtml(tokens  != null ? compactNumber(tokens)             : "-", "TOKENS", INK, noMr),
+        statHtml(spendUsd != null ? compactUsd(spendUsd)             : "-", "EST. SPEND", GREEN, { size: 60, marginRight: 0 }),
+        statHtml(streakDays  != null ? `${streakDays}d`             : "-", "STREAK", INK, noMr),
+        statHtml(activeHours != null ? compactNumber(activeHours)   : "-", "HOURS", INK, noMr),
     ].join("")}</div>`;
 
     // Filler: bar chart or second stat row (fills dead space)
     let filler: string;
     if (daily && daily.length > 0) {
-        filler = barChartHtml(daily);
+        filler = `<div style="display:flex;margin-top:44px">${barChartHtml(daily)}</div>`;
     } else if (parallelSessions != null || longestRunHours != null || commits != null || subagents != null) {
-        filler = `<div style="display:flex">${[
-            statHtml(parallelSessions != null ? String(parallelSessions)          : "-", "PARALLEL"),
-            statHtml(longestRunHours  != null ? `${longestRunHours}h`             : "-", "LONGEST RUN"),
-            statHtml(commits          != null ? commits.toLocaleString("en-US")   : "-", "COMMITS"),
-            statHtml(subagents        != null ? compactNumber(subagents)          : "-", "SUBAGENTS"),
+        filler = `<div style="display:flex;justify-content:space-between;margin-top:44px">${[
+            statHtml(parallelSessions != null ? String(parallelSessions)          : "-", "PARALLEL", INK, { marginRight: 0 }),
+            statHtml(longestRunHours  != null ? `${longestRunHours}h`             : "-", "LONGEST RUN", INK, { marginRight: 0 }),
+            statHtml(commits          != null ? commits.toLocaleString("en-US")   : "-", "COMMITS", INK, { marginRight: 0 }),
+            statHtml(subagents        != null ? compactNumber(subagents)          : "-", "SUBAGENTS", INK, { marginRight: 0 }),
         ].join("")}</div>`;
     } else {
         filler = "";
@@ -215,8 +249,12 @@ export const onRequestGet: PagesFunction = async (ctx) => {
 
     const footer = footerHtml("COMPILED FROM LOCAL TRANSCRIPTS");
 
-    // justify-content:space-between distributes sections across full 630px
-    const html = `<div style="display:flex;flex-direction:column;justify-content:space-between;width:1200px;height:630px;background:${CARD};padding:56px 64px;font-family:'JetBrains Mono'">${header}${loginHtml}${statBand1}${filler}${footer}</div>`;
+    // Top bands live in one inner column with designed margin-top gaps;
+    // outer space-between then has exactly two children, which pins the
+    // footer to the bottom padding instead of inflating the chart-to-footer
+    // gap with the leftover slack.
+    const inner = `<div style="display:flex;flex-direction:column">${header}${loginHtml}${statBand1}${filler}</div>`;
+    const html = `<div style="display:flex;flex-direction:column;justify-content:space-between;width:1200px;height:630px;background:${CARD};padding:56px 64px;font-family:'JetBrains Mono'">${inner}${footer}</div>`;
 
     const { regular, bold, serif } = await loadOgFonts();
 

--- a/apps/site/functions/og/[owner]/[gistId].ts
+++ b/apps/site/functions/og/[owner]/[gistId].ts
@@ -12,7 +12,7 @@ import { ImageResponse } from "workers-og";
 import { OG_RENDER_REV } from "../../_lib/og-meta";
 import {
     INK, DIM, CARD, GREEN, RED, ROSE, GOLD, BLUE, VIOLET,
-    esc, fmtUsd, statHtml, footerHtml, blockLogoHtml, loadOgFonts,
+    esc, fmtUsd, statHtml, footerHtml, blockLogoHtml, loadOgFonts, PAPER,
 } from "../../_lib/og-kit";
 
 interface SubagentCard {
@@ -158,8 +158,11 @@ export const onRequestGet: PagesFunction = async (ctx) => {
 
     // Block logo (pixel grid) replaces the old ASCII two-liner; same header
     // position, small scale so it fits in the 56px header band.
-    const logo = blockLogoHtml({ scale: 4, color: INK, dimColor: DIM });
-    // Watermark variant: large low-opacity block logo centered behind content.
+    // Single-color paper, no shadow: the two-tone ANSI shadow reads as mud
+    // below ~scale 8 (see og-kit blockLogoHtml).
+    const logo = blockLogoHtml({ scale: 5, color: PAPER, dimColor: "transparent" });
+    // Watermark variant: large enough that the two-tone shadow reads as
+    // intentional texture rather than blur.
     const watermarkLogo = blockLogoHtml({ scale: 10, color: INK, dimColor: DIM });
 
     const blocks: Record<string, string> = {


### PR DESCRIPTION
## Summary
Three parallel design reviews (brand/mark, layout/space, typography/data) over the annotated card, synthesized into one revision:
- **Logo fixed (red #1):** single-color paper pixel mark — the two-tone ANSI shadow blurred into mud at small scales. Same fix applied to the share card's header.
- **Footer fixed (red #2):** the near-invisible 24px serif "ax" replaced with the same block mark at scale 3 — one logo at two scales; Gelasio is now reserved for the @login hero (with a green @).
- **Space fixed (yellows):** harness chips fill the name row's right half; stat band + chart go full-bleed (space-between over the 1072px track); inner-column wrapper pins the footer and closes the chart→footer chasm.
- **Data clarity:** hero spend at 60px (wins by size); labels 16px/1px for ~500px unfurl legibility; the red bar is now explained in-caption ("PEAK JUN 10 · 290 SESSIONS").
- REV 8→9 busts social caches.

## Test Plan
- [x] 31 kit tests green (footer contract updated to the block-mark)
- [x] `wrangler pages functions build` compiles from repo root
- [x] Local render reviewed against the real gist (screenshot in thread)
- [ ] Post-merge prod check of /og-profile/necmttn

🤖 Generated with [Claude Code](https://claude.com/claude-code)