### PR TITLE
feat(insights): multi-hop telemetry enrichment of behavior insights

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,19 @@ docs/superpowers/specs/2026-06-15-otel-receiver-design.md.
 `ax cost sessions [--days=N] [--model=<name>] [--limit=N]` - top sessions by cost with id, project, model, started_at (default 14d/20 rows).
 `ax cost split [--days=N]` - origin (main vs subagent) × model matrix with cost and share-of-total; totals row. MCP: `cost_models`, `cost_split`.
 
+### Telemetry-enriched insights
+
+Existing behavior insights traverse the `telemetry_of` edge to attach
+OTLP-sourced cost/latency (shared helper `apps/axctl/src/queries/telemetry-rollup.ts`,
+batched + deref-free): `ax sessions churn` rows gain `otlp_cost_usd`/`otlp_tokens`
+(cost per episode); `fragility_cascade` edges gain `downstream_cost_usd`; the
+`ax insights friction` view gains per-row OTLP cost; `ax skills weighted` gains
+`median_recovery_ms` (recovery latency from `otel_log_event.duration_ms`).
+OTLP-sourced, kept SEPARATE from transcript `session_token_usage` cost (no
+double-count); columns/fields are null when a session has no telemetry. Lights
+up as OTLP data accumulates. Spec:
+docs/superpowers/specs/2026-06-15-telemetry-insight-enrichment-design.md.
+
 ### Plan quota
 
 `ax quota [--json|--statusline|--swiftbar] [--max-age=N] [--fresh]` - live Claude

--- a/apps/axctl/src/cli/insights-format.ts
+++ b/apps/axctl/src/cli/insights-format.ts
@@ -205,6 +205,23 @@ function formatClassifierThemeRows(rows: readonly InsightRow[]): string {
     }).join("\n\n");
 }
 
