### PR TITLE
feat(hooks-sdk): enforce-worktree keeps the primary tree parked on the default branch

### DIFF
--- a/apps/axctl/src/hooks/backtest.test.ts
+++ b/apps/axctl/src/hooks/backtest.test.ts
@@ -7,7 +7,7 @@ import enforceWorktree from "@ax/hooks-sdk/hooks/enforce-worktree";
 const rows = [
     {
         name: "Bash",
-        input: { command: "git checkout main" },
+        input: { command: "git checkout feat" },
         cwd: "/repo",
         source: "claude",
         project: "/repo",
@@ -42,7 +42,7 @@ describe("replayRows", () => {
             replayRows(enforceWorktree, rows).pipe(Effect.provide(layer)),
         );
 
-        // row 0: git checkout main, cwd=/repo (primary) -> Block
+        // row 0: git checkout feat, cwd=/repo (primary) -> Block
         // row 1: bun test (no git checkout verb) -> Allow
         // row 2: git switch x, cwd=/other (not primary per layer) -> Allow
         expect(results).toHaveLength(3);

--- a/packages/hooks-sdk/src/git-env.test.ts
+++ b/packages/hooks-sdk/src/git-env.test.ts
@@ -28,6 +28,7 @@ describe("GitEnvLive", () => {
         primary: yield* git.isPrimaryTree(repo),
         linked: yield* git.isPrimaryTree(wt),
         branch: yield* git.currentBranch(repo),
+        def: yield* git.defaultBranch(repo),
         root: yield* git.repoRoot(repo),
         dirty: yield* git.isDirty(repo),
         trackedDirty: yield* git.hasTrackedChanges(repo),
@@ -37,6 +38,7 @@ describe("GitEnvLive", () => {
     expect(r.primary).toBe(true);
     expect(r.linked).toBe(false);
     expect(r.branch).toBe("main");
+    expect(r.def).toBe("main"); // no origin/HEAD -> refs/heads/main fallback
     expect(r.root).toBe(realpathSync(repo));
     expect(r.dirty).toBe(false);
     expect(r.trackedDirty).toBe(false);

--- a/packages/hooks-sdk/src/git-env.ts
+++ b/packages/hooks-sdk/src/git-env.ts
@@ -10,6 +10,8 @@ export interface GitEnvService {
   readonly hasTrackedChanges: (dir: string) => Effect.Effect<boolean>;
   /** current branch short name, null when detached/not a repo. */
   readonly currentBranch: (dir: string) => Effect.Effect<string | null>;
+  /** the repo's default branch (origin/HEAD, falling back to main/master). */
+  readonly defaultBranch: (dir: string) => Effect.Effect<string>;
   /** repo toplevel for dir (walking up past not-yet-existing paths), null outside repos. */
   readonly repoRoot: (dir: string) => Effect.Effect<string | null>;
 }
@@ -63,6 +65,26 @@ const liveShape: GitEnvService = {
   currentBranch: (dir) =>
     Effect.sync(() => gitCmd(dir, ["symbolic-ref", "--short", "HEAD"])),
 
+  defaultBranch: (dir) =>
+    Effect.sync(() => {
+      const head = gitCmd(dir, [
+        "symbolic-ref",
+        "--short",
+        "refs/remotes/origin/HEAD",
+      ]);
+      if (head !== null) return head.replace(/^origin\//, "");
+      for (const b of ["main", "master"]) {
+        // gitCmd returns "" (not null) when show-ref exits 0 with no output.
+        if (
+          gitCmd(dir, ["show-ref", "--verify", "--quiet", `refs/heads/${b}`]) !==
+          null
+        ) {
+          return b;
+        }
+      }
+      return "main";
+    }),
+
   repoRoot: (dir) =>
     Effect.sync(() => {
       // Walk up past path segments that don't exist yet (new files staged in
@@ -87,6 +109,7 @@ export const GitEnvTest = (answers: {
   trackedDirty?: ReadonlyArray<string>;
   branches?: Record<string, string>;
   roots?: Record<string, string>;
+  defaults?: Record<string, string>;
 }): Layer.Layer<GitEnv> =>
   Layer.succeed(GitEnv)({
     isPrimaryTree: (dir) =>
@@ -110,5 +133,11 @@ export const GitEnvTest = (answers: {
         Object.entries(answers.roots ?? {}).find(([p]) =>
           dir.startsWith(p),
         )?.[1] ?? null,
+      ),
+    defaultBranch: (dir) =>
+      Effect.succeed(
+        Object.entries(answers.defaults ?? {}).find(([p]) =>
+          dir.startsWith(p),
+        )?.[1] ?? "main",
       ),
   });

--- a/packages/hooks-sdk/src/hooks/enforce-worktree.test.ts
+++ b/packages/hooks-sdk/src/hooks/enforce-worktree.test.ts
@@ -3,18 +3,23 @@ import { Effect } from "effect";
 import enforceWorktree from "./enforce-worktree.ts";
 import { GitEnvTest } from "../git-env.ts";
 
-const run = (command: string, opts?: { dirty?: boolean; trackedDirty?: boolean; primary?: boolean }) => {
+const run = (
+  command: string,
+  opts?: { dirty?: boolean; trackedDirty?: boolean; primary?: boolean; cwd?: string },
+) => {
+  const cwd = opts?.cwd ?? "/repo";
   const layer = GitEnvTest({
     primary: (opts?.primary ?? true) ? ["/repo"] : [],
     dirty: opts?.dirty ? ["/repo"] : [],
     trackedDirty: opts?.trackedDirty ? ["/repo"] : [],
     branches: { "/repo": "main" },
     roots: { "/repo": "/repo" },
+    defaults: { "/repo": "main" },
   });
   return Effect.runPromise(
     enforceWorktree
       .run({
-        harness: "claude", event: "PreToolUse", sessionId: null, cwd: "/repo",
+        harness: "claude", event: "PreToolUse", sessionId: null, cwd,
         tool: { name: "Bash", input: { command } },
         raw: {},
       })
@@ -27,18 +32,27 @@ const withEnv = async (k: string, fn: () => Promise<unknown>) => {
   try { return await fn(); } finally { delete process.env[k]; }
 };
 
-describe("guard A: branch switch on primary tree", () => {
-  test("git checkout main -> Block", async () => {
-    expect((await run("git checkout main"))._tag).toBe("Block");
+describe("guard A: primary tree stays on the default branch", () => {
+  test("git checkout main -> Allow (returning home)", async () => {
+    expect((await run("git checkout main"))._tag).toBe("Allow");
+  });
+  test("git switch main -> Allow (returning home)", async () => {
+    expect((await run("git switch main"))._tag).toBe("Allow");
+  });
+  test("git checkout feat -> Block", async () => {
+    expect((await run("git checkout feat"))._tag).toBe("Block");
   });
   test("git switch other -> Block", async () => {
     expect((await run("git switch other"))._tag).toBe("Block");
   });
-  test("git checkout -b new -> Allow", async () => {
-    expect((await run("git checkout -b new"))._tag).toBe("Allow");
+  test("git checkout -b new -> Block (create drifts primary off main)", async () => {
+    expect((await run("git checkout -b new"))._tag).toBe("Block");
   });
-  test("git switch -c new -> Allow", async () => {
-    expect((await run("git switch -c new"))._tag).toBe("Allow");
+  test("git switch -c new -> Block", async () => {
+    expect((await run("git switch -c new"))._tag).toBe("Block");
+  });
+  test("git checkout -B hotfix -> Block (uppercase create)", async () => {
+    expect((await run("git checkout -B hotfix"))._tag).toBe("Block");
   });
   test("git checkout -- file -> Allow", async () => {
     expect((await run("git checkout -- src/a.ts"))._tag).toBe("Allow");
@@ -46,22 +60,43 @@ describe("guard A: branch switch on primary tree", () => {
   test("git checkout . -> Allow", async () => {
     expect((await run("git checkout ."))._tag).toBe("Allow");
   });
-  test("linked worktree (not primary) -> Allow", async () => {
-    expect((await run("git checkout main", { primary: false }))._tag).toBe("Allow");
+  test("git -C /repo checkout feat from elsewhere -> Block (the -C hole)", async () => {
+    expect((await run("git -C /repo checkout feat", { cwd: "/elsewhere" }))._tag).toBe("Block");
   });
   test("bypass ALLOW_BRANCH_CHECKOUT=1 -> Allow", async () => {
-    const r = await withEnv("ALLOW_BRANCH_CHECKOUT", () => run("git checkout main"));
+    const r = await withEnv("ALLOW_BRANCH_CHECKOUT", () => run("git checkout feat"));
     expect((r as { _tag: string })._tag).toBe("Allow");
   });
   test("inline bypass ALLOW_BRANCH_CHECKOUT=1 -> Allow", async () => {
-    expect((await run("ALLOW_BRANCH_CHECKOUT=1 git checkout main", { dirty: true }))._tag).toBe("Allow");
-  });
-  test("git checkout -B hotfix -> Allow (uppercase create)", async () => {
-    expect((await run("git checkout -B hotfix"))._tag).toBe("Allow");
+    expect((await run("ALLOW_BRANCH_CHECKOUT=1 git checkout feat"))._tag).toBe("Allow");
   });
   test("ALLOW_DIRTY_MAIN_MUTATION=1 does NOT bypass guard A", async () => {
-    const r = await withEnv("ALLOW_DIRTY_MAIN_MUTATION", () => run("git checkout main"));
+    const r = await withEnv("ALLOW_DIRTY_MAIN_MUTATION", () => run("git checkout feat"));
     expect((r as { _tag: string })._tag).toBe("Block");
+  });
+});
+
+describe("guard A: linked worktree must not take the default branch", () => {
+  test("git checkout main in worktree -> Block (locks primary off main)", async () => {
+    expect((await run("git checkout main", { primary: false }))._tag).toBe("Block");
+  });
+  test("git switch main in worktree -> Block", async () => {
+    expect((await run("git switch main", { primary: false }))._tag).toBe("Block");
+  });
+  test("git checkout feat in worktree -> Allow", async () => {
+    expect((await run("git checkout feat", { primary: false }))._tag).toBe("Allow");
+  });
+  test("git checkout -b new in worktree -> Allow", async () => {
+    expect((await run("git checkout -b new", { primary: false }))._tag).toBe("Allow");
+  });
+  test("git checkout --detach in worktree -> Allow (inspect without holding)", async () => {
+    expect((await run("git checkout --detach abc123", { primary: false }))._tag).toBe("Allow");
+  });
+  test("non-repo dir -> Allow (no repo, nothing to guard)", async () => {
+    expect((await run("git checkout main", { primary: false, cwd: "/elsewhere" }))._tag).toBe("Allow");
+  });
+  test("inline bypass ALLOW_BRANCH_CHECKOUT=1 in worktree -> Allow", async () => {
+    expect((await run("ALLOW_BRANCH_CHECKOUT=1 git checkout main", { primary: false }))._tag).toBe("Allow");
   });
 });
 

--- a/packages/hooks-sdk/src/hooks/enforce-worktree.ts
+++ b/packages/hooks-sdk/src/hooks/enforce-worktree.ts
@@ -4,20 +4,26 @@ import { GitEnv } from "../git-env.ts";
 import { Verdict } from "../verdict.ts";
 import { findGitInvocations, type GitInvocation } from "./git-command.ts";
 
-/** checkout/switch forms that create a branch or restore files - always allowed. */
-const isCreateOrRestore = (verb: string, args: ReadonlyArray<string>): boolean => {
+/** checkout forms that only restore files - always allowed. */
+const isRestore = (verb: string, args: ReadonlyArray<string>): boolean => {
+  if (verb !== "checkout") return false;
   const a0 = args[0];
-  if (verb === "checkout") {
-    if (a0 === "-b" || a0 === "-B") return true; // create
-    if (a0 === "--") return true; // file restore
-    if (a0 === "." && args.length === 1) return true; // restore all
-    return false;
-  }
-  if (verb === "switch") {
-    return a0 === "-c" || a0 === "-C"; // create
-  }
+  if (a0 === "--") return true; // file restore
+  if (a0 === "." && args.length === 1) return true; // restore all
   return false;
 };
+
+/** checkout/switch forms that create a branch. */
+const isCreate = (verb: string, args: ReadonlyArray<string>): boolean => {
+  const a0 = args[0];
+  if (verb === "checkout") return a0 === "-b" || a0 === "-B";
+  if (verb === "switch") return a0 === "-c" || a0 === "-C";
+  return false;
+};
+
+/** the branch/ref a plain checkout/switch targets (first non-flag arg). */
+const switchTarget = (args: ReadonlyArray<string>): string | null =>
+  args.find((a) => !a.startsWith("-")) ?? null;
 
 /** Guard B verb set: ops that rewrite the target tree's state/history. */
 const isGuardedMutation = (inv: GitInvocation): boolean => {
@@ -25,7 +31,8 @@ const isGuardedMutation = (inv: GitInvocation): boolean => {
   if (inv.verb === "reset" && inv.args.includes("--hard")) return true;
   if (
     (inv.verb === "checkout" || inv.verb === "switch") &&
-    !isCreateOrRestore(inv.verb, inv.args)
+    !isCreate(inv.verb, inv.args) &&
+    !isRestore(inv.verb, inv.args)
   ) {
     return true;
   }
@@ -52,13 +59,26 @@ Do this instead:
 Bypass: ALLOW_DIRTY_MAIN_MUTATION=1
 (this guard is an ax SDK hook - author your own: ax hooks init)`;
 
-const blockSwitchMsg = `BLOCKED: Do not switch branches on the primary working tree.
+const blockSwitchMsg = (def: string) =>
+  `BLOCKED: the primary working tree stays on '${def}'.
 
-Use a worktree instead:
+Feature work happens in a linked worktree:
   git worktree add .claude/worktrees/<task-name> -b <branch-name>
 
-Allowed here: git checkout -b / git switch -c (create), git checkout -- <file>
-(restore). Bypass (rare): prefix with ALLOW_BRANCH_CHECKOUT=1
+Allowed here: git checkout ${def} (return to ${def}), git checkout -- <file>
+(file restore). Bypass (rare): prefix with ALLOW_BRANCH_CHECKOUT=1
+(this guard is an ax SDK hook - author your own: ax hooks init)`;
+
+const blockWorktreeDefaultMsg = (def: string) =>
+  `BLOCKED: do not check out '${def}' in a linked worktree.
+
+A branch can live in only one worktree at a time - holding '${def}' here
+locks the primary working tree off '${def}'.
+
+Do this instead:
+  git checkout --detach origin/${def}   # inspect ${def} without holding it
+
+Bypass (rare): prefix with ALLOW_BRANCH_CHECKOUT=1
 (this guard is an ax SDK hook - author your own: ax hooks init)`;
 
 const hook = defineHook({
@@ -89,16 +109,33 @@ const hook = defineHook({
         }
       }
 
-      // ---- Guard A: branch switching on the primary tree (cwd-scoped) ----
+      // ---- Guard A: the primary tree stays parked on the default branch ----
+      // Block branch create AND switch on the primary tree (only returning to
+      // the default branch is allowed); block linked worktrees from TAKING
+      // the default branch - a branch lives in one worktree at a time, so a
+      // worktree holding it locks the primary tree off it.
       if (process.env.ALLOW_BRANCH_CHECKOUT === "1") return Verdict.allow;
       for (const inv of invocations) {
         if (hasBypass("ALLOW_BRANCH_CHECKOUT", inv)) continue;
         if (inv.verb !== "checkout" && inv.verb !== "switch") continue;
-        // Explicit `git -C <path>` targets another tree - guard B territory.
-        if (inv.cPath !== null) continue;
-        if (isCreateOrRestore(inv.verb, inv.args)) continue;
-        if (yield* git.isPrimaryTree(event.cwd)) {
-          return Verdict.block(blockSwitchMsg);
+        if (isRestore(inv.verb, inv.args)) continue;
+        // Target tree: explicit `git -C <path>` wins, else the event cwd.
+        const target = inv.cPath ?? event.cwd;
+        if (yield* git.isPrimaryTree(target)) {
+          const def = yield* git.defaultBranch(target);
+          if (
+            !isCreate(inv.verb, inv.args) &&
+            switchTarget(inv.args) === def
+          ) {
+            continue; // returning the primary tree home
+          }
+          return Verdict.block(blockSwitchMsg(def));
+        }
+        if (isCreate(inv.verb, inv.args)) continue;
+        if ((yield* git.repoRoot(target)) === null) continue; // not a repo
+        const def = yield* git.defaultBranch(target);
+        if (switchTarget(inv.args) === def) {
+          return Verdict.block(blockWorktreeDefaultMsg(def));
         }
       }
       return Verdict.allow;


### PR DESCRIPTION
## Why

The primary checkout (`~/Projects/ax`) kept drifting off `main`. Today it sat on a merged feature branch while the `quota-meter` worktree held `main` hostage — restoring it needed a hook bypass. Two drift vectors in `enforce-worktree`:

1. **Branch create allowed on the primary tree** — `git checkout -b` / `git switch -c` were explicitly permitted, so feature branches got created in place and the primary walked off `main`.
2. **Worktrees could take `main`** — a branch lives in one worktree at a time, so a linked worktree checking out `main` locks the primary tree off it.

## What

- Guard A now parks the primary tree on the repo's default branch: branch create AND switch are blocked there; only returning home (`git checkout main`) and file restores pass without a bypass. Previously, returning to `main` was itself blocked.
- Linked worktrees are blocked from checking out the default branch (detach suggested instead).
- Guard A now also covers `git -C <path>` invocations (was guard-B-only).
- `GitEnv` grows `defaultBranch` (origin/HEAD → `main`/`master` fallback) with live + test layers.

`ALLOW_BRANCH_CHECKOUT=1` bypass unchanged.

## Verification

- `bun test`: 3768 pass / 0 fail
- `bun run typecheck`: clean (pre-existing warnings only)

After merge: refresh the installed hook copy (`cd ~/.ax/hooks && bun install --force`) — the `file:` dep is copied, not symlinked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)