### PR TITLE
feat: ax dojo - surplus-quota training loop (agenda CLI + skill)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,21 @@ cache. `--statusline` is one plain line for the Claude Code `statusLine` command
 `scripts/swiftbar/ax-quota.2m.sh`). Module: `apps/axctl/src/quota/` (QuotaEnv seam,
 Live/Test layers). No DB (runtime "none").
 
+### Dojo
+
+`ax dojo [--json] [--spar] [--budget=N] [--until=HH:MM] [--force] [--days=N]` -
+training agenda for the ax:dojo skill loop (burn surplus plan quota on
+self-improvement). Composes a budget envelope from the quota module (binding
+window remaining minus 15% reserve, deadline = earliest window reset) with a
+derived, self-clearing item list: pending verdicts, unfilled .ax/tasks briefs,
+judgment-flagged routing backtests, proposal minting (when open pool < 3),
+churn-hotspot experiments, opt-in spar (needs --spar AND >=30% spendable),
+explore fallback. Items vanish once the underlying system records the work
+(verdict locked / brief consumed / proposal created). State dirs:
+`~/.ax/dojo/outbox/` (upstream issue drafts, publish on review) and
+`~/.ax/dojo/reports/<date>.md`. Module: `apps/axctl/src/dojo/`. Spec:
+docs/superpowers/specs/2026-06-13-ax-dojo-design.md.
+
 ### Profile
 
 `ax profile show [--window=N] [--no-cost] [--json]` - render your local ax

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ ax hooks install ~/.ax/hooks/my-guard.ts --providers=claude,codex
 Two integration paths, same graph:
 
 ```bash
-npx skills add Necmttn/ax           # agent skills: setup, retro, extract-workflow, …
+npx skills add Necmttn/ax           # agent skills: setup, retro, extract-workflow, dojo, …
 claude mcp add ax -- ax mcp         # MCP server: read-only graph queries as tools
 ```
 

--- a/apps/axctl/src/cli/commands/dojo.test.ts
+++ b/apps/axctl/src/cli/commands/dojo.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { untilToIso } from "./dojo.ts";
+
+describe("untilToIso", () => {
+    const NOW = Date.parse("2026-06-13T10:00:00.000Z");
+    test("future time today", () => {
+        expect(untilToIso("23:30", NOW)).toMatch(/T\d{2}:30:00/);
+    });
+    test("past time rolls to tomorrow", () => {
+        const iso = untilToIso("01:00", NOW)!;
+        expect(Date.parse(iso)).toBeGreaterThan(NOW);
+    });
+    test("garbage returns null", () => {
+        expect(untilToIso("late", NOW)).toBeNull();
+    });
+});

--- a/apps/axctl/src/cli/commands/dojo.test.ts
+++ b/apps/axctl/src/cli/commands/dojo.test.ts
@@ -13,4 +13,8 @@ describe("untilToIso", () => {
     test("garbage returns null", () => {
         expect(untilToIso("late", NOW)).toBeNull();
     });
+    test("out-of-range hours/minutes return null", () => {
+        expect(untilToIso("25:00", NOW)).toBeNull();
+        expect(untilToIso("0:60", NOW)).toBeNull();
+    });
 });

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -26,8 +26,11 @@ import { jsonFlag } from "./shared.ts";
 export const untilToIso = (until: string, nowMs: number): string | null => {
     const m = /^(\d{1,2}):(\d{2})$/.exec(until);
     if (!m) return null;
+    const h = Number(m[1]);
+    const min = Number(m[2]);
+    if (h > 23 || min > 59) return null;
     const d = new Date(nowMs);
-    d.setHours(Number(m[1]), Number(m[2]), 0, 0);
+    d.setHours(h, min, 0, 0);
     if (d.getTime() <= nowMs) d.setDate(d.getDate() + 1);
     return d.toISOString();
 };
@@ -53,11 +56,15 @@ export const dojoCommand = Command.make(
                 Effect.map((r) => r.snapshot),
                 Effect.catch(() => Effect.succeed(null)), // budget degrades, agenda still renders
             );
+            const untilIso = until ? untilToIso(until, nowMs) : null;
+            if (until && untilIso === null) {
+                console.error("ax dojo: invalid --until, expected HH:MM"); // degrade, don't fail
+            }
             const envelope = computeBudgetEnvelope(
                 quota,
                 {
                     budgetPctOverride: budget > 0 ? budget : null,
-                    untilIso: until ? untilToIso(until, nowMs) : null,
+                    untilIso,
                     force,
                 },
                 nowMs,
@@ -69,7 +76,7 @@ export const dojoCommand = Command.make(
     },
 ).pipe(
     Command.withDescription(
-        "Training agenda: quota budget envelope + prioritized self-improvement work items (consumed by the ax:dojo skill loop)",
+        "Training agenda: quota budget envelope + prioritized self-improvement work items (--budget=N, --until=HH:MM, --spar, --force, --days=N, --json; consumed by the ax:dojo skill loop)",
     ),
 );
 

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -1,0 +1,78 @@
+/**
+ * `ax dojo` - budget envelope + prioritized training agenda for the
+ * ax:dojo skill loop. Spec: docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+ *
+ *   ax dojo            human agenda
+ *   ax dojo --json     DojoAgenda JSON (consumed by the skill each lap)
+ *
+ * The quota snapshot is fetched with error tolerance: if the usage endpoint
+ * (and cache) are unavailable, the budget degrades to "unavailable" but the
+ * agenda still renders - the items are derived from the local graph, not the
+ * quota API.
+ */
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { prettyPrint } from "@ax/lib/json";
+import { assembleAgenda, collectAgendaItems } from "../../dojo/agenda.ts";
+import { computeBudgetEnvelope } from "../../dojo/budget.ts";
+import { renderAgenda } from "../../dojo/format.ts";
+import { defaultQuotaCachePath } from "../../quota/cache.ts";
+import { QuotaEnvLive } from "../../quota/quota-env.ts";
+import { getQuota } from "../../quota/quota.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { jsonFlag } from "./shared.ts";
+
+/** "HH:MM" today (or tomorrow when already past) -> ISO */
+export const untilToIso = (until: string, nowMs: number): string | null => {
+    const m = /^(\d{1,2}):(\d{2})$/.exec(until);
+    if (!m) return null;
+    const d = new Date(nowMs);
+    d.setHours(Number(m[1]), Number(m[2]), 0, 0);
+    if (d.getTime() <= nowMs) d.setDate(d.getDate() + 1);
+    return d.toISOString();
+};
+
+export const dojoCommand = Command.make(
+    "dojo",
+    {
+        json: jsonFlag,
+        budget: Flag.integer("budget").pipe(Flag.withDefault(0)), // 0 = unset
+        until: Flag.string("until").pipe(Flag.withDefault("")),
+        force: Flag.boolean("force").pipe(Flag.withDefault(false)),
+        spar: Flag.boolean("spar").pipe(Flag.withDefault(false)),
+        days: Flag.integer("days").pipe(Flag.withDefault(30)),
+    },
+    ({ json, budget, until, force, spar, days }) => {
+        const nowMs = Date.now();
+        return Effect.gen(function* () {
+            const quota = yield* getQuota({
+                cachePath: defaultQuotaCachePath(),
+                maxAgeSeconds: 60,
+                nowMs,
+            }).pipe(
+                Effect.map((r) => r.snapshot),
+                Effect.catch(() => Effect.succeed(null)), // budget degrades, agenda still renders
+            );
+            const envelope = computeBudgetEnvelope(
+                quota,
+                {
+                    budgetPctOverride: budget > 0 ? budget : null,
+                    untilIso: until ? untilToIso(until, nowMs) : null,
+                    force,
+                },
+                nowMs,
+            );
+            const items = yield* collectAgendaItems({ nowMs, days, spar });
+            const agenda = assembleAgenda(envelope, items, { nowMs, spar });
+            console.log(json ? prettyPrint(agenda) : renderAgenda(agenda));
+        }).pipe(Effect.provide(QuotaEnvLive));
+    },
+).pipe(
+    Command.withDescription(
+        "Training agenda: quota budget envelope + prioritized self-improvement work items (consumed by the ax:dojo skill loop)",
+    ),
+);
+
+export const dojoRuntime: RuntimeManifest = {
+    dojo: "db",
+};

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -17,6 +17,7 @@ import { dogfoodCommand, dogfoodRuntime } from "./commands/dogfood.ts";
 import { costsGroupCommand, locCommand, pricingCommand, costsRuntime } from "./commands/costs.ts";
 import { costCommand, axCostRuntime } from "./commands/ax-cost.ts";
 import { quotaCommand, quotaRuntime } from "./commands/quota.ts";
+import { dojoCommand, dojoRuntime } from "./commands/dojo.ts";
 import { profileCommand, axProfileRuntime } from "./commands/profile.ts";
 import { dispatchesRootCommand, axDispatchesRuntime } from "./commands/ax-dispatches.ts";
 import { routingRootCommand, axRoutingRuntime } from "./commands/ax-routing.ts";
@@ -79,6 +80,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...costsRuntime,
     ...axCostRuntime,
     ...quotaRuntime,
+    ...dojoRuntime,
     ...axProfileRuntime,
     ...axDispatchesRuntime,
     ...axRoutingRuntime,
@@ -120,6 +122,7 @@ const registeredCommands: ReadonlyArray<Command.Command.Any> = [
     setupCommand,
     costCommand,
     quotaCommand,
+    dojoCommand,
     profileCommand,
     dispatchesRootCommand,
     routingRootCommand,

--- a/apps/axctl/src/dojo/agenda.test.ts
+++ b/apps/axctl/src/dojo/agenda.test.ts
@@ -48,11 +48,21 @@ describe("assembleAgenda", () => {
         );
         expect(fat.items.some((i) => i.kind === "spar")).toBe(true);
     });
+
+    test("spar gate boundary: spendable exactly 30 includes spar (>=)", () => {
+        const edge = assembleAgenda(
+            { ...budget, spendable_pct: 30 },
+            [item("v1", "verdict_pending")],
+            { nowMs: 0, spar: true },
+        );
+        expect(edge.items.some((i) => i.kind === "spar")).toBe(true);
+    });
 });
 
 describe("collectAgendaItems", () => {
-    // Every query returns one empty result set - an empty graph. fetchDispatches
-    // destructures a 4-tuple, but each missing slot degrades to [] internally.
+    // Every query returns one empty result set - an empty graph. fetchTuneProposals
+    // (which calls fetchDispatches internally) destructures a 4-tuple, but each
+    // missing slot degrades to [] internally.
     const emptyClient: SurrealClientShape = {
         query: <T extends unknown[]>(_sql: string, _bindings?: Record<string, unknown>) =>
             Effect.succeed([[]] as unknown[] as T),

--- a/apps/axctl/src/dojo/agenda.test.ts
+++ b/apps/axctl/src/dojo/agenda.test.ts
@@ -1,0 +1,81 @@
+// apps/axctl/src/dojo/agenda.test.ts
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect, Layer } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import type { Surreal } from "surrealdb";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { assembleAgenda, collectAgendaItems } from "./agenda.ts";
+import type { BudgetEnvelope, DojoItem } from "./schema.ts";
+
+const budget: BudgetEnvelope = {
+    has_surplus: true, spendable_pct: 20, binding_window: "five_hour",
+    window_remaining_pct: 35, reserve_pct: 15,
+    deadline: "2026-06-13T12:00:00.000Z", source: "quota",
+};
+
+const item = (id: string, kind: DojoItem["kind"]): DojoItem => ({
+    id, kind, title: id, commands: ["true"], success: "done", cost_class: "s",
+});
+
+describe("assembleAgenda", () => {
+    test("sorts by kind priority and stamps generated_at", () => {
+        const agenda = assembleAgenda(
+            budget,
+            [item("e1", "experiment"), item("v1", "verdict_pending"), item("b1", "brief_unfilled")],
+            { nowMs: Date.parse("2026-06-13T10:00:00.000Z"), spar: false },
+        );
+        expect(agenda.v).toBe(1);
+        expect(agenda.generated_at).toBe("2026-06-13T10:00:00.000Z");
+        expect(agenda.items.map((i) => i.id)).toEqual(["v1", "b1", "e1"]);
+    });
+
+    test("appends explore when otherwise empty", () => {
+        const agenda = assembleAgenda(budget, [], { nowMs: 0, spar: false });
+        expect(agenda.items).toHaveLength(1);
+        expect(agenda.items[0]?.kind).toBe("explore");
+    });
+
+    test("spar included only when requested AND spendable >= 30", () => {
+        const none = assembleAgenda(budget, [item("v1", "verdict_pending")], { nowMs: 0, spar: true });
+        expect(none.items.some((i) => i.kind === "spar")).toBe(false); // spendable 20 < 30
+        const fat = assembleAgenda(
+            { ...budget, spendable_pct: 40 },
+            [item("v1", "verdict_pending")],
+            { nowMs: 0, spar: true },
+        );
+        expect(fat.items.some((i) => i.kind === "spar")).toBe(true);
+    });
+});
+
+describe("collectAgendaItems", () => {
+    // Every query returns one empty result set - an empty graph. fetchDispatches
+    // destructures a 4-tuple, but each missing slot degrades to [] internally.
+    const emptyClient: SurrealClientShape = {
+        query: <T extends unknown[]>(_sql: string, _bindings?: Record<string, unknown>) =>
+            Effect.succeed([[]] as unknown[] as T),
+        upsert: () => Effect.void,
+        relate: () => Effect.void,
+        putFile: () => Effect.void,
+        getFile: () => Effect.succeed(""),
+        raw: null as unknown as Surreal, // never touched by read-only agenda sources
+    };
+    const env = Layer.mergeAll(Layer.succeed(SurrealClient, emptyClient), BunFileSystem.layer);
+
+    test("empty graph + missing task dir -> only the proposal-mint nudge", async () => {
+        const base = mkdtempSync(join(tmpdir(), "ax-dojo-agenda-"));
+        const items = await Effect.runPromise(
+            collectAgendaItems({
+                nowMs: Date.parse("2026-06-13T10:00:00.000Z"),
+                days: 30,
+                spar: false,
+                taskDir: join(base, "does-not-exist"),
+                routingTablePath: join(base, "missing-routing-table.json"),
+            }).pipe(Effect.provide(env)),
+        );
+        // 0 open proposals < MINT_THRESHOLD, so the mint nudge is the lone item.
+        expect(items.map((i) => i.kind)).toEqual(["proposal_mint"]);
+    });
+});

--- a/apps/axctl/src/dojo/agenda.ts
+++ b/apps/axctl/src/dojo/agenda.ts
@@ -88,7 +88,7 @@ const soft = <A, E, R>(
  */
 export const collectAgendaItems = (
     opts: CollectOptions,
-): Effect.Effect<DojoItem[], never, SurrealClient | FileSystem.FileSystem> =>
+): Effect.Effect<readonly DojoItem[], never, SurrealClient | FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const verdicts = yield* soft("verdicts", listPendingVerdicts(), []);
         const briefs = yield* soft("briefs", scanTaskDir(opts.taskDir ?? defaultTaskDir()), []);

--- a/apps/axctl/src/dojo/agenda.ts
+++ b/apps/axctl/src/dojo/agenda.ts
@@ -1,0 +1,122 @@
+/**
+ * ax dojo - agenda assembly. Spec: docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+ *
+ * `assembleAgenda` is the pure, tested core: budget + flat item list -> ordered
+ * agenda (priority sort, spar gate, explore fallback). `collectAgendaItems` is
+ * the Effect glue that runs every source with per-source failure isolation: a
+ * broken source logs to stderr and contributes nothing - it must never kill
+ * the whole agenda.
+ */
+import { Effect, type FileSystem } from "effect";
+import type { SurrealClient } from "@ax/lib/db";
+import { listProposals } from "../improve/list.ts";
+import { listPendingVerdicts } from "../improve/verdict-pending.ts";
+import { fetchSessionChurnSummary, type SessionChurnRow } from "../metrics/session-churn.ts";
+import { loadEffectiveRoutingTable } from "../queries/routing-table-io.ts";
+import { fetchTuneProposals, type TuneProposal } from "../queries/routing-tune.ts";
+import { defaultTaskDir, scanTaskDir } from "./briefs.ts";
+import {
+    churnHotspotItems,
+    exploreItem,
+    pendingVerdictItems,
+    proposalMintItem,
+    routingBacktestItems,
+    sparItem,
+} from "./items.ts";
+import type { BudgetEnvelope, DojoAgenda, DojoItem } from "./schema.ts";
+import { compareByPriority } from "./schema.ts";
+
+export const SPAR_MIN_SPENDABLE_PCT = 30;
+
+export interface AssembleOptions {
+    readonly nowMs: number;
+    readonly spar: boolean;
+}
+
+/** Pure: budget + flat item list -> ordered agenda. */
+export const assembleAgenda = (
+    budget: BudgetEnvelope,
+    items: readonly DojoItem[],
+    opts: AssembleOptions,
+): DojoAgenda => {
+    const sorted = [...items].sort(compareByPriority);
+    if (opts.spar && budget.spendable_pct >= SPAR_MIN_SPENDABLE_PCT) sorted.push(sparItem());
+    if (sorted.length === 0) sorted.push(exploreItem());
+    return {
+        v: 1,
+        generated_at: new Date(opts.nowMs).toISOString(),
+        budget,
+        items: sorted,
+    };
+};
+
+export interface CollectOptions {
+    readonly nowMs: number;
+    /** lookback window (days) for churn + routing tune */
+    readonly days: number;
+    readonly spar: boolean;
+    /** override for tests; defaults to AX_TASK_DIR ?? $PWD/.ax/tasks */
+    readonly taskDir?: string;
+    /** override for tests; defaults to ~/.ax/hooks/routing-table.json */
+    readonly routingTablePath?: string;
+}
+
+const DAY_MS = 86_400_000;
+
+/** Hot-session rows to consider before churnHotspotItems trims to its top 2. */
+const CHURN_SESSION_LIMIT = 20;
+
+/** Per-source failure isolation: log the failure, contribute the empty value. */
+const soft = <A, E, R>(
+    label: string,
+    eff: Effect.Effect<A, E, R>,
+    empty: A,
+): Effect.Effect<A, never, R> =>
+    eff.pipe(
+        Effect.catch((e) =>
+            Effect.sync(() => {
+                console.error(`dojo: source ${label} failed: ${String(e)}`);
+                return empty;
+            }),
+        ),
+    );
+
+/**
+ * Run every agenda source and flatten into items. Sources soft-fail
+ * independently, so the error channel is `never`; requirements are exactly
+ * what the underlying queries need (DB reads + task-dir/routing-table reads).
+ */
+export const collectAgendaItems = (
+    opts: CollectOptions,
+): Effect.Effect<DojoItem[], never, SurrealClient | FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const verdicts = yield* soft("verdicts", listPendingVerdicts(), []);
+        const briefs = yield* soft("briefs", scanTaskDir(opts.taskDir ?? defaultTaskDir()), []);
+        const churnRows = yield* soft(
+            "churn",
+            fetchSessionChurnSummary({
+                since: new Date(opts.nowMs - opts.days * DAY_MS),
+                limit: CHURN_SESSION_LIMIT,
+            }).pipe(Effect.map((summary): readonly SessionChurnRow[] => summary.hotSessions)),
+            [],
+        );
+        const open = yield* soft("proposals", listProposals({ status: "open" }), []);
+        const tune = yield* soft(
+            "routing",
+            Effect.gen(function* () {
+                const table = yield* loadEffectiveRoutingTable(opts.routingTablePath);
+                return yield* fetchTuneProposals({ sinceDays: opts.days, table });
+            }),
+            [] as TuneProposal[],
+        );
+
+        const items: DojoItem[] = [
+            ...pendingVerdictItems(verdicts),
+            ...briefs,
+            ...routingBacktestItems(tune, opts.days),
+            ...churnHotspotItems(churnRows),
+        ];
+        const mint = proposalMintItem(open.length);
+        if (mint) items.push(mint);
+        return items;
+    });

--- a/apps/axctl/src/dojo/briefs.test.ts
+++ b/apps/axctl/src/dojo/briefs.test.ts
@@ -1,6 +1,14 @@
 // apps/axctl/src/dojo/briefs.test.ts
 import { describe, expect, test } from "bun:test";