+function formatFrictionRows(rows: readonly InsightRow[]): string {
+    if (rows.length === 0) return "No friction events found.";
+    const hasCost = rows.some((r) => r.otlp_cost_usd != null);
+    return rows.map((row, index) => {
+        const costStr = hasCost
+            ? (row.otlp_cost_usd != null
+                ? `  cost$=${("$" + (row.otlp_cost_usd as number).toFixed(3))}`
+                : "  cost$=-")
+            : "";
+        return [
+            `${index + 1}. ${textOf(row.kind)}${costStr}  ${compactDate(row.ts)}`,
+            row.text ? `   ${truncate(row.text)}` : null,
+            row.project ? `   project=${textOf(row.project)}` : null,
+        ].filter(Boolean).join("\n");
+    }).join("\n\n");
+}
+
 function formatHarnessCandidateRows(rows: readonly InsightRow[]): string {
     if (rows.length === 0) return "No harness candidates found.";
     return rows.map((row, index) => {
@@ -236,6 +253,8 @@ function formatHarnessCandidateRows(rows: readonly InsightRow[]): string {
 export function formatInsightRows(view: InsightView, rows: readonly InsightRow[], opts: { readonly json?: boolean } = {}): string {
     if (opts.json) return prettyPrint(rows);
     switch (view) {
+        case "friction":
+            return formatFrictionRows(rows);
         case "feedback-language":
         case "message-signals":
             return formatSignalRows(rows);

--- a/apps/axctl/src/cli/skills-weighted-format.test.ts
+++ b/apps/axctl/src/cli/skills-weighted-format.test.ts
@@ -21,6 +21,7 @@ const twoClassified: SkillsWeightedResult = {
             roles: ["framing", "execution"],
             weight: 2.0,
             score: 248.0,
+            median_recovery_ms: null,
         },
         {
             skill_id: "skill:⟨caveman⟩",
@@ -30,6 +31,7 @@ const twoClassified: SkillsWeightedResult = {
             roles: ["execution-mode"],
             weight: 1.0,
             score: 87.0,
+            median_recovery_ms: null,
         },
     ],
     doctor: {
@@ -49,6 +51,7 @@ const withUnclassified: SkillsWeightedResult = {
             roles: ["framing", "execution"],
             weight: 2.0,
             score: 248.0,
+            median_recovery_ms: null,
         },
         {
             skill_id: "skill:⟨worktree-read-strategy⟩",
@@ -58,6 +61,7 @@ const withUnclassified: SkillsWeightedResult = {
             roles: [],
             weight: 1.0,
             score: 62.0,
+            median_recovery_ms: null,
         },
     ],
     doctor: {

--- a/apps/axctl/src/cli/skills-weighted-format.ts
+++ b/apps/axctl/src/cli/skills-weighted-format.ts
@@ -54,6 +54,9 @@ export function renderWeightedTable(result: SkillsWeightedResult): string {
         return lines.join("\n");
     }
 
+    // Show recovery_ms column only when at least one row has telemetry data.
+    const hasRecovery = rows.some((r) => r.median_recovery_ms != null);
+
     // Pre-compute column values so we can compute widths.
     type RenderedRow = {
         rank: string;
@@ -63,6 +66,7 @@ export function renderWeightedTable(result: SkillsWeightedResult): string {
         roles: string;
         weight: string;
         score: string;
+        recovery_ms: string;
     };
 
     const rendered: RenderedRow[] = rows.map((r, i) => ({
@@ -73,6 +77,7 @@ export function renderWeightedTable(result: SkillsWeightedResult): string {
         roles: fmtRoles(r.roles),
         weight: fmtFloat(r.weight),
         score: fmtFloat(r.score),
+        recovery_ms: r.median_recovery_ms != null ? fmtCount(Math.round(r.median_recovery_ms)) : "–",
     }));
 
     // Compute column widths (header floor).
@@ -84,6 +89,7 @@ export function renderWeightedTable(result: SkillsWeightedResult): string {
         roles: "roles",
         weight: "weight",
         score: "score",
+        recovery_ms: "recov_ms",
     };
 
     const colWidth = (key: keyof RenderedRow): number =>
@@ -99,6 +105,7 @@ export function renderWeightedTable(result: SkillsWeightedResult): string {
     const rolesW = Math.max(colWidth("roles"), 20);
     const wtW = colWidth("weight");
     const scoreW = colWidth("score");
+    const recovW = colWidth("recovery_ms");
 
     const header =
         headers.rank.padStart(rankW) +
@@ -113,7 +120,8 @@ export function renderWeightedTable(result: SkillsWeightedResult): string {
         "  " +
         headers.weight.padStart(wtW) +
         "  " +
-        headers.score.padStart(scoreW);
+        headers.score.padStart(scoreW) +
+        (hasRecovery ? "  " + headers.recovery_ms.padStart(recovW) : "");
 
     lines.push(header);
 
@@ -131,7 +139,8 @@ export function renderWeightedTable(result: SkillsWeightedResult): string {
             "  " +
             r.weight.padStart(wtW) +
             "  " +
-            r.score.padStart(scoreW);
+            r.score.padStart(scoreW) +
+            (hasRecovery ? "  " + r.recovery_ms.padStart(recovW) : "");
         lines.push(line);
     }
 
@@ -154,6 +163,7 @@ export interface WeightedJsonOutput {
         readonly roles: readonly string[];
         readonly weight: number;
         readonly score: number;
+        readonly median_recovery_ms: number | null;
     }>;
     readonly doctor: {
         readonly unclassified_count: number;
@@ -172,6 +182,7 @@ export function renderWeightedJson(result: SkillsWeightedResult): string {
             roles: r.roles,
             weight: r.weight,
             score: r.score,
+            median_recovery_ms: r.median_recovery_ms,
         })),
         doctor: {
             unclassified_count: result.doctor.unclassified_count,

--- a/apps/axctl/src/dashboard/next-actions.test.ts
+++ b/apps/axctl/src/dashboard/next-actions.test.ts
@@ -138,6 +138,8 @@ const churnRow = (
     episodes: verificationFailures > 0 ? 1 : 0,
     passedEpisodes: 0,
     topCheck: "test",
+    otlp_cost_usd: null,
+    otlp_tokens: null,
 });
 
 const makeCandidate = (

--- a/apps/axctl/src/dashboard/skills-weighted.test.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.test.ts
@@ -6,6 +6,7 @@
  * - Rows are merged correctly (role weights summed, floor 1.0).
  * - Doctor count and advice trigger at the threshold.
  * - Spar sessions are excluded from the weighted ranking.
+ * - Recovery latency (lens E): median_recovery_ms from recovered_by edges.
  *
  * Query order (call index):
  *   0 → fetchSparSessionIds (spar exclusion ids)
@@ -15,6 +16,8 @@
  *   4 → deleted skill ids
  *   5 → synthetic skill ids
  *   6 → skill names
+ *   7 → recovered_by edges (skill → session mapping)
+ *   8 → otel_log_event latency (from sessionTelemetryLatency, when sessions found)
  */
 import { describe, it, expect } from "bun:test";
 import { RecordId } from "surrealdb";
@@ -231,5 +234,152 @@ describe("fetchSkillsWeighted", () => {
         const invCall = db.calls[1];
         const bound = invCall?.bindings?.sparSessions as unknown[];
         expect(bound.some((b) => b instanceof RecordId && String(b) === "session:⟨spar-variant⟩")).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Recovery latency (lens E)
+// ---------------------------------------------------------------------------
+
+describe("recovery latency (lens E)", () => {
+    // recovered_by edges: tdd recovered 2 sessions; caveman has none.
+    const mockRecoveryEdges = [
+        [
+            { skill: "skill:⟨superpowers:tdd⟩", session: "session:sess-abc" },
+            { skill: "skill:⟨superpowers:tdd⟩", session: "session:sess-def" },
+        ],
+    ];
+
+    // otel_log_event latency for the two recovery sessions
+    const mockLatencyRows = [
+        [
+            { session_id: "sess-abc", d: 4000, n: 5 },
+            { session_id: "sess-def", d: 6000, n: 8 },
+        ],
+    ];
+
+    it("computes median_recovery_ms as median of recovery session durations", async () => {
+        const db = makeMockDb([
+            noSparSessions,    // 0 - spar ids
+            mockInvRows,       // 1 - invocation aggregate
+            mockRoleRows,      // 2 - role weights
+            mockDoctorBelow,   // 3 - doctor
+            [[]],              // 4 - deleted
+            [[]],              // 5 - synthetic
+            [[]],              // 6 - names
+            mockRecoveryEdges, // 7 - recovered_by
+            mockLatencyRows,   // 8 - otel_log_event latency
+        ]);
+
+        const result = await runWithMock(db, fetchSkillsWeighted());
+        const tdd = result.rows.find((r) => r.skill_name === "superpowers:tdd")!;
+
+        // median of [4000, 6000] (sorted) = (4000+6000)/2 = 5000
+        expect(tdd.median_recovery_ms).toBe(5000);
+    });
+
+    it("sets median_recovery_ms=null for skills with no recovery edges", async () => {
+        const db = makeMockDb([
+            noSparSessions,
+            mockInvRows,
+            mockRoleRows,
+            mockDoctorBelow,
+            [[]],
+            [[]],
+            [[]],
+            mockRecoveryEdges, // only tdd in edges; caveman absent
+            mockLatencyRows,
+        ]);
+
+        const result = await runWithMock(db, fetchSkillsWeighted());
+        const caveman = result.rows.find((r) => r.skill_name === "caveman")!;
+
+        expect(caveman.median_recovery_ms).toBeNull();
+    });
+
+    it("sets median_recovery_ms=null for all rows when no recovery edges exist", async () => {
+        const db = makeMockDb([
+            noSparSessions,
+            mockInvRows,
+            mockRoleRows,
+            mockDoctorBelow,
+            [[]],
+            [[]],
+            [[]],
+            [[]], // empty recovered_by - sessionTelemetryLatency exits early (no call 8)
+        ]);
+
+        const result = await runWithMock(db, fetchSkillsWeighted());
+
+        for (const row of result.rows) {
+            expect(row.median_recovery_ms).toBeNull();
+        }
+    });
+
+    it("recovered_by query is issued as a separate pass (index 7)", async () => {
+        const db = makeMockDb([
+            noSparSessions,
+            mockInvRows,
+            mockRoleRows,
+            mockDoctorBelow,
+        ]);
+
+        await runWithMock(db, fetchSkillsWeighted());
+
+        expect(db.captured[7]).toContain("recovered_by");
+    });
+
+    it("single recovery session: median_recovery_ms equals its duration", async () => {
+        const singleEdge = [[{ skill: "skill:⟨superpowers:tdd⟩", session: "session:only-one" }]];
+        const singleLatency = [[{ session_id: "only-one", d: 3750, n: 2 }]];
+
+        const db = makeMockDb([
+            noSparSessions,
+            mockInvRows,
+            mockRoleRows,
+            mockDoctorBelow,
+            [[]],
+            [[]],
+            [[]],
+            singleEdge,
+            singleLatency,
+        ]);
+
+        const result = await runWithMock(db, fetchSkillsWeighted());
+        const tdd = result.rows.find((r) => r.skill_name === "superpowers:tdd")!;
+
+        expect(tdd.median_recovery_ms).toBe(3750);
+    });
+
+    it("sessions with no telemetry data do not contribute to median", async () => {
+        // 3 edges for tdd; only 2 have latency data
+        const edges = [[
+            { skill: "skill:⟨superpowers:tdd⟩", session: "session:s1" },
+            { skill: "skill:⟨superpowers:tdd⟩", session: "session:s2" },
+            { skill: "skill:⟨superpowers:tdd⟩", session: "session:s3-no-telemetry" },
+        ]];
+        // s3-no-telemetry is absent from otel_log_event
+        const latency = [[
+            { session_id: "s1", d: 1000, n: 1 },
+            { session_id: "s2", d: 3000, n: 3 },
+        ]];
+
+        const db = makeMockDb([
+            noSparSessions,
+            mockInvRows,
+            mockRoleRows,
+            mockDoctorBelow,
+            [[]],
+            [[]],
+            [[]],
+            edges,
+            latency,
+        ]);
+
+        const result = await runWithMock(db, fetchSkillsWeighted());
+        const tdd = result.rows.find((r) => r.skill_name === "superpowers:tdd")!;
+
+        // median of [1000, 3000] = 2000 (s3 absent → not counted)
+        expect(tdd.median_recovery_ms).toBe(2000);
     });
 });

--- a/apps/axctl/src/dashboard/skills-weighted.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.ts
@@ -11,6 +11,7 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { fetchSparSessionIds } from "../queries/spar-sessions.ts";
+import { sessionTelemetryLatency, bareSession } from "../queries/telemetry-rollup.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -24,6 +25,12 @@ export interface WeightedSkillRow {
     readonly roles: readonly string[];
     readonly weight: number;
     readonly score: number;
+    /**
+     * Median duration_ms of sessions where this skill appears in a `recovered_by`
+     * edge (i.e. was used to recover from a failure). Source: `otel_log_event`.
+     * null when the skill has no recovery telemetry.
+     */
+    readonly median_recovery_ms: number | null;
 }
 
 export interface DoctorResult {
@@ -315,6 +322,7 @@ export const fetchSkillsWeighted = (
                 roles,
                 weight: weightSum,
                 score,
+                median_recovery_ms: null, // filled in by the recovery pass below
             });
         }
 
@@ -326,6 +334,79 @@ export const fetchSkillsWeighted = (
         });
 
         const topRows = rows.slice(0, limit);
+
+        // ---------------------------------------------------------------------------
+        // Recovery latency pass (lens E) - separate batched queries, no per-row derefs
+        //
+        // The `recovered_by` edge is TYPE RELATION FROM turn TO skill. We resolve
+        // turn→session via a one-hop deref (`in.session`) in a single batched query
+        // over the whole edge table. This is intentionally SEPARATE from the main
+        // weighted aggregate (which is deref-free) to avoid the stacked-deref hang
+        // that hit the invoked-edge query on 87k+ rows.
+        // ---------------------------------------------------------------------------
+
+        /**
+         * SQL to fetch all recovered_by edges mapped to their skill and session.
+         * `in.session` dereferences the turn record's `session` field in one hop.
+         * If the live DB ever fails this deref, the fallback is a 2-query approach:
+         *   1. SELECT type::string(out) AS skill, type::string(in) AS turn FROM recovered_by
+         *   2. SELECT type::string(id) AS turn, type::string(session) AS session FROM turn WHERE id IN [...]
+         */
+        const RECOVERY_EDGES_SQL = `SELECT type::string(out) AS skill, type::string(in.session) AS session FROM recovered_by;`;
+
+        const recoveryEdgesRes = yield* db.query<[Array<Record<string, unknown>>]>(RECOVERY_EDGES_SQL);
+        const recoveryEdges = (recoveryEdgesRes?.[0] ?? []) as Array<Record<string, unknown>>;
+
+        // Build Map<skillId, sessionId[]>
+        const skillToSessions = new Map<string, string[]>();
+        for (const r of recoveryEdges) {
+            const skillId = String(r.skill ?? "");
+            const session = String(r.session ?? "");
+            if (!skillId || !session) continue;
+            const list = skillToSessions.get(skillId);
+            if (list) {
+                list.push(session);
+            } else {
+                skillToSessions.set(skillId, [session]);
+            }
+        }
+
+        // Collect unique session ids across all recovery skills
+        const allRecoverySessions = [...new Set(
+            [...skillToSessions.values()].flat(),
+        )];
+
+        // One batched call to fetch latency for all recovery sessions
+        const latencyMap = yield* sessionTelemetryLatency(allRecoverySessions);
+
+        // Compute per-skill median recovery duration
+        const skillMedianMs = new Map<string, number | null>();
+        for (const [skillId, sessionIds] of skillToSessions) {
+            const durations: number[] = [];
+            for (const sid of sessionIds) {
+                const entry = latencyMap.get(bareSession(sid));
+                if (entry?.duration_ms != null) {
+                    durations.push(entry.duration_ms);
+                }
+            }
+            if (durations.length === 0) {
+                skillMedianMs.set(skillId, null);
+            } else {
+                durations.sort((a, b) => a - b);
+                const mid = Math.floor(durations.length / 2);
+                const median =
+                    durations.length % 2 === 0
+                        ? ((durations[mid - 1]! + durations[mid]!) / 2)
+                        : durations[mid]!;
+                skillMedianMs.set(skillId, median);
+            }
+        }
+
+        // Merge onto topRows (immutable: create new row objects)
+        const finalRows = topRows.map((row) => ({
+            ...row,
+            median_recovery_ms: skillMedianMs.get(row.skill_id) ?? null,
+        }));
 
         // ---------------------------------------------------------------------------
         // Doctor
@@ -346,7 +427,7 @@ export const fetchSkillsWeighted = (
                 : null;
 
         return {
-            rows: topRows,
+            rows: finalRows,
             doctor: {
                 unclassified_count: unclassifiedCount,
                 threshold: doctorThreshold,

--- a/apps/axctl/src/dojo/items.test.ts
+++ b/apps/axctl/src/dojo/items.test.ts
@@ -51,6 +51,8 @@ const churnRow = (
     episodes,
     passedEpisodes: passed,
     topCheck: "typecheck",
+    otlp_cost_usd: null,
+    otlp_tokens: null,
 });
 
 describe("item mappers", () => {

--- a/apps/axctl/src/metrics/fragility-cascade.test.ts
+++ b/apps/axctl/src/metrics/fragility-cascade.test.ts
@@ -29,6 +29,10 @@ interface Fixture {
     cascadeRows?: Array<Record<string, unknown>>;
     /** Stored cascade watermark rows (ingest_file_state). */
     watermarkRows?: Array<Record<string, unknown>>;
+    /** OTLP metric point rows (otel_metric_point) for sessionTelemetryCost. */
+    otelMetricRows?: Array<Record<string, unknown>>;
+    /** OTLP log event rows (otel_log_event) for sessionTelemetryCost. */
+    otelLogRows?: Array<Record<string, unknown>>;
     sink?: string[];
     seenSql?: string[];
 }
@@ -52,6 +56,8 @@ const db = (fx: Fixture) =>
             if (/FROM \[turn:/.test(sql)) return Effect.succeed([fx.turns ?? []] as unknown as T);
             if (/FROM produced/.test(sql)) return Effect.succeed([fx.produced ?? []] as unknown as T);
             if (/FROM edited/.test(sql)) return Effect.succeed([fx.edited ?? []] as unknown as T);
+            if (/FROM otel_metric_point/.test(sql)) return Effect.succeed([fx.otelMetricRows ?? []] as unknown as T);
+            if (/FROM otel_log_event/.test(sql)) return Effect.succeed([fx.otelLogRows ?? []] as unknown as T);
             return Effect.succeed([[]] as unknown as T);
         },
     } as never);
@@ -95,7 +101,7 @@ describe("computeFragilityCascade (cross-namespace bridge)", () => {
             turns: [{ id: "turn:`tB`", session: "session:`B`" }],
         };
         const edges = await run(computeFragilityCascade(), fx);
-        expect(edges).toEqual([{ origin: "session:`A`", downstream: "session:`B`", weight: 1 }]);
+        expect(edges).toEqual([{ origin: "session:`A`", downstream: "session:`B`", weight: 1, downstream_cost_usd: null, downstream_tokens: null }]);
     });
 
     test("origin→downstream edges weighted by distinct downstream fixers (direct keys)", async () => {
@@ -189,7 +195,7 @@ describe("computeFragilityCascade (cross-namespace bridge)", () => {
             turns: [{ id: "turn:`tB`", session: "session:`B`" }],
         };
         const edges = await run(computeFragilityCascade(limits), fx);
-        expect(edges).toEqual([{ origin: "session:`A`", downstream: "session:`B`", weight: 1 }]);
+        expect(edges).toEqual([{ origin: "session:`A`", downstream: "session:`B`", weight: 1, downstream_cost_usd: null, downstream_tokens: null }]);
     });
 
     test("the edited query selects the RAW in (turn) ref - never an in.session deref", async () => {
@@ -251,8 +257,8 @@ describe("persist + read (derive-stage precompute)", () => {
         const sink: string[] = [];
         const written = await run(
             persistFragilityCascade([
-                { origin: "session:`A`", downstream: "session:`B`", weight: 2 },
-                { origin: "session:⟨a-b-c⟩", downstream: "session:`D`", weight: 1 },
+                { origin: "session:`A`", downstream: "session:`B`", weight: 2, downstream_cost_usd: null, downstream_tokens: null },
+                { origin: "session:⟨a-b-c⟩", downstream: "session:`D`", weight: 1, downstream_cost_usd: null, downstream_tokens: null },
             ]),
             { sink },
         );
@@ -338,6 +344,28 @@ describe("persist + read (derive-stage precompute)", () => {
                 { origin: null, downstream: "session:`B`", weight: 1 }, // malformed → dropped
             ],
         });
-        expect(edges).toEqual([{ origin: "session:`A`", downstream: "session:`B`", weight: 3 }]);
+        expect(edges).toEqual([{ origin: "session:`A`", downstream: "session:`B`", weight: 3, downstream_cost_usd: null, downstream_tokens: null }]);
+    });
+
+    test("readFragilityCascade enriches edges with downstream OTLP cost; missing telemetry → null", async () => {
+        const fx: Fixture = {
+            cascadeRows: [
+                { origin: "session:`A`", downstream: "session:`B`", weight: 3 },
+                { origin: "session:`A`", downstream: "session:`C`", weight: 1 }, // no OTLP data
+            ],
+            // OTLP metric rows for the B downstream session (bare id is "`B`")
+            otelMetricRows: [
+                { session_id: "`B`", metric: "claude_code.cost.usage", total: 0.042 },
+                { session_id: "`B`", metric: "claude_code.token.usage", total: 8200 },
+            ],
+            otelLogRows: [],
+        };
+        const edges = await run(readFragilityCascade(), fx);
+        const edgeB = edges.find((e) => e.downstream === "session:`B`")!;
+        const edgeC = edges.find((e) => e.downstream === "session:`C`")!;
+        expect(edgeB.downstream_cost_usd).toBeCloseTo(0.042);
+        expect(edgeB.downstream_tokens).toBe(8200);
+        expect(edgeC.downstream_cost_usd).toBeNull();
+        expect(edgeC.downstream_tokens).toBeNull();
     });
 });

--- a/apps/axctl/src/metrics/fragility-cascade.ts
+++ b/apps/axctl/src/metrics/fragility-cascade.ts
@@ -1,6 +1,7 @@
 import { Array as Arr, Effect } from "effect";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
+import { bareSession, sessionTelemetryCost } from "../queries/telemetry-rollup.ts";
 import { recordKeyPart } from "@ax/lib/shared/derive-keys";
 import { localPathFileRecordKey, recordLiteral, stableDigest } from "@ax/lib/ids";
 import { selectByIds } from "@ax/lib/shared/record-select";
@@ -13,6 +14,8 @@ export interface CascadeEdge {
     readonly origin: string; // session that produced a reverted commit touching a file
     readonly downstream: string; // a later session that edited the same file
     readonly weight: number; // distinct downstream fixers for this origin
+    readonly downstream_cost_usd: number | null; // OTLP-sourced cost for the downstream session
+    readonly downstream_tokens: number | null; // OTLP-sourced token count for the downstream session
 }
 
 /**
@@ -112,7 +115,7 @@ export const joinCascadeEdges = (
     }
     return [...pairs].map((p) => {
         const [origin, downstream] = p.split(" ");
-        return { origin, downstream, weight: downstreamByOrigin.get(origin)!.size };
+        return { origin, downstream, weight: downstreamByOrigin.get(origin)!.size, downstream_cost_usd: null, downstream_tokens: null };
     });
 };
 
@@ -404,12 +407,21 @@ export const readFragilityCascade = (): Effect.Effect<CascadeEdge[], DbError, Su
         const rows = (yield* db.query<[Array<Record<string, unknown>>]>(
             `SELECT type::string(origin) AS origin, type::string(downstream) AS downstream, weight FROM fragility_cascade;`,
         ))?.[0] ?? [];
-        const out: CascadeEdge[] = [];
+        const partialEdges: CascadeEdge[] = [];
         for (const r of rows) {
             const origin = str(r.origin);
             const downstream = str(r.downstream);
             const weight = typeof r.weight === "number" && Number.isFinite(r.weight) ? r.weight : 0;
-            if (origin !== null && downstream !== null) out.push({ origin, downstream, weight });
+            if (origin !== null && downstream !== null) {
+                partialEdges.push({ origin, downstream, weight, downstream_cost_usd: null, downstream_tokens: null });
+            }
         }
-        return out;
+        // ONE batched OTLP cost lookup over deduped downstream ids.
+        const ids = [...new Set(partialEdges.map((e) => e.downstream))];
+        const cost = yield* sessionTelemetryCost(ids);
+        return partialEdges.map((e) => ({
+            ...e,
+            downstream_cost_usd: cost.get(bareSession(e.downstream))?.cost_usd ?? null,
+            downstream_tokens: cost.get(bareSession(e.downstream))?.tokens ?? null,
+        }));
     });

--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -7,6 +7,8 @@ import {
     formatSessionChurnSummary,
     normalizeCheckFamily,
     type ChurnEvent,
+    type SessionChurnRow,
+    type SessionChurnSummary,
 } from "./session-churn.ts";
 
 const edit = (session: string, tsMs: number, linesAdded: number, linesRemoved = 0, source = "codex"): ChurnEvent => ({
@@ -54,12 +56,16 @@ const db = (input: {
     outcomes?: Array<Record<string, unknown>>;
     hooks?: Array<Record<string, unknown>>;
     toolTexts?: Array<Record<string, unknown>>;
+    otelMetrics?: Array<Record<string, unknown>>;
+    otelLogs?: Array<Record<string, unknown>>;
     seenSql?: string[];
     respectBaseLimit?: boolean;
 }) =>
     Layer.succeed(SurrealClient, {
         query: <T>(sql: string) => {
             input.seenSql?.push(sql);
+            if (sql.includes("FROM otel_metric_point")) return Effect.succeed([input.otelMetrics ?? []] as unknown as T);
+            if (sql.includes("FROM otel_log_event")) return Effect.succeed([input.otelLogs ?? []] as unknown as T);
             if (sql.includes("FROM session_health")) return Effect.succeed([input.health ?? []] as unknown as T);
             if (sql.includes("FROM produced")) return Effect.succeed([input.produced ?? []] as unknown as T);
             if (sql.includes("FROM touched")) return Effect.succeed([input.touched ?? []] as unknown as T);
@@ -320,6 +326,16 @@ describe("computeSessionChurn", () => {
         expect(formatSessionChurnSummary(summary)).toBe(
             "no verification churn rows matched (run `ax ingest`, or loosen --since/--source/--here).",
         );
+    });
+
+    test("initializes otlp_cost_usd and otlp_tokens to null on every row", () => {
+        const summary = computeSessionChurn([
+            edit("s1", 1, 1),
+            fail("s1", 2, "test"),
+        ], landed([]), health([]));
+
+        expect(summary.hotSessions[0]?.otlp_cost_usd).toBeNull();
+        expect(summary.hotSessions[0]?.otlp_tokens).toBeNull();
     });
 
     test("normalizes DB-shaped and bare session ids across events and metadata maps", () => {
@@ -630,6 +646,40 @@ describe("fetchSessionChurnSummary", () => {
         });
     });
 
+    test("enriches hot sessions with OTLP cost; sessions without telemetry stay null", async () => {
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            base: [
+                { session: "session:`s1`", source: "codex" },
+                { session: "session:`s2`", source: "codex" },
+            ],
+            edits: [
+                { session: "session:`s1`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+                { session: "session:`s2`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+            ],
+            outcomes: [
+                { session: "session:`s1`", ts: "2026-06-11T00:02:00.000Z", status: "error", command_norm: "tsc" },
+                { session: "session:`s2`", ts: "2026-06-11T00:02:00.000Z", status: "error", command_norm: "tsc" },
+            ],
+            otelMetrics: [
+                { session_id: "s1", metric: "claude_code.cost.usage", total: 0.042 },
+            ],
+            otelLogs: [
+                { session_id: "s1", i: 1000, o: 500, r: 0, t: 0 },
+            ],
+        }))));
+
+        const s1 = summary.hotSessions.find((r) => r.session === "s1");
+        const s2 = summary.hotSessions.find((r) => r.session === "s2");
+        expect(s1?.otlp_cost_usd).toBeCloseTo(0.042, 5);
+        expect(s1?.otlp_tokens).toBe(1500);
+        expect(s2?.otlp_cost_usd).toBeNull();
+        expect(s2?.otlp_tokens).toBeNull();
+    });
+
     test("ambiguous runner norms resolve via batched tool_call text lookup", async () => {
         const seenSql: string[] = [];
         const summary = await Effect.runPromise(fetchSessionChurnSummary({
@@ -664,6 +714,62 @@ describe("fetchSessionChurnSummary", () => {
 });
 
 describe("formatSessionChurnSummary", () => {
+    test("shows cost$ column when at least one hot session has non-null otlp_cost_usd", () => {
+        const row = {
+            session: "s1",
+            source: "codex",
+            taskLabel: null,
+            landedLinesAdded: 0,
+            landedLinesRemoved: 0,
+            editLinesAdded: 5,
+            editLinesRemoved: 0,
+            repairLinesAdded: 3,
+            repairLinesRemoved: 0,
+            editEvents: 1,
+            verificationFailures: 1,
+            verificationPasses: 0,
+            episodes: 1,
+            passedEpisodes: 0,
+            topCheck: "test",
+            otlp_cost_usd: 0.042,
+            otlp_tokens: 1500,
+        } as unknown as SessionChurnRow;
+        const summary = {
+            generatedAt: "2026-06-11T00:00:00.000Z",
+            filters: { since: null, project: null, source: null, limit: 10 },
+            aggregates: [{
+                source: "codex",
+                sessions: 1,
+                sessionsWithFailures: 1,
+                landedLinesAdded: 0,
+                landedLinesRemoved: 0,
+                editLinesAdded: 5,
+                editLinesRemoved: 0,
+                repairLinesAdded: 3,
+                repairLinesRemoved: 0,
+                verificationFailures: 1,
+                episodes: 1,
+                passedEpisodes: 0,
+                topCheck: "test",
+            }],
+            hotSessions: [row],
+        } as unknown as SessionChurnSummary;
+
+        const rendered = formatSessionChurnSummary(summary);
+        expect(rendered).toContain("cost$");
+        expect(rendered).toContain("$0.042");
+    });
+
+    test("omits cost$ column when all hot session otlp costs are null", () => {
+        const summary = computeSessionChurn([
+            edit("s1", 1, 1),
+            fail("s1", 2, "test"),
+        ], landed([]), health([]));
+
+        const rendered = formatSessionChurnSummary(summary);
+        expect(rendered).not.toContain("cost$");
+    });
+
     test("flattens and truncates multi-line task labels in the table", () => {
         const summary = computeSessionChurn([
             edit("s1", 1, 1),

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { sessionTelemetryCost } from "../queries/telemetry-rollup.ts";
 import { recordLiteral } from "@ax/lib/ids";
 import { recordKeyPart } from "@ax/lib/shared/derive-keys";
 import { SurrealClient } from "@ax/lib/db";
@@ -45,6 +46,8 @@ export interface SessionChurnRow {
     readonly episodes: number;
     readonly passedEpisodes: number;
     readonly topCheck: string | null;
+    readonly otlp_cost_usd: number | null;
+    readonly otlp_tokens: number | null;
 }
 
 export interface SourceChurnAggregate {
@@ -302,10 +305,20 @@ ${where};`))?.[0] ?? [];
             fetchHookEvents(sessionIds, sourceBySession),
         ], { concurrency: 5 });
 
-        return computeSessionChurn([...edits, ...commandEvents, ...hookEvents], landed.bySession, health, {
+        const summary = computeSessionChurn([...edits, ...commandEvents, ...hookEvents], landed.bySession, health, {
             ...options,
             landedCommits: landed.commits,
         });
+
+        if (summary.hotSessions.length === 0) return summary;
+        const ids = summary.hotSessions.map((r) => r.session);
+        const cost = yield* sessionTelemetryCost(ids);
+        const hotSessions = summary.hotSessions.map((r) => ({
+            ...r,
+            otlp_cost_usd: cost.get(r.session)?.cost_usd ?? null,
+            otlp_tokens: cost.get(r.session)?.tokens ?? null,
+        }));
+        return { ...summary, hotSessions };
     });
 
 export const fetchLandedLocBySession = (
@@ -584,25 +597,34 @@ export const formatSessionChurnSummary = (summary: SessionChurnSummary): string 
         row.topCheck ?? "-",
     ]);
 
-    const sessionRows = summary.hotSessions.map((row) => [
-        truncate(row.session, 20),
-        row.source ?? "unknown",
-        String(row.verificationFailures),
-        String(row.episodes),
-        String(row.passedEpisodes),
-        loc(row.landedLinesAdded, row.landedLinesRemoved),
-        loc(row.editLinesAdded, row.editLinesRemoved),
-        loc(row.repairLinesAdded, row.repairLinesRemoved),
-        row.topCheck ?? "-",
-        row.taskLabel === null ? "-" : truncate(singleLine(row.taskLabel), 48),
-    ]);
+    const hasCost = summary.hotSessions.some((r) => r.otlp_cost_usd !== null);
+    const sessionRows = summary.hotSessions.map((row) => {
+        const cells = [
+            truncate(row.session, 20),
+            row.source ?? "unknown",
+            String(row.verificationFailures),
+            String(row.episodes),
+            String(row.passedEpisodes),
+            loc(row.landedLinesAdded, row.landedLinesRemoved),
+            loc(row.editLinesAdded, row.editLinesRemoved),
+            loc(row.repairLinesAdded, row.repairLinesRemoved),
+            row.topCheck ?? "-",
+            row.taskLabel === null ? "-" : truncate(singleLine(row.taskLabel), 48),
+        ];
+        if (hasCost) cells.push(row.otlp_cost_usd !== null ? `$${row.otlp_cost_usd.toFixed(3)}` : "-");
+        return cells;
+    });
+    const sessionHeaders = [
+        "session", "source", "fails", "episodes", "pass", "landed", "edits", "repair", "top", "task",
+        ...(hasCost ? ["cost$"] : []),
+    ];
 
     return [
         "verification churn by source",
         table(["source", "sess", "fail-sess", "fails", "episodes", "pass", "landed", "edits", "repair", "top"], sourceRows),
         "",
         "hot sessions",
-        table(["session", "source", "fails", "episodes", "pass", "landed", "edits", "repair", "top", "task"], sessionRows),
+        table(sessionHeaders, sessionRows),
     ].join("\n");
 };
 
@@ -697,6 +719,8 @@ const freezeRow = (state: MutableSessionState): SessionChurnRow => ({
     episodes: state.episodes,
     passedEpisodes: state.passedEpisodes,
     topCheck: topCheck(state.checkFailures),
+    otlp_cost_usd: null,
+    otlp_tokens: null,
 });
 
 const buildAggregates = (

--- a/apps/axctl/src/nav/next-links.test.ts
+++ b/apps/axctl/src/nav/next-links.test.ts
@@ -285,6 +285,7 @@ describe("buildSkillsWeightedNext", () => {
         roles: [],
         weight: 1,
         score: 10,
+        median_recovery_ms: null,
     };
 
     test("unclassified skills → classify cmd; top row → roles link", () => {

--- a/apps/axctl/src/queries/insights-enrich.test.ts
+++ b/apps/axctl/src/queries/insights-enrich.test.ts
@@ -96,4 +96,36 @@ describe("enrichInsightRows", () => {
         );
         expect(rows[0]!.previous_assistant).toBeUndefined();
     });
+
+    test("friction: enriches rows with otlp_cost_usd and otlp_tokens via a single batch", async () => {
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            routes: [
+                {
+                    match: "FROM otel_metric_point",
+                    rows: [[
+                        { session_id: "s1", metric: "claude_code.cost.usage", total: 0.25 },
+                        { session_id: "s1", metric: "claude_code.token.usage", total: 800 },
+                    ]],
+                },
+                {
+                    match: "FROM otel_log_event",
+                    rows: [[]],
+                },
+            ],
+        });
+        const frictionRows = [
+            { id: "friction_event:f1", session_ref: "session:s1", session: "session:s1", kind: "tool_failure", ts: new Date() },
+            { id: "friction_event:f2", session_ref: "session:s2", session: "session:s2", kind: "tool_failure", ts: new Date() },
+        ];
+        const rows = await Effect.runPromise(
+            enrichInsightRows("friction", frictionRows).pipe(Effect.provide(tc.layer)),
+        );
+        expect(rows[0]!.otlp_cost_usd).toBe(0.25);
+        expect(rows[0]!.otlp_tokens).toBe(800);
+        expect(rows[1]!.otlp_cost_usd).toBeNull();
+        expect(rows[1]!.otlp_tokens).toBeNull();
+        // Only 2 queries total (otel_metric_point + otel_log_event) - one batch, not per-row
+        expect(tc.captured).toHaveLength(2);
+    });
 });

--- a/apps/axctl/src/queries/insights-enrich.ts
+++ b/apps/axctl/src/queries/insights-enrich.ts
@@ -22,6 +22,7 @@ import type { DbError } from "@ax/lib/errors";
 import { recordIdString } from "@ax/lib/shared/row-fields";
 import { surrealDate } from "@ax/lib/shared/surql";
 import type { InsightView } from "./insights.ts";
+import { bareSession, sessionTelemetryCost } from "./telemetry-rollup.ts";
 
 /** Per-row fan-out width for the context lookups. */
 const ENRICH_FANOUT = 8;
@@ -117,10 +118,28 @@ const enrichRow = (
         };
     });
 
+/** Extract a bare session UUID from a friction row's session_ref (string from
+ *  `type::string(session)`) or fall back to the raw session field. */
+const frictionSessionId = (row: Row): string =>
+    bareSession(
+        typeof row.session_ref === "string"
+            ? row.session_ref
+            : (recordIdString(row.session) ?? String(row.session ?? "")),
+    );
+
 /** Enrich the rows of a classifier insight view with per-row context via
- *  indexed lookups. Views outside ENRICHED_VIEWS pass through untouched. */
+ *  indexed lookups. Views outside ENRICHED_VIEWS pass through untouched.
+ *  The "friction" view gets a single batched OTLP cost lookup appended. */
 export const enrichInsightRows = Effect.fn("queries.enrichInsightRows")(
     function* (view: InsightView, rows: ReadonlyArray<Row>) {
+        if (view === "friction") {
+            const ids = rows.map(frictionSessionId);
+            const cost = yield* sessionTelemetryCost(ids);
+            return rows.map((row): Row => {
+                const c = cost.get(frictionSessionId(row));
+                return { ...row, otlp_cost_usd: c?.cost_usd ?? null, otlp_tokens: c?.tokens ?? null };
+            });
+        }
         if (!ENRICHED_VIEWS.has(view)) return rows;
         return yield* Effect.forEach(rows, (row) => enrichRow(view, row), { concurrency: ENRICH_FANOUT });
     },

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -267,6 +267,7 @@ SELECT
     metrics,
     raw,
     session,
+    type::string(session) AS session_ref,
     session.project AS project,
     session.cwd AS cwd,
     turn,

--- a/apps/axctl/src/queries/telemetry-rollup.test.ts
+++ b/apps/axctl/src/queries/telemetry-rollup.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { sessionTelemetryCost, sessionTelemetryLatency } from "./telemetry-rollup.ts";
+
+const db = (rows: { metric?: unknown[]; log?: unknown[] }) =>
+    Layer.succeed(SurrealClient, {
+        query: <T>(sql: string) => {
+            if (/FROM otel_metric_point/.test(sql)) return Effect.succeed([rows.metric ?? []] as unknown as T);
+            if (/FROM otel_log_event/.test(sql)) return Effect.succeed([rows.log ?? []] as unknown as T);
+            return Effect.succeed([[]] as unknown as T);
+        },
+    } as never);
+const run = <A>(e: Effect.Effect<A, unknown, SurrealClient>, layer: Layer.Layer<SurrealClient>) =>
+    Effect.runPromise(e.pipe(Effect.provide(layer)));
+
+describe("sessionTelemetryCost", () => {
+    test("sums claude cost.usage → cost_usd and token.usage → tokens", async () => {
+        const layer = db({ metric: [
+            { session_id: "s1", metric: "claude_code.cost.usage", total: 0.5 },
+            { session_id: "s1", metric: "claude_code.token.usage", total: 1200 },
+        ] });
+        const m = await run(sessionTelemetryCost(["s1"]), layer);
+        expect(m.get("s1")?.cost_usd).toBe(0.5);
+        expect(m.get("s1")?.tokens).toBe(1200);
+        expect(m.get("s1")?.source).toBe("otlp");
+    });
+    test("codex log tokens, no cost metric → cost_usd null, tokens summed", async () => {
+        const layer = db({ log: [{ session_id: "c1", i: 100, o: 50, r: 10, t: 0 }] });
+        const m = await run(sessionTelemetryCost(["c1"]), layer);
+        expect(m.get("c1")?.cost_usd).toBeNull();
+        expect(m.get("c1")?.tokens).toBe(160);
+    });
+    test("no telemetry → session absent", async () => {
+        const m = await run(sessionTelemetryCost(["x"]), db({}));
+        expect(m.has("x")).toBe(false);
+    });
+    test("empty input → empty map", async () => {
+        const m = await run(sessionTelemetryCost([]), db({}));
+        expect(m.size).toBe(0);
+    });
+});
+describe("sessionTelemetryLatency", () => {
+    test("sums log duration_ms", async () => {
+        const layer = db({ log: [{ session_id: "c1", d: 693, n: 1 }] });
+        const m = await run(sessionTelemetryLatency(["c1"]), layer);
+        expect(m.get("c1")?.duration_ms).toBe(693);
+    });
+});

--- a/apps/axctl/src/queries/telemetry-rollup.ts
+++ b/apps/axctl/src/queries/telemetry-rollup.ts
@@ -1,0 +1,62 @@
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+
+export interface TelemetryCost { readonly cost_usd: number | null; readonly tokens: number; readonly source: "otlp"; }
+export interface TelemetryLatency { readonly duration_ms: number | null; readonly span_count: number; }
+
+const CHUNK = 500;
+const chunk = <T>(xs: readonly T[], n: number): T[][] => {
+    const out: T[][] = []; for (let i = 0; i < xs.length; i += n) out.push(xs.slice(i, i + n)); return out;
+};
+const numOf = (v: unknown): number => typeof v === "number" ? v : typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v)) ? Number(v) : 0;
+/** otel_*.session_id holds the bare session uuid; normalize any "table:uuid" form. */
+export const bareSession = (v: unknown): string => { const s = String(v ?? ""); const c = s.indexOf(":"); return c >= 0 ? s.slice(c + 1) : s; };
+const quotedList = (ids: readonly string[]): string => ids.map((i) => `"${bareSession(i)}"`).join(", ");
+
+export const sessionTelemetryCost = (sessionIds: readonly string[]): Effect.Effect<Map<string, TelemetryCost>, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        if (sessionIds.length === 0) return new Map<string, TelemetryCost>();
+        const db = yield* SurrealClient;
+        const acc = new Map<string, { cost_usd: number | null; tokens: number }>();
+        for (const ids of chunk(sessionIds, CHUNK)) {
+            const list = quotedList(ids);
+            const mrows = (yield* db.query<[Array<Record<string, unknown>>]>(
+                `SELECT session_id, metric, math::sum(value) AS total FROM otel_metric_point`
+                + ` WHERE session_id IN [${list}] GROUP BY session_id, metric;`))?.[0] ?? [];
+            for (const r of mrows) {
+                const sid = bareSession(r.session_id);
+                const cur = acc.get(sid) ?? { cost_usd: null, tokens: 0 };
+                if (r.metric === "claude_code.cost.usage") cur.cost_usd = (cur.cost_usd ?? 0) + numOf(r.total);
+                if (r.metric === "claude_code.token.usage") cur.tokens += numOf(r.total);
+                acc.set(sid, cur);
+            }
+            const lrows = (yield* db.query<[Array<Record<string, unknown>>]>(
+                `SELECT session_id, math::sum(input_tokens) AS i, math::sum(output_tokens) AS o,`
+                + ` math::sum(reasoning_tokens) AS r, math::sum(tool_tokens) AS t FROM otel_log_event`
+                + ` WHERE session_id IN [${list}] GROUP BY session_id;`))?.[0] ?? [];
+            for (const r of lrows) {
+                const sid = bareSession(r.session_id);
+                const cur = acc.get(sid) ?? { cost_usd: null, tokens: 0 };
+                cur.tokens += numOf(r.i) + numOf(r.o) + numOf(r.r) + numOf(r.t);
+                acc.set(sid, cur);
+            }
+        }
+        const out = new Map<string, TelemetryCost>();
+        for (const [k, v] of acc) out.set(k, { cost_usd: v.cost_usd, tokens: v.tokens, source: "otlp" });
+        return out;
+    });
+
+export const sessionTelemetryLatency = (sessionIds: readonly string[]): Effect.Effect<Map<string, TelemetryLatency>, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const out = new Map<string, TelemetryLatency>();
+        if (sessionIds.length === 0) return out;
+        const db = yield* SurrealClient;
+        for (const ids of chunk(sessionIds, CHUNK)) {
+            const rows = (yield* db.query<[Array<Record<string, unknown>>]>(
+                `SELECT session_id, math::sum(duration_ms) AS d, count() AS n FROM otel_log_event`
+                + ` WHERE session_id IN [${quotedList(ids)}] AND duration_ms != NONE GROUP BY session_id;`))?.[0] ?? [];
+            for (const r of rows) out.set(bareSession(r.session_id), { duration_ms: numOf(r.d), span_count: numOf(r.n) });
+        }
+        return out;
+    });

--- a/docs/superpowers/plans/2026-06-15-telemetry-insight-enrichment.md
+++ b/docs/superpowers/plans/2026-06-15-telemetry-insight-enrichment.md
@@ -1,0 +1,301 @@
+# Multi-hop Telemetry → Insight Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Attach OTLP-sourced cost/latency to existing behavior insights via the `session -> telemetry_of -> otel_*` edge - a shared batched rollup helper consumed by 4 existing surfaces (friction, churn, fragility, recovery).
+
+**Architecture:** One new `telemetry-rollup.ts` query helper (batched, deref-free, session-id keyed). Each of the 4 existing queries collects its session-id set, calls the helper once, merges cost/latency onto rows in JS. OTLP-sourced, kept separate from transcript cost (no double-count). Sessions without telemetry → null (graceful).
+
+**Tech Stack:** Bun, TS strict, effect@beta, SurrealDB 3.x via `@ax/lib/db`, `bun:test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-telemetry-insight-enrichment-design.md`
+
+**Key codebase facts (from recon):**
+- DB read: `const db = yield* SurrealClient; const rows = (yield* db.query<[Array<Record<string,unknown>>]>(sql))?.[0] ?? [];` (import `SurrealClient` from `@ax/lib/db`).
+- Session-id list → SQL literals: `sessionRefList(ids)` from `apps/axctl/src/metrics/util.ts` → `session:⟨a⟩, session:⟨b⟩`. Chunk at 500 (`chunked` helper, same file/pattern as session-churn).
+- `WHERE in IN [${sessionRefList(ids)}]` on the `telemetry_of` edge is SAFE (indexed `in` field) - this is the established pattern (`produced`, `tool_call` queries in session-churn.ts).
+- otel tables: `otel_metric_point` (harness, metric, value, session_id, model), `otel_log_event` (harness, event_name, session_id, input/output/reasoning/cached/tool_tokens, duration_ms), `otel_span` (duration_ms - **currently empty**, CC/Codex emit metrics/logs not spans).
+- SurrealDB v3: `type::record("session:"+id)` not `type::thing`.
+
+---
+
+## Task 1: `telemetry-rollup.ts` shared helper
+
+**Files:**
+- Create: `apps/axctl/src/queries/telemetry-rollup.ts`
+- Test: `apps/axctl/src/queries/telemetry-rollup.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { sessionTelemetryCost, sessionTelemetryLatency } from "./telemetry-rollup.ts";
+
+// Stub returns telemetry rows keyed by the SELECT'd table.
+const db = (rows: { metric?: unknown[]; log?: unknown[] }) =>
+    Layer.succeed(SurrealClient, {
+        query: <T>(sql: string) => {
+            if (/FROM otel_metric_point/.test(sql)) return Effect.succeed([rows.metric ?? []] as unknown as T);
+            if (/FROM otel_log_event/.test(sql)) return Effect.succeed([rows.log ?? []] as unknown as T);
+            return Effect.succeed([[]] as unknown as T);
+        },
+    } as never);
+
+const run = <A>(e: Effect.Effect<A, unknown, SurrealClient>, layer: Layer.Layer<SurrealClient>) =>
+    Effect.runPromise(e.pipe(Effect.provide(layer)));
+
+describe("sessionTelemetryCost", () => {
+    test("sums claude cost.usage → cost_usd and token.usage → tokens", async () => {
+        const layer = db({ metric: [
+            { session: "s1", metric: "claude_code.cost.usage", value: 0.5 },
+            { session: "s1", metric: "claude_code.token.usage", value: 1200 },
+        ] });
+        const m = await run(sessionTelemetryCost(["s1"]), layer);
+        expect(m.get("s1")?.cost_usd).toBe(0.5);
+        expect(m.get("s1")?.tokens).toBe(1200);
+        expect(m.get("s1")?.source).toBe("otlp");
+    });
+
+    test("codex log tokens with no cost metric → cost_usd null, tokens summed", async () => {
+        const layer = db({ log: [
+            { session: "c1", input_tokens: 100, output_tokens: 50, reasoning_tokens: 10, tool_tokens: 0 },
+        ] });
+        const m = await run(sessionTelemetryCost(["c1"]), layer);
+        expect(m.get("c1")?.cost_usd).toBeNull();
+        expect(m.get("c1")?.tokens).toBe(160);
+    });
+
+    test("session with no telemetry is absent from the map", async () => {
+        const m = await run(sessionTelemetryCost(["x"]), db({}));
+        expect(m.has("x")).toBe(false);
+    });
+
+    test("empty input → empty map, no query", async () => {
+        const m = await run(sessionTelemetryCost([]), db({}));
+        expect(m.size).toBe(0);
+    });
+});
+
+describe("sessionTelemetryLatency", () => {
+    test("sums log duration_ms → duration_ms", async () => {
+        const layer = db({ log: [
+            { session: "c1", duration_ms: 693 }, { session: "c1", duration_ms: 1000 },
+        ] });
+        const m = await run(sessionTelemetryLatency(["c1"]), layer);
+        expect(m.get("c1")?.duration_ms).toBe(1693);
+    });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** - `bun test apps/axctl/src/queries/telemetry-rollup.test.ts`
+
+- [ ] **Step 3: Implement** `telemetry-rollup.ts`:
+
+```ts
+import { Effect } from "effect";
+import { SurrealClient, type DbError } from "@ax/lib/db";
+import { sessionRefList } from "../metrics/util.ts";
+
+export interface TelemetryCost { readonly cost_usd: number | null; readonly tokens: number; readonly source: "otlp"; }
+export interface TelemetryLatency { readonly duration_ms: number | null; readonly span_count: number; }
+
+const CHUNK = 500;
+const chunk = <T>(xs: readonly T[], n: number): T[][] => {
+    const out: T[][] = [];
+    for (let i = 0; i < xs.length; i += n) out.push(xs.slice(i, i + n));
+    return out;
+};
+const numOf = (v: unknown): number => (typeof v === "number" ? v : typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v)) ? Number(v) : 0);
+const bareSession = (v: unknown): string => { const s = String(v ?? ""); const c = s.indexOf(":"); return c >= 0 ? s.slice(c + 1) : s; };
+
+/**
+ * OTLP cost/tokens per session via session_id match on the otel tables.
+ * Batched (chunked IN-list), deref-free - never walks <-telemetry_of per row.
+ * Claude cost from otel_metric_point claude_code.cost.usage; tokens from
+ * claude_code.token.usage + codex otel_log_event token columns. cost_usd is
+ * null for codex (token-only). Sessions with no telemetry are absent.
+ */
+export const sessionTelemetryCost = (
+    sessionIds: readonly string[],
+): Effect.Effect<Map<string, TelemetryCost>, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const out = new Map<string, { cost_usd: number | null; tokens: number }>();
+        if (sessionIds.length === 0) return new Map();
+        const db = yield* SurrealClient;
+        for (const ids of chunk(sessionIds, CHUNK)) {
+            const refs = sessionRefList(ids);
+            // metric points (claude): cost.usage + token.usage
+            const mrows = (yield* db.query<[Array<Record<string, unknown>>]>(
+                `SELECT session_id, metric, math::sum(value) AS total FROM otel_metric_point`
+                + ` WHERE session_id IN [${refs.replace(/session:/g, "")}] OR session_id IN [${ids.map((i) => `"${bareSession(i)}"`).join(", ")}]`
+                + ` GROUP BY session_id, metric;`,
+            ))?.[0] ?? [];
+            for (const r of mrows) {
+                const sid = bareSession(r.session_id);
+                const cur = out.get(sid) ?? { cost_usd: null, tokens: 0 };
+                if (r.metric === "claude_code.cost.usage") cur.cost_usd = (cur.cost_usd ?? 0) + numOf(r.total);
+                if (r.metric === "claude_code.token.usage") cur.tokens += numOf(r.total);
+                out.set(sid, cur);
+            }
+            // log events (codex): token columns
+            const lrows = (yield* db.query<[Array<Record<string, unknown>>]>(
+                `SELECT session_id, math::sum(input_tokens) AS i, math::sum(output_tokens) AS o,`
+                + ` math::sum(reasoning_tokens) AS r, math::sum(tool_tokens) AS t FROM otel_log_event`
+                + ` WHERE session_id IN [${ids.map((i) => `"${bareSession(i)}"`).join(", ")}] GROUP BY session_id;`,
+            ))?.[0] ?? [];
+            for (const r of lrows) {
+                const sid = bareSession(r.session_id);
+                const cur = out.get(sid) ?? { cost_usd: null, tokens: 0 };
+                cur.tokens += numOf(r.i) + numOf(r.o) + numOf(r.r) + numOf(r.t);
+                out.set(sid, cur);
+            }
+        }
+        const result = new Map<string, TelemetryCost>();
+        for (const [k, v] of out) result.set(k, { ...v, source: "otlp" });
+        return result;
+    });
+
+export const sessionTelemetryLatency = (
+    sessionIds: readonly string[],
+): Effect.Effect<Map<string, TelemetryLatency>, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const out = new Map<string, TelemetryLatency>();
+        if (sessionIds.length === 0) return out;
+        const db = yield* SurrealClient;
+        for (const ids of chunk(sessionIds, CHUNK)) {
+            const list = ids.map((i) => `"${bareSession(i)}"`).join(", ");
+            const rows = (yield* db.query<[Array<Record<string, unknown>>]>(
+                `SELECT session_id, math::sum(duration_ms) AS d, count() AS n FROM otel_log_event`
+                + ` WHERE session_id IN [${list}] AND duration_ms != NONE GROUP BY session_id;`,
+            ))?.[0] ?? [];
+            for (const r of rows) out.set(bareSession(r.session_id), { duration_ms: numOf(r.d), span_count: numOf(r.n) });
+        }
+        return out;
+    });
+```
+
+NOTE on the session_id match: `otel_metric_point.session_id` is a plain `string` column (not a record ref) holding the bare session uuid (Claude `session.id` attr) OR the codex `conversation.id`. The existing `session` rows are keyed by their own id. The join is **string equality on the bare id**. The metric query's first `IN [...]` (refs with `session:` stripped) is belt-and-suspenders; the authoritative match is the quoted bare-id list. The implementer MUST verify against real data whether `otel_metric_point.session_id` equals the bare `session` key - if the stored session_id differs (e.g. claude session.id vs ax session key), document the mismatch (correlation/enrichment then yields empty until reconciled - acceptable, graceful-null). Simplify the metric WHERE to just the quoted bare-id list if the refs form is redundant.
+
+- [ ] **Step 4: Run, expect PASS.** **Step 5: typecheck.** **Step 6: commit**
+```bash
+git add apps/axctl/src/queries/telemetry-rollup.ts apps/axctl/src/queries/telemetry-rollup.test.ts
+git commit -m "feat(insights): telemetry-rollup helper (batched session cost/latency)"
+```
+
+---
+
+## Task 2 (Lens B): churn episode → cost
+
+**Files:**
+- Modify: `apps/axctl/src/metrics/session-churn.ts` (`SessionChurnRow`, `fetchSessionChurnSummary`, `formatSessionChurnSummary`)
+- Test: `apps/axctl/src/metrics/session-churn.test.ts` (extend)
+
+- [ ] **Step 1: Write failing test** - add a test that `fetchSessionChurnSummary` populates `otlp_cost_usd`/`otlp_tokens` on hot-session rows when telemetry exists. Stub `SurrealClient` so the otel queries return a cost row for one hot session; assert that row's `otlp_cost_usd` matches and a session without telemetry has `otlp_cost_usd: null`. (Model the stub on the existing session-churn tests in this file - match their stub shape.)
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement:**
+  - Add to `SessionChurnRow`: `readonly otlp_cost_usd: number | null; readonly otlp_tokens: number | null;`
+  - `computeSessionChurn` is pure - default these to `null` there (it has no DB). Initialize both `null` when building each row.
+  - In `fetchSessionChurnSummary`, AFTER `hotSessions` is computed: collect `const ids = summary.hotSessions.map(r => r.session)`, call `const cost = yield* sessionTelemetryCost(ids)`, and map onto each hot row: `otlp_cost_usd: cost.get(r.session)?.cost_usd ?? null, otlp_tokens: cost.get(r.session)?.tokens ?? null`. Return the updated summary. Import `sessionTelemetryCost` from `../queries/telemetry-rollup.ts`.
+  - In `formatSessionChurnSummary`: add a `cost$` column to the hot-sessions table ONLY when at least one row has non-null `otlp_cost_usd` (else omit the column to avoid an all-`-` column). Render `otlp_cost_usd` as `$X.XXX` or `-`.
+
+- [ ] **Step 4: Run → PASS** (`bun test apps/axctl/src/metrics/session-churn.test.ts`). **Step 5: typecheck.** **Step 6: commit**
+```bash
+git add apps/axctl/src/metrics/session-churn.ts apps/axctl/src/metrics/session-churn.test.ts
+git commit -m "feat(insights): OTLP cost per churn episode/session (lens B)"
+```
+
+---
+
+## Task 3 (Lens C): fragility cascade → downstream cost
+
+**Files:**
+- Modify: `apps/axctl/src/metrics/fragility-cascade.ts` (`CascadeEdge`, `readFragilityCascade`)
+- Test: `apps/axctl/src/metrics/fragility-cascade.test.ts` (extend)
+
+- [ ] **Step 1: Write failing test** - stub `SurrealClient` so `readFragilityCascade`'s edge query returns one `{origin, downstream, weight}` and the otel cost query returns a cost for the downstream session; assert the returned edge has `downstream_cost_usd`/`downstream_tokens` populated; an edge whose downstream has no telemetry → null. Match the existing fragility test stub shape.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement:**
+  - Add to `CascadeEdge`: `readonly downstream_cost_usd: number | null; readonly downstream_tokens: number | null;`
+  - In `readFragilityCascade`, after reading edges: collect downstream ids (`edges.map(e => e.downstream)`, dedup), call `sessionTelemetryCost(ids)`, merge onto each edge by `e.downstream`. `CascadeEdge.downstream` is `type::string` form (`"session:uuid"`); the rollup's `bareSession` handles the prefix, so pass `e.downstream` through (the helper strips `session:`). Import the helper.
+
+- [ ] **Step 4: Run → PASS.** **Step 5: typecheck.** **Step 6: commit**
+```bash
+git add apps/axctl/src/metrics/fragility-cascade.ts apps/axctl/src/metrics/fragility-cascade.test.ts
+git commit -m "feat(insights): downstream OTLP cost on fragility cascades (lens C)"
+```
+
+---
+
+## Task 4 (Lens A): friction → cost
+
+**Files:**
+- Modify: `apps/axctl/src/cli/commands/report.ts` (`enrichInsightRows` for the `friction` view) OR `apps/axctl/src/queries/insights.ts`
+- Test: a test for the friction enrichment (place beside report/insights logic)
+
+- [ ] **Step 1: Write failing test** - assert that friction rows, after enrichment, carry an `otlp_cost_usd` field sourced from the rollup keyed by the row's `session`. Stub the rollup's DB queries. (If `enrichInsightRows` is the chosen seam, test it directly with view="friction".)
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement:** extend `enrichInsightRows` (report.ts) so the `friction` view gets a JS-side join: collect `rows.map(r => bareSession(r.session))`, call `sessionTelemetryCost(ids)`, attach `otlp_cost_usd`/`otlp_tokens` to each row. Ensure `formatInsightRows` includes the new fields in `--json` and, for table output, adds a `cost$` column only when populated. (`session` in friction rows is a record ref - cast/normalize with the same bare-id logic.) Import the helper + reuse `bareSession` (export it from telemetry-rollup.ts or duplicate the 1-liner).
+
+- [ ] **Step 4: Run → PASS.** **Step 5: typecheck.** **Step 6: commit**
+```bash
+git add apps/axctl/src/cli/commands/report.ts apps/axctl/src/queries/insights.ts apps/axctl/src/cli/insights-format.ts <test>
+git commit -m "feat(insights): OTLP cost on friction events (lens A)"
+```
+
+---
+
+## Task 5 (Lens E): recovery → latency  ⚠️ data-thin
+
+**Files:**
+- Modify: `apps/axctl/src/dashboard/skills-weighted.ts` (`WeightedSkillRow`, `fetchSkillsWeighted`)
+- Test: `apps/axctl/src/dashboard/skills-weighted.test.ts` (extend)
+
+**Caveat:** latency source is `otel_log_event.duration_ms` (NOT `otel_span` - spans are currently unpopulated). `WeightedSkillRow` has no session ids, so this needs a separate pass: `recovered_by` (turn→skill) → resolve the turn's `session` → `sessionTelemetryLatency`. If this proves structurally hostile, ship it as a `--json`-only field (`median_recovery_ms`) rather than a table column, and note it. This lens lights up only once recovery sessions have telemetry.
+
+- [ ] **Step 1: Write failing test** - stub so a `recovered_by`-grouped query yields skill→sessionIds, and the latency rollup yields a duration for those sessions; assert the skill row gains `median_recovery_ms`. Null when no telemetry.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement:**
+  - Add to `WeightedSkillRow`: `readonly median_recovery_ms: number | null;`
+  - In `fetchSkillsWeighted`, add a pass: `SELECT out AS skill, in.session AS session FROM recovered_by;` (resolve turn→session via the edge's `in` turn record's `session` field - verify the turn carries `session`). Group session ids by skill in JS, call `sessionTelemetryLatency(allSessionIds)`, compute per-skill median of the sessions' `duration_ms`, attach as `median_recovery_ms` (null if none). Keep the existing weighted query UNCHANGED (deref-free per [[weighted-query-per-edge-deref-hang]] - do the join as a separate batched query + JS merge, NOT stacked derefs in the main aggregate).
+
+- [ ] **Step 4: Run → PASS.** **Step 5: typecheck.** **Step 6: commit**
+```bash
+git add apps/axctl/src/dashboard/skills-weighted.ts apps/axctl/src/dashboard/skills-weighted.test.ts
+git commit -m "feat(insights): recovery latency per skill (lens E)"
+```
+
+---
+
+## Task 6: docs + full verification
+
+**Files:** Modify `CLAUDE.md`.
+
+- [ ] **Step 1:** Add a short note (near the OTLP receiver section or the cost-analytics section): existing insights now traverse `telemetry_of` to attach OTLP cost/latency - `ax sessions churn` (cost/episode), fragility cascades (downstream cost), `ax insights friction` (per-kind cost), `ax skills weighted` (recovery latency). OTLP-sourced, separate from transcript cost. Module: `apps/axctl/src/queries/telemetry-rollup.ts`.
+- [ ] **Step 2:** Full suite + typecheck: `bun test` + `bun run typecheck`. Fix any enrichment-caused breakage; report counts.
+- [ ] **Step 3: commit**
+```bash
+git add CLAUDE.md
+git commit -m "docs(insights): telemetry-enriched behavior insights"
+```
+
+---
+
+## Verification (whole-plan)
+- [ ] `bun test` green; `bun run typecheck` clean.
+- [ ] Each lens: new column/field populates with stubbed telemetry, null when absent (graceful).
+- [ ] No double-count: OTLP `otlp_*`/`median_recovery_ms` fields are separate from transcript `session_token_usage`/`estimatedCostUsd`.
+- [ ] Live (controller): with the dogfood telemetry present, `ax sessions churn` shows a cost column for sessions that have OTLP data.
+
+## Open items
+1. **session_id join key** - verify `otel_metric_point.session_id` / `otel_log_event.session_id` equals the bare `session` table key. If claude `session.id` / codex `conversation.id` differ from ax's session key, enrichment yields empty until reconciled (graceful null; document). This is the single highest-risk assumption - Task 1 implementer must check against real rows.
+2. Lens E latency from logs (spans empty); degrade to `--json` field if the weighted query can't cleanly carry it.

--- a/docs/superpowers/specs/2026-06-15-telemetry-insight-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-15-telemetry-insight-enrichment-design.md
@@ -1,0 +1,88 @@
+# Multi-hop telemetry → insight enrichment - design
+
+Status: approved (brainstorm 2026-06-15). Branch: `feat/telemetry-insight-enrichment`.
+Builds on the OTLP receiver/logs work (v0.31.0: #423/#426/#432).
+Context: investigation found ax's insight/improve system already IS adaline's
+"behaviors → improve" loop (and ahead on graph richness), but **no insight query
+traverses the new `telemetry_of` edge** - OTLP cost/latency is disconnected from
+the behavior graph. This wires it in.
+
+## Goal
+
+Attach OTLP-sourced cost/latency to existing behavior insights via the
+`session -> telemetry_of -> otel_*` multi-hop edge. No new command - enrich four
+existing surfaces in place. Realizes "behaviors with a $ dimension" through ax's
+existing system rather than a parallel feature.
+
+## Core component - `apps/axctl/src/queries/telemetry-rollup.ts`
+
+One shared, batched rollup the four lenses reuse:
+
+```
+sessionTelemetryCost(sessionIds: readonly string[])
+  : Effect<Map<string, TelemetryCost>, DbError, SurrealClient>
+sessionTelemetryLatency(sessionIds: readonly string[])
+  : Effect<Map<string, TelemetryLatency>, DbError, SurrealClient>
+```
+
+- `TelemetryCost = { cost_usd: number | null, tokens: number, source: "otlp" }`
+  - `cost_usd`: SUM of `otel_metric_point.value WHERE metric = 'claude_code.cost.usage'` for the session (Claude). **null** when no USD metric exists (Codex - token-only until a token→USD step lands).
+  - `tokens`: Claude `otel_metric_point WHERE metric='claude_code.token.usage'` value, PLUS Codex `otel_log_event` token columns (input+output+reasoning+tool) summed. (Reasoning/cached counting policy: sum input+output+reasoning+tool; exclude cached to avoid double-count - document inline.)
+- `TelemetryLatency = { duration_ms: number | null, span_count: number }`
+  - max/sum of `otel_span.duration_ms` for the session (fallback `otel_log_event.duration_ms`).
+
+### Hard constraints (from prior incidents)
+- **Batch by session id - never per-edge deref.** Query shape: one statement that
+  takes the session-id list, joins `telemetry_of`/`otel_*`, GROUP BY session.
+  Do NOT walk `<-telemetry_of` per row with stacked derefs ([[weighted-query-per-edge-deref-hang]]).
+- **SurrealDB v3 dialect**: use `type::record("session:" + id)` not `type::thing`
+  ([[otel-receiver-shipped]]); materialize record lists with `.map()` if the
+  `FROM [recordid]` bug bites ([[surreal-30x-record-list-select-bug]]).
+- **No double-count**: this is the OTLP-sourced lens, kept SEPARATE from
+  transcript-derived `session_token_usage`/`session_metrics.estimatedCostUsd`.
+  Columns are labeled `otlp_*` so the two sources are never summed.
+- **Graceful nulls**: sessions with no telemetry → absent from the map → callers
+  render `-`/null. Critical while telemetry is still thin.
+
+## Four enrichment points (existing surfaces)
+
+| Lens | File | Change |
+| --- | --- | --- |
+| A friction→cost | `queries/insights.ts` friction view + a rollup fn | per-`kind` OTLP cost: total + avg cost_usd / tokens for sessions where each friction kind occurs |
+| B episode→cost | `metrics/session-churn.ts` `SessionChurnRow` + CLI render (`cli/commands/sessions.ts`) | add `otlp_cost_usd`/`otlp_tokens` per session row + `cost_per_episode` (cost / max(episodes,1)) |
+| C cascade→cost | `metrics/fragility-cascade.ts` `CascadeEdge` + `readFragilityCascade` | add `downstream_cost_usd`/`downstream_tokens` (sum over the cascade's downstream sessions) |
+| E recovery→latency | `ax skills weighted` query (locate handler) | add median recovery `duration_ms` per skill, over the sessions of its `recovered_by` edges |
+
+Each lens: collect the relevant session-id set from the EXISTING query result,
+call the shared rollup ONCE for that set, merge the cost/latency back onto rows
+in JS (deref-free). `--json` outputs gain the new fields; table renderers gain a
+column (only when any row has telemetry, else omit to avoid an all-`-` column).
+
+## Data flow
+
+```
+existing behavior query → collect sessionIds
+        → sessionTelemetryCost(ids) / sessionTelemetryLatency(ids)  (1 batched query)
+        → merge map onto rows in JS → render (column shown only if populated)
+```
+
+## Testing (TDD)
+
+- **telemetry-rollup**: stub `SurrealClient.query` returning telemetry_of + otel
+  rows; assert `sessionTelemetryCost` sums claude cost.usage to `cost_usd`,
+  codex log token cols to `tokens`, `cost_usd: null` for codex-only sessions,
+  absent session → not in map. `sessionTelemetryLatency` from spans.
+- **each lens**: stub the existing query's rows + the rollup; assert the new
+  column populates when telemetry present and is null/omitted when absent.
+- No regression: existing churn/fragility/friction/weighted tests stay green.
+
+## Out of scope / deferred
+- Codex token→USD cost derivation (needs per-model pricing) - `cost_usd` stays
+  null for codex here; follow-up.
+- Dashboard/studio rendering of these columns - CLI/MCP/`--json` only this PR.
+- Backfilling telemetry - these light up as OTLP data accumulates.
+
+## Open
+- Exact `ax skills weighted` handler location for lens E - implementer locates
+  during build; if the weighted query is structurally hostile to a clean join,
+  E degrades to a separate `--json` field rather than a table column (note it).


### PR DESCRIPTION
## Summary

Wires the OTLP telemetry (v0.31.0) into ax's existing **insight/behavior** system via the `session -> telemetry_of -> otel_*` multi-hop edge. Investigation found ax's insights already *are* the equivalent of a competitor's "behaviors → improve" loop (and ahead on graph richness) — the gap was that **no insight query traversed the new telemetry**. This closes it: behaviors gain a real $/latency dimension. No new command — four existing surfaces enriched in place.

- **Shared helper** `apps/axctl/src/queries/telemetry-rollup.ts`: `sessionTelemetryCost`/`sessionTelemetryLatency` — batched (chunk 500), **deref-free** (flat `GROUP BY` on `session_id`, never `<-telemetry_of` per-row — honors the prior 87k-edge hang incident). OTLP-sourced, kept SEPARATE from transcript cost (no double-count). `cost_usd` null for Codex (token-only).
- **Lens B** — `ax sessions churn`: `otlp_cost_usd`/`otlp_tokens` per session (cost per episode).
- **Lens C** — `fragility_cascade`: `downstream_cost_usd`/`downstream_tokens` on cascade edges.
- **Lens A** — `ax insights friction`: per-row OTLP cost.
- **Lens E** — `ax skills weighted`: `median_recovery_ms` (recovery latency from `otel_log_event.duration_ms`; main aggregate untouched/deref-free, separate batched pass).
- All columns/fields **null when a session has no telemetry** (graceful — telemetry is still thin); table columns appear only when populated.

Spec/plan in `docs/superpowers/`.

## Test plan
- [x] TDD per task; **feature tests 82 pass / 0 fail** (rollup, churn, fragility, insights-enrich, skills-weighted×2). Typecheck: no new errors (shared-interface fixture sweeps done).
- [x] Deref-free verified by review on the two hot paths (rollup + weighted aggregate).
- [ ] **Live-validation deferred** — lights up only as OTLP data accumulates (run serve + real usage). Cannot demo against the current empty telemetry.

## Follow-ups (from review)
1. **session_id join key** — `otel_*.session_id` (claude `session.id` / codex `conversation.id`) must equal ax's bare `session` key for the join to populate; Claude likely matches, Codex's `conversation.id` may not. Graceful-null if mismatched. **Verify against real rows once telemetry exists.**
2. **Lens E skill_id string-match** — recovery query `type::string(out)` vs deserialized `RecordId`; smoke-check the column populates on real data.
3. **Lens E window-scope** — `median_recovery_ms` is currently all-time, not `--window`-scoped (has a `ts` to filter); minor.
4. Lens E populated-column render branch lacks a unit test (only the absent case is covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)