### PR TITLE
fix(studio): /api/sessions all-sources 400 (NONE columns → null)

### DIFF
--- a/apps/axctl/src/dashboard/sessions-list.ts
+++ b/apps/axctl/src/dashboard/sessions-list.ts
@@ -163,12 +163,17 @@ export const fetchSessionsList = (opts: SessionsListOpts = {}): Effect.Effect<Se
                 rawIdByBare.set(bareId, r.id);
                 return {
                     id: bareId,
-                    project: r.project,
+                    // SurrealDB returns absent/NONE columns as `undefined`, but the
+                    // SessionListRow schema fields are NullOr(String) (string | null) -
+                    // `undefined` fails encode and 400s the whole list. Coalesce every
+                    // pass-through nullable to `null`. (This was the all-sources bug: a
+                    // row with no ended_at/model/etc. broke `?source=` absent.)
+                    project: r.project ?? null,
                     source: r.source ?? "unknown",
-                    cwd: r.cwd,
-                    model: r.model,
-                    started_at: r.started_at,
-                    ended_at: r.ended_at,
+                    cwd: r.cwd ?? null,
+                    model: r.model ?? null,
+                    started_at: r.started_at ?? null,
+                    ended_at: r.ended_at ?? null,
                     has_raw_file: !!r.has_raw_file,
                     // turn_count intentionally NOT counted from `turn` here:
                     // the cross-session turn table is huge and a batched
@@ -331,12 +336,13 @@ export const fetchSessionChildren = (
 
         const children: SessionListRow[] = rows.map((r): SessionListRow => ({
             id: toBareSessionId(r.id),
-            project: r.project,
+            // coalesce NONE/undefined → null to satisfy NullOr(String) (see fetchSessionsList)
+            project: r.project ?? null,
             source: r.source ?? "unknown",
-            cwd: r.cwd,
-            model: r.model,
-            started_at: r.started_at,
-            ended_at: r.ended_at,
+            cwd: r.cwd ?? null,
+            model: r.model ?? null,
+            started_at: r.started_at ?? null,
+            ended_at: r.ended_at ?? null,
             has_raw_file: !!r.has_raw_file,
             turn_count: 0,
             parent_session,


### PR DESCRIPTION
The `/sessions` table showed an error / 0 rows on the default "all" tab.

**Root cause:** `fetchSessionsList` passes `project`/`cwd`/`model`/`ended_at` through raw. SurrealDB returns absent/`NONE` columns as `undefined`, but the `SessionListRow` schema fields are `NullOr(String)` (`string | null`) — `undefined` fails Schema encode, which 400s the *entire* list. It only bit the **all-sources** path (no `source` filter) because `?source=all` happened to match zero rows (literal source named "all") and trivially encoded; a real all-sources page that paged past the most-recent all-ended sessions hit a row with a NONE column and 400'd.

**Fix:** coalesce every pass-through nullable to `null` in both `fetchSessionsList` and `fetchSessionChildren`.

Verified: no-source `limit=200` → 200 with 200 rows (was 400); the `/sessions` table renders all 1,854 roots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)