### PR TITLE
feat(axctl): ax quota - Claude plan usage in CLI, statusline, and menubar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,19 @@ fresh clone.
 `ax cost sessions [--days=N] [--model=<name>] [--limit=N]` - top sessions by cost with id, project, model, started_at (default 14d/20 rows).
 `ax cost split [--days=N]` - origin (main vs subagent) × model matrix with cost and share-of-total; totals row. MCP: `cost_models`, `cost_split`.
 
+### Plan quota
+
+`ax quota [--json|--statusline|--swiftbar] [--max-age=N] [--fresh]` - live Claude
+plan usage (5h/7d windows) from the undocumented `api.anthropic.com/api/oauth/usage`
+endpoint, claude-meter style. Reads the Claude Code OAuth token (macOS Keychain
+`Claude Code-credentials`, fallback `~/.claude/.credentials.json`); never refreshes
+it. Responses cached at `~/.ax/quota-cache.json` (TTL `--max-age`, default 60s) so
+statusline/menubar callers can poll freely; fetch failures degrade to the stale
+cache. `--statusline` is one plain line for the Claude Code `statusLine` command;
+`--swiftbar` emits a SwiftBar/xbar plugin body (installable plugin:
+`scripts/swiftbar/ax-quota.2m.sh`). Module: `apps/axctl/src/quota/` (QuotaEnv seam,
+Live/Test layers). No DB (runtime "none").
+
 ### Profile
 
 `ax profile show [--window=N] [--no-cost] [--json]` - render your local ax

--- a/apps/axctl/src/cli/commands/quota.ts
+++ b/apps/axctl/src/cli/commands/quota.ts
@@ -1,0 +1,114 @@
+/**
+ * `ax quota` - live Claude plan usage (5h / 7d windows) from the Anthropic
+ * OAuth usage endpoint, claude-meter style. Reads the Claude Code OAuth
+ * token (Keychain / ~/.claude/.credentials.json), caches the response at
+ * ~/.ax/quota-cache.json (default TTL 60s) so statusline/menubar callers can
+ * poll freely without hammering the endpoint.
+ *
+ *   ax quota                 human table
+ *   ax quota --json          QuotaSnapshot JSON
+ *   ax quota --statusline    one line, e.g. for Claude Code statusLine:
+ *                            { "statusLine": { "type": "command",
+ *                              "command": "axctl quota --statusline" } }
+ *   ax quota --swiftbar      SwiftBar/xbar plugin body (menubar)
+ *
+ * Render-only modes (--statusline/--swiftbar) never fail loud: on any error
+ * they print a quiet "quota n/a" and exit 0, because their output lands in
+ * UI chrome.
+ */
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { prettyPrint } from "@ax/lib/json";
+import { defaultQuotaCachePath } from "../../quota/cache.ts";
+import { renderQuotaTable, renderStatusline, renderSwiftBar } from "../../quota/format.ts";
+import { QuotaEnvLive } from "../../quota/quota-env.ts";
+import { getQuota, type QuotaResult } from "../../quota/quota.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { fail, jsonFlag } from "./shared.ts";
+
+const TOKEN_HELP =
+    "ax quota: no Claude Code OAuth token found.\n" +
+    "Looked in the macOS Keychain (service \"Claude Code-credentials\") and\n" +
+    "~/.claude/.credentials.json - is Claude Code installed and logged in?";
+
+const sourceNote = (result: QuotaResult): string =>
+    result.source === "live"
+        ? "live"
+        : result.source === "cache"
+            ? "cached"
+            : "stale cache - usage endpoint unreachable";
+
+const cmdQuota = (input: {
+    readonly json: boolean;
+    readonly statusline: boolean;
+    readonly swiftbar: boolean;
+    readonly maxAgeSeconds: number;
+}) => {
+    const nowMs = Date.now();
+    const quiet = input.statusline || input.swiftbar;
+    const render = (result: QuotaResult): string => {
+        if (input.json) return prettyPrint({ ...result.snapshot, source: result.source });
+        if (input.statusline) return renderStatusline(result.snapshot, { nowMs });
+        if (input.swiftbar) return renderSwiftBar(result.snapshot, { nowMs });
+        return renderQuotaTable(result.snapshot, { nowMs, sourceNote: sourceNote(result) });
+    };
+    return getQuota({
+        cachePath: defaultQuotaCachePath(),
+        maxAgeSeconds: input.maxAgeSeconds,
+        nowMs,
+    }).pipe(
+        Effect.map((result) => {
+            console.log(render(result));
+        }),
+        Effect.catch((error) =>
+            Effect.sync(() => {
+                if (quiet) {
+                    // UI chrome: degrade silently, never an error dump.
+                    console.log(input.swiftbar ? "◌ quota n/a" : "quota n/a");
+                    return;
+                }
+                console.error(
+                    error._tag === "QuotaTokenMissing"
+                        ? TOKEN_HELP
+                        : `ax quota: usage endpoint failed (${error.message})`,
+                );
+                process.exit(1);
+            }),
+        ),
+        Effect.provide(QuotaEnvLive),
+    );
+};
+
+export const quotaCommand = Command.make(
+    "quota",
+    {
+        json: jsonFlag,
+        statusline: Flag.boolean("statusline").pipe(Flag.withDefault(false)),
+        swiftbar: Flag.boolean("swiftbar").pipe(Flag.withDefault(false)),
+        maxAge: Flag.integer("max-age").pipe(Flag.withDefault(60)),
+        fresh: Flag.boolean("fresh").pipe(Flag.withDefault(false)),
+    },
+    ({ json, statusline, swiftbar, maxAge, fresh }) => {
+        if (!Number.isInteger(maxAge) || maxAge < 0) {
+            fail(`ax quota: --max-age must be a non-negative integer of seconds (got "${maxAge}")`);
+        }
+        if ([json, statusline, swiftbar].filter(Boolean).length > 1) {
+            fail("ax quota: --json, --statusline, and --swiftbar are mutually exclusive");
+        }
+        return cmdQuota({
+            json,
+            statusline,
+            swiftbar,
+            maxAgeSeconds: fresh ? 0 : maxAge,
+        });
+    },
+).pipe(
+    Command.withDescription(
+        "Claude plan quota: 5h/7d window utilization from the Anthropic usage endpoint. " +
+        "--json  --statusline (one line)  --swiftbar (menubar plugin)  --max-age=N seconds (default 60)  --fresh",
+    ),
+);
+
+export const quotaRuntime: RuntimeManifest = {
+    quota: "none",
+};

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -16,6 +16,7 @@ import { starCommand, starRuntime } from "./commands/star.ts";
 import { dogfoodCommand, dogfoodRuntime } from "./commands/dogfood.ts";
 import { costsGroupCommand, locCommand, pricingCommand, costsRuntime } from "./commands/costs.ts";
 import { costCommand, axCostRuntime } from "./commands/ax-cost.ts";
