### PR TITLE
feat(profile): stacked window chart, workflow arcs, leverage-sorted rig

### DIFF
--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -120,8 +120,15 @@ export function formatProfile(p: ProfileV1): string {
     }
     lines.push("");
     lines.push(`rig: ${p.rig.skills.length} skills · ${p.rig.hooks.length} hooks · routing_table: ${p.rig.routing_table}${p.rig.rules ? ` · ${p.rig.rules.count} rules` : ""}`);
+    if (p.workflow && p.workflow.arcs.length > 0) {
+        const topArc = p.workflow.arcs[0]!;
+        lines.push(`workflow: ${topArc.steps.join(" → ")} (${topArc.count}x)`);
+    }
     for (const s of topSkills) {
-        lines.push(`  ${s.name.padEnd(nameWidth)} ${integer(s.runs).padStart(6)} runs  (${s.source})`);
+        const downstream = s.downstream_share !== undefined
+            ? `  · downstream ${(s.downstream_share * 100).toFixed(0)}%`
+            : "";
+        lines.push(`  ${s.name.padEnd(nameWidth)} ${integer(s.runs).padStart(6)} runs  (${s.source})${downstream}`);
     }
     if (p.insights) {
         const ins = p.insights;

--- a/apps/axctl/src/profile/downstream.test.ts
+++ b/apps/axctl/src/profile/downstream.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { computeDownstreamShares } from "./downstream.ts";
+
+// Helper: invocation event
+const inv = (session: string, skill: string, ts: string) => ({ session, skill, ts });
+// Helper: session row
+const sess = (id: string, s: string, e: string) => ({ id, s, e });
+
+describe("computeDownstreamShares", () => {
+    test("returns empty map with no data", () => {
+        const result = computeDownstreamShares([], []);
+        expect(result.size).toBe(0);
+    });
+
+    test("skill fires early -> high share", () => {
+        // Session: 60min duration; skill fires at +1min -> ~98% remaining
+        const invocations = [inv("s1", "tdd", "2026-06-13T10:01:00Z")];
+        const sessions = [sess("s1", "2026-06-13T10:00:00Z", "2026-06-13T11:00:00Z")];
+        const result = computeDownstreamShares(invocations, sessions);
+        const share = result.get("tdd");
+        expect(share).toBeDefined();
+        expect(share!).toBeGreaterThan(0.9);
+        expect(share!).toBeLessThanOrEqual(1.0);
+    });
+
+    test("skill fires late -> low share", () => {
+        // Session: 60min; skill fires at +55min -> ~8% remaining
+        const invocations = [inv("s1", "tdd", "2026-06-13T10:55:00Z")];
+        const sessions = [sess("s1", "2026-06-13T10:00:00Z", "2026-06-13T11:00:00Z")];
+        const result = computeDownstreamShares(invocations, sessions);
+        const share = result.get("tdd")!;
+        expect(share).toBeLessThan(0.2);
+        expect(share).toBeGreaterThanOrEqual(0);
+    });
+
+    test("averages across multiple sessions", () => {
+        // Session 1: 60min, fires at +1min (share ~0.983)
+        // Session 2: 60min, fires at +59min (share ~0.017)
+        // Average ~0.5
+        const invocations = [
+            inv("s1", "tdd", "2026-06-13T10:01:00Z"),
+            inv("s2", "tdd", "2026-06-13T11:59:00Z"),
+        ];
+        const sessions = [
+            sess("s1", "2026-06-13T10:00:00Z", "2026-06-13T11:00:00Z"),
+            sess("s2", "2026-06-13T11:00:00Z", "2026-06-13T12:00:00Z"),
+        ];
+        const result = computeDownstreamShares(invocations, sessions);
+        const share = result.get("tdd")!;
+        expect(share).toBeCloseTo(0.5, 1);
+    });
+
+    test("skips sessions < 5min duration", () => {
+        // Session: 4 min - should be excluded
+        const invocations = [inv("s1", "tdd", "2026-06-13T10:01:00Z")];
+        const sessions = [sess("s1", "2026-06-13T10:00:00Z", "2026-06-13T10:04:00Z")];
+        const result = computeDownstreamShares(invocations, sessions);
+        expect(result.get("tdd")).toBeUndefined();
+    });
+
+    test("skips sessions without timestamps", () => {
+        const invocations = [inv("s1", "tdd", "2026-06-13T10:01:00Z")];
+        const sessions = [sess("s1", "null", "null")];
+        const result = computeDownstreamShares(invocations, sessions);
+        expect(result.get("tdd")).toBeUndefined();
+    });
+
+    test("clamps result to [0, 1]", () => {
+        // Invocation before session start -> share clamped to 1
+        const invocations = [inv("s1", "tdd", "2026-06-13T09:59:00Z")];
+        const sessions = [sess("s1", "2026-06-13T10:00:00Z", "2026-06-13T11:00:00Z")];
+        const result = computeDownstreamShares(invocations, sessions);
+        const share = result.get("tdd")!;
+        expect(share).toBe(1.0);
+    });
+
+    test("uses first invocation per session when skill fires multiple times", () => {
+        // Fires at +2min and +58min; should use +2min (early = high share)
+        const invocations = [
+            inv("s1", "tdd", "2026-06-13T10:02:00Z"),
+            inv("s1", "tdd", "2026-06-13T10:58:00Z"),
+        ];
+        const sessions = [sess("s1", "2026-06-13T10:00:00Z", "2026-06-13T11:00:00Z")];
+        const result = computeDownstreamShares(invocations, sessions);
+        const share = result.get("tdd")!;
+        // +2min of 60min -> (60-2)/60 = 0.967
+        expect(share).toBeGreaterThan(0.9);
+    });
+
+    test("rounds to 2 decimal places", () => {
+        const invocations = [inv("s1", "tdd", "2026-06-13T10:01:00Z")];
+        const sessions = [sess("s1", "2026-06-13T10:00:00Z", "2026-06-13T11:00:00Z")];
+        const result = computeDownstreamShares(invocations, sessions);
+        const share = result.get("tdd")!;
+        expect(Number(share.toFixed(2))).toBe(share);
+    });
+
+    test("multiple skills computed independently", () => {
+        const invocations = [
+            inv("s1", "tdd", "2026-06-13T10:01:00Z"),  // early
+            inv("s1", "plan", "2026-06-13T10:55:00Z"), // late
+        ];
+        const sessions = [sess("s1", "2026-06-13T10:00:00Z", "2026-06-13T11:00:00Z")];
+        const result = computeDownstreamShares(invocations, sessions);
+        expect(result.get("tdd")!).toBeGreaterThan(0.9);
+        expect(result.get("plan")!).toBeLessThan(0.2);
+    });
+});

--- a/apps/axctl/src/profile/downstream.ts
+++ b/apps/axctl/src/profile/downstream.ts
@@ -1,0 +1,78 @@
+/**
+ * computeDownstreamShares: for each skill, the fraction of session wall-time
+ * AFTER its first invocation. Pure - no Effect, no IO.
+ *
+ * Formula: (ended_at - first_invocation_ts) / (ended_at - started_at)
+ * Clamped [0,1]. Sessions < 5min excluded. Average over qualifying sessions.
+ * Result rounded to 2 decimal places.
+ */
+
+export interface InvocationForShare {
+    readonly session: string;
+    readonly skill: string;
+    readonly ts: string;
+}
+
+export interface SessionForShare {
+    readonly id: string;
+    readonly s: string; // started_at ISO string
+    readonly e: string; // ended_at ISO string
+}
+
+const MS_5MIN = 5 * 60 * 1000;
+
+/**
+ * Returns a map of skill name -> downstream_share (2dp).
+ * Skills with no qualifying sessions are omitted from the map.
+ */
+export function computeDownstreamShares(
+    invocations: ReadonlyArray<InvocationForShare>,
+    sessions: ReadonlyArray<SessionForShare>,
+): Map<string, number> {
+    // Build session lookup by id
+    const sessionMap = new Map<string, { startMs: number; endMs: number }>();
+    for (const s of sessions) {
+        const startMs = Date.parse(s.s);
+        const endMs = Date.parse(s.e);
+        if (!isFinite(startMs) || !isFinite(endMs)) continue;
+        const duration = endMs - startMs;
+        if (duration < MS_5MIN) continue;
+        sessionMap.set(s.id, { startMs, endMs });
+    }
+
+    // Per skill per session, track the earliest invocation ts
+    // Map: skill -> session -> earliest_ts_ms
+    const earliest = new Map<string, Map<string, number>>();
+    for (const inv of invocations) {
+        const sess = sessionMap.get(inv.session);
+        if (sess === undefined) continue;
+        const tsMs = Date.parse(inv.ts);
+        if (!isFinite(tsMs)) continue;
+        let bySession = earliest.get(inv.skill);
+        if (bySession === undefined) { bySession = new Map(); earliest.set(inv.skill, bySession); }
+        const current = bySession.get(inv.session);
+        if (current === undefined || tsMs < current) bySession.set(inv.session, tsMs);
+    }
+
+    // Compute average downstream share per skill
+    const result = new Map<string, number>();
+    for (const [skill, bySession] of earliest) {
+        let sum = 0;
+        let n = 0;
+        for (const [sessionId, firstTs] of bySession) {
+            const sess = sessionMap.get(sessionId);
+            if (sess === undefined) continue;
+            const duration = sess.endMs - sess.startMs;
+            const remaining = sess.endMs - firstTs;
+            const share = Math.max(0, Math.min(1, remaining / duration));
+            sum += share;
+            n++;
+        }
+        if (n > 0) {
+            const avg = sum / n;
+            result.set(skill, Math.round(avg * 100) / 100);
+        }
+    }
+
+    return result;
+}

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -440,3 +440,161 @@ export const fetchWrappedCounts = Effect.fn("profile.fetchWrappedCounts")(
         } satisfies WrappedCounts;
     },
 );
