### PR TITLE
feat(otel): OTLP logs ingestion — Codex events into ax serve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,13 +90,15 @@ fresh clone.
 
 `ax serve` accepts harness OTLP/JSON telemetry on the daemon port (1738):
 `POST /v1/metrics` (Claude Code usage metrics) + `POST /v1/traces` (span
-sources); `/v1/logs` is accepted and dropped (v1 no-op - full logs ingestion is
-the next PR). NOTE: Codex emits OTLP *logs* (events: conversation_starts,
-user_prompt, token usage), NOT spans, and POSTs to the endpoint as-is, so its
-config targets `/v1/logs` (struct-variant exporter, `protocol = "json"`; see
-install-config.ts); its data lands once logs ingestion ships. Bodies decode via Effect
-`Schema` (curated OTLP/JSON subset, `apps/axctl/src/otel/`), normalize per-harness
-(`service.name` -> harness label), and land in `otel_metric_point` / `otel_span`.
+sources) + `POST /v1/logs` (Codex log events → `otel_log_event` table). NOTE:
+Codex emits OTLP *logs* (events: conversation_starts, user_prompt, token usage),
+NOT spans, and POSTs to the endpoint as-is, so its config targets `/v1/logs`
+(struct-variant exporter, `protocol = "json"`; see install-config.ts); session
+key is `conversation.id`; a curated allowlist drops transport noise
+(websocket/sse-non-usage); token counts (input/output/reasoning/cached/tool)
+land as typed columns. Bodies decode via Effect `Schema` (curated OTLP/JSON
+subset, `apps/axctl/src/otel/`), normalize per-harness (`service.name` ->
+harness label), and land in `otel_metric_point` / `otel_span` / `otel_log_event`.
 A correlation pass at ingest finish draws `session -> telemetry_of -> otel_*`
 edges by matching `session.id` (OTLP arrives before the transcript, so the
 ingest run owns linking; idempotent, best-effort via `Effect.ignore`). OTLP cost

--- a/apps/axctl/src/dashboard/contract/otel.test.ts
+++ b/apps/axctl/src/dashboard/contract/otel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { handleOtlp } from "./otel.ts";
+import codexLogs from "../../otel/__fixtures__/codex-logs.json" with { type: "json" };
 
 const captured: string[] = [];
 const stubDb = Layer.succeed(SurrealClient, {
@@ -51,4 +52,13 @@ describe("handleOtlp", () => {
         expect(captured).toHaveLength(0);
         expect(ack).toEqual({ partialSuccess: {} });
     });
+});
+
+test("logs body → writer UPSERT into otel_log_event, returns ack", async () => {
+    captured.length = 0;
+    const ack = await Effect.runPromise(
+        handleOtlp("logs", toBuf(JSON.stringify(codexLogs)), undefined).pipe(Effect.provide(stubDb)),
+    );
+    expect(captured.join("\n")).toContain("UPSERT otel_log_event:");
+    expect(ack).toEqual({ partialSuccess: {} });
 });

--- a/apps/axctl/src/dashboard/contract/otel.ts
+++ b/apps/axctl/src/dashboard/contract/otel.ts
@@ -17,8 +17,8 @@ import { HttpServerRequest } from "effect/unstable/http";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { AxApi } from "@ax/lib/shared/api-contract";
 import { OtelWriter, OtelWriterLive } from "../../otel/writer.ts";
-import { decodeMetricsPayload, decodeTracePayload } from "../../otel/decode.ts";
-import { normalizeMetrics, normalizeTrace } from "../../otel/normalize.ts";
+import { decodeLogsPayload, decodeMetricsPayload, decodeTracePayload } from "../../otel/decode.ts";
+import { normalizeLogs, normalizeMetrics, normalizeTrace } from "../../otel/normalize.ts";
 
 // ------------------------------------------------------------------ types
 