+import { quotaCommand, quotaRuntime } from "./commands/quota.ts";
 import { profileCommand, axProfileRuntime } from "./commands/profile.ts";
 import { dispatchesRootCommand, axDispatchesRuntime } from "./commands/ax-dispatches.ts";
 import { routingRootCommand, axRoutingRuntime } from "./commands/ax-routing.ts";
@@ -77,6 +78,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...dogfoodRuntime,
     ...costsRuntime,
     ...axCostRuntime,
+    ...quotaRuntime,
     ...axProfileRuntime,
     ...axDispatchesRuntime,
     ...axRoutingRuntime,
@@ -117,6 +119,7 @@ const registeredCommands: ReadonlyArray<Command.Command.Any> = [
     installCommand,
     setupCommand,
     costCommand,
+    quotaCommand,
     profileCommand,
     dispatchesRootCommand,
     routingRootCommand,

--- a/apps/axctl/src/quota/cache.ts
+++ b/apps/axctl/src/quota/cache.ts
@@ -1,0 +1,45 @@
+/**
+ * On-disk quota cache: one JSON snapshot at ~/.ax/quota-cache.json. The
+ * statusline integration fires `ax quota --statusline` every render tick, so
+ * reads must be cheap and the endpoint must not be hammered - the cache TTL
+ * (default 60s) bounds the poll rate regardless of caller cadence. Reads
+ * never throw; corruption degrades to "no cache". Atomic write mirrors
+ * profile/publish-state.ts (Bun.write tmp + mv; node:fs is banned by the
+ * check:no-node-fs CI gate).
+ */
+import { decodeQuotaSnapshot, type QuotaSnapshot } from "./schema.ts";
+import { decodeJsonOrNull } from "@ax/lib/decode";
+
+export const defaultQuotaCachePath = (): string =>
+    `${process.env.HOME}/.ax/quota-cache.json`;
+
+export async function loadQuotaCache(path: string): Promise<QuotaSnapshot | null> {
+    try {
+        const file = Bun.file(path);
+        if (!(await file.exists())) return null;
+        return decodeQuotaSnapshot(decodeJsonOrNull(await file.text()));
+    } catch {
+        return null;
+    }
+}
+
+export async function saveQuotaCache(path: string, snapshot: QuotaSnapshot): Promise<void> {
+    const tmp = `${path}.${process.pid}.tmp`;
+    await Bun.write(tmp, `${JSON.stringify(snapshot, null, 2)}\n`, { createPath: true });
+    const result = Bun.spawnSync(["mv", tmp, path]);
+    if (result.exitCode !== 0) {
+        Bun.spawnSync(["rm", "-f", tmp]);
+        throw new Error(`saveQuotaCache: mv ${tmp} -> ${path} failed (exit ${result.exitCode})`);
+    }
+}
+
+/** Snapshot age check; a malformed fetched_at counts as stale. */
+export const isFresh = (
+    snapshot: QuotaSnapshot,
+    nowMs: number,
+    maxAgeSeconds: number,
+): boolean => {
+    const fetchedMs = Date.parse(snapshot.fetched_at);
+    if (!Number.isFinite(fetchedMs)) return false;
+    return nowMs - fetchedMs < maxAgeSeconds * 1000;
+};

--- a/apps/axctl/src/quota/format.test.ts
+++ b/apps/axctl/src/quota/format.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { agoText, fmtReset, renderQuotaTable, renderStatusline, renderSwiftBar } from "./format.ts";
+import type { QuotaSnapshot } from "./schema.ts";
+
+const NOW_MS = Date.parse("2026-06-12T12:00:00.000Z");
+const UTC = { nowMs: NOW_MS, timeZone: "UTC" };
+
+const snapshot: QuotaSnapshot = {
+    v: 1,
+    fetched_at: "2026-06-12T11:59:48.000Z",
+    five_hour: { utilization: 88.0, resets_at: "2026-06-12T15:30:00.000Z" },
+    seven_day: { utilization: 51.0, resets_at: "2026-06-15T21:00:00.000Z" },
+    seven_day_opus: null,
+    seven_day_sonnet: { utilization: 4.0, resets_at: "2026-06-15T21:00:00.000Z" },
+    extra_usage: { is_enabled: false, utilization: null, used_credits: null, monthly_limit: null },
+};
+
+describe("fmtReset", () => {
+    test("same-day reset is bare time", () => {
+        expect(fmtReset("2026-06-12T15:30:00.000Z", UTC)).toBe("15:30");
+    });
+    test("later reset gains a weekday", () => {
+        expect(fmtReset("2026-06-15T21:00:00.000Z", UTC)).toBe("Mon 21:00");
+    });
+    test("garbage is '?'", () => {
+        expect(fmtReset("not-a-date", UTC)).toBe("?");
+    });
+});
+
+describe("agoText", () => {
+    test("seconds, minutes, hours", () => {
+        expect(agoText("2026-06-12T11:59:48.000Z", NOW_MS)).toBe("12s ago");
+        expect(agoText("2026-06-12T11:55:00.000Z", NOW_MS)).toBe("5m ago");
+        expect(agoText("2026-06-12T09:00:00.000Z", NOW_MS)).toBe("3h ago");
+    });
+});
+
+describe("renderStatusline", () => {
+    test("compact 5h + 7d line", () => {
+        expect(renderStatusline(snapshot, UTC)).toBe("5h 88% → 15:30 · 7d 51%");
+    });
+    test("empty snapshot degrades", () => {
+        expect(
+            renderStatusline(
+                { ...snapshot, five_hour: null, seven_day: null, seven_day_sonnet: null },
+                UTC,
+            ),
+        ).toBe("quota n/a");
+    });
+});
+
+describe("renderQuotaTable", () => {
+    test("lists windows with resets and footer", () => {
+        const out = renderQuotaTable(snapshot, { ...UTC, sourceNote: "live" });
+        expect(out).toContain("5h            88%  15:30");
+        expect(out).toContain("7d            51%  Mon 21:00");
+        expect(out).toContain("7d sonnet      4%  Mon 21:00");
+        expect(out).toContain("extra         off");
+        expect(out).toContain("(fetched 12s ago, live)");
+    });
+});
+
+describe("renderSwiftBar", () => {
+    test("title from 5h window, color at >=75 peak", () => {
+        const out = renderSwiftBar(snapshot, UTC).split("\n");
+        expect(out[0]).toBe("◕ 88% | color=orange");
+        expect(out[1]).toBe("---");
+        expect(out).toContain("5h: 88% - resets 15:30");
+        expect(out).toContain("7d: 51% - resets Mon 21:00");
+        expect(out).toContain("extra usage: off");
+    });
+    test("red at >=90", () => {
+        const hot = {
+            ...snapshot,
+            five_hour: { utilization: 95, resets_at: "2026-06-12T15:30:00.000Z" },
+        };
+        expect(renderSwiftBar(hot, UTC).split("\n")[0]).toBe("● 95% | color=red");
+    });
+    test("no windows degrades", () => {
+        const empty = {
+            ...snapshot,
+            five_hour: null,
+            seven_day: null,
+            seven_day_sonnet: null,
+        };
+        expect(renderSwiftBar(empty, UTC).split("\n")[0]).toBe("◌ quota n/a");
+    });
+});

--- a/apps/axctl/src/quota/format.ts
+++ b/apps/axctl/src/quota/format.ts
@@ -1,0 +1,155 @@
+/**
+ * Pure renderers over a QuotaSnapshot: human table (`ax quota`), one-line
+ * statusline (`--statusline`, wired into the Claude Code statusLine command),
+ * and SwiftBar/xbar plugin output (`--swiftbar`, menubar). All take nowMs +
+ * an optional IANA timeZone so tests are deterministic.
+ */
+import type { QuotaSnapshot, QuotaWindow } from "./schema.ts";
+
+export interface RenderOptions {
+    readonly nowMs: number;
+    /** IANA zone for reset times; defaults to the system zone. */
+    readonly timeZone?: string;
+}
+
+const pct = (utilization: number): string => `${Math.round(utilization)}%`;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** "15:30" when the reset lands within 24h, "Thu 21:00" otherwise. */
+export const fmtReset = (iso: string, options: RenderOptions): string => {
+    const ms = Date.parse(iso);
+    if (!Number.isFinite(ms)) return "?";
+    const date = new Date(ms);
+    const time = date.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+        timeZone: options.timeZone,
+    });
+    if (ms - options.nowMs < DAY_MS) return time;
+    const day = date.toLocaleDateString("en-US", {
+        weekday: "short",
+        timeZone: options.timeZone,
+    });
+    return `${day} ${time}`;
+};
+
+export const agoText = (fetchedAtIso: string, nowMs: number): string => {
+    const ms = Date.parse(fetchedAtIso);
+    if (!Number.isFinite(ms)) return "?";
+    const seconds = Math.max(0, Math.round((nowMs - ms) / 1000));
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.round(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    return `${Math.round(minutes / 60)}h ago`;
+};
+
+interface LabeledWindow {
+    readonly label: string;
+    readonly window: QuotaWindow;
+}
+
+const labeledWindows = (snapshot: QuotaSnapshot): LabeledWindow[] => {
+    const rows: LabeledWindow[] = [];
+    if (snapshot.five_hour) rows.push({ label: "5h", window: snapshot.five_hour });
+    if (snapshot.seven_day) rows.push({ label: "7d", window: snapshot.seven_day });
+    if (snapshot.seven_day_opus) rows.push({ label: "7d opus", window: snapshot.seven_day_opus });
+    if (snapshot.seven_day_sonnet) rows.push({ label: "7d sonnet", window: snapshot.seven_day_sonnet });
+    return rows;
+};
+
+// ---------------------------------------------------------------------------
+// ax quota (table)
+// ---------------------------------------------------------------------------
+
+export const renderQuotaTable = (
+    snapshot: QuotaSnapshot,
+    options: RenderOptions & { readonly sourceNote: string },
+): string => {
+    const rows = labeledWindows(snapshot);
+    if (rows.length === 0) return "(usage endpoint returned no quota windows)";
+    const lines: string[] = [];
+    lines.push(`${"window".padEnd(10)}  ${"used".padStart(5)}  resets`);
+    for (const { label, window } of rows) {
+        lines.push(
+            `${label.padEnd(10)}  ${pct(window.utilization).padStart(5)}  ${fmtReset(window.resets_at, options)}`,
+        );
+    }
+    const extra = snapshot.extra_usage;
+    if (extra !== null) {
+        const detail =
+            extra.is_enabled && extra.utilization !== null
+                ? pct(extra.utilization)
+                : extra.is_enabled
+                    ? "on"
+                    : "off";
+        lines.push(`${"extra".padEnd(10)}  ${detail.padStart(5)}`);
+    }
+    lines.push("");
+    lines.push(`(fetched ${agoText(snapshot.fetched_at, options.nowMs)}, ${options.sourceNote})`);
+    return lines.join("\n");
+};
+
+// ---------------------------------------------------------------------------
+// --statusline (one line, no ANSI - composes into any statusline command)
+// ---------------------------------------------------------------------------
+
+export const renderStatusline = (snapshot: QuotaSnapshot, options: RenderOptions): string => {
+    const parts: string[] = [];
+    if (snapshot.five_hour) {
+        parts.push(
+            `5h ${pct(snapshot.five_hour.utilization)} → ${fmtReset(snapshot.five_hour.resets_at, options)}`,
+        );
+    }
+    if (snapshot.seven_day) {
+        parts.push(`7d ${pct(snapshot.seven_day.utilization)}`);
+    }
+    return parts.length > 0 ? parts.join(" · ") : "quota n/a";
+};
+
+// ---------------------------------------------------------------------------
+// --swiftbar (SwiftBar/xbar plugin body: title, ---, dropdown lines)
+// ---------------------------------------------------------------------------
+
+const TITLE_GLYPHS: ReadonlyArray<readonly [number, string]> = [
+    [90, "●"],
+    [75, "◕"],
+    [50, "◑"],
+    [25, "◔"],
+    [0, "○"],
+];
+
+const titleGlyph = (utilization: number): string => {
+    for (const [threshold, glyph] of TITLE_GLYPHS) {
+        if (utilization >= threshold) return glyph;
+    }
+    return "○";
+};
+
+export const renderSwiftBar = (snapshot: QuotaSnapshot, options: RenderOptions): string => {
+    const rows = labeledWindows(snapshot);
+    const peak = Math.max(0, ...rows.map((r) => r.window.utilization));
+    const color = peak >= 90 ? " | color=red" : peak >= 75 ? " | color=orange" : "";
+    const headline = snapshot.five_hour ?? snapshot.seven_day;
+    const title =
+        headline === null
+            ? "◌ quota n/a"
+            : `${titleGlyph(peak)} ${pct(headline.utilization)}${color}`;
+    const lines: string[] = [title, "---", "Claude plan usage"];
+    for (const { label, window } of rows) {
+        lines.push(
+            `${label}: ${pct(window.utilization)} - resets ${fmtReset(window.resets_at, options)}`,
+        );
+    }
+    const extra = snapshot.extra_usage;
+    if (extra !== null) {
+        lines.push(
+            extra.is_enabled
+                ? `extra usage: ${extra.utilization !== null ? pct(extra.utilization) : "on"}`
+                : "extra usage: off",
+        );
+    }
+    lines.push(`fetched ${agoText(snapshot.fetched_at, options.nowMs)}`);
+    return lines.join("\n");
+};

--- a/apps/axctl/src/quota/quota-env.ts
+++ b/apps/axctl/src/quota/quota-env.ts
@@ -1,0 +1,133 @@
+/**
+ * QuotaEnv - the single seam through which `ax quota` reads the Claude Code
+ * OAuth token and calls the Anthropic usage endpoint. Live layer reads the
+ * macOS Keychain (`Claude Code-credentials`, where the Claude Code CLI
+ * stores its OAuth credentials) with a `~/.claude/.credentials.json`
+ * fallback for Linux/older installs, then fetches
+ * `api.anthropic.com/api/oauth/usage` with the Bearer token. ax never
+ * refreshes the token - the running Claude Code CLI rotates it; we just
+ * read whatever is current. Mirrors profile/github-env.ts.
+ */
+import { Context, Effect, Layer, Schema } from "effect";
+import { decodeJsonOrNull } from "@ax/lib/decode";
+
+export class QuotaApiError extends Schema.TaggedErrorClass<QuotaApiError>(
+    "QuotaApiError",
+)("QuotaApiError", {
+    status: Schema.Number,
+    message: Schema.String,
+}) {}
+
+const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+
+export interface QuotaEnvService {
+    /** OAuth access token, or null when no Claude Code credentials exist. */
+    readonly readToken: () => Effect.Effect<string | null>;
+    /** Raw JSON body of the usage endpoint (decoded by quota/schema.ts). */
+    readonly fetchUsage: (token: string) => Effect.Effect<unknown, QuotaApiError>;
+}
+
+export class QuotaEnv extends Context.Service<QuotaEnv, QuotaEnvService>()(
+    "axctl/quota/QuotaEnv",
+) {}
+
+/** `{ claudeAiOauth: { accessToken } }` - shared shape of keychain + file creds. */
+const tokenFromCredentialsJson = (raw: string): string | null => {
+    const parsed = decodeJsonOrNull(raw);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const oauth = (parsed as Record<string, unknown>).claudeAiOauth;
+    if (typeof oauth !== "object" || oauth === null) return null;
+    const token = (oauth as Record<string, unknown>).accessToken;
+    return typeof token === "string" && token.length > 0 ? token : null;
+};
+
+const readTokenLive = async (): Promise<string | null> => {
+    // macOS Keychain first - the canonical Claude Code credential store.
+    try {
+        const proc = Bun.spawnSync(
+            ["security", "find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"],
+            { stdout: "pipe", stderr: "ignore" },
+        );
+        if (proc.exitCode === 0) {
+            const token = tokenFromCredentialsJson(proc.stdout.toString().trim());
+            if (token !== null) return token;
+        }
+    } catch {
+        // `security` missing (non-macOS) - fall through to the file.
+    }
+    try {
+        const file = Bun.file(`${process.env.HOME}/.claude/.credentials.json`);
+        if (await file.exists()) return tokenFromCredentialsJson(await file.text());
+    } catch {
+        // unreadable file degrades to "no token"
+    }
+    return null;
+};
+
+const fetchUsageLive = async (token: string): Promise<unknown> => {
+    let response: Response;
+    try {
+        response = await fetch(USAGE_URL, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "anthropic-beta": "oauth-2025-04-20",
+            },
+        });
+    } catch (e) {
+        throw new QuotaApiError({
+            status: 0,
+            message: e instanceof Error ? e.message : String(e),
+        });
+    }
+    if (!response.ok) {
+        throw new QuotaApiError({
+            status: response.status,
+            message: `GET ${USAGE_URL} -> HTTP ${response.status}`,
+        });
+    }
+    const body = decodeJsonOrNull(await response.text());
+    if (body === null) {
+        throw new QuotaApiError({ status: 0, message: "usage endpoint returned non-JSON body" });
+    }
+    return body;
+};
+
+const liveShape: QuotaEnvService = {
+    readToken: () =>
+        Effect.promise(() => readTokenLive()).pipe(Effect.orElseSucceed(() => null)),
+    fetchUsage: (token) =>
+        Effect.tryPromise({
+            try: () => fetchUsageLive(token),
+            catch: (e) =>
+                e instanceof QuotaApiError
+                    ? e
+                    : new QuotaApiError({ status: 0, message: e instanceof Error ? e.message : String(e) }),
+        }),
+};
+
+export const QuotaEnvLive: Layer.Layer<QuotaEnv> = Layer.succeed(QuotaEnv, liveShape);
+
+/**
+ * Test layer: canned token + usage payload; records fetch calls. A `usage`
+ * value of `{ __error: { status, message } }` injects a QuotaApiError.
+ */
+export const QuotaEnvTest = (config: {
+    token: string | null;
+    usage?: unknown;
+}): { layer: Layer.Layer<QuotaEnv>; fetchCalls: string[] } => {
+    const fetchCalls: string[] = [];
+    const layer = Layer.succeed(QuotaEnv, {
+        readToken: () => Effect.succeed(config.token),
+        fetchUsage: (token) => {
+            fetchCalls.push(token);
+            const value = config.usage;
+            if (typeof value === "object" && value !== null && "__error" in value) {
+                const e = (value as { __error: { status: number; message: string } }).__error;
+                return Effect.fail(new QuotaApiError({ status: e.status, message: e.message }));
+            }
+            return Effect.succeed(value);
+        },
+    });
+    return { layer, fetchCalls };
+};

