### PR TITLE
feat(team): `.ax.local/` experiment overlay + promote (Mesh B)

### DIFF
--- a/apps/axctl/src/cli/commands/team.test.ts
+++ b/apps/axctl/src/cli/commands/team.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { renderSyncReport, renderTrustReport } from "./team.ts";
+import { renderSyncReport, renderTrustReport, renderExperimentList } from "./team.ts";
 
 describe("renderSyncReport", () => {
   it("summarizes activated, unchanged, and gated", () => {
@@ -26,4 +26,14 @@ describe("renderTrustReport", () => {
   it("empty-state when no executable hooks", () => {
     expect(renderTrustReport({ installed: [], changed: [], added: [], onDefault: true })).toContain("no executable");
   });
+});
+
+describe("renderExperimentList", () => {
+  it("lists overlay artifacts with shadow info", () => {
+    const out = renderExperimentList([{ key: "skill:tdd", shadows: true }, { key: "skill:exp", shadows: false }]);
+    expect(out).toContain("skill:tdd");
+    expect(out).toContain("skill:exp");
+    expect(out).toMatch(/shadow|overrides|committed/i);
+  });
+  it("empty-state", () => { expect(renderExperimentList([])).toContain("no experiments"); });
 });

--- a/apps/axctl/src/cli/commands/team.ts
+++ b/apps/axctl/src/cli/commands/team.ts
@@ -13,8 +13,16 @@
  *     bypasses the default-branch guard.
  */
 import { Effect } from "effect";
-import { Command, Flag } from "effect/unstable/cli";
-import { scanWithOverlay } from "../../team/overlay.ts";
+import { Argument, Command, Flag } from "effect/unstable/cli";
+import { scanWithOverlay, ensureAxLocalIgnored } from "../../team/overlay.ts";
+import {
+    startExperiment,
+    promoteExperiment,
+    dropExperiment,
+    isSafeKindName,
+    overlayPath,
+    committedPath,
+} from "../../team/experiment.ts";
 import { hashArtifact } from "../../team/hash.ts";
 import { loadTrust, saveTrust, classify, defaultTrustPath } from "../../team/trust.ts";
 import { activateArtifact, isSafeName } from "../../team/activate.ts";
@@ -420,6 +428,131 @@ const trustCommand = Command.make(
 );
 
 // ---------------------------------------------------------------------------
+// ax team experiment
+// ---------------------------------------------------------------------------
+
+export interface ExperimentItem {
+    readonly key: string;
+    readonly shadows: boolean;
+}
+
+/** Pure: format the experiment list for stdout. No IO. */
+export const renderExperimentList = (items: ReadonlyArray<ExperimentItem>): string => {
+    if (items.length === 0) return "[ax team experiment] no experiments in .ax.local/.";
+    const lines = ["[ax team experiment] active experiments (.ax.local/):"];
+    for (const it of items) lines.push(`  ${it.key}${it.shadows ? "  (overrides the committed version)" : "  (overlay-only)"}`);
+    lines.push("activate with `ax team sync` (or `ax team trust` for hooks); ship with `ax team experiment promote`");
+    return lines.join("\n");
+};
+
+/** Resolve the git repo root, or print an error + return null. */
+const resolveRoot = (): string | null => {
+    const r = Bun.spawnSync(["git", "rev-parse", "--show-toplevel"], {
+        stdout: "pipe",
+        stderr: "ignore",
+    });
+    if (r.exitCode !== 0) {
+        console.error("[ax team experiment] not inside a git repo - run from the team repo root");
+        return null;
+    }
+    return r.stdout.toString().trim();
+};
+
+const startCmd = Command.make(
+    "start",
+    { kind: Argument.string("kind"), name: Argument.string("name") },
+    ({ kind, name }) =>
+        Effect.promise(async () => {
+            const root = resolveRoot();
+            if (!root) return;
+            if (!isSafeKindName(kind, name)) {
+                console.error(
+                    `[ax team experiment start] invalid kind/name: "${kind}/${name}". kind must be skill|agent|hook; name must match [a-zA-Z0-9._-]+`,
+                );
+                return;
+            }
+            await ensureAxLocalIgnored(root);
+            const dst = await startExperiment(root, kind, name);
+            console.log(
+                `editing ${dst} - iterate, then \`ax team sync\` (or \`ax team trust\` for a hook) to activate it; \`ax team experiment promote ${kind} ${name}\` to ship.`,
+            );
+        }),
+).pipe(Command.withDescription("Copy a committed artifact (or scaffold a new one) into .ax.local/ for isolated iteration."));
+
+const listCmd = Command.make(
+    "list",
+    {},
+    () =>
+        Effect.promise(async () => {
+            const root = resolveRoot();
+            if (!root) return;
+            const { artifacts, gated } = await scanWithOverlay(root);
+            const overlayArtifacts = artifacts.filter((a) => a.overlay);
+            const overlayGated = gated.filter((g) => g.overlay);
+
+            const items: ExperimentItem[] = [];
+            for (const a of overlayArtifacts) {
+                const committed = committedPath(root, a.kind, a.name);
+                const shadows = Bun.spawnSync(["test", "-e", committed]).exitCode === 0;
+                items.push({ key: `${a.kind}:${a.name}`, shadows });
+            }
+            for (const g of overlayGated) {
+                const committed = committedPath(root, "hook", g.name);
+                const shadows = Bun.spawnSync(["test", "-e", committed]).exitCode === 0;
+                items.push({ key: `hook:${g.name}`, shadows });
+            }
+
+            console.log(renderExperimentList(items));
+        }),
+).pipe(Command.withDescription("List active experiments in .ax.local/."));
+
+const promoteCmd = Command.make(
+    "promote",
+    { kind: Argument.string("kind"), name: Argument.string("name") },
+    ({ kind, name }) =>
+        Effect.promise(async () => {
+            const root = resolveRoot();
+            if (!root) return;
+            if (!isSafeKindName(kind, name)) {
+                console.error(
+                    `[ax team experiment promote] invalid kind/name: "${kind}/${name}". kind must be skill|agent|hook; name must match [a-zA-Z0-9._-]+`,
+                );
+                return;
+            }
+            const dst = await promoteExperiment(root, kind, name);
+            Bun.spawnSync(["git", "add", dst], { cwd: root });
+            console.log(
+                `promoted ${kind}/${name} → .ax/. Open a PR: \`gh pr create\` (or commit + push). NOTE: a promoted hook must be re-trusted by teammates via \`ax team trust\` after the PR merges.`,
+            );
+        }),
+).pipe(Command.withDescription("Move the experiment from .ax.local/ into the committed .ax/ rig and stage it with git add."));
+
+const dropCmd = Command.make(
+    "drop",
+    { kind: Argument.string("kind"), name: Argument.string("name") },
+    ({ kind, name }) =>
+        Effect.promise(async () => {
+            const root = resolveRoot();
+            if (!root) return;
+            if (!isSafeKindName(kind, name)) {
+                console.error(
+                    `[ax team experiment drop] invalid kind/name: "${kind}/${name}". kind must be skill|agent|hook; name must match [a-zA-Z0-9._-]+`,
+                );
+                return;
+            }
+            await dropExperiment(root, kind, name);
+            console.log(`dropped ${overlayPath(root, kind, name)}`);
+        }),
+).pipe(Command.withDescription("Discard the experiment overlay, reverting to the committed version."));
+
+const experimentCommand = Command.make("experiment").pipe(
+    Command.withDescription(
+        "Iterate on a team artifact in an isolated .ax.local/ overlay, then promote it. start/list/promote/drop.",
+    ),
+    Command.withSubcommands([startCmd, listCmd, promoteCmd, dropCmd]),
+);
+
+// ---------------------------------------------------------------------------
 // ax team (group)
 // ---------------------------------------------------------------------------
 
@@ -427,7 +560,7 @@ export const teamCommand = Command.make("team").pipe(
     Command.withDescription(
         "Team rig management: activate the shared .ax/ skills and agents into your local runtime.",
     ),
-    Command.withSubcommands([syncCommand, trustCommand]),
+    Command.withSubcommands([syncCommand, trustCommand, experimentCommand]),
 );
 
 export const teamRuntime: RuntimeManifest = {
@@ -438,6 +571,7 @@ export const teamRuntime: RuntimeManifest = {
             subcommands: {
                 sync: "none",
                 trust: "none",
+                experiment: "none",
             },
         },
         hidden: false,

--- a/apps/axctl/src/cli/commands/team.ts
+++ b/apps/axctl/src/cli/commands/team.ts
@@ -14,7 +14,7 @@
  */
 import { Effect } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
-import { scanAxFolder } from "../../team/scan.ts";
+import { scanWithOverlay } from "../../team/overlay.ts";
 import { hashArtifact } from "../../team/hash.ts";
 import { loadTrust, saveTrust, classify, defaultTrustPath } from "../../team/trust.ts";
 import { activateArtifact, isSafeName } from "../../team/activate.ts";
@@ -98,13 +98,16 @@ const cmdSync = (input: { readonly dryRun: boolean; readonly yes: boolean }) =>
         }
         const root = r.stdout.toString().trim();
 
-        // 2. Scan .ax/ for artifacts + gated hooks
-        const { artifacts, gated } = yield* Effect.promise(() => scanAxFolder(root));
+        // 2. Scan .ax/ + .ax.local/ overlay for artifacts + gated hooks
+        const { artifacts, gated } = yield* Effect.promise(() => scanWithOverlay(root));
 
         if (artifacts.length === 0 && gated.length === 0) {
             console.log("[ax team sync] no .ax/ rig found in this repo");
             return;
         }
+
+        // Track which artifact keys are from the local overlay, for annotation in reports
+        const overlayKeys = new Set(artifacts.filter((a) => a.overlay).map((a) => artifactKey(a)));
 
         // 3. Pre-read all artifact files to build a sync hash map
         const fileContents = yield* Effect.promise(async () => {
@@ -129,7 +132,8 @@ const cmdSync = (input: { readonly dryRun: boolean; readonly yes: boolean }) =>
             const toActivate = [...cls.added, ...cls.changed];
             if (toActivate.length > 0) {
                 console.log(`[ax team sync] would activate ${toActivate.length}:`);
-                for (const a of toActivate) console.log(`  + ${a.kind}:${a.name}`);
+                for (const a of toActivate)
+                    console.log(`  + ${a.kind}:${a.name}${overlayKeys.has(artifactKey(a)) ? " (experiment)" : ""}`);
             }
             if (cls.unchanged.length > 0) {
                 console.log(`${cls.unchanged.length} unchanged`);
@@ -150,7 +154,8 @@ const cmdSync = (input: { readonly dryRun: boolean; readonly yes: boolean }) =>
         // 7. Without --yes, print what would happen and bail (activate NOTHING)
         if (toActivate.length > 0 && !input.yes) {
             console.log(`[ax team sync] ${toActivate.length} artifact(s) ready to activate:`);
-            for (const a of toActivate) console.log(`  + ${a.kind}:${a.name}`);
+            for (const a of toActivate)
+                console.log(`  + ${a.kind}:${a.name}${overlayKeys.has(artifactKey(a)) ? " (experiment)" : ""}`);
             console.log("re-run with --yes to approve");
             return;
         }
@@ -176,7 +181,7 @@ const cmdSync = (input: { readonly dryRun: boolean; readonly yes: boolean }) =>
                     hash: hashOf(a),
                     activated_at: new Date().toISOString(),
                 };
-                activated.push(`${a.kind}:${a.name}`);
+                activated.push(`${a.kind}:${a.name}${overlayKeys.has(artifactKey(a)) ? " (experiment)" : ""}`);
             }
         });
 
@@ -187,7 +192,7 @@ const cmdSync = (input: { readonly dryRun: boolean; readonly yes: boolean }) =>
         console.log(
             renderSyncReport({
                 activated,
-                unchanged: cls.unchanged.map((a) => `${a.kind}:${a.name}`),
+                unchanged: cls.unchanged.map((a) => `${a.kind}:${a.name}${overlayKeys.has(artifactKey(a)) ? " (experiment)" : ""}`),
                 gated: gated.map((g) => g.name),
             }),
         );
@@ -254,8 +259,8 @@ const cmdTrust = (input: { readonly yes: boolean; readonly allowBranch: boolean 
         }
         const root = r.stdout.toString().trim();
 
-        // 2. Scan .ax/ for gated hooks
-        const { gated } = yield* Effect.promise(() => scanAxFolder(root));
+        // 2. Scan .ax/ + .ax.local/ overlay for gated hooks
+        const { gated } = yield* Effect.promise(() => scanWithOverlay(root));
 
         if (gated.length === 0) {
             console.log("[ax team trust] no executable hooks in .ax/hooks/.");

--- a/apps/axctl/src/team/experiment.test.ts
+++ b/apps/axctl/src/team/experiment.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, afterEach } from "bun:test";
+import { overlayPath, committedPath, startExperiment, promoteExperiment, dropExperiment, isSafeKindName } from "./experiment.ts";
+
+describe("paths + guard", () => {
+  it("maps kind/name to overlay + committed paths", () => {
+    expect(overlayPath("/r", "skill", "x")).toBe("/r/.ax.local/skills/x");
+    expect(committedPath("/r", "agent", "y")).toBe("/r/.ax/agents/y.md");
+    expect(overlayPath("/r", "hook", "z")).toBe("/r/.ax.local/hooks/z.ts");
+  });
+  it("rejects unsafe kind/name", () => {
+    expect(isSafeKindName("skill", "x")).toBe(true);
+    expect(isSafeKindName("skill", "../e")).toBe(false);
+    expect(isSafeKindName("skill", "a/b")).toBe(false);
+    expect(isSafeKindName("bogus", "x")).toBe(false);
+    expect(isSafeKindName("skill", "..")).toBe(false);
+  });
+});
+
+describe("start / promote / drop", () => {
+  const root = `/tmp/ax-exp-${process.pid}`;
+  afterEach(() => Bun.spawnSync(["rm", "-rf", root]));
+  it("start copies a committed skill into the overlay", async () => {
+    await Bun.write(`${root}/.ax/skills/tdd/SKILL.md`, "committed");
+    await startExperiment(root, "skill", "tdd");
+    expect(await Bun.file(`${root}/.ax.local/skills/tdd/SKILL.md`).text()).toBe("committed");
+  });
+  it("start scaffolds a new overlay skill when none committed", async () => {
+    await startExperiment(root, "skill", "fresh");
+    expect(await Bun.file(`${root}/.ax.local/skills/fresh/SKILL.md`).exists()).toBe(true);
+  });
+  it("start scaffolds a new overlay agent + hook", async () => {
+    await startExperiment(root, "agent", "rev");
+    await startExperiment(root, "hook", "guard");
+    expect(await Bun.file(`${root}/.ax.local/agents/rev.md`).exists()).toBe(true);
+    expect(await Bun.file(`${root}/.ax.local/hooks/guard.ts`).exists()).toBe(true);
+  });
+  it("promote moves overlay → committed and removes the overlay copy", async () => {
+    await Bun.write(`${root}/.ax.local/skills/exp/SKILL.md`, "variant");
+    await promoteExperiment(root, "skill", "exp");
+    expect(await Bun.file(`${root}/.ax/skills/exp/SKILL.md`).text()).toBe("variant");
+    expect(await Bun.file(`${root}/.ax.local/skills/exp/SKILL.md`).exists()).toBe(false);
+  });
+  it("drop removes the overlay artifact", async () => {
+    await Bun.write(`${root}/.ax.local/skills/exp/SKILL.md`, "v");
+    await dropExperiment(root, "skill", "exp");
+    expect(await Bun.file(`${root}/.ax.local/skills/exp/SKILL.md`).exists()).toBe(false);
+  });
+  it("throws on unsafe name (no write escapes the repo)", async () => {
+    await expect(startExperiment(root, "skill", "../evil")).rejects.toThrow();
+    await expect(promoteExperiment(root, "skill", "../evil")).rejects.toThrow();
+    await expect(dropExperiment(root, "skill", "../evil")).rejects.toThrow();
+  });
+});

--- a/apps/axctl/src/team/experiment.test.ts
+++ b/apps/axctl/src/team/experiment.test.ts
@@ -40,6 +40,11 @@ describe("start / promote / drop", () => {
     expect(await Bun.file(`${root}/.ax/skills/exp/SKILL.md`).text()).toBe("variant");
     expect(await Bun.file(`${root}/.ax.local/skills/exp/SKILL.md`).exists()).toBe(false);
   });
+  it("promote with NO overlay throws and leaves the committed artifact intact (no data loss)", async () => {
+    await Bun.write(`${root}/.ax/skills/keep/SKILL.md`, "precious");
+    await expect(promoteExperiment(root, "skill", "keep")).rejects.toThrow();
+    expect(await Bun.file(`${root}/.ax/skills/keep/SKILL.md`).text()).toBe("precious");
+  });
   it("drop removes the overlay artifact", async () => {
     await Bun.write(`${root}/.ax.local/skills/exp/SKILL.md`, "v");
     await dropExperiment(root, "skill", "exp");

--- a/apps/axctl/src/team/experiment.ts
+++ b/apps/axctl/src/team/experiment.ts
@@ -1,0 +1,84 @@
+const KINDS = new Set(["skill", "agent", "hook"]);
+const NAME_RE = /^[a-zA-Z0-9._-]+$/;
+
+export const isSafeKindName = (kind: string, name: string): boolean =>
+  KINDS.has(kind) && NAME_RE.test(name) && name !== "." && name !== "..";
+
+const sub = (kind: string) =>
+  kind === "skill" ? "skills" : kind === "agent" ? "agents" : "hooks";
+
+const ext = (kind: string) => (kind === "agent" ? "md" : "ts");
+
+const rel = (kind: string, name: string) =>
+  kind === "skill" ? name : `${name}.${ext(kind)}`;
+
+export const overlayPath = (root: string, kind: string, name: string) =>
+  `${root}/.ax.local/${sub(kind)}/${rel(kind, name)}`;
+
+export const committedPath = (root: string, kind: string, name: string) =>
+  `${root}/.ax/${sub(kind)}/${rel(kind, name)}`;
+
+const guard = (kind: string, name: string) => {
+  if (!isSafeKindName(kind, name))
+    throw new Error(`unsafe experiment kind/name: ${kind}/${name}`);
+};
+
+const scaffold = (kind: string, name: string): string =>
+  kind === "hook"
+    ? `import { defineHook } from "@ax/hooks-sdk/define";\nexport default defineHook({ name: "${name}", events: [], run: () => ({ _tag: "Allow" }) });\n`
+    : `---\nname: ${name}\ndescription: TODO\n---\n`;
+
+/** Copy the committed artifact into the overlay for editing, or scaffold a new one. */
+export async function startExperiment(
+  root: string,
+  kind: string,
+  name: string,
+): Promise<string> {
+  guard(kind, name);
+  const dst = overlayPath(root, kind, name);
+  const src = committedPath(root, kind, name);
+  if (kind === "skill") {
+    Bun.spawnSync(["mkdir", "-p", `${root}/.ax.local/skills`]);
+    if (Bun.spawnSync(["test", "-d", src]).exitCode === 0) {
+      Bun.spawnSync(["rm", "-rf", dst]);
+      Bun.spawnSync(["cp", "-R", src, dst]);
+    } else {
+      await Bun.write(`${dst}/SKILL.md`, scaffold(kind, name), {
+        createPath: true,
+      });
+    }
+  } else {
+    const exists = await Bun.file(src).exists();
+    const content = exists ? await Bun.file(src).text() : scaffold(kind, name);
+    await Bun.write(dst, content, { createPath: true });
+  }
+  return dst;
+}
+
+/** Move the overlay artifact into the committed rig; clear the overlay copy. */
+export async function promoteExperiment(
+  root: string,
+  kind: string,
+  name: string,
+): Promise<string> {
+  guard(kind, name);
+  const src = overlayPath(root, kind, name);
+  const dst = committedPath(root, kind, name);
+  Bun.spawnSync(["mkdir", "-p", `${root}/.ax/${sub(kind)}`]);
+  Bun.spawnSync(["rm", "-rf", dst]);
+  const r = Bun.spawnSync(["cp", "-R", src, dst]);
+  if (r.exitCode !== 0)
+    throw new Error(`promote ${kind}/${name}: cp failed (${r.exitCode})`);
+  Bun.spawnSync(["rm", "-rf", src]);
+  return dst;
+}
+
+/** Discard the overlay artifact. */
+export async function dropExperiment(
+  root: string,
+  kind: string,
+  name: string,
+): Promise<void> {
+  guard(kind, name);
+  Bun.spawnSync(["rm", "-rf", overlayPath(root, kind, name)]);
+}

--- a/apps/axctl/src/team/experiment.ts
+++ b/apps/axctl/src/team/experiment.ts
@@ -64,6 +64,10 @@ export async function promoteExperiment(
   guard(kind, name);
   const src = overlayPath(root, kind, name);
   const dst = committedPath(root, kind, name);
+  // Verify the overlay source exists BEFORE touching the committed target -
+  // otherwise a typo'd name would rm -rf the committed artifact then fail the cp.
+  if (Bun.spawnSync(["test", "-e", src]).exitCode !== 0)
+    throw new Error(`promote ${kind}/${name}: no overlay at ${src} (run \`ax team experiment start ${kind} ${name}\` first)`);
   Bun.spawnSync(["mkdir", "-p", `${root}/.ax/${sub(kind)}`]);
   Bun.spawnSync(["rm", "-rf", dst]);
   const r = Bun.spawnSync(["cp", "-R", src, dst]);

--- a/apps/axctl/src/team/overlay.test.ts
+++ b/apps/axctl/src/team/overlay.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll, afterAll } from "bun:test";
-import { scanWithOverlay } from "./overlay.ts";
+import { scanWithOverlay, ensureAxLocalIgnored } from "./overlay.ts";
 
 let root: string;
 beforeAll(async () => {
@@ -32,4 +32,42 @@ describe("scanWithOverlay", () => {
     expect(r.artifacts).toEqual([]);
     expect(r.gated).toEqual([]);
   });
+});
+
+describe("ensureAxLocalIgnored", () => {
+  const tmpBase = `/tmp/ax-gitignore-${process.pid}`;
+
+  it("creates .gitignore and adds .ax.local/ when file is missing", async () => {
+    const dir = `${tmpBase}/a`;
+    await ensureAxLocalIgnored(dir);
+    const content = await Bun.file(`${dir}/.gitignore`).text();
+    expect(content).toMatch(/^\.ax\.local\/\s*$/m);
+  });
+
+  it("appends .ax.local/ to existing .gitignore without a trailing newline", async () => {
+    const dir = `${tmpBase}/b`;
+    await Bun.write(`${dir}/.gitignore`, "node_modules");
+    await ensureAxLocalIgnored(dir);
+    const content = await Bun.file(`${dir}/.gitignore`).text();
+    expect(content).toContain("node_modules\n.ax.local/\n");
+  });
+
+  it("does not duplicate when .ax.local/ is already present", async () => {
+    const dir = `${tmpBase}/c`;
+    await Bun.write(`${dir}/.gitignore`, "node_modules\n.ax.local/\n");
+    await ensureAxLocalIgnored(dir);
+    const content = await Bun.file(`${dir}/.gitignore`).text();
+    expect(content.split(".ax.local/").length - 1).toBe(1);
+  });
+
+  it("is idempotent across multiple calls", async () => {
+    const dir = `${tmpBase}/d`;
+    await ensureAxLocalIgnored(dir);
+    await ensureAxLocalIgnored(dir);
+    await ensureAxLocalIgnored(dir);
+    const content = await Bun.file(`${dir}/.gitignore`).text();
+    expect(content.split(".ax.local/").length - 1).toBe(1);
+  });
+
+  afterAll(() => Bun.spawnSync(["rm", "-rf", tmpBase]));
 });

--- a/apps/axctl/src/team/overlay.test.ts
+++ b/apps/axctl/src/team/overlay.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import { scanWithOverlay } from "./overlay.ts";
+
+let root: string;
+beforeAll(async () => {
+  root = `/tmp/ax-overlay-${process.pid}`;
+  await Bun.write(`${root}/.ax/skills/shared/SKILL.md`, "committed shared");
+  await Bun.write(`${root}/.ax/skills/tdd/SKILL.md`, "committed tdd");
+  await Bun.write(`${root}/.ax/hooks/guard.ts`, "committed hook");
+  await Bun.write(`${root}/.ax.local/skills/tdd/SKILL.md`, "OVERLAY tdd");
+  await Bun.write(`${root}/.ax.local/skills/exp/SKILL.md`, "overlay-only");
+  await Bun.write(`${root}/.ax.local/hooks/guard.ts`, "OVERLAY hook");
+});
+afterAll(() => Bun.spawnSync(["rm", "-rf", root]));
+
+describe("scanWithOverlay", () => {
+  it("overlay wins on collision; overlay-only appear; committed-only survive; each flagged", async () => {
+    const { artifacts, gated } = await scanWithOverlay(root);
+    const tdd = artifacts.find((a) => a.kind === "skill" && a.name === "tdd");
+    expect(tdd?.path).toContain(".ax.local/skills/tdd");
+    expect(tdd?.overlay).toBe(true);
+    const shared = artifacts.find((a) => a.kind === "skill" && a.name === "shared");
+    expect(shared?.path).toContain("/.ax/skills/shared");
+    expect(shared?.overlay).toBe(false);
+    expect(artifacts.find((a) => a.name === "exp")?.overlay).toBe(true);
+    const guard = gated.find((g) => g.name === "guard");
+    expect(guard?.path).toContain(".ax.local/hooks/guard");
+    expect(guard?.overlay).toBe(true);
+  });
+  it("empty repo (no .ax or .ax.local) → empty", async () => {
+    const r = await scanWithOverlay(`/tmp/ax-overlay-none-${process.pid}`);
+    expect(r.artifacts).toEqual([]);
+    expect(r.gated).toEqual([]);
+  });
+});

--- a/apps/axctl/src/team/overlay.ts
+++ b/apps/axctl/src/team/overlay.ts
@@ -1,0 +1,30 @@
+import { scanAxFolder } from "./scan.ts";
+import type { GatedArtifact, TeamArtifact } from "./model.ts";
+
+export const AX_LOCAL_DIR = ".ax.local";
+
+export type OverlayArtifact = TeamArtifact & { readonly overlay: boolean };
+export type OverlayGated = GatedArtifact & { readonly overlay: boolean };
+export interface OverlayScan {
+  readonly artifacts: ReadonlyArray<OverlayArtifact>;
+  readonly gated: ReadonlyArray<OverlayGated>;
+}
+
+/** Merge committed `.ax/` + `.ax.local/`, overlay winning on (kind,name). */
+export const scanWithOverlay = async (root: string): Promise<OverlayScan> => {
+  const base = await scanAxFolder(root, ".ax");
+  const over = await scanAxFolder(root, AX_LOCAL_DIR);
+  const merge = <T extends { kind: string; name: string }>(
+    b: ReadonlyArray<T>,
+    o: ReadonlyArray<T>,
+  ): Array<T & { overlay: boolean }> => {
+    const byKey = new Map<string, T & { overlay: boolean }>();
+    for (const x of b) byKey.set(`${x.kind}:${x.name}`, { ...x, overlay: false });
+    for (const x of o) byKey.set(`${x.kind}:${x.name}`, { ...x, overlay: true });
+    return [...byKey.values()].sort((a, b2) => a.name.localeCompare(b2.name));
+  };
+  return {
+    artifacts: merge(base.artifacts, over.artifacts) as OverlayArtifact[],
+    gated: merge(base.gated, over.gated) as OverlayGated[],
+  };
+};

--- a/apps/axctl/src/team/overlay.ts
+++ b/apps/axctl/src/team/overlay.ts
@@ -1,6 +1,14 @@
 import { scanAxFolder } from "./scan.ts";
 import type { GatedArtifact, TeamArtifact } from "./model.ts";
 
+/** Idempotently ensure `<root>/.gitignore` contains a line ignoring `.ax.local/`. */
+export async function ensureAxLocalIgnored(root: string): Promise<void> {
+  const gi = `${root}/.gitignore`;
+  const cur = (await Bun.file(gi).exists()) ? await Bun.file(gi).text() : "";
+  if (/^\.ax\.local\/?\s*$/m.test(cur)) return; // already ignored
+  await Bun.write(gi, `${cur}${cur && !cur.endsWith("\n") ? "\n" : ""}.ax.local/\n`, { createPath: true });
+}
+
 export const AX_LOCAL_DIR = ".ax.local";
 
 export type OverlayArtifact = TeamArtifact & { readonly overlay: boolean };

--- a/apps/axctl/src/team/scan.ts
+++ b/apps/axctl/src/team/scan.ts
@@ -10,10 +10,11 @@ export interface ScanResult {
 const dirExists = (path: string): boolean =>
   Bun.spawnSync(["test", "-d", path]).exitCode === 0;
 
-/** Scan `<repoRoot>/.ax/` for the team rig. Skills = each `skills/<name>/SKILL.md`
- *  (+ sibling files); agents = each `agents/<name>.md`; hooks = `hooks/*` (gated). */
-export const scanAxFolder = async (repoRoot: string): Promise<ScanResult> => {
-  const ax = `${repoRoot}/.ax`;
+/** Scan `<repoRoot>/<subdir>/` for the team rig. Skills = each `skills/<name>/SKILL.md`
+ *  (+ sibling files); agents = each `agents/<name>.md`; hooks = `hooks/*` (gated).
+ *  `subdir` defaults to `.ax`; pass `.ax.local` for the overlay scan. */
+export const scanAxFolder = async (repoRoot: string, subdir = ".ax"): Promise<ScanResult> => {
+  const ax = `${repoRoot}/${subdir}`;
   if (!dirExists(ax)) return { artifacts: [], gated: [] };
 
   const artifacts: TeamArtifact[] = [];

--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -677,13 +677,13 @@ removed launchd plists and the ax symlink`,
     eyebrow: "$ sync the team rig",
     title: "Team",
     blurb:
-      "Activate the shared .ax/ skills and agents committed to the repo into your local runtime, trust-gated per content hash. Executable hooks require a separate `ax team trust` review before installation.",
+      "Activate the shared .ax/ skills and agents committed to the repo into your local runtime, trust-gated per content hash. Iterate on artifacts privately in .ax.local/ before promoting. Executable hooks require a separate `ax team trust` review before installation.",
     commands: [
       {
         name: "team",
-        sub: ["sync", "trust"],
-        job: "Sync the team's .ax/ rig (skills + agents) and trust-review + install executable hooks.",
-        signature: "ax team sync|trust [--dry-run] [--yes] [--allow-branch]",
+        sub: ["sync", "trust", "experiment"],
+        job: "Sync the team's .ax/ rig, trust-review executable hooks, and iterate on artifacts in an isolated overlay before promoting.",
+        signature: "ax team sync|trust|experiment <start|list|promote|drop> [--dry-run] [--yes] [--allow-branch]",
         flags: [
           { flag: "--dry-run", desc: "show what would change without writing anything (sync only)" },
           { flag: "--yes", desc: "approve activation / installation of new or changed artifacts" },
@@ -704,6 +704,7 @@ $ ax team trust --yes
         detail: [
           "ax team sync: scans .ax/skills/, .ax/agents/, and .ax/hooks/ in the current git repo root. Skills and agents are non-executable and safe to copy; hooks in .ax/hooks/ are reported as gated but never activated.",
           "ax team trust: reviews + installs executable hooks from .ax/hooks/ using sha256 trust-on-change. Only installs when on the repo's default branch — refuses on feature branches.",
+          "ax team experiment: isolate→iterate→promote loop. `start` copies or scaffolds an artifact into a gitignored .ax.local/ overlay; `list` shows active experiments; `promote` moves the overlay into committed .ax/ + stages with git add (open a PR after); `drop` discards the overlay. Sync annotates overlay artifacts as (experiment).",
           "Content hashes prevent re-activating unchanged artifacts (idempotent). Changed artifacts are re-activated and their trust records updated.",
           "Fail-safe: non-TTY without --yes prints a summary and exits without installing anything.",
           "v1 limitation: team hooks must be self-contained or import from @ax/hooks-sdk.",

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -68,6 +68,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 ### Setup and ingest
 - `ax team sync` - activate the team's committed .ax/ rig (skills + agents) into your runtime, trust-gated (executable hooks gated)
 - `ax team trust` - review + install executable team hooks from .ax/hooks/ (sha256 trust-on-change, default-branch-only, fail-safe)
+- `ax team experiment <start|list|promote|drop> <kind> <name>` - isolate→iterate→promote loop: start copies/scaffolds an artifact into a gitignored .ax.local/ overlay, list shows active experiments, promote moves the overlay artifact into committed .ax/ + git adds it (open a PR after), drop discards the overlay; ax team sync activates the overlay version for you only (annotated as "(experiment)")
 - `ax setup` / `ax install` - first-time install: CLI, local SurrealDB, transcript watcher
 - `ax ingest [here] [--since=Nd]` - ingest transcripts, skills, and git history; `here` scopes to the current repo; the watcher does this automatically on new transcripts
 - `ax roles` - list role labels used for skill classification

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -270,6 +270,17 @@ Activate the team's committed `.ax/` rig (skills + agents) into your runtime, tr
 
 Review + install the team's executable `.ax/hooks/*` into your runtime. Uses sha256 trust-on-change: a hook is only installed when its content hash is new or changed, and only when running on the repo's default branch. `--yes` approves installation without interactive prompting. `--allow-branch` bypasses the default-branch guard (advanced use). Fail-safe: non-TTY without `--yes` installs nothing. Team hooks must be self-contained or import from `@ax/hooks-sdk` (v1 limitation: no arbitrary package resolution at hook fire time).
 
+`ax team experiment <start|list|promote|drop> <kind> <name>`
+
+Iterate on a team artifact (`kind` = `skill` | `agent` | `hook`) in an isolated, gitignored `.ax.local/` overlay, then promote it into the committed `.ax/` rig.
+
+- `start <kind> <name>` - copies the committed artifact (or scaffolds a new one) into `.ax.local/<kind>s/<name>` for isolated editing. Adds `.ax.local/` to `.gitignore` automatically.
+- `list` - shows all active experiments in `.ax.local/`, noting which ones override a committed version.
+- `promote <kind> <name>` - moves the overlay artifact to `.ax/<kind>s/<name>`, stages it with `git add`, and clears the overlay copy. Open a PR after this step. Promoted hooks must be re-trusted by teammates via `ax team trust` after the PR merges.
+- `drop <kind> <name>` - discards the overlay copy, reverting to the committed version.
+
+During iteration, use `ax team sync --yes` (or `ax team trust --yes` for a hook) to activate the overlay version in your own runtime; `sync` annotates overlay-sourced artifacts as `(experiment)` in its output. `experiment score` (telemetry-gated ranking of experiment vs baseline) is deferred to the hosted phase.
+
 ## Live ingest in the dashboard
 
 `axctl serve` exposes `POST /api/ingest` (also wired to the dashboard's **Live**

--- a/docs/superpowers/plans/2026-06-16-mesh-b-experiment-overlay.md
+++ b/docs/superpowers/plans/2026-06-16-mesh-b-experiment-overlay.md
@@ -1,0 +1,260 @@
+# Mesh B - `.ax.local/` Experiment Overlay + Promote Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let a dev iterate on a variant of a team artifact in an **isolated, gitignored `.ax.local/` overlay** (no branch, nothing shared), have `ax team sync`/`trust` activate the overlay version over the committed one, and **promote** a proven variant (`.ax.local/ → .ax/` + a PR). The "separate threads" mechanism with no clean tool today.
+
+**Architecture:** `.ax.local/` mirrors `.ax/`'s structure (`skills/`/`agents/`/`hooks/`) and is gitignored. `scanWithOverlay(root)` merges committed `.ax/` + `.ax.local/`, with the overlay **winning** on name collision - so a dev's experiment is what gets activated, only for them. `ax team experiment start|list|promote|drop` manage the overlay. Promote moves the overlay artifact into the committed `.ax/` and opens a PR (the team reviews; cross-dev telemetry-gated scoring is the deferred hosted phase). No backend, no auth, no secrets.
+
+**Tech Stack:** Bun + TS + Effect v4 + `effect/unstable/cli`. No DB (runtime "none"). Tests: `bun:test`. `node:fs` banned (Bun fs). Reuse Slice 0 `apps/axctl/src/team/{scan,model,activate}.ts` + the Mesh A `team.ts` command group.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-team-backend-design.md` build-order step 2.
+
+## Scope (v1, local)
+
+IN: the overlay (`.ax.local/`), overlay-aware activation (sync + trust prefer the overlay), and `ax team experiment start/list/promote/drop`.
+DEFERRED (hosted/fast-follow): `ax team experiment score` (telemetry-gated, cross-dev effectiveness) - v1 promote opens a PR for human review; the measured gate is the hosted phase.
+
+## File structure
+
+```
+apps/axctl/src/team/
+  overlay.ts      - scanWithOverlay(root) (merge .ax/ + .ax.local/, overlay wins) + AX_LOCAL_DIR + ensureGitignored
+  experiment.ts   - start / list / drop / promote (pure plan + thin IO over .ax.local/ and .ax/)
+apps/axctl/src/cli/commands/team.ts  - add `experiment` subgroup; switch sync+trust to scanWithOverlay (modify)
+docs/cli.md · llms.txt · -cli-reference.data.ts  - document `ax team experiment` (BOTH gates)
+```
+
+The `.ax.local/` convention mirrors `.ax/`: `.ax.local/skills/<name>/SKILL.md`, `.ax.local/agents/<name>.md`, `.ax.local/hooks/<name>.ts`.
+
+---
+
+## Task 1: `overlay.ts` - overlay-merged scan
+
+**Files:** Create `apps/axctl/src/team/overlay.ts` + `overlay.test.ts`
+
+- [ ] **Step 1: failing test** (real temp dirs; overlay precedence is the key behavior):
+
+```typescript
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import { scanWithOverlay } from "./overlay.ts";
+
+let root: string;
+beforeAll(async () => {
+  root = `/tmp/ax-overlay-${process.pid}`;
+  // committed rig
+  await Bun.write(`${root}/.ax/skills/shared/SKILL.md`, "committed shared");
+  await Bun.write(`${root}/.ax/skills/tdd/SKILL.md`, "committed tdd");
+  await Bun.write(`${root}/.ax/hooks/guard.ts`, "committed hook");
+  // overlay: overrides tdd, adds experiment-only, overrides the hook
+  await Bun.write(`${root}/.ax.local/skills/tdd/SKILL.md`, "OVERLAY tdd");
+  await Bun.write(`${root}/.ax.local/skills/exp/SKILL.md`, "overlay-only");
+  await Bun.write(`${root}/.ax.local/hooks/guard.ts`, "OVERLAY hook");
+});
+afterAll(() => Bun.spawnSync(["rm", "-rf", root]));
+
+describe("scanWithOverlay", () => {
+  it("overlay wins on name collision; overlay-only artifacts appear; committed-only survive; each flagged", async () => {
+    const { artifacts, gated } = await scanWithOverlay(root);
+    const tdd = artifacts.find((a) => a.kind === "skill" && a.name === "tdd");
+    expect(tdd?.path).toContain(".ax.local/skills/tdd");  // overlay path wins
+    expect(tdd?.overlay).toBe(true);
+    const shared = artifacts.find((a) => a.kind === "skill" && a.name === "shared");
+    expect(shared?.path).toContain("/.ax/skills/shared"); // committed survives
+    expect(shared?.overlay).toBe(false);
+    expect(artifacts.find((a) => a.name === "exp")?.overlay).toBe(true); // overlay-only
+    const guard = gated.find((g) => g.name === "guard");
+    expect(guard?.path).toContain(".ax.local/hooks/guard"); // overlay hook wins
+    expect(guard?.overlay).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/overlay.ts`. Reuse `scanAxFolder` by scanning BOTH dirs and merging. Add an `overlay: boolean` flag to the returned artifacts (extend the shape locally - the scan returns `TeamArtifact`/`GatedArtifact`; wrap with `{ ...a, overlay }`). The scanner reads `<root>/.ax` and `<root>/.ax.local`; `scanAxFolder` already takes a dir whose `.ax` subpath it reads - so call it with a base that makes it read `.ax.local`. Check `scan.ts`: it reads `${repoRoot}/.ax`. To scan `.ax.local`, pass a path such that `${X}/.ax` === `${root}/.ax.local`. Cleanest: add an optional 2nd arg to `scanAxFolder(repoRoot, subdir=".ax")`, OR write a tiny local scanner. Implementer: prefer extending `scanAxFolder` with a `subdir` param (default `.ax`) so overlay reuses it (`scanAxFolder(root, ".ax.local")`). Then:
+
+```typescript
+import { scanAxFolder } from "./scan.ts";
+import type { GatedArtifact, TeamArtifact } from "./model.ts";
+
+export const AX_LOCAL_DIR = ".ax.local";
+
+export type OverlayArtifact = TeamArtifact & { readonly overlay: boolean };
+export type OverlayGated = GatedArtifact & { readonly overlay: boolean };
+export interface OverlayScan { readonly artifacts: ReadonlyArray<OverlayArtifact>; readonly gated: ReadonlyArray<OverlayGated>; }
+
+/** Merge committed `.ax/` + `.ax.local/`, overlay winning on (kind,name). */
+export const scanWithOverlay = async (root: string): Promise<OverlayScan> => {
+  const base = await scanAxFolder(root, ".ax");
+  const over = await scanAxFolder(root, AX_LOCAL_DIR);
+  const merge = <T extends { kind: string; name: string }>(b: ReadonlyArray<T>, o: ReadonlyArray<T>) => {
+    const byKey = new Map<string, T & { overlay: boolean }>();
+    for (const x of b) byKey.set(`${x.kind}:${x.name}`, { ...x, overlay: false });
+    for (const x of o) byKey.set(`${x.kind}:${x.name}`, { ...x, overlay: true }); // overlay wins
+    return [...byKey.values()].sort((a, b2) => a.name.localeCompare(b2.name));
+  };
+  return {
+    artifacts: merge(base.artifacts, over.artifacts) as OverlayArtifact[],
+    gated: merge(base.gated, over.gated) as OverlayGated[],
+  };
+};
+```
+
+> Implementer: add the `subdir = ".ax"` param to `scanAxFolder` in `scan.ts` (default keeps all existing callers working - verify the existing scan tests still pass). Confirm `scanAxFolder` returns empty (not throws) when `.ax.local` is absent (it already guards a missing dir).
+
+- [ ] **Step 4: run, PASS** (overlay test + the existing `scan.test.ts` still green). **Step 5: commit.**
+
+---
+
+## Task 2: `experiment.ts` - start / list / drop / promote (pure plan + IO)
+
+**Files:** Create `apps/axctl/src/team/experiment.ts` + `experiment.test.ts`
+
+- [ ] **Step 1: failing test** - test the pure path helpers + the start/promote/drop plans against real temp dirs:
+
+```typescript
+import { describe, expect, it, afterEach } from "bun:test";
+import { overlayPath, committedPath, startExperiment, promoteExperiment, dropExperiment, isSafeKindName } from "./experiment.ts";
+
+describe("paths + guard", () => {
+  it("maps kind/name to overlay + committed paths", () => {
+    expect(overlayPath("/r", "skill", "x")).toBe("/r/.ax.local/skills/x");
+    expect(committedPath("/r", "agent", "y")).toBe("/r/.ax/agents/y.md");
+  });
+  it("rejects unsafe kind/name", () => {
+    expect(isSafeKindName("skill", "x")).toBe(true);
+    expect(isSafeKindName("skill", "../e")).toBe(false);
+    expect(isSafeKindName("bogus", "x")).toBe(false);
+  });
+});
+
+describe("start / promote / drop", () => {
+  const root = `/tmp/ax-exp-${process.pid}`;
+  afterEach(() => Bun.spawnSync(["rm", "-rf", root]));
+  it("start copies a committed skill into the overlay (or scaffolds new)", async () => {
+    await Bun.write(`${root}/.ax/skills/tdd/SKILL.md`, "committed");
+    await startExperiment(root, "skill", "tdd");
+    expect(await Bun.file(`${root}/.ax.local/skills/tdd/SKILL.md`).text()).toBe("committed");
+  });
+  it("start scaffolds a new overlay skill when none committed", async () => {
+    await startExperiment(root, "skill", "fresh");
+    expect(await Bun.file(`${root}/.ax.local/skills/fresh/SKILL.md`).exists()).toBe(true);
+  });
+  it("promote moves overlay → committed and removes the overlay copy", async () => {
+    await Bun.write(`${root}/.ax.local/skills/exp/SKILL.md`, "variant");
+    await promoteExperiment(root, "skill", "exp");
+    expect(await Bun.file(`${root}/.ax/skills/exp/SKILL.md`).text()).toBe("variant");
+    expect(await Bun.file(`${root}/.ax.local/skills/exp/SKILL.md`).exists()).toBe(false);
+  });
+  it("drop removes the overlay artifact", async () => {
+    await Bun.write(`${root}/.ax.local/skills/exp/SKILL.md`, "v");
+    await dropExperiment(root, "skill", "exp");
+    expect(await Bun.file(`${root}/.ax.local/skills/exp/SKILL.md`).exists()).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** `apps/axctl/src/team/experiment.ts`. Path-traversal guard on kind+name (writes/moves into the repo). `kind ∈ {skill,agent,hook}`. Skills are dirs; agents/hooks are files. Use Bun + shell (`cp -R`, `mkdir -p`, `mv`, `rm -rf` - node:fs banned):
+
+```typescript
+const KINDS = new Set(["skill", "agent", "hook"]);
+const NAME_RE = /^[a-zA-Z0-9._-]+$/;
+export const isSafeKindName = (kind: string, name: string): boolean =>
+  KINDS.has(kind) && NAME_RE.test(name) && name !== "." && name !== "..";
+
+const sub = (kind: string) => (kind === "skill" ? "skills" : kind === "agent" ? "agents" : "hooks");
+const leaf = (kind: string, name: string) => (kind === "skill" ? name : `${name}.${kind === "agent" ? "md" : "ts"}`);
+export const overlayPath = (root: string, kind: string, name: string) => `${root}/.ax.local/${sub(kind)}/${kind === "skill" ? name : leaf(kind, name)}`;
+export const committedPath = (root: string, kind: string, name: string) => `${root}/.ax/${sub(kind)}/${kind === "skill" ? name : leaf(kind, name)}`;
+```
+
+Implement `startExperiment` (copy committed→overlay if exists, else scaffold a minimal SKILL.md/agent/hook stub), `promoteExperiment` (overlay→committed via mkdir -p parent + cp -R/mv + rm -rf overlay), `dropExperiment` (rm -rf overlay path). Each guards `isSafeKindName` first and throws otherwise. For a skill (dir) use `cp -R`; for agent/hook (file) use content read+write or `cp`. Scaffold templates: skill = `---\nname: <name>\ndescription: TODO\n---\n`, agent = `---\nname: <name>\ndescription: TODO\n---\n`, hook = `import { defineHook } from "@ax/hooks-sdk/define";\nexport default defineHook({ name: "<name>", events: [], run: () => ({ _tag: "Allow" }) });\n`.
+
+> Implementer: keep the path/guard helpers exactly as tested. promote into a hook re-enters the trust flow (the dev runs `ax team trust` after promote + PR-merge) - note that; promote does NOT auto-install. Each IO fn guards the name first.
+
+- [ ] **Step 4: run, PASS.** **Step 5: commit.**
+
+---
+
+## Task 3: overlay-aware sync + trust + gitignore
+
+**Files:** Modify `apps/axctl/src/cli/commands/team.ts`
+
+- [ ] **Step 1:** switch `ax team sync`'s scan from `scanAxFolder(root)` to `scanWithOverlay(root)` so the overlay version activates. The artifacts now carry `overlay: boolean` - in the sync report, mark overlaid artifacts (e.g. `+ skill:tdd (experiment)`). Same for `ax team trust`'s gated hooks (use `scanWithOverlay(root).gated`). Behavior otherwise unchanged (trust/sync semantics identical; the overlay just changes WHICH file is the source).
+- [ ] **Step 2:** ensure `.ax.local/` is gitignored. Add a helper used by `experiment start`: if `<root>/.gitignore` doesn't already ignore `.ax.local/`, append it (idempotent). (Or: since `.ax/*` may already be carved per the rig PR, `.ax.local/` is a separate path that must be explicitly ignored - `experiment start` ensures `.gitignore` has a `.ax.local/` line.)
+- [ ] **Step 3:** verify existing `team.test.ts` (sync/trust renderers) still pass; `bun run typecheck` 0. **Step 4: commit.**
+
+---
+
+## Task 4: `ax team experiment` CLI subgroup
+
+**Files:** Modify `apps/axctl/src/cli/commands/team.ts` + `team.test.ts`
+
+- [ ] **Step 1: failing test** for the pure list renderer:
+
+```typescript
+import { renderExperimentList } from "./team.ts";
+describe("renderExperimentList", () => {
+  it("lists overlay artifacts with shadow info", () => {
+    const out = renderExperimentList([{ key: "skill:tdd", shadows: true }, { key: "skill:exp", shadows: false }]);
+    expect(out).toContain("skill:tdd");
+    expect(out).toMatch(/shadow|overrides/i);
+  });
+  it("empty-state", () => { expect(renderExperimentList([])).toContain("no experiments"); });
+});
+```
+
+- [ ] **Step 2: run, FAIL.**
+- [ ] **Step 3: implement** the `experiment` subgroup under `team`, mirroring the `sync`/`trust` subcommand wiring. Subcommands:
+  - `ax team experiment start <kind> <name>` → `startExperiment` + ensure `.ax.local/` gitignored; print "editing .ax.local/<...> - iterate, then `ax team sync` (or `trust` for hooks) to activate, `ax team experiment promote` to ship".
+  - `ax team experiment list` → `scanWithOverlay(root)`, filter `overlay:true`, render (mark which shadow a committed artifact).
+  - `ax team experiment promote <kind> <name>` → `promoteExperiment` + `git add` the new `.ax/<...>` + print the `gh pr create` command (do NOT auto-open; print guidance). Note: a promoted hook needs `ax team trust` after the PR merges.
+  - `ax team experiment drop <kind> <name>` → `dropExperiment`.
+  Args: `<kind>` and `<name>` positionals (validate via `isSafeKindName`; error cleanly on bad input). `renderExperimentList` pure + tested.
+- [ ] **Step 4: register** under the `team` group's `Command.withSubcommands([syncCommand, trustCommand, experimentCommand])`. `bun run typecheck` 0. **Step 5: commit.**
+
+---
+
+## Task 5: docs + both cli-reference gates + e2e
+
+**Files:** modify `docs/cli.md`, `apps/site/public/llms.txt`, `apps/site/app/routes/docs/-cli-reference.data.ts`
+
+- [ ] **Step 1: document** `ax team experiment <start|list|promote|drop>` in all three (the `team` card's `sub:` list gains `experiment`).
+- [ ] **Step 2: gates + tests + typecheck:**
+```
+bun test apps/axctl/src/team apps/axctl/src/cli/commands/team.test.ts
+bun scripts/check-cli-reference.ts 2>&1 | tail -1
+bun test scripts/check-site-cli-reference.test.ts 2>&1 | tail -3
+bun run typecheck 2>&1 | rg -c "error TS"
+```
+- [ ] **Step 3: e2e** (the experiment loop):
+```
+W=/Users/necmttn/Projects/ax/.claude/worktrees/team-experiment
+rm -rf /tmp/axexp && mkdir -p /tmp/axexp/.ax/skills/shared && (cd /tmp/axexp && git -c init.defaultBranch=main init -q && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init)
+printf -- '---\nname: shared\ndescription: x\n---\nbody\n' > /tmp/axexp/.ax/skills/shared/SKILL.md
+cd /tmp/axexp
+bun run $W/apps/axctl/src/cli/index.ts team experiment start skill myexp 2>&1 | head -4
+ls .ax.local/skills/myexp/SKILL.md && echo "overlay created"
+grep -q ".ax.local" .gitignore && echo ".ax.local gitignored"
+bun run $W/apps/axctl/src/cli/index.ts team experiment list 2>&1 | head -4
+# sync activates the overlay (into a temp HOME so we don't touch the real runtime)
+HOME=/tmp/axexp-home bun run $W/apps/axctl/src/cli/index.ts team sync --yes 2>&1 | head -6
+ls /tmp/axexp-home/.claude/skills/myexp/SKILL.md && echo "overlay skill activated"
+# promote → moves to .ax/ + prints PR guidance
+bun run $W/apps/axctl/src/cli/index.ts team experiment promote skill myexp 2>&1 | head -6
+ls .ax/skills/myexp/SKILL.md && echo "promoted to committed"
+ls .ax.local/skills/myexp 2>/dev/null && echo "overlay STILL present (bad)" || echo "overlay cleared after promote"
+```
+Expected: start creates `.ax.local/skills/myexp` + gitignores `.ax.local/`; list shows it; sync activates the overlay version (into the temp HOME); promote moves it to `.ax/skills/myexp`, clears the overlay, and prints a `gh pr create` hint. Paste output.
+- [ ] **Step 4: CLEANUP:** `rm -rf /tmp/axexp /tmp/axexp-home`.
+- [ ] **Step 5: commit.**
+
+---
+
+## Self-Review Notes
+- **Isolation:** the overlay is gitignored (`experiment start` ensures it) - nothing is shared until `promote` opens a PR. No branch of the main repo needed.
+- **Security:** path-traversal guard on kind+name; promoted hooks re-enter the Mesh A trust gate (`ax team trust`) - promote never auto-installs an executable.
+- **Reuse:** `scanAxFolder` (param-extended for the overlay), the Slice-0 activate path, the Mesh A trust flow.
+- **Scope honesty:** `experiment score` (telemetry-gated, cross-dev) is DEFERRED to the hosted phase - v1 promote = isolate→iterate→PR, the measured gate comes with the backend.
+- **CI:** BOTH cli-reference gates; the e2e git setup uses `-c user.email/-c user.name` (CI has no global git identity - the Mesh A lesson).


### PR DESCRIPTION
## Why

Completes the **local / git-native pull layer** of the team mesh (the dogfood showed this is where the individual-dev value lives, ahead of any hosted backend). Slice 0 synced the committed rig; Mesh A trust-gated executable hooks; **Mesh B** lets a dev *iterate* on a variant in isolation, then promote it.

Spec: `docs/superpowers/specs/2026-06-15-team-backend-design.md` (build-order step 2). Plan: `docs/superpowers/plans/2026-06-16-mesh-b-experiment-overlay.md`.

## What

```
ax team experiment start <kind> <name>   → scaffold/copy into gitignored .ax.local/  (isolated, no branch)
   …iterate; ax team sync / ax team trust now activate the OVERLAY version, only for you…
ax team experiment list                  → your active experiments (+ which shadow a committed artifact)
ax team experiment promote <kind> <name> → .ax.local/ → .ax/ + git add + prints `gh pr create`  (team reviews)
ax team experiment drop <kind> <name>    → discard the overlay
```

- **`scanWithOverlay`** merges committed `.ax/` + `.ax.local/`, the overlay winning on `(kind,name)` — so a dev's experiment is what gets synced/trusted, **only for them** (`.ax.local/` is gitignored).
- **Security preserved:** overlay artifacts are self-authored + local-only; they only leave via `promote` → PR review. A promoted **hook** re-enters the full Mesh A trust gate (`ax team trust`: sha256 + default-branch + full-source review + `--yes`) — `sync`/`trust` only changed their *scan source*, the gates are byte-for-byte intact.
- Path-traversal guard on `kind`/`name` in every op; `promote` verifies the overlay exists **before** touching the committed target (no data loss on a typo).
- `experiment score` (telemetry-gated, cross-dev effectiveness) is deferred to the hosted phase — v1 is isolate → iterate → PR.

## Test plan

- [x] 46 team tests (overlay precedence, experiment ops, path guards, gitignore helper, the renderers) + a regression test proving a typo'd `promote` can't delete a committed artifact
- [x] e2e: start (overlay + `.ax.local/` gitignored) · list · **sync activates the overlay** (marked `(experiment)`) · promote (→`.ax/`, overlay cleared, `git add`) · drop — all under an isolated temp HOME (real `~/.claude` untouched)
- [x] **Holistic opus review** — overlay precedence + path guards + the trust-flow-untouched claim verified; its one fix-before-merge finding (the promote data-loss bug) is fixed
- [x] Both cli-reference gates + docs; typecheck 0; `scanAxFolder`'s new `subdir` param doesn't break existing callers
- [ ] CI green against current origin/main

After this merges, everything left (Better Auth + CF/D1 backend + dashboard) is **gated on a design-partner price signal** — a deliberate stop point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)