### PR TITLE
refactor(otel): unify signal decode/normalize/write behind a SIGNALS registry (D)

### DIFF
--- a/apps/axctl/src/dashboard/contract/otel.ts
+++ b/apps/axctl/src/dashboard/contract/otel.ts
@@ -18,12 +18,11 @@ import { HttpServerRequest } from "effect/unstable/http";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { AxApi } from "@ax/lib/shared/api-contract";
 import { OtelWriter, OtelWriterLive } from "../../otel/writer.ts";
-import { decodeLogsPayload, decodeMetricsPayload, decodeTracePayload } from "../../otel/decode.ts";
-import { normalizeLogs, normalizeMetrics, normalizeTrace } from "../../otel/normalize.ts";
+import type { Signal } from "../../otel/signal.ts";
+import { SIGNALS } from "../../otel/signals.ts";
 
 // ------------------------------------------------------------------ types
 
-type Signal = "metrics" | "traces" | "logs";
 const ACK = { partialSuccess: {} } as const;
 
 // ------------------------------------------------------------------ core
@@ -53,21 +52,13 @@ export const handleOtlp = (
         if (json === null) return ACK;
 
         const writer = yield* OtelWriter;
+        const spec = SIGNALS[signal];
 
-        if (signal === "logs") {
-            const payload = yield* decodeLogsPayload(json).pipe(Effect.orElseSucceed(() => null));
-            if (payload) yield* writer.writeLogs(normalizeLogs(payload));
-        } else if (signal === "metrics") {
-            const payload = yield* decodeMetricsPayload(json).pipe(
-                Effect.orElseSucceed(() => null),
-            );
-            if (payload) yield* writer.writeMetrics(normalizeMetrics(payload));
-        } else {
-            const payload = yield* decodeTracePayload(json).pipe(
-                Effect.orElseSucceed(() => null),
-            );
-            if (payload) yield* writer.writeSpans(normalizeTrace(payload));
-        }
+        // Fail-open at the dispatch SEAM: the typed `OtelDecodeError` is swallowed
+        // to null HERE (never inside decode), so all three signals swallow in
+        // exactly one place. A decoded payload normalizes + writes per the spec.
+        const payload = yield* spec.decode(json).pipe(Effect.orElseSucceed(() => null));
+        if (payload !== null) yield* spec.write(writer)(spec.normalize(payload));
 
         return ACK;
     }).pipe(Effect.provide(OtelWriterLive));

--- a/apps/axctl/src/otel/decode.ts
+++ b/apps/axctl/src/otel/decode.ts
@@ -1,24 +1,9 @@
-import { Effect, Schema } from "effect";
 import { MetricsPayload, TracePayload, LogsPayload } from "./otlp-schema.ts";
+import { decodeSignal, OtelDecodeError } from "./signal.ts";
 
-export class OtelDecodeError extends Schema.TaggedErrorClass<OtelDecodeError>(
-    "OtelDecodeError",
-)("OtelDecodeError", {
-    signal: Schema.String,
-    message: Schema.String,
-}) {}
+/** Re-exported so existing importers keep `./decode.ts` as the source. */
+export { OtelDecodeError };
 
-export const decodeMetricsPayload = (json: unknown) =>
-    Schema.decodeUnknownEffect(MetricsPayload)(json).pipe(
-        Effect.mapError((e) => new OtelDecodeError({ signal: "metrics", message: String(e) })),
-    );
-
-export const decodeTracePayload = (json: unknown) =>
-    Schema.decodeUnknownEffect(TracePayload)(json).pipe(
-        Effect.mapError((e) => new OtelDecodeError({ signal: "traces", message: String(e) })),
-    );
-
-export const decodeLogsPayload = (json: unknown) =>
-    Schema.decodeUnknownEffect(LogsPayload)(json).pipe(
-        Effect.mapError((e) => new OtelDecodeError({ signal: "logs", message: String(e) })),
-    );
+export const decodeMetricsPayload = decodeSignal(MetricsPayload, "metrics");
+export const decodeTracePayload = decodeSignal(TracePayload, "traces");
+export const decodeLogsPayload = decodeSignal(LogsPayload, "logs");

--- a/apps/axctl/src/otel/normalize.ts
+++ b/apps/axctl/src/otel/normalize.ts
@@ -1,25 +1,18 @@
 import { attrMap, nanoToDate, type MetricsPayload, type TracePayload, type LogsPayload } from "./otlp-schema.ts";
 import type { OtelMetricPointRow, OtelSpanRow, OtelLogEventRow } from "./rows.ts";
-
-/** Map an OTLP service.name to ax's harness label. */
-const harnessOf = (serviceName: string | number | boolean | null | undefined): string => {
-    if (serviceName === "claude-code" || serviceName === "claude_code") return "claude";
-    if (serviceName === "codex_cli_rs") return "codex";
-    if (serviceName === "opencode") return "opencode";
-    if (typeof serviceName === "string" && serviceName.startsWith("pi")) return "pi";
-    if (typeof serviceName === "string" && serviceName.startsWith("codex")) return "codex";
-    return "unknown";
-};
+import { walkResources } from "./signal.ts";
 
 const str = (v: string | number | boolean | null | undefined): string | null =>
     typeof v === "string" ? v : v == null ? null : String(v);
 