--- a/apps/axctl/src/quota/quota.test.ts
+++ b/apps/axctl/src/quota/quota.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { isFresh, loadQuotaCache, saveQuotaCache } from "./cache.ts";
+import { QuotaEnvTest } from "./quota-env.ts";
+import { getQuota } from "./quota.ts";
+import type { QuotaSnapshot } from "./schema.ts";
+
+const NOW_MS = Date.parse("2026-06-12T12:00:00.000Z");
+
+const USAGE_PAYLOAD = {
+    five_hour: { utilization: 88.0, resets_at: "2026-06-12T15:30:00.000Z" },
+    seven_day: { utilization: 51.0, resets_at: "2026-06-15T21:00:00.000Z" },
+    seven_day_opus: null,
+    seven_day_sonnet: null,
+    extra_usage: null,
+};
+
+const snapshotAt = (fetchedAtIso: string): QuotaSnapshot => ({
+    v: 1,
+    fetched_at: fetchedAtIso,
+    five_hour: { utilization: 12, resets_at: "2026-06-12T15:30:00.000Z" },
+    seven_day: { utilization: 3, resets_at: "2026-06-15T21:00:00.000Z" },
+    seven_day_opus: null,
+    seven_day_sonnet: null,
+    extra_usage: null,
+});
+
+const tmpPaths: string[] = [];
+const tmpCachePath = (name: string): string => {
+    const path = `/tmp/ax-quota-test-${process.pid}-${name}.json`;
+    tmpPaths.push(path);
+    return path;
+};
+
+afterEach(() => {
+    for (const path of tmpPaths.splice(0)) Bun.spawnSync(["rm", "-f", path]);
+});
+
+describe("cache", () => {
+    test("save/load round-trip; missing + corrupt load as null", async () => {
+        const path = tmpCachePath("roundtrip");
+        const snapshot = snapshotAt("2026-06-12T11:59:00.000Z");
+        await saveQuotaCache(path, snapshot);
+        expect(await loadQuotaCache(path)).toEqual(snapshot);
+        expect(await loadQuotaCache(`${path}.missing`)).toBeNull();
+        await Bun.write(path, "{corrupt");
+        expect(await loadQuotaCache(path)).toBeNull();
+    });
+
+    test("isFresh respects TTL and malformed timestamps", () => {
+        expect(isFresh(snapshotAt("2026-06-12T11:59:30.000Z"), NOW_MS, 60)).toBe(true);
+        expect(isFresh(snapshotAt("2026-06-12T11:58:00.000Z"), NOW_MS, 60)).toBe(false);
+        expect(isFresh(snapshotAt("garbage"), NOW_MS, 60)).toBe(false);
+        // TTL 0 = force refetch even for a snapshot from "now"
+        expect(isFresh(snapshotAt("2026-06-12T12:00:00.000Z"), NOW_MS, 0)).toBe(false);
+    });
+});
+
+describe("getQuota", () => {
+    test("fresh cache short-circuits the fetch", async () => {
+        const path = tmpCachePath("fresh");
+        await saveQuotaCache(path, snapshotAt("2026-06-12T11:59:30.000Z"));
+        const env = QuotaEnvTest({ token: "tok", usage: USAGE_PAYLOAD });
+        const result = await Effect.runPromise(
+            getQuota({ cachePath: path, maxAgeSeconds: 60, nowMs: NOW_MS }).pipe(
+                Effect.provide(env.layer),
+            ),
+        );
+        expect(result.source).toBe("cache");
+        expect(result.snapshot.five_hour?.utilization).toBe(12);
+        expect(env.fetchCalls).toEqual([]);
+    });
+
+    test("stale cache triggers live fetch and rewrites the cache", async () => {
+        const path = tmpCachePath("stale");
+        await saveQuotaCache(path, snapshotAt("2026-06-12T11:00:00.000Z"));
+        const env = QuotaEnvTest({ token: "tok", usage: USAGE_PAYLOAD });
+        const result = await Effect.runPromise(
+            getQuota({ cachePath: path, maxAgeSeconds: 60, nowMs: NOW_MS }).pipe(
+                Effect.provide(env.layer),
+            ),
+        );
+        expect(result.source).toBe("live");
+        expect(result.snapshot.five_hour?.utilization).toBe(88);
+        expect(env.fetchCalls).toEqual(["tok"]);
+        expect((await loadQuotaCache(path))?.five_hour?.utilization).toBe(88);
+    });
+
+    test("fetch failure falls back to stale cache", async () => {
+        const path = tmpCachePath("fallback");
+        await saveQuotaCache(path, snapshotAt("2026-06-12T11:00:00.000Z"));
+        const env = QuotaEnvTest({
+            token: "tok",
+            usage: { __error: { status: 503, message: "down" } },
+        });
+        const result = await Effect.runPromise(
+            getQuota({ cachePath: path, maxAgeSeconds: 60, nowMs: NOW_MS }).pipe(
+                Effect.provide(env.layer),
+            ),
+        );
+        expect(result.source).toBe("stale-cache");
+        expect(result.snapshot.five_hour?.utilization).toBe(12);
+    });
+
+    test("no token + no cache fails QuotaTokenMissing", async () => {
+        const env = QuotaEnvTest({ token: null });
+        const exit = await Effect.runPromiseExit(
+            getQuota({
+                cachePath: tmpCachePath("notoken"),
+                maxAgeSeconds: 60,
+                nowMs: NOW_MS,
+            }).pipe(Effect.provide(env.layer)),
+        );
+        expect(exit._tag).toBe("Failure");
+    });
+
+    test("no token + stale cache degrades to stale-cache", async () => {
+        const path = tmpCachePath("notoken-stale");
+        await saveQuotaCache(path, snapshotAt("2026-06-12T11:00:00.000Z"));
+        const env = QuotaEnvTest({ token: null });
+        const result = await Effect.runPromise(
+            getQuota({ cachePath: path, maxAgeSeconds: 60, nowMs: NOW_MS }).pipe(
+                Effect.provide(env.layer),
+            ),
+        );
+        expect(result.source).toBe("stale-cache");
+    });
+
+    test("fetch failure with no cache propagates the api error", async () => {
+        const env = QuotaEnvTest({
+            token: "tok",
+            usage: { __error: { status: 401, message: "expired" } },
+        });
+        const exit = await Effect.runPromiseExit(
+            getQuota({
+                cachePath: tmpCachePath("hardfail"),
+                maxAgeSeconds: 60,
+                nowMs: NOW_MS,
+            }).pipe(Effect.provide(env.layer)),
+        );
+        expect(exit._tag).toBe("Failure");
+    });
+});

