### PR TITLE
refactor(hooks): hooks-sdk owns routing-table schema/read; drop vestigial GitEnv dep (ADR-0014)

### DIFF
--- a/apps/axctl/src/queries/dispatch-analytics.ts
+++ b/apps/axctl/src/queries/dispatch-analytics.ts
@@ -10,12 +10,18 @@
  *   (3) Agent tool_call rows in window: session, call_id, input_json.
  *   (4) Parent session models: SELECT id, model FROM session (non-subagent).
  *
- * Routing classes mirror packages/hooks-sdk/src/hooks/route-dispatch.ts
- * (feat/route-dispatch-hook branch). NOT imported from there - duplicated with
- * a comment. A compile-routing step will unify later.
+ * Routing classes come from @ax/hooks-sdk/routing-table (DEFAULT_ROUTING_TABLE)
+ * - the same module the route-dispatch hook reads, so hook and CLI can never
+ * drift (ADR-0014). ROUTING_CLASSES remains the exported name for the shipped
+ * default seed.
  */
 import { Effect, FileSystem, Path } from "effect";
 import { SurrealClient } from "@ax/lib/db";
+import {
+    DEFAULT_ROUTING_TABLE,
+    type RoutingClass,
+    type RoutingTable,
+} from "@ax/hooks-sdk/routing-table";
 import { estimateCost, type ModelPricing } from "../ingest/model-pricing.ts";
 import {
     defaultRoutingTablePath,
@@ -25,103 +31,17 @@ import {
 } from "./routing-table-io.ts";
 
 // ---------------------------------------------------------------------------
-// Routing classes
-// (mirrors packages/hooks-sdk/src/hooks/route-dispatch.ts DEFAULT_TABLE)
+// Routing classes (schema + defaults owned by @ax/hooks-sdk/routing-table)
 // ---------------------------------------------------------------------------
 
-export interface RoutingClass {
-    readonly id: string;
-    readonly pattern: string;
-    readonly flags: string;
-    readonly suggest: string; // "sonnet" | "haiku"
-    readonly reason: string;
-}
-
-export interface RoutingTable {
-    readonly version: 1;
-    readonly classes: ReadonlyArray<RoutingClass>;
-    readonly agentTypes: Readonly<Record<string, string>>;
-}
+export type { RoutingClass, RoutingTable };
 
 /**
- * ROUTING_CLASSES - exported typed constant.
- * Mirrors route-dispatch.ts DEFAULT_TABLE. Do NOT import from there;
- * a compile-routing step will unify them later.
+ * ROUTING_CLASSES - the shipped default seed (`ax routing compile` refreshes
+ * the stored table's origin:default rows from it). Alias of the hooks-sdk
+ * DEFAULT_ROUTING_TABLE that the route-dispatch hook falls back to.
  */
-export const ROUTING_CLASSES: RoutingTable = {
-    version: 1,
-    classes: [
-        // Quality reviews and PR reviews deliberately have NO class: the main
-        // model is the Q&A reviewer in this workflow, so only the mechanical
-        // spec-compliance pass routes down.
-        {
-            id: "spec-review",
-            pattern: "^spec review",
-            flags: "i",
-            suggest: "sonnet",
-            reason: "spec-compliance checklist review",
-        },
-        {
-            id: "search-locate",
-            pattern: "^(pattern-find|locate|find|map|sweep|grep)",
-            flags: "i",
-            suggest: "haiku",
-            reason: "code search/sweep",
-        },
-        {
-            id: "research",
-            pattern: "^(research|investigate docs|study)",
-            flags: "i",
-            suggest: "sonnet",
-            reason: "web/docs research",
-        },
-        {
-            id: "well-specified-impl",
-            pattern: "^implement ",
-            flags: "i",
-            suggest: "sonnet",
-            reason: "spec'd implementation",
-        },
-        {
-            id: "bulk-mechanical",
-            pattern: "^(write announcements|regenerate|standardize|merge main)",
-            flags: "i",
-            suggest: "sonnet",
-            reason: "bulk mechanical work",
-        },
-        // Mined by /routing-tune 2026-06-12 (adversarially backtested over 90d;
-        // brief: .ax/tasks/routing-tune-undated.md). The colon in task-N-impl
-        // is load-bearing: "Task 4 spec compliance review" (no colon) must NOT
-        // match - reviews stay on the main model.
-        {
-            id: "task-N-impl",
-            pattern: "^Task \\d+:",
-            flags: "i",
-            suggest: "sonnet",
-            reason: "numbered plan-task implementation",
-        },
-        {
-            id: "bug-fix",
-            pattern: "^Fix\\s",
-            flags: "i",
-            suggest: "sonnet",
-            reason: "bounded bug-fix remediation",
-        },
-        {
-            id: "feature-add",
-            pattern: "^Add\\s",
-            flags: "i",
-            suggest: "sonnet",
-            reason: "additive feature with a clear target",
-        },
-    ],
-    agentTypes: {
-        Explore: "haiku",
-        "codebase-locator": "haiku",
-        "codebase-pattern-finder": "haiku",
-        "codebase-analyzer": "sonnet",
-    },
-};
+export const ROUTING_CLASSES: RoutingTable = DEFAULT_ROUTING_TABLE;
 
 // Model name resolution for repricing suggestions
 const MODEL_ALIASES: Record<string, string> = {

--- a/apps/axctl/src/queries/routing-table-io.ts
+++ b/apps/axctl/src/queries/routing-table-io.ts
@@ -1,21 +1,35 @@
 /**
- * Stored routing-table format + IO.
+ * Stored routing-table merge/compile/save logic.
  *
  * ~/.ax/hooks/routing-table.json is the live source of truth read by the
- * route-dispatch hook and `ax dispatches --candidates`. Classes carry an
- * `origin` tag: "default" rows are refreshed from ROUTING_CLASSES on every
- * `ax routing compile`; "user" rows (mined by `ax routing tune` or hand-added)
- * survive regeneration. Merge key: class id; a default id always wins.
+ * route-dispatch hook and `ax dispatches --candidates`. The table SCHEMA
+ * (types + validation) and the READ path live in @ax/hooks-sdk/routing-table
+ * (ADR-0014) - re-exported here for existing consumers; this module owns the
+ * write side: merge, append, save.
+ *
+ * Classes carry an `origin` tag: "default" rows are refreshed from
+ * ROUTING_CLASSES on every `ax routing compile`; "user" rows (mined by
+ * `ax routing tune` or hand-added) survive regeneration. Merge key: class id;
+ * a default id always wins.
  *
  * agentTypes is asymmetric on merge: defaults refresh on every compile
  * (a stale stored copy never shadows an updated default), while user-ADDED
  * keys (absent from defaults) survive.
  */
 import { Effect, FileSystem, Path } from "effect";
-import { homedir } from "node:os";
-import { ROUTING_CLASSES, type RoutingClass, type RoutingTable } from "./dispatch-analytics.ts";
+import {
+    DEFAULT_ROUTING_TABLE,
+    defaultRoutingTablePath,
+    loadStoredRoutingTable,
+    type ClassOrigin,
+    type LoadedRoutingClass,
+    type LoadedRoutingTable,
+    type RoutingClass,
+    type RoutingTable,
+} from "@ax/hooks-sdk/routing-table";
 
-export type ClassOrigin = "default" | "user";
+export { defaultRoutingTablePath, loadStoredRoutingTable };
+export type { ClassOrigin, LoadedRoutingClass, LoadedRoutingTable };
 
 export interface StoredRoutingClass extends RoutingClass {
     readonly origin: ClassOrigin;
@@ -26,25 +40,6 @@ export interface StoredRoutingTable {
     readonly classes: ReadonlyArray<StoredRoutingClass>;
     readonly agentTypes: Readonly<Record<string, string>>;
 }
-
-/**
- * What a load from disk can actually promise: legacy files (written by the
- * pre-origin `ax dispatches compile-routing`) and hand-added rows may lack
- * the origin tag. mergeRoutingTables accepts this shape and always RETURNS
- * definite origins (origin-less rows are migrated to "user").
- */
-export interface LoadedRoutingClass extends RoutingClass {
-    readonly origin?: ClassOrigin;
-}
-
-export interface LoadedRoutingTable {
-    readonly version: 1;
-    readonly classes: ReadonlyArray<LoadedRoutingClass>;
-    readonly agentTypes: Readonly<Record<string, string>>;
-}
-
-export const defaultRoutingTablePath = (): string =>
-    `${homedir()}/.ax/hooks/routing-table.json`;
 
 /**
  * Refresh defaults, keep user classes. Default ids always win on collision.
@@ -88,65 +83,6 @@ export const appendUserClasses = (
     return { ...table, classes: [...table.classes, ...fresh] };
 };
 
-const isRecord = (v: unknown): v is Record<string, unknown> =>
-    typeof v === "object" && v !== null && !Array.isArray(v);
-
-/** Rebuild a class row from untrusted JSON; null when required fields are bad. */
-const normalizeClassRow = (row: unknown): LoadedRoutingClass | null => {
-    if (!isRecord(row)) return null;
-    if (
-        typeof row.id !== "string" ||
-        typeof row.pattern !== "string" ||
-        typeof row.suggest !== "string" ||
-        typeof row.reason !== "string"
-    ) {
-        return null;
-    }
-    const base = {
-        id: row.id,
-        pattern: row.pattern,
-        flags: typeof row.flags === "string" ? row.flags : "",
-        suggest: row.suggest,
-        reason: row.reason,
-    };
-    const origin = row.origin === "default" || row.origin === "user" ? row.origin : undefined;
-    return origin === undefined ? base : { ...base, origin };
-};
-
-/**
- * Read + parse + normalize the stored table. Null on missing file / bad JSON /
- * bad top-level shape. Malformed class rows are dropped; a missing or
- * non-object agentTypes becomes {} (hand-edited files must not type-lie
- * downstream).
- */
-export const loadStoredRoutingTable = (
-    path: string,
-): Effect.Effect<LoadedRoutingTable | null, never, FileSystem.FileSystem> =>
-    Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const text = yield* fs.readFileString(path).pipe(Effect.orElseSucceed(() => null));
-        if (text === null) return null;
-        try {
-            const parsed: unknown = JSON.parse(text);
-            if (!isRecord(parsed) || parsed.version !== 1 || !Array.isArray(parsed.classes)) {
-                return null;
-            }
-            const classes = parsed.classes
-                .map(normalizeClassRow)
-                .filter((c): c is LoadedRoutingClass => c !== null);
-            const agentTypes: Record<string, string> = isRecord(parsed.agentTypes)
-                ? Object.fromEntries(
-                      Object.entries(parsed.agentTypes).filter(
-                          (e): e is [string, string] => typeof e[1] === "string",
-                      ),
-                  )
-                : {};
-            return { version: 1, classes, agentTypes } satisfies LoadedRoutingTable;
-        } catch {
-            return null;
-        }
-    });
-
 export const saveStoredRoutingTable = (
     path: string,
     table: StoredRoutingTable,
@@ -167,7 +103,7 @@ export const loadEffectiveRoutingTable = (
 ): Effect.Effect<RoutingTable, never, FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const stored = yield* loadStoredRoutingTable(path ?? defaultRoutingTablePath());
-        if (stored === null) return ROUTING_CLASSES;
+        if (stored === null) return DEFAULT_ROUTING_TABLE;
         return {
             version: 1,
             classes: stored.classes,

--- a/docs/adr/0014-hooks-ownership-split.md
+++ b/docs/adr/0014-hooks-ownership-split.md
@@ -1,0 +1,62 @@
+# Hooks ownership split: hooks-sdk owns definition + fire path, axctl owns config + analysis
+
+Status: Accepted (2026-06-13)
+
+Hook functionality had grown in two places at once - `packages/hooks-sdk` (the
+fire-path runtime consumed from `~/.ax/hooks` via a `file:` dep) and
+`apps/axctl/src/hooks` (the CLI surface) - with no stated boundary. The locked
+split:
+
+- **`@ax/hooks-sdk`** owns the typed hook definition (`defineHook`,
+  `HookDefinition`, `runHook`/`runMain`), verdicts (allow / block / warn /
+  inject, defects fail OPEN), the fire path (`bun <file>.ts`, ~70ms budget, no
+  axctl in the hot path), the prebuilt hooks (`enforce-worktree`,
+  `enforce-worktree-write`, `route-dispatch`), the `GitEnv` service, AND the
+  routing-table schema + loader (`src/routing-table.ts`: Schema validation,
+  `~/.ax/hooks/routing-table.json` path, sync fail-open read for the fire
+  path, normalized Effect read for the compile side).
+- **`axctl`** owns provider config CRUD via `HookProviderRegistry`
+  (claude/codex codecs, ax ownership markers, park sidecars), install fan-out
+  (`ax hooks init|install`), telemetry (`hook_command_invocation` evidence
+  joins), backtest/cases (`ax hooks backtest|cases`), and routing ANALYSIS +
+  WRITES (`ax dispatches`, `ax routing compile|tune|show`:
+  merge/append/save in `queries/routing-table-io.ts`).
+
+The dependency arrow only ever points axctl → hooks-sdk. The sdk stays
+dependency-light (`effect` only, pinned not catalog:) because `~/.ax/hooks`
+workspaces resolve it outside the monorepo.
+
+## Consequence: routing-table dedup
+
+`route-dispatch.ts` and `queries/routing-table-io.ts` each carried their own
+schema + parse of routing-table.json, and the default class seed was duplicated
+verbatim (`DEFAULT_TABLE` in the hook, `ROUTING_CLASSES` in
+`dispatch-analytics.ts`) with mirror-me comments. Both now import one module,
+`@ax/hooks-sdk/routing-table`; `ROUTING_CLASSES` is an alias of the sdk's
+`DEFAULT_ROUTING_TABLE`, so the hook's fallback and the compile seed cannot
+drift. The defaults live in the sdk rather than axctl because the fire path
+must work before any `ax routing compile` step exists; axctl re-exports them,
+so no import cycle (this also broke the prior routing-table-io ↔
+dispatch-analytics cycle).
+
+The two read semantics are deliberately both kept, side by side in the one
+module: the fire path does a whole-table fail-open decode (any problem →
+built-in defaults; a corrupt table must never wedge the agent), while the
+compile side normalizes row-by-row and returns null on a structurally bad file
+(so `ax routing compile` can refuse to overwrite it).
+
+Also folded in: `route-dispatch` no longer requires `GitEnv` - routing is pure
+table matching on tool input. `HookDefinition.run`'s R-channel stays typed as
+`GitEnv` (covariant, `never` is assignable), so hooks that need git state keep
+it and pure hooks just don't yield it.
+
+## Trade-offs
+
+- The sdk imports `node:fs` in `routing-table.ts` (sync read keeps the hook's
+  error channel `never` under plain bun); the `check:no-node-fs` allowlist
+  entry moved from `hooks/route-dispatch.ts` to `routing-table.ts`.
+- Match logic is still implemented twice (`matchTable` in the hook,
+  `matchRoutingWith` in `dispatch-analytics.ts`) - same table, near-identical
+  semantics. Left as-is for now: the candidates path matches with
+  required-flags rows while the hook must tolerate hand-edited optional flags;
+  unifying it is a candidate follow-up, not part of this split.

--- a/packages/hooks-sdk/src/hooks/route-dispatch.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.ts
@@ -17,145 +17,23 @@
  *   - Codex has no Agent-tool dispatch equivalent; this hook is Claude-only
  *     but the SDK fires it for any harness - it will just never match on Codex
  *     because Codex never emits an `Agent` tool name.
+ *
+ * The routing-table schema, built-in defaults, and the fail-open read live in
+ * ../routing-table.ts (ADR-0014) - the same module `ax routing compile|tune`
+ * builds against, so the hook and the CLI can never drift on format.
  */
 
-import { Effect, Result, Schema } from "effect";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { Effect } from "effect";
 import { defineHook, runMain } from "../define.ts";
-import { GitEnv } from "../git-env.ts";
+import {
+  loadRoutingTableOrDefault,
+  type RoutingTableShape,
+} from "../routing-table.ts";
 import { Verdict } from "../verdict.ts";
 
-// ---------------------------------------------------------------------------
-// Routing table schema
-// ---------------------------------------------------------------------------
-
-const RoutingClass = Schema.Struct({
-  id: Schema.String,
-  pattern: Schema.String,
-  flags: Schema.optional(Schema.String),
-  suggest: Schema.String,
-  reason: Schema.String,
-  // Provenance tag written by ax routing compile/tune ("default" | "user").
-  // Kept as a plain optional string: the hook never reads origin, so an
-  // unknown value must not fail the whole-table decode (which would silently
-  // revert the user's routing table to DEFAULT_TABLE).
-  origin: Schema.optional(Schema.String),
-});
-
-const RoutingTable = Schema.Struct({
-  version: Schema.Literal(1),
-  classes: Schema.Array(RoutingClass),
-  agentTypes: Schema.optional(Schema.Record(Schema.String, Schema.String)),
-});
-
-type RoutingTableType = Schema.Schema.Type<typeof RoutingTable>;
-
-export { RoutingTable as RoutingTableSchema };
-
-// ---------------------------------------------------------------------------
-// Built-in defaults (used when ~/.ax/hooks/routing-table.json is absent /
-// unparseable - the hook must work before any compile-routing step exists)
-// ---------------------------------------------------------------------------
-
-const DEFAULT_TABLE: RoutingTableType = {
-  version: 1,
-  classes: [
-    // Quality reviews and PR reviews deliberately have NO class: the main
-    // model is the Q&A reviewer in this workflow, so only the mechanical
-    // spec-compliance pass routes down. Mirrors ROUTING_CLASSES in
-    // apps/axctl/src/queries/dispatch-analytics.ts (compile-routing unifies).
-    {
-      id: "spec-review",
-      pattern: "^spec review",
-      flags: "i",
-      suggest: "sonnet",
-      reason: "spec-compliance checklist review",
-    },
-    {
-      id: "search-locate",
-      pattern: "^(pattern-find|locate|find|map|sweep|grep)",
-      flags: "i",
-      suggest: "haiku",
-      reason: "code search/sweep",
-    },
-    {
-      id: "research",
-      pattern: "^(research|investigate docs|study)",
-      flags: "i",
-      suggest: "sonnet",
-      reason: "web/docs research",
-    },
-    {
-      id: "well-specified-impl",
-      pattern: "^implement ",
-      flags: "i",
-      suggest: "sonnet",
-      reason: "spec'd implementation",
-    },
-    {
-      id: "bulk-mechanical",
-      pattern: "^(write announcements|regenerate|standardize|merge main)",
-      flags: "i",
-      suggest: "sonnet",
-      reason: "bulk mechanical work",
-    },
-    // Mined by /routing-tune 2026-06-12; mirrors dispatch-analytics.ts.
-    {
-      id: "task-N-impl",
-      pattern: "^Task \\d+:",
-      flags: "i",
-      suggest: "sonnet",
-      reason: "numbered plan-task implementation",
-    },
-    {
-      id: "bug-fix",
-      pattern: "^Fix\\s",
-      flags: "i",
-      suggest: "sonnet",
-      reason: "bounded bug-fix remediation",
-    },
-    {
-      id: "feature-add",
-      pattern: "^Add\\s",
-      flags: "i",
-      suggest: "sonnet",
-      reason: "additive feature with a clear target",
-    },
-  ],
-  agentTypes: {
-    Explore: "haiku",
-    "codebase-locator": "haiku",
-    "codebase-pattern-finder": "haiku",
-    "codebase-analyzer": "sonnet",
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Load routing table (synchronous; fails open on any error)
-// ---------------------------------------------------------------------------
-
-const ROUTING_TABLE_PATH = `${homedir()}/.ax/hooks/routing-table.json`;
-
-const decodeRoutingTable = Schema.decodeUnknownResult(RoutingTable);
-
-/**
- * Load and validate the routing table from disk.
- * Returns DEFAULT_TABLE on any error (missing file, bad JSON, schema mismatch).
- */
-const loadRoutingTable = (): RoutingTableType => {
-  try {
-    const text = readFileSync(ROUTING_TABLE_PATH, "utf8");
-    const parsed: unknown = JSON.parse(text);
-    const result = decodeRoutingTable(parsed);
-    if (Result.isSuccess(result)) return result.success;
-    // Schema validation failed - fall back to defaults (fail open)
-    return DEFAULT_TABLE;
-  } catch {
-    // File absent, unreadable, or non-JSON - fall back to defaults
-    return DEFAULT_TABLE;
-  }
-};
+// Re-exported for consumers (ax hooks tooling, tests) that historically
+// imported the schema from the hook file.
+export { RoutingTableSchema } from "../routing-table.ts";
 
 // ---------------------------------------------------------------------------
 // Match logic (pure, synchronous)
@@ -169,7 +47,7 @@ interface MatchResult {
 }
 
 const matchTable = (
-  table: RoutingTableType,
+  table: RoutingTableShape,
   description: string | undefined,
   subagentType: string | undefined,
 ): MatchResult | null => {
@@ -236,13 +114,10 @@ const hook = defineHook({
   events: ["PreToolUse"],
   // Only fire for Agent-tool dispatches.
   matcher: { tools: ["Agent"] },
+  // No GitEnv needed: routing is pure table matching on the tool input.
+  // (R = never is assignable to the HookDefinition's R = GitEnv.)
   run: (event) =>
-    // GitEnv is required by the HookDefinition interface signature, but this
-    // hook does not need git state. We yield* it to satisfy the type, but
-    // never call any of its methods.
-    Effect.gen(function* () {
-      void (yield* GitEnv); // satisfy R=GitEnv; unused
-
+    Effect.sync(() => {
       const input = event.tool?.input ?? {};
       const model = input.model;
       const subagentType =
@@ -259,7 +134,7 @@ const hook = defineHook({
 
       const description = rawDescription ?? rawPrompt;
 
-      const table = loadRoutingTable();
+      const table = loadRoutingTableOrDefault();
       const match = matchTable(table, description, subagentType);
 
       if (match === null) return Verdict.allow;

--- a/packages/hooks-sdk/src/index.ts
+++ b/packages/hooks-sdk/src/index.ts
@@ -2,3 +2,19 @@ export { defineHook, matches, runHook, runMain, type HookDefinition } from "./de
 export { Verdict } from "./verdict.ts";
 export type { Harness, HookEvent, HookEventName } from "./event.ts";
 export { GitEnv, GitEnvLive, GitEnvTest, type GitEnvService } from "./git-env.ts";
+export {
+  DEFAULT_ROUTING_TABLE,
+  RoutingClassSchema,
+  RoutingTableSchema,
+  defaultRoutingTablePath,
+  loadRoutingTableOrDefault,
+  loadStoredRoutingTable,
+  parseStoredRoutingTable,
+  readRoutingTableSync,
+  type ClassOrigin,
+  type LoadedRoutingClass,
+  type LoadedRoutingTable,
+  type RoutingClass,
+  type RoutingTable,
+  type RoutingTableShape,
+} from "./routing-table.ts";

--- a/packages/hooks-sdk/src/routing-table.test.ts
+++ b/packages/hooks-sdk/src/routing-table.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { Result, Schema } from "effect";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_ROUTING_TABLE,
+  RoutingTableSchema,
+  loadRoutingTableOrDefault,
+  parseStoredRoutingTable,
+  readRoutingTableSync,
+} from "./routing-table.ts";
+
+const tmp = (): string => mkdtempSync(join(tmpdir(), "ax-routing-table-"));
+
+const validTable = {
+  version: 1,
+  classes: [
+    { id: "spec-review", pattern: "^spec review", flags: "i", suggest: "sonnet", reason: "x" },
+  ],
+  agentTypes: { Explore: "haiku" },
+};
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("RoutingTableSchema", () => {
+  const decode = Schema.decodeUnknownResult(RoutingTableSchema);
+
+  test("accepts origin-tagged classes written by ax routing compile/tune", () => {
+    const result = decode({
+      version: 1,
+      classes: [
+        { ...validTable.classes[0], origin: "default" },
+        { id: "mined", pattern: "^summarize", flags: "i", suggest: "haiku", reason: "y", origin: "user" },
+      ],
+      agentTypes: { Explore: "haiku" },
+    });
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+
+  test("decodes a legacy origin-less table without agentTypes", () => {
+    const result = decode({ version: 1, classes: validTable.classes });
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+
+  test("tolerates unknown origin values (must not revert table to defaults)", () => {
+    const result = decode({
+      version: 1,
+      classes: [{ id: "mined", pattern: "^summarize", suggest: "haiku", reason: "y", origin: "mined" }],
+    });
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+
+  test("rejects a wrong version", () => {
+    const result = decode({ version: 2, classes: [] });
+    expect(Result.isSuccess(result)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fire-path sync read (whole-table fail-open)
+// ---------------------------------------------------------------------------
+
+describe("readRoutingTableSync", () => {
+  test("reads and decodes a valid file", () => {
+    const p = join(tmp(), "routing-table.json");
+    writeFileSync(p, JSON.stringify(validTable));
+    const table = readRoutingTableSync(p);
+    expect(table).not.toBeNull();
+    expect(table!.classes[0]!.id).toBe("spec-review");
+  });
+
+  test("missing file → null", () => {
+    expect(readRoutingTableSync(join(tmp(), "absent.json"))).toBeNull();
+  });
+
+  test("corrupt JSON → null", () => {
+    const p = join(tmp(), "bad.json");
+    writeFileSync(p, "{not json");
+    expect(readRoutingTableSync(p)).toBeNull();
+  });
+
+  test("schema mismatch → null (whole-table semantics, not row-dropping)", () => {
+    const p = join(tmp(), "mismatch.json");
+    writeFileSync(p, JSON.stringify({ version: 1, classes: [{ id: 42 }] }));
+    expect(readRoutingTableSync(p)).toBeNull();
+  });
+});
+
+describe("loadRoutingTableOrDefault", () => {
+  test("falls back to DEFAULT_ROUTING_TABLE when the file is absent", () => {
+    const table = loadRoutingTableOrDefault(join(tmp(), "absent.json"));
+    expect(table).toBe(DEFAULT_ROUTING_TABLE);
+  });
+
+  test("returns the stored table when valid", () => {
+    const p = join(tmp(), "routing-table.json");
+    writeFileSync(p, JSON.stringify(validTable));
+    const table = loadRoutingTableOrDefault(p);
+    expect(table.classes).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compile-side normalize (row-level dropping)
+// ---------------------------------------------------------------------------
+
+describe("parseStoredRoutingTable", () => {
+  test("normalizes: malformed rows dropped, missing agentTypes becomes {}", () => {
+    const text = JSON.stringify({
+      version: 1,
+      classes: [validTable.classes[0], { id: 42 }],
+    });
+    const loaded = parseStoredRoutingTable(text);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.classes).toHaveLength(1);
+    expect(loaded!.agentTypes).toEqual({});
+  });
+
+  test("missing flags defaults to empty string; unknown origin dropped", () => {
+    const text = JSON.stringify({
+      version: 1,
+      classes: [{ id: "a", pattern: "^a", suggest: "haiku", reason: "r", origin: "mined" }],
+    });
+    const loaded = parseStoredRoutingTable(text);
+    expect(loaded!.classes[0]!.flags).toBe("");
+    expect(loaded!.classes[0]!.origin).toBeUndefined();
+  });
+
+  test("preserves default/user origin tags", () => {
+    const text = JSON.stringify({
+      version: 1,
+      classes: [
+        { id: "a", pattern: "^a", flags: "i", suggest: "haiku", reason: "r", origin: "default" },
+        { id: "b", pattern: "^b", flags: "i", suggest: "sonnet", reason: "r", origin: "user" },
+      ],
+    });
+    const loaded = parseStoredRoutingTable(text);
+    expect(loaded!.classes.map((c) => c.origin)).toEqual(["default", "user"]);
+  });
+
+  test("bad top-level shape → null (callers refuse to overwrite)", () => {
+    expect(parseStoredRoutingTable("{not json")).toBeNull();
+    expect(parseStoredRoutingTable(JSON.stringify({ version: 2, classes: [] }))).toBeNull();
+    expect(parseStoredRoutingTable(JSON.stringify({ version: 1, classes: "nope" }))).toBeNull();
+  });
+
+  test("non-string agentTypes values are filtered out", () => {
+    const text = JSON.stringify({
+      version: 1,
+      classes: [],
+      agentTypes: { Explore: "haiku", broken: 3 },
+    });
+    const loaded = parseStoredRoutingTable(text);
+    expect(loaded!.agentTypes).toEqual({ Explore: "haiku" });
+  });
+});

--- a/packages/hooks-sdk/src/routing-table.ts
+++ b/packages/hooks-sdk/src/routing-table.ts
@@ -1,0 +1,284 @@
+/**
+ * Routing-table schema + read seam - the single source of truth for
+ * ~/.ax/hooks/routing-table.json (ADR-0014).
+ *
+ * Consumed from two very different runtimes, so two readers live here:
+ *
+ *  - `readRoutingTableSync` / `loadRoutingTableOrDefault`: the hook FIRE PATH
+ *    (`bun <file>.ts` from ~/.ax/hooks, ~70ms budget). Synchronous node:fs
+ *    read so the hook's error channel stays `never` under plain bun, and
+ *    whole-table fail-open semantics: ANY problem (missing file, bad JSON,
+ *    schema mismatch) falls back to the built-in defaults - a corrupt table
+ *    must never wedge or silently disable the agent.
+ *
+ *  - `loadStoredRoutingTable` (+ pure `parseStoredRoutingTable`): the axctl
+ *    compile/tune side (`ax routing compile|tune|show`). Effect + FileSystem,
+ *    row-level normalization: malformed class rows are dropped (not the whole
+ *    table), a missing/non-object agentTypes becomes {}, and origin tags are
+ *    preserved so merge logic can tell defaults from user rows. Returns null
+ *    on a structurally bad file so callers can refuse to overwrite it.
+ *
+ * axctl's merge/compile/save logic stays in
+ * apps/axctl/src/queries/routing-table-io.ts - this module owns only the
+ * schema (types + validation) and the read path. Keep it dependency-light:
+ * the fire path loads it via a file: dep on this package (no axctl imports,
+ * `effect` only).
+ */
+
+import { Effect, FileSystem, Result, Schema } from "effect";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Schema (validation used on the fire path)
+// ---------------------------------------------------------------------------
+
+export const RoutingClassSchema = Schema.Struct({
+  id: Schema.String,
+  pattern: Schema.String,
+  flags: Schema.optional(Schema.String),
+  suggest: Schema.String,
+  reason: Schema.String,
+  // Provenance tag written by ax routing compile/tune ("default" | "user").
+  // Kept as a plain optional string: the hook never reads origin, so an
+  // unknown value must not fail the whole-table decode (which would silently
+  // revert the user's routing table to the built-in defaults).
+  origin: Schema.optional(Schema.String),
+});
+
+export const RoutingTableSchema = Schema.Struct({
+  version: Schema.Literal(1),
+  classes: Schema.Array(RoutingClassSchema),
+  agentTypes: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+});
+
+/** Decoded shape of a stored routing table (flags/origin/agentTypes optional). */
+export type RoutingTableShape = Schema.Schema.Type<typeof RoutingTableSchema>;
+
+// ---------------------------------------------------------------------------
+// Strict compile-side types (every default carries explicit flags/agentTypes)
+// ---------------------------------------------------------------------------
+
+export interface RoutingClass {
+  readonly id: string;
+  readonly pattern: string;
+  readonly flags: string;
+  readonly suggest: string; // "sonnet" | "haiku"
+  readonly reason: string;
+}
+
+export interface RoutingTable {
+  readonly version: 1;
+  readonly classes: ReadonlyArray<RoutingClass>;
+  readonly agentTypes: Readonly<Record<string, string>>;
+}
+
+export type ClassOrigin = "default" | "user";
+
+/**
+ * What a load from disk can actually promise: legacy files (written by the
+ * pre-origin `ax dispatches compile-routing`) and hand-added rows may lack
+ * the origin tag. axctl's mergeRoutingTables accepts this shape and always
+ * RETURNS definite origins (origin-less rows are migrated to "user").
+ */
+export interface LoadedRoutingClass extends RoutingClass {
+  readonly origin?: ClassOrigin;
+}
+
+export interface LoadedRoutingTable {
+  readonly version: 1;
+  readonly classes: ReadonlyArray<LoadedRoutingClass>;
+  readonly agentTypes: Readonly<Record<string, string>>;
+}
+
+// ---------------------------------------------------------------------------
+// Path
+// ---------------------------------------------------------------------------
+
+export const defaultRoutingTablePath = (): string =>
+  `${homedir()}/.ax/hooks/routing-table.json`;
+
+// ---------------------------------------------------------------------------
+// Built-in defaults: the shipped seed (axctl exposes it as ROUTING_CLASSES).
+// Used by the fire path when routing-table.json is absent/unparseable - the
+// route-dispatch hook must work before any compile-routing step exists - and
+// refreshed into the stored table on every `ax routing compile`.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_ROUTING_TABLE: RoutingTable = {
+  version: 1,
+  classes: [
+    // Quality reviews and PR reviews deliberately have NO class: the main
+    // model is the Q&A reviewer in this workflow, so only the mechanical
+    // spec-compliance pass routes down.
+    {
+      id: "spec-review",
+      pattern: "^spec review",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "spec-compliance checklist review",
+    },
+    {
+      id: "search-locate",
+      pattern: "^(pattern-find|locate|find|map|sweep|grep)",
+      flags: "i",
+      suggest: "haiku",
+      reason: "code search/sweep",
+    },
+    {
+      id: "research",
+      pattern: "^(research|investigate docs|study)",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "web/docs research",
+    },
+    {
+      id: "well-specified-impl",
+      pattern: "^implement ",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "spec'd implementation",
+    },
+    {
+      id: "bulk-mechanical",
+      pattern: "^(write announcements|regenerate|standardize|merge main)",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "bulk mechanical work",
+    },
+    // Mined by /routing-tune 2026-06-12 (adversarially backtested over 90d;
+    // brief: .ax/tasks/routing-tune-undated.md). The colon in task-N-impl
+    // is load-bearing: "Task 4 spec compliance review" (no colon) must NOT
+    // match - reviews stay on the main model.
+    {
+      id: "task-N-impl",
+      pattern: "^Task \\d+:",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "numbered plan-task implementation",
+    },
+    {
+      id: "bug-fix",
+      pattern: "^Fix\\s",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "bounded bug-fix remediation",
+    },
+    {
+      id: "feature-add",
+      pattern: "^Add\\s",
+      flags: "i",
+      suggest: "sonnet",
+      reason: "additive feature with a clear target",
+    },
+  ],
+  agentTypes: {
+    Explore: "haiku",
+    "codebase-locator": "haiku",
+    "codebase-pattern-finder": "haiku",
+    "codebase-analyzer": "sonnet",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Fire-path read (synchronous; fails open on any error)
+// ---------------------------------------------------------------------------
+
+const decodeRoutingTable = Schema.decodeUnknownResult(RoutingTableSchema);
+
+/**
+ * Synchronously read + validate a stored routing table.
+ * Returns null on ANY error (missing file, bad JSON, schema mismatch).
+ */
+export const readRoutingTableSync = (
+  path: string = defaultRoutingTablePath(),
+): RoutingTableShape | null => {
+  try {
+    const text = readFileSync(path, "utf8");
+    const parsed: unknown = JSON.parse(text);
+    const result = decodeRoutingTable(parsed);
+    if (Result.isSuccess(result)) return result.success;
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * The fire-path loader: stored table if valid, else the built-in defaults
+ * (fail open - a corrupt table must never disable routing suggestions).
+ */
+export const loadRoutingTableOrDefault = (
+  path: string = defaultRoutingTablePath(),
+): RoutingTableShape => readRoutingTableSync(path) ?? DEFAULT_ROUTING_TABLE;
+
+// ---------------------------------------------------------------------------
+// Compile-side read (row-level normalization; null = structurally bad file)
+// ---------------------------------------------------------------------------
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+/** Rebuild a class row from untrusted JSON; null when required fields are bad. */
+const normalizeClassRow = (row: unknown): LoadedRoutingClass | null => {
+  if (!isRecord(row)) return null;
+  if (
+    typeof row.id !== "string" ||
+    typeof row.pattern !== "string" ||
+    typeof row.suggest !== "string" ||
+    typeof row.reason !== "string"
+  ) {
+    return null;
+  }
+  const base = {
+    id: row.id,
+    pattern: row.pattern,
+    flags: typeof row.flags === "string" ? row.flags : "",
+    suggest: row.suggest,
+    reason: row.reason,
+  };
+  const origin = row.origin === "default" || row.origin === "user" ? row.origin : undefined;
+  return origin === undefined ? base : { ...base, origin };
+};
+
+/**
+ * Parse + normalize stored routing-table text. Null on bad JSON or a bad
+ * top-level shape. Malformed class rows are dropped; a missing or non-object
+ * agentTypes becomes {} (hand-edited files must not type-lie downstream).
+ */
+export const parseStoredRoutingTable = (text: string): LoadedRoutingTable | null => {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (!isRecord(parsed) || parsed.version !== 1 || !Array.isArray(parsed.classes)) {
+      return null;
+    }
+    const classes = parsed.classes
+      .map(normalizeClassRow)
+      .filter((c): c is LoadedRoutingClass => c !== null);
+    const agentTypes: Record<string, string> = isRecord(parsed.agentTypes)
+      ? Object.fromEntries(
+          Object.entries(parsed.agentTypes).filter(
+            (e): e is [string, string] => typeof e[1] === "string",
+          ),
+        )
+      : {};
+    return { version: 1, classes, agentTypes } satisfies LoadedRoutingTable;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Read + parse + normalize the stored table (Effect/FileSystem variant for
+ * axctl's compile/tune path). Null on missing file / bad JSON / bad top-level
+ * shape - callers use null to refuse overwriting a corrupt file.
+ */
+export const loadStoredRoutingTable = (
+  path: string,
+): Effect.Effect<LoadedRoutingTable | null, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const text = yield* fs.readFileString(path).pipe(Effect.orElseSucceed(() => null));
+    if (text === null) return null;
+    return parseStoredRoutingTable(text);
+  });

--- a/scripts/check-no-node-fs.ts
+++ b/scripts/check-no-node-fs.ts
@@ -41,7 +41,8 @@ const EXCLUDED_FILES: readonly string[] = [
     "packages/hooks-sdk/src/git-env.ts",
     // Same fire-path constraint: routing-table.json is read synchronously so
     // the hook's error channel stays `never` under plain bun (~70ms budget).
-    "packages/hooks-sdk/src/hooks/route-dispatch.ts",
+    // (Was hooks/route-dispatch.ts before the read seam moved here, ADR-0014.)
+    "packages/hooks-sdk/src/routing-table.ts",
 ];
 
 const BANNED_SPECIFIERS = [


### PR DESCRIPTION
Behavior-preserving refactor unifying hooks ownership between `packages/hooks-sdk` and `apps/axctl/src/hooks`, per the locked decision: **hooks-sdk owns hook definition, verdicts, fire path, prebuilt hooks, and the routing-table schema + loader; axctl owns provider config CRUD, install fan-out, telemetry, backtest, and analysis.** Recorded as `docs/adr/0014-hooks-ownership-split.md` (Status: Accepted, 2026-06-13).

## Single routing-table read seam

`route-dispatch.ts` and `queries/routing-table-io.ts` each carried their own schema + parse of `~/.ax/hooks/routing-table.json`. New `packages/hooks-sdk/src/routing-table.ts` is now the single source of truth:

- `RoutingTableSchema` / `RoutingClassSchema` + all table types (`RoutingClass`, `RoutingTable`, `LoadedRoutingTable`, `ClassOrigin`, ...)
- `defaultRoutingTablePath()`
- **Fire-path read**: `readRoutingTableSync` / `loadRoutingTableOrDefault` - sync `node:fs` read (error channel stays `never` under plain bun, ~70ms budget), whole-table fail-open to defaults. Identical semantics to the old in-hook loader.
- **Compile-side read**: `loadStoredRoutingTable` (Effect + FileSystem) / pure `parseStoredRoutingTable` - row-level normalization, `null` on a structurally bad file so `ax routing compile` keeps refusing to overwrite corrupt tables. Moved verbatim from `routing-table-io.ts`.

`routing-table-io.ts` keeps merge/append/save + `loadEffectiveRoutingTable` and re-exports the sdk reader/types, so every existing consumer (`ax routing compile|tune|show`, `ax dispatches --candidates`, MCP tools) compiles unchanged.

### Where the seeded defaults live (the judgment call)

The `DEFAULT_TABLE` in the hook and `ROUTING_CLASSES` in `dispatch-analytics.ts` were verbatim duplicates with mirror-me comments. The seed moved INTO the sdk as `DEFAULT_ROUTING_TABLE`, and `ROUTING_CLASSES` is now an alias of it. Rationale: the fire path must work before any compile step exists, so the hook needs the defaults without axctl; the constant is dependency-free, so it adds no weight to the `file:`-dep workspace; and this direction has no import cycle (axctl -> sdk only - it also dissolves the pre-existing `routing-table-io <-> dispatch-analytics` cycle). The sdk stays `effect`-only.

## Vestigial GitEnv removed from route-dispatch

`route-dispatch.ts:244` did `void (yield* GitEnv)` purely to satisfy `HookDefinition.run`'s R channel and never called any method (verified: no other usage in the hook or its tests). Since `Effect`'s R is covariant, the hook's `run` is now a plain `Effect.sync` with `R = never`, which remains assignable to the interface's `R = GitEnv`. `GitEnv` itself is untouched (the worktree guards use it); no test layer wiring needed changes - all hook tests pass as-is.

Also: `check:no-node-fs` allowlist entry moved from `hooks/route-dispatch.ts` to `routing-table.ts` (the sync read moved with the seam), and the hook keeps re-exporting `RoutingTableSchema` for back-compat. Installed `~/.ax/hooks` shims import `@ax/hooks-sdk/hooks/route-dispatch`'s default export, whose shape is unchanged.

## Verification

- `bun run typecheck` - clean (warnings are pre-existing language-service notices)
- `bun test` repo-wide - 3860 pass / 0 fail (includes hooks-sdk, routing-table-io, dispatch-analytics, routing-tune, and the deterministic `ax hooks cases` / sdk-install tests)
- `bun scripts/check-no-node-fs.ts` - clean
- Fire-path smoke test: `echo '{"hook_event_name":"PreToolUse","tool_name":"Agent","tool_input":{"description":"locate all usages of Foo"},...}' | bun packages/hooks-sdk/src/hooks/route-dispatch.ts` -> identical `systemMessage` warn verdict, exit 0

Deliberately NOT unified (noted in the ADR): the match logic (`matchTable` in the hook vs `matchRoutingWith` in dispatch-analytics) - same table, near-identical semantics, candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)