### PR TITLE
perf(dashboard): worktrees overview via deref-free aggregates - 57s timeout to under 4s

### DIFF
--- a/apps/axctl/src/dashboard/contract/system.ts
+++ b/apps/axctl/src/dashboard/contract/system.ts
@@ -17,8 +17,9 @@ import {
 import { SurrealClient } from "@ax/lib/db";
 import { AX_VERSION } from "../../cli/version.ts";
 import { graphHealthSql } from "../../queries/graph-health.ts";
-import { checkoutActivitySql, gitCorrelationSql } from "../../queries/insights.ts";
 import { API_VERSION, dashboardApiCapabilities } from "../capabilities.ts";
+import { fetchWorktreesOverview } from "../worktrees-overview.ts";
+import { asJsonValue } from "./common.ts";
 
 /**
  * Boot-time facts the contract handlers need from `serveDashboard`: the
@@ -74,10 +75,14 @@ export const SystemGroupLive = HttpApiBuilder.group(AxApi, "system", (handlers) 
             }))
         .handle("worktrees", () =>
             Effect.gen(function* () {
-                const db = yield* SurrealClient;
-                const activity = yield* db.query(checkoutActivitySql(50)).pipe(Effect.mapError(internal));
-                const git = yield* db.query(gitCorrelationSql(50)).pipe(Effect.mapError(internal));
-                return new WorktreesResult({ activity, git });
+                // Deref-free aggregates + JS join: the legacy correlated SQL
+                // took 50+ seconds and died on the 60s idleTimeout.
+                const overview = yield* fetchWorktreesOverview(50).pipe(Effect.mapError(internal));
+                // asJsonValue: rows carry RecordId instances - see common.ts.
+                return new WorktreesResult({
+                    activity: asJsonValue(overview.activity),
+                    git: asJsonValue(overview.git),
+                });
             }))
         .handle("selfImprove", () =>
             Effect.gen(function* () {

--- a/apps/axctl/src/dashboard/report.ts
+++ b/apps/axctl/src/dashboard/report.ts
@@ -6,14 +6,13 @@ import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { posixPath } from "@ax/lib/shared/path";
 import {
-    checkoutActivitySql,
-    gitCorrelationSql,
     recentFrictionSql,
     repositoryOverviewSql,
     schemaCoverageSql,
     sessionEvidenceSql,
     toolFailuresSql,
 } from "../queries/insights.ts";
+import { fetchWorktreesOverview } from "./worktrees-overview.ts";
 
 type Row = Record<string, unknown>;
 
@@ -88,13 +87,14 @@ export const fetchDashboardData = (
 ): Effect.Effect<DashboardData, DbError, SurrealClient> =>
     Effect.gen(function* () {
         const client = yield* SurrealClient;
-        const [countResult, tableCounts, git, checkoutActivity, repositories, friction, tools, sessions] =
+        const [countResult, tableCounts, worktrees, repositories, friction, tools, sessions] =
             yield* Effect.all(
                 [
                     client.query<unknown[]>(COUNT_SQL),
                     queryRows(client, schemaCoverageSql()),
-                    queryRows(client, gitCorrelationSql(limit)),
-                    queryRows(client, checkoutActivitySql(limit)),
+                    // Deref-free aggregates + JS join; the legacy correlated
+                    // SQL full-scanned turn/tool_call once per checkout.
+                    fetchWorktreesOverview(limit),
                     queryRows(client, repositoryOverviewSql(limit)),
                     queryRows(client, recentFrictionSql(limit)),
                     queryRows(client, toolFailuresSql(limit)),
@@ -102,6 +102,8 @@ export const fetchDashboardData = (
                 ],
                 { concurrency: 6 },
             );
+        const git = worktrees.git as DashboardData["git"];
+        const checkoutActivity = worktrees.activity as DashboardData["checkoutActivity"];
 
         return {
             generatedAt: new Date().toISOString(),

--- a/apps/axctl/src/dashboard/worktrees-overview.test.ts
+++ b/apps/axctl/src/dashboard/worktrees-overview.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer, ManagedRuntime } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { fetchWorktreesOverview } from "./worktrees-overview.ts";
+
+/** Canned aggregate rows keyed by a marker in the SQL text. */
+const fixtures: ReadonlyArray<{ readonly marker: string; readonly rows: unknown[] }> = [
+    {
+        marker: "FROM checkout",
+        rows: [
+            { id: "checkout:a", path: "/a", created_at: "2026-01-01", last_seen: "2026-01-01" },
+            { id: "checkout:b", path: "/b", created_at: "2026-02-01", last_seen: "2026-02-01" },
+        ],
+    },
+    {
+        marker: "FROM repository",
+        rows: [{ id: "repository:r1", name: "ax", checkout_count: 2, created_at: "2026-01-01", last_seen: "2026-01-01" }],
+    },
+    {
+        marker: "FROM session",
+        rows: [
+            { id: "session:s1", checkout: "checkout:a", repository: "repository:r1" },
+            { id: "session:s2", checkout: "checkout:a", repository: "repository:r1" },
+            { id: "session:s3", checkout: null, repository: "repository:r1" },
+        ],
+    },
+    { marker: "FROM turn", rows: [{ session: "session:s1", n: 10 }, { session: "session:s2", n: 5 }] },
+    {
+        marker: "FROM tool_call WHERE has_error",
+        rows: [{ session: "session:s1", n: 2 }],
+    },
+    { marker: "FROM tool_call GROUP", rows: [{ session: "session:s1", n: 7 }, { session: "session:s2", n: 3 }] },
+    { marker: "FROM produced GROUP BY in", rows: [{ in: "session:s1", n: 4 }] },
+    { marker: "FROM produced GROUP BY out", rows: [{ out: "commit:c1", n: 4 }] },
+    { marker: "FROM touched GROUP BY in", rows: [{ in: "commit:c1", n: 9 }, { in: "commit:c2", n: 2 }] },
+    { marker: "FROM commit WHERE repository", rows: [{ repository: "repository:r1", n: 6 }] },
+    {
+        marker: "FROM commit;",
+        rows: [
+            { id: "commit:c1", repository: "repository:r1" },
+            { id: "commit:c2", repository: "repository:r1" },
+        ],
+    },
+    {
+        // commit -> checkout linkage rides on produced edges; c2 has none,
+        // so its touched edges count for the repo only.
+        marker: "FROM produced WHERE checkout",
+        rows: [{ out: "commit:c1", checkout: "checkout:a" }],
+    },
+];
+
+const stubDb = Layer.mock(SurrealClient, {
+    query: <T extends unknown[] = unknown[]>(sql: string, _bindings?: Record<string, unknown> | undefined): Effect.Effect<T, DbError, never> => {
+        const hit = fixtures.find((f) => sql.includes(f.marker));
+        return Effect.succeed([hit?.rows ?? []] as unknown as T);
+    },
+    raw: null as never,
+});
+
+describe("fetchWorktreesOverview", () => {
+    test("joins per-session aggregates up to checkouts and repositories", async () => {
+        const rt = ManagedRuntime.make(stubDb);
+        const overview = await rt.runPromise(fetchWorktreesOverview(50));
+        await rt.dispose();
+
+        const a = overview.activity.find((c) => String(c.id) === "checkout:a");
+        expect(a).toMatchObject({
+            session_count: 2,
+            turn_count: 15,           // s1:10 + s2:5
+            tool_call_count: 10,      // s1:7 + s2:3
+            tool_failure_count: 2,    // s1:2
+            produced_count: 4,        // s1:4
+            touched_count: 9,
+        });
+        const b = overview.activity.find((c) => String(c.id) === "checkout:b");
+        expect(b).toMatchObject({ session_count: 0, turn_count: 0, touched_count: 0 });
+        // Sort: active checkout first.
+        expect(String(overview.activity[0]?.id)).toBe("checkout:a");
+
+        const r1 = overview.git[0];
+        expect(r1).toMatchObject({
+            session_count: 3,                  // s1, s2, s3
+            checkout_linked_session_count: 2,  // s1, s2
+            commit_count: 6,
+            touched_count: 11,                 // c1:9 + c2:2 rolled up via commits
+            produced_count: 4,                 // commit:c1's 4 edges
+            checkout_count: 2,
+        });
+    });
+
+    test("respects the row limit", async () => {
+        const rt = ManagedRuntime.make(stubDb);
+        const overview = await rt.runPromise(fetchWorktreesOverview(1));
+        await rt.dispose();
+        expect(overview.activity.length).toBe(1);
+        expect(String(overview.activity[0]?.id)).toBe("checkout:a");
+    });
+});

--- a/apps/axctl/src/dashboard/worktrees-overview.ts
+++ b/apps/axctl/src/dashboard/worktrees-overview.ts
@@ -1,0 +1,201 @@
+/**
+ * Checkout-activity + git-correlation overview, rebuilt deref-free.
+ *
+ * The legacy SQL (queries/insights.ts checkoutActivitySql/gitCorrelationSql)
+ * ran correlated per-row subqueries with record derefs - e.g.
+ * `(SELECT id FROM turn WHERE session.checkout = $parent.id)` is a full turn
+ * scan WITH a session deref per turn, repeated once per checkout. On a
+ * year-old graph that is 50+ seconds and the daemon's 60s idleTimeout kills
+ * the response. This module computes single-pass GROUP BY aggregates
+ * (~1s total) and joins them in JS, preserving the legacy row shapes.
+ *
+ * Same class of fix as the skills-weighted hang: keep aggregates deref-free,
+ * join in JS (see memory: weighted-query-per-edge-deref-hang).
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+
+export interface WorktreesOverview {
+    readonly activity: ReadonlyArray<Record<string, unknown>>;
+    readonly git: ReadonlyArray<Record<string, unknown>>;
+}
+
+interface GroupRow { readonly n: number; readonly [key: string]: unknown }
+
+const keyOf = (value: unknown): string => String(value);
+
+/** Build `String(group key) -> count` from GROUP BY rows. */
+function countMap(rows: ReadonlyArray<GroupRow>, key: string): Map<string, number> {
+    const map = new Map<string, number>();
+    for (const row of rows) {
+        const k = row[key];
+        if (k != null) map.set(keyOf(k), row.n);
+    }
+    return map;
+}
+
+const lastSeenOf = (row: Record<string, unknown>): string => {
+    const v = row.updated_at ?? row.created_at;
+    return v instanceof Date ? v.toISOString() : String(v ?? "");
+};
+
+const byCounts = (keys: ReadonlyArray<string>) =>
+(a: Record<string, unknown>, b: Record<string, unknown>): number => {
+    for (const k of keys) {
+        const d = ((b[k] as number) ?? 0) - ((a[k] as number) ?? 0);
+        if (d !== 0) return d;
+    }
+    return lastSeenOf(b).localeCompare(lastSeenOf(a));
+};
+
+export const fetchWorktreesOverview = (
+    limit = 50,
+): Effect.Effect<WorktreesOverview, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const [
+            [checkouts],
+            [repositories],
+            [sessions],
+            [turnsBySession],
+            [toolCallsBySession],
+            [toolFailuresBySession],
+            [producedBySession],
+            [producedByCommit],
+            [touchedByCommit],
+            [commitsByRepo],
+            [commits],
+            [producedCheckouts],
+        ] = yield* Effect.all([
+            db.query<[Array<Record<string, unknown>>]>(`
+SELECT id, repository, repository.name AS repository_name, repository.remote_url AS remote_url,
+    path, branch, worktree_name, head_sha, dirty, created_at, updated_at,
+    (updated_at ?? created_at) AS last_seen
+FROM checkout;`),
+            db.query<[Array<Record<string, unknown>>]>(`
+SELECT id, name, remote_url, root_path, created_at, updated_at,
+    (updated_at ?? created_at) AS last_seen,
+    array::len(->has_checkout->checkout) AS checkout_count
+FROM repository;`),
+            db.query<[Array<Record<string, unknown>>]>(
+                "SELECT id, checkout, repository FROM session;",
+            ),
+            db.query<[Array<GroupRow>]>("SELECT session, count() AS n FROM turn GROUP BY session;"),
+            db.query<[Array<GroupRow>]>("SELECT session, count() AS n FROM tool_call GROUP BY session;"),
+            db.query<[Array<GroupRow>]>(
+                "SELECT session, count() AS n FROM tool_call WHERE has_error = true GROUP BY session;",
+            ),
+            db.query<[Array<GroupRow>]>("SELECT in, count() AS n FROM produced GROUP BY in;"),
+            db.query<[Array<GroupRow>]>("SELECT out, count() AS n FROM produced GROUP BY out;"),
+            // touched is the biggest table (~430k edges). Grouping by its
+            // `checkout`/`repository` FIELDS materializes every row (~13s
+            // each, with or without a secondary index - SurrealDB only
+            // groups fast on the edge key `in`). So group by commit and roll
+            // up through the commit's checkout/repository in JS; touched
+            // edges inherit both from their commit at ingest.
+            db.query<[Array<GroupRow>]>("SELECT in, count() AS n FROM touched GROUP BY in;"),
+            db.query<[Array<GroupRow>]>(
+                "SELECT repository, count() AS n FROM commit WHERE repository IS NOT NONE GROUP BY repository;",
+            ),
+            db.query<[Array<Record<string, unknown>>]>("SELECT id, repository FROM commit;"),
+            // commit -> checkout linkage lives on produced edges (commit rows
+            // carry checkout = NONE in practice); ~7k rows, cheap full pull.
+            db.query<[Array<Record<string, unknown>>]>(
+                "SELECT out, checkout FROM produced WHERE checkout IS NOT NONE;",
+            ),
+        ], { concurrency: 4 });
+
+        const turnsPerSession = countMap(turnsBySession ?? [], "session");
+        const toolCallsPerSession = countMap(toolCallsBySession ?? [], "session");
+        const toolFailuresPerSession = countMap(toolFailuresBySession ?? [], "session");
+        const producedPerSession = countMap(producedBySession ?? [], "in");
+        const producedPerCommit = countMap(producedByCommit ?? [], "out");
+        const touchedPerCommit = countMap(touchedByCommit ?? [], "in");
+        const commitsPerRepo = countMap(commitsByRepo ?? [], "repository");
+
+        // Roll commit-grouped touched/produced counts up to checkout + repo.
+        // A commit's checkout comes from its produced edge (first one wins
+        // when several sessions produced the same commit).
+        const checkoutPerCommit = new Map<string, string>();
+        for (const edge of producedCheckouts ?? []) {
+            const ckey = keyOf(edge.out);
+            if (!checkoutPerCommit.has(ckey) && edge.checkout != null) {
+                checkoutPerCommit.set(ckey, keyOf(edge.checkout));
+            }
+        }
+        const touchedPerCheckout = new Map<string, number>();
+        const touchedPerRepo = new Map<string, number>();
+        const producedPerRepo = new Map<string, number>();
+        for (const commit of commits ?? []) {
+            const ckey = keyOf(commit.id);
+            const touched = touchedPerCommit.get(ckey) ?? 0;
+            const produced = producedPerCommit.get(ckey) ?? 0;
+            const checkout = checkoutPerCommit.get(ckey);
+            if (checkout !== undefined && touched > 0) {
+                touchedPerCheckout.set(checkout, (touchedPerCheckout.get(checkout) ?? 0) + touched);
+            }
+            if (commit.repository != null) {
+                const rk = keyOf(commit.repository);
+                if (touched > 0) touchedPerRepo.set(rk, (touchedPerRepo.get(rk) ?? 0) + touched);
+                if (produced > 0) producedPerRepo.set(rk, (producedPerRepo.get(rk) ?? 0) + produced);
+            }
+        }
+
+        // Sessions roll up to their checkout and repository.
+        const sessionsPerCheckout = new Map<string, string[]>();
+        const sessionsPerRepo = new Map<string, number>();
+        const checkoutSessionsPerRepo = new Map<string, number>();
+        for (const session of sessions ?? []) {
+            const sid = keyOf(session.id);
+            if (session.checkout != null) {
+                const ck = keyOf(session.checkout);
+                const list = sessionsPerCheckout.get(ck) ?? [];
+                list.push(sid);
+                sessionsPerCheckout.set(ck, list);
+            }
+            if (session.repository != null) {
+                const rk = keyOf(session.repository);
+                sessionsPerRepo.set(rk, (sessionsPerRepo.get(rk) ?? 0) + 1);
+                if (session.checkout != null) {
+                    checkoutSessionsPerRepo.set(rk, (checkoutSessionsPerRepo.get(rk) ?? 0) + 1);
+                }
+            }
+        }
+        const sumOver = (sids: ReadonlyArray<string>, map: Map<string, number>): number =>
+            sids.reduce((acc, sid) => acc + (map.get(sid) ?? 0), 0);
+
+        const activity = (checkouts ?? [])
+            .map((checkout) => {
+                const ck = keyOf(checkout.id);
+                const sids = sessionsPerCheckout.get(ck) ?? [];
+                return {
+                    ...checkout,
+                    session_count: sids.length,
+                    turn_count: sumOver(sids, turnsPerSession),
+                    tool_call_count: sumOver(sids, toolCallsPerSession),
+                    tool_failure_count: sumOver(sids, toolFailuresPerSession),
+                    produced_count: sumOver(sids, producedPerSession),
+                    touched_count: touchedPerCheckout.get(ck) ?? 0,
+                };
+            })
+            .sort(byCounts(["session_count", "turn_count", "produced_count"]))
+            .slice(0, limit);
+
+        const git = (repositories ?? [])
+            .map((repo) => {
+                const rk = keyOf(repo.id);
+                return {
+                    ...repo,
+                    session_count: sessionsPerRepo.get(rk) ?? 0,
+                    checkout_linked_session_count: checkoutSessionsPerRepo.get(rk) ?? 0,
+                    commit_count: commitsPerRepo.get(rk) ?? 0,
+                    touched_count: touchedPerRepo.get(rk) ?? 0,
+                    produced_count: producedPerRepo.get(rk) ?? 0,
+                };
+            })
+            .sort(byCounts(["session_count", "produced_count", "commit_count"]))
+            .slice(0, limit);
+
+        return { activity, git };
+    });


