### PR TITLE
feat(improve): impact engine - backtested projected value per proposal (PR5a)

### DIFF
--- a/apps/axctl/src/cli/commands/improve.ts
+++ b/apps/axctl/src/cli/commands/improve.ts
@@ -15,6 +15,7 @@ import { recommend, formatRecommendations, copyToClipboard, selectByIndices, par
 import { showExperiment, formatShow } from "../../improve/show.ts";
 import { renderAnalyzeBrief } from "../../improve/analyze-brief.ts";
 import { runPropose } from "../../improve/propose.ts";
+import { runHousekeep } from "../../improve/housekeep.ts";
 import { buildImproveProposalsNext } from "../../nav/next-links.ts";
 import { printNextLinks } from "../next-format.ts";
 import type { RuntimeManifest } from "./manifest.ts";
@@ -654,6 +655,37 @@ const improveAnalyzeCommand = Command.make(
     ({ force }) => cmdImproveAnalyze({ force }),
 ).pipe(Command.withDescription("Emit .ax/tasks/analyze-improve-<date>.md - a deep-analysis brief instructing an agent to mine the graph and write proposals back via `ax improve propose`."));
 
+const cmdImproveHousekeep = (input: { readonly days: number; readonly dryRun: boolean; readonly json: boolean }) =>
+    Effect.gen(function* () {
+        const report = yield* runHousekeep({ days: input.days, dryRun: input.dryRun });
+        if (input.json) {
+            console.log(JSON.stringify(report));
+            return;
+        }
+        if (report.staleProposals.length === 0 && report.removedTaskFiles.length === 0) {
+            console.log(`clean: no open proposals or task briefs older than ${input.days}d`);
+            return;
+        }
+        for (const row of report.staleProposals) {
+            console.log(`${input.dryRun ? "would expire" : "expired"}: [${row.form}] ${row.title} (sig=${row.dedupe_sig})`);
+        }
+        for (const f of report.removedTaskFiles) {
+            console.log(`${input.dryRun ? "would remove" : "removed"}: ${f}`);
+        }
+        if (input.dryRun) console.log("re-run without --dry-run to apply");
+        else console.log("anything still real gets re-mined on the next ingest (same dedupe_sig).");
+    });
+
+const improveHousekeepCommand = Command.make(
+    "housekeep",
+    {
+        days: Flag.integer("days").pipe(Flag.withDefault(30)),
+        dryRun: Flag.boolean("dry-run").pipe(Flag.withDefault(false)),
+        json: jsonFlag,
+    },
+    ({ days, dryRun, json }) => cmdImproveHousekeep({ days, dryRun, json }),
+).pipe(Command.withDescription("Sweep loop staleness: open proposals not re-observed in --days (default 30) are superseded; stale .ax/tasks briefs are deleted. Signals that still recur get re-mined automatically."));
+
 export const improveCommand = Command.make("improve").pipe(
     Command.withDescription("Experiment loop: rank proposals (recommend), accept (emit task brief or scaffold + dispatch subagent), lint grounded agent files, track verdicts at +3/+10/+30 sessions after accept."),
     Command.withSubcommands([
@@ -668,6 +700,7 @@ export const improveCommand = Command.make("improve").pipe(
         improveResetCommand,
         improveProposeCommand,
         improveAnalyzeCommand,
+        improveHousekeepCommand,
     ]),
 );
 

--- a/apps/axctl/src/dashboard/capabilities.ts
+++ b/apps/axctl/src/dashboard/capabilities.ts
@@ -28,6 +28,7 @@ export const baseApiCapabilities = [
     "next-actions", // /api/next-actions ranked action cards + agent briefs
     "improve-analyze", // GET /api/improve/analyze-brief - deep-analysis brief for agents
     "wrapped-generate", // GET /api/wrapped/generate-brief + agent card deck on /api/wrapped
+    "improve-impact", // GET /api/improve/:sig/impact - projected impact per proposal
     "events",      // /api/events (SSE)
     "ingest",      // POST /api/ingest -> { runId, stream } + Durable Streams sidecar
     "image",       // GET /api/image?path= -> local on-disk image bytes

--- a/apps/axctl/src/dashboard/contract/improve.ts
+++ b/apps/axctl/src/dashboard/contract/improve.ts
@@ -20,6 +20,7 @@ import {
 import { fetchImproveProposals } from "../improve-proposals.ts";
 import { fetchNextActionsCached, invalidateNextActionsCache } from "../read-caches.ts";
 import { renderAnalyzeBrief } from "../../improve/analyze-brief.ts";
+import { estimateImpactCached } from "../../improve/impact.ts";
 import { asJsonValue, internal, orInternal } from "./common.ts";
 
 interface ImproveActionResult { readonly status: string; readonly message?: string }
@@ -52,6 +53,18 @@ export const ImproveGroupLive = HttpApiBuilder.group(AxApi, "improve", (handlers
                 Effect.map((proposals) => asJsonValue({ proposals })),
             )))
         .handle("nextActions", () => orInternal(fetchNextActionsCached()))
+        .handle("improveImpact", ({ params }) =>
+            Effect.gen(function* () {
+                const proposals = yield* fetchImproveProposals().pipe(Effect.mapError(internal));
+                const proposal = proposals.find((p) => p.dedupe_sig === params.sig);
+                if (proposal === undefined) {
+                    return yield* new NotFoundError({ error: "proposal not found" });
+                }
+                const estimate = yield* estimateImpactCached(proposal, Date.now()).pipe(
+                    Effect.mapError(internal),
+                );
+                return asJsonValue({ sig: params.sig, impact: estimate });
+            }))
         .handle("analyzeBrief", () =>
             Effect.sync(() => ({
                 brief: renderAnalyzeBrief({ date: new Date().toISOString().slice(0, 10) }),

--- a/apps/axctl/src/dashboard/contract/skills-improve.test.ts
+++ b/apps/axctl/src/dashboard/contract/skills-improve.test.ts
@@ -36,6 +36,7 @@ describe("isContractRequest - skills/improve/live routing", () => {
         expect(isContractRequest("GET", "/api/improve")).toBe(true);
         expect(isContractRequest("GET", "/api/improve/analyze-brief")).toBe(true);
         expect(isContractRequest("GET", "/api/wrapped/generate-brief")).toBe(true);
+        expect(isContractRequest("GET", "/api/improve/some-sig/impact")).toBe(true);
         expect(isContractRequest("POST", "/api/ingest")).toBe(true);
     });
 

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -91,6 +91,7 @@ const CONTRACT_PATTERNS: ReadonlyArray<{ readonly method: string; readonly patte
     { method: "GET", pattern: /^\/api\/skills\/[^/]+\/(detail|source)$/ },
     { method: "POST", pattern: /^\/api\/skills\/[^/]+\/(decide|open)$/ },
     { method: "DELETE", pattern: /^\/api\/skills\/[^/]+\/decide$/ },
+    { method: "GET", pattern: /^\/api\/improve\/[^/]+\/impact$/ },
     // All actions route to the contract; the handler answers unknown ones
     // with the legacy 404 { error: "unknown_improve_action" }.
     { method: "POST", pattern: /^\/api\/improve\/[^/]+\/[^/]+$/ },

--- a/apps/axctl/src/dashboard/improve-proposals.test.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "bun:test";
 import { Effect, Layer } from "effect";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { resetImpactCacheForTest } from "../improve/impact.ts";
 import { fetchImproveProposals, renderHypothesisTemplate, resetHydrateCacheForTest } from "./improve-proposals.ts";
 import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
 
@@ -105,6 +106,33 @@ describe("fetchImproveProposals - hypothesis hydration", () => {
             makeSequencedDb([[[dynamicRow]], [[{ n: 42 }]]]),
         ) as ReadonlyArray<ProposalDto>;
         expect(rows[0]?.hypothesis).toBe("live: 42 occurrences");
+    });
+
+    it("mined routing proposal: hypothesis rebuilt from the live impact estimate", async () => {
+        resetHydrateCacheForTest();
+        resetImpactCacheForTest();
+        const routingRow = {
+            ...openRow,
+            form: "hook",
+            title: "Route mechanical subagent dispatches to cheaper models",
+            dedupe_sig: "sig-routing",
+            hypothesis:
+                "39 model-less dispatches on fable/opus matched mechanical routing classes in the last 2d; est $209.59 redirectable. Apply: ax dispatches compile-routing + route-dispatch hook (ax hooks install).",
+        };
+        const rows = await run(
+            fetchImproveProposals(),
+            // call 1: proposals list; call 2: fetchDispatchCandidates multi-statement
+            // (oversized empty tuple satisfies its destructuring with zero rows)
+            makeSequencedDb([[[routingRow]], Array.from({ length: 8 }, () => []) as QueryResult[]]),
+        ) as ReadonlyArray<ProposalDto>;
+        const h = rows[0]!.hypothesis;
+        // live figure (here $0.00 - empty candidates) replaces the frozen $209.59
+        expect(h).not.toContain("$209.59");
+        expect(h).toContain("est $0.00 redirectable over 30d");
+        // chip regex in next-actions reads "est $..." - keep that shape
+        expect(/est \$[\d,]+(?:\.\d+)?/.test(h)).toBe(true);
+        // the action tail survives hydration
+        expect(h).toContain("Apply: ax dispatches compile-routing");
     });
 
     it("fail-open: non-readonly or failing query keeps the frozen hypothesis", async () => {

--- a/apps/axctl/src/dashboard/improve-proposals.test.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, it } from "bun:test";
 import { Effect, Layer } from "effect";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import { fetchImproveProposals } from "./improve-proposals.ts";
+import { fetchImproveProposals, renderHypothesisTemplate, resetHydrateCacheForTest } from "./improve-proposals.ts";
 import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
 
 // ---------------------------------------------------------------------------
@@ -64,6 +64,65 @@ const acceptedRow: Record<string, unknown> = {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("renderHypothesisTemplate", () => {
+    it("fills placeholders, formats numbers, leaves unknown keys literal", () => {
+        expect(
+            renderHypothesisTemplate("{{count}} dispatches; est ${{savings}} - {{missing}}", {
+                count: 1234,
+                savings: "209.59",
+            }),
+        ).toBe("1,234 dispatches; est $209.59 - {{missing}}");
+    });
+});
+
+/** Call-sequenced mock: nth query gets nth result set. */
+const makeSequencedDb = (perCall: QueryResult[][]): Layer.Layer<SurrealClient> => {
+    let call = 0;
+    const stub: SurrealClientShape = {
+        query: (_sql: string) => {
+            const r = perCall[Math.min(call, perCall.length - 1)];
+            call += 1;
+            return Effect.succeed(r as unknown as [QueryResult, ...QueryResult[]]);
+        },
+    } as unknown as SurrealClientShape;
+    return Layer.succeed(SurrealClient, stub);
+};
+
+describe("fetchImproveProposals - hypothesis hydration", () => {
+    it("hydrates from evidence_query first row", async () => {
+        resetHydrateCacheForTest();
+        const dynamicRow = {
+            ...openRow,
+            dedupe_sig: "sig-dyn",
+            hypothesis: "frozen: 11 occurrences",
+            hypothesis_template: "live: {{n}} occurrences",
+            evidence_query: "SELECT count() AS n FROM tool_call GROUP ALL;",
+        };
+        const rows = await run(
+            fetchImproveProposals(),
+            // call 1: proposals list; call 2: the evidence query
+            makeSequencedDb([[[dynamicRow]], [[{ n: 42 }]]]),
+        ) as ReadonlyArray<ProposalDto>;
+        expect(rows[0]?.hypothesis).toBe("live: 42 occurrences");
+    });
+
+    it("fail-open: non-readonly or failing query keeps the frozen hypothesis", async () => {
+        resetHydrateCacheForTest();
+        const badRow = {
+            ...openRow,
+            dedupe_sig: "sig-bad",
+            hypothesis: "frozen stays",
+            hypothesis_template: "live: {{n}}",
+            evidence_query: "DELETE proposal;",
+        };
+        const rows = await run(
+            fetchImproveProposals(),
+            makeMockDb([[badRow]]),
+        ) as ReadonlyArray<ProposalDto>;
+        expect(rows[0]?.hypothesis).toBe("frozen stays");
+    });
+});
 
 describe("fetchImproveProposals - brief attachment", () => {
     it("open row: brief contains sig and open-status ask", async () => {

--- a/apps/axctl/src/dashboard/improve-proposals.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.ts
@@ -18,7 +18,8 @@ SELECT id, form, title, hypothesis, dedupe_sig, frequency, confidence, status, o
     (SELECT id, artifact_path, status, task_path, locked_verdict,
         type::string(created_at) AS created_at,
         type::string(scaffolded_at) AS scaffolded_at,
-        (SELECT kind, suggested, user_verdict, measured, type::string(observed_at) AS observed_at FROM checkpoint WHERE experiment = $parent.id ORDER BY observed_at DESC LIMIT 1)[0] AS latest_checkpoint
+        (SELECT kind, suggested, user_verdict, measured, type::string(observed_at) AS observed_at FROM checkpoint WHERE experiment = $parent.id ORDER BY observed_at DESC LIMIT 1)[0] AS latest_checkpoint,
+        (SELECT kind, suggested, user_verdict, measured, type::string(observed_at) AS observed_at FROM checkpoint WHERE experiment = $parent.id ORDER BY observed_at ASC) AS checkpoints
         FROM experiment WHERE proposal = $parent.id LIMIT 1)[0] AS experiment
 FROM proposal
 ORDER BY frequency DESC, created_at DESC

--- a/apps/axctl/src/dashboard/improve-proposals.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.ts
@@ -8,7 +8,7 @@ import { renderAgentBrief } from "./agent-brief.ts";
 // See docs/superpowers/plans/2026-05-25-experiment-loop-cleanup-and-rebuild.md
 // (Phase C10). Moved verbatim from server.ts queryApi (166-182).
 const PROPOSALS_SQL = `
-SELECT id, form, title, hypothesis, dedupe_sig, frequency, confidence, status, origin, baseline, reject_reason,
+SELECT id, form, title, hypothesis, hypothesis_template, evidence_query, dedupe_sig, frequency, confidence, status, origin, baseline, reject_reason,
     type::string(created_at) AS created_at,
     (SELECT trigger_pattern, suspected_gap, proposed_behavior, expected_impact FROM skill_proposal      WHERE proposal = $parent.id LIMIT 1)[0] AS skill_payload,
     (SELECT bounded_role, delegation_trigger, example_task_patterns FROM subagent_proposal   WHERE proposal = $parent.id LIMIT 1)[0] AS subagent_payload,
@@ -51,6 +51,52 @@ const withBrief = (p: ProposalDto): ProposalDto => ({
               }),
 });
 
+/** Fill {{placeholders}} from a result row; unknown keys stay literal so a
+ *  template bug is visible, not silently blank. */
+export const renderHypothesisTemplate = (
+    template: string,
+    row: Record<string, unknown>,
+): string =>
+    template.replace(/\{\{(\w+)\}\}/g, (whole, key: string) => {
+        const v = row[key];
+        if (v === undefined || v === null) return whole;
+        return typeof v === "number" ? v.toLocaleString("en") : String(v);
+    });
+
+/** Hydrate proposals that carry a live evidence query: the template's
+ *  numbers are recomputed at serve time, so mined/agent prose never
+ *  expires. Fail-open per proposal - a broken query keeps the frozen
+ *  hypothesis. Hydration results cache per sig for 5 minutes. */
+const HYDRATE_TTL_MS = 5 * 60_000;
+const hydrateCache = new Map<string, { hypothesis: string; at: number }>();
+
+export function resetHydrateCacheForTest(): void {
+    hydrateCache.clear();
+}
+
+const hydrateHypothesis = Effect.fn("dashboard.hydrateHypothesis")(function* (
+    p: ProposalDto,
+) {
+    const template = p.hypothesis_template;
+    const query = p.evidence_query;
+    if (!template || !query || !/^(SELECT|RETURN)\b/i.test(query.trim())) return p;
+    const hit = hydrateCache.get(p.dedupe_sig);
+    if (hit && Date.now() - hit.at < HYDRATE_TTL_MS) {
+        return { ...p, hypothesis: hit.hypothesis };
+    }
+    const db = yield* SurrealClient;
+    const hydrated = yield* db.query<[Array<Record<string, unknown>>]>(query).pipe(
+        Effect.map((result) => {
+            const row = result[0]?.[0];
+            return row ? renderHypothesisTemplate(template, row) : null;
+        }),
+        Effect.catch(() => Effect.succeed(null)),
+    );
+    if (hydrated === null) return p;
+    hydrateCache.set(p.dedupe_sig, { hypothesis: hydrated, at: Date.now() });
+    return { ...p, hypothesis: hydrated };
+});
+
 /** Raw proposal rows, loosely typed at the edge like the legacy queryApi endpoints. */
 export const fetchImproveProposals = Effect.fn("dashboard.fetchImproveProposals")(
     function* () {
@@ -58,6 +104,9 @@ export const fetchImproveProposals = Effect.fn("dashboard.fetchImproveProposals"
         const result = yield* db.query<[Array<Record<string, unknown>>]>(PROPOSALS_SQL);
         // TODO: replace with schema decode when the proposal wire shape stabilizes
         const rows = (result[0] ?? []) as unknown as ReadonlyArray<ProposalDto>;
-        return rows.map(withBrief);
+        const hydrated = yield* Effect.all(rows.map((p) => hydrateHypothesis(p)), {
+            concurrency: 4,
+        });
+        return hydrated.map(withBrief);
     },
 );

--- a/apps/axctl/src/dashboard/improve-proposals.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.ts
@@ -8,7 +8,7 @@ import { renderAgentBrief } from "./agent-brief.ts";
 // See docs/superpowers/plans/2026-05-25-experiment-loop-cleanup-and-rebuild.md
 // (Phase C10). Moved verbatim from server.ts queryApi (166-182).
 const PROPOSALS_SQL = `
-SELECT id, form, title, hypothesis, dedupe_sig, frequency, confidence, status, origin, reject_reason,
+SELECT id, form, title, hypothesis, dedupe_sig, frequency, confidence, status, origin, baseline, reject_reason,
     type::string(created_at) AS created_at,
     (SELECT trigger_pattern, suspected_gap, proposed_behavior, expected_impact FROM skill_proposal      WHERE proposal = $parent.id LIMIT 1)[0] AS skill_payload,
     (SELECT bounded_role, delegation_trigger, example_task_patterns FROM subagent_proposal   WHERE proposal = $parent.id LIMIT 1)[0] AS subagent_payload,

--- a/apps/axctl/src/dashboard/improve-proposals.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
+import { estimateImpactCached, ROUTING_PROPOSAL_TITLE } from "../improve/impact.ts";
 import { renderAgentBrief } from "./agent-brief.ts";
 
 // Experiment-loop shortlist + verdict state. Reads proposal +
@@ -74,9 +75,32 @@ export function resetHydrateCacheForTest(): void {
     hydrateCache.clear();
 }
 
+/** The mined routing proposal predates hypothesis_template/evidence_query,
+ *  so its dollar figure freezes at mine time while the impact endpoint
+ *  recomputes live. Builtin hydrator: rebuild the hypothesis from the SAME
+ *  cached estimate the drawer serves - card chip, card body, brief, and
+ *  drawer impact then cannot disagree. Fail-open: any error keeps the
+ *  frozen text. */
+const hydrateRoutingHypothesis = Effect.fn("dashboard.hydrateRoutingHypothesis")(
+    function* (p: ProposalDto) {
+        const est = yield* estimateImpactCached(p, Date.now()).pipe(
+            Effect.catch(() => Effect.succeed(null)),
+        );
+        if (est === null || est.kind !== "savings_usd") return p;
+        // the frozen "Apply: ..." tail is the action, not a measurement - keep it
+        const apply = / Apply: .*$/.exec(p.hypothesis)?.[0] ?? "";
+        // "~$608 redirectable over 30d" -> "est $608 ..." (the card chip parses "est $")
+        const headline = est.headline.replace(/^~\$/, "est $");
+        return { ...p, hypothesis: `${est.detail} ${headline}.${apply}` };
+    },
+);
+
 const hydrateHypothesis = Effect.fn("dashboard.hydrateHypothesis")(function* (
     p: ProposalDto,
 ) {
+    if (p.form === "hook" && p.title === ROUTING_PROPOSAL_TITLE) {
+        return yield* hydrateRoutingHypothesis(p);
+    }
     const template = p.hypothesis_template;
     const query = p.evidence_query;
     if (!template || !query || !/^(SELECT|RETURN)\b/i.test(query.trim())) return p;

--- a/apps/axctl/src/dashboard/next-actions.test.ts
+++ b/apps/axctl/src/dashboard/next-actions.test.ts
@@ -629,11 +629,11 @@ describe("fetchNextActions", () => {
         expect(typeof payload.generatedAt).toBe("string");
     });
 
-    test("a hanging source (Effect.never) is timed out and noted; all 5 sources noted", async () => {
+    test("a hanging source (Effect.never) is timed out and noted; all 6 sources noted", async () => {
         // db.query returns Effect.never - simulates a hung DB / slow query.
         // runQuery's internal Effect.catch only catches DbError failures; it does NOT
         // prevent fiber interruption from timeoutOrElse. The timeout fires, the
-        // orElse failure propagates to our guarded catch, and ALL 5 sources add a
+        // orElse failure propagates to our guarded catch, and ALL 6 sources add a
         // note - including tool_failure which normally swallows DB errors internally.
         const stub: SurrealClientShape = {
             query: (_sql: string) => Effect.never,
@@ -646,10 +646,10 @@ describe("fetchNextActions", () => {
         );
 
         expect(payload.cards).toEqual([]);
-        // All 5 direct-DB sources time out; tool_failure is also noted because
+        // All 6 direct-DB sources time out; tool_failure is also noted because
         // timeoutOrElse interrupts the fiber before runQuery's internal swallow fires.
         expect(new Set(payload.notes.map((n) => n.source))).toEqual(
-            new Set(["proposal", "tool_failure", "churn", "routing", "skill_hygiene"]),
+            new Set(["proposal", "tool_failure", "churn", "routing", "skill_hygiene", "housekeeping"]),
         );
         // At least one note should mention timed out (two words - our orElse uses "timed out after Nms")
         expect(payload.notes.some((n) => /timed out/i.test(n.note))).toBe(true);

--- a/apps/axctl/src/dashboard/next-actions.test.ts
+++ b/apps/axctl/src/dashboard/next-actions.test.ts
@@ -264,6 +264,21 @@ describe("impactChip", () => {
     });
 });
 
+describe("fixKind", () => {
+    test("names the mechanism per form, guidance names its file target", () => {
+        expect(proposalCards([openProposal({ form: "skill" })])[0]!.fix_kind).toBe("new skill");
+        expect(proposalCards([openProposal({ form: "hook" })])[0]!.fix_kind).toBe("new hook");
+        expect(
+            proposalCards([
+                openProposal({
+                    form: "guidance",
+                    guidance_payload: { file_target: "CLAUDE.md", section: null, suggested_text: "x" },
+                }),
+            ])[0]!.fix_kind,
+        ).toBe("edit CLAUDE.md");
+    });
+});
+
 describe("verdictCards", () => {
     test("only accepted proposals with experiment and no locked_verdict", () => {
         const proposals = [

--- a/apps/axctl/src/dashboard/next-actions.test.ts
+++ b/apps/axctl/src/dashboard/next-actions.test.ts
@@ -11,6 +11,7 @@ import type { CandidatesResult, CandidateRow } from "../queries/dispatch-analyti
 import type { SkillHygieneRow } from "../queries/skill-hygiene.ts";
 import {
     churnCards,
+    housekeepingCards,
     fetchNextActions,
     proposalCards,
     routingCards,
@@ -590,6 +591,21 @@ test("all builders return NextActionCard[] typed arrays", () => {
 // fetchNextActions aggregator
 // ---------------------------------------------------------------------------
 
+describe("housekeepingCards", () => {
+    test("one card when stale proposals exist, none when clean", () => {
+        expect(housekeepingCards([])).toHaveLength(0);
+        const cards = housekeepingCards([
+            { id: "proposal:a", title: "Old A", dedupe_sig: "a", form: "skill", updated_at: null },
+            { id: "proposal:b", title: "Old B", dedupe_sig: "b", form: "guidance", updated_at: null },
+        ]);
+        expect(cards).toHaveLength(1);
+        expect(cards[0]!.kind).toBe("housekeeping");
+        expect(cards[0]!.title).toContain("2 stale proposals");
+        expect(cards[0]!.brief).toContain("ax improve housekeep");
+        expect(cards[0]!.fix_kind).toContain("housekeep");
+    });
+});
+
 describe("fetchNextActions", () => {
     test("a failing source degrades to a note, never a defect", async () => {
         const stub: SurrealClientShape = {
@@ -608,7 +624,7 @@ describe("fetchNextActions", () => {
         // directly and do add notes. Exact set: if runQuery's internal swallow ever
         // changes and tool_failure starts noting, this surfaces it.
         expect(new Set(payload.notes.map((n) => n.source))).toEqual(
-            new Set(["proposal", "churn", "routing", "skill_hygiene"]),
+            new Set(["proposal", "churn", "routing", "skill_hygiene", "housekeeping"]),
         );
         expect(typeof payload.generatedAt).toBe("string");
     });

--- a/apps/axctl/src/dashboard/next-actions.test.ts
+++ b/apps/axctl/src/dashboard/next-actions.test.ts
@@ -245,6 +245,25 @@ describe("proposalCards", () => {
 // verdictCards
 // ---------------------------------------------------------------------------
 
+describe("impactChip", () => {
+    test("routing hypothesis yields a $ chip", () => {
+        const card = proposalCards([
+            openProposal({
+                form: "hook",
+                hypothesis: "71 model-less dispatches; est $296.84 redirectable. Top classes: x",
+            }),
+        ])[0]!;
+        expect(card.impact_chip).toBe("~$296.84 redirectable");
+    });
+
+    test("guidance frequency yields a recurring chip; freq 1 yields none", () => {
+        const a = proposalCards([openProposal({ form: "guidance", frequency: 9 })])[0]!;
+        expect(a.impact_chip).toBe("9x recurring");
+        const b = proposalCards([openProposal({ form: "guidance", frequency: 1 })])[0]!;
+        expect(b.impact_chip).toBeNull();
+    });
+});
+
 describe("verdictCards", () => {
     test("only accepted proposals with experiment and no locked_verdict", () => {
         const proposals = [

--- a/apps/axctl/src/dashboard/next-actions.ts
+++ b/apps/axctl/src/dashboard/next-actions.ts
@@ -90,7 +90,10 @@ export const proposalCards = (
                     id: `proposal:${p.dedupe_sig}`,
                     kind: "proposal",
                     title: `Decide proposal: ${p.title}`,
-                    evidence: `${p.form} proposal, confidence ${p.confidence}, seen ${p.frequency}x`,
+                    // The card's body line answers "what is the problem" -
+                    // the hypothesis IS the mined problem statement. Metadata
+                    // (form/confidence/frequency) lives in the chip + registry.
+                    evidence: p.hypothesis,
                     // agent-origin proposals outrank mined ones at equal confidence x frequency
                     impact: KIND_WEIGHT.proposal + bonus(cw * Math.log2(p.frequency + 1) + ((p.origin ?? "mined") === "agent" ? 1 : 0)),
                     brief: proposalReviewBrief(p),

--- a/apps/axctl/src/dashboard/next-actions.ts
+++ b/apps/axctl/src/dashboard/next-actions.ts
@@ -57,6 +57,20 @@ const capByImpact = (cards: NextActionCard[]): NextActionCard[] =>
 /** Null-safe interpolation: nullable DB strings must never render "null". */
 const nn = (v: string | null, fallback = "unknown"): string => v ?? fallback;
 
+/** Cheap value teaser - parsed from what the proposal row already carries
+ *  (no recompute; the full estimate lives at /api/improve/:sig/impact).
+ *  Mined routing proposals carry their savings figure in the hypothesis. */
+export const impactChip = (p: ProposalDto): string | null => {
+    if (p.form === "hook") {
+        const m = /est \$([\d,]+(?:\.\d+)?)/.exec(p.hypothesis);
+        if (m) return `~$${m[1]} redirectable`;
+    }
+    if (p.form === "guidance" || p.form === "skill") {
+        return p.frequency > 1 ? `${p.frequency}x recurring` : null;
+    }
+    return null;
+};
+
 // ---------------------------------------------------------------------------
 // proposalCards
 // ---------------------------------------------------------------------------
@@ -87,6 +101,7 @@ export const proposalCards = (
                         skill: null,
                         suggested_verdict: null,
                     },
+                    impact_chip: impactChip(p),
                 };
             }),
     );
@@ -140,6 +155,7 @@ export const verdictCards = (
                         skill: null,
                         suggested_verdict: suggested as string | null,
                     },
+                    impact_chip: impactChip(p),
                 };
             }),
     );

--- a/apps/axctl/src/dashboard/next-actions.ts
+++ b/apps/axctl/src/dashboard/next-actions.ts
@@ -78,6 +78,25 @@ export const impactChip = (p: ProposalDto): string | null => {
 /**
  * Cards for open improve proposals: review + accept or reject each one.
  */
+/** Name the fix MECHANISM - "checklist" alone doesn't say skill vs
+ *  guidance edit vs hook. Guidance names its actual file target. */
+export const fixKind = (p: ProposalDto): string => {
+    switch (p.form) {
+        case "skill":
+            return "new skill";
+        case "guidance":
+            return `edit ${p.guidance_payload?.file_target ?? "guidance"}`;
+        case "hook":
+            return "new hook";
+        case "subagent":
+            return "new subagent";
+        case "automation":
+            return "automation";
+        default:
+            return String(p.form);
+    }
+};
+
 export const proposalCards = (
     proposals: ReadonlyArray<ProposalDto>,
 ): NextActionCard[] =>
@@ -105,6 +124,7 @@ export const proposalCards = (
                         suggested_verdict: null,
                     },
                     impact_chip: impactChip(p),
+                    fix_kind: fixKind(p),
                 };
             }),
     );

--- a/apps/axctl/src/dashboard/next-actions.ts
+++ b/apps/axctl/src/dashboard/next-actions.ts
@@ -26,6 +26,7 @@ import { fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
 import type { SkillHygieneRow } from "../queries/skill-hygiene.ts";
 import { fetchSkillHygiene } from "../queries/skill-hygiene.ts";
 import { fetchImproveProposals, proposalReviewBrief } from "./improve-proposals.ts";
+import { findStaleOpenProposals, type StaleProposalRow } from "../improve/housekeep.ts";
 import { fetchToolFailures } from "./tool-failures.ts";
 import { renderAgentBrief } from "./agent-brief.ts";
 
@@ -40,6 +41,7 @@ const KIND_WEIGHT: Record<NextActionKind, number> = {
     routing: 60,
     churn: 50,
     skill_hygiene: 40,
+    housekeeping: 30,
 };
 
 const CONFIDENCE_WEIGHT: Record<string, number> = { high: 3, medium: 2, low: 1 };
@@ -344,6 +346,41 @@ export const skillHygieneCards = (
     );
 
 // ---------------------------------------------------------------------------
+// housekeepingCards
+// ---------------------------------------------------------------------------
+
+const HOUSEKEEP_DAYS = 30;
+
+/** One card when the loop itself has gone stale - a loop that suggests
+ *  cleanups must not hoard expired proposals. */
+export const housekeepingCards = (
+    stale: ReadonlyArray<StaleProposalRow>,
+): NextActionCard[] => {
+    if (stale.length === 0) return [];
+    const sample = stale.slice(0, 3).map((r) => r.title).join("; ");
+    return [
+        {
+            id: "housekeeping:stale-proposals",
+            kind: "housekeeping",
+            title: `Sweep ${stale.length} stale proposal${stale.length === 1 ? "" : "s"}`,
+            evidence: `Open >${HOUSEKEEP_DAYS}d without the signal re-occurring: ${sample}${stale.length > 3 ? "\u2026" : ""}. Anything still real gets re-mined.`,
+            impact: KIND_WEIGHT.housekeeping + bonus(Math.log2(stale.length + 1)),
+            brief: renderAgentBrief({
+                title: "Housekeep the improve loop",
+                evidence: `${stale.length} open proposals have not been re-observed in ${HOUSEKEEP_DAYS}d.`,
+                ask: "Run `ax improve housekeep` (use --dry-run first if cautious). Stale proposals are superseded; recurring signals come back on the next mine with the same dedupe_sig.",
+                verify: "`ax improve list --status=open` no longer shows the stale rows.",
+                source: "ax improve housekeep candidates",
+            }),
+            link: null,
+            inline_action: null,
+            impact_chip: null,
+            fix_kind: "run ax improve housekeep",
+        },
+    ];
+};
+
+// ---------------------------------------------------------------------------
 // aggregator
 // ---------------------------------------------------------------------------
 
@@ -405,7 +442,7 @@ export const fetchNextActions = Effect.fn("dashboard.fetchNextActions")(function
             ),
         );
 
-    const [proposals, failures, churn, routing, hygiene] = yield* Effect.all(
+    const [proposals, failures, churn, routing, hygiene, stale] = yield* Effect.all(
         [
             guarded("proposal", fetchImproveProposals(), [] as ReadonlyArray<ProposalDto>),
             guarded("tool_failure", fetchToolFailures(), null as ToolFailuresResponse | null),
@@ -419,6 +456,7 @@ export const fetchNextActions = Effect.fn("dashboard.fetchNextActions")(function
             ),
             guarded("routing", fetchDispatchCandidates({ sinceDays: ROUTING_WINDOW_DAYS }), null as CandidatesResult | null),
             guarded("skill_hygiene", fetchSkillHygiene({ minInvocations: 3, limit: 10 }), [] as ReadonlyArray<SkillHygieneRow>),
+            guarded("housekeeping", findStaleOpenProposals(HOUSEKEEP_DAYS), [] as ReadonlyArray<StaleProposalRow>),
         ] as const,
         { concurrency: 3 },
     );
@@ -430,6 +468,7 @@ export const fetchNextActions = Effect.fn("dashboard.fetchNextActions")(function
         ...(churn != null ? churnCards(churn) : []),
         ...(routing != null ? routingCards(routing) : []),
         ...skillHygieneCards(hygiene),
+        ...housekeepingCards(stale),
     ].sort((a, b) => b.impact - a.impact);
 
     return { generatedAt: new Date().toISOString(), cards, notes } satisfies NextActionsPayload;

--- a/apps/axctl/src/improve/analyze-brief.ts
+++ b/apps/axctl/src/improve/analyze-brief.ts
@@ -55,6 +55,20 @@ Payloads:
 - **subagent**: { "bounded_role", "delegation_trigger", "example_task_patterns"? }
 - **automation**: { "trigger_signal", "schedule"?, "action", ...same safety fields as hook }
 
+**Keep numbers alive (preferred):** instead of baking counts into the
+hypothesis prose (they expire), also pass:
+
+\`\`\`json
+{
+  "hypothesis": "fallback prose with today's numbers",
+  "hypothesis_template": "{{n}} failed Bash calls in the last 30d keep recurring",
+  "evidence_query": "SELECT count() AS n FROM tool_call WHERE name = 'Bash' AND status = 'error' AND ts > time::now() - 30d GROUP ALL;"
+}
+\`\`\`
+
+The dashboard re-runs the query at view time and fills the {{placeholders}} -
+your numbers never go stale. evidence_query must be read-only (SELECT/RETURN).
+
 **Rules:**
 - Every proposal MUST carry evidence refs (session ids / dedupe sigs / failure counts / $).
 - Re-proposing an existing pattern is fine - same title bumps its frequency instead of duplicating.

--- a/apps/axctl/src/improve/housekeep.test.ts
+++ b/apps/axctl/src/improve/housekeep.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import {
+    buildExpireStatement,
+    findStaleOpenProposals,
+    runHousekeep,
+} from "./housekeep.ts";
+
+const makeDb = (rows: Array<Record<string, unknown>>, log: string[] = []) => {
+    const stub: SurrealClientShape = {
+        query: (sql: string) => {
+            log.push(sql);
+            return Effect.succeed([rows]);
+        },
+    } as unknown as SurrealClientShape;
+    return Layer.succeed(SurrealClient, stub);
+};
+
+const staleRow = {
+    id: "proposal:old",
+    title: "Old idea",
+    dedupe_sig: "sig-old",
+    form: "skill",
+    updated_at: "2026-05-01T00:00:00Z",
+};
+
+describe("buildExpireStatement", () => {
+    test("supersedes only stale open proposals, with an explanatory reason", () => {
+        const sql = buildExpireStatement(30);
+        expect(sql).toContain("status = 'superseded'");
+        expect(sql).toContain("status = 'open'");
+        expect(sql).toContain("30d");
+        expect(sql).toContain("housekeeping:");
+        expect(sql).toContain("re-mined automatically");
+    });
+});
+
+describe("findStaleOpenProposals", () => {
+    test("returns rows from the stale select", async () => {
+        const rows = await Effect.runPromise(
+            findStaleOpenProposals(30).pipe(Effect.provide(makeDb([staleRow]))),
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.dedupe_sig).toBe("sig-old");
+    });
+});
+
+describe("runHousekeep", () => {
+    test("dry run reports but never mutates", async () => {
+        const log: string[] = [];
+        const report = await Effect.runPromise(
+            runHousekeep({ days: 30, dryRun: true, taskDir: "/tmp/nonexistent-ax-tasks" }).pipe(
+                Effect.provide(makeDb([staleRow], log)),
+            ),
+        );
+        expect(report.dryRun).toBe(true);
+        expect(report.staleProposals).toHaveLength(1);
+        expect(report.expired).toBe(0);
+        expect(log.some((s) => s.includes("UPDATE proposal"))).toBe(false);
+    });
+
+    test("real run expires stale proposals", async () => {
+        const log: string[] = [];
+        const report = await Effect.runPromise(
+            runHousekeep({ days: 30, dryRun: false, taskDir: "/tmp/nonexistent-ax-tasks" }).pipe(
+                Effect.provide(makeDb([staleRow], log)),
+            ),
+        );
+        expect(report.expired).toBe(1);
+        expect(log.some((s) => s.includes("UPDATE proposal"))).toBe(true);
+    });
+
+    test("no stale rows -> no mutation query", async () => {
+        const log: string[] = [];
+        const report = await Effect.runPromise(
+            runHousekeep({ days: 30, dryRun: false, taskDir: "/tmp/nonexistent-ax-tasks" }).pipe(
+                Effect.provide(makeDb([], log)),
+            ),
+        );
+        expect(report.expired).toBe(0);
+        expect(log.filter((s) => s.includes("UPDATE proposal"))).toHaveLength(0);
+    });
+});

--- a/apps/axctl/src/improve/housekeep.ts
+++ b/apps/axctl/src/improve/housekeep.ts
@@ -1,0 +1,116 @@
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+
+/**
+ * Housekeeping for the improve loop - a loop that suggests cleaning up
+ * your workflow must not hoard its own stale state. No migration shims:
+ * outdated rows are expired/deleted; the miners recreate anything still
+ * real on the next pass (dedupe_sig brings the frequency back).
+ *
+ * Sweeps:
+ *   1. Stale OPEN proposals - not re-observed (updated_at) within the
+ *      window -> status 'superseded' with an explanatory reject_reason.
+ *      Payload rows survive (REFERENCE CASCADE only fires on delete) but
+ *      superseded proposals drop out of every active surface.
+ *   2. Stale .ax/tasks briefs - emitted task/analyze/wrapped briefs older
+ *      than the window are deleted (the generators re-emit on demand).
+ */
+
+export interface StaleProposalRow {
+    readonly id: unknown;
+    readonly title: string;
+    readonly dedupe_sig: string;
+    readonly form: string;
+    readonly updated_at: string | null;
+}
+
+export interface HousekeepReport {
+    readonly staleProposals: ReadonlyArray<StaleProposalRow>;
+    readonly expired: number;
+    readonly removedTaskFiles: ReadonlyArray<string>;
+    readonly dryRun: boolean;
+}
+
+const STALE_SELECT = (days: number): string =>
+    `SELECT id, title, dedupe_sig, form, type::string(updated_at) AS updated_at
+FROM proposal
+WHERE status = 'open'
+  AND (updated_at IS NONE OR updated_at < time::now() - ${days}d)
+  AND created_at < time::now() - ${days}d;`;
+
+export const buildExpireStatement = (days: number): string =>
+    `UPDATE proposal SET
+    status = 'superseded',
+    reject_reason = 'housekeeping: signal not re-observed in ${days}d - re-mined automatically if it recurs',
+    updated_at = time::now()
+WHERE status = 'open'
+  AND (updated_at IS NONE OR updated_at < time::now() - ${days}d)
+  AND created_at < time::now() - ${days}d;`;
+
+export const findStaleOpenProposals = Effect.fn("improve.findStaleOpenProposals")(
+    function* (days: number) {
+        const db = yield* SurrealClient;
+        const result = yield* db.query<[StaleProposalRow[]]>(STALE_SELECT(days));
+        return result[0] ?? [];
+    },
+);
+
+/** Task-brief files older than the window. Bun-only - no node:fs (repo gate). */
+const staleTaskFiles = async (dir: string, days: number): Promise<string[]> => {
+    const cutoff = Date.now() - days * 86_400_000;
+    const glob = new Bun.Glob("*.md");
+    const stale: string[] = [];
+    try {
+        for await (const name of glob.scan({ cwd: dir, absolute: false })) {
+            const file = Bun.file(`${dir}/${name}`);
+            if ((await file.exists()) && file.lastModified < cutoff) {
+                stale.push(`${dir}/${name}`);
+            }
+        }
+    } catch {
+        /* no .ax/tasks dir - nothing to sweep */
+    }
+    return stale;
+};
+
+export const runHousekeep = Effect.fn("improve.runHousekeep")(function* (opts: {
+    readonly days: number;
+    readonly dryRun: boolean;
+    readonly taskDir?: string;
+}) {
+    const taskDir = opts.taskDir ?? ".ax/tasks";
+    const staleProposals = yield* findStaleOpenProposals(opts.days);
+    const staleFiles = yield* Effect.tryPromise(() => staleTaskFiles(taskDir, opts.days));
+
+    if (opts.dryRun) {
+        return {
+            staleProposals,
+            expired: 0,
+            removedTaskFiles: staleFiles,
+            dryRun: true,
+        } satisfies HousekeepReport;
+    }
+
+    if (staleProposals.length > 0) {
+        const db = yield* SurrealClient;
+        yield* db.query(buildExpireStatement(opts.days));
+    }
+    const removed: string[] = [];
+    for (const path of staleFiles) {
+        // Bun.file.delete() removes the file; ignore races.
+        yield* Effect.tryPromise(async () => {
+            try {
+                await Bun.file(path).delete();
+                removed.push(path);
+            } catch {
+                /* already gone */
+            }
+        });
+    }
+    return {
+        staleProposals,
+        expired: staleProposals.length,
+        removedTaskFiles: removed,
+        dryRun: false,
+    } satisfies HousekeepReport;
+});

--- a/apps/axctl/src/improve/impact.test.ts
+++ b/apps/axctl/src/improve/impact.test.ts
@@ -61,8 +61,10 @@ describe("estimateImpact", () => {
             makeDb([[[]]]),
         );
         expect(est.kind).toBe("correction_pressure");
-        expect(est.headline).toContain("9×");
+        // headline = LIVE frequency (matches the card chip); frozen baseline (9) becomes a growth note
+        expect(est.headline).toContain("7×");
         expect(est.detail).toContain("9 corrections across 4 sessions");
+        expect(est.detail).toContain("was 9x when first proposed");
         expect(est.confidence).toBe("indicative");
     });
 
@@ -71,8 +73,10 @@ describe("estimateImpact", () => {
             estimateImpact(proposal({ form: "skill", baseline: '{"tool":"Bash","frequency":12}' })),
             makeDb([[[]]]),
         );
-        expect(est.headline).toContain("12×");
+        // live frequency (7 on the fixture), not the frozen baseline 12
+        expect(est.headline).toContain("7×");
         expect(est.headline).toContain("Bash");
+        expect(est.detail).toContain("was 12x when first proposed");
     });
 
     test("hook with target_tool: addressable failures from tool_call stats", async () => {

--- a/apps/axctl/src/improve/impact.test.ts
+++ b/apps/axctl/src/improve/impact.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
+import {
+    estimateImpact,
+    estimateImpactCached,
+    parseBaseline,
+    resetImpactCacheForTest,
+    ROUTING_PROPOSAL_TITLE,
+} from "./impact.ts";
+
+const proposal = (over: Partial<ProposalDto>): ProposalDto =>
+    ({
+        id: "proposal:t",
+        form: "guidance",
+        title: "t",
+        hypothesis: "h",
+        dedupe_sig: "sig-t",
+        frequency: 7,
+        confidence: "medium",
+        status: "open",
+        reject_reason: null,
+        created_at: "2026-06-01T00:00:00Z",
+        ...over,
+    }) as ProposalDto;
+
+type QueryResult = Array<Record<string, unknown>>;
+const makeDb = (resultsPerCall: QueryResult[][]) => {
+    let call = 0;
+    const stub: SurrealClientShape = {
+        query: (_sql: string) => {
+            const r = resultsPerCall[Math.min(call, resultsPerCall.length - 1)];
+            call += 1;
+            return Effect.succeed(r);
+        },
+    } as unknown as SurrealClientShape;
+    return Layer.succeed(SurrealClient, stub);
+};
+
+const run = <A>(eff: Effect.Effect<A, unknown, SurrealClient>, layer: Layer.Layer<SurrealClient>) =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer)));
+
+afterEach(() => resetImpactCacheForTest());
+
+describe("parseBaseline", () => {
+    test("tolerates missing/corrupt baseline", () => {
+        expect(parseBaseline(proposal({}))).toEqual({});
+        expect(parseBaseline(proposal({ baseline: "not json" }))).toEqual({});
+        expect(parseBaseline(proposal({ baseline: '{"frequency":3}' }))).toEqual({ frequency: 3 });
+    });
+});
+
+describe("estimateImpact", () => {
+    test("guidance: correction pressure from baseline evidence", async () => {
+        const est = await run(
+            estimateImpact(proposal({
+                form: "guidance",
+                baseline: '{"frequency":9,"evidence":"9 corrections across 4 sessions"}',
+            })),
+            makeDb([[[]]]),
+        );
+        expect(est.kind).toBe("correction_pressure");
+        expect(est.headline).toContain("9×");
+        expect(est.detail).toContain("9 corrections across 4 sessions");
+        expect(est.confidence).toBe("indicative");
+    });
+
+    test("skill: frequency + tool from baseline", async () => {
+        const est = await run(
+            estimateImpact(proposal({ form: "skill", baseline: '{"tool":"Bash","frequency":12}' })),
+            makeDb([[[]]]),
+        );
+        expect(est.headline).toContain("12×");
+        expect(est.headline).toContain("Bash");
+    });
+
+    test("hook with target_tool: addressable failures from tool_call stats", async () => {
+        const est = await run(
+            estimateImpact(proposal({
+                form: "hook",
+                hook_payload: {
+                    event_name: "PreToolUse",
+                    target_tool: "Bash",
+                    hook_command: "x",
+                    recovery_path: null,
+                    smoke_test_command: null,
+                    disable_command: null,
+                    failure_mode: null,
+                },
+            } as Partial<ProposalDto>)),
+            makeDb([[[{ n: 200 }], [{ n: 14 }]]]),
+        );
+        expect(est.kind).toBe("addressable_failures");
+        expect(est.headline).toContain("14 failures");
+        expect(est.headline).toContain("200");
+        expect(est.basis).toContain("not a replay");
+    });
+
+    test("routing proposal: recomputes savings via dispatch candidates", async () => {
+        // fetchDispatchCandidates issues one multi-statement query; an
+        // oversized empty tuple satisfies its destructuring with zero rows.
+        const est = await run(
+            estimateImpact(proposal({ form: "hook", title: ROUTING_PROPOSAL_TITLE })),
+            makeDb([[Array.from({ length: 8 }, () => []) as unknown as QueryResult]]),
+        );
+        expect(est.kind).toBe("savings_usd");
+        expect(est.confidence).toBe("estimated");
+        expect(est.basis).toContain("dispatch history");
+    });
+
+    test("fallback: frequency", async () => {
+        const est = await run(
+            estimateImpact(proposal({ form: "automation" })),
+            makeDb([[[]]]),
+        );
+        expect(est.kind).toBe("frequency");
+        expect(est.headline).toContain("7×");
+    });
+});
+
+describe("estimateImpactCached", () => {
+    test("second call within TTL skips recompute", async () => {
+        const p = proposal({ form: "guidance", baseline: '{"frequency":3}' });
+        const layer = makeDb([[[]]]);
+        const a = await run(estimateImpactCached(p, 1_000), layer);
+        const b = await run(estimateImpactCached(p, 2_000), layer);
+        expect(b).toBe(a);
+    });
+
+    test("expired entry recomputes", async () => {
+        const p = proposal({ form: "guidance", baseline: '{"frequency":3}' });
+        const layer = makeDb([[[]]]);
+        const a = await run(estimateImpactCached(p, 1_000), layer);
+        const b = await run(estimateImpactCached(p, 1_000 + 11 * 60_000), layer);
+        expect(b).not.toBe(a);
+        expect(b).toEqual(a);
+    });
+});

--- a/apps/axctl/src/improve/impact.ts
+++ b/apps/axctl/src/improve/impact.ts
@@ -1,0 +1,142 @@
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { ImpactEstimate, ProposalDto } from "@ax/lib/shared/dashboard-types";
+import { fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
+
+/**
+ * Projected impact per proposal - the "what is this worth" engine
+ * (spec: improve loop v2). Estimators reuse existing analytics; every
+ * estimate states its basis and an honesty tier. Post-accept, checkpoint
+ * measurements supersede these (rendered side by side in the UI).
+ */
+
+/** Stable mined-routing proposal title (derive-proposals.ts:191). */
+export const ROUTING_PROPOSAL_TITLE = "Route mechanical subagent dispatches to cheaper models";
+
+const ROUTING_WINDOW_DAYS = 30;
+const HOOK_WINDOW_DAYS = 30;
+
+export const parseBaseline = (p: ProposalDto): Record<string, unknown> => {
+    const raw = (p as { baseline?: unknown }).baseline;
+    if (typeof raw !== "string" || raw.length === 0) return {};
+    try {
+        const parsed = JSON.parse(raw) as unknown;
+        return typeof parsed === "object" && parsed !== null
+            ? (parsed as Record<string, unknown>)
+            : {};
+    } catch {
+        return {};
+    }
+};
+
+const usd = (n: number): string =>
+    `$${n >= 100 ? Math.round(n).toLocaleString("en") : n.toFixed(2)}`;
+
+const isRoutingProposal = (p: ProposalDto): boolean =>
+    p.form === "hook" && p.title === ROUTING_PROPOSAL_TITLE;
+
+const routingImpact = Effect.fn("improve.routingImpact")(function* () {
+    const result = yield* fetchDispatchCandidates({ sinceDays: ROUTING_WINDOW_DAYS });
+    const total = result.total_est_savings_usd;
+    const top = result.top_classes
+        .slice(0, 3)
+        .map((c) => `${c.classId} (${usd(c.savings_usd)})`)
+        .join(", ");
+    return {
+        kind: "savings_usd",
+        headline: `~${usd(total)} redirectable over ${ROUTING_WINDOW_DAYS}d`,
+        detail: `${result.candidates.length} model-less dispatches on expensive models matched mechanical routing classes${top ? `. Top classes: ${top}` : ""}.`,
+        basis: `recomputed from your last ${ROUTING_WINDOW_DAYS}d of dispatch history (est_savings = actual child cost repriced at the suggested model)`,
+        confidence: "estimated",
+    } satisfies ImpactEstimate;
+});
+
+const TOOL_STATS_SQL = (
+    tool: string,
+) => `SELECT count() AS n FROM tool_call WHERE name = ${JSON.stringify(tool)} AND ts > time::now() - ${HOOK_WINDOW_DAYS}d GROUP ALL;
+SELECT count() AS n FROM tool_call WHERE name = ${JSON.stringify(tool)} AND status = "error" AND ts > time::now() - ${HOOK_WINDOW_DAYS}d GROUP ALL;`;
+
+const hookImpact = Effect.fn("improve.hookImpact")(function* (tool: string) {
+    const db = yield* SurrealClient;
+    const [totalRows, failRows] = yield* db.query<
+        [Array<{ n: number }>, Array<{ n: number }>]
+    >(TOOL_STATS_SQL(tool));
+    const total = Number(totalRows?.[0]?.n ?? 0);
+    const failures = Number(failRows?.[0]?.n ?? 0);
+    return {
+        kind: "addressable_failures",
+        headline: `intersects ${failures.toLocaleString("en")} failures (of ${total.toLocaleString("en")} ${tool} calls) in ${HOOK_WINDOW_DAYS}d`,
+        detail: failures > 0
+            ? `A guard on ${tool} sits in front of every one of those calls - the ${failures} that failed are its addressable surface.`
+            : `No recent ${tool} failures - this guard would be insurance, not triage.`,
+        basis: `your last ${HOOK_WINDOW_DAYS}d of tool_call history; addressable surface, not a replay (the hook isn't built yet)`,
+        confidence: "indicative",
+    } satisfies ImpactEstimate;
+});
+
+const guidanceImpact = (p: ProposalDto, baseline: Record<string, unknown>): ImpactEstimate => {
+    const evidence = typeof baseline.evidence === "string" ? baseline.evidence : null;
+    const freq = Number(baseline.frequency ?? p.frequency) || p.frequency;
+    return {
+        kind: "correction_pressure",
+        headline: `${freq}× repeated correction pressure`,
+        detail: evidence
+            ?? "The same correction keeps recurring across sessions; durable guidance removes the repeat-explanation tax.",
+        basis: "correction clusters mined from your transcripts (frozen at proposal creation)",
+        confidence: "indicative",
+    };
+};
+
+const skillImpact = (p: ProposalDto, baseline: Record<string, unknown>): ImpactEstimate => {
+    const tool = typeof baseline.tool === "string" ? baseline.tool : null;
+    const freq = Number(baseline.frequency ?? p.frequency) || p.frequency;
+    return {
+        kind: "frequency",
+        headline: `${freq}× recurring friction${tool ? ` on ${tool}` : ""}`,
+        detail: p.hypothesis,
+        basis: "failure/correction clusters mined from your transcripts (frozen at proposal creation)",
+        confidence: "indicative",
+    };
+};
+
+const fallbackImpact = (p: ProposalDto): ImpactEstimate => ({
+    kind: "frequency",
+    headline: `seen ${p.frequency}× in your history`,
+    detail: p.hypothesis,
+    basis: "signal frequency at proposal creation",
+    confidence: "indicative",
+});
+
+export const estimateImpact = Effect.fn("improve.estimateImpact")(function* (
+    p: ProposalDto,
+) {
+    if (isRoutingProposal(p)) return yield* routingImpact();
+    if (p.form === "hook" && p.hook_payload?.target_tool) {
+        return yield* hookImpact(p.hook_payload.target_tool);
+    }
+    const baseline = parseBaseline(p);
+    if (p.form === "guidance") return guidanceImpact(p, baseline);
+    if (p.form === "skill") return skillImpact(p, baseline);
+    return fallbackImpact(p);
+});
+
+// ---------------------------------------------------------------------------
+// Per-sig TTL cache. Failures are never stored (the lesson from ttl-cache).
+// ---------------------------------------------------------------------------
+
+const IMPACT_TTL_MS = 10 * 60_000;
+const cache = new Map<string, { estimate: ImpactEstimate; at: number }>();
+
+export const estimateImpactCached = Effect.fn("improve.estimateImpactCached")(
+    function* (p: ProposalDto, nowMs: number) {
+        const hit = cache.get(p.dedupe_sig);
+        if (hit && nowMs - hit.at < IMPACT_TTL_MS) return hit.estimate;
+        const estimate = yield* estimateImpact(p);
+        cache.set(p.dedupe_sig, { estimate, at: nowMs });
+        return estimate;
+    },
+);
+
+export function resetImpactCacheForTest(): void {
+    cache.clear();
+}

--- a/apps/axctl/src/improve/impact.ts
+++ b/apps/axctl/src/improve/impact.ts
@@ -74,27 +74,35 @@ const hookImpact = Effect.fn("improve.hookImpact")(function* (tool: string) {
     } satisfies ImpactEstimate;
 });
 
+/** The HEADLINE always uses the live frequency (matches the card chip);
+ *  the frozen baseline frequency becomes a growth note when it differs. */
+const growthNote = (p: ProposalDto, baseline: Record<string, unknown>): string => {
+    const frozen = Number(baseline.frequency ?? 0);
+    return frozen > 0 && frozen !== p.frequency
+        ? ` It was ${frozen}x when first proposed - still recurring.`
+        : "";
+};
+
 const guidanceImpact = (p: ProposalDto, baseline: Record<string, unknown>): ImpactEstimate => {
     const evidence = typeof baseline.evidence === "string" ? baseline.evidence : null;
-    const freq = Number(baseline.frequency ?? p.frequency) || p.frequency;
     return {
         kind: "correction_pressure",
-        headline: `${freq}× repeated correction pressure`,
-        detail: evidence
-            ?? "The same correction keeps recurring across sessions; durable guidance removes the repeat-explanation tax.",
-        basis: "correction clusters mined from your transcripts (frozen at proposal creation)",
+        headline: `${p.frequency}× repeated correction pressure`,
+        detail: (evidence
+            ?? "The same correction keeps recurring across sessions; durable guidance removes the repeat-explanation tax.")
+            + growthNote(p, baseline),
+        basis: "correction clusters mined from your transcripts (frequency is the live count; growth vs the frozen baseline noted)",
         confidence: "indicative",
     };
 };
 
 const skillImpact = (p: ProposalDto, baseline: Record<string, unknown>): ImpactEstimate => {
     const tool = typeof baseline.tool === "string" ? baseline.tool : null;
-    const freq = Number(baseline.frequency ?? p.frequency) || p.frequency;
     return {
         kind: "frequency",
-        headline: `${freq}× recurring friction${tool ? ` on ${tool}` : ""}`,
-        detail: p.hypothesis,
-        basis: "failure/correction clusters mined from your transcripts (frozen at proposal creation)",
+        headline: `${p.frequency}× recurring friction${tool ? ` on ${tool}` : ""}`,
+        detail: p.hypothesis + growthNote(p, baseline),
+        basis: "failure/correction clusters mined from your transcripts (frequency is the live count; growth vs the frozen baseline noted)",
         confidence: "indicative",
     };
 };

--- a/apps/axctl/src/improve/propose.ts
+++ b/apps/axctl/src/improve/propose.ts
@@ -26,6 +26,10 @@ const common = {
     confidence: Schema.Literals(["high", "medium", "low"]),
     frequency: Schema.optional(Schema.Int),
     evidence: Schema.optional(Schema.String),
+    /** hypothesis with {{placeholders}} hydrated at serve time - numbers stay live */
+    hypothesis_template: Schema.optional(Schema.String),
+    /** read-only SurrealQL (SELECT/RETURN) whose first row fills the template */
+    evidence_query: Schema.optional(Schema.String),
 };
 
 const SkillPayload = Schema.Struct({
@@ -174,6 +178,8 @@ export const buildProposeStatements = (
                 ["status", surrealString("open")],
                 ["origin", surrealString("agent")],
                 ["baseline", surrealOptionString(baseline)],
+                ["hypothesis_template", surrealOptionString(input.hypothesis_template ?? null)],
+                ["evidence_query", surrealOptionString(input.evidence_query ?? null)],
                 ["updated_at", "time::now()"],
             ])};`,
         );
@@ -201,8 +207,22 @@ export const buildProposeStatements = (
 export const decodeProposeInput = (raw: unknown) =>
     Schema.decodeUnknownEffect(ProposeInputSchema)(raw);
 
+/** Same guard as the dashboard SQL console: read-only statements only. */
+export const isReadOnlyEvidenceQuery = (sql: string): boolean =>
+    /^(SELECT|RETURN)\b/i.test(sql.trim());
+
 export const runPropose = Effect.fn("improve.runPropose")(function* (raw: unknown) {
     const input = yield* decodeProposeInput(raw);
+    if (input.evidence_query !== undefined && !isReadOnlyEvidenceQuery(input.evidence_query)) {
+        return yield* Effect.fail(
+            new Error("evidence_query must be a read-only SELECT or RETURN statement"),
+        );
+    }
+    if ((input.hypothesis_template === undefined) !== (input.evidence_query === undefined)) {
+        return yield* Effect.fail(
+            new Error("hypothesis_template and evidence_query must be provided together"),
+        );
+    }
     const sig = dedupeSig(input.form, normalizeTitle(input.title));
     const db = yield* SurrealClient;
     const existing = yield* db.query<[Array<{ id: unknown }>]>(

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+    ImpactEstimate,
     EpisodeTimelinePayload,
     GraphExplorerMode,
     GraphExplorerPayload,
@@ -435,6 +436,10 @@ export const api = {
 
     improveAnalyzeBrief: (): Promise<{ brief: string }> =>
         viaContract("/api/improve/analyze-brief", (c) => c.improve.analyzeBrief()),
+
+    improveImpact: (sig: string): Promise<{ sig: string; impact: ImpactEstimate }> =>
+        viaContract(`/api/improve/${encodeURIComponent(sig)}/impact`, (c) =>
+            c.improve.improveImpact({ params: { sig } })),
 
     wrappedGenerateBrief: (): Promise<{ brief: string }> =>
         viaContract("/api/wrapped/generate-brief", (c) => c.insights.wrappedGenerateBrief()),

--- a/apps/studio/src/components/copy-button.tsx
+++ b/apps/studio/src/components/copy-button.tsx
@@ -3,15 +3,17 @@ import { useState } from "react";
 export function CopyButton({
     text,
     label = "Copy agent brief",
+    className = "badge review",
 }: {
     readonly text: string;
     readonly label?: string;
+    readonly className?: string;
 }) {
     const [copied, setCopied] = useState(false);
     return (
         <button
             type="button"
-            className="badge review"
+            className={className}
             onClick={() => {
                 void navigator.clipboard.writeText(text).then(() => {
                     setCopied(true);

--- a/apps/studio/src/components/experiments-section.tsx
+++ b/apps/studio/src/components/experiments-section.tsx
@@ -1,0 +1,178 @@
+import type { CheckpointSnapshotDto, ProposalDto } from "@ax/lib/shared/dashboard-types";
+import { fmtTs } from "@ax/lib/shared/formatters";
+
+/**
+ * Experiments - past bets paying off. The deck above is futures; this is
+ * the ledger of accepted improvements with their measured effect. The
+ * trace strip is the argument: baseline frequency, then opportunities at
+ * +3/+10/+30 sessions. A bar shrinking to zero is a confirmed win.
+ */
+
+const VERDICT_ACCENT: Record<string, string> = {
+    adopted: "green",
+    no_longer_needed: "green",
+    partial: "gold",
+    ignored: "muted",
+    regressed: "rose",
+};
+
+/** Friendlier label for the internal verdict names. */
+const VERDICT_LABEL: Record<string, string> = {
+    adopted: "adopted",
+    no_longer_needed: "normalized",
+    partial: "partial",
+    ignored: "ignored",
+    regressed: "regressed",
+};
+
+interface TracePoint {
+    readonly label: string;
+    readonly opportunities: number;
+    readonly addressed: number;
+}
+
+const tracePoints = (p: ProposalDto): TracePoint[] => {
+    const points: TracePoint[] = [
+        { label: "baseline", opportunities: p.frequency, addressed: 0 },
+    ];
+    for (const cp of p.experiment?.checkpoints ?? []) {
+        if (cp.measured) {
+            points.push({
+                label: String(cp.kind),
+                opportunities: cp.measured.opportunities,
+                addressed: cp.measured.addressed,
+            });
+        }
+    }
+    return points;
+};
+
+function TraceStrip({ points, accent }: { readonly points: TracePoint[]; readonly accent: string }) {
+    const max = Math.max(...points.map((pt) => pt.opportunities), 1);
+    const lastIsZero = points.length > 1 && points[points.length - 1]!.opportunities === 0;
+    return (
+        <span
+            className={`experiment-trace${lastIsZero ? " is-win" : ""}`}
+            title={points.map((pt) => `${pt.label}: ${pt.opportunities} opportunities, ${pt.addressed} addressed`).join(" · ")}
+        >
+            {points.map((pt, i) => {
+                const oppH = Math.max(8, Math.round((pt.opportunities / max) * 100));
+                const addrH = pt.opportunities > 0
+                    ? Math.round((pt.addressed / pt.opportunities) * oppH)
+                    : 0;
+                return (
+                    <i key={i} style={{ height: pt.opportunities === 0 ? "4%" : `${oppH}%` }}>
+                        {addrH > 0 ? (
+                            <span
+                                className={`experiment-trace-addr accent-${accent}`}
+                                style={{ height: `${Math.round((addrH / Math.max(oppH, 1)) * 100)}%` }}
+                            />
+                        ) : null}
+                    </i>
+                );
+            })}
+        </span>
+    );
+}
+
+const stateOf = (p: ProposalDto): { accent: string; badge: string; note: string } => {
+    const exp = p.experiment;
+    const verdict = exp?.locked_verdict ?? null;
+    const checkpoints = (exp?.checkpoints ?? []).filter((c) => c.measured);
+    if (verdict) {
+        const accent = VERDICT_ACCENT[verdict] ?? "blue";
+        const last = checkpoints[checkpoints.length - 1];
+        const lastOpp = last?.measured?.opportunities ?? null;
+        const note = verdict === "no_longer_needed"
+            ? "pattern resolved · no longer firing"
+            : verdict === "regressed"
+            ? "pattern returned · review artifact"
+            : lastOpp !== null
+            ? `${lastOpp} occurrences in the last window · was ${p.frequency}x before`
+            : "verdict locked";
+        return { accent, badge: VERDICT_LABEL[verdict] ?? verdict, note };
+    }
+    if (checkpoints.length === 0) {
+        return { accent: "blue", badge: "pending", note: "waiting for sessions…" };
+    }
+    const suggested = exp?.latest_checkpoint?.suggested;
+    return {
+        accent: suggested === "regressed" ? "rose" : "blue",
+        badge: `${checkpoints.length}/3 checkpoints`,
+        note: suggested ? `suggested: ${suggested}` : "measuring…",
+    };
+};
+
+export function ExperimentsSection({
+    proposals,
+    onOpen,
+}: {
+    readonly proposals: ReadonlyArray<ProposalDto>;
+    readonly onOpen: (sig: string) => void;
+}) {
+    const experiments = proposals.filter(
+        (p) => p.status === "accepted" && p.experiment != null,
+    );
+    return (
+        <section className="experiments-section">
+            <div className="experiments-lead">
+                <span className="next-action-eyebrow" style={{ color: "var(--green)" }}>
+                    $ experiments
+                </span>
+                <h3 className="experiments-headline">
+                    {experiments.length > 0
+                        ? `${experiments.length} past bet${experiments.length === 1 ? "" : "s"}, measured`
+                        : "Past bets, measured"}
+                </h3>
+                <span className="experiments-count">
+                    checkpoints at +3 / +10 / +30 sessions
+                </span>
+            </div>
+            {experiments.length === 0 ? (
+                <div className="experiments-empty">
+                    <p className="experiments-empty-head">No bets placed yet.</p>
+                    <p className="proposal-prose" style={{ color: "var(--muted)" }}>
+                        Accept an improvement from the deck above - ax measures whether the
+                        fix actually changed your sessions over the next 30. A trace bar
+                        that shrinks to zero is a confirmed win.
+                    </p>
+                </div>
+            ) : (
+                <div className="experiments-list">
+                    {experiments.map((p) => {
+                        const st = stateOf(p);
+                        const exp = p.experiment!;
+                        const artifact = exp.artifact_path?.split("/").pop() ?? null;
+                        return (
+                            <button
+                                type="button"
+                                key={p.dedupe_sig}
+                                className={`experiment-card accent-${st.accent}${
+                                    st.accent === "green" ? " state-win" : st.accent === "rose" ? " state-regressed" : ""
+                                }`}
+                                onClick={() => onOpen(p.dedupe_sig)}
+                            >
+                                <span className="experiment-card-meta">
+                                    <span className="experiment-card-eyebrow">
+                                        {p.form} · accepted {exp.scaffolded_at ? fmtTs(exp.scaffolded_at) : fmtTs(exp.created_at)}
+                                    </span>
+                                    <span className="experiment-card-title">{p.title}</span>
+                                    {artifact ? (
+                                        <span className="experiment-card-artifact">{artifact}</span>
+                                    ) : null}
+                                </span>
+                                <span className="experiment-card-trace">
+                                    <TraceStrip points={tracePoints(p)} accent={st.accent} />
+                                    <span className="experiment-trace-caption">{st.note}</span>
+                                </span>
+                                <span className={`badge ${st.accent === "green" ? "keep" : st.accent === "rose" ? "archive" : "review"}`}>
+                                    {st.badge}
+                                </span>
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
+        </section>
+    );
+}

--- a/apps/studio/src/components/next-actions-panel.tsx
+++ b/apps/studio/src/components/next-actions-panel.tsx
@@ -7,42 +7,72 @@ import { CopyButton } from "./copy-button.tsx";
 export interface NextActionsHandlers {
     readonly onAccept: (sig: string) => void;
     readonly onVerdict: (sig: string, verdict: string) => void;
-    // "decide" inline actions (skill hygiene) intentionally have no one-click
-    // handler - role choice needs thought, so those cards offer copy + link only.
     /** true while any action mutation is in flight - disables all card buttons */
     readonly pending: boolean;
 }
 
+/** Eyebrow labels read as findings, not table names. */
 const KIND_LABEL: Record<NextActionKind, string> = {
     proposal: "proposal",
     verdict: "verdict due",
-    tool_failure: "tool failure",
+    tool_failure: "failing tool",
     churn: "churn",
-    routing: "routing $",
+    routing: "routing savings",
     skill_hygiene: "skill hygiene",
 };
 
+/** Semantic accent per kind: money green, failure rose, decision gold. */
+const KIND_ACCENT: Record<NextActionKind, string> = {
+    routing: "green",
+    proposal: "blue",
+    verdict: "gold",
+    tool_failure: "rose",
+    churn: "violet",
+    skill_hygiene: "gold",
+};
+
+/** Three rows of cards max before the registry below buries the page. */
+const DECK_CAP = 6;
+
 export function NextActionsPanel({ handlers }: { readonly handlers: NextActionsHandlers }) {
-    const query = useQuery({ queryKey: ["next-actions"], queryFn: () => api.nextActions(), staleTime: 60_000 });
+    const query = useQuery({
+        queryKey: ["next-actions"],
+        queryFn: () => api.nextActions(),
+        staleTime: 60_000,
+    });
     if (query.isLoading) return <div className="loading">Loading next actions&#8230;</div>;
     if (query.error) return <div className="error">next-actions: {String(query.error)}</div>;
     const cards = query.data?.cards ?? [];
     if (cards.length === 0) {
-        return <div className="empty">Nothing actionable right now &#8212; loop is clean.</div>;
+        return (
+            <div className="next-actions-empty">
+                Nothing actionable right now &#8212; the loop is clean.
+            </div>
+        );
     }
+    const deck = cards.slice(0, DECK_CAP);
+    const overflow = cards.length - deck.length;
     return (
-        <div className="next-actions">
-            {cards.map((card) => (
-                <NextActionCardView key={card.id} card={card} handlers={handlers} />
-            ))}
+        <>
+            <div className="next-actions">
+                {deck.map((card) => (
+                    <NextActionCardView key={card.id} card={card} handlers={handlers} />
+                ))}
+            </div>
+            {overflow > 0 ? (
+                <div className="next-actions-note">+{overflow} more in the registry below</div>
+            ) : null}
             {(query.data?.notes.length ?? 0) > 0 ? (
-                <div className="meta">
+                <div className="next-actions-note">
                     {query.data!.notes.map((n) => `${n.source}: unavailable`).join(" \xB7 ")}
                 </div>
             ) : null}
-        </div>
+        </>
     );
 }
+
+/** Strip the dead "Decide proposal:" prefix - the eyebrow already says it. */
+const cleanTitle = (title: string): string => title.replace(/^Decide proposal:\s*/i, "");
 
 function NextActionCardView({
     card,
@@ -55,46 +85,50 @@ function NextActionCardView({
     const acceptSig = a?.type === "accept" ? a.sig : null;
     const verdictSig = a?.type === "verdict" ? a.sig : null;
     const suggestedVerdict = a?.type === "verdict" ? a.suggested_verdict : null;
+    // "decide" inline actions (skill hygiene) intentionally have no one-click
+    // handler - role choice needs thought, so those cards offer copy + link only.
+
+    const title = cleanTitle(card.title);
+    // Every card gets exactly one serif line: the impact chip when present
+    // (the value IS the headline), otherwise the title takes the hero slot.
+    const heroIsTitle = card.impact_chip == null;
+    const hero = card.impact_chip ?? title;
+
     return (
-        <article className="panel next-action-card">
-            <header>
-                <span className={`badge ${card.kind === "verdict" ? "archive" : "review"}`}>
-                    {KIND_LABEL[card.kind] ?? card.kind}
-                </span>
-                <h4 style={{ margin: 0 }}>{card.title}</h4>
-            </header>
-            <p className="meta">
-                {card.impact_chip ? (
-                    <strong className="next-action-impact">{card.impact_chip}</strong>
-                ) : null}
-                {card.impact_chip ? " · " : null}
-                {card.evidence}
-            </p>
-            <div className="actions" style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                <CopyButton text={card.brief} />
+        <article className={`next-action-card accent-${KIND_ACCENT[card.kind] ?? "blue"}`}>
+            <span className="next-action-eyebrow">$ {KIND_LABEL[card.kind] ?? card.kind}</span>
+            <strong className={`next-action-hero${heroIsTitle ? " is-title" : ""}`}>{hero}</strong>
+            {heroIsTitle ? null : <h4 className="next-action-title">{title}</h4>}
+            <p className="next-action-evidence">{card.evidence}</p>
+            <div className="next-action-foot">
                 {acceptSig ? (
                     <button
                         type="button"
-                        className="badge keep"
+                        className="next-action-primary"
                         disabled={handlers.pending}
                         onClick={() => handlers.onAccept(acceptSig)}
                     >
-                        Accept &amp; scaffold
+                        {handlers.pending ? "…" : "Accept & scaffold"}
                     </button>
-                ) : null}
-                {verdictSig && suggestedVerdict ? (
+                ) : verdictSig && suggestedVerdict ? (
                     <button
                         type="button"
-                        className="badge keep"
+                        className="next-action-primary"
                         disabled={handlers.pending}
                         onClick={() => handlers.onVerdict(verdictSig, suggestedVerdict)}
                     >
-                        Lock: {suggestedVerdict}
+                        {handlers.pending ? "…" : `Lock: ${suggestedVerdict}`}
                     </button>
+                ) : card.link ? (
+                    // card.link values come from the server-side builders,
+                    // which only emit registered SPA paths
+                    <Link to={card.link} className="next-action-primary">
+                        Details &#8594;
+                    </Link>
                 ) : null}
-                {/* card.link values come from the server-side builders, which only emit registered SPA paths */}
-                {card.link ? (
-                    <Link to={card.link} className="badge review">
+                <CopyButton text={card.brief} label="copy brief" className="next-action-ghost" />
+                {card.link && (acceptSig || verdictSig) ? (
+                    <Link to={card.link} className="next-action-ghost">
                         details &#8594;
                     </Link>
                 ) : null}

--- a/apps/studio/src/components/next-actions-panel.tsx
+++ b/apps/studio/src/components/next-actions-panel.tsx
@@ -5,7 +5,9 @@ import { api } from "../api.ts";
 import { CopyButton } from "./copy-button.tsx";
 
 export interface NextActionsHandlers {
-    readonly onAccept: (sig: string) => void;
+    /** open the proposal case file (detail) - accepting happens THERE,
+     *  next to the plan rail and projected impact, not from the card. */
+    readonly onReview: (sig: string) => void;
     readonly onVerdict: (sig: string, verdict: string) => void;
     /** true while any action mutation is in flight - disables all card buttons */
     readonly pending: boolean;
@@ -112,10 +114,9 @@ function NextActionCardView({
                     <button
                         type="button"
                         className="next-action-primary"
-                        disabled={handlers.pending}
-                        onClick={() => handlers.onAccept(acceptSig)}
+                        onClick={() => handlers.onReview(acceptSig)}
                     >
-                        {handlers.pending ? "…" : "Accept & scaffold"}
+                        Review &#8594;
                     </button>
                 ) : verdictSig && suggestedVerdict ? (
                     <button

--- a/apps/studio/src/components/next-actions-panel.tsx
+++ b/apps/studio/src/components/next-actions-panel.tsx
@@ -98,8 +98,12 @@ function NextActionCardView({
         <article className={`next-action-card accent-${KIND_ACCENT[card.kind] ?? "blue"}`}>
             <span className="next-action-eyebrow">$ {KIND_LABEL[card.kind] ?? card.kind}</span>
             <strong className={`next-action-hero${heroIsTitle ? " is-title" : ""}`}>{hero}</strong>
-            {heroIsTitle ? null : <h4 className="next-action-title">{title}</h4>}
-            <p className="next-action-evidence">{card.evidence}</p>
+            <p className="next-action-problem">{card.evidence}</p>
+            {heroIsTitle ? null : (
+                <p className="next-action-fix">
+                    <span className="next-action-fix-label">fix &#8594;</span> {title}
+                </p>
+            )}
             <div className="next-action-foot">
                 {acceptSig ? (
                     <button

--- a/apps/studio/src/components/next-actions-panel.tsx
+++ b/apps/studio/src/components/next-actions-panel.tsx
@@ -101,7 +101,10 @@ function NextActionCardView({
             <p className="next-action-problem">{card.evidence}</p>
             {heroIsTitle ? null : (
                 <p className="next-action-fix">
-                    <span className="next-action-fix-label">fix &#8594;</span> {title}
+                    <span className="next-action-fix-label">
+                        fix &#8594;{card.fix_kind ? ` ${card.fix_kind}:` : ""}
+                    </span>{" "}
+                    {title}
                 </p>
             )}
             <div className="next-action-foot">

--- a/apps/studio/src/components/next-actions-panel.tsx
+++ b/apps/studio/src/components/next-actions-panel.tsx
@@ -21,6 +21,7 @@ const KIND_LABEL: Record<NextActionKind, string> = {
     churn: "churn",
     routing: "routing savings",
     skill_hygiene: "skill hygiene",
+    housekeeping: "housekeeping",
 };
 
 /** Semantic accent per kind: money green, failure rose, decision gold. */
@@ -31,6 +32,7 @@ const KIND_ACCENT: Record<NextActionKind, string> = {
     tool_failure: "rose",
     churn: "violet",
     skill_hygiene: "gold",
+    housekeeping: "muted",
 };
 
 /** Three rows of cards max before the registry below buries the page. */

--- a/apps/studio/src/components/next-actions-panel.tsx
+++ b/apps/studio/src/components/next-actions-panel.tsx
@@ -63,7 +63,13 @@ function NextActionCardView({
                 </span>
                 <h4 style={{ margin: 0 }}>{card.title}</h4>
             </header>
-            <p className="meta">{card.evidence}</p>
+            <p className="meta">
+                {card.impact_chip ? (
+                    <strong className="next-action-impact">{card.impact_chip}</strong>
+                ) : null}
+                {card.impact_chip ? " · " : null}
+                {card.evidence}
+            </p>
             <div className="actions" style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                 <CopyButton text={card.brief} />
                 {acceptSig ? (

--- a/apps/studio/src/mock-fixtures.ts
+++ b/apps/studio/src/mock-fixtures.ts
@@ -367,6 +367,18 @@ export async function mockFetch<T>(input: RequestInfo, init?: RequestInit): Prom
     if (path === "/api/wrapped/generate-brief") {
         return { brief: "## Task: Write my Agent Wrapped cards (mock)\n\nConnect a local daemon for the real brief." } as unknown as T;
     }
+    if (/^\/api\/improve\/[^/]+\/impact$/.test(path)) {
+        return {
+            sig: decodeURIComponent(path.split("/")[3]),
+            impact: {
+                kind: "savings_usd",
+                headline: "~$297 redirectable over 30d (mock)",
+                detail: "Connect a local daemon for a real estimate.",
+                basis: "mock fixture",
+                confidence: "indicative",
+            },
+        } as unknown as T;
+    }
     if (path === "/api/improve/analyze-brief") {
         return { brief: "## Task: Deep-analysis pass (mock)\n\nConnect a local daemon for the real brief." } as unknown as T;
     }

--- a/apps/studio/src/routes/improve.tsx
+++ b/apps/studio/src/routes/improve.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api.ts";
 import type {
+    ExperimentDto,
     ExperimentStatus,
     ImproveActionResponse,
     ProposalDto,
@@ -261,6 +262,15 @@ interface ProposalDetailProps {
     readonly pending: boolean;
 }
 
+const hasPayload = (p: ProposalDto): boolean =>
+    Boolean(
+        (p.form === "skill" && p.skill_payload) ||
+        (p.form === "guidance" && p.guidance_payload) ||
+        (p.form === "subagent" && p.subagent_payload) ||
+        (p.form === "hook" && p.hook_payload) ||
+        (p.form === "automation" && p.automation_payload),
+    );
+
 function ProposalDetail({
     proposal,
     rejectReason,
@@ -274,50 +284,48 @@ function ProposalDetail({
     const cp = exp?.latest_checkpoint ?? null;
     return (
         <>
-            <header>
-                <h3 style={{ margin: 0 }}>{proposal.title}</h3>
-                <span className="meta">{proposal.dedupe_sig} · {proposal.origin ?? "mined"}</span>
+            <header className="proposal-head">
+                <h3 className="proposal-title">{proposal.title}</h3>
+                <span className="meta">
+                    {proposal.form} · {proposal.origin ?? "mined"} · confidence {proposal.confidence}
+                    {" · "}seen {proposal.frequency}x · {fmtTs(proposal.created_at)}
+                </span>
             </header>
-            <dl className="kv">
-                <dt>Form</dt><dd>{proposal.form}</dd>
-                <dt>Status</dt><dd><StatusPill status={proposal.status} /></dd>
-                <dt>Confidence</dt><dd>{proposal.confidence}</dd>
-                <dt>Frequency</dt><dd>{proposal.frequency}</dd>
-                <dt>Created</dt><dd>{fmtTs(proposal.created_at)}</dd>
-                <dt>Hypothesis</dt><dd>{proposal.hypothesis}</dd>
-                {proposal.reject_reason ? (<><dt>Reject reason</dt><dd>{proposal.reject_reason}</dd></>) : null}
-            </dl>
 
-            <PayloadView proposal={proposal} />
+            <ImpactSection sig={proposal.dedupe_sig} experiment={exp} />
 
-            {exp ? (
-                <section className="panel" style={{ marginTop: 12 }}>
-                    <header>
-                        <h4 style={{ margin: 0 }}>Experiment</h4>
-                        <span className="meta">{fmtTs(exp.created_at)}</span>
-                    </header>
-                    <dl className="kv">
-                        {exp.status ? (<><dt>Exp. Status</dt><dd><ExperimentStatusBadge status={exp.status} /></dd></>) : null}
+            <section className="proposal-section">
+                <h4 className="proposal-section-label">why this fired</h4>
+                <p className="proposal-prose">{proposal.hypothesis}</p>
+                {proposal.reject_reason ? (
+                    <p className="proposal-prose meta">rejected: {proposal.reject_reason}</p>
+                ) : null}
+            </section>
+
+            {hasPayload(proposal) ? (
+                <section className="proposal-section">
+                    <h4 className="proposal-section-label">the fix</h4>
+                    <PayloadView proposal={proposal} />
+                </section>
+            ) : null}
+
+            <section className="proposal-section">
+                <h4 className="proposal-section-label">the plan</h4>
+                <LifecycleRail proposal={proposal} />
+                {exp ? (
+                    <dl className="kv" style={{ marginTop: 8 }}>
                         {exp.artifact_path ? (<><dt>Artifact</dt><dd><code>{exp.artifact_path}</code></dd></>) : null}
                         {exp.task_path && exp.status === "task_emitted"
                             ? (<><dt>Task path</dt><dd>{exp.task_path}</dd></>) : null}
-                        {exp.scaffolded_at ? (<><dt>Scaffolded</dt><dd>{fmtTs(exp.scaffolded_at)}</dd></>) : null}
-                        <dt>Verdict</dt><dd>
-                            {exp.locked_verdict
-                                ? <strong>{exp.locked_verdict} (locked)</strong>
-                                : cp?.suggested
-                                    ? <em>{cp.suggested} (suggested @ {cp.kind})</em>
-                                    : "pending - no checkpoint yet"}
-                        </dd>
                         {cp?.measured ? (
                             <>
-                                <dt>Opportunities</dt>
-                                <dd>{cp.measured.opportunities} ({cp.measured.addressed} addressed)</dd>
+                                <dt>Measured</dt>
+                                <dd>{cp.measured.addressed} of {cp.measured.opportunities} opportunities addressed</dd>
                             </>
                         ) : null}
                     </dl>
-                </section>
-            ) : null}
+                ) : null}
+            </section>
 
             <div className="actions" style={{ marginTop: 16, display: "flex", gap: 8, flexWrap: "wrap" }}>
                 {proposal.brief ? <CopyButton text={proposal.brief} /> : null}
@@ -481,4 +489,65 @@ function NextActionsHeadline() {
     });
     const n = query.data?.cards.length;
     return <>{n === undefined ? "What's next" : `${n} actions waiting`}</>;
+}
+
+/** Projected impact - the centerpiece. Lazily fetched per proposal; once an
+ *  experiment has measured checkpoints, the measurement shares the stage. */
+function ImpactSection({ sig, experiment }: { readonly sig: string; readonly experiment: ExperimentDto | null }) {
+    const query = useQuery({
+        queryKey: ["improve", "impact", sig],
+        queryFn: () => api.improveImpact(sig),
+        staleTime: 10 * 60_000,
+    });
+    const impact = query.data?.impact;
+    const measured = experiment?.latest_checkpoint?.measured ?? null;
+    if (query.isLoading) return <div className="loading">Estimating impact&#8230;</div>;
+    if (!impact) return null;
+    return (
+        <section className="proposal-impact">
+            <span className="proposal-section-label">
+                projected impact · <em>{impact.confidence}</em>
+            </span>
+            <strong className="proposal-impact-headline">{impact.headline}</strong>
+            <p className="proposal-prose">{impact.detail}</p>
+            {measured ? (
+                <p className="proposal-prose">
+                    <strong>measured so far:</strong> {measured.addressed} of {measured.opportunities} opportunities addressed
+                </p>
+            ) : null}
+            <span className="proposal-impact-basis">basis: {impact.basis}</span>
+        </section>
+    );
+}
+
+/** The accept lifecycle: what actually happens, with the current stage lit. */
+function LifecycleRail({ proposal }: { readonly proposal: ProposalDto }) {
+    const exp = proposal.experiment ?? null;
+    const hasCheckpoint = exp?.latest_checkpoint != null;
+    const locked = exp?.locked_verdict != null;
+    const stage = proposal.status === "open"
+        ? 0
+        : !exp || exp.status === "task_emitted"
+        ? 1
+        : !hasCheckpoint
+        ? 2
+        : !locked
+        ? 2
+        : 3;
+    const stages = [
+        { label: "accept", hint: "emits a task brief / scaffolds the artifact" },
+        { label: "apply", hint: "your agent lands the change" },
+        { label: "checkpoints", hint: "measured at +3/+10/+30 sessions" },
+        { label: "verdict", hint: locked ? `locked: ${exp?.locked_verdict}` : "adopted / ignored / regressed" },
+    ];
+    return (
+        <ol className="lifecycle-rail">
+            {stages.map((s, i) => (
+                <li key={s.label} className={i < stage ? "done" : i === stage ? "current" : ""} title={s.hint}>
+                    <span className="lifecycle-dot" />
+                    <span className="lifecycle-label">{s.label}</span>
+                </li>
+            ))}
+        </ol>
+    );
 }

--- a/apps/studio/src/routes/improve.tsx
+++ b/apps/studio/src/routes/improve.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api.ts";
 import type {
@@ -66,10 +66,16 @@ export function ImproveRoute() {
         },
         [proposals, formFilter, statusFilter],
     );
+    // The case file opens only on an explicit Review/row click - no
+    // auto-select - and resolves from ALL proposals, not the filtered view.
     const selected = useMemo(
-        () => filtered.find((p) => p.dedupe_sig === selectedSig) ?? filtered[0] ?? null,
-        [filtered, selectedSig],
+        () => proposals.find((p) => p.dedupe_sig === selectedSig) ?? null,
+        [proposals, selectedSig],
     );
+    const caseRef = useRef<HTMLDivElement | null>(null);
+    useEffect(() => {
+        if (selectedSig !== null) caseRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, [selectedSig]);
 
     const onActionResult = (action: string, res: ImproveActionResponse) => {
         if (res.status === "ok") {
@@ -122,7 +128,7 @@ export function ImproveRoute() {
             </header>
 
             <NextActionsPanel handlers={{
-                onAccept: (sig) => acceptMutation.mutate(sig),
+                onReview: (sig) => setSelectedSig(sig),
                 onVerdict: (sig, v) => verdictMutation.mutate({ sig, verdict: v }),
                 pending: acceptMutation.isPending || rejectMutation.isPending || verdictMutation.isPending,
             }} />
@@ -131,8 +137,30 @@ export function ImproveRoute() {
             {actionError ? <div className="error">{actionError}</div> : null}
             {actionInfo ? <div className="empty" style={{ color: "var(--green)" }}>{actionInfo}</div> : null}
 
+            {selected ? (
+                <div className="proposal-case panel" ref={caseRef}>
+                    <button
+                        type="button"
+                        className="next-action-ghost proposal-case-close"
+                        onClick={() => setSelectedSig(null)}
+                    >
+                        close &#10005;
+                    </button>
+                    <ProposalDetail
+                        proposal={selected}
+                        rejectReason={rejectReason}
+                        onRejectReason={setRejectReason}
+                        onAccept={() => acceptMutation.mutate(selected.dedupe_sig)}
+                        onReject={() => rejectMutation.mutate({ sig: selected.dedupe_sig, reason: rejectReason || null })}
+                        onSetVerdict={(verdict) => verdictMutation.mutate({ sig: selected.dedupe_sig, verdict })}
+                        pending={acceptMutation.isPending || rejectMutation.isPending || verdictMutation.isPending}
+                    />
+                </div>
+            ) : null}
+
+            <details className="improve-history">
+            <summary style={{ cursor: "pointer" }}><strong>All proposals</strong> <span className="meta">{proposals.length} total - history and filters</span></summary>
             <div className="improve-registry-head">
-                <h3>All proposals</h3>
                 <span className="meta" title="Ranked by confidence × frequency - click a row for details">
                     {proposals.length} proposals · {filtered.length} shown
                 </span>
@@ -158,8 +186,7 @@ export function ImproveRoute() {
                 <div className="empty">No proposals match the current filters.</div>
             ) : null}
 
-            <div className="improve-grid">
-                <table className="skills">
+            <table className="skills">
                     <thead>
                         <tr>
                             <th>Freq</th>
@@ -211,23 +238,7 @@ export function ImproveRoute() {
                         })}
                     </tbody>
                 </table>
-
-                <aside className="panel" style={{ position: "sticky", top: 16, alignSelf: "flex-start" }}>
-                    {selected ? (
-                        <ProposalDetail
-                            proposal={selected}
-                            rejectReason={rejectReason}
-                            onRejectReason={setRejectReason}
-                            onAccept={() => acceptMutation.mutate(selected.dedupe_sig)}
-                            onReject={() => rejectMutation.mutate({ sig: selected.dedupe_sig, reason: rejectReason || null })}
-                            onSetVerdict={(verdict) => verdictMutation.mutate({ sig: selected.dedupe_sig, verdict })}
-                            pending={acceptMutation.isPending || rejectMutation.isPending || verdictMutation.isPending}
-                        />
-                    ) : (
-                        <div className="empty">Select a proposal to see details, accept it, or set a verdict.</div>
-                    )}
-                </aside>
-            </div>
+            </details>
 
             <details style={{ marginTop: 24 }}>
                 <summary style={{ cursor: "pointer" }}><strong>Decision log</strong></summary>

--- a/apps/studio/src/routes/improve.tsx
+++ b/apps/studio/src/routes/improve.tsx
@@ -23,6 +23,18 @@ const VERDICTS: ReadonlyArray<string> = [
     "adopted", "ignored", "regressed", "partial", "no_longer_needed",
 ];
 const CONF_W: Record<string, number> = { high: 3, medium: 2, low: 1 };
+
+/** Mirror of the server-side impactChip (next-actions.ts) - cheap parse only. */
+const impactChipOf = (p: ProposalDto): string | null => {
+    if (p.form === "hook") {
+        const m = /est \$([\d,]+(?:\.\d+)?)/.exec(p.hypothesis);
+        if (m) return `~$${m[1]} redirectable`;
+    }
+    if (p.form === "guidance" || p.form === "skill") {
+        return p.frequency > 1 ? `${p.frequency}x recurring` : null;
+    }
+    return null;
+};
 const score = (p: ProposalDto) =>
     (CONF_W[p.confidence] ?? 1) * Math.log2(p.frequency + 1) +
     // agent-origin tiebreak above mined at equal confidence x frequency
@@ -177,6 +189,11 @@ export function ImproveRoute() {
                                             ? <span className="badge keep" style={{ marginRight: 6 }}>agent</span>
                                             : null}
                                         {p.title}
+                                        {impactChipOf(p) ? (
+                                            <span className="next-action-impact" style={{ marginLeft: 8 }}>
+                                                {impactChipOf(p)}
+                                            </span>
+                                        ) : null}
                                     </td>
                                 </tr>
                             );

--- a/apps/studio/src/routes/improve.tsx
+++ b/apps/studio/src/routes/improve.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api.ts";
 import type {
@@ -11,6 +12,7 @@ import type {
 } from "@ax/lib/shared/dashboard-types";
 import { fmtTs } from "@ax/lib/shared/formatters";
 import { NextActionsPanel } from "../components/next-actions-panel.tsx";
+import { ExperimentsSection } from "../components/experiments-section.tsx";
 import { CopyButton } from "../components/copy-button.tsx";
 import { DecisionsSection } from "../components/decisions-section.tsx";
 
@@ -45,7 +47,9 @@ export function ImproveRoute() {
     const queryClient = useQueryClient();
     const [formFilter, setFormFilter] = useState<ProposalForm | "all">("all");
     const [statusFilter, setStatusFilter] = useState<ProposalStatus | "all">("open");
-    const [selectedSig, setSelectedSig] = useState<string | null>(null);
+    const [selectedSig, setSelectedSig] = useState<string | null>(
+        () => new URLSearchParams(window.location.search).get("sig"),
+    );
     const [rejectReason, setRejectReason] = useState<string>("");
     const [actionError, setActionError] = useState<string | null>(null);
     const [actionInfo, setActionInfo] = useState<string | null>(null);
@@ -72,10 +76,20 @@ export function ImproveRoute() {
         () => proposals.find((p) => p.dedupe_sig === selectedSig) ?? null,
         [proposals, selectedSig],
     );
-    const caseRef = useRef<HTMLDivElement | null>(null);
+    // Drawer is linkable (?sig=) and closes on Escape; fixed overlay = no reflow.
     useEffect(() => {
-        if (selectedSig !== null) caseRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+        const url = new URL(window.location.href);
+        if (selectedSig) url.searchParams.set("sig", selectedSig);
+        else url.searchParams.delete("sig");
+        window.history.replaceState(null, "", url);
     }, [selectedSig]);
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setSelectedSig(null);
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, []);
 
     const onActionResult = (action: string, res: ImproveActionResponse) => {
         if (res.status === "ok") {
@@ -137,26 +151,40 @@ export function ImproveRoute() {
             {actionError ? <div className="error">{actionError}</div> : null}
             {actionInfo ? <div className="empty" style={{ color: "var(--green)" }}>{actionInfo}</div> : null}
 
-            {selected ? (
-                <div className="proposal-case panel" ref={caseRef}>
-                    <button
-                        type="button"
-                        className="next-action-ghost proposal-case-close"
-                        onClick={() => setSelectedSig(null)}
+            {selected ? createPortal(
+                <>
+                    <div className="proposal-drawer-scrim" onClick={() => setSelectedSig(null)} />
+                    <aside
+                        className="proposal-drawer"
+                        role="dialog"
+                        aria-modal="true"
+                        aria-label={selected.title}
                     >
-                        close &#10005;
-                    </button>
-                    <ProposalDetail
-                        proposal={selected}
-                        rejectReason={rejectReason}
-                        onRejectReason={setRejectReason}
-                        onAccept={() => acceptMutation.mutate(selected.dedupe_sig)}
-                        onReject={() => rejectMutation.mutate({ sig: selected.dedupe_sig, reason: rejectReason || null })}
-                        onSetVerdict={(verdict) => verdictMutation.mutate({ sig: selected.dedupe_sig, verdict })}
-                        pending={acceptMutation.isPending || rejectMutation.isPending || verdictMutation.isPending}
-                    />
-                </div>
+                        <button
+                            type="button"
+                            className="next-action-ghost proposal-drawer-close"
+                            onClick={() => setSelectedSig(null)}
+                        >
+                            &#8592; close
+                        </button>
+                        <ProposalDetail
+                            proposal={selected}
+                            rejectReason={rejectReason}
+                            onRejectReason={setRejectReason}
+                            onAccept={() => acceptMutation.mutate(selected.dedupe_sig)}
+                            onReject={() => rejectMutation.mutate({ sig: selected.dedupe_sig, reason: rejectReason || null })}
+                            onSetVerdict={(verdict) => verdictMutation.mutate({ sig: selected.dedupe_sig, verdict })}
+                            pending={acceptMutation.isPending || rejectMutation.isPending || verdictMutation.isPending}
+                        />
+                    </aside>
+                </>,
+                document.body,
             ) : null}
+
+            <ExperimentsSection
+                proposals={proposals}
+                onOpen={(sig) => setSelectedSig(sig)}
+            />
 
             <details className="improve-history">
             <summary style={{ cursor: "pointer" }}><strong>All proposals</strong> <span className="meta">{proposals.length} total - history and filters</span></summary>

--- a/apps/studio/src/routes/improve.tsx
+++ b/apps/studio/src/routes/improve.tsx
@@ -105,11 +105,18 @@ export function ImproveRoute() {
 
     return (
         <section className="panel improve-route">
-            <header>
-                <h2>Experiment Loop</h2>
-                <span className="meta">
-                    {proposals.length} proposals · {filtered.length} shown
-                </span>
+            <header className="improve-lead">
+                <div>
+                    <span className="next-action-eyebrow" style={{ color: "var(--green)" }}>
+                        $ what's next
+                    </span>
+                    <h2 className="improve-headline">
+                        <NextActionsHeadline />
+                    </h2>
+                    <p className="improve-sub">
+                        Mined from your sessions - savings to route, fixes that recur, verdicts due.
+                    </p>
+                </div>
                 <AnalysisBriefButton />
             </header>
 
@@ -121,24 +128,27 @@ export function ImproveRoute() {
 
             {query.error ? <div className="error">Error: {String(query.error)}</div> : null}
             {actionError ? <div className="error">{actionError}</div> : null}
-            {actionInfo ? <div className="empty" style={{ color: "#1d6f3d" }}>{actionInfo}</div> : null}
+            {actionInfo ? <div className="empty" style={{ color: "var(--green)" }}>{actionInfo}</div> : null}
 
-            <div className="filter-bar" style={{ display: "flex", gap: 12, alignItems: "center", marginBottom: 12, flexWrap: "wrap" }}>
-                <label>
-                    form{" "}
-                    <select value={formFilter} onChange={(e) => setFormFilter(e.target.value as ProposalForm | "all")}>
-                        {ALL_FORMS.map((f) => (<option key={f} value={f}>{f}</option>))}
-                    </select>
-                </label>
-                <label>
-                    status{" "}
-                    <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as ProposalStatus | "all")}>
-                        {ALL_STATUSES.map((s) => (<option key={s} value={s}>{s}</option>))}
-                    </select>
-                </label>
-                <span className="meta">
-                    Ranked by confidence × frequency · click a row for details
+            <div className="improve-registry-head">
+                <h3>All proposals</h3>
+                <span className="meta" title="Ranked by confidence × frequency - click a row for details">
+                    {proposals.length} proposals · {filtered.length} shown
                 </span>
+                <div className="filters">
+                    <label>
+                        form{" "}
+                        <select value={formFilter} onChange={(e) => setFormFilter(e.target.value as ProposalForm | "all")}>
+                            {ALL_FORMS.map((f) => (<option key={f} value={f}>{f}</option>))}
+                        </select>
+                    </label>
+                    <label>
+                        status{" "}
+                        <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as ProposalStatus | "all")}>
+                            {ALL_STATUSES.map((s) => (<option key={s} value={s}>{s}</option>))}
+                        </select>
+                    </label>
+                </div>
             </div>
 
             {query.isLoading ? <div className="loading">Loading…</div> : null}
@@ -460,4 +470,15 @@ function AnalysisBriefButton() {
     });
     if (!query.data) return null;
     return <CopyButton text={query.data.brief} label="Copy analysis brief" />;
+}
+
+/** Serif lead: counts what the loop found (shares the cached next-actions query). */
+function NextActionsHeadline() {
+    const query = useQuery({
+        queryKey: ["next-actions"],
+        queryFn: () => api.nextActions(),
+        staleTime: 60_000,
+    });
+    const n = query.data?.cards.length;
+    return <>{n === undefined ? "What's next" : `${n} actions waiting`}</>;
 }

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2668,6 +2668,7 @@ td.skill-cell .description {
 .next-action-card.accent-gold   { --card-accent: var(--gold); }
 .next-action-card.accent-violet { --card-accent: var(--violet); }
 .next-action-card.accent-rose   { --card-accent: var(--rose); }
+.next-action-card.accent-muted  { --card-accent: var(--muted); }
 
 .next-action-eyebrow {
     color: var(--card-accent);

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2635,3 +2635,10 @@ td.skill-cell .description {
     font-size: 14px;
     padding: 8px 14px;
 }
+
+.next-action-impact {
+    color: var(--green);
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 12px;
+    font-weight: 600;
+}

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2642,3 +2642,154 @@ td.skill-cell .description {
     font-size: 12px;
     font-weight: 600;
 }
+
+/* ---- next-action cards (Improve) - siblings of .wrapped-card ---- */
+.next-actions {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 16px;
+    margin: 4px 0 8px;
+}
+@media (max-width: 1280px) { .next-actions { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 760px)  { .next-actions { grid-template-columns: 1fr; } }
+
+.next-action-card {
+    border: 1px solid var(--line);
+    border-top: 4px solid var(--card-accent, var(--green));
+    background: var(--panel);
+    padding: 14px 16px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-height: 190px;
+}
+.next-action-card.accent-green  { --card-accent: var(--green); }
+.next-action-card.accent-blue   { --card-accent: var(--blue); }
+.next-action-card.accent-gold   { --card-accent: var(--gold); }
+.next-action-card.accent-violet { --card-accent: var(--violet); }
+.next-action-card.accent-rose   { --card-accent: var(--rose); }
+
+.next-action-eyebrow {
+    color: var(--card-accent);
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 12px;
+    letter-spacing: 0.01em;
+}
+.next-action-hero {
+    font-family: Georgia, serif;
+    font-weight: 600;
+    font-size: 24px;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+}
+.next-action-hero.is-title { font-size: 19px; }
+.next-action-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.35;
+    color: var(--ink);
+}
+.next-action-evidence {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--muted);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.next-action-foot {
+    margin-top: auto;
+    padding-top: 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+.next-action-primary {
+    background: var(--ink);
+    color: var(--page);
+    border: 1px solid var(--ink);
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 6px 12px;
+    cursor: pointer;
+    text-decoration: none;
+}
+.next-action-primary:disabled { opacity: 0.45; cursor: default; }
+.next-action-ghost {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    color: var(--muted);
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: none;
+}
+.next-action-ghost:hover { color: var(--ink); text-decoration: underline; }
+
+.next-actions-note {
+    margin: 6px 0 0;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    color: var(--muted-2);
+}
+.next-actions-empty {
+    border: 1px dashed var(--line);
+    background: var(--panel);
+    padding: 28px 16px;
+    text-align: center;
+    font-family: Georgia, serif;
+    font-size: 20px;
+    color: var(--muted);
+}
+
+/* ---- improve page lead + registry section ---- */
+.improve-lead {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+.panel .improve-headline,
+.improve-headline {
+    margin: 2px 0 4px;
+    font-family: Georgia, serif;
+    font-weight: 600;
+    font-size: clamp(26px, 2.4vw, 32px);
+    line-height: 1.05;
+    letter-spacing: -0.01em;
+    text-transform: none !important;
+}
+.improve-sub { margin: 0; color: var(--muted); font-size: 13px; }
+.improve-registry-head {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin: 28px 0 12px;
+}
+.improve-registry-head h3 {
+    margin: 0;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+.improve-registry-head .filters {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    margin-left: auto;
+}
+.improve-registry-head label {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    text-transform: uppercase;
+    color: var(--muted);
+}

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2912,3 +2912,159 @@ td.skill-cell .description {
     z-index: 1;
 }
 .improve-history { margin-top: 24px; }
+
+/* ---- proposal drawer (fixed overlay - zero reflow) ---- */
+.proposal-drawer-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 199;
+    background: rgba(20, 22, 21, 0.18);
+    cursor: pointer;
+}
+.proposal-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: clamp(460px, 38vw, 620px);
+    height: 100vh;
+    overflow-y: auto;
+    z-index: 200;
+    background: var(--panel);
+    border-left: 1px solid var(--line);
+    box-shadow: -8px 0 32px rgba(0, 0, 0, 0.12);
+    padding: 20px 28px 40px;
+    animation: drawer-in 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+@keyframes drawer-in {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+}
+.proposal-drawer-close { margin-bottom: 10px; }
+
+/* ---- experiments section (past bets, measured) ---- */
+.experiments-section { margin-top: 28px; }
+.experiments-lead {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 10px;
+}
+.experiments-headline {
+    margin: 0;
+    font-family: Georgia, serif;
+    font-weight: 600;
+    font-size: 20px;
+    letter-spacing: -0.01em;
+    text-transform: none;
+}
+.experiments-count {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    color: var(--muted-2);
+    margin-left: auto;
+}
+.experiments-list { display: flex; flex-direction: column; gap: 8px; }
+.experiment-card {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    width: 100%;
+    text-align: left;
+    border: 1px solid var(--line);
+    border-left: 4px solid var(--card-accent, var(--blue));
+    background: var(--panel);
+    padding: 12px 14px;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+}
+.experiment-card.accent-green  { --card-accent: var(--green); }
+.experiment-card.accent-blue   { --card-accent: var(--blue); }
+.experiment-card.accent-gold   { --card-accent: var(--gold); }
+.experiment-card.accent-rose   { --card-accent: var(--rose); }
+.experiment-card.accent-muted  { --card-accent: var(--muted); }
+.experiment-card.state-win        { background: color-mix(in srgb, var(--green) 4%, var(--panel)); }
+.experiment-card.state-regressed  { background: color-mix(in srgb, var(--rose) 4%, var(--panel)); }
+.experiment-card-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    flex: 1;
+    min-width: 0;
+}
+.experiment-card-eyebrow {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    color: var(--muted);
+}
+.experiment-card-title {
+    font-family: Georgia, serif;
+    font-size: 15px;
+    color: var(--ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.experiment-card-artifact {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 12px;
+    color: var(--muted);
+}
+.experiment-card-trace {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 3px;
+    flex-shrink: 0;
+}
+.experiment-trace {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    width: 64px;
+    height: 28px;
+    position: relative;
+}
+.experiment-trace i {
+    flex: 1;
+    background: color-mix(in srgb, var(--muted) 30%, var(--panel));
+    border-radius: 1px 1px 0 0;
+    position: relative;
+    min-height: 1px;
+}
+.experiment-trace-addr {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: var(--card-accent, var(--blue));
+    opacity: 0.85;
+    border-radius: 1px 1px 0 0;
+}
+.experiment-trace.is-win::after {
+    content: "";
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--green);
+}
+.experiment-trace-caption {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 10px;
+    color: var(--muted);
+    white-space: nowrap;
+}
+.experiments-empty {
+    border: 1px solid var(--line);
+    background: var(--panel);
+    padding: 20px;
+}
+.experiments-empty-head {
+    margin: 0 0 8px;
+    font-family: Georgia, serif;
+    font-size: 18px;
+    color: var(--ink);
+}

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2691,15 +2691,30 @@ td.skill-cell .description {
     line-height: 1.35;
     color: var(--ink);
 }
-.next-action-evidence {
+/* The problem statement - what's actually going wrong. Ink, not muted:
+   it's the reason the card exists. */
+.next-action-problem {
     margin: 0;
     font-size: 13px;
     line-height: 1.5;
-    color: var(--muted);
+    color: var(--ink);
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
+}
+.next-action-fix {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--muted);
+}
+.next-action-fix-label {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    color: var(--card-accent);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
 }
 .next-action-foot {
     margin-top: auto;

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2899,3 +2899,16 @@ td.skill-cell .description {
     color: var(--muted);
 }
 .lifecycle-rail li.current .lifecycle-label { color: var(--ink); font-weight: 600; }
+
+.proposal-case {
+    margin: 16px 0 4px;
+    position: relative;
+    border-left: 4px solid var(--green);
+}
+.proposal-case-close {
+    position: absolute;
+    top: 12px;
+    right: 14px;
+    z-index: 1;
+}
+.improve-history { margin-top: 24px; }

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -2808,3 +2808,94 @@ td.skill-cell .description {
     text-transform: uppercase;
     color: var(--muted);
 }
+
+/* ---- proposal detail narrative (improve) ---- */
+.proposal-head { border-bottom: 1px solid var(--line); padding-bottom: 8px; }
+.proposal-title {
+    margin: 0 0 2px;
+    font-family: Georgia, serif;
+    font-weight: 600;
+    font-size: 20px;
+    line-height: 1.15;
+}
+.proposal-section { margin-top: 14px; }
+.proposal-section-label {
+    display: block;
+    margin: 0 0 4px;
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+}
+.proposal-prose { margin: 0 0 4px; font-size: 13px; line-height: 1.55; }
+.proposal-impact {
+    margin-top: 14px;
+    border: 1px solid var(--line);
+    border-left: 4px solid var(--green);
+    background: color-mix(in srgb, var(--green) 5%, var(--panel));
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.proposal-impact-headline {
+    font-family: Georgia, serif;
+    font-weight: 600;
+    font-size: 24px;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+}
+.proposal-impact-basis {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px;
+    color: var(--muted-2);
+}
+.lifecycle-rail {
+    list-style: none;
+    display: flex;
+    gap: 0;
+    margin: 4px 0 0;
+    padding: 0;
+}
+.lifecycle-rail li {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    position: relative;
+}
+.lifecycle-rail li::before {
+    content: "";
+    position: absolute;
+    top: 5px;
+    left: -50%;
+    width: 100%;
+    height: 2px;
+    background: var(--track);
+}
+.lifecycle-rail li:first-child::before { display: none; }
+.lifecycle-rail li.done::before, .lifecycle-rail li.current::before { background: var(--green); }
+.lifecycle-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--track);
+    border: 2px solid var(--panel);
+    z-index: 1;
+}
+.lifecycle-rail li.done .lifecycle-dot { background: var(--green); }
+.lifecycle-rail li.current .lifecycle-dot {
+    background: var(--panel);
+    border: 3px solid var(--green);
+}
+.lifecycle-label {
+    font-family: ui-monospace, Menlo, monospace;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+}
+.lifecycle-rail li.current .lifecycle-label { color: var(--ink); font-weight: 600; }

--- a/docs/superpowers/plans/2026-06-12-improve-impact-pr5a.md
+++ b/docs/superpowers/plans/2026-06-12-improve-impact-pr5a.md
@@ -1,0 +1,36 @@
+# Improve Impact Engine (PR5a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every proposal can answer "what is this worth": `GET /api/improve/:sig/impact` returns a backtested/estimated `ImpactEstimate`; next-action cards carry a cheap `impact_chip`.
+
+**Spec:** docs/superpowers/specs/2026-06-12-improve-loop-v2-design.md (PR5a slice).
+
+**Hard-won rules:** contract endpoint ⇒ ImproveGroup + CONTRACT_PATTERNS (param route) + capability + mock fixture + viaContract client; param handlers get DECODED params; raw rows ⇒ asJsonValue; TTL caches must not cache failures (use the invalidate-on-cause pattern or plain Map). No node:fs. New CLI? none this PR (no cli-reference change).
+
+## Tasks
+
+### 1. ImpactEstimate types (dashboard-types) - kind/headline/detail/basis/confidence + `NextActionCard.impact_chip?: string|null`.
+
+### 2. impact.ts engine (TDD, mock-db)
+`apps/axctl/src/improve/impact.ts`:
+- `parseBaseline(p)` tolerant JSON parse.
+- Estimators:
+  - routing (form=hook && title is the stable routing title): `fetchDispatchCandidates({sinceDays: 30})` → `~$X/30d redirectable across N dispatches`, confidence "estimated", basis "recomputed from your last 30d of dispatch history".
+  - hook with target_tool: deref-free SQL `SELECT count() FROM tool_call WHERE tool=$tool AND ts>$since GROUP ALL` + same w/ status="error" → "intersects M failures (of N calls) in 30d", confidence "indicative".
+  - guidance: baseline {frequency, evidence} → correction_pressure headline `${frequency}× repeated correction pressure`, detail = evidence.
+  - skill: baseline {tool, frequency} → `${frequency}× recurring friction${tool ? ` on ${tool}` : ""}`.
+  - fallback: frequency kind from proposal.frequency.
+- `estimateImpact(p: ProposalDto)` Effect + per-sig 10-min Map cache (failures not cached).
+
+### 3. Endpoint
+- ImproveGroup: GET `/api/improve/:sig/impact` params {sig: Schema.String}, success Schema.Unknown, errors NotFound/Internal.
+- Handler (contract/improve.ts): find proposal via fetchImproveProposals() by sig → 404 or estimateImpact → asJsonValue.
+- CONTRACT_PATTERNS += GET `/^\/api\/improve\/[^/]+\/impact$/` (BEFORE generic actions? actions pattern is POST-only - no clash). Routing test line.
+- capability `improve-impact`; mock fixture; api client `improveImpact(sig)`.
+
+### 4. Impact chips
+- next-actions.ts: pure `impactChip(p)` - routing title → regex `est \$([\d,.]+)` from hypothesis → `~$X redirectable`; guidance/skill → `${frequency}× recurring`; else null. Set on proposal+verdict cards.
+- Panel renders chip as bold accent span; improve.tsx table shows it next to title. Tests for chip extraction.
+
+### 5. Gate + live smoke (curl impact for a real routing proposal - expect a $ headline) + PR.

--- a/docs/superpowers/specs/2026-06-12-improve-loop-v2-design.md
+++ b/docs/superpowers/specs/2026-06-12-improve-loop-v2-design.md
@@ -1,0 +1,67 @@
+# Improve Loop v2 - projected impact, design spec
+
+**Date:** 2026-06-12 · **Status:** draft for review
+**Driver vision:** "User lands on the dashboard, sees cool shareable data, a button takes them to what's next - and the improve loop makes them go 'oh, ax can help us.' Each item needs reason, how, the plan, and a projected impact backed by the existing data - backtesting: this will save $X, this would have been resolved."
+
+## Problem
+
+The Improve surface (PR1) is functionally complete but reads like an admin table: a proposal is a row with a hypothesis string. Nothing answers *why should I care*, *what happens if I accept*, or *what is this worth* - the three questions that convert a visitor into a believer. The wrapped CTA (PR4) now drives traffic here; the page must close.
+
+## Design
+
+### 1. Projected impact, backtested per proposal form
+
+New module `apps/axctl/src/improve/impact.ts` - `estimateImpact(proposal)` → `ImpactEstimate`:
+
+```ts
+interface ImpactEstimate {
+  kind: "savings_usd" | "addressable_failures" | "correction_pressure" | "frequency";
+  headline: string;   // "~$297/mo redirectable", "intersects 14 of your last 30 failures"
+  detail: string;     // one paragraph: how the number was derived
+  basis: string;      // the data window + method, honestly stated ("backtested over 30d of dispatch history")
+  confidence: "measured" | "estimated" | "indicative";
+}
+```
+
+Per form, using machinery that already exists:
+
+| Form | Method | Source |
+|---|---|---|
+| routing-class hooks (mined) | parse `baseline` JSON (carries est savings + class) or re-run `fetchDispatchCandidates` scoped to the class | `est_savings_usd` (dispatch-analytics.ts) |
+| hook (other) | match historical `tool_call` rows on `target_tool`/event scope: "N matching events in 30d, M failed - a guard here intersects M failures" | `fetchRows` slice of hooks/backtest.ts; full `replayRows` only when an artifact exists (post-accept) |
+| guidance | correction pressure from `baseline` (corrections × sessions) + churn repair LOC in the matching family | derive-retro baseline + session-churn |
+| skill | trigger-pattern frequency: invocations/corrections that match | skill_candidate / baseline |
+| automation | trigger-signal frequency in window | signal queries |
+
+Honesty rule: every estimate carries `basis` and the right `confidence` tier - never a naked number. Post-accept, the checkpoint system's *measured* `opportunities/addressed/ratio` replaces the estimate (the loop literally proves itself).
+
+### 2. API
+
+`GET /api/improve/:sig/impact` (contract endpoint, lazily computed per proposal, TTL-cached via `makeTtlCachedFetch`-style per-sig map). Not bulk-computed on `/api/improve` - keep the list fast.
+
+Next-actions proposal/verdict cards get an `impact_chip?: string` (cheap: parsed from baseline only, no recompute) so the panel shows "~$297/mo" at a glance.
+
+### 3. The proposal page (detail pane → narrative)
+
+Selected proposal renders four sections instead of a `<dl>` dump:
+
+1. **Why this fired** - hypothesis, rewritten visual: frequency badge, origin badge, the trigger pattern.
+2. **Evidence** - baseline refs expanded: linked sessions (`/sessions/<id>`), counts, the raw signal; payload fields formatted per form.
+3. **The plan** - what accept actually does, drawn as a 4-step lifecycle rail: `accept → artifact/task brief → checkpoints at +3/+10/+30 sessions → verdict`. Current stage highlighted for accepted proposals (data already in `experiment` + `latest_checkpoint`).
+4. **Projected impact** - the `ImpactEstimate` as the visual centerpiece (big headline number, basis line under it). For accepted experiments with checkpoints: measured ratio shown next to the original estimate ("estimated $297/mo → measured 4/6 opportunities addressed").
+
+### 4. Surface polish
+
+- Proposals table → card-list left rail (title, form, impact chip, freq) - denser than the table, scannable.
+- Zone order stays: Next Actions → proposals → decision log.
+- Empty/zero states sell the loop ("accept your first proposal; ax measures whether it worked at +3/+10/+30 sessions").
+
+## Out of scope
+
+- True hook replay for *unimplemented* hook proposals (needs a synthetic hook from payload - follow-up; v2 ships the honest "addressable surface" framing instead).
+- Auto-accept/auto-apply. Churn perf (#326) unchanged.
+
+## Delivery
+
+1. **PR5a**: impact.ts + per-form estimators (TDD against fixture baselines) + `/api/improve/:sig/impact` + impact chips in next-actions.
+2. **PR5b**: detail-pane narrative redesign (why/evidence/plan/impact + lifecycle rail) + card-list rail + empty states.

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -816,6 +816,11 @@ export const ImproveGroup = HttpApiGroup.make("improve")
             success: Schema.Unknown,
             error: InternalError,
         }),
+        HttpApiEndpoint.get("improveImpact", "/api/improve/:sig/impact", {
+            params: { sig: Schema.String },
+            success: Schema.Unknown,
+            error: [NotFoundError, InternalError],
+        }),
         HttpApiEndpoint.post("improveAction", "/api/improve/:sig/:action", {
             params: {
                 sig: Schema.String,

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -1207,6 +1207,8 @@ export interface ProposalDto {
     readonly experiment?: ExperimentDto | null;
     /** "mined" (signal-derived) or "agent" (ax improve propose); served coalesced. */
     readonly origin?: string;
+    /** JSON snapshot frozen at creation - evidence/frequency provenance */
+    readonly baseline?: string | null;
     /** server-rendered markdown agent brief */
     readonly brief?: string;
 }
@@ -1237,6 +1239,19 @@ export interface NextActionInlineAction {
     readonly suggested_verdict: string | null;
 }
 
+/** Projected impact for a proposal - estimated/backtested from the user's
+ *  own history. Every number carries its basis and an honesty tier. */
+export interface ImpactEstimate {
+    readonly kind: "savings_usd" | "addressable_failures" | "correction_pressure" | "frequency";
+    /** the centerpiece line, e.g. "~$297 redirectable over 30d" */
+    readonly headline: string;
+    /** one paragraph: how the number was derived */
+    readonly detail: string;
+    /** data window + method, honestly stated */
+    readonly basis: string;
+    readonly confidence: "measured" | "estimated" | "indicative";
+}
+
 export interface NextActionCard {
     /** stable id: `${kind}:${key}` */
     readonly id: string;
@@ -1251,6 +1266,8 @@ export interface NextActionCard {
     /** SPA drill-down path, e.g. /tools */
     readonly link: string | null;
     readonly inline_action: NextActionInlineAction | null;
+    /** cheap value teaser parsed from the proposal baseline/hypothesis */
+    readonly impact_chip?: string | null;
 }
 
 export interface NextActionsSourceNote {

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -1268,6 +1268,8 @@ export interface NextActionCard {
     readonly inline_action: NextActionInlineAction | null;
     /** cheap value teaser parsed from the proposal baseline/hypothesis */
     readonly impact_chip?: string | null;
+    /** the fix mechanism, human-named: "new skill" | "edit CLAUDE.md" | "new hook" | ... */
+    readonly fix_kind?: string | null;
 }
 
 export interface NextActionsSourceNote {

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -1211,6 +1211,10 @@ export interface ProposalDto {
     readonly origin?: string;
     /** JSON snapshot frozen at creation - evidence/frequency provenance */
     readonly baseline?: string | null;
+    /** hypothesis with {{placeholders}} - hydrated server-side from evidence_query */
+    readonly hypothesis_template?: string | null;
+    /** read-only query (SELECT/RETURN) whose first row fills the template */
+    readonly evidence_query?: string | null;
     /** server-rendered markdown agent brief */
     readonly brief?: string;
 }

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -1186,6 +1186,8 @@ export interface ExperimentDto {
     readonly created_at: string;
     readonly scaffolded_at: string | null;
     readonly latest_checkpoint: CheckpointSnapshotDto | null;
+    /** full +3s/+10s/+30s series, observed_at ASC - drives the trace strip */
+    readonly checkpoints?: ReadonlyArray<CheckpointSnapshotDto>;
 }
 
 export interface ProposalDto {

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -1233,7 +1233,8 @@ export type NextActionKind =
     | "tool_failure"
     | "churn"
     | "routing"
-    | "skill_hygiene";
+    | "skill_hygiene"
+    | "housekeeping";
 
 export interface NextActionInlineAction {
     readonly type: "accept" | "reject" | "verdict" | "decide";

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1608,6 +1608,12 @@ DEFINE FIELD status        ON proposal TYPE string DEFAULT 'open';
 DEFINE FIELD origin        ON proposal TYPE string DEFAULT 'mined';
     -- mined (signal-derived) | agent (written via `ax improve propose`)
     -- old rows read NONE - consumers coalesce to 'mined'
+DEFINE FIELD hypothesis_template ON proposal TYPE option<string>;
+    -- hypothesis with {{placeholders}} hydrated at serve time from
+    -- evidence_query's first row - numbers never expire
+DEFINE FIELD evidence_query      ON proposal TYPE option<string>;
+    -- read-only SurrealQL (SELECT/RETURN only, validated at write AND
+    -- serve) producing the row that fills hypothesis_template
 DEFINE FIELD reject_reason ON proposal TYPE option<string>;
 DEFINE FIELD baseline      ON proposal TYPE option<string>;
 DEFINE FIELD created_at    ON proposal TYPE datetime DEFAULT time::now();


### PR DESCRIPTION
PR5a of docs/superpowers/specs/2026-06-12-improve-loop-v2-design.md — the improve loop starts answering "what is this worth".

- **`estimateImpact(proposal)`** (apps/axctl/src/improve/impact.ts): per-form estimators reusing existing analytics — routing proposals recompute live savings via `fetchDispatchCandidates` ("~$608 redirectable over 30d", class breakdown); hook proposals intersect historical tool_call failures ("addressable surface, not a replay — the hook isn't built yet"); guidance/skill quantify frozen-baseline correction/friction pressure. Every estimate carries `basis` + an honesty tier (measured/estimated/indicative).
- **`GET /api/improve/:sig/impact`** — contract endpoint (capability `improve-impact`), per-sig 10-min cache that never stores failures, 404 on unknown sig.
- **Impact chips** — cheap parsed teasers (`~$296.84 redirectable`, `9x recurring`) on next-action cards and the proposals table, no recompute on the list path.

**Verified:** 3707 tests pass, typecheck/build/no-node-fs/cli-reference clean. Live: routing proposal returns a real recomputed estimate, guidance returns correction pressure, unknown sig 404s.

Next: PR5b — proposal detail pane redesign (why → evidence → plan lifecycle rail → impact centerpiece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)