### PR TITLE
feat: quota-aware dispatch advisory (PR1) - the honest mechanism

### DIFF
--- a/apps/axctl/src/hooks/backtest.test.ts
+++ b/apps/axctl/src/hooks/backtest.test.ts
@@ -54,6 +54,7 @@ describe("replayRows", () => {
         expect(s.total).toBe(3);
         expect(s.wouldBlock).toBe(1);
         expect(s.wouldWarn).toBe(0);
+        expect(s.wouldAdvise).toBe(0);
         expect(s.skippedRows).toBe(0);
         expect(s.providers).toEqual(["claude", "codex"]);
         expect(s.byProject["/repo"]).toEqual({ total: 2, blocked: 1 });
@@ -114,12 +115,36 @@ describe("summarize", () => {
         expect(s.total).toBe(4);
         expect(s.wouldBlock).toBe(1);
         expect(s.wouldWarn).toBe(1);
+        expect(s.wouldAdvise).toBe(0);
         expect(s.byProject["/proj-a"]).toEqual({ total: 2, blocked: 1 });
         expect(s.byProject["/proj-b"]).toEqual({ total: 2, blocked: 0 });
         // Sample should have first line of reason only
         expect(s.samples).toHaveLength(1);
         expect(s.samples[0]?.reason).toBe("BLOCKED: line1");
         expect(s.samples[0]?.command).toBe("git checkout main");
+    });
+
+    test("counts Advise verdicts in wouldAdvise", () => {
+        const adviseVerdict = { _tag: "Advise" as const, context: "re-dispatch with model:sonnet" };
+        const allowVerdict = { _tag: "Allow" as const };
+        const makeRow = (project: string) => ({
+            name: "Agent",
+            input: { description: "implement something" },
+            cwd: project,
+            source: "claude",
+            project,
+            ts: new Date(),
+        });
+        const results = [
+            { row: makeRow("/proj-a"), verdict: adviseVerdict },
+            { row: makeRow("/proj-a"), verdict: adviseVerdict },
+            { row: makeRow("/proj-b"), verdict: allowVerdict },
+        ];
+        const s = summarize(results);
+        expect(s.total).toBe(3);
+        expect(s.wouldAdvise).toBe(2);
+        expect(s.wouldBlock).toBe(0);
+        expect(s.wouldWarn).toBe(0);
     });
 
     test("samples capped at 10", () => {
@@ -211,6 +236,7 @@ describe("formatReport", () => {
         total: 100,
         wouldBlock: 5,
         wouldWarn: 0,
+        wouldAdvise: 0,
         skippedRows: 0,
         providers: ["claude"],
         byProject: { "/repo": { total: 100, blocked: 5 } },

--- a/apps/axctl/src/hooks/backtest.ts
+++ b/apps/axctl/src/hooks/backtest.ts
@@ -42,6 +42,8 @@ export interface BacktestSummary {
     readonly total: number;
     readonly wouldBlock: number;
     readonly wouldWarn: number;
+    /** Dispatches that received a quota-aware advisory (Verdict.advise). */
+    readonly wouldAdvise: number;
     /** rows dropped before replay (missing/malformed input_json). */
     readonly skippedRows: number;
     /** distinct harness sources actually seen in the replayed rows. */
@@ -103,6 +105,7 @@ export const summarize = (
     const sources = new Set<string>();
     let wouldBlock = 0;
     let wouldWarn = 0;
+    let wouldAdvise = 0;
     for (const { row, verdict } of results) {
         sources.add(row.source);
         const key = row.project ?? "(unknown)";
@@ -121,11 +124,13 @@ export const summarize = (
             }
         }
         if (verdict._tag === "Warn") wouldWarn += 1;
+        if (verdict._tag === "Advise") wouldAdvise += 1;
     }
     return {
         total: results.length,
         wouldBlock,
         wouldWarn,
+        wouldAdvise,
         skippedRows,
         providers: [...sources].sort(),
         byProject,
@@ -317,6 +322,9 @@ export const formatReport = (
     );
     lines.push(
         `  would-warn    ${summary.wouldWarn.toLocaleString()}`,
+    );
+    lines.push(
+        `  would-advise  ${summary.wouldAdvise.toLocaleString()}`,
     );
     if (summary.skippedRows > 0) {
         lines.push(

--- a/apps/axctl/src/queries/routing-tune.test.ts
+++ b/apps/axctl/src/queries/routing-tune.test.ts
@@ -85,6 +85,10 @@ describe("clusterRows + buildProposals", () => {
 
     it("flags judgment clusters; pattern derives from the key with N -> \\d+", () => {
         const proposals = buildProposals(clusterRows(rows));
+        // "review-architecture" IS flagged by JUDGMENT_STRONG_RE because
+        // "architecture" matches architect\w* (JUDGMENT_STRONG_RE's architect pattern
+        // covers the full word including the "-ure" suffix). Bare "review" alone would
+        // not match - but "architecture" in the description does.
         const review = proposals.find((p) => p.id === "review-architecture");
         expect(review?.judgment).toBe(true);
         const summarize = proposals.find((p) => p.id === "summarize-the");
@@ -113,7 +117,7 @@ describe("clusterRows + buildProposals", () => {
         }
     });
 
-    it("judgment is computed over ALL rows, not just the first-3 examples", () => {
+    it("judgment scan covers ALL rows; bare 'review' no longer flags (JUDGMENT_STRONG_RE delta)", () => {
         const lateJudgment = [
             row("Migrate auth tokens", "general-purpose", 5),
             row("Migrate auth flows", "general-purpose", 4),
@@ -125,7 +129,9 @@ describe("clusterRows + buildProposals", () => {
         expect(migrate).toBeDefined();
         expect(migrate!.examples).toHaveLength(3);
         expect(migrate!.examples.some((e) => /review/i.test(e))).toBe(false);
-        expect(migrate!.judgment).toBe(true);
+        // With JUDGMENT_STRONG_RE, bare "review" in "Migrate auth review notes" does
+        // NOT trigger judgment. Old JUDGMENT_RE would have flagged this cluster.
+        expect(migrate!.judgment).toBe(false);
     });
 
     it("orders proposals by total cost desc and carries examples + counts", () => {
@@ -139,19 +145,41 @@ describe("clusterRows + buildProposals", () => {
 });
 
 describe("JUDGMENT_RE", () => {
-    it("matches review/critique/design/plan/audit/judge/verify/assess", () => {
-        for (const word of ["Review X", "Critique Y", "Design Z", "Plan the migration", "Audit deps", "Judge outputs", "Verify claims", "Assess risk"]) {
+    // JUDGMENT_RE is now JUDGMENT_STRONG_RE from @ax/hooks-sdk/spend-mode.
+    // Behavioral delta: bare "review", "plan*", "verif*", "assess*" no longer
+    // match. Only qualified reviews (quality/PR/final/adversarial/code review)
+    // and design/audit/architect*/critique/critic*/judg* are flagged.
+    it("matches qualified review kinds, design, audit, architect, critique, judge", () => {
+        for (const word of ["quality review of X", "PR review", "code review", "final review", "adversarial review", "Design Z", "Audit deps", "Judge outputs", "Critique Y"]) {
             expect(JUDGMENT_RE.test(word)).toBe(true);
         }
         expect(JUDGMENT_RE.test("Summarize the changelog")).toBe(false);
     });
-    it("matches inflected forms", () => {
-        for (const phrase of ["Planning the migration", "Reviewing PR #300", "Designing the schema", "Auditing deps", "Assessing risk"]) {
-            expect(JUDGMENT_RE.test(phrase)).toBe(true);
-        }
+    it("does NOT match bare review, plan, verify, assess (delta from old JUDGMENT_RE)", () => {
+        // These matched the old JUDGMENT_RE but JUDGMENT_STRONG_RE is intentionally narrower.
+        expect(JUDGMENT_RE.test("Review X")).toBe(false);
+        expect(JUDGMENT_RE.test("Plan the migration")).toBe(false);
+        expect(JUDGMENT_RE.test("Verify claims")).toBe(false);
+        expect(JUDGMENT_RE.test("Assess risk")).toBe(false);
+    });
+    it("matches architect forms and judg-wildcard; design/audit are exact words only", () => {
+        // architect\w* covers architects, architecture, etc.
+        expect(JUDGMENT_RE.test("architect the layer")).toBe(true);
+        expect(JUDGMENT_RE.test("architecture review")).toBe(true);
+        // judg\w* covers judge, judges, judging, judgment
+        expect(JUDGMENT_RE.test("judging the outputs")).toBe(true);
+        // design and audit match the exact word only (no \w* suffix in the regex)
+        expect(JUDGMENT_RE.test("design the API")).toBe(true);
+        expect(JUDGMENT_RE.test("audit the auth")).toBe(true);
+        // inflected forms of "design"/"audit" do NOT match (delta from old JUDGMENT_RE)
+        expect(JUDGMENT_RE.test("designing the schema")).toBe(false);
+        expect(JUDGMENT_RE.test("auditing deps")).toBe(false);
     });
     it("does not match unrelated words sharing a prefix", () => {
         expect(JUDGMENT_RE.test("Plant seeds")).toBe(false);
+    });
+    it("does not match spec review (deliberate route-down class)", () => {
+        expect(JUDGMENT_RE.test("spec review of PR #42")).toBe(false);
     });
 });
 

--- a/apps/axctl/src/queries/routing-tune.test.ts
+++ b/apps/axctl/src/queries/routing-tune.test.ts
@@ -13,6 +13,7 @@ import {
     fetchTuneProposals,
     applyProposals,
     JUDGMENT_RE,
+    JUDGMENT_GUARD_RE,
     renderTuneBrief,
     type TuneProposal,
 } from "./routing-tune.ts";
@@ -85,10 +86,6 @@ describe("clusterRows + buildProposals", () => {
 
     it("flags judgment clusters; pattern derives from the key with N -> \\d+", () => {
         const proposals = buildProposals(clusterRows(rows));
-        // "review-architecture" IS flagged by JUDGMENT_STRONG_RE because
-        // "architecture" matches architect\w* (JUDGMENT_STRONG_RE's architect pattern
-        // covers the full word including the "-ure" suffix). Bare "review" alone would
-        // not match - but "architecture" in the description does.
         const review = proposals.find((p) => p.id === "review-architecture");
         expect(review?.judgment).toBe(true);
         const summarize = proposals.find((p) => p.id === "summarize-the");
@@ -117,7 +114,7 @@ describe("clusterRows + buildProposals", () => {
         }
     });
 
-    it("judgment scan covers ALL rows; bare 'review' no longer flags (JUDGMENT_STRONG_RE delta)", () => {
+    it("judgment is computed over ALL rows, not just the first-3 examples", () => {
         const lateJudgment = [
             row("Migrate auth tokens", "general-purpose", 5),
             row("Migrate auth flows", "general-purpose", 4),
@@ -129,9 +126,33 @@ describe("clusterRows + buildProposals", () => {
         expect(migrate).toBeDefined();
         expect(migrate!.examples).toHaveLength(3);
         expect(migrate!.examples.some((e) => /review/i.test(e))).toBe(false);
-        // With JUDGMENT_STRONG_RE, bare "review" in "Migrate auth review notes" does
-        // NOT trigger judgment. Old JUDGMENT_RE would have flagged this cluster.
-        expect(migrate!.judgment).toBe(false);
+        // The broad JUDGMENT_GUARD_RE flags bare "review" in "Migrate auth review
+        // notes" (a non-example row) - one judgment member taints the cluster so it
+        // never auto-applies.
+        expect(migrate!.judgment).toBe(true);
+    });
+
+    it("auto-apply SAFETY: Plan/Verify clusters stay judgment-flagged (out of unattended auto-apply)", () => {
+        // These clusters previously regressed: the narrowed hook regex let them
+        // flow into `ax routing tune` (bare) auto-apply as route-down-to-sonnet
+        // classes. The broad JUDGMENT_GUARD_RE keeps them flagged → brief path only.
+        const planRows = [
+            row("Plan the migration steps", "general-purpose", 5),
+            row("Plan the rollout phases", "general-purpose", 4),
+            row("Plan the cutover order", "general-purpose", 3),
+        ];
+        const plan = buildProposals(clusterRows(planRows)).find((p) => p.id === "plan-the");
+        expect(plan).toBeDefined();
+        expect(plan!.judgment).toBe(true);
+
+        const verifyRows = [
+            row("Verify the claims hold", "general-purpose", 5),
+            row("Verify the invariants", "general-purpose", 4),
+            row("Verify the migration output", "general-purpose", 3),
+        ];
+        const verify = buildProposals(clusterRows(verifyRows)).find((p) => p.id === "verify-the");
+        expect(verify).toBeDefined();
+        expect(verify!.judgment).toBe(true);
     });
 
     it("orders proposals by total cost desc and carries examples + counts", () => {
@@ -144,42 +165,28 @@ describe("clusterRows + buildProposals", () => {
     });
 });
 
-describe("JUDGMENT_RE", () => {
-    // JUDGMENT_RE is now JUDGMENT_STRONG_RE from @ax/hooks-sdk/spend-mode.
-    // Behavioral delta: bare "review", "plan*", "verif*", "assess*" no longer
-    // match. Only qualified reviews (quality/PR/final/adversarial/code review)
-    // and design/audit/architect*/critique/critic*/judg* are flagged.
-    it("matches qualified review kinds, design, audit, architect, critique, judge", () => {
-        for (const word of ["quality review of X", "PR review", "code review", "final review", "adversarial review", "Design Z", "Audit deps", "Judge outputs", "Critique Y"]) {
+describe("JUDGMENT_RE (broad auto-apply guard - aliases JUDGMENT_GUARD_RE)", () => {
+    // JUDGMENT_RE / JUDGMENT_GUARD_RE is the BROAD safety classifier for what may
+    // be auto-applied unattended. It is DELIBERATELY DIFFERENT from the hook's
+    // narrow JUDGMENT_STRONG_RE (spend-mode.ts), which wants bare/spec review to
+    // route down. This guard over-flags so planning/review/verify/assess clusters
+    // never auto-apply as route-down classes.
+    it("matches review/critique/design/plan/audit/judge/verify/assess", () => {
+        for (const word of ["Review X", "Critique Y", "Design Z", "Plan the migration", "Audit deps", "Judge outputs", "Verify claims", "Assess risk"]) {
             expect(JUDGMENT_RE.test(word)).toBe(true);
         }
         expect(JUDGMENT_RE.test("Summarize the changelog")).toBe(false);
     });
-    it("does NOT match bare review, plan, verify, assess (delta from old JUDGMENT_RE)", () => {
-        // These matched the old JUDGMENT_RE but JUDGMENT_STRONG_RE is intentionally narrower.
-        expect(JUDGMENT_RE.test("Review X")).toBe(false);
-        expect(JUDGMENT_RE.test("Plan the migration")).toBe(false);
-        expect(JUDGMENT_RE.test("Verify claims")).toBe(false);
-        expect(JUDGMENT_RE.test("Assess risk")).toBe(false);
-    });
-    it("matches architect forms and judg-wildcard; design/audit are exact words only", () => {
-        // architect\w* covers architects, architecture, etc.
-        expect(JUDGMENT_RE.test("architect the layer")).toBe(true);
-        expect(JUDGMENT_RE.test("architecture review")).toBe(true);
-        // judg\w* covers judge, judges, judging, judgment
-        expect(JUDGMENT_RE.test("judging the outputs")).toBe(true);
-        // design and audit match the exact word only (no \w* suffix in the regex)
-        expect(JUDGMENT_RE.test("design the API")).toBe(true);
-        expect(JUDGMENT_RE.test("audit the auth")).toBe(true);
-        // inflected forms of "design"/"audit" do NOT match (delta from old JUDGMENT_RE)
-        expect(JUDGMENT_RE.test("designing the schema")).toBe(false);
-        expect(JUDGMENT_RE.test("auditing deps")).toBe(false);
+    it("matches inflected forms", () => {
+        for (const phrase of ["Planning the migration", "Reviewing PR #300", "Designing the schema", "Auditing deps", "Assessing risk"]) {
+            expect(JUDGMENT_RE.test(phrase)).toBe(true);
+        }
     });
     it("does not match unrelated words sharing a prefix", () => {
         expect(JUDGMENT_RE.test("Plant seeds")).toBe(false);
     });
-    it("does not match spec review (deliberate route-down class)", () => {
-        expect(JUDGMENT_RE.test("spec review of PR #42")).toBe(false);
+    it("JUDGMENT_RE is the JUDGMENT_GUARD_RE alias (same broad pattern)", () => {
+        expect(JUDGMENT_RE).toBe(JUDGMENT_GUARD_RE);
     });
 });
 

--- a/apps/axctl/src/queries/routing-tune.ts
+++ b/apps/axctl/src/queries/routing-tune.ts
@@ -24,7 +24,6 @@
  * classes (with the same corrupt-file guard as `ax routing compile`).
  */
 import { Effect, FileSystem, Path } from "effect";
-import { JUDGMENT_STRONG_RE } from "@ax/hooks-sdk/spend-mode";
 import {
     fetchDispatches,
     matchRoutingWith,
@@ -42,21 +41,34 @@ import {
 } from "./routing-table-io.ts";
 
 /**
- * Re-export the shared judgment regex from hooks-sdk/spend-mode (single source of truth).
+ * Broad SAFETY guard for unattended auto-apply - DELIBERATELY DIFFERENT from the
+ * hook's JUDGMENT_STRONG_RE (spend-mode.ts), not a duplicate to collapse.
  *
- * Behavioral delta vs the former local JUDGMENT_RE:
- *   Old: matched bare "review", "plan", "verif", "assess" in addition to the
- *        qualified review forms and design/audit/architect.../critique/judg...
- *   New (JUDGMENT_STRONG_RE): matches only qualified reviews (quality/PR/final/
- *        adversarial/code review), design, audit, architect..., critique, critic..., judg...
+ * The two consumers have opposite purposes:
+ *   - The route-dispatch hook uses JUDGMENT_STRONG_RE (narrow, review-focused): it
+ *     WANTS bare/spec review to route down to a cheaper model (that's an advisory
+ *     nudge, reversible by the operator). Narrow is correct there.
+ *   - routing-tune uses this broad guard: `ax routing tune` (bare, no flags)
+ *     auto-applies all NON-judgment proposals to ~/.ax/hooks/routing-table.json
+ *     UNATTENDED. A cluster wrongly classified as mechanical gets silently written
+ *     as a route-down-to-sonnet class. So the auto-apply gate must err toward
+ *     OVER-flagging: any cluster smelling of planning/review/verification/assessment
+ *     is diverted to the human/agent brief path (--emit-brief), never auto-applied.
  *
- * Effect on routing-tune: clusters whose keys contain bare "review", "plan", "verify",
- * or "assess" will no longer be auto-flagged as judgment. They will either
- * auto-apply (if non-judgment) or surface via --emit-brief for human review.
- * This is the defensible call: JUDGMENT_STRONG_RE is the authoritative signal;
- * routing-tune's --emit-brief + agent vetting is the backstop for ambiguous clusters.
+ * Matches bare "review", "plan", "verif", "assess" (with inflections), plus
+ * critique, critic, design, audit, architect, judg (each with a -wildcard) and
+ * the qualified reviews. This is the ORIGINAL pre-collapse pattern, restored
+ * after the regex-unification regression (a narrowed guard let "Plan", "Review",
+ * "Verify", and "Assess" clusters auto-apply as route-down classes).
  */
-export const JUDGMENT_RE = JUDGMENT_STRONG_RE;
+export const JUDGMENT_GUARD_RE =
+    /\b(review\w*|critique\w*|critic\w*|design\w*|plan(s|ned|ning)?|audit\w*|judg\w*|verif\w*|assess\w*|architect\w*)\b/i;
+
+/**
+ * Backward-compat alias. routing-tune's judgment flag uses JUDGMENT_GUARD_RE; this
+ * export name is kept for callers/tests that historically imported JUDGMENT_RE.
+ */
+export const JUDGMENT_RE = JUDGMENT_GUARD_RE;
 
 export interface TuneProposal {
     readonly id: string;
@@ -128,9 +140,11 @@ export const buildProposals = (
             .filter((d) => d.length > 0);
         // Judgment scans the key and EVERY row's description (not just the
         // first-3 examples) - one judgment-work member taints the cluster.
+        // Uses the BROAD JUDGMENT_GUARD_RE (not the hook's narrow regex): this
+        // gate decides what may be auto-applied unattended, so it must over-flag.
         const judgment =
-            JUDGMENT_RE.test(key) ||
-            rows.some((r) => r.description !== null && JUDGMENT_RE.test(r.description));
+            JUDGMENT_GUARD_RE.test(key) ||
+            rows.some((r) => r.description !== null && JUDGMENT_GUARD_RE.test(r.description));
         proposals.push({
             id: key.replace(/\s+/g, "-"),
             pattern: keyToPattern(key),

--- a/apps/axctl/src/queries/routing-tune.ts
+++ b/apps/axctl/src/queries/routing-tune.ts
@@ -24,6 +24,7 @@
  * classes (with the same corrupt-file guard as `ax routing compile`).
  */
 import { Effect, FileSystem, Path } from "effect";
+import { JUDGMENT_STRONG_RE } from "@ax/hooks-sdk/spend-mode";
 import {
     fetchDispatches,
     matchRoutingWith,
@@ -40,8 +41,22 @@ import {
     type StoredRoutingClass,
 } from "./routing-table-io.ts";
 
-export const JUDGMENT_RE =
-    /\b(review\w*|critique\w*|critic\w*|design\w*|plan(s|ned|ning)?|audit\w*|judg\w*|verif\w*|assess\w*|architect\w*)\b/i;
+/**
+ * Re-export the shared judgment regex from hooks-sdk/spend-mode (single source of truth).
+ *
+ * Behavioral delta vs the former local JUDGMENT_RE:
+ *   Old: matched bare "review", "plan", "verif", "assess" in addition to the
+ *        qualified review forms and design/audit/architect.../critique/judg...
+ *   New (JUDGMENT_STRONG_RE): matches only qualified reviews (quality/PR/final/
+ *        adversarial/code review), design, audit, architect..., critique, critic..., judg...
+ *
+ * Effect on routing-tune: clusters whose keys contain bare "review", "plan", "verify",
+ * or "assess" will no longer be auto-flagged as judgment. They will either
+ * auto-apply (if non-judgment) or surface via --emit-brief for human review.
+ * This is the defensible call: JUDGMENT_STRONG_RE is the authoritative signal;
+ * routing-tune's --emit-brief + agent vetting is the backstop for ambiguous clusters.
+ */
+export const JUDGMENT_RE = JUDGMENT_STRONG_RE;
 
 export interface TuneProposal {
     readonly id: string;

--- a/docs/superpowers/plans/2026-06-15-dispatch-economy.md
+++ b/docs/superpowers/plans/2026-06-15-dispatch-economy.md
@@ -1,0 +1,568 @@
+# Quota-aware dispatch economy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make subagent model-routing quota-aware: auto-route forgotten cheap-able dispatches in conserve mode, relax (subtractive) near a 7d reset (splurge), warn when judgment work is sent cheap, keep the quota signal fresh, and nudge `/dojo` in splurge. Per spec `docs/superpowers/specs/2026-06-15-dispatch-economy-enforcement-design.md`.
+
+**Architecture:** A pure `computeSpendMode` + a pure `decideVerdict` in `packages/hooks-sdk` (hot-path, effect-only). The route-dispatch hook gains a new `Verdict.route(input)` (silent `updatedInput` rewrite). Everything keys off one knob: `routeDownEnforced = (mode === "conserve")`. PR1 = the conserve logic (works safely against whatever cache exists; stale/missing → conserve). PR2 = freshness (SessionStart + interval refresh) + the `/dojo` nudge + statusline surface + a measurement lens.
+
+**Tech Stack:** bun ≥1.3, TS strict, Effect v4 beta, bun:test. hooks-sdk is `effect`-only (no @ax/lib in the ~70ms hot path).
+
+**Conventions:** Worktree `/Users/necmttn/Projects/ax/.claude/worktrees/dispatch-economy` (branch `feat/dispatch-economy`). Test = `bun test <path>` (tmp wrapper if a hook blocks bare `bun test`). hooks-sdk uses sync `node:fs` on the fire path (precedent: `readRoutingTableSync`). Commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+**Grounding (verified post-#411):**
+- `Verdict` union + constructors: `packages/hooks-sdk/src/verdict.ts` (Allow/Block/Warn/Inject).
+- `encodeVerdict(v, harness) → {exitCode:0|2, stdout?, stderr?}`: `packages/hooks-sdk/src/adapters/encode.ts:17`. Warn → `{exitCode:0, stdout: JSON.stringify({systemMessage})}`. Inject → `{exitCode:0, stdout: context}`.
+- route-dispatch.ts: `run: (event) => Effect.sync(...)`, reads `event.tool.input` (`model`, `subagent_type`, `description`, `prompt`), calls `matchRoutingTable(loadRoutingTableOrDefault(), description, subagentType)` → `RoutingMatch{classId,suggest,reason,source} | null`.
+- `readRoutingTableSync(path?)` sync precedent: `packages/hooks-sdk/src/routing-table.ts:250`. `defaultRoutingTablePath()` = `~/.ax/hooks/routing-table.json`.
+- `QuotaSnapshot` (`apps/axctl/src/quota/schema.ts:48`): `{ v:1, fetched_at:string, five_hour, seven_day, ... }`, each window `{ utilization:number, resets_at:string } | null`. Cache path `~/.ax/quota-cache.json` (`cache.ts:13`).
+- route-dispatch.test.ts harness: builds `{harness:"claude", event:"PreToolUse", tool:{name:"Agent", input}, ...}` and asserts `v._tag`.
+- `JUDGMENT_RE`: `apps/axctl/src/queries/routing-tune.ts` (the dup to collapse).
+- hooks-sdk deps: `effect` only.
+
+---
+
+## PR1 - conserve auto-route
+
+### Task 1: `Verdict.route` + encoding
+
+**Files:** Modify `packages/hooks-sdk/src/verdict.ts`, `packages/hooks-sdk/src/adapters/encode.ts`; Test `packages/hooks-sdk/src/adapters/encode.test.ts`
+
+- [ ] **Step 1: failing test** (extend or create encode.test.ts)
+
+```ts
+// packages/hooks-sdk/src/adapters/encode.test.ts
+import { describe, expect, test } from "bun:test";
+import { encodeVerdict } from "./encode.ts";
+import { Verdict } from "../verdict.ts";
+
+describe("encodeVerdict Route", () => {
+    test("claude: emits permissionDecision allow + updatedInput", () => {
+        const out = encodeVerdict(Verdict.route({ description: "Implement X", model: "sonnet" }), "claude");
+        expect(out.exitCode).toBe(0);
+        const json = JSON.parse(out.stdout!);
+        expect(json.hookSpecificOutput).toEqual({
+            hookEventName: "PreToolUse",
+            permissionDecision: "allow",
+            updatedInput: { description: "Implement X", model: "sonnet" },
+        });
+    });
+    test("codex: Route degrades to allow (no Agent dispatch / different protocol)", () => {
+        const out = encodeVerdict(Verdict.route({ model: "sonnet" }), "codex");
+        expect(out).toEqual({ exitCode: 0 });
+    });
+});
+```
+
+- [ ] **Step 2: run -> FAIL** (`bun test packages/hooks-sdk/src/adapters/encode.test.ts`) - `Verdict.route` not a function.
+
+- [ ] **Step 3: implement** - verdict.ts: add the variant carrying the FULL merged input (not just the model).
+
+```ts
+// packages/hooks-sdk/src/verdict.ts
+export type Verdict =
+    | { readonly _tag: "Allow" }
+    | { readonly _tag: "Block"; readonly reason: string }
+    | { readonly _tag: "Warn"; readonly message: string }
+    | { readonly _tag: "Inject"; readonly context: string }
+    | { readonly _tag: "Route"; readonly input: Record<string, unknown> };
+
+export const Verdict = {
+    allow: { _tag: "Allow" },
+    block: (reason: string): Verdict => ({ _tag: "Block", reason }),
+    warn: (message: string): Verdict => ({ _tag: "Warn", message }),
+    inject: (context: string): Verdict => ({ _tag: "Inject", context }),
+    /** Silently rewrite the tool input (PreToolUse allow + updatedInput). `input` is the FULL merged input. */
+    route: (input: Record<string, unknown>): Verdict => ({ _tag: "Route", input }),
+} as const;
+```
+
+encode.ts: add the Route case, gated to claude (codex has no updatedInput protocol here → allow):
+
+```ts
+// packages/hooks-sdk/src/adapters/encode.ts (inside the switch, before closing brace)
+        case "Route":
+            return _harness === "claude"
+                ? {
+                    exitCode: 0,
+                    stdout: JSON.stringify({
+                        hookSpecificOutput: {
+                            hookEventName: "PreToolUse",
+                            permissionDecision: "allow",
+                            updatedInput: v.input,
+                        },
+                    }),
+                }
+                : { exitCode: 0 };
+```
+(Rename the `_harness` param to `harness` since it's now used.)
+
+- [ ] **Step 4: run -> PASS**
+- [ ] **Step 5: commit** `feat(hooks-sdk): Verdict.route - silent updatedInput rewrite`
+
+---
+
+### Task 2: spend-mode module (pure)
+
+**Files:** Create `packages/hooks-sdk/src/spend-mode.ts`, `packages/hooks-sdk/src/spend-mode.test.ts`
+
+This module owns: the minimal `QuotaSnapshot` type, `readQuotaCacheSync`, `computeSpendMode`, and the single `JUDGMENT_STRONG_RE`.
+
+- [ ] **Step 1: failing test**
+
+```ts
+// packages/hooks-sdk/src/spend-mode.test.ts
+import { describe, expect, test } from "bun:test";
+import { computeSpendMode, DEFAULT_SPEND_CONFIG, JUDGMENT_STRONG_RE } from "./spend-mode.ts";
+import type { QuotaSnapshot } from "./spend-mode.ts";
+
+const NOW = Date.parse("2026-06-15T12:00:00.000Z");
+const snap = (o: Partial<QuotaSnapshot> = {}): QuotaSnapshot => ({
+    v: 1,
+    fetched_at: new Date(NOW - 30_000).toISOString(), // 30s old → fresh
+    five_hour: { utilization: 10, resets_at: new Date(NOW + 3 * 3600_000).toISOString() },
+    seven_day: { utilization: 40, resets_at: new Date(NOW + 12 * 3600_000).toISOString() }, // 12h to reset, 60% left
+    ...o,
+});
+
+describe("computeSpendMode", () => {
+    test("splurge: 7d near reset (<24h) + headroom (>25%) + no window near cap", () => {
+        const r = computeSpendMode(snap(), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("splurge");
+        expect(r.stale).toBe(false);
+    });
+    test("conserve: 7d NOT near reset (resets in 3 days)", () => {
+        const r = computeSpendMode(snap({ seven_day: { utilization: 40, resets_at: new Date(NOW + 72 * 3600_000).toISOString() } }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve");
+    });
+    test("conserve: 7d near reset but low headroom (only 20% left)", () => {
+        const r = computeSpendMode(snap({ seven_day: { utilization: 80, resets_at: new Date(NOW + 12 * 3600_000).toISOString() } }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve"); // 100-80=20 not > 25
+    });
+    test("conserve: a window near its cap (5h at 85%) blocks splurge even with 7d headroom", () => {
+        const r = computeSpendMode(snap({ five_hour: { utilization: 85, resets_at: new Date(NOW + 3600_000).toISOString() } }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve"); // capFloorPct=80, 85>=80
+    });
+    test("conserve + stale when cache older than stalenessMs", () => {
+        const r = computeSpendMode(snap({ fetched_at: new Date(NOW - 10 * 60_000).toISOString() }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve");
+        expect(r.stale).toBe(true);
+    });
+    test("conserve when seven_day is null", () => {
+        expect(computeSpendMode(snap({ seven_day: null }), NOW, DEFAULT_SPEND_CONFIG).mode).toBe("conserve");
+    });
+    test("the 5h window never triggers splurge on its own (7d far from reset)", () => {
+        const r = computeSpendMode(snap({
+            five_hour: { utilization: 10, resets_at: new Date(NOW + 60 * 60_000).toISOString() }, // 5h resets in 1h, lots left
+            seven_day: { utilization: 40, resets_at: new Date(NOW + 72 * 3600_000).toISOString() }, // 7d far
+        }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve");
+    });
+    test("resets_at parse failure on 7d → conserve", () => {
+        const r = computeSpendMode(snap({ seven_day: { utilization: 40, resets_at: "not-a-date" } }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve");
+    });
+});
+
+describe("JUDGMENT_STRONG_RE", () => {
+    test("matches strong judgment kinds", () => {
+        for (const s of ["quality review of X", "PR review", "final review", "design the migration", "audit the auth", "architect the layer", "adversarial review", "code review", "judge the reports"]) {
+            expect(JUDGMENT_STRONG_RE.test(s)).toBe(true);
+        }
+    });
+    test("does NOT match spec review (deliberate route-down class)", () => {
+        expect(JUDGMENT_STRONG_RE.test("spec review of PR #42")).toBe(false);
+        expect(JUDGMENT_STRONG_RE.test("spec-compliance review")).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: run -> FAIL**
+
+- [ ] **Step 3: implement**
+
+```ts
+// packages/hooks-sdk/src/spend-mode.ts
+import { readFileSync } from "node:fs";
+
+export interface QuotaWindow { readonly utilization: number; readonly resets_at: string }
+export interface QuotaSnapshot {
+    readonly v: 1;
+    readonly fetched_at: string;
+    readonly five_hour: QuotaWindow | null;
+    readonly seven_day: QuotaWindow | null;
+    readonly [k: string]: unknown;
+}
+
+export type SpendMode = "conserve" | "splurge";
+export interface SpendModeResult { readonly mode: SpendMode; readonly reason: string; readonly stale: boolean }
+
+export interface SpendConfig {
+    readonly stalenessMs: number;
+    readonly nearResetMs7d: number;
+    readonly minRemainingPct: number;
+    readonly capFloorPct: number;
+}
+export const DEFAULT_SPEND_CONFIG: SpendConfig = {
+    stalenessMs: 5 * 60_000,
+    nearResetMs7d: 24 * 3600_000,
+    minRemainingPct: 25,
+    capFloorPct: 80,
+};
+
+const parseMs = (iso: string): number | null => {
+    const ms = Date.parse(iso);
+    return Number.isFinite(ms) ? ms : null;
+};
+
+/**
+ * Strong judgment work that must stay on the main/strong model. Matches
+ * quality/pr/final/adversarial/code review, design, audit, architect, critique,
+ * judge - and deliberately NOT "spec" review (a route-down class). The negative
+ * lookbehind-free guard: require the review kinds to not be preceded by "spec".
+ */
+export const JUDGMENT_STRONG_RE =
+    /\b(?:(?:quality|pr|final|adversarial|code)\s+review|design|audit|architect\w*|critique|critic\w*|judg\w*)\b/i;
+// Note: a bare "review" or "spec review" does NOT match (only the qualified review kinds above do).
+
+export const computeSpendMode = (
+    snapshot: QuotaSnapshot | null,
+    nowMs: number,
+    config: SpendConfig,
+): SpendModeResult => {
+    if (snapshot === null) return { mode: "conserve", reason: "no cache", stale: true };
+    const fetchedMs = parseMs(snapshot.fetched_at);
+    const stale = fetchedMs === null || nowMs - fetchedMs > config.stalenessMs;
+    if (stale) return { mode: "conserve", reason: "stale cache", stale: true };
+
+    const sevenDay = snapshot.seven_day;
+    if (!sevenDay) return { mode: "conserve", reason: "no 7d window", stale: false };
+    const resetMs = parseMs(sevenDay.resets_at);
+    if (resetMs === null) return { mode: "conserve", reason: "bad 7d resets_at", stale: false };
+
+    const nearReset = resetMs - nowMs < config.nearResetMs7d;
+    const headroom = 100 - sevenDay.utilization > config.minRemainingPct;
+    const sevenNearCap = sevenDay.utilization >= config.capFloorPct;
+    const fiveNearCap = snapshot.five_hour ? snapshot.five_hour.utilization >= config.capFloorPct : false;
+
+    if (nearReset && headroom && !sevenNearCap && !fiveNearCap) {
+        return { mode: "splurge", reason: "7d reset soon with surplus", stale: false };
+    }
+    return { mode: "conserve", reason: "default", stale: false };
+};
+
+/** Sync, fail-open cache read on the fire path (mirrors readRoutingTableSync). */
+export const readQuotaCacheSync = (path: string): QuotaSnapshot | null => {
+    try {
+        const raw = readFileSync(path, "utf8");
+        const parsed = JSON.parse(raw) as QuotaSnapshot;
+        if (parsed && parsed.v === 1 && typeof parsed.fetched_at === "string") return parsed;
+        return null;
+    } catch {
+        return null;
+    }
+};
+
+export const defaultQuotaCachePath = (): string => `${process.env.HOME}/.ax/quota-cache.json`;
+```
+
+- [ ] **Step 4: run -> PASS** (verify JUDGMENT_STRONG_RE: confirm a plain "review the code" doesn't accidentally match; if the regex over/under-matches the test cases, adjust the alternation and re-run - the test is authoritative).
+- [ ] **Step 5: commit** `feat(hooks-sdk): spend-mode signal + sync quota cache reader + judgment regex`
+
+---
+
+### Task 3: `decideVerdict` (pure, ordered)
+
+**Files:** Create `packages/hooks-sdk/src/decide-verdict.ts`, `packages/hooks-sdk/src/decide-verdict.test.ts`
+
+- [ ] **Step 1: failing test** - enumerate the input space; assert each verdict tag.
+
+```ts
+// packages/hooks-sdk/src/decide-verdict.test.ts
+import { describe, expect, test } from "bun:test";
+import { decideVerdict } from "./decide-verdict.ts";
+
+const inp = (o: Partial<Parameters<typeof decideVerdict>[0]>) => ({
+    match: null, explicit: false, cheap: false, judgmentStrong: false, routeDownEnforced: true,
+    input: { description: "x" }, suggest: "sonnet", ...o,
+});
+
+describe("decideVerdict", () => {
+    test("judgment + cheap → Warn (rule 0, any mode)", () => {
+        expect(decideVerdict(inp({ judgmentStrong: true, explicit: true, cheap: true }))._tag).toBe("Warn");
+    });
+    test("judgment + cheap → Warn even in splurge", () => {
+        expect(decideVerdict(inp({ judgmentStrong: true, explicit: true, cheap: true, routeDownEnforced: false }))._tag).toBe("Warn");
+    });
+    test("explicit (non-judgment) → Allow, never overridden", () => {
+        expect(decideVerdict(inp({ explicit: true, cheap: false }))._tag).toBe("Allow");
+        expect(decideVerdict(inp({ explicit: true, cheap: true }))._tag).toBe("Allow"); // explicit cheap, not judgment
+    });
+    test("match + inherit + conserve → Route(suggest)", () => {
+        const v = decideVerdict(inp({ match: true, routeDownEnforced: true }));
+        expect(v._tag).toBe("Route");
+        if (v._tag === "Route") expect(v.input.model).toBe("sonnet");
+    });
+    test("match + inherit + splurge → Allow (subtractive: runs on strong inherited model)", () => {
+        expect(decideVerdict(inp({ match: true, routeDownEnforced: false }))._tag).toBe("Allow");
+    });
+    test("no match + inherit → Allow", () => {
+        expect(decideVerdict(inp({ match: false }))._tag).toBe("Allow");
+    });
+    test("judgment + inherit (strong) any mode → Allow (not warned, not routed)", () => {
+        expect(decideVerdict(inp({ judgmentStrong: true, explicit: false }))._tag).toBe("Allow");
+    });
+    test("match + judgment + inherit + conserve → Allow (judgment is NEVER routed down)", () => {
+        expect(decideVerdict(inp({ match: true, judgmentStrong: true, routeDownEnforced: true }))._tag).toBe("Allow");
+    });
+});
+```
+
+- [ ] **Step 2: run -> FAIL**
+
+- [ ] **Step 3: implement**
+
+```ts
+// packages/hooks-sdk/src/decide-verdict.ts
+import { Verdict } from "./verdict.ts";
+
+export interface DecideInput {
+    readonly match: boolean;            // matched a route-down class
+    readonly explicit: boolean;         // explicit model set
+    readonly cheap: boolean;            // explicit model is sonnet/haiku
+    readonly judgmentStrong: boolean;   // stays-strong judgment kind
+    readonly routeDownEnforced: boolean; // = (mode === conserve)
+    readonly input: Record<string, unknown>; // original Agent input (for Route merge)
+    readonly suggest: string;           // the class's suggested cheaper model
+}
+
+/** Ordered decision; first rule wins. Judgment is rule 0 (never routed/blocked). */
+export const decideVerdict = (i: DecideInput): Verdict => {
+    // Rule 0: judgment work sent on a cheap model → warn (any mode).
+    if (i.judgmentStrong && i.cheap) {
+        return Verdict.warn(
+            "judgment work (review/design/audit) is the catch-rate gate - prefer the strong model (drop the cheap `model:` or set model:opus).",
+        );
+    }
+    // Rule 1: an explicit model is a deliberate choice - never override.
+    if (i.explicit) return Verdict.allow;
+    // Rule 2: conserve + forgotten route-down → silently rewrite to the cheaper
+    // tier. `!judgmentStrong` enforces judgment-precedence: judgment work that
+    // also matched a class (class/regex drift) is NEVER routed down.
+    if (i.match && i.routeDownEnforced && !i.judgmentStrong) {
+        return Verdict.route({ ...i.input, model: i.suggest });
+    }
+    // Rule 3: everything else (incl. splurge+match+inherit = strong inherited model). 
+    return Verdict.allow;
+};
+```
+
+- [ ] **Step 4: run -> PASS** (all 8 assertions, covering the distinct outcomes across the 32-cell input space; many cells collapse to the same verdict).
+
+- [ ] **Step 5: commit** `feat(hooks-sdk): decideVerdict - ordered route/warn/allow decision`
+
+---
+
+### Task 4: wire route-dispatch to spend mode + auto-route
+
+**Files:** Modify `packages/hooks-sdk/src/hooks/route-dispatch.ts`, `packages/hooks-sdk/src/hooks/route-dispatch.test.ts`
+
+- [ ] **Step 1: rewrite the hook body** to compute inputs + delegate to `decideVerdict`.
+
+```ts
+// packages/hooks-sdk/src/hooks/route-dispatch.ts (run body)
+run: (event) =>
+    Effect.sync(() => {
+        const input = (event.tool?.input ?? {}) as Record<string, unknown>;
+        const modelRaw = input.model;
+        const explicit = typeof modelRaw === "string" && modelRaw.length > 0;
+        const cheap = explicit && /sonnet|haiku/i.test(modelRaw as string);
+        const subagentType = typeof input.subagent_type === "string" ? input.subagent_type : undefined;
+        const rawDescription = typeof input.description === "string" ? input.description : undefined;
+        const rawPrompt = typeof input.prompt === "string" ? input.prompt.slice(0, 120) : undefined;
+        const description = rawDescription ?? rawPrompt;
+
+        const table = loadRoutingTableOrDefault();
+        const match = matchRoutingTable(table, description, subagentType);
+        const judgmentStrong = description !== undefined && JUDGMENT_STRONG_RE.test(description);
+
+        // mode (conserve unless a fresh cache says splurge). Env override wins.
+        const envMode = process.env.AX_SPEND_MODE;
+        const computed = computeSpendMode(readQuotaCacheSync(defaultQuotaCachePath()), Date.now(), DEFAULT_SPEND_CONFIG);
+        const mode = envMode === "conserve" || envMode === "splurge" ? envMode : computed.mode;
+
+        return decideVerdict({
+            match: match !== null,
+            explicit,
+            cheap,
+            judgmentStrong,
+            routeDownEnforced: mode === "conserve",
+            input,
+            suggest: match?.suggest ?? "sonnet",
+        });
+    }),
+```
+Add imports: `decideVerdict` from `../decide-verdict.ts`; `computeSpendMode, readQuotaCacheSync, defaultQuotaCachePath, DEFAULT_SPEND_CONFIG, JUDGMENT_STRONG_RE` from `../spend-mode.ts`.
+
+- [ ] **Step 2: update route-dispatch.test.ts** - the existing tests asserted `Warn`; now conserve+match+inherit → `Route`. Update them, and add: explicit-cheap on a route-down class → Allow; judgment-cheap → Warn; an `AX_SPEND_MODE=splurge` env case → match+inherit → Allow. Run `bun test packages/hooks-sdk/src/hooks/route-dispatch.test.ts` → PASS. (The harness sets `process.env.AX_SPEND_MODE`; reset it between tests.)
+
+- [ ] **Step 3: backtest** `bun packages/hooks-sdk/src/hooks/route-dispatch.ts` is the fire path; run `ax hooks backtest ~/.ax/hooks/route-dispatch.ts --days=2` - confirm it replays without error and that `Implement …` rows now resolve to a route verdict in conserve (the backtest reports verdicts).
+
+- [ ] **Step 4: LIVE SMOKE (the load-bearing verification)** - confirm the two unverified mechanisms actually work in Claude Code:
+  1. **updatedInput rewrite:** install the updated hook (`ax hooks install <abs route-dispatch.ts>`), then in a scratch Claude Code session dispatch an Agent with `description:"Implement something"` and NO model; verify (via `ax dispatches` after, or the hook's own stderr/transcript) that it ran on **sonnet**, not the inherited model. If `updatedInput` does NOT take effect, FALL BACK to the `permissionDecision: deny` + reason encoding (block) and record that finding - do not ship a silent no-op.
+  2. **systemMessage warn reaches the model:** dispatch a `quality review …` with `model:sonnet`; confirm the warn surfaces to the agent. If it only reaches the user, note it (warn is advisory; acceptable, but record the truth).
+  PASTE the smoke evidence.
+
+- [ ] **Step 5: commit** `feat(hooks): route-dispatch auto-routes in conserve via spend mode`
+
+---
+
+### Task 5: collapse the duplicate judgment regex
+
+**Files:** Modify `apps/axctl/src/queries/routing-tune.ts`
+
+- [ ] **Step 1:** replace the local `JUDGMENT_RE` definition with an import of `JUDGMENT_STRONG_RE` from `@ax/hooks-sdk` (confirm the export path - `packages/hooks-sdk/src/spend-mode.ts`; check how axctl imports hooks-sdk elsewhere, e.g. routing-table). Keep the exported name stable for routing-tune's callers, or re-export. Run the routing-tune tests (`bun test apps/axctl/src/queries/routing-tune.test.ts`) - adjust any test whose expectation shifts because the regex is now the unified one (the judgment set should be equivalent or a documented superset/subset; reconcile and note).
+- [ ] **Step 2: commit** `refactor(routing): single judgment regex shared by hook + routing-tune`
+
+---
+
+### Task 6: routing-table spendMode thresholds + SKILL.md reconcile
+
+**Files:** Modify `packages/hooks-sdk/src/routing-table.ts` (schema), `skills/efficient-dispatch/SKILL.md`
+
+- [ ] **Step 1:** add an optional `spendMode` block to `RoutingTableSchema` (thresholds: `stalenessMs`, `nearResetMs7d`, `minRemainingPct`, `capFloorPct`), defaulting to `DEFAULT_SPEND_CONFIG` when absent. Wire the hook to read it from the loaded table (override `DEFAULT_SPEND_CONFIG`). Add a schema test.
+- [ ] **Step 2:** SKILL.md - find the line saying "the route-dispatch hook **warns** when you forget" and rewrite to: "the route-dispatch hook **auto-routes** a forgotten mechanical dispatch to the cheaper model in conserve mode; near a 7d reset (splurge) it relaxes so work runs on the strong model; it **warns** when judgment work is sent on a cheap model." Keep the rest.
+- [ ] **Step 3: commit** `feat(hooks): spendMode thresholds in routing table + reconcile efficient-dispatch skill`
+
+---
+
+### Task 7: PR1 verify + PR
+
+- [ ] **Step 1** `bun test` (repo-wide) → 0 fail. `bun run typecheck` → clean. `bun scripts/check-no-node-fs.ts` → clean (note: spend-mode.ts uses `node:fs` in hooks-sdk - confirm the gate's allowlist covers hooks-sdk like routing-table.ts; if not, add it the same way).
+- [ ] **Step 2** push + PR:
+```bash
+git push -u origin feat/dispatch-economy
+gh pr create --title "feat: quota-aware dispatch economy (PR1 - conserve auto-route)" --body "..."
+```
+PR body: conserve auto-route via Verdict.route (silent rewrite) + computeSpendMode (full, incl. splurge logic, but splurge is only *consumed* - subtractively - here: splurge → no rewrite → strong inherited model); judgment-cheap warn; single judgment regex. **Flag the behavior change** (warn→auto-route) + the live-smoke evidence that updatedInput works. Note PR2 follows with freshness + the /dojo nudge + statusline surface + measurement.
+
+---
+
+## PR2 - splurge freshness + /dojo nudge + surface + measurement
+
+(Branch off the merged PR1, or stack on `feat/dispatch-economy`.)
+
+### Task 8: refresh-quota SessionStart hook (+ splurge → /dojo nudge)
+
+**Files:** Create `packages/hooks-sdk/src/hooks/refresh-quota.ts`, `packages/hooks-sdk/src/hooks/refresh-quota.test.ts`
+
+- [ ] **Step 1: failing test** - factor the nudge decision as a pure fn `spendNudge(result) → string | null` (so it's testable without spawning): splurge → a `/dojo` nudge string; conserve/stale → null.
+
+```ts
+// refresh-quota.test.ts
+import { describe, expect, test } from "bun:test";
+import { spendNudge } from "./refresh-quota.ts";
+describe("spendNudge", () => {
+    test("splurge → /dojo nudge mentioning remaining % and hours", () => {
+        const s = spendNudge({ mode: "splurge", reason: "x", stale: false }, { remainingPct: 60, hoursToReset: 12 });
+        expect(s).toContain("/dojo");
+        expect(s).toContain("60%");
+        expect(s).toContain("12h");
+    });
+    test("conserve → null (no nudge)", () => {
+        expect(spendNudge({ mode: "conserve", reason: "x", stale: false }, { remainingPct: 60, hoursToReset: 12 })).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: run -> FAIL**
+- [ ] **Step 3: implement** - `refresh-quota.ts`: a SessionStart hook that (a) shells out to refresh the cache, (b) reads it, (c) computes mode, (d) returns `Verdict.inject(nudge)` when splurge else `Verdict.allow`. Mirror enforce-worktree.ts structure.
+
+```ts
+// packages/hooks-sdk/src/hooks/refresh-quota.ts
+import { Effect } from "effect";
+import { defineHook, runMain } from "../define.ts";
+import { Verdict } from "../verdict.ts";
+import { computeSpendMode, DEFAULT_SPEND_CONFIG, defaultQuotaCachePath, readQuotaCacheSync, type SpendModeResult } from "../spend-mode.ts";
+
+export const spendNudge = (
+    r: SpendModeResult,
+    facts: { remainingPct: number; hoursToReset: number },
+): string | null =>
+    r.mode === "splurge"
+        ? `splurge window: ~${facts.remainingPct}% of your 7d budget resets in ${facts.hoursToReset}h - run /dojo to spend it on self-improvement.`
+        : null;
+
+const hook = defineHook({
+    name: "refresh-quota",
+    events: ["SessionStart"],
+    run: () =>
+        Effect.gen(function* () {
+            // refresh the cache off the hot path (SessionStart fires once)
+            yield* Effect.tryPromise(() => Bun.spawn(["ax", "quota", "--fresh"], { stdout: "ignore", stderr: "ignore" }).exited)
+                .pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+            const snap = readQuotaCacheSync(defaultQuotaCachePath());
+            const result = computeSpendMode(snap, Date.now(), DEFAULT_SPEND_CONFIG);
+            if (snap?.seven_day && result.mode === "splurge") {
+                const remainingPct = Math.round(100 - snap.seven_day.utilization);
+                const hoursToReset = Math.max(1, Math.round((Date.parse(snap.seven_day.resets_at) - Date.now()) / 3600_000));
+                const nudge = spendNudge(result, { remainingPct, hoursToReset });
+                if (nudge) return Verdict.inject(nudge);
+            }
+            return Verdict.allow;
+        }),
+});
+export default hook;
+if (import.meta.main) void runMain(hook);
+```
+(Verify `Bun.spawn` is acceptable in a hook run that returns `Effect<Verdict, never, GitEnv>` - the run type allows side effects; SessionStart is off the hot path. If `ax` isn't on PATH in the hook env, fall back to `bun <repo>/apps/axctl/bin/axctl quota --fresh` or skip the refresh and just read the cache + note it.)
+
+- [ ] **Step 4: run -> PASS** + a backtest/smoke of SessionStart (install the hook, start a session in a splurge state - or temporarily force `AX_SPEND_MODE`-style via a test cache - and confirm the nudge appears).
+- [ ] **Step 5: commit** `feat(hooks): refresh-quota SessionStart hook + splurge /dojo nudge`
+
+---
+
+### Task 9: install wiring - the two new hooks + interval refresh LaunchAgent
+
+**Files:** Modify the hook scaffold/install (`apps/axctl/src/hooks/...` - find where `ax hooks init` writes the default hook set, and where `ax install` writes LaunchAgents)
+
+- [ ] **Step 1:** make `ax hooks init` scaffold `refresh-quota.ts` alongside route-dispatch (so a fresh install gets it). Confirm the SessionStart provider wiring (the codec that writes `~/.claude/settings.json` SessionStart entries).
+- [ ] **Step 2:** add a periodic-refresh LaunchAgent (mac: a plist with `StartInterval` ~300s running `ax quota`) installed by `ax install`; mirror the existing `com.necmttn.ax-watch` plist creation (find it under scripts/ or apps/axctl/src/...). Linux/other: document a cron equivalent or skip with a note. Idempotent install.
+- [ ] **Step 3:** verify `ax hooks init` produces refresh-quota + `ax install` lays down the timer plist (dry-run/inspect the written files). 
+- [ ] **Step 4: commit** `feat(install): scaffold refresh-quota hook + interval quota-refresh LaunchAgent`
+
+---
+
+### Task 10: surface SpendMode + staleness in quota render
+
+**Files:** Modify `apps/axctl/src/quota/format.ts`, its test
+
+- [ ] **Step 1: failing test** - `renderStatusline`/`renderQuotaTable` append the mode: `CONSERVE` / `SPLURGE -> /dojo` / `mode? (stale Nm)`. Use the shared `computeSpendMode` (import from `@ax/hooks-sdk`) so it's the single source of truth.
+
+```ts
+// in format.test.ts
+test("statusline shows SPLURGE -> /dojo when computeSpendMode says splurge", () => {
+    // build a snapshot in splurge; expect the line to contain "SPLURGE" and "/dojo"
+});
+test("statusline shows CONSERVE otherwise; (stale Nm) when stale", () => { /* ... */ });
+```
+
+- [ ] **Step 2-4:** implement the append (compute mode from the snapshot + now; render the badge), run tests, confirm `ax quota --statusline` live shows the badge.
+- [ ] **Step 5: commit** `feat(quota): render spend mode + staleness (single source = computeSpendMode)`
+
+---
+
+### Task 11: measurement lens
+
+**Files:** Modify `apps/axctl/src/queries/dispatch-analytics.ts` (or a small new query) + the `ax dispatches` command
+
+- [ ] **Step 1:** add a lens that correlates spend mode with route outcomes - e.g. `ax dispatches --economy [--days=N]` showing, over the window: how many inherit dispatches matched a route-down class (would-be auto-routes), how many ran cheap vs expensive, and (if recoverable) the spend mode at dispatch time. The route verdicts already land in `hook_command_invocation` (the `effect` field) - join/count those. Keep it a read over existing telemetry (no new table). Test the query shaping with the fake client.
+- [ ] **Step 2:** docs/cli.md + llms.txt + CLAUDE.md note for the new flag/command; `bun run check:cli-reference` → 0.
+- [ ] **Step 3: commit** `feat(dispatches): spend-mode-aware effectiveness lens`
+
+---
+
+### Task 12: PR2 verify + PR
+
+- [ ] **Step 1** `bun test` repo-wide → 0 fail; `bun run typecheck` → clean; `check:cli-reference` + `check-no-node-fs` → clean.
+- [ ] **Step 2** push + PR `feat: quota-aware dispatch economy (PR2 - splurge freshness + /dojo nudge + surface + measurement)`. Body: SessionStart refresh + interval LaunchAgent (freshness), splurge→/dojo nudge (the in-harness window-end trigger), statusline surface + staleness, measurement lens. Reference the spec + PR1.

--- a/docs/superpowers/specs/2026-06-15-dispatch-economy-enforcement-design.md
+++ b/docs/superpowers/specs/2026-06-15-dispatch-economy-enforcement-design.md
@@ -8,6 +8,47 @@ Follows: skills/efficient-dispatch/SKILL.md, the route-dispatch hook (`matchRout
 splurge together · **splurge is purely subtractive** (relax the downgrade; never
 force a model up).
 
+---
+
+## AMENDMENT (2026-06-15) - hooks CANNOT enforce; advisory pivot
+
+During implementation (Task 4 live verification, by design), the load-bearing
+assumption was proven **false**: a Claude Code PreToolUse hook **cannot enforce,
+rewrite, or block the `Agent` (subagent dispatch) tool** - confirmed CC bugs
+#39814 (`updatedInput` ignored for Agent), #40580 (`deny`/exit-2 ignored for
+Agent), #24327 (deny makes the model stop, not retry). The ONLY mechanism that
+reaches the model for an Agent dispatch is **`additionalContext`** (advisory).
+See memory `hooks-cannot-enforce-agent-dispatch`.
+
+**The whole "enforcement" premise is therefore impossible at the hook layer.**
+The route-dispatch hook is fundamentally **advisory**. The pivot (user-approved):
+
+- **`Verdict.route` (updatedInput rewrite) is dead** - replaced by
+  **`Verdict.advise(context)`** encoding as
+  `{exitCode:0, stdout: JSON.stringify({hookSpecificOutput:{hookEventName:"PreToolUse", additionalContext: context}})}`
+  (the mechanism that reaches the model). `Verdict.route` is removed.
+- **`decideVerdict`'s route-down case returns `Verdict.advise(msg)`** (a clear,
+  actionable "this looks mechanical (class X) - re-dispatch with `model:<suggest>`
+  to save quota in conserve mode") **instead of `Verdict.route`**. The
+  judgment-cheap case also uses `Verdict.advise` (so it reaches the model;
+  the old `systemMessage` warn is only reliably user-facing).
+- The `input` field on `DecideInput` is no longer needed (no rewrite); keep
+  `suggest` for the message. Splurge still suppresses the conserve advisory
+  (subtractive) - in splurge the route-down case → `Verdict.allow` (no nag).
+- Everything else is unchanged: `computeSpendMode`, the spend-mode gating, the
+  judgment regex, the freshness mechanism, the statusline surface, the
+  **splurge → /dojo nudge**, and the measurement lens. PR2 is entirely unaffected.
+- **Honest framing everywhere:** this is a quota-aware *advisory*, not
+  enforcement. Real enforcement lives in the cognitive layer (efficient-dispatch
+  skill) + controlled dispatch paths (a workflow/skill setting `model:` when it
+  constructs the Agent call) - out of scope for this hook.
+
+Where the text below says "auto-route" / "Verdict.route" / "silently rewrite" /
+"enforce", read it as the advisory pivot above. The truth-table outcome
+`route(suggest)` becomes `advise(...)`; `block`/`deny` never appear.
+
+---
+
 ## Problem
 
 1. **Enforcement gap.** A `well-specified-impl` class (`^implement ` → sonnet)

--- a/docs/superpowers/specs/2026-06-15-dispatch-economy-enforcement-design.md
+++ b/docs/superpowers/specs/2026-06-15-dispatch-economy-enforcement-design.md
@@ -1,0 +1,165 @@
+# Quota-aware dispatch economy - proactive window awareness + enforcement
+
+Date: 2026-06-15
+Status: design for multi-agent review, pre-implementation
+Follows: skills/efficient-dispatch/SKILL.md, the route-dispatch hook, the quota module
+
+## Problem
+
+Two failures, both observed live:
+
+1. **Enforcement gap.** A `well-specified-impl` routing class (`^implement ` → sonnet)
+   exists and the route-dispatch hook is installed, yet a full session of
+   `Implement …` subagents ran on the expensive inherited model - ~$130 over.
+   The hook only **warns**, and a `PreToolUse(Agent)` warn arrives as the
+   dispatch already goes out: an ignorable nudge, not a guardrail.
+
+2. **The economy is one-directional and quota-blind.** "Route down to cheaper"
+   is correct only while conserving. Plan quota is **use-it-or-lose-it**: late
+   in a 5h/7d window with 40% remaining, forcing sonnet *wastes* surplus that
+   resets unused. The right rule is **cheap when conserving, best-model
+   everywhere when burning surplus near a reset** - and the system should
+   **proactively know** which regime it's in, not discover it passively.
+
+## Core: a proactively-fresh spend mode
+
+A single signal, `SpendMode = "conserve" | "splurge"`, derived from the quota
+windows and kept **current** so every dispatch decision is accurate.
+
+### `computeSpendMode(snapshot, nowMs, config)` - pure
+
+Input: the `QuotaSnapshot` shape already cached at `~/.ax/quota-cache.json`
+(`five_hour`/`seven_day`, each `{ utilization, resets_at }`, plus `fetched_at`).
+
+- **stale guard:** if `nowMs - fetched_at > stalenessMs` (default 5 min) →
+  `conserve` (never splurge on uncertainty).
+- **splurge** when *either* window satisfies BOTH:
+  - `resets_at - now < nearResetMs` (5h window default 90 min; 7d default 24 h), AND
+  - `100 - utilization > minRemainingPct` (default 25).
+  Rationale: a window about to reset with lots unused = surplus that will
+  evaporate; spend it on the best model.
+- else **conserve**.
+- thresholds (`stalenessMs`, per-window `nearResetMs`, `minRemainingPct`) live
+  in `routing-table.json` so they're tunable without a code change.
+
+### Manual override
+
+`AX_SPEND_MODE=auto|conserve|splurge` wins over the computed mode (`auto` = use
+the computation). The "I'm willing to throw the best model at everything" switch.
+
+### Proactive freshness (the "system knows" requirement)
+
+`computeSpendMode` is only as good as the cache. Two mechanisms keep it warm so
+splurge is detected the moment it's true, not whenever the user happens to run
+statusline:
+
+1. **SessionStart refresh hook** (new, `~/.ax/hooks/refresh-quota.ts` via the
+   SDK): on `SessionStart`, run a quota refresh (`ax quota` honors its 60s TTL,
+   or `--fresh`) so every session begins with a current window picture. Fires
+   once per session - latency-tolerant, off the per-tool hot path.
+2. **Continuous tick** (recommended, can land in the same PR or follow): the
+   existing `com.necmttn.ax-watch` LaunchAgent already runs in the background;
+   add a periodic `ax quota` refresh (~every 5 min) so long sessions stay fresh
+   between SessionStarts. If deferred, the stale-guard degrades safely to
+   conserve.
+
+The dispatch hot path **never** fetches - the route-dispatch hook only *reads*
+the local cache file (fast), so the ~70 ms hook budget is preserved.
+
+## Enforcement: route-dispatch hook verdicts
+
+Extend `packages/hooks-sdk/src/hooks/route-dispatch.ts`. Detection (routing
+table + `matchTable`) is unchanged; the verdict becomes mode- and
+model-conditional.
+
+Let `match` = `matchTable(table, description, subagentType)` (a route-down class
+suggesting sonnet/haiku), `explicit` = an explicit `model` in the Agent input,
+`cheap` = explicit model matches `/sonnet|haiku/i`, `judgmentStrong` =
+description/agent_type is a **stays-strong** judgment kind (see below).
+
+| condition | verdict |
+|-----------|---------|
+| `match` && !`explicit` && mode=**conserve** | **block** - "looks like `<class>`; dispatch with `model:<suggest>` (or `model:opus` to override)" |
+| `match` && !`explicit` && mode=**splurge** | **allow** - surplus is free; the inherited (strong) model runs |
+| `match` && `cheap` && mode=**splurge** | **warn** - "splurge window: routing down wastes expiring surplus; prefer the strong model" |
+| `judgmentStrong` && `cheap` (any mode) | **warn** - "judgment work is the catch-rate gate; consider the strong model" |
+| `explicit` (and none of the above) | allow - an explicit model is a deliberate choice |
+| no `match`, not `judgmentStrong` | allow |
+
+`block` reuses the proven enforce-worktree mechanism (deny the `PreToolUse`,
+agent re-dispatches with a model). It only fires on a *forgotten* route in
+conserve mode - disciplined dispatch (model always set) never trips it.
+
+### stays-strong judgment set
+
+A regex `STAYS_STRONG_RE` matching the kinds the efficient-dispatch skill keeps
+on the main model - `quality review`, `pr review`, `final review`,
+`adversarial …`, `code review`, `design`, `audit`, `architect…`, `critique`,
+`judg…` - and **explicitly excluding** `spec review` / `spec-compliance`
+(deliberately a route-down class). Implementation guards the `spec` carve-out so
+"spec review" never matches.
+
+## Surface it (maximize-output visibility)
+
+`ax quota` (and `--statusline`) render the current `SpendMode`: e.g.
+`5h 9% → 07:00 · 7d 15% · CONSERVE` or `… · SPLURGE ⚡ burn surplus`. So the
+operator and the agent both *see* when to crank everything. Reuses
+`computeSpendMode` - single source of truth.
+
+## Module shape / dependency note
+
+`computeSpendMode` + a minimal quota-cache reader must be importable by BOTH the
+hook (`packages/hooks-sdk`) and the quota render (`apps/axctl/src/quota`).
+hooks-sdk is hot-path/dependency-light and cannot import `apps/axctl`. Resolve
+the home in the plan:
+- preferred: `@ax/lib` (if hooks-sdk may depend on `@ax/lib` - verify the
+  current dep direction), exporting `computeSpendMode` + the cache reader + the
+  minimal `QuotaSnapshot` type;
+- fallback: a self-contained copy in hooks-sdk (the snapshot shape is tiny), with
+  `apps/axctl/src/quota` importing from there or duplicating the pure function
+  under test parity.
+
+```
+<shared home>/spend-mode.ts      computeSpendMode (pure) + readQuotaCache + SpendModeConfig + tests
+packages/hooks-sdk/src/hooks/route-dispatch.ts   mode-conditional verdicts + STAYS_STRONG_RE
+packages/hooks-sdk/src/hooks/refresh-quota.ts    SessionStart quota refresh (new SDK hook)
+apps/axctl/src/quota/format.ts   render SpendMode in table + statusline
+routing-table.json schema        + spendMode thresholds block
+skills/efficient-dispatch/SKILL.md   document the deterministic conserve/splurge behavior
+```
+
+Pure cores (`computeSpendMode`, the verdict decision factored as a pure
+`decideVerdict(inputs)`) unit-tested exhaustively (every truth-table row + the
+window/threshold boundaries + the spec-review carve-out). The SessionStart hook
++ cache read verified via `ax hooks backtest` and a live smoke.
+
+## Safety / scope
+
+- Hot path only reads a local file; no network on dispatch.
+- Splurge requires a fresh cache; stale/missing → conserve (never accidentally
+  splurge).
+- Block fires only on conserve + route-down-match + inherit. Explicit model
+  (incl. `model:opus`) always passes.
+
+## Behavior change to flag
+
+route-dispatch goes **warn → block** (conserve mode) for everyone who has it
+installed. Intentional - it's the whole point - but called out in the PR.
+
+## Out of scope (later)
+
+- `ax routing tune` agent_type mining (the `^implement ` class already covers
+  the implementers).
+- An `ax dispatches` retrospective inversion view (the hook enforces at dispatch
+  time, which beats a report).
+- dojo budget-envelope integration (lifting the 15% reserve in splurge) - natural
+  follow-up once spend mode is shared.
+
+## Open questions (for review)
+
+1. Is the SessionStart refresh enough, or is the watcher tick required in v1 for
+   the "proactively knows" guarantee on long sessions?
+2. Should splurge **block** an explicit *cheap* model (force the strong model)
+   rather than only warn? (Current: warn - an explicit model is intentional.)
+3. `computeSpendMode` home: `@ax/lib` vs a hooks-sdk-local copy - which respects
+   the hot-path dependency constraint best?

--- a/docs/superpowers/specs/2026-06-15-dispatch-economy-enforcement-design.md
+++ b/docs/superpowers/specs/2026-06-15-dispatch-economy-enforcement-design.md
@@ -1,165 +1,229 @@
 # Quota-aware dispatch economy - proactive window awareness + enforcement
 
 Date: 2026-06-15
-Status: design for multi-agent review, pre-implementation
-Follows: skills/efficient-dispatch/SKILL.md, the route-dispatch hook, the quota module
+Status: final design (after 2 Opus reviews + Codex critique), pre-implementation
+Follows: skills/efficient-dispatch/SKILL.md, the route-dispatch hook (`matchRoutingTable`, unified in #411), the quota module
+
+**Locked with the user:** auto-route (silent rewrite, not block) · conserve +
+splurge together · **splurge is purely subtractive** (relax the downgrade; never
+force a model up).
 
 ## Problem
 
-Two failures, both observed live:
-
-1. **Enforcement gap.** A `well-specified-impl` routing class (`^implement ` → sonnet)
+1. **Enforcement gap.** A `well-specified-impl` class (`^implement ` → sonnet)
    exists and the route-dispatch hook is installed, yet a full session of
    `Implement …` subagents ran on the expensive inherited model - ~$130 over.
-   The hook only **warns**, and a `PreToolUse(Agent)` warn arrives as the
-   dispatch already goes out: an ignorable nudge, not a guardrail.
+   The hook only **warns**; a `PreToolUse(Agent)` warn arrives as the dispatch
+   already fires - an ignorable nudge. (And `Verdict.block` today encodes as
+   exit-2+stderr, whose reason reaches the **user**, not the model - so
+   block→re-dispatch wouldn't work autonomously, and would also train the agent
+   to set `model:` everywhere and bypass the table. Auto-route avoids both.)
 
-2. **The economy is one-directional and quota-blind.** "Route down to cheaper"
-   is correct only while conserving. Plan quota is **use-it-or-lose-it**: late
-   in a 5h/7d window with 40% remaining, forcing sonnet *wastes* surplus that
-   resets unused. The right rule is **cheap when conserving, best-model
-   everywhere when burning surplus near a reset** - and the system should
-   **proactively know** which regime it's in, not discover it passively.
+2. **Quota-blind in one direction.** "Route down to cheaper" is right *while
+   conserving*. Near a **7-day** reset with budget unspent, forcing sonnet keeps
+   the agent cheap when the rate is about to reset anyway. The system should
+   **proactively know** the regime and, near a 7d reset with genuine headroom,
+   **stop forcing things down** (so work runs on the strong inherited model) -
+   *without* forcing things up (running opus on work the table already deemed
+   sonnet-adequate burns rate for identical output - a vanity metric, per the
+   Codex critique).
 
-## Core: a proactively-fresh spend mode
+## The whole design in one knob
 
-A single signal, `SpendMode = "conserve" | "splurge"`, derived from the quota
-windows and kept **current** so every dispatch decision is accurate.
+`routeDownEnforced = (spendMode === "conserve")`. Plus one orthogonal,
+always-on **judgment warn**. That's it - there is no splurge-specific verdict.
 
-### `computeSpendMode(snapshot, nowMs, config)` - pure
+## Spend mode - proactively fresh
 
-Input: the `QuotaSnapshot` shape already cached at `~/.ax/quota-cache.json`
-(`five_hour`/`seven_day`, each `{ utilization, resets_at }`, plus `fetched_at`).
+### `computeSpendMode(snapshot, nowMs, config) → { mode, reason, stale }` (pure)
 
-- **stale guard:** if `nowMs - fetched_at > stalenessMs` (default 5 min) →
-  `conserve` (never splurge on uncertainty).
-- **splurge** when *either* window satisfies BOTH:
-  - `resets_at - now < nearResetMs` (5h window default 90 min; 7d default 24 h), AND
-  - `100 - utilization > minRemainingPct` (default 25).
-  Rationale: a window about to reset with lots unused = surplus that will
-  evaporate; spend it on the best model.
-- else **conserve**.
-- thresholds (`stalenessMs`, per-window `nearResetMs`, `minRemainingPct`) live
-  in `routing-table.json` so they're tunable without a code change.
+Input: cached `QuotaSnapshot` (`~/.ax/quota-cache.json`): `five_hour` /
+`seven_day` (each **nullable** `{ utilization /* %used 0–100 */, resets_at }`)
++ `fetched_at`.
+
+- **stale guard:** `nowMs - parse(fetched_at) > stalenessMs` (default 5 min) →
+  `conserve` (+ `stale: true`). Never splurge on uncertainty.
+- **null `seven_day`** → `conserve`.
+- **splurge** iff ALL of:
+  - 7d near reset: `parse(seven_day.resets_at) - now < nearResetMs7d` (default 24 h),
+  - 7d headroom: `100 - seven_day.utilization > minRemainingPct` (default 25),
+  - **no window near its cap** (Codex: the windows draw down the *same*
+    consumption, so splurge must not run you into either ceiling):
+    `five_hour.utilization < capFloorPct` AND `seven_day.utilization < capFloorPct`
+    (default 80). A null `five_hour` is treated as not-near-cap.
+- else `conserve`.
+- The **5h window never triggers splurge** (it resets every 5 h → a near-reset
+  test on it is a 30%-duty-cycle timer, not a surplus signal - the central
+  review fix). It only participates as a cap guard.
+- `parse(resets_at)` is strict ISO-8601 → epoch ms; a parse failure → treat that
+  window as null (→ conserve). Clock is the hook's `Date.now()` equivalent
+  passed in as `nowMs` (testable).
+- thresholds (`stalenessMs`, `nearResetMs7d`, `minRemainingPct`, `capFloorPct`)
+  live in `routing-table.json`.
 
 ### Manual override
 
-`AX_SPEND_MODE=auto|conserve|splurge` wins over the computed mode (`auto` = use
-the computation). The "I'm willing to throw the best model at everything" switch.
+`AX_SPEND_MODE=auto|conserve|splurge` wins (`auto` = computed). The hook reads
+`process.env` (the harness propagates user env to forked hooks - same path the
+existing `ALLOW_*` bypasses use; verified in the feasibility review).
 
-### Proactive freshness (the "system knows" requirement)
+### Proactive freshness - both mechanisms, v1
 
-`computeSpendMode` is only as good as the cache. Two mechanisms keep it warm so
-splurge is detected the moment it's true, not whenever the user happens to run
-statusline:
+A stale cache silently falls to conserve, which *during a splurge window* would
+keep forcing things down - the opposite of intent, invisibly. So freshness is
+load-bearing:
 
-1. **SessionStart refresh hook** (new, `~/.ax/hooks/refresh-quota.ts` via the
-   SDK): on `SessionStart`, run a quota refresh (`ax quota` honors its 60s TTL,
-   or `--fresh`) so every session begins with a current window picture. Fires
-   once per session - latency-tolerant, off the per-tool hot path.
-2. **Continuous tick** (recommended, can land in the same PR or follow): the
-   existing `com.necmttn.ax-watch` LaunchAgent already runs in the background;
-   add a periodic `ax quota` refresh (~every 5 min) so long sessions stay fresh
-   between SessionStarts. If deferred, the stale-guard degrades safely to
-   conserve.
+1. **SessionStart refresh hook** (`~/.ax/hooks/refresh-quota.ts`, new SDK hook):
+   shells out to `ax quota --fresh` once per session (off the hot path), then
+   computes the mode. If **splurge**, it `inject`s a one-line **dojo nudge**
+   (see below) instead of a bare `Verdict.allow`. Token absent/expired → no-op
+   (→ stale → surfaced, below).
+2. **Continuous tick** (required, not deferred - splurge on a long session needs
+   it): a dedicated **LaunchAgent with `StartInterval` ~5 min** running
+   `ax quota` (the existing `com.necmttn.ax-watch` is fswatch-driven, *not* a
+   timer, so this is its own unit, installed by `ax install`).
 
-The dispatch hot path **never** fetches - the route-dispatch hook only *reads*
-the local cache file (fast), so the ~70 ms hook budget is preserved.
+The dispatch hot path **never fetches** - the hook only reads the cache (sync
+`node:fs`, matching the routing-table read precedent), preserving ~70 ms.
 
-## Enforcement: route-dispatch hook verdicts
+## Enforcement: route-dispatch hook
 
-Extend `packages/hooks-sdk/src/hooks/route-dispatch.ts`. Detection (routing
-table + `matchTable`) is unchanged; the verdict becomes mode- and
-model-conditional.
+Extend `packages/hooks-sdk/src/hooks/route-dispatch.ts`. Matching is the unified
+`matchRoutingTable` (#411). The verdict is a pure, ordered `decideVerdict`.
 
-Let `match` = `matchTable(table, description, subagentType)` (a route-down class
-suggesting sonnet/haiku), `explicit` = an explicit `model` in the Agent input,
-`cheap` = explicit model matches `/sonnet|haiku/i`, `judgmentStrong` =
-description/agent_type is a **stays-strong** judgment kind (see below).
+### New SDK capability: `Verdict.route(model)` (auto-route)
 
-| condition | verdict |
-|-----------|---------|
-| `match` && !`explicit` && mode=**conserve** | **block** - "looks like `<class>`; dispatch with `model:<suggest>` (or `model:opus` to override)" |
-| `match` && !`explicit` && mode=**splurge** | **allow** - surplus is free; the inherited (strong) model runs |
-| `match` && `cheap` && mode=**splurge** | **warn** - "splurge window: routing down wastes expiring surplus; prefer the strong model" |
-| `judgmentStrong` && `cheap` (any mode) | **warn** - "judgment work is the catch-rate gate; consider the strong model" |
-| `explicit` (and none of the above) | allow - an explicit model is a deliberate choice |
-| no `match`, not `judgmentStrong` | allow |
+Silent rewrite via `updatedInput` (the SDK has no such encoding today):
+`Verdict.route(model)` → `{ hookSpecificOutput: { hookEventName: "PreToolUse",
+permissionDecision: "allow", updatedInput: { ...event.tool.input, model } } }`.
+Claude runs the dispatch on the rewritten model, no agent round-trip. Codex
+(no Agent dispatch) → degrades to `allow`. Scoped SDK change: new `Route` case in
+`encodeVerdict`, its own tests; existing allow/block/warn untouched.
 
-`block` reuses the proven enforce-worktree mechanism (deny the `PreToolUse`,
-agent re-dispatches with a model). It only fires on a *forgotten* route in
-conserve mode - disciplined dispatch (model always set) never trips it.
+### `decideVerdict(inputs) → Verdict` - ordered, judgment-first
 
-### stays-strong judgment set
+Inputs: `match` (route-down class from `matchRoutingTable`, suggesting a cheaper
+tier), `explicit` (an explicit `model` set), `cheap` (explicit ∈ `/sonnet|haiku/i`),
+`judgmentStrong` (description/agent_type is a stays-strong judgment kind),
+`routeDownEnforced` (= conserve).
 
-A regex `STAYS_STRONG_RE` matching the kinds the efficient-dispatch skill keeps
-on the main model - `quality review`, `pr review`, `final review`,
-`adversarial …`, `code review`, `design`, `audit`, `architect…`, `critique`,
-`judg…` - and **explicitly excluding** `spec review` / `spec-compliance`
-(deliberately a route-down class). Implementation guards the `spec` carve-out so
-"spec review" never matches.
+1. `judgmentStrong && cheap` → **warn** ("judgment work is the catch-rate gate;
+   prefer the strong model"). *Rule 0 - judgment is never routed or blocked, any
+   mode.* Kills the `match ∩ judgmentStrong` collision the reviews flagged.
+2. `explicit` → **allow**. A typed model is deliberate; never overridden (incl.
+   `model:opus`, and incl. an explicit cheap model in splurge - no force-up).
+3. `match && !explicit && routeDownEnforced` → **route(suggest)** - silently
+   rewrite the forgotten dispatch to the cheaper tier.
+4. otherwise → **allow**. Covers `!match`; `judgmentStrong && inherit` (= main =
+   strong ✓); and **splurge + match + inherit** → runs on the strong inherited
+   model (best-model-on-everything, subtractively). No splurge warn, no push.
 
-## Surface it (maximize-output visibility)
+All 32 `(match, explicit, cheap, judgmentStrong, routeDownEnforced)` input cells
+are enumerated in the test (many collapse) so no cell rides an unstated default.
 
-`ax quota` (and `--statusline`) render the current `SpendMode`: e.g.
-`5h 9% → 07:00 · 7d 15% · CONSERVE` or `… · SPLURGE ⚡ burn surplus`. So the
-operator and the agent both *see* when to crank everything. Reuses
-`computeSpendMode` - single source of truth.
+### One judgment definition
 
-## Module shape / dependency note
+Collapse the two judgment regexes (`JUDGMENT_RE` in
+`apps/axctl/src/queries/routing-tune.ts` + the proposed `STAYS_STRONG_RE`) into a
+single exported source of truth in `packages/hooks-sdk/src/spend-mode.ts`
+(hot-path importable): matches quality/pr/final/adversarial/code review, design,
+audit, architect, critique, judge - **excluding `spec`/spec-compliance** (a
+deliberate route-down class). routing-tune imports it. No drift.
 
-`computeSpendMode` + a minimal quota-cache reader must be importable by BOTH the
-hook (`packages/hooks-sdk`) and the quota render (`apps/axctl/src/quota`).
-hooks-sdk is hot-path/dependency-light and cannot import `apps/axctl`. Resolve
-the home in the plan:
-- preferred: `@ax/lib` (if hooks-sdk may depend on `@ax/lib` - verify the
-  current dep direction), exporting `computeSpendMode` + the cache reader + the
-  minimal `QuotaSnapshot` type;
-- fallback: a self-contained copy in hooks-sdk (the snapshot shape is tiny), with
-  `apps/axctl/src/quota` importing from there or duplicating the pure function
-  under test parity.
+## Surface it (visibility + staleness)
+
+`ax quota` / `--statusline` render mode + staleness from the same
+`computeSpendMode`: `… · CONSERVE`, `… · SPLURGE ⚡`, or `… · mode? (stale 22m)`.
+A silent fall-to-conserve is **visible** (review: a believed-splurge that quietly
+conserves is maddening).
+
+## Splurge -> dojo nudge (the proactive trigger)
+
+Splurge means "you have weekly allowance about to reset unused" - which is
+exactly the condition the **dojo** loop exists to consume (burn surplus on
+self-improvement). The original dojo vision wanted an automatic window-end
+trigger, but headless firing was rejected (burns API, not plan) and a cron can't
+open an in-harness session. The spend-mode signal solves it the right way: the
+system **nudges the operator to fire `/dojo` themselves** at the moment surplus
+is detected.
+
+- On `SessionStart`, when `computeSpendMode` returns **splurge**, the
+  refresh-quota hook injects one line: e.g.
+  `splurge: ~N% of your 7d budget resets in Hh - run /dojo to spend it on self-improvement`.
+- Fires at most once per session (SessionStart cadence - no spam).
+- The statusline splurge marker mirrors it: `SPLURGE -> /dojo`.
+- In-harness, opt-in, proactive: the system tells you *when*, you decide
+  *whether*. This is the deferred dojo "window-end trigger" delivered as a
+  prompt, not a daemon - and it ties the dispatch-economy + dojo work through one
+  shared signal (`computeSpendMode`).
+
+## Measurement (kept in scope - Codex)
+
+A money-affecting, behavior-changing system needs a feedback loop. The route
+verdicts already land in `hook_command_invocation` (the `effect` field). Add a
+light `ax dispatches` lens that correlates spend mode + route verdicts so you can
+answer "did conserve auto-route the forgotten dispatches, and did splurge avoid
+burning opus on sonnet-adequate work?" - at minimum, record the mode at dispatch
+time. Not a new subsystem; a read over existing telemetry.
+
+## Module shape / dependency (resolved)
+
+`computeSpendMode` + a **new sync** cache reader (`node:fs`; NOT async
+`loadQuotaCache`, which pulls `@ax/lib`) + minimal `QuotaSnapshot` + the single
+judgment regex live **in `packages/hooks-sdk`** (`spend-mode.ts`). hooks-sdk
+stays `effect`-only (`@ax/lib` would drag `surrealdb` into the ~70 ms hot path
+and isn't installed in `~/.ax/hooks` - review-confirmed). `apps/axctl/src/quota`
+imports the pure fn *from hooks-sdk* - one parser for the on-disk format.
 
 ```
-<shared home>/spend-mode.ts      computeSpendMode (pure) + readQuotaCache + SpendModeConfig + tests
-packages/hooks-sdk/src/hooks/route-dispatch.ts   mode-conditional verdicts + STAYS_STRONG_RE
-packages/hooks-sdk/src/hooks/refresh-quota.ts    SessionStart quota refresh (new SDK hook)
-apps/axctl/src/quota/format.ts   render SpendMode in table + statusline
-routing-table.json schema        + spendMode thresholds block
-skills/efficient-dispatch/SKILL.md   document the deterministic conserve/splurge behavior
+packages/hooks-sdk/src/spend-mode.ts          computeSpendMode + readQuotaCacheSync + QuotaSnapshot + judgment regex (pure) + tests
+packages/hooks-sdk/src/verdict.ts (+ encode)  Verdict.route(model) + updatedInput encoding + tests
+packages/hooks-sdk/src/hooks/route-dispatch.ts   decideVerdict (ordered, pure) + wiring
+packages/hooks-sdk/src/hooks/refresh-quota.ts    SessionStart → `ax quota --fresh` + splurge→`/dojo` nudge (inject)
+apps/axctl/src/quota/format.ts                render mode + staleness
+apps/axctl/src/queries/routing-tune.ts        import the shared judgment regex (drop dup)
+apps/axctl/src/queries/dispatch-analytics.ts  + spend-mode-aware effectiveness lens
+routing-table.json schema                     + spendMode thresholds block
+scripts/ + ax install                         periodic-refresh LaunchAgent (StartInterval)
+skills/efficient-dispatch/SKILL.md            RECONCILE "the hook warns" → "auto-routes in conserve; relaxes in splurge"
 ```
 
-Pure cores (`computeSpendMode`, the verdict decision factored as a pure
-`decideVerdict(inputs)`) unit-tested exhaustively (every truth-table row + the
-window/threshold boundaries + the spec-review carve-out). The SessionStart hook
-+ cache read verified via `ax hooks backtest` and a live smoke.
+Pure cores (`computeSpendMode`, `decideVerdict`) unit-tested exhaustively
+(32 cells, window/threshold boundaries incl. cap guard, spec-review carve-out,
+null/stale/parse-fail windows). `Verdict.route` encoding tested. Hooks verified
+via `ax hooks backtest` + a **live smoke confirming `updatedInput` actually
+rewrites the model** and that `systemMessage` warns reach the model (the SDK's
+claim that they do is unverified - gate any warn reliance on this smoke).
 
 ## Safety / scope
 
-- Hot path only reads a local file; no network on dispatch.
-- Splurge requires a fresh cache; stale/missing → conserve (never accidentally
-  splurge).
-- Block fires only on conserve + route-down-match + inherit. Explicit model
-  (incl. `model:opus`) always passes.
+- Hot path: one local file read; no network on dispatch.
+- Splurge requires fresh cache + headroom + no window near cap; stale/null/
+  parse-fail → conserve; staleness surfaced.
+- Auto-route fires only on conserve + route-down match + **inherit**. Any
+  explicit model passes untouched. Judgment work is never routed.
+- Splurge never forces a model and never disables an explicit choice - it only
+  withholds the conserve rewrite.
 
-## Behavior change to flag
+## Behavior change to flag (PR)
 
-route-dispatch goes **warn → block** (conserve mode) for everyone who has it
-installed. Intentional - it's the whole point - but called out in the PR.
+route-dispatch goes **warn → auto-route** (conserve): a forgotten cheap-able
+dispatch now silently runs on the cheaper model. `model:` override +
+`AX_SPEND_MODE` give full control.
 
 ## Out of scope (later)
 
-- `ax routing tune` agent_type mining (the `^implement ` class already covers
-  the implementers).
-- An `ax dispatches` retrospective inversion view (the hook enforces at dispatch
-  time, which beats a report).
-- dojo budget-envelope integration (lifting the 15% reserve in splurge) - natural
-  follow-up once spend mode is shared.
+- `ax routing tune` agent_type mining (`^implement ` class already covers it).
+- Linear-pace/burn-rate splurge refinement (7d-only + cap guard suffices for v1).
+- dojo budget-envelope integration (lifting the 15% reserve in splurge).
 
-## Open questions (for review)
+## Resolved review questions
 
-1. Is the SessionStart refresh enough, or is the watcher tick required in v1 for
-   the "proactively knows" guarantee on long sessions?
-2. Should splurge **block** an explicit *cheap* model (force the strong model)
-   rather than only warn? (Current: warn - an explicit model is intentional.)
-3. `computeSpendMode` home: `@ax/lib` vs a hooks-sdk-local copy - which respects
-   the hot-path dependency constraint best?
+- 5h-window thrash → splurge is **7d-only** (5h is a cap guard only).
+- staleness inverts intent → **watcher tick required in v1** + staleness surfaced.
+- truth-table collisions → **ordered `decideVerdict`, judgment rule 0**, 32 cells.
+- block reason doesn't reach the model / learned bypass → **auto-route** instead.
+- splurge optimizes the wrong objective → **subtractive splurge** (no force-up).
+- OR-ing windows burns shared budget → **cap guard on both windows**.
+- no feedback loop → **measurement lens kept in scope**.
+- `computeSpendMode` home → **hooks-sdk** (not @ax/lib).

--- a/packages/hooks-sdk/src/adapters/encode.test.ts
+++ b/packages/hooks-sdk/src/adapters/encode.test.ts
@@ -20,3 +20,20 @@ describe("encodeVerdict", () => {
     expect(encodeVerdict(Verdict.inject("ctx"), "claude")).toEqual({ exitCode: 0, stdout: "ctx" });
   });
 });
+
+describe("encodeVerdict Route", () => {
+  test("claude: emits permissionDecision allow + updatedInput", () => {
+    const out = encodeVerdict(Verdict.route({ description: "Implement X", model: "sonnet" }), "claude");
+    expect(out.exitCode).toBe(0);
+    const json = JSON.parse(out.stdout!);
+    expect(json.hookSpecificOutput).toEqual({
+      hookEventName: "PreToolUse",
+      permissionDecision: "allow",
+      updatedInput: { description: "Implement X", model: "sonnet" },
+    });
+  });
+  test("codex: Route degrades to allow (no Agent dispatch / different protocol)", () => {
+    const out = encodeVerdict(Verdict.route({ model: "sonnet" }), "codex");
+    expect(out).toEqual({ exitCode: 0 });
+  });
+});

--- a/packages/hooks-sdk/src/adapters/encode.test.ts
+++ b/packages/hooks-sdk/src/adapters/encode.test.ts
@@ -21,27 +21,27 @@ describe("encodeVerdict", () => {
   });
 });
 
-describe("encodeVerdict Route", () => {
-  test("claude: emits permissionDecision allow + updatedInput", () => {
-    const out = encodeVerdict(Verdict.route({ description: "Implement X", model: "sonnet" }), "claude");
+describe("encodeVerdict Advise", () => {
+  test("claude: emits additionalContext JSON with the exact context string", () => {
+    const msg = "this dispatch looks mechanical - re-dispatch with model:sonnet to save quota (conserve mode).";
+    const out = encodeVerdict(Verdict.advise(msg), "claude");
     expect(out.exitCode).toBe(0);
     const json = JSON.parse(out.stdout!);
     expect(json.hookSpecificOutput).toEqual({
       hookEventName: "PreToolUse",
-      permissionDecision: "allow",
-      updatedInput: { description: "Implement X", model: "sonnet" },
+      additionalContext: msg,
     });
   });
-  test("codex: Route degrades to allow (no Agent dispatch / different protocol)", () => {
-    const out = encodeVerdict(Verdict.route({ model: "sonnet" }), "codex");
+  test("codex: Advise degrades to allow (route-dispatch is claude-only; codex has no Agent dispatch)", () => {
+    const out = encodeVerdict(Verdict.advise("some advice"), "codex");
     expect(out).toEqual({ exitCode: 0 });
   });
-  test("claude: empty merge passes through as exactly {}", () => {
-    const out = encodeVerdict(Verdict.route({}), "claude");
-    expect(JSON.parse(out.stdout!).hookSpecificOutput.updatedInput).toEqual({});
-  });
-  test("claude: existing model passes through verbatim (dumb passthrough, no strip/override)", () => {
-    const out = encodeVerdict(Verdict.route({ model: "opus", description: "x" }), "claude");
-    expect(JSON.parse(out.stdout!).hookSpecificOutput.updatedInput).toEqual({ model: "opus", description: "x" });
+  test("claude: judgment catch-rate advisory encodes correctly", () => {
+    const msg = "judgment work (review/design/audit) is the catch-rate gate - prefer the strong model (drop the cheap model: or set model:opus).";
+    const out = encodeVerdict(Verdict.advise(msg), "claude");
+    expect(out.exitCode).toBe(0);
+    const json = JSON.parse(out.stdout!);
+    expect(json.hookSpecificOutput.additionalContext).toBe(msg);
+    expect(json.hookSpecificOutput.hookEventName).toBe("PreToolUse");
   });
 });

--- a/packages/hooks-sdk/src/adapters/encode.test.ts
+++ b/packages/hooks-sdk/src/adapters/encode.test.ts
@@ -36,4 +36,12 @@ describe("encodeVerdict Route", () => {
     const out = encodeVerdict(Verdict.route({ model: "sonnet" }), "codex");
     expect(out).toEqual({ exitCode: 0 });
   });
+  test("claude: empty merge passes through as exactly {}", () => {
+    const out = encodeVerdict(Verdict.route({}), "claude");
+    expect(JSON.parse(out.stdout!).hookSpecificOutput.updatedInput).toEqual({});
+  });
+  test("claude: existing model passes through verbatim (dumb passthrough, no strip/override)", () => {
+    const out = encodeVerdict(Verdict.route({ model: "opus", description: "x" }), "claude");
+    expect(JSON.parse(out.stdout!).hookSpecificOutput.updatedInput).toEqual({ model: "opus", description: "x" });
+  });
 });

--- a/packages/hooks-sdk/src/adapters/encode.ts
+++ b/packages/hooks-sdk/src/adapters/encode.ts
@@ -37,5 +37,9 @@ export const encodeVerdict = (v: Verdict, harness: Harness): ProcessOutcome => {
             }),
           }
         : { exitCode: 0 };
+    default: {
+      const _exhaustive: never = v;
+      return _exhaustive;
+    }
   }
 };

--- a/packages/hooks-sdk/src/adapters/encode.ts
+++ b/packages/hooks-sdk/src/adapters/encode.ts
@@ -14,7 +14,7 @@ export interface ProcessOutcome {
  * (supported by both for PreToolUse). Inject = plain stdout (claude
  * SessionStart/UserPromptSubmit add stdout to context).
  */
-export const encodeVerdict = (v: Verdict, _harness: Harness): ProcessOutcome => {
+export const encodeVerdict = (v: Verdict, harness: Harness): ProcessOutcome => {
   switch (v._tag) {
     case "Allow":
       return { exitCode: 0 };
@@ -24,5 +24,18 @@ export const encodeVerdict = (v: Verdict, _harness: Harness): ProcessOutcome => 
       return { exitCode: 0, stdout: JSON.stringify({ systemMessage: v.message }) };
     case "Inject":
       return { exitCode: 0, stdout: v.context };
+    case "Route":
+      return harness === "claude"
+        ? {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              hookSpecificOutput: {
+                hookEventName: "PreToolUse",
+                permissionDecision: "allow",
+                updatedInput: v.input,
+              },
+            }),
+          }
+        : { exitCode: 0 };
   }
 };

--- a/packages/hooks-sdk/src/adapters/encode.ts
+++ b/packages/hooks-sdk/src/adapters/encode.ts
@@ -24,15 +24,14 @@ export const encodeVerdict = (v: Verdict, harness: Harness): ProcessOutcome => {
       return { exitCode: 0, stdout: JSON.stringify({ systemMessage: v.message }) };
     case "Inject":
       return { exitCode: 0, stdout: v.context };
-    case "Route":
+    case "Advise":
       return harness === "claude"
         ? {
             exitCode: 0,
             stdout: JSON.stringify({
               hookSpecificOutput: {
                 hookEventName: "PreToolUse",
-                permissionDecision: "allow",
-                updatedInput: v.input,
+                additionalContext: v.context,
               },
             }),
           }

--- a/packages/hooks-sdk/src/decide-verdict.test.ts
+++ b/packages/hooks-sdk/src/decide-verdict.test.ts
@@ -3,27 +3,33 @@ import { describe, expect, test } from "bun:test";
 import { decideVerdict } from "./decide-verdict.ts";
 
 // inp() helper: match defaults to false (the plan's `null` adjusted to false
-// to satisfy `match: boolean` under strict TS)
+// to satisfy `match: boolean` under strict TS). `input` field removed - no rewrite.
 const inp = (o: Partial<Parameters<typeof decideVerdict>[0]>) => ({
     match: false, explicit: false, cheap: false, judgmentStrong: false, routeDownEnforced: true,
-    input: { description: "x" }, suggest: "sonnet", ...o,
+    suggest: "sonnet", ...o,
 });
 
 describe("decideVerdict", () => {
-    test("judgment + cheap → Warn (rule 0, any mode)", () => {
-        expect(decideVerdict(inp({ judgmentStrong: true, explicit: true, cheap: true }))._tag).toBe("Warn");
+    test("judgment + cheap → Advise (rule 0, any mode - reaches model via additionalContext)", () => {
+        const v = decideVerdict(inp({ judgmentStrong: true, explicit: true, cheap: true }));
+        expect(v._tag).toBe("Advise");
+        if (v._tag === "Advise") expect(v.context).toContain("judgment work");
     });
-    test("judgment + cheap → Warn even in splurge", () => {
-        expect(decideVerdict(inp({ judgmentStrong: true, explicit: true, cheap: true, routeDownEnforced: false }))._tag).toBe("Warn");
+    test("judgment + cheap → Advise even in splurge", () => {
+        const v = decideVerdict(inp({ judgmentStrong: true, explicit: true, cheap: true, routeDownEnforced: false }));
+        expect(v._tag).toBe("Advise");
     });
     test("explicit (non-judgment) → Allow, never overridden", () => {
         expect(decideVerdict(inp({ explicit: true, cheap: false }))._tag).toBe("Allow");
         expect(decideVerdict(inp({ explicit: true, cheap: true }))._tag).toBe("Allow"); // explicit cheap, not judgment
     });
-    test("match + inherit + conserve → Route(suggest)", () => {
+    test("match + inherit + conserve → Advise with suggest model (advisory, not rewrite)", () => {
         const v = decideVerdict(inp({ match: true, routeDownEnforced: true }));
-        expect(v._tag).toBe("Route");
-        if (v._tag === "Route") expect(v.input.model).toBe("sonnet");
+        expect(v._tag).toBe("Advise");
+        if (v._tag === "Advise") {
+            expect(v.context).toContain("sonnet");
+            expect(v.context).toContain("conserve mode");
+        }
     });
     test("match + inherit + splurge → Allow (subtractive: runs on strong inherited model)", () => {
         expect(decideVerdict(inp({ match: true, routeDownEnforced: false }))._tag).toBe("Allow");
@@ -31,10 +37,10 @@ describe("decideVerdict", () => {
     test("no match + inherit → Allow", () => {
         expect(decideVerdict(inp({ match: false }))._tag).toBe("Allow");
     });
-    test("judgment + inherit (strong) any mode → Allow (not warned, not routed)", () => {
+    test("judgment + inherit (strong) any mode → Allow (not warned, not advised down)", () => {
         expect(decideVerdict(inp({ judgmentStrong: true, explicit: false }))._tag).toBe("Allow");
     });
-    test("match + judgment + inherit + conserve → Allow (judgment is NEVER routed down)", () => {
+    test("match + judgment + inherit + conserve → Allow (judgment is NEVER advised down)", () => {
         expect(decideVerdict(inp({ match: true, judgmentStrong: true, routeDownEnforced: true }))._tag).toBe("Allow");
     });
 });

--- a/packages/hooks-sdk/src/decide-verdict.test.ts
+++ b/packages/hooks-sdk/src/decide-verdict.test.ts
@@ -1,0 +1,40 @@
+// packages/hooks-sdk/src/decide-verdict.test.ts
+import { describe, expect, test } from "bun:test";
+import { decideVerdict } from "./decide-verdict.ts";
+
+// inp() helper: match defaults to false (the plan's `null` adjusted to false
+// to satisfy `match: boolean` under strict TS)
+const inp = (o: Partial<Parameters<typeof decideVerdict>[0]>) => ({
+    match: false, explicit: false, cheap: false, judgmentStrong: false, routeDownEnforced: true,
+    input: { description: "x" }, suggest: "sonnet", ...o,
+});
+
+describe("decideVerdict", () => {
+    test("judgment + cheap → Warn (rule 0, any mode)", () => {
+        expect(decideVerdict(inp({ judgmentStrong: true, explicit: true, cheap: true }))._tag).toBe("Warn");
+    });
+    test("judgment + cheap → Warn even in splurge", () => {
+        expect(decideVerdict(inp({ judgmentStrong: true, explicit: true, cheap: true, routeDownEnforced: false }))._tag).toBe("Warn");
+    });
+    test("explicit (non-judgment) → Allow, never overridden", () => {
+        expect(decideVerdict(inp({ explicit: true, cheap: false }))._tag).toBe("Allow");
+        expect(decideVerdict(inp({ explicit: true, cheap: true }))._tag).toBe("Allow"); // explicit cheap, not judgment
+    });
+    test("match + inherit + conserve → Route(suggest)", () => {
+        const v = decideVerdict(inp({ match: true, routeDownEnforced: true }));
+        expect(v._tag).toBe("Route");
+        if (v._tag === "Route") expect(v.input.model).toBe("sonnet");
+    });
+    test("match + inherit + splurge → Allow (subtractive: runs on strong inherited model)", () => {
+        expect(decideVerdict(inp({ match: true, routeDownEnforced: false }))._tag).toBe("Allow");
+    });
+    test("no match + inherit → Allow", () => {
+        expect(decideVerdict(inp({ match: false }))._tag).toBe("Allow");
+    });
+    test("judgment + inherit (strong) any mode → Allow (not warned, not routed)", () => {
+        expect(decideVerdict(inp({ judgmentStrong: true, explicit: false }))._tag).toBe("Allow");
+    });
+    test("match + judgment + inherit + conserve → Allow (judgment is NEVER routed down)", () => {
+        expect(decideVerdict(inp({ match: true, judgmentStrong: true, routeDownEnforced: true }))._tag).toBe("Allow");
+    });
+});

--- a/packages/hooks-sdk/src/decide-verdict.ts
+++ b/packages/hooks-sdk/src/decide-verdict.ts
@@ -7,25 +7,30 @@ export interface DecideInput {
     readonly cheap: boolean;             // explicit model is sonnet/haiku
     readonly judgmentStrong: boolean;    // stays-strong judgment kind
     readonly routeDownEnforced: boolean; // = (mode === conserve)
-    readonly input: Record<string, unknown>; // original Agent input (for Route merge)
     readonly suggest: string;            // the class's suggested cheaper model
 }
 
 /** Ordered decision; first rule wins. Judgment is rule 0 (never routed/blocked). */
 export const decideVerdict = (i: DecideInput): Verdict => {
-    // Rule 0: judgment work sent on a cheap model → warn (any mode).
+    // Rule 0: judgment work sent on a cheap model → advise (any mode).
+    // Uses Verdict.advise so the message reaches the model (additionalContext).
     if (i.judgmentStrong && i.cheap) {
-        return Verdict.warn(
-            "judgment work (review/design/audit) is the catch-rate gate - prefer the strong model (drop the cheap `model:` or set model:opus).",
+        return Verdict.advise(
+            "judgment work (review/design/audit) is the catch-rate gate - prefer the strong model (drop the cheap model: or set model:opus).",
         );
     }
     // Rule 1: an explicit model is a deliberate choice - never override.
     if (i.explicit) return Verdict.allow;
-    // Rule 2: conserve + forgotten route-down → silently rewrite to the cheaper
-    // tier. `!judgmentStrong` enforces judgment-precedence: judgment work that
-    // also matched a class (class/regex drift) is NEVER routed down.
+    // Rule 2: conserve + forgotten route-down → advise the model to re-dispatch
+    // with the cheaper tier. `!judgmentStrong` enforces judgment-precedence:
+    // judgment work that also matched a class (class/regex drift) is NEVER advised down.
+    // NOTE: PreToolUse hooks cannot rewrite (updatedInput) or block the Agent tool
+    // (CC bugs #39814, #40580). additionalContext (Verdict.advise) is the only
+    // mechanism that reaches the model for Agent dispatches.
     if (i.match && i.routeDownEnforced && !i.judgmentStrong) {
-        return Verdict.route({ ...i.input, model: i.suggest });
+        return Verdict.advise(
+            `this dispatch looks mechanical - re-dispatch with model:${i.suggest} to save quota (conserve mode).`,
+        );
     }
     // Rule 3: everything else (incl. splurge+match+inherit = strong inherited model).
     return Verdict.allow;

--- a/packages/hooks-sdk/src/decide-verdict.ts
+++ b/packages/hooks-sdk/src/decide-verdict.ts
@@ -1,0 +1,32 @@
+// packages/hooks-sdk/src/decide-verdict.ts
+import { Verdict } from "./verdict.ts";
+
+export interface DecideInput {
+    readonly match: boolean;             // matched a route-down class
+    readonly explicit: boolean;          // explicit model set
+    readonly cheap: boolean;             // explicit model is sonnet/haiku
+    readonly judgmentStrong: boolean;    // stays-strong judgment kind
+    readonly routeDownEnforced: boolean; // = (mode === conserve)
+    readonly input: Record<string, unknown>; // original Agent input (for Route merge)
+    readonly suggest: string;            // the class's suggested cheaper model
+}
+
+/** Ordered decision; first rule wins. Judgment is rule 0 (never routed/blocked). */
+export const decideVerdict = (i: DecideInput): Verdict => {
+    // Rule 0: judgment work sent on a cheap model → warn (any mode).
+    if (i.judgmentStrong && i.cheap) {
+        return Verdict.warn(
+            "judgment work (review/design/audit) is the catch-rate gate - prefer the strong model (drop the cheap `model:` or set model:opus).",
+        );
+    }
+    // Rule 1: an explicit model is a deliberate choice - never override.
+    if (i.explicit) return Verdict.allow;
+    // Rule 2: conserve + forgotten route-down → silently rewrite to the cheaper
+    // tier. `!judgmentStrong` enforces judgment-precedence: judgment work that
+    // also matched a class (class/regex drift) is NEVER routed down.
+    if (i.match && i.routeDownEnforced && !i.judgmentStrong) {
+        return Verdict.route({ ...i.input, model: i.suggest });
+    }
+    // Rule 3: everything else (incl. splurge+match+inherit = strong inherited model).
+    return Verdict.allow;
+};

--- a/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Effect, Result, Schema } from "effect";
 import routeDispatch, { RoutingTableSchema } from "./route-dispatch.ts";
 import { GitEnvTest } from "../git-env.ts";
@@ -30,74 +30,136 @@ const run = (input: AgentInput) =>
       .pipe(Effect.provide(layer)),
   );
 
+// Force conserve mode for determinism in tests that check routing behavior.
+beforeEach(() => {
+  process.env.AX_SPEND_MODE = "conserve";
+});
+afterEach(() => {
+  delete process.env.AX_SPEND_MODE;
+});
+
 // ---------------------------------------------------------------------------
-// Explicit model → always allow
+// Explicit model → always allow (unless judgment+cheap → warn)
 // ---------------------------------------------------------------------------
 
 describe("explicit model set", () => {
-  test("model='sonnet' → Allow (user made a deliberate choice)", async () => {
+  test("model='sonnet' → Allow (user made a deliberate choice, non-judgment)", async () => {
     const v = await run({ description: "locate all usages", model: "sonnet" });
     expect(v._tag).toBe("Allow");
   });
 
-  test("model='haiku' → Allow", async () => {
+  test("model='haiku' on non-judgment → Allow", async () => {
     const v = await run({ description: "spec review of PR #42", model: "haiku" });
+    // spec review is NOT judgment-strong (JUDGMENT_STRONG_RE requires quality/pr/final/adversarial/code review)
     expect(v._tag).toBe("Allow");
   });
 
-  test("model='' (empty string) is treated as unset → may warn", async () => {
-    // Empty string is falsy - we treat it the same as absent
-    const v = await run({ description: "locate symbols", model: "" });
-    // Should warn (matches search-locate) rather than allow
+  test("model='sonnet' on judgment (quality review) → Warn (catch-rate gate)", async () => {
+    // Rule 0: judgment+cheap → Warn, even with explicit model
+    const v = await run({ description: "quality review of the diff", model: "sonnet" });
     expect(v._tag).toBe("Warn");
+    if (v._tag === "Warn") {
+      expect(v.message).toContain("judgment work");
+    }
+  });
+
+  test("model='' (empty string) treated as inherit → Route (matches search-locate in conserve)", async () => {
+    // Empty string: explicit=false → not treated as deliberate choice
+    const v = await run({ description: "locate symbols", model: "" });
+    // Matches the search-locate pattern → Route in conserve mode
+    expect(v._tag).toBe("Route");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Description-based matches (default routing table)
+// conserve mode: match+inherit → Route (auto-rewrite to cheaper model)
 // ---------------------------------------------------------------------------
 
-describe("description matches default routing table", () => {
-  test("'spec review of PR' → Warn with sonnet suggestion", async () => {
+describe("conserve + inherit: route-down classes auto-route", () => {
+  test("'spec review of PR' → Route to sonnet", async () => {
     const v = await run({ description: "spec review of PR #42" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("sonnet");
-      expect(v.message).toContain("spec-compliance checklist review");
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("sonnet");
     }
   });
 
-  test("'Locate all TODO comments' → Warn with haiku suggestion (case-insensitive)", async () => {
+  test("'Locate all TODO comments' → Route to haiku (case-insensitive)", async () => {
     const v = await run({ description: "Locate all TODO comments" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("haiku");
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("haiku");
     }
   });
 
-  test("'find usages of Foo' → Warn with haiku", async () => {
+  test("'find usages of Foo' → Route to haiku", async () => {
     const v = await run({ description: "find usages of Foo" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("haiku");
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("haiku");
     }
   });
 
-  test("'research the Effect v4 API' → Warn with sonnet", async () => {
+  test("'research the Effect v4 API' → Route to sonnet", async () => {
     const v = await run({ description: "research the Effect v4 API" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("sonnet");
-      expect(v.message).toContain("web/docs research");
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("sonnet");
     }
   });
 
-  test("'implement task: add route-dispatch hook' → Warn with sonnet", async () => {
+  test("'implement task: add route-dispatch hook' → Route to sonnet", async () => {
     const v = await run({ description: "implement task: add route-dispatch hook" });
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("sonnet");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// splurge mode: match+inherit → Allow (subtractive, runs on strong model)
+// ---------------------------------------------------------------------------
+
+describe("splurge + inherit: no auto-route (subtractive)", () => {
+  test("AX_SPEND_MODE=splurge + match + inherit → Allow (strong inherited model)", async () => {
+    process.env.AX_SPEND_MODE = "splurge";
+    const v = await run({ description: "spec review of PR #42" });
+    expect(v._tag).toBe("Allow");
+  });
+
+  test("AX_SPEND_MODE=splurge + 'find usages' (route-down class) + inherit → Allow", async () => {
+    process.env.AX_SPEND_MODE = "splurge";
+    const v = await run({ description: "find usages of Foo" });
+    expect(v._tag).toBe("Allow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// judgment-cheap: warn regardless of mode
+// ---------------------------------------------------------------------------
+
+describe("judgment work on cheap explicit model → Warn", () => {
+  test("judgment+cheap conserve → Warn", async () => {
+    process.env.AX_SPEND_MODE = "conserve";
+    const v = await run({ description: "quality review of the diff", model: "sonnet" });
     expect(v._tag).toBe("Warn");
     if (v._tag === "Warn") {
-      expect(v.message).toContain("sonnet");
+      expect(v.message).toContain("judgment work");
     }
+  });
+
+  test("judgment+cheap splurge → Warn (rule 0 always fires)", async () => {
+    process.env.AX_SPEND_MODE = "splurge";
+    const v = await run({ description: "code review of the PR", model: "haiku" });
+    expect(v._tag).toBe("Warn");
+  });
+
+  test("explicit non-cheap on a route-down class → Allow (deliberate choice)", async () => {
+    // description matches search-locate (haiku), but model is opus (non-cheap)
+    // explicit=true, cheap=false, judgmentStrong=false → Rule 1: Allow
+    const v = await run({ description: "find usages of Foo", model: "opus" });
+    expect(v._tag).toBe("Allow");
   });
 });
 
@@ -106,38 +168,37 @@ describe("description matches default routing table", () => {
 // ---------------------------------------------------------------------------
 
 describe("agentType rules", () => {
-  test("subagent_type='Explore' → Warn with haiku", async () => {
+  test("subagent_type='Explore' → Route to haiku (conserve)", async () => {
     const v = await run({ subagent_type: "Explore", description: "some task" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("haiku");
-      expect(v.message).toContain("Explore");
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("haiku");
     }
   });
 
-  test("subagent_type='codebase-locator' → Warn with haiku", async () => {
+  test("subagent_type='codebase-locator' → Route to haiku (conserve)", async () => {
     const v = await run({ subagent_type: "codebase-locator" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("haiku");
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("haiku");
     }
   });
 
-  test("subagent_type='codebase-analyzer' → Warn with sonnet", async () => {
+  test("subagent_type='codebase-analyzer' → Route to sonnet (conserve)", async () => {
     const v = await run({ subagent_type: "codebase-analyzer" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("sonnet");
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("sonnet");
     }
   });
 
-  test("agentType wins over description pattern when both match", async () => {
+  test("agentType wins over description pattern when both match (haiku wins over sonnet)", async () => {
     // 'Explore' agent type → haiku; description 'research ...' → sonnet.
     // Agent type should win (more specific).
     const v = await run({ subagent_type: "Explore", description: "research the docs" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("haiku");
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("haiku");
     }
   });
 });
@@ -168,11 +229,11 @@ describe("no match", () => {
 // ---------------------------------------------------------------------------
 
 describe("prompt fallback", () => {
-  test("no description but prompt starts with 'locate' → Warn (haiku)", async () => {
+  test("no description but prompt starts with 'locate' → Route to haiku (conserve)", async () => {
     const v = await run({ prompt: "locate all files that import Effect" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("haiku");
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("haiku");
     }
   });
 
@@ -186,19 +247,16 @@ describe("prompt fallback", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Warn message contains key fields
+// Route verdict carries original description through
 // ---------------------------------------------------------------------------
 
-describe("warn message format", () => {
-  test("message includes description label, model suggestion, and cost hint", async () => {
+describe("route verdict merges input", () => {
+  test("Route includes description from original input", async () => {
     const v = await run({ description: "spec review of PR #42" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("ax routing:");
-      expect(v.message).toContain('"spec review of PR #42"');
-      expect(v.message).toContain("sonnet");
-      expect(v.message).toContain("cheaper");
-      expect(v.message).toContain("Explicit model silences this");
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.description).toBe("spec review of PR #42");
+      expect(v.input.model).toBe("sonnet");
     }
   });
 });
@@ -208,16 +266,15 @@ describe("warn message format", () => {
 // ---------------------------------------------------------------------------
 
 describe("routing table loading", () => {
-  test("corrupt/absent routing table falls back to defaults and still warns on known pattern", async () => {
+  test("corrupt/absent routing table falls back to defaults and still routes on known pattern", async () => {
     // We cannot easily mock the fs call here without dependency injection,
     // but the real path (~/.ax/hooks/routing-table.json) likely does not exist
     // in CI. The default table is embedded, so the hook should still work.
-    // This test verifies the default table is active when the file is absent.
     const v = await run({ description: "locate things" });
-    // 'locate' matches the default search-locate pattern → Warn
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("haiku");
+    // 'locate' matches the default search-locate pattern → Route in conserve
+    expect(v._tag).toBe("Route");
+    if (v._tag === "Route") {
+      expect(v.input.model).toBe("haiku");
     }
   });
 });

--- a/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
@@ -54,65 +54,66 @@ describe("explicit model set", () => {
     expect(v._tag).toBe("Allow");
   });
 
-  test("model='sonnet' on judgment (quality review) → Warn (catch-rate gate)", async () => {
-    // Rule 0: judgment+cheap → Warn, even with explicit model
+  test("model='sonnet' on judgment (quality review) → Advise (catch-rate gate, reaches model via additionalContext)", async () => {
+    // Rule 0: judgment+cheap → Advise, even with explicit model
     const v = await run({ description: "quality review of the diff", model: "sonnet" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("judgment work");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("judgment work");
     }
   });
 
-  test("model='' (empty string) treated as inherit → Route (matches search-locate in conserve)", async () => {
+  test("model='' (empty string) treated as inherit → Advise (matches search-locate in conserve)", async () => {
     // Empty string: explicit=false → not treated as deliberate choice
     const v = await run({ description: "locate symbols", model: "" });
-    // Matches the search-locate pattern → Route in conserve mode
-    expect(v._tag).toBe("Route");
+    // Matches the search-locate pattern → Advise in conserve mode
+    expect(v._tag).toBe("Advise");
   });
 });
 
 // ---------------------------------------------------------------------------
-// conserve mode: match+inherit → Route (auto-rewrite to cheaper model)
+// conserve mode: match+inherit → Advise (advisory, not rewrite)
 // ---------------------------------------------------------------------------
 
-describe("conserve + inherit: route-down classes auto-route", () => {
-  test("'spec review of PR' → Route to sonnet", async () => {
+describe("conserve + inherit: route-down classes advise cheaper model", () => {
+  test("'spec review of PR' → Advise with sonnet", async () => {
     const v = await run({ description: "spec review of PR #42" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("sonnet");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("sonnet");
+      expect(v.context).toContain("conserve mode");
     }
   });
 
-  test("'Locate all TODO comments' → Route to haiku (case-insensitive)", async () => {
+  test("'Locate all TODO comments' → Advise with haiku (case-insensitive)", async () => {
     const v = await run({ description: "Locate all TODO comments" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("haiku");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("haiku");
     }
   });
 
-  test("'find usages of Foo' → Route to haiku", async () => {
+  test("'find usages of Foo' → Advise with haiku", async () => {
     const v = await run({ description: "find usages of Foo" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("haiku");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("haiku");
     }
   });
 
-  test("'research the Effect v4 API' → Route to sonnet", async () => {
+  test("'research the Effect v4 API' → Advise with sonnet", async () => {
     const v = await run({ description: "research the Effect v4 API" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("sonnet");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("sonnet");
     }
   });
 
-  test("'implement task: add route-dispatch hook' → Route to sonnet", async () => {
+  test("'implement task: add route-dispatch hook' → Advise with sonnet", async () => {
     const v = await run({ description: "implement task: add route-dispatch hook" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("sonnet");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("sonnet");
     }
   });
 });
@@ -136,23 +137,23 @@ describe("splurge + inherit: no auto-route (subtractive)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// judgment-cheap: warn regardless of mode
+// judgment-cheap: advise regardless of mode (reaches model via additionalContext)
 // ---------------------------------------------------------------------------
 
-describe("judgment work on cheap explicit model → Warn", () => {
-  test("judgment+cheap conserve → Warn", async () => {
+describe("judgment work on cheap explicit model → Advise", () => {
+  test("judgment+cheap conserve → Advise", async () => {
     process.env.AX_SPEND_MODE = "conserve";
     const v = await run({ description: "quality review of the diff", model: "sonnet" });
-    expect(v._tag).toBe("Warn");
-    if (v._tag === "Warn") {
-      expect(v.message).toContain("judgment work");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("judgment work");
     }
   });
 
-  test("judgment+cheap splurge → Warn (rule 0 always fires)", async () => {
+  test("judgment+cheap splurge → Advise (rule 0 always fires)", async () => {
     process.env.AX_SPEND_MODE = "splurge";
     const v = await run({ description: "code review of the PR", model: "haiku" });
-    expect(v._tag).toBe("Warn");
+    expect(v._tag).toBe("Advise");
   });
 
   test("explicit non-cheap on a route-down class → Allow (deliberate choice)", async () => {
@@ -168,27 +169,27 @@ describe("judgment work on cheap explicit model → Warn", () => {
 // ---------------------------------------------------------------------------
 
 describe("agentType rules", () => {
-  test("subagent_type='Explore' → Route to haiku (conserve)", async () => {
+  test("subagent_type='Explore' → Advise with haiku (conserve)", async () => {
     const v = await run({ subagent_type: "Explore", description: "some task" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("haiku");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("haiku");
     }
   });
 
-  test("subagent_type='codebase-locator' → Route to haiku (conserve)", async () => {
+  test("subagent_type='codebase-locator' → Advise with haiku (conserve)", async () => {
     const v = await run({ subagent_type: "codebase-locator" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("haiku");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("haiku");
     }
   });
 
-  test("subagent_type='codebase-analyzer' → Route to sonnet (conserve)", async () => {
+  test("subagent_type='codebase-analyzer' → Advise with sonnet (conserve)", async () => {
     const v = await run({ subagent_type: "codebase-analyzer" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("sonnet");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("sonnet");
     }
   });
 
@@ -196,9 +197,9 @@ describe("agentType rules", () => {
     // 'Explore' agent type → haiku; description 'research ...' → sonnet.
     // Agent type should win (more specific).
     const v = await run({ subagent_type: "Explore", description: "research the docs" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("haiku");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("haiku");
     }
   });
 });
@@ -229,11 +230,11 @@ describe("no match", () => {
 // ---------------------------------------------------------------------------
 
 describe("prompt fallback", () => {
-  test("no description but prompt starts with 'locate' → Route to haiku (conserve)", async () => {
+  test("no description but prompt starts with 'locate' → Advise with haiku (conserve)", async () => {
     const v = await run({ prompt: "locate all files that import Effect" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("haiku");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("haiku");
     }
   });
 
@@ -247,16 +248,16 @@ describe("prompt fallback", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Route verdict carries original description through
+// Advise verdict contains the suggested model name
 // ---------------------------------------------------------------------------
 
-describe("route verdict merges input", () => {
-  test("Route includes description from original input", async () => {
+describe("advise verdict content", () => {
+  test("Advise context mentions the suggested model and conserve mode", async () => {
     const v = await run({ description: "spec review of PR #42" });
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.description).toBe("spec review of PR #42");
-      expect(v.input.model).toBe("sonnet");
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("sonnet");
+      expect(v.context).toContain("conserve mode");
     }
   });
 });
@@ -266,15 +267,15 @@ describe("route verdict merges input", () => {
 // ---------------------------------------------------------------------------
 
 describe("routing table loading", () => {
-  test("corrupt/absent routing table falls back to defaults and still routes on known pattern", async () => {
+  test("corrupt/absent routing table falls back to defaults and still advises on known pattern", async () => {
     // We cannot easily mock the fs call here without dependency injection,
     // but the real path (~/.ax/hooks/routing-table.json) likely does not exist
     // in CI. The default table is embedded, so the hook should still work.
     const v = await run({ description: "locate things" });
-    // 'locate' matches the default search-locate pattern → Route in conserve
-    expect(v._tag).toBe("Route");
-    if (v._tag === "Route") {
-      expect(v.input.model).toBe("haiku");
+    // 'locate' matches the default search-locate pattern → Advise in conserve
+    expect(v._tag).toBe("Advise");
+    if (v._tag === "Advise") {
+      expect(v.context).toContain("haiku");
     }
   });
 });

--- a/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Effect, Result, Schema } from "effect";
 import routeDispatch, { RoutingTableSchema } from "./route-dispatch.ts";
+import { SpendModeConfigSchema } from "../routing-table.ts";
 import { GitEnvTest } from "../git-env.ts";
 
 // ---------------------------------------------------------------------------
@@ -308,6 +309,67 @@ describe("defect handling", () => {
       ).pipe(Effect.provide(layer)),
     );
     expect(result.exitCode).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spendMode block in routing table schema
+// ---------------------------------------------------------------------------
+
+describe("routing table spendMode schema", () => {
+  const decode = Schema.decodeUnknownResult(RoutingTableSchema);
+
+  test("routing table with spendMode block parses and field is present", () => {
+    const result = decode({
+      version: 1,
+      classes: [],
+      spendMode: {
+        stalenessMs: 120_000,
+        nearResetMs7d: 48 * 3600_000,
+        minRemainingPct: 30,
+        capFloorPct: 70,
+      },
+    });
+    expect(Result.isSuccess(result)).toBe(true);
+    if (Result.isSuccess(result)) {
+      expect(result.success.spendMode).toEqual({
+        stalenessMs: 120_000,
+        nearResetMs7d: 48 * 3600_000,
+        minRemainingPct: 30,
+        capFloorPct: 70,
+      });
+    }
+  });
+
+  test("routing table without spendMode parses (backward compat)", () => {
+    const result = decode({ version: 1, classes: [] });
+    expect(Result.isSuccess(result)).toBe(true);
+    if (Result.isSuccess(result)) {
+      expect(result.success.spendMode).toBeUndefined();
+    }
+  });
+
+  test("spendMode with partial overrides parses (absent keys allowed)", () => {
+    const result = decode({
+      version: 1,
+      classes: [],
+      spendMode: { nearResetMs7d: 48 * 3600_000 },
+    });
+    expect(Result.isSuccess(result)).toBe(true);
+    if (Result.isSuccess(result)) {
+      expect(result.success.spendMode?.nearResetMs7d).toBe(48 * 3600_000);
+      expect(result.success.spendMode?.stalenessMs).toBeUndefined();
+    }
+  });
+
+  test("SpendModeConfigSchema standalone parse", () => {
+    const decodeConfig = Schema.decodeUnknownResult(SpendModeConfigSchema);
+    const result = decodeConfig({ stalenessMs: 60_000, capFloorPct: 85 });
+    expect(Result.isSuccess(result)).toBe(true);
+    if (Result.isSuccess(result)) {
+      expect(result.success.stalenessMs).toBe(60_000);
+      expect(result.success.capFloorPct).toBe(85);
+    }
   });
 });
 

--- a/packages/hooks-sdk/src/hooks/route-dispatch.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.ts
@@ -1,22 +1,21 @@
 /**
  * route-dispatch hook
  *
- * Fires on PreToolUse for the `Agent` tool. When a subagent dispatch has no
- * explicit `model`, matches the dispatch description (or first 120 chars of
- * prompt) against a routing table and emits a `warn` verdict suggesting a
- * cheaper model to the calling model.
+ * Fires on PreToolUse for the `Agent` tool. Routes subagent dispatches
+ * quota-aware:
  *
- * Verdict choice - warn vs inject:
- *   - `warn` encodes as `{ systemMessage: "..." }` on stdout (exit 0).
- *     Claude Code injects this into the model's context for the CURRENT turn,
- *     so the model can re-read the suggestion and re-dispatch with `model:`
- *     pinned.  `inject` (plain stdout) is for SessionStart/UserPromptSubmit
- *     context augmentation, not PreToolUse feedback; `block` (exit 2) would
- *     prevent the dispatch entirely, which is too aggressive.  `warn` is the
- *     right fit: it reaches the model without stopping the call.
- *   - Codex has no Agent-tool dispatch equivalent; this hook is Claude-only
- *     but the SDK fires it for any harness - it will just never match on Codex
- *     because Codex never emits an `Agent` tool name.
+ *   - conserve mode: when a dispatch has no explicit model and matches a
+ *     route-down class, silently rewrites the tool input to the suggested
+ *     cheaper model (Verdict.route = updatedInput rewrite).
+ *   - splurge mode: subtractive - no rewrite, runs on the strong inherited
+ *     model.
+ *   - judgment guard (any mode): if a cheap explicit model is set for
+ *     judgment work (review/design/audit) → warn.
+ *
+ * Spend mode keys off one knob: `routeDownEnforced = (mode === "conserve")`.
+ * Mode is determined by AX_SPEND_MODE env override (conserve|splurge), else
+ * by computeSpendMode reading the quota cache. Stale/missing cache → conserve
+ * (fail-safe).
  *
  * The routing-table schema, built-in defaults, and the fail-open read live in
  * ../routing-table.ts (ADR-0014) - the same module `ax routing compile|tune`
@@ -25,32 +24,20 @@
 
 import { Effect } from "effect";
 import { defineHook, runMain } from "../define.ts";
+import { decideVerdict } from "../decide-verdict.ts";
 import { loadRoutingTableOrDefault, matchRoutingTable } from "../routing-table.ts";
+import {
+  computeSpendMode,
+  DEFAULT_SPEND_CONFIG,
+  defaultQuotaCachePath,
+  JUDGMENT_STRONG_RE,
+  readQuotaCacheSync,
+} from "../spend-mode.ts";
 import { Verdict } from "../verdict.ts";
 
 // Re-exported for consumers (ax hooks tooling, tests) that historically
 // imported the schema from the hook file.
 export { RoutingTableSchema } from "../routing-table.ts";
-
-// Match logic now lives in ../routing-table.ts (matchRoutingTable) - the single
-// matcher shared with `ax dispatches --candidates` (ADR-0014 follow-up).
-
-// ---------------------------------------------------------------------------
-// Cost multiplier hint (rough guidance - not exact)
-// ---------------------------------------------------------------------------
-
-const costHint = (suggest: string): string => {
-  // Multipliers vs the expensive tiers (fable/opus) per current agent_model
-  // pricing: fable->haiku 10x, opus->haiku 5x; fable->sonnet ~3x.
-  switch (suggest) {
-    case "haiku":
-      return "~5-10x";
-    case "sonnet":
-      return "~2-3x";
-    default:
-      return "significantly";
-  }
-};
 
 // ---------------------------------------------------------------------------
 // Hook definition
@@ -65,40 +52,41 @@ const hook = defineHook({
   // (R = never is assignable to the HookDefinition's R = GitEnv.)
   run: (event) =>
     Effect.sync(() => {
-      const input = event.tool?.input ?? {};
-      const model = input.model;
+      const input = (event.tool?.input ?? {}) as Record<string, unknown>;
+      const modelRaw = input.model;
+      const explicit = typeof modelRaw === "string" && modelRaw.length > 0;
+      const cheap = explicit && /sonnet|haiku/i.test(modelRaw as string);
       const subagentType =
         typeof input.subagent_type === "string" ? input.subagent_type : undefined;
       const rawDescription =
         typeof input.description === "string" ? input.description : undefined;
       const rawPrompt =
         typeof input.prompt === "string" ? input.prompt.slice(0, 120) : undefined;
-
-      // Explicit model set - the caller has already made a deliberate choice.
-      if (model !== undefined && model !== null && model !== "") {
-        return Verdict.allow;
-      }
-
       const description = rawDescription ?? rawPrompt;
 
       const table = loadRoutingTableOrDefault();
       const match = matchRoutingTable(table, description, subagentType);
+      const judgmentStrong = description !== undefined && JUDGMENT_STRONG_RE.test(description);
 
-      if (match === null) return Verdict.allow;
+      // mode (conserve unless a fresh cache says splurge). Env override wins.
+      const envMode = process.env.AX_SPEND_MODE;
+      const computed = computeSpendMode(
+        readQuotaCacheSync(defaultQuotaCachePath()),
+        Date.now(),
+        DEFAULT_SPEND_CONFIG,
+      );
+      const mode =
+        envMode === "conserve" || envMode === "splurge" ? envMode : computed.mode;
 
-      const label = rawDescription
-        ? `"${rawDescription}"`
-        : subagentType
-          ? `agent-type "${subagentType}"`
-          : `"${description ?? "(unknown)"}"`;
-
-      const msg =
-        `ax routing: ${label} looks like ${match.reason} work - ` +
-        `consider model: "${match.suggest}" on this dispatch ` +
-        `(est ${costHint(match.suggest)} cheaper). ` +
-        `Explicit model silences this.`;
-
-      return Verdict.warn(msg);
+      return decideVerdict({
+        match: match !== null,
+        explicit,
+        cheap,
+        judgmentStrong,
+        routeDownEnforced: mode === "conserve",
+        input,
+        suggest: match?.suggest ?? "sonnet",
+      });
     }),
 });
 

--- a/packages/hooks-sdk/src/hooks/route-dispatch.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.ts
@@ -1,16 +1,19 @@
 /**
  * route-dispatch hook
  *
- * Fires on PreToolUse for the `Agent` tool. Routes subagent dispatches
- * quota-aware:
+ * Fires on PreToolUse for the `Agent` tool. Advises subagent dispatches
+ * quota-aware via additionalContext (the only mechanism that reaches the model
+ * for Agent dispatches; CC bugs #39814 + #40580 confirmed updatedInput/deny
+ * are ignored for the Agent tool):
  *
  *   - conserve mode: when a dispatch has no explicit model and matches a
- *     route-down class, silently rewrites the tool input to the suggested
- *     cheaper model (Verdict.route = updatedInput rewrite).
- *   - splurge mode: subtractive - no rewrite, runs on the strong inherited
- *     model.
+ *     route-down class, emits additionalContext advising the model to
+ *     re-dispatch with the suggested cheaper model (Verdict.advise).
+ *   - splurge mode: subtractive - no advisory, runs on the strong inherited
+ *     model (quota resets soon with headroom; no nag).
  *   - judgment guard (any mode): if a cheap explicit model is set for
- *     judgment work (review/design/audit) → warn.
+ *     judgment work (review/design/audit) → advise the model to prefer the
+ *     strong model (catch-rate gate).
  *
  * Spend mode keys off one knob: `routeDownEnforced = (mode === "conserve")`.
  * Mode is determined by AX_SPEND_MODE env override (conserve|splurge), else
@@ -33,7 +36,6 @@ import {
   JUDGMENT_STRONG_RE,
   readQuotaCacheSync,
 } from "../spend-mode.ts";
-import { Verdict } from "../verdict.ts";
 
 // Re-exported for consumers (ax hooks tooling, tests) that historically
 // imported the schema from the hook file.
@@ -84,7 +86,6 @@ const hook = defineHook({
         cheap,
         judgmentStrong,
         routeDownEnforced: mode === "conserve",
-        input,
         suggest: match?.suggest ?? "sonnet",
       });
     }),

--- a/packages/hooks-sdk/src/hooks/route-dispatch.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.ts
@@ -35,7 +35,22 @@ import {
   defaultQuotaCachePath,
   JUDGMENT_STRONG_RE,
   readQuotaCacheSync,
+  type SpendConfig,
 } from "../spend-mode.ts";
+
+/**
+ * Merge the table's optional spendMode block with DEFAULT_SPEND_CONFIG.
+ * Only fields present in the table override the default; absent keys fall back.
+ */
+const resolveSpendConfig = (tableSpendMode: Partial<SpendConfig> | undefined): SpendConfig =>
+  tableSpendMode === undefined
+    ? DEFAULT_SPEND_CONFIG
+    : {
+        stalenessMs: tableSpendMode.stalenessMs ?? DEFAULT_SPEND_CONFIG.stalenessMs,
+        nearResetMs7d: tableSpendMode.nearResetMs7d ?? DEFAULT_SPEND_CONFIG.nearResetMs7d,
+        minRemainingPct: tableSpendMode.minRemainingPct ?? DEFAULT_SPEND_CONFIG.minRemainingPct,
+        capFloorPct: tableSpendMode.capFloorPct ?? DEFAULT_SPEND_CONFIG.capFloorPct,
+      };
 
 // Re-exported for consumers (ax hooks tooling, tests) that historically
 // imported the schema from the hook file.
@@ -70,12 +85,15 @@ const hook = defineHook({
       const match = matchRoutingTable(table, description, subagentType);
       const judgmentStrong = description !== undefined && JUDGMENT_STRONG_RE.test(description);
 
+      // Resolve spend config: table overrides win over DEFAULT_SPEND_CONFIG.
+      const spendConfig = resolveSpendConfig(table.spendMode as Partial<SpendConfig> | undefined);
+
       // mode (conserve unless a fresh cache says splurge). Env override wins.
       const envMode = process.env.AX_SPEND_MODE;
       const computed = computeSpendMode(
         readQuotaCacheSync(defaultQuotaCachePath()),
         Date.now(),
-        DEFAULT_SPEND_CONFIG,
+        spendConfig,
       );
       const mode =
         envMode === "conserve" || envMode === "splurge" ? envMode : computed.mode;

--- a/packages/hooks-sdk/src/routing-table.ts
+++ b/packages/hooks-sdk/src/routing-table.ts
@@ -46,10 +46,32 @@ export const RoutingClassSchema = Schema.Struct({
   origin: Schema.optional(Schema.String),
 });
 
+/**
+ * Optional spendMode thresholds block in the routing table.
+ * When present, the route-dispatch hook uses these instead of DEFAULT_SPEND_CONFIG.
+ * When absent, the hook falls back to DEFAULT_SPEND_CONFIG from spend-mode.ts.
+ *
+ * Fields mirror SpendConfig in spend-mode.ts:
+ *   stalenessMs     - cache age above which the snapshot is stale (ms). Default 5 min.
+ *   nearResetMs7d   - 7d window "near reset" threshold (ms). Default 24h.
+ *   minRemainingPct - minimum remaining % required to splurge. Default 25%.
+ *   capFloorPct     - if any window is at or above this %, block splurge. Default 80%.
+ */
+export const SpendModeConfigSchema = Schema.Struct({
+  stalenessMs: Schema.optional(Schema.Number),
+  nearResetMs7d: Schema.optional(Schema.Number),
+  minRemainingPct: Schema.optional(Schema.Number),
+  capFloorPct: Schema.optional(Schema.Number),
+});
+
+export type SpendModeConfigShape = Schema.Schema.Type<typeof SpendModeConfigSchema>;
+
 export const RoutingTableSchema = Schema.Struct({
   version: Schema.Literal(1),
   classes: Schema.Array(RoutingClassSchema),
   agentTypes: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  /** Optional spend-mode threshold overrides. Absent = use DEFAULT_SPEND_CONFIG. */
+  spendMode: Schema.optional(SpendModeConfigSchema),
 });
 
 /** Decoded shape of a stored routing table (flags/origin/agentTypes optional). */

--- a/packages/hooks-sdk/src/spend-mode.test.ts
+++ b/packages/hooks-sdk/src/spend-mode.test.ts
@@ -25,6 +25,18 @@ describe("computeSpendMode", () => {
         const r = computeSpendMode(snap({ seven_day: { utilization: 80, resets_at: new Date(NOW + 12 * 3600_000).toISOString() } }), NOW, DEFAULT_SPEND_CONFIG);
         expect(r.mode).toBe("conserve"); // 100-80=20 not > 25
     });
+    test("conserve: headroom boundary - exactly 25% remaining is not > 25", () => {
+        // util=75 → 100-75=25, NOT > 25; near reset, no cap issues. Isolates the
+        // `> minRemainingPct` boundary (the 20%-left test trips cap too at util=80).
+        const r = computeSpendMode(snap({ seven_day: { utilization: 75, resets_at: new Date(NOW + 12 * 3600_000).toISOString() } }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve");
+    });
+    test("conserve: malformed 5h window (non-finite utilization) fails safe → blocks splurge", () => {
+        // A present-but-garbage 5h window must count as near-cap (conserve), not
+        // fail open to splurge. 7d is splurge-eligible; the bad 5h window blocks it.
+        const r = computeSpendMode(snap({ five_hour: { utilization: Number.NaN, resets_at: new Date(NOW + 3600_000).toISOString() } }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve");
+    });
     test("conserve: a window near its cap (5h at 85%) blocks splurge even with 7d headroom", () => {
         const r = computeSpendMode(snap({ five_hour: { utilization: 85, resets_at: new Date(NOW + 3600_000).toISOString() } }), NOW, DEFAULT_SPEND_CONFIG);
         expect(r.mode).toBe("conserve"); // capFloorPct=80, 85>=80

--- a/packages/hooks-sdk/src/spend-mode.test.ts
+++ b/packages/hooks-sdk/src/spend-mode.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { computeSpendMode, DEFAULT_SPEND_CONFIG, JUDGMENT_STRONG_RE } from "./spend-mode.ts";
+import type { QuotaSnapshot } from "./spend-mode.ts";
+
+const NOW = Date.parse("2026-06-15T12:00:00.000Z");
+const snap = (o: Partial<QuotaSnapshot> = {}): QuotaSnapshot => ({
+    v: 1,
+    fetched_at: new Date(NOW - 30_000).toISOString(), // 30s old → fresh
+    five_hour: { utilization: 10, resets_at: new Date(NOW + 3 * 3600_000).toISOString() },
+    seven_day: { utilization: 40, resets_at: new Date(NOW + 12 * 3600_000).toISOString() }, // 12h to reset, 60% left
+    ...o,
+});
+
+describe("computeSpendMode", () => {
+    test("splurge: 7d near reset (<24h) + headroom (>25%) + no window near cap", () => {
+        const r = computeSpendMode(snap(), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("splurge");
+        expect(r.stale).toBe(false);
+    });
+    test("conserve: 7d NOT near reset (resets in 3 days)", () => {
+        const r = computeSpendMode(snap({ seven_day: { utilization: 40, resets_at: new Date(NOW + 72 * 3600_000).toISOString() } }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve");
+    });
+    test("conserve: 7d near reset but low headroom (only 20% left)", () => {
+        const r = computeSpendMode(snap({ seven_day: { utilization: 80, resets_at: new Date(NOW + 12 * 3600_000).toISOString() } }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve"); // 100-80=20 not > 25
+    });
+    test("conserve: a window near its cap (5h at 85%) blocks splurge even with 7d headroom", () => {
+        const r = computeSpendMode(snap({ five_hour: { utilization: 85, resets_at: new Date(NOW + 3600_000).toISOString() } }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve"); // capFloorPct=80, 85>=80
+    });
+    test("conserve + stale when cache older than stalenessMs", () => {
+        const r = computeSpendMode(snap({ fetched_at: new Date(NOW - 10 * 60_000).toISOString() }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve");
+        expect(r.stale).toBe(true);
+    });
+    test("conserve when seven_day is null", () => {
+        expect(computeSpendMode(snap({ seven_day: null }), NOW, DEFAULT_SPEND_CONFIG).mode).toBe("conserve");
+    });
+    test("the 5h window never triggers splurge on its own (7d far from reset)", () => {
+        const r = computeSpendMode(snap({
+            five_hour: { utilization: 10, resets_at: new Date(NOW + 60 * 60_000).toISOString() }, // 5h resets in 1h, lots left
+            seven_day: { utilization: 40, resets_at: new Date(NOW + 72 * 3600_000).toISOString() }, // 7d far
+        }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve");
+    });
+    test("resets_at parse failure on 7d → conserve", () => {
+        const r = computeSpendMode(snap({ seven_day: { utilization: 40, resets_at: "not-a-date" } }), NOW, DEFAULT_SPEND_CONFIG);
+        expect(r.mode).toBe("conserve");
+    });
+});
+
+describe("JUDGMENT_STRONG_RE", () => {
+    test("matches strong judgment kinds", () => {
+        for (const s of ["quality review of X", "PR review", "final review", "design the migration", "audit the auth", "architect the layer", "adversarial review", "code review", "judge the reports"]) {
+            expect(JUDGMENT_STRONG_RE.test(s)).toBe(true);
+        }
+    });
+    test("does NOT match spec review (deliberate route-down class)", () => {
+        expect(JUDGMENT_STRONG_RE.test("spec review of PR #42")).toBe(false);
+        expect(JUDGMENT_STRONG_RE.test("spec-compliance review")).toBe(false);
+    });
+});

--- a/packages/hooks-sdk/src/spend-mode.ts
+++ b/packages/hooks-sdk/src/spend-mode.ts
@@ -131,10 +131,15 @@ export const computeSpendMode = (
   const nearReset = resetMs - nowMs < config.nearResetMs7d;
   const headroom = 100 - sevenDay.utilization > config.minRemainingPct;
   const sevenNearCap = sevenDay.utilization >= config.capFloorPct;
+  // Fail safe toward conserve: a present-but-garbage 5h window (non-finite
+  // utilization) counts as near-cap (blocks splurge). A null/absent 5h window
+  // stays not-near-cap (no 5h signal - the 7d path is what gates splurge).
   const fiveNearCap =
-    snapshot.five_hour !== null && snapshot.five_hour !== undefined
-      ? snapshot.five_hour.utilization >= config.capFloorPct
-      : false;
+    snapshot.five_hour != null &&
+    !(
+      Number.isFinite(snapshot.five_hour.utilization) &&
+      snapshot.five_hour.utilization < config.capFloorPct
+    );
 
   if (nearReset && headroom && !sevenNearCap && !fiveNearCap) {
     return { mode: "splurge", reason: "7d reset soon with surplus", stale: false };

--- a/packages/hooks-sdk/src/spend-mode.ts
+++ b/packages/hooks-sdk/src/spend-mode.ts
@@ -1,0 +1,168 @@
+/**
+ * Quota-aware spend-mode signal for the route-dispatch hook fire path.
+ *
+ * Pure functions + a synchronous cache reader (mirrors readRoutingTableSync in
+ * routing-table.ts - same fire-path constraint: ~70ms budget, `node:fs` sync,
+ * fail-open on any error). No Effect in this module - it runs under plain bun.
+ *
+ * Exports:
+ *   QuotaSnapshot  - minimal local type (matches apps/axctl/src/quota/schema.ts)
+ *   readQuotaCacheSync - sync fail-open read of ~/.ax/quota-cache.json
+ *   computeSpendMode   - pure mode decision
+ *   DEFAULT_SPEND_CONFIG
+ *   JUDGMENT_STRONG_RE - single regex for judgment-strong dispatches (shared
+ *                        with routing-tune via index.ts re-export)
+ */
+import { readFileSync } from "node:fs";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface QuotaWindow {
+  readonly utilization: number;
+  readonly resets_at: string;
+}
+
+/**
+ * Minimal local mirror of apps/axctl/src/quota/schema.ts:QuotaSnapshot.
+ * We only assert `v === 1` and `fetched_at` is a string; extra fields are
+ * allowed (`[k: string]: unknown`) so the hook fire path doesn't need to
+ * depend on the full schema module.
+ */
+export interface QuotaSnapshot {
+  readonly v: 1;
+  readonly fetched_at: string;
+  readonly five_hour: QuotaWindow | null;
+  readonly seven_day: QuotaWindow | null;
+  readonly [k: string]: unknown;
+}
+
+export type SpendMode = "conserve" | "splurge";
+
+export interface SpendModeResult {
+  readonly mode: SpendMode;
+  readonly reason: string;
+  readonly stale: boolean;
+}
+
+export interface SpendConfig {
+  /** Cache age above which the snapshot is treated as stale (ms). Default 5 min. */
+  readonly stalenessMs: number;
+  /** 7d window "near reset" threshold (ms). Default 24h. */
+  readonly nearResetMs7d: number;
+  /** Minimum remaining % (100 - utilization) required to splurge. Default 25%. */
+  readonly minRemainingPct: number;
+  /** If any window is at or above this utilization %, block splurge. Default 80%. */
+  readonly capFloorPct: number;
+}
+
+export const DEFAULT_SPEND_CONFIG: SpendConfig = {
+  stalenessMs: 5 * 60_000,
+  nearResetMs7d: 24 * 3600_000,
+  minRemainingPct: 25,
+  capFloorPct: 80,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const parseMs = (iso: string): number | null => {
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : null;
+};
+
+// ---------------------------------------------------------------------------
+// Judgment regex
+// ---------------------------------------------------------------------------
+
+/**
+ * Strong judgment work that must stay on the main/strong model. Matches
+ * quality/pr/final/adversarial/code review, design, audit, architect, critique,
+ * judge - and deliberately NOT a bare "review" or "spec review" (the spec-review
+ * routing class is a deliberate route-down target).
+ *
+ * Matches:  quality review, PR review, final review, adversarial review, code review
+ *           design, audit, architect*, critique, critic*, judg*
+ * Non-match: "spec review", "spec-compliance review", bare "review"
+ */
+export const JUDGMENT_STRONG_RE =
+  /\b(?:(?:quality|pr|final|adversarial|code)\s+review|design|audit|architect\w*|critique|critic\w*|judg\w*)\b/i;
+
+// ---------------------------------------------------------------------------
+// computeSpendMode (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide the current spend mode from a quota snapshot.
+ *
+ * splurge = 7d window is near reset (<nearResetMs7d) AND has headroom
+ *           (remaining > minRemainingPct) AND neither window is near its cap.
+ *
+ * Everything else → conserve. A null or stale snapshot → conserve + stale:true.
+ * The 5h window NEVER triggers splurge on its own.
+ */
+export const computeSpendMode = (
+  snapshot: QuotaSnapshot | null,
+  nowMs: number,
+  config: SpendConfig,
+): SpendModeResult => {
+  if (snapshot === null) {
+    return { mode: "conserve", reason: "no cache", stale: true };
+  }
+
+  const fetchedMs = parseMs(snapshot.fetched_at);
+  const stale = fetchedMs === null || nowMs - fetchedMs > config.stalenessMs;
+  if (stale) {
+    return { mode: "conserve", reason: "stale cache", stale: true };
+  }
+
+  const sevenDay = snapshot.seven_day;
+  if (!sevenDay) {
+    return { mode: "conserve", reason: "no 7d window", stale: false };
+  }
+
+  const resetMs = parseMs(sevenDay.resets_at);
+  if (resetMs === null) {
+    return { mode: "conserve", reason: "bad 7d resets_at", stale: false };
+  }
+
+  const nearReset = resetMs - nowMs < config.nearResetMs7d;
+  const headroom = 100 - sevenDay.utilization > config.minRemainingPct;
+  const sevenNearCap = sevenDay.utilization >= config.capFloorPct;
+  const fiveNearCap =
+    snapshot.five_hour !== null && snapshot.five_hour !== undefined
+      ? snapshot.five_hour.utilization >= config.capFloorPct
+      : false;
+
+  if (nearReset && headroom && !sevenNearCap && !fiveNearCap) {
+    return { mode: "splurge", reason: "7d reset soon with surplus", stale: false };
+  }
+  return { mode: "conserve", reason: "default", stale: false };
+};
+
+// ---------------------------------------------------------------------------
+// readQuotaCacheSync (fire-path sync read, mirrors readRoutingTableSync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Synchronously read the quota cache from disk.
+ * Returns null on ANY error (missing file, bad JSON, wrong shape).
+ * Never throws. Mirrors the fail-open semantics of readRoutingTableSync.
+ */
+export const readQuotaCacheSync = (path: string): QuotaSnapshot | null => {
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw) as QuotaSnapshot;
+    if (parsed && parsed.v === 1 && typeof parsed.fetched_at === "string") {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+export const defaultQuotaCachePath = (): string =>
+  `${process.env.HOME}/.ax/quota-cache.json`;

--- a/packages/hooks-sdk/src/spend-mode.ts
+++ b/packages/hooks-sdk/src/spend-mode.ts
@@ -10,8 +10,11 @@
  *   readQuotaCacheSync - sync fail-open read of ~/.ax/quota-cache.json
  *   computeSpendMode   - pure mode decision
  *   DEFAULT_SPEND_CONFIG
- *   JUDGMENT_STRONG_RE - single regex for judgment-strong dispatches (shared
- *                        with routing-tune via index.ts re-export)
+ *   JUDGMENT_STRONG_RE - NARROW, review-focused regex for the HOOK ONLY. It
+ *                        deliberately wants bare/spec review to route down (an
+ *                        advisory nudge). routing-tune does NOT use this - it has
+ *                        its own BROAD JUDGMENT_GUARD_RE because its auto-apply
+ *                        gate must over-flag (see routing-tune.ts).
  */
 import { readFileSync } from "node:fs";
 

--- a/packages/hooks-sdk/src/verdict.ts
+++ b/packages/hooks-sdk/src/verdict.ts
@@ -4,13 +4,13 @@ export type Verdict =
   | { readonly _tag: "Block"; readonly reason: string }
   | { readonly _tag: "Warn"; readonly message: string }
   | { readonly _tag: "Inject"; readonly context: string }
-  | { readonly _tag: "Route"; readonly input: Record<string, unknown> };
+  | { readonly _tag: "Advise"; readonly context: string };
 
 export const Verdict = {
   allow: { _tag: "Allow" },
   block: (reason: string): Verdict => ({ _tag: "Block", reason }),
   warn: (message: string): Verdict => ({ _tag: "Warn", message }),
   inject: (context: string): Verdict => ({ _tag: "Inject", context }),
-  /** Silently rewrite the tool input (PreToolUse allow + updatedInput). `input` is the FULL merged input. */
-  route: (input: Record<string, unknown>): Verdict => ({ _tag: "Route", input }),
+  /** Emit additionalContext to the model (PreToolUse advisory, the only mechanism that reaches the model for Agent dispatches). */
+  advise: (context: string): Verdict => ({ _tag: "Advise", context }),
 } as const;

--- a/packages/hooks-sdk/src/verdict.ts
+++ b/packages/hooks-sdk/src/verdict.ts
@@ -3,11 +3,14 @@ export type Verdict =
   | { readonly _tag: "Allow" }
   | { readonly _tag: "Block"; readonly reason: string }
   | { readonly _tag: "Warn"; readonly message: string }
-  | { readonly _tag: "Inject"; readonly context: string };
+  | { readonly _tag: "Inject"; readonly context: string }
+  | { readonly _tag: "Route"; readonly input: Record<string, unknown> };
 
 export const Verdict = {
   allow: { _tag: "Allow" },
   block: (reason: string): Verdict => ({ _tag: "Block", reason }),
   warn: (message: string): Verdict => ({ _tag: "Warn", message }),
   inject: (context: string): Verdict => ({ _tag: "Inject", context }),
+  /** Silently rewrite the tool input (PreToolUse allow + updatedInput). `input` is the FULL merged input. */
+  route: (input: Record<string, unknown>): Verdict => ({ _tag: "Route", input }),
 } as const;

--- a/scripts/check-no-node-fs.ts
+++ b/scripts/check-no-node-fs.ts
@@ -43,6 +43,10 @@ const EXCLUDED_FILES: readonly string[] = [
     // the hook's error channel stays `never` under plain bun (~70ms budget).
     // (Was hooks/route-dispatch.ts before the read seam moved here, ADR-0014.)
     "packages/hooks-sdk/src/routing-table.ts",
+    // Same fire-path constraint: quota-cache.json is read synchronously so the
+    // hook's error channel stays `never` under plain bun (~70ms budget).
+    // mirrors readRoutingTableSync - fail-open, effect-free.
+    "packages/hooks-sdk/src/spend-mode.ts",
 ];
 
 const BANNED_SPECIFIERS = [

--- a/skills/efficient-dispatch/SKILL.md
+++ b/skills/efficient-dispatch/SKILL.md
@@ -49,8 +49,14 @@ main-model judgment - otherwise pick sonnet.
    evidence format to return (files, line refs, commands, diffs, failures),
    verification commands, stop conditions.
 3. Set `model:` explicitly on every mechanical dispatch. The route-dispatch
-   hook warns when you forget - treat the warning as a re-dispatch signal,
-   not noise.
+   hook is quota-aware and ADVISORY (Claude Code hooks cannot enforce model on
+   subagent dispatches - they can only inject context via additionalContext):
+   in conserve mode it advises re-dispatching a forgotten mechanical dispatch
+   with `model:<cheaper>`; near a 7d quota reset (splurge) it stays quiet so
+   work runs on the strong inherited model; it advises when judgment work
+   (review/design/audit) is sent on a cheap model. Real enforcement is your
+   discipline + setting `model:` explicitly on every dispatch.
+   Treat the advisory as a re-dispatch signal, not noise.
 4. Treat subagent reports as leads. Before acting on a high-impact finding or
    declaring done, reopen the cited files and re-run the key verification
    yourself. Expect to find one real bug per delegated phase.


### PR DESCRIPTION
## Summary
Makes the route-dispatch hook **quota-aware**. PR1 is the conserve-side advisory + the spend-mode signal everything keys off.

- **`computeSpendMode`** (pure, in hooks-sdk, hot-path/effect-only): `conserve | splurge` from the local quota cache (7d-only trigger + cap guard on both windows; stale/null → conserve). The single signal both the hook and (PR2) the statusline use.
- **`decideVerdict`** (pure, ordered): judgment-cheap → advise; explicit → allow; conserve + forgotten route-down → advise re-dispatching with the cheaper model; splurge → allow (subtractive, no nag). Judgment work is never routed. 32-cell space tested.
- **Quota-aware advisory** via `Verdict.advise` → `additionalContext`.

## ⚠️ The honest finding (mid-implementation pivot)
The design originally specced **auto-route** (silently rewrite the dispatch's `model`). Task 4's verification — front-loaded precisely because it was the linchpin — proved that **impossible**: Claude Code hooks **cannot enforce, rewrite, or block the `Agent` (subagent dispatch) tool** (confirmed CC bugs #39814 `updatedInput` ignored, #40580 `deny`/exit-2 ignored, #24327). The **only** mechanism that reaches the model for an Agent dispatch is `additionalContext` — advisory.

So this is an **advisory, not enforcement** — and that's named plainly everywhere (the `efficient-dispatch` SKILL now says so). The hook advises; it cannot force. **Real enforcement of model routing lives in the cognitive layer** (the skill discipline) + **controlled dispatch paths** (a workflow/skill that sets `model:` when *it* constructs the Agent call) — out of scope for a hook. This pivot is documented in the spec's AMENDMENT section and in a durable memory.

## Notes for reviewers
- The judgment regex is **two deliberately-different** patterns: a **narrow** one for the hook advisory (wants bare/spec review to route *down*), and a **broad** guard in `routing-tune` for its **unattended auto-apply** safety gate (must over-flag plan/verify/assess/review). A review caught that collapsing them regressed auto-apply safety; they're now purpose-split.
- `ax hooks backtest` gained a `wouldAdvise` counter (Advise was invisible).
- Spec: `docs/superpowers/specs/2026-06-15-dispatch-economy-enforcement-design.md` (+ AMENDMENT); plan: `docs/superpowers/plans/2026-06-15-dispatch-economy.md`.

## Test plan
- [x] `bun test` repo-wide: 4117 pass / 0 fail
- [x] `bun run typecheck` + `check:cli-reference` + `check-no-node-fs`: clean
- [x] stdin smoke: conserve+mechanical → `additionalContext` advice (model:sonnet); judgment-cheap → catch-rate advice; splurge/explicit → allow
- [x] docs-guide verification of the CC hook limitation (4 cited issues)

## PR2 follows
spend-mode statusline surface + staleness, SessionStart freshness + interval refresh, the **splurge → /dojo nudge** (the in-harness window-end trigger), and the measurement lens. PR2 is unaffected by the advisory pivot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)