+
+// --- per-day per-model tokens -----------------------------------------------
+
+export interface DailyModelRow {
+    readonly date: string;
+    readonly model: string;
+    readonly tokens: number;
+}
+
+const DAILY_MODEL_TOKENS_SQL = (d: number) => `
+SELECT
+    time::format(ts, "%Y-%m-%d") AS date,
+    model,
+    math::sum(prompt_tokens ?? 0) + math::sum(completion_tokens ?? 0) AS tokens
+FROM session_token_usage
+WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
+GROUP BY date, model
+ORDER BY date ASC, tokens DESC;`;
+
+export const fetchDailyModels = Effect.fn("profile.fetchDailyModels")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(DAILY_MODEL_TOKENS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return rows.map((r) => ({
+            date: String(r.date),
+            model: r.model == null ? "(unattributed)" : String(r.model),
+            tokens: Number(r.tokens ?? 0),
+        })) satisfies DailyModelRow[];
+    },
+);
+
+// --- per-day tool call counts ------------------------------------------------
+
+export interface DailyToolCallRow {
+    readonly date: string;
+    readonly tool_calls: number;
+}
+
+const DAILY_TOOL_CALLS_SQL = (d: number) => `
+SELECT
+    time::format(ts, "%Y-%m-%d") AS date,
+    count() AS tool_calls
+FROM tool_call
+WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
+GROUP BY date
+ORDER BY date ASC;`;
+
+export const fetchDailyToolCalls = Effect.fn("profile.fetchDailyToolCalls")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(DAILY_TOOL_CALLS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return rows
+            .map((r) => ({
+                date: String(r.date),
+                tool_calls: Number(r.tool_calls ?? 0),
+            }))
+            .filter((r) => r.date !== "undefined" && r.date !== "null") satisfies DailyToolCallRow[];
+    },
+);
+
+// --- per-day commit counts ---------------------------------------------------
+
+export interface DailyCommitRow {
+    readonly date: string;
+    readonly commits: number;
+}
+
+const DAILY_COMMITS_SQL = (d: number) => `
+SELECT
+    time::format(ts, "%Y-%m-%d") AS date,
+    count() AS commits
+FROM commit
+WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
+GROUP BY date
+ORDER BY date ASC;`;
+
+export const fetchDailyCommits = Effect.fn("profile.fetchDailyCommits")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(DAILY_COMMITS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return rows
+            .map((r) => ({
+                date: String(r.date),
+                commits: Number(r.commits ?? 0),
+            }))
+            .filter((r) => r.date !== "undefined" && r.date !== "null") satisfies DailyCommitRow[];
+    },
+);
+
+// --- windowed invocation events (for workflow + downstream_share) ------------
+
+export interface WindowedInvocationRow {
+    readonly session: string;
+    readonly skill: string;
+    readonly ts: string;
+}
+
+const WINDOWED_INVOCATIONS_SQL = (d: number) => `
+SELECT
+    type::string(in.session) AS session,
+    out.name AS skill,
+    type::string(ts) AS ts
+FROM invoked
+WHERE ts > time::now() - ${win(d)};`;
+
+export const fetchWindowedInvocations = Effect.fn("profile.fetchWindowedInvocations")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(WINDOWED_INVOCATIONS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return rows
+            .filter((r) => r.session != null && r.skill != null && r.session !== "null" && r.skill !== "null")
+            .map((r) => ({
+                session: String(r.session),
+                skill: String(r.skill),
+                ts: String(r.ts),
+            })) satisfies WindowedInvocationRow[];
+    },
+);
+
+// --- windowed session times (for downstream_share) --------------------------
+
+export interface WindowedSessionRow {
+    readonly id: string;
+    readonly s: string;
+    readonly e: string;
+}
+
+const WINDOWED_SESSIONS_SQL = (d: number) => `
+SELECT
+    type::string(id) AS id,
+    type::string(started_at) AS s,
+    type::string(ended_at) AS e
+FROM session
+WHERE started_at > time::now() - ${win(d)} AND ended_at IS NOT NONE;`;
+
+export const fetchWindowedSessions = Effect.fn("profile.fetchWindowedSessions")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db
+            .query<[Array<Record<string, unknown>>]>(WINDOWED_SESSIONS_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        return rows
+            .filter((r) => r.id != null && r.s != null && r.e != null)
+            .map((r) => ({
+                id: String(r.id),
+                s: String(r.s),
+                e: String(r.e),
+            })) satisfies WindowedSessionRow[];
+    },
+);

--- a/apps/axctl/src/profile/render.test.ts
+++ b/apps/axctl/src/profile/render.test.ts
@@ -9,6 +9,8 @@ import { buildProfile } from "./render.ts";
 // 10 sessionDurations  11 peakHour  12 spawnedCount  13 commitCount  14 topTools
 // 15 wrappedCounts(toolAgg)  16 wrappedCounts(turnCount)
 // 17 wrappedCounts(distinctSkills)  18 wrappedCounts(reposCount)
+// 19 dailyModels  20 dailyToolCalls  21 dailyCommits
+// 22 windowedInvocations  23 windowedSessions
 const mockResults = [
     [[{ prompt_tokens: 31_000_000, completion_tokens: 7_000_000, sessions: 142 }]],
     [[{ date: "2026-06-11" }, { date: "2026-06-12" }]],
@@ -49,6 +51,27 @@ const mockResults = [
     [[{ count: 56 }]],
     // 18: wrappedCounts reposCount
     [[{ count: 12 }]],
+    // 19: dailyModels
+    [[
+        { date: "2026-06-11", model: "fable", tokens: 80_000 },
+        { date: "2026-06-12", model: "fable", tokens: 100_000_000 },
+        { date: "2026-06-12", model: "haiku", tokens: 20_000_000 },
+    ]],
+    // 20: dailyToolCalls
+    [[{ date: "2026-06-11", tool_calls: 200 }, { date: "2026-06-12", tool_calls: 3900 }]],
+    // 21: dailyCommits
+    [[{ date: "2026-06-11", commits: 7 }, { date: "2026-06-12", commits: 50 }]],
+    // 22: windowedInvocations
+    [[
+        { session: "session:1", skill: "tdd", ts: "2026-06-12T10:01:00Z" },
+        { session: "session:1", skill: "tdd", ts: "2026-06-12T10:30:00Z" },
+        { session: "session:2", skill: "tdd", ts: "2026-06-12T11:01:00Z" },
+    ]],
+    // 23: windowedSessions
+    [[
+        { id: "session:1", s: "2026-06-12T10:00:00Z", e: "2026-06-12T12:30:00Z" },
+        { id: "session:2", s: "2026-06-12T09:00:00Z", e: "2026-06-12T10:30:00Z" },
+    ]],
 ];
 
 const env = {
@@ -77,14 +100,35 @@ describe("buildProfile", () => {
             { name: "haiku", share: 0.25, cost_usd: 50 },
         ]);
         expect(p.stats.harnesses).toEqual(["claude", "codex"]);
-        expect(p.rig.skills).toEqual([{ name: "tdd", source: "superpowers", runs: 88 }]);
+        // tdd gets downstream_share from 2 qualifying sessions (avg ~0.5 due to late-fire in s2)
+        expect(p.rig.skills[0]!.name).toBe("tdd");
+        expect(p.rig.skills[0]!.source).toBe("superpowers");
+        expect(p.rig.skills[0]!.runs).toBe(88);
+        expect(p.rig.skills[0]!.downstream_share).toBeDefined();
         expect(p.rig.rules).toEqual({ count: 2 });
         expect(p.taste!.patterns[0]!.name).toBe("stop-edit-loops-early");
         // activity
         expect(p.activity).toBeDefined();
         expect(p.activity!.daily).toHaveLength(2);
-        expect(p.activity!.daily[0]).toEqual({ date: "2026-06-11", sessions: 5, tokens: 100_000 });
-        expect(p.activity!.daily[1]!.tokens).toBe(120_000_000);
+        // enriched daily
+        const day0 = p.activity!.daily[0]!;
+        expect(day0.date).toBe("2026-06-11");
+        expect(day0.sessions).toBe(5);
+        expect(day0.tokens).toBe(100_000);
+        expect(day0.models).toBeDefined();
+        expect(day0.models![0]!.name).toBe("fable");
+        expect(day0.models![0]!.tokens).toBe(80_000);
+        expect(day0.tool_calls).toBe(200);
+        expect(day0.commits).toBe(7);
+        const day1 = p.activity!.daily[1]!;
+        expect(day1.tokens).toBe(120_000_000);
+        expect(day1.models).toHaveLength(2); // fable + haiku
+        expect(day1.tool_calls).toBe(3900);
+        expect(day1.commits).toBe(50);
+        // workflow: tdd only fires in 2 sessions, no pair -> no bigrams >= 3, omitted
+        expect(p.workflow).toBeUndefined();
+        // downstream_share on tdd skill: 2 qualifying sessions -> defined
+        expect(p.rig.skills[0]!.downstream_share).toBeDefined();
         // insights
         expect(p.insights).toBeDefined();
         expect(p.insights!.hours_total).toBeCloseTo(4, 1); // 2.5h + 1.5h

--- a/apps/axctl/src/profile/render.ts
+++ b/apps/axctl/src/profile/render.ts
@@ -12,6 +12,9 @@ import {
     fetchCommitCount,
     fetchDailyActivity,
     fetchDailyActivityFull,
+    fetchDailyCommits,
+    fetchDailyModels,
+    fetchDailyToolCalls,
     fetchHarnesses,
     fetchPeakHour,
     fetchSessionDurations,
@@ -20,6 +23,8 @@ import {
     fetchSpawnedCount,
     fetchTokenTotals,
     fetchTopTools,
+    fetchWindowedInvocations,
+    fetchWindowedSessions,
     fetchWrappedCounts,
 } from "./queries.ts";
 import { deriveInsights } from "./insights.ts";
@@ -27,6 +32,8 @@ import { deriveRig } from "./rig.ts";
 import { computeStreak } from "./streak.ts";
 import { deriveTastePatterns } from "./taste.ts";
 import { decodeProfile, type ProfileV1 } from "./schema.ts";
+import { deriveWorkflowArcs } from "./workflow.ts";
+import { computeDownstreamShares } from "./downstream.ts";
 
 export interface ProfileEnv {
     readonly github: string;
@@ -53,6 +60,8 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         // 8+9 dailyActivityFull (sessions, tokens)  10 sessionDurations
         // 11 peakHour  12 spawnedCount  13 commitCount  14 topTools
         // 15+16+17+18 wrappedCounts (toolAgg, turnCount, distinctSkills, reposCount)
+        // 19 dailyModels  20 dailyToolCalls  21 dailyCommits
+        // 22 windowedInvocations  23 windowedSessions
         const totals = yield* fetchTokenTotals({ windowDays });
         const daily = yield* fetchDailyActivity({ windowDays });
         const harnesses = yield* fetchHarnesses({ windowDays });
@@ -67,6 +76,12 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         const commitCount = yield* fetchCommitCount({ windowDays });
         const topTools = yield* fetchTopTools({ windowDays });
         const wrappedCounts = yield* fetchWrappedCounts({ windowDays });
+        // Queries 19-23 (appended; keep mock order in render.test.ts aligned)
+        const dailyModels = yield* fetchDailyModels({ windowDays });
+        const dailyToolCalls = yield* fetchDailyToolCalls({ windowDays });
+        const dailyCommits = yield* fetchDailyCommits({ windowDays });
+        const windowedInvocations = yield* fetchWindowedInvocations({ windowDays });
+        const windowedSessions = yield* fetchWindowedSessions({ windowDays });
 
         const streak = computeStreak(daily, env.today);
 
@@ -97,6 +112,39 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
             wrapped: wrappedCounts,
         });
 
+        // Merge enriched daily fields into dailyFull rows
+        const toolCallMap = new Map(dailyToolCalls.map((r) => [r.date, r.tool_calls]));
+        const commitMap = new Map(dailyCommits.map((r) => [r.date, r.commits]));
+
+        // Group dailyModels by date; pivot to top-6 + "other"
+        const modelsByDate = new Map<string, Array<{ name: string; tokens: number }>>();
+        for (const row of dailyModels) {
+            let arr = modelsByDate.get(row.date);
+            if (arr === undefined) { arr = []; modelsByDate.set(row.date, arr); }
+            arr.push({ name: row.model, tokens: row.tokens });
+        }
+        const pivotModels = (rows: Array<{ name: string; tokens: number }>) => {
+            // Already sorted desc (SQL ORDER BY tokens DESC per date)
+            const top = rows.slice(0, 6);
+            const rest = rows.slice(6);
+            if (rest.length === 0) return top;
+            const otherTokens = rest.reduce((s, r) => s + r.tokens, 0);
+            return [...top, { name: "other", tokens: otherTokens }];
+        };
+
+        const enrichedDaily = dailyFull.map((row) => ({
+            ...row,
+            ...(modelsByDate.has(row.date) ? { models: pivotModels(modelsByDate.get(row.date)!) } : {}),
+            ...(toolCallMap.has(row.date) ? { tool_calls: toolCallMap.get(row.date) } : {}),
+            ...(commitMap.has(row.date) ? { commits: commitMap.get(row.date) } : {}),
+        }));
+
+        // Derive workflow arcs (uses scopes already fetched above)
+        const workflowArcs = deriveWorkflowArcs(windowedInvocations, scopes);
+
+        // Derive downstream shares (pure compute over windowed invocations + sessions)
+        const shareMap = computeDownstreamShares(windowedInvocations, windowedSessions);
+
         // decodeProfile throws on invariant breach -> Effect defect (die),
         // intentionally unrecoverable: a malformed profile is a bug here.
         const profile: ProfileV1 = decodeProfile({
@@ -123,10 +171,12 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
                 hookFiles: env.hookFiles,
                 hasRoutingTable: env.hasRoutingTable,
                 rulesMarkdown: env.rulesMarkdown,
+                shareMap,
             }),
             ...(patterns.length > 0 ? { taste: { patterns } } : {}),
-            ...(dailyFull.length > 0 ? { activity: { daily: dailyFull } } : {}),
+            ...(enrichedDaily.length > 0 ? { activity: { daily: enrichedDaily } } : {}),
             ...(insights !== null ? { insights } : {}),
+            ...(workflowArcs.length > 0 ? { workflow: { arcs: workflowArcs } } : {}),
         });
         return profile;
     },

