### PR TITLE
feat(contract): tighten the recall response to a real Schema (payload-typing template)

### DIFF
--- a/apps/axctl/src/dashboard/contract/recall-encode.test.ts
+++ b/apps/axctl/src/dashboard/contract/recall-encode.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Schema } from "effect";
+import { RecallResponse } from "@ax/lib/shared/api-contract";
+import { emptyRecallResponse } from "../recall.ts";
+
+/**
+ * HttpApi ENCODES a handler's return through the success schema. RecallResponse
+ * is deliberately a Schema.Struct, not a Schema.Class: a class schema's encode
+ * demands actual class instances and rejects the plain JS-mapped objects the
+ * recall handler returns (decode is lenient, encode is strict). These tests
+ * pin that - if someone switches the contract schema back to Schema.Class,
+ * the live endpoint 400s and this goes red first.
+ */
+const encode = Schema.encodeUnknownEffect(Schema.toCodecJson(RecallResponse));
+
+describe("RecallResponse contract schema encodes plain objects", () => {
+    test("the empty-q fast-path payload encodes", async () => {
+        const value = emptyRecallResponse("", 0, 50);
+        const json = await Effect.runPromise(encode(value)) as Record<string, unknown>;
+        expect(json).toMatchObject({
+            q: "",
+            hits: [],
+            commits: [],
+            skills: [],
+            total_counts: { turn: 0, commit: 0, skill: 0 },
+            window: { offset: 0, limit: 50 },
+        });
+    });
+
+    test("a fully-populated payload (all three hit kinds) encodes", async () => {
+        const value = {
+            q: "x",
+            hits: [{
+                turn_id: "turn:1", session_id: "s1", project: null, source: "claude",
+                cwd: "/p", role: "assistant", ts: "2026-01-01T00:00:00Z", snippet: "hi",
+            }],
+            commits: [{
+                commit_id: "commit:1", sha: "abc", repo: "ax", repository: "repository:r1",
+                ts: null, snippet: "msg", score: 1.5,
+            }],
+            skills: [{ skill_id: "skill:1", name: "tdd", description: null, snippet: "s", score: 2 }],
+            truncated: true,
+            total_count: 3,
+            total_counts: { turn: 1, commit: 1, skill: 1 },
+            window: { offset: 0, limit: 50 },
+        };
+        const back = await Effect.runPromise(encode(value)) as {
+            commits: Array<{ score: number }>; skills: Array<{ name: string }>;
+        };
+        expect(back.commits[0]?.score).toBe(1.5);
+        expect(back.skills[0]?.name).toBe("tdd");
+    });
+});

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -98,11 +98,70 @@ export const SystemGroup = HttpApiGroup.make("system")
         }),
     );
 
+// ---- recall payload (the first tightened insights response) -------------
+// These mirror the dashboard-types Recall* interfaces exactly. They are
+// Schema.Struct (not Schema.Class) on purpose: HttpApi ENCODES a handler's
+// return through the success schema, and a class schema's encode demands
+// actual class instances, while the recall handler returns plain JS-mapped
+// objects. A struct's Type is a plain object, so it encodes cleanly.
+
+export const RecallHit = Schema.Struct({
+    turn_id: Schema.String,
+    session_id: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    source: Schema.NullOr(Schema.String),
+    cwd: Schema.NullOr(Schema.String),
+    role: Schema.NullOr(Schema.String),
+    ts: Schema.NullOr(Schema.String),
+    snippet: Schema.String,
+});
+
+export const RecallCommitHit = Schema.Struct({
+    commit_id: Schema.String,
+    sha: Schema.String,
+    repo: Schema.NullOr(Schema.String),
+    repository: Schema.NullOr(Schema.String),
+    ts: Schema.NullOr(Schema.String),
+    snippet: Schema.String,
+    score: Schema.Number,
+});
+
+export const RecallSkillHit = Schema.Struct({
+    skill_id: Schema.String,
+    name: Schema.String,
+    description: Schema.NullOr(Schema.String),
+    snippet: Schema.String,
+    score: Schema.Number,
+});
+
+export const RecallResponse = Schema.Struct({
+    q: Schema.String,
+    hits: Schema.Array(RecallHit),
+    commits: Schema.Array(RecallCommitHit),
+    skills: Schema.Array(RecallSkillHit),
+    truncated: Schema.Boolean,
+    total_count: Schema.Number,
+    total_counts: Schema.Struct({
+        turn: Schema.Number,
+        commit: Schema.Number,
+        skill: Schema.Number,
+    }),
+    window: Schema.Struct({
+        offset: Schema.Number,
+        limit: Schema.Number,
+    }),
+});
+
+/** Studio-facing type derived from the contract (single source of truth). */
+export type RecallResponse = typeof RecallResponse.Type;
+
 /**
  * The insights family: cross-source recall, project pages, episode
  * timelines, the skill graph, wrapped profiles, workflow rollups, and tool
- * failures. Payloads are `Schema.Unknown` for now (same later-pass deal as
- * the system raw rows); paths, params, and status mapping are the contract.
+ * failures. Recall is the first response with a real Schema; the rest stay
+ * `Schema.Unknown` for now - tightening is per-family follow-up work, and
+ * raw-row passthroughs (graph-health, worktrees, self-improve) keep Unknown
+ * deliberately (validating untyped DB rows buys little and risks 400s).
  *
  * Path params are single-segment: every client URL-encodes ids, and the
  * legacy greedy `:param+` rows remain mounted for raw-slash ids.
@@ -118,7 +177,7 @@ export const InsightsGroup = HttpApiGroup.make("insights")
                 offset: Schema.optionalKey(Schema.Number),
                 limit: Schema.optionalKey(Schema.Number),
             },
-            success: Schema.Unknown,
+            success: RecallResponse,
             error: InternalError,
         }),
         HttpApiEndpoint.get("episodeTimeline", "/api/episodes/:parentId", {


### PR DESCRIPTION
## What

Deferred item 2, first slice + the reusable pattern. The recall endpoint's success payload goes from `Schema.Unknown` to real `Schema.Struct` types (`RecallResponse` + `RecallHit`/`RecallCommitHit`/`RecallSkillHit`), mirroring the `dashboard-types` Recall* interfaces. Responses now validate on the wire and the contract's generated type (OpenAPI, `HttpApiClient`) is precise.

## The encode gotcha (the load-bearing finding)

HttpApi **encodes** a handler's return through the success schema. `Schema.Class` encode demands actual class instances; the recall handler returns plain JS-mapped objects, so a class schema **400s every response** (decode is lenient, encode is strict — my first attempt did exactly this, caught in live smoke). `Schema.Struct`'s Type is a plain object and encodes cleanly. `recall-encode.test.ts` pins it (empty-q fast path + fully-populated all-three-sources payload) so nobody reverts to `Schema.Class`.

## Scope guidance for the tail

This is the template for per-family payload tightening. **Recommendation baked into the code comment:** tighten the curated JS-mapped payloads (sessions, skills, wrapped, …); leave the raw-row passthroughs (`graph-health`, `worktrees`, `self-improve`) as `Schema.Unknown` — validating untyped SurrealDB rows on every response buys little and risks 400s on benign drift. So item 2 is "tighten the ~20 curated payloads," not "all 32."

## Verification

Live: recall real-q, empty-q, and commit/skill sources all 200 (encode round-trips). Suite 3674 pass / typecheck clean / `build:web` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)