### PR TITLE
refactor(mcp): typed zod tool factory, drop TS2589 cast + manual coercion (B tier-2)

### DIFF
--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -95,15 +95,31 @@ describe("session_metrics arg mapping", () => {
         expect(result).toEqual([]);
     });
 
-    it("ignores non-numeric sinceDays/limit and non-string project", async () => {
+    it("passes valid args through to the runtime", async () => {
         const rt = {
             runPromise: () => Promise.resolve([{ session: "session:x" }]),
         } as never;
         const result = await tool.run(
-            { sinceDays: "7", limit: "10", project: 42 },
+            { sinceDays: 7, limit: 10, project: "/repo" },
             rt,
         );
         expect(result).toEqual([{ session: "session:x" }]);
+    });
+
+    // Behavior change (production-parity): the typed factory parses args through
+    // the zod shape, so wrong-typed args are REJECTED at the boundary instead of
+    // being silently coerced away in `run`. On the live MCP path the SDK already
+    // ran the same `safeParse` BEFORE the callback fired, so it always rejected
+    // these - the old per-tool `typeof` coercion was dead defensive code.
+    it("rejects non-numeric sinceDays/limit and non-string project", async () => {
+        const unreachableRt = {
+            runPromise: () => {
+                throw new Error("runtime should not be reached");
+            },
+        } as never;
+        await expect(
+            tool.run({ sinceDays: "7", limit: "10", project: 42 }, unreachableRt),
+        ).rejects.toThrow();
     });
 });
 
