### PR TITLE
fix(db): keep ax serve SurrealDB connection authenticated (#431)

### DIFF
--- a/packages/lib/src/db-auth.test.ts
+++ b/packages/lib/src/db-auth.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Redacted } from "effect";
+import type { ConnectOptions } from "surrealdb";
+import { acquire, connectOptions, type DbConfig, type SurrealLike } from "./db.ts";
+
+const cfg: DbConfig = {
+    url: "ws://127.0.0.1:8521",
+    ns: "ax",
+    db: "main",
+    user: "root",
+    pass: Redacted.make("s3cret"),
+};
+
+describe("connectOptions (regression for #431 - daemon loses auth mid-session)", () => {
+    test("supplies credentials as the connect-time auth provider", () => {
+        const opts = connectOptions(cfg);
+        // Auth MUST ride on connect() (the SDK auth *provider*) rather than a
+        // post-connect signin(). The provider is what the SDK replays on every
+        // reconnect AND on the token-expiry renewal timer; a post-hoc signin()
+        // sets authOverriden=true and disables that path, so once the root JWT
+        // expires the session silently degrades to anonymous.
+        expect(opts.authentication).toEqual({ username: "root", password: "s3cret" });
+    });
+
+    test("selects ns/db on connect so they replay on reconnect", () => {
+        const opts = connectOptions(cfg);
+        expect(opts.namespace).toBe("ax");
+        expect(opts.database).toBe("main");
+    });
+
+    test("keeps WS auto-reconnect enabled", () => {
+        expect(connectOptions(cfg).reconnect).toBe(true);
+    });
+});
+
+describe("acquire wiring", () => {
+    test("hands the credential-bearing options to connect() and never calls a bare signin", async () => {
+        let connectUrl: string | undefined;
+        let connectOpts: ConnectOptions | undefined;
+        const calls: string[] = [];
+
+        const fake: SurrealLike & { signin?: unknown; use?: unknown } = {
+            connect: async (url: string, options?: ConnectOptions) => {
+                calls.push("connect");
+                connectUrl = url;
+                connectOpts = options;
+                return undefined;
+            },
+            close: async () => {
+                calls.push("close");
+                return undefined;
+            },
+            // Tripwires: the old buggy path called these post-connect.
+            signin: () => {
+                calls.push("signin");
+            },
+            use: () => {
+                calls.push("use");
+            },
+        };
+
+        const db = await Effect.runPromise(acquire(cfg, () => fake));
+        expect(db).toBe(fake as unknown as typeof db);
+        expect(connectUrl).toBe("ws://127.0.0.1:8521");
+        expect(connectOpts?.authentication).toEqual({ username: "root", password: "s3cret" });
+        // The fix routes auth through connect; no separate signin()/use() that
+        // would mark the session authOverriden and break renewal.
+        expect(calls).toEqual(["connect"]);
+    });
+});

--- a/packages/lib/src/db.ts
+++ b/packages/lib/src/db.ts
@@ -3,6 +3,7 @@ import {
     RecordId,
     surql,
     type AnyRecordId,
+    type ConnectOptions,
     type Table,
 } from "surrealdb";
 import { Config, ConfigProvider, Context, Effect, Layer, Option, Redacted, Schedule } from "effect";
@@ -159,14 +160,67 @@ const connectError = (url: string, reason: string): DbError =>
         message: `daemon not reachable at ${url} (${reason}); recover with 'axctl daemon start' (or 'axctl daemon restart'); 'axctl doctor' shows where it stalled`,
     });
 
