### PR TITLE
refactor(recall): complete the Query Input Contract for recall (A1)

### DIFF
--- a/apps/axctl/src/cli/commands/recall.ts
+++ b/apps/axctl/src/cli/commands/recall.ts
@@ -10,7 +10,7 @@ import {
     buildRecallNext,
 } from "../../nav/next-links.ts";
 import { printNextLinks } from "../next-format.ts";
-import { fetchRecall, resolveRecallSources, type RecallSource, type RecallScope } from "../../dashboard/recall.ts";
+import { fetchRecall, normalizeRecallParams, resolveRecallSources, type RecallSource, type RecallScope } from "../../dashboard/recall.ts";
 import { resolvePwdRepository } from "../../pwd.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, parseCsvFlag } from "./shared.ts";
@@ -217,14 +217,14 @@ const cmdRecall = (opts: RecallCliOpts) =>
         const skill = yield* resolveSkill(opts.skill);
         const sources = parseSourcesFlag(opts.sources);
         const scope = yield* resolveScope(opts.scopeFlag);
-        const result = yield* fetchRecall({
+        const result = yield* fetchRecall(normalizeRecallParams({
             q: opts.query,
             project,
             skill,
             since: opts.since,
             ...(sources !== null ? { sources } : {}),
             scope,
-        });
+        }));
         const { hits, next } = buildRecallNext(result, {
             requestedSources: resolveRecallSources(sources),
         });

--- a/apps/axctl/src/dashboard/contract/insights.ts
+++ b/apps/axctl/src/dashboard/contract/insights.ts
@@ -13,7 +13,12 @@ import { fetchCostModels } from "../../queries/cost-analytics.ts";
 import { fetchContextBudget, fetchSkillDrift } from "../../queries/context-budget.ts";
 import { fetchEpisodeTimeline } from "../episode-timeline.ts";
 import { fetchProject } from "../project.ts";
-import { emptyRecallResponse, fetchRecall, type RecallParams } from "../recall.ts";
+import {
+    emptyRecallResponse,
+    fetchRecall,
+    isEmptyRecallQuery,
+    normalizeRecallParams,
+} from "../recall.ts";
 import { fetchSkillGraph } from "../skill-graph.ts";
 import { fetchToolFailureDetail, fetchToolFailures } from "../tool-failures.ts";
 import { fetchWorkflow } from "../workflow.ts";
