### PR TITLE
feat(site): generative dither art + trace minis on dossier insight cards

### DIFF
--- a/apps/site/app/components/dossier-card-art.test.ts
+++ b/apps/site/app/components/dossier-card-art.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "bun:test";
+import {
+    ART_COLS,
+    ART_ROWS,
+    buildDitherGrid,
+    fnv1a,
+    mulberry32,
+    type Tone,
+} from "./dossier-card-art.tsx";
+
+describe("fnv1a", () => {
+    it("is deterministic and returns a uint32", () => {
+        const a = fnv1a("How deep do you go?");
+        const b = fnv1a("How deep do you go?");
+        expect(a).toBe(b);
+        expect(a).toBeGreaterThanOrEqual(0);
+        expect(a).toBeLessThanOrEqual(0xffffffff);
+        expect(Number.isInteger(a)).toBe(true);
+    });
+
+    it("differs for different inputs", () => {
+        expect(fnv1a("a")).not.toBe(fnv1a("b"));
+        expect(fnv1a("Busiest day?")).not.toBe(fnv1a("How many repos?"));
+    });
+});
+
+describe("mulberry32", () => {
+    it("produces the same stream for the same seed", () => {
+        const r1 = mulberry32(12345);
+        const r2 = mulberry32(12345);
+        const s1 = [r1(), r1(), r1(), r1()];
+        const s2 = [r2(), r2(), r2(), r2()];
+        expect(s1).toEqual(s2);
+    });
+
+    it("stays within [0, 1)", () => {
+        const r = mulberry32(fnv1a("seed"));
+        for (let i = 0; i < 200; i++) {
+            const v = r();
+            expect(v).toBeGreaterThanOrEqual(0);
+            expect(v).toBeLessThan(1);
+        }
+    });
+});
+
+describe("buildDitherGrid", () => {
+    it("has the expected dimensions", () => {
+        const grid = buildDitherGrid("Longest single run?");
+        expect(grid.length).toBe(ART_ROWS);
+        for (const row of grid) expect(row.length).toBe(ART_COLS);
+    });
+
+    it("is fully deterministic for the same seed (hydration-safe)", () => {
+        const a = buildDitherGrid("When are you most alive?");
+        const b = buildDitherGrid("When are you most alive?");
+        expect(a).toEqual(b);
+    });
+
+    it("renders distinct topography for different seeds", () => {
+        const a = buildDitherGrid("How deep do you go?");
+        const b = buildDitherGrid("Tool failure rate?");
+        // grids should not be identical - different seeds, different terrain
+        expect(JSON.stringify(a)).not.toBe(JSON.stringify(b));
+    });
+
+    it("only emits valid tone values 0..3", () => {
+        const grid = buildDitherGrid("How many hands?");
+        const seen = new Set<Tone>();
+        for (const row of grid) {
+            for (const cell of row) {
+                expect([0, 1, 2, 3]).toContain(cell);
+                seen.add(cell);
+            }
+        }
+        // a real terrain field should use more than just bare panel
+        expect(seen.size).toBeGreaterThan(1);
+    });
+
+    it("respects custom dimensions", () => {
+        const grid = buildDitherGrid("x", 10, 4);
+        expect(grid.length).toBe(4);
+        expect(grid[0]!.length).toBe(10);
+    });
+
+    it("biases density toward the bottom (landscape, not flat noise)", () => {
+        // average tone of the bottom third should exceed the top third
+        const grid = buildDitherGrid("How many hands?");
+        const third = Math.floor(ART_ROWS / 3);
+        const avg = (rows: Tone[][]) => {
+            let sum = 0;
+            let n = 0;
+            for (const row of rows) for (const c of row) { sum += c; n++; }
+            return sum / n;
+        };
+        const top = avg(grid.slice(0, third));
+        const bottom = avg(grid.slice(ART_ROWS - third));
+        expect(bottom).toBeGreaterThan(top);
+    });
+});

