### PR TITLE
feat(studio): instrument-ify the rest of the dashboard + Context Budget (reclaim/drift)

### DIFF
--- a/apps/axctl/src/dashboard/contract/insights.ts
+++ b/apps/axctl/src/dashboard/contract/insights.ts
@@ -10,7 +10,7 @@ import { Effect } from "effect";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { AxApi, NotFoundError } from "@ax/lib/shared/api-contract";
 import { fetchCostModels } from "../../queries/cost-analytics.ts";
-import { fetchContextBudget } from "../../queries/context-budget.ts";
+import { fetchContextBudget, fetchSkillDrift } from "../../queries/context-budget.ts";
 import { fetchEpisodeTimeline } from "../episode-timeline.ts";
 import { fetchProject } from "../project.ts";
 import { emptyRecallResponse, fetchRecall, type RecallParams } from "../recall.ts";
@@ -83,6 +83,8 @@ export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handle
             orInternal(fetchCostModels({ sinceDays: 365 }).pipe(Effect.map(asJsonValue))))
         .handle("contextBudget", () =>
             orInternal(fetchContextBudget().pipe(Effect.map(asJsonValue))))
+        .handle("contextDrift", () =>
+            orInternal(fetchSkillDrift({ limit: 100 }).pipe(Effect.map(asJsonValue))))
         .handle("workflow", () => orInternal(fetchWorkflow()))
         .handle("toolFailures", () => orInternal(fetchToolFailures()))
         .handle("toolFailureDetail", ({ params }) => orInternal(fetchToolFailureDetail(params.label))));

--- a/apps/axctl/src/dashboard/contract/insights.ts
+++ b/apps/axctl/src/dashboard/contract/insights.ts
@@ -10,6 +10,7 @@ import { Effect } from "effect";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { AxApi, NotFoundError } from "@ax/lib/shared/api-contract";
 import { fetchCostModels } from "../../queries/cost-analytics.ts";
+import { fetchContextBudget } from "../../queries/context-budget.ts";
 import { fetchEpisodeTimeline } from "../episode-timeline.ts";
 import { fetchProject } from "../project.ts";
 import { emptyRecallResponse, fetchRecall, type RecallParams } from "../recall.ts";
@@ -80,6 +81,8 @@ export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handle
             })))
         .handle("costModels", () =>
             orInternal(fetchCostModels({ sinceDays: 365 }).pipe(Effect.map(asJsonValue))))
