### PR TITLE
feat(contract): tighten curated payloads - skills + insights families (13 endpoints)

### DIFF
--- a/apps/axctl/src/dashboard/contract/insights-encode.test.ts
+++ b/apps/axctl/src/dashboard/contract/insights-encode.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Schema } from "effect";
+import {
+    EpisodeTimelinePayload,
+    SkillGraphPayload,
+    ToolFailureDetailPayload,
+    ToolFailuresResponse,
+    WorkflowResponse,
+} from "@ax/lib/shared/api-contract";
+
+/**
+ * Encode regression for the insights-extra payloads. Same contract as
+ * recall/skills: these are Schema.Struct so the handlers' plain JS-mapped
+ * objects encode (a Schema.Class would 400). Synthetic full-shape values
+ * pin the field sets - CI has no DB, so these are the only encode guard.
+ */
+const roundtrip = (schema: Schema.Top, value: unknown): Promise<unknown> =>
+    Effect.runPromise(
+        Schema.encodeUnknownEffect(Schema.toCodecJson(schema as never))(value) as Effect.Effect<unknown>,
+    );
+
+describe("insights-extra payload encode", () => {
+    test("ToolFailuresResponse + detail", async () => {
+        await roundtrip(ToolFailuresResponse, {
+            generatedAt: "t", failures: [{
+                label: "Bash", failure_count: 3, last_seen: null, last_error_text: null,
+                last_project: null, distinct_sessions: 2, total_calls: 10, failure_rate: 0.3,
+                exit_codes: [1, 2], recommendation: "fix", recommendation_reason: "high rate",
+            }],
+        });
+        await roundtrip(ToolFailureDetailPayload, {
+            label: "Bash", samples: [{
+                ts: "t", exit_code: 1, error_text: null, output_excerpt: null,
+                command_text: null, project: null, session_id: null, cwd: null,
+            }],
+        });
+        expect(true).toBe(true);
+    });
+
+    test("SkillGraphPayload", async () => {
+        const back = await roundtrip(SkillGraphPayload, {
+            min_count: 1, limit: 50, node_count: 1, edge_count: 1, max_edge_count: 1,
+            nodes: [{ name: "tdd", weight: 3, last_seen: null }],
+            edges: [{ source: "tdd", target: "debugging", count: 2, last_seen: null }],
+        }) as { edges: Array<{ count: number }> };
+        expect(back.edges[0]?.count).toBe(2);
+    });
+
+    test("EpisodeTimelinePayload with a node", async () => {
+        const back = await roundtrip(EpisodeTimelinePayload, {
+            parent_session_id: "s1", project: null, started_at: null, ended_at: null,
+            duration_ms: null, node_count: 1, shape: "P→E",
+            nodes: [{
+                session_id: "s2", role: "child", project: null, source: null,
+                started_at: null, ended_at: null, duration_ms: null, phase: "plan",
+                top_skills: [{ skill: "tdd", count: 1 }], invocation_count: 1,
+            }],
+        }) as { nodes: Array<{ phase: string }> };
+        expect(back.nodes[0]?.phase).toBe("plan");
+    });
+
+    test("WorkflowResponse (deepest nesting)", async () => {
+        const back = await roundtrip(WorkflowResponse, {
+            generatedAt: "t", weeksLookback: 8, topK: 5,
+            skills: [{ week: "2026-W19", counts: [{ label: "tdd", count: 3 }] }],
+            tools: [], sessionShape: [{ week: "2026-W19", session_count: 4 }],
+            convergence: [{ week: "2026-W19", jaccard: null, topK: ["tdd"], newcomers: [], dropouts: [] }],
+            shapes: [{ shape: "P→E", phases: ["plan", "execute"], session_count: 2, example_session_ids: ["s1"] }],
+            shapesTotal: 2,
+            episodes: [{ parent_session_id: "s1", project: null, started_at: null, child_count: 3, distinct_nicknames: 2 }],
+            episode_shapes: [{ shape: "P→E", phases: ["plan"], episode_count: 1, example_parent_ids: ["s1"], avg_children: 3 }],
+            episode_shapes_total: 1, narrative: "converging",
+        }) as { shapes: Array<{ shape: string }> };
+        expect(back.shapes[0]?.shape).toBe("P→E");
+    });
+});