@@ -26,17 +31,14 @@ import { asJsonValue, orInternal } from "./common.ts";
 export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handlers) =>
     handlers
         .handle("recall", ({ query }) => {
-            const params: RecallParams = {
-                q: query.q ?? "",
-                project: query.project ?? null,
-                skill: query.skill ?? null,
-                since: query.since ?? null,
-                offset: query.offset ?? 0,
-                limit: query.limit ?? 50,
-            };
-            if (params.q.trim().length === 0) {
+            const params = normalizeRecallParams(query);
+            if (isEmptyRecallQuery(params.q)) {
                 return Effect.succeed(
-                    emptyRecallResponse(params.q, params.offset ?? 0, params.limit ?? 50),
+                    emptyRecallResponse(
+                        params.q,
+                        params.offset ?? 0,
+                        params.limit ?? 50,
+                    ),
                 );
             }
             return orInternal(fetchRecall(params));

--- a/apps/axctl/src/dashboard/recall.ts
+++ b/apps/axctl/src/dashboard/recall.ts
@@ -68,6 +68,58 @@ export const resolveRecallSources = (
 ): ReadonlyArray<RecallSource> =>
     requested && requested.length > 0 ? requested : RECALL_DEFAULT_SOURCES;
 
+/**
+ * Default offset/limit the recall transports fill when a caller omits them.
+ * `RECALL_DEFAULT_LIMIT` is derived from {@link RECALL_PAGINATION} so the
+ * presence-default and the clamp default cannot drift.
+ */
+export const RECALL_DEFAULT_OFFSET = 0;
+export const RECALL_DEFAULT_LIMIT = RECALL_PAGINATION.defaultLimit;
+
+/** Whether a recall query is effectively empty (the no-DB fast path predicate). */
+export const isEmptyRecallQuery = (q: string): boolean => q.trim().length === 0;
+
+/**
+ * The raw arguments a transport (CLI / HTTP / MCP) hands to recall, before the
+ * shared semantics are applied. Every field is optional/nullable because each
+ * transport carries a different subset (HTTP has no sources/scope, MCP no
+ * scope); the genuine surface differences are documented in the contract test.
+ */
+export interface RecallQueryArgs {
+    readonly q?: string | null;
+    readonly project?: string | null;
+    readonly skill?: string | null;
+    readonly since?: string | null;
+    readonly offset?: number | null;
+    readonly limit?: number | null;
+    readonly sources?: ReadonlyArray<RecallSource> | null;
+    readonly scope?: RecallScope;
+}
+
+/**
+ * The single home for recall argument semantics - the Query Input Contract seam
+ * every transport delegates to (CONTEXT.md "Query Input Contract"). Pure: it
+ * fills presence defaults only and leaves all downstream behaviour to
+ * `fetchRecall`. Specifically it:
+ *   - echoes RAW `q` (no trim/lowercase - `fetchRecall` lowercases internally
+ *     only for matching and echoes `params.q` verbatim);
+ *   - passes `sources` through UNRESOLVED (`fetchRecall` + `buildRecallNext`
+ *     both call `resolveRecallSources`; pre-resolving would double-apply);
+ *   - fills offset/limit PRESENCE defaults only - NO clamp (`fetchRecall` owns
+ *     `clampPagination` with `RECALL_PAGINATION`, max 200);
+ *   - passes project/skill/since/scope through (`fetchRecall` trims them).
+ */
+export const normalizeRecallParams = (args: RecallQueryArgs): RecallParams => ({
+    q: args.q ?? "",
+    project: args.project ?? null,
+    skill: args.skill ?? null,
+    since: args.since ?? null,
+    offset: args.offset ?? RECALL_DEFAULT_OFFSET,
+    limit: args.limit ?? RECALL_DEFAULT_LIMIT,
+    ...(args.sources != null ? { sources: args.sources } : {}),
+    ...(args.scope !== undefined ? { scope: args.scope } : {}),
+});
+
 export const emptyRecallResponse = (
     q: string,
     offset: number,

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -20,8 +20,8 @@ import { Effect, type ManagedRuntime, type Layer } from "effect";
 import type { AppLayer } from "@ax/lib/layers";
 import {
     fetchRecall,
+    normalizeRecallParams,
     resolveRecallSources,
-    type RecallParams,
     type RecallSource,
 } from "../dashboard/recall.ts";
 import {
@@ -112,7 +112,6 @@ const recallTool: AxMcpTool = {
             .describe('Which sources to search. Defaults to ["turn"]. Any of "turn", "commit", "skill".'),
     },
     run: async (args, rt) => {
-        const q = String(args.q ?? "").trim();
         const limit = typeof args.limit === "number" ? args.limit : undefined;
         const sources = Array.isArray(args.sources)
             ? (args.sources.filter((s): s is RecallSource =>
@@ -122,11 +121,15 @@ const recallTool: AxMcpTool = {
         // No scope param in v0: omit it so fetchRecall defaults to unscoped
         // (all repositories). Real repo-scoping needs the git resolver, which
         // is unfit for a long-lived server - revisit later.
-        const params: RecallParams = {
-            q,
+        //
+        // Route through the shared recall input contract. This now echoes the
+        // RAW q (previously `.trim()`ed here) to match the CLI/HTTP echo and the
+        // buildRecallNext follow-up links - a deliberate contract invariant.
+        const params = normalizeRecallParams({
+            q: typeof args.q === "string" ? args.q : "",
             ...(limit !== undefined ? { limit } : {}),
             ...(sources && sources.length > 0 ? { sources } : {}),
-        };
+        });
 
         const result = await rt.runPromise(fetchRecall(params));
         const { hits, next } = buildRecallNext(result, {

--- a/apps/axctl/src/queries/query-input-contract.test.ts
+++ b/apps/axctl/src/queries/query-input-contract.test.ts
@@ -19,6 +19,10 @@ import {
 import {
     resolveRecallSources,
     RECALL_DEFAULT_SOURCES,
+    normalizeRecallParams,
+    isEmptyRecallQuery,
+    RECALL_DEFAULT_OFFSET,
+    RECALL_DEFAULT_LIMIT,
 } from "../dashboard/recall.ts";
 import {
     normalizeSessionsAroundOpts,
@@ -118,6 +122,113 @@ describe("resolveRecallSources", () => {
             "commit",
             "skill",
         ]);
+    });
+});
+
+describe("isEmptyRecallQuery", () => {
+    test("empty / whitespace-only is empty; any non-blank char is not", () => {
+        expect(isEmptyRecallQuery("")).toBe(true);
+        expect(isEmptyRecallQuery("   ")).toBe(true);
+        expect(isEmptyRecallQuery("\t\n")).toBe(true);
+        expect(isEmptyRecallQuery("x")).toBe(false);
+        expect(isEmptyRecallQuery("  x  ")).toBe(false);
+    });
+});
+
+describe("normalizeRecallParams", () => {
+    test("echoes RAW q - no trim/lowercase (fetchRecall lowercases internally)", () => {
+        expect(normalizeRecallParams({ q: "  Foo BAR " }).q).toBe("  Foo BAR ");
+    });
+
+    test("missing/null q collapses to empty string", () => {
+        expect(normalizeRecallParams({}).q).toBe("");
+        expect(normalizeRecallParams({ q: null }).q).toBe("");
+    });
+
+    test("fills offset/limit PRESENCE defaults when absent", () => {
+        const out = normalizeRecallParams({ q: "auth" });
+        expect(out.offset).toBe(RECALL_DEFAULT_OFFSET);
+        expect(out.limit).toBe(RECALL_DEFAULT_LIMIT);
+        expect(RECALL_DEFAULT_OFFSET).toBe(0);
+        expect(RECALL_DEFAULT_LIMIT).toBe(50);
+    });
+
+    test("passes present offset/limit through and does NOT clamp (fetchRecall owns the clamp)", () => {
+        const out = normalizeRecallParams({ q: "auth", offset: 5, limit: 500 });
+        expect(out.offset).toBe(5);
+        expect(out.limit).toBe(500); // > maxLimit 200, intentionally unclamped here
+    });
+
+    test("passes sources through UNRESOLVED (no resolveRecallSources pre-application)", () => {
+        expect(normalizeRecallParams({ q: "a", sources: ["commit"] }).sources).toEqual([
+            "commit",
+        ]);
+        // absent sources stay absent so fetchRecall/buildRecallNext resolve once
+        expect("sources" in normalizeRecallParams({ q: "a" })).toBe(false);
+    });
+
+    test("passes project/skill/since/scope through, defaulting the first three to null", () => {
+        const bare = normalizeRecallParams({ q: "a" });
+        expect(bare.project).toBeNull();
+        expect(bare.skill).toBeNull();
+        expect(bare.since).toBeNull();
+        expect("scope" in bare).toBe(false);
+
+        const scoped = normalizeRecallParams({
+            q: "a",
+            project: "p",
+            skill: "s",
+            since: "2026-01-01",
+            scope: { kind: "all" },
+        });
+        expect(scoped.project).toBe("p");
+        expect(scoped.skill).toBe("s");
+        expect(scoped.since).toBe("2026-01-01");
+        expect(scoped.scope).toEqual({ kind: "all" });
+
+        // scope null (CLI --scope unset) is a meaningful value, preserved
+        expect(normalizeRecallParams({ q: "a", scope: null }).scope).toBeNull();
+    });
+});
+
+// Per-rule parity: each transport (CLI / HTTP-query / MCP-args) carries a
+// different SUBSET of recall args, but for the fields they share the normalized
+// result must agree. Documents the genuine surface differences (HTTP has no
+// sources/scope, MCP has no scope) as intentional, not drift.
+describe("normalizeRecallParams - cross-transport parity", () => {
+    const httpQuery = { q: "auth flow", project: "ax", skill: null, since: null };
+    const mcpArgs = { q: "auth flow", sources: ["turn"] as const };
+    const cliOpts = {
+        q: "auth flow",
+        project: "ax",
+        skill: null,
+        since: null,
+        sources: ["turn"] as const,
+        scope: null,
+    };
+
+    test("shared fields collapse identically: raw-q echo + presence defaults", () => {
+        const h = normalizeRecallParams(httpQuery);
+        const m = normalizeRecallParams(mcpArgs);
+        const c = normalizeRecallParams(cliOpts);
+        for (const p of [h, m, c]) {
+            expect(p.q).toBe("auth flow"); // raw echo, every transport
+            expect(p.offset).toBe(RECALL_DEFAULT_OFFSET);
+            expect(p.limit).toBe(RECALL_DEFAULT_LIMIT);
+        }
+    });
+
+    test("project agrees where carried (HTTP+CLI); MCP simply omits it", () => {
+        expect(normalizeRecallParams(httpQuery).project).toBe("ax");
+        expect(normalizeRecallParams(cliOpts).project).toBe("ax");
+        expect(normalizeRecallParams(mcpArgs).project).toBeNull();
+    });
+
+    test("documented surface differences: HTTP has no sources/scope, MCP no scope", () => {
+        expect("sources" in normalizeRecallParams(httpQuery)).toBe(false);
+        expect("scope" in normalizeRecallParams(httpQuery)).toBe(false);
+        expect("scope" in normalizeRecallParams(mcpArgs)).toBe(false);
+        expect(normalizeRecallParams(cliOpts).scope).toBeNull();
     });
 });
 


### PR DESCRIPTION
## What

Completes the **Query Input Contract** for recall — arg semantics now live in one shared `normalizeRecallParams` seam in `dashboard/recall.ts`, and all three transports (HTTP handler, MCP tool, CLI) delegate to it instead of each rebuilding the param struct with their own `?? ""` / `?? 0` / `?? 50` defaults.

Mirrors the 5 existing `normalize*Input` modules. Pure functions below the decode boundary.

## Behavior

- Fills offset/limit **presence** defaults only — `fetchRecall` keeps the single `clampPagination` authority (no second clamp).
- Echoes **RAW** `q` (fetchRecall lowercases internally only for matching).
- Passes `sources` through **unresolved** (`fetchRecall` + `buildRecallNext` already resolve once).
- **MCP now echoes RAW q** instead of a trimmed one — a deliberate, documented contract invariant so the echo + `buildRecallNext` follow-up links match CLI/HTTP.

## Tests

Per-rule cross-transport **parity test** added to `query-input-contract.test.ts` — the contract's payoff was previously unprovable (only the CLI path was normalized). Documents the genuine surface differences (HTTP has no sources/scope, MCP no scope) as intentional, not drift.

## Scope corrections (from review)

- Dropped the originally-scoped `packages/lib/package.json` edit — the `./*` wildcard already resolves `@ax/lib/shared/*` subpaths.
- Split from the original "Query Input Contract" candidate; cost-window default is sibling **A2**.

Arch-deepening **A1**. Plan: `docs/superpowers/plans/2026-06-16-arch-deepening-goal-package.md`

Verify: `bun test apps/axctl/src/queries/query-input-contract.test.ts` (29 pass) + `bunx tsc -p apps/axctl/tsconfig.json --noEmit` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)