### PR TITLE
feat(contract): tighten bounded sessions payloads - completes curated-payload typing

### DIFF
--- a/apps/axctl/src/dashboard/contract/sessions-encode.test.ts
+++ b/apps/axctl/src/dashboard/contract/sessions-encode.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Schema } from "effect";
+import {
+    SessionCanvasPayload,
+    SessionComparePayload,
+    SessionListResponse,
+    SessionOrchestration,
+    SessionSummary,
+} from "@ax/lib/shared/api-contract";
+
+/**
+ * Encode regression for the bounded sessions payloads (Schema.Struct, not
+ * Class - see recall-encode.test.ts). Plain handler objects must encode with
+ * full field sets; CI has no DB so these synthetic-value tests are the guard.
+ */
+const roundtrip = (schema: Schema.Top, value: unknown): Promise<unknown> =>
+    Effect.runPromise(
+        Schema.encodeUnknownEffect(Schema.toCodecJson(schema as never))(value) as Effect.Effect<unknown>,
+    );
+
+const listRow = {
+    id: "s1", project: null, source: "claude", cwd: null, model: null,
+    started_at: null, ended_at: null, has_raw_file: true, turn_count: 5,
+    parent_session: null, direct_children_count: 2, cost_usd: null, burn_buckets: null,
+    friction: null, signal: "clean" as const, produced_commits: null, reverted_commits: null,
+    lines_added: null, lines_removed: null, is_live: false,
+};
+
+describe("sessions payload encode", () => {
+    test("SessionListResponse with a fully-enriched row", async () => {
+        const back = await roundtrip(SessionListResponse, {
+            sessions: [listRow], total_count: 1, burn_p90: 608.3,
+            window: { offset: 0, limit: 200 },
+        }) as { sessions: Array<{ signal: string; direct_children_count?: number }> };
+        expect(back.sessions[0]?.signal).toBe("clean");
+        expect(back.sessions[0]?.direct_children_count).toBe(2);
+    });
+
+    test("SessionSummary + SessionOrchestration", async () => {
+        await roundtrip(SessionSummary, {
+            session_id: "s1", task: null, first_ask: null, last_assistant: null,
+            correction: null, turns: 3, tokens: null, cost_usd: null, model: null,
+            subagents: 1, tools: [{ name: "Bash", count: 4 }],
+        });
+        await roundtrip(SessionOrchestration, {
+            session_id: "s1", label: "x", started_at: null, ended_at: null, wait_pct: 0.2,
+            subagents: [{ id: "a", nickname: null, task: null, started_at: null, ended_at: null, tone: "quick", duration_ms: null }],
+        });
+        expect(true).toBe(true);
+    });
+
+    test("SessionComparePayload with token_usage + health + turns", async () => {
+        const back = await roundtrip(SessionComparePayload, {
+            task_label: null,
+            sessions: [{
+                session_id: "s1", source: "claude", model: null, project: null,
+                started_at: null, ended_at: null, duration_ms: null,
+                token_usage: {
+                    model: null, prompt_tokens: null, completion_tokens: null,
+                    cache_creation_input_tokens: null, cache_read_input_tokens: null,
+                    estimated_tokens: 100, estimated_cost_usd: null, pricing_source: null,
+                },
+                health: {
+                    turns: 3, tool_calls: 5, tool_errors: 0, user_corrections: 1,
+                    interruptions: 0, subagent_dispatches: 2, task_label: null,
+                },
+                commit_count: 1, noise_score: null,
+                turns: [{ seq: 0, role: "user", ts: null, gap_ms: null, est_tokens: null, est_cost_usd: null, has_error: false }],
+            }],
+            winners: { fastest: "s1", cheapest: null, fewest_tokens: null, cleanest: null },
+            not_found: [],
+        }) as { sessions: Array<{ token_usage: { estimated_tokens: number } }> };
+        expect(back.sessions[0]?.token_usage.estimated_tokens).toBe(100);
+    });
+
+    test("SessionCanvasPayload node with compactions + wait_segments", async () => {
+        const back = await roundtrip(SessionCanvasPayload, {
+            generatedAt: "t",
+            nodes: [{
+                id: "s1", label: "x", project: null, source: "claude", started_at: null, ended_at: null,
+                size: 1000, turns: 5, epochs: 1, compactions: [{ pre_tokens: 900, trigger: "auto" }],
+                context_pressure: "low", corrections: 0, tone: "neutral", is_subagent: false,
+                subagent_count: 0, wait_segments: [{ start: 0.1, end: 0.3 }],
+            }],
+            edges: [{ source: "s1", target: "s2", relation: "spawned", label: null }],
+            warnings: [],
+        }) as { nodes: Array<{ wait_segments: Array<{ end: number }> }> };
+        expect(back.nodes[0]?.wait_segments[0]?.end).toBe(0.3);
+    });
+});

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -366,12 +366,181 @@ export const InsightsGroup = HttpApiGroup.make("insights")
         }),
     );
 
