### PR TITLE
feat(usage): self-telemetry + personal utilization view (adoption Fix #1a)

### DIFF
--- a/apps/axctl/src/cli/commands/usage.test.ts
+++ b/apps/axctl/src/cli/commands/usage.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { renderUsage } from "./usage.ts";
+import type { UsageRollup } from "../../usage/query.ts";
+
+const roll: UsageRollup = {
+  windowDays: 30, total: 5, activeDays: 3,
+  topCommands: [{ command: "digest", count: 3, last_used: "2026-06-15T11:00:00.000Z" }],
+  unusedSurface: ["quota", "thinking"],
+  originSplit: { agent: 4, tty: 1 },
+  reliability: [],
+};
+
+describe("renderUsage", () => {
+  it("summarizes active days, top command, and unused count", () => {
+    const out = renderUsage(roll);
+    expect(out).toContain("3 active days");
+    expect(out).toContain("digest");
+    expect(out).toContain("2 never used");
+  });
+  it("empty-state line when nothing recorded", () => {
+    const empty: UsageRollup = { ...roll, total: 0, activeDays: 0, topCommands: [], originSplit: { agent: 0, tty: 0 } };
+    expect(renderUsage(empty)).toContain("no usage recorded yet");
+  });
+});

--- a/apps/axctl/src/cli/commands/usage.ts
+++ b/apps/axctl/src/cli/commands/usage.ts
@@ -1,0 +1,54 @@
+/**
+ * `ax usage` - your ax utilization: commands/day, active days, top commands,
+ *   agent-vs-tty split, and the never-used surface.
+ *
+ *   ax usage [--days=N] [--json]
+ */
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { prettyPrint } from "@ax/lib/json";
+import { fetchInvocations, rollup, type UsageRollup } from "../../usage/query.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { jsonFlag } from "./shared.ts";
+import { VISIBLE_COMMANDS } from "./visible-commands.ts";
+
+/** Render a UsageRollup as a human-readable board. Pure (tested). */
+export const renderUsage = (r: UsageRollup): string => {
+    if (r.total === 0) return "[ax] no usage recorded yet - run some ax commands, then ingest.";
+    const top = r.topCommands
+        .slice(0, 8)
+        .map((c) => `  ${c.command.padEnd(22)} ${String(c.count).padStart(5)}`)
+        .join("\n");
+    const unusedCount = r.unusedSurface.length;
+    const unusedList = r.unusedSurface.slice(0, 12).join(", ");
+    return [
+        `[ax] usage (${r.windowDays}d): ${r.total} runs across ${r.activeDays} active days  (agent ${r.originSplit.agent} / tty ${r.originSplit.tty})`,
+        "top commands:",
+        top,
+        `${unusedCount} never used: ${unusedList}`,
+    ].join("\n");
+};
+
+const cmdUsage = (input: { readonly json: boolean; readonly days: number }) =>
+    Effect.gen(function* () {
+        const rows = yield* fetchInvocations(input.days);
+        const r = rollup(rows, VISIBLE_COMMANDS, input.days);
+        console.log(input.json ? prettyPrint(r) : renderUsage(r));
+    });
+
+export const usageCommand = Command.make(
+    "usage",
+    {
+        json: jsonFlag,
+        days: Flag.integer("days").pipe(Flag.withDefault(30)),
+    },
+    ({ json, days }) => cmdUsage({ json, days }),
+).pipe(
+    Command.withDescription(
+        "Your ax utilization: commands/day, active days, top commands, agent-vs-tty split, and the never-used surface. --json  --days=N (default 30)",
+    ),
+);
+
+export const usageRuntime: RuntimeManifest = {
+    usage: { runtime: "db", hidden: false },
+};

--- a/apps/axctl/src/cli/commands/visible-commands.test.ts
+++ b/apps/axctl/src/cli/commands/visible-commands.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { VISIBLE_COMMANDS } from "./visible-commands.ts";
+
+/**
+ * Visible top-level subcommands parsed from `ax help` SUBCOMMANDS block - the
+ * same source `scripts/check-site-cli-reference.ts#visibleSubcommands` uses.
+ * Replicated inline rather than imported across the scripts boundary (the
+ * relative path would be ../../../../../scripts/... and would drag the site
+ * data module in via its COMMAND_NAMES import).
+ */
+function visibleSubcommands(): string[] {
+    const help = Bun.spawnSync(["bun", "apps/axctl/src/cli/index.ts", "help"], {
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    if (help.exitCode !== 0) {
+        throw new Error(
+            `\`ax help\` exited ${help.exitCode}: ${help.stderr.toString()}`,
+        );
+    }
+    const lines = help.stdout.toString().split("\n");
+    const start = lines.findIndex((line) => line.trim() === "SUBCOMMANDS");
+    if (start === -1) throw new Error("could not find SUBCOMMANDS block in `ax help`");
+    return lines
+        .slice(start + 1)
+        // SUBCOMMANDS entries are indented "  name  description"; an
+        // unindented line ends the block.
+        .filter((line) => /^\s{2,}[a-z]/.test(line))
+        .map((line) => line.trim().split(/\s+/)[0]!)
+        .filter((name) => name.length > 0);
+}
+
+describe("VISIBLE_COMMANDS stays in sync with the real CLI", () => {
+    it("matches the visible `ax help` subcommands (no drift, no stale entries)", () => {
+        const real = new Set(visibleSubcommands());
+        const declared = new Set(VISIBLE_COMMANDS);
+        const missing = [...real].filter((c) => !declared.has(c)); // real but not declared
+        const stale = [...declared].filter((c) => !real.has(c)); // declared but not real
+        expect({ missing, stale }).toEqual({ missing: [], stale: [] });
+    });
+});

--- a/apps/axctl/src/cli/commands/visible-commands.ts
+++ b/apps/axctl/src/cli/commands/visible-commands.ts
@@ -1,0 +1,34 @@
+/**
+ * Canonical list of visible top-level ax subcommands - used by `ax usage` to
+ * compute the "never used" surface.  Keep in sync with the non-hidden entries
+ * in `registeredCommands` in cli/index.ts.  Commands hidden via their family
+ * RuntimeManifest (hidden: true) are intentionally excluded here; dev-only
+ * commands (dogfood, AX_DEV=1) are also excluded.
+ */
+export const VISIBLE_COMMANDS: readonly string[] = [
+    "ingest",
+    "sessions",
+    "improve",
+    "wrapped",
+    "retro",
+    "recall",
+    "skills",
+    "signals",
+    "roles",
+    "hooks",
+    "serve",
+    "mcp",
+    "tui",
+    "share",
+    "install",
+    "setup",
+    "cost",
+    "quota",
+    "dojo",
+    "profile",
+    "dispatches",
+    "routing",
+    "thinking",
+    "digest",
+    "usage",
+];

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -198,11 +198,12 @@ describe("effect cli", () => {
     });
 
     test("resolveIngestStages: default runs every stage", () => {
-        // 28 = 24 original + agentDefStage (config-front-door agents domain)
+        // 29 = 24 original + agentDefStage (config-front-door agents domain)
         //    + deriveMetricsStage (graph-derived session metrics rollup)
         //    + githubPrStage (restored GitHub PR ingest - issue #172)
-        //    + digestStage (push-value digest snapshot writer).
-        expect(resolveIngestStages(testRegistry, [])).toHaveLength(28);
+        //    + digestStage (push-value digest snapshot writer)
+        //    + usageStage (usage-log ingest into ax_invocation).
+        expect(resolveIngestStages(testRegistry, [])).toHaveLength(29);
     });
 
     test("resolveIngestStages: local agent provider stages can be selected", () => {
@@ -239,6 +240,7 @@ describe("effect cli", () => {
             "subagents",
             "turn-analysis",
             "turn-content-blocks",
+            "usage",
         ]);
     });
 

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -23,6 +23,7 @@ import { dispatchesRootCommand, axDispatchesRuntime } from "./commands/ax-dispat
 import { routingRootCommand, axRoutingRuntime } from "./commands/ax-routing.ts";
 import { thinkingCommand, axThinkingRuntime } from "./commands/ax-thinking.ts";
 import { digestCommand, digestRuntime } from "./commands/digest.ts";
+import { usageCommand, usageRuntime } from "./commands/usage.ts";
 import { recallCommand, recallRuntime } from "./commands/recall.ts";
 import { hookCommand, hooksCommand, hooksRuntime } from "./commands/hooks.ts";
 import { retroCommand, retroRuntime } from "./commands/retro.ts";
@@ -89,6 +90,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...axRoutingRuntime,
     ...axThinkingRuntime,
     ...digestRuntime,
+    ...usageRuntime,
     ...recallRuntime,
     ...hooksRuntime,
     ...retroRuntime,
@@ -133,6 +135,7 @@ const registeredCommands: ReadonlyArray<Command.Command.Any> = [
     routingRootCommand,
     thinkingCommand,
     digestCommand,
+    usageCommand,
     // Maintenance / plumbing verbs - hidden via their family manifests.
     deriveCommand,
     deriveSignalsCommand,

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { Cause, Effect, Layer } from "effect";
+import { Cause, Effect, Exit, Layer } from "effect";
 import { BunFileSystem, BunPath, BunRuntime } from "@effect/platform-bun";
 import { Command } from "effect/unstable/cli";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
@@ -52,6 +52,7 @@ import {
     lifecycleRuntime,
 } from "./commands/lifecycle.ts";
 import { AX_VERSION, liveVersionDeps, printVersion } from "./version.ts";
+import { appendUsageRecord, defaultUsageLogPath, redactInvocation } from "../usage/record.ts";
 import { stderrExit } from "./output.ts";
 import { agentsCommand, agentsRuntime } from "../agents/cli.ts";
 import { ALL_STAGES } from "../ingest/stage/registry.ts";
@@ -384,8 +385,26 @@ const reportCliFailure = (cause: Cause.Cause<unknown>): Effect.Effect<void> =>
         console.error("axctl error:", err);
     });
 
+const recordInvocation = (args: ReadonlyArray<string>, t0: number, exitCode: number): Promise<void> => {
+    let repoTopdir: string | null = null;
+    try {
+        const r = Bun.spawnSync(["git", "rev-parse", "--show-toplevel"], { stdout: "pipe", stderr: "ignore" });
+        if (r.exitCode === 0) repoTopdir = r.stdout.toString().trim() || null;
+    } catch { /* no git / not a repo */ }
+    const rec = redactInvocation(args, {
+        now: new Date(),
+        exitCode,
+        durationMs: Math.max(0, Math.round(performance.now() - t0)),
+        isTty: process.stderr.isTTY === true,
+        repoTopdir,
+        version: AX_VERSION,
+    });
+    return appendUsageRecord(defaultUsageLogPath(), rec);
+};
+
 if (import.meta.main) {
     const args = process.argv.slice(2);
+    const t0 = performance.now();
     // BunRuntime.runMain makes the CLI the process main fiber: SIGINT/SIGTERM
     // interrupt it (finalizers run), then Runtime.defaultTeardown picks the
     // exit code - 0 success, 1 failure (incl. ShowHelp usage errors), 130 for
@@ -400,6 +419,9 @@ if (import.meta.main) {
         dispatch(args).pipe(
             Effect.tap(() => Effect.promise(() => maybePrintStarNudge(args))),
             Effect.tapCause(reportCliFailure),
+            Effect.onExit((exit) =>
+                Effect.promise(() => recordInvocation(args, t0, Exit.isSuccess(exit) ? 0 : 1)),
+            ),
         ),
         { disableErrorReporting: true },
     );

--- a/apps/axctl/src/dashboard/contract/usage.test.ts
+++ b/apps/axctl/src/dashboard/contract/usage.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { DbError } from "@ax/lib/errors";
+import { isContractRequest, makeContractWebHandler, type ContractWebHandler } from "./web-handler.ts";
+
+/** Stub DB returning empty ax_invocation results. */
+const emptyDb = Layer.mock(SurrealClient, {
+    query: <T extends unknown[] = unknown[]>(_sql: string, _bindings?: Record<string, unknown> | undefined) =>
+        Effect.succeed([[]] as unknown as T),
+    raw: null as never,
+});
+
+const seededDb = Layer.mock(SurrealClient, {
+    query: <T extends unknown[] = unknown[]>(sql: string, _bindings?: Record<string, unknown> | undefined) => {
+        if (sql.includes("ax_invocation")) {
+            const rows = [
+                { ts: "2026-06-01T10:00:00Z", command: "sessions", origin: "tty" as const, exit_code: 0 },
+                { ts: "2026-06-02T11:00:00Z", command: "sessions", origin: "tty" as const, exit_code: 0 },
+                { ts: "2026-06-03T12:00:00Z", command: "ingest", origin: "agent" as const, exit_code: 1 },
+            ];
+            return Effect.succeed([rows] as unknown as T);
+        }
+        return Effect.succeed([[]] as unknown as T);
+    },
+    raw: null as never,
+});
+
+const handlers: ContractWebHandler[] = [];
+function make(services: Parameters<typeof makeContractWebHandler>[0]["services"] = emptyDb): ContractWebHandler {
+    const h = makeContractWebHandler({ ingestStream: null, services });
+    handlers.push(h);
+    return h;
+}
+afterAll(async () => {
+    for (const h of handlers) await h.dispose();
+});
+
+const get = (path: string): Request => new Request(`http://127.0.0.1:1738${path}`);
+
+describe("isContractRequest - usage", () => {
+    test("GET /api/usage routes to the contract", () => {
+        expect(isContractRequest("GET", "/api/usage")).toBe(true);
+    });
+});
+
+describe("usageRollup handler", () => {
+    test("GET /api/usage returns 200 + UsageRollup shape with empty DB", async () => {
+        const { handler } = make(emptyDb);
+        const res = await handler(get("/api/usage"));
+        expect(res.status).toBe(200);
+        const body = await res.json() as {
+            windowDays: number;
+            total: number;
+            activeDays: number;
+            topCommands: unknown[];
+            unusedSurface: string[];
+            originSplit: { agent: number; tty: number };
+            reliability: unknown[];
+        };
+        expect(body).toHaveProperty("windowDays", 30);
+        expect(body).toHaveProperty("total", 0);
+        expect(body).toHaveProperty("activeDays", 0);
+        expect(Array.isArray(body.topCommands)).toBe(true);
+        expect(Array.isArray(body.unusedSurface)).toBe(true);
+        expect(typeof body.originSplit).toBe("object");
+        expect(body.originSplit).toHaveProperty("agent");
+        expect(body.originSplit).toHaveProperty("tty");
+        expect(Array.isArray(body.reliability)).toBe(true);
+    });
+
+    test("GET /api/usage?days=7 uses the supplied window", async () => {
+        const { handler } = make(emptyDb);
+        const res = await handler(get("/api/usage?days=7"));
+        expect(res.status).toBe(200);
+        const body = await res.json() as { windowDays: number };
+        expect(body.windowDays).toBe(7);
+    });
+
+    test("GET /api/usage returns correct rollup for seeded rows", async () => {
+        const { handler } = make(seededDb);
+        const res = await handler(get("/api/usage"));
+        expect(res.status).toBe(200);
+        const body = await res.json() as {
+            total: number;
+            activeDays: number;
+            topCommands: Array<{ command: string; count: number }>;
+            originSplit: { agent: number; tty: number };
+            reliability: Array<{ command: string; failureRate: number }>;
+            unusedSurface: string[];
+        };
+        expect(body.total).toBe(3);
+        // 3 distinct days
+        expect(body.activeDays).toBe(3);
+        // sessions is top command with 2 uses
+        expect(body.topCommands[0]).toMatchObject({ command: "sessions", count: 2 });
+        // origin split: 2 tty, 1 agent
+        expect(body.originSplit).toEqual({ tty: 2, agent: 1 });
+        // ingest had 1 failure out of 1 run
+        expect(body.reliability.some((r) => r.command === "ingest" && r.failureRate === 1)).toBe(true);
+        // sessions and ingest used, so both should NOT be in unusedSurface
+        expect(body.unusedSurface).not.toContain("sessions");
+        expect(body.unusedSurface).not.toContain("ingest");
+        // unused commands should be in unusedSurface
+        expect(body.unusedSurface).toContain("recall");
+    });
+
+    test("DB error returns 500", async () => {
+        const failDb = Layer.mock(SurrealClient, {
+            query: () => Effect.fail(new DbError({ operation: "query", message: "db exploded" })),
+            raw: null as never,
+        });
+        const { handler } = make(failDb);
+        const res = await handler(get("/api/usage"));
+        expect(res.status).toBe(500);
+        const body = await res.json() as { error: string };
+        expect(body).toHaveProperty("error");
+        expect(typeof body.error).toBe("string");
+    });
+});

--- a/apps/axctl/src/dashboard/contract/usage.ts
+++ b/apps/axctl/src/dashboard/contract/usage.ts
@@ -1,0 +1,22 @@
+/**
+ * Handler for the usage group of the Insights Surface Contract.
+ * GET /api/usage → fetchInvocations + rollup → UsageRollupSchema.
+ */
+import { Effect } from "effect";
+import { HttpApiBuilder } from "effect/unstable/httpapi";
+import { AxApi } from "@ax/lib/shared/api-contract";
+import { VISIBLE_COMMANDS } from "../../cli/commands/visible-commands.ts";
+import { fetchInvocations, rollup } from "../../usage/query.ts";
+import { orInternal } from "./common.ts";
+
+export const UsageGroupLive = HttpApiBuilder.group(AxApi, "usage", (handlers) =>
+    handlers
+        .handle("usageRollup", ({ query }) => {
+            const windowDays = query.days ?? 30;
+            return orInternal(
+                fetchInvocations(windowDays).pipe(
+                    Effect.map((rows) => rollup(rows, VISIBLE_COMMANDS, windowDays)),
+                ),
+            );
+        }),
+);

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -37,6 +37,7 @@ import { LiveGroupLive } from "./live.ts";
 import { SessionsGroupLive } from "./sessions.ts";
 import { SkillsGroupLive } from "./skills.ts";
 import { ContractServeInfo, SystemGroupLive } from "./system.ts";
+import { UsageGroupLive } from "./usage.ts";
 
 /** Everything the contract handlers reach for; widens as families join. */
 export type ContractServices = SurrealClient;
@@ -71,6 +72,8 @@ const CONTRACT_ROUTES: ReadonlySet<string> = new Set([
     "GET /api/improve",
     "GET /api/next-actions",
     "GET /api/improve/analyze-brief",
+    // usage
+    "GET /api/usage",
     // live (SSE /api/events + binary /api/image stay raw legacy routes)
     "POST /api/ingest",
     // docs
@@ -137,6 +140,7 @@ export function makeContractWebHandler(opts: MakeContractWebHandlerOptions): Con
             SessionsGroupLive,
             SkillsGroupLive,
             ImproveGroupLive,
+            UsageGroupLive,
             LiveGroupLive,
         ]),
         // FileSystem/Path appear twice deliberately: in the mergeAll OUTPUT

--- a/apps/axctl/src/ingest/stage/registry.ts
+++ b/apps/axctl/src/ingest/stage/registry.ts
@@ -29,13 +29,14 @@ import { OpportunitiesKey, opportunitiesStage } from "../derive-opportunities.ts
 import { RetroProposalsKey, retroProposalsStage } from "../derive-retro-proposals.ts";
 import { HarnessKey, harnessStage } from "../harness.ts";
 import { DigestKey, digestStage } from "../../digest/digest-stage.ts";
+import { UsageKey, usageStage } from "../../usage/usage-stage.ts";
 
 export type { StageDef } from "./types.ts";
 
 /** Composed union of every known Ingest Stage key. Each stage file exports its
  *  own `Schema.Literal("<key>")`; this union is reassembled by re-exporting
  *  them here. Adding a stage = one import + one entry in the union below. */
-export const IngestStageKey = Schema.Union([SkillsKey, CommandsKey, AgentDefKey, PricingKey, ClaudeKey, CodexKey, PiKey, OpenCodeKey, CursorKey, SubagentsKey, InvokedPositionsKey, SpawnedKey, GitKey, GithubPrKey, SignalsKey, OutcomesKey, TurnContentBlocksKey, TurnAnalysisKey, ReactionEventsKey, ClassifierResultsKey, SessionHealthKey, ClosureKey, DeriveMetricsKey, ProposalsKey, OpportunitiesKey, RetroProposalsKey, HarnessKey, DigestKey]);
+export const IngestStageKey = Schema.Union([SkillsKey, CommandsKey, AgentDefKey, PricingKey, ClaudeKey, CodexKey, PiKey, OpenCodeKey, CursorKey, SubagentsKey, InvokedPositionsKey, SpawnedKey, GitKey, GithubPrKey, SignalsKey, OutcomesKey, TurnContentBlocksKey, TurnAnalysisKey, ReactionEventsKey, ClassifierResultsKey, SessionHealthKey, ClosureKey, DeriveMetricsKey, ProposalsKey, OpportunitiesKey, RetroProposalsKey, HarnessKey, DigestKey, UsageKey]);
 export type IngestStageKey = typeof IngestStageKey.Type;
 
 export interface StageRegistryShape {
@@ -59,7 +60,7 @@ export const StageRegistryLive = (
     });
 
 /** The canonical list of stages provided by `StageRegistryDefault`. */
-export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, pricingStage, claudeStage, codexStage, piStage, opencodeStage, cursorStage, subagentsStage, invokedPositionsStage, spawnedStage, gitStage, githubPrStage, signalsStage, outcomesStage, turnContentBlocksStage, turnAnalysisStage, reactionEventsStage, classifierResultsStage, sessionHealthStage, closureStage, deriveMetricsStage, proposalsStage, opportunitiesStage, retroProposalsStage, harnessStage, digestStage] as const;
+export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, pricingStage, claudeStage, codexStage, piStage, opencodeStage, cursorStage, subagentsStage, invokedPositionsStage, spawnedStage, gitStage, githubPrStage, signalsStage, outcomesStage, turnContentBlocksStage, turnAnalysisStage, reactionEventsStage, classifierResultsStage, sessionHealthStage, closureStage, deriveMetricsStage, proposalsStage, opportunitiesStage, retroProposalsStage, harnessStage, digestStage, usageStage] as const;
 
 /** Production registry: the canonical list of stages provided by ax. Test code
  *  should prefer `StageRegistryLive([...])` with explicit fixtures. */

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -63,6 +63,7 @@ export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "file_memory", stage: "staged", note: "Reserved for per-file tribal knowledge and BM25 search." },
     { table: "tool", stage: "active", note: "Normalized CLI, MCP, and agent tool identities." },
     { table: "tool_call", stage: "active", note: "Claude and Codex tool calls with errors and command fields." },
