### PR TITLE
feat: ax dojo spar - replay benchmark (one task, one delta, scored)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ docs/superpowers/specs/2026-06-13-ax-dojo-design.md.
 `ax dojo report [--since=<iso>] [--notes-file=<path>]` writes the morning-report
 for a completed run; `ax dojo draft [--title=...] [--kind=bug|improvement]`
 stages an upstream finding to `~/.ax/dojo/outbox/` (never publishes);
-`ax dojo outbox` inspects staged drafts.
+`ax dojo outbox` inspects staged drafts. `ax dojo spar-plan <sha>` freezes a landed task's baseline (prompt + cost/turns/churn) and emits a brief with the worktree pin command + a delta slot; the agent runs the variant with ONE change in that worktree; `ax dojo spar-score <id>` scores variant vs baseline into a receipt (`~/.ax/dojo/spar/`). Hybrid: CLI scaffolds, agent re-runs.
 
 ### Profile
 

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -16,14 +16,32 @@
  * API.
  */
 import { Effect, FileSystem } from "effect";
-import { Command, Flag } from "effect/unstable/cli";
+import { Argument, Command, Flag } from "effect/unstable/cli";
+import { posixPath } from "@ax/lib/shared/path";
 import { prettyPrint } from "@ax/lib/json";
 import { assembleAgenda, collectAgendaItems } from "../../dojo/agenda.ts";
 import { computeBudgetEnvelope } from "../../dojo/budget.ts";
 import { renderAgenda } from "../../dojo/format.ts";
 import { writeDraft, listDrafts, type DraftKind } from "../../dojo/outbox.ts";
-import { dojoReportPath, dojoReportsDir, localDate } from "../../dojo/paths.ts";
+import {
+    dojoReportPath,
+    dojoReportsDir,
+    dojoSparBriefPath,
+    dojoSparDir,
+    dojoSparReportPath,
+    localDate,
+} from "../../dojo/paths.ts";
 import { gatherReport, renderReport } from "../../dojo/report.ts";
+import {
+    captureBaseline,
+    fetchSessionMetrics,
+    findVariantSession,
+    parseSparBrief,
+    renderSparBrief,
+    renderSparReport,
+    scoreSpar,
+} from "../../dojo/spar.ts";
+import { resolvePwdRepository } from "../../pwd.ts";
 import { defaultQuotaCachePath } from "../../quota/cache.ts";
 import { QuotaEnvLive } from "../../quota/quota-env.ts";
 import { getQuota } from "../../quota/quota.ts";
@@ -262,12 +280,139 @@ const outboxCommand = Command.make(
 );
 
 // ---------------------------------------------------------------------------
+// ax dojo spar-plan <sha> - capture + freeze a baseline, emit an experiment brief
+// ---------------------------------------------------------------------------
+
+/** Resolve $PWD to its git repoRoot + repository record key (mirrors `sessions near`). */
+const resolveRepo = Effect.gen(function* () {
+    const pwd = yield* resolvePwdRepository().pipe(
+        Effect.catchTag("NotAGitRepoError", (err) => {
+            console.error(`ax dojo: not in a git repository (cwd=${err.cwd})`);
+            return Effect.sync(() => process.exit(1)) as Effect.Effect<never>;
+        }),
+    );
+    return {
+        repoRoot: pwd.repoRoot,
+        repositoryKey: pwd.repositoryRecordId.id as string,
+    };
+});
+
+const sparPlanCommand = Command.make(
+    "spar-plan",
+    { sha: Argument.string("sha"), json: jsonFlag },
+    ({ sha, json }) =>
+        Effect.gen(function* () {
+            const { repoRoot, repositoryKey } = yield* resolveRepo;
+            const brief = yield* captureBaseline(
+                sha,
+                repoRoot,
+                repositoryKey,
+                new Date().toISOString(),
+            ).pipe(
+                Effect.catchTag("SparCaptureError", (err) => {
+                    console.error(`ax dojo spar-plan: ${err.message}`);
+                    return Effect.sync(() => process.exit(1)) as Effect.Effect<never>;
+                }),
+            );
+
+            const fs = yield* FileSystem.FileSystem;
+            yield* fs.makeDirectory(dojoSparDir(), { recursive: true });
+            const path = dojoSparBriefPath(brief.id);
+            const tmp = `${path}.tmp.${process.pid}`;
+            yield* fs.writeFileString(tmp, renderSparBrief(brief));
+            yield* fs.rename(tmp, path);
+
+            if (json) {
+                console.log(prettyPrint(brief));
+                return;
+            }
+            const worktreeCmd = `git worktree add ${brief.worktree} -b dojo/spar-${brief.id} ${brief.parentSha}`;
+            console.log(
+                `${path}\n\nNext:\n  ${worktreeCmd}\n  fill the Delta section, run the task in that worktree, then: ax dojo spar-score ${brief.id}`,
+            );
+        }),
+).pipe(
+    Command.withDescription(
+        "Capture + freeze a landed task's baseline (prompt + cost/turns/churn) and emit a one-delta experiment brief to ~/.ax/dojo/spar/<id>.md. --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax dojo spar-score <id> - score the agent's variant against the frozen baseline
+// ---------------------------------------------------------------------------
+
+const sparScoreCommand = Command.make(
+    "spar-score",
+    {
+        id: Argument.string("id"),
+        variantSession: Flag.string("variant-session").pipe(Flag.withDefault("")),
+        json: jsonFlag,
+    },
+    ({ id, variantSession, json }) =>
+        Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const briefPath = dojoSparBriefPath(id);
+            const content = yield* fs.readFileString(briefPath).pipe(
+                Effect.catch(() => {
+                    console.error(`ax dojo spar-score: no spar brief at ${briefPath}`);
+                    return Effect.sync(() => process.exit(1)) as Effect.Effect<never>;
+                }),
+            );
+            const brief = parseSparBrief(content);
+            if (brief === null) {
+                console.error(`ax dojo spar-score: could not parse spar brief at ${briefPath}`);
+                return yield* Effect.sync(() => process.exit(1));
+            }
+
+            // brief.worktree is repo-relative; sessions store an absolute cwd, so
+            // resolve it against the current repoRoot for the variant lookup.
+            const { repoRoot } = yield* resolveRepo;
+            const variantCwd = posixPath.join(repoRoot, brief.worktree);
+
+            let variantId: string | null;
+            if (variantSession.length > 0) {
+                variantId = variantSession;
+            } else {
+                variantId = yield* findVariantSession(variantCwd, Date.parse(brief.createdAt));
+            }
+            if (variantId === null) {
+                console.error(
+                    `ax dojo spar-score: no variant session found in ${variantCwd} since ${brief.createdAt} - has the agent run the task in the worktree yet?`,
+                );
+                return yield* Effect.sync(() => process.exit(1));
+            }
+
+            const variant = yield* fetchSessionMetrics(variantId, new Date(brief.createdAt));
+            const score = { ...scoreSpar(brief.baseline, variant), id, variantSession: variantId };
+
+            yield* fs.makeDirectory(dojoSparDir(), { recursive: true });
+            const path = dojoSparReportPath(id);
+            const tmp = `${path}.tmp.${process.pid}`;
+            yield* fs.writeFileString(tmp, renderSparReport(score, brief));
+            yield* fs.rename(tmp, path);
+
+            console.log(json ? prettyPrint(score) : renderSparReport(score, brief));
+        }),
+).pipe(
+    Command.withDescription(
+        "Score the agent's variant session against the frozen baseline and write a receipt to ~/.ax/dojo/spar/<id>-report.md. --variant-session=<id> --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
 // ax dojo (group)
 // ---------------------------------------------------------------------------
 
 export const dojoCommand = Command.make("dojo").pipe(
     Command.withDescription("Dojo training loop: agenda + report + outbox writers"),
-    Command.withSubcommands([agendaCommand, reportCommand, draftCommand, outboxCommand]),
+    Command.withSubcommands([
+        agendaCommand,
+        reportCommand,
+        draftCommand,
+        outboxCommand,
+        sparPlanCommand,
+        sparScoreCommand,
+    ]),
 );
 
 export const dojoRuntime: RuntimeManifest = {
@@ -280,6 +425,8 @@ export const dojoRuntime: RuntimeManifest = {
                 report: "db",
                 draft: "none",
                 outbox: "none",
+                "spar-plan": "db",
+                "spar-score": "db",
             },
         },
         hidden: false,

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -347,21 +347,24 @@ const sparPlanCommand = Command.make(
                 }),
             );
 
+            // Anchor the worktree at the MAIN repo root so the brief's embedded
+            // `git worktree add` command, the console hint, and spar-score's
+            // variant cwd lookup (which joins brief.worktree against the same
+            // main root) all agree on ONE absolute path - no matter which
+            // (possibly linked) worktree the agent runs spar-plan from.
+            const worktreeAbs = posixPath.join(mainRepoRoot, brief.worktree);
+
             const fs = yield* FileSystem.FileSystem;
             yield* fs.makeDirectory(dojoSparDir(), { recursive: true });
             const path = dojoSparBriefPath(brief.id);
             const tmp = `${path}.tmp.${process.pid}`;
-            yield* fs.writeFileString(tmp, renderSparBrief(brief));
+            yield* fs.writeFileString(tmp, renderSparBrief(brief, worktreeAbs));
             yield* fs.rename(tmp, path);
 
             if (json) {
                 console.log(prettyPrint(brief));
                 return;
             }