--- a/apps/axctl/src/quota/quota.ts
+++ b/apps/axctl/src/quota/quota.ts
@@ -1,0 +1,71 @@
+/**
+ * Quota orchestrator: cache-first read of the Anthropic plan-usage windows.
+ *
+ * Resolution order: fresh cache -> live fetch (then cache it) -> stale cache
+ * as a degraded fallback when the fetch fails (so the statusline doesn't
+ * flap on transient network errors). Token-missing and hard fetch failures
+ * with no cache surface as typed errors for the CLI layer to render.
+ */
+import { Effect, Schema } from "effect";
+import { isFresh, loadQuotaCache, saveQuotaCache } from "./cache.ts";
+import { QuotaApiError, QuotaEnv } from "./quota-env.ts";
+import { toQuotaSnapshot, type QuotaSnapshot } from "./schema.ts";
+
+export class QuotaTokenMissing extends Schema.TaggedErrorClass<QuotaTokenMissing>(
+    "QuotaTokenMissing",
+)("QuotaTokenMissing", {}) {}
+
+export type QuotaSource = "cache" | "live" | "stale-cache";
+
+export interface QuotaResult {
+    readonly snapshot: QuotaSnapshot;
+    readonly source: QuotaSource;
+}
+
+export interface GetQuotaOptions {
+    readonly cachePath: string;
+    /** Cache TTL in seconds; 0 forces a live fetch. */
+    readonly maxAgeSeconds: number;
+    readonly nowMs: number;
+}
+
+export const getQuota = (
+    options: GetQuotaOptions,
+): Effect.Effect<QuotaResult, QuotaTokenMissing | QuotaApiError, QuotaEnv> =>
+    Effect.gen(function* () {
+        const cached = yield* Effect.promise(() => loadQuotaCache(options.cachePath));
+        if (cached !== null && isFresh(cached, options.nowMs, options.maxAgeSeconds)) {
+            return { snapshot: cached, source: "cache" as const };
+        }
+
+        const env = yield* QuotaEnv;
+        const token = yield* env.readToken();
+        if (token === null) {
+            // A stale cache beats an error for render-only callers.
+            if (cached !== null) return { snapshot: cached, source: "stale-cache" as const };
+            return yield* Effect.fail(new QuotaTokenMissing({}));
+        }
+
+        const fetched = yield* env.fetchUsage(token).pipe(
+            Effect.map((raw) => toQuotaSnapshot(raw, new Date(options.nowMs).toISOString())),
+            Effect.catch((error) =>
+                cached !== null ? Effect.succeed(null) : Effect.fail(error),
+            ),
+        );
+        if (fetched === null) {
+            if (cached !== null) return { snapshot: cached, source: "stale-cache" as const };
+            return yield* Effect.fail(
+                new QuotaApiError({ status: 0, message: "usage endpoint returned an unrecognized shape" }),
+            );
+        }
+
+        // Cache-write failure must not break a successful read.
+        yield* Effect.promise(async () => {
+            try {
+                await saveQuotaCache(options.cachePath, fetched);
+            } catch {
+                // degraded: next call refetches
+            }
+        });
+        return { snapshot: fetched, source: "live" as const };
+    });

