### PR TITLE
polish(studio): quieter /sessions signal column + centered hero + fix overflow white bleed

### DIFF
--- a/apps/studio/src/components/session-insight/SignalBadge.tsx
+++ b/apps/studio/src/components/session-insight/SignalBadge.tsx
@@ -1,20 +1,37 @@
-/** Rightmost triage badge: clean (green) / friction N (red) / – (no data). */
+/** Rightmost triage signal: clean (green) / friction N (red) / – (no data).
+ *  Instrument readout, not a loud pill - colour lives in a single status dot,
+ *  the label stays neutral mono so a column of these reads calm. The friction
+ *  count is the one emphasised glyph (it's the signal worth noticing). */
 export function SignalBadge({ signal, friction }: {
     readonly signal: "clean" | "friction" | null;
     readonly friction: number | null;
 }) {
-    if (signal === null) return <span style={{ color: "var(--sx-ink-300)" }}>–</span>;
+    if (signal === null) return <span style={{ color: "var(--dim)", fontSize: 10 }}>–</span>;
     const warn = signal === "friction";
     return (
         <span style={{
-            fontSize: 10,
-            fontWeight: 600,
-            padding: "1px 6px",
-            borderRadius: 2,
-            background: warn ? "var(--sx-red-100)" : "var(--sx-green-100)",
-            color: warn ? "var(--sx-red-700)" : "var(--sx-green-700)",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontFamily: "var(--mono)",
+            fontSize: 10.5,
+            letterSpacing: "0.04em",
+            color: "var(--sec)",
+            whiteSpace: "nowrap",
         }}>
-            {warn ? `friction ${friction ?? ""}` : "clean"}
+            <span
+                aria-hidden="true"
+                style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: "50%",
+                    background: warn ? "var(--red)" : "var(--green)",
+                    flex: "none",
+                }}
+            />
+            {warn ? (
+                <>friction <b style={{ color: "var(--pri)", fontWeight: 600, fontVariantNumeric: "tabular-nums" }}>{friction ?? ""}</b></>
+            ) : "clean"}
         </span>
     );
 }

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -4033,10 +4033,16 @@ td.skill-cell .description {
    the rest of the kit: green accent, orange = alert only, no coloured chrome.
    ========================================================================= */
 .rdx .sessions-instrument { border: 0; background: transparent; padding: 0; }
-/* overflow:visible keeps the body as the vertical scroll container so the
-   thead can be viewport-sticky; the table just spills horizontally on a
-   too-narrow viewport (rare on the desktop target). */
-.rdx .sessions-instrument .sx-scroll { overflow: visible; }
+/* Contained scroll pane: the table scrolls inside its own box on BOTH axes, so
+   (a) the sticky thead pins to the top of this pane, and (b) the wide table
+   never overflows the dark .rdx shell horizontally (which would expose the
+   light page body to the right). max-height leaves room for the masthead +
+   controls above. */
+.rdx .sessions-instrument .sx-scroll {
+    overflow: auto;
+    max-height: calc(100dvh - 196px);
+    overscroll-behavior: contain;
+}
 .rdx .sessions-instrument table.sx-sessions {
     width: 100%;
     min-width: 1280px;
@@ -4044,9 +4050,12 @@ td.skill-cell .description {
     font-family: var(--sans);
     font-size: 13px;
 }
-/* sticky column-header row: pins to the top of the page scroll while the
-   list scrolls under it. Opaque page bg masks the rows; hairline + faint
-   shadow separate it once content is beneath. */
+/* The Doto hero is a short 2-line block; center the masthead row so the big
+   number sits against the title instead of floating above its baseline. */
+.rdx .sessions-instrument .inst-head-top { align-items: center; }
+/* sticky column-header row: pins to the top of the scroll pane while the
+   list scrolls under it. Opaque page bg masks the rows; hairline separates
+   it once content is beneath. */
 .rdx .sessions-instrument table.sx-sessions thead th {
     position: sticky;
     top: 0;


### PR DESCRIPTION
Taste pass on the `/sessions` instrument view (follow-up to #433).

## What changed
- **Quieter signal column.** `SignalBadge` dropped the loud filled pills — a column of red "friction" blocks dominated the right side. Now a single status dot carries the colour (green clean / red friction) with a neutral mono label; the friction *count* is the one emphasised glyph. Colour lives only in the dot, matching the source-chip house pattern.
- **Centered hero.** The masthead row is center-aligned so the Doto hero (`1,863`) sits against the `SESSIONS` title instead of floating above its baseline. Sessions-scoped — the shared `.inst-hero` (Context Budget) is untouched.
- **Fixed a white-bleed bug.** #433's sticky-header fix set `.sx-scroll` to `overflow:visible`, so the 1280px-min table overflowed the dark `.rdx` shell horizontally and exposed the light page body on the right when scrolled. Switched to a **contained scroll pane** (`overflow:auto` + `max-height`): the table scrolls inside its own box on both axes, the sticky thead pins to the pane top, and nothing bleeds past the dark shell.

## Verified
- `bun run typecheck` (apps/studio): **0 errors**.
- Live desktop captures (1480px): signal column calm (`• clean` / `• friction N`), hero centered, no white bleed when zoomed + scrolled right/down, sticky thead still pins within the pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