--- a/apps/axctl/src/profile/rig.test.ts
+++ b/apps/axctl/src/profile/rig.test.ts
@@ -116,4 +116,34 @@ describe("deriveRig", () => {
         });
         expect(rig.skills).toEqual([{ name: "commit", source: "local", runs: 5 }]);
     });
+
+    test("attaches downstream_share when shareMap provided", () => {
+        const rig = deriveRig({
+            invocations: [
+                { skill: "tdd", count: 88 },
+                { skill: "my-local", count: 3 },
+            ],
+            scopes: new Map([
+                ["tdd", "plugin:superpowers"],
+                ["my-local", "user"],
+            ]),
+            hookFiles: [],
+            hasRoutingTable: false,
+            rulesMarkdown: null,
+            shareMap: new Map([["tdd", 0.73]]),
+        });
+        expect(rig.skills[0]!.downstream_share).toBe(0.73);
+        expect(rig.skills[1]!.downstream_share).toBeUndefined();
+    });
+
+    test("downstream_share omitted when no shareMap", () => {
+        const rig = deriveRig({
+            invocations: [{ skill: "tdd", count: 88 }],
+            scopes: new Map([["tdd", "plugin:superpowers"]]),
+            hookFiles: [],
+            hasRoutingTable: false,
+            rulesMarkdown: null,
+        });
+        expect(rig.skills[0]!.downstream_share).toBeUndefined();
+    });
 });

--- a/apps/axctl/src/profile/rig.ts
+++ b/apps/axctl/src/profile/rig.ts
@@ -51,10 +51,11 @@ export interface RigInputs {
     readonly hookFiles: ReadonlyArray<string>;
     readonly hasRoutingTable: boolean;
     readonly rulesMarkdown: string | null;
+    readonly shareMap?: ReadonlyMap<string, number>;
 }
 
 export interface Rig {
-    readonly skills: ReadonlyArray<{ name: string; source: string; runs: number }>;
+    readonly skills: ReadonlyArray<{ name: string; source: string; runs: number; downstream_share?: number }>;
     readonly hooks: ReadonlyArray<string>;
     readonly routing_table: boolean;
     readonly rules?: { readonly count: number };
@@ -65,10 +66,13 @@ export function deriveRig(inputs: RigInputs): Rig {
         .filter((row) => !isToolScope(inputs.scopes.get(row.skill) ?? "user"))
         .map((row) => {
             const scope = inputs.scopes.get(row.skill) ?? "user";
+            const name = publicSkillName(row.skill, scope);
+            const downstream_share = inputs.shareMap?.get(name);
             return {
-                name: publicSkillName(row.skill, scope),
+                name,
                 source: skillSource(scope),
                 runs: row.count,
+                ...(downstream_share !== undefined ? { downstream_share } : {}),
             };
         });
     const hooks = inputs.hookFiles

--- a/apps/axctl/src/profile/schema.test.ts
+++ b/apps/axctl/src/profile/schema.test.ts
@@ -262,3 +262,129 @@ describe("activity + insights sections", () => {
         expect(() => decodeProfile(bad)).toThrow();
     });
 });
+
+describe("new enriched daily fields (optional)", () => {
+    const base = {
+        v: 1, github: "x", generated_at: "2026-06-13T00:00:00Z", window_days: 30,
+        stats: {
+            sessions: 1, active_days: 1, streak_days: 1,
+            tokens: { prompt: 0, completion: 0, total: 0 },
+            models: [], harnesses: [],
+        },
+        rig: { skills: [], hooks: [], routing_table: false },
+    };
+
+    test("daily row accepts optional models/tool_calls/commits", () => {
+        const p = decodeProfile({
+            ...base,
+            activity: {
+                daily: [{
+                    date: "2026-06-13", sessions: 5, tokens: 1_000_000,
+                    models: [{ name: "fable", tokens: 800_000 }],
+                    tool_calls: 4100,
+                    commits: 57,
+                }],
+            },
+        });
+        const row = p.activity!.daily[0]!;
+        expect(row.models).toHaveLength(1);
+        expect(row.models![0]!.name).toBe("fable");
+        expect(row.models![0]!.tokens).toBe(800_000);
+        expect(row.tool_calls).toBe(4100);
+        expect(row.commits).toBe(57);
+    });
+
+    test("daily row without new optional fields still decodes", () => {
+        const p = decodeProfile({
+            ...base,
+            activity: { daily: [{ date: "2026-06-13", sessions: 1, tokens: 0 }] },
+        });
+        expect(p.activity!.daily[0]!.models).toBeUndefined();
+        expect(p.activity!.daily[0]!.tool_calls).toBeUndefined();
+        expect(p.activity!.daily[0]!.commits).toBeUndefined();
+    });
+
+    test("daily models row rejects non-string name", () => {
+        expect(() => decodeProfile({
+            ...base,
+            activity: {
+                daily: [{
+                    date: "2026-06-13", sessions: 1, tokens: 0,
+                    models: [{ name: 42, tokens: 100 }],
+                }],
+            },
+        })).toThrow();
+    });
+
+    test("daily models row rejects non-number tokens", () => {
+        expect(() => decodeProfile({
+            ...base,
+            activity: {
+                daily: [{
+                    date: "2026-06-13", sessions: 1, tokens: 0,
+                    models: [{ name: "fable", tokens: "big" }],
+                }],
+            },
+        })).toThrow();
+    });
+
+    test("workflow section accepted when arcs present", () => {
+        const p = decodeProfile({
+            ...base,
+            workflow: {
+                arcs: [
+                    { steps: ["superpowers:brainstorming", "superpowers:writing-plans", "superpowers:subagent-driven-development"], count: 12 },
+                ],
+            },
+        });
+        expect(p.workflow!.arcs).toHaveLength(1);
+        expect(p.workflow!.arcs[0]!.steps[0]).toBe("superpowers:brainstorming");
+        expect(p.workflow!.arcs[0]!.count).toBe(12);
+    });
+
+    test("workflow section is optional", () => {
+        const p = decodeProfile(base);
+        expect(p.workflow).toBeUndefined();
+    });
+
+    test("workflow arc rejects non-array steps", () => {
+        expect(() => decodeProfile({
+            ...base,
+            workflow: { arcs: [{ steps: "not-array", count: 1 }] },
+        })).toThrow();
+    });
+
+    test("workflow arc rejects non-number count", () => {
+        expect(() => decodeProfile({
+            ...base,
+            workflow: { arcs: [{ steps: ["a", "b"], count: "twelve" }] },
+        })).toThrow();
+    });
+
+    test("rig skill accepts downstream_share", () => {
+        const p = decodeProfile({
+            ...base,
+            rig: {
+                skills: [{ name: "tdd", source: "superpowers", runs: 88, downstream_share: 0.73 }],
+                hooks: [], routing_table: false,
+            },
+        });
+        expect(p.rig.skills[0]!.downstream_share).toBe(0.73);
+    });
+
+    test("rig skill without downstream_share still decodes", () => {
+        const p = decodeProfile(base);
+        // rig.skills is [] but if it had a row without downstream_share, no error
+        expect(p.rig.skills).toHaveLength(0);
+    });
+
+    test("rig skill rejects non-number downstream_share", () => {
+        expect(() => decodeProfile({
+            ...base,
+            rig: {
+                skills: [{ name: "tdd", source: "superpowers", runs: 88, downstream_share: "high" }],
+                hooks: [], routing_table: false,
+            },
+        })).toThrow();
+    });
+});

--- a/apps/axctl/src/profile/schema.ts
+++ b/apps/axctl/src/profile/schema.ts
@@ -86,6 +86,7 @@ const Rig = Schema.Struct({
             name: Schema.String,
             source: Schema.String,
             runs: Schema.Number,
+            downstream_share: Schema.optional(Schema.Number),
         }),
     ),
     hooks: Schema.Array(Schema.String),
@@ -98,10 +99,27 @@ const Rig = Schema.Struct({
     ),
 });
 
