### PR TITLE
community: register Dariia-Smyrnova

### DIFF
--- a/community/users/dariia-smyrnova.json
+++ b/community/users/dariia-smyrnova.json
@@ -1,0 +1,5 @@
+{
+  "github": "Dariia-Smyrnova",
+  "gist_id": "243f14436cbddb624bcd02dd30b16198",
+  "joined": "2026-06-15"
+}


### PR DESCRIPTION
Adds my community profile entry (`community/users/dariia-smyrnova.json`) pointing at my public ax profile gist. Generated as part of `ax profile publish` registration. Touches only my own user file.