### PR TITLE
feat: seed the ax team rig (.ax/skills + .ax/agents) for `ax team sync`

### DIFF
--- a/.ax/agents/ax-schema-reviewer.md
+++ b/.ax/agents/ax-schema-reviewer.md
@@ -1,0 +1,11 @@
+---
+name: ax-schema-reviewer
+description: Reviews ax SurrealDB schema + ingest-stage changes for the registration gotchas that fail CI.
+---
+You review changes to ax's schema and ingest pipeline. Check, in order:
+1. Every new `DEFINE TABLE` in schema.surql is registered in SCHEMA_TABLES (insights.ts).
+2. Every new derive stage is in the registry union + ALL_STAGES, and effect-cli.test.ts's stage count + --derive-only list are updated.
+3. Stage bodies are failure-isolated (Effect.catchCause), never aborting ingest.
+4. New CLI subcommands appear in BOTH cli-reference gates.
+5. No `node:fs` (check:no-node-fs gate) — use Bun fs.
+Report concrete file:line findings, not generic advice.

--- a/.ax/skills/ax-add-ingest-stage/SKILL.md
+++ b/.ax/skills/ax-add-ingest-stage/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: ax-add-ingest-stage
+description: Use when adding a new ingest stage or a new SurrealDB table to the ax graph. Encodes the exact registration gotchas that fail CI if missed.
+---
+
+# Adding an ingest stage / table to ax
+
+Hard-won checklist - each step below has a CI gate that fails if you skip it.
+
+## New SurrealDB table
+1. Add the `DEFINE TABLE ... SCHEMAFULL` + fields to `packages/schema/src/schema.surql` (top-level fields explicit; nested objects → JSON-encoded `string`; datetimes via JS `Date`).
+2. **Register it in `SCHEMA_TABLES`** (`apps/axctl/src/queries/insights.ts`) - a mirror test diffs `DEFINE TABLE` names vs `SCHEMA_TABLES` and **fails CI** if missing.
+3. In a worktree, run `bun install` so `@ax/schema` resolves to the worktree copy (not the main tree's symlink) before the mirror test will pass.
+
+## New `derive`-tagged ingest stage
+1. Co-locate the `StageDef` at the bottom of the stage file (mirror `apps/axctl/src/ingest/derive-opportunities.ts`): `export const FooKey = Schema.Literal("foo")` + `fooStage`.
+2. Register in `apps/axctl/src/ingest/stage/registry.ts`: add the import, add `FooKey` to the `IngestStageKey` `Schema.Union([...])`, add `fooStage` to `ALL_STAGES`.
+3. **Update `apps/axctl/src/cli/effect-cli.test.ts`**: bump the `resolveIngestStages: default runs every stage` `.toHaveLength(N)` by 1, and add your key (sorted) to the `--derive-only` list. CI fails otherwise.
+4. **Isolate failures**: wrap the stage body in `Effect.catchCause` returning a zero-row stat, so a stage error never aborts the surrounding ingest.
+
+## New CLI subcommand
+Document it in **BOTH** cli-reference gates or CI fails: `docs/cli.md` (or README) + `apps/site/public/llms.txt` (scripts/check-cli-reference.ts), AND a card in `apps/site/app/routes/docs/-cli-reference.data.ts` (scripts/check-site-cli-reference.test.ts).
+
+## Effect v4 beta gotchas
+- Multi-arg `Schema.Literal(...)` collapses → use `Schema.Literals([...])`.
+- `Schema.Date` doesn't JSON round-trip → use `Schema.DateFromString.check(Schema.isDateValid())`.

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,13 @@ dist/
 .worktrees/
 .superpowers/
 
-# local agent + harness state
-.ax/
+# local agent + harness state (.ax/* ignores direct children + their trees, but
+# leaves .ax/ itself includable so the committed team rig can be re-included below)
+.ax/*
 .claude/agents/
+# ...except the committed team rig (ax team sync): skills + agents are versioned
+!.ax/skills/
+!.ax/agents/
 # committed named workflows (Bun-repo pattern) - keep *.workflow.js versioned,
 # ignore everything else in the dir (gitignore can't re-include inside an
 # excluded DIRECTORY, so exclude contents with /* instead)


### PR DESCRIPTION
## What

Dogfooding `ax team sync` (just merged, #440) on the ax repo itself — a real team rig:

- **`.ax/skills/ax-add-ingest-stage/SKILL.md`** — the schema-table + ingest-stage **registration gotchas that fail CI** (SCHEMA_TABLES mirror, registry union + `effect-cli.test.ts` count, both cli-reference gates, Effect v4 `Literals`/`DateFromString`). Real, hard-won ax-team knowledge.
- **`.ax/agents/ax-schema-reviewer.md`** — an agent that reviews schema/ingest changes for exactly those gotchas.

Run `ax team sync` from this repo to activate them into your runtime.

## The `.gitignore` mechanism (a real dogfood finding)

`.ax/` (and `.claude/agents/`) are **gitignored** in ax — they're local scratch (tasks/experiments/dojo state). The committed team rig must be carved out. The fix: `.ax/*` (ignore direct children + their trees) instead of `.ax/` (wholesale), so `!.ax/skills/` + `!.ax/agents/` can re-include the rig while `.ax/tasks`, `.ax/dojo`, `.ax/experiments` stay ignored. (Git can't re-include under a wholesale-excluded dir — hence `.ax/*`.)

This is a useful input to the team-backend spec: the "plain tracked `.ax/` folder" decision needs this gitignore carve-out (or a non-ignored folder).

## Test
- [x] `ax team sync` (no `--yes`) lists the 2 artifacts, activates nothing
- [x] `--yes` activates skill + agent into `~/.claude/`; the synced skill loaded live in the harness
- [x] `.ax/skills` + `.ax/agents` tracked; `.ax/tasks`/`.ax/dojo`/`.ax/experiments` stay ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)