+// ---- sessions payloads (the bounded ones) -------------------------------
+// Mirror the dashboard-types Session* interfaces. The deeply-nested
+// detail/inspect/insights payloads stay Schema.Unknown below (transcribing
+// the 54k-line inspect handler's output exactly is high-drift, low-value).
+
+const SessionListRow = Schema.Struct({
+    id: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    source: Schema.String,
+    cwd: Schema.NullOr(Schema.String),
+    model: Schema.NullOr(Schema.String),
+    started_at: Schema.NullOr(Schema.String),
+    ended_at: Schema.NullOr(Schema.String),
+    has_raw_file: Schema.Boolean,
+    turn_count: Schema.Number,
+    parent_session: Schema.NullOr(Schema.String),
+    direct_children_count: Schema.optionalKey(Schema.Number),
+    cost_usd: Schema.NullOr(Schema.Number),
+    burn_buckets: Schema.NullOr(Schema.Array(Schema.Number)),
+    friction: Schema.NullOr(Schema.Number),
+    signal: Schema.NullOr(Schema.Literals(["clean", "friction"])),
+    produced_commits: Schema.NullOr(Schema.Number),
+    reverted_commits: Schema.NullOr(Schema.Number),
+    lines_added: Schema.NullOr(Schema.Number),
+    lines_removed: Schema.NullOr(Schema.Number),
+    is_live: Schema.Boolean,
+});
+
+export const SessionListResponse = Schema.Struct({
+    sessions: Schema.Array(SessionListRow),
+    total_count: Schema.Number,
+    burn_p90: Schema.NullOr(Schema.Number),
+    window: Schema.Struct({ offset: Schema.Number, limit: Schema.Number }),
+});
+
+export const SessionChildrenResponse = Schema.Struct({
+    parent_session: Schema.String,
+    children: Schema.Array(SessionListRow),
+});
+
+export const SessionSummary = Schema.Struct({
+    session_id: Schema.String,
+    task: Schema.NullOr(Schema.String),
+    first_ask: Schema.NullOr(Schema.String),
+    last_assistant: Schema.NullOr(Schema.String),
+    correction: Schema.NullOr(Schema.String),
+    turns: Schema.Number,
+    tokens: Schema.NullOr(Schema.Number),
+    cost_usd: Schema.NullOr(Schema.Number),
+    model: Schema.NullOr(Schema.String),
+    subagents: Schema.Number,
+    tools: Schema.Array(Schema.Struct({ name: Schema.String, count: Schema.Number })),
+});
+
+const SessionOrchestrationSubagent = Schema.Struct({
+    id: Schema.String,
+    nickname: Schema.NullOr(Schema.String),
+    task: Schema.NullOr(Schema.String),
+    started_at: Schema.NullOr(Schema.String),
+    ended_at: Schema.NullOr(Schema.String),
+    tone: Schema.String,
+    duration_ms: Schema.NullOr(Schema.Number),
+});
+
+export const SessionOrchestration = Schema.Struct({
+    session_id: Schema.String,
+    label: Schema.String,
+    started_at: Schema.NullOr(Schema.String),
+    ended_at: Schema.NullOr(Schema.String),
+    wait_pct: Schema.Number,
+    subagents: Schema.Array(SessionOrchestrationSubagent),
+});
+
+const SessionTokenUsageDetail = Schema.Struct({
+    model: Schema.NullOr(Schema.String),
+    prompt_tokens: Schema.NullOr(Schema.Number),
+    completion_tokens: Schema.NullOr(Schema.Number),
+    cache_creation_input_tokens: Schema.NullOr(Schema.Number),
+    cache_read_input_tokens: Schema.NullOr(Schema.Number),
+    estimated_tokens: Schema.Number,
+    estimated_input_cost_usd: Schema.optionalKey(Schema.NullOr(Schema.Number)),
+    estimated_output_cost_usd: Schema.optionalKey(Schema.NullOr(Schema.Number)),
+    estimated_cache_creation_cost_usd: Schema.optionalKey(Schema.NullOr(Schema.Number)),
+    estimated_cache_read_cost_usd: Schema.optionalKey(Schema.NullOr(Schema.Number)),
+    estimated_cost_usd: Schema.NullOr(Schema.Number),
+    pricing_source: Schema.NullOr(Schema.String),
+});
+
+const SessionHealthSummary = Schema.Struct({
+    turns: Schema.Number,
+    tool_calls: Schema.Number,
+    tool_errors: Schema.Number,
+    user_corrections: Schema.Number,
+    interruptions: Schema.Number,
+    subagent_dispatches: Schema.Number,
+    task_label: Schema.NullOr(Schema.String),
+});
+
+const SessionCompareTurn = Schema.Struct({
+    seq: Schema.Number,
+    role: Schema.NullOr(Schema.String),
+    ts: Schema.NullOr(Schema.String),
+    gap_ms: Schema.NullOr(Schema.Number),
+    est_tokens: Schema.NullOr(Schema.Number),
+    est_cost_usd: Schema.NullOr(Schema.Number),
+    has_error: Schema.Boolean,
+});
+
+const SessionCompareEntry = Schema.Struct({
+    session_id: Schema.String,
+    source: Schema.String,
+    model: Schema.NullOr(Schema.String),
+    project: Schema.NullOr(Schema.String),
+    started_at: Schema.NullOr(Schema.String),
+    ended_at: Schema.NullOr(Schema.String),
+    duration_ms: Schema.NullOr(Schema.Number),
+    token_usage: Schema.NullOr(SessionTokenUsageDetail),
+    health: Schema.NullOr(SessionHealthSummary),
+    commit_count: Schema.Number,
+    noise_score: Schema.NullOr(Schema.Number),
+    turns: Schema.optionalKey(Schema.Array(SessionCompareTurn)),
+});
+
+export const SessionComparePayload = Schema.Struct({
+    task_label: Schema.NullOr(Schema.String),
+    sessions: Schema.Array(SessionCompareEntry),
+    winners: Schema.Struct({
+        fastest: Schema.NullOr(Schema.String),
+        cheapest: Schema.NullOr(Schema.String),
+        fewest_tokens: Schema.NullOr(Schema.String),
+        cleanest: Schema.NullOr(Schema.String),
+    }),
+    not_found: Schema.Array(Schema.String),
+});
+
+const SessionCanvasNode = Schema.Struct({
+    id: Schema.String,
+    label: Schema.String,
+    project: Schema.NullOr(Schema.String),
+    source: Schema.String,
+    started_at: Schema.NullOr(Schema.String),
+    ended_at: Schema.NullOr(Schema.String),
+    size: Schema.Number,
+    turns: Schema.Number,
+    epochs: Schema.Number,
+    compactions: Schema.Array(Schema.Struct({ pre_tokens: Schema.Number, trigger: Schema.String })),
+    context_pressure: Schema.String,
+    corrections: Schema.Number,
+    tone: Schema.String,
+    is_subagent: Schema.Boolean,
+    subagent_count: Schema.Number,
+    wait_segments: Schema.Array(Schema.Struct({ start: Schema.Number, end: Schema.Number })),
+});
+
+const SessionCanvasEdge = Schema.Struct({
+    source: Schema.String,
+    target: Schema.String,
+    relation: Schema.String,
+    label: Schema.NullOr(Schema.String),
+});
+
+export const SessionCanvasPayload = Schema.Struct({
+    generatedAt: Schema.String,
+    nodes: Schema.Array(SessionCanvasNode),
+    edges: Schema.Array(SessionCanvasEdge),
+    warnings: Schema.Array(Schema.String),
+});
+
 /**
- * The sessions family: per-session detail, list, canvas, compare, inspect,
- * timeline, insights, orchestration, children, and summary. Payloads are
- * `Schema.Unknown` (same later-pass deal); paths, params, and status mapping
- * are the contract. Path params are single-segment (client URL-encodes ids);
- * the legacy greedy `:param+` rows remain mounted for raw-slash ids.
+ * The sessions family: list, children, summary, orchestration, compare, and
+ * canvas are schema-typed. The detail/inspect/insights/timeline payloads
+ * stay `Schema.Unknown` deliberately - they are deeply-nested mega-payloads
+ * (inspect comes from the 54k-line session-inspect handler) where exact
+ * transcription is high-drift and low-value. Path params are single-segment
+ * (client URL-encodes ids); the legacy greedy `:param+` rows are retired.
  */
 export const SessionsGroup = HttpApiGroup.make("sessions")
     .add(
@@ -379,21 +548,21 @@ export const SessionsGroup = HttpApiGroup.make("sessions")
             query: {
                 limit: Schema.optionalKey(Schema.Number),
             },
-            success: Schema.Unknown,
+            success: SessionCanvasPayload,
             error: InternalError,
         }),
         HttpApiEndpoint.get("sessionSummary", "/api/session-summary", {
             query: {
                 id: Schema.String,
             },
-            success: Schema.Unknown,
+            success: SessionSummary,
             error: InternalError,
         }),
         HttpApiEndpoint.get("sessionOrchestration", "/api/session-orchestration", {
             query: {
                 id: Schema.String,
             },
-            success: Schema.Unknown,
+            success: SessionOrchestration,
             error: InternalError,
         }),
         HttpApiEndpoint.get("sessionsList", "/api/sessions", {
@@ -403,7 +572,7 @@ export const SessionsGroup = HttpApiGroup.make("sessions")
                 source: Schema.optionalKey(Schema.String),
                 project: Schema.optionalKey(Schema.String),
             },
-            success: Schema.Unknown,
+            success: SessionListResponse,
             error: InternalError,
         }),
         // Static path must precede the single-segment param path: HttpApi's
