### PR TITLE
refactor(queries): query input contracts shared by CLI and MCP transports

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,6 +93,16 @@ source of truth for routes, params, responses, errors, generated docs, and the
 generated client. SSE and binary escape hatches sit outside it as raw routes.
 _Avoid_: route table, endpoint list
 
+**Query Input Contract**:
+The typed input shape plus a `normalize` function a query module exports as the
+single seam every transport (CLI, MCP, HTTP) delegates to for argument semantics
+- defaults, clamping, default windows, presence rules - so the meaning of an
+argument cannot drift between transports. Protocol-level decoding (CLI flags,
+MCP zod schemas) and user-facing error wording stay transport-local; only the
+semantic normalization is shared. Where transports legitimately differ (e.g. a
+divergent limit default) the difference is a parameter, never silently unified.
+_Avoid_: arg parser
+
 **Turn**:
 A single message in an agent session transcript: one user or assistant
 JSONL record. The atomic unit of the transcript stream. A Turn may carry

--- a/apps/axctl/src/cli/commands/improve.ts
+++ b/apps/axctl/src/cli/commands/improve.ts
@@ -10,8 +10,8 @@ import { deriveCheckpoints } from "../../ingest/derive-checkpoints.ts";
 import { runAgentAccept } from "../../improve/agent-accept.ts";
 import { acceptProposal, rejectProposal } from "../../improve/actions.ts";
 import { lintFiles } from "../../improve/lint.ts";
-import { listProposals, type ProposalRow } from "../../improve/list.ts";
-import { recommend, formatRecommendations, copyToClipboard, selectByIndices, parseIndexInput } from "../../improve/recommend.ts";
+import { listProposals, normalizeListProposalsInput, type ProposalRow } from "../../improve/list.ts";
+import { recommend, normalizeRecommendInput, formatRecommendations, copyToClipboard, selectByIndices, parseIndexInput } from "../../improve/recommend.ts";
 import { showExperiment, formatShow } from "../../improve/show.ts";
 import { renderAnalyzeBrief } from "../../improve/analyze-brief.ts";
 import { runPropose } from "../../improve/propose.ts";
