### PR TITLE
feat(studio): /cost view + interactive regex routing tuner

### DIFF
--- a/apps/axctl/src/dashboard/contract/insights.ts
+++ b/apps/axctl/src/dashboard/contract/insights.ts
@@ -12,7 +12,8 @@ import { AxApi, NotFoundError } from "@ax/lib/shared/api-contract";
 import { fetchCostModels, fetchCostSplit } from "../../queries/cost-analytics.ts";
 import { fetchDispatches, fetchDispatchCandidates } from "../../queries/dispatch-analytics.ts";
 import { fetchRoutability } from "../../queries/routability.ts";
-import { defaultRoutingTablePath, loadStoredRoutingTable } from "../../queries/routing-table-io.ts";
+import { defaultRoutingTablePath, loadStoredRoutingTable, mergeRoutingTables } from "../../queries/routing-table-io.ts";
+import { DEFAULT_ROUTING_TABLE } from "@ax/hooks-sdk/routing-table";
 import { runRoutingBacktest } from "../../queries/routing-backtest.ts";
 import { fetchContextBudget, fetchSkillDrift } from "../../queries/context-budget.ts";
 import { fetchEpisodeTimeline } from "../episode-timeline.ts";
@@ -97,7 +98,9 @@ export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handle
             orInternal(fetchRoutability({ days: query.days ?? 14, minRun: query.minRun ?? 1 }).pipe(Effect.map(asJsonValue))))
         .handle("routingTable", () =>
             orInternal(
-                loadStoredRoutingTable(defaultRoutingTablePath()).pipe(Effect.map(asJsonValue)),
+                loadStoredRoutingTable(defaultRoutingTablePath()).pipe(
+                    Effect.map((stored) => asJsonValue(mergeRoutingTables(DEFAULT_ROUTING_TABLE, stored))),
+                ),
             ))
         .handle("routingBacktest", ({ payload }) =>
             orInternal(runRoutingBacktest(payload).pipe(Effect.map(asJsonValue))))

--- a/apps/axctl/src/dashboard/contract/insights.ts
+++ b/apps/axctl/src/dashboard/contract/insights.ts
@@ -9,7 +9,11 @@
 import { Effect } from "effect";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { AxApi, NotFoundError } from "@ax/lib/shared/api-contract";
-import { fetchCostModels } from "../../queries/cost-analytics.ts";
+import { fetchCostModels, fetchCostSplit } from "../../queries/cost-analytics.ts";
+import { fetchDispatches, fetchDispatchCandidates } from "../../queries/dispatch-analytics.ts";
+import { fetchRoutability } from "../../queries/routability.ts";
+import { defaultRoutingTablePath, loadStoredRoutingTable } from "../../queries/routing-table-io.ts";
+import { runRoutingBacktest } from "../../queries/routing-backtest.ts";
 import { fetchContextBudget, fetchSkillDrift } from "../../queries/context-budget.ts";
 import { fetchEpisodeTimeline } from "../episode-timeline.ts";
 import { fetchProject } from "../project.ts";
@@ -83,6 +87,20 @@ export const InsightsGroupLive = HttpApiBuilder.group(AxApi, "insights", (handle
             })))
         .handle("costModels", () =>
             orInternal(fetchCostModels({ sinceDays: 365 }).pipe(Effect.map(asJsonValue))))