-import { classifyBriefFile } from "./briefs.ts";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { classifyBriefFile, scanTaskDir } from "./briefs.ts";
+
+const runScan = (dir: string) =>
+    Effect.runPromise(scanTaskDir(dir).pipe(Effect.provide(BunFileSystem.layer)));
 
 describe("classifyBriefFile", () => {
     test("classify brief without primary_role is an unfilled item", () => {
@@ -39,5 +47,30 @@ describe("classifyBriefFile", () => {
 
     test("non-markdown files return null", () => {
         expect(classifyBriefFile(".DS_Store", "")).toBeNull();
+    });
+});
+
+describe("scanTaskDir", () => {
+    test("missing dir yields no items", async () => {
+        const base = mkdtempSync(join(tmpdir(), "ax-dojo-briefs-"));
+        const items = await runScan(join(base, "does-not-exist"));
+        expect(items).toEqual([]);
+    });
+
+    test("scans a real dir: one unfilled classify brief among filled + junk", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-dojo-briefs-"));
+        writeFileSync(
+            join(dir, "classify-superpowers__tdd.md"),
+            "---\nax_classify: superpowers:tdd\nprimary_role:\n---\n",
+        );
+        writeFileSync(
+            join(dir, "classify-superpowers__done.md"),
+            "---\nax_classify: superpowers:done\nprimary_role: verifier\n---\n",
+        );
+        writeFileSync(join(dir, ".DS_Store"), "");
+        const items = await runScan(dir);
+        expect(items).toHaveLength(1);
+        expect(items[0]?.id).toBe("brief:classify-superpowers__tdd.md");
+        expect(items[0]?.kind).toBe("brief_unfilled");
     });
 });

--- a/apps/axctl/src/dojo/briefs.test.ts
+++ b/apps/axctl/src/dojo/briefs.test.ts
@@ -1,6 +1,6 @@
 // apps/axctl/src/dojo/briefs.test.ts
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Effect } from "effect";
@@ -72,5 +72,17 @@ describe("scanTaskDir", () => {
         expect(items).toHaveLength(1);
         expect(items[0]?.id).toBe("brief:classify-superpowers__tdd.md");
         expect(items[0]?.kind).toBe("brief_unfilled");
+    });
+
+    test("subdirectory in the task dir is skipped, not a fatal BadResource", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-dojo-briefs-"));
+        mkdirSync(join(dir, "some-subdir.md")); // .md-named dir: worst case for the old read path
+        writeFileSync(
+            join(dir, "classify-superpowers__tdd.md"),
+            "---\nax_classify: superpowers:tdd\nprimary_role:\n---\n",
+        );
+        const items = await runScan(dir);
+        expect(items).toHaveLength(1);
+        expect(items[0]?.id).toBe("brief:classify-superpowers__tdd.md");
     });
 });

--- a/apps/axctl/src/dojo/briefs.test.ts
+++ b/apps/axctl/src/dojo/briefs.test.ts
@@ -1,0 +1,43 @@
+// apps/axctl/src/dojo/briefs.test.ts
+import { describe, expect, test } from "bun:test";
+import { classifyBriefFile } from "./briefs.ts";
+
+describe("classifyBriefFile", () => {
+    test("classify brief without primary_role is an unfilled item", () => {
+        const item = classifyBriefFile("classify-superpowers__tdd.md", "---\nax_classify: superpowers:tdd\nprimary_role:\n---\n");
+        expect(item).not.toBeNull();
+        expect(item?.kind).toBe("brief_unfilled");
+        expect(item?.id).toBe("brief:classify-superpowers__tdd.md");
+        expect(item?.commands).toEqual([
+            "$EDITOR .ax/tasks/classify-superpowers__tdd.md  # fill primary_role + rationale",
+            "ax skills lint",
+        ]);
+    });
+
+    test("classify brief WITH primary_role filled returns null (nothing to do)", () => {
+        const item = classifyBriefFile(
+            "classify-superpowers__tdd.md",
+            "---\nax_classify: superpowers:tdd\nprimary_role: verifier\n---\n",
+        );
+        expect(item).toBeNull();
+    });
+
+    test("routing-tune brief is an open routing_backtest item", () => {
+        const item = classifyBriefFile("routing-tune-2026-06-10.md", "| id | pattern |\n");
+        expect(item?.kind).toBe("routing_backtest");
+        expect(item?.commands).toContain("ax routing tune --apply=<ids from brief> --days=30");
+    });
+
+    test("improve accept brief is an unfilled item pointing at improve lint", () => {
+        const item = classifyBriefFile("a1b2c3d4.md", "---\nax_id: a1b2c3d4\n---\n");
+        expect(item?.kind).toBe("brief_unfilled");
+        expect(item?.commands).toEqual([
+            "$EDITOR .ax/tasks/a1b2c3d4.md  # act on the brief in the target files",
+            "ax improve lint",
+        ]);
+    });
+
+    test("non-markdown files return null", () => {
+        expect(classifyBriefFile(".DS_Store", "")).toBeNull();
+    });
+});

--- a/apps/axctl/src/dojo/briefs.ts
+++ b/apps/axctl/src/dojo/briefs.ts
@@ -1,0 +1,71 @@
+import { Effect, FileSystem } from "effect";
+import { posixPath } from "@ax/lib/shared/path";
+import type { DojoItem } from "./schema.ts";
+
+const FILLED_PRIMARY_ROLE = /^primary_role:[^\S\n]*\S/m;
+
+/** Pure: filename + content -> open agenda item, or null when nothing to do. */
+export const classifyBriefFile = (name: string, content: string): DojoItem | null => {
+    if (!name.endsWith(".md")) return null;
+    if (name.startsWith("classify-")) {
+        if (FILLED_PRIMARY_ROLE.test(content)) return null; // filled, skills lint will sweep it
+        return {
+            id: `brief:${name}`,
+            kind: "brief_unfilled",
+            title: `Fill skills-classify brief ${name}`,
+            commands: [
+                `$EDITOR .ax/tasks/${name}  # fill primary_role + rationale`,
+                "ax skills lint",
+            ],
+            success: "brief consumed by ax skills lint (file deleted, plays_role edges written)",
+            cost_class: "s",
+        };
+    }
+    if (name.startsWith("routing-tune-")) {
+        return {
+            id: `brief:${name}`,
+            kind: "routing_backtest",
+            title: `Backtest + apply routing-tune brief ${name}`,
+            commands: [
+                `$EDITOR .ax/tasks/${name}  # review judgment-flagged classes, backtest vs history`,
+                "ax routing tune --apply=<ids from brief> --days=30",
+            ],
+            success: "selected classes applied to ~/.ax/hooks/routing-table.json; brief resolved",
+            cost_class: "m",
+        };
+    }
+    return {
+        id: `brief:${name}`,
+        kind: "brief_unfilled",
+        title: `Act on improve brief ${name}`,
+        commands: [
+            `$EDITOR .ax/tasks/${name}  # act on the brief in the target files`,
+            "ax improve lint",
+        ],
+        success: "marker landed in target file; ax improve lint deletes the brief",
+        cost_class: "m",
+    };
+};
+
+/** Effect glue: scan the task dir (AX_TASK_DIR ?? $PWD/.ax/tasks) into items. */
+export const scanTaskDir = (
+    taskDir: string,
+): Effect.Effect<DojoItem[], never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const exists = yield* fs.exists(taskDir).pipe(Effect.orElseSucceed(() => false));
+        if (!exists) return [];
+        const names = yield* fs.readDirectory(taskDir).pipe(Effect.orElseSucceed(() => []));
+        const items: DojoItem[] = [];
+        for (const name of names) {
+            const content = yield* fs
+                .readFileString(posixPath.join(taskDir, name))
+                .pipe(Effect.orElseSucceed(() => ""));
+            const item = classifyBriefFile(name, content);
+            if (item) items.push(item);
+        }
+        return items;
+    });
+
+export const defaultTaskDir = (): string =>
+    process.env.AX_TASK_DIR ?? posixPath.join(process.cwd(), ".ax", "tasks");

--- a/apps/axctl/src/dojo/briefs.ts
+++ b/apps/axctl/src/dojo/briefs.ts
@@ -1,4 +1,5 @@
-import { Effect, FileSystem } from "effect";
+import { Effect, FileSystem, type PlatformError } from "effect";
+import { orAbsent, skipNotFound } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
 import type { DojoItem } from "./schema.ts";
 
@@ -28,6 +29,8 @@ export const classifyBriefFile = (name: string, content: string): DojoItem | nul
             title: `Backtest + apply routing-tune brief ${name}`,
             commands: [
                 `$EDITOR .ax/tasks/${name}  # review judgment-flagged classes, backtest vs history`,
+                // v0 limitation: --days=30 is a static default; once brief content is
+                // parsed, this should carry the brief's own --days window instead.
                 "ax routing tune --apply=<ids from brief> --days=30",
             ],
             success: "selected classes applied to ~/.ax/hooks/routing-table.json; brief resolved",
@@ -47,20 +50,29 @@ export const classifyBriefFile = (name: string, content: string): DojoItem | nul
     };
 };
 
-/** Effect glue: scan the task dir (AX_TASK_DIR ?? $PWD/.ax/tasks) into items. */
+/**
+ * Effect glue: scan the task dir (AX_TASK_DIR ?? $PWD/.ax/tasks) into items.
+ *
+ * Discovery probes (exists/readDirectory) use `orAbsent` - a missing or
+ * unreadable dir means "no open briefs". The per-file content read uses
+ * `skipNotFound(null)` + skip-on-null: a brief that vanished mid-scan is
+ * SKIPPED (never classified from an empty string into a spurious unfilled
+ * item); any other read fault (permission, IO) re-raises so real data is
+ * never silently dropped.
+ */
 export const scanTaskDir = (
     taskDir: string,
-): Effect.Effect<DojoItem[], never, FileSystem.FileSystem> =>
+): Effect.Effect<DojoItem[], PlatformError.PlatformError, FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        const exists = yield* fs.exists(taskDir).pipe(Effect.orElseSucceed(() => false));
-        if (!exists) return [];
-        const names = yield* fs.readDirectory(taskDir).pipe(Effect.orElseSucceed(() => []));
+        if (!(yield* fs.exists(taskDir).pipe(orAbsent(false)))) return [];
+        const names = yield* fs.readDirectory(taskDir).pipe(orAbsent([] as string[]));
         const items: DojoItem[] = [];
         for (const name of names) {
             const content = yield* fs
                 .readFileString(posixPath.join(taskDir, name))
-                .pipe(Effect.orElseSucceed(() => ""));
+                .pipe(skipNotFound(null));
+            if (content === null) continue; // vanished mid-scan - skip, don't misclassify
             const item = classifyBriefFile(name, content);
             if (item) items.push(item);
         }

--- a/apps/axctl/src/dojo/briefs.ts
+++ b/apps/axctl/src/dojo/briefs.ts
@@ -1,4 +1,5 @@
 import { Effect, FileSystem, type PlatformError } from "effect";
+import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
 import { orAbsent, skipNotFound } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
 import type { DojoItem } from "./schema.ts";
@@ -54,11 +55,14 @@ export const classifyBriefFile = (name: string, content: string): DojoItem | nul
  * Effect glue: scan the task dir (AX_TASK_DIR ?? $PWD/.ax/tasks) into items.
  *
  * Discovery probes (exists/readDirectory) use `orAbsent` - a missing or