@@ -169,13 +185,17 @@ describe("sessions_around date parsing", () => {
     } as never;
 
     it("rejects an invalid date string before hitting the runtime", async () => {
+        // The bespoke date check now lives in the schema as a `.refine`, so the
+        // failure carries the uniform validation envelope (message preserved).
         await expect(tool.run({ date: "not-a-date" }, unreachableRt)).rejects.toThrow(
             /Invalid date/,
         );
     });
 
-    it("rejects a missing date", async () => {
-        await expect(tool.run({}, unreachableRt)).rejects.toThrow(/Invalid date/);
+    it("rejects a missing date before hitting the runtime", async () => {
+        // Missing required `date` is rejected by the zod shape ("Required"),
+        // still before any DB call.
+        await expect(tool.run({}, unreachableRt)).rejects.toThrow();
     });
 
     it("maps a valid ISO date to a Date and returns the {sessions, next} envelope", async () => {

--- a/apps/axctl/src/mcp/server.ts
+++ b/apps/axctl/src/mcp/server.ts
@@ -15,72 +15,27 @@
 import { ManagedRuntime } from "effect";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AppLayer } from "@ax/lib/layers";
 import { AX_VERSION } from "../cli/version.ts";
 import { axMcpTools, type AxRuntime } from "./tools.ts";
 
-/**
- * Wrap a raw tool result in the MCP content envelope. Centralised so every
- * registered tool (and future Task-3 tools) gets identical serialisation: JSON
- * pretty-printed into a single text block.
- */
-export const wrapToolResult = (result: unknown): CallToolResult => ({
-    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-});
+// Re-exported for callers (and the smoke test) that import the envelope helpers
+// from the server module. They live in `./wrap.ts` to avoid a server<->tools
+// import cycle, since the tool factory needs them too.
+export { wrapToolResult, wrapToolError } from "./wrap.ts";
 
 /**
- * Wrap a thrown error as an MCP error result. The message is surfaced as text
- * (stderr-safe - this is the JSON-RPC response body, not a stdout log).
- */
-export const wrapToolError = (err: unknown): CallToolResult => ({
-    isError: true,
-    content: [
-        {
-            type: "text",
-            text: err instanceof Error ? err.message : String(err),
-        },
-    ],
-});
-
-/**
- * Build the MCP server and register every tool from `axMcpTools`. Each tool's
- * `run` is invoked with the validated args + the shared runtime; success flows
- * through `wrapToolResult`, failures through `wrapToolError`.
+ * Build the MCP server and register every tool from `axMcpTools`. Each tool
+ * owns its own `register(server, rt)` closure (see `defineMcpTool`), which wires
+ * the SDK callback through `wrapToolResult` / `wrapToolError`. Because the zod
+ * shape stays a deferred generic inside the factory, there is no longer a
+ * TS2589 cast here - registration is a plain typed call.
  */
 export const buildServer = (rt: AxRuntime): McpServer => {
     const server = new McpServer({ name: "ax", version: AX_VERSION });
-
-    // `registerTool`'s generic infers a callback type from the zod inputSchema.
-    // Driving that inference from a `ZodRawShape` (the registry's erased shape
-    // type) hits TS2589 (excessively deep). We register the tools through a
-    // permissive local alias - the shape is still validated by the SDK at
-    // runtime; we only opt out of the compile-time arg inference.
-    const register = server.registerTool.bind(server) as (
-        name: string,
-        config: { description?: string; inputSchema?: unknown },
-        cb: (args: Record<string, unknown>) => Promise<CallToolResult>,
-    ) => unknown;
-
     for (const tool of axMcpTools) {
-        register(
-            tool.name,
-            {
-                description: tool.description,
-                inputSchema: tool.inputSchema,
-            },
-            async (args: Record<string, unknown>): Promise<CallToolResult> => {
-                try {
-                    const result = await tool.run(args, rt);
-                    return wrapToolResult(result);
-                } catch (err) {
-                    console.error(`[ax mcp] tool "${tool.name}" failed:`, err);
-                    return wrapToolError(err);
-                }
-            },
-        );
+        tool.register(server, rt);
     }
-
     return server;
 };
 

--- a/apps/axctl/src/mcp/tools.test.ts
+++ b/apps/axctl/src/mcp/tools.test.ts
@@ -1,10 +1,116 @@
 import { describe, expect, it } from "bun:test";
-import { axMcpTools } from "./tools.ts";
+import { z } from "zod";
+import { axMcpTools, defineMcpTool } from "./tools.ts";
+
+/**
+ * Characterization: the advertised MCP surface (tool names + each tool's input
+ * shape) is pinned here so the typed-factory refactor cannot silently change
+ * what an MCP client sees. The keys are the zod raw-shape field names.
+ */
+const EXPECTED_INPUT_SHAPES: Record<string, readonly string[]> = {
+    recall: ["limit", "q", "sources"],
+    sessions_around: ["date", "days", "project"],
+    session_show: ["byRole", "expand", "expandAll", "sessionId"],
+    skills_weighted: ["limit", "windowDays"],
+    skills_by_role: ["limit", "role"],
+    skills_roles: ["skill"],
+    roles: [],
+    improve_recommend: ["agent", "forms", "limit", "sinceDays"],
+    improve_show: ["sigOrId"],
+    improve_list: ["form", "limit", "status"],
+    session_metrics: ["limit", "project", "sinceDays"],
+    signal_show: ["id", "limit"],
+    cost_models: ["days"],
+    cost_split: ["days"],
+    cost_routability: ["days", "min_run"],
+    dispatches: ["candidates", "days", "limit"],
+    dojo_agenda: ["days", "spar"],
+};
+
+describe("axMcpTools advertised surface", () => {
+    it("registers exactly the expected tool names", () => {
+        expect(axMcpTools.map((t) => t.name).sort()).toEqual(
+            Object.keys(EXPECTED_INPUT_SHAPES).sort(),
+        );
+    });
+
+    it("pins each tool's input shape field names", () => {
+        for (const tool of axMcpTools) {
+            expect(Object.keys(tool.inputSchema).sort()).toEqual(
+                [...EXPECTED_INPUT_SHAPES[tool.name]!].sort(),
+            );
+        }
+    });
+
+    it("exposes a register closure per tool", () => {
+        for (const tool of axMcpTools) {
+            expect(typeof tool.register).toBe("function");
+        }
+    });
+});
 
 describe("dojo_agenda MCP tool", () => {
     it("is registered with the expected name + input fields", () => {
         const t = axMcpTools.find((x) => x.name === "dojo_agenda");
         expect(t).toBeDefined();
         expect(Object.keys(t!.inputSchema).sort()).toEqual(["days", "spar"]);
+    });
+});
+
+describe("defineMcpTool (typed zod factory)", () => {
+    const rt = {} as never;
+
+    it("hands the inner run validated, typed args", async () => {
+        let seen: unknown;
+        const tool = defineMcpTool({
+            name: "echo",
+            description: "echo",
+            inputSchema: { n: z.number(), s: z.string().optional() },
+            run: async (args) => {
+                seen = args;
+                return { got: args.n };
+            },
+        });
+        const result = await tool.run({ n: 5 }, rt);
+        expect(result).toEqual({ got: 5 });
+        expect(seen).toEqual({ n: 5 });
+    });
+
+    it("omits absent optional keys (no undefined injected) so spread-callers hold", async () => {
+        let seen: Record<string, unknown> = { sentinel: true };
+        const tool = defineMcpTool({
+            name: "opt",
+            description: "opt",
+            inputSchema: { a: z.string().optional() },
+            run: async (args) => {
+                seen = args as Record<string, unknown>;
+                return null;
+            },
+        });
+        await tool.run({}, rt);
+        expect("a" in seen).toBe(false);
+    });
+
+    it("rejects args that violate the shape at the parse boundary", async () => {
+        const tool = defineMcpTool({
+            name: "strict",
+            description: "strict",
+            inputSchema: { n: z.number() },
+            run: async () => "unreachable",
+        });
+        await expect(tool.run({ n: "not-a-number" }, rt)).rejects.toThrow();
+    });
+
+    it("carries name/description/inputSchema onto the descriptor", () => {
+        const shape = { x: z.string() };
+        const tool = defineMcpTool({
+            name: "meta",
+            description: "the-desc",
+            inputSchema: shape,
+            run: async () => null,
+        });
+        expect(tool.name).toBe("meta");
+        expect(tool.description).toBe("the-desc");
+        expect(tool.inputSchema).toBe(shape);
     });
 });

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -1,28 +1,39 @@
 /**
  * MCP tool registry.
  *
- * Each entry is a self-contained descriptor: an MCP-facing name + description +
- * zod input shape, plus a `run` that maps the validated args onto an ax Effect
- * query and resolves it on the long-lived runtime. `server.ts` iterates this
- * array and wraps every result in the MCP content envelope, so adding a tool
- * (Task 3) means only appending a descriptor here - no transport changes.
+ * Each entry is a self-contained descriptor built through `defineMcpTool`: an
+ * MCP-facing name + description + zod input shape, plus a `run` that maps the
+ * *already-validated, typed* args onto an ax Effect query and resolves it on the
+ * long-lived runtime. The factory is the single boundary that:
+ *   - infers `run`'s args from the zod shape via `z.infer<ZodObject<Shape>>`
+ *     (NO hand-coercion - the args reaching `run` are typed, not `unknown`);
+ *   - parses raw args through the shape ONCE (idempotent with the SDK's own
+ *     pre-callback `safeParseAsync`, so direct `tool.run(...)` calls in tests
+ *     get the same validated input the live SDK delivers);
+ *   - carries a `register(server, rt)` closure that wires the descriptor into
+ *     the SDK with `wrapToolResult` / `wrapToolError`. Because the shape stays a
+ *     deferred generic `Shape` inside the factory, `registerTool`'s callback
+ *     type no longer eagerly expands `objectOutputType<ZodRawShape>` - which is
+ *     what hit TS2589 and forced the old `register` cast in `server.ts`.
  *
  * Boundary convention: zod for input validation at the MCP edge (the SDK speaks
  * zod natively); Effect Schema / Effect stays internal to the query functions.
  *
  * Optional-param idiom: under `exactOptionalPropertyTypes: true` you cannot
- * assign `undefined` to an optional prop. We build params with object spread -
- * `...(x !== undefined ? { x } : {})` - instead of `as`-casts, mirroring
- * `apps/axctl/src/dashboard/server.ts`.
+ * assign `undefined` to an optional prop. zod omits absent optional keys from
+ * the parsed object, so the `...(x !== undefined ? { x } : {})` spread callers
+ * keep working on the typed args, mirroring `apps/axctl/src/dashboard/server.ts`.
  */
 import { z, type ZodRawShape } from "zod";
 import { Effect, type ManagedRuntime, type Layer } from "effect";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { AppLayer } from "@ax/lib/layers";
+import { wrapToolError, wrapToolResult } from "./wrap.ts";
 import {
     fetchRecall,
     normalizeRecallParams,
     resolveRecallSources,
-    type RecallSource,
 } from "../dashboard/recall.ts";
 import {
     listSessionsAround,
@@ -79,21 +90,93 @@ export type AxRuntime = ManagedRuntime.ManagedRuntime<
 >;
 
 /**
- * A single MCP tool descriptor. `inputSchema` is a zod raw shape (the SDK's
- * `registerTool` accepts this directly and derives the JSON schema + arg type).
- * `run` receives the validated args and the runtime; it returns a raw JSON-able
- * value, which `server.ts` serialises into the MCP text content envelope.
+ * A single MCP tool descriptor produced by `defineMcpTool`.
+ *
+ * `inputSchema` is the zod raw shape (the SDK's `registerTool` accepts it
+ * directly and derives the JSON schema). `run` is the type-erased entry point
+ * used by direct callers (tests): it parses the raw args through the shape and
+ * delegates to the typed inner handler, so it always receives validated input.
+ * `register` wires the descriptor into a live `McpServer`.
  */
 export interface AxMcpTool {
     readonly name: string;
     readonly description: string;
     readonly inputSchema: ZodRawShape;
     readonly run: (args: Record<string, unknown>, rt: AxRuntime) => Promise<unknown>;
+    readonly register: (server: McpServer, rt: AxRuntime) => void;
 }
+
+/**
+ * The typed spec a tool author writes. `run` receives `z.infer<ZodObject<Shape>>`
+ * - fully typed args - and returns a raw JSON-able value.
+ */
+interface AxMcpToolSpec<Shape extends ZodRawShape> {
+    readonly name: string;
+    readonly description: string;
+    readonly inputSchema: Shape;
+    readonly run: (args: z.infer<z.ZodObject<Shape>>, rt: AxRuntime) => Promise<unknown>;
+}
+
+/**
+ * Minimal SDK registration seam. The SDK's `registerTool<InputArgs>` derives its
+ * callback type as `ToolCallback<InputArgs>` -> `ShapeOutput<InputArgs>`, a
+ * mapped type so deep that instantiating it over ANY `ZodRawShape` (generic or
+ * erased) hits TS2589. We pin the registration to this narrow signature so TS
+ * never expands that type. Type SAFETY is NOT lost: it has moved UP into
+ * `defineMcpTool`'s typed `run` boundary (args are `z.infer<ZodObject<Shape>>`),
+ * and the SDK still `safeParse`-validates args against the shape at runtime
+ * before the callback fires. This replaces the old broad `server.ts` cast that
+ * erased every tool's args to `Record<string, unknown>` and forced per-tool
+ * hand-coercion.
+ */
+type RegisterToolFn = (
+    name: string,
+    config: { description?: string; inputSchema?: ZodRawShape },
+    cb: (args: Record<string, unknown>) => Promise<CallToolResult>,
+) => unknown;
+
+/**
+ * The typed zod tool factory. Centralises the parse boundary, the
+ * `wrapToolResult`/`wrapToolError` envelope, and SDK registration so each tool
+ * is just a name + description + zod shape + a typed `run`. The typed `run`
+ * boundary is the deepening win: no tool hand-coerces `unknown` args anymore.
+ */
+export const defineMcpTool = <Shape extends ZodRawShape>(
+    spec: AxMcpToolSpec<Shape>,
+): AxMcpTool => {
+    const schema = z.object(spec.inputSchema);
+    // Parse raw args through the shape, then hand the typed result to the inner
+    // handler. The SDK already validates before its callback fires (mcp.js
+    // safeParseAsync), so this parse is idempotent on the live path; it exists
+    // so direct `tool.run(...)` callers (tests) get the same validated input.
+    const run = async (args: Record<string, unknown>, rt: AxRuntime): Promise<unknown> =>
+        spec.run(schema.parse(args), rt);
+    return {
+        name: spec.name,
+        description: spec.description,
+        inputSchema: spec.inputSchema,
+        run,
+        register: (server, rt) => {
+            const register = server.registerTool.bind(server) as unknown as RegisterToolFn;
+            register(
+                spec.name,
+                { description: spec.description, inputSchema: spec.inputSchema },
+                async (args) => {
+                    try {
+                        return wrapToolResult(await run(args, rt));
+                    } catch (err) {
+                        console.error(`[ax mcp] tool "${spec.name}" failed:`, err);
+                        return wrapToolError(err);
+                    }
+                },
+            );
+        },
+    };
+};
 
 const RECALL_SOURCES = ["turn", "commit", "skill"] as const;
 
-const recallTool: AxMcpTool = {
+const recallTool: AxMcpTool = defineMcpTool({
     name: "recall",
     description:
         `Full-text recall across the ax graph: search turns (conversation excerpts), git commits, and skills. Returns scored hits with source, excerpt, and provenance. ${NEXT_PROTOCOL_HINT}`,
@@ -112,12 +195,6 @@ const recallTool: AxMcpTool = {
             .describe('Which sources to search. Defaults to ["turn"]. Any of "turn", "commit", "skill".'),
     },
     run: async (args, rt) => {
-        const limit = typeof args.limit === "number" ? args.limit : undefined;
-        const sources = Array.isArray(args.sources)
-            ? (args.sources.filter((s): s is RecallSource =>
-                  RECALL_SOURCES.includes(s as RecallSource),
-              ))
-            : undefined;
         // No scope param in v0: omit it so fetchRecall defaults to unscoped
         // (all repositories). Real repo-scoping needs the git resolver, which
         // is unfit for a long-lived server - revisit later.
@@ -126,9 +203,9 @@ const recallTool: AxMcpTool = {
         // RAW q (previously `.trim()`ed here) to match the CLI/HTTP echo and the
         // buildRecallNext follow-up links - a deliberate contract invariant.
         const params = normalizeRecallParams({
-            q: typeof args.q === "string" ? args.q : "",
-            ...(limit !== undefined ? { limit } : {}),
-            ...(sources && sources.length > 0 ? { sources } : {}),
+            q: args.q,
+            ...(args.limit !== undefined ? { limit: args.limit } : {}),
+            ...(args.sources && args.sources.length > 0 ? { sources: args.sources } : {}),
         });
 
         const result = await rt.runPromise(fetchRecall(params));
@@ -137,15 +214,21 @@ const recallTool: AxMcpTool = {
         });
         return { ...result, hits, next };
     },
-};
+});
 
-const sessionsAroundTool: AxMcpTool = {
+const sessionsAroundTool: AxMcpTool = defineMcpTool({
     name: "sessions_around",
     description:
         `List agent sessions in a time window centred on a date (default +/-3 days). Returns an envelope { sessions, next } - session rows with turn counts and the first user message. Use to find what work happened around a given day. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {
         date: z
             .string()
+            // The lone bespoke check (was a hand-thrown Error in `run`) now lives
+            // in the schema as a `.refine`, so an invalid date yields the same
+            // uniform validation envelope every other bad arg does.
+            .refine((s) => !Number.isNaN(new Date(s).getTime()), {
+                message: "Invalid date. Expected an ISO timestamp or YYYY-MM-DD.",
+            })
             .describe("Centre date (required). ISO timestamp or YYYY-MM-DD."),
         days: z
             .number()
@@ -159,28 +242,21 @@ const sessionsAroundTool: AxMcpTool = {
             .describe("Optional Claude project slug to filter sessions to."),
     },
     run: async (args, rt) => {
-        const dateStr = String(args.date ?? "");
-        const date = new Date(dateStr);
-        if (Number.isNaN(date.getTime())) {
-            throw new Error(`Invalid date: ${JSON.stringify(args.date)}. Expected an ISO timestamp or YYYY-MM-DD.`);
-        }
-        const days = typeof args.days === "number" ? args.days : undefined;
-        const project = typeof args.project === "string" ? args.project : undefined;
         const opts = normalizeSessionsAroundOpts({
-            date,
-            ...(days !== undefined ? { days } : {}),
-            ...(project !== undefined ? { project } : {}),
+            date: new Date(args.date),
+            ...(args.days !== undefined ? { days: args.days } : {}),
+            ...(args.project !== undefined ? { project: args.project } : {}),
         });
         const rows = await rt.runPromise(listSessionsAround(opts));
         return buildSessionsNext(rows, {
-            date: dateStr,
-            ...(days !== undefined ? { days } : {}),
-            ...(project !== undefined ? { project } : {}),
+            date: args.date,
+            ...(args.days !== undefined ? { days: args.days } : {}),
+            ...(args.project !== undefined ? { project: args.project } : {}),
         });
     },
-};
+});
 
-const sessionShowTool: AxMcpTool = {
+const sessionShowTool: AxMcpTool = defineMcpTool({
     name: "session_show",
     description:
         `Show one session in detail: base facts, optionally expanded subagent children, and optional skill-by-role grouping. Use after sessions_around / recall to drill into a specific session id. ${NEXT_PROTOCOL_HINT}`,
@@ -202,33 +278,29 @@ const sessionShowTool: AxMcpTool = {
             .describe("Group the session's top skills by their role classifications."),
     },
     run: async (args, rt) => {
-        const sessionId = String(args.sessionId ?? "");
-        const expand = Array.isArray(args.expand)
-            ? new Set(args.expand.map((v) => String(v)))
-            : new Set<string>();
+        const expand = new Set(args.expand ?? []);
         const expandAll = args.expandAll === true;
-        const byRole = typeof args.byRole === "boolean" ? args.byRole : undefined;
         // Read through the Enriched Session facade (the single home for
         // assembling a session read model). The MCP tool needs the Session View
         // base only - no metrics/insights - so the response shape is the bare
         // SessionViewPayload, identical to the former fetchSessionShow call.
         const enriched = await rt.runPromise(
             fetchEnrichedSession({
-                sessionId,
+                sessionId: args.sessionId,
                 base: {
                     kind: "view",
                     expand,
                     expandAll,
-                    ...(byRole !== undefined ? { byRole } : {}),
+                    ...(args.byRole !== undefined ? { byRole: args.byRole } : {}),
                 },
             }),
         );
         const payload = enriched.view!;
         return { ...payload, next: buildSessionShowNext(payload) };
     },
-};
+});
 
-const skillsWeightedTool: AxMcpTool = {
+const skillsWeightedTool: AxMcpTool = defineMcpTool({
     name: "skills_weighted",
     description:
         `Rank skills by usage x role-weight (score = invocations x role-weight). Returns ranked rows plus a doctor summary of unclassified skills. Use to see which skills actually carry weight in recent work. ${NEXT_PROTOCOL_HINT}`,
@@ -247,18 +319,16 @@ const skillsWeightedTool: AxMcpTool = {
             .describe("Max ranked rows to return (default 25)."),
     },
     run: async (args, rt) => {
-        const windowDays = typeof args.windowDays === "number" ? args.windowDays : undefined;
-        const limit = typeof args.limit === "number" ? args.limit : undefined;
         const params = normalizeSkillsWeightedParams({
-            ...(windowDays !== undefined ? { windowDays } : {}),
-            ...(limit !== undefined ? { limit } : {}),
+            ...(args.windowDays !== undefined ? { windowDays: args.windowDays } : {}),
+            ...(args.limit !== undefined ? { limit: args.limit } : {}),
         });
         const result = await rt.runPromise(fetchSkillsWeighted(params));
         return { ...result, next: buildSkillsWeightedNext(result) };
     },
-};
+});
 
-const skillsByRoleTool: AxMcpTool = {
+const skillsByRoleTool: AxMcpTool = defineMcpTool({
     name: "skills_by_role",
     description:
         `List skills tagged with a given role, ranked by invocation count. Returns rows with source/confidence/rationale and whether any skill matched the role. ${NEXT_PROTOCOL_HINT}`,
@@ -274,18 +344,16 @@ const skillsByRoleTool: AxMcpTool = {
             .describe("Max skills to return (default 50)."),
     },
     run: async (args, rt) => {
-        const role = String(args.role ?? "");
-        const limit = typeof args.limit === "number" ? args.limit : undefined;
         const params = normalizeSkillsByRoleParams({
-            role,
-            ...(limit !== undefined ? { limit } : {}),
+            role: args.role,
+            ...(args.limit !== undefined ? { limit: args.limit } : {}),
         });
         const result = await rt.runPromise(fetchSkillsByRole(params));
-        return { ...result, next: buildSkillsByRoleNext(result, role) };
+        return { ...result, next: buildSkillsByRoleNext(result, args.role) };
     },
-};
+});
 
-const skillsRolesTool: AxMcpTool = {
+const skillsRolesTool: AxMcpTool = defineMcpTool({
     name: "skills_roles",
     description:
         `List the roles a given skill plays, with weights, source, confidence and rationale. Returns whether the skill exists. The inverse of skills_by_role. ${NEXT_PROTOCOL_HINT}`,
@@ -295,13 +363,12 @@ const skillsRolesTool: AxMcpTool = {
             .describe("Skill name to look up roles for (required)."),
     },
     run: async (args, rt) => {
-        const skill = String(args.skill ?? "");
-        const result = await rt.runPromise(fetchRolesForSkill({ skill }));
-        return { ...result, next: buildSkillsRolesNext(result, skill) };
+        const result = await rt.runPromise(fetchRolesForSkill({ skill: args.skill }));
+        return { ...result, next: buildSkillsRolesNext(result, args.skill) };
     },
-};
+});
 
-const rolesTool: AxMcpTool = {
+const rolesTool: AxMcpTool = defineMcpTool({
     name: "roles",
     description:
         `List the full role vocabulary with each role's weight and the number of skills classified into it. Use to discover valid role labels for skills_by_role. ${NEXT_PROTOCOL_HINT}`,
@@ -310,11 +377,11 @@ const rolesTool: AxMcpTool = {
         const result = await rt.runPromise(fetchAllRoles());
         return { ...result, next: buildRolesNext(result) };
     },
-};
+});
 
 const RECOMMEND_AGENTS = ["claude", "codex"] as const;
 
-const improveRecommendTool: AxMcpTool = {
+const improveRecommendTool: AxMcpTool = defineMcpTool({
     name: "improve_recommend",
     description:
         `Rank open self-improvement proposals by confidence x recency x frequency. Returns an envelope { proposals, next } - the shortlist of grounded suggestions the agent could accept. Use to surface what to improve next. ${NEXT_PROTOCOL_HINT}`,
@@ -345,19 +412,12 @@ const improveRecommendTool: AxMcpTool = {
         // meaningless at the MCP boundary). The MCP limit default is 10 (the
         // CLI's is 5) - both pass their own default into the shared normalizer,
         // which is why `defaultLimit` is a parameter rather than baked in.
-        const limit = typeof args.limit === "number" ? args.limit : undefined;
-        const forms = Array.isArray(args.forms)
-            ? args.forms.map((v) => String(v))
-            : undefined;
-        const agent =
-            args.agent === "claude" || args.agent === "codex" ? args.agent : undefined;
-        const sinceDays = typeof args.sinceDays === "number" ? args.sinceDays : undefined;
         const input = normalizeRecommendInput(
             {
-                ...(limit !== undefined ? { limit } : {}),
-                ...(forms !== undefined ? { forms } : {}),
-                ...(agent !== undefined ? { agent } : {}),
-                ...(sinceDays !== undefined ? { sinceDays } : {}),
+                ...(args.limit !== undefined ? { limit: args.limit } : {}),
+                ...(args.forms !== undefined ? { forms: args.forms } : {}),
+                ...(args.agent !== undefined ? { agent: args.agent } : {}),
+                ...(args.sinceDays !== undefined ? { sinceDays: args.sinceDays } : {}),
             },
             10,
         );
@@ -367,9 +427,9 @@ const improveRecommendTool: AxMcpTool = {
         );
         return { proposals: items, next };
     },
-};
+});
 
-const improveShowTool: AxMcpTool = {
+const improveShowTool: AxMcpTool = defineMcpTool({
     name: "improve_show",
     description:
         "Show one experiment's evidence trail: the proposal, its experiment, and recent checkpoints. Returns null if no proposal/experiment matches. Use to inspect a single improve_recommend / improve_list entry.",
@@ -379,13 +439,12 @@ const improveShowTool: AxMcpTool = {
             .describe("Proposal dedupe signature or experiment id (required)."),
     },
     run: async (args, rt) => {
-        const sigOrId = String(args.sigOrId ?? "");
         // null is a valid result (no match) - return it as plain JSON.
-        return await rt.runPromise(showExperiment({ sigOrId }));
+        return await rt.runPromise(showExperiment({ sigOrId: args.sigOrId }));
     },
-};
+});
 
-const improveListTool: AxMcpTool = {
+const improveListTool: AxMcpTool = defineMcpTool({
     name: "improve_list",
     description:
         `List the experiment-loop proposal shortlist, filterable by status and form. Returns an envelope { proposals, next } - proposal rows ordered by frequency. Use to browse proposals beyond the ranked improve_recommend view. ${NEXT_PROTOCOL_HINT}`,
@@ -406,13 +465,10 @@ const improveListTool: AxMcpTool = {
             .describe("Max proposals to return (default 30)."),
     },
     run: async (args, rt) => {
-        const status = typeof args.status === "string" ? args.status : undefined;
-        const form = typeof args.form === "string" ? args.form : undefined;
-        const limit = typeof args.limit === "number" ? args.limit : undefined;
         const input = normalizeListProposalsInput({
-            ...(status !== undefined ? { status } : {}),
-            ...(form !== undefined ? { form } : {}),
-            ...(limit !== undefined ? { limit } : {}),
+            ...(args.status !== undefined ? { status: args.status } : {}),
+            ...(args.form !== undefined ? { form: args.form } : {}),
+            ...(args.limit !== undefined ? { limit: args.limit } : {}),
         });
         const rows = await rt.runPromise(listProposals(input));
         const next = buildImproveProposalsNext(
@@ -420,9 +476,9 @@ const improveListTool: AxMcpTool = {
         );
         return { proposals: rows, next };
     },
-};
+});
 
-const sessionMetricsTool: AxMcpTool = {
+const sessionMetricsTool: AxMcpTool = defineMcpTool({
     name: "session_metrics",
     description:
         "Graph-derived per-session metrics: durability ratio (commits not later reverted), produced commits, time-to-land (commit -> PR merge), lines added/removed, first-edit latency, cold-start reads, delegation ratio, estimated cost, and user corrections. Sorted by produced commits (desc), then most fragile first.",
@@ -447,22 +503,19 @@ const sessionMetricsTool: AxMcpTool = {
             .describe("Filter to sessions whose project or cwd equals this path (e.g. a repo root)."),
     },
     run: async (args, rt) => {
-        const sinceDays = typeof args.sinceDays === "number" ? args.sinceDays : undefined;
         // Mirror the CLI's clamp (1..3650 days) so MCP and `ax sessions metrics`
         // agree on window semantics.
-        const since = sinceDays !== undefined
-            ? new Date(Date.now() - Math.min(Math.max(Math.trunc(sinceDays), 1), 3650) * 86_400_000)
+        const since = args.sinceDays !== undefined
+            ? new Date(Date.now() - Math.min(Math.max(Math.trunc(args.sinceDays), 1), 3650) * 86_400_000)
             : null;
-        const limit = typeof args.limit === "number" ? args.limit : 50;
+        const limit = args.limit ?? 50;
         const project =
-            typeof args.project === "string" && args.project.length > 0
-                ? args.project
-                : null;
+            args.project !== undefined && args.project.length > 0 ? args.project : null;
         return await rt.runPromise(fetchSessionMetrics({ since, limit, project }));
     },
-};
+});
 
-const signalShowTool: AxMcpTool = {
+const signalShowTool: AxMcpTool = defineMcpTool({
     name: "signal_show",
     description:
         "Signal catalog access. With no `id`: list all signal descriptors (id, kind, label, description). With an `id` (e.g. fragility_cascade): run that relation signal and return its edges sorted by weight (descending). Unknown ids error with the list of valid ids.",
@@ -480,10 +533,9 @@ const signalShowTool: AxMcpTool = {
             .describe("Max edges to return when running a signal (default 30)."),
     },
     run: async (args, rt) => {
-        const id =
-            typeof args.id === "string" && args.id.trim().length > 0
-                ? args.id.trim()
-                : undefined;
+        // A blank id is treated as "list the catalog" - domain semantics, not
+        // type coercion, so the trim/empty branch stays.
+        const id = args.id !== undefined && args.id.trim().length > 0 ? args.id.trim() : undefined;
         if (id === undefined) {
             return { signals: SIGNAL_CATALOG };
         }
@@ -500,14 +552,14 @@ const signalShowTool: AxMcpTool = {
                 note: "aggregate signals are not runnable via MCP yet",
             };
         }
-        const limit = typeof args.limit === "number" ? args.limit : 30;
+        const limit = args.limit ?? 30;
         const all = await rt.runPromise(runRelationSignal(descriptor.id));
         const edges = [...all].sort((a, b) => b.weight - a.weight).slice(0, limit);
         return { signal: descriptor, edges };
     },
-};
+});
 
-const costModelsTool: AxMcpTool = {
+const costModelsTool: AxMcpTool = defineMcpTool({
     name: "cost_models",
     description:
         `Per-model cost rollup over session_token_usage: sessions count, prompt/completion/cache tokens, estimated cost USD, sorted by cost desc. Includes an "(unattributed)" row for sessions with no model recorded. ${NEXT_PROTOCOL_HINT}`,
@@ -520,13 +572,13 @@ const costModelsTool: AxMcpTool = {
             .describe("Window in days (default 14)."),
     },
     run: async (args, rt) => {
-        const days = typeof args.days === "number" ? args.days : COST_DEFAULT_WINDOW_DAYS;
+        const days = args.days ?? COST_DEFAULT_WINDOW_DAYS;
         const result = await rt.runPromise(fetchCostModels({ sinceDays: days }));
         return { ...result, next: buildCostModelsNext(result) };
     },
-};
+});
 
-const costSplitTool: AxMcpTool = {
+const costSplitTool: AxMcpTool = defineMcpTool({
     name: "cost_split",
     description:
         `Cost matrix split by origin (main = non-subagent, subagent = claude-subagent) x model. Returns rows with cost, token sums, and share-of-total percent, plus a totals row. Use to understand how much subagent dispatch costs relative to top-level sessions. ${NEXT_PROTOCOL_HINT}`,
@@ -539,13 +591,13 @@ const costSplitTool: AxMcpTool = {
             .describe("Window in days (default 14)."),
     },
     run: async (args, rt) => {
-        const days = typeof args.days === "number" ? args.days : COST_DEFAULT_WINDOW_DAYS;
+        const days = args.days ?? COST_DEFAULT_WINDOW_DAYS;
         const result = await rt.runPromise(fetchCostSplit({ sinceDays: days }));
         return { ...result, next: buildCostSplitNext(result) };
     },
-};
+});
 
-const costRoutabilityTool: AxMcpTool = {
+const costRoutabilityTool: AxMcpTool = defineMcpTool({
     name: "cost_routability",
     description:
         `Main-thread routability lens: of main-agent (non-subagent) spend, how much sat in routable class-runs (gather -> haiku, mechanical-impl / niche-research -> sonnet) vs genuine judgment, with estimated savings repriced one tier down. Deterministic (tool composition + JUDGMENT_GUARD_RE text guard); turn-level by default. Use to see how much main-thread work could have been a cheaper subagent. ${NEXT_PROTOCOL_HINT}`,
@@ -564,14 +616,14 @@ const costRoutabilityTool: AxMcpTool = {
             .describe("Min consecutive same-class turns for a span to count (default 1)."),
     },
     run: async (args, rt) => {
-        const days = typeof args.days === "number" ? args.days : 30;
-        const minRun = typeof args.min_run === "number" ? args.min_run : 1;
+        const days = args.days ?? 30;
+        const minRun = args.min_run ?? 1;
         const result = await rt.runPromise(fetchRoutability({ days, minRun }));
         return result;
     },
-};
+});
 
-const dispatchesTool: AxMcpTool = {
+const dispatchesTool: AxMcpTool = defineMcpTool({
     name: "dispatches",
     description:
         `Subagent dispatch analytics over the spawned relation. Without candidates: table of dispatches sorted by child cost (ts, agent_type, description, dispatch_model, child_model, child_cost_usd) + summary (count, inherit%, total cost). With candidates=true: only inherit dispatches on expensive models (fable/opus) that match a routing class, with suggested model + est savings. ${NEXT_PROTOCOL_HINT}`,
@@ -594,7 +646,7 @@ const dispatchesTool: AxMcpTool = {
             .describe("When true, return only routing-optimisation candidates with est savings."),
     },
     run: async (args, rt) => {
-        const days = typeof args.days === "number" ? args.days : COST_DEFAULT_WINDOW_DAYS;
+        const days = args.days ?? COST_DEFAULT_WINDOW_DAYS;
         const candidates = args.candidates === true;
         if (candidates) {
             // Match against the live routing table (same file the hook and the
@@ -607,13 +659,13 @@ const dispatchesTool: AxMcpTool = {
             );
             return { ...result, next: buildCandidatesNext(result) };
         }
-        const limit = typeof args.limit === "number" ? args.limit : 30;
+        const limit = args.limit ?? 30;
         const result = await rt.runPromise(fetchDispatches({ sinceDays: days, limit }));
         return { ...result, next: buildDispatchesNext(result) };
     },
-};
+});
 
-const dojoAgendaTool: AxMcpTool = {
+const dojoAgendaTool: AxMcpTool = defineMcpTool({
     name: "dojo_agenda",
     description:
         "Dojo training agenda for surplus-quota self-improvement: budget envelope (window remaining minus reserve, deadline = window reset) + prioritized work items (pending verdicts, unfilled briefs, routing backtests, proposal minting, churn experiments, optional sparring). Mirrors `ax dojo agenda`. Read-only.",
@@ -631,7 +683,7 @@ const dojoAgendaTool: AxMcpTool = {
     },
     run: async (args, rt) => {
         const nowMs = Date.now();
-        const days = typeof args.days === "number" ? args.days : 30;
+        const days = args.days ?? 30;
         const spar = args.spar === true;
         return await rt.runPromise(
             Effect.gen(function* () {
@@ -651,7 +703,7 @@ const dojoAgendaTool: AxMcpTool = {
             }).pipe(Effect.provide(QuotaEnvLive)),
         );
     },
-};
+});
 
 /**
  * All registered MCP tools. `server.ts` iterates this array to register +

--- a/apps/axctl/src/mcp/wrap.ts
+++ b/apps/axctl/src/mcp/wrap.ts
@@ -1,0 +1,33 @@
+/**
+ * MCP result-envelope helpers.
+ *
+ * Lives in its own module so BOTH the transport (`server.ts`) and the tool
+ * factory (`tools.ts`) can import it without a server<->tools import cycle.
+ *
+ * IMPORTANT: stdio MCP servers communicate JSON-RPC over stdout. These helpers
+ * produce the JSON-RPC RESPONSE body (returned to the SDK), never a stdout log.
+ */
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Wrap a raw tool result in the MCP content envelope. Centralised so every
+ * registered tool gets identical serialisation: JSON pretty-printed into a
+ * single text block.
+ */
+export const wrapToolResult = (result: unknown): CallToolResult => ({
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+});
+
+/**
+ * Wrap a thrown error as an MCP error result. The message is surfaced as text
+ * (this is the JSON-RPC response body, not a stdout log).
+ */
+export const wrapToolError = (err: unknown): CallToolResult => ({
+    isError: true,
+    content: [
+        {
+            type: "text",
+            text: err instanceof Error ? err.message : String(err),
+        },
+    ],
+});


### PR DESCRIPTION
## What

A typed zod **tool factory** for the MCP server. `defineMcpTool<Shape>` infers each tool's `run` args from its zod shape via `z.infer<ZodObject<Shape>>` and centralises the parse boundary, the `wrapToolResult`/`wrapToolError` envelope, and SDK registration. All 17 read-only tools route through it.

> Stacked on **#A1** (`arch/a1-recall-contract`). The base of this PR is `arch/a1-recall-contract`, so the diff is just B's change. The recall tool's `normalizeRecallParams` routing comes from A1 and is preserved.

## Why - TS2589 root cause

The SDK's `ToolCallback<InputArgs>` → `ShapeOutput<InputArgs>` is a mapped type so deep that instantiating it over *any* `ZodRawShape` (generic or erased) hits **TS2589 "excessively deep"**. The old `server.ts:54-63` worked around this with a broad cast that erased every tool's args to `Record<string, unknown>` - which is exactly why each tool's `run` had to hand-coerce (`typeof x === "number" ? x : undefined`, `Array.isArray(...)`, `String(args.x ?? "")`).

The factory fixes the root cause by moving type safety **up** into the typed `run` boundary (args are `z.infer`'d, not `unknown`). The only remaining cast is a single, narrow, well-documented seam at the SDK `registerTool` call - the unavoidable cost of the SDK's own deep generic. The `server.ts` cast block is **deleted**; `buildServer` is now a plain typed loop over `tool.register(server, rt)`.

## Changes

- **`defineMcpTool` factory** (`mcp/tools.ts`) - typed `run`, parses args through the shape once (idempotent with the SDK's own pre-callback `safeParseAsync`, so direct `tool.run(...)` test calls get the same validated input the live SDK delivers), carries a `register(server, rt)` closure.
- **Delete the dead per-tool coercion** in every `run`. The SDK `safeParse`-validates args *before* the callback fires (`@modelcontextprotocol/sdk/.../server/mcp.js` L172-180), so the `typeof`/`Array.isArray`/`String(... ?? "")` blocks were unreachable defensive code.
- **Move the lone bespoke check** (sessions_around date parse) into a zod `.refine` - a free uniform validation envelope, message preserved (`/Invalid date/`).
- **Extract `wrapToolResult`/`wrapToolError`** to `mcp/wrap.ts` (server re-exports them) to avoid a server↔tools import cycle.
- **Behavior parity**: every `normalize*` / `buildXNext` call is unchanged; branching tools (`signal_show`, `dispatches --candidates`, `dojo_agenda`) keep their control flow inside `run`; AppLayer + QuotaEnvLive provided as before; the error envelope (`isError` text) and `{...result, next}` passthrough are intact. One documented change: wrong-typed args are now rejected at the schema boundary instead of silently ignored - this **matches production**, where the SDK already `safeParse`-rejected them before the callback.

## Tier-2 chosen over Tier-1 (spike deferred)

This ships **tier 2 only** - the zod `z.infer` factory on the existing `McpServer.registerTool` + zod SDK. **Tier 1** (Effect-native `McpServer` via `effect/unstable/ai`) is gated on a decisive live Claude-Code↔MCP stdio interop spike (tools/list + tools/call + isError envelope parity, stdout-is-sacred) that cannot run in a headless context, so it is deferred. The zod tier is the safe floor and unblocks the rest of the backbone.

## Contract-duplication premise rejected

The original candidate's "16 adapters duplicate the HttpApi contract / two sources of truth drift" framing was verified **false**: the zod `inputSchema`s in `tools.ts` are the **sole** source for MCP inputs, do not mirror `api-contract.ts`, and 5+ tools have no HTTP endpoint at all. `api-contract.ts` is intentionally **not** wired in; MCP inputs stay co-located zod schemas.

## Verification

- `bun test apps/axctl/src/mcp/` → **28 pass / 0 fail** (was 20; added characterization of the advertised tool list + per-tool input shapes, and pure `defineMcpTool` unit tests).
- `bun test apps/axctl/src` → **3198 pass / 0 fail**.
- `bunx tsc -p apps/axctl/tsconfig.json --noEmit` → **0 errors, no TS2589** (the cast removal is the point - inference holds at the typed `run` boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
