### PR TITLE
feat(site): measured $/mo profile hero (State of Agent Spend, Stage 1)

### DIFF
--- a/apps/site/app/lib/hero.test.ts
+++ b/apps/site/app/lib/hero.test.ts
@@ -40,10 +40,12 @@ describe("buildHero", () => {
         expect(h.sessions).toBe(142);
         expect(h.provenance).toBe("measured from 142 sessions over 30d · not a screenshot");
     });
-    test("--no-cost profile omits monthly spend", () => {
+    test("--no-cost profile omits monthly spend and the screenshot jab", () => {
         const { cost_usd: _omit, ...stats } = base.stats;
         const h = buildHero({ ...base, stats });
         expect(h.monthlyUsd).toBeUndefined();
+        expect(h.provenance).toBe("measured from 142 sessions over 30d");
+        expect(h.provenance).not.toContain("not a screenshot");
     });
     test("singular session phrasing", () => {
         const h = buildHero({ ...base, stats: { ...base.stats, sessions: 1 } });

--- a/apps/site/app/lib/hero.test.ts
+++ b/apps/site/app/lib/hero.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { monthlyUsd, buildHero } from "./hero";
+import type { ProfileV1 } from "./community";
+
+const base: ProfileV1 = {
+    v: 1,
+    github: "necmttn",
+    generated_at: "2026-06-13T00:00:00Z",
+    window_days: 30,
+    stats: {
+        sessions: 142,
+        active_days: 26,
+        streak_days: 12,
+        tokens: { prompt: 1, completion: 1, total: 38_000_000 },
+        cost_usd: 214.3,
+        models: [{ name: "fable", share: 0.6 }, { name: "haiku", share: 0.4 }],
+        harnesses: ["claude-code"],
+    },
+    rig: { skills: [{ name: "tdd", source: "superpowers", runs: 88 }], hooks: [], routing_table: true },
+};
+
+describe("monthlyUsd", () => {
+    test("30-day window passes through", () => {
+        expect(monthlyUsd(200, 30)).toBe(200);
+    });
+    test("14-day window scales up to a month", () => {
+        expect(monthlyUsd(140, 14)).toBeCloseTo(300);
+    });
+    test("zero/negative window does not divide by zero", () => {
+        expect(monthlyUsd(50, 0)).toBe(50);
+    });
+});
+
+describe("buildHero", () => {
+    test("derives monthly spend, counts, and provenance", () => {
+        const h = buildHero(base);
+        expect(h.monthlyUsd).toBeCloseTo(214.3);
+        expect(h.models).toBe(2);
+        expect(h.skills).toBe(1);
+        expect(h.sessions).toBe(142);
+        expect(h.provenance).toBe("measured from 142 sessions over 30d · not a screenshot");
+    });
+    test("--no-cost profile omits monthly spend", () => {
+        const { cost_usd: _omit, ...stats } = base.stats;
+        const h = buildHero({ ...base, stats });
+        expect(h.monthlyUsd).toBeUndefined();
+    });
+    test("singular session phrasing", () => {
+        const h = buildHero({ ...base, stats: { ...base.stats, sessions: 1 } });
+        expect(h.provenance).toContain("1 session over");
+    });
+});

--- a/apps/site/app/lib/hero.ts
+++ b/apps/site/app/lib/hero.ts
@@ -27,6 +27,8 @@ export function buildHero(p: ProfileV1): Hero {
         models: p.stats.models.length,
         skills: p.rig.skills.length,
         sessions,
-        provenance: `measured from ${sessions.toLocaleString("en-US")} session${sessions === 1 ? "" : "s"} over ${p.window_days}d · not a screenshot`,
+        provenance: p.stats.cost_usd !== undefined
+            ? `measured from ${sessions.toLocaleString("en-US")} session${sessions === 1 ? "" : "s"} over ${p.window_days}d · not a screenshot`
+            : `measured from ${sessions.toLocaleString("en-US")} session${sessions === 1 ? "" : "s"} over ${p.window_days}d`,
     };
 }

--- a/apps/site/app/lib/hero.ts
+++ b/apps/site/app/lib/hero.ts
@@ -1,0 +1,32 @@
+// Pure derivation of the /u hero stat row. No JSX, no IO - unit-tested in
+// hero.test.ts. stats.cost_usd is the spend TOTAL over window_days
+// (apps/axctl/src/profile/render.ts: stats.cost_usd = cost.total_cost_usd
+// for sinceDays: windowDays), so it is normalised to a 30-day month here to
+// keep the headline comparable to aistack's monthly figure.
+import type { ProfileV1 } from "./community";
+
+export function monthlyUsd(total: number, windowDays: number): number {
+    if (windowDays <= 0) return total;
+    return (total * 30) / windowDays;
+}
+
+export interface Hero {
+    readonly monthlyUsd?: number; // omitted on --no-cost profiles
+    readonly models: number;
+    readonly skills: number;
+    readonly sessions: number;
+    readonly provenance: string;
+}
+
+export function buildHero(p: ProfileV1): Hero {
+    const sessions = p.stats.sessions;
+    return {
+        monthlyUsd: p.stats.cost_usd !== undefined
+            ? monthlyUsd(p.stats.cost_usd, p.window_days)
+            : undefined,
+        models: p.stats.models.length,
+        skills: p.rig.skills.length,
+        sessions,
+        provenance: `measured from ${sessions.toLocaleString("en-US")} session${sessions === 1 ? "" : "s"} over ${p.window_days}d · not a screenshot`,
+    };
+}

--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -27,6 +27,7 @@ import {
     OTHER_NAME,
     type DayColumn,
 } from "~/lib/window-chart";
+import { buildHero } from "~/lib/hero";
 
 // mirrors LOGIN_RE in community.ts - GitHub handles only, sanitised before use.
 const LOGIN_RE = /^[A-Za-z0-9-]{1,39}$/;
@@ -199,11 +200,38 @@ function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsState })
                 </div>
             </header>
 
+            {/* hero: the measured headline - receipts, not a screenshot */}
+            {(() => {
+                const hero = buildHero(p);
+                return (
+                    <section className="pf-hero" aria-label="headline">
+                        <div className="pf-hero-spend">
+                            {hero.monthlyUsd !== undefined ? (
+                                <>
+                                    <span className="pf-hero-num">~{fmtMoney(hero.monthlyUsd)}</span>
+                                    <span className="pf-hero-per">/mo</span>
+                                </>
+                            ) : (
+                                <>
+                                    <span className="pf-hero-num">{fmtInt(hero.sessions)}</span>
+                                    <span className="pf-hero-per">sessions</span>
+                                </>
+                            )}
+                        </div>
+                        <span className="pf-hero-prov">{hero.provenance}</span>
+                        <div className="pf-hero-row">
+                            <Vital num={fmtInt(hero.models)} label="models" />
+                            <Vital num={fmtInt(hero.skills)} label="skills" />
+                            <Vital num={fmtInt(hero.sessions)} label="sessions" />
+                        </div>
+                    </section>
+                );
+            })()}
+
             {/* vitals ledger */}
             <section className="pf-ledger" aria-label="vitals">
                 <Vital num={fmtInt(p.stats.sessions)} label="sessions" />
                 <Vital num={fmtCompact(p.stats.tokens.total)} label="tokens" />
-                {p.stats.cost_usd !== undefined && <Vital num={`~${fmtMoney(p.stats.cost_usd)}`} label="est. spend" />}
                 {ins && <Vital num={fmtCompact(ins.hours_total)} unit="hrs" label="in the loop" />}
                 <Vital num={`${fmtInt(p.stats.active_days)}/${fmtInt(p.window_days)}`} label="days active" />
                 <Vital num={`${fmtInt(p.stats.streak_days)}d`} label="streak" />

--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -180,6 +180,7 @@ function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsState })
     const models = [...p.stats.models].sort((a, b) => b.share - a.share);
     const { colorOf } = buildModelColors(models);
     const arcs = p.workflow ? buildDisplayArcs(p.workflow.arcs, 5) : [];
