### PR TITLE
feat: ax hooks bench - hook latency ledger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,10 @@ warn / inject; defects fail OPEN. `GitEnv` service makes guards layer-testable.
   into provider configs via the existing codecs (ax ownership markers)
 - `ax hooks backtest <file> [--days]` - replay tool_call history through the
   hook in-process; state-dependent checks use CURRENT repo state (caveat printed)
+- `ax hooks bench <file> [--days --runs --budget-ms --json]` - latency ledger:
+  per-fire p50/p95 from real bun spawns, est fires/day from tool_call history,
+  installed-chain budget vs --budget-ms default 250. Pairs with `ax hooks backtest`
+  (benefit) for dojo hook proposals.
 - `ax hooks cases` - deterministic feedback-case backtests (enforce-worktree
   candidate query + structured pass/fail verdict; separate from backtest)
 - Codex: new hook entries written to `~/.codex/hooks.json` when that file

--- a/apps/axctl/src/hooks/bench.test.ts
+++ b/apps/axctl/src/hooks/bench.test.ts
@@ -80,6 +80,13 @@ describe("renderLedger", () => {
         expect(out).toContain("fires/day:     n/a");
         expect(out).not.toContain("daily cost:");
     });
+    test("chain:null + null logicMs/warmup -> no chain line, no crash", () => {
+        const out = renderLedger({ ...ledger, warmupMs: null, logicMs: null, chain: null });
+        expect(out).toContain("hook: enforce-worktree");
+        expect(out).not.toContain("chain (");
+        expect(out).not.toContain("warmup");
+        expect(out).not.toContain("logic");
+    });
 });
 
 describe("estFiresPerDay", () => {
@@ -96,5 +103,11 @@ describe("estFiresPerDay", () => {
             estFiresPerDay([], 30).pipe(Effect.provide(fakeClient([]).layer)),
         );
         expect(r.perDay).toBeNull();
+    });
+    test("total=0 -> perDay 0", async () => {
+        const r = await Effect.runPromise(
+            estFiresPerDay(["Bash"], 30).pipe(Effect.provide(fakeClient([{ total: 0 }]).layer)),
+        );
+        expect(r.perDay).toBe(0);
     });
 });

--- a/apps/axctl/src/hooks/bench.test.ts
+++ b/apps/axctl/src/hooks/bench.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { buildRepresentativePayload, percentiles, renderLedger } from "./bench.ts";
+import type { BenchLedger } from "./bench.ts";
+
+describe("percentiles", () => {
+    test("p50/p95/min/max/mean over samples", () => {
+        const p = percentiles([10, 20, 30, 40, 100]);
+        expect(p.min).toBe(10);
+        expect(p.max).toBe(100);
+        expect(p.p50).toBe(30); // median (nearest-rank)
+        expect(p.p95).toBe(100);
+        expect(p.mean).toBe(40);
+    });
+    test("single sample: all equal", () => {
+        expect(percentiles([7])).toEqual({ min: 7, max: 7, p50: 7, p95: 7, mean: 7 });
+    });
+    test("empty -> zeros", () => {
+        expect(percentiles([])).toEqual({ min: 0, max: 0, p50: 0, p95: 0, mean: 0 });
+    });
+});
+
+describe("buildRepresentativePayload", () => {
+    test("PreToolUse with a matched tool + sample input", () => {
+        const json = buildRepresentativePayload(
+            { name: "x", events: ["PreToolUse"], matcher: { tools: ["Bash", "Edit"] } },
+            { command: "git status" },
+            "/repo",
+        );
+        const parsed = JSON.parse(json);
+        expect(parsed.hook_event_name).toBe("PreToolUse");
+        expect(parsed.tool_name).toBe("Bash"); // first matched tool
+        expect(parsed.tool_input).toEqual({ command: "git status" });
+        expect(parsed.cwd).toBe("/repo");
+    });
+    test("non-tool event (no matcher) -> no tool_name/tool_input", () => {
+        const json = buildRepresentativePayload(
+            { name: "x", events: ["SessionStart"], matcher: undefined }, null, "/repo",
+        );
+        const parsed = JSON.parse(json);
+        expect(parsed.hook_event_name).toBe("SessionStart");
+        expect(parsed.tool_name).toBeUndefined();
+    });
+});
+
+describe("renderLedger", () => {
+    const ledger: BenchLedger = {
+        name: "enforce-worktree",
+        perFire: { p50: 72, p95: 84, min: 70, max: 140, mean: 78 },
+        warmupMs: 140, spawns: 19,
+        logicMs: 2,
+        frequency: { perDay: 14, matched: ["Bash", "Edit"], basis: "tool_call/30d" },
+        dailyCostMs: 1008,
+        chain: { event: "PreToolUse", beforeMs: 198, withMs: 270, budgetMs: 250, overBudget: true,
+                 hooks: ["enforce-worktree", "route-dispatch", "other"] },
+    };
+    test("renders headline + frequency + chain warning", () => {
+        const out = renderLedger(ledger);
+        expect(out).toContain("hook: enforce-worktree");
+        expect(out).toContain("p50 72ms");
+        expect(out).toContain("p95 84ms");
+        expect(out).toContain("fires/day");
+        expect(out).toContain("14");
+        expect(out).toContain("chain (PreToolUse): 198ms -> 270ms");
+        expect(out).toContain("over 250ms budget");
+    });
+    test("frequency n/a hides daily cost line", () => {
+        const out = renderLedger({ ...ledger, frequency: { perDay: null, matched: [], basis: "n/a" }, dailyCostMs: null });
+        expect(out).toContain("fires/day:     n/a");
+        expect(out).not.toContain("daily cost:");
+    });
+});

--- a/apps/axctl/src/hooks/bench.test.ts
+++ b/apps/axctl/src/hooks/bench.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { buildRepresentativePayload, percentiles, renderLedger } from "./bench.ts";
+import { Effect, Layer } from "effect";
+import { buildRepresentativePayload, estFiresPerDay, percentiles, renderLedger } from "./bench.ts";
 import type { BenchLedger } from "./bench.ts";
+import { SurrealClient } from "@ax/lib/db";
+
+// fake-client harness (mirrors apps/axctl/src/improve/show.test.ts)
+const fakeClient = (...fixtures: unknown[][]) => {
+    let i = 0;
+    return {
+        layer: Layer.succeed(SurrealClient, {
+            query: <T>(_: string) => Effect.succeed([(fixtures[i++] ?? [])] as unknown as T),
+        } as never),
+    };
+};
 
 describe("percentiles", () => {
     test("p50/p95/min/max/mean over samples", () => {
@@ -67,5 +79,22 @@ describe("renderLedger", () => {
         const out = renderLedger({ ...ledger, frequency: { perDay: null, matched: [], basis: "n/a" }, dailyCostMs: null });
         expect(out).toContain("fires/day:     n/a");
         expect(out).not.toContain("daily cost:");
+    });
+});
+
+describe("estFiresPerDay", () => {
+    test("counts matched tool_calls / days", async () => {
+        const client = fakeClient([{ total: 420 }]); // 420 matched over 30d
+        const r = await Effect.runPromise(
+            estFiresPerDay(["Bash", "Edit"], 30).pipe(Effect.provide(client.layer)),
+        );
+        expect(r.perDay).toBe(14);
+        expect(r.matched).toEqual(["Bash", "Edit"]);
+    });
+    test("no tools (non-tool hook) -> perDay null, basis n/a", async () => {
+        const r = await Effect.runPromise(
+            estFiresPerDay([], 30).pipe(Effect.provide(fakeClient([]).layer)),
+        );
+        expect(r.perDay).toBeNull();
     });
 });

--- a/apps/axctl/src/hooks/bench.test.ts
+++ b/apps/axctl/src/hooks/bench.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
-import { buildRepresentativePayload, composeChain, estFiresPerDay, percentiles, renderLedger } from "./bench.ts";
-import type { BenchLedger } from "./bench.ts";
+import { buildRepresentativePayload, composeChain, dedupeChainCosts, estFiresPerDay, percentiles, renderLedger } from "./bench.ts";
+import type { BenchLedger, ChainHookRow } from "./bench.ts";
 import { SurrealClient } from "@ax/lib/db";
 
 // fake-client harness (mirrors apps/axctl/src/improve/show.test.ts)
@@ -115,6 +115,37 @@ describe("composeChain", () => {
         expect(eq.overBudget).toBe(false);
         // 200 + 49 = 249 < 250 -> under
         expect(composeChain("E", [200], 49, 250, []).overBudget).toBe(false);
+    });
+});
+
+describe("dedupeChainCosts", () => {
+    const row = (command: string, enabled = true): ChainHookRow => ({ command, enabled });
+
+    test("dedupes by exact command (a dup install counts once); distinct commands stay", () => {
+        // Same command appearing twice (e.g. the same hook routed into two
+        // scopes that resolved to one command) collapses to a single cost.
+        const rows = [row("bun /h/a.ts"), row("bun /h/a.ts"), row("bun /h/b.ts")];
+        const r = dedupeChainCosts(rows, new Map(), 70);
+        expect(r.costs).toEqual([70, 70]); // a once + b once, both estimated
+        expect(r.names).toEqual(["a", "b"]);
+        expect(r.estimated).toBe(2);
+    });
+
+    test("recorded mean wins over default; only un-recorded commands are estimated", () => {
+        const rows = [row("bun /h/a.ts"), row("bun /h/b.ts"), row("bun /h/a.ts")];
+        const mean = new Map([["bun /h/a.ts", 42]]); // a recorded, b not
+        const r = dedupeChainCosts(rows, mean, 70);
+        expect(r.costs).toEqual([42, 70]); // a deduped to one @42, b @70 default
+        expect(r.names).toEqual(["a", "b"]);
+        expect(r.estimated).toBe(1); // only b
+    });
+
+    test("disabled rows are excluded", () => {
+        const rows = [row("bun /h/a.ts", false), row("bun /h/b.ts", true)];
+        const r = dedupeChainCosts(rows, new Map([["bun /h/b.ts", 55]]), 70);
+        expect(r.costs).toEqual([55]);
+        expect(r.names).toEqual(["b"]);
+        expect(r.estimated).toBe(0);
     });
 });
 

