### PR TITLE
feat(wrapped): paxel-style agent-generated recap cards (PR4)

### DIFF
--- a/apps/axctl/src/cli/commands/wrapped.ts
+++ b/apps/axctl/src/cli/commands/wrapped.ts
@@ -1,0 +1,78 @@
+/**
+ * `ax wrapped` - agent-authored Wrapped recap cards.
+ *
+ * Subcommands:
+ *   ax wrapped generate [--force]
+ *     Emit .ax/tasks/wrapped-generate-<date>.md - a brief instructing an
+ *     agent to mine the graph and publish Paxel-style headline cards.
+ *
+ *   ax wrapped publish [--file=PATH] [--json]
+ *     Read { cards: [...] } JSON (stdin or --file), validate, and replace
+ *     the wrapped_card set. The dashboard landing serves the new deck on
+ *     its next fetch.
+ */
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { renderWrappedGenerateBrief } from "../../dashboard/wrapped-generate-brief.ts";
+import { runPublishCards } from "../../dashboard/wrapped-cards.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { jsonFlag, optionValue } from "./shared.ts";
+
+const cmdWrappedGenerate = (input: { readonly force: boolean }) =>
+    Effect.gen(function* () {
+        const date = new Date().toISOString().slice(0, 10);
+        const path = `.ax/tasks/wrapped-generate-${date}.md`;
+        const exists = yield* Effect.tryPromise(() => Bun.file(path).exists());
+        if (exists && !input.force) {
+            console.log(`already exists: ${path} (re-run with --force to overwrite)`);
+            return;
+        }
+        // Bun.write creates parent directories itself (repo gate: check:no-node-fs).
+        yield* Effect.tryPromise(() => Bun.write(path, renderWrappedGenerateBrief({ date })));
+        console.log(`wrapped brief written: ${path}`);
+        console.log("hand it to an agent session; cards come back via `ax wrapped publish`");
+    });
+
+const cmdWrappedPublish = (input: { readonly file: string | undefined; readonly json: boolean }) =>
+    Effect.gen(function* () {
+        const raw = input.file !== undefined
+            ? yield* Effect.tryPromise(() => Bun.file(input.file as string).text())
+            : yield* Effect.tryPromise(() => Bun.stdin.text());
+        const parsed = yield* Effect.try({
+            try: () => JSON.parse(raw) as unknown,
+            catch: (err) =>
+                new Error(
+                    `invalid JSON on ${input.file ? input.file : "stdin"}: ${err instanceof Error ? err.message : String(err)}`,
+                ),
+        });
+        const result = yield* runPublishCards(parsed);
+        if (input.json) {
+            console.log(JSON.stringify(result));
+        } else {
+            console.log(`published ${result.count} wrapped cards - the dashboard landing serves them now`);
+        }
+    });
+
+const wrappedGenerateCommand = Command.make(
+    "generate",
+    {
+        force: Flag.boolean("force").pipe(Flag.withDefault(false)),
+    },
+    ({ force }) => cmdWrappedGenerate({ force }),
+).pipe(Command.withDescription("Emit .ax/tasks/wrapped-generate-<date>.md - a brief for an agent to mine the graph and write Paxel-style recap cards back via `ax wrapped publish`."));
+
+const wrappedPublishCommand = Command.make(
+    "publish",
+    {
+        file: Flag.string("file").pipe(Flag.optional),
+        json: jsonFlag,
+    },
+    ({ file, json }) => cmdWrappedPublish({ file: optionValue(file), json }),
+).pipe(Command.withDescription("Replace the wrapped card deck: read { cards: [{question, headline, body, sensitivity?}] } JSON from stdin or --file."));
+
+export const wrappedCommand = Command.make("wrapped").pipe(
+    Command.withDescription("Agent-authored Wrapped recap cards: generate the mining brief, publish the card deck."),
+    Command.withSubcommands([wrappedGenerateCommand, wrappedPublishCommand]),
+);
+
+export const wrappedRuntime: RuntimeManifest = { wrapped: "db" };

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -23,6 +23,7 @@ import { recallCommand, recallRuntime } from "./commands/recall.ts";
 import { hookCommand, hooksCommand, hooksRuntime } from "./commands/hooks.ts";
 import { retroCommand, retroRuntime } from "./commands/retro.ts";
 import { improveCommand, improveRuntime } from "./commands/improve.ts";
+import { wrappedCommand, wrappedRuntime } from "./commands/wrapped.ts";
 import { sessionsCommand, sessionsRuntime } from "./commands/sessions.ts";
 import { skillsCommand, rolesCommand, skillsRuntime } from "./commands/skills.ts";
 import { classifiersCommand, classifiersRuntime } from "./commands/classifiers.ts";
@@ -83,6 +84,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...hooksRuntime,
     ...retroRuntime,
     ...improveRuntime,
+    ...wrappedRuntime,
     ...sessionsRuntime,
     ...skillsRuntime,
     ...classifiersRuntime,
@@ -101,6 +103,7 @@ const registeredCommands: ReadonlyArray<Command.Command.Any> = [
     ingestCommand,
     sessionsCommand,
     improveCommand,
+    wrappedCommand,
     retroCommand,
     recallCommand,
     skillsCommand,

--- a/apps/axctl/src/dashboard/capabilities.ts
+++ b/apps/axctl/src/dashboard/capabilities.ts
@@ -27,6 +27,7 @@ export const baseApiCapabilities = [
     "improve",     // /api/improve + accept/reject/verdict
     "next-actions", // /api/next-actions ranked action cards + agent briefs
     "improve-analyze", // GET /api/improve/analyze-brief - deep-analysis brief for agents
+    "wrapped-generate", // GET /api/wrapped/generate-brief + agent card deck on /api/wrapped
     "events",      // /api/events (SSE)
     "ingest",      // POST /api/ingest -> { runId, stream } + Durable Streams sidecar
     "image",       // GET /api/image?path= -> local on-disk image bytes

--- a/apps/axctl/src/dashboard/contract/insights.ts
+++ b/apps/axctl/src/dashboard/contract/insights.ts
@@ -18,6 +18,7 @@ import { fetchWorkflow } from "../workflow.ts";
 import { sanitizeWrappedProfile } from "../wrapped.ts";
 import { fetchWrappedCached } from "../wrapped-cache.ts";
 import { fetchWrappedCards, sanitizeWrappedCards } from "../wrapped-cards.ts";
+import { renderWrappedGenerateBrief } from "../wrapped-generate-brief.ts";
 import { orInternal } from "./common.ts";
 
 export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handlers) =>
@@ -70,6 +71,10 @@ export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handle
                     })),
                 ),
             ))
+        .handle("wrappedGenerateBrief", () =>
+            Effect.sync(() => ({
+                brief: renderWrappedGenerateBrief({ date: new Date().toISOString().slice(0, 10) }),
+            })))
         .handle("workflow", () => orInternal(fetchWorkflow()))
         .handle("toolFailures", () => orInternal(fetchToolFailures()))
         .handle("toolFailureDetail", ({ params }) => orInternal(fetchToolFailureDetail(params.label))));

--- a/apps/axctl/src/dashboard/contract/insights.ts
+++ b/apps/axctl/src/dashboard/contract/insights.ts
@@ -19,7 +19,7 @@ import { sanitizeWrappedProfile } from "../wrapped.ts";
 import { fetchWrappedCached } from "../wrapped-cache.ts";
 import { fetchWrappedCards, sanitizeWrappedCards } from "../wrapped-cards.ts";
 import { renderWrappedGenerateBrief } from "../wrapped-generate-brief.ts";
-import { orInternal } from "./common.ts";
+import { asJsonValue, orInternal } from "./common.ts";
 
 export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handlers) =>
     handlers
@@ -59,16 +59,18 @@ export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handle
         .handle("wrapped", () =>
             orInternal(
                 Effect.all([fetchWrappedCached(), fetchWrappedCards()]).pipe(
-                    Effect.map(([profile, cards]) => ({ ...profile, cards })),
+                    // asJsonValue: card rows are raw query rows - see common.ts.
+                    Effect.map(([profile, cards]) => asJsonValue({ ...profile, cards })),
                 ),
             ))
         .handle("wrappedPublicPreview", () =>
             orInternal(
                 Effect.all([fetchWrappedCached(), fetchWrappedCards()]).pipe(
-                    Effect.map(([profile, cards]) => ({
-                        ...sanitizeWrappedProfile(profile),
-                        cards: sanitizeWrappedCards(cards),
-                    })),
+                    Effect.map(([profile, cards]) =>
+                        asJsonValue({
+                            ...sanitizeWrappedProfile(profile),
+                            cards: sanitizeWrappedCards(cards),
+                        })),
                 ),
             ))
         .handle("wrappedGenerateBrief", () =>

--- a/apps/axctl/src/dashboard/contract/insights.ts
+++ b/apps/axctl/src/dashboard/contract/insights.ts
@@ -17,6 +17,7 @@ import { fetchToolFailureDetail, fetchToolFailures } from "../tool-failures.ts";
 import { fetchWorkflow } from "../workflow.ts";
 import { sanitizeWrappedProfile } from "../wrapped.ts";
 import { fetchWrappedCached } from "../wrapped-cache.ts";
+import { fetchWrappedCards, sanitizeWrappedCards } from "../wrapped-cards.ts";
 import { orInternal } from "./common.ts";
 
 export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handlers) =>
@@ -51,9 +52,24 @@ export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handle
                         : Effect.succeed(payload)
                 ),
             ))
-        .handle("wrapped", () => orInternal(fetchWrappedCached()))
+        // Agent-authored cards merge onto the cached mechanical profile.
+        // The cards read is uncached on purpose: `ax wrapped publish` runs in
+        // a separate process and can't drop the daemon's in-memory TTL cache.
+        .handle("wrapped", () =>
+            orInternal(
+                Effect.all([fetchWrappedCached(), fetchWrappedCards()]).pipe(
+                    Effect.map(([profile, cards]) => ({ ...profile, cards })),
+                ),
+            ))
         .handle("wrappedPublicPreview", () =>
-            orInternal(fetchWrappedCached().pipe(Effect.map(sanitizeWrappedProfile))))
+            orInternal(
+                Effect.all([fetchWrappedCached(), fetchWrappedCards()]).pipe(
+                    Effect.map(([profile, cards]) => ({
+                        ...sanitizeWrappedProfile(profile),
+                        cards: sanitizeWrappedCards(cards),
+                    })),
+                ),
+            ))
         .handle("workflow", () => orInternal(fetchWorkflow()))
         .handle("toolFailures", () => orInternal(fetchToolFailures()))
         .handle("toolFailureDetail", ({ params }) => orInternal(fetchToolFailureDetail(params.label))));

