### PR TITLE
feat(site): agent-sign radar - six-axis spider chart, compare overlay, raw-values table

### DIFF
--- a/apps/site/app/components/radar-chart.tsx
+++ b/apps/site/app/components/radar-chart.tsx
@@ -1,0 +1,138 @@
+// apps/site/app/components/radar-chart.tsx
+//
+// Dependency-free SVG spider/radar chart for the agent-sign dossier section.
+// Renders 1 or 2 series over the six fixed RADAR axes. Pure geometry, no JS
+// interactivity beyond <title> tooltips on the vertices (so SSR == client).
+//
+// Untrusted strings (login) render as text only - never as markup.
+
+import { RADAR_AXES_META, type RadarAxes } from "~/lib/radar";
+
+export interface RadarSeries {
+    readonly login: string;
+    readonly axes: RadarAxes;
+    /** stroke/fill base colour, e.g. var(--green) or #2567a8 */
+    readonly color: string;
+}
+
+const RINGS = [25, 50, 75, 100] as const;
+const N = RADAR_AXES_META.length; // 6
+
+/** angle (radians) for axis i; first spoke points straight up, clockwise. */
+function angleFor(i: number): number {
+    return -Math.PI / 2 + (i / N) * Math.PI * 2;
+}
+
+/** map a 0..100 value on axis i to an [x,y] point inside the chart box. */
+function point(cx: number, cy: number, radius: number, i: number, value: number): readonly [number, number] {
+    const r = (Math.max(0, Math.min(100, value)) / 100) * radius;
+    const a = angleFor(i);
+    return [cx + Math.cos(a) * r, cy + Math.sin(a) * r];
+}
+
+const fmt = (n: number): string => (Math.round(n * 10) / 10).toString();
+
+export function RadarChart({
+    series,
+    size = 420,
+}: {
+    series: readonly RadarSeries[];
+    size?: number;
+}) {
+    const pad = 58; // room for spoke labels outside the rings
+    const cx = size / 2;
+    const cy = size / 2;
+    const radius = size / 2 - pad;
+
+    // ring polygons (hexagons matching the spoke count - reads cleaner than
+    // circles for a 6-axis chart and lines up with the spokes)
+    const ringPolys = RINGS.map((pct) => {
+        const r = (pct / 100) * radius;
+        const pts = Array.from({ length: N }, (_, i) => {
+            const a = angleFor(i);
+            return `${(cx + Math.cos(a) * r).toFixed(2)},${(cy + Math.sin(a) * r).toFixed(2)}`;
+        }).join(" ");
+        return { pct, pts };
+    });
+
+    // spoke endpoints + label anchors
+    const spokes = RADAR_AXES_META.map((meta, i) => {
+        const a = angleFor(i);
+        const ex = cx + Math.cos(a) * radius;
+        const ey = cy + Math.sin(a) * radius;
+        const lx = cx + Math.cos(a) * (radius + 22);
+        const ly = cy + Math.sin(a) * (radius + 22);
+        // horizontal anchoring by quadrant so labels don't overlap the rings
+        const cos = Math.cos(a);
+        const anchor: "middle" | "start" | "end" =
+            Math.abs(cos) < 0.25 ? "middle" : cos > 0 ? "start" : "end";
+        // nudge top/bottom labels vertically off the spoke tip
+        const sin = Math.sin(a);
+        const dy = Math.abs(sin) < 0.25 ? 0 : sin > 0 ? 11 : -4;
+        return { meta, ex, ey, lx, ly, anchor, dy };
+    });
+
+    return (
+        <div className="pf-radar-wrap">
+            <svg
+                className="pf-radar"
+                viewBox={`0 0 ${size} ${size}`}
+                role="img"
+                aria-label={`radar chart comparing ${series.map((s) => `@${s.login}`).join(" and ")} across six axes`}
+            >
+                {/* rings */}
+                {ringPolys.map((r) => (
+                    <polygon
+                        key={r.pct}
+                        className={r.pct === 100 ? "pf-radar-ring pf-radar-ring--outer" : "pf-radar-ring"}
+                        points={r.pts}
+                    />
+                ))}
+
+                {/* spokes + labels */}
+                {spokes.map((s) => (
+                    <g key={s.meta.key}>
+                        <line className="pf-radar-spoke" x1={cx} y1={cy} x2={s.ex} y2={s.ey} />
+                        <text
+                            className="pf-radar-axis-label"
+                            x={s.lx}
+                            y={s.ly + s.dy}
+                            textAnchor={s.anchor}
+                        >
+                            {s.meta.label}
+                        </text>
+                    </g>
+                ))}
+
+                {/* series polygons (drawn back-to-front: first series on top) */}
+                {[...series].reverse().map((serie) => {
+                    const pts = RADAR_AXES_META.map((meta, i) =>
+                        point(cx, cy, radius, i, serie.axes.scores[meta.key]),
+                    );
+                    const poly = pts.map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`).join(" ");
+                    return (
+                        <g key={serie.login} style={{ color: serie.color }}>
+                            <polygon className="pf-radar-area" points={poly} />
+                            {pts.map(([x, y], i) => (
+                                <circle key={RADAR_AXES_META[i]!.key} className="pf-radar-dot" cx={x} cy={y} r={3.2}>
+                                    <title>{`@${serie.login} · ${RADAR_AXES_META[i]!.label}: ${fmt(serie.axes.scores[RADAR_AXES_META[i]!.key])}`}</title>
+                                </circle>
+                            ))}
+                        </g>
+                    );
+                })}
+            </svg>
+
+            {series.length > 1 && (
+                <div className="pf-radar-legend">
+                    {series.map((s) => (
+                        <span className="pf-radar-chip" key={s.login}>
+                            <span className="pf-radar-chip-swatch" style={{ background: s.color }} aria-hidden="true" />
+                            @{s.login}
+                        </span>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/site/app/lib/radar.test.ts
+++ b/apps/site/app/lib/radar.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "bun:test";
+import {
+    archetypeFor,
+    dominantPair,
+    profileToAxes,
+    RADAR_AXIS_KEYS,
+    type RadarAxes,
+    type RadarAxisKey,
+} from "./radar";
+import type { ProfileInsights, ProfileV1 } from "./community";
+
+/* ---------- fixtures ---------- */
+
+const baseInsights = (over: Partial<ProfileInsights> = {}): ProfileInsights => ({
+    hours_total: 0,
+    longest_session_minutes: 0,
+    deep_session_share: 0,
+    peak_hour_utc: 0,
+    busiest_day: { date: "2026-01-01", sessions: 0 },
+    max_parallel_sessions: 0,
+    subagents_spawned: 0,
+    commits: 0,
+    tools_top: [],
+    ...over,
+});
+
+const profile = (over: {
+    tokensTotal?: number;
+    sessions?: number;
+    insights?: ProfileInsights | undefined;
+} = {}): ProfileV1 => ({
+    v: 1,
+    github: "tester",
+    generated_at: "2026-01-01T00:00:00Z",
+    window_days: 30,
+    stats: {
+        sessions: over.sessions ?? 100,
+        active_days: 20,
+        streak_days: 5,
+        tokens: { prompt: 0, completion: 0, total: over.tokensTotal ?? 0 },
+        models: [],
+        harnesses: [],
+    },
+    rig: { skills: [], hooks: [], routing_table: false },
+    insights: over.insights,
+});
+
+/* ---------- axis anchor math ---------- */
+
+describe("profileToAxes - SCALE log anchors", () => {
+    const scaleOf = (total: number) => profileToAxes(profile({ tokensTotal: total, insights: baseInsights() })).scores.SCALE;
+
+    it("hits the documented anchor points", () => {
+        expect(scaleOf(1e6)).toBeCloseTo(10, 1);
+        expect(scaleOf(1e8)).toBeCloseTo(40, 1);
+        expect(scaleOf(1e9)).toBeCloseTo(60, 1);
+        expect(scaleOf(1e10)).toBeCloseTo(85, 1);
+        expect(scaleOf(1e11)).toBeCloseTo(100, 1);
+    });
+
+    it("interpolates between anchors in log space (geometric midpoint sits between outputs)", () => {
+        // sqrt(1e8 * 1e9) = ~3.16e8 -> halfway between 40 and 60 in log space
+        const mid = scaleOf(Math.sqrt(1e8 * 1e9));
+        expect(mid).toBeGreaterThan(40);
+        expect(mid).toBeLessThan(60);
+        expect(mid).toBeCloseTo(50, 0);
+    });
+
+    it("caps above the top anchor and floors at 0 for non-positive", () => {
+        expect(scaleOf(1e15)).toBe(100);
+        expect(scaleOf(0)).toBe(0);
+        expect(scaleOf(-5)).toBe(0);
+    });
+});
+
+describe("profileToAxes - ENDURANCE log anchors", () => {
+    const endOf = (hours: number) => profileToAxes(profile({ insights: baseInsights({ hours_total: hours }) })).scores.ENDURANCE;
+    it("hits anchors", () => {
+        expect(endOf(10)).toBeCloseTo(20, 1);
+        expect(endOf(100)).toBeCloseTo(50, 1);
+        expect(endOf(1000)).toBeCloseTo(80, 1);
+        expect(endOf(3000)).toBeCloseTo(100, 1);
+    });
+    it("caps and floors", () => {
+        expect(endOf(99999)).toBe(100);
+        expect(endOf(0)).toBe(0);
+    });
+});
+
+describe("profileToAxes - linear axes + caps", () => {
+    it("DEPTH maps 0->0, 60%->100, caps above", () => {
+        expect(profileToAxes(profile({ insights: baseInsights({ deep_session_share: 0 }) })).scores.DEPTH).toBe(0);
+        expect(profileToAxes(profile({ insights: baseInsights({ deep_session_share: 0.3 }) })).scores.DEPTH).toBeCloseTo(50, 1);
+        expect(profileToAxes(profile({ insights: baseInsights({ deep_session_share: 0.6 }) })).scores.DEPTH).toBe(100);
+        expect(profileToAxes(profile({ insights: baseInsights({ deep_session_share: 0.9 }) })).scores.DEPTH).toBe(100);
+    });
+
+    it("RIGOR maps verification share 0->0, 15%->100, caps", () => {
+        const r = (verification: number, calls: number) =>
+            profileToAxes(profile({ insights: baseInsights({ verification_calls: verification, tool_calls: calls }) })).scores.RIGOR;
+        expect(r(0, 1000)).toBe(0);
+        expect(r(75, 1000)).toBeCloseTo(50, 1); // 7.5% -> 50
+        expect(r(150, 1000)).toBe(100); // 15% -> 100
+        expect(r(500, 1000)).toBe(100); // 50% -> capped
+    });
+
+    it("DELEGATION maps subagents/session 0->0, 2.0->100, caps", () => {
+        const d = (subagents: number, sessions: number) =>
+            profileToAxes(profile({ sessions, insights: baseInsights({ subagents_spawned: subagents }) })).scores.DELEGATION;
+        expect(d(0, 100)).toBe(0);
+        expect(d(100, 100)).toBeCloseTo(50, 1); // 1.0/session -> 50
+        expect(d(200, 100)).toBe(100); // 2.0/session -> 100
+        expect(d(1000, 100)).toBe(100); // capped
+    });
+
+    it("BREADTH blends skills*0.8 + repos*2, caps at 100", () => {
+        const b = (skills: number | undefined, repos: number | undefined) =>
+            profileToAxes(profile({ insights: baseInsights({ distinct_skills: skills, repos_count: repos }) })).scores.BREADTH;
+        expect(b(50, 10)).toBeCloseTo(60, 1); // 50*0.8 + 10*2 = 60
+        expect(b(125, 0)).toBe(100); // 100
+        expect(b(200, 50)).toBe(100); // capped
+        expect(b(10, undefined)).toBeCloseTo(8, 1); // repos missing -> treated as 0
+    });
+});
+
+/* ---------- partial handling ---------- */
+
+describe("profileToAxes - partial / missing", () => {
+    it("flags partial and lists all insight-derived axes when insights absent", () => {
+        const a = profileToAxes(profile({ tokensTotal: 1e9, insights: undefined }));
+        expect(a.partial).toBe(true);
+        expect(a.scores.SCALE).toBeCloseTo(60, 1); // SCALE still measurable from tokens
+        expect(a.scores.DEPTH).toBe(0);
+        expect(new Set(a.missing)).toEqual(new Set<RadarAxisKey>(["DEPTH", "RIGOR", "DELEGATION", "BREADTH", "ENDURANCE"]));
+    });
+
+    it("flags RIGOR missing when tool_calls absent but other insights present", () => {
+        const a = profileToAxes(profile({ insights: baseInsights({ hours_total: 100 }) }));
+        expect(a.partial).toBe(true);
+        expect(a.missing).toContain("RIGOR");
+        expect(a.missing).toContain("BREADTH");
+        expect(a.missing).not.toContain("DEPTH");
+        expect(a.missing).not.toContain("ENDURANCE");
+    });
+
+    it("a full insights profile is not partial", () => {
+        const a = profileToAxes(profile({
+            tokensTotal: 1e9,
+            insights: baseInsights({
+                hours_total: 100,
+                deep_session_share: 0.3,
+                subagents_spawned: 50,
+                verification_calls: 75,
+                tool_calls: 1000,
+                distinct_skills: 50,
+                repos_count: 10,
+            }),
+        }));
+        expect(a.partial).toBe(false);
+        expect(a.missing).toEqual([]);
+    });
+});
+
+/* ---------- determinism ---------- */
+
+describe("determinism", () => {
+    it("identical profiles yield identical axes + archetype", () => {
+        const p = profile({
+            tokensTotal: 5e9,
+            insights: baseInsights({ hours_total: 400, deep_session_share: 0.4, subagents_spawned: 120, verification_calls: 200, tool_calls: 1500, distinct_skills: 80, repos_count: 20 }),
+        });
+        const a1 = profileToAxes(p);
+        const a2 = profileToAxes(p);
+        expect(a1).toEqual(a2);
+        expect(archetypeFor(a1, p)).toEqual(archetypeFor(a2, p));
+    });
+});
+
+/* ---------- archetype matrix coverage ---------- */
+
+// build an axes object that ranks two chosen axes highest, deterministically
+function axesWithTop(top: RadarAxisKey, second: RadarAxisKey): RadarAxes {
+    const scores: Record<RadarAxisKey, number> = {
+        DEPTH: 5, SCALE: 5, RIGOR: 5, DELEGATION: 5, BREADTH: 5, ENDURANCE: 5,
+    };
+    scores[top] = 90;
+    scores[second] = 80;
+    return { scores, partial: false, missing: [] };
+}
+
+describe("archetypeFor - matrix coverage", () => {
+    it("every unordered axis pair maps to a named sign", () => {
+        const signs = new Set<string>();
+        for (let i = 0; i < RADAR_AXIS_KEYS.length; i++) {
+            for (let j = i + 1; j < RADAR_AXIS_KEYS.length; j++) {
+                const a = RADAR_AXIS_KEYS[i]!;
+                const b = RADAR_AXIS_KEYS[j]!;
+                const arch = archetypeFor(axesWithTop(a, b));
+                expect(arch.sign).toMatch(/^The /);
+                expect(arch.sign).not.toBe("The Unmeasured");
+                expect(arch.symbol.length).toBeGreaterThan(0);
+                signs.add(arch.sign);
+            }
+        }
+        // 15 pairs; signs may repeat by design but most are distinct
+        expect(signs.size).toBeGreaterThanOrEqual(10);
+    });
+
+    it("pair is order-independent (DEPTH+RIGOR == RIGOR+DEPTH)", () => {
+        expect(archetypeFor(axesWithTop("DEPTH", "RIGOR")).sign)
+            .toBe(archetypeFor(axesWithTop("RIGOR", "DEPTH")).sign);
+    });
+
+    it("known mappings hold", () => {
+        expect(archetypeFor(axesWithTop("DEPTH", "RIGOR")).sign).toBe("The Auditor");
+        expect(archetypeFor(axesWithTop("SCALE", "DELEGATION")).sign).toBe("The Fleet Commander");
+        expect(archetypeFor(axesWithTop("SCALE", "BREADTH")).sign).toBe("The Polyglot");
+        expect(archetypeFor(axesWithTop("DEPTH", "ENDURANCE")).sign).toBe("The Deep Worker");
+        expect(archetypeFor(axesWithTop("RIGOR", "DELEGATION")).sign).toBe("The Overseer");
+    });
+
+    it("all-zero axes yield the void sign", () => {
+        const zero: RadarAxes = {
+            scores: { DEPTH: 0, SCALE: 0, RIGOR: 0, DELEGATION: 0, BREADTH: 0, ENDURANCE: 0 },
+            partial: true,
+            missing: [...RADAR_AXIS_KEYS],
+        };
+        expect(archetypeFor(zero).sign).toBe("The Unmeasured");
+    });
+
+    it("ties break deterministically by axis order", () => {
+        // all equal -> top two are DEPTH, SCALE (first in RADAR_AXIS_KEYS)
+        const flat: RadarAxes = {
+            scores: { DEPTH: 50, SCALE: 50, RIGOR: 50, DELEGATION: 50, BREADTH: 50, ENDURANCE: 50 },
+            partial: false,
+            missing: [],
+        };
+        expect(dominantPair(flat)).toEqual(["DEPTH", "SCALE"]);
+        expect(archetypeFor(flat).sign).toBe("The Excavator");
+    });
+
+    it("blurb is grounded in real numbers when a profile is supplied", () => {
+        const p = profile({
+            tokensTotal: 5e9,
+            insights: baseInsights({ deep_session_share: 0.42, verification_calls: 3400, tool_calls: 10000, hours_total: 400 }),
+        });
+        const a = profileToAxes(p);
+        const arch = archetypeFor(a, p);
+        // a real number landed in the sentence (compact-formatted, e.g. "3.4K")
+        expect(arch.blurb).toMatch(/[\d.]+[KMB]?/);
+        expect(arch.blurb).toContain("verification calls");
+        expect(arch.blurb.length).toBeGreaterThan(20);
+    });
+});

--- a/apps/site/app/lib/radar.test.ts
+++ b/apps/site/app/lib/radar.test.ts
@@ -161,6 +161,74 @@ describe("profileToAxes - partial / missing", () => {
     });
 });
 
+/* ---------- raw values (reference-table labels) ---------- */
+
+describe("profileToAxes - raws", () => {
+    it("formats the un-normalised number behind every axis", () => {
+        const a = profileToAxes(profile({
+            tokensTotal: 19.6e9,
+            sessions: 100,
+            insights: baseInsights({
+                hours_total: 2300,
+                deep_session_share: 0.077,
+                subagents_spawned: 87,
+                verification_calls: 29,
+                tool_calls: 1000,
+                distinct_skills: 84,
+                repos_count: 12,
+            }),
+        }));
+        expect(a.raws.DEPTH.label).toBe("7.7% deep sessions");
+        expect(a.raws.SCALE.label).toBe("19.6B tokens");
+        expect(a.raws.RIGOR.label).toBe("2.9% verification share");
+        expect(a.raws.DELEGATION.label).toBe("0.87 subagents/session");
+        expect(a.raws.BREADTH.label).toBe("84 skills · 12 repos");
+        expect(a.raws.ENDURANCE.label).toBe("2.3K hrs");
+    });
+
+    it("carries comparable numerics matching the axis direction", () => {
+        const a = profileToAxes(profile({
+            tokensTotal: 1e9,
+            sessions: 50,
+            insights: baseInsights({
+                hours_total: 100,
+                deep_session_share: 0.3,
+                subagents_spawned: 25,
+                verification_calls: 75,
+                tool_calls: 1000,
+                distinct_skills: 50,
+                repos_count: 10,
+            }),
+        }));
+        expect(a.raws.DEPTH.value).toBeCloseTo(0.3, 5);
+        expect(a.raws.SCALE.value).toBe(1e9);
+        expect(a.raws.RIGOR.value).toBeCloseTo(0.075, 5);
+        expect(a.raws.DELEGATION.value).toBeCloseTo(0.5, 5);
+        expect(a.raws.BREADTH.value).toBeCloseTo(50 * 0.8 + 10 * 2, 5); // uncapped blend
+        expect(a.raws.ENDURANCE.value).toBe(100);
+    });
+
+    it("missing inputs yield a null value and an em-dash label", () => {
+        const a = profileToAxes(profile({ tokensTotal: 1e9, insights: undefined }));
+        expect(a.raws.DEPTH).toEqual({ label: "-", value: null });
+        expect(a.raws.RIGOR).toEqual({ label: "-", value: null });
+        expect(a.raws.DELEGATION).toEqual({ label: "-", value: null });
+        expect(a.raws.BREADTH).toEqual({ label: "-", value: null });
+        expect(a.raws.ENDURANCE).toEqual({ label: "-", value: null });
+        // SCALE is always measurable
+        expect(a.raws.SCALE.value).toBe(1e9);
+        expect(a.raws.SCALE.label).toBe("1B tokens");
+    });
+
+    it("every axis key has a raw entry", () => {
+        const a = profileToAxes(profile({ insights: baseInsights() }));
+        for (const k of RADAR_AXIS_KEYS) {
+            expect(a.raws[k]).toBeDefined();
+            expect(typeof a.raws[k].label).toBe("string");
+        }
+    });
+});
+
 /* ---------- determinism ---------- */
 
 describe("determinism", () => {
@@ -178,6 +246,16 @@ describe("determinism", () => {
 
 /* ---------- archetype matrix coverage ---------- */
 
+// hand-built axes need a raws record too; tests above cover real derivation
+const emptyRaws = (): Record<RadarAxisKey, { label: string; value: number | null }> => ({
+    DEPTH: { label: "-", value: null },
+    SCALE: { label: "-", value: null },
+    RIGOR: { label: "-", value: null },
+    DELEGATION: { label: "-", value: null },
+    BREADTH: { label: "-", value: null },
+    ENDURANCE: { label: "-", value: null },
+});
+
 // build an axes object that ranks two chosen axes highest, deterministically
 function axesWithTop(top: RadarAxisKey, second: RadarAxisKey): RadarAxes {
     const scores: Record<RadarAxisKey, number> = {
@@ -185,7 +263,7 @@ function axesWithTop(top: RadarAxisKey, second: RadarAxisKey): RadarAxes {
     };
     scores[top] = 90;
     scores[second] = 80;
-    return { scores, partial: false, missing: [] };
+    return { scores, raws: emptyRaws(), partial: false, missing: [] };
 }
 
 describe("archetypeFor - matrix coverage", () => {
@@ -222,6 +300,7 @@ describe("archetypeFor - matrix coverage", () => {
     it("all-zero axes yield the void sign", () => {
         const zero: RadarAxes = {
             scores: { DEPTH: 0, SCALE: 0, RIGOR: 0, DELEGATION: 0, BREADTH: 0, ENDURANCE: 0 },
+            raws: emptyRaws(),
             partial: true,
             missing: [...RADAR_AXIS_KEYS],
         };
@@ -232,6 +311,7 @@ describe("archetypeFor - matrix coverage", () => {
         // all equal -> top two are DEPTH, SCALE (first in RADAR_AXIS_KEYS)
         const flat: RadarAxes = {
             scores: { DEPTH: 50, SCALE: 50, RIGOR: 50, DELEGATION: 50, BREADTH: 50, ENDURANCE: 50 },
+            raws: emptyRaws(),
             partial: false,
             missing: [],
         };

--- a/apps/site/app/lib/radar.ts
+++ b/apps/site/app/lib/radar.ts
@@ -25,9 +25,22 @@ export const RADAR_AXIS_KEYS = [
 
 export type RadarAxisKey = (typeof RADAR_AXIS_KEYS)[number];
 
+/**
+ * The un-normalised number behind one axis, pre-formatted for the "raw
+ * values" reference table so the UI never re-derives. `value` is the
+ * comparable numeric used to pick a leader in compare mode (same direction
+ * as the axis: bigger = leads); null when the input was missing.
+ */
+export interface AxisRaw {
+    readonly label: string;
+    readonly value: number | null;
+}
+
 export interface RadarAxes {
     /** each value is 0..100, comparable across users */
     readonly scores: Readonly<Record<RadarAxisKey, number>>;
+    /** un-normalised raw value + display label per axis */
+    readonly raws: Readonly<Record<RadarAxisKey, AxisRaw>>;
     /**
      * true when one or more axes had to default to 0 because the profile
      * (an older ax version) lacked the optional input. The UI captions this so
@@ -125,11 +138,20 @@ export function profileToAxes(p: ProfileV1): RadarAxes {
     const ins = p.insights;
     const sessions = p.stats.sessions;
     const missing: RadarAxisKey[] = [];
+    const MISSING_RAW: AxisRaw = { label: "-", value: null };
 
     // DEPTH - present whenever insights exist
     let depth = 0;
-    if (ins) depth = score((ins.deep_session_share / 0.6) * 100);
-    else missing.push("DEPTH");
+    let depthRaw = MISSING_RAW;
+    if (ins) {
+        depth = score((ins.deep_session_share / 0.6) * 100);
+        depthRaw = {
+            label: `${pct1(ins.deep_session_share * 100)} deep sessions`,
+            value: ins.deep_session_share,
+        };
+    } else {
+        missing.push("DEPTH");
+    }
 
     // SCALE - tokens.total is always validated/present
     const scale = logAnchored(p.stats.tokens.total, [
@@ -139,35 +161,55 @@ export function profileToAxes(p: ProfileV1): RadarAxes {
         [1e10, 85],
         [1e11, 100],
     ]);
+    const scaleRaw: AxisRaw = {
+        label: `${fmtCompact.format(p.stats.tokens.total)} tokens`,
+        value: p.stats.tokens.total,
+    };
 
     // RIGOR - needs verification_calls + tool_calls
     let rigor = 0;
+    let rigorRaw = MISSING_RAW;
     if (ins && ins.verification_calls !== undefined && ins.tool_calls !== undefined && ins.tool_calls > 0) {
-        rigor = score((ins.verification_calls / ins.tool_calls / 0.15) * 100);
+        const share = ins.verification_calls / ins.tool_calls;
+        rigor = score((share / 0.15) * 100);
+        rigorRaw = { label: `${pct1(share * 100)} verification share`, value: share };
     } else {
         missing.push("RIGOR");
     }
 
     // DELEGATION - subagents per session
     let delegation = 0;
+    let delegationRaw = MISSING_RAW;
     if (ins && sessions > 0) {
-        delegation = score((ins.subagents_spawned / sessions / 2.0) * 100);
+        const ratio = ins.subagents_spawned / sessions;
+        delegation = score((ratio / 2.0) * 100);
+        delegationRaw = {
+            label: `${(Math.round(ratio * 100) / 100).toFixed(2)} subagents/session`,
+            value: ratio,
+        };
     } else {
         missing.push("DELEGATION");
     }
 
     // BREADTH - distinct_skills + repos_count blend
     let breadth = 0;
+    let breadthRaw = MISSING_RAW;
     if (ins && (ins.distinct_skills !== undefined || ins.repos_count !== undefined)) {
         const skills = ins.distinct_skills ?? 0;
         const repos = ins.repos_count ?? 0;
         breadth = score(skills * 0.8 + repos * 2);
+        breadthRaw = {
+            label: `${fmtCompact.format(skills)} skills · ${fmtCompact.format(repos)} repos`,
+            // the uncapped blend, so a leader is picked the same way the axis ranks
+            value: skills * 0.8 + repos * 2,
+        };
     } else {
         missing.push("BREADTH");
     }
 
     // ENDURANCE - hours_total log-anchored
     let endurance = 0;
+    let enduranceRaw = MISSING_RAW;
     if (ins) {
         endurance = logAnchored(ins.hours_total, [
             [10, 20],
@@ -175,6 +217,7 @@ export function profileToAxes(p: ProfileV1): RadarAxes {
             [1000, 80],
             [3000, 100],
         ]);
+        enduranceRaw = { label: `${fmtCompact.format(ins.hours_total)} hrs`, value: ins.hours_total };
     } else {
         missing.push("ENDURANCE");
     }
@@ -187,6 +230,14 @@ export function profileToAxes(p: ProfileV1): RadarAxes {
             DELEGATION: delegation,
             BREADTH: breadth,
             ENDURANCE: endurance,
+        },
+        raws: {
+            DEPTH: depthRaw,
+            SCALE: scaleRaw,
+            RIGOR: rigorRaw,
+            DELEGATION: delegationRaw,
+            BREADTH: breadthRaw,
+            ENDURANCE: enduranceRaw,
         },
         partial: missing.length > 0,
         missing,

--- a/apps/site/app/lib/radar.ts
+++ b/apps/site/app/lib/radar.ts
@@ -1,0 +1,311 @@
+/**
+ * radar.ts - pure, deterministic derivation of a six-axis "agent shape" from a
+ * validated ProfileV1, plus the astrology-flavored archetype ("agent sign")
+ * that the dominant two axes map onto.
+ *
+ * Everything here is a pure function of the profile numbers - no Date.now, no
+ * Math.random, no I/O - so the same profile always yields the same radar and
+ * the same sign (important for SSR/hydration agreement and for tests).
+ *
+ * The site does NOT depend on effect/Schema and must not import across apps;
+ * the archetype voice is modelled on apps/axctl/src/dashboard/wrapped.ts but
+ * reimplemented here as small pure helpers.
+ */
+
+import type { ProfileV1 } from "./community";
+
+export const RADAR_AXIS_KEYS = [
+    "DEPTH",
+    "SCALE",
+    "RIGOR",
+    "DELEGATION",
+    "BREADTH",
+    "ENDURANCE",
+] as const;
+
+export type RadarAxisKey = (typeof RADAR_AXIS_KEYS)[number];
+
+export interface RadarAxes {
+    /** each value is 0..100, comparable across users */
+    readonly scores: Readonly<Record<RadarAxisKey, number>>;
+    /**
+     * true when one or more axes had to default to 0 because the profile
+     * (an older ax version) lacked the optional input. The UI captions this so
+     * a thin polygon isn't mistaken for a weak operator.
+     */
+    readonly partial: boolean;
+    /** which axes were unmeasurable (input missing), for caption detail */
+    readonly missing: readonly RadarAxisKey[];
+}
+
+export interface AxisMeta {
+    readonly key: RadarAxisKey;
+    /** short uppercase label rendered on the spoke */
+    readonly label: string;
+    /** one-line plain description of what the axis measures */
+    readonly note: string;
+}
+
+export const RADAR_AXES_META: readonly AxisMeta[] = [
+    { key: "DEPTH", label: "DEPTH", note: "share of sessions that ran long" },
+    { key: "SCALE", label: "SCALE", note: "total tokens moved" },
+    { key: "RIGOR", label: "RIGOR", note: "verification share of tool calls" },
+    { key: "DELEGATION", label: "DELEG", note: "subagents per session" },
+    { key: "BREADTH", label: "BREADTH", note: "distinct skills × repos" },
+    { key: "ENDURANCE", label: "ENDURE", note: "hours in the loop" },
+];
+
+/* ---------- scaling helpers ---------- */
+
+const clamp = (x: number, lo: number, hi: number): number =>
+    Number.isFinite(x) ? Math.min(hi, Math.max(lo, x)) : lo;
+
+/** clamp to [0,100] and round to one decimal so scores stay stable + tidy */
+const score = (x: number): number => Math.round(clamp(x, 0, 100) * 10) / 10;
+
+/**
+ * Piecewise log-anchored mapping. `anchors` is a list of (input -> output)
+ * fixed points in ascending input order; between two anchors we interpolate
+ * linearly in log10(input) space (magnitudes span orders of magnitude, so
+ * linear-in-log keeps a 1B vs 10B gap legible instead of pinning both at 100).
+ * Inputs below the first anchor map below its output by the same log slope,
+ * floored at 0; inputs above the last anchor are capped at its output.
+ */
+function logAnchored(value: number, anchors: ReadonlyArray<readonly [number, number]>): number {
+    if (!Number.isFinite(value) || value <= 0) return 0;
+    const lv = Math.log10(value);
+    const first = anchors[0]!;
+    const last = anchors[anchors.length - 1]!;
+    // below first anchor: extend the first segment's slope downward, floor 0
+    if (value <= first[0]) {
+        const next = anchors[1] ?? first;
+        const x0 = Math.log10(first[0]);
+        const x1 = Math.log10(next[0]);
+        const slope = x1 > x0 ? (next[1] - first[1]) / (x1 - x0) : 0;
+        return score(first[1] + slope * (lv - x0));
+    }
+    // above last anchor: cap
+    if (value >= last[0]) return score(last[1]);
+    // between anchors: linear in log space
+    for (let i = 1; i < anchors.length; i++) {
+        const [px, pv] = anchors[i - 1]!;
+        const [cx, cv] = anchors[i]!;
+        if (value <= cx) {
+            const x0 = Math.log10(px);
+            const x1 = Math.log10(cx);
+            const f = x1 > x0 ? (lv - x0) / (x1 - x0) : 0;
+            return score(pv + (cv - pv) * f);
+        }
+    }
+    return score(last[1]);
+}
+
+/* ---------- axis derivation ---------- */
+
+/**
+ * profileToAxes - the six comparable axes. Anchors are documented inline; each
+ * axis is 0..100. Missing optional inputs collapse an axis to 0 and flag the
+ * result `partial` so the UI can say "some axes need a newer ax version".
+ *
+ * Axes:
+ *  - DEPTH      deep_session_share, linear: 0% -> 0, 60% -> 100 (capped).
+ *               Deep work plateaus; nobody runs 100% 90-min sessions.
+ *  - SCALE      tokens.total, log-anchored:
+ *                 1M -> 10, 100M -> 40, 1B -> 60, 10B -> 85, 100B -> 100.
+ *               Token totals span 5+ orders of magnitude; log keeps them legible.
+ *  - RIGOR      verification_calls / tool_calls, linear: 0% -> 0, 15% -> 100 (cap).
+ *               15% of calls being tests/lints/checks is already very rigorous.
+ *  - DELEGATION subagents_spawned / sessions, linear: 0 -> 0, 2.0/session -> 100 (cap).
+ *               Two dispatched subagents per session = heavy orchestration.
+ *  - BREADTH    blend: min(100, distinct_skills*0.8 + repos_count*2).
+ *               A skill is worth 0.8pt, a repo 2pt; ~125 skills or ~50 repos maxes.
+ *  - ENDURANCE  hours_total, log-anchored: 10h -> 20, 100h -> 50, 1000h -> 80, 3000h -> 100.
+ */
+export function profileToAxes(p: ProfileV1): RadarAxes {
+    const ins = p.insights;
+    const sessions = p.stats.sessions;
+    const missing: RadarAxisKey[] = [];
+
+    // DEPTH - present whenever insights exist
+    let depth = 0;
+    if (ins) depth = score((ins.deep_session_share / 0.6) * 100);
+    else missing.push("DEPTH");
+
+    // SCALE - tokens.total is always validated/present
+    const scale = logAnchored(p.stats.tokens.total, [
+        [1e6, 10],
+        [1e8, 40],
+        [1e9, 60],
+        [1e10, 85],
+        [1e11, 100],
+    ]);
+
+    // RIGOR - needs verification_calls + tool_calls
+    let rigor = 0;
+    if (ins && ins.verification_calls !== undefined && ins.tool_calls !== undefined && ins.tool_calls > 0) {
+        rigor = score((ins.verification_calls / ins.tool_calls / 0.15) * 100);
+    } else {
+        missing.push("RIGOR");
+    }
+
+    // DELEGATION - subagents per session
+    let delegation = 0;
+    if (ins && sessions > 0) {
+        delegation = score((ins.subagents_spawned / sessions / 2.0) * 100);
+    } else {
+        missing.push("DELEGATION");
+    }
+
+    // BREADTH - distinct_skills + repos_count blend
+    let breadth = 0;
+    if (ins && (ins.distinct_skills !== undefined || ins.repos_count !== undefined)) {
+        const skills = ins.distinct_skills ?? 0;
+        const repos = ins.repos_count ?? 0;
+        breadth = score(skills * 0.8 + repos * 2);
+    } else {
+        missing.push("BREADTH");
+    }
+
+    // ENDURANCE - hours_total log-anchored
+    let endurance = 0;
+    if (ins) {
+        endurance = logAnchored(ins.hours_total, [
+            [10, 20],
+            [100, 50],
+            [1000, 80],
+            [3000, 100],
+        ]);
+    } else {
+        missing.push("ENDURANCE");
+    }
+
+    return {
+        scores: {
+            DEPTH: depth,
+            SCALE: scale,
+            RIGOR: rigor,
+            DELEGATION: delegation,
+            BREADTH: breadth,
+            ENDURANCE: endurance,
+        },
+        partial: missing.length > 0,
+        missing,
+    };
+}
+
+/* ---------- archetype ("agent sign") ---------- */
+
+export interface Archetype {
+    readonly sign: string;
+    /** a short glyph for the sign - astrology-port flavour, plain unicode */
+    readonly symbol: string;
+    /** one horoscope-toned, number-grounded sentence */
+    readonly blurb: string;
+}
+
+/**
+ * The dominant ordering of axes. Ties are broken deterministically by the
+ * fixed RADAR_AXIS_KEYS order so the same scores always pick the same pair.
+ */
+function rankAxes(axes: RadarAxes): RadarAxisKey[] {
+    const order = new Map(RADAR_AXIS_KEYS.map((k, i) => [k, i] as const));
+    return [...RADAR_AXIS_KEYS].sort((a, b) => {
+        const d = axes.scores[b] - axes.scores[a];
+        if (d !== 0) return d;
+        return order.get(a)! - order.get(b)!; // stable, deterministic tiebreak
+    });
+}
+
+/**
+ * unordered-pair key so DEPTH+RIGOR and RIGOR+DEPTH resolve to one sign. The
+ * canonical order is RADAR_AXIS_KEYS order.
+ */
+function pairKey(a: RadarAxisKey, b: RadarAxisKey): string {
+    const idx = (k: RadarAxisKey) => RADAR_AXIS_KEYS.indexOf(k);
+    return idx(a) <= idx(b) ? `${a}+${b}` : `${b}+${a}`;
+}
+
+/**
+ * Full sign matrix: every unordered pair of the six axes maps to a sign. C(6,2)
+ * = 15 pairs. Each entry is a name + glyph; the blurb is generated from the
+ * actual numbers in `blurbFor` so it stays grounded.
+ */
+const SIGN_MATRIX: Record<string, { sign: string; symbol: string }> = {
+    "DEPTH+SCALE": { sign: "The Excavator", symbol: "♁" },
+    "DEPTH+RIGOR": { sign: "The Auditor", symbol: "⚖" },
+    "DEPTH+DELEGATION": { sign: "The Architect", symbol: "◈" },
+    "DEPTH+BREADTH": { sign: "The Cartographer", symbol: "✦" },
+    "DEPTH+ENDURANCE": { sign: "The Deep Worker", symbol: "◉" },
+    "SCALE+RIGOR": { sign: "The Refinery", symbol: "⧉" },
+    "SCALE+DELEGATION": { sign: "The Fleet Commander", symbol: "⚓" },
+    "SCALE+BREADTH": { sign: "The Polyglot", symbol: "✸" },
+    "SCALE+ENDURANCE": { sign: "The Marathoner", symbol: "∞" },
+    "RIGOR+DELEGATION": { sign: "The Overseer", symbol: "△" },
+    "RIGOR+BREADTH": { sign: "The Inspector", symbol: "✓" },
+    "RIGOR+ENDURANCE": { sign: "The Watchkeeper", symbol: "◉" },
+    "DELEGATION+BREADTH": { sign: "The Conductor", symbol: "⚘" },
+    "DELEGATION+ENDURANCE": { sign: "The Ringmaster", symbol: "❂" },
+    "BREADTH+ENDURANCE": { sign: "The Wanderer", symbol: "✵" },
+};
+
+/** when every axis is 0 (no insights at all) */
+const VOID_SIGN = { sign: "The Unmeasured", symbol: "○" };
+
+const fmtCompact = new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 });
+const pct1 = (x: number): string => `${Math.round(x * 10) / 10}%`;
+
+/**
+ * One dry, horoscope-toned sentence grounded in the real numbers behind the two
+ * dominant axes - "Mercury has nothing to do with it" energy.
+ */
+function blurbFor(top: RadarAxisKey, second: RadarAxisKey, p: ProfileV1): string {
+    const ins = p.insights;
+    const fact = (axis: RadarAxisKey): string => {
+        switch (axis) {
+            case "DEPTH":
+                return ins ? `${pct1(ins.deep_session_share * 100)} of your sessions run long` : "your deep-session share";
+            case "SCALE":
+                return `${fmtCompact.format(p.stats.tokens.total)} tokens moved`;
+            case "RIGOR":
+                return ins && ins.verification_calls !== undefined
+                    ? `${fmtCompact.format(ins.verification_calls)} verification calls`
+                    : "your verification habit";
+            case "DELEGATION":
+                return ins ? `${fmtCompact.format(ins.subagents_spawned)} subagents dispatched` : "your delegation rate";
+            case "BREADTH":
+                return ins && ins.distinct_skills !== undefined
+                    ? `${fmtCompact.format(ins.distinct_skills)} distinct skills`
+                    : "the width of your rig";
+            case "ENDURANCE":
+                return ins ? `${fmtCompact.format(ins.hours_total)} hours in the loop` : "your hours on the clock";
+        }
+    };
+    return `The stars are flattered, but it's ${fact(top)} and ${fact(second)} that wrote this chart.`;
+}
+
+/**
+ * archetypeFor - deterministic "agent sign" from the top-two dominant axes.
+ * Ties broken by RADAR_AXIS_KEYS order. When all axes are 0, returns a void
+ * sign rather than picking an arbitrary pair.
+ */
+export function archetypeFor(axes: RadarAxes, profile?: ProfileV1): Archetype {
+    const ranked = rankAxes(axes);
+    const top = ranked[0]!;
+    const second = ranked[1]!;
+    const allZero = RADAR_AXIS_KEYS.every((k) => axes.scores[k] === 0);
+    const base = allZero ? VOID_SIGN : (SIGN_MATRIX[pairKey(top, second)] ?? VOID_SIGN);
+
+    const blurb = allZero
+        ? "No telemetry, no chart. Publish with a newer ax and the stars align."
+        : profile
+            ? blurbFor(top, second, profile)
+            : `Born under ${top.toLowerCase()} rising, with ${second.toLowerCase()} on the ascendant.`;
+
+    return { sign: base.sign, symbol: base.symbol, blurb };
+}
+
+/** the two axes that defined the sign - handy for the compare delta block */
+export function dominantPair(axes: RadarAxes): readonly [RadarAxisKey, RadarAxisKey] {
+    const ranked = rankAxes(axes);
+    return [ranked[0]!, ranked[1]!];
+}

--- a/apps/site/app/routes/leaders.tsx
+++ b/apps/site/app/routes/leaders.tsx
@@ -87,7 +87,7 @@ function LeadersPage() {
                                     {state.lb.boards[board].map((row, i) => (
                                         <tr key={row.login}>
                                             <td>{i + 1}</td>
-                                            <td><Link to="/u/$login" params={{ login: row.login }}>@{row.login}</Link></td>
+                                            <td><Link to="/u/$login" params={{ login: row.login }} search={{ vs: undefined }}>@{row.login}</Link></td>
                                             <td>{valueLabel[board](row.value)}</td>
                                         </tr>
                                     ))}

--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -415,6 +415,10 @@ function SignSection({ n, profile, vs }: { n: string; profile: ProfileV1; vs: Vs
     return (
         <section className="pf-section">
             <Kicker n={n} title="The sign" note="six axes, one archetype" />
+            <p className="pf-sign-method">
+                Axes are log-anchored to fixed scales (not min-max), so shapes compare
+                across any two profiles.
+            </p>
             <div className="pf-sign">
                 <div className="pf-sign-chart">
                     <RadarChart series={series} size={420} />
@@ -442,11 +446,9 @@ function SignSection({ n, profile, vs }: { n: string; profile: ProfileV1; vs: Vs
                     </div>
                     <p className="pf-sign-blurb">{selfArch.blurb}</p>
 
-                    {vsReady && vsAxes ? (
-                        <DeltaList self={selfAxes} selfLogin={profile.github} vs={vsAxes} vsLogin={vsReady.login} />
-                    ) : (
-                        <ScoreList axes={selfAxes} />
-                    )}
+                    {/* compare mode: the raw-values table below carries the
+                        per-axis comparison - one table, not two summaries */}
+                    {!(vsReady && vsAxes) && <ScoreList axes={selfAxes} />}
 
                     {/* compare control */}
                     <div className="pf-sign-compare">
@@ -477,6 +479,12 @@ function SignSection({ n, profile, vs }: { n: string; profile: ProfileV1; vs: Vs
                     </div>
                 </div>
             </div>
+
+            <RawTable
+                self={selfAxes}
+                selfLogin={profile.github}
+                vs={vsReady && vsAxes ? { axes: vsAxes, login: vsReady.login } : undefined}
+            />
         </section>
     );
 }
@@ -503,30 +511,65 @@ function ScoreList({ axes }: { axes: RadarAxes }) {
     );
 }
 
-function DeltaList({
-    self, selfLogin, vs, vsLogin,
-}: { self: RadarAxes; selfLogin: string; vs: RadarAxes; vsLogin: string }) {
+/**
+ * "Raw values" reference table - the un-normalised numbers behind the chart,
+ * straight off RadarAxes.raws (never re-derived here). In compare mode each
+ * row gets two value columns and the per-metric leader is marked with a small
+ * green dot; ties and unmeasurable rows get no dot.
+ */
+function RawTable({
+    self, selfLogin, vs,
+}: {
+    self: RadarAxes;
+    selfLogin: string;
+    vs?: { axes: RadarAxes; login: string };
+}) {
     return (
-        <dl className="pf-sign-scores pf-sign-scores--delta">
-            {RADAR_AXES_META.map((m) => {
-                const sv = self.scores[m.key];
-                const vv = vs.scores[m.key];
-                const diff = sv - vv;
-                const leader = Math.abs(diff) < 0.05 ? "tie" : diff > 0 ? selfLogin : vsLogin;
-                return (
-                    <div className="pf-sign-score" key={m.key}>
-                        <dt>{m.label}</dt>
-                        <dd className="pf-sign-delta">
-                            <span className="pf-sign-delta-self" style={{ color: SELF_COLOR }}>{fmtScore(sv)}</span>
-                            <span className="pf-sign-delta-vs" style={{ color: VS_COLOR }}>{fmtScore(vv)}</span>
-                            <span className="pf-sign-delta-lead">
-                                {leader === "tie" ? "even" : `@${leader} +${fmtScore(Math.abs(diff))}`}
-                            </span>
-                        </dd>
-                    </div>
-                );
-            })}
-        </dl>
+        <div className="pf-rawvals">
+            <div className="pf-rawvals-head">
+                <span className="pf-rawvals-kicker">raw values</span>
+                <span className="pf-rawvals-note">un-normalised numbers behind the chart</span>
+            </div>
+            <table className="pf-rawvals-table">
+                <thead>
+                    <tr>
+                        <th scope="col">metric</th>
+                        <th scope="col" className="pf-rawvals-col">
+                            {vs ? <span style={{ color: SELF_COLOR }}>@{selfLogin}</span> : "value"}
+                        </th>
+                        {vs && (
+                            <th scope="col" className="pf-rawvals-col">
+                                <span style={{ color: VS_COLOR }}>@{vs.login}</span>
+                            </th>
+                        )}
+                    </tr>
+                </thead>
+                <tbody>
+                    {RADAR_AXES_META.map((m) => {
+                        const a = self.raws[m.key];
+                        const b = vs?.axes.raws[m.key];
+                        // leader: strictly greater comparable numeric; null never leads
+                        const aLeads = vs !== undefined && a.value !== null && (b?.value === null || b === undefined || a.value > b.value);
+                        const bLeads = vs !== undefined && b !== undefined && b.value !== null && (a.value === null || b.value > a.value);
+                        return (
+                            <tr key={m.key}>
+                                <th scope="row">{m.label}</th>
+                                <td className={aLeads ? "pf-rawvals-val pf-rawvals-val--lead" : "pf-rawvals-val"}>
+                                    {a.label}
+                                    {aLeads && <span className="pf-rawvals-dot" aria-label="leads" />}
+                                </td>
+                                {vs && b && (
+                                    <td className={bLeads ? "pf-rawvals-val pf-rawvals-val--lead" : "pf-rawvals-val"}>
+                                        {b.label}
+                                        {bLeads && <span className="pf-rawvals-dot" aria-label="leads" />}
+                                    </td>
+                                )}
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
     );
 }
 

--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -1,9 +1,17 @@
 // apps/site/app/routes/u.$login.tsx
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { useEffect, useState, type ReactNode } from "react";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
 import { SiteHeader } from "~/components/landing-sections/site-header";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
 import { CardArt, type CardArtAccent } from "~/components/dossier-card-art";
+import { RadarChart, type RadarSeries } from "~/components/radar-chart";
+import {
+    archetypeFor,
+    dominantPair,
+    profileToAxes,
+    RADAR_AXES_META,
+    type RadarAxes,
+} from "~/lib/radar";
 import {
     fetchProfile,
     type ProfileV1,
@@ -12,7 +20,16 @@ import {
     type ProfileSkill,
 } from "~/lib/community";
 
+// mirrors LOGIN_RE in community.ts - GitHub handles only, sanitised before use.
+const LOGIN_RE = /^[A-Za-z0-9-]{1,39}$/;
+// series colours: primary profile = ax green, comparison = ax blue.
+const SELF_COLOR = "var(--green)";
+const VS_COLOR = "#2567a8";
+
 export const Route = createFileRoute("/u/$login")({
+    validateSearch: (search: Record<string, unknown>) => ({
+        vs: typeof search.vs === "string" && LOGIN_RE.test(search.vs) ? search.vs : undefined,
+    }),
     head: ({ params }) => ({
         meta: [
             { title: `@${params.login} - ax profile` },
@@ -28,9 +45,21 @@ type State =
     | { kind: "error"; message: string }
     | { kind: "ready"; profile: ProfileV1 };
 
+// comparison-profile load state, kept separate from the primary dossier so a
+// missing/invalid `?vs=` peer degrades to a quiet inline note, never an error
+// page for the profile the visitor actually came to see.
+type VsState =
+    | { kind: "none" }
+    | { kind: "loading"; login: string }
+    | { kind: "not-found"; login: string }
+    | { kind: "error"; login: string }
+    | { kind: "ready"; login: string; profile: ProfileV1 };
+
 function ProfilePage() {
     const { login } = Route.useParams();
+    const { vs } = Route.useSearch();
     const [state, setState] = useState<State>({ kind: "loading" });
+    const [vsState, setVsState] = useState<VsState>({ kind: "none" });
 
     useEffect(() => {
         let alive = true;
@@ -57,6 +86,31 @@ function ProfilePage() {
         return () => { alive = false; };
     }, [login]);
 
+    useEffect(() => {
+        let alive = true;
+        if (!vs || vs.toLowerCase() === login.toLowerCase()) {
+            // self-compare is allowed (proves the overlay path); only skip the
+            // empty case so we don't double-render the same series silently.
+            if (!vs) { setVsState({ kind: "none" }); return; }
+        }
+        setVsState({ kind: "loading", login: vs });
+        fetchProfile(vs)
+            .then((profile) => {
+                if (!alive) return;
+                if (profile.github.toLowerCase() !== vs.toLowerCase()) {
+                    setVsState({ kind: "error", login: vs });
+                    return;
+                }
+                setVsState({ kind: "ready", login: vs, profile });
+            })
+            .catch((e: unknown) => {
+                if (!alive) return;
+                const notFound = typeof e === "object" && e !== null && (e as { notFound?: boolean }).notFound === true;
+                setVsState(notFound ? { kind: "not-found", login: vs } : { kind: "error", login: vs });
+            });
+        return () => { alive = false; };
+    }, [vs, login]);
+
     return (
         <>
             <SiteHeader />
@@ -64,7 +118,7 @@ function ProfilePage() {
                 {state.kind === "loading" && <p className="pf-loading">pulling the dossier on @{login}…</p>}
                 {state.kind === "not-found" && <UnclaimedDossier login={login} />}
                 {state.kind === "error" && <p className="pf-loading">couldn't load profile: {state.message}</p>}
-                {state.kind === "ready" && <ProfileDossier profile={state.profile} />}
+                {state.kind === "ready" && <ProfileDossier profile={state.profile} vs={vsState} />}
             </main>
             <SiteFooter />
         </>
@@ -109,7 +163,7 @@ const clampPct = (x: number): number => (Number.isFinite(x) ? Math.min(100, Math
 
 /* ---------- the dossier ---------- */
 
-function ProfileDossier({ profile: p }: { profile: ProfileV1 }) {
+function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsState }) {
     const daily = p.activity && p.activity.daily.length > 0
         ? [...p.activity.daily].sort((a, b) => (a.date < b.date ? -1 : 1))
         : [];
@@ -196,6 +250,9 @@ function ProfileDossier({ profile: p }: { profile: ProfileV1 }) {
                     </div>
                 </section>
             )}
+
+            {/* the sign: radar + agent archetype */}
+            <SignSection n={nextSection()} profile={p} vs={vs} />
 
             {/* tool taste */}
             {tools.length > 0 && (
@@ -329,6 +386,151 @@ function Kicker({ n, title, note }: { n: string; title: string; note?: string })
         </div>
     );
 }
+
+/* ---------- the sign: radar + archetype ---------- */
+
+function SignSection({ n, profile, vs }: { n: string; profile: ProfileV1; vs: VsState }) {
+    const navigate = useNavigate({ from: "/u/$login" });
+    const [draft, setDraft] = useState("");
+
+    const selfAxes = profileToAxes(profile);
+    const selfArch = archetypeFor(selfAxes, profile);
+
+    const vsReady = vs.kind === "ready" ? vs : null;
+    const vsAxes = vsReady ? profileToAxes(vsReady.profile) : null;
+    const vsArch = vsReady && vsAxes ? archetypeFor(vsAxes, vsReady.profile) : null;
+
+    const series: RadarSeries[] = [{ login: profile.github, axes: selfAxes, color: SELF_COLOR }];
+    if (vsReady && vsAxes) series.push({ login: vsReady.login, axes: vsAxes, color: VS_COLOR });
+
+    const submit = (e: FormEvent) => {
+        e.preventDefault();
+        const target = draft.trim().replace(/^@/, "");
+        if (!LOGIN_RE.test(target)) return;
+        void navigate({ search: { vs: target } });
+        setDraft("");
+    };
+    const clearCompare = () => void navigate({ search: { vs: undefined } });
+
+    return (
+        <section className="pf-section">
+            <Kicker n={n} title="The sign" note="six axes, one archetype" />
+            <div className="pf-sign">
+                <div className="pf-sign-chart">
+                    <RadarChart series={series} size={420} />
+                    {selfAxes.partial && (
+                        <p className="pf-sign-partial">
+                            some axes read 0 - they need a newer ax version to populate.
+                        </p>
+                    )}
+                </div>
+
+                <div className="pf-sign-read">
+                    {vsArch && vsReady ? (
+                        <p className="pf-sign-versus">
+                            <span style={{ color: SELF_COLOR }}>@{profile.github}</span> is {selfArch.sign}
+                            {" · "}
+                            <span style={{ color: VS_COLOR }}>@{vsReady.login}</span> is {vsArch.sign}
+                        </p>
+                    ) : (
+                        <span className="pf-sign-kicker">your agent sign</span>
+                    )}
+
+                    <div className="pf-sign-head">
+                        <span className="pf-sign-glyph" aria-hidden="true">{selfArch.symbol}</span>
+                        <h3 className="pf-sign-name">{selfArch.sign}</h3>
+                    </div>
+                    <p className="pf-sign-blurb">{selfArch.blurb}</p>
+
+                    {vsReady && vsAxes ? (
+                        <DeltaList self={selfAxes} selfLogin={profile.github} vs={vsAxes} vsLogin={vsReady.login} />
+                    ) : (
+                        <ScoreList axes={selfAxes} />
+                    )}
+
+                    {/* compare control */}
+                    <div className="pf-sign-compare">
+                        {vsReady ? (
+                            <button type="button" className="pf-sign-clear" onClick={clearCompare}>
+                                clear comparison
+                            </button>
+                        ) : (
+                            <form className="pf-sign-form" onSubmit={submit}>
+                                <span className="pf-sign-form-label">compare with</span>
+                                <input
+                                    className="pf-sign-input"
+                                    type="text"
+                                    value={draft}
+                                    onChange={(e) => setDraft(e.currentTarget.value)}
+                                    placeholder="github handle"
+                                    aria-label="github handle to compare with"
+                                    spellCheck={false}
+                                    autoCapitalize="off"
+                                    autoCorrect="off"
+                                />
+                                <button type="submit" className="pf-sign-go">overlay</button>
+                            </form>
+                        )}
+                        {vs.kind === "loading" && <span className="pf-sign-msg">pulling @{vs.login}…</span>}
+                        {vs.kind === "not-found" && <span className="pf-sign-msg">no dossier on file for @{vs.login}.</span>}
+                        {vs.kind === "error" && <span className="pf-sign-msg">couldn't load @{vs.login}.</span>}
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+function ScoreList({ axes }: { axes: RadarAxes }) {
+    const [a, b] = dominantPair(axes);
+    return (
+        <dl className="pf-sign-scores">
+            {RADAR_AXES_META.map((m) => {
+                const dom = m.key === a || m.key === b;
+                return (
+                    <div className={dom ? "pf-sign-score pf-sign-score--dom" : "pf-sign-score"} key={m.key}>
+                        <dt>{m.label}</dt>
+                        <dd>
+                            <span className="pf-sign-bar" aria-hidden="true">
+                                <span className="pf-sign-bar-fill" style={{ width: `${clampPct(axes.scores[m.key])}%` }} />
+                            </span>
+                            <span className="pf-sign-val">{fmtScore(axes.scores[m.key])}</span>
+                        </dd>
+                    </div>
+                );
+            })}
+        </dl>
+    );
+}
+
+function DeltaList({
+    self, selfLogin, vs, vsLogin,
+}: { self: RadarAxes; selfLogin: string; vs: RadarAxes; vsLogin: string }) {
+    return (
+        <dl className="pf-sign-scores pf-sign-scores--delta">
+            {RADAR_AXES_META.map((m) => {
+                const sv = self.scores[m.key];
+                const vv = vs.scores[m.key];
+                const diff = sv - vv;
+                const leader = Math.abs(diff) < 0.05 ? "tie" : diff > 0 ? selfLogin : vsLogin;
+                return (
+                    <div className="pf-sign-score" key={m.key}>
+                        <dt>{m.label}</dt>
+                        <dd className="pf-sign-delta">
+                            <span className="pf-sign-delta-self" style={{ color: SELF_COLOR }}>{fmtScore(sv)}</span>
+                            <span className="pf-sign-delta-vs" style={{ color: VS_COLOR }}>{fmtScore(vv)}</span>
+                            <span className="pf-sign-delta-lead">
+                                {leader === "tie" ? "even" : `@${leader} +${fmtScore(Math.abs(diff))}`}
+                            </span>
+                        </dd>
+                    </div>
+                );
+            })}
+        </dl>
+    );
+}
+
+const fmtScore = (n: number): string => String(Math.round(n));
 
 function ActivityTimeline({ daily, busiest }: { daily: readonly ProfileDailyRow[]; busiest?: string }) {
     const maxSessions = daily.reduce((m, d) => Math.max(m, d.sessions), 0);

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -10436,3 +10436,214 @@ footer .right {
     .pf-cta { padding: 28px 22px 22px; }
     .pf-cta-cmd { white-space: normal; word-break: break-all; }
 }
+
+/* ----- the sign: radar + archetype ----- */
+.pf-sign {
+    display: grid;
+    grid-template-columns: 420px minmax(0, 1fr);
+    gap: 52px;
+    align-items: center;
+}
+@media (max-width: 880px) {
+    .pf-sign { grid-template-columns: minmax(0, 1fr); gap: 28px; align-items: start; }
+}
+
+.pf-sign-chart { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+.pf-radar-wrap { display: flex; flex-direction: column; align-items: center; gap: 14px; }
+.pf-radar { width: 100%; max-width: 420px; height: auto; overflow: visible; }
+.pf-sign-partial {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--muted);
+    letter-spacing: 0.04em;
+    text-align: center;
+    max-width: 320px;
+    margin: 0;
+}
+
+.pf-radar-ring { fill: none; stroke: var(--line); stroke-width: 1; }
+.pf-radar-ring--outer { stroke: color-mix(in srgb, var(--ink) 28%, var(--line)); }
+.pf-radar-spoke { stroke: var(--line); stroke-width: 1; }
+.pf-radar-axis-label {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.13em;
+    fill: var(--muted);
+    text-transform: uppercase;
+}
+.pf-radar-area {
+    fill: currentColor;
+    fill-opacity: 0.18;
+    stroke: currentColor;
+    stroke-width: 1.75;
+    stroke-linejoin: round;
+}
+.pf-radar-dot { fill: currentColor; stroke: var(--page); stroke-width: 1; }
+
+.pf-radar-legend {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+.pf-radar-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.03em;
+    color: var(--ink);
+}
+.pf-radar-chip-swatch { width: 11px; height: 11px; border-radius: 50%; display: inline-block; }
+
+/* read column */
+.pf-sign-read { min-width: 0; }
+.pf-sign-kicker {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--muted);
+}
+.pf-sign-versus {
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.02em;
+    color: var(--muted);
+    margin: 0 0 4px;
+}
+.pf-sign-versus span { font-weight: 600; }
+.pf-sign-head { display: flex; align-items: baseline; gap: 14px; margin-top: 4px; }
+.pf-sign-glyph {
+    font-size: 34px;
+    line-height: 1;
+    color: var(--green);
+    transform: translateY(4px);
+}
+.pf-sign-name {
+    font-family: var(--serif);
+    font-size: 40px;
+    font-weight: 400;
+    letter-spacing: -1px;
+    line-height: 1;
+    margin: 0;
+}
+.pf-sign-blurb {
+    font-family: var(--serif);
+    font-size: 17px;
+    line-height: 1.5;
+    color: color-mix(in srgb, var(--ink) 82%, var(--page));
+    margin: 14px 0 22px;
+    max-width: 46ch;
+}
+
+/* score list */
+.pf-sign-scores { display: flex; flex-direction: column; gap: 0; margin: 0; }
+.pf-sign-score {
+    display: grid;
+    grid-template-columns: 84px minmax(0, 1fr);
+    align-items: center;
+    gap: 14px;
+    padding: 7px 0;
+    border-top: 1px solid var(--line);
+}
+.pf-sign-score:last-child { border-bottom: 1px solid var(--line); }
+.pf-sign-score dt {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted);
+}
+.pf-sign-score--dom dt { color: var(--ink); }
+.pf-sign-score dd { margin: 0; display: flex; align-items: center; gap: 10px; }
+.pf-sign-bar {
+    flex: 1;
+    height: 6px;
+    background: color-mix(in srgb, var(--line) 60%, var(--page));
+    position: relative;
+    overflow: hidden;
+}
+.pf-sign-bar-fill { position: absolute; inset: 0 auto 0 0; background: color-mix(in srgb, var(--green) 60%, var(--page)); }
+.pf-sign-score--dom .pf-sign-bar-fill { background: var(--green); }
+.pf-sign-val {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--ink);
+    width: 26px;
+    text-align: right;
+    flex: none;
+}
+
+/* delta list (compare mode) */
+.pf-sign-delta {
+    display: grid !important;
+    grid-template-columns: 44px 44px 1fr;
+    gap: 16px;
+    align-items: baseline;
+}
+.pf-sign-delta-self, .pf-sign-delta-vs {
+    font-family: var(--mono);
+    font-size: 13px;
+    text-align: right;
+    font-weight: 600;
+}
+.pf-sign-delta-lead {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+    text-align: left;
+    padding-left: 6px;
+}
+
+/* compare control */
+.pf-sign-compare {
+    margin-top: 22px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+.pf-sign-form { display: flex; align-items: center; gap: 8px; }
+.pf-sign-form-label {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted);
+}
+.pf-sign-input {
+    font-family: var(--mono);
+    font-size: 12px;
+    padding: 6px 9px;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    color: var(--ink);
+    width: 150px;
+}
+.pf-sign-input:focus { outline: none; border-color: var(--green); }
+.pf-sign-go, .pf-sign-clear {
+    font-family: var(--mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 6px 12px;
+    border: 1px solid var(--ink);
+    background: var(--ink);
+    color: var(--page);
+    cursor: pointer;
+}
+.pf-sign-clear { background: transparent; color: var(--muted); border-color: var(--line); }
+.pf-sign-go:hover { background: var(--green); border-color: var(--green); }
+.pf-sign-clear:hover { color: var(--ink); border-color: var(--ink); }
+.pf-sign-msg {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+}
+@media (max-width: 560px) {
+    .pf-sign-name { font-size: 32px; }
+    .pf-sign-delta { grid-template-columns: 38px 38px minmax(0, 1fr); }
+}

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -10576,28 +10576,6 @@ footer .right {
     flex: none;
 }
 
-/* delta list (compare mode) */
-.pf-sign-delta {
-    display: grid !important;
-    grid-template-columns: 44px 44px 1fr;
-    gap: 16px;
-    align-items: baseline;
-}
-.pf-sign-delta-self, .pf-sign-delta-vs {
-    font-family: var(--mono);
-    font-size: 13px;
-    text-align: right;
-    font-weight: 600;
-}
-.pf-sign-delta-lead {
-    font-family: var(--mono);
-    font-size: 10.5px;
-    letter-spacing: 0.04em;
-    color: var(--muted);
-    text-align: left;
-    padding-left: 6px;
-}
-
 /* compare control */
 .pf-sign-compare {
     margin-top: 22px;
@@ -10643,7 +10621,82 @@ footer .right {
     font-size: 11px;
     color: var(--muted);
 }
+/* normalization explainer under the kicker */
+.pf-sign-method {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.03em;
+    color: var(--muted);
+    margin: -12px 0 24px;
+    max-width: 64ch;
+}
+
+/* raw values reference table */
+.pf-rawvals { margin-top: 40px; }
+.pf-rawvals-head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+.pf-rawvals-kicker {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--ink);
+}
+.pf-rawvals-note {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+}
+.pf-rawvals-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: var(--mono);
+    font-size: 12.5px;
+}
+.pf-rawvals-table th, .pf-rawvals-table td { padding: 8px 0; }
+.pf-rawvals-table thead th {
+    font-size: 10.5px;
+    font-weight: 400;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted);
+    text-align: right;
+    border-bottom: 1px solid color-mix(in srgb, var(--ink) 28%, var(--line));
+}
+.pf-rawvals-table thead th:first-child { text-align: left; }
+.pf-rawvals-table thead th span { font-weight: 600; text-transform: none; letter-spacing: 0.03em; }
+.pf-rawvals-table tbody tr { border-bottom: 1px solid var(--line); }
+.pf-rawvals-table tbody th {
+    font-size: 10.5px;
+    font-weight: 400;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted);
+    text-align: left;
+    width: 110px;
+}
+.pf-rawvals-val {
+    text-align: right;
+    color: var(--ink);
+    white-space: nowrap;
+}
+.pf-rawvals-val--lead { font-weight: 600; }
+.pf-rawvals-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--green);
+    margin-left: 7px;
+    transform: translateY(-1px);
+}
 @media (max-width: 560px) {
     .pf-sign-name { font-size: 32px; }
-    .pf-sign-delta { grid-template-columns: 38px 38px minmax(0, 1fr); }
+    .pf-rawvals-table tbody th { width: 84px; }
+    .pf-rawvals-val { white-space: normal; }
 }


### PR DESCRIPTION
## Summary
The "spider diagram so I can compare with you" feature, with the astrology port:
- **Six log-anchored axes** (DEPTH, SCALE, RIGOR, DELEGATION, BREADTH, ENDURANCE) computed purely from the validated gist — fixed anchors, not min-max, so shapes compare across any two profiles (explainer line states this). Missing optional fields degrade to 0 with a caption.
- **15-sign archetype matrix** from the top-2 dominant axes ("The Auditor", "The Fleet Commander", "The Deep Worker"…) with horoscope-toned blurbs grounded in real numbers. @necmttn currently reads as **The Wanderer** (BREADTH 91 + ENDURANCE 95).
- **Compare overlay**: `?vs=<login>` fetches a second registered profile, overlays it (green vs blue), shows both signs, and a **raw-values reference table** (ported from the man-on-court padel radar) — un-normalized numbers per axis with a leader dot per metric. Inline "compare with @…" form.
- Dependency-free SVG chart; all untrusted strings render as text.

## Test Plan
- [x] 65 site tests green (23 radar tests: anchors, caps, determinism, full matrix coverage, raw labels, partial handling)
- [x] Build + typecheck clean for new files
- [x] Visual iteration on live data: single + self-compare overlay + leader-dot perturbation check (screenshots reviewed)
- [ ] Post-merge prod check; real two-user compare becomes possible with registration #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)