--- a/apps/axctl/src/quota/schema.test.ts
+++ b/apps/axctl/src/quota/schema.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { decodeQuotaSnapshot, toQuotaSnapshot } from "./schema.ts";
+
+/** Live response shape captured from api.anthropic.com/api/oauth/usage (2026-06-12). */
+const LIVE_PAYLOAD = {
+    five_hour: { utilization: 88.0, resets_at: "2026-06-12T15:30:00.459756+00:00" },
+    seven_day: { utilization: 51.0, resets_at: "2026-06-12T21:00:00.459780+00:00" },
+    seven_day_oauth_apps: null,
+    seven_day_opus: null,
+    seven_day_sonnet: { utilization: 4.0, resets_at: "2026-06-12T21:00:00.459791+00:00" },
+    // Unknown experiment fields the endpoint ships today - must be ignored.
+    seven_day_cowork: null,
+    tangelo: null,
+    iguana_necktie: null,
+    extra_usage: {
+        is_enabled: false,
+        monthly_limit: null,
+        used_credits: null,
+        utilization: null,
+        currency: null,
+        disabled_reason: null,
+    },
+};
+
+const FETCHED_AT = "2026-06-12T12:00:00.000Z";
+
+describe("toQuotaSnapshot", () => {
+    test("decodes the live payload shape", () => {
+        const snapshot = toQuotaSnapshot(LIVE_PAYLOAD, FETCHED_AT);
+        expect(snapshot).not.toBeNull();
+        expect(snapshot?.five_hour).toEqual({
+            utilization: 88.0,
+            resets_at: "2026-06-12T15:30:00.459756+00:00",
+        });
+        expect(snapshot?.seven_day?.utilization).toBe(51.0);
+        expect(snapshot?.seven_day_opus).toBeNull();
+        expect(snapshot?.seven_day_sonnet?.utilization).toBe(4.0);
+        expect(snapshot?.extra_usage).toEqual({
+            is_enabled: false,
+            utilization: null,
+            used_credits: null,
+            monthly_limit: null,
+        });
+        expect(snapshot?.fetched_at).toBe(FETCHED_AT);
+    });
+
+    test("tolerates missing optional windows", () => {
+        const snapshot = toQuotaSnapshot(
+            { five_hour: { utilization: 10, resets_at: FETCHED_AT } },
+            FETCHED_AT,
+        );
+        expect(snapshot?.five_hour?.utilization).toBe(10);
+        expect(snapshot?.seven_day).toBeNull();
+        expect(snapshot?.extra_usage).toBeNull();
+    });
+
+    test("rejects garbage", () => {
+        expect(toQuotaSnapshot("nope", FETCHED_AT)).toBeNull();
+        expect(toQuotaSnapshot(null, FETCHED_AT)).toBeNull();
+        expect(
+            toQuotaSnapshot({ five_hour: { utilization: "88", resets_at: 5 } }, FETCHED_AT),
+        ).toBeNull();
+    });
+});
+
+describe("decodeQuotaSnapshot", () => {
+    test("round-trips a snapshot through JSON (cache format)", () => {
+        const snapshot = toQuotaSnapshot(LIVE_PAYLOAD, FETCHED_AT);
+        const reread = decodeQuotaSnapshot(JSON.parse(JSON.stringify(snapshot)));
+        expect(reread).toEqual(snapshot);
+    });
+
+    test("rejects wrong version / shape", () => {
+        expect(decodeQuotaSnapshot({ v: 2, fetched_at: FETCHED_AT })).toBeNull();
+        expect(decodeQuotaSnapshot({})).toBeNull();
+    });
+});

