### PR TITLE
feat: ax cost routability — main-thread routability lens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ docs/superpowers/specs/2026-06-15-otel-receiver-design.md.
 `ax cost models [--days=N]` - per-model rollup: sessions, prompt/completion/cache tokens, estimated cost USD (default 14d).
 `ax cost sessions [--days=N] [--model=<name>] [--limit=N]` - top sessions by cost with id, project, model, started_at (default 14d/20 rows).
 `ax cost split [--days=N]` - origin (main vs subagent) × model matrix with cost and share-of-total; totals row. MCP: `cost_models`, `cost_split`.
+`ax cost routability [--days=N] [--min-run=1] [--json]` - main-thread routability lens: of main-agent spend, how much sat in routable class-runs (gather→haiku, mechanical-impl/niche-research→sonnet) vs genuine judgment, with est savings repriced one tier down. Deterministic - turn-level classification from tool composition + `JUDGMENT_GUARD_RE` text guard (the `thinking_tokens` signal is dead - 0 on ~97% of turns - so it's dropped; `--min-run` groups consecutive same-class turns, default 1 since Claude turns rarely form longer same-class runs). Non-Claude main turns lack per-turn cost rows so main spend reads ~Claude-only. MCP: `cost_routability`. Spec: docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md.
 
 ### Plan quota
 
@@ -228,11 +229,11 @@ task file, then run `axctl improve lint` to reconcile.
 
 ## MCP server
 
-`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 16 tools
+`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 17 tools
 (`recall`, `sessions_around`, `session_show`, `skills_weighted`, `skills_by_role`,
 `skills_roles`, `roles`, `improve_recommend`, `improve_show`, `improve_list`,
-`session_metrics`, `signal_show`, `cost_models`, `cost_split`, `dispatches`,
-`dojo_agenda`) so an agent can query the graph in-context. Run from source (no
+`session_metrics`, `signal_show`, `cost_models`, `cost_split`, `cost_routability`,
+`dispatches`, `dojo_agenda`) so an agent can query the graph in-context. Run from source (no
 native deps, so the compiled binary should work too - untested in v0). Mutating
 ops + `sessions_here`/`near` (need a git-resolved repo key) are intentionally not
 exposed. Server: `apps/axctl/src/mcp/server.ts`; registry: `apps/axctl/src/mcp/tools.ts`.

--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -258,7 +258,9 @@ function renderRoutability(r: RoutabilityResult): string {
         }
     }
     out.push("");
-    out.push("estimate from historical token counts; judgment work left on frontier by design.");
+    out.push("estimate: edit/read turns are assumed mechanically routable; reasoning before an");
+    out.push("edit isn't visible in the transcript, so read this as an upper-ish bound, not ground");
+    out.push("truth. judgment-text turns stay on frontier by design. claude main-agent only.");
     out.push("next: ax dispatches --candidates   # the subagent-side leak");
     return out.join("\n");
 }

--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -13,6 +13,7 @@ import {
     fetchCostSessions,
     fetchCostSplit,
 } from "../../queries/cost-analytics.ts";
