### PR TITLE
feat(team): local `ax team sync` — Slice 0 of the team improvement mesh

### DIFF
--- a/apps/axctl/src/cli/commands/team.test.ts
+++ b/apps/axctl/src/cli/commands/team.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { renderSyncReport } from "./team.ts";
+
+describe("renderSyncReport", () => {
+  it("summarizes activated, unchanged, and gated", () => {
+    const out = renderSyncReport({ activated: ["skill:tdd", "agent:rev"], unchanged: ["skill:x"], gated: ["guard"] });
+    expect(out).toContain("activated 2");
+    expect(out).toContain("1 unchanged");
+    expect(out).toContain("guard");
+    expect(out).toMatch(/gated|executable|trust/i);
+  });
+  it("empty-state when no rig", () => {
+    expect(renderSyncReport({ activated: [], unchanged: [], gated: [] })).toContain("no team rig");
+  });
+});

--- a/apps/axctl/src/cli/commands/team.ts
+++ b/apps/axctl/src/cli/commands/team.ts
@@ -1,0 +1,193 @@
+/**
+ * `ax team` - team rig management.
+ *
+ *   ax team sync [--dry-run] [--yes]
+ *     Activate the team's committed `.ax/` rig (skills + agents) into your
+ *     runtime, trust-gated. Executable hooks in `.ax/hooks/` are reported as
+ *     gated but never activated. `--dry-run` shows what would change without
+ *     writing anything. `--yes` approves activation of new or changed artifacts.
+ */
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { scanAxFolder } from "../../team/scan.ts";
+import { hashArtifact } from "../../team/hash.ts";
+import { loadTrust, saveTrust, classify, defaultTrustPath } from "../../team/trust.ts";
+import { activateArtifact, isSafeName } from "../../team/activate.ts";
+import { artifactKey, type TeamArtifact } from "../../team/model.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+
+// ---------------------------------------------------------------------------
+// Pure render helper (exported for tests)
+// ---------------------------------------------------------------------------
+
+export interface SyncReport {
+    readonly activated: ReadonlyArray<string>;
+    readonly unchanged: ReadonlyArray<string>;
+    readonly gated: ReadonlyArray<string>;
+}
+
+/** Pure: format a sync result for stdout. No IO. */
+export const renderSyncReport = (r: SyncReport): string => {
+    if (r.activated.length === 0 && r.unchanged.length === 0 && r.gated.length === 0) {
+        return "[ax team sync] no team rig found in .ax/";
+    }
+    const lines: string[] = ["[ax team sync]"];
+    if (r.activated.length > 0) {
+        lines.push(`activated ${r.activated.length}:`);
+        for (const name of r.activated) lines.push(`  + ${name}`);
+    }
+    if (r.unchanged.length > 0) {
+        lines.push(`${r.unchanged.length} unchanged`);
+    }
+    if (r.gated.length > 0) {
+        lines.push("gated (executable hooks - trust-review before installing):");
+        for (const name of r.gated) lines.push(`  ~ ${name}`);
+    }
+    return lines.join("\n");
+};
+
+// ---------------------------------------------------------------------------
+// ax team sync
+// ---------------------------------------------------------------------------
+
+const cmdSync = (input: { readonly dryRun: boolean; readonly yes: boolean }) =>
+    Effect.gen(function* () {
+        // 1. Get git repo root
+        const r = Bun.spawnSync(["git", "rev-parse", "--show-toplevel"], {
+            stdout: "pipe",
+            stderr: "ignore",
+        });
+        if (r.exitCode !== 0) {
+            console.error("[ax team] not inside a git repo - run from the team repo root");
+            return;
+        }
+        const root = r.stdout.toString().trim();
+
+        // 2. Scan .ax/ for artifacts + gated hooks
+        const { artifacts, gated } = yield* Effect.promise(() => scanAxFolder(root));
+
+        if (artifacts.length === 0 && gated.length === 0) {
+            console.log("[ax team sync] no .ax/ rig found in this repo");
+            return;
+        }
+
+        // 3. Pre-read all artifact files to build a sync hash map
+        const fileContents = yield* Effect.promise(async () => {
+            const map = new Map<string, string>();
+            for (const a of artifacts) {
+                for (const rel of a.files) {
+                    const abs = a.kind === "agent" ? a.path : `${a.path}/${rel}`;
+                    map.set(abs, await Bun.file(abs).text());
+                }
+            }
+            return map;
+        });
+        const readFile = (abs: string): string => fileContents.get(abs) ?? "";
+        const hashOf = (a: TeamArtifact) => hashArtifact(a, readFile);
+
+        // 4. Load trust state + classify artifacts
+        const trust = yield* Effect.promise(() => loadTrust(defaultTrustPath()));
+        const cls = classify(artifacts, hashOf, trust);
+
+        // 5. Dry-run: show what would happen, write nothing
+        if (input.dryRun) {
+            const toActivate = [...cls.added, ...cls.changed];
+            if (toActivate.length > 0) {
+                console.log(`[ax team sync] would activate ${toActivate.length}:`);
+                for (const a of toActivate) console.log(`  + ${a.kind}:${a.name}`);
+            }
+            if (cls.unchanged.length > 0) {
+                console.log(`${cls.unchanged.length} unchanged`);
+            }
+            if (gated.length > 0) {
+                console.log("gated (executable hooks - never activated):");
+                for (const g of gated) console.log(`  ~ ${g.name}`);
+            }
+            if (toActivate.length === 0 && cls.unchanged.length === 0) {
+                console.log("nothing to activate");
+            }
+            return;
+        }
+
+        // 6. Compute what needs activating
+        const toActivate = [...cls.added, ...cls.changed];
+
+        // 7. Without --yes, print what would happen and bail (activate NOTHING)
+        if (toActivate.length > 0 && !input.yes) {
+            console.log(`[ax team sync] ${toActivate.length} artifact(s) ready to activate:`);
+            for (const a of toActivate) console.log(`  + ${a.kind}:${a.name}`);
+            console.log("re-run with --yes to approve");
+            return;
+        }
+
+        // 8. Activate all in to_activate (skip unsafe names), update trust
+        const home = process.env.HOME ?? "/tmp";
+        const activated: string[] = [];
+        const mutableTrust = { ...trust };
+
+        yield* Effect.promise(async () => {
+            for (const a of toActivate) {
+                if (!isSafeName(a.name)) {
+                    console.warn(`[ax team sync] unsafe artifact name, skipped: ${JSON.stringify(a.name)}`);
+                    continue;
+                }
+                await activateArtifact(a, home);
+                mutableTrust[artifactKey(a)] = {
+                    hash: hashOf(a),
+                    activated_at: new Date().toISOString(),
+                };
+                activated.push(`${a.kind}:${a.name}`);
+            }
+        });
+
+        // 9. Save updated trust state
+        yield* Effect.promise(() => saveTrust(defaultTrustPath(), mutableTrust));
+
+        // 10. Print report
+        console.log(
+            renderSyncReport({
+                activated,
+                unchanged: cls.unchanged.map((a) => `${a.kind}:${a.name}`),
+                gated: gated.map((g) => g.name),
+            }),
+        );
+    });
+
+const syncCommand = Command.make(
+    "sync",
+    {
+        dryRun: Flag.boolean("dry-run").pipe(Flag.withDefault(false)),
+        yes: Flag.boolean("yes").pipe(Flag.withDefault(false)),
+    },
+    ({ dryRun, yes }) => cmdSync({ dryRun, yes }),
+).pipe(
+    Command.withDescription(
+        "Activate the team's committed .ax/ rig (skills + agents) into your runtime, trust-gated. " +
+        "Hooks in .ax/hooks/ are gated and never activated. " +
+        "--dry-run (show what would change)  --yes (approve activation of new or changed artifacts)",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax team (group)
+// ---------------------------------------------------------------------------
+
+export const teamCommand = Command.make("team").pipe(
+    Command.withDescription(
+        "Team rig management: activate the shared .ax/ skills and agents into your local runtime.",
+    ),
+    Command.withSubcommands([syncCommand]),
+);
+
+export const teamRuntime: RuntimeManifest = {
+    team: {
+        runtime: {
+            kind: "db-conditional",
+            fallback: "none",
+            subcommands: {
+                sync: "none",
+            },
+        },
+        hidden: false,
+    },
+};

--- a/apps/axctl/src/cli/commands/team.ts
+++ b/apps/axctl/src/cli/commands/team.ts
@@ -120,8 +120,13 @@ const cmdSync = (input: { readonly dryRun: boolean; readonly yes: boolean }) =>
             return;
         }
 
-        // 8. Activate all in to_activate (skip unsafe names), update trust
-        const home = process.env.HOME ?? "/tmp";
+        // 8. Activate all in to_activate (skip unsafe names), update trust.
+        // HOME must be set - never silently write the rig into a surprise location.
+        const home = process.env.HOME;
+        if (!home) {
+            console.error("[ax team sync] HOME is not set; cannot resolve the runtime (~/.claude). Aborting.");
+            return;
+        }
         const activated: string[] = [];
         const mutableTrust = { ...trust };
 

--- a/apps/axctl/src/cli/commands/visible-commands.ts
+++ b/apps/axctl/src/cli/commands/visible-commands.ts
@@ -30,5 +30,6 @@ export const VISIBLE_COMMANDS: readonly string[] = [
     "routing",
     "thinking",
     "digest",
+    "team",
     "usage",
 ];

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -23,6 +23,7 @@ import { dispatchesRootCommand, axDispatchesRuntime } from "./commands/ax-dispat
 import { routingRootCommand, axRoutingRuntime } from "./commands/ax-routing.ts";
 import { thinkingCommand, axThinkingRuntime } from "./commands/ax-thinking.ts";
 import { digestCommand, digestRuntime } from "./commands/digest.ts";
+import { teamCommand, teamRuntime } from "./commands/team.ts";
 import { usageCommand, usageRuntime } from "./commands/usage.ts";
 import { recallCommand, recallRuntime } from "./commands/recall.ts";
 import { hookCommand, hooksCommand, hooksRuntime } from "./commands/hooks.ts";
@@ -91,6 +92,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...axRoutingRuntime,
     ...axThinkingRuntime,
     ...digestRuntime,
+    ...teamRuntime,
     ...usageRuntime,
     ...recallRuntime,
     ...hooksRuntime,
@@ -136,6 +138,7 @@ const registeredCommands: ReadonlyArray<Command.Command.Any> = [
     routingRootCommand,
     thinkingCommand,
     digestCommand,
+    teamCommand,
     usageCommand,
     // Maintenance / plumbing verbs - hidden via their family manifests.
     deriveCommand,

--- a/apps/axctl/src/team/activate.test.ts
+++ b/apps/axctl/src/team/activate.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, afterEach } from "bun:test";
+import { runtimeTarget, activateArtifact, isSafeName } from "./activate.ts";
+import type { TeamArtifact } from "./model.ts";
+
+describe("runtimeTarget", () => {
+  it("maps skill → ~/.claude/skills/<name>, agent → ~/.claude/agents/<name>.md", () => {
+    expect(runtimeTarget({ kind: "skill", name: "tdd", path: "x", files: [] }, "/home/u"))
+      .toBe("/home/u/.claude/skills/tdd");
+    expect(runtimeTarget({ kind: "agent", name: "rev", path: "x", files: [] }, "/home/u"))
+      .toBe("/home/u/.claude/agents/rev.md");
+  });
+});
+
+describe("isSafeName", () => {
+  it("rejects path-escaping names", () => {
+    expect(isSafeName("tdd")).toBe(true);
+    expect(isSafeName("../../evil")).toBe(false);
+    expect(isSafeName("a/b")).toBe(false);
+    expect(isSafeName("..")).toBe(false);
+  });
+});
+
+describe("activateArtifact", () => {
+  const home = `/tmp/ax-team-act-${process.pid}`;
+  afterEach(() => Bun.spawnSync(["rm", "-rf", home]));
+  it("copies a skill dir into the runtime", async () => {
+    const src = `/tmp/ax-team-src-${process.pid}`;
+    await Bun.write(`${src}/SKILL.md`, "hi");
+    const a: TeamArtifact = { kind: "skill", name: "tdd", path: src, files: ["SKILL.md"] };
+    await activateArtifact(a, home);
+    expect(await Bun.file(`${home}/.claude/skills/tdd/SKILL.md`).text()).toBe("hi");
+    Bun.spawnSync(["rm", "-rf", src]);
+  });
+  it("copies an agent file into the runtime", async () => {
+    const src = `/tmp/ax-team-srcag-${process.pid}.md`;
+    await Bun.write(src, "agent body");
+    const a: TeamArtifact = { kind: "agent", name: "rev", path: src, files: ["rev.md"] };
+    await activateArtifact(a, home);
+    expect(await Bun.file(`${home}/.claude/agents/rev.md`).text()).toBe("agent body");
+    Bun.spawnSync(["rm", "-f", src]);
+  });
+  it("throws on unsafe artifact name", async () => {
+    const a: TeamArtifact = { kind: "skill", name: "../../evil", path: "/tmp/x", files: [] };
+    expect(activateArtifact(a, home)).rejects.toThrow("unsafe artifact name");
+  });
+});

--- a/apps/axctl/src/team/activate.ts
+++ b/apps/axctl/src/team/activate.ts
@@ -1,0 +1,30 @@
+import type { TeamArtifact } from "./model.ts";
+
+/** Returns true for names that are safe slugs (no path separators or traversal). */
+export const isSafeName = (name: string): boolean =>
+  name !== ".." && /^[a-zA-Z0-9._-]+$/.test(name);
+
+export const runtimeTarget = (a: TeamArtifact, home: string): string =>
+  a.kind === "skill"
+    ? `${home}/.claude/skills/${a.name}`
+    : `${home}/.claude/agents/${a.name}.md`;
+
+/** Copy an artifact's source into its runtime target (idempotent overwrite).
+ *  Non-executable only (skills/agents) - hooks are gated upstream, never reach here. */
+export async function activateArtifact(a: TeamArtifact, home: string): Promise<void> {
+  if (!isSafeName(a.name)) throw new Error(`unsafe artifact name: ${JSON.stringify(a.name)}`);
+
+  const target = runtimeTarget(a, home);
+
+  if (a.kind === "agent") {
+    const text = await Bun.file(a.path).text();
+    await Bun.write(target, text, { createPath: true });
+    return;
+  }
+
+  // skill: cp -R src → target (idempotent overwrite via rm + cp)
+  Bun.spawnSync(["mkdir", "-p", `${home}/.claude/skills`]);
+  Bun.spawnSync(["rm", "-rf", target]);
+  const r = Bun.spawnSync(["cp", "-R", a.path, target]);
+  if (r.exitCode !== 0) throw new Error(`activate ${a.name}: cp failed (${r.exitCode})`);
+}

--- a/apps/axctl/src/team/hash.test.ts
+++ b/apps/axctl/src/team/hash.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { hashArtifact } from "./hash.ts";
+import type { TeamArtifact } from "./model.ts";
+
+const read = (contents: Record<string, string>) => (abs: string) => contents[abs] ?? "";
+
+describe("hashArtifact", () => {
+  const a: TeamArtifact = { kind: "skill", name: "tdd", path: "/r/.ax/skills/tdd", files: ["SKILL.md", "ref.md"] };
+  it("is stable for identical content", () => {
+    const r = read({ "/r/.ax/skills/tdd/SKILL.md": "a", "/r/.ax/skills/tdd/ref.md": "b" });
+    expect(hashArtifact(a, r)).toBe(hashArtifact(a, r));
+  });
+  it("changes when any file content changes", () => {
+    const r1 = read({ "/r/.ax/skills/tdd/SKILL.md": "a", "/r/.ax/skills/tdd/ref.md": "b" });
+    const r2 = read({ "/r/.ax/skills/tdd/SKILL.md": "a", "/r/.ax/skills/tdd/ref.md": "B" });
+    expect(hashArtifact(a, r1)).not.toBe(hashArtifact(a, r2));
+  });
+  it("is independent of file order in `files`", () => {
+    const r = read({ "/r/.ax/skills/tdd/SKILL.md": "a", "/r/.ax/skills/tdd/ref.md": "b" });
+    const reordered: TeamArtifact = { ...a, files: ["ref.md", "SKILL.md"] };
+    expect(hashArtifact(a, r)).toBe(hashArtifact(reordered, r));
+  });
+  it("agent: path is the file itself, files = [basename]", () => {
+    const ag: TeamArtifact = { kind: "agent", name: "rev", path: "/r/.ax/agents/rev.md", files: ["rev.md"] };
+    const r = read({ "/r/.ax/agents/rev.md": "agent body" });
+    expect(typeof hashArtifact(ag, r)).toBe("string");
+    expect(hashArtifact(ag, r).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/axctl/src/team/hash.ts
+++ b/apps/axctl/src/team/hash.ts
@@ -1,0 +1,13 @@
+import type { TeamArtifact } from "./model.ts";
+
+/** Stable content hash over the artifact's files (sorted path + content), so
+ *  reorderings don't change it but any content change does. `readFile(abs)`
+ *  returns the file text. Pure given the reader. For a skill, abs = `${path}/${rel}`;
+ *  for an agent (single file), abs = `path` itself. */
+export const hashArtifact = (a: TeamArtifact, readFile: (abs: string) => string): string => {
+  const parts = [...a.files].sort().map((rel) => {
+    const abs = a.kind === "agent" ? a.path : `${a.path}/${rel}`;
+    return `${rel}\0${readFile(abs)}`;
+  });
+  return Bun.hash(parts.join("\0\0")).toString(16);
+};

--- a/apps/axctl/src/team/hash.ts
+++ b/apps/axctl/src/team/hash.ts
@@ -9,5 +9,9 @@ export const hashArtifact = (a: TeamArtifact, readFile: (abs: string) => string)
     const abs = a.kind === "agent" ? a.path : `${a.path}/${rel}`;
     return `${rel}\0${readFile(abs)}`;
   });
+  // Bun.hash is wyhash (non-cryptographic) - this detects CHANGE for the trust
+  // gate, it is NOT a security primitive. A collision only fails SAFE (a changed
+  // file read as unchanged keeps the older trusted content). The executable-hook
+  // trust layer (mesh spec) must use a cryptographic hash (sha256), not this.
   return Bun.hash(parts.join("\0\0")).toString(16);
 };

--- a/apps/axctl/src/team/model.test.ts
+++ b/apps/axctl/src/team/model.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { artifactKey, type TeamArtifact } from "./model.ts";
+
+describe("artifactKey", () => {
+  it("is kind:name", () => {
+    const a: TeamArtifact = { kind: "skill", name: "tdd", path: "/r/.ax/skills/tdd", files: ["SKILL.md"] };
+    expect(artifactKey(a)).toBe("skill:tdd");
+  });
+  it("distinguishes kinds", () => {
+    const a: TeamArtifact = { kind: "agent", name: "tdd", path: "/r/.ax/agents/tdd.md", files: ["tdd.md"] };
+    expect(artifactKey(a)).toBe("agent:tdd");
+  });
+});

--- a/apps/axctl/src/team/model.ts
+++ b/apps/axctl/src/team/model.ts
@@ -1,0 +1,31 @@
+export type ArtifactKind = "skill" | "agent";
+
+/** A non-executable team-rig artifact discovered in `.ax/`. `path` is the source
+ *  (dir for a skill, file for an agent); `files` are the relative file paths to hash/copy. */
+export interface TeamArtifact {
+  readonly kind: ArtifactKind;
+  readonly name: string;
+  readonly path: string;
+  readonly files: ReadonlyArray<string>;
+}
+
+/** An executable artifact (`.ax/hooks/*`) - listed, never activated in Slice 0. */
+export interface GatedArtifact {
+  readonly kind: "hook";
+  readonly name: string;
+  readonly path: string;
+}
+
+export interface TrustRecord {
+  readonly hash: string;
+  readonly activated_at: string;
+}
+export type TrustState = Record<string, TrustRecord>;
+
+export interface SyncClassification {
+  readonly added: ReadonlyArray<TeamArtifact>;
+  readonly changed: ReadonlyArray<TeamArtifact>;
+  readonly unchanged: ReadonlyArray<TeamArtifact>;
+}
+
+export const artifactKey = (a: TeamArtifact): string => `${a.kind}:${a.name}`;

--- a/apps/axctl/src/team/scan.test.ts
+++ b/apps/axctl/src/team/scan.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import { scanAxFolder } from "./scan.ts";
+
+let root: string;
+beforeAll(async () => {
+  root = `/tmp/ax-team-scan-${process.pid}`;
+  await Bun.write(`${root}/.ax/skills/tdd/SKILL.md`, "tdd skill");
+  await Bun.write(`${root}/.ax/skills/tdd/ref.md`, "ref");
+  await Bun.write(`${root}/.ax/agents/reviewer.md`, "agent");
+  await Bun.write(`${root}/.ax/hooks/guard.ts`, "export default {}");
+});
+afterAll(() => { Bun.spawnSync(["rm", "-rf", root]); });
+
+describe("scanAxFolder", () => {
+  it("finds skills (with bundled files), agents, and gates hooks", async () => {
+    const { artifacts, gated } = await scanAxFolder(root);
+    const skill = artifacts.find((a) => a.kind === "skill" && a.name === "tdd");
+    expect([...(skill?.files ?? [])].sort()).toEqual(["SKILL.md", "ref.md"]);
+    expect(artifacts.find((a) => a.kind === "agent" && a.name === "reviewer")).toBeTruthy();
+    expect(gated.map((g) => g.name)).toEqual(["guard"]);
+  });
+  it("returns empty for a repo with no .ax/", async () => {
+    const { artifacts, gated } = await scanAxFolder(`/tmp/ax-team-none-${process.pid}-nonexistent`);
+    expect(artifacts).toEqual([]);
+    expect(gated).toEqual([]);
+  });
+});

--- a/apps/axctl/src/team/scan.ts
+++ b/apps/axctl/src/team/scan.ts
@@ -1,0 +1,41 @@
+import { Glob } from "bun";
+import type { GatedArtifact, TeamArtifact } from "./model.ts";
+
+export interface ScanResult {
+  readonly artifacts: ReadonlyArray<TeamArtifact>;
+  readonly gated: ReadonlyArray<GatedArtifact>;
+}
+
+/** Returns true if `path` is an existing directory (no node:fs). */
+const dirExists = (path: string): boolean =>
+  Bun.spawnSync(["test", "-d", path]).exitCode === 0;
+
+/** Scan `<repoRoot>/.ax/` for the team rig. Skills = each `skills/<name>/SKILL.md`
+ *  (+ sibling files); agents = each `agents/<name>.md`; hooks = `hooks/*` (gated). */
+export const scanAxFolder = async (repoRoot: string): Promise<ScanResult> => {
+  const ax = `${repoRoot}/.ax`;
+  if (!dirExists(ax)) return { artifacts: [], gated: [] };
+
+  const artifacts: TeamArtifact[] = [];
+  const gated: GatedArtifact[] = [];
+
+  for await (const rel of new Glob("skills/*/SKILL.md").scan({ cwd: ax, onlyFiles: true })) {
+    const name = rel.split("/")[1]!;
+    const dir = `${ax}/skills/${name}`;
+    const files: string[] = [];
+    for await (const f of new Glob("**/*").scan({ cwd: dir, onlyFiles: true })) files.push(f);
+    artifacts.push({ kind: "skill", name, path: dir, files });
+  }
+  for await (const rel of new Glob("agents/*.md").scan({ cwd: ax, onlyFiles: true })) {
+    const name = rel.slice("agents/".length, -".md".length);
+    artifacts.push({ kind: "agent", name, path: `${ax}/${rel}`, files: [`${name}.md`] });
+  }
+  for await (const rel of new Glob("hooks/*").scan({ cwd: ax, onlyFiles: true })) {
+    const name = rel.slice("hooks/".length).replace(/\.[^.]+$/, "");
+    gated.push({ kind: "hook", name, path: `${ax}/${rel}` });
+  }
+  return {
+    artifacts: artifacts.sort((a, b) => a.name.localeCompare(b.name)),
+    gated: gated.sort((a, b) => a.name.localeCompare(b.name)),
+  };
+};

--- a/apps/axctl/src/team/trust.test.ts
+++ b/apps/axctl/src/team/trust.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { classify } from "./trust.ts";
+import type { TeamArtifact, TrustState } from "./model.ts";
+
+const art = (name: string): TeamArtifact => ({ kind: "skill", name, path: `/r/.ax/skills/${name}`, files: ["SKILL.md"] });
+
+describe("classify", () => {
+  it("buckets added / changed / unchanged by hash", () => {
+    const arts = [art("a"), art("b"), art("c")];
+    const hashes: Record<string, string> = { "skill:a": "h1", "skill:b": "h2", "skill:c": "h3" };
+    const trust: TrustState = {
+      "skill:b": { hash: "h2", activated_at: "x" },
+      "skill:c": { hash: "OLD", activated_at: "x" },
+    };
+    const c = classify(arts, (a) => hashes[`${a.kind}:${a.name}`]!, trust);
+    expect(c.added.map((x) => x.name)).toEqual(["a"]);
+    expect(c.changed.map((x) => x.name)).toEqual(["c"]);
+    expect(c.unchanged.map((x) => x.name)).toEqual(["b"]);
+  });
+});

--- a/apps/axctl/src/team/trust.ts
+++ b/apps/axctl/src/team/trust.ts
@@ -1,0 +1,36 @@
+import { decodeJsonOrNull } from "@ax/lib/decode";
+import { artifactKey, type SyncClassification, type TeamArtifact, type TrustState } from "./model.ts";
+
+export const defaultTrustPath = (): string => `${process.env.HOME}/.ax/team-trust.json`;
+
+export async function loadTrust(path: string): Promise<TrustState> {
+  try {
+    const f = Bun.file(path);
+    if (!(await f.exists())) return {};
+    const parsed = decodeJsonOrNull(await f.text());
+    return parsed && typeof parsed === "object" ? (parsed as TrustState) : {};
+  } catch { return {}; }
+}
+
+export async function saveTrust(path: string, state: TrustState): Promise<void> {
+  const tmp = `${path}.${process.pid}.tmp`;
+  await Bun.write(tmp, `${JSON.stringify(state, null, 2)}\n`, { createPath: true });
+  const r = Bun.spawnSync(["mv", tmp, path]);
+  if (r.exitCode !== 0) { Bun.spawnSync(["rm", "-f", tmp]); throw new Error(`saveTrust: mv failed (${r.exitCode})`); }
+}
+
+/** Pure: bucket artifacts vs trusted hashes. `hashOf` gives each artifact's current hash. */
+export const classify = (
+  artifacts: ReadonlyArray<TeamArtifact>,
+  hashOf: (a: TeamArtifact) => string,
+  trust: TrustState,
+): SyncClassification => {
+  const added: TeamArtifact[] = [], changed: TeamArtifact[] = [], unchanged: TeamArtifact[] = [];
+  for (const a of artifacts) {
+    const rec = trust[artifactKey(a)];
+    if (!rec) added.push(a);
+    else if (rec.hash !== hashOf(a)) changed.push(a);
+    else unchanged.push(a);
+  }
+  return { added, changed, unchanged };
+};

--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -673,6 +673,38 @@ removed launchd plists and the ax symlink`,
       },
     ],
   },
+  {
+    eyebrow: "$ sync the team rig",
+    title: "Team",
+    blurb:
+      "Activate the shared .ax/ skills and agents committed to the repo into your local runtime, trust-gated per content hash.",
+    commands: [
+      {
+        name: "team",
+        sub: ["sync"],
+        job: "Activate the team's committed .ax/ rig (skills + agents) into your runtime, trust-gated.",
+        signature: "ax team sync [--dry-run] [--yes]",
+        flags: [
+          { flag: "--dry-run", desc: "show what would change without writing anything" },
+          { flag: "--yes", desc: "approve activation of new or changed artifacts" },
+        ],
+        receipt: `$ ax team sync --yes
+[ax team sync]
+activated 2:
+  + skill:tdd
+  + agent:reviewer
+1 unchanged
+gated (executable hooks - trust-review before installing):
+  ~ enforce-worktree`,
+        detail: [
+          "ax team sync scans .ax/skills/, .ax/agents/, and .ax/hooks/ in the current git repo root.",
+          "Skills and agents are non-executable and safe to copy; hooks in .ax/hooks/ require a separate trust review and are never activated automatically.",
+          "Content hashes prevent re-activating unchanged artifacts (idempotent). A changed artifact is re-activated and its trust record updated.",
+          "--dry-run prints the plan without writing anything. Without --yes, prints the activation list and exits without activating.",
+        ],
+      },
+    ],
+  },
 ];
 
 /**

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -66,6 +66,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax tui` - terminal skills browser
 
 ### Setup and ingest
+- `ax team sync` - activate the team's committed .ax/ rig (skills + agents) into your runtime, trust-gated (executable hooks gated)
 - `ax setup` / `ax install` - first-time install: CLI, local SurrealDB, transcript watcher
 - `ax ingest [here] [--since=Nd]` - ingest transcripts, skills, and git history; `here` scopes to the current repo; the watcher does this automatically on new transcripts
 - `ax roles` - list role labels used for skill classification

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -260,6 +260,12 @@ The 16 tools, each mirroring the matching CLI command:
 > `sessions_here` / `sessions_near` are intentionally deferred - they need a
 > git/cwd-resolved repository key, a documented follow-up.
 
+## Team
+
+`ax team sync [--dry-run] [--yes]`
+
+Activate the team's committed `.ax/` rig (skills + agents) into your runtime, trust-gated. Non-executable only - hooks in `.ax/hooks/` are reported as gated but never activated. `--dry-run` shows what would change. `--yes` approves activation (required when activating new or changed artifacts).
+
 ## Live ingest in the dashboard
 
 `axctl serve` exposes `POST /api/ingest` (also wired to the dashboard's **Live**

--- a/docs/superpowers/plans/2026-06-16-team-sync-slice0.md
+++ b/docs/superpowers/plans/2026-06-16-team-sync-slice0.md
@@ -1,0 +1,474 @@
+# Slice 0 - Local `ax team sync` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A local, no-backend `ax team sync` that activates a repo's committed `.ax/` non-executable rig (skills + agent definitions) into the runtime, gated by a trust-on-change prompt. Validates the individual-pull wedge before any hosted plumbing.
+
+**Architecture:** `.ax/` (a unified, harness-agnostic team rig committed in the repo) → `ax team sync` scans it, content-hashes each artifact, diffs against a per-machine trust file (`~/.ax/team-trust.json`), shows new/changed artifacts for approval, and copies approved **non-executable** artifacts into the runtime (`~/.claude/skills/<name>/`, `~/.claude/agents/<name>.md`). Executable `.ax/hooks/` are **listed but never activated** (deferred to the mesh security spec). Pure scan/hash/diff/plan logic; thin IO.
+
+**Tech Stack:** Bun, TypeScript (strict), Effect v4 (where it fits), `effect/unstable/cli`. Tests: `bun:test`. No DB (runtime "none", like `ax quota`).
+
+**Spec:** `docs/superpowers/specs/2026-06-15-team-backend-design.md` (on `feat/team-backend-spec`), §"Build order" Slice 0 + §S4.
+
+## The `.ax/` convention (pinned for Slice 0)
+
+```
+<repo>/.ax/
+  skills/<name>/SKILL.md   (+ bundled files in that dir)   → non-executable, activated
+  agents/<name>.md                                         → non-executable, activated
+  hooks/*.ts                                               → EXECUTABLE, listed-not-activated (gated)
+```
+Activation targets (user-level so the rig is active everywhere, and the base for cross-harness later):
+- skill `<name>` → copy the dir to `~/.claude/skills/<name>/`
+- agent `<name>` → copy to `~/.claude/agents/<name>.md`
+
+Trust file `~/.ax/team-trust.json`: `{ "<kind>:<name>": { hash, activated_at } }`.
+
+## File structure
+
+```
+apps/axctl/src/team/
+  model.ts      - TeamArtifact, SyncClassification, TrustState (+ types)
+  scan.ts       - scanAxFolder(repoRoot, fs) → { artifacts, gated }
+  hash.ts       - hashArtifact(artifact) stable content hash
+  trust.ts      - load/save ~/.ax/team-trust.json + classify(artifacts, trust) (pure)
+  activate.ts   - activate plan + copy into runtime + record trust
+apps/axctl/src/cli/commands/team.ts   - `ax team sync [--dry-run] [--yes]`
+apps/axctl/src/cli/index.ts           - register teamCommand + teamRuntime (modify)
+docs/cli.md · apps/site/public/llms.txt · apps/site/app/routes/docs/-cli-reference.data.ts - document `ax team` (modify; BOTH cli-reference gates - the #414 lesson)
+```
+
+Reuse: atomic-write pattern from `apps/axctl/src/quota/cache.ts`; CLI command pattern from `apps/axctl/src/cli/commands/digest.ts` (Command.make + RuntimeManifest, runtime "none" since no DB); `node:fs` is BANNED (check:no-node-fs) - use Bun fs.
+
+---
+
+## Task 1: `model.ts` - types
+
+**Files:** Create `apps/axctl/src/team/model.ts` + `model.test.ts`
+
+- [ ] **Step 1: failing test** `apps/axctl/src/team/model.test.ts`:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { artifactKey, type TeamArtifact } from "./model.ts";
+
+describe("artifactKey", () => {
+  it("is kind:name", () => {
+    const a: TeamArtifact = { kind: "skill", name: "tdd", path: "/r/.ax/skills/tdd", files: ["SKILL.md"] };
+    expect(artifactKey(a)).toBe("skill:tdd");
+  });
+  it("distinguishes kinds", () => {
+    const a: TeamArtifact = { kind: "agent", name: "tdd", path: "/r/.ax/agents/tdd.md", files: ["tdd.md"] };
+    expect(artifactKey(a)).toBe("agent:tdd");
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/model.ts`:
+
+```typescript
+export type ArtifactKind = "skill" | "agent";
+
+/** A non-executable team-rig artifact discovered in `.ax/`. `path` is the source
+ *  (dir for a skill, file for an agent); `files` are the relative file paths to hash/copy. */
+export interface TeamArtifact {
+  readonly kind: ArtifactKind;
+  readonly name: string;
+  readonly path: string;
+  readonly files: ReadonlyArray<string>; // relative to `path` (a skill dir) or [basename] (an agent file)
+}
+
+/** An executable artifact (`.ax/hooks/*`) - listed, never activated in Slice 0. */
+export interface GatedArtifact {
+  readonly kind: "hook";
+  readonly name: string;
+  readonly path: string;
+}
+
+export interface TrustRecord {
+  readonly hash: string;
+  readonly activated_at: string; // ISO
+}
+export type TrustState = Record<string, TrustRecord>;
+
+export interface SyncClassification {
+  readonly added: ReadonlyArray<TeamArtifact>;     // not in trust
+  readonly changed: ReadonlyArray<TeamArtifact>;   // hash differs from trust
+  readonly unchanged: ReadonlyArray<TeamArtifact>; // hash matches trust
+}
+
+export const artifactKey = (a: TeamArtifact): string => `${a.kind}:${a.name}`;
+```
+
+- [ ] **Step 4: run, PASS.**
+- [ ] **Step 5: commit:** `git add apps/axctl/src/team/model.ts apps/axctl/src/team/model.test.ts && git commit -m "feat(team): team-sync artifact model"`
+
+---
+
+## Task 2: `hash.ts` - stable content hash
+
+**Files:** Create `apps/axctl/src/team/hash.ts` + `hash.test.ts`
+
+- [ ] **Step 1: failing test** (pure over an injected file-reader so it's DB/FS-free):
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { hashArtifact } from "./hash.ts";
+import type { TeamArtifact } from "./model.ts";
+
+const read = (contents: Record<string, string>) => (abs: string) => contents[abs] ?? "";
+
+describe("hashArtifact", () => {
+  const a: TeamArtifact = { kind: "skill", name: "tdd", path: "/r/.ax/skills/tdd", files: ["SKILL.md", "ref.md"] };
+  it("is stable for identical content", () => {
+    const r = read({ "/r/.ax/skills/tdd/SKILL.md": "a", "/r/.ax/skills/tdd/ref.md": "b" });
+    expect(hashArtifact(a, r)).toBe(hashArtifact(a, r));
+  });
+  it("changes when any file content changes", () => {
+    const r1 = read({ "/r/.ax/skills/tdd/SKILL.md": "a", "/r/.ax/skills/tdd/ref.md": "b" });
+    const r2 = read({ "/r/.ax/skills/tdd/SKILL.md": "a", "/r/.ax/skills/tdd/ref.md": "B" });
+    expect(hashArtifact(a, r1)).not.toBe(hashArtifact(a, r2));
+  });
+  it("is independent of file order in `files`", () => {
+    const r = read({ "/r/.ax/skills/tdd/SKILL.md": "a", "/r/.ax/skills/tdd/ref.md": "b" });
+    const reordered: TeamArtifact = { ...a, files: ["ref.md", "SKILL.md"] };
+    expect(hashArtifact(a, r)).toBe(hashArtifact(reordered, r));
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/hash.ts`:
+
+```typescript
+import type { TeamArtifact } from "./model.ts";
+
+/** Stable content hash over the artifact's files (sorted path + content), so
+ *  reorderings don't change it but any content change does. `readFile(abs)`
+ *  returns the file text. Pure given the reader. */
+export const hashArtifact = (a: TeamArtifact, readFile: (abs: string) => string): string => {
+  const parts = [...a.files].sort().map((rel) => {
+    const abs = a.kind === "agent" ? a.path : `${a.path}/${rel}`;
+    return `${rel}\0${readFile(abs)}`;
+  });
+  return Bun.hash(parts.join("\0\0")).toString(16);
+};
+```
+
+> Implementer note: for an agent (single file), `files = [basename]` and `path` is the file itself; the `a.kind === "agent" ? a.path : ...` keeps the abs path correct. Verify against the scan output in Task 3.
+
+- [ ] **Step 4: run, PASS.**
+- [ ] **Step 5: commit.**
+
+---
+
+## Task 3: `scan.ts` - read `.ax/`
+
+**Files:** Create `apps/axctl/src/team/scan.ts` + `scan.test.ts`
+
+- [ ] **Step 1: failing test** - use a real temp dir (Bun) so the fs walk is exercised:
+
+```typescript
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import { scanAxFolder } from "./scan.ts";
+
+let root: string;
+beforeAll(async () => {
+  root = `/tmp/ax-team-scan-${process.pid}`;
+  await Bun.write(`${root}/.ax/skills/tdd/SKILL.md`, "tdd skill");
+  await Bun.write(`${root}/.ax/skills/tdd/ref.md`, "ref");
+  await Bun.write(`${root}/.ax/agents/reviewer.md`, "agent");
+  await Bun.write(`${root}/.ax/hooks/guard.ts`, "export default {}");
+});
+afterAll(() => { Bun.spawnSync(["rm", "-rf", root]); });
+
+describe("scanAxFolder", () => {
+  it("finds skills (with bundled files), agents, and gates hooks", async () => {
+    const { artifacts, gated } = await scanAxFolder(root);
+    const skill = artifacts.find((a) => a.kind === "skill" && a.name === "tdd");
+    expect(skill?.files.sort()).toEqual(["SKILL.md", "ref.md"]);
+    expect(artifacts.find((a) => a.kind === "agent" && a.name === "reviewer")).toBeTruthy();
+    expect(gated.map((g) => g.name)).toEqual(["guard"]);
+  });
+  it("returns empty for a repo with no .ax/", async () => {
+    const { artifacts, gated } = await scanAxFolder(`/tmp/ax-team-none-${process.pid}`);
+    expect(artifacts).toEqual([]);
+    expect(gated).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/scan.ts` using Bun's filesystem APIs (NO node:fs). Use `Bun.Glob` to walk:
+
+```typescript
+import { Glob } from "bun";
+import type { GatedArtifact, TeamArtifact } from "./model.ts";
+
+export interface ScanResult {
+  readonly artifacts: ReadonlyArray<TeamArtifact>;
+  readonly gated: ReadonlyArray<GatedArtifact>;
+}
+
+/** Scan `<repoRoot>/.ax/` for the team rig. Skills = each `skills/<name>/SKILL.md`
+ *  (+ sibling files); agents = each `agents/<name>.md`; hooks = `hooks/*` (gated). */
+export const scanAxFolder = async (repoRoot: string): Promise<ScanResult> => {
+  const ax = `${repoRoot}/.ax`;
+  const artifacts: TeamArtifact[] = [];
+  const gated: GatedArtifact[] = [];
+
+  // skills: a dir with a SKILL.md
+  for await (const rel of new Glob("skills/*/SKILL.md").scan({ cwd: ax, onlyFiles: true })) {
+    const name = rel.split("/")[1]!;
+    const dir = `${ax}/skills/${name}`;
+    const files: string[] = [];
+    for await (const f of new Glob("**/*").scan({ cwd: dir, onlyFiles: true })) files.push(f);
+    artifacts.push({ kind: "skill", name, path: dir, files });
+  }
+  // agents: agents/<name>.md
+  for await (const rel of new Glob("agents/*.md").scan({ cwd: ax, onlyFiles: true })) {
+    const name = rel.slice("agents/".length, -".md".length);
+    artifacts.push({ kind: "agent", name, path: `${ax}/${rel}`, files: [`${name}.md`] });
+  }
+  // hooks: gated (executable)
+  for await (const rel of new Glob("hooks/*").scan({ cwd: ax, onlyFiles: true })) {
+    const name = rel.slice("hooks/".length).replace(/\.[^.]+$/, "");
+    gated.push({ kind: "hook", name, path: `${ax}/${rel}` });
+  }
+  return {
+    artifacts: artifacts.sort((a, b) => a.name.localeCompare(b.name)),
+    gated: gated.sort((a, b) => a.name.localeCompare(b.name)),
+  };
+};
+```
+
+> Implementer note: confirm `Bun.Glob` is available in this Bun version and the `scan({cwd,onlyFiles})` async-iterator API matches; adapt if the API differs (e.g. `glob.scanSync`). The agent `files:[`${name}.md`]` + `path` pointing at the file must match `hash.ts`'s `kind==="agent"` branch. A missing `.ax/` dir → empty result (Glob over a non-existent cwd yields nothing; verify it doesn't throw - wrap in a dir-exists check if it does).
+
+- [ ] **Step 4: run, PASS.**
+- [ ] **Step 5: commit.**
+
+---
+
+## Task 4: `trust.ts` - trust file + classify
+
+**Files:** Create `apps/axctl/src/team/trust.ts` + `trust.test.ts`
+
+- [ ] **Step 1: failing test:**
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { classify } from "./trust.ts";
+import type { TeamArtifact, TrustState } from "./model.ts";
+
+const art = (name: string): TeamArtifact => ({ kind: "skill", name, path: `/r/.ax/skills/${name}`, files: ["SKILL.md"] });
+
+describe("classify", () => {
+  it("buckets added / changed / unchanged by hash", () => {
+    const arts = [art("a"), art("b"), art("c")];
+    const hashes = { "skill:a": "h1", "skill:b": "h2", "skill:c": "h3" };
+    const trust: TrustState = {
+      "skill:b": { hash: "h2", activated_at: "x" },     // unchanged
+      "skill:c": { hash: "OLD", activated_at: "x" },    // changed
+    };                                                    // a absent → added
+    const c = classify(arts, (a) => hashes[`${a.kind}:${a.name}`]!, trust);
+    expect(c.added.map((x) => x.name)).toEqual(["a"]);
+    expect(c.changed.map((x) => x.name)).toEqual(["c"]);
+    expect(c.unchanged.map((x) => x.name)).toEqual(["b"]);
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/trust.ts`:
+
+```typescript
+import { decodeJsonOrNull } from "@ax/lib/decode";
+import { artifactKey, type SyncClassification, type TeamArtifact, type TrustState } from "./model.ts";
+
+export const defaultTrustPath = (): string => `${process.env.HOME}/.ax/team-trust.json`;
+
+export async function loadTrust(path: string): Promise<TrustState> {
+  try {
+    const f = Bun.file(path);
+    if (!(await f.exists())) return {};
+    const parsed = decodeJsonOrNull(await f.text());
+    return parsed && typeof parsed === "object" ? (parsed as TrustState) : {};
+  } catch { return {}; }
+}
+
+export async function saveTrust(path: string, state: TrustState): Promise<void> {
+  const tmp = `${path}.${process.pid}.tmp`;
+  await Bun.write(tmp, `${JSON.stringify(state, null, 2)}\n`, { createPath: true });
+  const r = Bun.spawnSync(["mv", tmp, path]);
+  if (r.exitCode !== 0) { Bun.spawnSync(["rm", "-f", tmp]); throw new Error(`saveTrust: mv failed (${r.exitCode})`); }
+}
+
+/** Pure: bucket artifacts vs trusted hashes. `hashOf` gives each artifact's current hash. */
+export const classify = (
+  artifacts: ReadonlyArray<TeamArtifact>,
+  hashOf: (a: TeamArtifact) => string,
+  trust: TrustState,
+): SyncClassification => {
+  const added: TeamArtifact[] = [], changed: TeamArtifact[] = [], unchanged: TeamArtifact[] = [];
+  for (const a of artifacts) {
+    const rec = trust[artifactKey(a)];
+    if (!rec) added.push(a);
+    else if (rec.hash !== hashOf(a)) changed.push(a);
+    else unchanged.push(a);
+  }
+  return { added, changed, unchanged };
+};
+```
+
+- [ ] **Step 4: run, PASS.**
+- [ ] **Step 5: commit.**
+
+---
+
+## Task 5: `activate.ts` - copy into runtime + record trust
+
+**Files:** Create `apps/axctl/src/team/activate.ts` + `activate.test.ts`
+
+- [ ] **Step 1: failing test** (real temp dirs):
+
+```typescript
+import { describe, expect, it, afterEach } from "bun:test";
+import { runtimeTarget, activateArtifact } from "./activate.ts";
+import type { TeamArtifact } from "./model.ts";
+
+describe("runtimeTarget", () => {
+  it("maps skill → ~/.claude/skills/<name>, agent → ~/.claude/agents/<name>.md", () => {
+    expect(runtimeTarget({ kind: "skill", name: "tdd", path: "x", files: [] }, "/home/u"))
+      .toBe("/home/u/.claude/skills/tdd");
+    expect(runtimeTarget({ kind: "agent", name: "rev", path: "x", files: [] }, "/home/u"))
+      .toBe("/home/u/.claude/agents/rev.md");
+  });
+});
+
+describe("activateArtifact", () => {
+  const home = `/tmp/ax-team-act-${process.pid}`;
+  afterEach(() => Bun.spawnSync(["rm", "-rf", home]));
+  it("copies a skill dir into the runtime", async () => {
+    const src = `/tmp/ax-team-src-${process.pid}`;
+    await Bun.write(`${src}/SKILL.md`, "hi");
+    const a: TeamArtifact = { kind: "skill", name: "tdd", path: src, files: ["SKILL.md"] };
+    await activateArtifact(a, home);
+    expect(await Bun.file(`${home}/.claude/skills/tdd/SKILL.md`).text()).toBe("hi");
+    Bun.spawnSync(["rm", "-rf", src]);
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/activate.ts` (copy via Bun + `cp -R` for dirs - node:fs banned):
+
+```typescript
+import type { TeamArtifact } from "./model.ts";
+
+export const runtimeTarget = (a: TeamArtifact, home: string): string =>
+  a.kind === "skill" ? `${home}/.claude/skills/${a.name}` : `${home}/.claude/agents/${a.name}.md`;
+
+/** Copy an artifact's source into its runtime target (idempotent overwrite). */
+export async function activateArtifact(a: TeamArtifact, home: string): Promise<void> {
+  const target = runtimeTarget(a, home);
+  if (a.kind === "agent") {
+    const text = await Bun.file(a.path).text();
+    await Bun.write(target, text, { createPath: true });
+    return;
+  }
+  // skill dir: ensure parent, replace target dir
+  Bun.spawnSync(["mkdir", "-p", `${home}/.claude/skills`]);
+  Bun.spawnSync(["rm", "-rf", target]);
+  const r = Bun.spawnSync(["cp", "-R", a.path, target]);
+  if (r.exitCode !== 0) throw new Error(`activate ${a.name}: cp failed (${r.exitCode})`);
+}
+```
+
+- [ ] **Step 4: run, PASS.**
+- [ ] **Step 5: commit.**
+
+---
+
+## Task 6: `ax team sync` CLI + docs + both cli-reference gates + e2e
+
+**Files:** Create `apps/axctl/src/cli/commands/team.ts` + `team.test.ts`; modify `apps/axctl/src/cli/index.ts`, `docs/cli.md`, `apps/site/public/llms.txt`, `apps/site/app/routes/docs/-cli-reference.data.ts`
+
+- [ ] **Step 1: failing test** for the pure renderer:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { renderSyncReport } from "./team.ts";
+
+describe("renderSyncReport", () => {
+  it("summarizes activated, unchanged, and gated", () => {
+    const out = renderSyncReport({ activated: ["skill:tdd", "agent:rev"], unchanged: ["skill:x"], gated: ["guard"] });
+    expect(out).toContain("activated 2");
+    expect(out).toContain("1 unchanged");
+    expect(out).toContain("guard");
+    expect(out).toMatch(/gated|executable|trust/i);
+  });
+  it("empty-state when no .ax/", () => {
+    expect(renderSyncReport({ activated: [], unchanged: [], gated: [] })).toContain("no team rig");
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/cli/commands/team.ts`. Mirror `apps/axctl/src/cli/commands/digest.ts` for `Command.make` + `RuntimeManifest` (runtime **"none"** - no DB, like quota). The command resolves the git repo root, scans, hashes, classifies, prompts for new/changed (unless `--yes` or `--dry-run`), activates approved, updates trust, prints `renderSyncReport`. Pure `renderSyncReport`:
+
+```typescript
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { jsonFlag } from "./shared.ts";          // reuse boolean-flag idiom if useful
+import type { RuntimeManifest } from "./manifest.ts";
+import { scanAxFolder } from "../../team/scan.ts";
+import { hashArtifact } from "../../team/hash.ts";
+import { classify, loadTrust, saveTrust, defaultTrustPath } from "../../team/trust.ts";
+import { activateArtifact } from "../../team/activate.ts";
+import { artifactKey } from "../../team/model.ts";
+
+export const renderSyncReport = (r: { activated: string[]; unchanged: string[]; gated: string[] }): string => {
+  if (r.activated.length === 0 && r.unchanged.length === 0 && r.gated.length === 0)
+    return "[ax team] no team rig found (.ax/ has no skills or agents).";
+  const lines = [`[ax team] sync: activated ${r.activated.length}, ${r.unchanged.length} unchanged`];
+  for (const k of r.activated) lines.push(`  + ${k}`);
+  if (r.gated.length) lines.push(`gated (executable hooks - require the mesh trust layer, NOT activated): ${r.gated.join(", ")}`);
+  return lines.join("\n");
+};
+```
+
+The command body (Effect.gen): resolve repo root via `git rev-parse --show-toplevel` (Bun.spawnSync); `scanAxFolder`; build `hashOf` reading files via `Bun.file(abs).text()` sync-ish (read all needed files first, or make hashArtifact accept an async reader - simplest: pre-read every artifact's files into a map, then `hashArtifact(a, (abs)=>map[abs])`); `loadTrust`; `classify`; if `--dry-run` print plan + exit; else for `added`+`changed` either auto-approve (`--yes`) or prompt (read a yes/no from stdin - keep simple; if not a TTY, require `--yes`); `activateArtifact` each approved; update trust with the new hashes + `activated_at`; `saveTrust`; print `renderSyncReport`. Read `apps/axctl/src/cli/commands/digest.ts` for the exact `Command.make`/`RuntimeManifest` shape; `teamRuntime = { team: { runtime: "none", hidden: false } }`.
+
+> Implementer note: `team` is a command GROUP (`ax team sync`) - model it as a subcommand of a `team` group, OR (simpler for Slice 0) a single `ax team sync`. Mirror how an existing group command is built (grep a `Command` with subcommands, e.g. `sessions`/`cost`); if groups are heavy, ship `ax team` with `sync` as its only action. Keep `renderSyncReport` pure + tested regardless. Interactive prompt: if `process.stdin.isTTY` is false and there are added/changed artifacts and no `--yes`, print "re-run with --yes to approve N new/changed artifacts" and activate nothing (fail-safe - never auto-activate without approval).
+
+- [ ] **Step 4: register + document.** index.ts: import + `...teamRuntime` + `teamCommand`. Document `ax team` in docs/cli.md (a `## Team` section), llms.txt (a `- \`ax team sync\`` line), and a `team` card in `-cli-reference.data.ts` (mirror the `digest`/`usage` cards; signature `ax team sync [--dry-run] [--yes]`; no axctl/`/Users` in copy).
+
+- [ ] **Step 5: verify - tests + BOTH gates + typecheck + e2e:**
+```
+bun test apps/axctl/src/team apps/axctl/src/cli/commands/team.test.ts
+bun scripts/check-cli-reference.ts 2>&1 | tail -1
+bun test scripts/check-site-cli-reference.test.ts 2>&1 | tail -3
+bun run typecheck 2>&1 | rg -c "error TS"
+# e2e: build a fake team rig + sync it
+rm -rf /tmp/axteam && mkdir -p /tmp/axteam && (cd /tmp/axteam && git init -q)
+mkdir -p /tmp/axteam/.ax/skills/demo-skill /tmp/axteam/.ax/agents /tmp/axteam/.ax/hooks
+printf -- '---\nname: demo-skill\ndescription: a demo\n---\nbody\n' > /tmp/axteam/.ax/skills/demo-skill/SKILL.md
+printf 'agent body\n' > /tmp/axteam/.ax/agents/demo-agent.md
+printf 'export default {}\n' > /tmp/axteam/.ax/hooks/demo-hook.ts
+cd /tmp/axteam && bun run /Users/necmttn/Projects/ax/.claude/worktrees/team-sync/apps/axctl/src/cli/index.ts team sync --yes
+ls ~/.claude/skills/demo-skill/SKILL.md ~/.claude/agents/demo-agent.md   # should exist
+# idempotency: re-run → "unchanged"
+cd /tmp/axteam && bun run /Users/necmttn/Projects/ax/.claude/worktrees/team-sync/apps/axctl/src/cli/index.ts team sync --yes
+```
+Expected: tests pass; both gates cover `ax team`; 0 typecheck errors; the demo skill + agent land in the runtime; the hook is reported gated (not activated - confirm `ls ~/.ax/hooks/demo-hook.ts` does NOT exist / it's not installed); second run reports unchanged. **Cleanup after e2e:** `rm -rf ~/.claude/skills/demo-skill ~/.claude/agents/demo-agent.md /tmp/axteam` and remove the demo entries from `~/.ax/team-trust.json` (don't leave demo state on the dev machine - the repo-root-clean rule).
+
+- [ ] **Step 6: commit.**
+
+---
+
+## Self-Review Notes
+- **Security (Slice 0):** only non-executable artifacts (skills/agents) are copied; `.ax/hooks/*` are listed-not-activated (the RCE carve-out). Trust-on-change: new/changed artifacts require approval (`--yes` or interactive); non-TTY without `--yes` activates nothing. This is the v1-sync behavior from spec §S4.
+- **No backend/auth/secrets** - pure local. Runtime "none" (no DB).
+- **CI gotchas carried from #414:** BOTH cli-reference gates + the docs updated in Task 6.
+- **Cleanup:** e2e must not leave demo skills/agents/trust on the dev machine.


### PR DESCRIPTION
## Why

First, **local** slice of the team product's improvement mesh (Fix #1b). A 3-way design review (2 opus + independent Codex) said: lead with the one feature that has *individual-developer pull*, ship it with **no backend/auth/secrets**, and validate the wedge before any hosted plumbing. That's `ax team sync`.

Spec: `docs/superpowers/specs/2026-06-15-team-backend-design.md` (§Build order, Slice 0). Plan: `docs/superpowers/plans/2026-06-16-team-sync-slice0.md`.

## What

`ax team sync` activates a repo's committed **`.ax/` team rig** into the developer's runtime, gated by trust-on-change:

```
<repo>/.ax/
  skills/<name>/SKILL.md (+files)  → ~/.claude/skills/<name>/     (activated)
  agents/<name>.md                 → ~/.claude/agents/<name>.md    (activated)
  hooks/*.ts                       → GATED — listed, never activated (RCE carve-out)
```

- Content-hashes each artifact, diffs against `~/.ax/team-trust.json`, and **only activates new/changed artifacts the developer approves**.
- **Fail-safe:** without `--yes` (or non-TTY), it prints what *would* activate and changes nothing.
- **Non-executable only:** skills + agent definitions are copied; executable `.ax/hooks/` are reported gated and never run (the executable-hook trust layer is its own future security spec).
- **Path-traversal guard** (`isSafeName`) on every artifact name before writing into `~/.claude/`.
- No DB / backend / network — runtime `"none"`, like `ax quota`.

```
$ ax team sync --yes
[ax team sync]
activated 2:
  + agent:reviewer
  + skill:tdd
gated (executable hooks - trust-review before installing):
  ~ enforce-deploy-recipe
```

## Test plan

- [x] 16 unit tests (model/hash/scan/trust/activate/CLI) — pure logic pinned, real-temp-dir fs walks
- [x] **Security verified end-to-end:** non-TTY-without-`--yes` activates nothing; `--yes` lands skill+agent but the hook is gated (not installed); path-traversal names rejected; idempotent re-run = "unchanged"
- [x] Both cli-reference gates + docs (the #414 lesson); `typecheck` 0
- [x] Holistic opus review: **Ship** (all 3 security invariants confirmed)
- [ ] CI green against current origin/main

## Notes
- `Bun.hash` (non-crypto) is fine here — the trust boundary is the human `--yes`, and a collision fails *safe*. The future executable-hook trust layer must use sha256 (commented in `hash.ts`).
- Carry-forward (non-blocking, per review): validate with a design partner that non-executable sync alone drives adoption; cross-harness (Codex) activation is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)