### PR TITLE
feat(team): executable-hook trust layer — `ax team trust` (Mesh A)

### DIFF
--- a/apps/axctl/src/cli/commands/team.test.ts
+++ b/apps/axctl/src/cli/commands/team.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { renderSyncReport } from "./team.ts";
+import { renderSyncReport, renderTrustReport } from "./team.ts";
 
 describe("renderSyncReport", () => {
   it("summarizes activated, unchanged, and gated", () => {
@@ -11,5 +11,19 @@ describe("renderSyncReport", () => {
   });
   it("empty-state when no rig", () => {
     expect(renderSyncReport({ activated: [], unchanged: [], gated: [] })).toContain("no team rig");
+  });
+});
+
+describe("renderTrustReport", () => {
+  it("shows installed count", () => {
+    const out = renderTrustReport({ installed: ["hook:enforce-x"], changed: [], added: [], onDefault: true });
+    expect(out).toContain("installed 1");
+  });
+  it("refuses off the default branch when there are hooks to install", () => {
+    const out = renderTrustReport({ installed: [], changed: ["hook:x"], added: [], onDefault: false });
+    expect(out).toMatch(/default branch|refus|not trusted/i);
+  });
+  it("empty-state when no executable hooks", () => {
+    expect(renderTrustReport({ installed: [], changed: [], added: [], onDefault: true })).toContain("no executable");
   });
 });

--- a/apps/axctl/src/cli/commands/team.ts
+++ b/apps/axctl/src/cli/commands/team.ts
@@ -27,9 +27,9 @@ import {
     defaultExecTrustPath,
     type ExecTrustState,
 } from "../../team/exec-trust.ts";
-import { sha256OfFile } from "../../team/exec-hash.ts";
+import { sha256Hex } from "../../team/exec-hash.ts";
 import { isOnDefaultBranch } from "../../team/git-branch.ts";
-import { installTeamHook } from "../../team/install-team-hook.ts";
+import { installTeamHook, isSafeHookName, hookSnapshotPath } from "../../team/install-team-hook.ts";
 import { HookProviderRegistryDefault } from "../../hooks/providers/registry.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 
@@ -212,6 +212,35 @@ const syncCommand = Command.make(
 // ax team trust
 // ---------------------------------------------------------------------------
 
+/**
+ * Make attacker-controlled hook source safe to print to a terminal.
+ * Strips C0 control chars + DEL (-> "?") and renders ESC visibly ("\x1b") so
+ * embedded ANSI can't scroll the payload out of view or spoof the NEW:/sha256:
+ * review labels. Keeps \n and \t. ESC is replaced FIRST so it survives as text.
+ */
+const sanitize = (s: string): string =>
+    s.replace(/\x1b/g, "\\x1b").replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "?");
+
+/** Full, sanitized line diff (no truncation - this is executable code about to
+ *  be trusted across the team, so the whole body must be reviewable). */
+const renderDiff = (oldText: string, newText: string): string => {
+    const oldLines = oldText.split("\n");
+    const newLines = newText.split("\n");
+    const out: string[] = [];
+    const n = Math.max(oldLines.length, newLines.length);
+    for (let i = 0; i < n; i++) {
+        const o = oldLines[i];
+        const nw = newLines[i];
+        if (o === nw) {
+            if (o !== undefined) out.push(`    ${sanitize(o)}`);
+        } else {
+            if (o !== undefined) out.push(`  - ${sanitize(o)}`);
+            if (nw !== undefined) out.push(`  + ${sanitize(nw)}`);
+        }
+    }
+    return out.join("\n");
+};
+
 const cmdTrust = (input: { readonly yes: boolean; readonly allowBranch: boolean }) =>
     Effect.gen(function* () {
         // 1. Get git repo root
@@ -233,14 +262,18 @@ const cmdTrust = (input: { readonly yes: boolean; readonly allowBranch: boolean 
             return;
         }
 
-        // 3. sha256 each gated hook
-        const shaMap = yield* Effect.promise(async () => {
-            const map = new Map<string, string>();
-            for (const h of gated) {
-                map.set(execKey(h), await sha256OfFile(h.path));
-            }
-            return map;
+        // 3. Read each gated hook's content ONCE; thread that single buffer
+        //    everywhere so judged == hashed == snapshotted == run == stored.
+        //    Re-reading between hash/diff/install opens a local TOCTOU race where
+        //    the bytes the human approves differ from what gets pinned + run.
+        const body = yield* Effect.promise(async () => {
+            const m = new Map<string, string>();
+            for (const h of gated) m.set(h.name, await Bun.file(h.path).text());
+            return m;
         });
+        const contentOf = (h: GatedArtifact): string => body.get(h.name) ?? "";
+        const shaMap = new Map<string, string>();
+        for (const h of gated) shaMap.set(execKey(h), sha256Hex(contentOf(h)));
         const shaOf = (h: GatedArtifact): string => shaMap.get(execKey(h)) ?? "";
 
         // 4. Load trust state + classify
@@ -268,36 +301,35 @@ const cmdTrust = (input: { readonly yes: boolean; readonly allowBranch: boolean 
             return;
         }
 
-        // 7. Show diffs for changed/added hooks
+        // 7. Show the FULL hook source for review, sanitized. The trust model is
+        //    "the human reads the executable bytes and approves with --yes". So
+        //    never truncate (a payload could hide past a benign head) and never
+        //    emit raw control bytes (ANSI could scroll the payload off-screen or
+        //    spoof the NEW:/sha256: labels). Bytes shown == bytes hashed/run.
         for (const h of cls.changed) {
             const rec = trust[execKey(h)];
             console.log(`CHANGED: ${execKey(h)}`);
             console.log(`  old sha256: ${rec?.sha256 ?? "(unknown)"}`);
             console.log(`  new sha256: ${shaOf(h)}`);
-            if (rec?.content) {
-                const newContent = yield* Effect.promise(() => Bun.file(h.path).text());
-                const oldLines = rec.content.split("\n");
-                const newLines = newContent.split("\n");
-                const diffLines: string[] = [];
-                const maxLines = Math.min(Math.max(oldLines.length, newLines.length), 30);
-                for (let i = 0; i < maxLines; i++) {
-                    if (oldLines[i] !== newLines[i]) {
-                        if (oldLines[i] !== undefined) diffLines.push(`  - ${oldLines[i]}`);
-                        if (newLines[i] !== undefined) diffLines.push(`  + ${newLines[i]}`);
-                    }
-                }
-                if (diffLines.length > 0) console.log(diffLines.join("\n"));
+            const newContent = contentOf(h);
+            if (rec?.content !== undefined) {
+                console.log(renderDiff(rec.content, newContent));
+            } else {
+                console.log(
+                    sanitize(newContent)
+                        .split("\n")
+                        .map((l) => `  | ${l}`)
+                        .join("\n"),
+                );
             }
         }
         for (const h of cls.added) {
-            const content = yield* Effect.promise(() => Bun.file(h.path).text());
             console.log(`NEW: ${execKey(h)}`);
             console.log(`  sha256: ${shaOf(h)}`);
             console.log(
-                content
+                sanitize(contentOf(h))
                     .split("\n")
-                    .slice(0, 15)
-                    .map((l) => `  ${l}`)
+                    .map((l) => `  | ${l}`)
                     .join("\n"),
             );
         }
@@ -319,12 +351,31 @@ const cmdTrust = (input: { readonly yes: boolean; readonly allowBranch: boolean 
             return;
         }
 
+        // 9.5 Validate ALL hook names up front, before installing ANY. An unsafe
+        //     name (e.g. .ax/hooks/.config) would throw mid-loop AFTER earlier
+        //     hooks already wrote to provider configs but BEFORE saveExecTrust,
+        //     leaving config/trust drift. Partition first; skip + warn the rest.
+        const safeInstall = toInstall.filter((h) => {
+            if (isSafeHookName(h.name)) return true;
+            console.warn(`[ax team trust] skipping unsafe hook name: ${JSON.stringify(h.name)}`);
+            return false;
+        });
+
         // 10. Install each approved hook + update trust record
         const installedKeys: string[] = [];
         const mutableTrust: ExecTrustState = { ...trust };
 
-        for (const h of toInstall) {
-            const content = yield* Effect.promise(() => Bun.file(h.path).text());
+        for (const h of safeInstall) {
+            const content = contentOf(h);
+            // Clobber warning: a pre-existing snapshot with no exec-trust record
+            // is somebody else's hook we're about to overwrite.
+            const snapPath = hookSnapshotPath(h.name, home);
+            const untrackedClobber =
+                !(execKey(h) in trust) &&
+                (yield* Effect.promise(() => Bun.file(snapPath).exists()));
+            if (untrackedClobber) {
+                console.warn(`[ax team trust] overwriting existing untracked hook at ${snapPath}`);
+            }
             yield* installTeamHook(h.name, content, home, ["claude", "codex"]);
             mutableTrust[execKey(h)] = {
                 sha256: shaOf(h),

--- a/apps/axctl/src/cli/commands/team.ts
+++ b/apps/axctl/src/cli/commands/team.ts
@@ -6,6 +6,11 @@
  *     runtime, trust-gated. Executable hooks in `.ax/hooks/` are reported as
  *     gated but never activated. `--dry-run` shows what would change without
  *     writing anything. `--yes` approves activation of new or changed artifacts.
+ *
+ *   ax team trust [--yes] [--allow-branch]
+ *     Review + install the team's executable `.ax/hooks/*` (sha256 trust-on-change,
+ *     default-branch-only). `--yes` approves installation. `--allow-branch`
+ *     bypasses the default-branch guard.
  */
 import { Effect } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
@@ -13,11 +18,23 @@ import { scanAxFolder } from "../../team/scan.ts";
 import { hashArtifact } from "../../team/hash.ts";
 import { loadTrust, saveTrust, classify, defaultTrustPath } from "../../team/trust.ts";
 import { activateArtifact, isSafeName } from "../../team/activate.ts";
-import { artifactKey, type TeamArtifact } from "../../team/model.ts";
+import { artifactKey, type TeamArtifact, type GatedArtifact } from "../../team/model.ts";
+import {
+    loadExecTrust,
+    saveExecTrust,
+    classifyExec,
+    execKey,
+    defaultExecTrustPath,
+    type ExecTrustState,
+} from "../../team/exec-trust.ts";
+import { sha256OfFile } from "../../team/exec-hash.ts";
+import { isOnDefaultBranch } from "../../team/git-branch.ts";
+import { installTeamHook } from "../../team/install-team-hook.ts";
+import { HookProviderRegistryDefault } from "../../hooks/providers/registry.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 
 // ---------------------------------------------------------------------------
-// Pure render helper (exported for tests)
+// Pure render helpers (exported for tests)
 // ---------------------------------------------------------------------------
 
 export interface SyncReport {
@@ -40,9 +57,27 @@ export const renderSyncReport = (r: SyncReport): string => {
         lines.push(`${r.unchanged.length} unchanged`);
     }
     if (r.gated.length > 0) {
-        lines.push("gated (executable hooks - trust-review before installing):");
+        lines.push("gated (executable hooks - run `ax team trust` to review + install them):");
         for (const name of r.gated) lines.push(`  ~ ${name}`);
     }
+    return lines.join("\n");
+};
+
+export interface TrustReport {
+    readonly installed: ReadonlyArray<string>;
+    readonly changed: ReadonlyArray<string>;
+    readonly added: ReadonlyArray<string>;
+    readonly onDefault: boolean;
+}
+
+/** Pure: format a trust result for stdout. No IO. */
+export const renderTrustReport = (r: TrustReport): string => {
+    if (r.installed.length === 0 && r.changed.length === 0 && r.added.length === 0)
+        return "[ax team trust] no executable hooks in .ax/hooks/.";
+    if (!r.onDefault && (r.changed.length || r.added.length) && r.installed.length === 0)
+        return "[ax team trust] refusing to install executable hooks: not on the repo's default branch (use --allow-branch to override).";
+    const lines = [`[ax team trust] installed ${r.installed.length} executable hook(s)`];
+    for (const k of r.installed) lines.push(`  + ${k}`);
     return lines.join("\n");
 };
 
@@ -100,7 +135,7 @@ const cmdSync = (input: { readonly dryRun: boolean; readonly yes: boolean }) =>
                 console.log(`${cls.unchanged.length} unchanged`);
             }
             if (gated.length > 0) {
-                console.log("gated (executable hooks - never activated):");
+                console.log("gated (executable hooks - run `ax team trust` to review + install them):");
                 for (const g of gated) console.log(`  ~ ${g.name}`);
             }
             if (toActivate.length === 0 && cls.unchanged.length === 0) {
@@ -168,8 +203,163 @@ const syncCommand = Command.make(
 ).pipe(
     Command.withDescription(
         "Activate the team's committed .ax/ rig (skills + agents) into your runtime, trust-gated. " +
-        "Hooks in .ax/hooks/ are gated and never activated. " +
+        "Hooks in .ax/hooks/ are gated (run `ax team trust` to install them). " +
         "--dry-run (show what would change)  --yes (approve activation of new or changed artifacts)",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax team trust
+// ---------------------------------------------------------------------------
+
+const cmdTrust = (input: { readonly yes: boolean; readonly allowBranch: boolean }) =>
+    Effect.gen(function* () {
+        // 1. Get git repo root
+        const r = Bun.spawnSync(["git", "rev-parse", "--show-toplevel"], {
+            stdout: "pipe",
+            stderr: "ignore",
+        });
+        if (r.exitCode !== 0) {
+            console.error("[ax team] not inside a git repo - run from the team repo root");
+            return;
+        }
+        const root = r.stdout.toString().trim();
+
+        // 2. Scan .ax/ for gated hooks
+        const { gated } = yield* Effect.promise(() => scanAxFolder(root));
+
+        if (gated.length === 0) {
+            console.log("[ax team trust] no executable hooks in .ax/hooks/.");
+            return;
+        }
+
+        // 3. sha256 each gated hook
+        const shaMap = yield* Effect.promise(async () => {
+            const map = new Map<string, string>();
+            for (const h of gated) {
+                map.set(execKey(h), await sha256OfFile(h.path));
+            }
+            return map;
+        });
+        const shaOf = (h: GatedArtifact): string => shaMap.get(execKey(h)) ?? "";
+
+        // 4. Load trust state + classify
+        const trust = yield* Effect.promise(() => loadExecTrust(defaultExecTrustPath()));
+        const cls = classifyExec(gated, shaOf, trust);
+        const toInstall = [...cls.added, ...cls.changed];
+
+        // 5. Branch guard: refuse if not on default branch and there are hooks to install
+        const onDefault = isOnDefaultBranch(root);
+        if (!onDefault && toInstall.length > 0 && !input.allowBranch) {
+            console.log(
+                renderTrustReport({
+                    installed: [],
+                    changed: cls.changed.map(execKey),
+                    added: cls.added.map(execKey),
+                    onDefault,
+                }),
+            );
+            return;
+        }
+
+        // 6. Nothing new to install
+        if (toInstall.length === 0) {
+            console.log(`[ax team trust] ${cls.trusted.length} hook(s) up to date`);
+            return;
+        }
+
+        // 7. Show diffs for changed/added hooks
+        for (const h of cls.changed) {
+            const rec = trust[execKey(h)];
+            console.log(`CHANGED: ${execKey(h)}`);
+            console.log(`  old sha256: ${rec?.sha256 ?? "(unknown)"}`);
+            console.log(`  new sha256: ${shaOf(h)}`);
+            if (rec?.content) {
+                const newContent = yield* Effect.promise(() => Bun.file(h.path).text());
+                const oldLines = rec.content.split("\n");
+                const newLines = newContent.split("\n");
+                const diffLines: string[] = [];
+                const maxLines = Math.min(Math.max(oldLines.length, newLines.length), 30);
+                for (let i = 0; i < maxLines; i++) {
+                    if (oldLines[i] !== newLines[i]) {
+                        if (oldLines[i] !== undefined) diffLines.push(`  - ${oldLines[i]}`);
+                        if (newLines[i] !== undefined) diffLines.push(`  + ${newLines[i]}`);
+                    }
+                }
+                if (diffLines.length > 0) console.log(diffLines.join("\n"));
+            }
+        }
+        for (const h of cls.added) {
+            const content = yield* Effect.promise(() => Bun.file(h.path).text());
+            console.log(`NEW: ${execKey(h)}`);
+            console.log(`  sha256: ${shaOf(h)}`);
+            console.log(
+                content
+                    .split("\n")
+                    .slice(0, 15)
+                    .map((l) => `  ${l}`)
+                    .join("\n"),
+            );
+        }
+
+        // 8. Approval gate: non-TTY or missing --yes → fail-safe, install nothing
+        if (!input.yes) {
+            console.log(
+                `[ax team trust] re-run with --yes to install ${toInstall.length} executable hook(s)`,
+            );
+            return;
+        }
+
+        // 9. HOME required
+        const home = process.env.HOME;
+        if (!home) {
+            console.error(
+                "[ax team trust] HOME is not set; cannot resolve the runtime (~/.ax/hooks). Aborting.",
+            );
+            return;
+        }
+
+        // 10. Install each approved hook + update trust record
+        const installedKeys: string[] = [];
+        const mutableTrust: ExecTrustState = { ...trust };
+
+        for (const h of toInstall) {
+            const content = yield* Effect.promise(() => Bun.file(h.path).text());
+            yield* installTeamHook(h.name, content, home, ["claude", "codex"]);
+            mutableTrust[execKey(h)] = {
+                sha256: shaOf(h),
+                content,
+                trusted_at: new Date().toISOString(),
+            };
+            installedKeys.push(execKey(h));
+        }
+
+        // 11. Save updated exec-trust state
+        yield* Effect.promise(() => saveExecTrust(defaultExecTrustPath(), mutableTrust));
+
+        // 12. Print report
+        console.log(
+            renderTrustReport({
+                installed: installedKeys,
+                changed: cls.changed.map(execKey),
+                added: cls.added.map(execKey),
+                onDefault,
+            }),
+        );
+    });
+
+const trustCommand = Command.make(
+    "trust",
+    {
+        yes: Flag.boolean("yes").pipe(Flag.withDefault(false)),
+        allowBranch: Flag.boolean("allow-branch").pipe(Flag.withDefault(false)),
+    },
+    ({ yes, allowBranch }) =>
+        cmdTrust({ yes, allowBranch }).pipe(Effect.provide(HookProviderRegistryDefault)),
+).pipe(
+    Command.withDescription(
+        "Review + install the team's executable .ax/hooks/* (sha256 trust-on-change, default-branch-only). " +
+        "--yes (approve installation)  --allow-branch (bypass default-branch guard)",
     ),
 );
 
@@ -181,7 +371,7 @@ export const teamCommand = Command.make("team").pipe(
     Command.withDescription(
         "Team rig management: activate the shared .ax/ skills and agents into your local runtime.",
     ),
-    Command.withSubcommands([syncCommand]),
+    Command.withSubcommands([syncCommand, trustCommand]),
 );
 
 export const teamRuntime: RuntimeManifest = {
@@ -191,6 +381,7 @@ export const teamRuntime: RuntimeManifest = {
             fallback: "none",
             subcommands: {
                 sync: "none",
+                trust: "none",
             },
         },
         hidden: false,

--- a/apps/axctl/src/team/exec-hash.test.ts
+++ b/apps/axctl/src/team/exec-hash.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "bun:test";
+import { sha256Hex } from "./exec-hash.ts";
+
+describe("sha256Hex", () => {
+  it("is the known sha256 of a string", () => {
+    expect(sha256Hex("abc")).toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  });
+  it("changes with content", () => {
+    expect(sha256Hex("a")).not.toBe(sha256Hex("b"));
+  });
+});

--- a/apps/axctl/src/team/exec-hash.ts
+++ b/apps/axctl/src/team/exec-hash.ts
@@ -1,0 +1,12 @@
+import { createHash } from "node:crypto";
+
+/** Full hex sha256 of text. Security-grade content pin for executable trust
+ *  (a non-cryptographic hash like Bun.hash would be insufficient here - a
+ *  collision is a trust-bypass, not just a missed change). */
+export const sha256Hex = (text: string): string => createHash("sha256").update(text).digest("hex");
+
+/** sha256 of a file's content; sha256("") for a missing/unreadable file. */
+export async function sha256OfFile(abs: string): Promise<string> {
+  const f = Bun.file(abs);
+  return (await f.exists()) ? sha256Hex(await f.text()) : sha256Hex("");
+}

--- a/apps/axctl/src/team/exec-trust.test.ts
+++ b/apps/axctl/src/team/exec-trust.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { classifyExec, execKey, type ExecTrustState } from "./exec-trust.ts";
+import type { GatedArtifact } from "./model.ts";
+
+const hook = (name: string): GatedArtifact => ({ kind: "hook", name, path: `/r/.ax/hooks/${name}.ts` });
+
+describe("classifyExec", () => {
+  it("buckets new / changed / trusted by sha256", () => {
+    const hooks = [hook("a"), hook("b"), hook("c")];
+    const sha: Record<string, string> = { a: "h1", b: "h2", c: "h3" };
+    const trust: ExecTrustState = {
+      "hook:b": { sha256: "h2", content: "...", trusted_at: "x" },
+      "hook:c": { sha256: "OLD", content: "old body", trusted_at: "x" },
+    };
+    const r = classifyExec(hooks, (h) => sha[h.name], trust);
+    expect(r.added.map((x) => x.name)).toEqual(["a"]);
+    expect(r.changed.map((x) => x.name)).toEqual(["c"]);
+    expect(r.trusted.map((x) => x.name)).toEqual(["b"]);
+  });
+  it("execKey is hook:name", () => {
+    expect(execKey(hook("x"))).toBe("hook:x");
+  });
+});

--- a/apps/axctl/src/team/exec-trust.ts
+++ b/apps/axctl/src/team/exec-trust.ts
@@ -1,0 +1,49 @@
+import { decodeJsonOrNull } from "@ax/lib/decode";
+import type { GatedArtifact } from "./model.ts";
+
+export interface ExecTrustRecord {
+  readonly sha256: string;
+  readonly content: string;
+  readonly trusted_at: string;
+}
+export type ExecTrustState = Record<string, ExecTrustRecord>; // key: "hook:<name>"
+
+export const execKey = (h: GatedArtifact): string => `${h.kind}:${h.name}`;
+export const defaultExecTrustPath = (): string => `${process.env.HOME}/.ax/team-trust-exec.json`;
+
+export async function loadExecTrust(path: string): Promise<ExecTrustState> {
+  try {
+    const f = Bun.file(path);
+    if (!(await f.exists())) return {};
+    const p = decodeJsonOrNull(await f.text());
+    return p && typeof p === "object" ? (p as ExecTrustState) : {};
+  } catch { return {}; }
+}
+
+export async function saveExecTrust(path: string, state: ExecTrustState): Promise<void> {
+  const tmp = `${path}.${process.pid}.tmp`;
+  await Bun.write(tmp, `${JSON.stringify(state, null, 2)}\n`, { createPath: true });
+  const r = Bun.spawnSync(["mv", tmp, path]);
+  if (r.exitCode !== 0) { Bun.spawnSync(["rm", "-f", tmp]); throw new Error(`saveExecTrust: mv failed (${r.exitCode})`); }
+}
+
+export interface ExecClassification {
+  readonly added: ReadonlyArray<GatedArtifact>;
+  readonly changed: ReadonlyArray<GatedArtifact>;
+  readonly trusted: ReadonlyArray<GatedArtifact>;
+}
+
+export const classifyExec = (
+  hooks: ReadonlyArray<GatedArtifact>,
+  shaOf: (h: GatedArtifact) => string,
+  trust: ExecTrustState,
+): ExecClassification => {
+  const added: GatedArtifact[] = [], changed: GatedArtifact[] = [], trusted: GatedArtifact[] = [];
+  for (const h of hooks) {
+    const rec = trust[execKey(h)];
+    if (!rec) added.push(h);
+    else if (rec.sha256 !== shaOf(h)) changed.push(h);
+    else trusted.push(h);
+  }
+  return { added, changed, trusted };
+};

--- a/apps/axctl/src/team/git-branch.test.ts
+++ b/apps/axctl/src/team/git-branch.test.ts
@@ -16,7 +16,9 @@ describe("isDefaultBranchName", () => {
 describe("isOnDefaultBranch (integration)", () => {
   it("isOnDefaultBranch: true on the default branch, false on a feature branch, false detached", () => {
     const root = `/tmp/ax-gitbranch-${process.pid}`;
-    Bun.spawnSync(["bash", "-c", `rm -rf ${root} && mkdir -p ${root} && cd ${root} && git init -q -b main && git commit -q --allow-empty -m init`]);
+    // -c identity so the commit works in CI (no global git user) + init.defaultBranch=main
+    // so the branch is "main" regardless of the runner's git config / version.
+    Bun.spawnSync(["bash", "-c", `rm -rf ${root} && mkdir -p ${root} && cd ${root} && git -c init.defaultBranch=main init -q && git -c user.email=ci@ax.test -c user.name=ci commit -q --allow-empty -m init`]);
     expect(currentBranch(root)).toBe("main");
     expect(isOnDefaultBranch(root)).toBe(true);   // no origin → main/master fallback
     Bun.spawnSync(["bash", "-c", `cd ${root} && git checkout -q -b feature/x`]);

--- a/apps/axctl/src/team/git-branch.test.ts
+++ b/apps/axctl/src/team/git-branch.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { isDefaultBranchName, isOnDefaultBranch, currentBranch } from "./git-branch.ts";
+
+describe("isDefaultBranchName", () => {
+  it("matches current to the resolved default", () => {
+    expect(isDefaultBranchName("main", "main")).toBe(true);
+    expect(isDefaultBranchName("feature/x", "main")).toBe(false);
+  });
+  it("falls back to main/master when default is unknown", () => {
+    expect(isDefaultBranchName("main", null)).toBe(true);
+    expect(isDefaultBranchName("master", null)).toBe(true);
+    expect(isDefaultBranchName("dev", null)).toBe(false);
+  });
+});
+
+describe("isOnDefaultBranch (integration)", () => {
+  it("isOnDefaultBranch: true on the default branch, false on a feature branch, false detached", () => {
+    const root = `/tmp/ax-gitbranch-${process.pid}`;
+    Bun.spawnSync(["bash", "-c", `rm -rf ${root} && mkdir -p ${root} && cd ${root} && git init -q -b main && git commit -q --allow-empty -m init`]);
+    expect(currentBranch(root)).toBe("main");
+    expect(isOnDefaultBranch(root)).toBe(true);   // no origin → main/master fallback
+    Bun.spawnSync(["bash", "-c", `cd ${root} && git checkout -q -b feature/x`]);
+    expect(isOnDefaultBranch(root)).toBe(false);
+    Bun.spawnSync(["bash", "-c", `cd ${root} && git checkout -q --detach`]);
+    expect(isOnDefaultBranch(root)).toBe(false);  // detached HEAD not trusted
+    Bun.spawnSync(["rm", "-rf", root]);
+  });
+});

--- a/apps/axctl/src/team/git-branch.ts
+++ b/apps/axctl/src/team/git-branch.ts
@@ -1,0 +1,24 @@
+/** Pure: is `current` the trusted default? If `defaultBranch` is known, exact
+ *  match; else fall back to the conventional main/master. */
+export const isDefaultBranchName = (current: string, defaultBranch: string | null): boolean =>
+  defaultBranch ? current === defaultBranch : current === "main" || current === "master";
+
+const git = (args: string[], cwd: string): string | null => {
+  const r = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "ignore" });
+  return r.exitCode === 0 ? r.stdout.toString().trim() || null : null;
+};
+
+export const currentBranch = (cwd: string): string | null => git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+
+/** origin's default branch (e.g. "main" from refs/remotes/origin/HEAD); null if undetermined. */
+export const defaultBranch = (cwd: string): string | null => {
+  const ref = git(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd); // "refs/remotes/origin/main"
+  return ref ? ref.split("/").pop() ?? null : null;
+};
+
+/** True when the repo at cwd is on its trusted default branch. Detached HEAD is NOT trusted. */
+export const isOnDefaultBranch = (cwd: string): boolean => {
+  const cur = currentBranch(cwd);
+  if (!cur || cur === "HEAD") return false;
+  return isDefaultBranchName(cur, defaultBranch(cwd));
+};

--- a/apps/axctl/src/team/install-team-hook.test.ts
+++ b/apps/axctl/src/team/install-team-hook.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, afterEach } from "bun:test";
+import { hookSnapshotPath, snapshotHook, isSafeHookName } from "./install-team-hook.ts";
+
+describe("hookSnapshotPath / isSafeHookName", () => {
+  it("maps to ~/.ax/hooks/<name>.ts", () => {
+    expect(hookSnapshotPath("enforce-x", "/home/u")).toBe("/home/u/.ax/hooks/enforce-x.ts");
+  });
+  it("rejects path-escaping hook names", () => {
+    expect(isSafeHookName("enforce-x")).toBe(true);
+    expect(isSafeHookName("../evil")).toBe(false);
+    expect(isSafeHookName("a/b")).toBe(false);
+    expect(isSafeHookName("..")).toBe(false);
+  });
+});
+describe("snapshotHook", () => {
+  const home = `/tmp/ax-mesha-${process.pid}`;
+  afterEach(() => Bun.spawnSync(["rm", "-rf", home]));
+  it("writes the trusted content to the snapshot path", async () => {
+    const p = await snapshotHook("enforce-x", "export default {}\n", home);
+    expect(p).toBe(`${home}/.ax/hooks/enforce-x.ts`);
+    expect(await Bun.file(p).text()).toBe("export default {}\n");
+  });
+  it("throws on an unsafe name (no write escapes ~/.ax/)", async () => {
+    await expect(snapshotHook("../evil", "x", home)).rejects.toThrow();
+  });
+});

--- a/apps/axctl/src/team/install-team-hook.ts
+++ b/apps/axctl/src/team/install-team-hook.ts
@@ -1,0 +1,56 @@
+import { Effect } from "effect";
+import { installHookFile } from "../hooks/sdk-install.ts";
+import type { HookScope } from "../hooks/providers/types.ts";
+
+/**
+ * Returns true only when the hook name is safe to use as a filename segment
+ * under ~/.ax/hooks/<name>.ts (no path-traversal characters).
+ */
+export const isSafeHookName = (n: string): boolean =>
+    /^[a-zA-Z0-9._-]+$/.test(n) && n !== "." && n !== "..";
+
+/**
+ * Compute the stable snapshot path for a team hook.
+ * The file lives in ~/.ax/hooks/<name>.ts - a user-owned copy, NOT a symlink
+ * to the repo, so a later repo change cannot silently mutate an installed hook.
+ */
+export const hookSnapshotPath = (name: string, home: string): string =>
+    `${home}/.ax/hooks/${name}.ts`;
+
+/**
+ * Write the trusted hook content to its snapshot path.
+ * Throws when `name` fails the safety check so nothing ever writes outside
+ * the ~/.ax/hooks/ directory.
+ */
+export async function snapshotHook(
+    name: string,
+    content: string,
+    home: string,
+): Promise<string> {
+    if (!isSafeHookName(name)) throw new Error(`unsafe hook name: ${name}`);
+    const path = hookSnapshotPath(name, home);
+    await Bun.write(path, content, { createPath: true });
+    return path;
+}
+
+/**
+ * Snapshot a trusted team hook and install it into the given providers.
+ *
+ * - `name`      – hook name (must pass isSafeHookName)
+ * - `content`   – the trusted hook source (the snapshot is a stable COPY)
+ * - `home`      – user home dir (defaults to process.env.HOME)
+ * - `providers` – provider list forwarded to installHookFile (e.g. ["claude"])
+ *
+ * Uses "global" scope so the hook fires in every project for the user.
+ */
+export const installTeamHook = (
+    name: string,
+    content: string,
+    home: string,
+    providers: ReadonlyArray<string>,
+) =>
+    Effect.gen(function* () {
+        const path = yield* Effect.promise(() => snapshotHook(name, content, home));
+        const scope: HookScope = "global";
+        return yield* installHookFile(path, providers, scope);
+    });

--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -677,16 +677,17 @@ removed launchd plists and the ax symlink`,
     eyebrow: "$ sync the team rig",
     title: "Team",
     blurb:
-      "Activate the shared .ax/ skills and agents committed to the repo into your local runtime, trust-gated per content hash.",
+      "Activate the shared .ax/ skills and agents committed to the repo into your local runtime, trust-gated per content hash. Executable hooks require a separate `ax team trust` review before installation.",
     commands: [
       {
         name: "team",
-        sub: ["sync"],
-        job: "Activate the team's committed .ax/ rig (skills + agents) into your runtime, trust-gated.",
-        signature: "ax team sync [--dry-run] [--yes]",
+        sub: ["sync", "trust"],
+        job: "Sync the team's .ax/ rig (skills + agents) and trust-review + install executable hooks.",
+        signature: "ax team sync|trust [--dry-run] [--yes] [--allow-branch]",
         flags: [
-          { flag: "--dry-run", desc: "show what would change without writing anything" },
-          { flag: "--yes", desc: "approve activation of new or changed artifacts" },
+          { flag: "--dry-run", desc: "show what would change without writing anything (sync only)" },
+          { flag: "--yes", desc: "approve activation / installation of new or changed artifacts" },
+          { flag: "--allow-branch", desc: "bypass the default-branch guard for trust (advanced)" },
         ],
         receipt: `$ ax team sync --yes
 [ax team sync]
@@ -694,13 +695,18 @@ activated 2:
   + skill:tdd
   + agent:reviewer
 1 unchanged
-gated (executable hooks - trust-review before installing):
-  ~ enforce-worktree`,
+gated (executable hooks - run \`ax team trust\` to install):
+  ~ enforce-worktree
+
+$ ax team trust --yes
+[ax team trust] installed 1 executable hook(s)
+  + hook:enforce-worktree`,
         detail: [
-          "ax team sync scans .ax/skills/, .ax/agents/, and .ax/hooks/ in the current git repo root.",
-          "Skills and agents are non-executable and safe to copy; hooks in .ax/hooks/ require a separate trust review and are never activated automatically.",
-          "Content hashes prevent re-activating unchanged artifacts (idempotent). A changed artifact is re-activated and its trust record updated.",
-          "--dry-run prints the plan without writing anything. Without --yes, prints the activation list and exits without activating.",
+          "ax team sync: scans .ax/skills/, .ax/agents/, and .ax/hooks/ in the current git repo root. Skills and agents are non-executable and safe to copy; hooks in .ax/hooks/ are reported as gated but never activated.",
+          "ax team trust: reviews + installs executable hooks from .ax/hooks/ using sha256 trust-on-change. Only installs when on the repo's default branch — refuses on feature branches.",
+          "Content hashes prevent re-activating unchanged artifacts (idempotent). Changed artifacts are re-activated and their trust records updated.",
+          "Fail-safe: non-TTY without --yes prints a summary and exits without installing anything.",
+          "v1 limitation: team hooks must be self-contained or import from @ax/hooks-sdk.",
         ],
       },
     ],

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -67,6 +67,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 
 ### Setup and ingest
 - `ax team sync` - activate the team's committed .ax/ rig (skills + agents) into your runtime, trust-gated (executable hooks gated)
+- `ax team trust` - review + install executable team hooks from .ax/hooks/ (sha256 trust-on-change, default-branch-only, fail-safe)
 - `ax setup` / `ax install` - first-time install: CLI, local SurrealDB, transcript watcher
 - `ax ingest [here] [--since=Nd]` - ingest transcripts, skills, and git history; `here` scopes to the current repo; the watcher does this automatically on new transcripts
 - `ax roles` - list role labels used for skill classification

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -266,6 +266,10 @@ The 16 tools, each mirroring the matching CLI command:
 
 Activate the team's committed `.ax/` rig (skills + agents) into your runtime, trust-gated. Non-executable only - hooks in `.ax/hooks/` are reported as gated but never activated. `--dry-run` shows what would change. `--yes` approves activation (required when activating new or changed artifacts).
 
+`ax team trust [--yes] [--allow-branch]`
+
+Review + install the team's executable `.ax/hooks/*` into your runtime. Uses sha256 trust-on-change: a hook is only installed when its content hash is new or changed, and only when running on the repo's default branch. `--yes` approves installation without interactive prompting. `--allow-branch` bypasses the default-branch guard (advanced use). Fail-safe: non-TTY without `--yes` installs nothing. Team hooks must be self-contained or import from `@ax/hooks-sdk` (v1 limitation: no arbitrary package resolution at hook fire time).
+
 ## Live ingest in the dashboard
 
 `axctl serve` exposes `POST /api/ingest` (also wired to the dashboard's **Live**

--- a/docs/superpowers/plans/2026-06-16-mesh-a-hook-trust.md
+++ b/docs/superpowers/plans/2026-06-16-mesh-a-hook-trust.md
@@ -1,0 +1,374 @@
+# Mesh A - Executable-Hook Trust Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let `ax team` activate the team's **executable** `.ax/hooks/*` - but only through a real trust gate: a **sha256** content-pin, **trust-on-change** (interactive diff + approval), **trusted-branch-only**, never auto-on-pull.
+
+**Architecture:** Slice 0 lists `.ax/hooks/*` as gated. Mesh A adds `ax team trust`: it sha256-hashes each hook, classifies new/changed/trusted against `~/.ax/team-trust-exec.json`, **refuses unless on the repo's default branch** (a feature branch could smuggle a malicious hook), shows new/changed hooks (with a diff for changed) for explicit approval, then **snapshots the approved content to `~/.ax/hooks/<name>.ts`** and installs it via the existing `installHookFile`. The trust gate is the human approval; the sha256 makes "changed" detection a security boundary (a non-crypto hash would be insufficient here).
+
+**Tech Stack:** Bun + TS + Effect v4 + `effect/unstable/cli`. sha256 via `node:crypto` `createHash` (allowed; only `node:fs` is banned). Reuse `apps/axctl/src/hooks/sdk-install.ts` `installHookFile`. Tests: `bun:test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-team-backend-design.md` §"Build order" step 1 (Mesh A) + §S4. Builds on Slice 0 (`apps/axctl/src/team/`, merged #440).
+
+## Threat model (what this defends)
+
+A teammate `git pull`s; `.ax/hooks/enforce-x.ts` is new or changed. Without a gate, activating it = arbitrary code execution on every machine (a merged PR or one compromised push = RCE). Mesh A makes activation **explicit + content-pinned + branch-restricted**. It does NOT defend against a malicious *default-branch* commit that passes human review (that's the team's PR review) - it defends against silent/auto activation and against feature-branch / unreviewed-checkout smuggling.
+
+## File structure
+
+```
+apps/axctl/src/team/
+  exec-hash.ts    - sha256OfFile(abs): full hex sha256 (security-grade, not Bun.hash)
+  exec-trust.ts   - ExecTrustState load/save (~/.ax/team-trust-exec.json) + classifyExec
+  git-branch.ts   - currentBranch(), defaultBranch(), isOnDefaultBranch() (git, Bun.spawnSync)
+  install-team-hook.ts - snapshot approved hook → ~/.ax/hooks/<name>.ts → installHookFile
+apps/axctl/src/cli/commands/team.ts   - add the `trust` subcommand (modify) + point sync's gated report at it
+docs/cli.md · apps/site/public/llms.txt · -cli-reference.data.ts - document `ax team trust` (BOTH gates)
+```
+
+Reuse: `apps/axctl/src/team/{model,scan,trust}.ts` (Slice 0); `installHookFile` from `apps/axctl/src/hooks/sdk-install.ts`; sha256 pattern from `apps/axctl/src/config-core/hash.ts`.
+
+---
+
+## Task 1: `exec-hash.ts` - sha256
+
+**Files:** Create `apps/axctl/src/team/exec-hash.ts` + `exec-hash.test.ts`
+
+- [ ] **Step 1: failing test** (pure given content):
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { sha256Hex } from "./exec-hash.ts";
+
+describe("sha256Hex", () => {
+  it("is the known sha256 of a string", () => {
+    expect(sha256Hex("abc")).toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  });
+  it("changes with content", () => {
+    expect(sha256Hex("a")).not.toBe(sha256Hex("b"));
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/exec-hash.ts`:
+
+```typescript
+import { createHash } from "node:crypto";
+
+/** Full hex sha256 of text. Security-grade content pin for executable trust
+ *  (a non-cryptographic hash like Bun.hash would be insufficient here - a
+ *  collision is a trust-bypass, not just a missed change). */
+export const sha256Hex = (text: string): string => createHash("sha256").update(text).digest("hex");
+
+/** sha256 of a file's content; "" hash for a missing/unreadable file. */
+export async function sha256OfFile(abs: string): Promise<string> {
+  const f = Bun.file(abs);
+  return (await f.exists()) ? sha256Hex(await f.text()) : sha256Hex("");
+}
+```
+
+- [ ] **Step 4: run, PASS.** **Step 5: commit.**
+
+---
+
+## Task 2: `git-branch.ts` - default-branch guard
+
+**Files:** Create `apps/axctl/src/team/git-branch.ts` + `git-branch.test.ts`
+
+- [ ] **Step 1: failing test** - the parsing logic is pure; the git calls are thin. Test the pure `isDefault` reconciler:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { isDefaultBranchName } from "./git-branch.ts";
+
+describe("isDefaultBranchName", () => {
+  it("matches current to the resolved default", () => {
+    expect(isDefaultBranchName("main", "main")).toBe(true);
+    expect(isDefaultBranchName("feature/x", "main")).toBe(false);
+  });
+  it("falls back to main/master when default is unknown", () => {
+    expect(isDefaultBranchName("main", null)).toBe(true);
+    expect(isDefaultBranchName("master", null)).toBe(true);
+    expect(isDefaultBranchName("dev", null)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/git-branch.ts`:
+
+```typescript
+/** Pure: is `current` the trusted default? If `defaultBranch` is known, exact
+ *  match; else fall back to the conventional main/master. */
+export const isDefaultBranchName = (current: string, defaultBranch: string | null): boolean =>
+  defaultBranch ? current === defaultBranch : current === "main" || current === "master";
+
+const git = (args: string[], cwd: string): string | null => {
+  const r = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "ignore" });
+  return r.exitCode === 0 ? r.stdout.toString().trim() || null : null;
+};
+
+export const currentBranch = (cwd: string): string | null => git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+
+/** origin's default branch, e.g. "main" from refs/remotes/origin/HEAD; null if undetermined. */
+export const defaultBranch = (cwd: string): string | null => {
+  const ref = git(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd); // "refs/remotes/origin/main"
+  return ref ? ref.split("/").pop() ?? null : null;
+};
+
+/** True when the repo at cwd is checked out on its trusted default branch. */
+export const isOnDefaultBranch = (cwd: string): boolean => {
+  const cur = currentBranch(cwd);
+  if (!cur || cur === "HEAD") return false; // detached HEAD is not trusted
+  return isDefaultBranchName(cur, defaultBranch(cwd));
+};
+```
+
+- [ ] **Step 4: run, PASS.** **Step 5: commit.**
+
+---
+
+## Task 3: `exec-trust.ts` - exec trust store + classify
+
+**Files:** Create `apps/axctl/src/team/exec-trust.ts` + `exec-trust.test.ts`
+
+- [ ] **Step 1: failing test:**
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { classifyExec, type ExecTrustState } from "./exec-trust.ts";
+import type { GatedArtifact } from "./model.ts";
+
+const hook = (name: string): GatedArtifact => ({ kind: "hook", name, path: `/r/.ax/hooks/${name}.ts` });
+
+describe("classifyExec", () => {
+  it("buckets new / changed / trusted by sha256", () => {
+    const hooks = [hook("a"), hook("b"), hook("c")];
+    const sha: Record<string, string> = { a: "h1", b: "h2", c: "h3" };
+    const trust: ExecTrustState = {
+      "hook:b": { sha256: "h2", content: "...", trusted_at: "x" },
+      "hook:c": { sha256: "OLD", content: "old body", trusted_at: "x" },
+    };
+    const r = classifyExec(hooks, (h) => sha[h.name], trust);
+    expect(r.added.map((x) => x.name)).toEqual(["a"]);
+    expect(r.changed.map((x) => x.name)).toEqual(["c"]);
+    expect(r.trusted.map((x) => x.name)).toEqual(["b"]);
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/exec-trust.ts`. The store caches the trusted **content** so a *changed* hook can show a diff:
+
+```typescript
+import { decodeJsonOrNull } from "@ax/lib/decode";
+import type { GatedArtifact } from "./model.ts";
+
+export interface ExecTrustRecord { readonly sha256: string; readonly content: string; readonly trusted_at: string; }
+export type ExecTrustState = Record<string, ExecTrustRecord>; // key: "hook:<name>"
+
+export const execKey = (h: GatedArtifact): string => `${h.kind}:${h.name}`;
+export const defaultExecTrustPath = (): string => `${process.env.HOME}/.ax/team-trust-exec.json`;
+
+export async function loadExecTrust(path: string): Promise<ExecTrustState> {
+  try {
+    const f = Bun.file(path);
+    if (!(await f.exists())) return {};
+    const p = decodeJsonOrNull(await f.text());
+    return p && typeof p === "object" ? (p as ExecTrustState) : {};
+  } catch { return {}; }
+}
+
+export async function saveExecTrust(path: string, state: ExecTrustState): Promise<void> {
+  const tmp = `${path}.${process.pid}.tmp`;
+  await Bun.write(tmp, `${JSON.stringify(state, null, 2)}\n`, { createPath: true });
+  const r = Bun.spawnSync(["mv", tmp, path]);
+  if (r.exitCode !== 0) { Bun.spawnSync(["rm", "-f", tmp]); throw new Error(`saveExecTrust: mv failed (${r.exitCode})`); }
+}
+
+export interface ExecClassification {
+  readonly added: ReadonlyArray<GatedArtifact>;
+  readonly changed: ReadonlyArray<GatedArtifact>;
+  readonly trusted: ReadonlyArray<GatedArtifact>;
+}
+
+export const classifyExec = (
+  hooks: ReadonlyArray<GatedArtifact>,
+  shaOf: (h: GatedArtifact) => string,
+  trust: ExecTrustState,
+): ExecClassification => {
+  const added: GatedArtifact[] = [], changed: GatedArtifact[] = [], trusted: GatedArtifact[] = [];
+  for (const h of hooks) {
+    const rec = trust[execKey(h)];
+    if (!rec) added.push(h);
+    else if (rec.sha256 !== shaOf(h)) changed.push(h);
+    else trusted.push(h);
+  }
+  return { added, changed, trusted };
+};
+```
+
+- [ ] **Step 4: run, PASS.** **Step 5: commit.**
+
+---
+
+## Task 4: `install-team-hook.ts` - snapshot + install
+
+**Files:** Create `apps/axctl/src/team/install-team-hook.ts` + `install-team-hook.test.ts`
+
+The approved hook content is **snapshotted** to `~/.ax/hooks/<name>.ts` (a stable user-owned copy, NOT the live repo file - so a later repo change can't alter an installed hook without re-trust), then installed via `installHookFile`.
+
+- [ ] **Step 1: failing test** - test the pure target-path + the snapshot write (real temp HOME); the `installHookFile` call is integration-verified in Task 6 e2e (mock or skip the provider write here):
+
+```typescript
+import { describe, expect, it, afterEach } from "bun:test";
+import { hookSnapshotPath, snapshotHook, isSafeHookName } from "./install-team-hook.ts";
+
+describe("hookSnapshotPath / isSafeHookName", () => {
+  it("maps to ~/.ax/hooks/<name>.ts", () => {
+    expect(hookSnapshotPath("enforce-x", "/home/u")).toBe("/home/u/.ax/hooks/enforce-x.ts");
+  });
+  it("rejects path-escaping hook names", () => {
+    expect(isSafeHookName("enforce-x")).toBe(true);
+    expect(isSafeHookName("../evil")).toBe(false);
+    expect(isSafeHookName("a/b")).toBe(false);
+  });
+});
+describe("snapshotHook", () => {
+  const home = `/tmp/ax-mesha-${process.pid}`;
+  afterEach(() => Bun.spawnSync(["rm", "-rf", home]));
+  it("writes the trusted content to the snapshot path", async () => {
+    const p = await snapshotHook("enforce-x", "export default {}\n", home);
+    expect(p).toBe(`${home}/.ax/hooks/enforce-x.ts`);
+    expect(await Bun.file(p).text()).toBe("export default {}\n");
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/install-team-hook.ts`:
+
+```typescript
+import { Effect } from "effect";
+import { installHookFile } from "../hooks/sdk-install.ts";
+
+export const isSafeHookName = (n: string): boolean => /^[a-zA-Z0-9._-]+$/.test(n) && n !== "." && n !== "..";
+export const hookSnapshotPath = (name: string, home: string): string => `${home}/.ax/hooks/${name}.ts`;
+
+/** Write the trusted content to ~/.ax/hooks/<name>.ts (the stable snapshot). */
+export async function snapshotHook(name: string, content: string, home: string): Promise<string> {
+  if (!isSafeHookName(name)) throw new Error(`unsafe hook name: ${name}`);
+  const path = hookSnapshotPath(name, home);
+  await Bun.write(path, content, { createPath: true });
+  return path;
+}
+
+/** Snapshot + install the team hook into the given providers via the existing SDK installer. */
+export const installTeamHook = (name: string, content: string, home: string, providers: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const path = yield* Effect.promise(() => snapshotHook(name, content, home));
+    // installHookFile signature: (absFile, providers, scope) -> Effect; verify against sdk-install.ts
+    return yield* installHookFile(path, providers as string[], "user" as never);
+  });
+```
+
+> Implementer note: read `apps/axctl/src/hooks/sdk-install.ts:217` for the EXACT `installHookFile(absFile, providers, scope)` signature + the `scope` type (grep `asScope`/`InstallScope`) and adapt the call. The snapshot dir `~/.ax/hooks/` must already have the SDK file:dep (it does after `ax hooks init`); if a team hook imports `@ax/hooks-sdk`, it resolves there. Note as a v1 limitation: team hooks must be self-contained or use `@ax/hooks-sdk` only.
+
+- [ ] **Step 4: run, PASS.** **Step 5: commit.**
+
+---
+
+## Task 5: `ax team trust` CLI + diff + approval + branch guard
+
+**Files:** Modify `apps/axctl/src/cli/commands/team.ts` (+ its test)
+
+- [ ] **Step 1: failing test** for the pure diff/report renderer:
+
+```typescript
+import { describe, expect, it } from "bun:test";
+import { renderTrustReport } from "./team.ts";
+
+describe("renderTrustReport", () => {
+  it("shows new/changed/installed counts + the branch guard", () => {
+    const out = renderTrustReport({ installed: ["hook:enforce-x"], changed: [], added: [], onDefault: true });
+    expect(out).toContain("installed 1");
+  });
+  it("refuses off the default branch", () => {
+    const out = renderTrustReport({ installed: [], changed: ["hook:x"], added: [], onDefault: false });
+    expect(out).toMatch(/default branch|refus|not trusted/i);
+  });
+  it("empty-state when no executable hooks", () => {
+    expect(renderTrustReport({ installed: [], changed: [], added: [], onDefault: true })).toContain("no executable");
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** the `trust` subcommand in `team.ts` + the pure `renderTrustReport`. Flow:
+  1. Resolve repo root (reuse sync's resolver). `scanAxFolder` → `gated` (hooks).
+  2. **Branch guard:** `isOnDefaultBranch(root)` (Task 2). If NOT on the default branch and there are added/changed hooks → refuse (print the guard message, install nothing) unless `--allow-branch` is passed (documented escape hatch; default fail-closed).
+  3. sha256 each hook (`sha256OfFile`); `loadExecTrust`; `classifyExec` → added/changed/trusted.
+  4. For each **changed** hook, show a diff: the trust record cached the old content; print "CHANGED" + the new sha256 + a simple line-diff (old vs new) so the approver sees what changed. For **added**, show the new content's first ~20 lines + sha256.
+  5. Approval: if added∪changed non-empty AND not `--yes`: if non-TTY, print "re-run with --yes to install N executable hook(s)" and install NOTHING (fail-safe, like sync). If `--yes`, approve all.
+  6. For approved: `installTeamHook(name, content, home, ["claude","codex"])` (or a `--providers` flag), then record `execTrust[execKey] = { sha256, content, trusted_at }`.
+  7. `saveExecTrust`. Print `renderTrustReport`.
+  Add `trustCommand = Command.make("trust", { yes, allowBranch, ... }, ...)` and add it to the `team` group's subcommands alongside `sync`.
+
+```typescript
+export const renderTrustReport = (r: { installed: string[]; changed: string[]; added: string[]; onDefault: boolean }): string => {
+  if (r.installed.length === 0 && r.changed.length === 0 && r.added.length === 0)
+    return "[ax team trust] no executable hooks in .ax/hooks/.";
+  if (!r.onDefault && (r.changed.length || r.added.length) && r.installed.length === 0)
+    return "[ax team trust] refusing to install executable hooks: not on the repo's default branch (use --allow-branch to override).";
+  const lines = [`[ax team trust] installed ${r.installed.length} executable hook(s)`];
+  for (const k of r.installed) lines.push(`  + ${k}`);
+  return lines.join("\n");
+};
+```
+
+> Implementer note: keep `renderTrustReport` pure + tested; the diff display + the `installTeamHook`/`saveExecTrust` IO live in the command body. Verify the group-subcommand API (`Command.withSubcommands([syncCommand, trustCommand])`) against the Slice-0 `team.ts`. Update sync's gated-hooks line to say "run `ax team trust` to review + install".
+
+- [ ] **Step 4: run, PASS.** **Step 5: commit.**
+
+---
+
+## Task 6: docs + both cli-reference gates + e2e
+
+**Files:** modify `docs/cli.md`, `apps/site/public/llms.txt`, `apps/site/app/routes/docs/-cli-reference.data.ts`
+
+- [ ] **Step 1: document `ax team trust`** in all three (the #414 lesson): docs/cli.md `## Team` section (add `ax team trust`), llms.txt line, and update the `team` card in `-cli-reference.data.ts` to mention `sync` + `trust`.
+- [ ] **Step 2: verify gates + tests + typecheck:**
+```
+bun test apps/axctl/src/team apps/axctl/src/cli/commands/team.test.ts
+bun scripts/check-cli-reference.ts 2>&1 | tail -1
+bun test scripts/check-site-cli-reference.test.ts 2>&1 | tail -3
+bun run typecheck 2>&1 | rg -c "error TS"
+```
+- [ ] **Step 3: e2e** (build a rig with a hook, on a default branch):
+```
+rm -rf /tmp/axhook && mkdir -p /tmp/axhook/.ax/hooks && (cd /tmp/axhook && git init -q -b main && git commit -q --allow-empty -m init)
+printf 'import { defineHook } from "@ax/hooks-sdk/define";\nexport default defineHook({ name: "demo-guard", events: ["PreToolUse"], run: () => ({ _tag: "Allow" }) as any });\n' > /tmp/axhook/.ax/hooks/demo-guard.ts
+W=/Users/necmttn/Projects/ax/.claude/worktrees/hook-trust
+# 1) non-TTY without --yes installs nothing
+cd /tmp/axhook && bun run $W/apps/axctl/src/cli/index.ts team trust < /dev/null 2>&1 | head -6
+# 2) --yes installs it (snapshot + provider install)
+cd /tmp/axhook && bun run $W/apps/axctl/src/cli/index.ts team trust --yes 2>&1 | head -8
+ls ~/.ax/hooks/demo-guard.ts 2>/dev/null && echo "snapshot present" || echo "snapshot MISSING"
+# 3) re-run = trusted/unchanged (no re-install)
+cd /tmp/axhook && bun run $W/apps/axctl/src/cli/index.ts team trust --yes 2>&1 | head -4
+# 4) off-default-branch refuses
+cd /tmp/axhook && git checkout -q -b feature/x && bun run $W/apps/axctl/src/cli/index.ts team trust --yes 2>&1 | head -4
+```
+Expected: (1) installs nothing; (2) snapshots to `~/.ax/hooks/demo-guard.ts` + reports installed + records sha256; (3) trusted/unchanged; (4) refuses off the default branch. Paste output.
+- [ ] **Step 4: CLEANUP** (don't leave the demo hook installed in the real config): `ax hooks remove demo-guard` (or revert the provider config edit), `rm -f ~/.ax/hooks/demo-guard.ts /tmp/axhook`, and drop `hook:demo-guard` from `~/.ax/team-trust-exec.json`. Confirm the demo hook is NOT left in `~/.claude/settings.json` / codex config.
+- [ ] **Step 5: commit.**
+
+---
+
+## Self-Review Notes
+- **Security:** sha256 (not Bun.hash) - collision = trust bypass; default-branch-only (feature-branch smuggling blocked); non-TTY/no-`--yes` installs nothing; path-traversal guard on hook names; the installed hook is a **snapshot** (a repo change can't mutate an installed hook without re-trust).
+- **Reuse:** `installHookFile` (existing SDK install path), the Slice-0 `scan`/`model`, sha256 helper pattern.
+- **CI:** BOTH cli-reference gates updated (Task 6).
+- **Cleanup:** e2e must remove the demo hook from real provider configs + the snapshot + exec-trust.
+- **v1 limitations to note in docs:** team hooks must be self-contained or use `@ax/hooks-sdk`; `--allow-branch` is the documented escape hatch; signing-against-an-org-key is deferred (post price-signal / hosted).


### PR DESCRIPTION
## Why

Slice 0 (`ax team sync`, #440) deliberately **gated** executable `.ax/hooks/*` — auto-activating committed executables across a team is an RCE/supply-chain vector. Dogfooding showed the *compelling* pull of the team mesh is exactly those gated hooks. **Mesh A** makes them activatable — through a real trust gate.

Spec: `docs/superpowers/specs/2026-06-15-team-backend-design.md` (build order step 1). Plan: `docs/superpowers/plans/2026-06-16-mesh-a-hook-trust.md`. Re-sequenced ahead of the hosted backend per the post-dogfood decision.

## What

`ax team trust [--yes] [--allow-branch]` reviews + installs the team's executable hooks, gated by:

- **sha256 content-pin** (`node:crypto`, full hex — a non-crypto hash here = trust bypass) with **trust-on-change**: a changed hook re-gates and shows a **full, sanitized diff**.
- **Default-branch-only, fail-closed** — refuses on a feature branch / detached HEAD / unresolved default (a feature branch could smuggle a malicious hook into a PR); `--allow-branch` is the only escape.
- **Fail-safe approval** — non-TTY or no `--yes` installs nothing.
- **Full source review** — prints the *entire* hook source (no truncation), sanitized against ANSI/control-char spoofing, because the human is approving executable code.
- **Read-once** — each hook is read once and that single buffer is hashed, displayed, snapshotted, installed, and stored (judged == hashed == run — no TOCTOU).
- **Snapshot, not symlink** — installs a copy to `~/.ax/hooks/<name>.ts` (via the existing `installHookFile`), so a later `git pull` can't mutate a trusted hook without re-approval.
- **Path-traversal guard** on hook names; up-front name validation (no partial-install drift); clobber warning on untracked same-named hooks.

## Test plan

- [x] 30 unit tests (sha256/git-branch/exec-trust/install/CLI) — incl. an `isOnDefaultBranch` integration test (real git: main trusted, feature branch + detached HEAD rejected) and the sha256 RFC vector
- [x] e2e (isolated temp HOME): `--yes` installs (snapshot + provider config + sha recorded) · idempotent · **off-branch refuses** · `--allow-branch` installs a change · non-TTY/no-`--yes` installs nothing · a >15-line hook prints in **full**
- [x] **Adversarial opus security review** — all crypto gates passed; the review's fix-before-merge findings (truncated review surface, ANSI-injectable diff, TOCTOU) are all fixed
- [x] Both cli-reference gates + docs; typecheck 0
- [ ] CI green against current origin/main

## Notes
- v1 limitation: team hooks must be self-contained or use `@ax/hooks-sdk` (the installer dynamically imports the snapshot, which resolves from `~/.ax/hooks/`).
- Signing-against-an-org-key is deferred (post hosted backend). The trust boundary today is human review of the full source + the default-branch restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)