--- a/apps/site/app/components/dossier-card-art.tsx
+++ b/apps/site/app/components/dossier-card-art.tsx
@@ -1,0 +1,242 @@
+// apps/site/app/components/dossier-card-art.tsx
+//
+// Generative dithered "terrain" artwork for the dossier insight cards.
+// Deterministic: a card's seed (its question text) always renders the same
+// art, so SSR and client hydration agree - no Math.random anywhere.
+//
+// Art recipe:
+//   seed string -> fnv1a hash -> mulberry32 PRNG
+//   -> a low-res value-noise field (COLS x ROWS cells), vertically biased so
+//      it reads as a rolling landscape (denser toward the bottom)
+//   -> each cell's value is thresholded through an ordered Bayer 4x4 matrix,
+//      producing three halftone tone layers: a light-green wash, a mid-green
+//      body, and sparse ink pixels on the ridge.
+//
+// The grid generator (`buildDitherGrid`) is exported pure for unit testing
+// (determinism + dimensions); the React component just paints its cells.
+
+export type CardArtAccent = "green" | "red" | "ink";
+
+export const ART_COLS = 56;
+export const ART_ROWS = 16;
+export const ART_CELL = 6; // px per cell
+
+/** tone level for one cell: 0 = bare panel, 1 = wash, 2 = body, 3 = ink */
+export type Tone = 0 | 1 | 2 | 3;
+
+/* ---------- seeded PRNG (hydration-safe) ---------- */
+
+/** fnv1a 32-bit hash of a string -> uint32 seed */
+export function fnv1a(str: string): number {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < str.length; i++) {
+        h ^= str.charCodeAt(i);
+        // h *= 16777619, kept in uint32 via Math.imul
+        h = Math.imul(h, 0x01000193);
+    }
+    return h >>> 0;
+}
+
+/** mulberry32: tiny, fast, deterministic PRNG returning [0, 1) */
+export function mulberry32(seed: number): () => number {
+    let a = seed >>> 0;
+    return () => {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+/* ---------- ordered Bayer 4x4 dither matrix ---------- */
+
+// classic 4x4 Bayer thresholds, normalized to (0,1)
+const BAYER_4 = [
+    [0, 8, 2, 10],
+    [12, 4, 14, 6],
+    [3, 11, 1, 9],
+    [15, 7, 13, 5],
+].map((row) => row.map((v) => (v + 0.5) / 16));
+
+/* ---------- value-noise terrain field ---------- */
+
+/**
+ * Build the dither grid for a seed. Returns a ROWS-by-COLS matrix of Tone
+ * values. Pure + deterministic - identical seed yields an identical grid.
+ *
+ * The field is a sum of a few sine ridges (frequencies + phases drawn from
+ * the PRNG) plus a low-frequency value-noise wobble, then biased vertically
+ * so density rises toward the bottom - a rolling landscape, not flat static.
+ */
+export function buildDitherGrid(
+    seed: string,
+    cols: number = ART_COLS,
+    rows: number = ART_ROWS,
+): Tone[][] {
+    const rng = mulberry32(fnv1a(seed));
+
+    // a handful of sine ridges define the silhouette of the terrain
+    const ridges = Array.from({ length: 3 }, () => ({
+        freq: 0.6 + rng() * 2.4, // waves across the width
+        phase: rng() * Math.PI * 2,
+        amp: 0.18 + rng() * 0.34,
+    }));
+
+    // a sparse low-freq value-noise lattice for organic wobble
+    const latticeN = 8;
+    const lattice = Array.from({ length: latticeN + 1 }, () => rng());
+    const sampleLattice = (x: number): number => {
+        const t = x * latticeN;
+        const i = Math.floor(t);
+        const f = t - i;
+        const a = lattice[i] ?? 0;
+        const b = lattice[i + 1] ?? a;
+        // smoothstep interpolation
+        const s = f * f * (3 - 2 * f);
+        return a + (b - a) * s;
+    };
+
+    // overall slope direction: occasionally tilt the ridge across the card
+    const slope = (rng() - 0.5) * 0.5;
+    const baseLine = 0.42 + rng() * 0.16; // where the horizon sits (0 top .. 1 bottom)
+
+    const grid: Tone[][] = [];
+    for (let y = 0; y < rows; y++) {
+        const row: Tone[] = [];
+        const yNorm = y / (rows - 1); // 0 top .. 1 bottom
+        for (let x = 0; x < cols; x++) {
+            const xNorm = x / (cols - 1);
+
+            // terrain height (0..1) at this column - higher = taller ridge
+            let ridge = 0;
+            for (const r of ridges) {
+                ridge += Math.sin(xNorm * r.freq * Math.PI * 2 + r.phase) * r.amp;
+            }
+            ridge += (sampleLattice(xNorm) - 0.5) * 0.5;
+            ridge += slope * (xNorm - 0.5);
+            const horizon = baseLine - ridge * 0.5; // 0..1 surface position
+
+            // value: how "solid" this cell is. Below the horizon line fills in,
+            // and density grows toward the bottom of the card (landscape mass).
+            const depth = yNorm - horizon; // >0 means below the surface
+            let value: number;
+            if (depth < 0) {
+                // sky: faint, fades out upward
+                value = 0.08 + (yNorm * 0.12) + depth * 0.6;
+            } else {
+                // ground: ramps up with depth, densest at the base
+                value = 0.35 + depth * 0.9 + yNorm * 0.18;
+            }
+            value = Math.max(0, Math.min(1, value));
+
+            // ordered dither threshold
+            const threshold = BAYER_4[y % 4]![x % 4]!;
+
+            // map dithered value -> three tone bands. Ink is intentionally
+            // sparse - specks on the ridge crest, not solid mass - so the
+            // ink-accent cards read as topography rather than black blocks.
+            let tone: Tone = 0;
+            if (value > threshold) {
+                if (value > 0.82 && value > threshold + 0.34) tone = 3; // sparse ink crest
+                else if (value > 0.45) tone = 2; // mid body
+                else tone = 1; // light wash
+            }
+            row.push(tone);
+        }
+        grid.push(row);
+    }
+    return grid;
+}
+
+/* ---------- colour mapping per accent ---------- */
+
+interface ToneColors {
+    readonly wash: string;
+    readonly body: string;
+    readonly ink: string;
+}
+
+function tonePalette(accent: CardArtAccent): ToneColors {
+    switch (accent) {
+        case "red":
+            return {
+                wash: "color-mix(in srgb, var(--red) 14%, var(--panel))",
+                body: "color-mix(in srgb, var(--red) 42%, var(--panel))",
+                ink: "color-mix(in srgb, var(--red) 78%, var(--ink))",
+            };
+        case "ink":
+            return {
+                wash: "color-mix(in srgb, var(--ink) 9%, var(--panel))",
+                body: "color-mix(in srgb, var(--ink) 32%, var(--panel))",
+                ink: "var(--ink)",
+            };
+        case "green":
+        default:
+            return {
+                wash: "color-mix(in srgb, var(--green) 14%, var(--panel))",
+                body: "color-mix(in srgb, var(--green) 40%, var(--panel))",
+                ink: "color-mix(in srgb, var(--green) 72%, var(--ink))",
+            };
+    }
+}
+
+/* ---------- the component ---------- */
+
+export function CardArt({
+    seed,
+    accent = "green",
+}: {
+    seed: string;
+    accent?: CardArtAccent;
+}) {
+    const grid = buildDitherGrid(seed);
+    const pal = tonePalette(accent);
+    const colorFor = (t: Tone): string | null => {
+        if (t === 1) return pal.wash;
+        if (t === 2) return pal.body;
+        if (t === 3) return pal.ink;
+        return null;
+    };
+
+    const w = ART_COLS * ART_CELL;
+    const h = ART_ROWS * ART_CELL;
+
+    // collect filled cells; group by tone is unnecessary - inline fill is fine
+    const rects: React.ReactNode[] = [];
+    for (let y = 0; y < ART_ROWS; y++) {
+        for (let x = 0; x < ART_COLS; x++) {
+            const fill = colorFor(grid[y]![x]!);
+            if (!fill) continue;
+            rects.push(
+                <rect
+                    key={`${x}-${y}`}
+                    x={x * ART_CELL}
+                    y={y * ART_CELL}
+                    width={ART_CELL}
+                    height={ART_CELL}
+                    fill={fill}
+                />,
+            );
+        }
+    }
+
+    return (
+        <div className="pf-card-art" aria-hidden="true">
+            <svg
+                className="pf-card-art-svg"
+                viewBox={`0 0 ${w} ${h}`}
+                preserveAspectRatio="none"
+                role="presentation"
+            >
+                {rects}
+            </svg>
+            {/* terminal-window wink: three dots top-left */}
+            <span className="pf-card-art-dots">
+                <span />
+                <span />
+                <span />
+            </span>
+        </div>
+    );
+}

--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useEffect, useState, type ReactNode } from "react";
 import { SiteHeader } from "~/components/landing-sections/site-header";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
+import { CardArt, type CardArtAccent } from "~/components/dossier-card-art";
 import {
     fetchProfile,
     type ProfileV1,
@@ -183,9 +184,13 @@ function ProfileDossier({ profile: p }: { profile: ProfileV1 }) {
                     <div className="pf-cards">
                         {buildInsightCards(ins).map((c) => (
                             <div className="pf-card" key={c.q}>
-                                <span className="pf-card-q">{c.q}</span>
-                                <span className="pf-card-a">{c.a}</span>
-                                <span className="pf-card-s">{c.s}</span>
+                                <CardArt seed={c.q} accent={c.accent ?? "green"} />
+                                <div className="pf-card-body">
+                                    <span className="pf-card-q">{c.q}</span>
+                                    <span className="pf-card-a">{c.a}</span>
+                                    {c.viz && <div className="pf-card-viz" aria-hidden="true">{c.viz}</div>}
+                                    <span className="pf-card-s">{c.s}</span>
+                                </div>
                             </div>
                         ))}
                     </div>
@@ -366,65 +371,141 @@ function ActivityTimeline({ daily, busiest }: { daily: readonly ProfileDailyRow[
     );
 }
 
-interface InsightCard { readonly q: string; readonly a: ReactNode; readonly s: string }
+interface InsightCard {
+    readonly q: string;
+    readonly a: ReactNode;
+    readonly s: string;
+    readonly accent?: CardArtAccent;
+    readonly viz?: ReactNode;
+}
+
+/* ----- mini trace-viz: tiny, mono, data-driven ----- */
+
+/** slim horizontal track with a filled segment; for share/ratio cards */
+function VizBar({ value, tone = "green" }: { value: number; tone?: "green" | "red" }) {
+    const pct = clampPct(value * 100);
+    return (
+        <span className="pf-viz pf-viz-bar">
+            <span
+                className={tone === "red" ? "pf-viz-bar-fill pf-viz-bar-fill--red" : "pf-viz-bar-fill"}
+                style={{ width: `${pct}%` }}
+            />
+        </span>
+    );
+}
+
+/**
+ * A row of ticks; caps at `cap`. When the real count exceeds the cap the last
+ * few ticks fade out and a dashed rail follows - signalling "more than fits"
+ * without misrepresenting the magnitude (the caption stays the source of
+ * truth). Small counts render exactly.
+ */
+function VizTicks({ count, cap = 20 }: { count: number; cap?: number }) {
+    const n = Math.max(0, Math.round(count));
+    const shown = Math.min(n, cap);
+    const overflow = n > cap;
+    return (
+        <span className="pf-viz pf-viz-ticks">
+            {Array.from({ length: shown }, (_, i) => {
+                const fade = overflow && i >= shown - 3;
+                return <span className={fade ? "pf-viz-tick pf-viz-tick--fade" : "pf-viz-tick"} key={i} />;
+            })}
+            {overflow && <span className="pf-viz-tick--rail" />}
+        </span>
+    );
+}
+
+/** slim rail with a marker positioned proportionally; for time/position cards */
+function VizRail({ pos }: { pos: number }) {
+    const p = clampPct(pos * 100);
+    return (
+        <span className="pf-viz pf-viz-rail">
+            <span className="pf-viz-rail-track" />
+            <span className="pf-viz-rail-marker" style={{ left: `${p}%` }} />
+        </span>
+    );
+}
 
 function buildInsightCards(ins: ProfileInsights): InsightCard[] {
+    // weekday index of the busiest day (0=Sun..6=Sat) for the rail position
+    const busiestDow = (() => {
+        const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(ins.busiest_day.date);
+        if (!m) return undefined;
+        const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+        return Number.isNaN(d.getTime()) ? undefined : d.getDay();
+    })();
+
     const cards: InsightCard[] = [
         {
             q: "How deep do you go?",
             a: fmtPct(ins.deep_session_share),
             s: "of sessions ran 90+ minutes - deliberate, not drive-by",
+            viz: <VizBar value={ins.deep_session_share} />,
         },
         {
             q: "How many agents at once?",
             a: fmtInt(ins.max_parallel_sessions),
             s: "sessions running in parallel at peak",
+            viz: <VizTicks count={ins.max_parallel_sessions} />,
         },
         {
             q: "Longest single run?",
             a: fmtDuration(ins.longest_session_minutes),
             s: "one session, end to end, without letting go",
+            viz: <VizRail pos={Math.min(1, ins.longest_session_minutes / (24 * 60))} />,
         },
         {
             q: "When are you most alive?",
             a: <>{fmtHour(ins.peak_hour_utc)}<small> UTC</small></>,
             s: "the hour the graph lights up",
+            viz: <VizRail pos={Math.min(1, Math.max(0, ins.peak_hour_utc) / 23)} />,
         },
         {
             q: "Busiest day?",
             a: fmtDay(ins.busiest_day.date),
             s: `${fmtInt(ins.busiest_day.sessions)} sessions in a single day`,
+            accent: "ink",
+            viz: busiestDow !== undefined ? <VizRail pos={busiestDow / 6} /> : undefined,
         },
         {
             q: "How many hands?",
             a: fmtCompact(ins.subagents_spawned),
             s: "subagents dispatched to do the legwork",
+            viz: <VizTicks count={ins.subagents_spawned} />,
         },
         {
             q: "What actually shipped?",
             a: fmtCompact(ins.commits),
             s: "commits landed across the window",
+            accent: "ink",
+            viz: <VizTicks count={ins.commits} />,
         },
         {
             q: "Time in the loop?",
             a: <>{fmtCompact(ins.hours_total)}<small> hrs</small></>,
             s: "of recorded agent time on the clock",
+            accent: "ink",
         },
     ];
 
     // wrapped-style cards - only shown when fields are present
     if (ins.verification_calls !== undefined && ins.tool_calls !== undefined && ins.tool_calls > 0) {
+        const share = ins.verification_calls / ins.tool_calls;
         cards.push({
             q: "How often do you verify?",
-            a: fmtPct(ins.verification_calls / ins.tool_calls),
+            a: fmtPct(share),
             s: `of tool calls are tests, checks, and lints`,
+            viz: <VizBar value={share} />,
         });
     }
     if (ins.tool_failures !== undefined && ins.tool_calls !== undefined && ins.tool_calls > 0) {
+        const share = ins.tool_failures / ins.tool_calls;
         cards.push({
             q: "Tool failure rate?",
-            a: fmtPct(ins.tool_failures / ins.tool_calls),
+            a: fmtPct(share),
             s: `failed calls across ${fmtCompact(ins.tool_calls)} tool runs`,
+            accent: "red",
+            viz: <VizBar value={share} tone="red" />,
         });
     }
     if (ins.distinct_skills !== undefined && ins.distinct_tools !== undefined) {
@@ -432,6 +513,8 @@ function buildInsightCards(ins: ProfileInsights): InsightCard[] {
             q: "How wide is the rig?",
             a: `${fmtInt(ins.distinct_skills)} skills`,
             s: `across ${fmtInt(ins.distinct_tools)} distinct tools`,
+            accent: "ink",
+            viz: <VizTicks count={ins.distinct_skills} />,
         });
     }
     if (ins.repos_count !== undefined) {
@@ -439,6 +522,7 @@ function buildInsightCards(ins: ProfileInsights): InsightCard[] {
             q: "How many repos?",
             a: fmtInt(ins.repos_count),
             s: "repositories touched this window",
+            viz: <VizTicks count={ins.repos_count} />,
         });
     }
 

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -9716,11 +9716,51 @@ footer .right {
 }
 .pf-card {
     background: var(--panel);
-    padding: 18px 20px 20px;
-    min-height: 158px;
+    min-height: 220px;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow: hidden;
+}
+/* generative dither art band - bleeds to the card's top + side edges */
+.pf-card-art {
+    position: relative;
+    height: 64px;
+    flex: none;
+    background: var(--panel);
+    border-bottom: 1px solid color-mix(in srgb, var(--line) 70%, var(--panel));
+    overflow: hidden;
+}
+.pf-card-art-svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    /* crisp pixel cells, no smoothing */
+    shape-rendering: crispEdges;
+}
+.pf-card-art-dots {
+    position: absolute;
+    top: 7px;
+    left: 9px;
+    display: flex;
+    gap: 4px;
+}
+.pf-card-art-dots span {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--muted) 55%, var(--panel));
+    box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--line) 80%, transparent);
+}
+.pf-card-art-dots span:nth-child(2) { background: color-mix(in srgb, var(--muted) 40%, var(--panel)); }
+.pf-card-art-dots span:nth-child(3) { background: color-mix(in srgb, var(--muted) 28%, var(--panel)); }
+
+.pf-card-body {
+    padding: 16px 20px 18px;
     display: flex;
     flex-direction: column;
     gap: 8px;
+    flex: 1;
     min-width: 0;
 }
 .pf-card-q {
@@ -9746,6 +9786,54 @@ footer .right {
     color: var(--muted);
 }
 .pf-card-s { font-size: 12.5px; line-height: 1.45; color: var(--muted); }
+
+/* mini trace-viz - tiny, mono, slots between answer and support line */
+.pf-card-viz { height: 16px; display: flex; align-items: center; }
+.pf-viz { display: block; width: 100%; }
+.pf-viz-bar {
+    position: relative;
+    height: 6px;
+    background: color-mix(in srgb, var(--line) 55%, var(--panel));
+}
+.pf-viz-bar-fill { display: block; height: 100%; background: var(--green); }
+.pf-viz-bar-fill--red { background: var(--red); }
+.pf-viz-ticks { display: flex; gap: 3px; align-items: flex-end; height: 12px; flex-wrap: nowrap; }
+.pf-viz-tick {
+    width: 4px;
+    height: 12px;
+    background: color-mix(in srgb, var(--green) 62%, var(--panel));
+    flex: none;
+}
+.pf-viz-tick--fade { opacity: 0.5; }
+.pf-viz-tick--rail {
+    flex: 1;
+    min-width: 12px;
+    height: 12px;
+    margin-left: 3px;
+    align-self: flex-end;
+    margin-bottom: 5px;
+    border-top: 1px dashed color-mix(in srgb, var(--green) 55%, var(--panel));
+}
+.pf-viz-rail { position: relative; height: 12px; }
+.pf-viz-rail-track {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 2px;
+    transform: translateY(-50%);
+    background: color-mix(in srgb, var(--line) 60%, var(--panel));
+}
+.pf-viz-rail-marker {
+    position: absolute;
+    top: 50%;
+    width: 7px;
+    height: 7px;
+    transform: translate(-50%, -50%);
+    background: var(--green);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--green) 22%, transparent);
+}
+
 @media (max-width: 980px) { .pf-cards { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 @media (max-width: 460px) {
     .pf-cards { grid-template-columns: minmax(0, 1fr); }


### PR DESCRIPTION
## Summary
The "trace-like cards" treatment for the profile dossier:
- **`<CardArt>`** — deterministic generative dither art per card (fnv1a→mulberry32 seeded; vertically-biased value-noise terrain through an ordered Bayer 4×4; three tone bands in the ax greens/ink, red accent for the failure card; terminal window dots). Same seed renders identically — SSR/hydration safe; grid generator exported pure with 10 determinism tests.
- **Trace minis** — share tracks (deep-work / verification / failure-rate), tick rows with honest dashed-overflow for counts (parallel / subagents / commits / repos), position rails for time cards (longest run vs 24h, peak hour on 0-23, busiest weekday).
- Art band bleeds to card edges; grid stays 4/2/1-col responsive.

## Test Plan
- [x] 42 site tests green (incl. 10 new determinism tests); build + typecheck clean for new files
- [x] Visual iteration on live data via dev-server screenshots (ink-crest density + overflow-tick honesty tuned after first look)
- [ ] Post-merge prod check of /u/necmttn

🤖 Generated with [Claude Code](https://claude.com/claude-code)