### PR TITLE
feat(site): four new showcases - dispatch routing, quota, improve loop, churn

### DIFF
--- a/apps/site/app/components/showcases/churn.tsx
+++ b/apps/site/app/components/showcases/churn.tsx
@@ -1,0 +1,226 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+const SOURCES = [
+  {
+    name: "codex",
+    sess: 57,
+    fails: 467,
+    episodes: 23,
+    pass: 22,
+    landed: "+330,730/-150,779",
+    edits: "+286/-142",
+    repair: "+58/-25",
+    // composition of added LOC
+    landedPct: 99.6,
+    editPct: 0.25,
+    repairPct: 0.15,
+    repairLabel: "<0.1%",
+  },
+  {
+    name: "claude-subagent",
+    sess: 71,
+    fails: 95,
+    episodes: 29,
+    pass: 13,
+    landed: "+23,979/-4,157",
+    edits: "+13,508/-2,199",
+    repair: "+981/-274",
+    landedPct: 62.3,
+    editPct: 35.1,
+    repairPct: 2.6,
+    repairLabel: "2.6%",
+  },
+  {
+    name: "claude",
+    sess: 14,
+    fails: 17,
+    episodes: 17,
+    pass: 3,
+    landed: "+117,641/-32,784",
+    edits: "+36,455/-9,172",
+    repair: "+3,867/-1,550",
+    landedPct: 74.5,
+    editPct: 23.1,
+    repairPct: 2.4,
+    repairLabel: "2.4%",
+  },
+];
+
+export function ChurnShowcase() {
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    if (reduce) return;
+
+    const bars = Array.from(root.querySelectorAll<HTMLElement>(".comp-bar > span"));
+    const original: Array<{ el: HTMLElement; width: string }> = [];
+    bars.forEach((b) => {
+      original.push({ el: b, width: b.style.width });
+      b.style.width = "0%";
+    });
+
+    const raf = requestAnimationFrame(() => {
+      original.forEach(({ el, width }) => {
+        el.style.transition = "width 700ms cubic-bezier(.2,.7,.2,1)";
+        el.style.width = width;
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return (
+    <section
+      id="churn"
+      className="showcase-churn"
+      ref={rootRef}
+      aria-label="Verification churn showcase"
+    >
+      <p className="eyebrow">who's thrashing · churn</p>
+      <h2>
+        Landed, edited, <em>repaired</em> - by source.
+      </h2>
+      <p className="lede">
+        Lines of code is a vanity metric until you split it.{" "}
+        <span className="cmd">ax sessions churn --here</span> classifies 30 days of writes
+        into landed vs edit vs repair LOC per provider, counts failed checks, and groups the
+        failures into episodes - so "which sessions thrash" has a number.
+      </p>
+
+      {/* ============ COMPOSITION BARS ============ */}
+      <div className="section-head">
+        <h3>Composition of added LOC · 30d</h3>
+        <div className="meta">~/Projects/ax · claude / claude-subagent / codex</div>
+      </div>
+
+      <section className="comp" aria-label="LOC composition by source">
+        {SOURCES.map((s) => (
+          <div className="comp-row" key={s.name}>
+            <span className="name">{s.name}</span>
+            <span className="comp-bar" aria-hidden="true">
+              <span className="landed" style={{ width: `${s.landedPct}%` }} />
+              <span className="edit" style={{ width: `${s.editPct}%` }} />
+              <span className="repair" style={{ width: `${s.repairPct}%` }} />
+            </span>
+            <span className="repair-share">repair {s.repairLabel}</span>
+          </div>
+        ))}
+        <div className="comp-key">
+          <span>
+            <span className="sw landed" /> landed · survived as written
+          </span>
+          <span>
+            <span className="sw edit" /> edit · reworked later
+          </span>
+          <span>
+            <span className="sw repair" /> repair · fixing a failed check
+          </span>
+        </div>
+        <p className="comp-note">
+          The repair sliver is the point - <strong>a tiny repair share means checks catch
+          problems before they ship</strong>. The edit band is where the real rework hides:
+          claude-subagent reworks a third of everything it writes.
+        </p>
+      </section>
+
+      {/* ============ THE TABLE ============ */}
+      <div className="ledger" role="table" aria-label="churn by source">
+        <div className="row head" role="row">
+          <span>source</span>
+          <span className="num">sess</span>
+          <span className="num">fails</span>
+          <span className="num">episodes</span>
+          <span className="num">pass</span>
+          <span className="num">landed</span>
+          <span className="num">edits</span>
+          <span className="num">repair</span>
+        </div>
+        {SOURCES.map((s) => (
+          <div className="row" role="row" key={s.name}>
+            <span className="src">{s.name}</span>
+            <span className="num">{s.sess}</span>
+            <span className="num fails">{s.fails}</span>
+            <span className="num">{s.episodes}</span>
+            <span className="num pass">{s.pass}</span>
+            <span className="num">{s.landed}</span>
+            <span className="num">{s.edits}</span>
+            <span className="num repair">{s.repair}</span>
+          </div>
+        ))}
+        <div className="ledger-foot">
+          ax sessions churn --here · 30d window · LOC shown as +added/-removed
+        </div>
+      </div>
+
+      {/* ============ EPISODE DIAGRAM ============ */}
+      <div className="section-head">
+        <h3>What an episode is</h3>
+        <div className="meta">failure opens · same-family pass closes · 30min expiry</div>
+      </div>
+
+      <section className="episode" aria-label="episode lifecycle">
+        <span className="ep-node open">
+          <b>✗</b>
+          <span className="ep-label">check fails</span>
+          <span className="ep-sub">episode opens</span>
+        </span>
+        <span className="ep-track" aria-hidden="true" />
+        <span className="ep-node more">
+          <b>✗ ✗</b>
+          <span className="ep-label">same-family failures</span>
+          <span className="ep-sub">join the open episode</span>
+        </span>
+        <span className="ep-track" aria-hidden="true" />
+        <span className="ep-node close">
+          <b>✓</b>
+          <span className="ep-label">same-family pass</span>
+          <span className="ep-sub">episode closes</span>
+        </span>
+        <span className="ep-track dashed" aria-hidden="true" />
+        <span className="ep-node expire">
+          <b>⏱</b>
+          <span className="ep-label">30 min silence</span>
+          <span className="ep-sub">episode expires</span>
+        </span>
+      </section>
+
+      {/* ============ INSIGHT ============ */}
+      <section className="insight">
+        <div className="ratio-num">
+          467<span className="x">✗</span>
+        </div>
+        <div className="body">
+          <strong>codex failed 467 checks in 30 days</strong> - 8.2 per session - and still
+          landed 330k LOC with under 0.1% repair share. The failures cluster into just 23
+          episodes: it thrashes in short windows against the test suite, then lands clean.
+          <span className="src">
+            claude-subagent is the opposite shape · 1.3 fails/session, 35% edit share
+          </span>
+        </div>
+      </section>
+
+      {/* ============ CAPTION ============ */}
+      <section className="caption">
+        <div className="col">
+          <div className="h">where the numbers come from</div>
+          Every <code>tool_call</code> that runs a check (tests, typecheck, lint, build) is
+          classified pass/fail by family. LOC written after a failure, touching the same
+          files, counts as repair; later rework of landed lines counts as edit.
+        </div>
+        <div className="col">
+          <div className="h">runs on your machine</div>
+          Same local graph as everything else - scope with <code>--here</code>, a specific{" "}
+          <code>--project</code>, or one <code>--source</code>. 30d window by default,{" "}
+          <code>--since=N</code> to change it.
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/apps/site/app/components/showcases/dispatch-routing.tsx
+++ b/apps/site/app/components/showcases/dispatch-routing.tsx
@@ -1,0 +1,237 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { Link } from "@tanstack/react-router";
+
+const ROWS = [
+  {
+    ts: "06-10 13:30",
+    type: "general-purpose",
+    desc: "Implement Task 3: session map strip",
+    suggest: "claude-sonnet-4-6",
+    child: "$50.26",
+    save: "$35.18",
+    pct: 100,
+  },
+  {
+    ts: "06-11 07:41",
+    type: "general-purpose",
+    desc: "Fix ingest run lifecycle",
+    suggest: "claude-sonnet-4-6",
+    child: "$30.98",
+    save: "$21.69",
+    pct: 62,
+  },
+  {
+    ts: "06-10 07:09",
+    type: "general-purpose",
+    desc: "Add deep span instrumentation",
+    suggest: "claude-sonnet-4-6",
+    child: "$26.41",
+    save: "$18.49",
+    pct: 53,
+  },
+  {
+    ts: "06-10 15:32",
+    type: "general-purpose",
+    desc: "Implement P2-T16 skills",
+    suggest: "claude-sonnet-4-6",
+    child: "$16.29",
+    save: "$11.40",
+    pct: 32,
+  },
+  {
+    ts: "06-11 07:42",
+    type: "general-purpose",
+    desc: "Sweep stale 8520 port refs",
+    suggest: "claude-haiku-4-5",
+    child: "$8.56",
+    save: "$7.70",
+    pct: 22,
+  },
+  {
+    ts: "06-12 06:44",
+    type: "codebase-analyzer",
+    desc: "Extract contracts for plan",
+    suggest: "claude-sonnet-4-6",
+    child: "$6.75",
+    save: "$4.73",
+    pct: 13,
+  },
+];
+
+export function DispatchRoutingShowcase() {
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    if (reduce) return;
+
+    const bars = Array.from(root.querySelectorAll<HTMLElement>(".save-bar > div"));
+    const original: Array<{ el: HTMLElement; width: string }> = [];
+    bars.forEach((b) => {
+      original.push({ el: b, width: b.style.width });
+      b.style.width = "0%";
+    });
+
+    const raf = requestAnimationFrame(() => {
+      original.forEach(({ el, width }) => {
+        el.style.transition = "width 700ms cubic-bezier(.2,.7,.2,1)";
+        el.style.width = width;
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return (
+    <section
+      id="dispatch-routing"
+      className="showcase-dispatch-routing"
+      ref={rootRef}
+      aria-label="Dispatch routing showcase"
+    >
+      <p className="eyebrow">route the intern work · dispatches</p>
+      <h2>
+        Stop paying frontier rates for <em>mechanical</em> dispatches.
+      </h2>
+      <p className="lede">
+        Every sub-task your agent spawns inherits your most expensive model unless something
+        says otherwise. <span className="cmd">ax dispatches --candidates</span> finds the
+        dispatches that ran on fable or opus but matched a mechanical routing class - and
+        reprices each one against the cheaper model, from the tokens it actually burned.
+      </p>
+
+      {/* ============ HERO STATS ============ */}
+      <section className="stats" aria-label="hero stats">
+        <div className="stat" data-kind="receipt">
+          <div className="label">biggest single receipt</div>
+          <div className="big">
+            $35<span className="unit">.18</span>
+          </div>
+          <div className="delta">one dispatch · $50.26 on inherit → sonnet</div>
+          <div className="submeta">"Implement Task 3: session map strip"</div>
+        </div>
+
+        <div className="stat" data-kind="redirect">
+          <div className="label">redirectable · last 2d</div>
+          <div className="big">
+            $209<span className="unit">.59</span>
+          </div>
+          <div className="delta">39 model-less dispatches on fable/opus</div>
+          <div className="submeta">matched mechanical routing classes</div>
+        </div>
+
+        <div className="stat" data-kind="harness">
+          <div className="label">where the fix fires</div>
+          <div className="big">
+            2<span className="unit">harnesses</span>
+          </div>
+          <div className="delta">route-dispatch hook · at dispatch time</div>
+          <div className="submeta">claude code + codex</div>
+        </div>
+      </section>
+
+      {/* ============ LEDGER ============ */}
+      <div className="section-head">
+        <h3>Top candidates, repriced</h3>
+        <div className="meta">ax dispatches --candidates --days=14</div>
+      </div>
+
+      <div className="ledger" role="table" aria-label="candidate dispatches">
+        <div className="row head" role="row">
+          <span>ts</span>
+          <span>agent_type</span>
+          <span>description</span>
+          <span>suggest</span>
+          <span className="num">child cost</span>
+          <span className="num">est savings</span>
+          <span aria-hidden="true" />
+        </div>
+        {ROWS.map((r) => (
+          <div className="row" role="row" key={r.ts + r.desc}>
+            <span className="ts">{r.ts}</span>
+            <span className="type">{r.type}</span>
+            <span className="desc">{r.desc}</span>
+            <span className="suggest">{r.suggest}</span>
+            <span className="num child">{r.child}</span>
+            <span className="num save">{r.save}</span>
+            <span className="save-bar" aria-hidden="true">
+              <div style={{ width: `${r.pct}%` }} />
+            </span>
+          </div>
+        ))}
+        <div className="ledger-foot">
+          top 6 of dozens of candidates in 14d · <b>$99.29</b> est. savings on these rows
+          alone · "inherit" means no model was specified, so the dispatch rode the expensive
+          default
+        </div>
+      </div>
+
+      {/* ============ PIPELINE ============ */}
+      <section className="pipe" aria-label="routing pipeline">
+        <div className="step">
+          <div className="step-head">
+            <span className="n">01</span>
+            <span className="verb">find</span>
+          </div>
+          <code>ax dispatches --candidates</code>
+          <p>
+            Inherited an expensive model + matched a mechanical class. Each row carries a
+            suggested model and the dollars it would have saved.
+          </p>
+        </div>
+        <div className="step">
+          <div className="step-head">
+            <span className="n">02</span>
+            <span className="verb">compile</span>
+          </div>
+          <code>ax routing compile</code>
+          <p>
+            Writes the class table to <code className="inline">~/.ax/hooks/routing-table.json</code> -
+            merge-preserving, your own classes survive a regenerate.
+          </p>
+        </div>
+        <div className="step">
+          <div className="step-head">
+            <span className="n">03</span>
+            <span className="verb">fire</span>
+          </div>
+          <code>route-dispatch hook</code>
+          <p>
+            Suggests the cheaper model at dispatch time, in Claude Code <em>and</em> Codex.
+            The next "Fix ingest run lifecycle" rides sonnet, not fable.
+          </p>
+        </div>
+      </section>
+
+      <p className="tune-note">
+        <span className="tag">tune</span> <code>ax routing tune</code> mines the unmatched
+        expensive dispatches into new classes - two-token prefix clustering, ≥3 members.
+        Mechanical classes auto-apply; judgment-flagged ones (review / design / plan / audit)
+        only ship via an emitted brief and an agent backtest.
+      </p>
+
+      {/* ============ CAPTION ============ */}
+      <section className="caption">
+        <div className="col">
+          <div className="h">where the numbers come from</div>
+          Every dispatch row joins the parent <code>tool_call</code> to the child session it
+          spawned. Savings are repriced from the tokens the child actually burned - not a
+          projection, a receipt.
+        </div>
+        <div className="col">
+          <div className="h">there's a whole page on this</div>
+          The leak, the loop, and 30 days of verbatim receipts from one machine:{" "}
+          <Link to="/routing" className="more">
+            ax · routing →
+          </Link>
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/apps/site/app/components/showcases/improve-loop.tsx
+++ b/apps/site/app/components/showcases/improve-loop.tsx
@@ -1,0 +1,191 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+const PROPOSALS = [
+  {
+    score: "16.03",
+    pct: 92,
+    kind: "skill",
+    id: "skill__508c34566d2f1d85",
+    rate: "26/wk",
+    title: "Post-feature verification checklist",
+    evidence: "Feature closure needs stronger same-file follow-up verification.",
+  },
+  {
+    score: "11.93",
+    pct: 68,
+    kind: "skill",
+    id: "skill__53cc564505d4c1f9",
+    rate: "8/wk",
+    title: "Graph query dogfood checklist",
+    evidence:
+      "Query builders can pass string tests while returning slow or low-signal output.",
+  },
+  {
+    score: "8.90",
+    pct: 51,
+    kind: "skill",
+    id: "skill__292666ce747117ee",
+    rate: "3/wk",
+    title: "SurrealDB schema change guardrail",
+    evidence: "Schema changes need a tighter migration/apply/query verification loop.",
+  },
+];
+
+export function ImproveLoopShowcase() {
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    if (reduce) return;
+
+    const bars = Array.from(root.querySelectorAll<HTMLElement>(".score-bar > div"));
+    const original: Array<{ el: HTMLElement; width: string }> = [];
+    bars.forEach((b) => {
+      original.push({ el: b, width: b.style.width });
+      b.style.width = "0%";
+    });
+
+    const raf = requestAnimationFrame(() => {
+      original.forEach(({ el, width }) => {
+        el.style.transition = "width 700ms cubic-bezier(.2,.7,.2,1)";
+        el.style.width = width;
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return (
+    <section
+      id="improve-loop"
+      className="showcase-improve-loop"
+      ref={rootRef}
+      aria-label="Improve loop showcase"
+    >
+      <p className="eyebrow">the graph talks back · improve</p>
+      <h2>
+        Proposals mined from <em>your own</em> transcripts.
+      </h2>
+      <p className="lede">
+        <span className="cmd">ax improve recommend</span> scores improvement proposals out of
+        your transcript graph - each one with an evidence trail and a backtested projected
+        value. Accept one and it becomes a brief an agent acts on. Lint reconciles what
+        actually got applied. Verdicts confirm it or retire it.
+      </p>
+
+      {/* ============ TOP PROPOSAL ============ */}
+      <article className="top-proposal" aria-label="top proposal">
+        <header className="tp-head">
+          <span className="score">17.49</span>
+          <span className="kind is-hook">hook</span>
+          <span className="pid">hook__17b5aaf6aade53e5</span>
+          <span className="conf">high · 39/wk</span>
+          <span className="origin">origin: system</span>
+        </header>
+        <h4 className="tp-title">Route mechanical subagent dispatches to cheaper models</h4>
+        <p className="tp-evidence">
+          <span className="lk">evidence</span> 39 model-less dispatches on fable/opus matched
+          mechanical routing classes in the last 2d; est <b>$209.59</b> redirectable. Top
+          classes: well-specified-impl ($95.27), bug-fix ($44.59), spec-review ($32.57).
+        </p>
+        <p className="tp-apply">
+          <span className="lk">apply</span>{" "}
+          <code>axctl improve accept hook__17b5aaf6aade53e5</code>
+        </p>
+      </article>
+
+      {/* ============ REST OF THE LIST ============ */}
+      <div className="proposals" role="list">
+        {PROPOSALS.map((p) => (
+          <div className="proposal" role="listitem" key={p.id}>
+            <span className="score">{p.score}</span>
+            <span className="score-bar" aria-hidden="true">
+              <div style={{ width: `${p.pct}%` }} />
+            </span>
+            <span className={`kind is-${p.kind}`}>{p.kind}</span>
+            <span className="title">{p.title}</span>
+            <span className="rate">high · {p.rate}</span>
+            <span className="evidence">{p.evidence}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* ============ THE LOOP ============ */}
+      <div className="section-head">
+        <h3>Accept is not the end - it's the experiment</h3>
+        <div className="meta">recommend → accept → apply → lint → verdict</div>
+      </div>
+
+      <section className="loop" aria-label="improve loop">
+        <span className="node">
+          <code>recommend</code>
+          <em>scored, with evidence</em>
+        </span>
+        <span className="arrow" aria-hidden="true">→</span>
+        <span className="node">
+          <code>accept</code>
+          <em>.ax/tasks/&lt;id&gt;.md brief</em>
+        </span>
+        <span className="arrow" aria-hidden="true">→</span>
+        <span className="node">
+          <code>agent applies</code>
+          <em>like any task file</em>
+        </span>
+        <span className="arrow" aria-hidden="true">→</span>
+        <span className="node">
+          <code>lint</code>
+          <em>reconciles guidance</em>
+        </span>
+        <span className="arrow" aria-hidden="true">→</span>
+        <span className="node">
+          <code>verdict</code>
+          <em>confirms or retires</em>
+        </span>
+      </section>
+
+      <p className="loop-note">
+        Agents write back too - <code>ax improve propose</code> /{" "}
+        <code>ax improve analyze</code> let a session file its own proposal mid-run; origin
+        badges keep agent-derived and system-derived suggestions distinguishable.
+      </p>
+
+      {/* ============ META RECEIPT ============ */}
+      <section className="insight">
+        <div className="ratio-num">
+          #1<span className="x">↑</span>
+        </div>
+        <div className="body">
+          <strong>The top proposal above is the first showcase on this page.</strong> The
+          graph mined "route mechanical dispatches to cheaper models" out of its own
+          transcripts - $209.59 redirectable in two days - before it existed as a feature.
+          We accepted the brief; it shipped as <a href="#dispatch-routing">dispatch routing</a>.
+          <span className="src">
+            the loop eating its own output · run <code>ax improve recommend</code> for yours
+          </span>
+        </div>
+      </section>
+
+      {/* ============ CAPTION ============ */}
+      <section className="caption">
+        <div className="col">
+          <div className="h">where the numbers come from</div>
+          Scores blend frequency, severity, and the impact engine's backtested projected
+          value - what the proposal would have saved or caught over your actual recent
+          history, not a hypothetical.
+        </div>
+        <div className="col">
+          <div className="h">runs on your machine</div>
+          Mined from the local graph, applied to your own agent files. Nothing auto-edits:
+          accept emits a brief, an agent does the work, <code>ax improve lint</code> checks
+          it landed.
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/apps/site/app/components/showcases/quota.tsx
+++ b/apps/site/app/components/showcases/quota.tsx
@@ -1,0 +1,162 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+const WINDOWS = [
+  { name: "5h", used: 64, resets: "04:29", tone: "warm" },
+  { name: "7d", used: 63, resets: "04:59", tone: "warm" },
+  { name: "7d sonnet", used: 5, resets: "04:59", tone: "ok" },
+] as const;
+
+export function QuotaShowcase() {
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    if (reduce) return;
+
+    const bars = Array.from(root.querySelectorAll<HTMLElement>(".meter .fill"));
+    const original: Array<{ el: HTMLElement; width: string }> = [];
+    bars.forEach((b) => {
+      original.push({ el: b, width: b.style.width });
+      b.style.width = "0%";
+    });
+
+    const raf = requestAnimationFrame(() => {
+      original.forEach(({ el, width }) => {
+        el.style.transition = "width 700ms cubic-bezier(.2,.7,.2,1)";
+        el.style.width = width;
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return (
+    <section
+      id="quota"
+      className="showcase-quota"
+      ref={rootRef}
+      aria-label="Plan quota showcase"
+    >
+      <p className="eyebrow">know the envelope · quota</p>
+      <h2>
+        Your plan limits, <em>live</em>, everywhere you look.
+      </h2>
+      <p className="lede">
+        Claude tells you about your usage limit when you hit it.{" "}
+        <span className="cmd">ax quota</span> reads the same usage endpoint the Claude app
+        does - your 5-hour and 7-day rolling windows, live, with the OAuth token you already
+        have. No new login, no DB, nothing leaves your machine but the one call Claude
+        already makes.
+      </p>
+
+      {/* ============ METERS ============ */}
+      <section className="meters" aria-label="plan usage windows">
+        {WINDOWS.map((w) => (
+          <div className="meter-row" key={w.name}>
+            <span className="name">{w.name}</span>
+            <span className="meter" data-tone={w.tone}>
+              <span className="fill" style={{ width: `${w.used}%` }} />
+            </span>
+            <span className="used">{w.used}%</span>
+            <span className="resets">resets {w.resets}</span>
+          </div>
+        ))}
+        <div className="meter-row extra">
+          <span className="name">extra</span>
+          <span className="off">off · no overage billing past the windows</span>
+        </div>
+      </section>
+
+      {/* ============ SURFACES ============ */}
+      <div className="section-head">
+        <h3>One cached read, three surfaces</h3>
+        <div className="meta">~/.ax/quota-cache.json · 60s ttl</div>
+      </div>
+
+      <section className="surfaces">
+        {/* CLI */}
+        <article className="surface">
+          <header className="surface-head">
+            <span className="where">terminal</span>
+            <code>ax quota</code>
+          </header>
+          <pre className="term" aria-label="ax quota output">
+            <span className="t-prompt">~ $</span> <span className="t-cmd">ax quota</span>
+            {"\n\n"}
+            <span className="t-muted">window       used  resets</span>
+            {"\n"}
+            {"5h            "}
+            <span className="t-warm">64%</span>
+            {"  04:29\n"}
+            {"7d            "}
+            <span className="t-warm">63%</span>
+            {"  04:59\n"}
+            {"7d sonnet      "}
+            <span className="t-ok">5%</span>
+            {"  04:59\n"}
+            {"extra         "}
+            <span className="t-muted">off</span>
+            {"\n\n"}
+            <span className="t-muted">(fetched 0s ago, live)</span>
+          </pre>
+        </article>
+
+        {/* statusline */}
+        <article className="surface">
+          <header className="surface-head">
+            <span className="where">claude code statusline</span>
+            <code>ax quota --statusline</code>
+          </header>
+          <div className="statusline" aria-label="statusline mock">
+            <span className="sl-left">~/Projects/ax · sonnet-4-6</span>
+            <span className="sl-right">5h 64% → 04:29 · 7d 63%</span>
+          </div>
+          <p className="surface-note">
+            One plain line for the <code className="inline">statusLine</code> command. Poll
+            every render - it's the cache answering, not the API.
+          </p>
+        </article>
+
+        {/* menubar */}
+        <article className="surface">
+          <header className="surface-head">
+            <span className="where">macOS menubar</span>
+            <code>ax quota --swiftbar</code>
+          </header>
+          <div className="menubar" aria-label="menubar mock">
+            <span className="mb-item ax">◕ 64%</span>
+            <span className="mb-item dim">⌥</span>
+            <span className="mb-item dim">⚙</span>
+            <span className="mb-item">Fri 09:41</span>
+          </div>
+          <p className="surface-note">
+            A SwiftBar/xbar plugin body - the burn rate lives next to the clock. Fetch
+            failures degrade to the stale cache, never a crash in the menubar.
+          </p>
+        </article>
+      </section>
+
+      {/* ============ CAPTION ============ */}
+      <section className="caption">
+        <div className="col">
+          <div className="h">where the numbers come from</div>
+          The same <code>api.anthropic.com/api/oauth/usage</code> endpoint the Claude app
+          polls, read with your existing Claude Code OAuth token - macOS Keychain first,{" "}
+          <code>~/.claude/.credentials.json</code> fallback. ax never refreshes the token.
+        </div>
+        <div className="col">
+          <div className="h">runs on your machine</div>
+          No SurrealDB involved at all - this is the one ax command with zero graph. Responses
+          cache at <code>~/.ax/quota-cache.json</code> (60s TTL) so statusline and menubar can
+          poll freely without hammering the endpoint.
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/apps/site/app/components/showcases/recall.tsx
+++ b/apps/site/app/components/showcases/recall.tsx
@@ -89,26 +89,6 @@ export function RecallShowcase() {
         <span className="caret" />
       </div>
 
-      {/* search widget */}
-      <div className="search" role="search">
-        <span className="glyph" aria-hidden="true">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="11" cy="11" r="7" />
-            <line x1="20" y1="20" x2="16.5" y2="16.5" />
-          </svg>
-        </span>
-        <input
-          id="q"
-          type="text"
-          defaultValue="auth middleware oauth refresh token"
-          spellCheck={false}
-          autoComplete="off"
-        />
-        <span className="kbd">
-          <span>search</span> <b>⏎</b>
-        </span>
-      </div>
-
       <div className="meta-row">
         <div className="scope">
           <span className="chip">14,832 turns</span>

--- a/apps/site/app/components/showcases/verdict-timeline.tsx
+++ b/apps/site/app/components/showcases/verdict-timeline.tsx
@@ -495,7 +495,9 @@ export function VerdictTimelineShowcase() {
           checkpoint joins evidence from the same graph that generated the proposal.
           Sessions, not days &mdash; a weekend doesn&apos;t artificially delay; a
           productive afternoon doesn&apos;t artificially rush. The verdict at +30
-          sessions is locked and feeds the next round.
+          sessions is locked and feeds the next round. Verdicts live in the improve
+          queue &mdash; <code>ax improve verdict</code> confirms or overrides one from
+          the CLI.
         </p>
       </figure>
 

--- a/apps/site/app/routes/showcases.tsx
+++ b/apps/site/app/routes/showcases.tsx
@@ -5,6 +5,10 @@ import { HookBacktestShowcase } from "~/components/showcases/hook-backtest";
 import { RecallShowcase } from "~/components/showcases/recall";
 import { TokenEconomyShowcase } from "~/components/showcases/token-economy";
 import { VerdictTimelineShowcase } from "~/components/showcases/verdict-timeline";
+import { DispatchRoutingShowcase } from "~/components/showcases/dispatch-routing";
+import { QuotaShowcase } from "~/components/showcases/quota";
+import { ImproveLoopShowcase } from "~/components/showcases/improve-loop";
+import { ChurnShowcase } from "~/components/showcases/churn";
 
 export const Route = createFileRoute("/showcases")({
   component: Showcases,
@@ -18,19 +22,26 @@ function Showcases() {
         <section className="showcases-intro">
           <p className="eyebrow">what ax actually does</p>
           <h1>
-            Four scenarios, <em>one graph</em>.
+            Eight scenarios, <em>one graph</em>.
           </h1>
           <p className="lede">
             Concrete demos of what your local ax instance already exposes -
             backtest a hook against history, search every session you've ever
             had, see where your tokens go, watch a verdict earn its place at
-            +30 sessions. Each one is something you can run today.
+            +30 sessions, route the intern work to cheaper models, keep your
+            plan budget in view, take proposals mined from your own
+            transcripts, and find out which sessions thrash. Each one is
+            something you can run today.
           </p>
           <nav className="showcases-nav" aria-label="showcase jump links">
             <a href="#hook-backtest">hook backtest</a>
             <a href="#recall">recall</a>
             <a href="#token-economy">token economy</a>
             <a href="#verdict-timeline">verdict timeline</a>
+            <a href="#dispatch-routing">dispatch routing</a>
+            <a href="#quota">quota</a>
+            <a href="#improve-loop">improve loop</a>
+            <a href="#churn">churn</a>
           </nav>
         </section>
 
@@ -38,6 +49,10 @@ function Showcases() {
         <RecallShowcase />
         <TokenEconomyShowcase />
         <VerdictTimelineShowcase />
+        <DispatchRoutingShowcase />
+        <QuotaShowcase />
+        <ImproveLoopShowcase />
+        <ChurnShowcase />
       </main>
       <SiteFooter />
     </>

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -4839,62 +4839,6 @@ footer .right {
   50% { opacity: 0; }
 }
 
-/* search panel */
-.showcase-recall .search {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 18px 20px;
-  display: grid;
-  grid-template-columns: 24px 1fr auto;
-  align-items: center;
-  gap: 14px;
-  box-shadow: 0 1px 0 #ece9df, 0 24px 60px -40px rgba(20, 20, 15, 0.25);
-  margin: 0 0 14px;
-  position: relative;
-}
-.showcase-recall .search:focus-within {
-  border-color: var(--ink);
-}
-.showcase-recall .search .glyph {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--muted);
-}
-.showcase-recall .search input {
-  appearance: none;
-  border: 0;
-  background: transparent;
-  font-family: var(--serif);
-  font-size: 22px;
-  color: var(--ink);
-  outline: none;
-  width: 100%;
-  padding: 4px 0;
-  letter-spacing: -0.2px;
-}
-.showcase-recall .search input::placeholder { color: #b3b1a8; }
-.showcase-recall .search .kbd {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  font-family: var(--mono);
-  font-size: 10.5px;
-  color: var(--muted);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-.showcase-recall .search .kbd b {
-  font-weight: 500;
-  background: #efece1;
-  border: 1px solid var(--line);
-  border-bottom-width: 2px;
-  padding: 2px 7px;
-  border-radius: 4px;
-  color: var(--ink);
-}
-
 .showcase-recall .meta-row {
   display: flex;
   justify-content: space-between;
@@ -5097,8 +5041,6 @@ footer .right {
 @media (max-width: 720px) {
   .showcase-recall h2 { font-size: 32px; }
   .showcase-recall .lede { font-size: 17px; }
-  .showcase-recall .search input { font-size: 18px; }
-  .showcase-recall .search { padding: 14px 16px; }
   .showcase-recall .result { grid-template-columns: 1fr; gap: 8px; }
   .showcase-recall .rank { padding-top: 0; }
   .showcase-recall .caption { grid-template-columns: 1fr; gap: 10px; }

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -6364,6 +6364,1254 @@ footer .right {
   .showcase-token-economy h2 { font-size: 32px; }
 }
 
+/* ----- showcase 5: dispatch routing ----- */
+.showcase-dispatch-routing {
+  --dr-soft: #ece9df;
+  --dr-soft-2: #ebe9e0;
+  --dr-amber: #b8860b;
+
+  display: block;
+  max-width: none;
+  margin: 0;
+  padding: 64px 0 96px;
+  background: var(--page);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+.showcase-dispatch-routing * { box-sizing: border-box; }
+
+.showcase-dispatch-routing .eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin: 0 0 14px;
+}
+.showcase-dispatch-routing h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 40px;
+  line-height: 1.1;
+  letter-spacing: -0.6px;
+  margin: 0 0 18px;
+}
+.showcase-dispatch-routing h2 em {
+  font-style: italic;
+  color: var(--muted);
+}
+.showcase-dispatch-routing p.lede {
+  margin: 0 0 36px;
+  font-size: 19px;
+  line-height: 1.5;
+  max-width: 62ch;
+  color: #2c2c28;
+}
+.showcase-dispatch-routing p.lede .cmd {
+  font-family: var(--mono);
+  font-size: 14px;
+  padding: 1px 6px;
+  background: var(--dr-soft-2);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+/* hero stats */
+.showcase-dispatch-routing .stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  margin-bottom: 56px;
+}
+.showcase-dispatch-routing .stat {
+  padding: 24px 24px 22px;
+  border-right: 1px solid var(--line);
+}
+.showcase-dispatch-routing .stat:last-child { border-right: none; }
+.showcase-dispatch-routing .stat .label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 14px;
+}
+.showcase-dispatch-routing .stat .big {
+  font-family: var(--mono);
+  font-size: 44px;
+  letter-spacing: -1px;
+  line-height: 1;
+  font-weight: 500;
+}
+.showcase-dispatch-routing .stat .big .unit {
+  font-size: 14px;
+  color: var(--muted);
+  letter-spacing: 0;
+  margin-left: 4px;
+  font-weight: 400;
+}
+.showcase-dispatch-routing .stat .delta {
+  font-family: var(--mono);
+  font-size: 12px;
+  margin-top: 12px;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+.showcase-dispatch-routing .stat .submeta {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--muted);
+  margin-top: 4px;
+  letter-spacing: 0.01em;
+}
+.showcase-dispatch-routing .stat[data-kind="receipt"]  .big { color: var(--green); }
+.showcase-dispatch-routing .stat[data-kind="redirect"] .big { color: var(--red); }
+.showcase-dispatch-routing .stat[data-kind="harness"]  .big { color: var(--ink); }
+
+/* section head */
+.showcase-dispatch-routing .section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0 0 18px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 10px;
+}
+.showcase-dispatch-routing .section-head h3 {
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 400;
+  margin: 0;
+  letter-spacing: -0.2px;
+}
+.showcase-dispatch-routing .section-head .meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+/* ledger */
+.showcase-dispatch-routing .ledger {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 6px 0 0;
+  margin-bottom: 48px;
+  overflow-x: auto;
+}
+.showcase-dispatch-routing .ledger .row {
+  display: grid;
+  grid-template-columns: 90px 140px minmax(220px, 1fr) 150px 80px 84px 96px;
+  gap: 12px;
+  align-items: center;
+  padding: 9px 16px;
+  font-family: var(--mono);
+  font-size: 12px;
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 55%, transparent);
+}
+.showcase-dispatch-routing .ledger .row.head {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+}
+.showcase-dispatch-routing .ledger .row .num { text-align: right; }
+.showcase-dispatch-routing .ledger .row .ts { color: var(--muted); }
+.showcase-dispatch-routing .ledger .row .type { color: var(--muted); }
+.showcase-dispatch-routing .ledger .row .desc { color: var(--ink); }
+.showcase-dispatch-routing .ledger .row .suggest { color: var(--blue); }
+.showcase-dispatch-routing .ledger .row .child { color: var(--red); }
+.showcase-dispatch-routing .ledger .row .save {
+  color: var(--green);
+  font-weight: 600;
+}
+.showcase-dispatch-routing .ledger .save-bar {
+  height: 6px;
+  background: var(--dr-soft);
+  border-radius: 1px;
+  overflow: hidden;
+  display: block;
+}
+.showcase-dispatch-routing .ledger .save-bar > div {
+  height: 100%;
+  background: var(--green);
+  opacity: 0.85;
+  border-radius: 1px;
+}
+.showcase-dispatch-routing .ledger-foot {
+  padding: 10px 16px 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+.showcase-dispatch-routing .ledger-foot b {
+  color: var(--green);
+  font-weight: 600;
+}
+
+/* pipeline */
+.showcase-dispatch-routing .pipe {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  margin-bottom: 22px;
+}
+.showcase-dispatch-routing .pipe .step {
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--panel);
+  padding: 16px 18px 14px;
+}
+.showcase-dispatch-routing .pipe .step-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.showcase-dispatch-routing .pipe .step-head .n {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+.showcase-dispatch-routing .pipe .step-head .verb {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink);
+}
+.showcase-dispatch-routing .pipe .step > code {
+  display: block;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--blue);
+  margin-bottom: 8px;
+}
+.showcase-dispatch-routing .pipe .step p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+.showcase-dispatch-routing .pipe .step p em { color: var(--ink); font-style: italic; }
+.showcase-dispatch-routing .pipe code.inline,
+.showcase-dispatch-routing .tune-note code,
+.showcase-dispatch-routing .caption code {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--dr-soft-2);
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--line);
+}
+.showcase-dispatch-routing .tune-note {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--muted);
+  max-width: 78ch;
+  margin: 0 0 56px;
+}
+.showcase-dispatch-routing .tune-note .tag {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink);
+  border: 1px solid var(--ink);
+  padding: 2px 8px;
+  border-radius: 999px;
+  margin-right: 8px;
+  vertical-align: 1px;
+}
+
+/* caption */
+.showcase-dispatch-routing .caption {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line);
+}
+.showcase-dispatch-routing .caption .col {
+  font-size: 14px;
+  line-height: 1.55;
+  color: #3a3a35;
+}
+.showcase-dispatch-routing .caption .col .h {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.showcase-dispatch-routing .caption .more {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--blue);
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--blue) 40%, transparent);
+}
+.showcase-dispatch-routing .caption .more:hover { border-bottom-color: var(--blue); }
+
+@media (max-width: 760px) {
+  .showcase-dispatch-routing { padding: 48px 20px 72px; }
+  .showcase-dispatch-routing h2 { font-size: 32px; }
+  .showcase-dispatch-routing .stats { grid-template-columns: 1fr; }
+  .showcase-dispatch-routing .stat { border-right: none; border-bottom: 1px solid var(--line); }
+  .showcase-dispatch-routing .stat:last-child { border-bottom: none; }
+  .showcase-dispatch-routing .pipe { grid-template-columns: 1fr; }
+  .showcase-dispatch-routing .caption { grid-template-columns: 1fr; }
+}
+
+/* ----- showcase 6: quota ----- */
+.showcase-quota {
+  --q-soft: #ece9df;
+  --q-soft-2: #ebe9e0;
+  --q-amber: #b8860b;
+  --q-term-bg: #14140f;
+  --q-term-fg: #e8e6dd;
+  --q-term-muted: #8a8780;
+  --q-term-warm: #e8c87a;
+  --q-term-ok: #6fcf80;
+
+  display: block;
+  max-width: none;
+  margin: 0;
+  padding: 64px 0 96px;
+  background: var(--page);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+.showcase-quota * { box-sizing: border-box; }
+
+.showcase-quota .eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin: 0 0 14px;
+}
+.showcase-quota h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 40px;
+  line-height: 1.1;
+  letter-spacing: -0.6px;
+  margin: 0 0 18px;
+}
+.showcase-quota h2 em { font-style: italic; color: var(--muted); }
+.showcase-quota p.lede {
+  margin: 0 0 36px;
+  font-size: 19px;
+  line-height: 1.5;
+  max-width: 62ch;
+  color: #2c2c28;
+}
+.showcase-quota p.lede .cmd {
+  font-family: var(--mono);
+  font-size: 14px;
+  padding: 1px 6px;
+  background: var(--q-soft-2);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+/* meters */
+.showcase-quota .meters {
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  padding: 22px 0 18px;
+  margin-bottom: 56px;
+}
+.showcase-quota .meter-row {
+  display: grid;
+  grid-template-columns: 110px 1fr 56px 120px;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+.showcase-quota .meter-row:last-child { margin-bottom: 0; }
+.showcase-quota .meter-row .name {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+.showcase-quota .meter {
+  display: block;
+  height: 10px;
+  background: var(--q-soft);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.showcase-quota .meter .fill {
+  display: block;
+  height: 100%;
+  border-radius: 1px;
+}
+.showcase-quota .meter[data-tone="warm"] .fill { background: var(--q-amber); opacity: 0.9; }
+.showcase-quota .meter[data-tone="ok"]   .fill { background: var(--green); opacity: 0.85; }
+.showcase-quota .meter-row .used {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 600;
+  text-align: right;
+}
+.showcase-quota .meter-row .resets {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+.showcase-quota .meter-row.extra { grid-template-columns: 110px 1fr; }
+.showcase-quota .meter-row.extra .off {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+
+/* section head */
+.showcase-quota .section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0 0 22px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 10px;
+}
+.showcase-quota .section-head h3 {
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 400;
+  margin: 0;
+  letter-spacing: -0.2px;
+}
+.showcase-quota .section-head .meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+/* surfaces */
+.showcase-quota .surfaces {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  margin-bottom: 56px;
+}
+.showcase-quota .surface {
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--panel);
+  padding: 14px 16px 14px;
+  display: flex;
+  flex-direction: column;
+}
+.showcase-quota .surface-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.showcase-quota .surface-head .where {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+}
+.showcase-quota .surface-head > code {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--blue);
+}
+.showcase-quota .term {
+  margin: 0;
+  background: var(--q-term-bg);
+  color: var(--q-term-fg);
+  border-radius: 3px;
+  padding: 14px 16px;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+.showcase-quota .term .t-prompt { color: var(--q-term-muted); }
+.showcase-quota .term .t-cmd { color: var(--q-term-fg); font-weight: 600; }
+.showcase-quota .term .t-muted { color: var(--q-term-muted); }
+.showcase-quota .term .t-warm { color: var(--q-term-warm); }
+.showcase-quota .term .t-ok { color: var(--q-term-ok); }
+.showcase-quota .statusline {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  background: var(--q-term-bg);
+  color: var(--q-term-muted);
+  border-radius: 3px;
+  padding: 8px 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.showcase-quota .statusline .sl-right { color: var(--q-term-warm); }
+.showcase-quota .menubar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 14px;
+  background: #e6e3d9;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink);
+}
+.showcase-quota .menubar .mb-item.ax {
+  font-weight: 600;
+  color: var(--q-amber);
+}
+.showcase-quota .menubar .mb-item.dim { color: var(--muted); }
+.showcase-quota .surface-note {
+  margin: 10px 0 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+.showcase-quota .surface-note code,
+.showcase-quota .caption code {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  background: var(--q-soft-2);
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--line);
+}
+
+/* caption */
+.showcase-quota .caption {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line);
+}
+.showcase-quota .caption .col {
+  font-size: 14px;
+  line-height: 1.55;
+  color: #3a3a35;
+}
+.showcase-quota .caption .col .h {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+
+@media (max-width: 760px) {
+  .showcase-quota { padding: 48px 20px 72px; }
+  .showcase-quota h2 { font-size: 32px; }
+  .showcase-quota .meter-row { grid-template-columns: 80px 1fr 48px; }
+  .showcase-quota .meter-row .resets { grid-column: 2 / span 2; margin-top: -8px; }
+  .showcase-quota .surfaces { grid-template-columns: 1fr; }
+  .showcase-quota .caption { grid-template-columns: 1fr; }
+}
+
+/* ----- showcase 7: improve loop ----- */
+.showcase-improve-loop {
+  --il-soft: #ece9df;
+  --il-soft-2: #ebe9e0;
+  --il-insight-bg: #eaf0e4;
+
+  display: block;
+  max-width: none;
+  margin: 0;
+  padding: 64px 0 96px;
+  background: var(--page);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+.showcase-improve-loop * { box-sizing: border-box; }
+
+.showcase-improve-loop .eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin: 0 0 14px;
+}
+.showcase-improve-loop h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 40px;
+  line-height: 1.1;
+  letter-spacing: -0.6px;
+  margin: 0 0 18px;
+}
+.showcase-improve-loop h2 em { font-style: italic; color: var(--muted); }
+.showcase-improve-loop p.lede {
+  margin: 0 0 36px;
+  font-size: 19px;
+  line-height: 1.5;
+  max-width: 62ch;
+  color: #2c2c28;
+}
+.showcase-improve-loop p.lede .cmd {
+  font-family: var(--mono);
+  font-size: 14px;
+  padding: 1px 6px;
+  background: var(--il-soft-2);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+/* top proposal */
+.showcase-improve-loop .top-proposal {
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--green);
+  border-radius: 3px;
+  background: var(--panel);
+  padding: 18px 22px 16px;
+  margin-bottom: 14px;
+}
+.showcase-improve-loop .tp-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+  font-family: var(--mono);
+}
+.showcase-improve-loop .tp-head .score {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--green);
+  letter-spacing: -0.5px;
+}
+.showcase-improve-loop .kind {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+.showcase-improve-loop .kind.is-hook {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+.showcase-improve-loop .tp-head .pid {
+  font-size: 11px;
+  color: var(--muted);
+}
+.showcase-improve-loop .tp-head .conf {
+  font-size: 11px;
+  color: var(--ink);
+}
+.showcase-improve-loop .tp-head .origin {
+  margin-left: auto;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  border: 1px dashed var(--line);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.showcase-improve-loop .tp-title {
+  font-family: var(--serif);
+  font-size: 21px;
+  font-weight: 400;
+  letter-spacing: -0.2px;
+  margin: 0 0 10px;
+}
+.showcase-improve-loop .tp-evidence {
+  margin: 0 0 8px;
+  font-size: 14px;
+  line-height: 1.55;
+  color: #3a3a35;
+  max-width: 80ch;
+}
+.showcase-improve-loop .tp-evidence b { color: var(--red); font-weight: 600; }
+.showcase-improve-loop .lk {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  margin-right: 8px;
+}
+.showcase-improve-loop .tp-apply { margin: 0; }
+.showcase-improve-loop .tp-apply code {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--blue);
+}
+
+/* proposal list */
+.showcase-improve-loop .proposals {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 56px;
+}
+.showcase-improve-loop .proposal {
+  display: grid;
+  grid-template-columns: 60px 70px 56px 1fr 96px;
+  gap: 8px 14px;
+  align-items: center;
+  padding: 11px 16px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--panel);
+  font-family: var(--mono);
+}
+.showcase-improve-loop .proposal .score {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+  text-align: right;
+}
+.showcase-improve-loop .proposal .score-bar {
+  display: block;
+  height: 5px;
+  background: var(--il-soft);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.showcase-improve-loop .proposal .score-bar > div {
+  height: 100%;
+  background: var(--green);
+  opacity: 0.7;
+  border-radius: 1px;
+}
+.showcase-improve-loop .proposal .title {
+  font-family: var(--sans);
+  font-size: 14.5px;
+  color: var(--ink);
+}
+.showcase-improve-loop .proposal .rate {
+  font-size: 11px;
+  color: var(--muted);
+  text-align: right;
+}
+.showcase-improve-loop .proposal .evidence {
+  grid-column: 4 / -1;
+  font-family: var(--sans);
+  font-size: 12.5px;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+/* section head */
+.showcase-improve-loop .section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0 0 22px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 10px;
+}
+.showcase-improve-loop .section-head h3 {
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 400;
+  margin: 0;
+  letter-spacing: -0.2px;
+}
+.showcase-improve-loop .section-head .meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+/* loop strip */
+.showcase-improve-loop .loop {
+  display: flex;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.showcase-improve-loop .loop .node {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--panel);
+  padding: 10px 14px;
+  min-width: 130px;
+}
+.showcase-improve-loop .loop .node code {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink);
+  font-weight: 600;
+}
+.showcase-improve-loop .loop .node em {
+  font-style: normal;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+.showcase-improve-loop .loop .arrow {
+  align-self: center;
+  font-family: var(--mono);
+  color: var(--muted);
+  font-size: 14px;
+}
+.showcase-improve-loop .loop-note {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--muted);
+  max-width: 78ch;
+  margin: 0 0 56px;
+}
+.showcase-improve-loop .loop-note code,
+.showcase-improve-loop .caption code {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--il-soft-2);
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--line);
+}
+
+/* meta-receipt insight */
+.showcase-improve-loop .insight {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  padding: 22px 26px;
+  border-left: 3px solid var(--green);
+  background: var(--il-insight-bg);
+  margin-bottom: 56px;
+  align-items: center;
+}
+.showcase-improve-loop .insight .ratio-num {
+  font-family: var(--mono);
+  font-size: 40px;
+  line-height: 1;
+  color: var(--green);
+  font-weight: 500;
+  letter-spacing: -1px;
+}
+.showcase-improve-loop .insight .ratio-num .x {
+  font-size: 22px;
+  color: var(--muted);
+  letter-spacing: 0;
+  margin-left: 2px;
+}
+.showcase-improve-loop .insight .body {
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.45;
+}
+.showcase-improve-loop .insight .body strong { font-weight: 600; }
+.showcase-improve-loop .insight .body a {
+  color: var(--blue);
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--blue) 40%, transparent);
+}
+.showcase-improve-loop .insight .body a:hover { border-bottom-color: var(--blue); }
+.showcase-improve-loop .insight .body .src {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  margin-top: 8px;
+  text-transform: uppercase;
+}
+.showcase-improve-loop .insight .body .src code {
+  font-family: var(--mono);
+  font-size: 11px;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* caption */
+.showcase-improve-loop .caption {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line);
+}
+.showcase-improve-loop .caption .col {
+  font-size: 14px;
+  line-height: 1.55;
+  color: #3a3a35;
+}
+.showcase-improve-loop .caption .col .h {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+
+@media (max-width: 760px) {
+  .showcase-improve-loop { padding: 48px 20px 72px; }
+  .showcase-improve-loop h2 { font-size: 32px; }
+  .showcase-improve-loop .proposal { grid-template-columns: 52px 1fr 90px; }
+  .showcase-improve-loop .proposal .score-bar { display: none; }
+  .showcase-improve-loop .proposal .kind { display: none; }
+  .showcase-improve-loop .proposal .evidence { grid-column: 1 / -1; }
+  .showcase-improve-loop .tp-head .origin { margin-left: 0; }
+  .showcase-improve-loop .caption { grid-template-columns: 1fr; }
+}
+
+/* ----- showcase 8: churn ----- */
+.showcase-churn {
+  --ch-soft: #ece9df;
+  --ch-soft-2: #ebe9e0;
+  --ch-amber: #b8860b;
+  --ch-insight-bg: #f0ece1;
+
+  display: block;
+  max-width: none;
+  margin: 0;
+  padding: 64px 0 96px;
+  background: var(--page);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+.showcase-churn * { box-sizing: border-box; }
+
+.showcase-churn .eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin: 0 0 14px;
+}
+.showcase-churn h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 40px;
+  line-height: 1.1;
+  letter-spacing: -0.6px;
+  margin: 0 0 18px;
+}
+.showcase-churn h2 em { font-style: italic; color: var(--muted); }
+.showcase-churn p.lede {
+  margin: 0 0 36px;
+  font-size: 19px;
+  line-height: 1.5;
+  max-width: 62ch;
+  color: #2c2c28;
+}
+.showcase-churn p.lede .cmd {
+  font-family: var(--mono);
+  font-size: 14px;
+  padding: 1px 6px;
+  background: var(--ch-soft-2);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+/* section head */
+.showcase-churn .section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0 0 22px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 10px;
+}
+.showcase-churn .section-head h3 {
+  font-family: var(--serif);
+  font-size: 22px;
+  font-weight: 400;
+  margin: 0;
+  letter-spacing: -0.2px;
+}
+.showcase-churn .section-head .meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+/* composition bars */
+.showcase-churn .comp { margin-bottom: 48px; }
+.showcase-churn .comp-row {
+  display: grid;
+  grid-template-columns: 150px 1fr 110px;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+.showcase-churn .comp-row .name {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+.showcase-churn .comp-bar {
+  display: flex;
+  height: 22px;
+  background: var(--ch-soft);
+  border-radius: 1px;
+  overflow: hidden;
+}
+.showcase-churn .comp-bar .landed { background: var(--green); opacity: 0.85; }
+.showcase-churn .comp-bar .edit   { background: var(--ch-amber); opacity: 0.85; min-width: 2px; }
+.showcase-churn .comp-bar .repair { background: var(--red); opacity: 0.85; min-width: 2px; }
+.showcase-churn .comp-row .repair-share {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  text-align: right;
+  letter-spacing: 0.02em;
+}
+.showcase-churn .comp-key {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  margin-top: 10px;
+  letter-spacing: 0.04em;
+}
+.showcase-churn .comp-key .sw {
+  display: inline-block;
+  width: 8px; height: 8px;
+  margin-right: 6px;
+  vertical-align: 1px;
+  border-radius: 1px;
+}
+.showcase-churn .comp-key .sw.landed { background: var(--green); }
+.showcase-churn .comp-key .sw.edit   { background: var(--ch-amber); }
+.showcase-churn .comp-key .sw.repair { background: var(--red); }
+.showcase-churn .comp-note {
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 22px;
+  line-height: 1.5;
+  max-width: 60ch;
+}
+.showcase-churn .comp-note strong { color: var(--ink); font-weight: 500; }
+
+/* table */
+.showcase-churn .ledger {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 6px 0 0;
+  margin-bottom: 48px;
+  overflow-x: auto;
+}
+.showcase-churn .ledger .row {
+  display: grid;
+  grid-template-columns: 140px 48px 52px 70px 48px minmax(140px, 1.2fr) minmax(110px, 1fr) minmax(96px, 0.9fr);
+  gap: 12px;
+  align-items: center;
+  padding: 9px 16px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 55%, transparent);
+}
+.showcase-churn .ledger .row.head {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+}
+.showcase-churn .ledger .row .num { text-align: right; }
+.showcase-churn .ledger .row .src { color: var(--ink); }
+.showcase-churn .ledger .row .fails { color: var(--red); }
+.showcase-churn .ledger .row .pass { color: var(--green); }
+.showcase-churn .ledger .row .repair { color: var(--red); }
+.showcase-churn .ledger-foot {
+  padding: 10px 16px 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+/* episode diagram */
+.showcase-churn .episode {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 56px;
+  flex-wrap: wrap;
+}
+.showcase-churn .ep-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--panel);
+  padding: 12px 18px 10px;
+  text-align: center;
+  min-width: 140px;
+}
+.showcase-churn .ep-node b {
+  font-family: var(--mono);
+  font-size: 18px;
+  line-height: 1;
+  font-weight: 600;
+}
+.showcase-churn .ep-node.open b,
+.showcase-churn .ep-node.more b { color: var(--red); }
+.showcase-churn .ep-node.close b { color: var(--green); }
+.showcase-churn .ep-node.expire b { color: var(--muted); }
+.showcase-churn .ep-node.expire { border-style: dashed; }
+.showcase-churn .ep-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+.showcase-churn .ep-sub {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+.showcase-churn .ep-track {
+  flex: 1 1 24px;
+  height: 1px;
+  background: var(--line);
+  min-width: 24px;
+}
+.showcase-churn .ep-track.dashed {
+  background: repeating-linear-gradient(
+    90deg,
+    var(--line) 0 6px,
+    transparent 6px 12px
+  );
+}
+
+/* insight */
+.showcase-churn .insight {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  padding: 22px 26px;
+  border-left: 3px solid var(--red);
+  background: var(--ch-insight-bg);
+  margin-bottom: 56px;
+  align-items: center;
+}
+.showcase-churn .insight .ratio-num {
+  font-family: var(--mono);
+  font-size: 40px;
+  line-height: 1;
+  color: var(--red);
+  font-weight: 500;
+  letter-spacing: -1px;
+}
+.showcase-churn .insight .ratio-num .x {
+  font-size: 22px;
+  color: var(--muted);
+  letter-spacing: 0;
+  margin-left: 4px;
+}
+.showcase-churn .insight .body {
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.45;
+}
+.showcase-churn .insight .body strong { font-weight: 600; }
+.showcase-churn .insight .body .src {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  margin-top: 8px;
+  text-transform: uppercase;
+}
+
+/* caption */
+.showcase-churn .caption {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line);
+}
+.showcase-churn .caption .col {
+  font-size: 14px;
+  line-height: 1.55;
+  color: #3a3a35;
+}
+.showcase-churn .caption .col .h {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.showcase-churn .caption code {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--ch-soft-2);
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--line);
+}
+
+@media (max-width: 760px) {
+  .showcase-churn { padding: 48px 20px 72px; }
+  .showcase-churn h2 { font-size: 32px; }
+  .showcase-churn .comp-row { grid-template-columns: 110px 1fr; }
+  .showcase-churn .comp-row .repair-share { grid-column: 2; text-align: left; margin-top: -8px; }
+  .showcase-churn .episode { flex-direction: column; align-items: stretch; }
+  .showcase-churn .ep-track { display: none; }
+  .showcase-churn .caption { grid-template-columns: 1fr; }
+}
+
 /* ----- /showcases route — intro panel + jump nav ----- */
 .showcases-intro {
   max-width: none;


### PR DESCRIPTION
## What

/showcases was stuck at the original four sections (hook backtest, recall, token economy, verdict timeline). This adds four showcases for features shipped since, in the same hand-laid receipt style:

- **dispatch routing** (`#dispatch-routing`) - `ax dispatches --candidates` repriced-ledger, find → compile → fire pipeline, links to /routing
- **quota** (`#quota`) - live 5h/7d plan meters; one cached read rendered on three surfaces (terminal, statusline, SwiftBar menubar)
- **improve loop** (`#improve-loop`) - scored proposals with evidence trails; closes with the meta-receipt that the top mined proposal *is* the dispatch-routing feature
- **churn** (`#churn`) - landed/edit/repair composition per source + episode lifecycle diagram

Intro updated to "Eight scenarios", nav gets four new jump links.

## Receipts

All figures are real output from `ax dispatches --candidates`, `ax quota` (incl. verbatim `--statusline` / `--swiftbar` formats), `ax improve recommend`, and `ax sessions churn --here` - magnitudes unchanged, rows trimmed for layout.

## Verification

- site build green; sections present in the client bundle
- site typecheck: zero new errors (93 pre-existing in changelog/ADR routes, untouched)
- screenshot-verified all four sections in headless Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)