### PR TITLE
feat(mcp): dojo_agenda tool + retire deferred cron trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,11 +204,12 @@ task file, then run `axctl improve lint` to reconcile.
 
 ## MCP server
 
-`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 10 tools
+`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 16 tools
 (`recall`, `sessions_around`, `session_show`, `skills_weighted`, `skills_by_role`,
-`skills_roles`, `roles`, `improve_recommend`, `improve_show`, `improve_list`) so an
-agent can query the graph in-context. Run from source (no native deps, so the
-compiled binary should work too - untested in v0). Mutating
+`skills_roles`, `roles`, `improve_recommend`, `improve_show`, `improve_list`,
+`session_metrics`, `signal_show`, `cost_models`, `cost_split`, `dispatches`,
+`dojo_agenda`) so an agent can query the graph in-context. Run from source (no
+native deps, so the compiled binary should work too - untested in v0). Mutating
 ops + `sessions_here`/`near` (need a git-resolved repo key) are intentionally not
 exposed. Server: `apps/axctl/src/mcp/server.ts`; registry: `apps/axctl/src/mcp/tools.ts`.
 

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -28,6 +28,7 @@ const EXPECTED_TOOLS = [
     "cost_models",
     "cost_split",
     "dispatches",
+    "dojo_agenda",
 ] as const;
 
 describe("axMcpTools registry", () => {
@@ -41,7 +42,7 @@ describe("axMcpTools registry", () => {
         expect(recall!.inputSchema).toHaveProperty("q");
     });
 
-    it("registers all 15 read-only tools, each well-formed", () => {
+    it("registers all 16 read-only tools, each well-formed", () => {
         expect(axMcpTools.map((t) => t.name).sort()).toEqual(
             [...EXPECTED_TOOLS].sort(),
         );

--- a/apps/axctl/src/mcp/tools.test.ts
+++ b/apps/axctl/src/mcp/tools.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "bun:test";
+import { axMcpTools } from "./tools.ts";
+
+describe("dojo_agenda MCP tool", () => {
+    it("is registered with the expected name + input fields", () => {
+        const t = axMcpTools.find((x) => x.name === "dojo_agenda");
+        expect(t).toBeDefined();
+        expect(Object.keys(t!.inputSchema).sort()).toEqual(["days", "spar"]);
+    });
+});

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -61,6 +61,11 @@ import { fetchCostModels, fetchCostSplit } from "../queries/cost-analytics.ts";
 import { fetchDispatches, fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
 import { loadEffectiveRoutingTable } from "../queries/routing-table-io.ts";
 import { buildDispatchesNext, buildCandidatesNext } from "../nav/next-links.ts";
+import { assembleAgenda, collectAgendaItems } from "../dojo/agenda.ts";
+import { computeBudgetEnvelope } from "../dojo/budget.ts";
+import { getQuota } from "../quota/quota.ts";
+import { defaultQuotaCachePath } from "../quota/cache.ts";
+import { QuotaEnvLive } from "../quota/quota-env.ts";
 
 /**
  * The long-lived MCP runtime, built from `AppLayer` (SurrealClient + config +
@@ -578,6 +583,46 @@ const dispatchesTool: AxMcpTool = {
     },
 };
 
+const dojoAgendaTool: AxMcpTool = {
+    name: "dojo_agenda",
+    description:
+        "Dojo training agenda for surplus-quota self-improvement: budget envelope (window remaining minus reserve, deadline = window reset) + prioritized work items (pending verdicts, unfilled briefs, routing backtests, proposal minting, churn experiments, optional sparring). Mirrors `ax dojo agenda`. Read-only.",
+    inputSchema: {
+        days: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Window in days (default 30)."),
+        spar: z
+            .boolean()
+            .optional()
+            .describe("Include opt-in sparring items (needs spendable headroom)."),
+    },
+    run: async (args, rt) => {
+        const nowMs = Date.now();
+        const days = typeof args.days === "number" ? args.days : 30;
+        const spar = args.spar === true;
+        return await rt.runPromise(
+            Effect.gen(function* () {
+                const quota = yield* getQuota(
+                    { cachePath: defaultQuotaCachePath(), maxAgeSeconds: 60, nowMs },
+                ).pipe(
+                    Effect.map((r) => r.snapshot),
+                    Effect.catch(() => Effect.succeed(null)),
+                );
+                const envelope = computeBudgetEnvelope(
+                    quota,
+                    { budgetPctOverride: null, untilIso: null, force: false },
+                    nowMs,
+                );
+                const items = yield* collectAgendaItems({ nowMs, days, spar });
+                return assembleAgenda(envelope, items, { nowMs, spar });
+            }).pipe(Effect.provide(QuotaEnvLive)),
+        );
+    },
+};
+
 /**
  * All registered MCP tools. `server.ts` iterates this array to register +
  * wrap each one.
@@ -603,4 +648,5 @@ export const axMcpTools: ReadonlyArray<AxMcpTool> = [
     costModelsTool,
     costSplitTool,
     dispatchesTool,
+    dojoAgendaTool,
 ];

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -70,7 +70,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax doctor` - validate the install (db, watcher, skills)
 
 ### For agents (MCP)
-- `ax mcp` - stdio MCP server exposing read-only graph queries as tools: recall, sessions_around, session_show, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, session_metrics, signal_show, cost_models, cost_split, dispatches
+- `ax mcp` - stdio MCP server exposing read-only graph queries as tools: recall, sessions_around, session_show, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, session_metrics, signal_show, cost_models, cost_split, dispatches, dojo_agenda
 
 ## Q&A - "how do I..." mapped to the ax answer
 
@@ -111,7 +111,7 @@ A: `ax hooks backtest <file> --days=14` - replays your real tool-call history th
 A: `ax hooks init` scaffolds `~/.ax/hooks` (typed Effect TypeScript, `defineHook`); `ax hooks install <file> --providers=claude,codex` fans it out to both configs.
 
 **Q: Can my agent query its own history mid-session, without me prompting it?**
-A: `ax mcp` - a stdio MCP server exposing the read-only graph queries as 15 tools. The agent asks "where is the spend" or "what did we try before" itself.
+A: `ax mcp` - a stdio MCP server exposing the read-only graph queries as 16 tools. The agent asks "where is the spend" or "what did we try before" itself.
 
 **Q: How do I show a session to a teammate?**
 A: `ax share <session-id>` - sanitized share via GitHub Gist, rendered in the hosted studio viewer.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -210,7 +210,7 @@ command = "ax"
 args = ["mcp"]
 ```
 
-The 10 tools, each mirroring the matching CLI command:
+The 16 tools, each mirroring the matching CLI command:
 
 - **recall** - full-text recall across turns / commits / skills (`ax recall`).
 - **sessions_around** - sessions in a date window (`ax sessions around`).
@@ -223,6 +223,12 @@ The 10 tools, each mirroring the matching CLI command:
 - **improve_recommend** - top improvement proposals, ranked (`ax improve recommend`).
 - **improve_show** - one proposal's evidence trail (`ax improve show`).
 - **improve_list** - proposals filtered by status / form (`ax improve list`).
+- **session_metrics** - graph-derived per-session metrics: commits, churn, cost, corrections (`ax sessions metrics`).
+- **signal_show** - signal catalog list or run a named relation signal (`ax signals`).
+- **cost_models** - per-model token and cost rollup (`ax cost models`).
+- **cost_split** - cost matrix split by origin x model (`ax cost split`).
+- **dispatches** - subagent dispatch analytics and routing candidates (`ax dispatches`).
+- **dojo_agenda** - dojo training agenda: budget envelope + prioritized work items (`ax dojo agenda`).
 
 > **Read-only.** Mutating ops (`improve accept/reject/verdict`, `skills
 > tag/lint`, `ingest`) stay on the CLI - they write task files / edges a human

--- a/docs/superpowers/specs/2026-06-13-ax-dojo-design.md
+++ b/docs/superpowers/specs/2026-06-13-ax-dojo-design.md
@@ -205,8 +205,11 @@ later.
 
 ## Out of scope (v1)
 
-- cron/launchd auto-trigger near window end (v2; prior art:
-  `~/.claude/self-improve/` launchd setup)
+- ~~cron/launchd auto-trigger near window end~~ **SUPERSEDED (2026-06-15)** by the
+  splurge → `/dojo` nudge (PR #413): a SessionStart hook detects surplus quota
+  (splurge spend-mode) and prompts the operator to run `/dojo` in-harness. An
+  in-harness prompt beats a headless daemon - a cron can't open an interactive
+  session and `claude -p` burns API, not plan. No daemon trigger will ship.
 - dashboard dojo surface
 - multi-repo experiment selection
 - `dojo_run` history table (reports are files first)


### PR DESCRIPTION
## What

- **MCP `dojo_agenda` tool** — exposes the dojo training agenda (budget envelope + prioritized self-improvement items) to MCP harnesses, mirroring `ax dojo agenda` exactly (`getQuota` cache → `computeBudgetEnvelope` → `collectAgendaItems` → `assembleAgenda`, `Effect.provide(QuotaEnvLive)`). Args: `days` (default 30), `spar`.
- **Docs accuracy** — the MCP tool list in `docs/cli.md` claimed "10 tools" but the registry had drifted to 15 undocumented; now lists all **16** (incl. the 5 that were missing: `session_metrics`, `signal_show`, `cost_models`, `cost_split`, `dispatches`, + `dojo_agenda`). `CLAUDE.md` + `llms.txt` counts updated to match.
- **Retire the cron trigger** — the deferred daemon/launchd window-end auto-trigger is formally **superseded** by the splurge→`/dojo` nudge (PR #413): an in-harness prompt beats a headless daemon (a cron can't open a session; `claude -p` burns API, not plan). Spec updated; no daemon trigger will ship.

## Why

Handoff TASK 2 dojo follow-ups. The agenda existed only on the CLI; MCP harnesses couldn't see it. The cron trigger was the right idea solved a better way by the spend-mode nudge.

## Evidence

- `bun run typecheck`: 0 errors. mcp tests: **20/20 pass**.
- Registry/docs count consistency verified across 4 surfaces (registry array, smoke test, docs/cli.md, CLAUDE.md) — all **16**.

## Note

"Read-only" means no graph/DB mutation. `getQuota` may, when its cache is stale >60s, make a read GET to the Anthropic usage endpoint + refresh the local `~/.ax/quota-cache.json` — identical to existing `ax quota` / `ax dojo agenda` behavior, fully `catch→null` degraded.

Spec: `docs/superpowers/specs/2026-06-13-ax-dojo-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)