--- a/apps/axctl/src/dashboard/contract/skills-encode.test.ts
+++ b/apps/axctl/src/dashboard/contract/skills-encode.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Schema } from "effect";
+import {
+    SkillDetailPayload,
+    SkillSourcePayload,
+    SkillTriageResponse,
+} from "@ax/lib/shared/api-contract";
+
+/**
+ * Encode regression for the skills-family payloads (Schema.Struct, not Class -
+ * see recall-encode.test.ts for why). Plain objects matching the
+ * dashboard-types interfaces must encode losslessly; a missing field would be
+ * silently dropped from the response, so these pin the full field set.
+ */
+describe("skills payload encode", () => {
+    test("SkillTriageResponse round-trips a fully-populated entry", async () => {
+        const value = {
+            generatedAt: "2026-01-01T00:00:00Z",
+            skills: [{
+                name: "tdd", scope: "user", description: null, dir_path: "/d", bytes: 12,
+                total_inv: 3, inv_7d: 1, inv_30d: 2, last_used: null, last_project: null,
+                corrections: 0, proposals: 0, commits_after: 0, taste_score: 1.5,
+                recommendation: "keep" as const, recommendation_reason: "used often",
+                decision: { skill_name: "tdd", decision: "keep" as const, reason: null, decided_at: "2026-01-01T00:00:00Z" },
+            }],
+        };
+        const back = await Effect.runPromise(
+            Schema.encodeUnknownEffect(Schema.toCodecJson(SkillTriageResponse))(value),
+        ) as typeof value;
+        expect(back.skills[0]?.taste_score).toBe(1.5);
+        expect(back.skills[0]?.decision?.decision).toBe("keep");
+    });
+
+    test("SkillDetailPayload round-trips nested invocations + arrays", async () => {
+        const value = {
+            name: "tdd", scope: "user", description: null, dir_path: null,
+            invocations: { total: 5, d7: 1, d30: 3, last: null },
+            recent: [{ ts: "2026-01-01T00:00:00Z", project: null, turn_has_error: true }],
+            corrections: [], proposals: [{ ts: "2026-01-01T00:00:00Z", project: null }],
+            paired: [{ partner: "debugging", count: 2, last_seen: null }],
+        };
+        const back = await Effect.runPromise(
+            Schema.encodeUnknownEffect(Schema.toCodecJson(SkillDetailPayload))(value),
+        ) as typeof value;
+        expect(back.invocations.total).toBe(5);
+        expect(back.recent[0]?.turn_has_error).toBe(true);
+        expect(back.paired[0]?.partner).toBe("debugging");
+    });
+
+    test("SkillSourcePayload round-trips the state literal", async () => {
+        const value = {
+            name: "tdd", scope: "user", dir_path: "/d", file_path: "/d/SKILL.md",
+            frontmatter: "x", body: "y", state: "active" as const, editable: true, error: null,
+        };
+        const back = await Effect.runPromise(
+            Schema.encodeUnknownEffect(Schema.toCodecJson(SkillSourcePayload))(value),
+        ) as typeof value;
+        expect(back.state).toBe("active");
+        expect(back.editable).toBe(true);
+    });
+});

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -155,6 +155,151 @@ export const RecallResponse = Schema.Struct({
 /** Studio-facing type derived from the contract (single source of truth). */
 export type RecallResponse = typeof RecallResponse.Type;
 
+// ---- tool-failures, skill-graph, episode-timeline, workflow payloads -----
+// Bounded curated shapes mirroring the dashboard-types interfaces. SessionId
+// is a branded string on the wire, so Schema.String here.
+
+const ToolFailureEntry = Schema.Struct({
+    label: Schema.String,
+    failure_count: Schema.Number,
+    last_seen: Schema.NullOr(Schema.String),
+    last_error_text: Schema.NullOr(Schema.String),
+    last_project: Schema.NullOr(Schema.String),
+    distinct_sessions: Schema.Number,
+    total_calls: Schema.Number,
+    failure_rate: Schema.Number,
+    exit_codes: Schema.Array(Schema.Number),
+    recommendation: Schema.Literals(["fix", "watch", "ignore"]),
+    recommendation_reason: Schema.String,
+});
+
+export const ToolFailuresResponse = Schema.Struct({
+    generatedAt: Schema.String,
+    failures: Schema.Array(ToolFailureEntry),
+});
+
+const ToolFailureSample = Schema.Struct({
+    ts: Schema.String,
+    exit_code: Schema.NullOr(Schema.Number),
+    error_text: Schema.NullOr(Schema.String),
+    output_excerpt: Schema.NullOr(Schema.String),
+    command_text: Schema.NullOr(Schema.String),
+    project: Schema.NullOr(Schema.String),
+    session_id: Schema.NullOr(Schema.String),
+    cwd: Schema.NullOr(Schema.String),
+});
+
+export const ToolFailureDetailPayload = Schema.Struct({
+    label: Schema.String,
+    samples: Schema.Array(ToolFailureSample),
+});
+
+const SkillGraphNode = Schema.Struct({
+    name: Schema.String,
+    weight: Schema.Number,
+    last_seen: Schema.NullOr(Schema.String),
+});
+
+const SkillGraphEdge = Schema.Struct({
+    source: Schema.String,
+    target: Schema.String,
+    count: Schema.Number,
+    last_seen: Schema.NullOr(Schema.String),
+});
+
+export const SkillGraphPayload = Schema.Struct({
+    min_count: Schema.Number,
+    limit: Schema.Number,
+    node_count: Schema.Number,
+    edge_count: Schema.Number,
+    max_edge_count: Schema.Number,
+    nodes: Schema.Array(SkillGraphNode),
+    edges: Schema.Array(SkillGraphEdge),
+});
+
+const PhaseLiteral = Schema.Literals(["plan", "execute", "review", "merge"]);
+
+const EpisodeNode = Schema.Struct({
+    session_id: Schema.String,
+    role: Schema.Literals(["parent", "child"]),
+    project: Schema.NullOr(Schema.String),
+    source: Schema.NullOr(Schema.String),
+    started_at: Schema.NullOr(Schema.String),
+    ended_at: Schema.NullOr(Schema.String),
+    duration_ms: Schema.NullOr(Schema.Number),
+    phase: Schema.Literals(["plan", "execute", "review", "merge", "other", "mixed"]),
+    top_skills: Schema.Array(Schema.Struct({ skill: Schema.String, count: Schema.Number })),
+    invocation_count: Schema.Number,
+});
+
+export const EpisodeTimelinePayload = Schema.Struct({
+    parent_session_id: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    started_at: Schema.NullOr(Schema.String),
+    ended_at: Schema.NullOr(Schema.String),
+    duration_ms: Schema.NullOr(Schema.Number),
+    node_count: Schema.Number,
+    nodes: Schema.Array(EpisodeNode),
+    shape: Schema.String,
+});
+
+const WorkflowWeekBucket = Schema.Struct({
+    week: Schema.String,
+    counts: Schema.Array(Schema.Struct({ label: Schema.String, count: Schema.Number })),
+});
+
+const WorkflowConvergencePoint = Schema.Struct({
+    week: Schema.String,
+    jaccard: Schema.NullOr(Schema.Number),
+    topK: Schema.Array(Schema.String),
+    newcomers: Schema.Array(Schema.String),
+    dropouts: Schema.Array(Schema.String),
+});
+
+const WorkflowSessionShape = Schema.Struct({
+    week: Schema.String,
+    session_count: Schema.Number,
+});
+
+const SessionShapeAggregate = Schema.Struct({
+    shape: Schema.String,
+    phases: Schema.Array(PhaseLiteral),
+    session_count: Schema.Number,
+    example_session_ids: Schema.Array(Schema.String),
+});
+
+const WorkflowEpisode = Schema.Struct({
+    parent_session_id: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    started_at: Schema.NullOr(Schema.String),
+    child_count: Schema.Number,
+    distinct_nicknames: Schema.Number,
+});
+
+const EpisodeShapeAggregate = Schema.Struct({
+    shape: Schema.String,
+    phases: Schema.Array(PhaseLiteral),
+    episode_count: Schema.Number,
+    example_parent_ids: Schema.Array(Schema.String),
+    avg_children: Schema.Number,
+});
+
+export const WorkflowResponse = Schema.Struct({
+    generatedAt: Schema.String,
+    weeksLookback: Schema.Number,
+    topK: Schema.Number,
+    skills: Schema.Array(WorkflowWeekBucket),
+    tools: Schema.Array(WorkflowWeekBucket),
+    sessionShape: Schema.Array(WorkflowSessionShape),
+    convergence: Schema.Array(WorkflowConvergencePoint),
+    shapes: Schema.Array(SessionShapeAggregate),
+    shapesTotal: Schema.Number,
+    episodes: Schema.Array(WorkflowEpisode),
+    episode_shapes: Schema.Array(EpisodeShapeAggregate),
+    episode_shapes_total: Schema.Number,
+    narrative: Schema.String,
+});
+
 /**
  * The insights family: cross-source recall, project pages, episode
  * timelines, the skill graph, wrapped profiles, workflow rollups, and tool
@@ -182,7 +327,7 @@ export const InsightsGroup = HttpApiGroup.make("insights")
         }),
         HttpApiEndpoint.get("episodeTimeline", "/api/episodes/:parentId", {
             params: { parentId: Schema.String },
-            success: Schema.Unknown,
+            success: EpisodeTimelinePayload,
             error: InternalError,
         }),
         HttpApiEndpoint.get("skillGraph", "/api/skill-graph", {
@@ -190,7 +335,7 @@ export const InsightsGroup = HttpApiGroup.make("insights")
                 minCount: Schema.optionalKey(Schema.Number),
                 limit: Schema.optionalKey(Schema.Number),
             },
-            success: Schema.Unknown,
+            success: SkillGraphPayload,
             error: InternalError,
         }),
         HttpApiEndpoint.get("project", "/api/projects/:project", {
@@ -207,16 +352,16 @@ export const InsightsGroup = HttpApiGroup.make("insights")
             error: InternalError,
         }),
         HttpApiEndpoint.get("workflow", "/api/workflow", {
-            success: Schema.Unknown,
+            success: WorkflowResponse,
             error: InternalError,
         }),
         HttpApiEndpoint.get("toolFailures", "/api/tool-failures", {
-            success: Schema.Unknown,
+            success: ToolFailuresResponse,
             error: InternalError,
         }),
         HttpApiEndpoint.get("toolFailureDetail", "/api/tool-failures/:label/detail", {
             params: { label: Schema.String },
-            success: Schema.Unknown,
+            success: ToolFailureDetailPayload,
             error: InternalError,
         }),
     );

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -319,19 +319,121 @@ export class ServiceUnavailableError extends Schema.ErrorClass<ServiceUnavailabl
 /** Skill triage decision states (mirrors dashboard-types TriageDecision). */
 export const TriageDecisionSchema = Schema.Literals(["keep", "archive", "review"]);
 
+// ---- skills payloads (Schema.Struct: encode-safe for plain handler returns) -
+// Mirror the dashboard-types Skill* interfaces exactly. Handlers JS-map their
+// rows, so plain objects encode cleanly through these (see RecallResponse).
+
+export const SkillTriageNote = Schema.Struct({
+    skill_name: Schema.String,
+    decision: TriageDecisionSchema,
+    reason: Schema.NullOr(Schema.String),
+    decided_at: Schema.String,
+});
+
+const SkillRowFields = {
+    name: Schema.String,
+    scope: Schema.String,
+    description: Schema.NullOr(Schema.String),
+    dir_path: Schema.NullOr(Schema.String),
+    bytes: Schema.NullOr(Schema.Number),
+    total_inv: Schema.Number,
+    inv_7d: Schema.Number,
+    inv_30d: Schema.Number,
+    last_used: Schema.NullOr(Schema.String),
+    last_project: Schema.NullOr(Schema.String),
+    corrections: Schema.Number,
+    proposals: Schema.Number,
+    commits_after: Schema.Number,
+    taste_score: Schema.Number,
+};
+
+export const SkillTriageEntry = Schema.Struct({
+    ...SkillRowFields,
+    recommendation: TriageDecisionSchema,
+    recommendation_reason: Schema.String,
+    decision: Schema.NullOr(SkillTriageNote),
+});
+
+export const SkillTriageResponse = Schema.Struct({
+    generatedAt: Schema.String,
+    skills: Schema.Array(SkillTriageEntry),
+});
+
+const SkillRecentInvocation = Schema.Struct({
+    ts: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    turn_has_error: Schema.optionalKey(Schema.Boolean),
+});
+
+const SkillProposalEvidence = Schema.Struct({
+    ts: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    context_excerpt: Schema.optionalKey(Schema.NullOr(Schema.String)),
+});
+
+const SkillPair = Schema.Struct({
+    partner: Schema.String,
+    count: Schema.Number,
+    last_seen: Schema.NullOr(Schema.String),
+});
+
+export const SkillDetailPayload = Schema.Struct({
+    name: Schema.String,
+    scope: Schema.NullOr(Schema.String),
+    description: Schema.NullOr(Schema.String),
+    dir_path: Schema.NullOr(Schema.String),
+    invocations: Schema.Struct({
+        total: Schema.Number,
+        d7: Schema.Number,
+        d30: Schema.Number,
+        last: Schema.NullOr(Schema.String),
+    }),
+    recent: Schema.Array(SkillRecentInvocation),
+    corrections: Schema.Array(SkillRecentInvocation),
+    proposals: Schema.Array(SkillProposalEvidence),
+    paired: Schema.Array(SkillPair),
+});
+
+export const SkillSourcePayload = Schema.Struct({
+    name: Schema.String,
+    scope: Schema.String,
+    dir_path: Schema.NullOr(Schema.String),
+    file_path: Schema.NullOr(Schema.String),
+    frontmatter: Schema.NullOr(Schema.String),
+    body: Schema.NullOr(Schema.String),
+    state: Schema.Literals(["active", "disabled", "missing"]),
+    editable: Schema.Boolean,
+    error: Schema.NullOr(Schema.String),
+});
+
+export const SkillDecisionsResponse = Schema.Struct({
+    decisions: Schema.Array(SkillTriageNote),
+});
+
+export const SkillDecideBulkResponse = Schema.Struct({
+    notes: Schema.Array(SkillTriageNote),
+});
+
+export const SkillDecideClearResponse = Schema.Struct({
+    cleared: Schema.Boolean,
+    skill_name: Schema.String,
+});
+
+export const SkillOpenResponse = Schema.Struct({ launched: Schema.String });
+
 /**
  * The skills family: triage listing, per-skill decide (POST/DELETE),
- * bulk decide, detail, source, open-in, and the decisions list. Payloads
- * `Schema.Unknown` except the mutation request bodies, which are typed.
+ * bulk decide, detail, source, open-in, and the decisions list. Request
+ * bodies AND responses are schema-typed; the handlers return plain objects.
  */
 export const SkillsGroup = HttpApiGroup.make("skills")
     .add(
         HttpApiEndpoint.get("decisions", "/api/decisions", {
-            success: Schema.Unknown,
+            success: SkillDecisionsResponse,
             error: InternalError,
         }),
         HttpApiEndpoint.get("skills", "/api/skills", {
-            success: Schema.Unknown,
+            success: SkillTriageResponse,
             error: InternalError,
         }),
         HttpApiEndpoint.post("skillDecideBulk", "/api/skills/decide-bulk", {
@@ -340,7 +442,7 @@ export const SkillsGroup = HttpApiGroup.make("skills")
                 decision: TriageDecisionSchema,
                 reason: Schema.optionalKey(Schema.NullOr(Schema.String)),
             }),
-            success: Schema.Unknown,
+            success: SkillDecideBulkResponse,
             error: [BadRequestError, InternalError],
         }),
         HttpApiEndpoint.post("skillDecide", "/api/skills/:name/decide", {
@@ -349,22 +451,22 @@ export const SkillsGroup = HttpApiGroup.make("skills")
                 decision: TriageDecisionSchema,
                 reason: Schema.optionalKey(Schema.NullOr(Schema.String)),
             }),
-            success: Schema.Unknown,
+            success: SkillTriageNote,
             error: InternalError,
         }),
         HttpApiEndpoint.delete("skillDecideClear", "/api/skills/:name/decide", {
             params: { name: Schema.String },
-            success: Schema.Unknown,
+            success: SkillDecideClearResponse,
             error: InternalError,
         }),
         HttpApiEndpoint.get("skillDetail", "/api/skills/:name/detail", {
             params: { name: Schema.String },
-            success: Schema.Unknown,
+            success: SkillDetailPayload,
             error: InternalError,
         }),
         HttpApiEndpoint.get("skillSource", "/api/skills/:name/source", {
             params: { name: Schema.String },
-            success: Schema.Unknown,
+            success: SkillSourcePayload,
             error: InternalError,
         }),
         HttpApiEndpoint.post("skillOpen", "/api/skills/:name/open", {
@@ -372,7 +474,7 @@ export const SkillsGroup = HttpApiGroup.make("skills")
             payload: Schema.Struct({
                 target: Schema.Literals(["finder", "editor"]),
             }),
-            success: Schema.Unknown,
+            success: SkillOpenResponse,
             error: InternalError,
         }),
     );