--- a/apps/axctl/src/hooks/bench.test.ts
+++ b/apps/axctl/src/hooks/bench.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
-import { buildRepresentativePayload, estFiresPerDay, percentiles, renderLedger } from "./bench.ts";
+import { buildRepresentativePayload, composeChain, estFiresPerDay, percentiles, renderLedger } from "./bench.ts";
 import type { BenchLedger } from "./bench.ts";
 import { SurrealClient } from "@ax/lib/db";
 
@@ -86,6 +86,35 @@ describe("renderLedger", () => {
         expect(out).not.toContain("chain (");
         expect(out).not.toContain("warmup");
         expect(out).not.toContain("logic");
+    });
+});
+
+describe("composeChain", () => {
+    test("sums installed costs + candidate p50; under budget", () => {
+        const c = composeChain("PreToolUse", [60, 70, 68], 72, 250, ["a", "b", "c"]);
+        expect(c.event).toBe("PreToolUse");
+        expect(c.beforeMs).toBe(198); // 60+70+68
+        expect(c.withMs).toBe(270); // 198 + 72
+        expect(c.budgetMs).toBe(250);
+        expect(c.overBudget).toBe(true); // 270 > 250
+        expect(c.hooks).toEqual(["a", "b", "c"]);
+    });
+    test("empty installed chain -> beforeMs 0, withMs = rounded candidate", () => {
+        const c = composeChain("PreToolUse", [], 72.4, 250, []);
+        expect(c.beforeMs).toBe(0);
+        expect(c.withMs).toBe(72); // round(72.4)
+        expect(c.overBudget).toBe(false);
+        expect(c.hooks).toEqual([]);
+    });
+    test("withMs strictly over budget is over; exactly == budget is NOT over", () => {
+        // 200 + 51 = 251 > 250 -> over
+        expect(composeChain("E", [200], 51, 250, []).overBudget).toBe(true);
+        // 200 + 50 = 250 == 250 -> NOT over (strict >)
+        const eq = composeChain("E", [200], 50, 250, []);
+        expect(eq.withMs).toBe(250);
+        expect(eq.overBudget).toBe(false);
+        // 200 + 49 = 249 < 250 -> under
+        expect(composeChain("E", [200], 49, 250, []).overBudget).toBe(false);
     });
 });
 

--- a/apps/axctl/src/hooks/bench.ts
+++ b/apps/axctl/src/hooks/bench.ts
@@ -207,7 +207,7 @@ export const composeChain = (
  *  `"/abs/hooks/block-bun-test.sh"` -> `block-bun-test`). Matches the last
  *  script-file token and strips its extension; falls back to the last
  *  whitespace token (quotes stripped) when no file-like token is present. */
