### PR TITLE
refactor(cli): shared render module for formatters - byte-identical output

### DIFF
--- a/apps/axctl/src/cli/classifiers-explain-format.ts
+++ b/apps/axctl/src/cli/classifiers-explain-format.ts
@@ -1,14 +1,9 @@
 import { prettyPrint } from "@ax/lib/json";
 import { safeJsonParse } from "@ax/lib/shared/safe-json";
 import type { ClassifierExplainPayload, ClassifierExplainResult } from "../dashboard/classifier-explain.ts";
+import { textOf, truncateText } from "./render.ts";
 
-const textOf = (value: unknown): string =>
-    typeof value === "string" ? value : value === null || value === undefined ? "" : String(value);
-
-const truncate = (value: unknown, max = 220): string => {
-    const text = textOf(value).replace(/\s+/g, " ").trim();
-    return text.length <= max ? text : `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
-};
+const truncate = (value: unknown, max = 220): string => truncateText(value, max);
 
 const formatJsonObject = (value: unknown): string => {
     if (value === null || value === undefined) return "";

--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -17,21 +17,9 @@ import {
     buildCostModelsNext,
     buildCostSplitNext,
 } from "../../nav/next-links.ts";
+import { integer, pct, usd } from "../render.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionValue, positiveLimit } from "./shared.ts";
-
-// ---------------------------------------------------------------------------
-// Formatters
-// ---------------------------------------------------------------------------
-
-const usd = (n: number): string =>
-    Number.isFinite(n) ? `$${n.toFixed(4)}` : "$0.0000";
-
-const integer = (n: number): string =>
-    Number.isFinite(n) ? Math.trunc(n).toLocaleString("en-US") : "0";
-
-const pct = (n: number): string =>
-    Number.isFinite(n) ? `${n.toFixed(1)}%` : "0.0%";
 
 // ---------------------------------------------------------------------------
 // ax cost models [--days=N] [--json]

--- a/apps/axctl/src/cli/commands/ax-dispatches.ts
+++ b/apps/axctl/src/cli/commands/ax-dispatches.ts
@@ -28,23 +28,9 @@ import {
 } from "../../queries/dispatch-analytics.ts";
 import { loadEffectiveRoutingTable } from "../../queries/routing-table-io.ts";
 import { buildDispatchesNext, buildCandidatesNext } from "../../nav/next-links.ts";
+import { pct, truncate, usd } from "../render.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionValue, positiveLimit } from "./shared.ts";
-
-// ---------------------------------------------------------------------------
-// Formatters
-// ---------------------------------------------------------------------------
-
-const usd = (n: number): string =>
-    Number.isFinite(n) ? `$${n.toFixed(4)}` : "$0.0000";
-
-const pct = (n: number): string =>
-    Number.isFinite(n) ? `${n.toFixed(1)}%` : "0.0%";
-
-const truncate = (s: string | null, len: number): string => {
-    if (!s) return "";
-    return s.length <= len ? s : `${s.slice(0, len - 1)}…`;
-};
 
 // ---------------------------------------------------------------------------
 // ax dispatches [--days=N] [--limit=N] [--candidates] [--json]

--- a/apps/axctl/src/cli/commands/ax-routing.ts
+++ b/apps/axctl/src/cli/commands/ax-routing.ts
@@ -31,11 +31,9 @@ import {
     renderTuneBrief,
     type TuneProposal,
 } from "../../queries/routing-tune.ts";
+import { usd } from "../render.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionValue, parseCsvFlag } from "./shared.ts";
-
-const usd = (n: number): string =>
-    Number.isFinite(n) ? `$${n.toFixed(2)}` : "$0.00";
 
 const printProposals = (proposals: ReadonlyArray<TuneProposal>) => {
     console.log(
@@ -44,7 +42,7 @@ const printProposals = (proposals: ReadonlyArray<TuneProposal>) => {
     for (const p of proposals) {
         console.log(
             `${p.id.padEnd(28)}  ${p.pattern.padEnd(32)}  ${p.suggest.padEnd(8)}  ` +
-            `${String(p.count).padStart(5)}  ${usd(p.total_cost_usd).padStart(11)}  ${p.judgment ? "YES" : "no"}`,
+            `${String(p.count).padStart(5)}  ${usd(p.total_cost_usd, 2).padStart(11)}  ${p.judgment ? "YES" : "no"}`,
         );
     }
 };
@@ -100,7 +98,7 @@ const tuneCommand = Command.make(
                 }
                 printProposals(proposals);
                 console.log(
-                    `\n${proposals.length} proposals  addressable spend: ${usd(proposals.reduce((s, p) => s + p.total_cost_usd, 0))}  (${days} days)`,
+                    `\n${proposals.length} proposals  addressable spend: ${usd(proposals.reduce((s, p) => s + p.total_cost_usd, 0), 2)}  (${days} days)`,
                 );
                 console.log(
                     `apply non-judgment: ax routing tune --days=${days}   brief: ax routing tune --emit-brief`,

--- a/apps/axctl/src/cli/commands/costs.ts
+++ b/apps/axctl/src/cli/commands/costs.ts
@@ -7,18 +7,9 @@ import { fetchCostSummary, type CostSummary } from "../../dashboard/cost-query.t
 import { fetchLocSummary, type LocSummary, type LocSelector } from "../../dashboard/loc-query.ts";
 import { resolvePwdRepository } from "../../pwd.ts";
 import { stderrExit } from "../output.ts";
+import { integer, usd } from "../render.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionalSince, optionValue, parseCsvFlag, positiveLimit } from "./shared.ts";
-
-const usd = (value: unknown): string => {
-    const n = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
-    return Number.isFinite(n) ? `$${n.toFixed(4)}` : "$0.0000";
-};
-
-const integer = (value: unknown): string => {
-    const n = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
-    return Number.isFinite(n) ? Math.trunc(n).toLocaleString("en-US") : "0";
-};
 
 const cmdCosts = (input: { readonly limit: number; readonly source: string | null; readonly sinceDays: number | null; readonly json: boolean }) =>
     Effect.gen(function* () {

--- a/apps/axctl/src/cli/commands/improve.ts
+++ b/apps/axctl/src/cli/commands/improve.ts
@@ -18,6 +18,7 @@ import { runPropose } from "../../improve/propose.ts";
 import { runHousekeep } from "../../improve/housekeep.ts";
 import { buildImproveProposalsNext } from "../../nav/next-links.ts";
 import { printNextLinks } from "../next-format.ts";
+import { compactPrint } from "../render.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionValue, parseFileHints, positiveLimit, requireOptionalPositiveInt, requirePositiveInt } from "./shared.ts";
 
@@ -614,7 +615,7 @@ const cmdImprovePropose = (input: { readonly file: string | undefined; readonly 
         });
         const result = yield* runPropose(parsed);
         if (input.json) {
-            console.log(JSON.stringify(result));
+            console.log(compactPrint(result));
         } else {
             console.log(`${result.status}: ${result.form} proposal "${result.title}" (sig=${result.sig})`);
             console.log("next: ax improve list - or review it in the dashboard Improve tab");
@@ -659,7 +660,7 @@ const cmdImproveHousekeep = (input: { readonly days: number; readonly dryRun: bo
     Effect.gen(function* () {
         const report = yield* runHousekeep({ days: input.days, dryRun: input.dryRun });
         if (input.json) {
-            console.log(JSON.stringify(report));
+            console.log(compactPrint(report));
             return;
         }
         if (report.staleProposals.length === 0 && report.removedTaskFiles.length === 0) {

--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -9,6 +9,7 @@ import { Command, Flag } from "effect/unstable/cli";
 import { prettyPrint } from "@ax/lib/json";
 import { buildProfile, type ProfileEnv } from "../../profile/render.ts";
 import type { ProfileV1 } from "../../profile/schema.ts";
+import { integer } from "../render.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionValue } from "./shared.ts";
 import { GitHubEnvLive } from "../../profile/github-env.ts";
@@ -84,9 +85,6 @@ const gatherEnv = Effect.gen(function* () {
 // ---------------------------------------------------------------------------
 // Formatting
 // ---------------------------------------------------------------------------
-
-const integer = (n: number): string =>
-    Number.isFinite(n) ? Math.trunc(n).toLocaleString("en-US") : "0";
 
 /** Human money: >=1000 -> "~$22.6K", else "$22". */
 const money = (n: number): string => {

--- a/apps/axctl/src/cli/commands/wrapped.ts
+++ b/apps/axctl/src/cli/commands/wrapped.ts
@@ -15,6 +15,7 @@ import { Effect } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import { renderWrappedGenerateBrief } from "../../dashboard/wrapped-generate-brief.ts";
 import { runPublishCards } from "../../dashboard/wrapped-cards.ts";
+import { compactPrint } from "../render.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { jsonFlag, optionValue } from "./shared.ts";
 
@@ -47,7 +48,7 @@ const cmdWrappedPublish = (input: { readonly file: string | undefined; readonly 
         });
         const result = yield* runPublishCards(parsed);
         if (input.json) {
-            console.log(JSON.stringify(result));
+            console.log(compactPrint(result));
         } else {
             console.log(`published ${result.count} wrapped cards - the dashboard landing serves them now`);
         }

--- a/apps/axctl/src/cli/insights-format.ts
+++ b/apps/axctl/src/cli/insights-format.ts
@@ -1,10 +1,8 @@
 import type { InsightView } from "../queries/insights.ts";
 import { prettyPrint } from "@ax/lib/json";
+import { textOf, truncateText } from "./render.ts";
 
 type InsightRow = Record<string, unknown>;
-
-const textOf = (value: unknown): string =>
-    typeof value === "string" ? value : value === undefined || value === null ? "" : String(value);
 
 const numberOf = (value: unknown): number | null =>
     typeof value === "number" && Number.isFinite(value) ? value : null;
@@ -14,10 +12,7 @@ const compactDate = (value: unknown): string => {
     return text.length >= 19 ? text.slice(0, 19).replace("T", " ") : text;
 };
 
-const truncate = (value: unknown, max = 180): string => {
-    const text = textOf(value).replace(/\s+/g, " ").trim();
-    return text.length <= max ? text : `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
-};
+const truncate = (value: unknown, max = 180): string => truncateText(value, max);
 
 const firstExampleText = (row: InsightRow): string => {
     const examples = row.examples;

--- a/apps/axctl/src/cli/render.test.ts
+++ b/apps/axctl/src/cli/render.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { compactPrint, integer, pct, textOf, truncate, truncateText, usd } from "./render.ts";
+
+// These tests snapshot the EXACT strings the formatters produced before they
+// were unified out of costs.ts / ax-cost.ts / ax-dispatches.ts / ax-routing.ts /
+// profile.ts / insights-format.ts / classifiers-explain-format.ts. The render
+// module's contract is byte-identical output - do not "fix" expectations.
+
+describe("usd", () => {
+    test("formats numbers with 4 decimals by default", () => {
+        expect(usd(0)).toBe("$0.0000");
+        expect(usd(0.1234567)).toBe("$0.1235");
+        expect(usd(12.5)).toBe("$12.5000");
+        expect(usd(-3.21)).toBe("$-3.2100");
+    });
+
+    test("coerces numeric strings (costs.ts behaviour)", () => {
+        expect(usd("1.5")).toBe("$1.5000");
+        expect(usd("not-a-number")).toBe("$0.0000");
+    });
+
+    test("non-finite and non-numeric values render zero", () => {
+        expect(usd(NaN)).toBe("$0.0000");
+        expect(usd(Infinity)).toBe("$0.0000");
+        expect(usd(null)).toBe("$0.0000");
+        expect(usd(undefined)).toBe("$0.0000");
+        expect(usd({})).toBe("$0.0000");
+    });
+
+    test("decimals=2 reproduces ax-routing.ts output", () => {
+        expect(usd(0, 2)).toBe("$0.00");
+        expect(usd(12.345, 2)).toBe("$12.35");
+        expect(usd(NaN, 2)).toBe("$0.00");
+    });
+});
+
+describe("integer", () => {
+    test("truncates and groups with en-US separators", () => {
+        expect(integer(0)).toBe("0");
+        expect(integer(1234567)).toBe("1,234,567");
+        expect(integer(12.9)).toBe("12");
+        expect(integer(-1234.9)).toBe("-1,234");
+    });
+
+    test("coerces numeric strings", () => {
+        expect(integer("4200")).toBe("4,200");
+    });
+
+    test("non-finite renders 0", () => {
+        expect(integer(NaN)).toBe("0");
+        expect(integer(Infinity)).toBe("0");
+        expect(integer(null)).toBe("0");
+        expect(integer(undefined)).toBe("0");
+    });
+});
+
+describe("pct", () => {
+    test("one decimal with percent sign", () => {
+        expect(pct(0)).toBe("0.0%");
+        expect(pct(12.34)).toBe("12.3%");
+        expect(pct(100)).toBe("100.0%");
+    });
+
+    test("non-finite renders 0.0%", () => {
+        expect(pct(NaN)).toBe("0.0%");
+        expect(pct(Infinity)).toBe("0.0%");
+    });
+});
+
+describe("truncate", () => {
+    test("nullish/empty input renders empty string", () => {
+        expect(truncate(null, 10)).toBe("");
+        expect(truncate("", 10)).toBe("");
+    });
+
+    test("short strings pass through unchanged", () => {
+        expect(truncate("abc", 5)).toBe("abc");
+        expect(truncate("abcde", 5)).toBe("abcde");
+    });
+
+    test("overflow replaces the last kept char with an ellipsis", () => {
+        expect(truncate("abcdef", 5)).toBe("abcd…");
+        expect(truncate("hello world", 8)).toBe("hello w…");
+    });
+
+    test("preserves internal whitespace (table-cell variant)", () => {
+        expect(truncate("a  b", 10)).toBe("a  b");
+    });
+});
+
+describe("textOf", () => {
+    test("strings pass through, nullish renders empty", () => {
+        expect(textOf("x")).toBe("x");
+        expect(textOf(null)).toBe("");
+        expect(textOf(undefined)).toBe("");
+    });
+
+    test("other values stringify", () => {
+        expect(textOf(42)).toBe("42");
+        expect(textOf(true)).toBe("true");
+    });
+});
+
+describe("truncateText", () => {
+    test("collapses whitespace runs and trims", () => {
+        expect(truncateText("  a  b\n\tc  ", 180)).toBe("a b c");
+    });
+
+    test("short text passes through after collapsing", () => {
+        expect(truncateText("hello", 5)).toBe("hello");
+    });
+
+    test("overflow trims trailing space before the ellipsis", () => {
+        expect(truncateText("aaaa bbbb", 6)).toBe("aaaa…");
+        expect(truncateText("abcdefgh", 5)).toBe("abcd…");
+    });
+
+    test("non-string values coerce via textOf", () => {
+        expect(truncateText(1234, 10)).toBe("1234");
+        expect(truncateText(null, 10)).toBe("");
+    });
+
+    test("max=0 renders a bare ellipsis for non-empty text", () => {
+        expect(truncateText("abc", 0)).toBe("…");
+    });
+});
+
+describe("compactPrint", () => {
+    test("byte-identical to bare JSON.stringify", () => {
+        const value = { b: 1, a: [1, "x", null], nested: { k: true } };
+        expect(compactPrint(value)).toBe(JSON.stringify(value));
+        expect(compactPrint(value)).toBe('{"b":1,"a":[1,"x",null],"nested":{"k":true}}');
+    });
+
+    test("no pretty-print whitespace", () => {
+        expect(compactPrint({ a: 1 })).toBe('{"a":1}');
+        expect(compactPrint([1, 2])).toBe("[1,2]");
+    });
+});

--- a/apps/axctl/src/cli/render.ts
+++ b/apps/axctl/src/cli/render.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared CLI output formatters - the single home for the small value
+ * formatters that used to be copy-pasted across command handlers
+ * (costs, ax-cost, ax-dispatches, ax-routing, profile, insights-format,
+ * classifiers-explain-format).
+ *
+ * BYTE-IDENTICAL contract: every formatter here reproduces the exact output
+ * of the local copies it replaced. Where copies differed (e.g. `usd` decimal
+ * places: 4 in cost tables, 2 in routing proposals; `truncate` default max),
+ * the difference is a parameter so each call site keeps its current bytes.
+ *
+ * Deliberately NOT unified here (semantics differ - do not "clean up"):
+ *  - `share/format.ts` usd (conditional 2/4 decimals on magnitude)
+ *  - `improve/impact.ts` usd (rounds >= 100 with en grouping)
+ *  - `session-show-format.ts` usd (null renders "?")
+ *  - `profile.ts` money ("~$22.6K" compaction)
+ *  - `quota/format.ts` pct (Math.round, no decimal)
+ *  - `metrics/session-churn.ts` truncate ("..." 3-char suffix)
+ */
+
+/**
+ * Format a value as USD with fixed decimals (default 4: "$0.1234").
+ * Coerces numeric strings; anything non-finite renders as zero
+ * ("$0.0000" / "$0.00") rather than throwing - cost tables must never crash
+ * on a missing aggregate.
+ */
+export const usd = (value: unknown, decimals: number = 4): string => {
+    const n = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+    return Number.isFinite(n) ? `$${n.toFixed(decimals)}` : `$${(0).toFixed(decimals)}`;
+};
+
+/**
+ * Format a value as a truncated integer with en-US thousands grouping
+ * ("1,234,567"). Coerces numeric strings; non-finite renders "0".
+ */
+export const integer = (value: unknown): string => {
+    const n = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+    return Number.isFinite(n) ? Math.trunc(n).toLocaleString("en-US") : "0";
+};
+
+/** Format a percentage with one decimal ("12.3%"); non-finite renders "0.0%". */
+export const pct = (n: number): string =>
+    Number.isFinite(n) ? `${n.toFixed(1)}%` : "0.0%";
+
+/**
+ * Truncate a plain string to `len` characters, replacing the last kept
+ * character with a single "…" when it overflows. Nullish/empty input
+ * renders "". Whitespace is preserved as-is (table cells - see
+ * `truncateText` for the prose variant).
+ */
+export const truncate = (s: string | null, len: number): string => {
+    if (!s) return "";
+    return s.length <= len ? s : `${s.slice(0, len - 1)}…`;
+};
+
+/** Render any value as text: strings pass through, nullish renders "". */
+export const textOf = (value: unknown): string =>
+    typeof value === "string" ? value : value === undefined || value === null ? "" : String(value);
+
+/**
+ * Prose-style truncation: collapse whitespace runs to single spaces, trim,
+ * then cap at `max` characters with a trailing "…" (trailing spaces trimmed
+ * before the ellipsis). Accepts any value via `textOf`.
+ */
+export const truncateText = (value: unknown, max: number): string => {
+    const text = textOf(value).replace(/\s+/g, " ").trim();
+    return text.length <= max ? text : `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+};
+
+/**
+ * Single-line JSON for machine-readable stdout (`--json` paths that
+ * intentionally do NOT pretty-print). Byte-identical to a bare
+ * `JSON.stringify(value)` - kept here so command handlers have one JSON
+ * output seam alongside `prettyPrint` (@ax/lib/json).
+ */
+export const compactPrint = (value: unknown): string => JSON.stringify(value);


### PR DESCRIPTION
## What

Creates `apps/axctl/src/cli/render.ts` - one deep CLI output rendering module - and deletes the formatter copies that had accumulated across command handlers. **Output is byte-identical**: no envelope shape changes, no spacing changes.

## Unified into render.ts

| Formatter | Replaced local copies | Notes |
|---|---|---|
| `usd(value, decimals=4)` | `costs.ts`, `ax-cost.ts`, `ax-dispatches.ts`, `ax-routing.ts` | routing used **2** decimals - its call sites now pass `usd(n, 2)` explicitly, so the difference is a parameter, not a behavior change. Keeps costs.ts's numeric-string coercion (identity for the number-typed call sites). |
| `integer(value)` | `costs.ts`, `ax-cost.ts`, `profile.ts` | identical bodies (`Math.trunc` + `toLocaleString("en-US")`) |
| `pct(n)` | `ax-dispatches.ts`, `ax-cost.ts` | identical bodies |
| `truncate(s, len)` | `ax-dispatches.ts` | ellipsis table truncation, whitespace preserved |
| `textOf(value)` + `truncateText(value, max)` | `insights-format.ts`, `classifiers-explain-format.ts` | bodies were identical except the default max (180 vs 220); each file keeps a one-line default binding over the shared implementation so every call site's bytes are unchanged |
| `compactPrint(value)` | `improve.ts` (propose/housekeep `--json`), `wrapped.ts` (publish `--json`) | these hand-rolled `JSON.stringify` outputs are intentionally **compact**; routing them through `prettyPrint` would change bytes (2-space indent), so they get a compact mode that is byte-identical to bare `JSON.stringify` |

## Deliberately NOT unified (semantics differ - verified, not assumed)

- `share/format.ts` `usd` - magnitude-conditional 2/4 decimals
- `improve/impact.ts` `usd` - rounds >= 100 with `en` grouping
- `session-show-format.ts` `usd` - `null` renders `"?"` (per task: internals untouched, no literally-identical primitive existed)
- `profile.ts` `money` - `~$22.6K` compaction
- `quota/format.ts` `pct` - `Math.round`, no decimal
- `metrics/session-churn.ts` `truncate` - `"..."` 3-char suffix
- `sessions.ts` `formatSessionsTable` - unique formatter, no duplicate exists anywhere; left intact (listed in the brief, but moving it would be restructuring, not de-duplication)
- `improve.ts` `formatProposalLine` - unique, no duplicate

## Byte-identity verification

- `render.test.ts`: 22 bun:test cases snapshotting the exact output strings (USD decimals/fallbacks, en-US grouping, ellipsis edge cases, whitespace collapse + `trimEnd`, compact JSON)
- Differential fuzz run: every replaced local implementation (verbatim copies) compared against the shared module over numeric edge cases (NaN/±Infinity/1e-8/negatives), numeric strings, unicode/emoji strings, and all truncation lengths used in the codebase - `PARITY OK`, zero mismatches
- `bun run typecheck` exit 0; `bun test` repo-wide: 3867 pass / 0 fail; `check:no-node-fs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)