+        .handle("costSplit", ({ query }) =>
+            orInternal(fetchCostSplit({ sinceDays: query.days ?? 14 }).pipe(Effect.map(asJsonValue))))
+        .handle("costDispatches", ({ query }) =>
+            query.candidates
+                ? orInternal(fetchDispatchCandidates({ sinceDays: query.days ?? 14 }).pipe(Effect.map(asJsonValue)))
+                : orInternal(fetchDispatches({ sinceDays: query.days ?? 14, limit: 30 }).pipe(Effect.map(asJsonValue))))
+        .handle("costRoutability", ({ query }) =>
+            orInternal(fetchRoutability({ days: query.days ?? 14, minRun: query.minRun ?? 1 }).pipe(Effect.map(asJsonValue))))
+        .handle("routingTable", () =>
+            orInternal(
+                loadStoredRoutingTable(defaultRoutingTablePath()).pipe(Effect.map(asJsonValue)),
+            ))
+        .handle("routingBacktest", ({ payload }) =>
+            orInternal(runRoutingBacktest(payload).pipe(Effect.map(asJsonValue))))
         .handle("contextBudget", () =>
             orInternal(fetchContextBudget().pipe(Effect.map(asJsonValue))))
         .handle("contextDrift", () =>

--- a/apps/axctl/src/dashboard/contract/routing.test.ts
+++ b/apps/axctl/src/dashboard/contract/routing.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { writesAllowed } from "./routing.ts";
+
+const orig = process.env.AX_SERVE_HOST;
+afterEach(() => {
+    if (orig === undefined) delete process.env.AX_SERVE_HOST;
+    else process.env.AX_SERVE_HOST = orig;
+});
+
+describe("routing write loopback gate", () => {
+    it("allows writes when AX_SERVE_HOST is unset (default 127.0.0.1 bind)", () => {
+        delete process.env.AX_SERVE_HOST;
+        expect(writesAllowed()).toBe(true);
+    });
+    it("allows writes on explicit loopback hosts", () => {
+        for (const h of ["127.0.0.1", "localhost", "::1"]) {
+            process.env.AX_SERVE_HOST = h;
+            expect(writesAllowed()).toBe(true);
+        }
+    });
+    it("blocks writes when bound to 0.0.0.0 (LAN exposure)", () => {
+        process.env.AX_SERVE_HOST = "0.0.0.0";
+        expect(writesAllowed()).toBe(false);
+    });
+    it("blocks writes when bound to a LAN IP", () => {
+        process.env.AX_SERVE_HOST = "192.168.1.50";
+        expect(writesAllowed()).toBe(false);
+    });
+});

--- a/apps/axctl/src/dashboard/contract/routing.ts
+++ b/apps/axctl/src/dashboard/contract/routing.ts
@@ -24,6 +24,22 @@ import {
 import { asJsonValue, orInternal } from "./common.ts";
 
 /**
+ * Loopback gate: routing writes mutate `routing-table.json`, which the live
+ * route-dispatch hook reads. They are allowed only when the daemon is bound to
+ * a loopback host (the default). If the operator opted into LAN exposure via
+ * `AX_SERVE_HOST=0.0.0.0` (or any non-loopback host), the write surface stays
+ * read-only so a networked daemon can't have its routing rewritten remotely.
+ * Mirrors how `server.ts` reads the bind host (`process.env.AX_SERVE_HOST`).
+ */
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]", ""]);
+export const writesAllowed = (): boolean => {
+    const host = (process.env.AX_SERVE_HOST ?? "").trim();
+    return LOOPBACK_HOSTS.has(host);
+};
+const NON_LOOPBACK_WRITE_ERROR =
+    "routing writes are loopback-only; the daemon is bound to a non-loopback host (AX_SERVE_HOST), so the routing table is read-only over the network";
+
+/**
  * Try compiling a regex; return the error message on failure, null on success.
  */
 const tryRegex = (pattern: string, flags: string | undefined): string | null => {
@@ -38,6 +54,9 @@ const tryRegex = (pattern: string, flags: string | undefined): string | null => 
 export const RoutingGroupLive = HttpApiBuilder.group(AxApi, "routing", (handlers) =>
     handlers
         .handle("routingUpsertClass", ({ payload }) => {
+            if (!writesAllowed()) {
+                return Effect.fail(new BadRequestError({ error: NON_LOOPBACK_WRITE_ERROR }));
+            }
             // Validate main pattern before touching the file.
             const patternErr = tryRegex(payload.pattern, payload.flags);
             if (patternErr !== null) {
@@ -73,6 +92,9 @@ export const RoutingGroupLive = HttpApiBuilder.group(AxApi, "routing", (handlers
             }));
         })
         .handle("routingRemoveClass", ({ params }) => {
+            if (!writesAllowed()) {
+                return Effect.fail(new BadRequestError({ error: NON_LOOPBACK_WRITE_ERROR }));
+            }
             const path = defaultRoutingTablePath();
             return orInternal(Effect.gen(function* () {
                 const existing = yield* loadStoredRoutingTable(path);

--- a/apps/axctl/src/dashboard/contract/routing.ts
+++ b/apps/axctl/src/dashboard/contract/routing.ts
@@ -1,0 +1,88 @@
+/**
+ * Handlers for the routing group of the Insights Surface Contract.
+ *
+ * Write endpoints for routing classes: upsert and delete by id. Both
+ * operate on `~/.ax/hooks/routing-table.json` (the same file the
+ * route-dispatch hook and `ax routing show/compile` manage).
+ *
+ * Regex validation is done before touching the file so callers get a clean
+ * BadRequestError instead of a corrupt table on disk.
+ */
+import { Effect } from "effect";
+import { HttpApiBuilder } from "effect/unstable/httpapi";
+import { AxApi, BadRequestError } from "@ax/lib/shared/api-contract";
+import { DEFAULT_ROUTING_TABLE } from "@ax/hooks-sdk/routing-table";
+import {
+    defaultRoutingTablePath,
+    loadStoredRoutingTable,
+    mergeRoutingTables,
+    removeUserClass,
+    saveStoredRoutingTable,
+    type StoredRoutingClass,
+    upsertUserClass,
+} from "../../queries/routing-table-io.ts";
+import { asJsonValue, orInternal } from "./common.ts";
+
+/**
+ * Try compiling a regex; return the error message on failure, null on success.
+ */
+const tryRegex = (pattern: string, flags: string | undefined): string | null => {
+    try {
+        new RegExp(pattern, flags ?? "");
+        return null;
+    } catch (err) {
+        return err instanceof Error ? err.message : String(err);
+    }
+};
+
+export const RoutingGroupLive = HttpApiBuilder.group(AxApi, "routing", (handlers) =>
+    handlers
+        .handle("routingUpsertClass", ({ payload }) => {
+            // Validate main pattern before touching the file.
+            const patternErr = tryRegex(payload.pattern, payload.flags);
+            if (patternErr !== null) {
+                return Effect.fail(new BadRequestError({ error: `invalid pattern: ${patternErr}` }));
+            }
+            // Validate each exclude pattern.
+            for (const ex of payload.exclude ?? []) {
+                const exErr = tryRegex(ex, payload.flags);
+                if (exErr !== null) {
+                    return Effect.fail(
+                        new BadRequestError({ error: `invalid exclude pattern "${ex}": ${exErr}` }),
+                    );
+                }
+            }
+
+            const path = defaultRoutingTablePath();
+            return orInternal(Effect.gen(function* () {
+                const existing = yield* loadStoredRoutingTable(path);
+                // mergeRoutingTables converts LoadedRoutingTable → StoredRoutingTable
+                // (adds definite origin tags) while refreshing default-origin rows.
+                const base = mergeRoutingTables(DEFAULT_ROUTING_TABLE, existing);
+                const cls: Omit<StoredRoutingClass, "origin"> = {
+                    id: payload.id,
+                    pattern: payload.pattern,
+                    flags: payload.flags ?? "",
+                    suggest: payload.suggest,
+                    reason: payload.reason ?? "",
+                    ...(payload.exclude !== undefined ? { exclude: payload.exclude } : {}),
+                };
+                const next = upsertUserClass(base, cls);
+                yield* saveStoredRoutingTable(path, next);
+                return asJsonValue(next);
+            }));
+        })
+        .handle("routingRemoveClass", ({ params }) => {
+            const path = defaultRoutingTablePath();
+            return orInternal(Effect.gen(function* () {
+                const existing = yield* loadStoredRoutingTable(path);
+                if (existing === null) {
+                    // File does not exist yet - nothing to remove.
+                    return asJsonValue({ removed: false, id: params.id });
+                }
+                const base = mergeRoutingTables(DEFAULT_ROUTING_TABLE, existing);
+                const next = removeUserClass(base, params.id);
+                yield* saveStoredRoutingTable(path, next);
+                return asJsonValue(next);
+            }));
+        }));

--- a/apps/axctl/src/dashboard/contract/routing.ts
+++ b/apps/axctl/src/dashboard/contract/routing.ts
@@ -72,6 +72,10 @@ export const RoutingGroupLive = HttpApiBuilder.group(AxApi, "routing", (handlers
                 }
             }
 
+            if (!["sonnet", "haiku"].includes(payload.suggest)) {
+                return Effect.fail(new BadRequestError({ error: `invalid suggest "${payload.suggest}" (expected sonnet|haiku)` }));
+            }
+
             const path = defaultRoutingTablePath();
             return orInternal(Effect.gen(function* () {
                 const existing = yield* loadStoredRoutingTable(path);

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -35,6 +35,7 @@ import { ImproveGroupLive } from "./improve.ts";
 import { InsightsGroupLive } from "./insights.ts";
 import { LiveGroupLive } from "./live.ts";
 import { OtelGroupLive } from "./otel.ts";
+import { RoutingGroupLive } from "./routing.ts";
 import { SessionsGroupLive } from "./sessions.ts";
 import { SkillsGroupLive } from "./skills.ts";
 import { ContractServeInfo, SystemGroupLive } from "./system.ts";
@@ -57,6 +58,12 @@ const CONTRACT_ROUTES: ReadonlySet<string> = new Set([
     "GET /api/wrapped/public-preview",
     "GET /api/wrapped/generate-brief",
     "GET /api/cost/models",
+    "GET /api/cost/split",
+    "GET /api/cost/dispatches",
+    "GET /api/cost/routability",
+    "GET /api/routing/table",
+    "POST /api/routing/backtest",
+    "POST /api/routing/classes",
     "GET /api/context/budget",
     "GET /api/context/drift",
     "GET /api/workflow",
@@ -102,6 +109,7 @@ const CONTRACT_PATTERNS: ReadonlyArray<{ readonly method: string; readonly patte
     { method: "GET", pattern: /^\/api\/skills\/[^/]+\/(detail|source)$/ },
     { method: "POST", pattern: /^\/api\/skills\/[^/]+\/(decide|open)$/ },
     { method: "DELETE", pattern: /^\/api\/skills\/[^/]+\/decide$/ },
+    { method: "DELETE", pattern: /^\/api\/routing\/classes\/[^/]+$/ },
     { method: "GET", pattern: /^\/api\/improve\/[^/]+\/impact$/ },
     // All actions route to the contract; the handler answers unknown ones
     // with the legacy 404 { error: "unknown_improve_action" }.
@@ -150,6 +158,7 @@ export function makeContractWebHandler(opts: MakeContractWebHandlerOptions): Con
             UsageGroupLive,
             LiveGroupLive,
             OtelGroupLive,
+            RoutingGroupLive,
         ]),
         // FileSystem/Path appear twice deliberately: in the mergeAll OUTPUT
         // for request-time handler requirements, and here for the build-time

--- a/apps/axctl/src/queries/routing-backtest.test.ts
+++ b/apps/axctl/src/queries/routing-backtest.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { backtestPattern, type BacktestDispatch } from "./routing-backtest.ts";
+
+const d = (description: string, childModel: string, cost: number): BacktestDispatch => ({
+  description, agent_type: "general-purpose", child_model: childModel, child_cost_usd: cost, dispatch_model: "inherit",
+});
+
+const rows: BacktestDispatch[] = [
+  d("Implement task 3", "claude-fable-5", 50),
+  d("Implement the design review", "claude-fable-5", 40),
+  d("Fix the build", "claude-fable-5", 30),
+  d("Implement small", "claude-sonnet-4-6", 5),
+];
+
+describe("backtestPattern", () => {
+  it("partitions matched / excluded / missed", () => {
+    const r = backtestPattern(rows, { pattern: "^implement", flags: "i", suggest: "sonnet", exclude: ["design"] }, new Map());
+    expect(r.matched.map((m) => m.description)).toContain("Implement task 3");
+    expect(r.excluded.map((m) => m.description)).toContain("Implement the design review");
+    expect(r.missed.map((m) => m.description)).toContain("Fix the build"); // expensive inherit, not matched
+    expect(r.matched.map((m) => m.description)).not.toContain("Fix the build");
+  });
+  it("no exclude → nothing excluded", () => {
+    const r = backtestPattern(rows, { pattern: "^implement", flags: "i", suggest: "sonnet" }, new Map());
+    expect(r.excluded.length).toBe(0);
+  });
+  it("invalid pattern → no matches, no throw", () => {
+    const r = backtestPattern(rows, { pattern: "(", flags: "", suggest: "sonnet" }, new Map());
+    expect(r.matched.length).toBe(0);
+  });
+  it("estSavings is 0 without usage rows (cost-only fixtures) and never negative", () => {
+    const r = backtestPattern(rows, { pattern: "^implement", flags: "i", suggest: "sonnet" }, new Map());
+    expect(r.estSavingsUsd).toBeGreaterThanOrEqual(0);
+  });
+  it("with a usage row + cheap-tier catalog, matched expensive dispatch yields positive savings", () => {
+    const catalog = new Map([["claude-sonnet-4-6", { provider: "anthropic", inputPerMillionUsd: 3, outputPerMillionUsd: 15, cacheReadPerMillionUsd: 0.3, cacheCreationPerMillionUsd: 3.75, fastMultiplier: 1, pricingSource: "test" }]]);
+    const withUsage: BacktestDispatch[] = [{
+      description: "Implement big", agent_type: "general-purpose", child_model: "claude-fable-5", child_cost_usd: 50, dispatch_model: "inherit",
+      usage: { prompt_tokens: 2_000_000, completion_tokens: 200_000, cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 50 },
+    }];
+    const r = backtestPattern(withUsage, { pattern: "^implement", flags: "i", suggest: "sonnet" }, catalog as any);
+    expect(r.estSavingsUsd).toBeGreaterThan(0);
+  });
+});

--- a/apps/axctl/src/queries/routing-backtest.ts
+++ b/apps/axctl/src/queries/routing-backtest.ts
@@ -3,9 +3,16 @@
  *
  * No DB access - callers supply the rows and catalog so this is trivially testable
  * and reusable from both the CLI (`ax routing tune`) and the studio cost view.
+ *
+ * `runRoutingBacktest` is the DB-backed Effect entry-point for the dashboard
+ * handler: it fetches dispatch rows + agent_model pricing, then delegates to the
+ * pure `backtestPattern` function above.
  */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
 import { reprice, MODEL_ALIASES, type RepriceUsage } from "./reprice.ts";
 import type { ModelPricing } from "../ingest/model-pricing.ts";
+import { fetchDispatches } from "./dispatch-analytics.ts";
 
 /** Regex that matches model names considered "expensive" for routing purposes. */
 const EXPENSIVE_RE = /fable|opus/i;
@@ -116,3 +123,67 @@ export function backtestPattern(
 
     return { matched, excluded, missed, estSavingsUsd, matchedCount: matched.length };
 }
+
+// ---------------------------------------------------------------------------
+// DB-backed Effect entry-point (used by the dashboard /api/routing/backtest
+// handler).  Fetches dispatch rows + agent_model pricing catalog, then
+// delegates to the pure backtestPattern above.
+// ---------------------------------------------------------------------------
+
+const AGENT_MODELS_SQL = `
+SELECT name, input_per_million_usd, output_per_million_usd,
+       cache_read_per_million_usd, cache_creation_per_million_usd
+FROM agent_model;
+`;
+
+export const runRoutingBacktest = Effect.fn("queries.runRoutingBacktest")(
+    function* (payload: BacktestPattern & { readonly days?: number }) {
+        const db = yield* SurrealClient;
+        const sinceDays = Math.max(1, Math.trunc(payload.days ?? 14));
+
+        // Fetch dispatch rows (includes per-dispatch token usage).
+        const result = yield* fetchDispatches({ sinceDays, limit: 2000 });
+
+        // Build pricingCatalog from agent_model - same pattern as
+        // fetchDispatchCandidates in dispatch-analytics.ts.
+        const agentModelRows = yield* db
+            .query<[Array<Record<string, unknown>>]>(AGENT_MODELS_SQL)
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+
+        const pricingCatalog = new Map<string, ModelPricing>();
+        for (const am of agentModelRows) {
+            const name = String(am.name ?? "");
+            if (!name) continue;
+            pricingCatalog.set(name, {
+                provider: "anthropic",
+                inputPerMillionUsd: am.input_per_million_usd == null ? null : Number(am.input_per_million_usd),
+                outputPerMillionUsd: am.output_per_million_usd == null ? null : Number(am.output_per_million_usd),
+                cacheCreationPerMillionUsd: am.cache_creation_per_million_usd == null ? null : Number(am.cache_creation_per_million_usd),
+                cacheReadPerMillionUsd: am.cache_read_per_million_usd == null ? null : Number(am.cache_read_per_million_usd),
+                fastMultiplier: 1,
+                pricingSource: "agent_model",
+            });
+        }
+
+        // Map DispatchRow[] → BacktestDispatch[].
+        const backtestRows: BacktestDispatch[] = result.rows.map((row) => ({
+            description: row.description,
+            agent_type: row.agent_type,
+            child_model: row.child_model,
+            child_cost_usd: row.child_cost_usd,
+            dispatch_model: row.dispatch_model,
+            usage:
+                row.prompt_tokens > 0 || row.completion_tokens > 0
+                    ? {
+                        prompt_tokens: row.prompt_tokens,
+                        completion_tokens: row.completion_tokens,
+                        cache_read_tokens: row.cache_read_tokens,
+                        cache_create_tokens: row.cache_create_tokens,
+                        cost_usd: row.child_cost_usd,
+                    }
+                    : null,
+        }));
+
+        return backtestPattern(backtestRows, payload, pricingCatalog);
+    },
+);

--- a/apps/axctl/src/queries/routing-backtest.ts
+++ b/apps/axctl/src/queries/routing-backtest.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure backtest utility: partition a dispatch history by a candidate routing regex.
+ *
+ * No DB access - callers supply the rows and catalog so this is trivially testable
+ * and reusable from both the CLI (`ax routing tune`) and the studio cost view.
+ */
+import { reprice, MODEL_ALIASES, type RepriceUsage } from "./reprice.ts";
+import type { ModelPricing } from "../ingest/model-pricing.ts";
+
+/** Regex that matches model names considered "expensive" for routing purposes. */
+const EXPENSIVE_RE = /fable|opus/i;
+
+export interface BacktestDispatch {
+    description: string | null;
+    agent_type: string | null;
+    child_model: string | null;
+    child_cost_usd: number;
+    dispatch_model: string;
+    usage?: RepriceUsage | null;
+}
+
+export interface BacktestPattern {
+    pattern: string;
+    flags?: string;
+    suggest: string;
+    exclude?: readonly string[];
+}
+
+export interface BacktestRow {
+    description: string | null;
+    childModel: string | null;
+    costUsd: number;
+    estSavingsUsd: number;
+}
+
+export interface BacktestResult {
+    matched: BacktestRow[];
+    excluded: BacktestRow[];
+    missed: BacktestRow[];
+    estSavingsUsd: number;
+    matchedCount: number;
+}
+
+/**
+ * Partition `rows` into matched / excluded / missed buckets given a candidate
+ * routing pattern `p`.
+ *
+ * - **matched**: description matches `p.pattern` AND does NOT match any exclude regex.
+ * - **excluded**: description matches `p.pattern` but also matches an exclude regex.
+ * - **missed**: does NOT match `p.pattern`, is an `inherit` dispatch, and ran on an
+ *   expensive model (fable/opus) - i.e. a dispatch the pattern should have caught.
+ *
+ * `estSavingsUsd` is the sum of per-row savings for matched rows only. Savings
+ * are computed via `reprice` when `row.usage` is present; 0 otherwise.
+ *
+ * An invalid `p.pattern` is caught silently - all rows land in `missed`.
+ */
+export function backtestPattern(
+    rows: ReadonlyArray<BacktestDispatch>,
+    p: BacktestPattern,
+    pricingCatalog: ReadonlyMap<string, ModelPricing>,
+): BacktestResult {
+    // Compile main pattern - null on syntax error (fail-safe).
+    let re: RegExp | null = null;
+    try { re = new RegExp(p.pattern, p.flags ?? ""); } catch { re = null; }
+
+    // Compile exclude patterns, skip invalid ones.
+    const excludeRes = (p.exclude ?? [])
+        .map((ex) => { try { return new RegExp(ex, p.flags ?? ""); } catch { return null; } })
+        .filter((x): x is RegExp => x !== null);
+
+    const target = MODEL_ALIASES[p.suggest] ?? p.suggest;
+
+    const matched: BacktestRow[] = [];
+    const excluded: BacktestRow[] = [];
+    const missed: BacktestRow[] = [];
+    let estSavingsUsd = 0;
+
+    for (const row of rows) {
+        const desc = row.description ?? "";
+        const hit = re ? re.test(desc) : false;
+        const expensiveInherit =
+            row.dispatch_model === "inherit" &&
+            !!row.child_model &&
+            EXPENSIVE_RE.test(row.child_model);
+
+        // Compute per-row savings: only meaningful when token usage is present.
+        const repriced = row.usage
+            ? reprice(row.usage, target, pricingCatalog)
+            : row.child_cost_usd; // no usage → can't reprice, treat as equal
+        const saving = row.usage
+            ? Math.max(0, row.child_cost_usd - Math.min(repriced, row.child_cost_usd))
+            : 0;
+
+        const out: BacktestRow = {
+            description: row.description,
+            childModel: row.child_model,
+            costUsd: row.child_cost_usd,
+            estSavingsUsd: saving,
+        };
+
+        if (hit && excludeRes.some((ex) => ex.test(desc))) {
+            excluded.push(out);
+            continue;
+        }
+        if (hit) {
+            matched.push(out);
+            estSavingsUsd += saving;
+            continue;
+        }
+        // Not matched - only surface in missed when it's an expensive inherit dispatch.
+        if (expensiveInherit) {
+            missed.push(out);
+        }
+    }
+
+    return { matched, excluded, missed, estSavingsUsd, matchedCount: matched.length };
+}

--- a/apps/axctl/src/queries/routing-table-io.test.ts
+++ b/apps/axctl/src/queries/routing-table-io.test.ts
@@ -72,7 +72,7 @@ describe("mergeRoutingTables", () => {
         expect(ids).toContain("my-mined-class");
     });
 
-    it("user class shadowed by a new default of the same id defers to the default", () => {
+    it("user class with same id as a default overrides the default (user wins)", () => {
         const existing: StoredRoutingTable = {
             version: 1,
             classes: [{ ...userClass, id: "spec-review" }],
@@ -81,7 +81,7 @@ describe("mergeRoutingTables", () => {
         const merged = mergeRoutingTables(ROUTING_CLASSES, existing);
         const specReview = merged.classes.filter((c) => c.id === "spec-review");
         expect(specReview).toHaveLength(1);
-        expect(specReview[0]!.origin).toBe("default");
+        expect(specReview[0]!.origin).toBe("user");
     });
 
     it("refreshes agentTypes from defaults but keeps user-added keys", () => {
@@ -187,5 +187,22 @@ describe("routing-table-io exclude + upsert/remove", () => {
     it("removeUserClass does NOT remove a default class", () => {
         const withDefault: StoredRoutingTable = { version: 1, agentTypes: {}, classes: [{ id: "d", pattern: "^x", flags: "", suggest: "sonnet", reason: "d", origin: "default" }] };
         expect(removeUserClass(withDefault, "d").classes.find((c) => c.id === "d")).toBeDefined();
+    });
+});
+
+describe("mergeRoutingTables user override of defaults", () => {
+    it("a user class with a default id overrides the default (exclude persists)", () => {
+        const defaults = { version: 1 as const, classes: [{ id: "bug-fix", pattern: "^Fix\\s", flags: "", suggest: "sonnet", reason: "fix" }], agentTypes: {} };
+        const existing: StoredRoutingTable = { version: 1, agentTypes: {}, classes: [{ id: "bug-fix", pattern: "^Fix\\s", flags: "", suggest: "sonnet", reason: "fix", exclude: ["design"], origin: "user" }] };
+        const merged = mergeRoutingTables(defaults as any, existing);
+        const c = merged.classes.filter((x) => x.id === "bug-fix");
+        expect(c.length).toBe(1);
+        expect(c[0]!.exclude).toEqual(["design"]);
+        expect(c[0]!.origin).toBe("user");
+    });
+    it("a default with no user override still refreshes from defaults", () => {
+        const defaults = { version: 1 as const, classes: [{ id: "spec-review", pattern: "^spec review", flags: "", suggest: "sonnet", reason: "r" }], agentTypes: {} };
+        const merged = mergeRoutingTables(defaults as any, { version: 1, agentTypes: {}, classes: [] });
+        expect(merged.classes.find((x) => x.id === "spec-review")?.origin).toBe("default");
     });
 });

--- a/apps/axctl/src/queries/routing-table-io.test.ts
+++ b/apps/axctl/src/queries/routing-table-io.test.ts
@@ -12,6 +12,8 @@ import {
     saveStoredRoutingTable,
     loadEffectiveRoutingTable,
     appendUserClasses,
+    upsertUserClass,
+    removeUserClass,
     type LoadedRoutingTable,
     type StoredRoutingTable,
     type StoredRoutingClass,
@@ -159,5 +161,31 @@ describe("load/save round-trip", () => {
         expect(eff1.classes.map((c) => c.id)).toEqual(ROUTING_CLASSES.classes.map((c) => c.id));
         const eff2 = await run(loadEffectiveRoutingTable(join(dir, "absent.json")));
         expect(eff2.classes.length).toBe(ROUTING_CLASSES.classes.length);
+    });
+});
+
+const base: StoredRoutingTable = { version: 1, classes: [], agentTypes: {} };
+
+describe("routing-table-io exclude + upsert/remove", () => {
+    it("upsert adds a user class with exclude preserved", () => {
+        const t = upsertUserClass(base, { id: "issue-n", pattern: "^issue", flags: "i", suggest: "sonnet", reason: "issue", exclude: ["design"] });
+        const c = t.classes.find((x) => x.id === "issue-n");
+        expect(c?.origin).toBe("user");
+        expect(c?.exclude).toEqual(["design"]);
+    });
+    it("upsert replaces an existing user class by id (no dup)", () => {
+        const t1 = upsertUserClass(base, { id: "x", pattern: "^a", flags: "", suggest: "sonnet", reason: "a" });
+        const t2 = upsertUserClass(t1, { id: "x", pattern: "^b", flags: "", suggest: "haiku", reason: "b", exclude: ["q"] });
+        expect(t2.classes.filter((c) => c.id === "x").length).toBe(1);
+        expect(t2.classes.find((c) => c.id === "x")?.suggest).toBe("haiku");
+        expect(t2.classes.find((c) => c.id === "x")?.exclude).toEqual(["q"]);
+    });
+    it("removeUserClass removes a user class", () => {
+        const t1 = upsertUserClass(base, { id: "x", pattern: "^a", flags: "", suggest: "sonnet", reason: "a" });
+        expect(removeUserClass(t1, "x").classes.find((c) => c.id === "x")).toBeUndefined();
+    });
+    it("removeUserClass does NOT remove a default class", () => {
+        const withDefault: StoredRoutingTable = { version: 1, agentTypes: {}, classes: [{ id: "d", pattern: "^x", flags: "", suggest: "sonnet", reason: "d", origin: "default" }] };
+        expect(removeUserClass(withDefault, "d").classes.find((c) => c.id === "d")).toBeDefined();
     });
 });

--- a/apps/axctl/src/queries/routing-table-io.ts
+++ b/apps/axctl/src/queries/routing-table-io.ts
@@ -42,10 +42,12 @@ export interface StoredRoutingTable {
 }
 
 /**
- * Refresh defaults, keep user classes. Default ids always win on collision.
+ * Refresh defaults, keep user classes. User classes WIN on id collision:
+ * a stored user class with the same id as a default overrides the default so
+ * hand-tuned exclude lists, patterns, etc. survive `ax routing compile`.
  * Classes: rows with origin !== "default" (i.e. "user" or legacy origin-less)
- * are preserved and tagged "user"; rows tagged "default" are replaced
- * wholesale by the current defaults (stale ones drop).
+ * are preserved and tagged "user"; default-origin rows from the stored file are
+ * replaced wholesale by the current defaults (stale ones drop).
  * agentTypes: defaults overwrite stored values key-by-key (stale stored
  * copies never shadow updated defaults); user-added keys survive.
  */
@@ -53,17 +55,32 @@ export const mergeRoutingTables = (
     defaults: RoutingTable,
     existing: LoadedRoutingTable | null,
 ): StoredRoutingTable => {
-    const defaultClasses: StoredRoutingClass[] = defaults.classes.map((c) => ({
-        ...c,
-        origin: "default" as const,
-    }));
-    const defaultIds = new Set(defaultClasses.map((c) => c.id));
-    const userClasses: StoredRoutingClass[] = (existing?.classes ?? [])
-        .filter((c) => c.origin !== "default" && !defaultIds.has(c.id))
-        .map((c) => ({ ...c, origin: "user" as const }));
+    // Build a lookup of user-origin classes (any non-"default" origin) keyed by id.
+    const userById = new Map<string, StoredRoutingClass>();
+    for (const c of (existing?.classes ?? [])) {
+        if (c.origin !== "default") {
+            userById.set(c.id, { ...c, origin: "user" as const });
+        }
+    }
+    const defaultIds = new Set(defaults.classes.map((c) => c.id));
+
+    // For each default: if a user class with the same id exists, the user wins;
+    // otherwise use the refreshed default.
+    const mergedClasses: StoredRoutingClass[] = defaults.classes.map((c) => {
+        const userOverride = userById.get(c.id);
+        return userOverride ?? { ...c, origin: "default" as const };
+    });
+
+    // Append user classes with non-default ids (preserved from existing).
+    for (const [id, cls] of userById) {
+        if (!defaultIds.has(id)) {
+            mergedClasses.push(cls);
+        }
+    }
+
     return {
         version: 1,
-        classes: [...defaultClasses, ...userClasses],
+        classes: mergedClasses,
         agentTypes: { ...(existing?.agentTypes ?? {}), ...defaults.agentTypes },
     };
 };

--- a/apps/axctl/src/queries/routing-table-io.ts
+++ b/apps/axctl/src/queries/routing-table-io.ts
@@ -83,6 +83,20 @@ export const appendUserClasses = (
     return { ...table, classes: [...table.classes, ...fresh] };
 };
 
+/** Upsert a user-origin class by id (replaces same-id, else appends). */
+export function upsertUserClass(
+    table: StoredRoutingTable,
+    cls: Omit<StoredRoutingClass, "origin">,
+): StoredRoutingTable {
+    const next: StoredRoutingClass = { ...cls, origin: "user" };
+    return { ...table, classes: [...table.classes.filter((c) => c.id !== cls.id), next] };
+}
+
+/** Remove a class by id, but never a default-origin class. */
+export function removeUserClass(table: StoredRoutingTable, id: string): StoredRoutingTable {
+    return { ...table, classes: table.classes.filter((c) => !(c.id === id && c.origin !== "default")) };
+}
+
 export const saveStoredRoutingTable = (
     path: string,
     table: StoredRoutingTable,

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -506,6 +506,20 @@ export const api = {
 
     costModels: (): Promise<CostModelsResult> =>
         viaContract("/api/cost/models", (c) => c.insights.costModels()) as Promise<CostModelsResult>,
+    costSplit: (days = 30): Promise<unknown> =>
+        viaContract("/api/cost/split", (c) => c.insights.costSplit({ query: { days } })),
+    costDispatches: (days = 30, candidates = false): Promise<unknown> =>
+        viaContract("/api/cost/dispatches", (c) => c.insights.costDispatches({ query: { days, candidates } })),
+    costRoutability: (days = 30, minRun = 1): Promise<unknown> =>
+        viaContract("/api/cost/routability", (c) => c.insights.costRoutability({ query: { days, minRun } })),
+    routingTable: (): Promise<unknown> =>
+        viaContract("/api/routing/table", (c) => c.insights.routingTable()),
+    routingBacktest: (body: { pattern: string; flags?: string; suggest: string; exclude?: string[]; days?: number }): Promise<unknown> =>
+        viaContract("/api/routing/backtest", (c) => c.insights.routingBacktest({ payload: body }), { method: "POST" }),
+    routingUpsertClass: (body: { id: string; pattern: string; flags?: string; suggest: string; reason?: string; exclude?: string[] }): Promise<unknown> =>
+        viaContract("/api/routing/classes", (c) => c.routing.routingUpsertClass({ payload: body }), { method: "POST" }),
+    routingRemoveClass: (id: string): Promise<unknown> =>
+        viaContract(`/api/routing/classes/${encodeURIComponent(id)}`, (c) => c.routing.routingRemoveClass({ params: { id } }), { method: "DELETE" }),
     contextBudget: (): Promise<ContextBudgetResult> =>
         viaContract("/api/context/budget", (c) => c.insights.contextBudget()) as Promise<ContextBudgetResult>,
     contextDrift: (): Promise<ContextDriftResult> =>

--- a/apps/studio/src/components/cost-bars.tsx
+++ b/apps/studio/src/components/cost-bars.tsx
@@ -1,0 +1,21 @@
+export function SplitBar({ segs }: { segs: { label: string; value: number; color: string }[] }) {
+  const total = segs.reduce((s, x) => s + x.value, 0) || 1;
+  return (
+    <div style={{ display: "flex", width: "100%", height: 26, borderRadius: 4, overflow: "hidden" }}>
+      {segs.map((s) => (
+        <div key={s.label} title={`${s.label}: ${(100 * s.value / total).toFixed(1)}%`}
+          style={{ width: `${(100 * s.value / total).toFixed(2)}%`, background: s.color }} />
+      ))}
+    </div>
+  );
+}
+export function BarRow({ label, value, max, sub, color = "#888" }: { label: string; value: number; max: number; sub?: string; color?: string }) {
+  return (
+    <div style={{ margin: "6px 0" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13 }}><span>{label}</span><span style={{ opacity: 0.7 }}>{sub}</span></div>
+      <div style={{ height: 8, background: "#2a2a2a" }}>
+        <div style={{ width: `${Math.max(2, 100 * value / (max || 1)).toFixed(1)}%`, height: 8, background: color }} />
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/src/components/routing-tuner.tsx
+++ b/apps/studio/src/components/routing-tuner.tsx
@@ -1,0 +1,343 @@
+/**
+ * Interactive routing-class tuner: browse existing classes, author new ones,
+ * debounced live backtest against dispatch history, save/remove via the
+ * routing write API (gated to live daemon connections).
+ */
+import { useState, useEffect, useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { api, studioConnection } from "../api.ts";
+
+// ---------------------------------------------------------------------------
+// Local shapes (api methods return unknown - cast here)
+// ---------------------------------------------------------------------------
+
+interface RoutingClass {
+    id: string;
+    pattern: string;
+    flags?: string;
+    suggest: string;
+    reason: string;
+    origin?: string;
+    exclude?: string[];
+}
+
+interface StoredRoutingTable {
+    version: number;
+    classes: RoutingClass[];
+    agentTypes?: Record<string, string>;
+}
+
+interface BacktestRow {
+    description: string | null;
+    childModel: string | null;
+    costUsd: number;
+    estSavingsUsd: number;
+}
+
+interface BacktestResult {
+    matched: BacktestRow[];
+    excluded: BacktestRow[];
+    missed: BacktestRow[];
+    estSavingsUsd: number;
+    matchedCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function RoutingTuner() {
+    const isLive = studioConnection.isLive();
+    const queryClient = useQueryClient();
+
+    const { data: tableRaw, isLoading: tableLoading } = useQuery({
+        queryKey: ["routing-table"],
+        queryFn: () => api.routingTable(),
+    });
+    const table = tableRaw as StoredRoutingTable | null | undefined;
+
+    // Form state
+    const [pattern, setPattern] = useState("");
+    const [flags, setFlags] = useState("i");
+    const [suggest, setSuggest] = useState("sonnet");
+    const [excludeStr, setExcludeStr] = useState("");
+    const [days, setDays] = useState(30);
+    const [customId, setCustomId] = useState("");
+    const [reason, setReason] = useState("");
+
+    // Selected row for edit
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+
+    // Backtest state
+    const [backtestResult, setBacktestResult] = useState<BacktestResult | null>(null);
+    const [backtestLoading, setBacktestLoading] = useState(false);
+
+    // Action status
+    const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+    const [removeStatus, setRemoveStatus] = useState<"idle" | "removing" | "done" | "error">("idle");
+
+    const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Debounced live backtest
+    useEffect(() => {
+        if (!pattern.trim()) { setBacktestResult(null); return; }
+        if (debounceTimer.current) clearTimeout(debounceTimer.current);
+        debounceTimer.current = setTimeout(() => {
+            setBacktestLoading(true);
+            const body: Parameters<typeof api.routingBacktest>[0] = { pattern, suggest, days };
+            if (flags.trim()) body.flags = flags;
+            if (excludeStr.trim()) body.exclude = excludeStr.split(",").map((s) => s.trim()).filter(Boolean);
+            api.routingBacktest(body)
+                .then((res) => { setBacktestResult(res as BacktestResult); })
+                .catch(() => { setBacktestResult(null); })
+                .finally(() => { setBacktestLoading(false); });
+        }, 600);
+        return () => { if (debounceTimer.current) clearTimeout(debounceTimer.current); };
+    }, [pattern, flags, suggest, excludeStr, days]);
+
+    // Load selected class into form
+    useEffect(() => {
+        if (!selectedId || !table) return;
+        const cls = table.classes.find((c) => c.id === selectedId);
+        if (!cls) return;
+        setPattern(cls.pattern);
+        setFlags(cls.flags ?? "i");
+        setSuggest(cls.suggest);
+        setExcludeStr((cls.exclude ?? []).join(", "));
+        setCustomId(cls.id);
+        setReason(cls.reason ?? "");
+    }, [selectedId, table]);
+
+    const handleSave = () => {
+        if (!pattern.trim() || !isLive) return;
+        setSaveStatus("saving");
+        const body: Parameters<typeof api.routingUpsertClass>[0] = {
+            id: customId.trim() || selectedId || `custom-${Date.now()}`,
+            pattern,
+            suggest,
+        };
+        if (flags.trim()) body.flags = flags;
+        if (reason.trim()) body.reason = reason;
+        if (excludeStr.trim()) body.exclude = excludeStr.split(",").map((s) => s.trim()).filter(Boolean);
+        api.routingUpsertClass(body)
+            .then(() => {
+                void queryClient.invalidateQueries({ queryKey: ["routing-table"] });
+                setSaveStatus("saved");
+                setTimeout(() => setSaveStatus("idle"), 2000);
+            })
+            .catch(() => { setSaveStatus("error"); setTimeout(() => setSaveStatus("idle"), 2000); });
+    };
+
+    const handleRemove = (id: string) => {
+        if (!isLive) return;
+        setRemoveStatus("removing");
+        api.routingRemoveClass(id)
+            .then(() => {
+                void queryClient.invalidateQueries({ queryKey: ["routing-table"] });
+                if (selectedId === id) { setSelectedId(null); setPattern(""); setCustomId(""); }
+                setRemoveStatus("done");
+                setTimeout(() => setRemoveStatus("idle"), 1500);
+            })
+            .catch(() => { setRemoveStatus("error"); setTimeout(() => setRemoveStatus("idle"), 1500); });
+    };
+
+    const inputStyle: React.CSSProperties = {
+        padding: "4px 8px", fontSize: 13,
+        border: "1px solid var(--line, #cfd8d4)", borderRadius: 3,
+        background: "var(--panel, #fff)", color: "inherit",
+    };
+
+    return (
+        <div>
+            <h3 style={{ margin: "20px 0 8px", fontSize: "0.85em", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                Routing tuner{!isLive && (
+                    <span style={{ opacity: 0.5, fontWeight: 400, textTransform: "none", marginLeft: 8 }}>
+                        (connect to a live daemon to save)
+                    </span>
+                )}
+            </h3>
+
+            {/* Existing classes table */}
+            {tableLoading
+                ? <p style={{ opacity: 0.5, fontSize: 13 }}>Loading routing table…</p>
+                : table?.classes && table.classes.length > 0
+                    ? (
+                        <div style={{ marginBottom: 12, overflowX: "auto" }}>
+                            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+                                <thead>
+                                    <tr>
+                                        {["id", "pattern", "suggest", "origin"].map((h) => (
+                                            <th key={h} style={{ textAlign: "left", padding: "2px 8px 2px 0", opacity: 0.6, fontWeight: 500 }}>{h}</th>
+                                        ))}
+                                        {isLive && <th />}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {table.classes.map((cls) => (
+                                        <tr key={cls.id}
+                                            onClick={() => setSelectedId(selectedId === cls.id ? null : cls.id)}
+                                            style={{
+                                                cursor: "pointer",
+                                                background: selectedId === cls.id ? "var(--track, #e4ebe8)" : "transparent",
+                                            }}>
+                                            <td style={{ padding: "3px 8px 3px 0", fontFamily: "monospace", fontSize: 11 }}>{cls.id}</td>
+                                            <td style={{ padding: "3px 8px 3px 0", fontFamily: "monospace", fontSize: 11, maxWidth: 180, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{cls.pattern}</td>
+                                            <td style={{ padding: "3px 8px 3px 0", color: "var(--blue, #2567a8)" }}>{cls.suggest}</td>
+                                            <td style={{ padding: "3px 8px 3px 0", opacity: 0.5, fontSize: 11 }}>{cls.origin ?? "default"}</td>
+                                            {isLive && (
+                                                <td style={{ padding: "3px 0" }}>
+                                                    <button
+                                                        onClick={(e) => { e.stopPropagation(); handleRemove(cls.id); }}
+                                                        style={{ ...inputStyle, padding: "1px 6px", cursor: "pointer", background: "transparent" }}>
+                                                        {removeStatus === "removing" ? "…" : "✕"}
+                                                    </button>
+                                                </td>
+                                            )}
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    )
+                    : <p style={{ opacity: 0.5, fontSize: 13 }}>No routing table loaded.</p>
+            }
+
+            {/* Pattern editor */}
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 60px 120px", gap: 8, marginBottom: 8 }}>
+                <div>
+                    <label style={{ fontSize: 12, opacity: 0.6, display: "block", marginBottom: 2 }}>Pattern (regex)</label>
+                    <input value={pattern} onChange={(e) => setPattern(e.target.value)}
+                        placeholder="e.g. summarize|translate"
+                        style={{ ...inputStyle, width: "100%" }} />
+                </div>
+                <div>
+                    <label style={{ fontSize: 12, opacity: 0.6, display: "block", marginBottom: 2 }}>Flags</label>
+                    <input value={flags} onChange={(e) => setFlags(e.target.value)}
+                        placeholder="i"
+                        style={{ ...inputStyle, width: "100%" }} />
+                </div>
+                <div>
+                    <label style={{ fontSize: 12, opacity: 0.6, display: "block", marginBottom: 2 }}>Suggest model</label>
+                    <select value={suggest} onChange={(e) => setSuggest(e.target.value)}
+                        style={{ ...inputStyle, width: "100%" }}>
+                        <option value="haiku">haiku</option>
+                        <option value="sonnet">sonnet</option>
+                    </select>
+                </div>
+            </div>
+
+            <div style={{ marginBottom: 8 }}>
+                <label style={{ fontSize: 12, opacity: 0.6, display: "block", marginBottom: 2 }}>Exclude patterns (comma-separated)</label>
+                <input value={excludeStr} onChange={(e) => setExcludeStr(e.target.value)}
+                    placeholder="e.g. review, audit"
+                    style={{ ...inputStyle, width: "100%" }} />
+            </div>
+
+            <div style={{ display: "flex", gap: 8, alignItems: "flex-end", marginBottom: 10 }}>
+                <div>
+                    <label style={{ fontSize: 12, opacity: 0.6, display: "block", marginBottom: 2 }}>Days</label>
+                    <input type="number" value={days} onChange={(e) => setDays(Number(e.target.value))}
+                        style={{ ...inputStyle, width: 64 }} />
+                </div>
+                {isLive && (
+                    <>
+                        <div style={{ flex: 1 }}>
+                            <label style={{ fontSize: 12, opacity: 0.6, display: "block", marginBottom: 2 }}>ID</label>
+                            <input value={customId} onChange={(e) => setCustomId(e.target.value)}
+                                placeholder="class-id"
+                                style={{ ...inputStyle, width: "100%" }} />
+                        </div>
+                        <div style={{ flex: 2 }}>
+                            <label style={{ fontSize: 12, opacity: 0.6, display: "block", marginBottom: 2 }}>Reason</label>
+                            <input value={reason} onChange={(e) => setReason(e.target.value)}
+                                placeholder="optional reason"
+                                style={{ ...inputStyle, width: "100%" }} />
+                        </div>
+                    </>
+                )}
+            </div>
+
+            {/* Backtest results */}
+            {backtestLoading && <p style={{ opacity: 0.5, fontSize: 13 }}>Running backtest…</p>}
+            {backtestResult && !backtestLoading && (
+                <div style={{ marginBottom: 12, fontSize: 13 }}>
+                    <div style={{ display: "flex", gap: 16, marginBottom: 6, flexWrap: "wrap" }}>
+                        <span><strong>{backtestResult.matchedCount}</strong> matched</span>
+                        <span><strong>{backtestResult.excluded.length}</strong> excluded</span>
+                        <span><strong>{backtestResult.missed.length}</strong> missed (expensive inherit)</span>
+                        <span style={{ color: "var(--green, #16845e)" }}>
+                            est. <strong>${backtestResult.estSavingsUsd.toFixed(4)}</strong> savings
+                        </span>
+                    </div>
+                    {backtestResult.matched.length > 0 && (
+                        <details style={{ marginBottom: 4 }}>
+                            <summary style={{ cursor: "pointer", opacity: 0.7, fontSize: 12 }}>
+                                Matched ({backtestResult.matched.length})
+                            </summary>
+                            <div style={{ paddingLeft: 12, maxHeight: 140, overflowY: "auto" }}>
+                                {backtestResult.matched.slice(0, 20).map((r, i) => (
+                                    <div key={i} style={{ fontSize: 12, padding: "2px 0", opacity: 0.8, fontFamily: "monospace", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                                        {r.description ?? "(no description)"}
+                                        <span style={{ color: "var(--green, #16845e)", marginLeft: 8 }}>
+                                            −${r.estSavingsUsd.toFixed(4)}
+                                        </span>
+                                    </div>
+                                ))}
+                                {backtestResult.matched.length > 20 && (
+                                    <div style={{ fontSize: 11, opacity: 0.5 }}>…and {backtestResult.matched.length - 20} more</div>
+                                )}
+                            </div>
+                        </details>
+                    )}
+                    {backtestResult.excluded.length > 0 && (
+                        <details style={{ marginBottom: 4 }}>
+                            <summary style={{ cursor: "pointer", opacity: 0.7, fontSize: 12 }}>
+                                Excluded ({backtestResult.excluded.length})
+                            </summary>
+                            <div style={{ paddingLeft: 12, maxHeight: 100, overflowY: "auto" }}>
+                                {backtestResult.excluded.slice(0, 10).map((r, i) => (
+                                    <div key={i} style={{ fontSize: 12, padding: "2px 0", opacity: 0.6, fontFamily: "monospace", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                                        {r.description ?? "(no description)"}
+                                    </div>
+                                ))}
+                            </div>
+                        </details>
+                    )}
+                    {backtestResult.missed.length > 0 && (
+                        <details>
+                            <summary style={{ cursor: "pointer", opacity: 0.7, fontSize: 12 }}>
+                                Missed - expensive inherits pattern did not catch ({backtestResult.missed.length})
+                            </summary>
+                            <div style={{ paddingLeft: 12, maxHeight: 100, overflowY: "auto" }}>
+                                {backtestResult.missed.slice(0, 10).map((r, i) => (
+                                    <div key={i} style={{ fontSize: 12, padding: "2px 0", opacity: 0.6, fontFamily: "monospace", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                                        {r.description ?? "(no description)"}
+                                        {r.childModel && <span style={{ opacity: 0.5, marginLeft: 6 }}>({r.childModel})</span>}
+                                    </div>
+                                ))}
+                            </div>
+                        </details>
+                    )}
+                </div>
+            )}
+
+            {/* Save / label */}
+            {isLive && (
+                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <button onClick={handleSave}
+                        disabled={!pattern.trim() || saveStatus === "saving"}
+                        style={{
+                            padding: "5px 14px", fontSize: 13, cursor: "pointer",
+                            background: "var(--green, #16845e)", color: "#fff",
+                            border: "none", borderRadius: 4, opacity: !pattern.trim() ? 0.5 : 1,
+                        }}>
+                        {saveStatus === "saving" ? "Saving…" : saveStatus === "saved" ? "Saved ✓" : saveStatus === "error" ? "Error" : "Save class"}
+                    </button>
+                    {selectedId && (
+                        <span style={{ fontSize: 12, opacity: 0.6 }}>editing: {selectedId}</span>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/studio/src/components/routing-tuner.tsx
+++ b/apps/studio/src/components/routing-tuner.tsx
@@ -46,6 +46,8 @@ interface BacktestResult {
 // Component
 // ---------------------------------------------------------------------------
 
+const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 export function RoutingTuner() {
     const isLive = studioConnection.isLive();
     const queryClient = useQueryClient();
@@ -276,11 +278,27 @@ export function RoutingTuner() {
                             </summary>
                             <div style={{ paddingLeft: 12, maxHeight: 140, overflowY: "auto" }}>
                                 {backtestResult.matched.slice(0, 20).map((r, i) => (
-                                    <div key={i} style={{ fontSize: 12, padding: "2px 0", opacity: 0.8, fontFamily: "monospace", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                                        {r.description ?? "(no description)"}
-                                        <span style={{ color: "var(--green, #16845e)", marginLeft: 8 }}>
+                                    <div key={i} style={{ fontSize: 12, padding: "2px 0", opacity: 0.8, fontFamily: "monospace", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", display: "flex", alignItems: "center", gap: 6 }}>
+                                        <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis" }}>{r.description ?? "(no description)"}</span>
+                                        <span style={{ color: "var(--green, #16845e)" }}>
                                             −${r.estSavingsUsd.toFixed(4)}
                                         </span>
+                                        {isLive && r.description && (
+                                            <button
+                                                onClick={() => {
+                                                    const esc = escapeRegex(r.description ?? "");
+                                                    if (!esc) return;
+                                                    setExcludeStr((prev) => {
+                                                        const parts = prev.split(",").map((s) => s.trim()).filter(Boolean);
+                                                        if (parts.includes(esc)) return prev;
+                                                        return [...parts, esc].join(", ");
+                                                    });
+                                                }}
+                                                style={{ fontSize: 10, padding: "1px 4px", cursor: "pointer", background: "transparent", border: "1px solid var(--line, #cfd8d4)", borderRadius: 2, flexShrink: 0 }}
+                                                title="Add to exclude list">
+                                                ✕ exclude
+                                            </button>
+                                        )}
                                     </div>
                                 ))}
                                 {backtestResult.matched.length > 20 && (
@@ -296,8 +314,24 @@ export function RoutingTuner() {
                             </summary>
                             <div style={{ paddingLeft: 12, maxHeight: 100, overflowY: "auto" }}>
                                 {backtestResult.excluded.slice(0, 10).map((r, i) => (
-                                    <div key={i} style={{ fontSize: 12, padding: "2px 0", opacity: 0.6, fontFamily: "monospace", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                                        {r.description ?? "(no description)"}
+                                    <div key={i} style={{ fontSize: 12, padding: "2px 0", opacity: 0.6, fontFamily: "monospace", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", display: "flex", alignItems: "center", gap: 6 }}>
+                                        <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis" }}>{r.description ?? "(no description)"}</span>
+                                        {isLive && r.description && (
+                                            <button
+                                                onClick={() => {
+                                                    const esc = escapeRegex(r.description ?? "");
+                                                    if (!esc) return;
+                                                    setExcludeStr((prev) => {
+                                                        const parts = prev.split(",").map((s) => s.trim()).filter(Boolean);
+                                                        if (parts.includes(esc)) return prev;
+                                                        return [...parts, esc].join(", ");
+                                                    });
+                                                }}
+                                                style={{ fontSize: 10, padding: "1px 4px", cursor: "pointer", background: "transparent", border: "1px solid var(--line, #cfd8d4)", borderRadius: 2, flexShrink: 0 }}
+                                                title="Add to exclude list">
+                                                ✕ exclude
+                                            </button>
+                                        )}
                                     </div>
                                 ))}
                             </div>

--- a/apps/studio/src/instrument/shell.tsx
+++ b/apps/studio/src/instrument/shell.tsx
@@ -9,6 +9,7 @@ export const RAIL = [
     { g: "≣", to: "/sessions", label: "sessions" },
     { g: "◷", to: "/workflow", label: "workflow" },
     { g: "⎈", to: "/improve", label: "improve" },
+    { g: "◧", to: "/cost", label: "cost" },
     { g: "✦", to: "/skills", label: "skills" },
     { g: "⚙", to: "/lab", label: "lab" },
 ] as const;

--- a/apps/studio/src/router.tsx
+++ b/apps/studio/src/router.tsx
@@ -23,6 +23,7 @@ import type { GraphExplorerMode } from "@ax/lib/shared/dashboard-types";
 import { MissionControl } from "./instrument/mission-control.tsx";
 import { ImproveRoute } from "./routes/improve.tsx";
 import { UsageRoute } from "./routes/usage.tsx";
+import { CostRoute } from "./routes/cost.tsx";
 import { LabRoute } from "./routes/lab.tsx";
 import { SigilGalleryRoute } from "./routes/sigil-gallery.tsx";
 import { ReviewView } from "./routes/review-view.tsx";
@@ -207,6 +208,12 @@ const usageRoute = createRoute({
     component: UsageRoute,
 });
 
+const costRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/cost",
+    component: CostRoute,
+});
+
 const labRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/lab",
@@ -266,6 +273,7 @@ const routeTree = rootRoute.addChildren([
     canvasRoute,
     improveRoute,
     usageRoute,
+    costRoute,
     labRoute,
     sigilGalleryRoute,
     narrationDemoRoute,

--- a/apps/studio/src/routes/cost.tsx
+++ b/apps/studio/src/routes/cost.tsx
@@ -1,0 +1,302 @@
+/**
+ * Cost analytics route: spend split, dispatch candidates, main-thread
+ * routability lens, and interactive routing-class tuner.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api.ts";
+import { SplitBar, BarRow } from "../components/cost-bars.tsx";
+import { RoutingTuner } from "../components/routing-tuner.tsx";
+
+// ---------------------------------------------------------------------------
+// Local cast shapes (api methods return unknown - narrow here)
+// ---------------------------------------------------------------------------
+
+interface CostSplitRow {
+    origin: "main" | "subagent";
+    model: string;
+    sessions: number;
+    cost_usd: number;
+    share_pct: number;
+}
+interface CostSplitResult {
+    rows: CostSplitRow[];
+    totals: { cost_usd: number; sessions: number };
+}
+
+interface CandidateRow {
+    ts: string;
+    description: string | null;
+    agent_type: string | null;
+    dispatch_model: string;
+    child_model: string | null;
+    child_cost_usd: number;
+    routing_match: { classId: string; suggest: string };
+    suggested_model: string;
+    est_savings_usd: number;
+}
+interface CandidatesResult {
+    candidates: CandidateRow[];
+    total_est_savings_usd: number;
+    top_classes: Array<{ classId: string; savings_usd: number }>;
+}
+
+interface RoutabilityClassRow {
+    class: string;
+    verdict: "routable" | "stays";
+    runs: number;
+    turns: number;
+    mainCostUsd: number;
+    tier: string | null;
+    repricedUsd: number | null;
+    estSavingsUsd: number | null;
+}
+interface RoutabilityResult {
+    mainSpendUsd: number;
+    routableUsd: number;
+    routablePct: number;
+    estSavingsUsd: number;
+    rows: RoutabilityClassRow[];
+    days: number;
+    minRun: number;
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+const fmt = (n: number) => `$${n.toFixed(4)}`;
+const pct = (n: number) => `${n.toFixed(1)}%`;
+
+// ---------------------------------------------------------------------------
+// Section helpers
+// ---------------------------------------------------------------------------
+
+function SectionHead({ title, meta }: { title: string; meta?: string }) {
+    return (
+        <h3 style={{ margin: "20px 0 8px", fontSize: "0.85em", textTransform: "uppercase", letterSpacing: "0.05em", display: "flex", alignItems: "baseline", gap: 8 }}>
+            {title}{meta && <span style={{ fontWeight: 400, opacity: 0.5, textTransform: "none", fontSize: "0.9em" }}>{meta}</span>}
+        </h3>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+export function CostRoute() {
+    // --- 1. Spend split ---
+    const splitQ = useQuery({
+        queryKey: ["cost-split"],
+        queryFn: () => api.costSplit(30),
+    });
+    const split = splitQ.data as CostSplitResult | undefined;
+
+    // --- 2. Dispatch candidates ---
+    const dispQ = useQuery({
+        queryKey: ["cost-dispatches-cand"],
+        queryFn: () => api.costDispatches(30, true),
+    });
+    const candidates = dispQ.data as CandidatesResult | undefined;
+
+    // --- 3. Routability ---
+    const routabilityQ = useQuery({
+        queryKey: ["cost-routability"],
+        queryFn: () => api.costRoutability(30, 1),
+    });
+    const routability = routabilityQ.data as RoutabilityResult | undefined;
+
+    // Derived split values
+    const mainCost = split?.rows.filter((r) => r.origin === "main").reduce((s, r) => s + r.cost_usd, 0) ?? 0;
+    const subCost = split?.rows.filter((r) => r.origin === "subagent").reduce((s, r) => s + r.cost_usd, 0) ?? 0;
+    const totalCost = (mainCost + subCost) || 1;
+    const subagentRows = split?.rows.filter((r) => r.origin === "subagent") ?? [];
+    const maxSubCost = Math.max(...subagentRows.map((r) => r.cost_usd), 1);
+
+    return (
+        <section className="panel">
+            <header>
+                <h2>Cost</h2>
+                <span className="meta">30d window</span>
+            </header>
+
+            {/* ======================================================== */}
+            {/* Section 1: Spend split                                    */}
+            {/* ======================================================== */}
+            <SectionHead title="Spend split" />
+
+            {splitQ.isLoading && <p style={{ opacity: 0.5, fontSize: 13 }}>Loading…</p>}
+            {splitQ.error && (
+                <p style={{ color: "var(--red, #bd443b)", fontSize: 13 }}>
+                    {splitQ.error instanceof Error ? splitQ.error.message : "Failed to load"}
+                </p>
+            )}
+            {split && !splitQ.isLoading && (
+                <>
+                    <SplitBar segs={[
+                        { label: "main", value: mainCost, color: "var(--blue, #2567a8)" },
+                        { label: "subagent", value: subCost, color: "var(--rose, #b32650)" },
+                    ]} />
+                    <div style={{ display: "flex", gap: 28, margin: "8px 0 14px", flexWrap: "wrap" }}>
+                        <div>
+                            <div style={{ fontSize: "1.3em", fontWeight: 600 }}>{fmt(mainCost)}</div>
+                            <div className="meta">main ({pct(100 * mainCost / totalCost)})</div>
+                        </div>
+                        <div>
+                            <div style={{ fontSize: "1.3em", fontWeight: 600 }}>{fmt(subCost)}</div>
+                            <div className="meta">subagent ({pct(100 * subCost / totalCost)})</div>
+                        </div>
+                        <div>
+                            <div style={{ fontSize: "1.3em", fontWeight: 600 }}>{fmt(split.totals.cost_usd)}</div>
+                            <div className="meta">total · {split.totals.sessions} sessions</div>
+                        </div>
+                    </div>
+                    {subagentRows.length > 0 && (
+                        <>
+                            <div style={{ fontSize: "0.8em", opacity: 0.6, marginBottom: 4 }}>Subagent by model</div>
+                            {subagentRows.map((r) => (
+                                <BarRow key={r.model}
+                                    label={r.model}
+                                    value={r.cost_usd}
+                                    max={maxSubCost}
+                                    sub={`${fmt(r.cost_usd)} · ${r.sessions} sessions`}
+                                    color="var(--rose, #b32650)" />
+                            ))}
+                        </>
+                    )}
+                    {split.rows.length === 0 && (
+                        <p style={{ opacity: 0.5, fontSize: 13 }}>No cost data in the 30-day window.</p>
+                    )}
+                </>
+            )}
+
+            {/* ======================================================== */}
+            {/* Section 2: Dispatch candidates                            */}
+            {/* ======================================================== */}
+            <SectionHead title="Dispatch candidates" meta="inherit + expensive + routable class" />
+
+            {dispQ.isLoading && <p style={{ opacity: 0.5, fontSize: 13 }}>Loading…</p>}
+            {dispQ.error && (
+                <p style={{ color: "var(--red, #bd443b)", fontSize: 13 }}>
+                    {dispQ.error instanceof Error ? dispQ.error.message : "Failed to load"}
+                </p>
+            )}
+            {candidates && !dispQ.isLoading && (
+                candidates.candidates.length === 0
+                    ? <p style={{ opacity: 0.5, fontSize: 13 }}>No routable dispatch candidates in window.</p>
+                    : (
+                        <>
+                            <div style={{ display: "flex", gap: 24, margin: "4px 0 10px", fontSize: 13, flexWrap: "wrap" }}>
+                                <div><strong>{candidates.candidates.length}</strong> candidates</div>
+                                <div style={{ color: "var(--green, #16845e)" }}>
+                                    est. <strong>{fmt(candidates.total_est_savings_usd)}</strong> savings
+                                </div>
+                            </div>
+                            {candidates.top_classes.length > 0 && (
+                                <div style={{ marginBottom: 8, fontSize: 12, opacity: 0.7 }}>
+                                    Top classes: {candidates.top_classes.map((c) => `${c.classId} (${fmt(c.savings_usd)})`).join(" · ")}
+                                </div>
+                            )}
+                            <div style={{ overflowX: "auto" }}>
+                                <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+                                    <thead>
+                                        <tr>
+                                            {["description", "child model", "suggested", "cost", "est. savings"].map((h) => (
+                                                <th key={h} style={{ textAlign: "left", padding: "2px 8px 2px 0", opacity: 0.6, fontWeight: 500 }}>{h}</th>
+                                            ))}
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {candidates.candidates.slice(0, 15).map((c, i) => (
+                                            <tr key={i}>
+                                                <td style={{ padding: "3px 8px 3px 0", maxWidth: 220, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                                                    {c.description ?? c.agent_type ?? "-"}
+                                                </td>
+                                                <td style={{ padding: "3px 8px 3px 0", fontFamily: "monospace", fontSize: 11 }}>{c.child_model ?? "?"}</td>
+                                                <td style={{ padding: "3px 8px 3px 0", color: "var(--blue, #2567a8)" }}>{c.suggested_model}</td>
+                                                <td style={{ padding: "3px 8px 3px 0" }}>{fmt(c.child_cost_usd)}</td>
+                                                <td style={{ padding: "3px 0", color: "var(--green, #16845e)" }}>{fmt(c.est_savings_usd)}</td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                                {candidates.candidates.length > 15 && (
+                                    <p style={{ fontSize: 12, opacity: 0.5, margin: "4px 0 0" }}>…and {candidates.candidates.length - 15} more</p>
+                                )}
+                            </div>
+                        </>
+                    )
+            )}
+
+            {/* ======================================================== */}
+            {/* Section 3: Main-thread routability                        */}
+            {/* ======================================================== */}
+            <SectionHead title="Main-thread routability" meta="Claude main-agent cost only" />
+
+            {routabilityQ.isLoading && <p style={{ opacity: 0.5, fontSize: 13 }}>Loading…</p>}
+            {routabilityQ.error && (
+                <p style={{ color: "var(--red, #bd443b)", fontSize: 13 }}>
+                    {routabilityQ.error instanceof Error ? routabilityQ.error.message : "Failed to load"}
+                </p>
+            )}
+            {routability && !routabilityQ.isLoading && (
+                routability.mainSpendUsd === 0
+                    ? <p style={{ opacity: 0.5, fontSize: 13 }}>No Claude main-agent spend in window.</p>
+                    : (
+                        <>
+                            <div style={{ display: "flex", gap: 28, margin: "4px 0 10px", flexWrap: "wrap" }}>
+                                <div>
+                                    <div style={{ fontSize: "1.3em", fontWeight: 600 }}>{pct(routability.routablePct)}</div>
+                                    <div className="meta">routable</div>
+                                </div>
+                                <div>
+                                    <div style={{ fontSize: "1.3em", fontWeight: 600, color: "var(--green, #16845e)" }}>{fmt(routability.estSavingsUsd)}</div>
+                                    <div className="meta">est. savings</div>
+                                </div>
+                                <div>
+                                    <div style={{ fontSize: "1.3em", fontWeight: 600 }}>{fmt(routability.mainSpendUsd)}</div>
+                                    <div className="meta">main spend ({routability.days}d)</div>
+                                </div>
+                            </div>
+                            <SplitBar segs={[
+                                { label: "routable", value: routability.routableUsd, color: "var(--gold, #a66d10)" },
+                                { label: "stays main", value: routability.mainSpendUsd - routability.routableUsd, color: "var(--blue, #2567a8)" },
+                            ]} />
+                            {routability.rows.length > 0 && (
+                                <div style={{ overflowX: "auto", marginTop: 8 }}>
+                                    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+                                        <thead>
+                                            <tr>
+                                                {["class", "verdict", "runs", "turns", "main cost", "tier", "est. savings"].map((h) => (
+                                                    <th key={h} style={{ textAlign: "left", padding: "2px 8px 2px 0", opacity: 0.6, fontWeight: 500 }}>{h}</th>
+                                                ))}
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {routability.rows.map((r) => (
+                                                <tr key={r.class}>
+                                                    <td style={{ padding: "3px 8px 3px 0", fontFamily: "monospace" }}>{r.class}</td>
+                                                    <td style={{ padding: "3px 8px 3px 0", color: r.verdict === "routable" ? "var(--gold, #a66d10)" : "var(--muted, #66706b)" }}>{r.verdict}</td>
+                                                    <td style={{ padding: "3px 8px 3px 0" }}>{r.runs}</td>
+                                                    <td style={{ padding: "3px 8px 3px 0" }}>{r.turns}</td>
+                                                    <td style={{ padding: "3px 8px 3px 0" }}>{fmt(r.mainCostUsd)}</td>
+                                                    <td style={{ padding: "3px 8px 3px 0", color: "var(--blue, #2567a8)" }}>{r.tier ?? "-"}</td>
+                                                    <td style={{ padding: "3px 0", color: "var(--green, #16845e)" }}>
+                                                        {r.estSavingsUsd != null ? fmt(r.estSavingsUsd) : "-"}
+                                                    </td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            )}
+                        </>
+                    )
+            )}
+
+            {/* ======================================================== */}
+            {/* Section 4: Routing tuner (interactive)                   */}
+            {/* ======================================================== */}
+            <RoutingTuner />
+        </section>
+    );
+}

--- a/docs/superpowers/plans/2026-06-16-studio-cost-view.md
+++ b/docs/superpowers/plans/2026-06-16-studio-cost-view.md
@@ -1,0 +1,532 @@
+# Studio /cost View + Interactive Routing Tuner - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A studio `/cost` dashboard that measures spend (split / dispatches / routability) and lets the user interactively tune routing regexes against real dispatch history - flag false positives (persisted as class exclusions) and save classes back to `routing-table.json`, which the route-dispatch hook reads live.
+
+**Architecture:** Add `exclude?: string[]` to the shared routing matcher (one change → hook + `ax dispatches --candidates` both honor it). Surface existing cost queries + a live regex backtest + routing-table writes over the Effect HttpApi contract (read = `Schema.Unknown` like `costModels`; writes follow the `skillDecide` POST/DELETE precedent, loopback-gated). A studio `/cost` route renders measure bars + an interactive tuner.
+
+**Tech Stack:** bun ≥1.3, TS strict, effect@beta (`HttpApi*`, `Effect.fn`, `Schema`), bun:test, React 19 (studio).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-studio-cost-view-design.md`
+**Worktree:** `/Users/necmttn/Projects/ax/.claude/worktrees/studio-cost` (branch `feat/studio-cost-view`, deps installed). All paths relative to it. Do NOT push.
+
+---
+
+## File Structure
+- `packages/hooks-sdk/src/routing-table.ts` - add `exclude` to schema + `RoutingClass` + matcher.
+- `packages/hooks-sdk/src/routing-table.test.ts` - exclusion matcher tests.
+- `apps/axctl/src/queries/routing-table-io.ts` - preserve `exclude` on user classes; upsert/remove helpers.
+- `apps/axctl/src/queries/routing-backtest.ts` (new) - pure backtest over dispatch rows.
+- `apps/axctl/src/queries/routing-backtest.test.ts` (new).
+- `packages/lib/src/shared/api-contract.ts` - read + backtest + write endpoints.
+- `apps/axctl/src/dashboard/contract/insights.ts` - read + backtest handlers.
+- `apps/axctl/src/dashboard/contract/routing.ts` (new) - write handlers (loopback-gated) OR add to insights; see Task 5.
+- `apps/studio/src/api.ts` - client methods.
+- `apps/studio/src/routes/cost.tsx` (new) - the view.
+- `apps/studio/src/components/cost-bars.tsx` (new) - studio bar primitive.
+- `apps/studio/src/router.tsx` + the `<Shell>` nav - register + link.
+
+---
+
+## Task 1: `exclude[]` in the shared matcher (highest risk - it's in the live hook path)
+
+**Files:** Modify `packages/hooks-sdk/src/routing-table.ts`; Test `packages/hooks-sdk/src/routing-table.test.ts`.
+
+- [ ] **Step 1: Write the failing tests** - append to `packages/hooks-sdk/src/routing-table.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { matchRoutingTable, type RoutingTableShape } from "./routing-table.ts";
+
+const tbl = (cls: object): RoutingTableShape => ({
+  version: 1,
+  classes: [{ id: "impl", pattern: "^implement", flags: "i", suggest: "sonnet", reason: "impl", ...cls }],
+  agentTypes: {},
+});
+
+describe("matchRoutingTable exclude", () => {
+  it("matches when no exclude", () => {
+    expect(matchRoutingTable(tbl({}), "Implement task 3", null)?.suggest).toBe("sonnet");
+  });
+  it("exclude regex suppresses a match (falls through to null)", () => {
+    const t = tbl({ exclude: ["design"] });
+    expect(matchRoutingTable(t, "Implement the design review", null)).toBeNull();
+  });
+  it("exclude that does not match leaves the class matching", () => {
+    const t = tbl({ exclude: ["zzz"] });
+    expect(matchRoutingTable(t, "Implement task 3", null)?.suggest).toBe("sonnet");
+  });
+  it("invalid exclude regex is ignored (fail-open, still matches)", () => {
+    const t = tbl({ exclude: ["("] }); // invalid regex
+    expect(matchRoutingTable(t, "Implement task 3", null)?.suggest).toBe("sonnet");
+  });
+  it("a later class still matches after an excluded earlier one", () => {
+    const t: RoutingTableShape = {
+      version: 1, agentTypes: {},
+      classes: [
+        { id: "impl", pattern: "^implement", flags: "i", suggest: "sonnet", reason: "i", exclude: ["design"] },
+        { id: "any", pattern: "design", flags: "i", suggest: "haiku", reason: "d" },
+      ],
+    };
+    expect(matchRoutingTable(t, "Implement the design", null)?.suggest).toBe("haiku");
+  });
+});
+```
+
+- [ ] **Step 2: Run - expect FAIL** (`exclude` not honored): `bun test packages/hooks-sdk/src/routing-table.test.ts`
+
+- [ ] **Step 3: Implement.** In `packages/hooks-sdk/src/routing-table.ts`:
+
+(a) Add to `RoutingClassSchema` (after `reason`): `exclude: Schema.optional(Schema.Array(Schema.String)),`
+(b) Add to the `RoutingClass` interface: `readonly exclude?: readonly string[];`
+(c) In `matchRoutingTable`, replace the matched-class `return {...}` block so an exclude can veto it:
+
+```ts
+      try {
+        const re = new RegExp(cls.pattern, cls.flags ?? "");
+        if (re.test(description)) {
+          const excluded = (cls.exclude ?? []).some((ex) => {
+            try { return new RegExp(ex, cls.flags ?? "").test(description); }
+            catch { return false; } // invalid exclude regex → ignore (fail-open)
+          });
+          if (excluded) continue; // false-positive carve-out: skip, try next class
+          return {
+            classId: cls.id,
+            suggest: cls.suggest,
+            reason: cls.reason,
+            source: "description",
+          };
+        }
+      } catch {
+        continue;
+      }
+```
+
+- [ ] **Step 4: Run - expect PASS** (all 5 + existing matcher tests): `bun test packages/hooks-sdk/src/routing-table.test.ts`
+- [ ] **Step 5: Typecheck** `bun run typecheck 2>&1 | rg "routing-table" || echo clean`
+- [ ] **Step 6: Commit** `git add packages/hooks-sdk/src/routing-table.ts packages/hooks-sdk/src/routing-table.test.ts && git commit -m "feat(hooks-sdk): routing-class exclude[] regex carve-out in matchRoutingTable"`
+
+---
+
+## Task 2: Preserve `exclude` + upsert/remove in routing-table-io
+
+**Files:** Modify `apps/axctl/src/queries/routing-table-io.ts`; Test `apps/axctl/src/queries/routing-table-io.test.ts` (append).
+
+- [ ] **Step 1: Read the file first** to see `StoredRoutingClass`, the merge fn, and the save/load fns: `sed -n '1,140p' apps/axctl/src/queries/routing-table-io.ts`. `StoredRoutingClass extends RoutingClass` so it inherits `exclude` automatically - verify the merge spreads the whole class (`{...c, origin}`) so `exclude` survives. If merge reconstructs fields explicitly, add `exclude`.
+
+- [ ] **Step 2: Write failing tests** - append to `routing-table-io.test.ts` (mirror existing test style; use the existing merge/save fn names found in Step 1 - shown here as `mergeRoutingTable`/`upsertUserClass`/`removeUserClass`, RENAME to match the file):
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { upsertUserClass, removeUserClass, type StoredRoutingTable } from "./routing-table-io.ts";
+
+const base: StoredRoutingTable = { version: 1, classes: [], agentTypes: {} };
+
+describe("routing-table-io exclude + upsert/remove", () => {
+  it("upsert adds a user class with exclude preserved", () => {
+    const t = upsertUserClass(base, { id: "issue-n", pattern: "^issue", flags: "i", suggest: "sonnet", reason: "issue", exclude: ["design"] });
+    const c = t.classes.find((x) => x.id === "issue-n");
+    expect(c?.origin).toBe("user");
+    expect(c?.exclude).toEqual(["design"]);
+  });
+  it("upsert replaces an existing user class by id", () => {
+    const t1 = upsertUserClass(base, { id: "x", pattern: "^a", flags: "", suggest: "sonnet", reason: "a" });
+    const t2 = upsertUserClass(t1, { id: "x", pattern: "^b", flags: "", suggest: "haiku", reason: "b", exclude: ["q"] });
+    expect(t2.classes.filter((c) => c.id === "x").length).toBe(1);
+    expect(t2.classes.find((c) => c.id === "x")?.suggest).toBe("haiku");
+    expect(t2.classes.find((c) => c.id === "x")?.exclude).toEqual(["q"]);
+  });
+  it("removeUserClass removes a user class", () => {
+    const t1 = upsertUserClass(base, { id: "x", pattern: "^a", flags: "", suggest: "sonnet", reason: "a" });
+    expect(removeUserClass(t1, "x").classes.find((c) => c.id === "x")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 3: Run - expect FAIL** (`upsertUserClass`/`removeUserClass` not exported): `bun test apps/axctl/src/queries/routing-table-io.test.ts`
+
+- [ ] **Step 4: Implement** in `routing-table-io.ts` - add two pure helpers (place near the existing merge fn; match the real `StoredRoutingTable`/`StoredRoutingClass` type names):
+
+```ts
+/** Upsert a user-origin class by id (replaces same-id, else appends). */
+export function upsertUserClass(
+  table: StoredRoutingTable,
+  cls: Omit<StoredRoutingClass, "origin">,
+): StoredRoutingTable {
+  const next: StoredRoutingClass = { ...cls, origin: "user" };
+  const rest = table.classes.filter((c) => c.id !== cls.id);
+  return { ...table, classes: [...rest, next] };
+}
+
+/** Remove a user-origin class by id. Default classes are not removable. */
+export function removeUserClass(table: StoredRoutingTable, id: string): StoredRoutingTable {
+  return {
+    ...table,
+    classes: table.classes.filter((c) => !(c.id === id && c.origin !== "default")),
+  };
+}
+```
+
+Confirm the merge fn (Step 1) spreads `exclude`; if it whitelists fields, add `exclude`.
+
+- [ ] **Step 5: Run - expect PASS** + typecheck: `bun test apps/axctl/src/queries/routing-table-io.test.ts && bun run typecheck 2>&1 | rg routing-table-io || echo clean`
+- [ ] **Step 6: Commit** `git add apps/axctl/src/queries/routing-table-io.ts apps/axctl/src/queries/routing-table-io.test.ts && git commit -m "feat(routing): upsert/remove user classes + preserve exclude in io"`
+
+---
+
+## Task 3: Pure backtest logic
+
+**Files:** Create `apps/axctl/src/queries/routing-backtest.ts` + `.test.ts`.
+
+Read `apps/axctl/src/queries/dispatch-analytics.ts` first for the dispatch row shape + `reprice`/`MODEL_ALIASES` (now in `./reprice.ts`) so the backtest reprices identically.
+
+- [ ] **Step 1: Write failing test** `apps/axctl/src/queries/routing-backtest.test.ts`:
+
+```ts
+import { describe, expect, it } from "bun:test";
+import { backtestPattern, type BacktestDispatch } from "./routing-backtest.ts";
+
+const d = (description: string, childModel: string, cost: number): BacktestDispatch => ({
+  description, agent_type: "general-purpose", child_model: childModel, child_cost_usd: cost, dispatch_model: "inherit",
+});
+
+const rows: BacktestDispatch[] = [
+  d("Implement task 3", "claude-fable-5", 50),     // matches ^implement, expensive → candidate
+  d("Implement the design review", "claude-fable-5", 40), // matches, but exclude 'design' → excluded
+  d("Fix the build", "claude-fable-5", 30),         // misses ^implement → missed (expensive inherit)
+  d("Implement small", "claude-sonnet-4-6", 5),     // matches but already cheap → matched, ~0 savings
+];
+
+describe("backtestPattern", () => {
+  it("partitions matched / excluded / missed with savings", () => {
+    const r = backtestPattern(rows, { pattern: "^implement", flags: "i", suggest: "sonnet", exclude: ["design"] }, new Map());
+    expect(r.matched.map((m) => m.description)).toContain("Implement task 3");
+    expect(r.excluded.map((m) => m.description)).toContain("Implement the design review");
+    expect(r.missed.map((m) => m.description)).toContain("Fix the build");
+    expect(r.estSavingsUsd).toBeGreaterThan(0);
+  });
+  it("no exclude → nothing excluded", () => {
+    const r = backtestPattern(rows, { pattern: "^implement", flags: "i", suggest: "sonnet" }, new Map());
+    expect(r.excluded.length).toBe(0);
+  });
+  it("invalid pattern → empty matched, all expensive go to missed, no throw", () => {
+    const r = backtestPattern(rows, { pattern: "(", flags: "", suggest: "sonnet" }, new Map());
+    expect(r.matched.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run - expect FAIL.** `bun test apps/axctl/src/queries/routing-backtest.test.ts`
+
+- [ ] **Step 3: Implement** `apps/axctl/src/queries/routing-backtest.ts`:
+
+```ts
+import { reprice, MODEL_ALIASES, type RepriceUsage } from "./reprice.ts";
+import type { ModelPricing } from "../ingest/model-pricing.ts";
+
+const EXPENSIVE_RE = /fable|opus/i;
+
+export interface BacktestDispatch {
+  description: string | null;
+  agent_type: string | null;
+  child_model: string | null;
+  child_cost_usd: number;
+  dispatch_model: string;
+  usage?: RepriceUsage | null; // when present, savings repriced precisely; else 0
+}
+
+export interface BacktestPattern {
+  pattern: string; flags?: string; suggest: string; exclude?: readonly string[];
+}
+export interface BacktestRow { description: string | null; childModel: string | null; costUsd: number; estSavingsUsd: number; }
+export interface BacktestResult {
+  matched: BacktestRow[]; excluded: BacktestRow[]; missed: BacktestRow[];
+  estSavingsUsd: number; matchedCount: number;
+}
+
+export function backtestPattern(
+  rows: ReadonlyArray<BacktestDispatch>,
+  p: BacktestPattern,
+  pricingCatalog: Map<string, ModelPricing>,
+): BacktestResult {
+  let re: RegExp | null = null;
+  try { re = new RegExp(p.pattern, p.flags ?? ""); } catch { re = null; }
+  const excludeRes = (p.exclude ?? []).map((ex) => {
+    try { return new RegExp(ex, p.flags ?? ""); } catch { return null; }
+  }).filter((x): x is RegExp => x !== null);
+
+  const matched: BacktestRow[] = [], excluded: BacktestRow[] = [], missed: BacktestRow[] = [];
+  let estSavingsUsd = 0;
+  const target = MODEL_ALIASES[p.suggest] ?? p.suggest;
+
+  for (const row of rows) {
+    const desc = row.description ?? "";
+    const hit = re ? re.test(desc) : false;
+    const isExpensiveInherit = row.dispatch_model === "inherit" && !!row.child_model && EXPENSIVE_RE.test(row.child_model);
+    const saving = row.usage
+      ? Math.max(0, row.child_cost_usd - Math.min(reprice(row.usage, target, pricingCatalog), row.child_cost_usd))
+      : 0;
+    const out: BacktestRow = { description: row.description, childModel: row.child_model, costUsd: row.child_cost_usd, estSavingsUsd: saving };
+    if (hit && excludeRes.some((ex) => ex.test(desc))) { excluded.push(out); continue; }
+    if (hit) { matched.push(out); estSavingsUsd += saving; continue; }
+    if (isExpensiveInherit) missed.push(out);
+  }
+  return { matched, excluded, missed, estSavingsUsd, matchedCount: matched.length };
+}
+```
+
+- [ ] **Step 4: Run - expect PASS** + typecheck. `bun test apps/axctl/src/queries/routing-backtest.test.ts && bun run typecheck 2>&1 | rg routing-backtest || echo clean`
+- [ ] **Step 5: Commit** `git add apps/axctl/src/queries/routing-backtest.ts apps/axctl/src/queries/routing-backtest.test.ts && git commit -m "feat(routing): pure backtestPattern (matched/excluded/missed + savings)"`
+
+---
+
+## Task 4: Contract endpoints (read + backtest + write)
+
+**Files:** Modify `packages/lib/src/shared/api-contract.ts`.
+
+- [ ] **Step 1: Read** the `InsightsGroup` `costModels` endpoint (~line 363) and the `SkillsGroup` POST/DELETE endpoints (`skillDecide` ~774, `skillDecideClear` DELETE ~792) to mirror request-body + params shapes exactly.
+
+- [ ] **Step 2: Add read + backtest endpoints to `InsightsGroup`** (after `costModels`):
+
+```ts
+        HttpApiEndpoint.get("costSplit", "/api/cost/split", {
+          query: { days: Schema.optionalKey(Schema.Number) },
+          success: Schema.Unknown, error: InternalError,
+        }),
+        HttpApiEndpoint.get("costDispatches", "/api/cost/dispatches", {
+          query: { days: Schema.optionalKey(Schema.Number), candidates: Schema.optionalKey(Schema.Boolean) },
+          success: Schema.Unknown, error: InternalError,
+        }),
+        HttpApiEndpoint.get("costRoutability", "/api/cost/routability", {
+          query: { days: Schema.optionalKey(Schema.Number), minRun: Schema.optionalKey(Schema.Number) },
+          success: Schema.Unknown, error: InternalError,
+        }),
+        HttpApiEndpoint.get("routingTable", "/api/routing/table", {
+          success: Schema.Unknown, error: InternalError,
+        }),
+        HttpApiEndpoint.post("routingBacktest", "/api/routing/backtest", {
+          payload: {
+            pattern: Schema.String, flags: Schema.optionalKey(Schema.String),
+            suggest: Schema.String, exclude: Schema.optionalKey(Schema.Array(Schema.String)),
+            days: Schema.optionalKey(Schema.Number),
+          },
+          success: Schema.Unknown, error: [BadRequestError, InternalError],
+        }),
+```
+
+- [ ] **Step 3: Add write endpoints.** Put them in a new group `RoutingGroup` (cleaner than overloading Insights) OR in InsightsGroup - match the file's grouping style. Group form:
+
+```ts
+export const RoutingGroup = HttpApiGroup.make("routing")
+  .add(
+    HttpApiEndpoint.post("routingUpsertClass", "/api/routing/classes", {
+      payload: {
+        id: Schema.String, pattern: Schema.String, flags: Schema.optionalKey(Schema.String),
+        suggest: Schema.String, reason: Schema.optionalKey(Schema.String),
+        exclude: Schema.optionalKey(Schema.Array(Schema.String)),
+      },
+      success: Schema.Unknown, error: [BadRequestError, InternalError],
+    }),
+    HttpApiEndpoint.del("routingRemoveClass", "/api/routing/classes/:id", {
+      params: { id: Schema.String },
+      success: Schema.Unknown, error: [BadRequestError, InternalError],
+    }),
+  );
+```
+
+Then `.add(RoutingGroup)` to the `AxApi` (`HttpApi.make(...)` list near line 968). (Verify the exact `.del` vs `.delete` builder name from the `skillDecideClear` precedent - use whatever that file uses.)
+
+- [ ] **Step 4: Typecheck the contract** `bun run typecheck 2>&1 | rg "api-contract" || echo clean`
+- [ ] **Step 5: Commit** `git add packages/lib/src/shared/api-contract.ts && git commit -m "feat(contract): cost read + routing backtest/table + class write endpoints"`
+
+---
+
+## Task 5: Dashboard handlers (read + backtest + loopback-gated writes)
+
+**Files:** Modify `apps/axctl/src/dashboard/contract/insights.ts`; create `apps/axctl/src/dashboard/contract/routing.ts`; register the new group where groups are assembled (find via `rg -n "InsightsGroupLive|HttpApiBuilder|\.group\(" apps/axctl/src/dashboard`).
+
+- [ ] **Step 1: Read** `insights.ts` imports + `orInternal`/`asJsonValue` (`./common.ts`) + how groups are registered into the server.
+
+- [ ] **Step 2: Add read + backtest handlers** to `InsightsGroupLive` (after `costModels`). Import `fetchCostSplit` (cost-analytics), `fetchDispatches`/`fetchDispatchCandidates` (dispatch-analytics), `fetchRoutability` (routability), `loadEffectiveRoutingTable` (routing-table-io), `backtestPattern` (routing-backtest), plus the agent_model→pricingCatalog builder (copy the small loop from dispatch-analytics, or extract a helper):
+
+```ts
+.handle("costSplit", ({ query }) =>
+  orInternal(fetchCostSplit({ sinceDays: query.days ?? 30 }).pipe(Effect.map(asJsonValue))))
+.handle("costDispatches", ({ query }) =>
+  orInternal((query.candidates
+    ? fetchDispatchCandidates({ sinceDays: query.days ?? 30 })
+    : fetchDispatches({ sinceDays: query.days ?? 30 })
+  ).pipe(Effect.map(asJsonValue))))
+.handle("costRoutability", ({ query }) =>
+  orInternal(fetchRoutability({ days: query.days ?? 30, minRun: query.minRun ?? 1 }).pipe(Effect.map(asJsonValue))))
+.handle("routingTable", () =>
+  orInternal(loadEffectiveRoutingTable().pipe(Effect.map(asJsonValue))))
+.handle("routingBacktest", ({ payload }) =>
+  orInternal(runRoutingBacktest(payload).pipe(Effect.map(asJsonValue))))
+```
+
+Where `runRoutingBacktest` is an `Effect.fn` you add (in routing-backtest.ts or a dashboard helper): query dispatch history for the window (reuse the SQL/shape `fetchDispatches` uses), build the pricing catalog, call `backtestPattern(rows, payload, catalog)`. Confirm `fetchDispatches`/`fetchDispatchCandidates` input field names against dispatch-analytics.ts.
+
+- [ ] **Step 3: Write handlers** - create `apps/axctl/src/dashboard/contract/routing.ts` (`RoutingGroupLive`), loopback-gated. The handler context exposes the request; gate non-loopback:
+
+```ts
+import { Effect } from "effect";
+import { HttpApiBuilder, HttpServerRequest } from "effect/unstable/httpapi"; // confirm import path from insights.ts
+import { AxApi } from "@ax/lib/shared/api-contract";
+import { BadRequestError } from "@ax/lib/shared/api-contract";
+import { orInternal, asJsonValue } from "./common.ts";
+import { loadStoredRoutingTable, saveRoutingTable, upsertUserClass, removeUserClass } from "../../queries/routing-table-io.ts";
+
+const requireLoopback = Effect.gen(function* () {
+  const req = yield* HttpServerRequest.HttpServerRequest;
+  const host = req.headers["host"] ?? "";
+  const ok = host.startsWith("127.0.0.1") || host.startsWith("localhost") || host.startsWith("[::1]");
+  if (!ok) return yield* Effect.fail(new BadRequestError({ error: "routing writes are loopback-only" }));
+});
+
+function validateRegex(pattern: string, flags?: string): boolean {
+  try { new RegExp(pattern, flags ?? ""); return true; } catch { return false; }
+}
+
+export const RoutingGroupLive = HttpApiBuilder.group(AxApi, "routing", (h) =>
+  h
+    .handle("routingUpsertClass", ({ payload }) =>
+      requireLoopback.pipe(Effect.andThen(
+        !validateRegex(payload.pattern, payload.flags) || (payload.exclude ?? []).some((e) => !validateRegex(e, payload.flags))
+          ? Effect.fail(new BadRequestError({ error: "invalid regex" }))
+          : orInternal(Effect.gen(function* () {
+              const t = yield* loadStoredRoutingTable();
+              const next = upsertUserClass(t, {
+                id: payload.id, pattern: payload.pattern, flags: payload.flags ?? "",
+                suggest: payload.suggest, reason: payload.reason ?? payload.id,
+                ...(payload.exclude ? { exclude: payload.exclude } : {}),
+              });
+              yield* saveRoutingTable(next);
+              return asJsonValue(next);
+            }))
+      )))
+    .handle("routingRemoveClass", ({ params }) =>
+      requireLoopback.pipe(Effect.andThen(orInternal(Effect.gen(function* () {
+        const t = yield* loadStoredRoutingTable();
+        const next = removeUserClass(t, params.id);
+        yield* saveRoutingTable(next);
+        return asJsonValue(next);
+      })))))
+);
+```
+
+(Names `loadStoredRoutingTable`/`saveRoutingTable`/`loadEffectiveRoutingTable` are indicative - use the REAL exports from routing-table-io.ts found in Task 2 Step 1. Confirm the `HttpServerRequest` import + builder names against an existing handler file.)
+
+- [ ] **Step 4: Register `RoutingGroupLive`** in the server's layer assembly (next to `InsightsGroupLive`).
+
+- [ ] **Step 5: Typecheck + dashboard tests** `bun run typecheck 2>&1 | rg "dashboard|insights|routing" | head; bun test apps/axctl/src/dashboard 2>&1 | tail -4`
+- [ ] **Step 6: Commit** `git add apps/axctl/src/dashboard apps/axctl/src/queries/routing-backtest.ts && git commit -m "feat(dashboard): cost reads + routing backtest + loopback-gated class writes"`
+
+---
+
+## Task 6: Studio API client
+
+**Files:** Modify `apps/studio/src/api.ts`.
+
+- [ ] **Step 1: Read** the `costModels` + a POST client method (`skillDecide`/`improveAction`) to mirror `viaContract` request shapes.
+
+- [ ] **Step 2: Add methods** (after `costModels`); import result types from the query modules for casts:
+
+```ts
+costSplit: (days = 30): Promise<unknown> =>
+  viaContract("/api/cost/split", (c) => c.insights.costSplit({ query: { days } })),
+costDispatches: (days = 30, candidates = false): Promise<unknown> =>
+  viaContract("/api/cost/dispatches", (c) => c.insights.costDispatches({ query: { days, candidates } })),
+costRoutability: (days = 30, minRun = 1): Promise<unknown> =>
+  viaContract("/api/cost/routability", (c) => c.insights.costRoutability({ query: { days, minRun } })),
+routingTable: (): Promise<unknown> =>
+  viaContract("/api/routing/table", (c) => c.insights.routingTable()),
+routingBacktest: (body: { pattern: string; flags?: string; suggest: string; exclude?: string[]; days?: number }): Promise<unknown> =>
+  viaContract("/api/routing/backtest", (c) => c.insights.routingBacktest({ payload: body })),
+routingUpsertClass: (body: { id: string; pattern: string; flags?: string; suggest: string; reason?: string; exclude?: string[] }): Promise<unknown> =>
+  viaContract("/api/routing/classes", (c) => c.routing.routingUpsertClass({ payload: body })),
+routingRemoveClass: (id: string): Promise<unknown> =>
+  viaContract(`/api/routing/classes/${encodeURIComponent(id)}`, (c) => c.routing.routingRemoveClass({ params: { id } })),
+```
+
+(Adjust `c.routing.*` to the actual generated client group accessor. Tighten `unknown` to the real result types where cheap.)
+
+- [ ] **Step 3: Typecheck** `bun run typecheck 2>&1 | rg "studio/src/api" || echo clean`
+- [ ] **Step 4: Commit** `git add apps/studio/src/api.ts && git commit -m "feat(studio): api client for cost + routing tuner endpoints"`
+
+---
+
+## Task 7: Studio `/cost` route - measure bars + interactive tuner
+
+**Files:** Create `apps/studio/src/components/cost-bars.tsx` + `apps/studio/src/routes/cost.tsx`.
+
+- [ ] **Step 1: Read** `apps/studio/src/routes/usage.tsx` (panel/useQuery/loading/error pattern) + an existing studio mutation component (a skill-decide button) for the write+refetch pattern, and the studio CSS class conventions (`panel`, `meta`, `badge`).
+
+- [ ] **Step 2: Build `cost-bars.tsx`** - a small presentational bar primitive (no data fetching):
+
+```tsx
+export function SplitBar({ segs }: { segs: { label: string; value: number; tone: "ink" | "green" }[] }) {
+  const total = segs.reduce((s, x) => s + x.value, 0) || 1;
+  return (
+    <div className="cost-splitbar" style={{ display: "flex", width: "100%", height: 28 }}>
+      {segs.map((s) => (
+        <div key={s.label} title={`${s.label} ${(100 * s.value / total).toFixed(1)}%`}
+          style={{ width: `${(100 * s.value / total).toFixed(2)}%`, background: s.tone === "green" ? "var(--ax-green, #2f9e44)" : "var(--ax-ink, #222)" }} />
+      ))}
+    </div>
+  );
+}
+export function BarRow({ label, value, max, sub }: { label: string; value: number; max: number; sub?: string }) {
+  return (
+    <div className="cost-bar-row" style={{ margin: "6px 0" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13 }}><span>{label}</span><span>{sub}</span></div>
+      <div style={{ height: 8, background: "var(--ax-line,#eee)" }}>
+        <div style={{ width: `${Math.max(2, (100 * value / (max || 1))).toFixed(1)}%`, height: 8, background: "var(--ax-ink,#222)" }} />
+      </div>
+    </div>
+  );
+}
+```
+
+(Use the real studio CSS tokens/classes found in Step 1; keep inline styles minimal or move to studio CSS.)
+
+- [ ] **Step 3: Build `cost.tsx`** - `CostRoute` with `useQuery` per section (split/dispatches/routability/routingTable) and the tuner. The tuner: controlled `pattern`/`suggest`/`exclude[]` state, a debounced `api.routingBacktest(...)` call rendering matched (green, $ saved) / missed / excluded; a "flag false positive" button on a matched row that pushes a token from its description into `exclude`; a Save button → `api.routingUpsertClass(...)` then refetch `routingTable` + `costDispatches`. Guard the whole tuner behind `api.isLive()` (writes need the daemon). Loading/error/empty states like `UsageRoute`. Keep it one focused component; extract sub-parts if it grows past ~250 lines.
+
+  Write it to compile + render with real data; exact JSX is the implementer's craft, but it MUST: (a) call all 4 read endpoints, (b) call backtest on edit (debounced), (c) call upsert/remove and refetch, (d) degrade when `!api.isLive()`.
+
+- [ ] **Step 4: Verify it builds** `cd apps/studio && bun run typecheck 2>&1 | rg "cost.tsx|cost-bars" || echo clean` (studio typecheck; from repo root if studio has no own script).
+- [ ] **Step 5: Commit** `git add apps/studio/src/routes/cost.tsx apps/studio/src/components/cost-bars.tsx && git commit -m "feat(studio): /cost view - spend bars + interactive routing tuner"`
+
+---
+
+## Task 8: Register route + nav
+
+**Files:** Modify `apps/studio/src/router.tsx` + the `<Shell>` nav component.
+
+- [ ] **Step 1: Add the route** in `router.tsx` (mirror `usageRoute`):
+
+```ts
+import { CostRoute } from "./routes/cost.tsx";
+const costRoute = createRoute({ getParentRoute: () => rootRoute, path: "/cost", component: CostRoute });
+```
+Add `costRoute` to the `rootRoute.addChildren([...])` / route tree array (find where `usageRoute` is added).
+
+- [ ] **Step 2: Add nav link.** Find `<Shell>` (`rg -n "Shell" apps/studio/src/*.tsx apps/studio/src/components/*.tsx`); add a `<Link to="/cost">Cost</Link>` next to the Usage link.
+
+- [ ] **Step 3: Build studio + verify** `cd apps/studio && bun run build:web 2>&1 | tail -5` (or the staged build); fix any route-tree type errors.
+- [ ] **Step 4: Commit** `git add apps/studio/src/router.tsx apps/studio/src/components && git commit -m "feat(studio): register /cost route + nav link"`
+
+---
+
+## Final verification
+- [ ] `bun test` (repo) - hooks-sdk matcher, io, backtest, dashboard handlers green; no new failures.
+- [ ] `bun run typecheck` - no NEW errors in touched packages (note studio's pre-existing baseline).
+- [ ] Live: `ax serve` running (LaunchAgent) + `cd apps/studio && bun run dev`; open `/cost` via cmux against the local DB. Confirm: split bar ≈ `ax cost split`; edit a pattern → live matches; flag an FP → moves to excluded; Save → `ax routing show` reflects the new user class with `exclude`; `ax dispatches --candidates` still correct.
+- [ ] `ax dispatches --candidates` regression check WITH an exclude present (shared matcher).
+- [ ] Do NOT push / PR until asked.
+
+## Self-Review
+- **Spec coverage:** exclude mechanism (T1) ✓; io preserve+upsert/remove (T2) ✓; backtest (T3) ✓; read+backtest+write contract (T4) ✓; handlers incl loopback gate (T5) ✓; client (T6) ✓; /cost measure+tuner UI (T7) ✓; route+nav (T8) ✓; fail-open regex (T1/T3) ✓; localhost-only writes (T5) ✓; not-live degrade (T7) ✓. Phase 3 (showcases+screenshot+article) intentionally out of this plan.
+- **Type consistency:** `exclude?: readonly string[]` consistent T1→T2; `BacktestPattern`/`BacktestResult` T3 used by T5; client method names T6 match contract endpoint ids T4. Indicative io fn names flagged "use real exports" where the file wasn't fully read.
+- **Placeholders:** DB-touching/import-path specifics are flagged "confirm against <file>" (existing symbols that must be read, not invented) rather than guessed - deliberate; pure-logic tasks (T1–T3) carry complete code + tests.

--- a/docs/superpowers/specs/2026-06-16-studio-cost-view-design.md
+++ b/docs/superpowers/specs/2026-06-16-studio-cost-view-design.md
@@ -1,140 +1,144 @@
-# Studio cost view - `/cost` dashboard
+# Studio cost view + interactive routing tuner - `/cost`
 
 Date: 2026-06-16
 Status: design (pre-implementation)
 Branch: feat/studio-cost-view
-Follows: the Effect HttpApi insights contract (`packages/lib/src/shared/api-contract.ts`
-`InsightsGroup`, `costModels` is the precedent), the cost query layer
-(`fetchCostSplit`, `fetchDispatches`/`fetchDispatchCandidates`, `fetchRoutability`),
-studio routing (`apps/studio/src/router.tsx` + `<Shell>` nav).
+Follows: the Effect HttpApi insights contract (`packages/lib/src/shared/api-contract.ts`),
+the cost query layer (`fetchCostSplit`, `fetchDispatches`/`fetchDispatchCandidates`,
+`fetchRoutability`), the shared routing matcher (`packages/hooks-sdk/src/routing-table.ts`
+`matchRoutingTable`) + stored-table io (`apps/axctl/src/queries/routing-table-io.ts`),
+studio routing (`apps/studio/src/router.tsx` + `<Shell>`).
 
 ## Problem
 
-The blog article's signature visuals (main-vs-subagent split, per-model bars, dispatch
-candidates, the routability lens) live only in the CLI + the article's hand-built figures.
-Studio - the live dashboard - has **no cost view**; its only spend-adjacent route is
-`/usage` (command utilization, not $). There's nothing to screenshot as "the live product"
-for cost, and a user who installs ax can't *see* their bill broken down in the dashboard.
+Routing is regex at its core: routing classes are regex patterns on the dispatch description
+(`^implement`, `^Fix\s`, `^issue\s+\d+\b`) → a cheaper model; `ax routing tune` mines new
+regexes; the judgment guard + routability classifier are regex too. But tuning is blind: you
+edit a pattern, run `ax routing tune --emit-brief`, an agent backtests it, you apply IDs. No
+live "what does this pattern actually catch?", and the false-positive problem (a class regex
+that also matches judgment work) is only caught by that slow brief loop.
 
-This adds a `/cost` studio route backed by the existing cost queries, exposed over the
-dashboard HTTP API. v1 scope (user-chosen): **split + dispatches + routability**.
+Meanwhile studio has no cost view at all (only `/usage`, command utilization). This builds one
+`/cost` dashboard that does both halves:
+- **Measure** (read-only): the spend split, dispatch candidates, and main-thread routability.
+- **Tune** (interactive): a regex playground over your real dispatch history - edit a class
+  pattern, see matches vs misses + est savings live, flag false positives (→ persisted
+  exclusions), add/edit/remove classes, all written back to `~/.ax/hooks/routing-table.json`
+  which the route-dispatch hook reads live.
+
+v1 scope (user-chosen): full interactive incl. save-to-table, combined into one `/cost` view.
 
 ## Non-goals
 
-- No new analytics. Pure surfacing of `fetchCostSplit` / `fetchDispatchCandidates` /
-  `fetchRoutability` (already built + tested) through the dashboard API into studio.
-- No curated payload schemas. Mirror `costModels` (`success: Schema.Unknown`) - these are
-  read-only display payloads; the query fns own the shape. (A later tightening pass can add
-  schemas, same as the rest of the insights surface.)
-- Not the article embed. The `/showcases` update + screenshot into the post is Phase 3,
-  separate.
+- No new spend analytics - surfaces existing query fns. No new mining algorithm (the live
+  backtest reuses the candidate/repricing logic; `ax routing tune`'s clustering stays CLI).
+- Measure payloads stay `Schema.Unknown` (mirror `costModels`); the query fns own the shape.
 
-## Architecture (mirror `costModels` × 3)
+## New cross-cutting piece: routing-class exclusions
 
-### 1. Contract - `packages/lib/src/shared/api-contract.ts` `InsightsGroup`
+`RoutingClass` gains `exclude?: readonly string[]` (regex strings). In `matchRoutingTable`:
+after a class's `pattern` (or agentType) matches, if ANY `exclude` regex matches the
+description, the class does **not** route down (treated as no-match / falls through). This is
+the persistent false-positive mechanism, and because the hook fire-path and
+`ax dispatches --candidates` both call `matchRoutingTable`, exclusions take effect everywhere
+with one change. Touch points:
+- `packages/hooks-sdk/src/routing-table.ts`: add `exclude` to the schema + `RoutingClass` +
+  matcher logic (compile each exclude once; invalid regex → ignore that entry, never throw -
+  fail-open like the rest of the hook).
+- `routing-table-io.ts`: preserve `exclude` on user classes through merge/compile/save.
+- Defaults (`ROUTING_CLASSES`) may omit `exclude` (optional); user/tuned classes carry it.
 
-Add three GET endpoints (alongside `costModels`):
+## API (contract + handlers)
 
-```ts
-HttpApiEndpoint.get("costSplit", "/api/cost/split", {
-  query: { days: Schema.optionalKey(Schema.Number) },
-  success: Schema.Unknown, error: InternalError,
-}),
-HttpApiEndpoint.get("costDispatches", "/api/cost/dispatches", {
-  query: {
-    days: Schema.optionalKey(Schema.Number),
-    candidates: Schema.optionalKey(Schema.Boolean),
-  },
-  success: Schema.Unknown, error: InternalError,
-}),
-HttpApiEndpoint.get("costRoutability", "/api/cost/routability", {
-  query: {
-    days: Schema.optionalKey(Schema.Number),
-    minRun: Schema.optionalKey(Schema.Number),
-  },
-  success: Schema.Unknown, error: InternalError,
-}),
-```
+### Read endpoints - `InsightsGroup` (mirror `costModels`, `success: Schema.Unknown`)
+- `GET /api/cost/split?days` → `fetchCostSplit({sinceDays})`
+- `GET /api/cost/dispatches?days&candidates` → `fetchDispatches` / `fetchDispatchCandidates`
+- `GET /api/cost/routability?days&minRun` → `fetchRoutability`
+- `GET /api/routing/table` → the effective stored table (classes w/ origin + agentTypes +
+  exclude) for the tuner list.
 
-### 2. Handlers - `apps/axctl/src/dashboard/contract/insights.ts`
+### Backtest endpoint (read, but takes a candidate class)
+- `POST /api/routing/backtest` body `{pattern, suggest, agentType?, exclude?: string[], days}`
+  → over dispatch history: `matched` (dispatches the pattern catches, with child_cost +
+  est savings repriced to `suggest`, minus those killed by `exclude`), `excluded` (matches
+  the exclude removed), `missed` (expensive inherit dispatches the pattern does NOT catch -
+  candidates for widening). Reuses the candidate/repricing path with an ad-hoc one-class table.
+  POST (not GET) so `exclude[]` rides a JSON body cleanly. Read-only (no write).
 
-```ts
-.handle("costSplit", ({ query }) =>
-  orInternal(fetchCostSplit({ sinceDays: query.days ?? 30 }).pipe(Effect.map(asJsonValue))))
-.handle("costDispatches", ({ query }) =>
-  orInternal((query.candidates
-    ? fetchDispatchCandidates({ sinceDays: query.days ?? 30 })
-    : fetchDispatches({ sinceDays: query.days ?? 30 })
-  ).pipe(Effect.map(asJsonValue))))
-.handle("costRoutability", ({ query }) =>
-  orInternal(fetchRoutability({ days: query.days ?? 30, minRun: query.minRun ?? 1 })
-    .pipe(Effect.map(asJsonValue))))
-```
+### Write endpoints (follow `skillDecide`/`improveAction` POST precedent; localhost-bound)
+- `POST /api/routing/classes` body `{id, pattern, suggest, agentType?, exclude?: string[]}` -
+  upsert a `user`-origin class into routing-table.json via the merge-preserving compile/save
+  logic (refuses to clobber a corrupt file, same as `ax routing compile`). Validate regex
+  before write (400 on invalid pattern/exclude).
+- `DELETE /api/routing/classes/:id` - remove a `user` class (default classes are not
+  deletable; return 400/409). 
+- Writes go through `routing-table-io` save (single source of truth), so the CLI + hook + UI
+  all agree. The route-dispatch hook re-reads the file at fire time → edits are live.
 
-Import the three fns (`cost-analytics.ts`, `dispatch-analytics.ts`, `routability.ts`).
-Verify the exact `fetchDispatches`/`fetchDispatchCandidates` input field names at build time.
+## Studio `/cost` view (`apps/studio/src/routes/cost.tsx`)
 
-### 3. Studio client - `apps/studio/src/api.ts`
+`useQuery` per section (mirror `UsageRoute`'s panel/loading/error). Sections:
 
-Three `viaContract` methods mirroring `costModels`:
+1. **Spend split** - proportional stacked bar (main vs subagent of total) + per-model bars
+   (cost-weighted, fable peak). Native studio bar primitive (do NOT import the site blog kit).
+2. **Dispatch candidates** - table/bars of inherit+expensive dispatches matching a route-down
+   class, suggested model + est savings.
+3. **Main-thread routability** - routable-class rollup + est savings.
+4. **Routing tuner** (the interactive half):
+   - List current classes (default vs user, each with pattern/suggest/exclude).
+   - A pattern editor: type/edit `pattern` + `suggest` (+ optional agentType); debounced
+     `POST /api/routing/backtest` shows **matched** dispatches (green, with $ saved),
+     **missed** expensive ones, running est savings. Live regex feedback (invalid pattern →
+     inline error, no crash).
+   - **Flag false positive**: click a wrong match → its description seeds an `exclude` entry;
+     re-backtest shows it moved to `excluded`. Exclusions editable as a list.
+   - **Save**: `POST /api/routing/classes` (upsert) or `DELETE` (remove user class).
+     Optimistic refresh of the table + candidates.
+   - A mutation confirms with a toast + shows the equivalent CLI (`ax routing ...`) for
+     transparency.
 
-```ts
-costSplit: (days = 30): Promise<CostSplitResult> =>
-  viaContract("/api/cost/split", (c) => c.insights.costSplit({ query: { days } })) as ...,
-costDispatches: (days = 30, candidates = false): Promise<...> =>
-  viaContract("/api/cost/dispatches", (c) => c.insights.costDispatches({ query: { days, candidates } })) as ...,
-costRoutability: (days = 30, minRun = 1): Promise<RoutabilityResult> =>
-  viaContract("/api/cost/routability", (c) => c.insights.costRoutability({ query: { days, minRun } })) as ...,
-```
-
-Reuse the query result types (`CostSplitResult`, `RoutabilityResult`, dispatch types) imported
-from the query modules for the casts.
-
-### 4. Studio route - `apps/studio/src/routes/cost.tsx` (`/cost`)
-
-`CostRoute` component (mirror `UsageRoute`'s `useQuery` + `panel` shape), three sections:
-- **Spend split** - a proportional stacked bar (main vs subagent of total) + per-model bars
-  (cost-weighted, fable peak). The article's hero visual, native in studio styling.
-- **Dispatch candidates** - table/bars of inherit+expensive dispatches matching a route-down
-  class, with suggested model + est savings (from `costDispatches({candidates:true})`).
-- **Main-thread routability** - the routable-class rollup + est savings bars (from
-  `costRoutability`).
-Small shared bar primitive in studio (studio owns its CSS; do NOT import the site's
-`bk-*` blog kit - separate app). Light empty/loading/error states like `UsageRoute`.
-
-### 5. Register + nav
-
-`router.tsx`: add `costRoute` (`getParentRoute: () => rootRoute, path: "/cost"`) to the route
-tree. Add a `/cost` link to the `<Shell>` nav (find the nav in the Shell component).
+### Register + nav
+`router.tsx`: add `costRoute` (`path: "/cost"`). Add a `/cost` link to `<Shell>` nav.
 
 ## Testing
-
-- Contract/handler: the dashboard contract has a wiring test pattern - add coverage that the
-  three endpoints resolve (or at least typecheck into the group). Follow existing insights
-  handler test precedent if present.
-- Pure query fns are already unit-tested (cost-analytics, routability). No new query logic.
-- studio render: a light smoke if the studio test harness supports it; else rely on the live
-  cmux screenshot for verification.
+- **Exclusion matcher** (hooks-sdk): unit tests - class matches, exclude kills it, invalid
+  exclude ignored, no exclude = unchanged. This is the highest-risk logic (touches the live
+  hook) → exhaustive.
+- **io merge**: exclude preserved on user classes across compile/merge/save.
+- **Backtest**: pure repricing/match over a fixture dispatch set → matched/excluded/missed
+  partition + savings math.
+- **Write handlers**: upsert + delete round-trip through routing-table-io (temp file), invalid
+  regex → 400, default class not deletable.
+- studio render: light smoke if harness supports; else cmux live verification.
 
 ## Verification
+- `bun test` (hooks-sdk matcher, io, backtest, handlers) + `bun run typecheck` green for
+  touched packages.
+- `ax dispatches --candidates` still correct WITH an exclude present (regression - the shared
+  matcher now skips excluded).
+- Live: `ax serve` + studio dev, open `/cost` via cmux against the local DB; edit a pattern,
+  watch matches; flag an FP; save; confirm routing-table.json updated and `ax routing show`
+  reflects it. Screenshot for the article.
 
-- `bun run typecheck` (repo) green for the touched packages (lib/axctl/studio); baseline noise
-  excluded.
-- `bun test` for axctl dashboard + lib contract.
-- Build studio (`stage-studio.ts` or studio's `build:web`); run `ax serve` + studio dev,
-  open `/cost` via cmux against the live local DB, screenshot. mainSpend etc. should match
-  `ax cost split` / `ax cost routability`.
+## Safety
+- Dashboard binds 127.0.0.1 by default - write endpoints are local-only (same trust boundary
+  as the CLI writing the file). Note: with `AX_SERVE_HOST=0.0.0.0` the write surface is
+  exposed on the LAN; gate the routing write endpoints behind a localhost check (or a
+  capability flag) so 0.0.0.0 exposure stays read-only. Decide at build: simplest is reject
+  routing writes when the request isn't from loopback.
+- All regex compiled in try/catch; invalid never throws into the hook path.
+- routing-table-io already refuses to overwrite a corrupt file.
 
 ## Phase 3 (separate, after this lands)
-
-- Update `/showcases` to reference/show the studio cost view.
-- Screenshot the live `/cost` view; embed as a `<Figure>` in the routing-tune blog post.
+- Update `/showcases` to reference the studio cost+tuner view.
+- Screenshot the live `/cost` view (measure + tuner); embed as a `<Figure>` in the
+  routing-tune blog post.
 
 ## Risks
-
-- `viaContract` returns the typed contract result but `success: Schema.Unknown` means the
-  client casts - same trade-off the rest of the insights surface already makes (acceptable;
-  the query types carry the real shape).
-- studio bundles ship to the hosted studio (`stage-studio.ts` → site). Keep the new route
-  code-split-friendly; verify the staged build still works (the blog PR's CF build is the
-  precedent gate).
+- Biggest: the exclusion change touches the live route-dispatch hook matcher. Fail-open +
+  exhaustive matcher tests are mandatory.
+- `viaContract` casts the `Schema.Unknown` measure payloads (same trade-off as the rest of the
+  insights surface).
+- Studio bundles ship to hosted studio via `stage-studio.ts`; the write endpoints are daemon
+  (local) only - hosted studio simply won't have a daemon to write to (read parts degrade,
+  tuner save disabled when `api.isLive()` is false). Handle the not-live case in the UI.

--- a/docs/superpowers/specs/2026-06-16-studio-cost-view-design.md
+++ b/docs/superpowers/specs/2026-06-16-studio-cost-view-design.md
@@ -1,0 +1,140 @@
+# Studio cost view - `/cost` dashboard
+
+Date: 2026-06-16
+Status: design (pre-implementation)
+Branch: feat/studio-cost-view
+Follows: the Effect HttpApi insights contract (`packages/lib/src/shared/api-contract.ts`
+`InsightsGroup`, `costModels` is the precedent), the cost query layer
+(`fetchCostSplit`, `fetchDispatches`/`fetchDispatchCandidates`, `fetchRoutability`),
+studio routing (`apps/studio/src/router.tsx` + `<Shell>` nav).
+
+## Problem
+
+The blog article's signature visuals (main-vs-subagent split, per-model bars, dispatch
+candidates, the routability lens) live only in the CLI + the article's hand-built figures.
+Studio - the live dashboard - has **no cost view**; its only spend-adjacent route is
+`/usage` (command utilization, not $). There's nothing to screenshot as "the live product"
+for cost, and a user who installs ax can't *see* their bill broken down in the dashboard.
+
+This adds a `/cost` studio route backed by the existing cost queries, exposed over the
+dashboard HTTP API. v1 scope (user-chosen): **split + dispatches + routability**.
+
+## Non-goals
+
+- No new analytics. Pure surfacing of `fetchCostSplit` / `fetchDispatchCandidates` /
+  `fetchRoutability` (already built + tested) through the dashboard API into studio.
+- No curated payload schemas. Mirror `costModels` (`success: Schema.Unknown`) - these are
+  read-only display payloads; the query fns own the shape. (A later tightening pass can add
+  schemas, same as the rest of the insights surface.)
+- Not the article embed. The `/showcases` update + screenshot into the post is Phase 3,
+  separate.
+
+## Architecture (mirror `costModels` × 3)
+
+### 1. Contract - `packages/lib/src/shared/api-contract.ts` `InsightsGroup`
+
+Add three GET endpoints (alongside `costModels`):
+
+```ts
+HttpApiEndpoint.get("costSplit", "/api/cost/split", {
+  query: { days: Schema.optionalKey(Schema.Number) },
+  success: Schema.Unknown, error: InternalError,
+}),
+HttpApiEndpoint.get("costDispatches", "/api/cost/dispatches", {
+  query: {
+    days: Schema.optionalKey(Schema.Number),
+    candidates: Schema.optionalKey(Schema.Boolean),
+  },
+  success: Schema.Unknown, error: InternalError,
+}),
+HttpApiEndpoint.get("costRoutability", "/api/cost/routability", {
+  query: {
+    days: Schema.optionalKey(Schema.Number),
+    minRun: Schema.optionalKey(Schema.Number),
+  },
+  success: Schema.Unknown, error: InternalError,
+}),
+```
+
+### 2. Handlers - `apps/axctl/src/dashboard/contract/insights.ts`
+
+```ts
+.handle("costSplit", ({ query }) =>
+  orInternal(fetchCostSplit({ sinceDays: query.days ?? 30 }).pipe(Effect.map(asJsonValue))))
+.handle("costDispatches", ({ query }) =>
+  orInternal((query.candidates
+    ? fetchDispatchCandidates({ sinceDays: query.days ?? 30 })
+    : fetchDispatches({ sinceDays: query.days ?? 30 })
+  ).pipe(Effect.map(asJsonValue))))
+.handle("costRoutability", ({ query }) =>
+  orInternal(fetchRoutability({ days: query.days ?? 30, minRun: query.minRun ?? 1 })
+    .pipe(Effect.map(asJsonValue))))
+```
+
+Import the three fns (`cost-analytics.ts`, `dispatch-analytics.ts`, `routability.ts`).
+Verify the exact `fetchDispatches`/`fetchDispatchCandidates` input field names at build time.
+
+### 3. Studio client - `apps/studio/src/api.ts`
+
+Three `viaContract` methods mirroring `costModels`:
+
+```ts
+costSplit: (days = 30): Promise<CostSplitResult> =>
+  viaContract("/api/cost/split", (c) => c.insights.costSplit({ query: { days } })) as ...,
+costDispatches: (days = 30, candidates = false): Promise<...> =>
+  viaContract("/api/cost/dispatches", (c) => c.insights.costDispatches({ query: { days, candidates } })) as ...,
+costRoutability: (days = 30, minRun = 1): Promise<RoutabilityResult> =>
+  viaContract("/api/cost/routability", (c) => c.insights.costRoutability({ query: { days, minRun } })) as ...,
+```
+
+Reuse the query result types (`CostSplitResult`, `RoutabilityResult`, dispatch types) imported
+from the query modules for the casts.
+
+### 4. Studio route - `apps/studio/src/routes/cost.tsx` (`/cost`)
+
+`CostRoute` component (mirror `UsageRoute`'s `useQuery` + `panel` shape), three sections:
+- **Spend split** - a proportional stacked bar (main vs subagent of total) + per-model bars
+  (cost-weighted, fable peak). The article's hero visual, native in studio styling.
+- **Dispatch candidates** - table/bars of inherit+expensive dispatches matching a route-down
+  class, with suggested model + est savings (from `costDispatches({candidates:true})`).
+- **Main-thread routability** - the routable-class rollup + est savings bars (from
+  `costRoutability`).
+Small shared bar primitive in studio (studio owns its CSS; do NOT import the site's
+`bk-*` blog kit - separate app). Light empty/loading/error states like `UsageRoute`.
+
+### 5. Register + nav
+
+`router.tsx`: add `costRoute` (`getParentRoute: () => rootRoute, path: "/cost"`) to the route
+tree. Add a `/cost` link to the `<Shell>` nav (find the nav in the Shell component).
+
+## Testing
+
+- Contract/handler: the dashboard contract has a wiring test pattern - add coverage that the
+  three endpoints resolve (or at least typecheck into the group). Follow existing insights
+  handler test precedent if present.
+- Pure query fns are already unit-tested (cost-analytics, routability). No new query logic.
+- studio render: a light smoke if the studio test harness supports it; else rely on the live
+  cmux screenshot for verification.
+
+## Verification
+
+- `bun run typecheck` (repo) green for the touched packages (lib/axctl/studio); baseline noise
+  excluded.
+- `bun test` for axctl dashboard + lib contract.
+- Build studio (`stage-studio.ts` or studio's `build:web`); run `ax serve` + studio dev,
+  open `/cost` via cmux against the live local DB, screenshot. mainSpend etc. should match
+  `ax cost split` / `ax cost routability`.
+
+## Phase 3 (separate, after this lands)
+
+- Update `/showcases` to reference/show the studio cost view.
+- Screenshot the live `/cost` view; embed as a `<Figure>` in the routing-tune blog post.
+
+## Risks
+
+- `viaContract` returns the typed contract result but `success: Schema.Unknown` means the
+  client casts - same trade-off the rest of the insights surface already makes (acceptable;
+  the query types carry the real shape).
+- studio bundles ship to the hosted studio (`stage-studio.ts` → site). Keep the new route
+  code-split-friendly; verify the staged build still works (the blog PR's CF build is the
+  precedent gate).

--- a/packages/hooks-sdk/src/routing-table.test.ts
+++ b/packages/hooks-sdk/src/routing-table.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import { Result, Schema } from "effect";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -10,6 +10,7 @@ import {
   matchRoutingTable,
   parseStoredRoutingTable,
   readRoutingTableSync,
+  type RoutingTableShape,
 } from "./routing-table.ts";
 
 const tmp = (): string => mkdtempSync(join(tmpdir(), "ax-routing-table-"));
@@ -206,5 +207,40 @@ describe("matchRoutingTable", () => {
       ],
     };
     expect(matchRoutingTable(table, "ship it", null)?.classId).toBe("good");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchRoutingTable exclude[] carve-out
+// ---------------------------------------------------------------------------
+
+const tbl = (cls: object): RoutingTableShape => ({
+  version: 1,
+  classes: [{ id: "impl", pattern: "^implement", flags: "i", suggest: "sonnet", reason: "impl", ...cls }],
+  agentTypes: {},
+});
+
+describe("matchRoutingTable exclude", () => {
+  it("matches when no exclude", () => {
+    expect(matchRoutingTable(tbl({}), "Implement task 3", null)?.suggest).toBe("sonnet");
+  });
+  it("exclude regex suppresses a match (falls through to null)", () => {
+    expect(matchRoutingTable(tbl({ exclude: ["design"] }), "Implement the design review", null)).toBeNull();
+  });
+  it("exclude that does not match leaves the class matching", () => {
+    expect(matchRoutingTable(tbl({ exclude: ["zzz"] }), "Implement task 3", null)?.suggest).toBe("sonnet");
+  });
+  it("invalid exclude regex is ignored (fail-open, still matches)", () => {
+    expect(matchRoutingTable(tbl({ exclude: ["("] }), "Implement task 3", null)?.suggest).toBe("sonnet");
+  });
+  it("a later class still matches after an excluded earlier one", () => {
+    const t: RoutingTableShape = {
+      version: 1, agentTypes: {},
+      classes: [
+        { id: "impl", pattern: "^implement", flags: "i", suggest: "sonnet", reason: "i", exclude: ["design"] },
+        { id: "any", pattern: "design", flags: "i", suggest: "haiku", reason: "d" },
+      ],
+    };
+    expect(matchRoutingTable(t, "Implement the design", null)?.suggest).toBe("haiku");
   });
 });

--- a/packages/hooks-sdk/src/routing-table.ts
+++ b/packages/hooks-sdk/src/routing-table.ts
@@ -44,6 +44,10 @@ export const RoutingClassSchema = Schema.Struct({
   // unknown value must not fail the whole-table decode (which would silently
   // revert the user's routing table to the built-in defaults).
   origin: Schema.optional(Schema.String),
+  // Optional list of regex strings: if ANY exclude matches the description,
+  // the class is skipped (false-positive carve-out). Invalid exclude regexes
+  // are silently ignored (fail-open).
+  exclude: Schema.optional(Schema.Array(Schema.String)),
 });
 
 /**
@@ -87,6 +91,7 @@ export interface RoutingClass {
   readonly flags: string;
   readonly suggest: string; // "sonnet" | "haiku"
   readonly reason: string;
+  readonly exclude?: readonly string[];
 }
 
 export interface RoutingTable {
@@ -154,6 +159,11 @@ export const matchRoutingTable = (
       try {
         const re = new RegExp(cls.pattern, cls.flags ?? "");
         if (re.test(description)) {
+          const excluded = (cls.exclude ?? []).some((ex) => {
+            try { return new RegExp(ex, cls.flags ?? "").test(description); }
+            catch { return false; } // invalid exclude regex → ignore (fail-open)
+          });
+          if (excluded) continue; // false-positive carve-out: skip, try next class
           return {
             classId: cls.id,
             suggest: cls.suggest,

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -364,6 +364,42 @@ export const InsightsGroup = HttpApiGroup.make("insights")
             success: Schema.Unknown,
             error: InternalError,
         }),
+        HttpApiEndpoint.get("costSplit", "/api/cost/split", {
+            query: { days: Schema.optionalKey(Schema.Number) },
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("costDispatches", "/api/cost/dispatches", {
+            query: {
+                days: Schema.optionalKey(Schema.Number),
+                candidates: Schema.optionalKey(Schema.Boolean),
+            },
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("costRoutability", "/api/cost/routability", {
+            query: {
+                days: Schema.optionalKey(Schema.Number),
+                minRun: Schema.optionalKey(Schema.Number),
+            },
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.get("routingTable", "/api/routing/table", {
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
+        HttpApiEndpoint.post("routingBacktest", "/api/routing/backtest", {
+            payload: Schema.Struct({
+                pattern: Schema.String,
+                flags: Schema.optionalKey(Schema.String),
+                suggest: Schema.String,
+                exclude: Schema.optionalKey(Schema.Array(Schema.String)),
+                days: Schema.optionalKey(Schema.Number),
+            }),
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
         HttpApiEndpoint.get("contextBudget", "/api/context/budget", {
             success: Schema.Unknown,
             error: InternalError,
@@ -963,6 +999,28 @@ export const LiveGroup = HttpApiGroup.make("live")
         }),
     );
 
+/** Routing class write endpoints (upsert + delete by id). */
+export const RoutingGroup = HttpApiGroup.make("routing")
+    .add(
+        HttpApiEndpoint.post("routingUpsertClass", "/api/routing/classes", {
+            payload: Schema.Struct({
+                id: Schema.String,
+                pattern: Schema.String,
+                flags: Schema.optionalKey(Schema.String),
+                suggest: Schema.String,
+                reason: Schema.optionalKey(Schema.String),
+                exclude: Schema.optionalKey(Schema.Array(Schema.String)),
+            }),
+            success: Schema.Unknown,
+            error: [BadRequestError, InternalError],
+        }),
+        HttpApiEndpoint.delete("routingRemoveClass", "/api/routing/classes/:id", {
+            params: { id: Schema.String },
+            success: Schema.Unknown,
+            error: [BadRequestError, InternalError],
+        }),
+    );
+
 /** The Insights Surface Contract. Families join as they migrate (ADR-0013). */
 export const AxApi = HttpApi.make("ax")
     .add(SystemGroup)
@@ -973,5 +1031,6 @@ export const AxApi = HttpApi.make("ax")
     .add(UsageGroup)
     .add(LiveGroup)
     .add(OtelGroup)
+    .add(RoutingGroup)
     .annotate(OpenApi.Title, "ax daemon API")
     .annotate(OpenApi.Version, "1");


### PR DESCRIPTION
## What

A studio `/cost` dashboard that **measures** spend and lets you **tune routing regexes live against your real dispatch history** — the first interactive write surface on the dashboard.

- **Measure** (read-only): main-vs-subagent spend split + per-model bars, dispatch candidates (suggested model + est savings), main-thread routability.
- **Tune** (interactive): a regex playground — type a class pattern → live **matched / excluded / missed** over history with est savings; one-click **✕ exclude** to curate false positives; **save/remove** classes to `~/.ax/hooks/routing-table.json`, which the route-dispatch hook reads live.

## How (mirrors existing patterns)

- **Routing-class exclusions** (the one new primitive): `RoutingClass` gains `exclude?: string[]`, checked in the shared `matchRoutingTable` — so the hook **and** `ax dispatches --candidates` honor exclusions with one change. Fail-open on invalid regex; **no regression on the default (no-exclude) path** (byte-equivalent).
- **Contract**: cost read endpoints (`Schema.Unknown`, mirroring `costModels`) + `routingBacktest` (POST) + a `RoutingGroup` with upsert/delete (mirroring the `skillDecide` POST/DELETE precedent).
- **Writes are loopback-gated**: rejected when `AX_SERVE_HOST` is non-loopback, so a LAN-exposed daemon stays read-only.
- **User classes override defaults by id** in `mergeRoutingTables`, so an `exclude` added to a default class (e.g. `bug-fix`) persists across compiles.
- Studio `/cost` route + rail nav; tuner degrades to read-only when no live daemon.

## Tests

4536 pass / 0 fail; typecheck 0 errors. Exhaustive matcher exclusion tests (fail-open, fall-through, no-regression), io merge/override + upsert/remove, pure backtest partition + savings, loopback-gate, suggest validation.

## Verified live

New endpoints curl'd against the real DB: `/api/cost/split` returns real rows; `/api/cost/routability` → mainSpend $15,052 / 22.5% routable / $1,829 savings. UI renders all sections + tuner + correct offline-degrade. (A live-data UI screenshot is deferred to the follow-up that stages studio for the article — dev cross-origin/stale-bundle wrinkle, not a code issue; both ends independently verified.)

## Review

Adversarial review (Opus) — no Critical; one Important (default-class edits silently lost) + 3 minors all fixed in `6776a495`.

Spec: `docs/superpowers/specs/2026-06-16-studio-cost-view-design.md`
Plan: `docs/superpowers/plans/2026-06-16-studio-cost-view.md`

## Follow-up (Phase 3, separate)
Stage the new studio bundle → live `/cost` screenshot → update `/showcases` → embed in the routing-tune blog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)