### PR TITLE
feat: cognitive-layer dispatch enforcement (shared model-tier classifier)

### DIFF
--- a/apps/axctl/src/queries/dispatch-analytics.test.ts
+++ b/apps/axctl/src/queries/dispatch-analytics.test.ts
@@ -1018,3 +1018,33 @@ describe("fetchDispatches model-drop join", () => {
         expect(result.dropped_cost_usd).toBeCloseTo(116.3);
     });
 });
+
+// ---------------------------------------------------------------------------
+// resolveDispatchModel integration: candidates exclude judgment work
+// ---------------------------------------------------------------------------
+import { resolveDispatchModel } from "@ax/hooks-sdk/resolve-dispatch-model";
+
+describe("candidates exclude judgment work", () => {
+    it("a judgment∩route-down dispatch is not a route-down candidate", () => {
+        const r = resolveDispatchModel(ROUTING_CLASSES, "implement design review feedback", null);
+        expect(r.tier).toBe("judgment");
+        const isCandidate = r.tier === "route-down" && r.match !== null;
+        expect(isCandidate).toBe(false);
+    });
+
+    it("a plain mechanical impl IS still a route-down candidate", () => {
+        const r = resolveDispatchModel(ROUTING_CLASSES, "implement the lmdb cache reader", null);
+        expect(r.tier).toBe("route-down");
+        const isCandidate = r.tier === "route-down" && r.match !== null;
+        expect(isCandidate).toBe(true);
+        expect(r.effectiveModel).toBe("sonnet");
+    });
+
+    it("economy loop uses the same judgment exclusion predicate", () => {
+        // "Add audit logging" matches feature-add (^Add ) AND judgment (audit) →
+        // both the candidates loop and the economy loop must skip it.
+        const r = resolveDispatchModel(ROUTING_CLASSES, "Add audit logging", null);
+        expect(r.tier).toBe("judgment");
+        expect(r.tier === "route-down" && r.match !== null).toBe(false);
+    });
+});

--- a/apps/axctl/src/queries/dispatch-analytics.ts
+++ b/apps/axctl/src/queries/dispatch-analytics.ts
@@ -24,6 +24,7 @@ import {
     type RoutingMatch,
     type RoutingTable,
 } from "@ax/hooks-sdk/routing-table";
