### PR TITLE
refactor(queries): enriched-session facade for session show across surfaces

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,6 +43,12 @@ A model-derived summary or classification of an agent session, such as goal,
 outcome, friction, helpfulness, and satisfaction signals.
 _Avoid_: ground truth
 
+**Enriched Session**:
+The assembled read model of one session - session detail plus metrics plus
+**Session Insights** - produced by one facade so every surface reads the same
+shape.
+_Avoid_: session detail blob
+
 **Derivation Engine**:
 The agent-neutral logic that turns normalized sessions, edits, commits, and touched files into **Change Sets** and **File Memories**.
 _Avoid_: Codex parser, adapter

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -11,7 +11,7 @@ import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
 import { encodeClaudeProjectSlug } from "@ax/lib/transcript-locator";
 import { detectStaleness } from "@ax/lib/transcript-staleness";
 import { fetchSessionCompare } from "../../dashboard/session-compare.ts";
-import { fetchSessionShow } from "../../dashboard/session-show.ts";
+import { fetchEnrichedSession } from "../../queries/enriched-session.ts";
 import {
     listSessionsHere,
     listSessionsAround,
@@ -373,15 +373,28 @@ const cmdSessionShow = (input: {
             input.expand.map((v) => v.trim()).filter((v) => v.length > 0),
         );
 
+        // The Enriched Session facade (`fetchEnrichedSession`) is the single
+        // home for assembling a session's read model. The CLI base is the full
+        // Session View (expand + by-role + compactions). Metrics are fetched in
+        // a distinct step below rather than via `includeMetrics`, because the
+        // durability drill-down must run against the prefix-RESOLVED id; folding
+        // it into this probe would re-issue it on the unresolved id and add a
+        // query (the `ax sessions` hang guard - each caller keeps its exact
+        // query set). `includeInsights` stays off: the CLI never fetched them.
         let resolvedId = sessionId;
-        let payload = yield* fetchSessionShow({
-            sessionId,
+        const viewBase = {
+            kind: "view",
             expand: expandSet,
             expandAll,
             byRole,
+        } as const;
+        let enriched = yield* fetchEnrichedSession({
+            sessionId,
+            base: viewBase,
         }).pipe(
             catchDbErrorAndExit("axctl session show"),
         );
+        let payload = enriched.view!;
 
         // Prefix fallback: agents paste the short ids shown in listings
         // (dogfood retro R2). Unambiguous prefix → resolve + proceed;
@@ -393,12 +406,11 @@ const cmdSessionShow = (input: {
             if (candidates.length === 1) {
                 resolvedId = candidates[0]!;
                 process.stderr.write(`resolved id prefix ${sessionId} → ${resolvedId}\n`);
-                payload = yield* fetchSessionShow({
+                enriched = yield* fetchEnrichedSession({
                     sessionId: resolvedId,
-                    expand: expandSet,
-                    expandAll,
-                    byRole,
+                    base: viewBase,
                 }).pipe(catchDbErrorAndExit("axctl session show"));
+                payload = enriched.view!;
             } else if (candidates.length > 1) {
                 process.stderr.write(
                     `session id prefix "${sessionId}" is ambiguous:\n` +

--- a/apps/axctl/src/dashboard/contract/sessions.ts
+++ b/apps/axctl/src/dashboard/contract/sessions.ts
@@ -11,9 +11,9 @@ import { Effect } from "effect";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { AxApi, BadRequestError, InternalError, NotFoundError } from "@ax/lib/shared/api-contract";
 import { extractSessionTimeline, SessionTimelineServiceLayer } from "../../timeline/service.ts";
+import { fetchEnrichedSession } from "../../queries/enriched-session.ts";
 import { fetchSessionCanvas, fetchSessionOrchestration } from "../session-canvas.ts";
 import { fetchSessionCompare } from "../session-compare.ts";
-import { fetchSessionDetail } from "../session-detail.ts";
 import { fetchSessionInsights } from "../session-insights.ts";
 import { fetchSessionInspect } from "../session-inspect.ts";
 import { fetchSessionSummary } from "../session-summary.ts";
@@ -73,4 +73,13 @@ export const SessionsGroupLive = HttpApiBuilder.group(AxApi, "sessions", (handle
                 Effect.mapError(notFoundOrInternal),
             ))
         .handle("sessionDetail", ({ params }) =>
-            orInternal(fetchSessionDetail(params.id))));
+            // The Enriched Session facade is the single home for assembling a
+            // session read model. This route fetches strictly LESS than the CLI:
+            // the bare Session Detail base (`base: "detail"`), no metrics, no
+            // insights - so the HTTP response shape stays the bare
+            // SessionDetailPayload and the query count is exactly one, as before.
+            orInternal(
+                fetchEnrichedSession({ sessionId: params.id, base: { kind: "detail" } }).pipe(
+                    Effect.map((enriched) => enriched.detail!),
+                ),
+            )));

--- a/apps/axctl/src/queries/enriched-session.test.ts
+++ b/apps/axctl/src/queries/enriched-session.test.ts
@@ -1,0 +1,179 @@
+/**
+ * enriched-session.test.ts - the Enriched Session facade options matrix.
+ *
+ * Stubs every composed fetcher and asserts which ones run for a given options
+ * combination (the performance guard - each caller issues exactly the queries
+ * it asked for, nothing more) and that the assembled shape routes each result
+ * into the right slot.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import type {
+    SessionDetailPayload,
+    SessionInsightsPayload,
+    SessionViewPayload,
+} from "@ax/lib/shared/dashboard-types";
+import type { SessionDurabilityDetail } from "../metrics/reverted-commits.ts";
+import {
+    fetchEnrichedSession,
+    type EnrichedSessionFetchers,
+    type EnrichedSessionOptions,
+} from "./enriched-session.ts";
+
+// ---------------------------------------------------------------------------
+// Stub payloads (shape-cast - the facade routes them, it does not inspect them)
+// ---------------------------------------------------------------------------
+
+const VIEW = { session: { overview: { id: "v" } } } as unknown as SessionViewPayload;
+const DETAIL = { overview: { id: "d" } } as unknown as SessionDetailPayload;
+const METRICS = { producedCommits: 1, revertedCommits: 0, durabilityRatio: 1, reverted: [] } as SessionDurabilityDetail;
+const INSIGHTS = { phases: [] } as unknown as SessionInsightsPayload;
+
+interface Calls {
+    view: string[];
+    detail: string[];
+    metrics: string[];
+    insights: string[];
+}
+
+const makeFetchers = (): { fetchers: EnrichedSessionFetchers; calls: Calls } => {
+    const calls: Calls = { view: [], detail: [], metrics: [], insights: [] };
+    const fetchers: EnrichedSessionFetchers = {
+        fetchView: ((opts: { sessionId: string }) => {
+            calls.view.push(opts.sessionId);
+            return Effect.succeed(VIEW);
+        }) as EnrichedSessionFetchers["fetchView"],
+        fetchDetail: ((id: string) => {
+            calls.detail.push(id);
+            return Effect.succeed(DETAIL);
+        }) as EnrichedSessionFetchers["fetchDetail"],
+        fetchMetrics: ((id: string) => {
+            calls.metrics.push(id);
+            return Effect.succeed(METRICS);
+        }) as EnrichedSessionFetchers["fetchMetrics"],
+        fetchInsights: ((id: string) => {
+            calls.insights.push(id);
+            return Effect.succeed(INSIGHTS);
+        }) as EnrichedSessionFetchers["fetchInsights"],
+    };
+    return { fetchers, calls };
+};
+
+const run = (opts: EnrichedSessionOptions, fetchers: EnrichedSessionFetchers) =>
+    Effect.runPromise(
+        fetchEnrichedSession(opts, fetchers).pipe(
+            // Satisfy the SurrealClient requirement; the stubs never touch it.
+            Effect.provide(makeTestSurrealClient({ denyWrites: true }).layer),
+        ),
+    );
+
+// ---------------------------------------------------------------------------
+// Options matrix → which fetchers run
+// ---------------------------------------------------------------------------
+
+describe("fetchEnrichedSession - base selection", () => {
+    it("base=view runs fetchView only, populates .view", async () => {
+        const { fetchers, calls } = makeFetchers();
+        const result = await run(
+            { sessionId: "s1", base: { kind: "view", expand: new Set(), expandAll: false, byRole: false } },
+            fetchers,
+        );
+        expect(calls.view).toEqual(["s1"]);
+        expect(calls.detail).toEqual([]);
+        expect(calls.metrics).toEqual([]);
+        expect(calls.insights).toEqual([]);
+        expect(result.view).toBe(VIEW);
+        expect(result.detail).toBeNull();
+    });
+
+    it("base=detail runs fetchDetail only, populates .detail", async () => {
+        const { fetchers, calls } = makeFetchers();
+        const result = await run({ sessionId: "s2", base: { kind: "detail" } }, fetchers);
+        expect(calls.detail).toEqual(["s2"]);
+        expect(calls.view).toEqual([]);
+        expect(calls.metrics).toEqual([]);
+        expect(calls.insights).toEqual([]);
+        expect(result.detail).toBe(DETAIL);
+        expect(result.view).toBeNull();
+    });
+});
+
+describe("fetchEnrichedSession - include flags gate the optional fetchers", () => {
+    it("includeMetrics=false → no metrics query, .metrics null", async () => {
+        const { fetchers, calls } = makeFetchers();
+        const result = await run({ sessionId: "s", base: { kind: "detail" } }, fetchers);
+        expect(calls.metrics).toEqual([]);
+        expect(result.metrics).toBeNull();
+    });
+
+    it("includeMetrics=true → one metrics query, .metrics populated", async () => {
+        const { fetchers, calls } = makeFetchers();
+        const result = await run(
+            { sessionId: "s", base: { kind: "detail" }, includeMetrics: true },
+            fetchers,
+        );
+        expect(calls.metrics).toEqual(["s"]);
+        expect(result.metrics).toBe(METRICS);
+    });
+
+    it("includeInsights=false → no insights query, .insights null", async () => {
+        const { fetchers, calls } = makeFetchers();
+        const result = await run({ sessionId: "s", base: { kind: "detail" } }, fetchers);
+        expect(calls.insights).toEqual([]);
+        expect(result.insights).toBeNull();
+    });
+
+    it("includeInsights=true → one insights query, .insights populated", async () => {
+        const { fetchers, calls } = makeFetchers();
+        const result = await run(
+            { sessionId: "s", base: { kind: "detail" }, includeInsights: true },
+            fetchers,
+        );
+        expect(calls.insights).toEqual(["s"]);
+        expect(result.insights).toBe(INSIGHTS);
+    });
+
+    it("both includes on → view + metrics + insights all run exactly once", async () => {
+        const { fetchers, calls } = makeFetchers();
+        const result = await run(
+            {
+                sessionId: "s",
+                base: { kind: "view", expand: new Set(), expandAll: false },
+                includeMetrics: true,
+                includeInsights: true,
+            },
+            fetchers,
+        );
+        expect(calls.view).toEqual(["s"]);
+        expect(calls.detail).toEqual([]);
+        expect(calls.metrics).toEqual(["s"]);
+        expect(calls.insights).toEqual(["s"]);
+        expect(result.view).toBe(VIEW);
+        expect(result.metrics).toBe(METRICS);
+        expect(result.insights).toBe(INSIGHTS);
+    });
+});
+
+describe("fetchEnrichedSession - call-site parity", () => {
+    it("CLI parity: view base, no metrics/insights folded in (probe issues view only)", async () => {
+        const { fetchers, calls } = makeFetchers();
+        await run(
+            { sessionId: "cli", base: { kind: "view", expand: new Set(), expandAll: false, byRole: true } },
+            fetchers,
+        );
+        // Exactly the one view query the CLI probe issued before the facade.
+        expect(calls.view).toEqual(["cli"]);
+        expect(calls.detail.length + calls.metrics.length + calls.insights.length).toBe(0);
+    });
+
+    it("HTTP parity: detail base, nothing else (exactly one query)", async () => {
+        const { fetchers, calls } = makeFetchers();
+        await run({ sessionId: "http", base: { kind: "detail" } }, fetchers);
+        const total =
+            calls.view.length + calls.detail.length + calls.metrics.length + calls.insights.length;
+        expect(total).toBe(1);
+        expect(calls.detail).toEqual(["http"]);
+    });
+});

--- a/apps/axctl/src/queries/enriched-session.ts
+++ b/apps/axctl/src/queries/enriched-session.ts
@@ -1,0 +1,146 @@
+/**
+ * enriched-session.ts - the single named home for "show one session with
+ * metrics + insights".
+ *
+ * Before this facade, every surface that wanted a session's read model
+ * orchestrated the dashboard / metrics / insights layers itself: the CLI
+ * `ax sessions show` handler assembled `fetchSessionView` + `fetchSession-
+ * DurabilityDetail`; the HTTP `/api/sessions/:id` route called the bare
+ * `fetchSessionDetail`. The Enriched Session is that assembled value -
+ * session detail (as a full Session View or the bare detail), plus optional
+ * durability metrics, plus optional Session Insights - produced by ONE facade
+ * so every surface reads the same shape.
+ *
+ * PERFORMANCE GUARD: `ax sessions` has a history of hang regressions from
+ * turn-scans. The facade adds no queries. The `base` option selects exactly
+ * one base fetcher (view OR bare detail); metrics/insights run only when their
+ * flag is set, otherwise they resolve to `null` with no query. Each caller
+ * therefore issues exactly the queries it issued before adopting the facade.
+ */
+
+import { Effect } from "effect";
+import type { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import type {
+    SessionDetailPayload,
+    SessionInsightsPayload,
+    SessionViewPayload,
+} from "@ax/lib/shared/dashboard-types";
+import { fetchSessionDetail } from "../dashboard/session-detail.ts";
+import { fetchSessionInsights } from "../dashboard/session-insights.ts";
+import {
+    fetchSessionView,
+    type FetchSessionViewOptions,
+} from "../dashboard/session-view.ts";
+import {
+    fetchSessionDurabilityDetail,
+    type SessionDurabilityDetail,
+} from "../metrics/reverted-commits.ts";
+
+/**
+ * How the base session-detail facts are fetched. The two surfaces fetch
+ * different amounts today; the discriminant makes that explicit instead of
+ * leaving it implicit in each call site.
+ *
+ * - `view`: the richer Session View (base detail + child expansion + by-role
+ *   grouping + compactions). Used by `ax sessions show`.
+ * - `detail`: the bare Session Detail payload, no expansion / by-role /
+ *   compactions. Used by the HTTP `/api/sessions/:id` route, which fetches
+ *   strictly less.
+ */
+export type EnrichedSessionBase =
+    | ({ readonly kind: "view" } & Omit<FetchSessionViewOptions, "sessionId">)
+    | { readonly kind: "detail" };
+
+export interface EnrichedSessionOptions {
+    readonly sessionId: string;
+    /** Which base fetcher to use (view vs bare detail). */
+    readonly base: EnrichedSessionBase;
+    /** Fetch the durability drill-down (#176). Off by default. */
+    readonly includeMetrics?: boolean;
+    /** Fetch model-derived Session Insights. Off by default. */
+    readonly includeInsights?: boolean;
+}
+
+/**
+ * The assembled Enriched Session read model. Exactly one of `view` / `detail`
+ * is populated, matching the requested `base`. `metrics` / `insights` are
+ * `null` when their include flag was not set (no query issued).
+ */
+export interface EnrichedSession {
+    /** Populated when `base.kind === "view"`. */
+    readonly view: SessionViewPayload | null;
+    /** Populated when `base.kind === "detail"`. */
+    readonly detail: SessionDetailPayload | null;
+    /** Durability drill-down, or `null` when `includeMetrics` was not set. */
+    readonly metrics: SessionDurabilityDetail | null;
+    /** Session Insights, or `null` when `includeInsights` was not set. */
+    readonly insights: SessionInsightsPayload | null;
+}
+
+/**
+ * Injectable fetchers - lets tests assert which fetchers run for a given
+ * options matrix without a live SurrealDB. Production uses the real fetchers.
+ */
+export interface EnrichedSessionFetchers {
+    readonly fetchView: typeof fetchSessionView;
+    readonly fetchDetail: typeof fetchSessionDetail;
+    readonly fetchMetrics: typeof fetchSessionDurabilityDetail;
+    readonly fetchInsights: typeof fetchSessionInsights;
+}
+
+const defaultFetchers: EnrichedSessionFetchers = {
+    fetchView: fetchSessionView,
+    fetchDetail: fetchSessionDetail,
+    fetchMetrics: fetchSessionDurabilityDetail,
+    fetchInsights: fetchSessionInsights,
+};
+
+/**
+ * Assemble the Enriched Session for one session id. Composes the existing
+ * fetchers; rewrites none of them. The base fetch and the two optional
+ * enrichments are independent, so they run concurrently.
+ */
+export const fetchEnrichedSession: (
+    opts: EnrichedSessionOptions,
+    fetchers?: EnrichedSessionFetchers,
+) => Effect.Effect<EnrichedSession, DbError, SurrealClient> = Effect.fn(
+    "queries.fetchEnrichedSession",
+)(function* (opts, fetchers = defaultFetchers) {
+    const baseEffect: Effect.Effect<
+        { view: SessionViewPayload | null; detail: SessionDetailPayload | null },
+        DbError,
+        SurrealClient
+    > = opts.base.kind === "view"
+        ? fetchers
+            .fetchView({
+                sessionId: opts.sessionId,
+                expand: opts.base.expand,
+                expandAll: opts.base.expandAll,
+                ...(opts.base.byRole === undefined ? {} : { byRole: opts.base.byRole }),
+            })
+            .pipe(Effect.map((view) => ({ view, detail: null })))
+        : fetchers
+            .fetchDetail(opts.sessionId)
+            .pipe(Effect.map((detail) => ({ view: null, detail })));
+
+    const metricsEffect = opts.includeMetrics === true
+        ? fetchers.fetchMetrics(opts.sessionId)
+        : Effect.succeed(null);
+
+    const insightsEffect = opts.includeInsights === true
+        ? fetchers.fetchInsights(opts.sessionId)
+        : Effect.succeed(null);
+
+    const [base, metrics, insights] = yield* Effect.all(
+        [baseEffect, metricsEffect, insightsEffect],
+        { concurrency: 3 },
+    );
+
+    return {
+        view: base.view,
+        detail: base.detail,
+        metrics,
+        insights,
+    };
+});


### PR DESCRIPTION
## What

Gives "show one session with metrics + insights" a single named home - an **Enriched Session** facade (`apps/axctl/src/queries/enriched-session.ts`) - instead of every caller orchestrating the dashboard / metrics / insights layers itself.

Before:
- CLI `ax sessions show` assembled `fetchSessionView` + `fetchSessionDurabilityDetail` inline.
- HTTP `GET /api/sessions/:id` called the bare `fetchSessionDetail` directly.

After: both read through `fetchEnrichedSession`, which **composes the existing fetchers** (rewrites none).

## Options encode the call-site difference

`base` is a discriminant that makes explicit that the HTTP route fetches strictly less than the CLI:
- `base: { kind: "view", expand, expandAll, byRole }` → full Session View (detail + child expansion + by-role + compactions). Used by the CLI.
- `base: { kind: "detail" }` → bare `SessionDetailPayload`, no expansion / by-role / compactions. Used by the HTTP route.

`includeMetrics` / `includeInsights` gate the optional durability + Session Insights fetchers; both default off. The result carries `view`/`detail`/`metrics`/`insights` slots (exactly one of `view`/`detail` populated, optionals `null` when not requested).

## Behavior preservation

- **CLI output bytes**: unchanged. The handler now reads `enriched.view` and feeds the same `renderSessionMarkdown` / `renderSessionJson`. NavLink building + formatting stay caller-side.
- **HTTP response shape**: unchanged. The route maps `enriched.detail` back to the bare `SessionDetailPayload` it returned before.
- **MCP**: `apps/axctl/src/mcp/tools.ts` untouched (sibling agent owns it this phase; facade adoption there is a follow-up).

## PERFORMANCE GUARD - no added queries

`ax sessions` has a history of hang regressions from turn-scans. Verified each caller issues **exactly** the queries it issued before:

- The facade `base` selects exactly ONE base fetcher (view OR detail). `metrics` / `insights` run only when their flag is set, otherwise they resolve to `Effect.succeed(null)` with no query.
- **CLI**: the prefix-resolution probe issues a single view-only facade call (`includeMetrics: false`), exactly as the old `fetchSessionShow` probe did. The durability drill-down stays a **distinct** `fetchSessionDurabilityDetail` step against the prefix-RESOLVED id - folding it into the probe via `includeMetrics` would have re-issued it against the unresolved id and added a query. So the happy path is still 1 view + 1 metrics; the prefix path is still 2 views + 1 metrics + 1 prefix lookup.
- **HTTP**: a single `base: "detail"` facade call → exactly one query, as before.
- The options-matrix unit test (`enriched-session.test.ts`) asserts call counts per fetcher with stubs, including dedicated CLI-parity and HTTP-parity cases.

## Tests

- New `apps/axctl/src/queries/enriched-session.test.ts`: options matrix → which fetchers run + result-slot routing, with every composed fetcher stubbed.
- `bun run typecheck` (repo root): exit 0.
- `bun test apps/axctl/src`: 2815 pass / 0 fail / 4 skip.

## Docs

Added the **Enriched Session** entry to CONTEXT.md's Language section, right after **Session Insight**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)