### PR TITLE
refactor(ingest): shared parser toolkit behind the NormalizedTranscriptBatch seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,6 +47,10 @@ _Avoid_: ground truth
 The agent-neutral logic that turns normalized sessions, edits, commits, and touched files into **Change Sets** and **File Memories**.
 _Avoid_: Codex parser, adapter
 
+**Parser Toolkit**:
+The shared write-builder and JSON-access layer of the **Derivation Engine** that provider parsers compose - field probes, JSONL/SQLite JSON decoding, and the common tool-call, compaction, and token-usage write shapes.
+_Avoid_: helper utils, parser utils
+
 **Ingest Stage**:
 One named unit of the ingest run - skills, commands, claude, codex, subagents,
 spawned, git, signals, outcomes, session-health, closure, learning-registry, or

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -2,8 +2,7 @@ import { Effect, FileSystem, Path, PlatformError, Schema, Stream } from "effect"
 import { RecordId, SurrealClient, filePointer } from "@ax/lib/db";
 import { SkillName } from "@ax/lib/brands";
 import { AxConfig } from "@ax/lib/config";
-import { decodeJsonOrNull } from "@ax/lib/decode";
-import { recordRef, surrealDate, surrealJsonOption, surrealObject, surrealOptionInt, surrealOptionString, surrealString } from "@ax/lib/shared/surql";
+import { surrealJsonOption } from "@ax/lib/shared/surql";
 import { AppLayer } from "@ax/lib/layers";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import { annotateStageProgress, stageFileFailureAnnotator } from "./stage/runner.ts";
@@ -18,12 +17,7 @@ import {
     type AgentEventParentEdgeWrite,
     type AgentEventWrite,
 } from "./provider-events.ts";
-import {
-    extractCommandTool,
-    normalizeCommand,
-    parseCodexFunctionOutput,
-    toolKindForName,
-} from "./tool-calls.ts";
+import { parseCodexFunctionOutput } from "./tool-calls.ts";
 import { extractCodexCompaction, type CompactionWrite } from "./compaction.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
 import { providerDelegationSignalAvailability } from "./delegation.ts";
@@ -32,16 +26,27 @@ import {
     providerPlanSignalAvailability,
     toPlanSnapshotWrite,
 } from "./plans.ts";
-import { toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
+import { toolCallRecordKey } from "./record-keys.ts";
 import { extractToolFileEvidence } from "./tool-file-evidence.ts";
 import {
     buildNormalizedTranscriptStatements,
     type NormalizedTranscriptBatch,
 } from "./normalized/transcripts.ts";
+// Codex token counts arrive as numbers OR numeric strings - the toolkit's
+// integer probe (`intField`) is this parser's `numberField`.
+import { intField as numberField, isRecord, jsonText, parseJsonl, parseMaybeJson, stringField } from "./normalized/toolkit.ts";
+import {
+    applyCommandFields,
+    makeToolCallWrite,
+    type MutableToolCallWrite,
+} from "./normalized/tool-call-write.ts";
+import {
+    buildSessionTokenUsageStatement,
+    buildTurnTokenUsageStatement,
+} from "./token-usage-writers.ts";
 import { decodeCodexTranscriptLine } from "./line-schemas.ts";
 import { executeStatements } from "@ax/lib/shared/statement-exec";
 import { isNotFound, skipNotFound } from "@ax/lib/shared/fs-error";
-import { safeKeyPart } from "@ax/lib/shared/derive-keys";
 import { tokenQualityLabels } from "./token-quality.ts";
 import { estimateCost } from "./model-pricing.ts";
 import { walkJsonlFilesStrict } from "./walk-jsonl.ts";
@@ -113,46 +118,6 @@ export interface CodexTurnTokenUsage {
     usageQuality: string;
     raw: Record<string, unknown>;
 }
-
-function parseJsonl(line: string): Record<string, unknown> | null {
-    const decoded = decodeJsonOrNull(line);
-    return isRecord(decoded) ? decoded : null;
-}
-
-function isRecord(input: unknown): input is Record<string, unknown> {
-    return typeof input === "object" && input !== null && !Array.isArray(input);
-}
-
-function stringField(input: Record<string, unknown>, field: string): string | null {
-    const value = input[field];
-    return typeof value === "string" ? value : null;
-}
-
-function numberField(input: Record<string, unknown>, field: string): number | null {
-    const value = input[field];
-    const n = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
-    return Number.isFinite(n) ? Math.trunc(n) : null;
-}
-
-function parseCodexArguments(input: unknown): unknown {
-    if (typeof input !== "string") return input ?? null;
-    const decoded = decodeJsonOrNull(input);
-    return decoded ?? input;
-}
-
-function jsonText(input: unknown): string | null {
-    try {
-        const encoded = JSON.stringify(input);
-        return encoded === undefined ? null : encoded;
-    } catch {
-        return null;
-    }
-}
-
-const surrealOptionFloat = (value: number | null | undefined): string =>
-    value === null || value === undefined || !Number.isFinite(value)
-        ? "NONE"
-        : Number(value.toFixed(8)).toString();
 
 function outputText(input: unknown): string | null {
     return typeof input === "string" ? input : jsonText(input);
@@ -301,10 +266,6 @@ function compactCodexFunctionOutputEventRaw(
         output: compactPayload(payload.output, maxBytes),
     };
 }
-
-type MutableToolCallWrite = {
-    -readonly [Key in keyof ToolCallWrite]: ToolCallWrite[Key];
-};
 
 type ToolResultFields = {
     outputJson: unknown;
@@ -601,33 +562,23 @@ function createCodexExtractor(
         // carries the raw patch text in `input` - wrap it so apply-patch LOC
         // consumers find their `patch` field.
         const customInput = payload.arguments === undefined ? stringField(payload, "input") : null;
-        const inputJson = customInput !== null ? { patch: customInput } : parseCodexArguments(payload.arguments);
-        const turnKey = turnRecordKey(currentSession.id, seq);
+        const inputJson = customInput !== null ? { patch: customInput } : parseMaybeJson(payload.arguments);
         const toolCallKey = toolCallRecordKey({
             sessionId: currentSession.id,
             seq,
             callId,
         });
-        const call: MutableToolCallWrite = {
+        const call: MutableToolCallWrite = makeToolCallWrite({
             provider: "codex",
             toolName,
-            toolKind: toolKindForName(toolName),
             sessionId: currentSession.id,
             seq,
-            turnKey,
-            agentEventKey: agentEventRecordKey({
-                provider: "codex",
-                providerSessionId: currentSession.id,
-                providerEventId: callId,
-                seq,
-            }),
             callId,
             ts,
             cwd: currentSession.cwd,
             inputJson,
             rawJson: payload,
-            hasError: false,
-        };
+        });
 
         pushProviderEvent({
             providerEventId: callId,
@@ -646,14 +597,7 @@ function createCodexExtractor(
             metrics: { turnSeq: seq },
         }, currentSession);
 
-        if (toolName === "exec_command" && isRecord(inputJson)) {
-            const command = stringField(inputJson, "command") ?? stringField(inputJson, "cmd");
-            if (command) {
-                call.commandText = command;
-                call.commandToolName = extractCommandTool(command);
-                call.commandNorm = normalizeCommand(command);
-            }
-        }
+        if (toolName === "exec_command") applyCommandFields(call, inputJson);
 
         toolCalls.push(call);
         toolCallsByCallId.set(callId, call);
@@ -1223,80 +1167,64 @@ const buildCodexTokenUsageStatements = (usage: CodexTokenUsage | null): string[]
     });
     return [
         // TODO(burn-buckets): codex batching makes per-session series unavailable here; backfill via derive stage
-        `UPSERT ${recordRef("session_token_usage", safeKeyPart(usage.session))} MERGE ${surrealObject([
-            ["session", recordRef("session", usage.session)],
-            ["source", surrealString("codex")],
-            ["workflow_epoch", "NONE"],
-            ["model", surrealOptionString(usage.model)],
-            ["prompt_tokens", surrealOptionInt(usage.promptTokens)],
-            ["completion_tokens", surrealOptionInt(usage.completionTokens)],
-            ["cache_creation_input_tokens", "NONE"],
-            ["cache_read_input_tokens", surrealOptionInt(usage.cacheReadInputTokens)],
-            ["estimated_tokens", Math.trunc(usage.estimatedTokens).toString(10)],
-            ["transcript_bytes", "0"],
-            ["context_window", surrealOptionInt(usage.contextWindow)],
-            ["model_ref", usage.model ? recordRef("agent_model", usage.model) : "NONE"],
-            ["estimated_input_cost_usd", surrealOptionFloat(cost.inputUsd)],
-            ["estimated_output_cost_usd", surrealOptionFloat(cost.outputUsd)],
-            ["estimated_cache_creation_cost_usd", surrealOptionFloat(cost.cacheCreationUsd)],
-            ["estimated_cache_read_cost_usd", surrealOptionFloat(cost.cacheReadUsd)],
-            ["estimated_cost_usd", surrealOptionFloat(cost.totalUsd)],
-            ["pricing_source", surrealOptionString(cost.pricingSource)],
-            ["labels", surrealJsonOption(tokenQualityLabels({
+        buildSessionTokenUsageStatement({
+            sessionId: usage.session,
+            source: "codex",
+            model: usage.model,
+            promptTokens: usage.promptTokens,
+            completionTokens: usage.completionTokens,
+            cacheCreationInputTokens: null,
+            cacheReadInputTokens: usage.cacheReadInputTokens,
+            estimatedTokens: usage.estimatedTokens,
+            contextWindow: usage.contextWindow,
+            cost: { modelRefKey: usage.model, estimate: cost },
+            labels: surrealJsonOption(tokenQualityLabels({
                 source: "codex_token_count",
                 tokenSourceQuality: "explicit",
                 tokenSourceDetail: "codex_token_count.total_token_usage",
                 model: usage.model,
                 modelSourceDetail: usage.model ? "codex_session.model_provider" : "missing_codex_model_provider",
-            }))],
-            ["metrics", surrealJsonOption({
+            })),
+            metrics: surrealJsonOption({
                 total_token_usage: usage.totalTokenUsage,
                 last_token_usage: usage.lastTokenUsage,
                 token_count_events: usage.tokenCountEvents,
-            })],
-            ["ts", surrealDate(usage.ts)],
-        ])};`,
+            }),
+            ts: usage.ts,
+        }),
     ];
 };
 
 const buildCodexTurnTokenUsageStatements = (
     usages: readonly CodexTurnTokenUsage[],
 ): string[] =>
-    usages.map((usage) => {
-        const cost = estimateCost({
-            modelKey: usage.model,
+    usages.map((usage) =>
+        buildTurnTokenUsageStatement({
+            sessionId: usage.session,
+            seq: usage.seq,
+            source: "codex",
+            model: usage.model,
             promptTokens: usage.promptTokens,
             completionTokens: usage.completionTokens,
             cacheCreationInputTokens: usage.cacheCreationInputTokens,
             cacheReadInputTokens: usage.cacheReadInputTokens,
+            freshInputTokens: usage.freshInputTokens,
             estimatedTokens: usage.estimatedTokens,
-        });
-        const turnKey = turnRecordKey(usage.session, usage.seq);
-        return `UPSERT ${recordRef("turn_token_usage", turnKey)} MERGE ${surrealObject([
-            ["session", recordRef("session", usage.session)],
-            ["turn", recordRef("turn", turnKey)],
-            ["seq", Math.trunc(usage.seq).toString(10)],
-            ["source", surrealString("codex")],
-            ["model", surrealOptionString(usage.model)],
-            ["prompt_tokens", surrealOptionInt(usage.promptTokens)],
-            ["completion_tokens", surrealOptionInt(usage.completionTokens)],
-            ["cache_creation_input_tokens", surrealOptionInt(usage.cacheCreationInputTokens)],
-            ["cache_read_input_tokens", surrealOptionInt(usage.cacheReadInputTokens)],
-            ["fresh_input_tokens", surrealOptionInt(usage.freshInputTokens)],
-            ["estimated_tokens", Math.trunc(usage.estimatedTokens).toString(10)],
-            ["model_ref", usage.model ? recordRef("agent_model", usage.model) : "NONE"],
-            ["estimated_input_cost_usd", surrealOptionFloat(cost.inputUsd)],
-            ["estimated_output_cost_usd", surrealOptionFloat(cost.outputUsd)],
-            ["estimated_cache_creation_cost_usd", surrealOptionFloat(cost.cacheCreationUsd)],
-            ["estimated_cache_read_cost_usd", surrealOptionFloat(cost.cacheReadUsd)],
-            ["estimated_cost_usd", surrealOptionFloat(cost.totalUsd)],
-            ["pricing_source", surrealOptionString(cost.pricingSource)],
-            ["usage_source", surrealString(usage.usageSource)],
-            ["usage_quality", surrealString(usage.usageQuality)],
-            ["raw", surrealJsonOption(usage.raw)],
-            ["ts", surrealDate(usage.ts)],
-        ])};`;
-    });
+            modelRefKey: usage.model,
+            cost: estimateCost({
+                modelKey: usage.model,
+                promptTokens: usage.promptTokens,
+                completionTokens: usage.completionTokens,
+                cacheCreationInputTokens: usage.cacheCreationInputTokens,
+                cacheReadInputTokens: usage.cacheReadInputTokens,
+                estimatedTokens: usage.estimatedTokens,
+            }),
+            usageSource: usage.usageSource,
+            usageQuality: usage.usageQuality,
+            raw: surrealJsonOption(usage.raw),
+            ts: usage.ts,
+        })
+    );
 
 const toCodexNormalizedBatch = (
     batch: MutableCodexExtract,
@@ -1372,7 +1300,7 @@ const toCodexNormalizedBatch = (
     })),
     toolCallSkillRelations: batch.skillRelations,
     planSnapshots: batch.planSnapshots,