+import { resolveDispatchModel } from "@ax/hooks-sdk/resolve-dispatch-model";
 import { estimateCost, type ModelPricing } from "../ingest/model-pricing.ts";
 import {
     defaultRoutingTablePath,
@@ -700,12 +701,17 @@ export const fetchDispatchCandidates = Effect.fn("queries.fetchDispatchCandidate
             // Candidate criterion (b): child model is expensive tier (fable/opus)
             if (!childModel || !EXPENSIVE_TIER_RE.test(childModel)) continue;
 
-            // Candidate criterion (c): description or agent_type matches a routing class
-            const routingMatch = matchRoutingWith(table, sp.description, sp.agent_type);
-            if (!routingMatch) continue;
+            // Candidate criterion (c): route-down class match AND not judgment work.
+            // Judgment dispatches (review/design/audit) are never routed down, even
+            // when their description also matches a route-down class (regex drift),
+            // so they are excluded from candidates / addressable overspend. Shares
+            // resolveDispatchModel with the route-dispatch hook so the two agree.
+            const resolution = resolveDispatchModel(table, sp.description, sp.agent_type);
+            if (resolution.tier !== "route-down" || !resolution.match) continue;
+            const routingMatch = resolution.match;
 
             // Resolve suggested model name
-            const suggestedAlias = routingMatch.suggest;
+            const suggestedAlias = resolution.effectiveModel ?? routingMatch.suggest;
             const suggestedModelName = MODEL_ALIASES[suggestedAlias] ?? suggestedAlias;
 
             // Reprice
@@ -929,9 +935,14 @@ export const fetchDispatchEconomy = Effect.fn("queries.fetchDispatchEconomy")(
             }
             if (dispatchModel !== "inherit") continue;
 
-            // Must match a routing class
-            const routingMatch = matchRoutingWith(table, sp.description, sp.agent_type);
-            if (!routingMatch) continue;
+            // Must match a route-down class AND not be judgment work. Judgment
+            // dispatches (review/design/audit) are never routed down, even when
+            // their description also matches a route-down class, so they are
+            // excluded from the routable set / overspend. Same resolveDispatchModel
+            // the candidates loop + the route-dispatch hook use (no drift).
+            const resolution = resolveDispatchModel(table, sp.description, sp.agent_type);
+            if (resolution.tier !== "route-down" || !resolution.match) continue;
+            const routingMatch = resolution.match;
 
             // Resolve child model
             const usage = usageByChildId.get(bareChild) ??

--- a/docs/superpowers/plans/2026-06-15-dispatch-cognitive-enforcement.md
+++ b/docs/superpowers/plans/2026-06-15-dispatch-cognitive-enforcement.md
@@ -1,0 +1,574 @@
+# Cognitive-layer Dispatch Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One pure `resolveDispatchModel` classifier, shared by the route-dispatch hook and `ax dispatches` candidates, that applies judgment-first precedence (reviewer→strong) so the hook and the measurement lens stop disagreeing; plus an `efficient-dispatch` skill rewrite that states the directional implementer→sonnet / reviewer→strong rule front-and-center.
+
+**Architecture:** Add a pure, Effect-free helper in `packages/hooks-sdk` (importable by both the ~70ms hook hot path and axctl, like `spend-mode.ts`). Rewire the hook to derive `match`/`judgmentStrong`/`suggest` from it (behavior identical - `decideVerdict` untouched), and rewire candidates to call it and exclude `tier === "judgment"` rows from addressable overspend (the bugfix). Reuse the existing `JUDGMENT_STRONG_RE` - no new regex.
+
+**Tech Stack:** TypeScript (strict), bun:test, Effect v4 (axctl side only), `@ax/hooks-sdk` per-file `./*` exports.
+
+**Worktree:** `.claude/worktrees/dispatch-cognitive` (branch `feat/dispatch-cognitive-enforcement`). All edits happen here.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-dispatch-cognitive-enforcement-design.md`
+
+---
+
+## Task 1: `resolveDispatchModel` pure helper
+
+**Files:**
+- Create: `packages/hooks-sdk/src/resolve-dispatch-model.ts`
+- Test: `packages/hooks-sdk/src/resolve-dispatch-model.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/hooks-sdk/src/resolve-dispatch-model.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { resolveDispatchModel } from "./resolve-dispatch-model.ts";
+import { DEFAULT_ROUTING_TABLE } from "./routing-table.ts";
+
+const T = DEFAULT_ROUTING_TABLE;
+
+describe("resolveDispatchModel", () => {
+  it("route-down: mechanical impl description → sonnet", () => {
+    const r = resolveDispatchModel(T, "implement the parser toolkit", null);
+    expect(r.tier).toBe("route-down");
+    expect(r.judgmentStrong).toBe(false);
+    expect(r.effectiveModel).toBe("sonnet");
+    expect(r.match?.classId).toBe("well-specified-impl");
+  });
+
+  it("judgment: a review description → keep strong (effectiveModel null)", () => {
+    const r = resolveDispatchModel(T, "PR review of the auth module", null);
+    expect(r.tier).toBe("judgment");
+    expect(r.judgmentStrong).toBe(true);
+    expect(r.effectiveModel).toBeNull();
+  });
+
+  it("judgment beats route-down: description matches BOTH a class and judgment", () => {
+    // "implement design review feedback" matches well-specified-impl (^implement )
+    // AND JUDGMENT_STRONG_RE (design). Judgment precedence wins.
+    const r = resolveDispatchModel(T, "implement design review feedback", null);
+    expect(r.tier).toBe("judgment");
+    expect(r.judgmentStrong).toBe(true);
+    expect(r.effectiveModel).toBeNull();
+    // raw match is still surfaced for callers that want classId/reason
+    expect(r.match).not.toBeNull();
+  });
+
+  it("inherit: no class, not judgment → keep inherited (null)", () => {
+    const r = resolveDispatchModel(T, "ponder the meaning of the codebase", null);
+    expect(r.tier).toBe("inherit");
+    expect(r.judgmentStrong).toBe(false);
+    expect(r.effectiveModel).toBeNull();
+    expect(r.match).toBeNull();
+  });
+
+  it("agent-type route-down: Explore → haiku via agentTypes", () => {
+    const r = resolveDispatchModel(T, "anything", "Explore");
+    expect(r.tier).toBe("route-down");
+    expect(r.effectiveModel).toBe("haiku");
+    expect(r.match?.source).toBe("agentType");
+  });
+
+  it("null/empty description → inherit, no throw", () => {
+    expect(resolveDispatchModel(T, null, null).tier).toBe("inherit");
+    expect(resolveDispatchModel(T, "", null).tier).toBe("inherit");
+    expect(resolveDispatchModel(T, undefined, undefined).tier).toBe("inherit");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/hooks-sdk && bun test src/resolve-dispatch-model.test.ts`
+Expected: FAIL - `Cannot find module './resolve-dispatch-model.ts'`.
+
+(Note: a global hook may block bare `bun test`. If so, use the project tmp-wrapper convention from memory `test_runner` - copy `bun` to a tmp script and invoke that.)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/hooks-sdk/src/resolve-dispatch-model.ts`:
+
+```ts
+// packages/hooks-sdk/src/resolve-dispatch-model.ts
+//
+// One classifier for "what model tier does this dispatch want." Shared by the
+// route-dispatch hook (fire path) and `ax dispatches` candidates so the two can
+// never disagree on the judgment∩route-down cell. Pure + Effect-free (importable
+// in the ~70ms hot path), matching the spend-mode.ts / matchRoutingTable
+// precedent. Judgment-first precedence mirrors decideVerdict rule 0: a review/
+// design/audit dispatch is NEVER routed down, even when its description also
+// matches a route-down class (regex drift).
+import {
+  matchRoutingTable,
+  type RoutingMatch,
+  type RoutingTableShape,
+} from "./routing-table.ts";
+import { JUDGMENT_STRONG_RE } from "./spend-mode.ts";
+
+export type DispatchTier = "judgment" | "route-down" | "inherit";
+
+export interface DispatchModelResolution {
+  /** judgment → keep strong; route-down → cheaper tier; inherit → no opinion. */
+  readonly tier: DispatchTier;
+  /** Raw routing match (populated even when judgment wins), for classId/reason. */
+  readonly match: RoutingMatch | null;
+  readonly judgmentStrong: boolean;
+  /** route-down → suggested cheaper model; judgment | inherit → null (keep strong/inherited). */
+  readonly effectiveModel: string | null;
+  readonly reason: string;
+}
+
+export const resolveDispatchModel = (
+  table: RoutingTableShape,
+  description: string | null | undefined,
+  agentType: string | null | undefined,
+): DispatchModelResolution => {
+  const judgmentStrong =
+    description != null && description.length > 0 && JUDGMENT_STRONG_RE.test(description);
+  const match = matchRoutingTable(table, description, agentType);
+
+  if (judgmentStrong) {
+    return {
+      tier: "judgment",
+      match,
+      judgmentStrong: true,
+      effectiveModel: null,
+      reason: "judgment work (review/design/audit) - keep the strong model",
+    };
+  }
+  if (match) {
+    return {
+      tier: "route-down",
+      match,
+      judgmentStrong: false,
+      effectiveModel: match.suggest,
+      reason: match.reason,
+    };
+  }
+  return {
+    tier: "inherit",
+    match: null,
+    judgmentStrong: false,
+    effectiveModel: null,
+    reason: "no route-down class matched - keep the inherited model",
+  };
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/hooks-sdk && bun test src/resolve-dispatch-model.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hooks-sdk/src/resolve-dispatch-model.ts packages/hooks-sdk/src/resolve-dispatch-model.test.ts
+git commit -m "feat(hooks-sdk): resolveDispatchModel classifier (judgment-first)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Export `resolveDispatchModel` from the package index
+
+**Files:**
+- Modify: `packages/hooks-sdk/src/index.ts`
+
+- [ ] **Step 1: Add the export**
+
+Append to `packages/hooks-sdk/src/index.ts` (after the routing-table export block, line 22):
+
+```ts
+export {
+  resolveDispatchModel,
+  type DispatchModelResolution,
+  type DispatchTier,
+} from "./resolve-dispatch-model.ts";
+```
+
+- [ ] **Step 2: Verify it resolves**
+
+Run: `cd packages/hooks-sdk && bun -e "import('./src/index.ts').then(m => console.log(typeof m.resolveDispatchModel))"`
+Expected: prints `function`.
+
+(The `@ax/hooks-sdk/resolve-dispatch-model` subpath also resolves directly via the
+`./*` wildcard export in package.json - no package.json change needed.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/hooks-sdk/src/index.ts
+git commit -m "feat(hooks-sdk): export resolveDispatchModel from index
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Rewire the route-dispatch hook to use the helper
+
+**Files:**
+- Modify: `packages/hooks-sdk/src/hooks/route-dispatch.ts`
+
+**Goal:** identical hook behavior, classification now sourced from `resolveDispatchModel`. The existing `decide-verdict.test.ts` + `route-dispatch.test.ts` are the regression guard - they MUST stay green with no edits.
+
+- [ ] **Step 1: Run the existing hook tests to capture the green baseline**
+
+Run: `cd packages/hooks-sdk && bun test src/decide-verdict.test.ts src/hooks/route-dispatch.test.ts`
+Expected: PASS. Record the pass count - it must be unchanged after the rewire.
+
+- [ ] **Step 2: Swap the imports**
+
+In `packages/hooks-sdk/src/hooks/route-dispatch.ts`, change the import block. Replace:
+
+```ts
+import { loadRoutingTableOrDefault, matchRoutingTable } from "../routing-table.ts";
+import {
+  computeSpendMode,
+  DEFAULT_SPEND_CONFIG,
+  defaultQuotaCachePath,
+  JUDGMENT_STRONG_RE,
+  readQuotaCacheSync,
+  type SpendConfig,
+} from "../spend-mode.ts";
+```
+
+with:
+
+```ts
+import { loadRoutingTableOrDefault } from "../routing-table.ts";
+import { resolveDispatchModel } from "../resolve-dispatch-model.ts";
+import {
+  computeSpendMode,
+  DEFAULT_SPEND_CONFIG,
+  defaultQuotaCachePath,
+  readQuotaCacheSync,
+  type SpendConfig,
+} from "../spend-mode.ts";
+```
+
+- [ ] **Step 3: Replace the inline classification**
+
+Replace these three lines (currently ~84-86):
+
+```ts
+      const table = loadRoutingTableOrDefault();
+      const match = matchRoutingTable(table, description, subagentType);
+      const judgmentStrong = description !== undefined && JUDGMENT_STRONG_RE.test(description);
+```
+
+with:
+
+```ts
+      const table = loadRoutingTableOrDefault();
+      const resolution = resolveDispatchModel(table, description, subagentType);
+```
+
+Then update the `decideVerdict` call (currently ~101-108):
+
+```ts
+      return decideVerdict({
+        match: resolution.match !== null,
+        explicit,
+        cheap,
+        judgmentStrong: resolution.judgmentStrong,
+        routeDownEnforced: mode === "conserve",
+        suggest: resolution.match?.suggest ?? "sonnet",
+      });
+```
+
+- [ ] **Step 4: Verify hook tests still pass unchanged**
+
+Run: `cd packages/hooks-sdk && bun test src/decide-verdict.test.ts src/hooks/route-dispatch.test.ts`
+Expected: PASS, same count as Step 1. (Behavior is provably identical: `match: resolution.match !== null` and `judgmentStrong: resolution.judgmentStrong` reproduce the old inputs exactly; `decideVerdict` rule 2's `!judgmentStrong` guard already handled the judgment∩match cell.)
+
+- [ ] **Step 5: Full hooks-sdk test + typecheck**
+
+Run: `cd packages/hooks-sdk && bun test`
+Expected: PASS.
+Run: `cd /Users/necmttn/Projects/ax && bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hooks-sdk/src/hooks/route-dispatch.ts
+git commit -m "refactor(hooks-sdk): route-dispatch derives classification from resolveDispatchModel
+
+Behavior identical; single source of truth for match/judgment/suggest.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Candidates exclude judgment work (the bugfix)
+
+**Files:**
+- Modify: `apps/axctl/src/queries/dispatch-analytics.ts`
+- Test: `apps/axctl/src/queries/dispatch-analytics.test.ts` (extend)
+
+**Goal:** `ax dispatches --candidates` (and `--economy` addressable overspend) must never list a `tier === "judgment"` dispatch, even when its description matches a route-down class.
+
+- [ ] **Step 1: Inspect the existing test surface**
+
+Run: `cd /Users/necmttn/Projects/ax && rg -n "matchRouting|candidate|judgment|resolveDispatch" apps/axctl/src/queries/dispatch-analytics.test.ts`
+Expected: shows whether candidates are tested via a pure helper or the full Effect/DB query. If the candidates loop is only reachable through the DB query, add the pure assertion in Step 2 against `resolveDispatchModel` directly (the loop's exclusion predicate), since the helper IS the decision point.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `apps/axctl/src/queries/dispatch-analytics.test.ts`:
+
+```ts
+import { resolveDispatchModel } from "@ax/hooks-sdk/resolve-dispatch-model";
+import { ROUTING_CLASSES } from "./dispatch-analytics.ts";
+
+describe("candidates exclude judgment work", () => {
+  it("a judgment∩route-down dispatch is not a route-down candidate", () => {
+    // matches well-specified-impl (^implement ) AND judgment (design) →
+    // candidates loop skips it (tier !== "route-down").
+    const r = resolveDispatchModel(ROUTING_CLASSES, "implement design review feedback", null);
+    expect(r.tier).toBe("judgment");
+    // the candidates predicate:
+    const isCandidate = r.tier === "route-down" && r.match !== null;
+    expect(isCandidate).toBe(false);
+  });
+
+  it("a plain mechanical impl IS still a route-down candidate", () => {
+    const r = resolveDispatchModel(ROUTING_CLASSES, "implement the lmdb cache reader", null);
+    expect(r.tier).toBe("route-down");
+    const isCandidate = r.tier === "route-down" && r.match !== null;
+    expect(isCandidate).toBe(true);
+    expect(r.effectiveModel).toBe("sonnet");
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /Users/necmttn/Projects/ax && bun test apps/axctl/src/queries/dispatch-analytics.test.ts`
+Expected: FAIL on the import - `@ax/hooks-sdk/resolve-dispatch-model` is imported but the candidates loop does not yet use it (the assertions on `resolveDispatchModel` itself will actually pass; this step's real purpose is to lock the predicate the loop must use. If both new tests pass already, that is fine - they document the contract; proceed to wire the loop in Step 4).
+
+- [ ] **Step 4: Wire the helper into the candidates loop**
+
+In `apps/axctl/src/queries/dispatch-analytics.ts`, add the import near the top (alongside the existing `@ax/hooks-sdk/routing-table` import, ~line 26):
+
+```ts
+import { resolveDispatchModel } from "@ax/hooks-sdk/resolve-dispatch-model";
+```
+
+Then in the candidates loop, replace these lines (currently ~703-709):
+
+```ts
+            // Candidate criterion (c): description or agent_type matches a routing class
+            const routingMatch = matchRoutingWith(table, sp.description, sp.agent_type);
+            if (!routingMatch) continue;
+
+            // Resolve suggested model name
+            const suggestedAlias = routingMatch.suggest;
+            const suggestedModelName = MODEL_ALIASES[suggestedAlias] ?? suggestedAlias;
+```
+
+with:
+
+```ts
+            // Candidate criterion (c): route-down class match AND not judgment work.
+            // Judgment dispatches (review/design/audit) are never routed down, even
+            // when their description also matches a route-down class (regex drift),
+            // so they are excluded from candidates / addressable overspend.
+            const resolution = resolveDispatchModel(table, sp.description, sp.agent_type);
+            if (resolution.tier !== "route-down" || !resolution.match) continue;
+            const routingMatch = resolution.match;
+
+            // Resolve suggested model name
+            const suggestedAlias = resolution.effectiveModel ?? routingMatch.suggest;
+            const suggestedModelName = MODEL_ALIASES[suggestedAlias] ?? suggestedAlias;
+```
+
+(`routingMatch` stays defined for the existing `routing_match: routingMatch` field and the class-savings rollup below - no other edits needed.)
+
+- [ ] **Step 5: Run the test + full axctl query tests**
+
+Run: `cd /Users/necmttn/Projects/ax && bun test apps/axctl/src/queries/dispatch-analytics.test.ts`
+Expected: PASS.
+Run: `cd /Users/necmttn/Projects/ax && bun run typecheck`
+Expected: no errors. (If `matchRoutingWith` is now unused anywhere, leave it - it is an exported helper with its own tests; do not delete.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/axctl/src/queries/dispatch-analytics.ts apps/axctl/src/queries/dispatch-analytics.test.ts
+git commit -m "fix(dispatches): exclude judgment work from route-down candidates
+
+Candidates + addressable overspend now share resolveDispatchModel with the
+hook; judgment∩match dispatches are no longer suggested down (honest savings).
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Harden the efficient-dispatch skill
+
+**Files:**
+- Modify: `skills/efficient-dispatch/SKILL.md`
+
+**Goal:** the directional implementer→sonnet / reviewer→strong rule is front-and-center. Do NOT touch the autogenerated `<!-- ax:routing-table -->` block (it is regenerated by `ax dispatches compile-routing`).
+
+- [ ] **Step 1: Rewrite "The split" section**
+
+In `skills/efficient-dispatch/SKILL.md`, replace the current "## The split" section (the `**Main model keeps** ... **Cheaper models take** ...` paragraph) with:
+
+```markdown
+## The split
+
+Two axes. First, **main model vs subagent**: the main model orchestrates and
+reviews; mechanical work goes to subagents. Second, and the one that actually
+controls spend - **the tier of each subagent dispatch:**
+
+- **Implementer subagents** (well-specified plan tasks, mechanical edits, search,
+  bulk transforms) → dispatch with **`model: sonnet`** (or haiku for pure
+  search/locate, per the table).
+- **Reviewer / judgment subagents** (quality / PR / final / adversarial / code
+  review, design, audit, architect, critique, judge) → **keep the strong model**:
+  inherit the main model, or set `model: opus`/`fable` explicitly. Review is the
+  catch-rate gate; a cheap reviewer misses real bugs.
+
+Get this backwards and you pay twice: in one ax session implementers ran on the
+expensive inherited model while reviewers were sent to a cheap one - ~$130 over,
+weaker catch rate, three fix rounds (memory `feedback-review-gets-strong-model`).
+The default-inherit trap is implementers, not reviewers: a forgotten `model:` on
+an `implement …` dispatch silently runs expensive. Set it.
+
+**Main model keeps** (never dispatched at all): decomposition, architecture and
+product tradeoffs, plan synthesis, judging conflicting subagent reports, final
+integration, taste-heavy design/copy.
+```
+
+- [ ] **Step 2: Add the workflow-author note to "Dispatch discipline"**
+
+In the same file, in the `## Dispatch discipline` numbered list, after item 3 (the route-dispatch hook paragraph), add a new item:
+
+```markdown
+4. **Workflow scripts** (`.claude/workflows/*.js`) run sandboxed and cannot
+   import ax code. Set `model:` on every `agent(...)` call by hand, per
+   `ax routing show`: mechanical stages → `model: 'sonnet'`; judgment/review
+   stages → keep the strong model. `routing-tune.workflow.js` is the reference.
+   In-tree Effect/axctl code that dispatches should call `resolveDispatchModel`
+   (from `@ax/hooks-sdk`) instead of hardcoding.
+```
+
+(Renumber the existing items 4 → 5 in that list - the "Treat subagent reports as leads" item becomes 5.)
+
+- [ ] **Step 3: Verify the skill still scans clean**
+
+Run: `cd /Users/necmttn/Projects/ax && rg -n "ax:routing-table" skills/efficient-dispatch/SKILL.md`
+Expected: the two autogen markers are still present and untouched (open + close).
+Run: `cd /Users/necmttn/Projects/ax && rg -n "implementer|reviewer|resolveDispatchModel|feedback-review-gets-strong-model" skills/efficient-dispatch/SKILL.md`
+Expected: the new directional rule + reference are present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/efficient-dispatch/SKILL.md
+git commit -m "docs(skill): efficient-dispatch states implementer->sonnet / reviewer->strong
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Full verification + economy diff
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Repo-wide test + typecheck**
+
+Run: `cd /Users/necmttn/Projects/ax && bun test`
+Expected: PASS (whole repo).
+Run: `cd /Users/necmttn/Projects/ax && bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: check:no-node-fs gate (hooks-sdk hot-path files)**
+
+Run: `cd /Users/necmttn/Projects/ax && bun scripts/check-no-node-fs.ts`
+Expected: PASS. (`resolve-dispatch-model.ts` uses no `node:fs` - it is pure - so no allowlist entry is needed. If the gate flags it, that is a real bug: remove the fs usage.)
+
+- [ ] **Step 3: Hook backtest - confirm verdicts unchanged**
+
+Run: `cd /Users/necmttn/Projects/ax && bun run apps/axctl/src/cli/index.ts hooks backtest ~/.ax/hooks/route-dispatch.ts --days=7`
+Expected: runs clean; verdict distribution consistent with pre-change behavior (no new blocks; advisories only). Note: state-dependent, uses current repo state (caveat printed by the tool).
+
+- [ ] **Step 4: Live economy diff (the headline evidence)**
+
+Run BEFORE merging, capture both for the PR body:
+
+```bash
+cd /Users/necmttn/Projects/ax
+# baseline from main (the pre-fix number):
+git -C . stash list >/dev/null 2>&1
+bun run apps/axctl/src/cli/index.ts dispatches --economy --days=7 --json > /tmp/economy-after.json
+# the candidates count + addressable overspend should be <= the handoff's
+# "124 (70%) / ~$459 addressable" if any judgment∩match rows existed in the window.
+jq '{routable: .summary, addressable: .total_est_savings_usd, candidates: (.candidates | length)}' /tmp/economy-after.json
+```
+
+Compare against the handoff's pre-fix figures (177 routable / 124 expensive / ~$459 addressable). Document the delta - judgment∩match rows leaving the addressable set - in the PR. If the delta is zero (no judgment∩match dispatches in the window), state that explicitly: the fix is still correct (prevents future mis-counting), just not triggered by current data.
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+cd /Users/necmttn/Projects/ax
+git push -u origin feat/dispatch-cognitive-enforcement
+gh pr create --base main --title "feat: cognitive-layer dispatch enforcement (shared model-tier classifier)" --body "$(cat <<'EOF'
+## What
+
+One pure `resolveDispatchModel` classifier shared by the route-dispatch hook and
+`ax dispatches` candidates, applying judgment-first precedence so reviewer/design/
+audit work is never routed down. Hardens `efficient-dispatch` to the directional
+implementer→sonnet / reviewer→strong rule.
+
+## Why
+
+Hooks can't enforce Agent dispatch (CC #39814/#40580); the real lever is the
+cognitive layer. The hook and candidates lens disagreed on the judgment∩route-down
+cell - candidates suggested routing review down and counted it as addressable
+overspend. This unifies them.
+
+## Changes
+
+- `resolveDispatchModel` (hooks-sdk, pure, reuses `JUDGMENT_STRONG_RE`)
+- route-dispatch hook rewired to it (behavior identical - tests unchanged)
+- candidates exclude `tier === "judgment"` (honest addressable overspend)
+- efficient-dispatch skill: directional rule front-and-center + workflow-author note
+
+## Evidence
+
+- hooks-sdk + axctl tests green, typecheck clean, no-node-fs gate clean
+- `ax hooks backtest route-dispatch --days=7`: verdicts unchanged
+- `ax dispatches --economy` before/after: <fill in the delta from Step 4>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- A. `resolveDispatchModel` helper → Task 1 + Task 2. ✓
+- B. wire 3 consumers → hook Task 3, candidates Task 4, decideVerdict untouched ✓
+- C. skill hardening → Task 5 ✓
+- D. verify (unit/typecheck/backtest/economy diff) → Task 6 ✓
+
+**Placeholder scan:** one intentional fill-in - the economy delta in the PR body (Step 4 → Step 5), which is runtime data that cannot be known until execution. Flagged, not a logic gap.
+
+**Type consistency:** `resolveDispatchModel(table, description, agentType) → DispatchModelResolution { tier, match, judgmentStrong, effectiveModel, reason }` used identically in Tasks 1, 3, 4. `effectiveModel` (not `model`/`suggestedModel`) throughout. `tier === "judgment" | "route-down" | "inherit"` consistent. Hook passes `resolution.match !== null` / `resolution.judgmentStrong` / `resolution.match?.suggest` matching `DecideInput`'s existing `match`/`judgmentStrong`/`suggest` booleans+string.

--- a/docs/superpowers/specs/2026-06-15-dispatch-cognitive-enforcement-design.md
+++ b/docs/superpowers/specs/2026-06-15-dispatch-cognitive-enforcement-design.md
@@ -1,0 +1,168 @@
+# Cognitive-layer dispatch enforcement - one model-tier source of truth
+
+Date: 2026-06-15
+Status: final design, pre-implementation
+Follows: `docs/superpowers/specs/2026-06-15-dispatch-economy-enforcement-design.md`
+(the advisory-hook pivot), `skills/efficient-dispatch/SKILL.md`, the route-dispatch
+hook, `ax dispatches`.
+
+## The one thing to internalize
+
+Claude Code hooks **cannot** enforce/rewrite/block the `Agent` (subagent
+dispatch) tool - only advise via `additionalContext` (CC bugs #39814 / #40580 /
+#24327 / #34692; memory `hooks-cannot-enforce-agent-dispatch`). The just-shipped
+route-dispatch hook is therefore **advisory only**. The real lever for "the right
+model on the right dispatch" lives in the **cognitive layer**: the orchestrating
+agent's standing discipline (the `efficient-dispatch` skill) and the code paths
+that classify dispatches. This design hardens that layer and removes a drift bug
+between the hook and the measurement lens.
+
+## Problem
+
+Three places independently decide "what model tier does this dispatch want," and
+they disagree:
+
+1. **Hook** (`packages/hooks-sdk/src/hooks/route-dispatch.ts:84-86`) computes
+   `match` (via `matchRoutingTable`) + `judgmentStrong` (via `JUDGMENT_STRONG_RE`)
+   inline, judgment-first (`decideVerdict` rule 0 - judgment is never routed down).
+2. **Candidates** (`apps/axctl/src/queries/dispatch-analytics.ts:707`) resolves
+   `suggested_model` straight from `routingMatch.suggest` with **no judgment
+   carve-out**. A judgment task that also matches a route-down class (regex drift,
+   e.g. an `^implement ` description that is really a review) is suggested *down*
+   to sonnet and **counted as addressable overspend**.
+3. The two therefore **disagree on the judgment∩match cell**: the hook keeps it
+   strong, candidates wants it cheap.
+
+Plus: the **skill** frames the split as *main-model vs subagent*, not the
+directional rule that actually matters - *implementer subagent → sonnet,
+reviewer/judgment subagent → strong*. This session's dispatch economy inverted
+exactly that (implementers ran expensive, reviewers cheap; ~$130 over; memory
+`feedback-review-gets-strong-model`). The skill never states the direction
+front-and-center, so the orchestrating agent has nothing unambiguous to follow.
+
+## Goal
+
+Make implementer→sonnet / reviewer→strong the **explicit, single-sourced** rule
+across:
+- the **skill** (standing discipline the orchestrating agent follows),
+- a pure **helper** (one classifier all code calls),
+- the **candidates** lens (honest measurement),
+reconciled with the advisory hook.
+
+## Components
+
+### A. `resolveDispatchModel` helper (hooks-sdk, pure)
+
+New file `packages/hooks-sdk/src/resolve-dispatch-model.ts`. Pure, plain TS (no
+Effect, no `@ax/lib`) so it is importable by both the hooks-sdk hot path and
+axctl - matching the `spend-mode.ts` / `matchRoutingTable` precedent.
+
+```ts
+export interface DispatchModelResolution {
+  readonly tier: "judgment" | "route-down" | "inherit";
+  readonly match: RoutingMatch | null;   // raw match, for classId/reason
+  readonly judgmentStrong: boolean;
+  readonly effectiveModel: string | null; // route-down → match.suggest;
+                                           // judgment | inherit → null (keep strong)
+  readonly reason: string;
+}
+
+export const resolveDispatchModel = (
+  table: RoutingTableShape,
+  description: string | null | undefined,
+  agentType: string | null | undefined,
+): DispatchModelResolution
+```
+
+Logic (judgment-first, mirrors `decideVerdict` rule 0):
+1. `judgmentStrong = description != null && JUDGMENT_STRONG_RE.test(description)`
+   - **reuse the existing narrow `JUDGMENT_STRONG_RE`** from `spend-mode.ts` (one
+     regex for hook + helper + candidates; deliberately excludes bare/`spec`
+     review, which is a route-down class). No new regex - that would reintroduce
+     the drift this work removes.
+2. `match = matchRoutingTable(table, description, agentType)`.
+3. If `judgmentStrong` → `{ tier: "judgment", effectiveModel: null, ... }`
+   (keep strong even when `match !== null`).
+4. else if `match` → `{ tier: "route-down", effectiveModel: match.suggest, ... }`.
+5. else → `{ tier: "inherit", effectiveModel: null, ... }`.
+
+`effectiveModel: null` means "do not route down - keep the strong/inherited
+model." Exhaustively unit-tested (judgment-only, match-only, judgment∩match,
+neither, null/empty description, agent-type match).
+
+### B. Wire the consumers (no behavior change except the bugfix)
+
+1. **Hook** (`route-dispatch.ts`): derive `match` / `judgmentStrong` / `suggest`
+   from `resolveDispatchModel` instead of computing them inline. `decideVerdict`
+   is unchanged (still takes booleans). Net hook behavior **identical** - proven
+   by the existing decide-verdict tests + `ax hooks backtest`.
+2. **Candidates** (`dispatch-analytics.ts`): call `resolveDispatchModel`;
+   **skip rows where `tier === "judgment"`** so judgment∩match dispatches are
+   never listed as candidates and never counted in addressable overspend. Use
+   `effectiveModel` for `suggested_model`. This is the measurable bugfix:
+   candidates stop suggesting that review/design/audit be routed down, and the
+   headline `--economy` savings drops to the honest figure (judgment work was
+   never actually addressable).
+3. `decideVerdict` stays as-is.
+
+### C. Skill hardening (`skills/efficient-dispatch/SKILL.md`)
+
+Rewrite "The split" so the **directional, subagent-tier rule** is front-and-center:
+
+> **Implementer subagents** (well-specified plan tasks, mechanical work) →
+> `model: sonnet`.
+> **Reviewer / judgment subagents** (quality / PR / final / adversarial / code
+> review, design, audit, architect, critique, judge) → **keep the strong model**
+> (inherit the main model, or set `model: opus`/`fable` explicitly).
+
+Cite the inversion as the *why* (memory `feedback-review-gets-strong-model`: this
+session ran it backwards - implementers expensive, reviewers cheap - ~$130 over,
+weaker catch rate). Keep the advisory-hook framing (already correct in dispatch
+discipline step 3). Add the **workflow-author note**: sandboxed
+`.claude/workflows/*.js` scripts cannot import ax code - set `model:` per
+`ax routing show`, and **judgment stages keep the strong model** (the existing
+`routing-tune.workflow.js` is the reference: mechanical stages set
+`model: "sonnet"`).
+
+### D. Verify
+
+- Exhaustive unit tests on `resolveDispatchModel`.
+- `bun test` on touched packages (hooks-sdk + axctl), `bun run typecheck`.
+- `ax hooks backtest ~/.ax/hooks/route-dispatch.ts --days=7` - confirm hook
+  verdicts unchanged after the rewire.
+- **Live `ax dispatches --economy` before/after** - capture the candidates-number
+  change (judgment∩match rows leaving the addressable set) as PR evidence.
+
+## What this is NOT
+
+- Not enforcement - hooks can't enforce Agent dispatch (settled). The lever is
+  skill discipline + the shared classifier.
+- Not a controlled dispatch helper for workflow scripts - they run sandboxed
+  (no imports). They get the table via `ax routing show`; the helper serves
+  in-tree Effect/axctl code (and unifies the hook + candidates today).
+- Not a new regex - reuses `JUDGMENT_STRONG_RE`.
+
+## Honest framing of the win
+
+Component B's candidates fix is the only **same-session** measurable change
+(judgment work stops inflating addressable overspend). The skill (Component C)
+moves the real number - the inherit/inversion rate - via **adoption over future
+sessions**, not instantly. The `--economy` lens is the feedback loop to confirm
+it over time.
+
+## Module map
+
+```
+packages/hooks-sdk/src/resolve-dispatch-model.ts        NEW: resolveDispatchModel (pure) + tests
+packages/hooks-sdk/src/hooks/route-dispatch.ts          rewire to use the helper (behavior identical)
+packages/hooks-sdk/src/index.ts                         export resolveDispatchModel + types
+apps/axctl/src/queries/dispatch-analytics.ts            candidates: use helper, exclude tier==="judgment"
+skills/efficient-dispatch/SKILL.md                      "The split" directional rewrite + workflow-author note
+```
+
+## Out of scope (later)
+
+- A real ax dispatch path (none exists today - the helper is forward-compatible
+  for when one does).
+- `ax routing tune` agent_type mining.
+- MCP `dojo_agenda` + other deferred dojo follow-ups (Task 2 in the handoff).

--- a/packages/hooks-sdk/src/hooks/route-dispatch.ts
+++ b/packages/hooks-sdk/src/hooks/route-dispatch.ts
@@ -28,12 +28,12 @@
 import { Effect } from "effect";
 import { defineHook, runMain } from "../define.ts";
 import { decideVerdict } from "../decide-verdict.ts";
-import { loadRoutingTableOrDefault, matchRoutingTable } from "../routing-table.ts";
+import { loadRoutingTableOrDefault } from "../routing-table.ts";
+import { resolveDispatchModel } from "../resolve-dispatch-model.ts";
 import {
   computeSpendMode,
   DEFAULT_SPEND_CONFIG,
   defaultQuotaCachePath,
-  JUDGMENT_STRONG_RE,
   readQuotaCacheSync,
   type SpendConfig,
 } from "../spend-mode.ts";
@@ -82,8 +82,7 @@ const hook = defineHook({
       const description = rawDescription ?? rawPrompt;
 
       const table = loadRoutingTableOrDefault();
-      const match = matchRoutingTable(table, description, subagentType);
-      const judgmentStrong = description !== undefined && JUDGMENT_STRONG_RE.test(description);
+      const resolution = resolveDispatchModel(table, description, subagentType);
 
       // Resolve spend config: table overrides win over DEFAULT_SPEND_CONFIG.
       const spendConfig = resolveSpendConfig(table.spendMode as Partial<SpendConfig> | undefined);
@@ -99,12 +98,12 @@ const hook = defineHook({
         envMode === "conserve" || envMode === "splurge" ? envMode : computed.mode;
 
       return decideVerdict({
-        match: match !== null,
+        match: resolution.match !== null,
         explicit,
         cheap,
-        judgmentStrong,
+        judgmentStrong: resolution.judgmentStrong,
         routeDownEnforced: mode === "conserve",
-        suggest: match?.suggest ?? "sonnet",
+        suggest: resolution.match?.suggest ?? "sonnet",
       });
     }),
 });

--- a/packages/hooks-sdk/src/index.ts
+++ b/packages/hooks-sdk/src/index.ts
@@ -20,3 +20,8 @@ export {
   type RoutingTable,
   type RoutingTableShape,
 } from "./routing-table.ts";
+export {
+  resolveDispatchModel,
+  type DispatchModelResolution,
+  type DispatchTier,
+} from "./resolve-dispatch-model.ts";

--- a/packages/hooks-sdk/src/resolve-dispatch-model.test.ts
+++ b/packages/hooks-sdk/src/resolve-dispatch-model.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { resolveDispatchModel } from "./resolve-dispatch-model.ts";
+import { DEFAULT_ROUTING_TABLE } from "./routing-table.ts";
+
+const T = DEFAULT_ROUTING_TABLE;
+
+describe("resolveDispatchModel", () => {
+  it("route-down: mechanical impl description → sonnet", () => {
+    const r = resolveDispatchModel(T, "implement the parser toolkit", null);
+    expect(r.tier).toBe("route-down");
+    expect(r.judgmentStrong).toBe(false);
+    expect(r.effectiveModel).toBe("sonnet");
+    expect(r.match?.classId).toBe("well-specified-impl");
+  });
+
+  it("judgment: a review description → keep strong (effectiveModel null)", () => {
+    const r = resolveDispatchModel(T, "PR review of the auth module", null);
+    expect(r.tier).toBe("judgment");
+    expect(r.judgmentStrong).toBe(true);
+    expect(r.effectiveModel).toBeNull();
+  });
+
+  it("judgment beats route-down: description matches BOTH a class and judgment", () => {
+    const r = resolveDispatchModel(T, "implement design review feedback", null);
+    expect(r.tier).toBe("judgment");
+    expect(r.judgmentStrong).toBe(true);
+    expect(r.effectiveModel).toBeNull();
+    expect(r.match).not.toBeNull();
+  });
+
+  it("inherit: no class, not judgment → keep inherited (null)", () => {
+    const r = resolveDispatchModel(T, "ponder the meaning of the codebase", null);
+    expect(r.tier).toBe("inherit");
+    expect(r.judgmentStrong).toBe(false);
+    expect(r.effectiveModel).toBeNull();
+    expect(r.match).toBeNull();
+  });
+
+  it("agent-type route-down: Explore → haiku via agentTypes", () => {
+    const r = resolveDispatchModel(T, "anything", "Explore");
+    expect(r.tier).toBe("route-down");
+    expect(r.effectiveModel).toBe("haiku");
+    expect(r.match?.source).toBe("agentType");
+  });
+
+  it("null/empty description → inherit, no throw", () => {
+    expect(resolveDispatchModel(T, null, null).tier).toBe("inherit");
+    expect(resolveDispatchModel(T, "", null).tier).toBe("inherit");
+    expect(resolveDispatchModel(T, undefined, undefined).tier).toBe("inherit");
+  });
+});

--- a/packages/hooks-sdk/src/resolve-dispatch-model.ts
+++ b/packages/hooks-sdk/src/resolve-dispatch-model.ts
@@ -1,0 +1,64 @@
+// packages/hooks-sdk/src/resolve-dispatch-model.ts
+//
+// One classifier for "what model tier does this dispatch want." Shared by the
+// route-dispatch hook (fire path) and `ax dispatches` candidates so the two can
+// never disagree on the judgment∩route-down cell. Pure + Effect-free (importable
+// in the ~70ms hot path), matching the spend-mode.ts / matchRoutingTable
+// precedent. Judgment-first precedence mirrors decideVerdict rule 0: a review/
+// design/audit dispatch is NEVER routed down, even when its description also
+// matches a route-down class (regex drift).
+import {
+  matchRoutingTable,
+  type RoutingMatch,
+  type RoutingTableShape,
+} from "./routing-table.ts";
+import { JUDGMENT_STRONG_RE } from "./spend-mode.ts";
+
+export type DispatchTier = "judgment" | "route-down" | "inherit";
+
+export interface DispatchModelResolution {
+  /** judgment → keep strong; route-down → cheaper tier; inherit → no opinion. */
+  readonly tier: DispatchTier;
+  /** Raw routing match (populated even when judgment wins), for classId/reason. */
+  readonly match: RoutingMatch | null;
+  readonly judgmentStrong: boolean;
+  /** route-down → suggested cheaper model; judgment | inherit → null (keep strong/inherited). */
+  readonly effectiveModel: string | null;
+  readonly reason: string;
+}
+
+export const resolveDispatchModel = (
+  table: RoutingTableShape,
+  description: string | null | undefined,
+  agentType: string | null | undefined,
+): DispatchModelResolution => {
+  const judgmentStrong =
+    description != null && description.length > 0 && JUDGMENT_STRONG_RE.test(description);
+  const match = matchRoutingTable(table, description, agentType);
+
+  if (judgmentStrong) {
+    return {
+      tier: "judgment",
+      match,
+      judgmentStrong: true,
+      effectiveModel: null,
+      reason: "judgment work (review/design/audit) - keep the strong model",
+    };
+  }
+  if (match) {
+    return {
+      tier: "route-down",
+      match,
+      judgmentStrong: false,
+      effectiveModel: match.suggest,
+      reason: match.reason,
+    };
+  }
+  return {
+    tier: "inherit",
+    match: null,
+    judgmentStrong: false,
+    effectiveModel: null,
+    reason: "no route-down class matched - keep the inherited model",
+  };
+};

--- a/skills/efficient-dispatch/SKILL.md
+++ b/skills/efficient-dispatch/SKILL.md
@@ -11,12 +11,27 @@ checkable against your own ax graph.
 
 ## The split
 
-**Main model keeps** (never route down): decomposition, architecture and
-product tradeoffs, plan synthesis, quality review, PR review, judging
-conflicting subagent reports, final integration, taste-heavy design/copy.
+Two axes. First, **main model vs subagent**: the main model orchestrates and
+reviews; mechanical work goes to subagents. Second, and the one that actually
+controls spend - **the tier of each subagent dispatch:**
 
-**Cheaper models take** mechanical work - dispatch with an explicit
-`model:` per the routing table below.
+- **Implementer subagents** (well-specified plan tasks, mechanical edits, search,
+  bulk transforms) → dispatch with **`model: sonnet`** (or haiku for pure
+  search/locate, per the table).
+- **Reviewer / judgment subagents** (quality / PR / final / adversarial / code
+  review, design, audit, architect, critique, judge) → **keep the strong model**:
+  inherit the main model, or set `model: opus`/`fable` explicitly. Review is the
+  catch-rate gate; a cheap reviewer misses real bugs.
+
+Get this backwards and you pay twice: in one ax session implementers ran on the
+expensive inherited model while reviewers were sent to a cheap one - ~$130 over,
+weaker catch rate, three fix rounds (memory `feedback-review-gets-strong-model`).
+The default-inherit trap is implementers, not reviewers: a forgotten `model:` on
+an `implement …` dispatch silently runs expensive. Set it.
+
+**Main model keeps** (never dispatched at all): decomposition, architecture and
+product tradeoffs, plan synthesis, judging conflicting subagent reports, final
+integration, taste-heavy design/copy.
 
 ## Routing table
 
@@ -57,7 +72,13 @@ main-model judgment - otherwise pick sonnet.
    (review/design/audit) is sent on a cheap model. Real enforcement is your
    discipline + setting `model:` explicitly on every dispatch.
    Treat the advisory as a re-dispatch signal, not noise.
-4. Treat subagent reports as leads. Before acting on a high-impact finding or
+4. **Workflow scripts** (`.claude/workflows/*.js`) run sandboxed and cannot
+   import ax code. Set `model:` on every `agent(...)` call by hand, per
+   `ax routing show`: mechanical stages → `model: 'sonnet'`; judgment/review
+   stages → keep the strong model. `routing-tune.workflow.js` is the reference.
+   In-tree Effect/axctl code that dispatches should call `resolveDispatchModel`
+   (from `@ax/hooks-sdk`) instead of hardcoding.
+5. Treat subagent reports as leads. Before acting on a high-impact finding or
    declaring done, reopen the cited files and re-run the key verification
    yourself. Expect to find one real bug per delegated phase.
 


### PR DESCRIPTION
## What

One pure `resolveDispatchModel` classifier shared by the route-dispatch hook and `ax dispatches` (both the `--candidates` and `--economy` loops), applying **judgment-first** precedence so reviewer/design/audit work is never routed down — even when its description also matches a route-down class. Hardens the `efficient-dispatch` skill to state the directional **implementer→sonnet / reviewer→strong** rule front-and-center.

## Why

Claude Code hooks can't enforce the `Agent` dispatch tool (CC #39814/#40580/#24327/#34692) — the route-dispatch hook is advisory-only. The real lever is the cognitive layer: the orchestrating agent's discipline (the skill) + the code that classifies dispatches. Two surfaces independently decided "what tier does this dispatch want" and **disagreed on the judgment∩route-down cell**: the hook kept it strong (`decideVerdict` rule 0), but `ax dispatches` candidates/economy suggested routing it down and counted it as addressable overspend. This unifies them.

## Changes

- **`packages/hooks-sdk/src/resolve-dispatch-model.ts`** (new, pure, Effect-free) — `resolveDispatchModel(table, desc, agentType) → { tier, match, judgmentStrong, effectiveModel, reason }`. Reuses the existing `JUDGMENT_STRONG_RE` (no new regex).
- **route-dispatch hook** rewired to derive its classification from the helper — behavior provably identical (42 hook/verdict tests unchanged).
- **`ax dispatches` candidates + economy loops** both call the helper and exclude `tier === "judgment"` — judgment work leaves the routable base, overspend, and savings. Honest addressable overspend.
- **`efficient-dispatch` skill**: directional implementer→sonnet / reviewer→strong rule front-and-center (cites the ~\$130 inversion + memory `feedback-review-gets-strong-model`) + a workflow-author note (`ax routing show`; sandboxed `.claude/workflows/*.js` can't import ax; in-tree code calls `resolveDispatchModel`).

## Evidence

- `bun run typecheck`: **0 errors**. `bun scripts/check-no-node-fs.ts`: clean. hooks-sdk **164/164**, dispatch-analytics **53/53** pass.
- `ax hooks backtest route-dispatch --days=7`: 756 calls replayed, **0 would-block / 0 would-warn / 204 would-advise** (advisory-only, as designed).
- `ax dispatches --economy --days=7` before (main) → after (same window):

  | metric | before | after |
  |---|---|---|
  | routable | 177 | 166 (−11 judgment∩match excluded) |
  | ran_expensive | 124 | 123 |
  | ran_cheap | 44 | 34 |
  | overspend | \$717.02 | \$715.56 |
  | addressable | \$459.24 | \$458.66 |

  The dollar swing is small in this window (most excluded rows already ran cheap); the win is **correctness + consistency** — the lens no longer claims review/design/audit work is addressable overspend, and now agrees with the hook.

Spec: `docs/superpowers/specs/2026-06-15-dispatch-cognitive-enforcement-design.md`
Plan: `docs/superpowers/plans/2026-06-15-dispatch-cognitive-enforcement.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)