### PR TITLE
feat: ax dojo report + outbox writers (dojo command family)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Live/Test layers). No DB (runtime "none").
 
 ### Dojo
 
-`ax dojo [--json] [--spar] [--budget=N] [--until=HH:MM] [--force] [--days=N]` -
+`ax dojo agenda [--json] [--spar] [--budget=N] [--until=HH:MM] [--force] [--days=N]` -
 training agenda for the ax:dojo skill loop (burn surplus plan quota on
 self-improvement). Composes a budget envelope from the quota module (binding
 window remaining minus 15% reserve, deadline = earliest window reset) with a
@@ -149,6 +149,10 @@ explore fallback. Items vanish once the underlying system records the work
 `~/.ax/dojo/outbox/` (upstream issue drafts, publish on review) and
 `~/.ax/dojo/reports/<date>.md`. Module: `apps/axctl/src/dojo/`. Spec:
 docs/superpowers/specs/2026-06-13-ax-dojo-design.md.
+`ax dojo report [--since=<iso>] [--notes-file=<path>]` writes the morning-report
+for a completed run; `ax dojo draft [--title=...] [--kind=bug|improvement]`
+stages an upstream finding to `~/.ax/dojo/outbox/` (never publishes);
+`ax dojo outbox` inspects staged drafts.
 
 ### Profile
 