--- a/apps/axctl/src/quota/schema.ts
+++ b/apps/axctl/src/quota/schema.ts
@@ -1,0 +1,93 @@
+/**
+ * Wire + snapshot types for Anthropic plan-quota usage (claude-meter parity).
+ *
+ * Source endpoint is the undocumented `api.anthropic.com/api/oauth/usage`
+ * that the Claude Code CLI's own usage view reads (shape verified live
+ * 2026-06-12). Decode is tolerant: unknown top-level fields are ignored and
+ * every window is nullable, so endpoint drift degrades to missing tiles
+ * instead of a hard failure.
+ */
+import { Option, Schema } from "effect";
+
+export const QuotaWindowSchema = Schema.Struct({
+    utilization: Schema.Number,
+    resets_at: Schema.String,
+});
+export type QuotaWindow = typeof QuotaWindowSchema.Type;
+
+const WireWindow = Schema.optional(Schema.NullOr(QuotaWindowSchema));
+
+const WireExtraUsage = Schema.Struct({
+    is_enabled: Schema.optional(Schema.NullOr(Schema.Boolean)),
+    monthly_limit: Schema.optional(Schema.NullOr(Schema.Number)),
+    used_credits: Schema.optional(Schema.NullOr(Schema.Number)),
+    utilization: Schema.optional(Schema.NullOr(Schema.Number)),
+});
+
+export const UsageResponseSchema = Schema.Struct({
+    five_hour: WireWindow,
+    seven_day: WireWindow,
+    seven_day_opus: WireWindow,
+    seven_day_sonnet: WireWindow,
+    extra_usage: Schema.optional(Schema.NullOr(WireExtraUsage)),
+});
+export type UsageResponse = typeof UsageResponseSchema.Type;
+
+export const ExtraUsageStateSchema = Schema.Struct({
+    is_enabled: Schema.Boolean,
+    utilization: Schema.NullOr(Schema.Number),
+    used_credits: Schema.NullOr(Schema.Number),
+    monthly_limit: Schema.NullOr(Schema.Number),
+});
+export type ExtraUsageState = typeof ExtraUsageStateSchema.Type;
+
+/**
+ * Timestamped view of one usage fetch - the single shape every renderer
+ * (table, statusline, SwiftBar, --json) and the on-disk cache consume.
+ */
+export const QuotaSnapshotSchema = Schema.Struct({
+    v: Schema.Literal(1),
+    fetched_at: Schema.String,
+    five_hour: Schema.NullOr(QuotaWindowSchema),
+    seven_day: Schema.NullOr(QuotaWindowSchema),
+    seven_day_opus: Schema.NullOr(QuotaWindowSchema),
+    seven_day_sonnet: Schema.NullOr(QuotaWindowSchema),
+    extra_usage: Schema.NullOr(ExtraUsageStateSchema),
+});
+export type QuotaSnapshot = typeof QuotaSnapshotSchema.Type;
+
+const decodeUsage = Schema.decodeUnknownOption(UsageResponseSchema);
+const decodeSnapshot = Schema.decodeUnknownOption(QuotaSnapshotSchema);
+
+export const decodeQuotaSnapshot = (raw: unknown): QuotaSnapshot | null => {
+    const result = decodeSnapshot(raw);
+    return Option.isSome(result) ? result.value : null;
+};
+
+const window = (w: QuotaWindow | null | undefined): QuotaWindow | null =>
+    w == null ? null : { utilization: w.utilization, resets_at: w.resets_at };
+
+/** Decode one raw usage-endpoint payload into a snapshot; null = unparseable. */
+export const toQuotaSnapshot = (raw: unknown, fetchedAt: string): QuotaSnapshot | null => {
+    const result = decodeUsage(raw);
+    if (Option.isNone(result)) return null;
+    const usage = result.value;
+    const extra = usage.extra_usage;
+    return {
+        v: 1,
+        fetched_at: fetchedAt,
+        five_hour: window(usage.five_hour),
+        seven_day: window(usage.seven_day),
+        seven_day_opus: window(usage.seven_day_opus),
+        seven_day_sonnet: window(usage.seven_day_sonnet),
+        extra_usage:
+            extra == null
+                ? null
+                : {
+                    is_enabled: extra.is_enabled ?? false,
+                    utilization: extra.utilization ?? null,
+                    used_credits: extra.used_credits ?? null,
+                    monthly_limit: extra.monthly_limit ?? null,
+                },
+    };
+};

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -33,6 +33,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `efficient-dispatch` skill - orchestration pattern: the main model keeps judgment and review, mechanical dispatches carry an explicit cheaper model
 - `route-dispatch` hook - deterministic dispatch-time nudge when a mechanical dispatch forgets an explicit model
 - `ax costs summary | for --session/--query/--commit/--branch` - what any session, feature, or branch cost in tokens and USD