-const acquire = (cfg: DbConfig): Effect.Effect<Surreal, DbError> =>
+/**
+ * Build the {@link ConnectOptions} for a long-lived SurrealDB connection.
+ *
+ * Critically, credentials + ns/db are passed to `connect()` rather than applied
+ * after the fact via `signin()`/`use()`. This is what keeps a long-running
+ * daemon connection authenticated across the connection's whole life:
+ *
+ *  - The SDK stores `authentication` as its internal auth *provider*. On every
+ *    (re)connect AND on the token-expiry renewal timer it replays the provider
+ *    (`#applyAuthProvider` -> `signin(..., skipOverride=true)`), so the session
+ *    is re-signed-in instead of silently falling back to anonymous.
+ *  - `namespace`/`database` are stored on the root session and replayed via
+ *    `use()` on every reconnect (`#restoreSession`).
+ *
+ * By contrast, calling the public `db.signin()` sets `authOverriden = true`,
+ * which *disables* the auth provider on renewal. The root JWT issued by signin
+ * has a finite TTL and no refresh token, so once it expires the SDK's renewal
+ * logic finds nothing to renew with and invalidates the session -> every
+ * subsequent query returns "Anonymous access not allowed". That is the
+ * recurring `ax serve` auth-loss bug (#431); routing auth through `connect()`
+ * fixes it for both the reconnect and the token-expiry path.
+ *
+ * Exported for hermetic unit tests (assert credentials are wired so the SDK's
+ * re-auth path stays live).
+ */
+export const connectOptions = (cfg: DbConfig): ConnectOptions => ({
+    namespace: cfg.ns,
+    database: cfg.db,
+    authentication: {
+        username: cfg.user,
+        password: Redacted.value(cfg.pass),
+    },
+    // Explicit even though the SDK default is true: the WS engine must
+    // auto-reconnect a dropped daemon connection, and on reconnect the auth
+    // provider above re-signs-in (see #restoreSession / #applyAuthentication).
+    reconnect: true,
+});
+
+/** Minimal slice of the Surreal client `acquire` depends on. Lets tests inject
+ *  a fake that records the connect options without a live daemon. */
+export interface SurrealLike {
+    connect(url: string, options?: ConnectOptions): Promise<unknown>;
+    close(): Promise<unknown>;
+}
+
+/** Factory for the underlying client. Overridable in tests. */
+export type SurrealFactory = () => SurrealLike;
+
+const defaultSurrealFactory: SurrealFactory = () => new Surreal();
+
+export const acquire = (
+    cfg: DbConfig,
+    createClient: SurrealFactory = defaultSurrealFactory,
+): Effect.Effect<Surreal, DbError> =>
     Effect.tryPromise({
         try: async () => {
-            const db = new Surreal();
-            await db.connect(cfg.url);
-            await db.signin({ username: cfg.user, password: Redacted.value(cfg.pass) });
-            await db.use({ namespace: cfg.ns, database: cfg.db });
-            return db;
+            const db = createClient();
+            // Auth + ns/db travel with connect() so the SDK re-applies them on
+            // every reconnect and token renewal (see connectOptions docs).
+            await db.connect(cfg.url, connectOptions(cfg));
+            return db as Surreal;
         },
         catch: (err) => connectError(cfg.url, errorMessage(err)),
     }).pipe(


### PR DESCRIPTION
## Issue
Fixes #431. The `ax serve` daemon recurrently loses its SurrealDB auth mid-session: after the daemon runs a while, DB-backed endpoints return HTTP 500 with `{"error":"Anonymous access not allowed: Not enough permissions to perform this action"}`, while `/api/version` (no DB hit) keeps returning 200. Killing + restarting the daemon fixes it temporarily.

## Root cause
`acquire()` in `packages/lib/src/db.ts` connected with a bare `db.connect(url)` and then applied auth via the public `db.signin({username,password})` + `db.use()`.

In the `surrealdb@2.0.3` JS SDK, calling the **public** `signin()` sets the session's `authOverriden = true`, which **disables the SDK's auth provider on renewal**. The root JWT issued by signin has a finite TTL and **no refresh token**. So when the SDK's token-expiry renewal timer (`#applyAuthentication`) fires it finds:

1. access token expired (`exp - now <= 60`) -> can't re-`authenticate` with it,
2. no refresh token -> can't `refresh`,
3. auth provider suppressed (`authOverriden === true`) -> can't re-`signin`,

and falls through to `#abortAuthentication` -> `invalidate()`. The connection is now **anonymous**, so every subsequent query returns "Anonymous access not allowed". The same dead-end is hit on a WebSocket reconnect once the token has expired (`#onConnected` -> `#restoreSession` -> `#applyAuthentication`).

This is why `/api/version` stayed healthy (no DB) and a restart "fixed" it (fresh signin, fresh token).

## Fix
Pass credentials + ns/db to `connect()` via `ConnectOptions` (`authentication`, `namespace`, `database`, `reconnect: true`) and drop the post-connect `signin()`/`use()`.

The SDK stores `authentication` as its internal auth **provider** (so `authOverriden` stays `false`) and replays it on **every (re)connect AND on the token-expiry renewal timer** via `#restoreSession` -> `#applyAuthProvider` -> `signin(..., skipOverride=true)`. `connect()` resolves only after `#onConnected` has re-applied auth, so the first query never races the signin. `namespace`/`database` are likewise stored on the root session and replayed on reconnect.

## Changes
- `packages/lib/src/db.ts`
  - `connectOptions(cfg)` — exported, pure, unit-testable builder of the credential-bearing `ConnectOptions`.
  - `acquire(cfg, createClient?)` — exported with an injectable client factory; now does a single `db.connect(url, connectOptions(cfg))`.
  - extensive comment documenting the SDK renewal/reconnect mechanics so this isn't re-broken.
- `packages/lib/src/db-auth.test.ts` (new) — regression tests: auth rides `connect()` (not a post-hoc `signin()` that would set `authOverriden`), ns/db are selected on connect, reconnect stays enabled, and `acquire` calls only `connect` (no bare `signin`/`use` tripwires).

## Verification
- `bun run typecheck` — clean (only pre-existing warnings/messages; no errors).
- `bun test packages/lib/src/db-auth.test.ts packages/lib/src/db-config.test.ts` — 6 pass / 0 fail.
- `bun run build` — compiles `dist/axctl` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)