### PR DESCRIPTION
## What

Item 2 continued — 13 more curated payloads move from `Schema.Unknown` to real `Schema.Struct` types, in two commits:

**Skills family (8):** `skills` (SkillTriageResponse), `decisions`, `skillDecide`/`decide-bulk`/`decide-clear`, `skillDetail` (SkillDetailPayload), `skillSource` (SkillSourcePayload), `skillOpen`.

**Insights-extra (5):** `toolFailures` (ToolFailuresResponse), `toolFailureDetail`, `skillGraph` (SkillGraphPayload), `episodeTimeline` (EpisodeTimelinePayload), `workflow` (WorkflowResponse — the deepest nesting).

All `Schema.Struct` (not Class) per the recall precedent — HttpApi encodes handler returns and class encode rejects the handlers' plain objects.

## The field-drift check (load-bearing)

`Schema.Struct` encode silently *drops* fields not in the schema. For every endpoint I diffed the live encoded response's keys against the schema and confirmed the full field set survives — nothing vanishes. `skills-encode.test.ts` + `insights-encode.test.ts` pin the shapes (CI has no DB, so synthetic-value encode tests are the only guard against Class-revert and field drift).

## Verification

Live: all 13 endpoints 200 with intact field sets (skills entry 17 fields, workflow 13 keys, etc.). Suite 3681 pass / typecheck clean.

## Remaining tail

Sessions family (list/detail/inspect/canvas/timeline/compare/insights — the deeply-nested mega-payloads) + project + wrapped. Those are the heaviest; next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)