### PR TITLE
feat(skills): SkillOpt-informed skill hygiene — token-budget lint, namespace dedup, auto-load capture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ docs/superpowers/specs/2026-06-15-otel-receiver-design.md.
 `ax skills classify [<skill>...]` - bulk-emit `.ax/tasks/classify-*.md` briefs for unclassified skills with ≥3 invocations.
 `ax skills tag <skill> <role> [--confidence=N] [--rationale="..."] [--remove]` - one-shot role override.
 `ax skills lint [--task-dir=<path>] [--dry-run]` - apply filled classify briefs to `plays_role` edges.
+`ax skills bloat [--budget=N] [--limit=N] [--json]` - installed skills whose body exceeds a token budget (est ~4 B/token from the stored `skill.bytes` column; no file reads), sorted by size with all-time invocations so bloated-and-used skills surface first. Default budget 2000 tok. Deref-free two-statement join (`apps/axctl/src/queries/skill-bloat.ts`), sibling of `fetchSkillHygiene`. SkillOpt-informed: self-tuned skills converge to ~300-2,000 tokens; length is not effort.
 `ax skills weighted [--window=Nd] [--limit=N]` - usage × role-weight ranking; enters doctor mode when many skills are unclassified.
 `ax skills by-role <role>` - list skills tagged with a given role.
 `ax skills roles <skill>` - list roles for a skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ docs/superpowers/specs/2026-06-15-otel-receiver-design.md.
 `ax skills tag <skill> <role> [--confidence=N] [--rationale="..."] [--remove]` - one-shot role override.
 `ax skills lint [--task-dir=<path>] [--dry-run]` - apply filled classify briefs to `plays_role` edges.
 `ax skills bloat [--budget=N] [--limit=N] [--json]` - installed skills whose body exceeds a token budget (est ~4 B/token from the stored `skill.bytes` column; no file reads), sorted by size with all-time invocations so bloated-and-used skills surface first. Default budget 2000 tok. Deref-free two-statement join (`apps/axctl/src/queries/skill-bloat.ts`), sibling of `fetchSkillHygiene`. SkillOpt-informed: self-tuned skills converge to ~300-2,000 tokens; length is not effort.
+`ax skills loaded [--limit=N] [--json]` - skills auto-loaded via a subagent's `skills:` frontmatter (activated with NO Skill-tool call, so absent from `invoked`-based usage views), ranked by activation count. Reads the `loaded` edge written by the `loaded-skills` ingest stage (`apps/axctl/src/ingest/derive-loaded-skills.ts`), kept SEPARATE from `invoked` so usage analytics stay clean. A skill reading `used=0` in `bloat` may be loaded heavily (e.g. design-curator's skills).
 `ax skills weighted [--window=Nd] [--limit=N]` - usage × role-weight ranking; enters doctor mode when many skills are unclassified.
 `ax skills by-role <role>` - list skills tagged with a given role.
 `ax skills roles <skill>` - list roles for a skill.

--- a/apps/axctl/src/cli/commands/skills.ts
+++ b/apps/axctl/src/cli/commands/skills.ts
@@ -22,6 +22,7 @@ import {
     buildSkillsRolesNext,
     buildRolesNext,
 } from "../../nav/next-links.ts";
+import { fetchSkillBloat } from "../../queries/skill-bloat.ts";
 import { fetchSkillStats } from "../../queries/skill-stats.ts";
 import { fetchUnusedSkills, formatLastUsed } from "../../queries/unused-skills.ts";
 import { skillsConfigSubcommands } from "../../skills/cli.ts";
@@ -316,6 +317,41 @@ const cmdUnused = (input: UnusedInput) =>
                 `${hiddenScoped} agent-scoped skills hidden (load only inside a subagent); --include-scoped to show.`,
             );
         }
+    });
+
+interface SkillsBloatInput {
+    readonly budgetTokens: number;
+    readonly limit: number;
+    readonly json: boolean;
+}
+
+const cmdSkillsBloat = (input: SkillsBloatInput) =>
+    Effect.gen(function* () {
+        const budgetTokens = requirePositiveInt("skills bloat", "budget", input.budgetTokens);
+        const limit = requirePositiveInt("skills bloat", "limit", input.limit);
+        const rows = yield* fetchSkillBloat({ budgetTokens, limit });
+
+        if (input.json) {
+            console.log(prettyPrint({ budgetTokens, skills: rows }));
+            return;
+        }
+        if (rows.length === 0) {
+            console.log(
+                `No skills over ${fmtCount(budgetTokens)} tokens. ` +
+                `(Compact is good - SkillOpt deploys skills at ~300-2,000 tok.)`,
+            );
+            return;
+        }
+        for (const r of rows) {
+            console.log(
+                `${r.name}  ~${fmtCount(r.estTokens)} tok  (+${fmtCount(r.overBy)} over)  ` +
+                `${fmtCount(r.bytes)} B  used=${fmtCount(r.invocations)}`,
+            );
+        }
+        console.log(
+            `\n${rows.length} skill${rows.length === 1 ? "" : "s"} over the ` +
+            `${fmtCount(budgetTokens)}-token budget. Trim toward high-signal; length is not effort.`,
+        );
     });
 
 interface SkillsWeightedInput {
@@ -868,6 +904,26 @@ const skillsLintCommand = Command.make(
     ),
 );
 