@@ -414,7 +583,7 @@ export const SessionsGroup = HttpApiGroup.make("sessions")
                 ids: Schema.String,
                 turns: Schema.optionalKey(Schema.String),
             },
-            success: Schema.Unknown,
+            success: SessionComparePayload,
             error: [BadRequestError, InternalError],
         }),
         HttpApiEndpoint.get("sessionChildren", "/api/sessions/:id/children", {
@@ -422,7 +591,7 @@ export const SessionsGroup = HttpApiGroup.make("sessions")
             query: {
                 limit: Schema.optionalKey(Schema.Number),
             },
-            success: Schema.Unknown,
+            success: SessionChildrenResponse,
             error: InternalError,
         }),
         HttpApiEndpoint.get("sessionInsights", "/api/sessions/:id/insights", {


### PR DESCRIPTION
## What

Final schema-tightening slice. The six **bounded** sessions endpoints move from `Schema.Unknown` to real `Schema.Struct` types: `sessionsList` (SessionListResponse — the 20-field enriched row with burn buckets, signal, LOC outcomes), `sessionChildren`, `sessionSummary`, `sessionOrchestration`, `sessionCompare` (token-usage + health + per-turn detail), `sessionCanvas` (swimlane nodes with compactions + wait_segments).

This **completes the curated-payload pass** across the whole contract.

## What stays `Schema.Unknown` (documented inline, on purpose)

- **Raw-row passthroughs:** `graph-health`, `worktrees`, `self-improve`, `analyze-brief` — untyped SurrealDB rows; validating them buys little and risks 400s on benign drift.
- **Deeply-nested mega-payloads:** session `detail`/`inspect`/`insights`/`timeline`, `project`, `wrapped` — exact transcription of the 54k-line inspect handler's output (and the wrapped personality recap) is high-drift, low-value.

## Verification

Live: all 6 endpoints 200 with full field sets (list row 20 keys, canvas node 16, compare entry 11 — all diffed against the schemas, nothing dropped). `sessions-encode.test.ts` pins the shapes. Suite 3685 pass / typecheck clean.

## Tally for the whole item-2 effort

Tightened across 4 PRs: recall (#346) → skills + insights-extra (#347) → bounded sessions (this). 20 curated endpoints now schema-validated with precise generated-client/OpenAPI types; the ~10 remaining are deliberate `Unknown` (raw rows + mega-payloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)