@@ -44,14 +44,16 @@ const cmdImproveList = (input: {
 }) =>
     Effect.gen(function* () {
         const json = input.json;
+        // Transport-local validation (exit 2 with usage wording) stays here; the
+        // status default + presence rules come from the shared normalizer.
         const limit = requirePositiveInt("improve list", "limit", input.limit);
-        const formFilter = input.form;
-        const statusFilter = input.status ?? "open";
-        const rows = yield* listProposals({
-            status: statusFilter,
-            ...(formFilter !== undefined ? { form: formFilter } : {}),
-            limit,
-        });
+        const rows = yield* listProposals(
+            normalizeListProposalsInput({
+                ...(input.status !== undefined ? { status: input.status } : {}),
+                ...(input.form !== undefined ? { form: input.form } : {}),
+                limit,
+            }),
+        );
         if (json) {
             console.log(prettyPrint(rows));
             return;
@@ -146,11 +148,19 @@ const cmdImproveRecommend = (input: {
         const limit = requirePositiveInt("improve recommend", "limit", input.limit);
         const sinceDays = requireOptionalPositiveInt("improve recommend", "since", input.sinceDays);
         const forms = input.forms.flatMap((v) => parseFileHints(Option.some(v)));
-        const items = yield* recommend({
-            limit,
-            ...(forms.length > 0 ? { forms } : {}),
-            ...(sinceDays === undefined ? {} : { sinceDays }),
-        });
+        // Validation (exit 2) stays here; the CLI limit default is 5 (MCP's is
+        // 10), both passed into the shared normalizer so the constructed input
+        // shape cannot drift between transports.
+        const items = yield* recommend(
+            normalizeRecommendInput(
+                {
+                    limit,
+                    ...(forms.length > 0 ? { forms } : {}),
+                    ...(sinceDays === undefined ? {} : { sinceDays }),
+                },
+                5,
+            ),
+        );
         if (json) {
             console.log(prettyPrint(items));
             return;

--- a/apps/axctl/src/cli/commands/recall.ts
+++ b/apps/axctl/src/cli/commands/recall.ts
@@ -10,7 +10,7 @@ import {
     buildRecallNext,
 } from "../../nav/next-links.ts";
 import { printNextLinks } from "../next-format.ts";
-import { fetchRecall, type RecallSource, type RecallScope } from "../../dashboard/recall.ts";
+import { fetchRecall, resolveRecallSources, type RecallSource, type RecallScope } from "../../dashboard/recall.ts";
 import { resolvePwdRepository } from "../../pwd.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, parseCsvFlag } from "./shared.ts";
@@ -226,7 +226,7 @@ const cmdRecall = (opts: RecallCliOpts) =>
             scope,
         });
         const { hits, next } = buildRecallNext(result, {
-            requestedSources: sources ?? ["turn"],
+            requestedSources: resolveRecallSources(sources),
         });
         if (opts.json) {
             console.log(prettyPrint({ ...result, hits, next }));

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -17,6 +17,7 @@ import {
     listSessionsAround,
     listSessionsNear,
     findSessionIdsByPrefix,
+    normalizeSessionsAroundOpts,
     type SessionRow,
 } from "../../dashboard/sessions-query.ts";
 import { ingestTranscripts } from "../../ingest/transcripts.ts";
@@ -262,7 +263,9 @@ const cmdSessionsAround = (input: {
                 : projectRaw;
         }
 
-        const rows = yield* listSessionsAround({ date, days, project });
+        const rows = yield* listSessionsAround(
+            normalizeSessionsAroundOpts({ date, days, project }),
+        );
         const { sessions, next } = buildSessionsNext(rows, {
             date: positional,
             days,

--- a/apps/axctl/src/cli/commands/skills.ts
+++ b/apps/axctl/src/cli/commands/skills.ts
@@ -5,11 +5,15 @@ import { SurrealClient } from "@ax/lib/db";
 import { prettyPrint } from "@ax/lib/json";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
-import { fetchSkillsWeighted } from "../../dashboard/skills-weighted.ts";
+import {
+    fetchSkillsWeighted,
+    normalizeSkillsWeightedParams,
+} from "../../dashboard/skills-weighted.ts";
 import {
     fetchSkillsByRole,
     fetchRolesForSkill,
     fetchAllRoles,
+    normalizeSkillsByRoleParams,
 } from "../../dashboard/role-queries.ts";
 import { loadAgentScopeMap } from "../../ingest/agent-scope.ts";
 import {
@@ -332,13 +336,16 @@ const cmdSkillsWeighted = (input: SkillsWeightedInput) =>
 
         // --window=0 is invalid: requireOptionalPositiveInt rejects it (n <= 0)
         // with exit 2, mirroring the old parseOptionalPositiveIntFlag behavior.
+        // Validation stays here; defaults/presence come from the shared normalizer.
 
-        const result = yield* fetchSkillsWeighted({
-            ...(windowDays !== undefined ? { windowDays } : {}),
-            limit,
-            doctorThreshold,
-            includeTools,
-        }).pipe(
+        const result = yield* fetchSkillsWeighted(
+            normalizeSkillsWeightedParams({
+                ...(windowDays !== undefined ? { windowDays } : {}),
+                limit,
+                doctorThreshold,
+                includeTools,
+            }),
+        ).pipe(
             catchDbErrorAndExit("axctl skills weighted"),
         );
 
@@ -372,7 +379,9 @@ const cmdSkillsByRole = (input: SkillsByRoleInput) =>
         const json = wantsJsonFlag(input.json);
         const limit = requirePositiveInt("skills by-role", "limit", input.limit);
 
-        const result = yield* fetchSkillsByRole({ role, limit }).pipe(
+        const result = yield* fetchSkillsByRole(
+            normalizeSkillsByRoleParams({ role, limit }),
+        ).pipe(
             catchDbErrorAndExit("axctl skills by-role"),
         );
 

--- a/apps/axctl/src/dashboard/recall.ts
+++ b/apps/axctl/src/dashboard/recall.ts
@@ -50,6 +50,24 @@ export interface RecallParams {
     readonly scope?: RecallScope;
 }
 
+/**
+ * The source set `fetchRecall` searches when none is requested. Exported so the
+ * CLI flag parser and the MCP zod handler use the same default when they build
+ * the `next` links (`requestedSources`) instead of re-spelling `["turn"]`.
+ */
+export const RECALL_DEFAULT_SOURCES: ReadonlyArray<RecallSource> = ["turn"];
+
+/**
+ * Resolve the effective source set for a recall request: a non-empty requested
+ * set, else {@link RECALL_DEFAULT_SOURCES}. This is the single semantic the
+ * query, the CLI, and the MCP tool share - `fetchRecall` applies the same rule
+ * internally for the actual fan-out.
+ */
+export const resolveRecallSources = (
+    requested: ReadonlyArray<RecallSource> | null | undefined,
+): ReadonlyArray<RecallSource> =>
+    requested && requested.length > 0 ? requested : RECALL_DEFAULT_SOURCES;
+
 export const emptyRecallResponse = (
     q: string,
     offset: number,
@@ -76,10 +94,7 @@ export const fetchRecall = (
             RECALL_PAGINATION,
         );
 
-        const sources: ReadonlyArray<RecallSource> =
-            params.sources && params.sources.length > 0
-                ? params.sources
-                : ["turn"];
+        const sources = resolveRecallSources(params.sources);
 
         if (!q) {
             return emptyRecallResponse(params.q, offset, limit);

--- a/apps/axctl/src/dashboard/role-queries.ts
+++ b/apps/axctl/src/dashboard/role-queries.ts
@@ -49,6 +49,32 @@ export interface FetchSkillsByRoleParams {
     readonly limit?: number;
 }
 
+/** Shared default row cap for `fetchSkillsByRole` (CLI + MCP). */
+export const SKILLS_BY_ROLE_DEFAULT_LIMIT = 50;
+
+/**
+ * Transport-agnostic raw input for `fetchSkillsByRole`. The CLI flag parser and
+ * the MCP zod handler decode into this then call
+ * {@link normalizeSkillsByRoleParams} so the limit default lives in one place.
+ *
+ * `limit` positivity stays in the transports (CLI `requirePositiveInt`, MCP
+ * zod `.positive()`); this only fills the default.
+ */
+export interface SkillsByRoleQueryArgs {
+    readonly role: string;
+    readonly limit?: number | undefined;
+}
+
+export const normalizeSkillsByRoleParams = (
+    args: SkillsByRoleQueryArgs,
+): FetchSkillsByRoleParams => ({
+    role: args.role,
+    limit:
+        typeof args.limit === "number" && Number.isFinite(args.limit)
+            ? args.limit
+            : SKILLS_BY_ROLE_DEFAULT_LIMIT,
+});
+
 export interface FetchSkillsByRoleResult {
     readonly rows: readonly SkillByRoleRow[];
     readonly found: boolean;
@@ -59,7 +85,7 @@ export const fetchSkillsByRole = (
 ): Effect.Effect<FetchSkillsByRoleResult, DbError, SurrealClient> =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
-        const limit = params.limit ?? 50;
+        const limit = params.limit ?? SKILLS_BY_ROLE_DEFAULT_LIMIT;
 
         const sql = `
 SELECT

--- a/apps/axctl/src/dashboard/sessions-query.ts
+++ b/apps/axctl/src/dashboard/sessions-query.ts
@@ -192,6 +192,39 @@ export interface SessionsAroundOpts {
     readonly project?: string | null;
 }
 
+/** Shared half-width default for the around-date window (CLI + MCP). */
+export const SESSIONS_AROUND_DEFAULT_DAYS = 3;
+
+/**
+ * Transport-agnostic raw input for `listSessionsAround`. The CLI flag parser
+ * and the MCP zod handler both decode their wire shapes (date string, optional
+ * days/project) into a resolved {@link Date} plus optionals, then call
+ * {@link normalizeSessionsAroundOpts} so the half-width default + project
+ * presence rule live in one place.
+ *
+ * Date parsing/validation (the CLI's strict YYYY-MM-DD guard, the MCP's
+ * `Number.isNaN` reject) stays transport-local - both pass an already-resolved
+ * `Date`. `days` positivity also stays transport-local.
+ */
+export interface SessionsAroundQueryArgs {
+    readonly date: Date;
+    readonly days?: number | undefined;
+    readonly project?: string | null | undefined;
+}
+
+export const normalizeSessionsAroundOpts = (
+    args: SessionsAroundQueryArgs,
+): SessionsAroundOpts => ({
+    date: args.date,
+    days:
+        typeof args.days === "number" && Number.isFinite(args.days)
+            ? args.days
+            : SESSIONS_AROUND_DEFAULT_DAYS,
+    ...(args.project != null && args.project !== ""
+        ? { project: args.project }
+        : {}),
+});
+
 /**
  * List sessions in the window [date - days, date + days].
  *
@@ -202,7 +235,7 @@ export const listSessionsAround = (
 ): Effect.Effect<SessionRow[], DbError, SurrealClient | AxConfig> =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
-        const days = opts.days ?? 3;
+        const days = opts.days ?? SESSIONS_AROUND_DEFAULT_DAYS;
         const from = new Date(opts.date.getTime() - days * 24 * 60 * 60 * 1000);
         const to = new Date(opts.date.getTime() + days * 24 * 60 * 60 * 1000);
 

--- a/apps/axctl/src/dashboard/skills-weighted.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.ts
@@ -49,6 +49,43 @@ export interface SkillsWeightedParams {
     readonly includeTools?: boolean;
 }
 
+/** Shared defaults for the weighted-skills ranking (CLI + MCP). */
+export const SKILLS_WEIGHTED_DEFAULT_LIMIT = 25;
+export const SKILLS_WEIGHTED_DEFAULT_DOCTOR_THRESHOLD = 5;
+
+/**
+ * Transport-agnostic raw input. The CLI flag parser and the MCP zod handler
+ * decode into this then call {@link normalizeSkillsWeightedParams} so the
+ * limit/doctor-threshold/includeTools defaults live in one place.
+ *
+ * Positivity validation of `limit`, `windowDays`, and `doctorThreshold` stays
+ * in the transports (CLI `requirePositiveInt`/`requireOptionalPositiveInt`
+ * exit 2; MCP zod `.positive()` rejects at the edge); this only fills defaults
+ * + presence rules.
+ */
+export interface SkillsWeightedQueryArgs {
+    readonly windowDays?: number | undefined;
+    readonly limit?: number | undefined;
+    readonly doctorThreshold?: number | undefined;
+    readonly includeTools?: boolean | undefined;
+}
+
+export const normalizeSkillsWeightedParams = (
+    args: SkillsWeightedQueryArgs,
+): SkillsWeightedParams => ({
+    ...(args.windowDays !== undefined ? { windowDays: args.windowDays } : {}),
+    limit:
+        typeof args.limit === "number" && Number.isFinite(args.limit)
+            ? args.limit
+            : SKILLS_WEIGHTED_DEFAULT_LIMIT,
+    doctorThreshold:
+        typeof args.doctorThreshold === "number" &&
+        Number.isFinite(args.doctorThreshold)
+            ? args.doctorThreshold
+            : SKILLS_WEIGHTED_DEFAULT_DOCTOR_THRESHOLD,
+    includeTools: args.includeTools ?? false,
+});
+
 // ---------------------------------------------------------------------------
 // SQL helpers
 // ---------------------------------------------------------------------------
@@ -151,8 +188,9 @@ export const fetchSkillsWeighted = (
 ): Effect.Effect<SkillsWeightedResult, DbError, SurrealClient> =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
-        const limit = params.limit ?? 25;
-        const doctorThreshold = params.doctorThreshold ?? 5;
+        const limit = params.limit ?? SKILLS_WEIGHTED_DEFAULT_LIMIT;
+        const doctorThreshold =
+            params.doctorThreshold ?? SKILLS_WEIGHTED_DEFAULT_DOCTOR_THRESHOLD;
         const includeTools = params.includeTools ?? false;
 
         // Run passes + doctor + tombstone + synthetic-tool id queries concurrently.

--- a/apps/axctl/src/improve/list.ts
+++ b/apps/axctl/src/improve/list.ts
@@ -27,6 +27,36 @@ export interface ListProposalsInput {
     readonly limit?: number;    // default 30
 }
 
+/** Default proposal status filter ("all" disables it). Shared by CLI + MCP. */
+export const LIST_PROPOSALS_DEFAULT_STATUS = "open";
+/** Default row cap for the proposal shortlist. Shared by CLI + MCP. */
+export const LIST_PROPOSALS_DEFAULT_LIMIT = 30;
+
+/**
+ * Transport-agnostic raw input for `listProposals`. The CLI flag parser and the
+ * MCP zod schema both decode into this then call {@link normalizeListProposalsInput}
+ * so the status/limit defaults live in one place and cannot drift.
+ *
+ * `limit` positivity (CLI `requirePositiveInt`, MCP zod `.positive()`) stays in
+ * the transports; this only fills defaults + presence rules.
+ */
+export interface ListProposalsQueryArgs {
+    readonly status?: string | undefined;
+    readonly form?: string | undefined;
+    readonly limit?: number | undefined;
+}
+
+export const normalizeListProposalsInput = (
+    args: ListProposalsQueryArgs,
+): ListProposalsInput => ({
+    status: args.status ?? LIST_PROPOSALS_DEFAULT_STATUS,
+    ...(args.form !== undefined ? { form: args.form } : {}),
+    limit:
+        typeof args.limit === "number" && Number.isFinite(args.limit)
+            ? args.limit
+            : LIST_PROPOSALS_DEFAULT_LIMIT,
+});
+
 export const listProposals = (
     input: ListProposalsInput,
 ): Effect.Effect<ReadonlyArray<ProposalRow>, DbError, SurrealClient> =>

--- a/apps/axctl/src/improve/recommend.ts
+++ b/apps/axctl/src/improve/recommend.ts
@@ -18,6 +18,49 @@ export interface RecommendInput {
     readonly sinceDays?: number;
 }
 
+/**
+ * Transport-agnostic raw input for `recommend`. Both the CLI flag parser and
+ * the MCP zod schema decode their wire shapes into this, then call
+ * {@link normalizeRecommendInput} so the limit default + non-finite guards live
+ * in one place. The CLI and MCP apply DIFFERENT limit defaults (5 vs 10), so
+ * the default is a required parameter here rather than baked in - see
+ * `defaultLimit` below.
+ */
+export interface RecommendQueryArgs {
+    readonly limit?: number | undefined;
+    readonly forms?: ReadonlyArray<string> | undefined;
+    readonly agent?: "claude" | "codex" | undefined;
+    readonly sinceDays?: number | undefined;
+}
+
+/**
+ * Apply default limit + drop empty optional collections. Transports keep their
+ * own limit default (CLI 5, MCP 10) by passing `defaultLimit`; everything else
+ * (forms/agent/sinceDays presence rules) is shared semantics.
+ *
+ * Note: positivity/integer validation of `limit` and `sinceDays` stays in the
+ * transports (CLI `requirePositiveInt` exits 2 with usage wording; MCP zod
+ * rejects at the edge). This function only applies defaults + presence rules so
+ * the constructed {@link RecommendInput} cannot drift between callers.
+ */
+export const normalizeRecommendInput = (
+    args: RecommendQueryArgs,
+    defaultLimit: number,
+): RecommendInput => {
+    const limit =
+        typeof args.limit === "number" && Number.isFinite(args.limit)
+            ? args.limit
+            : defaultLimit;
+    const forms =
+        args.forms && args.forms.length > 0 ? args.forms : undefined;
+    return {
+        limit,
+        ...(forms !== undefined ? { forms } : {}),
+        ...(args.agent !== undefined ? { agent: args.agent } : {}),
+        ...(args.sinceDays !== undefined ? { sinceDays: args.sinceDays } : {}),
+    };
+};
+
 export interface RecommendItem {
     readonly shortId: string;
     readonly title: string;

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -20,28 +20,29 @@ import { Effect, type ManagedRuntime, type Layer } from "effect";
 import type { AppLayer } from "@ax/lib/layers";
 import {
     fetchRecall,
+    resolveRecallSources,
     type RecallParams,
     type RecallSource,
 } from "../dashboard/recall.ts";
 import {
     listSessionsAround,
-    type SessionsAroundOpts,
+    normalizeSessionsAroundOpts,
 } from "../dashboard/sessions-query.ts";
 import { fetchSessionShow } from "../dashboard/session-show.ts";
 import type { FetchSessionViewOptions } from "../dashboard/session-view.ts";
 import {
     fetchSkillsWeighted,
-    type SkillsWeightedParams,
+    normalizeSkillsWeightedParams,
 } from "../dashboard/skills-weighted.ts";
 import {
     fetchSkillsByRole,
     fetchRolesForSkill,
     fetchAllRoles,
-    type FetchSkillsByRoleParams,
+    normalizeSkillsByRoleParams,
 } from "../dashboard/role-queries.ts";
-import { recommend, type RecommendInput } from "../improve/recommend.ts";
+import { recommend, normalizeRecommendInput } from "../improve/recommend.ts";
 import { showExperiment } from "../improve/show.ts";
-import { listProposals, type ListProposalsInput } from "../improve/list.ts";
+import { listProposals, normalizeListProposalsInput } from "../improve/list.ts";
 import { fetchSessionMetrics } from "../metrics/session-metrics-query.ts";
 import { SIGNAL_CATALOG, findSignal, runRelationSignal } from "../metrics/catalog.ts";
 import {
@@ -124,7 +125,7 @@ const recallTool: AxMcpTool = {
 
         const result = await rt.runPromise(fetchRecall(params));
         const { hits, next } = buildRecallNext(result, {
-            requestedSources: params.sources ?? ["turn"],
+            requestedSources: resolveRecallSources(params.sources),
         });
         return { ...result, hits, next };
     },
@@ -157,11 +158,11 @@ const sessionsAroundTool: AxMcpTool = {
         }
         const days = typeof args.days === "number" ? args.days : undefined;
         const project = typeof args.project === "string" ? args.project : undefined;
-        const opts: SessionsAroundOpts = {
+        const opts = normalizeSessionsAroundOpts({
             date,
             ...(days !== undefined ? { days } : {}),
             ...(project !== undefined ? { project } : {}),
-        };
+        });
         const rows = await rt.runPromise(listSessionsAround(opts));
         return buildSessionsNext(rows, {
             date: dateStr,
@@ -231,10 +232,10 @@ const skillsWeightedTool: AxMcpTool = {
     run: async (args, rt) => {
         const windowDays = typeof args.windowDays === "number" ? args.windowDays : undefined;
         const limit = typeof args.limit === "number" ? args.limit : undefined;
-        const params: SkillsWeightedParams = {
+        const params = normalizeSkillsWeightedParams({
             ...(windowDays !== undefined ? { windowDays } : {}),
             ...(limit !== undefined ? { limit } : {}),
-        };
+        });
         const result = await rt.runPromise(fetchSkillsWeighted(params));
         return { ...result, next: buildSkillsWeightedNext(result) };
     },
@@ -258,10 +259,10 @@ const skillsByRoleTool: AxMcpTool = {
     run: async (args, rt) => {
         const role = String(args.role ?? "");
         const limit = typeof args.limit === "number" ? args.limit : undefined;
-        const params: FetchSkillsByRoleParams = {
+        const params = normalizeSkillsByRoleParams({
             role,
             ...(limit !== undefined ? { limit } : {}),
-        };
+        });
         const result = await rt.runPromise(fetchSkillsByRole(params));
         return { ...result, next: buildSkillsByRoleNext(result, role) };
     },
@@ -323,22 +324,26 @@ const improveRecommendTool: AxMcpTool = {
             .describe("Only proposals updated within the last N days."),
     },
     run: async (args, rt) => {
-        // `limit` is required on RecommendInput with no internal default - so
-        // default it to 10 here. cwd/project are deliberately not exposed (they
-        // are cwd-bound and meaningless at the MCP boundary).
-        const limit = typeof args.limit === "number" ? args.limit : 10;
+        // cwd/project are deliberately not exposed (they are cwd-bound and
+        // meaningless at the MCP boundary). The MCP limit default is 10 (the
+        // CLI's is 5) - both pass their own default into the shared normalizer,
+        // which is why `defaultLimit` is a parameter rather than baked in.
+        const limit = typeof args.limit === "number" ? args.limit : undefined;
         const forms = Array.isArray(args.forms)
             ? args.forms.map((v) => String(v))
             : undefined;
         const agent =
             args.agent === "claude" || args.agent === "codex" ? args.agent : undefined;
         const sinceDays = typeof args.sinceDays === "number" ? args.sinceDays : undefined;
-        const input: RecommendInput = {
-            limit,
-            ...(forms !== undefined ? { forms } : {}),
-            ...(agent !== undefined ? { agent } : {}),
-            ...(sinceDays !== undefined ? { sinceDays } : {}),
-        };
+        const input = normalizeRecommendInput(
+            {
+                ...(limit !== undefined ? { limit } : {}),
+                ...(forms !== undefined ? { forms } : {}),
+                ...(agent !== undefined ? { agent } : {}),
+                ...(sinceDays !== undefined ? { sinceDays } : {}),
+            },
+            10,
+        );
         const items = await rt.runPromise(recommend(input));
         const next = buildImproveProposalsNext(
             items.map((i) => ({ sig: i.shortId, title: i.title })),
@@ -387,11 +392,11 @@ const improveListTool: AxMcpTool = {
         const status = typeof args.status === "string" ? args.status : undefined;
         const form = typeof args.form === "string" ? args.form : undefined;
         const limit = typeof args.limit === "number" ? args.limit : undefined;
-        const input: ListProposalsInput = {
+        const input = normalizeListProposalsInput({
             ...(status !== undefined ? { status } : {}),
             ...(form !== undefined ? { form } : {}),
             ...(limit !== undefined ? { limit } : {}),
-        };
+        });
         const rows = await rt.runPromise(listProposals(input));
         const next = buildImproveProposalsNext(
             rows.map((r) => ({ sig: r.dedupe_sig, title: r.title })),

--- a/apps/axctl/src/queries/query-input-contract.test.ts
+++ b/apps/axctl/src/queries/query-input-contract.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Query Input Contract tests.
+ *
+ * Each query module that backs both a CLI command and an MCP tool exports a
+ * `normalize*` function that applies the shared argument semantics (defaults,
+ * presence rules) so the two transports cannot drift. These tests pin those
+ * semantics: defaults, divergent per-transport defaults, and how non-finite /
+ * empty inputs collapse to the canonical shape.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+    normalizeRecommendInput,
+} from "../improve/recommend.ts";
+import {
+    normalizeListProposalsInput,
+    LIST_PROPOSALS_DEFAULT_STATUS,
+    LIST_PROPOSALS_DEFAULT_LIMIT,
+} from "../improve/list.ts";
+import {
+    resolveRecallSources,
+    RECALL_DEFAULT_SOURCES,
+} from "../dashboard/recall.ts";
+import {
+    normalizeSessionsAroundOpts,
+    SESSIONS_AROUND_DEFAULT_DAYS,
+} from "../dashboard/sessions-query.ts";
+import {
+    normalizeSkillsWeightedParams,
+    SKILLS_WEIGHTED_DEFAULT_LIMIT,
+    SKILLS_WEIGHTED_DEFAULT_DOCTOR_THRESHOLD,
+} from "../dashboard/skills-weighted.ts";
+import {
+    normalizeSkillsByRoleParams,
+    SKILLS_BY_ROLE_DEFAULT_LIMIT,
+} from "../dashboard/role-queries.ts";
+
+// ---------------------------------------------------------------------------
+// recommend - DIVERGENT limit default (CLI 5, MCP 10)
+// ---------------------------------------------------------------------------
+
+describe("normalizeRecommendInput", () => {
+    test("applies the caller's default limit when limit is absent", () => {
+        expect(normalizeRecommendInput({}, 5).limit).toBe(5);
+        expect(normalizeRecommendInput({}, 10).limit).toBe(10);
+    });
+
+    test("a supplied limit overrides the caller default", () => {
+        expect(normalizeRecommendInput({ limit: 3 }, 10).limit).toBe(3);
+    });
+
+    test("non-finite limit falls back to the caller default", () => {
+        expect(normalizeRecommendInput({ limit: Number.NaN }, 5).limit).toBe(5);
+        expect(normalizeRecommendInput({ limit: Infinity }, 7).limit).toBe(7);
+    });
+
+    test("empty forms array is dropped, non-empty is kept", () => {
+        expect(normalizeRecommendInput({ forms: [] }, 5).forms).toBeUndefined();
+        expect(normalizeRecommendInput({ forms: ["skill"] }, 5).forms).toEqual([
+            "skill",
+        ]);
+    });
+
+    test("agent/sinceDays are only present when supplied", () => {
+        const bare = normalizeRecommendInput({}, 5);
+        expect("agent" in bare).toBe(false);
+        expect("sinceDays" in bare).toBe(false);
+        const full = normalizeRecommendInput(
+            { agent: "codex", sinceDays: 14 },
+            5,
+        );
+        expect(full.agent).toBe("codex");
+        expect(full.sinceDays).toBe(14);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// list proposals - shared status + limit defaults
+// ---------------------------------------------------------------------------
+
+describe("normalizeListProposalsInput", () => {
+    test("defaults status to open and limit to 30", () => {
+        const out = normalizeListProposalsInput({});
+        expect(out.status).toBe(LIST_PROPOSALS_DEFAULT_STATUS);
+        expect(out.status).toBe("open");
+        expect(out.limit).toBe(LIST_PROPOSALS_DEFAULT_LIMIT);
+        expect(out.limit).toBe(30);
+    });
+
+    test("explicit status (including 'all') and limit pass through", () => {
+        const out = normalizeListProposalsInput({ status: "all", limit: 5 });
+        expect(out.status).toBe("all");
+        expect(out.limit).toBe(5);
+    });
+
+    test("form is only present when supplied", () => {
+        expect("form" in normalizeListProposalsInput({})).toBe(false);
+        expect(normalizeListProposalsInput({ form: "hook" }).form).toBe("hook");
+    });
+
+    test("non-finite limit falls back to the default", () => {
+        expect(normalizeListProposalsInput({ limit: Number.NaN }).limit).toBe(30);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// recall - shared default source set
+// ---------------------------------------------------------------------------
+
+describe("resolveRecallSources", () => {
+    test("null/undefined/empty all resolve to the default [turn]", () => {
+        expect(resolveRecallSources(null)).toEqual(RECALL_DEFAULT_SOURCES);
+        expect(resolveRecallSources(undefined)).toEqual(["turn"]);
+        expect(resolveRecallSources([])).toEqual(["turn"]);
+    });
+
+    test("a non-empty requested set passes through unchanged", () => {
+        expect(resolveRecallSources(["commit", "skill"])).toEqual([
+            "commit",
+            "skill",
+        ]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// sessions around - shared half-width default
+// ---------------------------------------------------------------------------
+
+describe("normalizeSessionsAroundOpts", () => {
+    const date = new Date("2026-06-01T00:00:00.000Z");
+
+    test("defaults days to 3 and omits project when absent", () => {
+        const out = normalizeSessionsAroundOpts({ date });
+        expect(out.days).toBe(SESSIONS_AROUND_DEFAULT_DAYS);
+        expect(out.days).toBe(3);
+        expect("project" in out).toBe(false);
+        expect(out.date).toBe(date);
+    });
+
+    test("null/empty project is omitted, a real slug is kept", () => {
+        expect("project" in normalizeSessionsAroundOpts({ date, project: null })).toBe(
+            false,
+        );
+        expect("project" in normalizeSessionsAroundOpts({ date, project: "" })).toBe(
+            false,
+        );
+        expect(
+            normalizeSessionsAroundOpts({ date, project: "my-proj" }).project,
+        ).toBe("my-proj");
+    });
+
+    test("non-finite days falls back to 3, explicit days passes through", () => {
+        expect(normalizeSessionsAroundOpts({ date, days: Number.NaN }).days).toBe(3);
+        expect(normalizeSessionsAroundOpts({ date, days: 7 }).days).toBe(7);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// skills weighted - shared limit / doctor-threshold / includeTools defaults
+// ---------------------------------------------------------------------------
+
+describe("normalizeSkillsWeightedParams", () => {
+    test("applies shared defaults", () => {
+        const out = normalizeSkillsWeightedParams({});
+        expect(out.limit).toBe(SKILLS_WEIGHTED_DEFAULT_LIMIT);
+        expect(out.limit).toBe(25);
+        expect(out.doctorThreshold).toBe(SKILLS_WEIGHTED_DEFAULT_DOCTOR_THRESHOLD);
+        expect(out.doctorThreshold).toBe(5);
+        expect(out.includeTools).toBe(false);
+        expect("windowDays" in out).toBe(false);
+    });
+
+    test("supplied values pass through; windowDays only when present", () => {
+        const out = normalizeSkillsWeightedParams({
+            windowDays: 30,
+            limit: 10,
+            doctorThreshold: 8,
+            includeTools: true,
+        });
+        expect(out.windowDays).toBe(30);
+        expect(out.limit).toBe(10);
+        expect(out.doctorThreshold).toBe(8);
+        expect(out.includeTools).toBe(true);
+    });
+
+    test("non-finite limit / threshold collapse to defaults", () => {
+        const out = normalizeSkillsWeightedParams({
+            limit: Infinity,
+            doctorThreshold: Number.NaN,
+        });
+        expect(out.limit).toBe(25);
+        expect(out.doctorThreshold).toBe(5);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// skills by-role - shared limit default
+// ---------------------------------------------------------------------------
+
+describe("normalizeSkillsByRoleParams", () => {
+    test("defaults limit to 50 and carries the role through", () => {
+        const out = normalizeSkillsByRoleParams({ role: "execution" });
+        expect(out.role).toBe("execution");
+        expect(out.limit).toBe(SKILLS_BY_ROLE_DEFAULT_LIMIT);
+        expect(out.limit).toBe(50);
+    });
+
+    test("supplied limit overrides, non-finite falls back", () => {
+        expect(normalizeSkillsByRoleParams({ role: "r", limit: 12 }).limit).toBe(12);
+        expect(
+            normalizeSkillsByRoleParams({ role: "r", limit: Number.NaN }).limit,
+        ).toBe(50);
+    });
+});


### PR DESCRIPTION
## What

Make each MCP-paired query module the **single seam** for argument semantics so CLI flag parsing and MCP zod schemas can no longer drift on the *meaning* of an argument. Each module exports a `normalize*` function (plus default constants); both transports decode their wire shape locally, then delegate defaults / clamping / default-windows / presence-rules to the shared function.

Protocol decoding (CLI `Flag.*`, MCP zod) and user-facing error wording stay **transport-local** by design - the normalizers only fill defaults + presence rules, so each transport's validation and error text is byte-for-byte unchanged. Behavior-preserving: CLI output strings, `--json` envelopes, and MCP tool response shapes are identical.

## Modules with a shared normalizer

| Query | Normalizer | Shared semantics |
|-------|-----------|------------------|
| improve recommend | `normalizeRecommendInput(args, defaultLimit)` | limit default (**parameterized** - see divergence below), forms/agent/sinceDays presence |
| improve list | `normalizeListProposalsInput` | status `"open"`, limit `30` |
| recall | `resolveRecallSources` + `RECALL_DEFAULT_SOURCES` | the `["turn"]` default (now also used inside `fetchRecall`) |
| sessions around | `normalizeSessionsAroundOpts` | days `3`, project presence |
| skills weighted | `normalizeSkillsWeightedParams` | limit `25`, doctor-threshold `5`, includeTools `false` |
| skills by-role | `normalizeSkillsByRoleParams` | limit `50` |

## Preserved divergence (NOT unified)

- **`improve recommend` limit default**: the CLI defaults to **5**, the MCP `improve_recommend` tool defaults to **10**. This was already divergent before this PR. Rather than silently unify, `defaultLimit` is a required parameter of `normalizeRecommendInput`; the CLI passes `5`, the MCP passes `10`. A unit test pins both.

No other transport-default mismatches were found among the paired queries.

## Skipped (genuinely no duplicated semantics)

- **improve_show** (`{ sigOrId }`), **skills_roles** (`{ skill }`), **roles** (no input): the transports only coerce a string / pass nothing - there are no defaults, clamps, or windows to share.
- **session_show**: the two transports build the `expand` set **differently** (CLI trims + filters empty strings; MCP coerces each value via `String(...)`). Folding these into one normalizer would change matching behavior for one transport, which violates the "don't silently unify" rule, so it's left as-is.

## Tests

- New `apps/axctl/src/queries/query-input-contract.test.ts` pins every normalizer: defaults, the divergent recommend limit, explicit overrides, non-finite (`NaN`/`Infinity`) fallback to default, and empty-collection / null-project presence rules.
- Existing CLI, MCP, and dashboard query tests stay green. Full repo suite: 3864 pass / 0 fail. `tsc` clean; `check:no-node-fs` clean.

## Docs

Adds the **Query Input Contract** entry to `CONTEXT.md`'s Language section, immediately after **Insights Surface Contract**, following the existing entry format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)