### PR TITLE
refactor(ingest): finish Parser Toolkit — shared textFromContent + classifyUserText (C)

### DIFF
--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -34,7 +34,17 @@ import {
 } from "./normalized/transcripts.ts";
 // Codex token counts arrive as numbers OR numeric strings - the toolkit's
 // integer probe (`intField`) is this parser's `numberField`.
-import { intField as numberField, isRecord, jsonText, parseJsonl, parseMaybeJson, stringField } from "./normalized/toolkit.ts";
+import {
+    intField as numberField,
+    isRecord,
+    jsonText,
+    parseJsonl,
+    parseMaybeJson,
+    RESPONSES_TEXT_TYPES,
+    stringField,
+    textFromContent,
+} from "./normalized/toolkit.ts";
+import { classifyUserText, FULL_CONTEXT_RULES } from "./normalized/message-kind.ts";
 import {
     applyCommandFields,
     makeToolCallWrite,
@@ -135,39 +145,10 @@ function codexMessageRecord(payload: Record<string, unknown>): Record<string, un
     return null;
 }
 
-function textFromCodexContent(content: unknown): string | null {
-    if (typeof content === "string") return content;
-    if (!Array.isArray(content)) return null;
-    const text = content
-        .filter(isRecord)
-        .filter((block) => {
-            const type = stringField(block, "type");
-            return type === "text" || type === "input_text" || type === "output_text";
-        })
-        .map((block) => stringField(block, "text"))
-        .filter((text): text is string => typeof text === "string" && text.length > 0)
-        .join("\n");
-    return text.length > 0 ? text : null;
-}
-
 function codexMessageKind(role: string, itemType: string | null, textExcerpt: string | null): string {
     if (role === "system" || role === "developer") return "system_or_developer";
     if (role === "user") {
-        if (textExcerpt?.startsWith("<command-name>")) {
-            return "control";
-        }
-        if (textExcerpt && (
-            textExcerpt.startsWith("# AGENTS.md instructions") ||
-            textExcerpt.startsWith("# CLAUDE.md") ||
-            textExcerpt.startsWith("<local-command-caveat>") ||
-            textExcerpt.startsWith("Base directory for this skill:") ||
-            textExcerpt.startsWith("Base directory for this plugin:") ||
-            textExcerpt.includes("<environment_context>") ||
-            textExcerpt.includes("<INSTRUCTIONS>")
-        )) {
-            return "context";
-        }
-        return "task";
+        return classifyUserText(textExcerpt, FULL_CONTEXT_RULES);
     }
     if (role === "assistant") return "assistant";
     if (itemType === "function_call") return "tool_call";
@@ -890,7 +871,10 @@ function createCodexExtractor(
                           ? (stringField(message ?? {}, "role") ?? "assistant")
                           : (itemType ?? "unknown");
 
-                const text = textFromCodexContent(message?.content);
+                const text = textFromContent(message?.content, {
+                    acceptedTypes: RESPONSES_TEXT_TYPES,
+                    emptyStringIsNull: false,
+                });
                 const textExcerpt = text === null ? null : text.slice(0, 500);
                 const kind = codexMessageKind(role, itemType, textExcerpt);
                 turns.push({

--- a/apps/axctl/src/ingest/normalized/message-kind.test.ts
+++ b/apps/axctl/src/ingest/normalized/message-kind.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+    classifyUserText,
+    FULL_CONTEXT_RULES,
+    PI_CONTEXT_RULES,
+    type UserTextRules,
+} from "./message-kind.ts";
+
+describe("classifyUserText", () => {
+    // The user-branch excerpt → control|context|task rules, shared across parsers.
+    // FULL_CONTEXT_RULES is claude≡codex (proven byte-identical pre-refactor);
+    // PI_CONTEXT_RULES is the narrower pi subset.
+    const cases: ReadonlyArray<{
+        excerpt: string | null;
+        full: "control" | "context" | "task";
+        pi: "control" | "context" | "task";
+        note: string;
+    }> = [
+        { excerpt: "<command-name>foo", full: "control", pi: "control", note: "control prefix shared" },
+        { excerpt: "# CLAUDE.md here", full: "context", pi: "context", note: "CLAUDE.md shared" },
+        {
+            excerpt: "# AGENTS.md instructions for /x",
+            full: "context",
+            pi: "context",
+            note: "AGENTS.md shared",
+        },
+        {
+            excerpt: "wraps <environment_context> inside",
+            full: "context",
+            pi: "context",
+            note: "environment_context include shared",
+        },
+        { excerpt: "<INSTRUCTIONS>do x", full: "context", pi: "context", note: "INSTRUCTIONS include shared" },
+        // The three prefixes pi DELIBERATELY omits (narrower table preserved):
+        {
+            excerpt: "<local-command-caveat>note",
+            full: "context",
+            pi: "task",
+            note: "local-command-caveat: full only",
+        },
+        {
+            excerpt: "Base directory for this skill: /s",
+            full: "context",
+            pi: "task",
+            note: "skill base dir: full only",
+        },
+        {
+            excerpt: "Base directory for this plugin: /p",
+            full: "context",
+            pi: "task",
+            note: "plugin base dir: full only",
+        },
+        { excerpt: "ordinary user request", full: "task", pi: "task", note: "plain task" },
+        { excerpt: null, full: "task", pi: "task", note: "null excerpt → task" },
+        { excerpt: "", full: "task", pi: "task", note: "empty excerpt → task" },
+    ];
+
+    for (const c of cases) {
+        test(`${c.note}: ${JSON.stringify(c.excerpt)}`, () => {
+            expect(classifyUserText(c.excerpt, FULL_CONTEXT_RULES)).toBe(c.full);
+            expect(classifyUserText(c.excerpt, PI_CONTEXT_RULES)).toBe(c.pi);
+        });
+    }
+
+    test("FULL_CONTEXT_RULES are the exact claude/codex context table", () => {
+        expect(FULL_CONTEXT_RULES.control).toEqual(["<command-name>"]);
+        expect(FULL_CONTEXT_RULES.contextStartsWith).toEqual([
+            "# AGENTS.md instructions",
+            "# CLAUDE.md",
+            "<local-command-caveat>",
+            "Base directory for this skill:",
+            "Base directory for this plugin:",
+        ]);
+        expect(FULL_CONTEXT_RULES.contextIncludes).toEqual(["<environment_context>", "<INSTRUCTIONS>"]);
+    });
+
+    test("PI_CONTEXT_RULES are a strict subset of the full startsWith table", () => {
+        expect(PI_CONTEXT_RULES.control).toEqual(["<command-name>"]);
+        expect(PI_CONTEXT_RULES.contextStartsWith).toEqual(["# AGENTS.md instructions", "# CLAUDE.md"]);
+        expect(PI_CONTEXT_RULES.contextIncludes).toEqual(["<environment_context>", "<INSTRUCTIONS>"]);
+        // every pi startsWith rule is also in the full table (subset, not divergence)
+        for (const prefix of PI_CONTEXT_RULES.contextStartsWith) {
+            expect(FULL_CONTEXT_RULES.contextStartsWith).toContain(prefix);
+        }
+    });
+
+    test("control takes precedence over context", () => {
+        const rules: UserTextRules = {
+            control: ["<command-name>"],
+            contextStartsWith: ["<command-name>"],
+            contextIncludes: [],
+        };
+        expect(classifyUserText("<command-name>x", rules)).toBe("control");
+    });
+});

--- a/apps/axctl/src/ingest/normalized/message-kind.ts
+++ b/apps/axctl/src/ingest/normalized/message-kind.ts
@@ -1,0 +1,79 @@
+/**
+ * User-turn message-kind classification - the ONE genuinely shared slice of
+ * the per-parser `messageKind` functions.
+ *
+ * Role dispatch (tool_result detection, system/developer handling, assistant,
+ * itemType fallthrough) is DELIBERATELY NOT folded here: it is genuinely
+ * divergent across the 5 parsers (claude = tool_result-from-blocks; codex =
+ * itemType function_call → tool_call; pi/opencode/cursor = role-string; claude
+ * does not special-case system/developer while the others do). Each parser
+ * keeps its own role-dispatch branch and calls `classifyUserText` ONLY for the
+ * user branch.
+ *
+ * "config is data": the rule tables are exported constants, not Effect/Schema.
+ */
+
+export interface UserTextRules {
+    /** Excerpt prefixes that mark a `control` turn (highest precedence). */
+    readonly control: readonly string[];
+    /** Excerpt prefixes that mark a `context` turn. */
+    readonly contextStartsWith: readonly string[];
+    /** Substrings anywhere in the excerpt that mark a `context` turn. */
+    readonly contextIncludes: readonly string[];
+}
+
+/**
+ * Classify a user-turn excerpt into control / context / task.
+ *
+ *   - startsWith any `control` prefix  → "control"
+ *   - else startsWith any `contextStartsWith` OR includes any `contextIncludes`
+ *     → "context"
+ *   - else "task"
+ *
+ * A null/empty excerpt is "task" (matches the pre-toolkit `textExcerpt?.` /
+ * `textExcerpt && (...)` guards exactly).
+ */
+export function classifyUserText(
+    excerpt: string | null,
+    rules: UserTextRules,
+): "control" | "context" | "task" {
+    if (excerpt === null) return "task";
+    if (rules.control.some((prefix) => excerpt.startsWith(prefix))) return "control";
+    if (
+        rules.contextStartsWith.some((prefix) => excerpt.startsWith(prefix)) ||
+        rules.contextIncludes.some((needle) => excerpt.includes(needle))
+    ) {
+        return "context";
+    }
+    return "task";
+}
+
+/**
+ * claude ≡ codex context table - proven byte-identical pre-refactor
+ * (transcripts.ts 213-227 ≡ codex.ts 156-169).
+ */
+export const FULL_CONTEXT_RULES: UserTextRules = {
+    control: ["<command-name>"],
+    contextStartsWith: [
+        "# AGENTS.md instructions",
+        "# CLAUDE.md",
+        "<local-command-caveat>",
+        "Base directory for this skill:",
+        "Base directory for this plugin:",
+    ],
+    contextIncludes: ["<environment_context>", "<INSTRUCTIONS>"],
+};
+
+/**
+ * pi context table - a STRICT SUBSET of {@link FULL_CONTEXT_RULES} that omits 3
+ * startsWith prefixes (`<local-command-caveat>`, the two `Base directory for
+ * this skill:/plugin:`). This narrower table is PRESERVED as-is - whether it is
+ * intentional or stale drift is an open domain-owner question (see PR notes);
+ * collapsing it to one shared table would change pi's classification behavior
+ * and is a deferred follow-up.
+ */
+export const PI_CONTEXT_RULES: UserTextRules = {
+    control: ["<command-name>"],
+    contextStartsWith: ["# AGENTS.md instructions", "# CLAUDE.md"],
+    contextIncludes: ["<environment_context>", "<INSTRUCTIONS>"],
+};

--- a/apps/axctl/src/ingest/normalized/toolkit.test.ts
+++ b/apps/axctl/src/ingest/normalized/toolkit.test.ts
@@ -3,6 +3,7 @@ import {
     booleanField,
     boundExcerpt,
     boundedExcerpt,
+    CLAUDE_TEXT_TYPES,
     coercedNumberField,
     intField,
     isRecord,
@@ -12,8 +13,10 @@ import {
     parseJsonRecord,
     parseJsonl,
     parseMaybeJson,
+    RESPONSES_TEXT_TYPES,
     stringArray,
     stringField,
+    textFromContent,
 } from "./toolkit.ts";
 
 describe("parser toolkit JSON access", () => {
@@ -129,5 +132,72 @@ describe("parser toolkit JSON access", () => {
         expect(stringArray(["a", 1, "b", null])).toEqual(["a", "b"]);
         expect(stringArray("a")).toBeNull();
         expect(stringArray(undefined)).toBeNull();
+    });
+});
+
+describe("textFromContent (collapsed 3 parser copies)", () => {
+    // claude preset: { acceptedTypes: CLAUDE_TEXT_TYPES, emptyStringIsNull: false }
+    const claude = (input: unknown) =>
+        textFromContent(input, { acceptedTypes: CLAUDE_TEXT_TYPES, emptyStringIsNull: false });
+    // codex preset: { acceptedTypes: RESPONSES_TEXT_TYPES, emptyStringIsNull: false }
+    const codex = (input: unknown) =>
+        textFromContent(input, { acceptedTypes: RESPONSES_TEXT_TYPES, emptyStringIsNull: false });
+    // pi preset: { acceptedTypes: RESPONSES_TEXT_TYPES, emptyStringIsNull: true }
+    const pi = (input: unknown) =>
+        textFromContent(input, { acceptedTypes: RESPONSES_TEXT_TYPES, emptyStringIsNull: true });
+
+    test("string passthrough - empty string preserved unless emptyStringIsNull", () => {
+        // claude/codex (emptyStringIsNull:false) keep the empty string bit-for-bit
+        expect(claude("")).toBe("");
+        expect(codex("")).toBe("");
+        // pi (emptyStringIsNull:true) collapses empty string to null - load-bearing drift trap
+        expect(pi("")).toBeNull();
+        // non-empty strings always pass through unchanged
+        expect(claude("hello")).toBe("hello");
+        expect(codex("hi")).toBe("hi");
+        expect(pi("hi")).toBe("hi");
+    });
+
+    test("array path joins accepted text blocks with newline, drops empties", () => {
+        expect(claude([{ type: "text", text: "a" }, { type: "text", text: "b" }])).toBe("a\nb");
+        expect(codex([{ type: "text", text: "a" }, { type: "text", text: "b" }])).toBe("a\nb");
+        expect(pi([{ type: "text", text: "a" }, { type: "text", text: "b" }])).toBe("a\nb");
+        // empty-string text blocks are filtered out → all-empty array yields null
+        expect(claude([{ type: "text", text: "" }])).toBeNull();
+        expect(codex([{ type: "text", text: "" }])).toBeNull();
+        expect(pi([{ type: "text", text: "" }])).toBeNull();
+    });
+
+    test("accepted-types matrix - claude accepts only 'text', responses accepts the 3 responses types", () => {
+        const responsesBlocks = [
+            { type: "input_text", text: "x" },
+            { type: "output_text", text: "y" },
+            { type: "text", text: "z" },
+        ];
+        // claude (CLAUDE_TEXT_TYPES) keeps only the plain 'text' block
+        expect(claude(responsesBlocks)).toBe("z");
+        // codex/pi (RESPONSES_TEXT_TYPES) keep all three, in order
+        expect(codex(responsesBlocks)).toBe("x\ny\nz");
+        expect(pi(responsesBlocks)).toBe("x\ny\nz");
+        // input_text alone: dropped by claude, kept by responses presets
+        expect(claude([{ type: "input_text", text: "only" }])).toBeNull();
+        expect(codex([{ type: "input_text", text: "only" }])).toBe("only");
+        expect(pi([{ type: "input_text", text: "only" }])).toBe("only");
+    });
+
+    test("unknown block types and non-record members are dropped", () => {
+        expect(claude([{ type: "thinking", thinking: "hidden" }])).toBeNull();
+        expect(codex([{ type: "tool_use", id: "t1" }])).toBeNull();
+        expect(pi([{ type: "toolCall", name: "x" }])).toBeNull();
+        // non-record array members are filtered by isRecord
+        expect(claude(["bare-string", 42, { type: "text", text: "kept" }])).toBe("kept");
+    });
+
+    test("non-array, non-string input is null", () => {
+        expect(claude(null)).toBeNull();
+        expect(codex(undefined)).toBeNull();
+        expect(pi(42)).toBeNull();
+        expect(claude({ type: "text", text: "x" })).toBeNull(); // bare record, not array
+        expect(claude([])).toBeNull();
     });
 });

--- a/apps/axctl/src/ingest/normalized/toolkit.ts
+++ b/apps/axctl/src/ingest/normalized/toolkit.ts
@@ -163,3 +163,50 @@ export function boundExcerpt(input: unknown, max = 1200): string | null {
 export function stringArray(input: unknown): readonly string[] | null {
     return Array.isArray(input) ? input.filter((x): x is string => typeof x === "string") : null;
 }
+
+/** Claude content blocks only flatten the plain `text` block type. */
+export const CLAUDE_TEXT_TYPES: ReadonlySet<string> = new Set(["text"]);
+
+/** OpenAI Responses-shaped harnesses (codex, pi) flatten the three text
+ *  variants. */
+export const RESPONSES_TEXT_TYPES: ReadonlySet<string> = new Set([
+    "text",
+    "input_text",
+    "output_text",
+]);
+
+/**
+ * Flatten a message `content` value to its joined text, or null.
+ *
+ * Collapses the three pre-toolkit copies (transcripts `textFromContent`, codex
+ * `textFromCodexContent`, pi `textFromPiContent`) - each kept its own preset:
+ *   - claude: `{ acceptedTypes: CLAUDE_TEXT_TYPES, emptyStringIsNull: false }`
+ *   - codex:  `{ acceptedTypes: RESPONSES_TEXT_TYPES, emptyStringIsNull: false }`
+ *   - pi:     `{ acceptedTypes: RESPONSES_TEXT_TYPES, emptyStringIsNull: true }`
+ *
+ * Behavior (preserved bit-for-bit):
+ *   - string input → the string, EXCEPT when `emptyStringIsNull` and it is
+ *     empty, then null (pi-only). Non-empty strings always pass through.
+ *   - array input → keep record members whose `type` is in `acceptedTypes`,
+ *     read their `text` field, drop empties, join with `\n`; null when empty.
+ *   - anything else → null.
+ */
+export function textFromContent(
+    input: unknown,
+    opts: { acceptedTypes: ReadonlySet<string>; emptyStringIsNull?: boolean },
+): string | null {
+    if (typeof input === "string") {
+        return opts.emptyStringIsNull && input.length === 0 ? null : input;
+    }
+    if (!Array.isArray(input)) return null;
+    const text = input
+        .filter(isRecord)
+        .filter((block) => {
+            const type = stringField(block, "type");
+            return type !== null && opts.acceptedTypes.has(type);
+        })
+        .map((block) => stringField(block, "text"))
+        .filter((value): value is string => typeof value === "string" && value.length > 0)
+        .join("\n");
+    return text.length > 0 ? text : null;
+}

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -24,8 +24,11 @@ import {
     numberField,
     parseJsonl,
     parseMaybeJson,
+    RESPONSES_TEXT_TYPES,
     stringField,
+    textFromContent,
 } from "./normalized/toolkit.ts";
+import { classifyUserText, PI_CONTEXT_RULES } from "./normalized/message-kind.ts";
 import {
     applyCommandFields,
     makeToolCallWrite,
@@ -184,20 +187,7 @@ function applyToolResult(call: MutableToolCallWrite, result: ToolResultFields): 
 }
 
 export function textFromPiContent(content: unknown): string | null {
-    if (typeof content === "string") return content.length > 0 ? content : null;
-    if (!Array.isArray(content)) return null;
-
-    const text = content
-        .filter(isRecord)
-        .filter((block) => {
-            const type = stringField(block, "type");
-            return type === "text" || type === "input_text" || type === "output_text";
-        })
-        .map((block) => stringField(block, "text"))
-        .filter((value): value is string => typeof value === "string" && value.length > 0)
-        .join("\n");
-
-    return text.length > 0 ? text : null;
+    return textFromContent(content, { acceptedTypes: RESPONSES_TEXT_TYPES, emptyStringIsNull: true });
 }
 
 function hasPiToolUse(content: unknown): boolean {
@@ -210,16 +200,7 @@ function piMessageKind(role: string, textExcerpt: string | null): string {
     if (role === "toolResult" || role === "tool_result") return "tool_result";
     if (role === "assistant") return "assistant";
     if (role === "user") {
-        if (textExcerpt?.startsWith("<command-name>")) return "control";
-        if (textExcerpt && (
-            textExcerpt.startsWith("# AGENTS.md instructions") ||
-            textExcerpt.startsWith("# CLAUDE.md") ||
-            textExcerpt.includes("<environment_context>") ||
-            textExcerpt.includes("<INSTRUCTIONS>")
-        )) {
-            return "context";
-        }
-        return "task";
+        return classifyUserText(textExcerpt, PI_CONTEXT_RULES);
     }
     return role;
 }

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -47,7 +47,16 @@ import {
     type NormalizedTranscriptBatch,
     type NormalizedTurnWrite,
 } from "./normalized/transcripts.ts";
-import { isRecord, jsonText, numberField, parseJsonl, stringField } from "./normalized/toolkit.ts";
+import {
+    CLAUDE_TEXT_TYPES,
+    isRecord,
+    jsonText,
+    numberField,
+    parseJsonl,
+    stringField,
+    textFromContent,
+} from "./normalized/toolkit.ts";
+import { classifyUserText, FULL_CONTEXT_RULES } from "./normalized/message-kind.ts";
 import {
     buildTurnTokenUsageStatement,
     surrealOptionFloat,
@@ -192,39 +201,13 @@ function asContentBlocks(input: unknown): Record<string, unknown>[] {
     return Array.isArray(input) ? input.filter(isRecord) : [];
 }
 
-function textFromContent(input: unknown): string | null {
-    if (typeof input === "string") {
-        return input;
-    }
-    const text = asContentBlocks(input)
-        .filter((block) => stringField(block, "type") === "text")
-        .map((block) => stringField(block, "text"))
-        .filter((text): text is string => typeof text === "string" && text.length > 0)
-        .join("\n");
-    return text.length > 0 ? text : null;
-}
-
 function messageKind(role: string, content: unknown, textExcerpt: string | null): string {
     const blocks = asContentBlocks(content);
     if (blocks.length > 0 && blocks.every((block) => stringField(block, "type") === "tool_result")) {
         return "tool_result";
     }
     if (role === "user") {
-        if (textExcerpt?.startsWith("<command-name>")) {
-            return "control";
-        }
-        if (textExcerpt && (
-            textExcerpt.startsWith("# AGENTS.md instructions") ||
-            textExcerpt.startsWith("# CLAUDE.md") ||
-            textExcerpt.startsWith("<local-command-caveat>") ||
-            textExcerpt.startsWith("Base directory for this skill:") ||
-            textExcerpt.startsWith("Base directory for this plugin:") ||
-            textExcerpt.includes("<environment_context>") ||
-            textExcerpt.includes("<INSTRUCTIONS>")
-        )) {
-            return "context";
-        }
-        return "task";
+        return classifyUserText(textExcerpt, FULL_CONTEXT_RULES);
     }
     if (role === "assistant") return "assistant";
     return role;
@@ -947,7 +930,10 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
             const messageContent = message?.content;
             const content = asContentBlocks(messageContent);
 
-            const text = textFromContent(messageContent);
+            const text = textFromContent(messageContent, {
+                acceptedTypes: CLAUDE_TEXT_TYPES,
+                emptyStringIsNull: false,
+            });
             const textExcerpt = text === null ? null : text.slice(0, 500);
             let hasToolUse = false;
             let hasError = false;


### PR DESCRIPTION
Work-package **C** of the arch-deepening goal. Finishes the Parser Toolkit by collapsing the duplicated content-flatteners and user-text classifiers across the claude / codex / pi parsers. Characterization-first: existing parser tests stay green = no drift.

## What landed

**1. `textFromContent` (toolkit.ts)** — one flattener replaces 3 copies (transcripts `textFromContent`, codex `textFromCodexContent`, pi `textFromPiContent`):
```ts
textFromContent(input, { acceptedTypes: ReadonlySet<string>; emptyStringIsNull?: boolean })
CLAUDE_TEXT_TYPES = new Set(['text'])
RESPONSES_TEXT_TYPES = new Set(['text','input_text','output_text'])
```
Each parser binds its exact preset, preserving behavior bit-for-bit:
- claude `{ CLAUDE_TEXT_TYPES, emptyStringIsNull: false }`
- codex `{ RESPONSES_TEXT_TYPES, emptyStringIsNull: false }`
- pi `{ RESPONSES_TEXT_TYPES, emptyStringIsNull: true }` (empty-string→null preserved)

`textFromPiContent` stays exported as a thin delegation (keeps its existing direct unit test as a characterization guard).

**2. `classifyUserText` (new message-kind.ts)** — the one genuinely-shared slice of the per-parser `messageKind` user branch:
```ts
classifyUserText(excerpt: string|null, rules: UserTextRules): "control"|"context"|"task"
FULL_CONTEXT_RULES  // claude ≡ codex (byte-identical pre-refactor)
PI_CONTEXT_RULES    // pi's narrower subset
```
Role dispatch (tool_result detection, system/developer, assistant, codex `function_call`→tool_call) stays per-parser — genuinely divergent, deliberately NOT folded.

**3. `outputText` extraction DROPPED.** The 3 copies diverge on an uncaptured null axis (`jsonText(null)`→`'null'` for claude/codex vs null short-circuit for opencode); a merged helper would silently flip null output. Left untouched in all parsers.

Not touched: `opencode.ts`, `cursor.ts`, `compaction.ts`.

## Open question — pi's narrower context table (decision)

Pi's user-context table omits 3 startsWith prefixes that claude+codex carry (`<local-command-caveat>`, `Base directory for this skill:`, `Base directory for this plugin:`). Per the spec's safe default, **pi's current narrower behavior is PRESERVED as-is** in `PI_CONTEXT_RULES` (zero classification change). Collapsing to one shared table is a **deferred follow-up** that needs a domain-owner decision on whether the divergence is intentional or stale drift — `message-kind.test.ts` pins both tables and the divergence explicitly so the decision is documented, not silent.

## Tests / gate

- Characterization-first: table-driven specs added to `toolkit.test.ts` (accepted-types matrix × string passthrough × empty→null(pi) × unknown-block drop) and new `message-kind.test.ts` (proves claude≡codex share FULL_CONTEXT_RULES, pi uses the subset, control>context precedence).
- **No drift:** existing `transcripts.test.ts` / `codex.test.ts` / `pi.test.ts` (which assert `text` + `message_kind` end-to-end on fixtures) stay green.
- Repo-wide `bun test`: **4357 pass / 0 fail**.
- `bunx tsc -p apps/axctl/tsconfig.json --noEmit`: exit 0, no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)