@@ -38,8 +38,6 @@ export const handleOtlp = (
     contentEncoding: string | undefined,
 ) =>
     Effect.gen(function* () {
-        if (signal === "logs") return ACK;
-
         const bytes = new Uint8Array(body);
         const raw = contentEncoding === "gzip" ? Bun.gunzipSync(bytes) : bytes;
 
@@ -55,7 +53,10 @@ export const handleOtlp = (
 
         const writer = yield* OtelWriter;
 
-        if (signal === "metrics") {
+        if (signal === "logs") {
+            const payload = yield* decodeLogsPayload(json).pipe(Effect.orElseSucceed(() => null));
+            if (payload) yield* writer.writeLogs(normalizeLogs(payload));
+        } else if (signal === "metrics") {
             const payload = yield* decodeMetricsPayload(json).pipe(
                 Effect.orElseSucceed(() => null),
             );

--- a/apps/axctl/src/dashboard/contract/otel.ts
+++ b/apps/axctl/src/dashboard/contract/otel.ts
@@ -4,8 +4,9 @@
  * All three signals return `{ partialSuccess: {} }` (the OTLP/HTTP ack).
  * The handler is fail-open: a bad body or decode failure logs a warning and
  * returns the ack without writing, so a misconfigured sender never crashes the
- * daemon. Only metrics and traces are written today; logs are accepted and
- * silently dropped (no table yet).
+ * daemon. All three signals are decoded, normalized, and written to their
+ * tables: metrics to otel_metric_point, traces to otel_span, logs to
+ * otel_log_event.
  *
  * `handleOtlp` is a plain Effect (no HTTP layer) so the test suite can drive
  * it directly with a stub DB layer. `OtelGroupLive` wires it into the contract

--- a/apps/axctl/src/otel/__fixtures__/codex-logs.json
+++ b/apps/axctl/src/otel/__fixtures__/codex-logs.json
@@ -1,0 +1,477 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "codex_exec"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "0.139.0"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "codex"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "0",
+              "observedTimeUnixNano": "1781532925235852000",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": null,
+              "attributes": [
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "codex.sse_event"
+                  }
+                },
+                {
+                  "key": "event.kind",
+                  "value": {
+                    "stringValue": "response.completed"
+                  }
+                },
+                {
+                  "key": "input_token_count",
+                  "value": {
+                    "stringValue": "9994"
+                  }
+                },
+                {
+                  "key": "output_token_count",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "cached_token_count",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "reasoning_token_count",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "tool_token_count",
+                  "value": {
+                    "stringValue": "9994"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-06-15T14:15:25.235Z"
+                  }
+                },
+                {
+                  "key": "conversation.id",
+                  "value": {
+                    "stringValue": "019ecba3-1618-7c63-8e2e-e2eaf13075f3"
+                  }
+                },
+                {
+                  "key": "app.version",
+                  "value": {
+                    "stringValue": "0.139.0"
+                  }
+                },
+                {
+                  "key": "auth_mode",
+                  "value": {
+                    "stringValue": "Chatgpt"
+                  }
+                },
+                {
+                  "key": "originator",
+                  "value": {
+                    "stringValue": "codex_exec"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "1fd34b75-ae2b-4877-b6a1-0536a28abf2b"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "necmettin.karakaya@gmail.com"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "ghostty/1.3.2-HEAD-_05c3e29"
+                  }
+                },
+                {
+                  "key": "model",
+                  "value": {
+                    "stringValue": "gpt-5.5"
+                  }
+                },
+                {
+                  "key": "slug",
+                  "value": {
+                    "stringValue": "gpt-5.5"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "flags": 0,
+              "traceId": "",
+              "spanId": "",
+              "eventName": "event otel/src/events/session_telemetry.rs:925"
+            },
+            {
+              "timeUnixNano": "0",
+              "observedTimeUnixNano": "1781532923537220000",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": null,
+              "attributes": [
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "codex.user_prompt"
+                  }
+                },
+                {
+                  "key": "prompt_length",
+                  "value": {
+                    "stringValue": "41"
+                  }
+                },
+                {
+                  "key": "prompt",
+                  "value": {
+                    "stringValue": "[REDACTED]"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-06-15T14:15:23.537Z"
+                  }
+                },
+                {
+                  "key": "conversation.id",
+                  "value": {
+                    "stringValue": "019ecba3-1618-7c63-8e2e-e2eaf13075f3"
+                  }
+                },
+                {
+                  "key": "app.version",
+                  "value": {
+                    "stringValue": "0.139.0"
+                  }
+                },
+                {
+                  "key": "auth_mode",
+                  "value": {
+                    "stringValue": "Chatgpt"
+                  }
+                },
+                {
+                  "key": "originator",
+                  "value": {
+                    "stringValue": "codex_exec"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "1fd34b75-ae2b-4877-b6a1-0536a28abf2b"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "necmettin.karakaya@gmail.com"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "ghostty/1.3.2-HEAD-_05c3e29"
+                  }
+                },
+                {
+                  "key": "model",
+                  "value": {
+                    "stringValue": "gpt-5.5"
+                  }
+                },
+                {
+                  "key": "slug",
+                  "value": {
+                    "stringValue": "gpt-5.5"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "flags": 0,
+              "traceId": "",
+              "spanId": "",
+              "eventName": "event otel/src/events/session_telemetry.rs:968"
+            },
+            {
+              "timeUnixNano": "0",
+              "observedTimeUnixNano": "1781532923494563000",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": null,
+              "attributes": [
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "codex.conversation_starts"
+                  }
+                },
+                {
+                  "key": "provider_name",
+                  "value": {
+                    "stringValue": "OpenAI"
+                  }
+                },
+                {
+                  "key": "auth.env_openai_api_key_present",
+                  "value": {
+                    "boolValue": false
+                  }
+                },
+                {
+                  "key": "auth.env_codex_api_key_present",
+                  "value": {
+                    "boolValue": false
+                  }
+                },
+                {
+                  "key": "auth.env_codex_api_key_enabled",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "auth.env_refresh_token_url_override_present",
+                  "value": {
+                    "boolValue": false
+                  }
+                },
+                {
+                  "key": "reasoning_effort",
+                  "value": {
+                    "stringValue": "xhigh"
+                  }
+                },
+                {
+                  "key": "reasoning_summary",
+                  "value": {
+                    "stringValue": "auto"
+                  }
+                },
+                {
+                  "key": "approval_policy",
+                  "value": {
+                    "stringValue": "never"
+                  }
+                },
+                {
+                  "key": "sandbox_policy",
+                  "value": {
+                    "stringValue": "workspace-write"
+                  }
+                },
+                {
+                  "key": "mcp_servers",
+                  "value": {
+                    "stringValue": "codex_apps"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-06-15T14:15:23.494Z"
+                  }
+                },
+                {
+                  "key": "conversation.id",
+                  "value": {
+                    "stringValue": "019ecba3-1618-7c63-8e2e-e2eaf13075f3"
+                  }
+                },
+                {
+                  "key": "app.version",
+                  "value": {
+                    "stringValue": "0.139.0"
+                  }
+                },
+                {
+                  "key": "auth_mode",
+                  "value": {
+                    "stringValue": "Chatgpt"
+                  }
+                },
+                {
+                  "key": "originator",
+                  "value": {
+                    "stringValue": "codex_exec"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "1fd34b75-ae2b-4877-b6a1-0536a28abf2b"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "necmettin.karakaya@gmail.com"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "ghostty/1.3.2-HEAD-_05c3e29"
+                  }
+                },
+                {
+                  "key": "model",
+                  "value": {
+                    "stringValue": "gpt-5.5"
+                  }
+                },
+                {
+                  "key": "slug",
+                  "value": {
+                    "stringValue": "gpt-5.5"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "flags": 0,
+              "traceId": "",
+              "spanId": "",
+              "eventName": "event otel/src/events/session_telemetry.rs:450"
+            },
+            {
+              "timeUnixNano": "0",
+              "observedTimeUnixNano": "1781532925021734000",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": null,
+              "attributes": [
+                {
+                  "key": "event.name",
+                  "value": {
+                    "stringValue": "codex.websocket_event"
+                  }
+                },
+                {
+                  "key": "event.kind",
+                  "value": {
+                    "stringValue": "codex.rate_limits"
+                  }
+                },
+                {
+                  "key": "duration_ms",
+                  "value": {
+                    "stringValue": "192"
+                  }
+                },
+                {
+                  "key": "success",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "event.timestamp",
+                  "value": {
+                    "stringValue": "2026-06-15T14:15:25.021Z"
+                  }
+                },
+                {
+                  "key": "conversation.id",
+                  "value": {
+                    "stringValue": "019ecba3-1618-7c63-8e2e-e2eaf13075f3"
+                  }
+                },
+                {
+                  "key": "app.version",
+                  "value": {
+                    "stringValue": "0.139.0"
+                  }
+                },
+                {
+                  "key": "auth_mode",
+                  "value": {
+                    "stringValue": "Chatgpt"
+                  }
+                },
+                {
+                  "key": "originator",
+                  "value": {
+                    "stringValue": "codex_exec"
+                  }
+                },
+                {
+                  "key": "user.account_id",
+                  "value": {
+                    "stringValue": "1fd34b75-ae2b-4877-b6a1-0536a28abf2b"
+                  }
+                },
+                {
+                  "key": "user.email",
+                  "value": {
+                    "stringValue": "necmettin.karakaya@gmail.com"
+                  }
+                },
+                {
+                  "key": "terminal.type",
+                  "value": {
+                    "stringValue": "ghostty/1.3.2-HEAD-_05c3e29"
+                  }
+                },
+                {
+                  "key": "model",
+                  "value": {
+                    "stringValue": "gpt-5.5"
+                  }
+                },
+                {
+                  "key": "slug",
+                  "value": {
+                    "stringValue": "gpt-5.5"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "flags": 0,
+              "traceId": "",
+              "spanId": "",
+              "eventName": "event otel/src/events/session_telemetry.rs:778"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/apps/axctl/src/otel/correlate.test.ts
+++ b/apps/axctl/src/otel/correlate.test.ts
@@ -48,6 +48,24 @@ describe("correlateOrphanOtel", () => {
         expect(all).toContain("m1");
     });
 
+    test("RELATEs an orphan log event row to its session", async () => {
+        sql.length = 0;
+        const logEventDb = Layer.succeed(SurrealClient, {
+            query: <T>(q: string) => {
+                sql.push(q);
+                if (/otel_log_event/.test(q) && /SELECT/i.test(q)) {
+                    return Effect.succeed([[{ id: "otel_log_event:l1", session_id: "s1" }]] as unknown as T);
+                }
+                return Effect.succeed([[]] as unknown as T);
+            },
+        } as never);
+        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(logEventDb)));
+        const all = sql.join("\n");
+        expect(all).toContain("RELATE session:");
+        expect(all).toContain("telemetry_of");
+        expect(all).toContain("otel_log_event:");
+    });
+
     test("no orphans → no RELATE", async () => {
         sql.length = 0;
         // override: both selects return empty by re-importing with a fresh stub

--- a/apps/axctl/src/otel/correlate.ts
+++ b/apps/axctl/src/otel/correlate.ts
@@ -4,7 +4,7 @@ import { executeStatements, recordRef } from "@ax/lib/shared/surreal";
 
 interface Orphan { readonly id: unknown; readonly session_id: string }
 
-const RELATABLE = ["otel_metric_point", "otel_span"] as const;
+const RELATABLE = ["otel_metric_point", "otel_span", "otel_log_event"] as const;
 
 /**
  * Extract the bare record KEY from a SurrealDB row `id`, which the SDK returns

--- a/apps/axctl/src/otel/decode.ts
+++ b/apps/axctl/src/otel/decode.ts
@@ -1,5 +1,5 @@
 import { Effect, Schema } from "effect";
-import { MetricsPayload, TracePayload } from "./otlp-schema.ts";
+import { MetricsPayload, TracePayload, LogsPayload } from "./otlp-schema.ts";
 
 export class OtelDecodeError extends Schema.TaggedErrorClass<OtelDecodeError>(
     "OtelDecodeError",
@@ -16,4 +16,9 @@ export const decodeMetricsPayload = (json: unknown) =>
 export const decodeTracePayload = (json: unknown) =>
     Schema.decodeUnknownEffect(TracePayload)(json).pipe(
         Effect.mapError((e) => new OtelDecodeError({ signal: "traces", message: String(e) })),
+    );
+
+export const decodeLogsPayload = (json: unknown) =>
+    Schema.decodeUnknownEffect(LogsPayload)(json).pipe(
+        Effect.mapError((e) => new OtelDecodeError({ signal: "logs", message: String(e) })),
     );

--- a/apps/axctl/src/otel/normalize.test.ts
+++ b/apps/axctl/src/otel/normalize.test.ts
@@ -62,3 +62,32 @@ describe("normalize", () => {
         expect(rows[0]!.harness).toBe("unknown");
     });
 });
+
+import { normalizeLogs } from "./normalize.ts";
+import codexLogs from "./__fixtures__/codex-logs.json" with { type: "json" };
+
+describe("normalizeLogs", () => {
+    test("allowlist drops transport noise, keeps signal events", () => {
+        const rows = normalizeLogs(codexLogs as never);
+        const names = rows.map((r) => r.event_name);
+        expect(names).not.toContain("codex.websocket_event");
+        expect(names).toContain("codex.user_prompt");
+        expect(names).toContain("codex.conversation_starts");
+        expect(rows.every((r) => r.harness === "codex")).toBe(true);
+    });
+
+    test("sse_event row lifts token columns + session from conversation.id", () => {
+        const rows = normalizeLogs(codexLogs as never);
+        const sse = rows.find((r) => r.event_name === "codex.sse_event");
+        expect(sse).toBeDefined();
+        expect(sse!.input_tokens).toBe(9994);
+        expect(sse!.model).toBe("gpt-5.5");
+        expect(sse!.session_id).toBe("019ecba3-1618-7c63-8e2e-e2eaf13075f3");
+    });
+
+    test("non-allowlisted-only payload → 0 rows", () => {
+        const noise = { resourceLogs: [{ resource: { attributes: [{ key: "service.name", value: { stringValue: "codex_exec" } }] },
+            scopeLogs: [{ logRecords: [{ attributes: [{ key: "event.name", value: { stringValue: "codex.websocket_event" } }] }] }] }] };
+        expect(normalizeLogs(noise as never)).toHaveLength(0);
+    });
+});

--- a/apps/axctl/src/otel/normalize.ts
+++ b/apps/axctl/src/otel/normalize.ts
@@ -1,5 +1,5 @@
-import { attrMap, nanoToDate, type MetricsPayload, type TracePayload } from "./otlp-schema.ts";
-import type { OtelMetricPointRow, OtelSpanRow } from "./rows.ts";
+import { attrMap, nanoToDate, type MetricsPayload, type TracePayload, type LogsPayload } from "./otlp-schema.ts";
+import type { OtelMetricPointRow, OtelSpanRow, OtelLogEventRow } from "./rows.ts";
 
 /** Map an OTLP service.name to ax's harness label. */
 const harnessOf = (serviceName: string | number | boolean | null | undefined): string => {
@@ -7,6 +7,7 @@ const harnessOf = (serviceName: string | number | boolean | null | undefined): s
     if (serviceName === "codex_cli_rs") return "codex";
     if (serviceName === "opencode") return "opencode";
     if (typeof serviceName === "string" && serviceName.startsWith("pi")) return "pi";
+    if (typeof serviceName === "string" && serviceName.startsWith("codex")) return "codex";
     return "unknown";
 };
 
@@ -65,6 +66,63 @@ export const normalizeTrace = (payload: TracePayload): OtelSpanRow[] => {
                     duration_ms: ended.getTime() - started.getTime(),
                     attrs: a.size ? JSON.stringify(Object.fromEntries(a.entries())) : null,
                     observed_at: started,
+                });
+            }
+        }
+    }
+    return out;
+};
+
+const LOG_ALLOWLIST: Record<string, ReadonlySet<string>> = {
+    codex: new Set([
+        "codex.sse_event", "codex.api_request", "codex.user_prompt",
+        "codex.turn_ttft", "codex.conversation_starts",
+    ]),
+    claude: new Set([
+        "claude_code.tool_decision", "claude_code.skill_activated",
+        "claude_code.user_prompt", "claude_code.api_error",
+    ]),
+};
+
+const num = (v: string | number | boolean | null | undefined): number | null =>
+    typeof v === "number" ? v : typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v)) ? Number(v) : null;
+
+const eventTime = (
+    a: Map<string, string | number | boolean | null>,
+    observedNano: string | undefined,
+    nano: string | undefined,
+): Date => {
+    const ts = a.get("event.timestamp");
+    if (typeof ts === "string") { const d = new Date(ts); if (!Number.isNaN(d.getTime())) return d; }
+    return nanoToDate(observedNano ?? nano);
+};
+
+export const normalizeLogs = (payload: LogsPayload): OtelLogEventRow[] => {
+    const out: OtelLogEventRow[] = [];
+    for (const rl of payload.resourceLogs) {
+        const res = attrMap(rl.resource?.attributes);
+        const harness = harnessOf(res.get("service.name") ?? null);
+        const allow = LOG_ALLOWLIST[harness];
+        for (const sl of rl.scopeLogs) {
+            for (const rec of sl.logRecords) {
+                const a = attrMap(rec.attributes);
+                const eventName = a.get("event.name");
+                if (typeof eventName !== "string") continue;
+                if (!allow || !allow.has(eventName)) continue;
+                out.push({
+                    harness,
+                    event_name: eventName,
+                    session_id: str(a.get("conversation.id") ?? a.get("session.id") ?? res.get("session.id")),
+                    model: str(a.get("model")),
+                    input_tokens: num(a.get("input_token_count")),
+                    output_tokens: num(a.get("output_token_count")),
+                    reasoning_tokens: num(a.get("reasoning_token_count")),
+                    cached_tokens: num(a.get("cached_token_count")),
+                    tool_tokens: num(a.get("tool_token_count")),
+                    duration_ms: num(a.get("duration_ms")),
+                    status_code: num(a.get("http.response.status_code")),
+                    attrs: a.size ? JSON.stringify(Object.fromEntries(a)) : null,
+                    observed_at: eventTime(a, rec.observedTimeUnixNano, rec.timeUnixNano),
                 });
             }
         }

--- a/apps/axctl/src/otel/otlp-schema.test.ts
+++ b/apps/axctl/src/otel/otlp-schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Schema } from "effect";
-import { AnyValue, MetricsPayload, TracePayload, attrValueToScalar } from "./otlp-schema.ts";
+import { AnyValue, LogsPayload, MetricsPayload, TracePayload, attrValueToScalar } from "./otlp-schema.ts";
 
 describe("otlp envelope schemas", () => {
     test("decodes an AnyValue stringValue", () => {
@@ -50,5 +50,19 @@ describe("otlp envelope schemas", () => {
         };
         const decoded = Schema.decodeUnknownSync(TracePayload)(payload);
         expect(decoded.resourceSpans[0]?.scopeSpans[0]?.spans[0]?.name).toBe("session_loop");
+    });
+
+    test("decodes a minimal logs payload", () => {
+        const payload = {
+            resourceLogs: [{
+                resource: { attributes: [{ key: "service.name", value: { stringValue: "codex_exec" } }] },
+                scopeLogs: [{ logRecords: [{
+                    observedTimeUnixNano: "1718409600000000000",
+                    attributes: [{ key: "event.name", value: { stringValue: "codex.user_prompt" } }],
+                }] }],
+            }],
+        };
+        const d = Schema.decodeUnknownSync(LogsPayload)(payload);
+        expect(d.resourceLogs[0]?.scopeLogs[0]?.logRecords[0]?.attributes?.[0]?.key).toBe("event.name");
     });
 });

--- a/apps/axctl/src/otel/otlp-schema.ts
+++ b/apps/axctl/src/otel/otlp-schema.ts
@@ -78,6 +78,23 @@ export const TracePayload = Schema.Struct({
 });
 export type TracePayload = Schema.Schema.Type<typeof TracePayload>;
 
+const LogRecord = Schema.Struct({
+    timeUnixNano: Schema.optional(Schema.String),
+    observedTimeUnixNano: Schema.optional(Schema.String),
+    attributes: Schema.optional(Schema.Array(KeyValue)),
+    body: Schema.optional(Schema.Unknown),
+});
+
+export const LogsPayload = Schema.Struct({
+    resourceLogs: Schema.Array(Schema.Struct({
+        resource: Schema.optional(Schema.Struct({ attributes: Schema.optional(Schema.Array(KeyValue)) })),
+        scopeLogs: Schema.Array(Schema.Struct({
+            logRecords: Schema.Array(LogRecord),
+        })),
+    })),
+});
+export type LogsPayload = Schema.Schema.Type<typeof LogsPayload>;
+
 /** nano-string -> JS Date. */
 export const nanoToDate = (nano: string | undefined): Date =>
     new Date(Number(BigInt(nano ?? "0") / 1_000_000n));

--- a/apps/axctl/src/otel/rows.test.ts
+++ b/apps/axctl/src/otel/rows.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { metricPointKey, spanKey, type OtelMetricPointRow } from "./rows.ts";
+import { logEventKey, type OtelLogEventRow } from "./rows.ts";
 
 describe("otel record keys", () => {
     test("metricPointKey is deterministic for same point", () => {
@@ -22,5 +23,23 @@ describe("otel record keys", () => {
 
     test("spanKey is the span_id", () => {
         expect(spanKey({ span_id: "abc" })).toBe("abc");
+    });
+});
+
+describe("otel log event keys", () => {
+    const base: OtelLogEventRow = {
+        harness: "codex", event_name: "codex.sse_event", session_id: "c1",
+        model: "gpt-5.5", input_tokens: 9994, output_tokens: 0, reasoning_tokens: 0,
+        cached_tokens: 0, tool_tokens: 9994, duration_ms: null, status_code: null,
+        attrs: null, observed_at: new Date("2026-06-15T00:00:00Z"),
+    };
+    test("deterministic for same event+index", () => {
+        expect(logEventKey(base, 0)).toBe(logEventKey(base, 0));
+    });
+    test("differs by index (distinct same-name events at same ts)", () => {
+        expect(logEventKey(base, 0)).not.toBe(logEventKey(base, 1));
+    });
+    test("differs by event_name", () => {
+        expect(logEventKey(base, 0)).not.toBe(logEventKey({ ...base, event_name: "x" }, 0));
     });
 });

--- a/apps/axctl/src/otel/rows.ts
+++ b/apps/axctl/src/otel/rows.ts
@@ -38,3 +38,30 @@ export const metricPointKey = (r: OtelMetricPointRow): string => {
 
 /** Spans carry a globally-unique span_id; use it directly. */
 export const spanKey = (r: Pick<OtelSpanRow, "span_id">): string => r.span_id;
+
+export const OtelLogEventRow = Schema.Struct({
+    harness: Schema.String,
+    event_name: Schema.String,
+    session_id: Schema.NullOr(Schema.String),
+    model: Schema.NullOr(Schema.String),
+    input_tokens: Schema.NullOr(Schema.Number),
+    output_tokens: Schema.NullOr(Schema.Number),
+    reasoning_tokens: Schema.NullOr(Schema.Number),
+    cached_tokens: Schema.NullOr(Schema.Number),
+    tool_tokens: Schema.NullOr(Schema.Number),
+    duration_ms: Schema.NullOr(Schema.Number),
+    status_code: Schema.NullOr(Schema.Number),
+    attrs: Schema.NullOr(Schema.String),
+    observed_at: Schema.Date,
+});
+export type OtelLogEventRow = Schema.Schema.Type<typeof OtelLogEventRow>;
+
+/**
+ * Deterministic id. Log events repeat by name within a session/second, so the
+ * per-payload record `index` is folded in to keep distinct events distinct
+ * (idempotent across re-delivery of the SAME payload).
+ */
+export const logEventKey = (r: OtelLogEventRow, index: number): string => {
+    const ts = r.observed_at instanceof Date ? r.observed_at.toISOString() : String(r.observed_at);
+    return `${r.harness}|${r.event_name}|${r.session_id ?? ""}|${ts}|${index}`;
+};

--- a/apps/axctl/src/otel/writer.test.ts
+++ b/apps/axctl/src/otel/writer.test.ts
@@ -3,6 +3,7 @@ import { Effect, Layer } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { OtelWriter, OtelWriterLive } from "./writer.ts";
 import type { OtelMetricPointRow, OtelSpanRow } from "./rows.ts";
+import type { OtelLogEventRow } from "./rows.ts";
 
 const captured: string[] = [];
 const stubDb = Layer.succeed(SurrealClient, {
@@ -60,4 +61,27 @@ describe("OtelWriter", () => {
         );
         expect(captured).toHaveLength(0);
     });
+});
+
+test("writeLogs issues an UPSERT into otel_log_event with token cols", async () => {
+    captured.length = 0;
+    const row: OtelLogEventRow = {
+        harness: "codex", event_name: "codex.sse_event", session_id: "c1", model: "gpt-5.5",
+        input_tokens: 9994, output_tokens: 0, reasoning_tokens: 0, cached_tokens: 0, tool_tokens: 9994,
+        duration_ms: null, status_code: null, attrs: null, observed_at: new Date("2026-06-15T00:00:00Z"),
+    };
+    await Effect.runPromise(Effect.gen(function* () {
+        const w = yield* OtelWriter; yield* w.writeLogs([row]);
+    }).pipe(Effect.provide(OtelWriterLive), Effect.provide(stubDb)));
+    const sql = captured.join("\n");
+    expect(sql).toContain("UPSERT otel_log_event:");
+    expect(sql).toContain("input_tokens = 9994");
+});
+
+test("writeLogs empty → no query", async () => {
+    captured.length = 0;
+    await Effect.runPromise(Effect.gen(function* () {
+        const w = yield* OtelWriter; yield* w.writeLogs([]);
+    }).pipe(Effect.provide(OtelWriterLive), Effect.provide(stubDb)));
+    expect(captured).toHaveLength(0);
 });

--- a/apps/axctl/src/otel/writer.ts
+++ b/apps/axctl/src/otel/writer.ts
@@ -11,16 +11,21 @@ import {
 import {
     metricPointKey,
     spanKey,
+    logEventKey,
     type OtelMetricPointRow,
     type OtelSpanRow,
+    type OtelLogEventRow,
 } from "./rows.ts";
 
 export interface OtelWriterShape {
     readonly writeMetrics: (rows: readonly OtelMetricPointRow[]) => Effect.Effect<void, DbError, SurrealClient>;
     readonly writeSpans: (rows: readonly OtelSpanRow[]) => Effect.Effect<void, DbError, SurrealClient>;
+    readonly writeLogs: (rows: readonly OtelLogEventRow[]) => Effect.Effect<void, DbError, SurrealClient>;
 }
 
 export class OtelWriter extends Context.Service<OtelWriter, OtelWriterShape>()("ax/otel/OtelWriter") {}
+
+const optNum = (n: number | null): string => n === null ? "NONE" : String(n);
 
 const metricStmt = (r: OtelMetricPointRow): string => {
     return (
@@ -55,9 +60,27 @@ const spanStmt = (r: OtelSpanRow): string => {
     );
 };
 
+const logStmt = (r: OtelLogEventRow, i: number): string =>
+    `UPSERT ${recordRef("otel_log_event", logEventKey(r, i))} SET ` +
+    `harness = ${surrealString(r.harness)}, ` +
+    `event_name = ${surrealString(r.event_name)}, ` +
+    `session_id = ${surrealOptionString(r.session_id)}, ` +
+    `model = ${surrealOptionString(r.model)}, ` +
+    `input_tokens = ${optNum(r.input_tokens)}, ` +
+    `output_tokens = ${optNum(r.output_tokens)}, ` +
+    `reasoning_tokens = ${optNum(r.reasoning_tokens)}, ` +
+    `cached_tokens = ${optNum(r.cached_tokens)}, ` +
+    `tool_tokens = ${optNum(r.tool_tokens)}, ` +
+    `duration_ms = ${optNum(r.duration_ms)}, ` +
+    `status_code = ${optNum(r.status_code)}, ` +
+    `attrs = ${surrealOptionString(r.attrs)}, ` +
+    `observed_at = ${surrealDate(r.observed_at)};`;
+
 export const OtelWriterLive: Layer.Layer<OtelWriter> = Layer.succeed(OtelWriter, {
     writeMetrics: (rows) =>
         rows.length === 0 ? Effect.void : executeStatements(rows.map(metricStmt)),
     writeSpans: (rows) =>
         rows.length === 0 ? Effect.void : executeStatements(rows.map(spanStmt)),
+    writeLogs: (rows) =>
+        rows.length === 0 ? Effect.void : executeStatements(rows.map((r, i) => logStmt(r, i))),
 });

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -171,6 +171,7 @@ export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "wrapped_card", stage: "active", note: "Agent-authored Wrapped recap cards (ax wrapped publish)." },
     { table: "otel_metric_point", stage: "active", note: "Harness OTLP metric data points (cost/token/usage)." },
     { table: "otel_span", stage: "active", note: "Harness OTLP trace spans (Codex session_loop + children)." },
+    { table: "otel_log_event", stage: "active", note: "Harness OTLP log events (codex events incl. token usage)." },
     { table: "telemetry_of", stage: "active", note: "Edge: session -> otel telemetry row (drawn at ingest)." },
 ] as const;
 

--- a/docs/superpowers/plans/2026-06-15-otel-logs-ingestion.md
+++ b/docs/superpowers/plans/2026-06-15-otel-logs-ingestion.md
@@ -1,0 +1,502 @@
+# OTLP Logs Ingestion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the no-op `POST /v1/logs` to ingest OTLP log events (Codex events; CC events) into a new `otel_log_event` table with typed token columns, curated by an allowlist, correlated to sessions.
+
+**Architecture:** Extends the existing `apps/axctl/src/otel/` pipeline (built in PR #423) - add a logs decoder + normalizer (allowlist + per-harness attr lifting) + writer method, implement the logs branch in the contract handler, register a new table, and extend the correlation pass. Mirrors the metrics/spans path exactly.
+
+**Tech Stack:** Bun ≥1.3, TypeScript strict, `effect@beta` (Schema/Layer), SurrealDB 3.x via `@ax/lib/db`, `bun:test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-otel-logs-ingestion-design.md`
+**Fixture:** `apps/axctl/src/otel/__fixtures__/codex-logs.json` (already committed).
+
+**effect@beta facts (from PR #423, reuse):** `Schema.Date` (not DateFromSelf), `Schema.decodeUnknownEffect` (not decodeUnknown), `Schema.TaggedErrorClass`, `Effect.orElseSucceed`/`Effect.ignore` (no Effect.catchAll). surql helpers `surrealString`/`surrealDate`/`surrealOptionString`/`recordRef`/`executeStatements` in `@ax/lib/shared/surreal.ts`. Numeric option helper: check `@ax/lib/shared/surreal.ts` for `surrealOptionInt`/`surrealOptionNumber` (use the real name; for a nullable number render the number or `NONE`).
+
+---
+
+## Task 1: `otel_log_event` table + registration
+
+**Files:**
+- Modify: `packages/schema/src/schema.surql` (near the other `otel_*` tables)
+- Modify: `apps/axctl/src/queries/insights.ts` (`SCHEMA_TABLES`)
+- Test: `apps/axctl/src/queries/insights.test.ts` (existing mirror guard)
+
+- [ ] **Step 1: Add DDL** to `schema.surql` (place beside `otel_span`):
+
+```surql
+DEFINE TABLE otel_log_event SCHEMAFULL;
+DEFINE FIELD harness          ON otel_log_event TYPE string;
+DEFINE FIELD event_name       ON otel_log_event TYPE string;
+DEFINE FIELD session_id       ON otel_log_event TYPE option<string>;
+DEFINE FIELD model            ON otel_log_event TYPE option<string>;
+DEFINE FIELD input_tokens     ON otel_log_event TYPE option<number>;
+DEFINE FIELD output_tokens    ON otel_log_event TYPE option<number>;
+DEFINE FIELD reasoning_tokens ON otel_log_event TYPE option<number>;
+DEFINE FIELD cached_tokens    ON otel_log_event TYPE option<number>;
+DEFINE FIELD tool_tokens      ON otel_log_event TYPE option<number>;
+DEFINE FIELD duration_ms      ON otel_log_event TYPE option<number>;
+DEFINE FIELD status_code      ON otel_log_event TYPE option<number>;
+DEFINE FIELD attrs            ON otel_log_event TYPE option<string>;
+DEFINE FIELD observed_at      ON otel_log_event TYPE datetime;
+DEFINE INDEX IF NOT EXISTS otel_log_event_session ON otel_log_event FIELDS session_id;
+```
+
+- [ ] **Step 2: Register** in `SCHEMA_TABLES` (match neighboring entry shape):
+
+```ts
+    { table: "otel_log_event", stage: "active", note: "Harness OTLP log events (codex events incl. token usage)." },
+```
+
+- [ ] **Step 3: Run mirror test** - `bun test apps/axctl/src/queries/insights.test.ts` → PASS. (Run `bun install` in the worktree first if `@ax/schema` resolution fails.)
+
+- [ ] **Step 4: Commit**
+```bash
+git add packages/schema/src/schema.surql apps/axctl/src/queries/insights.ts
+git commit -m "feat(otel): otel_log_event table"
+```
+
+---
+
+## Task 2: `OtelLogEventRow` + `logEventKey`
+
+**Files:**
+- Modify: `apps/axctl/src/otel/rows.ts`
+- Test: `apps/axctl/src/otel/rows.test.ts` (extend)
+
+- [ ] **Step 1: Write failing test** - append to `rows.test.ts`:
+
+```ts
+import { logEventKey, type OtelLogEventRow } from "./rows.ts";
+
+describe("otel log event keys", () => {
+    const base: OtelLogEventRow = {
+        harness: "codex", event_name: "codex.sse_event", session_id: "c1",
+        model: "gpt-5.5", input_tokens: 9994, output_tokens: 0, reasoning_tokens: 0,
+        cached_tokens: 0, tool_tokens: 9994, duration_ms: null, status_code: null,
+        attrs: null, observed_at: new Date("2026-06-15T00:00:00Z"),
+    };
+    test("deterministic for same event+index", () => {
+        expect(logEventKey(base, 0)).toBe(logEventKey(base, 0));
+    });
+    test("differs by index (distinct same-name events at same ts)", () => {
+        expect(logEventKey(base, 0)).not.toBe(logEventKey(base, 1));
+    });
+    test("differs by event_name", () => {
+        expect(logEventKey(base, 0)).not.toBe(logEventKey({ ...base, event_name: "x" }, 0));
+    });
+});
+```
+
+- [ ] **Step 2: Run** - `bun test apps/axctl/src/otel/rows.test.ts` → FAIL (logEventKey/type missing).
+
+- [ ] **Step 3: Implement** - append to `rows.ts`:
+
+```ts
+export const OtelLogEventRow = Schema.Struct({
+    harness: Schema.String,
+    event_name: Schema.String,
+    session_id: Schema.NullOr(Schema.String),
+    model: Schema.NullOr(Schema.String),
+    input_tokens: Schema.NullOr(Schema.Number),
+    output_tokens: Schema.NullOr(Schema.Number),
+    reasoning_tokens: Schema.NullOr(Schema.Number),
+    cached_tokens: Schema.NullOr(Schema.Number),
+    tool_tokens: Schema.NullOr(Schema.Number),
+    duration_ms: Schema.NullOr(Schema.Number),
+    status_code: Schema.NullOr(Schema.Number),
+    attrs: Schema.NullOr(Schema.String),
+    observed_at: Schema.Date,
+});
+export type OtelLogEventRow = Schema.Schema.Type<typeof OtelLogEventRow>;
+
+/**
+ * Deterministic id. Log events repeat by name within a session/second, so the
+ * per-payload record `index` is folded in to keep distinct events distinct
+ * (idempotent across re-delivery of the SAME payload).
+ */
+export const logEventKey = (r: OtelLogEventRow, index: number): string => {
+    const ts = r.observed_at instanceof Date ? r.observed_at.toISOString() : String(r.observed_at);
+    return `${r.harness}|${r.event_name}|${r.session_id ?? ""}|${ts}|${index}`;
+};
+```
+
+(`Schema` is already imported at the top of rows.ts - confirm; if not, add `import { Schema } from "effect";`.)
+
+- [ ] **Step 4: Run** → PASS. **Step 5: Typecheck** `bun run typecheck` (no new errors).
+- [ ] **Step 6: Commit**
+```bash
+git add apps/axctl/src/otel/rows.ts apps/axctl/src/otel/rows.test.ts
+git commit -m "feat(otel): OtelLogEventRow + logEventKey"
+```
+
+---
+
+## Task 3: `LogsPayload` schema
+
+**Files:**
+- Modify: `apps/axctl/src/otel/otlp-schema.ts`
+- Test: `apps/axctl/src/otel/otlp-schema.test.ts` (extend)
+
+- [ ] **Step 1: Write failing test** - append:
+
+```ts
+import { LogsPayload } from "./otlp-schema.ts";
+
+test("decodes a minimal logs payload", () => {
+    const payload = {
+        resourceLogs: [{
+            resource: { attributes: [{ key: "service.name", value: { stringValue: "codex_exec" } }] },
+            scopeLogs: [{ logRecords: [{
+                observedTimeUnixNano: "1718409600000000000",
+                attributes: [{ key: "event.name", value: { stringValue: "codex.user_prompt" } }],
+            }] }],
+        }],
+    };
+    const d = Schema.decodeUnknownSync(LogsPayload)(payload);
+    expect(d.resourceLogs[0]?.scopeLogs[0]?.logRecords[0]?.attributes?.[0]?.key).toBe("event.name");
+});
+```
+
+- [ ] **Step 2: Run** → FAIL. 
+
+- [ ] **Step 3: Implement** - append to `otlp-schema.ts` (reuses `KeyValue`/`Resource` already defined there; if `Resource` is module-private and not exported, redefine inline):
+
+```ts
+const LogRecord = Schema.Struct({
+    timeUnixNano: Schema.optional(Schema.String),
+    observedTimeUnixNano: Schema.optional(Schema.String),
+    attributes: Schema.optional(Schema.Array(KeyValue)),
+    body: Schema.optional(Schema.Unknown),
+});
+
+export const LogsPayload = Schema.Struct({
+    resourceLogs: Schema.Array(Schema.Struct({
+        resource: Schema.optional(Schema.Struct({ attributes: Schema.optional(Schema.Array(KeyValue)) })),
+        scopeLogs: Schema.Array(Schema.Struct({
+            logRecords: Schema.Array(LogRecord),
+        })),
+    })),
+});
+export type LogsPayload = Schema.Schema.Type<typeof LogsPayload>;
+```
+
+- [ ] **Step 4: Run** → PASS. **Step 5: Commit**
+```bash
+git add apps/axctl/src/otel/otlp-schema.ts apps/axctl/src/otel/otlp-schema.test.ts
+git commit -m "feat(otel): OTLP logs envelope schema"
+```
+
+---
+
+## Task 4: `decodeLogsPayload` + `normalizeLogs` (allowlist + token lifting)
+
+**Files:**
+- Modify: `apps/axctl/src/otel/decode.ts`
+- Modify: `apps/axctl/src/otel/normalize.ts`
+- Test: `apps/axctl/src/otel/normalize.test.ts` (extend, uses the committed fixture)
+
+- [ ] **Step 1: Write failing test** - append to `normalize.test.ts`:
+
+```ts
+import { normalizeLogs } from "./normalize.ts";
+import codexLogs from "./__fixtures__/codex-logs.json" with { type: "json" };
+
+describe("normalizeLogs", () => {
+    test("allowlist drops transport noise, keeps signal events", () => {
+        const rows = normalizeLogs(codexLogs as never);
+        const names = rows.map((r) => r.event_name).sort();
+        // fixture has sse_event(tokens) + user_prompt + conversation_starts + websocket_event(noise)
+        expect(names).not.toContain("codex.websocket_event");
+        expect(names).toContain("codex.user_prompt");
+        expect(names).toContain("codex.conversation_starts");
+        expect(rows.every((r) => r.harness === "codex")).toBe(true);
+    });
+
+    test("sse_event row lifts token columns + session from conversation.id", () => {
+        const rows = normalizeLogs(codexLogs as never);
+        const sse = rows.find((r) => r.event_name === "codex.sse_event");
+        expect(sse).toBeDefined();
+        expect(sse!.input_tokens).toBe(9994);
+        expect(sse!.model).toBe("gpt-5.5");
+        expect(sse!.session_id).toBe("019ecba3-1618-7c63-8e2e-e2eaf13075f3");
+    });
+
+    test("non-allowlisted-only payload → 0 rows", () => {
+        const noise = { resourceLogs: [{ resource: { attributes: [{ key: "service.name", value: { stringValue: "codex_exec" } }] },
+            scopeLogs: [{ logRecords: [{ attributes: [{ key: "event.name", value: { stringValue: "codex.websocket_event" } }] }] }] }] };
+        expect(normalizeLogs(noise as never)).toHaveLength(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run** → FAIL.
+
+- [ ] **Step 3: Implement decode** - append to `decode.ts`:
+
+```ts
+import { LogsPayload } from "./otlp-schema.ts"; // add to existing import if same module
+export const decodeLogsPayload = (json: unknown) =>
+    Schema.decodeUnknownEffect(LogsPayload)(json).pipe(
+        Effect.mapError((e) => new OtelDecodeError({ signal: "logs", message: String(e) })),
+    );
+```
+(Merge the `LogsPayload` import into the existing `./otlp-schema.ts` import line. `Schema`/`Effect`/`OtelDecodeError` already in scope.)
+
+- [ ] **Step 4: Implement normalize** - append to `normalize.ts` (reuse existing `attrMap`/`nanoToDate`/`str`/`harnessOf`):
+
+First, EXTEND `harnessOf` so codex log service names map (the existing one checks `codex_cli_rs`; logs use `codex_exec`):
+```ts
+// in harnessOf, before the final return:
+    if (typeof serviceName === "string" && serviceName.startsWith("codex")) return "codex";
+```
+(Place this AFTER the existing `=== "codex_cli_rs"` check; the startsWith covers codex_exec/codex_tui too.)
+
+Then add the allowlist + normalizer:
+```ts
+import { type LogsPayload } from "./otlp-schema.ts"; // merge into existing import
+import type { OtelLogEventRow } from "./rows.ts";    // merge into existing import
+
+const LOG_ALLOWLIST: Record<string, ReadonlySet<string>> = {
+    codex: new Set([
+        "codex.sse_event", "codex.api_request", "codex.user_prompt",
+        "codex.turn_ttft", "codex.conversation_starts",
+    ]),
+    claude: new Set([
+        "claude_code.tool_decision", "claude_code.skill_activated",
+        "claude_code.user_prompt", "claude_code.api_error",
+    ]),
+};
+
+const num = (v: string | number | boolean | null | undefined): number | null =>
+    typeof v === "number" ? v : typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v)) ? Number(v) : null;
+
+const eventTime = (a: Map<string, string | number | boolean | null>, observedNano: string | undefined, nano: string | undefined): Date => {
+    const ts = a.get("event.timestamp");
+    if (typeof ts === "string") { const d = new Date(ts); if (!Number.isNaN(d.getTime())) return d; }
+    return nanoToDate(observedNano ?? nano);
+};
+
+export const normalizeLogs = (payload: LogsPayload): OtelLogEventRow[] => {
+    const out: OtelLogEventRow[] = [];
+    for (const rl of payload.resourceLogs) {
+        const res = attrMap(rl.resource?.attributes);
+        const harness = harnessOf(res.get("service.name") ?? null);
+        const allow = LOG_ALLOWLIST[harness];
+        for (const sl of rl.scopeLogs) {
+            for (const rec of sl.logRecords) {
+                const a = attrMap(rec.attributes);
+                const eventName = a.get("event.name");
+                if (typeof eventName !== "string") continue;
+                if (!allow || !allow.has(eventName)) continue;
+                out.push({
+                    harness,
+                    event_name: eventName,
+                    session_id: str(a.get("conversation.id") ?? a.get("session.id") ?? res.get("session.id")),
+                    model: str(a.get("model")),
+                    input_tokens: num(a.get("input_token_count")),
+                    output_tokens: num(a.get("output_token_count")),
+                    reasoning_tokens: num(a.get("reasoning_token_count")),
+                    cached_tokens: num(a.get("cached_token_count")),
+                    tool_tokens: num(a.get("tool_token_count")),
+                    duration_ms: num(a.get("duration_ms")),
+                    status_code: num(a.get("http.response.status_code")),
+                    attrs: a.size ? JSON.stringify(Object.fromEntries(a)) : null,
+                    observed_at: eventTime(a, rec.observedTimeUnixNano, rec.timeUnixNano),
+                });
+            }
+        }
+    }
+    return out;
+};
+```
+
+- [ ] **Step 5: Run** → PASS (3 tests). **Step 6: Typecheck.**
+- [ ] **Step 7: Commit**
+```bash
+git add apps/axctl/src/otel/decode.ts apps/axctl/src/otel/normalize.ts apps/axctl/src/otel/normalize.test.ts
+git commit -m "feat(otel): logs decoder + normalizer (allowlist + token lifting)"
+```
+
+---
+
+## Task 5: `OtelWriter.writeLogs`
+
+**Files:**
+- Modify: `apps/axctl/src/otel/writer.ts`
+- Test: `apps/axctl/src/otel/writer.test.ts` (extend)
+
+- [ ] **Step 1: Write failing test** - append:
+
+```ts
+import type { OtelLogEventRow } from "./rows.ts";
+
+test("writeLogs issues an UPSERT into otel_log_event with token cols", async () => {
+    captured.length = 0;
+    const row: OtelLogEventRow = {
+        harness: "codex", event_name: "codex.sse_event", session_id: "c1", model: "gpt-5.5",
+        input_tokens: 9994, output_tokens: 0, reasoning_tokens: 0, cached_tokens: 0, tool_tokens: 9994,
+        duration_ms: null, status_code: null, attrs: null, observed_at: new Date("2026-06-15T00:00:00Z"),
+    };
+    await Effect.runPromise(Effect.gen(function* () {
+        const w = yield* OtelWriter; yield* w.writeLogs([row]);
+    }).pipe(Effect.provide(OtelWriterLive), Effect.provide(stubDb)));
+    const sql = captured.join("\n");
+    expect(sql).toContain("UPSERT otel_log_event:");
+    expect(sql).toContain("input_tokens = 9994");
+});
+
+test("writeLogs empty → no query", async () => {
+    captured.length = 0;
+    await Effect.runPromise(Effect.gen(function* () {
+        const w = yield* OtelWriter; yield* w.writeLogs([]);
+    }).pipe(Effect.provide(OtelWriterLive), Effect.provide(stubDb)));
+    expect(captured).toHaveLength(0);
+});
+```
+(`captured`/`stubDb`/`OtelWriter`/`OtelWriterLive`/`Effect` already set up in this test file.)
+
+- [ ] **Step 2: Run** → FAIL.
+
+- [ ] **Step 3: Implement** - in `writer.ts`:
+
+Add to `OtelWriterShape`:
+```ts
+    readonly writeLogs: (rows: readonly OtelLogEventRow[]) => Effect.Effect<void, DbError, SurrealClient>;
+```
+Import `OtelLogEventRow` + `logEventKey` from `./rows.ts` (merge into existing import). Add a statement builder + wire into the Live layer. For nullable numbers, render the number or `NONE` (use the real surql numeric-option helper from `@ax/lib/shared/surreal.ts`; if none exists, inline `const optNum = (n: number | null) => n === null ? "NONE" : String(n);`):
+
+```ts
+const logStmt = (r: OtelLogEventRow, i: number): string =>
+    `UPSERT ${recordRef("otel_log_event", logEventKey(r, i))} SET ` +
+    `harness = ${surrealString(r.harness)}, ` +
+    `event_name = ${surrealString(r.event_name)}, ` +
+    `session_id = ${surrealOptionString(r.session_id)}, ` +
+    `model = ${surrealOptionString(r.model)}, ` +
+    `input_tokens = ${optNum(r.input_tokens)}, ` +
+    `output_tokens = ${optNum(r.output_tokens)}, ` +
+    `reasoning_tokens = ${optNum(r.reasoning_tokens)}, ` +
+    `cached_tokens = ${optNum(r.cached_tokens)}, ` +
+    `tool_tokens = ${optNum(r.tool_tokens)}, ` +
+    `duration_ms = ${optNum(r.duration_ms)}, ` +
+    `status_code = ${optNum(r.status_code)}, ` +
+    `attrs = ${surrealOptionString(r.attrs)}, ` +
+    `observed_at = ${surrealDate(r.observed_at)};`;
+```
+In `OtelWriterLive`:
+```ts
+    writeLogs: (rows) => rows.length === 0 ? Effect.void : executeStatements(rows.map((r, i) => logStmt(r, i))),
+```
+
+- [ ] **Step 4: Run** → PASS. **Step 5: Typecheck.**
+- [ ] **Step 6: Commit**
+```bash
+git add apps/axctl/src/otel/writer.ts apps/axctl/src/otel/writer.test.ts
+git commit -m "feat(otel): OtelWriter.writeLogs"
+```
+
+---
+
+## Task 6: Implement the `/v1/logs` handler branch
+
+**Files:**
+- Modify: `apps/axctl/src/dashboard/contract/otel.ts`
+- Test: `apps/axctl/src/dashboard/contract/otel.test.ts` (extend)
+
+- [ ] **Step 1: Write failing test** - append (mirror the metrics test):
+
+```ts
+import codexLogs from "../../otel/__fixtures__/codex-logs.json" with { type: "json" };
+
+test("logs body → writer UPSERT into otel_log_event, returns ack", async () => {
+    captured.length = 0;
+    const ack = await Effect.runPromise(
+        handleOtlp("logs", toBuf(JSON.stringify(codexLogs)), undefined).pipe(Effect.provide(stubDb)),
+    );
+    expect(captured.join("\n")).toContain("UPSERT otel_log_event:");
+    expect(ack).toEqual({ partialSuccess: {} });
+});
+```
+(`captured`/`stubDb`/`toBuf`/`handleOtlp`/`Effect` already in this test file.)
+
+- [ ] **Step 2: Run** → FAIL (currently logs is a no-op, no UPSERT).
+
+- [ ] **Step 3: Implement** - in `otel.ts`, replace the `if (signal === "logs") return ACK;` early return. The handler currently branches metrics/traces; add a logs branch that decodes→normalizes→writes. Import `decodeLogsPayload` + `normalizeLogs`. Inside the gen, after `json` is parsed and `writer` obtained, structure as:
+
+```ts
+        if (signal === "logs") {
+            const payload = yield* decodeLogsPayload(json).pipe(
+                Effect.orElseSucceed(() => null),
+            );
+            if (payload) yield* writer.writeLogs(normalizeLogs(payload));
+        } else if (signal === "metrics") {
+            // ...existing...
+        } else {
+            // ...existing traces...
+        }
+```
+IMPORTANT: the existing handler returns ACK early for "logs" BEFORE obtaining `writer`/parsing `json`. Move the logs handling to AFTER the json-parse + `const writer = yield* OtelWriter;` lines, alongside metrics/traces. Read the current file structure and integrate cleanly (keep the fail-open: bad json → ACK no write; provide OtelWriterLive as today). Do NOT remove the metrics/traces branches.
+
+- [ ] **Step 4: Run** → PASS. Also run `bun test apps/axctl/src/dashboard/contract/otel.test.ts` (all prior tests still green). **Step 5: Typecheck.**
+- [ ] **Step 6: Commit**
+```bash
+git add apps/axctl/src/dashboard/contract/otel.ts apps/axctl/src/dashboard/contract/otel.test.ts
+git commit -m "feat(otel): implement /v1/logs ingestion handler"
+```
+
+---
+
+## Task 7: Correlate log events + docs + full verification
+
+**Files:**
+- Modify: `apps/axctl/src/otel/correlate.ts`
+- Modify: `CLAUDE.md`
+- Test: `apps/axctl/src/otel/correlate.test.ts` (already passes; add otel_log_event coverage)
+
+- [ ] **Step 1: Extend RELATABLE** in `correlate.ts`:
+```ts
+const RELATABLE = ["otel_metric_point", "otel_span", "otel_log_event"] as const;
+```
+
+- [ ] **Step 2: Add a correlation test** - append to `correlate.test.ts` a stub returning an orphan `otel_log_event` row and assert a `RELATE ...->telemetry_of->otel_log_event:` statement is issued (mirror the existing metric-row test; the stub's SELECT regex should also match `otel_log_event`).
+
+- [ ] **Step 3: Run** - `bun test apps/axctl/src/otel/correlate.test.ts` → PASS.
+
+- [ ] **Step 4: Update CLAUDE.md** OTLP receiver section - change the `/v1/logs` line from "accepted and dropped (v1 no-op)" to: ingests OTLP log events → `otel_log_event` (codex events incl. token usage on `codex.sse_event`; curated allowlist; session key `conversation.id`). Keep it to ~3 sentences.
+
+- [ ] **Step 5: Full suite + typecheck** - `bun test` (repo-wide) + `bun run typecheck`. Fix any otel-caused breakage; list pre-existing unrelated failures. Expect green.
+
+- [ ] **Step 6: Commit**
+```bash
+git add apps/axctl/src/otel/correlate.ts apps/axctl/src/otel/correlate.test.ts CLAUDE.md
+git commit -m "feat(otel): correlate log events + docs"
+```
+
+---
+
+## Task 8: Live smoke (controller-run; document steps)
+
+**Files:** Create `apps/axctl/src/otel/SMOKE.md` addition (or note in PR).
+
+- [ ] **Step 1:** Document the smoke (the controller will run it against a live daemon):
+```bash
+# daemon on merged code, then POST the fixture as a logs body:
+curl -sS -X POST http://127.0.0.1:1738/v1/logs -H 'content-type: application/json' \
+  --data @apps/axctl/src/otel/__fixtures__/codex-logs.json
+# expect {"partialSuccess":{}}, then:
+#   SELECT event_name, input_tokens, model, session_id FROM otel_log_event;
+# expect 3 rows (websocket_event dropped); sse_event row with input_tokens=9994.
+```
+- [ ] **Step 2: Commit** any doc note.
+
+---
+
+## Verification (whole-plan)
+- [ ] `bun test` green; `bun run typecheck` clean.
+- [ ] SCHEMA_TABLES mirror green (Task 1).
+- [ ] Live: posting the fixture to `/v1/logs` lands 3 rows incl. token columns.
+- [ ] Allowlist drops `codex.websocket_event` (verified in normalize test + live).
+
+## Open items (from spec)
+1. Does codex transcript `session` id == `conversation.id`? Verify with a real ingested codex session; if not, log rows stay orphan (still useful). Correlation is best-effort.
+2. CC events need `OTEL_LOGS_EXPORTER=otlp` in install config to flow - deferred follow-up (claude allowlist entries are wired, untested live).

--- a/docs/superpowers/specs/2026-06-15-otel-logs-ingestion-design.md
+++ b/docs/superpowers/specs/2026-06-15-otel-logs-ingestion-design.md
@@ -1,0 +1,143 @@
+# OTLP logs ingestion - design
+
+Status: approved (brainstorm 2026-06-15). Branch: `feat/otel-logs-ingestion`.
+Builds on the OTLP receiver (PR #423) + Codex config fix (PR #426).
+Extends memory [[otel-receiver-shipped]].
+
+## Goal
+
+Implement the currently-no-op `POST /v1/logs` to ingest OTLP **log events** into a
+new `otel_log_event` table, and correlate them to sessions. This unblocks
+**Codex** dogfood data: Codex emits OTLP *logs* (events), not spans, so nothing
+Codex produces lands today. Also forward-covers Claude Code events
+(tool_decision accept/reject, skill_activated) on the same path.
+
+## Why logs (the dogfood finding)
+
+Live capture (2026-06-15) against real `codex exec`: Codex's otlp-http exporter
+POSTs OTLP `resourceLogs` (JSON) to the endpoint **as-is** (no `/v1/<signal>`
+appending; config targets `/v1/logs`). Service name `codex_exec`. Events carry
+`event.name` and rich attributes. The spec's original "Codex = traces"
+assumption was wrong.
+
+Captured event vocabulary (one `codex exec` turn):
+`codex.websocket_event` (×16, transport noise), `codex.startup_phase` (×8),
+`codex.sse_event` (×2 - **carries token usage**), `codex.websocket_request`,
+`codex.api_request` (http status + duration), `codex.websocket_connect`,
+`codex.user_prompt`, `codex.turn_ttft` (latency), `codex.conversation_starts`
+(model + reasoning_effort).
+
+**Token usage rides on `codex.sse_event`**: `input_token_count`,
+`output_token_count`, `reasoning_token_count`, `cached_token_count`,
+`tool_token_count`, plus `model`, `conversation.id`. (NOT on api_request -
+api_request carries `duration_ms`, `http.response.status_code`.)
+
+Session key = **`conversation.id`** attr (not `session.id`). Log-record
+`timeUnixNano` is `0`; real time is the `event.timestamp` string attr.
+
+Real captured fixture committed at
+`apps/axctl/src/otel/__fixtures__/codex-logs.json` (compact: one sse_event with
+tokens, one user_prompt, one conversation_starts, one websocket_event for the
+filter test).
+
+## Decisions
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Storage | new `otel_log_event` table | mirrors `otel_metric_point`/`otel_span`; additive |
+| Event scope | **curated allowlist** | drops the ~80% transport noise (websocket/sse-non-usage); clean rows |
+| Token data | **typed columns** on the row | Codex usage queryable/summable like CC metrics |
+| Session key | `conversation.id` ?? `session.id` | codex vs claude attr naming |
+| Timestamp | `event.timestamp` attr ?? observedTimeUnixNano | logRecord timeUnixNano is 0 |
+| Decode | Effect `Schema` (reuse AnyValue/KeyValue/attrMap) | consistency |
+| Correlation | add `otel_log_event` to existing `correlateOrphanOtel` | `telemetry_of` is unconstrained |
+
+## Curated allowlist
+
+A `const` (easy to extend), keyed by harness:
+
+- **codex**: `codex.sse_event` (tokens), `codex.api_request` (latency/status),
+  `codex.user_prompt`, `codex.turn_ttft`, `codex.conversation_starts`
+- **claude**: `claude_code.tool_decision`, `claude_code.skill_activated`,
+  `claude_code.user_prompt`, `claude_code.api_error`
+
+Events whose `event.name` is not in the harness's allowlist are skipped (not
+written). `codex.websocket_event`/`websocket_request`/`websocket_connect`/
+`startup_phase`/`sse_event`-without-usage noise is dropped. (An sse_event with
+no token attrs still matches the allowlist but lands with null token columns -
+acceptable; the allowlist is by name, token columns are best-effort.)
+
+## Architecture
+
+Extends `apps/axctl/src/otel/` (mirror the metrics/spans pipeline exactly).
+
+```
+POST /v1/logs (JSON) ──► decodeLogsPayload ─► normalizeLogs (allowlist + harness)
+                                                  │
+                                                  ▼
+                                            OtelWriter.writeLogs ─► otel_log_event
+ingest finish ──► correlateOrphanOtel (now includes otel_log_event) ─► telemetry_of
+```
+
+### Components
+
+1. **`otlp-schema.ts`** - add `LogsPayload` Schema:
+   `resourceLogs[].{resource?, scopeLogs[].logRecords[]}` where a `LogRecord`
+   has `timeUnixNano?`, `observedTimeUnixNano?`, `attributes?`, `body?`. Reuse
+   `AnyValue`/`KeyValue`/`attrMap`. Export `LogsPayload` (+type).
+2. **`rows.ts`** - add `OtelLogEventRow`:
+   `harness, event_name, session_id, model, observed_at` (Date),
+   token columns `input_tokens, output_tokens, reasoning_tokens, cached_tokens,
+   tool_tokens` (NullOr number), `duration_ms` (NullOr number),
+   `status_code` (NullOr number), `attrs` (NullOr string JSON).
+   Plus `logEventKey(r)` deterministic id =
+   `harness|event_name|session_id|observed_at.iso|<short hash of attrs>` (events
+   repeat per name+session+ts; include a stable discriminator so distinct
+   same-name events at the same second don't collide - use the record index or
+   an attr-derived suffix; the writer passes an index).
+3. **`decode.ts`** - `decodeLogsPayload(json)` (Effect, maps to OtelDecodeError signal "logs").
+4. **`normalize.ts`** - `normalizeLogs(payload): OtelLogEventRow[]`:
+   - `harnessOf(service.name)` extended: `codex_exec`/`codex_tui`/startsWith `codex` → "codex".
+   - per record: read `event.name`; if not in `ALLOWLIST[harness]` → skip.
+   - `session_id` = attr `conversation.id` ?? `session.id`.
+   - `observed_at` = parse `event.timestamp` attr ?? `observedTimeUnixNano`/`timeUnixNano` via nanoToDate.
+   - lift `input_token_count`→input_tokens, etc; `duration_ms`; `http.response.status_code`→status_code; `model`.
+   - `attrs` = JSON of full bag.
+5. **`writer.ts`** - add `writeLogs(rows)` to `OtelWriterShape` + Live (UPSERT into
+   `otel_log_event` via `recordRef` + `executeStatements`, numeric/option helpers).
+6. **`contract/otel.ts`** - replace the `signal === "logs"` early-return no-op with
+   decode→normalize→writeLogs (same fail-open shape as metrics/traces).
+7. **schema** - `otel_log_event` DDL (SCHEMAFULL, fields above, INDEX on session_id)
+   in `schema.surql` + `SCHEMA_TABLES`. `telemetry_of` unchanged (unconstrained).
+8. **`correlate.ts`** - add `"otel_log_event"` to `RELATABLE`.
+9. **docs** - correct the CLAUDE.md OTLP section ("logs now ingested → otel_log_event").
+
+## Correlation note (verify during build)
+
+`correlateOrphanOtel` links rows whose `session_id` matches an existing `session`
+id. For Codex, `session_id` = `conversation.id`. Whether ax's codex transcript
+ingest keys its `session` rows by that same uuid is unverified - check against a
+real ingested codex session. If they match → `telemetry_of` edges draw; if not →
+log rows stay queryable standalone (still useful for usage analytics). Either
+way correlation is best-effort under `Effect.ignore`, so no risk.
+
+## Testing (TDD)
+
+- **normalize**: the committed `__fixtures__/codex-logs.json` → assert 3 rows
+  (websocket_event dropped), sse_event row has token columns populated
+  (input_tokens=9994, model gpt-5.5, session_id=conversation.id), user_prompt +
+  conversation_starts rows present.
+- **allowlist**: a payload with only `websocket_event`/`startup_phase` → 0 rows.
+- **schema mirror**: new table registered (guard test).
+- **writer**: `writeLogs([row])` issues `UPSERT otel_log_event:` with token cols; empty → no query.
+- **handler**: post the fixture body to `handleOtlp("logs", …)` → writer called, ack `{partialSuccess:{}}`; malformed → ack, no write.
+- **correlate**: orphan otel_log_event with a matching session → RELATE issued.
+
+## Out of scope / deferred
+
+- CC events live-capture (the claude allowlist entries are wired but only Codex
+  is dogfood-verified here; CC events need `OTEL_LOGS_EXPORTER=otlp` which ax
+  install does not yet set - follow-up).
+- Cost USD derivation from codex token counts (ax cost analytics integration) -
+  separate follow-up; this PR lands the raw token columns.
+- Span ingestion for codex (if a future codex version emits a trace exporter).

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1910,6 +1910,22 @@ DEFINE FIELD attrs          ON otel_span TYPE option<string>;        -- JSON-enc
 DEFINE FIELD observed_at    ON otel_span TYPE datetime;
 DEFINE INDEX IF NOT EXISTS otel_span_session ON otel_span FIELDS session_id;
 
+DEFINE TABLE otel_log_event SCHEMAFULL;
+DEFINE FIELD harness          ON otel_log_event TYPE string;
+DEFINE FIELD event_name       ON otel_log_event TYPE string;
+DEFINE FIELD session_id       ON otel_log_event TYPE option<string>;
+DEFINE FIELD model            ON otel_log_event TYPE option<string>;
+DEFINE FIELD input_tokens     ON otel_log_event TYPE option<number>;
+DEFINE FIELD output_tokens    ON otel_log_event TYPE option<number>;
+DEFINE FIELD reasoning_tokens ON otel_log_event TYPE option<number>;
+DEFINE FIELD cached_tokens    ON otel_log_event TYPE option<number>;
+DEFINE FIELD tool_tokens      ON otel_log_event TYPE option<number>;
+DEFINE FIELD duration_ms      ON otel_log_event TYPE option<number>;
+DEFINE FIELD status_code      ON otel_log_event TYPE option<number>;
+DEFINE FIELD attrs            ON otel_log_event TYPE option<string>;
+DEFINE FIELD observed_at      ON otel_log_event TYPE datetime;
+DEFINE INDEX IF NOT EXISTS otel_log_event_session ON otel_log_event FIELDS session_id;
+
 -- ---------------------------------------------------------------------------
 -- wrapped_card - agent-authored Wrapped recap cards (improve-first dashboard
 -- PR4). `ax wrapped generate` emits a brief; an agent mines the graph and


### PR DESCRIPTION
## Summary

Follow-up to #423/#426. Implements the previously-no-op `POST /v1/logs` so ax ingests OTLP **log events** — unblocking **Codex** dogfood data. Codex emits OTLP *logs* (events), not spans, so nothing it produced landed before this.

- **New `otel_log_event` table** with typed token columns (input/output/reasoning/cached/tool) + duration_ms/status_code + attrs JSON.
- **Curated allowlist** keeps signal events (codex: `sse_event` [carries token usage], `api_request`, `user_prompt`, `turn_ttft`, `conversation_starts`; claude: `tool_decision`, `skill_activated`, `user_prompt`, `api_error`) and drops Codex transport noise (websocket/sse-non-usage).
- **Per-harness normalize**: `service.name` `codex_exec`/`codex*` → codex; session key = **`conversation.id`** ?? `session.id`; timestamp from `event.timestamp` attr; token counts → typed columns.
- **`/v1/logs` handler** decodes→normalizes→writes (same fail-open as metrics/traces).
- **Correlation** extended to `otel_log_event` (`session -> telemetry_of -> otel_log_event`).

New code in `apps/axctl/src/otel/`. Spec/plan in docs/superpowers/. Real fixture: `apps/axctl/src/otel/__fixtures__/codex-logs.json`.

## Test plan

- [x] TDD per task; full repo suite **4281 pass / 0 fail**, typecheck exit 0.
- [x] **Live smoke**: POSTed real codex fixture to `/v1/logs` → ack → 3 rows (websocket_event dropped); sse_event row `input_tokens=9994`, `model=gpt-5.5`, session=`conversation.id`.

## Notes / follow-ups
- CC events need `OTEL_LOGS_EXPORTER=otlp` in install to flow (allowlist wired, untested live).
- Correlation key: codex session_id=`conversation.id`; if ax codex sessions don't key by that, log rows stay standalone (best-effort, no risk).
- Cost USD from codex tokens → ax cost analytics: follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)