### PR TITLE
fix(studio): dark-bridge remaining light-era route stragglers

### DIFF
--- a/apps/studio/src/routes/improve.tsx
+++ b/apps/studio/src/routes/improve.tsx
@@ -239,7 +239,7 @@ export function ImproveRoute() {
                                     onClick={() => setSelectedSig(p.dedupe_sig)}
                                     style={{
                                         cursor: "pointer",
-                                        background: selected?.dedupe_sig === p.dedupe_sig ? "rgba(0,0,0,0.05)" : undefined,
+                                        background: selected?.dedupe_sig === p.dedupe_sig ? "var(--track)" : undefined,
                                     }}
                                 >
                                     <td style={{ textAlign: "right" }}>{p.frequency}</td>

--- a/apps/studio/src/routes/review-view.tsx
+++ b/apps/studio/src/routes/review-view.tsx
@@ -112,7 +112,7 @@ function HunkCard({ event, path, label, onOpenTranscript, onFocusTurn }: {
                     <FileDiff
                         fileDiff={fileDiff}
                         options={{
-                            themeType: "light",
+                            themeType: "dark",
                             theme: { light: "github-light", dark: "pierre-dark" },
                             diffStyle: "unified",
                             overflow: "wrap",

--- a/apps/studio/src/routes/sessions-compare.tsx
+++ b/apps/studio/src/routes/sessions-compare.tsx
@@ -180,7 +180,7 @@ export function SessionsCompareRoute() {
                                                 <div
                                                     key={ti}
                                                     className={`turn-cell${t.has_error ? " err" : ""}`}
-                                                    style={{ background: `rgba(56, 189, 248, ${intensity})` }}
+                                                    style={{ background: `color-mix(in srgb, var(--blue) ${(intensity * 100).toFixed(1)}%, transparent)` }}
                                                     title={`turn ${t.seq} · ${t.role ?? "?"} · ${fmtTokens(t.est_tokens)} tok${t.gap_ms != null ? ` · gap ${Math.round(t.gap_ms / 1000)}s` : ""}${t.has_error ? " · ERROR" : ""}`}
                                                 >
                                                     {fmtTokens(t.est_tokens)}

--- a/apps/studio/src/routes/share-inspect.tsx
+++ b/apps/studio/src/routes/share-inspect.tsx
@@ -956,12 +956,13 @@ const VIEW_TOGGLE_BUTTON_STYLE: CSSProperties = {
  *  hook_fire markers (both use `hook-<n>` ids for the shared jump). */
 const HARNESS_HOOK_IDX_BASE = 1_000_000;
 
-const harnessTone = (accent: string): { bg: string; fg: string; bar: string } => ({
+const harnessTone = (accent: string): { bg: string; fg: string; bar: string; chip: string } => ({
     bg: `color-mix(in srgb, ${accent} 8%, var(--panel))`,
     fg: `color-mix(in srgb, ${accent} 45%, var(--ink))`,
     bar: accent,
+    chip: `color-mix(in srgb, ${accent} 24%, var(--panel))`,
 });
-const HARNESS_EFFECT_TONE: Record<string, { bg: string; fg: string; bar: string }> = {
+const HARNESS_EFFECT_TONE: Record<string, { bg: string; fg: string; bar: string; chip: string }> = {
     blocked: harnessTone("var(--red)"),
     modified_input: harnessTone("var(--gold)"),
     injected_context: harnessTone("var(--green)"),
@@ -972,7 +973,7 @@ const HARNESS_EFFECT_TONE: Record<string, { bg: string; fg: string; bar: string 
  *  injected). Shows the guardrail activity inline in the shared transcript. */
 function HarnessHookMarker(props: { readonly hook: ShareHarnessHookView }) {
     const { hook } = props;
-    const tone = HARNESS_EFFECT_TONE[hook.effect] ?? { bg: "var(--page)", fg: "var(--ink)", bar: "var(--muted-2)" };
+    const tone = HARNESS_EFFECT_TONE[hook.effect] ?? { bg: "var(--page)", fg: "var(--ink)", bar: "var(--muted-2)", chip: "var(--track)" };
     return (
         <div
             id={`hook-${HARNESS_HOOK_IDX_BASE + hook.idx}`}
@@ -985,7 +986,7 @@ function HarnessHookMarker(props: { readonly hook: ShareHarnessHookView }) {
             <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
                 <span style={{ fontWeight: 700 }}>⚙ hook</span>
                 <span style={{ fontWeight: 600 }}>{hook.hook_name}</span>
-                <span style={{ background: tone.bar, color: "#fff", padding: "0 6px", borderRadius: 2, fontSize: 10, fontWeight: 600 }}>
+                <span style={{ background: tone.chip, color: tone.fg, padding: "0 6px", borderRadius: 2, fontSize: 10, fontWeight: 600 }}>
                     {hook.effect.replace(/_/g, " ")}
                 </span>
                 {hook.command ? <span style={{ opacity: 0.7 }}>{hook.command}</span> : null}

--- a/apps/studio/src/routes/tools.tsx
+++ b/apps/studio/src/routes/tools.tsx
@@ -277,7 +277,7 @@ function FailureDetail({
                                 </pre>
                             ) : null}
                             {s.error_text ? (
-                                <pre style={{ margin: "4px 0", padding: "6px 8px", background: "rgba(189, 68, 59, 0.07)", color: "var(--red)", overflowX: "auto" }}>
+                                <pre style={{ margin: "4px 0", padding: "6px 8px", background: "color-mix(in srgb, var(--red) 7%, transparent)", color: "var(--red)", overflowX: "auto" }}>
                                     {truncate(s.error_text, 320)}
                                 </pre>
                             ) : null}

--- a/apps/studio/src/routes/usage.tsx
+++ b/apps/studio/src/routes/usage.tsx
@@ -58,10 +58,10 @@ export function UsageRoute() {
                                     <td style={{ padding: "3px 8px 3px 0", fontFamily: "monospace" }}>
                                         ax {cmd.command}
                                     </td>
-                                    <td style={{ padding: "3px 8px", color: "var(--color-meta, #888)" }}>
+                                    <td style={{ padding: "3px 8px", color: "var(--muted)" }}>
                                         {cmd.count}×
                                     </td>
-                                    <td style={{ padding: "3px 0", color: "var(--color-meta, #888)", fontSize: "0.85em" }}>
+                                    <td style={{ padding: "3px 0", color: "var(--muted)", fontSize: "0.85em" }}>
                                         last {new Date(cmd.last_used).toLocaleDateString()}
                                     </td>
                                 </tr>
@@ -82,7 +82,7 @@ export function UsageRoute() {
                                 key={cmd}
                                 style={{
                                     padding: "2px 8px",
-                                    background: "var(--color-bg-alt, rgba(0,0,0,0.06))",
+                                    background: "var(--track)",
                                     borderRadius: "4px",
                                     fontSize: "0.85em",
                                 }}
@@ -106,10 +106,10 @@ export function UsageRoute() {
                                     <td style={{ padding: "3px 8px 3px 0", fontFamily: "monospace" }}>
                                         ax {r.command}
                                     </td>
-                                    <td style={{ padding: "3px 8px", color: "var(--color-meta, #888)" }}>
+                                    <td style={{ padding: "3px 8px", color: "var(--muted)" }}>
                                         {r.failures}/{r.runs} failed
                                     </td>
-                                    <td style={{ padding: "3px 0", color: "var(--color-meta, #888)", fontSize: "0.85em" }}>
+                                    <td style={{ padding: "3px 0", color: "var(--muted)", fontSize: "0.85em" }}>
                                         {(r.failureRate * 100).toFixed(0)}%
                                     </td>
                                 </tr>

--- a/apps/studio/src/routes/workflow.tsx
+++ b/apps/studio/src/routes/workflow.tsx
@@ -58,10 +58,10 @@ function buildMatrix(
 }
 
 const intensity = (count: number, max: number): string => {
-    if (count === 0 || max === 0) return "rgba(37, 103, 168, 0)";
+    if (count === 0 || max === 0) return "transparent";
     const ratio = Math.min(1, Math.log10(count + 1) / Math.log10(max + 1));
     const alpha = 0.08 + 0.7 * ratio;
-    return `rgba(37, 103, 168, ${alpha.toFixed(3)})`;
+    return `color-mix(in srgb, var(--blue) ${(alpha * 100).toFixed(1)}%, transparent)`;
 };
 
 const jaccardWidth = (point: WorkflowConvergencePoint): number => {


### PR DESCRIPTION
Continues PR #433 (session detail / transcript inspector). Audited the whole studio app for components authored before the dark fold-in that render as loud white boxes / near-invisible chips / dark-on-dark text inside the `.rdx[data-theme="dark"]` instrument shell. Replaced light literals, undefined-var light fallbacks, and a forced-light syntax-diff theme with the bridged instrument vars (`--track`, `--muted`, `var(--blue/--red)` via `color-mix`).

## Per-route fixes

| Route | Before | After |
|---|---|---|
| **review-view** | `FileDiff` `themeType: "light"` → bright github-light code box on dark shell | `themeType: "dark"` (pierre-dark) |
| **usage** | `var(--color-meta, #888)` (undefined var) text; "never used" chips `var(--color-bg-alt, rgba(0,0,0,0.06))` → near-invisible black-on-dark | `var(--muted)` text; chips `var(--track)` (now visible raised surface) |
| **improve** | selected proposal row `rgba(0,0,0,0.05)` → darkened instead of lifting on dark | `var(--track)` |
| **sessions-compare** | turn heatmap `rgba(56,189,248,a)` sky-blue; at high token counts light fill + `var(--ink)` light text = light-on-light invisible | `color-mix(in srgb, var(--blue) N%, transparent)` |
| **workflow** | convergence heatmap `rgba(37,103,168,a)` hardcoded blue | `color-mix(var(--blue) N%, transparent)` |
| **tools** | `error_text` `<pre>` `rgba(189,68,59,0.07)` hardcoded red tint | `color-mix(in srgb, var(--red) 7%, transparent)` |
| **share-inspect** (in-scope, not ShareChrome) | harness-hook effect pill `#fff` text on raw hue bar → low contrast on bright instrument gold/green | tinted chip (`color-mix` hue 24%) + hued-ink fg, matching the session-inspect spawn-chip recipe; `harnessTone` extended with a `chip` field |

The sessions-compare change fixed a genuine dark-mode legibility bug (`.turn-cell` text is `var(--ink)` = light on dark, but the cell bg was a light sky-blue at high intensity).

## Left as-is (intentional)
- **canvas + canvas-detail-\*** — self-contained dark navy palette (`#0a0d13` ground, `#cfe0ff` text). Already renders dark; not a light-era mismatch. The one `#fff` is a selection ring.
- **components/session-insight/\*** `--sx-*` ramp usage — already dark-bridged under `.rdx[data-theme="dark"]` in `instrument/instrument.css` (verified every token used is covered, amber→gold).
- **ShareChrome / share-footer** — excluded standalone surface per scope.
- **skills.tsx** `var(--rose, #b32650)` — `--rose` is bridged, fallback is dead code.
- All other listed routes (**lab, graph, project, episode, skill-graph, files-touched-panel, inspector-filter-bar, subagent-metrics**) grep clean — already on bridged vars.

## Verification
- `apps/studio bun run typecheck` → 0 `error TS`.
- Touched-file tests pass: 53/53 (`review-view.story`, `share-inspect`, `session-inspect`).
- Live captures at `1480×940` (`/usage`, `/improve`, `/tools`, `/workflow`, `/narration-demo`): dark surfaces, visible chips, bridged phase/heatmap hues, diff on dark ground, zero white boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)