### PR TITLE
fix(signals): exclude harness-injected turns from correction derivation

### DIFF
--- a/apps/axctl/src/ingest/signals/core.test.ts
+++ b/apps/axctl/src/ingest/signals/core.test.ts
@@ -13,6 +13,7 @@ import {
     deriveRecovered,
     deriveSkillPairs,
     groupTurnsBySession,
+    isHarnessInjected,
     matchNegation,
     shouldDeriveAllTimeSkillPairs,
     skillPairedEdgeId,
@@ -86,6 +87,22 @@ describe("matchNegation", () => {
     });
 });
 
+describe("isHarnessInjected", () => {
+    test("flags harness-injected wrappers + task/monitor prompts", () => {
+        expect(isHarnessInjected('<subagent_notification> {"status":"done"}')).toBe(true);
+        expect(isHarnessInjected("<task-notification> <task-id>x</task-id>")).toBe(true);
+        expect(isHarnessInjected("<system-reminder>\nbe brief</system-reminder>")).toBe(true);
+        expect(isHarnessInjected("## Your task\nMonitor the staging deploy for `abc`")).toBe(true);
+        expect(isHarnessInjected("Monitor event: codex roast finished")).toBe(true);
+        expect(isHarnessInjected("Continue prod monitoring for the #957 fix")).toBe(true);
+    });
+    test("does NOT flag genuine user corrections", () => {
+        expect(isHarnessInjected("no, that's the wrong file")).toBe(false);
+        expect(isHarnessInjected("wait, that deletes prod data")).toBe(false);
+        expect(isHarnessInjected("actually, use the other parser instead")).toBe(false);
+    });
+});
+
 describe("deriveCorrections", () => {
     const assistant = turn({
         id: { tb: "turn", id: "0a1b2c3d__seq_000003" },
@@ -127,6 +144,22 @@ describe("deriveCorrections", () => {
 
     test("a negation before any assistant turn emits nothing", () => {
         expect(deriveCorrections(bundle([pushback]))).toEqual([]);
+    });
+
+    test("harness-injected turn is skipped and does not consume the anchor", () => {
+        const notification = turn({
+            id: { tb: "turn", id: "0a1b2c3d__seq_000004c" },
+            seq: 4,
+            role: "user",
+            text_excerpt: '<subagent_notification> {"status":"completed"} no further action',
+        });
+        // assistant -> harness notification (transparent) -> real pushback:
+        // the notification yields no edge, and the pushback still anchors to the
+        // assistant (one correction, not two; notification excluded).
+        const edges = deriveCorrections(bundle([assistant, notification, pushback]));
+        expect(edges).toHaveLength(1);
+        expect(edges[0]?.toTurnKey).toBe("0a1b2c3d__seq_000005");
+        expect(edges[0]?.fromTurnKey).toBe("0a1b2c3d__seq_000003");
     });
 
     test("a text-bearing user turn resets the anchor even without a negation", () => {

--- a/apps/axctl/src/ingest/signals/core.ts
+++ b/apps/axctl/src/ingest/signals/core.ts
@@ -54,6 +54,24 @@ export function matchNegation(text: string): string | null {
     return null;
 }
 
+// Harness-injected user turns (subagent/task notifications, system reminders,
+// slash-command echoes, monitor/loop task prompts) appear in the transcript
+// with the user role but are NOT user-authored corrections. They routinely
+// contain negation words ("no", "wait", "stop") and were polluting the
+// user_correction signal (~13%+ of rows). Exclude them from correction
+// derivation so friction/correction insights stay clean.
+const HARNESS_INJECTED_PATTERNS: ReadonlyArray<RegExp> = [
+    /^<(?:subagent_notification|task-notification|system-reminder|command-name|command-message|command-args|local-command-stdout|local-command-stderr)\b/i,
+    /^##\s+Your task\b/i,
+    /^Monitor (?:the staging deploy|event:)/i,
+    /\bprod monitoring\b/i,
+] as const;
+
+export function isHarnessInjected(text: string): boolean {
+    const head = text.trimStart().slice(0, 400);
+    return HARNESS_INJECTED_PATTERNS.some((re) => re.test(head));
+}
+
 /**
  * Deterministic edge id for `skill_paired`. Pair is treated as undirected, so
  * the lexicographically-smaller skill key always sits in the `in` slot. A
@@ -312,6 +330,10 @@ export function deriveCorrections(bundle: SessionTurns): CorrectionEdge[] {
         // disturbing the anchor (this is what was masking interrupted-by-user
         // turns, which sit immediately after a tool_result user turn).
         if (!text) continue;
+        // Harness-injected user turns (notifications/reminders/task prompts) are
+        // not corrections; skip transparently so they neither count as a
+        // correction nor consume the anchor for a later genuine one.
+        if (isHarnessInjected(text)) continue;
         if (lastAssistantIdx === null) continue;
         const matched = matchNegation(text);
         if (matched) {


### PR DESCRIPTION
## Summary

`deriveCorrections` was mis-classifying **harness system messages** as `user_correction` friction. Subagent/task notifications, `<system-reminder>`s, slash-command echoes, and monitor/loop task prompts appear in the transcript with the user role and routinely contain negation words ("no", "wait", "stop") → they tripped `matchNegation` and got recorded as corrections. ~**13%+** of `user_correction` rows by obvious patterns alone, and *dominant* among recurring ones — polluting every downstream correction insight (friction view, correction themes, and the new telemetry-cost-on-friction lens from #439).

Fix: add an `isHarnessInjected()` guard. Harness-injected user turns are now skipped **transparently** — they don't count as a correction *and* don't consume the anchor for a later genuine correction.

Found via an embedding-clustering spike (evaluating an adaline-style "behaviors" gap): its top 7/8 clusters were all harness-notification noise, which exposed the derivation bug. The spike itself concluded embeddings aren't worth building yet — this was the real, cheaper win it surfaced.

## Test plan
- [x] `isHarnessInjected` unit tests (flags wrappers/task/monitor prompts; does NOT flag genuine corrections like "no, that's the wrong file").
- [x] `deriveCorrections` transparency test: a harness notification between assistant and a real pushback yields exactly one correction (the real one), anchored to the assistant.
- [x] `bun test apps/axctl/src/ingest/signals/core.test.ts` → 35 pass. Typecheck clean in changed files.

## Note
Existing polluted historical rows clear on the next signal re-derive (`ax ingest`); no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)