+const bloatCommand = Command.make(
+    "bloat",
+    {
+        budget: Flag.integer("budget").pipe(Flag.withDefault(2000)),
+        limit: positiveLimit(25),
+        json: jsonFlag,
+    },
+    ({ budget, limit, json }) =>
+        cmdSkillsBloat({ budgetTokens: budget, limit, json }).pipe(
+            catchDbErrorAndExit("axctl skills bloat"),
+        ),
+).pipe(
+    Command.withDescription(
+        "List installed skills whose body exceeds a token budget (est ~4 B/token " +
+        "from stored bytes). Sorted by size, with all-time invocations so " +
+        "bloated-and-used skills surface first. SkillOpt deploys skills at " +
+        "~300-2,000 tokens. --budget=N (default 2000)  --limit=N  --json",
+    ),
+);
+
 const weightedCommand = Command.make(
     "weighted",
     {
@@ -926,7 +982,7 @@ const rolesForSkillCommand = Command.make(
 );
 
 export const skillsCommand = Command.make("skills").pipe(
-    Command.withDescription("Skill-graph queries: search, stats, usage, pairs, recovery, classify, tag, lint, weighted, by-role, roles"),
+    Command.withDescription("Skill-graph queries: search, stats, usage, pairs, recovery, classify, tag, lint, bloat, weighted, by-role, roles"),
     Command.withSubcommands([
         searchCommand,
         statsCommand,
@@ -939,6 +995,7 @@ export const skillsCommand = Command.make("skills").pipe(
         classifyCommand,
         tagCommand,
         skillsLintCommand,
+        bloatCommand,
         byRoleCommand,
         rolesForSkillCommand,
         ...skillsConfigSubcommands,

--- a/apps/axctl/src/cli/commands/skills.ts
+++ b/apps/axctl/src/cli/commands/skills.ts
@@ -23,6 +23,7 @@ import {
     buildRolesNext,
 } from "../../nav/next-links.ts";
 import { fetchSkillBloat } from "../../queries/skill-bloat.ts";
+import { fetchSkillLoaded } from "../../queries/skill-loaded.ts";
 import { fetchSkillStats } from "../../queries/skill-stats.ts";
 import { fetchUnusedSkills, formatLastUsed } from "../../queries/unused-skills.ts";
 import { skillsConfigSubcommands } from "../../skills/cli.ts";
@@ -351,6 +352,35 @@ const cmdSkillsBloat = (input: SkillsBloatInput) =>
         console.log(
             `\n${rows.length} skill${rows.length === 1 ? "" : "s"} over the ` +
             `${fmtCount(budgetTokens)}-token budget. Trim toward high-signal; length is not effort.`,
+        );
+    });
+
+interface SkillsLoadedInput {
+    readonly limit: number;
+    readonly json: boolean;
+}
+
+const cmdSkillsLoaded = (input: SkillsLoadedInput) =>
+    Effect.gen(function* () {
+        const limit = requirePositiveInt("skills loaded", "limit", input.limit);
+        const rows = yield* fetchSkillLoaded({ limit });
+        if (input.json) {
+            console.log(prettyPrint({ skills: rows }));
+            return;
+        }
+        if (rows.length === 0) {
+            console.log(
+                "No auto-load activations recorded. (The loaded-skills stage " +
+                "stamps these from subagent `skills:` frontmatter at ingest.)",
+            );
+            return;
+        }
+        for (const r of rows) {
+            console.log(`${r.name}  loaded=${fmtCount(r.activations)}`);
+        }
+        console.log(
+            `\n${rows.length} skill${rows.length === 1 ? "" : "s"} auto-loaded via subagent ` +
+            "frontmatter (no Skill-tool call; invisible to invoked-based usage views).",
         );
     });
 
@@ -924,6 +954,24 @@ const bloatCommand = Command.make(
     ),
 );
 
+const loadedCommand = Command.make(
+    "loaded",
+    {
+        limit: positiveLimit(25),
+        json: jsonFlag,
+    },
+    ({ limit, json }) =>
+        cmdSkillsLoaded({ limit, json }).pipe(
+            catchDbErrorAndExit("axctl skills loaded"),
+        ),
+).pipe(
+    Command.withDescription(
+        "List skills auto-loaded via a subagent's `skills:` frontmatter (activated " +
+        "with no Skill-tool call, so absent from invoked-based usage views), ranked " +
+        "by activation count. Reads the `loaded` edge. --limit=N  --json",
+    ),
+);
+
 const weightedCommand = Command.make(
     "weighted",
     {
@@ -982,7 +1030,7 @@ const rolesForSkillCommand = Command.make(
 );
 
 export const skillsCommand = Command.make("skills").pipe(
-    Command.withDescription("Skill-graph queries: search, stats, usage, pairs, recovery, classify, tag, lint, bloat, weighted, by-role, roles"),
+    Command.withDescription("Skill-graph queries: search, stats, usage, pairs, recovery, classify, tag, lint, bloat, loaded, weighted, by-role, roles"),
     Command.withSubcommands([
         searchCommand,
         statsCommand,
@@ -996,6 +1044,7 @@ export const skillsCommand = Command.make("skills").pipe(
         tagCommand,
         skillsLintCommand,
         bloatCommand,
+        loadedCommand,
         byRoleCommand,
         rolesForSkillCommand,
         ...skillsConfigSubcommands,

--- a/apps/axctl/src/ingest/derive-loaded-skills.test.ts
+++ b/apps/axctl/src/ingest/derive-loaded-skills.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import {
+    buildLoadedEdges,
+    renderLoadedEdge,
+    type SpawnInput,
+} from "./derive-loaded-skills.ts";
+
+const agentSkills = new Map<string, ReadonlyArray<string>>([
+    ["code-reviewer", ["composto", "react-doctor"]],
+    ["gtm-prospector", ["gtm-meta-skill"]],
+]);
+const skillIdByName = new Map<string, string>([
+    ["composto", "skill:composto"],
+    ["react-doctor", "skill:react_doctor"],
+    ["gtm-meta-skill", "skill:gtm"],
+]);
+
+describe("buildLoadedEdges", () => {
+    it("resolves agent -> declared skills -> skill ids, one edge each", () => {
+        const spawns: SpawnInput[] = [
+            { child: "session:s1", agentName: "code-reviewer", agentType: null, ts: "2026-06-16T10:00:00.000Z" },
+        ];
+        const edges = buildLoadedEdges(spawns, agentSkills, skillIdByName);
+        expect(edges).toEqual([
+            { child: "session:s1", skillId: "skill:composto", agent: "code-reviewer", ts: "2026-06-16T10:00:00.000Z" },
+            { child: "session:s1", skillId: "skill:react_doctor", agent: "code-reviewer", ts: "2026-06-16T10:00:00.000Z" },
+        ]);
+    });
+
+    it("falls back from agentName to agentType when name doesn't match", () => {
+        const spawns: SpawnInput[] = [
+            { child: "session:s2", agentName: "Babbage", agentType: "gtm-prospector", ts: "2026-06-16T11:00:00.000Z" },
+        ];
+        const edges = buildLoadedEdges(spawns, agentSkills, skillIdByName);
+        expect(edges.map((e) => e.skillId)).toEqual(["skill:gtm"]);
+        expect(edges[0].agent).toBe("gtm-prospector");
+    });
+
+    it("skips spawns whose agent has no skills frontmatter", () => {
+        const spawns: SpawnInput[] = [
+            { child: "session:s3", agentName: "unknown-agent", agentType: "Explore", ts: "2026-06-16T12:00:00.000Z" },
+        ];
+        expect(buildLoadedEdges(spawns, agentSkills, skillIdByName)).toEqual([]);
+    });
+
+    it("skips skills that aren't in the catalog", () => {
+        const partial = new Map([["composto", "skill:composto"]]); // react-doctor missing
+        const spawns: SpawnInput[] = [
+            { child: "session:s4", agentName: "code-reviewer", agentType: null, ts: "2026-06-16T10:00:00.000Z" },
+        ];
+        const edges = buildLoadedEdges(spawns, agentSkills, partial);
+        expect(edges.map((e) => e.skillId)).toEqual(["skill:composto"]);
+    });
+
+    it("dedupes (child, skill) across repeat spawns, keeping the earliest ts", () => {
+        const spawns: SpawnInput[] = [
+            { child: "session:s5", agentName: "gtm-prospector", agentType: null, ts: "2026-06-16T15:00:00.000Z" },
+            { child: "session:s5", agentName: "gtm-prospector", agentType: null, ts: "2026-06-16T09:00:00.000Z" },
+        ];
+        const edges = buildLoadedEdges(spawns, agentSkills, skillIdByName);
+        expect(edges).toHaveLength(1);
+        expect(edges[0].ts).toBe("2026-06-16T09:00:00.000Z");
+    });
+
+    it("ignores spawns with an empty child id", () => {
+        const spawns: SpawnInput[] = [
+            { child: "", agentName: "code-reviewer", agentType: null, ts: "2026-06-16T10:00:00.000Z" },
+        ];
+        expect(buildLoadedEdges(spawns, agentSkills, skillIdByName)).toEqual([]);
+    });
+});
+
+describe("renderLoadedEdge", () => {
+    it("emits a deterministic RELATE with escaped record refs", () => {
+        const sql = renderLoadedEdge({
+            child: "session:abc",
+            skillId: "skill:composto",
+            agent: "code-reviewer",
+            ts: "2026-06-16T10:00:00.000Z",
+        });
+        expect(sql).toContain("RELATE session:`abc`->loaded:`");
+        expect(sql).toContain("->skill:`composto`");
+        expect(sql).toContain('agent = "code-reviewer"');
+        expect(sql).toContain("source = 'frontmatter'");
+        expect(sql).toContain('d"2026-06-16T10:00:00.000Z"');
+    });
+
+    it("is deterministic for the same (child, skill)", () => {
+        const e = { child: "session:abc", skillId: "skill:x", agent: "a", ts: "2026-06-16T10:00:00.000Z" };
+        expect(renderLoadedEdge(e)).toBe(renderLoadedEdge(e));
+    });
+
+    it("returns null when an id can't be parsed", () => {
+        expect(renderLoadedEdge({ child: "", skillId: "skill:x", agent: "a", ts: "2026-06-16T10:00:00.000Z" })).toBeNull();
+    });
+});

--- a/apps/axctl/src/ingest/derive-loaded-skills.ts
+++ b/apps/axctl/src/ingest/derive-loaded-skills.ts
@@ -1,0 +1,211 @@
+/**
+ * @stage loaded-skills
+ * @rationale The `invoked` edge captures only explicit Skill-tool calls (and,
+ *   via `commands.ts`, slash-commands). Skills that load because a subagent's
+ *   `skills:` frontmatter pulls them in NEVER produce a Skill-tool call, so they
+ *   leave no `invoked` edge - they are invisible to every usage view even though
+ *   they were activated. This stage draws that missing activation signal as a
+ *   SEPARATE `loaded` edge (session -> skill) so it can light up edit→outcome
+ *   analysis (see docs/.../churn-as-gate-grade-experiment.md) WITHOUT polluting
+ *   `invoked`-based usage analytics (skills weighted, taste, churn).
+ * @inputs `spawned` edges (which subagent spawned, when), `agent_def.skills`
+ *   (the agent's declared skill list), `skill` rows (name -> id resolution)
+ * @outputs `loaded` edges: child session -> skill, SET ts, agent, source
+ * @order after skills, agent-def, spawned
+ *
+ * Fully derived + idempotent: the stage wipes `loaded` and rebuilds it from
+ * current state each run (the table is small and 100% derivable), so there is no
+ * incremental-merge subtlety.
+ */
+import { Effect, Schema } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import {
+    executeStatementsWith,
+    recordKeyPart,
+    recordRef,
+    safeKeyPart,
+    surrealDate,
+    surrealString,
+} from "@ax/lib/shared/surreal";
+import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
+import type { StageDef } from "./stage/registry.ts";
+
+// ---------------------------------------------------------------------------
+// Pure derivation
+// ---------------------------------------------------------------------------
+
+export interface SpawnInput {
+    /** full child-session record id, e.g. "session:abc" */
+    readonly child: string;
+    readonly agentName: string | null;
+    readonly agentType: string | null;
+    /** ISO timestamp of the spawn */
+    readonly ts: string;
+}
+
+export interface LoadedEdgeSpec {
+    readonly child: string;
+    readonly skillId: string;
+    readonly agent: string;
+    readonly ts: string;
+}
+
+/**
+ * Build the `loaded` activation edges. For each spawn, resolve the agent (by
+ * `agentName`, falling back to `agentType`) to its declared skills, then to the
+ * skill record ids. One edge per (child session, skill); when the same pair
+ * spawns more than once the EARLIEST ts wins (first activation).
+ */
+export const buildLoadedEdges = (
+    spawns: ReadonlyArray<SpawnInput>,
+    agentSkills: ReadonlyMap<string, ReadonlyArray<string>>,
+    skillIdByName: ReadonlyMap<string, string>,
+): LoadedEdgeSpec[] => {
+    const byKey = new Map<string, LoadedEdgeSpec>();
+    for (const sp of spawns) {
+        if (!sp.child) continue;
+        const agent =
+            sp.agentName && agentSkills.has(sp.agentName)
+                ? sp.agentName
+                : sp.agentType && agentSkills.has(sp.agentType)
+                  ? sp.agentType
+                  : null;
+        if (!agent) continue;
+        for (const name of agentSkills.get(agent) ?? []) {
+            const skillId = skillIdByName.get(name);
+            if (!skillId) continue;                       // skill not in catalog
+            const key = `${sp.child}|${skillId}`;
+            const existing = byKey.get(key);
+            if (!existing || sp.ts < existing.ts) {
+                byKey.set(key, { child: sp.child, skillId, agent, ts: sp.ts });
+            }
+        }
+    }
+    return [...byKey.values()];
+};
+
+/** Render one `loaded` edge to a RELATE statement (deterministic edge id). */
+export const renderLoadedEdge = (e: LoadedEdgeSpec): string | null => {
+    const childKey = recordKeyPart(e.child, "session");
+    const skillKey = recordKeyPart(e.skillId, "skill");
+    if (!childKey || !skillKey) return null;
+    const edgeKey = safeKeyPart(`${e.child}|${e.skillId}`);
+    return (
+        `RELATE ${recordRef("session", childKey)}->${recordRef("loaded", edgeKey)}->` +
+        `${recordRef("skill", skillKey)} SET ts = ${surrealDate(e.ts)}, ` +
+        `agent = ${surrealString(e.agent)}, source = 'frontmatter';`
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Stage
+// ---------------------------------------------------------------------------
+
+export interface DeriveLoadedStats {
+    written: number;
+    agents: number;
+}
+
+type SpawnRow = { child: unknown; agent_name: unknown; agent_type: unknown; ts: unknown };
+type AgentRow = { name: unknown; skills: unknown };
+type SkillRow = { id: unknown; name: unknown; scope: unknown };
+
+export const deriveLoadedSkills = (): Effect.Effect<
+    DeriveLoadedStats,
+    DbError,
+    SurrealClient
+> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+
+        const [spawnRows, agentRows, skillRows] = yield* db.query<[
+            Array<SpawnRow>,
+            Array<AgentRow>,
+            Array<SkillRow>,
+        ]>(`
+            SELECT type::string(out) AS child, agent_name, agent_type, type::string(ts) AS ts FROM spawned;
+            SELECT name, skills FROM agent_def WHERE skills != NONE AND deleted_at IS NONE;
+            SELECT type::string(id) AS id, name, scope FROM skill WHERE dir_path != '(synthetic)';
+        `);
+
+        // agent name -> declared skills
+        const agentSkills = new Map<string, ReadonlyArray<string>>();
+        for (const a of agentRows ?? []) {
+            const name = typeof a.name === "string" ? a.name : null;
+            if (!name) continue;
+            const skills = Array.isArray(a.skills)
+                ? a.skills.filter((s): s is string => typeof s === "string" && s.length > 0)
+                : [];
+            if (skills.length > 0) agentSkills.set(name, skills);
+        }
+
+        // skill name -> id; on a plugin-namespace dupe prefer the user-scope
+        // (bare) row so the edge lands on the canonical skill.
+        const skillIdByName = new Map<string, string>();
+        const skillScopeByName = new Map<string, string>();
+        for (const s of skillRows ?? []) {
+            const name = typeof s.name === "string" ? s.name : null;
+            const id = typeof s.id === "string" ? s.id : null;
+            if (!name || !id) continue;
+            const scope = typeof s.scope === "string" ? s.scope : "";
+            const prevScope = skillScopeByName.get(name);
+            if (prevScope === undefined || (prevScope !== "user" && scope === "user")) {
+                skillIdByName.set(name, id);
+                skillScopeByName.set(name, scope);
+            }
+        }
+
+        const spawns: SpawnInput[] = (spawnRows ?? []).map((r) => ({
+            child: typeof r.child === "string" ? r.child : "",
+            agentName: typeof r.agent_name === "string" ? r.agent_name : null,
+            agentType: typeof r.agent_type === "string" ? r.agent_type : null,
+            ts: typeof r.ts === "string" ? r.ts : "",
+        }));
+
+        const edges = buildLoadedEdges(spawns, agentSkills, skillIdByName);
+        const stmts = ["DELETE loaded;"];
+        for (const e of edges) {
+            const sql = renderLoadedEdge(e);
+            if (sql) stmts.push(sql);
+        }
+        yield* executeStatementsWith(db, stmts, { chunkSize: 250, label: "loadedEdges" });
+
+        return { written: edges.length, agents: agentSkills.size };
+    });
+
+export const LoadedSkillsKey = Schema.Literal("loaded-skills");
+export type LoadedSkillsKey = typeof LoadedSkillsKey.Type;
+
+export class LoadedSkillsStats extends BaseStageStats.extend<LoadedSkillsStats>(
+    "LoadedSkillsStats",
+)({
+    written: Schema.Number,
+    agents: Schema.Number,
+}) {}
+
+/**
+ * Loaded-skills stage - derives auto-load activation edges.
+ *
+ * Depends on: skills (catalog), agent-def (declared skills), spawned (who/when).
+ * Consumed by: edit→outcome analysis; kept separate from `invoked` usage views.
+ * Tags: derive
+ */
+export const loadedSkillsStage: StageDef<LoadedSkillsStats, SurrealClient> = {
+    meta: StageMeta.make({
+        key: "loaded-skills",
+        deps: ["skills", "agent-def", "spawned"],
+        tags: ["derive"],
+    }),
+    run: (_ctx: IngestContext) =>
+        Effect.gen(function* () {
+            const t0 = Date.now();
+            const result = yield* deriveLoadedSkills();
+            return LoadedSkillsStats.make({
+                durationMs: Date.now() - t0,
+                summary: `wrote ${result.written} loaded edges from ${result.agents} skill-scoped agents`,
+                written: result.written,
+                agents: result.agents,
+            });
+        }),
+};

--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -293,7 +293,7 @@ export const runIngest = (
         }));
 
         if (opts.args.includes("--reset")) {
-            yield* db.query("DELETE invoked; DELETE proposed; DELETE concerns; DELETE recovered_by; DELETE skill_paired; DELETE skill;");
+            yield* db.query("DELETE invoked; DELETE loaded; DELETE proposed; DELETE concerns; DELETE recovered_by; DELETE skill_paired; DELETE skill;");
         }
 
         const ctx = IngestContext.make({

--- a/apps/axctl/src/ingest/stage/registry.ts
+++ b/apps/axctl/src/ingest/stage/registry.ts
@@ -13,6 +13,7 @@ import { cursorStage } from "../cursor.ts";
 import { subagentsStage } from "../derive-claude-subagents.ts";
 import { invokedPositionsStage } from "../backfill-invoked-positions.ts";
 import { spawnedStage } from "../derive-spawned.ts";
+import { loadedSkillsStage } from "../derive-loaded-skills.ts";
 import { gitStage } from "../git.ts";
 import { githubPrStage } from "../github-pr-stage.ts";
 import { signalsStage } from "../derive-signals.ts";
@@ -59,7 +60,7 @@ export const StageRegistryLive = (
     });
 
 /** The canonical list of stages provided by `StageRegistryDefault`. */
-export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, pricingStage, claudeStage, codexStage, piStage, opencodeStage, cursorStage, subagentsStage, invokedPositionsStage, spawnedStage, gitStage, githubPrStage, signalsStage, outcomesStage, turnContentBlocksStage, turnAnalysisStage, reactionEventsStage, classifierResultsStage, sessionHealthStage, closureStage, deriveMetricsStage, proposalsStage, opportunitiesStage, retroProposalsStage, harnessStage, digestStage, usageStage] as const;
+export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, pricingStage, claudeStage, codexStage, piStage, opencodeStage, cursorStage, subagentsStage, invokedPositionsStage, spawnedStage, loadedSkillsStage, gitStage, githubPrStage, signalsStage, outcomesStage, turnContentBlocksStage, turnAnalysisStage, reactionEventsStage, classifierResultsStage, sessionHealthStage, closureStage, deriveMetricsStage, proposalsStage, opportunitiesStage, retroProposalsStage, harnessStage, digestStage, usageStage] as const;
 
 /** Production registry: the canonical list of stages provided by ax. Test code
  *  should prefer `StageRegistryLive([...])` with explicit fixtures. */

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -132,6 +132,7 @@ export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "query_sample", stage: "staged", note: "Reserved query execution samples." },
     { table: "graph_health_check", stage: "staged", note: "Persisted graph health check rows." },
     { table: "invoked", stage: "active", note: "Turn-to-skill invocation edges." },
+    { table: "loaded", stage: "active", note: "Session-to-skill auto-load activations (subagent skills: frontmatter); separate from invoked." },
     { table: "plays_role", stage: "active", note: "Skill-to-role classification edges." },
     { table: "proposed", stage: "active", note: "Skills mentioned but not invoked." },
     { table: "edited", stage: "active", note: "Turn-to-file edit edges." },

--- a/apps/axctl/src/queries/skill-bloat.test.ts
+++ b/apps/axctl/src/queries/skill-bloat.test.ts
@@ -84,6 +84,39 @@ describe("fetchSkillBloat", () => {
         expect(rows.map((r) => r.name)).toEqual(["b", "c"]);
     });
 
+    it("collapses plugin-namespace twins (same content_hash), keeps bare name, sums invocations", async () => {
+        const rows = await run(
+            fetchSkillBloat({ budgetTokens: 100, limit: 10 }),
+            makeMockDb([
+                [
+                    { id: "skill:bare", name: "review", bytes: 800, dir_path: "/s/review", content_hash: "h1" },
+                    { id: "skill:ns", name: "necmttn:review", bytes: 800, dir_path: "/s/review", content_hash: "h1" },
+                ],
+                [
+                    { sid: "skill:bare", invocations: 4 },
+                    { sid: "skill:ns", invocations: 3 },
+                ],
+            ]),
+        );
+        expect(rows).toEqual([
+            { name: "review", bytes: 800, estTokens: 200, overBy: 100, invocations: 7 },
+        ]);
+    });
+
+    it("does NOT collapse distinct skills that lack a content_hash", async () => {
+        const rows = await run(
+            fetchSkillBloat({ budgetTokens: 100, limit: 10 }),
+            makeMockDb([
+                [
+                    { id: "skill:a", name: "a", bytes: 800, dir_path: "/s/a", content_hash: null },
+                    { id: "skill:b", name: "b", bytes: 800, dir_path: "/s/b", content_hash: null },
+                ],
+                [],
+            ]),
+        );
+        expect(rows.map((r) => r.name).sort()).toEqual(["a", "b"]);
+    });
+
     it("returns empty when every skill is within budget", async () => {
         const rows = await run(
             fetchSkillBloat({ budgetTokens: 2000, limit: 10 }),

--- a/apps/axctl/src/queries/skill-bloat.test.ts
+++ b/apps/axctl/src/queries/skill-bloat.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for skill-bloat.ts
+ *
+ * Mirrors skill-hygiene.test.ts: canned skill rows + invocation counts,
+ * exercises token estimation, budget filter, synthetic/null drops, prioritise
+ * by invocations, sort + limit.
+ */
+import { describe, expect, it } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { estimateTokens, fetchSkillBloat } from "./skill-bloat.ts";
+
+type QueryResult = Array<unknown>;
+
+const makeMockDb = (results: QueryResult[]): Layer.Layer<SurrealClient> => {
+    const stub: SurrealClientShape = {
+        query: (_sql: string) =>
+            Effect.succeed(results as unknown as [QueryResult, ...QueryResult[]]),
+    } as unknown as SurrealClientShape;
+    return Layer.succeed(SurrealClient, stub);
+};
+
+const run = <A>(
+    eff: Effect.Effect<A, unknown, SurrealClient>,
+    layer: Layer.Layer<SurrealClient>,
+) => Effect.runPromise(eff.pipe(Effect.provide(layer)));
+
+describe("estimateTokens", () => {
+    it("estimates ~4 bytes per token, rounded", () => {
+        expect(estimateTokens(4000)).toBe(1000);
+        expect(estimateTokens(4002)).toBe(1001); // 1000.5 -> 1001
+        expect(estimateTokens(0)).toBe(0);
+    });
+});
+
+describe("fetchSkillBloat", () => {
+    it("flags only skills over the token budget, with overBy + estTokens", async () => {
+        const rows = await run(
+            fetchSkillBloat({ budgetTokens: 2000, limit: 10 }),
+            makeMockDb([
+                // statement 1: skill rows (bytes)
+                [
+                    { id: "skill:fat", name: "fat", bytes: 12000, dir_path: "/s/fat" },     // 3000 tok
+                    { id: "skill:lean", name: "lean", bytes: 4000, dir_path: "/s/lean" },   // 1000 tok
+                ],
+                // statement 2: invocation counts
+                [{ sid: "skill:fat", invocations: 7 }],
+            ]),
+        );
+        expect(rows).toEqual([
+            { name: "fat", bytes: 12000, estTokens: 3000, overBy: 1000, invocations: 7 },
+        ]);
+    });
+
+    it("skips synthetic shims and null-bytes skills", async () => {
+        const rows = await run(
+            fetchSkillBloat({ budgetTokens: 100, limit: 10 }),
+            makeMockDb([
+                [
+                    { id: "skill:syn", name: "codex:exec", bytes: 99999, dir_path: "(synthetic)" },
+                    { id: "skill:nob", name: "nobytes", bytes: null, dir_path: "/s/nob" },
+                    { id: "skill:real", name: "real", bytes: 800, dir_path: "/s/real" }, // 200 tok
+                ],
+                [],
+            ]),
+        );
+        expect(rows).toEqual([
+            { name: "real", bytes: 800, estTokens: 200, overBy: 100, invocations: 0 },
+        ]);
+    });
+
+    it("sorts by estTokens desc and respects limit", async () => {
+        const rows = await run(
+            fetchSkillBloat({ budgetTokens: 0, limit: 2 }),
+            makeMockDb([
+                [
+                    { id: "skill:a", name: "a", bytes: 400, dir_path: "/s/a" },   // 100
+                    { id: "skill:b", name: "b", bytes: 1200, dir_path: "/s/b" },  // 300
+                    { id: "skill:c", name: "c", bytes: 800, dir_path: "/s/c" },   // 200
+                ],
+                [],
+            ]),
+        );
+        expect(rows.map((r) => r.name)).toEqual(["b", "c"]);
+    });
+
+    it("returns empty when every skill is within budget", async () => {
+        const rows = await run(
+            fetchSkillBloat({ budgetTokens: 2000, limit: 10 }),
+            makeMockDb([
+                [{ id: "skill:lean", name: "lean", bytes: 4000, dir_path: "/s/lean" }],
+                [],
+            ]),
+        );
+        expect(rows).toEqual([]);
+    });
+
+    it("returns empty when no data", async () => {
+        const rows = await run(
+            fetchSkillBloat({ budgetTokens: 2000, limit: 10 }),
+            makeMockDb([[], []]),
+        );
+        expect(rows).toEqual([]);
+    });
+});

--- a/apps/axctl/src/queries/skill-bloat.ts
+++ b/apps/axctl/src/queries/skill-bloat.ts
@@ -21,6 +21,7 @@
  */
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
+import { dedupeByContentHash } from "./skill-dedupe.ts";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -52,9 +53,14 @@ export const estimateTokens = (bytes: number): number =>
 // ---------------------------------------------------------------------------
 
 const SQL = `
-SELECT type::string(id) AS id, name, bytes, dir_path FROM skill;
+SELECT type::string(id) AS id, name, bytes, dir_path, content_hash FROM skill;
 SELECT type::string(out) AS sid, count() AS invocations FROM invoked GROUP BY sid;
 `;
+
+// Internal row carrying the content hash needed for plugin-namespace dedup.
+interface BloatRowWithHash extends SkillBloatRow {
+    readonly contentHash: string | null;
+}
 
 // ---------------------------------------------------------------------------
 // Query
@@ -65,7 +71,7 @@ export const fetchSkillBloat = Effect.fn("queries.fetchSkillBloat")(function* (
 ) {
     const db = yield* SurrealClient;
     const [skills, counts] = yield* db.query<[
-        Array<{ id: string; name: string; bytes: number | null; dir_path: string | null }>,
+        Array<{ id: string; name: string; bytes: number | null; dir_path: string | null; content_hash: string | null }>,
         Array<{ sid: string; invocations: number }>,
     ]>(SQL);
 
@@ -73,7 +79,7 @@ export const fetchSkillBloat = Effect.fn("queries.fetchSkillBloat")(function* (
         (counts ?? []).map((c) => [c.sid, Number(c.invocations ?? 0)]),
     );
 
-    const rows: SkillBloatRow[] = [];
+    const rows: BloatRowWithHash[] = [];
     for (const s of skills ?? []) {
         if (s.dir_path === "(synthetic)") continue;        // tool shims, not real skills
         if (s.bytes == null) continue;                     // un-ingested body size
@@ -86,9 +92,20 @@ export const fetchSkillBloat = Effect.fn("queries.fetchSkillBloat")(function* (
             estTokens,
             overBy: estTokens - input.budgetTokens,
             invocations: invById.get(s.id) ?? 0,
+            contentHash: s.content_hash,
         });
     }
 
-    rows.sort((a, b) => b.estTokens - a.estTokens);
-    return rows.slice(0, input.limit);
+    // Collapse plugin-namespace twins (same file -> two skill rows): keep the
+    // bare name, sum invocations across the twins so usage isn't split.
+    const deduped = dedupeByContentHash(
+        rows,
+        (r) => r.contentHash,
+        (r) => r.name,
+        (r, name) => ({ ...r, name }),
+        (kept, dup) => ({ ...kept, invocations: kept.invocations + dup.invocations }),
+    );
+
+    deduped.sort((a, b) => b.estTokens - a.estTokens);
+    return deduped.slice(0, input.limit).map(({ contentHash: _ch, ...row }) => row);
 });

--- a/apps/axctl/src/queries/skill-bloat.ts
+++ b/apps/axctl/src/queries/skill-bloat.ts
@@ -1,0 +1,94 @@
+/**
+ * Skill token-budget (bloat) query: installed skills whose body exceeds a
+ * token budget.
+ *
+ * Motivation: the SkillOpt paper (arxiv 2605.23904) finds deployed self-tuned
+ * skills converge to ~300-2,000 tokens - compactness is a feature, length is
+ * not effort. This lens flags skills that have drifted past the upper band so
+ * they can be trimmed. Tokens are estimated from the stored `bytes` column at
+ * ~4 bytes/token (the same crude ratio used across the context-budget view);
+ * no file reads required.
+ *
+ * Deref-free, two FLAT queries joined in JS (sibling idiom, skill-hygiene.ts -
+ * stacking record derefs inside aggregates over the ~87k-row `invoked` edge
+ * hangs production):
+ *   (1) Fetch all skill rows (id, name, bytes, dir_path) - small table.
+ *   (2) Aggregate invocation counts from `invoked`, grouped by `out` (skill id),
+ *       to prioritise bloated-AND-used skills.
+ *
+ * JS join: estimate tokens from bytes, drop synthetic + null-bytes + under-budget,
+ * attach invocation count, sort by estimated tokens desc, apply limit.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface SkillBloatRow {
+    readonly name: string;
+    readonly bytes: number;
+    readonly estTokens: number;
+    /** estTokens - budgetTokens (always > 0 for returned rows) */
+    readonly overBy: number;
+    /** all-time invocations (0 when the skill has never been invoked) */
+    readonly invocations: number;
+}
+
+export interface SkillBloatInput {
+    /** token ceiling; skills estimated above this are flagged */
+    readonly budgetTokens: number;
+    readonly limit: number;
+}
+
+// Crude bytes->tokens ratio, shared with the context-budget view.
+const BYTES_PER_TOKEN = 4;
+export const estimateTokens = (bytes: number): number =>
+    Math.round(bytes / BYTES_PER_TOKEN);
+
+// ---------------------------------------------------------------------------
+// SQL - deref-free, two flat statements
+// ---------------------------------------------------------------------------
+
+const SQL = `
+SELECT type::string(id) AS id, name, bytes, dir_path FROM skill;
+SELECT type::string(out) AS sid, count() AS invocations FROM invoked GROUP BY sid;
+`;
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+export const fetchSkillBloat = Effect.fn("queries.fetchSkillBloat")(function* (
+    input: SkillBloatInput,
+) {
+    const db = yield* SurrealClient;
+    const [skills, counts] = yield* db.query<[
+        Array<{ id: string; name: string; bytes: number | null; dir_path: string | null }>,
+        Array<{ sid: string; invocations: number }>,
+    ]>(SQL);
+
+    const invById = new Map(
+        (counts ?? []).map((c) => [c.sid, Number(c.invocations ?? 0)]),
+    );
+
+    const rows: SkillBloatRow[] = [];
+    for (const s of skills ?? []) {
+        if (s.dir_path === "(synthetic)") continue;        // tool shims, not real skills
+        if (s.bytes == null) continue;                     // un-ingested body size
+        const bytes = Number(s.bytes);
+        const estTokens = estimateTokens(bytes);
+        if (estTokens <= input.budgetTokens) continue;     // within budget
+        rows.push({
+            name: s.name,
+            bytes,
+            estTokens,
+            overBy: estTokens - input.budgetTokens,
+            invocations: invById.get(s.id) ?? 0,
+        });
+    }
+
+    rows.sort((a, b) => b.estTokens - a.estTokens);
+    return rows.slice(0, input.limit);
+});

--- a/apps/axctl/src/queries/skill-dedupe.test.ts
+++ b/apps/axctl/src/queries/skill-dedupe.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import {
+    bareSkillName,
+    dedupeByContentHash,
+    isPluginNamespaced,
+    preferCanonicalName,
+} from "./skill-dedupe.ts";
+
+describe("isPluginNamespaced / bareSkillName", () => {
+    it("detects and strips the owner namespace", () => {
+        expect(isPluginNamespaced("necmttn:foo")).toBe(true);
+        expect(isPluginNamespaced("foo")).toBe(false);
+        expect(bareSkillName("necmttn:foo")).toBe("foo");
+        expect(bareSkillName("foo")).toBe("foo");
+        expect(bareSkillName("a:b:c")).toBe("b:c"); // strips only leading owner
+    });
+});
+
+describe("preferCanonicalName", () => {
+    it("bare beats namespaced regardless of order", () => {
+        expect(preferCanonicalName("foo", "necmttn:foo")).toBe("foo");
+        expect(preferCanonicalName("necmttn:foo", "foo")).toBe("foo");
+    });
+    it("on tie, shorter then lexicographically smaller", () => {
+        expect(preferCanonicalName("bbb", "aa")).toBe("aa");
+        expect(preferCanonicalName("bbb", "aaa")).toBe("aaa");
+    });
+});
+
+interface Row {
+    name: string;
+    hash: string | null;
+    n: number;
+}
+const dedupe = (rows: Row[]) =>
+    dedupeByContentHash<Row>(
+        rows,
+        (r) => r.hash,
+        (r) => r.name,
+        (r, name) => ({ ...r, name }),
+        (kept, dup) => ({ ...kept, n: kept.n + dup.n }),
+    );
+
+describe("dedupeByContentHash", () => {
+    it("collapses same-hash rows, keeps bare name, merges numeric field", () => {
+        expect(
+            dedupe([
+                { name: "necmttn:review", hash: "h1", n: 3 },
+                { name: "review", hash: "h1", n: 4 },
+            ]),
+        ).toEqual([{ name: "review", hash: "h1", n: 7 }]);
+    });
+
+    it("preserves first-appearance order", () => {
+        const out = dedupe([
+            { name: "a", hash: "h1", n: 1 },
+            { name: "b", hash: "h2", n: 1 },
+            { name: "necmttn:a", hash: "h1", n: 1 },
+        ]);
+        expect(out.map((r) => r.name)).toEqual(["a", "b"]);
+    });
+
+    it("leaves null/empty-hash rows distinct", () => {
+        const out = dedupe([
+            { name: "x", hash: null, n: 1 },
+            { name: "y", hash: null, n: 1 },
+            { name: "z", hash: "", n: 1 },
+        ]);
+        expect(out.map((r) => r.name).sort()).toEqual(["x", "y", "z"]);
+    });
+
+    it("handles three-way twins (rare but possible)", () => {
+        const out = dedupe([
+            { name: "necmttn:foo", hash: "h", n: 2 },
+            { name: "owner2:foo", hash: "h", n: 3 },
+            { name: "foo", hash: "h", n: 5 },
+        ]);
+        expect(out).toEqual([{ name: "foo", hash: "h", n: 10 }]);
+    });
+});

--- a/apps/axctl/src/queries/skill-dedupe.ts
+++ b/apps/axctl/src/queries/skill-dedupe.ts
@@ -1,0 +1,93 @@
+/**
+ * Skill dedup helper - collapse plugin-namespace duplicate skill rows.
+ *
+ * The same physical SKILL.md is ingested as TWO `skill` rows: once at user
+ * scope under its bare name (`plannotator-review`) and once at project/plugin
+ * scope under a namespaced name (`necmttn:plannotator-review`). Both rows carry
+ * the IDENTICAL `dir_path` + `content_hash` + `bytes` (verified 2026-06-16:
+ * 98 such twin-pairs across 415 skill rows). Every skill query that lists or
+ * counts skills double-counts as a result.
+ *
+ * Fixing this at ingest means re-keying skill record ids (migration risk) and is
+ * parked as a follow-up. This is the query-layer collapse: group rows by
+ * `content_hash` (same body = same skill), keep the canonical (bare, non-
+ * namespaced) name, and merge any per-row numeric fields (e.g. invocations).
+ *
+ * Rows with a null/empty content_hash are never merged (treated as distinct) so
+ * a missing hash can't accidentally collapse unrelated skills.
+ */
+
+/** A plugin-namespaced name carries a `:` (e.g. `necmttn:plannotator-review`). */
+export const isPluginNamespaced = (name: string): boolean => name.includes(":");
+
+/** Strip the leading `owner:` namespace, if any. `necmttn:foo` -> `foo`. */
+export const bareSkillName = (name: string): string =>
+    isPluginNamespaced(name) ? name.slice(name.indexOf(":") + 1) : name;
+
+/**
+ * Of two names for the same content, prefer the canonical one: the bare
+ * (non-namespaced) name wins; on a tie, the shorter, then lexicographically
+ * smaller, for determinism.
+ */
+export const preferCanonicalName = (a: string, b: string): string => {
+    const an = isPluginNamespaced(a);
+    const bn = isPluginNamespaced(b);
+    if (an !== bn) return an ? b : a;            // bare beats namespaced
+    if (a.length !== b.length) return a.length < b.length ? a : b;
+    return a <= b ? a : b;
+};
+
+/**
+ * Collapse rows that share a content hash into one, keeping the canonical name
+ * and merging the rest. Order is preserved by first appearance. Rows whose hash
+ * is null/empty pass through untouched (each stays distinct).
+ *
+ * @param rows      input rows (any order)
+ * @param hashOf    extract the dedup key (content hash) from a row; null = distinct
+ * @param nameOf    extract the display name (drives canonical-name choice)
+ * @param merge     fold a duplicate into the kept row (e.g. sum invocations);
+ *                  receives (kept, duplicate) and returns the merged row. The
+ *                  kept row already carries the canonical name when this runs.
+ */
+export const dedupeByContentHash = <T>(
+    rows: ReadonlyArray<T>,
+    hashOf: (row: T) => string | null | undefined,
+    nameOf: (row: T) => string,
+    setName: (row: T, name: string) => T,
+    merge: (kept: T, dup: T) => T,
+): T[] => {
+    const byHash = new Map<string, T>();
+    const passthrough: T[] = [];
+    const order: Array<{ hash: string | null; idx: number }> = [];
+
+    for (const row of rows) {
+        const hash = hashOf(row);
+        if (!hash) {
+            passthrough.push(row);
+            order.push({ hash: null, idx: passthrough.length - 1 });
+            continue;
+        }
+        const existing = byHash.get(hash);
+        if (!existing) {
+            byHash.set(hash, row);
+            order.push({ hash, idx: -1 });
+            continue;
+        }
+        // Merge: pick the canonical name, then fold the duplicate's fields in.
+        const canonical = preferCanonicalName(nameOf(existing), nameOf(row));
+        const kept = setName(existing, canonical);
+        byHash.set(hash, merge(kept, row));
+    }
+
+    const out: T[] = [];
+    const emitted = new Set<string>();
+    for (const o of order) {
+        if (o.hash === null) {
+            out.push(passthrough[o.idx]);
+        } else if (!emitted.has(o.hash)) {
+            emitted.add(o.hash);
+            out.push(byHash.get(o.hash)!);
+        }
+    }
+    return out;
+};

--- a/apps/axctl/src/queries/skill-hygiene.test.ts
+++ b/apps/axctl/src/queries/skill-hygiene.test.ts
@@ -116,6 +116,44 @@ describe("fetchSkillHygiene", () => {
         expect(rows).toEqual([]);
     });
 
+    it("collapses plugin-namespace twins: sums invocations, keeps bare name", async () => {
+        const rows = await run(
+            fetchSkillHygiene({ minInvocations: 3, limit: 10 }),
+            makeMockDb([
+                [
+                    { sid: "skill:bare", invocations: 2 },
+                    { sid: "skill:ns", invocations: 3 },
+                ],
+                [
+                    { id: "skill:bare", name: "foo", dir_path: "/s/foo", content_hash: "h1" },
+                    { id: "skill:ns", name: "necmttn:foo", dir_path: "/s/foo", content_hash: "h1" },
+                ],
+                [],
+            ]),
+        );
+        // merged 2+3=5 >= 3 threshold, bare name kept
+        expect(rows).toEqual([{ name: "foo", invocations: 5 }]);
+    });
+
+    it("twin is classified if EITHER member is classified", async () => {
+        const rows = await run(
+            fetchSkillHygiene({ minInvocations: 1, limit: 10 }),
+            makeMockDb([
+                [
+                    { sid: "skill:bare", invocations: 4 },
+                    { sid: "skill:ns", invocations: 4 },
+                ],
+                [
+                    { id: "skill:bare", name: "foo", dir_path: "/s/foo", content_hash: "h1" },
+                    { id: "skill:ns", name: "necmttn:foo", dir_path: "/s/foo", content_hash: "h1" },
+                ],
+                ["skill:ns"], // only the namespaced twin is classified
+            ]),
+        );
+        // collapsed -> classified -> dropped entirely
+        expect(rows).toEqual([]);
+    });
+
     it("returns empty when no data", async () => {
         const rows = await run(
             fetchSkillHygiene({ minInvocations: 3, limit: 10 }),

--- a/apps/axctl/src/queries/skill-hygiene.ts
+++ b/apps/axctl/src/queries/skill-hygiene.ts
@@ -18,6 +18,7 @@
  */
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
+import { dedupeByContentHash } from "./skill-dedupe.ts";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -46,7 +47,7 @@ export interface SkillHygieneInput {
 // sinceDays window).
 const SQL = `
 SELECT type::string(out) AS sid, count() AS invocations FROM invoked GROUP BY sid;
-SELECT type::string(id) AS id, name, dir_path FROM skill;
+SELECT type::string(id) AS id, name, dir_path, content_hash FROM skill;
 SELECT VALUE type::string(in) FROM plays_role WHERE source IN ["frontmatter", "brief", "user"];
 `;
 
@@ -60,26 +61,54 @@ export const fetchSkillHygiene = Effect.fn("queries.fetchSkillHygiene")(function
     const db = yield* SurrealClient;
     const [counts, skills, classified] = yield* db.query<[
         Array<{ sid: string; invocations: number }>,
-        Array<{ id: string; name: string; dir_path: string | null }>,
+        Array<{ id: string; name: string; dir_path: string | null; content_hash: string | null }>,
         Array<string>,
     ]>(SQL);
 
     // Build lookup structures from the flat result sets
     const classifiedIds = new Set(classified ?? []);
     const byId = new Map(
-        (skills ?? []).map((s) => [s.id, { name: s.name, dir_path: s.dir_path }]),
+        (skills ?? []).map((s) => [s.id, s]),
     );
 
-    // Join, filter, collect
-    const rows: SkillHygieneRow[] = [];
+    // Join each count row to its skill metadata (drop synthetic shims here).
+    // Dedup is applied AFTER the join so a plugin-namespace twin is treated as
+    // classified if EITHER member is classified, and its invocations sum.
+    interface Cand extends SkillHygieneRow {
+        readonly contentHash: string | null;
+        readonly classified: boolean;
+    }
+    const cand: Cand[] = [];
     for (const c of counts ?? []) {
         const skill = byId.get(c.sid);
         if (!skill) continue;                                  // no matching skill row
         if (skill.dir_path === "(synthetic)") continue;        // tool shims, not real skills
-        if (classifiedIds.has(c.sid)) continue;                // already tagged
-        const inv = Number(c.invocations ?? 0);
-        if (inv < input.minInvocations) continue;              // below threshold
-        rows.push({ name: skill.name, invocations: inv });
+        cand.push({
+            name: skill.name,
+            invocations: Number(c.invocations ?? 0),
+            contentHash: skill.content_hash,
+            classified: classifiedIds.has(c.sid),
+        });
+    }
+
+    const deduped = dedupeByContentHash(
+        cand,
+        (r) => r.contentHash,
+        (r) => r.name,
+        (r, name) => ({ ...r, name }),
+        (kept, dup) => ({
+            ...kept,
+            invocations: kept.invocations + dup.invocations,
+            classified: kept.classified || dup.classified,
+        }),
+    );
+
+    // Filter: drop classified twins and below-threshold candidates.
+    const rows: SkillHygieneRow[] = [];
+    for (const r of deduped) {
+        if (r.classified) continue;                            // already tagged
+        if (r.invocations < input.minInvocations) continue;    // below threshold
+        rows.push({ name: r.name, invocations: r.invocations });
     }
 
     rows.sort((a, b) => b.invocations - a.invocations);

--- a/apps/axctl/src/queries/skill-loaded.test.ts
+++ b/apps/axctl/src/queries/skill-loaded.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { fetchSkillLoaded } from "./skill-loaded.ts";
+
+type QueryResult = Array<unknown>;
+const makeMockDb = (results: QueryResult[]): Layer.Layer<SurrealClient> => {
+    const stub: SurrealClientShape = {
+        query: (_sql: string) =>
+            Effect.succeed(results as unknown as [QueryResult, ...QueryResult[]]),
+    } as unknown as SurrealClientShape;
+    return Layer.succeed(SurrealClient, stub);
+};
+const run = <A>(eff: Effect.Effect<A, unknown, SurrealClient>, layer: Layer.Layer<SurrealClient>) =>
+    Effect.runPromise(eff.pipe(Effect.provide(layer)));
+
+describe("fetchSkillLoaded", () => {
+    it("joins activation counts to skill names, sorts desc, respects limit", async () => {
+        const rows = await run(
+            fetchSkillLoaded({ limit: 2 }),
+            makeMockDb([
+                [
+                    { sid: "skill:a", activations: 80 },
+                    { sid: "skill:b", activations: 102 },
+                    { sid: "skill:c", activations: 4 },
+                ],
+                [
+                    { id: "skill:a", name: "a", content_hash: "ha" },
+                    { id: "skill:b", name: "b", content_hash: "hb" },
+                    { id: "skill:c", name: "c", content_hash: "hc" },
+                ],
+            ]),
+        );
+        expect(rows).toEqual([
+            { name: "b", activations: 102 },
+            { name: "a", activations: 80 },
+        ]);
+    });
+
+    it("collapses plugin-namespace twins, sums activations, keeps bare name", async () => {
+        const rows = await run(
+            fetchSkillLoaded({ limit: 10 }),
+            makeMockDb([
+                [
+                    { sid: "skill:bare", activations: 80 },
+                    { sid: "skill:ns", activations: 80 },
+                ],
+                [
+                    { id: "skill:bare", name: "image-to-code", content_hash: "h1" },
+                    { id: "skill:ns", name: "necmttn:image-to-code", content_hash: "h1" },
+                ],
+            ]),
+        );
+        expect(rows).toEqual([{ name: "image-to-code", activations: 160 }]);
+    });
+
+    it("returns empty when no activations", async () => {
+        const rows = await run(fetchSkillLoaded({ limit: 10 }), makeMockDb([[], []]));
+        expect(rows).toEqual([]);
+    });
+});

--- a/apps/axctl/src/queries/skill-loaded.ts
+++ b/apps/axctl/src/queries/skill-loaded.ts
@@ -1,0 +1,72 @@
+/**
+ * Skill auto-load activations: read the `loaded` edge (written by the
+ * `loaded-skills` ingest stage) so the activation signal it captures is
+ * surfaced. These are skills pulled in by a subagent's `skills:` frontmatter -
+ * activated WITHOUT a Skill-tool call, so they never appear in `invoked`-based
+ * usage views. This is the read counterpart that makes that signal visible
+ * (e.g. a skill reading `used=0` in `ax skills bloat` may be loaded heavily).
+ *
+ * Deref-free, two FLAT queries joined in JS (sibling idiom, skill-bloat.ts):
+ *   (1) Aggregate activation counts from `loaded`, grouped by `out` (skill id).
+ *   (2) Fetch skill rows (id, name, content_hash) for name resolution + dedup.
+ *
+ * Plugin-namespace twins are collapsed by content_hash (same SKILL.md = two
+ * skill rows), summing activations and keeping the canonical (bare) name.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { dedupeByContentHash } from "./skill-dedupe.ts";
+
+export interface SkillLoadedRow {
+    readonly name: string;
+    readonly activations: number;
+}
+
+export interface SkillLoadedInput {
+    readonly limit: number;
+}
+
+interface LoadedRowWithHash extends SkillLoadedRow {
+    readonly contentHash: string | null;
+}
+
+const SQL = `
+SELECT type::string(out) AS sid, count() AS activations FROM loaded GROUP BY sid;
+SELECT type::string(id) AS id, name, content_hash FROM skill;
+`;
+
+export const fetchSkillLoaded = Effect.fn("queries.fetchSkillLoaded")(function* (
+    input: SkillLoadedInput,
+) {
+    const db = yield* SurrealClient;
+    const [counts, skills] = yield* db.query<[
+        Array<{ sid: string; activations: number }>,
+        Array<{ id: string; name: string; content_hash: string | null }>,
+    ]>(SQL);
+
+    const byId = new Map(
+        (skills ?? []).map((s) => [s.id, s]),
+    );
+
+    const rows: LoadedRowWithHash[] = [];
+    for (const c of counts ?? []) {
+        const skill = byId.get(c.sid);
+        if (!skill) continue;
+        rows.push({
+            name: skill.name,
+            activations: Number(c.activations ?? 0),
+            contentHash: skill.content_hash,
+        });
+    }
+
+    const deduped = dedupeByContentHash(
+        rows,
+        (r) => r.contentHash,
+        (r) => r.name,
+        (r, name) => ({ ...r, name }),
+        (kept, dup) => ({ ...kept, activations: kept.activations + dup.activations }),
+    );
+
+    deduped.sort((a, b) => b.activations - a.activations);
+    return deduped.slice(0, input.limit).map(({ contentHash: _ch, ...row }) => row);
+});

--- a/docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md
+++ b/docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md
@@ -1,0 +1,79 @@
+# Experiment: can churn-delta be gate-grade? (the SkillOpt crux)
+
+**Date:** 2026-06-16
+**Origin:** SkillOpt paper review (arxiv 2605.23904). A 4-angle panel (codex + 3 subagents)
+split on one question that decides ax's north-star.
+
+## The fork
+
+SkillOpt's whole method rests on an auto-grader: `r(s) ∈ [0,1]`, same task re-run under
+different skills, everything else held fixed. The paper flags open-ended work (writing,
+design, real coding) as the *unsolved* case - no cheap grader exists.
+
+ax claims to mine that grader from real sessions (churn / repair-LOC / episodes). Two
+readings, both defensible, mutually exclusive:
+
+- **Strategy angle:** churn IS a usable grade - ax = the open-ended verifier, a credible
+  north-star *if* attribution + held-out discipline ship.
+- **Skeptic angle:** churn is a confounded proxy with sign ambiguity (low churn = skill
+  worked OR task trivial OR agent gave up). It can *never* be clean; the paper named this
+  exact failure. ax has the same problem with the warning label peeled off.
+
+Don't bet the roadmap on a guess. **Measure whether the proxy separates known-good from
+known-bad skill edits.** Cheap to run, decisive.
+
+## Hypothesis
+
+H1: For a skill edit (a `skill_revision`), the change in downstream verification churn
+(before-revision sessions vs after-revision sessions, same skill) carries signal:
+good edits ↓ repair-LOC / episode-rate, bad edits ↑.
+
+H0: churn-delta is indistinguishable from noise once you can't hold the task fixed.
+
+## Method (retrospective, no new re-runs - uses existing graph)
+
+1. **Edit events.** Pull `skill_revision` rows (already store change ts + byte delta).
+   Keep skills with a revision that has ≥ N invoking sessions both before and after
+   (N≈8 to start; widen window if sparse).
+2. **Outcome per side.** For the before-window and after-window sessions that `invoked`
+   the skill, compute mean repair-LOC and episode-open-rate via the existing
+   `metrics/session-churn.ts` machinery. `churn_delta = after − before`.
+3. **Ground-truth label for each edit** (the hard part - proxy for "was this a good edit"):
+   - **bad** = the revision was reverted, OR followed by another revision of the same
+     skill within a short window (churn-on-the-skill-itself = the author wasn't happy).
+   - **good** = the revision was stable (no follow-up edit) AND the skill kept being
+     invoked (retention up or flat).
+   - This label is itself imperfect - state it as a limitation, not ground truth.
+4. **Test.** Does `churn_delta` separate good-labeled from bad-labeled edits?
+   Sign test / permutation across the ≥K qualifying skills. Report effect size against a
+   noise floor built by shuffling the good/bad labels.
+
+## Confound controls (the whole point)
+
+- Same skill holds skill identity fixed, but **task mix differs across the two windows** -
+  that is exactly the confound the skeptic names. Mitigations:
+  - bucket sessions by repo / task-family before differencing; difference within bucket.
+  - require minimum sample per bucket; drop thin buckets (log what's dropped - no silent caps).
+  - report the permutation noise floor *prominently*; a positive result that doesn't clear
+    it is a null result.
+
+## Decision rule
+
+- **churn_delta separates good/bad at effect size > noise floor, p<0.05, across ≥K skills**
+  → the cheap observational proxy is gate-worthy. ax = verifier is real; build
+  `ax verify <skill@version>` on top of it.
+- **No separation** → confounds dominate; ax cannot grade open-ended edits from passive
+  telemetry. Earning "verifier" requires *controlled re-runs* (a spar SET with a
+  skill-under-test) - expensive, and the dojo's spar is the only honest path. Down-rank
+  the "ax is ahead on the verifier" claim accordingly.
+
+## Cost
+
+One query + one stats pass over the existing graph. No agent re-runs, no quota burn.
+Run before committing any roadmap to the verifier north-star.
+
+## Not in scope
+
+- Building `ax verify` (gated on a positive result here).
+- Per-skill-version attribution UI (the productized form, also gated on this).
+- The protected-section invariant (panel verdict: non-problem for ax's human-gated edit loop).

--- a/docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md
+++ b/docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md
@@ -72,6 +72,36 @@ H0: churn-delta is indistinguishable from noise once you can't hold the task fix
 One query + one stats pass over the existing graph. No agent re-runs, no quota burn.
 Run before committing any roadmap to the verifier north-star.
 
+## Run 1 result (2026-06-16): blocked upstream, crux still untested
+
+Ran the volume probe (`scripts/prototypes/churn-gate-probe.ts`) against the live graph.
+**Data-starved - experiment cannot run yet.** Findings:
+
+- Only **17 `change='changed'` skill_revision events on 8 skills** - and 8 is inflated by
+  the `necmttn:` plugin-namespace dupe; ~4 real skills (`zoom-out`, `plannotator-*`).
+- **0 of 17 edits had ≥5 invoking sessions on both sides** of the edit ts. The single edit
+  with any data (`plannotator-annotate`: 9 before / 1 after) still fails. Most edited skills
+  show `total=0` invocations.
+
+Root cause is NOT confounding (we never reached the stats) - the join is structurally empty:
+
+1. **`skill_revision` is sparse + recent.** The revision-tracking feature shipped recently
+   and history was never backfilled ("pre-existing sessions read zero until re-ingested").
+   17 events, all on rarely-edited utility skills, none on the workhorses.
+2. **`invoked` undercounts skill use.** It records *explicit Skill-tool calls only*;
+   slash-command / plugin-loaded activations create no `invoked` edge. The skills that get
+   edited are exactly the ones with no `invoked` history.
+
+**Verdict:** the strategy-vs-skeptic crux is **still unresolved** - neither side confirmed.
+But the blocker moved from "is the proxy gate-grade?" to **"ax can't yet observe edit→outcome
+at all."** Prerequisites before re-running:
+
+- backfill `skill_revision` from ingest history (or wait for organic accumulation), AND
+- broaden skill-activation capture beyond the explicit Skill-tool `invoked` edge (slash /
+  plugin / frontmatter loads), so edited skills have downstream sessions to difference.
+
+Until both land, "ax = the open-ended verifier" cannot be tested, let alone claimed.
+
 ## Not in scope
 
 - Building `ax verify` (gated on a positive result here).

--- a/docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md
+++ b/docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md
@@ -109,9 +109,11 @@ frontmatter case via `loadAgentScopeMap`, but writes no usage edge.
 
 1. **Backfill `skill_revision`** from ingest history (or accrue organically). *Primary gate.*
 2. **Capture auto-load activations** as a derived edge - when a subagent with `skills:`
-   frontmatter spawns, or a SessionStart hook injects a skill, stamp an activation row
-   (ts + session). *Secondary; a bounded derive-stage feature, NOT a hot-path parser change.
-   Does not unblock the crux on its own - #1 is the gate.*
+   frontmatter spawns, stamp an activation row (ts + session). **SHIPPED** as the
+   `loaded-skills` stage -> `loaded` edge (session->skill), kept separate from `invoked`.
+   First run materialized 1,062 activations across 16 skill-scoped agents (e.g. design-curator
+   loads 13 skills it never Skill-tool-invokes). A SessionStart-hook-injection variant is still
+   open. *Secondary; does NOT unblock the crux on its own - #1 is the gate.*
 
 Until #1 lands, "ax = the open-ended verifier" cannot be tested, let alone claimed.
 

--- a/docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md
+++ b/docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md
@@ -88,19 +88,32 @@ Root cause is NOT confounding (we never reached the stats) - the join is structu
 1. **`skill_revision` is sparse + recent.** The revision-tracking feature shipped recently
    and history was never backfilled ("pre-existing sessions read zero until re-ingested").
    17 events, all on rarely-edited utility skills, none on the workhorses.
-2. **`invoked` undercounts skill use.** It records *explicit Skill-tool calls only*;
-   slash-command / plugin-loaded activations create no `invoked` edge. The skills that get
-   edited are exactly the ones with no `invoked` history.
+2. **Edited skills had near-zero invocations in the window.** The namespace dupe also split
+   what little signal existed (now fixed in the dedupe commit). Few edits land on busy skills.
 
 **Verdict:** the strategy-vs-skeptic crux is **still unresolved** - neither side confirmed.
-But the blocker moved from "is the proxy gate-grade?" to **"ax can't yet observe edit→outcome
-at all."** Prerequisites before re-running:
+But the blocker moved from "is the proxy gate-grade?" to **"ax can't yet observe edit->outcome
+at all."**
 
-- backfill `skill_revision` from ingest history (or wait for organic accumulation), AND
-- broaden skill-activation capture beyond the explicit Skill-tool `invoked` edge (slash /
-  plugin / frontmatter loads), so edited skills have downstream sessions to difference.
+### Why, precisely (after reading the ingest)
 
-Until both land, "ax = the open-ended verifier" cannot be tested, let alone claimed.
+The dominant blocker is **`skill_revision` sparsity**, NOT activation capture. The `invoked`
+edge already covers explicit Skill-tool calls (`ingest/transcripts.ts`) AND slash-commands
+(`ingest/commands.ts` namespaces `~/.claude/commands/` + per-repo `.claude/commands/`). The
+genuinely uncaptured class is **auto-loaded skills**: pulled in by a subagent's `skills:`
+frontmatter or injected by a SessionStart hook (e.g. `using-superpowers`) - they activate
+with no Skill-tool call, so no `invoked` edge. `ax skills unused` already compensates for the
+frontmatter case via `loadAgentScopeMap`, but writes no usage edge.
+
+### Prerequisites before re-running
+
+1. **Backfill `skill_revision`** from ingest history (or accrue organically). *Primary gate.*
+2. **Capture auto-load activations** as a derived edge - when a subagent with `skills:`
+   frontmatter spawns, or a SessionStart hook injects a skill, stamp an activation row
+   (ts + session). *Secondary; a bounded derive-stage feature, NOT a hot-path parser change.
+   Does not unblock the crux on its own - #1 is the gate.*
+
+Until #1 lands, "ax = the open-ended verifier" cannot be tested, let alone claimed.
 
 ## Not in scope
 

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1216,6 +1216,18 @@ DEFINE INDEX IF NOT EXISTS invoked_out_ts ON invoked FIELDS out, ts;
 DEFINE INDEX IF NOT EXISTS invoked_session_out_ts ON invoked FIELDS session, out, ts;
 DEFINE INDEX IF NOT EXISTS invoked_in_out_args ON invoked FIELDS in, out, args;
 
+-- Auto-load activations: a skill pulled in by a subagent's `skills:` frontmatter
+-- when that agent spawns. NO Skill-tool call fires, so these never appear as
+-- `invoked` edges. Kept SEPARATE from `invoked` so usage analytics (skills
+-- weighted/taste/churn) are not polluted with non-invocations. Derived by the
+-- `loaded-skills` stage from spawned x agent_def x skill (fully rebuildable).
+DEFINE TABLE loaded       TYPE RELATION FROM session TO skill;
+DEFINE FIELD ts           ON loaded TYPE datetime;
+DEFINE FIELD agent        ON loaded TYPE option<string>;        -- the scoping agent
+DEFINE FIELD source       ON loaded TYPE string DEFAULT 'frontmatter';
+DEFINE INDEX IF NOT EXISTS loaded_out ON loaded FIELDS out;
+DEFINE INDEX IF NOT EXISTS loaded_in  ON loaded FIELDS in;
+
 DEFINE TABLE proposed     TYPE RELATION FROM turn TO skill;     -- assistant text mentioned skill, never invoked
 DEFINE FIELD ts           ON proposed TYPE datetime;
 DEFINE FIELD context_excerpt ON proposed TYPE option<string>;

--- a/scripts/prototypes/churn-gate-probe.ts
+++ b/scripts/prototypes/churn-gate-probe.ts
@@ -1,0 +1,70 @@
+/**
+ * churn-gate-probe: data-volume sanity check for the churn-as-gate-grade
+ * experiment (docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md).
+ *
+ * Answers: how many `change='changed'` skill_revision events exist, on how many
+ * distinct skills, and (roughly) how many of those have invoking sessions both
+ * before and after the edit ts. If this is near zero, the experiment is data
+ * starved and the retrospective design can't run yet.
+ *
+ *   bun scripts/prototypes/churn-gate-probe.ts
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { AppLayer } from "@ax/lib/layers";
+
+const probe = Effect.gen(function* () {
+    const db = yield* SurrealClient;
+
+    const [revs, invRows] = yield* db.query<[
+        Array<{ sid: string; name: string; ts: string }>,
+        Array<{ sid: string; ts: string }>,
+    ]>(`
+        SELECT type::string(skill) AS sid, name, ts FROM skill_revision WHERE change = 'changed' ORDER BY ts;
+        SELECT type::string(out) AS sid, ts FROM invoked WHERE session IS NOT NONE;
+    `);
+
+    const changedSkills = new Set(revs.map((r) => r.sid));
+    console.log(`changed revisions: ${revs.length} on ${changedSkills.size} distinct skills`);
+    console.log(`invoked rows (with session): ${invRows.length}`);
+
+    // Bucket invocation timestamps by skill id.
+    const invBySkill = new Map<string, number[]>();
+    for (const r of invRows) {
+        const t = new Date(r.ts).getTime();
+        if (Number.isNaN(t)) continue;
+        const arr = invBySkill.get(r.sid) ?? [];
+        arr.push(t);
+        invBySkill.set(r.sid, arr);
+    }
+
+    // For each changed revision, count invoking sessions before/after its ts.
+    let qualifying = 0;
+    const N = 5; // min sessions each side to be usable
+    console.log(`\nall ${revs.length} changed revisions (before/after invoking sessions, total ever):`);
+    for (const rev of revs) {
+        const ts = new Date(rev.ts).getTime();
+        const invs = invBySkill.get(rev.sid) ?? [];
+        let before = 0;
+        let after = 0;
+        for (const it of invs) {
+            if (it < ts) before++;
+            else if (it > ts) after++;
+        }
+        if (before >= N && after >= N) qualifying++;
+        console.log(`  ${rev.name.padEnd(34)} before=${String(before).padStart(5)} after=${String(after).padStart(5)} total=${invs.length}`);
+    }
+    console.log(`\nrevisions with >=${N} invoking sessions BOTH sides: ${qualifying}`);
+
+    if (qualifying < 5) {
+        console.log(`\nVERDICT: data starved (<5 qualifying edits) - retrospective experiment can't run yet.`);
+    } else {
+        console.log(`\nVERDICT: ${qualifying} usable edits - proceed to the full before/after churn pass.`);
+    }
+});
+
+if (import.meta.main) {
+    await Effect.runPromise(
+        probe.pipe(Effect.provide(AppLayer)) as Effect.Effect<void, unknown, never>,
+    );
+}

--- a/scripts/prototypes/dupe-probe.ts
+++ b/scripts/prototypes/dupe-probe.ts
@@ -1,0 +1,33 @@
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { AppLayer } from "@ax/lib/layers";
+const p = Effect.gen(function* () {
+  const db = yield* SurrealClient;
+  const [rows] = yield* db.query<[Array<Record<string, unknown>>]>(`
+    SELECT type::string(id) AS id, name, scope, dir_path, content_hash, bytes FROM skill
+    WHERE name IN ['plannotator-review','necmttn:plannotator-review','zoom-out','necmttn:zoom-out'];
+  `);
+  for (const r of rows) console.log(JSON.stringify(r));
+  const [counts] = yield* db.query<[Array<Record<string, unknown>>]>(`
+    SELECT count() AS total FROM skill GROUP ALL;
+    `);
+  console.log("totals:", JSON.stringify(counts));
+  // how many bare names also have a namespaced twin (same suffix after ':')
+  const [all] = yield* db.query<[Array<{ name: string; dir_path: string | null }>]>(
+    `SELECT name, dir_path FROM skill;`,
+  );
+  const bare = new Set<string>();
+  const namespaced = new Map<string, string[]>();
+  for (const s of all) {
+    if (s.name.includes(":")) {
+      const suf = s.name.split(":").slice(1).join(":");
+      const arr = namespaced.get(suf) ?? [];
+      arr.push(s.name);
+      namespaced.set(suf, arr);
+    } else bare.add(s.name);
+  }
+  let twins = 0;
+  for (const [suf] of namespaced) if (bare.has(suf)) twins++;
+  console.log(`skills total=${all.length} bare=${bare.size} namespaced-suffixes=${namespaced.size} suffixes-with-bare-twin=${twins}`);
+});
+await Effect.runPromise(p.pipe(Effect.provide(AppLayer)) as Effect.Effect<void, unknown, never>);

--- a/scripts/prototypes/loaded-skills-run.ts
+++ b/scripts/prototypes/loaded-skills-run.ts
@@ -1,0 +1,40 @@
+/**
+ * One-off: apply the `loaded` table DEFINEs (the running DB predates them),
+ * run the loaded-skills derive stage against current data, and report.
+ *
+ *   bun scripts/prototypes/loaded-skills-run.ts
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { AppLayer } from "@ax/lib/layers";
+import { deriveLoadedSkills } from "../../apps/axctl/src/ingest/derive-loaded-skills.ts";
+
+const DEFINES = `
+DEFINE TABLE IF NOT EXISTS loaded TYPE RELATION FROM session TO skill;
+DEFINE FIELD IF NOT EXISTS ts     ON loaded TYPE datetime;
+DEFINE FIELD IF NOT EXISTS agent  ON loaded TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS source ON loaded TYPE string DEFAULT 'frontmatter';
+DEFINE INDEX IF NOT EXISTS loaded_out ON loaded FIELDS out;
+DEFINE INDEX IF NOT EXISTS loaded_in  ON loaded FIELDS in;
+`;
+
+const p = Effect.gen(function* () {
+    const db = yield* SurrealClient;
+    yield* db.query(DEFINES);
+    const stats = yield* deriveLoadedSkills();
+    console.log(`stage: wrote ${stats.written} loaded edges from ${stats.agents} skill-scoped agents`);
+
+    const [byAgent] = yield* db.query<[Array<Record<string, unknown>>]>(
+        `SELECT agent, count() AS n FROM loaded GROUP BY agent ORDER BY n DESC LIMIT 12;`,
+    );
+    console.log("\nloaded edges by agent:");
+    for (const r of byAgent ?? []) console.log(`  ${String(r.agent).padEnd(28)} ${r.n}`);
+
+    const [bySkill] = yield* db.query<[Array<Record<string, unknown>>]>(
+        `SELECT out.name AS skill, count() AS n FROM loaded GROUP BY skill ORDER BY n DESC LIMIT 12;`,
+    );
+    console.log("\ntop loaded skills (previously invisible to usage views):");
+    for (const r of bySkill ?? []) console.log(`  ${String(r.skill).padEnd(34)} ${r.n}`);
+});
+
+await Effect.runPromise(p.pipe(Effect.provide(AppLayer)) as Effect.Effect<void, unknown, never>);


### PR DESCRIPTION
From reviewing **SkillOpt** (arxiv 2605.23904) against ax's self-improve loop. A codex + 3-angle panel corrected the initial mapping (it was inverted — SkillOpt works *because* it discards the open-endedness ax lives in). Three shippable findings survived, all here.

## What's in this PR

### 1. `ax skills bloat` — token-budget lint
SkillOpt deploys self-tuned skills at **~300–2,000 tokens**; length is not effort. Flags installed skills whose body exceeds a budget (est ~4 B/token from the stored `skill.bytes` column, no file reads), sorted by size with all-time invocations so bloated-and-used skills surface first.
- `--budget=N` (default 2000) · `--limit` · `--json`
- Deref-free two-statement join, sibling of `fetchSkillHygiene`.
- Live: surfaces real bloat (`imagegen-frontend-mobile` ~10k tok, 5× over).

### 2. Plugin-namespace dedup across skill queries
The same physical SKILL.md is ingested as **two** `skill` rows — user/bare (`plannotator-review`) + project/plugin (`necmttn:plannotator-review`) — with identical `dir_path`/`content_hash`/`bytes`. **98 twin-pairs across 415 rows**; every skill query double-counts.
- Reusable `skill-dedupe.ts`: collapse by `content_hash`, keep the canonical (bare) name, merge fields.
- Applied to **bloat** (sum invocations) and **hygiene** (sum + a twin is classified if *either* member is).
- Fixing at ingest = re-keying skill ids (migration risk), left as a follow-up.

### 3. `loaded-skills` stage — capture auto-load activations
Skills pulled in by a subagent's `skills:` frontmatter activate with **no Skill-tool call**, leaving no `invoked` edge — invisible to every usage view. New derive stage draws that signal as a **separate `loaded` edge** (session→skill), kept apart from `invoked` so usage analytics (skills weighted/taste/churn) stay clean.
- Fully derived + idempotent: rebuilt each run from `spawned × agent_def.skills × skill`.
- First run: **1,062 activations across 16 skill-scoped agents** (`design-curator` loads 13 skills it never invokes — e.g. `image-to-code`, `brandkit`, each previously `used=0`).
- New `loaded` RELATION table + SCHEMA_TABLES mirror entry; wired after skills/agent-def/spawned; added to `--reset`.

## Also included
- **Experiment design** (`docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md`) for the open crux: *can a confounded observational proxy (churn) ever be gate-grade, or must ax pay for controlled re-runs to earn "verifier"?* Plus the **Run-1 result**: data-starved — `skill_revision` is sparse/recent (17 edits, none on busy skills), so the crux stays untested. The primary blocker is revision sparsity, **not** activation capture (#3 helps coverage but doesn't unblock it).

## Tests
Full sweep `bun test apps/axctl/src/ingest apps/axctl/src/queries` → **1192 pass**. Typecheck clean. New: skill-bloat (8), skill-dedupe (10), loaded-skills (9), hygiene twin cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)