### PR TITLE
fix(ci): community-users validate reports on every PR (required-check prerequisite)

### DIFF
--- a/.github/workflows/community-users.yml
+++ b/.github/workflows/community-users.yml
@@ -1,13 +1,15 @@
-# IMPORTANT: auto-merge is only safe when the `validate` job of this workflow
-# is configured as a REQUIRED status check on main (repo Settings → Branches →
-# Protection rules) and "Allow auto-merge" is enabled on the repo.  Without
-# that, --auto can merge unvalidated synchronize commits.
+# Auto-merge safety model:
+#   - the `validate` job is a REQUIRED status check on main (repo ruleset),
+#     so --auto cannot merge unvalidated synchronize commits (TOCTOU), and
+#   - "Allow auto-merge" is enabled on the repo.
+# To keep `validate` safe as a required check it must report on EVERY PR -
+# path-filtered required checks wedge unrelated PRs in "expected" forever.
+# So this workflow runs on all PRs and passes trivially when no
+# community/users files are touched.
 name: community-users
 
 on:
   pull_request_target:
-    paths:
-      - "community/users/**"
 
 permissions:
   contents: read
@@ -19,66 +21,74 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      # pull_request_target runs with base-repo secrets; check out the PR
-      # head EXPLICITLY and never execute its code - we only read JSON files
-      # and run OUR validator from the base ref. The pr-head/ checkout is
-      # DATA-ONLY: nothing inside it is executed, installed, or sourced.
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: pr-head
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.10"
-
-      - name: Only community/users files changed
+      - name: Classify changed files
         id: scope
-        # Use the GitHub API (gh pr diff) instead of local git diff: the
-        # pr-head checkout is fetch-depth:1 so base.sha is absent and
-        # `git diff base...head` would fail with "fatal: bad object".
-        # gh pr diff returns paths without any pr-head/ prefix; we add it
-        # below when emitting the files list (the validator reads from the
-        # pr-head checkout).
-        # Filename filter is strict-lowercase: GitHub logins are
-        # case-insensitive but our convention is lowercase filenames and the
-        # validator enforces it.
+        # Modes:
+        #   none  - no community/users files touched -> trivially pass
+        #   clean - ONLY community/users/<login>.json files -> validate + auto-merge
+        #   mixed - community/users files alongside anything else (or
+        #           non-conforming filenames) -> human review comment
+        # gh pr diff is API-based: the checkouts below are fetch-depth:1 so a
+        # local base...head diff would fail with "fatal: bad object".
+        # Filename filter is strict-lowercase (grep -E; plain grep treats `+`
+        # literally): GitHub logins are case-insensitive but the convention is
+        # lowercase filenames and the validator enforces it.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           changed=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
           echo "$changed"
-          if echo "$changed" | grep -v '^community/users/[a-z0-9-]+\.json$' | grep -q .; then
-            echo "outside=true" >> "$GITHUB_OUTPUT"
+          community=$(echo "$changed" | grep -E '^community/users/' || true)
+          if [ -z "$community" ]; then
+            echo "mode=none" >> "$GITHUB_OUTPUT"
+            echo "no community/users files - passing trivially"
+          elif echo "$changed" | grep -Ev '^community/users/[a-z0-9-]+\.json$' | grep -q .; then
+            echo "mode=mixed" >> "$GITHUB_OUTPUT"
           else
-            echo "outside=false" >> "$GITHUB_OUTPUT"
+            echo "mode=clean" >> "$GITHUB_OUTPUT"
             echo "files<<EOF" >> "$GITHUB_OUTPUT"
             echo "$changed" | sed 's|^|pr-head/|' >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
           fi
 
+      # pull_request_target runs with base-repo secrets; check out the PR
+      # head EXPLICITLY and never execute its code - we only read JSON files
+      # and run OUR validator from the base ref. The pr-head/ checkout is
+      # DATA-ONLY: nothing inside it is executed, installed, or sourced.
+      - uses: actions/checkout@v4
+        if: steps.scope.outputs.mode == 'clean'
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: actions/checkout@v4
+        if: steps.scope.outputs.mode == 'clean'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
+
+      - uses: oven-sh/setup-bun@v2
+        if: steps.scope.outputs.mode == 'clean'
+        with:
+          bun-version: "1.3.10"
+
       - name: Validate registrations
-        if: steps.scope.outputs.outside == 'false'
+        if: steps.scope.outputs.mode == 'clean'
         run: |
           bun install --frozen-lockfile
           echo "${{ steps.scope.outputs.files }}" | xargs bun scripts/validate-community-users.ts \
             --author="${{ github.event.pull_request.user.login }}"
 
       - name: Auto-merge
-        if: steps.scope.outputs.outside == 'false'
+        if: steps.scope.outputs.mode == 'clean'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge ${{ github.event.pull_request.number }} --squash --auto --repo ${{ github.repository }}
 
       - name: Comment when human review needed
-        if: steps.scope.outputs.outside == 'true'
+        if: steps.scope.outputs.mode == 'mixed'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} \
-            --body "This PR touches files outside community/users/, so it needs normal human review (no auto-merge)."
+            --body "This PR touches community/users/ alongside other files (or non-conforming filenames), so it needs normal human review (no auto-merge)."


### PR DESCRIPTION
## Summary
Prerequisite for making `community-users / validate` a required status check (the TOCTOU guard for registration auto-merge):
- Path-filtered required checks wedge every unrelated PR in "expected" forever — the workflow now runs on **all** PRs and classifies the diff itself: `none` (no community files → trivially pass), `clean` (only conforming registrations → validate + auto-merge), `mixed` (registrations alongside other files → human-review comment).
- Fixes a latent scope bug: the filename grep used `+` without `-E` (BRE = literal plus), which misrouted even valid registration PRs to the human-review path — confirmed by PR #323's behavior.
- Security model unchanged: PR head stays data-only; checkouts now only happen in `clean` mode.

After merge: a repo ruleset makes `validate` + `verify` required on main (with a github-actions bypass so the nightly compile's direct push keeps working). "Allow auto-merge" is already enabled.

## Test Plan
- [x] YAML parses; logic table covered in the scope step comments
- [ ] This PR itself exercises the `none` path (touches only the workflow → validate must pass trivially)
- [ ] Post-ruleset: next registration PR exercises `clean` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)