-    compactions: batch.compactions ?? [],
+    compactions: batch.compactions,
 });
 
 const buildCodexBatchStatements = (

--- a/apps/axctl/src/ingest/compaction.ts
+++ b/apps/axctl/src/ingest/compaction.ts
@@ -8,6 +8,7 @@ import {
     surrealOptionString,
     surrealString,
 } from "@ax/lib/shared/surql";
+import { isRecord, stringArray } from "./normalized/toolkit.ts";
 
 export type CompactionStrategy = "summarize" | "history_replacement" | "encrypted";
 export type CompactionTrigger = "auto" | "manual" | "hook";
@@ -30,12 +31,6 @@ export interface CompactionWrite {
     readonly modifiedFiles?: readonly string[] | null;
     readonly raw?: unknown;
 }
-
-const isRecord = (v: unknown): v is Record<string, unknown> =>
-    typeof v === "object" && v !== null && !Array.isArray(v);
-
-const stringArray = (v: unknown): readonly string[] | null =>
-    Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : null;
 
 export const compactionRecordKey = (
     harness: string,
@@ -66,7 +61,9 @@ export const buildCompactionStatements = (
             ])};`,
     );
 
-export interface PiCompactionCtx {
+/** The per-event context every harness shares; provider extractors extend it
+ *  with harness-specific fields (tokensBefore, boundaryRef, summary, ...). */
+export interface CompactionCtxBase {
     readonly sessionId: string;
     readonly providerSessionId: string;
     readonly seq: number;
@@ -74,38 +71,71 @@ export interface PiCompactionCtx {
     readonly agentEventKey?: string | null;
 }
 
+/** The harness-interpreted slice of a CompactionWrite - everything that is
+ *  NOT mechanically derived from {@link CompactionCtxBase}. */
+interface CompactionWriteParts {
+    readonly trigger: CompactionTrigger | null;
+    readonly strategy: CompactionStrategy;
+    readonly summary?: string | null;
+    readonly tokensBefore?: number | null;
+    readonly boundaryRef?: string | null;
+    readonly keptCount?: number | null;
+    readonly readFiles?: readonly string[] | null;
+    readonly modifiedFiles?: readonly string[] | null;
+    readonly raw?: unknown;
+}
+
+/**
+ * The ONE shared CompactionWrite build path (Parser Toolkit): record key,
+ * session/event linkage, and null-defaults are derived here; each provider
+ * extractor below only interprets its raw event into {@link CompactionWriteParts}.
+ * All provider compactions are explicit signals today, hence the fixed
+ * `sourceConfidence`.
+ */
+const makeCompactionWrite = (
+    harness: string,
+    ctx: CompactionCtxBase,
+    parts: CompactionWriteParts,
+): CompactionWrite => ({
+    compactionKey: compactionRecordKey(harness, ctx.providerSessionId, ctx.seq),
+    sessionId: ctx.sessionId,
+    agentEventKey: ctx.agentEventKey ?? null,
+    harness,
+    ts: ctx.ts,
+    trigger: parts.trigger,
+    strategy: parts.strategy,
+    sourceConfidence: "explicit",
+    summary: parts.summary ?? null,
+    tokensBefore: parts.tokensBefore ?? null,
+    boundaryRef: parts.boundaryRef ?? null,
+    keptCount: parts.keptCount ?? null,
+    readFiles: parts.readFiles ?? null,
+    modifiedFiles: parts.modifiedFiles ?? null,
+    raw: parts.raw ?? null,
+});
+
+export type PiCompactionCtx = CompactionCtxBase;
+
 export const extractPiCompaction = (
     entry: Record<string, unknown>,
     ctx: PiCompactionCtx,
 ): CompactionWrite | null => {
     if (entry.type !== "compaction") return null;
     const details = isRecord(entry.details) ? entry.details : null;
-    return {
-        compactionKey: compactionRecordKey("pi", ctx.providerSessionId, ctx.seq),
-        sessionId: ctx.sessionId,
-        agentEventKey: ctx.agentEventKey ?? null,
-        harness: "pi",
-        ts: ctx.ts,
+    return makeCompactionWrite("pi", ctx, {
         trigger: entry.fromHook === true ? "hook" : "auto",
         strategy: "summarize",
-        sourceConfidence: "explicit",
         summary: typeof entry.summary === "string" ? entry.summary : null,
         tokensBefore: typeof entry.tokensBefore === "number" ? entry.tokensBefore : null,
         boundaryRef:
             typeof entry.firstKeptEntryId === "string" ? entry.firstKeptEntryId : null,
-        keptCount: null,
         readFiles: details ? stringArray(details.readFiles) : null,
         modifiedFiles: details ? stringArray(details.modifiedFiles) : null,
         raw: { fromHook: entry.fromHook === true },
-    };
+    });
 };
 
-export interface CodexCompactionCtx {
-    readonly sessionId: string;
-    readonly providerSessionId: string;
-    readonly seq: number;
-    readonly ts: Date;
-    readonly agentEventKey?: string | null;
+export interface CodexCompactionCtx extends CompactionCtxBase {
     readonly tokensBefore?: number | null;
     readonly boundaryRef?: string | null;
 }
@@ -118,81 +148,43 @@ export const extractCodexCompaction = (
         ? payload.replacement_history
         : [];
     const message = typeof payload.message === "string" ? payload.message : "";
-    return {
-        compactionKey: compactionRecordKey("codex", ctx.providerSessionId, ctx.seq),
-        sessionId: ctx.sessionId,
-        agentEventKey: ctx.agentEventKey ?? null,
-        harness: "codex",
-        ts: ctx.ts,
+    return makeCompactionWrite("codex", ctx, {
         trigger: message.length > 0 ? "manual" : "auto",
         strategy: "history_replacement",
-        sourceConfidence: "explicit",
         summary: message.length > 0 ? message : null,
         tokensBefore: ctx.tokensBefore ?? null,
         boundaryRef: ctx.boundaryRef ?? null,
         keptCount: replacement.length,
-        readFiles: null,
-        modifiedFiles: null,
         raw: { replacement_count: replacement.length },
-    };
+    });
 };
 
-export interface ClaudeCompactionCtx {
-    readonly sessionId: string;
-    readonly providerSessionId: string;
-    readonly seq: number;
-    readonly ts: Date;
-    readonly agentEventKey?: string | null;
+export interface ClaudeCompactionCtx extends CompactionCtxBase {
     readonly summary: string | null;
     readonly boundaryRef?: string | null;
 }
 
 export const extractClaudeCompaction = (
     ctx: ClaudeCompactionCtx,
-): CompactionWrite => ({
-    compactionKey: compactionRecordKey("claude", ctx.providerSessionId, ctx.seq),
-    sessionId: ctx.sessionId,
-    agentEventKey: ctx.agentEventKey ?? null,
-    harness: "claude",
-    ts: ctx.ts,
-    trigger: "auto",
-    strategy: "summarize",
-    sourceConfidence: "explicit",
-    summary: ctx.summary,
-    tokensBefore: null,
-    boundaryRef: ctx.boundaryRef ?? null,
-    keptCount: null,
-    readFiles: null,
-    modifiedFiles: null,
-    raw: null,
-});
+): CompactionWrite =>
+    makeCompactionWrite("claude", ctx, {
+        trigger: "auto",
+        strategy: "summarize",
+        summary: ctx.summary,
+        boundaryRef: ctx.boundaryRef ?? null,
+    });
 
-export interface CursorCompactionCtx {
-    readonly sessionId: string;
-    readonly providerSessionId: string;
-    readonly seq: number;
-    readonly ts: Date;
-    readonly agentEventKey?: string | null;
+export interface CursorCompactionCtx extends CompactionCtxBase {
     readonly boundaryRef?: string | null;
     readonly summarizedComposers: readonly string[];
 }
 
 export const extractCursorCompaction = (
     ctx: CursorCompactionCtx,
-): CompactionWrite => ({
-    compactionKey: compactionRecordKey("cursor", ctx.providerSessionId, ctx.seq),
-    sessionId: ctx.sessionId,
-    agentEventKey: ctx.agentEventKey ?? null,
-    harness: "cursor",
-    ts: ctx.ts,
-    trigger: "auto",
-    strategy: "encrypted",
-    sourceConfidence: "explicit",
-    summary: null,
-    tokensBefore: null,
-    boundaryRef: ctx.boundaryRef ?? null,
-    keptCount: null,
-    readFiles: null,
-    modifiedFiles: null,
-    raw: { summarized_composers: ctx.summarizedComposers },
-});
+): CompactionWrite =>
+    makeCompactionWrite("cursor", ctx, {
+        trigger: "auto",
+        strategy: "encrypted",
+        boundaryRef: ctx.boundaryRef ?? null,
+        raw: { summarized_composers: ctx.summarizedComposers },
+    });

--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -3,7 +3,6 @@ import { Effect, FileSystem, Option, Path, Schema } from "effect";
 import { AxConfig } from "@ax/lib/config";
 import { SkillName } from "@ax/lib/brands";
 import { RecordId, SurrealClient } from "@ax/lib/db";
-import { jsonParseErrorText } from "@ax/lib/decode";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
 import { posixPath } from "@ax/lib/shared/path";
@@ -19,10 +18,12 @@ import { providerDelegationSignalAvailability } from "./delegation.ts";
 import { agentEventRecordKey, type AgentEventWrite } from "./provider-events.ts";
 import { buildNormalizedTranscriptStatements, type NormalizedTranscriptBatch } from "./normalized/transcripts.ts";
 import { providerPlanSignalAvailability } from "./plans.ts";
-import { identityPart, toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
+import { identityPart, toolCallRecordKey } from "./record-keys.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
-import { extractCommandTool, normalizeCommand, toolKindForName } from "./tool-calls.ts";
+import { boundExcerpt, isRecord, parseJsonRecord, stringField } from "./normalized/toolkit.ts";
+import { makeToolCallWrite } from "./normalized/tool-call-write.ts";
+import { extractCommandTool, normalizeCommand } from "./tool-calls.ts";
 
 export const CursorKey = Schema.Literal("cursor");
 export type CursorKey = typeof CursorKey.Type;
@@ -119,15 +120,6 @@ export function isAllowedCursorHistoryKey(key: string): boolean {
     return CURSOR_HISTORY_KEYS.has(key) || key.startsWith(CURSOR_COMPOSER_DATA_PREFIX);
 }
 
-function isRecord(input: unknown): input is Record<string, unknown> {
-    return typeof input === "object" && input !== null && !Array.isArray(input);
-}
-
-function stringField(input: Record<string, unknown>, field: string): string | null {
-    const value = input[field];
-    return typeof value === "string" ? value : null;
-}
-
 function validTimestamp(input: unknown, fallback: string): { ts: string; warning: string | null } {
     if (input === null || input === undefined) return { ts: fallback, warning: "missing timestamp" };
     if (typeof input !== "string" && typeof input !== "number") {
@@ -207,44 +199,12 @@ function decodeSqliteValue(value: SQLiteValue | undefined): string | null {
  *  parse. */
 const decodeJsonStringOption = Schema.decodeUnknownOption(Schema.UnknownFromJsonString);
 
-function parseJsonRecord(raw: string | null, label: string, warnings: string[]): Record<string, unknown> | null {
-    if (raw === null || raw.trim().length === 0) {
-        warnings.push(`${label}: missing JSON data`);
-        return null;
-    }
-    const parsed = decodeJsonStringOption(raw);
-    if (Option.isNone(parsed)) {
-        warnings.push(`${label}: invalid JSON data (${jsonParseErrorText(raw)})`);
-        return null;
-    }
-    if (isRecord(parsed.value)) return parsed.value;
-    warnings.push(`${label}: JSON data is not an object`);
-    return null;
-}
-
 function parseJsonValue(input: unknown): unknown {
     if (typeof input !== "string") return input;
     const trimmed = input.trim();
     if (trimmed.length === 0) return null;
     const parsed = decodeJsonStringOption(trimmed);
     return Option.isSome(parsed) ? parsed.value : input;
-}
-
-function boundExcerpt(input: unknown, max = 1200): string | null {
-    let text: string | null = null;
-    if (typeof input === "string") {
-        text = input;
-    } else if (input !== null && input !== undefined) {
-        try {
-            text = JSON.stringify(input);
-        } catch {
-            text = String(input);
-        }
-    }
-    if (text === null) return null;
-    const normalized = text.replace(/\r\n/g, "\n").trim();
-    if (normalized.length === 0) return null;
-    return normalized.length <= max ? normalized : `${normalized.slice(0, max - 1)}…`;
 }
 
 function cursorToolCallId(
@@ -349,7 +309,6 @@ function pushCursorToolCall(input: {
     ordinal: number;
     ts: string;
     sourceKey: string;
-    turnKey: string;
     toolCalls: ToolCallWrite[];
     providerEvents: AgentEventWrite[];
     invocations: CursorInvocation[];
@@ -376,29 +335,26 @@ function pushCursorToolCall(input: {
         : null;
     const eventSeq = SYNTHETIC_PROVIDER_SEQ_OFFSET + (input.seq * 1000) + input.ordinal;
     const call: ToolCallWrite = {
-        provider: "cursor",
-        toolName,
-        toolKind: toolKindForName(toolName),
-        sessionId: input.session.id,
-        seq: input.seq,
-        turnKey: input.turnKey,
-        agentEventKey: agentEventRecordKey({
+        ...makeToolCallWrite({
             provider: "cursor",
-            providerSessionId: input.session.id,
-            providerEventId: callId,
-            seq: eventSeq,
+            toolName,
+            sessionId: input.session.id,
+            seq: input.seq,
+            callId,
+            eventSeq,
+            ts: input.ts,
+            inputJson,
+            rawJson: {
+                source: "cursor_state_vscdb",
+                sourceKey: input.sourceKey,
+                tool: rawToolPayload(input.raw),
+            },
         }),
-        callId,
-        ts: input.ts,
-        inputJson,
         outputJson,
-        rawJson: {
-            source: "cursor_state_vscdb",
-            sourceKey: input.sourceKey,
-            tool: rawToolPayload(input.raw),
-        },
         outputExcerpt: boundExcerpt(outputJson),
         errorText,
+        // Cursor always carries the command triple (possibly null) rather
+        // than the exec_command-gated applyCommandFields path.
         commandText: command,
         commandToolName: extractCommandTool(command),
         commandNorm: normalizeCommand(command),
@@ -577,7 +533,6 @@ function pushCursorMessage(input: {
         },
     });
 
-    const turnKey = turnRecordKey(input.session.id, input.seq);
     activities.forEach((activity, index) => {
         pushCursorToolCall({
             session: input.session,
@@ -586,7 +541,6 @@ function pushCursorMessage(input: {
             ordinal: index + 1,
             ts,
             sourceKey: input.sourceKey,
-            turnKey,
             toolCalls: input.toolCalls,
             providerEvents: input.providerEvents,
             invocations: input.invocations,
@@ -942,6 +896,8 @@ const toCursorNormalizedBatch = (
     })),
     toolCalls: extract.toolCalls,
     // Cursor intentionally emits NO tool-file evidence today; do not add it here.
+    toolFileEvidence: [],
+    agentEventParentEdges: [],
     syntheticSkillInvocations: extract.invocations.map((invocation) => ({
         sessionId: invocation.session,
         seq: invocation.seq,
@@ -952,6 +908,7 @@ const toCursorNormalizedBatch = (
         skillContentHash: "cursor",
     })),
     toolCallSkillRelations: extract.skillRelations,
+    planSnapshots: [],
     compactions: extract.compactions,
 });
 

--- a/apps/axctl/src/ingest/normalized/tool-call-write.test.ts
+++ b/apps/axctl/src/ingest/normalized/tool-call-write.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { agentEventRecordKey } from "../provider-events.ts";
+import { turnRecordKey } from "../record-keys.ts";
+import { applyCommandFields, makeToolCallWrite } from "./tool-call-write.ts";
+
+describe("makeToolCallWrite", () => {
+    test("builds the common write shape with callId/seq defaults for the event key", () => {
+        const call = makeToolCallWrite({
+            provider: "codex",
+            toolName: "exec_command",
+            sessionId: "s1",
+            seq: 3,
+            callId: "call-1",
+            ts: "2026-06-13T00:00:00.000Z",
+            cwd: "/repo",
+            inputJson: { command: "ls" },
+            rawJson: { name: "exec_command" },
+        });
+        expect(call.provider).toBe("codex");
+        expect(call.toolKind).toBe("builtin");
+        expect(call.turnKey).toBe(turnRecordKey("s1", 3));
+        expect(call.agentEventKey).toBe(agentEventRecordKey({
+            provider: "codex",
+            providerSessionId: "s1",
+            providerEventId: "call-1",
+            seq: 3,
+        }));
+        expect(call.hasError).toBe(false);
+        expect(call.cwd).toBe("/repo");
+    });
+
+    test("honors providerEventId/eventSeq overrides (opencode-style part identity)", () => {
+        const call = makeToolCallWrite({
+            provider: "opencode",
+            toolName: "grep",
+            sessionId: "s1",
+            seq: 2,
+            callId: "call-9",
+            providerEventId: "part-row-1",
+            eventSeq: 1_000_002_001,
+            ts: "2026-06-13T00:00:00.000Z",
+            cwd: null,
+            inputJson: null,
+            rawJson: {},
+        });
+        expect(call.agentEventKey).toBe(agentEventRecordKey({
+            provider: "opencode",
+            providerSessionId: "s1",
+            providerEventId: "part-row-1",
+            seq: 1_000_002_001,
+        }));
+        // seq on the write stays the TURN seq, not the synthetic event seq.
+        expect(call.seq).toBe(2);
+        expect(call.callId).toBe("call-9");
+    });
+
+    test("omits the cwd key entirely when undefined (cursor has no cwd)", () => {
+        const call = makeToolCallWrite({
+            provider: "cursor",
+            toolName: "edit_file",
+            sessionId: "s1",
+            seq: 1,
+            callId: "c1",
+            ts: "2026-06-13T00:00:00.000Z",
+            inputJson: null,
+            rawJson: {},
+        });
+        expect("cwd" in call).toBe(false);
+    });
+});
+
+describe("applyCommandFields", () => {
+    test("fills the command triple from command or cmd", () => {
+        const call = makeToolCallWrite({
+            provider: "pi",
+            toolName: "exec_command",
+            sessionId: "s1",
+            seq: 1,
+            callId: "c1",
+            ts: "2026-06-13T00:00:00.000Z",
+            cwd: null,
+            inputJson: { command: "git status" },
+            rawJson: {},
+        });
+        applyCommandFields(call, { command: "git status" });
+        expect(call.commandText).toBe("git status");
+        expect(call.commandToolName).toBe("git");
+        expect(call.commandNorm).toBeDefined();
+    });
+
+    test("no-ops for non-record input or a missing command", () => {
+        const call = makeToolCallWrite({
+            provider: "pi",
+            toolName: "exec_command",
+            sessionId: "s1",
+            seq: 1,
+            callId: "c1",
+            ts: "2026-06-13T00:00:00.000Z",
+            cwd: null,
+            inputJson: "raw string",
+            rawJson: {},
+        });
+        applyCommandFields(call, "raw string");
+        applyCommandFields(call, { other: 1 });
+        expect(call.commandText).toBeUndefined();
+        expect(call.commandToolName).toBeUndefined();
+        expect(call.commandNorm).toBeUndefined();
+    });
+});

--- a/apps/axctl/src/ingest/normalized/tool-call-write.ts
+++ b/apps/axctl/src/ingest/normalized/tool-call-write.ts
@@ -1,0 +1,82 @@
+/**
+ * Parser Toolkit - the shared ToolCallWrite mapping every provider parser
+ * (codex, pi, opencode, cursor) previously copy-pasted: provider + tool
+ * identity, the turn/agent_event record keys, and the exec-command field
+ * triple. Provider-specific interpretation (which raw fields hold the call
+ * id, input, output, errors) stays in each parser; only the common write
+ * shape lives here.
+ */
+import type { ToolCallWrite } from "../evidence-writers.ts";
+import { agentEventRecordKey, type AgentProviderName } from "../provider-events.ts";
+import { turnRecordKey } from "../record-keys.ts";
+import { extractCommandTool, normalizeCommand, toolKindForName } from "../tool-calls.ts";
+import { isRecord, stringField } from "./toolkit.ts";
+
+/** Locally-mutable ToolCallWrite: parsers fill result fields as the matching
+ *  tool output arrives later in the stream. */
+export type MutableToolCallWrite = {
+    -readonly [Key in keyof ToolCallWrite]: ToolCallWrite[Key];
+};
+
+export interface BaseToolCallWriteInput {
+    readonly provider: AgentProviderName;
+    readonly toolName: string;
+    readonly sessionId: string;
+    /** Turn sequence the call belongs to - drives both the persisted `seq`
+     *  and the turn record key. */
+    readonly seq: number;
+    readonly callId: string;
+    /** agent_event identity override: defaults to `callId` when the provider
+     *  keys its tool-call event by call id (codex, pi, cursor); opencode keys
+     *  it by the part row id instead. */
+    readonly providerEventId?: string;
+    /** agent_event seq override: defaults to `seq`; providers that emit
+     *  synthetic per-block events (pi, opencode, cursor) pass their offset
+     *  event seq here. */
+    readonly eventSeq?: number;
+    readonly ts: string;
+    /** Omitted entirely from the write when undefined (cursor has no cwd). */
+    readonly cwd?: string | null;
+    readonly inputJson: unknown;
+    readonly rawJson: unknown;
+}
+
+/**
+ * Build the cross-provider ToolCallWrite base: identity, record keys, and
+ * payloads, with `hasError: false` until a result arrives. Callers layer
+ * provider-specific result fields on top (spread or {@link applyCommandFields}).
+ */
+export const makeToolCallWrite = (input: BaseToolCallWriteInput): MutableToolCallWrite => ({
+    provider: input.provider,
+    toolName: input.toolName,
+    toolKind: toolKindForName(input.toolName),
+    sessionId: input.sessionId,
+    seq: input.seq,
+    turnKey: turnRecordKey(input.sessionId, input.seq),
+    agentEventKey: agentEventRecordKey({
+        provider: input.provider,
+        providerSessionId: input.sessionId,
+        providerEventId: input.providerEventId ?? input.callId,
+        seq: input.eventSeq ?? input.seq,
+    }),
+    callId: input.callId,
+    ts: input.ts,
+    ...(input.cwd === undefined ? {} : { cwd: input.cwd }),
+    inputJson: input.inputJson,
+    rawJson: input.rawJson,
+    hasError: false,
+});
+
+/**
+ * Fill the `commandText` / `commandToolName` / `commandNorm` triple from a
+ * record input's `command` (or `cmd`) field. No-op when the input is not a
+ * record or carries no command - exactly the guard every parser repeated.
+ */
+export const applyCommandFields = (call: MutableToolCallWrite, inputJson: unknown): void => {
+    if (!isRecord(inputJson)) return;
+    const command = stringField(inputJson, "command") ?? stringField(inputJson, "cmd");
+    if (!command) return;
+    call.commandText = command;
+    call.commandToolName = extractCommandTool(command);
+    call.commandNorm = normalizeCommand(command);
+};

--- a/apps/axctl/src/ingest/normalized/toolkit.test.ts
+++ b/apps/axctl/src/ingest/normalized/toolkit.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import {
+    booleanField,
+    boundExcerpt,
+    boundedExcerpt,
+    coercedNumberField,
+    intField,
+    isRecord,
+    jsonText,
+    nestedStringField,
+    numberField,
+    parseJsonRecord,
+    parseJsonl,
+    parseMaybeJson,
+    stringArray,
+    stringField,
+} from "./toolkit.ts";
+
+describe("parser toolkit JSON access", () => {
+    test("isRecord narrows to plain object records only", () => {
+        expect(isRecord({})).toBe(true);
+        expect(isRecord({ a: 1 })).toBe(true);
+        expect(isRecord([])).toBe(false);
+        expect(isRecord(null)).toBe(false);
+        expect(isRecord("x")).toBe(false);
+        expect(isRecord(42)).toBe(false);
+    });
+
+    test("stringField returns strings and null otherwise", () => {
+        expect(stringField({ a: "x" }, "a")).toBe("x");
+        expect(stringField({ a: 1 }, "a")).toBeNull();
+        expect(stringField({}, "a")).toBeNull();
+    });
+
+    test("numberField is strict: finite numbers only, no coercion, no truncation", () => {
+        expect(numberField({ a: 1.5 }, "a")).toBe(1.5);
+        expect(numberField({ a: "2" }, "a")).toBeNull();
+        expect(numberField({ a: Number.NaN }, "a")).toBeNull();
+        expect(numberField({ a: Infinity }, "a")).toBeNull();
+        expect(numberField({}, "a")).toBeNull();
+    });
+
+    test("intField coerces numeric strings and truncates (codex variant)", () => {
+        expect(intField({ a: 1.9 }, "a")).toBe(1);
+        expect(intField({ a: "42" }, "a")).toBe(42);
+        expect(intField({ a: "4.7" }, "a")).toBe(4);
+        expect(intField({ a: "nope" }, "a")).toBeNull();
+        expect(intField({ a: true }, "a")).toBeNull();
+    });
+
+    test("coercedNumberField accepts number|bigint|string without truncating (opencode variant)", () => {
+        expect(coercedNumberField({ a: 1.5 }, "a")).toBe(1.5);
+        expect(coercedNumberField({ a: 10n }, "a")).toBe(10);
+        expect(coercedNumberField({ a: "2.5" }, "a")).toBe(2.5);
+        expect(coercedNumberField({ a: " " }, "a")).toBeNull();
+        expect(coercedNumberField({ a: "abc" }, "a")).toBeNull();
+    });
+
+    test("booleanField returns booleans and null otherwise", () => {
+        expect(booleanField({ a: true }, "a")).toBe(true);
+        expect(booleanField({ a: false }, "a")).toBe(false);
+        expect(booleanField({ a: "true" }, "a")).toBeNull();
+    });
+
+    test("nestedStringField reads one record deep", () => {
+        expect(nestedStringField({ m: { id: "x" } }, "m", "id")).toBe("x");
+        expect(nestedStringField({ m: "flat" }, "m", "id")).toBeNull();
+        expect(nestedStringField({}, "m", "id")).toBeNull();
+    });
+
+    test("parseJsonl decodes record lines and rejects non-records", () => {
+        expect(parseJsonl('{"type":"message"}')).toEqual({ type: "message" });
+        expect(parseJsonl("[1,2]")).toBeNull();
+        expect(parseJsonl("not json")).toBeNull();
+        expect(parseJsonl('"str"')).toBeNull();
+    });
+
+    test("parseJsonRecord pushes labelled warnings for missing/invalid/non-object data", () => {
+        const warnings: string[] = [];
+        expect(parseJsonRecord('{"a":1}', "row r1", warnings)).toEqual({ a: 1 });
+        expect(warnings).toEqual([]);
+
+        expect(parseJsonRecord(null, "row r2", warnings)).toBeNull();
+        expect(warnings[0]).toBe("row r2: missing JSON data");
+
+        expect(parseJsonRecord("  ", "row r3", warnings)).toBeNull();
+        expect(warnings[1]).toBe("row r3: missing JSON data");
+
+        expect(parseJsonRecord("{bad", "row r4", warnings)).toBeNull();
+        expect(warnings[2]).toStartWith("row r4: invalid JSON data (");
+
+        expect(parseJsonRecord("[1]", "row r5", warnings)).toBeNull();
+        expect(warnings[3]).toBe("row r5: JSON data is not an object");
+    });
+
+    test("parseMaybeJson decodes strings, passes values through, nullish to null", () => {
+        expect(parseMaybeJson('{"a":1}')).toEqual({ a: 1 });
+        expect(parseMaybeJson("not json")).toBe("not json");
+        expect(parseMaybeJson({ a: 1 })).toEqual({ a: 1 });
+        expect(parseMaybeJson(undefined)).toBeNull();
+        expect(parseMaybeJson(null)).toBeNull();
+    });
+
+    test("jsonText stringifies, collapsing undefined and circular input to null", () => {
+        expect(jsonText({ a: 1 })).toBe('{"a":1}');
+        expect(jsonText(undefined)).toBeNull();
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        expect(jsonText(circular)).toBeNull();
+    });
+
+    test("boundedExcerpt slices without ellipsis", () => {
+        expect(boundedExcerpt("short")).toBe("short");
+        expect(boundedExcerpt("abcdef", 3)).toBe("abc");
+        expect(boundedExcerpt("a".repeat(1300)).length).toBe(1200);
+    });
+
+    test("boundExcerpt normalizes, trims, and ellipsis-terminates when clipped (cursor variant)", () => {
+        expect(boundExcerpt("  hi\r\nthere  ")).toBe("hi\nthere");
+        expect(boundExcerpt({ a: 1 })).toBe('{"a":1}');
+        expect(boundExcerpt(null)).toBeNull();
+        expect(boundExcerpt("   ")).toBeNull();
+        const clipped = boundExcerpt("x".repeat(20), 10)!;
+        expect(clipped.length).toBe(10);
+        expect(clipped.endsWith("…")).toBe(true);
+    });
+
+    test("stringArray keeps only string members and rejects non-arrays", () => {
+        expect(stringArray(["a", 1, "b", null])).toEqual(["a", "b"]);
+        expect(stringArray("a")).toBeNull();
+        expect(stringArray(undefined)).toBeNull();
+    });
+});

--- a/apps/axctl/src/ingest/normalized/toolkit.ts
+++ b/apps/axctl/src/ingest/normalized/toolkit.ts
@@ -1,0 +1,165 @@
+/**
+ * Parser Toolkit - the shared JSON-access layer of the Derivation Engine that
+ * the provider parsers (claude, codex, pi, opencode, cursor) compose.
+ *
+ * Every helper here was copy-pasted across 2-5 parsers before this module
+ * existed. Where two copies differed SUBTLY the variants are kept as distinct
+ * exports (see the three `*Field` number probes) so each call site preserves
+ * its exact pre-toolkit behavior - never "merge and hope".
+ */
+import { Option, Schema } from "effect";
+import { decodeJsonOrNull, jsonParseErrorText } from "@ax/lib/decode";
+
+/** Narrow `unknown` to a plain JSON object record (arrays excluded). */
+export function isRecord(input: unknown): input is Record<string, unknown> {
+    return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+
+/** A string field, or null when absent / not a string. */
+export function stringField(input: Record<string, unknown>, field: string): string | null {
+    const value = input[field];
+    return typeof value === "string" ? value : null;
+}
+
+/**
+ * STRICT number probe: a finite `number` value, otherwise null. No string
+ * coercion, no truncation. (pi + claude variant.)
+ */
+export function numberField(input: Record<string, unknown>, field: string): number | null {
+    const value = input[field];
+    return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * INTEGER probe: accepts a number OR a numeric string, truncates to an
+ * integer, null when non-finite. (codex variant - token counts arrive as
+ * either type in codex transcripts.)
+ */
+export function intField(input: Record<string, unknown>, field: string): number | null {
+    const value = input[field];
+    const n = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+    return Number.isFinite(n) ? Math.trunc(n) : null;
+}
+
+/**
+ * COERCING number probe: number, bigint, or numeric string - NOT truncated.
+ * (opencode variant - SQLite hands back bigints and stringly numbers.)
+ */
+export function coercedNumberField(input: Record<string, unknown>, field: string): number | null {
+    const value = input[field];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "bigint") return Number(value);
+    if (typeof value !== "string" || value.trim().length === 0) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** A boolean field, or null when absent / not a boolean. */
+export function booleanField(input: Record<string, unknown>, field: string): boolean | null {
+    const value = input[field];
+    return typeof value === "boolean" ? value : null;
+}
+
+/** A string field nested one record deep (`input[objectField][field]`). */
+export function nestedStringField(
+    input: Record<string, unknown>,
+    objectField: string,
+    field: string,
+): string | null {
+    const value = input[objectField];
+    if (!isRecord(value)) return null;
+    return stringField(value, field);
+}
+
+/** Decode one JSONL line into a record; null for unparseable JSON or a
+ *  non-record payload. (claude + codex + pi line boundary.) */
+export function parseJsonl(line: string): Record<string, unknown> | null {
+    const decoded = decodeJsonOrNull(line);
+    return isRecord(decoded) ? decoded : null;
+}
+
+/** Effect-Schema-backed JSON decode at the SQLite blob boundary. `Option`
+ *  (not `null`) so a literal JSON `null` is distinguishable from a failed
+ *  parse. */
+const decodeJsonStringOption = Schema.decodeUnknownOption(Schema.UnknownFromJsonString);
+
+/**
+ * Decode a SQLite-sourced JSON blob into a record, pushing a labelled warning
+ * for missing / invalid / non-object data. (opencode + cursor boundary; the
+ * `typeof raw !== "string"` guard is exactly the null check for the declared
+ * `string | null` input, so both pre-toolkit copies behave identically.)
+ */
+export function parseJsonRecord(
+    raw: string | null,
+    label: string,
+    warnings: string[],
+): Record<string, unknown> | null {
+    if (typeof raw !== "string" || raw.trim().length === 0) {
+        warnings.push(`${label}: missing JSON data`);
+        return null;
+    }
+    const parsed = decodeJsonStringOption(raw);
+    if (Option.isNone(parsed)) {
+        warnings.push(`${label}: invalid JSON data (${jsonParseErrorText(raw)})`);
+        return null;
+    }
+    if (isRecord(parsed.value)) return parsed.value;
+    warnings.push(`${label}: JSON data is not an object`);
+    return null;
+}
+
+/**
+ * Parse a value that MAY be a JSON string: strings decode (falling back to
+ * the original string on parse failure), non-strings pass through, with
+ * nullish input collapsing to null. (codex `arguments` + opencode part
+ * inputs + pi tool inputs.)
+ */
+export function parseMaybeJson(input: unknown): unknown {
+    if (typeof input !== "string") return input ?? null;
+    return decodeJsonOrNull(input) ?? input;
+}
+
+/** `JSON.stringify`, with `undefined` results and throwing inputs collapsed
+ *  to null. (claude + codex.) */
+export function jsonText(input: unknown): string | null {
+    try {
+        const encoded = JSON.stringify(input);
+        return encoded === undefined ? null : encoded;
+    } catch {
+        return null;
+    }
+}
+
+/** Plain bounded slice of a string - no normalization, no ellipsis.
+ *  (pi + opencode excerpt bound.) */
+export function boundedExcerpt(text: string, max = 1200): string {
+    return text.length <= max ? text : text.slice(0, max);
+}
+
+/**
+ * Bounded excerpt of an ARBITRARY value: stringify non-strings, normalize
+ * CRLF, trim, and ellipsis-terminate when clipped; null for empty/nullish
+ * input. (cursor variant - deliberately different from {@link boundedExcerpt}.)
+ */
+export function boundExcerpt(input: unknown, max = 1200): string | null {
+    let text: string | null = null;
+    if (typeof input === "string") {
+        text = input;
+    } else if (input !== null && input !== undefined) {
+        try {
+            text = JSON.stringify(input);
+        } catch {
+            text = String(input);
+        }
+    }
+    if (text === null) return null;
+    const normalized = text.replace(/\r\n/g, "\n").trim();
+    if (normalized.length === 0) return null;
+    return normalized.length <= max ? normalized : `${normalized.slice(0, max - 1)}…`;
+}
+
+/** The string members of an array value, or null when not an array.
+ *  (compaction raw interpreters.) */
+export function stringArray(input: unknown): readonly string[] | null {
+    return Array.isArray(input) ? input.filter((x): x is string => typeof x === "string") : null;
+}

--- a/apps/axctl/src/ingest/normalized/transcripts.test.ts
+++ b/apps/axctl/src/ingest/normalized/transcripts.test.ts
@@ -15,6 +15,22 @@ import { SkillName } from "@ax/lib/brands";
 // Fixture skill names are plain string literals; brand via the schema constructor.
 const sn = (s: string): SkillName => SkillName.make(s);
 
+// Batch fields are all REQUIRED on the seam; fixtures spread this and
+// override only the sections under test.
+const emptyBatch: NormalizedTranscriptBatch = {
+    providers: [],
+    sessions: [],
+    events: [],
+    turns: [],
+    toolCalls: [],
+    toolFileEvidence: [],
+    agentEventParentEdges: [],
+    syntheticSkillInvocations: [],
+    toolCallSkillRelations: [],
+    planSnapshots: [],
+    compactions: [],
+};
+
 describe("normalized transcript persistence", () => {
     it("writes escaped turn records with optional agent event links", () => {
         const sql = buildNormalizedTurnStatements([
@@ -46,6 +62,7 @@ describe("normalized transcript persistence", () => {
 
     it("builds provider graph, session graph, and turns from one batch", () => {
         const sql = buildNormalizedTranscriptStatements({
+            ...emptyBatch,
             providers: [{
                 name: "cursor",
                 displayName: "Cursor",
@@ -107,6 +124,7 @@ describe("normalized transcript persistence", () => {
         });
         const turnKey = turnRecordKey("session-a", 1);
         const sql = buildNormalizedTranscriptStatements({
+            ...emptyBatch,
             sessions: [{
                 id: "session-a",
                 provider: "opencode",
@@ -202,6 +220,7 @@ describe("normalized transcript persistence", () => {
 
     it("appends parent edges, plan snapshots, and compactions and forwards clearExisting", () => {
         const batch: NormalizedTranscriptBatch = {
+            ...emptyBatch,
             sessions: [{ id: "s1", provider: "codex" }],
             events: [{
                 provider: "codex", providerSessionId: "s1", providerEventId: "e1",
@@ -225,6 +244,7 @@ describe("normalized transcript persistence", () => {
 
     it("threads statement options through writeNormalizedTranscriptBatch", async () => {
         const batch: NormalizedTranscriptBatch = {
+            ...emptyBatch,
             sessions: [{ id: "s1", provider: "codex" }],
             events: [{
                 provider: "codex", providerSessionId: "s1", providerEventId: "e1",

--- a/apps/axctl/src/ingest/normalized/transcripts.ts
+++ b/apps/axctl/src/ingest/normalized/transcripts.ts
@@ -86,21 +86,27 @@ export interface NormalizedSyntheticSkillInvocationWrite {
     readonly skillContentHash?: string;
 }
 
+/**
+ * Every array field is REQUIRED: a parser with no such data passes an
+ * explicit empty array, so "this provider emits none of X" is a visible
+ * decision at each `to*NormalizedBatch` converter rather than an implicit
+ * `?? []` fallback inside the seam.
+ */
 export interface NormalizedTranscriptBatch {
-    readonly providers?: readonly AgentProviderWrite[];
+    readonly providers: readonly AgentProviderWrite[];
     readonly sessions: readonly NormalizedSessionWrite[];
-    readonly events?: readonly AgentEventWrite[];
+    readonly events: readonly AgentEventWrite[];
     readonly turns: readonly NormalizedTurnWrite[];
-    readonly toolCalls?: readonly ToolCallWrite[];
-    readonly toolFileEvidence?: readonly ToolFileEvidenceWrite[];
+    readonly toolCalls: readonly ToolCallWrite[];
+    readonly toolFileEvidence: readonly ToolFileEvidenceWrite[];
     /** Cross-batch agent_event parent edges (streaming parsers resolve parents
      *  flushed in an earlier batch themselves; within-batch edges are derived
      *  by buildAgentEventStatements). */
-    readonly agentEventParentEdges?: readonly AgentEventParentEdgeWrite[];
-    readonly syntheticSkillInvocations?: readonly NormalizedSyntheticSkillInvocationWrite[];
-    readonly toolCallSkillRelations?: readonly ToolCallSkillRelationWrite[];
-    readonly planSnapshots?: readonly PlanSnapshotWrite[];
-    readonly compactions?: readonly CompactionWrite[];
+    readonly agentEventParentEdges: readonly AgentEventParentEdgeWrite[];
+    readonly syntheticSkillInvocations: readonly NormalizedSyntheticSkillInvocationWrite[];
+    readonly toolCallSkillRelations: readonly ToolCallSkillRelationWrite[];
+    readonly planSnapshots: readonly PlanSnapshotWrite[];
+    readonly compactions: readonly CompactionWrite[];
 }
 
 export interface BuildNormalizedTranscriptStatementsOptions {
@@ -204,23 +210,23 @@ export const buildNormalizedTranscriptStatements = (
     batch: NormalizedTranscriptBatch,
     options?: BuildNormalizedTranscriptStatementsOptions,
 ): string[] => [
-    ...buildAgentProviderStatements(batch.providers ?? []),
+    ...buildAgentProviderStatements(batch.providers),
     ...buildAgentEventStatements(
-        { sessions: batch.sessions.map(toAgentSession), events: batch.events ?? [] },
+        { sessions: batch.sessions.map(toAgentSession), events: batch.events },
         { clearExisting: options?.clearExisting ?? true },
     ),
     ...buildNormalizedTurnStatements(batch.turns),
-    ...buildToolCallStatements(batch.toolCalls ?? []),
-    ...buildToolFileEvidenceStatements(batch.toolFileEvidence ?? []),
-    ...(batch.agentEventParentEdges ?? []).map(buildAgentEventParentEdgeStatement),
-    ...buildNormalizedSyntheticSkillInvocationStatements(batch.syntheticSkillInvocations ?? []),
-    ...(batch.toolCallSkillRelations ?? []).flatMap((relation) =>
+    ...buildToolCallStatements(batch.toolCalls),
+    ...buildToolFileEvidenceStatements(batch.toolFileEvidence),
+    ...batch.agentEventParentEdges.map(buildAgentEventParentEdgeStatement),
+    ...buildNormalizedSyntheticSkillInvocationStatements(batch.syntheticSkillInvocations),
+    ...batch.toolCallSkillRelations.flatMap((relation) =>
         buildRelateToolCallSkillStatements(relation)
     ),
-    ...(batch.planSnapshots ?? []).flatMap((snapshot) =>
+    ...batch.planSnapshots.flatMap((snapshot) =>
         buildPlanSnapshotStatements(snapshot)
     ),
-    ...buildCompactionStatements(batch.compactions ?? []),
+    ...buildCompactionStatements(batch.compactions),
 ];
 
 export const writeNormalizedTranscriptBatch = (

--- a/apps/axctl/src/ingest/opencode.ts
+++ b/apps/axctl/src/ingest/opencode.ts
@@ -3,7 +3,6 @@ import { Effect, FileSystem, Option, Path, Schema } from "effect";
 import { AxConfig } from "@ax/lib/config";
 import { SkillName } from "@ax/lib/brands";
 import { RecordId, SurrealClient } from "@ax/lib/db";
-import { decodeJsonOrNull, jsonParseErrorText } from "@ax/lib/decode";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { executeStatements } from "@ax/lib/shared/statement-exec";
 import {
@@ -14,12 +13,28 @@ import { makeFileFailureCollector } from "./file-isolation.ts";
 import { classifyTurnIntent } from "./intent-kind.ts";
 import { providerDelegationSignalAvailability } from "./delegation.ts";
 import { buildNormalizedTranscriptStatements } from "./normalized/transcripts.ts";
-import { agentEventRecordKey, type AgentEventWrite } from "./provider-events.ts";
+import { type AgentEventWrite } from "./provider-events.ts";
 import { providerPlanSignalAvailability } from "./plans.ts";
-import { toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
+import { toolCallRecordKey } from "./record-keys.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
-import { extractCommandTool, normalizeCommand, toolKindForName } from "./tool-calls.ts";
+// OpenCode reads numbers out of SQLite rows (number | bigint | stringly) -
+// the toolkit's coercing probe is this parser's `numberField`.
+import {
+    booleanField,
+    boundedExcerpt,
+    coercedNumberField as numberField,
+    isRecord,
+    nestedStringField,
+    parseJsonRecord,
+    parseMaybeJson,
+    stringField,
+} from "./normalized/toolkit.ts";
+import {
+    applyCommandFields,
+    makeToolCallWrite,
+    type MutableToolCallWrite,
+} from "./normalized/tool-call-write.ts";
 
 export const OpenCodeKey = Schema.Literal("opencode");
 export type OpenCodeKey = typeof OpenCodeKey.Type;
@@ -139,12 +154,7 @@ interface ToolResultFields {
     readonly durationMs: number | null;
 }
 
-type MutableToolCallWrite = {
-    -readonly [Key in keyof ToolCallWrite]: ToolCallWrite[Key];
-};
-
 const SYNTHETIC_PROVIDER_SEQ_OFFSET = 1_000_000_000;
-const MAX_OUTPUT_EXCERPT_CHARS = 1200;
 
 function validTimestamp(input: SQLiteValue | undefined, fallback: string): { ts: string; warning: string | null } {
     if (input === null || input === undefined) {
@@ -207,70 +217,8 @@ function hasColumns(columns: Set<string>, names: readonly string[]): boolean {
     return names.every((name) => columns.has(name));
 }
 
-function isRecord(input: unknown): input is Record<string, unknown> {
-    return typeof input === "object" && input !== null && !Array.isArray(input);
-}
-
-/** Effect-Schema-backed JSON decode at the SQLite blob boundary. `Option`
- *  (not `null`) so a literal JSON `null` is distinguishable from a failed
- *  parse. */
-const decodeJsonStringOption = Schema.decodeUnknownOption(Schema.UnknownFromJsonString);
-
-function parseJsonRecord(raw: string | null, label: string, warnings: string[]): Record<string, unknown> | null {
-    if (typeof raw !== "string" || raw.trim().length === 0) {
-        warnings.push(`${label}: missing JSON data`);
-        return null;
-    }
-    const parsed = decodeJsonStringOption(raw);
-    if (Option.isNone(parsed)) {
-        warnings.push(`${label}: invalid JSON data (${jsonParseErrorText(raw)})`);
-        return null;
-    }
-    if (isRecord(parsed.value)) return parsed.value;
-    warnings.push(`${label}: JSON data is not an object`);
-    return null;
-}
-
-function stringField(input: Record<string, unknown>, field: string): string | null {
-    const value = input[field];
-    return typeof value === "string" ? value : null;
-}
-
-function numberField(input: Record<string, unknown>, field: string): number | null {
-    const value = input[field];
-    if (typeof value === "number" && Number.isFinite(value)) return value;
-    if (typeof value === "bigint") return Number(value);
-    if (typeof value !== "string" || value.trim().length === 0) return null;
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-}
-
-function booleanField(input: Record<string, unknown>, field: string): boolean | null {
-    const value = input[field];
-    return typeof value === "boolean" ? value : null;
-}
-
-function nestedStringField(
-    input: Record<string, unknown>,
-    objectField: string,
-    field: string,
-): string | null {
-    const value = input[objectField];
-    if (!isRecord(value)) return null;
-    return stringField(value, field);
-}
-
 function hasErrorFlag(input: Record<string, unknown>): boolean {
     return input.error !== null && input.error !== undefined;
-}
-
-function boundedExcerpt(text: string, max = MAX_OUTPUT_EXCERPT_CHARS): string {
-    return text.length <= max ? text : text.slice(0, max);
-}
-
-function parseMaybeJson(input: unknown): unknown {
-    if (typeof input !== "string") return input ?? null;
-    return decodeJsonOrNull(input) ?? input;
 }
 
 function textFromPartData(data: Record<string, unknown>): string | null {
@@ -486,38 +434,29 @@ function processToolPart(input: {
         callId,
     });
     const call: MutableToolCallWrite = {
-        provider: "opencode",
-        toolName,
-        toolKind: toolKindForName(toolName),
-        sessionId: input.session.id,
-        seq: input.turnSeq,
-        turnKey: turnRecordKey(input.session.id, input.turnSeq),
-        agentEventKey: agentEventRecordKey({
+        ...makeToolCallWrite({
             provider: "opencode",
-            providerSessionId: input.session.id,
+            toolName,
+            sessionId: input.session.id,
+            seq: input.turnSeq,
+            callId,
+            // OpenCode keys the tool-call agent_event by the PART row id, not
+            // the call id.
             providerEventId,
-            seq: eventSeq,
+            eventSeq,
+            ts,
+            cwd: input.session.cwd,
+            inputJson,
+            rawJson: input.part.data,
         }),
-        callId,
-        ts,
-        cwd: input.session.cwd,
-        inputJson,
         outputJson: result.outputJson,
-        rawJson: input.part.data,
         outputExcerpt: result.outputExcerpt,
         errorText: result.errorText,
         durationMs: result.durationMs,
         hasError: result.hasError,
     };
 
-    if (isRecord(inputJson)) {
-        const command = stringField(inputJson, "command") ?? stringField(inputJson, "cmd");
-        if (command) {
-            call.commandText = command;
-            call.commandToolName = extractCommandTool(command);
-            call.commandNorm = normalizeCommand(command);
-        }
-    }
+    applyCommandFields(call, inputJson);
 
     input.providerEvents.push({
         provider: "opencode",
@@ -905,6 +844,9 @@ const buildOpenCodeBatchStatements = (
             },
         })),
         toolCalls: extract.toolCalls,
+        // OpenCode emits no tool-file evidence today (pre-toolkit behavior preserved).
+        toolFileEvidence: [],
+        agentEventParentEdges: [],
         syntheticSkillInvocations: extract.invocations.map((invocation) => ({
             sessionId: invocation.session,
             seq: invocation.seq,
@@ -915,6 +857,8 @@ const buildOpenCodeBatchStatements = (
             skillContentHash: "opencode",
         })),
         toolCallSkillRelations: extract.skillRelations,
+        planSnapshots: [],
+        compactions: [],
     });
 
 export const __testBuildOpenCodeBatchStatements = buildOpenCodeBatchStatements;

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -2,18 +2,8 @@ import { Effect, FileSystem, Path, Schema } from "effect";
 import { AxConfig } from "@ax/lib/config";
 import { SkillName } from "@ax/lib/brands";
 import { RecordId, SurrealClient } from "@ax/lib/db";
-import { decodeJsonOrNull } from "@ax/lib/decode";
-import { safeKeyPart } from "@ax/lib/shared/derive-keys";
 import { executeStatements } from "@ax/lib/shared/statement-exec";
-import {
-    recordRef,
-    surrealDate,
-    surrealJsonTextOption,
-    surrealObject,
-    surrealOptionInt,
-    surrealOptionString,
-    surrealString,
-} from "@ax/lib/shared/surql";
+import { surrealJsonTextOption } from "@ax/lib/shared/surql";
 import {
     type ToolCallSkillRelationWrite,
     type ToolCallWrite,
@@ -24,10 +14,24 @@ import { classifyTurnIntent } from "./intent-kind.ts";
 import { providerDelegationSignalAvailability } from "./delegation.ts";
 import { agentEventRecordKey, type AgentEventWrite } from "./provider-events.ts";
 import { providerPlanSignalAvailability } from "./plans.ts";
-import { toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
+import { toolCallRecordKey } from "./record-keys.ts";
 import { BaseStageStats, IngestContext, sinceDaysFromCtx, StageMeta } from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
-import { extractCommandTool, normalizeCommand, toolKindForName } from "./tool-calls.ts";
+import {
+    booleanField,
+    boundedExcerpt,
+    isRecord,
+    numberField,
+    parseJsonl,
+    parseMaybeJson,
+    stringField,
+} from "./normalized/toolkit.ts";
+import {
+    applyCommandFields,
+    makeToolCallWrite,
+    type MutableToolCallWrite,
+} from "./normalized/tool-call-write.ts";
+import { buildSessionTokenUsageStatement } from "./token-usage-writers.ts";
 import { extractToolFileEvidence } from "./tool-file-evidence.ts";
 import { makeFileFailureCollector } from "./file-isolation.ts";
 import { decodePiTranscriptLine } from "./line-schemas.ts";
@@ -106,30 +110,6 @@ export interface PiStats {
 const SAFE_FALLBACK_TS = "1970-01-01T00:00:00.000Z";
 const SYNTHETIC_PROVIDER_SEQ_OFFSET = 1_000_000_000;
 
-function isRecord(input: unknown): input is Record<string, unknown> {
-    return typeof input === "object" && input !== null && !Array.isArray(input);
-}
-
-function stringField(input: Record<string, unknown>, field: string): string | null {
-    const value = input[field];
-    return typeof value === "string" ? value : null;
-}
-
-function numberField(input: Record<string, unknown>, field: string): number | null {
-    const value = input[field];
-    return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function booleanField(input: Record<string, unknown>, field: string): boolean | null {
-    const value = input[field];
-    return typeof value === "boolean" ? value : null;
-}
-
-function parseJsonl(line: string): Record<string, unknown> | null {
-    const decoded = decodeJsonOrNull(line);
-    return isRecord(decoded) ? decoded : null;
-}
-
 function validIsoTimestamp(input: string | number): string | null {
     const date = new Date(input);
     return Number.isFinite(date.getTime()) ? date.toISOString() : null;
@@ -180,14 +160,6 @@ interface ToolResultFields {
     hasError: boolean;
 }
 
-type MutableToolCallWrite = {
-    -readonly [Key in keyof ToolCallWrite]: ToolCallWrite[Key];
-};
-
-function boundedExcerpt(text: string, max = 1200): string {
-    return text.length <= max ? text : text.slice(0, max);
-}
-
 function piToolCallId(block: Record<string, unknown>): string | null {
     return stringField(block, "id") ??
         stringField(block, "toolCallId") ??
@@ -201,9 +173,7 @@ function piToolName(input: Record<string, unknown>): string | null {
 }
 
 function piToolInput(block: Record<string, unknown>): unknown {
-    const input = block.input ?? block.arguments ?? block.args ?? null;
-    if (typeof input !== "string") return input;
-    return decodeJsonOrNull(input) ?? input;
+    return parseMaybeJson(block.input ?? block.arguments ?? block.args ?? null);
 }
 
 function applyToolResult(call: MutableToolCallWrite, result: ToolResultFields): void {
@@ -329,35 +299,20 @@ function createPiExtractor(filePath: string) {
             seq,
             callId,
         });
-        const call: MutableToolCallWrite = {
+        const call: MutableToolCallWrite = makeToolCallWrite({
             provider: "pi",
             toolName,
-            toolKind: toolKindForName(toolName),
             sessionId: currentSession.id,
             seq,
-            turnKey: turnRecordKey(currentSession.id, seq),
-            agentEventKey: agentEventRecordKey({
-                provider: "pi",
-                providerSessionId: currentSession.id,
-                providerEventId: callId,
-                seq: eventSeq,
-            }),
             callId,
+            eventSeq,
             ts,
             cwd: currentSession.cwd,
             inputJson,
             rawJson: block,
-            hasError: false,
-        };
+        });
 
-        if (toolName === "exec_command" && isRecord(inputJson)) {
-            const command = stringField(inputJson, "command") ?? stringField(inputJson, "cmd");
-            if (command) {
-                call.commandText = command;
-                call.commandToolName = extractCommandTool(command);
-                call.commandNorm = normalizeCommand(command);
-            }
-        }
+        if (toolName === "exec_command") applyCommandFields(call, inputJson);
 
         pushProviderEvent({
             providerEventId: callId,
@@ -623,19 +578,17 @@ const buildPiTokenUsageStatements = (extract: PiExtract): string[] => {
         ? extract.usage.totalTokens
         : extract.usage.input + extract.usage.output;
     return [
-        `UPSERT ${recordRef("session_token_usage", safeKeyPart(extract.session.id))} MERGE ${surrealObject([
-            ["session", recordRef("session", extract.session.id)],
-            ["source", surrealString("pi")],
-            ["workflow_epoch", "NONE"],
-            ["model", surrealOptionString(extract.session.model)],
-            ["prompt_tokens", surrealOptionInt(extract.usage.input || null)],
-            ["completion_tokens", surrealOptionInt(extract.usage.output || null)],
-            ["cache_creation_input_tokens", surrealOptionInt(extract.usage.cacheWrite || null)],
-            ["cache_read_input_tokens", surrealOptionInt(extract.usage.cacheRead || null)],
-            ["estimated_tokens", Math.trunc(estimatedTokens).toString(10)],
-            ["transcript_bytes", "0"],
-            ["context_window", "NONE"],
-            ["labels", surrealJsonTextOption({
+        buildSessionTokenUsageStatement({
+            sessionId: extract.session.id,
+            source: "pi",
+            model: extract.session.model,
+            promptTokens: extract.usage.input || null,
+            completionTokens: extract.usage.output || null,
+            cacheCreationInputTokens: extract.usage.cacheWrite || null,
+            cacheReadInputTokens: extract.usage.cacheRead || null,
+            estimatedTokens,
+            contextWindow: null,
+            labels: surrealJsonTextOption({
                 ...tokenQualityLabels({
                     source: "pi_jsonl",
                     tokenSourceQuality: "explicit",
@@ -643,10 +596,10 @@ const buildPiTokenUsageStatements = (extract: PiExtract): string[] => {
                     model: extract.session.model,
                     modelSourceDetail: extract.session.model ? "pi_session.model" : "missing_pi_session_model",
                 }),
-            })],
-            ["metrics", surrealJsonTextOption({ usage: extract.usage })],
-            ["ts", surrealDate(extract.session.ended_at)],
-        ])};`,
+            }),
+            metrics: surrealJsonTextOption({ usage: extract.usage }),
+            ts: extract.session.ended_at,
+        }),
     ];
 };
 
@@ -706,6 +659,7 @@ const toPiNormalizedBatch = (extract: PiExtract): NormalizedTranscriptBatch => (
     })),
     toolCalls: extract.toolCalls,
     toolFileEvidence: extractToolFileEvidence(extract.toolCalls),
+    agentEventParentEdges: [],
     // turnHasError/turnIndex omitted: seam defaults preserve
     // `turn_has_error = false, turn_index = ${seq}`.
     syntheticSkillInvocations: extract.invocations.map((invocation) => ({
@@ -718,6 +672,7 @@ const toPiNormalizedBatch = (extract: PiExtract): NormalizedTranscriptBatch => (
         skillContentHash: "pi",
     })),
     toolCallSkillRelations: extract.skillRelations,
+    planSnapshots: [],
     compactions: extract.compactions,
 });
 

--- a/apps/axctl/src/ingest/provider-parity.ts
+++ b/apps/axctl/src/ingest/provider-parity.ts
@@ -289,7 +289,8 @@ export const PROVIDER_PARITY_FEATURES: readonly ProviderParityFeature[] = [
             ]),
             pi: supported("Pi usage fields write explicit token usage when present.", [
                 { path: "apps/axctl/src/ingest/pi.ts", contains: "buildPiTokenUsageStatements" },
-                { path: "apps/axctl/src/ingest/pi.ts", contains: "recordRef(\"session_token_usage\"" },
+                // Statement shape lives in the shared Parser Toolkit writer.
+                { path: "apps/axctl/src/ingest/token-usage-writers.ts", contains: "recordRef(\"session_token_usage\"" },
             ]),
             opencode: supported("OpenCode sessions receive estimated token usage from session-health.", [
                 { path: "apps/axctl/src/ingest/session-health.ts", contains: "UPSERT ${recordRef(\"session_token_usage\"" },

--- a/apps/axctl/src/ingest/token-usage-writers.test.ts
+++ b/apps/axctl/src/ingest/token-usage-writers.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import { surrealJsonOption } from "@ax/lib/shared/surql";
+import type { CostEstimate } from "./model-pricing.ts";
+import {
+    buildSessionTokenUsageStatement,
+    buildTurnTokenUsageStatement,
+    surrealOptionFloat,
+} from "./token-usage-writers.ts";
+
+const cost: CostEstimate = {
+    inputUsd: 0.123456789,
+    outputUsd: null,
+    cacheCreationUsd: null,
+    cacheReadUsd: 0.5,
+    totalUsd: 0.623456789,
+    pricingSource: "model_pricing.ts",
+};
+
+describe("surrealOptionFloat", () => {
+    test("rounds to 8 decimals and NONEs nullish / non-finite values", () => {
+        expect(surrealOptionFloat(0.123456789)).toBe("0.12345679");
+        expect(surrealOptionFloat(1)).toBe("1");
+        expect(surrealOptionFloat(null)).toBe("NONE");
+        expect(surrealOptionFloat(undefined)).toBe("NONE");
+        expect(surrealOptionFloat(Number.NaN)).toBe("NONE");
+    });
+});
+
+describe("buildSessionTokenUsageStatement", () => {
+    test("emits the cost-less shape (pi) without model_ref/cost/pricing fields", () => {
+        const sql = buildSessionTokenUsageStatement({
+            sessionId: "session-1",
+            source: "pi",
+            model: "gpt-x",
+            promptTokens: 10,
+            completionTokens: 20,
+            cacheCreationInputTokens: null,
+            cacheReadInputTokens: 5,
+            estimatedTokens: 30,
+            contextWindow: null,
+            labels: surrealJsonOption({ k: "v" }),
+            metrics: surrealJsonOption(null),
+            ts: "2026-06-13T00:00:00.000Z",
+        });
+        expect(sql).toStartWith("UPSERT session_token_usage:`session_1` MERGE {");
+        expect(sql).toContain('source: "pi"');
+        expect(sql).toContain("workflow_epoch: NONE");
+        expect(sql).toContain("prompt_tokens: 10");
+        expect(sql).toContain("cache_creation_input_tokens: NONE");
+        expect(sql).toContain("context_window: NONE");
+        expect(sql).not.toContain("model_ref");
+        expect(sql).not.toContain("estimated_cost_usd");
+        expect(sql).not.toContain("pricing_source");
+        expect(sql).toContain('ts: d"2026-06-13T00:00:00.000Z"');
+    });
+
+    test("emits the costed shape (codex) with the model_ref..pricing_source block before labels", () => {
+        const sql = buildSessionTokenUsageStatement({
+            sessionId: "session-1",
+            source: "codex",
+            model: "gpt-5.1-codex",
+            promptTokens: 10,
+            completionTokens: 20,
+            cacheCreationInputTokens: null,
+            cacheReadInputTokens: 5,
+            estimatedTokens: 30,
+            contextWindow: 272000,
+            cost: { modelRefKey: "gpt-5.1-codex", estimate: cost },
+            labels: surrealJsonOption({ k: "v" }),
+            metrics: surrealJsonOption({ m: 1 }),
+            ts: "2026-06-13T00:00:00.000Z",
+        });
+        expect(sql).toContain("model_ref: agent_model:`gpt-5.1-codex`");
+        expect(sql).toContain("estimated_input_cost_usd: 0.12345679");
+        expect(sql).toContain("estimated_output_cost_usd: NONE");
+        expect(sql).toContain("estimated_cost_usd: 0.62345679");
+        expect(sql).toContain('pricing_source: "model_pricing.ts"');
+        expect(sql).toContain("context_window: 272000");
+        // Field order: cost block sits between context_window and labels.
+        expect(sql.indexOf("context_window")).toBeLessThan(sql.indexOf("model_ref"));
+        expect(sql.indexOf("pricing_source")).toBeLessThan(sql.indexOf("labels"));
+    });
+
+    test("NONEs model_ref when the cost block has no model key", () => {
+        const sql = buildSessionTokenUsageStatement({
+            sessionId: "s",
+            source: "codex",
+            model: null,
+            promptTokens: null,
+            completionTokens: null,
+            cacheCreationInputTokens: null,
+            cacheReadInputTokens: null,
+            estimatedTokens: 0,
+            contextWindow: null,
+            cost: { modelRefKey: null, estimate: cost },
+            labels: "NONE",
+            metrics: "NONE",
+            ts: "2026-06-13T00:00:00.000Z",
+        });
+        expect(sql).toContain("model_ref: NONE");
+    });
+});
+
+describe("buildTurnTokenUsageStatement", () => {
+    const base = {
+        sessionId: "session-1",
+        seq: 4,
+        source: "codex",
+        model: "gpt-5.1-codex",
+        promptTokens: 100,
+        completionTokens: 50,
+        cacheCreationInputTokens: null,
+        cacheReadInputTokens: 25,
+        freshInputTokens: 75,
+        estimatedTokens: 150,
+        modelRefKey: "gpt-5.1-codex",
+        cost,
+        usageSource: "codex_token_count.last_token_usage",
+        usageQuality: "provider_turn",
+        ts: "2026-06-13T00:00:00.000Z",
+    };
+
+    test("includes the raw column only when a pre-rendered literal is given", () => {
+        const withRaw = buildTurnTokenUsageStatement({
+            ...base,
+            raw: surrealJsonOption({ input_tokens: 100 }),
+        });
+        expect(withRaw).toContain("UPSERT turn_token_usage:");
+        expect(withRaw).toContain("fresh_input_tokens: 75");
+        expect(withRaw).toContain('usage_source: "codex_token_count.last_token_usage"');
+        expect(withRaw).toContain("raw: ");
+        expect(withRaw.indexOf("usage_quality")).toBeLessThan(withRaw.indexOf("raw: "));
+        expect(withRaw.indexOf("raw: ")).toBeLessThan(withRaw.indexOf('ts: d"'));
+
+        const withoutRaw = buildTurnTokenUsageStatement(base);
+        expect(withoutRaw).not.toContain("raw: ");
+        expect(withoutRaw).toContain('usage_quality: "provider_turn", ts: d"');
+    });
+
+    test("keys the row and the turn link by the same turn record key", () => {
+        const sql = buildTurnTokenUsageStatement(base);
+        const key = sql.slice("UPSERT turn_token_usage:`".length, sql.indexOf("` MERGE"));
+        expect(key).toStartWith("session_1__");
+        expect(key).toEndWith("__seq_000004");
+        expect(sql).toContain(`turn: turn:\`${key}\``);
+        expect(sql).toContain("seq: 4");
+    });
+});

