### PR TITLE
fix(site): document `ax dojo` in CLI reference (unbreak main)

### DIFF
--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -301,6 +301,29 @@ claude-sonnet-4             54          120   18.7%        201,330`,
         ],
       },
       {
+        name: "dojo",
+        job: "Training agenda: spends surplus plan quota on a prioritized self-improvement work list.",
+        signature: "ax dojo [--budget=N] [--until=HH:MM] [--spar] [--days=N] [--json]",
+        flags: [
+          { flag: "--budget=N", desc: "cap the spend envelope at N% of the binding quota window" },
+          { flag: "--until=HH:MM", desc: "deadline for this session (default: earliest window reset)" },
+          { flag: "--spar", desc: "opt into adversarial spar items (needs >=30% spendable quota)" },
+        ],
+        receipt: `$ ax dojo
+budget    37% of 7d window spendable  ·  until 22:59 (reset)
+agenda
+  1  lock 2 pending verdicts            (improve)
+  2  drain 1 unfilled .ax/tasks brief   (task)
+  3  mint proposals - open pool < 3     (recommend)
+fed to the ax:dojo skill loop`,
+        detail: [
+          "ax dojo composes a budget envelope from the quota module (binding window remaining minus a 15% reserve, deadline = earliest window reset) and a derived, self-clearing item list.",
+          "Items: pending verdicts, unfilled .ax/tasks briefs, judgment-flagged routing backtests, proposal minting (when the open pool < 3), churn-hotspot experiments, opt-in spar, and an explore fallback.",
+          "Each item vanishes once the underlying system records the work (verdict locked, brief consumed, proposal created) - the agenda is stateless between runs.",
+          "Consumed by the ax:dojo skill loop; drafts land in ~/.ax/dojo/outbox/ and a per-day report in ~/.ax/dojo/reports/.",
+        ],
+      },
+      {
         name: "wrapped",
         sub: ["generate", "publish"],
         job: "Agent-authored Wrapped recap cards for the dashboard landing.",


### PR DESCRIPTION
## What
Adds a `dojo` command card to `/docs/cli-reference` so the freshness gate passes.

## Why
The CLI-reference freshness lint shipped in #394 caught a real gap: `ax dojo` (the training-agenda command, registered at `apps/axctl/src/cli/index.ts`) landed on main in parallel with the reference rebuild. The WS3 agent forked before dojo merged, so its local `bun test` passed; on merged main the visible command surface includes `dojo` and `scripts/check-site-cli-reference.test.ts` failed → main CI red.

This is the gate working as designed. Documenting the command is the correct fix.

## Verified
- `bun scripts/check-site-cli-reference.ts` → documents all 23 visible CLI subcommands
- `bun test scripts/check-site-cli-reference.test.ts` → 7 pass / 0 fail
- `cd apps/site && bun run build` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)