### PR TITLE
refactor(cost): single-source 14-day cost window via clampInt + COST_DEFAULT_WINDOW_DAYS (A2)

### DIFF
--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -9,6 +9,7 @@ import { Command, Flag } from "effect/unstable/cli";
 import { prettyPrint } from "@ax/lib/json";
 import { printNextLinks } from "../next-format.ts";
 import {
+    COST_DEFAULT_WINDOW_DAYS,
     fetchCostModels,
     fetchCostSessions,
     fetchCostSplit,
@@ -69,7 +70,7 @@ const cmdCostModels = (input: {
 const costModelsCommand = Command.make(
     "models",
     {
-        days: Flag.integer("days").pipe(Flag.withDefault(14)),
+        days: Flag.integer("days").pipe(Flag.withDefault(COST_DEFAULT_WINDOW_DAYS)),
         json: jsonFlag,
     },
     ({ days, json }) => {
@@ -136,7 +137,7 @@ const cmdCostSessions = (input: {
 const costSessionsCommand = Command.make(
     "sessions",
     {
-        days: Flag.integer("days").pipe(Flag.withDefault(14)),
+        days: Flag.integer("days").pipe(Flag.withDefault(COST_DEFAULT_WINDOW_DAYS)),
         model: Flag.string("model").pipe(Flag.optional),
         limit: positiveLimit(20),
         json: jsonFlag,
@@ -224,7 +225,7 @@ const cmdCostSplit = (input: {
 const costSplitCommand = Command.make(
     "split",
     {
-        days: Flag.integer("days").pipe(Flag.withDefault(14)),
+        days: Flag.integer("days").pipe(Flag.withDefault(COST_DEFAULT_WINDOW_DAYS)),
         json: jsonFlag,
     },
     ({ days, json }) => {

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -57,7 +57,7 @@ import {
     buildCostModelsNext,
     buildCostSplitNext,
 } from "../nav/next-links.ts";
-import { fetchCostModels, fetchCostSplit } from "../queries/cost-analytics.ts";
+import { COST_DEFAULT_WINDOW_DAYS, fetchCostModels, fetchCostSplit } from "../queries/cost-analytics.ts";
 import { fetchRoutability } from "../queries/routability.ts";
 import { fetchDispatches, fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
 import { loadEffectiveRoutingTable } from "../queries/routing-table-io.ts";
@@ -517,7 +517,7 @@ const costModelsTool: AxMcpTool = {
             .describe("Window in days (default 14)."),
     },
     run: async (args, rt) => {
-        const days = typeof args.days === "number" ? args.days : 14;
+        const days = typeof args.days === "number" ? args.days : COST_DEFAULT_WINDOW_DAYS;
         const result = await rt.runPromise(fetchCostModels({ sinceDays: days }));
         return { ...result, next: buildCostModelsNext(result) };
     },
@@ -536,7 +536,7 @@ const costSplitTool: AxMcpTool = {
             .describe("Window in days (default 14)."),
     },
     run: async (args, rt) => {
-        const days = typeof args.days === "number" ? args.days : 14;
+        const days = typeof args.days === "number" ? args.days : COST_DEFAULT_WINDOW_DAYS;
         const result = await rt.runPromise(fetchCostSplit({ sinceDays: days }));
         return { ...result, next: buildCostSplitNext(result) };
     },
@@ -591,7 +591,7 @@ const dispatchesTool: AxMcpTool = {
             .describe("When true, return only routing-optimisation candidates with est savings."),
     },
     run: async (args, rt) => {
-        const days = typeof args.days === "number" ? args.days : 14;
+        const days = typeof args.days === "number" ? args.days : COST_DEFAULT_WINDOW_DAYS;
         const candidates = args.candidates === true;
         if (candidates) {
             // Match against the live routing table (same file the hook and the

--- a/apps/axctl/src/queries/cost-analytics.ts
+++ b/apps/axctl/src/queries/cost-analytics.ts
@@ -16,6 +16,23 @@ import { SurrealClient } from "@ax/lib/db";
 import { surrealLiteral } from "@ax/lib/json";
 
 // ---------------------------------------------------------------------------
+// Shared constants + SQL-boundary helpers
+// ---------------------------------------------------------------------------
+
+/** Default look-back window for all `ax cost *` subcommands (models / sessions / split). */
+export const COST_DEFAULT_WINDOW_DAYS = 14;
+
+/**
+ * SQL-interpolation boundary guard for day-window values.
+ *
+ * Distinct from transport-level defaults: this guard lives at the SQL
+ * interpolation site to prevent negative/fractional/NaN values reaching
+ * SurrealDB. It is intentionally SEPARATE from clampInt / Flag.withDefault so
+ * that neither the CLI default nor the MCP default bypass the injection guard.
+ */
+const sqlWindowDays = (n: number): number => Math.max(1, Math.trunc(n));
+
+// ---------------------------------------------------------------------------
 // cost models
 // ---------------------------------------------------------------------------
 
@@ -48,7 +65,7 @@ SELECT
     math::sum(cache_creation_input_tokens) AS cache_create_tokens,
     math::sum(estimated_cost_usd) AS cost_usd
 FROM session_token_usage
-WHERE ts > time::now() - ${Math.max(1, Math.trunc(sinceDays))}d
+WHERE ts > time::now() - ${sqlWindowDays(sinceDays)}d
 GROUP BY model
 ORDER BY cost_usd DESC;
 `;
@@ -98,7 +115,7 @@ export interface CostSessionsResult {
 
 const COST_SESSIONS_SQL = (sinceDays: number, limit: number, modelFilter: string | null) => {
     const whereFragments = [
-        `ts > time::now() - ${Math.max(1, Math.trunc(sinceDays))}d`,
+        `ts > time::now() - ${sqlWindowDays(sinceDays)}d`,
         "estimated_cost_usd != NONE",
     ];
     if (modelFilter) {
@@ -187,7 +204,7 @@ SELECT
     math::sum(cache_creation_input_tokens) AS cache_create_tokens,
     math::sum(estimated_cost_usd) AS cost_usd
 FROM session_token_usage
-WHERE ts > time::now() - ${Math.max(1, Math.trunc(sinceDays))}d
+WHERE ts > time::now() - ${sqlWindowDays(sinceDays)}d
 GROUP BY source, model
 ORDER BY cost_usd DESC;
 `;

--- a/packages/lib/src/shared/pagination.test.ts
+++ b/packages/lib/src/shared/pagination.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+    clampInt,
     clampLimit,
     clampOffset,
     clampPagination,
+    type ClampIntConfig,
     type PaginationConfig,
 } from "./pagination.ts";
 
@@ -35,6 +37,40 @@ describe("clampLimit", () => {
         expect(clampLimit(undefined, sessionsCfg)).toBe(200);
         expect(clampLimit(9999, sessionsCfg)).toBe(500);
     });
+});
+
+describe("clampInt", () => {
+    const cfg: ClampIntConfig = { default: 14, min: 1 };
+    const cfgWithMax: ClampIntConfig = { default: 14, min: 1, max: 30 };
+    const cfgNoMin: ClampIntConfig = { default: 14 };
+
+    // --- default ---
+    test("undefined → default", () => expect(clampInt(undefined, cfg)).toBe(14));
+
+    // --- min ---
+    test("zero (below min) → default", () => expect(clampInt(0, cfg)).toBe(14));
+    test("negative (below min) → default", () => expect(clampInt(-3, cfg)).toBe(14));
+    test("exactly at min passes through", () => expect(clampInt(1, cfg)).toBe(1));
+    test("above min passes through", () => expect(clampInt(7, cfg)).toBe(7));
+
+    // --- max ---
+    test("over max clamps to max", () => expect(clampInt(90, cfgWithMax)).toBe(30));
+    test("exactly at max passes through", () => expect(clampInt(30, cfgWithMax)).toBe(30));
+    test("between min and max passes through", () => expect(clampInt(14, cfgWithMax)).toBe(14));
+
+    // --- non-finite ---
+    test("NaN → default", () => expect(clampInt(NaN, cfg)).toBe(14));
+    test("Infinity → default", () => expect(clampInt(Infinity, cfg)).toBe(14));
+    test("-Infinity → default", () => expect(clampInt(-Infinity, cfg)).toBe(14));
+
+    // --- fractional truncation ---
+    test("fractional truncates toward zero", () => expect(clampInt(7.9, cfg)).toBe(7));
+    test("fractional below min after trunc → default", () => expect(clampInt(0.9, cfg)).toBe(14));
+
+    // --- no min configured ---
+    test("no min: any finite value passes", () => expect(clampInt(0, cfgNoMin)).toBe(0));
+    test("no min: negative passes", () => expect(clampInt(-5, cfgNoMin)).toBe(-5));
+    test("no min: undefined → default", () => expect(clampInt(undefined, cfgNoMin)).toBe(14));
 });
 
 describe("clampPagination", () => {

--- a/packages/lib/src/shared/pagination.ts
+++ b/packages/lib/src/shared/pagination.ts
@@ -53,3 +53,44 @@ export const clampPagination = (
     offset: clampOffset(params.offset),
     limit: clampLimit(params.limit, config),
 });
+
+// ---------------------------------------------------------------------------
+// clampInt - general-purpose integer clamper (clampLimit minus the optional-max)
+// ---------------------------------------------------------------------------
+
+/**
+ * Config for clampInt.
+ *
+ * - `default`: returned when the value is absent, non-finite, or below `min`.
+ * - `min`:     inclusive lower bound; values below it return `default` (optional - no lower check when absent).
+ * - `max`:     inclusive upper cap (optional - no cap when absent).
+ */
+export interface ClampIntConfig {
+    readonly default: number;
+    readonly min?: number;
+    readonly max?: number;
+}
+
+/**
+ * General-purpose integer clamp.
+ *
+ * Truncates toward zero (like clampLimit/clampOffset), substitutes `default`
+ * for undefined, non-finite, or below-minimum values, and optionally caps at
+ * `max`. Drop-in generalisation of clampLimit for non-pagination uses (day
+ * windows, custom floors/ceilings).
+ *
+ * Rules:
+ *  - `undefined` → `config.default`
+ *  - NaN / ±Infinity → `config.default`
+ *  - fractional → truncated toward zero, then tested
+ *  - value < `config.min` → `config.default` (only when `min` is given)
+ *  - value > `config.max` → `config.max` (only when `max` is given)
+ *  - else → truncated value
+ */
+export const clampInt = (value: number | undefined, config: ClampIntConfig): number => {
+    const n = Math.trunc(value ?? config.default);
+    if (!Number.isFinite(n)) return config.default;
+    if (config.min !== undefined && n < config.min) return config.default;
+    if (config.max !== undefined) return Math.min(config.max, n);
+    return n;
+};


### PR DESCRIPTION
## Summary

- **`packages/lib/src/shared/pagination.ts`**: Added `clampInt(value, ClampIntConfig)` — a generalisation of `clampLimit` without the optional-max. Handles `undefined`/non-finite/below-min → `default`, fractional truncation toward zero, optional upper cap. `ClampIntConfig` exported as an interface.
- **`packages/lib/src/shared/pagination.test.ts`**: 16 new `clampInt` unit tests covering default/min/max/non-finite/fractional truncation/no-min boundary cases. All 39 pagination tests green.
- **`apps/axctl/src/queries/cost-analytics.ts`**: Exported `COST_DEFAULT_WINDOW_DAYS = 14`; added local `sqlWindowDays` SQL-injection boundary guard (`Math.max(1, Math.trunc(n))`); applied it to the 3 true day-window SQL builders (models/sessions/split). The LIMIT clamp at line 137 (`Math.min(Math.max(1,Math.trunc(limit)),500)`) is untouched.
- **`apps/axctl/src/cli/commands/ax-cost.ts`**: `Flag.withDefault(COST_DEFAULT_WINDOW_DAYS)` on the 3 cost subcommands (models, sessions, split). Routability stays at 30.
- **`apps/axctl/src/mcp/tools.ts`**: `COST_DEFAULT_WINDOW_DAYS` replaces inline `14` in `cost_models`, `cost_split`, and `dispatches` handlers. `cost_routability` stays at 30.

## Design decisions

- `14` was duplicated 5× (CLI 3× + MCP 2×); all transports now reference the single exported constant.
- `sqlWindowDays` stays a **separate** injection-boundary guard — it is intentionally NOT folded into the transport default call so the SQL boundary is never bypassed.
- `clampInt` lives in `pagination.ts` (generalises the existing `clampLimit`). No new `window.ts` module created.
- Touches only cost-analytics.ts day-window builders. `dispatch/thinking/hook-latency/context-budget/feedback-cases` are untouched — their clamps are LIMIT/tail/windowMinutes, not day windows.

## Test plan

- [x] `bun test packages/lib/src/shared/pagination.test.ts` — 39 pass, 0 fail
- [x] `bunx tsc -p packages/lib/tsconfig.json --noEmit` — no errors
- [x] `bunx tsc -p apps/axctl/tsconfig.json --noEmit` — no errors (warnings are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)