+        .handle("contextBudget", () =>
+            orInternal(fetchContextBudget().pipe(Effect.map(asJsonValue))))
         .handle("workflow", () => orInternal(fetchWorkflow()))
         .handle("toolFailures", () => orInternal(fetchToolFailures()))
         .handle("toolFailureDetail", ({ params }) => orInternal(fetchToolFailureDetail(params.label))));

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -56,6 +56,7 @@ const CONTRACT_ROUTES: ReadonlySet<string> = new Set([
     "GET /api/wrapped/generate-brief",
     "GET /api/cost/models",
     "GET /api/context/budget",
+    "GET /api/context/drift",
     "GET /api/workflow",
     "GET /api/tool-failures",
     // sessions

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -55,6 +55,7 @@ const CONTRACT_ROUTES: ReadonlySet<string> = new Set([
     "GET /api/wrapped/public-preview",
     "GET /api/wrapped/generate-brief",
     "GET /api/cost/models",
+    "GET /api/context/budget",
     "GET /api/workflow",
     "GET /api/tool-failures",
     // sessions

--- a/apps/axctl/src/ingest/skill-upsert.ts
+++ b/apps/axctl/src/ingest/skill-upsert.ts
@@ -16,6 +16,8 @@ export interface SkillContent {
 
 interface SkillLookupRow {
     readonly id?: unknown;
+    readonly content_hash?: unknown;
+    readonly bytes?: unknown;
 }
 
 export function skillRecordIdFromLookup(raw: unknown, fallbackName: SkillName): RecordId {
@@ -34,11 +36,35 @@ export function upsertSkillByName(
 ): Effect.Effect<RecordId, DbError> {
     return Effect.gen(function* () {
         const result = yield* db.query<[SkillLookupRow[]]>(
-            "SELECT id FROM skill WHERE name = $name LIMIT 1;",
+            "SELECT id, content_hash, bytes FROM skill WHERE name = $name LIMIT 1;",
             { name: content.name },
         );
-        const existingId = result?.[0]?.[0]?.id;
-        const id = skillRecordIdFromLookup(existingId, content.name);
+        const existing = result?.[0]?.[0];
+        const id = skillRecordIdFromLookup(existing?.id, content.name);
+
+        // Drift log: append a skill_revision ONLY on a real content change (the
+        // hash flipped) or the first sighting of a new skill. The current `skill`
+        // row is the baseline; this is the append-only trail to diff against.
+        // Fails open - the audit write must never break ingest.
+        const prevHash = typeof existing?.content_hash === "string" ? existing.content_hash : undefined;
+        const isNew = existing == null;
+        const changed = prevHash != null && prevHash !== content.content_hash;
+        if ((isNew || changed) && content.content_hash) {
+            yield* Effect.ignore(db.query(
+                "CREATE skill_revision SET skill = $skill, name = $name, scope = $scope, content_hash = $hash, prev_hash = $prev, bytes = $bytes, prev_bytes = $prevBytes, change = $change;",
+                {
+                    skill: id,
+                    name: content.name,
+                    scope: content.scope,
+                    hash: content.content_hash,
+                    prev: prevHash ?? null,
+                    bytes: content.bytes ?? null,
+                    prevBytes: typeof existing?.bytes === "number" ? existing.bytes : null,
+                    change: isNew ? "added" : "changed",
+                },
+            ));
+        }
+
         yield* db.upsert(id, { ...content });
         return id;
     });

--- a/apps/axctl/src/queries/context-budget.ts
+++ b/apps/axctl/src/queries/context-budget.ts
@@ -19,7 +19,9 @@
  */
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
+import { normalizeLastUsed, UNUSED_RECENT_SQL, UNUSED_SUMMARY_SQL } from "./unused-skills.ts";
 
+const WINDOW_DAYS = 30;
 const CHARS_PER_TOKEN = 4;
 const toTokens = (chars: number) => Math.round(chars / CHARS_PER_TOKEN);
 
@@ -40,6 +42,11 @@ function sourceOf(scope: string): string {
 }
 const isToolScope = (scope: string) => TOOL_SCOPE.test(scope);
 
+/** Description longer than this (chars) is a "trim" candidate - the always-
+ *  loaded index cost is mostly a bloated frontmatter description. ~500 chars
+ *  ≈ 125 tokens in every session. */
+const VERBOSE_CHARS = 500;
+
 export interface SkillBudgetRow {
     readonly name: string;
     readonly scope: string;
@@ -51,6 +58,12 @@ export interface SkillBudgetRow {
     readonly content_hash: string;
     readonly dir_path: string;
     readonly is_tool: boolean;
+    // usage (summed across the user↔project mirror), for cost÷usage actions
+    readonly uses_total: number;
+    readonly uses_window: number;   // invocations inside the recency window
+    readonly last_used: string | null;
+    readonly dead_weight: boolean;  // costs always-loaded tokens, unused in window → reclaim
+    readonly verbose: boolean;      // bloated description → trim
 }
 
 export interface SourceBudgetRow {
@@ -61,6 +74,9 @@ export interface SourceBudgetRow {
     readonly index_tokens: number;
     readonly body_tokens: number;
     readonly is_tool: boolean;
+    readonly uses_window: number;
+    readonly dead_skills: number;
+    readonly reclaimable_index_tokens: number;  // always-loaded tokens from this source's dead weight
 }
 
 export interface ContextBudgetResult {
@@ -77,11 +93,17 @@ export interface ContextBudgetResult {
         /** Claude-skill subset only (excludes other-harness tool catalogs). */
         readonly cc_index_tokens: number;
         readonly cc_body_tokens: number;
+        /** Always-loaded tokens recoverable by disabling unused (dead-weight) skills. */
+        readonly reclaimable_index_tokens: number;
+        readonly reclaimable_skills: number;
+        readonly verbose_skills: number;
+        /** Recency window (days) used to judge "unused". */
+        readonly window_days: number;
     };
 }
 
 const BUDGET_SQL = `
-SELECT name, scope, bytes, string::len(description ?? "") AS desc_len, content_hash, dir_path
+SELECT id, name, scope, bytes, string::len(description ?? "") AS desc_len, content_hash, dir_path
 FROM skill;
 `;
 
@@ -91,21 +113,54 @@ function preferScope(a: string, b: string): boolean {
     const rank = (s: string) => (s.startsWith("project") ? 2 : s.includes(":") && !s.startsWith("plugin") ? 1 : 0);
     return rank(a) <= rank(b);
 }
+const idStr = (v: unknown) => String(v ?? "");
 
 export const fetchContextBudget = Effect.fn("queries.fetchContextBudget")(
     function* () {
         const db = yield* SurrealClient;
-        const raw = yield* db.query<[Array<Record<string, unknown>>]>(BUDGET_SQL)
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        // budget rows + bulk usage (per skill id) over the invoked edge table,
+        // computed deref-free - see unused-skills.ts for the perf rationale.
+        const [rawRes, summaryRes, recentRes] = yield* Effect.all([
+            db.query<[Array<Record<string, unknown>>]>(BUDGET_SQL),
+            db.query<[Array<Record<string, unknown>>]>(UNUSED_SUMMARY_SQL),
+            db.query<[Array<Record<string, unknown>>]>(UNUSED_RECENT_SQL(WINDOW_DAYS)),
+        ], { concurrency: 3 });
+        const raw = rawRes?.[0] ?? [];
 
-        // Dedup by content_hash, keeping the canonical scope.
-        const byHash = new Map<string, SkillBudgetRow>();
+        const usageById = new Map<string, { uses: number; last: string | null }>();
+        for (const r of summaryRes?.[0] ?? []) {
+            usageById.set(idStr(r.skill_id), { uses: Number(r.total_inv ?? 0), last: normalizeLastUsed(r.last_used) });
+        }
+        const recentById = new Map<string, number>();
+        for (const r of recentRes?.[0] ?? []) recentById.set(idStr(r.skill_id), Number(r.recent ?? 0));
+
+        // Group by content_hash: sum usage across the mirror ids, keep canonical.
+        interface Group { canonical: Record<string, unknown>; canonicalScope: string; uses: number; window: number; last: string | null; }
+        const groups = new Map<string, Group>();
         for (const row of raw) {
-            const scope = String(row.scope ?? "");
             const hash = String(row.content_hash ?? `${row.name}`);
+            const scope = String(row.scope ?? "");
+            const id = idStr(row.id);
+            const u = usageById.get(id);
+            const win = recentById.get(id) ?? 0;
+            const g = groups.get(hash);
+            if (!g) {
+                groups.set(hash, { canonical: row, canonicalScope: scope, uses: u?.uses ?? 0, window: win, last: u?.last ?? null });
+            } else {
+                g.uses += u?.uses ?? 0;
+                g.window += win;
+                if (u?.last && (!g.last || u.last > g.last)) g.last = u.last;
+                if (preferScope(scope, g.canonicalScope)) { g.canonical = row; g.canonicalScope = scope; }
+            }
+        }
+
+        const skills: SkillBudgetRow[] = [...groups.values()].map((g) => {
+            const row = g.canonical;
+            const scope = String(row.scope ?? "");
             const index_chars = Number(row.desc_len ?? 0);
             const body_chars = Number(row.bytes ?? 0);
-            const candidate: SkillBudgetRow = {
+            const is_tool = isToolScope(scope);
+            return {
                 name: String(row.name ?? "(unnamed)"),
                 scope,
                 source: sourceOf(scope),
@@ -113,47 +168,54 @@ export const fetchContextBudget = Effect.fn("queries.fetchContextBudget")(
                 body_chars,
                 index_tokens: toTokens(index_chars),
                 body_tokens: toTokens(body_chars),
-                content_hash: hash,
+                content_hash: String(row.content_hash ?? ""),
                 dir_path: String(row.dir_path ?? ""),
-                is_tool: isToolScope(scope),
+                is_tool,
+                uses_total: g.uses,
+                uses_window: g.window,
+                last_used: g.last,
+                dead_weight: !is_tool && g.window === 0 && index_chars > 0,
+                verbose: !is_tool && index_chars > VERBOSE_CHARS,
             };
-            const existing = byHash.get(hash);
-            if (!existing || preferScope(scope, existing.scope)) byHash.set(hash, candidate);
-        }
+        }).sort((a, b) => b.body_chars - a.body_chars);
 
-        const skills = [...byHash.values()].sort((a, b) => b.body_chars - a.body_chars);
-
-        // Per-source rollup.
+        // Per-source rollup (+ usage / reclaim).
         interface MutableSource {
             source: string; skills: number; index_chars: number; body_chars: number;
             index_tokens: number; body_tokens: number; is_tool: boolean;
+            uses_window: number; dead_skills: number; reclaimable_index_tokens: number;
         }
         const srcMap = new Map<string, MutableSource>();
         for (const s of skills) {
             const cur = srcMap.get(s.source) ?? {
                 source: s.source, skills: 0, index_chars: 0, body_chars: 0,
                 index_tokens: 0, body_tokens: 0, is_tool: s.is_tool,
+                uses_window: 0, dead_skills: 0, reclaimable_index_tokens: 0,
             };
             cur.skills += 1;
             cur.index_chars += s.index_chars;
             cur.body_chars += s.body_chars;
             cur.index_tokens += s.index_tokens;
             cur.body_tokens += s.body_tokens;
+            cur.uses_window += s.uses_window;
+            if (s.dead_weight) { cur.dead_skills += 1; cur.reclaimable_index_tokens += s.index_tokens; }
             srcMap.set(s.source, cur);
         }
         const sources = [...srcMap.values()].sort((a, b) => b.index_chars - a.index_chars);
 
-        const sum = (pick: (s: SkillBudgetRow) => number, tools: boolean) =>
-            skills.filter((s) => s.is_tool === tools).reduce((n, s) => n + pick(s), 0);
-
+        const cc = skills.filter((s) => !s.is_tool);
         const totals = {
             skills: skills.length,
             index_chars: skills.reduce((n, s) => n + s.index_chars, 0),
             body_chars: skills.reduce((n, s) => n + s.body_chars, 0),
             index_tokens: skills.reduce((n, s) => n + s.index_tokens, 0),
             body_tokens: skills.reduce((n, s) => n + s.body_tokens, 0),
-            cc_index_tokens: toTokens(sum((s) => s.index_chars, false)),
-            cc_body_tokens: toTokens(sum((s) => s.body_chars, false)),
+            cc_index_tokens: toTokens(cc.reduce((n, s) => n + s.index_chars, 0)),
+            cc_body_tokens: toTokens(cc.reduce((n, s) => n + s.body_chars, 0)),
+            reclaimable_index_tokens: cc.filter((s) => s.dead_weight).reduce((n, s) => n + s.index_tokens, 0),
+            reclaimable_skills: cc.filter((s) => s.dead_weight).length,
+            verbose_skills: cc.filter((s) => s.verbose).length,
+            window_days: WINDOW_DAYS,
         };
 
         return { skills, sources, totals } satisfies ContextBudgetResult;

--- a/apps/axctl/src/queries/context-budget.ts
+++ b/apps/axctl/src/queries/context-budget.ts
@@ -1,0 +1,161 @@
+/**
+ * `ax context budget` / studio Context view: what fills a fresh Claude Code /
+ * Codex session before the user types anything. Every installed skill costs
+ * tokens two ways:
+ *   - INDEX (always loaded): the skill's name + description sit in the system
+ *     prompt's skill catalog of EVERY session, whether or not it's invoked.
+ *   - BODY (on demand): the full SKILL.md loads only when the skill is invoked.
+ * We measure both from the `skill` table (`bytes` = body size, `description`
+ * length = index size, `content_hash` = drift detection) and roll them up by
+ * source. Token estimate = chars / 4 (≈ GPT/Claude BPE average).
+ *
+ * Dedup: the same skill is registered under multiple scopes (e.g. `user` and
+ * `project:<name>`) with an identical content_hash; the harness loads it once,
+ * so we dedup by content_hash for the budget totals and attribute it to a
+ * canonical source.
+ *
+ * Tables used (read-only): skill { name, scope, bytes, description,
+ *   content_hash, dir_path }.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+
+const CHARS_PER_TOKEN = 4;
+const toTokens = (chars: number) => Math.round(chars / CHARS_PER_TOKEN);
+
+/** Other-harness tool catalogs (codex/cursor/opencode/pi) and similar - not
+ *  part of a Claude Code session's context, tracked separately. */
+const TOOL_SCOPE = /-tool$/;
+
+/** Collapse a raw scope into a display source bucket. */
+function sourceOf(scope: string): string {
+    if (scope === "user") return "user skills";
+    if (scope === "agents-shared") return "shared agents";
+    if (scope === "command") return "slash commands";
+    if (scope.startsWith("project-command")) return "project commands";
+    if (scope.startsWith("plugin:")) return `plugin · ${scope.slice("plugin:".length)}`;
+    if (scope.startsWith("project:")) return `project · ${scope.slice("project:".length)}`;
+    if (TOOL_SCOPE.test(scope)) return `${scope.replace(TOOL_SCOPE, "")} tools`;
+    return scope;
+}
+const isToolScope = (scope: string) => TOOL_SCOPE.test(scope);
+
+export interface SkillBudgetRow {
+    readonly name: string;
+    readonly scope: string;
+    readonly source: string;
+    readonly index_chars: number;   // description length → always-loaded
+    readonly body_chars: number;    // SKILL.md bytes → on-demand
+    readonly index_tokens: number;
+    readonly body_tokens: number;
+    readonly content_hash: string;
+    readonly dir_path: string;
+    readonly is_tool: boolean;
+}
+
+export interface SourceBudgetRow {
+    readonly source: string;
+    readonly skills: number;
+    readonly index_chars: number;
+    readonly body_chars: number;
+    readonly index_tokens: number;
+    readonly body_tokens: number;
+    readonly is_tool: boolean;
+}
+
+export interface ContextBudgetResult {
+    /** Distinct skills (deduped by content_hash), heaviest body first. */
+    readonly skills: ReadonlyArray<SkillBudgetRow>;
+    /** Per-source rollup, heaviest index first. */
+    readonly sources: ReadonlyArray<SourceBudgetRow>;
+    readonly totals: {
+        readonly skills: number;
+        readonly index_chars: number;
+        readonly body_chars: number;
+        readonly index_tokens: number;
+        readonly body_tokens: number;
+        /** Claude-skill subset only (excludes other-harness tool catalogs). */
+        readonly cc_index_tokens: number;
+        readonly cc_body_tokens: number;
+    };
+}
+
+const BUDGET_SQL = `
+SELECT name, scope, bytes, string::len(description ?? "") AS desc_len, content_hash, dir_path
+FROM skill;
+`;
+
+/** Prefer a non-namespaced / non-project scope as the canonical home of a
+ *  deduped skill (user/plugin/command over the project mirror). */
+function preferScope(a: string, b: string): boolean {
+    const rank = (s: string) => (s.startsWith("project") ? 2 : s.includes(":") && !s.startsWith("plugin") ? 1 : 0);
+    return rank(a) <= rank(b);
+}
+
+export const fetchContextBudget = Effect.fn("queries.fetchContextBudget")(
+    function* () {
+        const db = yield* SurrealClient;
+        const raw = yield* db.query<[Array<Record<string, unknown>>]>(BUDGET_SQL)
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+
+        // Dedup by content_hash, keeping the canonical scope.
+        const byHash = new Map<string, SkillBudgetRow>();
+        for (const row of raw) {
+            const scope = String(row.scope ?? "");
+            const hash = String(row.content_hash ?? `${row.name}`);
+            const index_chars = Number(row.desc_len ?? 0);
+            const body_chars = Number(row.bytes ?? 0);
+            const candidate: SkillBudgetRow = {
+                name: String(row.name ?? "(unnamed)"),
+                scope,
+                source: sourceOf(scope),
+                index_chars,
+                body_chars,
+                index_tokens: toTokens(index_chars),
+                body_tokens: toTokens(body_chars),
+                content_hash: hash,
+                dir_path: String(row.dir_path ?? ""),
+                is_tool: isToolScope(scope),
+            };
+            const existing = byHash.get(hash);
+            if (!existing || preferScope(scope, existing.scope)) byHash.set(hash, candidate);
+        }
+
+        const skills = [...byHash.values()].sort((a, b) => b.body_chars - a.body_chars);
+
+        // Per-source rollup.
+        interface MutableSource {
+            source: string; skills: number; index_chars: number; body_chars: number;
+            index_tokens: number; body_tokens: number; is_tool: boolean;
+        }
+        const srcMap = new Map<string, MutableSource>();
+        for (const s of skills) {
+            const cur = srcMap.get(s.source) ?? {
+                source: s.source, skills: 0, index_chars: 0, body_chars: 0,
+                index_tokens: 0, body_tokens: 0, is_tool: s.is_tool,
+            };
+            cur.skills += 1;
+            cur.index_chars += s.index_chars;
+            cur.body_chars += s.body_chars;
+            cur.index_tokens += s.index_tokens;
+            cur.body_tokens += s.body_tokens;
+            srcMap.set(s.source, cur);
+        }
+        const sources = [...srcMap.values()].sort((a, b) => b.index_chars - a.index_chars);
+
+        const sum = (pick: (s: SkillBudgetRow) => number, tools: boolean) =>
+            skills.filter((s) => s.is_tool === tools).reduce((n, s) => n + pick(s), 0);
+
+        const totals = {
+            skills: skills.length,
+            index_chars: skills.reduce((n, s) => n + s.index_chars, 0),
+            body_chars: skills.reduce((n, s) => n + s.body_chars, 0),
+            index_tokens: skills.reduce((n, s) => n + s.index_tokens, 0),
+            body_tokens: skills.reduce((n, s) => n + s.body_tokens, 0),
+            cc_index_tokens: toTokens(sum((s) => s.index_chars, false)),
+            cc_body_tokens: toTokens(sum((s) => s.body_chars, false)),
+        };
+
+        return { skills, sources, totals } satisfies ContextBudgetResult;
+    },
+);

--- a/apps/axctl/src/queries/context-budget.ts
+++ b/apps/axctl/src/queries/context-budget.ts
@@ -159,3 +159,57 @@ export const fetchContextBudget = Effect.fn("queries.fetchContextBudget")(
         return { skills, sources, totals } satisfies ContextBudgetResult;
     },
 );
+
+// ---------------------------------------------------------------------------
+// drift: the append-only skill_revision change log
+// ---------------------------------------------------------------------------
+
+export interface SkillDriftRow {
+    readonly name: string;
+    readonly scope: string;
+    readonly change: string;        // 'added' | 'changed'
+    readonly ts: string;            // ISO
+    readonly bytes: number;
+    readonly prev_bytes: number;
+    readonly byte_delta: number;    // bytes - prev_bytes (0 for 'added')
+    readonly token_delta: number;   // byte_delta / 4
+}
+
+export interface SkillDriftResult {
+    readonly changes: ReadonlyArray<SkillDriftRow>;
+    readonly total: number;
+}
+
+const DRIFT_SQL = (limit: number) => `
+SELECT name, scope, change, content_hash, prev_hash, bytes, prev_bytes, ts
+FROM skill_revision
+ORDER BY ts DESC
+LIMIT ${Math.max(1, Math.trunc(limit))};
+`;
+
+export const fetchSkillDrift = Effect.fn("queries.fetchSkillDrift")(
+    function* (opts: { readonly limit: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* db.query<[Array<Record<string, unknown>>]>(DRIFT_SQL(opts.limit))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+
+        const changes: SkillDriftRow[] = rows.map((row) => {
+            const bytes = Number(row.bytes ?? 0);
+            const prev_bytes = Number(row.prev_bytes ?? 0);
+            const byte_delta = row.change === "added" ? 0 : bytes - prev_bytes;
+            const ts = row.ts instanceof Date ? row.ts.toISOString() : String(row.ts ?? "");
+            return {
+                name: String(row.name ?? "(unnamed)"),
+                scope: String(row.scope ?? ""),
+                change: String(row.change ?? "changed"),
+                ts,
+                bytes,
+                prev_bytes,
+                byte_delta,
+                token_delta: Math.round(byte_delta / CHARS_PER_TOKEN),
+            };
+        });
+
+        return { changes, total: changes.length } satisfies SkillDriftResult;
+    },
+);

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -44,6 +44,7 @@ import { graphHealthSql } from "./graph-health.ts";
 
 export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "skill", stage: "active", note: "Installed skills and slash commands." },
+    { table: "skill_revision", stage: "active", note: "Append-only skill content-change log (drift over time)." },
     { table: "agent_def", stage: "active", note: "Agent definition files (~/.claude/agents) with reconcile lifecycle." },
     { table: "role", stage: "active", note: "Skill role labels used for weighting and grouping." },
     { table: "session", stage: "active", note: "Claude and Codex transcript sessions." },

--- a/apps/studio/src/Shell.tsx
+++ b/apps/studio/src/Shell.tsx
@@ -1,28 +1,17 @@
 import { useEffect, useState, type ReactNode } from "react";
-import { Link, useRouterState } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
+import { useRouterState } from "@tanstack/react-router";
 import { api, studioConnection, type DaemonVersion } from "./api.ts";
 import { IngestSplash } from "./components/ingest-splash.tsx";
 import { useIngestEvents } from "./use-ingest-events.ts";
 import { fmtLastUsed } from "@ax/lib/shared/formatters";
 import { cmpSemver, STUDIO_VERSION } from "./version.ts";
+import { InstrumentShell } from "./instrument/shell.tsx";
 
 const STUDIO_MOCK = import.meta.env.VITE_STUDIO_MOCK === "true";
 const DEFAULT_LOCAL_ENDPOINT = "http://127.0.0.1:1738";
 // Min api_version the studio expects. Bump when the studio starts
 // relying on a new endpoint or breaking field rename.
 const STUDIO_MIN_API_VERSION = 1;
-
-interface Tab {
-    readonly to:
-        | "/"
-        | "/improve"
-        | "/sessions"
-        | "/skills"
-        | "/workflow";
-    readonly label: string;
-    readonly prefetch: () => Promise<unknown>;
-}
 
 export function Shell({ children }: { children: ReactNode }) {
     const state = useRouterState();
@@ -41,7 +30,35 @@ export function Shell({ children }: { children: ReactNode }) {
     const path = state.location.pathname;
     const isInstrument = path === "/" || path.startsWith("/mc") || path.startsWith("/wrapped") || path.startsWith("/lab/sigils");
     if (isInstrument) return <>{children}</>;
-    return <FullChrome>{children}</FullChrome>;
+    // Every other route now lives inside the instrument rail too (was FullChrome).
+    return <InstrumentChrome>{children}</InstrumentChrome>;
+}
+
+/** The instrument rail shell + the live/connection chrome the old masthead
+ *  carried (live indicator, ingest splash, mock-mode connect banner). Renders
+ *  the legacy studio routes inside the unified dark HUD; their content is
+ *  dark-bridged via the .rdx studio-token mapping until each is restyled to
+ *  instrument cards. */
+function InstrumentChrome({ children }: { children: ReactNode }) {
+    const live = useIngestEvents();
+    return (
+        <InstrumentShell>
+            {STUDIO_MOCK ? <StudioBanner /> : null}
+            <div className="rdx-topbar">
+                <span
+                    className={`live-indicator ${live.connected ? "on" : "off"}`}
+                    title={live.lastEventAt
+                        ? `last ingest ${fmtLastUsed(live.lastEventAt)}`
+                        : live.connected ? "connected, no events yet" : "disconnected"}
+                >
+                    <span className="live-dot" />
+                    {live.connected ? "live" : "offline"}
+                </span>
+                <IngestSplash />
+            </div>
+            {children}
+        </InstrumentShell>
+    );
 }
 
 /** Slim chrome for a standalone shared-session gist view. */
@@ -77,114 +94,6 @@ function ShareChrome({ children }: { children: ReactNode }) {
                 >
                     ax.necmttn.com →
                 </a>
-            </footer>
-        </div>
-    );
-}
-
-function FullChrome({ children }: { children: ReactNode }) {
-    const state = useRouterState();
-    const path = state.location.pathname;
-    const queryClient = useQueryClient();
-    const live = useIngestEvents();
-
-    const TABS: ReadonlyArray<Tab> = [
-        {
-            to: "/",
-            label: "Wrapped",
-            prefetch: () =>
-                Promise.all([
-                    queryClient.prefetchQuery({
-                        queryKey: ["wrapped"],
-                        queryFn: () => api.wrapped(),
-                    }),
-                    queryClient.prefetchQuery({
-                        queryKey: ["wrapped", "public-preview"],
-                        queryFn: () => api.wrappedPublicPreview(),
-                    }),
-                ]),
-        },
-        {
-            to: "/improve",
-            label: "Improve",
-            prefetch: () =>
-                queryClient.prefetchQuery({
-                    queryKey: ["improve"],
-                    queryFn: () => api.improve(),
-                }),
-        },
-        {
-            to: "/sessions",
-            label: "Sessions",
-            prefetch: () =>
-                queryClient.prefetchQuery({
-                    queryKey: ["sessions", "all"],
-                    queryFn: () => api.sessions({ limit: 200 }),
-                }),
-        },
-        {
-            to: "/skills",
-            label: "Skills",
-            prefetch: () =>
-                queryClient.prefetchQuery({
-                    queryKey: ["skills"],
-                    queryFn: () => api.skills(),
-                }),
-        },
-        {
-            to: "/workflow",
-            label: "Workflow",
-            prefetch: () =>
-                queryClient.prefetchQuery({
-                    queryKey: ["workflow"],
-                    queryFn: () => api.workflow(),
-                }),
-        },
-    ];
-
-    return (
-        <div className="shell">
-            {STUDIO_MOCK ? <StudioBanner /> : null}
-            <header className="masthead">
-                <div className="brand">
-                    <h1>ax</h1>
-                    <span className="brand-tag">agent experience</span>
-                </div>
-                <span
-                    className={`live-indicator ${live.connected ? "on" : "off"}`}
-                    title={
-                        live.lastEventAt
-                            ? `last ingest ${fmtLastUsed(live.lastEventAt)}`
-                            : live.connected
-                            ? "connected, no events yet"
-                            : "disconnected"
-                    }
-                >
-                    <span className="live-dot" />
-                    {live.connected ? "live" : "offline"}
-                </span>
-                <IngestSplash />
-                <nav className="tabs">
-                    {TABS.map((tab) => {
-                        const active =
-                            path === tab.to || (tab.to === "/" && path === "/wrapped");
-                        return (
-                            <Link
-                                key={tab.to}
-                                to={tab.to}
-                                className={active ? "active" : undefined}
-                                onMouseEnter={() => void tab.prefetch()}
-                                onFocus={() => void tab.prefetch()}
-                            >
-                                {tab.label}
-                            </Link>
-                        );
-                    })}
-                </nav>
-            </header>
-            {children}
-            <footer className="shell-footer">
-                <Link to="/lab">Lab</Link>
             </footer>
         </div>
     );

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -197,6 +197,11 @@ export interface ContextSkillRow {
     readonly content_hash: string;
     readonly dir_path: string;
     readonly is_tool: boolean;
+    readonly uses_total: number;
+    readonly uses_window: number;
+    readonly last_used: string | null;
+    readonly dead_weight: boolean;
+    readonly verbose: boolean;
 }
 export interface ContextSourceRow {
     readonly source: string;
@@ -206,6 +211,9 @@ export interface ContextSourceRow {
     readonly index_tokens: number;
     readonly body_tokens: number;
     readonly is_tool: boolean;
+    readonly uses_window: number;
+    readonly dead_skills: number;
+    readonly reclaimable_index_tokens: number;
 }
 export interface ContextBudgetResult {
     readonly skills: ReadonlyArray<ContextSkillRow>;
@@ -218,6 +226,10 @@ export interface ContextBudgetResult {
         readonly body_tokens: number;
         readonly cc_index_tokens: number;
         readonly cc_body_tokens: number;
+        readonly reclaimable_index_tokens: number;
+        readonly reclaimable_skills: number;
+        readonly verbose_skills: number;
+        readonly window_days: number;
     };
 }
 export interface ContextDriftRow {

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -185,6 +185,42 @@ export interface CostModelsResult {
     readonly total_cost_usd: number;
 }
 
+// --- context budget (session startup footprint) ----------------------------
+export interface ContextSkillRow {
+    readonly name: string;
+    readonly scope: string;
+    readonly source: string;
+    readonly index_chars: number;
+    readonly body_chars: number;
+    readonly index_tokens: number;
+    readonly body_tokens: number;
+    readonly content_hash: string;
+    readonly dir_path: string;
+    readonly is_tool: boolean;
+}
+export interface ContextSourceRow {
+    readonly source: string;
+    readonly skills: number;
+    readonly index_chars: number;
+    readonly body_chars: number;
+    readonly index_tokens: number;
+    readonly body_tokens: number;
+    readonly is_tool: boolean;
+}
+export interface ContextBudgetResult {
+    readonly skills: ReadonlyArray<ContextSkillRow>;
+    readonly sources: ReadonlyArray<ContextSourceRow>;
+    readonly totals: {
+        readonly skills: number;
+        readonly index_chars: number;
+        readonly body_chars: number;
+        readonly index_tokens: number;
+        readonly body_tokens: number;
+        readonly cc_index_tokens: number;
+        readonly cc_body_tokens: number;
+    };
+}
+
 // The version handshake type now comes from the Insights Surface Contract -
 // the same Schema the daemon serves - so the two cannot drift.
 export type { DaemonVersion } from "@ax/lib/shared/api-contract";
@@ -443,6 +479,8 @@ export const api = {
 
     costModels: (): Promise<CostModelsResult> =>
         viaContract("/api/cost/models", (c) => c.insights.costModels()) as Promise<CostModelsResult>,
+    contextBudget: (): Promise<ContextBudgetResult> =>
+        viaContract("/api/context/budget", (c) => c.insights.contextBudget()) as Promise<ContextBudgetResult>,
 
     nextActions: (): Promise<NextActionsPayload> =>
         viaContract("/api/next-actions", (c) => c.improve.nextActions()),

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -220,6 +220,20 @@ export interface ContextBudgetResult {
         readonly cc_body_tokens: number;
     };
 }
+export interface ContextDriftRow {
+    readonly name: string;
+    readonly scope: string;
+    readonly change: string;
+    readonly ts: string;
+    readonly bytes: number;
+    readonly prev_bytes: number;
+    readonly byte_delta: number;
+    readonly token_delta: number;
+}
+export interface ContextDriftResult {
+    readonly changes: ReadonlyArray<ContextDriftRow>;
+    readonly total: number;
+}
 
 // The version handshake type now comes from the Insights Surface Contract -
 // the same Schema the daemon serves - so the two cannot drift.
@@ -481,6 +495,8 @@ export const api = {
         viaContract("/api/cost/models", (c) => c.insights.costModels()) as Promise<CostModelsResult>,
     contextBudget: (): Promise<ContextBudgetResult> =>
         viaContract("/api/context/budget", (c) => c.insights.contextBudget()) as Promise<ContextBudgetResult>,
+    contextDrift: (): Promise<ContextDriftResult> =>
+        viaContract("/api/context/drift", (c) => c.insights.contextDrift()) as Promise<ContextDriftResult>,
 
     nextActions: (): Promise<NextActionsPayload> =>
         viaContract("/api/next-actions", (c) => c.improve.nextActions()),

--- a/apps/studio/src/instrument/instrument.css
+++ b/apps/studio/src/instrument/instrument.css
@@ -41,6 +41,28 @@
     --dot: #e1ded2; --glyph-dim: #dad7cb; --glyph-lit: #173a22;
     --c0: #e6e3d7; --c1: #cfe6d3; --c2: #9fd0aa; --c3: #5fb074; --c4: #2f9e44;
 }
+.rdx[data-theme="dark"] { color-scheme: dark; }
+.rdx[data-theme="light"] { color-scheme: light; }
+
+/* ---- studio-token bridge ----
+   The legacy studio routes (sessions/workflow/improve/skills) are styled with a
+   light-only token set (--page/--panel/--ink…). Re-map those names to the
+   instrument palette so any route rendered inside the .rdx instrument shell
+   adopts the dark (or light) HUD automatically. Shared names (--green/--blue/
+   --red/--gold/--violet) already resolve to the instrument values inside .rdx,
+   so only the differing names need bridging; --bg/--surface/etc. are
+   theme-scoped, so this one rule adapts to both themes. */
+.rdx {
+    --ink: var(--pri);
+    --muted: var(--sec);
+    --muted-2: var(--dim);
+    --page: var(--bg);
+    --line: var(--border);
+    --panel: var(--surface);
+    --track: var(--surface2);
+}
+/* slim live/ingest strip atop the legacy routes inside the instrument shell */
+.rdx-topbar { display: flex; align-items: center; gap: 12px; padding: 4px 2px 14px; font-family: var(--mono); font-size: 11px; color: var(--sec); }
 
 /* ---- primitives ---- */
 .rdx-doto { font-family: var(--doto); font-variant-numeric: tabular-nums; letter-spacing: 0.01em; }

--- a/apps/studio/src/routes/sessions.tsx
+++ b/apps/studio/src/routes/sessions.tsx
@@ -167,7 +167,7 @@ const Row = memo(function Row({
     };
 
     const rowStyle: CSSProperties | undefined = indent
-        ? { background: "#fafafa" }
+        ? { background: "var(--track)" }
         : undefined;
 
     return (
@@ -415,9 +415,9 @@ export function SessionsRoute() {
 
     const filterBtnStyle = (active: boolean): CSSProperties => ({
         padding: "4px 12px", fontSize: 11, fontWeight: 600,
-        border: "1px solid var(--line)",
-        background: active ? "var(--ink)" : "#fff",
-        color: active ? "#fff" : "var(--muted)",
+        border: `1px solid ${active ? "var(--green)" : "var(--line)"}`,
+        background: active ? "var(--green)" : "var(--track)",
+        color: active ? "#06140b" : "var(--muted)",
         borderRadius: 4, cursor: "pointer",
     });
 
@@ -449,7 +449,7 @@ export function SessionsRoute() {
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     placeholder="filter by id / project / cwd / model"
-                    style={{ flex: 1, maxWidth: 360, padding: "4px 8px", fontSize: 12, border: "1px solid var(--line)", borderRadius: 4 }}
+                    style={{ flex: 1, maxWidth: 360, padding: "4px 8px", fontSize: 12, border: "1px solid var(--line)", borderRadius: 4, background: "var(--panel)", color: "var(--ink)" }}
                 />
                 {allExpandableIds.length > 0 ? (
                     <button
@@ -458,7 +458,7 @@ export function SessionsRoute() {
                         )}
                         style={{
                             padding: "4px 10px", fontSize: 11, border: "1px solid var(--line)",
-                            background: "#fff", color: "var(--muted)", borderRadius: 4, cursor: "pointer",
+                            background: "var(--track)", color: "var(--muted)", borderRadius: 4, cursor: "pointer",
                         }}
                     >
                         {expanded.size === allExpandableIds.length ? "collapse all" : "expand all"}
@@ -470,9 +470,9 @@ export function SessionsRoute() {
                     title={selected.size < 2 ? "Select 2+ sessions to compare" : `Compare ${selected.size} sessions`}
                     style={{
                         padding: "4px 12px", fontSize: 11, fontWeight: 600,
-                        border: "1px solid var(--line)", borderRadius: 4,
-                        background: selected.size >= 2 ? "var(--ink)" : "#fff",
-                        color: selected.size >= 2 ? "#fff" : "var(--muted-2)",
+                        border: `1px solid ${selected.size >= 2 ? "var(--green)" : "var(--line)"}`, borderRadius: 4,
+                        background: selected.size >= 2 ? "var(--green)" : "var(--track)",
+                        color: selected.size >= 2 ? "#06140b" : "var(--muted-2)",
                         cursor: selected.size >= 2 ? "pointer" : "not-allowed",
                     }}
                 >
@@ -483,7 +483,7 @@ export function SessionsRoute() {
                         onClick={() => setSelected(new Set())}
                         style={{
                             padding: "4px 8px", fontSize: 11, border: "1px solid var(--line)",
-                            background: "#fff", color: "var(--muted)", borderRadius: 4, cursor: "pointer",
+                            background: "var(--track)", color: "var(--muted)", borderRadius: 4, cursor: "pointer",
                         }}
                     >
                         clear
@@ -564,7 +564,7 @@ export function SessionsRoute() {
                                                 onClick={() => void loadMore(PAGE_SIZE)}
                                                 style={{
                                                     padding: "2px 10px", marginLeft: 6, fontSize: 11,
-                                                    border: "1px solid var(--line)", background: "#fff",
+                                                    border: "1px solid var(--line)", background: "var(--track)",
                                                     color: "var(--muted)", borderRadius: 4, cursor: "pointer",
                                                 }}
                                             >load {PAGE_SIZE} more</button>

--- a/apps/studio/src/routes/skills.tsx
+++ b/apps/studio/src/routes/skills.tsx
@@ -1,665 +1,466 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Link, useSearch } from "@tanstack/react-router";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { api } from "../api.ts";
 import type {
-    SkillDetailPayload,
-    SkillSourcePayload,
-    SkillTriageEntry,
-    SkillTriageNote,
-    SkillTriageResponse,
-    TriageDecision,
-} from "@ax/lib/shared/dashboard-types";
-import { fmtCount, fmtLastUsed, fmtScore, fmtTs } from "@ax/lib/shared/formatters";
-import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
+    ContextBudgetResult,
+    ContextSkillRow,
+    ContextSourceRow,
+} from "../api.ts";
+import { fmtCount } from "@ax/lib/shared/formatters";
 
-type Filter = "all" | "actionable" | "keep" | "archive" | "review";
+/* ===========================================================================
+   SESSION CONTEXT BUDGET
+   What fills your context before you type anything in a fresh Claude Code /
+   Codex session. Skills cost tokens two ways:
+     - INDEX  (index_tokens): always-loaded. Every skill's name + description
+       sits in the system-prompt skill catalog of EVERY session. This is the
+       tax you pay on turn zero.
+     - BODY   (body_tokens): on-demand. The SKILL.md body, only loaded when the
+       skill is actually invoked.
+   The page reveals that cost and lets you navigate the skills as an index.
+   No triage. These are real measurements - let the numbers speak.
+   ========================================================================= */
 
-type SortKey = "score" | "30d" | "7d" | "total" | "last" | "name";
+/** chars/4 token est is already done server-side; we format for display. */
+const fmtTokens = (n: number): string => fmtCount(Math.round(n));
+
+/** Source palette: colour lives in the data-viz, keyed to the source so the
+ *  stacked budget bar reads as one instrument. Green is the house accent and
+ *  belongs to the dominant user-skills slice; the rest spread across the
+ *  luminance-matched accent set. NOT orange (reserved for alert). */
+const SOURCE_HUES = [
+    "var(--green)",
+    "var(--blue)",
+    "var(--violet)",
+    "var(--gold)",
+    "var(--rose, #b32650)",
+    "color-mix(in srgb, var(--green) 55%, var(--blue))",
+    "color-mix(in srgb, var(--violet) 60%, var(--surface2))",
+    "color-mix(in srgb, var(--blue) 55%, var(--surface2))",
+] as const;
+
+type SortKey = "body" | "index" | "name" | "source";
 type SortDir = "asc" | "desc";
 
-const FILTERS: ReadonlyArray<{ key: Filter; label: string }> = [
-    { key: "actionable", label: "Actionable" },
-    { key: "review", label: "Review" },
-    { key: "archive", label: "Archive" },
-    { key: "keep", label: "Keep" },
-    { key: "all", label: "All" },
-];
-
 const DEFAULT_DIR: Record<SortKey, SortDir> = {
-    score: "desc",
-    "30d": "desc",
-    "7d": "desc",
-    total: "desc",
-    last: "desc",
+    body: "desc",
+    index: "desc",
     name: "asc",
+    source: "asc",
 };
 
-const SKILL_RENDER_PAGE_SIZE = 80;
+const RENDER_PAGE = 80;
 
-const filterByRecommendation = (
-    rows: ReadonlyArray<SkillTriageEntry>,
-    filter: Filter,
-): ReadonlyArray<SkillTriageEntry> => {
-    if (filter === "all") return rows;
-    if (filter === "actionable") {
-        return rows.filter(
-            (r) => r.recommendation !== "keep" && r.decision === null,
-        );
-    }
-    return rows.filter((r) => r.recommendation === filter);
-};
-
-const filterByScope = (
-    rows: ReadonlyArray<SkillTriageEntry>,
-    scope: string | null,
-): ReadonlyArray<SkillTriageEntry> => {
-    if (!scope || scope === "all") return rows;
-    return rows.filter((r) => r.scope === scope);
-};
-
-const filterBySearch = (
-    rows: ReadonlyArray<SkillTriageEntry>,
-    query: string,
-): ReadonlyArray<SkillTriageEntry> => {
-    const q = query.trim().toLowerCase();
-    if (!q) return rows;
-    return rows.filter((r) => {
-        if (r.name.toLowerCase().includes(q)) return true;
-        if (r.scope.toLowerCase().includes(q)) return true;
-        if ((r.description ?? "").toLowerCase().includes(q)) return true;
-        return false;
+/** Stable hue per source name (so colour survives sort/filter and matches the
+ *  legend even when the row order changes). */
+function buildHueMap(sources: ReadonlyArray<ContextSourceRow>): Map<string, string> {
+    const map = new Map<string, string>();
+    sources.forEach((s, i) => {
+        map.set(s.source, SOURCE_HUES[i % SOURCE_HUES.length]);
     });
-};
-
-const sortRows = (
-    rows: ReadonlyArray<SkillTriageEntry>,
-    key: SortKey,
-    dir: SortDir,
-): SkillTriageEntry[] => {
-    const out = rows.slice();
-    out.sort((a, b) => {
-        let cmp = 0;
-        switch (key) {
-            case "score":
-                cmp = a.taste_score - b.taste_score;
-                break;
-            case "30d":
-                cmp = a.inv_30d - b.inv_30d;
-                break;
-            case "7d":
-                cmp = a.inv_7d - b.inv_7d;
-                break;
-            case "total":
-                cmp = a.total_inv - b.total_inv;
-                break;
-            case "last": {
-                const ta = a.last_used ? Date.parse(a.last_used) : 0;
-                const tb = b.last_used ? Date.parse(b.last_used) : 0;
-                cmp = ta - tb;
-                break;
-            }
-            case "name":
-                cmp = a.name.localeCompare(b.name);
-                break;
-        }
-        return dir === "desc" ? -cmp : cmp;
-    });
-    return out;
-};
+    return map;
+}
 
 export function SkillsRoute() {
-    const search0 = useSearch({ strict: false }) as { q?: string };
-    const queryClient = useQueryClient();
-    const skillsQuery = useQuery({
-        queryKey: ["skills"],
-        queryFn: () => api.skills(),
+    const budget = useQuery({
+        queryKey: ["context-budget"],
+        queryFn: () => api.contextBudget(),
     });
-    const data = skillsQuery.data ?? null;
-    const [actionError, setError] = useState<string | null>(null);
-    const error =
-        actionError ?? (skillsQuery.error ? String(skillsQuery.error) : null);
-    const loading = skillsQuery.isLoading;
-    const refreshing = skillsQuery.isFetching && !skillsQuery.isLoading;
-    const setData = (
-        updater: (curr: SkillTriageResponse | null) => SkillTriageResponse | null,
-    ) => {
-        queryClient.setQueryData<SkillTriageResponse>(["skills"], (curr) => {
-            const next = updater(curr ?? null);
-            return next ?? curr;
-        });
-    };
-    const [filter, setFilter] = useState<Filter>(search0.q ? "all" : "actionable");
-    const [search, setSearch] = useState(search0.q ?? "");
-    const [scope, setScope] = useState<string>("all");
-    const [sortKey, setSortKey] = useState<SortKey>("score");
+    const data: ContextBudgetResult | null = budget.data ?? null;
+    const loading = budget.isLoading;
+    const refreshing = budget.isFetching && !budget.isLoading;
+    const error = budget.error ? String(budget.error) : null;
+
+    const [showTools, setShowTools] = useState(false);
+    const [search, setSearch] = useState("");
+    const [sourceFilter, setSourceFilter] = useState<string | null>(null);
+    const [sortKey, setSortKey] = useState<SortKey>("body");
     const [sortDir, setSortDir] = useState<SortDir>("desc");
-    const [renderLimit, setRenderLimit] = useState(SKILL_RENDER_PAGE_SIZE);
-    const [lastSaved, setLastSaved] = useState<string | null>(null);
-    const [pending, setPending] = useState<string | null>(null);
-    const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
-    const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
-    const [details, setDetails] = useState<Record<string, SkillDetailPayload>>({});
-    const [sources, setSources] = useState<Record<string, SkillSourcePayload>>({});
-    const [detailLoading, setDetailLoading] = useState<ReadonlySet<string>>(new Set());
-    // Start at -1 so no row reads as "pre-selected for keyboard nav". First
-    // j/k press promotes to 0.
-    const [highlight, setHighlight] = useState(-1);
-    const [showHelp, setShowHelp] = useState(false);
+    const [renderLimit, setRenderLimit] = useState(RENDER_PAGE);
     const searchRef = useRef<HTMLInputElement | null>(null);
-    const tbodyRef = useRef<HTMLTableSectionElement | null>(null);
 
-    const load = async (_mode: "initial" | "refresh" = "refresh") => {
-        await skillsQuery.refetch();
-    };
+    // Split Claude-Code session sources from the other-harness tool catalogs.
+    // The headline is the Claude Code session footprint; tools live behind a
+    // toggle so they never inflate the numbers that matter.
+    const ccSources = useMemo(
+        () => (data ? data.sources.filter((s) => !s.is_tool) : []),
+        [data],
+    );
+    const toolSources = useMemo(
+        () => (data ? data.sources.filter((s) => s.is_tool) : []),
+        [data],
+    );
+    const hueMap = useMemo(() => buildHueMap(ccSources), [ccSources]);
 
-    const scopes = useMemo(() => {
-        if (!data) return [] as string[];
-        return Array.from(new Set(data.skills.map((s) => s.scope))).sort();
-    }, [data]);
+    // The always-loaded tax: sum of session-source index tokens. This is the
+    // headline. cc_index_tokens from totals is the authoritative figure.
+    const indexTotal = data?.totals.cc_index_tokens ?? 0;
+    const bodyTotal = data?.totals.cc_body_tokens ?? 0;
+    const ccSkillCount = useMemo(
+        () => ccSources.reduce((n, s) => n + s.skills, 0),
+        [ccSources],
+    );
 
-    const visible = useMemo(() => {
+    // Stacked-bar segments over the session index budget only.
+    const indexSum = useMemo(
+        () => ccSources.reduce((n, s) => n + s.index_tokens, 0),
+        [ccSources],
+    );
+    const maxIndexSource = useMemo(
+        () => ccSources.reduce((m, s) => Math.max(m, s.index_tokens), 0),
+        [ccSources],
+    );
+
+    const visibleSkills = useMemo(() => {
         if (!data) return [];
-        return sortRows(
-            filterBySearch(
-                filterByScope(
-                    filterByRecommendation(data.skills, filter),
-                    scope,
-                ),
-                search,
-            ),
-            sortKey,
-            sortDir,
-        );
-    }, [data, filter, scope, search, sortKey, sortDir]);
+        const q = search.trim().toLowerCase();
+        let rows = data.skills.filter((s) => showTools || !s.is_tool);
+        if (sourceFilter) rows = rows.filter((s) => s.source === sourceFilter);
+        if (q) {
+            rows = rows.filter(
+                (s) =>
+                    s.name.toLowerCase().includes(q) ||
+                    s.source.toLowerCase().includes(q) ||
+                    s.scope.toLowerCase().includes(q),
+            );
+        }
+        return sortSkills(rows, sortKey, sortDir);
+    }, [data, showTools, sourceFilter, search, sortKey, sortDir]);
 
     const rendered = useMemo(
-        () => visible.slice(0, renderLimit),
-        [visible, renderLimit],
+        () => visibleSkills.slice(0, renderLimit),
+        [visibleSkills, renderLimit],
     );
-    const hasMoreRows = rendered.length < visible.length;
-    const renderedNames = useMemo(() => new Set(rendered.map((v) => v.name)), [rendered]);
-    const selectedVisible = useMemo(
-        () => Array.from(selected).filter((name) => renderedNames.has(name)),
-        [selected, renderedNames],
+    const hasMore = rendered.length < visibleSkills.length;
+    // Relative body bar normalized to the largest rendered body - a readout the
+    // eye can calibrate, not a raw absolute.
+    const maxBody = useMemo(
+        () => rendered.reduce((m, s) => Math.max(m, s.body_tokens), 0),
+        [rendered],
     );
 
-    const applyNote = (note: SkillTriageNote): void => {
-        setData((curr) =>
-            curr === null
-                ? curr
-                : {
-                      ...curr,
-                      skills: curr.skills.map((row) =>
-                          row.name === note.skill_name ? { ...row, decision: note } : row,
-                      ),
-                  },
-        );
-    };
+    useEffect(() => {
+        setRenderLimit(RENDER_PAGE);
+    }, [search, sourceFilter, showTools, sortKey, sortDir]);
 
-    const clearLocally = (name: string): void => {
-        setData((curr) =>
-            curr === null
-                ? curr
-                : {
-                      ...curr,
-                      skills: curr.skills.map((row) =>
-                          row.name === name ? { ...row, decision: null } : row,
-                      ),
-                  },
-        );
-    };
-
-    const flashSaved = (name: string) => {
-        setLastSaved(name);
-        window.setTimeout(() => {
-            setLastSaved((curr) => (curr === name ? null : curr));
-        }, 1200);
-    };
-
-    const decide = async (row: SkillTriageEntry, decision: TriageDecision) => {
-        const alreadyActive = row.decision?.decision === decision;
-        setPending(row.name);
-        try {
-            if (alreadyActive) {
-                await api.clearDecision(row.name);
-                clearLocally(row.name);
-            } else {
-                const note = await api.decide(row.name, decision);
-                applyNote(note);
+    // `/` to focus search, esc to leave.
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            const t = e.target as HTMLElement | null;
+            const tag = t?.tagName ?? "";
+            if (tag === "INPUT" || tag === "TEXTAREA" || t?.isContentEditable) {
+                if (e.key === "Escape" && t instanceof HTMLInputElement) t.blur();
+                return;
             }
-            flashSaved(row.name);
-            // A decision can flip the skill's on-disk state (archive disables
-            // it, keep/review restores it). Refresh the open source panel so
-            // the "disabled on disk" badge stays honest.
-            if (expanded.has(row.name)) {
-                try {
-                    const s = await api.skillSource(row.name);
-                    setSources((curr) => ({ ...curr, [row.name]: s }));
-                } catch {
-                    /* disk-state refresh is best-effort */
-                }
+            if (e.metaKey || e.ctrlKey || e.altKey) return;
+            if (e.key === "/") {
+                e.preventDefault();
+                searchRef.current?.focus();
             }
-        } catch (err) {
-            setError(err instanceof Error ? err.message : String(err));
-        } finally {
-            setPending(null);
-        }
-    };
-
-    const openSkill = async (name: string, target: "finder" | "editor") => {
-        try {
-            await api.openSkill(name, target);
-        } catch (err) {
-            setError(err instanceof Error ? err.message : String(err));
-        }
-    };
-
-    const bulkDecide = async (decision: TriageDecision) => {
-        if (selectedVisible.length === 0) return;
-        setPending("__bulk__");
-        try {
-            const { notes } = await api.decideBulk(selectedVisible, decision);
-            for (const note of notes) applyNote(note);
-            setSelected(new Set());
-        } catch (err) {
-            setError(err instanceof Error ? err.message : String(err));
-        } finally {
-            setPending(null);
-        }
-    };
-
-    const toggleSelected = (name: string) => {
-        setSelected((curr) => {
-            const next = new Set(curr);
-            if (next.has(name)) next.delete(name);
-            else next.add(name);
-            return next;
-        });
-    };
-
-    const selectAllVisible = () => {
-        setSelected(new Set(rendered.map((r) => r.name)));
-    };
-
-    const clearSelection = () => setSelected(new Set());
-
-    const toggleExpanded = async (row: SkillTriageEntry) => {
-        const isOpen = expanded.has(row.name);
-        setExpanded((curr) => {
-            const next = new Set(curr);
-            if (isOpen) next.delete(row.name);
-            else next.add(row.name);
-            return next;
-        });
-        if (!isOpen && !details[row.name]) {
-            setDetailLoading((curr) => new Set(curr).add(row.name));
-            try {
-                const [d, s] = await Promise.all([
-                    api.detail(row.name),
-                    api.skillSource(row.name),
-                ]);
-                setDetails((curr) => ({ ...curr, [row.name]: d }));
-                setSources((curr) => ({ ...curr, [row.name]: s }));
-            } catch (err) {
-                setError(err instanceof Error ? err.message : String(err));
-            } finally {
-                setDetailLoading((curr) => {
-                    const next = new Set(curr);
-                    next.delete(row.name);
-                    return next;
-                });
-            }
-        }
-    };
+        };
+        document.addEventListener("keydown", handler);
+        return () => document.removeEventListener("keydown", handler);
+    }, []);
 
     const onSortClick = (key: SortKey) => {
-        if (key === sortKey) {
-            setSortDir((d) => (d === "desc" ? "asc" : "desc"));
-        } else {
+        if (key === sortKey) setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+        else {
             setSortKey(key);
             setSortDir(DEFAULT_DIR[key]);
         }
     };
 
-    useEffect(() => {
-        setRenderLimit(SKILL_RENDER_PAGE_SIZE);
-    }, [filter, scope, search, sortKey, sortDir]);
-
-    // Clamp highlight when the rendered set changes (filter/search/sort/load).
-    useEffect(() => {
-        if (rendered.length === 0) {
-            if (highlight !== -1) setHighlight(-1);
-            return;
-        }
-        if (highlight >= rendered.length) setHighlight(rendered.length - 1);
-    }, [rendered, highlight]);
-
-    // Scroll the highlighted row into view when keyboard navigation moves it.
-    useEffect(() => {
-        if (highlight < 0) return;
-        const tbody = tbodyRef.current;
-        if (!tbody) return;
-        const row = tbody.children[highlight] as HTMLElement | undefined;
-        row?.scrollIntoView({ block: "nearest" });
-    }, [highlight]);
-
-    // Global keybindings. Skip when the user is typing into a form field so
-    // `/` doesn't double-fire and `j` doesn't move the row while filtering.
-    useEffect(() => {
-        const handler = (e: KeyboardEvent) => {
-            const target = e.target as HTMLElement | null;
-            const tag = target?.tagName ?? "";
-            if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) {
-                if (e.key === "Escape" && target instanceof HTMLInputElement) {
-                    target.blur();
-                }
-                return;
-            }
-            if (e.metaKey || e.ctrlKey || e.altKey) return;
-
-            switch (e.key) {
-                case "/":
-                    e.preventDefault();
-                    searchRef.current?.focus();
-                    return;
-                case "?":
-                    e.preventDefault();
-                    setShowHelp((v) => !v);
-                    return;
-                case "j":
-                    setHighlight((h) => Math.min(rendered.length - 1, h < 0 ? 0 : h + 1));
-                    return;
-                case "k":
-                    setHighlight((h) => Math.max(0, h - 1));
-                    return;
-                case "g":
-                    setHighlight(0);
-                    return;
-                case "G":
-                    setHighlight(Math.max(0, rendered.length - 1));
-                    return;
-                case "r":
-                    void load("refresh");
-                    return;
-                case "x": {
-                    const row = rendered[highlight];
-                    if (row) toggleSelected(row.name);
-                    return;
-                }
-                case "1":
-                case "2":
-                case "3": {
-                    const row = rendered[highlight];
-                    if (!row) return;
-                    const decision: TriageDecision =
-                        e.key === "1" ? "keep" : e.key === "2" ? "review" : "archive";
-                    void decide(row, decision);
-                    return;
-                }
-                case "Enter": {
-                    const row = rendered[highlight];
-                    if (row) void toggleExpanded(row);
-                    return;
-                }
-                default:
-                    return;
-            }
-        };
-        document.addEventListener("keydown", handler);
-        return () => document.removeEventListener("keydown", handler);
-        // load/decide/toggleExpanded/toggleSelected are stable enough; rendered
-        // and highlight are the meaningful deps.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [rendered, highlight]);
-
-    const allVisibleSelected =
-        rendered.length > 0 && rendered.every((r) => selected.has(r.name));
-
-    const computeStats = (rows: ReadonlyArray<SkillTriageEntry>) => {
-        let decided = 0;
-        let keep = 0;
-        let archive = 0;
-        let review = 0;
-        let actionable = 0;
-        for (const row of rows) {
-            if (row.decision) decided += 1;
-            if (row.recommendation !== "keep" && row.decision === null) actionable += 1;
-            switch (row.decision?.decision ?? row.recommendation) {
-                case "keep":
-                    keep += 1;
-                    break;
-                case "archive":
-                    archive += 1;
-                    break;
-                case "review":
-                    review += 1;
-                    break;
-            }
-        }
-        return { total: rows.length, decided, keep, archive, review, actionable };
-    };
-
-    // Global stats = progress meter across the full dataset. View stats =
-    // breakdown for what's currently shown.
-    const globalStats = useMemo(
-        () => (data ? computeStats(data.skills) : null),
-        [data],
-    );
-    const viewStats = useMemo(() => computeStats(visible), [visible]);
-
     return (
-        <section className="panel">
-            <header>
-                <h2>Skill Triage</h2>
-                <span className="meta">
-                    {globalStats
-                        ? `${globalStats.total} total · ${globalStats.decided} decided · ${globalStats.actionable} actionable`
-                        : ""}
-                    {data ? ` · generated ${fmtTs(data.generatedAt)}` : ""}
-                </span>
-            </header>
-            {data ? (
-                <div className="view-stats">
-                    <span>
-                        <strong>{visible.length}</strong> visible
-                    </span>
-                    {hasMoreRows ? (
-                        <span>· showing {rendered.length}</span>
-                    ) : null}
-                    <span>· keep {viewStats.keep}</span>
-                    <span>· review {viewStats.review}</span>
-                    <span>· archive {viewStats.archive}</span>
-                    {viewStats.decided > 0 ? (
-                        <span>· {viewStats.decided} decided</span>
-                    ) : null}
-                </div>
-            ) : null}
-
-            <div className="actions toolbar">
-                {FILTERS.map((f) => (
-                    <button
-                        key={f.key}
-                        className={filter === f.key ? "is-active" : undefined}
-                        onClick={() => setFilter(f.key)}
-                        type="button"
-                    >
-                        {f.label}
-                    </button>
-                ))}
-                <input
-                    type="search"
-                    placeholder="search name / scope / description  ( / focus · esc leave )"
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    className="search"
-                    aria-label="Search skills"
-                    ref={searchRef}
-                />
-                <button
-                    type="button"
-                    onClick={() => setShowHelp((v) => !v)}
-                    title="keyboard shortcuts (?)"
-                    aria-label="keyboard shortcuts"
-                    className="help-button"
-                >
-                    ? help
-                </button>
-                <button
-                    onClick={() => load("refresh")}
-                    type="button"
-                    style={{ marginLeft: "auto" }}
-                    disabled={refreshing}
-                >
-                    {refreshing ? "Refreshing…" : "Refresh"}
-                </button>
-            </div>
-
-            {scopes.length > 1 ? (
-                <div className="actions scope-bar">
-                    <span className="scope-label">scope:</span>
-                    <button
-                        type="button"
-                        className={scope === "all" ? "is-active" : undefined}
-                        onClick={() => setScope("all")}
-                    >
-                        all
-                    </button>
-                    {scopes.map((s) => (
-                        <button
-                            key={s}
-                            type="button"
-                            className={scope === s ? "is-active" : undefined}
-                            onClick={() => setScope(s)}
-                        >
-                            {s}
-                        </button>
-                    ))}
-                </div>
-            ) : null}
-
-            {selectedVisible.length > 0 ? (
-                <div className="bulk-bar">
-                    <span>
-                        <strong>{selectedVisible.length}</strong> selected
-                    </span>
-                    <div className="actions">
-                        <button
-                            type="button"
-                            onClick={() => bulkDecide("keep")}
-                            disabled={pending === "__bulk__"}
-                        >
-                            keep all
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => bulkDecide("review")}
-                            disabled={pending === "__bulk__"}
-                        >
-                            review all
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => bulkDecide("archive")}
-                            disabled={pending === "__bulk__"}
-                        >
-                            archive all
-                        </button>
-                        <button type="button" onClick={clearSelection}>
-                            clear selection
-                        </button>
+        <section className="panel ctx-budget skills-instrument">
+            <header className="inst-head">
+                <div className="inst-head-top">
+                    <div>
+                        <div className="inst-kicker">$ ax context</div>
+                        <h2 className="inst-title">Context Budget</h2>
+                        {data ? (
+                            <div className="inst-head-meta" style={{ marginTop: 8 }}>
+                                <b>{fmtCount(ccSkillCount)}</b> skills
+                                <span>·</span>
+                                <b>{fmtCount(ccSources.length)}</b> sources
+                                <span>·</span>
+                                <span className="live">
+                                    <span className="rdx-led" aria-hidden="true" />live
+                                </span>
+                            </div>
+                        ) : null}
                     </div>
+                    {data ? (
+                        <div className="inst-hero ctx-hero">
+                            <span className="rdx-doto n">{fmtTokens(indexTotal)}</span>
+                            <span className="l">tokens loaded into every session before you type</span>
+                            <span className="ctx-hero-sub">
+                                + <b>{fmtTokens(bodyTotal)}</b> on demand, only when a skill runs
+                            </span>
+                        </div>
+                    ) : null}
                 </div>
-            ) : null}
+            </header>
 
             {error ? <div className="error">Error: {error}</div> : null}
             {loading && !data ? <div className="loading">Loading…</div> : null}
 
-            {data && visible.length === 0 && !loading ? (
-                <div className="empty">No skills match.</div>
-            ) : null}
+            {data ? (
+                <>
+                    {/* --- WHERE THE BUDGET GOES: always-loaded index by source --- */}
+                    <section className="ctx-breakdown">
+                        <div className="ctx-breakdown-head">
+                            <h3>Where the always-loaded budget goes</h3>
+                            <span className="ctx-breakdown-note">
+                                {fmtTokens(indexSum)} index tokens · every session, turn zero
+                            </span>
+                        </div>
 
-            {showHelp ? <HelpOverlay onClose={() => setShowHelp(false)} /> : null}
+                        <div className="ctx-stack" aria-hidden="true">
+                            {ccSources
+                                .filter((s) => s.index_tokens > 0)
+                                .map((s) => (
+                                    <span
+                                        key={s.source}
+                                        className={`ctx-stack-seg${sourceFilter === s.source ? " is-active" : ""}`}
+                                        style={{
+                                            flexGrow: s.index_tokens,
+                                            background: hueMap.get(s.source),
+                                        }}
+                                        title={`${s.source} - ${fmtTokens(s.index_tokens)} index tokens`}
+                                        onClick={() =>
+                                            setSourceFilter((cur) =>
+                                                cur === s.source ? null : s.source,
+                                            )
+                                        }
+                                        role="button"
+                                    />
+                                ))}
+                        </div>
 
-            {data && visible.length > 0 ? (
-                <table
-                    className="skills"
-                    style={{ opacity: refreshing ? 0.6 : 1 }}
-                >
-                    <thead>
-                        <tr>
-                            <th style={{ width: 32 }}>
-                                <input
-                                    type="checkbox"
-                                    aria-label="select loaded rows"
-                                    checked={allVisibleSelected}
-                                    onChange={() =>
-                                        allVisibleSelected
-                                            ? clearSelection()
-                                            : selectAllVisible()
+                        <ul className="ctx-source-list">
+                            {ccSources.map((s) => (
+                                <li
+                                    key={s.source}
+                                    className={`ctx-source-row${sourceFilter === s.source ? " is-active" : ""}`}
+                                    onClick={() =>
+                                        setSourceFilter((cur) =>
+                                            cur === s.source ? null : s.source,
+                                        )
                                     }
+                                >
+                                    <span className="ctx-source-name">
+                                        <i
+                                            className="ctx-swatch"
+                                            style={{ background: hueMap.get(s.source) }}
+                                            aria-hidden="true"
+                                        />
+                                        {s.source}
+                                    </span>
+                                    <span className="ctx-source-skills">
+                                        {fmtCount(s.skills)} {s.skills === 1 ? "skill" : "skills"}
+                                    </span>
+                                    <span className="ctx-source-bar" aria-hidden="true">
+                                        <i
+                                            style={{
+                                                width: `${maxIndexSource > 0 ? Math.max(2, (s.index_tokens / maxIndexSource) * 100) : 0}%`,
+                                                background: hueMap.get(s.source),
+                                            }}
+                                        />
+                                    </span>
+                                    <span className="ctx-source-index">
+                                        {fmtTokens(s.index_tokens)}
+                                        <small>always</small>
+                                    </span>
+                                    <span className="ctx-source-body">
+                                        {fmtTokens(s.body_tokens)}
+                                        <small>on demand</small>
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                        {toolSources.length > 0 ? (
+                            <p className="ctx-foot">
+                                {toolSources.length} other-harness tool{" "}
+                                {toolSources.length === 1 ? "catalog" : "catalogs"} (codex /
+                                cursor / opencode / pi) excluded from the Claude Code session
+                                budget.{" "}
+                                <button
+                                    type="button"
+                                    className="ctx-link"
+                                    onClick={() => setShowTools((v) => !v)}
+                                >
+                                    {showTools ? "hide" : "show"} in the index below
+                                </button>
+                            </p>
+                        ) : null}
+                    </section>
+
+                    {/* --- SKILL INDEX: navigable, sortable, dense --- */}
+                    <div className="inst-controls ctx-controls">
+                        <button
+                            type="button"
+                            className={`inst-chip${sourceFilter === null ? " is-active" : ""}`}
+                            onClick={() => setSourceFilter(null)}
+                        >
+                            all sources
+                        </button>
+                        {sourceFilter ? (
+                            <span className="ctx-active-filter">
+                                <i
+                                    className="ctx-swatch"
+                                    style={{ background: hueMap.get(sourceFilter) }}
+                                    aria-hidden="true"
                                 />
-                            </th>
-                            <SortHeader k="name" current={sortKey} dir={sortDir} onClick={onSortClick}>
-                                Skill
-                            </SortHeader>
-                            <th>Recommendation</th>
-                            <SortHeader k="score" current={sortKey} dir={sortDir} onClick={onSortClick} className="num">
-                                Score
-                            </SortHeader>
-                            <SortHeader k="30d" current={sortKey} dir={sortDir} onClick={onSortClick} className="num">
-                                30d
-                            </SortHeader>
-                            <SortHeader k="7d" current={sortKey} dir={sortDir} onClick={onSortClick} className="num">
-                                7d
-                            </SortHeader>
-                            <SortHeader k="total" current={sortKey} dir={sortDir} onClick={onSortClick} className="num">
-                                total
-                            </SortHeader>
-                            <SortHeader k="last" current={sortKey} dir={sortDir} onClick={onSortClick} className="num">
-                                last
-                            </SortHeader>
-                            <th>Decision</th>
-                        </tr>
-                    </thead>
-                    <tbody ref={tbodyRef}>
-                        {rendered.map((row, idx) => (
-                            <SkillRowView
-                                key={row.name}
-                                row={row}
-                                highlighted={idx === highlight}
-                                justSaved={lastSaved === row.name}
-                                pending={pending === row.name || pending === "__bulk__"}
-                                selected={selected.has(row.name)}
-                                expanded={expanded.has(row.name)}
-                                detail={details[row.name] ?? null}
-                                source={sources[row.name] ?? null}
-                                detailLoading={detailLoading.has(row.name)}
-                                onDecide={(d) => decide(row, d)}
-                                onOpen={openSkill}
-                                onToggleSelect={() => toggleSelected(row.name)}
-                                onToggleExpand={() => toggleExpanded(row)}
-                            />
-                        ))}
-                    </tbody>
-                </table>
-            ) : null}
-            {data && hasMoreRows ? (
-                <div className="load-more">
-                    <button
-                        type="button"
-                        onClick={() =>
-                            setRenderLimit((limit) =>
-                                Math.min(limit + SKILL_RENDER_PAGE_SIZE, visible.length),
-                            )
-                        }
-                    >
-                        load {Math.min(SKILL_RENDER_PAGE_SIZE, visible.length - rendered.length)} more
-                    </button>
-                </div>
+                                {sourceFilter}
+                                <button
+                                    type="button"
+                                    className="ctx-link"
+                                    onClick={() => setSourceFilter(null)}
+                                >
+                                    clear
+                                </button>
+                            </span>
+                        ) : null}
+                        <input
+                            type="search"
+                            placeholder="search name / source / scope   ( / focus · esc leave )"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                            className="inst-search"
+                            aria-label="search skills"
+                            ref={searchRef}
+                        />
+                        <button
+                            type="button"
+                            className="inst-chip"
+                            onClick={() => budget.refetch()}
+                            disabled={refreshing}
+                        >
+                            {refreshing ? "refreshing…" : "refresh"}
+                        </button>
+                    </div>
+
+                    <div className="inst-head-meta" style={{ margin: "0 0 10px" }}>
+                        <b>{fmtCount(visibleSkills.length)}</b> in index
+                        {hasMore ? (
+                            <>
+                                <span>·</span> showing {rendered.length}
+                            </>
+                        ) : null}
+                    </div>
+
+                    {visibleSkills.length === 0 ? (
+                        <div className="empty">No skills match.</div>
+                    ) : (
+                        <table className="skills ctx-table" style={{ opacity: refreshing ? 0.6 : 1 }}>
+                            <thead>
+                                <tr>
+                                    <SortHeader k="name" current={sortKey} dir={sortDir} onClick={onSortClick}>
+                                        Skill
+                                    </SortHeader>
+                                    <SortHeader k="source" current={sortKey} dir={sortDir} onClick={onSortClick}>
+                                        Source
+                                    </SortHeader>
+                                    <SortHeader k="index" current={sortKey} dir={sortDir} onClick={onSortClick} className="num">
+                                        Index <span className="th-sub">always</span>
+                                    </SortHeader>
+                                    <SortHeader k="body" current={sortKey} dir={sortDir} onClick={onSortClick} className="num">
+                                        Body <span className="th-sub">on demand</span>
+                                    </SortHeader>
+                                    <th className="num">Weight</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {rendered.map((s) => (
+                                    <SkillRow
+                                        key={`${s.source}/${s.name}`}
+                                        row={s}
+                                        hue={hueMap.get(s.source) ?? "var(--dim)"}
+                                        maxBody={maxBody}
+                                    />
+                                ))}
+                            </tbody>
+                        </table>
+                    )}
+
+                    {hasMore ? (
+                        <div className="load-more">
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    setRenderLimit((l) =>
+                                        Math.min(l + RENDER_PAGE, visibleSkills.length),
+                                    )
+                                }
+                            >
+                                load {Math.min(RENDER_PAGE, visibleSkills.length - rendered.length)} more
+                            </button>
+                        </div>
+                    ) : null}
+                </>
             ) : null}
         </section>
     );
+}
+
+function SkillRow({
+    row,
+    hue,
+    maxBody,
+}: {
+    row: ContextSkillRow;
+    hue: string;
+    maxBody: number;
+}) {
+    const frac = maxBody > 0 ? Math.max(0.02, row.body_tokens / maxBody) : 0;
+    return (
+        <tr className="skill-row">
+            <td className="skill-cell">
+                <strong>{row.name}</strong>
+                {row.is_tool ? <span className="ctx-tool-tag">tool</span> : null}
+            </td>
+            <td>
+                <span className="ctx-cell-source">
+                    <i className="ctx-swatch" style={{ background: hue }} aria-hidden="true" />
+                    {row.source}
+                </span>
+            </td>
+            <td className="num">{fmtTokens(row.index_tokens)}</td>
+            <td className="num">{fmtTokens(row.body_tokens)}</td>
+            <td className="num">
+                <span className="ctx-weight" aria-hidden="true">
+                    <i style={{ width: `${frac * 100}%`, background: hue }} />
+                </span>
+            </td>
+        </tr>
+    );
+}
+
+function sortSkills(
+    rows: ReadonlyArray<ContextSkillRow>,
+    key: SortKey,
+    dir: SortDir,
+): ContextSkillRow[] {
+    const out = rows.slice();
+    out.sort((a, b) => {
+        let cmp = 0;
+        switch (key) {
+            case "body":
+                cmp = a.body_tokens - b.body_tokens;
+                break;
+            case "index":
+                cmp = a.index_tokens - b.index_tokens;
+                break;
+            case "name":
+                cmp = a.name.localeCompare(b.name);
+                break;
+            case "source":
+                cmp = a.source.localeCompare(b.source) || b.body_tokens - a.body_tokens;
+                break;
+        }
+        return dir === "desc" ? -cmp : cmp;
+    });
+    return out;
 }
 
 function SortHeader({
@@ -690,363 +491,5 @@ function SortHeader({
                 {caret}
             </button>
         </th>
-    );
-}
-
-function SkillRowView({
-    row,
-    highlighted,
-    justSaved,
-    pending,
-    selected,
-    expanded,
-    detail,
-    source,
-    detailLoading,
-    onDecide,
-    onOpen,
-    onToggleSelect,
-    onToggleExpand,
-}: {
-    row: SkillTriageEntry;
-    highlighted: boolean;
-    justSaved: boolean;
-    pending: boolean;
-    selected: boolean;
-    expanded: boolean;
-    detail: SkillDetailPayload | null;
-    source: SkillSourcePayload | null;
-    detailLoading: boolean;
-    onDecide: (decision: TriageDecision) => void;
-    onOpen: (name: string, target: "finder" | "editor") => void;
-    onToggleSelect: () => void;
-    onToggleExpand: () => void;
-}) {
-    const decisionLabel = row.decision ? row.decision.decision : null;
-    const trClasses = [
-        "skill-row",
-        highlighted ? "row-highlighted" : "",
-        decisionLabel ? `row-decided row-decision-${decisionLabel}` : "",
-        justSaved ? "row-just-saved" : "",
-    ]
-        .filter(Boolean)
-        .join(" ");
-    // Whole-row click toggles the accordion - but suppress when the user is
-    // dragging a selection (so they can copy a skill name without expanding).
-    const handleRowClick = () => {
-        if ((window.getSelection()?.toString().length ?? 0) > 0) return;
-        onToggleExpand();
-    };
-    // Anything with its own handler needs to stop the row click so the two
-    // don't fight (checkbox toggle, decision buttons, the reason badge).
-    const stop = (e: React.MouseEvent | React.ChangeEvent) => e.stopPropagation();
-    return (
-        <>
-            <tr
-                className={trClasses}
-                onClick={handleRowClick}
-                aria-expanded={expanded}
-            >
-                <td onClick={stop}>
-                    <input
-                        type="checkbox"
-                        aria-label={`select ${row.name}`}
-                        checked={selected}
-                        onChange={onToggleSelect}
-                        onClick={stop}
-                    />
-                </td>
-                <td className="skill-cell">
-                    <strong>{row.name}</strong>
-                    <small>
-                        <span className="chip">{row.scope}</span>
-                        {row.description ? (
-                            <span className="description" title={row.description}>
-                                {row.description}
-                            </span>
-                        ) : null}
-                    </small>
-                </td>
-                <td>
-                    <div
-                        className="reason-button"
-                        title={expanded ? "click row to hide evidence" : "click row to show evidence"}
-                    >
-                        <span className={`badge ${row.recommendation}`}>
-                            {row.recommendation}
-                        </span>
-                        <small>
-                            {row.recommendation_reason} {expanded ? "▴" : "▾"}
-                        </small>
-                    </div>
-                </td>
-                <td className="num">{fmtScore(row.taste_score)}</td>
-                <td className="num">{fmtCount(row.inv_30d)}</td>
-                <td className="num">{fmtCount(row.inv_7d)}</td>
-                <td className="num">{fmtCount(row.total_inv)}</td>
-                <td className="num">{fmtLastUsed(row.last_used)}</td>
-                <td onClick={stop}>
-                    <div className="actions">
-                        {(["keep", "review", "archive"] as TriageDecision[]).map((d) => (
-                            <button
-                                key={d}
-                                type="button"
-                                disabled={pending}
-                                className={decisionLabel === d ? "is-active" : undefined}
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    onDecide(d);
-                                }}
-                                title={
-                                    decisionLabel === d
-                                        ? "click to clear decision"
-                                        : `mark as ${d}`
-                                }
-                            >
-                                {d}
-                            </button>
-                        ))}
-                    </div>
-                    {row.decision ? (
-                        <small>decided {fmtTs(row.decision.decided_at)}</small>
-                    ) : null}
-                </td>
-            </tr>
-            {expanded ? (
-                <tr className="detail-row">
-                    <td />
-                    <td colSpan={8}>
-                        <DetailPanel
-                            detail={detail}
-                            source={source}
-                            loading={detailLoading}
-                            onOpen={onOpen}
-                        />
-                    </td>
-                </tr>
-            ) : null}
-        </>
-    );
-}
-
-function DetailPanel({
-    detail,
-    source,
-    loading,
-    onOpen,
-}: {
-    detail: SkillDetailPayload | null;
-    source: SkillSourcePayload | null;
-    loading: boolean;
-    onOpen: (name: string, target: "finder" | "editor") => void;
-}) {
-    if (loading && !detail) return <div className="loading">Loading evidence…</div>;
-    if (!detail) return <div className="empty">No evidence yet.</div>;
-    return (
-        <div className="detail-grid">
-            <div>
-                <h3>Recent invocations</h3>
-                {detail.recent.length === 0 ? (
-                    <p className="empty">none</p>
-                ) : (
-                    <ul>
-                        {detail.recent.map((r, i) => (
-                            <li key={`${r.ts}-${i}`}>
-                                <code>{fmtTs(r.ts)}</code>{" "}
-                                <span>{prettifyProjectSlug(r.project)}</span>
-                                {r.turn_has_error ? <span className="badge review">error</span> : null}
-                            </li>
-                        ))}
-                    </ul>
-                )}
-            </div>
-            <div>
-                <h3>Corrections ({detail.corrections.length})</h3>
-                {detail.corrections.length === 0 ? (
-                    <p className="empty">none - clean usage</p>
-                ) : (
-                    <ul>
-                        {detail.corrections.map((r, i) => (
-                            <li key={`${r.ts}-${i}`}>
-                                <code>{fmtTs(r.ts)}</code>{" "}
-                                <span>{prettifyProjectSlug(r.project)}</span>
-                            </li>
-                        ))}
-                    </ul>
-                )}
-            </div>
-            <div>
-                <h3>Proposals ({detail.proposals.length})</h3>
-                {detail.proposals.length === 0 ? (
-                    <p className="empty">none</p>
-                ) : (
-                    <ul>
-                        {detail.proposals.map((p, i) => (
-                            <li key={`${p.ts}-${i}`}>
-                                <code>{fmtTs(p.ts)}</code>{" "}
-                                <span>{prettifyProjectSlug(p.project)}</span>
-                                {p.context_excerpt ? (
-                                    <small>{p.context_excerpt}</small>
-                                ) : null}
-                            </li>
-                        ))}
-                    </ul>
-                )}
-            </div>
-            <div style={{ gridColumn: "1 / -1" }}>
-                <h3>Frequently paired with ({detail.paired.length})</h3>
-                {detail.paired.length === 0 ? (
-                    <p className="empty">no co-occurring skills</p>
-                ) : (
-                    <ul className="paired-list">
-                        {detail.paired.map((p) => (
-                            <li key={p.partner}>
-                                <Link to="/skills" search={{ q: p.partner }}>
-                                    <strong>{p.partner}</strong>
-                                </Link>
-                                <span className="chip">{p.count}x</span>
-                                <small>last {fmtLastUsed(p.last_seen)}</small>
-                            </li>
-                        ))}
-                    </ul>
-                )}
-            </div>
-            <div style={{ gridColumn: "1 / -1" }}>
-                <h3>Skill source</h3>
-                <SkillSourceView source={source} onOpen={onOpen} />
-            </div>
-        </div>
-    );
-}
-
-const SOURCE_STATE_LABEL: Record<string, string> = {
-    active: "active",
-    disabled: "disabled on disk",
-    missing: "no file",
-};
-
-function SkillSourceView({
-    source,
-    onOpen,
-}: {
-    source: SkillSourcePayload | null;
-    onOpen: (name: string, target: "finder" | "editor") => void;
-}) {
-    if (!source) return <div className="loading">Loading source…</div>;
-
-    const stateBadge =
-        source.state === "active" ? "keep"
-        : source.state === "disabled" ? "archive"
-        : "review";
-
-    return (
-        <div className="skill-source">
-            <div className="skill-source-head">
-                <span className={`badge ${stateBadge}`}>
-                    {SOURCE_STATE_LABEL[source.state] ?? source.state}
-                </span>
-                <span className="chip">{source.scope}</span>
-                {source.file_path ? (
-                    <code className="skill-source-path">{source.file_path}</code>
-                ) : (
-                    <small className="empty">
-                        no on-disk SKILL.md (synthetic / built-in skill)
-                    </small>
-                )}
-            </div>
-
-            {source.error ? (
-                <div className="error">Could not read file: {source.error}</div>
-            ) : null}
-
-            {source.file_path ? (
-                <div className="actions skill-source-actions">
-                    <button
-                        type="button"
-                        onClick={() => onOpen(source.name, "editor")}
-                    >
-                        Open in editor
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => onOpen(source.name, "finder")}
-                    >
-                        Reveal in Finder
-                    </button>
-                    {!source.editable ? (
-                        <small className="empty">
-                            read-only - {source.scope} skills are not disk-editable;
-                            decisions stay labels only
-                        </small>
-                    ) : source.state === "disabled" ? (
-                        <small className="empty">
-                            disabled - mark “keep” or “review” to restore it
-                        </small>
-                    ) : (
-                        <small className="empty">
-                            marking “archive” renames SKILL.md so the agent stops
-                            loading it
-                        </small>
-                    )}
-                </div>
-            ) : null}
-
-            {source.frontmatter ? (
-                <>
-                    <h4>Frontmatter</h4>
-                    <pre className="skill-source-block skill-source-frontmatter">
-                        {source.frontmatter}
-                    </pre>
-                </>
-            ) : null}
-
-            {source.body ? (
-                <>
-                    <h4>SKILL.md body</h4>
-                    <pre className="skill-source-block skill-source-body">
-                        {source.body}
-                    </pre>
-                </>
-            ) : source.file_path && !source.error ? (
-                <p className="empty">empty body</p>
-            ) : null}
-        </div>
-    );
-}
-
-const SHORTCUTS: ReadonlyArray<{ keys: string; what: string }> = [
-    { keys: "/", what: "focus search" },
-    { keys: "esc", what: "leave search" },
-    { keys: "j / k", what: "move row down / up" },
-    { keys: "g / G", what: "jump top / bottom" },
-    { keys: "Enter", what: "expand evidence" },
-    { keys: "x", what: "toggle row selection" },
-    { keys: "1 / 2 / 3", what: "keep / review / archive" },
-    { keys: "r", what: "refresh" },
-    { keys: "?", what: "toggle this help" },
-];
-
-function HelpOverlay({ onClose }: { onClose: () => void }) {
-    return (
-        <div className="help-overlay" onClick={onClose}>
-            <div className="help-card" onClick={(e) => e.stopPropagation()}>
-                <header>
-                    <h3>Keyboard shortcuts</h3>
-                    <button type="button" onClick={onClose} aria-label="close help">
-                        ×
-                    </button>
-                </header>
-                <dl>
-                    {SHORTCUTS.map((s) => (
-                        <div key={s.keys}>
-                            <dt>
-                                <kbd>{s.keys}</kbd>
-                            </dt>
-                            <dd>{s.what}</dd>
-                        </div>
-                    ))}
-                </dl>
-            </div>
-        </div>
     );
 }

--- a/apps/studio/src/routes/skills.tsx
+++ b/apps/studio/src/routes/skills.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "../api.ts";
 import type {
     ContextBudgetResult,
+    ContextDriftRow,
     ContextSkillRow,
     ContextSourceRow,
 } from "../api.ts";
@@ -66,6 +67,11 @@ export function SkillsRoute() {
         queryKey: ["context-budget"],
         queryFn: () => api.contextBudget(),
     });
+    const drift = useQuery({
+        queryKey: ["context-drift"],
+        queryFn: () => api.contextDrift(),
+    });
+    const driftRows = drift.data?.changes ?? [];
     const data: ContextBudgetResult | null = budget.data ?? null;
     const loading = budget.isLoading;
     const refreshing = budget.isFetching && !budget.isLoading;
@@ -295,6 +301,8 @@ export function SkillsRoute() {
                         ) : null}
                     </section>
 
+                    <DriftPanel rows={driftRows} />
+
                     {/* --- SKILL INDEX: navigable, sortable, dense --- */}
                     <div className="inst-controls ctx-controls">
                         <button
@@ -399,6 +407,65 @@ export function SkillsRoute() {
                     ) : null}
                 </>
             ) : null}
+        </section>
+    );
+}
+
+/** Compact relative time ("3d ago") from an ISO timestamp. */
+function relTime(iso: string): string {
+    const t = Date.parse(iso);
+    if (!Number.isFinite(t)) return "";
+    const s = (Date.now() - t) / 1000;
+    if (s < 60) return "just now";
+    if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+    if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+    return `${Math.floor(s / 86400)}d ago`;
+}
+
+/** DRIFT: the append-only skill change log - what shifted since baseline. The
+ *  same skill registered under user + project scopes logs twice; collapse the
+ *  mirror so each change shows once. */
+function DriftPanel({ rows }: { rows: ReadonlyArray<ContextDriftRow> }) {
+    const seen = new Set<string>();
+    const items = rows
+        .filter((r) => {
+            const base = r.name.replace(/^[^:]+:/, "");
+            // collapse the user↔project mirror: same change logged ~same minute
+            // under two scopes, with timestamps a fraction apart.
+            const k = `${r.ts.slice(0, 16)}|${base}|${r.change}|${r.token_delta}`;
+            if (seen.has(k)) return false;
+            seen.add(k);
+            return true;
+        })
+        .slice(0, 12);
+    return (
+        <section className="ctx-drift">
+            <div className="ctx-breakdown-head">
+                <span className="inst-kicker">$ drift</span>
+                <span className="ctx-breakdown-note">skills changed since baseline - tracked from first ingest</span>
+            </div>
+            {items.length === 0 ? (
+                <p className="ctx-foot">
+                    No drift yet. When you - or an agent - edit a skill, the change lands here with its token delta.
+                </p>
+            ) : (
+                <ul className="ctx-drift-list">
+                    {items.map((r, i) => {
+                        const base = r.name.replace(/^[^:]+:/, "");
+                        const delta = r.token_delta;
+                        return (
+                            <li key={`${r.ts}-${base}-${i}`} className="ctx-drift-row">
+                                <span className={`ctx-drift-tag is-${r.change}`}>{r.change}</span>
+                                <span className="ctx-drift-name">{base}</span>
+                                <span className="ctx-drift-delta">
+                                    {r.change === "added" ? "new" : `${delta > 0 ? "+" : ""}${fmtCount(delta)} tok`}
+                                </span>
+                                <span className="ctx-drift-time">{relTime(r.ts)}</span>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
         </section>
     );
 }

--- a/apps/studio/src/routes/skills.tsx
+++ b/apps/studio/src/routes/skills.tsx
@@ -18,8 +18,9 @@ import { fmtCount } from "@ax/lib/shared/formatters";
        tax you pay on turn zero.
      - BODY   (body_tokens): on-demand. The SKILL.md body, only loaded when the
        skill is actually invoked.
-   The page reveals that cost and lets you navigate the skills as an index.
-   No triage. These are real measurements - let the numbers speak.
+   The page reveals that cost AND offers an ACTION LAYER: reclaim the
+   always-loaded tax that buys you nothing. CTAs are copy-to-run only - the
+   page never touches your files; ax observes, you run the command.
    ========================================================================= */
 
 /** chars/4 token est is already done server-side; we format for display. */
@@ -40,7 +41,7 @@ const SOURCE_HUES = [
     "color-mix(in srgb, var(--blue) 55%, var(--surface2))",
 ] as const;
 
-type SortKey = "body" | "index" | "name" | "source";
+type SortKey = "body" | "index" | "name" | "source" | "used";
 type SortDir = "asc" | "desc";
 
 const DEFAULT_DIR: Record<SortKey, SortDir> = {
@@ -48,9 +49,15 @@ const DEFAULT_DIR: Record<SortKey, SortDir> = {
     index: "desc",
     name: "asc",
     source: "asc",
+    used: "desc",
 };
 
 const RENDER_PAGE = 80;
+
+/** How many dead-weight skills to surface in the reclaim panel before "show
+ *  all". Heaviest first - the opportunity, not a purge checklist. */
+const RECLAIM_TOP = 8;
+const RECLAIM_TRIM = 6;
 
 /** Stable hue per source name (so colour survives sort/filter and matches the
  *  legend even when the row order changes). */
@@ -83,6 +90,7 @@ export function SkillsRoute() {
     const [sortKey, setSortKey] = useState<SortKey>("body");
     const [sortDir, setSortDir] = useState<SortDir>("desc");
     const [renderLimit, setRenderLimit] = useState(RENDER_PAGE);
+    const [reclaimAll, setReclaimAll] = useState(false);
     const searchRef = useRef<HTMLInputElement | null>(null);
 
     // Split Claude-Code session sources from the other-harness tool catalogs.
@@ -102,6 +110,10 @@ export function SkillsRoute() {
     // headline. cc_index_tokens from totals is the authoritative figure.
     const indexTotal = data?.totals.cc_index_tokens ?? 0;
     const bodyTotal = data?.totals.cc_body_tokens ?? 0;
+    const windowDays = data?.totals.window_days ?? 30;
+    const reclaimTokens = data?.totals.reclaimable_index_tokens ?? 0;
+    const reclaimSkills = data?.totals.reclaimable_skills ?? 0;
+    const verboseCount = data?.totals.verbose_skills ?? 0;
     const ccSkillCount = useMemo(
         () => ccSources.reduce((n, s) => n + s.skills, 0),
         [ccSources],
@@ -116,6 +128,36 @@ export function SkillsRoute() {
         () => ccSources.reduce((m, s) => Math.max(m, s.index_tokens), 0),
         [ccSources],
     );
+
+    // --- RECLAIM: dead-weight skills, heaviest always-loaded cost first. The
+    // opportunity is the index tax these buy you nothing for. dir_path drives
+    // the copy-to-run `trash` command. Tools excluded (no SKILL.md to disable).
+    const deadWeight = useMemo(() => {
+        if (!data) return [];
+        return data.skills
+            .filter((s) => s.dead_weight && !s.is_tool && s.dir_path)
+            .sort((a, b) => b.index_tokens - a.index_tokens);
+    }, [data]);
+
+    // --- TRIM: verbose skills (description > 500 chars). Keep the skill, tighten
+    // the always-loaded part. Heaviest index first; exclude tools.
+    const verboseSkills = useMemo(() => {
+        if (!data) return [];
+        return data.skills
+            .filter((s) => s.verbose && !s.is_tool)
+            .sort((a, b) => b.index_tokens - a.index_tokens);
+    }, [data]);
+
+    // dir_paths of dead-weight skills per source - the [mute] copy-command body.
+    const deadBySource = useMemo(() => {
+        const map = new Map<string, ContextSkillRow[]>();
+        for (const s of deadWeight) {
+            const arr = map.get(s.source) ?? [];
+            arr.push(s);
+            map.set(s.source, arr);
+        }
+        return map;
+    }, [deadWeight]);
 
     const visibleSkills = useMemo(() => {
         if (!data) return [];
@@ -212,6 +254,20 @@ export function SkillsRoute() {
 
             {data ? (
                 <>
+                    {/* --- RECLAIM: the CTA. Opportunity-framed, heaviest first --- */}
+                    {reclaimTokens > 0 ? (
+                        <ReclaimPanel
+                            reclaimTokens={reclaimTokens}
+                            reclaimSkills={reclaimSkills}
+                            indexTotal={indexTotal}
+                            windowDays={windowDays}
+                            deadWeight={deadWeight}
+                            showAll={reclaimAll}
+                            onToggleAll={() => setReclaimAll((v) => !v)}
+                            hueMap={hueMap}
+                        />
+                    ) : null}
+
                     {/* --- WHERE THE BUDGET GOES: always-loaded index by source --- */}
                     <section className="ctx-breakdown">
                         <div className="ctx-breakdown-head">
@@ -245,43 +301,20 @@ export function SkillsRoute() {
 
                         <ul className="ctx-source-list">
                             {ccSources.map((s) => (
-                                <li
+                                <SourceRow
                                     key={s.source}
-                                    className={`ctx-source-row${sourceFilter === s.source ? " is-active" : ""}`}
-                                    onClick={() =>
+                                    s={s}
+                                    hue={hueMap.get(s.source) ?? "var(--dim)"}
+                                    maxIndexSource={maxIndexSource}
+                                    active={sourceFilter === s.source}
+                                    windowDays={windowDays}
+                                    deadSkills={deadBySource.get(s.source) ?? []}
+                                    onSelect={() =>
                                         setSourceFilter((cur) =>
                                             cur === s.source ? null : s.source,
                                         )
                                     }
-                                >
-                                    <span className="ctx-source-name">
-                                        <i
-                                            className="ctx-swatch"
-                                            style={{ background: hueMap.get(s.source) }}
-                                            aria-hidden="true"
-                                        />
-                                        {s.source}
-                                    </span>
-                                    <span className="ctx-source-skills">
-                                        {fmtCount(s.skills)} {s.skills === 1 ? "skill" : "skills"}
-                                    </span>
-                                    <span className="ctx-source-bar" aria-hidden="true">
-                                        <i
-                                            style={{
-                                                width: `${maxIndexSource > 0 ? Math.max(2, (s.index_tokens / maxIndexSource) * 100) : 0}%`,
-                                                background: hueMap.get(s.source),
-                                            }}
-                                        />
-                                    </span>
-                                    <span className="ctx-source-index">
-                                        {fmtTokens(s.index_tokens)}
-                                        <small>always</small>
-                                    </span>
-                                    <span className="ctx-source-body">
-                                        {fmtTokens(s.body_tokens)}
-                                        <small>on demand</small>
-                                    </span>
-                                </li>
+                                />
                             ))}
                         </ul>
                         {toolSources.length > 0 ? (
@@ -300,6 +333,11 @@ export function SkillsRoute() {
                             </p>
                         ) : null}
                     </section>
+
+                    {/* --- TRIM: verbose skills, keep but tighten --- */}
+                    {verboseSkills.length > 0 ? (
+                        <TrimPanel rows={verboseSkills} hueMap={hueMap} verboseCount={verboseCount} />
+                    ) : null}
 
                     <DriftPanel rows={driftRows} />
 
@@ -369,6 +407,9 @@ export function SkillsRoute() {
                                     <SortHeader k="source" current={sortKey} dir={sortDir} onClick={onSortClick}>
                                         Source
                                     </SortHeader>
+                                    <SortHeader k="used" current={sortKey} dir={sortDir} onClick={onSortClick} className="num">
+                                        Used <span className="th-sub">{windowDays}d</span>
+                                    </SortHeader>
                                     <SortHeader k="index" current={sortKey} dir={sortDir} onClick={onSortClick} className="num">
                                         Index <span className="th-sub">always</span>
                                     </SortHeader>
@@ -409,6 +450,304 @@ export function SkillsRoute() {
             ) : null}
         </section>
     );
+}
+
+/* ===========================================================================
+   ACTION LAYER
+   Three CTAs, all copy-to-run. The page NEVER mutates a file - it copies a
+   command/brief to the clipboard. ax observes; you run it.
+   ========================================================================= */
+
+/** Copies `text` to the clipboard and flips to a "copied ✓" state for 1.6s.
+ *  The whole affordance is the button; caption sits in the panel. */
+function CopyAction({
+    text,
+    label,
+    className = "ctx-act",
+    title,
+}: {
+    readonly text: string;
+    readonly label: string;
+    readonly className?: string;
+    readonly title?: string;
+}) {
+    const [copied, setCopied] = useState(false);
+    return (
+        <button
+            type="button"
+            className={`${className}${copied ? " is-copied" : ""}`}
+            title={title}
+            onClick={() => {
+                void navigator.clipboard.writeText(text).then(() => {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 1600);
+                });
+            }}
+        >
+            {copied ? "copied ✓" : label}
+        </button>
+    );
+}
+
+/** `trash <dir_path>` - repo prefers trash over rm. */
+const disableCmd = (s: ContextSkillRow): string => `trash ${shellQuote(s.dir_path)}`;
+
+/** A multi-line `trash dir1 dir2 …` for every dead-weight skill of one source. */
+function muteCmd(rows: ReadonlyArray<ContextSkillRow>): string {
+    const dirs = rows.filter((r) => r.dir_path).map((r) => shellQuote(r.dir_path));
+    if (dirs.length === 0) return "";
+    // one trash call so the user reclaims the whole source in a single run
+    return `trash \\\n  ${dirs.join(" \\\n  ")}`;
+}
+
+/** A one-line agent brief that tightens the always-loaded description. */
+const trimCmd = (s: ContextSkillRow): string =>
+    `axctl improve recommend --skill ${shellQuote(s.name)}  # tighten SKILL.md frontmatter description (~${Math.round(s.index_tokens)} tok always-loaded)`;
+
+/** Minimal shell quoting - wrap in single quotes if the path has spaces or
+ *  shell-special chars; the skill dirs are plain paths but be safe. */
+function shellQuote(s: string): string {
+    if (s === "") return "''";
+    if (/^[A-Za-z0-9_./@:-]+$/.test(s)) return s;
+    return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/** CTA 1 - reclaim dead weight. Opportunity headline + the heaviest offenders.
+ *  Calm instrument tone: this is opt-in browsing of the heaviest dead weight,
+ *  not a purge checklist. The {windowDays}d-unused basis is made explicit. */
+function ReclaimPanel({
+    reclaimTokens,
+    reclaimSkills,
+    indexTotal,
+    windowDays,
+    deadWeight,
+    showAll,
+    onToggleAll,
+    hueMap,
+}: {
+    readonly reclaimTokens: number;
+    readonly reclaimSkills: number;
+    readonly indexTotal: number;
+    readonly windowDays: number;
+    readonly deadWeight: ReadonlyArray<ContextSkillRow>;
+    readonly showAll: boolean;
+    readonly onToggleAll: () => void;
+    readonly hueMap: Map<string, string>;
+}) {
+    const shown = showAll ? deadWeight : deadWeight.slice(0, RECLAIM_TOP);
+    const more = deadWeight.length - shown.length;
+    const pct = indexTotal > 0 ? Math.round((reclaimTokens / indexTotal) * 100) : 0;
+    return (
+        <section className="ctx-reclaim">
+            <div className="ctx-reclaim-head">
+                <div className="ctx-reclaim-lede">
+                    <span className="inst-kicker">$ ax reclaim</span>
+                    <h3 className="ctx-reclaim-h">
+                        Reclaim up to <em>~{fmtTokens(reclaimTokens)}</em> tok / session
+                    </h3>
+                    <p className="ctx-reclaim-sub">
+                        {pct}% of your always-loaded tax sits in{" "}
+                        <b>{fmtCount(reclaimSkills)}</b> skills not invoked in the last{" "}
+                        <b>{windowDays}d</b>. Browse the heaviest first - disabling them
+                        cuts the turn-zero load; nothing here runs automatically.
+                    </p>
+                </div>
+                <div className="ctx-reclaim-gauge" aria-hidden="true">
+                    <span className="ctx-reclaim-gauge-bar">
+                        <i style={{ width: `${pct}%` }} />
+                    </span>
+                    <span className="ctx-reclaim-gauge-cap">
+                        {pct}% reclaimable
+                    </span>
+                </div>
+            </div>
+
+            <ul className="ctx-reclaim-list">
+                {shown.map((s) => (
+                    <li key={`${s.source}/${s.name}`} className="ctx-reclaim-row">
+                        <span className="ctx-reclaim-name">
+                            <i
+                                className="ctx-swatch"
+                                style={{ background: hueMap.get(s.source) ?? "var(--dim)" }}
+                                aria-hidden="true"
+                            />
+                            {s.name}
+                        </span>
+                        <span className="ctx-reclaim-reclaim">
+                            {fmtTokens(s.index_tokens)}<small>reclaim</small>
+                        </span>
+                        <span className="ctx-reclaim-last">{lastUsedLabel(s, windowDays)}</span>
+                        <CopyAction
+                            text={disableCmd(s)}
+                            label="[disable]"
+                            className="ctx-act"
+                            title={`copy: ${disableCmd(s)}`}
+                        />
+                    </li>
+                ))}
+            </ul>
+
+            <p className="ctx-reclaim-foot">
+                {more > 0 ? (
+                    <button type="button" className="ctx-link" onClick={onToggleAll}>
+                        {showAll ? "show fewer" : `show ${more} more dead-weight ${more === 1 ? "skill" : "skills"}`}
+                    </button>
+                ) : (
+                    <span>showing all {deadWeight.length}</span>
+                )}
+                <span className="ctx-reclaim-note">
+                    [disable] copies <code>trash &lt;dir&gt;</code> to run yourself - ax
+                    won't touch your files.
+                </span>
+            </p>
+        </section>
+    );
+}
+
+/** CTA 3 - trim verbose skills. Keep the skill, tighten its bloated (always-
+ *  loaded) description. Copies an `axctl improve recommend` brief. */
+function TrimPanel({
+    rows,
+    hueMap,
+    verboseCount,
+}: {
+    readonly rows: ReadonlyArray<ContextSkillRow>;
+    readonly hueMap: Map<string, string>;
+    readonly verboseCount: number;
+}) {
+    const [open, setOpen] = useState(false);
+    const shown = open ? rows : rows.slice(0, RECLAIM_TRIM);
+    const more = rows.length - shown.length;
+    const trimmable = rows.reduce((n, s) => n + s.index_tokens, 0);
+    return (
+        <section className="ctx-trim">
+            <div className="ctx-breakdown-head">
+                <span className="inst-kicker">$ ax trim</span>
+                <span className="ctx-breakdown-note">
+                    {fmtCount(verboseCount)} verbose {verboseCount === 1 ? "skill" : "skills"} ·
+                    long descriptions ride in every session ({fmtTokens(trimmable)} tok across them)
+                </span>
+            </div>
+            <ul className="ctx-trim-list">
+                {shown.map((s) => (
+                    <li key={`${s.source}/${s.name}`} className="ctx-trim-row">
+                        <span className="ctx-reclaim-name">
+                            <i
+                                className="ctx-swatch"
+                                style={{ background: hueMap.get(s.source) ?? "var(--dim)" }}
+                                aria-hidden="true"
+                            />
+                            {s.name}
+                        </span>
+                        <span className="ctx-trim-cost">
+                            {fmtTokens(s.index_tokens)}<small>always</small>
+                        </span>
+                        <CopyAction
+                            text={trimCmd(s)}
+                            label="[trim]"
+                            className="ctx-act ctx-act-trim"
+                            title={`copy: ${trimCmd(s)}`}
+                        />
+                    </li>
+                ))}
+            </ul>
+            {more > 0 ? (
+                <p className="ctx-reclaim-foot">
+                    <button type="button" className="ctx-link" onClick={() => setOpen((v) => !v)}>
+                        {open ? "show fewer" : `show ${more} more`}
+                    </button>
+                    <span className="ctx-reclaim-note">
+                        [trim] copies an <code>axctl improve recommend</code> brief - the
+                        skill stays, its description gets tighter.
+                    </span>
+                </p>
+            ) : (
+                <p className="ctx-reclaim-foot">
+                    <span className="ctx-reclaim-note">
+                        [trim] copies an <code>axctl improve recommend</code> brief - the
+                        skill stays, its description gets tighter.
+                    </span>
+                </p>
+            )}
+        </section>
+    );
+}
+
+/** Per-source ledger row. CTA 2 lives here: sources with dead skills get a
+ *  [mute] action that reclaims the whole source's dead-weight index at once. */
+function SourceRow({
+    s,
+    hue,
+    maxIndexSource,
+    active,
+    windowDays,
+    deadSkills,
+    onSelect,
+}: {
+    readonly s: ContextSourceRow;
+    readonly hue: string;
+    readonly maxIndexSource: number;
+    readonly active: boolean;
+    readonly windowDays: number;
+    readonly deadSkills: ReadonlyArray<ContextSkillRow>;
+    readonly onSelect: () => void;
+}) {
+    // An entirely-cold source (0 invocations in window) is the cleanest mute.
+    const cold = s.uses_window === 0;
+    const canMute = s.dead_skills > 0 && deadSkills.length > 0 && s.reclaimable_index_tokens > 0;
+    return (
+        <li
+            className={`ctx-source-row${active ? " is-active" : ""}${cold ? " is-cold" : ""}`}
+            onClick={onSelect}
+        >
+            <span className="ctx-source-name">
+                <i className="ctx-swatch" style={{ background: hue }} aria-hidden="true" />
+                {s.source}
+            </span>
+            <span className="ctx-source-skills">
+                {fmtCount(s.skills)} {s.skills === 1 ? "skill" : "skills"}
+                {s.dead_skills > 0 ? (
+                    <span className="ctx-source-dead" title={`${s.dead_skills} unused in ${windowDays}d`}>
+                        {fmtCount(s.dead_skills)} cold
+                    </span>
+                ) : null}
+            </span>
+            <span className="ctx-source-bar" aria-hidden="true">
+                <i
+                    style={{
+                        width: `${maxIndexSource > 0 ? Math.max(2, (s.index_tokens / maxIndexSource) * 100) : 0}%`,
+                        background: hue,
+                    }}
+                />
+            </span>
+            <span className="ctx-source-index">
+                {fmtTokens(s.index_tokens)}
+                <small>always</small>
+            </span>
+            <span className="ctx-source-action" onClick={(e) => e.stopPropagation()}>
+                {canMute ? (
+                    <CopyAction
+                        text={muteCmd(deadSkills)}
+                        label={`[mute ${fmtTokens(s.reclaimable_index_tokens)}]`}
+                        className="ctx-act"
+                        title={`copy: trash the ${deadSkills.length} cold ${deadSkills.length === 1 ? "skill" : "skills"} in this source (~${fmtTokens(s.reclaimable_index_tokens)} tok)`}
+                    />
+                ) : (
+                    <span className="ctx-source-body">
+                        {fmtTokens(s.body_tokens)}
+                        <small>on demand</small>
+                    </span>
+                )}
+            </span>
+        </li>
+    );
+}
+
+/** "never" when last_used is null, else "Nd ago"; appended with the window
+ *  basis so the cold-skill judgement is legible, not arbitrary. */
+function lastUsedLabel(s: ContextSkillRow, _windowDays: number): string {
+    if (!s.last_used) return s.uses_total > 0 ? "not in window" : "never used";
+    return `last ${relTime(s.last_used)}`;
 }
 
 /** Compact relative time ("3d ago") from an ISO timestamp. */
@@ -480,16 +819,33 @@ function SkillRow({
     maxBody: number;
 }) {
     const frac = maxBody > 0 ? Math.max(0.02, row.body_tokens / maxBody) : 0;
+    const cls = [
+        "skill-row",
+        row.dead_weight ? "is-dead" : "",
+        row.verbose ? "is-verbose" : "",
+    ].filter(Boolean).join(" ");
     return (
-        <tr className="skill-row">
+        <tr className={cls}>
             <td className="skill-cell">
                 <strong>{row.name}</strong>
                 {row.is_tool ? <span className="ctx-tool-tag">tool</span> : null}
+                {row.verbose && !row.is_tool ? (
+                    <span className="ctx-flag ctx-flag-verbose" title="description > 500 chars - always-loaded">verbose</span>
+                ) : null}
+                {row.dead_weight && !row.is_tool ? (
+                    <span className="ctx-flag ctx-flag-dead" title="0 invocations in window - always-loaded cost, no use">cold</span>
+                ) : null}
             </td>
             <td>
                 <span className="ctx-cell-source">
                     <i className="ctx-swatch" style={{ background: hue }} aria-hidden="true" />
                     {row.source}
+                </span>
+            </td>
+            <td className="num">
+                <span className={`ctx-used${row.uses_window === 0 ? " is-zero" : ""}`}>
+                    {row.uses_window > 0 ? fmtCount(row.uses_window) : "-"}
+                    <small>{row.last_used ? relTime(row.last_used) : (row.uses_total > 0 ? "older" : "never")}</small>
                 </span>
             </td>
             <td className="num">{fmtTokens(row.index_tokens)}</td>
@@ -517,6 +873,10 @@ function sortSkills(
                 break;
             case "index":
                 cmp = a.index_tokens - b.index_tokens;
+                break;
+            case "used":
+                cmp = a.uses_window - b.uses_window ||
+                    (Date.parse(a.last_used ?? "") || 0) - (Date.parse(b.last_used ?? "") || 0);
                 break;
             case "name":
                 cmp = a.name.localeCompare(b.name);

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -3740,6 +3740,273 @@ td.skill-cell .description {
 }
 .rdx .ctx-weight i { display: block; height: 100%; border-radius: 3px; }
 
+/* ===========================================================================
+   ACTION LAYER  (reclaim / mute / trim)
+   The CTA on the budget. Every action COPIES a command to run yourself - the
+   page never mutates a file. Opportunity-framed, calm, instrument tone. GREEN
+   is the only accent (the reclaim is a win); orange stays reserved for alerts.
+   Colour lives in the gauge + swatches, never as a panel border.
+   ========================================================================= */
+
+/* the copy-to-run affordance: a quiet mono chip that confirms in place. The
+   bracketed [label] reads as a terminal action, not a CTA button. */
+.rdx .ctx-act {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.02em;
+    color: var(--accent);
+    background: none;
+    border: 1px solid color-mix(in srgb, var(--accent) 32%, transparent);
+    border-radius: 5px;
+    padding: 3px 9px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.12s var(--ease, ease), border-color 0.12s var(--ease, ease), color 0.12s var(--ease, ease);
+}
+.rdx .ctx-act:hover {
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+}
+.rdx .ctx-act.is-copied {
+    color: var(--display);
+    background: color-mix(in srgb, var(--accent) 22%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 60%, transparent);
+}
+/* trim is a softer action (keep the skill) - render it muted, not accented */
+.rdx .ctx-act-trim {
+    color: var(--sec);
+    border-color: var(--border);
+}
+.rdx .ctx-act-trim:hover {
+    color: var(--pri);
+    background: var(--surface2);
+    border-color: var(--border-hi);
+}
+
+/* --- CTA 1: reclaim dead weight ---------------------------------------- */
+.rdx .ctx-reclaim {
+    margin: 4px 0 26px;
+    padding: 18px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--accent) 4%, var(--surface));
+    border: 1px solid var(--border);
+}
+.rdx .ctx-reclaim-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+}
+.rdx .ctx-reclaim-lede { min-width: 0; flex: 1 1 320px; }
+.rdx .ctx-reclaim-h {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 21px;
+    line-height: 1.1;
+    color: var(--display);
+    margin: 6px 0 6px;
+}
+.rdx .ctx-reclaim-h em {
+    font-style: normal;
+    color: var(--accent);
+    font-variant-numeric: tabular-nums;
+}
+.rdx .ctx-reclaim-sub {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    line-height: 1.5;
+    color: var(--sec);
+    margin: 0;
+    max-width: 56ch;
+}
+.rdx .ctx-reclaim-sub b { color: var(--pri); font-weight: 600; }
+.rdx .ctx-reclaim-gauge {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 5px;
+    padding-top: 4px;
+}
+.rdx .ctx-reclaim-gauge-bar {
+    width: 132px;
+    height: 7px;
+    border-radius: 4px;
+    background: var(--surface2);
+    overflow: hidden;
+    display: block;
+}
+.rdx .ctx-reclaim-gauge-bar i {
+    display: block;
+    height: 100%;
+    border-radius: 4px;
+    background: var(--accent);
+    transition: width 0.5s var(--ease, ease);
+}
+.rdx .ctx-reclaim-gauge-cap {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dim);
+}
+
+.rdx .ctx-reclaim-list { list-style: none; margin: 0; padding: 0; }
+.rdx .ctx-reclaim-row {
+    display: grid;
+    grid-template-columns: minmax(150px, 1fr) 96px minmax(96px, 150px) 88px;
+    align-items: center;
+    gap: 14px;
+    padding: 7px 4px;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+}
+.rdx .ctx-reclaim-row:last-child { border-bottom: 0; }
+.rdx .ctx-reclaim-name {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    color: var(--display);
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.rdx .ctx-reclaim-reclaim {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 13px;
+    color: var(--accent);
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 1px;
+    line-height: 1.1;
+}
+.rdx .ctx-reclaim-reclaim small,
+.rdx .ctx-trim-cost small {
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dim);
+}
+.rdx .ctx-reclaim-last {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--dim);
+    text-align: right;
+    white-space: nowrap;
+}
+.rdx .ctx-reclaim-row .ctx-act { justify-self: end; }
+.rdx .ctx-reclaim-foot {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin: 14px 0 0;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--dim);
+}
+.rdx .ctx-reclaim-note { color: var(--dim); }
+.rdx .ctx-reclaim-note code {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--sec);
+    background: var(--surface2);
+    padding: 1px 5px;
+    border-radius: 3px;
+}
+
+/* --- CTA 3: trim verbose ------------------------------------------------ */
+.rdx .ctx-trim { margin: 0 0 26px; }
+.rdx .ctx-trim-list { list-style: none; margin: 10px 0 0; padding: 0; }
+.rdx .ctx-trim-row {
+    display: grid;
+    grid-template-columns: minmax(150px, 1fr) 96px 70px;
+    align-items: center;
+    gap: 14px;
+    padding: 6px 4px;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+}
+.rdx .ctx-trim-row:last-child { border-bottom: 0; }
+.rdx .ctx-trim-cost {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 13px;
+    color: var(--pri);
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 1px;
+    line-height: 1.1;
+}
+.rdx .ctx-trim-row .ctx-act { justify-self: end; }
+
+/* --- CTA 2: per-source mute + cold badge -------------------------------- */
+.rdx .ctx-source-dead {
+    font-family: var(--mono);
+    font-size: 9.5px;
+    letter-spacing: 0.04em;
+    color: var(--dim);
+    margin-left: 8px;
+    padding: 1px 5px;
+    border-radius: 3px;
+    border: 1px solid var(--border);
+}
+.rdx .ctx-source-row.is-cold .ctx-source-dead {
+    color: var(--sec);
+    border-color: var(--border-hi);
+}
+.rdx .ctx-source-action {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+}
+.rdx .ctx-source-action .ctx-act { padding: 3px 8px; }
+.rdx .ctx-source-action .ctx-source-body { align-items: flex-end; }
+
+/* --- skill-index usage column + dead/verbose flags ---------------------- */
+.rdx .ctx-used {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 1px;
+    line-height: 1.1;
+    font-variant-numeric: tabular-nums;
+    color: var(--pri);
+}
+.rdx .ctx-used.is-zero { color: var(--dim); }
+.rdx .ctx-used small {
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: 0.04em;
+    color: var(--dim);
+    text-transform: lowercase;
+}
+.rdx .ctx-flag {
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border-radius: 3px;
+    padding: 1px 5px;
+    margin-left: 7px;
+    border: 1px solid var(--border);
+    color: var(--dim);
+    vertical-align: middle;
+}
+.rdx .ctx-flag-verbose { color: var(--sec); }
+/* "cold" is information, not alarm - keep it dim, not orange */
+.rdx .skill-row.is-dead td.skill-cell strong { color: var(--sec); }
+
 @media (max-width: 640px) {
     .rdx .ctx-source-row {
         grid-template-columns: 1fr auto;
@@ -3748,5 +4015,12 @@ td.skill-cell .description {
     .rdx .ctx-source-bar { display: none; }
     .rdx .ctx-source-skills { grid-row: 1; }
     .rdx .ctx-source-index { grid-column: 1; align-items: flex-start; flex-direction: row; gap: 6px; align-items: baseline; }
-    .rdx .ctx-source-body { grid-column: 2; flex-direction: row; gap: 6px; align-items: baseline; }
+    .rdx .ctx-source-action { grid-column: 2; }
+    .rdx .ctx-reclaim-row {
+        grid-template-columns: 1fr auto;
+        gap: 3px 12px;
+    }
+    .rdx .ctx-reclaim-last { grid-column: 1; text-align: left; }
+    .rdx .ctx-reclaim-row .ctx-act { grid-row: 1 / span 2; grid-column: 2; }
+    .rdx .ctx-trim-row { grid-template-columns: 1fr auto auto; }
 }

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -3080,3 +3080,645 @@ td.skill-cell .description {
     font-size: 18px;
     color: var(--ink);
 }
+
+/* ============================================================================
+   INSTRUMENT DATA-ROUTE KIT  (reference impl: /skills)
+   Reusable, route-agnostic primitives for elevating a dense data route into
+   the ax instrument readout (Mission Control house style). Scoped under .rdx
+   so they inherit the dark/light HUD palette. Other data routes
+   (sessions/workflow/improve) should adopt this same kit.
+   Conventions enforced here:
+     - GREEN is the accent; --alert (orange) is reserved for warnings.
+     - Colour lives in the DATA VIZ (sparklines, score bars, status dots),
+       never as decorative card/panel chrome (no coloured borders).
+     - Doto is reserved for a SINGLE hero number; table numbers stay tabular
+       mono (--mono + tabular-nums).
+   ========================================================================= */
+
+/* --- masthead: receipt-ruled header band ---------------------------------- */
+.rdx .inst-head {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-bottom: 16px;
+    margin-bottom: 16px;
+    border-bottom: 1px solid var(--border);
+}
+.rdx .inst-head-top {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+.rdx .inst-kicker {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+.rdx .inst-title {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 32px;
+    line-height: 1.02;
+    letter-spacing: -0.01em;
+    color: var(--display);
+    margin: 4px 0 0;
+}
+.rdx .inst-head-meta {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    letter-spacing: 0.04em;
+    color: var(--sec);
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+.rdx .inst-head-meta b {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--pri);
+    font-weight: 600;
+}
+.rdx .inst-head-meta .live {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--green);
+}
+/* the ONE Doto hero readout per view: triage completion */
+.rdx .inst-hero {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 6px;
+    flex: none;
+}
+.rdx .inst-hero .n {
+    font-family: var(--doto);
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    font-size: 40px;
+    line-height: 0.9;
+    color: var(--display);
+}
+.rdx .inst-hero .n small {
+    font-family: var(--mono);
+    font-size: 14px;
+    font-weight: 400;
+    color: var(--sec);
+    margin-left: 2px;
+}
+.rdx .inst-hero .l {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--sec);
+}
+/* triage progress: thin green meter under the masthead */
+.rdx .inst-progress {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.rdx .inst-progress .bar {
+    flex: 1;
+    height: 4px;
+    background: var(--surface2);
+    border-radius: 2px;
+    overflow: hidden;
+}
+.rdx .inst-progress .bar i {
+    display: block;
+    height: 100%;
+    background: var(--green);
+    border-radius: 2px;
+    transition: width 0.4s var(--ease, ease);
+}
+.rdx .inst-progress .pct {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+    color: var(--sec);
+    flex: none;
+}
+
+/* --- controls: chip rows ------------------------------------------------- */
+.rdx .inst-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 10px;
+}
+.rdx .inst-controls .grow { flex: 1 1 200px; }
+.rdx .inst-controls.scope {
+    margin-bottom: 14px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid var(--border);
+}
+.rdx .inst-chiplabel {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--dim);
+    margin-right: 2px;
+}
+.rdx .inst-chip {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--sec);
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 5px 11px;
+    cursor: pointer;
+    transition: 0.14s var(--ease, ease);
+    white-space: nowrap;
+}
+.rdx .inst-chip:hover {
+    color: var(--pri);
+    border-color: var(--border-hi);
+}
+.rdx .inst-chip.is-active {
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+.rdx .inst-chip[disabled] { opacity: 0.5; cursor: default; }
+.rdx .inst-search {
+    flex: 1 1 240px;
+    min-width: 180px;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--pri);
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 6px 12px;
+}
+.rdx .inst-search::placeholder { color: var(--dim); }
+.rdx .inst-search:focus {
+    outline: none;
+    border-color: var(--border-hi);
+}
+
+/* --- table: hairline instrument readout ---------------------------------- */
+.rdx .skills-instrument table.skills {
+    font-family: var(--sans);
+    font-size: 13px;
+}
+.rdx .skills-instrument table.skills th {
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 400;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--dim);
+    padding: 0 10px 10px;
+    border-bottom: 1px solid var(--border);
+}
+.rdx .skills-instrument table.skills td {
+    padding: 12px 10px;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+    vertical-align: middle;
+}
+.rdx .skills-instrument button.sort-header {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--dim);
+}
+.rdx .skills-instrument button.sort-header.is-active,
+.rdx .skills-instrument button.sort-header:hover { color: var(--accent); }
+.rdx .skills-instrument tr.skill-row:hover td {
+    background: var(--surface2);
+}
+.rdx .skills-instrument td.skill-cell strong {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--display);
+    font-weight: 500;
+}
+.rdx .skills-instrument td.skill-cell .description {
+    font-family: var(--sans);
+    color: var(--sec);
+}
+.rdx .skills-instrument td.skill-cell .chip {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--dim);
+    background: transparent;
+    border-color: var(--border);
+}
+/* tabular numerals for every metric column */
+.rdx .skills-instrument td.num {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 12.5px;
+    color: var(--pri);
+}
+.rdx .skills-instrument td.num.dim { color: var(--dim); }
+
+/* highlight rail: green (the house accent), not blue */
+.rdx .skills-instrument tr.row-highlighted td {
+    box-shadow: inset 3px 0 0 var(--accent);
+    background: color-mix(in srgb, var(--accent) 9%, transparent);
+}
+.rdx .skills-instrument tr.row-highlighted td.skill-cell strong { color: var(--accent); }
+
+/* --- score: thin segbar (colour = the data) ------------------------------ */
+.rdx .inst-score { display: inline-flex; align-items: center; gap: 8px; }
+.rdx .inst-score .v {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 12.5px;
+    color: var(--pri);
+    min-width: 30px;
+    text-align: right;
+}
+.rdx .inst-score-bar {
+    width: 38px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--surface2);
+    overflow: hidden;
+    flex: none;
+}
+.rdx .inst-score-bar i {
+    display: block;
+    height: 100%;
+    border-radius: 2px;
+}
+
+/* --- usage sparkline: 7d / 30d / total recency mini-bars ----------------- */
+.rdx .inst-spark {
+    display: inline-flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 18px;
+    vertical-align: middle;
+}
+.rdx .inst-spark i {
+    width: 5px;
+    min-height: 2px;
+    border-radius: 1px 1px 0 0;
+    background: color-mix(in srgb, var(--green) 28%, var(--surface2));
+}
+.rdx .inst-spark i.hot {
+    background: var(--green);
+}
+.rdx .inst-usage {
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+}
+.rdx .inst-usage .v {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 12.5px;
+    color: var(--pri);
+}
+.rdx .inst-usage.idle .v { color: var(--dim); }
+
+/* --- recommendation / decision badges as instrument chips ---------------- */
+.rdx .skills-instrument .badge {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border-radius: 5px;
+    padding: 3px 8px;
+    border: 1px solid var(--border);
+    background: transparent;
+}
+.rdx .skills-instrument .badge.keep {
+    color: var(--green);
+    border-color: color-mix(in srgb, var(--green) 45%, var(--border));
+    background: color-mix(in srgb, var(--green) 9%, transparent);
+}
+.rdx .skills-instrument .badge.review {
+    color: var(--gold);
+    border-color: color-mix(in srgb, var(--gold) 40%, var(--border));
+    background: color-mix(in srgb, var(--gold) 8%, transparent);
+}
+.rdx .skills-instrument .badge.archive {
+    color: var(--dim);
+    border-color: var(--border);
+    background: transparent;
+}
+.rdx .skills-instrument .reason-button small {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--sec);
+}
+
+/* decision toggle: minimal instrument buttons, semantic when active */
+.rdx .skills-instrument td .actions button {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: lowercase;
+    color: var(--sec);
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 9px;
+}
+.rdx .skills-instrument td .actions button:hover {
+    color: var(--pri);
+    border-color: var(--border-hi);
+}
+.rdx .skills-instrument td .actions button.is-active {
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.rdx .skills-instrument td small {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--dim);
+}
+
+/* decided-row rails keyed to decision (right edge), green for keep */
+.rdx .skills-instrument tr.row-decision-keep td:last-child { box-shadow: inset -3px 0 0 var(--green); }
+.rdx .skills-instrument tr.row-decision-review td:last-child { box-shadow: inset -3px 0 0 var(--gold); }
+.rdx .skills-instrument tr.row-decision-archive td:last-child { box-shadow: inset -3px 0 0 var(--dim); }
+.rdx .skills-instrument tr.row-just-saved td {
+    animation: inst-saved-flash 1.1s ease-out;
+}
+@keyframes inst-saved-flash {
+    0% { background-color: color-mix(in srgb, var(--green) 16%, transparent); }
+    100% { background-color: transparent; }
+}
+
+/* bulk bar: keep the dark instrument surface, not an ink slab */
+.rdx .skills-instrument .bulk-bar {
+    background: var(--surface2);
+    color: var(--pri);
+    border: 1px solid var(--border-hi);
+    border-radius: 8px;
+}
+.rdx .skills-instrument .bulk-bar strong { color: var(--accent); }
+.rdx .skills-instrument .bulk-bar .actions button {
+    background: transparent;
+    color: var(--sec);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-family: var(--mono);
+    font-size: 11px;
+}
+.rdx .skills-instrument .bulk-bar .actions button:hover {
+    color: var(--pri);
+    border-color: var(--border-hi);
+}
+.rdx .skills-instrument .load-more button {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--sec);
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 7px 16px;
+    cursor: pointer;
+}
+.rdx .skills-instrument .load-more button:hover { color: var(--pri); border-color: var(--border-hi); }
+
+/* =========================================================================
+   CONTEXT BUDGET  (the /skills route, rebuilt)
+   Reveals the session-startup token tax. Colour lives in the budget viz
+   (stacked bar + per-source bars + weight bars), keyed to the source. The ONE
+   Doto hero is the always-loaded index total; everything else is tabular mono.
+   ========================================================================= */
+
+/* hero: framed as the always-loaded tax, with an on-demand secondary stat */
+.rdx .ctx-hero { max-width: 340px; }
+.rdx .ctx-hero .l { text-align: right; text-transform: none; letter-spacing: 0.02em; font-size: 11px; line-height: 1.35; }
+.rdx .ctx-hero-sub {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 11.5px;
+    color: var(--sec);
+    text-align: right;
+    margin-top: 2px;
+}
+.rdx .ctx-hero-sub b { color: var(--pri); font-weight: 600; }
+
+/* --- the breakdown: heart of the page ---------------------------------- */
+.rdx .ctx-breakdown { margin: 4px 0 26px; }
+.rdx .ctx-breakdown-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+}
+.rdx .ctx-breakdown-head h3 {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 19px;
+    color: var(--display);
+    margin: 0;
+}
+.rdx .ctx-breakdown-note {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    color: var(--sec);
+}
+
+/* the stacked segmented bar - one continuous instrument of the index tax */
+.rdx .ctx-stack {
+    display: flex;
+    height: 22px;
+    width: 100%;
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--surface2);
+    gap: 1.5px;
+    margin-bottom: 16px;
+}
+.rdx .ctx-stack-seg {
+    min-width: 2px;
+    cursor: pointer;
+    transition: filter 0.14s var(--ease, ease), opacity 0.14s var(--ease, ease);
+    opacity: 0.92;
+}
+.rdx .ctx-stack-seg:hover { filter: brightness(1.15); opacity: 1; }
+.rdx .ctx-stack-seg.is-active { opacity: 1; box-shadow: inset 0 0 0 1.5px var(--display); }
+
+/* per-source ledger rows */
+.rdx .ctx-source-list { list-style: none; margin: 0; padding: 0; }
+.rdx .ctx-source-row {
+    display: grid;
+    grid-template-columns: minmax(150px, 1.4fr) 76px minmax(80px, 1fr) 92px 100px;
+    align-items: center;
+    gap: 14px;
+    padding: 9px 8px;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+    cursor: pointer;
+    transition: background 0.12s var(--ease, ease);
+}
+.rdx .ctx-source-row:hover { background: var(--surface2); }
+.rdx .ctx-source-row.is-active { background: color-mix(in srgb, var(--accent) 7%, transparent); }
+.rdx .ctx-source-name {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    color: var(--display);
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+}
+.rdx .ctx-swatch {
+    width: 9px;
+    height: 9px;
+    border-radius: 2px;
+    flex: none;
+    display: inline-block;
+}
+.rdx .ctx-source-skills {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--dim);
+    text-align: right;
+    white-space: nowrap;
+}
+.rdx .ctx-source-bar {
+    height: 5px;
+    border-radius: 3px;
+    background: var(--surface2);
+    overflow: hidden;
+}
+.rdx .ctx-source-bar i {
+    display: block;
+    height: 100%;
+    border-radius: 3px;
+    transition: width 0.4s var(--ease, ease);
+}
+.rdx .ctx-source-index,
+.rdx .ctx-source-body {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 13px;
+    color: var(--pri);
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 1px;
+    line-height: 1.1;
+}
+.rdx .ctx-source-index { color: var(--display); }
+.rdx .ctx-source-body { color: var(--sec); }
+.rdx .ctx-source-index small,
+.rdx .ctx-source-body small {
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dim);
+}
+.rdx .ctx-foot {
+    font-family: var(--mono);
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--dim);
+    margin: 14px 0 0;
+}
+.rdx .ctx-link {
+    font-family: var(--mono);
+    font-size: inherit;
+    color: var(--accent);
+    background: none;
+    border: 0;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+.rdx .ctx-link:hover { filter: brightness(1.15); }
+
+/* --- skill index controls + table -------------------------------------- */
+.rdx .ctx-controls {
+    margin-top: 18px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border);
+}
+.rdx .ctx-active-filter {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--display);
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid var(--border-hi);
+    border-radius: 6px;
+    padding: 4px 10px;
+}
+.rdx .ctx-table th .th-sub {
+    font-size: 8.5px;
+    letter-spacing: 0.1em;
+    color: var(--dim);
+    margin-left: 4px;
+}
+.rdx .ctx-table td.skill-cell strong {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    color: var(--display);
+    font-weight: 500;
+}
+.rdx .ctx-tool-tag {
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dim);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 1px 5px;
+    margin-left: 8px;
+}
+.rdx .ctx-cell-source {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    color: var(--sec);
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+.rdx .ctx-weight {
+    display: inline-block;
+    width: 64px;
+    height: 5px;
+    border-radius: 3px;
+    background: var(--surface2);
+    overflow: hidden;
+    vertical-align: middle;
+}
+.rdx .ctx-weight i { display: block; height: 100%; border-radius: 3px; }
+
+@media (max-width: 640px) {
+    .rdx .ctx-source-row {
+        grid-template-columns: 1fr auto;
+        gap: 4px 12px;
+    }
+    .rdx .ctx-source-bar { display: none; }
+    .rdx .ctx-source-skills { grid-row: 1; }
+    .rdx .ctx-source-index { grid-column: 1; align-items: flex-start; flex-direction: row; gap: 6px; align-items: baseline; }
+    .rdx .ctx-source-body { grid-column: 2; flex-direction: row; gap: 6px; align-items: baseline; }
+}

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -3640,6 +3640,34 @@ td.skill-cell .description {
     color: var(--dim);
     margin: 14px 0 0;
 }
+/* DRIFT: skill change log */
+.rdx .ctx-drift { margin: 0 0 26px; }
+.rdx .ctx-drift-list { list-style: none; margin: 10px 0 0; padding: 0; }
+.rdx .ctx-drift-row {
+    display: grid;
+    grid-template-columns: 74px 1fr auto auto;
+    align-items: baseline;
+    gap: 12px;
+    padding: 6px 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+    font-family: var(--mono);
+    font-size: 12px;
+}
+.rdx .ctx-drift-row:last-child { border-bottom: 0; }
+.rdx .ctx-drift-tag {
+    font-size: 9.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 2px 6px;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    color: var(--sec);
+    justify-self: start;
+}
+.rdx .ctx-drift-tag.is-added { color: var(--green); border-color: color-mix(in srgb, var(--green) 45%, transparent); }
+.rdx .ctx-drift-name { color: var(--pri); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rdx .ctx-drift-delta { color: var(--sec); font-variant-numeric: tabular-nums; }
+.rdx .ctx-drift-time { color: var(--dim); font-size: 11px; }
 .rdx .ctx-link {
     font-family: var(--mono);
     font-size: inherit;

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -347,7 +347,7 @@ a {
     font-size: 12px;
     font-weight: 600;
     text-decoration: none;
-    color: #fff;
+    color: var(--page);
     background: var(--ink);
     border: 1px solid var(--ink);
     border-radius: 6px;
@@ -477,7 +477,7 @@ table.skills th {
 
 table.skills td {
     padding: 10px 8px;
-    border-bottom: 1px solid rgba(207, 216, 212, 0.74);
+    border-bottom: 1px solid color-mix(in srgb, var(--line) 74%, transparent);
     vertical-align: top;
 }
 
@@ -696,7 +696,7 @@ tr.skill-row {
 }
 
 tr.skill-row:hover td {
-    background: rgba(0, 0, 0, 0.025);
+    background: color-mix(in srgb, var(--ink) 5%, transparent);
 }
 
 tr.skill-row:hover .reason-button small {
@@ -711,7 +711,7 @@ tr.skill-row .actions button {
 
 tr.row-highlighted td {
     box-shadow: inset 6px 0 0 var(--blue);
-    background: rgba(37, 103, 168, 0.07);
+    background: color-mix(in srgb, var(--blue) 12%, transparent);
 }
 
 tr.row-highlighted td.skill-cell strong {
@@ -1605,7 +1605,7 @@ table.heatmap td {
     text-align: center;
     padding: 4px 6px;
     min-width: 56px;
-    border-bottom: 1px solid rgba(207, 216, 212, 0.4);
+    border-bottom: 1px solid color-mix(in srgb, var(--line) 40%, transparent);
     color: var(--ink);
 }
 
@@ -2316,7 +2316,7 @@ td.skill-cell .description {
 /* "Recorded with ax" CTA card at the end of a shared transcript. */
 .share-footer {
     border: 1px solid var(--line);
-    background: #fff;
+    background: var(--panel);
     padding: 16px 20px 18px;
     margin-top: 16px;
     display: grid;
@@ -2458,13 +2458,24 @@ td.skill-cell .description {
     width: min(560px, calc(100vw - 32px));
     max-height: calc(100vh - 64px);
     overflow-y: auto;
-    background: var(--paper, #fff);
-    box-shadow: 0 12px 48px rgba(0, 0, 0, 0.25);
+    background: var(--panel);
+    box-shadow: 0 12px 48px rgba(0, 0, 0, 0.45);
 }
 .masthead-ingest-btn {
     font-size: 12px;
     padding: 4px 10px;
     cursor: pointer;
+    background: var(--track);
+    color: var(--muted);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    font-family: ui-monospace, Menlo, monospace;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.masthead-ingest-btn:hover {
+    border-color: var(--green);
+    color: var(--ink);
 }
 .masthead-ingest-error {
     max-width: 280px;

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -363,6 +363,10 @@ export const InsightsGroup = HttpApiGroup.make("insights")
             success: Schema.Unknown,
             error: InternalError,
         }),
+        HttpApiEndpoint.get("contextDrift", "/api/context/drift", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
         HttpApiEndpoint.get("workflow", "/api/workflow", {
             success: WorkflowResponse,
             error: InternalError,

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -359,6 +359,10 @@ export const InsightsGroup = HttpApiGroup.make("insights")
             success: Schema.Unknown,
             error: InternalError,
         }),
+        HttpApiEndpoint.get("contextBudget", "/api/context/budget", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
         HttpApiEndpoint.get("workflow", "/api/workflow", {
             success: WorkflowResponse,
             error: InternalError,

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -36,6 +36,24 @@ DEFINE INDEX IF NOT EXISTS skill_search_desc
     ON skill FIELDS description
     FULLTEXT ANALYZER skill_text BM25 HIGHLIGHTS;
 
+-- Append-only change log for skills: one row per *content change* (content_hash
+-- flip) detected at ingest. The baseline is the current `skill` row; this table
+-- captures drift over time so an edit to a skill (by the user OR an agent that
+-- proactively rewrites it) leaves a tracked point to diff against. Written by
+-- apps/axctl/src/ingest/skill-upsert.ts only when the hash differs.
+DEFINE TABLE skill_revision SCHEMAFULL;
+DEFINE FIELD skill          ON skill_revision TYPE record<skill>;
+DEFINE FIELD name           ON skill_revision TYPE string;
+DEFINE FIELD scope          ON skill_revision TYPE option<string>;
+DEFINE FIELD content_hash   ON skill_revision TYPE string;
+DEFINE FIELD prev_hash      ON skill_revision TYPE option<string>;   -- null on 'added'
+DEFINE FIELD bytes          ON skill_revision TYPE option<int>;
+DEFINE FIELD prev_bytes     ON skill_revision TYPE option<int>;
+DEFINE FIELD change         ON skill_revision TYPE string;           -- 'added' | 'changed'
+DEFINE FIELD ts             ON skill_revision TYPE datetime VALUE time::now();
+DEFINE INDEX IF NOT EXISTS skill_revision_ts ON skill_revision FIELDS ts;
+DEFINE INDEX IF NOT EXISTS skill_revision_skill ON skill_revision FIELDS skill;
+
 -- Agent definition files (`~/.claude/agents/*.md`, `<repo>/.claude/agents/*.md`).
 -- Full graph entity with the same reconcile lifecycle as `skill` (see
 -- apps/axctl/src/ingest/agent-def.ts + apps/axctl/src/agents/). The `skills`


### PR DESCRIPTION
Continues the nullframe instrument design system (PR #415) into the rest of the studio, and rebuilds /skills into something useful.

## Chrome unification
- Legacy light masthead gone; `/sessions`, `/workflow`, `/improve`, `/skills` render inside the instrument rail (like Mission Control). Live indicator + ingest splash + mock banner relocated into the shell.
- Dark token-bridge: legacy `--page/--panel/--ink` tokens re-map to the instrument palette on `.rdx`, so route content adopts the dark/light HUD automatically.
- Dark restyle of all four routes (filter chips, tables, inputs, badges).

## /skills → Session Context Budget (the rethink)
The keep/review/archive triage gave no value. Replaced with **what fills your context before you type**:
- `GET /api/context/budget` — every skill costs INDEX tokens (name+description, always in the system-prompt catalog) + BODY tokens (SKILL.md, on invoke). Rolled up by source, deduped by content hash. (~9.5K always-loaded / ~262K on-demand locally.)
- **Reclaim / Mute / Trim** — cost÷usage: dead-weight skills (always-loaded cost + 0 uses in 30d) surfaced biggest-first with `[disable]` (copies `trash <dir>`), per-source `[mute]`, verbose descriptions `[trim]` (copies an `axctl improve` brief). Safe copy-to-run; ax never mutates from the web. (~6.7K tok/session reclaimable across 133 skills locally.)
- **DRIFT** + `GET /api/context/drift` — append-only `skill_revision` log (written at ingest only when a content hash flips, fails open). The baseline to diff against when a skill/CLAUDE.md is edited.

## Backend
`queries/context-budget.ts` (budget + drift + usage join, reusing unused-skills.ts's deref-free aggregation), `skill_revision` table (in SCHEMA_TABLES), contract + handlers + allowlist, studio `api.contextBudget()/contextDrift()`.

## Notes
`/sessions` is dark-styled but its table is blocked by a **pre-existing** backend bug (the daemon's `/api/sessions` can't return all-sources: no `source` → 400, `source=all` → 0 rows). Untouched here — flagged for a separate fix. v2 follow-ups: fold CLAUDE.md + harness base prompt + MCP into the budget; change-history diff view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)