+import { fetchRoutability, type RoutabilityResult } from "../../queries/routability.ts";
 import {
     buildCostModelsNext,
     buildCostSplitNext,
@@ -240,6 +241,68 @@ const costSplitCommand = Command.make(
 );
 
 // ---------------------------------------------------------------------------
+// ax cost routability [--days=N] [--min-run=N] [--json]
+// ---------------------------------------------------------------------------
+
+function renderRoutability(r: RoutabilityResult): string {
+    const usdFmt = (n: number) => `$${n.toFixed(2)}`;
+    const out: string[] = [];
+    out.push(`main-agent spend: ${usdFmt(r.mainSpendUsd)}   routable: ${usdFmt(r.routableUsd)} (${r.routablePct.toFixed(0)}%)   est. savings: ${usdFmt(r.estSavingsUsd)}`);
+    out.push("");
+    out.push("class            runs   turns   main_cost    tier     repriced    est_savings");
+    for (const row of r.rows) {
+        if (row.verdict === "stays") {
+            out.push(`${"stays main".padEnd(15)} ${String(row.runs).padStart(5)}  ${String(row.turns).padStart(6)}  ${usdFmt(row.mainCostUsd).padStart(10)}   ${"-".padEnd(7)} ${"-".padStart(10)}  ${"-".padStart(11)}`);
+        } else {
+            out.push(`${row.class.padEnd(15)} ${String(row.runs).padStart(5)}  ${String(row.turns).padStart(6)}  ${usdFmt(row.mainCostUsd).padStart(10)}   ${(row.tier ?? "").padEnd(7)} ${usdFmt(row.repricedUsd ?? 0).padStart(10)}  ${usdFmt(row.estSavingsUsd ?? 0).padStart(11)}`);
+        }
+    }
+    out.push("");
+    out.push("estimate from historical token counts; judgment work left on frontier by design.");
+    out.push("next: ax dispatches --candidates   # the subagent-side leak");
+    return out.join("\n");
+}
+
+const cmdCostRoutability = (input: {
+    readonly days: number;
+    readonly minRun: number;
+    readonly json: boolean;
+}) =>
+    Effect.gen(function* () {
+        const result = yield* fetchRoutability({ days: input.days, minRun: input.minRun });
+
+        if (input.json) {
+            console.log(prettyPrint(result));
+            return;
+        }
+
+        console.log(renderRoutability(result));
+    });
+
+const costRoutabilityCommand = Command.make(
+    "routability",
+    {
+        days: Flag.integer("days").pipe(Flag.withDefault(30)),
+        minRun: Flag.integer("min-run").pipe(Flag.withDefault(1)),
+        json: jsonFlag,
+    },
+    ({ days, minRun, json }) => {
+        if (!Number.isInteger(days) || days <= 0) {
+            fail(`ax cost routability: --days must be a positive integer (got "${days}")`);
+        }
+        if (!Number.isInteger(minRun) || minRun <= 0) {
+            fail(`ax cost routability: --min-run must be a positive integer (got "${minRun}")`);
+        }
+        return cmdCostRoutability({ days, minRun, json });
+    },
+).pipe(
+    Command.withDescription(
+        "Estimate how much main-agent spend was routable to a cheaper subagent. " +
+        "--days=N (default 30)  --min-run=N (default 1)  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
 // ax cost (group command)
 // ---------------------------------------------------------------------------
 
@@ -251,6 +314,7 @@ export const costCommand = Command.make("cost").pipe(
         costModelsCommand,
         costSessionsCommand,
         costSplitCommand,
+        costRoutabilityCommand,
     ]),
 );
 

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_TOOLS = [
     "signal_show",
     "cost_models",
     "cost_split",
+    "cost_routability",
     "dispatches",
     "dojo_agenda",
 ] as const;
@@ -42,7 +43,7 @@ describe("axMcpTools registry", () => {
         expect(recall!.inputSchema).toHaveProperty("q");
     });
 
-    it("registers all 16 read-only tools, each well-formed", () => {
+    it("registers all 17 read-only tools, each well-formed", () => {
         expect(axMcpTools.map((t) => t.name).sort()).toEqual(
             [...EXPECTED_TOOLS].sort(),
         );

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -58,6 +58,7 @@ import {
     buildCostSplitNext,
 } from "../nav/next-links.ts";
 import { fetchCostModels, fetchCostSplit } from "../queries/cost-analytics.ts";
+import { fetchRoutability } from "../queries/routability.ts";
 import { fetchDispatches, fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
 import { loadEffectiveRoutingTable } from "../queries/routing-table-io.ts";
 import { buildDispatchesNext, buildCandidatesNext } from "../nav/next-links.ts";
@@ -541,6 +542,32 @@ const costSplitTool: AxMcpTool = {
     },
 };
 
+const costRoutabilityTool: AxMcpTool = {
+    name: "cost_routability",
+    description:
+        `Main-thread routability lens: of main-agent (non-subagent) spend, how much sat in routable class-runs (gather -> haiku, mechanical-impl / niche-research -> sonnet) vs genuine judgment, with estimated savings repriced one tier down. Deterministic (tool composition + JUDGMENT_GUARD_RE text guard); turn-level by default. Use to see how much main-thread work could have been a cheaper subagent. ${NEXT_PROTOCOL_HINT}`,
+    inputSchema: {
+        days: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Window in days (default 30)."),
+        min_run: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Min consecutive same-class turns for a span to count (default 1)."),
+    },
+    run: async (args, rt) => {
+        const days = typeof args.days === "number" ? args.days : 30;
+        const minRun = typeof args.min_run === "number" ? args.min_run : 1;
+        const result = await rt.runPromise(fetchRoutability({ days, minRun }));
+        return result;
+    },
+};
+
 const dispatchesTool: AxMcpTool = {
     name: "dispatches",
     description:
@@ -647,6 +674,7 @@ export const axMcpTools: ReadonlyArray<AxMcpTool> = [
     signalShowTool,
     costModelsTool,
     costSplitTool,
+    costRoutabilityTool,
     dispatchesTool,
     dojoAgendaTool,
 ];

--- a/apps/axctl/src/queries/dispatch-analytics.ts
+++ b/apps/axctl/src/queries/dispatch-analytics.ts
@@ -25,7 +25,8 @@ import {
     type RoutingTable,
 } from "@ax/hooks-sdk/routing-table";
 import { resolveDispatchModel } from "@ax/hooks-sdk/resolve-dispatch-model";
-import { estimateCost, type ModelPricing } from "../ingest/model-pricing.ts";
+import { type ModelPricing } from "../ingest/model-pricing.ts";
+import { MODEL_ALIASES, reprice as repriceUsage, type RepriceUsage } from "./reprice.ts";
 import {
     defaultRoutingTablePath,
     loadStoredRoutingTable,
@@ -45,12 +46,6 @@ export type { RoutingClass, RoutingTable, RoutingMatch };
  * DEFAULT_ROUTING_TABLE that the route-dispatch hook falls back to.
  */
 export const ROUTING_CLASSES: RoutingTable = DEFAULT_ROUTING_TABLE;
-
-// Model name resolution for repricing suggestions
-const MODEL_ALIASES: Record<string, string> = {
-    sonnet: "claude-sonnet-4-6",
-    haiku: "claude-haiku-4-5-20251001",
-};
 
 // Expensive model tiers (candidate filter)
 export const EXPENSIVE_TIER_RE = /fable|opus/i;
@@ -651,21 +646,11 @@ export const fetchDispatchCandidates = Effect.fn("queries.fetchDispatchCandidate
         }
 
         // Helper: reprice token buckets at a given model's rates. Delegates to
-        // the ingest's estimateCost - prompt_tokens here is TOTAL billed input
+        // the shared reprice utility - prompt_tokens here is TOTAL billed input
         // (fresh + both cache buckets), and estimateCost recovers fresh input
         // by subtracting the cache buckets before applying the input rate.
-        const reprice = (usage: UsageRow, targetModelName: string): number => {
-            const cost = estimateCost({
-                modelKey: targetModelName,
-                promptTokens: usage.prompt_tokens,
-                completionTokens: usage.completion_tokens,
-                cacheCreationInputTokens: usage.cache_create_tokens,
-                cacheReadInputTokens: usage.cache_read_tokens,
-                estimatedTokens: usage.prompt_tokens + usage.completion_tokens,
-                ...(pricingCatalog.size > 0 ? { pricingCatalog } : {}),
-            });
-            return cost.totalUsd ?? usage.cost_usd;
-        };
+        const reprice = (usage: UsageRow, targetModelName: string): number =>
+            repriceUsage(usage as RepriceUsage, targetModelName, pricingCatalog);
 
         const candidates: CandidateRow[] = [];
 
@@ -888,18 +873,8 @@ export const fetchDispatchEconomy = Effect.fn("queries.fetchDispatchEconomy")(
             });
         }
 
-        const reprice = (usage: UsageRow, targetModelName: string): number => {
-            const cost = estimateCost({
-                modelKey: targetModelName,
-                promptTokens: usage.prompt_tokens,
-                completionTokens: usage.completion_tokens,
-                cacheCreationInputTokens: usage.cache_create_tokens,
-                cacheReadInputTokens: usage.cache_read_tokens,
-                estimatedTokens: usage.prompt_tokens + usage.completion_tokens,
-                ...(pricingCatalog.size > 0 ? { pricingCatalog } : {}),
-            });
-            return cost.totalUsd ?? usage.cost_usd;
-        };
+        const reprice = (usage: UsageRow, targetModelName: string): number =>
+            repriceUsage(usage as RepriceUsage, targetModelName, pricingCatalog);
 
         // Per-class economy accumulators
         interface ClassAccumulator {

--- a/apps/axctl/src/queries/reprice.test.ts
+++ b/apps/axctl/src/queries/reprice.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { MODEL_ALIASES, reprice, type RepriceUsage } from "./reprice.ts";
+
+const usage: RepriceUsage = {
+    prompt_tokens: 1_000_000,
+    completion_tokens: 200_000,
+    cache_read_tokens: 0,
+    cache_create_tokens: 0,
+    cost_usd: 5,
+};
+
+describe("MODEL_ALIASES", () => {
+    it("resolves sonnet and haiku to full ids", () => {
+        expect(MODEL_ALIASES.sonnet).toBe("claude-sonnet-4-6");
+        expect(MODEL_ALIASES.haiku).toBe("claude-haiku-4-5-20251001");
+    });
+});
+
+describe("reprice", () => {
+    it("returns a positive cost cheaper than a frontier original for a known tier", () => {
+        const catalog = new Map([
+            ["claude-sonnet-4-6", {
+                provider: "anthropic",
+                inputPerMillionUsd: 3,
+                outputPerMillionUsd: 15,
+                cacheReadPerMillionUsd: 0.3,
+                cacheCreationPerMillionUsd: 3.75,
+                fastMultiplier: 1,
+                pricingSource: "test",
+            }],
+        ]);
+        const cost = reprice(usage, "claude-sonnet-4-6", catalog);
+        expect(cost).toBeGreaterThan(0);
+        expect(cost).toBeLessThan(20);
+    });
+
+    it("falls back to usage.cost_usd when the target model is unknown to the catalog", () => {
+        const cost = reprice(usage, "unknown-model", new Map());
+        expect(cost).toBe(5);
+    });
+});

--- a/apps/axctl/src/queries/reprice.ts
+++ b/apps/axctl/src/queries/reprice.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared repricing utility for dispatch analytics and cost-routability queries.
+ *
+ * Delegates to `estimateCost` from the ingest layer, which recovers fresh
+ * input tokens by subtracting the cache buckets before applying the input rate.
+ */
+import { estimateCost, type ModelPricing } from "../ingest/model-pricing.ts";
+
+export type { ModelPricing };
+
+/** Short aliases → canonical model ids used in repricing suggestions. */
+export const MODEL_ALIASES: Record<string, string> = {
+    sonnet: "claude-sonnet-4-6",
+    haiku: "claude-haiku-4-5-20251001",
+};
+
+/**
+ * Token usage fields needed for repricing. Structurally compatible with
+ * `UsageRow` in dispatch-analytics and with future cost-routability rows.
+ */
+export interface RepriceUsage {
+    readonly prompt_tokens: number;
+    readonly completion_tokens: number;
+    readonly cache_read_tokens: number;
+    readonly cache_create_tokens: number;
+    readonly cost_usd: number;
+}
+
+/**
+ * Reprice token buckets at a given model's rates.
+ *
+ * When `pricingCatalog` is non-empty it is forwarded to `estimateCost` so
+ * DB-loaded rates take priority over the built-in catalog. Falls back to
+ * `usage.cost_usd` when the target model is unknown to the catalog.
+ */
+export function reprice(
+    usage: RepriceUsage,
+    targetModelName: string,
+    pricingCatalog: ReadonlyMap<string, ModelPricing>,
+): number {
+    const cost = estimateCost({
+        modelKey: targetModelName,
+        promptTokens: usage.prompt_tokens,
+        completionTokens: usage.completion_tokens,
+        cacheCreationInputTokens: usage.cache_create_tokens,
+        cacheReadInputTokens: usage.cache_read_tokens,
+        estimatedTokens: usage.prompt_tokens + usage.completion_tokens,
+        ...(pricingCatalog.size > 0 ? { pricingCatalog } : {}),
+    });
+    return cost.totalUsd ?? usage.cost_usd;
+}

--- a/apps/axctl/src/queries/routability.test.ts
+++ b/apps/axctl/src/queries/routability.test.ts
@@ -21,11 +21,11 @@ describe("classifyTurn", () => {
   it("edit/bash dominant, low thinking -> mechanical-impl", () => {
     expect(classifyTurn({ ...base, toolNames: ["Edit", "Bash", "Edit", "Write"] }, false)).toBe("mechanical-impl");
   });
-  it("high thinking, no tools -> synthesis", () => {
-    expect(classifyTurn({ ...base, thinkingTokens: 4000, toolNames: [] }, false)).toBe("synthesis");
+  it("no tools, no text -> interactive (thinking signal dropped)", () => {
+    expect(classifyTurn({ ...base, thinkingTokens: 4000, toolNames: [] }, false)).toBe("interactive");
   });
-  it("high thinking + edits -> design-decision", () => {
-    expect(classifyTurn({ ...base, thinkingTokens: 4000, toolNames: ["Edit"] }, false)).toBe("design-decision");
+  it("edits with no judgment text -> mechanical-impl (thinking signal dropped)", () => {
+    expect(classifyTurn({ ...base, thinkingTokens: 4000, toolNames: ["Edit"] }, false)).toBe("mechanical-impl");
   });
   it("judgment text -> design-decision even with read tools", () => {
     expect(classifyTurn({ ...base, text: "Review the design of this module", toolNames: ["Read"] }, false)).toBe("design-decision");

--- a/apps/axctl/src/queries/routability.test.ts
+++ b/apps/axctl/src/queries/routability.test.ts
@@ -40,3 +40,58 @@ describe("classifyTurn", () => {
     expect(classifyTurn(base, false)).toBe("interactive");
   });
 });
+
+import { buildSpans } from "./routability.ts";
+import type { RepriceUsage } from "./reprice.ts";
+
+const u: RepriceUsage = {
+  prompt_tokens: 1000, completion_tokens: 100,
+  cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 1,
+};
+
+function turn(seq: number, role: string, tools: string[], extra: Partial<TurnFacts> = {}): TurnFacts {
+  return { seq, role, toolNames: tools, thinkingTokens: 0, intentKind: null, text: null, usage: u, ...extra };
+}
+
+describe("buildSpans", () => {
+  it("groups consecutive same-class assistant turns into one span", () => {
+    const turns = [
+      turn(1, "user", []),
+      turn(2, "assistant", ["Read", "Grep"]),
+      turn(3, "assistant", ["Read"]),
+      turn(4, "assistant", ["Read", "Glob"]),
+    ];
+    const spans = buildSpans(turns, 3);
+    // turn 2 is adjacentToUser -> interactive (own span); 3 & 4 -> gather run of 2
+    const gather = spans.find((s) => s.cls === "gather");
+    expect(gather?.turnCount).toBe(2);
+  });
+
+  it("a user turn breaks a run even when class would continue", () => {
+    const turns = [
+      turn(1, "user", []), turn(2, "assistant", ["Edit"]), turn(3, "assistant", ["Edit"]),
+      turn(4, "user", []), turn(5, "assistant", ["Edit"]), turn(6, "assistant", ["Edit"]),
+    ];
+    const mech = buildSpans(turns, 1).filter((s) => s.cls === "mechanical-impl");
+    expect(mech.length).toBe(2);
+  });
+
+  it("marks a routable span only when run length >= minRun", () => {
+    const turns = [
+      turn(1, "user", []),
+      turn(2, "assistant", ["Read"]), // interactive (adjacent)
+      turn(3, "assistant", ["Read"]), turn(4, "assistant", ["Read"]), turn(5, "assistant", ["Read"]), // gather run of 3
+    ];
+    expect(buildSpans(turns, 3).find((s) => s.cls === "gather")?.routable).toBe(true);
+    expect(buildSpans(turns, 4).find((s) => s.cls === "gather")?.routable).toBe(false);
+  });
+
+  it("sums usage across a span", () => {
+    const turns = [
+      turn(1, "user", []), turn(2, "assistant", ["Read"]),
+      turn(3, "assistant", ["Read"]), turn(4, "assistant", ["Read"]),
+    ];
+    const gather = buildSpans(turns, 1).find((s) => s.cls === "gather");
+    expect(gather?.usage.cost_usd).toBe(2); // turns 3 & 4 (turn 2 is interactive)
+  });
+});

--- a/apps/axctl/src/queries/routability.test.ts
+++ b/apps/axctl/src/queries/routability.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { classifyTurn, type TurnFacts } from "./routability.ts";
+
+const base: TurnFacts = {
+  seq: 1,
+  role: "assistant",
+  toolNames: [],
+  thinkingTokens: 0,
+  intentKind: null,
+  text: null,
+  usage: null,
+};
+
+describe("classifyTurn", () => {
+  it("read-only tools, no thinking -> gather", () => {
+    expect(classifyTurn({ ...base, toolNames: ["Read", "Grep", "Read", "Glob"] }, false)).toBe("gather");
+  });
+  it("web research + reads -> niche-research", () => {
+    expect(classifyTurn({ ...base, toolNames: ["WebFetch", "Read", "WebSearch"] }, false)).toBe("niche-research");
+  });
+  it("edit/bash dominant, low thinking -> mechanical-impl", () => {
+    expect(classifyTurn({ ...base, toolNames: ["Edit", "Bash", "Edit", "Write"] }, false)).toBe("mechanical-impl");
+  });
+  it("high thinking, no tools -> synthesis", () => {
+    expect(classifyTurn({ ...base, thinkingTokens: 4000, toolNames: [] }, false)).toBe("synthesis");
+  });
+  it("high thinking + edits -> design-decision", () => {
+    expect(classifyTurn({ ...base, thinkingTokens: 4000, toolNames: ["Edit"] }, false)).toBe("design-decision");
+  });
+  it("judgment text -> design-decision even with read tools", () => {
+    expect(classifyTurn({ ...base, text: "Review the design of this module", toolNames: ["Read"] }, false)).toBe("design-decision");
+  });
+  it("adjacent to a user turn -> interactive", () => {
+    expect(classifyTurn({ ...base, toolNames: ["Read", "Grep"] }, true)).toBe("interactive");
+  });
+  it("correction intent -> interactive", () => {
+    expect(classifyTurn({ ...base, intentKind: "correction", toolNames: ["Edit"] }, false)).toBe("interactive");
+  });
+  it("no signal -> interactive (conservative fallback)", () => {
+    expect(classifyTurn(base, false)).toBe("interactive");
+  });
+});

--- a/apps/axctl/src/queries/routability.test.ts
+++ b/apps/axctl/src/queries/routability.test.ts
@@ -41,7 +41,8 @@ describe("classifyTurn", () => {
   });
 });
 
-import { buildSpans } from "./routability.ts";
+import { buildSpans, aggregateRoutability, type Span } from "./routability.ts";
+import { MODEL_ALIASES, type ModelPricing } from "./reprice.ts";
 import type { RepriceUsage } from "./reprice.ts";
 
 const u: RepriceUsage = {
@@ -93,5 +94,57 @@ describe("buildSpans", () => {
     ];
     const gather = buildSpans(turns, 1).find((s) => s.cls === "gather");
     expect(gather?.usage.cost_usd).toBe(2); // turns 3 & 4 (turn 2 is interactive)
+  });
+});
+
+describe("aggregateRoutability", () => {
+  const catalog = new Map<string, ModelPricing>([
+    [MODEL_ALIASES.sonnet, { provider: "anthropic", inputPerMillionUsd: 3, outputPerMillionUsd: 15, cacheReadPerMillionUsd: 0.3, cacheCreationPerMillionUsd: 3.75, fastMultiplier: 1, pricingSource: "test" }],
+    [MODEL_ALIASES.haiku, { provider: "anthropic", inputPerMillionUsd: 0.8, outputPerMillionUsd: 4, cacheReadPerMillionUsd: 0.08, cacheCreationPerMillionUsd: 1, fastMultiplier: 1, pricingSource: "test" }],
+  ]);
+
+  const bigUsage: RepriceUsage = {
+    prompt_tokens: 2_000_000, completion_tokens: 400_000,
+    cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 50,
+  };
+
+  const spans: Span[] = [
+    { cls: "gather", turnCount: 5, usage: bigUsage, routable: true },
+    { cls: "mechanical-impl", turnCount: 4, usage: bigUsage, routable: true },
+    { cls: "synthesis", turnCount: 3, usage: bigUsage, routable: false },
+    { cls: "gather", turnCount: 2, usage: bigUsage, routable: false },
+  ];
+
+  it("rolls up routable spans by class with positive savings", () => {
+    const r = aggregateRoutability(spans, catalog, { days: 30, minRun: 3 });
+    const gather = r.rows.find((row) => row.class === "gather" && row.verdict === "routable");
+    expect(gather?.runs).toBe(1);
+    expect(gather?.tier).toBe("haiku");
+    expect(gather!.estSavingsUsd!).toBeGreaterThan(0);
+  });
+
+  it("aggregates everything else into a single 'stays main' rollup", () => {
+    const r = aggregateRoutability(spans, catalog, { days: 30, minRun: 3 });
+    const stays = r.rows.find((row) => row.verdict === "stays");
+    expect(stays).toBeDefined();
+    expect(stays!.mainCostUsd).toBe(100);
+  });
+
+  it("totals: routable + est savings + main spend + pct", () => {
+    const r = aggregateRoutability(spans, catalog, { days: 30, minRun: 3 });
+    expect(r.mainSpendUsd).toBe(200);
+    expect(r.routableUsd).toBe(100);
+    expect(r.routablePct).toBeCloseTo(50, 0);
+    expect(r.estSavingsUsd).toBeGreaterThan(0);
+  });
+
+  it("never reports negative savings (already-cheap span contributes 0)", () => {
+    const cheap: Span = {
+      cls: "gather", turnCount: 5,
+      usage: { prompt_tokens: 10, completion_tokens: 1, cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0.0001 },
+      routable: true,
+    };
+    const r = aggregateRoutability([cheap], catalog, { days: 30, minRun: 3 });
+    expect(r.estSavingsUsd).toBeGreaterThanOrEqual(0);
   });
 });

--- a/apps/axctl/src/queries/routability.ts
+++ b/apps/axctl/src/queries/routability.ts
@@ -340,10 +340,17 @@ export const fetchRoutability = Effect.fn("queries.fetchRoutability")(
             const sessionId = String(row.session_id ?? "");
             if (!turnId || !sessionId) continue;
 
+            const role = String(row.role ?? "");
             const usg = usageByTurn.get(turnId);
+            // Only Claude-main work enters grouping. Keep user turns (buildSpans
+            // splits class-runs at them) and any turn carrying a Claude usage row;
+            // drop assistant/tool_result turns with no Claude cost (non-Claude or
+            // cost-less) so they don't inflate the displayed run/turn counts.
+            if (role !== "user" && usg === undefined) continue;
+
             const tf: TurnFacts = {
                 seq: Number(row.seq ?? 0),
-                role: String(row.role ?? ""),
+                role,
                 toolNames: toolsByTurn.get(turnId) ?? [],
                 // thinking signal dropped (dead: 0 on ~97% of turns); field kept
                 // for test fixtures / future reasoning signal.

--- a/apps/axctl/src/queries/routability.ts
+++ b/apps/axctl/src/queries/routability.ts
@@ -4,6 +4,8 @@
  * Deterministic: tool composition (A) + thinking signal (B). No LLM.
  * Spec: docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md
  */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
 import { JUDGMENT_GUARD_RE } from "./routing-tune.ts";
 import { MODEL_ALIASES, reprice } from "./reprice.ts";
 import type { RepriceUsage, ModelPricing } from "./reprice.ts";
@@ -194,3 +196,194 @@ export function aggregateRoutability(
     estSavingsUsd, rows, days: input.days, minRun: input.minRun,
   };
 }
+
+// ---------------------------------------------------------------------------
+// DB fetch
+// ---------------------------------------------------------------------------
+
+const sinceDays = (d: number): number => Math.max(1, Math.trunc(d));
+
+/**
+ * All turns in the window (user + assistant). Ordered by (session, seq) so
+ * each session's slice is contiguous and seq-ordered when read sequentially.
+ * Uses text_excerpt (~500 chars) rather than full text - adequate for
+ * JUDGMENT_GUARD_RE pattern matching which targets first-sentence keywords.
+ */
+const TURNS_SQL = (days: number) => `
+SELECT
+    type::string(id) AS turn_id,
+    type::string(session) AS session_id,
+    seq,
+    role,
+    intent_kind,
+    text_excerpt AS text,
+    thinking_tokens
+FROM turn
+WHERE ts > time::now() - ${sinceDays(days)}d;
+`;
+
+/**
+ * Tool names per turn in the window. tool_call.turn is option<record<turn>>,
+ * so we filter NONE. No index on turn alone; the ts filter limits the scan
+ * to the same window as the turn query.
+ */
+const TOOL_CALLS_SQL = (days: number) => `
+SELECT
+    type::string(turn) AS turn_id,
+    name
+FROM tool_call
+WHERE ts > time::now() - ${sinceDays(days)}d
+  AND turn != NONE;
+`;
+
+/**
+ * Per-turn token usage. source distinguishes main ('claude-code' etc.) from
+ * subagent ('claude-subagent') at the session level - all rows for a subagent
+ * session carry source='claude-subagent'. Filtering happens in JS.
+ */
+const TURN_USAGE_SQL = (days: number) => `
+SELECT
+    type::string(turn) AS turn_id,
+    type::string(session) AS session_id,
+    source,
+    prompt_tokens,
+    completion_tokens,
+    cache_read_input_tokens,
+    cache_creation_input_tokens,
+    estimated_cost_usd
+FROM turn_token_usage
+WHERE ts > time::now() - ${sinceDays(days)}d;
+`;
+
+/** Pricing catalog - same query and field mapping as dispatch-analytics. */
+const AGENT_MODELS_SQL = `
+SELECT
+    name,
+    input_per_million_usd,
+    output_per_million_usd,
+    cache_read_per_million_usd,
+    cache_creation_per_million_usd
+FROM agent_model;
+`;
+
+/**
+ * Pull main-agent turns from SurrealDB, group into class-run spans per
+ * session, and return a RoutabilityResult. Mirrors fetchCostSplit in
+ * cost-analytics.ts: flat queries + JS join/aggregate, no GROUP BY derefs.
+ *
+ * Session classification: a session is a subagent session if ANY of its
+ * turn_token_usage rows have source='claude-subagent'; those sessions are
+ * excluded entirely. Sessions with no usage rows (e.g. purely user-turn
+ * stubs) are treated as main - they contribute zero cost and don't skew
+ * the result.
+ */
+export const fetchRoutability = Effect.fn("queries.fetchRoutability")(
+    function* (input: RoutabilityInput) {
+        const db = yield* SurrealClient;
+
+        const [turnRows, toolCallRows, usageRows, agentModelRows] = yield* db.query<[
+            Array<Record<string, unknown>>,
+            Array<Record<string, unknown>>,
+            Array<Record<string, unknown>>,
+            Array<Record<string, unknown>>,
+        ]>(
+            TURNS_SQL(input.days) +
+            TOOL_CALLS_SQL(input.days) +
+            TURN_USAGE_SQL(input.days) +
+            AGENT_MODELS_SQL,
+        );
+
+        // ---- tool names: turn_id → string[] --------------------------------
+        const toolsByTurn = new Map<string, string[]>();
+        for (const row of toolCallRows ?? []) {
+            const tid = String(row.turn_id ?? "");
+            if (!tid) continue;
+            const names = toolsByTurn.get(tid);
+            if (names) {
+                names.push(String(row.name ?? ""));
+            } else {
+                toolsByTurn.set(tid, [String(row.name ?? "")]);
+            }
+        }
+
+        // ---- usage map + subagent session classification ------------------
+        interface UsageData {
+            readonly prompt_tokens: number;
+            readonly completion_tokens: number;
+            readonly cache_read_tokens: number;
+            readonly cache_create_tokens: number;
+            readonly cost_usd: number;
+        }
+        const usageByTurn = new Map<string, UsageData>();
+        const subagentSessionIds = new Set<string>();
+
+        for (const row of usageRows ?? []) {
+            const tid = String(row.turn_id ?? "");
+            const sid = String(row.session_id ?? "");
+            if (!tid) continue;
+            if (String(row.source ?? "") === "claude-subagent") {
+                subagentSessionIds.add(sid);
+            }
+            usageByTurn.set(tid, {
+                prompt_tokens: Number(row.prompt_tokens ?? 0),
+                completion_tokens: Number(row.completion_tokens ?? 0),
+                cache_read_tokens: Number(row.cache_read_input_tokens ?? 0),
+                cache_create_tokens: Number(row.cache_creation_input_tokens ?? 0),
+                cost_usd: Number(row.estimated_cost_usd ?? 0),
+            });
+        }
+
+        // ---- group turns by session (main only), preserving DB seq order --
+        const turnsBySession = new Map<string, TurnFacts[]>();
+        for (const row of turnRows ?? []) {
+            const turnId = String(row.turn_id ?? "");
+            const sessionId = String(row.session_id ?? "");
+            if (!turnId || !sessionId) continue;
+            if (subagentSessionIds.has(sessionId)) continue;
+
+            const usg = usageByTurn.get(turnId);
+            const tf: TurnFacts = {
+                seq: Number(row.seq ?? 0),
+                role: String(row.role ?? ""),
+                toolNames: toolsByTurn.get(turnId) ?? [],
+                thinkingTokens: Number(row.thinking_tokens ?? 0),
+                intentKind: row.intent_kind == null ? null : String(row.intent_kind),
+                text: row.text == null ? null : String(row.text),
+                usage: usg ?? null,
+            };
+            const bucket = turnsBySession.get(sessionId);
+            if (bucket) {
+                bucket.push(tf);
+            } else {
+                turnsBySession.set(sessionId, [tf]);
+            }
+        }
+
+        // ---- pricing catalog: same field mapping as dispatch-analytics ----
+        const pricingCatalog = new Map<string, ModelPricing>();
+        for (const am of agentModelRows ?? []) {
+            if (am.name == null) continue;
+            pricingCatalog.set(String(am.name), {
+                provider: "anthropic",
+                inputPerMillionUsd: am.input_per_million_usd == null ? null : Number(am.input_per_million_usd),
+                outputPerMillionUsd: am.output_per_million_usd == null ? null : Number(am.output_per_million_usd),
+                cacheReadPerMillionUsd: am.cache_read_per_million_usd == null ? null : Number(am.cache_read_per_million_usd),
+                cacheCreationPerMillionUsd: am.cache_creation_per_million_usd == null ? null : Number(am.cache_creation_per_million_usd),
+                fastMultiplier: 1,
+                pricingSource: "agent_model",
+            });
+        }
+
+        // ---- build spans per session, concat, aggregate ------------------
+        const allSpans: Span[] = [];
+        for (const turns of turnsBySession.values()) {
+            // DB orders by (session, seq); sort defensively in case of ties.
+            turns.sort((a, b) => a.seq - b.seq);
+            for (const s of buildSpans(turns, input.minRun)) {
+                allSpans.push(s);
+            }
+        }
+
+        return aggregateRoutability(allSpans, pricingCatalog, input);
+    },
+);

--- a/apps/axctl/src/queries/routability.ts
+++ b/apps/axctl/src/queries/routability.ts
@@ -62,3 +62,60 @@ export function classifyTurn(t: TurnFacts, adjacentToUser: boolean): WorkClass {
 
     return "interactive";
 }
+
+export interface Span {
+  cls: WorkClass;
+  turnCount: number;
+  usage: RepriceUsage; // summed across the span's turns
+  routable: boolean; // cls is routable AND turnCount >= minRun
+}
+
+const ZERO_USAGE = (): RepriceUsage => ({
+  prompt_tokens: 0, completion_tokens: 0, cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0,
+});
+
+function addUsage(a: RepriceUsage, b: RepriceUsage | null): RepriceUsage {
+  if (!b) return a;
+  return {
+    prompt_tokens: a.prompt_tokens + b.prompt_tokens,
+    completion_tokens: a.completion_tokens + b.completion_tokens,
+    cache_read_tokens: a.cache_read_tokens + b.cache_read_tokens,
+    cache_create_tokens: a.cache_create_tokens + b.cache_create_tokens,
+    cost_usd: a.cost_usd + b.cost_usd,
+  };
+}
+
+/**
+ * Group ONE session's main-agent turns (seq order) into class-run spans.
+ * Splits at every user turn (judgment boundary); within a segment, groups
+ * consecutive assistant turns sharing a class. A turn neighbouring a user
+ * turn is forced to `interactive`. A span is routable iff its class is
+ * routable AND its run length >= minRun.
+ */
+export function buildSpans(turns: ReadonlyArray<TurnFacts>, minRun: number): Span[] {
+  const spans: Span[] = [];
+  let cur: { cls: WorkClass; turnCount: number; usage: RepriceUsage } | null = null;
+
+  const flush = () => {
+    if (!cur) return;
+    const tier = ROUTABLE_TIER[cur.cls];
+    spans.push({ cls: cur.cls, turnCount: cur.turnCount, usage: cur.usage, routable: tier !== undefined && cur.turnCount >= minRun });
+    cur = null;
+  };
+
+  for (let i = 0; i < turns.length; i++) {
+    const t = turns[i];
+    if (t.role !== "assistant") { flush(); continue; }
+    const prevIsUser = i > 0 && turns[i - 1].role === "user";
+    const cls = classifyTurn(t, prevIsUser);
+    if (cur && cur.cls === cls) {
+      cur.turnCount += 1;
+      cur.usage = addUsage(cur.usage, t.usage);
+    } else {
+      flush();
+      cur = { cls, turnCount: 1, usage: addUsage(ZERO_USAGE(), t.usage) };
+    }
+  }
+  flush();
+  return spans;
+}

--- a/apps/axctl/src/queries/routability.ts
+++ b/apps/axctl/src/queries/routability.ts
@@ -218,8 +218,7 @@ SELECT
     seq,
     role,
     intent_kind,
-    text_excerpt AS text,
-    thinking_tokens
+    text_excerpt AS text
 FROM turn
 WHERE ts > time::now() - ${sinceDays(days)}d;
 `;
@@ -239,22 +238,24 @@ WHERE ts > time::now() - ${sinceDays(days)}d
 `;
 
 /**
- * Per-turn token usage. source distinguishes main ('claude-code' etc.) from
- * subagent ('claude-subagent') at the session level - all rows for a subagent
- * session carry source='claude-subagent'. Filtering happens in JS.
+ * Per-turn token usage for Claude MAIN-agent turns only. Positive allowlist
+ * (source = 'claude') rather than a denylist: claude-subagent is a distinct
+ * source value (excluded), and non-Claude providers carry their own source
+ * (codex/opencode/cursor/pi) WITH real estimated_cost_usd - including them
+ * would pollute the Claude-main denominator and make the routability framing
+ * false. So we admit only Claude main turns here.
  */
 const TURN_USAGE_SQL = (days: number) => `
 SELECT
     type::string(turn) AS turn_id,
-    type::string(session) AS session_id,
-    source,
     prompt_tokens,
     completion_tokens,
     cache_read_input_tokens,
     cache_creation_input_tokens,
     estimated_cost_usd
 FROM turn_token_usage
-WHERE ts > time::now() - ${sinceDays(days)}d;
+WHERE ts > time::now() - ${sinceDays(days)}d
+  AND source = 'claude';
 `;
 
 /** Pricing catalog - same query and field mapping as dispatch-analytics. */
@@ -269,15 +270,15 @@ FROM agent_model;
 `;
 
 /**
- * Pull main-agent turns from SurrealDB, group into class-run spans per
+ * Pull Claude main-agent turns from SurrealDB, group into class-run spans per
  * session, and return a RoutabilityResult. Mirrors fetchCostSplit in
  * cost-analytics.ts: flat queries + JS join/aggregate, no GROUP BY derefs.
  *
- * Session classification: a session is a subagent session if ANY of its
- * turn_token_usage rows have source='claude-subagent'; those sessions are
- * excluded entirely. Sessions with no usage rows (e.g. purely user-turn
- * stubs) are treated as main - they contribute zero cost and don't skew
- * the result.
+ * Main-agent scoping: TURN_USAGE_SQL allowlists source='claude' (Claude
+ * main-agent cost only). claude-subagent and non-Claude providers
+ * (codex/opencode/cursor/pi) carry distinct source values and are excluded
+ * from the cost denominator - their turns may still appear in the grouping
+ * but contribute $0, so they never enter the routable totals.
  */
 export const fetchRoutability = Effect.fn("queries.fetchRoutability")(
     function* (input: RoutabilityInput) {
@@ -308,7 +309,7 @@ export const fetchRoutability = Effect.fn("queries.fetchRoutability")(
             }
         }
 
-        // ---- usage map + subagent session classification ------------------
+        // ---- usage map (Claude main turns only; allowlisted in TURN_USAGE_SQL)
         interface UsageData {
             readonly prompt_tokens: number;
             readonly completion_tokens: number;
@@ -317,15 +318,10 @@ export const fetchRoutability = Effect.fn("queries.fetchRoutability")(
             readonly cost_usd: number;
         }
         const usageByTurn = new Map<string, UsageData>();
-        const subagentSessionIds = new Set<string>();
 
         for (const row of usageRows ?? []) {
             const tid = String(row.turn_id ?? "");
-            const sid = String(row.session_id ?? "");
             if (!tid) continue;
-            if (String(row.source ?? "") === "claude-subagent") {
-                subagentSessionIds.add(sid);
-            }
             usageByTurn.set(tid, {
                 prompt_tokens: Number(row.prompt_tokens ?? 0),
                 completion_tokens: Number(row.completion_tokens ?? 0),
@@ -335,20 +331,23 @@ export const fetchRoutability = Effect.fn("queries.fetchRoutability")(
             });
         }
 
-        // ---- group turns by session (main only), preserving DB seq order --
+        // ---- group turns by session, preserving DB seq order -------------
+        // Non-Claude / subagent turns have no usage row (claude-only allowlist)
+        // so they contribute $0 cost; they never enter the routable denominator.
         const turnsBySession = new Map<string, TurnFacts[]>();
         for (const row of turnRows ?? []) {
             const turnId = String(row.turn_id ?? "");
             const sessionId = String(row.session_id ?? "");
             if (!turnId || !sessionId) continue;
-            if (subagentSessionIds.has(sessionId)) continue;
 
             const usg = usageByTurn.get(turnId);
             const tf: TurnFacts = {
                 seq: Number(row.seq ?? 0),
                 role: String(row.role ?? ""),
                 toolNames: toolsByTurn.get(turnId) ?? [],
-                thinkingTokens: Number(row.thinking_tokens ?? 0),
+                // thinking signal dropped (dead: 0 on ~97% of turns); field kept
+                // for test fixtures / future reasoning signal.
+                thinkingTokens: 0,
                 intentKind: row.intent_kind == null ? null : String(row.intent_kind),
                 text: row.text == null ? null : String(row.text),
                 usage: usg ?? null,

--- a/apps/axctl/src/queries/routability.ts
+++ b/apps/axctl/src/queries/routability.ts
@@ -35,7 +35,6 @@ export interface TurnFacts {
     usage: RepriceUsage | null;
 }
 
-export const THINK_HI = 1500; // output tokens of thinking that marks "reasoning"
 const READ_TOOLS = new Set(["Read", "Grep", "Glob", "LS"]);
 const RESEARCH_TOOLS = new Set(["WebFetch", "WebSearch"]);
 const EDIT_TOOLS = new Set(["Edit", "Write", "NotebookEdit", "Bash"]);
@@ -45,19 +44,22 @@ const INTERACTIVE_INTENTS = new Set(["correction", "preference", "wrapper_instru
  * Assign one work-class to a main-agent turn. Judgment-first precedence so
  * review/design/interactive can never be classed routable. `adjacentToUser`
  * is computed by buildSpans (turn neighbours a user turn).
+ *
+ * Turn-level tool composition only - the `thinking_tokens` signal was dropped
+ * after calibration showed it is 0 on 96.6% of main assistant turns (mixed
+ * turns report 0 = lower bound; transcripts strip thinking text), so no
+ * threshold separated design work from routine edits. Judgment is now caught
+ * solely via JUDGMENT_GUARD_RE on the turn text plus the interactive guards.
  */
 export function classifyTurn(t: TurnFacts, adjacentToUser: boolean): WorkClass {
     if (adjacentToUser) return "interactive";
     if (t.intentKind && INTERACTIVE_INTENTS.has(t.intentKind)) return "interactive";
 
-    const hasEdit = t.toolNames.some((n) => EDIT_TOOLS.has(n));
     const editCount = t.toolNames.filter((n) => EDIT_TOOLS.has(n)).length;
     const readCount = t.toolNames.filter((n) => READ_TOOLS.has(n)).length;
     const researchCount = t.toolNames.filter((n) => RESEARCH_TOOLS.has(n)).length;
 
     if (t.text && JUDGMENT_GUARD_RE.test(t.text)) return "design-decision";
-    if (t.thinkingTokens >= THINK_HI && hasEdit) return "design-decision";
-    if (t.thinkingTokens >= THINK_HI && t.toolNames.length <= 1) return "synthesis";
 
     if (editCount > 0 && editCount >= readCount && editCount >= researchCount) return "mechanical-impl";
     if (researchCount > 0) return "niche-research";

--- a/apps/axctl/src/queries/routability.ts
+++ b/apps/axctl/src/queries/routability.ts
@@ -5,7 +5,8 @@
  * Spec: docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md
  */
 import { JUDGMENT_GUARD_RE } from "./routing-tune.ts";
-import type { RepriceUsage } from "./reprice.ts";
+import { MODEL_ALIASES, reprice } from "./reprice.ts";
+import type { RepriceUsage, ModelPricing } from "./reprice.ts";
 
 export type WorkClass =
     | "gather"
@@ -118,4 +119,78 @@ export function buildSpans(turns: ReadonlyArray<TurnFacts>, minRun: number): Spa
   }
   flush();
   return spans;
+}
+
+export interface RoutabilityInput {
+  days: number;
+  minRun: number;
+}
+
+export interface RoutabilityClassRow {
+  class: string;
+  verdict: "routable" | "stays";
+  runs: number;
+  turns: number;
+  mainCostUsd: number;
+  tier: string | null;
+  repricedUsd: number | null;
+  estSavingsUsd: number | null;
+}
+
+export interface RoutabilityResult {
+  mainSpendUsd: number;
+  routableUsd: number;
+  routablePct: number;
+  estSavingsUsd: number;
+  rows: ReadonlyArray<RoutabilityClassRow>;
+  days: number;
+  minRun: number;
+}
+
+/**
+ * Roll spans up into per-class routable rows + one "stays main" rollup, and
+ * compute est savings (routable spans repriced one tier down, never negative).
+ */
+export function aggregateRoutability(
+  spans: ReadonlyArray<Span>,
+  pricingCatalog: Map<string, ModelPricing>,
+  input: RoutabilityInput,
+): RoutabilityResult {
+  const routableByClass = new Map<WorkClass, { runs: number; turns: number; main: number; repriced: number }>();
+  let staysMain = 0, staysTurns = 0, staysRuns = 0;
+
+  for (const s of spans) {
+    if (!s.routable) {
+      staysMain += s.usage.cost_usd; staysTurns += s.turnCount; staysRuns += 1;
+      continue;
+    }
+    const tierAlias = ROUTABLE_TIER[s.cls]!;
+    const targetModel = MODEL_ALIASES[tierAlias] ?? tierAlias;
+    const repriced = reprice(s.usage, targetModel, pricingCatalog);
+    const acc = routableByClass.get(s.cls) ?? { runs: 0, turns: 0, main: 0, repriced: 0 };
+    acc.runs += 1; acc.turns += s.turnCount; acc.main += s.usage.cost_usd;
+    acc.repriced += Math.min(repriced, s.usage.cost_usd); // clamp: never "save" by repricing up
+    routableByClass.set(s.cls, acc);
+  }
+
+  const rows: RoutabilityClassRow[] = [];
+  let routableUsd = 0, estSavingsUsd = 0;
+
+  for (const [cls, acc] of routableByClass) {
+    const savings = Math.max(0, acc.main - acc.repriced);
+    routableUsd += acc.main; estSavingsUsd += savings;
+    rows.push({ class: cls, verdict: "routable", runs: acc.runs, turns: acc.turns, mainCostUsd: acc.main, tier: ROUTABLE_TIER[cls] ?? null, repricedUsd: acc.repriced, estSavingsUsd: savings });
+  }
+  rows.sort((a, b) => (b.estSavingsUsd ?? 0) - (a.estSavingsUsd ?? 0));
+
+  if (staysRuns > 0) {
+    rows.push({ class: "stays main", verdict: "stays", runs: staysRuns, turns: staysTurns, mainCostUsd: staysMain, tier: null, repricedUsd: null, estSavingsUsd: null });
+  }
+
+  const mainSpendUsd = routableUsd + staysMain;
+  return {
+    mainSpendUsd, routableUsd,
+    routablePct: mainSpendUsd > 0 ? (routableUsd / mainSpendUsd) * 100 : 0,
+    estSavingsUsd, rows, days: input.days, minRun: input.minRun,
+  };
 }

--- a/apps/axctl/src/queries/routability.ts
+++ b/apps/axctl/src/queries/routability.ts
@@ -1,0 +1,64 @@
+/**
+ * Main-thread routability lens - classify main-agent class-runs by whether they
+ * could have been a cheaper subagent dispatch, and reprice routable spans.
+ * Deterministic: tool composition (A) + thinking signal (B). No LLM.
+ * Spec: docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md
+ */
+import { JUDGMENT_GUARD_RE } from "./routing-tune.ts";
+import type { RepriceUsage } from "./reprice.ts";
+
+export type WorkClass =
+    | "gather"
+    | "niche-research"
+    | "mechanical-impl"
+    | "synthesis"
+    | "design-decision"
+    | "interactive";
+
+/** Routable classes and the tier they should drop to. Others stay on main. */
+export const ROUTABLE_TIER: Partial<Record<WorkClass, "haiku" | "sonnet">> = {
+    gather: "haiku",
+    "niche-research": "sonnet",
+    "mechanical-impl": "sonnet",
+};
+
+export interface TurnFacts {
+    seq: number;
+    role: string;
+    toolNames: ReadonlyArray<string>;
+    thinkingTokens: number;
+    intentKind: string | null;
+    text: string | null;
+    usage: RepriceUsage | null;
+}
+
+export const THINK_HI = 1500; // output tokens of thinking that marks "reasoning"
+const READ_TOOLS = new Set(["Read", "Grep", "Glob", "LS"]);
+const RESEARCH_TOOLS = new Set(["WebFetch", "WebSearch"]);
+const EDIT_TOOLS = new Set(["Edit", "Write", "NotebookEdit", "Bash"]);
+const INTERACTIVE_INTENTS = new Set(["correction", "preference", "wrapper_instruction"]);
+
+/**
+ * Assign one work-class to a main-agent turn. Judgment-first precedence so
+ * review/design/interactive can never be classed routable. `adjacentToUser`
+ * is computed by buildSpans (turn neighbours a user turn).
+ */
+export function classifyTurn(t: TurnFacts, adjacentToUser: boolean): WorkClass {
+    if (adjacentToUser) return "interactive";
+    if (t.intentKind && INTERACTIVE_INTENTS.has(t.intentKind)) return "interactive";
+
+    const hasEdit = t.toolNames.some((n) => EDIT_TOOLS.has(n));
+    const editCount = t.toolNames.filter((n) => EDIT_TOOLS.has(n)).length;
+    const readCount = t.toolNames.filter((n) => READ_TOOLS.has(n)).length;
+    const researchCount = t.toolNames.filter((n) => RESEARCH_TOOLS.has(n)).length;
+
+    if (t.text && JUDGMENT_GUARD_RE.test(t.text)) return "design-decision";
+    if (t.thinkingTokens >= THINK_HI && hasEdit) return "design-decision";
+    if (t.thinkingTokens >= THINK_HI && t.toolNames.length <= 1) return "synthesis";
+
+    if (editCount > 0 && editCount >= readCount && editCount >= researchCount) return "mechanical-impl";
+    if (researchCount > 0) return "niche-research";
+    if (readCount > 0) return "gather";
+
+    return "interactive";
+}

--- a/docs/superpowers/plans/2026-06-15-cost-routability-lens.md
+++ b/docs/superpowers/plans/2026-06-15-cost-routability-lens.md
@@ -1,0 +1,1053 @@
+# Main-thread Routability Lens Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `ax cost routability` - a read-only lens that estimates how much main-agent spend sat in routable class-runs (gather / mechanical-impl / niche-research) vs genuine judgment, repricing the routable spans one tier down for an est-savings figure.
+
+**Architecture:** Deterministic class-run classification over the existing `turn` / `tool_call` / `turn_token_usage` graph. Pure cores (`classifyTurn`, `buildSpans`, `aggregateRoutability`) are unit-tested with no DB; `fetchRoutability` (Effect.fn + SurrealClient) pulls main-agent turns with tool names + thinking + intent + per-turn usage + the pricing catalog, then runs the pure cores in JS (the cost-analytics "derived dimensions in JS" precedent). A small shared `reprice.ts` is extracted from `dispatch-analytics.ts` so both callers use one repricing path.
+
+**Tech Stack:** bun ≥1.3, TypeScript strict, effect@beta (`Command`/`Flag` from `effect/unstable/cli`, `Effect.fn`, `SurrealClient`), bun:test. CI gates: `bun test` + `bun run typecheck`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md`
+
+**Worktree:** `/Users/necmttn/Projects/ax/.claude/worktrees/cost-routability` (branch `feat/cost-routability-lens`). All commands below run from there.
+
+---
+
+## File Structure
+
+- **Create** `apps/axctl/src/queries/reprice.ts` - `MODEL_ALIASES`, `RepriceUsage`, `reprice(usage, targetModelName, pricingCatalog)`. Shared repricing.
+- **Create** `apps/axctl/src/queries/reprice.test.ts` - reprice math + alias resolution.
+- **Modify** `apps/axctl/src/queries/dispatch-analytics.ts` - import the shared reprice instead of the two local closures (DRY; behavior unchanged).
+- **Create** `apps/axctl/src/queries/routability.ts` - `WorkClass`, `ROUTABLE_TIER`, `TurnFacts`, `Span`, `classifyTurn`, `buildSpans`, `aggregateRoutability`, `RoutabilityInput/Result`, `fetchRoutability`.
+- **Create** `apps/axctl/src/queries/routability.test.ts` - pure-core tests (classify, spans, aggregate).
+- **Modify** `apps/axctl/src/cli/commands/ax-cost.ts` - add `routability` subcommand + render.
+- **Modify** `apps/axctl/src/mcp/tools.ts` - register read-only `cost_routability`.
+- **Modify** `CLAUDE.md` - document the new subcommand under "Cost analytics".
+
+---
+
+## Task 1: Extract shared repricing module
+
+**Files:**
+- Create: `apps/axctl/src/queries/reprice.ts`
+- Test: `apps/axctl/src/queries/reprice.test.ts`
+- Modify: `apps/axctl/src/queries/dispatch-analytics.ts` (replace the two local `reprice` closures + private `MODEL_ALIASES`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/axctl/src/queries/reprice.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { MODEL_ALIASES, reprice, type RepriceUsage } from "./reprice.ts";
+
+const usage: RepriceUsage = {
+  prompt_tokens: 1_000_000,
+  completion_tokens: 200_000,
+  cache_read_tokens: 0,
+  cache_create_tokens: 0,
+  cost_usd: 5,
+};
+
+describe("MODEL_ALIASES", () => {
+  it("resolves sonnet and haiku to full ids", () => {
+    expect(MODEL_ALIASES.sonnet).toBe("claude-sonnet-4-6");
+    expect(MODEL_ALIASES.haiku).toBe("claude-haiku-4-5-20251001");
+  });
+});
+
+describe("reprice", () => {
+  it("returns a positive cost cheaper than a frontier original for a known tier", () => {
+    const catalog = new Map([
+      ["claude-sonnet-4-6", {
+        inputPerMillionUsd: 3,
+        outputPerMillionUsd: 15,
+        cacheReadPerMillionUsd: 0.3,
+        cacheCreationPerMillionUsd: 3.75,
+      }],
+    ]);
+    const cost = reprice(usage, "claude-sonnet-4-6", catalog);
+    expect(cost).toBeGreaterThan(0);
+    // 1M input @ $3 + 200k output @ $15 = ~$6 (catalog-driven; far below a fable original)
+    expect(cost).toBeLessThan(20);
+  });
+
+  it("falls back to usage.cost_usd when the target model is unknown to the catalog", () => {
+    const cost = reprice(usage, "unknown-model", new Map());
+    expect(cost).toBe(5);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/queries/reprice.test.ts`
+Expected: FAIL - `Cannot find module './reprice.ts'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+First inspect the exact `ModelPricing` shape and `estimateCost` signature so the call matches:
+
+Run: `rg -n "export interface ModelPricing|export function estimateCost|export const estimateCost" apps/axctl/src/ingest/model-pricing.ts`
+
+Then create `apps/axctl/src/queries/reprice.ts` (mirror the existing closure at `dispatch-analytics.ts:657`):
+
+```ts
+/**
+ * Shared repricing - estimate what a token bundle would cost on a target model.
+ * Extracted from dispatch-analytics so cost-routability and dispatch candidates
+ * use ONE repricing path (was two identical local closures).
+ */
+import { estimateCost, type ModelPricing } from "../ingest/model-pricing.ts";
+
+// Model name resolution for repricing suggestions.
+export const MODEL_ALIASES: Record<string, string> = {
+  sonnet: "claude-sonnet-4-6",
+  haiku: "claude-haiku-4-5-20251001",
+};
+
+export interface RepriceUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  cache_read_tokens: number;
+  cache_create_tokens: number;
+  cost_usd: number;
+}
+
+/**
+ * Reprice `usage` as if it ran on `targetModelName`, using the supplied
+ * agent_model pricing catalog. Falls back to the original `usage.cost_usd`
+ * when the target model / pricing is unknown (never invents a number).
+ */
+export const reprice = (
+  usage: RepriceUsage,
+  targetModelName: string,
+  pricingCatalog: Map<string, ModelPricing>,
+): number => {
+  const cost = estimateCost({
+    modelKey: targetModelName,
+    promptTokens: usage.prompt_tokens,
+    completionTokens: usage.completion_tokens,
+    cacheCreationInputTokens: usage.cache_create_tokens,
+    cacheReadInputTokens: usage.cache_read_tokens,
+    estimatedTokens: usage.prompt_tokens + usage.completion_tokens,
+    ...(pricingCatalog.size > 0 ? { pricingCatalog } : {}),
+  });
+  return cost.totalUsd ?? usage.cost_usd;
+};
+```
+
+> If `rg` in this step shows different `ModelPricing` field names (e.g. `input_per_million_usd`) or a different `estimateCost` key than `modelKey`, copy them verbatim from `dispatch-analytics.ts:657-668` - that closure is the source of truth.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/queries/reprice.test.ts`
+Expected: PASS (both describes).
+
+- [ ] **Step 5: Refactor dispatch-analytics to use the shared module**
+
+In `apps/axctl/src/queries/dispatch-analytics.ts`:
+1. Delete the private `const MODEL_ALIASES = {...}` (around line 50).
+2. Add to imports: `import { MODEL_ALIASES, reprice as repriceUsage, type RepriceUsage } from "./reprice.ts";`
+3. Replace BOTH local `const reprice = (usage: UsageRow, targetModelName) => {...}` closures (around lines 657 and 891) with a thin adapter that calls the shared one with the local `pricingCatalog`:
+
+```ts
+const reprice = (usage: UsageRow, targetModelName: string): number =>
+  repriceUsage(usage, targetModelName, pricingCatalog);
+```
+
+`UsageRow` already has `prompt_tokens/completion_tokens/cache_read_tokens/cache_create_tokens/cost_usd`, so it is structurally a `RepriceUsage` - no row reshaping needed.
+
+- [ ] **Step 6: Run the full dispatch-analytics + typecheck to verify no behavior change**
+
+Run: `bun test apps/axctl/src/queries/dispatch-analytics.test.ts && bun run typecheck`
+Expected: PASS, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/axctl/src/queries/reprice.ts apps/axctl/src/queries/reprice.test.ts apps/axctl/src/queries/dispatch-analytics.ts
+git commit -m "refactor(queries): extract shared reprice module from dispatch-analytics"
+```
+
+---
+
+## Task 2: `classifyTurn` pure core
+
+**Files:**
+- Create: `apps/axctl/src/queries/routability.ts`
+- Test: `apps/axctl/src/queries/routability.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/axctl/src/queries/routability.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { classifyTurn, type TurnFacts } from "./routability.ts";
+
+const base: TurnFacts = {
+  seq: 1,
+  role: "assistant",
+  toolNames: [],
+  thinkingTokens: 0,
+  intentKind: null,
+  text: null,
+  usage: null,
+};
+
+describe("classifyTurn", () => {
+  it("read-only tools, no thinking -> gather", () => {
+    expect(classifyTurn({ ...base, toolNames: ["Read", "Grep", "Read", "Glob"] }, false))
+      .toBe("gather");
+  });
+
+  it("web research + reads -> niche-research", () => {
+    expect(classifyTurn({ ...base, toolNames: ["WebFetch", "Read", "WebSearch"] }, false))
+      .toBe("niche-research");
+  });
+
+  it("edit/bash dominant, low thinking -> mechanical-impl", () => {
+    expect(classifyTurn({ ...base, toolNames: ["Edit", "Bash", "Edit", "Write"] }, false))
+      .toBe("mechanical-impl");
+  });
+
+  it("high thinking, no tools -> synthesis", () => {
+    expect(classifyTurn({ ...base, thinkingTokens: 4000, toolNames: [] }, false))
+      .toBe("synthesis");
+  });
+
+  it("high thinking + edits -> design-decision", () => {
+    expect(classifyTurn({ ...base, thinkingTokens: 4000, toolNames: ["Edit"] }, false))
+      .toBe("design-decision");
+  });
+
+  it("judgment text -> design-decision even with read tools", () => {
+    expect(classifyTurn(
+      { ...base, text: "Review the design of this module", toolNames: ["Read"] },
+      false,
+    )).toBe("design-decision");
+  });
+
+  it("adjacent to a user turn -> interactive (judgment-first, never routed)", () => {
+    expect(classifyTurn({ ...base, toolNames: ["Read", "Grep"] }, true))
+      .toBe("interactive");
+  });
+
+  it("correction intent -> interactive", () => {
+    expect(classifyTurn({ ...base, intentKind: "correction", toolNames: ["Edit"] }, false))
+      .toBe("interactive");
+  });
+
+  it("no tools, no thinking, no signal -> interactive (conservative fallback)", () => {
+    expect(classifyTurn(base, false)).toBe("interactive");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/queries/routability.test.ts`
+Expected: FAIL - `Cannot find module './routability.ts'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/axctl/src/queries/routability.ts`:
+
+```ts
+/**
+ * Main-thread routability lens - classify main-agent class-runs by whether they
+ * could have been a cheaper subagent dispatch, and reprice routable spans.
+ * Deterministic: tool composition (A) + thinking signal (B). No LLM.
+ * Spec: docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md
+ */
+import { JUDGMENT_GUARD_RE } from "./routing-tune.ts";
+import type { RepriceUsage } from "./reprice.ts";
+
+export type WorkClass =
+  | "gather"
+  | "niche-research"
+  | "mechanical-impl"
+  | "synthesis"
+  | "design-decision"
+  | "interactive";
+
+/** Routable classes and the tier they should drop to. Others stay on main. */
+export const ROUTABLE_TIER: Partial<Record<WorkClass, "haiku" | "sonnet">> = {
+  gather: "haiku",
+  "niche-research": "sonnet",
+  "mechanical-impl": "sonnet",
+};
+
+export interface TurnFacts {
+  seq: number;
+  role: string; // 'user' | 'assistant' | 'tool_result' | ...
+  toolNames: ReadonlyArray<string>;
+  thinkingTokens: number;
+  intentKind: string | null;
+  text: string | null;
+  usage: RepriceUsage | null;
+}
+
+// Classification thresholds (calibrated in Task 5 against real data; documented
+// constants so a run is auditable).
+export const THINK_HI = 1500; // output tokens of thinking that marks "reasoning"
+const READ_TOOLS = new Set(["Read", "Grep", "Glob", "LS"]);
+const RESEARCH_TOOLS = new Set(["WebFetch", "WebSearch"]);
+const EDIT_TOOLS = new Set(["Edit", "Write", "NotebookEdit", "Bash"]);
+const INTERACTIVE_INTENTS = new Set([
+  "correction",
+  "preference",
+  "wrapper_instruction",
+]);
+
+/**
+ * Assign one work-class to a main-agent turn. Judgment-first precedence so
+ * review/design/interactive can never be classed routable.
+ * `adjacentToUser` is computed by buildSpans (turn neighbors a user turn).
+ */
+export function classifyTurn(t: TurnFacts, adjacentToUser: boolean): WorkClass {
+  if (adjacentToUser) return "interactive";
+  if (t.intentKind && INTERACTIVE_INTENTS.has(t.intentKind)) return "interactive";
+
+  const hasEdit = t.toolNames.some((n) => EDIT_TOOLS.has(n));
+  const editCount = t.toolNames.filter((n) => EDIT_TOOLS.has(n)).length;
+  const readCount = t.toolNames.filter((n) => READ_TOOLS.has(n)).length;
+  const researchCount = t.toolNames.filter((n) => RESEARCH_TOOLS.has(n)).length;
+
+  if (t.text && JUDGMENT_GUARD_RE.test(t.text)) return "design-decision";
+  if (t.thinkingTokens >= THINK_HI && hasEdit) return "design-decision";
+  if (t.thinkingTokens >= THINK_HI && t.toolNames.length <= 1) return "synthesis";
+
+  if (editCount > 0 && editCount >= readCount && editCount >= researchCount) {
+    return "mechanical-impl";
+  }
+  if (researchCount > 0) return "niche-research";
+  if (readCount > 0) return "gather";
+
+  return "interactive"; // conservative: unclassified stays on main
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/queries/routability.test.ts`
+Expected: PASS (all `classifyTurn` cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/queries/routability.ts apps/axctl/src/queries/routability.test.ts
+git commit -m "feat(routability): classifyTurn work-class core (tool comp + thinking)"
+```
+
+---
+
+## Task 3: `buildSpans` pure core
+
+**Files:**
+- Modify: `apps/axctl/src/queries/routability.ts`
+- Modify: `apps/axctl/src/queries/routability.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/axctl/src/queries/routability.test.ts`:
+
+```ts
+import { buildSpans, type Span } from "./routability.ts";
+
+const u: RepriceUsage = {
+  prompt_tokens: 1000,
+  completion_tokens: 100,
+  cache_read_tokens: 0,
+  cache_create_tokens: 0,
+  cost_usd: 1,
+};
+
+function turn(seq: number, role: string, tools: string[], extra: Partial<TurnFacts> = {}): TurnFacts {
+  return {
+    seq, role, toolNames: tools, thinkingTokens: 0, intentKind: null,
+    text: null, usage: u, ...extra,
+  };
+}
+
+describe("buildSpans", () => {
+  it("groups consecutive same-class assistant turns into one span", () => {
+    const turns = [
+      turn(1, "user", []),
+      turn(2, "assistant", ["Read", "Grep"]),
+      turn(3, "assistant", ["Read"]),
+      turn(4, "assistant", ["Read", "Glob"]),
+    ];
+    const spans = buildSpans(turns, 3);
+    // turn 2 is adjacentToUser -> interactive (own span); 3 & 4 -> gather run of 2
+    const gather = spans.find((s) => s.cls === "gather");
+    expect(gather?.turnCount).toBe(2);
+  });
+
+  it("a user turn breaks a run even when class would continue", () => {
+    const turns = [
+      turn(1, "user", []),
+      turn(2, "assistant", ["Edit"]),
+      turn(3, "assistant", ["Edit"]),
+      turn(4, "user", []),
+      turn(5, "assistant", ["Edit"]),
+      turn(6, "assistant", ["Edit"]),
+    ];
+    const spans = buildSpans(turns, 1);
+    const mech = spans.filter((s) => s.cls === "mechanical-impl");
+    // two separate runs (split by the user turn at seq 4), not one of 4
+    expect(mech.length).toBe(2);
+  });
+
+  it("marks a routable span only when its run length >= minRun", () => {
+    const turns = [
+      turn(1, "user", []),
+      turn(2, "assistant", ["Read"]),   // interactive (adjacent)
+      turn(3, "assistant", ["Read"]),   // gather
+      turn(4, "assistant", ["Read"]),   // gather
+      turn(5, "assistant", ["Read"]),   // gather  -> run of 3
+    ];
+    expect(buildSpans(turns, 3).find((s) => s.cls === "gather")?.routable).toBe(true);
+    expect(buildSpans(turns, 4).find((s) => s.cls === "gather")?.routable).toBe(false);
+  });
+
+  it("sums usage across a span", () => {
+    const turns = [
+      turn(1, "user", []),
+      turn(2, "assistant", ["Read"]),
+      turn(3, "assistant", ["Read"]),
+      turn(4, "assistant", ["Read"]),
+    ];
+    const gather = buildSpans(turns, 1).find((s) => s.cls === "gather");
+    expect(gather?.usage.cost_usd).toBe(2); // turns 3 & 4 (turn 2 is interactive)
+  });
+
+  it("does not group across sessions (caller passes per-session ordered turns)", () => {
+    // buildSpans assumes a single session's turns in seq order; verified by Task 5 query
+    const spans = buildSpans([turn(1, "user", []), turn(2, "assistant", ["Read"])], 1);
+    expect(spans.every((s) => s.turnCount >= 1)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/queries/routability.test.ts`
+Expected: FAIL - `buildSpans`/`Span` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `apps/axctl/src/queries/routability.ts`:
+
+```ts
+export interface Span {
+  cls: WorkClass;
+  turnCount: number;
+  usage: RepriceUsage; // summed across the span's turns
+  routable: boolean; // cls is routable AND turnCount >= minRun
+}
+
+const ZERO_USAGE = (): RepriceUsage => ({
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  cache_read_tokens: 0,
+  cache_create_tokens: 0,
+  cost_usd: 0,
+});
+
+function addUsage(a: RepriceUsage, b: RepriceUsage | null): RepriceUsage {
+  if (!b) return a;
+  return {
+    prompt_tokens: a.prompt_tokens + b.prompt_tokens,
+    completion_tokens: a.completion_tokens + b.completion_tokens,
+    cache_read_tokens: a.cache_read_tokens + b.cache_read_tokens,
+    cache_create_tokens: a.cache_create_tokens + b.cache_create_tokens,
+    cost_usd: a.cost_usd + b.cost_usd,
+  };
+}
+
+/**
+ * Group ONE session's main-agent turns (seq order) into class-run spans.
+ * Splits at every user turn (judgment boundary); within a segment, groups
+ * consecutive assistant turns sharing a class. A turn neighbouring a user
+ * turn is forced to `interactive`. A span is routable iff its class is
+ * routable AND its run length >= minRun.
+ */
+export function buildSpans(turns: ReadonlyArray<TurnFacts>, minRun: number): Span[] {
+  const spans: Span[] = [];
+  let cur: { cls: WorkClass; turnCount: number; usage: RepriceUsage } | null = null;
+
+  const flush = () => {
+    if (!cur) return;
+    const tier = ROUTABLE_TIER[cur.cls];
+    spans.push({
+      cls: cur.cls,
+      turnCount: cur.turnCount,
+      usage: cur.usage,
+      routable: tier !== undefined && cur.turnCount >= minRun,
+    });
+    cur = null;
+  };
+
+  for (let i = 0; i < turns.length; i++) {
+    const t = turns[i];
+    if (t.role === "user" || t.role === "tool_result") {
+      flush(); // user/tool_result turns are boundaries, never classified
+      continue;
+    }
+    if (t.role !== "assistant") {
+      flush();
+      continue;
+    }
+    const prevIsUser = i > 0 && turns[i - 1].role === "user";
+    const nextIsUser = i + 1 < turns.length && turns[i + 1].role === "user";
+    const cls = classifyTurn(t, prevIsUser || nextIsUser);
+
+    if (cur && cur.cls === cls) {
+      cur.turnCount += 1;
+      cur.usage = addUsage(cur.usage, t.usage);
+    } else {
+      flush();
+      cur = { cls, turnCount: 1, usage: addUsage(ZERO_USAGE(), t.usage) };
+    }
+  }
+  flush();
+  return spans;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/queries/routability.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/queries/routability.ts apps/axctl/src/queries/routability.test.ts
+git commit -m "feat(routability): buildSpans class-run grouping with min-run gate"
+```
+
+---
+
+## Task 4: `aggregateRoutability` pure core
+
+**Files:**
+- Modify: `apps/axctl/src/queries/routability.ts`
+- Modify: `apps/axctl/src/queries/routability.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/axctl/src/queries/routability.test.ts`:
+
+```ts
+import { aggregateRoutability } from "./routability.ts";
+import { MODEL_ALIASES } from "./reprice.ts";
+
+describe("aggregateRoutability", () => {
+  // Pricing catalog: sonnet/haiku cheap so repricing clearly < original.
+  const catalog = new Map([
+    [MODEL_ALIASES.sonnet, { inputPerMillionUsd: 3, outputPerMillionUsd: 15, cacheReadPerMillionUsd: 0.3, cacheCreationPerMillionUsd: 3.75 }],
+    [MODEL_ALIASES.haiku, { inputPerMillionUsd: 0.8, outputPerMillionUsd: 4, cacheReadPerMillionUsd: 0.08, cacheCreationPerMillionUsd: 1 }],
+  ]);
+
+  const bigUsage: RepriceUsage = {
+    prompt_tokens: 2_000_000, completion_tokens: 400_000,
+    cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 50, // expensive original
+  };
+
+  const spans: Span[] = [
+    { cls: "gather", turnCount: 5, usage: bigUsage, routable: true },
+    { cls: "mechanical-impl", turnCount: 4, usage: bigUsage, routable: true },
+    { cls: "synthesis", turnCount: 3, usage: bigUsage, routable: false },
+    { cls: "gather", turnCount: 2, usage: bigUsage, routable: false }, // below min-run
+  ];
+
+  it("rolls up routable spans by class with positive savings", () => {
+    const r = aggregateRoutability(spans, catalog, { days: 30, minRun: 3 });
+    const gather = r.rows.find((row) => row.class === "gather" && row.verdict === "routable");
+    expect(gather?.runs).toBe(1); // only the routable run of 5
+    expect(gather?.tier).toBe("haiku");
+    expect(gather!.estSavingsUsd!).toBeGreaterThan(0);
+  });
+
+  it("aggregates everything else into a single 'stays main' rollup", () => {
+    const r = aggregateRoutability(spans, catalog, { days: 30, minRun: 3 });
+    const stays = r.rows.find((row) => row.verdict === "stays");
+    expect(stays).toBeDefined();
+    // synthesis span + the below-min-run gather span both stay
+    expect(stays!.mainCostUsd).toBe(100);
+  });
+
+  it("totals: routable + est savings + main spend + pct", () => {
+    const r = aggregateRoutability(spans, catalog, { days: 30, minRun: 3 });
+    expect(r.mainSpendUsd).toBe(200); // 4 spans * $50
+    expect(r.routableUsd).toBe(100); // 2 routable spans * $50
+    expect(r.routablePct).toBeCloseTo(50, 0);
+    expect(r.estSavingsUsd).toBeGreaterThan(0);
+  });
+
+  it("never reports negative savings (already-cheap span contributes 0)", () => {
+    const cheap: Span = {
+      cls: "gather", turnCount: 5,
+      usage: { prompt_tokens: 10, completion_tokens: 1, cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0.0001 },
+      routable: true,
+    };
+    const r = aggregateRoutability([cheap], catalog, { days: 30, minRun: 3 });
+    expect(r.estSavingsUsd).toBeGreaterThanOrEqual(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/queries/routability.test.ts`
+Expected: FAIL - `aggregateRoutability` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `apps/axctl/src/queries/routability.ts` (add import at top: `import { MODEL_ALIASES, reprice } from "./reprice.ts";` and `import type { ModelPricing } from "../ingest/model-pricing.ts";`):
+
+```ts
+export interface RoutabilityInput {
+  days: number;
+  minRun: number;
+}
+
+export interface RoutabilityClassRow {
+  class: string;
+  verdict: "routable" | "stays";
+  runs: number;
+  turns: number;
+  mainCostUsd: number;
+  tier: string | null;
+  repricedUsd: number | null;
+  estSavingsUsd: number | null;
+}
+
+export interface RoutabilityResult {
+  mainSpendUsd: number;
+  routableUsd: number;
+  routablePct: number;
+  estSavingsUsd: number;
+  rows: ReadonlyArray<RoutabilityClassRow>;
+  days: number;
+  minRun: number;
+}
+
+/**
+ * Roll spans up into per-class routable rows + one "stays main" rollup, and
+ * compute est savings (routable spans repriced one tier down, never negative).
+ */
+export function aggregateRoutability(
+  spans: ReadonlyArray<Span>,
+  pricingCatalog: Map<string, ModelPricing>,
+  input: RoutabilityInput,
+): RoutabilityResult {
+  const routableByClass = new Map<WorkClass, { runs: number; turns: number; main: number; repriced: number }>();
+  let staysMain = 0;
+  let staysTurns = 0;
+  let staysRuns = 0;
+
+  for (const s of spans) {
+    if (!s.routable) {
+      staysMain += s.usage.cost_usd;
+      staysTurns += s.turnCount;
+      staysRuns += 1;
+      continue;
+    }
+    const tierAlias = ROUTABLE_TIER[s.cls]!; // routable guarantees a tier
+    const targetModel = MODEL_ALIASES[tierAlias] ?? tierAlias;
+    const repriced = reprice(s.usage, targetModel, pricingCatalog);
+    const acc = routableByClass.get(s.cls) ?? { runs: 0, turns: 0, main: 0, repriced: 0 };
+    acc.runs += 1;
+    acc.turns += s.turnCount;
+    acc.main += s.usage.cost_usd;
+    acc.repriced += Math.min(repriced, s.usage.cost_usd); // clamp: never "save" by repricing up
+    routableByClass.set(s.cls, acc);
+  }
+
+  const rows: RoutabilityClassRow[] = [];
+  let routableUsd = 0;
+  let estSavingsUsd = 0;
+
+  for (const [cls, acc] of routableByClass) {
+    const savings = Math.max(0, acc.main - acc.repriced);
+    routableUsd += acc.main;
+    estSavingsUsd += savings;
+    rows.push({
+      class: cls,
+      verdict: "routable",
+      runs: acc.runs,
+      turns: acc.turns,
+      mainCostUsd: acc.main,
+      tier: ROUTABLE_TIER[cls] ?? null,
+      repricedUsd: acc.repriced,
+      estSavingsUsd: savings,
+    });
+  }
+
+  rows.sort((a, b) => (b.estSavingsUsd ?? 0) - (a.estSavingsUsd ?? 0));
+
+  if (staysRuns > 0) {
+    rows.push({
+      class: "stays main",
+      verdict: "stays",
+      runs: staysRuns,
+      turns: staysTurns,
+      mainCostUsd: staysMain,
+      tier: null,
+      repricedUsd: null,
+      estSavingsUsd: null,
+    });
+  }
+
+  const mainSpendUsd = routableUsd + staysMain;
+  return {
+    mainSpendUsd,
+    routableUsd,
+    routablePct: mainSpendUsd > 0 ? (routableUsd / mainSpendUsd) * 100 : 0,
+    estSavingsUsd,
+    rows,
+    days: input.days,
+    minRun: input.minRun,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/queries/routability.test.ts && bun run typecheck`
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/queries/routability.ts apps/axctl/src/queries/routability.test.ts
+git commit -m "feat(routability): aggregateRoutability rollup + est-savings math"
+```
+
+---
+
+## Task 5: `fetchRoutability` (Effect.fn + SurrealClient)
+
+**Files:**
+- Modify: `apps/axctl/src/queries/routability.ts`
+
+This is the DB integration. It mirrors `fetchCostSplit` (`cost-analytics.ts:200`). Read that function first for the exact `SurrealClient` import path, `Effect.fn` naming, and the `sinceDays` window pattern.
+
+- [ ] **Step 1: Inspect the patterns to copy**
+
+Run:
+```bash
+sed -n '1,30p;196,260p' apps/axctl/src/queries/cost-analytics.ts
+rg -n "agent_model|agentModelsResult|pricingCatalog.set" apps/axctl/src/queries/dispatch-analytics.ts | head
+rg -n "DEFINE FIELD (model|prompt_tokens|completion_tokens|cache_read_input_tokens|cache_creation_input_tokens|estimated_cost_usd|source) ON turn_token_usage" packages/schema/src/schema.surql
+```
+Note the exact field names (the schema uses `cache_read_input_tokens` / `cache_creation_input_tokens` - map them to `RepriceUsage.cache_read_tokens` / `cache_create_tokens` in JS).
+
+- [ ] **Step 2: Write the implementation**
+
+Append to `apps/axctl/src/queries/routability.ts` (add imports mirroring cost-analytics: `import { Effect } from "effect";` and the `SurrealClient` import exactly as cost-analytics.ts has it):
+
+```ts
+import { SurrealClient } from "../lib/db.ts"; // COPY exact path/name from cost-analytics.ts:1-20
+
+/**
+ * Pull main-agent turns (source != 'claude-subagent') in the window with their
+ * tool names, thinking tokens, intent, and per-turn usage; plus the agent_model
+ * pricing catalog. Group + classify in JS (cost-analytics "derived in JS"
+ * precedent). One row per turn; tool names aggregated per turn.
+ */
+export const fetchRoutability = Effect.fn("queries.fetchRoutability")(
+  function* (input: RoutabilityInput) {
+    const db = yield* SurrealClient;
+
+    // Per-turn facts for MAIN-agent turns, ordered (session, seq). tool names
+    // come from tool_call joined by turn; usage from turn_token_usage.
+    const [turnRows] = yield* db.query<[Array<Record<string, unknown>>]>(
+      /* surql */ `
+      LET $since = time::now() - ${"" + input.days}d;
+      SELECT
+        session AS session_id,
+        seq,
+        role,
+        intent_kind,
+        text,
+        (thinking_tokens OR 0) AS thinking_tokens,
+        (SELECT VALUE name FROM tool_call WHERE turn = $parent.id) AS tool_names,
+        (SELECT * FROM turn_token_usage WHERE turn = $parent.id LIMIT 1)[0] AS usage
+      FROM turn
+      WHERE ts >= $since
+        AND (usage.source != 'claude-subagent' OR usage.source = NONE)
+      ORDER BY session_id, seq;
+      `,
+    );
+
+    // agent_model -> pricing catalog (same construction as dispatch-analytics).
+    const [agentModelRows] = yield* db.query<[Array<Record<string, unknown>>]>(
+      /* surql */ `SELECT name, input_per_million_usd, output_per_million_usd,
+        cache_read_per_million_usd, cache_creation_per_million_usd FROM agent_model;`,
+    );
+    const pricingCatalog = new Map<string, ModelPricing>();
+    for (const r of agentModelRows ?? []) {
+      pricingCatalog.set(String(r.name), {
+        // COPY the exact ModelPricing field names from dispatch-analytics.ts:642
+        inputPerMillionUsd: Number(r.input_per_million_usd ?? 0),
+        outputPerMillionUsd: Number(r.output_per_million_usd ?? 0),
+        cacheReadPerMillionUsd: Number(r.cache_read_per_million_usd ?? 0),
+        cacheCreationPerMillionUsd: Number(r.cache_creation_per_million_usd ?? 0),
+      });
+    }
+
+    // Group rows by session, build TurnFacts, then spans per session.
+    const bySession = new Map<string, TurnFacts[]>();
+    for (const r of turnRows ?? []) {
+      const sid = String(r.session_id ?? "");
+      const usageRaw = r.usage as Record<string, unknown> | null | undefined;
+      const facts: TurnFacts = {
+        seq: Number(r.seq ?? 0),
+        role: String(r.role ?? ""),
+        toolNames: Array.isArray(r.tool_names) ? (r.tool_names as string[]) : [],
+        thinkingTokens: Number(r.thinking_tokens ?? 0),
+        intentKind: r.intent_kind == null ? null : String(r.intent_kind),
+        text: r.text == null ? null : String(r.text),
+        usage: usageRaw
+          ? {
+              prompt_tokens: Number(usageRaw.prompt_tokens ?? 0),
+              completion_tokens: Number(usageRaw.completion_tokens ?? 0),
+              cache_read_tokens: Number(usageRaw.cache_read_input_tokens ?? 0),
+              cache_create_tokens: Number(usageRaw.cache_creation_input_tokens ?? 0),
+              cost_usd: Number(usageRaw.estimated_cost_usd ?? 0),
+            }
+          : null,
+      };
+      const arr = bySession.get(sid) ?? [];
+      arr.push(facts);
+      bySession.set(sid, arr);
+    }
+
+    const allSpans: Span[] = [];
+    for (const turns of bySession.values()) {
+      allSpans.push(...buildSpans(turns, input.minRun));
+    }
+
+    return aggregateRoutability(allSpans, pricingCatalog, input);
+  },
+);
+```
+
+> The surql is a first cut. Step 3 verifies it runs against the real DB; adjust subquery syntax to whatever the existing queries use (check `cost-analytics.ts` / `dispatch-analytics.ts` for the project's sub-SELECT idiom - e.g. `$parent.id` vs `$this`). Keep the JS shaping identical.
+
+- [ ] **Step 3: Smoke-test against the real DB + calibrate THINK_HI**
+
+Run (the daemon DB must be up - `ax serve status`):
+```bash
+cd apps/axctl && bun -e "import {Effect} from 'effect'; import {fetchRoutability} from './src/queries/routability.ts'; import {DbLive} from './src/lib/db.ts'; /* COPY runner from an existing query script */ Effect.runPromise(fetchRoutability({days:30,minRun:3}).pipe(Effect.provide(DbLive))).then(r=>console.log(JSON.stringify(r,null,2)))"
+```
+Expected: a `RoutabilityResult` with `mainSpendUsd` in the ballpark of `ax cost split` main total (~$17.7K/30d). If `routablePct` looks absurd (e.g. >80% - too aggressive - or ~0% - too conservative), adjust `THINK_HI` and re-run. Document the chosen value in a comment.
+
+> If you cannot write an ad-hoc runner cleanly, defer the smoke test to Task 6 (run the actual CLI command) and calibrate there.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/queries/routability.ts
+git commit -m "feat(routability): fetchRoutability DB query + main-thread span pipeline"
+```
+
+---
+
+## Task 6: CLI subcommand `ax cost routability`
+
+**Files:**
+- Modify: `apps/axctl/src/cli/commands/ax-cost.ts`
+
+- [ ] **Step 1: Read the existing split subcommand to mirror**
+
+Run: `sed -n '162,255p' apps/axctl/src/cli/commands/ax-cost.ts`
+Note: `Command.make`, `Flag` usage, the `--days` parse + `fail(...)`, `--json` branch, `fetchCostSplit({ sinceDays })`, render helpers, and how subcommands are added to `costCommand` (the `withSubcommands([...])` array).
+
+- [ ] **Step 2: Add the subcommand**
+
+In `apps/axctl/src/cli/commands/ax-cost.ts`:
+1. Import: `import { fetchRoutability, type RoutabilityResult } from "../../queries/routability.ts";`
+2. Add a render function:
+
+```ts
+function renderRoutability(r: RoutabilityResult): string {
+  const usd = (n: number) => `$${n.toFixed(2)}`;
+  const lines: string[] = [];
+  lines.push(
+    `main-agent spend: ${usd(r.mainSpendUsd)}   routable: ${usd(r.routableUsd)} (${r.routablePct.toFixed(0)}%)   est. savings: ${usd(r.estSavingsUsd)}`,
+  );
+  lines.push("");
+  lines.push("class            runs  turns  main_cost   tier     repriced   est_savings");
+  for (const row of r.rows) {
+    if (row.verdict === "stays") {
+      lines.push(`stays main       ${String(row.runs).padStart(4)}  ${String(row.turns).padStart(5)}  ${usd(row.mainCostUsd).padStart(9)}   -        -          -`);
+    } else {
+      lines.push(
+        `${row.class.padEnd(15)} ${String(row.runs).padStart(4)}  ${String(row.turns).padStart(5)}  ${usd(row.mainCostUsd).padStart(9)}   ${(row.tier ?? "").padEnd(7)} ${usd(row.repricedUsd ?? 0).padStart(9)}  ${usd(row.estSavingsUsd ?? 0).padStart(9)}`,
+      );
+    }
+  }
+  lines.push("");
+  lines.push("estimate from historical token counts; judgment work left on frontier by design.");
+  lines.push("next: ax dispatches --candidates   # the subagent-side leak");
+  return lines.join("\n");
+}
+```
+
+3. Define the command (mirror `costSplitCommand` exactly for flags + runtime):
+
+```ts
+// ax cost routability [--days=N] [--min-run=N] [--json]
+const costRoutabilityCommand = Command.make(
+  "routability",
+  {
+    days: Flag.integer("days").pipe(Flag.withDefault(30)),
+    minRun: Flag.integer("min-run").pipe(Flag.withDefault(3)),
+    json: Flag.boolean("json").pipe(Flag.withDefault(false)),
+  },
+  (input) =>
+    Effect.gen(function* () {
+      if (input.days <= 0) fail(`ax cost routability: --days must be a positive integer`);
+      if (input.minRun <= 0) fail(`ax cost routability: --min-run must be a positive integer`);
+      const result = yield* fetchRoutability({ days: input.days, minRun: input.minRun });
+      if (input.json) {
+        yield* Console.log(JSON.stringify(result, null, 2));
+      } else {
+        yield* Console.log(renderRoutability(result));
+      }
+    }),
+).pipe(
+  Command.withDescription(
+    "Estimate how much main-agent spend was routable to a cheaper subagent",
+  ),
+);
+```
+
+> Copy the EXACT `Flag`/`Command`/`Console`/`fail`/runtime-provision idiom from `costSplitCommand` - names above are indicative; match the file.
+
+4. Add `costRoutabilityCommand` to the `Command.withSubcommands([...])` array on `costCommand`.
+
+- [ ] **Step 3: Build + run the real command**
+
+Run:
+```bash
+bun run build 2>/dev/null || true
+./bin/axctl cost routability --days=30
+./bin/axctl cost routability --days=30 --json | head -30
+```
+Expected: the table renders; `mainSpendUsd` ≈ the `ax cost split` main total. Calibrate `THINK_HI` (Task 5) now if the smoke test was deferred.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/cli/commands/ax-cost.ts apps/axctl/src/queries/routability.ts
+git commit -m "feat(cli): ax cost routability subcommand + render"
+```
+
+---
+
+## Task 7: MCP registration
+
+**Files:**
+- Modify: `apps/axctl/src/mcp/tools.ts`
+
+- [ ] **Step 1: Read how cost_split is registered**
+
+Run: `rg -n "cost_split|cost_models|fetchCostSplit" apps/axctl/src/mcp/tools.ts`
+Mirror that registration exactly (name, input schema with `days`/`min_run`, the handler calling `fetchRoutability`).
+
+- [ ] **Step 2: Register `cost_routability`**
+
+Add an entry mirroring `cost_split`, e.g.:
+
+```ts
+{
+  name: "cost_routability",
+  description: "Estimate how much main-agent spend was routable to a cheaper subagent (gather/mechanical/niche-research class-runs), with est savings.",
+  inputSchema: { /* COPY the cost_split schema shape; days default 30, min_run default 3 */ },
+  handler: (args) => fetchRoutability({ days: args.days ?? 30, minRun: args.min_run ?? 3 }),
+},
+```
+
+Add the import: `import { fetchRoutability } from "../queries/routability.ts";` (match the file's import style).
+
+- [ ] **Step 3: Typecheck + test**
+
+Run: `bun run typecheck && bun test apps/axctl/src/mcp`
+Expected: no errors; MCP registry tests (if any) pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/axctl/src/mcp/tools.ts
+git commit -m "feat(mcp): expose cost_routability read-only tool"
+```
+
+---
+
+## Task 8: Docs
+
+**Files:**
+- Modify: `CLAUDE.md` (the "Cost analytics" block)
+
+- [ ] **Step 1: Add the subcommand line**
+
+In `CLAUDE.md`, under `### Cost analytics`, after the `ax cost split` line, add:
+
+```
+`ax cost routability [--days=N] [--min-run=N] [--json]` - main-thread routability lens: of main-agent spend, how much sat in routable class-runs (gather→haiku, mechanical-impl/niche-research→sonnet) vs genuine judgment, with est savings repriced one tier down. Deterministic (tool composition + thinking signal); reuses JUDGMENT_GUARD_RE + shared reprice. MCP: `cost_routability`. Spec: docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md.
+```
+
+- [ ] **Step 2: Verify the new-subcommand docs gate passes**
+
+Run: `bun test 2>&1 | rg -i "docs|subcommand|claude.md" | head` (and the full `bun test` below).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: ax cost routability subcommand"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Full gates**
+
+Run: `bun test && bun run typecheck`
+Expected: all pass, no type errors.
+
+- [ ] **Step 2: End-to-end sanity**
+
+Run: `./bin/axctl cost routability --days=30`
+Expected: main spend ≈ `ax cost split` main total; routable% plausible (calibrated); judgment classes in the "stays main" rollup.
+
+- [ ] **Step 3: Push branch + open PR (only when asked)**
+
+Do not push/PR unless the user requests it.
+
+---
+
+## Self-Review (completed during authoring)
+
+- **Spec coverage:** class-run unit (T3) ✓; A+B taxonomy + judgment-first precedence (T2) ✓; reprice/savings (T1,T4) ✓; `fetchRoutability` mirrors fetchCostSplit (T5) ✓; `ax cost routability` command (T6) ✓; MCP `cost_routability` (T7) ✓; CLAUDE.md docs gate (T8) ✓; honest-estimate framing in render (T6) ✓; thresholds documented/auditable (T2,T5) ✓. Phase-awareness explicitly v2 - not planned ✓.
+- **Type consistency:** `RepriceUsage`, `TurnFacts`, `Span`, `RoutabilityInput/Result`, `WorkClass`, `ROUTABLE_TIER` names identical across T2–T7. `reprice(usage, targetModelName, pricingCatalog)` signature identical in T1 and used in T4/T5.
+- **Placeholder scan:** the surql query (T5) and exact Flag/ModelPricing/SurrealClient idioms are flagged "copy from <file:line>" rather than guessed - deliberate, since those are existing project symbols whose exact form must be read from source, not invented. Every pure-core step has complete code + tests.

--- a/docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md
+++ b/docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md
@@ -42,43 +42,59 @@ Routable main-agent work is multi-turn (a research sweep, a mechanical refactor)
 3. Within each segment, group **consecutive turns sharing a work-class** → a **span**
    (a maximal class-run).
 4. A span is **routable** iff its class is routable AND its run length ≥ `--min-run`
-   (default 3) - so a stray `Read` between decisions is never billed as "should've been a
-   subagent." Routable work clusters; the threshold enforces that.
+   (**default 1** - see calibration note). `--min-run` stays a flag for users who want to
+   require clustering.
 
-Class-runs are *finer than phases*: a "research" segment decomposes into alternating
-`gather` runs (routable) and `synthesis` runs (stays main) automatically - which captures
-"niche research → subagent, reasoning → smart agent" without modeling phases.
+### CALIBRATION NOTE (2026-06-15, post-smoke-test on real data)
 
-## Work-class taxonomy (the A+B blend)
+Two design assumptions in the original draft were refuted by the data and corrected:
 
-Each main-agent turn is assigned ONE class from its tool composition (A) with
-`thinking_tokens`/`intent_kind` as tiebreak (B). Routable classes carry a target tier;
-the rest stay main.
+- **`thinking_tokens` is a dead signal.** It is 0 on **96.6%** of main-agent turns (p99
+  = 1317; only 0.8% cross 1500) because transcripts strip thinking text (schema caveat).
+  The `THINK_HI` threshold was a no-op (the "think+edit" bucket it protected was empty,
+  $0/n=0). **Dropped entirely.** Judgment protection now rests on `JUDGMENT_GUARD_RE`
+  (turn text) + the interactive/adjacency rules. (`thinking_blocks`, a populated count,
+  is a candidate reasoning signal for a later version - deferred.)
+- **Class-runs of length ≥3 barely exist** (77.7% length 1, 18.7% length 2, 3.6% ≥3):
+  Claude turns interleave tools, user turns split runs, and the adjacency rule forces the
+  first assistant turn of each segment to `interactive`. `minRun=3` gated out ~everything
+  (0.0% routable). The **turn is the natural unit**, so the default is `minRun=1`.
 
-| class              | signal                                                              | verdict            |
-|--------------------|---------------------------------------------------------------------|--------------------|
-| `gather`           | Read/Grep/Glob/LS dominant, `thinking_tokens` ≈ 0                    | routable → haiku   |
-| `niche-research`   | reads + WebFetch/WebSearch/docs, low thinking                       | routable → sonnet  |
-| `mechanical-impl`  | Edit/Write/Bash dominant, low thinking, no decision `intent_kind`   | routable → sonnet  |
-| `synthesis`        | high `thinking_tokens`, few/no tools                                | stays main         |
-| `design-decision`  | thinking + edits together, or `JUDGMENT_GUARD_RE`/decision intent   | stays main         |
-| `interactive`      | turn adjacent to a user turn, `intent_kind` correction/preference   | stays main         |
+At `minRun=1` on the reference machine, ~34% of main-agent assistant cost ($5.2K/30d)
+lands in routable classes - larger than the entire subagent routing leak. The class-run
+grouping mechanic is retained (it still merges adjacent same-class turns and powers the
+`--min-run` knob), just defaulted to 1.
+
+## Work-class taxonomy (tool composition + text-judgment guard)
+
+Each main-agent turn is assigned ONE class from its tool composition, with
+`JUDGMENT_GUARD_RE` (turn text) + adjacency/intent as the judgment guard. Routable classes
+carry a target tier; the rest stay main. (The thinking-token signal was dropped - see the
+calibration note above.)
+
+| class              | signal                                                            | verdict            |
+|--------------------|-------------------------------------------------------------------|--------------------|
+| `gather`           | Read/Grep/Glob/LS present, no edits                               | routable → haiku   |
+| `niche-research`   | WebFetch/WebSearch present                                        | routable → sonnet  |
+| `mechanical-impl`  | Edit/Write/NotebookEdit/Bash dominant                            | routable → sonnet  |
+| `design-decision`  | `JUDGMENT_GUARD_RE` matches the turn text                        | stays main         |
+| `interactive`      | turn follows a user turn, or correction/preference intent, or no classifiable tool | stays main |
+| `synthesis`        | (unreachable in v0 - kept in the union for a future reasoning signal) | stays main      |
 
 Classification precedence (first match wins, judgment-first so it can never be routed):
-1. `interactive` - turn immediately follows/precedes a user turn in the segment, or
+1. `interactive` - turn immediately follows a user turn in the session, or
    `intent_kind ∈ {correction, preference, wrapper_instruction}`.
-2. `design-decision` - `JUDGMENT_GUARD_RE` matches the turn text, OR (`thinking_tokens` ≥
-   `THINK_HI` AND has edits).
-3. `synthesis` - `thinking_tokens` ≥ `THINK_HI` AND tool count ≤ `TOOL_LO`.
-4. `mechanical-impl` - edit/bash tools dominate, `thinking_tokens` < `THINK_HI`.
-5. `niche-research` - research tools (WebFetch/WebSearch) present, read-heavy.
-6. `gather` - read-only tools dominate.
-7. fallback → `interactive` (conservative: unclassified stays main).
+2. `design-decision` - `JUDGMENT_GUARD_RE` matches the turn text.
+3. `mechanical-impl` - edit tools dominate (`editCount ≥ readCount` and `≥ researchCount`).
+4. `niche-research` - research tools (WebFetch/WebSearch) present.
+5. `gather` - read-only tools present.
+6. fallback → `interactive` (conservative: pure-text / coordination / Task-dispatch turns
+   stay main - this is the bulk of main spend and is genuinely judgment/coordination).
 
-Thresholds (`THINK_HI`, `TOOL_LO`, `min-run`) are module constants, `--min-run` overridable.
-Default `THINK_HI` calibrated against real data during build (start ~1500 output tokens of
-thinking); `TOOL_LO` ~1. Tool-class sets reuse the routing-table grain
-(search-locate→haiku, well-specified-impl→sonnet).
+`--min-run` is the one tunable (default 1). Tool-class sets reuse the routing-table grain
+(search-locate→haiku, well-specified-impl→sonnet). Adjacency = *follows* a user turn
+(the agent's first response); the turn before the next user turn is classified on its own
+merits.
 
 ## Cost + repricing
 
@@ -126,7 +142,7 @@ interface RoutabilityResult {
 
 ## CLI surface
 
-`ax cost routability [--days=N] [--min-run=3] [--json]` - in the `cost` namespace
+`ax cost routability [--days=N] [--min-run=1] [--json]` - in the `cost` namespace
 (cost-analytics already owns the main/subagent origin logic). Default window 30d to match the
 other cost commands. `--json` returns the `RoutabilityResult` envelope.
 
@@ -135,19 +151,19 @@ Render:
 ```
 $ ax cost routability --days=30
 
-main-agent spend: $17,756   routable: $6,120 (34%)   est. savings: $4,890
+main-agent spend: $15,137   routable: $5,162 (34%)   est. savings: ~$X
 
 class            runs   turns   main_cost   tier     repriced   est_savings
-gather             142    518    $2,310      haiku    $  185     $2,125
-mechanical-impl     88    402    $2,740      sonnet   $  822     $1,918
-niche-research      41    160    $1,070      sonnet   $  321     $  749
-stays main (synthesis/design-decision/interactive)   $11,636    -
+mechanical-impl  ...    ...     $4,498      sonnet   ...        ...
+gather           ...    ...     $  628      haiku    ...        ...
+niche-research   ...    ...     $   35      sonnet   ...        ...
+stays main (interactive/design-decision)             $9,975     -
 
 estimate from historical token counts; judgment work left on frontier by design.
 next: ax dispatches --candidates   # the subagent-side leak
 ```
 
-(Numbers illustrative; real figures computed at run.)
+(Numbers from the reference-machine smoke test at minRun=1; est_savings filled at run.)
 
 ## Reactivity / MCP
 
@@ -159,12 +175,17 @@ next: ax dispatches --candidates   # the subagent-side leak
 
 ## Risks / open calibration
 
-- `THINK_HI` / `TOOL_LO` thresholds are the accuracy knob - calibrate against a hand-labeled
-  sample of real main spans during build; print the chosen constants in `--json` so a run is
-  auditable.
-- Codex/other harnesses: `thinking_tokens` coverage varies (claude mixed turns read 0 →
-  lower bound). The lens is most accurate on Claude main sessions; non-claude main turns fall
-  to `mechanical-impl`/`gather` on tool mix alone (no reasoning signal) - acceptable, noted.
+- **Accuracy rests on tool composition alone** (thinking signal dropped). A turn that
+  reasons hard *then* does a mechanical edit reads as `mechanical-impl` (routable) - the
+  lens can't see the reasoning that preceded the edit. This is a known over-count direction;
+  `JUDGMENT_GUARD_RE` on the turn text is the only judgment catch. Acceptable for an
+  estimate; a populated reasoning signal (`thinking_blocks`) is the v2 refinement.
+- **Non-Claude main spend is under-counted.** ~$3K/30d of main spend (GPT-5.x, etc.) has no
+  per-turn `turn_token_usage` cost row, so `mainSpendUsd` (~$15.1K) sits below the
+  `ax cost split` main total (~$18.1K). The lens is Claude-main accurate; note the gap.
+- The biggest pool - the `interactive` fallback ($9.7K/64%, pure-text/coordination/Task
+  turns) - is left as stays-main by design. If a future version wants to probe it (e.g.
+  Task-dispatch turns vs genuine reasoning), that's a separate classification problem.
 - `intent_kind` is sparsely populated on older sessions → precedence rule 7 fallback
   (`interactive`/stays) keeps it conservative (never over-claims savings).
 

--- a/docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md
+++ b/docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md
@@ -1,0 +1,176 @@
+# Main-thread routability lens - `ax cost routability`
+
+Date: 2026-06-15
+Status: design (pre-implementation)
+Branch: feat/cost-routability-lens
+Follows: cost-analytics module (`apps/axctl/src/queries/cost-analytics.ts`), dispatch routing
+classes + judgment guard (`apps/axctl/src/queries/routing-tune.ts` `JUDGMENT_GUARD_RE`,
+`dispatch-analytics.ts` reprice/MODEL_ALIASES), the route-dispatch / efficient-dispatch loop.
+
+## Problem
+
+`ax cost split` shows the main agent is **78–81% of spend** every window - on one machine,
+~$17.7K/30d main vs ~$4.9K subagent. The whole routing-tune loop optimizes the ~20%
+subagent tail (the $605/mo addressable leak). The bigger, unmeasured lever is the main
+thread itself: work the main agent did *in-line on the frontier model* that could have been
+a bounded dispatch to a cheap subagent ("subagent-driven development").
+
+The behavioral shift is already visible - dispatch rate ramped 19→114/day (6×) over 90 days
+as the operator pushed work out. But ax cannot yet **quantify** it: subagent dispatches carry
+a description (routability-classified), main-agent turns do **not**. So "how much of the main
+spend was routable-to-cheap vs genuine judgment" is invisible.
+
+This lens answers that question with a deterministic estimate.
+
+## Non-goals
+
+- Not ground truth. It is a heuristic estimate over tool composition + reasoning signal,
+  labeled as such (same honesty as the routing-tune projections).
+- Not enforcement / not a hook. A read-only analytics lens.
+- Not phase detection (research/implement/review labeling) - that is a clean v2 dimension;
+  the schema leaves room (an optional `phase` column) but v0 does not compute it.
+- No LLM classification. Deterministic only (fits ax's receipt ethos).
+
+## Core idea: classify main-thread **class-runs**
+
+Routable main-agent work is multi-turn (a research sweep, a mechanical refactor), and a
+**user turn is a judgment boundary** (the human stepped in). So:
+
+1. Take main-agent turns only (`turn_token_usage.source != 'claude-subagent'`), ordered by
+   `(session, seq)`.
+2. Split the thread at every `role = 'user'` turn → **segments**.
+3. Within each segment, group **consecutive turns sharing a work-class** → a **span**
+   (a maximal class-run).
+4. A span is **routable** iff its class is routable AND its run length ≥ `--min-run`
+   (default 3) - so a stray `Read` between decisions is never billed as "should've been a
+   subagent." Routable work clusters; the threshold enforces that.
+
+Class-runs are *finer than phases*: a "research" segment decomposes into alternating
+`gather` runs (routable) and `synthesis` runs (stays main) automatically - which captures
+"niche research → subagent, reasoning → smart agent" without modeling phases.
+
+## Work-class taxonomy (the A+B blend)
+
+Each main-agent turn is assigned ONE class from its tool composition (A) with
+`thinking_tokens`/`intent_kind` as tiebreak (B). Routable classes carry a target tier;
+the rest stay main.
+
+| class              | signal                                                              | verdict            |
+|--------------------|---------------------------------------------------------------------|--------------------|
+| `gather`           | Read/Grep/Glob/LS dominant, `thinking_tokens` ≈ 0                    | routable → haiku   |
+| `niche-research`   | reads + WebFetch/WebSearch/docs, low thinking                       | routable → sonnet  |
+| `mechanical-impl`  | Edit/Write/Bash dominant, low thinking, no decision `intent_kind`   | routable → sonnet  |
+| `synthesis`        | high `thinking_tokens`, few/no tools                                | stays main         |
+| `design-decision`  | thinking + edits together, or `JUDGMENT_GUARD_RE`/decision intent   | stays main         |
+| `interactive`      | turn adjacent to a user turn, `intent_kind` correction/preference   | stays main         |
+
+Classification precedence (first match wins, judgment-first so it can never be routed):
+1. `interactive` - turn immediately follows/precedes a user turn in the segment, or
+   `intent_kind ∈ {correction, preference, wrapper_instruction}`.
+2. `design-decision` - `JUDGMENT_GUARD_RE` matches the turn text, OR (`thinking_tokens` ≥
+   `THINK_HI` AND has edits).
+3. `synthesis` - `thinking_tokens` ≥ `THINK_HI` AND tool count ≤ `TOOL_LO`.
+4. `mechanical-impl` - edit/bash tools dominate, `thinking_tokens` < `THINK_HI`.
+5. `niche-research` - research tools (WebFetch/WebSearch) present, read-heavy.
+6. `gather` - read-only tools dominate.
+7. fallback → `interactive` (conservative: unclassified stays main).
+
+Thresholds (`THINK_HI`, `TOOL_LO`, `min-run`) are module constants, `--min-run` overridable.
+Default `THINK_HI` calibrated against real data during build (start ~1500 output tokens of
+thinking); `TOOL_LO` ~1. Tool-class sets reuse the routing-table grain
+(search-locate→haiku, well-specified-impl→sonnet).
+
+## Cost + repricing
+
+Per-turn cost = `turn_token_usage.estimated_cost_usd` joined to its `turn`. A span's
+`main_cost` = sum over its turns. Repricing reuses `dispatch-analytics` `reprice(usage,
+modelName)` + `MODEL_ALIASES` (haiku/sonnet → full model id) on each routable span's token
+counts. `est_savings` = `main_cost − repriced`. Spans with non-positive savings (already
+cheap) contribute 0, never negative.
+
+Honest caveats surfaced in output: estimate from historical token counts, not A/B parity;
+assumes the routable chunk would run equivalently one tier down; main turns that genuinely
+needed frontier judgment are deliberately left in "stays main."
+
+## Module shape
+
+```
+apps/axctl/src/queries/routability.ts        classifyTurn (pure) + buildSpans (pure) +
+                                              fetchRoutability (Effect.fn, SurrealClient)
+apps/axctl/src/queries/routability.test.ts   pure-core unit tests (classify + span build
+                                              + reprice math) over fixture turns
+apps/axctl/src/cli/commands/ax-cost.ts        wire `routability` subcommand + flags + render
+```
+
+Pure cores (`classifyTurn`, `buildSpans`, savings math) are exhaustively unit-tested over
+fixture turn/tool_call/usage rows - no DB. `fetchRoutability` follows the existing
+`fetchCostSplit` shape: one `db.query` pulling main-agent turns with their tool names,
+thinking tokens, intent, and per-turn cost; all span-grouping + classification happens in JS
+(matches the module's "derived dimensions in JS" precedent - see cost-analytics.ts:5).
+
+### Query inputs / outputs
+
+```ts
+interface RoutabilityInput { days: number; minRun: number }       // contract object
+interface RoutabilityClassRow {
+  class: string; verdict: "routable" | "stays";
+  runs: number; turns: number; mainCostUsd: number;
+  tier: string | null; repricedUsd: number | null; estSavingsUsd: number | null;
+}
+interface RoutabilityResult {
+  mainSpendUsd: number; routableUsd: number; routablePct: number; estSavingsUsd: number;
+  rows: ReadonlyArray<RoutabilityClassRow>;   // routable rows + a single "stays main" rollup
+  days: number; minRun: number;
+}
+```
+
+## CLI surface
+
+`ax cost routability [--days=N] [--min-run=3] [--json]` - in the `cost` namespace
+(cost-analytics already owns the main/subagent origin logic). Default window 30d to match the
+other cost commands. `--json` returns the `RoutabilityResult` envelope.
+
+Render:
+
+```
+$ ax cost routability --days=30
+
+main-agent spend: $17,756   routable: $6,120 (34%)   est. savings: $4,890
+
+class            runs   turns   main_cost   tier     repriced   est_savings
+gather             142    518    $2,310      haiku    $  185     $2,125
+mechanical-impl     88    402    $2,740      sonnet   $  822     $1,918
+niche-research      41    160    $1,070      sonnet   $  321     $  749
+stays main (synthesis/design-decision/interactive)   $11,636    -
+
+estimate from historical token counts; judgment work left on frontier by design.
+next: ax dispatches --candidates   # the subagent-side leak
+```
+
+(Numbers illustrative; real figures computed at run.)
+
+## Reactivity / MCP
+
+- Add `cost_routability` to the read-only MCP tool registry (mirrors `cost_models`,
+  `cost_split`).
+- No ingest change - reads existing `turn` / `tool_call` / `turn_token_usage` graph.
+- Docs: CLAUDE.md "Cost analytics" block gains the new subcommand (the new-subcommand docs
+  gate).
+
+## Risks / open calibration
+
+- `THINK_HI` / `TOOL_LO` thresholds are the accuracy knob - calibrate against a hand-labeled
+  sample of real main spans during build; print the chosen constants in `--json` so a run is
+  auditable.
+- Codex/other harnesses: `thinking_tokens` coverage varies (claude mixed turns read 0 →
+  lower bound). The lens is most accurate on Claude main sessions; non-claude main turns fall
+  to `mechanical-impl`/`gather` on tool mix alone (no reasoning signal) - acceptable, noted.
+- `intent_kind` is sparsely populated on older sessions → precedence rule 7 fallback
+  (`interactive`/stays) keeps it conservative (never over-claims savings).
+
+## v2 (out of scope)
+
+- Phase labeling (research/implement/review) as a second grouping dimension.
+- Per-session routability drill-down (`ax cost routability --here` / `<session>`).
+- Tie the lens to the dispatch-rate trend (the 6× ramp) as a "how much did pushing work out
+  actually save" before/after.

--- a/docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md
+++ b/docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md
@@ -60,10 +60,11 @@ Two design assumptions in the original draft were refuted by the data and correc
   first assistant turn of each segment to `interactive`. `minRun=3` gated out ~everything
   (0.0% routable). The **turn is the natural unit**, so the default is `minRun=1`.
 
-At `minRun=1` on the reference machine, ~34% of main-agent assistant cost ($5.2K/30d)
-lands in routable classes - larger than the entire subagent routing leak. The class-run
-grouping mechanic is retained (it still merges adjacent same-class turns and powers the
-`--min-run` knob), just defaulted to 1.
+At `minRun=1` on the reference machine (Claude main only), ~22% of main-agent assistant
+cost is routable (~$3.2K/30d routable -> ~$1.8K/30d est. savings, ~$21K/yr) - several
+times the entire subagent routing leak ($605/mo). The class-run grouping mechanic is
+retained (it still merges adjacent same-class turns and powers the `--min-run` knob),
+just defaulted to 1.
 
 ## Work-class taxonomy (tool composition + text-judgment guard)
 
@@ -151,19 +152,19 @@ Render:
 ```
 $ ax cost routability --days=30
 
-main-agent spend: $15,137   routable: $5,162 (34%)   est. savings: ~$X
+main-agent spend: $14,460   routable: $3,236 (22%)   est. savings: $1,764
 
 class            runs   turns   main_cost   tier     repriced   est_savings
-mechanical-impl  ...    ...     $4,498      sonnet   ...        ...
-gather           ...    ...     $  628      haiku    ...        ...
-niche-research   ...    ...     $   35      sonnet   ...        ...
-stays main (interactive/design-decision)             $9,975     -
+mechanical-impl  ...    ...     $2,887      sonnet   $1,406     $1,481
+gather           ...    ...     $  326      haiku    $   56     $  270
+niche-research   ...    ...     $   23      sonnet   $   10     $   12
+stays main (interactive/design-decision)             $11,224    -
 
-estimate from historical token counts; judgment work left on frontier by design.
+estimate: edit/read turns assumed mechanically routable (upper-ish bound); claude main only.
 next: ax dispatches --candidates   # the subagent-side leak
 ```
 
-(Numbers from the reference-machine smoke test at minRun=1; est_savings filled at run.)
+(Numbers from the reference-machine smoke test, Claude main only, minRun=1.)
 
 ## Reactivity / MCP
 
@@ -180,9 +181,13 @@ next: ax dispatches --candidates   # the subagent-side leak
   lens can't see the reasoning that preceded the edit. This is a known over-count direction;
   `JUDGMENT_GUARD_RE` on the turn text is the only judgment catch. Acceptable for an
   estimate; a populated reasoning signal (`thinking_blocks`) is the v2 refinement.
-- **Non-Claude main spend is under-counted.** ~$3K/30d of main spend (GPT-5.x, etc.) has no
-  per-turn `turn_token_usage` cost row, so `mainSpendUsd` (~$15.1K) sits below the
-  `ax cost split` main total (~$18.1K). The lens is Claude-main accurate; note the gap.
+- **Claude-main only by construction.** `fetchRoutability` allowlists `turn_token_usage.source
+  = 'claude'`, so `mainSpendUsd` (~$14.5K/30d) is *Claude main-agent spend only* - it
+  deliberately excludes Codex/OpenCode/Cursor/Pi main turns (which carry other `source`
+  values, some with their own cost rows) and all `claude-subagent` rows. It therefore sits
+  below the cross-provider `ax cost split` main total by design; it is not a bug or an
+  under-count of Claude. Routing-class tool names are Claude-shaped, so this also avoids
+  mis-pricing non-Claude tool turns. Non-Claude routability is out of scope for v0.
 - The biggest pool - the `interactive` fallback ($9.7K/64%, pure-text/coordination/Task
   turns) - is left as stays-main by design. If a future version wants to probe it (e.g.
   Task-dispatch turns vs genuine reasoning), that's a separate classification problem.


### PR DESCRIPTION
## What

`ax cost routability` — a read-only lens estimating how much **main-agent** spend sat in work that could have been dispatched to a cheaper subagent ("subagent-driven development"), vs genuine judgment that should stay on the frontier model.

The routing-tune loop optimizes the ~20% **subagent** tail. This measures the other 80% — the main thread itself.

```
$ ax cost routability --days=30

main-agent spend: $14,478   routable: $3,240 (22%)   est. savings: $1,766

class            runs   turns   main_cost    tier     repriced    est_savings
mechanical-impl 10442   10499    $2890.34   sonnet    $1407.69     $1482.66
gather           1334    1348     $326.94   haiku       $56.01      $270.93
niche-research     71      95      $22.54   sonnet      $10.20       $12.34
stays main      28750   39481   $11238.33   -                -            -
```

~$1.8K/mo (~$21K/yr) on one machine — several times the entire subagent routing leak ($605/mo).

## How

Deterministic, no LLM. Classifies main-agent (`turn_token_usage.source = 'claude'` allowlist) turns from **tool composition** + a `JUDGMENT_GUARD_RE` text guard:

- `gather` (Read/Grep/Glob/LS) → haiku · `mechanical-impl` (Edit/Write/Bash) → sonnet · `niche-research` (WebFetch/WebSearch) → sonnet — **routable**
- `design-decision` (judgment text) · `interactive` (user-adjacent / coordination / pure-text) — **stays main**

Routable spans repriced one tier down via a shared `reprice.ts` (extracted from `dispatch-analytics`). Turn = the unit (`--min-run` default 1).

## Calibration (the spec pivoted on real data — see commits)

- `thinking_tokens` is a **dead signal** (0 on 96.6% of turns — transcripts strip thinking text), so the original thinking-based rules were dropped.
- Claude turns interleave too heavily for class-runs of ≥3 to form (77.7% length-1) → turn-level default.
- Allowlist `source='claude'` (not denylist `!= claude-subagent`) so non-Claude main spend never pollutes the denominator — the number is Claude-main-only by construction.
- Framed as an **upper-bound estimate** (reasoning before an edit isn't visible in the transcript), not ground truth.

## Surface

- CLI: `ax cost routability [--days=N] [--min-run=1] [--json]`
- MCP: `cost_routability` (17 read-only tools now)
- Docs: CLAUDE.md cost-analytics block

## Tests

4290 pass / 0 fail, typecheck clean. Pure cores (`classifyTurn` / `buildSpans` / `aggregateRoutability` / `reprice`) unit-tested with fixtures; `fetchRoutability` smoke-tested against the live graph.

Spec: `docs/superpowers/specs/2026-06-15-cost-routability-lens-design.md`
Plan: `docs/superpowers/plans/2026-06-15-cost-routability-lens.md`

## Follow-ups (noted, non-blocking)

- `--min-run > 1` is near-useless in practice (tool_result turns break runs) — fine at default 1; retire or document.
- v2: probe the $11K "stays main" bucket (Task-dispatch vs genuine reasoning); `thinking_blocks` as a real reasoning signal; phase labeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)