+    const hero = buildHero(p);
     let section = 0;
     const nextSection = (): string => String(++section).padStart(2, "0");
 
@@ -201,32 +202,27 @@ function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsState })
             </header>
 
             {/* hero: the measured headline - receipts, not a screenshot */}
-            {(() => {
-                const hero = buildHero(p);
-                return (
-                    <section className="pf-hero" aria-label="headline">
-                        <div className="pf-hero-spend">
-                            {hero.monthlyUsd !== undefined ? (
-                                <>
-                                    <span className="pf-hero-num">~{fmtMoney(hero.monthlyUsd)}</span>
-                                    <span className="pf-hero-per">/mo</span>
-                                </>
-                            ) : (
-                                <>
-                                    <span className="pf-hero-num">{fmtInt(hero.sessions)}</span>
-                                    <span className="pf-hero-per">sessions</span>
-                                </>
-                            )}
-                        </div>
-                        <span className="pf-hero-prov">{hero.provenance}</span>
-                        <div className="pf-hero-row">
-                            <Vital num={fmtInt(hero.models)} label="models" />
-                            <Vital num={fmtInt(hero.skills)} label="skills" />
-                            <Vital num={fmtInt(hero.sessions)} label="sessions" />
-                        </div>
-                    </section>
-                );
-            })()}
+            <section className="pf-hero" aria-label="headline">
+                <div className="pf-hero-spend">
+                    {hero.monthlyUsd !== undefined ? (
+                        <>
+                            <span className="pf-hero-num">~{fmtMoney(hero.monthlyUsd)}</span>
+                            <span className="pf-hero-per">/mo</span>
+                        </>
+                    ) : (
+                        <>
+                            <span className="pf-hero-num">{fmtInt(hero.sessions)}</span>
+                            <span className="pf-hero-per">sessions</span>
+                        </>
+                    )}
+                </div>
+                <span className="pf-hero-prov">{hero.provenance}</span>
+                <div className="pf-hero-row">
+                    <Vital num={fmtInt(hero.models)} label="models" />
+                    <Vital num={fmtInt(hero.skills)} label="skills" />
+                    <Vital num={fmtInt(hero.sessions)} label="sessions" />
+                </div>
+            </section>
 
             {/* vitals ledger */}
             <section className="pf-ledger" aria-label="vitals">

--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -226,7 +226,6 @@ function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsState })
 
             {/* vitals ledger */}
             <section className="pf-ledger" aria-label="vitals">
-                <Vital num={fmtInt(p.stats.sessions)} label="sessions" />
                 <Vital num={fmtCompact(p.stats.tokens.total)} label="tokens" />
                 {ins && <Vital num={fmtCompact(ins.hours_total)} unit="hrs" label="in the loop" />}
                 <Vital num={`${fmtInt(p.stats.active_days)}/${fmtInt(p.window_days)}`} label="days active" />

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -10777,6 +10777,16 @@ footer .right {
     .pf-vital-num { font-size: 25px; }
 }
 
