### PR TITLE
feat(site): blog section + origin-grade article system

### DIFF
--- a/apps/site/app/components/landing-sections/site-header.tsx
+++ b/apps/site/app/components/landing-sections/site-header.tsx
@@ -34,6 +34,7 @@ export function SiteHeader() {
         <Link to="/showcases">Showcases</Link>
         <Link to="/leaders">Leaders</Link>
         <Link to="/how-it-works">How</Link>
+        <Link to="/blog">Blog</Link>
         <Link to="/docs">Docs</Link>
         <Link to="/origin">Origin</Link>
         <a

--- a/apps/site/app/components/mdx-components.tsx
+++ b/apps/site/app/components/mdx-components.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, ReactNode } from "react";
+import { Children, isValidElement, type ComponentProps, type ReactElement, type ReactNode } from "react";
 
 // ============================================================================
 // MDX article component kit
@@ -160,6 +160,202 @@ export function KBD({ children }: { children?: ReactNode }) {
   return <kbd className="bk-kbd">{children}</kbd>;
 }
 
+// --- SplitBar / SplitSeg ----------------------------------------------------
+// One horizontal stacked bar that makes a proportional split obvious at a
+// glance: the dominant segment is the ink mass, minor ones are tinted slivers.
+// origin's bar-chart language - token-driven fills, mono legend, hairline rule.
+// Composable like StatGrid/Stat: <SplitSeg> is a pure data carrier the parent
+// reads via Children, so it renders the bar AND the legend deterministically.
+type SplitTone = "ink" | "green" | "muted";
+
+type SplitSegProps = {
+  /** legend label, e.g. "main agent" */
+  label: ReactNode;
+  /** preformatted amount, e.g. "$21,015.22" (kept exact, not computed) */
+  amount: ReactNode;
+  /** share, doubles as the bar segment width, e.g. "84.0%" */
+  pct: string;
+  tone?: SplitTone;
+};
+
+// Marker component - never renders on its own; SplitBar reads its props.
+export function SplitSeg(_props: SplitSegProps) {
+  return null;
+}
+
+type SplitBarProps = {
+  /** preformatted grand total for the legend total row, e.g. "$25,027.00" */
+  total?: ReactNode;
+  /** label for the total row (default "total") */
+  totalLabel?: ReactNode;
+  children?: ReactNode;
+};
+
+export function SplitBar({ total, totalLabel = "total", children }: SplitBarProps) {
+  const segs = Children.toArray(children).filter(isValidElement) as ReactElement<SplitSegProps>[];
+  return (
+    <div className="bk-split">
+      <div className="bk-split-bar" role="img" aria-label="proportional cost split">
+        {segs.map((s, i) => (
+          <span
+            key={i}
+            className={`bk-split-seg bk-tone-${s.props.tone ?? "ink"}`}
+            style={{ width: s.props.pct }}
+          >
+            <span className="bk-split-seg-in">{s.props.pct}</span>
+          </span>
+        ))}
+      </div>
+      <div className="bk-split-legend">
+        {segs.map((s, i) => (
+          <div key={i} className="bk-split-leg">
+            <span className={`bk-split-dot bk-tone-${s.props.tone ?? "ink"}`} aria-hidden />
+            <span className="bk-split-leg-label">{s.props.label}</span>
+            <span className="bk-split-leg-amt">{s.props.amount}</span>
+            <span className="bk-split-leg-pct">{s.props.pct}</span>
+          </div>
+        ))}
+        {total ? (
+          <div className="bk-split-leg bk-split-leg-total">
+            <span className="bk-split-dot bk-split-dot-empty" aria-hidden />
+            <span className="bk-split-leg-label">{totalLabel}</span>
+            <span className="bk-split-leg-amt">{total}</span>
+            <span className="bk-split-leg-pct">100.0%</span>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// --- BarChart / Bar ---------------------------------------------------------
+// Horizontal bar chart: one row per item, bar fill proportional to `value`.
+// The peak (most expensive) bar gets a hot tone (origin's red peak); the rest
+// are ink. Widths are computed in JS from value/max - fully deterministic, so
+// SSR/prerender produce identical markup. <Bar> is a marker like <SplitSeg>.
+type BarProps = {
+  /** row label, rendered mono (e.g. a model name) */
+  name: ReactNode;
+  /** preformatted value, e.g. "$1,979.34" (kept exact) */
+  amount: ReactNode;
+  /** optional share, e.g. "7.9%" */
+  pct?: ReactNode;
+  /** numeric magnitude that drives bar width */
+  value: number;
+  /** muted sub-note under the bar, e.g. "247 sessions" */
+  sub?: ReactNode;
+  /** mark the hot/peak bar (the max); gets the warm tone */
+  peak?: boolean;
+};
+
+export function Bar(_props: BarProps) {
+  return null;
+}
+
+type BarChartProps = {
+  /** mono eyebrow above the chart */
+  label?: ReactNode;
+  /** override the max used for proportional widths (default = largest value) */
+  max?: number;
+  children?: ReactNode;
+};
+
+export function BarChart({ label, max, children }: BarChartProps) {
+  const bars = Children.toArray(children).filter(isValidElement) as ReactElement<BarProps>[];
+  const peak = bars.reduce((m, b) => Math.max(m, b.props.value), 0);
+  const denom = max ?? peak ?? 1;
+  return (
+    <div className="bk-barchart">
+      {label ? <span className="bk-barchart-label">{label}</span> : null}
+      {bars.map((b, i) => {
+        const ratio = denom > 0 ? b.props.value / denom : 0;
+        const width = `${Math.max(0, Math.min(100, ratio * 100)).toFixed(2)}%`;
+        return (
+          <div className="bk-bar-row" key={i}>
+            <div className="bk-bar-head">
+              <span className="bk-bar-name">{b.props.name}</span>
+              <span className="bk-bar-amt">{b.props.amount}</span>
+              {b.props.pct ? <span className="bk-bar-pct">{b.props.pct}</span> : null}
+            </div>
+            <div className="bk-bar-track">
+              <span
+                className={`bk-bar-fill${b.props.peak ? " bk-bar-fill-peak" : ""}`}
+                style={{ width }}
+              />
+            </div>
+            {b.props.sub ? <span className="bk-bar-sub">{b.props.sub}</span> : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- AxResult ---------------------------------------------------------------
+// A colorized terminal receipt for `ax` command output. The author passes the
+// raw output as a single string child:
+//   <AxResult>{`$ ax cost split\n...`}</AxResult>
+// Each line is tokenized with small, deterministic regexes so the money (the
+// signal) reads green, percentages blue, drop/off-model markers red, model
+// names a subtle tint, the `$ ...` prompt line dim. SSR-safe (pure string ops).
+
+// One alternation, capture-group order = token class. Kept narrow on purpose
+// (2-4 colors, scannability not a rainbow).
+const AX_TOKEN =
+  /(\$[\d,]+(?:\.\d{1,2})?)|(\d+(?:\.\d+)?%)|(claude-[a-z0-9.-]+|\b(?:sonnet|haiku|opus|fable)\b)|(\boff-model\b|\bdropped\b|!)/g;
+
+function tokenizeAxLine(line: string, lineKey: number): ReactNode {
+  // The command/prompt line reads dim - it's the input, not the result.
+  if (/^\s*\$\s/.test(line)) {
+    return <span className="bk-ax-cmd">{line}</span>;
+  }
+  // Comments (# ...) stay muted too.
+  if (/^\s*#/.test(line)) {
+    return <span className="bk-ax-cmd">{line}</span>;
+  }
+  const out: ReactNode[] = [];
+  let last = 0;
+  let key = 0;
+  AX_TOKEN.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = AX_TOKEN.exec(line)) !== null) {
+    if (m.index > last) out.push(line.slice(last, m.index));
+    const cls = m[1]
+      ? "bk-ax-money"
+      : m[2]
+        ? "bk-ax-pct"
+        : m[3]
+          ? "bk-ax-model"
+          : "bk-ax-warn";
+    out.push(
+      <span className={cls} key={`${lineKey}-${key++}`}>
+        {m[0]}
+      </span>,
+    );
+    last = m.index + m[0].length;
+  }
+  if (last < line.length) out.push(line.slice(last));
+  return out;
+}
+
+export function AxResult({ children }: { children?: ReactNode }) {
+  const raw = typeof children === "string" ? children : String(children ?? "");
+  const text = raw.replace(/^\n+/, "").replace(/\s+$/, "");
+  const lines = text.split("\n");
+  return (
+    <pre className="bk-axresult">
+      <code>
+        {lines.map((ln, i) => (
+          <span className="bk-ax-line" key={i}>
+            {tokenizeAxLine(ln, i)}
+            {i < lines.length - 1 ? "\n" : null}
+          </span>
+        ))}
+      </code>
+    </pre>
+  );
+}
+
 // ----------------------------------------------------------------------------
 // Components map handed to <MDXContent>. The lowercase `a` keeps external links
 // safe; the capitalized entries are the article kit. Prose typography itself is
@@ -183,4 +379,9 @@ export const mdxComponents = {
   FrameworkList,
   FrameworkItem,
   KBD,
+  SplitBar,
+  SplitSeg,
+  BarChart,
+  Bar,
+  AxResult,
 };

--- a/apps/site/app/components/mdx-components.tsx
+++ b/apps/site/app/components/mdx-components.tsx
@@ -1,10 +1,170 @@
-import type { ComponentProps } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
-// Plain semantic elements - all typography is owned by the `.prose` scope in
-// globals.css (Tailwind utilities are dead here: they live in a cascade layer
-// the unlayered design-system rules override). Keeping these as thin
-// pass-throughs lets rehype-pretty-code's `pre`/`code` output flow through
-// untouched while `.prose` handles spacing, color, and rhythm.
+// ============================================================================
+// MDX article component kit
+//
+// Origin-grade editorial components for the ax blog. Every `.md`/`.mdx` post
+// rendered through `<MDXContent components={mdxComponents} />` can drop these
+// in by their capitalized tag name - no import needed in the markdown.
+//
+// Design language is lifted from the /origin essay (app/routes/origin.tsx +
+// app/components/origin-sections/*): numbered exhibit chrome, hairline rules,
+// mono captions, serif pull quotes, the green "signal reinjected" callout.
+// All styling lives under the `.blog-essay` scope in globals.css and is
+// token-driven (no hardcoded hex). Components are pure render - SSR/prerender
+// safe, no client-only APIs at module scope.
+// ============================================================================
+
+// --- Figure / Exhibit -------------------------------------------------------
+// A bordered, numbered figure: a mono `.fig-id` chip + right-aligned label on a
+// hairline-ruled head, arbitrary children (a code receipt, a table, a diagram),
+// and a mono caption with an optional bold lead-in (origin's figcaption shape).
+type FigureProps = {
+  /** left chip, e.g. "Exhibit 1" or "Receipt 03" */
+  id?: string;
+  /** right-aligned mono meta, e.g. "ax cost split · 30 days" */
+  label?: string;
+  /** bold lead sentence on the caption (origin's <strong> opener) */
+  lead?: ReactNode;
+  /** muted caption continuation */
+  caption?: ReactNode;
+  children?: ReactNode;
+};
+
+export function Figure({ id, label, lead, caption, children }: FigureProps) {
+  const hasHead = Boolean(id || label);
+  const hasCap = Boolean(lead || caption);
+  return (
+    <figure className="bk-figure">
+      {hasHead ? (
+        <div className="bk-fig-head">
+          <span className="bk-fig-id">{id}</span>
+          {label ? <span className="bk-fig-label">{label}</span> : null}
+        </div>
+      ) : null}
+      <div className="bk-fig-body">{children}</div>
+      {hasCap ? (
+        <figcaption className="bk-fig-cap">
+          {lead ? <strong>{lead}</strong> : null}
+          {lead && caption ? " " : null}
+          {caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+// `<Exhibit>` reads better for built diagrams; same component.
+export const Exhibit = Figure;
+
+// --- Callout ----------------------------------------------------------------
+// The green reinject-style highlight box. tone="good" = green rule (a result,
+// a "this is the point" line); tone="note" = blue rule (an aside / caveat).
+type CalloutProps = {
+  tone?: "good" | "note";
+  /** optional mono eyebrow above the body */
+  title?: ReactNode;
+  children?: ReactNode;
+};
+
+export function Callout({ tone = "note", title, children }: CalloutProps) {
+  return (
+    <aside className={`bk-callout bk-callout--${tone}`}>
+      {title ? <p className="bk-callout-title">{title}</p> : null}
+      <div className="bk-callout-body">{children}</div>
+    </aside>
+  );
+}
+
+// --- StatGrid / Stat --------------------------------------------------------
+// A numbered/labeled stat row, like origin's exhibit grids: a big serif numeral
+// over a mono label, hairline-separated. Use for the three-leak math etc.
+type StatGridProps = {
+  /** mono eyebrow above the grid */
+  label?: ReactNode;
+  children?: ReactNode;
+};
+
+export function StatGrid({ label, children }: StatGridProps) {
+  return (
+    <div className="bk-statgrid">
+      {label ? <span className="bk-statgrid-label">{label}</span> : null}
+      <div className="bk-stats">{children}</div>
+    </div>
+  );
+}
+
+type StatProps = {
+  /** the big numeral / headline figure, e.g. "$605.02" */
+  value: ReactNode;
+  /** mono label under the figure */
+  label: ReactNode;
+  /** optional muted sub-note */
+  sub?: ReactNode;
+};
+
+export function Stat({ value, label, sub }: StatProps) {
+  return (
+    <div className="bk-stat">
+      <span className="bk-stat-value">{value}</span>
+      <span className="bk-stat-label">{label}</span>
+      {sub ? <span className="bk-stat-sub">{sub}</span> : null}
+    </div>
+  );
+}
+
+// --- PullQuote --------------------------------------------------------------
+// Large serif pull quote for punchy lines.
+type PullQuoteProps = {
+  children?: ReactNode;
+  cite?: ReactNode;
+};
+
+export function PullQuote({ children, cite }: PullQuoteProps) {
+  return (
+    <blockquote className="bk-pull">
+      <p>{children}</p>
+      {cite ? <cite>{cite}</cite> : null}
+    </blockquote>
+  );
+}
+
+// --- FrameworkList ----------------------------------------------------------
+// A mono two-column definition list (term + note), origin's framework-list.
+type FrameworkListProps = {
+  label?: ReactNode;
+  children?: ReactNode;
+};
+
+export function FrameworkList({ label, children }: FrameworkListProps) {
+  return (
+    <div className="bk-framework">
+      {label ? <span className="bk-framework-label">{label}</span> : null}
+      <ul>{children}</ul>
+    </div>
+  );
+}
+
+export function FrameworkItem({ name, children }: { name: ReactNode; children?: ReactNode }) {
+  return (
+    <li>
+      <span className="bk-fw-name">{name}</span>
+      <span className="bk-fw-note">{children}</span>
+    </li>
+  );
+}
+
+// --- KBD --------------------------------------------------------------------
+// Inline keycap. Markdown <kbd> also works; this is the JSX-friendly handle.
+export function KBD({ children }: { children?: ReactNode }) {
+  return <kbd className="bk-kbd">{children}</kbd>;
+}
+
+// ----------------------------------------------------------------------------
+// Components map handed to <MDXContent>. The lowercase `a` keeps external links
+// safe; the capitalized entries are the article kit. Prose typography itself is
+// owned by the `.blog-essay` / `.prose` scopes in globals.css.
+// ----------------------------------------------------------------------------
 export const mdxComponents = {
   a: (props: ComponentProps<"a">) => {
     const external = typeof props.href === "string" && /^https?:/.test(props.href);
@@ -14,4 +174,13 @@ export const mdxComponents = {
       <a {...props} />
     );
   },
+  Figure,
+  Exhibit,
+  Callout,
+  StatGrid,
+  Stat,
+  PullQuote,
+  FrameworkList,
+  FrameworkItem,
+  KBD,
 };

--- a/apps/site/app/routes/blog.tsx
+++ b/apps/site/app/routes/blog.tsx
@@ -1,0 +1,89 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { allBlogs } from "content-collections";
+import { SiteFooter } from "~/components/landing-sections/site-footer";
+import { SiteHeader } from "~/components/landing-sections/site-header";
+
+export const Route = createFileRoute("/blog")({
+  head: () => ({
+    meta: [
+      { title: "Blog - ax" },
+      {
+        name: "description",
+        content:
+          "Field notes on agent cost, routing, and telemetry - measured from real transcripts, not surveyed.",
+      },
+    ],
+  }),
+  loader: () => ({
+    posts: [...allBlogs]
+      .filter((p) => !p.draft)
+      .sort((a, b) => b.date.localeCompare(a.date)),
+  }),
+  component: BlogIndex,
+});
+
+function fmtDate(iso: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  if (!m) return iso;
+  const months = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+  return `${months[Number(m[2]) - 1]} ${Number(m[3])}, ${m[1]}`;
+}
+
+function BlogIndex() {
+  const { posts } = Route.useLoaderData();
+  return (
+    <>
+      <SiteHeader />
+      <main className="blog-index">
+        <header className="blog-index-head">
+          <p className="eyebrow">field notes</p>
+          <h1>
+            What the <em>transcripts</em> say.
+          </h1>
+          <p className="lede">
+            Essays on agent cost, routing, and telemetry - every number
+            measured from real sessions on one machine, not surveyed.
+          </p>
+        </header>
+
+        {posts.length === 0 ? (
+          <p className="muted">No posts yet.</p>
+        ) : (
+          <div className="blog-list">
+            {posts.map((post) => (
+              <article key={post.slug} className="blog-entry">
+                <div className="blog-meta">
+                  <time dateTime={post.date}>{fmtDate(post.date)}</time>
+                  {post.tags && post.tags.length > 0 ? (
+                    <span className="blog-tags">
+                      {post.tags.slice(0, 3).map((t) => (
+                        <span key={t} className="blog-tag">{t}</span>
+                      ))}
+                    </span>
+                  ) : null}
+                </div>
+                <h2>
+                  <Link to="/blog/$slug" params={{ slug: post.slug }}>
+                    {post.title}
+                  </Link>
+                </h2>
+                <p className="blog-excerpt">{post.excerpt}</p>
+                <Link
+                  to="/blog/$slug"
+                  params={{ slug: post.slug }}
+                  className="blog-entry-link"
+                >
+                  Read →
+                </Link>
+              </article>
+            ))}
+          </div>
+        )}
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/apps/site/app/routes/blog_.$slug.tsx
+++ b/apps/site/app/routes/blog_.$slug.tsx
@@ -1,0 +1,85 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { MDXContent } from "@content-collections/mdx/react";
+import { allBlogs } from "content-collections";
+import { mdxComponents } from "~/components/mdx-components";
+import { SiteFooter } from "~/components/landing-sections/site-footer";
+import { SiteHeader } from "~/components/landing-sections/site-header";
+
+const SITE_ORIGIN = "https://ax.necmttn.com";
+// Bump to bust cached OG renders when the blog card template changes.
+const OG_BLOG_REV = 1;
+
+function ogImageUrl(slug: string, title: string, date: string): string {
+  const q = new URLSearchParams({
+    title,
+    date,
+    r: String(OG_BLOG_REV),
+  });
+  return `${SITE_ORIGIN}/og-blog/${slug}?${q.toString()}`;
+}
+
+function fmtDate(iso: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  if (!m) return iso;
+  const months = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+  return `${months[Number(m[2]) - 1]} ${Number(m[3])}, ${m[1]}`;
+}
+
+export const Route = createFileRoute("/blog_/$slug")({
+  // NOTE: like every dynamic content-collections route in this app
+  // (docs/adr.$slug, changelog_.$version), the strict site typecheck does not
+  // thread loaderData's type into `head` - it reads as `never`. Accepted,
+  // pre-existing repo-wide pattern; the build/runtime are correct. Matching the
+  // adr-style optional-chain shape here for consistency.
+  head: ({ loaderData }) => {
+    const post = loaderData?.post;
+    if (!post) return { meta: [{ title: "Blog - ax" }] };
+    const og = ogImageUrl(post.slug, post.title, post.date);
+    return {
+      meta: [
+        { title: `${post.title} - ax` },
+        { name: "description", content: post.excerpt },
+        { property: "og:type", content: "article" },
+        { property: "og:title", content: post.title },
+        { property: "og:description", content: post.excerpt },
+        { property: "og:image", content: og },
+        { property: "og:image:width", content: "1200" },
+        { property: "og:image:height", content: "630" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:title", content: post.title },
+        { name: "twitter:description", content: post.excerpt },
+        { name: "twitter:image", content: og },
+      ],
+    };
+  },
+  loader: ({ params }) => {
+    const post = allBlogs.find((p) => p.slug === params.slug);
+    if (!post) throw notFound();
+    return { post };
+  },
+  component: BlogPost,
+});
+
+function BlogPost() {
+  const { post } = Route.useLoaderData();
+  // The markdown body carries its own H1, so we render only a date eyebrow
+  // above it - no second, competing headline.
+  return (
+    <>
+      <SiteHeader />
+      <main className="doc-main blog-post">
+        <nav className="doc-crumb" aria-label="breadcrumb">
+          <Link to="/blog">← Blog</Link>
+        </nav>
+        <p className="blog-post-date">{fmtDate(post.date)}</p>
+        <article className="prose">
+          <MDXContent code={post.body} components={mdxComponents} />
+        </article>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/apps/site/app/routes/blog_.$slug.tsx
+++ b/apps/site/app/routes/blog_.$slug.tsx
@@ -75,7 +75,7 @@ function BlogPost() {
           <Link to="/blog">← Blog</Link>
         </nav>
         <p className="blog-post-date">{fmtDate(post.date)}</p>
-        <article className="prose">
+        <article className="prose blog-essay">
           <MDXContent code={post.body} components={mdxComponents} />
         </article>
       </main>

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -14292,6 +14292,30 @@ footer.site-footer { padding: 48px 32px 56px; }
   line-height: 1.6;
   padding: 16px 18px;
 }
+
+/* --- code-block overflow: long lines scroll horizontally inside the rounded
+   block instead of clipping past its right edge. min-width:0 defeats the
+   intrinsic min-content sizing that lets an unbreakable line (e.g. a curl URL)
+   blow out the box in a flex/grid wrapper; overflow-x:auto keeps the scroll
+   contained within the rounded panel. Width still tracks the reading column
+   (70ch via `.blog-essay > *`) - we only fix the scroll, not the measure. --- */
+.blog-essay pre {
+  min-width: 0;
+  overflow-x: auto;
+}
+.blog-essay pre code {
+  display: block;
+  min-width: 0;
+  white-space: pre;
+}
+.blog-essay figure[data-rehype-pretty-code-figure] {
+  min-width: 0;
+  max-width: 100%;
+}
+.blog-essay .bk-fig-body,
+.blog-essay .bk-fig-body figure[data-rehype-pretty-code-figure] {
+  min-width: 0;
+}
 .blog-essay .bk-fig-cap {
   margin-top: 16px;
   padding-top: 12px;
@@ -14443,6 +14467,152 @@ footer.site-footer { padding: 48px 32px 56px; }
 .blog-essay .bk-fw-name { color: var(--ink); letter-spacing: 0.02em; }
 .blog-essay .bk-fw-note { color: var(--muted); }
 
+/* --- SplitBar (one proportional stacked bar + mono legend) --- */
+.blog-essay .bk-split { margin: 8px 0 4px; }
+.blog-essay .bk-split-bar {
+  display: flex;
+  width: 100%;
+  height: 38px;
+  border: 1px solid var(--ink);
+  background: var(--page);
+  overflow: hidden;
+}
+.blog-essay .bk-split-seg {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0 10px;
+  min-width: 0;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  border-right: 1px solid var(--page);
+}
+.blog-essay .bk-split-seg:last-child { border-right: none; }
+.blog-essay .bk-split-seg.bk-tone-ink { background: var(--ink); color: var(--page); }
+.blog-essay .bk-split-seg.bk-tone-green { background: var(--green); color: var(--page); }
+.blog-essay .bk-split-seg.bk-tone-muted { background: var(--muted); color: var(--page); }
+.blog-essay .bk-split-seg-in { opacity: 0.92; }
+
+.blog-essay .bk-split-legend {
+  margin-top: 16px;
+  border-top: 1px solid var(--line);
+}
+.blog-essay .bk-split-leg {
+  display: grid;
+  grid-template-columns: 14px 1fr auto 64px;
+  align-items: baseline;
+  gap: 12px;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+.blog-essay .bk-split-leg:last-child { border-bottom: none; }
+.blog-essay .bk-split-dot {
+  width: 10px;
+  height: 10px;
+  align-self: center;
+  border: 1px solid var(--ink);
+}
+.blog-essay .bk-split-dot.bk-tone-ink { background: var(--ink); }
+.blog-essay .bk-split-dot.bk-tone-green { background: var(--green); border-color: var(--green); }
+.blog-essay .bk-split-dot.bk-tone-muted { background: var(--muted); border-color: var(--muted); }
+.blog-essay .bk-split-dot-empty { background: transparent; border-color: var(--line); }
+.blog-essay .bk-split-leg-label { color: var(--ink); }
+.blog-essay .bk-split-leg-amt { color: var(--ink); text-align: right; }
+.blog-essay .bk-split-leg-pct { color: var(--muted); text-align: right; }
+.blog-essay .bk-split-leg-total .bk-split-leg-label,
+.blog-essay .bk-split-leg-total .bk-split-leg-amt,
+.blog-essay .bk-split-leg-total .bk-split-leg-pct {
+  color: var(--ink);
+  font-weight: 600;
+}
+.blog-essay .bk-split-leg-total { border-top: 1px solid var(--ink); }
+
+/* --- BarChart (horizontal bars, fill ∝ value, hot peak) --- */
+.blog-essay .bk-barchart { margin: 24px 0 4px; }
+.blog-essay .bk-barchart-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin-bottom: 16px;
+}
+.blog-essay .bk-bar-row { margin-bottom: 16px; }
+.blog-essay .bk-bar-row:last-child { margin-bottom: 0; }
+.blog-essay .bk-bar-head {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 6px;
+  font-family: var(--mono);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+.blog-essay .bk-bar-name { color: var(--ink); letter-spacing: 0.01em; }
+.blog-essay .bk-bar-amt { color: var(--ink); text-align: right; }
+.blog-essay .bk-bar-pct { color: var(--muted); text-align: right; min-width: 44px; }
+.blog-essay .bk-bar-track {
+  height: 12px;
+  background: var(--page);
+  border: 1px solid var(--line);
+}
+.blog-essay .bk-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--ink);
+  min-width: 2px;
+}
+.blog-essay .bk-bar-fill-peak { background: var(--red); }
+.blog-essay .bk-bar-sub {
+  display: block;
+  margin-top: 5px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+/* --- AxResult (colorized ax command receipt) --- */
+.blog-essay .bk-axresult {
+  margin: 0;
+  min-width: 0;
+  overflow-x: auto;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 16px 18px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.62;
+  color: var(--ink);
+}
+.blog-essay .bk-fig-body .bk-axresult {
+  border: none;
+  border-radius: 0;
+}
+.blog-essay .bk-axresult code {
+  font-family: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  white-space: pre;
+}
+.blog-essay .bk-ax-line { display: inline; }
+.blog-essay .bk-ax-cmd { color: var(--muted); }
+.blog-essay .bk-ax-money { color: var(--green); font-weight: 600; }
+.blog-essay .bk-ax-pct { color: var(--blue); }
+.blog-essay .bk-ax-model { color: var(--ink); border-bottom: 1px dotted var(--line); }
+.blog-essay .bk-ax-warn { color: var(--red); font-weight: 600; }
+
 @media (max-width: 640px) {
   .blog-essay { --bk-read: 100%; }
   .blog-essay p { font-size: 17px; line-height: 1.62; }
@@ -14454,4 +14624,7 @@ footer.site-footer { padding: 48px 32px 56px; }
   }
   .blog-essay .bk-stat:first-child { padding-top: 0; border-top: none; }
   .blog-essay .bk-framework li { grid-template-columns: 1fr; gap: 2px; }
+  .blog-essay .bk-split-leg { grid-template-columns: 12px 1fr auto 54px; gap: 8px; font-size: 12px; }
+  .blog-essay .bk-split-seg-in { font-size: 11px; }
+  .blog-essay .bk-bar-head { font-size: 12px; gap: 8px; }
 }

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -10930,6 +10930,35 @@ footer.site-footer { padding: 48px 32px 56px; }
   text-decoration: none;
 }
 .doc-crumb a:hover { color: var(--ink); }
+
+/* --- Blog --------------------------------------------------------------- */
+.blog-index { padding-top: 8px; padding-bottom: 96px; }
+.blog-index-head { max-width: 760px; padding: 48px 0 8px; }
+.blog-index-head h1 { font-family: var(--serif); font-size: 44px; line-height: 1.1; margin: 8px 0 0; }
+.blog-index-head h1 em { font-style: italic; color: var(--green); }
+.blog-index-head .lede { color: var(--muted); font-size: 18px; line-height: 1.6; margin-top: 14px; }
+.blog-list { margin-top: 40px; border-top: 1px solid var(--line); }
+.blog-entry { padding: 28px 0; border-bottom: 1px solid var(--line); }
+.blog-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.blog-tags { display: flex; gap: 6px; }
+.blog-tag { padding: 2px 8px; background: var(--panel); border: 1px solid var(--line); border-radius: 3px; }
+.blog-entry h2 { font-family: var(--serif); font-size: 28px; line-height: 1.2; margin: 10px 0 0; }
+.blog-entry h2 a { color: var(--ink); text-decoration: none; }
+.blog-entry h2 a:hover { color: var(--blue); }
+.blog-excerpt { color: var(--muted); font-size: 16.5px; line-height: 1.6; margin: 10px 0 0; max-width: 720px; }
+.blog-entry-link { display: inline-block; margin-top: 12px; font-family: var(--mono); font-size: 13px; color: var(--blue); text-decoration: none; }
+.blog-entry-link:hover { text-decoration: underline; }
+.blog-post-date { font-family: var(--mono); font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; padding: 18px 0 0; }
+
 .doc-head { max-width: 760px; padding: 28px 0 4px; }
 .doc-head .eyebrow {
   font-family: var(--mono);

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -14155,3 +14155,303 @@ footer.site-footer { padding: 48px 32px 56px; }
 .pf-vital-num { font-family: "Doto", var(--mono); font-variant-numeric: tabular-nums; font-weight: 600; letter-spacing: 0; }
 .pf-vital-num small { font-family: var(--mono); font-weight: 400; }
 .pf-stack-col { transform-origin: bottom; animation: pf-bar-rise 0.55s cubic-bezier(0.34,1.56,0.64,1) both; }
+
+/* ============================================================
+   .blog-essay - origin-grade editorial typography for blog posts.
+   Layered on top of .prose (which still owns code-block / table
+   base styling). Serif reading column matching /origin, centered
+   within the 1080 shell; the MDX article kit (.bk-*) breaks out
+   wider. Light theme only - the only dark surface is a framed
+   code receipt, read as a terminal panel inside light chrome.
+   ============================================================ */
+
+.blog-essay {
+  --bk-read: 70ch;
+  --bk-wide: 920px;
+  max-width: var(--bk-wide);
+  margin: 0 auto;
+  color: var(--ink);
+}
+
+/* reading column centered; kit exhibits break out wider */
+.blog-essay > * {
+  max-width: var(--bk-read);
+  margin-left: auto;
+  margin-right: auto;
+}
+.blog-essay > .bk-figure,
+.blog-essay > .bk-statgrid,
+.blog-essay > .bk-pull,
+.blog-essay > .bk-callout,
+.blog-essay > .bk-wide {
+  max-width: var(--bk-wide);
+}
+
+/* --- type: serif editorial body --- */
+.blog-essay p {
+  font-family: var(--serif);
+  font-size: 19px;
+  line-height: 1.66;
+  color: var(--ink);
+  margin: 0 0 20px;
+}
+.blog-essay h1 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(34px, 5vw, 52px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 28px;
+}
+.blog-essay h2 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(26px, 3.4vw, 36px);
+  line-height: 1.12;
+  letter-spacing: -0.015em;
+  margin: 60px 0 18px;
+  padding: 0;
+  border: none;
+}
+.blog-essay h3 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 22px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  margin: 40px 0 12px;
+}
+.blog-essay li {
+  font-family: var(--serif);
+  font-size: 18px;
+  line-height: 1.6;
+}
+.blog-essay :not(pre) > code {
+  font-family: var(--mono);
+  font-size: 0.88em;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--ink);
+}
+.blog-essay hr {
+  border: none;
+  border-top: 1px solid var(--line);
+  margin: 56px auto;
+  max-width: var(--bk-read);
+}
+.blog-essay blockquote:not(.bk-pull) {
+  margin: 22px auto;
+  padding: 4px 0 4px 22px;
+  border-left: 3px solid var(--line);
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--muted);
+}
+
+/* --- kbd --- */
+.blog-essay kbd,
+.blog-essay .bk-kbd {
+  font-family: var(--mono);
+  font-size: 0.82em;
+  padding: 1px 6px;
+  border: 1px solid var(--line);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  background: var(--panel);
+  color: var(--ink);
+}
+
+/* --- Figure / Exhibit --- */
+.blog-essay .bk-figure {
+  margin: 48px auto 56px;
+  padding: 0;
+}
+.blog-essay .bk-fig-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 18px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--ink);
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+}
+.blog-essay .bk-fig-id { color: var(--ink); }
+.blog-essay .bk-fig-label { text-align: right; }
+.blog-essay .bk-fig-body { margin: 0; }
+.blog-essay .bk-fig-body figure[data-rehype-pretty-code-figure] { margin: 0; }
+.blog-essay .bk-fig-body pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  font-size: 12.5px;
+  line-height: 1.6;
+  padding: 16px 18px;
+}
+.blog-essay .bk-fig-cap {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+.blog-essay .bk-fig-cap strong { color: var(--ink); font-weight: 500; }
+
+/* --- Callout (green reinject-style box) --- */
+.blog-essay .bk-callout {
+  margin: 28px auto;
+  padding: 16px 20px;
+  background: var(--panel);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  border-left: 3px solid var(--line);
+}
+.blog-essay .bk-callout--good { border-left-color: var(--green); }
+.blog-essay .bk-callout--note { border-left-color: var(--blue); }
+.blog-essay .bk-callout-title {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  margin: 0 0 8px;
+  color: var(--green);
+}
+.blog-essay .bk-callout--note .bk-callout-title { color: var(--blue); }
+.blog-essay .bk-callout-body p {
+  font-family: var(--serif);
+  font-size: 16.5px;
+  line-height: 1.6;
+  margin: 0 0 10px;
+}
+.blog-essay .bk-callout-body > :last-child { margin-bottom: 0; }
+
+/* --- StatGrid / Stat --- */
+.blog-essay .bk-statgrid {
+  margin: 44px auto;
+  border-top: 1px solid var(--ink);
+  padding-top: 16px;
+}
+.blog-essay .bk-statgrid-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin-bottom: 20px;
+}
+.blog-essay .bk-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+.blog-essay .bk-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-left: 22px;
+  border-left: 1px solid var(--line);
+}
+.blog-essay .bk-stat:first-child { padding-left: 0; border-left: none; }
+.blog-essay .bk-stat-value {
+  font-family: var(--serif);
+  font-size: clamp(28px, 4vw, 42px);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+.blog-essay .bk-stat-label {
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ink);
+}
+.blog-essay .bk-stat-sub {
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+
+/* --- PullQuote --- */
+.blog-essay .bk-pull {
+  margin: 44px auto;
+  padding: 4px 0 4px 28px;
+  border-left: 2px solid var(--ink);
+}
+.blog-essay .bk-pull p {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: clamp(24px, 3.2vw, 33px);
+  line-height: 1.32;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  margin: 0;
+  max-width: none;
+}
+.blog-essay .bk-pull cite {
+  display: block;
+  margin-top: 14px;
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+/* --- FrameworkList --- */
+.blog-essay .bk-framework {
+  margin: 28px auto;
+  padding: 16px 0 14px;
+  border-top: 1px solid var(--ink);
+  border-bottom: 1px solid var(--line);
+}
+.blog-essay .bk-framework-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  margin-bottom: 14px;
+}
+.blog-essay .bk-framework ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+.blog-essay .bk-framework li {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 18px;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--muted);
+  margin: 0;
+}
+.blog-essay .bk-framework li::marker { content: ""; }
+.blog-essay .bk-fw-name { color: var(--ink); letter-spacing: 0.02em; }
+.blog-essay .bk-fw-note { color: var(--muted); }
+
+@media (max-width: 640px) {
+  .blog-essay { --bk-read: 100%; }
+  .blog-essay p { font-size: 17px; line-height: 1.62; }
+  .blog-essay .bk-stats { grid-template-columns: 1fr; }
+  .blog-essay .bk-stat {
+    padding: 16px 0 0 0;
+    border-left: none;
+    border-top: 1px solid var(--line);
+  }
+  .blog-essay .bk-stat:first-child { padding-top: 0; border-top: none; }
+  .blog-essay .bk-framework li { grid-template-columns: 1fr; gap: 2px; }
+}

--- a/apps/site/content-collections.ts
+++ b/apps/site/content-collections.ts
@@ -123,4 +123,23 @@ const howItWorks = defineCollection({
   },
 });
 
-export default defineConfig({ content: [adrs, howItWorks, releaseAnnouncements, changelog] });
+const blog = defineCollection({
+  name: "blog",
+  directory: "content/blog",
+  include: "*.md",
+  schema: z.object({
+    title: z.string(),
+    date: z.string(),
+    excerpt: z.string(),
+    tags: z.array(z.string()).optional(),
+    draft: z.boolean().optional(),
+    content: z.string(),
+  }),
+  transform: async (doc, ctx) => {
+    const body = await compileMDX(ctx, doc, mdxOptions);
+    const slug = doc._meta.fileName.replace(/\.md$/, "");
+    return { ...doc, slug, body };
+  },
+});
+
+export default defineConfig({ content: [adrs, howItWorks, releaseAnnouncements, changelog, blog] });

--- a/apps/site/content/blog/2026-06-13-routing-tune.md
+++ b/apps/site/content/blog/2026-06-13-routing-tune.md
@@ -11,19 +11,26 @@ There's a hidden bucket in your AI coding bill, and it's bigger than you think. 
 
 Last month my AI coding agents spent $25,027. $3,956.59 of that was those helpers - 1,368 of them, and 67% ran on the default expensive model for work a cheaper one would have nailed. "Find every caller of this function" does not need your top-tier model. It got it anyway, 1,368 times.
 
-> **Quick glossary** (this piece uses these a lot):
-> - **dispatch** - a helper task your main agent launches to do one side job
-> - **inherit** - the helper runs on the same model as your main chat (the pricey default)
-> - **frontier** - the top-tier, most expensive model (right now that's the likes of opus or fable)
-> - **routing** - sending routine helper work to a cheaper model on purpose
+<FrameworkList label="Quick glossary - this piece uses these a lot">
+  <FrameworkItem name="dispatch">a helper task your main agent launches to do one side job</FrameworkItem>
+  <FrameworkItem name="inherit">the helper runs on the same model as your main chat (the pricey default)</FrameworkItem>
+  <FrameworkItem name="frontier">the top-tier, most expensive model (right now that's the likes of opus or fable)</FrameworkItem>
+  <FrameworkItem name="routing">sending routine helper work to a cheaper model on purpose</FrameworkItem>
+</FrameworkList>
 
-The expensive default here happened to be `claude-fable-5` - a model so good and so short-lived that people still talk about it like a band that broke up too soon. That's the trap, though: the name on the invoice keeps changing. Fable this month, opus the next, whatever frontier tier your helpers inherit after that. You can't build a cost strategy on which model is cheap today. The leak isn't a model. It's that your helpers inherit the expensive one by default, and that outlives every model that comes and goes.
+The expensive default here happened to be `claude-fable-5` - a model so good and so short-lived that people still talk about it like a band that broke up too soon. That's the trap, though: the name on the invoice keeps changing. Fable this month, opus the next, whatever frontier tier your helpers inherit after that. You can't build a cost strategy on which model is cheap today.
+
+<PullQuote cite="the leak isn't a model">
+The leak isn't a model. It's that your helpers inherit the expensive one by default - and that outlives every model that comes and goes.
+</PullQuote>
 
 One helper task makes the gap concrete. "Implement Task 3: session map strip" - bounded scope, written spec - ran inherit, landed on fable, and cost $50.26; ax re-prices the same work at sonnet rates as $15.08. Two days later a near-identical task ran with sonnet named on purpose and cost $5.23. The only thing that changed was whether anyone picked the model.
 
-```
-"Implement Task 3" inherit→fable $50.26   ax-priced sonnet $15.08   same shape, sonnet named $5.23
-```
+<StatGrid label="One helper task, three prices - 'Implement Task 3: session map strip'">
+  <Stat value="$50.26" label="inherit → ran on fable" sub="what it actually cost" />
+  <Stat value="$15.08" label="ax-priced at sonnet" sub="same work, repriced" />
+  <Stat value="$5.23" label="sonnet named on purpose" sub="two days later, same shape" />
+</StatGrid>
 
 Multiply that gap across hundreds of helper tasks a month, and that's the bill.
 
@@ -45,6 +52,8 @@ In Claude Code, the `model` override applies to the first leg only. The dispatch
 
 One dispatch made it obvious. "Implement S2-T4" routed to sonnet. The sonnet leg cost about $1. Then it continued, flipped to fable, and ran up $116 of its $117 total - 99% of the cost landed after the override I'd set was already gone.
 
+<Figure id="Receipt" label="'Implement S2-T4' · the route that didn't stick" lead="The override applied to the first leg only." caption="99% of the cost landed after the routed leg, on the parent's frontier model - and the dispatch_model column still reads sonnet.">
+
 ```
 "Implement S2-T4"
   requested:    sonnet
@@ -53,7 +62,11 @@ One dispatch made it obvious. "Implement S2-T4" routed to sonnet. The sonnet leg
   total:        $117    (99% billed off-model, after the route)
 ```
 
+</Figure>
+
 Across the same 30 days: 66 routed dispatches continued on a different model than requested, $571.52 of spend on those dropped legs. The leak you can't see is the same size as the one you can. `ax dispatches` flags these rows with a `!` marker and a dropped-cost footer, so a route that didn't stick stops looking like a route that worked. ax measures that gap. Nothing else does.
+
+<Figure id="ax dispatches" label="--days=30 · dropped-leg footer" lead="The leak you can't see, made visible." caption="ax marks dropped-leg rows with a ! and a dropped-cost footer, so a route that didn't stick stops looking like a route that worked.">
 
 ```
 $ ax dispatches --days=30
@@ -64,6 +77,8 @@ ts                   description            dispatch_model  child_model        c
 
 dropped (off-model continuation): 66 dispatches  $571.52
 ```
+
+</Figure>
 
 So I built the loop that finds it and closes it. ax is free, open source, and local - it reads your transcripts, never your code, never your API keys. github.com/Necmttn/ax
 
@@ -94,6 +109,8 @@ ax ingest --since=30
 
 The matrix your harness never shows: who spent the money - main agent or subagents - and on which model.
 
+<Figure id="ax cost split" label="--days=30 · origin × model" lead="The split your invoice never breaks out." caption="Share is each row's slice of the $25,027 total. The real table breaks out every main-agent model and adds token columns - collapsed to one line here so the subagent split stays the point.">
+
 ```
 $ ax cost split --days=30
 
@@ -112,11 +129,13 @@ main agent (models trimmed)             $21,015.22   84.0%
 TOTAL (main + subagent)                  $25,027.00  100.0%
 ```
 
-Share is each row's slice of the $25,027 total. The real table breaks out every main-agent model and adds token columns - collapsed to one line here so the subagent split stays the point.
+</Figure>
 
 ### Rule 3: List every dispatch with its price tag
 
 Every Task dispatch: its description, whether a model was specified, what the child actually cost. Sorted by cost. The expensive rows tell you everything.
+
+<Figure id="ax dispatches" label="--days=30 · sorted by child cost" lead="Every dispatch, priced and sorted." caption="The expensive inherit rows tell you everything; the footer counts the routed dispatches that continued off-model.">
 
 ```
 $ ax dispatches --days=30
@@ -130,14 +149,17 @@ ts                   description                        dispatch_model  child_mo
 model drops: 66 routed dispatches continued on a different model ($571.52 on dropped legs, marked "!")
 ```
 
+</Figure>
+
 ### Rule 4: Read the inherit percentage. That's the leak.
 
 `inherit` means no one chose a model - the dispatch silently took the main model. Some of those should be frontier. Most are "implement this spec" and "fix this test." Mine was 67%; an earlier 14-day window on the same machine was 80.7% (574 dispatches, $2,116 subagent spend). Defaults don't audit themselves.
 
-```
-67.0% of 1,368 dispatches: inherit
-→ bounded, well-specified work billed at frontier rates by default
-```
+<Callout tone="good" title="the leak, in one line">
+
+67.0% of 1,368 dispatches ran `inherit` - bounded, well-specified work billed at frontier rates by default, because no one picked a cheaper model.
+
+</Callout>
 
 ### Rule 5: Compute your own annual number
 
@@ -154,6 +176,8 @@ $605.02 flagged / 30 days  ×12 ≈ $7,260 / year
 ### Rule 6: Start from the shipped defaults
 
 ax ships a default routing table - description prefixes and agent types mapped to the cheapest model that handles them. `ax routing compile` writes it to `~/.ax/hooks/routing-table.json`, merge-preserving, so your own classes survive regeneration. `ax routing show` prints what landed.
+
+<Figure id="ax routing show" label="the shipped default table" lead="Description prefixes and agent types, mapped to the cheapest model that handles them." caption="ax routing compile writes the table merge-preserving, so your own classes survive regeneration; show prints what landed, with origins.">
 
 ```
 $ ax routing compile
@@ -176,9 +200,13 @@ agent-type:codebase-pattern-finder                                        haiku 
 agent-type:codebase-analyzer                                              sonnet    default
 ```
 
+</Figure>
+
 ### Rule 7: Flag the candidates and get a dollar figure
 
 `--candidates` filters your dispatch history to the expensive inherit runs that match a routing class, prices the alternative per dispatch, and shows where the $605.02 actually lives:
+
+<Figure id="ax dispatches --candidates" label="--days=30 · est. savings by class" lead="Where the $605.02 actually lives." caption="inherit dispatches that match a routing class, repriced one tier down, ranked by the class that would save the most.">
 
 ```
 $ ax dispatches --candidates --days=30
@@ -192,9 +220,13 @@ top classes by savings:
   bug-fix               $ 69.37
 ```
 
+</Figure>
+
 ### Rule 8: Mine new classes from your unmatched spend
 
 Your dispatch descriptions have patterns the defaults don't know. `ax routing tune` clusters the expensive inherit dispatches that no class caught (two-token prefix clustering, clusters of 3+) and proposes new classes suggesting sonnet. Dry-run first. On my history that surfaced $599.00 of spend the default table never saw:
+
+<Figure id="ax routing tune --dry-run" label="--days=30 · mined proposals" lead="New classes mined from your own history." caption="Two-token prefix clustering over the expensive inherit dispatches no default class caught; judgment-flagged clusters never auto-apply.">
 
 ```
 $ ax routing tune --days=30 --dry-run
@@ -211,6 +243,8 @@ impl-N           ^impl\s+\d+\b          sonnet      10       $25.18  no
 20 proposals  addressable spend: $599.00  (30 days)
 apply non-judgment: ax routing tune --days=30   brief: ax routing tune --emit-brief
 ```
+
+</Figure>
 
 The `issue-N` row alone - "Issue 248 manifest hidden flag" and eleven siblings - is $161.42 of inherit spend with a two-token pattern sitting on top of it.
 
@@ -348,6 +382,8 @@ Everything above tunes the subagent bill. But go back to Rule 2: subagents were 
 
 So I built a command to look at the trunk. `ax cost routability` classifies main-agent turns by the tools they actually used. Read-only sweeps (gather → haiku), mechanical edits (mechanical-impl → sonnet), and web research (niche-research → sonnet) are routable - bounded work the frontier model did inline that a cheap subagent could have done instead. Reasoning, coordination, and judgment stay on frontier. Then it reprices the routable turns one tier down.
 
+<Figure id="ax cost routability" label="--days=30 · main-agent turns, repriced" lead="The trunk, not the tail." caption="$1,766/month - several times the entire subagent leak - sitting in the model you talk to all day. The stays-main row is genuine reasoning and coordination, correctly left on frontier.">
+
 ```
 $ ax cost routability --days=30
 
@@ -362,11 +398,17 @@ stays main      28750   39481   $11238.33   -                -            -
 estimate: edit/read turns assumed mechanically routable (upper-ish bound); claude main only.
 ```
 
+</Figure>
+
 $1,766 a month. About $21K a year. Several times the entire subagent leak the rest of this article is about - $605 a month - and it was sitting in the model I talk to all day. mechanical-impl is the bulk: the main agent editing files itself instead of handing the edit to a sonnet subagent. The $11,238 `stays main` row is genuine reasoning, coordination, and dispatching work, correctly left on frontier. The goal was never cheap everywhere. It's: stop doing bounded mechanical work inline on the most expensive model you have.
 
 Same caveats as the rest, louder here because the number is bigger. It's an upper bound - a turn that reasons hard and then makes one mechanical edit reads as routable, because the transcript strips the thinking, so call $1,766 a ceiling, not a quote. It's Claude main-agent only by construction; other harnesses' main spend isn't counted. And it's projected from historical token counts, not A/B-tested for quality parity.
 
-The behavior moved before the command existed. Over 90 days my subagent dispatch rate went from 19/day to 114/day - 6x. Call it subagent-driven development: once you see the trunk you start pushing work off it, sending bounded, well-specified, mechanical jobs out to cheap subagents instead of running them inline. Routing those subagents cheaper - the 17 rules - is step 2. Step 1 is not doing the expensive work in the main thread at all. The biggest line on the bill is the model you're talking to.
+The behavior moved before the command existed. Over 90 days my subagent dispatch rate went from 19/day to 114/day - 6x. Call it subagent-driven development: once you see the trunk you start pushing work off it, sending bounded, well-specified, mechanical jobs out to cheap subagents instead of running them inline. Routing those subagents cheaper - the 17 rules - is step 2. Step 1 is not doing the expensive work in the main thread at all.
+
+<PullQuote cite="step 1, before any routing">
+The biggest line on the bill is the model you're talking to.
+</PullQuote>
 
 ---
 
@@ -374,13 +416,19 @@ The behavior moved before the command existed. Over 90 days my subagent dispatch
 
 30 days, one machine, real transcripts. $25,027 total agent spend, $3,956.59 of it subagents across 1,368 dispatches, 67.0% inherit. The waste came in three leaks of comparable size:
 
-- $605.02 the shipped routing classes catch - $7,260/year (well-specified-impl $282.69, spec-review $80.66, bug-fix $69.37)
-- $599.00 `ax routing tune` mined into 20 new classes: $218.63 auto-applied, $380.35 judgment-gated pending backtest
-- $571.52 you can't see by reading the dispatch model column at all - 66 routed dispatches that continued off-model after the override was set
+<StatGrid label="Three leaks of comparable size · 30 days, one machine">
+  <Stat value="$605.02" label="shipped classes catch" sub="$7,260/yr · impl $282.69 · review $80.66 · bug-fix $69.37" />
+  <Stat value="$599.00" label="ax routing tune mined → 20 classes" sub="$218.63 auto-applied · $380.35 judgment-gated pending backtest" />
+  <Stat value="$571.52" label="invisible off-model" sub="66 routed dispatches that continued off-model after the override" />
+</StatGrid>
 
 The earlier 14-day window on the same machine told the same story: $2,301 of sub-task spend on fable/opus against $83 on sonnet.
 
-Honest caveats, because the numbers deserve them. The savings are projections from historical token counts, not A/B-tested quality parity. The route-dispatch hook is Claude Code only and advisory by nature - it can't rewrite an Agent dispatch, so it nudges the model rather than enforcing. It's the backstop, not the strategy; the main mechanism is the agent choosing explicit cheap models at dispatch time. And some inherit dispatches genuinely should be frontier - judgment work the table never touches in either direction.
+<Callout tone="note" title="honest caveats, because the numbers deserve them">
+
+The savings are projections from historical token counts, not A/B-tested quality parity. The route-dispatch hook is Claude Code only and advisory by nature - it can't rewrite an Agent dispatch, so it nudges the model rather than enforcing. It's the backstop, not the strategy; the main mechanism is the agent choosing explicit cheap models at dispatch time. And some inherit dispatches genuinely should be frontier - judgment work the table never touches in either direction.
+
+</Callout>
 
 ## What I'm still trying to understand
 

--- a/apps/site/content/blog/2026-06-13-routing-tune.md
+++ b/apps/site/content/blog/2026-06-13-routing-tune.md
@@ -1,0 +1,393 @@
+---
+title: "My router said sonnet. The invoice said fable."
+date: "2026-06-13"
+excerpt: "A hidden bucket in your AI coding bill: the helper agents your coding agent launches quietly default to your most expensive model. How to measure it, route it down - and the bigger leak hiding in the main agent itself."
+tags: ["cost", "routing", "agents"]
+---
+
+# My router said sonnet. The invoice said fable.
+
+There's a hidden bucket in your AI coding bill, and it's bigger than you think. When your coding agent works, it quietly launches little helper agents to do side jobs - find a function, fix a test, review a spec. Each helper picks a model to run on. By default it picks the same model you're chatting on, which is usually your most expensive one. Nobody chose that. It's just what happens when no one picks something cheaper.
+
+Last month my AI coding agents spent $25,027. $3,956.59 of that was those helpers - 1,368 of them, and 67% ran on the default expensive model for work a cheaper one would have nailed. "Find every caller of this function" does not need your top-tier model. It got it anyway, 1,368 times.
+
+> **Quick glossary** (this piece uses these a lot):
+> - **dispatch** - a helper task your main agent launches to do one side job
+> - **inherit** - the helper runs on the same model as your main chat (the pricey default)
+> - **frontier** - the top-tier, most expensive model (right now that's the likes of opus or fable)
+> - **routing** - sending routine helper work to a cheaper model on purpose
+
+The expensive default here happened to be `claude-fable-5` - a model so good and so short-lived that people still talk about it like a band that broke up too soon. That's the trap, though: the name on the invoice keeps changing. Fable this month, opus the next, whatever frontier tier your helpers inherit after that. You can't build a cost strategy on which model is cheap today. The leak isn't a model. It's that your helpers inherit the expensive one by default, and that outlives every model that comes and goes.
+
+One helper task makes the gap concrete. "Implement Task 3: session map strip" - bounded scope, written spec - ran inherit, landed on fable, and cost $50.26; ax re-prices the same work at sonnet rates as $15.08. Two days later a near-identical task ran with sonnet named on purpose and cost $5.23. The only thing that changed was whether anyone picked the model.
+
+```
+"Implement Task 3" inherit→fable $50.26   ax-priced sonnet $15.08   same shape, sonnet named $5.23
+```
+
+Multiply that gap across hundreds of helper tasks a month, and that's the bill.
+
+## Why everyone defaults to inherit
+
+Three reasons, none of them stupid. Naming a model per dispatch is friction - the field is optional, the default works, the main agent is thinking about the task, not the invoice. The failure mode is invisible - an overpriced dispatch still succeeds; no error, no warning, no diff, just a number at month-end too big to argue with. And nothing measures it: your harness shows a total, not which subagent ran which model on which description, or what the same dispatch would have cost one tier down.
+
+## The problem nobody measures
+
+Split those 30 days by model (Rule 2) and the shape jumps out: sonnet did 517 review-and-implement dispatches for $478.36; fable did 247 for $1,979.34 - 4x the spend for half the dispatches, on the same shapes of bounded work. Fable's gone now; read its row as whatever frontier model your inherit dispatches land on this month. The waste outlives the price list.
+
+`ax dispatches --candidates` flags $605.02 of that month as addressable: inherit dispatches that match a routine routing class and would have run fine one tier down. $7,260 a year, on my own disk.
+
+## The leak you can't see: your routing is lying to you
+
+Routing the dispatch is not the same as the dispatch running on the routed model.
+
+In Claude Code, the `model` override applies to the first leg only. The dispatch starts on the cheap model you named. Then a SendMessage follow-up or a post-compaction resume continues the same task and silently drops back to the parent's frontier model. The dispatch model column still says `sonnet`. The bill says `fable`.
+
+One dispatch made it obvious. "Implement S2-T4" routed to sonnet. The sonnet leg cost about $1. Then it continued, flipped to fable, and ran up $116 of its $117 total - 99% of the cost landed after the override I'd set was already gone.
+
+```
+"Implement S2-T4"
+  requested:    sonnet
+  sonnet leg:   ~$1
+  continued on: claude-fable-5   $116
+  total:        $117    (99% billed off-model, after the route)
+```
+
+Across the same 30 days: 66 routed dispatches continued on a different model than requested, $571.52 of spend on those dropped legs. The leak you can't see is the same size as the one you can. `ax dispatches` flags these rows with a `!` marker and a dropped-cost footer, so a route that didn't stick stops looking like a route that worked. ax measures that gap. Nothing else does.
+
+```
+$ ax dispatches --days=30
+
+ts                   description            dispatch_model  child_model        cost
+2026-06-XXT..:..:..  Implement S2-T4    !   sonnet          claude-fable-5     $117.00
+...
+
+dropped (off-model continuation): 66 dispatches  $571.52
+```
+
+So I built the loop that finds it and closes it. ax is free, open source, and local - it reads your transcripts, never your code, never your API keys. github.com/Necmttn/ax
+
+## The three-minute version
+
+If you only do three things:
+
+1. **Measure whether helpers are a real part of your bill.** Install ax, ingest 30 days, run `ax cost split` and `ax dispatches`. If the helper spend is noise, stop here - you're done.
+2. **See which expensive helper runs could've used a cheaper model.** `ax dispatches --candidates --days=30` puts a dollar figure on it. Mine was $605/month.
+3. **If that number's worth it, install the hook** that nudges future helper tasks onto the cheaper tier. Today that auto-advice runs on Claude Code only - ax still *measures* the leak on Codex, Cursor, OpenCode and Pi, you just steer it by hand there for now.
+
+That's the whole loop. Everything below is the deep version for people who want to tune it hard - 17 rules across measure, tune, operate, and adapt. Skim the headings; dive where it matters.
+
+---
+
+## MEASURE: know your number before you touch anything
+
+### Rule 1: Ingest your own transcripts first
+
+ax reads the session files your agents already write - Claude Code, Codex, Pi, OpenCode, Cursor - into a local SurrealDB graph. Nothing leaves your machine. Measuring works on all five; the auto-advice hook in Rule 10 is Claude Code only for now, so on the others you read the leak and steer by hand.
+
+```
+curl -fsSL https://raw.githubusercontent.com/Necmttn/ax/main/install.sh | sh
+ax ingest --since=30
+```
+
+### Rule 2: Split your spend by origin and model
+
+The matrix your harness never shows: who spent the money - main agent or subagents - and on which model.
+
+```
+$ ax cost split --days=30
+
+origin × model, 30 days   (subagent rows shown; main rows + token columns trimmed)
+
+origin    model               sessions          cost    share
+subagent  claude-fable-5           247     $1,979.34    7.9%
+subagent  claude-opus-4-7         229     $  758.83    3.0%
+subagent  claude-opus-4-8         225     $  747.93    3.0%
+subagent  claude-sonnet-4-6      517     $  478.36    1.9%
+subagent  claude-haiku           114     $   47.32    0.2%
+                                        ──────────   ───────
+subagent subtotal                        $4,011.78   16.0%
+main agent (models trimmed)             $21,015.22   84.0%
+                                        ──────────   ───────
+TOTAL (main + subagent)                  $25,027.00  100.0%
+```
+
+Share is each row's slice of the $25,027 total. The real table breaks out every main-agent model and adds token columns - collapsed to one line here so the subagent split stays the point.
+
+### Rule 3: List every dispatch with its price tag
+
+Every Task dispatch: its description, whether a model was specified, what the child actually cost. Sorted by cost. The expensive rows tell you everything.
+
+```
+$ ax dispatches --days=30
+
+ts                   description                        dispatch_model  child_model        cost
+2026-06-11T08:52:56  Issue 248 manifest hidden flag     inherit         claude-fable-5     $22.72
+2026-06-12T15:25:16  Implement S2-T3: actor attribution sonnet          claude-sonnet-4-6  $ 5.23
+...
+
+1368 dispatches  67.0% inherit  total subagent cost: $3956.59  (30 days)
+model drops: 66 routed dispatches continued on a different model ($571.52 on dropped legs, marked "!")
+```
+
+### Rule 4: Read the inherit percentage. That's the leak.
+
+`inherit` means no one chose a model - the dispatch silently took the main model. Some of those should be frontier. Most are "implement this spec" and "fix this test." Mine was 67%; an earlier 14-day window on the same machine was 80.7% (574 dispatches, $2,116 subagent spend). Defaults don't audit themselves.
+
+```
+67.0% of 1,368 dispatches: inherit
+→ bounded, well-specified work billed at frontier rates by default
+```
+
+### Rule 5: Compute your own annual number
+
+Multiply the flagged savings by 12 and decide if it's worth fifteen minutes of setup. Mine was $605.02 over 30 days - about $7,260 a year.
+
+```
+$605.02 flagged / 30 days  ×12 ≈ $7,260 / year
+```
+
+---
+
+## TUNE: compile a routing table from your own history
+
+### Rule 6: Start from the shipped defaults
+
+ax ships a default routing table - description prefixes and agent types mapped to the cheapest model that handles them. `ax routing compile` writes it to `~/.ax/hooks/routing-table.json`, merge-preserving, so your own classes survive regeneration. `ax routing show` prints what landed.
+
+```
+$ ax routing compile
+routing-table written: ~/.ax/hooks/routing-table.json
+
+$ ax routing show
+
+id                            pattern                                     suggest   origin
+spec-review                   ^spec review                                sonnet    default
+search-locate                 ^(pattern-find|locate|find|map|sweep|grep)  haiku     default
+research                      ^(research|investigate docs|study)          sonnet    default
+well-specified-impl           ^implement                                  sonnet    default
+bulk-mechanical               ^(write announcements|regenerate|standardize|merge main)  sonnet  default
+task-N-impl                   ^Task \d+:                                  sonnet    default
+bug-fix                       ^Fix\s                                      sonnet    default
+feature-add                   ^Add\s                                      sonnet    default
+agent-type:Explore                                                        haiku     default
+agent-type:codebase-locator                                               haiku     default
+agent-type:codebase-pattern-finder                                        haiku     default
+agent-type:codebase-analyzer                                              sonnet    default
+```
+
+### Rule 7: Flag the candidates and get a dollar figure
+
+`--candidates` filters your dispatch history to the expensive inherit runs that match a routing class, prices the alternative per dispatch, and shows where the $605.02 actually lives:
+
+```
+$ ax dispatches --candidates --days=30
+
+flagged: inherit + fable/opus + class match
+est. savings: $605.02
+
+top classes by savings:
+  well-specified-impl   $282.69
+  spec-review           $ 80.66
+  bug-fix               $ 69.37
+```
+
+### Rule 8: Mine new classes from your unmatched spend
+
+Your dispatch descriptions have patterns the defaults don't know. `ax routing tune` clusters the expensive inherit dispatches that no class caught (two-token prefix clustering, clusters of 3+) and proposes new classes suggesting sonnet. Dry-run first. On my history that surfaced $599.00 of spend the default table never saw:
+
+```
+$ ax routing tune --days=30 --dry-run
+
+id               pattern                suggest  count  addressable  judgment
+issue-N          ^issue\s+\d+\b         sonnet      12      $161.42  no
+quality-review   ^quality\s+review\b    sonnet      43      $105.90  YES
+plan-phase       ^plan\s+phase\b        sonnet       4       $77.64  YES
+final-review     ^final\s+review\b      sonnet      16       $75.70  YES
+attempt-N        ^attempt\s+\d+\b       sonnet       9       $26.89  no
+impl-N           ^impl\s+\d+\b          sonnet      10       $25.18  no
+...
+
+20 proposals  addressable spend: $599.00  (30 days)
+apply non-judgment: ax routing tune --days=30   brief: ax routing tune --emit-brief
+```
+
+The `issue-N` row alone - "Issue 248 manifest hidden flag" and eleven siblings - is $161.42 of inherit spend with a two-token pattern sitting on top of it.
+
+```
+$ ax routing tune --days=30
+applied non-judgment proposals → ~/.ax/hooks/routing-table.json  (origin: user)
+```
+
+### Rule 9: Never let judgment work auto-route. Backtest it.
+
+This is the rule that keeps the loop honest. In the dry-run above, 14 of my 20 proposals carry `judgment: YES` - quality-review ($105.90), plan-phase ($77.64), final-review ($75.70) - the biggest clusters, and never auto-applied. Of the $599.00 mined, only $218.63 is auto-appliable; $380.35 is judgment-gated. A false-positive routing class on review or plan work costs more than it saves. Gated proposals ship as a task brief, your agent adversarially backtests each class against false positives, and only survivors get applied.
+
+```
+$ ax routing tune --days=30 --emit-brief
+wrote .ax/tasks/routing-tune-2026-06-13.md
+
+# agent backtests each proposed class against history,
+# hunting for dispatches that would have routed wrong
+
+$ ax routing tune --apply=<id>,<id> --days=30
+```
+
+### Rule 10: Install the hook that makes it real
+
+The routing table does nothing until something reads it. The `route-dispatch` hook fires on every Agent dispatch in Claude Code, reads `routing-table.json` at fire time, and when a forgotten dispatch matches a route-down class, advises the model to re-dispatch on the cheaper tier.
+
+It advises - it does not enforce. A Claude Code hook can't rewrite or block an `Agent` dispatch: the `updatedInput` and `deny` paths are silently ignored for that tool (CC bugs #39814, #40580). The only channel that reaches the model is context, so the hook injects an advisory and the model acts on it. The real routing lives one layer up, in the cognitive loop: the `efficient-dispatch` skill teaches the main agent to name a cheap model in the first place, and the hook is the backstop that catches what it forgot. Fails open.
+
+```
+ax hooks init
+ax hooks install ~/.ax/hooks/route-dispatch.ts --providers=claude
+npx skills add Necmttn/ax
+```
+
+---
+
+## OPERATE: keep the leak closed
+
+### Rule 11: Treat flagged savings as a health metric. It should trend to zero.
+
+Once the hook is live, `--candidates` measures what's escaping the table. Run it weekly; a rising number means new dispatch patterns it hasn't learned yet. My hook installed mid-window, so the current week still shows the pre-hook leak:
+
+```
+$ ax dispatches --candidates --days=7
+
+total est savings: $419.50
+top classes: well-specified-impl ($212.30), spec-review ($65.15), bug-fix ($54.65)
+
+# target as routed dispatches replace inherit ones: → $0
+```
+
+### Rule 12: Audit the table, not the vibes
+
+`ax routing show` prints the effective table with origins - which classes are shipped defaults, which ones you mined from your own history. If you don't recognize a `user` class, trace it back to the tune run that created it.
+
+```
+$ ax routing show
+
+id                    pattern              suggest   origin
+spec-review           ^spec review         sonnet    default
+well-specified-impl   ^implement           sonnet    default
+bug-fix               ^Fix\s               sonnet    default
+...
+issue-N               ^issue\s+\d+\b       sonnet    user      ← mined by tune
+```
+
+### Rule 13: Write dispatch descriptions that route well
+
+The matcher is prefix patterns on the description. Real rows from my candidates list - dispatches whose names already match a class but ran inherit before the hook:
+
+```
+"Implement Task 1: EventJournal core"   matched ^implement      ran fable $12.72   sonnet est. saves $8.91
+"Sweep stale 8520 port refs"            matched ^(...|sweep)    ran fable $ 8.56   haiku  est. saves $7.70
+"Fix ingest run lifecycle"              matched ^Fix\s          ran fable $30.98   sonnet est. saves $21.69
+```
+
+"Issue 248 manifest hidden flag" matched nothing until tune mined the `issue-N` class from twelve siblings. "Implement the retry logic from the spec" routes; the same work named "look into the retry thing" inherits fable. Description discipline is free money.
+
+### Rule 14: Re-tune monthly. Your dispatch patterns drift.
+
+New projects mean new description shapes. A monthly tune run catches clusters the table missed; judgment-flagged ones go through the brief flow, same as Rule 9.
+
+```
+ax routing tune --days=30 --dry-run    # review proposals
+ax routing tune --days=30              # apply mechanical ones
+ax routing tune --days=30 --emit-brief # gate the judgment ones
+```
+
+### Rule 15: Keep judgment work on frontier. On purpose.
+
+Inherit is not always wrong. Architecture decisions, plan reviews, tricky design calls should run on the strongest model you have, and the table deliberately never touches them. The goal is not "cheapest model everywhere." It's "frontier where judgment lives, sonnet and haiku where the spec is already written." From my 30 days, dispatches that ran inherit on fable and should have:
+
+```
+stayed frontier, correctly:
+  "Plan phase 2 CLI families"          $28.17
+  "Plan phase 4 parser seam"           $25.29
+  "Correctness review of arch PRs"     $21.04
+```
+
+tune clustered these too (`plan-phase`, $77.64) and flagged the cluster `judgment: YES`, so it never auto-routes.
+
+Judgment protection cuts both ways, but only one way is automatic. The hook never routes review, design, or architecture work down. Hand one of those an explicit *cheap* model and it warns you off: "judgment is the catch-rate gate; prefer the strong model." What it does not do is route judgment *up*. Forcing opus onto a dispatch the table already deemed sonnet-adequate buys identical output and burns rate - a vanity metric. So the rule isn't "smartest model on review." It's: never route judgment down, never let you quietly cheap it out, never spend the strong model just to feel safe.
+
+---
+
+## ADAPT: route to your quota, not just your bill
+
+### Rule 16: Conserve by default. Splurge only when the meter says you've earned it.
+
+Routing down is right while you're conserving rate. It's wrong in exactly one window: when your weekly quota is about to reset with budget unspent. Force sonnet then and you just leave allowance on the table. So the hook reads a spend mode off your live plan quota - the same `ax quota` snapshot at `~/.ax/quota-cache.json`, read sync on the hot path, no network on dispatch.
+
+```
+conserve  (default)   route-down advisories ON    7d window tight, or cache stale/unknown
+splurge   (earned)    route-down advisories OFF   7d resets soon, real headroom, no window near its cap
+```
+
+`conserve` is the safe default; stale cache, missing token, low headroom all fall here. Never splurge on uncertainty. `splurge` has to be earned: the 7d window near reset (under 24h), real headroom (over 25% unused), and neither the 5h nor the 7d window near its ceiling - they draw down the same budget, so either cap kills it. Override anytime with `AX_SPEND_MODE=conserve|splurge`.
+
+Splurge is purely subtractive. It does not force anything up. It stops forcing things down, so your forgotten dispatches run on the strong inherited model while the allowance you'd otherwise waste is there to use.
+
+```
+$ ax quota --statusline
+5h 30% → 15:00 · 7d 19% · SPLURGE ⚡ → /dojo
+```
+
+### Rule 17: When you're in splurge, spend the surplus on purpose.
+
+Splurge means weekly allowance about to reset unused, and unused allowance evaporates. That's the budget to burn on self-improvement, not on opus-for-vanity. When the mode flips, ax nudges you once per session to run `/dojo` - the loop that spends surplus quota on backtests, proposal mining, and churn experiments. The system tells you *when* the surplus exists; you decide *whether* to spend it. Proactive, opt-in, in-harness - not a daemon burning your API in the background.
+
+---
+
+## The bigger leak: the main agent itself
+
+Everything above tunes the subagent bill. But go back to Rule 2: subagents were 16% of the $25,027. The main agent - the model running your actual chat - was the other 84%. Every window I split it the same way, the main agent lands between 78 and 81% of total spend. The 17 rules optimize the tail.
+
+So I built a command to look at the trunk. `ax cost routability` classifies main-agent turns by the tools they actually used. Read-only sweeps (gather → haiku), mechanical edits (mechanical-impl → sonnet), and web research (niche-research → sonnet) are routable - bounded work the frontier model did inline that a cheap subagent could have done instead. Reasoning, coordination, and judgment stay on frontier. Then it reprices the routable turns one tier down.
+
+```
+$ ax cost routability --days=30
+
+main-agent spend: $14,478   routable: $3,240 (22%)   est. savings: $1,766
+
+class            runs   turns   main_cost    tier     repriced    est_savings
+mechanical-impl 10442   10499    $2890.34   sonnet    $1407.69     $1482.66
+gather           1334    1348     $326.94   haiku       $56.01      $270.93
+niche-research     71      95      $22.54   sonnet      $10.20       $12.34
+stays main      28750   39481   $11238.33   -                -            -
+
+estimate: edit/read turns assumed mechanically routable (upper-ish bound); claude main only.
+```
+
+$1,766 a month. About $21K a year. Several times the entire subagent leak the rest of this article is about - $605 a month - and it was sitting in the model I talk to all day. mechanical-impl is the bulk: the main agent editing files itself instead of handing the edit to a sonnet subagent. The $11,238 `stays main` row is genuine reasoning, coordination, and dispatching work, correctly left on frontier. The goal was never cheap everywhere. It's: stop doing bounded mechanical work inline on the most expensive model you have.
+
+Same caveats as the rest, louder here because the number is bigger. It's an upper bound - a turn that reasons hard and then makes one mechanical edit reads as routable, because the transcript strips the thinking, so call $1,766 a ceiling, not a quote. It's Claude main-agent only by construction; other harnesses' main spend isn't counted. And it's projected from historical token counts, not A/B-tested for quality parity.
+
+The behavior moved before the command existed. Over 90 days my subagent dispatch rate went from 19/day to 114/day - 6x. Call it subagent-driven development: once you see the trunk you start pushing work off it, sending bounded, well-specified, mechanical jobs out to cheap subagents instead of running them inline. Routing those subagents cheaper - the 17 rules - is step 2. Step 1 is not doing the expensive work in the main thread at all. The biggest line on the bill is the model you're talking to.
+
+---
+
+## Where the math lands
+
+30 days, one machine, real transcripts. $25,027 total agent spend, $3,956.59 of it subagents across 1,368 dispatches, 67.0% inherit. The waste came in three leaks of comparable size:
+
+- $605.02 the shipped routing classes catch - $7,260/year (well-specified-impl $282.69, spec-review $80.66, bug-fix $69.37)
+- $599.00 `ax routing tune` mined into 20 new classes: $218.63 auto-applied, $380.35 judgment-gated pending backtest
+- $571.52 you can't see by reading the dispatch model column at all - 66 routed dispatches that continued off-model after the override was set
+
+The earlier 14-day window on the same machine told the same story: $2,301 of sub-task spend on fable/opus against $83 on sonnet.
+
+Honest caveats, because the numbers deserve them. The savings are projections from historical token counts, not A/B-tested quality parity. The route-dispatch hook is Claude Code only and advisory by nature - it can't rewrite an Agent dispatch, so it nudges the model rather than enforcing. It's the backstop, not the strategy; the main mechanism is the agent choosing explicit cheap models at dispatch time. And some inherit dispatches genuinely should be frontier - judgment work the table never touches in either direction.
+
+## What I'm still trying to understand
+
+The boundary cases. "Implement the spec" routes clean. "Review the design" stays frontier. But "refactor this module" sits in the middle - sometimes mechanical, sometimes a judgment call wearing a mechanical name. ax answers with a gate: anything that smells like judgment goes through an agent-backtested brief before it ever routes down. That's a process answer, not a model answer. I don't yet know if the middle can be classified, or only quarantined.
+
+So here's the actual ask. Run one command: `ax dispatches --candidates --days=30`. Read the number. If it's meaningful, install the hook (Rule 10) and let it nudge your helper tasks cheaper. If you're on Cursor, OpenCode, Codex, or Pi, ax still measures the hidden spend - the auto-advice is Claude Code only for now, so you steer by hand. And if the number comes back as noise, stop. The honest result is sometimes "you don't have this problem," and that's fine. github.com/Necmttn/ax
+
+p.s. - every hosted router has the same shape: a platform sits between you and the model, routes your tokens, and takes its cut somewhere in the stack. ax can't do that. it's a local CLI reading transcripts off your own disk - it doesn't proxy your tokens, doesn't bill you, doesn't profit when you spend more or less. the routing table it compiles is yours, built from your history, applied by a hook you can read in one file.
+
+the incentive to lower your bill is clean because there's no bill on the other side.

--- a/apps/site/content/blog/2026-06-13-routing-tune.md
+++ b/apps/site/content/blog/2026-06-13-routing-tune.md
@@ -54,13 +54,11 @@ One dispatch made it obvious. "Implement S2-T4" routed to sonnet. The sonnet leg
 
 <Figure id="Receipt" label="'Implement S2-T4' · the route that didn't stick" lead="The override applied to the first leg only." caption="99% of the cost landed after the routed leg, on the parent's frontier model - and the dispatch_model column still reads sonnet.">
 
-```
-"Implement S2-T4"
+<AxResult>{`"Implement S2-T4"
   requested:    sonnet
   sonnet leg:   ~$1
   continued on: claude-fable-5   $116
-  total:        $117    (99% billed off-model, after the route)
-```
+  total:        $117    (99% billed off-model, after the route)`}</AxResult>
 
 </Figure>
 
@@ -68,15 +66,13 @@ Across the same 30 days: 66 routed dispatches continued on a different model tha
 
 <Figure id="ax dispatches" label="--days=30 · dropped-leg footer" lead="The leak you can't see, made visible." caption="ax marks dropped-leg rows with a ! and a dropped-cost footer, so a route that didn't stick stops looking like a route that worked.">
 
-```
-$ ax dispatches --days=30
+<AxResult>{`$ ax dispatches --days=30
 
 ts                   description            dispatch_model  child_model        cost
 2026-06-XXT..:..:..  Implement S2-T4    !   sonnet          claude-fable-5     $117.00
 ...
 
-dropped (off-model continuation): 66 dispatches  $571.52
-```
+dropped (off-model continuation): 66 dispatches  $571.52`}</AxResult>
 
 </Figure>
 
@@ -109,25 +105,20 @@ ax ingest --since=30
 
 The matrix your harness never shows: who spent the money - main agent or subagents - and on which model.
 
-<Figure id="ax cost split" label="--days=30 · origin × model" lead="The split your invoice never breaks out." caption="Share is each row's slice of the $25,027 total. The real table breaks out every main-agent model and adds token columns - collapsed to one line here so the subagent split stays the point.">
+<Figure id="ax cost split" label="--days=30 · origin × model" lead="The split your invoice never breaks out." caption="Main agent is the bill: 84% of the $25,027 total. The subagent green slice - the whole subject of this article - is the 16% sliver, broken out below by model. fable is the hot bar: 4x sonnet's spend on half its sessions.">
 
-```
-$ ax cost split --days=30
+<SplitBar total="$25,027.00" totalLabel="total (main + subagent)">
+  <SplitSeg label="main agent" amount="$21,015.22" pct="84.0%" tone="ink" />
+  <SplitSeg label="subagent" amount="$4,011.78" pct="16.0%" tone="green" />
+</SplitBar>
 
-origin × model, 30 days   (subagent rows shown; main rows + token columns trimmed)
-
-origin    model               sessions          cost    share
-subagent  claude-fable-5           247     $1,979.34    7.9%
-subagent  claude-opus-4-7         229     $  758.83    3.0%
-subagent  claude-opus-4-8         225     $  747.93    3.0%
-subagent  claude-sonnet-4-6      517     $  478.36    1.9%
-subagent  claude-haiku           114     $   47.32    0.2%
-                                        ──────────   ───────
-subagent subtotal                        $4,011.78   16.0%
-main agent (models trimmed)             $21,015.22   84.0%
-                                        ──────────   ───────
-TOTAL (main + subagent)                  $25,027.00  100.0%
-```
+<BarChart label="subagent spend by model · 30 days">
+  <Bar name="claude-fable-5" amount="$1,979.34" pct="7.9%" value={1979.34} sub="247 sessions" peak />
+  <Bar name="claude-opus-4-7" amount="$758.83" pct="3.0%" value={758.83} sub="229 sessions" />
+  <Bar name="claude-opus-4-8" amount="$747.93" pct="3.0%" value={747.93} sub="225 sessions" />
+  <Bar name="claude-sonnet-4-6" amount="$478.36" pct="1.9%" value={478.36} sub="517 sessions" />
+  <Bar name="claude-haiku" amount="$47.32" pct="0.2%" value={47.32} sub="114 sessions" />
+</BarChart>
 
 </Figure>
 
@@ -137,8 +128,7 @@ Every Task dispatch: its description, whether a model was specified, what the ch
 
 <Figure id="ax dispatches" label="--days=30 · sorted by child cost" lead="Every dispatch, priced and sorted." caption="The expensive inherit rows tell you everything; the footer counts the routed dispatches that continued off-model.">
 
-```
-$ ax dispatches --days=30
+<AxResult>{`$ ax dispatches --days=30
 
 ts                   description                        dispatch_model  child_model        cost
 2026-06-11T08:52:56  Issue 248 manifest hidden flag     inherit         claude-fable-5     $22.72
@@ -146,8 +136,7 @@ ts                   description                        dispatch_model  child_mo
 ...
 
 1368 dispatches  67.0% inherit  total subagent cost: $3956.59  (30 days)
-model drops: 66 routed dispatches continued on a different model ($571.52 on dropped legs, marked "!")
-```
+model drops: 66 routed dispatches continued on a different model ($571.52 on dropped legs, marked "!")`}</AxResult>
 
 </Figure>
 
@@ -165,9 +154,7 @@ model drops: 66 routed dispatches continued on a different model ($571.52 on dro
 
 Multiply the flagged savings by 12 and decide if it's worth fifteen minutes of setup. Mine was $605.02 over 30 days - about $7,260 a year.
 
-```
-$605.02 flagged / 30 days  ×12 ≈ $7,260 / year
-```
+<AxResult>{`$605.02 flagged / 30 days  ×12 ≈ $7,260 / year`}</AxResult>
 
 ---
 
@@ -208,8 +195,7 @@ agent-type:codebase-analyzer                                              sonnet
 
 <Figure id="ax dispatches --candidates" label="--days=30 · est. savings by class" lead="Where the $605.02 actually lives." caption="inherit dispatches that match a routing class, repriced one tier down, ranked by the class that would save the most.">
 
-```
-$ ax dispatches --candidates --days=30
+<AxResult>{`$ ax dispatches --candidates --days=30
 
 flagged: inherit + fable/opus + class match
 est. savings: $605.02
@@ -217,8 +203,7 @@ est. savings: $605.02
 top classes by savings:
   well-specified-impl   $282.69
   spec-review           $ 80.66
-  bug-fix               $ 69.37
-```
+  bug-fix               $ 69.37`}</AxResult>
 
 </Figure>
 
@@ -248,24 +233,20 @@ apply non-judgment: ax routing tune --days=30   brief: ax routing tune --emit-br
 
 The `issue-N` row alone - "Issue 248 manifest hidden flag" and eleven siblings - is $161.42 of inherit spend with a two-token pattern sitting on top of it.
 
-```
-$ ax routing tune --days=30
-applied non-judgment proposals → ~/.ax/hooks/routing-table.json  (origin: user)
-```
+<AxResult>{`$ ax routing tune --days=30
+applied non-judgment proposals → ~/.ax/hooks/routing-table.json  (origin: user)`}</AxResult>
 
 ### Rule 9: Never let judgment work auto-route. Backtest it.
 
 This is the rule that keeps the loop honest. In the dry-run above, 14 of my 20 proposals carry `judgment: YES` - quality-review ($105.90), plan-phase ($77.64), final-review ($75.70) - the biggest clusters, and never auto-applied. Of the $599.00 mined, only $218.63 is auto-appliable; $380.35 is judgment-gated. A false-positive routing class on review or plan work costs more than it saves. Gated proposals ship as a task brief, your agent adversarially backtests each class against false positives, and only survivors get applied.
 
-```
-$ ax routing tune --days=30 --emit-brief
+<AxResult>{`$ ax routing tune --days=30 --emit-brief
 wrote .ax/tasks/routing-tune-2026-06-13.md
 
 # agent backtests each proposed class against history,
 # hunting for dispatches that would have routed wrong
 
-$ ax routing tune --apply=<id>,<id> --days=30
-```
+$ ax routing tune --apply=<id>,<id> --days=30`}</AxResult>
 
 ### Rule 10: Install the hook that makes it real
 
@@ -287,14 +268,12 @@ npx skills add Necmttn/ax
 
 Once the hook is live, `--candidates` measures what's escaping the table. Run it weekly; a rising number means new dispatch patterns it hasn't learned yet. My hook installed mid-window, so the current week still shows the pre-hook leak:
 
-```
-$ ax dispatches --candidates --days=7
+<AxResult>{`$ ax dispatches --candidates --days=7
 
 total est savings: $419.50
 top classes: well-specified-impl ($212.30), spec-review ($65.15), bug-fix ($54.65)
 
-# target as routed dispatches replace inherit ones: → $0
-```
+# target as routed dispatches replace inherit ones: → $0`}</AxResult>
 
 ### Rule 12: Audit the table, not the vibes
 
@@ -337,12 +316,10 @@ ax routing tune --days=30 --emit-brief # gate the judgment ones
 
 Inherit is not always wrong. Architecture decisions, plan reviews, tricky design calls should run on the strongest model you have, and the table deliberately never touches them. The goal is not "cheapest model everywhere." It's "frontier where judgment lives, sonnet and haiku where the spec is already written." From my 30 days, dispatches that ran inherit on fable and should have:
 
-```
-stayed frontier, correctly:
+<AxResult>{`stayed frontier, correctly:
   "Plan phase 2 CLI families"          $28.17
   "Plan phase 4 parser seam"           $25.29
-  "Correctness review of arch PRs"     $21.04
-```
+  "Correctness review of arch PRs"     $21.04`}</AxResult>
 
 tune clustered these too (`plan-phase`, $77.64) and flagged the cluster `judgment: YES`, so it never auto-routes.
 
@@ -365,10 +342,8 @@ splurge   (earned)    route-down advisories OFF   7d resets soon, real headroom,
 
 Splurge is purely subtractive. It does not force anything up. It stops forcing things down, so your forgotten dispatches run on the strong inherited model while the allowance you'd otherwise waste is there to use.
 
-```
-$ ax quota --statusline
-5h 30% → 15:00 · 7d 19% · SPLURGE ⚡ → /dojo
-```
+<AxResult>{`$ ax quota --statusline
+5h 30% → 15:00 · 7d 19% · SPLURGE ⚡ → /dojo`}</AxResult>
 
 ### Rule 17: When you're in splurge, spend the surplus on purpose.
 
@@ -384,8 +359,7 @@ So I built a command to look at the trunk. `ax cost routability` classifies main
 
 <Figure id="ax cost routability" label="--days=30 · main-agent turns, repriced" lead="The trunk, not the tail." caption="$1,766/month - several times the entire subagent leak - sitting in the model you talk to all day. The stays-main row is genuine reasoning and coordination, correctly left on frontier.">
 
-```
-$ ax cost routability --days=30
+<AxResult>{`$ ax cost routability --days=30
 
 main-agent spend: $14,478   routable: $3,240 (22%)   est. savings: $1,766
 
@@ -395,8 +369,7 @@ gather           1334    1348     $326.94   haiku       $56.01      $270.93
 niche-research     71      95      $22.54   sonnet      $10.20       $12.34
 stays main      28750   39481   $11238.33   -                -            -
 
-estimate: edit/read turns assumed mechanically routable (upper-ish bound); claude main only.
-```
+estimate: edit/read turns assumed mechanically routable (upper-ish bound); claude main only.`}</AxResult>
 
 </Figure>
 

--- a/apps/site/functions/og-blog/[slug].ts
+++ b/apps/site/functions/og-blog/[slug].ts
@@ -1,0 +1,91 @@
+/**
+ * Blog post OG card (1200x630 PNG).
+ *
+ * Renders purely from query params - the post page (blog_.$slug.tsx) knows the
+ * title/date from its loader and passes them on the og:image URL, so this
+ * function needs no content-collections access or manifest:
+ *   /og-blog/<slug>?title=<encoded>&date=YYYY-MM-DD&r=<rev>
+ *
+ * Satori rules (same as the profile/share cards): display:flex everywhere,
+ * integer px, margin-right not gap, no overflow/border-radius on tracks,
+ * no raw svg, hex colors only (no rgb() - commas break the style parser),
+ * no flex-wrap. Plain text in a fixed-width div wraps fine (it's text, not
+ * flex children).
+ */
+import { ImageResponse } from "workers-og";
+import {
+  INK, PAPER, DIM, CARD, GREEN,
+  esc, footerHtml, blockLogoHtml, loadOgFonts,
+} from "../_lib/og-kit";
+
+const MONTHS = [
+  "JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+  "JUL", "AUG", "SEP", "OCT", "NOV", "DEC",
+] as const;
+
+function fmtDate(iso: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  if (!m) return "";
+  const month = MONTHS[Number(m[2]) - 1];
+  return month ? `${month} ${Number(m[3])}, ${m[1]}` : "";
+}
+
+export const onRequestGet: PagesFunction = async (ctx) => {
+  const cache = (caches as unknown as { default: Cache }).default;
+  const u = new URL(ctx.request.url);
+  const cacheKey = new Request(u.toString());
+  const hit = await cache.match(cacheKey);
+  if (hit) return hit;
+
+  const rawTitle = (u.searchParams.get("title") ?? "").slice(0, 140).trim();
+  const title = rawTitle.length > 0 ? rawTitle : "ax blog";
+  const dateLabel = fmtDate(u.searchParams.get("date") ?? "");
+
+  // Header: block logo left, kicker right.
+  const logo = blockLogoHtml({ scale: 4, color: PAPER, dimColor: "transparent" });
+  const kicker = `AX · FIELD NOTES${dateLabel ? ` · ${esc(dateLabel)}` : ""}`;
+  const header = `<div style="display:flex;justify-content:space-between;align-items:center"><div style="display:flex">${logo}</div><span style="font-size:14px;letter-spacing:3px;color:${DIM}">${kicker}</span></div>`;
+
+  // Title: large serif, wraps within the content width. Size steps down for
+  // longer headlines so a long title still fits 630px tall.
+  const titleSize = title.length > 80 ? 60 : title.length > 48 ? 72 : 88;
+  const titleHtml = `<div style="display:flex;margin-top:48px"><div style="display:flex;width:1040px;font-family:'Gelasio';font-weight:700;font-size:${titleSize}px;line-height:1.08;color:${INK}">${esc(title)}</div></div>`;
+
+  // Accent rule under the title (green = the house "live/earned" accent).
+  const rule = `<div style="display:flex;margin-top:36px"><div style="display:flex;width:120px;height:8px;background:${GREEN}"></div></div>`;
+
+  const inner = `<div style="display:flex;flex-direction:column">${header}${titleHtml}${rule}</div>`;
+  const footer = footerHtml("ax.necmttn.com/blog · measured from local transcripts");
+  const html = `<div style="display:flex;flex-direction:column;justify-content:space-between;width:1200px;height:630px;background:${CARD};padding:56px 64px;font-family:'JetBrains Mono'">${inner}${footer}</div>`;
+
+  const { regular, bold, serif } = await loadOgFonts();
+
+  let png: ArrayBuffer;
+  try {
+    const image = new ImageResponse(html, {
+      width: 1200,
+      height: 630,
+      fonts: [
+        { name: "JetBrains Mono", data: regular, weight: 400, style: "normal" },
+        { name: "JetBrains Mono", data: bold, weight: 700, style: "normal" },
+        { name: "Gelasio", data: serif, weight: 700, style: "normal" },
+      ],
+    });
+    png = await image.arrayBuffer();
+  } catch (err) {
+    return new Response(
+      `render error: ${err instanceof Error ? `${err.message}\n${err.stack ?? ""}` : String(err)}`,
+      { status: 500 },
+    );
+  }
+  if (png.byteLength === 0) return new Response("render produced 0 bytes", { status: 500 });
+
+  const res = new Response(png, {
+    headers: {
+      "content-type": "image/png",
+      "cache-control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+  ctx.waitUntil(cache.put(cacheKey, res.clone()));
+  return res;
+};


### PR DESCRIPTION
## What

A blog at **/blog** on the site, with an **origin-grade article system** so every post reads like the /origin essay — not plain markdown.

## How

- **5th content collection** (`content-collections.ts`) reads `apps/site/content/blog/*.md` (frontmatter: title/date/excerpt/tags). Routes `/blog` (index) + `/blog/$slug` (post), mirroring the changelog pattern.
- **Reusable MDX article kit** (`app/components/mdx-components.tsx`, `.blog-essay` scope) any post drops inline:
  - `Figure`/`Exhibit` — numbered chip + label + monospace caption
  - `StatGrid`/`Stat` — origin's big-numeral exhibit grid
  - `SplitBar` — proportional stacked bar (e.g. main 84% vs subagent 16%)
  - `BarChart`/`Bar` — horizontal bars, fill ∝ value, peak tone
  - `AxResult` — colorized `ax` command output (money green, `!`/dropped/off-model red, prompt dim, model names tinted)
  - `Callout`, `PullQuote`, `FrameworkList`, `KBD`
- **Per-post OG cards** (`functions/og-blog/[slug].ts`) render a 1200×630 Satori card from title/date query params the post passes on `og:image` — no manifest.
- **First post**: the routing-tune article, upgraded to the kit — receipts → Figures, the cost-split → SplitBar + per-model BarChart, the three-price contrast → StatGrid, 11 ax receipts colorized via AxResult.

## Verify

- `bun run build` exits 0; prerenders `/blog` + `/blog/2026-06-13-routing-tune`; OG meta in the HTML.
- Previewed against `/origin` via cmux — split bar, per-model bars (fable red peak), colorized receipts, pull-quotes all match the bar.
- `bun run typecheck`: 95 (= 93 pre-existing site strict-null baseline + the 2 `loaderData`-never errors every dynamic content-collections route already has — adr, changelog; no new categories).

## Follow-ups (noted, non-blocking)
- Studio has no cost/dispatch view to screenshot for this topic; building one is a separate effort (then /showcases + a studio screenshot land in the post).
- `rehype-pretty-code` is configured but not transforming blog input code blocks (plain output) — pre-existing; real syntax colors on input blocks is a later look.
- Routing-table output blocks (regex patterns) left as plain code — template-literal escaping would corrupt `\d`/`\s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)