### PR TITLE
feat(site): rebuild /brand as a self-demonstrating specimen page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,43 @@ Use the templates in `.github/ISSUE_TEMPLATE/`. For bugs, include:
 Worktree vs. Workspace are not interchangeable. See
 [`CONTEXT.md`](CONTEXT.md) before naming new tables, fields, or commands.
 
+## Brand & naming for contributors
+
+The brand is the product - every contributor surface should feel like the same
+hand drew it. The public, visitor-facing brand (wordmark, palette, typography,
+voice, motifs) is documented and demonstrated live at
+[`/brand`](https://ax.computer/brand). This section covers the contributor-side
+mechanics that don't belong on the public page.
+
+### Naming in code vs. copy
+
+- Visitor-facing copy is always **`ax`** (`ax doctor`, `ax serve`, `ax retro`),
+  never `axctl`.
+- `axctl` is the npm package / binary name - use it only when the technical
+  layer genuinely matters (`axctl install`, the `bin/axctl` shim). User stories
+  say "run `ax doctor`", not "run `axctl doctor`".
+- New user-facing commands follow `ax <verb>`. Check
+  [`CONTEXT.md`](CONTEXT.md) for the domain vocabulary before naming a new
+  command, table, or field.
+
+### Receipts and scrubbing
+
+- Docs, the README, and showcases use **real CLI output** - real timestamps,
+  real token counts, real session ids. Don't fake data to make a point land.
+- **Scrub project names** in any committed receipt or screenshot. Use the
+  `acme-app` / `acme-api` placeholder for repo names so no contributor's
+  private project names leak into the repo.
+
+### Commit messages
+
+- **No emoji** in commit messages, code, or docs unless a maintainer explicitly
+  asks. Conventional-commit prefixes only (see Ground rules above).
+- **No ALL-CAPS headings** except `AGENT EXPERIENCE` (the brand tag) and
+  uppercase column headers in dashboard tables.
+- **No marketing taglines on commands.** "`ax doctor` - checks your system"
+  beats "`ax doctor` - your trusted AI health companion".
+
 ## License
 
 By contributing, you agree your contribution will be licensed under the
-[MIT License](LICENSE).
+project license (see [LICENSE](LICENSE)).

--- a/apps/site/app/routes/-brand.data.ts
+++ b/apps/site/app/routes/-brand.data.ts
@@ -1,0 +1,177 @@
+/**
+ * Typed brand-specimen data for /brand.
+ *
+ * Curated, hand-authored mirror of the ax visual identity. The route renders
+ * these as live specimens (typeset wordmark, real color swatches, animated
+ * live-pulse, serif/mono scale) rather than prose - the page demonstrates the
+ * rules it documents.
+ *
+ * Audience split (deliberate): this module + the /brand page are PUBLIC brand
+ * material - voice, wordmark, palette, typography, motifs, the voice contract.
+ * Contributor mechanics (commit-message rules, project-name scrubbing, repo
+ * paths) live in CONTRIBUTING.md, not here.
+ *
+ * Hex values are mirrored from the live tokens in apps/site/app/styles/globals.css
+ * (:root). Keep them in sync if the tokens move.
+ *
+ * Always "ax" in visitor-facing copy, never "axctl".
+ */
+
+/** One palette token rendered as a real swatch (swatch + name + hex + role). */
+export interface BrandSwatch {
+  /** CSS custom property name, e.g. "--ink". */
+  readonly token: string;
+  /** Live hex value mirrored from :root. */
+  readonly hex: string;
+  /** What this color carries. Color only when it means something. */
+  readonly role: string;
+  /** True for ink/page/panel/line - the monochrome ground. */
+  readonly mono?: boolean;
+}
+
+/** The ink-on-paper ground + the four information colors. */
+export const BRAND_SWATCHES: readonly BrandSwatch[] = [
+  { token: "--ink", hex: "#0a0a0a", role: "Primary text, the wordmark, 2px masthead rules.", mono: true },
+  { token: "--page", hex: "#f6f5f0", role: "The paper. Every page sits on it.", mono: true },
+  { token: "--panel", hex: "#fbfaf5", role: "Card and panel ground, a half-shade off the page.", mono: true },
+  { token: "--line", hex: "#d8d6cf", role: "Hairline borders. Hierarchy comes from rules, never shadows.", mono: true },
+  { token: "--muted", hex: "#6b6b66", role: "Secondary text, eyebrows, captions, table meta.", mono: true },
+  { token: "--green", hex: "#2f9e44", role: "The live pulse, success, the primary accent.  Use the pulse once per surface." },
+  { token: "--blue", hex: "#2567a8", role: "References and links. Flag names in the CLI reference." },
+  { token: "--red", hex: "#c0392b", role: "Failure, regressions, offline state." },
+  { token: "--amber", hex: "#b07900", role: "Review buckets and watch-list items that need a look." },
+];
+
+/** One row of the serif headline scale, rendered live at its real size. */
+export interface SerifSpecimen {
+  /** Display label for the row. */
+  readonly label: string;
+  /** Inline font-size used to render the live specimen. */
+  readonly px: number;
+  /** Where this size appears in the product. */
+  readonly use: string;
+  /** The string to typeset. */
+  readonly sample: string;
+}
+
+export const SERIF_SCALE: readonly SerifSpecimen[] = [
+  { label: "Wordmark", px: 36, use: "Masthead. Georgia, -1px tracking.", sample: "ax" },
+  { label: "Hero headline", px: 34, use: "Page h1 across docs and marketing.", sample: "Receipts over vibes." },
+  { label: "Section title", px: 28, use: "Group headings (h2).", sample: "See where the money goes" },
+  { label: "Card title", px: 20, use: "Sub-section headings (h3).", sample: "The experiment loop" },
+];
+
+/** A mono $-eyebrow specimen, rendered exactly as it leads a section. */
+export const EYEBROW_SAMPLES: readonly string[] = [
+  "$ mine your history",
+  "$ see where the money goes",
+  "$ review proposals",
+  "$ guard the harness",
+];
+
+/** A voice rule from the contract - kept verbatim from docs/brand.md. */
+export interface VoiceRule {
+  readonly label: string;
+  readonly rule: string;
+}
+
+/**
+ * The voice contract, verbatim from the prior brand doc. This is good and
+ * survives the rebuild unchanged.
+ */
+export const VOICE_RULES: readonly VoiceRule[] = [
+  { label: "Pronoun", rule: "Second person (\"your agent\", \"you\"). Never first-person plural (\"we\")." },
+  { label: "Case", rule: "Lowercase headings where they fit (e.g. ax retro, ax doctor). Sentence case prose." },
+  { label: "Tone", rule: "Terse, evidence-first, no startup voice. State facts, then move on." },
+  { label: "Forbidden words", rule: "\"magical\", \"delight\", \"revolutionary\", \"powered by AI\", \"unlock\"." },
+  { label: "Hedge sparingly", rule: "Say what's true. Mark what's roadmap with \"tracked next\"." },
+];
+
+/** A do / instead-of voice example. No emoji - the rule forbids them. */
+export interface VoiceExample {
+  /** The on-brand line. */
+  readonly say: string;
+  /** The off-brand line it replaces. */
+  readonly instead: string;
+}
+
+export const VOICE_EXAMPLES: readonly VoiceExample[] = [
+  {
+    say: "ax answers these by reading what already happened.",
+    instead: "ax magically uncovers hidden patterns in your agent history.",
+  },
+  {
+    say: "Skill triage - which of your installed skills get used, which never fire.",
+    instead: "Get powerful insights into your skill usage.",
+  },
+];
+
+/** A typography stack and where it is used. */
+export interface TypeStack {
+  readonly stack: string;
+  readonly cssVar: string;
+  readonly use: string;
+}
+
+export const TYPE_STACKS: readonly TypeStack[] = [
+  { stack: "Georgia, serif", cssVar: "--serif", use: "Wordmark, headlines, section titles." },
+  { stack: "ui-monospace, Menlo", cssVar: "--mono", use: "$-eyebrows, receipts, flags, table meta, the brand tag." },
+  { stack: "system-ui sans", cssVar: "--sans", use: "Prose and body copy." },
+];
+
+/** A naming-canon entry: how a verb is spoken vs. shipped. */
+export interface NamingEntry {
+  /** The command as a visitor speaks it. */
+  readonly command: string;
+  /** What it does. */
+  readonly desc: string;
+  /** "shipped" renders normally; "roadmap" gets a tracked-next tag. */
+  readonly status: "shipped" | "roadmap";
+}
+
+/**
+ * The naming canon. Visitor copy is always "ax <verb>". Roadmap entries are
+ * marked, never presented as if they ship today.
+ */
+export const NAMING_CANON: readonly NamingEntry[] = [
+  { command: "ax doctor", desc: "System check.", status: "shipped" },
+  { command: "ax retro", desc: "Session retrospective.", status: "shipped" },
+  { command: "ax wrapped", desc: "Annual recap cards.", status: "shipped" },
+  { command: "ax serve", desc: "The dashboard daemon (ax studio lives at /studio).", status: "shipped" },
+  { command: "ax improve", desc: "Rank proposals, accept them, track verdicts.", status: "shipped" },
+  { command: "ax routing", desc: "Mine dispatch history, route mechanical work to cheaper models.", status: "shipped" },
+];
+
+/** A brand motif documented as a live specimen. */
+export interface Motif {
+  readonly title: string;
+  readonly body: string;
+}
+
+export const MOTIFS: readonly Motif[] = [
+  {
+    title: "Receipts, not vibes",
+    body:
+      "ax makes claims with real numbers - $605 redirectable, 26x recurring, +3/+10/+30 sessions measured. Every figure is something the graph actually computed. The home page and /origin are the canonical executions: proposal cards and a measured-bets strip, not marketing adjectives.",
+  },
+  {
+    title: "Real numbers as proof",
+    body:
+      "Receipts use actual CLI output - real timestamps, real session ids, real token counts. The proof is the data, not the framing. Never fake a figure to make a point land.",
+  },
+  {
+    title: "Ink on paper",
+    body:
+      "Monochrome by default. Color only when it carries information: green for live and success, blue for references, red for failure, amber for review. A surface that's all color is a surface where nothing means anything.",
+  },
+  {
+    title: "Hairline rules",
+    body:
+      "1px lines separate sections. A 2px ink rule caps the masthead and group heads. Hierarchy comes from rules and type, never from drop shadows.",
+  },
+  {
+    title: "The live pulse",
+    body:
+      "A single green dot on a 1.6s ease-in-out opacity loop signals freshness. One per surface - duplicate it and it stops meaning \"live\".",
+  },
+];

--- a/apps/site/app/routes/brand.tsx
+++ b/apps/site/app/routes/brand.tsx
@@ -1,27 +1,304 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
-import { MDXContent } from "@content-collections/mdx/react";
-import { allPages } from "content-collections";
-import { mdxComponents } from "~/components/mdx-components";
-import { DocShell } from "~/components/doc-shell";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { SiteHeader } from "~/components/landing-sections/site-header";
+import { SiteFooter } from "~/components/landing-sections/site-footer";
+import {
+  BRAND_SWATCHES,
+  SERIF_SCALE,
+  EYEBROW_SAMPLES,
+  VOICE_RULES,
+  VOICE_EXAMPLES,
+  TYPE_STACKS,
+  NAMING_CANON,
+  MOTIFS,
+} from "./-brand.data";
 
 export const Route = createFileRoute("/brand")({
   head: () => ({
     meta: [
       { title: "Brand - ax" },
-      { name: "description", content: "ax brand guidelines: voice, wordmark, and palette." },
+      {
+        name: "description",
+        content:
+          "The ax brand, shown not told: the typeset wordmark, the ink-on-paper palette as live swatches, the serif and mono scale, the live pulse, and the voice contract.",
+      },
     ],
   }),
-  loader: () => {
-    const page = allPages.find((p) => p.slug === "brand");
-    if (!page) throw notFound();
-    return { page };
-  },
-  component: () => {
-    const { page } = Route.useLoaderData();
-    return (
-      <DocShell eyebrow="brand">
-        <MDXContent code={page.body} components={mdxComponents} />
-      </DocShell>
-    );
-  },
+  component: BrandSpecimen,
 });
+
+/** A labelled specimen frame: caption above, the live thing below. */
+function Specimen({
+  label,
+  meta,
+  children,
+}: {
+  label: string;
+  meta?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <figure className="brand-specimen">
+      <figcaption className="brand-specimen__cap">
+        <span className="brand-specimen__label">{label}</span>
+        {meta && <span className="brand-specimen__meta">{meta}</span>}
+      </figcaption>
+      <div className="brand-specimen__body">{children}</div>
+    </figure>
+  );
+}
+
+function BrandSpecimen() {
+  return (
+    <>
+      <SiteHeader />
+      <main className="doc-main brand-page">
+        <nav className="doc-crumb" aria-label="breadcrumb">
+          <Link to="/docs">← Docs</Link>
+        </nav>
+
+        <header className="doc-head">
+          <p className="eyebrow">$ the brand is the typography</p>
+          <h1>Brand</h1>
+          <p className="lede">
+            No logo, no glyph. ax is set in Georgia on paper, measured in mono,
+            and proven with real numbers. This page demonstrates its own rules -
+            the specimens below are the live treatments, not pictures of them.
+          </p>
+        </header>
+
+        {/* ---- Wordmark ---- */}
+        <section className="brand-section" id="wordmark">
+          <header className="brand-section__head">
+            <p className="brand-section__eyebrow">$ the wordmark</p>
+            <h2 className="brand-section__title">ax, agent experience</h2>
+            <p className="brand-section__blurb">
+              Lowercase <code>ax</code> in Georgia serif, paired with the mono
+              tag. <strong>ax</strong> is the project; <code>axctl</code> is the
+              npm package name - visitor copy always says ax.
+            </p>
+          </header>
+
+          <Specimen label="Wordmark" meta="Georgia · 36px · -1px tracking">
+            <span className="brand-wordmark-demo">
+              <span className="brand-wordmark-demo__mark">ax</span>
+              <span className="brand-wordmark-demo__tag">agent experience</span>
+            </span>
+          </Specimen>
+
+          <ul className="brand-notes">
+            <li>
+              <strong>ax</strong> - lowercase, Georgia serif, 36px in the
+              masthead. No uppercase, no abbreviation.
+            </li>
+            <li>
+              <strong>agent experience</strong> - uppercase mono, 10px,
+              letter-spacing 0.16em, baseline-aligned and muted.
+            </li>
+            <li>A 10px gap separates the two on screen; a single space in text.</li>
+          </ul>
+        </section>
+
+        {/* ---- Palette ---- */}
+        <section className="brand-section" id="palette">
+          <header className="brand-section__head">
+            <p className="brand-section__eyebrow">$ ink on paper</p>
+            <h2 className="brand-section__title">Palette</h2>
+            <p className="brand-section__blurb">
+              Monochrome by default; color only when it carries information.
+              These swatches render from the live tokens in{" "}
+              <code>globals.css</code> :root.
+            </p>
+          </header>
+
+          <div className="brand-swatches">
+            {BRAND_SWATCHES.map((s) => (
+              <div
+                key={s.token}
+                className={`brand-swatch${s.mono ? " brand-swatch--mono" : ""}`}
+              >
+                <span
+                  className="brand-swatch__chip"
+                  style={{ background: `var(${s.token})` }}
+                  aria-hidden="true"
+                />
+                <div className="brand-swatch__meta">
+                  <code className="brand-swatch__token">{s.token}</code>
+                  <code className="brand-swatch__hex">{s.hex}</code>
+                  <span className="brand-swatch__role">{s.role}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ---- Motifs (incl. live pulse) ---- */}
+        <section className="brand-section" id="motifs">
+          <header className="brand-section__head">
+            <p className="brand-section__eyebrow">$ how it carries meaning</p>
+            <h2 className="brand-section__title">Motifs</h2>
+            <p className="brand-section__blurb">
+              Receipts is the core idea. The rest keeps the surface honest:
+              real numbers, hairline rules, one live pulse.
+            </p>
+          </header>
+
+          <Specimen label="The live pulse" meta="green dot · 1.6s ease-in-out · once per surface">
+            <span className="live brand-live-demo" title="the agent experience layer is alive">
+              live
+            </span>
+          </Specimen>
+
+          <Specimen label="Hairline rules" meta="1px --line · 2px --ink cap">
+            <div className="brand-rule-demo">
+              <span className="brand-rule-demo__hair" />
+              <span className="brand-rule-demo__hair" />
+              <span className="brand-rule-demo__ink" />
+            </div>
+          </Specimen>
+
+          <div className="brand-cards">
+            {MOTIFS.map((m) => (
+              <article key={m.title} className="brand-card">
+                <h3 className="brand-card__title">{m.title}</h3>
+                <p className="brand-card__body">{m.body}</p>
+              </article>
+            ))}
+          </div>
+
+          <p className="brand-section__foot">
+            The home page (<Link to="/">/</Link>) and{" "}
+            <Link to="/origin">/origin</Link> are the canonical executions:
+            proposal cards with redirectable-dollar figures and a measured-bets
+            strip checkpointed at +3 / +10 / +30 sessions.
+          </p>
+        </section>
+
+        {/* ---- Typography ---- */}
+        <section className="brand-section" id="typography">
+          <header className="brand-section__head">
+            <p className="brand-section__eyebrow">$ serif headline, mono eyebrow</p>
+            <h2 className="brand-section__title">Typography</h2>
+            <p className="brand-section__blurb">
+              Three stacks, each with a job. Serif for headlines, mono for the
+              machine voice, sans for prose.
+            </p>
+          </header>
+
+          <Specimen label="Serif scale" meta="Georgia · live at real size">
+            <div className="brand-scale">
+              {SERIF_SCALE.map((row) => (
+                <div key={row.label} className="brand-scale__row">
+                  <span
+                    className="brand-scale__sample"
+                    style={{ fontSize: `${row.px}px` }}
+                  >
+                    {row.sample}
+                  </span>
+                  <span className="brand-scale__note">
+                    <code>{row.px}px</code> · {row.label} - {row.use}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </Specimen>
+
+          <Specimen label="Mono $-eyebrow" meta="ui-monospace · the section lead">
+            <div className="brand-eyebrows">
+              {EYEBROW_SAMPLES.map((e) => (
+                <span key={e} className="brand-eyebrows__item">
+                  {e}
+                </span>
+              ))}
+            </div>
+          </Specimen>
+
+          <dl className="brand-stacks">
+            {TYPE_STACKS.map((t) => (
+              <div key={t.cssVar} className="brand-stacks__row">
+                <dt>
+                  <code>{t.cssVar}</code>
+                  <span className="brand-stacks__name">{t.stack}</span>
+                </dt>
+                <dd>{t.use}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        {/* ---- Voice ---- */}
+        <section className="brand-section" id="voice">
+          <header className="brand-section__head">
+            <p className="brand-section__eyebrow">$ the voice contract</p>
+            <h2 className="brand-section__title">Voice</h2>
+            <p className="brand-section__blurb">
+              Terse, evidence-first, second person. State what's true, then move
+              on.
+            </p>
+          </header>
+
+          <dl className="brand-voice">
+            {VOICE_RULES.map((v) => (
+              <div key={v.label} className="brand-voice__row">
+                <dt>{v.label}</dt>
+                <dd>{v.rule}</dd>
+              </div>
+            ))}
+          </dl>
+
+          <div className="brand-examples">
+            {VOICE_EXAMPLES.map((ex) => (
+              <div key={ex.say} className="brand-example">
+                <p className="brand-example__say">{ex.say}</p>
+                <p className="brand-example__instead">
+                  <span className="brand-example__tag">instead of</span>
+                  {ex.instead}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ---- Naming canon ---- */}
+        <section className="brand-section" id="naming">
+          <header className="brand-section__head">
+            <p className="brand-section__eyebrow">$ ax &lt;verb&gt;</p>
+            <h2 className="brand-section__title">Naming</h2>
+            <p className="brand-section__blurb">
+              User-facing commands read <code>ax &lt;verb&gt;</code>. The full
+              vocabulary lives in <Link to="/docs/language">the language
+              reference</Link>.
+            </p>
+          </header>
+
+          <dl className="brand-naming">
+            {NAMING_CANON.map((n) => (
+              <div key={n.command} className="brand-naming__row">
+                <dt>
+                  <code>{n.command}</code>
+                  {n.status === "roadmap" && (
+                    <span className="brand-naming__tag">tracked next</span>
+                  )}
+                </dt>
+                <dd>{n.desc}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <p className="brand-page__foot">
+          Contributing? Naming, scrubbing, and commit conventions for the repo
+          live in{" "}
+          <a
+            href="https://github.com/Necmttn/ax/blob/main/CONTRIBUTING.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            CONTRIBUTING.md
+          </a>
+          .
+        </p>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -13,6 +13,7 @@
   --green: #2f9e44;
   --blue: #2567a8;
   --red: #c0392b;
+  --amber: #b07900;
   --serif: Georgia, "Times New Roman", serif;
   --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", "Helvetica Neue", sans-serif;
@@ -12655,4 +12656,409 @@ footer.site-footer { padding: 48px 32px 56px; }
     .cliref-card { padding: 16px 16px 14px; }
     .cliref-card__flag { grid-template-columns: 1fr; gap: 2px; }
     .cliref-index nav { columns: 1; }
+}
+
+/* ============================================================
+   /brand - the self-demonstrating specimen page (WS6)
+   Reuses the cliref editorial language: 2px-cap section heads,
+   mono $-eyebrows, serif titles, hairline-ruled panels.
+   ============================================================ */
+
+.brand-page { padding-bottom: 96px; }
+
+.brand-section { margin: 0 0 64px; }
+
+.brand-section__head {
+    border-top: 2px solid var(--ink);
+    padding-top: 20px;
+    margin-bottom: 28px;
+    max-width: 720px;
+}
+.brand-section__eyebrow {
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    color: var(--green);
+    margin: 0 0 8px;
+}
+.brand-section__title {
+    font-family: var(--serif);
+    font-size: 28px;
+    line-height: 1.1;
+    color: var(--ink);
+    margin: 0 0 10px;
+}
+.brand-section__blurb {
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.55;
+    color: var(--muted);
+    margin: 0;
+}
+.brand-section__blurb code,
+.brand-section__blurb strong { color: var(--ink); }
+.brand-section__blurb code { font-family: var(--mono); font-size: 0.92em; }
+.brand-section__foot {
+    font-family: var(--sans);
+    font-size: 14.5px;
+    line-height: 1.6;
+    color: var(--muted);
+    margin: 20px 0 0;
+    max-width: 720px;
+}
+.brand-section__foot a { color: var(--blue); text-decoration: underline; text-underline-offset: 2px; }
+
+/* --- specimen frame: caption + the live thing --- */
+.brand-specimen {
+    margin: 0 0 20px;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    border-radius: 10px;
+    overflow: hidden;
+}
+.brand-specimen__cap {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--line);
+    background: var(--page);
+}
+.brand-specimen__label {
+    font-family: var(--mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--ink);
+}
+.brand-specimen__meta {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+    text-align: right;
+}
+.brand-specimen__body {
+    padding: 32px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 96px;
+}
+
+/* --- wordmark demo (mirrors .brand / .wordmark / .brand-tag) --- */
+.brand-wordmark-demo {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+}
+.brand-wordmark-demo__mark {
+    font-family: var(--serif);
+    font-size: 36px;
+    line-height: 1;
+    letter-spacing: -1px;
+    color: var(--ink);
+}
+.brand-wordmark-demo__tag {
+    font-family: var(--mono);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--muted);
+    white-space: nowrap;
+}
+
+.brand-notes {
+    margin: 16px 0 0;
+    padding-left: 20px;
+    max-width: 720px;
+}
+.brand-notes li {
+    font-family: var(--sans);
+    font-size: 14.5px;
+    line-height: 1.6;
+    color: var(--muted);
+    margin: 6px 0;
+}
+.brand-notes li::marker { color: var(--line); }
+.brand-notes strong { color: var(--ink); font-weight: 600; }
+
+/* --- palette swatches --- */
+.brand-swatches {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 14px;
+}
+.brand-swatch {
+    display: flex;
+    align-items: stretch;
+    gap: 14px;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    border-radius: 8px;
+    padding: 12px;
+}
+.brand-swatch__chip {
+    flex-shrink: 0;
+    width: 56px;
+    border-radius: 6px;
+    border: 1px solid color-mix(in srgb, var(--ink) 12%, transparent);
+}
+.brand-swatch--mono .brand-swatch__chip {
+    border-color: var(--line);
+}
+.brand-swatch__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+}
+.brand-swatch__token {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink);
+}
+.brand-swatch__hex {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--muted);
+    text-transform: uppercase;
+}
+.brand-swatch__role {
+    font-family: var(--sans);
+    font-size: 12.5px;
+    line-height: 1.45;
+    color: var(--muted);
+    margin-top: 2px;
+}
+
+/* --- motif: live pulse / hairline rules --- */
+.brand-live-demo { font-size: 13px; }
+.brand-rule-demo {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    width: 100%;
+    max-width: 360px;
+}
+.brand-rule-demo__hair { height: 1px; background: var(--line); }
+.brand-rule-demo__ink { height: 2px; background: var(--ink); }
+
+/* --- motif cards --- */
+.brand-cards {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    margin-top: 4px;
+}
+.brand-card {
+    border: 1px solid var(--line);
+    background: var(--panel);
+    border-radius: 10px;
+    padding: 18px 20px;
+}
+.brand-card__title {
+    font-family: var(--serif);
+    font-size: 19px;
+    line-height: 1.2;
+    color: var(--ink);
+    margin: 0 0 8px;
+}
+.brand-card__body {
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--muted);
+    margin: 0;
+}
+
+/* --- serif scale --- */
+.brand-scale {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    width: 100%;
+    align-items: flex-start;
+}
+.brand-scale__row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+}
+.brand-scale__sample {
+    font-family: var(--serif);
+    line-height: 1.1;
+    letter-spacing: -0.5px;
+    color: var(--ink);
+}
+.brand-scale__note {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    color: var(--muted);
+}
+.brand-scale__note code { color: var(--blue); }
+
+/* --- mono eyebrows --- */
+.brand-eyebrows {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 20px;
+    width: 100%;
+}
+.brand-eyebrows__item {
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    color: var(--green);
+}
+
+/* --- type stacks --- */
+.brand-stacks { margin: 16px 0 0; max-width: 720px; }
+.brand-stacks__row {
+    display: grid;
+    grid-template-columns: minmax(220px, max-content) 1fr;
+    gap: 16px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--line);
+    align-items: baseline;
+}
+.brand-stacks__row dt {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.brand-stacks__row dt code { font-family: var(--mono); font-size: 13px; color: var(--blue); }
+.brand-stacks__name { font-family: var(--sans); font-size: 13px; color: var(--ink); }
+.brand-stacks__row dd {
+    margin: 0;
+    font-family: var(--sans);
+    font-size: 14px;
+    color: var(--muted);
+}
+
+/* --- voice contract --- */
+.brand-voice { margin: 0; max-width: 720px; }
+.brand-voice__row {
+    display: grid;
+    grid-template-columns: minmax(140px, max-content) 1fr;
+    gap: 16px;
+    padding: 11px 0;
+    border-bottom: 1px solid var(--line);
+    align-items: baseline;
+}
+.brand-voice__row dt {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--ink);
+}
+.brand-voice__row dd {
+    margin: 0;
+    font-family: var(--sans);
+    font-size: 14.5px;
+    line-height: 1.55;
+    color: var(--muted);
+}
+
+.brand-examples {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+    margin-top: 24px;
+}
+.brand-example {
+    border: 1px solid var(--line);
+    background: var(--panel);
+    border-radius: 10px;
+    padding: 16px 18px;
+}
+.brand-example__say {
+    font-family: var(--sans);
+    font-size: 14.5px;
+    line-height: 1.5;
+    color: var(--ink);
+    margin: 0 0 12px;
+    padding-left: 12px;
+    border-left: 2px solid var(--green);
+}
+.brand-example__instead {
+    font-family: var(--sans);
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: var(--muted);
+    margin: 0;
+    padding-left: 12px;
+    border-left: 2px solid var(--line);
+}
+.brand-example__tag {
+    display: block;
+    font-family: var(--mono);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    margin-bottom: 4px;
+}
+
+/* --- naming canon --- */
+.brand-naming { margin: 0; max-width: 720px; }
+.brand-naming__row {
+    display: grid;
+    grid-template-columns: minmax(160px, max-content) 1fr;
+    gap: 16px;
+    padding: 11px 0;
+    border-bottom: 1px solid var(--line);
+    align-items: baseline;
+}
+.brand-naming__row dt {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+.brand-naming__row dt code {
+    font-family: var(--mono);
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--ink);
+}
+.brand-naming__tag {
+    font-family: var(--mono);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--amber);
+    border: 1px solid color-mix(in srgb, var(--amber) 40%, var(--line));
+    border-radius: 4px;
+    padding: 1px 6px;
+}
+.brand-naming__row dd {
+    margin: 0;
+    font-family: var(--sans);
+    font-size: 14px;
+    color: var(--muted);
+}
+
+.brand-page__foot {
+    font-family: var(--sans);
+    font-size: 14px;
+    color: var(--muted);
+    margin: 8px 0 0;
+    padding-top: 24px;
+    border-top: 1px solid var(--line);
+    max-width: 720px;
+}
+.brand-page__foot a { color: var(--blue); text-decoration: underline; text-underline-offset: 2px; }
+
+@media (max-width: 760px) {
+    .brand-swatches,
+    .brand-cards,
+    .brand-examples { grid-template-columns: 1fr; }
+    .brand-section__title { font-size: 24px; }
+    .brand-specimen__body { padding: 24px 16px; }
+    .brand-stacks__row,
+    .brand-voice__row,
+    .brand-naming__row { grid-template-columns: 1fr; gap: 4px; }
 }


### PR DESCRIPTION
## What

Rebuilds `/brand` from a raw-markdown dump into a specimen page that **demonstrates its own rules** instead of describing them:

- **Typeset wordmark** - live "ax" in Georgia 36px + mono `agent experience` tag, read from the real masthead treatment.
- **Real color swatches** rendered from the live `:root` tokens (`--ink/--page/--panel/--line/--muted/--green/--blue/--red/--amber`), each showing the chip + token name + hex + role.
- **Animated green live-pulse** dot, exactly as it appears in the product.
- **Hairline rules drawn as hairline rules**; serif headline scale + mono `$`-eyebrow shown as live specimens at real size.
- Names **"receipts"** as the core concept and documents real-numbers-as-proof + ink-on-paper, citing `/` and `/origin` as canonical executions.

Curated content is a new colocated TS data module (`app/routes/-brand.data.ts`, mirroring `-cli-reference.data.ts`); the route stops reading `docs/brand.md` via the content collections. The old `.md` is left orphaned in place (later cleanup PR) so `content-collections.ts` is untouched.

## Why

The old page told instead of showed (wordmark as a fenced code block, palette as a prose table with no swatches, live-pulse only described), predated the receipts identity, leaked contributor-contract material into a public page, and listed nonexistent commands.

Fact fixes: drop `ax pilot` / `ax score`, `axctl serve` -> `ax serve`, remove the dead `src/dashboard/web/src/styles.css` path, fix the broken language link to `/docs/language`. Contributor mechanics (naming-in-code, receipt scrubbing, commit-message rules) moved to a new **"Brand & naming for contributors"** section in `CONTRIBUTING.md`. The voice contract is kept verbatim (public). `--amber` added to `:root` (was scoped to `.features-page`).

## Verified

- `cd apps/site && bun run build` exits 0; `/brand` prerenders clean.
- `cd apps/site && bun test` -> 128 pass / 0 fail (CLI-reference freshness test intact).
- Visual check at 1280x900 and 390x844 via agent-browser (desktop + mobile full-page); shots at `/tmp/site-audit/ws6-brand-{desktop,mobile}.png`.
- No `ax pilot` / `ax score` / `axctl serve` / `styles.css` leakage in the new files.
- Pre-existing typecheck errors in `changelog`/`adr` routes are unrelated (content-collections codegen) and not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)