+- `ax quota [--statusline|--swiftbar|--json]` - live Claude plan usage (5h/7d windows) from the Anthropic usage endpoint, cached locally; one-line statusline output and a SwiftBar menubar plugin ship with it
 
 ### Profile
 - `ax profile show [--window=N] [--no-cost]` - your local agent profile rendered from the graph: usage stats, rig (skills/hooks/rules), and evidence-grounded taste patterns

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,7 @@ axctl costs for --terms <a,b,c> [--since=N] # cost for sessions matching any ter
 axctl costs for --commit <sha>              # cost for sessions that produced a commit
 axctl costs for --branch <name>             # cost for sessions linked to a branch
 axctl cost <models|sessions|split>          # model/cost analytics incl. main-vs-subagent split
+axctl quota [--statusline|--swiftbar]       # Claude plan usage (5h/7d windows); statusline + menubar output
 axctl dispatches [--candidates]             # subagent dispatch routing analytics + est savings
 axctl routing tune [--dry-run|--emit-brief] # mine YOUR dispatch history for new routing classes
 axctl routing compile                       # regenerate ~/.ax/hooks/routing-table.json (user classes preserved)

--- a/scripts/swiftbar/ax-quota.2m.sh
+++ b/scripts/swiftbar/ax-quota.2m.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# <xbar.title>ax quota</xbar.title>
+# <xbar.desc>Claude plan usage (5h/7d windows) in the menubar, via `ax quota`.</xbar.desc>
+# <xbar.dependencies>axctl</xbar.dependencies>
+#
+# SwiftBar/xbar plugin. Install:
+#   cp scripts/swiftbar/ax-quota.2m.sh "$(defaults read com.ameba.SwiftBar PluginDirectory)/"
+#   chmod +x ".../ax-quota.2m.sh"
+# The "2m" in the filename is the refresh cadence; the endpoint itself is
+# only polled when the ax-side cache (default 60s TTL) has expired.
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+AX_BIN="$(command -v ax || command -v axctl || true)"
+if [ -z "$AX_BIN" ]; then
+    echo "◌ ax?"
+    echo "---"
+    echo "ax CLI not found on PATH | color=red"
+    exit 0
+fi
+
+"$AX_BIN" quota --swiftbar --max-age=90