+.pf-hero { display: flex; flex-direction: column; gap: 8px; margin: 32px 0 12px; }
+.pf-hero-spend { display: flex; align-items: baseline; gap: 10px; }
+.pf-hero-num { font-family: var(--mono); font-size: 76px; font-weight: 700; line-height: 1; color: var(--green); }
+.pf-hero-per { font-family: var(--mono); font-size: 24px; color: var(--muted); }
+.pf-hero-prov { font-family: var(--mono); font-size: 13px; color: var(--muted); letter-spacing: 0.5px; }
+.pf-hero-row { display: flex; gap: 32px; margin-top: 16px; }
+@media (max-width: 640px) {
+    .pf-hero-num { font-size: 56px; }
+}
+
 /* ----- section kicker ----- */
 .pf-section { margin-top: 60px; }
 .pf-kicker {

--- a/apps/site/functions/_lib/og-kit.test.ts
+++ b/apps/site/functions/_lib/og-kit.test.ts
@@ -5,6 +5,7 @@ import {
     fmtUsd,
     compactNumber,
     compactUsd,
+    perMonthUsd,
     statHtml,
     footerHtml,
     blockLogoHtml,
@@ -69,6 +70,18 @@ describe("compactUsd", () => {
     });
     test("small spend stays exact", () => {
         expect(compactUsd(42.4)).toBe("$42");
+    });
+});
+
+describe("perMonthUsd", () => {
+    test("30-day window passes through", () => {
+        expect(perMonthUsd(200, 30)).toBe(200);
+    });
+    test("14-day window scales up", () => {
+        expect(perMonthUsd(140, 14)).toBeCloseTo(300);
+    });
+    test("guards divide-by-zero", () => {
+        expect(perMonthUsd(50, 0)).toBe(50);
     });
 });
 