--- a/apps/axctl/src/ingest/token-usage-writers.ts
+++ b/apps/axctl/src/ingest/token-usage-writers.ts
@@ -1,0 +1,137 @@
+/**
+ * Parser Toolkit - shared `session_token_usage` / `turn_token_usage`
+ * statement builders. Token-usage rows are deliberately provider "extras"
+ * OUTSIDE the NormalizedTranscriptBatch seam (see ADR-0012); this module
+ * keeps the statement SHAPE single-sourced while each parser still decides
+ * which raw usage fields feed it and how labels/metrics are encoded
+ * (`surrealJsonOption` vs `surrealJsonTextOption` differ per provider, so
+ * those arrive pre-rendered).
+ */
+import { safeKeyPart } from "@ax/lib/shared/derive-keys";
+import {
+    recordRef,
+    surrealDate,
+    surrealObject,
+    surrealOptionInt,
+    surrealOptionString,
+    surrealString,
+} from "@ax/lib/shared/surql";
+import type { CostEstimate } from "./model-pricing.ts";
+import { turnRecordKey } from "./record-keys.ts";
+
+/** A float literal rounded to 8 decimals, or `NONE` for nullish/non-finite. */
+export const surrealOptionFloat = (value: number | null | undefined): string =>
+    value === null || value === undefined || !Number.isFinite(value)
+        ? "NONE"
+        : Number(value.toFixed(8)).toString();
+
+export interface SessionTokenUsageCostFields {
+    /** Key for the `model_ref` record link; `NONE` when null. */
+    readonly modelRefKey: string | null;
+    readonly estimate: CostEstimate;
+}
+
+export interface SessionTokenUsageStatementInput {
+    readonly sessionId: string;
+    readonly source: string;
+    readonly model: string | null;
+    readonly promptTokens: number | null;
+    readonly completionTokens: number | null;
+    readonly cacheCreationInputTokens: number | null;
+    readonly cacheReadInputTokens: number | null;
+    readonly estimatedTokens: number;
+    readonly contextWindow: number | null;
+    /** When present, the model_ref + estimated-cost + pricing_source field
+     *  block is emitted (codex); absent reproduces the cost-less pi shape. */
+    readonly cost?: SessionTokenUsageCostFields;
+    /** Pre-rendered SurrealQL literal for the `labels` column. */
+    readonly labels: string;
+    /** Pre-rendered SurrealQL literal for the `metrics` column. */
+    readonly metrics: string;
+    readonly ts: Date | string;
+}
+
+const costFieldPairs = (
+    modelRefKey: string | null,
+    cost: CostEstimate,
+): readonly (readonly [string, string])[] => [
+    ["model_ref", modelRefKey ? recordRef("agent_model", modelRefKey) : "NONE"],
+    ["estimated_input_cost_usd", surrealOptionFloat(cost.inputUsd)],
+    ["estimated_output_cost_usd", surrealOptionFloat(cost.outputUsd)],
+    ["estimated_cache_creation_cost_usd", surrealOptionFloat(cost.cacheCreationUsd)],
+    ["estimated_cache_read_cost_usd", surrealOptionFloat(cost.cacheReadUsd)],
+    ["estimated_cost_usd", surrealOptionFloat(cost.totalUsd)],
+    ["pricing_source", surrealOptionString(cost.pricingSource)],
+];
+
+/** One per-session `session_token_usage` UPSERT, field order locked to the
+ *  pre-toolkit codex/pi builders. */
+export const buildSessionTokenUsageStatement = (
+    input: SessionTokenUsageStatementInput,
+): string =>
+    `UPSERT ${recordRef("session_token_usage", safeKeyPart(input.sessionId))} MERGE ${surrealObject([
+        ["session", recordRef("session", input.sessionId)],
+        ["source", surrealString(input.source)],
+        ["workflow_epoch", "NONE"],
+        ["model", surrealOptionString(input.model)],
+        ["prompt_tokens", surrealOptionInt(input.promptTokens)],
+        ["completion_tokens", surrealOptionInt(input.completionTokens)],
+        ["cache_creation_input_tokens", surrealOptionInt(input.cacheCreationInputTokens)],
+        ["cache_read_input_tokens", surrealOptionInt(input.cacheReadInputTokens)],
+        ["estimated_tokens", Math.trunc(input.estimatedTokens).toString(10)],
+        ["transcript_bytes", "0"],
+        ["context_window", surrealOptionInt(input.contextWindow)],
+        ...(input.cost ? costFieldPairs(input.cost.modelRefKey, input.cost.estimate) : []),
+        ["labels", input.labels],
+        ["metrics", input.metrics],
+        ["ts", surrealDate(input.ts)],
+    ])};`;
+
+export interface TurnTokenUsageStatementInput {
+    readonly sessionId: string;
+    readonly seq: number;
+    readonly source: string;
+    readonly model: string | null;
+    readonly promptTokens: number | null;
+    readonly completionTokens: number | null;
+    readonly cacheCreationInputTokens: number | null;
+    readonly cacheReadInputTokens: number | null;
+    readonly freshInputTokens: number | null;
+    readonly estimatedTokens: number;
+    /** Key for the `model_ref` record link (claude normalizes the model name
+     *  first; codex links the raw session model). `NONE` when null. */
+    readonly modelRefKey: string | null;
+    readonly cost: CostEstimate;
+    readonly usageSource: string;
+    readonly usageQuality: string;
+    /** Pre-rendered SurrealQL literal for the `raw` column; the field pair is
+     *  omitted entirely when undefined (claude writes no raw column). */
+    readonly raw?: string;
+    readonly ts: Date | string;
+}
+
+/** One per-turn `turn_token_usage` UPSERT, field order locked to the
+ *  pre-toolkit codex/claude builders. */
+export const buildTurnTokenUsageStatement = (
+    input: TurnTokenUsageStatementInput,
+): string => {
+    const turnKey = turnRecordKey(input.sessionId, input.seq);
+    return `UPSERT ${recordRef("turn_token_usage", turnKey)} MERGE ${surrealObject([
+        ["session", recordRef("session", input.sessionId)],
+        ["turn", recordRef("turn", turnKey)],
+        ["seq", Math.trunc(input.seq).toString(10)],
+        ["source", surrealString(input.source)],
+        ["model", surrealOptionString(input.model)],
+        ["prompt_tokens", surrealOptionInt(input.promptTokens)],
+        ["completion_tokens", surrealOptionInt(input.completionTokens)],
+        ["cache_creation_input_tokens", surrealOptionInt(input.cacheCreationInputTokens)],
+        ["cache_read_input_tokens", surrealOptionInt(input.cacheReadInputTokens)],
+        ["fresh_input_tokens", surrealOptionInt(input.freshInputTokens)],
+        ["estimated_tokens", Math.trunc(input.estimatedTokens).toString(10)],
+        ...costFieldPairs(input.modelRefKey, input.cost),
+        ["usage_source", surrealString(input.usageSource)],
+        ["usage_quality", surrealString(input.usageQuality)],
+        ...(input.raw === undefined ? [] : [["raw", input.raw] as const]),
+        ["ts", surrealDate(input.ts)],
+    ])};`;
+};

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -2,7 +2,6 @@ import { Effect, FileSystem, Option, Path, PlatformError, Schema, Stream } from 
 import { RecordId, SurrealClient, filePointer } from "@ax/lib/db";
 import { AxConfig } from "@ax/lib/config";
 import { surrealLiteral } from "@ax/lib/json";
