### PR TITLE
feat: spar analytics-exclusion tag (behavioral-only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ docs/superpowers/specs/2026-06-13-ax-dojo-design.md.
 `ax dojo report [--since=<iso>] [--notes-file=<path>]` writes the morning-report
 for a completed run; `ax dojo draft [--title=...] [--kind=bug|improvement]`
 stages an upstream finding to `~/.ax/dojo/outbox/` (never publishes);
-`ax dojo outbox` inspects staged drafts. `ax dojo spar-plan <sha>` freezes a landed task's baseline (prompt + cost/turns/churn) and emits a brief with the worktree pin command + a delta slot; the agent runs the variant with ONE change in that worktree; `ax dojo spar-score <id>` scores variant vs baseline into a receipt (`~/.ax/dojo/spar/`). Hybrid: CLI scaffolds, agent re-runs.
+`ax dojo outbox` inspects staged drafts. `ax dojo spar-plan <sha>` freezes a landed task's baseline (prompt + cost/turns/churn) and emits a brief with the worktree pin command + a delta slot; the agent runs the variant with ONE change in that worktree; `ax dojo spar-score <id>` scores variant vs baseline into a receipt (`~/.ax/dojo/spar/`). Hybrid: CLI scaffolds, agent re-runs. **Spar exclusion**: spar-score stamps the variant session `labels=["spar"]` so it is excluded from behavioral analytics (`ax skills weighted`, `ax thinking`); it stays in cost analytics.
 
 ### Profile
 

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -427,7 +427,7 @@ const sparScoreCommand = Command.make(
             // analytics (ax skills weighted, ax thinking) can exclude it.
             // Idempotent and non-fatal: if the stamp fails, scoring still writes
             // the receipt (the label is best-effort telemetry).
-            yield* stampSparSession(variantId).pipe(Effect.orElse(() => Effect.void));
+            yield* stampSparSession(variantId).pipe(Effect.catch(() => Effect.void));
 
             const variant = yield* fetchSessionMetrics(variantId, new Date(brief.createdAt));
             const score = { ...scoreSpar(brief.baseline, variant), id, variantSession: variantId };

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -41,6 +41,7 @@ import {
     renderSparBrief,
     renderSparReport,
     scoreSpar,
+    stampSparSession,
 } from "../../dojo/spar.ts";
 import { resolvePwdRepository } from "../../pwd.ts";
 import { defaultQuotaCachePath } from "../../quota/cache.ts";
@@ -421,6 +422,12 @@ const sparScoreCommand = Command.make(
                 );
                 return yield* Effect.sync(() => process.exit(1));
             }
+
+            // Stamp the variant session's labels with "spar" so behavioral
+            // analytics (ax skills weighted, ax thinking) can exclude it.
+            // Idempotent and non-fatal: if the stamp fails, scoring still writes
+            // the receipt (the label is best-effort telemetry).
+            yield* stampSparSession(variantId).pipe(Effect.orElse(() => Effect.void));
 
             const variant = yield* fetchSessionMetrics(variantId, new Date(brief.createdAt));
             const score = { ...scoreSpar(brief.baseline, variant), id, variantSession: variantId };

--- a/apps/axctl/src/dashboard/skills-weighted.test.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.test.ts
@@ -5,6 +5,16 @@
  * - The invocation query includes/omits a WHERE window clause.
  * - Rows are merged correctly (role weights summed, floor 1.0).
  * - Doctor count and advice trigger at the threshold.
+ * - Spar sessions are excluded from the weighted ranking.
+ *
+ * Query order (call index):
+ *   0 → fetchSparSessionIds (spar exclusion ids)
+ *   1 → invocation aggregate (pass 1)
+ *   2 → role weights (pass 2)
+ *   3 → doctor query
+ *   4 → deleted skill ids
+ *   5 → synthetic skill ids
+ *   6 → skill names
  */
 import { describe, it, expect } from "bun:test";
 import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
@@ -13,6 +23,9 @@ import { fetchSkillsWeighted } from "./skills-weighted.ts";
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
+
+/** Empty spar-session result - prepend to every positional response list. */
+const noSparSessions = [[]];
 
 // invocation response (pass 1)
 const mockInvRows = [
@@ -44,7 +57,7 @@ const mockDoctorAbove = [[{ n: 7 }]];
 
 describe("fetchSkillsWeighted", () => {
     it("returns rows sorted by score DESC", async () => {
-        const db = makeMockDb([mockInvRows, mockRoleRows, mockDoctorBelow]);
+        const db = makeMockDb([noSparSessions, mockInvRows, mockRoleRows, mockDoctorBelow]);
         const result = await runWithMock(db, fetchSkillsWeighted());
 
         // tdd: 124 × 2.0 = 248, caveman: 87 × 1.0 = 87, worktree: 62 × 1.0 = 62
@@ -57,7 +70,7 @@ describe("fetchSkillsWeighted", () => {
     });
 
     it("sums role weights for multi-role skills", async () => {
-        const db = makeMockDb([mockInvRows, mockRoleRows, mockDoctorBelow]);
+        const db = makeMockDb([noSparSessions, mockInvRows, mockRoleRows, mockDoctorBelow]);
         const result = await runWithMock(db, fetchSkillsWeighted());
 
         const tdd = result.rows.find((r) => r.skill_name === "superpowers:tdd")!;
@@ -66,7 +79,7 @@ describe("fetchSkillsWeighted", () => {
     });
 
     it("gives unclassified skills weight 1.0", async () => {
-        const db = makeMockDb([mockInvRows, mockRoleRows, mockDoctorBelow]);
+        const db = makeMockDb([noSparSessions, mockInvRows, mockRoleRows, mockDoctorBelow]);
         const result = await runWithMock(db, fetchSkillsWeighted());
 
         const worktree = result.rows.find((r) => r.skill_name === "worktree-read-strategy")!;
@@ -75,14 +88,14 @@ describe("fetchSkillsWeighted", () => {
     });
 
     it("respects limit param", async () => {
-        const db = makeMockDb([mockInvRows, mockRoleRows, mockDoctorBelow]);
+        const db = makeMockDb([noSparSessions, mockInvRows, mockRoleRows, mockDoctorBelow]);
         const result = await runWithMock(db, fetchSkillsWeighted({ limit: 2 }));
         expect(result.rows.length).toBe(2);
     });
 
     // -----------------------------------------------------------------------
     // Provider-tool exclusion + name map (query order:
-    // 0 inv, 1 role, 2 doctor, 3 deleted, 4 synthetic, 5 names)
+    // 0 spar, 1 inv, 2 role, 3 doctor, 4 deleted, 5 synthetic, 6 names)
     // -----------------------------------------------------------------------
 
     // inv rows: a real skill + a synthetic codex tool that would otherwise rank #1
@@ -102,7 +115,7 @@ describe("fetchSkillsWeighted", () => {
 
     it("excludes synthetic provider tools by default and uses the name field", async () => {
         const db = makeMockDb([
-            invWithTool, mockRoleRows, mockDoctorBelow, [[]], synthIds, nameRows,
+            noSparSessions, invWithTool, mockRoleRows, mockDoctorBelow, [[]], synthIds, nameRows,
         ]);
         const result = await runWithMock(db, fetchSkillsWeighted());
 
@@ -112,48 +125,50 @@ describe("fetchSkillsWeighted", () => {
 
     it("includeTools=true keeps tools and drops the synthetic doctor clause", async () => {
         const db = makeMockDb([
-            invWithTool, mockRoleRows, mockDoctorBelow, [[]], synthIds, nameRows,
+            noSparSessions, invWithTool, mockRoleRows, mockDoctorBelow, [[]], synthIds, nameRows,
         ]);
 
         const result = await runWithMock(db, fetchSkillsWeighted({ includeTools: true }));
 
         // Tool is ranked (and named) when opted in.
         expect(result.rows[0]!.skill_name).toBe("codex:exec_command");
-        // Doctor SQL (index 2) must NOT exclude synthetics when includeTools.
-        expect(db.captured[2]).not.toContain('dir_path = "(synthetic)"');
+        // Doctor SQL (index 3) must NOT exclude synthetics when includeTools.
+        expect(db.captured[3]).not.toContain('dir_path = "(synthetic)"');
     });
 
     it("doctor SQL excludes synthetics by default", async () => {
         const db = makeMockDb();
 
         await runWithMock(db, fetchSkillsWeighted());
-        expect(db.captured[2]).toContain('dir_path = "(synthetic)"');
+        // Doctor query is at index 3 (after spar query at 0, inv at 1, role at 2)
+        expect(db.captured[3]).toContain('dir_path = "(synthetic)"');
     });
 
     it("includes window clause when windowDays is set", async () => {
         const db = makeMockDb();
 
         await runWithMock(db, fetchSkillsWeighted({ windowDays: 30 }));
-        // First SQL is the invocation query
-        expect(db.captured[0]).toContain("ts >= time::now() - 30d");
+        // Invocation query is at index 1 (after spar query at 0)
+        expect(db.captured[1]).toContain("ts >= time::now() - 30d");
     });
 
     it("omits window clause when windowDays is not set", async () => {
         const db = makeMockDb();
 
         await runWithMock(db, fetchSkillsWeighted());
-        expect(db.captured[0]).not.toContain("ts >= time::now()");
+        // Invocation query at index 1 must not have a time window
+        expect(db.captured[1]).not.toContain("ts >= time::now()");
     });
 
     it("doctor: no advice when count < threshold", async () => {
-        const db = makeMockDb([mockInvRows, mockRoleRows, mockDoctorBelow]);
+        const db = makeMockDb([noSparSessions, mockInvRows, mockRoleRows, mockDoctorBelow]);
         const result = await runWithMock(db, fetchSkillsWeighted({ doctorThreshold: 5 }));
         expect(result.doctor.advice).toBeNull();
         expect(result.doctor.unclassified_count).toBe(3);
     });
 
     it("doctor: advice present when count >= threshold", async () => {
-        const db = makeMockDb([mockInvRows, mockRoleRows, mockDoctorAbove]);
+        const db = makeMockDb([noSparSessions, mockInvRows, mockRoleRows, mockDoctorAbove]);
         const result = await runWithMock(db, fetchSkillsWeighted({ doctorThreshold: 5 }));
         expect(result.doctor.advice).not.toBeNull();
         expect(result.doctor.advice).toContain("axctl skills classify");
@@ -161,10 +176,42 @@ describe("fetchSkillsWeighted", () => {
     });
 
     it("handles empty invocation result gracefully", async () => {
-        const db = makeMockDb([[[]], [[]], [[{ n: 0 }]]]);
+        const db = makeMockDb([noSparSessions, [[]], [[]], [[{ n: 0 }]]]);
         const result = await runWithMock(db, fetchSkillsWeighted());
         expect(result.rows).toHaveLength(0);
         expect(result.doctor.unclassified_count).toBe(0);
         expect(result.doctor.advice).toBeNull();
+    });
+
+    // -----------------------------------------------------------------------
+    // Spar exclusion
+    // -----------------------------------------------------------------------
+
+    it("invocation SQL contains NOT IN $sparSessions clause", async () => {
+        const db = makeMockDb();
+        await runWithMock(db, fetchSkillsWeighted());
+        // Invocation query at index 1
+        expect(db.captured[1]).toContain("session NOT IN $sparSessions");
+    });
+
+    it("passes sparSessions binding to the invocation query", async () => {
+        // Spar query returns one session id; assert it is bound in the invocation call.
+        const sparSessionRow = [{ id: "session:⟨spar-abc⟩" }];
+        const db = makeMockDb([[sparSessionRow], mockInvRows, mockRoleRows, mockDoctorBelow]);
+        await runWithMock(db, fetchSkillsWeighted());
+        const invCall = db.calls[1];
+        expect(invCall?.bindings?.sparSessions).toEqual(["session:⟨spar-abc⟩"]);
+    });
+
+    it("excludes spar session invocations from the ranking (behavioral exclusion)", async () => {
+        // The mock returns normal inv rows - the exclusion is enforced via the
+        // NOT IN SQL clause + param binding. Verify the spar id from the first
+        // query is wired as the $sparSessions binding on the invocation query.
+        const sparId = "session:⟨spar-variant⟩";
+        const sparRows = [{ id: sparId }];
+        const db = makeMockDb([[sparRows], mockInvRows, mockRoleRows, mockDoctorBelow]);
+        await runWithMock(db, fetchSkillsWeighted());
+        const invCall = db.calls[1];
+        expect(invCall?.bindings?.sparSessions).toContain(sparId);
     });
 });

--- a/apps/axctl/src/dashboard/skills-weighted.test.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.test.ts
@@ -17,6 +17,7 @@
  *   6 → skill names
  */
 import { describe, it, expect } from "bun:test";
+import { RecordId } from "surrealdb";
 import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
 import { fetchSkillsWeighted } from "./skills-weighted.ts";
 
@@ -185,6 +186,16 @@ describe("fetchSkillsWeighted", () => {
 
     // -----------------------------------------------------------------------
     // Spar exclusion
+    //
+    // NOTE: the mock layer never evaluates SurrealQL, so these stubs CANNOT
+    // verify that NOT IN actually excludes spar rows. They assert the
+    // STRUCTURAL contract that makes the exclusion fire on the live DB:
+    //   (1) the SQL contains `session NOT IN $sparSessions`, and
+    //   (2) the bound $sparSessions values are RecordId instances (record-typed),
+    //       NOT strings - a string[] binding makes NOT IN a silent no-op
+    //       (record<session> NOT IN [<string>...] is always TRUE).
+    // True semantic validation is the live-DB before/after check in the
+    // spar-exclusion design (a tagged session's skill counts must drop).
     // -----------------------------------------------------------------------
 
     it("invocation SQL contains NOT IN $sparSessions clause", async () => {
@@ -194,24 +205,31 @@ describe("fetchSkillsWeighted", () => {
         expect(db.captured[1]).toContain("session NOT IN $sparSessions");
     });
 
-    it("passes sparSessions binding to the invocation query", async () => {
-        // Spar query returns one session id; assert it is bound in the invocation call.
-        const sparSessionRow = [{ id: "session:⟨spar-abc⟩" }];
-        const db = makeMockDb([[sparSessionRow], mockInvRows, mockRoleRows, mockDoctorBelow]);
+    it("binds $sparSessions as RecordId values (record-typed, not strings)", async () => {
+        // Spar query (index 0) returns raw RecordIds via SELECT VALUE id; assert
+        // they are passed through to the invocation call's binding unchanged and
+        // are RecordId instances - the only form NOT IN actually evaluates.
+        const sparRid = new RecordId("session", "spar-abc");
+        const db = makeMockDb([[[sparRid]], mockInvRows, mockRoleRows, mockDoctorBelow]);
         await runWithMock(db, fetchSkillsWeighted());
         const invCall = db.calls[1];
-        expect(invCall?.bindings?.sparSessions).toEqual(["session:⟨spar-abc⟩"]);
+        const bound = invCall?.bindings?.sparSessions as unknown[];
+        expect(Array.isArray(bound)).toBe(true);
+        expect(bound).toHaveLength(1);
+        // Record-typed contract: the binding MUST be a RecordId, not a string.
+        expect(bound[0]).toBeInstanceOf(RecordId);
+        expect(String(bound[0])).toBe("session:⟨spar-abc⟩");
     });
 
-    it("excludes spar session invocations from the ranking (behavioral exclusion)", async () => {
-        // The mock returns normal inv rows - the exclusion is enforced via the
-        // NOT IN SQL clause + param binding. Verify the spar id from the first
-        // query is wired as the $sparSessions binding on the invocation query.
-        const sparId = "session:⟨spar-variant⟩";
-        const sparRows = [{ id: sparId }];
-        const db = makeMockDb([[sparRows], mockInvRows, mockRoleRows, mockDoctorBelow]);
+    it("wires the spar query's RecordIds into the invocation binding", async () => {
+        // End-to-end (within the stub): the RecordIds emitted by the spar
+        // query (call 0) appear verbatim as $sparSessions on the invocation
+        // query (call 1). On the live DB this is what drops spar invocations.
+        const sparRid = new RecordId("session", "spar-variant");
+        const db = makeMockDb([[[sparRid]], mockInvRows, mockRoleRows, mockDoctorBelow]);
         await runWithMock(db, fetchSkillsWeighted());
         const invCall = db.calls[1];
-        expect(invCall?.bindings?.sparSessions).toContain(sparId);
+        const bound = invCall?.bindings?.sparSessions as unknown[];
+        expect(bound.some((b) => b instanceof RecordId && String(b) === "session:⟨spar-variant⟩")).toBe(true);
     });
 });

--- a/apps/axctl/src/dashboard/skills-weighted.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.ts
@@ -10,6 +10,7 @@
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
+import { fetchSparSessionIds } from "../queries/spar-sessions.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -103,11 +104,19 @@ export const normalizeSkillsWeightedParams = (
  * fetch the small set of tombstoned skill ids once (DELETED_SKILLS_SQL) and
  * filter them out in JS during the merge.
  */
-function buildInvocationSql(windowDays: number | undefined): string {
-    const whereClause =
-        windowDays !== undefined && windowDays > 0
-            ? `WHERE ts >= time::now() - ${windowDays}d\n`
-            : "";
+function buildInvocationSql(
+    windowDays: number | undefined,
+    sparSessions: readonly string[],
+): string {
+    const conditions: string[] = [];
+    if (windowDays !== undefined && windowDays > 0) {
+        conditions.push(`ts >= time::now() - ${windowDays}d`);
+    }
+    // Exclude spar variant sessions using a flat NOT IN against the denormalized
+    // `session` field on `invoked` (no graph deref - safe on 87k+ edges).
+    // When sparSessions is empty, NOT IN [] excludes nothing.
+    conditions.push(`session NOT IN $sparSessions`);
+    const whereClause = `WHERE ${conditions.join("\n  AND ")}\n`;
     return `
 SELECT
     out AS skill_id,
@@ -193,11 +202,16 @@ export const fetchSkillsWeighted = (
             params.doctorThreshold ?? SKILLS_WEIGHTED_DEFAULT_DOCTOR_THRESHOLD;
         const includeTools = params.includeTools ?? false;
 
+        // Fetch spar variant session ids first (flat, deref-free).
+        // Used to exclude spar traffic from the weighted ranking via NOT IN.
+        const sparSessions = yield* fetchSparSessionIds();
+
         // Run passes + doctor + tombstone + synthetic-tool id queries concurrently.
         const [invRes, roleRes, doctorRes, deletedRes, toolRes, nameRes] = yield* Effect.all(
             [
                 db.query<[Array<Record<string, unknown>>]>(
-                    buildInvocationSql(params.windowDays),
+                    buildInvocationSql(params.windowDays, sparSessions),
+                    { sparSessions: [...sparSessions] },
                 ),
                 db.query<[Array<Record<string, unknown>>]>(ROLE_WEIGHT_SQL),
                 db.query<[Array<Record<string, unknown>>]>(

--- a/apps/axctl/src/dashboard/skills-weighted.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.ts
@@ -104,17 +104,19 @@ export const normalizeSkillsWeightedParams = (
  * fetch the small set of tombstoned skill ids once (DELETED_SKILLS_SQL) and
  * filter them out in JS during the merge.
  */
-function buildInvocationSql(
-    windowDays: number | undefined,
-    sparSessions: readonly string[],
-): string {
+function buildInvocationSql(windowDays: number | undefined): string {
     const conditions: string[] = [];
     if (windowDays !== undefined && windowDays > 0) {
         conditions.push(`ts >= time::now() - ${windowDays}d`);
     }
     // Exclude spar variant sessions using a flat NOT IN against the denormalized
     // `session` field on `invoked` (no graph deref - safe on 87k+ edges).
-    // When sparSessions is empty, NOT IN [] excludes nothing.
+    // $sparSessions is bound as a RecordId[] (NOT a string[]) so the comparison
+    // is record-vs-record: `record<session> NOT IN [<string>...]` is always TRUE
+    // (excludes nothing) - the string IN-list silently matches nothing
+    // (see apps/axctl/src/context/file-context.ts:647-651). Verified on the live
+    // DB: RecordId[] excludes correctly; string[] excludes 0 of 31,734 rows.
+    // When $sparSessions is empty, NOT IN [] excludes nothing (intended).
     conditions.push(`session NOT IN $sparSessions`);
     const whereClause = `WHERE ${conditions.join("\n  AND ")}\n`;
     return `
@@ -203,14 +205,15 @@ export const fetchSkillsWeighted = (
         const includeTools = params.includeTools ?? false;
 
         // Fetch spar variant session ids first (flat, deref-free).
-        // Used to exclude spar traffic from the weighted ranking via NOT IN.
+        // RecordId[] (NOT string[]) - bound as $sparSessions so the NOT IN
+        // comparison is record-vs-record and actually excludes spar traffic.
         const sparSessions = yield* fetchSparSessionIds();
 
         // Run passes + doctor + tombstone + synthetic-tool id queries concurrently.
         const [invRes, roleRes, doctorRes, deletedRes, toolRes, nameRes] = yield* Effect.all(
             [
                 db.query<[Array<Record<string, unknown>>]>(
-                    buildInvocationSql(params.windowDays, sparSessions),
+                    buildInvocationSql(params.windowDays),
                     { sparSessions: [...sparSessions] },
                 ),
                 db.query<[Array<Record<string, unknown>>]>(ROLE_WEIGHT_SQL),

--- a/apps/axctl/src/dojo/spar.test.ts
+++ b/apps/axctl/src/dojo/spar.test.ts
@@ -13,6 +13,7 @@ import {
     renderSparReport,
     REPAIR_TOL,
     scoreSpar,
+    stampSparSession,
 } from "./spar.ts";
 import type { SparBrief, SparMetrics } from "./spar.ts";
 
@@ -266,5 +267,59 @@ describe("findVariantSession", () => {
             tc.layer,
         );
         expect(id).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// stampSparSession
+// ---------------------------------------------------------------------------
+
+describe("stampSparSession", () => {
+    test("issues UPDATE with labels = [\"spar\"] when session has no existing labels", async () => {
+        const tc = makeTestSurrealClient({
+            denyWrites: false,
+            routes: {
+                // SELECT labels read: no existing labels (NONE row)
+                "SELECT labels FROM": [[{ labels: null }]],
+                // UPDATE: captured in tc.captured
+                "UPDATE ": [[]],
+            },
+        });
+        await runDbOnly(stampSparSession("session:abc"), tc.layer);
+        // The UPDATE should set labels to the JSON-encoded ["spar"]
+        const updateSql = tc.captured.find((s) => s.startsWith("UPDATE "));
+        expect(updateSql).toBeDefined();
+        // The SQL wraps the JSON-encoded string in a SurrealQL string literal;
+        // the escaped form is: \"[\\\"spar\\\"]\". Check the label key is present.
+        expect(updateSql).toContain("spar");
+    });
+
+    test("merges into existing labels without clobbering them", async () => {
+        const tc = makeTestSurrealClient({
+            denyWrites: false,
+            routes: {
+                "SELECT labels FROM": [[{ labels: JSON.stringify(["existing"]) }]],
+                "UPDATE ": [[]],
+            },
+        });
+        await runDbOnly(stampSparSession("session:abc"), tc.layer);
+        const updateSql = tc.captured.find((s) => s.startsWith("UPDATE "));
+        expect(updateSql).toBeDefined();
+        // Must include both labels
+        expect(updateSql).toContain("existing");
+        expect(updateSql).toContain("spar");
+    });
+
+    test("is idempotent: does not issue an UPDATE when already tagged", async () => {
+        const tc = makeTestSurrealClient({
+            denyWrites: false,
+            routes: {
+                "SELECT labels FROM": [[{ labels: JSON.stringify(["spar"]) }]],
+            },
+        });
+        await runDbOnly(stampSparSession("session:abc"), tc.layer);
+        // Only the SELECT query should be captured; no UPDATE
+        const updateSql = tc.captured.find((s) => s.startsWith("UPDATE "));
+        expect(updateSql).toBeUndefined();
     });
 });

--- a/apps/axctl/src/dojo/spar.ts
+++ b/apps/axctl/src/dojo/spar.ts
@@ -462,6 +462,44 @@ export const captureBaseline = (
     });
 
 /**
+ * Stamp a variant session's `labels` field with `"spar"` so behavioral
+ * analytics (`ax skills weighted`, `ax thinking`) can exclude it.
+ *
+ * Merge-union: reads the current labels JSON, adds `"spar"` if absent, and
+ * writes back. Idempotent: re-stamping an already-tagged session is a no-op.
+ * No-op when the session id cannot be resolved (silently returns).
+ *
+ * The `labels` field is `option<string>` containing a JSON-encoded string[]
+ * (schema rule of thumb for SurrealDB v3: nested arrays → JSON string).
+ */
+export const stampSparSession = (
+    sessionId: string,
+): Effect.Effect<void, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+
+        // Read current labels (may be NONE / null / a JSON-encoded string[]).
+        const readRows = yield* db.query<[Array<{ labels: string | null }>]>(
+            `SELECT labels FROM ${recordLiteral("session", cleanSessionId(sessionId))};`,
+        );
+        const existing = readRows?.[0]?.[0]?.labels ?? null;
+        let current: string[];
+        try {
+            current = existing != null ? (JSON.parse(existing) as string[]) : [];
+            if (!Array.isArray(current)) current = [];
+        } catch {
+            current = [];
+        }
+
+        if (current.includes("spar")) return; // idempotent
+
+        const merged = [...current, "spar"];
+        yield* db.query(
+            `UPDATE ${recordLiteral("session", cleanSessionId(sessionId))} SET labels = ${surrealString(JSON.stringify(merged))};`,
+        );
+    });
+
+/**
  * Find the most recent variant session run in `cwd` at/after `sinceMs` (the
  * brief's createdAt). Returns the bare session id, or null when the agent
  * hasn't run the task yet.

--- a/apps/axctl/src/queries/spar-sessions.test.ts
+++ b/apps/axctl/src/queries/spar-sessions.test.ts
@@ -2,35 +2,43 @@
  * Tests for spar-sessions.ts: fetchSparSessionIds.
  *
  * Uses the shared mock SurrealClient factory to assert the query shape and
- * filtering behaviour.
+ * filtering behaviour. fetchSparSessionIds returns RAW RecordId values (via
+ * SELECT VALUE id) - NOT strings - so the weighted-path NOT IN comparison is
+ * record-vs-record. These unit tests assert the structural contract (RecordId
+ * instances, correct query shape); they CANNOT validate NOT IN semantics - the
+ * mock layer never evaluates SurrealQL. True semantic validation is the
+ * live-DB before/after check documented in the spar-exclusion design.
  */
 import { describe, expect, it } from "bun:test";
+import { RecordId } from "surrealdb";
 import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
 import { fetchSparSessionIds } from "./spar-sessions.ts";
 
+const rid = (uuid: string) => new RecordId("session", uuid);
+
 describe("fetchSparSessionIds", () => {
-    it("returns ids of spar-labelled sessions", async () => {
+    it("returns RecordId values of spar-labelled sessions", async () => {
         const db = makeMockDb([
-            [
-                [{ id: "session:⟨spar-abc⟩" }, { id: "session:⟨spar-def⟩" }],
-            ],
+            [[rid("spar-abc"), rid("spar-def")]],
         ]);
         const ids = await runWithMock(db, fetchSparSessionIds());
         expect(ids).toHaveLength(2);
-        expect(ids).toContain("session:⟨spar-abc⟩");
-        expect(ids).toContain("session:⟨spar-def⟩");
+        // Contract: every element is a RecordId (NOT a string) so the
+        // downstream NOT IN $sparSessions is record-typed.
+        expect(ids.every((id) => id instanceof RecordId)).toBe(true);
+        expect(ids.map((id) => String(id))).toContain("session:⟨spar-abc⟩");
+        expect(ids.map((id) => String(id))).toContain("session:⟨spar-def⟩");
     });
 
     it("excludes unlabelled sessions (returns only spar rows)", async () => {
         // The DB query filters server-side; here the mock returns only the
         // matching rows. Verify no extras slip through the JS mapping.
         const db = makeMockDb([
-            [
-                [{ id: "session:⟨spar-only⟩" }],
-            ],
+            [[rid("spar-only")]],
         ]);
         const ids = await runWithMock(db, fetchSparSessionIds());
-        expect(ids).toEqual(["session:⟨spar-only⟩"]);
+        expect(ids).toHaveLength(1);
+        expect(String(ids[0])).toBe("session:⟨spar-only⟩");
     });
 
     it("returns [] when no spar sessions exist", async () => {
@@ -40,22 +48,27 @@ describe("fetchSparSessionIds", () => {
         expect(ids).toEqual([]);
     });
 
-    it("filters out falsy id strings from the row mapping", async () => {
-        // Defensive: rows with a null/empty id should be dropped.
+    it("drops non-RecordId rows defensively (only RecordId instances survive)", async () => {
+        // SELECT VALUE id should only ever return RecordIds, but guard against
+        // a stray string/null slipping through.
         const db = makeMockDb([
-            [
-                [{ id: "session:⟨valid⟩" }, { id: "" }, { id: null }],
-            ],
+            [[rid("valid"), "session:⟨string-form⟩", null]],
         ]);
         const ids = await runWithMock(db, fetchSparSessionIds());
-        expect(ids).toEqual(["session:⟨valid⟩"]);
+        expect(ids).toHaveLength(1);
+        expect(ids[0]).toBeInstanceOf(RecordId);
+        // "valid" is unquoted-safe (alphanumeric), so no ⟨⟩ wrapping.
+        expect(String(ids[0])).toBe("session:valid");
     });
 
-    it("issues a query containing the spar label filter", async () => {
+    it("issues a SELECT VALUE id query containing the spar label filter", async () => {
         const db = makeMockDb();
         await runWithMock(db, fetchSparSessionIds());
+        // Must use SELECT VALUE id (raw RecordIds), NOT type::string(id) (strings):
+        // the string form makes NOT IN a no-op against record<session> fields.
+        expect(db.captured[0]).toContain("SELECT VALUE id");
+        expect(db.captured[0]).not.toContain("type::string(id)");
         expect(db.captured[0]).toContain("string::contains(labels, 'spar')");
         expect(db.captured[0]).toContain("labels != NONE");
-        expect(db.captured[0]).toContain("type::string(id) AS id");
     });
 });

--- a/apps/axctl/src/queries/spar-sessions.test.ts
+++ b/apps/axctl/src/queries/spar-sessions.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for spar-sessions.ts: fetchSparSessionIds.
+ *
+ * Uses the shared mock SurrealClient factory to assert the query shape and
+ * filtering behaviour.
+ */
+import { describe, expect, it } from "bun:test";
+import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
+import { fetchSparSessionIds } from "./spar-sessions.ts";
+
+describe("fetchSparSessionIds", () => {
+    it("returns ids of spar-labelled sessions", async () => {
+        const db = makeMockDb([
+            [
+                [{ id: "session:⟨spar-abc⟩" }, { id: "session:⟨spar-def⟩" }],
+            ],
+        ]);
+        const ids = await runWithMock(db, fetchSparSessionIds());
+        expect(ids).toHaveLength(2);
+        expect(ids).toContain("session:⟨spar-abc⟩");
+        expect(ids).toContain("session:⟨spar-def⟩");
+    });
+
+    it("excludes unlabelled sessions (returns only spar rows)", async () => {
+        // The DB query filters server-side; here the mock returns only the
+        // matching rows. Verify no extras slip through the JS mapping.
+        const db = makeMockDb([
+            [
+                [{ id: "session:⟨spar-only⟩" }],
+            ],
+        ]);
+        const ids = await runWithMock(db, fetchSparSessionIds());
+        expect(ids).toEqual(["session:⟨spar-only⟩"]);
+    });
+
+    it("returns [] when no spar sessions exist", async () => {
+        // Empty result set from the DB.
+        const db = makeMockDb([[[]]]);
+        const ids = await runWithMock(db, fetchSparSessionIds());
+        expect(ids).toEqual([]);
+    });
+
+    it("filters out falsy id strings from the row mapping", async () => {
+        // Defensive: rows with a null/empty id should be dropped.
+        const db = makeMockDb([
+            [
+                [{ id: "session:⟨valid⟩" }, { id: "" }, { id: null }],
+            ],
+        ]);
+        const ids = await runWithMock(db, fetchSparSessionIds());
+        expect(ids).toEqual(["session:⟨valid⟩"]);
+    });
+
+    it("issues a query containing the spar label filter", async () => {
+        const db = makeMockDb();
+        await runWithMock(db, fetchSparSessionIds());
+        expect(db.captured[0]).toContain("string::contains(labels, 'spar')");
+        expect(db.captured[0]).toContain("labels != NONE");
+        expect(db.captured[0]).toContain("type::string(id) AS id");
+    });
+});

--- a/apps/axctl/src/queries/spar-sessions.ts
+++ b/apps/axctl/src/queries/spar-sessions.ts
@@ -9,27 +9,40 @@
  * Spec: docs/superpowers/specs/2026-06-15-spar-exclusion-tag-design.md
  */
 import { Effect } from "effect";
+import { RecordId } from "surrealdb";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 
 /**
- * Record-ids of sessions tagged as spar variants (behavioral-analytics
- * exclusion). Returns a flat array of bare session id strings
- * (e.g. `["session:abc123"]`). Returns `[]` when no spar sessions exist.
+ * RecordIds of sessions tagged as spar variants (behavioral-analytics
+ * exclusion). Returns a flat array of `RecordId` values (NOT strings).
+ * Returns `[]` when no spar sessions exist.
+ *
+ * IMPORTANT: the ids are RAW `record<session>` values, not `type::string(id)`
+ * strings. `invoked.session` / `session.id` are record links, and SurrealDB
+ * compares `record<session> NOT IN [<string>...]` as ALWAYS-TRUE (the string
+ * IN-list silently matches nothing - documented rule, see
+ * apps/axctl/src/context/file-context.ts:647-651). The exclusion at the
+ * weighted aggregate binds these RecordIds so the comparison is
+ * record-vs-record and actually fires. Verified empirically on the live DB:
+ * a string[] param excludes 0 rows; a RecordId[] param excludes correctly.
  *
  * Deref-free: no graph traversal. Safe against the 87k-edge invoked hang
  * (memory `weighted-query-per-edge-deref-hang`).
  */
 export const fetchSparSessionIds = (): Effect.Effect<
-    readonly string[],
+    readonly RecordId[],
     DbError,
     SurrealClient
 > =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
-        const result = yield* db.query<[Array<{ id: string }>]>(
-            `SELECT type::string(id) AS id FROM session WHERE labels != NONE AND string::contains(labels, 'spar');`,
+        // SELECT VALUE id returns the raw RecordId values (the surreal SDK's
+        // record-id form), NOT a string projection - so NOT IN against this
+        // array is a record-vs-record comparison.
+        const result = yield* db.query<[Array<unknown>]>(
+            `SELECT VALUE id FROM session WHERE labels != NONE AND string::contains(labels, 'spar');`,
         );
         const rows = result?.[0] ?? [];
-        return rows.map((r) => String(r.id ?? "")).filter(Boolean);
+        return rows.filter((r): r is RecordId => r instanceof RecordId);
     });

--- a/apps/axctl/src/queries/spar-sessions.ts
+++ b/apps/axctl/src/queries/spar-sessions.ts
@@ -1,0 +1,35 @@
+/**
+ * Fetch the set of session ids tagged as spar variant sessions.
+ *
+ * Spar-score stamps the variant session's `labels` field with the JSON-encoded
+ * string `["spar"]`. This helper returns a flat id list used by behavioral
+ * analytics surfaces (`ax skills weighted`, `ax thinking`) to exclude spar
+ * sessions from their rollups.
+ *
+ * Spec: docs/superpowers/specs/2026-06-15-spar-exclusion-tag-design.md
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+
+/**
+ * Record-ids of sessions tagged as spar variants (behavioral-analytics
+ * exclusion). Returns a flat array of bare session id strings
+ * (e.g. `["session:abc123"]`). Returns `[]` when no spar sessions exist.
+ *
+ * Deref-free: no graph traversal. Safe against the 87k-edge invoked hang
+ * (memory `weighted-query-per-edge-deref-hang`).
+ */
+export const fetchSparSessionIds = (): Effect.Effect<
+    readonly string[],
+    DbError,
+    SurrealClient
+> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const result = yield* db.query<[Array<{ id: string }>]>(
+            `SELECT type::string(id) AS id FROM session WHERE labels != NONE AND string::contains(labels, 'spar');`,
+        );
+        const rows = result?.[0] ?? [];
+        return rows.map((r) => String(r.id ?? "")).filter(Boolean);
+    });

--- a/apps/axctl/src/queries/thinking-analytics.test.ts
+++ b/apps/axctl/src/queries/thinking-analytics.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, expect, it } from "bun:test";
 import { Effect, Layer } from "effect";
+import { RecordId } from "surrealdb";
 import { SurrealClient } from "@ax/lib/db";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
 
@@ -15,23 +16,24 @@ const run = <A>(eff: Effect.Effect<A, unknown, SurrealClient>, layer: Layer.Laye
 
 /**
  * Build a test layer for fetchThinking that routes:
- *   - The spar-sessions query (contains "string::contains") → sparRows
+ *   - The spar-sessions query (contains "string::contains") → sparRids
  *   - Everything else (the batched 5-statement thinking SQL) → batchResults
  *
  * Route response shape:
- *   spar query returns `[Array<{id}>]` (1-tuple) → route rows = [sparRows]
+ *   spar query is `SELECT VALUE id ...` → flat array of RecordId values, so the
+ *     route rows = [sparRids] (one statement result wrapping the RecordId array).
  *   batch query returns `[thinking, sessions, efforts, reasoning, models]` → fallback = batchResults
  */
 const makeThinkingMock = (
     batchResults: QueryResult[],
-    sparRows: Array<{ id: string }> = [],
+    sparRids: RecordId[] = [],
 ): Layer.Layer<SurrealClient> => {
     const tc = makeTestSurrealClient({
         denyWrites: true,
         routes: {
-            // spar query: SELECT type::string(id) ... WHERE string::contains(labels, 'spar')
-            // returns [Array<{id}>] - one statement result
-            "string::contains(labels": [sparRows] as unknown as Array<unknown[]>,
+            // spar query: SELECT VALUE id ... WHERE string::contains(labels, 'spar')
+            // returns [Array<RecordId>] - one statement result
+            "string::contains(labels": [sparRids] as unknown as Array<unknown[]>,
         },
         // fallback: the batched 5-statement query returns batchResults tuple
         fallback: batchResults as unknown as Array<unknown[]>,
@@ -203,10 +205,13 @@ describe("fetchThinking", () => {
         ];
         const result = await run(
             fetchThinking({ sinceDays: 14 }),
-            // sparRows: spar-s2 is flagged; makeThinkingMock routes spar query to [sparRows]
+            // sparRids: spar-s2 flagged as a RecordId (matches the SELECT VALUE id
+            // form). makeThinkingMock routes the spar query to [sparRids].
+            // String(RecordId) -> "session:⟨spar-s2⟩" -> cleanSessionId -> "spar-s2",
+            // which matches the thinking row's session_id "session:spar-s2".
             makeThinkingMock(
                 [thinking, sessions, [], [], agentModels],
-                [{ id: "session:spar-s2" }],
+                [new RecordId("session", "spar-s2")],
             ),
         );
         // Only s1's thinking tokens (800) should appear; spar-s2's 5000 excluded.

--- a/apps/axctl/src/queries/thinking-analytics.test.ts
+++ b/apps/axctl/src/queries/thinking-analytics.test.ts
@@ -4,11 +4,14 @@
 import { describe, expect, it } from "bun:test";
 import { Effect, Layer } from "effect";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
 
 import { fetchThinking, reasoningCostUsd, rollupThinkingByModel } from "./thinking-analytics.ts";
 
 type QueryResult = Array<Record<string, unknown>>;
 
+/** Local mock: always returns the same results tuple from any db.query() call.
+ *  Used for the pure-rollup tests that don't involve fetchSparSessionIds. */
 const makeMockDb = (results: QueryResult[]): Layer.Layer<SurrealClient> => {
     const stub: SurrealClientShape = {
         query: (_sql: string) => Effect.succeed(results as [QueryResult, ...QueryResult[]]),
@@ -18,6 +21,32 @@ const makeMockDb = (results: QueryResult[]): Layer.Layer<SurrealClient> => {
 
 const run = <A>(eff: Effect.Effect<A, unknown, SurrealClient>, layer: Layer.Layer<SurrealClient>) =>
     Effect.runPromise(eff.pipe(Effect.provide(layer)));
+
+/**
+ * Build a test layer for fetchThinking that routes:
+ *   - The spar-sessions query (contains "string::contains") → sparRows
+ *   - Everything else (the batched 5-statement thinking SQL) → batchResults
+ *
+ * Route response shape:
+ *   spar query returns `[Array<{id}>]` (1-tuple) → route rows = [sparRows]
+ *   batch query returns `[thinking, sessions, efforts, reasoning, models]` → fallback = batchResults
+ */
+const makeThinkingMock = (
+    batchResults: QueryResult[],
+    sparRows: Array<{ id: string }> = [],
+): Layer.Layer<SurrealClient> => {
+    const tc = makeTestSurrealClient({
+        denyWrites: true,
+        routes: {
+            // spar query: SELECT type::string(id) ... WHERE string::contains(labels, 'spar')
+            // returns [Array<{id}>] - one statement result
+            "string::contains(labels": [sparRows] as unknown as Array<unknown[]>,
+        },
+        // fallback: the batched 5-statement query returns batchResults tuple
+        fallback: batchResults as unknown as Array<unknown[]>,
+    });
+    return tc.layer;
+};
 
 describe("rollupThinkingByModel", () => {
     it("aggregates per model with pct and avg tokens", () => {
@@ -125,6 +154,12 @@ describe("reasoningCostUsd", () => {
 });
 
 describe("fetchThinking", () => {
+    // fetchThinking now issues two db.query() calls:
+    //   1. fetchSparSessionIds (SQL contains "string::contains(labels")
+    //   2. the batched 5-statement thinking/session/effort/reasoning/model SQL
+    //
+    // makeThinkingMock routes by SQL pattern so each call gets the right data.
+
     it("joins thinking rows to session models and maps codex signals", async () => {
         const thinking = [
             { session_id: "session:`s1`", blocks: 2, tokens: 800, assistant_turns: 4, thinking_turns: 2 },
@@ -145,7 +180,7 @@ describe("fetchThinking", () => {
         ];
         const result = await run(
             fetchThinking({ sinceDays: 14 }),
-            makeMockDb([thinking, sessions, efforts, reasoning, agentModels]),
+            makeThinkingMock([thinking, sessions, efforts, reasoning, agentModels]),
         );
         expect(result.models).toHaveLength(1);
         expect(result.models[0].model).toBe("claude-fable-5");
@@ -160,5 +195,32 @@ describe("fetchThinking", () => {
         // 5000 reasoning tokens x $20/M -> $0.1
         expect(result.codex_reasoning[0].reasoning_cost_usd).toBeCloseTo(0.1);
         expect(result.window_days).toBe(14);
+    });
+
+    it("excludes a spar-tagged session from thinking totals", async () => {
+        // s1 is a normal session; spar-s2 is a spar variant that should be dropped.
+        const thinking = [
+            { session_id: "session:s1", blocks: 2, tokens: 800, assistant_turns: 4, thinking_turns: 2 },
+            { session_id: "session:spar-s2", blocks: 5, tokens: 5000, assistant_turns: 10, thinking_turns: 5 },
+        ];
+        const sessions = [
+            { session_id: "session:s1", model: "claude-fable-5", source: "claude" },
+            { session_id: "session:spar-s2", model: "claude-fable-5", source: "claude" },
+        ];
+        const agentModels = [
+            { name: "claude-fable-5", output_per_million_usd: 15 },
+        ];
+        const result = await run(
+            fetchThinking({ sinceDays: 14 }),
+            // sparRows: spar-s2 is flagged; makeThinkingMock routes spar query to [sparRows]
+            makeThinkingMock(
+                [thinking, sessions, [], [], agentModels],
+                [{ id: "session:spar-s2" }],
+            ),
+        );
+        // Only s1's thinking tokens (800) should appear; spar-s2's 5000 excluded.
+        expect(result.models).toHaveLength(1);
+        expect(result.models[0].thinking_tokens).toBe(800);
+        expect(result.models[0].sessions).toBe(1);
     });
 });

--- a/apps/axctl/src/queries/thinking-analytics.test.ts
+++ b/apps/axctl/src/queries/thinking-analytics.test.ts
@@ -3,21 +3,12 @@
  */
 import { describe, expect, it } from "bun:test";
 import { Effect, Layer } from "effect";
-import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { SurrealClient } from "@ax/lib/db";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
 
 import { fetchThinking, reasoningCostUsd, rollupThinkingByModel } from "./thinking-analytics.ts";
 
 type QueryResult = Array<Record<string, unknown>>;
-
-/** Local mock: always returns the same results tuple from any db.query() call.
- *  Used for the pure-rollup tests that don't involve fetchSparSessionIds. */
-const makeMockDb = (results: QueryResult[]): Layer.Layer<SurrealClient> => {
-    const stub: SurrealClientShape = {
-        query: (_sql: string) => Effect.succeed(results as [QueryResult, ...QueryResult[]]),
-    } as unknown as SurrealClientShape;
-    return Layer.succeed(SurrealClient, stub);
-};
 
 const run = <A>(eff: Effect.Effect<A, unknown, SurrealClient>, layer: Layer.Layer<SurrealClient>) =>
     Effect.runPromise(eff.pipe(Effect.provide(layer)));

--- a/apps/axctl/src/queries/thinking-analytics.ts
+++ b/apps/axctl/src/queries/thinking-analytics.ts
@@ -17,6 +17,7 @@
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { normalizeModelName } from "../ingest/model-pricing.ts";
+import { fetchSparSessionIds } from "./spar-sessions.ts";
 
 // ---------------------------------------------------------------------------
 // Result shapes
@@ -220,6 +221,11 @@ export const fetchThinking = Effect.fn("queries.fetchThinking")(
     function* (opts: { readonly sinceDays: number }) {
         const db = yield* SurrealClient;
 
+        // Fetch spar variant session ids before the main query so we can
+        // exclude them from behavioral totals at the JS join.
+        const sparSessionIds = yield* fetchSparSessionIds();
+        const sparSet = new Set(sparSessionIds.map(cleanSessionId));
+
         const [thinkingResult, sessionsResult, effortResult, reasoningResult, agentModelsResult] = yield* db.query<[
             Array<Record<string, unknown>>,
             Array<Record<string, unknown>>,
@@ -244,18 +250,26 @@ export const fetchThinking = Effect.fn("queries.fetchThinking")(
             );
         }
 
-        const sessionRows: SessionThinkingRow[] = (thinkingResult ?? []).map((r) => ({
-            session_id: String(r.session_id ?? ""),
-            blocks: Number(r.blocks ?? 0),
-            tokens: Number(r.tokens ?? 0),
-            assistant_turns: Number(r.assistant_turns ?? 0),
-            thinking_turns: Number(r.thinking_turns ?? 0),
-        }));
+        // Drop spar sessions at the JS join: filter sessionRows before passing
+        // to rollupThinkingByModel so spar traffic doesn't inflate thinking totals.
+        const sessionRows: SessionThinkingRow[] = (thinkingResult ?? [])
+            .map((r) => ({
+                session_id: String(r.session_id ?? ""),
+                blocks: Number(r.blocks ?? 0),
+                tokens: Number(r.tokens ?? 0),
+                assistant_turns: Number(r.assistant_turns ?? 0),
+                thinking_turns: Number(r.thinking_turns ?? 0),
+            }))
+            .filter((r) => !sparSet.has(cleanSessionId(r.session_id)));
 
         const modelBySession = new Map<string, string | null>();
         for (const r of sessionsResult ?? []) {
+            const cleanId = cleanSessionId(String(r.session_id ?? ""));
+            // Also exclude spar sessions from the model map so they don't
+            // appear in the effort/session counts.
+            if (sparSet.has(cleanId)) continue;
             modelBySession.set(
-                cleanSessionId(String(r.session_id ?? "")),
+                cleanId,
                 r.model == null ? null : String(r.model),
             );
         }

--- a/apps/axctl/src/queries/thinking-analytics.ts
+++ b/apps/axctl/src/queries/thinking-analytics.ts
@@ -154,8 +154,17 @@ export interface SessionThinkingRow {
     readonly thinking_turns: number;
 }
 
+// Strip the `session:` prefix + record-id delimiters. Handles both the
+// backtick form (`type::string(session)` / `type::string(id)` casts ->
+// session:`uuid`) AND the angle-bracket form (a raw RecordId's String() ->
+// session:⟨uuid⟩, as returned by fetchSparSessionIds' SELECT VALUE id). The
+// spar-session ids and the turn-scan session_id columns must normalize to the
+// same bare uuid or the spar exclusion below silently misses.
 const cleanSessionId = (id: string): string =>
-    id.replace(/^session:/, "").replace(/^`(.*)`$/, "$1");
+    id
+        .replace(/^session:/, "")
+        .replace(/^[`⟨]+/, "")
+        .replace(/[`⟩]+$/, "");
 
 export const rollupThinkingByModel = (
     sessionRows: ReadonlyArray<SessionThinkingRow>,
@@ -222,9 +231,12 @@ export const fetchThinking = Effect.fn("queries.fetchThinking")(
         const db = yield* SurrealClient;
 
         // Fetch spar variant session ids before the main query so we can
-        // exclude them from behavioral totals at the JS join.
+        // exclude them from behavioral totals at the JS join. fetchSparSessionIds
+        // returns RecordId[] (record-vs-record exclusion for the weighted path);
+        // here we normalize each via String() -> cleanSessionId to the bare uuid
+        // so the Set keys match the `type::string(session)` rows below.
         const sparSessionIds = yield* fetchSparSessionIds();
-        const sparSet = new Set(sparSessionIds.map(cleanSessionId));
+        const sparSet = new Set(sparSessionIds.map((id) => cleanSessionId(String(id))));
 
         const [thinkingResult, sessionsResult, effortResult, reasoningResult, agentModelsResult] = yield* db.query<[
             Array<Record<string, unknown>>,

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -41,7 +41,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax dojo draft [--title=<t>] [--kind=bug|improvement] [--body-file=<path>] [--session=<id>]` - stage an upstream finding (ax bug or improvement discovered during training) to `~/.ax/dojo/outbox/<slug>.md`; never publishes - user reviews and publishes via ax-repo skill / gh.
 - `ax dojo outbox [--json]` - list staged upstream issue drafts in `~/.ax/dojo/outbox/`.
 - `ax dojo spar-plan <sha> [--json]` - capture a landed task's baseline (prompt + cost/turns/churn) and emit a one-delta experiment brief to `~/.ax/dojo/spar/<id>.md`; prints the `git worktree add` command that pins the parent SHA.
-- `ax dojo spar-score <id> [--variant-session=<id>] [--json]` - score the agent's variant session against the frozen baseline; auto-discovers the variant session from the worktree cwd or accepts an explicit id; writes the receipt to `~/.ax/dojo/spar/<id>-report.md`.
+- `ax dojo spar-score <id> [--variant-session=<id>] [--json]` - score the agent's variant session against the frozen baseline; auto-discovers the variant session from the worktree cwd or accepts an explicit id; writes the receipt to `~/.ax/dojo/spar/<id>-report.md`. Stamps the variant session `labels=["spar"]` so it is excluded from `ax skills weighted` and `ax thinking` (behavioral analytics); it remains in cost analytics.
 - `ax digest [--json|--refresh]` - your ranked digest board (improve proposals, routing savings, repair-loops, quota), written to ~/.ax/digest.json every ingest and pushed into the agent's context at session start by the surface-digest hook so value arrives without being asked for
 
 ### Profile

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,7 +39,7 @@ axctl dojo report [--since=<iso>] [--notes-file=<path>] [--json]      # write th
 axctl dojo draft [--title=<t>] [--kind=bug|improvement] [--body-file=<path>] [--session=<id>]  # stage an upstream finding to ~/.ax/dojo/outbox/<slug>.md (never publishes)
 axctl dojo outbox [--json]                                            # list staged upstream issue drafts
 axctl dojo spar-plan <sha> [--json]                              # capture a landed task's baseline + emit a one-delta experiment brief
-axctl dojo spar-score <id> [--variant-session=<id>] [--json]     # score the agent's variant vs the frozen baseline
+axctl dojo spar-score <id> [--variant-session=<id>] [--json]     # score the agent's variant vs the frozen baseline; stamps variant session labels=["spar"] (excluded from ax skills weighted + ax thinking, kept in cost)
 axctl dispatches [--candidates] [--economy] # subagent dispatch routing analytics + est savings + effectiveness lens
 axctl routing tune [--dry-run|--emit-brief] # mine YOUR dispatch history for new routing classes
 axctl routing compile                       # regenerate ~/.ax/hooks/routing-table.json (user classes preserved)

--- a/docs/superpowers/specs/2026-06-15-spar-exclusion-tag-design.md
+++ b/docs/superpowers/specs/2026-06-15-spar-exclusion-tag-design.md
@@ -1,0 +1,136 @@
+# Spar analytics-exclusion tag
+
+Date: 2026-06-15
+Status: final design, pre-implementation
+Follows: `docs/superpowers/specs/2026-06-13-ax-dojo-design.md` (dojo/spar), memory
+`weighted-query-per-edge-deref-hang`.
+
+## Problem
+
+`ax dojo spar` runs a variant of a landed task in a pinned worktree to compare
+against a frozen baseline. That variant session is real traffic and gets ingested
+like any other - so it shows up in **behavioral usage analytics** (`ax skills
+weighted`, `ax thinking`) and skews "what I actually do." Spar is synthetic
+experimentation, not real work; it should be excludable from those signals.
+
+It IS real spend, so it must remain in **cost** analytics (`ax cost
+models/sessions/split`) - hiding it there would understate real money. And
+`ax dojo spar-score` itself reads the variant via per-session-id metrics
+(`fetchSessionMetrics`), which must NOT exclude spar or scoring breaks.
+
+## Decisions (locked)
+
+- **Behavioral-only exclusion.** Exclude spar from `ax skills weighted` + `ax
+  thinking`. Keep it in cost. Leave per-session-id queries (`session_metrics`,
+  used by spar scoring) untouched.
+- **Stamp at spar-score.** `ax dojo spar-score` already resolves the variant
+  session id (by worktree cwd, `discoverVariantSession`); it `UPDATE`s that
+  session's `labels` to include a spar marker. Post-hoc, deterministic,
+  idempotent (re-running spar-score re-stamps the same marker).
+- **No `--include-spar` flag in v1.** Exclusion is unconditional on the two
+  behavioral surfaces. A flag is a later add if wanted.
+
+## Design
+
+### 1. Schema: `session.labels`
+
+Add to `packages/schema/src/schema.surql` (mirroring the existing `labels`
+convention on `agent_session`/`tool`/etc.):
+
+```surql
+DEFINE FIELD labels ON session TYPE option<string>;  -- JSON-encoded string[] (e.g. ["spar"])
+```
+
+`session` is a normalized top-level table, not a new table, so no
+`SCHEMA_TABLES` registration is needed (that guard is for new tables - memory
+`schema-tables-mirror`). The field is `option<string>`, JSON-encoded like every
+other `labels` field (schema rule of thumb: nested → JSON string in v3). Existing
+rows read `NONE`.
+
+### 2. Stamp at spar-score
+
+In `apps/axctl/src/dojo/spar.ts` (the spar-score path), after the variant session
+id is resolved, stamp it:
+
+```surql
+UPDATE $sessionId SET labels = <string>[ "spar" ];
+```
+
+Implementation notes:
+- The marker is the JSON-encoded array `["spar"]` (a string field). Use the
+  same JSON-encode helper the ingest path uses for other `labels` fields so the
+  on-disk shape matches (a JSON string, not a native array).
+- Merge-safe: if the session already has labels, union in `"spar"` rather than
+  overwrite. v1 spar sessions have no prior labels, but the stamp should read →
+  parse → add-if-absent → write to avoid clobbering future labels.
+- Stamp only the **variant** session (the one discovered in the spar worktree),
+  never the baseline (the baseline is real landed work).
+- Idempotent: stamping an already-`["spar"]` session is a no-op.
+
+### 3. Shared exclusion helper
+
+New `apps/axctl/src/queries/spar-sessions.ts`:
+
+```ts
+/** Record-ids of sessions tagged as spar variants (behavioral-analytics exclusion). */
+export const fetchSparSessionIds = (): Effect.Effect<readonly string[], DbError, SurrealClient> =>
+  // SELECT id FROM session WHERE labels != NONE AND string::contains(labels, 'spar')
+  // Flat id list - cheap, no graph traversal.
+```
+
+This returns a small array of session record-ids. Both behavioral surfaces use
+it and exclude with a **flat `NOT IN`** - deliberately deref-free to respect
+memory `weighted-query-per-edge-deref-hang` (no `in.session.labels` deref inside
+the 87k-row `invoked` aggregate).
+
+### 4. `ax skills weighted` exclusion
+
+In the weighted aggregate (`apps/axctl/src/cli/commands/skills.ts`, the
+`FROM invoked` aggregate, ~line 122), add a flat exclusion bound as a param:
+
+```surql
+... FROM invoked WHERE in.session NOT IN $sparSessions ...   -- $sparSessions = fetchSparSessionIds()
+```
+
+`NOT IN` against a flat array of record-ids is a primitive comparison, NOT a
+per-edge deref - safe for the 87k-edge scan. When `fetchSparSessionIds()` is
+empty, pass `[]` (NOT IN [] excludes nothing). Apply the same bound to any
+sibling per-window invoked counts in that command that feed the ranking.
+
+### 5. `ax thinking` exclusion
+
+`apps/axctl/src/queries/thinking-analytics.ts` joins per-session turn aggregates
+to `SESSION_MODELS_SQL` in JS. Exclude at the join: drop sessions whose id is in
+`fetchSparSessionIds()` before aggregating totals. (Simplest: fetch the spar id
+set, then `.filter()` the session-keyed rows in the existing JS join - no SQL
+change to the turn scan needed.)
+
+## Out of scope / later
+
+- `ax dispatches` spar exclusion (subagent-focused; a spar variant's child
+  dispatches are marginal - adopt the helper later if it matters).
+- `--include-spar` flag.
+- Excluding spar from `ax recall` / wrapped / profile.
+- Ingest-time tagging (rejected: needs a marker-file convention + pipeline
+  change; spar-score post-hoc stamp is simpler and sufficient).
+
+## Verify
+
+- Unit: `fetchSparSessionIds` query shape; the spar-score stamp UPDATE
+  (merge-union, idempotent) via the existing spar test layer.
+- `ax thinking` drops a spar-labeled session from totals (test layer with a
+  spar + non-spar session).
+- `ax skills weighted` excludes invocations from a spar session (test layer).
+- `bun run typecheck`, touched-package `bun test`.
+- Manual: tag a known session `["spar"]`, confirm it leaves `ax skills weighted`
+  / `ax thinking` but stays in `ax cost sessions`.
+
+## Module map
+
+```
+packages/schema/src/schema.surql                  + DEFINE FIELD labels ON session
+apps/axctl/src/dojo/spar.ts                        spar-score stamps variant session labels (merge-union)
+apps/axctl/src/queries/spar-sessions.ts            NEW fetchSparSessionIds (flat id list) + test
+apps/axctl/src/cli/commands/skills.ts              weighted aggregate: NOT IN $sparSessions (deref-free)
+apps/axctl/src/queries/thinking-analytics.ts       drop spar sessions at the JS session-join
+```

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -64,6 +64,7 @@ DEFINE FIELD source         ON session TYPE string DEFAULT 'claude';  -- 'claude
 DEFINE FIELD started_at     ON session TYPE option<datetime>;
 DEFINE FIELD ended_at       ON session TYPE option<datetime>;
 DEFINE FIELD raw_file       ON session TYPE option<string>;  -- f"transcripts:/<id>.jsonl" pointer; full original jsonl
+DEFINE FIELD labels         ON session TYPE option<string>;  -- JSON-encoded string[] (e.g. ["spar"]); spar-score stamps variant sessions
 DEFINE FIELD repository     ON session TYPE option<record<repository>>;
 DEFINE FIELD checkout       ON session TYPE option<record<checkout>>;
 DEFINE FIELD workspace      ON session TYPE option<record<workspace>>;


### PR DESCRIPTION
## What

Spar variant sessions (`ax dojo spar`) are synthetic experimentation but get ingested like real work, skewing behavioral usage signals. This tags them and excludes them from behavioral analytics — while keeping them in cost (the money was really spent).

- **Schema:** `DEFINE FIELD labels ON session TYPE option<string>` (JSON-encoded, matching the existing `labels` convention).
- **Stamp:** `ax dojo spar-score` stamps the resolved variant session `labels=["spar"]` (merge-union, idempotent, variant-only, non-fatal).
- **`fetchSparSessionIds`:** shared helper returning the spar session **record ids**.
- **`ax skills weighted`:** excludes via `session NOT IN $sparSessions` against the denormalized `invoked.session` field — **deref-free** (respects the 87k-edge hang memory) and **record-typed** (see below).
- **`ax thinking`:** drops spar sessions at the JS session-join.
- **Untouched:** cost analytics + per-id `session_metrics` (the latter is used by spar scoring itself).

## Two bugs caught in review (both fixed + verified)

1. **Record-vs-string `NOT IN` was inert.** The first cut returned `type::string(id)` strings, but `invoked.session` is `record<session>` — `record NOT IN [string]` is always true, so the exclusion removed *nothing* (verified on a live 31,734-edge session: excluded 0). Fixed: `fetchSparSessionIds` returns raw `RecordId[]`, bound record-vs-record. This is the documented codebase rule (`file-context.ts:647` — id-as-string IN-lists silently match nothing).
2. **Thinking `⟨⟩` normalization.** `String(RecordId)` yields `session:⟨uuid⟩`; thinking's local `cleanSessionId` stripped backticks but not angle brackets, so spar keys never matched. Fixed.

## Evidence

- Live before/after on a tagged real session: `ax skills weighted` `worktree-read-strategy` **55 → 54 → 55** (tag → exclude → untag); its cost row stayed in `session_token_usage` throughout (**cost unaffected**). DB left clean.
- `bun run typecheck`: 0 errors. Touched tests: **48/48 pass**. Weighted/spar-sessions tests now assert the record-typed contract (the stub can't evaluate `NOT IN`; the live-DB check is the semantic validation).

## Follow-up (non-blocking)

`thinking-analytics.ts` keeps a local `cleanSessionId` behaviorally identical to the shared `toBareSessionId` (`@ax/lib/shared/session-id`) — one regex-drift away from re-diverging (the exact class of bug #2). Cheap follow-up: import the shared helper, drop the local copy.

Spec: `docs/superpowers/specs/2026-06-15-spar-exclusion-tag-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)