-            // Anchor the worktree at the MAIN repo root so spar-score (which
-            // joins brief.worktree against the same main root) finds the variant
-            // session's cwd no matter where the agent ran spar-plan from.
-            const worktreeAbs = posixPath.join(mainRepoRoot, brief.worktree);
             const worktreeCmd = `git worktree add ${worktreeAbs} -b dojo/spar-${brief.id} ${brief.parentSha}`;
             console.log(
                 `${path}\n\nNext:\n  ${worktreeCmd}\n  fill the Delta section, run the task in that worktree, then: ax dojo spar-score ${brief.id}`,

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -18,6 +18,7 @@
 import { Effect, FileSystem } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { posixPath } from "@ax/lib/shared/path";
+import { ProcessService } from "@ax/lib/process";
 import { prettyPrint } from "@ax/lib/json";
 import { assembleAgenda, collectAgendaItems } from "../../dojo/agenda.ts";
 import { computeBudgetEnvelope } from "../../dojo/budget.ts";
@@ -283,7 +284,36 @@ const outboxCommand = Command.make(
 // ax dojo spar-plan <sha> - capture + freeze a baseline, emit an experiment brief
 // ---------------------------------------------------------------------------
 
-/** Resolve $PWD to its git repoRoot + repository record key (mirrors `sessions near`). */
+/**
+ * Resolve the MAIN repository root, even when invoked from inside a linked
+ * worktree. `git rev-parse --show-toplevel` (what resolvePwdRepository uses)
+ * returns the LINKED worktree's own toplevel, so a spar worktree path that is
+ * relative to the main repo would double-nest. `--git-common-dir` always points
+ * at the main repo's `.git`; its parent dir is the main repo root. Falls back to
+ * `repoRoot` when there is no linked worktree (or the rev-parse fails).
+ */
+const resolveMainRepoRoot = (repoRoot: string) =>
+    Effect.gen(function* () {
+        const proc = yield* ProcessService;
+        const res = yield* proc.exec("git", ["rev-parse", "--git-common-dir"], {
+            cwd: repoRoot,
+        });
+        const commonDir = res.code === 0 ? res.stdout.trim() : "";
+        if (commonDir.length === 0) return repoRoot;
+        // commonDir is usually absolute (".../<main>/.git") but can be the bare
+        // ".git" relative form when already at the main root.
+        if (commonDir === ".git") return repoRoot;
+        const abs = posixPath.isAbsolute(commonDir)
+            ? commonDir
+            : posixPath.join(repoRoot, commonDir);
+        return posixPath.dirname(abs);
+    });
+
+/**
+ * Resolve $PWD to its git repoRoot + repository record key (mirrors
+ * `sessions near`), plus the MAIN repo root (worktree-aware) used to anchor the
+ * spar worktree path the agent creates.
+ */
 const resolveRepo = Effect.gen(function* () {
     const pwd = yield* resolvePwdRepository().pipe(
         Effect.catchTag("NotAGitRepoError", (err) => {
@@ -291,8 +321,10 @@ const resolveRepo = Effect.gen(function* () {
             return Effect.sync(() => process.exit(1)) as Effect.Effect<never>;
         }),
     );
+    const mainRepoRoot = yield* resolveMainRepoRoot(pwd.repoRoot);
     return {
         repoRoot: pwd.repoRoot,
+        mainRepoRoot,
         repositoryKey: pwd.repositoryRecordId.id as string,
     };
 });
@@ -302,7 +334,7 @@ const sparPlanCommand = Command.make(
     { sha: Argument.string("sha"), json: jsonFlag },
     ({ sha, json }) =>
         Effect.gen(function* () {
-            const { repoRoot, repositoryKey } = yield* resolveRepo;
+            const { repoRoot, mainRepoRoot, repositoryKey } = yield* resolveRepo;
             const brief = yield* captureBaseline(
                 sha,
                 repoRoot,
@@ -326,7 +358,11 @@ const sparPlanCommand = Command.make(
                 console.log(prettyPrint(brief));
                 return;
             }
-            const worktreeCmd = `git worktree add ${brief.worktree} -b dojo/spar-${brief.id} ${brief.parentSha}`;
+            // Anchor the worktree at the MAIN repo root so spar-score (which
+            // joins brief.worktree against the same main root) finds the variant
+            // session's cwd no matter where the agent ran spar-plan from.
+            const worktreeAbs = posixPath.join(mainRepoRoot, brief.worktree);
+            const worktreeCmd = `git worktree add ${worktreeAbs} -b dojo/spar-${brief.id} ${brief.parentSha}`;
             console.log(
                 `${path}\n\nNext:\n  ${worktreeCmd}\n  fill the Delta section, run the task in that worktree, then: ax dojo spar-score ${brief.id}`,
             );
@@ -353,7 +389,7 @@ const sparScoreCommand = Command.make(
             const fs = yield* FileSystem.FileSystem;
             const briefPath = dojoSparBriefPath(id);
             const content = yield* fs.readFileString(briefPath).pipe(
-                Effect.catch(() => {
+                Effect.catchTag("PlatformError", () => {
                     console.error(`ax dojo spar-score: no spar brief at ${briefPath}`);
                     return Effect.sync(() => process.exit(1)) as Effect.Effect<never>;
                 }),
@@ -364,10 +400,11 @@ const sparScoreCommand = Command.make(
                 return yield* Effect.sync(() => process.exit(1));
             }
 
-            // brief.worktree is repo-relative; sessions store an absolute cwd, so
-            // resolve it against the current repoRoot for the variant lookup.
-            const { repoRoot } = yield* resolveRepo;
-            const variantCwd = posixPath.join(repoRoot, brief.worktree);
+            // brief.worktree is relative to the MAIN repo root; sessions store an
+            // absolute cwd, so resolve it against the worktree-aware main root
+            // (not the linked-worktree toplevel, which would double-nest).
+            const { mainRepoRoot } = yield* resolveRepo;
+            const variantCwd = posixPath.join(mainRepoRoot, brief.worktree);
 
             let variantId: string | null;
             if (variantSession.length > 0) {

--- a/apps/axctl/src/dojo/items.ts
+++ b/apps/axctl/src/dojo/items.ts
@@ -86,8 +86,9 @@ export const sparItem = (): DojoItem => ({
     kind: "spar",
     title: "Sparring: one task, one delta, scored (see skill playbook)",
     commands: [
-        "ax sessions here --days=30  # pick a landed task as baseline",
-        "git worktree add .claude/worktrees/dojo-spar <parent-sha>",
+        "ax sessions here --days=30  # pick a landed task; note its commit sha",
+        "ax dojo spar-plan <sha>     # capture baseline + emit the experiment brief",
+        "ax dojo spar-score <id>     # after running the variant in the worktree",
     ],
     success: "spar report appended to the dojo report; goal package updated",
     cost_class: "xl",

--- a/apps/axctl/src/dojo/paths.test.ts
+++ b/apps/axctl/src/dojo/paths.test.ts
@@ -1,6 +1,6 @@
 // apps/axctl/src/dojo/paths.test.ts
 import { describe, expect, test } from "bun:test";
-import { dojoOutboxDir, dojoReportPath, dojoReportsDir } from "./paths.ts";
+import { dojoOutboxDir, dojoReportPath, dojoReportsDir, dojoSparBriefPath, dojoSparDir, dojoSparReportPath } from "./paths.ts";
 
 describe("dojo paths", () => {
     test("derive from an injectable base dir", () => {
@@ -8,6 +8,16 @@ describe("dojo paths", () => {
         expect(dojoReportsDir("/tmp/axhome/.ax/dojo")).toBe("/tmp/axhome/.ax/dojo/reports");
         expect(dojoReportPath("2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
             "/tmp/axhome/.ax/dojo/reports/2026-06-13.md",
+        );
+    });
+
+    test("spar paths derive from an injectable base dir", () => {
+        expect(dojoSparDir("/tmp/axhome/.ax/dojo")).toBe("/tmp/axhome/.ax/dojo/spar");
+        expect(dojoSparBriefPath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
+            "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13.md",
+        );
+        expect(dojoSparReportPath("ab12cd34-2026-06-13", "/tmp/axhome/.ax/dojo")).toBe(
+            "/tmp/axhome/.ax/dojo/spar/ab12cd34-2026-06-13-report.md",
         );
     });
 

--- a/apps/axctl/src/dojo/paths.ts
+++ b/apps/axctl/src/dojo/paths.ts
@@ -10,6 +10,15 @@ export const dojoOutboxDir = (base: string = defaultDojoDir()): string =>
 export const dojoReportsDir = (base: string = defaultDojoDir()): string =>
     posixPath.join(base, "reports");
 
+export const dojoSparDir = (base: string = defaultDojoDir()): string =>
+    posixPath.join(base, "spar");
+
+export const dojoSparBriefPath = (id: string, base: string = defaultDojoDir()): string =>
+    posixPath.join(dojoSparDir(base), `${id}.md`);
+
+export const dojoSparReportPath = (id: string, base: string = defaultDojoDir()): string =>
+    posixPath.join(dojoSparDir(base), `${id}-report.md`);
+
 /** date is YYYY-MM-DD */
 export const dojoReportPath = (date: string, base: string = defaultDojoDir()): string =>
     posixPath.join(dojoReportsDir(base), `${date}.md`);

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -5,11 +5,13 @@ import { SurrealClient } from "@ax/lib/db";
 import { AxConfig, AxConfigTest } from "@ax/lib/config";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
 import {
+    COST_TOL,
     fetchSessionMetrics,
     findVariantSession,
     parseSparBrief,
     renderSparBrief,
     renderSparReport,
+    REPAIR_TOL,
     scoreSpar,
 } from "./spar.ts";
 import type { SparBrief, SparMetrics } from "./spar.ts";
@@ -51,6 +53,21 @@ describe("scoreSpar", () => {
     test("mixed: cheaper but more repair", () => {
         expect(scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.9, repairLines: 80 })).verdict).toBe("mixed");
     });
+    test("tolerances: COST_TOL gates the win, REPAIR_TOL flips win -> mixed", () => {
+        const base = brief.baseline;
+        // cost win inside the COST_TOL noise band -> not a win (mixed)
+        const noise = scoreSpar(base, baseMetrics({ costUsd: base.costUsd! - (COST_TOL / 2) }));
+        expect(noise.verdict).toBe("mixed");
+        // cost win clearly past COST_TOL, repair unchanged -> win
+        const win = scoreSpar(base, baseMetrics({ costUsd: base.costUsd! - (COST_TOL * 4) }));
+        expect(win.verdict).toBe("win");
+        // same clear cost win, but repair past REPAIR_TOL -> mixed (tradeoff)
+        const tradeoff = scoreSpar(base, baseMetrics({
+            costUsd: base.costUsd! - (COST_TOL * 4),
+            repairLines: base.repairLines + REPAIR_TOL + 1,
+        }));
+        expect(tradeoff.verdict).toBe("mixed");
+    });
 });
 
 describe("renderSparBrief / parseSparBrief roundtrip", () => {
@@ -66,6 +83,16 @@ describe("renderSparBrief / parseSparBrief roundtrip", () => {
     });
     test("non-brief content -> null", () => {
         expect(parseSparBrief("nope")).toBeNull();
+    });
+    test("baseline block missing `landed` -> null (no silent landed:undefined)", () => {
+        const md = renderSparBrief(brief);
+        const { landed, ...rest } = brief.baseline;
+        void landed;
+        const stripped = md.replace(
+            /```json baseline\n[\s\S]*?\n```/,
+            "```json baseline\n" + JSON.stringify(rest, null, 2) + "\n```",
+        );
+        expect(parseSparBrief(stripped)).toBeNull();
     });
 });
 
@@ -143,6 +170,42 @@ describe("fetchSessionMetrics", () => {
         expect(m.landed).toBe(true);
         expect(m.repairLines).toBeGreaterThan(0);
         expect(m.episodes).toBeGreaterThan(0);
+    });
+
+    test("clean variant: in produced edge but absent from hotSessions -> landed:true, repair:0", async () => {
+        // Regression guard: a session that landed cleanly (produced a commit,
+        // zero verification failures) is FILTERED OUT of churn.hotSessions by
+        // hasVerificationSignal. landed must come from the produced edge, not
+        // hotSessions - otherwise the best outcome scores as a regression.
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            routes: {
+                "FROM session_token_usage": [[
+                    { session: "session:`clean`", model: "claude", estimated_cost_usd: 0.7 },
+                ]],
+                // churn base scan: clean session has NO verification signal, so
+                // it never appears here (and thus never in hotSessions).
+                "AS session, source\nFROM session": [[]],
+                // produced edge + touched LOC DO carry the clean session.
+                "FROM produced": [[{ session: "session:`clean`", commit: "commit:`cc`" }]],
+                "FROM touched": [[
+                    { commit: "commit:`cc`", file: "file:`f1`", path: "src/a.ts", additions: 9, deletions: 1 },
+                ]],
+                "AS turn_count": [[
+                    { turn_count: 12, s: "2026-06-11T00:00:00.000Z", e: "2026-06-11T00:05:00.000Z" },
+                ]],
+            },
+        });
+
+        const m = await runDb(
+            fetchSessionMetrics("session:`clean`", new Date("2026-06-11T00:00:00.000Z")),
+            tc.layer,
+        );
+        expect(m.landed).toBe(true);
+        expect(m.repairLines).toBe(0);
+        expect(m.episodes).toBe(0);
+        expect(m.costUsd).toBe(0.7);
+        expect(m.turns).toBe(12);
     });
 
     test("null cost + null turn/wall when nothing matches", async () => {

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { parseSparBrief, renderSparBrief, renderSparReport, scoreSpar } from "./spar.ts";
+import type { SparBrief, SparMetrics } from "./spar.ts";
+
+const baseMetrics = (o: Partial<SparMetrics> = {}): SparMetrics => ({
+    costUsd: 1.20,
+    turns: 18,
+    wallMs: 600_000,
+    repairLines: 40,
+    episodes: 3,
+    landed: true,
+    ...o,
+});
+
+const brief: SparBrief = {
+    id: "ab12cd34-2026-06-13",
+    createdAt: "2026-06-13T10:00:00.000Z",
+    prompt: "Add the foo endpoint",
+    parentSha: "ab12cd34",
+    baselineSession: "session:base",
+    worktree: ".claude/worktrees/dojo-spar-ab12cd34-2026-06-13",
+    baseline: baseMetrics(),
+    delta: "skill: tdd ON",
+};
+
+describe("scoreSpar", () => {
+    test("win: cheaper + still landed + repair not worse", () => {
+        const s = scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.80, repairLines: 30 }));
+        expect(s.verdict).toBe("win");
+        expect(s.deltas.costUsd).toBeCloseTo(-0.40, 5);
+        expect(s.deltas.repairLines).toBe(-10);
+    });
+    test("regression: lost landed", () => {
+        expect(scoreSpar(brief.baseline, baseMetrics({ landed: false })).verdict).toBe("regression");
+    });
+    test("regression: clearly costlier", () => {
+        expect(scoreSpar(brief.baseline, baseMetrics({ costUsd: 2.0 })).verdict).toBe("regression");
+    });
+    test("mixed: cheaper but more repair", () => {
+        expect(scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.9, repairLines: 80 })).verdict).toBe("mixed");
+    });
+});
+
+describe("renderSparBrief / parseSparBrief roundtrip", () => {
+    test("brief renders frontmatter + JSON baseline block and parses back", () => {
+        const md = renderSparBrief(brief);
+        expect(md).toContain("# Spar: ab12cd34-2026-06-13");
+        expect(md).toContain("git worktree add");
+        expect(md).toContain(brief.prompt);
+        const parsed = parseSparBrief(md);
+        expect(parsed?.id).toBe(brief.id);
+        expect(parsed?.baseline.costUsd).toBe(1.20);
+        expect(parsed?.parentSha).toBe("ab12cd34");
+    });
+    test("non-brief content -> null", () => {
+        expect(parseSparBrief("nope")).toBeNull();
+    });
+});
+
+describe("renderSparReport", () => {
+    test("receipt table with baseline|variant|delta + verdict", () => {
+        const score = scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.80 }));
+        const md = renderSparReport(score, brief);
+        expect(md).toContain("# Spar report: ab12cd34-2026-06-13");
+        expect(md).toContain("skill: tdd ON");
+        expect(md).toContain("cost");
+        expect(md).toContain("WIN");
+    });
+});

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -81,6 +81,15 @@ describe("renderSparBrief / parseSparBrief roundtrip", () => {
         expect(parsed?.baseline.costUsd).toBe(1.20);
         expect(parsed?.parentSha).toBe("ab12cd34");
     });
+    test("worktreeAbs puts the absolute path in the command but keeps frontmatter relative", () => {
+        const md = renderSparBrief(brief, `/Users/x/ax/${brief.worktree}`);
+        // The command the agent runs must be absolute (so a run from inside a
+        // linked worktree still lands the variant at the main-root path).
+        expect(md).toContain(`git worktree add /Users/x/ax/${brief.worktree} -b dojo/spar-${brief.id}`);
+        // ...but the frontmatter stays relative so spar-score re-joins it.
+        expect(md).toContain(`worktree: ${brief.worktree}`);
+        expect(parseSparBrief(md)?.worktree).toBe(brief.worktree);
+    });
     test("non-brief content -> null", () => {
         expect(parseSparBrief("nope")).toBeNull();
     });

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { parseSparBrief, renderSparBrief, renderSparReport, scoreSpar } from "./spar.ts";
+import { Effect, Layer } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { SurrealClient } from "@ax/lib/db";
+import { AxConfig, AxConfigTest } from "@ax/lib/config";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import {
+    fetchSessionMetrics,
+    findVariantSession,
+    parseSparBrief,
+    renderSparBrief,
+    renderSparReport,
+    scoreSpar,
+} from "./spar.ts";
 import type { SparBrief, SparMetrics } from "./spar.ts";
 
 const baseMetrics = (o: Partial<SparMetrics> = {}): SparMetrics => ({
@@ -65,5 +77,112 @@ describe("renderSparReport", () => {
         expect(md).toContain("skill: tdd ON");
         expect(md).toContain("cost");
         expect(md).toContain("WIN");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Effect glue (fake SurrealClient)
+// ---------------------------------------------------------------------------
+
+// enrichSessions/churn read fan-out width from AxConfig.knobs.
+const configLayer = AxConfigTest({}).pipe(Layer.provide(BunFileSystem.layer));
+
+const runDb = <A>(
+    eff: Effect.Effect<A, unknown, SurrealClient | AxConfig>,
+    layer: Layer.Layer<SurrealClient>,
+): Promise<A> =>
+    Effect.runPromise(eff.pipe(Effect.provide(Layer.mergeAll(layer, configLayer))));
+
+const runDbOnly = <A>(
+    eff: Effect.Effect<A, unknown, SurrealClient>,
+    layer: Layer.Layer<SurrealClient>,
+): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(layer)));
+
+describe("fetchSessionMetrics", () => {
+    test("composes cost + churn + turn/wall for a session", async () => {
+        const since = new Date("2026-06-11T00:00:00.000Z");
+        // routes: cost usage, churn base scan, churn fan-out, and the focused
+        // turn/wall lookup. Unmatched -> [[]] (pricing falls back to built-in).
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            routes: {
+                "FROM session_token_usage": [[
+                    { session: "session:`s1`", model: "claude", estimated_cost_usd: 1.5 },
+                ]],
+                // churn base session scan (selects id AS session, source)
+                "AS session, source\nFROM session": [[
+                    { session: "session:`s1`", source: "codex" },
+                ]],
+                "FROM produced": [[{ session: "session:`s1`", commit: "commit:`c1`" }]],
+                "FROM touched": [[
+                    { commit: "commit:`c1`", file: "file:`f1`", path: "src/a.ts", additions: 13, deletions: 3 },
+                ]],
+                // churn edit events: an initial edit (enables episode opening),
+                // then the repair edit between the failure and its pass.
+                "FROM tool_call": [[
+                    { session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+                    { session: "session:`s1`", ts: "2026-06-11T00:03:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb\nc" }) },
+                ]],
+                // failure opens an episode; the later pass closes it so the
+                // edit between them is classified as repair.
+                "FROM command_outcome": [[
+                    { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", status: "error", command_norm: "tsc" },
+                    { session: "session:`s1`", ts: "2026-06-11T00:04:00.000Z", status: "ok", command_norm: "tsc" },
+                ]],
+                // focused turn/wall lookup
+                "AS turn_count": [[
+                    { turn_count: 21, s: "2026-06-11T00:00:00.000Z", e: "2026-06-11T00:10:00.000Z" },
+                ]],
+            },
+        });
+
+        const m = await runDb(fetchSessionMetrics("session:`s1`", since), tc.layer);
+        expect(m.costUsd).toBe(1.5);
+        expect(m.turns).toBe(21);
+        expect(m.wallMs).toBe(600_000);
+        expect(m.landed).toBe(true);
+        expect(m.repairLines).toBeGreaterThan(0);
+        expect(m.episodes).toBeGreaterThan(0);
+    });
+
+    test("null cost + null turn/wall when nothing matches", async () => {
+        const tc = makeTestSurrealClient({ denyWrites: true });
+        const m = await runDb(
+            fetchSessionMetrics("session:`ghost`", new Date("2026-06-11T00:00:00.000Z")),
+            tc.layer,
+        );
+        expect(m.costUsd).toBeNull();
+        expect(m.turns).toBeNull();
+        expect(m.wallMs).toBeNull();
+        expect(m.repairLines).toBe(0);
+        expect(m.episodes).toBe(0);
+        expect(m.landed).toBe(false);
+    });
+});
+
+describe("findVariantSession", () => {
+    test("returns the most recent bare id; embeds cwd + since literals", async () => {
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            routes: { "FROM session": [[{ id: "session:variant" }]] },
+        });
+        const id = await runDbOnly(
+            findVariantSession("/abs/cwd", Date.parse("2026-06-13T10:00:00.000Z")),
+            tc.layer,
+        );
+        expect(id).toBe("session:variant");
+        const sql = tc.captured[0]!;
+        expect(sql).toContain(`cwd = "/abs/cwd"`);
+        expect(sql).toContain("started_at >=");
+        expect(sql).toContain("ORDER BY started_at DESC LIMIT 1");
+    });
+
+    test("returns null when no variant session exists", async () => {
+        const tc = makeTestSurrealClient({ denyWrites: true });
+        const id = await runDbOnly(
+            findVariantSession("/abs/cwd", Date.now()),
+            tc.layer,
+        );
+        expect(id).toBeNull();
     });
 });

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -156,10 +156,12 @@ describe("fetchSessionMetrics", () => {
                     { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", status: "error", command_norm: "tsc" },
                     { session: "session:`s1`", ts: "2026-06-11T00:04:00.000Z", status: "ok", command_norm: "tsc" },
                 ]],
-                // focused turn/wall lookup
-                "AS turn_count": [[
+                // focused turn/wall lookup: `FROM ONLY` returns the bare object,
+                // so the statement result is `[ {turn_count, s, e} ]` (NOT
+                // doubly-nested - that mismatch hid the rows[0][0] indexing bug).
+                "AS turn_count": [
                     { turn_count: 21, s: "2026-06-11T00:00:00.000Z", e: "2026-06-11T00:10:00.000Z" },
-                ]],
+                ],
             },
         });
 
@@ -191,9 +193,9 @@ describe("fetchSessionMetrics", () => {
                 "FROM touched": [[
                     { commit: "commit:`cc`", file: "file:`f1`", path: "src/a.ts", additions: 9, deletions: 1 },
                 ]],
-                "AS turn_count": [[
+                "AS turn_count": [
                     { turn_count: 12, s: "2026-06-11T00:00:00.000Z", e: "2026-06-11T00:05:00.000Z" },
-                ]],
+                ],
             },
         });
 

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -17,7 +17,7 @@ import { surrealDate, surrealString } from "@ax/lib/shared/surql";
 import { ProcessService, type ProcessError } from "@ax/lib/process";
 import { findCommitWindow } from "@ax/lib/git-window";
 import { fetchSessionCostMap } from "../metrics/cost-estimate.ts";
-import { fetchSessionChurnSummary } from "../metrics/session-churn.ts";
+import { fetchLandedLocBySession, fetchSessionChurnSummary } from "../metrics/session-churn.ts";
 import { cleanSessionId } from "../metrics/util.ts";
 import { listSessionsNear } from "../dashboard/sessions-query.ts";
 
@@ -69,6 +69,11 @@ export interface SparScore {
 // scoreSpar (pure)
 // ---------------------------------------------------------------------------
 
+/** Cost delta (USD) below this magnitude is treated as noise (no win/regression). */
+export const COST_TOL = 0.05;
+/** Repair-line delta above this counts as materially more repair churn. */
+export const REPAIR_TOL = 20;
+
 const sub = (a: number | null, b: number | null): number | null =>
     a == null || b == null ? null : a - b;
 
@@ -87,8 +92,6 @@ export const scoreSpar = (baseline: SparMetrics, variant: SparMetrics): SparScor
         repairLines: variant.repairLines - baseline.repairLines,
         episodes: variant.episodes - baseline.episodes,
     };
-    const REPAIR_TOL = 20; // lines
-    const COST_TOL = 0.05; // usd, ignore noise
     let verdict: SparVerdict;
     if (!variant.landed) {
         verdict = "regression";
@@ -167,6 +170,26 @@ const section = (content: string, heading: string): string => {
     return m?.[1]?.trim() ?? "";
 };
 
+/** Validate a parsed baseline block into SparMetrics, or null on a bad shape. */
+const asBaselineMetrics = (v: unknown): SparMetrics | null => {
+    if (typeof v !== "object" || v === null) return null;
+    const o = v as Record<string, unknown>;
+    const isFiniteNum = (x: unknown): x is number => typeof x === "number" && Number.isFinite(x);
+    // costUsd/turns/wallMs are `number | null`; reject any other type.
+    const okNullable = (x: unknown): x is number | null => x === null || isFiniteNum(x);
+    if (typeof o.landed !== "boolean") return null;
+    if (!isFiniteNum(o.repairLines) || !isFiniteNum(o.episodes)) return null;
+    if (!okNullable(o.costUsd) || !okNullable(o.turns) || !okNullable(o.wallMs)) return null;
+    return {
+        costUsd: o.costUsd,
+        turns: o.turns,
+        wallMs: o.wallMs,
+        repairLines: o.repairLines,
+        episodes: o.episodes,
+        landed: o.landed,
+    };
+};
+
 export const parseSparBrief = (content: string): SparBrief | null => {
     if (!content.startsWith("---")) return null;
     const id = field(content, "id");
@@ -178,12 +201,17 @@ export const parseSparBrief = (content: string): SparBrief | null => {
 
     const blockMatch = BASELINE_BLOCK.exec(content);
     if (!blockMatch?.[1]) return null;
-    let baseline: SparMetrics;
+    let parsed: unknown;
     try {
-        baseline = JSON.parse(blockMatch[1]) as SparMetrics;
+        parsed = JSON.parse(blockMatch[1]);
     } catch {
         return null;
     }
+    // Shape guard: a hand-edited brief missing `landed` (or with the wrong
+    // type) must not slip through as `landed: undefined`, which would silently
+    // score every variant as a regression.
+    const baseline = asBaselineMetrics(parsed);
+    if (baseline === null) return null;
 
     const prompt = section(content, "Task");
     const deltaRaw = section(content, "Delta");
@@ -248,11 +276,18 @@ interface TurnWallRow {
 
 /**
  * Resolve one session's spar metrics: cost (from the shared cost map), repair
- * /episodes/landed (from the churn summary, matched by clean id), and turns +
- * wall (from a focused single-session lookup).
+ * /episodes (from the churn summary), `landed` (from the `produced` edge), and
+ * turns + wall (from a focused single-session lookup).
  *
- * `landed` here is a proxy (landedLinesAdded > 0); captureBaseline overrides it
- * to true (a baseline is, by definition, a landed task).
+ * `landed` MUST come from the produced edge, NOT from `churn.hotSessions`:
+ * hotSessions is gated by `hasVerificationSignal`, so a CLEAN variant (landed,
+ * zero failures/repair) is absent from it - reading landed off hotSessions
+ * would score the best outcome (clean land) as a regression. The produced-edge
+ * query (`fetchLandedLocBySession`) is immune to that gate. repair/episodes
+ * stay on the churn row - absence -> 0 is correct for a clean session.
+ *
+ * Note: this still pulls a full-window churn summary just for repair/episodes
+ * (acceptable v1); only the `landed` signal uses the targeted produced query.
  */
 export const fetchSessionMetrics = (
     sessionId: string,
@@ -265,11 +300,15 @@ export const fetchSessionMetrics = (
         const costMap = yield* fetchSessionCostMap([sessionId]);
         const costUsd = costMap.get(cleanId)?.estimatedCostUsd ?? null;
 
+        // landed: did this session produce a commit? Read straight off the
+        // produced edge (gate-immune), keyed by clean id.
+        const landedLoc = yield* fetchLandedLocBySession([sessionId]);
+        const landed = landedLoc.bySession.has(cleanId);
+
         const churn = yield* fetchSessionChurnSummary({ since: sinceForChurn, limit: 1000 });
         const churnRow = churn.hotSessions.find((r) => r.session === cleanId);
         const repairLines = churnRow?.repairLinesAdded ?? 0;
         const episodes = churnRow?.episodes ?? 0;
-        const landed = (churnRow?.landedLinesAdded ?? 0) > 0;
 
         // turns + wall: count() over the turn_session_seq index + the session's
         // own start/end timestamps (mirrors enrichSessions' indexed lookup).
@@ -294,7 +333,8 @@ export const fetchSessionMetrics = (
  * Capture + freeze a landed task's baseline from the graph.
  *
  * v1 heuristic: within the commit's [predecessor..commit] window, the landed
- * session is the one with the highest turn_count. `landed` is forced true.
+ * session is the one with the highest turn_count. `landed` is forced true (a
+ * baseline is a landed task by construction).
  *
  * Not unit-tested (needs git + a real graph) - covered by the live spar-plan
  * smoke.
@@ -353,6 +393,10 @@ export const captureBaseline = (
         );
 
         const metrics = yield* fetchSessionMetrics(landedSession.id, from);
+        // Belt-and-suspenders: fetchSessionMetrics now derives landed from the
+        // produced edge, but the highest-turn_count session in the window is
+        // not guaranteed to be the exact commit producer. A baseline is a
+        // landed task by construction, so force it true.
         const baseline: SparMetrics = { ...metrics, landed: true };
 
         const id = `${sha.slice(0, 8)}-${nowIso.slice(0, 10)}`;

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -125,8 +125,16 @@ const field = (content: string, key: string): string | null => {
 
 const DELTA_PLACEHOLDER = "FILL: which single change to test";
 
-export const renderSparBrief = (brief: SparBrief): string => {
-    const worktreeCmd = `git worktree add ${brief.worktree} -b dojo/spar-${brief.id} ${brief.parentSha}`;
+export const renderSparBrief = (brief: SparBrief, worktreeAbs?: string): string => {
+    // The agent reads the worktree command FROM THIS FILE, so it must carry the
+    // ABSOLUTE path: `git worktree add <relative>` run from inside a linked
+    // worktree creates the variant at the wrong place, and spar-score (which
+    // joins brief.worktree against the main repo root) then never finds the
+    // variant session's cwd. The frontmatter `worktree:` stays relative-to-main
+    // for that join; only the command line is absolute. Callers without the
+    // main root (pure-render tests) fall back to the relative path.
+    const worktreePath = worktreeAbs ?? brief.worktree;
+    const worktreeCmd = `git worktree add ${worktreePath} -b dojo/spar-${brief.id} ${brief.parentSha}`;
     const delta = brief.delta.trim().length > 0 ? brief.delta : DELTA_PLACEHOLDER;
     return [
         "---",
@@ -232,7 +240,7 @@ const fmtSignedNum = (n: number | null): string =>
 const fmtUsd = (n: number | null): string => (n == null ? "-" : `$${n.toFixed(2)}`);
 
 const fmtSignedUsd = (n: number | null): string =>
-    n == null ? "-" : `${n >= 0 ? "+" : "-"}$${Math.abs(n).toFixed(2)}`;
+    n == null ? "-" : `${n > 0 ? "+" : n < 0 ? "-" : ""}$${Math.abs(n).toFixed(2)}`;
 
 const fmtBool = (b: boolean): string => (b ? "yes" : "no");
 
@@ -305,8 +313,17 @@ export const fetchSessionMetrics = (
         const landedLoc = yield* fetchLandedLocBySession([sessionId]);
         const landed = landedLoc.bySession.has(cleanId);
 
-        const churn = yield* fetchSessionChurnSummary({ since: sinceForChurn, limit: 1000 });
+        const CHURN_SCAN_LIMIT = 1000;
+        const churn = yield* fetchSessionChurnSummary({ since: sinceForChurn, limit: CHURN_SCAN_LIMIT });
         const churnRow = churn.hotSessions.find((r) => r.session === cleanId);
+        // A miss with a saturated scan means the session fell off the top-N by
+        // churn, NOT that it was clean - recording 0 would understate the
+        // baseline and inflate a variant into a false "win". Warn so it's visible.
+        if (churnRow === undefined && churn.hotSessions.length >= CHURN_SCAN_LIMIT) {
+            console.error(
+                `ax dojo spar: baseline session ${cleanId} not in the top-${CHURN_SCAN_LIMIT} churn rows for the window; repair/episodes recorded as 0 (may understate the baseline).`,
+            );
+        }
         const repairLines = churnRow?.repairLinesAdded ?? 0;
         const episodes = churnRow?.episodes ?? 0;
 

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -313,14 +313,18 @@ export const fetchSessionMetrics = (
         // turns + wall: count() over the turn_session_seq index + the session's
         // own start/end timestamps (mirrors enrichSessions' indexed lookup).
         const lit = recordLiteral("session", cleanId);
-        const rows = yield* db.query<[TurnWallRow[]]>(
+        // `FROM ONLY <lit>` returns the bare object (not an array of rows), so
+        // the query result is `[ {turn_count, s, e} ]` - read rows[0] directly.
+        // (Indexing rows[0][0] would step INTO the object and yield undefined,
+        // which previously left turns/wall always null.)
+        const rows = yield* db.query<[TurnWallRow | null]>(
             `SELECT
                 (SELECT count() FROM turn WHERE session = ${lit} GROUP ALL)[0].count AS turn_count,
                 type::string(started_at) AS s,
                 type::string(ended_at) AS e
              FROM ONLY ${lit};`,
         );
-        const row = rows?.[0]?.[0] ?? null;
+        const row = rows?.[0] ?? null;
         const turns = row?.turn_count != null ? Number(row.turn_count) || 0 : null;
         const startMs = row?.s ? Date.parse(row.s) : NaN;
         const endMs = row?.e ? Date.parse(row.e) : NaN;

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -8,6 +8,18 @@
  *
  * Spec: docs/superpowers/specs/2026-06-13-dojo-spar-design.md
  */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { AxConfig } from "@ax/lib/config";
+import type { DbError } from "@ax/lib/errors";
+import { recordLiteral } from "@ax/lib/ids";
+import { surrealDate, surrealString } from "@ax/lib/shared/surql";
+import { ProcessService, type ProcessError } from "@ax/lib/process";
+import { findCommitWindow } from "@ax/lib/git-window";
+import { fetchSessionCostMap } from "../metrics/cost-estimate.ts";
+import { fetchSessionChurnSummary } from "../metrics/session-churn.ts";
+import { cleanSessionId } from "../metrics/util.ts";
+import { listSessionsNear } from "../dashboard/sessions-query.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -223,3 +235,156 @@ export const renderSparReport = (score: SparScore, brief: SparBrief): string => 
         "",
     ].join("\n");
 };
+
+// ---------------------------------------------------------------------------
+// Effect glue: metrics, baseline capture, variant lookup
+// ---------------------------------------------------------------------------
+
+interface TurnWallRow {
+    readonly turn_count: number | null;
+    readonly s: string | null;
+    readonly e: string | null;
+}
+
+/**
+ * Resolve one session's spar metrics: cost (from the shared cost map), repair
+ * /episodes/landed (from the churn summary, matched by clean id), and turns +
+ * wall (from a focused single-session lookup).
+ *
+ * `landed` here is a proxy (landedLinesAdded > 0); captureBaseline overrides it
+ * to true (a baseline is, by definition, a landed task).
+ */
+export const fetchSessionMetrics = (
+    sessionId: string,
+    sinceForChurn: Date,
+): Effect.Effect<SparMetrics, DbError, SurrealClient | AxConfig> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const cleanId = cleanSessionId(sessionId);
+
+        const costMap = yield* fetchSessionCostMap([sessionId]);
+        const costUsd = costMap.get(cleanId)?.estimatedCostUsd ?? null;
+
+        const churn = yield* fetchSessionChurnSummary({ since: sinceForChurn, limit: 1000 });
+        const churnRow = churn.hotSessions.find((r) => r.session === cleanId);
+        const repairLines = churnRow?.repairLinesAdded ?? 0;
+        const episodes = churnRow?.episodes ?? 0;
+        const landed = (churnRow?.landedLinesAdded ?? 0) > 0;
+
+        // turns + wall: count() over the turn_session_seq index + the session's
+        // own start/end timestamps (mirrors enrichSessions' indexed lookup).
+        const lit = recordLiteral("session", cleanId);
+        const rows = yield* db.query<[TurnWallRow[]]>(
+            `SELECT
+                (SELECT count() FROM turn WHERE session = ${lit} GROUP ALL)[0].count AS turn_count,
+                type::string(started_at) AS s,
+                type::string(ended_at) AS e
+             FROM ONLY ${lit};`,
+        );
+        const row = rows?.[0]?.[0] ?? null;
+        const turns = row?.turn_count != null ? Number(row.turn_count) || 0 : null;
+        const startMs = row?.s ? Date.parse(row.s) : NaN;
+        const endMs = row?.e ? Date.parse(row.e) : NaN;
+        const wallMs = Number.isFinite(startMs) && Number.isFinite(endMs) ? endMs - startMs : null;
+
+        return { costUsd, turns, wallMs, repairLines, episodes, landed };
+    });
+
+/**
+ * Capture + freeze a landed task's baseline from the graph.
+ *
+ * v1 heuristic: within the commit's [predecessor..commit] window, the landed
+ * session is the one with the highest turn_count. `landed` is forced true.
+ *
+ * Not unit-tested (needs git + a real graph) - covered by the live spar-plan
+ * smoke.
+ */
+export class SparCaptureError {
+    readonly _tag = "SparCaptureError";
+    constructor(readonly message: string) {}
+}
+
+export const captureBaseline = (
+    sha: string,
+    repoRoot: string,
+    repositoryKey: string | null,
+    nowIso: string,
+): Effect.Effect<
+    SparBrief,
+    DbError | ProcessError | SparCaptureError,
+    SurrealClient | AxConfig | ProcessService
+> =>
+    Effect.gen(function* () {
+        const proc = yield* ProcessService;
+
+        const window = yield* findCommitWindow(repoRoot, sha);
+        if (window.kind === "not_found") {
+            return yield* Effect.fail(new SparCaptureError(`unknown sha ${sha}`));
+        }
+
+        let from: Date;
+        let to: Date;
+        if (window.kind === "orphan") {
+            from = new Date(window.commitTs.getTime() - 3 * 24 * 60 * 60 * 1000);
+            to = new Date(window.commitTs.getTime() + 3 * 24 * 60 * 60 * 1000);
+        } else {
+            from = window.from;
+            to = window.to;
+        }
+
+        // Parent SHA for the worktree pin: `<sha>^` (the predecessor). For an
+        // orphan (root) commit there is no parent, so pin the commit itself.
+        const parentRes = yield* proc.exec("git", ["rev-parse", "--verify", "--quiet", `${sha}^`], {
+            cwd: repoRoot,
+        });
+        const parentSha =
+            parentRes.code === 0 && parentRes.stdout.trim().length > 0
+                ? parentRes.stdout.trim()
+                : sha;
+
+        const sessions = yield* listSessionsNear({ from, to, repositoryKey });
+        if (sessions.length === 0) {
+            return yield* Effect.fail(
+                new SparCaptureError(`no sessions found in the commit window for ${sha}`),
+            );
+        }
+        const landedSession = sessions.reduce((best, s) =>
+            s.turn_count > best.turn_count ? s : best,
+        );
+
+        const metrics = yield* fetchSessionMetrics(landedSession.id, from);
+        const baseline: SparMetrics = { ...metrics, landed: true };
+
+        const id = `${sha.slice(0, 8)}-${nowIso.slice(0, 10)}`;
+        return {
+            id,
+            createdAt: nowIso,
+            prompt: landedSession.first_user_message ?? "",
+            parentSha,
+            baselineSession: landedSession.id,
+            worktree: `.claude/worktrees/dojo-spar-${id}`,
+            baseline,
+            delta: "",
+        };
+    });
+
+/**
+ * Find the most recent variant session run in `cwd` at/after `sinceMs` (the
+ * brief's createdAt). Returns the bare session id, or null when the agent
+ * hasn't run the task yet.
+ */
+export const findVariantSession = (
+    cwd: string,
+    sinceMs: number,
+): Effect.Effect<string | null, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const rows = yield* db.query<[Array<{ id: string }>]>(
+            `SELECT type::string(id) AS id FROM session`
+            + ` WHERE cwd = ${surrealString(cwd)}`
+            + ` AND started_at >= ${surrealDate(new Date(sinceMs))}`
+            + ` ORDER BY started_at DESC LIMIT 1;`,
+        );
+        const id = rows?.[0]?.[0]?.id;
+        return id ? String(id) : null;
+    });

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -423,8 +423,11 @@ export const findVariantSession = (
 ): Effect.Effect<string | null, DbError, SurrealClient> =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
+        // `started_at` must stay in the projection: SurrealDB v3 resolves the
+        // ORDER BY idiom against the SELECT shape, so ordering by a field that
+        // was projected away ("AS id" only) fails to parse.
         const rows = yield* db.query<[Array<{ id: string }>]>(
-            `SELECT type::string(id) AS id FROM session`
+            `SELECT type::string(id) AS id, started_at FROM session`
             + ` WHERE cwd = ${surrealString(cwd)}`
             + ` AND started_at >= ${surrealDate(new Date(sinceMs))}`
             + ` ORDER BY started_at DESC LIMIT 1;`,

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -388,7 +388,14 @@ export const captureBaseline = (
                 new SparCaptureError(`no sessions found in the commit window for ${sha}`),
             );
         }
-        const landedSession = sessions.reduce((best, s) =>
+        // The baseline must be a MAIN session: subagent sessions
+        // (source="claude-subagent") rack up high turn_counts by design and would
+        // win the highest-turn_count reduce, yielding a bogus baseline (no real
+        // first_user_message, null turns/wall). Prefer main sessions; fall back
+        // to the unfiltered list only when the window has no main session at all.
+        const mainSessions = sessions.filter((s) => s.source === "claude");
+        const candidates = mainSessions.length > 0 ? mainSessions : sessions;
+        const landedSession = candidates.reduce((best, s) =>
             s.turn_count > best.turn_count ? s : best,
         );
 

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -1,0 +1,225 @@
+/**
+ * ax dojo spar - replay benchmark.
+ *
+ * Pure cores (scoreSpar, renderSparBrief/parseSparBrief, renderSparReport) are
+ * fully unit-tested. The Effect glue (captureBaseline, findVariantSession,
+ * fetchSessionMetrics) composes existing query functions and is tested with a
+ * fake SurrealClient + a live spar-plan smoke.
+ *
+ * Spec: docs/superpowers/specs/2026-06-13-dojo-spar-design.md
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SparMetrics {
+    readonly costUsd: number | null;
+    readonly turns: number | null;
+    readonly wallMs: number | null;
+    readonly repairLines: number;
+    readonly episodes: number;
+    readonly landed: boolean;
+}
+
+export interface SparBrief {
+    readonly id: string;
+    readonly createdAt: string;
+    readonly prompt: string;
+    readonly parentSha: string;
+    readonly baselineSession: string;
+    readonly worktree: string;
+    readonly baseline: SparMetrics;
+    /** filled by the agent; "" at plan time */
+    readonly delta: string;
+}
+
+export type SparVerdict = "win" | "regression" | "mixed";
+
+export interface SparDeltas {
+    readonly costUsd: number | null;
+    readonly turns: number | null;
+    readonly wallMs: number | null;
+    readonly repairLines: number;
+    readonly episodes: number;
+}
+
+export interface SparScore {
+    readonly id: string;
+    readonly variantSession: string;
+    readonly baseline: SparMetrics;
+    readonly variant: SparMetrics;
+    readonly deltas: SparDeltas;
+    readonly verdict: SparVerdict;
+}
+
+// ---------------------------------------------------------------------------
+// scoreSpar (pure)
+// ---------------------------------------------------------------------------
+
+const sub = (a: number | null, b: number | null): number | null =>
+    a == null || b == null ? null : a - b;
+
+/**
+ * Compute deltas + verdict from baseline/variant metrics. The caller (score
+ * command) fills `id`/`variantSession`.
+ *
+ * Verdict: primary axis is "did it still land, and is spend lower without more
+ * repair".
+ */
+export const scoreSpar = (baseline: SparMetrics, variant: SparMetrics): SparScore => {
+    const deltas: SparDeltas = {
+        costUsd: sub(variant.costUsd, baseline.costUsd),
+        turns: sub(variant.turns, baseline.turns),
+        wallMs: sub(variant.wallMs, baseline.wallMs),
+        repairLines: variant.repairLines - baseline.repairLines,
+        episodes: variant.episodes - baseline.episodes,
+    };
+    const REPAIR_TOL = 20; // lines
+    const COST_TOL = 0.05; // usd, ignore noise
+    let verdict: SparVerdict;
+    if (!variant.landed) {
+        verdict = "regression";
+    } else {
+        const cheaper = deltas.costUsd != null && deltas.costUsd < -COST_TOL;
+        const costlier = deltas.costUsd != null && deltas.costUsd > COST_TOL;
+        const moreRepair = deltas.repairLines > REPAIR_TOL;
+        // win: clearly cheaper without paying it back in repair churn.
+        if (cheaper && !moreRepair) verdict = "win";
+        // regression: clearly costlier, or no cost win to offset worse repair.
+        else if (costlier || (moreRepair && !cheaper)) verdict = "regression";
+        // mixed: a genuine tradeoff (e.g. cheaper but more repair, or noise).
+        else verdict = "mixed";
+    }
+    return { id: "", variantSession: "", baseline, variant, deltas, verdict };
+};
+
+// ---------------------------------------------------------------------------
+// brief render/parse (pure)
+// ---------------------------------------------------------------------------
+
+/** Collapse CR/LF to a space so an interpolated value can't break its line. */
+const oneLine = (v: string): string => v.replace(/[\r\n]/g, " ");
+
+/** Mirror of outbox.ts's frontmatter field reader. */
+const field = (content: string, key: string): string | null => {
+    const m = new RegExp(`^${key}:[^\\S\\n]*(.*)$`, "m").exec(content);
+    const v = m?.[1]?.trim();
+    return v && v.length > 0 ? v : null;
+};
+
+const DELTA_PLACEHOLDER = "FILL: which single change to test";
+
+export const renderSparBrief = (brief: SparBrief): string => {
+    const worktreeCmd = `git worktree add ${brief.worktree} -b dojo/spar-${brief.id} ${brief.parentSha}`;
+    const delta = brief.delta.trim().length > 0 ? brief.delta : DELTA_PLACEHOLDER;
+    return [
+        "---",
+        `id: ${oneLine(brief.id)}`,
+        `created_at: ${oneLine(brief.createdAt)}`,
+        `parent_sha: ${oneLine(brief.parentSha)}`,
+        `baseline_session: ${oneLine(brief.baselineSession)}`,
+        `worktree: ${oneLine(brief.worktree)}`,
+        "---",
+        "",
+        `# Spar: ${brief.id}`,
+        "",
+        "## Task",
+        "",
+        brief.prompt,
+        "",
+        "## Worktree",
+        "",
+        "```bash",
+        worktreeCmd,
+        "```",
+        "",
+        "## Baseline",
+        "",
+        "```json baseline",
+        JSON.stringify(brief.baseline, null, 2),
+        "```",
+        "",
+        "## Delta",
+        "",
+        delta,
+        "",
+    ].join("\n");
+};
+
+const BASELINE_BLOCK = /```json baseline\n([\s\S]*?)\n```/;
+
+const section = (content: string, heading: string): string => {
+    const re = new RegExp(`^## ${heading}\\n([\\s\\S]*?)(?=\\n## |$)`, "m");
+    const m = re.exec(content);
+    return m?.[1]?.trim() ?? "";
+};
+
+export const parseSparBrief = (content: string): SparBrief | null => {
+    if (!content.startsWith("---")) return null;
+    const id = field(content, "id");
+    const createdAt = field(content, "created_at");
+    const parentSha = field(content, "parent_sha");
+    const baselineSession = field(content, "baseline_session");
+    const worktree = field(content, "worktree");
+    if (!id || !createdAt || !parentSha || !baselineSession || !worktree) return null;
+
+    const blockMatch = BASELINE_BLOCK.exec(content);
+    if (!blockMatch?.[1]) return null;
+    let baseline: SparMetrics;
+    try {
+        baseline = JSON.parse(blockMatch[1]) as SparMetrics;
+    } catch {
+        return null;
+    }
+
+    const prompt = section(content, "Task");
+    const deltaRaw = section(content, "Delta");
+    const delta = deltaRaw === DELTA_PLACEHOLDER ? "" : deltaRaw;
+
+    return { id, createdAt, prompt, parentSha, baselineSession, worktree, baseline, delta };
+};
+
+// ---------------------------------------------------------------------------
+// report render (pure)
+// ---------------------------------------------------------------------------
+
+const fmtNum = (n: number | null): string => (n == null ? "-" : `${n}`);
+
+const fmtSignedNum = (n: number | null): string =>
+    n == null ? "-" : n > 0 ? `+${n}` : `${n}`;
+
+const fmtUsd = (n: number | null): string => (n == null ? "-" : `$${n.toFixed(2)}`);
+
+const fmtSignedUsd = (n: number | null): string =>
+    n == null ? "-" : `${n >= 0 ? "+" : "-"}$${Math.abs(n).toFixed(2)}`;
+
+const fmtBool = (b: boolean): string => (b ? "yes" : "no");
+
+export const renderSparReport = (score: SparScore, brief: SparBrief): string => {
+    const { baseline, variant, deltas, verdict } = score;
+    const rows: ReadonlyArray<readonly [string, string, string, string]> = [
+        ["cost", fmtUsd(baseline.costUsd), fmtUsd(variant.costUsd), fmtSignedUsd(deltas.costUsd)],
+        ["turns", fmtNum(baseline.turns), fmtNum(variant.turns), fmtSignedNum(deltas.turns)],
+        ["wall (ms)", fmtNum(baseline.wallMs), fmtNum(variant.wallMs), fmtSignedNum(deltas.wallMs)],
+        ["repair", `${baseline.repairLines}`, `${variant.repairLines}`, fmtSignedNum(deltas.repairLines)],
+        ["episodes", `${baseline.episodes}`, `${variant.episodes}`, fmtSignedNum(deltas.episodes)],
+        ["landed", fmtBool(baseline.landed), fmtBool(variant.landed), "-"],
+    ];
+    const table = [
+        "| metric | baseline | variant | delta |",
+        "| --- | --- | --- | --- |",
+        ...rows.map(([m, b, v, d]) => `| ${m} | ${b} | ${v} | ${d} |`),
+    ].join("\n");
+
+    return [
+        `# Spar report: ${brief.id}`,
+        "",
+        `delta tested: ${brief.delta.trim().length > 0 ? brief.delta : "(none)"}`,
+        "",
+        table,
+        "",
+        `verdict: **${verdict.toUpperCase()}**`,
+        "",
+    ].join("\n");
+};

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -308,7 +308,7 @@ ${where};`))?.[0] ?? [];
         });
     });
 
-const fetchLandedLocBySession = (
+export const fetchLandedLocBySession = (
     sessionIds: readonly string[],
 ): Effect.Effect<LandedLoc, DbError, SurrealClient> =>
     Effect.gen(function* () {

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -39,6 +39,8 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax dojo report [--since=<iso>] [--notes-file=<path>] [--json]` - write the morning report for a completed dojo run: budget envelope, per-lap item log, proposals created, verdicts locked, outbox drafts awaiting review.
 - `ax dojo draft [--title=<t>] [--kind=bug|improvement] [--body-file=<path>] [--session=<id>]` - stage an upstream finding (ax bug or improvement discovered during training) to `~/.ax/dojo/outbox/<slug>.md`; never publishes - user reviews and publishes via ax-repo skill / gh.
 - `ax dojo outbox [--json]` - list staged upstream issue drafts in `~/.ax/dojo/outbox/`.
+- `ax dojo spar-plan <sha> [--json]` - capture a landed task's baseline (prompt + cost/turns/churn) and emit a one-delta experiment brief to `~/.ax/dojo/spar/<id>.md`; prints the `git worktree add` command that pins the parent SHA.
+- `ax dojo spar-score <id> [--variant-session=<id>] [--json]` - score the agent's variant session against the frozen baseline; auto-discovers the variant session from the worktree cwd or accepts an explicit id; writes the receipt to `~/.ax/dojo/spar/<id>-report.md`.
 
 ### Profile
 - `ax profile show [--window=N] [--no-cost]` - your local agent profile rendered from the graph: usage stats, rig (skills/hooks/rules), and evidence-grounded taste patterns

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,6 +38,8 @@ axctl dojo agenda [--json|--spar|--budget=N|--until=HH:MM|--force|--days=N]  # t
 axctl dojo report [--since=<iso>] [--notes-file=<path>] [--json]      # write the morning report for a completed dojo run
 axctl dojo draft [--title=<t>] [--kind=bug|improvement] [--body-file=<path>] [--session=<id>]  # stage an upstream finding to ~/.ax/dojo/outbox/<slug>.md (never publishes)
 axctl dojo outbox [--json]                                            # list staged upstream issue drafts
+axctl dojo spar-plan <sha> [--json]                              # capture a landed task's baseline + emit a one-delta experiment brief
+axctl dojo spar-score <id> [--variant-session=<id>] [--json]     # score the agent's variant vs the frozen baseline
 axctl dispatches [--candidates]             # subagent dispatch routing analytics + est savings
 axctl routing tune [--dry-run|--emit-brief] # mine YOUR dispatch history for new routing classes
 axctl routing compile                       # regenerate ~/.ax/hooks/routing-table.json (user classes preserved)

--- a/docs/superpowers/plans/2026-06-13-dojo-spar.md
+++ b/docs/superpowers/plans/2026-06-13-dojo-spar.md
@@ -1,0 +1,267 @@
+# ax dojo spar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Ship `ax dojo spar-plan <sha>` (capture + freeze a baseline, emit an experiment brief) and `ax dojo spar-score <id>` (score the agent's variant against the frozen baseline, write a receipt), per spec `docs/superpowers/specs/2026-06-13-dojo-spar-design.md`. Hybrid: CLI scaffolds, agent runs the re-run.
+
+**Architecture:** Pure cores (scoreSpar, brief render/parse, report render) unit-tested; Effect glue (baseline capture, variant lookup, metric fetch) composes existing query functions (`findCommitWindow`, `listSessionsNear`, `fetchSessionCostMap`, `fetchSessionChurnSummary`), tested with fakes + a live `spar-plan` smoke. Two flat subcommands in the `ax dojo` family.
+
+**Tech Stack:** bun ≥1.3, TS strict, Effect v4 beta (`effect/unstable/cli`), bun:test, SurrealDB via `SurrealClient`.
+
+**Conventions:** Worktree `/Users/necmttn/Projects/ax/.claude/worktrees/dojo-spar`. Test = `bun test <path>` (tmp wrapper if a hook blocks bare `bun test`). Datetime via `surrealDate()`/`surrealString()` from `@ax/lib/shared/surql`. FileSystem via `import { Effect, FileSystem } from "effect"` + `FileSystem.FileSystem`. Atomic writes tmp+rename (see `apps/axctl/src/dojo/outbox.ts`). Commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+**Decision: flat subcommands.** `ax dojo spar-plan` / `ax dojo spar-score` (more leaf commands in the existing dojo family - same shape as agenda/report/draft/outbox). Avoids 2-level CLI nesting.
+
+**Grounding facts (verified):**
+- `findCommitWindow(repoRoot, sha)` → `{ kind: "window", from: Date, to: Date } | { kind: "orphan", commitTs } | { kind: "not_found" }` + the parent SHA (`packages/lib/src/git-window.ts:22`; read it for the exact parent-SHA field - it runs `git log -1 --format=%aI <sha>^`). Requires `ProcessService`.
+- `listSessionsNear({ from, to, repositoryKey? })` → `SessionRow[]` with `id, started_at, ended_at, source, project, cwd, repository, turn_count, first_user_message` (`apps/axctl/src/dashboard/sessions-query.ts:281`; SessionRow at :17). Requires `SurrealClient | AxConfig`.
+- `fetchSessionCostMap([id])` → `Map<id, { model, estimatedCostUsd, pricingSource, estimated }>` (`apps/axctl/src/metrics/cost-estimate.ts:168`). estimatedCostUsd is the spend axis.
+- `fetchSessionChurnSummary({ since?, project?, source?, limit })` → `SessionChurnSummary` with `rows: SessionChurnRow[]` (`session, landedLinesAdded, repairLinesAdded, episodes, passedEpisodes, ...`, `apps/axctl/src/metrics/session-churn.ts:264`, row type :32). Filter the matching session in JS.
+- dojo paths: `defaultDojoDir`, `dojoReportsDir` (`apps/axctl/src/dojo/paths.ts`). dojo CLI family + db-conditional manifest (`apps/axctl/src/cli/commands/dojo.ts`). sparItem (`apps/axctl/src/dojo/items.ts`).
+- repoRoot resolution: how `ax sessions near` gets repoRoot + repositoryKey - read `apps/axctl/src/cli/commands/sessions.ts:285` (cmdSessionsNear) and mirror it.
+
+---
+
+### Task 1: spar paths + pure cores
+
+**Files:** Modify `apps/axctl/src/dojo/paths.ts`; create `apps/axctl/src/dojo/spar.ts`, `apps/axctl/src/dojo/spar.test.ts`
+
+- [ ] **Step 1: paths** - add to paths.ts:
+
+```ts
+export const dojoSparDir = (base: string = defaultDojoDir()): string =>
+    posixPath.join(base, "spar");
+export const dojoSparBriefPath = (id: string, base: string = defaultDojoDir()): string =>
+    posixPath.join(dojoSparDir(base), `${id}.md`);
+export const dojoSparReportPath = (id: string, base: string = defaultDojoDir()): string =>
+    posixPath.join(dojoSparDir(base), `${id}-report.md`);
+```
+Add a paths.test.ts case mirroring the existing ones (injectable base → spar/<id>.md, spar/<id>-report.md).
+
+- [ ] **Step 2: failing test** for the pure cores:
+
+```ts
+// apps/axctl/src/dojo/spar.test.ts
+import { describe, expect, test } from "bun:test";
+import { parseSparBrief, renderSparBrief, renderSparReport, scoreSpar } from "./spar.ts";
+import type { SparBrief, SparMetrics } from "./spar.ts";
+
+const baseMetrics = (o: Partial<SparMetrics> = {}): SparMetrics => ({
+    costUsd: 1.20, turns: 18, wallMs: 600_000, repairLines: 40, episodes: 3, landed: true, ...o,
+});
+
+const brief: SparBrief = {
+    id: "ab12cd34-2026-06-13",
+    createdAt: "2026-06-13T10:00:00.000Z",
+    prompt: "Add the foo endpoint",
+    parentSha: "ab12cd34",
+    baselineSession: "session:base",
+    worktree: ".claude/worktrees/dojo-spar-ab12cd34-2026-06-13",
+    baseline: baseMetrics(),
+    delta: "skill: tdd ON",
+};
+
+describe("scoreSpar", () => {
+    test("win: cheaper + still landed + repair not worse", () => {
+        const s = scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.80, repairLines: 30 }));
+        expect(s.verdict).toBe("win");
+        expect(s.deltas.costUsd).toBeCloseTo(-0.40, 5);
+        expect(s.deltas.repairLines).toBe(-10);
+    });
+    test("regression: lost landed", () => {
+        expect(scoreSpar(brief.baseline, baseMetrics({ landed: false })).verdict).toBe("regression");
+    });
+    test("regression: clearly costlier", () => {
+        expect(scoreSpar(brief.baseline, baseMetrics({ costUsd: 2.0 })).verdict).toBe("regression");
+    });
+    test("mixed: cheaper but more repair", () => {
+        expect(scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.9, repairLines: 80 })).verdict).toBe("mixed");
+    });
+});
+
+describe("renderSparBrief / parseSparBrief roundtrip", () => {
+    test("brief renders frontmatter + JSON baseline block and parses back", () => {
+        const md = renderSparBrief(brief);
+        expect(md).toContain("# Spar: ab12cd34-2026-06-13");
+        expect(md).toContain("git worktree add");
+        expect(md).toContain(brief.prompt);
+        const parsed = parseSparBrief(md);
+        expect(parsed?.id).toBe(brief.id);
+        expect(parsed?.baseline.costUsd).toBe(1.20);
+        expect(parsed?.parentSha).toBe("ab12cd34");
+    });
+    test("non-brief content -> null", () => {
+        expect(parseSparBrief("nope")).toBeNull();
+    });
+});
+
+describe("renderSparReport", () => {
+    test("receipt table with baseline|variant|delta + verdict", () => {
+        const score = scoreSpar(brief.baseline, baseMetrics({ costUsd: 0.80 }));
+        const md = renderSparReport(score, brief);
+        expect(md).toContain("# Spar report: ab12cd34-2026-06-13");
+        expect(md).toContain("skill: tdd ON");
+        expect(md).toContain("cost");
+        expect(md).toContain("WIN");
+    });
+});
+```
+
+- [ ] **Step 3: implement** - types + pure fns.
+
+```ts
+// apps/axctl/src/dojo/spar.ts  (pure portion)
+export interface SparMetrics {
+    readonly costUsd: number | null;
+    readonly turns: number | null;
+    readonly wallMs: number | null;
+    readonly repairLines: number;
+    readonly episodes: number;
+    readonly landed: boolean;
+}
+export interface SparBrief {
+    readonly id: string;
+    readonly createdAt: string;
+    readonly prompt: string;
+    readonly parentSha: string;
+    readonly baselineSession: string;
+    readonly worktree: string;
+    readonly baseline: SparMetrics;
+    readonly delta: string;       // filled by the agent; "" at plan time
+}
+export type SparVerdict = "win" | "regression" | "mixed";
+export interface SparScore {
+    readonly id: string;
+    readonly variantSession: string;
+    readonly baseline: SparMetrics;
+    readonly variant: SparMetrics;
+    readonly deltas: { readonly costUsd: number | null; readonly turns: number | null; readonly wallMs: number | null; readonly repairLines: number; readonly episodes: number };
+    readonly verdict: SparVerdict;
+}
+
+const sub = (a: number | null, b: number | null): number | null =>
+    a == null || b == null ? null : a - b;
+
+export const scoreSpar = (baseline: SparMetrics, variant: SparMetrics): SparScore["deltas"] extends never ? never : SparScore => {
+    const deltas = {
+        costUsd: sub(variant.costUsd, baseline.costUsd),
+        turns: sub(variant.turns, baseline.turns),
+        wallMs: sub(variant.wallMs, baseline.wallMs),
+        repairLines: variant.repairLines - baseline.repairLines,
+        episodes: variant.episodes - baseline.episodes,
+    };
+    // verdict: primary axis is "did it still land, and is spend lower without more repair".
+    const REPAIR_TOL = 20;       // lines
+    const COST_TOL = 0.05;       // usd, ignore noise
+    let verdict: SparVerdict;
+    if (!variant.landed) {
+        verdict = "regression";
+    } else {
+        const cheaper = deltas.costUsd != null && deltas.costUsd < -COST_TOL;
+        const costlier = deltas.costUsd != null && deltas.costUsd > COST_TOL;
+        const moreRepair = deltas.repairLines > REPAIR_TOL;
+        if (cheaper && !moreRepair) verdict = "win";
+        else if (costlier || moreRepair) verdict = "regression";
+        else verdict = "mixed";
+    }
+    return { id: "", variantSession: "", baseline, variant, deltas, verdict } as SparScore;
+};
+```
+(Note: drop the contrived conditional return type - declare `scoreSpar = (baseline, variant): SparScore` plainly. The `id`/`variantSession` are filled by the caller in the score command; scoreSpar computes deltas+verdict from metrics only.)
+
+`renderSparBrief(brief)`: frontmatter (`id`, `created_at`, `parent_sha`, `baseline_session`, `worktree`) + a `## Task` prompt block + the `git worktree add .claude/worktrees/dojo-spar-<id> -b dojo/spar-<id> <parentSha>` command in a fenced block + a fenced ```json baseline``` block (JSON.stringify(brief.baseline)) + a `## Delta` section with the brief.delta (or a "FILL: which single change to test" placeholder when empty).
+`parseSparBrief(content)`: require the frontmatter + a ```json baseline``` block; extract id/parent_sha/worktree/baseline_session from frontmatter (reuse the field() helper pattern from outbox.ts), JSON.parse the baseline block, read the prompt + delta sections; return null if the json block or required fields are missing.
+`renderSparReport(score, brief)`: `# Spar report: <id>`, the tested `delta`, a markdown table with rows cost/turns/wall/repair/episodes/landed and columns baseline|variant|delta, and the verdict in caps (WIN/REGRESSION/MIXED).
+
+- [ ] **Step 4: run -> PASS** (paths + spar pure tests)
+- [ ] **Step 5: commit** `feat(dojo): spar paths + pure cores (score, brief, report)`
+
+---
+
+### Task 2: spar Effect glue (metrics, baseline capture, variant lookup)
+
+**Files:** Modify `apps/axctl/src/dojo/spar.ts`, `apps/axctl/src/dojo/spar.test.ts`
+
+READ FIRST: `apps/axctl/src/cli/commands/sessions.ts:285` (cmdSessionsNear - repoRoot + repositoryKey resolution + findCommitWindow usage), `apps/axctl/src/dashboard/sessions-query.ts` (listSessionsNear + SessionRow + enrichSessions), `apps/axctl/src/metrics/cost-estimate.ts:168`, `apps/axctl/src/metrics/session-churn.ts:264`, `apps/axctl/src/improve/show.test.ts` (fake client).
+
+- [ ] **Step 1: implement `fetchSessionMetrics(sessionId, sinceForChurn)`** → `Effect<SparMetrics, DbError, SurrealClient | AxConfig>`:
+  - cost: `fetchSessionCostMap([sessionId])` → entry.estimatedCostUsd.
+  - churn: `fetchSessionChurnSummary({ since: sinceForChurn, limit: 1000 })` → `rows.find(r => r.session === cleanId)`; repairLines = repairLinesAdded, episodes, landed = landedLinesAdded > 0 (proxy; baseline overrides to true).
+  - turns + wall: a focused session-row query (`SELECT turn_count?, type::string(started_at) AS s, type::string(ended_at) AS e FROM <id>`) OR reuse a single-session enrich. Read SessionRow/enrichSessions to get turn_count; wallMs = ended−started when both present, else null.
+
+- [ ] **Step 2: implement `captureBaseline(sha, repoRoot, nowIso)`** → `Effect<SparBrief, ..., ProcessService | SurrealClient | AxConfig>`:
+  - `findCommitWindow(repoRoot, sha)`; on `not_found` fail cleanly; get parentSha + window.
+  - `listSessionsNear({ from, to, repositoryKey })`; pick the landed session = the in-window session with the highest `turn_count` (v1 heuristic per spec).
+  - prompt = session.first_user_message ?? "".
+  - baseline = fetchSessionMetrics(session.id, from) with landed forced true.
+  - id = `${sha.slice(0,8)}-${nowIso.slice(0,10)}`; worktree = `.claude/worktrees/dojo-spar-${id}`; delta = "".
+  - return the SparBrief.
+
+- [ ] **Step 3: implement `findVariantSession(cwd, sinceMs)`** → `Effect<string | null, DbError, SurrealClient>`:
+  `SELECT type::string(id) AS id FROM session WHERE cwd = ${surrealString(cwd)} AND started_at >= ${surrealDate(new Date(sinceMs))} ORDER BY started_at DESC LIMIT 1;` → id or null.
+
+- [ ] **Step 4: tests** - `fetchSessionMetrics` + `findVariantSession` with the fake client (fixtures for the cost map, churn rows, session row, and the variant lookup). `captureBaseline` end-to-end is covered by the live smoke in Task 3 (it needs git + the real graph); state this. Run `bun test apps/axctl/src/dojo/spar.test.ts` + `bun run typecheck`.
+
+- [ ] **Step 5: commit** `feat(dojo): spar baseline capture + variant lookup + metrics`
+
+---
+
+### Task 3: CLI spar-plan / spar-score + sparItem wiring + smoke
+
+**Files:** Modify `apps/axctl/src/cli/commands/dojo.ts`, `apps/axctl/src/dojo/items.ts`
+
+READ FIRST: dojo.ts (the family: agendaCommand/reportCommand/draftCommand/outboxCommand, db-conditional manifest, atomic write helper, QuotaEnvLive provision pattern), `apps/axctl/src/cli/commands/sessions.ts` (repoRoot resolution for `near`).
+
+- [ ] **Step 1: sparPlanCommand** = `Command.make("spar-plan", { sha: Argument.string("sha"), json: jsonFlag }, handler)`. Handler: resolve repoRoot (mirror cmdSessionsNear), `captureBaseline(sha, repoRoot, nowIso)`, write `dojoSparBriefPath(brief.id)` atomically (mkdir spar dir recursive), `console.log(json ? prettyPrint(brief) : "<path>\n\nNext: " + the worktree command + "\n  then fill the Delta section, run the task, and `ax dojo spar-score " + brief.id + "`")`. Clean nonzero exit when the commit window has no sessions.
+
+- [ ] **Step 2: sparScoreCommand** = `Command.make("spar-score", { id: Argument.string("id"), variantSession: Flag.string("variant-session").withDefault(""), json: jsonFlag }, handler)`. Handler: read+parse `dojoSparBriefPath(id)` (fail cleanly if missing/unparseable); resolve variant session (explicit `--variant-session`, else `findVariantSession(brief.worktree-as-abs-cwd, Date.parse(brief.createdAt))`); fail cleanly with a helpful message if none ("no variant session found in <cwd> since <createdAt> - has the agent run the task?"); `fetchSessionMetrics(variantId, brief.createdAt-as-Date)`; `const score = { ...scoreSpar(brief.baseline, variant), id, variantSession: variantId }`; write `dojoSparReportPath(id)` atomically; `console.log(json ? prettyPrint(score) : renderSparReport(score, brief))`.
+  - NOTE: brief.worktree is repo-relative; resolve to abs via repoRoot for the cwd match (sessions store absolute cwd). Mirror repoRoot resolution.
+
+- [ ] **Step 3: register** both in the dojo family `withSubcommands([...])` and extend the db-conditional manifest subcommands map: `"spar-plan": "db", "spar-score": "db"`.
+
+- [ ] **Step 4: sparItem wiring** - in `apps/axctl/src/dojo/items.ts`, update `sparItem()`'s commands to the real flow:
+  ```
+  commands: [
+    "ax sessions here --days=30  # pick a landed task; note its commit sha",
+    "ax dojo spar-plan <sha>     # capture baseline + emit the experiment brief",
+    "ax dojo spar-score <id>     # after running the variant in the worktree",
+  ]
+  ```
+  Update the existing sparItem test in items.test.ts accordingly (keep kind/cost_class assertions).
+
+- [ ] **Step 5: tests + smoke**
+  - `bun test apps/axctl/src/dojo/items.test.ts apps/axctl/src/cli/commands/dojo.test.ts apps/axctl/src/cli/effect-cli.test.ts` → pass.
+  - Live smoke (DB up; run inside the ax repo so git + sessions resolve): pick a recent real commit - `git log --oneline -5` - and `bun apps/axctl/src/cli/index.ts dojo spar-plan <recent-sha> --json` → a SparBrief with a real prompt + baseline metrics (proves findCommitWindow + listSessionsNear + metric fetch all wire up). Confirm `~/.ax/dojo/spar/<id>.md` written. PASTE output. (spar-score needs an actual variant run - smoke it only as far as "missing variant → clean error": `bun apps/axctl/src/cli/index.ts dojo spar-score <id-from-plan>` with no variant present → the helpful "no variant session found" message + nonzero exit.)
+  - `bun apps/axctl/src/cli/index.ts dojo spar-plan deadbeef` (bad sha) → clean not-found error.
+  Clean up the smoke brief afterward (`trash ~/.ax/dojo/spar/<id>.md`).
+- [ ] **Step 6: commit** `feat(cli): ax dojo spar-plan + spar-score + sparItem wiring`
+
+---
+
+### Task 4: docs + SKILL.md
+
+**Files:** Modify `docs/cli.md`, `apps/site/public/llms.txt`, `CLAUDE.md`, `skills/dojo/SKILL.md`
+
+- [ ] **Step 1** docs/cli.md - add under the dojo family:
+```
+axctl dojo spar-plan <sha> [--json]            # capture a landed task's baseline + emit a one-delta experiment brief
+axctl dojo spar-score <id> [--variant-session=<id>|--json]   # score the agent's variant vs the frozen baseline
+```
+- [ ] **Step 2** llms.txt - add a bullet for the spar pair near the dojo entries.
+- [ ] **Step 3** CLAUDE.md "### Dojo" - append: "`ax dojo spar-plan <sha>` freezes a landed task's baseline (prompt + cost/turns/churn) and emits a brief with the worktree pin command + a delta slot; the agent runs the variant with ONE change; `ax dojo spar-score <id>` scores variant vs baseline into a receipt (`~/.ax/dojo/spar/`). Hybrid: CLI scaffolds, agent re-runs."
+- [ ] **Step 4** skills/dojo/SKILL.md - rewrite the **spar** playbook to the concrete flow: pick a landed task (`ax sessions here`), `ax dojo spar-plan <sha>`, read the brief, run `git worktree add` at the parent SHA, apply exactly ONE delta, do the task, then `ax dojo spar-score <id>`; append the receipt to the dojo report; track multi-run campaigns as goal files. Keep all other playbooks + hard rails intact. Verify each command name is real.
+- [ ] **Step 5** `bun run check:cli-reference` → exit 0 (dojo parent already covered). Commit `docs(dojo): spar command reference + SKILL spar flow`.
+
+---
+
+### Task 5: verify + PR
+
+- [ ] **Step 1** `bun test` (repo-wide) → 0 fail.
+- [ ] **Step 2** `bun run typecheck` → clean.
+- [ ] **Step 3** `bun run check:cli-reference` + `bun scripts/check-no-node-fs.ts` → clean.
+- [ ] **Step 4** push + PR:
+```bash
+git push -u origin feat/dojo-spar
+gh pr create --title "feat: ax dojo spar - replay benchmark (one task, one delta, scored)" --body "..."
+```
+PR body: summary (spar-plan freezes a baseline + brief; agent re-runs with one delta; spar-score writes the receipt); the hybrid framing (CLI scaffolds, agent runs); the comparability caveat (single run = raw delta, not significance; campaigns accrue confidence via goal files); test plan incl. the live spar-plan smoke; deferred (analytics tagging, cross-harness spar, automated re-run).

--- a/docs/superpowers/specs/2026-06-13-dojo-spar-design.md
+++ b/docs/superpowers/specs/2026-06-13-dojo-spar-design.md
@@ -1,0 +1,143 @@
+# ax dojo spar - replay benchmark (one task, one delta, scored)
+
+Date: 2026-06-13
+Status: approved design, pre-implementation
+Follows: docs/superpowers/specs/2026-06-13-ax-dojo-design.md (dojo core, "Sparring" section)
+
+## Problem
+
+The dojo's most differentiated idea is sparring: take a past landed task, re-run
+it with exactly ONE change (a skill on/off, a hook on/off, a prompt tweak, a
+model swap), and score the variant against the historical baseline using the
+graph's own metrics. The user's transcript history is a benchmark corpus nobody
+else has. Today `sparItem()` is a static agenda stub with placeholder commands -
+the mechanism doesn't exist.
+
+## Honest shape: a hybrid (CLI scaffolds, agent runs)
+
+You cannot fully automate "re-run a past coding task" in a CLI - the re-run is an
+agent doing real work in a worktree. So spar splits cleanly:
+
+- **CLI owns** baseline capture (from the graph), the experiment brief, variant
+  scoring, and the receipt. All deterministic, testable, evidence-derived.
+- **Agent owns** the re-run: pin a worktree at the baseline's parent SHA, apply
+  the ONE delta, do the task. (skill-prose in SKILL.md.)
+
+Two phases, frozen baseline in between:
+
+```
+ax dojo spar plan <sha|session>   ->  baseline captured + brief written (~/.ax/dojo/spar/<id>.md)
+   [agent: git worktree add ... <parentSha>; apply ONE delta; run the task]
+ax dojo spar score <id> [--variant-session=<id>]  ->  baseline vs variant receipt (~/.ax/dojo/spar/<id>-report.md)
+```
+
+## `ax dojo spar plan <sha|session> [--json]`
+
+Captures and freezes the baseline.
+
+1. Resolve the window: `findCommitWindow(repoRoot, sha)` (`packages/lib/src/
+   git-window.ts`) → parent SHA + predecessor→commit time window. (If a session
+   id is passed instead, use it directly + its session's commit if linked.)
+2. `listSessionsNear({ from, to, repositoryKey })` (`apps/axctl/src/dashboard/
+   sessions-query.ts`) → the landed session for the window. Pick the session
+   whose work produced the commit (the most substantive in-window session; if
+   ambiguous, the longest by turn_count). Capture its `first_user_message` (the
+   task prompt) + `turn_count`, `started_at`/`ended_at` (wall time).
+3. Baseline metrics (frozen): `fetchSessionCostMap([sessionId])` (tokens + cost,
+   `apps/axctl/src/metrics/cost-estimate.ts`) and `fetchSessionChurnSummary`
+   (landed/edit/repair lines, episodes, verification, `apps/axctl/src/metrics/
+   session-churn.ts`) for that session. `landed` = produced the commit (true for
+   the baseline by construction).
+4. Write a `SparBrief` to `~/.ax/dojo/spar/<id>.md` (id = `<shortSha>-<date>`),
+   frontmatter + a fenced JSON `baseline` block + prose:
+   - the task prompt (verbatim, the agent re-runs this)
+   - pin point: parent SHA + the exact `git worktree add .claude/worktrees/
+     dojo-spar-<id> -b dojo/spar-<id> <parentSha>` command
+   - frozen baseline metrics (tokens, turns, wallMs, repairLines, episodes,
+     landed)
+   - a **DELTA slot** the agent fills: which single change to test
+     (skill/hook/prompt/model) + rationale
+5. Print the brief path (or `--json` the SparBrief). cost_class xl: this stages
+   an expensive re-run.
+
+## `ax dojo spar score <id> [--variant-session=<id>] [--json]`
+
+Scores the variant the agent produced against the frozen baseline.
+
+1. Load + parse the `SparBrief` (`~/.ax/dojo/spar/<id>.md`) → frozen baseline +
+   the spar worktree cwd.
+2. Resolve the variant session: `--variant-session=<id>` explicit, else
+   auto-find the most recent session whose `cwd` is the spar worktree path and
+   `started_at >= brief.created_at` (adapt the `listSessionsNear` query pattern:
+   `WHERE cwd = $cwd AND started_at >= $since ORDER BY started_at DESC LIMIT 1`).
+   Fail cleanly if none found (the agent hasn't run it yet).
+3. Fetch variant metrics (same functions as baseline).
+4. `scoreSpar(baseline, variant)` (pure) → per-axis deltas + a verdict:
+   - axes: tokens, turns, wallMs, repairLines, episodes, landed(bool)
+   - `delta` per axis (variant − baseline) + direction (lower-is-better for
+     tokens/turns/wall/repair/episodes; landed must stay true)
+   - `verdict`: `win` (primary axis tokens-to-land improved AND still landed AND
+     repair not worse), `regression` (landed lost OR clearly worse), else `mixed`
+5. Write the spar report receipt to `~/.ax/dojo/spar/<id>-report.md` - a
+   baseline | variant | delta table + the tested delta + verdict - and append a
+   one-line pointer to the day's dojo report if present. `--json` emits SparScore.
+
+## Module shape
+
+```
+apps/axctl/src/dojo/spar.ts
+  - SparBaseline, SparBrief, SparVariant, SparScore types
+  - scoreSpar(baseline, variant): SparScore                 (pure)
+  - renderSparBrief(brief): string                          (pure: md + JSON block)
+  - parseSparBrief(content): SparBrief | null               (pure: frontmatter + JSON block)
+  - renderSparReport(score, brief): string                  (pure: receipt)
+  - captureBaseline(shaOrSession, repoRoot): Effect<SparBrief-without-delta, ...>
+  - findVariantSession(cwd, sinceMs): Effect<string | null, DbError, SurrealClient>
+  - fetchSessionMetrics(sessionId): Effect<SparBaseline|SparVariant, ...>   (wraps cost + churn + session row)
+apps/axctl/src/dojo/spar.test.ts
+apps/axctl/src/dojo/paths.ts          # add dojoSparDir + dojoSparBriefPath(id) + dojoSparReportPath(id)
+apps/axctl/src/dojo/items.ts          # sparItem() commands -> real `ax dojo spar plan/score`
+apps/axctl/src/cli/commands/dojo.ts   # add the spar subcommand(s)
+```
+
+Pure cores (`scoreSpar`, `renderSparBrief`, `parseSparBrief`, `renderSparReport`)
+unit-tested. Effect glue (`captureBaseline`, `findVariantSession`,
+`fetchSessionMetrics`) tested with the fake-SurrealClient harness + fixtures;
+end-to-end `spar plan` covered by a live smoke against a real recent commit.
+
+## CLI nesting
+
+`ax dojo` is already a family (agenda/report/draft/outbox). Spar has two phases.
+Preferred: 2-level nesting `ax dojo spar plan` / `ax dojo spar score` (a `spar`
+subcommand group under `dojo`). The plan verifies Effect `effect/unstable/cli`
+supports nesting a `withSubcommands` command inside another `withSubcommands`; if
+not, fall back to flat `ax dojo spar-plan` / `ax dojo spar-score`. Runtime: both
+need `db` (graph metrics) - extend the dojo db-conditional manifest.
+
+## Safety / scope
+
+- Read-only against the graph; writes only to `~/.ax/dojo/spar/`. The re-run
+  itself happens in an agent-created worktree (the CLI never spawns it).
+- Frozen baseline: captured once at `plan`, scored against at `score` - the
+  comparison can't drift.
+- Variant identified by worktree cwd + time; explicit `--variant-session`
+  preferred.
+
+## Out of scope (v1) / known caveats
+
+- **Analytics pollution**: variant runs are real sessions and DO count in usage/
+  cost/taste analytics. v1 marks them only by worktree cwd; a `session.labels`
+  tag to exclude spar traffic is deferred (schema change). Noted in the report.
+- **Comparability caveat**: re-running a task is non-deterministic - the variant
+  may diverge in scope from the baseline. The receipt reports raw metrics + the
+  delta honestly; it does not claim statistical significance from one run. The
+  spar campaign (multiple runs, goal-file tracked) is how confidence accrues -
+  that's the dojo `/goal` curriculum, not this CLI.
+- Cross-harness spar (Claude Code vs Codex, same task) - deferred.
+- Automated worktree creation / re-run - out of scope by design (agent-driven).
+
+## Open questions
+
+- Picking THE landed session when a window has several: longest-by-turns is the
+  v1 heuristic; a commit→session link (if one exists) would be exact - check
+  whether `changeset`/commit rows reference a session.

--- a/skills/dojo/SKILL.md
+++ b/skills/dojo/SKILL.md
@@ -67,12 +67,14 @@ docs/superpowers/specs/2026-06-13-ax-dojo-design.md (in the Necmttn/ax repo).
   overrun outweighs the benefit shown by backtest. Both ledgers must appear in
   the proposal; neither alone is sufficient.
 - **spar** - only present when invoked with --spar and spendable >= 30%.
-  One task, one delta, scored: pick a landed task (`ax sessions here`),
-  pin a worktree at the parent SHA, re-run it with exactly ONE change
-  (skill on/off, hook on/off, prompt, thinking level, model via subagent
-  override), score against the historical baseline using graph metrics
-  (tokens, turns, churn, landed). Append the comparison receipt to the
-  report. Track multi-night campaigns as goal files.
+  One task, one delta, scored. Concrete flow:
+  1. Pick a landed task: `ax sessions here --days=30` - note its commit sha from `ax sessions near <sha>` or `git log`.
+  2. `ax dojo spar-plan <sha>` - captures the baseline (prompt + cost/turns/churn) and writes `~/.ax/dojo/spar/<id>.md`; the command prints the exact `git worktree add` command to run next.
+  3. Read the brief at `~/.ax/dojo/spar/<id>.md`; run the printed `git worktree add .claude/worktrees/dojo-spar-<id> -b dojo/spar-<id> <parentSha>` command to pin the worktree at the parent SHA.
+  4. Apply exactly ONE delta in the delta section (skill on/off, hook on/off, prompt change, thinking level, or model override) - no compound changes.
+  5. Do the task in that worktree; let it finish naturally.
+  6. `ax dojo spar-score <id>` - auto-discovers the variant session from the worktree cwd; or pass `--variant-session=<id>` if there are multiple sessions. Writes the receipt to `~/.ax/dojo/spar/<id>-report.md`.
+  7. Append the receipt to the dojo report. Track multi-run campaigns as goal files under docs/superpowers/goals/ so the next session can resume.
 - **explore** - free investigation, retro-meta style: follow a hunch
   through `ax recall` / `ax sessions churn`, and convert anything real
   into a proposal or outbox draft.


### PR DESCRIPTION
## Summary
The dojo's sparring mechanism: take a past **landed** task, re-run it with exactly ONE change, and score the variant against the historical baseline using the graph's own metrics. Your transcript history is the benchmark corpus.

It's a **hybrid** — the CLI scaffolds (deterministic, evidence-derived), the agent does the re-run (you can't automate "re-run a past coding task" in a CLI):

- **`ax dojo spar-plan <sha> [--json]`** — resolves the commit's session, freezes its baseline (prompt + cost + turns + wall + churn + landed), and writes a brief to `~/.ax/dojo/spar/<id>.md` with the exact `git worktree add <parentSha>` pin command + a delta slot for the agent to fill.
- *(agent: pins the worktree, applies ONE delta — skill/hook/prompt/model — runs the task)*
- **`ax dojo spar-score <id> [--variant-session=<id>] [--json]`** — auto-finds the variant session (by worktree cwd + time), scores it vs the frozen baseline, writes a receipt (baseline | variant | delta + verdict) to `~/.ax/dojo/spar/<id>-report.md`.
- `sparItem()` and the SKILL.md spar playbook now drive this real flow.
- Spec: `docs/superpowers/specs/2026-06-13-dojo-spar-design.md`; plan: `docs/superpowers/plans/2026-06-13-dojo-spar.md`.

## Correctness work (caught by review + live smoke)
Four real bugs found and fixed before merge — all the kind that only surface against the real graph:
- **`landed` comes from the `produced` edge**, not `hotSessions` (which filters out clean sessions) — otherwise a *successful* clean variant scores `landed:false` → false regression. The worst possible failure mode for a benchmark.
- **Baseline must be a main session**, not a subagent (subagents win the turn-count heuristic but yield null metrics).
- **Variant worktree cwd resolves against the main repo root** via `git rev-parse --git-common-dir`, not a linked worktree's toplevel (else the path double-nests and the variant is never found).
- **`FROM ONLY` returns a bare object**, not a row array — turns/wall were silently null.

Live smoke (real commit): baseline = a main session, turns 848, wall ~15h, cost \$77, landed:true; missing-variant → friendly exit; bad sha → clean error.

## Honest caveats (in the spec)
A single re-run is a raw delta, **not** statistical significance — the receipt reports the metrics honestly and doesn't overclaim. Confidence accrues across a campaign (multiple runs, tracked as a `/goal` curriculum). Variant runs are real sessions and **do** count in usage analytics in v1 (a `session.labels` exclusion tag is deferred).

## Test plan
- [x] `bun test` repo-wide: 4073 pass / 0 fail
- [x] `bun run typecheck`: clean
- [x] `check:cli-reference` + `check:no-node-fs`: clean
- [x] Live smoke: spar-plan real baseline; spar-score missing-variant + bad-sha paths; worktree cwd single-nested

## Deferred (follow-up)
analytics-exclusion tagging for variant sessions, cross-harness spar, exact commit→session linkage (vs turn-count heuristic), automated re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)