- * unreadable dir means "no open briefs". The per-file content read uses
- * `skipNotFound(null)` + skip-on-null: a brief that vanished mid-scan is
- * SKIPPED (never classified from an empty string into a spurious unfilled
- * item); any other read fault (permission, IO) re-raises so real data is
- * never silently dropped.
+ * unreadable dir means "no open briefs". Each entry is classified first
+ * (`classifyNoFollow`, the house pattern from ingest) and non-files
+ * (subdirectories, symlinks) are skipped - readFileString on a directory
+ * raises BadResource and would otherwise kill the whole source. The per-file
+ * content read uses `skipNotFound(null)` + skip-on-null: a brief that
+ * vanished mid-scan is SKIPPED (never classified from an empty string into a
+ * spurious unfilled item); any other read fault (permission, IO) re-raises so
+ * real data is never silently dropped.
  */
 export const scanTaskDir = (
     taskDir: string,
@@ -69,9 +73,10 @@ export const scanTaskDir = (
         const names = yield* fs.readDirectory(taskDir).pipe(orAbsent([] as string[]));
         const items: DojoItem[] = [];
         for (const name of names) {
-            const content = yield* fs
-                .readFileString(posixPath.join(taskDir, name))
-                .pipe(skipNotFound(null));
+            const path = posixPath.join(taskDir, name);
+            const kind = yield* classifyNoFollow(path);
+            if (kind !== "File") continue; // subdir/symlink/etc - not a brief
+            const content = yield* fs.readFileString(path).pipe(skipNotFound(null));
             if (content === null) continue; // vanished mid-scan - skip, don't misclassify
             const item = classifyBriefFile(name, content);
             if (item) items.push(item);

--- a/apps/axctl/src/dojo/budget.test.ts
+++ b/apps/axctl/src/dojo/budget.test.ts
@@ -1,0 +1,75 @@
+// apps/axctl/src/dojo/budget.test.ts
+import { describe, expect, test } from "bun:test";
+import type { QuotaSnapshot } from "../quota/schema.ts";
+import { computeBudgetEnvelope } from "./budget.ts";
+
+const NOW_MS = Date.parse("2026-06-13T10:00:00.000Z");
+
+const snapshot = (fiveHourUtil: number, sevenDayUtil: number): QuotaSnapshot => ({
+    v: 1,
+    fetched_at: "2026-06-13T09:59:00.000Z",
+    five_hour: { utilization: fiveHourUtil, resets_at: "2026-06-13T12:00:00.000Z" },
+    seven_day: { utilization: sevenDayUtil, resets_at: "2026-06-15T00:00:00.000Z" },
+    seven_day_opus: null,
+    seven_day_sonnet: null,
+    extra_usage: null,
+});
+
+describe("computeBudgetEnvelope", () => {
+    test("binding window is the one with least remaining; reserve subtracted", () => {
+        const env = computeBudgetEnvelope(snapshot(40, 70), {}, NOW_MS);
+        expect(env.binding_window).toBe("seven_day");
+        expect(env.window_remaining_pct).toBe(30);
+        expect(env.reserve_pct).toBe(15);
+        expect(env.spendable_pct).toBe(15);
+        expect(env.has_surplus).toBe(true);
+        expect(env.deadline).toBe("2026-06-13T12:00:00.000Z"); // earliest reset
+        expect(env.source).toBe("quota");
+    });
+
+    test("no surplus when remaining <= reserve", () => {
+        const env = computeBudgetEnvelope(snapshot(95, 50), {}, NOW_MS);
+        expect(env.binding_window).toBe("five_hour");
+        expect(env.spendable_pct).toBe(0);
+        expect(env.has_surplus).toBe(false);
+    });
+
+    test("--budget override caps spendable but never exceeds remaining", () => {
+        const env = computeBudgetEnvelope(snapshot(40, 70), { budgetPctOverride: 50 }, NOW_MS);
+        expect(env.spendable_pct).toBe(30); // min(50, remaining 30)
+        expect(env.source).toBe("override");
+    });
+
+    test("--until override replaces the deadline", () => {
+        const env = computeBudgetEnvelope(
+            snapshot(40, 70),
+            { untilIso: "2026-06-13T11:30:00.000Z" },
+            NOW_MS,
+        );
+        expect(env.deadline).toBe("2026-06-13T11:30:00.000Z");
+    });
+
+    test("force grants a floor budget when there is no surplus", () => {
+        const env = computeBudgetEnvelope(snapshot(99, 99), { force: true }, NOW_MS);
+        expect(env.has_surplus).toBe(true);
+        expect(env.spendable_pct).toBe(1); // whatever actually remains
+        expect(env.source).toBe("forced");
+    });
+
+    test("null snapshot (no token / fetch failed): unavailable, no surplus unless forced", () => {
+        const env = computeBudgetEnvelope(null, {}, NOW_MS);
+        expect(env.has_surplus).toBe(false);
+        expect(env.source).toBe("unavailable");
+        expect(env.binding_window).toBeNull();
+        const forced = computeBudgetEnvelope(null, { force: true }, NOW_MS);
+        expect(forced.has_surplus).toBe(true);
+        expect(forced.source).toBe("forced");
+    });
+
+    test("missing windows are skipped; lone five_hour window binds", () => {
+        const snap: QuotaSnapshot = { ...snapshot(80, 0), seven_day: null };
+        const env = computeBudgetEnvelope(snap, {}, NOW_MS);
+        expect(env.binding_window).toBe("five_hour");
+        expect(env.window_remaining_pct).toBe(20);
+    });
+});

--- a/apps/axctl/src/dojo/budget.test.ts
+++ b/apps/axctl/src/dojo/budget.test.ts
@@ -61,9 +61,21 @@ describe("computeBudgetEnvelope", () => {
         expect(env.has_surplus).toBe(false);
         expect(env.source).toBe("unavailable");
         expect(env.binding_window).toBeNull();
+        expect(env.deadline).toBe(new Date(NOW_MS).toISOString());
         const forced = computeBudgetEnvelope(null, { force: true }, NOW_MS);
         expect(forced.has_surplus).toBe(true);
         expect(forced.source).toBe("forced");
+    });
+
+    test("forced with null snapshot: deadline falls back to 2h after now, --until still wins", () => {
+        const forced = computeBudgetEnvelope(null, { force: true }, NOW_MS);
+        expect(forced.deadline).toBe(new Date(NOW_MS + 2 * 60 * 60 * 1000).toISOString());
+        const until = computeBudgetEnvelope(
+            null,
+            { force: true, untilIso: "2026-06-13T11:30:00.000Z" },
+            NOW_MS,
+        );
+        expect(until.deadline).toBe("2026-06-13T11:30:00.000Z");
     });
 
     test("missing windows are skipped; lone five_hour window binds", () => {

--- a/apps/axctl/src/dojo/budget.ts
+++ b/apps/axctl/src/dojo/budget.ts
@@ -1,0 +1,78 @@
+import type { QuotaSnapshot } from "../quota/schema.ts";
+import type { BindingWindow, BudgetEnvelope } from "./schema.ts";
+
+export const DEFAULT_RESERVE_PCT = 15;
+
+export interface BudgetOptions {
+    /** keep this many percentage points untouched (default 15) */
+    readonly reservePct?: number;
+    /** --budget=N : spend at most N points, replaces reserve math */
+    readonly budgetPctOverride?: number | null;
+    /** --until resolved to ISO by the CLI layer */
+    readonly untilIso?: string | null;
+    /** --force : dojo with no surplus */
+    readonly force?: boolean;
+}
+
+export const computeBudgetEnvelope = (
+    snapshot: QuotaSnapshot | null,
+    opts: BudgetOptions,
+    nowMs: number,
+): BudgetEnvelope => {
+    const reserve = opts.reservePct ?? DEFAULT_RESERVE_PCT;
+
+    const windows: Array<{ name: BindingWindow; remaining: number; resetsAt: string }> = [];
+    if (snapshot?.five_hour) {
+        windows.push({
+            name: "five_hour",
+            remaining: Math.max(0, 100 - snapshot.five_hour.utilization),
+            resetsAt: snapshot.five_hour.resets_at,
+        });
+    }
+    if (snapshot?.seven_day) {
+        windows.push({
+            name: "seven_day",
+            remaining: Math.max(0, 100 - snapshot.seven_day.utilization),
+            resetsAt: snapshot.seven_day.resets_at,
+        });
+    }
+
+    if (windows.length === 0) {
+        return {
+            has_surplus: opts.force === true,
+            spendable_pct: 0,
+            binding_window: null,
+            window_remaining_pct: 0,
+            reserve_pct: reserve,
+            deadline: opts.untilIso ?? new Date(nowMs).toISOString(),
+            source: opts.force === true ? "forced" : "unavailable",
+        };
+    }
+
+    const binding = windows.reduce((min, w) => (w.remaining < min.remaining ? w : min));
+    const earliestReset = windows.reduce((min, w) =>
+        Date.parse(w.resetsAt) < Date.parse(min.resetsAt) ? w : min,
+    ).resetsAt;
+
+    const fromReserve = Math.max(0, binding.remaining - reserve);
+    const overridden = opts.budgetPctOverride != null
+        ? Math.min(opts.budgetPctOverride, binding.remaining)
+        : null;
+    let spendable = overridden ?? fromReserve;
+    let source: BudgetEnvelope["source"] = overridden != null ? "override" : "quota";
+
+    if (spendable <= 0 && opts.force === true) {
+        spendable = Math.max(1, binding.remaining);
+        source = "forced";
+    }
+
+    return {
+        has_surplus: spendable > 0,
+        spendable_pct: spendable,
+        binding_window: binding.name,
+        window_remaining_pct: binding.remaining,
+        reserve_pct: reserve,
+        deadline: opts.untilIso ?? earliestReset,
+        source,
+    };
+};

--- a/apps/axctl/src/dojo/budget.ts
+++ b/apps/axctl/src/dojo/budget.ts
@@ -3,6 +3,9 @@ import type { BindingWindow, BudgetEnvelope } from "./schema.ts";
 
 export const DEFAULT_RESERVE_PCT = 15;
 
+/** Forced training window when quota is unreachable: 2 hours from now. */
+export const FORCED_FALLBACK_WINDOW_MS = 2 * 60 * 60 * 1000;
+
 export interface BudgetOptions {
     /** keep this many percentage points untouched (default 15) */
     readonly reservePct?: number;
@@ -44,7 +47,8 @@ export const computeBudgetEnvelope = (
             binding_window: null,
             window_remaining_pct: 0,
             reserve_pct: reserve,
-            deadline: opts.untilIso ?? new Date(nowMs).toISOString(),
+            deadline: opts.untilIso
+                ?? new Date(opts.force === true ? nowMs + FORCED_FALLBACK_WINDOW_MS : nowMs).toISOString(),
             source: opts.force === true ? "forced" : "unavailable",
         };
     }

--- a/apps/axctl/src/dojo/format.test.ts
+++ b/apps/axctl/src/dojo/format.test.ts
@@ -30,6 +30,14 @@ describe("renderAgenda", () => {
         expect(out).toContain("   done when: locked");
     });
 
+    test("null binding window renders the no-window label", () => {
+        const out = renderAgenda({
+            ...agenda,
+            budget: { ...agenda.budget, binding_window: null },
+        });
+        expect(out).toContain("budget: 20% spendable (no window, 35% left, 15% reserve)");
+    });
+
     test("no-surplus agenda warns about --force", () => {
         const out = renderAgenda({
             ...agenda,

--- a/apps/axctl/src/dojo/format.test.ts
+++ b/apps/axctl/src/dojo/format.test.ts
@@ -1,0 +1,41 @@
+// apps/axctl/src/dojo/format.test.ts
+import { describe, expect, test } from "bun:test";
+import type { DojoAgenda } from "./schema.ts";
+import { renderAgenda } from "./format.ts";
+
+const agenda: DojoAgenda = {
+    v: 1,
+    generated_at: "2026-06-13T10:00:00.000Z",
+    budget: {
+        has_surplus: true, spendable_pct: 20, binding_window: "five_hour",
+        window_remaining_pct: 35, reserve_pct: 15,
+        deadline: "2026-06-13T12:00:00.000Z", source: "quota",
+    },
+    items: [
+        {
+            id: "verdict:experiment:aaa", kind: "verdict_pending",
+            title: "Lock verdict: Stop bare bun test",
+            commands: ["ax improve verdict aaa"], success: "locked", cost_class: "s",
+        },
+    ],
+};
+
+describe("renderAgenda", () => {
+    test("renders budget line + item rows", () => {
+        const out = renderAgenda(agenda);
+        expect(out).toContain("budget: 20% spendable (5h window, 35% left, 15% reserve)");
+        expect(out).toContain("deadline 2026-06-13T12:00");
+        expect(out).toContain("1. [verdict_pending/s] Lock verdict: Stop bare bun test");
+        expect(out).toContain("   $ ax improve verdict aaa");
+        expect(out).toContain("   done when: locked");
+    });
+
+    test("no-surplus agenda warns about --force", () => {
+        const out = renderAgenda({
+            ...agenda,
+            budget: { ...agenda.budget, has_surplus: false, spendable_pct: 0 },
+        });
+        expect(out).toContain("no surplus");
+        expect(out).toContain("--force");
+    });
+});

--- a/apps/axctl/src/dojo/format.ts
+++ b/apps/axctl/src/dojo/format.ts
@@ -1,0 +1,28 @@
+/**
+ * ax dojo - human-readable agenda renderer.
+ * Spec: docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+ */
+import type { DojoAgenda } from "./schema.ts";
+
+const windowLabel = (w: DojoAgenda["budget"]["binding_window"]): string =>
+    w === "five_hour" ? "5h window" : w === "seven_day" ? "7d window" : "no window";
+
+export const renderAgenda = (agenda: DojoAgenda): string => {
+    const b = agenda.budget;
+    const lines: string[] = [];
+    lines.push(
+        `budget: ${b.spendable_pct}% spendable (${windowLabel(b.binding_window)}, ` +
+        `${b.window_remaining_pct}% left, ${b.reserve_pct}% reserve) - ` +
+        `deadline ${b.deadline.slice(0, 16)} [${b.source}]`,
+    );
+    if (!b.has_surplus) {
+        lines.push("no surplus in the current window - dojo will not start without --force");
+    }
+    lines.push("");
+    agenda.items.forEach((item, i) => {
+        lines.push(`${i + 1}. [${item.kind}/${item.cost_class}] ${item.title}`);
+        for (const cmd of item.commands) lines.push(`   $ ${cmd}`);
+        lines.push(`   done when: ${item.success}`);
+    });
+    return lines.join("\n");
+};

--- a/apps/axctl/src/dojo/items.test.ts
+++ b/apps/axctl/src/dojo/items.test.ts
@@ -98,6 +98,14 @@ describe("item mappers", () => {
         expect(items[0]?.cost_class).toBe("l");
     });
 
+    test("churn hotspots: repair-only branch - all episodes passed but repair LOC over threshold", () => {
+        const items = churnHotspotItems([
+            churnRow("s5", 2, 2, 300), // episodes === passedEpisodes, repair > threshold -> included
+            churnRow("s6", 2, 2, 100), // episodes === passedEpisodes, repair under threshold -> excluded
+        ]);
+        expect(items.map((i) => i.id)).toEqual(["experiment:s5"]);
+    });
+
     test("proposal mint emitted only when open proposals are scarce", () => {
         expect(proposalMintItem(0)).not.toBeNull();
         expect(proposalMintItem(2)).not.toBeNull();

--- a/apps/axctl/src/dojo/items.test.ts
+++ b/apps/axctl/src/dojo/items.test.ts
@@ -1,0 +1,112 @@
+// apps/axctl/src/dojo/items.test.ts
+import { describe, expect, test } from "bun:test";
+import type { SessionChurnRow } from "../metrics/session-churn.ts";
+import type { TuneProposal } from "../queries/routing-tune.ts";
+import {
+    churnHotspotItems,
+    exploreItem,
+    MINT_THRESHOLD,
+    pendingVerdictItems,
+    proposalMintItem,
+    routingBacktestItems,
+    sparItem,
+} from "./items.ts";
+
+const tune = (
+    id: string,
+    pattern: string,
+    count: number,
+    cost: number,
+    judgment: boolean,
+): TuneProposal => ({
+    id,
+    pattern,
+    flags: "i",
+    suggest: "sonnet",
+    reason: `mined: ${count} dispatches, $${cost.toFixed(2)} addressable`,
+    count,
+    total_cost_usd: cost,
+    examples: [],
+    judgment,
+});
+
+const churnRow = (
+    session: string,
+    episodes: number,
+    passed: number,
+    repair: number,
+): SessionChurnRow => ({
+    session,
+    source: "claude",
+    taskLabel: `task ${session}`,
+    landedLinesAdded: 0,
+    landedLinesRemoved: 0,
+    editLinesAdded: 0,
+    editLinesRemoved: 0,
+    repairLinesAdded: repair,
+    repairLinesRemoved: 0,
+    editEvents: 0,
+    verificationFailures: episodes,
+    verificationPasses: passed,
+    episodes,
+    passedEpisodes: passed,
+    topCheck: "typecheck",
+});
+
+describe("item mappers", () => {
+    test("pending verdicts -> verdict_pending items with improve verdict commands", () => {
+        const items = pendingVerdictItems([
+            { id: "experiment:aaa", title: "Stop bare bun test", status: "scaffolded" },
+        ]);
+        expect(items).toEqual([
+            {
+                id: "verdict:experiment:aaa",
+                kind: "verdict_pending",
+                title: "Lock verdict: Stop bare bun test",
+                commands: ["ax improve verdict aaa", "ax improve verdict aaa --set <verdict>"],
+                success: "experiment.locked_verdict set",
+                cost_class: "s",
+            },
+        ]);
+    });
+
+    test("judgment-flagged tune proposals -> routing_backtest items; non-judgment skipped", () => {
+        const items = routingBacktestItems(
+            [
+                tune("rt1", "^review", 5, 4.2, true),
+                tune("rt2", "^fmt", 3, 0.4, false),
+            ],
+            30,
+        );
+        expect(items).toHaveLength(1);
+        expect(items[0]?.id).toBe("routing:rt1");
+        expect(items[0]?.commands).toEqual([
+            "ax routing tune --days=30 --emit-brief",
+            "ax routing tune --apply=rt1 --days=30",
+        ]);
+    });
+
+    test("churn hotspots: only sessions with failed episodes, top 2, cost l", () => {
+        const items = churnHotspotItems([
+            churnRow("s1", 4, 1, 500),
+            churnRow("s2", 0, 0, 0), // clean - skipped
+            churnRow("s3", 6, 2, 900),
+            churnRow("s4", 2, 1, 100),
+        ]);
+        expect(items.map((i) => i.id)).toEqual(["experiment:s3", "experiment:s1"]); // by repair desc, top 2
+        expect(items[0]?.kind).toBe("experiment");
+        expect(items[0]?.cost_class).toBe("l");
+    });
+
+    test("proposal mint emitted only when open proposals are scarce", () => {
+        expect(proposalMintItem(0)).not.toBeNull();
+        expect(proposalMintItem(2)).not.toBeNull();
+        expect(proposalMintItem(MINT_THRESHOLD)).toBeNull();
+    });
+
+    test("spar + explore singletons", () => {
+        expect(sparItem().kind).toBe("spar");
+        expect(sparItem().cost_class).toBe("xl");
+        expect(exploreItem().kind).toBe("explore");
+    });
+});

--- a/apps/axctl/src/dojo/items.test.ts
+++ b/apps/axctl/src/dojo/items.test.ts
@@ -56,14 +56,14 @@ const churnRow = (
 describe("item mappers", () => {
     test("pending verdicts -> verdict_pending items with improve verdict commands", () => {
         const items = pendingVerdictItems([
-            { id: "experiment:aaa", title: "Stop bare bun test", status: "scaffolded" },
+            { id: "experiment:aaa", sig: "sig-aaa", title: "Stop bare bun test", status: "scaffolded" },
         ]);
         expect(items).toEqual([
             {
                 id: "verdict:experiment:aaa",
                 kind: "verdict_pending",
                 title: "Lock verdict: Stop bare bun test",
-                commands: ["ax improve verdict aaa", "ax improve verdict aaa --set <verdict>"],
+                commands: ["ax improve verdict sig-aaa", "ax improve verdict sig-aaa --set <verdict>"],
                 success: "experiment.locked_verdict set",
                 cost_class: "s",
             },
@@ -96,6 +96,9 @@ describe("item mappers", () => {
         expect(items.map((i) => i.id)).toEqual(["experiment:s3", "experiment:s1"]); // by repair desc, top 2
         expect(items[0]?.kind).toBe("experiment");
         expect(items[0]?.cost_class).toBe("l");
+        // worktree path/branch are session-derived so the two items never collide
+        expect(items[0]?.commands).toContain("git worktree add .claude/worktrees/dojo-s3 -b dojo/s3");
+        expect(items[1]?.commands).toContain("git worktree add .claude/worktrees/dojo-s1 -b dojo/s1");
     });
 
     test("churn hotspots: repair-only branch - all episodes passed but repair LOC over threshold", () => {

--- a/apps/axctl/src/dojo/items.ts
+++ b/apps/axctl/src/dojo/items.ts
@@ -10,16 +10,14 @@ import type { SessionChurnRow } from "../metrics/session-churn.ts";
 import type { TuneProposal } from "../queries/routing-tune.ts";
 import type { DojoItem } from "./schema.ts";
 
-const shortId = (recordId: string): string => recordId.split(":").pop() ?? recordId;
-
 export const pendingVerdictItems = (rows: readonly PendingVerdictRow[]): DojoItem[] =>
     rows.map((r) => ({
         id: `verdict:${r.id}`,
         kind: "verdict_pending",
         title: `Lock verdict: ${r.title}`,
         commands: [
-            `ax improve verdict ${shortId(r.id)}`,
-            `ax improve verdict ${shortId(r.id)} --set <verdict>`,
+            `ax improve verdict ${r.sig}`,
+            `ax improve verdict ${r.sig} --set <verdict>`,
         ],
         success: "experiment.locked_verdict set",
         cost_class: "s",
@@ -61,6 +59,10 @@ export const proposalMintItem = (openProposalCount: number): DojoItem | null =>
 /** Repair LOC above this marks a session a churn hotspot even when every episode passed. */
 export const REPAIR_LINE_HOTSPOT_THRESHOLD = 200;
 
+/** Last 8 chars of the session id, sanitized to [a-z0-9-] for worktree/branch names. */
+const sessionShort = (session: string): string =>
+    session.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(-8);
+
 export const churnHotspotItems = (rows: readonly SessionChurnRow[]): DojoItem[] =>
     rows
         .filter((r) => r.episodes > r.passedEpisodes || r.repairLinesAdded > REPAIR_LINE_HOTSPOT_THRESHOLD)
@@ -72,7 +74,7 @@ export const churnHotspotItems = (rows: readonly SessionChurnRow[]): DojoItem[] 
             title: `Worktree experiment: reduce ${r.topCheck} churn (${r.taskLabel})`,
             commands: [
                 `ax sessions show ${r.session}`,
-                "git worktree add .claude/worktrees/dojo-experiment -b dojo/experiment",
+                `git worktree add .claude/worktrees/dojo-${sessionShort(r.session)} -b dojo/${sessionShort(r.session)}`,
                 "ax improve recommend  # package the result as a proposal",
             ],
             success: "experiment branch + evidence captured as an improve proposal",

--- a/apps/axctl/src/dojo/items.ts
+++ b/apps/axctl/src/dojo/items.ts
@@ -58,9 +58,12 @@ export const proposalMintItem = (openProposalCount: number): DojoItem | null =>
             cost_class: "m",
         };
 
+/** Repair LOC above this marks a session a churn hotspot even when every episode passed. */
+export const REPAIR_LINE_HOTSPOT_THRESHOLD = 200;
+
 export const churnHotspotItems = (rows: readonly SessionChurnRow[]): DojoItem[] =>
     rows
-        .filter((r) => r.episodes > r.passedEpisodes || r.repairLinesAdded > 200)
+        .filter((r) => r.episodes > r.passedEpisodes || r.repairLinesAdded > REPAIR_LINE_HOTSPOT_THRESHOLD)
         .sort((a, b) => b.repairLinesAdded - a.repairLinesAdded)
         .slice(0, 2)
         .map((r) => ({

--- a/apps/axctl/src/dojo/items.ts
+++ b/apps/axctl/src/dojo/items.ts
@@ -1,0 +1,98 @@
+/**
+ * ax dojo - pure row -> DojoItem mappers for every agenda source.
+ * Spec: docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+ *
+ * All mappers are pure: query outputs in, agenda items out. The Effect glue
+ * that actually runs the queries lives in agenda.ts.
+ */
+import type { PendingVerdictRow } from "../improve/verdict-pending.ts";
+import type { SessionChurnRow } from "../metrics/session-churn.ts";
+import type { TuneProposal } from "../queries/routing-tune.ts";
+import type { DojoItem } from "./schema.ts";
+
+const shortId = (recordId: string): string => recordId.split(":").pop() ?? recordId;
+
+export const pendingVerdictItems = (rows: readonly PendingVerdictRow[]): DojoItem[] =>
+    rows.map((r) => ({
+        id: `verdict:${r.id}`,
+        kind: "verdict_pending",
+        title: `Lock verdict: ${r.title}`,
+        commands: [
+            `ax improve verdict ${shortId(r.id)}`,
+            `ax improve verdict ${shortId(r.id)} --set <verdict>`,
+        ],
+        success: "experiment.locked_verdict set",
+        cost_class: "s",
+    }));
+
+/** Judgment-flagged proposals only: non-judgment ones auto-apply via `ax routing tune`. */
+export const routingBacktestItems = (
+    proposals: readonly TuneProposal[],
+    days: number,
+): DojoItem[] =>
+    proposals
+        .filter((p) => p.judgment)
+        .map((p) => ({
+            id: `routing:${p.id}`,
+            kind: "routing_backtest",
+            title: `Backtest routing class ${p.pattern} (${p.count} dispatches, $${p.total_cost_usd.toFixed(2)})`,
+            commands: [
+                `ax routing tune --days=${days} --emit-brief`,
+                `ax routing tune --apply=${p.id} --days=${days}`,
+            ],
+            success: "class applied to routing table (origin: user) or rejected with rationale",
+            cost_class: "m",
+        }));
+
+export const MINT_THRESHOLD = 3;
+
+export const proposalMintItem = (openProposalCount: number): DojoItem | null =>
+    openProposalCount >= MINT_THRESHOLD
+        ? null
+        : {
+            id: "mint:improve-recommend",
+            kind: "proposal_mint",
+            title: "Mint new improvement proposals (open pool is low)",
+            commands: ["ax improve recommend", "ax improve accept <id>"],
+            success: "new open proposals exist; accepted ones emitted .ax/tasks briefs",
+            cost_class: "m",
+        };
+
+export const churnHotspotItems = (rows: readonly SessionChurnRow[]): DojoItem[] =>
+    rows
+        .filter((r) => r.episodes > r.passedEpisodes || r.repairLinesAdded > 200)
+        .sort((a, b) => b.repairLinesAdded - a.repairLinesAdded)
+        .slice(0, 2)
+        .map((r) => ({
+            id: `experiment:${r.session}`,
+            kind: "experiment",
+            title: `Worktree experiment: reduce ${r.topCheck} churn (${r.taskLabel})`,
+            commands: [
+                `ax sessions show ${r.session}`,
+                "git worktree add .claude/worktrees/dojo-experiment -b dojo/experiment",
+                "ax improve recommend  # package the result as a proposal",
+            ],
+            success: "experiment branch + evidence captured as an improve proposal",
+            cost_class: "l",
+        }));
+
+export const sparItem = (): DojoItem => ({
+    id: "spar:campaign",
+    kind: "spar",
+    title: "Sparring: one task, one delta, scored (see skill playbook)",
+    commands: [
+        "ax sessions here --days=30  # pick a landed task as baseline",
+        "git worktree add .claude/worktrees/dojo-spar <parent-sha>",
+    ],
+    success: "spar report appended to the dojo report; goal package updated",
+    cost_class: "xl",
+});
+
+export const exploreItem = (): DojoItem => ({
+    id: "explore:retro-meta",
+    kind: "explore",
+    title: "Agenda dry - free investigation (retro-meta style)",
+    commands: ["ax recall <hunch> --scope=all", "ax sessions churn --since=30"],
+    success: "at least one new outbox draft, proposal, or goal package",
+    cost_class: "l",
+});

--- a/apps/axctl/src/dojo/paths.test.ts
+++ b/apps/axctl/src/dojo/paths.test.ts
@@ -1,0 +1,17 @@
+// apps/axctl/src/dojo/paths.test.ts
+import { describe, expect, test } from "bun:test";
+import { dojoOutboxDir, dojoReportPath, dojoReportsDir } from "./paths.ts";
+
+describe("dojo paths", () => {
+    test("derive from an injectable base dir", () => {
+        expect(dojoOutboxDir("/tmp/axhome/.ax/dojo")).toBe("/tmp/axhome/.ax/dojo/outbox");
+        expect(dojoReportsDir("/tmp/axhome/.ax/dojo")).toBe("/tmp/axhome/.ax/dojo/reports");
+        expect(dojoReportPath("2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
+            "/tmp/axhome/.ax/dojo/reports/2026-06-13.md",
+        );
+    });
+
+    test("default base ends with /.ax/dojo", () => {
+        expect(dojoOutboxDir()).toMatch(/\/\.ax\/dojo\/outbox$/);
+    });
+});

--- a/apps/axctl/src/dojo/paths.ts
+++ b/apps/axctl/src/dojo/paths.ts
@@ -1,7 +1,8 @@
+import { homedir } from "node:os";
 import { posixPath } from "@ax/lib/shared/path";
 
 export const defaultDojoDir = (): string =>
-    posixPath.join(process.env.HOME ?? "~", ".ax", "dojo");
+    posixPath.join(homedir(), ".ax", "dojo");
 
 export const dojoOutboxDir = (base: string = defaultDojoDir()): string =>
     posixPath.join(base, "outbox");

--- a/apps/axctl/src/dojo/paths.ts
+++ b/apps/axctl/src/dojo/paths.ts
@@ -1,0 +1,14 @@
+import { posixPath } from "@ax/lib/shared/path";
+
+export const defaultDojoDir = (): string =>
+    posixPath.join(process.env.HOME ?? "~", ".ax", "dojo");
+
+export const dojoOutboxDir = (base: string = defaultDojoDir()): string =>
+    posixPath.join(base, "outbox");
+
+export const dojoReportsDir = (base: string = defaultDojoDir()): string =>
+    posixPath.join(base, "reports");
+
+/** date is YYYY-MM-DD */
+export const dojoReportPath = (date: string, base: string = defaultDojoDir()): string =>
+    posixPath.join(dojoReportsDir(base), `${date}.md`);

--- a/apps/axctl/src/dojo/schema.test.ts
+++ b/apps/axctl/src/dojo/schema.test.ts
@@ -1,0 +1,28 @@
+// apps/axctl/src/dojo/schema.test.ts
+import { describe, expect, test } from "bun:test";
+import { compareByPriority, KIND_PRIORITY } from "./schema.ts";
+
+describe("KIND_PRIORITY", () => {
+    test("orders kinds per spec (cheap + high-signal first)", () => {
+        expect(KIND_PRIORITY).toEqual([
+            "verdict_pending",
+            "brief_unfilled",
+            "routing_backtest",
+            "proposal_mint",
+            "experiment",
+            "upstream_draft",
+            "spar",
+            "explore",
+        ]);
+    });
+
+    test("compareByPriority sorts items by kind order, stable within kind", () => {
+        const items = [
+            { id: "b", kind: "experiment" },
+            { id: "a", kind: "verdict_pending" },
+            { id: "c", kind: "verdict_pending" },
+        ] as const;
+        const sorted = [...items].sort(compareByPriority);
+        expect(sorted.map((i) => i.id)).toEqual(["a", "c", "b"]);
+    });
+});

--- a/apps/axctl/src/dojo/schema.ts
+++ b/apps/axctl/src/dojo/schema.ts
@@ -1,0 +1,63 @@
+/**
+ * ax dojo - agenda types. Spec: docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+ */
+
+export type DojoCostClass = "s" | "m" | "l" | "xl";
+
+export type DojoItemKind =
+    | "verdict_pending"
+    | "brief_unfilled"
+    | "routing_backtest"
+    | "proposal_mint"
+    | "experiment"
+    | "upstream_draft"
+    | "spar"
+    | "explore";
+
+export const KIND_PRIORITY: readonly DojoItemKind[] = [
+    "verdict_pending",
+    "brief_unfilled",
+    "routing_backtest",
+    "proposal_mint",
+    "experiment",
+    "upstream_draft",
+    "spar",
+    "explore",
+];
+
+export interface DojoItem {
+    readonly id: string;
+    readonly kind: DojoItemKind;
+    readonly title: string;
+    /** exact CLI invocations the executing agent runs for this item */
+    readonly commands: readonly string[];
+    /** observable completion criterion - what makes this item vanish from the next agenda */
+    readonly success: string;
+    readonly cost_class: DojoCostClass;
+}
+
+export type BindingWindow = "five_hour" | "seven_day";
+
+export interface BudgetEnvelope {
+    readonly has_surplus: boolean;
+    /** spendable percentage points of the binding window after reserve */
+    readonly spendable_pct: number;
+    readonly binding_window: BindingWindow | null;
+    readonly window_remaining_pct: number;
+    readonly reserve_pct: number;
+    /** ISO datetime - earliest window reset, or the --until override */
+    readonly deadline: string;
+    readonly source: "quota" | "override" | "forced" | "unavailable";
+}
+
+export interface DojoAgenda {
+    readonly v: 1;
+    readonly generated_at: string;
+    readonly budget: BudgetEnvelope;
+    readonly items: readonly DojoItem[];
+}
+
+export const compareByPriority = (
+    a: Pick<DojoItem, "kind">,
+    b: Pick<DojoItem, "kind">,
+): number => KIND_PRIORITY.indexOf(a.kind) - KIND_PRIORITY.indexOf(b.kind);

--- a/apps/axctl/src/improve/verdict-pending.test.ts
+++ b/apps/axctl/src/improve/verdict-pending.test.ts
@@ -12,9 +12,11 @@ const layerWith = (...fixtures: unknown[][]) => {
 
 describe("listPendingVerdicts", () => {
     test("returns experiments lacking locked_verdict with their proposal title", async () => {
+        // created_at is in the projection only to satisfy SurrealDB's
+        // ORDER BY rules; the query must strip it from returned rows.
         const layer = layerWith([
-            { id: "experiment:aaa", title: "Stop using bare bun test", status: "scaffolded" },
-            { id: "experiment:bbb", title: "Guard worktree merges", status: "task_emitted" },
+            { id: "experiment:aaa", title: "Stop using bare bun test", status: "scaffolded", created_at: "2026-01-01T00:00:00Z" },
+            { id: "experiment:bbb", title: "Guard worktree merges", status: "task_emitted", created_at: "2026-01-01T00:00:00Z" },
         ]);
         const rows = await Effect.runPromise(
             listPendingVerdicts().pipe(Effect.provide(layer)),
@@ -23,6 +25,7 @@ describe("listPendingVerdicts", () => {
             { id: "experiment:aaa", title: "Stop using bare bun test", status: "scaffolded" },
             { id: "experiment:bbb", title: "Guard worktree merges", status: "task_emitted" },
         ]);
+        expect(rows[0]).not.toHaveProperty("created_at");
     });
 
     test("returns [] when no experiments are pending", async () => {

--- a/apps/axctl/src/improve/verdict-pending.test.ts
+++ b/apps/axctl/src/improve/verdict-pending.test.ts
@@ -15,15 +15,15 @@ describe("listPendingVerdicts", () => {
         // created_at is in the projection only to satisfy SurrealDB's
         // ORDER BY rules; the query must strip it from returned rows.
         const layer = layerWith([
-            { id: "experiment:aaa", title: "Stop using bare bun test", status: "scaffolded", created_at: "2026-01-01T00:00:00Z" },
-            { id: "experiment:bbb", title: "Guard worktree merges", status: "task_emitted", created_at: "2026-01-01T00:00:00Z" },
+            { id: "experiment:aaa", sig: "sig-aaa", title: "Stop using bare bun test", status: "scaffolded", created_at: "2026-01-01T00:00:00Z" },
+            { id: "experiment:bbb", sig: "sig-bbb", title: "Guard worktree merges", status: "task_emitted", created_at: "2026-01-01T00:00:00Z" },
         ]);
         const rows = await Effect.runPromise(
             listPendingVerdicts().pipe(Effect.provide(layer)),
         );
         expect(rows).toEqual([
-            { id: "experiment:aaa", title: "Stop using bare bun test", status: "scaffolded" },
-            { id: "experiment:bbb", title: "Guard worktree merges", status: "task_emitted" },
+            { id: "experiment:aaa", sig: "sig-aaa", title: "Stop using bare bun test", status: "scaffolded" },
+            { id: "experiment:bbb", sig: "sig-bbb", title: "Guard worktree merges", status: "task_emitted" },
         ]);
         expect(rows[0]).not.toHaveProperty("created_at");
     });

--- a/apps/axctl/src/improve/verdict-pending.test.ts
+++ b/apps/axctl/src/improve/verdict-pending.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { listPendingVerdicts } from "./verdict-pending.ts";
+import { SurrealClient } from "@ax/lib/db";
+
+const layerWith = (...fixtures: unknown[][]) => {
+    let i = 0;
+    return Layer.succeed(SurrealClient, {
+        query: <T>(_: string) => Effect.succeed([(fixtures[i++] ?? [])] as unknown as T),
+    } as never);
+};
+
+describe("listPendingVerdicts", () => {
+    test("returns experiments lacking locked_verdict with their proposal title", async () => {
+        const layer = layerWith([
+            { id: "experiment:aaa", title: "Stop using bare bun test", status: "scaffolded" },
+            { id: "experiment:bbb", title: "Guard worktree merges", status: "task_emitted" },
+        ]);
+        const rows = await Effect.runPromise(
+            listPendingVerdicts().pipe(Effect.provide(layer)),
+        );
+        expect(rows).toEqual([
+            { id: "experiment:aaa", title: "Stop using bare bun test", status: "scaffolded" },
+            { id: "experiment:bbb", title: "Guard worktree merges", status: "task_emitted" },
+        ]);
+    });
+
+    test("returns [] when no experiments are pending", async () => {
+        const rows = await Effect.runPromise(
+            listPendingVerdicts().pipe(Effect.provide(layerWith([]))),
+        );
+        expect(rows).toEqual([]);
+    });
+});

--- a/apps/axctl/src/improve/verdict-pending.ts
+++ b/apps/axctl/src/improve/verdict-pending.ts
@@ -11,6 +11,7 @@ import type { DbError } from "@ax/lib/errors";
 
 export interface PendingVerdictRow {
     readonly id: string;      // full record id string, e.g. "experiment:aaa"
+    readonly sig: string;     // proposal dedupe_sig - the only id `ax improve verdict` resolves
     readonly title: string;   // proposal title
     readonly status: string;
 }
@@ -27,6 +28,7 @@ export const listPendingVerdicts = (): Effect.Effect<PendingVerdictRow[], DbErro
         // projection, so created_at is selected and stripped below.
         const sql = `SELECT
                 type::string(id) AS id,
+                proposal.dedupe_sig AS sig,
                 proposal.title AS title,
                 status,
                 type::string(created_at) AS created_at
@@ -35,5 +37,5 @@ export const listPendingVerdicts = (): Effect.Effect<PendingVerdictRow[], DbErro
             ORDER BY created_at ASC
             LIMIT 20;`; // cap keeps the dojo agenda to one reviewable sitting
         const result = yield* db.query<[Array<PendingVerdictRow & { created_at?: string }>]>(sql);
-        return (result?.[0] ?? []).map(({ id, title, status }) => ({ id, title, status }));
+        return (result?.[0] ?? []).map(({ id, sig, title, status }) => ({ id, sig, title, status }));
     });

--- a/apps/axctl/src/improve/verdict-pending.ts
+++ b/apps/axctl/src/improve/verdict-pending.ts
@@ -1,0 +1,39 @@
+/**
+ * Pending-verdict experiments: rows in the improve loop whose
+ * `locked_verdict` has not been set yet. Feeds the dojo agenda
+ * (and anything else that wants "what still needs a human verdict").
+ * Pure query - presentation lives in the caller.
+ */
+
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+
+export interface PendingVerdictRow {
+    readonly id: string;      // full record id string, e.g. "experiment:aaa"
+    readonly title: string;   // proposal title
+    readonly status: string;
+}
+
+/**
+ * Oldest-first list of experiments still awaiting a locked verdict.
+ * Ordered by `created_at` (always set; `scaffolded_at` is NONE for
+ * status='task_emitted' rows, so it is not a safe sort key).
+ */
+export const listPendingVerdicts = (): Effect.Effect<PendingVerdictRow[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        // SurrealDB 3.0 requires the ORDER BY field to appear in the
+        // projection, so created_at is selected and stripped below.
+        const sql = `SELECT
+                type::string(id) AS id,
+                proposal.title AS title,
+                status,
+                type::string(created_at) AS created_at
+            FROM experiment
+            WHERE locked_verdict IS NONE AND status != 'retired'
+            ORDER BY created_at ASC
+            LIMIT 20;`;
+        const result = yield* db.query<[Array<PendingVerdictRow & { created_at?: string }>]>(sql);
+        return (result?.[0] ?? []).map(({ id, title, status }) => ({ id, title, status }));
+    });

--- a/apps/axctl/src/improve/verdict-pending.ts
+++ b/apps/axctl/src/improve/verdict-pending.ts
@@ -33,7 +33,7 @@ export const listPendingVerdicts = (): Effect.Effect<PendingVerdictRow[], DbErro
             FROM experiment
             WHERE locked_verdict IS NONE AND status != 'retired'
             ORDER BY created_at ASC
-            LIMIT 20;`;
+            LIMIT 20;`; // cap keeps the dojo agenda to one reviewable sitting
         const result = yield* db.query<[Array<PendingVerdictRow & { created_at?: string }>]>(sql);
         return (result?.[0] ?? []).map(({ id, title, status }) => ({ id, title, status }));
     });

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -44,6 +44,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 ### Self-improvement loop
 - `ax improve recommend / accept / lint / show` - evidence-backed proposals (guidance, skills, hooks, automations) derived from the graph; accept emits a task brief, lint reconciles applied guidance
 - `ax retro emit / pending / brief` + `ax:retro` skill - guided experiment-loop retrospective: triage proposals, lock verdicts, review hook effectiveness
+- `ax:dojo` skill - surplus-quota overnight training loop: budget-bounded self-improvement (verdicts, briefs, routing, proposals, experiments); install via `npx skills add Necmttn/ax`
 - `ax hooks init / install / backtest / cases` - author typed TypeScript hooks once, run them on Claude Code + Codex; replay history through a hook before installing it
 
 ### Graph insights

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -34,6 +34,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `route-dispatch` hook - deterministic dispatch-time nudge when a mechanical dispatch forgets an explicit model
 - `ax costs summary | for --session/--query/--commit/--branch` - what any session, feature, or branch cost in tokens and USD
 - `ax quota [--statusline|--swiftbar|--json]` - live Claude plan usage (5h/7d windows) from the Anthropic usage endpoint, cached locally; one-line statusline output and a SwiftBar menubar plugin ship with it
+- `ax dojo [--json] [--spar] [--budget=N] [--until=HH:MM] [--force] [--days=N]` - training agenda for surplus-quota self-improvement: budget envelope (5h/7d window remaining minus reserve, deadline = window reset) + prioritized items (pending verdicts, unfilled briefs, routing backtests, proposal minting, churn experiments, optional sparring). Consumed lap-by-lap by the ax:dojo skill.
 
 ### Profile
 - `ax profile show [--window=N] [--no-cost]` - your local agent profile rendered from the graph: usage stats, rig (skills/hooks/rules), and evidence-grounded taste patterns

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,7 @@ axctl costs for --commit <sha>              # cost for sessions that produced a 
 axctl costs for --branch <name>             # cost for sessions linked to a branch
 axctl cost <models|sessions|split>          # model/cost analytics incl. main-vs-subagent split
 axctl quota [--statusline|--swiftbar]       # Claude plan usage (5h/7d windows); statusline + menubar output
-axctl dojo [--json|--spar|--budget=N|--until=HH:MM|--force]   # training agenda: quota budget envelope + prioritized self-improvement items for the ax:dojo skill loop
+axctl dojo [--json|--spar|--budget=N|--until=HH:MM|--force|--days=N]   # training agenda: quota budget envelope + prioritized self-improvement items for the ax:dojo skill loop
 axctl dispatches [--candidates]             # subagent dispatch routing analytics + est savings
 axctl routing tune [--dry-run|--emit-brief] # mine YOUR dispatch history for new routing classes
 axctl routing compile                       # regenerate ~/.ax/hooks/routing-table.json (user classes preserved)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,6 +34,7 @@ axctl costs for --commit <sha>              # cost for sessions that produced a 
 axctl costs for --branch <name>             # cost for sessions linked to a branch
 axctl cost <models|sessions|split>          # model/cost analytics incl. main-vs-subagent split
 axctl quota [--statusline|--swiftbar]       # Claude plan usage (5h/7d windows); statusline + menubar output
+axctl dojo [--json|--spar|--budget=N|--until=HH:MM|--force]   # training agenda: quota budget envelope + prioritized self-improvement items for the ax:dojo skill loop
 axctl dispatches [--candidates]             # subagent dispatch routing analytics + est savings
 axctl routing tune [--dry-run|--emit-brief] # mine YOUR dispatch history for new routing classes
 axctl routing compile                       # regenerate ~/.ax/hooks/routing-table.json (user classes preserved)

--- a/docs/superpowers/plans/2026-06-13-ax-dojo-core.md
+++ b/docs/superpowers/plans/2026-06-13-ax-dojo-core.md
@@ -1,0 +1,1515 @@
+# ax dojo (core loop) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `ax dojo` (budget envelope + prioritized agenda CLI) and the `ax:dojo` installable skill (thin loop driver), per the approved spec `docs/superpowers/specs/2026-06-13-ax-dojo-design.md`.
+
+**Architecture:** New `apps/axctl/src/dojo/` module. Pure, fully-tested core (budget math, brief classification, item mapping, agenda assembly, rendering) + thin Effect glue that calls existing exported queries (`listProposals`, `fetchSessionChurnSummary`, `fetchTuneProposals`, quota's `getQuota`). One new CLI command (`runtime: db`), one new SKILL.md in `skills/dojo/`.
+
+**Tech Stack:** bun ≥1.3, TypeScript strict, Effect v4 beta (`effect/unstable/cli` Command/Flag), bun:test, SurrealDB via existing `SurrealClient` service.
+
+**Scope decomposition (from spec):** This plan = core loop only. Deferred to follow-up plans: (a) hook latency ledger (`ax hooks bench` / backtest timing), (b) sparring mechanism (`--spar` executes; this plan only emits the agenda item + skill playbook text), (c) MCP `dojo_agenda` tool, (d) cron/launchd trigger.
+
+**Conventions for the engineer:**
+- Run all commands from the repo root (`/Users/necmttn/Projects/ax/.claude/worktrees/ax-dojo-spec` if executing in the spec worktree; otherwise your own worktree off main with the spec commits).
+- Test runner is **bun:test** (`bun test <path>`). A global hook may block bare `bun test` invocations; if so, wrap in a tmp script (see memory: project uses bun:test).
+- Mirror import paths from neighboring files when in doubt - e.g. the exact `SurrealClient`/`DbError` imports used by `apps/axctl/src/improve/list.ts`, and the query-helper style used by `apps/axctl/src/improve/actions.ts:534`.
+- Em-dashes in repo docs get normalized to `-` by tooling; don't fight it.
+
+---
+
+## File structure
+
+```
+apps/axctl/src/dojo/
+├── schema.ts          # DojoItem, BudgetEnvelope, DojoAgenda types + KIND_PRIORITY
+├── budget.ts          # computeBudgetEnvelope (pure)
+├── budget.test.ts
+├── briefs.ts          # classifyBriefFile (pure) + scanTaskDir (FileSystem glue)
+├── briefs.test.ts
+├── items.ts           # pure row→DojoItem mappers for every DB source
+├── items.test.ts
+├── agenda.ts          # assembleAgenda (pure) + collectAgenda (Effect glue)
+├── agenda.test.ts
+├── format.ts          # renderAgenda (pure)
+├── format.test.ts
+└── paths.ts           # dojo state dirs (~/.ax/dojo/{outbox,reports})
+    paths.test.ts
+apps/axctl/src/improve/verdict-pending.ts   # listPendingVerdicts query (+ test)
+apps/axctl/src/cli/commands/dojo.ts          # CLI command + RuntimeManifest
+apps/axctl/src/cli/index.ts                  # register (modify)
+skills/dojo/SKILL.md                         # the ax:dojo skill
+docs/cli.md, apps/site/public/llms.txt, CLAUDE.md, README.md  # docs gate
+```
+
+---
+
+### Task 1: dojo schema + kind priority
+
+**Files:**
+- Create: `apps/axctl/src/dojo/schema.ts`
+- Test: `apps/axctl/src/dojo/schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/axctl/src/dojo/schema.test.ts
+import { describe, expect, test } from "bun:test";
+import { compareByPriority, KIND_PRIORITY } from "./schema.ts";
+
+describe("KIND_PRIORITY", () => {
+    test("orders kinds per spec (cheap + high-signal first)", () => {
+        expect(KIND_PRIORITY).toEqual([
+            "verdict_pending",
+            "brief_unfilled",
+            "routing_backtest",
+            "proposal_mint",
+            "experiment",
+            "upstream_draft",
+            "spar",
+            "explore",
+        ]);
+    });
+
+    test("compareByPriority sorts items by kind order, stable within kind", () => {
+        const items = [
+            { id: "b", kind: "experiment" },
+            { id: "a", kind: "verdict_pending" },
+            { id: "c", kind: "verdict_pending" },
+        ] as const;
+        const sorted = [...items].sort(compareByPriority);
+        expect(sorted.map((i) => i.id)).toEqual(["a", "c", "b"]);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dojo/schema.test.ts`
+Expected: FAIL - `Cannot find module './schema.ts'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// apps/axctl/src/dojo/schema.ts
+/**
+ * ax dojo - agenda types. Spec: docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+ */
+
+export type DojoCostClass = "s" | "m" | "l" | "xl";
+
+export type DojoItemKind =
+    | "verdict_pending"
+    | "brief_unfilled"
+    | "routing_backtest"
+    | "proposal_mint"
+    | "experiment"
+    | "upstream_draft"
+    | "spar"
+    | "explore";
+
+export const KIND_PRIORITY: readonly DojoItemKind[] = [
+    "verdict_pending",
+    "brief_unfilled",
+    "routing_backtest",
+    "proposal_mint",
+    "experiment",
+    "upstream_draft",
+    "spar",
+    "explore",
+];
+
+export interface DojoItem {
+    readonly id: string;
+    readonly kind: DojoItemKind;
+    readonly title: string;
+    /** exact CLI invocations the executing agent runs for this item */
+    readonly commands: readonly string[];
+    /** observable completion criterion - what makes this item vanish from the next agenda */
+    readonly success: string;
+    readonly cost_class: DojoCostClass;
+}
+
+export type BindingWindow = "five_hour" | "seven_day";
+
+export interface BudgetEnvelope {
+    readonly has_surplus: boolean;
+    /** spendable percentage points of the binding window after reserve */
+    readonly spendable_pct: number;
+    readonly binding_window: BindingWindow | null;
+    readonly window_remaining_pct: number;
+    readonly reserve_pct: number;
+    /** ISO datetime - earliest window reset, or the --until override */
+    readonly deadline: string;
+    readonly source: "quota" | "override" | "forced" | "unavailable";
+}
+
+export interface DojoAgenda {
+    readonly v: 1;
+    readonly generated_at: string;
+    readonly budget: BudgetEnvelope;
+    readonly items: readonly DojoItem[];
+}
+
+export const compareByPriority = (
+    a: Pick<DojoItem, "kind">,
+    b: Pick<DojoItem, "kind">,
+): number => KIND_PRIORITY.indexOf(a.kind) - KIND_PRIORITY.indexOf(b.kind);
+```
+
+Note: `Array.prototype.sort` is stable in Bun/V8, which the test relies on.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/dojo/schema.test.ts`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/dojo/schema.ts apps/axctl/src/dojo/schema.test.ts
+git commit -m "feat(dojo): agenda schema + kind priority"
+```
+
+---
+
+### Task 2: budget envelope (pure)
+
+**Files:**
+- Create: `apps/axctl/src/dojo/budget.ts`
+- Test: `apps/axctl/src/dojo/budget.test.ts`
+
+The quota snapshot shape comes from `apps/axctl/src/quota/schema.ts`: `QuotaSnapshot` with nullable `five_hour` / `seven_day` windows, each `{ utilization: number; resets_at: string }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/axctl/src/dojo/budget.test.ts
+import { describe, expect, test } from "bun:test";
+import type { QuotaSnapshot } from "../quota/schema.ts";
+import { computeBudgetEnvelope } from "./budget.ts";
+
+const NOW_MS = Date.parse("2026-06-13T10:00:00.000Z");
+
+const snapshot = (fiveHourUtil: number, sevenDayUtil: number): QuotaSnapshot => ({
+    v: 1,
+    fetched_at: "2026-06-13T09:59:00.000Z",
+    five_hour: { utilization: fiveHourUtil, resets_at: "2026-06-13T12:00:00.000Z" },
+    seven_day: { utilization: sevenDayUtil, resets_at: "2026-06-15T00:00:00.000Z" },
+    seven_day_opus: null,
+    seven_day_sonnet: null,
+    extra_usage: null,
+});
+
+describe("computeBudgetEnvelope", () => {
+    test("binding window is the one with least remaining; reserve subtracted", () => {
+        const env = computeBudgetEnvelope(snapshot(40, 70), {}, NOW_MS);
+        expect(env.binding_window).toBe("seven_day");
+        expect(env.window_remaining_pct).toBe(30);
+        expect(env.reserve_pct).toBe(15);
+        expect(env.spendable_pct).toBe(15);
+        expect(env.has_surplus).toBe(true);
+        expect(env.deadline).toBe("2026-06-13T12:00:00.000Z"); // earliest reset
+        expect(env.source).toBe("quota");
+    });
+
+    test("no surplus when remaining <= reserve", () => {
+        const env = computeBudgetEnvelope(snapshot(95, 50), {}, NOW_MS);
+        expect(env.binding_window).toBe("five_hour");
+        expect(env.spendable_pct).toBe(0);
+        expect(env.has_surplus).toBe(false);
+    });
+
+    test("--budget override caps spendable but never exceeds remaining", () => {
+        const env = computeBudgetEnvelope(snapshot(40, 70), { budgetPctOverride: 50 }, NOW_MS);
+        expect(env.spendable_pct).toBe(30); // min(50, remaining 30)
+        expect(env.source).toBe("override");
+    });
+
+    test("--until override replaces the deadline", () => {
+        const env = computeBudgetEnvelope(
+            snapshot(40, 70),
+            { untilIso: "2026-06-13T11:30:00.000Z" },
+            NOW_MS,
+        );
+        expect(env.deadline).toBe("2026-06-13T11:30:00.000Z");
+    });
+
+    test("force grants a floor budget when there is no surplus", () => {
+        const env = computeBudgetEnvelope(snapshot(99, 99), { force: true }, NOW_MS);
+        expect(env.has_surplus).toBe(true);
+        expect(env.spendable_pct).toBe(1); // whatever actually remains
+        expect(env.source).toBe("forced");
+    });
+
+    test("null snapshot (no token / fetch failed): unavailable, no surplus unless forced", () => {
+        const env = computeBudgetEnvelope(null, {}, NOW_MS);
+        expect(env.has_surplus).toBe(false);
+        expect(env.source).toBe("unavailable");
+        expect(env.binding_window).toBeNull();
+        const forced = computeBudgetEnvelope(null, { force: true }, NOW_MS);
+        expect(forced.has_surplus).toBe(true);
+        expect(forced.source).toBe("forced");
+    });
+
+    test("missing windows are skipped; lone five_hour window binds", () => {
+        const snap: QuotaSnapshot = { ...snapshot(80, 0), seven_day: null };
+        const env = computeBudgetEnvelope(snap, {}, NOW_MS);
+        expect(env.binding_window).toBe("five_hour");
+        expect(env.window_remaining_pct).toBe(20);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dojo/budget.test.ts`
+Expected: FAIL - `Cannot find module './budget.ts'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// apps/axctl/src/dojo/budget.ts
+import type { QuotaSnapshot } from "../quota/schema.ts";
+import type { BindingWindow, BudgetEnvelope } from "./schema.ts";
+
+export const DEFAULT_RESERVE_PCT = 15;
+
+export interface BudgetOptions {
+    /** keep this many percentage points untouched (default 15) */
+    readonly reservePct?: number;
+    /** --budget=N : spend at most N points, replaces reserve math */
+    readonly budgetPctOverride?: number | null;
+    /** --until resolved to ISO by the CLI layer */
+    readonly untilIso?: string | null;
+    /** --force : dojo with no surplus */
+    readonly force?: boolean;
+}
+
+export const computeBudgetEnvelope = (
+    snapshot: QuotaSnapshot | null,
+    opts: BudgetOptions,
+    nowMs: number,
+): BudgetEnvelope => {
+    const reserve = opts.reservePct ?? DEFAULT_RESERVE_PCT;
+
+    const windows: Array<{ name: BindingWindow; remaining: number; resetsAt: string }> = [];
+    if (snapshot?.five_hour) {
+        windows.push({
+            name: "five_hour",
+            remaining: Math.max(0, 100 - snapshot.five_hour.utilization),
+            resetsAt: snapshot.five_hour.resets_at,
+        });
+    }
+    if (snapshot?.seven_day) {
+        windows.push({
+            name: "seven_day",
+            remaining: Math.max(0, 100 - snapshot.seven_day.utilization),
+            resetsAt: snapshot.seven_day.resets_at,
+        });
+    }
+
+    if (windows.length === 0) {
+        return {
+            has_surplus: opts.force === true,
+            spendable_pct: 0,
+            binding_window: null,
+            window_remaining_pct: 0,
+            reserve_pct: reserve,
+            deadline: opts.untilIso ?? new Date(nowMs).toISOString(),
+            source: opts.force === true ? "forced" : "unavailable",
+        };
+    }
+
+    const binding = windows.reduce((min, w) => (w.remaining < min.remaining ? w : min));
+    const earliestReset = windows.reduce((min, w) =>
+        Date.parse(w.resetsAt) < Date.parse(min.resetsAt) ? w : min,
+    ).resetsAt;
+
+    const fromReserve = Math.max(0, binding.remaining - reserve);
+    const overridden = opts.budgetPctOverride != null
+        ? Math.min(opts.budgetPctOverride, binding.remaining)
+        : null;
+    let spendable = overridden ?? fromReserve;
+    let source: BudgetEnvelope["source"] = overridden != null ? "override" : "quota";
+
+    if (spendable <= 0 && opts.force === true) {
+        spendable = Math.max(1, binding.remaining);
+        source = "forced";
+    }
+
+    return {
+        has_surplus: spendable > 0,
+        spendable_pct: spendable,
+        binding_window: binding.name,
+        window_remaining_pct: binding.remaining,
+        reserve_pct: reserve,
+        deadline: opts.untilIso ?? earliestReset,
+        source,
+    };
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/dojo/budget.test.ts`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/dojo/budget.ts apps/axctl/src/dojo/budget.test.ts
+git commit -m "feat(dojo): budget envelope from quota snapshot"
+```
+
+---
+
+### Task 3: dojo state paths
+
+**Files:**
+- Create: `apps/axctl/src/dojo/paths.ts`
+- Test: `apps/axctl/src/dojo/paths.test.ts`
+
+Follow the parameterized-base pattern of `packages/lib/src/runtime-state.ts:28` (default from env/home, injectable for tests). Dojo state lives in `~/.ax/dojo/` (same family as `~/.ax/quota-cache.json` and `~/.ax/hooks/`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/axctl/src/dojo/paths.test.ts
+import { describe, expect, test } from "bun:test";
+import { dojoOutboxDir, dojoReportPath, dojoReportsDir } from "./paths.ts";
+
+describe("dojo paths", () => {
+    test("derive from an injectable base dir", () => {
+        expect(dojoOutboxDir("/tmp/axhome/.ax/dojo")).toBe("/tmp/axhome/.ax/dojo/outbox");
+        expect(dojoReportsDir("/tmp/axhome/.ax/dojo")).toBe("/tmp/axhome/.ax/dojo/reports");
+        expect(dojoReportPath("2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
+            "/tmp/axhome/.ax/dojo/reports/2026-06-13.md",
+        );
+    });
+
+    test("default base ends with /.ax/dojo", () => {
+        expect(dojoOutboxDir()).toMatch(/\/\.ax\/dojo\/outbox$/);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dojo/paths.test.ts`
+Expected: FAIL - `Cannot find module './paths.ts'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// apps/axctl/src/dojo/paths.ts
+import { homedir } from "node:os";
+import * as path from "node:path";
+
+export const defaultDojoDir = (): string => path.join(homedir(), ".ax", "dojo");
+
+export const dojoOutboxDir = (base: string = defaultDojoDir()): string =>
+    path.join(base, "outbox");
+
+export const dojoReportsDir = (base: string = defaultDojoDir()): string =>
+    path.join(base, "reports");
+
+/** date is YYYY-MM-DD */
+export const dojoReportPath = (date: string, base: string = defaultDojoDir()): string =>
+    path.join(dojoReportsDir(base), `${date}.md`);
+```
+
+NOTE: if the repo's `check:no-node-fs` gate complains about `node:os`/`node:path` in this location, mirror how `apps/axctl/src/quota/cache.ts:13` (`defaultQuotaCachePath`) builds `~/.ax/...` paths and follow that exact import style instead.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/dojo/paths.test.ts`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/dojo/paths.ts apps/axctl/src/dojo/paths.test.ts
+git commit -m "feat(dojo): state dir path helpers (~/.ax/dojo)"
+```
+
+---
+
+### Task 4: brief classification (pure) + task-dir scan
+
+**Files:**
+- Create: `apps/axctl/src/dojo/briefs.ts`
+- Test: `apps/axctl/src/dojo/briefs.test.ts`
+
+Brief conventions (verified in repo):
+- `classify-*.md` (skills classify) - *unfilled* while frontmatter `primary_role:` is empty/absent (`apps/axctl/src/cli/skills-lint.ts:73`); filled briefs are consumed+deleted by `ax skills lint`.
+- `routing-tune-*.md` - present until `ax routing tune --apply=...` consumes the decision; presence = open item.
+- anything else (`<dedupe_sig>.md` from `ax improve accept`) - presence = un-reconciled scaffold; `ax improve lint` deletes it when the marker lands.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/axctl/src/dojo/briefs.test.ts
+import { describe, expect, test } from "bun:test";
+import { classifyBriefFile } from "./briefs.ts";
+
+describe("classifyBriefFile", () => {
+    test("classify brief without primary_role is an unfilled item", () => {
+        const item = classifyBriefFile("classify-superpowers__tdd.md", "---\nax_classify: superpowers:tdd\nprimary_role:\n---\n");
+        expect(item).not.toBeNull();
+        expect(item?.kind).toBe("brief_unfilled");
+        expect(item?.id).toBe("brief:classify-superpowers__tdd.md");
+        expect(item?.commands).toEqual([
+            "$EDITOR .ax/tasks/classify-superpowers__tdd.md  # fill primary_role + rationale",
+            "ax skills lint",
+        ]);
+    });
+
+    test("classify brief WITH primary_role filled returns null (nothing to do)", () => {
+        const item = classifyBriefFile(
+            "classify-superpowers__tdd.md",
+            "---\nax_classify: superpowers:tdd\nprimary_role: verifier\n---\n",
+        );
+        expect(item).toBeNull();
+    });
+
+    test("routing-tune brief is an open routing_backtest item", () => {
+        const item = classifyBriefFile("routing-tune-2026-06-10.md", "| id | pattern |\n");
+        expect(item?.kind).toBe("routing_backtest");
+        expect(item?.commands).toContain("ax routing tune --apply=<ids from brief> --days=30");
+    });
+
+    test("improve accept brief is an unfilled item pointing at improve lint", () => {
+        const item = classifyBriefFile("a1b2c3d4.md", "---\nax_id: a1b2c3d4\n---\n");
+        expect(item?.kind).toBe("brief_unfilled");
+        expect(item?.commands).toEqual([
+            "$EDITOR .ax/tasks/a1b2c3d4.md  # act on the brief in the target files",
+            "ax improve lint",
+        ]);
+    });
+
+    test("non-markdown files return null", () => {
+        expect(classifyBriefFile(".DS_Store", "")).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dojo/briefs.test.ts`
+Expected: FAIL - `Cannot find module './briefs.ts'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// apps/axctl/src/dojo/briefs.ts
+import * as path from "node:path";
+import { Effect } from "effect";
+import { FileSystem } from "effect/platform/FileSystem";
+import type { DojoItem } from "./schema.ts";
+
+const FILLED_PRIMARY_ROLE = /^primary_role:\s*\S+/m;
+
+/** Pure: filename + content -> open agenda item, or null when nothing to do. */
+export const classifyBriefFile = (name: string, content: string): DojoItem | null => {
+    if (!name.endsWith(".md")) return null;
+    if (name.startsWith("classify-")) {
+        if (FILLED_PRIMARY_ROLE.test(content)) return null; // filled, skills lint will sweep it
+        return {
+            id: `brief:${name}`,
+            kind: "brief_unfilled",
+            title: `Fill skills-classify brief ${name}`,
+            commands: [
+                `$EDITOR .ax/tasks/${name}  # fill primary_role + rationale`,
+                "ax skills lint",
+            ],
+            success: "brief consumed by ax skills lint (file deleted, plays_role edges written)",
+            cost_class: "s",
+        };
+    }
+    if (name.startsWith("routing-tune-")) {
+        return {
+            id: `brief:${name}`,
+            kind: "routing_backtest",
+            title: `Backtest + apply routing-tune brief ${name}`,
+            commands: [
+                `$EDITOR .ax/tasks/${name}  # review judgment-flagged classes, backtest vs history`,
+                "ax routing tune --apply=<ids from brief> --days=30",
+            ],
+            success: "selected classes applied to ~/.ax/hooks/routing-table.json; brief resolved",
+            cost_class: "m",
+        };
+    }
+    return {
+        id: `brief:${name}`,
+        kind: "brief_unfilled",
+        title: `Act on improve brief ${name}`,
+        commands: [
+            `$EDITOR .ax/tasks/${name}  # act on the brief in the target files`,
+            "ax improve lint",
+        ],
+        success: "marker landed in target file; ax improve lint deletes the brief",
+        cost_class: "m",
+    };
+};
+
+/** Effect glue: scan the task dir (AX_TASK_DIR ?? $PWD/.ax/tasks) into items. */
+export const scanTaskDir = (
+    taskDir: string,
+): Effect.Effect<DojoItem[], never, FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem;
+        const exists = yield* fs.exists(taskDir).pipe(Effect.orElseSucceed(() => false));
+        if (!exists) return [];
+        const names = yield* fs.readDirectory(taskDir).pipe(Effect.orElseSucceed(() => []));
+        const items: DojoItem[] = [];
+        for (const name of names) {
+            const content = yield* fs
+                .readFileString(path.join(taskDir, name))
+                .pipe(Effect.orElseSucceed(() => ""));
+            const item = classifyBriefFile(name, content);
+            if (item) items.push(item);
+        }
+        return items;
+    });
+
+export const defaultTaskDir = (): string =>
+    process.env.AX_TASK_DIR ?? path.join(process.cwd(), ".ax", "tasks");
+```
+
+NOTE: mirror the exact `FileSystem` import path used elsewhere in the repo (e.g. `apps/axctl/src/improve/lint.ts` imports it for the same purpose) - Effect v4 beta moves platform modules around; copy, don't guess.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/dojo/briefs.test.ts`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/dojo/briefs.ts apps/axctl/src/dojo/briefs.test.ts
+git commit -m "feat(dojo): task-dir brief scan -> agenda items"
+```
+
+---
+
+### Task 5: pending-verdict query
+
+**Files:**
+- Create: `apps/axctl/src/improve/verdict-pending.ts`
+- Test: `apps/axctl/src/improve/verdict-pending.test.ts`
+
+There is no exported "list pending verdicts" today (the `ax improve verdict` CLI handler at `apps/axctl/src/cli/commands/improve.ts:387` does it inline). Add a small exported query next to its siblings. Model the query on `apps/axctl/src/improve/actions.ts:534` and the service/test style on `apps/axctl/src/improve/list.ts` + `apps/axctl/src/improve/show.test.ts` (which shows how `SurrealClient` is faked in tests - copy that harness).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/axctl/src/improve/verdict-pending.test.ts
+// Copy the fake-SurrealClient harness from apps/axctl/src/improve/show.test.ts verbatim,
+// then:
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { listPendingVerdicts } from "./verdict-pending.ts";
+
+describe("listPendingVerdicts", () => {
+    test("returns experiments lacking locked_verdict with their proposal title", async () => {
+        const client = fakeClient([
+            [
+                { id: "experiment:aaa", title: "Stop using bare bun test", status: "scaffolded" },
+                { id: "experiment:bbb", title: "Guard worktree merges", status: "task_emitted" },
+            ],
+        ]);
+        const rows = await Effect.runPromise(
+            listPendingVerdicts().pipe(Effect.provide(client.layer)),
+        );
+        expect(rows).toEqual([
+            { id: "experiment:aaa", title: "Stop using bare bun test", status: "scaffolded" },
+            { id: "experiment:bbb", title: "Guard worktree merges", status: "task_emitted" },
+        ]);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/improve/verdict-pending.test.ts`
+Expected: FAIL - `Cannot find module './verdict-pending.ts'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// apps/axctl/src/improve/verdict-pending.ts
+// Imports: copy the SurrealClient/DbError import lines from ./list.ts exactly.
+import { Effect } from "effect";
+import { /* SurrealClient, DbError - as in list.ts */ } from "@ax/lib/db";
+
+export interface PendingVerdictRow {
+    readonly id: string;
+    readonly title: string;
+    readonly status: string;
+}
+
+const QUERY = `
+SELECT type::string(id) AS id,
+       proposal.title AS title,
+       status
+FROM experiment
+WHERE locked_verdict IS NONE AND status != 'retired'
+ORDER BY scaffolded_at ASC
+LIMIT 20;
+`;
+
+export const listPendingVerdicts = (): Effect.Effect<
+    PendingVerdictRow[],
+    DbError,
+    SurrealClient
+> =>
+    Effect.gen(function* () {
+        const client = yield* SurrealClient;
+        const rows = yield* client.query<PendingVerdictRow[]>(QUERY); // match list.ts's query call shape
+        return rows ?? [];
+    });
+```
+
+The exact `client.query` call shape MUST be copied from `apps/axctl/src/improve/list.ts:30`'s implementation - same generic, same result unwrapping. If `proposal.title` deref misbehaves on your SurrealDB 3.0.x (see repo memory on record-deref bugs), fall back to two queries (ids first, then titles) - the table is small.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/improve/verdict-pending.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/improve/verdict-pending.ts apps/axctl/src/improve/verdict-pending.test.ts
+git commit -m "feat(improve): listPendingVerdicts query for dojo agenda"
+```
+
+---
+
+### Task 6: DB row -> item mappers (pure)
+
+**Files:**
+- Create: `apps/axctl/src/dojo/items.ts`
+- Test: `apps/axctl/src/dojo/items.test.ts`
+
+Pure mappers from existing query outputs to `DojoItem`s. Inputs (all verified exports):
+- `PendingVerdictRow` (Task 5)
+- `TuneProposal` from `apps/axctl/src/queries/routing-tune.ts:136` (`fetchTuneProposals`) - fields: `id`, `pattern`, `suggest`, `count`, `total_cost_usd`, `judgment`
+- `SessionChurnRow` from `apps/axctl/src/metrics/session-churn.ts:32` - fields used: `session`, `taskLabel`, `repairLinesAdded`, `episodes`, `passedEpisodes`, `topCheck`
+- open-proposal count from `listProposals` (`apps/axctl/src/improve/list.ts:30`)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/axctl/src/dojo/items.test.ts
+import { describe, expect, test } from "bun:test";
+import {
+    churnHotspotItems,
+    exploreItem,
+    pendingVerdictItems,
+    proposalMintItem,
+    routingBacktestItems,
+    sparItem,
+} from "./items.ts";
+
+describe("item mappers", () => {
+    test("pending verdicts -> verdict_pending items with improve verdict commands", () => {
+        const items = pendingVerdictItems([
+            { id: "experiment:aaa", title: "Stop bare bun test", status: "scaffolded" },
+        ]);
+        expect(items).toEqual([
+            {
+                id: "verdict:experiment:aaa",
+                kind: "verdict_pending",
+                title: "Lock verdict: Stop bare bun test",
+                commands: ["ax improve verdict aaa", "ax improve verdict aaa --set <verdict>"],
+                success: "experiment.locked_verdict set",
+                cost_class: "s",
+            },
+        ]);
+    });
+
+    test("judgment-flagged tune proposals -> routing_backtest items; non-judgment skipped", () => {
+        const items = routingBacktestItems(
+            [
+                { id: "rt1", pattern: "^review", suggest: "sonnet", count: 5, total_cost_usd: 4.2, judgment: true },
+                { id: "rt2", pattern: "^fmt", suggest: "sonnet", count: 3, total_cost_usd: 0.4, judgment: false },
+            ],
+            30,
+        );
+        expect(items).toHaveLength(1);
+        expect(items[0]?.id).toBe("routing:rt1");
+        expect(items[0]?.commands).toEqual([
+            "ax routing tune --days=30 --emit-brief",
+            "ax routing tune --apply=rt1 --days=30",
+        ]);
+    });
+
+    test("churn hotspots: only sessions with failed episodes, top 2, cost l", () => {
+        const row = (session: string, episodes: number, passed: number, repair: number) => ({
+            session,
+            source: "claude",
+            taskLabel: `task ${session}`,
+            landedLinesAdded: 0, landedLinesRemoved: 0,
+            editLinesAdded: 0, editLinesRemoved: 0,
+            repairLinesAdded: repair, repairLinesRemoved: 0,
+            editEvents: 0, verificationFailures: episodes, verificationPasses: passed,
+            episodes, passedEpisodes: passed, topCheck: "typecheck",
+        });
+        const items = churnHotspotItems([
+            row("s1", 4, 1, 500),
+            row("s2", 0, 0, 0),   // clean - skipped
+            row("s3", 6, 2, 900),
+            row("s4", 2, 1, 100),
+        ]);
+        expect(items.map((i) => i.id)).toEqual(["experiment:s3", "experiment:s1"]); // by repair desc, top 2
+        expect(items[0]?.kind).toBe("experiment");
+        expect(items[0]?.cost_class).toBe("l");
+    });
+
+    test("proposal mint emitted only when open proposals are scarce", () => {
+        expect(proposalMintItem(0)).not.toBeNull();
+        expect(proposalMintItem(2)).not.toBeNull();
+        expect(proposalMintItem(3)).toBeNull();
+    });
+
+    test("spar + explore singletons", () => {
+        expect(sparItem().kind).toBe("spar");
+        expect(sparItem().cost_class).toBe("xl");
+        expect(exploreItem().kind).toBe("explore");
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dojo/items.test.ts`
+Expected: FAIL - `Cannot find module './items.ts'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// apps/axctl/src/dojo/items.ts
+import type { PendingVerdictRow } from "../improve/verdict-pending.ts";
+import type { SessionChurnRow } from "../metrics/session-churn.ts";
+import type { TuneProposal } from "../queries/routing-tune.ts";
+import type { DojoItem } from "./schema.ts";
+
+const shortId = (recordId: string): string => recordId.split(":").pop() ?? recordId;
+
+export const pendingVerdictItems = (rows: readonly PendingVerdictRow[]): DojoItem[] =>
+    rows.map((r) => ({
+        id: `verdict:${r.id}`,
+        kind: "verdict_pending",
+        title: `Lock verdict: ${r.title}`,
+        commands: [
+            `ax improve verdict ${shortId(r.id)}`,
+            `ax improve verdict ${shortId(r.id)} --set <verdict>`,
+        ],
+        success: "experiment.locked_verdict set",
+        cost_class: "s",
+    }));
+
+export const routingBacktestItems = (
+    proposals: readonly TuneProposal[],
+    days: number,
+): DojoItem[] =>
+    proposals
+        .filter((p) => p.judgment)
+        .map((p) => ({
+            id: `routing:${p.id}`,
+            kind: "routing_backtest",
+            title: `Backtest routing class ${p.pattern} (${p.count} dispatches, $${p.total_cost_usd.toFixed(2)})`,
+            commands: [
+                `ax routing tune --days=${days} --emit-brief`,
+                `ax routing tune --apply=${p.id} --days=${days}`,
+            ],
+            success: "class applied to routing table (origin: user) or rejected with rationale",
+            cost_class: "m",
+        }));
+
+export const MINT_THRESHOLD = 3;
+
+export const proposalMintItem = (openProposalCount: number): DojoItem | null =>
+    openProposalCount >= MINT_THRESHOLD
+        ? null
+        : {
+            id: "mint:improve-recommend",
+            kind: "proposal_mint",
+            title: "Mint new improvement proposals (open pool is low)",
+            commands: ["ax improve recommend", "ax improve accept <id>"],
+            success: "new open proposals exist; accepted ones emitted .ax/tasks briefs",
+            cost_class: "m",
+        };
+
+export const churnHotspotItems = (rows: readonly SessionChurnRow[]): DojoItem[] =>
+    rows
+        .filter((r) => r.episodes > r.passedEpisodes || r.repairLinesAdded > 200)
+        .sort((a, b) => b.repairLinesAdded - a.repairLinesAdded)
+        .slice(0, 2)
+        .map((r) => ({
+            id: `experiment:${r.session}`,
+            kind: "experiment",
+            title: `Worktree experiment: reduce ${r.topCheck} churn (${r.taskLabel})`,
+            commands: [
+                `ax sessions show ${r.session}`,
+                "git worktree add .claude/worktrees/dojo-experiment -b dojo/experiment",
+                "ax improve recommend  # package the result as a proposal",
+            ],
+            success: "experiment branch + evidence captured as an improve proposal",
+            cost_class: "l",
+        }));
+
+export const sparItem = (): DojoItem => ({
+    id: "spar:campaign",
+    kind: "spar",
+    title: "Sparring: one task, one delta, scored (see skill playbook)",
+    commands: [
+        "ax sessions here --days=30  # pick a landed task as baseline",
+        "git worktree add .claude/worktrees/dojo-spar <parent-sha>",
+    ],
+    success: "spar report appended to the dojo report; goal package updated",
+    cost_class: "xl",
+});
+
+export const exploreItem = (): DojoItem => ({
+    id: "explore:retro-meta",
+    kind: "explore",
+    title: "Agenda dry - free investigation (retro-meta style)",
+    commands: ["ax recall <hunch> --scope=all", "ax sessions churn --since=30"],
+    success: "at least one new outbox draft, proposal, or goal package",
+    cost_class: "l",
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/dojo/items.test.ts`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/dojo/items.ts apps/axctl/src/dojo/items.test.ts
+git commit -m "feat(dojo): pure row->item mappers for all agenda sources"
+```
+
+---
+
+### Task 7: agenda assembly (pure core + Effect glue)
+
+**Files:**
+- Create: `apps/axctl/src/dojo/agenda.ts`
+- Test: `apps/axctl/src/dojo/agenda.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/axctl/src/dojo/agenda.test.ts
+import { describe, expect, test } from "bun:test";
+import type { BudgetEnvelope, DojoItem } from "./schema.ts";
+import { assembleAgenda } from "./agenda.ts";
+
+const budget: BudgetEnvelope = {
+    has_surplus: true, spendable_pct: 20, binding_window: "five_hour",
+    window_remaining_pct: 35, reserve_pct: 15,
+    deadline: "2026-06-13T12:00:00.000Z", source: "quota",
+};
+
+const item = (id: string, kind: DojoItem["kind"]): DojoItem => ({
+    id, kind, title: id, commands: ["true"], success: "done", cost_class: "s",
+});
+
+describe("assembleAgenda", () => {
+    test("sorts by kind priority and stamps generated_at", () => {
+        const agenda = assembleAgenda(
+            budget,
+            [item("e1", "experiment"), item("v1", "verdict_pending"), item("b1", "brief_unfilled")],
+            { nowMs: Date.parse("2026-06-13T10:00:00.000Z"), spar: false },
+        );
+        expect(agenda.v).toBe(1);
+        expect(agenda.generated_at).toBe("2026-06-13T10:00:00.000Z");
+        expect(agenda.items.map((i) => i.id)).toEqual(["v1", "b1", "e1"]);
+    });
+
+    test("appends explore when otherwise empty", () => {
+        const agenda = assembleAgenda(budget, [], { nowMs: 0, spar: false });
+        expect(agenda.items).toHaveLength(1);
+        expect(agenda.items[0]?.kind).toBe("explore");
+    });
+
+    test("spar included only when requested AND spendable >= 30", () => {
+        const none = assembleAgenda(budget, [item("v1", "verdict_pending")], { nowMs: 0, spar: true });
+        expect(none.items.some((i) => i.kind === "spar")).toBe(false); // spendable 20 < 30
+        const fat = assembleAgenda(
+            { ...budget, spendable_pct: 40 },
+            [item("v1", "verdict_pending")],
+            { nowMs: 0, spar: true },
+        );
+        expect(fat.items.some((i) => i.kind === "spar")).toBe(true);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dojo/agenda.test.ts`
+Expected: FAIL - `Cannot find module './agenda.ts'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// apps/axctl/src/dojo/agenda.ts
+import { Effect } from "effect";
+import { listPendingVerdicts } from "../improve/verdict-pending.ts";
+import { listProposals } from "../improve/list.ts";
+import { fetchSessionChurnSummary } from "../metrics/session-churn.ts";
+import { fetchTuneProposals } from "../queries/routing-tune.ts";
+import { defaultTaskDir, scanTaskDir } from "./briefs.ts";
+import {
+    churnHotspotItems, exploreItem, pendingVerdictItems,
+    proposalMintItem, routingBacktestItems, sparItem,
+} from "./items.ts";
+import type { BudgetEnvelope, DojoAgenda, DojoItem } from "./schema.ts";
+import { compareByPriority } from "./schema.ts";
+
+export const SPAR_MIN_SPENDABLE_PCT = 30;
+
+export interface AssembleOptions {
+    readonly nowMs: number;
+    readonly spar: boolean;
+}
+
+/** Pure: budget + flat item list -> ordered agenda. */
+export const assembleAgenda = (
+    budget: BudgetEnvelope,
+    items: readonly DojoItem[],
+    opts: AssembleOptions,
+): DojoAgenda => {
+    const sorted = [...items].sort(compareByPriority);
+    if (opts.spar && budget.spendable_pct >= SPAR_MIN_SPENDABLE_PCT) sorted.push(sparItem());
+    if (sorted.length === 0) sorted.push(exploreItem());
+    return {
+        v: 1,
+        generated_at: new Date(opts.nowMs).toISOString(),
+        budget,
+        items: sorted,
+    };
+};
+
+export interface CollectOptions {
+    readonly nowMs: number;
+    readonly days: number; // lookback for churn + routing tune
+    readonly spar: boolean;
+    readonly taskDir?: string;
+}
+
+/**
+ * Effect glue: run every source, tolerate individual source failures
+ * (a broken source must not kill the whole agenda - log to stderr, emit []).
+ * Requirements: SurrealClient + FileSystem (+ whatever fetchTuneProposals needs:
+ * it takes the loaded RoutingTable - load it via the same helper
+ * `ax routing show` uses, see apps/axctl/src/queries/routing-tune.ts imports).
+ */
+export const collectAgendaItems = (opts: CollectOptions) =>
+    Effect.gen(function* () {
+        const soft = <A>(label: string, eff: Effect.Effect<A, unknown, never>, empty: A) =>
+            eff.pipe(
+                Effect.catchAll((e) =>
+                    Effect.sync(() => {
+                        console.error(`dojo: source ${label} failed: ${String(e)}`);
+                        return empty;
+                    }),
+                ),
+            );
+        // NOTE to engineer: provide the actual environments at the call site (CLI task 9);
+        // the per-source `soft` wrapper pattern stays as shown.
+        const verdicts = yield* soft("verdicts", listPendingVerdicts() as never, []);
+        const briefs = yield* soft("briefs", scanTaskDir(opts.taskDir ?? defaultTaskDir()) as never, []);
+        const churn = yield* soft("churn", fetchSessionChurnSummary({ sinceDays: opts.days } as never) as never, null);
+        const open = yield* soft("proposals", listProposals({ status: "open" } as never) as never, []);
+        const tune = yield* soft("routing", fetchTuneProposals({ sinceDays: opts.days, table: /* load routing table as routing-show does */ undefined as never }) as never, []);
+
+        const items: DojoItem[] = [
+            ...pendingVerdictItems(verdicts as never),
+            ...(briefs as DojoItem[]),
+            ...routingBacktestItems(tune as never, opts.days),
+            ...churnHotspotItems(((churn as never) ?? { rows: [] }).rows ?? []),
+        ];
+        const mint = proposalMintItem((open as unknown[]).length);
+        if (mint) items.push(mint);
+        return items;
+    });
+```
+
+The `as never` casts above mark the seams the engineer must resolve against the real signatures (exact input shapes of `fetchSessionChurnSummary` / `fetchTuneProposals` / `listProposals` - read each function's input type and call it properly; the routing table loads via the same loader `ax routing show` uses in `apps/axctl/src/cli/commands/ax-routing.ts`). The pure `assembleAgenda` and the `soft` failure-isolation pattern are the tested contract; `collectAgendaItems` is glue verified by typecheck + the CLI smoke test in Task 9.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/dojo/agenda.test.ts`
+Expected: PASS (3 tests). Then `bun run typecheck` to force resolving the glue seams properly - do not leave `as never` casts in committed code.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/dojo/agenda.ts apps/axctl/src/dojo/agenda.test.ts
+git commit -m "feat(dojo): agenda assembly - priority sort, spar gate, explore fallback"
+```
+
+---
+
+### Task 8: text rendering
+
+**Files:**
+- Create: `apps/axctl/src/dojo/format.ts`
+- Test: `apps/axctl/src/dojo/format.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/axctl/src/dojo/format.test.ts
+import { describe, expect, test } from "bun:test";
+import type { DojoAgenda } from "./schema.ts";
+import { renderAgenda } from "./format.ts";
+
+const agenda: DojoAgenda = {
+    v: 1,
+    generated_at: "2026-06-13T10:00:00.000Z",
+    budget: {
+        has_surplus: true, spendable_pct: 20, binding_window: "five_hour",
+        window_remaining_pct: 35, reserve_pct: 15,
+        deadline: "2026-06-13T12:00:00.000Z", source: "quota",
+    },
+    items: [
+        {
+            id: "verdict:experiment:aaa", kind: "verdict_pending",
+            title: "Lock verdict: Stop bare bun test",
+            commands: ["ax improve verdict aaa"], success: "locked", cost_class: "s",
+        },
+    ],
+};
+
+describe("renderAgenda", () => {
+    test("renders budget line + item rows", () => {
+        const out = renderAgenda(agenda);
+        expect(out).toContain("budget: 20% spendable (5h window, 35% left, 15% reserve)");
+        expect(out).toContain("deadline 2026-06-13T12:00");
+        expect(out).toContain("1. [verdict_pending/s] Lock verdict: Stop bare bun test");
+        expect(out).toContain("   $ ax improve verdict aaa");
+    });
+
+    test("no-surplus agenda warns about --force", () => {
+        const out = renderAgenda({
+            ...agenda,
+            budget: { ...agenda.budget, has_surplus: false, spendable_pct: 0 },
+        });
+        expect(out).toContain("no surplus");
+        expect(out).toContain("--force");
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dojo/format.test.ts`
+Expected: FAIL - `Cannot find module './format.ts'`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// apps/axctl/src/dojo/format.ts
+import type { DojoAgenda } from "./schema.ts";
+
+const windowLabel = (w: DojoAgenda["budget"]["binding_window"]): string =>
+    w === "five_hour" ? "5h window" : w === "seven_day" ? "7d window" : "no window";
+
+export const renderAgenda = (agenda: DojoAgenda): string => {
+    const b = agenda.budget;
+    const lines: string[] = [];
+    lines.push(
+        `budget: ${b.spendable_pct}% spendable (${windowLabel(b.binding_window)}, ` +
+        `${b.window_remaining_pct}% left, ${b.reserve_pct}% reserve) - ` +
+        `deadline ${b.deadline.slice(0, 16)} [${b.source}]`,
+    );
+    if (!b.has_surplus) {
+        lines.push("no surplus in the current window - dojo will not start without --force");
+    }
+    lines.push("");
+    agenda.items.forEach((item, i) => {
+        lines.push(`${i + 1}. [${item.kind}/${item.cost_class}] ${item.title}`);
+        for (const cmd of item.commands) lines.push(`   $ ${cmd}`);
+        lines.push(`   done when: ${item.success}`);
+    });
+    return lines.join("\n");
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/dojo/format.test.ts`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/dojo/format.ts apps/axctl/src/dojo/format.test.ts
+git commit -m "feat(dojo): text agenda renderer"
+```
+
+---
+
+### Task 9: CLI command + registration
+
+**Files:**
+- Create: `apps/axctl/src/cli/commands/dojo.ts`
+- Modify: `apps/axctl/src/cli/index.ts` (two spots: `RUNTIME_BY_COMMAND` spread around line 68-95; `registeredCommands` around line 103-149)
+
+Model on `apps/axctl/src/cli/commands/quota.ts` (flags/handler) and `ax-routing.ts` (db runtime). Dojo needs **db runtime** (verdicts/churn/proposals) AND the QuotaEnv layer (budget) - provide `QuotaEnvLive` inside the handler like quota.ts does, the db layer comes from the manifest.
+
+- [ ] **Step 1: Write the command**
+
+```ts
+// apps/axctl/src/cli/commands/dojo.ts
+/**
+ * `ax dojo` - budget envelope + prioritized training agenda for the
+ * ax:dojo skill loop. Spec: docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+ *
+ *   ax dojo            human agenda
+ *   ax dojo --json     DojoAgenda JSON (consumed by the skill each lap)
+ */
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { prettyPrint } from "@ax/lib/json";
+import { assembleAgenda, collectAgendaItems } from "../../dojo/agenda.ts";
+import { computeBudgetEnvelope } from "../../dojo/budget.ts";
+import { renderAgenda } from "../../dojo/format.ts";
+import { defaultQuotaCachePath } from "../../quota/cache.ts";
+import { QuotaEnvLive } from "../../quota/quota-env.ts";
+import { getQuota } from "../../quota/quota.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { jsonFlag } from "./shared.ts";
+
+/** "HH:MM" today (or tomorrow when already past) -> ISO */
+export const untilToIso = (until: string, nowMs: number): string | null => {
+    const m = /^(\d{1,2}):(\d{2})$/.exec(until);
+    if (!m) return null;
+    const d = new Date(nowMs);
+    d.setHours(Number(m[1]), Number(m[2]), 0, 0);
+    if (d.getTime() <= nowMs) d.setDate(d.getDate() + 1);
+    return d.toISOString();
+};
+
+export const dojoCommand = Command.make(
+    "dojo",
+    {
+        json: jsonFlag,
+        budget: Flag.integer("budget").pipe(Flag.withDefault(0)), // 0 = unset
+        until: Flag.string("until").pipe(Flag.withDefault("")),
+        force: Flag.boolean("force").pipe(Flag.withDefault(false)),
+        spar: Flag.boolean("spar").pipe(Flag.withDefault(false)),
+        days: Flag.integer("days").pipe(Flag.withDefault(30)),
+    },
+    ({ json, budget, until, force, spar, days }) => {
+        const nowMs = Date.now();
+        return Effect.gen(function* () {
+            const quota = yield* getQuota({
+                cachePath: defaultQuotaCachePath(),
+                maxAgeSeconds: 60,
+                nowMs,
+            }).pipe(
+                Effect.map((r) => r.snapshot),
+                Effect.catchAll(() => Effect.succeed(null)), // budget degrades, agenda still renders
+            );
+            const envelope = computeBudgetEnvelope(
+                quota,
+                {
+                    budgetPctOverride: budget > 0 ? budget : null,
+                    untilIso: until ? untilToIso(until, nowMs) : null,
+                    force,
+                },
+                nowMs,
+            );
+            const items = yield* collectAgendaItems({ nowMs, days, spar });
+            const agenda = assembleAgenda(envelope, items, { nowMs, spar });
+            console.log(json ? prettyPrint(agenda) : renderAgenda(agenda));
+        }).pipe(Effect.provide(QuotaEnvLive));
+    },
+).pipe(
+    Command.withDescription(
+        "Training agenda: quota budget envelope + prioritized self-improvement work items (consumed by the ax:dojo skill loop)",
+    ),
+);
+
+export const dojoRuntime: RuntimeManifest = {
+    dojo: "db",
+};
+```
+
+- [ ] **Step 2: Register in cli/index.ts**
+
+In `apps/axctl/src/cli/index.ts`:
+1. Import: `import { dojoCommand, dojoRuntime } from "./commands/dojo.ts";`
+2. Spread `...dojoRuntime,` into `RUNTIME_BY_COMMAND` alongside the other manifests.
+3. Add `dojoCommand` to `registeredCommands` (place after `quota` in the visible order).
+
+- [ ] **Step 3: Verify with the existing CLI exhaustiveness test + smoke run**
+
+Run: `bun test apps/axctl/src/cli/effect-cli.test.ts`
+Expected: PASS - the "every registered top-level command declares its runtime" test now covers dojo.
+
+Run: `bun apps/axctl/src/cli/index.ts dojo --json` (DB running; `scripts/db-start.sh` if not)
+Expected: JSON with `"v": 1`, a `budget` object, an `items` array (possibly just the explore fallback on a clean graph). Exit 0.
+
+Run: `bun apps/axctl/src/cli/index.ts dojo`
+Expected: human agenda; budget line first.
+
+- [ ] **Step 4: Add untilToIso unit test**
+
+Append to `apps/axctl/src/dojo/format.test.ts` or create `apps/axctl/src/cli/commands/dojo.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { untilToIso } from "./dojo.ts";
+
+describe("untilToIso", () => {
+    const NOW = Date.parse("2026-06-13T10:00:00.000Z");
+    test("future time today", () => {
+        expect(untilToIso("23:30", NOW)).toMatch(/T\d{2}:30:00/);
+    });
+    test("past time rolls to tomorrow", () => {
+        const iso = untilToIso("01:00", NOW)!;
+        expect(Date.parse(iso)).toBeGreaterThan(NOW);
+    });
+    test("garbage returns null", () => {
+        expect(untilToIso("late", NOW)).toBeNull();
+    });
+});
+```
+
+Run: `bun test apps/axctl/src/cli/commands/dojo.test.ts` - Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/cli/commands/dojo.ts apps/axctl/src/cli/commands/dojo.test.ts apps/axctl/src/cli/index.ts
+git commit -m "feat(cli): ax dojo - budget envelope + training agenda"
+```
+
+---
+
+### Task 10: docs gate (README/cli.md + llms.txt + CLAUDE.md)
+
+**Files:**
+- Modify: `docs/cli.md` (add under the command list, near quota)
+- Modify: `apps/site/public/llms.txt` (REQUIRED - `check:cli-reference` fails without it)
+- Modify: `CLAUDE.md` (new section after "### Plan quota")
+
+- [ ] **Step 1: docs/cli.md**
+
+Add (match surrounding format):
+
+```
+axctl dojo [--json|--spar|--budget=N|--until=HH:MM|--force]   # training agenda: quota budget envelope + prioritized self-improvement items for the ax:dojo skill loop
+```
+
+- [ ] **Step 2: apps/site/public/llms.txt**
+
+Add (match surrounding format):
+
+```
+- `ax dojo [--json] [--spar] [--budget=N] [--until=HH:MM] [--force] [--days=N]` - training agenda for surplus-quota self-improvement: budget envelope (5h/7d window remaining minus reserve, deadline = window reset) + prioritized items (pending verdicts, unfilled briefs, routing backtests, proposal minting, churn experiments, optional sparring). Consumed lap-by-lap by the ax:dojo skill.
+```
+
+- [ ] **Step 3: CLAUDE.md**
+
+Add after the "### Plan quota" section:
+
+```markdown
+### Dojo
+
+`ax dojo [--json] [--spar] [--budget=N] [--until=HH:MM] [--force] [--days=N]` -
+training agenda for the ax:dojo skill loop (burn surplus plan quota on
+self-improvement). Composes a budget envelope from the quota module (binding
+window remaining minus 15% reserve, deadline = earliest window reset) with a
+derived, self-clearing item list: pending verdicts, unfilled .ax/tasks briefs,
+judgment-flagged routing backtests, proposal minting (when open pool < 3),
+churn-hotspot experiments, opt-in spar (needs --spar AND >=30% spendable),
+explore fallback. Items vanish once the underlying system records the work
+(verdict locked / brief consumed / proposal created). State dirs:
+`~/.ax/dojo/outbox/` (upstream issue drafts, publish on review) and
+`~/.ax/dojo/reports/<date>.md`. Module: `apps/axctl/src/dojo/`. Spec:
+docs/superpowers/specs/2026-06-13-ax-dojo-design.md.
+```
+
+- [ ] **Step 4: Run the gate**
+
+Run: `bun run check:cli-reference`
+Expected: exits 0, no missing-subcommand output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/cli.md apps/site/public/llms.txt CLAUDE.md
+git commit -m "docs: ax dojo command reference + CLAUDE.md section"
+```
+
+---
+
+### Task 11: the ax:dojo skill
+
+**Files:**
+- Create: `skills/dojo/SKILL.md`
+
+Frontmatter format per `skills/retro/SKILL.md` (name + description with explicit triggers + explicit do-NOT-fire guidance).
+
+- [ ] **Step 1: Write the skill**
+
+```markdown
+---
+name: dojo
+description: Surplus-quota training loop over the ax graph - the agent burns the remaining 5h/7d plan-quota window on self-improvement: locking pending verdicts, filling briefs, backtesting routing classes, minting proposals, running worktree experiments, and drafting upstream issue reports. Triggers when the user says "/dojo", "enter the dojo", "dojo time", "train overnight", "burn my surplus quota", "dream mode" (legacy name), or invokes /loop /dojo. Requires ax (axctl) on PATH and the local SurrealDB running. Do NOT auto-trigger on unrelated work or when the user merely mentions quotas.
+---
+
+# ax:dojo - overnight training loop
+
+You are entering a budget-bounded self-improvement loop. The brain is
+`ax dojo --json`; you are the thin driver. Spec for humans:
+docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
+
+## Entry
+
+1. Run `ax dojo --json`. If it fails with a connection error, tell the user
+   to run `scripts/db-start.sh` (or `ax doctor`) and STOP.
+2. If `budget.has_surplus` is false: report the envelope and STOP unless the
+   user re-invokes with `--force` (then pass `--force` on every lap).
+3. On Claude Code: enter loop mode now - invoke the `/loop` skill with
+   `/dojo` as the recurring prompt (dynamic mode, self-paced). Each wakeup
+   re-runs this skill from the top; that is expected and correct.
+   On Codex (no /loop): run as ONE long turn - do not end the turn until a
+   stop condition below is met.
+
+## The lap
+
+1. `ax dojo --json` -> agenda.
+2. STOP conditions (write the report, then stop):
+   - `budget.has_surplus` is false (and not forced)
+   - now >= `budget.deadline`
+   - `items` is empty
+3. Otherwise: take `items[0]`, follow its playbook below, then go to 1.
+   Completed work self-clears: the item vanishes from the next agenda
+   because the underlying system recorded it (verdict locked, brief
+   consumed, proposal created). If the same item survives 2 laps untouched,
+   skip it and note why in the report.
+
+## Playbooks by kind
+
+- **verdict_pending** - `ax improve verdict <id>` to see the suggested
+  verdict + checkpoint evidence; confirm with `--set <verdict>` only when
+  the evidence supports it. Distinguish "pattern resolved" from "artifact
+  never fired" before locking no_longer_needed.
+- **brief_unfilled** - open the `.ax/tasks/*.md` brief, do what it says in
+  the target files, then run the reconciler it names (`ax skills lint` /
+  `ax improve lint`).
+- **routing_backtest** - judgment-flagged routing classes: backtest the
+  pattern against dispatch history (`ax dispatches --candidates`), check
+  false-positive risk, then `ax routing tune --apply=<ids> --days=<window>`
+  or reject with a written rationale in the report.
+- **proposal_mint** - `ax improve recommend`; accept the grounded ones
+  (`ax improve accept <id>`) so briefs exist for the next lap.
+- **experiment** - heavy item. Work ONLY in a fresh worktree
+  (`git worktree add .claude/worktrees/dojo-<slug> -b dojo/<slug>`).
+  Reproduce the churn pattern, attempt the fix/hook/skill, capture evidence.
+  If it will not finish inside this budget: package it as a goal file
+  (objective + checkpoint index + gates) under docs/superpowers/goals/ so
+  the NEXT dojo session resumes it. Output = an improve proposal; merging
+  the proposal is what activates anything. NEVER merge, never touch main.
+- **New hooks specifically** - author via @ax/hooks-sdk, validate with
+  `ax hooks backtest <file>`, and put BOTH sides in the proposal: cases it
+  would have caught AND the latency ledger (per-fire cost, est fires/day,
+  cumulative installed-chain overhead). Reject your own hook when overhead
+  outweighs benefit.
+- **spar** - only present when invoked with --spar and surplus is large.
+  One task, one delta, scored: pick a landed task (`ax sessions here`),
+  pin a worktree at the parent SHA, re-run it with exactly ONE change
+  (skill on/off, hook on/off, prompt, thinking level, model via subagent
+  override), score against the historical baseline using graph metrics
+  (tokens, turns, churn, landed). Append the comparison receipt to the
+  report. Track multi-night campaigns as goal files.
+- **explore** - free investigation, retro-meta style: follow a hunch
+  through `ax recall` / `ax sessions churn`, and convert anything real
+  into a proposal or outbox draft.
+- **Upstream findings (any lap)** - an ax bug or improvement found while
+  training goes to `~/.ax/dojo/outbox/<slug>.md` as a complete issue draft
+  (title, body, repro, session refs). NEVER publish from the dojo - the
+  user reviews and publishes in the morning (ax-repo skill / gh).
+
+## Exit - the morning report
+
+Write `~/.ax/dojo/reports/<YYYY-MM-DD>.md` (create dirs if missing):
+- budget: envelope at start, spendable consumed (re-run `ax quota` and diff)
+- per lap: item, what happened, evidence refs
+- proposals created/advanced, briefs filled, verdicts locked
+- outbox drafts awaiting review (list paths)
+- skipped/stuck items and why
+Then tell the user the report path and the top 3 things awaiting their
+review. Done.
+
+## Hard rails
+
+- worktrees only; never write on main; never merge anything
+- proposals are the only activation path
+- outbox only; nothing leaves the machine
+- respect the deadline even mid-item: checkpoint, report, stop
+```
+
+- [ ] **Step 2: Verify skill list consistency**
+
+Check whether any manifest/registry lists the installable skills (e.g. a `skills` index in `package.json`, README section listing `npx skills add Necmttn/ax` contents, or `apps/site` content). Search: `rg -l "ax-extract-workflow" --type md README.md docs/ apps/site/` and add `dojo` wherever sibling skills are enumerated.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/dojo/SKILL.md
+git commit -m "feat(skills): ax:dojo - surplus-quota training loop skill"
+```
+
+---
+
+### Task 12: full verification + PR
+
+- [ ] **Step 1: Full test suite**
+
+Run: `bun test`
+Expected: all pass (if a global hook blocks bare `bun test`, use the tmp-wrapper workaround from project memory).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run typecheck`
+Expected: clean. Specifically confirm no `as never` seams survive in `apps/axctl/src/dojo/agenda.ts`.
+
+- [ ] **Step 3: Docs gate + smoke**
+
+Run: `bun run check:cli-reference` - Expected: exit 0.
+Run: `bun apps/axctl/src/cli/index.ts dojo` - Expected: human agenda renders against the live local graph.
+Run: `bun apps/axctl/src/cli/index.ts dojo --json | jq .budget` - Expected: envelope object with `spendable_pct`.
+
+- [ ] **Step 4: PR**
+
+```bash
+git push -u origin feat/ax-dojo-spec
+gh pr create --title "feat: ax dojo - surplus-quota training loop (agenda CLI + skill)" --body "$(cat <<'EOF'
+## Summary
+- `ax dojo [--json]`: budget envelope (quota window remaining - reserve, deadline = reset) + prioritized self-clearing agenda (verdicts, briefs, routing backtests, proposal minting, churn experiments, opt-in spar, explore fallback)
+- `skills/dojo/SKILL.md`: thin loop driver - /dojo composes /loop on Claude Code, single long turn on Codex; proposal-gated autonomy, outbox-only upstream drafts, morning report
+- spec: docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+
+## Deferred (follow-up plans)
+hook latency bench, spar execution mechanics, MCP dojo_agenda tool, cron trigger
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR opens; CI green (bun test + typecheck + check:cli-reference).

--- a/docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+++ b/docs/superpowers/specs/2026-06-13-ax-dojo-design.md
@@ -92,9 +92,21 @@ Per lap:
 3. take the top item, follow its playbook
 4. goto 1
 
-On Claude Code it pairs naturally with `/loop` dynamic mode; on Codex the
-same SKILL.md drives the loop. The skill text contains no discovery logic -
-only loop mechanics + per-kind playbooks.
+**Entry mechanics** (user types `/dojo`, nothing else):
+
+- Claude Code: skills compose - the dojo SKILL.md's first step invokes
+  `/loop` dynamic mode with `/dojo` as the prompt, which unlocks
+  `ScheduleWakeup` self-pacing between laps (wakeups re-fire the skill, so
+  the run survives early turn-ends and context growth). Typing `/loop /dojo`
+  directly reaches the same path. A bare skill cannot self-schedule wakeups
+  without entering through /loop - that gating is why dojo composes rather
+  than reimplements.
+- Codex: no /loop equivalent - v1 runs as one long in-turn loop ("do not
+  end the turn until budget exhausted or agenda empty"). Weaker resilience,
+  acceptable for v1.
+
+The skill text contains no discovery logic - only loop mechanics + per-kind
+playbooks.
 
 ### Training output = proposals
 
@@ -186,8 +198,6 @@ later.
 
 ## Open questions
 
-- Does Codex expose enough loop control for parity, or does v1 Codex run as
-  a single long turn?
 - Cost-class estimation: static per-kind, or learned from dispatch history?
 - Spar model deltas: subagent model override covers Claude-family swaps on
   plan quota; is that enough for v1, or does model comparison need the

--- a/docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+++ b/docs/superpowers/specs/2026-06-13-ax-dojo-design.md
@@ -108,6 +108,21 @@ Per lap:
 The skill text contains no discovery logic - only loop mechanics + per-kind
 playbooks.
 
+**Heavy items become goal packages** (`/goal` composition, one level down):
+
+- /loop and /goal terminate differently: /loop ends on budget/deadline
+  (dojo's outer driver - "done" is never "objective complete"); /goal ends
+  on objective gates. So /goal never drives the night, but a *heavy agenda
+  item* - a spar campaign, a multi-replay experiment - is exactly a goal:
+  objective, checkpoint index, gates, evidence log (prior art:
+  `docs/superpowers/goals/*.md`, e.g. the SetFit goal's E0-E498 arc).
+- Dojo lap on a heavy item: create-or-resume its goal file, advance
+  checkpoints until the lap budget says stop, leave the checkpoint index
+  updated. The NEXT dojo session resumes the same goal where it stopped.
+- Net effect: the goals dir is dojo's **curriculum** - cross-night memory
+  for experiments too big for one surplus window; gates decide when a
+  campaign is concluded and its proposal ships.
+
 ### Training output = proposals
 
 - **Code experiments**: worktrees only (existing enforce-worktree hooks

--- a/docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+++ b/docs/superpowers/specs/2026-06-13-ax-dojo-design.md
@@ -74,7 +74,8 @@ New module `apps/axctl/src/dojo/`. Composes two things:
 | 4 | `proposal_mint` | fresh `ax improve recommend` pass | generate new grounded proposals |
 | 5 | `experiment` | churn hotspots (`ax sessions churn`) | worktree experiment: fix/hook/skill, backtest, emit proposal |
 | 6 | `upstream_draft` | findings during any item | write issue draft to outbox with repro + session refs |
-| 7 | `explore` | agenda dry | retro-meta style free investigation |
+| 7 | `spar` | opt-in (`--spar`), needs large surplus | replay benchmark: one variable changed, scored delta (see Sparring) |
+| 8 | `explore` | agenda dry | retro-meta style free investigation |
 
 Each item: `id`, `kind`, `commands` (exact CLI invocations), `success`
 criteria, `cost_class` (s/m/l). The agenda is **derived state** - a locked
@@ -101,11 +102,53 @@ only loop mechanics + per-kind playbooks.
   already block main writes). Branch + evidence, surfaced as an improve
   proposal; optionally a draft PR.
 - **New hooks**: authored via `@ax/hooks-sdk`, validated with
-  `ax hooks backtest` (evidence attached), shipped as a proposal.
+  `ax hooks backtest` (evidence attached), shipped as a proposal. Evidence
+  must show **both sides of the ledger**:
+  - *benefit*: cases from history this hook would have caught/fixed
+  - *cost*: per-fire latency (p50/p95 measured during backtest), estimated
+    fires/day from tool_call history → daily overhead, and the **cumulative
+    installed-chain latency** (every hook rides the ~70ms bun hot path;
+    chains add up). Agenda warns when total chain exceeds a budget
+    (default ~250ms per event); dojo must reject its own hook when overhead
+    outweighs benefit.
 - **New skills**: scaffolded draft + usage evidence from the graph, shipped
   as a proposal.
 - **Merging the proposal activates it.** Morning user reviews a queue, never
   a surprise diff.
+
+### Sparring - opt-in replay benchmarks (`--spar`)
+
+The dojo metaphor's practice matches. Context: the field needs better
+harness/model benchmarks; the user's own transcript history is a benchmark
+corpus nobody else has.
+
+Mechanism - **one task, one delta, scored**:
+
+1. Pick a past task with a known outcome from the graph (a session that
+   landed a commit; `ax sessions near <sha>` gives the window).
+2. Pin a worktree at the parent commit - frozen environment.
+3. Re-run the same task prompt with exactly **one variable changed**:
+   model, skill present/absent, hook present/absent, thinking level, or
+   prompt wording.
+4. Score the delta from the graph's own metrics: tokens spent, turns,
+   verification churn / episodes, wall time, did-it-land.
+5. Output a **spar report** (receipt-style comparison, baseline vs variant)
+   into the dojo report + optionally an improve proposal ("adding skill X
+   to this task class saves ~N tokens").
+
+Guardrails:
+
+- opt-in only (`--spar` flag or config), `cost_class: xl` - agenda includes
+  spar items only when surplus is large (a spar can burn a meaningful slice
+  of the window)
+- pinned worktree, no pushes; baseline = the historical run (free - already
+  in the graph), so one spar = one live re-run, not two
+- variant runs are tagged in the graph (so spar traffic never pollutes
+  taste/usage analytics)
+
+v1 ships the mechanism for skill/hook/prompt deltas inside the same harness
+(model deltas via subagent model override where the harness allows it);
+cross-harness sparring (Claude Code vs Codex on the same task) is v2.
 
 ### Outbox + report
 
@@ -128,6 +171,10 @@ later.
 - outbox, never unattended publishing
 - budget reserve keeps 15% of the window untouched
 - `--force` required to dojo with no surplus
+- hook proposals carry a latency ledger; installed-chain budget warns at
+  ~250ms/event
+- spar is opt-in, surplus-gated, and tagged so benchmark runs never pollute
+  usage analytics
 
 ## Out of scope (v1)
 
@@ -142,3 +189,8 @@ later.
 - Does Codex expose enough loop control for parity, or does v1 Codex run as
   a single long turn?
 - Cost-class estimation: static per-kind, or learned from dispatch history?
+- Spar model deltas: subagent model override covers Claude-family swaps on
+  plan quota; is that enough for v1, or does model comparison need the
+  harness's own model switch?
+- Hook latency measurement: extend `ax hooks backtest` with timing, or a
+  separate `ax hooks bench`? How to attribute fires/day per event type?

--- a/docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+++ b/docs/superpowers/specs/2026-06-13-ax-dojo-design.md
@@ -1,0 +1,144 @@
+# ax dojo - overnight training loop for agents
+
+Date: 2026-06-13
+Status: approved design, pre-implementation
+
+## Problem
+
+First-run ax story is clear: install → ingest → dashboard shows routes,
+insights, improve section. The recurring story is not. After setup, what does
+the user *do* with ax week over week?
+
+Vision: users end their 5h/weekly quota windows with unspent tokens. One
+command, triggered inside their harness of choice (Claude Code or Codex),
+sends the agent into detective mode - backtest history, drain pending
+judgment queues, run experiments, mint new skills/hooks, draft upstream bug
+reports - burning the surplus before the window resets. Like dreaming, but
+more than memory consolidation: the agent *trains*. Hence **dojo** - agents
+train overnight and come back with solutions.
+
+## Decisions (locked)
+
+1. **Runner**: v1 is an in-session skill loop on the user's plan quota. No
+   headless `claude -p` (that burns API, not plan). Cron/launchd automation
+   deferred until the loop works manually.
+2. **Blast radius**: full-autonomy *capable*, proposal-*gated*. All code work
+   happens in worktrees, backed by backtests against prior transcript
+   history. Output lands as `ax improve` proposals - **merging a proposal is
+   what activates it**. Dojo never merges, never touches main.
+3. **Brain location**: `ax dojo` CLI emits a machine-readable agenda; the
+   skill is a thin loop driver. Logic is typed, Effect-native, testable; the
+   Codex port is free because the brain lives in the CLI.
+4. **Budget**: the agenda carries the budget envelope, computed from the
+   quota module. Skill re-checks every lap.
+5. **Upstream reporting**: draft locally to an outbox, publish only on
+   morning review. Nothing leaves the machine unattended.
+6. **Name**: dojo. `ax dojo` subcommand, `ax:dojo` skill.
+
+## Architecture
+
+Two pieces, one brain:
+
+```
+ax:dojo skill (thin loop)            ax dojo CLI (brain)
+┌─────────────────────────┐          ┌──────────────────────────────┐
+│ loop:                   │  --json  │ budget envelope (QuotaEnv)   │
+│   ax dojo --json ───────┼─────────▶│ + prioritized agenda items   │
+│   budget gone / empty?  │          │   derived from existing      │
+│     → write report, stop│          │   queries - self-clearing    │
+│   else: top item        │          └──────────────────────────────┘
+│     → execute playbook  │
+│     → repeat            │
+└─────────────────────────┘
+```
+
+### `ax dojo [--json]` - the agenda
+
+New module `apps/axctl/src/dojo/`. Composes two things:
+
+**Budget envelope** (reuses `apps/axctl/src/quota/` QuotaEnv seam):
+
+- `spendable` = remaining tokens in the current window − reserve
+  (default 15% headroom)
+- `deadline` = next window reset (min of 5h and 7d resets)
+- starting with no surplus → warn, proceed only with `--force`
+- overrides: `--budget=N%`, `--until=HH:MM`
+
+**Agenda items**, priority order (cheap + high-signal first):
+
+| # | kind | source | playbook sketch |
+|---|------|--------|-----------------|
+| 1 | `verdict_pending` | improve loop pending verdicts | confirm/override verdict with retro evidence |
+| 2 | `brief_unfilled` | `.ax/tasks/*.md` (classify, routing-tune, improve accept) | fill brief, run the matching lint/apply command |
+| 3 | `routing_backtest` | judgment-flagged routing-tune candidates | backtest class against history, apply or reject |
+| 4 | `proposal_mint` | fresh `ax improve recommend` pass | generate new grounded proposals |
+| 5 | `experiment` | churn hotspots (`ax sessions churn`) | worktree experiment: fix/hook/skill, backtest, emit proposal |
+| 6 | `upstream_draft` | findings during any item | write issue draft to outbox with repro + session refs |
+| 7 | `explore` | agenda dry | retro-meta style free investigation |
+
+Each item: `id`, `kind`, `commands` (exact CLI invocations), `success`
+criteria, `cost_class` (s/m/l). The agenda is **derived state** - a locked
+verdict, filled brief, or created proposal disappears from the next lap's
+agenda automatically. No new SurrealDB table in v1.
+
+### `ax:dojo` skill - the loop
+
+Lives in the ax skills set (installable via `npx skills add Necmttn/ax`).
+Per lap:
+
+1. `ax dojo --json`
+2. budget exhausted, deadline passed, or agenda empty → write report, stop
+3. take the top item, follow its playbook
+4. goto 1
+
+On Claude Code it pairs naturally with `/loop` dynamic mode; on Codex the
+same SKILL.md drives the loop. The skill text contains no discovery logic -
+only loop mechanics + per-kind playbooks.
+
+### Training output = proposals
+
+- **Code experiments**: worktrees only (existing enforce-worktree hooks
+  already block main writes). Branch + evidence, surfaced as an improve
+  proposal; optionally a draft PR.
+- **New hooks**: authored via `@ax/hooks-sdk`, validated with
+  `ax hooks backtest` (evidence attached), shipped as a proposal.
+- **New skills**: scaffolded draft + usage evidence from the graph, shipped
+  as a proposal.
+- **Merging the proposal activates it.** Morning user reviews a queue, never
+  a surprise diff.
+
+### Outbox + report
+
+- `~/.ax/dojo/outbox/*.md` - upstream issue drafts (full evidence). Publish
+  on review via the existing `ax-repo` skill / `gh`.
+- `~/.ax/dojo/reports/<date>.md` - what trained, what was proposed, tokens
+  spent vs envelope.
+- v2: dojo report feeds the dashboard next-actions panel.
+
+### Scope
+
+Graph chores (verdicts, briefs, routing, proposals) are global. Code
+experiments are scoped to the current repo in v1; multi-repo selection
+later.
+
+## Safety rails (summary)
+
+- worktree-only edits (deterministic hooks, not skill prose)
+- proposals, never merges
+- outbox, never unattended publishing
+- budget reserve keeps 15% of the window untouched
+- `--force` required to dojo with no surplus
+
+## Out of scope (v1)
+
+- cron/launchd auto-trigger near window end (v2; prior art:
+  `~/.claude/self-improve/` launchd setup)
+- dashboard dojo surface
+- multi-repo experiment selection
+- `dojo_run` history table (reports are files first)
+
+## Open questions
+
+- Does Codex expose enough loop control for parity, or does v1 Codex run as
+  a single long turn?
+- Cost-class estimation: static per-kind, or learned from dispatch history?

--- a/skills/dojo/SKILL.md
+++ b/skills/dojo/SKILL.md
@@ -12,7 +12,7 @@ docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
 ## Entry
 
 1. Run `ax dojo --json`. If it fails with a connection error, tell the user
-   to run `scripts/db-start.sh` (or `ax doctor`) and STOP.
+   to run `ax doctor` and STOP.
 2. If `budget.has_surplus` is false: report the envelope and STOP unless the
    user re-invokes with `--force` (then pass `--force` on every lap).
 3. On Claude Code: enter loop mode now - invoke the `/loop` skill with

--- a/skills/dojo/SKILL.md
+++ b/skills/dojo/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: dojo
+description: Surplus-quota training loop over the ax graph - the agent burns the remaining 5h/7d plan-quota window on self-improvement: locking pending verdicts, filling briefs, backtesting routing classes, minting proposals, running worktree experiments, and drafting upstream issue reports. Triggers when the user says "/dojo", "enter the dojo", "dojo time", "train overnight", "burn my surplus quota", "dream mode" (legacy name), or invokes /loop /dojo. Requires ax (axctl) on PATH and the local SurrealDB running. Do NOT auto-trigger on unrelated work or when the user merely mentions quotas.
+---
+
+# ax:dojo - overnight training loop
+
+You are entering a budget-bounded self-improvement loop. The brain is
+`ax dojo --json`; you are the thin driver. Spec for humans:
+docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
+
+## Entry
+
+1. Run `ax dojo --json`. If it fails with a connection error, tell the user
+   to run `scripts/db-start.sh` (or `ax doctor`) and STOP.
+2. If `budget.has_surplus` is false: report the envelope and STOP unless the
+   user re-invokes with `--force` (then pass `--force` on every lap).
+3. On Claude Code: enter loop mode now - invoke the `/loop` skill with
+   `/dojo` as the recurring prompt (dynamic mode, self-paced). Each wakeup
+   re-runs this skill from the top; that is expected and correct.
+   On Codex (no /loop): run as ONE long turn - do not end the turn until a
+   stop condition below is met.
+
+## The lap
+
+1. `ax dojo --json` -> agenda.
+2. STOP conditions (write the report, then stop):
+   - `budget.has_surplus` is false (and not forced)
+   - now >= `budget.deadline`
+   - `items` is empty
+3. Otherwise: take `items[0]`, follow its playbook below, then go to 1.
+   Completed work self-clears: the item vanishes from the next agenda
+   because the underlying system recorded it (verdict locked, brief
+   consumed, proposal created). If the same item survives 2 laps untouched,
+   skip it and note why in the report.
+
+## Playbooks by kind
+
+- **verdict_pending** - `ax improve verdict <id>` to see the suggested
+  verdict + checkpoint evidence; confirm with `--set <verdict>` only when
+  the evidence supports it. Distinguish "pattern resolved" from "artifact
+  never fired" before locking no_longer_needed.
+- **brief_unfilled** - open the `.ax/tasks/*.md` brief, do what it says in
+  the target files, then run the reconciler it names (`ax skills lint` /
+  `ax improve lint`).
+- **routing_backtest** - judgment-flagged routing classes: backtest the
+  pattern against dispatch history (`ax dispatches --candidates`), check
+  false-positive risk, then `ax routing tune --apply=<ids> --days=<window>`
+  or reject with a written rationale in the report.
+- **proposal_mint** - `ax improve recommend`; accept the grounded ones
+  (`ax improve accept <id>`) so briefs exist for the next lap.
+- **experiment** - heavy item. Work ONLY in a fresh worktree
+  (`git worktree add .claude/worktrees/dojo-<slug> -b dojo/<slug>`).
+  Reproduce the churn pattern, attempt the fix/hook/skill, capture evidence.
+  If it will not finish inside this budget: package it as a goal file
+  (objective + checkpoint index + gates) under docs/superpowers/goals/ so
+  the NEXT dojo session resumes it. Output = an improve proposal; merging
+  the proposal is what activates anything. NEVER merge, never touch main.
+- **New hooks specifically** - author via @ax/hooks-sdk, validate with
+  `ax hooks backtest <file>`, and put BOTH sides in the proposal: cases it
+  would have caught AND the latency ledger (per-fire cost, est fires/day,
+  cumulative installed-chain overhead). Reject your own hook when overhead
+  outweighs benefit.
+- **spar** - only present when invoked with --spar and surplus is large.
+  One task, one delta, scored: pick a landed task (`ax sessions here`),
+  pin a worktree at the parent SHA, re-run it with exactly ONE change
+  (skill on/off, hook on/off, prompt, thinking level, model via subagent
+  override), score against the historical baseline using graph metrics
+  (tokens, turns, churn, landed). Append the comparison receipt to the
+  report. Track multi-night campaigns as goal files.
+- **explore** - free investigation, retro-meta style: follow a hunch
+  through `ax recall` / `ax sessions churn`, and convert anything real
+  into a proposal or outbox draft.
+- **Upstream findings (any lap)** - an ax bug or improvement found while
+  training goes to `~/.ax/dojo/outbox/<slug>.md` as a complete issue draft
+  (title, body, repro, session refs). NEVER publish from the dojo - the
+  user reviews and publishes in the morning (ax-repo skill / gh).
+
+## Exit - the morning report
+
+Write `~/.ax/dojo/reports/<YYYY-MM-DD>.md` (create dirs if missing):
+- budget: envelope at start, spendable consumed (re-run `ax quota` and diff)
+- per lap: item, what happened, evidence refs
+- proposals created/advanced, briefs filled, verdicts locked
+- outbox drafts awaiting review (list paths)
+- skipped/stuck items and why
+Then tell the user the report path and the top 3 things awaiting their
+review. Done.
+
+## Hard rails
+
+- worktrees only; never write on main; never merge anything
+- proposals are the only activation path
+- outbox only; nothing leaves the machine
+- respect the deadline even mid-item: checkpoint, report, stop

--- a/skills/dojo/SKILL.md
+++ b/skills/dojo/SKILL.md
@@ -25,7 +25,7 @@ docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
 
 1. `ax dojo --json` -> agenda.
 2. STOP conditions (write the report, then stop):
-   - `budget.has_surplus` is false (and not forced)
+   - `budget.has_surplus` is false
    - now >= `budget.deadline`
    - `items` is empty
 3. Otherwise: take `items[0]`, follow its playbook below, then go to 1.
@@ -61,7 +61,7 @@ docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
   would have caught AND the latency ledger (per-fire cost, est fires/day,
   cumulative installed-chain overhead). Reject your own hook when overhead
   outweighs benefit.
-- **spar** - only present when invoked with --spar and surplus is large.
+- **spar** - only present when invoked with --spar and spendable >= 30%.
   One task, one delta, scored: pick a landed task (`ax sessions here`),
   pin a worktree at the parent SHA, re-run it with exactly ONE change
   (skill on/off, hook on/off, prompt, thinking level, model via subagent
@@ -72,7 +72,8 @@ docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
   through `ax recall` / `ax sessions churn`, and convert anything real
   into a proposal or outbox draft.
 - **Upstream findings (any lap)** - an ax bug or improvement found while
-  training goes to `~/.ax/dojo/outbox/<slug>.md` as a complete issue draft
+  training (items of kind `upstream_draft` are handled by this same rule)
+  goes to `~/.ax/dojo/outbox/<slug>.md` as a complete issue draft
   (title, body, repro, session refs). NEVER publish from the dojo - the
   user reviews and publishes in the morning (ax-repo skill / gh).
 


### PR DESCRIPTION
## Summary
- **`ax dojo [--json]`**: budget envelope (quota window remaining − 15% reserve, deadline = earliest window reset, `--budget/--until/--force` overrides) + prioritized self-clearing agenda: pending verdicts → unfilled `.ax/tasks` briefs → judgment-flagged routing backtests → proposal minting (open pool < 3) → churn-hotspot experiments → opt-in spar (`--spar` + ≥30% spendable) → explore fallback. Items vanish when the underlying system records the work (verdict locked / brief consumed / proposal created). Per-source failure isolation: a broken source logs and contributes nothing, never kills the agenda.
- **`skills/dojo/SKILL.md`**: thin loop driver — `/dojo` composes `/loop` dynamic mode on Claude Code, single long turn on Codex. Proposal-gated autonomy (worktrees only, merge-=-activate), outbox-only upstream drafts (`~/.ax/dojo/outbox/`), morning report (`~/.ax/dojo/reports/<date>.md`).
- `listPendingVerdicts` query (improve), CLI registration (`runtime: db`), docs gate (cli.md + llms.txt + CLAUDE.md + README skills list).
- Spec: `docs/superpowers/specs/2026-06-13-ax-dojo-design.md`; plan: `docs/superpowers/plans/2026-06-13-ax-dojo-core.md`.

## Notes for reviewers
- Routing-tune briefs classify as `routing_backtest` (priority 3), a deliberate refinement of the spec's row-2 placement — the backtest playbook is what applies to them.
- `paths.ts` outbox/report helpers are contract anchors for the future report CLI; today only SKILL.md prose + tests use them.
- `upstream_draft` kind exists in the schema but no source emits it — SKILL.md handles upstream findings as an any-lap rule.

## Test plan
- [x] `bun test` repo-wide: 3829 pass / 0 fail
- [x] `bun run typecheck`: no errors (pre-existing lint-style messages only)
- [x] `bun run check:cli-reference` + `check:no-node-fs`: clean
- [x] Live smoke: `ax dojo` against the real graph — budget line from live quota, 4 real briefs + routing candidates as items; `--force --budget=50 --until=23:00` flag flow verified

## Deferred (follow-up plans)
hook latency bench (`ax hooks bench`), spar execution mechanics, MCP `dojo_agenda` tool, cron/launchd trigger near window end

🤖 Generated with [Claude Code](https://claude.com/claude-code)