### PR TITLE
feat(site): IA restructure - install path, three-tier docs hub, sitemap footer, ADR demotion

### DIFF
--- a/apps/site/app/components/landing-sections/site-footer.tsx
+++ b/apps/site/app/components/landing-sections/site-footer.tsx
@@ -1,14 +1,46 @@
+import { Link } from "@tanstack/react-router";
+
 export function SiteFooter() {
   return (
-    <footer>
-      <div className="row">
-        <div>
-          <a href="https://github.com/Necmttn/ax" target="_blank" rel="noopener noreferrer">github.com/Necmttn/ax</a>
-          &nbsp;·&nbsp; <a href="https://discord.gg/E4R88Cvr5R" target="_blank" rel="noopener noreferrer">Discord</a>
-          &nbsp;·&nbsp; AGPL-3.0 licensed
-          &nbsp;·&nbsp; 2026
+    <footer className="site-footer">
+      <nav className="footer-sitemap" aria-label="Footer">
+        <div className="footer-col">
+          <div className="footer-col-head">Product</div>
+          <Link to="/features">Features</Link>
+          <Link to="/routing">Routing</Link>
+          <Link to="/showcases">Showcases</Link>
+          <Link to="/changelog">Changelog</Link>
         </div>
-        <div className="right">the missing layer</div>
+        <div className="footer-col">
+          <div className="footer-col-head">Story</div>
+          <Link to="/origin">Origin</Link>
+          <Link to="/manifesto">Manifesto</Link>
+        </div>
+        <div className="footer-col">
+          <div className="footer-col-head">Community</div>
+          <Link to="/leaders">Leaders</Link>
+          <a href="https://github.com/Necmttn/ax" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://discord.gg/E4R88Cvr5R" target="_blank" rel="noopener noreferrer">Discord</a>
+        </div>
+        <div className="footer-col">
+          <div className="footer-col-head">Docs</div>
+          <Link to="/docs/install">Install</Link>
+          <Link to="/docs/cli-reference">CLI reference</Link>
+          <Link to="/docs/language">Concepts</Link>
+        </div>
+      </nav>
+
+      <div className="footer-base">
+        <div className="footer-base-links">
+          <Link to="/teams">For teams</Link>
+          <span aria-hidden="true">·</span>
+          <Link to="/registry">Registry</Link>
+          <span aria-hidden="true">·</span>
+          <Link to="/brand">Brand</Link>
+        </div>
+        <div className="footer-base-meta">
+          AGPL-3.0 licensed &nbsp;·&nbsp; 2026 &nbsp;·&nbsp; the missing layer
+        </div>
       </div>
     </footer>
   );

--- a/apps/site/app/components/landing-sections/site-header.tsx
+++ b/apps/site/app/components/landing-sections/site-header.tsx
@@ -30,13 +30,25 @@ export function SiteHeader() {
 
       <nav className="top-nav">
         <Link to="/features">Features</Link>
+        <Link to="/routing">Routing</Link>
         <Link to="/showcases">Showcases</Link>
         <Link to="/leaders">Leaders</Link>
         <Link to="/how-it-works">How</Link>
         <Link to="/docs">Docs</Link>
-        <Link to="/changelog">Changelog</Link>
         <Link to="/origin">Origin</Link>
-        <a className="primary" href="https://github.com/Necmttn/ax" target="_blank" rel="noopener noreferrer">GitHub →</a>
+        <a
+          className="nav-icon"
+          href="https://github.com/Necmttn/ax"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="ax on GitHub"
+          title="ax on GitHub"
+        >
+          <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+          </svg>
+        </a>
+        <Link className="primary" to="/docs/install">Install</Link>
       </nav>
     </header>
   );

--- a/apps/site/app/components/landing-v2/footer-cards.tsx
+++ b/apps/site/app/components/landing-v2/footer-cards.tsx
@@ -4,16 +4,16 @@ export function FooterCards() {
   return (
     <section className="cards">
       <div className="cards-grid">
-        <Link className="card" to="/how-it-works">
+        <Link className="card" to="/docs/install">
           <span className="num">01</span>
           <span className="card-title">
-            How it works <span className="arrow">&rarr;</span>
+            Install ax <span className="arrow">&rarr;</span>
           </span>
         </Link>
-        <Link className="card" to="/showcases">
+        <Link className="card" to="/routing">
           <span className="num">02</span>
           <span className="card-title">
-            Showcases <span className="arrow">&rarr;</span>
+            Routing <span className="arrow">&rarr;</span>
           </span>
         </Link>
         <Link className="card" to="/features">

--- a/apps/site/app/routes/docs/adr.$slug.tsx
+++ b/apps/site/app/routes/docs/adr.$slug.tsx
@@ -6,7 +6,11 @@ import { DocShell } from "~/components/doc-shell";
 
 export const Route = createFileRoute("/docs/adr/$slug")({
   head: ({ loaderData }) => ({
-    meta: [{ title: `${loaderData?.adr.title ?? "ADR"} - ax` }],
+    meta: [
+      { title: `${loaderData?.adr.title ?? "ADR"} - ax` },
+      // ADRs are internal engineering records, not visitor-facing docs.
+      { name: "robots", content: "noindex, nofollow" },
+    ],
   }),
   loader: ({ params }) => {
     const adr = allAdrs.find((a) => a.slug === params.slug);
@@ -18,8 +22,14 @@ export const Route = createFileRoute("/docs/adr/$slug")({
 
 function AdrPage() {
   const { adr } = Route.useLoaderData();
+  // The markdown body carries its own H1, so DocShell renders no title here -
+  // that avoids a second, slug-mangled headline competing with the real one.
   return (
-    <DocShell eyebrow="architecture decision record" title={adr.title}>
+    <DocShell eyebrow="architecture decision record">
+      <p className="adr-preface">
+        Internal working engineering record - kept for reference, not a
+        user-facing guide.
+      </p>
       <MDXContent code={adr.body} components={mdxComponents} />
     </DocShell>
   );

--- a/apps/site/app/routes/docs/index.tsx
+++ b/apps/site/app/routes/docs/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { allAdrs, allPages } from "content-collections";
+import { allAdrs } from "content-collections";
 import { SiteHeader } from "~/components/landing-sections/site-header";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
 
@@ -7,54 +7,122 @@ export const Route = createFileRoute("/docs/")({
   head: () => ({
     meta: [
       { title: "Docs - ax" },
-      { name: "description", content: "Reference, guides, and architecture decision records for ax." },
+      {
+        name: "description",
+        content:
+          "Install ax, learn the language, and look up any command. Guides for every shipped loop plus the full CLI reference.",
+      },
     ],
   }),
   loader: () => ({
     adrs: [...allAdrs].sort((a, b) => a.slug.localeCompare(b.slug)),
-    pageCount: allPages.length,
   }),
   component: DocsIndex,
 });
 
-const REFERENCE = [
+type Card = {
+  to: string;
+  params?: Record<string, string>;
+  kicker: string;
+  title: string;
+  blurb: string;
+};
+
+const START: Card[] = [
   {
-    to: "/how-it-works" as const,
+    to: "/docs/install",
+    kicker: "start here",
+    title: "Install ax",
+    blurb:
+      "One curl, the skills, your first ingest, then ax improve recommend. The obvious first stop.",
+  },
+];
+
+const GUIDES: Card[] = [
+  {
+    to: "/features",
     kicker: "guide",
-    title: "How ax sees your work",
-    blurb: "From raw transcripts to a typed graph - the ingest pipeline, stage by stage.",
+    title: "The improve deck",
+    blurb:
+      "Mined proposals reviewed one at a time, an impact engine, and the experiments strip - past bets, measured.",
   },
   {
-    to: "/docs/language" as const,
-    kicker: "reference",
-    title: "Language",
-    blurb: "The shared vocabulary - sessions, turns, roles, verdicts, and how they connect.",
+    to: "/routing",
+    kicker: "guide",
+    title: "Cost routing",
+    blurb:
+      "ax dispatches and ax routing tune|compile|show route mechanical work to cheaper models. Receipts, not vibes.",
   },
   {
-    to: "/docs/cli-reference" as const,
+    to: "/features",
+    kicker: "guide",
+    title: "Hooks SDK",
+    blurb:
+      "Author typed Effect TS hooks once, run them on Claude Code and Codex. Deterministic guards, fail-open.",
+  },
+  {
+    to: "/leaders",
+    kicker: "guide",
+    title: "Profiles & community",
+    blurb:
+      "ax profile publish posts a public gist; /u/<login> and /leaders render the registered boards.",
+  },
+  {
+    to: "/features",
+    kicker: "guide",
+    title: "MCP server",
+    blurb:
+      "ax mcp exposes ten read-only graph queries over stdio so an agent can query your history in-context.",
+  },
+  {
+    to: "/features",
+    kicker: "guide",
+    title: "Quota, recall & churn",
+    blurb:
+      "ax quota tracks live plan usage; ax recall searches turns, commits and skills; ax sessions churn measures verification churn.",
+  },
+];
+
+const REFERENCE: Card[] = [
+  {
+    to: "/docs/cli-reference",
     kicker: "reference",
     title: "CLI reference",
     blurb: "Every ax command, flag, and scoped query you can run from the terminal.",
   },
   {
-    to: "/changelog" as const,
+    to: "/docs/language",
+    kicker: "reference",
+    title: "Language",
+    blurb: "The shared vocabulary - sessions, turns, roles, verdicts, and how they connect.",
+  },
+  {
+    to: "/changelog",
     kicker: "releases",
     title: "Changelog",
     blurb: "Release announcements in product language, plus the generated commit log.",
   },
-  {
-    to: "/manifesto" as const,
-    kicker: "position paper",
-    title: "Manifesto",
-    blurb: "Why the agent experience layer needs to exist at all.",
-  },
-  {
-    to: "/brand" as const,
-    kicker: "brand",
-    title: "Brand",
-    blurb: "Voice, wordmark, and palette for anyone referencing ax.",
-  },
 ];
+
+function CardGrid({ cards }: { cards: Card[] }) {
+  return (
+    <div className="docs-grid">
+      {cards.map((item, i) => (
+        <Link
+          key={`${item.to}-${i}`}
+          to={item.to}
+          params={item.params}
+          className="docs-card"
+        >
+          <span className="docs-card-kicker">{item.kicker}</span>
+          <span className="docs-card-title">{item.title}</span>
+          <span className="docs-card-blurb">{item.blurb}</span>
+          <span className="docs-card-arrow" aria-hidden="true">→</span>
+        </Link>
+      ))}
+    </div>
+  );
+}
 
 function DocsIndex() {
   const { adrs } = Route.useLoaderData();
@@ -65,41 +133,51 @@ function DocsIndex() {
         <header className="docs-hero">
           <p className="eyebrow">documentation</p>
           <h1>
-            Everything ax <em>knows how to tell you</em>.
+            Install it, learn the language, <em>look up any command</em>.
           </h1>
           <p className="lede">
-            Reference for the CLI and the graph language, the guides behind the
-            pipeline, and the architecture decisions that got us here.
+            Start with the install path, then the guides behind each shipped
+            loop, then the full command reference.
           </p>
         </header>
 
         <section className="docs-section">
-          <div className="section-kicker">reference &amp; guides</div>
-          <div className="docs-grid">
-            {REFERENCE.map((item) => (
-              <Link key={item.to} to={item.to} className="docs-card">
-                <span className="docs-card-kicker">{item.kicker}</span>
-                <span className="docs-card-title">{item.title}</span>
-                <span className="docs-card-blurb">{item.blurb}</span>
-                <span className="docs-card-arrow" aria-hidden="true">→</span>
-              </Link>
-            ))}
-          </div>
+          <div className="section-kicker">start here</div>
+          <CardGrid cards={START} />
         </section>
 
         <section className="docs-section">
-          <div className="section-kicker">architecture decision records</div>
-          <ul className="docs-adr-list">
-            {adrs.map((adr) => (
-              <li key={adr.slug}>
-                <Link to="/docs/adr/$slug" params={{ slug: adr.slug }}>
-                  <span className="adr-slug">{adr.slug.replace(/^(\d+)-.*/, "ADR $1")}</span>
-                  <span className="adr-title">{adr.title}</span>
-                  <span className="adr-arrow" aria-hidden="true">→</span>
-                </Link>
-              </li>
-            ))}
-          </ul>
+          <div className="section-kicker">guides</div>
+          <CardGrid cards={GUIDES} />
+        </section>
+
+        <section className="docs-section">
+          <div className="section-kicker">reference</div>
+          <CardGrid cards={REFERENCE} />
+        </section>
+
+        <section className="docs-section docs-quiet">
+          <details className="docs-quiet-records">
+            <summary>
+              Engineering records →
+              <span className="docs-quiet-note">
+                {adrs.length} internal architecture decision records
+              </span>
+            </summary>
+            <ul className="docs-adr-list">
+              {adrs.map((adr) => (
+                <li key={adr.slug}>
+                  <Link to="/docs/adr/$slug" params={{ slug: adr.slug }}>
+                    <span className="adr-slug">
+                      {adr.slug.replace(/^(\d+)-.*/, "$1")}
+                    </span>
+                    <span className="adr-title">{adr.title}</span>
+                    <span className="adr-arrow" aria-hidden="true">→</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </details>
         </section>
       </main>
       <SiteFooter />

--- a/apps/site/app/routes/docs/install.tsx
+++ b/apps/site/app/routes/docs/install.tsx
@@ -1,0 +1,154 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+import { DocShell } from "~/components/doc-shell";
+
+export const Route = createFileRoute("/docs/install")({
+  head: () => ({
+    meta: [
+      { title: "Install ax - the agent experience layer" },
+      {
+        name: "description",
+        content:
+          "Get ax running in five steps: one curl for the CLI, the skills, your first ingest watched live at ax serve, ax doctor to verify, then your first ax improve recommend.",
+      },
+    ],
+  }),
+  component: InstallPage,
+});
+
+type Step = {
+  n: string;
+  label: string;
+  title: string;
+  cmd: ReactNode;
+  note: ReactNode;
+};
+
+const STEPS: Step[] = [
+  {
+    n: "01",
+    label: "the cli",
+    title: "Install ax",
+    cmd: (
+      <>
+        <span className="prompt">$ </span>curl -fsSL ax.necmttn.com/install | sh
+      </>
+    ),
+    note: (
+      <>
+        One script. Drops the <code>ax</code> binary on your PATH and registers
+        the background watcher so new sessions get ingested automatically.
+      </>
+    ),
+  },
+  {
+    n: "02",
+    label: "the skills",
+    title: "Add the ax skills",
+    cmd: (
+      <>
+        <span className="prompt">$ </span>npx skills add Necmttn/ax
+      </>
+    ),
+    note: (
+      <>
+        Installs the retro and workflow-extraction skills your agent triggers
+        on - so the loop runs inside Claude Code, Codex, and the rest.
+      </>
+    ),
+  },
+  {
+    n: "03",
+    label: "first ingest",
+    title: "Ingest your history",
+    cmd: (
+      <>
+        <span className="prompt">$ </span>ax ingest
+      </>
+    ),
+    note: (
+      <>
+        Reads your coding-agent transcripts into the local graph. Watch it live
+        at <code>ax serve</code> →{" "}
+        <a href="http://127.0.0.1:1738" target="_blank" rel="noopener noreferrer">
+          http://127.0.0.1:1738
+        </a>
+        . Nothing leaves your machine.
+      </>
+    ),
+  },
+  {
+    n: "04",
+    label: "verify",
+    title: "Check the install",
+    cmd: (
+      <>
+        <span className="prompt">$ </span>ax doctor
+      </>
+    ),
+    note: (
+      <>
+        Confirms the CLI, the watcher, the skills, and the database are all
+        wired up. Green across the board means you're ready.
+      </>
+    ),
+  },
+  {
+    n: "05",
+    label: "first fix",
+    title: "See your first recommendation",
+    cmd: (
+      <>
+        <span className="prompt">$ </span>ax improve recommend
+      </>
+    ),
+    note: (
+      <>
+        ax surfaces the repeated mistakes it found and proposes small,
+        repo-specific fixes - reviewed one at a time. Receipts over vibes.
+      </>
+    ),
+  },
+];
+
+function InstallPage() {
+  return (
+    <DocShell
+      eyebrow="get started"
+      title="Install ax"
+      lede="Five steps from zero to your first mined fix. ax is local - your transcripts and graph never leave your machine."
+    >
+      <ol className="install-steps">
+        {STEPS.map((step) => (
+          <li className="install-step" key={step.n}>
+            <div className="install-step-head">
+              <span className="install-step-num">{step.n}</span>
+              <span className="install-step-label">{step.label}</span>
+              <span className="install-step-title">{step.title}</span>
+            </div>
+            <pre className="install">
+              <code>{step.cmd}</code>
+            </pre>
+            <p className="install-step-note">{step.note}</p>
+          </li>
+        ))}
+      </ol>
+
+      <hr />
+
+      <h2>What you just did</h2>
+      <p>
+        ax now watches your coding-agent sessions across every harness you run -
+        Claude Code, Codex, Pi, OpenCode, and Cursor - mines the mistakes that
+        repeat, and turns them into proposals you accept or reject one at a time.
+      </p>
+      <p>
+        Next stops: the{" "}
+        <Link to="/routing">cost-routing loop</Link> (route mechanical work to
+        cheaper models and measure the savings), the{" "}
+        <Link to="/docs/cli-reference">CLI reference</Link> for every command,
+        and the <Link to="/docs/language">language</Link> behind the graph.
+      </p>
+    </DocShell>
+  );
+}

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -213,6 +213,15 @@ nav.top-nav a.primary {
   border-color: var(--ink);
 }
 
+nav.top-nav a.nav-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+  color: var(--muted);
+}
+nav.top-nav a.nav-icon:hover { color: var(--ink); border-color: var(--line); }
+
 /* ---- CSS-only mobile menu (no JS, prerender-safe) ---- */
 .nav-toggle {
   position: absolute;
@@ -293,6 +302,13 @@ nav.top-nav a.primary {
     text-align: center;
     border: 1px solid var(--ink);
   }
+  /* in the stacked dropdown, label the GitHub icon link */
+  nav.top-nav a.nav-icon {
+    justify-content: flex-start;
+    gap: 10px;
+    padding: 12px 4px;
+  }
+  nav.top-nav a.nav-icon::after { content: "GitHub"; font-size: 15px; }
 }
 
 /* ---------- releases ---------- */
@@ -908,6 +924,62 @@ pre.install .prompt {
   color: var(--ink);
 }
 
+/* ----- /docs/install activation steps (inside .prose) ----- */
+.prose ol.install-steps {
+  list-style: none;
+  margin: 32px 0 8px;
+  padding: 0;
+  counter-reset: none;
+}
+.prose ol.install-steps > li.install-step {
+  margin: 0 0 28px;
+  padding: 0 0 28px;
+  border-bottom: 1px solid var(--line);
+}
+.prose ol.install-steps > li.install-step:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+.install-step-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin: 0 0 12px;
+  flex-wrap: wrap;
+}
+.install-step-num {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ink);
+}
+.install-step-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+.install-step-title {
+  font-family: var(--serif);
+  font-size: 21px;
+  line-height: 1.2;
+  color: var(--ink);
+}
+.prose .install-step pre.install {
+  margin: 0 0 12px;
+}
+.install-step-note {
+  margin: 0;
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--muted);
+}
+.install-step-note code {
+  font-family: var(--mono);
+  font-size: 0.92em;
+}
+
 .cta {
   display: flex;
   gap: 12px;
@@ -1138,6 +1210,63 @@ footer .right {
   text-transform: uppercase;
   letter-spacing: 0.16em;
   color: var(--muted);
+}
+
+/* ---------- footer sitemap ---------- */
+
+footer.site-footer { padding: 48px 32px 56px; }
+
+.footer-sitemap {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 32px;
+  border-top: 2px solid var(--ink);
+  padding-top: 28px;
+}
+.footer-col { display: flex; flex-direction: column; gap: 10px; }
+.footer-col-head {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink);
+  margin-bottom: 4px;
+}
+.footer-col a {
+  font-size: 14px;
+  color: var(--muted);
+  text-decoration: none;
+  width: fit-content;
+}
+.footer-col a:hover { color: var(--ink); }
+
+.footer-base {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 40px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+.footer-base-links { display: flex; align-items: baseline; gap: 10px; }
+.footer-base-links a { color: var(--muted); text-decoration: none; }
+.footer-base-links a:hover { color: var(--ink); }
+.footer-base-meta {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+@media (max-width: 720px) {
+  .footer-sitemap { grid-template-columns: repeat(2, 1fr); gap: 28px; }
+}
+@media (max-width: 420px) {
+  .footer-sitemap { grid-template-columns: 1fr; }
 }
 
 /* ---------- fig-shell / figure shared ---------- */
@@ -10482,6 +10611,32 @@ footer .right {
   .docs-adr-list .adr-slug { grid-column: 1 / -1; }
 }
 
+/* ADRs are demoted: one quiet, collapsed records drawer at the bottom */
+.docs-quiet { padding-top: 28px; }
+.docs-quiet-records summary {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  cursor: pointer;
+  list-style: none;
+  font-family: var(--mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  padding: 6px 0;
+}
+.docs-quiet-records summary::-webkit-details-marker { display: none; }
+.docs-quiet-records summary:hover { color: var(--ink); }
+.docs-quiet-note {
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+.docs-quiet-records[open] summary { margin-bottom: 12px; }
+.docs-quiet-records .docs-adr-list { border-top: 1px solid var(--line); }
+
 /* ----- documentation shell (MDX pages) ----- */
 .doc-main { padding-top: 8px; padding-bottom: 96px; }
 .doc-crumb { padding: 28px 0 0; }
@@ -10515,6 +10670,20 @@ footer .right {
   line-height: 1.6;
   color: var(--muted);
   margin: 0;
+}
+
+/* standing preface on demoted ADR pages */
+.adr-preface {
+  max-width: 720px;
+  margin: 24px 0 8px;
+  padding: 10px 14px;
+  border-left: 3px solid var(--line);
+  background: var(--panel);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.6;
+  letter-spacing: 0.02em;
+  color: var(--muted);
 }
 
 /* ----- prose: shared typography for all MDX documents ----- */


### PR DESCRIPTION
## What

WS1 site information-architecture restructure: un-orphan the money pages, create an activation path, demote internal engineering records.

- **Header** (`site-header.tsx`): nav is now Features · Routing · Showcases · Leaders · How · Docs · Origin, plus a primary **Install** CTA → `/docs/install`. Added the missing **Routing** link. GitHub demoted to an icon. Changelog dropped from top nav (still reachable via the version badge and the Docs Reference tier) to keep the bar uncrowded on mobile.
- **New `/docs/install`** (`docs/install.tsx`): a designed, receipts-style activation page on the `DocShell` chrome. Five numbered steps — `curl -fsSL ax.necmttn.com/install | sh` → `npx skills add Necmttn/ax` → first `ax ingest` (watch live at `ax serve` → http://127.0.0.1:1738) → `ax doctor` → `ax improve recommend` — with a "What you just did" closer linking Routing / CLI reference / Language. Route meta title + description added.
- **Docs hub** (`docs/index.tsx`): rebuilt into three tiers using the existing `docs-card` component — **Start here** (Install first), **Guides** (one card per shipped loop: improve deck, cost routing → `/routing`, hooks SDK, profiles & community, MCP, quota/recall/churn), **Reference** (CLI reference, Language, Changelog). ADRs collapsed to ONE quiet "Engineering records →" drawer at the bottom. Lede rewritten to drop the ADR/architecture framing. Removed the dead `pageCount` loader field. Both ADR 0009 entries disambiguated by full slug + title.
- **ADR demotion** (`adr.$slug.tsx`): `noindex, nofollow` robots meta, a standing one-line internal-record preface, and the page title now comes from the markdown H1 (DocShell renders no competing slug-derived headline).
- **Footer** (`site-footer.tsx`): real four-column sitemap — Product / Story / Community / Docs — plus a quiet For teams · Registry · Brand base row. No dead-ends. Landing `FooterCards` now surface Install + Routing.

## Why

The docs hub gave 15 internal ADRs co-equal billing while the single most important user-facing doc (install) was absent; recent main-event loops (routing, profiles, MCP, quota) had no entry; the footer was a one-line credit. This makes Install the obvious first stop, surfaces the money pages, and files the engineering records where they belong.

## Verified

- `cd apps/site && bun run build` → exit 0 (content codegen + prerender; `/docs/install` and all ADR routes prerender clean).
- `cd apps/site && bun test` → 121 pass, 0 fail.
- Rendered preview of `/docs/install` and `/docs` confirmed: nav target set, 5 install steps with the real commands + ax serve link, three docs tiers, collapsed ADR drawer (0009 x2 disambiguated), four-column footer sitemap.
- Did NOT touch `features.tsx`, `docs/cli-reference.tsx`, or `content-collections.ts` (other waves/workstreams).
- Pre-existing `loaderData: never` typecheck note in `adr.$slug.tsx` is the documented codegen-order condition on clean main (the original file had the identical `loaderData?.adr.title` head pattern); the real CI gate `bun run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)