+const WorkflowArc = Schema.Struct({
+    steps: Schema.Array(Schema.String),
+    count: Schema.Number,
+});
+
+const Workflow = Schema.Struct({
+    arcs: Schema.Array(WorkflowArc),
+});
+
+const DailyModelRow = Schema.Struct({
+    name: Schema.String,
+    tokens: Schema.Number,
+});
+
 const DailyRow = Schema.Struct({
     date: Schema.String,
     sessions: Schema.Number,
     tokens: Schema.Number,
+    models: Schema.optional(Schema.Array(DailyModelRow)),
+    tool_calls: Schema.optional(Schema.Number),
+    commits: Schema.optional(Schema.Number),
 });
 
 const BusiestDay = Schema.Struct({
@@ -149,6 +167,7 @@ export const ProfileV1 = Schema.Struct({
     taste: Schema.optional(Schema.Struct({ patterns: Schema.Array(TastePattern) })),
     activity: Schema.optional(Activity),
     insights: Schema.optional(Insights),
+    workflow: Schema.optional(Workflow),
 });
 export type ProfileV1 = typeof ProfileV1.Type;
 

--- a/apps/axctl/src/profile/workflow.test.ts
+++ b/apps/axctl/src/profile/workflow.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { deriveWorkflowArcs } from "./workflow.ts";
+
+// Helpers
+const mkEvents = (session: string, skills: string[]) =>
+    skills.map((skill, i) => ({ session, skill, ts: `2026-06-13T10:${String(i).padStart(2, "0")}:00Z` }));
+
+describe("deriveWorkflowArcs", () => {
+    test("returns empty when no invocations", () => {
+        expect(deriveWorkflowArcs([], new Map())).toEqual([]);
+    });
+
+    test("returns empty when count < 3", () => {
+        const events = [
+            ...mkEvents("s1", ["a", "b"]),
+            ...mkEvents("s2", ["a", "b"]),
+        ];
+        expect(deriveWorkflowArcs(events, new Map())).toEqual([]);
+    });
+
+    test("mines bigrams with count >= 3", () => {
+        const sessions = ["s1", "s2", "s3", "s4"].map((id) =>
+            mkEvents(id, ["brainstorming", "writing-plans"]),
+        );
+        const events = sessions.flat();
+        const arcs = deriveWorkflowArcs(events, new Map());
+        expect(arcs).toHaveLength(1);
+        expect(arcs[0]!.steps).toEqual(["brainstorming", "writing-plans"]);
+        expect(arcs[0]!.count).toBe(4);
+    });
+
+    test("trigrams ranked above bigrams at equal count; bigrams absorbed by trigrams dropped", () => {
+        // 5 sessions each with a->b->c; the bigrams a->b and b->c also appear 5x
+        // Only the trigram should survive (bigrams absorbed).
+        const sessions = ["s1","s2","s3","s4","s5"].map((id) =>
+            mkEvents(id, ["a", "b", "c"]),
+        );
+        const events = sessions.flat();
+        const arcs = deriveWorkflowArcs(events, new Map());
+        const steps = arcs.map((a) => a.steps.join("->"));
+        expect(steps).toContain("a->b->c");
+        // bigram a->b or b->c must NOT appear because absorbed
+        expect(steps).not.toContain("a->b");
+        expect(steps).not.toContain("b->c");
+    });
+
+    test("applies publicSkillName via scopes: tool-scope skills excluded; project names stripped", () => {
+        const events = [
+            ...mkEvents("s1", ["proj:commit", "codex-native", "superpowers:tdd"]),
+            ...mkEvents("s2", ["proj:commit", "codex-native", "superpowers:tdd"]),
+            ...mkEvents("s3", ["proj:commit", "codex-native", "superpowers:tdd"]),
+        ];
+        const scopes = new Map([
+            ["proj:commit", "project:proj"],
+            ["codex-native", "codex-tool"],
+            ["superpowers:tdd", "plugin:superpowers"],
+        ]);
+        const arcs = deriveWorkflowArcs(events, scopes);
+        // codex-native is tool-scope -> excluded; proj:commit -> "commit"; superpowers:tdd stays
+        // So per session the sequence is ["commit", "superpowers:tdd"] -> bigram
+        const steps = arcs[0]?.steps ?? [];
+        expect(steps).toEqual(["commit", "superpowers:tdd"]);
+        expect(arcs[0]!.count).toBe(3);
+    });
+
+    test("collapses consecutive duplicates within session", () => {
+        // a a b -> should become [a, b]
+        const events = [
+            ...mkEvents("s1", ["a", "a", "b"]),
+            ...mkEvents("s2", ["a", "a", "b"]),
+            ...mkEvents("s3", ["a", "a", "b"]),
+        ];
+        const arcs = deriveWorkflowArcs(events, new Map());
+        expect(arcs[0]!.steps).toEqual(["a", "b"]);
+    });
+
+    test("top 5 arcs returned, ranked count desc then lexicographic", () => {
+        // Create 7 distinct bigrams with enough repetitions
+        const pairs = [
+            ["f","g"],["e","f"],["d","e"],["c","d"],["b","c"],["a","b"],["h","i"],
+        ];
+        const events = pairs.flatMap(([x, y], i) =>
+            Array.from({ length: 7 - i }, (_, j) => mkEvents(`s${i}-${j}`, [x!, y!])).flat(),
+        );
+        const arcs = deriveWorkflowArcs(events, new Map());
+        expect(arcs).toHaveLength(5);
+        // Must be sorted count desc
+        for (let i = 0; i < arcs.length - 1; i++) {
+            expect(arcs[i]!.count).toBeGreaterThanOrEqual(arcs[i + 1]!.count);
+        }
+    });
+
+    test("lexicographic tiebreak is deterministic", () => {
+        // Two bigrams same count 4: [a,z] and [a,b]
+        const events1 = Array.from({ length: 4 }, (_, i) => mkEvents(`az-${i}`, ["a", "z"])).flat();
+        const events2 = Array.from({ length: 4 }, (_, i) => mkEvents(`ab-${i}`, ["a", "b"])).flat();
+        const arcs = deriveWorkflowArcs([...events1, ...events2], new Map());
+        expect(arcs[0]!.steps.join(",")).toBe("a,b");
+        expect(arcs[1]!.steps.join(",")).toBe("a,z");
+    });
+});

--- a/apps/axctl/src/profile/workflow.ts
+++ b/apps/axctl/src/profile/workflow.ts
@@ -1,0 +1,113 @@
+/**
+ * Workflow arc mining: discovers frequent skill n-gram sequences
+ * (bigrams + trigrams) across sessions. Pure - no Effect, no IO.
+ * Input comes from fetchWindowedInvocations + skill scopes.
+ */
+import { isToolScope, publicSkillName } from "./rig.ts";
+
+export interface InvocationEvent {
+    readonly session: string;
+    readonly skill: string;
+    readonly ts: string;
+}
+
+export interface WorkflowArc {
+    readonly steps: string[];
+    readonly count: number;
+}
+
+/**
+ * Map skill name through public-name pipeline:
+ * - exclude tool-scope pseudo-skills
+ * - strip project prefixes via scopes map
+ * Returns null if skill should be excluded.
+ */
+function mapSkillName(skill: string, scopes: ReadonlyMap<string, string>): string | null {
+    const scope = scopes.get(skill) ?? "user";
+    if (isToolScope(scope)) return null;
+    return publicSkillName(skill, scope);
+}
+
+/**
+ * Mine bigram + trigram arcs from windowed invocation events.
+ * Returns top 5 arcs, trigrams ranked above bigrams at equal count;
+ * bigrams fully contained in a kept trigram are dropped.
+ * count >= 3 threshold applied. Sorted count desc, lexicographic tiebreak.
+ */
+export function deriveWorkflowArcs(
+    events: ReadonlyArray<InvocationEvent>,
+    scopes: ReadonlyMap<string, string>,
+): WorkflowArc[] {
+    // Group by session, sort by ts
+    const bySession = new Map<string, Array<{ skill: string; ts: string }>>();
+    for (const ev of events) {
+        let arr = bySession.get(ev.session);
+        if (arr === undefined) { arr = []; bySession.set(ev.session, arr); }
+        arr.push({ skill: ev.skill, ts: ev.ts });
+    }
+
+    // Per session: sort by ts, map names, exclude tools, collapse consecutive dupes
+    const sequences: string[][] = [];
+    for (const arr of bySession.values()) {
+        arr.sort((a, b) => a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0);
+        const mapped: string[] = [];
+        for (const { skill } of arr) {
+            const name = mapSkillName(skill, scopes);
+            if (name === null) continue;
+            // Collapse consecutive duplicates
+            if (mapped[mapped.length - 1] !== name) mapped.push(name);
+        }
+        if (mapped.length >= 2) sequences.push(mapped);
+    }
+
+    // Count all bigrams and trigrams
+    const bigrams = new Map<string, number>();
+    const trigrams = new Map<string, number>();
+
+    const key = (steps: string[]): string => steps.join("\0");
+    const unkey = (k: string): string[] => k.split("\0");
+
+    for (const seq of sequences) {
+        for (let i = 0; i < seq.length - 1; i++) {
+            const bk = key([seq[i]!, seq[i + 1]!]);
+            bigrams.set(bk, (bigrams.get(bk) ?? 0) + 1);
+            if (i + 2 < seq.length) {
+                const tk = key([seq[i]!, seq[i + 1]!, seq[i + 2]!]);
+                trigrams.set(tk, (trigrams.get(tk) ?? 0) + 1);
+            }
+        }
+    }
+
+    // Filter count >= 3
+    const keptTrigrams: WorkflowArc[] = [];
+    for (const [k, count] of trigrams) {
+        if (count >= 3) keptTrigrams.push({ steps: unkey(k), count });
+    }
+
+    // Build set of bigram keys absorbed by kept trigrams
+    const absorbed = new Set<string>();
+    for (const arc of keptTrigrams) {
+        absorbed.add(key([arc.steps[0]!, arc.steps[1]!]));
+        absorbed.add(key([arc.steps[1]!, arc.steps[2]!]));
+    }
+
+    const keptBigrams: WorkflowArc[] = [];
+    for (const [k, count] of bigrams) {
+        if (count >= 3 && !absorbed.has(k)) {
+            keptBigrams.push({ steps: unkey(k), count });
+        }
+    }
+
+    // Combine: trigrams first (rank above bigrams at equal count), then bigrams
+    // Sort within each group by count desc, then lexicographic
+    const sort = (arcs: WorkflowArc[]): WorkflowArc[] =>
+        arcs.sort((a, b) => {
+            if (b.count !== a.count) return b.count - a.count;
+            return a.steps.join(",") < b.steps.join(",") ? -1 : 1;
+        });
+
+    const sorted = [...sort(keptTrigrams), ...sort(keptBigrams)];
+
+    // Enforce top 5 (trigrams already rank above bigrams by position)
+    return sorted.slice(0, 5);
+}

--- a/apps/site/app/lib/community.test.ts
+++ b/apps/site/app/lib/community.test.ts
@@ -190,6 +190,107 @@ describe("validateLeaderboard", () => {
     });
 });
 
