### PR TITLE
chore(site): drop orphaned pages content collection

### DIFF
--- a/apps/site/content-collections.ts
+++ b/apps/site/content-collections.ts
@@ -38,21 +38,6 @@ const adrs = defineCollection({
   },
 });
 
-const pages = defineCollection({
-  name: "pages",
-  directory: "../../docs",
-  include: ["manifesto.md", "brand.md", "language.md"],
-  // See `adrs.schema` above for why `content: z.string()` is here.
-  schema: z.object({
-    content: z.string(),
-  }),
-  transform: async (doc, ctx) => {
-    const body = await compileMDX(ctx, doc, mdxOptions);
-    const slug = doc._meta.fileName.replace(/\.md$/, "");
-    return { ...doc, slug, body };
-  },
-});
-
 const releaseAnnouncements = defineCollection({
   name: "releaseAnnouncements",
   directory: "../../docs/releases",
@@ -138,4 +123,4 @@ const howItWorks = defineCollection({
   },
 });
 
-export default defineConfig({ content: [adrs, pages, howItWorks, releaseAnnouncements, changelog] });
+export default defineConfig({ content: [adrs, howItWorks, releaseAnnouncements, changelog] });


### PR DESCRIPTION
## What
Removes the now-orphaned `pages` content collection from `apps/site/content-collections.ts` (definition + `defineConfig` entry).

## Why
The `/manifesto`, `/brand`, and `/docs/language` routes were repointed to curated colocated data modules in waves 1–2, so nothing imports `allPages` anymore (`rg allPages apps/site` → none). The collection just compiled three internal markdown files (`docs/manifesto.md`, `brand.md`, `language.md`) that no longer reach the site.

The `.md` files stay on disk — they're still linked from README.md and docs/cli.md as repo docs. This only stops them being published through the site.

(The CONTRIBUTING.md MIT→AGPL item from the deferred list was already clean — the License section reads "the project license (see LICENSE)".)

## Verified
- `cd apps/site && bun run build` → exit 0
- `bun test` → 128 pass / 0 fail
- `rg allPages apps/site` → no consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)