--- a/apps/axctl/src/cli/commands/dojo.test.ts
+++ b/apps/axctl/src/cli/commands/dojo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { untilToIso } from "./dojo.ts";
+import { isValidKind, localDate, startOfLocalDay, untilToIso } from "./dojo.ts";
 
 describe("untilToIso", () => {
     const NOW = Date.parse("2026-06-13T10:00:00.000Z");
@@ -16,5 +16,37 @@ describe("untilToIso", () => {
     test("out-of-range hours/minutes return null", () => {
         expect(untilToIso("25:00", NOW)).toBeNull();
         expect(untilToIso("0:60", NOW)).toBeNull();
+    });
+});
+
+describe("isValidKind", () => {
+    test("accepts the two supported kinds", () => {
+        expect(isValidKind("bug")).toBe(true);
+        expect(isValidKind("improvement")).toBe(true);
+    });
+    test("rejects anything else", () => {
+        expect(isValidKind("nonsense")).toBe(false);
+        expect(isValidKind("")).toBe(false);
+        expect(isValidKind("Bug")).toBe(false);
+    });
+});
+
+describe("startOfLocalDay / localDate", () => {
+    test("startOfLocalDay zeroes the time-of-day in local tz", () => {
+        const now = new Date(2026, 5, 13, 14, 37, 9, 123).getTime(); // local 2026-06-13 14:37:09.123
+        const start = new Date(startOfLocalDay(now));
+        expect(start.getHours()).toBe(0);
+        expect(start.getMinutes()).toBe(0);
+        expect(start.getSeconds()).toBe(0);
+        expect(start.getMilliseconds()).toBe(0);
+        expect(start.getFullYear()).toBe(2026);
+        expect(start.getMonth()).toBe(5);
+        expect(start.getDate()).toBe(13);
+        expect(startOfLocalDay(now)).toBeLessThanOrEqual(now);
+    });
+
+    test("localDate renders zero-padded local YYYY-MM-DD", () => {
+        const now = new Date(2026, 0, 7, 23, 59, 0).getTime(); // local 2026-01-07
+        expect(localDate(now)).toBe("2026-01-07");
     });
 });

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -22,7 +22,7 @@ import { assembleAgenda, collectAgendaItems } from "../../dojo/agenda.ts";
 import { computeBudgetEnvelope } from "../../dojo/budget.ts";
 import { renderAgenda } from "../../dojo/format.ts";
 import { writeDraft, listDrafts, type DraftKind } from "../../dojo/outbox.ts";
-import { dojoReportPath, dojoReportsDir } from "../../dojo/paths.ts";
+import { dojoReportPath, dojoReportsDir, localDate } from "../../dojo/paths.ts";
 import { gatherReport, renderReport } from "../../dojo/report.ts";
 import { defaultQuotaCachePath } from "../../quota/cache.ts";
 import { QuotaEnvLive } from "../../quota/quota-env.ts";
@@ -54,14 +54,8 @@ export const startOfLocalDay = (nowMs: number): number => {
     return d.getTime();
 };
 
-/** Local YYYY-MM-DD for `nowMs`. */
-export const localDate = (nowMs: number): string => {
-    const d = new Date(nowMs);
-    const y = d.getFullYear();
-    const m = `${d.getMonth() + 1}`.padStart(2, "0");
-    const day = `${d.getDate()}`.padStart(2, "0");
-    return `${y}-${m}-${day}`;
-};
+/** Local YYYY-MM-DD for `nowMs` (single source: dojo/paths.ts). */
+export { localDate };
 
 const VALID_KINDS: ReadonlyArray<DraftKind> = ["bug", "improvement"];
 

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -1,26 +1,38 @@
 /**
- * `ax dojo` - budget envelope + prioritized training agenda for the
- * ax:dojo skill loop. Spec: docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+ * `ax dojo` - the dojo training loop, a command family.
+ * Spec: docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+ *      + docs/superpowers/specs/2026-06-13-dojo-report-outbox-design.md
  *
- *   ax dojo            human agenda
- *   ax dojo --json     DojoAgenda JSON (consumed by the skill each lap)
+ *   ax dojo agenda [--json]   budget envelope + prioritized training agenda
+ *   ax dojo report [--json]   evidence-derived morning receipt (writes ~/.ax/dojo/reports/<date>.md)
+ *   ax dojo draft  ...        stage an upstream issue draft into ~/.ax/dojo/outbox/
+ *   ax dojo outbox [--json]   list pending outbox drafts
  *
- * The quota snapshot is fetched with error tolerance: if the usage endpoint
- * (and cache) are unavailable, the budget degrades to "unavailable" but the
- * agenda still renders - the items are derived from the local graph, not the
- * quota API.
+ * Effect's effect/unstable/cli does not support a parent handler alongside
+ * subcommands, so the root is handler-less (withSubcommands). The quota
+ * snapshot is fetched with error tolerance: if the usage endpoint (and cache)
+ * are unavailable, the budget degrades to "unavailable" but the agenda/report
+ * still render - their items are derived from the local graph, not the quota
+ * API.
  */
-import { Effect } from "effect";
+import { Effect, FileSystem } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import { prettyPrint } from "@ax/lib/json";
 import { assembleAgenda, collectAgendaItems } from "../../dojo/agenda.ts";
 import { computeBudgetEnvelope } from "../../dojo/budget.ts";
 import { renderAgenda } from "../../dojo/format.ts";
+import { writeDraft, listDrafts, type DraftKind } from "../../dojo/outbox.ts";
+import { dojoReportPath, dojoReportsDir } from "../../dojo/paths.ts";
+import { gatherReport, renderReport } from "../../dojo/report.ts";
 import { defaultQuotaCachePath } from "../../quota/cache.ts";
 import { QuotaEnvLive } from "../../quota/quota-env.ts";
 import { getQuota } from "../../quota/quota.ts";
 import type { RuntimeManifest } from "./manifest.ts";
-import { jsonFlag } from "./shared.ts";
+import { fail, jsonFlag } from "./shared.ts";
+
+// ---------------------------------------------------------------------------
+// pure resolution helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
 
 /** "HH:MM" today (or tomorrow when already past) -> ISO */
 export const untilToIso = (until: string, nowMs: number): string | null => {
@@ -35,8 +47,34 @@ export const untilToIso = (until: string, nowMs: number): string | null => {
     return d.toISOString();
 };
 
-export const dojoCommand = Command.make(
-    "dojo",
+/** Epoch-ms of local midnight for the day containing `nowMs`. */
+export const startOfLocalDay = (nowMs: number): number => {
+    const d = new Date(nowMs);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+};
+
+/** Local YYYY-MM-DD for `nowMs`. */
+export const localDate = (nowMs: number): string => {
+    const d = new Date(nowMs);
+    const y = d.getFullYear();
+    const m = `${d.getMonth() + 1}`.padStart(2, "0");
+    const day = `${d.getDate()}`.padStart(2, "0");
+    return `${y}-${m}-${day}`;
+};
+
+const VALID_KINDS: ReadonlyArray<DraftKind> = ["bug", "improvement"];
+
+/** Narrow a raw --kind value to a DraftKind, or null when it is invalid. */
+export const isValidKind = (kind: string): kind is DraftKind =>
+    (VALID_KINDS as ReadonlyArray<string>).includes(kind);
+
+// ---------------------------------------------------------------------------
+// ax dojo agenda
+// ---------------------------------------------------------------------------
+
+const agendaCommand = Command.make(
+    "agenda",
     {
         json: jsonFlag,
         budget: Flag.integer("budget").pipe(Flag.withDefault(0)), // 0 = unset
@@ -58,7 +96,7 @@ export const dojoCommand = Command.make(
             );
             const untilIso = until ? untilToIso(until, nowMs) : null;
             if (until && untilIso === null) {
-                console.error("ax dojo: invalid --until, expected HH:MM"); // degrade, don't fail
+                console.error("ax dojo agenda: invalid --until, expected HH:MM"); // degrade, don't fail
             }
             const envelope = computeBudgetEnvelope(
                 quota,
@@ -80,6 +118,176 @@ export const dojoCommand = Command.make(
     ),
 );
 
+// ---------------------------------------------------------------------------
+// ax dojo report
+// ---------------------------------------------------------------------------
+
+const reportCommand = Command.make(
+    "report",
+    {
+        json: jsonFlag,
+        since: Flag.string("since").pipe(Flag.withDefault("")),
+        notesFile: Flag.string("notes-file").pipe(Flag.withDefault("")),
+    },
+    ({ json, since, notesFile }) => {
+        const nowMs = Date.now();
+        return Effect.gen(function* () {
+            // --since ISO; bad/absent -> start of the local day.
+            let sinceMs = startOfLocalDay(nowMs);
+            if (since) {
+                const parsed = Date.parse(since);
+                if (Number.isNaN(parsed)) {
+                    console.error(
+                        `ax dojo report: invalid --since "${since}", falling back to start of today`,
+                    );
+                } else {
+                    sinceMs = parsed;
+                }
+            }
+
+            const fs = yield* FileSystem.FileSystem;
+
+            // --notes-file: empty string on any absence/read error.
+            const notes = notesFile
+                ? yield* fs.readFileString(notesFile).pipe(Effect.orElseSucceed(() => ""))
+                : "";
+
+            const data = yield* gatherReport({ sinceMs, nowMs, notes });
+
+            // Atomic write: tmp + rename into the reports dir.
+            const dir = dojoReportsDir();
+            yield* fs.makeDirectory(dir, { recursive: true });
+            const path = dojoReportPath(localDate(nowMs));
+            const tmp = `${path}.tmp.${process.pid}`;
+            yield* fs.writeFileString(tmp, renderReport(data));
+            yield* fs.rename(tmp, path);
+
+            console.log(json ? prettyPrint(data) : renderReport(data));
+        }).pipe(Effect.provide(QuotaEnvLive));
+    },
+).pipe(
+    Command.withDescription(
+        "Evidence-derived morning report: verdicts locked + proposals created since --since (default start of today), pending outbox drafts, ending budget. Writes ~/.ax/dojo/reports/<date>.md. --since=<iso>  --notes-file=<path>  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax dojo draft
+// ---------------------------------------------------------------------------
+
+const draftCommand = Command.make(
+    "draft",
+    {
+        json: jsonFlag,
+        title: Flag.string("title"),
+        kind: Flag.string("kind"),
+        bodyFile: Flag.string("body-file").pipe(Flag.withDefault("")),
+        session: Flag.string("session").pipe(Flag.withDefault("")),
+    },
+    ({ json, title, kind, bodyFile, session }) => {
+        if (!isValidKind(kind)) {
+            fail(`ax dojo draft: --kind must be one of bug|improvement (got "${kind}")`);
+        }
+        const nowMs = Date.now();
+        return Effect.gen(function* () {
+            const body =
+                bodyFile === "-"
+                    ? yield* Effect.tryPromise(() => Bun.stdin.text()).pipe(
+                          Effect.orElseSucceed(() => ""),
+                      )
+                    : bodyFile
+                        ? yield* Effect.tryPromise(() => Bun.file(bodyFile).text()).pipe(
+                              Effect.orElseSucceed(() => ""),
+                          )
+                        : "";
+            const res = yield* writeDraft({
+                title,
+                kind,
+                body,
+                session: session || null,
+                nowMs,
+            });
+            console.log(
+                json
+                    ? prettyPrint({ path: res.path, slug: res.slug, title, kind })
+                    : res.path,
+            );
+        });
+    },
+).pipe(
+    Command.withDescription(
+        "Stage an upstream issue draft into ~/.ax/dojo/outbox/ (publish stays manual). --title=<s> --kind=bug|improvement [--body-file=<path>|- for stdin] [--session=<id>] --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax dojo outbox
+// ---------------------------------------------------------------------------
+
+const reltime = (createdAt: string, nowMs: number): string => {
+    const t = Date.parse(createdAt);
+    if (Number.isNaN(t)) return createdAt;
+    const mins = Math.max(0, Math.round((nowMs - t) / 60000));
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.round(mins / 60);
+    if (hrs < 48) return `${hrs}h ago`;
+    return `${Math.round(hrs / 24)}d ago`;
+};
+
+const outboxCommand = Command.make(
+    "outbox",
+    { json: jsonFlag },
+    ({ json }) => {
+        const nowMs = Date.now();
+        return Effect.gen(function* () {
+            const drafts = yield* listDrafts();
+            if (json) {
+                console.log(prettyPrint(drafts));
+                return;
+            }
+            if (drafts.length === 0) {
+                console.log("no pending drafts");
+                return;
+            }
+            const titleW = Math.max(5, ...drafts.map((d) => d.title.length));
+            const kindW = Math.max(4, ...drafts.map((d) => d.kind.length));
+            console.log(
+                `${"title".padEnd(titleW)}  ${"kind".padEnd(kindW)}  ${"created".padEnd(9)}  file`,
+            );
+            for (const d of drafts) {
+                console.log(
+                    `${d.title.padEnd(titleW)}  ${d.kind.padEnd(kindW)}  ${reltime(d.created_at, nowMs).padEnd(9)}  ${d.file}`,
+                );
+            }
+        });
+    },
+).pipe(
+    Command.withDescription(
+        "List pending upstream issue drafts in ~/.ax/dojo/outbox/. --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax dojo (group)
+// ---------------------------------------------------------------------------
+
+export const dojoCommand = Command.make("dojo").pipe(
+    Command.withDescription("Dojo training loop: agenda + report + outbox writers"),
+    Command.withSubcommands([agendaCommand, reportCommand, draftCommand, outboxCommand]),
+);
+
 export const dojoRuntime: RuntimeManifest = {
-    dojo: "db",
+    dojo: {
+        runtime: {
+            kind: "db-conditional",
+            fallback: "none",
+            subcommands: {
+                agenda: "db",
+                report: "db",
+                draft: "none",
+                outbox: "none",
+            },
+        },
+        hidden: false,
+    },
 };

--- a/apps/axctl/src/dojo/format.ts
+++ b/apps/axctl/src/dojo/format.ts
@@ -4,7 +4,9 @@
  */
 import type { DojoAgenda } from "./schema.ts";
 
-const windowLabel = (w: DojoAgenda["budget"]["binding_window"]): string =>
+/** Human label for a binding window - the single source for both the agenda
+ *  and the dojo report budget lines. */
+export const windowLabel = (w: DojoAgenda["budget"]["binding_window"]): string =>
     w === "five_hour" ? "5h window" : w === "seven_day" ? "7d window" : "no window";
 
 export const renderAgenda = (agenda: DojoAgenda): string => {

--- a/apps/axctl/src/dojo/outbox.test.ts
+++ b/apps/axctl/src/dojo/outbox.test.ts
@@ -1,0 +1,43 @@
+// apps/axctl/src/dojo/outbox.test.ts
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { listDrafts, parseDraftFrontmatter, writeDraft } from "./outbox.ts";
+
+describe("parseDraftFrontmatter", () => {
+    test("extracts title/kind/created_at/session", () => {
+        const md = "---\ntitle: Fix scanner\nkind: bug\ncreated_at: 2026-06-13T10:00:00.000Z\nsession: s1\n---\nbody\n";
+        expect(parseDraftFrontmatter("x.md", md)).toEqual({
+            file: "x.md", title: "Fix scanner", kind: "bug",
+            created_at: "2026-06-13T10:00:00.000Z", session: "s1",
+        });
+    });
+    test("missing optional session -> null; non-frontmatter -> null", () => {
+        expect(parseDraftFrontmatter("y.md", "---\ntitle: T\nkind: improvement\ncreated_at: 2026-01-01T00:00:00Z\n---\n")?.session).toBeNull();
+        expect(parseDraftFrontmatter("z.md", "no frontmatter")).toBeNull();
+    });
+});
+
+describe("writeDraft + listDrafts", () => {
+    test("writes a frontmatter draft and lists it back", async () => {
+        const base = mkdtempSync(`${tmpdir()}/dojo-outbox-`);
+        const run = <A>(e: Effect.Effect<A, unknown, any>) =>
+            Effect.runPromise(e.pipe(Effect.provide(BunFileSystem.layer)) as Effect.Effect<A, unknown, never>);
+        const written = await run(writeDraft({
+            title: "Fix the scanner!", kind: "bug", body: "repro steps",
+            session: "s1", nowMs: Date.parse("2026-06-13T10:00:00.000Z"), outboxDir: base,
+        }));
+        expect(written.path).toMatch(/fix-the-scanner-[0-9a-f]{8}\.md$/);
+        const drafts = await run(listDrafts(base));
+        expect(drafts).toHaveLength(1);
+        expect(drafts[0]).toMatchObject({ title: "Fix the scanner!", kind: "bug", session: "s1" });
+    });
+    test("missing outbox dir -> []", async () => {
+        const drafts = await Effect.runPromise(
+            listDrafts("/no/such/dir").pipe(Effect.provide(BunFileSystem.layer)) as Effect.Effect<any, unknown, never>,
+        );
+        expect(drafts).toEqual([]);
+    });
+});

--- a/apps/axctl/src/dojo/outbox.test.ts
+++ b/apps/axctl/src/dojo/outbox.test.ts
@@ -7,10 +7,10 @@ import { BunFileSystem } from "@effect/platform-bun";
 import { listDrafts, parseDraftFrontmatter, writeDraft } from "./outbox.ts";
 
 describe("parseDraftFrontmatter", () => {
-    test("extracts title/kind/created_at/session", () => {
+    test("extracts title/kind/created_at/session; file is basename, path is full", () => {
         const md = "---\ntitle: Fix scanner\nkind: bug\ncreated_at: 2026-06-13T10:00:00.000Z\nsession: s1\n---\nbody\n";
-        expect(parseDraftFrontmatter("x.md", md)).toEqual({
-            file: "x.md", title: "Fix scanner", kind: "bug",
+        expect(parseDraftFrontmatter("/out/x.md", md)).toEqual({
+            file: "x.md", path: "/out/x.md", title: "Fix scanner", kind: "bug",
             created_at: "2026-06-13T10:00:00.000Z", session: "s1",
         });
     });
@@ -33,6 +33,21 @@ describe("writeDraft + listDrafts", () => {
         const drafts = await run(listDrafts(base));
         expect(drafts).toHaveLength(1);
         expect(drafts[0]).toMatchObject({ title: "Fix the scanner!", kind: "bug", session: "s1" });
+        expect(drafts[0]?.path).toBe(written.path);
+    });
+    test("newline in title can't inject extra frontmatter keys", async () => {
+        const base = mkdtempSync(`${tmpdir()}/dojo-outbox-`);
+        const run = <A>(e: Effect.Effect<A, unknown, any>) =>
+            Effect.runPromise(e.pipe(Effect.provide(BunFileSystem.layer)) as Effect.Effect<A, unknown, never>);
+        await run(writeDraft({
+            title: "foo\nkind: injected", kind: "bug", body: "body",
+            nowMs: Date.parse("2026-06-13T10:00:00.000Z"), outboxDir: base,
+        }));
+        const drafts = await run(listDrafts(base));
+        expect(drafts).toHaveLength(1);
+        // The injected "kind: injected" line must not win - real kind survives, title is one line.
+        expect(drafts[0]?.kind).toBe("bug");
+        expect(drafts[0]?.title).toBe("foo kind: injected");
     });
     test("missing outbox dir -> []", async () => {
         const drafts = await Effect.runPromise(

--- a/apps/axctl/src/dojo/outbox.ts
+++ b/apps/axctl/src/dojo/outbox.ts
@@ -1,0 +1,92 @@
+import { Effect, FileSystem, type PlatformError } from "effect";
+import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
+import { skipNotFound } from "@ax/lib/shared/fs-error";
+import { posixPath } from "@ax/lib/shared/path";
+import { dojoOutboxDir } from "./paths.ts";
+import { shortHash, slugify } from "./slug.ts";
+
+export type DraftKind = "bug" | "improvement";
+
+export interface OutboxDraft {
+    readonly file: string;
+    readonly title: string;
+    readonly kind: string;
+    readonly created_at: string;
+    readonly session: string | null;
+}
+
+export interface WriteDraftInput {
+    readonly title: string;
+    readonly kind: DraftKind;
+    readonly body: string;
+    readonly session?: string | null;
+    readonly nowMs: number;
+    readonly outboxDir?: string;
+}
+
+const field = (content: string, key: string): string | null => {
+    const m = new RegExp(`^${key}:[^\\S\\n]*(.*)$`, "m").exec(content);
+    const v = m?.[1]?.trim();
+    return v && v.length > 0 ? v : null;
+};
+
+/** Pure: parse a draft's frontmatter, or null when it isn't a frontmatter doc. */
+export const parseDraftFrontmatter = (file: string, content: string): OutboxDraft | null => {
+    if (!content.startsWith("---")) return null;
+    const title = field(content, "title");
+    const kind = field(content, "kind");
+    const created_at = field(content, "created_at");
+    if (!title || !kind || !created_at) return null;
+    return { file, title, kind, created_at, session: field(content, "session") };
+};
+
+const render = (i: WriteDraftInput): string => {
+    const fm = [
+        "---",
+        `title: ${i.title}`,
+        `kind: ${i.kind}`,
+        `created_at: ${new Date(i.nowMs).toISOString()}`,
+        ...(i.session ? [`session: ${i.session}`] : []),
+        "---",
+        "",
+    ].join("\n");
+    return `${fm}${i.body}\n`;
+};
+
+export const writeDraft = (
+    input: WriteDraftInput,
+): Effect.Effect<{ path: string; slug: string }, PlatformError.PlatformError, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const dir = input.outboxDir ?? dojoOutboxDir();
+        yield* fs.makeDirectory(dir, { recursive: true });
+        const slug = slugify(input.title);
+        const name = `${slug}-${shortHash(input.title)}.md`;
+        const path = posixPath.join(dir, name);
+        const tmp = `${path}.tmp.${process.pid}`;
+        yield* fs.writeFileString(tmp, render(input));
+        yield* fs.rename(tmp, path);
+        return { path, slug };
+    });
+
+export const listDrafts = (
+    outboxDir: string = dojoOutboxDir(),
+): Effect.Effect<OutboxDraft[], PlatformError.PlatformError, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const exists = yield* fs.exists(outboxDir).pipe(Effect.orElseSucceed(() => false));
+        if (!exists) return [];
+        const names = yield* fs.readDirectory(outboxDir).pipe(Effect.orElseSucceed(() => [] as string[]));
+        const drafts: OutboxDraft[] = [];
+        for (const name of names) {
+            if (!name.endsWith(".md")) continue;
+            const full = posixPath.join(outboxDir, name);
+            const kind = yield* classifyNoFollow(full);
+            if (kind !== "File") continue;
+            const content = yield* fs.readFileString(full).pipe(skipNotFound(null));
+            if (content === null) continue;
+            const draft = parseDraftFrontmatter(name, content);
+            if (draft) drafts.push(draft);
+        }
+        return drafts.sort((a, b) => a.created_at.localeCompare(b.created_at));
+    });

--- a/apps/axctl/src/dojo/outbox.ts
+++ b/apps/axctl/src/dojo/outbox.ts
@@ -8,7 +8,10 @@ import { shortHash, slugify } from "./slug.ts";
 export type DraftKind = "bug" | "improvement";
 
 export interface OutboxDraft {
+    /** basename of the draft file, e.g. "fix-x-deadbeef.md" */
     readonly file: string;
+    /** full path to the draft file (a publish step needs this) */
+    readonly path: string;
     readonly title: string;
     readonly kind: string;
     readonly created_at: string;
@@ -30,23 +33,29 @@ const field = (content: string, key: string): string | null => {
     return v && v.length > 0 ? v : null;
 };
 
-/** Pure: parse a draft's frontmatter, or null when it isn't a frontmatter doc. */
-export const parseDraftFrontmatter = (file: string, content: string): OutboxDraft | null => {
+/**
+ * Pure: parse a draft's frontmatter, or null when it isn't a frontmatter doc.
+ * `path` is the full path; `file` is derived as its basename.
+ */
+export const parseDraftFrontmatter = (path: string, content: string): OutboxDraft | null => {
     if (!content.startsWith("---")) return null;
     const title = field(content, "title");
     const kind = field(content, "kind");
     const created_at = field(content, "created_at");
     if (!title || !kind || !created_at) return null;
-    return { file, title, kind, created_at, session: field(content, "session") };
+    return { file: posixPath.basename(path), path, title, kind, created_at, session: field(content, "session") };
 };
+
+/** Collapse CR/LF to a space so an interpolated value can't break out of its YAML line. */
+const oneLine = (v: string): string => v.replace(/[\r\n]/g, " ");
 
 const render = (i: WriteDraftInput): string => {
     const fm = [
         "---",
-        `title: ${i.title}`,
+        `title: ${oneLine(i.title)}`,
         `kind: ${i.kind}`,
         `created_at: ${new Date(i.nowMs).toISOString()}`,
-        ...(i.session ? [`session: ${i.session}`] : []),
+        ...(i.session ? [`session: ${oneLine(i.session)}`] : []),
         "---",
         "",
     ].join("\n");
@@ -85,7 +94,7 @@ export const listDrafts = (
             if (kind !== "File") continue;
             const content = yield* fs.readFileString(full).pipe(skipNotFound(null));
             if (content === null) continue;
-            const draft = parseDraftFrontmatter(name, content);
+            const draft = parseDraftFrontmatter(full, content);
             if (draft) drafts.push(draft);
         }
         return drafts.sort((a, b) => a.created_at.localeCompare(b.created_at));

--- a/apps/axctl/src/dojo/paths.ts
+++ b/apps/axctl/src/dojo/paths.ts
@@ -13,3 +13,12 @@ export const dojoReportsDir = (base: string = defaultDojoDir()): string =>
 /** date is YYYY-MM-DD */
 export const dojoReportPath = (date: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoReportsDir(base), `${date}.md`);
+
+/** Local YYYY-MM-DD for an epoch-ms timestamp (the report filename's date). */
+export const localDate = (ms: number): string => {
+    const d = new Date(ms);
+    const y = d.getFullYear();
+    const m = `${d.getMonth() + 1}`.padStart(2, "0");
+    const day = `${d.getDate()}`.padStart(2, "0");
+    return `${y}-${m}-${day}`;
+};

--- a/apps/axctl/src/dojo/report.test.ts
+++ b/apps/axctl/src/dojo/report.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { SurrealClient } from "@ax/lib/db";
+import { QuotaEnvTest } from "../quota/quota-env.ts";
+import { writeDraft } from "./outbox.ts";
+import { gatherReport, renderReport } from "./report.ts";
+import type { ReportData } from "./report.ts";
+
+const data: ReportData = {
+    date: "2026-06-13",
+    since: "2026-06-13T02:00:00.000Z",
+    generated_at: "2026-06-13T05:00:00.000Z",
+    budgetLine: "12% spendable (7d window, 27% left) [quota]",
+    verdicts: [{ verdict: "confirmed", title: "Stop bare bun test", sig: "stop-bare-bun" }],
+    proposals: [{ id: "proposal:p1", title: "Guard merges", form: "hook", dedupe_sig: "guard-merges" }],
+    drafts: [{ file: "fix-x-deadbeef.md", path: "/o/fix-x-deadbeef.md", title: "Fix X", kind: "bug", created_at: "2026-06-13T04:00:00.000Z", session: null }],
+    notes: "ran 4 laps",
+};
+
+describe("renderReport", () => {
+    test("renders all sections with counts", () => {
+        const md = renderReport(data);
+        expect(md).toContain("# Dojo report - 2026-06-13");
+        expect(md).toContain("ending budget: 12% spendable");
+        expect(md).toContain("## Verdicts locked (1)");
+        expect(md).toContain("- confirmed");
+        expect(md).toContain("## Proposals created (1)");
+        expect(md).toContain("## Outbox drafts pending review (1)");
+        expect(md).toContain("## Notes\nran 4 laps");
+    });
+    test("empty sections render '- (none)' and no Notes header when notes empty", () => {
+        const md = renderReport({ ...data, verdicts: [], proposals: [], drafts: [], notes: "" });
+        expect(md).toContain("## Verdicts locked (0)\n- (none)");
+        expect(md).not.toContain("## Notes");
+    });
+});
+
+// Fake SurrealClient: serves verdict-query rows then proposal-query rows.
+const fakeDb = (...fixtures: unknown[][]) => {
+    let i = 0;
+    return Layer.succeed(SurrealClient, {
+        query: <T>(_: string) => Effect.succeed([(fixtures[i++] ?? [])] as unknown as T),
+    } as never);
+};
+
+describe("gatherReport", () => {
+    test("composes queries + outbox + quota under soft isolation", async () => {
+        const outboxDir = mkdtempSync(`${tmpdir()}/dojo-report-`);
+        const nowMs = Date.parse("2026-06-13T05:00:00.000Z");
+        const sinceMs = Date.parse("2026-06-13T02:00:00.000Z");
+
+        // gatherReport queries verdicts first, then proposals.
+        const layer = Layer.mergeAll(
+            fakeDb(
+                [{ verdict: "confirmed", title: "Stop bare bun test", sig: "stop-bare-bun", observed_at: "2026-06-13T03:00:00Z" }],
+                [{ id: "proposal:p1", title: "Guard merges", form: "hook", dedupe_sig: "guard-merges", created_at: "2026-06-13T03:00:00Z" }],
+            ),
+            BunFileSystem.layer,
+            QuotaEnvTest({ token: null }).layer, // no token -> budget degrades, never aborts
+        );
+
+        const out = await Effect.runPromise(
+            Effect.gen(function* () {
+                yield* writeDraft({ title: "Fix X", kind: "bug", body: "repro", session: null, nowMs, outboxDir });
+                return yield* gatherReport({ sinceMs, nowMs, notes: "ran 4 laps", outboxDir });
+            }).pipe(Effect.provide(layer)) as Effect.Effect<ReportData, unknown, never>,
+        );
+
+        expect(out.date).toBe("2026-06-13");
+        expect(out.since).toBe(new Date(sinceMs).toISOString());
+        expect(out.notes).toBe("ran 4 laps");
+        expect(out.verdicts).toEqual([{ verdict: "confirmed", title: "Stop bare bun test", sig: "stop-bare-bun" }]);
+        expect(out.proposals).toEqual([{ id: "proposal:p1", title: "Guard merges", form: "hook", dedupe_sig: "guard-merges" }]);
+        expect(out.drafts).toHaveLength(1);
+        expect(out.drafts[0]).toMatchObject({ title: "Fix X", kind: "bug" });
+        expect(out.budgetLine).toContain("spendable");
+    });
+
+    test("DB failure degrades to empty verdicts/proposals, never aborts", async () => {
+        const failDb = Layer.succeed(SurrealClient, {
+            query: <T>(_: string) => Effect.fail(new Error("db down")) as Effect.Effect<T, unknown>,
+        } as never);
+        const nowMs = Date.parse("2026-06-13T05:00:00.000Z");
+        const out = await Effect.runPromise(
+            gatherReport({ sinceMs: nowMs - 3_600_000, nowMs, notes: "", outboxDir: "/no/such/dir" }).pipe(
+                Effect.provide(Layer.mergeAll(failDb, BunFileSystem.layer, QuotaEnvTest({ token: null }).layer)),
+            ) as Effect.Effect<ReportData, unknown, never>,
+        );
+        expect(out.verdicts).toEqual([]);
+        expect(out.proposals).toEqual([]);
+        expect(out.drafts).toEqual([]);
+    });
+});

--- a/apps/axctl/src/dojo/report.ts
+++ b/apps/axctl/src/dojo/report.ts
@@ -23,6 +23,7 @@ import type { QuotaSnapshot } from "../quota/schema.ts";
 import { computeBudgetEnvelope } from "./budget.ts";
 import { windowLabel } from "./format.ts";
 import { listDrafts, type OutboxDraft } from "./outbox.ts";
+import { localDate } from "./paths.ts";
 import type { BudgetEnvelope } from "./schema.ts";
 
 export interface ReportData {
@@ -70,15 +71,6 @@ export interface GatherReportInput {
     readonly notes: string;
     readonly outboxDir?: string;
 }
-
-/** local YYYY-MM-DD */
-const localDate = (ms: number): string => {
-    const d = new Date(ms);
-    const y = d.getFullYear();
-    const m = `${d.getMonth() + 1}`.padStart(2, "0");
-    const day = `${d.getDate()}`.padStart(2, "0");
-    return `${y}-${m}-${day}`;
-};
 
 /**
  * Run the two queries + outbox lister + quota read; each source degrades to

--- a/apps/axctl/src/dojo/report.ts
+++ b/apps/axctl/src/dojo/report.ts
@@ -1,0 +1,128 @@
+/**
+ * ax dojo report - evidence-derived morning receipt.
+ *
+ * `renderReport` is a pure function over a `ReportData` struct (fully unit
+ * tested). `gatherReport` is the Effect glue: it runs the two improve-loop
+ * queries + the outbox lister + a quota read under per-source soft isolation -
+ * a failing source contributes its empty value and never aborts the report.
+ *
+ * Spec: docs/superpowers/specs/2026-06-13-dojo-report-outbox-design.md
+ */
+import { Effect, FileSystem } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import {
+    listProposalsCreatedSince,
+    listVerdictsLockedSince,
+    type CreatedProposalRow,
+    type LockedVerdictRow,
+} from "../improve/report-queries.ts";
+import { defaultQuotaCachePath } from "../quota/cache.ts";
+import { QuotaEnv } from "../quota/quota-env.ts";
+import { getQuota } from "../quota/quota.ts";
+import type { QuotaSnapshot } from "../quota/schema.ts";
+import { computeBudgetEnvelope } from "./budget.ts";
+import { listDrafts, type OutboxDraft } from "./outbox.ts";
+import type { BudgetEnvelope } from "./schema.ts";
+
+export interface ReportData {
+    /** local YYYY-MM-DD of the report's nowMs */
+    readonly date: string;
+    /** ISO cutoff: only verdicts/proposals at/after this are reported */
+    readonly since: string;
+    readonly generated_at: string;
+    /** pre-formatted ending-budget summary line */
+    readonly budgetLine: string;
+    readonly verdicts: readonly LockedVerdictRow[];
+    readonly proposals: readonly CreatedProposalRow[];
+    readonly drafts: readonly OutboxDraft[];
+    readonly notes: string;
+}
+
+const windowLabel = (w: BudgetEnvelope["binding_window"]): string =>
+    w === "five_hour" ? "5h window" : w === "seven_day" ? "7d window" : "no window";
+
+/** "12% spendable (7d window, 27% left) [quota]" */
+export const formatBudgetLine = (b: BudgetEnvelope): string =>
+    `${b.spendable_pct}% spendable (${windowLabel(b.binding_window)}, ${b.window_remaining_pct}% left) [${b.source}]`;
+
+const section = <T>(heading: string, rows: readonly T[], line: (row: T) => string): string => {
+    const lines = rows.length === 0 ? ["- (none)"] : rows.map(line);
+    return `## ${heading} (${rows.length})\n${lines.join("\n")}`;
+};
+
+/** Pure render of a report markdown document. */
+export const renderReport = (data: ReportData): string => {
+    const blocks: string[] = [
+        `# Dojo report - ${data.date}`,
+        `since ${data.since} - generated ${data.generated_at}`,
+        `ending budget: ${data.budgetLine}`,
+        section("Verdicts locked", data.verdicts, (v) => `- ${v.verdict} - ${v.title} (${v.sig})`),
+        section("Proposals created", data.proposals, (p) => `- ${p.form} - ${p.title} (${p.dedupe_sig})`),
+        section("Outbox drafts pending review", data.drafts, (d) => `- ${d.kind} - ${d.title} (${d.file})`),
+    ];
+    if (data.notes.trim().length > 0) {
+        blocks.push(`## Notes\n${data.notes}`);
+    }
+    return `${blocks.join("\n\n")}\n`;
+};
+
+export interface GatherReportInput {
+    readonly sinceMs: number;
+    readonly nowMs: number;
+    readonly notes: string;
+    readonly outboxDir?: string;
+}
+
+/** local YYYY-MM-DD */
+const localDate = (ms: number): string => {
+    const d = new Date(ms);
+    const y = d.getFullYear();
+    const m = `${d.getMonth() + 1}`.padStart(2, "0");
+    const day = `${d.getDate()}`.padStart(2, "0");
+    return `${y}-${m}-${day}`;
+};
+
+/**
+ * Run the two queries + outbox lister + quota read; each source degrades to
+ * its empty value on failure so a flaky DB / missing dir / unreachable usage
+ * endpoint never aborts the report.
+ */
+export const gatherReport = (
+    input: GatherReportInput,
+): Effect.Effect<ReportData, never, SurrealClient | FileSystem.FileSystem | QuotaEnv> =>
+    Effect.gen(function* () {
+        const since = new Date(input.sinceMs);
+
+        const verdicts = yield* listVerdictsLockedSince(since).pipe(
+            Effect.orElseSucceed(() => [] as LockedVerdictRow[]),
+        );
+        const proposals = yield* listProposalsCreatedSince(since).pipe(
+            Effect.orElseSucceed(() => [] as CreatedProposalRow[]),
+        );
+        const drafts = yield* listDrafts(input.outboxDir).pipe(
+            Effect.orElseSucceed(() => [] as OutboxDraft[]),
+        );
+
+        // Match the agenda command: quota read tolerates token/endpoint failure.
+        const snapshot: QuotaSnapshot | null = yield* getQuota({
+            cachePath: defaultQuotaCachePath(),
+            maxAgeSeconds: 60,
+            nowMs: input.nowMs,
+        }).pipe(
+            Effect.map((r) => r.snapshot),
+            Effect.catch(() => Effect.succeed(null)),
+        );
+
+        const envelope = computeBudgetEnvelope(snapshot, {}, input.nowMs);
+
+        return {
+            date: localDate(input.nowMs),
+            since: since.toISOString(),
+            generated_at: new Date(input.nowMs).toISOString(),
+            budgetLine: formatBudgetLine(envelope),
+            verdicts,
+            proposals,
+            drafts,
+            notes: input.notes,
+        };
+    });

--- a/apps/axctl/src/dojo/report.ts
+++ b/apps/axctl/src/dojo/report.ts
@@ -21,6 +21,7 @@ import { QuotaEnv } from "../quota/quota-env.ts";
 import { getQuota } from "../quota/quota.ts";
 import type { QuotaSnapshot } from "../quota/schema.ts";
 import { computeBudgetEnvelope } from "./budget.ts";
+import { windowLabel } from "./format.ts";
 import { listDrafts, type OutboxDraft } from "./outbox.ts";
 import type { BudgetEnvelope } from "./schema.ts";
 
@@ -37,9 +38,6 @@ export interface ReportData {
     readonly drafts: readonly OutboxDraft[];
     readonly notes: string;
 }
-
-const windowLabel = (w: BudgetEnvelope["binding_window"]): string =>
-    w === "five_hour" ? "5h window" : w === "seven_day" ? "7d window" : "no window";
 
 /** "12% spendable (7d window, 27% left) [quota]" */
 export const formatBudgetLine = (b: BudgetEnvelope): string =>

--- a/apps/axctl/src/dojo/slug.test.ts
+++ b/apps/axctl/src/dojo/slug.test.ts
@@ -1,0 +1,28 @@
+// apps/axctl/src/dojo/slug.test.ts
+import { describe, expect, test } from "bun:test";
+import { shortHash, slugify } from "./slug.ts";
+
+describe("slugify", () => {
+    test("kebabs, lowercases, strips punctuation, collapses dashes", () => {
+        expect(slugify("Dojo: Fix the Briefs Scanner!")).toBe("dojo-fix-the-briefs-scanner");
+    });
+    test("truncates to 50 chars without trailing dash", () => {
+        const s = slugify("a".repeat(80));
+        expect(s.length).toBeLessThanOrEqual(50);
+        expect(s.endsWith("-")).toBe(false);
+    });
+    test("empty / punctuation-only -> 'draft'", () => {
+        expect(slugify("")).toBe("draft");
+        expect(slugify("!!!")).toBe("draft");
+    });
+});
+
+describe("shortHash", () => {
+    test("deterministic 8-hex for the same input", () => {
+        expect(shortHash("hello")).toBe(shortHash("hello"));
+        expect(shortHash("hello")).toMatch(/^[0-9a-f]{8}$/);
+    });
+    test("different inputs differ", () => {
+        expect(shortHash("a")).not.toBe(shortHash("b"));
+    });
+});

--- a/apps/axctl/src/dojo/slug.ts
+++ b/apps/axctl/src/dojo/slug.ts
@@ -1,0 +1,20 @@
+/** kebab-case slug, <=50 chars, never empty (falls back to "draft"). */
+export const slugify = (title: string): string => {
+    const base = title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 50)
+        .replace(/-+$/g, "");
+    return base.length > 0 ? base : "draft";
+};
+
+/** FNV-1a 32-bit, 8-hex. Stable, dependency-free; not for security. */
+export const shortHash = (input: string): string => {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < input.length; i++) {
+        h ^= input.charCodeAt(i);
+        h = Math.imul(h, 0x01000193);
+    }
+    return (h >>> 0).toString(16).padStart(8, "0");
+};

--- a/apps/axctl/src/improve/report-queries.test.ts
+++ b/apps/axctl/src/improve/report-queries.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { listProposalsCreatedSince, listVerdictsLockedSince } from "./report-queries.ts";
+
+// Fake-client harness (mirrors improve/show.test.ts): each yielded query()
+// returns the next fixture wrapped as a one-element result tuple.
+const layerWith = (...fixtures: unknown[][]) => {
+    let i = 0;
+    return Layer.succeed(SurrealClient, {
+        query: <T>(_: string) => Effect.succeed([(fixtures[i++] ?? [])] as unknown as T),
+    } as never);
+};
+
+describe("listProposalsCreatedSince", () => {
+    test("maps rows to {id, title, form, dedupe_sig}", async () => {
+        const layer = layerWith([
+            { id: "proposal:p1", title: "Guard merges", form: "hook", dedupe_sig: "guard-merges", created_at: "2026-06-13T01:00:00Z" },
+        ]);
+        const rows = await Effect.runPromise(
+            listProposalsCreatedSince(new Date("2026-06-13T00:00:00Z")).pipe(Effect.provide(layer)),
+        );
+        expect(rows).toEqual([{ id: "proposal:p1", title: "Guard merges", form: "hook", dedupe_sig: "guard-merges" }]);
+    });
+
+    test("empty result -> []", async () => {
+        const rows = await Effect.runPromise(
+            listProposalsCreatedSince(new Date("2026-06-13T00:00:00Z")).pipe(Effect.provide(layerWith([]))),
+        );
+        expect(rows).toEqual([]);
+    });
+});
+
+describe("listVerdictsLockedSince", () => {
+    test("maps rows to {verdict, title, sig}", async () => {
+        const layer = layerWith([
+            { verdict: "confirmed", title: "Stop bare bun test", sig: "stop-bare-bun", observed_at: "2026-06-13T01:00:00Z" },
+        ]);
+        const rows = await Effect.runPromise(
+            listVerdictsLockedSince(new Date("2026-06-13T00:00:00Z")).pipe(Effect.provide(layer)),
+        );
+        expect(rows).toEqual([{ verdict: "confirmed", title: "Stop bare bun test", sig: "stop-bare-bun" }]);
+    });
+
+    test("empty result -> []", async () => {
+        const rows = await Effect.runPromise(
+            listVerdictsLockedSince(new Date("2026-06-13T00:00:00Z")).pipe(Effect.provide(layerWith([]))),
+        );
+        expect(rows).toEqual([]);
+    });
+});

--- a/apps/axctl/src/improve/report-queries.ts
+++ b/apps/axctl/src/improve/report-queries.ts
@@ -1,0 +1,72 @@
+/**
+ * Report graph queries: what the improve loop produced in a window.
+ *
+ *   listProposalsCreatedSince - proposals minted since a cutoff
+ *   listVerdictsLockedSince    - checkpoints whose user_verdict was set since a cutoff
+ *
+ * Pure queries feeding `ax dojo report`; presentation lives in the caller.
+ *
+ * Datetime comparison inlines a real SurrealQL datetime literal via
+ * `surrealDate` (the repo's dominant pattern - see session-metrics-query.ts /
+ * aggregates.ts / session-churn.ts), not a `$bind`, so the cutoff is compared
+ * as a datetime rather than a quoted string. SurrealDB 3.0 requires any ORDER
+ * BY field to appear in the projection, so the sort key is selected and
+ * stripped in JS (mirrors verdict-pending.ts).
+ */
+
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { surrealDate } from "@ax/lib/shared/surql";
+
+export interface CreatedProposalRow {
+    readonly id: string;
+    readonly title: string;
+    readonly form: string;
+    readonly dedupe_sig: string;
+}
+
+export interface LockedVerdictRow {
+    readonly verdict: string;
+    readonly title: string;
+    readonly sig: string;
+}
+
+/** Oldest-first proposals minted at/after `since`. */
+export const listProposalsCreatedSince = (
+    since: Date,
+): Effect.Effect<CreatedProposalRow[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const sql = `SELECT
+                type::string(id) AS id,
+                title,
+                form,
+                dedupe_sig,
+                type::string(created_at) AS created_at
+            FROM proposal
+            WHERE created_at >= ${surrealDate(since)}
+            ORDER BY created_at ASC
+            LIMIT 50;`;
+        const result = yield* db.query<[Array<CreatedProposalRow & { created_at?: string }>]>(sql);
+        return (result?.[0] ?? []).map(({ id, title, form, dedupe_sig }) => ({ id, title, form, dedupe_sig }));
+    });
+
+/** Oldest-first checkpoints whose `user_verdict` was locked at/after `since`. */
+export const listVerdictsLockedSince = (
+    since: Date,
+): Effect.Effect<LockedVerdictRow[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const sql = `SELECT
+                user_verdict AS verdict,
+                experiment.proposal.title AS title,
+                experiment.proposal.dedupe_sig AS sig,
+                type::string(observed_at) AS observed_at
+            FROM checkpoint
+            WHERE user_verdict IS NOT NONE AND observed_at >= ${surrealDate(since)}
+            ORDER BY observed_at ASC
+            LIMIT 50;`;
+        const result = yield* db.query<[Array<LockedVerdictRow & { observed_at?: string }>]>(sql);
+        return (result?.[0] ?? []).map(({ verdict, title, sig }) => ({ verdict, title, sig }));
+    });

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -35,7 +35,10 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `route-dispatch` hook - deterministic dispatch-time nudge when a mechanical dispatch forgets an explicit model
 - `ax costs summary | for --session/--query/--commit/--branch` - what any session, feature, or branch cost in tokens and USD
 - `ax quota [--statusline|--swiftbar|--json]` - live Claude plan usage (5h/7d windows) from the Anthropic usage endpoint, cached locally; one-line statusline output and a SwiftBar menubar plugin ship with it
-- `ax dojo [--json] [--spar] [--budget=N] [--until=HH:MM] [--force] [--days=N]` - training agenda for surplus-quota self-improvement: budget envelope (5h/7d window remaining minus reserve, deadline = window reset) + prioritized items (pending verdicts, unfilled briefs, routing backtests, proposal minting, churn experiments, optional sparring). Consumed lap-by-lap by the ax:dojo skill.
+- `ax dojo agenda [--json] [--spar] [--budget=N] [--until=HH:MM] [--force] [--days=N]` - training agenda for surplus-quota self-improvement: budget envelope (5h/7d window remaining minus reserve, deadline = window reset) + prioritized items (pending verdicts, unfilled briefs, routing backtests, proposal minting, churn experiments, optional sparring). Consumed lap-by-lap by the ax:dojo skill.
+- `ax dojo report [--since=<iso>] [--notes-file=<path>] [--json]` - write the morning report for a completed dojo run: budget envelope, per-lap item log, proposals created, verdicts locked, outbox drafts awaiting review.
+- `ax dojo draft [--title=<t>] [--kind=bug|improvement] [--dry-run]` - stage an upstream finding (ax bug or improvement discovered during training) to `~/.ax/dojo/outbox/<slug>.md`; never publishes - user reviews and publishes via ax-repo skill / gh.
+- `ax dojo outbox [--list|--show=<slug>]` - inspect staged upstream issue drafts in `~/.ax/dojo/outbox/`.
 
 ### Profile
 - `ax profile show [--window=N] [--no-cost]` - your local agent profile rendered from the graph: usage stats, rig (skills/hooks/rules), and evidence-grounded taste patterns

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -37,8 +37,8 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax quota [--statusline|--swiftbar|--json]` - live Claude plan usage (5h/7d windows) from the Anthropic usage endpoint, cached locally; one-line statusline output and a SwiftBar menubar plugin ship with it
 - `ax dojo agenda [--json] [--spar] [--budget=N] [--until=HH:MM] [--force] [--days=N]` - training agenda for surplus-quota self-improvement: budget envelope (5h/7d window remaining minus reserve, deadline = window reset) + prioritized items (pending verdicts, unfilled briefs, routing backtests, proposal minting, churn experiments, optional sparring). Consumed lap-by-lap by the ax:dojo skill.
 - `ax dojo report [--since=<iso>] [--notes-file=<path>] [--json]` - write the morning report for a completed dojo run: budget envelope, per-lap item log, proposals created, verdicts locked, outbox drafts awaiting review.
-- `ax dojo draft [--title=<t>] [--kind=bug|improvement] [--dry-run]` - stage an upstream finding (ax bug or improvement discovered during training) to `~/.ax/dojo/outbox/<slug>.md`; never publishes - user reviews and publishes via ax-repo skill / gh.
-- `ax dojo outbox [--list|--show=<slug>]` - inspect staged upstream issue drafts in `~/.ax/dojo/outbox/`.
+- `ax dojo draft [--title=<t>] [--kind=bug|improvement] [--body-file=<path>] [--session=<id>]` - stage an upstream finding (ax bug or improvement discovered during training) to `~/.ax/dojo/outbox/<slug>.md`; never publishes - user reviews and publishes via ax-repo skill / gh.
+- `ax dojo outbox [--json]` - list staged upstream issue drafts in `~/.ax/dojo/outbox/`.
 
 ### Profile
 - `ax profile show [--window=N] [--no-cost]` - your local agent profile rendered from the graph: usage stats, rig (skills/hooks/rules), and evidence-grounded taste patterns

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,10 @@ axctl costs for --commit <sha>              # cost for sessions that produced a 
 axctl costs for --branch <name>             # cost for sessions linked to a branch
 axctl cost <models|sessions|split>          # model/cost analytics incl. main-vs-subagent split
 axctl quota [--statusline|--swiftbar]       # Claude plan usage (5h/7d windows); statusline + menubar output
-axctl dojo [--json|--spar|--budget=N|--until=HH:MM|--force|--days=N]   # training agenda: quota budget envelope + prioritized self-improvement items for the ax:dojo skill loop
+axctl dojo agenda [--json|--spar|--budget=N|--until=HH:MM|--force|--days=N]  # training agenda: quota budget envelope + prioritized self-improvement items for the ax:dojo skill loop
+axctl dojo report [--since=<iso>] [--notes-file=<path>] [--json]      # write the morning report for a completed dojo run
+axctl dojo draft [--title=<t>] [--kind=bug|improvement] [--dry-run]   # stage an upstream finding to ~/.ax/dojo/outbox/<slug>.md (never publishes)
+axctl dojo outbox [--list|--show=<slug>]                               # inspect staged upstream issue drafts
 axctl dispatches [--candidates]             # subagent dispatch routing analytics + est savings
 axctl routing tune [--dry-run|--emit-brief] # mine YOUR dispatch history for new routing classes
 axctl routing compile                       # regenerate ~/.ax/hooks/routing-table.json (user classes preserved)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,8 +36,8 @@ axctl cost <models|sessions|split>          # model/cost analytics incl. main-vs
 axctl quota [--statusline|--swiftbar]       # Claude plan usage (5h/7d windows); statusline + menubar output
 axctl dojo agenda [--json|--spar|--budget=N|--until=HH:MM|--force|--days=N]  # training agenda: quota budget envelope + prioritized self-improvement items for the ax:dojo skill loop
 axctl dojo report [--since=<iso>] [--notes-file=<path>] [--json]      # write the morning report for a completed dojo run
-axctl dojo draft [--title=<t>] [--kind=bug|improvement] [--dry-run]   # stage an upstream finding to ~/.ax/dojo/outbox/<slug>.md (never publishes)
-axctl dojo outbox [--list|--show=<slug>]                               # inspect staged upstream issue drafts
+axctl dojo draft [--title=<t>] [--kind=bug|improvement] [--body-file=<path>] [--session=<id>]  # stage an upstream finding to ~/.ax/dojo/outbox/<slug>.md (never publishes)
+axctl dojo outbox [--json]                                            # list staged upstream issue drafts
 axctl dispatches [--candidates]             # subagent dispatch routing analytics + est savings
 axctl routing tune [--dry-run|--emit-brief] # mine YOUR dispatch history for new routing classes
 axctl routing compile                       # regenerate ~/.ax/hooks/routing-table.json (user classes preserved)

--- a/docs/superpowers/plans/2026-06-13-dojo-report-outbox.md
+++ b/docs/superpowers/plans/2026-06-13-dojo-report-outbox.md
@@ -1,0 +1,454 @@
+# ax dojo report + outbox writers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add `ax dojo report` / `ax dojo draft` / `ax dojo outbox` and restructure `ax dojo` (agenda) into a command family, per spec `docs/superpowers/specs/2026-06-13-dojo-report-outbox-design.md`.
+
+**Architecture:** Pure cores (slugify/shortHash, frontmatter parse, report render) unit-tested; Effect glue (FS writers, two graph queries, gatherReport) tested with BunFileSystem + the fake-SurrealClient harness from `improve/show.test.ts`. The agenda leaf becomes `ax dojo agenda`; the new writers are db-conditional subcommands.
+
+**Tech Stack:** bun ≥1.3, TS strict, Effect v4 beta (`effect/unstable/cli`), bun:test, SurrealDB via `SurrealClient`.
+
+**Conventions:** Run from worktree root `/Users/necmttn/Projects/ax/.claude/worktrees/dojo-report`. Test = `bun test <path>` (tmp wrapper if a hook blocks bare `bun test`). Repo bans `node:fs`/`node:path` in apps - use `@ax/lib/shared/path` `posixPath` + `node:os` `homedir` (see `apps/axctl/src/dojo/paths.ts`). FileSystem via `effect/platform/FileSystem` (mirror `apps/axctl/src/dojo/briefs.ts`). Em-dashes normalize to `-`. Commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: slug + shortHash (pure)
+
+**Files:** Create `apps/axctl/src/dojo/slug.ts`, `apps/axctl/src/dojo/slug.test.ts`
+
+- [ ] **Step 1: failing test**
+
+```ts
+// apps/axctl/src/dojo/slug.test.ts
+import { describe, expect, test } from "bun:test";
+import { shortHash, slugify } from "./slug.ts";
+
+describe("slugify", () => {
+    test("kebabs, lowercases, strips punctuation, collapses dashes", () => {
+        expect(slugify("Dojo: Fix the Briefs Scanner!")).toBe("dojo-fix-the-briefs-scanner");
+    });
+    test("truncates to 50 chars without trailing dash", () => {
+        const s = slugify("a".repeat(80));
+        expect(s.length).toBeLessThanOrEqual(50);
+        expect(s.endsWith("-")).toBe(false);
+    });
+    test("empty / punctuation-only -> 'draft'", () => {
+        expect(slugify("")).toBe("draft");
+        expect(slugify("!!!")).toBe("draft");
+    });
+});
+
+describe("shortHash", () => {
+    test("deterministic 8-hex for the same input", () => {
+        expect(shortHash("hello")).toBe(shortHash("hello"));
+        expect(shortHash("hello")).toMatch(/^[0-9a-f]{8}$/);
+    });
+    test("different inputs differ", () => {
+        expect(shortHash("a")).not.toBe(shortHash("b"));
+    });
+});
+```
+
+- [ ] **Step 2: run -> FAIL** (`bun test apps/axctl/src/dojo/slug.test.ts`)
+
+- [ ] **Step 3: implement**
+
+```ts
+// apps/axctl/src/dojo/slug.ts
+/** kebab-case slug, <=50 chars, never empty (falls back to "draft"). */
+export const slugify = (title: string): string => {
+    const base = title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 50)
+        .replace(/-+$/g, "");
+    return base.length > 0 ? base : "draft";
+};
+
+/** FNV-1a 32-bit, 8-hex. Stable, dependency-free; not for security. */
+export const shortHash = (input: string): string => {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < input.length; i++) {
+        h ^= input.charCodeAt(i);
+        h = Math.imul(h, 0x01000193);
+    }
+    return (h >>> 0).toString(16).padStart(8, "0");
+};
+```
+
+- [ ] **Step 4: run -> PASS**
+- [ ] **Step 5: commit** `feat(dojo): slugify + shortHash helpers`
+
+---
+
+### Task 2: outbox draft type + writer + lister
+
+**Files:** Create `apps/axctl/src/dojo/outbox.ts`, `apps/axctl/src/dojo/outbox.test.ts`
+
+READ FIRST: `apps/axctl/src/dojo/briefs.ts` (FileSystem import + classifyNoFollow pattern), `apps/axctl/src/improve/actions.ts` ~lines 443-451 (atomic tmp+rename write), `apps/axctl/src/dojo/paths.ts` (dojoOutboxDir).
+
+- [ ] **Step 1: failing test**
+
+```ts
+// apps/axctl/src/dojo/outbox.test.ts
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { listDrafts, parseDraftFrontmatter, writeDraft } from "./outbox.ts";
+
+describe("parseDraftFrontmatter", () => {
+    test("extracts title/kind/created_at/session", () => {
+        const md = "---\ntitle: Fix scanner\nkind: bug\ncreated_at: 2026-06-13T10:00:00.000Z\nsession: s1\n---\nbody\n";
+        expect(parseDraftFrontmatter("x.md", md)).toEqual({
+            file: "x.md", title: "Fix scanner", kind: "bug",
+            created_at: "2026-06-13T10:00:00.000Z", session: "s1",
+        });
+    });
+    test("missing optional session -> null; non-frontmatter -> null", () => {
+        expect(parseDraftFrontmatter("y.md", "---\ntitle: T\nkind: improvement\ncreated_at: 2026-01-01T00:00:00Z\n---\n")?.session).toBeNull();
+        expect(parseDraftFrontmatter("z.md", "no frontmatter")).toBeNull();
+    });
+});
+
+describe("writeDraft + listDrafts", () => {
+    test("writes a frontmatter draft and lists it back", async () => {
+        const base = mkdtempSync(`${tmpdir()}/dojo-outbox-`);
+        const run = <A>(e: Effect.Effect<A, unknown, any>) =>
+            Effect.runPromise(e.pipe(Effect.provide(BunFileSystem.layer)) as Effect.Effect<A, unknown, never>);
+        const written = await run(writeDraft({
+            title: "Fix the scanner!", kind: "bug", body: "repro steps",
+            session: "s1", nowMs: Date.parse("2026-06-13T10:00:00.000Z"), outboxDir: base,
+        }));
+        expect(written.path).toMatch(/fix-the-scanner-[0-9a-f]{8}\.md$/);
+        const drafts = await run(listDrafts(base));
+        expect(drafts).toHaveLength(1);
+        expect(drafts[0]).toMatchObject({ title: "Fix the scanner!", kind: "bug", session: "s1" });
+    });
+    test("missing outbox dir -> []", async () => {
+        const drafts = await Effect.runPromise(
+            listDrafts("/no/such/dir").pipe(Effect.provide(BunFileSystem.layer)) as Effect.Effect<any, unknown, never>,
+        );
+        expect(drafts).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: run -> FAIL**
+
+- [ ] **Step 3: implement** (mirror briefs.ts for FS import + classifyNoFollow skip-non-files in listDrafts; mirror actions.ts atomic write)
+
+```ts
+// apps/axctl/src/dojo/outbox.ts
+import { Effect } from "effect";
+import { FileSystem } from "effect/platform/FileSystem";
+import { posixPath } from "@ax/lib/shared/path";
+import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
+import { skipNotFound } from "@ax/lib/shared/fs-error";
+import { dojoOutboxDir } from "./paths.ts";
+import { shortHash, slugify } from "./slug.ts";
+
+export type DraftKind = "bug" | "improvement";
+
+export interface OutboxDraft {
+    readonly file: string;
+    readonly title: string;
+    readonly kind: string;
+    readonly created_at: string;
+    readonly session: string | null;
+}
+
+export interface WriteDraftInput {
+    readonly title: string;
+    readonly kind: DraftKind;
+    readonly body: string;
+    readonly session?: string | null;
+    readonly nowMs: number;
+    readonly outboxDir?: string;
+}
+
+const field = (content: string, key: string): string | null => {
+    const m = new RegExp(`^${key}:[^\\S\\n]*(.*)$`, "m").exec(content);
+    const v = m?.[1]?.trim();
+    return v && v.length > 0 ? v : null;
+};
+
+/** Pure: parse a draft's frontmatter, or null when it isn't a frontmatter doc. */
+export const parseDraftFrontmatter = (file: string, content: string): OutboxDraft | null => {
+    if (!content.startsWith("---")) return null;
+    const title = field(content, "title");
+    const kind = field(content, "kind");
+    const created_at = field(content, "created_at");
+    if (!title || !kind || !created_at) return null;
+    return { file, title, kind, created_at, session: field(content, "session") };
+};
+
+const render = (i: WriteDraftInput): string => {
+    const fm = [
+        "---",
+        `title: ${i.title}`,
+        `kind: ${i.kind}`,
+        `created_at: ${new Date(i.nowMs).toISOString()}`,
+        ...(i.session ? [`session: ${i.session}`] : []),
+        "---",
+        "",
+    ].join("\n");
+    return `${fm}${i.body}\n`;
+};
+
+export const writeDraft = (
+    input: WriteDraftInput,
+): Effect.Effect<{ path: string; slug: string }, unknown, FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem;
+        const dir = input.outboxDir ?? dojoOutboxDir();
+        yield* fs.makeDirectory(dir, { recursive: true });
+        const slug = slugify(input.title);
+        const name = `${slug}-${shortHash(input.title)}.md`;
+        const path = posixPath.join(dir, name);
+        const tmp = `${path}.tmp.${process.pid}`;
+        yield* fs.writeFileString(tmp, render(input));
+        yield* fs.rename(tmp, path);
+        return { path, slug };
+    });
+
+export const listDrafts = (
+    outboxDir: string = dojoOutboxDir(),
+): Effect.Effect<OutboxDraft[], unknown, FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem;
+        const exists = yield* fs.exists(outboxDir).pipe(Effect.orElseSucceed(() => false));
+        if (!exists) return [];
+        const names = yield* fs.readDirectory(outboxDir).pipe(Effect.orElseSucceed(() => []));
+        const drafts: OutboxDraft[] = [];
+        for (const name of names) {
+            if (!name.endsWith(".md")) continue;
+            const full = posixPath.join(outboxDir, name);
+            const kind = yield* classifyNoFollow(full);
+            if (kind !== "File") continue;
+            const content = yield* fs.readFileString(full).pipe(skipNotFound(null));
+            if (content === null) continue;
+            const draft = parseDraftFrontmatter(name, content);
+            if (draft) drafts.push(draft);
+        }
+        return drafts.sort((a, b) => a.created_at.localeCompare(b.created_at));
+    });
+```
+
+- [ ] **Step 4: run -> PASS**; then `bun run typecheck` (resolve any real FileSystem-API drift against briefs.ts).
+- [ ] **Step 5: commit** `feat(dojo): outbox draft writer + lister`
+
+---
+
+### Task 3: report graph queries
+
+**Files:** Create `apps/axctl/src/improve/report-queries.ts`, `apps/axctl/src/improve/report-queries.test.ts`
+
+READ FIRST: `apps/axctl/src/improve/verdict-pending.ts` (query shape, SurrealClient/DbError imports, created_at-in-projection-then-strip pattern), `apps/axctl/src/improve/show.test.ts` (fake client harness).
+
+Schema facts: `proposal.created_at` (datetime), `checkpoint.observed_at` (datetime) + `checkpoint.user_verdict` (option<string>) + `checkpoint.experiment` (record). SurrealDB 3.0 requires any ORDER BY field to be in the projection (per verdict-pending.ts lesson). Datetime comparison: bind the cutoff as a `Date` (SDK passes JS Date), e.g. `WHERE created_at >= $since`.
+
+- [ ] **Step 1: failing test** -- two queries, each returning rows for a populated fake and `[]` for empty. Mirror verdict-pending.test.ts exactly for the harness.
+
+```ts
+// apps/axctl/src/improve/report-queries.test.ts
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { listProposalsCreatedSince, listVerdictsLockedSince } from "./report-queries.ts";
+// copy layerWith / fake-client harness from show.test.ts
+
+describe("listProposalsCreatedSince", () => {
+    test("maps rows to {id, title, form, dedupe_sig}", async () => {
+        const client = fakeClient([[{ id: "proposal:p1", title: "Guard merges", form: "hook", dedupe_sig: "guard-merges" }]]);
+        const rows = await Effect.runPromise(
+            listProposalsCreatedSince(new Date("2026-06-13T00:00:00Z")).pipe(Effect.provide(client.layer)),
+        );
+        expect(rows).toEqual([{ id: "proposal:p1", title: "Guard merges", form: "hook", dedupe_sig: "guard-merges" }]);
+    });
+});
+
+describe("listVerdictsLockedSince", () => {
+    test("maps rows to {verdict, title, sig}", async () => {
+        const client = fakeClient([[{ verdict: "confirmed", title: "Stop bare bun test", sig: "stop-bare-bun" }]]);
+        const rows = await Effect.runPromise(
+            listVerdictsLockedSince(new Date("2026-06-13T00:00:00Z")).pipe(Effect.provide(client.layer)),
+        );
+        expect(rows).toEqual([{ verdict: "confirmed", title: "Stop bare bun test", sig: "stop-bare-bun" }]);
+    });
+});
+```
+
+- [ ] **Step 2: run -> FAIL**
+
+- [ ] **Step 3: implement** (copy import lines + query-call shape from verdict-pending.ts; strip any projection-only fields in JS)
+
+```ts
+// apps/axctl/src/improve/report-queries.ts
+import { Effect } from "effect";
+// SurrealClient from "@ax/lib/db"; DbError type from "@ax/lib/errors" - copy verdict-pending.ts exactly
+
+export interface CreatedProposalRow {
+    readonly id: string; readonly title: string;
+    readonly form: string; readonly dedupe_sig: string;
+}
+export interface LockedVerdictRow {
+    readonly verdict: string; readonly title: string; readonly sig: string;
+}
+
+export const listProposalsCreatedSince = (since: Date): Effect.Effect<CreatedProposalRow[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const r = yield* db.query<[Array<CreatedProposalRow & { created_at?: string }>]>(
+            `SELECT type::string(id) AS id, title, form, dedupe_sig, type::string(created_at) AS created_at
+             FROM proposal WHERE created_at >= $since ORDER BY created_at ASC LIMIT 50;`,
+            { since },
+        );
+        return (r?.[0] ?? []).map(({ created_at, ...row }) => row);
+    });
+
+export const listVerdictsLockedSince = (since: Date): Effect.Effect<LockedVerdictRow[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const r = yield* db.query<[Array<LockedVerdictRow & { observed_at?: string }>]>(
+            `SELECT user_verdict AS verdict, experiment.proposal.title AS title,
+                    experiment.proposal.dedupe_sig AS sig, type::string(observed_at) AS observed_at
+             FROM checkpoint WHERE user_verdict IS NOT NONE AND observed_at >= $since
+             ORDER BY observed_at ASC LIMIT 50;`,
+            { since },
+        );
+        return (r?.[0] ?? []).map(({ observed_at, ...row }) => row);
+    });
+```
+
+VERIFY the exact `db.query` arg shape (does it take a bindings object? check verdict-pending.ts / list.ts - if those queries don't pass a second bindings arg, inline the cutoff via the repo's datetime literal helper instead, e.g. `d"<iso>"` or a surql helper; adapt and note in report). Smoke against the live DB if up: both queries must parse and return without error.
+
+- [ ] **Step 4: run -> PASS**; typecheck clean.
+- [ ] **Step 5: commit** `feat(improve): report queries - proposals created + verdicts locked since`
+
+---
+
+### Task 4: report data + render
+
+**Files:** Create `apps/axctl/src/dojo/report.ts`, `apps/axctl/src/dojo/report.test.ts`
+
+- [ ] **Step 1: failing test** -- renderReport is pure over a ReportData struct.
+
+```ts
+// apps/axctl/src/dojo/report.test.ts
+import { describe, expect, test } from "bun:test";
+import { renderReport } from "./report.ts";
+import type { ReportData } from "./report.ts";
+
+const data: ReportData = {
+    date: "2026-06-13",
+    since: "2026-06-13T02:00:00.000Z",
+    generated_at: "2026-06-13T05:00:00.000Z",
+    budgetLine: "12% spendable (7d window, 27% left) [quota]",
+    verdicts: [{ verdict: "confirmed", title: "Stop bare bun test", sig: "stop-bare-bun" }],
+    proposals: [{ id: "proposal:p1", title: "Guard merges", form: "hook", dedupe_sig: "guard-merges" }],
+    drafts: [{ file: "fix-x-deadbeef.md", title: "Fix X", kind: "bug", created_at: "2026-06-13T04:00:00.000Z", session: null }],
+    notes: "ran 4 laps",
+};
+
+describe("renderReport", () => {
+    test("renders all sections with counts", () => {
+        const md = renderReport(data);
+        expect(md).toContain("# Dojo report - 2026-06-13");
+        expect(md).toContain("ending budget: 12% spendable");
+        expect(md).toContain("## Verdicts locked (1)");
+        expect(md).toContain("- confirmed");
+        expect(md).toContain("## Proposals created (1)");
+        expect(md).toContain("## Outbox drafts pending review (1)");
+        expect(md).toContain("## Notes\nran 4 laps");
+    });
+    test("empty sections render '- (none)' and no Notes header when notes empty", () => {
+        const md = renderReport({ ...data, verdicts: [], proposals: [], drafts: [], notes: "" });
+        expect(md).toContain("## Verdicts locked (0)\n- (none)");
+        expect(md).not.toContain("## Notes");
+    });
+});
+```
+
+- [ ] **Step 2: run -> FAIL**
+
+- [ ] **Step 3: implement** -- `ReportData` type, pure `renderReport`, and `gatherReport` Effect glue that runs the two queries + listDrafts + getQuota under `soft`-style isolation (reuse the failure-tolerant pattern: a failing source yields its empty value; never abort). gatherReport signature:
+
+```ts
+export interface GatherReportInput {
+    readonly sinceMs: number;
+    readonly nowMs: number;
+    readonly notes: string;
+    readonly outboxDir?: string;
+}
+export const gatherReport = (input: GatherReportInput): Effect.Effect<ReportData, never, SurrealClient | FileSystem>
+```
+
+`gatherReport` builds `budgetLine` by calling `getQuota` (degrade to "unavailable") + `computeBudgetEnvelope` (reuse from budget.ts) and formatting the binding window line (factor the budget-line formatting out of `format.ts`'s `renderAgenda` if it isn't already reusable; otherwise inline a small formatter). `date` = local YYYY-MM-DD of nowMs. Provide `QuotaEnvLive` at the CLI layer, not here (keep gatherReport's R channel `SurrealClient | FileSystem | QuotaEnv` if getQuota needs it - match how the agenda command provides QuotaEnvLive).
+
+- [ ] **Step 4: run -> PASS** (renderReport fully covered; gatherReport covered by a fake-client+BunFileSystem test if feasible, else by the CLI smoke in Task 5 - state which in the commit).
+- [ ] **Step 5: commit** `feat(dojo): report data gather + render`
+
+---
+
+### Task 5: CLI restructure into a command family
+
+**Files:** Modify `apps/axctl/src/cli/commands/dojo.ts`, `apps/axctl/src/cli/commands/dojo.test.ts`, `apps/axctl/src/cli/index.ts`
+
+READ FIRST: `apps/axctl/src/cli/commands/ax-routing.ts` (handler-less root + `Command.withSubcommands` + db-conditional `RuntimeManifest`), the current `dojo.ts`.
+
+- [ ] **Step 1: restructure dojo.ts**
+  - Rename the existing leaf command body to `agendaCommand = Command.make("agenda", {...same flags...}, sameHandler)`.
+  - Add `reportCommand = Command.make("report", { json, since: Flag.string("since").withDefault(""), notesFile: Flag.string("notes-file").withDefault("") }, handler)`. Handler: resolve sinceMs (parse `--since` ISO; default = start of local day from nowMs), read notes file if given (FileSystem, empty on absent), `gatherReport`, write `dojoReportPath(date)` (atomic), `console.log(json ? prettyPrint(data) : renderReport(data))`. Provide QuotaEnvLive.
+  - Add `draftCommand = Command.make("draft", { json, title: Flag.string("title"), kind: Flag.string("kind"), bodyFile: Flag.string("body-file").withDefault(""), session: Flag.string("session").withDefault("") }, handler)`. Validate kind ∈ {bug, improvement} via `fail()` (mirror quota.ts validation). Body from `--body-file` (`-` => read stdin) or "". `writeDraft`, print path or `{path,slug,title,kind}`.
+  - Add `outboxCommand = Command.make("outbox", { json }, handler)`: `listDrafts`, render a small table or JSON.
+  - Root: `export const dojoCommand = Command.make("dojo").pipe(Command.withDescription("..."), Command.withSubcommands([agendaCommand, reportCommand, draftCommand, outboxCommand]))`.
+  - `export const dojoRuntime: RuntimeManifest = { dojo: { runtime: { kind: "db-conditional", fallback: "none", subcommands: { agenda: "db", report: "db", draft: "none", outbox: "none" } }, hidden: false } }`.
+  - Keep + export `untilToIso` (still used by agenda).
+
+- [ ] **Step 2: index.ts** -- no change needed if `dojoCommand`/`dojoRuntime` names are unchanged (they're already imported + spread + registered). Confirm the spread of the new object-form manifest typechecks.
+
+- [ ] **Step 3: tests** -- keep the `untilToIso` tests. Add a `dojo.test.ts` case asserting kind validation rejects a bad `--kind` (or test the validate helper directly if extracted). Run `bun test apps/axctl/src/cli/commands/dojo.test.ts` and `apps/axctl/src/cli/effect-cli.test.ts` -> PASS.
+
+- [ ] **Step 4: smoke (DB up; scripts/db-start.sh if not)**
+  - `bun apps/axctl/src/cli/index.ts dojo agenda --json` -> the old agenda JSON (v:1, budget, items). Confirm rename works.
+  - `bun apps/axctl/src/cli/index.ts dojo draft --title "Test draft" --kind improvement` -> writes a file, prints path; then `bun apps/axctl/src/cli/index.ts dojo outbox` lists it. Clean up the test file after (`trash` the written outbox md).
+  - `bun apps/axctl/src/cli/index.ts dojo report --json` -> ReportData JSON, empty sections fine; confirm `~/.ax/dojo/reports/<today>.md` written.
+  Paste output snippets.
+
+- [ ] **Step 5: commit** `feat(cli): ax dojo command family - agenda + report + draft + outbox`
+
+---
+
+### Task 6: docs gate + SKILL.md rename
+
+**Files:** Modify `docs/cli.md`, `apps/site/public/llms.txt`, `CLAUDE.md`, `skills/dojo/SKILL.md`
+
+- [ ] **Step 1: docs/cli.md** -- replace the single `dojo` line with the family:
+```
+axctl dojo agenda [--json|--spar|--budget=N|--until=HH:MM|--force|--days=N]   # training agenda
+axctl dojo report [--since=<iso>|--json|--notes-file=<path>]                  # evidence-derived morning report
+axctl dojo draft --title=<s> --kind=bug|improvement [--body-file=<path>]      # stage an upstream issue draft
+axctl dojo outbox [--json]                                                    # list pending drafts
+```
+- [ ] **Step 2: llms.txt** -- update the dojo bullet to enumerate the four subcommands (one bullet, mention agenda/report/draft/outbox).
+- [ ] **Step 3: CLAUDE.md** -- in the "### Dojo" section, change `ax dojo [...]` to `ax dojo agenda [...]` and append one sentence: "`ax dojo report` writes an evidence-derived morning report (verdicts locked + proposals created since, outbox drafts, ending budget); `ax dojo draft`/`ax dojo outbox` stage and list local upstream issue drafts (publish stays manual)."
+- [ ] **Step 4: skills/dojo/SKILL.md** -- replace every `ax dojo --json` with `ax dojo agenda --json`; in the Exit/morning-report section, replace the hand-write instruction with: "Run `ax dojo report --since=<loop-start-iso> --notes-file=<your lap notes>` to write the receipt; it derives verdicts/proposals/outbox/budget. Stage upstream findings with `ax dojo draft --title=... --kind=bug|improvement` (never publish)."
+- [ ] **Step 5: gate + commit**
+  Run `bun run check:cli-reference` -> exit 0 (the family subcommands count as covered via the `dojo agenda`/`dojo report`/... lines; verify the checker matches `ax dojo` prefix - if it wants each leaf, ensure all four appear in llms.txt).
+  Commit `docs(dojo): command-family reference + SKILL report/draft usage`.
+
+---
+
+### Task 7: verify + PR
+
+- [ ] **Step 1** `bun test` (repo-wide) -> 0 fail.
+- [ ] **Step 2** `bun run typecheck` -> clean (no new errors).
+- [ ] **Step 3** `bun run check:cli-reference` + `bun scripts/check-no-node-fs.ts` -> clean.
+- [ ] **Step 4** push + PR:
+```bash
+git push -u origin feat/dojo-report
+gh pr create --title "feat: ax dojo report + outbox writers (dojo command family)" --body "..."
+```
+PR body: summary (agenda renamed to `ax dojo agenda`; new `report`/`draft`/`outbox`); **call out the `ax dojo` -> `ax dojo agenda` rename as the one breaking change, justified by zero users since #390**; test plan; deferred (publish automation, dojo_run table + budget diff, dashboard).

--- a/docs/superpowers/specs/2026-06-13-dojo-report-outbox-design.md
+++ b/docs/superpowers/specs/2026-06-13-dojo-report-outbox-design.md
@@ -1,0 +1,155 @@
+# ax dojo report + outbox writers
+
+Date: 2026-06-13
+Status: approved design, pre-implementation
+Follows: docs/superpowers/specs/2026-06-13-ax-dojo-design.md (core loop, shipped PR #390)
+
+## Problem
+
+The dojo core loop emits an agenda and tells the skill agent to hand-write the
+morning report and upstream issue drafts as markdown. Hand-authored artifacts
+drift in shape and aren't machine-checkable. ax's identity is receipts -- the
+dojo's nightly output should be evidence-derived and reproducible, not prose.
+
+This piece hardens the loop's output end into CLI writers:
+- `ax dojo report` -- evidence-derived morning report (idempotent)
+- `ax dojo draft` -- write a staged upstream issue draft to the outbox
+- `ax dojo outbox` -- list pending drafts (for review + the skill)
+
+## Decision: restructure `ax dojo` into a command family
+
+Effect's `effect/unstable/cli` does NOT support a parent run-handler alongside
+subcommands (verified: every `withSubcommands` parent in this repo is
+handler-less). To add `report`/`draft`/`outbox` as `ax dojo <sub>`, the
+existing bare-leaf `ax dojo` (the agenda) must become an explicit subcommand:
+
+- `ax dojo agenda [flags]` -- the current agenda command, verbatim behavior
+- `ax dojo report [...]`, `ax dojo draft [...]`, `ax dojo outbox [...]` -- new
+
+`ax dojo` itself becomes a handler-less parent (prints subcommand help).
+dojo shipped in PR #390 minutes ago with zero users, so this rename is free now
+and never again. SKILL.md + docs/cli.md + llms.txt + CLAUDE.md update to
+`ax dojo agenda`. This is the only user-facing break; called out in the PR.
+
+Runtime manifest becomes db-conditional:
+
+```ts
+dojo: {
+  runtime: {
+    kind: "db-conditional",
+    fallback: "none",
+    subcommands: { agenda: "db", report: "db", draft: "none", outbox: "none" },
+  },
+  hidden: false,
+}
+```
+
+## `ax dojo report [--since=<iso>] [--json] [--notes-file=<path>]`
+
+Derives the night's receipt from graph + filesystem, writes
+`~/.ax/dojo/reports/<YYYY-MM-DD>.md` (local date), idempotent overwrite, and
+echoes the same as JSON under `--json`.
+
+Evidence gathered (all best-effort; a failed source contributes an empty
+section, never aborts the report -- same `soft` discipline as the agenda):
+
+| Section | Source | Query / read |
+|---|---|---|
+| Verdicts locked | graph `checkpoint` | `user_verdict != NONE AND observed_at >= since` (joined to experiment/proposal title) |
+| Proposals created | graph `proposal` | `created_at >= since ORDER BY created_at` |
+| Outbox drafts pending | filesystem | parse frontmatter of every `~/.ax/dojo/outbox/*.md` |
+| Ending budget | quota module | `getQuota` snapshot -> binding window remaining (degrades to "unavailable") |
+| Notes | `--notes-file` | optional agent narrative, appended under `## Notes` verbatim |
+
+`--since` default: start of the current local day (a reasonable "this session"
+proxy). The skill passes the real loop-start ISO. No `dojo_run` table (deferred
+in the core spec) -- the report is a file, derived fresh each run.
+
+Schema note: `experiment` has no `locked_at`; verdict-lock time is proxied by
+the `checkpoint.observed_at` of the checkpoint carrying `user_verdict`.
+
+Markdown shape (stable, receipt-style):
+
+```
+# Dojo report - 2026-06-13
+
+window: <since> -> <generated_at>
+ending budget: 12% spendable (7d window, 27% left) [quota]
+
+## Verdicts locked (2)
+- <verdict> · <proposal title> · experiment:<sig>
+
+## Proposals created (1)
+- [<form>] <title> (<dedupe_sig>)
+
+## Outbox drafts pending review (1)
+- <title> [<kind>] -> ~/.ax/dojo/outbox/<file>
+
+## Notes
+<verbatim --notes-file contents, if given>
+```
+
+Empty sections render `- (none)` so the report is always complete.
+
+## `ax dojo draft --title=<s> --kind=bug|improvement [--body-file=<path>|-] [--session=<id>]`
+
+Writes one staged upstream issue draft. Never publishes (publishing stays a
+manual review step via the ax-repo skill / gh, per the core spec).
+
+- Path: `~/.ax/dojo/outbox/<slug>-<shorthash>.md`, where `slug` =
+  kebab of the title (new tiny `slugify` in `apps/axctl/src/dojo/slug.ts`,
+  since the repo has none) truncated to ~50 chars, and `shorthash` = first 8
+  hex of a stable hash of the title (collision guard; deterministic so the
+  same title overwrites rather than duplicates). Hashing: reuse whatever the
+  repo already uses for dedupe_sig-style short ids; if none reusable, a small
+  FNV-1a in slug.ts (no crypto dep).
+- Frontmatter: `title`, `kind`, `created_at` (ISO from injected nowMs),
+  `session` (optional source ref). Body: `--body-file` path or `-` for stdin;
+  empty body allowed (a stub the agent fills).
+- Atomic write (tmp + rename), mirroring `improve/actions.ts` task writer.
+- Prints the written path. `--json` prints `{ path, slug, title, kind }`.
+
+## `ax dojo outbox [--json]`
+
+Lists pending drafts: reads every `~/.ax/dojo/outbox/*.md`, parses frontmatter,
+prints a table (`title`, `kind`, `created`, `file`) or JSON array. Read-only;
+the morning review + the skill enumerate from here. Publishing/clearing is out
+of scope (manual).
+
+## Module shape
+
+```
+apps/axctl/src/dojo/
+├── slug.ts            # slugify + shortHash (pure) + test
+├── outbox.ts          # OutboxDraft type, writeDraft (FS), listDrafts (FS), parseFrontmatter (pure) + test
+├── report.ts          # ReportData type, gatherReport (Effect: graph+fs+quota), renderReport (pure) + test
+apps/axctl/src/improve/
+├── report-queries.ts  # listVerdictsLockedSince, listProposalsCreatedSince (Effect, SurrealClient) + test
+apps/axctl/src/cli/commands/
+├── dojo.ts            # restructure: agendaCommand (was the leaf) + report/draft/outbox subcommands + handler-less root + db-conditional manifest
+```
+
+Pure cores (`slugify`, `shortHash`, `parseFrontmatter`, `renderReport`,
+`renderOutboxTable`) are unit-tested in isolation; Effect glue
+(`writeDraft`, `listDrafts`, `gatherReport`, the two queries) tested with the
+BunFileSystem layer + the fake-SurrealClient harness from
+`improve/show.test.ts`.
+
+## Safety / scope
+
+- Writers never publish anything outward (outbox is local; report is local).
+- All three new subcommands are additive except the `agenda` rename.
+- No new SurrealDB table; report derives from existing `checkpoint`/`proposal`.
+- Idempotent: report overwrites today's file; draft overwrites same-title file.
+
+## Out of scope (later)
+
+- Publishing automation (`ax dojo outbox --publish`) -- stays manual per core spec.
+- `dojo_run` history table + budget *diff* (start vs end) -- v1 shows ending budget only.
+- Dashboard surface for reports.
+
+## Open questions
+
+- Should `report` also fold in filled-brief counts? Briefs are consumed
+  (deleted) by their reconcilers, leaving no timestamped trace -- deferred
+  unless a cheap signal exists.

--- a/skills/dojo/SKILL.md
+++ b/skills/dojo/SKILL.md
@@ -6,12 +6,12 @@ description: Surplus-quota training loop over the ax graph - the agent burns the
 # ax:dojo - overnight training loop
 
 You are entering a budget-bounded self-improvement loop. The brain is
-`ax dojo --json`; you are the thin driver. Spec for humans:
+`ax dojo agenda --json`; you are the thin driver. Spec:
 docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
 
 ## Entry
 
-1. Run `ax dojo --json`. If it fails with a connection error, tell the user
+1. Run `ax dojo agenda --json`. If it fails with a connection error, tell the user
    to run `ax doctor` and STOP.
 2. If `budget.has_surplus` is false: report the envelope and STOP unless the
    user re-invokes with `--force` (then pass `--force` on every lap).
@@ -23,7 +23,7 @@ docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
 
 ## The lap
 
-1. `ax dojo --json` -> agenda.
+1. `ax dojo agenda --json` -> agenda.
 2. STOP conditions (write the report, then stop):
    - `budget.has_surplus` is false
    - now >= `budget.deadline`
@@ -72,21 +72,26 @@ docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
   through `ax recall` / `ax sessions churn`, and convert anything real
   into a proposal or outbox draft.
 - **Upstream findings (any lap)** - an ax bug or improvement found while
-  training (items of kind `upstream_draft` are handled by this same rule)
-  goes to `~/.ax/dojo/outbox/<slug>.md` as a complete issue draft
-  (title, body, repro, session refs). NEVER publish from the dojo - the
-  user reviews and publishes in the morning (ax-repo skill / gh).
+  training (items of kind `upstream_draft` are handled by this same rule):
+  run `ax dojo draft --title=<title> --kind=bug|improvement` to stage it
+  to `~/.ax/dojo/outbox/<slug>.md` (complete issue draft: title, body,
+  repro, session refs written by the command). NEVER publish from the dojo -
+  the user reviews and publishes in the morning (ax-repo skill / gh).
 
 ## Exit - the morning report
 
-Write `~/.ax/dojo/reports/<YYYY-MM-DD>.md` (create dirs if missing):
-- budget: envelope at start, spendable consumed (re-run `ax quota` and diff)
-- per lap: item, what happened, evidence refs
-- proposals created/advanced, briefs filled, verdicts locked
-- outbox drafts awaiting review (list paths)
-- skipped/stuck items and why
-Then tell the user the report path and the top 3 things awaiting their
-review. Done.
+Run `ax dojo report --since=<loop-start-iso> --notes-file=<lap-notes-path>` to
+write `~/.ax/dojo/reports/<YYYY-MM-DD>.md`. The command collects the budget
+envelope, per-lap item log (from the lap notes file), proposals created,
+verdicts locked, and outbox drafts awaiting review - pass it the ISO timestamp
+you recorded when the loop started and the scratch file you appended notes to.
+Then tell the user the report path and the top 3 things awaiting their review.
+
+For upstream findings (ax bugs or improvements discovered during training), stage
+them with `ax dojo draft --title=<title> --kind=bug|improvement` before the
+report step - never publish directly. The draft lands in
+`~/.ax/dojo/outbox/<slug>.md`; the user reviews and publishes via ax-repo skill /
+gh in the morning.
 
 ## Hard rails
 


### PR DESCRIPTION
## Summary
Hardens the dojo loop's output end from skill-prose into CLI writers, and restructures `ax dojo` into a command family.

- **`ax dojo agenda`** — the training agenda (renamed from bare `ax dojo`; behavior unchanged).
- **`ax dojo report [--since=<iso>] [--json] [--notes-file=<path>]`** — evidence-derived morning report: verdicts locked + proposals created since the cutoff (graph), outbox drafts pending (filesystem), ending budget (quota). Idempotent — overwrites `~/.ax/dojo/reports/<date>.md`. Per-source soft isolation: a failing source contributes an empty section, never aborts.
- **`ax dojo draft --title=<s> --kind=bug|improvement [--body-file=<path>|-] [--session=<id>]`** — stages one upstream issue draft to `~/.ax/dojo/outbox/<slug>-<hash>.md` (frontmatter + body, atomic write, deterministic name). Never publishes.
- **`ax dojo outbox [--json]`** — lists pending drafts for review.
- Spec: `docs/superpowers/specs/2026-06-13-dojo-report-outbox-design.md`; plan: `docs/superpowers/plans/2026-06-13-dojo-report-outbox.md`.

## ⚠️ One breaking change
`ax dojo` (bare) no longer runs the agenda — it's now `ax dojo agenda`. Effect's CLI can't have a parent handler alongside subcommands, so the leaf had to become an explicit subcommand to make room for `report`/`draft`/`outbox`. dojo shipped in #390 with zero users, so this rename is free now. SKILL.md + all docs updated.

## Notes for reviewers
- Report queries inline the datetime cutoff via `surrealDate()` (`d"..."` literal) — the repo's datetime-compare convention; SurrealClient.query takes no bindings object. Both queries smoke-tested against the live graph (6 real proposals mapped).
- Frontmatter values are newline-sanitized to prevent draft-file corruption from agent-supplied titles.
- `slugify` + FNV-1a `shortHash` added (repo had no slug helper).

## Test plan
- [x] `bun test` repo-wide: 4029 pass / 0 fail
- [x] `bun run typecheck`: clean
- [x] `check:cli-reference` + `check:no-node-fs`: clean
- [x] Live smoke: `dojo agenda --json`, `dojo draft` → `dojo outbox`, `dojo report --json` (writes the report file), `dojo draft --kind nonsense` → clean validation failure

## Deferred (follow-up)
publish automation (`outbox --publish`), `dojo_run` history table + budget *diff*, dashboard report surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)