-const chainHookName = (command: string): string => {
+export const chainHookName = (command: string): string => {
     const matches = [...command.matchAll(/([^/\s"']+)\.(?:ts|js|mjs|cjs|sh|py)\b/g)];
     const last = matches[matches.length - 1];
     if (last?.[1]) return last[1];
@@ -216,17 +216,75 @@ const chainHookName = (command: string): string => {
     return token.split("/").pop() || token;
 };
 
+/** One installed-hook row reduced to what the chain aggregation needs. */
+export interface ChainHookRow {
+    readonly command: string;
+    readonly enabled: boolean;
+}
+
+export interface ChainCosts {
+    readonly costs: number[];
+    readonly names: string[];
+    /** count of distinct commands that had no recorded duration (estimate path). */
+    readonly estimated: number;
+}
+
 /**
- * For the candidate's first event, enumerate the OTHER hooks installed on that
- * event and compose the budget chain. Per-hook cost = recorded mean
+ * PURE: reduce installed-hook rows to per-hook costs + display names for the
+ * chain. Enabled-only; **deduped by exact command** so the same command counted
+ * twice (e.g. a duplicate install on one provider) is added once. Caller is
+ * responsible for scoping `rows` to a SINGLE harness first - a real
+ * PreToolUse fire only runs one harness's chain, so summing across providers
+ * would ~2x reality. Within a harness, multiple scopes (global+project) are
+ * legitimately additive but still share the command dedup.
+ *
+ * Per-hook cost = recorded mean from `meanByCommand` when present, else
+ * `defaultMs` (and counted in `estimated`).
+ */
+export const dedupeChainCosts = (
+    rows: ReadonlyArray<ChainHookRow>,
+    meanByCommand: ReadonlyMap<string, number>,
+    defaultMs: number,
+): ChainCosts => {
+    const costs: number[] = [];
+    const names: string[] = [];
+    const seen = new Set<string>();
+    let estimated = 0;
+    for (const r of rows) {
+        if (!r.enabled) continue;
+        if (seen.has(r.command)) continue;
+        seen.add(r.command);
+        const recorded = meanByCommand.get(r.command);
+        if (recorded === undefined) estimated += 1;
+        costs.push(recorded ?? defaultMs);
+        names.push(chainHookName(r.command));
+    }
+    return { costs, names, estimated };
+};
+
+/** The harness whose chain a single fire actually runs. A PreToolUse fire runs
+ *  exactly ONE harness's hook chain; we scope to claude (the bench's home
+ *  harness) so the budget reflects reality instead of summing every provider. */
+const CHAIN_PROVIDER = "claude";
+
+/**
+ * For the candidate's first event, enumerate the hooks installed on that event
+ * and compose the budget chain, INCLUDING the candidate itself (so the chain
+ * the model actually runs is fully represented). Per-hook cost = recorded mean
  * `duration_ms` (from `queryHookSummary`, matched by exact command) when
  * present, else `DEFAULT_SPAWN_MS`. Returns null when the candidate has no
  * events.
  *
+ * Single-harness scope: `readAllHooks` returns one row per (provider × scope),
+ * so a hook installed under both claude and codex would be summed twice. A real
+ * fire only runs one harness's chain, so we filter to `CHAIN_PROVIDER` and
+ * dedupe by exact command (`dedupeChainCosts`). Global+project scopes within
+ * the harness stay additive (both fire); only exact-command dupes collapse.
+ *
  * Best-effort + soft-fail: a failed config read or summary query degrades to
- * the default-estimate path and `log()`s that the chain is an estimate (no
- * silent approximation). Deps: HookProviderRegistry | FileSystem | Path |
- * SurrealClient (whatever readAllHooks needs).
+ * the default-estimate path and writes a notice to STDERR (so `--json` stdout
+ * stays clean) - never a silent approximation. Deps: HookProviderRegistry |
+ * FileSystem | Path | SurrealClient.
  */
 export const gatherChain = (
     meta: InstallableHookMeta,
@@ -241,10 +299,11 @@ export const gatherChain = (
         const event = meta.events[0];
         if (!event) return null;
 
-        // Installed hooks on this event (across providers/scopes). Soft-fail to
-        // an empty chain (just the candidate) rather than aborting the bench.
+        // Installed hooks on this event, scoped to the single harness that a
+        // fire actually runs. Soft-fail to an empty chain (candidate only).
         const installed: ReadonlyArray<ConfiguredHookWithEvidence> = yield* readAllHooks({
             eventFilter: event,
+            providerFilter: CHAIN_PROVIDER,
             withEvidence: false,
         }).pipe(
             Effect.catch((e) =>
@@ -269,23 +328,18 @@ export const gatherChain = (
             }
         }
 
-        let estimated = 0;
-        const costs: number[] = [];
-        const names: string[] = [];
-        for (const h of installed) {
-            if (!h.enabled) continue;
-            const recorded = meanByCommand.get(h.command);
-            if (recorded === undefined) estimated += 1;
-            costs.push(recorded ?? DEFAULT_SPAWN_MS);
-            names.push(chainHookName(h.command));
-        }
+        const { costs, names, estimated } = dedupeChainCosts(installed, meanByCommand, DEFAULT_SPAWN_MS);
 
         if (estimated > 0) {
             // stderr keeps stdout clean for the `--json` ledger (see note above).
             process.stderr.write(`hooks bench: ${estimated}/${costs.length} installed hook(s) on ${event} have no recorded duration; using ${DEFAULT_SPAWN_MS}ms estimate for those\n`);
         }
 
-        return composeChain(event, costs, candidateP50, budgetMs, names);
+        // Include the candidate itself in the rendered chain (render says "with
+        // this"); beforeMs stays the installed-only sum, withMs adds the
+        // candidate p50 (composeChain). meta.name is already a clean hook name.
+        const chainNames = [...names, meta.name];
+        return composeChain(event, costs, candidateP50, budgetMs, chainNames);
     });
 
 /** Fetch one recent `tool_call.input_json` for `tool`, parsed to an object, or
@@ -366,10 +420,13 @@ export const benchHook = (
         const sampleInput = firstTool ? yield* sampleToolInput(firstTool) : null;
         const payload = buildRepresentativePayload(lite, sampleInput, process.cwd());
 
-        // Spawn-time samples; first is the cold warm-up, kept separate.
+        // Spawn-time samples; first is the cold warm-up, kept separate. With
+        // <2 runs there is no steady-state slice, so perFire falls back to the
+        // single sample AND warmup is null (reporting the same value as both
+        // warmup and perFire would be misleading).
         const samples = yield* measureSpawn(absFile, payload, opts.runs);
-        const warmup = samples[0] ?? null;
         const rest = samples.slice(1);
+        const warmup = rest.length ? (samples[0] ?? null) : null;
         const perFire = percentiles(rest.length ? rest : samples);
 
         // Fire frequency + projected daily cost. Soft-fail to null.

--- a/apps/axctl/src/hooks/bench.ts
+++ b/apps/axctl/src/hooks/bench.ts
@@ -1,0 +1,78 @@
+/**
+ * ax hooks bench - hook latency ledger.
+ *
+ * Pure cores (this file's top section) are unit-tested; Effect glue (subprocess
+ * spawn timing, graph queries, installed-hook chain) is tested with fakes + a
+ * live CLI smoke. Built incrementally across the hooks-bench plan tasks.
+ */
+
+export interface PerFireStats {
+    readonly p50: number; readonly p95: number;
+    readonly min: number; readonly max: number; readonly mean: number;
+}
+export interface ChainSummary {
+    readonly event: string;
+    readonly beforeMs: number; readonly withMs: number;
+    readonly budgetMs: number; readonly overBudget: boolean;
+    readonly hooks: readonly string[];
+}
+export interface BenchLedger {
+    readonly name: string;
+    readonly perFire: PerFireStats;
+    readonly warmupMs: number | null;
+    readonly spawns: number;
+    readonly logicMs: number | null;
+    readonly frequency: { readonly perDay: number | null; readonly matched: readonly string[]; readonly basis: string };
+    readonly dailyCostMs: number | null;
+    readonly chain: ChainSummary | null;
+}
+export interface HookMetaLite {
+    readonly name: string;
+    readonly events: readonly string[];
+    readonly matcher?: { readonly tools?: readonly string[] } | undefined;
+}
+
+const round = (n: number) => Math.round(n);
+
+/** Nearest-rank percentiles over wall-time samples (ms). Empty -> zeros. */
+export const percentiles = (samples: readonly number[]): PerFireStats => {
+    if (samples.length === 0) return { p50: 0, p95: 0, min: 0, max: 0, mean: 0 };
+    const s = [...samples].sort((a, b) => a - b);
+    const at = (q: number) => s[Math.min(s.length - 1, Math.ceil(q * s.length) - 1)] ?? 0;
+    const mean = s.reduce((a, b) => a + b, 0) / s.length;
+    return { min: round(s[0] ?? 0), max: round(s[s.length - 1] ?? 0), p50: round(at(0.5)), p95: round(at(0.95)), mean: round(mean) };
+};
+
+/** Raw harness stdin payload that decodeHookInput accepts. */
+export const buildRepresentativePayload = (
+    meta: HookMetaLite,
+    sampleInput: Record<string, unknown> | null,
+    cwd: string,
+): string => {
+    const event = meta.events[0] ?? "PreToolUse";
+    const firstTool = meta.matcher?.tools?.[0];
+    const payload: Record<string, unknown> = { hook_event_name: event, cwd };
+    if (firstTool) {
+        payload.tool_name = firstTool;
+        payload.tool_input = sampleInput ?? {};
+    }
+    return JSON.stringify(payload);
+};
+
+export const renderLedger = (l: BenchLedger): string => {
+    const lines: string[] = [`hook: ${l.name}`];
+    const warm = l.warmupMs != null ? `, 1 warmup ${l.warmupMs}ms` : "";
+    const logic = l.logicMs != null ? ` · logic ${l.logicMs}ms` : "";
+    lines.push(`per-fire:      p50 ${l.perFire.p50}ms · p95 ${l.perFire.p95}ms · (${l.spawns} spawns${warm})${logic}`);
+    if (l.frequency.perDay == null) {
+        lines.push(`fires/day:     n/a  (${l.frequency.basis})`);
+    } else {
+        lines.push(`fires/day:     ~${l.frequency.perDay}  (${l.frequency.matched.join(",")} via ${l.frequency.basis})`);
+        if (l.dailyCostMs != null) lines.push(`daily cost:    ~${(l.dailyCostMs / 1000).toFixed(1)} s/day`);
+    }
+    if (l.chain) {
+        const warn = l.chain.overBudget ? `  ⚠ over ${l.chain.budgetMs}ms budget` : ` (under ${l.chain.budgetMs}ms budget)`;
+        lines.push(`chain (${l.chain.event}): ${l.chain.beforeMs}ms -> ${l.chain.withMs}ms with this${warn}`);
+    }
+    return lines.join("\n");
+};

--- a/apps/axctl/src/hooks/bench.ts
+++ b/apps/axctl/src/hooks/bench.ts
@@ -88,7 +88,7 @@ export const renderLedger = (l: BenchLedger): string => {
 
 export interface FireFrequency {
     readonly perDay: number | null;
-    readonly matched: string[];
+    readonly matched: readonly string[];
     readonly basis: string;
 }
 
@@ -109,20 +109,31 @@ export const estFiresPerDay = (
     Effect.gen(function* () {
         if (tools.length === 0) return { perDay: null, matched: [], basis: "n/a" };
         const db = yield* SurrealClient;
-        const since = new Date(Date.now() - days * 86_400_000);
+        // Guard days so days=0 can't divide to Infinity.
+        const window = Math.max(1, days);
+        const since = new Date(Date.now() - window * 86_400_000);
         const list = tools.map((t) => surrealString(t)).join(", ");
         const r = yield* db.query<[Array<{ total: number }>]>(
             `SELECT count() AS total FROM tool_call WHERE name IN [${list}] AND ts > ${surrealDate(since)} GROUP ALL;`,
         );
         const total = r?.[0]?.[0]?.total ?? 0;
-        return { perDay: Math.round(total / days), matched: [...tools], basis: `tool_call/${days}d` };
+        return { perDay: Math.round(total / window), matched: [...tools], basis: `tool_call/${window}d` };
     });
+
+/**
+ * Per-spawn deadline (ms). Hooks have a 10s harness limit, so 15s is a safe
+ * ceiling: a hook that blows past it is misbehaving/hanging and we kill it
+ * rather than stall the bench forever. The deadline value is recorded as the
+ * sample so percentiles still reflect the timeout cost.
+ */
+const SPAWN_DEADLINE_MS = 15_000;
 
 /**
  * Spawn `bun <absFile>` feeding `payload` on stdin, `runs` times (capped 1-100),
  * timing each invocation with `performance.now()`. Returns all wall-time samples
- * (ms). Covered by the live CLI smoke (Task 3), not a unit test - spawning bun
- * in unit tests is slow/flaky.
+ * (ms). Each spawn is bounded by SPAWN_DEADLINE_MS: a hanging hook is killed and
+ * the deadline recorded as its sample (no leaked process). Covered by the live
+ * CLI smoke (Task 3), not a unit test - spawning bun in unit tests is slow/flaky.
  */
 export const measureSpawn = (
     absFile: string,
@@ -139,8 +150,21 @@ export const measureSpawn = (
                 stdout: "ignore",
                 stderr: "ignore",
             });
-            await proc.exited;
-            samples.push(performance.now() - t0);
+            let timer: ReturnType<typeof setTimeout> | undefined;
+            const timedOut = await Promise.race([
+                proc.exited.then(() => false),
+                new Promise<boolean>((resolve) => {
+                    timer = setTimeout(() => resolve(true), SPAWN_DEADLINE_MS);
+                }),
+            ]);
+            if (timer !== undefined) clearTimeout(timer);
+            if (timedOut) {
+                // Kill the hanging process and record the deadline as the cost.
+                proc.kill();
+                samples.push(SPAWN_DEADLINE_MS);
+            } else {
+                samples.push(performance.now() - t0);
+            }
         }
         return samples;
     });

--- a/apps/axctl/src/hooks/bench.ts
+++ b/apps/axctl/src/hooks/bench.ts
@@ -6,6 +6,11 @@
  * live CLI smoke. Built incrementally across the hooks-bench plan tasks.
  */
 
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { surrealDate, surrealString } from "@ax/lib/shared/surql";
+
 export interface PerFireStats {
     readonly p50: number; readonly p95: number;
     readonly min: number; readonly max: number; readonly mean: number;
@@ -76,3 +81,66 @@ export const renderLedger = (l: BenchLedger): string => {
     }
     return lines.join("\n");
 };
+
+// ---------------------------------------------------------------------------
+// Effect glue: fire-frequency query + subprocess spawn timing
+// ---------------------------------------------------------------------------
+
+export interface FireFrequency {
+    readonly perDay: number | null;
+    readonly matched: string[];
+    readonly basis: string;
+}
+
+/**
+ * Estimate fires/day for a tool-matching hook: COUNT tool_call rows whose
+ * `name` is in the hook's matched tools over the last `days`, divided by days.
+ * Non-tool hooks (no matched tools) have no tool_call basis -> perDay null.
+ *
+ * Datetime cutoff inlined via `surrealDate` (SurrealClient.query takes no
+ * bindings; same pattern as report-queries.ts). Count idiom: top-level
+ * `count() AS total ... GROUP ALL` (mirrors wrapped.ts / recall.ts; the repo
+ * memory note that count needs GROUP ALL).
+ */
+export const estFiresPerDay = (
+    tools: readonly string[],
+    days: number,
+): Effect.Effect<FireFrequency, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        if (tools.length === 0) return { perDay: null, matched: [], basis: "n/a" };
+        const db = yield* SurrealClient;
+        const since = new Date(Date.now() - days * 86_400_000);
+        const list = tools.map((t) => surrealString(t)).join(", ");
+        const r = yield* db.query<[Array<{ total: number }>]>(
+            `SELECT count() AS total FROM tool_call WHERE name IN [${list}] AND ts > ${surrealDate(since)} GROUP ALL;`,
+        );
+        const total = r?.[0]?.[0]?.total ?? 0;
+        return { perDay: Math.round(total / days), matched: [...tools], basis: `tool_call/${days}d` };
+    });
+
+/**
+ * Spawn `bun <absFile>` feeding `payload` on stdin, `runs` times (capped 1-100),
+ * timing each invocation with `performance.now()`. Returns all wall-time samples
+ * (ms). Covered by the live CLI smoke (Task 3), not a unit test - spawning bun
+ * in unit tests is slow/flaky.
+ */
+export const measureSpawn = (
+    absFile: string,
+    payload: string,
+    runs: number,
+): Effect.Effect<number[]> =>
+    Effect.promise(async () => {
+        const samples: number[] = [];
+        const n = Math.min(100, Math.max(1, runs));
+        for (let i = 0; i < n; i++) {
+            const t0 = performance.now();
+            const proc = Bun.spawn(["bun", absFile], {
+                stdin: new TextEncoder().encode(payload),
+                stdout: "ignore",
+                stderr: "ignore",
+            });
+            await proc.exited;
+            samples.push(performance.now() - t0);
+        }
+        return samples;
+    });

--- a/apps/axctl/src/hooks/bench.ts
+++ b/apps/axctl/src/hooks/bench.ts
@@ -6,10 +6,18 @@
  * live CLI smoke. Built incrementally across the hooks-bench plan tasks.
  */
 
-import { Effect } from "effect";
+import { Effect, FileSystem, Path } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { surrealDate, surrealString } from "@ax/lib/shared/surql";
+import { HOME } from "@ax/lib/paths";
+import { readAllHooks } from "./config.ts";
+import type { ConfiguredHookWithEvidence } from "./config.ts";
+import { HookProviderRegistry } from "./providers/registry.ts";
+import { queryHookSummary } from "../queries/hooks.ts";
+import type { HookSummaryRow } from "../queries/hooks.ts";
+import { loadHookMeta } from "./sdk-install.ts";
+import type { InstallableHookMeta } from "./sdk-install.ts";
 
 export interface PerFireStats {
     readonly p50: number; readonly p95: number;
@@ -168,3 +176,225 @@ export const measureSpawn = (
         }
         return samples;
     });
+
+// ---------------------------------------------------------------------------
+// Installed-chain composition + benchHook orchestration
+// ---------------------------------------------------------------------------
+
+/** Fallback per-hook cost (ms) when no recorded mean exists. The ~70ms is the
+ *  measured `bun <file>.ts` cold-spawn floor noted in the hooks-sdk docs. */
+export const DEFAULT_SPAWN_MS = 70;
+
+/**
+ * PURE: aggregate installed hook costs + the candidate's p50 into a budget
+ * verdict for one event. `beforeMs` = sum of installed; `withMs` = before +
+ * candidate p50; `overBudget` is STRICT (== budget is NOT over).
+ */
+export const composeChain = (
+    event: string,
+    installedCostsMs: readonly number[],
+    candidateP50: number,
+    budgetMs: number,
+    hookNames: readonly string[],
+): ChainSummary => {
+    const before = round(installedCostsMs.reduce((a, b) => a + b, 0));
+    const withC = before + round(candidateP50);
+    return { event, beforeMs: before, withMs: withC, budgetMs, overBudget: withC > budgetMs, hooks: [...hookNames] };
+};
+
+/** Derive a short display name for an installed hook from its command string
+ *  (`bun /abs/path/enforce-worktree.ts` -> `enforce-worktree`,
+ *  `"/abs/hooks/block-bun-test.sh"` -> `block-bun-test`). Matches the last
+ *  script-file token and strips its extension; falls back to the last
+ *  whitespace token (quotes stripped) when no file-like token is present. */
+const chainHookName = (command: string): string => {
+    const matches = [...command.matchAll(/([^/\s"']+)\.(?:ts|js|mjs|cjs|sh|py)\b/g)];
+    const last = matches[matches.length - 1];
+    if (last?.[1]) return last[1];
+    const tokens = command.replace(/["']/g, "").replace(/\s+/g, " ").trim().split(" ");
+    const token = tokens[tokens.length - 1] ?? command;
+    return token.split("/").pop() || token;
+};
+
+/**
+ * For the candidate's first event, enumerate the OTHER hooks installed on that
+ * event and compose the budget chain. Per-hook cost = recorded mean
+ * `duration_ms` (from `queryHookSummary`, matched by exact command) when
+ * present, else `DEFAULT_SPAWN_MS`. Returns null when the candidate has no
+ * events.
+ *
+ * Best-effort + soft-fail: a failed config read or summary query degrades to
+ * the default-estimate path and `log()`s that the chain is an estimate (no
+ * silent approximation). Deps: HookProviderRegistry | FileSystem | Path |
+ * SurrealClient (whatever readAllHooks needs).
+ */
+export const gatherChain = (
+    meta: InstallableHookMeta,
+    candidateP50: number,
+    budgetMs: number,
+): Effect.Effect<
+    ChainSummary | null,
+    never,
+    HookProviderRegistry | FileSystem.FileSystem | Path.Path | SurrealClient
+> =>
+    Effect.gen(function* () {
+        const event = meta.events[0];
+        if (!event) return null;
+
+        // Installed hooks on this event (across providers/scopes). Soft-fail to
+        // an empty chain (just the candidate) rather than aborting the bench.
+        const installed: ReadonlyArray<ConfiguredHookWithEvidence> = yield* readAllHooks({
+            eventFilter: event,
+            withEvidence: false,
+        }).pipe(
+            Effect.catch((e) =>
+                Effect.sync(() => {
+                    // stderr, not Effect.log: the configured logger writes to stdout
+                    // and would corrupt the `--json` ledger on the same stream.
+                    process.stderr.write(`hooks bench: could not enumerate installed hooks on ${event} (${String(e)}); chain shows candidate only\n`);
+                    return [] as ReadonlyArray<ConfiguredHookWithEvidence>;
+                }),
+            ),
+        );
+
+        // Recorded mean duration per command. Soft-fail to an empty map -> every
+        // installed hook costs DEFAULT_SPAWN_MS (estimate path, logged below).
+        const summary: ReadonlyArray<HookSummaryRow> = yield* queryHookSummary({ tail: 1000 }).pipe(
+            Effect.catch(() => Effect.succeed([] as ReadonlyArray<HookSummaryRow>)),
+        );
+        const meanByCommand = new Map<string, number>();
+        for (const row of summary) {
+            if (typeof row.avg_duration_ms === "number" && Number.isFinite(row.avg_duration_ms)) {
+                meanByCommand.set(row.command, row.avg_duration_ms);
+            }
+        }
+
+        let estimated = 0;
+        const costs: number[] = [];
+        const names: string[] = [];
+        for (const h of installed) {
+            if (!h.enabled) continue;
+            const recorded = meanByCommand.get(h.command);
+            if (recorded === undefined) estimated += 1;
+            costs.push(recorded ?? DEFAULT_SPAWN_MS);
+            names.push(chainHookName(h.command));
+        }
+
+        if (estimated > 0) {
+            // stderr keeps stdout clean for the `--json` ledger (see note above).
+            process.stderr.write(`hooks bench: ${estimated}/${costs.length} installed hook(s) on ${event} have no recorded duration; using ${DEFAULT_SPAWN_MS}ms estimate for those\n`);
+        }
+
+        return composeChain(event, costs, candidateP50, budgetMs, names);
+    });
+
+/** Fetch one recent `tool_call.input_json` for `tool`, parsed to an object, or
+ *  null when none / unparseable. Soft-fails (a DB error -> null) so the bench
+ *  always proceeds with an empty payload body. */
+const sampleToolInput = (
+    tool: string,
+): Effect.Effect<Record<string, unknown> | null, never, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const rows = yield* db.query<[Array<{ input_json: string | null }>]>(
+            `SELECT input_json FROM tool_call WHERE name = ${surrealString(tool)} AND input_json != NONE ORDER BY ts DESC LIMIT 1;`,
+        ).pipe(Effect.catch(() => Effect.succeed([[]] as [Array<{ input_json: string | null }>])));
+        const raw = rows?.[0]?.[0]?.input_json;
+        if (typeof raw !== "string") return null;
+        try {
+            const parsed = JSON.parse(raw);
+            return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+                ? (parsed as Record<string, unknown>)
+                : null;
+        } catch {
+            return null;
+        }
+    });
+
+export interface BenchOptions {
+    readonly file: string;
+    readonly days: number;
+    readonly runs: number;
+    readonly budgetMs: number;
+}
+
+/**
+ * Orchestrate the full latency ledger for one SDK hook file:
+ *   resolve -> load meta -> sample payload -> spawn-time -> fire-frequency ->
+ *   installed-chain budget.
+ *
+ * loadHookMeta failures (import/validation) are surfaced with a clean stderr
+ * line + nonzero exit (mirrors backtest); every graph source is soft-isolated
+ * so a missing DB/config degrades a single field instead of aborting.
+ */
+export const benchHook = (
+    opts: BenchOptions,
+): Effect.Effect<
+    BenchLedger,
+    never,
+    SurrealClient | FileSystem.FileSystem | Path.Path | HookProviderRegistry
+> =>
+    Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const absFile = path.resolve(expandTilde(opts.file));
+
+        // Import + validate. A typed failure -> clean message + nonzero exit.
+        const meta = yield* loadHookMeta(absFile).pipe(
+            Effect.catchTags({
+                SdkHookImportError: (e) =>
+                    Effect.sync(() => {
+                        process.stderr.write(`cannot import hook file ${absFile}: ${e.reason}\n`);
+                        process.exit(1);
+                    }) as Effect.Effect<never>,
+                SdkHookValidationError: (e) =>
+                    Effect.sync(() => {
+                        process.stderr.write(`${absFile}: ${e.reason}\n`);
+                        process.exit(1);
+                    }) as Effect.Effect<never>,
+            }),
+        );
+
+        const lite: HookMetaLite = {
+            name: meta.name,
+            events: meta.events,
+            matcher: meta.matcher?.tools ? { tools: meta.matcher.tools } : undefined,
+        };
+        const tools = meta.matcher?.tools ?? [];
+
+        // Representative stdin payload (one real tool_call input when available).
+        const firstTool = tools[0];
+        const sampleInput = firstTool ? yield* sampleToolInput(firstTool) : null;
+        const payload = buildRepresentativePayload(lite, sampleInput, process.cwd());
+
+        // Spawn-time samples; first is the cold warm-up, kept separate.
+        const samples = yield* measureSpawn(absFile, payload, opts.runs);
+        const warmup = samples[0] ?? null;
+        const rest = samples.slice(1);
+        const perFire = percentiles(rest.length ? rest : samples);
+
+        // Fire frequency + projected daily cost. Soft-fail to null.
+        const freq = yield* estFiresPerDay(tools, opts.days).pipe(
+            Effect.catch(() =>
+                Effect.succeed<FireFrequency>({ perDay: null, matched: [...tools], basis: "n/a (db unavailable)" }),
+            ),
+        );
+        const dailyCostMs = freq.perDay != null ? round(perFire.p50 * freq.perDay) : null;
+
+        // Installed-chain budget on the candidate's first event.
+        const chain = yield* gatherChain(meta, perFire.p50, opts.budgetMs);
+
+        return {
+            name: meta.name,
+            perFire,
+            warmupMs: warmup != null ? round(warmup) : null,
+            spawns: rest.length ? rest.length : samples.length,
+            logicMs: null,
+            frequency: freq,
+            dailyCostMs,
+            chain,
+        } satisfies BenchLedger;
+    });
+
+/** Expand a leading `~` to the user's home directory (mirrors hooks/cli.ts). */
+const expandTilde = (p: string): string =>
+    p === "~" ? HOME : p.startsWith("~/") ? `${HOME}/${p.slice(2)}` : p;

--- a/apps/axctl/src/hooks/cli.ts
+++ b/apps/axctl/src/hooks/cli.ts
@@ -20,6 +20,7 @@ import { HookNotFoundError } from "./errors.ts";
 import { installHookFile } from "./sdk-install.ts";
 import { GitEnvLive } from "@ax/hooks-sdk/git-env";
 import { fetchRows, replayRows, summarize, formatReport } from "./backtest.ts";
+import { benchHook, renderLedger } from "./bench.ts";
 import type { HookDefinition } from "@ax/hooks-sdk/define";
 
 /**
@@ -303,6 +304,22 @@ const backtestCommand = Command.make(
         }),
 ).pipe(Command.withDescription("Replay historical tool_call rows through an SDK hook in-process (--days=30 --provider=claude --json)"));
 
+const benchCommand = Command.make(
+    "bench",
+    {
+        file: Argument.string("file"),
+        days: Flag.integer("days").pipe(Flag.withDefault(30)),
+        runs: Flag.integer("runs").pipe(Flag.withDefault(20)),
+        budgetMs: Flag.integer("budget-ms").pipe(Flag.withDefault(250)),
+        json: Flag.boolean("json").pipe(Flag.withDefault(false)),
+    },
+    ({ file, days, runs, budgetMs, json: asJson }) =>
+        Effect.gen(function* () {
+            const ledger = yield* benchHook({ file, days, runs, budgetMs });
+            console.log(asJson ? prettyPrint(ledger) : renderLedger(ledger));
+        }).pipe(Effect.provide(HookProviderRegistryDefault)),
+).pipe(Command.withDescription("Latency ledger for an SDK hook: per-fire p50/p95 (spawn) + fires/day + installed-chain budget (--days=30 --runs=20 --budget-ms=250 --json)"));
+
 /** Spliced into `hooksCommand`'s subcommand list in cli/index.ts. */
 export const hooksConfigSubcommands = [
     configCommand,
@@ -314,4 +331,5 @@ export const hooksConfigSubcommands = [
     initCommand,
     installCommand,
     backtestCommand,
+    benchCommand,
 ];

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -49,7 +49,8 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax improve recommend / accept / lint / show` - evidence-backed proposals (guidance, skills, hooks, automations) derived from the graph; accept emits a task brief, lint reconciles applied guidance
 - `ax retro emit / pending / brief` + `ax:retro` skill - guided experiment-loop retrospective: triage proposals, lock verdicts, review hook effectiveness
 - `ax:dojo` skill - surplus-quota overnight training loop: budget-bounded self-improvement (verdicts, briefs, routing, proposals, experiments); install via `npx skills add Necmttn/ax`
-- `ax hooks init / install / backtest / cases` - author typed TypeScript hooks once, run them on Claude Code + Codex; replay history through a hook before installing it
+- `ax hooks init / install / backtest / bench / cases` - author typed TypeScript hooks once, run them on Claude Code + Codex; replay history through a hook before installing it
+- `ax hooks bench <file> [--days=N] [--runs=N] [--budget-ms=N] [--json]` - latency ledger: per-fire p50/p95 from real bun spawns, est fires/day from tool_call history, installed-chain budget vs --budget-ms default 250
 
 ### Graph insights
 - `ax insights <view>` - 31 read-only graph views

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,7 +55,9 @@ axctl evidence <guidance-next|session-summary|weekly>
 axctl improve <list|show|accept|reject|verdict|checkpoint|reset>
 axctl retro <emit|list|pending|brief|reflect|meta|plan>   # the retro-loop CLI
 axctl hook <fire>                           # hook helper invoked from settings.json
-axctl hooks <summary|invocations|backtest|session|config ...>   # + hook-config CRUD
+axctl hooks <summary|invocations|backtest|bench|session|config ...>   # + hook-config CRUD
+axctl hooks bench <file> [--days=N] [--runs=N] [--budget-ms=N] [--json]
+                                            # latency ledger: per-fire p50/p95 (spawn) + fires/day + installed-chain budget
 
 axctl daemon <status|start|stop|restart>
 axctl doctor                                # local-install health check

--- a/docs/superpowers/plans/2026-06-13-hooks-bench.md
+++ b/docs/superpowers/plans/2026-06-13-hooks-bench.md
@@ -1,0 +1,347 @@
+# ax hooks bench Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add `ax hooks bench <file>` - a hook latency ledger (per-fire p50/p95 via synthetic spawn, fires/day from history, installed-chain budget) - per spec `docs/superpowers/specs/2026-06-13-hooks-bench-design.md`.
+
+**Architecture:** Pure cores (percentiles, representative-payload builder, ledger renderer) unit-tested; Effect glue (subprocess spawn timing, two graph queries, installed-hook chain) tested with fakes + live CLI smoke. New `bench` subcommand in the existing `hooks` family (runtime already `db`).
+
+**Tech Stack:** bun ≥1.3, TS strict, Effect v4 beta (`effect/unstable/cli`), bun:test, SurrealDB via `SurrealClient`, `Bun.spawn` for subprocess timing, `performance.now()` for wall clock.
+
+**Conventions:** Worktree `/Users/necmttn/Projects/ax/.claude/worktrees/dojo-hookbench`. Test = `bun test <path>` (tmp wrapper if a hook blocks bare `bun test`). Datetime cutoffs inline via `surrealDate()` from `@ax/lib/shared/surql` (`d"..."` literal - SurrealClient.query takes no bindings; see `apps/axctl/src/improve/report-queries.ts`). FileSystem via `import { Effect, FileSystem } from "effect"` + `FileSystem.FileSystem` (see `apps/axctl/src/dojo/briefs.ts`). Commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+**Grounding facts (verified):**
+- Hook meta: `loadHookMeta(file)` (`apps/axctl/src/hooks/sdk-install.ts:85`) → `InstallableHookMeta { name, events: string[], matcher?: { tools?: string[] } }`.
+- Raw stdin payload `decodeHookInput` accepts (`packages/hooks-sdk/src/adapters/decode.ts`, confirmed in `define.test.ts:26`): `{ hook_event_name, tool_name, tool_input, cwd, session_id? }`.
+- Fire command: `bun <absFile>` (`sdk-install.ts` planInstall).
+- backtest command pattern + `fetchRows(days, toolNames, providerFilter)` / `replayRows` (`apps/axctl/src/hooks/cli.ts:236`, `backtest.ts:62,199`).
+- Installed hooks: `readAllHooks` (`apps/axctl/src/hooks/config.ts:108`). Recorded durations: `buildHookSummaryQuery` (`apps/axctl/src/queries/hooks.ts:70`) over `hook_command_invocation` (fields: command, hook_name, event_name, duration_ms, ts, harness).
+- tool_call fields: `name`, `ts`, `session` (`packages/schema/src/schema.surql:324`). backtest's `TOOL_CALL_Q_*` is the count template.
+- hooks family registration: `hooksConfigSubcommands` array (`apps/axctl/src/hooks/cli.ts:307`); runtime manifest `hooks: "db"` (`apps/axctl/src/cli/commands/hooks.ts:268`).
+
+---
+
+### Task 1: bench pure cores + types
+
+**Files:** Create `apps/axctl/src/hooks/bench.ts`, `apps/axctl/src/hooks/bench.test.ts`
+
+- [ ] **Step 1: failing test**
+
+```ts
+// apps/axctl/src/hooks/bench.test.ts
+import { describe, expect, test } from "bun:test";
+import { buildRepresentativePayload, percentiles, renderLedger } from "./bench.ts";
+import type { BenchLedger } from "./bench.ts";
+
+describe("percentiles", () => {
+    test("p50/p95/min/max/mean over samples", () => {
+        const p = percentiles([10, 20, 30, 40, 100]);
+        expect(p.min).toBe(10);
+        expect(p.max).toBe(100);
+        expect(p.p50).toBe(30); // median (nearest-rank)
+        expect(p.p95).toBe(100);
+        expect(p.mean).toBe(40);
+    });
+    test("single sample: all equal", () => {
+        expect(percentiles([7])).toEqual({ min: 7, max: 7, p50: 7, p95: 7, mean: 7 });
+    });
+    test("empty -> zeros", () => {
+        expect(percentiles([])).toEqual({ min: 0, max: 0, p50: 0, p95: 0, mean: 0 });
+    });
+});
+
+describe("buildRepresentativePayload", () => {
+    test("PreToolUse with a matched tool + sample input", () => {
+        const json = buildRepresentativePayload(
+            { name: "x", events: ["PreToolUse"], matcher: { tools: ["Bash", "Edit"] } },
+            { command: "git status" },
+            "/repo",
+        );
+        const parsed = JSON.parse(json);
+        expect(parsed.hook_event_name).toBe("PreToolUse");
+        expect(parsed.tool_name).toBe("Bash"); // first matched tool
+        expect(parsed.tool_input).toEqual({ command: "git status" });
+        expect(parsed.cwd).toBe("/repo");
+    });
+    test("non-tool event (no matcher) -> no tool_name/tool_input", () => {
+        const json = buildRepresentativePayload(
+            { name: "x", events: ["SessionStart"], matcher: undefined }, null, "/repo",
+        );
+        const parsed = JSON.parse(json);
+        expect(parsed.hook_event_name).toBe("SessionStart");
+        expect(parsed.tool_name).toBeUndefined();
+    });
+});
+
+describe("renderLedger", () => {
+    const ledger: BenchLedger = {
+        name: "enforce-worktree",
+        perFire: { p50: 72, p95: 84, min: 70, max: 140, mean: 78 },
+        warmupMs: 140, spawns: 19,
+        logicMs: 2,
+        frequency: { perDay: 14, matched: ["Bash", "Edit"], basis: "tool_call/30d" },
+        dailyCostMs: 1008,
+        chain: { event: "PreToolUse", beforeMs: 198, withMs: 270, budgetMs: 250, overBudget: true,
+                 hooks: ["enforce-worktree", "route-dispatch", "other"] },
+    };
+    test("renders headline + frequency + chain warning", () => {
+        const out = renderLedger(ledger);
+        expect(out).toContain("hook: enforce-worktree");
+        expect(out).toContain("p50 72ms");
+        expect(out).toContain("p95 84ms");
+        expect(out).toContain("fires/day");
+        expect(out).toContain("14");
+        expect(out).toContain("chain (PreToolUse): 198ms -> 270ms");
+        expect(out).toContain("over 250ms budget");
+    });
+    test("frequency n/a hides daily cost line", () => {
+        const out = renderLedger({ ...ledger, frequency: { perDay: null, matched: [], basis: "n/a" }, dailyCostMs: null });
+        expect(out).toContain("fires/day:     n/a");
+        expect(out).not.toContain("daily cost:");
+    });
+});
+```
+
+- [ ] **Step 2: run -> FAIL**
+
+- [ ] **Step 3: implement** - types + the three pure fns.
+
+```ts
+// apps/axctl/src/hooks/bench.ts  (pure portion; Effect glue lands in Tasks 2-3)
+export interface PerFireStats {
+    readonly p50: number; readonly p95: number;
+    readonly min: number; readonly max: number; readonly mean: number;
+}
+export interface ChainSummary {
+    readonly event: string;
+    readonly beforeMs: number; readonly withMs: number;
+    readonly budgetMs: number; readonly overBudget: boolean;
+    readonly hooks: readonly string[];
+}
+export interface BenchLedger {
+    readonly name: string;
+    readonly perFire: PerFireStats;
+    readonly warmupMs: number | null;
+    readonly spawns: number;
+    readonly logicMs: number | null;
+    readonly frequency: { readonly perDay: number | null; readonly matched: readonly string[]; readonly basis: string };
+    readonly dailyCostMs: number | null;
+    readonly chain: ChainSummary | null;
+}
+export interface HookMetaLite {
+    readonly name: string;
+    readonly events: readonly string[];
+    readonly matcher?: { readonly tools?: readonly string[] } | undefined;
+}
+
+const round = (n: number) => Math.round(n);
+
+/** Nearest-rank percentiles over wall-time samples (ms). Empty -> zeros. */
+export const percentiles = (samples: readonly number[]): PerFireStats => {
+    if (samples.length === 0) return { p50: 0, p95: 0, min: 0, max: 0, mean: 0 };
+    const s = [...samples].sort((a, b) => a - b);
+    const at = (q: number) => s[Math.min(s.length - 1, Math.ceil(q * s.length) - 1)] ?? 0;
+    const mean = s.reduce((a, b) => a + b, 0) / s.length;
+    return { min: round(s[0] ?? 0), max: round(s[s.length - 1] ?? 0), p50: round(at(0.5)), p95: round(at(0.95)), mean: round(mean) };
+};
+
+/** Raw harness stdin payload that decodeHookInput accepts. */
+export const buildRepresentativePayload = (
+    meta: HookMetaLite,
+    sampleInput: Record<string, unknown> | null,
+    cwd: string,
+): string => {
+    const event = meta.events[0] ?? "PreToolUse";
+    const firstTool = meta.matcher?.tools?.[0];
+    const payload: Record<string, unknown> = { hook_event_name: event, cwd };
+    if (firstTool) {
+        payload.tool_name = firstTool;
+        payload.tool_input = sampleInput ?? {};
+    }
+    return JSON.stringify(payload);
+};
+
+export const renderLedger = (l: BenchLedger): string => {
+    const lines: string[] = [`hook: ${l.name}`];
+    const warm = l.warmupMs != null ? `, 1 warmup ${l.warmupMs}ms` : "";
+    const logic = l.logicMs != null ? ` · logic ${l.logicMs}ms` : "";
+    lines.push(`per-fire:      p50 ${l.perFire.p50}ms · p95 ${l.perFire.p95}ms · (${l.spawns} spawns${warm})${logic}`);
+    if (l.frequency.perDay == null) {
+        lines.push(`fires/day:     n/a  (${l.frequency.basis})`);
+    } else {
+        lines.push(`fires/day:     ~${l.frequency.perDay}  (${l.frequency.matched.join(",")} via ${l.frequency.basis})`);
+        if (l.dailyCostMs != null) lines.push(`daily cost:    ~${(l.dailyCostMs / 1000).toFixed(1)} s/day`);
+    }
+    if (l.chain) {
+        const warn = l.chain.overBudget ? `  ⚠ over ${l.chain.budgetMs}ms budget` : ` (under ${l.chain.budgetMs}ms budget)`;
+        lines.push(`chain (${l.chain.event}): ${l.chain.beforeMs}ms -> ${l.chain.withMs}ms with this${warn}`);
+    }
+    return lines.join("\n");
+};
+```
+
+- [ ] **Step 4: run -> PASS** (8 tests)
+- [ ] **Step 5: commit** `feat(hooks): bench pure cores - percentiles, payload, ledger render`
+
+---
+
+### Task 2: spawn timing + fire-frequency query
+
+**Files:** Modify `apps/axctl/src/hooks/bench.ts`, `apps/axctl/src/hooks/bench.test.ts`
+
+READ FIRST: `apps/axctl/src/hooks/backtest.ts` (TOOL_CALL_Q_ALL/FILTERED + fetchRows + surrealDate cutoff), `apps/axctl/src/improve/report-queries.ts` (query call shape + projection-strip), `apps/axctl/src/improve/show.test.ts` (fake client).
+
+- [ ] **Step 1: failing test** - `estFiresPerDay`:
+
+```ts
+// add to bench.test.ts
+import { Effect } from "effect";
+import { estFiresPerDay } from "./bench.ts";
+// fake-client harness from show.test.ts
+
+describe("estFiresPerDay", () => {
+    test("counts matched tool_calls / days", async () => {
+        const client = fakeClient([[{ total: 420 }]]); // 420 matched over 30d
+        const r = await Effect.runPromise(
+            estFiresPerDay(["Bash", "Edit"], 30).pipe(Effect.provide(client.layer)),
+        );
+        expect(r.perDay).toBe(14);
+        expect(r.matched).toEqual(["Bash", "Edit"]);
+    });
+    test("no tools (non-tool hook) -> perDay null, basis n/a", async () => {
+        const r = await Effect.runPromise(estFiresPerDay([], 30).pipe(Effect.provide(fakeClient([[]]).layer)));
+        expect(r.perDay).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: run -> FAIL**
+
+- [ ] **Step 3: implement** `estFiresPerDay` + `measureSpawn`.
+
+```ts
+// estFiresPerDay: COUNT tool_call WHERE name IN [tools] AND ts > since(days)
+export const estFiresPerDay = (tools: readonly string[], days: number) =>
+    Effect.gen(function* () {
+        if (tools.length === 0) return { perDay: null as number | null, matched: [] as string[], basis: "n/a" };
+        const db = yield* SurrealClient;
+        const since = new Date(Date.now() - days * 86_400_000);
+        const list = tools.map((t) => surrealString(t)).join(", "); // surrealString from @ax/lib/shared/surql
+        const r = yield* db.query<[Array<{ total: number }>]>(
+            `SELECT count() AS total FROM tool_call WHERE name IN [${list}] AND ts > ${surrealDate(since)} GROUP ALL;`,
+        );
+        const total = r?.[0]?.[0]?.total ?? 0;
+        return { perDay: Math.round(total / days), matched: [...tools], basis: `tool_call/${days}d` };
+    });
+```
+
+VERIFY: `count() ... GROUP ALL` is how the repo counts (see the weighted-query memory: count needs GROUP ALL). Check an existing COUNT query (`apps/axctl/src/queries/` or skill-stats) for the exact idiom and mirror it. `surrealString`/`surrealDate` live in `@ax/lib/shared/surql` - confirm import.
+
+`measureSpawn(absFile, payload, runs)`: spawn `bun <absFile>` feeding `payload` on stdin, `runs` times; time each with `performance.now()`; return all samples (ms). Use `Bun.spawn(["bun", absFile], { stdin: new TextEncoder().encode(payload), stdout: "ignore", stderr: "ignore" })` then `await proc.exited`. Wrap as `Effect.promise`. Cap runs at 100. Return `number[]`.
+
+```ts
+export const measureSpawn = (absFile: string, payload: string, runs: number): Effect.Effect<number[]> =>
+    Effect.promise(async () => {
+        const samples: number[] = [];
+        const n = Math.min(100, Math.max(1, runs));
+        for (let i = 0; i < n; i++) {
+            const t0 = performance.now();
+            const proc = Bun.spawn(["bun", absFile], { stdin: new TextEncoder().encode(payload), stdout: "ignore", stderr: "ignore" });
+            await proc.exited;
+            samples.push(performance.now() - t0);
+        }
+        return samples;
+    });
+```
+
+(measureSpawn is covered by the live smoke in Task 3, not a unit test - spawning bun in unit tests is slow/flaky. State this.)
+
+- [ ] **Step 4: run -> PASS** (estFiresPerDay tests); typecheck clean.
+- [ ] **Step 5: commit** `feat(hooks): bench spawn timing + fire-frequency query`
+
+---
+
+### Task 3: installed-chain + benchHook orchestration + CLI command
+
+**Files:** Modify `apps/axctl/src/hooks/bench.ts`, `apps/axctl/src/hooks/bench.test.ts`; modify `apps/axctl/src/hooks/cli.ts` (add benchCommand to `hooksConfigSubcommands`).
+
+READ FIRST: `apps/axctl/src/hooks/config.ts` (readAllHooks → installed hooks per provider/event), `apps/axctl/src/queries/hooks.ts` (buildHookSummaryQuery → recorded mean duration per command), the `backtestCommand` in `cli.ts` (command shape, file resolution, DB-error handling, expandTilde, Path.Path).
+
+- [ ] **Step 1: gatherChain** - for the candidate's first event, list installed hooks on that event; per-hook cost = recorded mean `duration_ms` (from a hook-summary query keyed by command/hook_name) when present, else `DEFAULT_SPAWN_MS = 70`. `beforeMs` = sum of installed; `withMs` = before + candidate p50; `overBudget` = withMs > budgetMs.
+
+Write `gatherChain(meta, candidateP50, budgetMs)` returning `ChainSummary | null` (null when the candidate has no events). Keep the recorded-duration lookup best-effort: if the summary query is heavy or the matcher decomposition is unclear, fall back to counting installed hooks on the event × DEFAULT_SPAWN_MS and `log()` that it's an estimate (no silent approximation). Test the PURE aggregation by factoring a helper:
+
+```ts
+export const composeChain = (
+    event: string, installedCostsMs: readonly number[], candidateP50: number, budgetMs: number, hookNames: readonly string[],
+): ChainSummary => {
+    const before = Math.round(installedCostsMs.reduce((a, b) => a + b, 0));
+    const withC = before + Math.round(candidateP50);
+    return { event, beforeMs: before, withMs: withC, budgetMs, overBudget: withC > budgetMs, hooks: [...hookNames] };
+};
+```
+
+Test `composeChain` purely (sum, over/under budget boundary at exactly budgetMs → not over). `gatherChain` (the Effect that fetches installed costs) is covered by the live smoke.
+
+- [ ] **Step 2: benchHook orchestration** - `benchHook({ file, days, runs, budgetMs })`:
+  1. resolve absFile (expandTilde + Path.resolve, like backtest).
+  2. `loadHookMeta(absFile)` → meta (handle the typed import/validation errors with a clean message + nonzero exit, mirroring backtest).
+  3. pick a sample input: query one recent `tool_call.input_json` for `meta.matcher.tools[0]` if any (reuse fetchRows or a tiny SELECT ... LIMIT 1); parse to object; else null.
+  4. payload = buildRepresentativePayload(meta, sampleInput, process.cwd()).
+  5. samples = measureSpawn(absFile, payload, runs); warmup = samples[0]; rest = samples.slice(1); perFire = percentiles(rest.length ? rest : samples).
+  6. freq = estFiresPerDay(meta.matcher?.tools ?? [], days).
+  7. dailyCostMs = freq.perDay != null ? perFire.p50 * freq.perDay : null.
+  8. chain = gatherChain(meta, perFire.p50, budgetMs).
+  9. assemble BenchLedger. (logicMs: optional - skip in v1 unless cheap; set null.)
+  Return type: `Effect<BenchLedger, never, SurrealClient | FileSystem | Path | HookProviderRegistry>` (whatever readAllHooks needs). Soft-isolate each source (a failed query → its empty/default), never abort.
+
+- [ ] **Step 3: benchCommand** - mirror backtestCommand:
+
+```ts
+const benchCommand = Command.make("bench", {
+    file: Argument.string("file"),
+    days: Flag.integer("days").pipe(Flag.withDefault(30)),
+    runs: Flag.integer("runs").pipe(Flag.withDefault(20)),
+    budgetMs: Flag.integer("budget-ms").pipe(Flag.withDefault(250)),
+    json: Flag.boolean("json").pipe(Flag.withDefault(false)),
+}, ({ file, days, runs, budgetMs, json }) => Effect.gen(function* () {
+    const ledger = yield* benchHook({ file, days, runs, budgetMs });
+    console.log(json ? prettyPrint(ledger) : renderLedger(ledger));
+})).pipe(Command.withDescription("Latency ledger for an SDK hook: per-fire p50/p95 (spawn) + fires/day + installed-chain budget (--days=30 --runs=20 --budget-ms=250 --json)"));
+```
+Add `benchCommand` to the `hooksConfigSubcommands` array. Runtime: `hooks` is already `"db"` - no manifest change (the db-conditional check: confirm `hooks: "db"` covers subcommands, which it does since it's a flat "db").
+
+- [ ] **Step 4: tests + smoke**
+  - `bun test apps/axctl/src/hooks/bench.test.ts` → pure tests pass (percentiles, payload, render, estFiresPerDay, composeChain).
+  - `bun test apps/axctl/src/cli/effect-cli.test.ts` → pass.
+  - Live smoke (DB up; `~/.ax/hooks/` has installed hooks like enforce-worktree.ts): `bun apps/axctl/src/cli/index.ts hooks bench ~/.ax/hooks/enforce-worktree.ts --runs=5 --json` → a BenchLedger with real perFire numbers (p50 ~50-120ms proves the spawn + stdin format is correct), a frequency, and a chain. Then non-json for the table. PASTE output. If `~/.ax/hooks` is empty, run `ax hooks init` first or point at any SDK hook file in the repo.
+- [ ] **Step 5: commit** `feat(hooks): ax hooks bench - latency ledger command`
+
+---
+
+### Task 4: docs + SKILL.md
+
+**Files:** Modify `docs/cli.md`, `apps/site/public/llms.txt`, `CLAUDE.md`, `skills/dojo/SKILL.md`
+
+- [ ] **Step 1** docs/cli.md: add under the hooks commands -
+```
+axctl hooks bench <file> [--days=N|--runs=N|--budget-ms=N|--json]   # hook latency ledger: per-fire p50/p95 + fires/day + installed-chain budget
+```
+- [ ] **Step 2** llms.txt: add a bullet near the hooks entries describing `ax hooks bench`.
+- [ ] **Step 3** CLAUDE.md "## Hooks SDK" section: add a bullet - `ax hooks bench <file> [--days --runs --budget-ms --json]` - latency ledger (per-fire p50/p95 from real `bun <file>` spawns, est fires/day from tool_call history, installed-chain budget vs --budget-ms default 250). Pairs with `ax hooks backtest` (benefit) for dojo hook proposals.
+- [ ] **Step 4** skills/dojo/SKILL.md "new hooks" playbook: after `ax hooks backtest`, add: run `ax hooks bench <file> --json` and embed BOTH ledgers in the proposal - backtest = cases caught (benefit), bench = per-fire/day cost + chain budget (cost). Reject the hook when daily cost or a chain-budget overrun outweighs the benefit.
+- [ ] **Step 5** `bun run check:cli-reference` → exit 0 (hooks parent already covered; just keep docs accurate). Commit `docs(hooks): bench command reference + dojo new-hook ledger usage`.
+
+---
+
+### Task 5: verify + PR
+
+- [ ] **Step 1** `bun test` (repo-wide) → 0 fail.
+- [ ] **Step 2** `bun run typecheck` → clean.
+- [ ] **Step 3** `bun run check:cli-reference` + `bun scripts/check-no-node-fs.ts` → clean.
+- [ ] **Step 4** push + PR:
+```bash
+git push -u origin feat/dojo-hookbench
+gh pr create --title "feat: ax hooks bench - hook latency ledger" --body "..."
+```
+PR body: summary (per-fire p50/p95 via real spawn, fires/day from history, installed-chain budget); the dojo "new hooks" use case it completes; test plan (incl. live smoke proving the stdin format); deferred (continuous regression tracking, true recorded percentiles, auto-reject).

--- a/docs/superpowers/specs/2026-06-13-hooks-bench-design.md
+++ b/docs/superpowers/specs/2026-06-13-hooks-bench-design.md
@@ -1,0 +1,144 @@
+# ax hooks bench - hook latency ledger
+
+Date: 2026-06-13
+Status: approved design, pre-implementation
+Follows: docs/superpowers/specs/2026-06-13-ax-dojo-design.md (dojo core, "new hooks" use case)
+
+## Problem
+
+The dojo's highest-value use case (user's words: "the greatest use case") is the
+agent authoring a NEW hook, backtesting it, and shipping it as a proposal. But
+every hook rides the harness hot path (`bun <file>.ts`, ~70ms cold spawn per
+fire), and chains stack. A hook proposal must show BOTH sides of the ledger:
+benefit (cases the hook catches - `ax hooks backtest` already does this) AND
+cost (per-fire latency, fires/day, cumulative installed-chain budget). Today the
+cost side doesn't exist. `ax hooks backtest` replays in-process - it measures
+logic time but NOT the spawn tax the harness actually pays.
+
+`ax hooks bench <file>` produces the cost ledger.
+
+## Two sources of latency truth
+
+1. **Synthetic spawn** (the headline): a just-authored hook has no production
+   history, so we measure it directly - spawn `bun <absFile>` feeding a
+   representative event on stdin, N times, take percentiles. This is the real
+   fire path (validated: if the stdin shape is wrong the hook errors).
+2. **Recorded production fires**: `hook_command_invocation.duration_ms` holds
+   what already-installed hooks actually cost in real sessions
+   (`buildHookSummaryQuery` aggregates mean/max per command). Feeds the
+   installed-chain budget so the candidate's cost is shown in context.
+
+## `ax hooks bench <file> [--days=N] [--runs=N] [--budget-ms=N] [--json]`
+
+New subcommand in the `hooks` family (runtime `db` - needs `tool_call` +
+`hook_command_invocation`). `<file>` = absolute path to a `@ax/hooks-sdk` hook.
+
+Steps:
+
+1. **Load meta**: `loadHookMeta(file)` (`apps/axctl/src/hooks/sdk-install.ts`) →
+   `{ name, events[], matcher?.tools[] }`. Fail cleanly if not a valid hook.
+
+2. **Per-fire latency (headline)**: build a representative raw stdin payload for
+   the hook's first event + a matched tool (see "stdin shape" below), then
+   `Bun.spawn(["bun", absFile], { stdin: payload })` `--runs` times (default 20),
+   timing each with `performance.now()` around spawn→exit. Discard run 1 (compile
+   -cache warmup, reported separately). Compute p50/p95/min/max/mean over the
+   rest (pure `percentiles()`).
+   - Secondary breakdown: reuse `replayRows`-style in-process `run()` timing for
+     one fire → "logic" ms (the author-controllable part vs the fixed runtime
+     tax = p50 − logic). Best-effort; omit if it complicates.
+
+3. **Fire frequency**: count `tool_call WHERE name IN $tools AND ts > $since`
+   over `--days` (default 30) ÷ days → est fires/day. If the hook has no tool
+   matcher (fires on every event of its type, e.g. SessionStart), report
+   "all <event> events" with a count of those events/day if derivable, else mark
+   frequency `n/a` (and skip daily-overhead). Reuse backtest's `tool_call` query
+   + `surrealDate` cutoff convention.
+
+4. **Daily overhead** = p50 × fires/day (ms/day this hook adds).
+
+5. **Installed-chain budget**: enumerate installed hooks (`readAllHooks`,
+   `apps/axctl/src/hooks/config.ts`); for each event type the candidate fires on,
+   sum the per-fire cost of every hook on that event. Per-hook cost = recorded
+   mean `duration_ms` from `hook_command_invocation` when present, else a default
+   spawn estimate (constant, ~70ms). Show the chain BEFORE and WITH the candidate
+   vs `--budget-ms` (default 250). Warn when any event-type chain exceeds budget.
+   - v1 may approximate: if precise per-event matcher decomposition is heavy,
+     report installed-hook count + summed recorded cost + candidate contribution
+     + the worst event-type chain, and `log()` what was approximated. No silent
+     truncation.
+
+6. **Ledger output** (table by default, `--json` for the dojo agent to embed
+   verbatim in a hook proposal):
+
+```
+hook: enforce-worktree
+per-fire:      p50 72ms · p95 84ms · (19 spawns, 1 warmup 140ms) · logic 2ms
+fires/day:     ~14  (Bash,Edit,Write matched over 30d)
+daily cost:    ~1.0 s/day
+chain (PreToolUse): 3 hooks 198ms -> 270ms with this  ⚠ over 250ms budget
+verdict:       SHIP only if the benefit ledger (ax hooks backtest) justifies +72ms/fire
+```
+
+The `--json` shape is a typed `BenchLedger` (per-fire stats, frequency, daily
+cost, per-event chain rows, budget + over-budget flag).
+
+## stdin shape (key integration risk)
+
+The subprocess reads the HARNESS raw payload via `decodeHookInput(stdinText, env)`
+(`packages/hooks-sdk/src/event.ts`) - NOT the decoded `HookEvent`. The bench must
+emit a payload `decodeHookInput` accepts (Claude Code PreToolUse JSON:
+`hook_event_name`, `tool_name`, `tool_input`, `cwd`, `session_id`, ...). The
+implementer reads `decodeHookInput` + `event.ts` to match it exactly, and
+**smoke-validates by benching a real installed hook** (e.g. `~/.ax/hooks/
+enforce-worktree.ts`): a correct payload yields a normal verdict exit, a wrong
+one errors - so the smoke proves the format.
+
+## Module shape
+
+```
+apps/axctl/src/hooks/bench.ts
+  - percentiles(samples: number[]): { p50, p95, min, max, mean }      (pure)
+  - buildRepresentativePayload(meta, sampleInput): string             (pure: raw stdin JSON)
+  - renderLedger(ledger: BenchLedger): string                         (pure)
+  - measureSpawn(absFile, payload, runs): Effect<number[], ...>        (Bun.spawn timing)
+  - estFiresPerDay(tools, days): Effect<{perDay, matched}, DbError, SurrealClient>
+  - gatherChain(meta, candidateP50, budgetMs): Effect<ChainRow[], DbError, SurrealClient | FileSystem | HookProviderRegistry>
+  - benchHook(input): Effect<BenchLedger, ...>                         (orchestration)
+apps/axctl/src/hooks/bench.test.ts
+apps/axctl/src/cli/commands/hooks.ts   # add benchCommand to the family (runtime already db)
+```
+
+Pure cores (`percentiles`, `buildRepresentativePayload`, `renderLedger`) unit-
+tested in isolation. `estFiresPerDay`/`gatherChain` tested with the fake-
+SurrealClient harness + fixtures. `measureSpawn`/`benchHook` covered by the live
+CLI smoke (spawning is inherently integration).
+
+## Dojo wiring
+
+`skills/dojo/SKILL.md` "new hooks" playbook updates: after authoring + `ax hooks
+backtest`, run `ax hooks bench <file>` and embed BOTH ledgers (benefit from
+backtest, cost from bench) in the proposal; reject the hook when the daily cost
+or chain-budget overrun outweighs the benefit. No dojo CLI code change - this is
+skill-prose + the new command.
+
+## Safety / scope
+
+- Read-only against the graph; spawns the hook in a child process (the hook
+  itself may have side effects - bench notes that hooks should be pure; running
+  a real hook's `run()` once is what `backtest` already does, so no new risk).
+- `--runs` capped (e.g. ≤100) to bound wall time.
+- No new SurrealDB table.
+
+## Out of scope (later)
+
+- Continuous latency tracking / regression alerts on installed hooks.
+- p50/p95 from recorded `duration_ms` percentiles (v1 uses mean/max the existing
+  query provides; true percentiles need a histogram query - deferred).
+- Auto-reject in the CLI - the SHIP/skip judgment stays with the agent.
+
+## Open questions
+
+- Non-tool-event hooks (SessionStart/Stop): fires/day has no `tool_call` proxy.
+  v1 marks frequency `n/a`; a per-event-type count from `hook_command_invocation`
+  history could fill it if the hook is already installed.

--- a/skills/dojo/SKILL.md
+++ b/skills/dojo/SKILL.md
@@ -56,11 +56,16 @@ docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
   (objective + checkpoint index + gates) under docs/superpowers/goals/ so
   the NEXT dojo session resumes it. Output = an improve proposal; merging
   the proposal is what activates anything. NEVER merge, never touch main.
-- **New hooks specifically** - author via @ax/hooks-sdk, validate with
-  `ax hooks backtest <file>`, and put BOTH sides in the proposal: cases it
-  would have caught AND the latency ledger (per-fire cost, est fires/day,
-  cumulative installed-chain overhead). Reject your own hook when overhead
-  outweighs benefit.
+- **New hooks specifically** - author via @ax/hooks-sdk, then run BOTH
+  validators and embed their output in the proposal:
+  1. `ax hooks backtest <file> --json` → cases caught (benefit side): would-block/
+     would-warn rates, false-positive count, cases with evidence.
+  2. `ax hooks bench <file> --json` → per-fire p50/p95 from real bun spawns,
+     est fires/day from tool_call history, installed-chain budget vs --budget-ms
+     default 250 (cost side).
+  Reject the hook when daily cost (fires/day × p95) or an installed-chain budget
+  overrun outweighs the benefit shown by backtest. Both ledgers must appear in
+  the proposal; neither alone is sufficient.
 - **spar** - only present when invoked with --spar and spendable >= 30%.
   One task, one delta, scored: pick a landed task (`ax sessions here`),
   pin a worktree at the parent SHA, re-run it with exactly ONE change


### PR DESCRIPTION
## Summary
`ax hooks bench <file>` produces the **cost** side of a hook proposal's ledger — completing the dojo "new hooks" use case (pairs with `ax hooks backtest`, which shows the benefit side).

- **Per-fire latency** — spawns `bun <file>` feeding a representative event on stdin, N times, reports p50/p95/min/max (warmup spawn reported separately). This is the real fire path the harness pays, not the in-process logic time `backtest` measures.
- **Fires/day** — counts matched `tool_call` events over `--days` → estimated frequency, × p50 = daily overhead.
- **Installed-chain budget** — sums the per-fire cost of every hook on the candidate's event (recorded `hook_command_invocation.duration_ms` where available, else a spawn estimate), scoped to one harness + deduped by command, vs `--budget-ms` (default 250). Shows the chain before/with the candidate and flags overruns.
- `ax hooks bench <file> [--days=N] [--runs=N] [--budget-ms=N] [--json]` — new subcommand in the `hooks` family. `--json` for the dojo agent to embed in a proposal.
- Spec: `docs/superpowers/specs/2026-06-13-hooks-bench-design.md`; plan: `docs/superpowers/plans/2026-06-13-hooks-bench.md`.

## Real signal from the dogfood smoke
Benching `~/.ax/hooks/enforce-worktree.ts` on this machine: ~70ms/fire, ~1418 Bash fires/day (~100s/day), and a **PreToolUse chain of 7 hooks at 439ms — already 1.75× over the 250ms budget** before adding anything. The ledger surfaces exactly the kind of cost the dojo needs to weigh against benefit.

## Notes for reviewers
- Headline latency is the **subprocess spawn** (real fire path), which self-validates the stdin payload format (`{hook_event_name, tool_name, tool_input, cwd}`) — a wrong shape would error the hook.
- Chain scoping fixed during review: a single fire runs one harness's hooks, so the chain filters to `claude` and dedupes by command (an earlier pass double-counted codex-installed dupes, inflating the chain ~30%).
- `measureSpawn` has a 15s per-spawn deadline (kills hangs); count queries use the `GROUP ALL` + `surrealDate` conventions.

## Test plan
- [x] `bun test` repo-wide: 4058 pass / 0 fail
- [x] `bun run typecheck`: clean
- [x] `check:cli-reference` + `check:no-node-fs`: clean
- [x] Live smoke: `hooks bench <installed hook> --json` (real p50/p95/chain), table render, nonexistent-file → clean error+nonzero exit

## Deferred (follow-up)
continuous latency regression tracking, true recorded percentiles (v1 uses mean/max the existing query provides), CLI-side auto-reject (the SHIP/skip judgment stays with the agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)