--- a/apps/site/functions/_lib/og-kit.ts
+++ b/apps/site/functions/_lib/og-kit.ts
@@ -53,6 +53,12 @@ export const compactNumber = (n: number): string => {
 export const compactUsd = (n: number): string =>
     n >= 1_000 ? `~$${compactNumber(n)}` : `$${n.toFixed(0)}`;
 
+/** Window-total USD normalised to a 30-day month (mirrors app/lib/hero.ts;
+ * functions and the SPA are separate bundles, so the one-liner lives in
+ * both). */
+export const perMonthUsd = (total: number, windowDays: number): number =>
+    windowDays > 0 ? (total * 30) / windowDays : total;
+
 // ---------------------------------------------------------------------------
 // Stat block - 46px numeral + 14px letter-spaced label (matches share card)
 // ---------------------------------------------------------------------------

--- a/apps/site/functions/_lib/og-meta.ts
+++ b/apps/site/functions/_lib/og-meta.ts
@@ -13,7 +13,7 @@
  */
 
 /** Bump when the poster template changes; busts edge + social image caches. */
-export const OG_RENDER_REV = 9;
+export const OG_RENDER_REV = 10;
 
 /** FNV-1a 32-bit as 8 hex chars - tiny, synchronous, stable across runtimes. */
 const fnv1a = (s: string): string => {

--- a/apps/site/functions/og-profile/[login].ts
+++ b/apps/site/functions/og-profile/[login].ts
@@ -16,7 +16,7 @@ import { ImageResponse } from "workers-og";
 import { OG_RENDER_REV } from "../_lib/og-meta";
 import {
     INK, PAPER, DIM, CARD, GREEN, RED,
-    esc, statHtml, footerHtml, blockLogoHtml, compactNumber, compactUsd, loadOgFonts,
+    esc, statHtml, footerHtml, blockLogoHtml, compactNumber, compactUsd, perMonthUsd, loadOgFonts,
 } from "../_lib/og-kit";
 
 const LOGIN_RE = /^[A-Za-z0-9_-]{1,39}$/;
@@ -191,7 +191,7 @@ export const onRequestGet: PagesFunction = async (ctx) => {
         const ins = gistProfile.insights;
         sessions     = s.sessions;
         tokens       = s.tokens.total;
-        spendUsd     = s.cost_usd ?? null;
+        spendUsd     = s.cost_usd != null ? perMonthUsd(s.cost_usd, gistProfile.window_days) : null;
         streakDays   = s.streak_days;
         activeHours  = ins?.hours_total ?? null;
         parallelSessions = ins?.parallel_sessions ?? null;
@@ -227,7 +227,7 @@ export const onRequestGet: PagesFunction = async (ctx) => {
     const statBand1 = `<div style="display:flex;justify-content:space-between;align-items:flex-end;margin-top:36px">${[
         statHtml(sessions != null ? sessions.toLocaleString("en-US") : "-", "SESSIONS", INK, noMr),
         statHtml(tokens  != null ? compactNumber(tokens)             : "-", "TOKENS", INK, noMr),
-        statHtml(spendUsd != null ? compactUsd(spendUsd)             : "-", "EST. SPEND", GREEN, { size: 60, marginRight: 0 }),
+        statHtml(spendUsd != null ? compactUsd(spendUsd)             : "-", "EST. $/MO", GREEN, { size: 60, marginRight: 0 }),
         statHtml(streakDays  != null ? `${streakDays}d`             : "-", "STREAK", INK, noMr),
         statHtml(activeHours != null ? compactNumber(activeHours)   : "-", "HOURS", INK, noMr),
     ].join("")}</div>`;
@@ -247,7 +247,7 @@ export const onRequestGet: PagesFunction = async (ctx) => {
         filler = "";
     }
 
-    const footer = footerHtml("COMPILED FROM LOCAL TRANSCRIPTS");
+    const footer = footerHtml("MEASURED FROM LOCAL TRANSCRIPTS · NOT A SCREENSHOT");
 
     // Top bands live in one inner column with designed margin-top gaps;
     // outer space-between then has exactly two children, which pins the

--- a/apps/site/functions/og-profile/[login].ts
+++ b/apps/site/functions/og-profile/[login].ts
@@ -65,6 +65,7 @@ interface ProfileStub {
     readonly sessions?: number;
     readonly tokens?: number;
     readonly estimated_spend_usd?: number | null;
+    readonly window_days?: number;
     readonly streak_days?: number;
     readonly active_hours?: number;
     readonly parallel_sessions?: number;
@@ -177,7 +178,9 @@ export const onRequestGet: PagesFunction = async (ctx) => {
     if (stub) {
         sessions     = stub.sessions ?? null;
         tokens       = stub.tokens ?? null;
-        spendUsd     = stub.estimated_spend_usd ?? null;
+        spendUsd     = stub.estimated_spend_usd != null
+            ? (stub.window_days != null ? perMonthUsd(stub.estimated_spend_usd, stub.window_days) : stub.estimated_spend_usd)
+            : null;
         streakDays   = stub.streak_days ?? null;
         activeHours  = stub.active_hours ?? null;
         parallelSessions = stub.parallel_sessions ?? null;

--- a/docs/superpowers/plans/2026-06-13-state-of-agent-spend-hero.md
+++ b/docs/superpowers/plans/2026-06-13-state-of-agent-spend-hero.md
@@ -1,0 +1,405 @@
+# Measured-Spend Profile Hero (Stage 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lead the `/u/<login>` profile and its OG share card with a measured monthly-spend headline (`~$214/mo · measured from 142 sessions · not a screenshot`), out-receipting aistack.to's hand-typed number on its own metric.
+
+**Architecture:** Pure derivation (`monthlyUsd`/`buildHero`) over data already in `ProfileV1` - no gist schema change. The site route renders a new hero block above the existing vitals ledger; the CF Pages OG function normalises the same spend to a monthly figure. Window-total spend (`stats.cost_usd` over `window_days`) is scaled to a 30-day month so the headline is comparable across windows.
+
+**Tech Stack:** TanStack Start SPA (`apps/site/app`), CF Pages Functions + `workers-og` (`apps/site/functions`), bun:test, TypeScript strict.
+
+**Scope note:** This plan is Stage 1 of the [State of Agent Spend spec](../specs/2026-06-13-state-of-agent-spend-design.md), narrowed during planning. The spec's Stage 1 also listed **tool takes** (derived `stack-choice` patterns + optional manual override). Code inspection shows `apps/axctl/src/profile/taste.ts` *defers* stack-choice derivation ("needs dep/import signals") - there is no data source, and the manual-override path needs a new input + schema + publish wiring. Both are a separate subsystem from rendering the hero, so they move to **Stage 1.1** (own plan). This plan ships the share artifact and registration driver - pure render over existing data.
+
+**Convention checks before you start:**
+- Tests run from the worktree root with `bun test <path>` (repo-wide bun:test).
+- CSS vars in use: `--green`, `--muted`, `--mono`, `--ink`, `--line` (see `apps/site/app/styles/globals.css`).
+- The route's money/int formatters already exist: `fmtMoney` (`$` + compact), `fmtInt` (`apps/site/app/routes/u.$login.tsx:143-147`).
+
+---
+
+### Task 1: Pure hero derivation module
+
+**Files:**
+- Create: `apps/site/app/lib/hero.ts`
+- Test: `apps/site/app/lib/hero.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/site/app/lib/hero.test.ts
+import { describe, expect, test } from "bun:test";
+import { monthlyUsd, buildHero } from "./hero";
+import type { ProfileV1 } from "./community";
+
+const base: ProfileV1 = {
+    v: 1,
+    github: "necmttn",
+    generated_at: "2026-06-13T00:00:00Z",
+    window_days: 30,
+    stats: {
+        sessions: 142,
+        active_days: 26,
+        streak_days: 12,
+        tokens: { prompt: 1, completion: 1, total: 38_000_000 },
+        cost_usd: 214.3,
+        models: [{ name: "fable", share: 0.6 }, { name: "haiku", share: 0.4 }],
+        harnesses: ["claude-code"],
+    },
+    rig: { skills: [{ name: "tdd", source: "superpowers", runs: 88 }], hooks: [], routing_table: true },
+};
+
+describe("monthlyUsd", () => {
+    test("30-day window passes through", () => {
+        expect(monthlyUsd(200, 30)).toBe(200);
+    });
+    test("14-day window scales up to a month", () => {
+        expect(monthlyUsd(140, 14)).toBeCloseTo(300);
+    });
+    test("zero/negative window does not divide by zero", () => {
+        expect(monthlyUsd(50, 0)).toBe(50);
+    });
+});
+
+describe("buildHero", () => {
+    test("derives monthly spend, counts, and provenance", () => {
+        const h = buildHero(base);
+        expect(h.monthlyUsd).toBeCloseTo(214.3);
+        expect(h.models).toBe(2);
+        expect(h.skills).toBe(1);
+        expect(h.sessions).toBe(142);
+        expect(h.provenance).toBe("measured from 142 sessions over 30d · not a screenshot");
+    });
+    test("--no-cost profile omits monthly spend", () => {
+        const { cost_usd: _omit, ...stats } = base.stats;
+        const h = buildHero({ ...base, stats });
+        expect(h.monthlyUsd).toBeUndefined();
+    });
+    test("singular session phrasing", () => {
+        const h = buildHero({ ...base, stats: { ...base.stats, sessions: 1 } });
+        expect(h.provenance).toContain("1 session over");
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/site/app/lib/hero.test.ts`
+Expected: FAIL - `Cannot find module './hero'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// apps/site/app/lib/hero.ts
+// Pure derivation of the /u hero stat row. No JSX, no IO - unit-tested in
+// hero.test.ts. stats.cost_usd is the spend TOTAL over window_days
+// (apps/axctl/src/profile/render.ts: stats.cost_usd = cost.total_cost_usd
+// for sinceDays: windowDays), so it is normalised to a 30-day month here to
+// keep the headline comparable to aistack's monthly figure.
+import type { ProfileV1 } from "./community";
+
+export function monthlyUsd(total: number, windowDays: number): number {
+    if (windowDays <= 0) return total;
+    return (total * 30) / windowDays;
+}
+
+export interface Hero {
+    readonly monthlyUsd?: number; // omitted on --no-cost profiles
+    readonly models: number;
+    readonly skills: number;
+    readonly sessions: number;
+    readonly provenance: string;
+}
+
+export function buildHero(p: ProfileV1): Hero {
+    const sessions = p.stats.sessions;
+    return {
+        monthlyUsd: p.stats.cost_usd !== undefined
+            ? monthlyUsd(p.stats.cost_usd, p.window_days)
+            : undefined,
+        models: p.stats.models.length,
+        skills: p.rig.skills.length,
+        sessions,
+        provenance: `measured from ${sessions.toLocaleString("en-US")} session${sessions === 1 ? "" : "s"} over ${p.window_days}d · not a screenshot`,
+    };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/site/app/lib/hero.test.ts`
+Expected: PASS - 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/site/app/lib/hero.ts apps/site/app/lib/hero.test.ts
+git commit -m "feat(site): pure hero derivation - monthly spend + provenance"
+```
+
+---
+
+### Task 2: Render the hero block on `/u/<login>`
+
+**Files:**
+- Modify: `apps/site/app/routes/u.$login.tsx` (add import; insert hero block after `</header>`; remove the `est. spend` vital from the ledger)
+
+- [ ] **Step 1: Add the import**
+
+Find the `~/lib/window-chart` import block (around `apps/site/app/routes/u.$login.tsx:21-29`) and add below it:
+
+```tsx
+import { buildHero } from "~/lib/hero";
+```
+
+- [ ] **Step 2: Insert the hero block**
+
+In `ProfilePage`'s returned JSX, immediately after the closing `</header>` of `pf-mast` and before `{/* vitals ledger */}`, insert:
+
+```tsx
+            {/* hero: the measured headline - receipts, not a screenshot */}
+            {(() => {
+                const hero = buildHero(p);
+                return (
+                    <section className="pf-hero" aria-label="headline">
+                        <div className="pf-hero-spend">
+                            {hero.monthlyUsd !== undefined ? (
+                                <>
+                                    <span className="pf-hero-num">~{fmtMoney(hero.monthlyUsd)}</span>
+                                    <span className="pf-hero-per">/mo</span>
+                                </>
+                            ) : (
+                                <>
+                                    <span className="pf-hero-num">{fmtInt(hero.sessions)}</span>
+                                    <span className="pf-hero-per">sessions</span>
+                                </>
+                            )}
+                        </div>
+                        <span className="pf-hero-prov">{hero.provenance}</span>
+                        <div className="pf-hero-row">
+                            <Vital num={fmtInt(hero.models)} label="models" />
+                            <Vital num={fmtInt(hero.skills)} label="skills" />
+                            <Vital num={fmtInt(hero.sessions)} label="sessions" />
+                        </div>
+                    </section>
+                );
+            })()}
+```
+
+- [ ] **Step 3: Remove the now-duplicated est. spend vital from the ledger**
+
+In the `{/* vitals ledger */}` section, delete this exact line (the monthly figure now lives in the hero):
+
+```tsx
+                {p.stats.cost_usd !== undefined && <Vital num={`~${fmtMoney(p.stats.cost_usd)}`} label="est. spend" />}
+```
+
+- [ ] **Step 4: Verify it typechecks**
+
+Run: `cd apps/site && bun run build`
+Expected: build succeeds (no TS error referencing `u.$login.tsx` or `hero.ts`). Note: site `bun run typecheck` requires a prior build (route/content codegen) per project CLAUDE.md - `bun run build` is the gate here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/site/app/routes/u.\$login.tsx
+git commit -m "feat(site): lead /u profile with measured \$/mo hero"
+```
+
+---
+
+### Task 3: Hero styles
+
+**Files:**
+- Modify: `apps/site/app/styles/globals.css` (append hero rules near the other `.pf-*` rules)
+
+- [ ] **Step 1: Append the CSS**
+
+Add to `apps/site/app/styles/globals.css` (after the `.pf-ledger` / `.pf-vital` block - search for `.pf-vital`):
+
+```css
+.pf-hero { display: flex; flex-direction: column; gap: 8px; margin: 32px 0 12px; }
+.pf-hero-spend { display: flex; align-items: baseline; gap: 10px; }
+.pf-hero-num { font-family: var(--mono); font-size: 76px; font-weight: 700; line-height: 1; color: var(--green); }
+.pf-hero-per { font-family: var(--mono); font-size: 24px; color: var(--muted); }
+.pf-hero-prov { font-family: var(--mono); font-size: 13px; color: var(--muted); letter-spacing: 0.5px; }
+.pf-hero-row { display: flex; gap: 32px; margin-top: 16px; }
+@media (max-width: 640px) {
+    .pf-hero-num { font-size: 56px; }
+}
+```
+
+- [ ] **Step 2: Verify the build still succeeds**
+
+Run: `cd apps/site && bun run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/site/app/styles/globals.css
+git commit -m "style(site): hero spend headline + stat row"
+```
+
+---
+
+### Task 4: `perMonthUsd` helper in the OG kit
+
+**Files:**
+- Modify: `apps/site/functions/_lib/og-kit.ts` (add helper next to `compactUsd`)
+- Test: `apps/site/functions/_lib/og-kit.test.ts` (add a describe block)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/site/functions/_lib/og-kit.test.ts` (and add `perMonthUsd` to the import list at the top of that file):
+
+```ts
+import { perMonthUsd } from "./og-kit";
+
+describe("perMonthUsd", () => {
+    test("30-day window passes through", () => {
+        expect(perMonthUsd(200, 30)).toBe(200);
+    });
+    test("14-day window scales up", () => {
+        expect(perMonthUsd(140, 14)).toBeCloseTo(300);
+    });
+    test("guards divide-by-zero", () => {
+        expect(perMonthUsd(50, 0)).toBe(50);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/site/functions/_lib/og-kit.test.ts`
+Expected: FAIL - `perMonthUsd` is not exported.
+
+- [ ] **Step 3: Add the helper**
+
+In `apps/site/functions/_lib/og-kit.ts`, immediately after the `compactUsd` export (around line 53-54), add:
+
+```ts
+/** Window-total USD normalised to a 30-day month (mirrors app/lib/hero.ts;
+ * functions and the SPA are separate bundles, so the one-liner lives in
+ * both). */
+export const perMonthUsd = (total: number, windowDays: number): number =>
+    windowDays > 0 ? (total * 30) / windowDays : total;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/site/functions/_lib/og-kit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/site/functions/_lib/og-kit.ts apps/site/functions/_lib/og-kit.test.ts
+git commit -m "feat(site): perMonthUsd helper for the OG card"
+```
+
+---
+
+### Task 5: OG card leads monthly spend + provenance footer
+
+**Files:**
+- Modify: `apps/site/functions/og-profile/[login].ts`
+
+- [ ] **Step 1: Import the helper**
+
+In the `og-kit` import block (`apps/site/functions/og-profile/[login].ts:19-21`), add `perMonthUsd` to the named imports:
+
+```tsx
+    esc, statHtml, footerHtml, blockLogoHtml, compactNumber, compactUsd, perMonthUsd, loadOgFonts,
+```
+
+- [ ] **Step 2: Normalise the gist-profile spend to monthly**
+
+In the `else if (gistProfile)` branch (around line 192-194), replace:
+
+```tsx
+        spendUsd     = s.cost_usd ?? null;
+```
+
+with:
+
+```tsx
+        spendUsd     = s.cost_usd != null ? perMonthUsd(s.cost_usd, gistProfile.window_days) : null;
+```
+
+(The placeholder `stub` branch keeps `estimated_spend_usd` unchanged - it has no window and is a fallback card.)
+
+- [ ] **Step 3: Relabel the spend stat to `$/MO`**
+
+In `statBand1` (around line 230), change the spend stat's label from `"EST. SPEND"` to `"EST. $/MO"`:
+
+```tsx
+        statHtml(spendUsd != null ? compactUsd(spendUsd)             : "-", "EST. $/MO", GREEN, { size: 60, marginRight: 0 }),
+```
+
+- [ ] **Step 4: Make the footer carry the provenance jab**
+
+Find the footer line (around line 247):
+
+```tsx
+    const footer = footerHtml("COMPILED FROM LOCAL TRANSCRIPTS");
+```
+
+replace with:
+
+```tsx
+    const footer = footerHtml("MEASURED FROM LOCAL TRANSCRIPTS · NOT A SCREENSHOT");
+```
+
+- [ ] **Step 5: Bump the OG render revision so caches refresh**
+
+Open `apps/site/functions/_lib/og-meta.ts`, find `OG_RENDER_REV`, and increment its numeric value by 1 (e.g. `7` → `8`). This is the cache-key bump the OG template-change convention requires (see the OG satori quirks note).
+
+- [ ] **Step 6: Verify the build succeeds**
+
+Run: `cd apps/site && bun run build`
+Expected: build succeeds, no TS error in `og-profile/[login].ts`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/site/functions/og-profile/\[login\].ts apps/site/functions/_lib/og-meta.ts
+git commit -m "feat(site): OG card leads measured \$/mo + provenance"
+```
+
+---
+
+### Task 6: Visual verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build and preview**
+
+Run: `cd apps/site && bun run build && bun run preview` (or the project's site dev command).
+Open `/u/necmttn` (or any registered login). Confirm:
+- Hero shows `~$<n>/mo` in green at the top, with the `measured from N sessions over Wd · not a screenshot` subline.
+- Stat row reads `models · skills · sessions`.
+- The old `est. spend` vital is gone from the ledger (no duplicate spend figure).
+
+- [ ] **Step 2: Verify the OG card**
+
+Fetch `/og-profile/necmttn.png` (the OG image route) and confirm the green hero numeral reads `~$<n>/mo` with the `EST. $/MO` label and the `MEASURED … NOT A SCREENSHOT` footer. Verify the rendered number matches `ax profile show` monthly-normalised spend for the same login (figures must match real output - do not trust the mock).
+
+- [ ] **Step 3: Verify the --no-cost path**
+
+Against a `--no-cost` fixture/profile (no `stats.cost_usd`), confirm the hero falls back to leading with `sessions` and renders no `$/mo` slot, and the OG spend stat shows `-`.
+
+---
+
+## Self-Review
+
+**Spec coverage (Stage 1 of the design doc):**
+- `$/mo` mirror-and-beat headline + provenance subline → Task 1 (derive), Task 2 (render).
+- Stat row (`$/mo · models · skills · sessions`; `tools` → `skills`, since ax has no product-level "tools" concept - the rig-surface count is skills) → Task 2.
+- Promote `est. spend` into the hero / remove the mid-page duplicate → Task 2 Step 3.
+- `--no-cost` reads correctly → Task 1 test + Task 2 fallback + Task 6 Step 3.
+- OG card mirrors the headline → Tasks 4-5; cache bump Task 5 Step 5; figure verified against real output Task 6 Step 2.
+- **Deferred to Stage 1.1 (not this plan):** derived `stack-choice` tool takes (no data source - `taste.ts` defers it) and optional manual `rig.skills[].note` override (new input + schema + publish). Stated in the plan header.
+
+**Placeholder scan:** none - every code step carries complete code; commands have expected output.
+
+**Type consistency:** `monthlyUsd`/`buildHero`/`Hero` (Task 1) match their use in Task 2; `perMonthUsd` (Task 4) matches its use in Task 5; `fmtMoney`/`fmtInt`/`Vital` are pre-existing in `u.$login.tsx`. `ProfileV1` (site `~/lib/community`) is the type both the route and the OG function already use.

--- a/docs/superpowers/specs/2026-06-13-state-of-agent-spend-design.md
+++ b/docs/superpowers/specs/2026-06-13-state-of-agent-spend-design.md
@@ -1,0 +1,187 @@
+# State of Agent Spend - Measured, Not Surveyed - Design
+
+Date: 2026-06-13
+Status: approved (brainstorm + grill), pending implementation plan
+Related: [2026-06-12-ax-profiles-design.md](./2026-06-12-ax-profiles-design.md),
+parked registry+mesh design (memory `ax-registry-mesh-design`)
+
+## Origin
+
+Competitive recon on [aistack.to](https://aistack.to) ("Like Stackshare but
+for AI", repo `alp82/aistack`) started this as a "steal their profile hero +
+clone loop" spec. Grilling moved it up a level:
+
+- **Clone loop: cut.** Their `npx collect`/`create` moves static config files
+  between strangers - a dotfiles copy. ax's edge is *showing what works with
+  receipts*, not installing a stranger's rig. `/u/<login>` stays an
+  inspect-and-decide surface; no install command. (Team-ring rig sharing, if
+  ever, is committed `.ax/` in a shared repo - a different, later thing.)
+- **The real competitor is the survey.** aistack shows one self-reported
+  profile at a time; `stateofai.dev` / Devographics State-of-X reports ask
+  people what they use. **The entire genre is self-reported.** ax reads N
+  engineers' actual transcripts. That is the whole pitch and nobody in the
+  category can copy it.
+
+## Goal
+
+A measured **"State of Agent Spend"** report at `/state/<year>` - the
+collective, evidence-backed answer to what AI engineers actually pay, route,
+run, and recover from - built only from data ax already ingests, on the
+profiles rails already shipped. No owned servers; aggregates only.
+
+The per-profile hero at `/u/<login>` is **the unit that feeds it and the
+share artifact that grows it** - not a side feature. It ships first because
+it is the only lever that grows registrations, and `/state` is vaporware
+until registrations climb.
+
+## Principles
+
+- **Measured, never surveyed.** Every number traces to ingested transcripts.
+- **No owned servers.** Gists (data plane) → nightly GitHub Action compile →
+  `community/state/<year>.json` → CF Pages static read. Same rails as
+  `/leaders`.
+- **Aggregates only.** Cross-user output carries distributions and shares,
+  never another user's transcript content, paths, or project names. Per-user
+  numbers appear only on that user's own `/u` page (already public, consented
+  at publish).
+- **Hero-first sequencing is forced, not chosen.** A collective page needs a
+  population; the hero is what creates it.
+
+---
+
+## Build sequence (one spec, three sequenced plans)
+
+Each stage is its own implementation plan. **We do not plan stage 3 until
+stage 1 ships and real N is visible.**
+
+### Stage 1 - Per-profile hero (ships first, works at N=1)
+
+The share-on-X artifact and registration driver. Mostly presentation over
+data already in `ProfileV1` (`apps/axctl/src/profile/schema.ts`:
+`stats.cost_usd`, `stats.models[]`, `rig.*`). **No gist schema change for the
+core hero.**
+
+- **Headline `$/mo`, mirror-and-beat.** Where aistack hand-types `$256/mo`
+  from a screenshot, ax renders **`~$214/mo · measured from 142 sessions`**
+  with the window stated inline. Spend is the number they fake and ax proves
+  - out-receipting them on their own metric is the sharpest jab. Provenance
+  subline `measured from N sessions over Wd · not a screenshot` ships in the
+  hero, not a footnote.
+- **Stat row** above the radar/dossier, mirroring their four-stat layout:
+  `$/mo · tools · models · sessions`. Promote the existing mid-page
+  `est. spend` vital into this row.
+- **`--no-cost` profiles** hide the `$/mo` slot and lead with sessions; the
+  row must read correctly with cost absent (existing gist option).
+- **OG card** (`functions/og-profile/[login].ts`) mirrors the stat row so the
+  shared image carries the number. Verify rendered figures against real
+  `ax profile show` output (OG satori quirks memo applies).
+- **Tool takes: derived, with optional manual override.** Lead with existing
+  `ProfileV1` `stack-choice` patterns (`slot`, `name`, `over[]`, `context`)
+  rendered as the tool blurbs - taste *earned from evidence*, the on-thesis
+  answer to aistack's hand-typed tool cards. Allow an optional one-line
+  manual override per tool where the data is thin: additive optional
+  `rig.skills[].note` (≤140 chars), run through the same scrub the publish
+  path already applies to taste prose. Manual is the exception; derived is
+  the default.
+
+### Stage 2 - Nightly aggregate compile (once N climbs)
+
+Extend the existing compile (`scripts/compile-community.ts`, the Action that
+already builds `leaderboard`/`skill-stats`) to emit
+`community/state/<year>.json`. ETag-cached, absurd rows dropped, schema
+validated - identical posture to the current compile.
+
+Aggregates produced:
+- **Spend distribution** - median, p90, histogram bands of `stats.cost_usd`
+  (window-normalised to /mo).
+- **Model split** - token-weighted share across `stats.models[]`.
+- **Rig leverage** - skill run-share across `rig.skills[].runs` (what *ran*,
+  not what was installed).
+- **(v1.1) Failure→recovery rates** - see §4 below; needs a new compiled
+  `pattern-stats.json` and is explicitly deferred past the first `/state`
+  cut.
+
+### Stage 3 - `/state/<year>` render (centerpiece, gated on non-embarrassing N)
+
+A scrolly report route reading the compiled JSON via CF Pages static fetch.
+Sections:
+
+- **§1 What people pay** - spend distribution (the legible hook that earns
+  the click). The aistack number, collective and measured.
+- **§2 Model routing in the wild** - the fable/opus/sonnet/haiku split.
+  aistack's top profile hand-writes this; ax aggregates it from the same data
+  `ax dispatches` reads.
+- **§3 What rigs actually fire** - skill-leverage bars.
+- **§4 Failure → recovery rates** *(v1.1, north-star section)* - "X% of
+  edit-loop-thrash episodes recovered within 3 turns." **The section no
+  survey can ask** - ax's deepest moat and the reason the genre is
+  uncopyable. Deferred from the first cut only because the cross-user
+  recovery aggregate (`pattern-stats.json`) does not exist yet; the first
+  `/state` ships §1-§3 and §4 lands as soon as that compile does.
+
+---
+
+## Data flow
+
+```
+per-user gist (ax-profile.json)          data plane - shipped
+        │  nightly GitHub Action (compile-community.ts, extended)
+        ▼
+community/state/<year>.json              new aggregate artifact (stage 2)
+        │  CF Pages static read
+        ▼
+/state/<year>  scrolly report            new centerpiece route (stage 3)
+/u/<login>     hero + derived takes       the unit + share artifact (stage 1)
+```
+
+## Privacy & security
+
+- Inherits the profiles spec posture wholesale. Cross-user output is
+  aggregate-only, enforced by the compiled artifact's output type.
+- Per-user spend is already public/consented on `/u`; the aggregate adds no
+  new disclosure.
+- Manual tool-note input (stage 1) goes through the existing publish-path
+  scrub before it reaches the gist.
+- Numbers are self-published-but-measured: gameable at the edge (a user could
+  publish a doctored gist), accepted for v1 and stated on `/state`. Absurd
+  rows dropped in compile, same as `/leaders`.
+- Site escapes everything sourced from gists or compiled JSON.
+
+## Testing
+
+- Stage 1: hero derivation is a pure function - snapshot tests against
+  fixture `ProfileV1` rows (existing profile-renderer pattern). OG card
+  rendered against fixtures. `--no-cost` path covered.
+- Stage 2: fixture gist sets → expected `state/<year>.json`; ETag
+  short-circuit and absurd-row drop covered (mirror existing compile tests).
+- Stage 3: `/state` components rendered against fixture compiled JSON;
+  empty/low-N state renders honestly.
+
+## Non-goals (v1)
+
+- **`ax rig clone` / any install command** - cut. `/u` is show-not-install.
+- Hosting user-authored skill/hook content.
+- Per-profile upvotes / social directory mechanics - `/leaders` already
+  ranks.
+- Changes to the registration/control plane - rides existing fork+gist rails
+  untouched.
+- A full multi-topic `/state` ("State of Agent Engineering" beyond spend) -
+  this spec is spend + routing + rig + recovery only; broader topics stay in
+  the profiles-spec Deferred list.
+
+## Open questions
+
+1. **Window normalisation when `window_days` ≠ 30** - show native-window
+   total plus a derived `~$X/mo` so the hero headline stays comparable to
+   aistack's monthly number? (Lean: yes, derived `/mo` with native total
+   beside it.)
+2. **`/state` go-live threshold** - what N makes the page non-embarrassing,
+   and what does it show below that (a "measuring…" honest empty state vs a
+   noindex hold)? Decide at the stage-2/3 boundary with real numbers.
+3. **§4 recovery aggregate shape** - what is the unit (episode? session?) and
+   the recovery predicate, and does it reuse `ax sessions churn` episode
+   logic (failure opens / same-family pass closes / 30min expiry)? Resolve in
+   the stage-2 v1.1 plan.
+4. **Derived tool-take coverage** - what fraction of a real profile produces a
+   usable `stack-choice` take vs falls back to manual? Audit one real profile
+   before finalising stage-1 take UX.


### PR DESCRIPTION
## Summary

Leads the `/u/<login>` profile and its OG share card with a **measured monthly-spend headline** — `~$X/mo · measured from N sessions · not a screenshot` — normalising window-total spend to a 30-day month. Out-receipts [aistack.to](https://aistack.to)'s hand-typed monthly number on its own metric, using data already in `ProfileV1` (no gist schema change).

Stage 1 of the [State of Agent Spend design](docs/superpowers/specs/2026-06-13-state-of-agent-spend-design.md). Spec + plan included in the branch. Recon → brainstorm+grill pivoted this from "clone aistack's profile + install loop" to "measured profile hero that bootstraps a measured `/state` report"; the clone loop was cut (show-not-install).

### What changed
- `apps/site/app/lib/hero.ts` — pure `monthlyUsd` / `buildHero` derivation (unit-tested)
- `apps/site/app/routes/u.$login.tsx` — hero block (`$/mo` headline + provenance + models·skills·sessions row); removed the now-duplicated `est. spend` and `sessions` ledger vitals
- `apps/site/app/styles/globals.css` — `.pf-hero*` rules
- `apps/site/functions/_lib/og-kit.ts` — `perMonthUsd` helper (unit-tested)
- `apps/site/functions/og-profile/[login].ts` — OG card leads `EST. $/MO` + `MEASURED … NOT A SCREENSHOT` footer; stub path normalizes when a window is supplied
- `apps/site/functions/_lib/og-meta.ts` — OG_RENDER_REV 9→10 (cache bust)

### Out of scope (Stage 1.1)
Derived `stack-choice` tool-takes (no data source — `taste.ts` defers stack-choice derivation) and optional manual `rig.skills[].note` override. Both need their own subsystem.

## Test Plan
- [x] `bun test apps/site/app/lib/hero.test.ts apps/site/functions/_lib/og-kit.test.ts` → 34 pass
- [x] `tsc --noEmit` clean on all touched files (pre-existing unrelated `@pierre/diffs` studio break + TanStack route-codegen-needs-build errors aside)
- [ ] **Visual QA on the preview deploy** — confirm the `/u/<login>` hero renders `~$X/mo` + provenance + stat row, and `/og-profile/<login>.png` shows `EST. $/MO` (green) with the new footer. Verify the rendered figure matches `ax profile show` monthly-normalised spend.
- [ ] `--no-cost` profile: hero falls back to sessions headline, no `$/mo` slot, no "not a screenshot" jab; OG spend stat shows `-`

🤖 Generated with [Claude Code](https://claude.com/claude-code)