-import { decodeJsonOrNull } from "@ax/lib/decode";
 import { SkillName } from "@ax/lib/brands";
 import { resolveSkillName, skillRecordKey } from "@ax/lib/skill-id";
 import { AppLayer } from "@ax/lib/layers";
@@ -48,6 +47,11 @@ import {
     type NormalizedTranscriptBatch,
     type NormalizedTurnWrite,
 } from "./normalized/transcripts.ts";
+import { isRecord, jsonText, numberField, parseJsonl, stringField } from "./normalized/toolkit.ts";
+import {
+    buildTurnTokenUsageStatement,
+    surrealOptionFloat,
+} from "./token-usage-writers.ts";
 import { decodeClaudeTranscriptLine } from "./line-schemas.ts";
 
 import { selectByIds } from "@ax/lib/shared/record-select";
@@ -180,15 +184,6 @@ export function transcriptEditFileRecordKey(path: string): string {
     return fileRecordKey("_", path);
 }
 
-function isRecord(input: unknown): input is Record<string, unknown> {
-    return typeof input === "object" && input !== null && !Array.isArray(input);
-}
-
-function parseJsonl(line: string): Record<string, unknown> | null {
-    const decoded = decodeJsonOrNull(line);
-    return isRecord(decoded) ? decoded : null;
-}
-
 function asContentBlocks(input: unknown): Record<string, unknown>[] {
     return Array.isArray(input) ? input.filter(isRecord) : [];
 }