+    { table: "ax_invocation", stage: "active", note: "ax's own CLI invocations (redacted) for self-telemetry / utilization." },
     { table: "plan", stage: "active", note: "Current plan state per session/source." },
     { table: "plan_item", stage: "active", note: "Latest stable plan items for each plan." },
     { table: "artifact", stage: "active", note: "Generated reports, dogfood artifacts, and guidance evidence." },

--- a/apps/axctl/src/usage/model.test.ts
+++ b/apps/axctl/src/usage/model.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { UsageRecord, parseUsageLine, encodeUsageLine } from "./model.ts";
+
+const rec = () => UsageRecord.make({
+  ts: new Date("2026-06-15T12:00:00Z"),
+  command: "sessions churn",
+  flags: ["--here", "--json"],
+  exit_code: 0,
+  duration_ms: 1200,
+  origin: "agent",
+  repo_key: "ax",
+  ax_version: "0.29.0",
+});
+
+describe("usage model", () => {
+  it("encodeUsageLine -> parseUsageLine round-trips", () => {
+    const line = encodeUsageLine(rec());
+    expect(line.endsWith("\n")).toBe(false);
+    const back = parseUsageLine(line);
+    expect(back?.command).toBe("sessions churn");
+    expect(back?.flags).toEqual(["--here", "--json"]);
+    expect(back?.origin).toBe("agent");
+  });
+  it("parseUsageLine returns null on malformed / non-JSON / bad-shape lines", () => {
+    expect(parseUsageLine("not json")).toBeNull();
+    expect(parseUsageLine(JSON.stringify({ nope: 1 }))).toBeNull();
+    expect(parseUsageLine("")).toBeNull();
+  });
+  it("repo_key is optional (null outside a repo)", () => {
+    const r = UsageRecord.make({ ...rec(), repo_key: null });
+    const back = parseUsageLine(encodeUsageLine(r));
+    expect(back?.repo_key).toBeNull();
+  });
+});

--- a/apps/axctl/src/usage/model.ts
+++ b/apps/axctl/src/usage/model.ts
@@ -1,0 +1,30 @@
+import { Schema } from "effect";
+
+const IsoDate = Schema.DateFromString.check(Schema.isDateValid());
+
+export const UsageOrigin = Schema.Literals(["tty", "agent"]);
+export type UsageOrigin = typeof UsageOrigin.Type;
+
+export class UsageRecord extends Schema.Class<UsageRecord>("UsageRecord")({
+  ts: IsoDate,
+  command: Schema.String,
+  flags: Schema.Array(Schema.String),
+  exit_code: Schema.Number,
+  duration_ms: Schema.Number,
+  origin: UsageOrigin,
+  repo_key: Schema.NullOr(Schema.String),
+  ax_version: Schema.String,
+}) {}
+
+export const encodeUsageLine = (rec: UsageRecord): string =>
+  JSON.stringify(Schema.encodeSync(UsageRecord)(rec));
+
+export const parseUsageLine = (line: string): UsageRecord | null => {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    return Schema.decodeUnknownSync(UsageRecord)(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+};

--- a/apps/axctl/src/usage/query.test.ts
+++ b/apps/axctl/src/usage/query.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { rollup, type InvocationRow } from "./query.ts";
+
+const row = (over: Partial<InvocationRow>): InvocationRow => ({
+  ts: "2026-06-15T12:00:00.000Z", command: "digest", origin: "agent", exit_code: 0, ...over,
+});
+
+describe("rollup", () => {
+  const visible = ["digest", "sessions", "recall", "quota", "thinking"];
+  const rows: InvocationRow[] = [
+    row({ command: "digest", ts: "2026-06-15T10:00:00.000Z" }),
+    row({ command: "digest", ts: "2026-06-15T11:00:00.000Z", origin: "tty" }),
+    row({ command: "sessions", ts: "2026-06-14T10:00:00.000Z" }),
+    row({ command: "recall", ts: "2026-06-13T10:00:00.000Z", exit_code: 1 }),
+  ];
+
+  it("topCommands ranks by count desc with last_used", () => {
+    const r = rollup(rows, visible);
+    expect(r.topCommands[0]).toMatchObject({ command: "digest", count: 2 });
+    expect(r.topCommands[0].last_used).toBe("2026-06-15T11:00:00.000Z");
+  });
+  it("activeDays counts distinct UTC days with >=1 run", () => {
+    expect(rollup(rows, visible).activeDays).toBe(3);
+  });
+  it("unusedSurface = visible commands never invoked", () => {
+    expect(rollup(rows, visible).unusedSurface.sort()).toEqual(["quota", "thinking"]);
+  });
+  it("originSplit counts agent vs tty", () => {
+    expect(rollup(rows, visible).originSplit).toEqual({ agent: 3, tty: 1 });
+  });
+  it("reliability flags commands with a nonzero exit-rate", () => {
+    const recall = rollup(rows, visible).reliability.find((x) => x.command === "recall");
+    expect(recall?.failureRate).toBeCloseTo(1, 5);
+  });
+  it("empty rows -> empty rollup, all visible commands unused", () => {
+    const r = rollup([], visible);
+    expect(r.topCommands).toEqual([]);
+    expect(r.activeDays).toBe(0);
+    expect(r.unusedSurface.sort()).toEqual([...visible].sort());
+  });
+});

--- a/apps/axctl/src/usage/query.test.ts
+++ b/apps/axctl/src/usage/query.test.ts
@@ -38,4 +38,8 @@ describe("rollup", () => {
     expect(r.activeDays).toBe(0);
     expect(r.unusedSurface.sort()).toEqual([...visible].sort());
   });
+  it("unusedSurface treats a used group command as used (top-level normalization)", () => {
+    const r = rollup([row({ command: "sessions show" }), row({ command: "sessions churn" })], ["sessions", "digest"]);
+    expect(r.unusedSurface).toEqual(["digest"]); // "sessions" is used, not unused
+  });
 });