--- a/apps/axctl/src/dashboard/contract/skills-improve.test.ts
+++ b/apps/axctl/src/dashboard/contract/skills-improve.test.ts
@@ -35,6 +35,7 @@ describe("isContractRequest - skills/improve/live routing", () => {
         expect(isContractRequest("POST", "/api/skills/decide-bulk")).toBe(true);
         expect(isContractRequest("GET", "/api/improve")).toBe(true);
         expect(isContractRequest("GET", "/api/improve/analyze-brief")).toBe(true);
+        expect(isContractRequest("GET", "/api/wrapped/generate-brief")).toBe(true);
         expect(isContractRequest("POST", "/api/ingest")).toBe(true);
     });
 

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -53,6 +53,7 @@ const CONTRACT_ROUTES: ReadonlySet<string> = new Set([
     "GET /api/skill-graph",
     "GET /api/wrapped",
     "GET /api/wrapped/public-preview",
+    "GET /api/wrapped/generate-brief",
     "GET /api/workflow",
     "GET /api/tool-failures",
     // sessions

--- a/apps/axctl/src/dashboard/ttl-cache.test.ts
+++ b/apps/axctl/src/dashboard/ttl-cache.test.ts
@@ -37,6 +37,25 @@ describe("makeTtlCachedFetch", () => {
         expect(await Effect.runPromise(cache.fetch())).toBe(42);
     });
 
+    test("a failed compute is NOT cached - next fetch retries", async () => {
+        let calls = 0;
+        const cache = makeTtlCachedFetch(
+            "test",
+            () =>
+                Effect.suspend(() => {
+                    calls += 1;
+                    return calls === 1
+                        ? Effect.fail(new Error("db hiccup"))
+                        : Effect.succeed(calls);
+                }),
+            "1 minute",
+        );
+        await expect(Effect.runPromise(cache.fetch())).rejects.toThrow("db hiccup");
+        const second = await Effect.runPromise(cache.fetch());
+        expect(second).toBe(2);
+        expect(calls).toBe(2);
+    });
+
     test("concurrent first callers share one compute", async () => {
         let computes = 0;
         const cache = makeTtlCachedFetch(

--- a/apps/axctl/src/dashboard/ttl-cache.ts
+++ b/apps/axctl/src/dashboard/ttl-cache.ts
@@ -34,8 +34,12 @@ export const makeTtlCachedFetch = <A, E, R>(
     });
     return {
         fetch: Effect.fn(`dashboard.${name}.cached`)(function* () {
-            const [cached] = yield* ensure;
-            return yield* cached;
+            const [cached, invalidate] = yield* ensure;
+            // cachedInvalidateWithTTL stores the EXIT - a failed or
+            // interrupted compute would otherwise be served instantly for the
+            // whole TTL window. Never cache failures: drop the entry so the
+            // next caller recomputes.
+            return yield* cached.pipe(Effect.tapCause(() => invalidate));
         }),
         invalidate: Effect.fn(`dashboard.${name}.invalidate`)(function* () {
             if (holder !== null) {

--- a/apps/axctl/src/dashboard/wrapped-cards.test.ts
+++ b/apps/axctl/src/dashboard/wrapped-cards.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import {
+    buildPublishStatements,
+    fetchWrappedCards,
+    runPublishCards,
+    sanitizeWrappedCards,
+} from "./wrapped-cards.ts";
+
+const card = (n: number, sensitivity = "public") => ({
+    question: `Q${n}?`,
+    headline: `Headline ${n}`,
+    body: `Body ${n}.`,
+    sensitivity,
+    position: n,
+});
+
+const makeDb = (rows: Array<Record<string, unknown>>, log: string[] = []) => {
+    const stub: SurrealClientShape = {
+        query: (sql: string) => {
+            log.push(sql);
+            return Effect.succeed([rows]);
+        },
+    } as unknown as SurrealClientShape;
+    return Layer.succeed(SurrealClient, stub);
+};
+
+describe("fetchWrappedCards", () => {
+    test("returns ordered rows", async () => {
+        const rows = await Effect.runPromise(
+            fetchWrappedCards().pipe(Effect.provide(makeDb([card(0), card(1)]))),
+        );
+        expect(rows).toHaveLength(2);
+        expect(rows[0]?.headline).toBe("Headline 0");
+    });
+});
+
+describe("sanitizeWrappedCards", () => {
+    test("drops sensitive cards", () => {
+        const out = sanitizeWrappedCards([card(0), card(1, "sensitive"), card(2)]);
+        expect(out.map((c) => c.position)).toEqual([0, 2]);
+    });
+});
+
+describe("buildPublishStatements", () => {
+    test("full replace: DELETE first, CREATE per card with index positions", () => {
+        const stmts = buildPublishStatements({
+            cards: [
+                { question: "Q?", headline: "Big", body: "b", sensitivity: "sensitive" },
+                { question: "Q2?", headline: "Bigger", body: "b2" },
+            ],
+        });
+        expect(stmts[0]).toBe("DELETE wrapped_card;");
+        expect(stmts).toHaveLength(3);
+        expect(stmts[1]).toContain('sensitivity: "sensitive"');
+        expect(stmts[1]).toContain("position: 0");
+        expect(stmts[2]).toContain('sensitivity: "public"');
+        expect(stmts[2]).toContain("position: 1");
+    });
+});
+
+describe("runPublishCards", () => {
+    test("publishes valid input", async () => {
+        const log: string[] = [];
+        const res = await Effect.runPromise(
+            runPublishCards({ cards: [{ question: "Q?", headline: "H", body: "b" }] }).pipe(
+                Effect.provide(makeDb([], log)),
+            ),
+        );
+        expect(res).toEqual({ status: "published", count: 1 });
+        expect(log[0]).toBe("DELETE wrapped_card;");
+        expect(log[1]).toContain("CREATE wrapped_card CONTENT");
+    });
+
+    test("rejects empty card list", async () => {
+        await expect(
+            Effect.runPromise(
+                runPublishCards({ cards: [] }).pipe(Effect.provide(makeDb([]))),
+            ),
+        ).rejects.toThrow("at least 1 card");
+    });
+
+    test("rejects more than 24 cards", async () => {
+        const cards = Array.from({ length: 25 }, (_, i) => ({
+            question: `Q${i}?`,
+            headline: `H${i}`,
+            body: "b",
+        }));
+        await expect(
+            Effect.runPromise(
+                runPublishCards({ cards }).pipe(Effect.provide(makeDb([]))),
+            ),
+        ).rejects.toThrow("at most 24");
+    });
+
+    test("rejects bad sensitivity", async () => {
+        await expect(
+            Effect.runPromise(
+                runPublishCards({
+                    cards: [{ question: "Q?", headline: "H", body: "b", sensitivity: "secret" }],
+                }).pipe(Effect.provide(makeDb([]))),
+            ),
+        ).rejects.toThrow();
+    });
+});

--- a/apps/axctl/src/dashboard/wrapped-cards.ts
+++ b/apps/axctl/src/dashboard/wrapped-cards.ts
@@ -16,6 +16,9 @@ const CardSchema = Schema.Struct({
     headline: Schema.String,
     body: Schema.String,
     sensitivity: Schema.optional(Schema.Literals(["public", "sensitive"])),
+    /** real grounding data points, rendered as the card's bar strip */
+    series: Schema.optional(Schema.Array(Schema.Number)),
+    series_label: Schema.optional(Schema.String),
 });
 
 export const PublishInputSchema = Schema.Struct({
@@ -26,7 +29,7 @@ export type PublishInput = typeof PublishInputSchema.Type;
 
 const MAX_CARDS = 24;
 
-const CARDS_SQL = `SELECT question, headline, body, sensitivity, position FROM wrapped_card ORDER BY position ASC;`;
+const CARDS_SQL = `SELECT question, headline, body, sensitivity, position, series, series_label FROM wrapped_card ORDER BY position ASC;`;
 
 export const fetchWrappedCards = Effect.fn("dashboard.fetchWrappedCards")(
     function* () {
@@ -52,6 +55,11 @@ export const buildPublishStatements = (input: PublishInput): string[] => [
             ["body", surrealString(card.body)],
             ["sensitivity", surrealString(card.sensitivity ?? "public")],
             ["position", String(index)],
+            // grounding series capped at 64 points - enough for daily/weekly shapes
+            ["series", `[${(card.series ?? []).slice(0, 64).map((n) => String(Number(n) || 0)).join(", ")}]`],
+            ...(card.series_label !== undefined
+                ? ([["series_label", surrealString(card.series_label)]] as const)
+                : []),
         ])};`,
     ),
 ];

--- a/apps/axctl/src/dashboard/wrapped-cards.ts
+++ b/apps/axctl/src/dashboard/wrapped-cards.ts
@@ -1,0 +1,76 @@
+import { Effect, Schema } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { WrappedCardDto } from "@ax/lib/shared/dashboard-types";
+import { surrealObject, surrealString } from "@ax/lib/shared/surql";
+
+/**
+ * Agent-authored Wrapped recap cards. `ax wrapped publish` replaces the
+ * full set atomically (DELETE + CREATE) - the read side is a trivial
+ * ordered select, deliberately uncached so a publish from the CLI shows
+ * up on the next dashboard fetch (the daemon's in-memory TTL caches only
+ * cover the expensive mechanical profile).
+ */
+
+const CardSchema = Schema.Struct({
+    question: Schema.String,
+    headline: Schema.String,
+    body: Schema.String,
+    sensitivity: Schema.optional(Schema.Literals(["public", "sensitive"])),
+});
+
+export const PublishInputSchema = Schema.Struct({
+    cards: Schema.Array(CardSchema),
+});
+
+export type PublishInput = typeof PublishInputSchema.Type;
+
+const MAX_CARDS = 24;
+
+const CARDS_SQL = `SELECT question, headline, body, sensitivity, position FROM wrapped_card ORDER BY position ASC;`;
+
+export const fetchWrappedCards = Effect.fn("dashboard.fetchWrappedCards")(
+    function* () {
+        const db = yield* SurrealClient;
+        const result = yield* db.query<[Array<Record<string, unknown>>]>(CARDS_SQL);
+        return (result[0] ?? []) as unknown as ReadonlyArray<WrappedCardDto>;
+    },
+);
+
+/** Drop sensitive cards for the public preview. */
+export const sanitizeWrappedCards = (
+    cards: ReadonlyArray<WrappedCardDto>,
+): ReadonlyArray<WrappedCardDto> =>
+    cards.filter((c) => c.sensitivity !== "sensitive");
+
+/** Pure: full-replace statement list. */
+export const buildPublishStatements = (input: PublishInput): string[] => [
+    "DELETE wrapped_card;",
+    ...input.cards.map((card, index) =>
+        `CREATE wrapped_card CONTENT ${surrealObject([
+            ["question", surrealString(card.question)],
+            ["headline", surrealString(card.headline)],
+            ["body", surrealString(card.body)],
+            ["sensitivity", surrealString(card.sensitivity ?? "public")],
+            ["position", String(index)],
+        ])};`,
+    ),
+];
+
+export const runPublishCards = Effect.fn("dashboard.runPublishCards")(function* (
+    raw: unknown,
+) {
+    const input = yield* Schema.decodeUnknownEffect(PublishInputSchema)(raw);
+    if (input.cards.length === 0) {
+        return yield* Effect.fail(new Error("publish needs at least 1 card"));
+    }
+    if (input.cards.length > MAX_CARDS) {
+        return yield* Effect.fail(
+            new Error(`publish accepts at most ${MAX_CARDS} cards (got ${input.cards.length})`),
+        );
+    }
+    const db = yield* SurrealClient;
+    for (const stmt of buildPublishStatements(input)) {
+        yield* db.query(stmt);
+    }
+    return { status: "published" as const, count: input.cards.length };
+});

--- a/apps/axctl/src/dashboard/wrapped-generate-brief.test.ts
+++ b/apps/axctl/src/dashboard/wrapped-generate-brief.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { renderWrappedGenerateBrief } from "./wrapped-generate-brief.ts";
+
+describe("renderWrappedGenerateBrief", () => {
+    const brief = renderWrappedGenerateBrief({ date: "2026-06-12" });
+
+    test("teaches the publish command and JSON shape", () => {
+        expect(brief).toContain("ax wrapped publish");
+        expect(brief).toContain('"cards"');
+        expect(brief).toContain('"question"');
+        expect(brief).toContain('"headline"');
+        expect(brief).toContain('"sensitivity"');
+    });
+
+    test("names the mining sources", () => {
+        expect(brief).toContain("/api/wrapped");
+        expect(brief).toContain("ax cost models");
+        expect(brief).toContain("ax sessions churn");
+        expect(brief).toContain("ax recall");
+    });
+
+    test("encodes the card rules", () => {
+        expect(brief).toContain("<= 6 words");
+        expect(brief).toContain("REPLACES the whole set");
+        expect(brief).toContain("sensitive");
+    });
+
+    test("stamps the date", () => {
+        expect(brief).toContain("2026-06-12");
+    });
+});

--- a/apps/axctl/src/dashboard/wrapped-generate-brief.ts
+++ b/apps/axctl/src/dashboard/wrapped-generate-brief.ts
@@ -27,7 +27,7 @@ people read headlines, not paragraphs. Personality over template-speak:
 - \`ax recall <phrase>\` - hunt a specific memorable moment (the best card
   is often one real quote or one absurd number)
 
-**Then publish 10-16 cards:**
+**Then publish ~12 cards (10 minimum, 16 max):**
 
 \`\`\`bash
 echo '<json>' | ax wrapped publish
@@ -57,6 +57,15 @@ echo '<json>' | ax wrapped publish
 - Every card grounded in a real number or real quote from the data - no inventions.
 - Mix: archetype, model loyalty, productivity rhythm, prompt style, a funny
   low-light (failed run, all-caps moment), shipping volume, delegation habits.
+- ALWAYS include a value-multiplier card: \`ax cost models --days=30\` gives
+  API-priced usage in USD; compare it to what the user actually pays in
+  subscriptions (ask or assume Claude Code + Codex tiers). "$400 in,
+  $23.9K out - a 60x multiplier" - then make the dollars physical: that's
+  N base-model Honda Civics a year, M years of rent, you name it.
+- Physical-scale comparisons are welcome on any big number (books stacked
+  to Eiffel Towers, paper weighed in blue whales, distance flown by a 747) -
+  the dashboard already draws a token-scale board, so aim yours at OTHER
+  numbers (cost, tool calls, lines shipped).
 - Cards order = array order (most shareable first).
 - Mark \`"sensitivity": "sensitive"\` on anything with private paths, client
   names, or embarrassing specifics - those stay off the public preview.

--- a/apps/axctl/src/dashboard/wrapped-generate-brief.ts
+++ b/apps/axctl/src/dashboard/wrapped-generate-brief.ts
@@ -48,6 +48,12 @@ echo '<json>' | ax wrapped publish
 
 **Card rules:**
 - headline <= 6 words; body <= 2 short sentences; question is the eyebrow.
+- GROUND the card visually when you can: attach \`"series": [..]\` - 14-30 REAL
+  data points that back the claim (daily sessions on that model, redirects per
+  week, commits per hour-of-day) plus a short \`"series_label"\` (e.g.
+  "sessions/day on fable"). The dashboard draws it as the card's bar strip -
+  real shapes beat decoration. Mine the numbers with the SQL console
+  (\`POST /api/query\`) or the CLIs above.
 - Every card grounded in a real number or real quote from the data - no inventions.
 - Mix: archetype, model loyalty, productivity rhythm, prompt style, a funny
   low-light (failed run, all-caps moment), shipping volume, delegation habits.

--- a/apps/axctl/src/dashboard/wrapped-generate-brief.ts
+++ b/apps/axctl/src/dashboard/wrapped-generate-brief.ts
@@ -1,0 +1,63 @@
+/**
+ * The Wrapped-generation brief - `ax wrapped generate` writes it to
+ * `.ax/tasks/`, the dashboard's "Regenerate wrapped" button serves it via
+ * GET /api/wrapped/generate-brief. An agent session mines the graph and
+ * publishes headline cards through `ax wrapped publish`.
+ */
+
+export interface WrappedGenerateBriefInput {
+    readonly date: string;
+}
+
+export const renderWrappedGenerateBrief = ({ date }: WrappedGenerateBriefInput): string =>
+    `## Task: Write my Agent Wrapped cards (${date})
+
+You are writing the recap cards for the ax dashboard landing page. The
+style target: Paxel-style share cards - an eyebrow question, a BIG short
+headline, and at most two supporting lines. The headline carries the card;
+people read headlines, not paragraphs. Personality over template-speak:
+"You steer, hard" beats "High redirect frequency detected".
+
+**Mine the numbers first (read-only):**
+- \`curl -s http://127.0.0.1:1738/api/wrapped\` (or your daemon port) - the
+  mechanical profile: usage, streaks, archetypes, metrics, facts
+- \`ax cost models --days=30\` - model mix and spend
+- \`ax sessions churn --since=30\` - what kept failing
+- \`ax dispatches --days=30\` - delegation habits
+- \`ax recall <phrase>\` - hunt a specific memorable moment (the best card
+  is often one real quote or one absurd number)
+
+**Then publish 10-16 cards:**
+
+\`\`\`bash
+echo '<json>' | ax wrapped publish
+\`\`\`
+
+\`\`\`json
+{
+  "cards": [
+    {
+      "question": "Which archetype are you?",
+      "headline": "The Architect",
+      "body": "You plan first, codify decisions, and build scaffolding that compounds.",
+      "sensitivity": "public"
+    }
+  ]
+}
+\`\`\`
+
+**Card rules:**
+- headline <= 6 words; body <= 2 short sentences; question is the eyebrow.
+- Every card grounded in a real number or real quote from the data - no inventions.
+- Mix: archetype, model loyalty, productivity rhythm, prompt style, a funny
+  low-light (failed run, all-caps moment), shipping volume, delegation habits.
+- Cards order = array order (most shareable first).
+- Mark \`"sensitivity": "sensitive"\` on anything with private paths, client
+  names, or embarrassing specifics - those stay off the public preview.
+- Publishing REPLACES the whole set - emit the full deck in one call.
+
+**Verify:** the dashboard landing (Wrapped) shows your cards; the public
+preview hides the sensitive ones.
+
+_source: ax wrapped generate ${date}_
+`;

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -167,6 +167,7 @@ export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "cites_evidence", stage: "active", note: "Proposal-to-evidence edges." },
     { table: "opportunity", stage: "active", note: "Experiment trigger recurrence evidence edges." },
     { table: "reviewed", stage: "active", note: "Session-to-retro review edges." },
+    { table: "wrapped_card", stage: "active", note: "Agent-authored Wrapped recap cards (ax wrapped publish)." },
 ] as const;
 
 export function isInsightView(value: string): value is InsightView {

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -37,6 +37,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 ### Profile
 - `ax profile show [--window=N] [--no-cost]` - your local agent profile rendered from the graph: usage stats, rig (skills/hooks/rules), and evidence-grounded taste patterns
 - `ax profile publish` - share it: consent-gated public gist (updated in place by the watcher) + one-time community registration PR; `ax profile unpublish` reverses it
+- `ax wrapped generate / publish` - agent-authored Wrapped recap cards: generate emits a mining brief, publish replaces the card deck the dashboard landing serves
 
 ### Self-improvement loop
 - `ax improve recommend / accept / lint / show` - evidence-backed proposals (guidance, skills, hooks, automations) derived from the graph; accept emits a task brief, lint reconciles applied guidance

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -436,6 +436,9 @@ export const api = {
     improveAnalyzeBrief: (): Promise<{ brief: string }> =>
         viaContract("/api/improve/analyze-brief", (c) => c.improve.analyzeBrief()),
 
+    wrappedGenerateBrief: (): Promise<{ brief: string }> =>
+        viaContract("/api/wrapped/generate-brief", (c) => c.insights.wrappedGenerateBrief()),
+
     /** Read-only SQL console (Lab) - daemon accepts SELECT/RETURN/INFO only. */
     query: (sql: string): Promise<{ result: unknown; durationMs: number }> =>
         viaContract(

--- a/apps/studio/src/components/token-scale.tsx
+++ b/apps/studio/src/components/token-scale.tsx
@@ -1,0 +1,86 @@
+/**
+ * Token scale - turns an unrelatable token total into physical reality:
+ * tokens → words → novels → shelf-stack height → landmark multiples.
+ * Rendered as a monospace conversion chain, a bookshelf strip (house
+ * trace-bar material), and a row of Eiffel towers.
+ *
+ * Rough constants, deliberately conservative and stated in the UI:
+ *   ~0.75 words per token, ~90k words per novel, ~2.4 cm spine per book.
+ */
+
+export interface TokenScaleFacts {
+    readonly tokens: number;
+    readonly words: number;
+    readonly novels: number;
+    readonly stackMeters: number;
+    readonly eiffels: number;
+}
+
+const WORDS_PER_TOKEN = 0.75;
+const WORDS_PER_NOVEL = 90_000;
+const SPINE_METERS = 0.024;
+const EIFFEL_METERS = 330;
+
+export const tokenScale = (tokens: number): TokenScaleFacts => {
+    const words = tokens * WORDS_PER_TOKEN;
+    const novels = words / WORDS_PER_NOVEL;
+    const stackMeters = novels * SPINE_METERS;
+    return { tokens, words, novels, stackMeters, eiffels: stackMeters / EIFFEL_METERS };
+};
+
+const compact = (n: number): string =>
+    new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(n);
+
+const km = (meters: number): string =>
+    meters >= 1000 ? `${(meters / 1000).toFixed(1)} km` : `${Math.round(meters)} m`;
+
+const SHELF_SPINES = 44;
+const TOWER_CAP = 16;
+
+/** Deterministic spine heights so the shelf doesn't flicker. */
+const spineHeight = (i: number): number => 55 + ((i * 2654435761) % 41);
+
+export function TokenScale({ tokens }: { readonly tokens: number | null }) {
+    if (tokens === null || tokens < 1_000_000) return null;
+    const s = tokenScale(tokens);
+    const towers = Math.max(1, Math.min(TOWER_CAP, Math.floor(s.eiffels)));
+    return (
+        <div className="token-scale" aria-label="Token total in physical terms">
+            <span className="token-scale-chain">
+                {compact(s.tokens)} tokens → {compact(s.words)} words → {compact(s.novels)} novels
+                → a {km(s.stackMeters)} stack → {s.eiffels >= 1 ? `${s.eiffels.toFixed(1)}× the Eiffel Tower` : `${Math.round((s.stackMeters / EIFFEL_METERS) * 100)}% of the Eiffel Tower`}
+            </span>
+            <div className="token-scale-shelf" aria-hidden="true">
+                {Array.from({ length: SHELF_SPINES }, (_, i) => (
+                    <i key={i} style={{ height: `${spineHeight(i)}%` }} />
+                ))}
+            </div>
+            <div className="token-scale-towers" aria-hidden="true">
+                {Array.from({ length: towers }, (_, i) => (
+                    <EiffelGlyph key={i} />
+                ))}
+                {s.eiffels > towers ? (
+                    <span className="token-scale-tower-overflow">×{s.eiffels.toFixed(1)}</span>
+                ) : null}
+            </div>
+            <span className="token-scale-note">
+                everything you and your agents wrote and read, printed and stacked
+                · ~{Math.round(WORDS_PER_TOKEN * 100) / 100} words/token, {compact(WORDS_PER_NOVEL)}-word novels
+            </span>
+        </div>
+    );
+}
+
+function EiffelGlyph() {
+    return (
+        <svg viewBox="0 0 24 40" className="token-scale-tower">
+            <path
+                d="M12 1 L13 9 L16 22 Q16.5 25 21 30 L23 31 L23 33 L17 33 Q14.5 28 12 28 Q9.5 28 7 33 L1 33 L1 31 L3 30 Q7.5 25 8 22 L11 9 Z M9.5 17 L14.5 17 M8.6 22 L15.4 22 Q12 26.5 8.6 22 Z"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}

--- a/apps/studio/src/components/token-scale.tsx
+++ b/apps/studio/src/components/token-scale.tsx
@@ -1,11 +1,13 @@
 /**
  * Token scale - turns an unrelatable token total into physical reality:
- * tokens → words → novels → shelf-stack height → landmark multiples.
- * Rendered as a monospace conversion chain, a bookshelf strip (house
- * trace-bar material), and a row of Eiffel towers.
+ * tokens → words → novels, then the novel stack measured two ways -
+ * HEIGHT against landmarks (Eiffel, Burj Khalifa, a 747) and WEIGHT
+ * against animals/ships (elephants, blue whales, the Titanic). Rendered
+ * as monospace conversion chains, a bookshelf strip (house trace-bar
+ * material), and a row of Eiffel towers.
  *
  * Rough constants, deliberately conservative and stated in the UI:
- *   ~0.75 words per token, ~90k words per novel, ~2.4 cm spine per book.
+ *   ~0.75 words/token, ~90k words/novel, ~2.4 cm spine, ~350 g/paperback.
  */
 
 export interface TokenScaleFacts {
@@ -13,26 +15,61 @@ export interface TokenScaleFacts {
     readonly words: number;
     readonly novels: number;
     readonly stackMeters: number;
+    readonly paperTonnes: number;
     readonly eiffels: number;
+    readonly burjs: number;
+    readonly jumbo747s: number;
+    readonly elephants: number;
+    readonly blueWhales: number;
+    readonly titanics: number;
 }
 
 const WORDS_PER_TOKEN = 0.75;
 const WORDS_PER_NOVEL = 90_000;
 const SPINE_METERS = 0.024;
+const PAPERBACK_KG = 0.35;
 const EIFFEL_METERS = 330;
+const BURJ_METERS = 828;
+const B747_METERS = 76;
+const ELEPHANT_TONNES = 6;
+const BLUE_WHALE_TONNES = 150;
+const TITANIC_TONNES = 52_310;
 
 export const tokenScale = (tokens: number): TokenScaleFacts => {
     const words = tokens * WORDS_PER_TOKEN;
     const novels = words / WORDS_PER_NOVEL;
     const stackMeters = novels * SPINE_METERS;
-    return { tokens, words, novels, stackMeters, eiffels: stackMeters / EIFFEL_METERS };
+    const paperTonnes = (novels * PAPERBACK_KG) / 1000;
+    return {
+        tokens,
+        words,
+        novels,
+        stackMeters,
+        paperTonnes,
+        eiffels: stackMeters / EIFFEL_METERS,
+        burjs: stackMeters / BURJ_METERS,
+        jumbo747s: stackMeters / B747_METERS,
+        elephants: paperTonnes / ELEPHANT_TONNES,
+        blueWhales: paperTonnes / BLUE_WHALE_TONNES,
+        titanics: paperTonnes / TITANIC_TONNES,
+    };
 };
 
 const compact = (n: number): string =>
     new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(n);
 
+const mult = (n: number): string => (n >= 10 ? String(Math.round(n)) : n.toFixed(1));
+
 const km = (meters: number): string =>
     meters >= 1000 ? `${(meters / 1000).toFixed(1)} km` : `${Math.round(meters)} m`;
+
+/** Pick the most relatable weight comparison - the largest unit with a
+ *  multiple >= 0.5, so "0.5 blue whales" beats "12,000 elephants". */
+const weightLine = (s: TokenScaleFacts): string => {
+    if (s.titanics >= 0.5) return `${mult(s.titanics)}× the Titanic`;
+    if (s.blueWhales >= 0.5) return `${mult(s.blueWhales)} blue whales`;
+    return `${mult(s.elephants)} African elephants`;
+};
 
 const SHELF_SPINES = 44;
 const TOWER_CAP = 16;
@@ -48,7 +85,11 @@ export function TokenScale({ tokens }: { readonly tokens: number | null }) {
         <div className="token-scale" aria-label="Token total in physical terms">
             <span className="token-scale-chain">
                 {compact(s.tokens)} tokens → {compact(s.words)} words → {compact(s.novels)} novels
-                → a {km(s.stackMeters)} stack → {s.eiffels >= 1 ? `${s.eiffels.toFixed(1)}× the Eiffel Tower` : `${Math.round((s.stackMeters / EIFFEL_METERS) * 100)}% of the Eiffel Tower`}
+                → a {km(s.stackMeters)} stack → {mult(s.eiffels)}× the Eiffel Tower
+            </span>
+            <span className="token-scale-chain token-scale-chain-alt">
+                that stack: {mult(s.burjs)}× Burj Khalifa · {mult(s.jumbo747s)}× a 747, nose to tail
+                · on the scale: {compact(s.paperTonnes)} t of paper ≈ {weightLine(s)}
             </span>
             <div className="token-scale-shelf" aria-hidden="true">
                 {Array.from({ length: SHELF_SPINES }, (_, i) => (
@@ -60,12 +101,12 @@ export function TokenScale({ tokens }: { readonly tokens: number | null }) {
                     <EiffelGlyph key={i} />
                 ))}
                 {s.eiffels > towers ? (
-                    <span className="token-scale-tower-overflow">×{s.eiffels.toFixed(1)}</span>
+                    <span className="token-scale-tower-overflow">×{mult(s.eiffels)}</span>
                 ) : null}
             </div>
             <span className="token-scale-note">
                 everything you and your agents wrote and read, printed and stacked
-                · ~{Math.round(WORDS_PER_TOKEN * 100) / 100} words/token, {compact(WORDS_PER_NOVEL)}-word novels
+                · ~{WORDS_PER_TOKEN} words/token, {compact(WORDS_PER_NOVEL)}-word, 350 g paperbacks
             </span>
         </div>
     );

--- a/apps/studio/src/components/wrapped-cards.tsx
+++ b/apps/studio/src/components/wrapped-cards.tsx
@@ -1,10 +1,11 @@
 import type { WrappedCardDto } from "@ax/lib/shared/dashboard-types";
 
 /**
- * Paxel-style recap card grid: eyebrow question, BIG headline, two
- * supporting lines, dithered halftone art header. The headline carries the
- * card. Art + rotation jitter are deterministic per index so the deck is
- * stable across renders.
+ * Trace cards - the ax-native wrapped deck. Each card opens with an
+ * activity-bar strip in the card's accent (the house sparkline/heatmap
+ * material), then a monospace query eyebrow, a serif headline, and a quiet
+ * body. Accents rotate through the studio's luminance-matched palette;
+ * the bars are deterministic per headline so the deck is stable.
  */
 export function WrappedCardGrid({ cards }: { readonly cards: ReadonlyArray<WrappedCardDto> }) {
     return (
@@ -16,28 +17,40 @@ export function WrappedCardGrid({ cards }: { readonly cards: ReadonlyArray<Wrapp
     );
 }
 
-/** Deterministic visual variant: art density/shape + rotation by index. */
-const variant = (i: number) => ({
-    art: `wrapped-card-art v${i % 4}`,
-    rotation: [-1.2, 0.8, -0.5, 1.1, -0.9, 0.4][i % 6] ?? 0,
-});
+const ACCENTS = ["green", "blue", "gold", "violet", "rose"] as const;
+
+/** Tiny deterministic PRNG seeded from a string - no Math.random so the
+ *  strip never flickers between renders. */
+function* seededBars(seed: string, count: number): Generator<number> {
+    let h = 2166136261;
+    for (let i = 0; i < seed.length; i++) {
+        h ^= seed.charCodeAt(i);
+        h = Math.imul(h, 16777619);
+    }
+    for (let i = 0; i < count; i++) {
+        h ^= h << 13;
+        h ^= h >>> 17;
+        h ^= h << 5;
+        h >>>= 0;
+        // 25%..100% of strip height
+        yield 25 + (h % 76);
+    }
+}
+
+const BAR_COUNT = 22;
 
 function WrappedCardView({ card, index }: { readonly card: WrappedCardDto; readonly index: number }) {
-    const v = variant(index);
+    const accent = ACCENTS[index % ACCENTS.length];
+    const bars = [...seededBars(card.headline, BAR_COUNT)];
     return (
-        <article
-            className="wrapped-card"
-            style={{ transform: `rotate(${v.rotation}deg)` }}
-        >
-            <div className={v.art} aria-hidden="true">
-                <span className="wrapped-card-dots">
-                    <i />
-                    <i />
-                    <i />
-                </span>
+        <article className={`wrapped-card accent-${accent}`}>
+            <div className="wrapped-card-strip" aria-hidden="true">
+                {bars.map((h, i) => (
+                    <i key={i} style={{ height: `${h}%` }} />
+                ))}
             </div>
             <div className="wrapped-card-copy">
-                <span className="wrapped-card-eyebrow">{card.question}</span>
+                <span className="wrapped-card-eyebrow">$ {card.question}</span>
                 <h3 className="wrapped-card-headline">{card.headline}</h3>
                 <p className="wrapped-card-body">{card.body}</p>
                 {card.sensitivity === "sensitive" ? (

--- a/apps/studio/src/components/wrapped-cards.tsx
+++ b/apps/studio/src/components/wrapped-cards.tsx
@@ -1,0 +1,49 @@
+import type { WrappedCardDto } from "@ax/lib/shared/dashboard-types";
+
+/**
+ * Paxel-style recap card grid: eyebrow question, BIG headline, two
+ * supporting lines, dithered halftone art header. The headline carries the
+ * card. Art + rotation jitter are deterministic per index so the deck is
+ * stable across renders.
+ */
+export function WrappedCardGrid({ cards }: { readonly cards: ReadonlyArray<WrappedCardDto> }) {
+    return (
+        <div className="wrapped-cards" aria-label="Wrapped recap cards">
+            {cards.map((card, i) => (
+                <WrappedCardView key={`${card.position}-${card.headline}`} card={card} index={i} />
+            ))}
+        </div>
+    );
+}
+
+/** Deterministic visual variant: art density/shape + rotation by index. */
+const variant = (i: number) => ({
+    art: `wrapped-card-art v${i % 4}`,
+    rotation: [-1.2, 0.8, -0.5, 1.1, -0.9, 0.4][i % 6] ?? 0,
+});
+
+function WrappedCardView({ card, index }: { readonly card: WrappedCardDto; readonly index: number }) {
+    const v = variant(index);
+    return (
+        <article
+            className="wrapped-card"
+            style={{ transform: `rotate(${v.rotation}deg)` }}
+        >
+            <div className={v.art} aria-hidden="true">
+                <span className="wrapped-card-dots">
+                    <i />
+                    <i />
+                    <i />
+                </span>
+            </div>
+            <div className="wrapped-card-copy">
+                <span className="wrapped-card-eyebrow">{card.question}</span>
+                <h3 className="wrapped-card-headline">{card.headline}</h3>
+                <p className="wrapped-card-body">{card.body}</p>
+                {card.sensitivity === "sensitive" ? (
+                    <span className="badge archive wrapped-card-flag">private</span>
+                ) : null}
+            </div>
+        </article>
+    );
+}

--- a/apps/studio/src/components/wrapped-cards.tsx
+++ b/apps/studio/src/components/wrapped-cards.tsx
@@ -39,15 +39,33 @@ function* seededBars(seed: string, count: number): Generator<number> {
 
 const BAR_COUNT = 22;
 
+/** Normalize a real data series into 8..100% bar heights. */
+const normalizeSeries = (series: ReadonlyArray<number>): number[] => {
+    const max = Math.max(...series, 1);
+    return series.map((v) => 8 + Math.round((Math.max(0, v) / max) * 92));
+};
+
 function WrappedCardView({ card, index }: { readonly card: WrappedCardDto; readonly index: number }) {
     const accent = ACCENTS[index % ACCENTS.length];
-    const bars = [...seededBars(card.headline, BAR_COUNT)];
+    // Grounded cards draw their REAL series (e.g. daily sessions on the
+    // card's model); ungrounded ones get a deterministic decorative strip.
+    const grounded = (card.series?.length ?? 0) >= 2;
+    const bars = grounded
+        ? normalizeSeries(card.series ?? [])
+        : [...seededBars(card.headline, BAR_COUNT)];
     return (
         <article className={`wrapped-card accent-${accent}`}>
-            <div className="wrapped-card-strip" aria-hidden="true">
+            <div
+                className="wrapped-card-strip"
+                aria-hidden={grounded ? undefined : true}
+                title={grounded ? (card.series_label ?? undefined) : undefined}
+            >
                 {bars.map((h, i) => (
                     <i key={i} style={{ height: `${h}%` }} />
                 ))}
+                {grounded && card.series_label ? (
+                    <span className="wrapped-card-series-label">{card.series_label}</span>
+                ) : null}
             </div>
             <div className="wrapped-card-copy">
                 <span className="wrapped-card-eyebrow">$ {card.question}</span>

--- a/apps/studio/src/mock-fixtures.ts
+++ b/apps/studio/src/mock-fixtures.ts
@@ -364,6 +364,9 @@ export async function mockFetch<T>(input: RequestInfo, init?: RequestInit): Prom
     if (path.startsWith("/api/recall")) return EMPTY_RECALL as unknown as T;
     if (path === "/api/wrapped" || path === "/api/wrapped/public-preview") return EMPTY_WRAPPED as unknown as T;
 
+    if (path === "/api/wrapped/generate-brief") {
+        return { brief: "## Task: Write my Agent Wrapped cards (mock)\n\nConnect a local daemon for the real brief." } as unknown as T;
+    }
     if (path === "/api/improve/analyze-brief") {
         return { brief: "## Task: Deep-analysis pass (mock)\n\nConnect a local daemon for the real brief." } as unknown as T;
     }

--- a/apps/studio/src/routes/wrapped.tsx
+++ b/apps/studio/src/routes/wrapped.tsx
@@ -10,6 +10,7 @@ import type {
 import { fmtCount, fmtTs } from "@ax/lib/shared/formatters";
 import { CopyButton } from "../components/copy-button.tsx";
 import { WrappedCardGrid } from "../components/wrapped-cards.tsx";
+import { TokenScale } from "../components/token-scale.tsx";
 
 const hourLabel = (hour: number | null): string => {
     if (hour == null) return "n/a";
@@ -73,6 +74,7 @@ export function WrappedRoute() {
                             {/* The agent deck supersedes the mechanical hero +
                                 facts - only the raw stats live here. */}
                             <MetricGrid profile={data} />
+                            <TokenScale tokens={data.usage.totalTokens} />
                             <DailyHeatmap days={data.usage.days} />
                         </details>
                         <PublicPreview
@@ -86,6 +88,7 @@ export function WrappedRoute() {
                         <GenerateCta />
                         <WrappedHero profile={data} />
                         <MetricGrid profile={data} />
+                        <TokenScale tokens={data.usage.totalTokens} />
                         <DailyHeatmap days={data.usage.days} />
                         <Facts facts={data.facts} />
                         <PublicPreview

--- a/apps/studio/src/routes/wrapped.tsx
+++ b/apps/studio/src/routes/wrapped.tsx
@@ -1,11 +1,9 @@
-import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 import { api } from "../api.ts";
 import type {
-    WrappedArchetype,
     WrappedFact,
     WrappedProfile,
-    WrappedUsageDay,
 } from "@ax/lib/shared/dashboard-types";
 import { fmtCount, fmtTs } from "@ax/lib/shared/formatters";
 import { CopyButton } from "../components/copy-button.tsx";
@@ -21,34 +19,15 @@ const hourLabel = (hour: number | null): string => {
 
 const maybeCount = (value: number | null): string => (value == null ? "n/a" : fmtCount(value));
 
-const scoreLabel = (archetype: WrappedArchetype): string =>
-    `${archetype.confidence} confidence`;
-
-const heatLevel = (day: WrappedUsageDay, max: number): number => {
-    if (max <= 0 || day.sessions <= 0) return 0;
-    return Math.max(1, Math.min(4, Math.ceil((day.sessions / max) * 4)));
-};
-
-const activityLabel = (day: WrappedUsageDay): string =>
-    `${day.date}: ${fmtCount(day.sessions)} sessions, ${fmtCount(day.turns)} turns, ${
-        day.tokens == null ? "tokens not available" : `${fmtCount(day.tokens)} tokens`
-    }`;
-
 export function WrappedRoute() {
     const wrappedQuery = useQuery({
         queryKey: ["wrapped"],
         queryFn: () => api.wrapped(),
     });
-    const publicQuery = useQuery({
-        queryKey: ["wrapped", "public-preview"],
-        queryFn: () => api.wrappedPublicPreview(),
-    });
 
     const data = wrappedQuery.data ?? null;
-    const publicProfile = publicQuery.data ?? null;
     const loading = wrappedQuery.isLoading;
     const error = wrappedQuery.error ? String(wrappedQuery.error) : null;
-    const publicError = publicQuery.error ? String(publicQuery.error) : null;
 
     return (
         <section className="panel wrapped-page">
@@ -69,19 +48,14 @@ export function WrappedRoute() {
                 (data.cards?.length ?? 0) > 0 ? (
                     <>
                         <WrappedCardGrid cards={data.cards ?? []} />
+                        <ImproveCta />
                         <details open style={{ marginTop: 24 }}>
                             <summary style={{ cursor: "pointer" }}><strong>The numbers</strong></summary>
                             {/* The agent deck supersedes the mechanical hero +
                                 facts - only the raw stats live here. */}
                             <MetricGrid profile={data} />
                             <TokenScale tokens={data.usage.totalTokens} />
-                            <DailyHeatmap days={data.usage.days} />
                         </details>
-                        <PublicPreview
-                            profile={publicProfile}
-                            loading={publicQuery.isLoading}
-                            error={publicError}
-                        />
                     </>
                 ) : (
                     <>
@@ -89,13 +63,8 @@ export function WrappedRoute() {
                         <WrappedHero profile={data} />
                         <MetricGrid profile={data} />
                         <TokenScale tokens={data.usage.totalTokens} />
-                        <DailyHeatmap days={data.usage.days} />
                         <Facts facts={data.facts} />
-                        <PublicPreview
-                            profile={publicProfile}
-                            loading={publicQuery.isLoading}
-                            error={publicError}
-                        />
+                        <ImproveCta />
                     </>
                 )
             ) : null}
@@ -144,38 +113,6 @@ function MetricGrid({ profile }: { profile: WrappedProfile }) {
     );
 }
 
-function DailyHeatmap({ days }: { days: ReadonlyArray<WrappedUsageDay> }) {
-    const maxSessions = useMemo(
-        () => days.reduce((max, day) => Math.max(max, day.sessions), 0),
-        [days],
-    );
-
-    return (
-        <>
-            <h3 className="wrapped-h3">Daily activity</h3>
-            {days.length === 0 ? (
-                <div className="empty">No daily activity in this period.</div>
-            ) : (
-                <>
-                    <div className="wrapped-heatmap" aria-hidden="true">
-                        {days.map((day) => (
-                            <span
-                                key={day.date}
-                                className={`wrapped-day level-${heatLevel(day, maxSessions)}`}
-                                title={activityLabel(day)}
-                            />
-                        ))}
-                    </div>
-                    <ul className="sr-only" aria-label="Daily activity values">
-                        {days.map((day) => (
-                            <li key={day.date}>{activityLabel(day)}</li>
-                        ))}
-                    </ul>
-                </>
-            )}
-        </>
-    );
-}
 
 function Facts({ facts }: { facts: ReadonlyArray<WrappedFact> }) {
     return (
@@ -201,62 +138,6 @@ function Facts({ facts }: { facts: ReadonlyArray<WrappedFact> }) {
     );
 }
 
-function PublicPreview({
-    profile,
-    loading,
-    error,
-}: {
-    profile: WrappedProfile | null;
-    loading: boolean;
-    error: string | null;
-}) {
-    return (
-        <>
-            <h3 className="wrapped-h3">Public preview</h3>
-            {error ? <div className="error">Public preview error: {error}</div> : null}
-            {loading && !profile ? <div className="loading">Loading public preview…</div> : null}
-            {profile ? (
-                <div className="wrapped-public-preview">
-                    <div>
-                        <span className="badge keep">
-                            {profile.privacy.publicSafe ? "public safe" : "check"}
-                        </span>
-                        <h4>{profile.primaryArchetype.label}</h4>
-                        <p>{profile.primaryArchetype.publicLine}</p>
-                        <small>{scoreLabel(profile.primaryArchetype)}</small>
-                    </div>
-                    <ul>
-                        {/* The agent deck is the public artifact - list its
-                            surviving (non-sensitive) cards; mechanical facts
-                            only appear when no deck exists yet. */}
-                        {(profile.cards?.length ?? 0) > 0 ? (
-                            profile.cards!.map((card) => (
-                                <li key={`${card.position}-${card.headline}`}>
-                                    <strong>{card.headline}</strong>
-                                    <span>{card.body}</span>
-                                </li>
-                            ))
-                        ) : profile.facts.length === 0 ? (
-                            <li>No public facts available.</li>
-                        ) : (
-                            profile.facts.map((fact) => (
-                                <li key={fact.id}>
-                                    <strong>{fact.title}</strong>
-                                    <span>{fact.publicText}</span>
-                                </li>
-                            ))
-                        )}
-                    </ul>
-                    {profile.privacy.redactedFields.length > 0 ? (
-                        <p className="wrapped-redactions">
-                            Redacted: {profile.privacy.redactedFields.join(", ")}
-                        </p>
-                    ) : null}
-                </div>
-            ) : null}
-        </>
-    );
-}
 
 /** Header action: copies the generation brief for an agent session. */
 function GenerateBriefButton({ hasCards }: { readonly hasCards: boolean }) {
@@ -284,6 +165,32 @@ function GenerateCta() {
                 paste it into an agent session, and it will mine your graph and publish
                 headline cards here via <code>ax wrapped publish</code>.
             </p>
+        </div>
+    );
+}
+
+/** The bridge from "cool shareable recap" to the product's real job:
+ *  the improve loop. Counts come from the (cached) next-actions feed. */
+function ImproveCta() {
+    const query = useQuery({
+        queryKey: ["next-actions"],
+        queryFn: () => api.nextActions(),
+        staleTime: 60_000,
+    });
+    const count = query.data?.cards.length ?? 0;
+    return (
+        <div className="wrapped-improve-cta panel">
+            <div>
+                <h3 style={{ margin: "0 0 4px" }}>Now make it better</h3>
+                <p className="meta" style={{ margin: 0 }}>
+                    {count > 0
+                        ? `ax mined ${count} concrete next actions from this data - proposals to decide, failures to fix, savings to route.`
+                        : "ax mines your sessions for concrete next actions - proposals, failure fixes, routing savings."}
+                </p>
+            </div>
+            <Link to="/improve" className="badge keep wrapped-improve-link">
+                {count > 0 ? `What's next (${count}) →` : "Open the improve loop →"}
+            </Link>
         </div>
     );
 }

--- a/apps/studio/src/routes/wrapped.tsx
+++ b/apps/studio/src/routes/wrapped.tsx
@@ -69,7 +69,7 @@ export function WrappedRoute() {
                 (data.cards?.length ?? 0) > 0 ? (
                     <>
                         <WrappedCardGrid cards={data.cards ?? []} />
-                        <details style={{ marginTop: 24 }}>
+                        <details open style={{ marginTop: 24 }}>
                             <summary style={{ cursor: "pointer" }}><strong>The numbers</strong></summary>
                             {/* The agent deck supersedes the mechanical hero +
                                 facts - only the raw stats live here. */}

--- a/apps/studio/src/routes/wrapped.tsx
+++ b/apps/studio/src/routes/wrapped.tsx
@@ -21,7 +21,7 @@ const hourLabel = (hour: number | null): string => {
 const maybeCount = (value: number | null): string => (value == null ? "n/a" : fmtCount(value));
 
 const scoreLabel = (archetype: WrappedArchetype): string =>
-    `${Math.round(archetype.score)} score · ${archetype.confidence} confidence`;
+    `${archetype.confidence} confidence`;
 
 const heatLevel = (day: WrappedUsageDay, max: number): number => {
     if (max <= 0 || day.sessions <= 0) return 0;
@@ -70,10 +70,10 @@ export function WrappedRoute() {
                         <WrappedCardGrid cards={data.cards ?? []} />
                         <details style={{ marginTop: 24 }}>
                             <summary style={{ cursor: "pointer" }}><strong>The numbers</strong></summary>
-                            <WrappedHero profile={data} />
+                            {/* The agent deck supersedes the mechanical hero +
+                                facts - only the raw stats live here. */}
                             <MetricGrid profile={data} />
                             <DailyHeatmap days={data.usage.days} />
-                            <Facts facts={data.facts} />
                         </details>
                         <PublicPreview
                             profile={publicProfile}
@@ -109,10 +109,9 @@ function WrappedHero({ profile }: { profile: WrappedProfile }) {
                 <h3>{archetype.label}</h3>
                 <p className="wrapped-public-line">{archetype.publicLine}</p>
                 <p className="wrapped-internal">{archetype.internalExplanation || "No internal explanation available."}</p>
-            </div>
-            <div className="wrapped-score">
-                <strong>{Math.round(archetype.score)}</strong>
-                <span>{archetype.confidence} confidence</span>
+                {/* The raw archetype score is an internal ranking value -
+                    only the confidence band means anything to a reader. */}
+                <small className="wrapped-confidence">{archetype.confidence} confidence</small>
             </div>
         </div>
     );
@@ -161,9 +160,7 @@ function DailyHeatmap({ days }: { days: ReadonlyArray<WrappedUsageDay> }) {
                                 key={day.date}
                                 className={`wrapped-day level-${heatLevel(day, maxSessions)}`}
                                 title={activityLabel(day)}
-                            >
-                                <span>{day.date.slice(5)}</span>
-                            </span>
+                            />
                         ))}
                     </div>
                     <ul className="sr-only" aria-label="Daily activity values">

--- a/apps/studio/src/routes/wrapped.tsx
+++ b/apps/studio/src/routes/wrapped.tsx
@@ -8,6 +8,8 @@ import type {
     WrappedUsageDay,
 } from "@ax/lib/shared/dashboard-types";
 import { fmtCount, fmtTs } from "@ax/lib/shared/formatters";
+import { CopyButton } from "../components/copy-button.tsx";
+import { WrappedCardGrid } from "../components/wrapped-cards.tsx";
 
 const hourLabel = (hour: number | null): string => {
     if (hour == null) return "n/a";
@@ -56,23 +58,43 @@ export function WrappedRoute() {
                         ? `${data.period.label} · generated ${fmtTs(data.generatedAt)}`
                         : ""}
                 </span>
+                <GenerateBriefButton hasCards={(data?.cards?.length ?? 0) > 0} />
             </header>
 
             {error ? <div className="error">Error: {error}</div> : null}
             {loading && !data ? <div className="loading">Loading…</div> : null}
 
             {data ? (
-                <>
-                    <WrappedHero profile={data} />
-                    <MetricGrid profile={data} />
-                    <DailyHeatmap days={data.usage.days} />
-                    <Facts facts={data.facts} />
-                    <PublicPreview
-                        profile={publicProfile}
-                        loading={publicQuery.isLoading}
-                        error={publicError}
-                    />
-                </>
+                (data.cards?.length ?? 0) > 0 ? (
+                    <>
+                        <WrappedCardGrid cards={data.cards ?? []} />
+                        <details style={{ marginTop: 24 }}>
+                            <summary style={{ cursor: "pointer" }}><strong>The numbers</strong></summary>
+                            <WrappedHero profile={data} />
+                            <MetricGrid profile={data} />
+                            <DailyHeatmap days={data.usage.days} />
+                            <Facts facts={data.facts} />
+                        </details>
+                        <PublicPreview
+                            profile={publicProfile}
+                            loading={publicQuery.isLoading}
+                            error={publicError}
+                        />
+                    </>
+                ) : (
+                    <>
+                        <GenerateCta />
+                        <WrappedHero profile={data} />
+                        <MetricGrid profile={data} />
+                        <DailyHeatmap days={data.usage.days} />
+                        <Facts facts={data.facts} />
+                        <PublicPreview
+                            profile={publicProfile}
+                            loading={publicQuery.isLoading}
+                            error={publicError}
+                        />
+                    </>
+                )
             ) : null}
         </section>
     );
@@ -223,5 +245,35 @@ function PublicPreview({
                 </div>
             ) : null}
         </>
+    );
+}
+
+/** Header action: copies the generation brief for an agent session. */
+function GenerateBriefButton({ hasCards }: { readonly hasCards: boolean }) {
+    const query = useQuery({
+        queryKey: ["wrapped", "generate-brief"],
+        queryFn: () => api.wrappedGenerateBrief(),
+        staleTime: Infinity,
+    });
+    if (!query.data) return null;
+    return (
+        <CopyButton
+            text={query.data.brief}
+            label={hasCards ? "Regenerate wrapped" : "Copy wrapped brief"}
+        />
+    );
+}
+
+/** Empty-deck call to action above the mechanical fallback view. */
+function GenerateCta() {
+    return (
+        <div className="wrapped-cta panel">
+            <h3 style={{ margin: "0 0 4px" }}>Make this page yours</h3>
+            <p className="meta" style={{ margin: 0 }}>
+                These are the mechanical numbers. Copy the wrapped brief (top right),
+                paste it into an agent session, and it will mine your graph and publish
+                headline cards here via <code>ax wrapped publish</code>.
+            </p>
+        </div>
     );
 }

--- a/apps/studio/src/routes/wrapped.tsx
+++ b/apps/studio/src/routes/wrapped.tsx
@@ -223,7 +223,17 @@ function PublicPreview({
                         <small>{scoreLabel(profile.primaryArchetype)}</small>
                     </div>
                     <ul>
-                        {profile.facts.length === 0 ? (
+                        {/* The agent deck is the public artifact - list its
+                            surviving (non-sensitive) cards; mechanical facts
+                            only appear when no deck exists yet. */}
+                        {(profile.cards?.length ?? 0) > 0 ? (
+                            profile.cards!.map((card) => (
+                                <li key={`${card.position}-${card.headline}`}>
+                                    <strong>{card.headline}</strong>
+                                    <span>{card.body}</span>
+                                </li>
+                            ))
+                        ) : profile.facts.length === 0 ? (
                             <li>No public facts available.</li>
                         ) : (
                             profile.facts.map((fact) => (

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2501,71 +2501,66 @@ td.skill-cell .description {
     max-width: 280px;
 }
 
-/* ---- wrapped recap cards (Paxel-style) ---- */
+/* ---- wrapped recap cards (trace cards) ---- */
 .wrapped-cards {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 20px;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 16px;
     margin: 16px 0 8px;
 }
 .wrapped-card {
-    border: 1px solid var(--accent, #e8590c);
-    outline: 1px dashed color-mix(in srgb, var(--accent, #e8590c) 55%, transparent);
-    outline-offset: -6px;
-    background: var(--paper, #fff);
+    border: 1px solid var(--line);
+    background: var(--panel);
     display: flex;
     flex-direction: column;
-    min-height: 280px;
-    box-shadow: 2px 3px 0 color-mix(in srgb, var(--accent, #e8590c) 25%, transparent);
+    min-height: 250px;
 }
-.wrapped-card-art {
-    height: 110px;
-    position: relative;
-    background-color: color-mix(in srgb, var(--accent, #e8590c) 14%, #fff);
-    background-image:
-        radial-gradient(color-mix(in srgb, var(--accent, #e8590c) 75%, transparent) 1.2px, transparent 1.3px),
-        radial-gradient(color-mix(in srgb, var(--accent, #e8590c) 45%, transparent) 1px, transparent 1.1px);
-    background-size: 7px 7px, 11px 11px;
-    background-position: 0 0, 3px 5px;
-}
-.wrapped-card-art.v1 { background-size: 5px 5px, 9px 9px; }
-.wrapped-card-art.v2 { background-size: 9px 9px, 13px 13px; background-position: 2px 1px, 0 0; }
-.wrapped-card-art.v3 { background-size: 6px 6px, 14px 14px; }
-.wrapped-card-dots {
-    position: absolute;
-    top: 8px;
-    right: 10px;
+.wrapped-card.accent-green  { --card-accent: var(--green); }
+.wrapped-card.accent-blue   { --card-accent: var(--blue); }
+.wrapped-card.accent-gold   { --card-accent: var(--gold); }
+.wrapped-card.accent-violet { --card-accent: var(--violet); }
+.wrapped-card.accent-rose   { --card-accent: var(--rose); }
+.wrapped-card-strip {
     display: flex;
-    gap: 5px;
+    align-items: flex-end;
+    gap: 3px;
+    height: 56px;
+    padding: 10px 14px 0;
+    border-bottom: 1px solid var(--line);
+    background: color-mix(in srgb, var(--card-accent) 6%, var(--panel));
 }
-.wrapped-card-dots i {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: #fff;
+.wrapped-card-strip i {
+    flex: 1;
+    background: color-mix(in srgb, var(--card-accent) 78%, var(--panel));
+    border-radius: 1px 1px 0 0;
+    min-height: 4px;
 }
 .wrapped-card-copy {
     padding: 14px 16px 18px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 7px;
 }
 .wrapped-card-eyebrow {
-    color: var(--accent, #e8590c);
+    color: var(--card-accent);
+    font-family: ui-monospace, Menlo, monospace;
     font-size: 12px;
-    letter-spacing: 0.02em;
+    letter-spacing: 0.01em;
 }
 .wrapped-card-headline {
     margin: 0;
-    font-size: clamp(22px, 2.2vw, 28px);
-    line-height: 1.08;
+    font-family: Georgia, serif;
+    font-weight: 600;
+    font-size: clamp(24px, 2.4vw, 30px);
+    line-height: 1.06;
     letter-spacing: -0.01em;
+    color: var(--ink);
 }
 .wrapped-card-body {
     margin: 0;
     font-size: 14px;
-    line-height: 1.45;
-    color: var(--ink-soft, #444);
+    line-height: 1.5;
+    color: var(--muted);
 }
 .wrapped-card-flag { align-self: flex-start; margin-top: 4px; }
 .wrapped-cta { margin: 12px 0 16px; padding: 14px 16px; }

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2500,3 +2500,72 @@ td.skill-cell .description {
 .masthead-ingest-error {
     max-width: 280px;
 }
+
+/* ---- wrapped recap cards (Paxel-style) ---- */
+.wrapped-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 20px;
+    margin: 16px 0 8px;
+}
+.wrapped-card {
+    border: 1px solid var(--accent, #e8590c);
+    outline: 1px dashed color-mix(in srgb, var(--accent, #e8590c) 55%, transparent);
+    outline-offset: -6px;
+    background: var(--paper, #fff);
+    display: flex;
+    flex-direction: column;
+    min-height: 280px;
+    box-shadow: 2px 3px 0 color-mix(in srgb, var(--accent, #e8590c) 25%, transparent);
+}
+.wrapped-card-art {
+    height: 110px;
+    position: relative;
+    background-color: color-mix(in srgb, var(--accent, #e8590c) 14%, #fff);
+    background-image:
+        radial-gradient(color-mix(in srgb, var(--accent, #e8590c) 75%, transparent) 1.2px, transparent 1.3px),
+        radial-gradient(color-mix(in srgb, var(--accent, #e8590c) 45%, transparent) 1px, transparent 1.1px);
+    background-size: 7px 7px, 11px 11px;
+    background-position: 0 0, 3px 5px;
+}
+.wrapped-card-art.v1 { background-size: 5px 5px, 9px 9px; }
+.wrapped-card-art.v2 { background-size: 9px 9px, 13px 13px; background-position: 2px 1px, 0 0; }
+.wrapped-card-art.v3 { background-size: 6px 6px, 14px 14px; }
+.wrapped-card-dots {
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    display: flex;
+    gap: 5px;
+}
+.wrapped-card-dots i {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #fff;
+}
+.wrapped-card-copy {
+    padding: 14px 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.wrapped-card-eyebrow {
+    color: var(--accent, #e8590c);
+    font-size: 12px;
+    letter-spacing: 0.02em;
+}
+.wrapped-card-headline {
+    margin: 0;
+    font-size: clamp(22px, 2.2vw, 28px);
+    line-height: 1.08;
+    letter-spacing: -0.01em;
+}
+.wrapped-card-body {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.45;
+    color: var(--ink-soft, #444);
+}
+.wrapped-card-flag { align-self: flex-start; margin-top: 4px; }
+.wrapped-cta { margin: 12px 0 16px; padding: 14px 16px; }

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2473,9 +2473,21 @@ td.skill-cell .description {
 /* ---- wrapped recap cards (trace cards) ---- */
 .wrapped-cards {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    /* Explicit column counts per viewport: a 12-card deck divides into
+       clean full rows at 4/3/2/1 - auto-fill packed 5 ragged columns on
+       wide screens and starved the headlines. */
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 16px;
     margin: 16px 0 8px;
+}
+@media (max-width: 1500px) {
+    .wrapped-cards { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+@media (max-width: 1020px) {
+    .wrapped-cards { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 640px) {
+    .wrapped-cards { grid-template-columns: 1fr; }
 }
 .wrapped-card {
     border: 1px solid var(--line);

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2601,3 +2601,8 @@ td.skill-cell .description {
     padding: 0 4px;
     border-radius: 2px;
 }
+
+.token-scale-chain-alt {
+    color: var(--muted);
+    font-size: 12px;
+}

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2588,3 +2588,16 @@ td.skill-cell .description {
     color: var(--muted-2);
     font-size: 11.5px;
 }
+
+.wrapped-card-strip { position: relative; }
+.wrapped-card-series-label {
+    position: absolute;
+    top: 4px;
+    right: 8px;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 10px;
+    color: var(--card-accent);
+    background: color-mix(in srgb, var(--panel) 80%, transparent);
+    padding: 0 4px;
+    border-radius: 2px;
+}

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2618,3 +2618,20 @@ td.skill-cell .description {
     color: var(--muted);
     font-size: 12px;
 }
+
+.wrapped-improve-cta {
+    margin-top: 20px;
+    padding: 16px 18px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    border: 1px solid var(--ink);
+}
+.wrapped-improve-link {
+    text-decoration: none;
+    white-space: nowrap;
+    font-size: 14px;
+    padding: 8px 14px;
+}

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2533,3 +2533,58 @@ td.skill-cell .description {
 }
 .wrapped-card-flag { align-self: flex-start; margin-top: 4px; }
 .wrapped-cta { margin: 12px 0 16px; padding: 14px 16px; }
+
+/* ---- token scale (tokens -> novels -> Eiffel towers) ---- */
+.token-scale {
+    border: 1px solid var(--line);
+    background: var(--panel);
+    padding: 14px 16px;
+    margin-top: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+.token-scale-chain {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 13px;
+    color: var(--ink);
+    line-height: 1.6;
+}
+.token-scale-shelf {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 34px;
+    border-bottom: 2px solid var(--ink);
+    padding: 0 2px;
+}
+.token-scale-shelf i {
+    flex: 1;
+    border-radius: 1px 1px 0 0;
+}
+.token-scale-shelf i:nth-child(5n + 1) { background: color-mix(in srgb, var(--green) 75%, var(--panel)); }
+.token-scale-shelf i:nth-child(5n + 2) { background: color-mix(in srgb, var(--blue) 75%, var(--panel)); }
+.token-scale-shelf i:nth-child(5n + 3) { background: color-mix(in srgb, var(--gold) 75%, var(--panel)); }
+.token-scale-shelf i:nth-child(5n + 4) { background: color-mix(in srgb, var(--violet) 75%, var(--panel)); }
+.token-scale-shelf i:nth-child(5n + 5) { background: color-mix(in srgb, var(--rose) 75%, var(--panel)); }
+.token-scale-towers {
+    display: flex;
+    align-items: flex-end;
+    gap: 6px;
+    color: var(--muted);
+}
+.token-scale-tower {
+    width: 22px;
+    height: 38px;
+}
+.token-scale-tower-overflow {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 13px;
+    color: var(--ink);
+    margin-left: 4px;
+    align-self: center;
+}
+.token-scale-note {
+    color: var(--muted-2);
+    font-size: 11.5px;
+}

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -1929,26 +1929,11 @@ td.skill-cell .description {
     overflow-wrap: anywhere;
 }
 
-.wrapped-score {
-    align-self: stretch;
-    border: 1px solid var(--line);
-    background: var(--panel);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    min-width: 0;
-    padding: 12px;
-    text-align: center;
+.wrapped-confidence {
+    color: var(--muted);
+    font-size: 12px;
 }
 
-.wrapped-score strong {
-    font-size: 40px;
-    line-height: 1;
-    font-variant-numeric: tabular-nums;
-}
-
-.wrapped-score span,
 .wrapped-metric span,
 .wrapped-public-preview small,
 .wrapped-redactions {
@@ -2121,40 +2106,24 @@ td.skill-cell .description {
 
 .wrapped-heatmap {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(42px, 1fr));
-    gap: 4px;
-    padding: 10px;
+    grid-template-columns: repeat(auto-fill, minmax(14px, 1fr));
+    gap: 3px;
+    padding: 12px;
     border: 1px solid var(--line);
     background: var(--panel);
 }
 
 .wrapped-day {
-    min-height: 32px;
-    border: 1px solid rgba(20, 22, 21, 0.08);
+    aspect-ratio: 1;
+    border-radius: 2px;
+    border: 1px solid rgba(20, 22, 21, 0.06);
     background: var(--track);
-    display: flex;
-    align-items: end;
-    justify-content: center;
-    padding: 3px;
-    overflow: hidden;
-}
-
-.wrapped-day span {
-    color: var(--muted);
-    font-family: ui-monospace, Menlo, monospace;
-    font-size: 10px;
-    white-space: nowrap;
 }
 
 .wrapped-day.level-1 { background: rgba(37, 103, 168, 0.16); }
 .wrapped-day.level-2 { background: rgba(37, 103, 168, 0.32); }
 .wrapped-day.level-3 { background: rgba(22, 132, 94, 0.42); }
 .wrapped-day.level-4 { background: rgba(22, 132, 94, 0.68); }
-
-.wrapped-day.level-3 span,
-.wrapped-day.level-4 span {
-    color: var(--panel);
-}
 
 .wrapped-facts {
     display: grid;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,6 +38,7 @@ axctl routing tune [--dry-run|--emit-brief] # mine YOUR dispatch history for new
 axctl routing compile                       # regenerate ~/.ax/hooks/routing-table.json (user classes preserved)
 axctl routing show                          # effective routing table with class origins
 axctl profile show [--window=N] [--no-cost] # local profile: stats + rig + taste from the graph
+axctl wrapped <generate|publish>            # agent-authored Wrapped recap cards for the dashboard landing
 axctl profile publish [--if-stale=H] [--yes] [--skip-registration]
                                             # publish profile gist + one-time community registration PR
 axctl profile unpublish                     # delete the published gist + local consent

--- a/docs/superpowers/plans/2026-06-12-wrapped-remake-pr4.md
+++ b/docs/superpowers/plans/2026-06-12-wrapped-remake-pr4.md
@@ -1,0 +1,45 @@
+# Wrapped Remake (PR4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wrapped landing becomes a Paxel-style headline-card recap whose copy is agent-generated (`ax wrapped generate` brief → agent → `ax wrapped publish`), falling back to the mechanical view when no cards exist.
+
+**Architecture:** New `wrapped_card` table (agent-authored copy; trivial read, no TTL cache so publish reflects instantly). The heavy mechanical profile stays cached (PR2); the contract wrapped handlers merge `cards` into the payload. Brief template shared by CLI + a contract GET endpoint. Card visual = CSS halftone art, headline-first typography.
+
+**Spec:** PR4 section of `docs/superpowers/specs/2026-06-12-improve-first-dashboard-design.md`. Paxel reference: eyebrow question → big headline → 2-line body, orange dither.
+
+**Hard-won rules:** new table ⇒ SCHEMA_TABLES (apps/axctl/src/queries/insights.ts:45); new endpoint ⇒ contract group + CONTRACT_ROUTES pair (web-handler.ts) + capability + mock fixture + viaContract client; `bun run db:schema` to apply DDL locally; sensitivity value space matches facts: `public | sensitive`.
+
+---
+
+### Task 1: `wrapped_card` table + types
+- schema.surql: question/headline/body (string), sensitivity (string DEFAULT 'public'), position (int DEFAULT 0), generated_at (datetime DEFAULT time::now()). SCHEMA_TABLES entry. `bun run db:schema`.
+- dashboard-types: `WrappedCardDto { question, headline, body, sensitivity, position }`; `WrappedProfile.cards?: ReadonlyArray<WrappedCardDto>`.
+- Commit `feat(schema): wrapped_card table + dto`.
+
+### Task 2: cards module (TDD)
+- `apps/axctl/src/dashboard/wrapped-cards.ts`: `fetchWrappedCards()` (SELECT ordered by position, type::string coercion on nothing needed - no record ids cross JS), `buildPublishStatements(cards)` pure (DELETE all + CREATE per card), `runPublishCards(raw)` (Schema-validated stdin shape `{ cards: [{question, headline, body, sensitivity?}] }`, 1..24 cards), `sanitizeWrappedCards` (drop sensitive).
+- Mock-DB tests: fetch ordering, publish statements snapshot, validation rejects empty/oversized, sensitive filter.
+- Commit `feat(dashboard): wrapped cards fetch + publish core`.
+
+### Task 3: serve merged profile
+- contract/insights.ts: `wrapped` handler → `Effect.all([fetchWrappedCached(), fetchWrappedCards()])` → `{...profile, cards}`; `wrappedPublicPreview` → sanitize profile + sanitizeWrappedCards.
+- Commit `feat(dashboard): serve agent cards on /api/wrapped`.
+
+### Task 4: generate brief + CLI
+- `apps/axctl/src/dashboard/wrapped-generate-brief.ts`: template - mine `curl /api/wrapped` mechanical numbers + `ax cost models` + `ax sessions churn` + `ax recall`; write 10-16 Paxel cards (eyebrow question, ≤6-word headline, ≤2-line body, personality not template-speak; mark sensitive ones); publish via `ax wrapped publish` JSON shape. Test asserts shape docs + publish command.
+- CLI `commands/wrapped.ts`: `wrapped generate [--force]` (writes .ax/tasks/wrapped-generate-<date>.md via Bun.write - NO node:fs, gate!), `wrapped publish [--file]` (stdin JSON → runPublishCards). Register in cli/index.ts + runtime manifest "db".
+- Commit `feat(cli): ax wrapped generate + publish`.
+
+### Task 5: brief endpoint
+- Contract InsightsGroup (or new wrapped slot): GET `/api/wrapped/generate-brief` → `{ brief }`; CONTRACT_ROUTES pair; capability `wrapped-generate`; mock fixture; api client `wrappedGenerateBrief()`; contract-routing test line.
+- Commit `feat(dashboard): wrapped generate-brief endpoint`.
+
+### Task 6: studio remake
+- wrapped.tsx: cards.length > 0 → `<WrappedCardGrid>` (eyebrow/headline/body, CSS halftone art header w/ deterministic per-index variant, slight rotation jitter, dotted borders) + collapsible `<details>` "The numbers" wrapping MetricGrid/heatmap/facts; header gains CopyButton(generate brief) labeled "Regenerate wrapped". No cards → current mechanical view + CTA panel "Generate your wrapped" with the same CopyButton + one-line instructions.
+- styles.css: `.wrapped-cards` grid, `.wrapped-card`, `.wrapped-card-art` (orange radial-gradient dot field), headline typography (clamp ~28px, tight leading).
+- Public preview keeps working (sanitized cards render there when present).
+- Commit `feat(studio): paxel-style wrapped card landing`.
+
+### Task 7: gate + e2e + PR
+- Full tests/typecheck/build/no-node-fs. Live: publish sample cards → /api/wrapped serves them → preview in vite → screenshot-level eyeball by user. Clean up sample cards or leave (user data - leave real ones only if user generated; sample = delete). PR; merge at CLEAN.

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -147,6 +147,10 @@ export const InsightsGroup = HttpApiGroup.make("insights")
             success: Schema.Unknown,
             error: InternalError,
         }),
+        HttpApiEndpoint.get("wrappedGenerateBrief", "/api/wrapped/generate-brief", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
         HttpApiEndpoint.get("workflow", "/api/workflow", {
             success: Schema.Unknown,
             error: InternalError,

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -768,6 +768,18 @@ export interface WrappedPrivacySummary {
     readonly redactedFields: ReadonlyArray<string>;
 }
 
+/** Agent-authored Wrapped recap card (ax wrapped publish). */
+export interface WrappedCardDto {
+    /** eyebrow question, e.g. "Which archetype are you?" */
+    readonly question: string;
+    /** the big line - headlines carry the card */
+    readonly headline: string;
+    readonly body: string;
+    /** 'sensitive' cards are dropped from the public preview */
+    readonly sensitivity: string;
+    readonly position: number;
+}
+
 export interface WrappedProfile {
     readonly generatedAt: string;
     readonly period: WrappedPeriod;
@@ -777,6 +789,8 @@ export interface WrappedProfile {
     readonly facts: ReadonlyArray<WrappedFact>;
     readonly metrics: WrappedMetrics;
     readonly privacy: WrappedPrivacySummary;
+    /** agent-authored recap cards; absent/empty until `ax wrapped publish` */
+    readonly cards?: ReadonlyArray<WrappedCardDto>;
 }
 
 export interface IngestEvent {

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -778,6 +778,9 @@ export interface WrappedCardDto {
     /** 'sensitive' cards are dropped from the public preview */
     readonly sensitivity: string;
     readonly position: number;
+    /** optional REAL data series grounding the card (drawn as its bar strip) */
+    readonly series?: ReadonlyArray<number>;
+    readonly series_label?: string | null;
 }
 
 export interface WrappedProfile {

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1847,3 +1847,17 @@ DEFINE FIELD since_days  ON ingest_file_state TYPE option<number>;  -- git histo
 DEFINE FIELD ingested_at ON ingest_file_state TYPE datetime DEFAULT time::now();
 DEFINE INDEX IF NOT EXISTS ingest_file_state_path_uq ON ingest_file_state FIELDS path UNIQUE;
 DEFINE INDEX IF NOT EXISTS ingest_file_state_source  ON ingest_file_state FIELDS source_kind;
+
+-- ---------------------------------------------------------------------------
+-- wrapped_card - agent-authored Wrapped recap cards (improve-first dashboard
+-- PR4). `ax wrapped generate` emits a brief; an agent mines the graph and
+-- publishes 10-16 headline cards via `ax wrapped publish` (full replace).
+-- The dashboard serves them merged onto /api/wrapped; `sensitivity =
+-- 'sensitive'` cards are dropped from the public preview.
+DEFINE TABLE wrapped_card SCHEMAFULL;
+DEFINE FIELD question     ON wrapped_card TYPE string;   -- eyebrow, e.g. "Which archetype are you?"
+DEFINE FIELD headline     ON wrapped_card TYPE string;   -- the big line, <=6 words
+DEFINE FIELD body         ON wrapped_card TYPE string;   -- <=2 supporting lines
+DEFINE FIELD sensitivity  ON wrapped_card TYPE string DEFAULT 'public';  -- public | sensitive
+DEFINE FIELD position     ON wrapped_card TYPE int DEFAULT 0;
+DEFINE FIELD generated_at ON wrapped_card TYPE datetime DEFAULT time::now();

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1860,4 +1860,8 @@ DEFINE FIELD headline     ON wrapped_card TYPE string;   -- the big line, <=6 wo
 DEFINE FIELD body         ON wrapped_card TYPE string;   -- <=2 supporting lines
 DEFINE FIELD sensitivity  ON wrapped_card TYPE string DEFAULT 'public';  -- public | sensitive
 DEFINE FIELD position     ON wrapped_card TYPE int DEFAULT 0;
+DEFINE FIELD series       ON wrapped_card TYPE array<number> DEFAULT [];
+    -- optional grounding sparkline - REAL data points (e.g. daily sessions
+    -- on the card's model), rendered as the card's bar strip
+DEFINE FIELD series_label ON wrapped_card TYPE option<string>;
 DEFINE FIELD generated_at ON wrapped_card TYPE datetime DEFAULT time::now();


### PR DESCRIPTION
PR4 (final) of docs/superpowers/specs/2026-06-12-improve-first-dashboard-design.md.

The Wrapped landing stops being mechanical template strings:

- **`wrapped_card` table** — agent-authored deck (question/headline/body/sensitivity/position), registered in SCHEMA_TABLES, full-replace publish semantics.
- **`ax wrapped generate`** — emits the mining brief (Paxel card rules: eyebrow question, ≤6-word headline, ≤2-line body, grounded in real numbers, personality over template-speak). Also served at `GET /api/wrapped/generate-brief` (capability `wrapped-generate`) for the dashboard's "Regenerate wrapped" copy button.
- **`ax wrapped publish`** — JSON stdin/--file, schema-validated (1–24 cards), atomic replace. Reads are deliberately uncached so a publish shows up on next fetch; the heavy mechanical profile keeps its PR2 TTL cache.
- **Serving** — `/api/wrapped` merges `cards` onto the cached profile; public-preview drops `sensitivity: "sensitive"` cards.
- **Studio** — cards present → Paxel grid (CSS halftone art, rotation jitter, headline-first type) with the mechanical view collapsed under "The numbers"; no cards → mechanical view + generate CTA.

**Verified:** 3681 tests pass, typecheck/build/no-node-fs clean. Live e2e: published a 6-card sample deck → `/api/wrapped` serves 6, public-preview serves 5 (sensitive dropped), vite preview renders the grid.

Closes out the improve-first dashboard spec (PR1 #327, PR2 #332, PR3 #340). Remaining follow-ups tracked separately: #326 churn perf, Workflow remake design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)