### PR TITLE
fix(cli): doctor honors AX_DB_URL + classify dead-end loop (dogfood)

### DIFF
--- a/apps/axctl/src/cli/install.test.ts
+++ b/apps/axctl/src/cli/install.test.ts
@@ -3,10 +3,46 @@ import {
     formatDaemonStatus,
     formatDoctorReport,
     parseDaemonCommand,
+    resolveDaemonHostPort,
     staleRunningIngestRuns,
     type DaemonStatus,
     type DoctorReport,
 } from "./install.ts";
+
+describe("resolveDaemonHostPort (doctor honors AX_DB_URL)", () => {
+    const state = {
+        version: 1 as const,
+        db: { host: "127.0.0.1", port: 8521 },
+        updatedAt: "2026-06-16T00:00:00.000Z",
+    };
+
+    test("falls back to runtime-state when AX_DB_URL is unset", () => {
+        expect(resolveDaemonHostPort(state, undefined)).toEqual({
+            host: "127.0.0.1",
+            port: 8521,
+            url: "ws://127.0.0.1:8521",
+        });
+    });
+
+    test("honors an explicit AX_DB_URL host:port over runtime-state", () => {
+        // Regression: doctor probed the runtime-state default (8521) while the
+        // rest of the CLI connected via AX_DB_URL - so it checked the wrong
+        // instance and reported another db's listener / stuck ingest_runs.
+        expect(resolveDaemonHostPort(state, "ws://10.0.0.5:8531")).toEqual({
+            host: "10.0.0.5",
+            port: 8531,
+            url: "ws://10.0.0.5:8531",
+        });
+    });
+
+    test("ignores a malformed AX_DB_URL and keeps runtime-state", () => {
+        expect(resolveDaemonHostPort(state, "not a url")).toEqual({
+            host: "127.0.0.1",
+            port: 8521,
+            url: "ws://127.0.0.1:8521",
+        });
+    });
+});
 
 describe("cli install operations", () => {
     test("parses daemon subcommands", () => {

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -19,6 +19,7 @@ import {
     DEFAULT_DB_PORT,
     dbUrlFromState,
     readRuntimeState,
+    type RuntimeState,
     runtimeStatePath,
     writeRuntimeState,
 } from "@ax/lib/runtime-state";
@@ -640,10 +641,42 @@ function launchdStatus(
     });
 }
 
+/** Parse `ws://host:port` (or http/wss) into host + port. null on garbage. */
+function hostPortFromUrl(url: string): { host: string; port: number } | null {
+    try {
+        const u = new URL(url);
+        const port = u.port ? Number(u.port) : NaN;
+        if (!u.hostname || !Number.isFinite(port)) return null;
+        return { host: u.hostname, port };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Resolve the DB endpoint doctor should probe. Mirrors the SurrealClient's own
+ * precedence (`AX_DB_URL` wins, else the daemon's runtime-state port - see
+ * packages/lib/src/config.ts) so doctor checks the SAME instance the rest of the
+ * CLI connects to. Without this, an `AX_DB_URL` override (remote DB, custom port,
+ * a second instance) silently left doctor probing the default 8521 daemon and
+ * reporting another instance's listener / buckets / stuck ingest_runs.
+ *
+ * Pure (no fs / process.env reads) so it is unit-testable.
+ */
+export function resolveDaemonHostPort(
+    state: RuntimeState,
+    envUrl: string | undefined,
+): { host: string; port: number; url: string } {
+    const override = envUrl ? hostPortFromUrl(envUrl) : null;
+    if (override) return { host: override.host, port: override.port, url: envUrl as string };
+    return { host: state.db.host, port: state.db.port, url: dbUrlFromState(state) };
+}
+
 function collectDaemonEndpoint(): Effect.Effect<DaemonEndpoint, never, FileSystem.FileSystem> {
     return Effect.gen(function* () {
         const state = yield* readRuntimeState();
-        const probe = probePort(state.db.port);
+        const { host, port, url } = resolveDaemonHostPort(state, process.env.AX_DB_URL);
+        const probe = probePort(port);
         const loadedPid = loadedDbPid();
         // Treat conflict as "another process is listening", not us. When launchd
         // says our DB agent owns this PID, suppress the conflict in the report.
@@ -652,9 +685,9 @@ function collectDaemonEndpoint(): Effect.Effect<DaemonEndpoint, never, FileSyste
                 ? null
                 : probe.holder;
         return {
-            host: state.db.host,
-            port: state.db.port,
-            url: dbUrlFromState(state),
+            host,
+            port,
+            url,
             listening: probe.listening,
             conflict,
             runtimeStatePath: runtimeStatePath(),

--- a/apps/axctl/src/cli/skills-classify.test.ts
+++ b/apps/axctl/src/cli/skills-classify.test.ts
@@ -22,6 +22,51 @@ function mockDb(rows: MockRow[]): SurrealClientShape {
     return makeTestSurrealClient({ denyWrites: true, fallback: [rows] }).client;
 }
 
+/**
+ * Default mode now delegates to fetchSkillHygiene, which issues ONE 3-statement
+ * query ([invocation counts, skill rows, classified ids]) and joins them in JS.
+ * This builds that 3-statement fixture so the given rows survive the join as the
+ * selected unclassified skills. `extraSkills` lets a test seed skills that should
+ * be filtered OUT (synthetic / classified / below-threshold) to exercise the
+ * predicate end-to-end.
+ */
+function hygieneMockDb(
+    rows: MockRow[],
+    extraSkills: Array<{
+        name: string;
+        invocations: number;
+        sessions?: number;
+        dir_path?: string;
+        classified?: boolean;
+    }> = [],
+): SurrealClientShape {
+    const all = [
+        ...rows.map((r) => ({ ...r, dir_path: `/skills/${r.name}`, classified: false })),
+        ...extraSkills.map((s) => ({
+            name: s.name,
+            invocations: s.invocations,
+            sessions: s.sessions ?? 1,
+            dir_path: s.dir_path ?? `/skills/${s.name}`,
+            classified: s.classified ?? false,
+        })),
+    ];
+    const counts = all.map((s) => ({
+        sid: `skill:${s.name}`,
+        invocations: s.invocations,
+        sessions: s.sessions,
+    }));
+    const skills = all.map((s) => ({
+        id: `skill:${s.name}`,
+        name: s.name,
+        dir_path: s.dir_path,
+    }));
+    const classified = all.filter((s) => s.classified).map((s) => `skill:${s.name}`);
+    return makeTestSurrealClient({
+        denyWrites: true,
+        fallback: [counts, skills, classified],
+    }).client;
+}
+
 // Forced-dependency edit: cmdSkillsClassify now requires FileSystem + Path
 // (the @effect/platform migration); run against the REAL Bun-backed layers.
 const BunFsLayer = Layer.merge(BunFileSystem.layer, BunPath.layer);
@@ -60,7 +105,7 @@ describe("cmdSkillsClassify default mode", () => {
             { name: "composto", invocations: 15, sessions: 4 },
             { name: "codex:rescue", invocations: 8, sessions: 3 },
         ];
-        const db = mockDb(rows);
+        const db = hygieneMockDb(rows);
         await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
 
         for (const row of rows) {
@@ -73,10 +118,38 @@ describe("cmdSkillsClassify default mode", () => {
         }
     });
 
+    // Regression for the dead-end loop: default mode must SELECT unclassified
+    // skills with ≥3 invocations and exclude classified / synthetic / low-count.
+    // The previous correlated `NOT (subquery)[0]` predicate returned NONE (not
+    // false) for unclassified skills and silently excluded every one of them, so
+    // classify always reported "none found" while `ax skills weighted` reported
+    // a positive count. Now both share fetchSkillHygiene.
+    test("selects unclassified ≥3 and drops classified / synthetic / low-count", async () => {
+        const outDir = mkdtempSync(join(tmpdir(), "ax-classify-filter-"));
+        const db = hygieneMockDb(
+            [{ name: "keep-me", invocations: 9, sessions: 3 }],
+            [
+                { name: "already-tagged", invocations: 20, classified: true },
+                { name: "codex:exec", invocations: 999, dir_path: "(synthetic)" },
+                { name: "too-rare", invocations: 2 },
+            ],
+        );
+        const logged: string[] = [];
+        const origLog = console.log;
+        console.log = (msg: string) => { logged.push(msg); };
+        try {
+            await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: true }));
+        } finally {
+            console.log = origLog;
+        }
+        const parsed = JSON.parse(logged[0] ?? "[]") as Array<Record<string, unknown>>;
+        expect(parsed.map((r) => r.skill)).toEqual(["keep-me"]);
+    });
+
     test("is idempotent - skips existing files without re-writing", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-idem-"));
         const rows: MockRow[] = [{ name: "composto", invocations: 15, sessions: 4 }];
-        const db = mockDb(rows);
+        const db = hygieneMockDb(rows);
 
         // First run - write the file
         await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
@@ -96,7 +169,7 @@ describe("cmdSkillsClassify default mode", () => {
     test("dry-run does not write any files", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-dry-"));
         const rows: MockRow[] = [{ name: "composto", invocations: 15, sessions: 4 }];
-        const db = mockDb(rows);
+        const db = hygieneMockDb(rows);
         await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: true, json: false }));
         const filePath = join(outDir, `classify-composto.md`);
         const exists = await access(filePath).then(() => true, () => false);
@@ -106,7 +179,7 @@ describe("cmdSkillsClassify default mode", () => {
     test("json mode outputs structured list, no files written", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-json-"));
         const rows: MockRow[] = [{ name: "composto", invocations: 15, sessions: 4 }];
-        const db = mockDb(rows);
+        const db = hygieneMockDb(rows);
 
         const logged: string[] = [];
         const origLog = console.log;
@@ -132,7 +205,7 @@ describe("cmdSkillsClassify default mode", () => {
 
     test("empty result from DB prints informational message", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-empty-"));
-        const db = mockDb([]);
+        const db = hygieneMockDb([]);
         const logged: string[] = [];
         const origLog = console.log;
         console.log = (msg: string) => { logged.push(msg); };
@@ -195,24 +268,21 @@ describe("cmdSkillsClassify explicit mode", () => {
 // ---------------------------------------------------------------------------
 
 describe("SQL shape (default mode)", () => {
-    test("default query requires invocations >= 3 and NOT plays_role", async () => {
+    // Default mode delegates to fetchSkillHygiene, whose deref-free 3-statement
+    // query reads the classified set from plays_role (the role-source filter) and
+    // joins counts→skills in JS. The ≥3 threshold and synthetic exclusion are
+    // applied in JS (see fetchSkillHygiene), NOT in SQL - so they are asserted by
+    // the behavioral filter test above, not by string-matching the query.
+    test("default query reads the plays_role classification sources", async () => {
         const outDir = mkdtempSync(join(tmpdir(), "ax-classify-sql-"));
-        const tc = makeTestSurrealClient({ denyWrites: true });
+        const tc = makeTestSurrealClient({ denyWrites: true, fallback: [[], [], []] });
         await runWith(tc.client, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
-        const capturedSql = tc.captured.at(-1) ?? "";
+        const capturedSql = tc.captured.join("\n");
         expect(capturedSql).toContain("plays_role");
-        expect(capturedSql).toContain(">= 3");
+        expect(capturedSql).toContain("invoked");
         expect(capturedSql).toContain(`"frontmatter"`);
         expect(capturedSql).toContain(`"brief"`);
         expect(capturedSql).toContain(`"user"`);
-    });
-
-    test("default query excludes synthetic provider-tool skills", async () => {
-        const outDir = mkdtempSync(join(tmpdir(), "ax-classify-synthetic-"));
-        const tc = makeTestSurrealClient({ denyWrites: true });
-        await runWith(tc.client, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
-        const capturedSql = tc.captured.at(-1) ?? "";
-        expect(capturedSql).toContain('dir_path != "(synthetic)"');
     });
 });
 
@@ -226,7 +296,7 @@ describe("output path", () => {
         const rows: MockRow[] = [
             { name: "superpowers:subagent-driven-development", invocations: 10, sessions: 5 },
         ];
-        const db = mockDb(rows);
+        const db = hygieneMockDb(rows);
         await runWith(db, cmdSkillsClassify({ names: [], outDir, dryRun: false, json: false }));
         const expectedFile = join(outDir, "classify-superpowers__subagent-driven-development.md");
         const exists = await access(expectedFile).then(() => true, () => false);

--- a/apps/axctl/src/cli/skills-classify.ts
+++ b/apps/axctl/src/cli/skills-classify.ts
@@ -13,6 +13,7 @@ import { prettyPrint } from "@ax/lib/json";
 import { skillNameToSlug, renderClassifyBrief } from "./skills-classify-template.ts";
 import { validateSkillName } from "@ax/lib/role-name";
 import { fail } from "./commands/shared.ts";
+import { fetchSkillHygiene, SKILL_HYGIENE_MIN_INVOCATIONS } from "../queries/skill-hygiene.ts";
 
 export interface ClassifyRow {
     readonly name: string;
@@ -26,25 +27,13 @@ export interface ClassifyResult {
     readonly skipped: string[];
 }
 
-/**
- * SurrealQL for default mode: unclassified skills with >= 3 invocations.
- * A skill is "unclassified" when it has no plays_role edge with source in
- * ("frontmatter", "brief", "user").
- */
-const buildDefaultSql = () => `
-SELECT
-    name,
-    // $parent.id refers to the outer SELECT row's id (SurrealDB correlated subquery)
-    // https://surrealdb.com/docs/surrealql/statements/select#subqueries
-    array::len((SELECT id FROM invoked WHERE out = $parent.id)) AS invocations,
-    array::len(array::distinct((SELECT in.session FROM invoked WHERE out = $parent.id).in.session)) AS sessions
-FROM skill
-WHERE
-    NOT (SELECT id FROM plays_role WHERE in = $parent.id AND source IN ["frontmatter", "brief", "user"])[0]
-    AND array::len((SELECT id FROM invoked WHERE out = $parent.id)) >= 3
-    AND dir_path != "(synthetic)"
-ORDER BY invocations DESC;
-`.trim();
+// Default mode ("unclassified skills with ≥3 invocations") no longer has its own
+// SurrealQL here. It delegates to fetchSkillHygiene - the single source of truth
+// shared with `ax skills weighted`. The old correlated predicate
+// (`NOT (SELECT ... )[0]`) was broken: that subquery yields NONE for an
+// unclassified skill, and `NOT NONE` is NONE (not true), so the WHERE clause
+// silently excluded EVERY unclassified skill and classify always reported
+// "none found" while weighted reported a positive count.
 
 /**
  * SurrealQL for explicit mode: named skills only, no invocation threshold and
@@ -97,18 +86,31 @@ export const cmdSkillsClassify = (
             }
         }
 
-        const sql = opts.names.length > 0
-            ? buildExplicitSql(opts.names)
-            : buildDefaultSql();
-
-        const result = yield* db.query<[Array<Record<string, unknown>>]>(sql);
-        const rows = (result?.[0] ?? []) as Array<Record<string, unknown>>;
-
-        const selected: ClassifyRow[] = rows.map((r) => ({
-            name: String(r.name ?? ""),
-            invocations: Number(r.invocations ?? 0),
-            sessions: Number(r.sessions ?? 0),
-        })).filter((r) => r.name.length > 0);
+        // Default mode shares fetchSkillHygiene with `ax skills weighted` so the
+        // two surfaces can never disagree on what counts as unclassified.
+        // Explicit mode keeps its own query (named skills, no threshold, no
+        // classified filter - re-classification must be allowed).
+        let selected: ClassifyRow[];
+        if (opts.names.length > 0) {
+            const result = yield* db.query<[Array<Record<string, unknown>>]>(
+                buildExplicitSql(opts.names),
+            );
+            const rows = (result?.[0] ?? []) as Array<Record<string, unknown>>;
+            selected = rows.map((r) => ({
+                name: String(r.name ?? ""),
+                invocations: Number(r.invocations ?? 0),
+                sessions: Number(r.sessions ?? 0),
+            })).filter((r) => r.name.length > 0);
+        } else {
+            const hygiene = yield* fetchSkillHygiene({
+                minInvocations: SKILL_HYGIENE_MIN_INVOCATIONS,
+            });
+            selected = hygiene.map((r) => ({
+                name: r.name,
+                invocations: r.invocations,
+                sessions: r.sessions,
+            }));
+        }
 
         if (opts.json) {
             const out = selected.map((r) => ({

--- a/apps/axctl/src/dashboard/next-actions.test.ts
+++ b/apps/axctl/src/dashboard/next-actions.test.ts
@@ -515,7 +515,7 @@ describe("routingCards", () => {
 
 describe("skillHygieneCards", () => {
     test("decide inline_action with correct skill name", () => {
-        const rows: SkillHygieneRow[] = [{ name: "superpowers:brainstorming", invocations: 15 }];
+        const rows: SkillHygieneRow[] = [{ name: "superpowers:brainstorming", invocations: 15, sessions: 6 }];
         const cards = skillHygieneCards(rows);
         expect(cards).toHaveLength(1);
         expect(cards[0]!.inline_action).toEqual({
@@ -527,25 +527,25 @@ describe("skillHygieneCards", () => {
     });
 
     test("id format is skill_hygiene:name", () => {
-        const rows: SkillHygieneRow[] = [{ name: "my-skill", invocations: 10 }];
+        const rows: SkillHygieneRow[] = [{ name: "my-skill", invocations: 10, sessions: 4 }];
         const cards = skillHygieneCards(rows);
         expect(cards[0]!.id).toBe("skill_hygiene:my-skill");
     });
 
     test("evidence includes invocations", () => {
-        const rows: SkillHygieneRow[] = [{ name: "my-skill", invocations: 42 }];
+        const rows: SkillHygieneRow[] = [{ name: "my-skill", invocations: 42, sessions: 9 }];
         const cards = skillHygieneCards(rows);
         expect(cards[0]!.evidence).toContain("42 invocations");
     });
 
     test("link is /skills", () => {
-        const rows: SkillHygieneRow[] = [{ name: "my-skill", invocations: 10 }];
+        const rows: SkillHygieneRow[] = [{ name: "my-skill", invocations: 10, sessions: 4 }];
         const cards = skillHygieneCards(rows);
         expect(cards[0]!.link).toBe("/skills");
     });
 
     test("brief asks to run classify or tag", () => {
-        const rows: SkillHygieneRow[] = [{ name: "my-skill", invocations: 10 }];
+        const rows: SkillHygieneRow[] = [{ name: "my-skill", invocations: 10, sessions: 4 }];
         const cards = skillHygieneCards(rows);
         expect(cards[0]!.brief).toContain("ax skills classify my-skill");
         expect(cards[0]!.brief).toContain("ax skills tag my-skill");
@@ -555,6 +555,7 @@ describe("skillHygieneCards", () => {
         const rows: SkillHygieneRow[] = Array.from({ length: 7 }, (_, i) => ({
             name: `skill-${i}`,
             invocations: 10 + i,
+            sessions: 1 + i,
         }));
         const cards = skillHygieneCards(rows);
         expect(cards).toHaveLength(5);
@@ -562,9 +563,9 @@ describe("skillHygieneCards", () => {
 
     test("cards sorted by impact descending", () => {
         const rows: SkillHygieneRow[] = [
-            { name: "rare", invocations: 3 },
-            { name: "common", invocations: 100 },
-            { name: "mid", invocations: 20 },
+            { name: "rare", invocations: 3, sessions: 2 },
+            { name: "common", invocations: 100, sessions: 40 },
+            { name: "mid", invocations: 20, sessions: 8 },
         ];
         const cards = skillHygieneCards(rows);
         for (let i = 1; i < cards.length; i++) {
@@ -586,7 +587,7 @@ test("all builders return NextActionCard[] typed arrays", () => {
         churnSummary([churnRow("sess-x", 100, 50, 10, 10, 2)]),
     );
     const rc: NextActionCard[] = routingCards(candidatesResult([makeCandidate("research", 0.05)]));
-    const sc: NextActionCard[] = skillHygieneCards([{ name: "x", invocations: 10 }]);
+    const sc: NextActionCard[] = skillHygieneCards([{ name: "x", invocations: 10, sessions: 3 }]);
 
     // All present (guards against tree-shaking)
     expect([pc, vc, tc, cc, rc, sc].every(Array.isArray)).toBe(true);

--- a/apps/axctl/src/dashboard/skills-weighted.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.ts
@@ -164,7 +164,15 @@ const SKILL_NAMES_SQL = `SELECT id, name FROM skill`;
 
 /**
  * Doctor query: count unclassified skills with >= 3 invocations.
- * Mirrors the predicate from src/cli/skills-classify.ts.
+ *
+ * This MUST stay semantically in sync with the canonical predicate in
+ * queries/skill-hygiene.ts (which `ax skills classify` uses): ≥3 invocations,
+ * unclassified = no plays_role edge in (frontmatter|brief|user), synthetic tools
+ * excluded unless includeTools. If the two drift, the doctor nudge ("run ax
+ * skills classify") can point at a command that finds nothing - the dead-end
+ * loop bug. (classify previously diverged via a broken correlated
+ * `NOT (subquery)[0]` predicate - NONE, not false - and excluded every
+ * unclassified skill; it now delegates to fetchSkillHygiene.)
  *
  * NON-correlated by construction: the original per-skill subqueries
  * (`... WHERE in = $parent.id`) ran two graph lookups for every skill row,

--- a/apps/axctl/src/queries/skill-hygiene.test.ts
+++ b/apps/axctl/src/queries/skill-hygiene.test.ts
@@ -37,16 +37,16 @@ const run = <A>(
 // ---------------------------------------------------------------------------
 
 describe("fetchSkillHygiene", () => {
-    it("joins counts to names, drops synthetic + classified + low-count", async () => {
+    it("joins counts to names, drops synthetic + classified + low-count, carries sessions", async () => {
         const rows = await run(
             fetchSkillHygiene({ minInvocations: 3, limit: 10 }),
             makeMockDb([
-                // statement 1: invocation counts by skill id
+                // statement 1: invocation + distinct-session counts by skill id
                 [
-                    { sid: "skill:composto", invocations: 41 },
-                    { sid: "skill:codex_exec", invocations: 39545 },
-                    { sid: "skill:tagged", invocations: 12 },
-                    { sid: "skill:rare", invocations: 2 },
+                    { sid: "skill:composto", invocations: 41, sessions: 12 },
+                    { sid: "skill:codex_exec", invocations: 39545, sessions: 800 },
+                    { sid: "skill:tagged", invocations: 12, sessions: 5 },
+                    { sid: "skill:rare", invocations: 2, sessions: 1 },
                 ],
                 // statement 2: skill rows
                 [
@@ -59,7 +59,7 @@ describe("fetchSkillHygiene", () => {
                 ["skill:tagged"],
             ]),
         );
-        expect(rows).toEqual([{ name: "composto", invocations: 41 }]);
+        expect(rows).toEqual([{ name: "composto", invocations: 41, sessions: 12 }]);
     });
 
     it("respects limit and sorts by invocations desc", async () => {
@@ -67,8 +67,8 @@ describe("fetchSkillHygiene", () => {
             fetchSkillHygiene({ minInvocations: 3, limit: 1 }),
             makeMockDb([
                 [
-                    { sid: "skill:a", invocations: 5 },
-                    { sid: "skill:b", invocations: 9 },
+                    { sid: "skill:a", invocations: 5, sessions: 2 },
+                    { sid: "skill:b", invocations: 9, sessions: 3 },
                 ],
                 [
                     { id: "skill:a", name: "a", dir_path: "/s/a" },
@@ -77,14 +77,34 @@ describe("fetchSkillHygiene", () => {
                 [],
             ]),
         );
-        expect(rows).toEqual([{ name: "b", invocations: 9 }]);
+        expect(rows).toEqual([{ name: "b", invocations: 9, sessions: 3 }]);
+    });
+
+    it("returns ALL rows (no slice) when limit is omitted", async () => {
+        const rows = await run(
+            fetchSkillHygiene({ minInvocations: 1 }),
+            makeMockDb([
+                [
+                    { sid: "skill:a", invocations: 5, sessions: 2 },
+                    { sid: "skill:b", invocations: 9, sessions: 3 },
+                    { sid: "skill:c", invocations: 1, sessions: 1 },
+                ],
+                [
+                    { id: "skill:a", name: "a", dir_path: "/s/a" },
+                    { id: "skill:b", name: "b", dir_path: "/s/b" },
+                    { id: "skill:c", name: "c", dir_path: "/s/c" },
+                ],
+                [],
+            ]),
+        );
+        expect(rows.map((r) => r.name)).toEqual(["b", "a", "c"]);
     });
 
     it("returns empty when all skills are synthetic", async () => {
         const rows = await run(
             fetchSkillHygiene({ minInvocations: 1, limit: 10 }),
             makeMockDb([
-                [{ sid: "skill:codex_exec", invocations: 999 }],
+                [{ sid: "skill:codex_exec", invocations: 999, sessions: 50 }],
                 [{ id: "skill:codex_exec", name: "codex:exec_command", dir_path: "(synthetic)" }],
                 [],
             ]),
@@ -92,11 +112,23 @@ describe("fetchSkillHygiene", () => {
         expect(rows).toEqual([]);
     });
 
+    it("includeSynthetic keeps synthetic provider tools", async () => {
+        const rows = await run(
+            fetchSkillHygiene({ minInvocations: 1, includeSynthetic: true }),
+            makeMockDb([
+                [{ sid: "skill:codex_exec", invocations: 999, sessions: 50 }],
+                [{ id: "skill:codex_exec", name: "codex:exec_command", dir_path: "(synthetic)" }],
+                [],
+            ]),
+        );
+        expect(rows).toEqual([{ name: "codex:exec_command", invocations: 999, sessions: 50 }]);
+    });
+
     it("returns empty when all skills are classified", async () => {
         const rows = await run(
             fetchSkillHygiene({ minInvocations: 1, limit: 10 }),
             makeMockDb([
-                [{ sid: "skill:foo", invocations: 10 }],
+                [{ sid: "skill:foo", invocations: 10, sessions: 4 }],
                 [{ id: "skill:foo", name: "foo", dir_path: "/skills/foo" }],
                 ["skill:foo"],
             ]),
@@ -108,7 +140,7 @@ describe("fetchSkillHygiene", () => {
         const rows = await run(
             fetchSkillHygiene({ minInvocations: 5, limit: 10 }),
             makeMockDb([
-                [{ sid: "skill:rare", invocations: 2 }],
+                [{ sid: "skill:rare", invocations: 2, sessions: 1 }],
                 [{ id: "skill:rare", name: "rare", dir_path: "/skills/rare" }],
                 [],
             ]),
@@ -128,7 +160,7 @@ describe("fetchSkillHygiene", () => {
         const rows = await run(
             fetchSkillHygiene({ minInvocations: 1, limit: 10 }),
             makeMockDb([
-                [{ sid: "skill:orphan", invocations: 10 }],
+                [{ sid: "skill:orphan", invocations: 10, sessions: 4 }],
                 [],  // no skill rows
                 [],
             ]),

--- a/apps/axctl/src/queries/skill-hygiene.ts
+++ b/apps/axctl/src/queries/skill-hygiene.ts
@@ -5,7 +5,9 @@
  * The `invoked` edge table has ~87k rows; stacking `out.name` derefs inside
  * a GROUP BY aggregate caused a production hang. Lesson documented in CLAUDE.md.
  *
- *   (1) Aggregate invocation counts from `invoked`, grouped by `out` (skill id).
+ *   (1) Aggregate invocation + distinct-session counts from `invoked`, grouped
+ *       by `out` (skill id). A single `in.session` deref is safe; the production
+ *       hang was STACKED derefs (out.deleted_at + in.session) on 87k+ edges.
  *   (2) Fetch all skill rows (id, name, dir_path) - small table, full scan fine.
  *   (3) Fetch classified skill ids via plays_role (user/frontmatter/brief sources).
  *
@@ -15,6 +17,13 @@
  *   - For each count row in (1): skip synthetic (dir_path == "(synthetic)"),
  *     skip classified, skip below threshold, then push to results.
  *   - Sort desc by invocations, apply limit.
+ *
+ * This is the SINGLE source of truth for "unclassified skill with ≥N
+ * invocations". `ax skills classify` (default mode) and `ax skills weighted`'s
+ * doctor count both consume it, so they can never disagree (regression: a
+ * correlated `NOT (subquery)[0]` predicate in classify returned NONE - not
+ * false - for unclassified skills, silently excluding every one of them, so
+ * classify reported "none found" while weighted reported a positive count).
  */
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
@@ -23,14 +32,30 @@ import { SurrealClient } from "@ax/lib/db";
 // Public types
 // ---------------------------------------------------------------------------
 
+/**
+ * Invocation threshold below which a skill is too rarely used to be worth a
+ * classify brief. Shared by `ax skills classify` (default mode) and `ax skills
+ * weighted`'s doctor count so the two surfaces agree on "unclassified".
+ */
+export const SKILL_HYGIENE_MIN_INVOCATIONS = 3;
+
 export interface SkillHygieneRow {
     readonly name: string;
     readonly invocations: number;
+    readonly sessions: number;
 }
 
 export interface SkillHygieneInput {
     readonly minInvocations: number;
-    readonly limit: number;
+    /** Max rows to return. Omit (or pass a non-positive value) for no cap. */
+    readonly limit?: number;
+    /**
+     * Include synthetic provider built-in tools (codex/pi/opencode/cursor tool
+     * calls, `dir_path = "(synthetic)"`). Default false - they can never carry a
+     * role, so they only inflate the count. weighted's `--include-tools` maps onto
+     * this so the doctor count and `skills classify` agree.
+     */
+    readonly includeSynthetic?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -45,7 +70,7 @@ export interface SkillHygieneInput {
 // Invocation counts are deliberately ALL-TIME (lifetime hygiene signal; no
 // sinceDays window).
 const SQL = `
-SELECT type::string(out) AS sid, count() AS invocations FROM invoked GROUP BY sid;
+SELECT type::string(out) AS sid, count() AS invocations, array::len(array::distinct(in.session)) AS sessions FROM invoked GROUP BY sid;
 SELECT type::string(id) AS id, name, dir_path FROM skill;
 SELECT VALUE type::string(in) FROM plays_role WHERE source IN ["frontmatter", "brief", "user"];
 `;
@@ -59,7 +84,7 @@ export const fetchSkillHygiene = Effect.fn("queries.fetchSkillHygiene")(function
 ) {
     const db = yield* SurrealClient;
     const [counts, skills, classified] = yield* db.query<[
-        Array<{ sid: string; invocations: number }>,
+        Array<{ sid: string; invocations: number; sessions: number }>,
         Array<{ id: string; name: string; dir_path: string | null }>,
         Array<string>,
     ]>(SQL);
@@ -75,13 +100,13 @@ export const fetchSkillHygiene = Effect.fn("queries.fetchSkillHygiene")(function
     for (const c of counts ?? []) {
         const skill = byId.get(c.sid);
         if (!skill) continue;                                  // no matching skill row
-        if (skill.dir_path === "(synthetic)") continue;        // tool shims, not real skills
+        if (!input.includeSynthetic && skill.dir_path === "(synthetic)") continue; // tool shims, not real skills
         if (classifiedIds.has(c.sid)) continue;                // already tagged
         const inv = Number(c.invocations ?? 0);
         if (inv < input.minInvocations) continue;              // below threshold
-        rows.push({ name: skill.name, invocations: inv });
+        rows.push({ name: skill.name, invocations: inv, sessions: Number(c.sessions ?? 0) });
     }
 
     rows.sort((a, b) => b.invocations - a.invocations);
-    return rows.slice(0, input.limit);
+    return input.limit && input.limit > 0 ? rows.slice(0, input.limit) : rows;
 });


### PR DESCRIPTION
Two bugs surfaced **dogfooding ax from scratch** (fresh v0.31.0 install in an isolated sandbox). Both reproduce against `main`.

## Bug A — `ax doctor` ignored `AX_DB_URL` host:port
Doctor derived its probe endpoint from runtime-state (default `8521`) while taking `ns/db/user/pass` from env. So an `AX_DB_URL` override (remote DB, custom port, a second instance) silently made doctor check the **wrong** instance — it reported another db's listener, buckets, and "stuck ingest_runs" while the configured db was elsewhere.

**Fix:** new pure `resolveDaemonHostPort(state, envUrl)` mirrors the SurrealClient's precedence (`AX_DB_URL` wins, else runtime-state — `packages/lib/src/config.ts`). All three checks (db-listener, buckets, ingest-runs) now resolve from one place.

```
$ AX_DB_URL=ws://127.0.0.1:9999 ax doctor   # before: 8521 is listening (wrong)
  warn db-listener: 127.0.0.1:9999 is not listening   # after: correct
```

## Bug B — `skills weighted` ↔ `skills classify` dead-end loop
`ax skills weighted` nudged "N skills unclassified → run `ax skills classify`", but classify always answered **"no unclassified skills found"** — an onboarding loop that goes nowhere.

**Root cause:** classify's default query used a correlated `NOT (subquery)[0]` predicate. That subquery yields `NONE` for an unclassified skill, and `NOT NONE` is `NONE` (not `true`) in SurrealDB — so the `WHERE` excluded **every** unclassified skill.

**Fix:** classify default mode now delegates to the proven, deref-free `fetchSkillHygiene` (single source of truth; also removes a slow correlated scan that took ~25s on the real graph). hygiene gains a `sessions` field + `includeSynthetic` option. weighted's own count query is unchanged (already correct) with a comment pinning the sync requirement.

```
$ ax skills classify --dry-run   # before: "no unclassified skills found"
(dry-run: 37 skills would be written)   # after: matches weighted's 37
```

## Not bugs (investigated, no change)
- launchd DB plist **already** sets `SURREAL_BUCKET_FOLDER_ALLOWLIST` (`install.ts`) — the `File access denied` was only a hand-rolled sandbox startup.
- `skills lint --task-dir` is correct (only `classify` uses `--out-dir`); `ax insights <view>` works in HEAD (intentionally-hidden plumbing verb), just absent from the older 0.31.0 release.

## Verification
- `bun test apps/axctl/src` → **3349 pass, 0 fail**
- `tsc --noEmit -p apps/axctl/tsconfig.json` → no errors
- New tests: `resolveDaemonHostPort` (env precedence + malformed-url fallback), classify filter regression, hygiene `sessions`/`includeSynthetic`/no-limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)