### PR TITLE
fix(site): truth pass on story/credibility pages (features, origin, manifesto)

### DIFF
--- a/apps/site/app/components/features/features-page.tsx
+++ b/apps/site/app/components/features/features-page.tsx
@@ -16,7 +16,7 @@ export function FeaturesPage() {
         <div className="scale">
           <div className="stat">
             <span className="v">369,132</span>
-            <span className="k">turns indexed</span>
+            <span className="k">user + assistant turns</span>
           </div>
           <div className="stat">
             <span className="v">4,773</span>
@@ -31,6 +31,10 @@ export function FeaturesPage() {
             <span className="k">derived per ingest</span>
           </div>
         </div>
+        <p className="scale-asof">
+          One developer&apos;s local graph, as of June 2026. Turn count is role-filtered to
+          user + assistant exchanges - the real signal, not raw provider events.
+        </p>
         <div className="toc">
           <a href="#sources">01 Sources</a>
           <a href="#graph">02 The graph</a>
@@ -114,9 +118,9 @@ export function FeaturesPage() {
           <p>
             A LaunchAgent (<code>com.necmttn.ax-watch</code>) tails your Claude and Codex transcript
             directories and runs <code>ax ingest --since=1</code> in the background within seconds of a
-            new turn. A weekly cron does a deep-scan backfill for anything the watcher missed.
-            Nothing is uploaded, queued, or phoned home - every read stays on the same filesystem
-            your agent already writes to.
+            new turn. A weekly self-improve cron for deep-scan backfill is on the roadmap (wire-up
+            pending). Nothing is uploaded, queued, or phoned home - every read stays on the same
+            filesystem your agent already writes to.
           </p>
         </div>
 
@@ -128,9 +132,9 @@ export function FeaturesPage() {
             </span>
           </div>
           <div className="item">
-            <span className="k">weekly</span>
+            <span className="k">roadmap</span>
             <span className="v">
-              <b>cron</b> deep-scans for missed sessions + drift
+              <b>weekly cron</b> deep-scan backfill for missed sessions + drift (wire-up pending)
             </span>
           </div>
         </div>
@@ -154,19 +158,17 @@ export function FeaturesPage() {
             <span className="c">{`// schema sketch - SurrealDB v3, ns=ax, db=main`}</span>
             {`\n\n       `}
             <span className="n">session</span>
-            {` ──owns──▶ `}
+            {` ────▶ `}
             <span className="n">turn</span>
             {` ──invoked──▶ `}
-            <span className="n">tool_call</span>
-            {`\n          │                  │                    │\n          │                  │                    ├──touched──▶ `}
-            <span className="n">file</span>
-            {`\n          │                  │                    └──fired────▶ `}
-            <span className="n">hook_event</span>
-            {`\n          │                  │\n          │                  └──addressed──▶ `}
             <span className="n">skill</span>
+            {`\n          │             │\n          │             ├──(owns)───▶ `}
+            <span className="n">tool_call</span>
+            {`\n          │             └──edited───▶ `}
+            <span className="n">file</span>
             {`\n          │\n          └──produced──▶ `}
             <span className="n">commit</span>
-            {` ──changes──▶ `}
+            {` ──touched──▶ `}
             <span className="n">file</span>
             {`\n\n       `}
             <span className="c">{`// relations are first-class - every edge is queryable`}</span>
@@ -207,27 +209,23 @@ export function FeaturesPage() {
               </div>
             </div>
             <div className="legend-block">
-              <div className="legend-title">Relations - 5</div>
+              <div className="legend-title">Relations - 4</div>
               <div className="legend-list">
                 <div className="row rel">
                   <code>invoked</code>
-                  <span className="desc">turn → tool_call</span>
+                  <span className="desc">turn → skill (Skill tool call)</span>
                 </div>
                 <div className="row rel">
                   <code>edited</code>
-                  <span className="desc">tool_call → file (Edit/Write)</span>
+                  <span className="desc">turn → file (Edit/Write)</span>
                 </div>
                 <div className="row rel">
                   <code>touched</code>
-                  <span className="desc">tool_call → file (Read)</span>
+                  <span className="desc">commit → file</span>
                 </div>
                 <div className="row rel">
                   <code>produced</code>
                   <span className="desc">session → commit</span>
-                </div>
-                <div className="row rel">
-                  <code>addressed</code>
-                  <span className="desc">turn → skill (mentioned/loaded)</span>
                 </div>
               </div>
             </div>
@@ -256,7 +254,7 @@ export function FeaturesPage() {
             </div>
             <div className="stage-purpose">Classifies each commit as feature-only or feature-then-fix.</div>
             <div className="stage-meta">
-              writes <b>commit.closure</b>
+              writes <b>commit_classification</b>
             </div>
           </div>
 
@@ -324,7 +322,7 @@ export function FeaturesPage() {
               Audits installed skills, hooks, plists, and settings.json for drift, conflicts, dead weight.
             </div>
             <div className="stage-meta">
-              writes <b>harness_finding</b>
+              live audit - no table; surfaced by <b>ax doctor</b>
             </div>
           </div>
 
@@ -377,7 +375,7 @@ export function FeaturesPage() {
               <div className="iv-form">
                 <span className="nm">hook</span>
                 <span className="ds">
-                  a pre/post-tool gate in <code className="inline">settings.json</code>
+                  a typed pre/post-tool gate in <code className="inline">~/.ax/hooks/</code>, fanned into both harnesses
                 </span>
               </div>
               <div className="iv-form">
@@ -578,7 +576,7 @@ export function FeaturesPage() {
         <div className="section-head">
           <span className="section-num">06 / Surfaces</span>
           <h2>
-            One CLI, <em>eight verbs.</em>
+            One CLI, <em>every query.</em>
           </h2>
           <p className="section-lede">
             Everything ax knows is reachable from <code className="inline">ax</code>. The dashboard, TUI,
@@ -606,6 +604,30 @@ export function FeaturesPage() {
           <div className="cli-row">
             <span className="cmd">ax doctor</span>
             <span className="desc">Harness health check - drift, conflicts, dead weight across skills + hooks + plists.</span>
+          </div>
+          <div className="cli-row">
+            <span className="cmd">
+              ax dispatches <span className="arg">--candidates</span> · ax routing <span className="arg">tune / compile / show</span>
+            </span>
+            <span className="desc">See where subagent spend goes, then route mechanical dispatches to cheaper models. The route-dispatch hook is the deterministic backstop.</span>
+          </div>
+          <div className="cli-row">
+            <span className="cmd">
+              ax cost <span className="arg">models / sessions / split</span>
+            </span>
+            <span className="desc">Per-model and origin (main vs subagent) cost rollups with estimated USD and share-of-total.</span>
+          </div>
+          <div className="cli-row">
+            <span className="cmd">
+              ax quota <span className="arg">--statusline / --swiftbar</span>
+            </span>
+            <span className="desc">Live Claude plan usage (5h / 7d windows) in the CLI, statusline, or menubar. Cached, no DB.</span>
+          </div>
+          <div className="cli-row">
+            <span className="cmd">
+              ax profile <span className="arg">show / publish</span>
+            </span>
+            <span className="desc">Render your local ax profile, or publish it to a public gist - opt-in, consent-gated, registered into the community leaderboard.</span>
           </div>
           <div className="cli-row">
             <span className="cmd">

--- a/apps/site/app/components/origin-sections/chapter-2-scope.tsx
+++ b/apps/site/app/components/origin-sections/chapter-2-scope.tsx
@@ -41,7 +41,7 @@ export function Chapter2Scope() {
       </p>
 
       <p>
-        The interview-style skills — Matt Peacock’s{" "}
+        The interview-style skills — Matt Pocock’s{" "}
         <code>grillme</code> is the sharpest example — turn the
         agent into a debugger of your own intent. Before any code runs,
         the model grills you for scope, terminology, decision-tree

--- a/apps/site/app/components/origin-sections/chapter-6-retro.tsx
+++ b/apps/site/app/components/origin-sections/chapter-6-retro.tsx
@@ -21,17 +21,18 @@ export function Chapter6Retro() {
       <p>
         The user still decides. The graph decides what is worth asking
         about. Every accepted fix becomes an experiment with checkpoints
-        at t+7, t+30, and t+90.
+        at +3, +10, and +30 sessions - measured in sessions, not calendar
+        days, so a quiet weekend never delays the verdict.
       </p>
 
       <aside className="framework-list" aria-label="five requirements the retro loop has to meet">
         <span className="framework-list-label">what the loop has to do</span>
         <ul>
-          <li><span className="fw-name">01 · fire at the right time</span><span className="fw-note">the Stop hook on session-end is the only moment the agent still has its context. five seconds later it is gone.</span></li>
+          <li><span className="fw-name">01 · capture while context is warm</span><span className="fw-note">the reflection has to land while the agent still has its context loaded. ax does it pull-based - a background watcher ingests as sessions land, no Stop hook wedged into the turn.</span></li>
           <li><span className="fw-name">02 · structured by default</span><span className="fw-note">json with four fields — tried, worked, failed, next. free-form is an escape hatch, not the default.</span></li>
           <li><span className="fw-name">03 · cover sub-agents</span><span className="fw-note">main-session retros are nice. sub-agent retros are the unlock. the hook has to fire for them too.</span></li>
           <li><span className="fw-name">04 · become a proposal</span><span className="fw-note">“that worked, do it more” is not useful. the retro feeds a deduplicated queue you accept, reject, or skip.</span></li>
-          <li><span className="fw-name">05 · become an experiment</span><span className="fw-note">accepted proposals get scaffolded as real artifacts. checkpoints at t+7, t+30, t+90 close the verdict.</span></li>
+          <li><span className="fw-name">05 · become an experiment</span><span className="fw-note">accepted proposals get scaffolded as real artifacts. checkpoints at +3, +10, +30 sessions close the verdict.</span></li>
         </ul>
       </aside>
     </section>

--- a/apps/site/app/components/origin-sections/chapter-8-what-ax-is.tsx
+++ b/apps/site/app/components/origin-sections/chapter-8-what-ax-is.tsx
@@ -17,9 +17,9 @@ export function Chapter8WhatAxIs() {
       </p>
 
       <p>
-        It ingests Claude Code and Codex transcripts, tool calls, skills,
-        hooks, corrections, and local git history into a typed graph on
-        your laptop. It asks for session retros while context is still
+        It ingests transcripts from Claude Code, Codex, Pi, OpenCode, and
+        Cursor - plus tool calls, skills, hooks, corrections, and local git
+        history - into a typed graph on your laptop. It asks for session retros while context is still
         warm. It lets bigger retros surface repeated friction. It turns
         proposed fixes into experiments and asks for verdicts later.
       </p>

--- a/apps/site/app/components/origin-sections/chapter-exhibit-e.tsx
+++ b/apps/site/app/components/origin-sections/chapter-exhibit-e.tsx
@@ -42,7 +42,7 @@ export function ChapterExhibitE() {
         verdict: "kept",
         verdictLabel: "KEPT",
         verdictMeta: "merged 2026-05-22",
-        ticks: { 7: '<span class="lk">t+7</span> 12 sessions clean', 30: '<span class="lk">t+30</span> 0 incidents', 90: '<span class="lk">t+90</span> <span style="color:var(--green)">verdict=kept</span>' },
+        ticks: { 7: '<span class="lk">+3</span> 12 sessions clean', 30: '<span class="lk">+10</span> 0 incidents', 90: '<span class="lk">+30</span> <span style="color:var(--green)">verdict=kept</span>' },
       },
       {
         id: "oxlint-swap",
@@ -54,7 +54,7 @@ export function ChapterExhibitE() {
         verdict: "regressed",
         verdictLabel: "REGRESSED",
         verdictMeta: "reverted 2026-05-15",
-        ticks: { 7: '<span class="lk">t+7</span> 3 false positives', 30: '<span class="lk">t+30</span> 1 missed rule', 90: '<span class="lk">t+90</span> <span class="lv-err">reverted</span>' },
+        ticks: { 7: '<span class="lk">+3</span> 3 false positives', 30: '<span class="lk">+10</span> 1 missed rule', 90: '<span class="lk">+30</span> <span class="lv-err">reverted</span>' },
       },
       {
         id: "parallel-task",
@@ -66,7 +66,7 @@ export function ChapterExhibitE() {
         verdict: "self-resolved",
         verdictLabel: "SELF-RESOLVED",
         verdictMeta: "Task tool defaults changed",
-        ticks: { 7: '<span class="lk">t+7</span> 4 invocations', 30: '<span class="lk">t+30</span> 0 invocations', 90: "<span class=\"lk\">t+90</span> upstream patched" },
+        ticks: { 7: '<span class="lk">+3</span> 4 invocations', 30: '<span class="lk">+10</span> 0 invocations', 90: "<span class=\"lk\">+30</span> upstream patched" },
       },
     ];
 
@@ -303,12 +303,13 @@ export function ChapterExhibitE() {
     }
 
     function dayLabel(p: number) {
+      // Internal scale stays 0–90 for the scrubber math; labels read in sessions.
       const d = Math.round(p * 90);
-      if (d === 0) return "t+0 · now";
-      if (d < 7)   return `t+${d} · early`;
-      if (d < 30)  return `t+${d} · week ${Math.ceil(d / 7)}`;
-      if (d < 90)  return `t+${d} · tracking`;
-      return "t+90 · verdict";
+      if (d === 0) return "now";
+      if (d < 7)   return "tracking · early";
+      if (d < 30)  return "+3 sessions";
+      if (d < 90)  return "+10 sessions";
+      return "+30 sessions · verdict";
     }
 
     function renderScrubber() {
@@ -397,7 +398,7 @@ export function ChapterExhibitE() {
       clearEl(expBody!);
       clearEl(verdBody!);
 
-      [["proposals", "drag a retro here"], ["experiments", "start an experiment"], ["verdicts", "resolve at t+90"]].forEach(([col, text]) => {
+      [["proposals", "drag a retro here"], ["experiments", "start an experiment"], ["verdicts", "resolve at +30 sessions"]].forEach(([col, text]) => {
         const bodyEl = root.querySelector<HTMLElement>(`[data-drop="${col}"]`);
         const em = document.createElement("div");
         em.className = "col-empty";
@@ -602,7 +603,7 @@ export function ChapterExhibitE() {
 
   return (
     <figure id="pipeline" className="fig-pipeline" ref={rootRef}
-      aria-label="Interactive four-column pipeline: drag a retro into proposals, start an experiment, then drag the scrubber to t+90 to lock a verdict">
+      aria-label="Interactive four-column pipeline: drag a retro into proposals, start an experiment, then drag the scrubber to +30 sessions to lock a verdict">
       <div className="fig-head">
         <span className="fig-id">Exhibit E</span>
         <span>retro → proposal → experiment → verdict</span>
@@ -632,21 +633,21 @@ export function ChapterExhibitE() {
         <div className="pipeline-col" data-col="verdicts">
           <div className="col-head"><span className="col-num">04</span>verdicts<span className="col-meta" data-count-rejected>locked</span></div>
           <div className="col-body" data-drop="verdicts">
-            <div className="col-empty" data-empty="verdicts">resolve at t+90</div>
+            <div className="col-empty" data-empty="verdicts">resolve at +30 sessions</div>
           </div>
         </div>
       </div>
 
-      <div className="pipeline-scrubber" data-pipeline-scrubber data-position="0" aria-label="scrubber: drag from now to t+90">
+      <div className="pipeline-scrubber" data-pipeline-scrubber data-position="0" aria-label="scrubber: drag from now to +30 sessions">
         <div className="scrubber-rail" data-scrubber-rail>
           <div className="scrubber-fill" data-scrubber-fill></div>
-          <button type="button" className="scrubber-tick" data-tick="0"  style={{left: "0%"}}      aria-label="now"><span>t+0</span></button>
-          <button type="button" className="scrubber-tick" data-tick="7"  style={{left: "33.333%"}} aria-label="t plus 7 days"><span>t+7</span></button>
-          <button type="button" className="scrubber-tick" data-tick="30" style={{left: "66.666%"}} aria-label="t plus 30 days"><span>t+30</span></button>
-          <button type="button" className="scrubber-tick" data-tick="90" style={{left: "100%"}}    aria-label="t plus 90 days"><span>t+90</span></button>
+          <button type="button" className="scrubber-tick" data-tick="0"  style={{left: "0%"}}      aria-label="now"><span>now</span></button>
+          <button type="button" className="scrubber-tick" data-tick="7"  style={{left: "33.333%"}} aria-label="plus 3 sessions"><span>+3</span></button>
+          <button type="button" className="scrubber-tick" data-tick="30" style={{left: "66.666%"}} aria-label="plus 10 sessions"><span>+10</span></button>
+          <button type="button" className="scrubber-tick" data-tick="90" style={{left: "100%"}}    aria-label="plus 30 sessions"><span>+30</span></button>
           <div className="scrubber-handle" data-scrubber-handle style={{left: "0%"}} tabIndex={0} role="slider" aria-valuemin={0} aria-valuemax={90} aria-valuenow={0} aria-label="time scrubber"></div>
         </div>
-        <div className="scrubber-readout" data-scrubber-readout>t+0 · now</div>
+        <div className="scrubber-readout" data-scrubber-readout>now</div>
       </div>
 
       <figcaption>

--- a/apps/site/app/components/origin-sections/chapter-exhibit-h.tsx
+++ b/apps/site/app/components/origin-sections/chapter-exhibit-h.tsx
@@ -56,7 +56,7 @@ export function ChapterExhibitH() {
       { text: "swap eslint → oxlint in CI",                  verdict: "regressed",     exp: "reverted 2026-05-15" },
       { text: "skill: parallel-task-helper",                  verdict: "self-resolved", exp: "upstream patched" },
       { text: "tighten typecheck before commit",             verdict: "kept",          exp: "0 missed types" },
-      { text: "add retro Stop hook",                         verdict: "kept",          exp: "3 sessions clean" },
+      { text: "tag classify briefs for unused skills",       verdict: "kept",          exp: "3 sessions clean" },
     ] as { text: string; verdict: string; exp: string }[];
 
     let n = 0;
@@ -217,6 +217,9 @@ export function ChapterExhibitH() {
       root.querySelector("[data-race-counter]")?.appendChild(cap);
     } else {
       setPillState("idle", "auto · idle");
+      // Pre-seed a few iterations so both lanes show content on first paint
+      // instead of two empty panels until the section scrolls into view.
+      for (let i = 0; i < 3; i++) step();
       let io: IntersectionObserver | null = null;
       let fired = false;
       if ("IntersectionObserver" in window) {

--- a/apps/site/app/routes/-manifesto.content.tsx
+++ b/apps/site/app/routes/-manifesto.content.tsx
@@ -1,0 +1,287 @@
+/**
+ * Curated manifesto content for /manifesto.
+ *
+ * Replaces the raw-markdown render of docs/manifesto.md (which is now
+ * orphaned in the content collection per the WS2a de-conflict rule - a later
+ * cleanup PR removes the .md). This module is the source of truth for the
+ * manifesto page: the same long-form prose, brought up to product truth
+ * (June 2026) - pull-based retro loop, AGPL-3.0, +3/+10/+30 session
+ * checkpoints, real receipts - plus three designed editorial beats:
+ *   1. a small loop diagram after "That's the spec"
+ *   2. the five requirements as numbered editorial cards
+ *   3. one real receipt pull-quote
+ *
+ * Genre is long-form prose; the design moments are additive, not a rebuild.
+ * Styling lives in the `.prose` scope (globals.css) + the `.mf-*` section
+ * appended there.
+ *
+ * Always "ax" in visitor copy, never "axctl".
+ */
+
+const REQUIREMENTS = [
+  {
+    n: "01",
+    title: "Capture while context is warm",
+    body:
+      "The reflection has to land while the agent still has its context loaded. ax does this pull-based - a background watcher ingests sessions as they land, and /retro drains the pending ones using idle plan quota. No Stop hook wedged into the turn (it would fire per-turn and block the agent).",
+  },
+  {
+    n: "02",
+    title: "Structured by default",
+    body:
+      "Free-text retros don't compound. JSON with four fields - tried, worked, failed, next - lets the graph index, query, and diff each piece independently. Free-form is an escape hatch, not the default.",
+  },
+  {
+    n: "03",
+    title: "Cover sub-agents",
+    body:
+      "Main-session retros are nice. Sub-agent retros are the unlock. Sub-agents fan out, finish fast, and die with everything they learned. The loop has to reach them too, and the retro has to roll up to the parent session.",
+  },
+  {
+    n: "04",
+    title: "Become a proposal",
+    body:
+      "“That worked, do it more” isn't useful. “That worked, here is the skill / hook / guidance candidate that captures it, ranked by how often it would have fired” is. The retro feeds a deduplicated proposal queue you accept, reject, or skip.",
+  },
+  {
+    n: "05",
+    title: "Become an experiment",
+    body:
+      "Accepted proposals get scaffolded as real artifacts and tracked as experiments. Checkpoints at +3 / +10 / +30 sessions after accept close the verdict - sessions, not calendar days, so a weekend doesn't delay it and a productive afternoon doesn't rush it. Every verdict is itself signal for next time.",
+  },
+];
+
+const LOOP_STEPS = ["ingest", "reflect", "propose", "experiment", "verdict"];
+
+export function ManifestoContent() {
+  return (
+    <>
+      <h1>The retro loop</h1>
+      <p>
+        <em>A manifesto for self-improving AI coding agents.</em>
+      </p>
+
+      <hr />
+
+      <p>
+        Every sub-agent you spawn finishes its work and disappears. Whatever it
+        figured out - which command failed three times before the right one,
+        which file actually mattered, which approach to skip next time - dies
+        with it. The next sub-agent rediscovers it from scratch. Your own next
+        session does too.
+      </p>
+      <p>
+        This is not a memory problem. <em>Memory</em> is what you remember.{" "}
+        <em>Retro</em> is what you reflect on, structure, and turn into the next
+        bet. The agent stack has compute, tools, and logs. It does not have a
+        reflection loop.
+      </p>
+      <p>
+        <code>ax</code> is that loop. As sessions land, <code>ax</code> ingests
+        them in the background and asks the agent for a structured retro: what
+        was tried, what worked, what failed, what to try next. Each retro
+        becomes an <em>experiment</em> in a typed local graph. Each experiment
+        gets a verdict the next time the same situation appears. Over weeks, the
+        graph carries the signal your sessions otherwise dropped on the floor.
+      </p>
+      <p>
+        This is verbal self-reflection at the engineering layer. Reflexion for
+        software. The closed loop is the product.
+      </p>
+
+      <h2>What&apos;s in the stack today</h2>
+      <p>
+        Look at any production AI-agent setup in 2026. You have the frontier
+        models and the open-weights crowd. You have inference platforms. You
+        have a tool layer: shells, editors, MCP servers, IDEs. You have memory
+        bolt-ons: a vector store, maybe Letta, maybe just a long context window.
+        You have observability at the API level - LangSmith, Langfuse, Phoenix -
+        telling you what the agent did.
+      </p>
+      <p>
+        What none of them have is a <em>reflection step</em>. Nothing in the
+        stack asks the agent at end-of-session: <em>what did you learn?</em> and
+        turns the answer into something the next session can read.
+      </p>
+      <p>
+        The closest analog is the human side: code review, retros, postmortems.
+        Engineers do them because <em>the act of structuring what happened</em>{" "}
+        is what makes the next iteration better. Without it the team just does
+        the same thing again.
+      </p>
+      <p>
+        Agents are now in the same place. They have the intelligence. They lack
+        the reflection loop.
+      </p>
+
+      <h2>What the loop has to do</h2>
+      <p>A real retro loop for AI coding agents needs five things:</p>
+
+      <ol className="mf-reqs" aria-label="five requirements the retro loop has to meet">
+        {REQUIREMENTS.map((r) => (
+          <li className="mf-req" key={r.n}>
+            <span className="mf-req-n">{r.n}</span>
+            <div className="mf-req-text">
+              <strong>{r.title}</strong>
+              <span>{r.body}</span>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <p>
+        That&apos;s the spec. Ingest, reflect, propose, experiment, verdict -
+        then the next session reads what worked.
+      </p>
+
+      <figure className="mf-loop" aria-label="the retro loop: ingest, reflect, propose, experiment, verdict, and back">
+        <div className="mf-loop-track">
+          {LOOP_STEPS.map((step, i) => (
+            <span className="mf-loop-step" key={step}>
+              <span className="mf-loop-dot" aria-hidden="true" />
+              {step}
+              {i < LOOP_STEPS.length - 1 && (
+                <span className="mf-loop-arrow" aria-hidden="true">
+                  &rarr;
+                </span>
+              )}
+            </span>
+          ))}
+          <span className="mf-loop-return" aria-hidden="true">
+            &#8617; next session reads what worked
+          </span>
+        </div>
+      </figure>
+
+      <h2>What <code>ax</code> is</h2>
+      <p>
+        <code>ax</code> is the reference implementation. Local typed graph,
+        agent-readable queries, a React dashboard, AGPL-3.0 licensed. Runs on
+        your laptop.
+      </p>
+      <p>
+        It is past a journal of retros. The improve-first dashboard ranks
+        proposals by projected value - one recent deck surfaced{" "}
+        <strong>$605 in redirectable model spend</strong> and a recurring
+        pattern worth <strong>26x</strong> its cost to fix. The cost-routing
+        loop (<code>ax dispatches</code>, <code>ax routing tune</code>) moves
+        mechanical sub-agent dispatches onto cheaper models and measures whether
+        the routing actually landed. Accepted fixes become experiments with
+        checkpoints at +3 / +10 / +30 sessions, so the dashboard can show you,
+        from backing data, which past bets earned their place.
+      </p>
+
+      <blockquote className="mf-receipt">
+        <p>add pre-tool hook: block writes on main &mdash; KEPT</p>
+        <cite>experiment closed at +30 sessions &middot; 0 incidents</cite>
+      </blockquote>
+
+      <p>The surface is small on purpose:</p>
+      <ul>
+        <li>
+          <code>ax install</code> sets up the local graph and the background
+          watcher that tails your Claude Code and Codex transcript directories.
+          One command, one time. No Stop hook - it would fire per turn and block
+          the agent.
+        </li>
+        <li>
+          <code>ax retro</code> (the slash-command skill) drains the pending
+          sessions the watcher ingested, walking you through triage in Claude
+          Code while idle plan quota does the reflection work.
+        </li>
+        <li>
+          <code>ax improve list</code> shows the proposal queue derived from
+          accumulated retros and friction signals.
+        </li>
+        <li>
+          <code>ax improve accept | reject</code> triages it. Acceptance
+          scaffolds the artifact and opens an experiment.
+        </li>
+        <li>
+          <code>ax improve verdict</code> shows the checkpoint state and locks
+          the outcome.
+        </li>
+        <li>
+          <code>ax serve</code> opens the improve-first dashboard - proposal
+          deck, impact engine, and the experiments strip of past bets, measured.
+        </li>
+      </ul>
+      <p>
+        That&apos;s the loop. Everything else - the typed graph, the search, the
+        skill-taste scoring, the hooks SDK, the MCP server - is in service of it.
+        Pieces of this ship elsewhere; nobody else ships the whole closed loop,
+        local-first, on your laptop.
+      </p>
+
+      <h2>Why this matters now</h2>
+      <p>
+        The interesting agent work in 2026 - inside labs and out - is
+        multi-agent. Sub-agent fan-out, role delegation, parallel worktrees.
+        Every additional sub-agent multiplies the amount of evidence silently
+        thrown away. The marginal cost of <em>not</em> closing the loop goes up
+        with every Task tool call you make.
+      </p>
+      <p>
+        The labs know this. Internal evals at OpenAI and Anthropic absolutely
+        track this stuff. What&apos;s missing publicly is an open, local-first
+        reference for what the loop should look like at the end-user side - on
+        the developer&apos;s laptop, with their data, in their hands.
+      </p>
+      <p>
+        <code>ax</code> exists because I needed it. I&apos;m publishing it
+        because the shape of the loop matters more than the implementation, and
+        the shape gets locked in early.
+      </p>
+
+      <h2>What&apos;s next</h2>
+      <p>
+        Read the{" "}
+        <a href="https://github.com/Necmttn/ax" target="_blank" rel="noopener noreferrer">
+          README on GitHub
+        </a>
+        . Install <code>ax</code>. Let it watch a week of your sessions. Run{" "}
+        <code>ax retro</code> at the end of one. Look at what falls out.
+      </p>
+      <p>
+        Then tell me what&apos;s wrong with the shape - the{" "}
+        <a
+          href="https://github.com/Necmttn/ax/tree/main/docs/adr"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ADRs in <code>docs/adr/</code>
+        </a>{" "}
+        argue with my past self about exactly that. If you want to argue with the
+        framing, open an{" "}
+        <a href="https://github.com/Necmttn/ax/issues" target="_blank" rel="noopener noreferrer">
+          issue
+        </a>
+        . If you want to extend it,{" "}
+        <a
+          href="https://github.com/Necmttn/ax/blob/main/CONTRIBUTING.md"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          read CONTRIBUTING.md
+        </a>
+        .
+      </p>
+      <p>
+        If you&apos;re building agent infrastructure inside an AI lab right now -
+        and I know you are - you&apos;re building some version of this. Your
+        version will be better-funded, more polished, deeper-integrated. It
+        should be. What it won&apos;t be is open, local-first, and
+        shape-of-the-problem first. That&apos;s what an open reference does - it
+        shapes the problem statement before the closed implementations lock in
+        proprietary vocabularies.
+      </p>
+      <p>The stack is missing a reflection step. Let&apos;s build it.</p>
+      <p>
+        <a href="https://github.com/Necmttn" target="_blank" rel="noopener noreferrer">
+          Necmettin Karakaya
+        </a>
+        , 2026
+      </p>
+    </>
+  );
+}

--- a/apps/site/app/routes/manifesto.tsx
+++ b/apps/site/app/routes/manifesto.tsx
@@ -1,8 +1,6 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
-import { MDXContent } from "@content-collections/mdx/react";
-import { allPages } from "content-collections";
-import { mdxComponents } from "~/components/mdx-components";
+import { createFileRoute } from "@tanstack/react-router";
 import { DocShell } from "~/components/doc-shell";
+import { ManifestoContent } from "./-manifesto.content";
 
 export const Route = createFileRoute("/manifesto")({
   head: () => ({
@@ -11,17 +9,11 @@ export const Route = createFileRoute("/manifesto")({
       { name: "description", content: "Why ax exists - the agent experience layer." },
     ],
   }),
-  loader: () => {
-    const page = allPages.find((p) => p.slug === "manifesto");
-    if (!page) throw notFound();
-    return { page };
-  },
-  component: () => {
-    const { page } = Route.useLoaderData();
-    return (
-      <DocShell eyebrow="position paper">
-        <MDXContent code={page.body} components={mdxComponents} />
-      </DocShell>
-    );
-  },
+  // Content is the curated TS module (-manifesto.content.tsx), not the orphaned
+  // docs/manifesto.md (left in the content collection for a later cleanup PR).
+  component: () => (
+    <DocShell eyebrow="position paper">
+      <ManifestoContent />
+    </DocShell>
+  ),
 });

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -4748,6 +4748,59 @@ footer.site-footer { padding: 48px 32px 56px; }
   transition: width 320ms ease-out;
 }
 
+/* ============================================================
+   WS2a: Exhibit H race-counter readout + step/run controls.
+   These rendered as an unstyled "steprun 20" blob before - match
+   the mono-caps button chrome of the AUTO/RESET controls used in
+   Exhibits A/E/G.
+   ============================================================ */
+.fig-race .rc-readout {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.fig-race .rc-readout [data-race-current] {
+  color: var(--ink);
+  font-weight: 600;
+}
+.fig-race .rc-of {
+  color: var(--line);
+  margin-left: 1px;
+}
+
+.fig-race .rc-controls {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+.fig-race .rc-controls .step,
+.fig-race .rc-controls .run20 {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid var(--line);
+  padding: 4px 9px;
+  cursor: pointer;
+  line-height: 1;
+}
+.fig-race .rc-controls .step:hover,
+.fig-race .rc-controls .run20:hover {
+  color: var(--ink);
+  border-color: var(--ink);
+}
+.fig-race .rc-controls .run20 {
+  color: var(--ink);
+  border-color: var(--ink);
+}
+.fig-race .rc-controls .run20:hover {
+  background: color-mix(in srgb, var(--ink) 4%, transparent);
+}
+
 /* essay kbd + mobile audit — Task 5 */
 /* ============================================================
    <kbd> key-cap (article only) — Tab as a clickable artifact
@@ -8117,6 +8170,14 @@ footer.site-footer { padding: 48px 32px 56px; }
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.14em;
+  color: var(--muted);
+}
+/* WS2a: as-of stamp under the hero stat row (honest provenance). */
+.features-page section.hero .scale-asof {
+  margin-top: 16px;
+  max-width: 52ch;
+  font-size: 13px;
+  line-height: 1.55;
   color: var(--muted);
 }
 .features-page section.hero .toc {
@@ -12655,4 +12716,132 @@ footer.site-footer { padding: 48px 32px 56px; }
     .cliref-card { padding: 16px 16px 14px; }
     .cliref-card__flag { grid-template-columns: 1fr; gap: 2px; }
     .cliref-index nav { columns: 1; }
+}
+
+/* ============================================================
+   WS2a: Manifesto designed beats (long-form prose page).
+   Three additive moments inside the .prose scope - a loop
+   diagram, the five requirements as numbered editorial cards,
+   and one real receipt pull-quote. Ink-on-paper, hairline
+   rules, mono labels - the receipts language.
+   ============================================================ */
+
+/* five requirements as numbered editorial cards */
+.prose ol.mf-reqs {
+  list-style: none;
+  margin: 24px 0 28px;
+  padding: 0;
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--line);
+}
+.prose ol.mf-reqs > li.mf-req {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  align-items: start;
+  padding: 18px 4px;
+  border-bottom: 1px solid var(--line);
+}
+.prose .mf-req-n {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  padding-top: 2px;
+}
+.prose .mf-req-text {
+  display: block;
+}
+.prose .mf-req-text strong {
+  display: block;
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 19px;
+  line-height: 1.3;
+  margin-bottom: 6px;
+  letter-spacing: -0.01em;
+}
+.prose .mf-req-text span {
+  display: block;
+  color: var(--muted);
+  font-size: 15.5px;
+  line-height: 1.6;
+}
+
+/* loop diagram: ingest -> reflect -> propose -> experiment -> verdict */
+.prose figure.mf-loop {
+  margin: 28px 0 36px;
+  padding: 18px 16px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+}
+.prose .mf-loop-track {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink);
+}
+.prose .mf-loop-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.prose .mf-loop-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink);
+  display: inline-block;
+}
+.prose .mf-loop-arrow {
+  color: var(--muted);
+  margin-left: 4px;
+}
+.prose .mf-loop-return {
+  width: 100%;
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: none;
+  color: var(--muted);
+}
+
+/* one real receipt pull-quote (verdict KEPT) */
+.prose blockquote.mf-receipt {
+  margin: 26px 0;
+  padding: 16px 18px;
+  border-left: 3px solid var(--green);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+  font-style: normal;
+  color: var(--ink);
+}
+.prose blockquote.mf-receipt p {
+  margin: 0 0 6px;
+  font-family: var(--mono);
+  font-size: 14px;
+  letter-spacing: 0.01em;
+}
+.prose blockquote.mf-receipt cite {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--green);
+  font-style: normal;
+}
+
+@media (max-width: 560px) {
+  .prose ol.mf-reqs > li.mf-req { grid-template-columns: 1fr; gap: 4px; }
+  .prose .mf-loop-track { font-size: 11px; letter-spacing: 0.08em; }
 }


### PR DESCRIPTION
## What

A surgical truth + light-design pass on the three story/credibility pages so the site tells one consistent, true story. No home / teams / registry / routing / docs-language changes (those are locked / owned by other agents).

**Features** (`features-page.tsx`)
- Roadmap-label the weekly self-improve cron (it's a planned wire-up, not shipped).
- Fix three false schema claims: `harness_doctor` is a live audit (no `harness_finding` table), `closure` writes `commit_classification` (not `commit.closure`), and the graph legend now lists the real edges `invoked / edited / touched / produced` (dropped the non-existent `addressed`). ASCII graph corrected to match.
- Fix the "eight verbs" miscount; date-stamp the hero stats and clarify the turn count is role-filtered to user + assistant exchanges.
- Align the intervention `hook` form with the hooks-SDK reality (`~/.ax/hooks`, fanned into both harnesses).
- Add coverage for shipped main events that were missing: cost-routing (`ax dispatches --candidates`, `ax routing`), cost analytics, quota, profiles/community. (recall + MCP were already covered.) Sections 04 + 05 left untouched - they're accurate.

**Origin** (north-star fixes only, no restructure)
- `Matt Peacock` → `Matt Pocock`.
- "Claude Code and Codex transcripts" → all five harnesses.
- Retro checkpoints `t+7/t+30/t+90` → `+3/+10/+30 sessions` (chapter-6 + Exhibit E ticks/readouts/labels/aria); reworded requirement 01 off the Stop-hook mechanism to the pull-based "capture while context is warm" framing.
- Exhibit H: added the missing `.rc-readout / .rc-of / .step / .run20` CSS (rendered as an unstyled `steprun 20` blob before - now matches the AUTO/RESET mono-caps button chrome), pre-seeded 3 iterations so the lanes aren't empty on first paint, and dropped the "retro Stop hook" sample row.

**Manifesto**
- Replaced the raw-markdown render with a curated colocated TS module (`-manifesto.content.tsx`), leaving `docs/manifesto.md` orphaned in the content collection per the de-conflict rule (no `content-collections.ts` edits).
- Rewrote requirement 1 + the `ax install` bullet off the Stop-hook claim to the shipped pull-based design (background watcher + `/retro` drains pending sessions with idle quota).
- `MIT` → `AGPL-3.0`; fixed the three broken repo-relative CTAs to real GitHub URLs; dropped the dead "nineteen ADRs" count; added a paragraph of real receipts ($605 redirectable / 26x / cost routing / +3/+10/+30 checkpoints); reconciled the command list; softened "nobody is shipping all of it"; fixed the `post-mortems` hyphen break and the dated model-name list.
- Three designed beats inside the prose genre: a loop diagram (ingest→reflect→propose→experiment→verdict), the five requirements as numbered editorial cards, and one KEPT receipt pull-quote. New CSS appended to `globals.css`.

## Why

The story pages carried stale and false claims (MIT license, Stop-hook mechanism, calendar-day checkpoints, non-existent tables/edges, wrong attribution) and were missing the 2026 shipped main events. They now ground every claim against product truth.

## Verified

- `cd apps/site && bun run build` exits 0 (content codegen + prerender; /features, /origin, /manifesto all prerender).
- `cd apps/site && bun test` → 128 pass, 0 fail (incl. the CLI-reference freshness test, untouched).
- `bun run typecheck`: zero new errors in touched files (the pre-existing chapter-exhibit-e / PipelineFlow / changelog / adr errors are unchanged from base).
- `content-collections.ts` and `docs/manifesto.md` left untouched (de-conflict rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)