### PR TITLE
fix(dojo): spar-plan warns on subagent-only baselines

### DIFF
--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -34,6 +34,7 @@ const brief: SparBrief = {
     baselineSession: "session:base",
     worktree: ".claude/worktrees/dojo-spar-ab12cd34-2026-06-13",
     baseline: baseMetrics(),
+    baselineIsSubagent: false,
     delta: "skill: tdd ON",
 };
 
@@ -80,6 +81,13 @@ describe("renderSparBrief / parseSparBrief roundtrip", () => {
         expect(parsed?.id).toBe(brief.id);
         expect(parsed?.baseline.costUsd).toBe(1.20);
         expect(parsed?.parentSha).toBe("ab12cd34");
+        expect(parsed?.baselineIsSubagent).toBe(false);
+    });
+    test("subagent baseline renders a caution and roundtrips the flag", () => {
+        const md = renderSparBrief({ ...brief, baselineIsSubagent: true });
+        expect(md).toContain("baseline is a SUBAGENT session");
+        expect(md).toContain("baseline_is_subagent: true");
+        expect(parseSparBrief(md)?.baselineIsSubagent).toBe(true);
     });
     test("worktreeAbs puts the absolute path in the command but keeps frontmatter relative", () => {
         const md = renderSparBrief(brief, `/Users/x/ax/${brief.worktree}`);

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -42,6 +42,12 @@ export interface SparBrief {
     readonly baselineSession: string;
     readonly worktree: string;
     readonly baseline: SparMetrics;
+    /**
+     * True when the commit window had no main session and the baseline fell
+     * back to a subagent session - its metrics are not a re-runnable task, so
+     * the agent should pick a different (main-session-authored) sha.
+     */
+    readonly baselineIsSubagent: boolean;
     /** filled by the agent; "" at plan time */
     readonly delta: string;
 }
@@ -143,9 +149,13 @@ export const renderSparBrief = (brief: SparBrief, worktreeAbs?: string): string 
         `parent_sha: ${oneLine(brief.parentSha)}`,
         `baseline_session: ${oneLine(brief.baselineSession)}`,
         `worktree: ${oneLine(brief.worktree)}`,
+        `baseline_is_subagent: ${brief.baselineIsSubagent}`,
         "---",
         "",
         `# Spar: ${brief.id}`,
+        ...(brief.baselineIsSubagent
+            ? ["", "> ⚠ baseline is a SUBAGENT session, not a re-runnable task - pick a sha authored by a main session before sparring."]
+            : []),
         "",
         "## Task",
         "",
@@ -224,8 +234,9 @@ export const parseSparBrief = (content: string): SparBrief | null => {
     const prompt = section(content, "Task");
     const deltaRaw = section(content, "Delta");
     const delta = deltaRaw === DELTA_PLACEHOLDER ? "" : deltaRaw;
+    const baselineIsSubagent = field(content, "baseline_is_subagent") === "true";
 
-    return { id, createdAt, prompt, parentSha, baselineSession, worktree, baseline, delta };
+    return { id, createdAt, prompt, parentSha, baselineSession, worktree, baseline, baselineIsSubagent, delta };
 };
 
 // ---------------------------------------------------------------------------
@@ -415,10 +426,19 @@ export const captureBaseline = (
         // first_user_message, null turns/wall). Prefer main sessions; fall back
         // to the unfiltered list only when the window has no main session at all.
         const mainSessions = sessions.filter((s) => s.source === "claude");
-        const candidates = mainSessions.length > 0 ? mainSessions : sessions;
+        const baselineIsSubagent = mainSessions.length === 0;
+        const candidates = baselineIsSubagent ? sessions : mainSessions;
         const landedSession = candidates.reduce((best, s) =>
             s.turn_count > best.turn_count ? s : best,
         );
+        if (baselineIsSubagent) {
+            // The window holds only subagent sessions (common for commits whose
+            // work was done by dispatched agents). A subagent baseline is not a
+            // task a human would re-run; warn so the operator picks another sha.
+            console.error(
+                `ax dojo spar-plan: no main session in ${sha}'s commit window - baseline falls back to a subagent (${landedSession.id}). Its metrics are not a re-runnable task; prefer a sha authored by a main session.`,
+            );
+        }
 
         const metrics = yield* fetchSessionMetrics(landedSession.id, from);
         // Belt-and-suspenders: fetchSessionMetrics now derives landed from the
@@ -436,6 +456,7 @@ export const captureBaseline = (
             baselineSession: landedSession.id,
             worktree: `.claude/worktrees/dojo-spar-${id}`,
             baseline,
+            baselineIsSubagent,
             delta: "",
         };
     });


### PR DESCRIPTION
## What
Dogfooding `ax dojo spar-plan` on real commits surfaced a bug: when a commit's window has **no main session** (common — commits whose work was done by dispatched subagents), spar-plan silently baselined on a **subagent** session (e.g. a 27-turn code review), which is not a re-runnable task. The `source === "claude"` main-session filter was correct, but the graceful fallback picked the subagent with no signal.

## Fix
- `captureBaseline` now `console.error`-warns when it falls back to a subagent baseline (names the session + tells the operator to pick a main-session-authored sha).
- `SparBrief` carries `baselineIsSubagent` — surfaced in the brief frontmatter (`baseline_is_subagent:`), a `⚠ baseline is a SUBAGENT session` caution line in the body, and the `--json` output — so the dojo agent sees it before sparring.

## Test plan
- [x] spar/dojo/items/cli tests: 110 pass / 0 fail
- [x] typecheck clean
- [x] new tests: subagent caution renders + flag roundtrips through parse

Found via end-to-end dogfood of the merged dojo (#390/#403/#404/#405).

🤖 Generated with [Claude Code](https://claude.com/claude-code)