### PR TITLE
feat(site): truth pass on product pages + curated glossary (WS2b)

### DIFF
--- a/apps/site/app/components/routing/routing-page.tsx
+++ b/apps/site/app/components/routing/routing-page.tsx
@@ -5,7 +5,7 @@ export function RoutingPage() {
     <main className="features-page routing-page">
       {/* ============= hero ============= */}
       <section className="hero">
-        <span className="eyebrow">cost routing &middot; new in ax</span>
+        <span className="eyebrow">cost routing &middot; since v0.27</span>
         <h1>
           Your frontier model is doing <em>intern work.</em>
         </h1>
@@ -75,7 +75,7 @@ export function RoutingPage() {
               <span className="rt-step-num">02</span>
               <span className="rt-step-verb">nudge</span>
             </div>
-            <code className="rt-step-cmd">
+            <code className="rt-step-cmd rt-step-cmd--wrap">
               ax hooks install ~/.ax/hooks/route-dispatch.ts --providers=claude
             </code>
             <p className="rt-step-body">
@@ -115,11 +115,12 @@ export function RoutingPage() {
         <div className="section-head">
           <span className="section-num">02 / The receipts</span>
           <h2>
-            One machine, 30 days, <em>verbatim.</em>
+            One machine, <em>verbatim.</em>
           </h2>
           <p className="section-lede">
-            20 patterns of routine work found, $591.57 of addressable spend, $512.91 flagged
-            once the table applied &mdash; the same machine as the numbers above.{" "}
+            Over 30 days: 20 patterns of routine work found, $591.57 of addressable spend.
+            Reprice the last 14 days against the cheaper model and $512.91 is recoverable
+            &mdash; the same machine as the numbers above.{" "}
             <code className="inline">ax routing tune --dry-run</code> prints yours in one
             command.
           </p>
@@ -149,7 +150,7 @@ export function RoutingPage() {
             <span className="p">$</span> <span className="cmd">ax dispatches --candidates --days=14</span>
             {"\n\n"}
             {"total est savings: "}
-            <span className="fig">$512.9076</span>
+            <span className="fig">$512.91</span>
             {"\n"}
             {"top classes: well-specified-impl ("}
             <span className="fig">$222.78</span>
@@ -243,6 +244,10 @@ export function RoutingPage() {
         <div className="rt-install">
           <code>
             <span className="p">$</span> curl -fsSL https://ax.necmttn.com/install | bash
+          </code>
+          <code>
+            <span className="p">$</span> ax ingest{" "}
+            <span className="dim"># first run: build the graph from your history</span>
           </code>
           <code>
             <span className="p">$</span> ax routing tune

--- a/apps/site/app/routes/docs/-language.data.ts
+++ b/apps/site/app/routes/docs/-language.data.ts
@@ -1,0 +1,192 @@
+/**
+ * Curated PUBLIC glossary for /docs/language.
+ *
+ * Visitor-facing only. The raw docs/language.md (brand-internal vocabulary,
+ * forbidden-terms competitor table, language-governance section, schema/edge
+ * internals) is intentionally NOT rendered here anymore - the route reads this
+ * typed module instead. The .md stays in the content collection (orphaned) so
+ * a later cleanup PR can remove it without colliding with parallel edits.
+ *
+ * Each term: a mono $-eyebrow (the term), a serif definition, and one
+ * "in the wild" usage receipt. Always "ax" in visitor copy, never "axctl".
+ * Drift fixed vs the old .md: checkpoints are +3/+10/+30 SESSIONS (not days);
+ * the retro loop is watcher-driven (no Stop hook); "ax skills weighted"
+ * (not "axctl skills taste"); no repo paths.
+ */
+
+/** One glossary entry rendered as a definition card. */
+export interface GlossaryTerm {
+  /** Mono $-eyebrow - the term as written. */
+  readonly term: string;
+  /** Optional expansion shown beside the term (e.g. "Agent Experience"). */
+  readonly expansion?: string;
+  /** Serif definition, 1-3 sentences. */
+  readonly definition: string;
+  /** One "in the wild" usage line - how it reads in real copy. */
+  readonly usage: string;
+}
+
+/** A grouped run of terms under a mono $-eyebrow + human heading. */
+export interface GlossaryGroup {
+  /** Mono $-eyebrow, e.g. "$ the category". */
+  readonly eyebrow: string;
+  /** Short human heading. */
+  readonly title: string;
+  readonly terms: readonly GlossaryTerm[];
+}
+
+export const GLOSSARY_GROUPS: readonly GlossaryGroup[] = [
+  {
+    eyebrow: "$ the category",
+    title: "What ax is",
+    terms: [
+      {
+        term: "AX",
+        expansion: "Agent Experience",
+        definition:
+          "The discipline of measuring, shaping, and improving what an AI coding agent perceives, remembers, and acts on across sessions. The direct analog of Developer Experience (DX) for human engineers.",
+        usage: "AX is to AI agents what DX is to humans.",
+      },
+      {
+        term: "AXL",
+        expansion: "Agent Experience Layer",
+        definition:
+          "A software layer that owns the AX surface - ingest, storage, query, and agent-readable interfaces over the evidence of prior agent behavior. ax is the reference implementation.",
+        usage:
+          "An Agent Experience Layer needs typed evidence, multi-agent ingest, and an agent-readable interface.",
+      },
+    ],
+  },
+  {
+    eyebrow: "$ the product surface",
+    title: "Names you will see",
+    terms: [
+      {
+        term: "ax",
+        definition:
+          "The project. Lowercase, always. The whole thing - the agent experience layer over your coding-agent history.",
+        usage: "ax watches your sessions and proposes small, repo-specific fixes.",
+      },
+      {
+        term: "axctl",
+        definition:
+          "The CLI binary under the hood. You mostly type ax; axctl is the technical name of the executable.",
+        usage: "The ax command you run is the axctl binary on disk.",
+      },
+      {
+        term: "ax studio",
+        definition:
+          "The live local dashboard. The improve-first view of your graph: what's next, the proposal deck, experiments, cost and routing.",
+        usage: "Open ax studio to triage proposals and watch experiments land.",
+      },
+      {
+        term: "retro",
+        definition:
+          "A structured reflection collected after a session: what was tried, what worked, what failed, and the next experiment to run. It is a bet on the next session, not a recap. ax drains pending retros in the background (watcher-driven) and through the /retro skill - never via a per-turn Stop hook.",
+        usage: "Six retros this week propose the same hook - that's a pattern worth shipping.",
+      },
+    ],
+  },
+  {
+    eyebrow: "$ the improve loop",
+    title: "How fixes get made",
+    terms: [
+      {
+        term: "proposal",
+        definition:
+          "A repeated-mistake pattern ax mines from your history, surfaced as one small candidate fix - a skill, a hook, a piece of guidance, or a routing change. Reviewed one at a time, never auto-applied.",
+        usage: "ax found a 26x recurring mistake and turned it into one proposal.",
+      },
+      {
+        term: "experiment",
+        definition:
+          "What an accepted proposal becomes: the scaffolded artifact plus a checkpoint schedule. ax measures whether it actually helped at +3, +10, and +30 sessions.",
+        usage: "Past bets, measured - this experiment is +10 sessions in and holding.",
+      },
+      {
+        term: "verdict",
+        definition:
+          "The outcome locked at a checkpoint. One of: adopted (doing real work), ignored (created but never invoked), regressed (made things worse), partial (mixed signal), or no_longer_needed (the pattern self-resolved).",
+        usage: "I locked the schema-guardrail verdict as adopted.",
+      },
+      {
+        term: "ax-loop",
+        definition:
+          "The closed self-improvement cycle: retro -> proposal -> experiment -> verdict -> the next session reads what worked. \"Close the loop\" means one full pass from retro to verdict.",
+        usage: "Receipts over vibes - the ax-loop only ships fixes it can measure.",
+      },
+      {
+        term: "ax-graph",
+        definition:
+          "The local typed evidence store behind everything: sessions, turns, tool calls, skills, commits, retros, proposals, experiments, verdicts. The abstraction is \"the ax-graph\"; the database is an implementation detail.",
+        usage: "Everything ax shows you is read back from the local ax-graph.",
+      },
+      {
+        term: "impact / projected value",
+        definition:
+          "The backtested estimate of what a proposal is worth, computed from your own history - e.g. \"$605 redirectable\" or \"26x recurring.\" ax reprices what already happened from real tokens; it never reports fabricated savings.",
+        usage: "This proposal's projected value is $605 redirectable spend.",
+      },
+    ],
+  },
+  {
+    eyebrow: "$ cost & routing",
+    title: "Where the money goes",
+    terms: [
+      {
+        term: "dispatch",
+        definition:
+          "A sub-task your agent spawns - the routine work that runs on whatever model the harness picks. Left alone, dispatches default to your most expensive model.",
+        usage: "ax dispatches shows which sub-tasks ran on the expensive default.",
+      },
+      {
+        term: "routing class",
+        definition:
+          "A named bucket of look-alike dispatches (file search, well-specified implementation, bug fixes) that can safely tier down to a cheaper model. Judgment work - review, design, planning, audits - never routes automatically.",
+        usage: "ax routing tune mined a new routing class from work you keep overpaying for.",
+      },
+      {
+        term: "quota",
+        definition:
+          "Your live Claude plan usage across the 5-hour and 7-day windows. ax surfaces it in the CLI, your statusline, and the menubar so you see the limit before you hit it.",
+        usage: "ax quota --statusline puts your plan usage one glance away.",
+      },
+    ],
+  },
+  {
+    eyebrow: "$ the surface for agents",
+    title: "What agents and people read back",
+    terms: [
+      {
+        term: "recall",
+        definition:
+          "Full-text search across your turns, commits, and skills. Auto-scopes to the current repo when run inside a git tree. The fastest way to ask \"have I solved this before?\"",
+        usage: "ax recall \"surreal index drift\" --scope=here pulled the fix from a session last month.",
+      },
+      {
+        term: "hook",
+        definition:
+          "A typed guard authored once in Effect TypeScript and run on both Claude Code and Codex via the ax hooks SDK. Verdicts are allow / block / warn / inject; a defect fails open. This is how one person's trick becomes a deterministic team-wide rule.",
+        usage: "The route-dispatch hook warns the moment a routine sub-task is about to run expensive.",
+      },
+      {
+        term: "ax skills weighted",
+        definition:
+          "The ranking of your skills by real usage times their role weight - the honest answer to \"which skills actually earn their place?\" Replaces any older \"taste score\" phrasing.",
+        usage: "ax skills weighted surfaced three skills I install everywhere but never run.",
+      },
+      {
+        term: "profile",
+        definition:
+          "A shareable summary of one seat - stats, rig, and taste patterns - published with ax profile publish. The consent prompt shows you the exact JSON before anything leaves your machine.",
+        usage: "ax profile publish posted my profile to a gist after I approved the payload.",
+      },
+      {
+        term: "leaders",
+        definition:
+          "The public community boards compiled from registered profiles - leaderboards and trending skills at /leaders, with each member's page at /u/<login>. Aggregates only; no code, no transcripts.",
+        usage: "/leaders shows trending skills across everyone who opted in.",
+      },
+    ],
+  },
+];

--- a/apps/site/app/routes/docs/language.tsx
+++ b/apps/site/app/routes/docs/language.tsx
@@ -1,27 +1,64 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
-import { MDXContent } from "@content-collections/mdx/react";
-import { allPages } from "content-collections";
-import { mdxComponents } from "~/components/mdx-components";
+import { createFileRoute } from "@tanstack/react-router";
 import { DocShell } from "~/components/doc-shell";
+import { GLOSSARY_GROUPS, type GlossaryTerm } from "./-language.data";
 
 export const Route = createFileRoute("/docs/language")({
   head: () => ({
     meta: [
       { title: "Language - ax" },
-      { name: "description", content: "The shared vocabulary ax uses to describe agent work." },
+      {
+        name: "description",
+        content:
+          "The shared vocabulary ax uses to describe agent work: AX, the improve loop, cost routing, profiles and the surface agents read back.",
+      },
     ],
   }),
-  loader: () => {
-    const page = allPages.find((p) => p.slug === "language");
-    if (!page) throw notFound();
-    return { page };
-  },
-  component: () => {
-    const { page } = Route.useLoaderData();
-    return (
-      <DocShell eyebrow="reference">
-        <MDXContent code={page.body} components={mdxComponents} />
-      </DocShell>
-    );
-  },
+  component: Language,
 });
+
+function TermCard({ entry }: { entry: GlossaryTerm }) {
+  return (
+    <article className="gloss-card">
+      <p className="gloss-card__term">
+        <span className="gloss-card__dollar" aria-hidden="true">
+          $
+        </span>
+        {entry.term}
+        {entry.expansion && (
+          <span className="gloss-card__exp">{entry.expansion}</span>
+        )}
+      </p>
+      <p className="gloss-card__def">{entry.definition}</p>
+      <p className="gloss-card__usage">
+        <span className="gloss-card__usage-label">in the wild</span>
+        {entry.usage}
+      </p>
+    </article>
+  );
+}
+
+function Language() {
+  return (
+    <DocShell
+      eyebrow="$ ax language"
+      title="Language"
+      lede="The shared vocabulary ax uses to describe agent work. Each term: what it means, and how it reads in real copy."
+    >
+      <div className="gloss">
+        {GLOSSARY_GROUPS.map((group) => (
+          <section key={group.eyebrow} className="gloss-group">
+            <header className="gloss-group__head">
+              <p className="gloss-group__eyebrow">{group.eyebrow}</p>
+              <h2 className="gloss-group__title">{group.title}</h2>
+            </header>
+            <div className="gloss-group__cards">
+              {group.terms.map((t) => (
+                <TermCard key={t.term} entry={t} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </DocShell>
+  );
+}

--- a/apps/site/app/routes/registry.tsx
+++ b/apps/site/app/routes/registry.tsx
@@ -5,8 +5,7 @@ import { FooterCards } from "~/components/landing-v2";
 import { HeroLogoField } from "~/components/landing-v2/supports-strip";
 import "../styles/pitch.css";
 
-const MAILTO =
-  "mailto:necmettin.karakaya@gmail.com?subject=ax%20registry%20-%20early%20access";
+const CONTACT_URL = "https://github.com/Necmttn/ax/discussions";
 
 export const Route = createFileRoute("/registry")({
   head: () => ({
@@ -41,7 +40,10 @@ function Registry() {
         {/* ============= hero ============= */}
         <section className="hero">
           <HeroLogoField />
-          <span className="eyebrow">ax skill registry</span>
+          <span className="eyebrow">
+            ax for teams: governed skills &middot; early access
+          </span>
+          <span className="reg-badge">building with design partners</span>
           <h1>
             Ship curated skills<br />
             to your <em>whole team</em>.
@@ -50,17 +52,24 @@ function Registry() {
             Authored by your engineers. Used by everyone. Never polluted.
           </p>
           <p className="lede">
-            A few engineers build the skills; a lot of people use them. ax syncs
-            your blessed skills down to every laptop, read-only &mdash; and when a
-            consumer&rsquo;s agent hits an edge case, it sends a fix back upstream
-            for you to review. The repo stays clean without locking anyone out.
+            The vision: a few engineers build the skills; a lot of people use
+            them. ax <em>will</em> sync your blessed skills down to every laptop,
+            read-only &mdash; and when a consumer&rsquo;s agent hits an edge case,
+            send a fix back upstream for you to review. We&rsquo;re building this
+            with a handful of design partners. Skills install, the local improve
+            loop, and profile publishing all work today.
           </p>
 
           <div className="install-wrap">
             <span className="install-label">git &amp; npm stay your pipe &mdash; ax adds the brain</span>
             <div className="cta-row">
-              <a className="prompt-pill is-solo" href={MAILTO}>
-                <span className="prompt-pill__label">Request early access</span>
+              <a
+                className="prompt-pill is-solo"
+                href={CONTACT_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span className="prompt-pill__label">Talk to us on GitHub</span>
               </a>
               <a className="cta-secondary" href="#loop">
                 <span className="cta-secondary__icon" aria-hidden="true">
@@ -142,6 +151,83 @@ function Registry() {
           </div>
         </section>
 
+        {/* ============= today vs building ============= */}
+        <section className="pitch-section" id="status">
+          <div className="pitch-head">
+            <span className="eyebrow">where this is</span>
+            <h2>
+              What works today vs what we&rsquo;re <em>building with partners</em>.
+            </h2>
+            <p>
+              Honest about the line: the local half of this loop is shipped. The
+              sync fabric that turns it into a team registry is the design-partner
+              work.
+            </p>
+          </div>
+          <div className="pitch-lanes">
+            <div className="pitch-lane is-out">
+              <h3><span className="dot"></span> works today</h3>
+              <ul>
+                <li><b>Skills install</b> <span className="dim">(npx skills add Necmttn/ax)</span></li>
+                <li><b>Local improve loop</b> <span className="dim">(mine mistakes → reviewed fix)</span></li>
+                <li><b>Profile publishing</b> <span className="dim">(ax profile publish → gist, consent-gated)</span></li>
+                <li><b>Hooks SDK</b> <span className="dim">(typed Effect hooks, Claude Code + Codex)</span></li>
+              </ul>
+            </div>
+            <div className="pitch-lane is-local">
+              <h3><span className="dot"></span> building with design partners</h3>
+              <ul>
+                <li><b>Sync-down</b> <span className="dim">(blessed skills read-only on every laptop)</span></li>
+                <li><b>Suggest-up</b> <span className="dim">(agents propose fixes upstream)</span></li>
+                <li><b>Review queue</b> <span className="dim">(ranked by real usage)</span></li>
+                <li><b>Regulated mode</b> <span className="dim">(consent gate, provenance, fail-closed)</span></li>
+              </ul>
+            </div>
+          </div>
+
+          {/* ----- one receipt-style preview artifact ----- */}
+          <div className="reg-preview" role="img" aria-label="suggestion review queue preview">
+            <div className="reg-preview__bar">
+              <span className="reg-preview__eyebrow">$ ax suggestions review</span>
+              <span className="reg-preview__tag">PREVIEW &middot; in development</span>
+            </div>
+            <div className="reg-preview__card">
+              <div className="reg-preview__head">
+                <span className="reg-preview__skill">contract-redline</span>
+                <span className="reg-preview__rank">rank 1 / 6</span>
+              </div>
+              <p className="reg-preview__title">
+                Fix flowed back: clause-numbering edge case
+              </p>
+              <dl className="reg-preview__stats">
+                <div>
+                  <dt>seats hit</dt>
+                  <dd>9</dd>
+                </div>
+                <div>
+                  <dt>failures, 14d</dt>
+                  <dd>23</dd>
+                </div>
+                <div>
+                  <dt>repro</dt>
+                  <dd>synthetic, PII-free</dd>
+                </div>
+                <div>
+                  <dt>matter</dt>
+                  <dd className="reg-preview__never">never sent</dd>
+                </div>
+              </dl>
+              <div className="reg-preview__actions">
+                <span className="reg-preview__accept">accept &amp; re-sync</span>
+                <span className="reg-preview__reject">reject</span>
+              </div>
+            </div>
+            <p className="reg-preview__note">
+              Mock of the review queue we&rsquo;re building. Numbers illustrative.
+            </p>
+          </div>
+        </section>
+
         {/* ============= the loop ============= */}
         <section className="pitch-section" id="loop">
           <div className="pitch-head">
@@ -164,7 +250,7 @@ function Registry() {
             <div className="pitch-step">
               <span className="n">02</span>
               <h4>Sync down</h4>
-              <p>Blessed skills land read-only on every consumer&rsquo;s laptop, current.</p>
+              <p>ax <em>will</em> land blessed skills read-only on every consumer&rsquo;s laptop, current.</p>
             </div>
             <div className="pitch-step">
               <span className="n">03</span>
@@ -174,12 +260,12 @@ function Registry() {
             <div className="pitch-step">
               <span className="n">04</span>
               <h4>Suggest up</h4>
-              <p>The agent sends back a PII-redacted repro test &mdash; the failure, not the matter.</p>
+              <p>The agent <em>will</em> send back a PII-redacted repro test &mdash; the failure, not the matter.</p>
             </div>
             <div className="pitch-step">
               <span className="n">05</span>
               <h4>Review</h4>
-              <p>ax ranks suggestions by real usage; your engineer accepts, it re-syncs.</p>
+              <p>ax <em>will</em> rank suggestions by real usage; your engineer accepts, it re-syncs.</p>
             </div>
           </div>
         </section>
@@ -229,8 +315,13 @@ function Registry() {
             let&rsquo;s talk.
           </p>
           <div className="cta-row">
-            <a className="prompt-pill is-solo" href={MAILTO}>
-              <span className="prompt-pill__label">Request early access</span>
+            <a
+              className="prompt-pill is-solo"
+              href={CONTACT_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span className="prompt-pill__label">Talk to us on GitHub</span>
             </a>
             <Link to="/teams" className="cta-secondary">
               See the manager angle

--- a/apps/site/app/routes/teams.tsx
+++ b/apps/site/app/routes/teams.tsx
@@ -9,6 +9,7 @@ import { HeroLogoField } from "~/components/landing-v2/supports-strip";
 import "../styles/pitch.css";
 
 const BOOK_URL = "https://cal.com/necmttn/30min";
+const LEADERS_URL = "/leaders";
 
 export const Route = createFileRoute("/teams")({
   head: () => ({
@@ -53,13 +54,15 @@ function ImpactSection() {
   return (
     <section ref={impactRef} className="pitch-section">
       <div className="pitch-head">
-        <span className="eyebrow">what deeper adoption looks like</span>
+        <span className="eyebrow">what deeper adoption will look like</span>
         <h2>
           A faster team has a different <em>shape</em>.
         </h2>
         <p>
           Gates open as a workflow goes from one person&rsquo;s trick to team
-          practice. The scroll <em>is</em> your adoption curve.
+          practice. The aggregation layer that rolls every seat into this curve
+          is what we&rsquo;re building with design partners &mdash; the scroll
+          below sketches the shape it will draw.
         </p>
       </div>
 
@@ -68,10 +71,11 @@ function ImpactSection() {
         <PipelineFlow scrollProgress={scrollProgress} />
         <p className="impact-frame">
           Stuck gates are workflows still trapped in one head &mdash; ax finds
-          them.
+          them per seat today.
         </p>
         <p className="impact-illus">
-          illustrative &mdash; your numbers render from real sessions
+          sketch of the team view &mdash; in development; per-seat receipts are
+          live now (see below)
         </p>
       </div>
     </section>
@@ -86,7 +90,7 @@ function Teams() {
         {/* ============= hero ============= */}
         <section className="hero">
           <HeroLogoField />
-          <span className="eyebrow">ax for engineering teams</span>
+          <span className="eyebrow">ax for engineering teams &middot; early access</span>
           <h1>
             See how your team<br />
             actually ships with <em>AI</em>.
@@ -96,9 +100,11 @@ function Teams() {
             sticking.
           </p>
           <p className="lede">
-            ax turns local coding-agent sessions into evidence for your AI
-            enablement work: which workflows improve real shipping, where the
-            team is stuck, and what should become standard practice.
+            ax is live per seat today &mdash; it turns one engineer&rsquo;s local
+            coding-agent sessions into receipts. The team aggregation layer that
+            rolls those seats together is in development; we&rsquo;re building it
+            with design partners. A walkthrough runs on each engineer&rsquo;s own
+            local ax data, today.
           </p>
 
           <div className="install-wrap">
@@ -184,81 +190,145 @@ function Teams() {
           </div>
         </section>
 
-        {/* ============= dashboard preview ============= */}
+        {/* ============= per-seat receipts (real, single-seat) ============= */}
         <section className="demo" id="demo">
           <div className="demo-intro">
-            <span className="eyebrow">one screen, the whole team</span>
-            <h2>The evidence layer for internal AI enablement.</h2>
+            <span className="eyebrow">this is what one seat looks like</span>
+            <h2>Real receipts, generated locally &mdash; today.</h2>
             <p>
-              Your AI lead shouldn&rsquo;t have to guess what stuck after the
-              workshop. ax shows where leverage is showing up, where usage stays
-              shallow, and which workflows are ready to spread.
+              These are the numbers ax already surfaces from a single
+              engineer&rsquo;s history (run <code>ax studio</code> on your own
+              machine). The team product aggregates these per-seat receipts into
+              one view &mdash; same numbers, rolled up.
             </p>
           </div>
 
-          <div className="browser" role="img" aria-label="ax team dashboard preview">
+          <div className="browser" role="img" aria-label="ax studio per-seat receipts">
             <div className="browser-bar">
               <div className="browser-dots"><span></span><span></span><span></span></div>
-              <div className="browser-url">app.ax / team &middot; this month</div>
+              <div className="browser-url">ax studio &middot; one seat &middot; 14 days</div>
               <div className="browser-spacer"></div>
             </div>
             <div className="dash">
-              <p className="dash-head">Shared agent practice &middot; 12 engineers</p>
+              <p className="dash-head">What ax found on one machine</p>
               <div className="ministats">
                 <div className="mini">
-                  <div className="mini-label">AI-native workflows</div>
-                  <div className="mini-value">41<span className="unit">%</span></div>
-                  <div className="mini-sub"><b>59%</b> still shallow</div>
+                  <div className="mini-label">Redirectable spend</div>
+                  <div className="mini-value"><span className="unit">$</span>605</div>
+                  <div className="mini-sub"><b>routine sub-tasks</b> on the expensive default</div>
                 </div>
                 <div className="mini">
-                  <div className="mini-label">Power users</div>
-                  <div className="mini-value">3<span className="unit">/ 12</span></div>
-                  <div className="mini-sub"><span className="neg">9 not using patterns</span></div>
+                  <div className="mini-label">Top recurring fix</div>
+                  <div className="mini-value">26<span className="unit">×</span></div>
+                  <div className="mini-sub">same mistake, <b>one proposal</b></div>
                 </div>
                 <div className="mini">
-                  <div className="mini-label">Shipping workflows</div>
-                  <div className="mini-value">6</div>
-                  <div className="mini-sub"><span className="pos">+2</span> found this week</div>
+                  <div className="mini-label">Routing est. savings</div>
+                  <div className="mini-value"><span className="unit">$</span>512<span className="unit">.91</span></div>
+                  <div className="mini-sub"><span className="pos">repriced</span> from real tokens</div>
                 </div>
                 <div className="mini">
-                  <div className="mini-label">Ready to spread</div>
-                  <div className="mini-value">3</div>
-                  <div className="mini-sub"><b>proven</b> playbooks</div>
+                  <div className="mini-label">Churn episodes</div>
+                  <div className="mini-value">7</div>
+                  <div className="mini-sub"><span className="neg">failure → repair</span> loops, 30d</div>
                 </div>
               </div>
             </div>
           </div>
           <p className="demo-caption">
-            Aggregates only &mdash; not to police anyone, just to see whether AI
-            is becoming part of how the team ships.
+            Every number here is per-seat and local. The team layer
+            <em> aggregates</em> them &mdash; never per-person behavior, never
+            transcripts.
           </p>
+        </section>
+
+        {/* ============= one person's trick → team practice ============= */}
+        <section className="pitch-section" id="spread">
+          <div className="pitch-head">
+            <span className="eyebrow">one person&rsquo;s trick → team practice</span>
+            <h2>
+              The mechanism that spreads a workflow <em>already ships</em>.
+            </h2>
+            <p>
+              You don&rsquo;t need the aggregation layer to move a good pattern
+              across the team. Two shipped surfaces already do it.
+            </p>
+          </div>
+          <div className="pitch-triad">
+            <div className="pitch-fcard">
+              <span className="ic" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M4 5.5A1.5 1.5 0 0 1 5.5 4H16l4 4v10.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 4 18.5z" />
+                  <path d="M15 4v5h5M8 13h8M8 16h5" />
+                </svg>
+              </span>
+              <h3>Skills &amp; hooks SDK</h3>
+              <p>
+                When ax finds a fix worth keeping, it becomes a skill or a typed
+                Effect hook (Claude Code + Codex). Commit it once; everyone&rsquo;s
+                agent runs it. That&rsquo;s one person&rsquo;s trick becoming team
+                practice, today.
+              </p>
+            </div>
+            <div className="pitch-fcard">
+              <span className="ic" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="8" r="3.2" />
+                  <path d="M5 20c0-3.3 3.1-6 7-6s7 2.7 7 6" />
+                </svg>
+              </span>
+              <h3>Public profiles &amp; leaders</h3>
+              <p>
+                <code>ax profile publish</code> turns one seat into a shareable
+                profile. <a href={LEADERS_URL}>/leaders</a> and
+                {" "}<a href="/u/necmttn">/u/&lt;login&gt;</a> are live multi-person
+                surfaces on the aggregates-only model &mdash; proof the rollup
+                works without sending anyone&rsquo;s code.
+              </p>
+            </div>
+            <div className="pitch-fcard">
+              <span className="ic" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M3 12a9 9 0 0 1 15-6.7L21 8M21 3v5h-5" />
+                  <path d="M21 12a9 9 0 0 1-15 6.7L3 16M3 21v-5h5" />
+                </svg>
+              </span>
+              <h3>The improve loop</h3>
+              <p>
+                ax mines repeated mistakes and proposes a small repo-specific fix,
+                reviewed one at a time. Accept it and it&rsquo;s in the repo &mdash;
+                no aggregation server required.
+              </p>
+            </div>
+          </div>
         </section>
 
         {/* ============= impact signal ============= */}
         <ImpactSection />
 
-        {/* ============= the privacy line ============= */}
+        {/* ============= the privacy contract ============= */}
         <section className="pitch-section" id="privacy">
           <div className="pitch-head">
-            <span className="eyebrow">the privacy line</span>
+            <span className="eyebrow">the privacy contract</span>
             <h2>
-              The collector is <em>open source</em>, so you can read exactly what
-              leaves.
+              You see the exact JSON <em>before</em> anything leaves.
             </h2>
             <p>
-              ax runs on each laptop and computes small derived rows. Only those
-              aggregates ship; the sensitive work stays put by construction.
-              Because it&rsquo;s OSS, you can verify that line instead of
-              trusting it.
+              ax is AGPL-3.0 and runs entirely on each laptop. There is one real
+              export today &mdash; <code>ax profile publish</code> &mdash; and it
+              shows you the precise JSON in a consent prompt before the first byte
+              moves. The team aggregation layer is built to the same contract: a
+              local consent gate, ax-shaped aggregates only. Below is the design
+              contract we&rsquo;re building to.
             </p>
           </div>
           <div className="pitch-lanes">
             <div className="pitch-lane is-out">
-              <h3><span className="dot"></span> what leaves the laptop</h3>
+              <h3><span className="dot"></span> what will leave (after consent)</h3>
               <ul>
                 <li>Per-seat <b>adoption signal</b> <span className="dim">(active days, depth of use)</span></li>
                 <li>Skill / workflow <b>usage rollups</b> <span className="dim">(names, not contents)</span></li>
-                <li><b>What correlates with shipping</b> <span className="dim">(the patterns worth spreading)</span></li>
+                <li><b>Cost &amp; routing aggregates</b> <span className="dim">(the spend worth redirecting)</span></li>
                 <li>Team-level <b>aggregates</b> <span className="dim">(never per-person behavior)</span></li>
               </ul>
             </div>
@@ -268,19 +338,26 @@ function Teams() {
                 <li>Transcript text &amp; <b>prompts</b> <span className="dim">(read locally, never sent)</span></li>
                 <li>Your <b>code</b>, diffs and file contents <span className="dim">(stay on disk)</span></li>
                 <li><b>What</b> each person is building <span className="dim">(yours to keep)</span></li>
-                <li>Everything else ax touches to compute the rollups</li>
+                <li>Anything not in the consent-prompt JSON you approved</li>
               </ul>
             </div>
           </div>
+          <p className="demo-caption">
+            Verifiable today: <code>ax profile publish</code> prints the full
+            payload and waits for your yes. Source is AGPL-3.0 &mdash; read the
+            line, don&rsquo;t trust it.
+          </p>
         </section>
 
         {/* ============= closing CTA ============= */}
         <section className="pitch-cta">
           <h2>What gets measured gets improved.</h2>
           <p>
-            Right now AI adoption isn&rsquo;t measured at all. A walkthrough on
-            your own data shows what stuck, what stayed shallow, and which
-            workflows are ready to become standard practice.
+            Right now AI adoption isn&rsquo;t measured at all. The walkthrough
+            runs on each engineer&rsquo;s own local ax data &mdash; live today
+            &mdash; and shows what stuck, what stayed shallow, and which workflows
+            are ready to spread. We&rsquo;re onboarding design partners for the
+            team aggregation layer as we build it.
           </p>
           <div className="cta-row">
             <a className="prompt-pill is-solo" href={BOOK_URL}>

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -12656,3 +12656,243 @@ footer.site-footer { padding: 48px 32px 56px; }
     .cliref-card__flag { grid-template-columns: 1fr; gap: 2px; }
     .cliref-index nav { columns: 1; }
 }
+
+/* ============================================================
+   WS2b truth-pass additions (teams / registry / routing / glossary)
+   Appended as one block so parallel edits merge cleanly. Reuses
+   root tokens (--ink/--page/--panel/--line/--muted/--green/--blue
+   /--red/--amber/--serif/--mono/--sans). Receipts aesthetic.
+   ============================================================ */
+
+/* --- routing: let the long install command wrap instead of clip --- */
+.routing-page .rt-step-cmd--wrap {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+/* routing CTA: dim inline comment on an install line */
+.routing-page .rt-install code .dim {
+    color: #8a8a82;
+}
+
+/* --- registry: design-partner badge + preview receipt card --- */
+.landing-v2 .reg-badge {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--amber);
+    border: 1px solid var(--amber);
+    border-radius: 999px;
+    padding: 3px 10px;
+    margin: 8px 0 4px;
+}
+
+.landing-v2 .reg-preview {
+    max-width: 560px;
+    margin: 36px auto 0;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: var(--panel);
+    overflow: hidden;
+}
+.landing-v2 .reg-preview__bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--line);
+    background: var(--page);
+}
+.landing-v2 .reg-preview__eyebrow {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--green);
+}
+.landing-v2 .reg-preview__tag {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--amber);
+    border: 1px solid var(--amber);
+    border-radius: 4px;
+    padding: 2px 6px;
+}
+.landing-v2 .reg-preview__card {
+    padding: 18px 18px 14px;
+}
+.landing-v2 .reg-preview__head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+.landing-v2 .reg-preview__skill {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--blue);
+}
+.landing-v2 .reg-preview__rank {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+}
+.landing-v2 .reg-preview__title {
+    font-family: var(--serif);
+    font-size: 18px;
+    line-height: 1.25;
+    color: var(--ink);
+    margin: 0 0 14px;
+}
+.landing-v2 .reg-preview__stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+    margin: 0 0 16px;
+}
+.landing-v2 .reg-preview__stats div {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.landing-v2 .reg-preview__stats dt {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+.landing-v2 .reg-preview__stats dd {
+    font-family: var(--mono);
+    font-size: 15px;
+    color: var(--ink);
+    margin: 0;
+}
+.landing-v2 .reg-preview__never {
+    color: var(--green) !important;
+    font-size: 12px !important;
+}
+.landing-v2 .reg-preview__actions {
+    display: flex;
+    gap: 10px;
+}
+.landing-v2 .reg-preview__accept,
+.landing-v2 .reg-preview__reject {
+    font-family: var(--mono);
+    font-size: 12px;
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--line);
+}
+.landing-v2 .reg-preview__accept {
+    color: var(--page);
+    background: var(--ink);
+    border-color: var(--ink);
+}
+.landing-v2 .reg-preview__reject {
+    color: var(--muted);
+    background: var(--page);
+}
+.landing-v2 .reg-preview__note {
+    margin: 0;
+    padding: 10px 14px 14px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+    border-top: 1px solid var(--line);
+    text-align: center;
+}
+@media (max-width: 520px) {
+    .landing-v2 .reg-preview__stats { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* --- glossary (/docs/language) curated definition cards --- */
+.gloss { margin-top: 8px; }
+.gloss-group { margin-bottom: 48px; }
+.gloss-group__head {
+    border-top: 1px solid var(--line);
+    padding-top: 18px;
+    margin-bottom: 20px;
+}
+.gloss-group__eyebrow {
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    color: var(--green);
+    margin: 0 0 6px;
+}
+.gloss .gloss-group__title {
+    font-family: var(--serif);
+    font-size: 26px;
+    line-height: 1.1;
+    color: var(--ink);
+    margin: 0;
+    border: 0;
+    padding: 0;
+}
+.gloss-group__cards {
+    display: grid;
+    gap: 16px;
+}
+.gloss-card {
+    border: 1px solid var(--line);
+    background: var(--panel);
+    border-radius: 10px;
+    padding: 18px 20px 16px;
+}
+.gloss .gloss-card__term {
+    font-family: var(--mono);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--ink);
+    margin: 0 0 10px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 10px;
+}
+.gloss-card__dollar {
+    color: var(--green);
+    margin-right: -4px;
+}
+.gloss-card__exp {
+    font-family: var(--sans);
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--muted);
+}
+.gloss .gloss-card__def {
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--ink);
+    margin: 0 0 12px;
+}
+.gloss .gloss-card__usage {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 14.5px;
+    line-height: 1.55;
+    color: var(--muted);
+    margin: 0;
+    padding-left: 12px;
+    border-left: 2px solid var(--line);
+}
+.gloss-card__usage-label {
+    display: block;
+    font-family: var(--mono);
+    font-style: normal;
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--green);
+    margin-bottom: 4px;
+}
+@media (max-width: 480px) {
+    .gloss .gloss-group__title { font-size: 22px; }
+    .gloss-card { padding: 14px 16px; }
+}


### PR DESCRIPTION
## What

Truth-pass on the product-marketing pages plus a redesigned public glossary.

- **teams.tsx** — Reframed honestly as early-access/design-partner. The team aggregation layer is stated as *in development*; the walkthrough runs on each engineer's existing LOCAL ax data. Fabricated `app.ax/team` ministats (41% AI-native, 3/12 power users) replaced with **real single-seat receipts** ($605 redirectable, 26× recurring, $512.91 routing savings, churn episodes) framed "this is what one seat looks like." Privacy section rewritten as a design **contract** grounded in the one real export today (`ax profile publish` consent prompt, AGPL-3.0). Added `/leaders` + `/u/<login>` community proof and a "one person's trick → team practice" section (hooks SDK, skills, improve loop).
- **registry.tsx** — Explicit design-partner preview: early-access badge, roadmap voice ("ax *will* sync…"), a today-vs-building split, and one receipt-style **PREVIEW** suggestion-review card. Personal Gmail mailto → GitHub Discussions. Resolved the "ax for teams: governed skills" naming note. PitchSwitch kept (/registry stays unlisted, shared via outreach — no registry link added to teams).
- **routing-page.tsx** — Unclipped the step-02 install command (wraps now), reconciled the 14d/30d window splice, evergreen eyebrow ("since v0.27"), added a bridging `ax ingest` CTA step, `$512.9076` → `$512.91`.
- **glossary (/docs/language)** — Route now reads a NEW colocated `-language.data.ts` (per de-conflict rule; `docs/language.md` left orphaned in the collection, `content-collections.ts` untouched). Visitor-facing terms only + 2026 vocabulary (routing class, dispatch, quota, profile, leaders, impact, hook, recall). Dropped the competitor/governance/schema-internals sections. Drift fixed: checkpoints +3/+10/+30 **sessions**, watcher-driven retro (no Stop hook), "ax skills weighted", no repo paths. New CSS appended to globals.css.

## Why

These pages stated vaporware as shipped and contradicted the product truth (fabricated team stats, a non-existent open-source "collector", a personal Gmail, present-tense for parked features, drifted glossary terms). The brand is real numbers / receipts over vibes — the pages now match what ax actually does today and clearly future-tense what's being built with design partners.

## Verified

- `cd apps/site && bun run build` → exit 0 (content codegen + prerender; /teams, /registry, /routing, /docs/language all prerendered).
- `cd apps/site && bun test` → 128 pass / 0 fail (above 121 baseline; CLI-reference freshness test green).
- No `mailto:`/personal Gmail remains; language route no longer imports content-collections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)