### PR TITLE
fix(site): window chart height matches legend column

### DIFF
--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -9643,7 +9643,7 @@ footer .right {
     display: flex;
     align-items: flex-end;
     gap: 3px;
-    height: 156px;
+    height: 324px;
     border-bottom: 2px solid var(--ink);
 }
 .pf-stack-day {


### PR DESCRIPTION
## Summary
Dossier feedback: the stacked window chart (156px) sat much shorter than the model-split legend beside it, leaving a dead band. Chart track is now 324px — baseline aligns with the legend's last row; taller bars also give the per-model segments more legible area. (The all-gray bars in the same report were stale gist CDN cache, not a code issue — verified colored after expiry.)

## Test Plan
- [x] Local dev-server screenshot against live gist: chart and legend columns now match
- [ ] Post-merge prod glance

🤖 Generated with [Claude Code](https://claude.com/claude-code)