### PR TITLE
feat: ax hooks latency - regression lens over real hook-fire telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,8 @@ warn / inject; defects fail OPEN. `GitEnv` service makes guards layer-testable.
   installed-chain budget vs --budget-ms default 250. Pairs with `ax hooks backtest`
   (benefit) for dojo hook proposals.
 - `ax hooks latency [--days=7] [--baseline=21] [--json]` - regression lens over
-  hook_command_invocation.duration_ms: compare recent vs baseline p95 per hook,
+  hook_command_invocation.duration_ms: compare recent vs baseline p95 per hook
+  event (hook_name is event-granular, e.g. PreToolUse:Bash, UserPromptSubmit),
   flag regressions (factor 1.5, ≥15ms delta, ≥20 samples). Empty-state when
   duration_ms is absent (provider-reported; run bench for synthetic measure).
 - `ax hooks cases` - deterministic feedback-case backtests (enforce-worktree

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,10 @@ warn / inject; defects fail OPEN. `GitEnv` service makes guards layer-testable.
   per-fire p50/p95 from real bun spawns, est fires/day from tool_call history,
   installed-chain budget vs --budget-ms default 250. Pairs with `ax hooks backtest`
   (benefit) for dojo hook proposals.
+- `ax hooks latency [--days=7] [--baseline=21] [--json]` - regression lens over
+  hook_command_invocation.duration_ms: compare recent vs baseline p95 per hook,
+  flag regressions (factor 1.5, ≥15ms delta, ≥20 samples). Empty-state when
+  duration_ms is absent (provider-reported; run bench for synthetic measure).
 - `ax hooks cases` - deterministic feedback-case backtests (enforce-worktree
   candidate query + structured pass/fail verdict; separate from backtest)
 - Codex: new hook entries written to `~/.codex/hooks.json` when that file

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Write a hook once in typed TypeScript, prove it against your own history, run it
 ax hooks init                                    # scaffold ~/.ax/hooks (TypeScript, @ax/hooks-sdk)
 ax hooks backtest ~/.ax/hooks/my-guard.ts        # replay weeks of real tool calls through it first
 ax hooks install ~/.ax/hooks/my-guard.ts --providers=claude,codex
-ax hooks latency [--days=7] [--baseline=21]      # regression lens: recent vs baseline p95 per hook
+ax hooks latency [--days=7] [--baseline=21]      # regression lens: recent vs baseline p95 per hook event
 ```
 
 ## Your agent can query all of this mid-session

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Write a hook once in typed TypeScript, prove it against your own history, run it
 ax hooks init                                    # scaffold ~/.ax/hooks (TypeScript, @ax/hooks-sdk)
 ax hooks backtest ~/.ax/hooks/my-guard.ts        # replay weeks of real tool calls through it first
 ax hooks install ~/.ax/hooks/my-guard.ts --providers=claude,codex
+ax hooks latency [--days=7] [--baseline=21]      # regression lens: recent vs baseline p95 per hook
 ```
 
 ## Your agent can query all of this mid-session

--- a/apps/axctl/src/hooks/cli.ts
+++ b/apps/axctl/src/hooks/cli.ts
@@ -22,6 +22,7 @@ import { GitEnvLive } from "@ax/hooks-sdk/git-env";
 import { fetchRows, replayRows, summarize, formatReport } from "./backtest.ts";
 import { benchHook, renderLedger } from "./bench.ts";
 import type { HookDefinition } from "@ax/hooks-sdk/define";
+import { fetchHookLatencyRegression, renderHookLatency } from "../queries/hook-latency.ts";
 
 /**
  * `ax hooks` config CRUD subcommands (provider-agnostic: claude/cursor/codex/
@@ -320,6 +321,32 @@ const benchCommand = Command.make(
         }).pipe(Effect.provide(HookProviderRegistryDefault)),
 ).pipe(Command.withDescription("Latency ledger for an SDK hook: per-fire p50/p95 (spawn) + fires/day + installed-chain budget (--days=30 --runs=20 --budget-ms=250 --json)"));
 
+const latencyCommand = Command.make(
+    "latency",
+    {
+        days: Flag.integer("days").pipe(Flag.withDefault(7)),
+        baseline: Flag.integer("baseline").pipe(Flag.withDefault(21)),
+        json: Flag.boolean("json").pipe(Flag.withDefault(false)),
+    },
+    ({ days, baseline, json: asJson }) =>
+        fetchHookLatencyRegression({ recentDays: days, baselineDays: baseline }).pipe(
+            Effect.flatMap((report) =>
+                Effect.sync(() => {
+                    console.log(asJson ? prettyPrint(report) : renderHookLatency(report));
+                }),
+            ),
+            Effect.catchTag("DbError", (e) =>
+                Effect.promise(async () => {
+                    process.stderr.write(
+                        `DB unreachable or query failed: ${e.message}\n` +
+                        "Start the DB with 'axctl daemon start' and retry.\n",
+                    );
+                    process.exit(1);
+                }),
+            ),
+        ),
+).pipe(Command.withDescription("Regression lens over hook_command_invocation.duration_ms: compare recent (--days, default 7) vs baseline (--baseline, default 21) p95 per hook; flags regressions (factor 1.5, min 15ms delta, min 20 samples). Empty-state when duration_ms is absent. (--json)"));
+
 /** Spliced into `hooksCommand`'s subcommand list in cli/index.ts. */
 export const hooksConfigSubcommands = [
     configCommand,
@@ -332,4 +359,5 @@ export const hooksConfigSubcommands = [
     installCommand,
     backtestCommand,
     benchCommand,
+    latencyCommand,
 ];

--- a/apps/axctl/src/queries/hook-latency.test.ts
+++ b/apps/axctl/src/queries/hook-latency.test.ts
@@ -238,6 +238,57 @@ describe("renderHookLatency", () => {
         // trim trailing spaces; the warn column for non-regressed is empty string
         expect(hookLine?.trimEnd()).not.toMatch(/⚠\s*$/);
     });
+
+    it("blanks Δp95 and ratio (-/n/a) when a window has 0 samples", () => {
+        // baseline.samples === 0: the numeric delta/ratio would be meaningless
+        // (the hook only fired recently). The comparison columns must blank out.
+        const recentOnly: HookLatencyRow = {
+            hook_name: "recent-only-hook",
+            recent: { p50: 91, p95: 221, samples: 50 },
+            baseline: { p50: 0, p95: 0, samples: 0 },
+            p95_delta_ms: 221, // raw number kept in the model
+            p95_ratio: 0,
+            regressed: false,
+        };
+        const report: HookLatencyReport = {
+            recent_days: 7,
+            baseline_days: 21,
+            rows: [recentOnly],
+            total_fires_with_latency: 50,
+        };
+        const output = renderHookLatency(report);
+        const hookLine = output.split("\n").find((l) => l.includes("recent-only-hook"))!;
+        // Δp95 column shows em dash, NOT a signed "+221ms"
+        expect(hookLine).toContain("-");
+        expect(hookLine).not.toContain("+221ms");
+        // ratio column shows n/a
+        expect(hookLine).toContain("n/a");
+        // the populated window's p50/p95 still render
+        expect(hookLine).toContain("221ms");
+    });
+
+    it("blanks the comparison columns when recent has 0 samples (inverse case)", () => {
+        // recent.samples === 0: a hook that stopped firing - the large negative
+        // delta is not an "improvement", just missing recent data.
+        const baselineOnly: HookLatencyRow = {
+            hook_name: "stopped-hook",
+            recent: { p50: 0, p95: 0, samples: 0 },
+            baseline: { p50: 557, p95: 2808, samples: 444 },
+            p95_delta_ms: -2808,
+            p95_ratio: 0,
+            regressed: false,
+        };
+        const report: HookLatencyReport = {
+            recent_days: 7,
+            baseline_days: 21,
+            rows: [baselineOnly],
+            total_fires_with_latency: 444,
+        };
+        const output = renderHookLatency(report);
+        const hookLine = output.split("\n").find((l) => l.includes("stopped-hook"))!;
+        expect(hookLine).toContain("-");
+        expect(hookLine).not.toContain("-2808ms");
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/axctl/src/queries/hook-latency.test.ts
+++ b/apps/axctl/src/queries/hook-latency.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Tests for hook-latency.ts: regression lens over hook_command_invocation.duration_ms.
+ */
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import type { Layer } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+
+import {
+    fetchHookLatencyRegression,
+    computeHookLatency,
+    renderHookLatency,
+    type HookLatencyReport,
+    type HookLatencyRow,
+} from "./hook-latency.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const run = <A>(eff: Effect.Effect<A, unknown, SurrealClient>, layer: Layer.Layer<SurrealClient>) =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer)));
+
+/** Build a test layer routing the hook latency query to given rows. */
+const makeLatencyMock = (rawRows: unknown[]) => {
+    const tc = makeTestSurrealClient({
+        denyWrites: true,
+        fallback: [rawRows],
+    });
+    return tc;
+};
+
+/**
+ * Build a synthetic ISO timestamp that is `offsetMs` milliseconds ago from now.
+ */
+const ago = (offsetMs: number): string => new Date(Date.now() - offsetMs).toISOString();
+
+const DAY_MS = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// computeHookLatency (pure, unit tests)
+// ---------------------------------------------------------------------------
+
+describe("computeHookLatency", () => {
+    const baseOpts = { recentDays: 7, baselineDays: 21, factor: 1.5, minDeltaMs: 15, minSamples: 5 };
+
+    it("flags a hook as regressed when recent p95 is much higher than baseline", () => {
+        // 10 baseline fires at ~50ms, 10 recent fires at ~200ms
+        const rows = [
+            // baseline: 21+7=28 days ago .. 7 days ago
+            ...Array.from({ length: 10 }, (_, i) => ({
+                hook_name: "slow-hook",
+                ts: ago((8 + i) * DAY_MS), // 8-17 days ago (in baseline window)
+                duration_ms: 50 + i,
+            })),
+            // recent: last 7 days
+            ...Array.from({ length: 10 }, (_, i) => ({
+                hook_name: "slow-hook",
+                ts: ago((i + 1) * DAY_MS * 0.5), // 0.5-5 days ago (in recent window)
+                duration_ms: 200 + i,
+            })),
+        ];
+        const result = computeHookLatency(rows, baseOpts);
+        expect(result).toHaveLength(1);
+        const row = result[0]!;
+        expect(row.hook_name).toBe("slow-hook");
+        expect(row.regressed).toBe(true);
+        expect(row.recent.samples).toBe(10);
+        expect(row.baseline.samples).toBe(10);
+        expect(row.recent.p95).toBeGreaterThan(row.baseline.p95);
+        expect(row.p95_delta_ms).toBe(row.recent.p95 - row.baseline.p95);
+        expect(row.p95_ratio).toBeGreaterThan(0);
+    });
+
+    it("does NOT flag a hook below minSamples even if slower", () => {
+        // Only 3 recent fires (below minSamples=5)
+        const rows = [
+            ...Array.from({ length: 5 }, (_, i) => ({
+                hook_name: "sparse-hook",
+                ts: ago((8 + i) * DAY_MS),
+                duration_ms: 50,
+            })),
+            ...Array.from({ length: 3 }, (_, i) => ({
+                hook_name: "sparse-hook",
+                ts: ago((i + 1) * DAY_MS * 0.5),
+                duration_ms: 300, // much slower, but only 3 samples
+            })),
+        ];
+        const result = computeHookLatency(rows, baseOpts);
+        expect(result).toHaveLength(1);
+        expect(result[0]!.regressed).toBe(false);
+    });
+
+    it("does NOT flag a stable hook (similar p95)", () => {
+        const rows = [
+            ...Array.from({ length: 10 }, (_, i) => ({
+                hook_name: "stable-hook",
+                ts: ago((8 + i) * DAY_MS),
+                duration_ms: 80 + i,
+            })),
+            ...Array.from({ length: 10 }, (_, i) => ({
+                hook_name: "stable-hook",
+                ts: ago((i + 1) * DAY_MS * 0.5),
+                duration_ms: 82 + i, // negligible difference
+            })),
+        ];
+        const result = computeHookLatency(rows, baseOpts);
+        expect(result[0]!.regressed).toBe(false);
+    });
+
+    it("sorts: regressed first, then p95_delta_ms desc", () => {
+        const regressedRows = Array.from({ length: 10 }, (_, i) => ({
+            hook_name: "a-regressed",
+            ts: ago((8 + i) * DAY_MS),
+            duration_ms: 50,
+        })).concat(Array.from({ length: 10 }, (_, i) => ({
+            hook_name: "a-regressed",
+            ts: ago((i + 1) * 12 * 3600 * 1000),
+            duration_ms: 200,
+        })));
+        const stableRows = Array.from({ length: 10 }, (_, i) => ({
+            hook_name: "b-stable",
+            ts: ago((8 + i) * DAY_MS),
+            duration_ms: 80,
+        })).concat(Array.from({ length: 10 }, (_, i) => ({
+            hook_name: "b-stable",
+            ts: ago((i + 1) * 12 * 3600 * 1000),
+            duration_ms: 82,
+        })));
+        const result = computeHookLatency([...stableRows, ...regressedRows], baseOpts);
+        expect(result[0]!.hook_name).toBe("a-regressed");
+        expect(result[0]!.regressed).toBe(true);
+    });
+
+    it("a fire exactly at the recent/baseline boundary lands in baseline (<=)", () => {
+        // A ts that is exactly now - recentDays·d should be in baseline (not recent)
+        const exactCutoff = new Date(Date.now() - baseOpts.recentDays * DAY_MS);
+        const rows = [
+            // The boundary fire - exactly at recentCutoffMs. Since `isRecent` uses strict >,
+            // this ts == recentCutoffMs so it is NOT recent and falls into baseline.
+            {
+                hook_name: "boundary-hook",
+                ts: exactCutoff.toISOString(),
+                duration_ms: 100,
+            },
+            // Extra baseline fires so the bucket appears
+            ...Array.from({ length: 4 }, (_, i) => ({
+                hook_name: "boundary-hook",
+                ts: ago((8 + i) * DAY_MS),
+                duration_ms: 100,
+            })),
+        ];
+        const result = computeHookLatency(rows, { ...baseOpts, minSamples: 1 });
+        expect(result).toHaveLength(1);
+        const row = result[0]!;
+        // The boundary fire is in baseline (total baseline = 5), recent = 0
+        expect(row.baseline.samples).toBe(5);
+        expect(row.recent.samples).toBe(0);
+    });
+
+    it("excludes rows that are neither in recent nor baseline window", () => {
+        // 40 days ago - outside the totalDays=28 window
+        const rows = [
+            {
+                hook_name: "old-hook",
+                ts: ago(40 * DAY_MS),
+                duration_ms: 50,
+            },
+        ];
+        const result = computeHookLatency(rows, baseOpts);
+        // The row is filtered out (outside both windows)
+        expect(result).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// renderHookLatency (pure, unit tests)
+// ---------------------------------------------------------------------------
+
+describe("renderHookLatency", () => {
+    it("empty-state when total_fires_with_latency is 0", () => {
+        const report: HookLatencyReport = {
+            recent_days: 7,
+            baseline_days: 21,
+            rows: [],
+            total_fires_with_latency: 0,
+        };
+        const output = renderHookLatency(report);
+        expect(output).toContain("no hook latency telemetry in this window");
+        expect(output).toContain("duration_ms");
+        expect(output).toContain("ax hooks bench");
+    });
+
+    it("regressed row shows ⚠", () => {
+        const row: HookLatencyRow = {
+            hook_name: "slow-hook",
+            recent: { p50: 150, p95: 300, samples: 25 },
+            baseline: { p50: 60, p95: 80, samples: 25 },
+            p95_delta_ms: 220,
+            p95_ratio: 3.75,
+            regressed: true,
+        };
+        const report: HookLatencyReport = {
+            recent_days: 7,
+            baseline_days: 21,
+            rows: [row],
+            total_fires_with_latency: 50,
+        };
+        const output = renderHookLatency(report);
+        expect(output).toContain("⚠");
+        expect(output).toContain("slow-hook");
+        expect(output).toContain("1 regressed / 1 hooks");
+    });
+
+    it("non-regressed row does NOT show ⚠", () => {
+        const row: HookLatencyRow = {
+            hook_name: "fast-hook",
+            recent: { p50: 70, p95: 85, samples: 25 },
+            baseline: { p50: 65, p95: 80, samples: 25 },
+            p95_delta_ms: 5,
+            p95_ratio: 1.06,
+            regressed: false,
+        };
+        const report: HookLatencyReport = {
+            recent_days: 7,
+            baseline_days: 21,
+            rows: [row],
+            total_fires_with_latency: 50,
+        };
+        const output = renderHookLatency(report);
+        // The ⚠ column header appears but the row's warn cell is empty
+        expect(output).toContain("fast-hook");
+        expect(output).toContain("0 regressed / 1 hooks");
+        // The warning ⚠ should only appear in the header row
+        const lines = output.split("\n");
+        const hookLine = lines.find((l) => l.includes("fast-hook"));
+        // trim trailing spaces; the warn column for non-regressed is empty string
+        expect(hookLine?.trimEnd()).not.toMatch(/⚠\s*$/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchHookLatencyRegression (DB-stub integration tests)
+// ---------------------------------------------------------------------------
+
+describe("fetchHookLatencyRegression", () => {
+    it("two hooks: one regressed, one stable → correct flags, delta, ratio, sort order", async () => {
+        // slow-hook: baseline ~50ms p95, recent ~300ms p95 → regressed
+        // fast-hook: baseline ~80ms p95, recent ~85ms p95 → stable
+        const baselineTs = (i: number) => ago((8 + i) * DAY_MS);
+        const recentTs = (i: number) => ago((i + 1) * 12 * 3600 * 1000); // 0.5-12h ago
+
+        const rawRows = [
+            // slow-hook baseline (25 fires at 40-65ms)
+            ...Array.from({ length: 25 }, (_, i) => ({
+                hook_name: "slow-hook",
+                ts: baselineTs(i % 10),
+                duration_ms: 40 + i,
+            })),
+            // slow-hook recent (25 fires at 200-300ms)
+            ...Array.from({ length: 25 }, (_, i) => ({
+                hook_name: "slow-hook",
+                ts: recentTs(i % 10),
+                duration_ms: 200 + i * 4,
+            })),
+            // fast-hook baseline (25 fires at 70-80ms)
+            ...Array.from({ length: 25 }, (_, i) => ({
+                hook_name: "fast-hook",
+                ts: baselineTs(i % 10),
+                duration_ms: 70 + (i % 10),
+            })),
+            // fast-hook recent (25 fires at 72-82ms - negligible change)
+            ...Array.from({ length: 25 }, (_, i) => ({
+                hook_name: "fast-hook",
+                ts: recentTs(i % 10),
+                duration_ms: 72 + (i % 10),
+            })),
+        ];
+
+        const tc = makeLatencyMock(rawRows);
+        const result = await run(
+            fetchHookLatencyRegression({ recentDays: 7, baselineDays: 21, minSamples: 20 }),
+            tc.layer,
+        );
+
+        expect(result.total_fires_with_latency).toBe(100);
+        expect(result.rows).toHaveLength(2);
+
+        // regressed-first sort
+        expect(result.rows[0]!.hook_name).toBe("slow-hook");
+        expect(result.rows[0]!.regressed).toBe(true);
+        expect(result.rows[0]!.p95_delta_ms).toBeGreaterThan(100);
+        expect(result.rows[0]!.p95_ratio).toBeGreaterThan(1.5);
+
+        expect(result.rows[1]!.hook_name).toBe("fast-hook");
+        expect(result.rows[1]!.regressed).toBe(false);
+    });
+
+    it("hook below minSamples is NOT flagged even if p95 is higher", async () => {
+        const rawRows = [
+            // only 3 recent fires (below minSamples=20)
+            ...Array.from({ length: 20 }, (_, i) => ({
+                hook_name: "sparse-hook",
+                ts: ago((8 + i % 10) * DAY_MS),
+                duration_ms: 50,
+            })),
+            ...Array.from({ length: 3 }, (_, i) => ({
+                hook_name: "sparse-hook",
+                ts: ago((i + 1) * 12 * 3600 * 1000),
+                duration_ms: 500,
+            })),
+        ];
+
+        const tc = makeLatencyMock(rawRows);
+        const result = await run(
+            fetchHookLatencyRegression({ recentDays: 7, baselineDays: 21 }),
+            tc.layer,
+        );
+        expect(result.rows[0]!.regressed).toBe(false);
+        expect(result.rows[0]!.recent.samples).toBe(3);
+    });
+
+    it("returns empty rows (not error) when total_fires_with_latency is 0", async () => {
+        const tc = makeLatencyMock([]);
+        const result = await run(
+            fetchHookLatencyRegression({ recentDays: 7, baselineDays: 21 }),
+            tc.layer,
+        );
+        expect(result.total_fires_with_latency).toBe(0);
+        expect(result.rows).toHaveLength(0);
+    });
+
+    it("duration_ms NONE rows are excluded by the WHERE clause (stub reflects this)", async () => {
+        // Stub only returns rows WITHOUT duration_ms=NONE (the WHERE filters them DB-side).
+        // We verify that a stub with valid rows still counts correctly.
+        const rawRows = [
+            { hook_name: "test-hook", ts: ago(1 * DAY_MS * 0.5), duration_ms: 100 },
+            { hook_name: "test-hook", ts: ago(10 * DAY_MS), duration_ms: 80 },
+        ];
+        const tc = makeLatencyMock(rawRows);
+        const result = await run(
+            fetchHookLatencyRegression({ recentDays: 7, baselineDays: 21 }),
+            tc.layer,
+        );
+        // Both valid rows counted
+        expect(result.total_fires_with_latency).toBe(2);
+    });
+});

--- a/apps/axctl/src/queries/hook-latency.ts
+++ b/apps/axctl/src/queries/hook-latency.ts
@@ -1,0 +1,215 @@
+/**
+ * `ax hooks latency` query: windowed regression lens over hook_command_invocation.duration_ms.
+ *
+ * Detects whether installed hooks are getting slower over time by comparing
+ * a "recent" window against a "baseline" window of the same width immediately before.
+ * No new schema needed - reads existing hook_command_invocation telemetry.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { percentiles } from "../hooks/bench.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface HookLatencyWindow {
+    readonly p50: number;
+    readonly p95: number;
+    readonly samples: number;
+}
+
+export interface HookLatencyRow {
+    readonly hook_name: string;
+    readonly recent: HookLatencyWindow;
+    readonly baseline: HookLatencyWindow;
+    readonly p95_delta_ms: number;    // recent.p95 - baseline.p95
+    readonly p95_ratio: number;       // recent.p95 / baseline.p95 (0 if baseline.p95 === 0)
+    readonly regressed: boolean;
+}
+
+export interface HookLatencyReport {
+    readonly recent_days: number;
+    readonly baseline_days: number;
+    readonly rows: ReadonlyArray<HookLatencyRow>;
+    readonly total_fires_with_latency: number;
+}
+
+// ---------------------------------------------------------------------------
+// Raw DB row shape
+// ---------------------------------------------------------------------------
+
+interface RawInvocationRow {
+    readonly hook_name: string;
+    readonly ts: string | Date;
+    readonly duration_ms: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+const validDays = (n: number): number => Math.max(1, Math.trunc(n));
+
+/**
+ * PURE: group raw rows into recent/baseline buckets per hook, compute percentiles,
+ * apply regression flag, sort.
+ */
+export const computeHookLatency = (
+    rows: ReadonlyArray<RawInvocationRow>,
+    opts: {
+        recentDays: number;
+        baselineDays: number;
+        factor: number;
+        minDeltaMs: number;
+        minSamples: number;
+    },
+): HookLatencyRow[] => {
+    const nowMs = Date.now();
+    const recentCutoffMs = nowMs - opts.recentDays * 86_400_000;
+    const baselineCutoffMs = nowMs - (opts.recentDays + opts.baselineDays) * 86_400_000;
+
+    // Bucket: hook_name -> { recent: ms[], baseline: ms[] }
+    const byHook = new Map<string, { recent: number[]; baseline: number[] }>();
+    for (const row of rows) {
+        const tsMs = row.ts instanceof Date ? row.ts.getTime() : new Date(String(row.ts)).getTime();
+        const ms = Number(row.duration_ms);
+        if (!Number.isFinite(ms)) continue;
+        // recent window: ts > now - recentDays·d
+        const isRecent = tsMs > recentCutoffMs;
+        // baseline window: now - (recentDays+baselineDays)·d < ts <= now - recentDays·d
+        const isBaseline = tsMs > baselineCutoffMs && tsMs <= recentCutoffMs;
+        if (!isRecent && !isBaseline) continue;
+        const entry = byHook.get(row.hook_name) ?? { recent: [], baseline: [] };
+        if (isRecent) entry.recent.push(ms);
+        else entry.baseline.push(ms);
+        byHook.set(row.hook_name, entry);
+    }
+
+    const result: HookLatencyRow[] = [];
+    for (const [hook_name, { recent: recentMs, baseline: baselineMs }] of byHook.entries()) {
+        const recentStats = percentiles(recentMs);
+        const baselineStats = percentiles(baselineMs);
+        const p95_delta_ms = recentStats.p95 - baselineStats.p95;
+        const p95_ratio = baselineStats.p95 === 0 ? 0 : recentStats.p95 / baselineStats.p95;
+        const regressed =
+            recentMs.length >= opts.minSamples &&
+            baselineMs.length >= opts.minSamples &&
+            p95_delta_ms >= opts.minDeltaMs &&
+            recentStats.p95 >= baselineStats.p95 * opts.factor;
+        result.push({
+            hook_name,
+            recent: { p50: recentStats.p50, p95: recentStats.p95, samples: recentMs.length },
+            baseline: { p50: baselineStats.p50, p95: baselineStats.p95, samples: baselineMs.length },
+            p95_delta_ms,
+            p95_ratio,
+            regressed,
+        });
+    }
+
+    // Sort: regressed first, then p95_delta_ms desc
+    result.sort((a, b) => {
+        if (a.regressed !== b.regressed) return a.regressed ? -1 : 1;
+        return b.p95_delta_ms - a.p95_delta_ms;
+    });
+
+    return result;
+};
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+const pad = (s: string, n: number) => s.padEnd(n);
+const rpad = (s: string, n: number) => s.padStart(n);
+
+/**
+ * PURE: render a HookLatencyReport as a string.
+ * Table: hook_name · recent p50/p95 (n) · baseline p50/p95 (n) · Δp95 · ratio · ⚠
+ * Footer: N regressed / M hooks
+ * Empty-state when total_fires_with_latency === 0.
+ */
+export const renderHookLatency = (report: HookLatencyReport): string => {
+    if (report.total_fires_with_latency === 0) {
+        return "no hook latency telemetry in this window - duration_ms is provider-reported and may be absent; try a wider --days or run `ax hooks bench <file>` for a synthetic measure.";
+    }
+
+    const rows = report.rows;
+    if (rows.length === 0) {
+        return `no hook invocations with latency data found (total_fires_with_latency=${report.total_fires_with_latency})`;
+    }
+
+    const header = [
+        pad("hook", 32),
+        rpad("rec p50", 8),
+        rpad("rec p95", 8),
+        rpad("rec n", 7),
+        rpad("base p50", 9),
+        rpad("base p95", 9),
+        rpad("base n", 7),
+        rpad("Δp95", 8),
+        rpad("ratio", 7),
+        "⚠",
+    ].join(" ");
+
+    const lines: string[] = [header];
+    for (const row of rows) {
+        const warn = row.regressed ? "⚠" : "";
+        lines.push([
+            pad(row.hook_name, 32),
+            rpad(`${row.recent.p50}ms`, 8),
+            rpad(`${row.recent.p95}ms`, 8),
+            rpad(String(row.recent.samples), 7),
+            rpad(`${row.baseline.p50}ms`, 9),
+            rpad(`${row.baseline.p95}ms`, 9),
+            rpad(String(row.baseline.samples), 7),
+            rpad(`${row.p95_delta_ms >= 0 ? "+" : ""}${row.p95_delta_ms}ms`, 8),
+            rpad(row.p95_ratio === 0 ? "n/a" : `${row.p95_ratio.toFixed(2)}x`, 7),
+            warn,
+        ].join(" "));
+    }
+
+    const regrCount = rows.filter((r) => r.regressed).length;
+    lines.push(`\n${regrCount} regressed / ${rows.length} hooks  (recent=${report.recent_days}d vs baseline=${report.baseline_days}d)`);
+    return lines.join("\n");
+};
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+
+export const fetchHookLatencyRegression = (opts: {
+    readonly recentDays: number;
+    readonly baselineDays: number;
+    readonly factor?: number;
+    readonly minDeltaMs?: number;
+    readonly minSamples?: number;
+}): Effect.Effect<HookLatencyReport, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const factor = opts.factor ?? 1.5;
+        const minDeltaMs = opts.minDeltaMs ?? 15;
+        const minSamples = opts.minSamples ?? 20;
+        const totalDays = validDays(opts.recentDays) + validDays(opts.baselineDays);
+
+        const sql = `SELECT hook_name, <string>ts AS ts, duration_ms FROM hook_command_invocation WHERE duration_ms != NONE AND ts > time::now() - ${totalDays}d ORDER BY ts DESC;`;
+
+        const [rows] = yield* db.query<[RawInvocationRow[]]>(sql);
+        const rawRows = rows ?? [];
+
+        const computedRows = computeHookLatency(rawRows, {
+            recentDays: validDays(opts.recentDays),
+            baselineDays: validDays(opts.baselineDays),
+            factor,
+            minDeltaMs,
+            minSamples,
+        });
+
+        return {
+            recent_days: validDays(opts.recentDays),
+            baseline_days: validDays(opts.baselineDays),
+            rows: computedRows,
+            total_fires_with_latency: rawRows.length,
+        } satisfies HookLatencyReport;
+    });

--- a/apps/axctl/src/queries/hook-latency.ts
+++ b/apps/axctl/src/queries/hook-latency.ts
@@ -156,6 +156,18 @@ export const renderHookLatency = (report: HookLatencyReport): string => {
     const lines: string[] = [header];
     for (const row of rows) {
         const warn = row.regressed ? "⚠" : "";
+        // Δp95 and ratio compare the two windows - meaningless when EITHER
+        // window has no samples (e.g. a hook that only fired recently shows a
+        // huge "+delta" purely because baseline is empty). Blank them so the
+        // table can't be misread as a regression/improvement. The populated
+        // window's p50/p95 columns still render; the raw JSON keeps the numbers.
+        const oneWindowEmpty = row.recent.samples === 0 || row.baseline.samples === 0;
+        const deltaCell = oneWindowEmpty
+            ? "-"
+            : `${row.p95_delta_ms >= 0 ? "+" : ""}${row.p95_delta_ms}ms`;
+        const ratioCell = oneWindowEmpty || row.p95_ratio === 0
+            ? "n/a"
+            : `${row.p95_ratio.toFixed(2)}x`;
         lines.push([
             pad(row.hook_name, 32),
             rpad(`${row.recent.p50}ms`, 8),
@@ -164,8 +176,8 @@ export const renderHookLatency = (report: HookLatencyReport): string => {
             rpad(`${row.baseline.p50}ms`, 9),
             rpad(`${row.baseline.p95}ms`, 9),
             rpad(String(row.baseline.samples), 7),
-            rpad(`${row.p95_delta_ms >= 0 ? "+" : ""}${row.p95_delta_ms}ms`, 8),
-            rpad(row.p95_ratio === 0 ? "n/a" : `${row.p95_ratio.toFixed(2)}x`, 7),
+            rpad(deltaCell, 8),
+            rpad(ratioCell, 7),
             warn,
         ].join(" "));
     }

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -56,6 +56,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax:dojo` skill - surplus-quota overnight training loop: budget-bounded self-improvement (verdicts, briefs, routing, proposals, experiments); install via `npx skills add Necmttn/ax`
 - `ax hooks init / install / backtest / bench / cases` - author typed TypeScript hooks once, run them on Claude Code + Codex; replay history through a hook before installing it
 - `ax hooks bench <file> [--days=N] [--runs=N] [--budget-ms=N] [--json]` - latency ledger: per-fire p50/p95 from real bun spawns, est fires/day from tool_call history, installed-chain budget vs --budget-ms default 250
+- `ax hooks latency [--days=N] [--baseline=M] [--json]` - regression lens: compare recent (default 7d) vs baseline (default 21d) hook fire latency from hook_command_invocation telemetry; flags hooks where p95 regressed (factor 1.5, min 15ms delta, min 20 samples)
 
 ### Graph insights
 - `ax insights <view>` - 31 read-only graph views

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -56,7 +56,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax:dojo` skill - surplus-quota overnight training loop: budget-bounded self-improvement (verdicts, briefs, routing, proposals, experiments); install via `npx skills add Necmttn/ax`
 - `ax hooks init / install / backtest / bench / cases` - author typed TypeScript hooks once, run them on Claude Code + Codex; replay history through a hook before installing it
 - `ax hooks bench <file> [--days=N] [--runs=N] [--budget-ms=N] [--json]` - latency ledger: per-fire p50/p95 from real bun spawns, est fires/day from tool_call history, installed-chain budget vs --budget-ms default 250
-- `ax hooks latency [--days=N] [--baseline=M] [--json]` - regression lens: compare recent (default 7d) vs baseline (default 21d) hook fire latency from hook_command_invocation telemetry; flags hooks where p95 regressed (factor 1.5, min 15ms delta, min 20 samples)
+- `ax hooks latency [--days=N] [--baseline=M] [--json]` - regression lens: compare recent (default 7d) vs baseline (default 21d) fire latency per hook event (hook_name is event-granular, e.g. PreToolUse:Bash) from hook_command_invocation telemetry; flags hook events where p95 regressed (factor 1.5, min 15ms delta, min 20 samples)
 
 ### Graph insights
 - `ax insights <view>` - 31 read-only graph views

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,7 +61,7 @@ axctl hooks <summary|invocations|backtest|bench|session|config ...>   # + hook-c
 axctl hooks bench <file> [--days=N] [--runs=N] [--budget-ms=N] [--json]
                                             # latency ledger: per-fire p50/p95 (spawn) + fires/day + installed-chain budget
 axctl hooks latency [--days=N (default 7)] [--baseline=M (default 21)] [--json]
-                                            # regression lens: compare recent vs baseline hook fire latency from telemetry
+                                            # regression lens: compare recent vs baseline fire latency by hook event from telemetry
 
 axctl daemon <status|start|stop|restart>
 axctl doctor                                # local-install health check

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,6 +60,8 @@ axctl hook <fire>                           # hook helper invoked from settings.
 axctl hooks <summary|invocations|backtest|bench|session|config ...>   # + hook-config CRUD
 axctl hooks bench <file> [--days=N] [--runs=N] [--budget-ms=N] [--json]
                                             # latency ledger: per-fire p50/p95 (spawn) + fires/day + installed-chain budget
+axctl hooks latency [--days=N (default 7)] [--baseline=M (default 21)] [--json]
+                                            # regression lens: compare recent vs baseline hook fire latency from telemetry
 
 axctl daemon <status|start|stop|restart>
 axctl doctor                                # local-install health check

--- a/docs/superpowers/specs/2026-06-15-hook-latency-regression-design.md
+++ b/docs/superpowers/specs/2026-06-15-hook-latency-regression-design.md
@@ -1,0 +1,136 @@
+# Hook-latency regression tracking
+
+Date: 2026-06-15
+Status: final design, pre-implementation
+Follows: `ax hooks bench` (`apps/axctl/src/hooks/bench.ts`), the hook telemetry
+tables, the dispatch-economy / churn "windowed lens" pattern.
+
+## Problem
+
+Hooks run on the agent hot path (~70 ms budget). `ax hooks bench` measures a
+candidate's latency *synthetically* (real bun spawns) at a point in time, but
+nothing tracks whether an installed hook is getting **slower over time** in real
+use - a latency regression (a new dep, a heavier query, a bigger routing table)
+silently erodes the hot-path budget.
+
+The real per-fire latency is already in the graph: `hook_command_invocation` has
+`duration_ms` (option<int>), `hook_name`, `harness`, `ts`. So regression tracking
+can be a **windowed read** over existing telemetry - no new storage - matching
+the `ax dispatches --economy` / `ax sessions churn` idiom.
+
+## Decision (locked)
+
+- **Telemetry-lens now.** Ship a windowed regression lens over
+  `hook_command_invocation.duration_ms`. No new schema/table.
+- **Bench-snapshot table later (noted follow-up).** If real-fire `duration_ms`
+  proves too sparse to trust (it is provider-reported and may be absent for some
+  harnesses/events), a future PR can persist `ax hooks bench` snapshots to a new
+  table for dense, deterministic history. Out of scope here; flagged in the PR.
+
+## Design
+
+### Query: `fetchHookLatencyRegression`
+
+New `apps/axctl/src/queries/hook-latency.ts`:
+
+```ts
+export interface HookLatencyWindow {
+  readonly p50: number; readonly p95: number; readonly samples: number;
+}
+export interface HookLatencyRow {
+  readonly hook_name: string;
+  readonly recent: HookLatencyWindow;
+  readonly baseline: HookLatencyWindow;
+  readonly p95_delta_ms: number;     // recent.p95 - baseline.p95
+  readonly p95_ratio: number;        // recent.p95 / baseline.p95 (0 if baseline.p95 === 0)
+  readonly regressed: boolean;
+}
+export interface HookLatencyReport {
+  readonly recent_days: number;
+  readonly baseline_days: number;
+  readonly rows: ReadonlyArray<HookLatencyRow>;   // sorted: regressed first, then p95_delta desc
+  readonly total_fires_with_latency: number;      // for the empty-state guard
+}
+export const fetchHookLatencyRegression = (opts: {
+  recentDays: number; baselineDays: number;
+  factor?: number; minDeltaMs?: number; minSamples?: number;
+}): Effect.Effect<HookLatencyReport, DbError, SurrealClient>
+```
+
+Mechanics:
+- **Windows.** recent = `ts > now - recentDays·d`. baseline = the span of
+  `baselineDays` immediately BEFORE the recent window:
+  `now - (recentDays+baselineDays)·d < ts <= now - recentDays·d`. (Disjoint, so a
+  regression compares "now" against "the period before now," not against itself.)
+- **Fetch** `hook_name`, `ts`, `duration_ms` from `hook_command_invocation`
+  WHERE `duration_ms != NONE` AND `ts > now - (recentDays+baselineDays)·d`. Flat
+  fields only (no graph traversal/derefs). Bucket each row into recent/baseline
+  by `ts` in JS.
+- **Percentiles.** Reuse the exported `percentiles()` from `apps/axctl/src/hooks/bench.ts`
+  (DRY - same p50/p95 helper the bench ledger uses) on each hook×window duration
+  array. (If reusing forces an awkward import direction, lift `percentiles` to a
+  small shared util both import; prefer reuse first.)
+- **Regression flag** (all must hold, to suppress noise):
+  `recent.samples >= minSamples` (default 20) AND `baseline.samples >= minSamples`
+  AND `recent.p95 - baseline.p95 >= minDeltaMs` (default 15) AND
+  `recent.p95 >= baseline.p95 * factor` (default 1.5).
+- **Sort** rows: regressed first, then by `p95_delta_ms` desc.
+
+### CLI: `ax hooks latency`
+
+`apps/axctl/src/hooks/cli.ts` - new subcommand mirroring `benchCommand`:
+`ax hooks latency [--days=N] [--baseline=M] [--json]` (defaults: days 7,
+baseline 21).
+- Table: `hook_name · recent p50/p95 (n) · baseline p50/p95 (n) · Δp95 · ratio · ⚠`
+  for regressed rows. Sorted regressed-first.
+- Footer: count regressed / total hooks with telemetry.
+- **Empty-state:** when `total_fires_with_latency === 0`, print a clear line:
+  "no hook latency telemetry in this window - `duration_ms` is provider-reported
+  and may be absent; try a wider --days or run `ax hooks bench <file>` for a
+  synthetic measure." (Exit 0, not an error.)
+- `--json` emits the `HookLatencyReport`.
+
+### Format helper
+Put rendering in a small pure `renderHookLatency(report) → string` (testable)
+next to the query or in the existing hooks-format location, mirroring how bench
+splits `benchHook` (compute) from `renderLedger` (format).
+
+## Tests
+- `fetchHookLatencyRegression`: route-stub test layer (like
+  `thinking-analytics.test.ts`) - seed recent+baseline fires for two hooks, one
+  regressed (recent p95 ≫ baseline) one stable; assert the regressed flag, delta,
+  ratio, sort order, and that sub-`minSamples` hooks are NOT flagged. Assert
+  `duration_ms == NONE` rows are excluded.
+- `renderHookLatency`: regressed row shows ⚠; empty report shows the empty-state
+  line.
+- Window bucketing: a fire exactly at the recent/baseline boundary lands in the
+  intended window.
+
+## Docs (check:cli-reference gate - this IS a new subcommand)
+- `README.md` + `docs/cli.md`: `axctl hooks latency` entry.
+- `apps/site/public/llms.txt`: the `ax hooks latency` line.
+- `CLAUDE.md` Hooks SDK section: a bullet for `ax hooks latency`.
+Run `bun run check:cli-reference` to confirm coverage.
+
+## Verify
+- Unit tests above; `bun run typecheck`; touched-package `bun test`.
+- **Live validation (report it):** run `ax hooks latency --days=7 --baseline=21`
+  against the local DB and report whether `duration_ms` is populated enough to be
+  useful. If the lens is empty (sparse telemetry), that's an expected degrade -
+  confirm the empty-state renders and note it in the PR (it's the trigger for the
+  snapshot-table follow-up).
+
+## Out of scope / later
+- Bench-snapshot persistence table (the "dense history" alternative) - follow-up
+  if telemetry is too sparse.
+- MCP `hook_latency` tool - add later if wanted (read-only, would fit).
+- Per-event / per-harness latency breakdown (v1 is per `hook_name`).
+- Alerting / CI gate on regression (v1 is a lens you run).
+
+## Module map
+```
+apps/axctl/src/queries/hook-latency.ts        NEW fetchHookLatencyRegression + types + renderHookLatency + tests
+apps/axctl/src/hooks/cli.ts                    + `ax hooks latency` subcommand
+apps/axctl/src/hooks/bench.ts                  reuse exported percentiles() (no change, or lift to shared util)
+README.md / docs/cli.md / llms.txt / CLAUDE.md  new-subcommand docs (check:cli-reference)
+```


### PR DESCRIPTION
## What

`ax hooks latency [--days=N] [--baseline=M] [--json]` — a windowed regression lens over `hook_command_invocation.duration_ms` (the real per-fire latency already in the graph). Per hook **event** (`hook_name` is event-granular, e.g. `PreToolUse:Bash`, `UserPromptSubmit`), it compares a recent window's p50/p95 against the disjoint baseline window before it and flags events whose p95 regressed.

Closes the last handoff TASK 2 item (continuous hook-latency regression tracking). No new schema/storage — a read over existing telemetry, matching the `ax dispatches --economy` / `ax sessions churn` idiom.

## How it works

- **Windows:** recent = `ts > now-days·d`; baseline = the `baseline` days immediately before (disjoint; a boundary fire lands in baseline).
- **Percentiles:** reuses the exported `percentiles()` from `hooks/bench.ts` (DRY).
- **Regression gate** (all must hold, to suppress noise): recent.samples ≥ 20 AND baseline.samples ≥ 20 AND Δp95 ≥ 15ms AND recent.p95 ≥ baseline.p95 × 1.5.
- **Empty/one-sided windows:** Δp95 + ratio render as `—`/`n/a` (not a misleading number); `--json` keeps raw values. Clean empty-state when telemetry is absent.

## Evidence (live)

`duration_ms` is well-populated locally — the lens surfaced a real regression:

```
hook                  rec p50  rec p95  rec n   base p50  base p95  base n    Δp95   ratio ⚠
UserPromptSubmit        485ms    860ms   1371      373ms     439ms     110  +421ms   1.96x ⚠
PreToolUse:Agent         91ms    221ms     50        0ms       0ms       0       —     n/a
PreToolUse:Read           0ms      0ms      0      557ms    2808ms     444       —     n/a
...
1 regressed / 12 hooks  (recent=7d vs baseline=21d)
```

- `bun run typecheck`: 0 errors. `check:cli-reference`: pass (25 subcommands). hook-latency tests: **15/15**.

## Follow-up (noted, out of scope)

- **Bench-snapshot table** for dense, deterministic history if real-fire `duration_ms` is too sparse on a given machine (the locked "lens now, snapshots later" decision).
- Group by hook *command/file* (not just event), MCP `hook_latency` tool, per-harness breakdown.

Spec: `docs/superpowers/specs/2026-06-15-hook-latency-regression-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)