@@ -231,11 +226,6 @@ function messageKind(role: string, content: unknown, textExcerpt: string | null)
     return role;
 }
 
-function stringField(input: Record<string, unknown>, field: string): string | null {
-    const value = input[field];
-    return typeof value === "string" ? value : null;
-}
-
 function stableHash(input: string): string {
     return Bun.hash(input).toString(16).padStart(16, "0");
 }
@@ -255,24 +245,10 @@ function stringOrJsonExcerpt(input: unknown): string | null {
     return excerpt.length > 0 ? excerpt : null;
 }
 
-function numberField(input: Record<string, unknown>, field: string): number | null {
-    const value = input[field];
-    return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
 export function claudeConcurrency(raw = process.env.AX_CLAUDE_CONCURRENCY): number {
     if (!raw) return DEFAULT_CLAUDE_CONCURRENCY;
     const parsed = Number.parseInt(raw, 10);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CLAUDE_CONCURRENCY;
-}
-
-function jsonText(input: unknown): string | null {
-    try {
-        const encoded = JSON.stringify(input);
-        return encoded === undefined ? null : encoded;
-    } catch {
-        return null;
-    }
 }
 
 function outputText(input: unknown): string | null {
@@ -1464,15 +1440,14 @@ export const toClaudeNormalizedBatch = (
     turns: extracted.turns.map(toNormalizedClaudeTurn),
     toolCalls: extracted.toolCalls,
     toolFileEvidence: extractToolFileEvidence(extracted.toolCalls),
+    agentEventParentEdges: [],
+    // Real claude skill invocations flow through the effectful
+    // relateInvocations path (catalog-resolved), never the synthetic builder.
+    syntheticSkillInvocations: [],
     toolCallSkillRelations: skillRelations,
     planSnapshots: extracted.planSnapshots,
     compactions: extracted.compactions,
 });
-
-const surrealOptionFloat = (value: number | null | undefined): string =>
-    value === null || value === undefined || !Number.isFinite(value)
-        ? "NONE"
-        : Number(value.toFixed(8)).toString();
 
 /**
  * Build the `session_token_usage` UPSERT for a Claude session, priced from the
@@ -1543,38 +1518,33 @@ export const buildClaudeTurnTokenUsageStatements = (
     const sessionId = extracted.session.id;
     return extracted.turnTokenUsages.map((usage) => {
         const modelKey = normalizeModelName(usage.model);
-        const cost = estimateCost({
-            modelKey,
+        return buildTurnTokenUsageStatement({
+            sessionId,
+            seq: usage.seq,
+            source,
+            model: usage.model,
             promptTokens: usage.promptTokens,
             completionTokens: usage.completionTokens,
             cacheCreationInputTokens: usage.cacheCreationInputTokens,
             cacheReadInputTokens: usage.cacheReadInputTokens,
+            freshInputTokens: usage.freshInputTokens,
             estimatedTokens: usage.estimatedTokens,
+            // Claude links model_ref through the NORMALIZED model name (the
+            // raw header model string is kept on the `model` column).
+            modelRefKey: modelKey,
+            cost: estimateCost({
+                modelKey,
+                promptTokens: usage.promptTokens,
+                completionTokens: usage.completionTokens,
+                cacheCreationInputTokens: usage.cacheCreationInputTokens,
+                cacheReadInputTokens: usage.cacheReadInputTokens,
+                estimatedTokens: usage.estimatedTokens,
+            }),
+            usageSource: "claude_transcript.message_usage",
+            usageQuality: "provider_turn",
+            // No raw column for claude turn usage rows.
+            ts: usage.ts,
         });
-        const turnKey = turnRecordKey(sessionId, usage.seq);
-        return `UPSERT ${recordRef("turn_token_usage", turnKey)} MERGE ${surrealObject([
-            ["session", recordRef("session", sessionId)],
-            ["turn", recordRef("turn", turnKey)],
-            ["seq", Math.trunc(usage.seq).toString(10)],
-            ["source", surrealString(source)],
-            ["model", surrealOptionString(usage.model)],
-            ["prompt_tokens", surrealOptionInt(usage.promptTokens)],
-            ["completion_tokens", surrealOptionInt(usage.completionTokens)],
-            ["cache_creation_input_tokens", surrealOptionInt(usage.cacheCreationInputTokens)],
-            ["cache_read_input_tokens", surrealOptionInt(usage.cacheReadInputTokens)],
-            ["fresh_input_tokens", surrealOptionInt(usage.freshInputTokens)],
-            ["estimated_tokens", Math.trunc(usage.estimatedTokens).toString(10)],
-            ["model_ref", modelKey ? recordRef("agent_model", modelKey) : "NONE"],
-            ["estimated_input_cost_usd", surrealOptionFloat(cost.inputUsd)],
-            ["estimated_output_cost_usd", surrealOptionFloat(cost.outputUsd)],
-            ["estimated_cache_creation_cost_usd", surrealOptionFloat(cost.cacheCreationUsd)],
-            ["estimated_cache_read_cost_usd", surrealOptionFloat(cost.cacheReadUsd)],
-            ["estimated_cost_usd", surrealOptionFloat(cost.totalUsd)],
-            ["pricing_source", surrealOptionString(cost.pricingSource)],
-            ["usage_source", surrealString("claude_transcript.message_usage")],
-            ["usage_quality", surrealString("provider_turn")],
-            ["ts", surrealDate(usage.ts)],
-        ])};`;
     });
 };
 


### PR DESCRIPTION
## What

The 4-5 provider parsers (claude, codex, pi, opencode, cursor) were copy-paste forks. This adds a **Parser Toolkit** - the shared write-builder + JSON-access layer of the Derivation Engine that provider parsers compose - so each parser shrinks to provider-specific raw-event interpretation. ADR-0012's seam is untouched: parsers still end at `NormalizedTranscriptBatch`, statement building stays behind the seam.

## Dedup numbers (LOC removed per area)

| Area | Removed | Added (call-site) | Net in parsers |
|---|---|---|---|
| codex.ts | 131 | 59 | **-72** |
| opencode.ts | 93 | 37 | **-56** |
| pi.ts | 84 | 39 | **-45** |
| cursor.ts | 65 | 22 | **-43** |
| transcripts.ts (claude) | 60 | 30 | **-30** |
| compaction.ts | 78 | 70 | **-8** (4 extractors → thin raw interpreters over one shared build path) |

Total: **-530 / +307** in existing files; new shared modules are 384 LOC (`normalized/toolkit.ts` 165, `token-usage-writers.ts` 137, `normalized/tool-call-write.ts` 82) plus 390 LOC of new unit tests.

## Work items

1. **JSON access toolkit** (`normalized/toolkit.ts`): superset of the 5 duplicated helper sets. Subtle variants preserved as distinct exports instead of merged: `numberField` (strict, pi/claude), `intField` (string-coercing + truncating, codex - aliased to `numberField` at the codex import), `coercedNumberField` (number|bigint|string, opencode), and `boundedExcerpt` (plain slice) vs `boundExcerpt` (normalize/trim/ellipsis, cursor). `parseJsonRecord`'s opencode/cursor copies differ only in a guard that is equivalent for the declared `string | null` input (noted in the doc comment). Cursor's `parseJsonValue` stays local (genuinely different semantics).
2. **Compaction unification** (`compaction.ts`): `extractPi/Codex/Claude/CursorCompaction` are now raw interpreters producing `CompactionWriteParts`; one shared `makeCompactionWrite` derives keys, linkage, and null-defaults. Public signatures and outputs unchanged.
3. **Token-usage builders** (`token-usage-writers.ts`): one `buildSessionTokenUsageStatement` (pi cost-less shape = codex shape minus the optional `model_ref..pricing_source` block) and one `buildTurnTokenUsageStatement` (codex with `raw`, claude without; `modelRefKey` parameterizes claude's normalized-model link). Field order locked to the legacy builders; labels/metrics arrive pre-rendered because codex uses `surrealJsonOption` and pi `surrealJsonTextOption`.
4. **Tool-call write mapping** (`normalized/tool-call-write.ts`): `makeToolCallWrite` (identity, turn/agent_event record keys, `hasError: false` base; `providerEventId`/`eventSeq` overrides for opencode's part-row identity and the synthetic event seqs; `cwd` key omitted when undefined for cursor) + `applyCommandFields` (the exec-command triple). Provider-specific result/error interpretation stays local; cursor keeps its always-present command triple inline.
5. **`NormalizedTranscriptBatch` tightened**: all array fields REQUIRED; the 5 converters pass explicit empty arrays (e.g. cursor/opencode `toolFileEvidence: []`, claude `syntheticSkillInvocations: []` with the relateInvocations rationale) and `buildNormalizedTranscriptStatements` drops every `?? []` fallback.
6. **CONTEXT.md**: Parser Toolkit added to the Language section.

## Behavior-preservation verification

- **Golden parity suites green unchanged**: `codex.parity.test.ts`, `pi.parity.test.ts`, `cursor.parity.test.ts`, `transcripts.parity.test.ts` (byte-level statement assertions per ADR-0012's delta-ledger contract), plus `codex-stream-batches`, `transcript-stream-parity`, and all per-parser extraction tests.
- **Repo-wide**: `bun test` → 3870 pass / 0 fail (402 files); `bun run typecheck` → clean; `check:no-node-fs` → clean.
- Only test edits: `normalized/transcripts.test.ts` fixtures spread a shared `emptyBatch` for the now-required fields (assertions untouched), and one `provider-parity.ts` writer-evidence path follows the moved `session_token_usage` statement into `token-usage-writers.ts`.
- New unit tests cover the toolkit probes/decoders, the tool-call write builder, and both token-usage statement shapes (25 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)