--- a/apps/axctl/src/usage/query.ts
+++ b/apps/axctl/src/usage/query.ts
@@ -37,8 +37,10 @@ export const rollup = (rows: ReadonlyArray<InvocationRow>, visibleCommands: Read
   const topCommands = [...byCommand.entries()]
     .map(([command, e]) => ({ command, count: e.count, last_used: e.last }))
     .sort((a, b) => b.count - a.count || (a.command < b.command ? -1 : 1));
-  const invoked = new Set(byCommand.keys());
-  const unusedSurface = visibleCommands.filter((c) => !invoked.has(c));
+  // unusedSurface compares against top-level command tokens (VISIBLE_COMMANDS is
+  // top-level), so normalize invoked commands to their first token.
+  const invokedTop = new Set([...byCommand.keys()].map((c) => c.split(" ")[0]));
+  const unusedSurface = visibleCommands.filter((c) => !invokedTop.has(c));
   const reliability = [...byCommand.entries()]
     .map(([command, e]) => ({ command, runs: e.count, failures: e.failures, failureRate: e.failures / e.count }))
     .filter((x) => x.failures > 0)

--- a/apps/axctl/src/usage/query.ts
+++ b/apps/axctl/src/usage/query.ts
@@ -1,0 +1,56 @@
+import { Effect } from "effect";
+import type { DbError } from "@ax/lib/errors";
+import { SurrealClient } from "@ax/lib/db";
+
+export interface InvocationRow {
+  readonly ts: string;
+  readonly command: string;
+  readonly origin: "tty" | "agent";
+  readonly exit_code: number;
+}
+
+export interface UsageRollup {
+  readonly windowDays: number;
+  readonly total: number;
+  readonly activeDays: number;
+  readonly topCommands: ReadonlyArray<{ command: string; count: number; last_used: string }>;
+  readonly unusedSurface: string[];
+  readonly originSplit: { agent: number; tty: number };
+  readonly reliability: ReadonlyArray<{ command: string; runs: number; failures: number; failureRate: number }>;
+}
+
+const utcDay = (iso: string): string => iso.slice(0, 10);
+
+export const rollup = (rows: ReadonlyArray<InvocationRow>, visibleCommands: ReadonlyArray<string>, windowDays = 30): UsageRollup => {
+  const byCommand = new Map<string, { count: number; last: string; failures: number }>();
+  const days = new Set<string>();
+  let agent = 0, tty = 0;
+  for (const r of rows) {
+    days.add(utcDay(r.ts));
+    if (r.origin === "tty") tty++; else agent++;
+    const e = byCommand.get(r.command) ?? { count: 0, last: r.ts, failures: 0 };
+    e.count++;
+    if (r.ts > e.last) e.last = r.ts;
+    if (r.exit_code !== 0) e.failures++;
+    byCommand.set(r.command, e);
+  }
+  const topCommands = [...byCommand.entries()]
+    .map(([command, e]) => ({ command, count: e.count, last_used: e.last }))
+    .sort((a, b) => b.count - a.count || (a.command < b.command ? -1 : 1));
+  const invoked = new Set(byCommand.keys());
+  const unusedSurface = visibleCommands.filter((c) => !invoked.has(c));
+  const reliability = [...byCommand.entries()]
+    .map(([command, e]) => ({ command, runs: e.count, failures: e.failures, failureRate: e.failures / e.count }))
+    .filter((x) => x.failures > 0)
+    .sort((a, b) => b.failureRate - a.failureRate);
+  return { windowDays, total: rows.length, activeDays: days.size, topCommands, unusedSurface, originSplit: { agent, tty }, reliability };
+};
+
+export const fetchInvocations = (windowDays: number): Effect.Effect<InvocationRow[], DbError, SurrealClient> =>
+  Effect.gen(function* () {
+    const db = yield* SurrealClient;
+    const result = yield* db.query<[InvocationRow[]]>(
+      `SELECT type::string(ts) AS ts, command, origin, exit_code FROM ax_invocation WHERE ts > time::now() - ${Math.max(1, Math.trunc(windowDays))}d;`,
+    );
+    return result?.[0] ?? [];
+  });

--- a/apps/axctl/src/usage/record.test.ts
+++ b/apps/axctl/src/usage/record.test.ts
@@ -4,10 +4,15 @@ import { redactInvocation } from "./record.ts";
 describe("redactInvocation", () => {
   const base = { now: new Date("2026-06-15T12:00:00Z"), exitCode: 0, durationMs: 5, isTty: false, repoTopdir: "/Users/me/Projects/ax", version: "0.29.0" };
 
-  it("keeps the subcommand path, drops positional args", () => {
+  it("records the top-level subcommand, drops all positionals", () => {
     const r = redactInvocation(["sessions", "show", "abc-123-uuid"], base);
-    expect(r.command).toBe("sessions show");
+    expect(r.command).toBe("sessions");
     expect(r.flags).toEqual([]);
+  });
+  it("a user value after a known group is NOT captured (top-level only)", () => {
+    const r = redactInvocation(["sessions", "my-secret-branch"], base);
+    expect(r.command).toBe("sessions");
+    expect(JSON.stringify(r)).not.toContain("my-secret-branch");
   });
   it("keeps flag NAMES, strips flag values", () => {
     const r = redactInvocation(["recall", "secret query text", "--days=30", "--project=/Users/me/x", "--json"], base);

--- a/apps/axctl/src/usage/record.test.ts
+++ b/apps/axctl/src/usage/record.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { redactInvocation } from "./record.ts";
+
+describe("redactInvocation", () => {
+  const base = { now: new Date("2026-06-15T12:00:00Z"), exitCode: 0, durationMs: 5, isTty: false, repoTopdir: "/Users/me/Projects/ax", version: "0.29.0" };
+
+  it("keeps the subcommand path, drops positional args", () => {
+    const r = redactInvocation(["sessions", "show", "abc-123-uuid"], base);
+    expect(r.command).toBe("sessions show");
+    expect(r.flags).toEqual([]);
+  });
+  it("keeps flag NAMES, strips flag values", () => {
+    const r = redactInvocation(["recall", "secret query text", "--days=30", "--project=/Users/me/x", "--json"], base);
+    expect(r.command).toBe("recall");
+    expect(r.flags).toEqual(["--days", "--json", "--project"]);
+  });
+  it("repo_key is the lowercased basename, never the full path", () => {
+    expect(redactInvocation(["digest"], base).repo_key).toBe("ax");
+    expect(redactInvocation(["digest"], { ...base, repoTopdir: null }).repo_key).toBeNull();
+  });
+  it("origin from isTty", () => {
+    expect(redactInvocation(["digest"], { ...base, isTty: true }).origin).toBe("tty");
+    expect(redactInvocation(["digest"], { ...base, isTty: false }).origin).toBe("agent");
+  });
+  it("no positional value ever survives in command or flags", () => {
+    const r = redactInvocation(["sessions", "show", "/Users/me/secret", "--here"], base);
+    const blob = JSON.stringify(r);
+    expect(blob).not.toContain("secret");
+    expect(blob).not.toContain("/Users/me");
+  });
+});

--- a/apps/axctl/src/usage/record.test.ts
+++ b/apps/axctl/src/usage/record.test.ts
@@ -28,4 +28,21 @@ describe("redactInvocation", () => {
     expect(blob).not.toContain("secret");
     expect(blob).not.toContain("/Users/me");
   });
+  it("malformed positional[1] (a path) is NOT captured into command", () => {
+    const r = redactInvocation(["sessions", "/Users/me/secret/path"], base);
+    expect(r.command).toBe("sessions");
+    const blob = JSON.stringify(r);
+    expect(blob).not.toContain("secret");
+    expect(blob).not.toContain("/Users/me");
+  });
+  it("tokens after -- (end-of-options) never reach command", () => {
+    const r = redactInvocation(["ingest", "--", "secret"], base);
+    expect(r.command).toBe("ingest");
+    expect(JSON.stringify(r)).not.toContain("secret");
+  });
+  it("a non-command head is recorded as (unknown), never the raw token", () => {
+    const r = redactInvocation(["/weird/path"], base);
+    expect(r.command).toBe("(unknown)");
+    expect(JSON.stringify(r)).not.toContain("weird");
+  });
 });

--- a/apps/axctl/src/usage/record.ts
+++ b/apps/axctl/src/usage/record.ts
@@ -12,36 +12,6 @@ export interface RecordInputs {
   readonly version: string;
 }
 
-// Top-level commands that take a second positional word as part of their
-// subcommand path (e.g. "sessions show", "skills weighted"). A stale or
-// missing entry here only mislabels the command string - it never leaks data,
-// because positionals beyond index 1 are always dropped regardless.
-const KNOWN_SUBCOMMAND_FIRST = new Set([
-  "sessions",   // sessions show / here / around / near / churn / compare / metrics
-  "skills",     // skills classify / tag / weighted / by-role / roles / lint / …
-  "cost",       // cost models / sessions / split
-  "routing",    // routing tune / compile / show
-  "profile",    // profile show / publish / unpublish
-  "hooks",      // hooks log / summary / …
-  "dojo",       // dojo agenda / report / draft / outbox / spar-plan / spar-score
-  "agents",     // agents config / reconcile / scope / park / unpark / rm
-  "classifiers", // classifiers subcommands
-  "insights",   // insights subcommands
-  "signals",    // signals list / …
-  "evidence",   // evidence subcommands
-  "project",    // project subcommands
-  "costs",      // costs subcommands (legacy group)
-  "wrapped",    // wrapped subcommands
-  "daemon",     // daemon start / stop / restart / status
-  "improve",    // improve recommend / lint / list / show / accept / …
-  "retro",      // retro emit / list / pending / brief / reflect / meta / plan
-  // Added: real group commands present in the CLI but missing from original set
-  "dispatches", // dispatches compile-routing
-  "ingest",     // ingest here
-  "derive",     // derive signals / intents
-  "serve",      // serve status / stop
-]);
-
 // Verbs/command names are short lowercase kebab tokens. Anything else
 // (a path, an id, a query, a --escaped value) is user data → never persisted.
 const VERB = /^[a-z][a-z-]{0,30}$/;
@@ -52,14 +22,11 @@ export const redactInvocation = (argv: ReadonlyArray<string>, inp: RecordInputs)
   const scan = sep === -1 ? argv : argv.slice(0, sep);
 
   const positionals = scan.filter((a) => !a.startsWith("-"));
-  const head = positionals[0] && VERB.test(positionals[0]) ? positionals[0] : "(unknown)";
-  const command =
-    head !== "(unknown)" &&
-    KNOWN_SUBCOMMAND_FIRST.has(head) &&
-    positionals[1] &&
-    VERB.test(positionals[1])
-      ? `${head} ${positionals[1]}`
-      : head;
+  // Record ONLY the top-level subcommand (validated). The second positional is
+  // user-controllable (branch/skill/slug names) for some groups, so it is never
+  // captured - top-level granularity is the safe surface (this data is the basis
+  // for the future external team-publish). A non-command head -> "(unknown)".
+  const command = positionals[0] && VERB.test(positionals[0]) ? positionals[0] : "(unknown)";
 
   const flags = [...new Set(
     scan.filter((a) => a.startsWith("-") && a !== "--").map((a) => a.split("=")[0]!),

--- a/apps/axctl/src/usage/record.ts
+++ b/apps/axctl/src/usage/record.ts
@@ -42,28 +42,40 @@ const KNOWN_SUBCOMMAND_FIRST = new Set([
   "serve",      // serve status / stop
 ]);
 
+// Verbs/command names are short lowercase kebab tokens. Anything else
+// (a path, an id, a query, a --escaped value) is user data → never persisted.
+const VERB = /^[a-z][a-z-]{0,30}$/;
+
 export const redactInvocation = (argv: ReadonlyArray<string>, inp: RecordInputs): UsageRecord => {
-  const positionals = argv.filter((a) => !a.startsWith("-"));
-  const head = positionals[0] ?? "(root)";
-  const command = KNOWN_SUBCOMMAND_FIRST.has(head) && positionals[1]
-    ? `${head} ${positionals[1]}`
-    : head;
+  // Everything after a bare "--" is end-of-options USER DATA, never a subcommand.
+  const sep = argv.indexOf("--");
+  const scan = sep === -1 ? argv : argv.slice(0, sep);
+
+  const positionals = scan.filter((a) => !a.startsWith("-"));
+  const head = positionals[0] && VERB.test(positionals[0]) ? positionals[0] : "(unknown)";
+  const command =
+    head !== "(unknown)" &&
+    KNOWN_SUBCOMMAND_FIRST.has(head) &&
+    positionals[1] &&
+    VERB.test(positionals[1])
+      ? `${head} ${positionals[1]}`
+      : head;
+
   const flags = [...new Set(
-    argv.filter((a) => a.startsWith("-")).map((a) => a.split("=")[0]!),
+    scan.filter((a) => a.startsWith("-") && a !== "--").map((a) => a.split("=")[0]!),
   )].sort();
+
   const repo_key = inp.repoTopdir ? inp.repoTopdir.split("/").filter(Boolean).pop()!.toLowerCase() : null;
   return UsageRecord.make({
-    ts: inp.now,
-    command,
-    flags,
-    exit_code: inp.exitCode,
-    duration_ms: inp.durationMs,
-    origin: inp.isTty ? "tty" : "agent",
-    repo_key,
-    ax_version: inp.version,
+    ts: inp.now, command, flags,
+    exit_code: inp.exitCode, duration_ms: inp.durationMs,
+    origin: inp.isTty ? "tty" : "agent", repo_key, ax_version: inp.version,
   });
 };
 
+// v0 tradeoff: read-modify-write; a line may be lost under concurrent
+// invocations (acceptable for telemetry), bounded by the 5MB cap +
+// per-ingest truncation. node:fs appendFile is banned by check:no-node-fs.
 export async function appendUsageRecord(path: string, rec: UsageRecord): Promise<void> {
   try {
     const file = Bun.file(path);

--- a/apps/axctl/src/usage/record.ts
+++ b/apps/axctl/src/usage/record.ts
@@ -1,0 +1,74 @@
+import { UsageRecord, encodeUsageLine } from "./model.ts";
+
+export const defaultUsageLogPath = (): string => `${process.env.HOME}/.ax/usage-log.jsonl`;
+const MAX_LOG_BYTES = 5 * 1024 * 1024;
+
+export interface RecordInputs {
+  readonly now: Date;
+  readonly exitCode: number;
+  readonly durationMs: number;
+  readonly isTty: boolean;
+  readonly repoTopdir: string | null;
+  readonly version: string;
+}
+
+// Top-level commands that take a second positional word as part of their
+// subcommand path (e.g. "sessions show", "skills weighted"). A stale or
+// missing entry here only mislabels the command string - it never leaks data,
+// because positionals beyond index 1 are always dropped regardless.
+const KNOWN_SUBCOMMAND_FIRST = new Set([
+  "sessions",   // sessions show / here / around / near / churn / compare / metrics
+  "skills",     // skills classify / tag / weighted / by-role / roles / lint / …
+  "cost",       // cost models / sessions / split
+  "routing",    // routing tune / compile / show
+  "profile",    // profile show / publish / unpublish
+  "hooks",      // hooks log / summary / …
+  "dojo",       // dojo agenda / report / draft / outbox / spar-plan / spar-score
+  "agents",     // agents config / reconcile / scope / park / unpark / rm
+  "classifiers", // classifiers subcommands
+  "insights",   // insights subcommands
+  "signals",    // signals list / …
+  "evidence",   // evidence subcommands
+  "project",    // project subcommands
+  "costs",      // costs subcommands (legacy group)
+  "wrapped",    // wrapped subcommands
+  "daemon",     // daemon start / stop / restart / status
+  "improve",    // improve recommend / lint / list / show / accept / …
+  "retro",      // retro emit / list / pending / brief / reflect / meta / plan
+  // Added: real group commands present in the CLI but missing from original set
+  "dispatches", // dispatches compile-routing
+  "ingest",     // ingest here
+  "derive",     // derive signals / intents
+  "serve",      // serve status / stop
+]);
+
+export const redactInvocation = (argv: ReadonlyArray<string>, inp: RecordInputs): UsageRecord => {
+  const positionals = argv.filter((a) => !a.startsWith("-"));
+  const head = positionals[0] ?? "(root)";
+  const command = KNOWN_SUBCOMMAND_FIRST.has(head) && positionals[1]
+    ? `${head} ${positionals[1]}`
+    : head;
+  const flags = [...new Set(
+    argv.filter((a) => a.startsWith("-")).map((a) => a.split("=")[0]!),
+  )].sort();
+  const repo_key = inp.repoTopdir ? inp.repoTopdir.split("/").filter(Boolean).pop()!.toLowerCase() : null;
+  return UsageRecord.make({
+    ts: inp.now,
+    command,
+    flags,
+    exit_code: inp.exitCode,
+    duration_ms: inp.durationMs,
+    origin: inp.isTty ? "tty" : "agent",
+    repo_key,
+    ax_version: inp.version,
+  });
+};
+
+export async function appendUsageRecord(path: string, rec: UsageRecord): Promise<void> {
+  try {
+    const file = Bun.file(path);
+    if (await file.exists() && file.size > MAX_LOG_BYTES) return;
+    const prev = (await file.exists()) ? await file.text() : "";
+    await Bun.write(path, `${prev}${encodeUsageLine(rec)}\n`, { createPath: true });
+  } catch { /* never throw on the hot path */ }
+}

--- a/apps/axctl/src/usage/usage-stage.test.ts
+++ b/apps/axctl/src/usage/usage-stage.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { invocationRowKey, parseUsageLog } from "./usage-stage.ts";
+import { UsageRecord } from "./model.ts";
+
+const rec = (over: Partial<ConstructorParameters<typeof UsageRecord>[0]> = {}) => UsageRecord.make({
+  ts: new Date("2026-06-15T12:00:00Z"), command: "digest", flags: [], exit_code: 0,
+  duration_ms: 5, origin: "agent", repo_key: "ax", ax_version: "0.29.0", ...over,
+});
+
+describe("parseUsageLog", () => {
+  it("parses valid lines, skips malformed ones", () => {
+    const text = [
+      JSON.stringify({ ts: "2026-06-15T12:00:00.000Z", command: "digest", flags: [], exit_code: 0, duration_ms: 5, origin: "agent", repo_key: "ax", ax_version: "0.29.0" }),
+      "GARBAGE",
+      "",
+    ].join("\n");
+    const rows = parseUsageLog(text);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].command).toBe("digest");
+  });
+});
+
+describe("invocationRowKey", () => {
+  it("is stable for the same (ts, command, repo_key, origin)", () => {
+    expect(invocationRowKey(rec())).toBe(invocationRowKey(rec()));
+  });
+  it("differs when ts or command differs", () => {
+    expect(invocationRowKey(rec())).not.toBe(invocationRowKey(rec({ command: "ingest" })));
+    expect(invocationRowKey(rec())).not.toBe(invocationRowKey(rec({ ts: new Date("2026-06-15T13:00:00Z") })));
+  });
+});

--- a/apps/axctl/src/usage/usage-stage.ts
+++ b/apps/axctl/src/usage/usage-stage.ts
@@ -1,0 +1,62 @@
+import { Cause, Effect, Schema } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { surrealDate, recordRef, surrealOptionString } from "@ax/lib/shared/surql";
+import { surrealLiteral } from "@ax/lib/json";
+import { executeStatementsWith } from "@ax/lib/shared/statement-exec";
+import { BaseStageStats, type IngestContext, StageMeta } from "../ingest/stage/types.ts";
+import type { StageDef } from "../ingest/stage/registry.ts";
+import { UsageRecord, parseUsageLine } from "./model.ts";
+import { defaultUsageLogPath } from "./record.ts";
+
+export const invocationRowKey = (r: UsageRecord): string =>
+  Bun.hash(`${r.ts.getTime()}:${r.command}:${r.repo_key ?? ""}:${r.origin}`).toString(16);
+
+export const parseUsageLog = (text: string): UsageRecord[] =>
+  text.split("\n").map(parseUsageLine).filter((r): r is UsageRecord => r !== null);
+
+const buildStatements = (rows: ReadonlyArray<UsageRecord>): string[] =>
+  rows.map((r) => {
+    const id = invocationRowKey(r);
+    const flagsJson = surrealLiteral(JSON.stringify([...r.flags]));
+    const repo = surrealOptionString(r.repo_key);
+    return `UPSERT ${recordRef("ax_invocation", id)} CONTENT { ts: ${surrealDate(r.ts)}, command: ${surrealLiteral(r.command)}, flags: ${flagsJson}, exit_code: ${r.exit_code}, duration_ms: ${r.duration_ms}, origin: ${surrealLiteral(r.origin)}, repo_key: ${repo}, ax_version: ${surrealLiteral(r.ax_version)} };`;
+  });
+
+export const ingestUsageLog = (): Effect.Effect<number, DbError, SurrealClient> =>
+  Effect.gen(function* () {
+    const db = yield* SurrealClient;
+    const path = defaultUsageLogPath();
+    const text = yield* Effect.promise(async () => {
+      const f = Bun.file(path);
+      return (await f.exists()) ? await f.text() : "";
+    });
+    const rows = parseUsageLog(text);
+    if (rows.length === 0) return 0;
+    yield* executeStatementsWith(db, buildStatements(rows), { chunkSize: 500 });
+    yield* Effect.promise(() => Bun.write(path, ""));
+    return rows.length;
+  });
+
+export const UsageKey = Schema.Literal("usage");
+export type UsageKey = typeof UsageKey.Type;
+
+export class UsageStats extends BaseStageStats.extend<UsageStats>("UsageStats")({
+  invocations: Schema.Number,
+}) {}
+
+export const usageStage: StageDef<UsageStats, SurrealClient> = {
+  meta: StageMeta.make({ key: "usage", deps: [], tags: ["derive"] }),
+  run: (_ctx: IngestContext) =>
+    Effect.gen(function* () {
+      const t0 = Date.now();
+      const n = yield* ingestUsageLog();
+      return UsageStats.make({ durationMs: Date.now() - t0, summary: `ingested ${n} invocations`, invocations: n });
+    }).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning(`usage stage skipped: ${Cause.pretty(cause)}`).pipe(
+          Effect.as(UsageStats.make({ durationMs: 0, summary: "usage skipped (non-fatal)", invocations: 0 })),
+        ),
+      ),
+    ),
+};

--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -254,6 +254,31 @@ claude-sonnet-4             54          120   18.7%        201,330`,
           "Sources: open improve proposals, routing savings, repair-loop churn, and quota burn (surfaced only above 70%). Compute and surface are split by the snapshot file, so a DB hiccup never blocks session boot.",
         ],
       },
+      {
+        name: "usage",
+        job: "Your ax utilization: total runs, active days, top commands, agent-vs-tty split, and the surface you have never touched.",
+        signature: "ax usage [--json] [--days=N]",
+        flags: [
+          { flag: "--days=N", desc: "window in days (default 30)" },
+          { flag: "--json", desc: "machine output: full UsageRollup JSON" },
+        ],
+        receipt: `$ ax usage
+[ax] usage (30d): 147 runs across 18 active days  (agent 89 / tty 58)
+top commands:
+  ingest                   42
+  sessions                 31
+  improve                  19
+  cost                     14
+  quota                     9
+  dispatches                8
+  thinking                  7
+  recall                    5
+3 never used: tui, share, dojo`,
+        detail: [
+          "Usage records are written at every invocation (including failures) to ~/.ax/usage.jsonl and imported into ax_invocation at ingest time. Run ax ingest first to see populated results.",
+          "The never-used list shows visible top-level commands with zero invocations in the window - a quick way to spot surface you have not explored.",
+        ],
+      },
     ],
   },
   {

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -43,6 +43,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax dojo spar-plan <sha> [--json]` - capture a landed task's baseline (prompt + cost/turns/churn) and emit a one-delta experiment brief to `~/.ax/dojo/spar/<id>.md`; prints the `git worktree add` command that pins the parent SHA.
 - `ax dojo spar-score <id> [--variant-session=<id>] [--json]` - score the agent's variant session against the frozen baseline; auto-discovers the variant session from the worktree cwd or accepts an explicit id; writes the receipt to `~/.ax/dojo/spar/<id>-report.md`.
 - `ax digest [--json|--refresh]` - your ranked digest board (improve proposals, routing savings, repair-loops, quota), written to ~/.ax/digest.json every ingest and pushed into the agent's context at session start by the surface-digest hook so value arrives without being asked for
+- `ax usage [--json] [--days=N]` - your ax utilization: total runs, active days, top commands by count, agent-vs-tty split, and the never-used surface (visible commands with zero invocations in the window)
 
 ### Profile
 - `ax profile show [--window=N] [--no-cost]` - your local agent profile rendered from the graph: usage stats, rig (skills/hooks/rules), and evidence-grounded taste patterns

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -28,6 +28,7 @@ import type {
     WorkflowResponse,
     WrappedProfile,
 } from "@ax/lib/shared/dashboard-types";
+import type { UsageRollupSchema } from "@ax/lib/shared/api-contract";
 
 // Studio mock-mode build flag. When true (set at build time for the public
 // studio bundle), every fetch is either:
@@ -456,6 +457,13 @@ export const api = {
 
     wrappedGenerateBrief: (): Promise<{ brief: string }> =>
         viaContract("/api/wrapped/generate-brief", (c) => c.insights.wrappedGenerateBrief()),
+
+    /** CLI utilization rollup: active days, top commands, unused surface. */
+    usage: (params: { days?: number } = {}): Promise<UsageRollupSchema> =>
+        viaContract("/api/usage", (c) =>
+            c.usage.usageRollup({
+                query: params.days != null ? { days: params.days } : {},
+            })),
 
     /** Read-only SQL console (Lab) - daemon accepts SELECT/RETURN/INFO only. */
     query: (sql: string): Promise<{ result: unknown; durationMs: number }> =>

--- a/apps/studio/src/router.tsx
+++ b/apps/studio/src/router.tsx
@@ -22,6 +22,7 @@ import { CanvasRoute } from "./routes/canvas.tsx";
 import type { GraphExplorerMode } from "@ax/lib/shared/dashboard-types";
 import { MissionControl } from "./instrument/mission-control.tsx";
 import { ImproveRoute } from "./routes/improve.tsx";
+import { UsageRoute } from "./routes/usage.tsx";
 import { LabRoute } from "./routes/lab.tsx";
 import { SigilGalleryRoute } from "./routes/sigil-gallery.tsx";
 import { ReviewView } from "./routes/review-view.tsx";
@@ -200,6 +201,12 @@ const improveRoute = createRoute({
     component: ImproveRoute,
 });
 
+const usageRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/usage",
+    component: UsageRoute,
+});
+
 const labRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/lab",
@@ -258,6 +265,7 @@ const routeTree = rootRoute.addChildren([
     graphRoute,
     canvasRoute,
     improveRoute,
+    usageRoute,
     labRoute,
     sigilGalleryRoute,
     narrationDemoRoute,

--- a/apps/studio/src/routes/usage.tsx
+++ b/apps/studio/src/routes/usage.tsx
@@ -1,0 +1,126 @@
+/**
+ * Utilization panel - minimal view of GET /api/usage.
+ * Shows: active days, total invocations, top commands, never-used commands.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api.ts";
+import type { UsageRollupSchema } from "@ax/lib/shared/api-contract";
+
+export function UsageRoute() {
+    const { data, isLoading, error } = useQuery({
+        queryKey: ["usage"],
+        queryFn: () => api.usage(),
+    });
+
+    if (isLoading) return <section className="panel"><p>Loading…</p></section>;
+    if (error || !data) {
+        return (
+            <section className="panel">
+                <header><h2>Utilization</h2></header>
+                <p className="meta">{error instanceof Error ? error.message : "Failed to load"}</p>
+            </section>
+        );
+    }
+
+    return (
+        <section className="panel">
+            <header>
+                <h2>Utilization</h2>
+                <span className="meta">{data.windowDays}d window</span>
+            </header>
+
+            <div style={{ display: "flex", gap: "32px", margin: "8px 0 16px" }}>
+                <div>
+                    <div style={{ fontSize: "1.6em", fontWeight: 600 }}>{data.activeDays}</div>
+                    <div className="meta">active days</div>
+                </div>
+                <div>
+                    <div style={{ fontSize: "1.6em", fontWeight: 600 }}>{data.total}</div>
+                    <div className="meta">total invocations</div>
+                </div>
+                <div>
+                    <div style={{ fontSize: "1.6em", fontWeight: 600 }}>
+                        {data.originSplit.agent} / {data.originSplit.tty}
+                    </div>
+                    <div className="meta">agent / tty</div>
+                </div>
+            </div>
+
+            {data.topCommands.length > 0 && (
+                <>
+                    <h3 style={{ margin: "12px 0 6px", fontSize: "0.85em", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                        Top commands
+                    </h3>
+                    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.9em" }}>
+                        <tbody>
+                            {data.topCommands.map((cmd) => (
+                                <tr key={cmd.command}>
+                                    <td style={{ padding: "3px 8px 3px 0", fontFamily: "monospace" }}>
+                                        ax {cmd.command}
+                                    </td>
+                                    <td style={{ padding: "3px 8px", color: "var(--color-meta, #888)" }}>
+                                        {cmd.count}×
+                                    </td>
+                                    <td style={{ padding: "3px 0", color: "var(--color-meta, #888)", fontSize: "0.85em" }}>
+                                        last {new Date(cmd.last_used).toLocaleDateString()}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </>
+            )}
+
+            {data.unusedSurface.length > 0 && (
+                <>
+                    <h3 style={{ margin: "16px 0 6px", fontSize: "0.85em", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                        Never used in this window
+                    </h3>
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: "6px" }}>
+                        {data.unusedSurface.map((cmd) => (
+                            <code
+                                key={cmd}
+                                style={{
+                                    padding: "2px 8px",
+                                    background: "var(--color-bg-alt, rgba(0,0,0,0.06))",
+                                    borderRadius: "4px",
+                                    fontSize: "0.85em",
+                                }}
+                            >
+                                ax {cmd}
+                            </code>
+                        ))}
+                    </div>
+                </>
+            )}
+
+            {data.reliability.length > 0 && (
+                <>
+                    <h3 style={{ margin: "16px 0 6px", fontSize: "0.85em", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                        Reliability (commands with failures)
+                    </h3>
+                    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.9em" }}>
+                        <tbody>
+                            {data.reliability.map((r) => (
+                                <tr key={r.command}>
+                                    <td style={{ padding: "3px 8px 3px 0", fontFamily: "monospace" }}>
+                                        ax {r.command}
+                                    </td>
+                                    <td style={{ padding: "3px 8px", color: "var(--color-meta, #888)" }}>
+                                        {r.failures}/{r.runs} failed
+                                    </td>
+                                    <td style={{ padding: "3px 0", color: "var(--color-meta, #888)", fontSize: "0.85em" }}>
+                                        {(r.failureRate * 100).toFixed(0)}%
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </>
+            )}
+        </section>
+    );
+}
+
+// Re-export the type for api.ts consumers.
+export type { UsageRollupSchema };

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,6 +151,22 @@ without being asked for:
   the raw snapshot. Install the hook with `ax hooks install
   <path>/surface-digest.ts --providers=claude,codex`.
 
+## Utilization
+
+`ax usage [--days=N] [--json]` shows your ax utilization for the last N days
+(default 30):
+
+- **Active days**: calendar days with at least one invocation.
+- **Top commands**: ranked by run count, up to 8 shown.
+- **Agent vs TTY split**: how many invocations came from an agent subshell vs
+  an interactive terminal.
+- **Never used**: visible top-level commands with zero invocations in the
+  window - the surface you haven't explored yet.
+
+Usage records are written by the CLI itself at every invocation (including
+failures) to `~/.ax/usage.jsonl`; `ax ingest` imports them into the
+`ax_invocation` table.  Run `ax ingest` first to see populated results.
+
 ## Dispatch model drops
 
 `ax dispatches` flags routed dispatches whose child ran legs on a different

--- a/docs/superpowers/plans/2026-06-15-usage-telemetry.md
+++ b/docs/superpowers/plans/2026-06-15-usage-telemetry.md
@@ -1,0 +1,845 @@
+# Self-Telemetry + Utilization View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture ax's own CLI invocations (redacted) into an `ax_invocation` table and surface "what you actually run" via `ax usage --json` and an `ax serve` Utilization route.
+
+**Architecture:** Capture is split from graph by a local append-only log. The CLI entrypoint appends one redacted JSONL line per invocation to `~/.ax/usage-log.jsonl` (cheap, no DB, fail-silent). A `derive`-tagged ingest stage parses the log into `ax_invocation` rows on the next ingest and truncates consumed lines (failure-isolated). Pure rollup functions feed both the CLI and the dashboard.
+
+**Tech Stack:** Bun, TypeScript (strict), Effect v4 (`effect@beta`), Effect Schema, SurrealDB via `@ax/lib/db`, `effect/unstable/cli`. Tests: `bun:test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-usage-telemetry-design.md`
+
+**Reference (already on main):** the push-value digest feature is the template for this whole shape - `apps/axctl/src/digest/` (model/stage/snapshot atomic-write), `apps/axctl/src/digest/digest-stage.ts` (derive-stage + `Effect.catchCause` isolation), `apps/axctl/src/cli/commands/digest.ts` (CLI command pattern). Read these first.
+
+---
+
+## File Structure
+
+```
+packages/schema/src/schema.surql                  - ax_invocation table DDL (modify)
+apps/axctl/src/queries/insights.ts                - SCHEMA_TABLES += ax_invocation (modify)
+apps/axctl/src/usage/
+  model.ts        - UsageRecord schema + parseUsageLine + encodeUsageLine
+  record.ts       - redactInvocation (pure) + appendUsageRecord (fail-silent IO)
+  usage-stage.ts  - derive-tagged StageDef: parse log → rows, truncate, isolated
+  query.ts        - pure rollups over decoded rows (+ injected command list)
+apps/axctl/src/cli/index.ts                        - wrap runMain to record on exit (modify)
+apps/axctl/src/cli/commands/usage.ts               - `ax usage [--json] [--days=N]`
+apps/axctl/src/cli/index.ts                        - register usageCommand + usageRuntime (modify)
+apps/axctl/src/ingest/stage/registry.ts            - register usageStage (modify)
+apps/axctl/src/cli/effect-cli.test.ts              - stage count + derive set (modify)
+README.md / docs/cli.md / apps/site/public/llms.txt - document ax usage (modify)
+apps/site/app/routes/docs/-cli-reference.data.ts   - ax usage card (modify)
+apps/axctl/src/dashboard/...                       - /api/usage route (functional-minimal)
+```
+
+Reuse: atomic-write + JSONL patterns from `apps/axctl/src/digest/` and `apps/axctl/src/quota/cache.ts`; StageDef from `apps/axctl/src/digest/digest-stage.ts`; CLI command from `apps/axctl/src/cli/commands/digest.ts`; schema DDL from the `hook_command_invocation` block in `schema.surql`.
+
+---
+
+## Task 1: `ax_invocation` schema + registration
+
+**Files:**
+- Modify: `packages/schema/src/schema.surql` (add the table DDL near `hook_command_invocation`, ~line 1525)
+- Modify: `apps/axctl/src/queries/insights.ts` (add to `SCHEMA_TABLES`, ~line 45)
+- Test: there is an existing test that asserts every `schema.surql` table is in `SCHEMA_TABLES` - find it with `rg -l "SCHEMA_TABLES" apps/axctl/src --glob '*.test.ts'` and run it.
+
+- [ ] **Step 1: Add the table DDL** to `packages/schema/src/schema.surql` (after the `hook_command_invocation` indexes block):
+
+```surql
+DEFINE TABLE ax_invocation SCHEMAFULL;
+DEFINE FIELD ts          ON ax_invocation TYPE datetime;
+DEFINE FIELD command     ON ax_invocation TYPE string;           -- "sessions churn" | "digest" | "ingest"
+DEFINE FIELD flags       ON ax_invocation TYPE string;           -- JSON-encoded string[] of flag NAMES
+DEFINE FIELD exit_code   ON ax_invocation TYPE int;
+DEFINE FIELD duration_ms ON ax_invocation TYPE int;
+DEFINE FIELD origin      ON ax_invocation TYPE string;           -- tty | agent
+DEFINE FIELD repo_key    ON ax_invocation TYPE option<string>;   -- basename(git toplevel), lowercased
+DEFINE FIELD ax_version  ON ax_invocation TYPE string;
+DEFINE INDEX IF NOT EXISTS ax_invocation_by_ts      ON ax_invocation FIELDS ts;
+DEFINE INDEX IF NOT EXISTS ax_invocation_by_command ON ax_invocation FIELDS command, ts;
+```
+
+- [ ] **Step 2: Register in `SCHEMA_TABLES`** (`apps/axctl/src/queries/insights.ts`, add one entry to the array):
+
+```typescript
+    { table: "ax_invocation", stage: "active", note: "ax's own CLI invocations (redacted) for self-telemetry / utilization." },
+```
+
+- [ ] **Step 3: Run the schema-tables mirror test**
+
+Run: `bun test $(rg -l "SCHEMA_TABLES" apps/axctl/src --glob '*.test.ts' | head -1)`
+Expected: PASS (the table is now mirrored). If the test enumerates `DEFINE TABLE` from schema.surql, it now finds `ax_invocation` in `SCHEMA_TABLES`.
+
+- [ ] **Step 4: Apply schema to the local DB + verify**
+
+Run: `bun run apps/axctl/src/cli/index.ts ingest --stages=skills 2>&1 | tail -3` (any ingest applies schema first) OR the repo's schema-apply script (`rg -n "apply-schema" scripts/`). Then verify the table exists:
+Run: `printf 'INFO FOR TABLE ax_invocation;\n' | surreal sql --endpoint http://127.0.0.1:8521 --username root --password root --namespace ax --database main 2>&1 | tail -2`
+Expected: shows the field definitions (proves DDL applied, no orphan-field crash).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/schema/src/schema.surql apps/axctl/src/queries/insights.ts
+git commit -m "feat(usage): ax_invocation table + SCHEMA_TABLES registration"
+```
+
+---
+
+## Task 2: `model.ts` - UsageRecord schema + JSONL
+
+**Files:**
+- Create: `apps/axctl/src/usage/model.ts`
+- Test: `apps/axctl/src/usage/model.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/axctl/src/usage/model.test.ts
+import { describe, expect, it } from "bun:test";
+import { UsageRecord, parseUsageLine, encodeUsageLine } from "./model.ts";
+
+const rec = () => UsageRecord.make({
+  ts: new Date("2026-06-15T12:00:00Z"),
+  command: "sessions churn",
+  flags: ["--here", "--json"],
+  exit_code: 0,
+  duration_ms: 1200,
+  origin: "agent",
+  repo_key: "ax",
+  ax_version: "0.29.0",
+});
+
+describe("usage model", () => {
+  it("encodeUsageLine -> parseUsageLine round-trips", () => {
+    const line = encodeUsageLine(rec());
+    expect(line.endsWith("\n")).toBe(false); // caller adds the newline
+    const back = parseUsageLine(line);
+    expect(back?.command).toBe("sessions churn");
+    expect(back?.flags).toEqual(["--here", "--json"]);
+    expect(back?.origin).toBe("agent");
+  });
+  it("parseUsageLine returns null on malformed / non-JSON / bad-shape lines", () => {
+    expect(parseUsageLine("not json")).toBeNull();
+    expect(parseUsageLine(JSON.stringify({ nope: 1 }))).toBeNull();
+    expect(parseUsageLine("")).toBeNull();
+  });
+  it("repo_key is optional (null outside a repo)", () => {
+    const r = UsageRecord.make({ ...rec(), repo_key: null });
+    const back = parseUsageLine(encodeUsageLine(r));
+    expect(back?.repo_key).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify FAIL** (`bun test apps/axctl/src/usage/model.test.ts`).
+
+- [ ] **Step 3: Implement** `apps/axctl/src/usage/model.ts`. NOTE on effect@beta Schema (confirmed from the digest feature on main): multi-arg `Schema.Literal(...)` collapses - use `Schema.Literals([...])` for the origin union; `Schema.Date` does not JSON round-trip - use the validating ISO codec pattern from `apps/axctl/src/digest/model.ts` (read it; it exports an `IsoDate` built as `Schema.DateFromString.check(Schema.isDateValid())`). Reuse that exact pattern here.
+
+```typescript
+import { Schema } from "effect";
+
+// Same validating ISO codec the digest model uses (decodes ISO string -> Date,
+// rejects garbage, encodes Date -> ISO string for JSONL persistence).
+const IsoDate = Schema.DateFromString.check(Schema.isDateValid());
+
+export const UsageOrigin = Schema.Literals(["tty", "agent"]);
+export type UsageOrigin = typeof UsageOrigin.Type;
+
+export class UsageRecord extends Schema.Class<UsageRecord>("UsageRecord")({
+  ts: IsoDate,
+  command: Schema.String,
+  flags: Schema.Array(Schema.String),
+  exit_code: Schema.Number,
+  duration_ms: Schema.Number,
+  origin: UsageOrigin,
+  repo_key: Schema.NullOr(Schema.String),
+  ax_version: Schema.String,
+}) {}
+
+/** Encode a record to a single JSONL line (no trailing newline). */
+export const encodeUsageLine = (rec: UsageRecord): string =>
+  JSON.stringify(Schema.encodeSync(UsageRecord)(rec));
+
+/** Parse one JSONL line; null on any parse/decode failure (caller skips it). */
+export const parseUsageLine = (line: string): UsageRecord | null => {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    return Schema.decodeUnknownSync(UsageRecord)(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+};
+```
+
+- [ ] **Step 4: Run test, verify PASS** (`bun test apps/axctl/src/usage/model.test.ts`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/usage/model.ts apps/axctl/src/usage/model.test.ts
+git commit -m "feat(usage): UsageRecord schema + JSONL parse/encode"
+```
+
+---
+
+## Task 3: `record.ts` - redaction + fail-silent append
+
+**Files:**
+- Create: `apps/axctl/src/usage/record.ts`
+- Test: `apps/axctl/src/usage/record.test.ts`
+
+- [ ] **Step 1: Write the failing test** (redaction is the safety-critical part - test it hard):
+
+```typescript
+// apps/axctl/src/usage/record.test.ts
+import { describe, expect, it } from "bun:test";
+import { redactInvocation } from "./record.ts";
+
+describe("redactInvocation", () => {
+  const base = { now: new Date("2026-06-15T12:00:00Z"), exitCode: 0, durationMs: 5, isTty: false, repoTopdir: "/Users/me/Projects/ax", version: "0.29.0" };
+
+  it("keeps the subcommand path, drops positional args", () => {
+    const r = redactInvocation(["sessions", "show", "abc-123-uuid"], base);
+    expect(r.command).toBe("sessions show");
+    expect(r.flags).toEqual([]);
+  });
+  it("keeps flag NAMES, strips flag values", () => {
+    const r = redactInvocation(["recall", "secret query text", "--days=30", "--project=/Users/me/x", "--json"], base);
+    expect(r.command).toBe("recall");
+    expect(r.flags).toEqual(["--days", "--json", "--project"]); // sorted, names only, no values
+  });
+  it("repo_key is the lowercased basename, never the full path", () => {
+    expect(redactInvocation(["digest"], base).repo_key).toBe("ax");
+    expect(redactInvocation(["digest"], { ...base, repoTopdir: null }).repo_key).toBeNull();
+  });
+  it("origin from isTty", () => {
+    expect(redactInvocation(["digest"], { ...base, isTty: true }).origin).toBe("tty");
+    expect(redactInvocation(["digest"], { ...base, isTty: false }).origin).toBe("agent");
+  });
+  it("no positional value ever survives in command or flags", () => {
+    const r = redactInvocation(["sessions", "show", "/Users/me/secret", "--here"], base);
+    const blob = JSON.stringify(r);
+    expect(blob).not.toContain("secret");
+    expect(blob).not.toContain("/Users/me");
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify FAIL.**
+
+- [ ] **Step 3: Implement** `apps/axctl/src/usage/record.ts`:
+
+```typescript
+import { UsageRecord, encodeUsageLine } from "./model.ts";
+
+export const defaultUsageLogPath = (): string => `${process.env.HOME}/.ax/usage-log.jsonl`;
+/** Skip appending above this size if ingest never ran (bounds runaway growth). */
+const MAX_LOG_BYTES = 5 * 1024 * 1024;
+
+export interface RecordInputs {
+  readonly now: Date;
+  readonly exitCode: number;
+  readonly durationMs: number;
+  readonly isTty: boolean;
+  readonly repoTopdir: string | null; // absolute git toplevel, or null
+  readonly version: string;
+}
+
+const KNOWN_SUBCOMMAND_FIRST = new Set([
+  // first tokens that take a SECOND word as part of the command path. Keep this
+  // conservative: only multi-word command groups. Everything else = 1-word cmd.
+  "sessions", "skills", "cost", "routing", "profile", "hooks", "dojo", "agents",
+  "classifiers", "insights", "signals", "evidence", "project", "costs", "wrapped",
+  "daemon", "improve", "retro",
+]);
+
+/** Pure redaction: argv -> a privacy-safe UsageRecord. Positional values and
+ *  flag values never survive; repo_key is basename-only. */
+export const redactInvocation = (argv: ReadonlyArray<string>, inp: RecordInputs): UsageRecord => {
+  const positionals = argv.filter((a) => !a.startsWith("-"));
+  const head = positionals[0] ?? "(root)";
+  // command path = head, plus the second positional ONLY when head is a known
+  // command group (so "sessions show <id>" -> "sessions show", but "recall <q>" -> "recall").
+  const command = KNOWN_SUBCOMMAND_FIRST.has(head) && positionals[1]
+    ? `${head} ${positionals[1]}`
+    : head;
+  const flags = [...new Set(
+    argv.filter((a) => a.startsWith("-")).map((a) => a.split("=")[0]!), // strip =value
+  )].sort();
+  const repo_key = inp.repoTopdir ? inp.repoTopdir.split("/").filter(Boolean).pop()!.toLowerCase() : null;
+  return UsageRecord.make({
+    ts: inp.now,
+    command,
+    flags,
+    exit_code: inp.exitCode,
+    duration_ms: inp.durationMs,
+    origin: inp.isTty ? "tty" : "agent",
+    repo_key,
+    ax_version: inp.version,
+  });
+};
+
+/** Fail-silent append of one record. ANY fault is swallowed - telemetry must
+ *  never break or slow a command. Skips if the log is already huge. */
+export async function appendUsageRecord(path: string, rec: UsageRecord): Promise<void> {
+  try {
+    const file = Bun.file(path);
+    if (await file.exists() && file.size > MAX_LOG_BYTES) return;
+    const prev = (await file.exists()) ? await file.text() : "";
+    await Bun.write(path, `${prev}${encodeUsageLine(rec)}\n`, { createPath: true });
+  } catch { /* never throw on the hot path */ }
+}
+```
+
+> Implementer note: `appendUsageRecord` re-reads + rewrites the file for simplicity (telemetry volume is low). If you prefer a true append, use a Bun `FileSink` (`Bun.file(path).writer({ createPath: true })` then `.write()`/`.flush()`), still wrapped in the same try/catch. Either is acceptable; keep it fail-silent. The `KNOWN_SUBCOMMAND_FIRST` set should mirror the real command groups - cross-check against `ax help` SUBCOMMANDS and the command registry; a stale entry only mislabels the command string, never leaks data.
+
+- [ ] **Step 4: Run test, verify PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/usage/record.ts apps/axctl/src/usage/record.test.ts
+git commit -m "feat(usage): redact invocation + fail-silent append"
+```
+
+---
+
+## Task 4: Entrypoint wiring - record on every invocation
+
+**Files:**
+- Modify: `apps/axctl/src/cli/index.ts` (the `if (import.meta.main)` / `BunRuntime.runMain` block)
+
+- [ ] **Step 1: Read the entrypoint** `apps/axctl/src/cli/index.ts` around `BunRuntime.runMain(dispatch(args)...)`. The recorder must: stamp a start time, run the program, and on completion (success OR failure) append a record with the duration + a best-effort exit code, WITHOUT changing the program's own exit behavior.
+
+- [ ] **Step 2: Add the recorder wiring.** Add an `Effect.onExit` to the piped program that fires the append. Compute the git toplevel once (best-effort `git rev-parse --show-toplevel`). Exit code: 0 on Success, 1 on Failure (matching runMain's teardown). Implementation:
+
+```typescript
+// near the other imports at the top of apps/axctl/src/cli/index.ts
+import { appendUsageRecord, defaultUsageLogPath, redactInvocation } from "../usage/record.ts";
+import { Exit } from "effect";
+
+// helper, define above `if (import.meta.main)`:
+const recordInvocation = (args: ReadonlyArray<string>, t0: number, exitCode: number): Promise<void> => {
+  let repoTopdir: string | null = null;
+  try {
+    const r = Bun.spawnSync(["git", "rev-parse", "--show-toplevel"], { stdout: "pipe", stderr: "ignore" });
+    if (r.exitCode === 0) repoTopdir = r.stdout.toString().trim() || null;
+  } catch { /* no git / not a repo */ }
+  const rec = redactInvocation(args, {
+    now: new Date(),
+    exitCode,
+    durationMs: Math.max(0, Math.round(performance.now() - t0)),
+    isTty: process.stderr.isTTY === true,
+    repoTopdir,
+    version: AX_VERSION,
+  });
+  return appendUsageRecord(defaultUsageLogPath(), rec);
+};
+```
+
+Then wrap the program inside `if (import.meta.main)`:
+
+```typescript
+if (import.meta.main) {
+    const args = process.argv.slice(2);
+    const t0 = performance.now();
+    BunRuntime.runMain(
+        dispatch(args).pipe(
+            Effect.tap(() => Effect.promise(() => maybePrintStarNudge(args))),
+            Effect.tapCause(reportCliFailure),
+            // record AFTER the program settles; onExit never alters the exit channel.
+            Effect.onExit((exit) =>
+                Effect.promise(() => recordInvocation(args, t0, Exit.isSuccess(exit) ? 0 : 1)),
+            ),
+        ),
+        { disableErrorReporting: true },
+    );
+}
+```
+
+> Implementer note: confirm `AX_VERSION` is in scope at the entrypoint (it's passed to `Command.runWith`; grep it). Confirm `Effect.onExit` exists in effect@beta (if named differently, use `Effect.ensuring` with the exit captured via `Effect.exit` / `Effect.tapBoth` - the requirement is "run the append exactly once after the program settles, success or failure, without swallowing the program's failure or changing its exit code"). The append is fail-silent, so an `Effect.promise` (which dies on throw) is fine because `appendUsageRecord` never throws. Do NOT record for the long-lived `serve`/`mcp` commands' lifetime - `onExit` only fires when the fiber settles, which for `serve` is at shutdown; that's acceptable (one record at process exit). If `serve` never exits cleanly, no record is written - fine.
+
+- [ ] **Step 3: Manual smoke test** (TDD-by-hand - this is wiring, verified by observing the side effect):
+
+```bash
+rm -f ~/.ax/usage-log.jsonl
+bun run apps/axctl/src/cli/index.ts version >/dev/null 2>&1
+bun run apps/axctl/src/cli/index.ts sessions here --days=1 >/dev/null 2>&1 || true
+cat ~/.ax/usage-log.jsonl
+```
+Expected: two JSONL lines; the `version` line has `"command":"version"`, the sessions line has `"command":"sessions here"`, `"flags":["--days"]` (no `=1`), `"origin":"agent"` (piped) or `"tty"`, `"repo_key":"ax"`. No absolute paths, no positional values present.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `bun run typecheck 2>&1 | rg -c "error TS"` → expect 0 (in the touched file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/cli/index.ts
+git commit -m "feat(usage): record every CLI invocation on exit (fail-silent)"
+```
+
+---
+
+## Task 5: `usage-stage.ts` - log → rows, truncate, isolated + registry
+
+**Files:**
+- Create: `apps/axctl/src/usage/usage-stage.ts`
+- Modify: `apps/axctl/src/ingest/stage/registry.ts`
+- Modify: `apps/axctl/src/cli/effect-cli.test.ts`
+- Test: `apps/axctl/src/usage/usage-stage.test.ts`
+
+- [ ] **Step 1: Write the failing test** (parsing + idempotent id + isolation; reads the digest-stage test as a template for the failing-DB-layer pattern):
+
+```typescript
+// apps/axctl/src/usage/usage-stage.test.ts
+import { describe, expect, it } from "bun:test";
+import { invocationRowKey, parseUsageLog } from "./usage-stage.ts";
+import { UsageRecord } from "./model.ts";
+
+const rec = (over: Partial<ConstructorParameters<typeof UsageRecord>[0]> = {}) => UsageRecord.make({
+  ts: new Date("2026-06-15T12:00:00Z"), command: "digest", flags: [], exit_code: 0,
+  duration_ms: 5, origin: "agent", repo_key: "ax", ax_version: "0.29.0", ...over,
+});
+
+describe("parseUsageLog", () => {
+  it("parses valid lines, skips malformed ones", () => {
+    const text = [
+      JSON.stringify({ ts: "2026-06-15T12:00:00.000Z", command: "digest", flags: [], exit_code: 0, duration_ms: 5, origin: "agent", repo_key: "ax", ax_version: "0.29.0" }),
+      "GARBAGE",
+      "",
+    ].join("\n");
+    const rows = parseUsageLog(text);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].command).toBe("digest");
+  });
+});
+
+describe("invocationRowKey", () => {
+  it("is stable for the same (ts, command, repo_key, origin) - idempotent re-parse", () => {
+    expect(invocationRowKey(rec())).toBe(invocationRowKey(rec()));
+  });
+  it("differs when ts or command differs", () => {
+    expect(invocationRowKey(rec())).not.toBe(invocationRowKey(rec({ command: "ingest" })));
+    expect(invocationRowKey(rec())).not.toBe(invocationRowKey(rec({ ts: new Date("2026-06-15T13:00:00Z") })));
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify FAIL.**
+
+- [ ] **Step 3: Implement** `apps/axctl/src/usage/usage-stage.ts`. Mirror `apps/axctl/src/digest/digest-stage.ts` for the StageDef + `Effect.catchCause` isolation, and `apps/axctl/src/digest/snapshot.ts` for the atomic-write/truncate. Read both first.
+
+```typescript
+import { Cause, Effect, Schema } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { surrealDate, recordRef } from "@ax/lib/shared/surql";
+import { executeStatementsWith } from "@ax/lib/shared/statement-exec";
+import { BaseStageStats, IngestContext, StageMeta } from "../ingest/stage/types.ts";
+import type { StageDef } from "../ingest/stage/registry.ts";
+import { UsageRecord, parseUsageLine } from "./model.ts";
+import { defaultUsageLogPath } from "./record.ts";
+
+/** Stable, idempotent row id over the identifying fields. */
+export const invocationRowKey = (r: UsageRecord): string =>
+  Bun.hash(`${r.ts.getTime()}:${r.command}:${r.repo_key ?? ""}:${r.origin}`).toString(16);
+
+export const parseUsageLog = (text: string): UsageRecord[] =>
+  text.split("\n").map(parseUsageLine).filter((r): r is UsageRecord => r !== null);
+
+const buildStatements = (rows: ReadonlyArray<UsageRecord>): string[] =>
+  rows.map((r) => {
+    const id = invocationRowKey(r);
+    const flagsJson = JSON.stringify([...r.flags]).replace(/'/g, "\\'");
+    const repo = r.repo_key === null ? "NONE" : `'${r.repo_key.replace(/'/g, "\\'")}'`;
+    return `UPDATE ${recordRef("ax_invocation", id)} CONTENT { ts: ${surrealDate(r.ts.toISOString())}, command: '${r.command.replace(/'/g, "\\'")}', flags: '${flagsJson}', exit_code: ${r.exit_code}, duration_ms: ${r.duration_ms}, origin: '${r.origin}', repo_key: ${repo}, ax_version: '${r.ax_version.replace(/'/g, "\\'")}' };`;
+  });
+
+/** Parse the log, UPSERT rows (idempotent), then truncate the consumed log. */
+export const ingestUsageLog = (): Effect.Effect<number, never, SurrealClient> =>
+  Effect.gen(function* () {
+    const db = yield* SurrealClient;
+    const path = defaultUsageLogPath();
+    const text = yield* Effect.promise(async () => {
+      const f = Bun.file(path);
+      return (await f.exists()) ? await f.text() : "";
+    });
+    const rows = parseUsageLog(text);
+    if (rows.length === 0) return 0;
+    yield* executeStatementsWith(db, buildStatements(rows), { chunkSize: 500 });
+    // truncate only AFTER a successful write
+    yield* Effect.promise(() => Bun.write(path, ""));
+    return rows.length;
+  });
+
+export const UsageKey = Schema.Literal("usage");
+export type UsageKey = typeof UsageKey.Type;
+
+export class UsageStats extends BaseStageStats.extend<UsageStats>("UsageStats")({
+  invocations: Schema.Number,
+}) {}
+
+/** Derive-tagged: parses ~/.ax/usage-log.jsonl into ax_invocation. Self-isolated
+ *  via catchCause so a parse/DB error never aborts the surrounding ingest. */
+export const usageStage: StageDef<UsageStats, SurrealClient> = {
+  meta: StageMeta.make({ key: "usage", deps: [], tags: ["derive"] }),
+  run: (_ctx: IngestContext) =>
+    Effect.gen(function* () {
+      const t0 = Date.now();
+      const n = yield* ingestUsageLog();
+      return UsageStats.make({ durationMs: Date.now() - t0, summary: `ingested ${n} invocations`, invocations: n });
+    }).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning(`usage stage skipped: ${Cause.pretty(cause)}`).pipe(
+          Effect.as(UsageStats.make({ durationMs: 0, summary: "usage skipped (non-fatal)", invocations: 0 })),
+        ),
+      ),
+    ),
+};
+```
+
+> Implementer note: verify `surrealDate`, `recordRef`, `executeStatementsWith` signatures against `@ax/lib/shared/surql` + `@ax/lib/shared/statement-exec` (the digest + derive-opportunities stages use them - copy their exact usage). The SQL uses `UPDATE <id> CONTENT {...}` for idempotent upsert keyed by the stable id (re-parsing the same log twice produces the same rows). Confirm string-escaping is sufficient; prefer the project's existing `surrealLiteral`/`recordRef` helpers over hand-rolled quoting if available (grep `surrealLiteral` in `@ax/lib/json`). If a helper exists, use it instead of `.replace(/'/g, ...)`.
+
+- [ ] **Step 4: Register the stage** in `apps/axctl/src/ingest/stage/registry.ts`:
+  1. Import: `import { UsageKey, usageStage } from "../../usage/usage-stage.ts";`
+  2. Add `UsageKey` to the `IngestStageKey` `Schema.Union([...])` list.
+  3. Add `usageStage` to `ALL_STAGES`.
+
+- [ ] **Step 5: Update `effect-cli.test.ts`** - the default-stage count and the derive set both grow by one. Find the `resolveIngestStages: default runs every stage` test (`.toHaveLength(N)`) and bump N by 1 (update the comment to mention `usageStage`). Find the `--derive-only` test's sorted array and insert `"usage"` in sorted position.
+
+- [ ] **Step 6: Run tests + verify registration**
+
+Run: `bun test apps/axctl/src/usage/usage-stage.test.ts apps/axctl/src/cli/effect-cli.test.ts` → PASS.
+Run: `bun run typecheck 2>&1 | rg -c "error TS"` → 0.
+Run (e2e): seed a log line then run the stage -
+```bash
+printf '%s\n' '{"ts":"2026-06-15T12:00:00.000Z","command":"digest","flags":["--json"],"exit_code":0,"duration_ms":5,"origin":"agent","repo_key":"ax","ax_version":"0.29.0"}' > ~/.ax/usage-log.jsonl
+bun run apps/axctl/src/cli/index.ts ingest --stages=usage 2>&1 | tail -3
+printf 'SELECT command, origin, flags FROM ax_invocation LIMIT 5;\n' | surreal sql --endpoint http://127.0.0.1:8521 --username root --password root --namespace ax --database main 2>&1 | tail -2
+wc -l ~/.ax/usage-log.jsonl   # should be 0 (truncated)
+```
+Expected: one `ax_invocation` row (command digest), log truncated to empty.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/axctl/src/usage/usage-stage.ts apps/axctl/src/usage/usage-stage.test.ts apps/axctl/src/ingest/stage/registry.ts apps/axctl/src/cli/effect-cli.test.ts
+git commit -m "feat(usage): ingest stage parses usage log into ax_invocation (isolated)"
+```
+
+---
+
+## Task 6: `query.ts` - utilization rollups
+
+**Files:**
+- Create: `apps/axctl/src/usage/query.ts`
+- Test: `apps/axctl/src/usage/query.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// apps/axctl/src/usage/query.test.ts
+import { describe, expect, it } from "bun:test";
+import { rollup, type InvocationRow } from "./query.ts";
+
+const row = (over: Partial<InvocationRow>): InvocationRow => ({
+  ts: "2026-06-15T12:00:00.000Z", command: "digest", origin: "agent", exit_code: 0, ...over,
+});
+
+describe("rollup", () => {
+  const visible = ["digest", "sessions", "recall", "quota", "thinking"];
+  const rows: InvocationRow[] = [
+    row({ command: "digest", ts: "2026-06-15T10:00:00.000Z" }),
+    row({ command: "digest", ts: "2026-06-15T11:00:00.000Z", origin: "tty" }),
+    row({ command: "sessions", ts: "2026-06-14T10:00:00.000Z" }),
+    row({ command: "recall", ts: "2026-06-13T10:00:00.000Z", exit_code: 1 }),
+  ];
+
+  it("topCommands ranks by count desc with last_used", () => {
+    const r = rollup(rows, visible);
+    expect(r.topCommands[0]).toMatchObject({ command: "digest", count: 2 });
+    expect(r.topCommands[0].last_used).toBe("2026-06-15T11:00:00.000Z");
+  });
+  it("activeDays counts distinct UTC days with >=1 run", () => {
+    expect(rollup(rows, visible).activeDays).toBe(3); // 06-15, 06-14, 06-13
+  });
+  it("unusedSurface = visible commands never invoked", () => {
+    expect(rollup(rows, visible).unusedSurface.sort()).toEqual(["quota", "thinking"]);
+  });
+  it("originSplit counts agent vs tty", () => {
+    const r = rollup(rows, visible);
+    expect(r.originSplit).toEqual({ agent: 3, tty: 1 });
+  });
+  it("reliability flags commands with a nonzero exit-rate", () => {
+    const r = rollup(rows, visible);
+    const recall = r.reliability.find((x) => x.command === "recall");
+    expect(recall?.failureRate).toBeCloseTo(1, 5);
+  });
+  it("empty rows -> empty rollup, all visible commands unused", () => {
+    const r = rollup([], visible);
+    expect(r.topCommands).toEqual([]);
+    expect(r.activeDays).toBe(0);
+    expect(r.unusedSurface.sort()).toEqual([...visible].sort());
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify FAIL.**
+
+- [ ] **Step 3: Implement** `apps/axctl/src/usage/query.ts`:
+
+```typescript
+import { Effect } from "effect";
+import type { DbError } from "@ax/lib/errors";
+import { SurrealClient } from "@ax/lib/db";
+
+export interface InvocationRow {
+  readonly ts: string;       // ISO
+  readonly command: string;
+  readonly origin: "tty" | "agent";
+  readonly exit_code: number;
+}
+
+export interface UsageRollup {
+  readonly windowDays: number;
+  readonly total: number;
+  readonly activeDays: number;
+  readonly topCommands: ReadonlyArray<{ command: string; count: number; last_used: string }>;
+  readonly unusedSurface: ReadonlyArray<string>;
+  readonly originSplit: { agent: number; tty: number };
+  readonly reliability: ReadonlyArray<{ command: string; runs: number; failures: number; failureRate: number }>;
+}
+
+const utcDay = (iso: string): string => iso.slice(0, 10);
+
+/** Pure rollup over decoded rows + the visible-command list (for unusedSurface). */
+export const rollup = (rows: ReadonlyArray<InvocationRow>, visibleCommands: ReadonlyArray<string>, windowDays = 30): UsageRollup => {
+  const byCommand = new Map<string, { count: number; last: string; failures: number }>();
+  const days = new Set<string>();
+  let agent = 0, tty = 0;
+  for (const r of rows) {
+    days.add(utcDay(r.ts));
+    if (r.origin === "tty") tty++; else agent++;
+    const e = byCommand.get(r.command) ?? { count: 0, last: r.ts, failures: 0 };
+    e.count++;
+    if (r.ts > e.last) e.last = r.ts;
+    if (r.exit_code !== 0) e.failures++;
+    byCommand.set(r.command, e);
+  }
+  const topCommands = [...byCommand.entries()]
+    .map(([command, e]) => ({ command, count: e.count, last_used: e.last }))
+    .sort((a, b) => b.count - a.count || (a.command < b.command ? -1 : 1));
+  const invoked = new Set(byCommand.keys());
+  const unusedSurface = visibleCommands.filter((c) => !invoked.has(c));
+  const reliability = [...byCommand.entries()]
+    .map(([command, e]) => ({ command, runs: e.count, failures: e.failures, failureRate: e.failures / e.count }))
+    .filter((x) => x.failures > 0)
+    .sort((a, b) => b.failureRate - a.failureRate);
+  return {
+    windowDays, total: rows.length, activeDays: days.size,
+    topCommands, unusedSurface, originSplit: { agent, tty }, reliability,
+  };
+};
+
+/** Fetch invocation rows within the window from the DB. */
+export const fetchInvocations = (windowDays: number): Effect.Effect<InvocationRow[], DbError, SurrealClient> =>
+  Effect.gen(function* () {
+    const db = yield* SurrealClient;
+    const result = yield* db.query<[InvocationRow[]]>(
+      `SELECT type::string(ts) AS ts, command, origin, exit_code FROM ax_invocation WHERE ts > time::now() - ${Math.max(1, Math.trunc(windowDays))}d;`,
+    );
+    return result?.[0] ?? [];
+  });
+```
+
+> Implementer note: confirm the `db.query` shape + `type::string(ts)` idiom against an existing query (e.g. `apps/axctl/src/queries/thinking-analytics.ts`). `rollup` is pure and fully tested; `fetchInvocations` is the thin DB adapter. The caller supplies `visibleCommands` (Task 7 / the dashboard route) so `query.ts` needs no subprocess.
+
+- [ ] **Step 4: Run test, verify PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/usage/query.ts apps/axctl/src/usage/query.test.ts
+git commit -m "feat(usage): utilization rollups (activity/top/unused/origin/reliability)"
+```
+
+---
+
+## Task 7: `ax usage` CLI + docs + both cli-reference gates
+
+**Files:**
+- Create: `apps/axctl/src/cli/commands/usage.ts`
+- Modify: `apps/axctl/src/cli/index.ts` (register command + runtime)
+- Modify: `README.md` OR `docs/cli.md`; `apps/site/public/llms.txt`; `apps/site/app/routes/docs/-cli-reference.data.ts`
+- Test: `apps/axctl/src/cli/commands/usage.test.ts`
+
+- [ ] **Step 1: Write the failing test** (pure renderer):
+
+```typescript
+// apps/axctl/src/cli/commands/usage.test.ts
+import { describe, expect, it } from "bun:test";
+import { renderUsage } from "./usage.ts";
+import type { UsageRollup } from "../../usage/query.ts";
+
+const roll: UsageRollup = {
+  windowDays: 30, total: 5, activeDays: 3,
+  topCommands: [{ command: "digest", count: 3, last_used: "2026-06-15T11:00:00.000Z" }],
+  unusedSurface: ["quota", "thinking"],
+  originSplit: { agent: 4, tty: 1 },
+  reliability: [],
+};
+
+describe("renderUsage", () => {
+  it("summarizes active days, top command, and unused count", () => {
+    const out = renderUsage(roll);
+    expect(out).toContain("3 active days");
+    expect(out).toContain("digest");
+    expect(out).toContain("2 never used");
+  });
+  it("empty-state line when nothing recorded", () => {
+    const empty: UsageRollup = { ...roll, total: 0, activeDays: 0, topCommands: [], originSplit: { agent: 0, tty: 0 } };
+    expect(renderUsage(empty)).toContain("no usage recorded yet");
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify FAIL.**
+
+- [ ] **Step 3: Implement** `apps/axctl/src/cli/commands/usage.ts`. Mirror `apps/axctl/src/cli/commands/digest.ts` (read it) for the `Command.make` + `RuntimeManifest` + `jsonFlag` pattern. The visible-command list for `unusedSurface` comes from the CLI's own registered subcommands - reuse the existing helper if importable, else derive from `rootCommand`. Simplest: import `visibleSubcommands` is a script (spawns a subprocess) - avoid. Instead read the command names from the same registry the CLI builds. Grep `rootCommand` in `apps/axctl/src/cli/index.ts`; if its subcommand names are exportable, use them; otherwise hardcode-free fallback: pass the `COMMAND_NAMES` from `apps/site/app/routes/docs/-cli-reference.data.ts` (already the curated visible set).
+
+```typescript
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { prettyPrint } from "@ax/lib/json";
+import { COMMAND_NAMES } from "../../../../site/app/routes/docs/-cli-reference.data.ts"; // implementer: verify this relative path resolves; if not, see note
+import { fetchInvocations, rollup, type UsageRollup } from "../../usage/query.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { jsonFlag } from "./shared.ts";
+
+export const renderUsage = (r: UsageRollup): string => {
+  if (r.total === 0) return "[ax] no usage recorded yet - run some ax commands, then ingest.";
+  const top = r.topCommands.slice(0, 8).map((c) => `  ${c.command.padEnd(22)} ${String(c.count).padStart(5)}`).join("\n");
+  return [
+    `[ax] usage (${r.windowDays}d): ${r.total} runs across ${r.activeDays} active days  (agent ${r.originSplit.agent} / tty ${r.originSplit.tty})`,
+    "top commands:", top,
+    `${r.unusedSurface.length} never used: ${r.unusedSurface.slice(0, 12).join(", ")}`,
+  ].join("\n");
+};
+
+const cmdUsage = (input: { json: boolean; days: number }) =>
+  Effect.gen(function* () {
+    const rows = yield* fetchInvocations(input.days);
+    const r = rollup(rows, COMMAND_NAMES, input.days);
+    console.log(input.json ? prettyPrint(r) : renderUsage(r));
+  });
+
+export const usageCommand = Command.make(
+  "usage",
+  { json: jsonFlag, days: Flag.integer("days").pipe(Flag.withDefault(30)) },
+  ({ json, days }) => cmdUsage({ json, days }),
+).pipe(
+  Command.withDescription(
+    "Your ax utilization: commands/day, active days, top commands, agent-vs-tty split, and the never-used surface. --json  --days=N (default 30)",
+  ),
+);
+
+export const usageRuntime: RuntimeManifest = { usage: { runtime: "db", hidden: false } };
+```
+
+> Implementer note: the cross-package import of `COMMAND_NAMES` from the site app may not resolve cleanly from axctl (different workspace). If it doesn't typecheck, the cleanest fix is to add a tiny exported `VISIBLE_COMMANDS` array in `apps/axctl/src/cli/` (or export the names the CLI already registers) and use that as the single source - then also have `-cli-reference.data.ts` / the freshness checks consume it if practical. Do NOT spawn `ax help` from inside a command. Keep `renderUsage` pure + tested regardless of where the command list comes from.
+
+- [ ] **Step 4: Register** in `apps/axctl/src/cli/index.ts`: import `{ usageCommand, usageRuntime }`, add `...usageRuntime` to the runtime spread, add `usageCommand` to the subcommand list (mirror how `digestCommand` was added - grep `digestCommand` / `digestRuntime`).
+
+- [ ] **Step 5: Document `ax usage` in BOTH cli-reference gates + the human docs** (this is the #414 lesson - there are TWO gates):
+  1. `docs/cli.md` - add an `## Utilization` section describing `ax usage [--json] [--days=N]`.
+  2. `apps/site/public/llms.txt` - add a `- \`ax usage\` - ...` line near the cost/analytics block.
+  3. `apps/site/app/routes/docs/-cli-reference.data.ts` - add a `usage` card to a group (mirror the `digest` card that already exists there: `name`, `job`, `signature: "ax usage [--json] [--days=N]"`, `flags`, `receipt`, `detail`; no "axctl" in copy; no `/Users/` paths).
+
+- [ ] **Step 6: Verify both gates + tests**
+
+Run: `bun test apps/axctl/src/cli/commands/usage.test.ts` → PASS.
+Run: `bun scripts/check-cli-reference.ts` → covers `ax usage`.
+Run: `bun test scripts/check-site-cli-reference.test.ts` → PASS (usage card present).
+Run: `bun run typecheck 2>&1 | rg -c "error TS"` → 0.
+Run: `bun run apps/axctl/src/cli/index.ts usage --help` → shows the command.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/axctl/src/cli/commands/usage.ts apps/axctl/src/cli/commands/usage.test.ts apps/axctl/src/cli/index.ts docs/cli.md apps/site/public/llms.txt apps/site/app/routes/docs/-cli-reference.data.ts
+git commit -m "feat(usage): ax usage CLI + docs + both cli-reference gates"
+```
+
+---
+
+## Task 8: Dashboard `/api/usage` route (functional-minimal)
+
+**Files:**
+- Modify/Create: a route under `apps/axctl/src/dashboard/router/routes/` + contract under `apps/axctl/src/dashboard/contract/` (mirror an existing read route, e.g. `insights.ts` / `system.ts`)
+- Test: alongside the route (mirror `*.test.ts` siblings)
+
+> Scope per spec's Visual scope note: this task ships the BACKEND route returning the rollup JSON + a MINIMAL studio view. Do NOT invest in heavy visual design - correct data + restrained layout only; the visual pass is deferred for the user's review.
+
+- [ ] **Step 1: Read an existing read-only route + its test** - `apps/axctl/src/dashboard/router/routes/system.ts` + `system.test.ts` and `apps/axctl/src/dashboard/contract/insights.ts` to learn the route/contract registration pattern (how a GET handler is declared, how it runs a query with the DB layer, how it's tested).
+
+- [ ] **Step 2: Write the failing test** for the route handler - assert `GET /api/usage` returns the rollup shape (status 200, JSON has `activeDays`, `topCommands`, `unusedSurface`, `originSplit`). Mirror the exact test harness the sibling route tests use (they construct the handler and invoke it without a live server). Use a seeded/fake DB layer the same way the sibling tests do.
+
+- [ ] **Step 3: Implement the handler** - a GET that runs `fetchInvocations` + `rollup` (reuse Task 6; supply the visible-command list the same way Task 7 did) and returns the `UsageRollup` as JSON. Register it in the route table next to the other `/api/*` reads. Keep it read-only.
+
+- [ ] **Step 4: Minimal studio view** - if the studio SPA (`apps/studio` per CLAUDE.md / the stage-studio build) has a simple pattern for adding a tab/route that fetches a JSON endpoint and renders tiles, add a "Utilization" view that fetches `/api/usage` and renders: active-days + total, a top-commands list, and the never-used chips. Restrained layout, no bespoke visuals. If wiring a new studio route is non-trivial or risks the build, STOP and report DONE_WITH_CONCERNS - the backend route + `ax usage` already expose the data, and the visual is explicitly deferred for review.
+
+- [ ] **Step 5: Verify**
+
+Run: `bun test <the new route test>` → PASS.
+Run: `bun run typecheck 2>&1 | rg -c "error TS"` → 0.
+Run (if studio touched): `bunx turbo run build --filter=@ax/site 2>&1 | tail -5` OR the stage-studio script - confirm the build still succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/axctl/src/dashboard/ apps/studio/ 2>/dev/null
+git commit -m "feat(usage): /api/usage dashboard route + minimal utilization view"
+```
+
+---
+
+## Task 9: Full verification + spec checklist
+
+- [ ] **Step 1: e2e** - real invocation → ingest → query:
+```bash
+rm -f ~/.ax/usage-log.jsonl
+bun run apps/axctl/src/cli/index.ts version >/dev/null 2>&1
+bun run apps/axctl/src/cli/index.ts digest --json >/dev/null 2>&1 || true
+bun run apps/axctl/src/cli/index.ts ingest --stages=usage 2>&1 | tail -2
+bun run apps/axctl/src/cli/index.ts usage --days=1
+```
+Expected: `ax usage` prints a board with the just-run commands, an active-day, and a never-used list. Paste the output.
+
+- [ ] **Step 2: Full gates**
+```bash
+bun test 2>&1 | tail -6
+bun run typecheck 2>&1 | rg -c "error TS"
+bun scripts/check-cli-reference.ts 2>&1 | tail -1
+```
+Expected: tests pass (only pre-existing DB-dependent failures, if any - confirm none are usage-related); 0 typecheck errors; cli-reference covers `ax usage`.
+
+- [ ] **Step 3: Tick the spec checklist** in `docs/superpowers/specs/2026-06-15-usage-telemetry-design.md` (`[ ]` → `[x]`), commit.
+
+```bash
+git add docs/superpowers/specs/2026-06-15-usage-telemetry-design.md
+git commit -m "chore(usage): e2e verification + tick spec checklist"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** schema (T1), model/JSONL (T2), redaction+capture (T3+T4), stage+truncate+isolation (T5), rollups (T6), CLI+docs+gates (T7), dashboard route+minimal view (T8), e2e (T9). All spec sections mapped.
+- **Privacy:** redaction is pure + heavily tested in T3 (no positional values, flag names only, basename-only repo_key). The "no /Users path, no positional value survives" assertion is the safety net.
+- **Isolation:** the usage stage mirrors the digest stage's `Effect.catchCause` so a telemetry fault never aborts ingest (T5).
+- **CI gotchas carried from #414:** BOTH cli-reference gates + the `effect-cli.test.ts` stage count are updated in-plan (T5 + T7) - the exact things that failed #414's CI.
+- **Known implementer judgment calls (flagged, not placeholders):** the visible-command source for `unusedSurface` (T7 note - prefer a single exported list over a cross-package import or subprocess); the studio view depth (T8 - explicitly minimal, may report DONE_WITH_CONCERNS); `Effect.onExit` exact API (T4 note - fallback given).

--- a/docs/superpowers/specs/2026-06-15-usage-telemetry-design.md
+++ b/docs/superpowers/specs/2026-06-15-usage-telemetry-design.md
@@ -1,0 +1,117 @@
+# Fix #1a - Self-Telemetry + Personal Utilization View
+
+**Date:** 2026-06-15
+**Branch:** `feat/usage-telemetry`
+**Parent diagnosis:** `docs/superpowers/specs/2026-06-15-team-adoption-diagnosis.md`
+
+## Problem
+
+ax cannot see its own adoption (diagnosis Finding 1). It measures *agent transcripts* but never *whether ax itself is run* - the only way to see usage was mining Bash `tool_call` rows, which misses direct-terminal (human) invocations entirely. A team buyer's first question - "are my devs using it?" - has no answer surface.
+
+This is **Fix #1**, scoped to its foundational half: **self-telemetry capture + a personal utilization view**. The team aggregate (the buyer's multi-user surface) is a follow-up spec that publishes from the `ax_invocation` table this one creates.
+
+## Goal
+
+ax records its own CLI invocations (redacted) into the graph, and surfaces "what you actually run" - commands/day, active-days, top commands, agent-vs-human split, and the never-used surface - in `ax serve` plus a thin `ax usage --json`.
+
+## Constraint
+
+Every `ax` command must stay fast and DB-free at the call site (`ax --help`, `ax quota`, `ax serve`). So **capture** (every invocation, cheap, local file append) is split from **graph** (batch parse into the DB on the next ingest) - the same compute/surface seam as the push-value digest.
+
+## Architecture
+
+```
+apps/axctl/src/usage/
+  model.ts        - UsageRecord (Effect Schema) + JSONL line parse/encode
+  record.ts       - redact + append one JSONL line to ~/.ax/usage-log.jsonl (fail-silent)
+  usage-stage.ts  - derive-tagged ingest stage: parse log → ax_invocation rows, truncate consumed log
+  query.ts        - utilization rollups (pure over decoded rows + CLI registry)
+apps/axctl/src/cli/commands/usage.ts          - thin `ax usage [--json] [--days=N]`
+apps/axctl/src/dashboard/router/routes/...     - read-only "Utilization" route serving query.ts
+apps/studio/...                                - Utilization SPA view
+packages/schema/src/schema.surql               - ax_invocation table DDL (+ SCHEMA_TABLES)
+```
+
+**Capture (cheap, no DB):** the CLI entrypoint (`apps/axctl/src/cli/index.ts`, around `BunRuntime.runMain`) stamps start, and on fiber completion appends one redacted line - subcommand, flag *names*, exit code, duration_ms, repo_key, origin, ax_version, ts. Pure file append, fail-silent: a recorder error never breaks or slows the command.
+
+**Graph (batch):** a `derive`-tagged ingest stage parses `~/.ax/usage-log.jsonl` into `ax_invocation` on the next ingest (the watcher runs after every session), then truncates the consumed lines. Failure-isolated via `Effect.catchCause` so a parse error never aborts the surrounding ingest (lesson from the digest stage).
+
+**Surface:** `query.ts` rollups feed both the `ax serve` Utilization route and `ax usage --json`. No heavy new CLI surface - respects the Fix #3 anti-sprawl goal; `ax usage` is also the exact payload the future team-publish gists.
+
+## Data model & redaction
+
+`UsageRecord` (Effect Schema; one JSONL line per invocation):
+```
+ts          Date              invocation start
+command     string            resolved subcommand path: "sessions churn" | "digest" | "ingest"
+flags       string[]          flag NAMES only, sorted: ["--here","--json"]  (never values)
+exit_code   number            0 = ok
+duration_ms number
+origin      "tty" | "agent"   process.stderr.isTTY ? "tty" : "agent"
+repo_key    string | null     basename(git toplevel), lowercased; null outside a repo
+ax_version  string
+```
+
+**Redaction (at `record.ts`, before anything hits disk):**
+- Drop ALL positional args (`sessions show <id>`, `recall "<query>"` → `command` + `flags` only).
+- Drop flag *values* (`--days=30` → `"--days"`, `--project=/Users/...` → `"--project"`).
+- `repo_key` = `basename` only - never the absolute path; null when not in a git repo.
+- No env, no cwd beyond repo_key, no usernames, no positional values.
+
+A row says *"someone ran `sessions churn --here` from repo `ax`, 1.2s, exit 0, from an agent"* - enough for utilization, nothing sensitive. This redacted shape IS what the future team-publish aggregates, so the privacy boundary is set once, here.
+
+`ax_invocation` table (SCHEMAFULL): top-level fields explicit; `flags` JSON-encoded as `string` (v3 rule); `ts` as JS `Date`. Record id = stable hash of (ts, command, repo_key, origin) so re-parsing a not-yet-truncated log is idempotent. Registered in `SCHEMA_TABLES`.
+
+## Utilization rollups (`query.ts`, pure, default 30d window)
+
+- **`activity`** - invocations/day series + active-days count (days with ≥1 run) + current streak.
+- **`topCommands`** - count + last-used per command, descending.
+- **`unusedSurface`** - every visible subcommand (from the CLI registry, same source the cli-reference freshness gate reads) minus ever-invoked commands → commands never run. Finding 2 made measurable.
+- **`originSplit`** - agent vs tty counts + per-command %.
+- **`reliability`** - exit-code≠0 rate per command (only flagged above a threshold).
+
+Each is a pure function over decoded rows (+ the registry for `unusedSurface`), unit-testable with fixture rows, no DB.
+
+## Surfaces
+
+**`ax serve` "Utilization" route** (read-only; serves `query.ts` JSON, SPA renders):
+- Hero: active-days/window + invocations/day sparkline + streak.
+- Top-commands list with last-used + inline origin split.
+- "Never used" chips (unused surface) as a discovery nudge.
+- Reliability flags only when a command's failure rate is non-trivial.
+
+> **Visual scope note:** the v0 studio view is **functional-but-minimal** - correct data, restrained layout, NOT a finished visual. The data path + backend `/api/usage` route is the substance; the visual treatment is deliberately left for a taste pass after review (avoids over-investing in a design that may be redirected, per the radar/wrapped house style). The backend route + `ax usage --json` fully expose the data regardless of the view's polish.
+
+**`ax usage [--json] [--days=N]`** - thin command: `--json` prints the rollup bundle (the future team-publish payload); plain TTY prints a compact summary. Registered with a card in BOTH cli-reference gates (`scripts/check-cli-reference.ts` docs + `apps/site/app/routes/docs/-cli-reference.data.ts`), and in README/docs/cli.md + llms.txt.
+
+## Error handling
+
+- **Recorder** (`record.ts`): wrapped so ANY fault (fs error, no HOME, git not installed) is swallowed - the invocation proceeds and exits normally. Never adds latency on the hot path beyond a single append; if the append would block, skip it.
+- **Stage** (`usage-stage.ts`): `Effect.catchCause` → logs a warning, returns a zero-row stat; a corrupt log line is skipped (parse-or-skip per line), not fatal. Truncation only removes lines successfully parsed + written.
+- **Log growth:** the stage truncates consumed lines each ingest; between ingests the log is bounded by invocation volume. A safety cap (e.g. skip-append above N MB) prevents unbounded growth if ingest never runs.
+- **Query/view:** empty table → empty-state ("no usage recorded yet - run some ax commands"), never an error.
+
+## Testing (bun:test, layer-testable)
+
+- `model.test.ts` - UsageRecord encode/decode round-trip; JSONL parse skips malformed lines.
+- `record.test.ts` - redaction: positional args dropped, flag values stripped to names, repo_key is basename-only, origin from injected isTTY; append is fail-silent on a stubbed failing fs.
+- `usage-stage.test.ts` - parse fixture log → rows; idempotent re-parse (stable id); truncation; failure-isolation (failing DB layer → Success with 0 rows).
+- `query.test.ts` - each rollup against fixture rows: active-days, streak, top-commands ordering, unusedSurface against a fixture registry, origin split, reliability threshold.
+- `usage.test.ts` - `ax usage` renderer (pure) + `--json` shape.
+- Stage registered: `resolveIngestStages` default count +1, `usage`-stage in the derive set (update `effect-cli.test.ts`).
+- Both cli-reference gates updated for `ax usage`.
+
+## Out of scope (next spec)
+
+- **Team aggregation + buyer dashboard** - multi-user rollup. Publishes from `ax_invocation` via the community-rails pattern (gist → nightly compile → board). This spec deliberately ends at the single-user table + view that the team layer will consume.
+- Wiring utilization into the digest/front-door (Fix #2/#3 follow-up).
+
+## Status
+
+- [ ] schema: ax_invocation + SCHEMA_TABLES
+- [ ] model.ts + JSONL parse
+- [ ] record.ts (redact + append, fail-silent) + entrypoint wiring
+- [ ] usage-stage.ts (parse → rows, truncate, isolated) + registry
+- [ ] query.ts rollups
+- [ ] ax usage CLI (+ both cli-reference gates, docs)
+- [ ] dashboard Utilization route + studio view

--- a/docs/superpowers/specs/2026-06-15-usage-telemetry-design.md
+++ b/docs/superpowers/specs/2026-06-15-usage-telemetry-design.md
@@ -43,7 +43,10 @@ packages/schema/src/schema.surql               - ax_invocation table DDL (+ SCHE
 `UsageRecord` (Effect Schema; one JSONL line per invocation):
 ```
 ts          Date              invocation start
-command     string            resolved subcommand path: "sessions churn" | "digest" | "ingest"
+command     string            TOP-LEVEL subcommand only: "sessions" | "digest" | "ingest"
+                              (v0 records the top-level command, NOT the two-word path -
+                               see Redaction note; two-word granularity is a deferred
+                               enhancement needing a registry-derived subverb allowlist)
 flags       string[]          flag NAMES only, sorted: ["--here","--json"]  (never values)
 exit_code   number            0 = ok
 duration_ms number
@@ -53,7 +56,7 @@ ax_version  string
 ```
 
 **Redaction (at `record.ts`, before anything hits disk):**
-- Drop ALL positional args (`sessions show <id>`, `recall "<query>"` → `command` + `flags` only).
+- Drop ALL positional args including the second positional - `command` is the validated TOP-LEVEL subcommand only (`sessions show <id>` → `"sessions"`, `recall "<query>"` → `"recall"`). A non-command head → `"(unknown)"`. (Capturing the second positional would leak user-controllable branch/skill/slug names for some groups; top-level is the safe, zero-maintenance surface - and it's what the external team-publish will aggregate.)
 - Drop flag *values* (`--days=30` → `"--days"`, `--project=/Users/...` → `"--project"`).
 - `repo_key` = `basename` only - never the absolute path; null when not in a git repo.
 - No env, no cwd beyond repo_key, no usernames, no positional values.

--- a/docs/superpowers/specs/2026-06-15-usage-telemetry-design.md
+++ b/docs/superpowers/specs/2026-06-15-usage-telemetry-design.md
@@ -108,10 +108,10 @@ Each is a pure function over decoded rows (+ the registry for `unusedSurface`), 
 
 ## Status
 
-- [ ] schema: ax_invocation + SCHEMA_TABLES
-- [ ] model.ts + JSONL parse
-- [ ] record.ts (redact + append, fail-silent) + entrypoint wiring
-- [ ] usage-stage.ts (parse → rows, truncate, isolated) + registry
-- [ ] query.ts rollups
-- [ ] ax usage CLI (+ both cli-reference gates, docs)
-- [ ] dashboard Utilization route + studio view
+- [x] schema: ax_invocation + SCHEMA_TABLES
+- [x] model.ts + JSONL parse
+- [x] record.ts (redact + append, fail-silent) + entrypoint wiring
+- [x] usage-stage.ts (parse → rows, truncate, isolated) + registry
+- [x] query.ts rollups
+- [x] ax usage CLI (+ both cli-reference gates, docs)
+- [x] dashboard Utilization route + studio view

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -843,6 +843,57 @@ export const ImproveGroup = HttpApiGroup.make("improve")
         }),
     );
 
+// ---- usage rollup payload ------------------------------------------------
+
+/** Command utilization entry in a UsageRollup response. */
+export const TopCommandEntry = Schema.Struct({
+    command: Schema.String,
+    count: Schema.Number,
+    last_used: Schema.String,
+});
+
+/** Per-command failure entry in a UsageRollup response. */
+export const ReliabilityEntry = Schema.Struct({
+    command: Schema.String,
+    runs: Schema.Number,
+    failures: Schema.Number,
+    failureRate: Schema.Number,
+});
+
+/**
+ * CLI utilization rollup: how the user's ax surface is actually being used.
+ * Returned by GET /api/usage. Mirrors the `UsageRollup` type in
+ * apps/axctl/src/usage/query.ts (single source of truth for computation;
+ * this schema is the contract encoding for the HTTP surface).
+ */
+export const UsageRollupSchema = Schema.Struct({
+    windowDays: Schema.Number,
+    total: Schema.Number,
+    activeDays: Schema.Number,
+    topCommands: Schema.Array(TopCommandEntry),
+    unusedSurface: Schema.Array(Schema.String),
+    originSplit: Schema.Struct({ agent: Schema.Number, tty: Schema.Number }),
+    reliability: Schema.Array(ReliabilityEntry),
+});
+
+/** Studio-facing type derived from the contract. */
+export type UsageRollupSchema = typeof UsageRollupSchema.Type;
+
+/**
+ * The usage family: CLI utilization rollup (active days, top commands,
+ * unused surface, origin split, reliability).
+ */
+export const UsageGroup = HttpApiGroup.make("usage")
+    .add(
+        HttpApiEndpoint.get("usageRollup", "/api/usage", {
+            query: {
+                days: Schema.optionalKey(Schema.Number),
+            },
+            success: UsageRollupSchema,
+            error: InternalError,
+        }),
+    );
+
 /** POST /api/ingest - trigger a live ingest run (Durable Streams sidecar). */
 export class IngestTriggerResult extends Schema.Class<IngestTriggerResult>("ax/IngestTriggerResult")({
     runId: Schema.String,
@@ -874,6 +925,7 @@ export const AxApi = HttpApi.make("ax")
     .add(SessionsGroup)
     .add(SkillsGroup)
     .add(ImproveGroup)
+    .add(UsageGroup)
     .add(LiveGroup)
     .annotate(OpenApi.Title, "ax daemon API")
     .annotate(OpenApi.Version, "1");

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1529,6 +1529,21 @@ DEFINE INDEX IF NOT EXISTS hook_command_invocation_by_status  ON hook_command_in
 DEFINE INDEX IF NOT EXISTS hook_command_invocation_by_effect  ON hook_command_invocation FIELDS effect;
 
 -- ---------------------------------------------------------------------------
+-- ax's own CLI invocations (redacted) for self-telemetry / utilization.
+-- ---------------------------------------------------------------------------
+DEFINE TABLE ax_invocation SCHEMAFULL;
+DEFINE FIELD ts          ON ax_invocation TYPE datetime;
+DEFINE FIELD command     ON ax_invocation TYPE string;
+DEFINE FIELD flags       ON ax_invocation TYPE string;
+DEFINE FIELD exit_code   ON ax_invocation TYPE int;
+DEFINE FIELD duration_ms ON ax_invocation TYPE int;
+DEFINE FIELD origin      ON ax_invocation TYPE string;
+DEFINE FIELD repo_key    ON ax_invocation TYPE option<string>;
+DEFINE FIELD ax_version  ON ax_invocation TYPE string;
+DEFINE INDEX IF NOT EXISTS ax_invocation_by_ts      ON ax_invocation FIELDS ts;
+DEFINE INDEX IF NOT EXISTS ax_invocation_by_command ON ax_invocation FIELDS command, ts;
+
+-- ---------------------------------------------------------------------------
 -- Generic feedback case definitions and deterministic backtest results.
 -- Case types encode "what behavior should follow this evidence?" without
 -- creating hook-specific tables. Results are per evidence item/run.


### PR DESCRIPTION
## Why

ax can't see its own adoption (diagnosis Finding 1): it measures *agent transcripts* but never *whether ax itself is run* — the only signal was mining Bash `tool_call` rows, which misses direct-terminal (human) use entirely. A team buyer's first question — "are my devs using it?" — had no answer surface.

This is **Fix #1a** (the foundational half of Fix #1): self-telemetry capture + a personal utilization view. The **team aggregate** (the buyer's multi-user surface) is a follow-up spec that publishes from the `ax_invocation` table this PR creates.

Specs: `docs/superpowers/specs/2026-06-15-team-adoption-diagnosis.md` + `2026-06-15-usage-telemetry-design.md`.

## What

Same compute/surface seam as the digest (#414): cheap local capture, batch graph ingest.

- **Capture (no DB, fail-silent):** the CLI entrypoint appends one **redacted** JSONL line per invocation to `~/.ax/usage-log.jsonl` via `Effect.onExit` — records exactly once, never alters the program's exit code.
- **Redaction (privacy-first):** only the validated **top-level subcommand** + **flag names** + exit/duration/origin/`repo_key` (basename only) + version. No positional values, no flag values, no absolute paths. Heavily tested incl. adversarial cases (`--` end-of-options escape, path-shaped positionals).
- **Graph:** a `derive`-tagged `usage` ingest stage parses the log into `ax_invocation` (idempotent UPSERT on a stable key), truncates the consumed log, and is failure-isolated via `Effect.catchCause` — a telemetry fault never aborts ingest.
- **Surface:** pure `rollup` (active-days, top commands, **never-used surface**, agent-vs-tty split, reliability) powers `ax usage [--json] [--days=N]` + a read-only `/api/usage` contract route + a minimal studio `/usage` view.

## Proven end-to-end

```
$ ax usage --days=1
[ax] usage (1d): 9 runs across 1 active days  (agent 9 / tty 0)
top commands:
  ingest                     5
  digest                     2
  sessions                   1
  version                    1
23 never used: cost, routing, profile, thinking, quota, ...
```
Redacted log verified (no paths, no `=values`); the background watcher consumes the log in the real reactive loop.

## Review notes (for @necmttn)

- **Privacy decision:** v0 records the **top-level command only** (not `"sessions show"`). A holistic review caught that capturing the 2nd positional leaks user-controllable branch/skill names, and that two-word commands broke the never-used surface (mismatched the top-level command set). Top-level is privacy-bulletproof + zero-maintenance; two-word granularity is a deferred enhancement (needs a registry-derived subverb allowlist). Flagged in the spec.
- **Visual scope:** the studio `/usage` view is intentionally **functional-but-minimal** (URL-accessible, no nav tab) — the data path + `ax usage`/`/api/usage` are the substance; the visual treatment is left for your taste pass.

## Test plan

- [x] Per-unit tests (model/record-redaction/stage/query/CLI/contract) + drift gate for the command list
- [x] Privacy: adversarial redaction tests (no positional/flag value, no path reaches disk) + an injection test against the live DB (escaped, non-exploitable)
- [x] Stage failure-isolation + idempotent re-ingest (re-parse → no dup rows)
- [x] Both cli-reference gates + `effect-cli` stage count updated (the #414 CI lesson)
- [x] `bun test` repo-wide 4208 pass / 0 feature-related failures · `typecheck` 0 · studio build exit 0
- [ ] CI green against current origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)