-export const normalizeMetrics = (payload: MetricsPayload): OtelMetricPointRow[] => {
-    const out: OtelMetricPointRow[] = [];
-    for (const rm of payload.resourceMetrics) {
-        const res = attrMap(rm.resource?.attributes);
-        const harness = harnessOf(res.get("service.name"));
-        for (const sm of rm.scopeMetrics) {
+export const normalizeMetrics = (payload: MetricsPayload): OtelMetricPointRow[] =>
+    walkResources(
+        payload.resourceMetrics,
+        (rm) => rm.resource,
+        (rm) => rm.scopeMetrics,
+        // Leaf stays per-signal: metric-level name/unit closure + sum/gauge 1→N fan-out.
+        ({ res, harness }, sm) => {
+            const out: OtelMetricPointRow[] = [];
             for (const metric of sm.metrics) {
                 const points = metric.sum?.dataPoints ?? metric.gauge?.dataPoints ?? [];
                 for (const dp of points) {
@@ -39,22 +32,21 @@ export const normalizeMetrics = (payload: MetricsPayload): OtelMetricPointRow[] 
                     });
                 }
             }
-        }
-    }
-    return out;
-};
+            return out;
+        },
+    );
 
-export const normalizeTrace = (payload: TracePayload): OtelSpanRow[] => {
-    const out: OtelSpanRow[] = [];
-    for (const rs of payload.resourceSpans) {
-        const res = attrMap(rs.resource?.attributes);
-        const harness = harnessOf(res.get("service.name"));
-        for (const ss of rs.scopeSpans) {
-            for (const span of ss.spans) {
+export const normalizeTrace = (payload: TracePayload): OtelSpanRow[] =>
+    walkResources(
+        payload.resourceSpans,
+        (rs) => rs.resource,
+        (rs) => rs.scopeSpans,
+        ({ res, harness }, ss) =>
+            ss.spans.map((span): OtelSpanRow => {
                 const a = attrMap(span.attributes);
                 const started = nanoToDate(span.startTimeUnixNano);
                 const ended = nanoToDate(span.endTimeUnixNano);
-                out.push({
+                return {
                     harness,
                     name: span.name,
                     trace_id: span.traceId,
@@ -66,12 +58,9 @@ export const normalizeTrace = (payload: TracePayload): OtelSpanRow[] => {
                     duration_ms: ended.getTime() - started.getTime(),
                     attrs: a.size ? JSON.stringify(Object.fromEntries(a.entries())) : null,
                     observed_at: started,
-                });
-            }
-        }
-    }
-    return out;
-};
+                };
+            }),
+    );
 
 const LOG_ALLOWLIST: Record<string, ReadonlySet<string>> = {
     codex: new Set([
@@ -97,13 +86,16 @@ const eventTime = (
     return nanoToDate(observedNano ?? nano);
 };
 
-export const normalizeLogs = (payload: LogsPayload): OtelLogEventRow[] => {
-    const out: OtelLogEventRow[] = [];
-    for (const rl of payload.resourceLogs) {
-        const res = attrMap(rl.resource?.attributes);
-        const harness = harnessOf(res.get("service.name") ?? null);
-        const allow = LOG_ALLOWLIST[harness];
-        for (const sl of rl.scopeLogs) {
+export const normalizeLogs = (payload: LogsPayload): OtelLogEventRow[] =>
+    walkResources(
+        payload.resourceLogs,
+        (rl) => rl.resource,
+        (rl) => rl.scopeLogs,
+        // Leaf stays per-signal: allowlist filter drops non-signal records, so the
+        // emitted array (the one writer indexes at render time) is post-filter.
+        ({ res, harness }, sl) => {
+            const allow = LOG_ALLOWLIST[harness];
+            const out: OtelLogEventRow[] = [];
             for (const rec of sl.logRecords) {
                 const a = attrMap(rec.attributes);
                 const eventName = a.get("event.name");
@@ -125,7 +117,6 @@ export const normalizeLogs = (payload: LogsPayload): OtelLogEventRow[] => {
                     observed_at: eventTime(a, rec.observedTimeUnixNano, rec.timeUnixNano),
                 });
             }
-        }
-    }
-    return out;
-};
+            return out;
+        },
+    );

--- a/apps/axctl/src/otel/signal.test.ts
+++ b/apps/axctl/src/otel/signal.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Exit, Layer } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import {
+    harnessOf,
+    harnessFromResource,
+    walkResources,
+    decodeSignal,
+} from "./signal.ts";
+import { MetricsPayload } from "./otlp-schema.ts";
+import { OtelWriter, OtelWriterLive, metricStmt, spanStmt, logStmt } from "./writer.ts";
+import { metricPointKey, spanKey, logEventKey, type OtelMetricPointRow, type OtelSpanRow, type OtelLogEventRow } from "./rows.ts";
+import { normalizeLogs } from "./normalize.ts";
+import { SIGNALS } from "./signals.ts";
+import { handleOtlp } from "../dashboard/contract/otel.ts";
+
+// ------------------------------------------------------------------ stub DB
+const captured: string[] = [];
+const stubDb = Layer.succeed(SurrealClient, {
+    query: <T>(sql: string) => { captured.push(sql); return Effect.succeed([[]] as unknown as T); },
+} as never);
+
+const writerEnv = Layer.mergeAll(OtelWriterLive, stubDb);
+const runWrite = async (eff: Effect.Effect<void, unknown, OtelWriter | SurrealClient>) => {
+    captured.length = 0;
+    await Effect.runPromise(eff.pipe(Effect.provide(writerEnv)) as Effect.Effect<void>);
+    return captured.join("\n");
+};
+
+const metricRow = (o: Partial<OtelMetricPointRow> = {}): OtelMetricPointRow => ({
+    harness: "claude", metric: "claude_code.cost.usage", value: 0.12, unit: "USD",
+    session_id: "s1", model: "opus", skill_name: null, agent_name: null,
+    attrs: null, observed_at: new Date("2026-06-15T00:00:00Z"), ...o,
+});
+const spanRow = (o: Partial<OtelSpanRow> = {}): OtelSpanRow => ({
+    harness: "codex", name: "session_loop", trace_id: "aa", span_id: "bb",
+    parent_span_id: null, session_id: "cdx1",
+    started_at: new Date("2026-06-15T00:00:00Z"), ended_at: new Date("2026-06-15T00:00:01Z"),
+    duration_ms: 1000, attrs: null, observed_at: new Date("2026-06-15T00:00:00Z"), ...o,
+});
+const logRow = (o: Partial<OtelLogEventRow> = {}): OtelLogEventRow => ({
+    harness: "codex", event_name: "codex.sse_event", session_id: "c1", model: "gpt-5.5",
+    input_tokens: 9994, output_tokens: 0, reasoning_tokens: 0, cached_tokens: 0, tool_tokens: 9994,
+    duration_ms: null, status_code: null, attrs: null, observed_at: new Date("2026-06-15T00:00:00Z"), ...o,
+});
+
+// ============================================================ shared seams
+
+describe("harness lift", () => {
+    test("harnessOf maps service.name → harness label", () => {
+        expect(harnessOf("claude-code")).toBe("claude");
+        expect(harnessOf("claude_code")).toBe("claude");
+        expect(harnessOf("codex_cli_rs")).toBe("codex");
+        expect(harnessOf("codex_exec")).toBe("codex");
+        expect(harnessOf("opencode")).toBe("opencode");
+        expect(harnessOf("pi-agent")).toBe("pi");
+        expect(harnessOf(undefined)).toBe("unknown");
+        expect(harnessOf(null)).toBe("unknown");
+    });
+
+    test("harnessFromResource lifts attrs + harness (null/undefined service.name identical)", () => {
+        const a = harnessFromResource({ attributes: [{ key: "service.name", value: { stringValue: "codex_cli_rs" } }] });
+        expect(a.harness).toBe("codex");
+        expect(a.res.get("service.name")).toBe("codex_cli_rs");
+        // missing service.name → unknown (the logs `?? null` pre-unify was a no-op)
+        expect(harnessFromResource(undefined).harness).toBe("unknown");
+        expect(harnessFromResource({ attributes: [] }).harness).toBe("unknown");
+    });
+});
+
+describe("walkResources (synthetic 1-field spec)", () => {
+    test("lifts harness per resource and concatenates scope rows in order", () => {
+        type Res = { resource?: { attributes?: { key: string; value: { stringValue: string } }[] }; scopes: string[] };
+        const resources: Res[] = [
+            { resource: { attributes: [{ key: "service.name", value: { stringValue: "claude-code" } }] }, scopes: ["a", "b"] },
+            { resource: { attributes: [{ key: "service.name", value: { stringValue: "opencode" } }] }, scopes: ["c"] },
+        ];
+        const rows = walkResources(
+            resources,
+            (r) => r.resource,
+            (r) => r.scopes,
+            (ctx, scope) => [`${ctx.harness}:${scope}`],
+        );
+        expect(rows).toEqual(["claude:a", "claude:b", "opencode:c"]);
+    });
+});
+
+describe("decodeSignal", () => {
+    test("good payload decodes", async () => {
+        const out = await Effect.runPromise(decodeSignal(MetricsPayload, "metrics")({ resourceMetrics: [] }));
+        expect(out.resourceMetrics).toEqual([]);
+    });
+    test("bad payload fails with typed OtelDecodeError (NOT swallowed here)", async () => {
+        const exit = await Effect.runPromiseExit(decodeSignal(MetricsPayload, "metrics")({ nope: true }));
+        expect(Exit.isFailure(exit)).toBe(true);
+        const err = exit._tag === "Failure" ? exit.cause : null;
+        // the failure carries the signal label
+        expect(JSON.stringify(err)).toContain("metrics");
+        expect(JSON.stringify(err)).toContain("OtelDecodeError");
+    });
+});
+
+// ====================================================== column raw-vs-NONE
+
+describe("writer column SQL - NONE vs raw is load-bearing", () => {
+    test("metrics: value renders RAW, null option columns render NONE", async () => {
+        const sql = await runWrite(Effect.gen(function* () {
+            const w = yield* OtelWriter; yield* w.writeMetrics([metricRow({ model: null, skill_name: null, agent_name: null })]);
+        }));
+        expect(sql).toContain("value = 0.12");      // RAW number, never quoted/NONE
+        expect(sql).toContain("model = NONE");
+        expect(sql).toContain("skill_name = NONE");
+        expect(sql).toContain("agent_name = NONE");
+        expect(sql).toContain("unit = \"USD\"");
+    });
+
+    test("span: duration_ms renders RAW, null parent_span_id renders NONE", async () => {
+        const sql = await runWrite(Effect.gen(function* () {
+            const w = yield* OtelWriter; yield* w.writeSpans([spanRow({ parent_span_id: null })]);
+        }));
+        expect(sql).toContain("duration_ms = 1000");
+        expect(sql).toContain("parent_span_id = NONE");
+    });
+
+    test("logs: token columns optNum - 0 stays 0, null becomes NONE", async () => {
+        const sql = await runWrite(Effect.gen(function* () {
+            const w = yield* OtelWriter; yield* w.writeLogs([logRow({ input_tokens: 9994, output_tokens: 0, duration_ms: null, status_code: null })]);
+        }));
+        expect(sql).toContain("input_tokens = 9994");
+        expect(sql).toContain("output_tokens = 0");      // 0 is NOT NONE
+        expect(sql).toContain("duration_ms = NONE");
+        expect(sql).toContain("status_code = NONE");
+    });
+
+    test("attrs is a pre-encoded option<string> - quoted once, never re-encoded; null → NONE", async () => {
+        const sqlWith = await runWrite(Effect.gen(function* () {
+            const w = yield* OtelWriter; yield* w.writeMetrics([metricRow({ attrs: "{\"a\":1}" })]);
+        }));
+        // surrealOptionString JSON-quotes the already-JSON string exactly once
+        expect(sqlWith).toContain("attrs = \"{\\\"a\\\":1}\"");
+        const sqlNull = await runWrite(Effect.gen(function* () {
+            const w = yield* OtelWriter; yield* w.writeMetrics([metricRow({ attrs: null })]);
+        }));
+        expect(sqlNull).toContain("attrs = NONE");
+    });
+});
+
+// ============================================ log record-id index stability
+
+describe("log record-id index - computed at RENDER over post-allowlist array", () => {
+    test("dropped records before kept ones do NOT shift kept indices (no collision)", () => {
+        const sse = { key: "event.name", value: { stringValue: "codex.sse_event" } } as const;
+        // [drop, keep, drop, keep] - original positions 1 and 3 are kept
+        const payload = {
+            resourceLogs: [{
+                resource: { attributes: [{ key: "service.name", value: { stringValue: "codex_cli_rs" } }] },
+                scopeLogs: [{ logRecords: [
+                    { attributes: [{ key: "event.name", value: { stringValue: "codex.websocket_event" } }], timeUnixNano: "1718409600000000000" },
+                    { attributes: [sse, { key: "conversation.id", value: { stringValue: "z" } }], timeUnixNano: "1718409600000000000" },
+                    { attributes: [{ key: "event.name", value: { stringValue: "codex.websocket_event" } }], timeUnixNano: "1718409600000000000" },
+                    { attributes: [sse, { key: "conversation.id", value: { stringValue: "z" } }], timeUnixNano: "1718409600000000000" },
+                ] }],
+            }],
+        };
+        const rows = normalizeLogs(payload as never);
+        expect(rows).toHaveLength(2);
+        // Both kept rows are content-identical → index is the ONLY discriminator.
+        const k0 = logEventKey(rows[0]!, 0);
+        const k1 = logEventKey(rows[1]!, 1);
+        expect(k0).not.toBe(k1);
+        expect(k0.endsWith("|0")).toBe(true);
+        expect(k1.endsWith("|1")).toBe(true);
+        // render-time indices are contiguous (0,1) NOT original positions (1,3)
+        expect(k1.endsWith("|3")).toBe(false);
+    });
+});
+
+// ==================================== record-key uniqueness (verify, dont freeze)
+
+describe("metric/span record-key uniqueness - characterized, see PR for gaps", () => {
+    test("metricPointKey discriminates harness/metric/session/model/skill/ts", () => {
+        const b = metricRow();
+        expect(metricPointKey(b)).not.toBe(metricPointKey(metricRow({ harness: "codex" })));
+        expect(metricPointKey(b)).not.toBe(metricPointKey(metricRow({ metric: "x" })));
+        expect(metricPointKey(b)).not.toBe(metricPointKey(metricRow({ session_id: "s2" })));
+        expect(metricPointKey(b)).not.toBe(metricPointKey(metricRow({ model: "sonnet" })));
+        expect(metricPointKey(b)).not.toBe(metricPointKey(metricRow({ skill_name: "tdd" })));
+        expect(metricPointKey(b)).not.toBe(metricPointKey(metricRow({ observed_at: new Date("2026-06-15T00:00:01Z") })));
+    });
+
+    test("KNOWN GAP: metricPointKey omits agent_name though it is persisted (pinned to prove no drift)", () => {
+        // Two points identical except agent_name collide to ONE record id. This is a
+        // PRE-EXISTING gap (rows.ts:36) - pinned here, filed as a follow-up, not changed.
+        expect(metricPointKey(metricRow({ agent_name: "a" }))).toBe(metricPointKey(metricRow({ agent_name: "b" })));
+        // value/unit are not part of the key (the measurement, not identity)
+        expect(metricPointKey(metricRow({ value: 1 }))).toBe(metricPointKey(metricRow({ value: 2 })));
+        expect(metricPointKey(metricRow({ unit: "tok" }))).toBe(metricPointKey(metricRow({ unit: "USD" })));
+    });
+
+    test("spanKey is span_id alone (trace_id omitted) - adequate: span_id is globally unique", () => {
+        expect(spanKey(spanRow({ span_id: "x" }))).toBe("x");
+        // same span_id, different trace_id → same key (documents trace_id omission)
+        expect(spanKey(spanRow({ span_id: "x", trace_id: "t1" }))).toBe(spanKey(spanRow({ span_id: "x", trace_id: "t2" })));
+    });
+});
+
+// ============================================ SIGNALS registry / column gate
+
+describe("SIGNALS registry", () => {
+    const samples: Record<string, OtelMetricPointRow | OtelSpanRow | OtelLogEventRow> = {
+        metrics: metricRow(), traces: spanRow(), logs: logRow(),
+    };
+    // Parse the `col = ` LHS tokens out of a rendered UPSERT (samples use attrs=null
+    // so no value contains a comma → split is safe).
+    const renderedCols = (sql: string): string[] =>
+        sql.slice(sql.indexOf(" SET ") + 5).replace(/;$/, "").split(", ").map((c) => c.split(" = ")[0]!.trim());
+
+    test("dispatch keys cover exactly the 3 signals", () => {
+        expect(Object.keys(SIGNALS).sort()).toEqual(["logs", "metrics", "traces"]);
+    });
+
+    for (const signal of ["metrics", "traces", "logs"] as const) {
+        const spec = SIGNALS[signal];
+
+        test(`${signal}: declared columns ⊇ Row schema fields (HARD column gate)`, () => {
+            const schemaFields = Object.keys(spec.rowSchema.fields);
+            const colSet = new Set(spec.columns);
+            for (const f of schemaFields) expect(colSet.has(f)).toBe(true);
+        });
+
+        test(`${signal}: declared columns match what stmt actually renders (no drift)`, () => {
+            const cols = renderedCols(spec.stmt(samples[signal] as never, 0));
+            expect(cols.sort()).toEqual([...spec.columns].sort());
+        });
+
+        test(`${signal}: spec.stmt is the writer stmt builder`, () => {
+            const expected = { metrics: metricStmt, traces: spanStmt, logs: logStmt }[signal];
+            expect(spec.stmt).toBe(expected);
+        });
+    }
+});
+
+// =================================================== malformed-gzip fail-open
+
+describe("malformed-gzip path (gunzip is OUTSIDE the JSON-parse fail-open try)", () => {
+    test("gzip-flagged non-gzip body does not write; characterizes current behavior", async () => {
+        captured.length = 0;
+        const notGzip = new TextEncoder().encode("not gzip at all");
+        const buf = notGzip.buffer.slice(notGzip.byteOffset, notGzip.byteOffset + notGzip.byteLength) as ArrayBuffer;
+        const exit = await Effect.runPromiseExit(
+            handleOtlp("metrics", buf, "gzip").pipe(Effect.provide(stubDb)),
+        );
+        // Either way it must never write a malformed body.
+        expect(captured).toHaveLength(0);
+        // CHARACTERIZATION: gunzip throws OUTSIDE the fail-open try, so it surfaces
+        // as a defect (NOT the ACK fail-open the JSON/decode paths give). Pinned so
+        // the registry refactor cannot silently change it; gap documented in the PR.
+        expect(Exit.isFailure(exit)).toBe(true);
+    });
+});

--- a/apps/axctl/src/otel/signal.ts
+++ b/apps/axctl/src/otel/signal.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared OTLP signal seams (D - signal-flow unify).
+ *
+ * Extracts ONLY the genuinely-deep cross-signal machinery that was triplicated:
+ *   - `harnessFromResource` + `harnessOf`  - the resource→harness lift (3×)
+ *   - `walkResources`                       - the resource→scope iteration (3×),
+ *     abstracting resource+scope+harness ONLY. The leaf (scope → rows) stays
+ *     per-signal: metrics owns its metric→dataPoints fan-out, logs owns its
+ *     allowlist filter - there is deliberately NO universal leaf walker.
+ *   - `decodeSignal`                        - Schema decode → typed
+ *     `OtelDecodeError` (the error stays in the TYPED channel; fail-open
+ *     `orElseSucceed(null)` is applied at the handleOtlp dispatch seam, NEVER
+ *     here - fail-open is byte-sensitive).
+ *   - `writeRows`                           - the `rows.length ? exec : void`
+ *     render-and-write body (3×). `stmt` receives `(row, i)` so the LOG record
+ *     id index is computed at RENDER time over the post-allowlist-filter
+ *     emitted array (metric/span stmts ignore `i`).
+ *
+ * The flat, greppable per-column UPSERT SQL is intentionally NOT abstracted into
+ * a Column DSL (kept in writer.ts).
+ */
+import { Effect, Schema } from "effect";
+import type { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { executeStatements } from "@ax/lib/shared/surreal";
+import { attrMap, type KeyValue } from "./otlp-schema.ts";
+
+export type Signal = "metrics" | "traces" | "logs";
+
+/** A flat attr lookup, as produced by `attrMap`. */
+export type AttrMap = Map<string, string | number | boolean | null>;
+
+/** The per-resource context shared by every signal's leaf: lifted attrs + harness. */
+export interface ResourceCtx {
+    readonly res: AttrMap;
+    readonly harness: string;
+}
+
+/** Map an OTLP `service.name` to ax's harness label. Repeated 3× pre-unify. */
+export const harnessOf = (
+    serviceName: string | number | boolean | null | undefined,
+): string => {
+    if (serviceName === "claude-code" || serviceName === "claude_code") return "claude";
+    if (serviceName === "codex_cli_rs") return "codex";
+    if (serviceName === "opencode") return "opencode";
+    if (typeof serviceName === "string" && serviceName.startsWith("pi")) return "pi";
+    if (typeof serviceName === "string" && serviceName.startsWith("codex")) return "codex";
+    return "unknown";
+};
+
+interface WithAttributes {
+    // `| undefined` matches `Schema.optional` (the resource attr lists are decoded
+    // via Schema.optional, which includes undefined under exactOptionalPropertyTypes).
+    readonly attributes?: readonly KeyValue[] | undefined;
+}
+
+/** Lift a resource's attribute list into `{ res, harness }`. */
+export const harnessFromResource = (
+    resource: WithAttributes | undefined,
+): ResourceCtx => {
+    const res = attrMap(resource?.attributes);
+    return { res, harness: harnessOf(res.get("service.name")) };
+};
+
+/**
+ * Walk OTLP resource → scope, lifting each resource to `{ res, harness }`, and
+ * concatenating each scope's emitted rows. The leaf `emit` stays per-signal.
+ */
+export const walkResources = <R, S, Row>(
+    resources: readonly R[],
+    getResource: (r: R) => WithAttributes | undefined,
+    getScopes: (r: R) => readonly S[],
+    emit: (ctx: ResourceCtx, scope: S) => readonly Row[],
+): Row[] => {
+    const out: Row[] = [];
+    for (const r of resources) {
+        const ctx = harnessFromResource(getResource(r));
+        for (const scope of getScopes(r)) {
+            for (const row of emit(ctx, scope)) out.push(row);
+        }
+    }
+    return out;
+};
+
+/**
+ * The typed-error decode seam. Keeps the failure in the TYPED `OtelDecodeError`
+ * channel - fail-open is NOT applied here (it is applied once, at the dispatch
+ * seam, so every signal swallows in exactly one place).
+ */
+export const decodeSignal = <S extends Schema.Top>(schema: S, signal: string) =>
+(json: unknown): Effect.Effect<S["Type"], OtelDecodeError, S["DecodingServices"]> =>
+    Schema.decodeUnknownEffect(schema)(json).pipe(
+        Effect.mapError((e) => new OtelDecodeError({ signal, message: String(e) })),
+    );
+
+/**
+ * Render rows to UPSERT statements and execute them; no statement for an empty
+ * batch. `stmt` is called as `stmt(row, i)` over the post-filter emitted array,
+ * so a per-payload `index` (logs) stays stable and collision-free.
+ */
+export const writeRows = <Row>(
+    rows: readonly Row[],
+    stmt: (row: Row, i: number) => string,
+): Effect.Effect<void, DbError, SurrealClient> =>
+    rows.length === 0 ? Effect.void : executeStatements(rows.map((r, i) => stmt(r, i)));
+
+/** Typed decode failure. Lives here so `decodeSignal` has no import cycle. */
+export class OtelDecodeError extends Schema.TaggedErrorClass<OtelDecodeError>(
+    "OtelDecodeError",
+)("OtelDecodeError", {
+    signal: Schema.String,
+    message: Schema.String,
+}) {}

--- a/apps/axctl/src/otel/signals.ts
+++ b/apps/axctl/src/otel/signals.ts
@@ -1,0 +1,86 @@
+/**
+ * The OTLP signal registry - the thin dispatch table that kills the 3-way `if`
+ * in `handleOtlp`. Each entry bundles a signal's decode + normalize + writer
+ * binding + (for the meta-test) its statement renderer, declared column set, and
+ * Row schema. The per-signal normalizers/leaves are NOT merged (no universal
+ * leaf walker); only the resource→scope→harness machinery is shared (signal.ts).
+ */
+import type { Effect } from "effect";
+import type { Schema } from "effect";
+import type { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import type { OtelDecodeError, Signal } from "./signal.ts";
+import { decodeLogsPayload, decodeMetricsPayload, decodeTracePayload } from "./decode.ts";
+import { normalizeLogs, normalizeMetrics, normalizeTrace } from "./normalize.ts";
+import {
+    OtelMetricPointRow,
+    OtelSpanRow,
+    OtelLogEventRow,
+} from "./rows.ts";
+import {
+    type OtelWriterShape,
+    metricStmt,
+    spanStmt,
+    logStmt,
+    METRIC_COLUMNS,
+    SPAN_COLUMNS,
+    LOG_COLUMNS,
+} from "./writer.ts";
+
+/**
+ * A fully-typed signal spec. `P` = decoded payload, `Row` = normalized row. The
+ * registry erases to `OtelSignalSpec<any, any>` at the dispatch seam (handleOtlp
+ * only needs `json → Effect<void>`); `defineSignal` keeps each spec typed at its
+ * definition site.
+ */
+export interface OtelSignalSpec<P, Row> {
+    readonly signal: Signal;
+    readonly table: string;
+    readonly decode: (json: unknown) => Effect.Effect<P, OtelDecodeError>;
+    readonly normalize: (payload: P) => Row[];
+    readonly write: (writer: OtelWriterShape) => (rows: readonly Row[]) => Effect.Effect<void, DbError, SurrealClient>;
+    /** Statement renderer (flat SQL, kept in writer.ts) - used by the column gate. */
+    readonly stmt: (row: Row, i: number) => string;
+    /** Declared SET column names - gated `⊇` the Row schema fields. */
+    readonly columns: readonly string[];
+    /** Row schema, for the column-set meta-test. */
+    readonly rowSchema: Schema.Struct<Record<string, Schema.Top>>;
+}
+
+/** Identity helper: keeps each spec typed at the definition site. */
+export const defineSignal = <P, Row>(spec: OtelSignalSpec<P, Row>): OtelSignalSpec<P, Row> => spec;
+
+const metrics = defineSignal({
+    signal: "metrics",
+    table: "otel_metric_point",
+    decode: decodeMetricsPayload,
+    normalize: normalizeMetrics,
+    write: (w) => w.writeMetrics,
+    stmt: metricStmt,
+    columns: METRIC_COLUMNS,
+    rowSchema: OtelMetricPointRow as unknown as Schema.Struct<Record<string, Schema.Top>>,
+});
+
+const traces = defineSignal({
+    signal: "traces",
+    table: "otel_span",
+    decode: decodeTracePayload,
+    normalize: normalizeTrace,
+    write: (w) => w.writeSpans,
+    stmt: spanStmt,
+    columns: SPAN_COLUMNS,
+    rowSchema: OtelSpanRow as unknown as Schema.Struct<Record<string, Schema.Top>>,
+});
+
+const logs = defineSignal({
+    signal: "logs",
+    table: "otel_log_event",
+    decode: decodeLogsPayload,
+    normalize: normalizeLogs,
+    write: (w) => w.writeLogs,
+    stmt: logStmt,
+    columns: LOG_COLUMNS,
+    rowSchema: OtelLogEventRow as unknown as Schema.Struct<Record<string, Schema.Top>>,
+});
+
+export const SIGNALS: Record<Signal, OtelSignalSpec<any, any>> = { metrics, traces, logs };

--- a/apps/axctl/src/otel/writer.ts
+++ b/apps/axctl/src/otel/writer.ts
@@ -1,8 +1,8 @@
-import { Context, Effect, Layer } from "effect";
+import { Context, Layer } from "effect";
+import type { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import {
-    executeStatements,
     recordRef,
     surrealString,
     surrealDate,
@@ -16,6 +16,7 @@ import {
     type OtelSpanRow,
     type OtelLogEventRow,
 } from "./rows.ts";
+import { writeRows } from "./signal.ts";
 
 export interface OtelWriterShape {
     readonly writeMetrics: (rows: readonly OtelMetricPointRow[]) => Effect.Effect<void, DbError, SurrealClient>;
@@ -25,42 +26,62 @@ export interface OtelWriterShape {
 
 export class OtelWriter extends Context.Service<OtelWriter, OtelWriterShape>()("ax/otel/OtelWriter") {}
 
+/** null → SurrealQL `NONE` for the log token/cost columns (declared `option<number>`). */
 const optNum = (n: number | null): string => n === null ? "NONE" : String(n);
 
-const metricStmt = (r: OtelMetricPointRow): string => {
-    return (
-        `UPSERT ${recordRef("otel_metric_point", metricPointKey(r))} SET ` +
-        `harness = ${surrealString(r.harness)}, ` +
-        `metric = ${surrealString(r.metric)}, ` +
-        `value = ${r.value}, ` +
-        `unit = ${surrealOptionString(r.unit)}, ` +
-        `session_id = ${surrealOptionString(r.session_id)}, ` +
-        `model = ${surrealOptionString(r.model)}, ` +
-        `skill_name = ${surrealOptionString(r.skill_name)}, ` +
-        `agent_name = ${surrealOptionString(r.agent_name)}, ` +
-        `attrs = ${surrealOptionString(r.attrs)}, ` +
-        `observed_at = ${surrealDate(r.observed_at)};`
-    );
-};
+// ---------------------------------------------------------------- statements
+// Flat, greppable per-column UPSERT SQL - deliberately NOT a Column DSL. The
+// column-name arrays below are asserted (signal.test.ts) to be a superset of
+// each Row schema's fields AND to match what the stmt actually renders.
+// NONE-vs-raw is load-bearing: metric `value` + span `duration_ms` render RAW
+// (non-null Schema.Number); log token/cost columns render NONE via `optNum`.
 
-const spanStmt = (r: OtelSpanRow): string => {
-    return (
-        `UPSERT ${recordRef("otel_span", spanKey(r))} SET ` +
-        `harness = ${surrealString(r.harness)}, ` +
-        `name = ${surrealString(r.name)}, ` +
-        `trace_id = ${surrealString(r.trace_id)}, ` +
-        `span_id = ${surrealString(r.span_id)}, ` +
-        `parent_span_id = ${surrealOptionString(r.parent_span_id)}, ` +
-        `session_id = ${surrealOptionString(r.session_id)}, ` +
-        `started_at = ${surrealDate(r.started_at)}, ` +
-        `ended_at = ${surrealDate(r.ended_at)}, ` +
-        `duration_ms = ${r.duration_ms}, ` +
-        `attrs = ${surrealOptionString(r.attrs)}, ` +
-        `observed_at = ${surrealDate(r.observed_at)};`
-    );
-};
+export const METRIC_COLUMNS = [
+    "harness", "metric", "value", "unit", "session_id", "model",
+    "skill_name", "agent_name", "attrs", "observed_at",
+] as const;
 
-const logStmt = (r: OtelLogEventRow, i: number): string =>
+export const metricStmt = (r: OtelMetricPointRow, _i: number): string =>
+    `UPSERT ${recordRef("otel_metric_point", metricPointKey(r))} SET ` +
+    `harness = ${surrealString(r.harness)}, ` +
+    `metric = ${surrealString(r.metric)}, ` +
+    `value = ${r.value}, ` +
+    `unit = ${surrealOptionString(r.unit)}, ` +
+    `session_id = ${surrealOptionString(r.session_id)}, ` +
+    `model = ${surrealOptionString(r.model)}, ` +
+    `skill_name = ${surrealOptionString(r.skill_name)}, ` +
+    `agent_name = ${surrealOptionString(r.agent_name)}, ` +
+    `attrs = ${surrealOptionString(r.attrs)}, ` +
+    `observed_at = ${surrealDate(r.observed_at)};`;
+
+export const SPAN_COLUMNS = [
+    "harness", "name", "trace_id", "span_id", "parent_span_id", "session_id",
+    "started_at", "ended_at", "duration_ms", "attrs", "observed_at",
+] as const;
+
+export const spanStmt = (r: OtelSpanRow, _i: number): string =>
+    `UPSERT ${recordRef("otel_span", spanKey(r))} SET ` +
+    `harness = ${surrealString(r.harness)}, ` +
+    `name = ${surrealString(r.name)}, ` +
+    `trace_id = ${surrealString(r.trace_id)}, ` +
+    `span_id = ${surrealString(r.span_id)}, ` +
+    `parent_span_id = ${surrealOptionString(r.parent_span_id)}, ` +
+    `session_id = ${surrealOptionString(r.session_id)}, ` +
+    `started_at = ${surrealDate(r.started_at)}, ` +
+    `ended_at = ${surrealDate(r.ended_at)}, ` +
+    `duration_ms = ${r.duration_ms}, ` +
+    `attrs = ${surrealOptionString(r.attrs)}, ` +
+    `observed_at = ${surrealDate(r.observed_at)};`;
+
+export const LOG_COLUMNS = [
+    "harness", "event_name", "session_id", "model", "input_tokens",
+    "output_tokens", "reasoning_tokens", "cached_tokens", "tool_tokens",
+    "duration_ms", "status_code", "attrs", "observed_at",
+] as const;
+
+// `i` is the post-allowlist-filter render index - folded into the record id so
+// distinct same-name events at the same second do not collide.
+export const logStmt = (r: OtelLogEventRow, i: number): string =>
     `UPSERT ${recordRef("otel_log_event", logEventKey(r, i))} SET ` +
     `harness = ${surrealString(r.harness)}, ` +
     `event_name = ${surrealString(r.event_name)}, ` +
@@ -77,10 +98,7 @@ const logStmt = (r: OtelLogEventRow, i: number): string =>
     `observed_at = ${surrealDate(r.observed_at)};`;
 
 export const OtelWriterLive: Layer.Layer<OtelWriter> = Layer.succeed(OtelWriter, {
-    writeMetrics: (rows) =>
-        rows.length === 0 ? Effect.void : executeStatements(rows.map(metricStmt)),
-    writeSpans: (rows) =>
-        rows.length === 0 ? Effect.void : executeStatements(rows.map(spanStmt)),
-    writeLogs: (rows) =>
-        rows.length === 0 ? Effect.void : executeStatements(rows.map((r, i) => logStmt(r, i))),
+    writeMetrics: (rows) => writeRows(rows, metricStmt),
+    writeSpans: (rows) => writeRows(rows, spanStmt),
+    writeLogs: (rows) => writeRows(rows, logStmt),
 });


### PR DESCRIPTION
Work-package **D — OTLP signal-flow unify** from the arch-deepening goal package. Extracts only the genuinely-deep shared OTLP seams + a thin dispatch table to kill the 3-way `if`, keeping per-signal normalizers/leaves and flat greppable SQL.

## What changed

**New**
- `otel/signal.ts` — the shared seams: `harnessOf`/`harnessFromResource` (resource→harness lift, was 3×), `walkResources` (abstracts resource+scope+harness **only** — no universal leaf walker), `decodeSignal` (Schema decode → typed `OtelDecodeError`), `writeRows` (the `rows.length ? exec : void` body, `stmt(row, i)`). `OtelDecodeError` now lives here, re-exported by `decode.ts`.
- `otel/signals.ts` — `OtelSignalSpec` + `defineSignal` identity helper + the `SIGNALS` registry (`metrics`/`traces`/`logs`).
- `otel/signal.test.ts` — characterization-first traps + seam unit tests + the column gate.

**Refactored (named exports kept as thin delegations → zero test churn)**
- `decode.ts` → `decodeSignal(schema, signal)` per signal.
- `normalize.ts` → `walkResources` + per-signal leaves preserved bit-for-bit (metrics keeps its metric→dataPoints fan-out; logs keeps its allowlist filter).
- `writer.ts` → `writeRows` + flat per-column stmt builders + exported column arrays. `OtelWriter` stays a `Context.Service` with `OtelWriterLive` + the stub-DB test layer.
- `dashboard/contract/otel.ts` → `handleOtlp` dispatches through `SIGNALS`.

## Fail-open centralization (byte-sensitive)

The typed `OtelDecodeError` stays in the **error channel** through `decode`; `orElseSucceed(null)` is applied at the **single dispatch seam** in `handleOtlp`, so all three signals swallow in exactly one byte-identical place (was three near-identical `Effect.orElseSucceed(() => null)` branches). The JSON-parse try/catch and the raw-handler `orElseSucceed(ACK)` wrapper are unchanged.

**gunzip gap (characterized, not changed):** `Bun.gunzipSync` runs **outside** the JSON-parse try (otel.ts), so a malformed gzip body surfaces as an Effect **defect**, NOT the ACK fail-open the JSON/decode paths give. This is pre-existing. Added an explicit `malformed-gzip` test that pins current behavior (`Exit.isFailure` + never writes) so the registry refactor cannot silently change it. **Follow-up candidate:** move the gunzip inside the fail-open scope so a bad `content-encoding: gzip` body also acks instead of dying — deliberately out of scope for this behavior-preserving refactor.

## Record-key uniqueness — verified, not silently frozen

Confirmed the keys before abstracting and **preserved them exactly** (changing a key changes persisted record ids → re-ingest duplication, so out of scope for a behavior-preserving refactor). Two pre-existing gaps are pinned as characterization tests + filed here:
- `metricPointKey` omits `agent_name` though it is persisted → two points identical except `agent_name` collide to one record id (rows.ts).
- `spanKey` is `span_id` alone (`trace_id` omitted) → adequate in practice (span_id is globally unique), kept.

**Decision: fix separately, not here.** Both are latent and require a record-id migration story; folding them into a byte-sensitive registry refactor would mix concerns and risk the re-ingest path.

## Column-set gate — hard-gate, not AST derivation

Picked the simpler option per the spec. Each spec carries a declared column-name array (greppable, adjacent to the stmt builder). `signal.test.ts` asserts, per signal: (a) `columns ⊇ Row schema fields` (the required hard gate — catches an unwritten field), and (b) `columns == what stmt actually renders` (keeps the declared list honest vs the flat SQL). Per-column NONE-vs-raw is pinned by SQL-text tests: metric `value` + span `duration_ms` render RAW; log token/cost columns render `NONE` via `optNum`; `attrs` is quoted once (not re-encoded).

## Gate

- otel tests: **61 pass / 0 fail** (37 pre-existing unchanged + 24 new; `rows.test.ts` + `writer.test.ts` + `normalize.test.ts` + `otel.test.ts` kept as regression guard).
- full axctl suite: **3220 pass / 0 fail**.
- `bunx tsc -p apps/axctl/tsconfig.json --noEmit`: **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)