+describe("validateProfileV1 - new optional fields (enriched daily, downstream_share, workflow)", () => {
+    const base = {
+        v: 1,
+        github: "necmttn",
+        generated_at: "2026-06-13T00:00:00Z",
+        window_days: 30,
+        stats: {
+            sessions: 1, active_days: 1, streak_days: 1,
+            tokens: { prompt: 0, completion: 0, total: 0 },
+            models: [], harnesses: [],
+        },
+        rig: { skills: [], hooks: [], routing_table: false },
+    };
+
+    test("accepts daily row with models/tool_calls/commits", () => {
+        const p = validateProfileV1({
+            ...base,
+            activity: {
+                daily: [{
+                    date: "2026-06-13", sessions: 1, tokens: 0,
+                    models: [{ name: "fable", tokens: 800_000 }],
+                    tool_calls: 100,
+                    commits: 5,
+                }],
+            },
+        });
+        expect(p.activity!.daily[0]!.models![0]!.name).toBe("fable");
+        expect(p.activity!.daily[0]!.tool_calls).toBe(100);
+        expect(p.activity!.daily[0]!.commits).toBe(5);
+    });
+
+    test("rejects daily models row with non-string name", () => {
+        expect(() => validateProfileV1({
+            ...base,
+            activity: {
+                daily: [{ date: "x", sessions: 1, tokens: 0, models: [{ name: 42, tokens: 100 }] }],
+            },
+        })).toThrow();
+    });
+
+    test("rejects daily models row with non-number tokens", () => {
+        expect(() => validateProfileV1({
+            ...base,
+            activity: {
+                daily: [{ date: "x", sessions: 1, tokens: 0, models: [{ name: "fable", tokens: "big" }] }],
+            },
+        })).toThrow();
+    });
+
+    test("accepts skill with downstream_share", () => {
+        const p = validateProfileV1({
+            ...base,
+            rig: {
+                skills: [{ name: "tdd", source: "superpowers", runs: 88, downstream_share: 0.73 }],
+                hooks: [], routing_table: false,
+            },
+        });
+        expect(p.rig.skills[0]!.downstream_share).toBe(0.73);
+    });
+
+    test("rejects skill with non-number downstream_share", () => {
+        expect(() => validateProfileV1({
+            ...base,
+            rig: {
+                skills: [{ name: "tdd", source: "superpowers", runs: 88, downstream_share: "high" }],
+                hooks: [], routing_table: false,
+            },
+        })).toThrow();
+    });
+
+    test("accepts workflow section with arcs", () => {
+        const p = validateProfileV1({
+            ...base,
+            workflow: {
+                arcs: [{ steps: ["brainstorming", "writing-plans", "subagent-driven-development"], count: 12 }],
+            },
+        });
+        expect(p.workflow!.arcs[0]!.count).toBe(12);
+        expect(p.workflow!.arcs[0]!.steps).toHaveLength(3);
+    });
+
+    test("rejects workflow arc with non-array steps", () => {
+        expect(() => validateProfileV1({
+            ...base,
+            workflow: { arcs: [{ steps: "not-array", count: 1 }] },
+        })).toThrow();
+    });
+
+    test("rejects workflow arc with non-number count", () => {
+        expect(() => validateProfileV1({
+            ...base,
+            workflow: { arcs: [{ steps: ["a"], count: "twelve" }] },
+        })).toThrow();
+    });
+
+    test("workflow section is optional - omit and still validates", () => {
+        const p = validateProfileV1(base);
+        expect(p.workflow).toBeUndefined();
+    });
+});
+
 describe("urls", () => {
     test("registration + gist raw urls", () => {
         expect(registrationRawUrl("Necmttn")).toBe(

--- a/apps/site/app/lib/community.ts
+++ b/apps/site/app/lib/community.ts
@@ -36,6 +36,7 @@ export interface ProfileSkill {
     readonly name: string;
     readonly source: string;
     readonly runs: number;
+    readonly downstream_share?: number;
 }
 export interface TastePattern {
     readonly category: string;
@@ -46,10 +47,24 @@ export interface TastePattern {
     readonly context?: string;
     readonly evidence: { readonly sessions: number; readonly confidence: number; readonly last_reinforced?: string; readonly trend?: string };
 }
+export interface ProfileDailyModelRow {
+    readonly name: string;
+    readonly tokens: number;
+}
 export interface ProfileDailyRow {
     readonly date: string;
     readonly sessions: number;
     readonly tokens: number;
+    readonly models?: readonly ProfileDailyModelRow[];
+    readonly tool_calls?: number;
+    readonly commits?: number;
+}
+export interface WorkflowArc {
+    readonly steps: readonly string[];
+    readonly count: number;
+}
+export interface ProfileWorkflow {
+    readonly arcs: readonly WorkflowArc[];
 }
 export interface ProfileToolRun {
     readonly name: string;
@@ -98,6 +113,7 @@ export interface ProfileV1 {
     readonly taste?: { readonly patterns: readonly TastePattern[] };
     readonly activity?: { readonly daily: readonly ProfileDailyRow[] };
     readonly insights?: ProfileInsights;
+    readonly workflow?: ProfileWorkflow;
 }
 
 const optNum = (v: unknown, what: string): void => {
@@ -146,6 +162,7 @@ export function validateProfileV1(value: unknown): ProfileV1 {
         str(s.name, "skill.name");
         str(s.source, "skill.source");
         num(s.runs, "skill.runs");
+        optNum(s.downstream_share, "skill.downstream_share");
     }
     if (value.taste !== undefined) {
         if (!isRecord(value.taste) || !Array.isArray(value.taste.patterns)) throw new Error("invalid taste");
@@ -169,6 +186,17 @@ export function validateProfileV1(value: unknown): ProfileV1 {
             str(d.date, "activity.daily.date");
             num(d.sessions, "activity.daily.sessions");
             num(d.tokens, "activity.daily.tokens");
+            // New optional daily fields
+            optNum(d.tool_calls, "activity.daily.tool_calls");
+            optNum(d.commits, "activity.daily.commits");
+            if (d.models !== undefined) {
+                if (!Array.isArray(d.models)) throw new Error("invalid activity.daily.models");
+                for (const m of d.models) {
+                    if (!isRecord(m)) throw new Error("invalid daily model row");
+                    str(m.name, "daily.model.name");
+                    num(m.tokens, "daily.model.tokens");
+                }
+            }
         }
     }
     if (value.insights !== undefined) {
@@ -199,6 +227,17 @@ export function validateProfileV1(value: unknown): ProfileV1 {
         optNum(ins.repos_count, "insights.repos_count");
         optNum(ins.verification_calls, "insights.verification_calls");
         optNum(ins.context_calls, "insights.context_calls");
+    }
+    if (value.workflow !== undefined) {
+        if (!isRecord(value.workflow) || !Array.isArray(value.workflow.arcs)) {
+            throw new Error("invalid workflow");
+        }
+        for (const arc of value.workflow.arcs) {
+            if (!isRecord(arc)) throw new Error("invalid workflow arc");
+            if (!Array.isArray(arc.steps)) throw new Error("invalid workflow arc.steps");
+            for (const step of arc.steps) str(step, "workflow.arc.step");
+            num(arc.count, "workflow.arc.count");
+        }
     }
     return value as unknown as ProfileV1;
 }

--- a/apps/site/app/lib/window-chart.test.ts
+++ b/apps/site/app/lib/window-chart.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import {
+    buildModelColors,
+    buildDayColumns,
+    buildDisplayArcs,
+    sortSkillsByLeverage,
+    stripSkillPrefix,
+    MODEL_RAMP,
+    OTHER_COLOR,
+    OTHER_NAME,
+} from "./window-chart";
+import type { ProfileDailyRow, ProfileModel, ProfileSkill, WorkflowArc } from "./community";
+
+describe("buildModelColors", () => {
+    test("top model is green, rest follow the ramp", () => {
+        const models: ProfileModel[] = [
+            { name: "claude-fable-5", share: 0.5 },
+            { name: "claude-opus", share: 0.3 },
+            { name: "gpt-5", share: 0.2 },
+        ];
+        const { colorOf, order } = buildModelColors(models);
+        expect(colorOf("claude-fable-5")).toBe(MODEL_RAMP[0]!);
+        expect(colorOf("claude-opus")).toBe(MODEL_RAMP[1]!);
+        expect(colorOf("gpt-5")).toBe(MODEL_RAMP[2]!);
+        expect(order).toEqual(["claude-fable-5", "claude-opus", "gpt-5"]);
+    });
+
+    test("colour is by share order, not array order", () => {
+        const models: ProfileModel[] = [
+            { name: "b", share: 0.2 },
+            { name: "a", share: 0.8 },
+        ];
+        const { colorOf } = buildModelColors(models);
+        expect(colorOf("a")).toBe(MODEL_RAMP[0]!);
+        expect(colorOf("b")).toBe(MODEL_RAMP[1]!);
+    });
+
+    test("tail beyond ramp collapses to a single other bucket", () => {
+        const models: ProfileModel[] = Array.from({ length: 9 }, (_, i) => ({
+            name: `m${i}`,
+            share: 1 - i * 0.1,
+        }));
+        const { colorOf, order } = buildModelColors(models);
+        expect(colorOf("m6")).toBe(OTHER_COLOR);
+        expect(colorOf("m8")).toBe(OTHER_COLOR);
+        expect(order.filter((n) => n === OTHER_NAME)).toHaveLength(1);
+        expect(order).toContain(OTHER_NAME);
+    });
+
+    test("unknown model falls back to other colour", () => {
+        const { colorOf } = buildModelColors([{ name: "a", share: 1 }]);
+        expect(colorOf("nope")).toBe(OTHER_COLOR);
+    });
+});
+
+describe("buildDayColumns", () => {
+    const colorOf = buildModelColors([
+        { name: "fable", share: 0.6 },
+        { name: "opus", share: 0.4 },
+    ]).colorOf;
+
+    test("segments sum to the day total; height scaled to window max", () => {
+        const daily: ProfileDailyRow[] = [
+            { date: "2026-06-01", sessions: 2, tokens: 100, models: [
+                { name: "fable", tokens: 60 }, { name: "opus", tokens: 40 },
+            ] },
+            { date: "2026-06-02", sessions: 4, tokens: 200, models: [
+                { name: "fable", tokens: 200 },
+            ] },
+        ];
+        const cols = buildDayColumns(daily, colorOf, { peakDate: "2026-06-02" });
+        expect(cols).toHaveLength(2);
+        expect(cols[0]!.segments.reduce((s, x) => s + x.tokens, 0)).toBe(100);
+        expect(cols[0]!.heightShare).toBeCloseTo(0.5);
+        expect(cols[1]!.heightShare).toBeCloseTo(1);
+        expect(cols[1]!.isPeak).toBe(true);
+        expect(cols[0]!.isPeak).toBe(false);
+    });
+
+    test("sub-threshold models merge into other", () => {
+        const daily: ProfileDailyRow[] = [
+            { date: "d", sessions: 1, tokens: 1000, models: [
+                { name: "fable", tokens: 980 },
+                { name: "opus", tokens: 15 }, // 1.5% kept
+                { name: "tiny", tokens: 5 }, // 0.5% merged
+            ] },
+        ];
+        const cols = buildDayColumns(daily, colorOf, { minSegmentShare: 0.01 });
+        const seg = cols[0]!.segments;
+        const other = seg.find((s) => s.name === OTHER_NAME);
+        expect(other?.tokens).toBe(5);
+        expect(seg.some((s) => s.name === "fable")).toBe(true);
+        expect(seg.some((s) => s.name === "opus")).toBe(true);
+    });
+
+    test("no model breakdown yields one neutral segment", () => {
+        const daily: ProfileDailyRow[] = [{ date: "d", sessions: 1, tokens: 50 }];
+        const cols = buildDayColumns(daily, colorOf);
+        expect(cols[0]!.segments).toHaveLength(1);
+        expect(cols[0]!.segments[0]!.color).toBe(OTHER_COLOR);
+    });
+
+    test("zero-token day has no segments and zero height", () => {
+        const daily: ProfileDailyRow[] = [{ date: "d", sessions: 0, tokens: 0 }];
+        const cols = buildDayColumns(daily, colorOf);
+        expect(cols[0]!.segments).toHaveLength(0);
+        expect(cols[0]!.heightShare).toBe(0);
+    });
+});
+
+describe("stripSkillPrefix", () => {
+    test("strips known namespaces", () => {
+        expect(stripSkillPrefix("superpowers:writing-plans")).toBe("writing-plans");
+        expect(stripSkillPrefix("caveman:caveman")).toBe("caveman");
+    });
+    test("strips generic ns:thing", () => {
+        expect(stripSkillPrefix("foo:bar")).toBe("bar");
+    });
+    test("leaves plain names alone", () => {
+        expect(stripSkillPrefix("simplify")).toBe("simplify");
+    });
+});
+
+describe("buildDisplayArcs", () => {
+    test("strongest first, capped, with display+full pairs", () => {
+        const arcs: WorkflowArc[] = [
+            { steps: ["superpowers:brainstorming", "writing-plans"], count: 3 },
+            { steps: ["review-all", "composto", "simplify"], count: 11 },
+            { steps: ["a"], count: 1 },
+        ];
+        const out = buildDisplayArcs(arcs, 5);
+        expect(out[0]!.count).toBe(11);
+        expect(out[1]!.count).toBe(3);
+        expect(out[1]!.steps[0]).toEqual({ display: "brainstorming", full: "superpowers:brainstorming" });
+    });
+    test("caps at the limit", () => {
+        const arcs: WorkflowArc[] = Array.from({ length: 8 }, (_, i) => ({ steps: ["x"], count: i }));
+        expect(buildDisplayArcs(arcs, 5)).toHaveLength(5);
+    });
+    test("drops empty-step arcs", () => {
+        const arcs: WorkflowArc[] = [{ steps: [], count: 9 }, { steps: ["x"], count: 1 }];
+        const out = buildDisplayArcs(arcs);
+        expect(out).toHaveLength(1);
+        expect(out[0]!.steps[0]!.display).toBe("x");
+    });
+});
+
+describe("sortSkillsByLeverage", () => {
+    test("downstream_share desc, missing last, then runs desc", () => {
+        const skills: ProfileSkill[] = [
+            { name: "lowshare", source: "s", runs: 100, downstream_share: 0.2 },
+            { name: "noshare-hi", source: "s", runs: 50 },
+            { name: "hishare", source: "s", runs: 5, downstream_share: 0.99 },
+            { name: "noshare-lo", source: "s", runs: 10 },
+        ];
+        const out = sortSkillsByLeverage(skills).map((s) => s.name);
+        expect(out).toEqual(["hishare", "lowshare", "noshare-hi", "noshare-lo"]);
+    });
+    test("stable on name when share + runs tie", () => {
+        const skills: ProfileSkill[] = [
+            { name: "b", source: "s", runs: 1, downstream_share: 0.5 },
+            { name: "a", source: "s", runs: 1, downstream_share: 0.5 },
+        ];
+        expect(sortSkillsByLeverage(skills).map((s) => s.name)).toEqual(["a", "b"]);
+    });
+});

--- a/apps/site/app/lib/window-chart.ts
+++ b/apps/site/app/lib/window-chart.ts
@@ -1,0 +1,184 @@
+/**
+ * Pure helpers behind the dossier "window" stacked-bar chart, the workflow
+ * arcs, and the leverage-sorted rig. Kept out of the route component so the
+ * non-trivial logic (stable model->colour assignment, per-day sub-1% merging,
+ * arc display formatting, leverage sort) is unit-testable without React.
+ *
+ * Everything here is fed untrusted gist data; callers still render the result
+ * as text only.
+ */
+import type { ProfileDailyRow, ProfileModel, ProfileSkill, WorkflowArc } from "./community";
+
+/**
+ * Stable model -> colour assignment. The top model (by window share) is always
+ * ax green; the rest follow an editorial ramp. "other" (the merged tail) is the
+ * faint line colour. The same model name always maps to the same colour, so a
+ * per-day segment and its legend chip agree.
+ */
+export const MODEL_RAMP: readonly string[] = [
+    "var(--green)", // top model
+    "#2567a8", // blue
+    "#b08968", // tan
+    "#8b6db0", // violet-muted
+    "#c0392b", // red-muted
+    "#6b6b66", // gray
+];
+export const OTHER_COLOR = "var(--line)";
+export const OTHER_NAME = "other";
+
+export interface ModelColor {
+    readonly name: string;
+    readonly color: string;
+}
+
+/**
+ * Assign colours to models in window-share order. Models beyond the ramp length
+ * collapse into a single "other" bucket sharing OTHER_COLOR. Returns an ordered
+ * map (lookup) plus the ordered legend list.
+ */
+export function buildModelColors(models: readonly ProfileModel[]): {
+    readonly colorOf: (name: string) => string;
+    readonly order: readonly string[];
+} {
+    const sorted = [...models].sort((a, b) => b.share - a.share);
+    const map = new Map<string, string>();
+    const order: string[] = [];
+    sorted.forEach((m, i) => {
+        if (i < MODEL_RAMP.length) {
+            map.set(m.name, MODEL_RAMP[i]!);
+            order.push(m.name);
+        } else {
+            // tail collapses to a single "other" legend entry
+            if (!order.includes(OTHER_NAME)) order.push(OTHER_NAME);
+            map.set(m.name, OTHER_COLOR);
+        }
+    });
+    return {
+        colorOf: (name: string) => map.get(name) ?? OTHER_COLOR,
+        order,
+    };
+}
+
+export interface DaySegment {
+    readonly name: string;
+    readonly tokens: number;
+    readonly color: string;
+    readonly share: number; // of the day's total tokens
+}
+export interface DayColumn {
+    readonly date: string;
+    readonly sessions: number;
+    readonly tokens: number;
+    readonly tool_calls?: number;
+    readonly commits?: number;
+    readonly segments: readonly DaySegment[];
+    /** column height as a share (0..1) of the busiest day's total tokens */
+    readonly heightShare: number;
+    readonly isPeak: boolean;
+}
+
+/**
+ * Turn the daily rows into stacked columns. Within each day, models under
+ * `minSegmentShare` of that day's tokens merge into a single "other" segment so
+ * a 7-model day stays legible. Column height is scaled to the max daily tokens
+ * across the window. Segments are colour-keyed by the window-level assignment
+ * so a model is the same colour everywhere.
+ */
+export function buildDayColumns(
+    daily: readonly ProfileDailyRow[],
+    colorOf: (name: string) => string,
+    opts: { readonly peakDate?: string; readonly minSegmentShare?: number } = {},
+): readonly DayColumn[] {
+    const minShare = opts.minSegmentShare ?? 0.01;
+    const maxTokens = daily.reduce((m, d) => Math.max(m, d.tokens), 0);
+    return daily.map((d) => {
+        const total = d.tokens;
+        let segments: DaySegment[] = [];
+        if (d.models && d.models.length > 0 && total > 0) {
+            const big: DaySegment[] = [];
+            let otherTokens = 0;
+            // group identical names (defensive) and split big vs tail
+            const byName = new Map<string, number>();
+            for (const m of d.models) byName.set(m.name, (byName.get(m.name) ?? 0) + m.tokens);
+            const rows = [...byName.entries()].sort((a, b) => b[1] - a[1]);
+            for (const [name, tokens] of rows) {
+                const share = tokens / total;
+                if (share >= minShare && colorOf(name) !== OTHER_COLOR) {
+                    big.push({ name, tokens, color: colorOf(name), share });
+                } else {
+                    otherTokens += tokens;
+                }
+            }
+            // keep big segments in the window colour order (already share-sorted
+            // here, which is close enough and reads as a clean ramp per day)
+            segments = big;
+            if (otherTokens > 0) {
+                segments.push({
+                    name: OTHER_NAME,
+                    tokens: otherTokens,
+                    color: OTHER_COLOR,
+                    share: otherTokens / total,
+                });
+            }
+        } else if (total > 0) {
+            // no per-model breakdown: one neutral column
+            segments = [{ name: OTHER_NAME, tokens: total, color: OTHER_COLOR, share: 1 }];
+        }
+        return {
+            date: d.date,
+            sessions: d.sessions,
+            tokens: d.tokens,
+            tool_calls: d.tool_calls,
+            commits: d.commits,
+            segments,
+            heightShare: maxTokens > 0 ? d.tokens / maxTokens : 0,
+            isPeak: opts.peakDate !== undefined && d.date === opts.peakDate,
+        };
+    });
+}
+
+/** Known plugin/skill namespaces stripped for display (full name kept in title). */
+const SKILL_PREFIXES = ["superpowers:", "caveman:", "lazyweb:", "codex:", "brand:"];
+
+/** "superpowers:writing-plans" -> "writing-plans" for display. */
+export function stripSkillPrefix(name: string): string {
+    for (const p of SKILL_PREFIXES) {
+        if (name.startsWith(p)) return name.slice(p.length);
+    }
+    // generic "ns:thing" fallback
+    const colon = name.indexOf(":");
+    return colon > 0 ? name.slice(colon + 1) : name;
+}
+
+export interface DisplayArc {
+    readonly steps: readonly { readonly display: string; readonly full: string }[];
+    readonly count: number;
+}
+
+/** Strongest arcs first, capped, with display/full step pairs. */
+export function buildDisplayArcs(arcs: readonly WorkflowArc[], limit = 5): readonly DisplayArc[] {
+    return [...arcs]
+        .filter((a) => a.steps.length > 0)
+        .sort((a, b) => b.count - a.count)
+        .slice(0, limit)
+        .map((a) => ({
+            count: a.count,
+            steps: a.steps.map((s) => ({ display: stripSkillPrefix(s), full: s })),
+        }));
+}
+
+/**
+ * Sort skills within a group by leverage (downstream_share) DESC; rows missing
+ * a share sort last, then by runs DESC. Stable on name for determinism.
+ */
+export function sortSkillsByLeverage(skills: readonly ProfileSkill[]): readonly ProfileSkill[] {
+    return [...skills].sort((a, b) => {
+        const as = a.downstream_share;
+        const bs = b.downstream_share;
+        if (as !== undefined && bs !== undefined && as !== bs) return bs - as;
+        if (as !== undefined && bs === undefined) return -1;
+        if (as === undefined && bs !== undefined) return 1;
+        if (a.runs !== b.runs) return b.runs - a.runs;
+        return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+    });
+}

--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -19,6 +19,14 @@ import {
     type ProfileInsights,
     type ProfileSkill,
 } from "~/lib/community";
+import {
+    buildModelColors,
+    buildDayColumns,
+    buildDisplayArcs,
+    sortSkillsByLeverage,
+    OTHER_NAME,
+    type DayColumn,
+} from "~/lib/window-chart";
 
 // mirrors LOGIN_RE in community.ts - GitHub handles only, sanitised before use.
 const LOGIN_RE = /^[A-Za-z0-9-]{1,39}$/;
@@ -169,7 +177,8 @@ function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsState })
         : [];
     const ins = p.insights;
     const models = [...p.stats.models].sort((a, b) => b.share - a.share);
-    const tools = ins && ins.tools_top.length > 0 ? ins.tools_top.slice(0, 10) : [];
+    const { colorOf } = buildModelColors(models);
+    const arcs = p.workflow ? buildDisplayArcs(p.workflow.arcs, 5) : [];
     let section = 0;
     const nextSection = (): string => String(++section).padStart(2, "0");
 
@@ -200,35 +209,21 @@ function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsState })
                 <Vital num={`${fmtInt(p.stats.streak_days)}d`} label="streak" />
             </section>
 
-            {/* the window: activity timeline + model split, one story */}
+            {/* the window: one stacked-bar chart, model-keyed, with a legend */}
             <section className="pf-section">
                 <Kicker n={nextSection()} title="The window" note={`last ${p.window_days} days`} />
-                <div className={daily.length > 0 ? "pf-window" : "pf-window pf-window--solo"}>
-                    {daily.length > 0 && <ActivityTimeline daily={daily} busiest={ins?.busiest_day.date} />}
-                    <div className="pf-models">
-                        <div className="pf-models-head">
-                            model split · {fmtInt(p.stats.sessions)} sessions over {p.window_days} days
-                        </div>
-                        {models.map((m, i) => (
-                            <div className="pf-model" key={`${m.name}-${i}`}>
-                                <div className="pf-model-top">
-                                    <span className="pf-model-name">{m.name}</span>
-                                    <span className="pf-model-meta">
-                                        <strong>{fmtPct(m.share)}</strong>
-                                        {m.cost_usd !== undefined ? ` · ~${fmtMoney(m.cost_usd)}` : ""}
-                                    </span>
-                                </div>
-                                <span className="pf-model-track">
-                                    <span
-                                        className={i === 0 ? "pf-model-fill pf-model-fill--lead" : "pf-model-fill"}
-                                        style={{ width: `${clampPct(m.share * 100)}%` }}
-                                    />
-                                </span>
-                            </div>
-                        ))}
-                        {models.length === 0 && <p className="pf-quiet">no model data in this window.</p>}
-                    </div>
-                </div>
+                {daily.length > 0 ? (
+                    <StackedWindow
+                        daily={daily}
+                        colorOf={colorOf}
+                        busiest={ins?.busiest_day.date}
+                        models={models}
+                        sessions={p.stats.sessions}
+                        windowDays={p.window_days}
+                    />
+                ) : (
+                    <p className="pf-quiet">no daily activity recorded in this window.</p>
+                )}
             </section>
 
             {/* wrapped-style insight cards */}
@@ -254,54 +249,54 @@ function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsState })
             {/* the sign: radar + agent archetype */}
             <SignSection n={nextSection()} profile={p} vs={vs} />
 
-            {/* tool taste */}
-            {tools.length > 0 && (
-                <section className="pf-section">
-                    <Kicker n={nextSection()} title="Tool taste" note="what the hands actually reach for" />
-                    <div className="pf-tools">
-                        {tools.map((t, i) => {
-                            const max = tools[0]?.runs ?? 0;
-                            const w = max > 0 ? clampPct((t.runs / max) * 100) : 0;
-                            return (
-                                <div className="pf-tool" key={`${t.name}-${i}`}>
-                                    <span className="pf-tool-rank">{String(i + 1).padStart(2, "0")}</span>
-                                    <span className="pf-tool-name">{t.name}</span>
-                                    <span className="pf-tool-track" aria-hidden="true">
-                                        <span
-                                            className={i === 0 ? "pf-tool-bar pf-tool-bar--lead" : "pf-tool-bar"}
-                                            style={{ width: `${w}%` }}
-                                        />
+            {/* the rig: workflow arcs + leverage-sorted skills + guardrails */}
+            <section className="pf-section">
+                <Kicker n={nextSection()} title="The rig" note={`${fmtInt(p.rig.skills.length)} skills · ${fmtInt(p.rig.hooks.length)} hooks`} />
+                {arcs.length > 0 && (
+                    <div className="pf-workflow">
+                        <div className="pf-workflow-head">
+                            <span className="pf-workflow-title">The workflow</span>
+                            <span className="pf-workflow-note">recurring skill sequences mined from session order</span>
+                        </div>
+                        <div className="pf-arcs">
+                            {arcs.map((arc, i) => (
+                                <div className="pf-arc" key={i}>
+                                    <span className="pf-arc-chain">
+                                        {arc.steps.map((step, j) => (
+                                            <span className="pf-arc-step-wrap" key={j}>
+                                                {j > 0 && <span className="pf-arc-sep" aria-hidden="true">→</span>}
+                                                <span className="pf-arc-chip" title={step.full}>{step.display}</span>
+                                            </span>
+                                        ))}
                                     </span>
-                                    <span className="pf-tool-runs">{fmtCompact(t.runs)}</span>
+                                    <span className="pf-arc-count">×{fmtInt(arc.count)}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
+                <div className="pf-rig">
+                    <div className="pf-rig-skills">
+                        {groupSkills(p.rig.skills).map((g) => {
+                            const skills = sortSkillsByLeverage(g.skills);
+                            return (
+                                <div className="pf-rig-group" key={g.source}>
+                                    <div className="pf-rig-group-head">
+                                        <span>{g.source}</span>
+                                        <span>{fmtInt(g.skills.length)} skills · {fmtCompact(g.runs)} runs</span>
+                                    </div>
+                                    <div className="pf-rig-group-hint">
+                                        sorted by downstream share - how much of the session follows the skill, not how often it fires
+                                    </div>
+                                    {skills.slice(0, 10).map((s) => (
+                                        <SkillRow key={s.name} skill={s} />
+                                    ))}
+                                    {g.skills.length > 10 && (
+                                        <div className="pf-rig-more">+ {fmtInt(g.skills.length - 10)} more</div>
+                                    )}
                                 </div>
                             );
                         })}
-                    </div>
-                </section>
-            )}
-
-            {/* the rig: skills grouped by source + guardrails */}
-            <section className="pf-section">
-                <Kicker n={nextSection()} title="The rig" note={`${fmtInt(p.rig.skills.length)} skills · ${fmtInt(p.rig.hooks.length)} hooks`} />
-                <div className="pf-rig">
-                    <div className="pf-rig-skills">
-                        {groupSkills(p.rig.skills).map((g) => (
-                            <div className="pf-rig-group" key={g.source}>
-                                <div className="pf-rig-group-head">
-                                    <span>{g.source}</span>
-                                    <span>{fmtInt(g.skills.length)} skills · {fmtCompact(g.runs)} runs</span>
-                                </div>
-                                {g.skills.slice(0, 10).map((s) => (
-                                    <div className="pf-skill" key={s.name}>
-                                        <span className="pf-skill-name">{s.name}</span>
-                                        <span className="pf-skill-runs">{fmtCompact(s.runs)} runs</span>
-                                    </div>
-                                ))}
-                                {g.skills.length > 10 && (
-                                    <div className="pf-rig-more">+ {fmtInt(g.skills.length - 10)} more</div>
-                                )}
-                            </div>
-                        ))}
                         {p.rig.skills.length === 0 && <p className="pf-quiet">no skills recorded in this window.</p>}
                     </div>
                     <aside className="pf-guardrails">
@@ -575,43 +570,179 @@ function RawTable({
 
 const fmtScore = (n: number): string => String(Math.round(n));
 
-function ActivityTimeline({ daily, busiest }: { daily: readonly ProfileDailyRow[]; busiest?: string }) {
-    const maxSessions = daily.reduce((m, d) => Math.max(m, d.sessions), 0);
+/* ---------- the window: one model-keyed stacked-bar chart ---------- */
+
+interface ProfileModelLite { readonly name: string; readonly share: number; readonly cost_usd?: number }
+
+/**
+ * GitHub-heatmap-style daily bars, but each bar is segmented by model tokens
+ * and the whole row carries every daily metric in a hover tooltip. Bar height
+ * scales to the busiest token-day; segments are colour-keyed by the same
+ * window-level model->colour map the legend uses, so a model reads identically
+ * everywhere. Keyboard/touch fallback rides the column's `title` attribute.
+ */
+function StackedWindow({
+    daily, colorOf, busiest, models, sessions, windowDays,
+}: {
+    daily: readonly ProfileDailyRow[];
+    colorOf: (name: string) => string;
+    busiest?: string;
+    models: readonly ProfileModelLite[];
+    sessions: number;
+    windowDays: number;
+}) {
+    const cols = buildDayColumns(daily, colorOf, { peakDate: busiest });
+    const [hover, setHover] = useState<number | null>(null);
     const maxTokens = daily.reduce((m, d) => Math.max(m, d.tokens), 0);
-    const totalSessions = daily.reduce((s, d) => s + d.sessions, 0);
-    const avg = daily.length > 0 ? totalSessions / daily.length : 0;
-    const first = daily[0];
-    const last = daily[daily.length - 1];
+    const first = cols[0];
+    const last = cols[cols.length - 1];
+    const hovered = hover !== null ? cols[hover] : undefined;
+
     return (
-        <div className="pf-activity">
-            <div
-                className="pf-chart"
-                role="img"
-                aria-label={`daily sessions over ${daily.length} days, peaking at ${fmtInt(maxSessions)}`}
-            >
-                {daily.map((d) => {
-                    const h = maxSessions > 0 ? clampPct((d.sessions / maxSessions) * 100) : 0;
-                    const q = maxTokens > 0 ? Math.min(4, Math.max(1, Math.ceil((d.tokens / maxTokens) * 4))) : 1;
-                    const peak = busiest !== undefined && d.date === busiest;
-                    return (
-                        <span
-                            className="pf-chart-day"
-                            key={d.date}
-                            title={`${d.date} · ${fmtInt(d.sessions)} sessions · ${fmtCompact(d.tokens)} tokens`}
+        <div className="pf-window">
+            <div className="pf-stack-wrap">
+                <div
+                    className="pf-stack"
+                    role="img"
+                    aria-label={`daily tokens over ${cols.length} days, segmented by model, peaking at ${fmtCompact(maxTokens)} tokens`}
+                    onMouseLeave={() => setHover(null)}
+                >
+                    {cols.map((c, i) => (
+                        <button
+                            type="button"
+                            className={`pf-stack-day${c.isPeak ? " is-peak" : ""}${hover === i ? " is-hover" : ""}`}
+                            key={c.date}
+                            title={tooltipText(c)}
+                            onMouseEnter={() => setHover(i)}
+                            onFocus={() => setHover(i)}
+                            onBlur={() => setHover(null)}
+                            aria-label={tooltipText(c)}
                         >
                             <span
-                                className={`pf-chart-fill pf-q${q}${peak ? " is-peak" : ""}`}
-                                style={{ height: `${Math.max(h, d.sessions > 0 ? 3 : 0)}%` }}
-                            />
-                        </span>
-                    );
-                })}
+                                className="pf-stack-col"
+                                style={{ height: `${Math.max(c.heightShare * 100, c.tokens > 0 ? 2 : 0)}%` }}
+                            >
+                                {c.segments.map((s, j) => (
+                                    <span
+                                        className="pf-stack-seg"
+                                        key={`${s.name}-${j}`}
+                                        style={{ flexGrow: s.share, background: s.color }}
+                                    />
+                                ))}
+                            </span>
+                            {c.isPeak && <span className="pf-stack-peak" aria-hidden="true">▲</span>}
+                        </button>
+                    ))}
+                    {hovered && (
+                        <WindowTooltip
+                            col={hovered}
+                            index={hover!}
+                            total={cols.length}
+                            colorOf={colorOf}
+                        />
+                    )}
+                </div>
+                <div className="pf-chart-axis">
+                    <span>{first ? fmtDay(first.date) : ""}</span>
+                    <span className="pf-chart-axis-mid">
+                        {fmtInt(sessions)} sessions over {windowDays} days · bar height = daily tokens, colour = model{busiest !== undefined ? " · ▲ peak day" : ""}
+                    </span>
+                    <span>{last ? fmtDay(last.date) : ""}</span>
+                </div>
             </div>
-            <div className="pf-chart-axis">
-                <span>{first ? fmtDay(first.date) : ""}</span>
-                <span className="pf-chart-axis-mid">~{fmtInt(avg)} sessions/day · darker = heavier token days{busiest !== undefined ? " · peak in red" : ""}</span>
-                <span>{last ? fmtDay(last.date) : ""}</span>
+
+            {/* legend: replaces the old model-split rows */}
+            {models.length > 0 && (
+                <div className="pf-legend" aria-label="model legend">
+                    <div className="pf-legend-head">model split · window totals</div>
+                    {models.map((m) => (
+                        <div className="pf-legend-row" key={m.name}>
+                            <span className="pf-legend-chip" style={{ background: colorOf(m.name) }} aria-hidden="true" />
+                            <span className="pf-legend-name" title={m.name}>{m.name}</span>
+                            <span className="pf-legend-meta">
+                                <strong>{fmtPct(m.share)}</strong>
+                                {m.cost_usd !== undefined ? ` · ~${fmtMoney(m.cost_usd)}` : ""}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function tooltipText(c: DayColumn): string {
+    const parts = [
+        fmtDay(c.date),
+        `${fmtInt(c.sessions)} sessions`,
+        `${fmtCompact(c.tokens)} tokens`,
+    ];
+    if (c.tool_calls !== undefined) parts.push(`${fmtCompact(c.tool_calls)} tool calls`);
+    if (c.commits !== undefined) parts.push(`${fmtInt(c.commits)} commits`);
+    return parts.join(" · ");
+}
+
+/** Positioned tooltip; clamps to the chart edges via percentage + transform. */
+function WindowTooltip({
+    col, index, total, colorOf,
+}: {
+    col: DayColumn;
+    index: number;
+    total: number;
+    colorOf: (name: string) => string;
+}) {
+    const frac = total > 1 ? index / (total - 1) : 0.5;
+    // clamp the anchor so the box never overflows the chart edges
+    const leftPct = clampPct(frac * 100);
+    const align = frac < 0.18 ? "0%" : frac > 0.82 ? "-100%" : "-50%";
+    return (
+        <div
+            className="pf-tip"
+            style={{ left: `${leftPct}%`, transform: `translateX(${align})` }}
+            role="tooltip"
+        >
+            <div className="pf-tip-date">{fmtDay(col.date)}</div>
+            <div className="pf-tip-rows">
+                <span className="pf-tip-k">sessions</span><span className="pf-tip-v">{fmtInt(col.sessions)}</span>
+                <span className="pf-tip-k">tokens</span><span className="pf-tip-v">{fmtCompact(col.tokens)}</span>
+                {col.tool_calls !== undefined && (
+                    <><span className="pf-tip-k">tool calls</span><span className="pf-tip-v">{fmtCompact(col.tool_calls)}</span></>
+                )}
+                {col.commits !== undefined && (
+                    <><span className="pf-tip-k">commits</span><span className="pf-tip-v">{fmtInt(col.commits)}</span></>
+                )}
             </div>
+            {col.segments.length > 0 && (
+                <div className="pf-tip-models">
+                    {col.segments.map((s, j) => (
+                        <div className="pf-tip-model" key={`${s.name}-${j}`}>
+                            <span className="pf-tip-chip" style={{ background: s.color }} aria-hidden="true" />
+                            <span className="pf-tip-model-name">{s.name === OTHER_NAME ? "other" : s.name}</span>
+                            <span className="pf-tip-model-tok">{fmtCompact(s.tokens)}</span>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+/** One leverage-sorted skill: name left, leverage bar + share% + runs right. */
+function SkillRow({ skill }: { skill: ProfileSkill }) {
+    const share = skill.downstream_share;
+    const display = skill.name.includes(":") ? skill.name.slice(skill.name.indexOf(":") + 1) : skill.name;
+    return (
+        <div className="pf-skill">
+            <span className="pf-skill-name" title={skill.name}>{display}</span>
+            <span className="pf-skill-lev">
+                <span className="pf-skill-track" aria-hidden="true">
+                    {share !== undefined && (
+                        <span className="pf-skill-bar" style={{ width: `${clampPct(share * 100)}%` }} />
+                    )}
+                </span>
+                <span className="pf-skill-share">{share !== undefined ? fmtPct(share) : "-"}</span>
+                <span className="pf-skill-runs">· {fmtCompact(skill.runs)} runs</span>
+            </span>
         </div>
     );
 }

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -9632,32 +9632,104 @@ footer .right {
     gap: 44px;
     align-items: start;
 }
-.pf-window--solo { grid-template-columns: minmax(0, 1fr); max-width: 640px; }
 @media (max-width: 880px) {
     .pf-window { grid-template-columns: minmax(0, 1fr); gap: 36px; }
 }
 
-.pf-chart {
+/* stacked-bar chart: one model-keyed column per day, hover tooltip */
+.pf-stack-wrap { min-width: 0; }
+.pf-stack {
+    position: relative;
     display: flex;
     align-items: flex-end;
     gap: 3px;
-    height: 132px;
+    height: 156px;
     border-bottom: 2px solid var(--ink);
 }
-.pf-chart-day {
+.pf-stack-day {
+    position: relative;
     flex: 1 1 0;
     min-width: 0;
     height: 100%;
     display: flex;
     align-items: flex-end;
+    justify-content: stretch;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    background: none;
+    cursor: default;
+    appearance: none;
 }
-.pf-chart-fill { width: 100%; display: block; }
-.pf-chart-fill.pf-q1 { background: color-mix(in srgb, var(--green) 28%, var(--page)); }
-.pf-chart-fill.pf-q2 { background: color-mix(in srgb, var(--green) 52%, var(--page)); }
-.pf-chart-fill.pf-q3 { background: color-mix(in srgb, var(--green) 78%, var(--page)); }
-.pf-chart-fill.pf-q4 { background: var(--green); }
-.pf-chart-fill.is-peak { background: var(--red); }
-.pf-chart-day:hover .pf-chart-fill { background: var(--ink); }
+.pf-stack-day:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
+.pf-stack-col {
+    position: relative;
+    width: 100%;
+    display: flex;
+    flex-direction: column-reverse; /* first (largest) segment at the base */
+    min-height: 0;
+    transition: opacity 0.08s ease;
+}
+.pf-stack-seg { display: block; flex-basis: 0; min-height: 1px; }
+/* dim the rest of the chart when one day is hovered, so the focused bar pops */
+.pf-stack:hover .pf-stack-day:not(.is-hover) .pf-stack-col { opacity: 0.45; }
+.pf-stack-day.is-peak .pf-stack-col { box-shadow: 0 0 0 1.5px var(--ink); }
+.pf-stack-peak {
+    position: absolute;
+    bottom: -16px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 8px;
+    line-height: 1;
+    color: var(--ink);
+}
+@media (max-width: 560px) {
+    .pf-stack { gap: 2px; height: 116px; }
+}
+
+/* hover tooltip - heatmap-style, all daily metrics */
+.pf-tip {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    z-index: 5;
+    width: max-content;
+    max-width: 220px;
+    background: var(--ink);
+    color: var(--page);
+    border: 1px solid var(--ink);
+    padding: 9px 11px 10px;
+    box-shadow: 4px 4px 0 color-mix(in srgb, var(--ink) 14%, transparent);
+    pointer-events: none;
+    font-family: var(--mono);
+}
+.pf-tip-date {
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--page) 70%, var(--ink));
+    margin-bottom: 6px;
+}
+.pf-tip-rows {
+    display: grid;
+    grid-template-columns: auto auto;
+    gap: 2px 14px;
+    font-size: 12px;
+    margin-bottom: 6px;
+}
+.pf-tip-k { color: color-mix(in srgb, var(--page) 62%, var(--ink)); }
+.pf-tip-v { text-align: right; font-weight: 600; }
+.pf-tip-models {
+    border-top: 1px solid color-mix(in srgb, var(--page) 28%, var(--ink));
+    padding-top: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+.pf-tip-model { display: grid; grid-template-columns: 9px 1fr auto; gap: 8px; align-items: center; font-size: 11.5px; }
+.pf-tip-chip { width: 9px; height: 9px; display: block; }
+.pf-tip-model-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pf-tip-model-tok { color: color-mix(in srgb, var(--page) 70%, var(--ink)); }
+
 .pf-chart-axis {
     display: flex;
     justify-content: space-between;
@@ -9670,41 +9742,35 @@ footer .right {
 }
 .pf-chart-axis-mid { text-align: center; }
 @media (max-width: 560px) {
-    .pf-chart { gap: 2px; height: 96px; }
     .pf-chart-axis-mid { display: none; }
 }
 
-.pf-models { min-width: 0; }
-.pf-models-head {
+/* legend: color chip + model + share% + cost - replaces the old split rows */
+.pf-legend { min-width: 0; align-self: start; }
+.pf-legend-head {
     font-family: var(--mono);
     font-size: 10.5px;
     text-transform: uppercase;
     letter-spacing: 0.13em;
     color: var(--muted);
     padding-bottom: 9px;
-    margin-bottom: 16px;
+    margin-bottom: 12px;
     border-bottom: 1px solid var(--line);
 }
-.pf-model { margin-bottom: 15px; }
-.pf-model-top {
-    display: flex;
-    justify-content: space-between;
+.pf-legend-row {
+    display: grid;
+    grid-template-columns: 11px minmax(0, 1fr) auto;
+    gap: 10px;
     align-items: baseline;
-    gap: 14px;
+    padding: 6px 0;
     font-family: var(--mono);
     font-size: 13px;
+    border-bottom: 1px solid var(--line);
 }
-.pf-model-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.pf-model-meta { color: var(--muted); white-space: nowrap; font-size: 12px; }
-.pf-model-meta strong { color: var(--ink); font-weight: 600; font-size: 13px; }
-.pf-model-track {
-    display: block;
-    height: 6px;
-    background: color-mix(in srgb, var(--line) 55%, var(--page));
-    margin-top: 6px;
-}
-.pf-model-fill { display: block; height: 100%; background: var(--ink); }
-.pf-model-fill--lead { background: var(--green); }
+.pf-legend-chip { width: 11px; height: 11px; display: block; align-self: center; box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--ink) 18%, transparent); }
+.pf-legend-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.pf-legend-meta { color: var(--muted); white-space: nowrap; font-size: 12px; }
+.pf-legend-meta strong { color: var(--ink); font-weight: 600; font-size: 13px; }
 
 /* ----- 02 insight cards (wrapped-style) ----- */
 .pf-cards {
@@ -9841,29 +9907,51 @@ footer .right {
     .pf-card-a { font-size: 32px; }
 }
 
-/* ----- 03 tool taste ----- */
-.pf-tools { max-width: 760px; }
-.pf-tool {
-    display: grid;
-    grid-template-columns: 26px minmax(96px, 168px) minmax(0, 1fr) 64px;
+/* ----- the rig: workflow arcs ----- */
+.pf-workflow { margin-bottom: 36px; }
+.pf-workflow-head {
+    display: flex;
+    align-items: baseline;
     gap: 14px;
-    align-items: center;
-    font-family: var(--mono);
-    font-size: 13px;
-    padding: 8px 0;
-    border-bottom: 1px solid var(--line);
+    border-bottom: 1px solid var(--ink);
+    padding-bottom: 6px;
+    margin-bottom: 14px;
 }
-.pf-tool-rank { color: var(--muted); font-size: 11px; }
-.pf-tool-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.pf-tool-track { display: block; min-width: 0; }
-.pf-tool-bar { display: block; height: 9px; background: var(--ink); }
-.pf-tool-bar--lead { background: var(--green); }
-.pf-tool-runs { text-align: right; color: var(--muted); font-size: 12px; }
-@media (max-width: 560px) {
-    .pf-tool { grid-template-columns: 22px minmax(72px, 110px) minmax(0, 1fr) 52px; gap: 10px; font-size: 12px; }
+.pf-workflow-title {
+    font-family: var(--serif);
+    font-size: 19px;
+    letter-spacing: -0.3px;
+    color: var(--ink);
+}
+.pf-workflow-note { font-family: var(--mono); font-size: 11.5px; color: var(--muted); }
+.pf-arcs { display: flex; flex-direction: column; gap: 10px; }
+.pf-arc {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+.pf-arc-chain { display: flex; align-items: center; flex-wrap: wrap; gap: 0; min-width: 0; }
+.pf-arc-step-wrap { display: inline-flex; align-items: center; }
+.pf-arc-sep { color: var(--muted); margin: 0 7px; font-size: 13px; }
+.pf-arc-chip {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    color: var(--ink);
+    padding: 3px 9px;
+    white-space: nowrap;
+}
+.pf-arc-count {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--green);
+    font-weight: 600;
+    white-space: nowrap;
 }
 
-/* ----- 04 the rig ----- */
+/* ----- the rig ----- */
 .pf-rig {
     display: grid;
     grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
@@ -9888,18 +9976,37 @@ footer .right {
     margin-bottom: 4px;
 }
 .pf-rig-group-head span:first-child { color: var(--ink); }
+.pf-rig-group-hint {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    line-height: 1.4;
+    color: var(--muted);
+    padding: 6px 0 8px;
+}
 .pf-skill {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
     gap: 16px;
-    padding: 6px 0;
+    padding: 7px 0;
     border-bottom: 1px solid var(--line);
     font-family: var(--mono);
     font-size: 13px;
 }
 .pf-skill-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.pf-skill-runs { color: var(--muted); font-size: 11.5px; white-space: nowrap; }
+.pf-skill-lev { display: flex; align-items: center; gap: 9px; white-space: nowrap; }
+.pf-skill-track {
+    display: block;
+    width: 60px;
+    height: 7px;
+    background: color-mix(in srgb, var(--line) 55%, var(--page));
+}
+.pf-skill-bar { display: block; height: 100%; background: var(--green); }
+.pf-skill-share { font-size: 12px; color: var(--ink); font-weight: 600; min-width: 30px; text-align: right; }
+.pf-skill-runs { color: var(--muted); font-size: 11.5px; }
+@media (max-width: 560px) {
+    .pf-skill-track { width: 40px; }
+}
 .pf-rig-more {
     font-family: var(--mono);
     font-size: 11px;


### PR DESCRIPTION
## Summary
Direct dossier feedback, both layers:
- **One window, stacked** — `activity.daily` gains per-model token segments + daily tool_calls/commits; the site merges the bars + model-split into a single stacked chart with hover tooltips (date, sessions, tokens by model, tool calls, commits). Stable model→color map shared by bars/tooltip/legend; sub-1% models fold into "other"; peak day = ▲ marker. Separate model rows replaced by a compact legend (% · ~$).
- **Tool taste dropped** — section removed; `tools_top` stays in the gist. (The multi-hop tool→outcome version is the only comeback path, spec-deferred.)
- **The workflow** — new `workflow.arcs` section: skill sequences mined from invoked-edge order per session (bigrams/trigrams, min support 3, trigram-absorbing, top 5), public-name scrubbed. Rendered as arrow chip chains. Top live arc: `brainstorming → writing-plans → subagent-driven-development ×12`.
- **Leverage over frequency** — `rig.skills[].downstream_share`: avg fraction of session wall-time after the skill's first firing. Rig sorts by it (brainstorming-style initiators rise; post-commit mechanical skills sink), with a leverage bar + runs as secondary.

## Test Plan
- [x] 234 axctl-side tests + 90 site tests green (window-chart lib unit-covered)
- [x] typecheck / no-node-fs / site build clean
- [x] Live smoke: real arcs mined; per-day model pivot verified (191 sessions, 2.8B tokens, 7 models on day-0)
- [x] Visual iteration with enriched fixture (live gist predates schema; republish follows merge)
- [ ] Post-merge: rebuild local binary, republish gist, verify prod renders arcs + stacked window

🤖 Generated with [Claude Code](https://claude.com/claude-code)