### PR DESCRIPTION
## What

Deferred item 3: `/api/worktrees` (and the same data in `ax report`) timed out at the daemon's 60s idle limit. The legacy SQL ran correlated per-checkout subqueries with record derefs — a full `turn` scan with a `session` deref per row, once per checkout.

`fetchWorktreesOverview` replaces it: single-pass `GROUP BY` aggregates + JS join, legacy row shapes preserved.

## Measured findings (profiled live, baked into comments)

- `turn`/`tool_call` GROUP BY session: ~1.1s total. Fine.
- `touched` (430k commit→file edges) grouped by its `checkout`/`repository` **fields**: ~13s each — and a secondary index does NOT help (tested: built one, still 16.7s, removed it). SurrealDB only groups fast on the edge key `in` (~0.6s).
- So touched counts group by commit and roll up in JS via `commit→repository` and the **`produced` edge's checkout** — `commit.checkout` is `NONE` across the whole graph; `produced.checkout` (7.2k rows) is the real linkage. First version shipped zeros here; caught by checking the rollup distribution, not just the status code.
- Bonus fix the timeout was masking: raw rows carry `RecordId` instances → the contract handler now `asJsonValue`s (else empty-400 on encode).

## Result

57s-timeout → **3.8s** live, 24 checkouts + all repos with populated counts. 2 unit tests pin the join math (incl. the no-checkout-commit case). Suite 3658 pass / typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)