### PR TITLE
refactor(cli): pure renderTable column-builder (E)

### DIFF
--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -19,6 +19,8 @@ import {
     buildCostSplitNext,
 } from "../../nav/next-links.ts";
 import { integer, pct, usd } from "../render.ts";
+import { renderTable } from "../table.js";
+import type { Column, FooterLine } from "../table.js";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionValue, positiveLimit } from "./shared.ts";
 
@@ -45,24 +47,37 @@ const cmdCostModels = (input: {
 
         printNextLinks(buildCostModelsNext(result));
 
-        const colWidths = {
-            model: Math.max(20, ...result.rows.map((r) => r.model.length)),
+        type ModelRow = {
+            model: string;
+            sessions: string;
+            prompt: string;
+            completion: string;
+            cache_read: string;
+            cache_create: string;
+            cost: string;
         };
 
-        console.log(
-            `${"model".padEnd(colWidths.model)}  ${"sessions".padStart(8)}  ${"prompt".padStart(14)}  ${"completion".padStart(14)}  ${"cache_read".padStart(12)}  ${"cache_create".padStart(12)}  ${"cost".padStart(10)}`,
-        );
-        for (const row of result.rows) {
-            console.log(
-                `${row.model.padEnd(colWidths.model)}  ` +
-                `${integer(row.sessions).padStart(8)}  ` +
-                `${integer(row.prompt_tokens).padStart(14)}  ` +
-                `${integer(row.completion_tokens).padStart(14)}  ` +
-                `${integer(row.cache_read_tokens).padStart(12)}  ` +
-                `${integer(row.cache_create_tokens).padStart(12)}  ` +
-                `${usd(row.cost_usd).padStart(10)}`,
-            );
-        }
+        const rendered: ModelRow[] = result.rows.map((r) => ({
+            model: r.model,
+            sessions: integer(r.sessions),
+            prompt: integer(r.prompt_tokens),
+            completion: integer(r.completion_tokens),
+            cache_read: integer(r.cache_read_tokens),
+            cache_create: integer(r.cache_create_tokens),
+            cost: usd(r.cost_usd),
+        }));
+
+        const cols: Column<ModelRow>[] = [
+            { header: "model", get: (r) => r.model, min: 20 },
+            { header: "sessions", get: (r) => r.sessions, align: "right", width: 8 },
+            { header: "prompt", get: (r) => r.prompt, align: "right", width: 14 },
+            { header: "completion", get: (r) => r.completion, align: "right", width: 14 },
+            { header: "cache_read", get: (r) => r.cache_read, align: "right", width: 12 },
+            { header: "cache_create", get: (r) => r.cache_create, align: "right", width: 12 },
+            { header: "cost", get: (r) => r.cost, align: "right", width: 10 },
+        ];
+
+        console.log(renderTable({ columns: cols, rows: rendered, gap: " " }));
         console.log(`\ntotal: ${usd(result.total_cost_usd)}  (${input.sinceDays} days)`);
     });
 
@@ -112,25 +127,38 @@ const cmdCostSessions = (input: {
             return;
         }
 
-        console.log(
-            `${"session".padEnd(36)}  ${"project".padEnd(24)}  ${"model".padEnd(28)}  ${"started".padEnd(19)}  ${"cost".padStart(10)}  ${"completion".padStart(12)}  ${"cache_read".padStart(12)}`,
-        );
-        for (const row of result.rows) {
+        type SessionRow = {
+            session: string;
+            project: string;
+            model: string;
+            started: string;
+            cost: string;
+            completion: string;
+            cache_read: string;
+        };
+
+        const rendered: SessionRow[] = result.rows.map((r) => ({
             // Strip "session:" prefix and optional SurrealDB backtick wrapping (`uuid`)
-            const sid = row.session_id.replace(/^session:/, "").replace(/^`(.*)`$/, "$1").slice(0, 36);
-            const proj = (row.project ?? "").slice(0, 24);
-            const mdl = (row.model ?? "?").slice(0, 28);
-            const ts = (row.started_at ?? "").slice(0, 19);
-            console.log(
-                `${sid.padEnd(36)}  ` +
-                `${proj.padEnd(24)}  ` +
-                `${mdl.padEnd(28)}  ` +
-                `${ts.padEnd(19)}  ` +
-                `${usd(row.cost_usd).padStart(10)}  ` +
-                `${integer(row.completion_tokens).padStart(12)}  ` +
-                `${integer(row.cache_read_tokens).padStart(12)}`,
-            );
-        }
+            session: r.session_id.replace(/^session:/, "").replace(/^`(.*)`$/, "$1"),
+            project: r.project ?? "",
+            model: r.model ?? "?",
+            started: r.started_at ?? "",
+            cost: usd(r.cost_usd),
+            completion: integer(r.completion_tokens),
+            cache_read: integer(r.cache_read_tokens),
+        }));
+
+        const cols: Column<SessionRow>[] = [
+            { header: "session", get: (r) => r.session, width: 36 },
+            { header: "project", get: (r) => r.project, width: 24, overflow: "clip" },
+            { header: "model", get: (r) => r.model, width: 28, overflow: "clip" },
+            { header: "started", get: (r) => r.started, width: 19, overflow: "clip" },
+            { header: "cost", get: (r) => r.cost, align: "right", width: 10 },
+            { header: "completion", get: (r) => r.completion, align: "right", width: 12 },
+            { header: "cache_read", get: (r) => r.cache_read, align: "right", width: 12 },
+        ];
+
+        console.log(renderTable({ columns: cols, rows: rendered, gap: " " }));
     });
 
 const costSessionsCommand = Command.make(
@@ -182,42 +210,54 @@ const cmdCostSplit = (input: {
 
         printNextLinks(buildCostSplitNext(result));
 
-        const colWidths = {
-            origin: 8,
-            model: Math.max(20, ...result.rows.map((r) => r.model.length)),
+        type SplitRow = {
+            origin: string;
+            model: string;
+            sessions: string;
+            prompt: string;
+            completion: string;
+            cost: string;
+            share: string;
         };
 
-        console.log(
-            `${"origin".padEnd(colWidths.origin)}  ${"model".padEnd(colWidths.model)}  ${"sessions".padStart(8)}  ${"prompt".padStart(14)}  ${"completion".padStart(14)}  ${"cost".padStart(10)}  ${"share".padStart(7)}`,
-        );
-        for (const row of result.rows) {
-            console.log(
-                `${row.origin.padEnd(colWidths.origin)}  ` +
-                `${row.model.padEnd(colWidths.model)}  ` +
-                `${integer(row.sessions).padStart(8)}  ` +
-                `${integer(row.prompt_tokens).padStart(14)}  ` +
-                `${integer(row.completion_tokens).padStart(14)}  ` +
-                `${usd(row.cost_usd).padStart(10)}  ` +
-                `${pct(row.share_pct).padStart(7)}`,
-        );
-        }
+        const rendered: SplitRow[] = result.rows.map((r) => ({
+            origin: r.origin,
+            model: r.model,
+            sessions: integer(r.sessions),
+            prompt: integer(r.prompt_tokens),
+            completion: integer(r.completion_tokens),
+            cost: usd(r.cost_usd),
+            share: pct(r.share_pct),
+        }));
 
-        // Totals row
         const t = result.totals;
-        const totalLabel = "TOTAL";
-        console.log(
-            `\n${"".padEnd(colWidths.origin)}  ${"".padEnd(colWidths.model)}  ` +
-            `${"".padStart(8)}  ${"".padStart(14)}  ${"".padStart(14)}  ` +
-            `${"─".repeat(10)}  ${"─".repeat(7)}`,
-        );
-        console.log(
-            `${totalLabel.padEnd(colWidths.origin)}  ${"".padEnd(colWidths.model)}  ` +
-            `${integer(t.sessions).padStart(8)}  ` +
-            `${integer(t.prompt_tokens).padStart(14)}  ` +
-            `${integer(t.completion_tokens).padStart(14)}  ` +
-            `${usd(t.cost_usd).padStart(10)}  ` +
-            `${"100.0%".padStart(7)}`,
-        );
+        const footer: FooterLine[] = [
+            {
+                cells: [
+                    "TOTAL",
+                    null,
+                    integer(t.sessions),
+                    integer(t.prompt_tokens),
+                    integer(t.completion_tokens),
+                    usd(t.cost_usd),
+                    "100.0%",
+                ],
+            },
+        ];
+
+        const modelW = Math.max(20, ...result.rows.map((r) => r.model.length));
+
+        const cols: Column<SplitRow>[] = [
+            { header: "origin", get: (r) => r.origin, width: 8 },
+            { header: "model", get: (r) => r.model, min: modelW },
+            { header: "sessions", get: (r) => r.sessions, align: "right", width: 8 },
+            { header: "prompt", get: (r) => r.prompt, align: "right", width: 14 },
+            { header: "completion", get: (r) => r.completion, align: "right", width: 14 },
+            { header: "cost", get: (r) => r.cost, align: "right", width: 10, footerRule: true },
+            { header: "share", get: (r) => r.share, align: "right", width: 7, footerRule: true },
+        ];
+
+        console.log(renderTable({ columns: cols, rows: rendered, gap: " ", footer }));
         console.log(`\n(${input.sinceDays} days)`);
     });
 

--- a/apps/axctl/src/cli/commands/ax-dispatches.ts
+++ b/apps/axctl/src/cli/commands/ax-dispatches.ts
@@ -37,7 +37,9 @@ import {
 } from "../../queries/dispatch-analytics.ts";
 import { loadEffectiveRoutingTable } from "../../queries/routing-table-io.ts";
 import { buildDispatchesNext, buildCandidatesNext } from "../../nav/next-links.ts";
-import { pct, truncate, usd } from "../render.ts";
+import { pct, usd } from "../render.ts";
+import { renderTable } from "../table.js";
+import type { Column } from "../table.js";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionValue, positiveLimit } from "./shared.ts";
 
@@ -93,17 +95,35 @@ const cmdDispatches = (input: {
             // By-class table
             if (result.by_class.length > 0) {
                 console.log("");
-                const classW = 28;
-                console.log(
-                    `${"class".padEnd(classW)}  ${"total".padStart(6)}  ${"cheap".padStart(6)}  ${"expensive".padStart(9)}  ${"overspend".padStart(10)}  ${"est_savings".padStart(11)}`,
-                );
-                for (const row of result.by_class) {
-                    console.log(
-                        `${truncate(row.classId, classW).padEnd(classW)}  ${row.count.toString().padStart(6)}  ` +
-                        `${row.ran_cheap.toString().padStart(6)}  ${row.ran_expensive.toString().padStart(9)}  ` +
-                        `${usd(row.overspend_usd).padStart(10)}  ${usd(row.est_savings_usd).padStart(11)}`,
-                    );
-                }
+
+                type EconRow = {
+                    classId: string;
+                    count: string;
+                    ran_cheap: string;
+                    ran_expensive: string;
+                    overspend: string;
+                    est_savings: string;
+                };
+
+                const econRows: EconRow[] = result.by_class.map((row) => ({
+                    classId: row.classId,
+                    count: row.count.toString(),
+                    ran_cheap: row.ran_cheap.toString(),
+                    ran_expensive: row.ran_expensive.toString(),
+                    overspend: usd(row.overspend_usd),
+                    est_savings: usd(row.est_savings_usd),
+                }));
+
+                const econCols: Column<EconRow>[] = [
+                    { header: "class", get: (r) => r.classId, width: 28, overflow: "ellipsis" },
+                    { header: "total", get: (r) => r.count, align: "right", width: 6 },
+                    { header: "cheap", get: (r) => r.ran_cheap, align: "right", width: 6 },
+                    { header: "expensive", get: (r) => r.ran_expensive, align: "right", width: 9 },
+                    { header: "overspend", get: (r) => r.overspend, align: "right", width: 10 },
+                    { header: "est_savings", get: (r) => r.est_savings, align: "right", width: 11 },
+                ];
+
+                console.log(renderTable({ columns: econCols, rows: econRows }));
             }
 
             console.log(`\ntip: ax dispatches --candidates  for per-dispatch view of the expensive-tier rows`);
@@ -126,25 +146,34 @@ const cmdDispatches = (input: {
 
             printNextLinks(buildCandidatesNext(result));
 
-            // Header
-            const descW = 48;
-            const modelW = 28;
-            console.log(
-                `${"ts".padEnd(19)}  ${"agent_type".padEnd(24)}  ${"description".padEnd(descW)}  ` +
-                `${"suggest".padEnd(modelW)}  ${"child_cost".padStart(10)}  ${"est_savings".padStart(11)}`,
-            );
+            type CandRow = {
+                ts: string;
+                agent_type: string;
+                description: string;
+                suggest: string;
+                child_cost: string;
+                est_savings: string;
+            };
 
-            for (const row of result.candidates) {
-                const ts = row.ts.slice(0, 19);
-                const at = truncate(row.agent_type, 24);
-                const desc = truncate(row.description, descW);
-                const suggest = row.suggested_model.slice(0, modelW);
-                console.log(
-                    `${ts.padEnd(19)}  ${at.padEnd(24)}  ${desc.padEnd(descW)}  ` +
-                    `${suggest.padEnd(modelW)}  ${usd(row.child_cost_usd).padStart(10)}  ` +
-                    `${usd(row.est_savings_usd).padStart(11)}`,
-                );
-            }
+            const candRows: CandRow[] = result.candidates.map((row) => ({
+                ts: row.ts,
+                agent_type: row.agent_type ?? "",
+                description: row.description ?? "",
+                suggest: row.suggested_model,
+                child_cost: usd(row.child_cost_usd),
+                est_savings: usd(row.est_savings_usd),
+            }));
+
+            const candCols: Column<CandRow>[] = [
+                { header: "ts", get: (r) => r.ts, width: 19, overflow: "clip" },
+                { header: "agent_type", get: (r) => r.agent_type, width: 24, overflow: "ellipsis" },
+                { header: "description", get: (r) => r.description, width: 48, overflow: "ellipsis" },
+                { header: "suggest", get: (r) => r.suggest, width: 28, overflow: "clip" },
+                { header: "child_cost", get: (r) => r.child_cost, align: "right", width: 10 },
+                { header: "est_savings", get: (r) => r.est_savings, align: "right", width: 11 },
+            ];
+
+            console.log(renderTable({ columns: candCols, rows: candRows }));
 
             console.log(`\ntotal est savings: ${usd(result.total_est_savings_usd)}`);
             if (result.top_classes.length > 0) {
@@ -171,28 +200,36 @@ const cmdDispatches = (input: {
 
         printNextLinks(buildDispatchesNext(result));
 
-        const descW = 48;
-        const dmW = 16; // dispatch model column
-        const cmW = 28; // child model column
+        type DispatchRow = {
+            ts: string;
+            agent_type: string;
+            description: string;
+            dispatch_model: string;
+            child_model: string;
+            child_cost: string;
+        };
 
-        console.log(
-            `${"ts".padEnd(19)}  ${"agent_type".padEnd(24)}  ${"description".padEnd(descW)}  ` +
-            `${"dispatch_model".padEnd(dmW)}  ${"child_model".padEnd(cmW)}  ${"child_cost".padStart(10)}`,
-        );
-
-        for (const row of result.rows) {
-            const ts = row.ts.slice(0, 19);
-            const at = truncate(row.agent_type, 24);
-            const desc = truncate(row.description, descW);
-            const dm = row.dispatch_model.slice(0, dmW);
+        const dispRows: DispatchRow[] = result.rows.map((row) => ({
+            ts: row.ts,
+            agent_type: row.agent_type ?? "",
+            description: row.description ?? "",
+            dispatch_model: row.dispatch_model,
             // "!" marks a routed dispatch whose child ran legs on another model
             // (Claude Code drops the model override on continuations).
-            const cm = `${row.model_dropped ? "!" : ""}${row.child_model ?? "?"}`.slice(0, cmW);
-            console.log(
-                `${ts.padEnd(19)}  ${at.padEnd(24)}  ${desc.padEnd(descW)}  ` +
-                `${dm.padEnd(dmW)}  ${cm.padEnd(cmW)}  ${usd(row.child_cost_usd).padStart(10)}`,
-            );
-        }
+            child_model: `${row.model_dropped ? "!" : ""}${row.child_model ?? "?"}`,
+            child_cost: usd(row.child_cost_usd),
+        }));
+
+        const dispCols: Column<DispatchRow>[] = [
+            { header: "ts", get: (r) => r.ts, width: 19, overflow: "clip" },
+            { header: "agent_type", get: (r) => r.agent_type, width: 24, overflow: "ellipsis" },
+            { header: "description", get: (r) => r.description, width: 48, overflow: "ellipsis" },
+            { header: "dispatch_model", get: (r) => r.dispatch_model, width: 16, overflow: "clip" },
+            { header: "child_model", get: (r) => r.child_model, width: 28, overflow: "clip" },
+            { header: "child_cost", get: (r) => r.child_cost, align: "right", width: 10 },
+        ];
+
+        console.log(renderTable({ columns: dispCols, rows: dispRows }));
 
         console.log(
             `\n${result.total_dispatches} dispatches  ${pct(result.inherit_pct)} inherit  ` +

--- a/apps/axctl/src/cli/role-format.test.ts
+++ b/apps/axctl/src/cli/role-format.test.ts
@@ -406,3 +406,76 @@ describe("renderByRoleSection", () => {
         expect(out).toContain("no skill invocations");
     });
 });
+
+// ---------------------------------------------------------------------------
+// Golden string assertions — full byte-identity snapshots
+// These guard that renderTable migration did not change output bytes.
+// ---------------------------------------------------------------------------
+
+describe("renderSkillsByRoleTable - golden string", () => {
+    it("produces byte-identical output to the pre-renderTable version", () => {
+        const out = renderSkillsByRoleTable(SKILLS_BY_ROLE_RESULT, "debugging");
+        expect(out).toBe(
+            "rank  skill                         invocations  source        confidence\n" +
+            "   1  caveman                               100  frontmatter         0.90\n" +
+            "   2  diagnose                               42  brief               0.80\n" +
+            "\n" +
+            "(2 skills for role \"debugging\")",
+        );
+    });
+});
+
+describe("renderRolesForSkillTable - golden string", () => {
+    it("produces byte-identical output to the pre-renderTable version", () => {
+        const out = renderRolesForSkillTable(ROLES_FOR_SKILL_RESULT, "caveman");
+        expect(out).toBe(
+            "role                  source        confidence  rationale                     \n" +
+            "debugging             frontmatter         0.90  primary debugging tool        \n" +
+            "triage                user                   1                                \n" +
+            "\n" +
+            "(2 roles for skill \"caveman\")",
+        );
+    });
+
+    it("ellipsis-truncates rationale at max 50 chars (U+2026)", () => {
+        const longRationale = "x".repeat(100);
+        const result: FetchRolesForSkillResult = {
+            skillExists: true,
+            rows: [
+                {
+                    role_name: "test",
+                    role_weight: 1.0,
+                    source: "user",
+                    confidence: 1.0,
+                    edge_weight_override: null,
+                    rationale: longRationale,
+                    since: null,
+                },
+            ],
+        };
+        const out = renderRolesForSkillTable(result, "myskill");
+        // Column width = 50 (max), rationale = 49 x's + '…'
+        expect(out).toBe(
+            "role                  source        confidence  rationale                                         \n" +
+            "test                  user                   1  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…\n" +
+            "\n" +
+            "(1 role for skill \"myskill\")",
+        );
+        expect(out).toContain("…");
+        expect(out).not.toContain("...");
+    });
+});
+
+describe("renderAllRolesTable - golden string", () => {
+    it("produces byte-identical output to the pre-renderTable version", () => {
+        const out = renderAllRolesTable(ALL_ROLES_RESULT);
+        expect(out).toBe(
+            "role                  weight  skills\n" +
+            "debugging               1.50      12\n" +
+            "planning                   2       8\n" +
+            "empty-role                 1       0\n" +
+            "\n" +
+            "(3 roles)",
+        );
+    });
+});

--- a/apps/axctl/src/cli/role-format.ts
+++ b/apps/axctl/src/cli/role-format.ts
@@ -2,6 +2,9 @@
  * P3.7: Role read renderers - pure table + JSON output.
  *
  * No I/O, no Effect. Given typed result objects, returns strings.
+ *
+ * Migrated to renderTable (table.ts) for auto-width column-building.
+ * Output is byte-identical to the previous hand-rolled pad/join version.
  */
 
 import type {
@@ -13,6 +16,8 @@ import type {
     RoleRow,
 } from "../dashboard/role-queries.ts";
 import type { SessionSkillRoleGroup } from "@ax/lib/shared/dashboard-types";
+import { renderTable } from "./table.js";
+import type { Column } from "./table.js";
 
 export type { SessionSkillRoleGroup as ByRoleGroup } from "@ax/lib/shared/dashboard-types";
 
@@ -26,11 +31,6 @@ function fmtFloat(n: number): string {
 
 function fmtCount(n: number): string {
     return n.toLocaleString("en-US");
-}
-
-function truncate(s: string | null, max: number): string {
-    if (!s) return "";
-    return s.length > max ? s.slice(0, max - 1) + "…" : s;
 }
 
 // ---------------------------------------------------------------------------
@@ -47,7 +47,7 @@ export function renderSkillsByRoleTable(
 
     const { rows } = result;
 
-    type Row = {
+    type RenderedRow = {
         rank: string;
         skill: string;
         invocations: string;
@@ -55,7 +55,7 @@ export function renderSkillsByRoleTable(
         confidence: string;
     };
 
-    const rendered: Row[] = rows.map((r: SkillByRoleRow, i: number) => ({
+    const rendered: RenderedRow[] = rows.map((r: SkillByRoleRow, i: number) => ({
         rank: String(i + 1),
         skill: r.skill_name,
         invocations: fmtCount(r.invocations),
@@ -63,43 +63,20 @@ export function renderSkillsByRoleTable(
         confidence: fmtFloat(r.confidence),
     }));
 
-    const headers: Row = {
-        rank: "rank",
-        skill: "skill",
-        invocations: "invocations",
-        source: "source",
-        confidence: "confidence",
-    };
+    const cols: Column<RenderedRow>[] = [
+        { header: "rank", get: (r) => r.rank, align: "right" },
+        { header: "skill", get: (r) => r.skill, min: 28 },
+        { header: "invocations", get: (r) => r.invocations, align: "right" },
+        { header: "source", get: (r) => r.source, min: 12 },
+        { header: "confidence", get: (r) => r.confidence, align: "right" },
+    ];
 
-    const colW = (key: keyof Row): number =>
-        Math.max(headers[key].length, ...rendered.map((r) => r[key].length));
-
-    const rankW = colW("rank");
-    const skillW = Math.max(colW("skill"), 28);
-    const invW = colW("invocations");
-    const srcW = Math.max(colW("source"), 12);
-    const confW = colW("confidence");
-
-    const fmt = (r: Row): string =>
-        r.rank.padStart(rankW) +
-        "  " +
-        r.skill.padEnd(skillW) +
-        "  " +
-        r.invocations.padStart(invW) +
-        "  " +
-        r.source.padEnd(srcW) +
-        "  " +
-        r.confidence.padStart(confW);
-
-    const lines: string[] = [];
-    lines.push(fmt(headers));
-    for (const r of rendered) {
-        lines.push(fmt(r));
-    }
-    lines.push("");
-    lines.push(`(${rows.length} skill${rows.length === 1 ? "" : "s"} for role "${role}")`);
-
-    return lines.join("\n");
+    const table = renderTable({ columns: cols, rows: rendered });
+    return [
+        table,
+        "",
+        `(${rows.length} skill${rows.length === 1 ? "" : "s"} for role "${role}")`,
+    ].join("\n");
 }
 
 export function renderSkillsByRoleJson(
@@ -143,53 +120,40 @@ export function renderRolesForSkillTable(
         return `axctl skills roles: no roles assigned to "${skill}"`;
     }
 
-    type Row = {
+    type RenderedRow = {
         role: string;
         source: string;
         confidence: string;
         rationale: string;
     };
 
-    const rendered: Row[] = rows.map((r: RoleForSkillRow) => ({
+    const rendered: RenderedRow[] = rows.map((r: RoleForSkillRow) => ({
         role: r.role_name,
         source: r.source,
         confidence: fmtFloat(r.confidence),
-        rationale: truncate(r.rationale, 50),
+        // Raw rationale — renderTable handles truncation via overflow:'ellipsis' + max:50
+        rationale: r.rationale ?? "",
     }));
 
-    const headers: Row = {
-        role: "role",
-        source: "source",
-        confidence: "confidence",
-        rationale: "rationale",
-    };
+    const cols: Column<RenderedRow>[] = [
+        { header: "role", get: (r) => r.role, min: 20 },
+        { header: "source", get: (r) => r.source, min: 12 },
+        { header: "confidence", get: (r) => r.confidence, align: "right" },
+        {
+            header: "rationale",
+            get: (r) => r.rationale,
+            min: 30,
+            max: 50,
+            overflow: "ellipsis",
+        },
+    ];
 
-    const colW = (key: keyof Row): number =>
-        Math.max(headers[key].length, ...rendered.map((r) => r[key].length));
-
-    const roleW = Math.max(colW("role"), 20);
-    const srcW = Math.max(colW("source"), 12);
-    const confW = colW("confidence");
-    const ratW = Math.max(colW("rationale"), 30);
-
-    const fmt = (r: Row): string =>
-        r.role.padEnd(roleW) +
-        "  " +
-        r.source.padEnd(srcW) +
-        "  " +
-        r.confidence.padStart(confW) +
-        "  " +
-        r.rationale.padEnd(ratW);
-
-    const lines: string[] = [];
-    lines.push(fmt(headers));
-    for (const r of rendered) {
-        lines.push(fmt(r));
-    }
-    lines.push("");
-    lines.push(`(${rows.length} role${rows.length === 1 ? "" : "s"} for skill "${skill}")`);
-
-    return lines.join("\n");
+    const table = renderTable({ columns: cols, rows: rendered });
+    return [
+        table,
+        "",
+        `(${rows.length} role${rows.length === 1 ? "" : "s"} for skill "${skill}")`,
+    ].join("\n");
 }
 
 export function renderRolesForSkillJson(
@@ -226,43 +190,30 @@ export function renderAllRolesTable(result: FetchAllRolesResult): string {
         return "(no roles found)";
     }
 
-    type Row = {
+    type RenderedRow = {
         role: string;
         weight: string;
         skill_count: string;
     };
 
-    const rendered: Row[] = rows.map((r: RoleRow) => ({
+    const rendered: RenderedRow[] = rows.map((r: RoleRow) => ({
         role: r.name,
         weight: fmtFloat(r.weight),
         skill_count: fmtCount(r.skill_count),
     }));
 
-    const headers: Row = {
-        role: "role",
-        weight: "weight",
-        skill_count: "skills",
-    };
+    const cols: Column<RenderedRow>[] = [
+        { header: "role", get: (r) => r.role, min: 20 },
+        { header: "weight", get: (r) => r.weight, align: "right" },
+        { header: "skills", get: (r) => r.skill_count, align: "right", min: 6 },
+    ];
 
-    const colW = (key: keyof Row): number =>
-        Math.max(headers[key].length, ...rendered.map((r) => r[key].length));
-
-    const roleW = Math.max(colW("role"), 20);
-    const wtW = colW("weight");
-    const cntW = Math.max(colW("skill_count"), 6);
-
-    const fmt = (r: Row): string =>
-        r.role.padEnd(roleW) + "  " + r.weight.padStart(wtW) + "  " + r.skill_count.padStart(cntW);
-
-    const lines: string[] = [];
-    lines.push(fmt(headers));
-    for (const r of rendered) {
-        lines.push(fmt(r));
-    }
-    lines.push("");
-    lines.push(`(${rows.length} role${rows.length === 1 ? "" : "s"})`);
-
-    return lines.join("\n");
+    const table = renderTable({ columns: cols, rows: rendered });
+    return [
+        table,
+        "",
+        `(${rows.length} role${rows.length === 1 ? "" : "s"})`,
+    ].join("\n");
 }
 
 export function renderAllRolesJson(result: FetchAllRolesResult): string {

--- a/apps/axctl/src/cli/table.test.ts
+++ b/apps/axctl/src/cli/table.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for renderTable column-builder (table.ts).
+ *
+ * Covers all hard constraints from spec §E:
+ *   1. Auto-width includes header
+ *   2. min floor (auto floor) vs width (fixed) are distinct
+ *   3. fixed width overrides auto
+ *   4. max cap on auto-width
+ *   5. clip overflow (no ellipsis)
+ *   6. ellipsis overflow (U+2026, NOT "...")
+ *   7. custom gap
+ *   8. right-align
+ *   9. empty rows → just header
+ *  10. footer lines appear AFTER rule row
+ *  11. footerRule columns draw '─' chars
+ *  12. no-footerRule columns → no rule row emitted
+ *
+ * All assertions use FULL string equality, not just length checks.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { renderTable } from "./table.ts";
+import type { Column, FooterLine } from "./table.ts";
+
+// ---------------------------------------------------------------------------
+// Test 1: Auto-width includes header length
+// ---------------------------------------------------------------------------
+describe("auto-width includes header", () => {
+    it("header longer than all cells → header width wins", () => {
+        const cols: Column<{ a: string }>[] = [
+            { header: "longheader", get: (r) => r.a },
+        ];
+        const out = renderTable({ columns: cols, rows: [{ a: "short" }, { a: "x" }] });
+        // Width = max(0, 10, 5, 1) = 10
+        expect(out).toBe("longheader\nshort     \nx         ");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: min floor
+// ---------------------------------------------------------------------------
+describe("min floor", () => {
+    it("min > max cell and header length → min wins", () => {
+        const cols: Column<{ a: string }>[] = [
+            { header: "h", get: (r) => r.a, min: 15 },
+        ];
+        const out = renderTable({ columns: cols, rows: [{ a: "short" }] });
+        // Width = max(15, 1, 5) = 15
+        expect(out).toBe("h              \nshort          ");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: fixed width (col.width takes precedence over everything)
+// ---------------------------------------------------------------------------
+describe("fixed width", () => {
+    it("width overrides auto-width from header and cells", () => {
+        const cols: Column<{ a: string }>[] = [
+            { header: "col", get: (r) => r.a, width: 10 },
+        ];
+        const out = renderTable({ columns: cols, rows: [{ a: "a" }] });
+        // Width = 10 (fixed), auto would be max(0, 3, 1) = 3
+        expect(out).toBe("col       \na         ");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: max cap truncates auto-width
+// ---------------------------------------------------------------------------
+describe("max cap", () => {
+    it("auto-width is capped at col.max", () => {
+        const cols: Column<{ a: string }>[] = [
+            { header: "hdr", get: (r) => r.a, max: 20 },
+        ];
+        const out = renderTable({
+            columns: cols,
+            rows: [{ a: "a".repeat(100) }],
+        });
+        // Auto = max(0, 3, 100) = 100, cap = min(100, 20) = 20
+        expect(out).toBe("hdr                 \naaaaaaaaaaaaaaaaaaaa");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: clip overflow (no ellipsis)
+// ---------------------------------------------------------------------------
+describe("clip overflow", () => {
+    it("clips cell to width without ellipsis", () => {
+        const cols: Column<{ a: string }>[] = [
+            { header: "h", get: (r) => r.a, width: 5 },
+        ];
+        const out = renderTable({ columns: cols, rows: [{ a: "hello world" }] });
+        // clip: "hello world".slice(0, 5) = "hello"
+        expect(out).toBe("h    \nhello");
+        expect(out).not.toContain("…");
+        expect(out).not.toContain("...");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: ellipsis overflow (U+2026, NOT "...")
+// ---------------------------------------------------------------------------
+describe("ellipsis overflow", () => {
+    it("uses U+2026 (…) not three dots (...)", () => {
+        const cols: Column<{ a: string }>[] = [
+            { header: "h", get: (r) => r.a, width: 5, overflow: "ellipsis" },
+        ];
+        const out = renderTable({ columns: cols, rows: [{ a: "hello world" }] });
+        // truncate("hello world", 5) = "hell…" (4 chars + 1 U+2026 = 5 chars)
+        expect(out).toBe("h    \nhell…");
+        expect(out).toContain("…");
+        expect(out).not.toContain("...");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 7: custom gap (single space)
+// ---------------------------------------------------------------------------
+describe("custom gap", () => {
+    it("uses single space between columns when gap=' '", () => {
+        const cols: Column<{ a: string; b: string }>[] = [
+            { header: "A", get: (r) => r.a, width: 3 },
+            { header: "B", get: (r) => r.b, width: 3 },
+        ];
+        const out = renderTable({
+            columns: cols,
+            rows: [{ a: "x", b: "y" }],
+            gap: " ",
+        });
+        // "A  " + " " + "B  " = "A   B  "
+        // "x  " + " " + "y  " = "x   y  "
+        expect(out).toBe("A   B  \nx   y  ");
+    });
+
+    it("default gap is two spaces", () => {
+        const cols: Column<{ a: string; b: string }>[] = [
+            { header: "A", get: (r) => r.a, width: 1 },
+            { header: "B", get: (r) => r.b, width: 1 },
+        ];
+        const out = renderTable({ columns: cols, rows: [{ a: "x", b: "y" }] });
+        // "A" + "  " + "B" = "A  B"
+        expect(out).toBe("A  B\nx  y");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 8: right-align (padStart)
+// ---------------------------------------------------------------------------
+describe("right-align", () => {
+    it("right-aligns header and cell values with padStart", () => {
+        const cols: Column<{ n: string }>[] = [
+            { header: "num", get: (r) => r.n, align: "right", width: 10 },
+        ];
+        const out = renderTable({ columns: cols, rows: [{ n: "42" }] });
+        expect(out).toBe("       num\n        42");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 9: empty rows → just header line
+// ---------------------------------------------------------------------------
+describe("empty rows", () => {
+    it("renders only the header when rows is empty", () => {
+        const cols: Column<{ a: string }>[] = [
+            { header: "col", get: (r) => r.a },
+        ];
+        const out = renderTable({ columns: cols, rows: [] });
+        // Width = max(0, 3) = 3, header "col" padEnd(3) = "col"
+        expect(out).toBe("col");
+        expect(out.split("\n")).toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 10: footer lines appear AFTER the rule row
+// ---------------------------------------------------------------------------
+describe("footer ordering", () => {
+    it("rule row appears before footer lines", () => {
+        const cols: Column<{ a: string; b: string }>[] = [
+            { header: "A", get: (r) => r.a, width: 5, footerRule: true },
+            { header: "B", get: (r) => r.b, width: 5 },
+        ];
+        const footer: FooterLine[] = [{ cells: ["tot", null] }];
+        const out = renderTable({
+            columns: cols,
+            rows: [{ a: "data", b: "info" }],
+            footer,
+        });
+        // header: "A      B    "
+        // row:    "data   info "
+        // rule:   "─────       "
+        // footer: "tot         "
+        expect(out).toBe("A      B    \ndata   info \n─────       \ntot         ");
+        const lines = out.split("\n");
+        const ruleIdx = lines.findIndex((l) => l.includes("─"));
+        const footerIdx = lines.findIndex((l) => l.startsWith("tot"));
+        expect(ruleIdx).toBeGreaterThan(0);
+        expect(footerIdx).toBeGreaterThan(ruleIdx);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 11: footerRule draws '─' chars at resolved column width
+// ---------------------------------------------------------------------------
+describe("footerRule", () => {
+    it("draws '─' chars for footerRule columns, spaces for others", () => {
+        const cols: Column<{ a: string }>[] = [
+            { header: "x", get: (r) => r.a, width: 4, footerRule: true },
+        ];
+        const out = renderTable({
+            columns: cols,
+            rows: [{ a: "hi" }],
+            footer: [{ cells: ["end"] }],
+        });
+        // header: "x   "
+        // row:    "hi  "
+        // rule:   "────"
+        // footer: "end "
+        expect(out).toBe("x   \nhi  \n────\nend ");
+        expect(out).toContain("────");
+        expect(out).not.toContain("---");
+    });
+
+    it("rule row only drawn when footer is provided", () => {
+        const cols: Column<{ a: string }>[] = [
+            { header: "x", get: (r) => r.a, width: 4, footerRule: true },
+        ];
+        const out = renderTable({ columns: cols, rows: [{ a: "hi" }] });
+        // footer: undefined → no rule row
+        expect(out).toBe("x   \nhi  ");
+        expect(out).not.toContain("─");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Test 12: footer with no footerRule columns → no rule row emitted
+// ---------------------------------------------------------------------------
+describe("no footerRule → no rule row", () => {
+    it("omits rule row when no column has footerRule: true", () => {
+        const cols: Column<{ a: string }>[] = [
+            { header: "A", get: (r) => r.a, width: 5 },
+        ];
+        const footer: FooterLine[] = [{ cells: ["total"] }];
+        const out = renderTable({
+            columns: cols,
+            rows: [{ a: "x" }],
+            footer,
+        });
+        // header: "A    "
+        // row:    "x    "
+        // footer: "total"
+        // NO rule row
+        expect(out).toBe("A    \nx    \ntotal");
+        expect(out).not.toContain("─");
+    });
+});

--- a/apps/axctl/src/cli/table.ts
+++ b/apps/axctl/src/cli/table.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure column-builder for CLI tabular output.
+ *
+ * Key design decisions (see spec: arch-deepening-goal-package.md §E):
+ *  - Column.get owns raw cell text, null-fallbacks, and synthesized prefixes.
+ *    renderTable owns 100% of pad/clip/truncation — do NOT call truncate()/slice()
+ *    inside a get() implementation.
+ *  - Auto-width INCLUDES the header: max(min??0, header.length, ...cellLengths).
+ *  - `width` (fixed) and `min` (auto floor) are DISTINCT: `width` short-circuits
+ *    all auto logic; `min` is just a floor passed into auto.
+ *  - `overflow: 'ellipsis'` delegates to render.ts `truncate` (U+2026, NOT "...").
+ *  - `gap` is per-call (default "  ", two spaces). Cost tables pass " " (one space).
+ *  - Footer rule row: drawn BEFORE footer lines when any Column has footerRule:true.
+ *    Rule row renders '─'.repeat(w) on footerRule columns, ' '.repeat(w) elsewhere.
+ *  - Terminal-width: opt-in via opts.maxWidth ONLY. NEVER read process.stdout.columns
+ *    or env vars inside renderTable — breaks byte-identity for non-interactive callers.
+ *  - Cells must be ANSI-free. No strwidth seam yet — add one before accepting ANSI input.
+ */
+
+import { truncate } from "./render.js";
+
+export type Align = "left" | "right";
+export type Overflow = "clip" | "ellipsis";
+
+export interface Column<T> {
+    header: string;
+    get: (row: T) => string;
+    align?: Align; // default 'left'
+    width?: number; // FIXED width (overrides auto)
+    min?: number; // floor for auto-width
+    max?: number; // cap for auto-width
+    overflow?: Overflow; // default 'clip'
+    footerRule?: boolean; // draw '─'.repeat(resolvedWidth) in the rule row
+}
+
+export interface FooterLine {
+    cells: (string | null)[]; // null → blank (filled with spaces)
+}
+
+export interface TableOptions<T> {
+    columns: Column<T>[];
+    rows: T[];
+    gap?: string; // default '  ' (two spaces)
+    footer?: FooterLine[]; // appended after rule row (if any)
+    maxWidth?: number; // opt-in only; NEVER read process.stdout.columns
+}
+
+export function renderTable<T>(opts: TableOptions<T>): string {
+    const gap = opts.gap ?? "  ";
+    const cols = opts.columns;
+
+    // Compute all cell values upfront
+    const cellMatrix = opts.rows.map((row) => cols.map((col) => col.get(row)));
+
+    // Resolve widths
+    const widths = cols.map((col, i) => {
+        if (col.width !== undefined) return col.width; // fixed
+        const cells = cellMatrix.map((row) => row[i]);
+        const auto = Math.max(
+            col.min ?? 0,
+            col.header.length,
+            ...cells.map((c) => c.length),
+        );
+        return col.max !== undefined ? Math.min(auto, col.max) : auto;
+    });
+
+    // Render a cell to exact width
+    function renderCell(text: string, w: number, col: Column<T>): string {
+        const overflow = col.overflow ?? "clip";
+        let cell: string;
+        if (text.length > w) {
+            cell = overflow === "ellipsis" ? truncate(text, w) : text.slice(0, w);
+        } else {
+            cell = text;
+        }
+        return col.align === "right" ? cell.padStart(w) : cell.padEnd(w);
+    }
+
+    const lines: string[] = [];
+
+    // Header row
+    lines.push(
+        cols
+            .map((col, i) => {
+                const w = widths[i];
+                return col.align === "right"
+                    ? col.header.padStart(w)
+                    : col.header.padEnd(w);
+            })
+            .join(gap),
+    );
+
+    // Data rows
+    for (const row of cellMatrix) {
+        lines.push(
+            cols.map((col, i) => renderCell(row[i], widths[i], col)).join(gap),
+        );
+    }
+
+    // Footer rule row (if any col has footerRule: true)
+    if (opts.footer !== undefined && cols.some((c) => c.footerRule)) {
+        lines.push(
+            cols
+                .map((col, i) =>
+                    col.footerRule
+                        ? "─".repeat(widths[i])
+                        : " ".repeat(widths[i]),
+                )
+                .join(gap),
+        );
+    }
+
+    // Footer lines
+    if (opts.footer) {
+        for (const fl of opts.footer) {
+            lines.push(
+                cols
+                    .map((col, i) => {
+                        const cell = fl.cells[i] ?? null;
+                        if (cell === null) return " ".repeat(widths[i]);
+                        return col.align === "right"
+                            ? cell.padStart(widths[i])
+                            : cell.padEnd(widths[i]);
+                    })
+                    .join(gap),
+            );
+        }
+    }
+
+    return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

- New pure `apps/axctl/src/cli/table.ts` with `Column<T>` / `FooterLine` / `TableOptions` / `renderTable<T>`
- `table.test.ts`: 14 unit tests covering auto-width (header-inclusive), min floor, fixed width, max cap, clip vs ellipsis, custom gap, right-align, empty rows, footer rule ordering, footerRule '─' chars, no-footerRule skips rule row
- Migrated `role-format.ts` (canary) — byte-identical output verified via golden string snapshots added to `role-format.test.ts`
- Migrated `ax-cost.ts` (3 subcmds: models, sessions, split + TOTAL footer line with footerRule on cost/share columns)
- Migrated `ax-dispatches.ts` (3 views: default table, --candidates, --economy by-class table) — description column uses `overflow: 'ellipsis'`; `'!'` prefix for model-dropped rows in `Column.get`

## Hard constraints satisfied

- Auto-width includes header: `Math.max(min ?? 0, header.length, ...cellLengths)`
- `width` (fixed) vs `min` (auto floor) are distinct — `width` short-circuits all auto logic
- Ellipsis uses `truncate` from `render.ts` (U+2026 `…`, not `'...'`)
- `gap` is per-call: cost tables use `' '` (one space), dispatches/role-format use `'  '` (default two spaces)
- Footer rule: `'─'.repeat(w)` only on `footerRule: true` columns; others get `' '.repeat(w)`
- Terminal-width opt-in only via `opts.maxWidth`; `process.stdout.columns` never read inside `renderTable`
- `Column.get` owns raw cell text and synthesized prefixes; `renderTable` owns all pad/clip/truncation

## Test output

56 tests pass (14 table + 42 role-format), 0 failures. Type check: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)