### PR DESCRIPTION
## What

claude-meter (https://github.com/m13v/claude-meter) parity inside ax: `ax quota` surfaces your Claude plan's 5-hour / 7-day usage windows from the same undocumented `api.anthropic.com/api/oauth/usage` endpoint, with three render targets:

- `ax quota` — human table (used %, reset times, extra-usage state)
- `ax quota --statusline` — one plain line for the Claude Code `statusLine` command:
  ```json
  { "statusLine": { "type": "command", "command": "axctl quota --statusline" } }
  ```
  → `5h 93% → 23:30 · 7d 52%`
- `ax quota --swiftbar` — SwiftBar/xbar plugin body; `scripts/swiftbar/ax-quota.2m.sh` is the installable menubar plugin (glyph + color escalation at 75%/90%)
- `ax quota --json` — snapshot + source for scripting

## How

- Token: read-only from the macOS Keychain (`Claude Code-credentials`), fallback `~/.claude/.credentials.json` (Linux/older installs). ax never refreshes it — the Claude Code CLI rotates it.
- `QuotaEnv` seam (mirrors `profile/github-env.ts`): Live layer = keychain + fetch; Test layer = canned responses + recorded calls, so the orchestrator is fully testable offline.
- Tolerant Schema decode: every window nullable, unknown endpoint fields ignored — endpoint drift degrades to missing rows, not a crash.
- Cache at `~/.ax/quota-cache.json` (atomic tmp+mv, no node:fs), default TTL 60s, `--max-age=N` / `--fresh` overrides. Statusline/menubar can poll every render tick without hammering the endpoint; fetch failures and missing-token degrade to stale cache, and render-only modes print `quota n/a` instead of error dumps.
- Runtime `"none"` in the CLI manifest (no DB touch); manifest exhaustiveness guard covered by existing `effect-cli.test.ts`.

## Verified

- 60 tests pass (schema decode incl. live-captured payload fixture, cache TTL, orchestrator cache/live/stale paths, all three renderers)
- `bun run typecheck` clean
- Live smoke against the real endpoint: table / statusline / swiftbar / json all render; one fetch shared via cache across calls

## Follow-ups (not in this PR)

- Dashboard quota tile in `ax serve`
- Quota burn × cost-split correlation (which sessions/dispatch classes ate the window) — the part claude-meter can't do
- Electron tray (folds into the parked studio-desktop direction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)