### PR TITLE
fix(otel): correct Codex [otel] config format (was breaking all codex commands)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,12 @@ fresh clone.
 ### OTLP receiver (ax serve)
 
 `ax serve` accepts harness OTLP/JSON telemetry on the daemon port (1738):
-`POST /v1/metrics` (Claude Code usage metrics) + `POST /v1/traces` (Codex
-spans); `/v1/logs` is accepted and dropped (v1 no-op). Bodies decode via Effect
+`POST /v1/metrics` (Claude Code usage metrics) + `POST /v1/traces` (span
+sources); `/v1/logs` is accepted and dropped (v1 no-op - full logs ingestion is
+the next PR). NOTE: Codex emits OTLP *logs* (events: conversation_starts,
+user_prompt, token usage), NOT spans, and POSTs to the endpoint as-is, so its
+config targets `/v1/logs` (struct-variant exporter, `protocol = "json"`; see
+install-config.ts); its data lands once logs ingestion ships. Bodies decode via Effect
 `Schema` (curated OTLP/JSON subset, `apps/axctl/src/otel/`), normalize per-harness
 (`service.name` -> harness label), and land in `otel_metric_point` / `otel_span`.
 A correlation pass at ingest finish draws `session -> telemetry_of -> otel_*`

--- a/apps/axctl/src/otel/install-config.test.ts
+++ b/apps/axctl/src/otel/install-config.test.ts
@@ -23,11 +23,35 @@ describe("install-config", () => {
         expect(next.env.FOO).toBe("bar");
     });
 
-    test("codex toml gains an [otel] block with the endpoint", () => {
+    test("codex toml writes the struct-variant exporter (NOT a bare string)", () => {
         const toml = applyCodexOtelToml("", ENDPOINT);
         expect(toml).toContain("[otel]");
-        expect(toml).toContain(ENDPOINT);
-        expect(toml).toContain("http/json");
+        // The bug this guards: `exporter = "otlp-http"` is a unit variant and
+        // fails Codex config load, breaking every codex command. It MUST be a
+        // struct variant.
+        expect(toml).toContain("exporter = { otlp-http = {");
+        expect(toml).not.toContain(`exporter = "otlp-http"`);
+        // Codex posts as-is + emits logs → endpoint carries the /v1/logs path.
+        expect(toml).toContain(`endpoint = "${ENDPOINT}/v1/logs"`);
+        // Codex's protocol value is "json" (not OTEL env's "http/json").
+        expect(toml).toContain(`protocol = "json"`);
+        expect(toml).not.toContain("http/json");
+    });
+
+    test("codex toml is valid TOML and parses to the expected shape", async () => {
+        const { tmpdir } = await import("node:os");
+        const { join } = await import("node:path");
+        const toml = applyCodexOtelToml(`model = "gpt-5"\n`, ENDPOINT);
+        // Bun parses .toml on import; an invalid struct (the old bug) throws here.
+        const file = join(tmpdir(), `ax-codex-otel-${process.pid}-${Math.trunc(performance.now())}.toml`);
+        await Bun.write(file, toml);
+        const cfg = (await import(file)).default as {
+            model: string;
+            otel: { exporter: { "otlp-http": { endpoint: string; protocol: string } } };
+        };
+        expect(cfg.model).toBe("gpt-5"); // unrelated content preserved
+        expect(cfg.otel.exporter["otlp-http"].endpoint).toBe(`${ENDPOINT}/v1/logs`);
+        expect(cfg.otel.exporter["otlp-http"].protocol).toBe("json");
     });
 
     test("codex toml is idempotent", () => {

--- a/apps/axctl/src/otel/install-config.ts
+++ b/apps/axctl/src/otel/install-config.ts
@@ -17,8 +17,22 @@ export const applyClaudeOtelEnv = (
 };
 
 const CODEX_MARKER = "# ax:otel";
-const codexBlock = (endpoint: string): string =>
-    `${CODEX_MARKER}\n[otel]\nexporter = "otlp-http"\nendpoint = "${endpoint}"\nprotocol = "http/json"\n`;
+/**
+ * Codex's `[otel]` schema differs from Claude's env-based config in three ways
+ * (all learned the hard way against a live Codex):
+ *   1. `exporter` is a STRUCT-VARIANT enum - a bare string (`"otlp-http"`) is
+ *      parsed as a unit variant and fails config load, breaking ALL codex
+ *      commands. It must be `exporter = { otlp-http = { ... } }`.
+ *   2. The otlp-http exporter POSTs to the endpoint AS-IS (it does NOT append
+ *      `/v1/<signal>`), and Codex emits OTLP *logs* (events: conversation_starts,
+ *      user_prompt, token usage...), not spans. So the endpoint must carry the
+ *      full `/v1/logs` path - that is where ax's receiver takes Codex telemetry.
+ *   3. `protocol` is Codex's own value `"json"` (not OTEL env's `"http/json"`).
+ */
+const codexBlock = (endpoint: string): string => {
+    const logsEndpoint = `${endpoint.replace(/\/+$/, "")}/v1/logs`;
+    return `${CODEX_MARKER}\n[otel]\nexporter = { otlp-http = { endpoint = "${logsEndpoint}", protocol = "json" } }\n`;
+};
 
 // Matches the ax-owned marker + [otel] block until the next [section] header
 // (that is NOT [otel] itself) or end-of-string. The `?=\n\[(?!otel])` lookahead


### PR DESCRIPTION
## Summary

Follow-up to #423. `applyCodexOtelToml` shipped an **invalid Codex config** that breaks **every Codex command** once `ax install` writes it:

```toml
[otel]
exporter = "otlp-http"   # ← bare string = unit variant → "invalid type: unit variant, expected struct variant"
```

Codex's `exporter` is a **struct-variant enum**; the correct form is:

```toml
[otel]
exporter = { otlp-http = { endpoint = "http://127.0.0.1:1738/v1/logs", protocol = "json" } }
```

Found by dogfooding against a live Codex (`codex exec` → config load error). Three corrections, all verified against real Codex behavior:

1. **Struct-variant `exporter`** (the breakage) — not a bare string.
2. **Endpoint carries the full `/v1/logs` path** — Codex's otlp-http exporter POSTs to the endpoint *as-is* (no `/v1/<signal>` appending, unlike the standard OTEL SDK), and Codex emits OTLP **logs** (events: `codex.conversation_starts`, `user_prompt`, token usage), **not spans**. `/v1/logs` is where ax's receiver takes Codex telemetry (full logs ingestion is the next PR; today it's a no-op 200).
3. **`protocol = "json"`** — Codex's own value, not OTEL env's `"http/json"`.

Claude config (`applyClaudeOtelEnv`) is unchanged and correct (it uses the env-based `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` + base endpoint; CC appends `/v1/metrics` itself — verified landing real metrics).

## Test plan

- [x] New `install-config.test.ts` test **parses the generated TOML** (Bun `.toml` import) and asserts `otel.exporter["otlp-http"].endpoint`/`.protocol` — this catches the unit-variant regression. The old test only checked substrings (`http/json`, `[otel]`) all present in the broken output, so it passed on the bug.
- [x] Asserts `exporter = { otlp-http = {` present and `exporter = "otlp-http"` absent.
- [x] `bun test apps/axctl/src/otel/install-config.test.ts` → 7 pass. Typecheck clean.
- [x] Verified live: corrected config loads, `codex exec` runs, Codex POSTs JSON OTLP logs to the endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)