### PR TITLE
feat(site): dark-instrument Mission Control mock on the landing + cycling wrapped popups

### DIFF
--- a/apps/site/app/components/landing-v2/dashboard-preview.tsx
+++ b/apps/site/app/components/landing-v2/dashboard-preview.tsx
@@ -1,8 +1,150 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { HeroLogoField, PROVIDERS } from "./supports-strip";
 import { RetroTerminal } from "./retro-terminal";
+
+// ============================================================================
+// Mission Control preview - a static recreation of the studio home (instrument
+// HUD) for the landing. Charts are CSS-only (segbars, heat cells, LED, archetype
+// sigil); numbers are representative demo data. Mirrors the real component at
+// apps/studio/src/instrument/mission-control.tsx so the landing reflects the
+// ramped studio. Styles: .browser--instrument .mc-* in globals.css.
+// ============================================================================
+const MC_MODELS = [
+  { name: "opus", pct: 46, usd: "$1.9K", tone: "var(--blue)" },
+  { name: "sonnet", pct: 31, usd: "$1.3K", tone: "#e0556f" },
+  { name: "fable", pct: 14, usd: "$588", tone: "var(--green)" },
+  { name: "haiku", pct: 6, usd: "$252", tone: "var(--violet)" },
+  { name: "gpt-5", pct: 3, usd: "$126", tone: "var(--gold)" },
+];
+
+// deterministic ~21-week activity strip (5 rows × 30 cols), contribution levels 0..4
+const MC_ACTIVITY: number[] = Array.from({ length: 150 }, (_, i) => {
+  const x = i % 30;
+  const y = Math.floor(i / 30);
+  const v = Math.sin(x * 0.7 + y) * 0.5 + Math.sin(x * 0.3) * 0.4 + 0.5;
+  if (v < 0.18) return 0;
+  return v > 0.85 ? 4 : v > 0.6 ? 3 : v > 0.35 ? 2 : 1;
+});
+
+// archetype "ring" sigil (11×7 dot-matrix), the studio's primary-archetype glyph
+const MC_SIGIL: number[] = Array.from({ length: 77 }, (_, i) => {
+  const x = i % 11;
+  const y = Math.floor(i / 11);
+  const d = Math.hypot(x - 5, (y - 3) * 1.25);
+  const v = Math.max(0, Math.min(1, 1.1 - Math.abs(d - 2.7) * 0.8));
+  return v > 0.66 ? 4 : v > 0.4 ? 3 : v > 0.15 ? 2 : v > 0 ? 1 : 0;
+});
+
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+function McLed({ tone }: { tone?: "alert" }) {
+  return <span className={`mc-led${tone ? ` mc-led--${tone}` : ""}`} aria-hidden="true" />;
+}
+
+function McSeg({
+  total,
+  on,
+  color,
+  gradient,
+}: { total: number; on: number; color?: string; gradient?: boolean }) {
+  return (
+    <div className="mc-seg" aria-hidden="true">
+      {Array.from({ length: total }, (_, i) => {
+        const lit = i < on;
+        const style: React.CSSProperties = { animationDelay: `${0.2 + i * 0.04}s` };
+        if (lit && color) {
+          if (gradient) {
+            const pct = Math.round(34 + 66 * (on <= 1 ? 1 : i / (on - 1)));
+            style.background = `color-mix(in srgb, ${color} ${pct}%, var(--surface2))`;
+          } else {
+            style.background = color;
+          }
+        }
+        return <i key={i} className={lit ? "on" : ""} style={style} />;
+      })}
+    </div>
+  );
+}
+
+function McCells({
+  levels,
+  cols,
+  cell = 11,
+}: { levels: number[]; cols: number; cell?: number }) {
+  return (
+    <div
+      className="mc-cells"
+      aria-hidden="true"
+      style={{
+        gridTemplateColumns: `repeat(${cols}, ${cell}px)`,
+        gridAutoRows: `${cell}px`,
+      }}
+    >
+      {levels.map((l, i) => {
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+        return (
+          <i
+            key={i}
+            className={l ? `lvl-${l}` : ""}
+            style={{ animationDelay: `${0.15 + (col + row) * 0.016}s` }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+// SSR-stable placeholder until the clock mounts client-side, then it ticks live.
+const MC_PLACEHOLDER = new Date(2026, 5, 16, 23, 14, 7);
+
+function McClock() {
+  const [now, setNow] = useState<Date | null>(null);
+  useEffect(() => {
+    setNow(new Date());
+    const iv = window.setInterval(() => {
+      if (!document.hidden) setNow(new Date());
+    }, 1000);
+    return () => window.clearInterval(iv);
+  }, []);
+  const t = now ?? MC_PLACEHOLDER;
+  const day = t.toLocaleDateString("en-US", { weekday: "long" });
+  const date = t
+    .toLocaleDateString("en-US", { day: "2-digit", month: "short", year: "numeric" })
+    .toUpperCase();
+  return (
+    <section className="mc-card mc-clock">
+      <div className="mc-clock-top mc-label">
+        <span>local time</span>
+        <span className="mc-live">
+          <McLed />
+          live &middot; 312 active days
+        </span>
+      </div>
+      <div className="mc-clock-time">
+        <McLed tone="alert" />
+        <span className="mc-doto t">
+          {pad2(t.getHours())}:{pad2(t.getMinutes())}
+        </span>
+        <span className="mc-doto s">{pad2(t.getSeconds())}</span>
+      </div>
+      <div className="mc-clock-foot">
+        <div>
+          <div className="mc-day">{day}</div>
+          <div className="mc-label">{date} &middot; 2,847 sessions traced</div>
+        </div>
+        <div className="mc-clock-push">
+          <div className="mc-label">archetype &middot; high</div>
+          <div className="mc-label mc-strong">
+            The Cartographer <span className="mc-sq" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
 
 const INSTALL_CMD = "curl -fsSL ax.necmttn.com/install | sh";
 const DOCS_URL = "https://ax.necmttn.com/docs";
@@ -26,9 +168,347 @@ const AGENT_PROMPT = `Set up ax for me, end to end. ax is a local agent-experien
 
 6. GIVE ME A NEXT STEP - recommend 1-2 under-used skills you'd reach for based on what you saw, then end with a concrete CTA: the exact command or prompt I should run next, and what outcome it will produce.`;
 
+// ---- Wrapped recap charts (static recreations of the studio card-viz registry:
+// apps/studio/src/instrument/card-viz.tsx). Each keys --card-accent. ----
+function McBars({ data }: { data: number[] }) {
+  const max = Math.max(...data, 1);
+  const last = data.length - 1;
+  return (
+    <div className="mc-bars" aria-hidden="true">
+      {data.map((b, i) => (
+        <i
+          key={i}
+          className={i === last ? "is-now" : undefined}
+          style={{ height: `${Math.max(6, (b / max) * 100)}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function McLine({ data }: { data: number[] }) {
+  const W = 100;
+  const H = 46;
+  const padX = 2;
+  const padT = 5;
+  const padB = 5;
+  const uh = H - padT - padB;
+  const n = data.length;
+  const max = Math.max(...data, 1);
+  const xy = data.map((v, i) => [padX + (i / (n - 1)) * (W - 2 * padX), padT + (1 - v / max) * uh] as const);
+  const stroke = `M ${xy.map((p) => `${p[0].toFixed(1)} ${p[1].toFixed(1)}`).join(" L ")}`;
+  const area = `${stroke} L ${xy[n - 1][0].toFixed(1)} ${H - padB} L ${xy[0][0].toFixed(1)} ${H - padB} Z`;
+  return (
+    <svg className="mc-line" viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" aria-hidden="true">
+      <defs>
+        <linearGradient id="mcLineFill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="var(--card-accent)" stopOpacity="0.32" />
+          <stop offset="100%" stopColor="var(--card-accent)" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={area} fill="url(#mcLineFill)" />
+      <path d={stroke} className="mc-line-stroke" fill="none" />
+    </svg>
+  );
+}
+
+function McRadar({ data }: { data: number[] }) {
+  const axes = data.length;
+  const cx = 23;
+  const cy = 23;
+  const R = 21;
+  const max = Math.max(...data, 1);
+  const ang = (i: number) => -Math.PI / 2 + (i / axes) * Math.PI * 2;
+  const at = (i: number, r: number) => [cx + Math.cos(ang(i)) * r, cy + Math.sin(ang(i)) * r] as const;
+  const rad = (v: number) => ((v / max) * 0.84 + 0.08) * R;
+  const fmt = (p: readonly [number, number]) => `${p[0].toFixed(1)},${p[1].toFixed(1)}`;
+  const poly = data.map((v, i) => fmt(at(i, rad(v)))).join(" ");
+  return (
+    <svg className="mc-radar" viewBox="0 0 46 46" aria-hidden="true">
+      {[0.4, 0.7, 1].map((rr, k) => (
+        <polygon key={k} className="web" points={Array.from({ length: axes }, (_, i) => fmt(at(i, rr * R))).join(" ")} />
+      ))}
+      <polygon className="mc-radar-fill" points={poly} />
+      {data.map((v, i) => {
+        const [x, y] = at(i, rad(v));
+        return <circle key={i} className="mc-radar-node" cx={x.toFixed(1)} cy={y.toFixed(1)} r={1.5} />;
+      })}
+    </svg>
+  );
+}
+
+function McRing({ pct }: { pct: number }) {
+  const R = 15.5;
+  const C = 2 * Math.PI * R;
+  const dash = C * 0.75;
+  const frac = Math.max(0.04, pct / 100);
+  return (
+    <div className="mc-ring" aria-hidden="true">
+      <svg viewBox="0 0 40 40">
+        <circle cx="20" cy="20" r={R} className="bg" strokeDasharray={`${dash} ${C}`} />
+        <circle cx="20" cy="20" r={R} className="fg" strokeDasharray={`${dash} ${C}`} strokeDashoffset={dash * (1 - frac)} />
+      </svg>
+      <span className="mc-ring-val">{pct}</span>
+    </div>
+  );
+}
+
+function McWaffle({ pct }: { pct: number }) {
+  const ROWS = 5;
+  const COLS = 14;
+  const total = ROWS * COLS;
+  const on = Math.round((pct / 100) * total);
+  return (
+    <div className="mc-waffle" aria-hidden="true">
+      {Array.from({ length: total }, (_, i) => {
+        const col = i % COLS;
+        const row = Math.floor(i / COLS);
+        const order = col * ROWS + (ROWS - 1 - row);
+        return <span key={i} className={`mc-waffle-cell${order < on ? " on" : ""}`} />;
+      })}
+    </div>
+  );
+}
+
+function McCandles({ data }: { data: number[] }) {
+  const max = Math.max(...data, 1);
+  const min = Math.min(...data, 0);
+  const span = Math.max(1, max - min);
+  const Y = (v: number) => 4 + (1 - (v - min) / span) * 36;
+  return (
+    <div className="mc-candles" aria-hidden="true">
+      {data.map((v, i) => {
+        const prev = i === 0 ? data[0] : data[i - 1];
+        const up = v >= prev;
+        const oY = Y(prev);
+        const cY = Y(v);
+        const top = Math.min(oY, cY);
+        const bodyH = Math.max(2, Math.abs(cY - oY));
+        const wickTop = Math.min(top, Y(Math.max(v, prev)) - 3);
+        const wickBot = Math.max(top + bodyH, Y(Math.min(v, prev)) + 3);
+        return (
+          <span key={i} className={`mc-candle ${up ? "up" : "dn"}`}>
+            <span className="mc-candle-wick" style={{ top: `${wickTop}px`, height: `${Math.max(3, wickBot - wickTop)}px` }} />
+            <span className="mc-candle-body" style={{ top: `${top}px`, height: `${bodyH}px` }} />
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function McComet({ pct }: { pct: number }) {
+  const cx = 23;
+  const cy = 23;
+  const rx = 19;
+  const ry = 15;
+  const frac = Math.max(0.02, pct / 100);
+  const C = Math.PI * (3 * (rx + ry) - Math.sqrt((3 * rx + ry) * (rx + 3 * ry)));
+  const dash = C * frac;
+  const ang = -Math.PI / 2 + frac * Math.PI * 2;
+  const hx = cx + Math.cos(ang) * rx;
+  const hy = cy + Math.sin(ang) * ry;
+  return (
+    <div className="mc-comet" aria-hidden="true">
+      <svg viewBox="0 0 46 46">
+        <ellipse className="mc-comet-orbit" cx={cx} cy={cy} rx={rx} ry={ry} />
+        <ellipse
+          className="mc-comet-trail"
+          cx={cx}
+          cy={cy}
+          rx={rx}
+          ry={ry}
+          strokeDasharray={`${dash.toFixed(1)} ${C.toFixed(1)}`}
+          transform={`rotate(-90 ${cx} ${cy})`}
+        />
+        <circle className="mc-comet-head" cx={hx.toFixed(1)} cy={hy.toFixed(1)} r={2.6} />
+      </svg>
+    </div>
+  );
+}
+
+function McWave({ data }: { data: number[] }) {
+  const W = 100;
+  const H = 46;
+  const mid = H / 2;
+  const n = data.length;
+  const max = Math.max(...data, 1);
+  const min = Math.min(...data, 0);
+  const span = Math.max(1, max - min);
+  const d = data
+    .map((v, i) => {
+      const x = (i / (n - 1)) * (W - 2) + 1;
+      const y = mid + (0.5 - (v - min) / span) * (H - 10);
+      return `${i === 0 ? "M" : "L"} ${x.toFixed(1)} ${y.toFixed(1)}`;
+    })
+    .join(" ");
+  return (
+    <svg className="mc-wave" viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" aria-hidden="true">
+      <line className="mc-wave-grat" x1="0" y1={mid} x2={W} y2={mid} />
+      <line className="mc-wave-grat dash" x1={W * 0.5} y1="2" x2={W * 0.5} y2={H - 2} />
+      <path className="mc-wave-trace" d={d} fill="none" vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}
+
+function McBullet({ actual, target }: { actual: number; target: number }) {
+  const onTrack = actual >= target;
+  return (
+    <div className="mc-bullet" aria-hidden="true">
+      <div className="mc-bullet-track">
+        <span className="mc-bullet-fill" style={{ width: `${actual}%` }} />
+        <span className={`mc-bullet-tick${onTrack ? " ok" : ""}`} style={{ left: `${target}%` }} />
+      </div>
+      <div className="mc-bullet-foot">
+        <span className="mc-bullet-val">{actual}</span>
+        <span className="mc-bullet-goal">/ {target} goal</span>
+      </div>
+    </div>
+  );
+}
+
+function McSignal({ on, bars = 6 }: { on: number; bars?: number }) {
+  return (
+    <div className="mc-signal" aria-hidden="true">
+      {Array.from({ length: bars }, (_, i) => (
+        <span
+          key={i}
+          className={`mc-signal-bar${i < on ? " on" : ""}`}
+          style={{ height: `${28 + (i / (bars - 1)) * 70}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function McScatter({ data }: { data: number[] }) {
+  const n = data.length;
+  const max = Math.max(...data, 1);
+  const min = Math.min(...data, 0);
+  const span = Math.max(1, max - min);
+  const mean = data.reduce((a, b) => a + b, 0) / n;
+  const meanY = 4 + (1 - (mean - min) / span) * 38;
+  return (
+    <div className="mc-scatter" aria-hidden="true">
+      <svg className="mc-scatter-svg" viewBox="0 0 100 46" preserveAspectRatio="none">
+        <line className="mc-scatter-mean" x1="0" y1={meanY.toFixed(1)} x2="100" y2={meanY.toFixed(1)} vectorEffect="non-scaling-stroke" />
+      </svg>
+      <div className="mc-scatter-dots">
+        {data.map((v, i) => {
+          const x = (i / (n - 1)) * 100;
+          const y = 4 + (1 - (v - min) / span) * 38;
+          return <span key={i} className={`mc-scatter-dot${v >= mean ? " hot" : ""}`} style={{ left: `${x}%`, top: `${y}px` }} />;
+        })}
+      </div>
+    </div>
+  );
+}
+
+function McDelta({ data }: { data: number[] }) {
+  const last = data[data.length - 1];
+  const first = data[0];
+  const diff = last - first;
+  const up = diff >= 0;
+  const n = data.length;
+  const max = Math.max(...data, 1);
+  const min = Math.min(...data, 0);
+  const span = Math.max(1, max - min);
+  const spark = data.map((v, i) => `${(i / (n - 1)) * 100},${(14 - ((v - min) / span) * 12).toFixed(1)}`).join(" ");
+  return (
+    <div className={`mc-delta ${up ? "up" : "dn"}`} aria-hidden="true">
+      <div className="mc-delta-num">
+        <span className="mc-delta-val">{Math.round(last)}</span>
+        <span className="mc-delta-trend">
+          <i>{up ? "▲" : "▼"}</i>
+          {Math.abs(Math.round(diff))}
+        </span>
+      </div>
+      <svg className="mc-delta-spark" viewBox="0 0 100 14" preserveAspectRatio="none">
+        <polyline points={spark} fill="none" stroke="var(--card-accent)" strokeWidth="1.25" vectorEffect="non-scaling-stroke" />
+      </svg>
+    </div>
+  );
+}
+
+// The 12 wrapped readouts the floating popups cycle through - each keys a channel
+// accent and carries one chart + a one-line caption. (Recreated from the studio
+// card-viz registry: apps/studio/src/instrument/card-viz.tsx.)
+const POP_CHARTS: ReadonlyArray<{
+  key: string;
+  accent: string;
+  q: string;
+  h: string;
+  viz: React.ReactNode;
+}> = [
+  { key: "bars", accent: "acc-green", q: "when you ship", h: "Tuesday nights", viz: <McBars data={[22, 31, 28, 44, 39, 58, 47, 63, 71, 55, 82, 90, 74, 61, 88, 96]} /> },
+  { key: "ring", accent: "acc-gold", q: "fixes stick", h: "82% hold", viz: <McRing pct={82} /> },
+  { key: "line", accent: "acc-blue", q: "tokens / year", h: "1.4B", viz: <McLine data={[18, 24, 21, 33, 40, 38, 52, 60, 57, 71, 80, 78, 92, 100]} /> },
+  { key: "radar", accent: "acc-violet", q: "skill profile", h: "systems mind", viz: <McRadar data={[82, 64, 91, 48, 73]} /> },
+  { key: "waffle", accent: "acc-green", q: "paths covered", h: "73%", viz: <McWaffle pct={73} /> },
+  { key: "candles", accent: "acc-rose", q: "session swings", h: "big nights", viz: <McCandles data={[40, 60, 55, 75, 70, 50, 62, 80, 72, 88]} /> },
+  { key: "comet", accent: "acc-blue", q: "quota burn", h: "61%", viz: <McComet pct={61} /> },
+  { key: "wave", accent: "acc-violet", q: "latency", h: "steady", viz: <McWave data={[50, 80, 20, 60, 35, 70, 45, 66, 30, 72]} /> },
+  { key: "scatter", accent: "acc-rose", q: "cost vs reward", h: "lands cheap", viz: <McScatter data={[30, 50, 45, 70, 60, 85, 55, 40, 66, 52]} /> },
+  { key: "bullet", accent: "acc-gold", q: "ship goal", h: "82 / 70", viz: <McBullet actual={82} target={70} /> },
+  { key: "signal", accent: "acc-green", q: "harness health", h: "5 / 6", viz: <McSignal on={5} /> },
+  { key: "delta", accent: "acc-blue", q: "weekly tokens", h: "+18", viz: <McDelta data={[40, 55, 48, 62, 70, 66, 78, 84]} /> },
+];
+
+// chart kinds that render small/fixed-size (center them in the popup viz row);
+// the rest are full-width and stretch.
+const POP_CENTERED = new Set(["ring", "radar", "comet", "waffle"]);
+// 3 popup slots, each offset into the 12-chart ring so they always show
+// different findings; advancing `popTick` cycles every chart through every slot.
+const POP_SLOTS = [
+  { off: 0, place: "mc-pop--tr" },
+  { off: 4, place: "mc-pop--bl" },
+  { off: 8, place: "mc-pop--br" },
+];
+
 export function DashboardPreview() {
   const [copiedPrompt, setCopiedPrompt] = useState(false);
   const [hovered, setHovered] = useState(false);
+  // Scroll-driven: the wrapped popups parallax (each at a different rate, for
+  // depth) and cycle through all 12 charts as the section moves up the viewport.
+  const mcStageRef = useRef<HTMLDivElement>(null);
+  const [popTick, setPopTick] = useState(0);
+  useEffect(() => {
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const stage = mcStageRef.current;
+    if (!stage) return;
+    const pops = Array.from(stage.querySelectorAll<HTMLElement>(".mc-pop"));
+    const FACTORS = [1, -0.85, 0.5]; // per-slot parallax rate (tr, bl, br)
+    const AMP = 46; // px of parallax drift
+    const STEP = 120; // px of scroll per chart advance
+    let scheduled = false;
+    const update = () => {
+      scheduled = false;
+      const rect = stage.getBoundingClientRect();
+      const vh = window.innerHeight || 1;
+      const raw = ((vh - rect.top) / (vh + rect.height) - 0.5) * 2;
+      const centered = Math.max(-1, Math.min(1, raw)); // clamp to -1..1
+
+      pops.forEach((el, i) => {
+        el.style.setProperty("--py", `${(centered * AMP * (FACTORS[i] ?? 0)).toFixed(1)}px`);
+      });
+      const scrolled = Math.max(0, vh - rect.top);
+      const tick = Math.floor(scrolled / STEP);
+      setPopTick((prev) => (prev === tick ? prev : tick));
+    };
+    const onScroll = () => {
+      if (!scheduled) {
+        scheduled = true;
+        requestAnimationFrame(update);
+      }
+    };
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, []);
 
   function onCopyPrompt() {
     if (typeof navigator === "undefined" || !navigator.clipboard) return;
@@ -125,170 +605,161 @@ export function DashboardPreview() {
       {/* ============= retro terminal: the mechanism ============= */}
       <RetroTerminal />
 
-      {/* ============= demo: improve deck (mirrors studio /improve) ============= */}
-      <section className="demo">
+      {/* ============= demo: Mission Control window + floating wrapped-highlight popups ============= */}
+      <section className="demo demo--popups">
         <div className="demo-intro">
-          <span className="eyebrow">open the dashboard, fixes are waiting</span>
+          <span className="eyebrow">open the studio</span>
           <h2>
-            Your next fixes, already&nbsp;mined.
+            Mission Control for your&nbsp;agents.
           </h2>
           <p>
-            The Improve deck turns your history into ranked proposals &mdash;
-            spend to reroute, failures that recur, tools that keep breaking.
-            Accept one, and ax measures your next 30 sessions to see if it
-            actually worked.
+            Run <code>ax serve</code> and the whole HUD lights up &mdash; archetype
+            sigil, live activity, streaks, token spend by model. The wrapped
+            highlights pop out as ax finds them.
           </p>
         </div>
 
-        <div
-          className="browser"
-          role="img"
-          aria-label="ax dashboard, Improve view at 127.0.0.1:1738"
-        >
-          <div className="browser-bar">
-            <div className="browser-dots">
-              <span></span>
-              <span></span>
-              <span></span>
+        <div className="mc-stage" ref={mcStageRef}>
+          <div
+            className="browser browser--instrument"
+            role="img"
+            aria-label="ax studio Mission Control, dark instrument dashboard at 127.0.0.1:1738"
+          >
+            <div className="browser-bar">
+              <div className="browser-dots">
+                <span></span>
+                <span></span>
+                <span></span>
+              </div>
+              <div className="browser-url">127.0.0.1:1738</div>
+              <div className="browser-spacer"></div>
             </div>
-            <div className="browser-url">127.0.0.1:1738</div>
-            <div className="browser-spacer"></div>
+
+            <div className="mc-shell">
+              <nav className="mc-rail" aria-hidden="true">
+                <span className="mc-logo">ax</span>
+                <span className="mc-railbtn on">◎</span>
+                <span className="mc-railbtn">✦</span>
+                <span className="mc-railbtn">▤</span>
+                <span className="mc-railbtn">◳</span>
+                <span className="mc-railbtn">⎈</span>
+              </nav>
+
+              <div className="mc-main">
+                <McClock />
+
+                <div className="mc-bento">
+                  <section className="mc-card mc-hero span2 row2">
+                    <div className="mc-meta mc-label">
+                      <span>archetype &middot; primary</span>
+                      <span>high confidence</span>
+                    </div>
+                    <div className="mc-sigil">
+                      <McCells levels={MC_SIGIL} cols={11} cell={16} />
+                    </div>
+                    <div className="mc-hero-text">
+                      <div className="mc-hero-name">The Cartographer</div>
+                      <p className="mc-hero-tag">
+                        Maps the whole repo before touching a line &mdash; reads
+                        wide, edits once.
+                      </p>
+                    </div>
+                  </section>
+
+                  <section className="mc-card">
+                    <div className="mc-label">sessions</div>
+                    <div className="mc-metric mc-bottom">2,847</div>
+                    <div className="mc-label">58.2K messages</div>
+                  </section>
+
+                  <section className="mc-card">
+                    <div className="mc-label">tokens</div>
+                    <div className="mc-metric mc-bottom">1.4B</div>
+                    <div className="mc-label">+18% vs prior 90d</div>
+                  </section>
+
+                  <section className="mc-card span2">
+                    <div className="mc-meta mc-label">
+                      <span>activity &middot; daily</span>
+                      <span className="mc-live">
+                        <McLed />
+                        live
+                      </span>
+                    </div>
+                    <div className="mc-actwrap">
+                      <McCells levels={MC_ACTIVITY} cols={30} cell={11} />
+                    </div>
+                    <div className="mc-meta mc-label">
+                      <span>312 active days</span>
+                      <span>21 weeks</span>
+                    </div>
+                  </section>
+
+                  <section className="mc-card">
+                    <div className="mc-label">streak</div>
+                    <div className="mc-num mc-bottom">
+                      23<small>d</small>
+                    </div>
+                    <McSeg total={41} on={23} color="var(--alert)" gradient />
+                    <div className="mc-label">best 41 days</div>
+                  </section>
+
+                  <section className="mc-card">
+                    <div className="mc-label">peak hour</div>
+                    <div className="mc-metric mc-bottom">11 PM</div>
+                    <div className="mc-label">most active</div>
+                  </section>
+
+                  <section className="mc-card span2 mc-split">
+                    <div className="mc-meta mc-label">
+                      <span>model split &middot; 365d</span>
+                      <span>~$4.2K total</span>
+                    </div>
+                    <div className="mc-splitlist">
+                      {MC_MODELS.map((m) => (
+                        <div className="mc-split-row" key={m.name}>
+                          <span className="mc-model">
+                            <span className="mc-swatch" style={{ background: m.tone }} />
+                            {m.name}
+                          </span>
+                          <span>
+                            {m.pct}% &middot; {m.usd}
+                          </span>
+                          <span className="mc-segwrap">
+                            <McSeg total={24} on={Math.max(1, Math.round((m.pct / 100) * 24))} color={m.tone} />
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                </div>
+              </div>
+            </div>
           </div>
 
-          <div className="dash dash--improve">
-            <div className="dash-tabs" aria-hidden="true">
-              <span>Wrapped</span>
-              <span className="is-active">Improve</span>
-              <span>Sessions</span>
-              <span>Skills</span>
-              <span>Workflow</span>
-            </div>
-
-            <div className="nx-head">
-              <div>
-                <p className="nx-eyebrow">$ what&apos;s next</p>
-                <p className="nx-title">20 actions waiting</p>
-                <p className="nx-sub">
-                  Mined from your sessions &mdash; savings to route, fixes that
-                  recur, verdicts due.
-                </p>
-              </div>
-              <span className="nx-brief">copy analysis brief</span>
-            </div>
-
-            <div className="nx-grid">
-              <article className="nx-card">
-                <p className="nx-tag">$ proposal</p>
-                <h3 className="nx-card-title">~$605 redirectable</h3>
-                <p className="nx-card-desc">
-                  252 model-less dispatches on expensive models matched
-                  mechanical routing classes.
-                </p>
-                <p className="nx-fix">
-                  <b>FIX &rarr; NEW HOOK:</b> route mechanical subagent
-                  dispatches to cheaper models
-                </p>
-                <div className="nx-actions">
-                  <span className="nx-btn">REVIEW &rarr;</span>
-                  <span className="nx-copy">copy brief</span>
-                </div>
-              </article>
-
-              <article className="nx-card">
-                <p className="nx-tag">$ proposal</p>
-                <h3 className="nx-card-title">26&times; recurring</h3>
-                <p className="nx-card-desc">
-                  Feature closure needs stronger same-file follow-up
-                  verification.
-                </p>
-                <p className="nx-fix">
-                  <b>FIX &rarr; NEW SKILL:</b> post-feature verification
-                  checklist
-                </p>
-                <div className="nx-actions">
-                  <span className="nx-btn">REVIEW &rarr;</span>
-                  <span className="nx-copy">copy brief</span>
-                </div>
-              </article>
-
-              <article className="nx-card nx-card--alert">
-                <p className="nx-tag nx-tag--alert">$ failing tool</p>
-                <h3 className="nx-card-title">
-                  Fix <code>write_stdin</code> cluster
-                </h3>
-                <p className="nx-card-desc">
-                  1,681 failures across 205 sessions &mdash; one flaky tool
-                  taxing every run.
-                </p>
-                <p className="nx-exits">
-                  exits [2, 1, 130, -1, 127&hellip;]
-                </p>
-                <div className="nx-actions">
-                  <span className="nx-btn">DETAILS &rarr;</span>
-                  <span className="nx-copy">copy brief</span>
-                </div>
-              </article>
-            </div>
-
-            <p className="nx-foot">+17 more in the registry below</p>
-
-            <div className="nx-exp">
-              <div className="nx-exp-head">
-                <p className="nx-exp-title">
-                  <span className="nx-eyebrow">$ experiments</span> Past bets,
-                  measured
-                </p>
-                <span className="nx-exp-meta">
-                  checkpoints at +3 / +10 / +30 sessions
-                </span>
-              </div>
-              <div className="nx-exp-empty">
-                <div className="nx-exp-empty-copy">
-                  <p className="nx-exp-empty-title">No bets placed yet.</p>
-                  <p className="nx-exp-note">
-                    Every accepted fix becomes a bet. ax watches your next 30
-                    sessions &mdash; a trace bar that shrinks to zero is a
-                    confirmed win.
-                  </p>
-                </div>
-                <div className="nx-trace" aria-hidden="true">
-                  <div className="nx-trace-row">
-                    <span className="nx-trace-label">+3</span>
-                    <span className="nx-trace-track">
-                      <span
-                        className="nx-trace-bar"
-                        style={{ width: "92%" }}
-                      ></span>
-                    </span>
+          {/* floating wrapped highlights - cycle through all 12 charts */}
+          <div className="mc-pop-strip">
+            {POP_SLOTS.map(({ off, place }) => {
+              const c = POP_CHARTS[(popTick + off) % POP_CHARTS.length];
+              return (
+                <article key={place} className={`mc-pop ${place} ${c.accent} browser--instrument`}>
+                  <span className="mc-pop-badge">wrapped</span>
+                  <div key={c.key} className="mc-pop-swap">
+                    <div className={`mc-pop-viz${POP_CENTERED.has(c.key) ? " mc-pop-viz--center" : ""}`}>
+                      {c.viz}
+                    </div>
+                    <span className="mc-pop-q">$ {c.q}</span>
+                    <h4 className="mc-pop-h">{c.h}</h4>
                   </div>
-                  <div className="nx-trace-row">
-                    <span className="nx-trace-label">+10</span>
-                    <span className="nx-trace-track">
-                      <span
-                        className="nx-trace-bar"
-                        style={{ width: "44%" }}
-                      ></span>
-                    </span>
-                  </div>
-                  <div className="nx-trace-row">
-                    <span className="nx-trace-label">+30</span>
-                    <span className="nx-trace-track">
-                      <span
-                        className="nx-trace-bar nx-trace-bar--win"
-                        style={{ width: "7%" }}
-                      ></span>
-                      <span className="nx-trace-win">&#10003; confirmed win</span>
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
+                </article>
+              );
+            })}
           </div>
         </div>
 
         <p className="demo-caption">
-          Run <code>ax serve</code> to see yours &mdash; Improve deck, Agent
-          Wrapped, sessions, skill triage.
+          Run <code>ax serve</code> to see yours &mdash; Mission Control, the
+          Improve deck, Agent Wrapped, sessions and skill triage.
         </p>
       </section>
     </>

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -9892,6 +9892,815 @@ footer.site-footer { padding: 48px 32px 56px; }
   color: var(--ink);
 }
 
+/* ===========================================================================
+   dark-instrument Improve preview - ports the studio's nullframe instrument
+   house style (apps/studio/src/instrument/instrument.css, dark theme) onto the
+   landing's hand-coded /improve mockup. Scoped to .browser--instrument so the
+   shared .browser/.dash--improve/.nx-* styles stay LIGHT for /how-it-works'
+   PROPOSE act, which reuses the same classes. Strategy: re-map the light root
+   tokens to instrument-dark values on the container so the existing .nx-* rules
+   adopt dark automatically, then override the few hardcoded #fff/light bits and
+   add the instrument signatures (dot-grid, dashed tear-line, green accent).
+   ========================================================================= */
+.landing-v2 .browser--instrument {
+  /* instrument dark palette (instrument.css :root[data-theme="dark"]) */
+  --ink: #e6e9e2;        /* --pri    */
+  --muted: #939b8f;      /* --sec    */
+  --soft: #5f685e;       /* --dim    */
+  --line: #1f241f;       /* --border */
+  --line-hi: #31382f;    /* --border-hi */
+  --panel: #111311;      /* --surface */
+  --surface: #111311;
+  --surface2: #181b18;
+  --page: #0b0d0b;       /* --bg     */
+  --dot: #1b211a;
+  --green: #56b06a;
+  --blue: #5b8fd6;
+  --red: #d7493b;
+  --amber: #d6a14a;      /* --gold   */
+  --gold: #d6a14a;
+  --violet: #9a86f0;
+  --alert: #f26522;
+  --accent: #56b06a;
+  --display: #fff;
+  /* contribution-heat ramp (instrument dark --c0..--c4) */
+  --c0: #1a1f1a; --c1: #1e3526; --c2: #2c5639; --c3: #3f8a50; --c4: #62c878;
+  background: var(--panel);
+  border-color: var(--line);
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.3),
+    0 18px 44px -22px rgba(0, 0, 0, 0.7),
+    0 40px 80px -50px rgba(0, 0, 0, 0.6);
+}
+/* window chrome */
+.landing-v2 .browser--instrument .browser-bar {
+  background: var(--surface2);
+  border-bottom-color: var(--line);
+}
+.landing-v2 .browser--instrument .browser-dots span { background: var(--line-hi); }
+.landing-v2 .browser--instrument .browser-url {
+  background: var(--page);
+  border-color: var(--line);
+  color: var(--muted);
+}
+.landing-v2 .browser--instrument .browser-url::before {
+  background: var(--green);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--green) 24%, transparent);
+}
+/* dash surface: instrument dot-grid over the dark panel */
+.landing-v2 .browser--instrument .dash {
+  background-color: var(--page);
+  background-image: radial-gradient(circle, var(--dot) 1.1px, transparent 1.1px);
+  background-size: 16px 16px;
+  background-position: 8px 8px;
+}
+/* nav tabs: quiet dark chips, active = green accent */
+.landing-v2 .browser--instrument .dash-tabs span {
+  background: var(--surface2);
+  border-color: var(--line);
+  color: var(--muted);
+}
+.landing-v2 .browser--instrument .dash-tabs span.is-active {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  color: var(--accent);
+}
+/* masthead: dashed receipt tear-line + display-white title */
+.landing-v2 .browser--instrument .nx-head {
+  border-bottom: 1.5px dashed var(--line-hi);
+}
+.landing-v2 .browser--instrument .nx-title { color: #fff; }
+.landing-v2 .browser--instrument .nx-brief {
+  background: var(--surface2);
+  border-color: color-mix(in srgb, var(--amber) 55%, var(--line));
+}
+/* proposal cards: dark surface, green channel-rule, white display titles */
+.landing-v2 .browser--instrument .nx-card {
+  background: var(--panel);
+  border-color: var(--line);
+  border-top-color: var(--accent);
+}
+.landing-v2 .browser--instrument .nx-card:hover {
+  border-color: var(--line-hi);
+  box-shadow: 0 14px 32px -20px rgba(0, 0, 0, 0.8);
+}
+.landing-v2 .browser--instrument .nx-card--alert { border-top-color: var(--alert, #f26522); }
+.landing-v2 .browser--instrument .nx-tag { color: var(--accent); }
+.landing-v2 .browser--instrument .nx-tag--alert { color: var(--alert, #f26522); }
+.landing-v2 .browser--instrument .nx-card-title { color: #fff; }
+.landing-v2 .browser--instrument .nx-card-title code {
+  background: var(--surface2);
+  border-color: var(--line);
+  color: var(--ink);
+}
+.landing-v2 .browser--instrument .nx-fix b { color: var(--accent); }
+/* primary action: filled green, dark ink (instrument promptpill) */
+.landing-v2 .browser--instrument .nx-btn {
+  background: var(--accent);
+  color: #07140c;
+}
+/* experiments empty-state + ghost trace bars */
+.landing-v2 .browser--instrument .nx-exp-empty {
+  background: var(--surface2);
+  border-color: var(--line);
+}
+.landing-v2 .browser--instrument .nx-exp-empty-title,
+.landing-v2 .browser--instrument .nx-exp-title { color: #fff; }
+.landing-v2 .browser--instrument .nx-trace-bar {
+  background: color-mix(in srgb, #fff 14%, transparent);
+}
+.landing-v2 .browser--instrument .nx-trace-bar--win { background: var(--green); }
+
+/* ===========================================================================
+   Mission Control preview - static recreation of the studio home (instrument
+   HUD bento). Ports apps/studio/src/instrument/{instrument.css,viz.tsx} (icon
+   rail + Doto clock + bento cards + CSS-only charts: segbars, heat cells, LED,
+   archetype sigil). All scoped under .browser--instrument; the dark token block
+   above feeds it. Renamed v-mc/rdx-* → mc-* so nothing leaks to shared styles.
+   ========================================================================= */
+.landing-v2 .browser--instrument .mc-shell {
+  display: grid;
+  grid-template-columns: 54px 1fr;
+}
+.landing-v2 .browser--instrument .mc-rail {
+  border-right: 1px solid var(--line);
+  background: var(--surface2);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 14px 0;
+}
+.landing-v2 .browser--instrument .mc-logo {
+  font-family: var(--serif);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--display);
+  margin-bottom: 10px;
+}
+.landing-v2 .browser--instrument .mc-railbtn {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  border: 1px solid transparent;
+  color: var(--soft);
+  font-size: 14px;
+  display: grid;
+  place-items: center;
+}
+.landing-v2 .browser--instrument .mc-railbtn.on {
+  color: var(--display);
+  border-color: var(--line-hi);
+  background: var(--page);
+}
+.landing-v2 .browser--instrument .mc-main {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+.landing-v2 .browser--instrument .mc-main::-webkit-scrollbar { width: 8px; }
+.landing-v2 .browser--instrument .mc-main::-webkit-scrollbar-thumb {
+  background: var(--line-hi);
+  border-radius: 4px;
+}
+.landing-v2 .browser--instrument .mc-main::-webkit-scrollbar-track { background: transparent; }
+/* card primitive */
+.landing-v2 .browser--instrument .mc-card {
+  position: relative;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  opacity: 0;
+  animation: mcCardIn 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+@keyframes mcCardIn {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to { opacity: 1; transform: none; }
+}
+.landing-v2 .browser--instrument .mc-label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.landing-v2 .browser--instrument .mc-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.landing-v2 .browser--instrument .mc-live {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  color: var(--green);
+}
+.landing-v2 .browser--instrument .mc-bottom { margin-top: auto; }
+.landing-v2 .browser--instrument .mc-strong { color: var(--ink); }
+.landing-v2 .browser--instrument .mc-metric {
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--display);
+}
+.landing-v2 .browser--instrument .mc-num {
+  font-family: "n", var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  font-size: 42px;
+  line-height: 1;
+  color: var(--display);
+}
+.landing-v2 .browser--instrument .mc-num small {
+  font-size: 15px;
+  color: var(--muted);
+  margin-left: 3px;
+}
+.landing-v2 .browser--instrument .mc-doto {
+  font-family: "n", var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+/* clock hero */
+.landing-v2 .browser--instrument .mc-clock {
+  gap: 0;
+  justify-content: space-between;
+  min-height: 188px;
+  background-image: radial-gradient(circle, var(--dot) 1.1px, transparent 1.1px);
+  background-size: 16px 16px;
+  background-position: 8px 8px;
+}
+.landing-v2 .browser--instrument .mc-clock-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+.landing-v2 .browser--instrument .mc-clock-time {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  flex: 1;
+}
+.landing-v2 .browser--instrument .mc-clock-time .t {
+  font-size: clamp(48px, 8vw, 86px);
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--display);
+}
+.landing-v2 .browser--instrument .mc-clock-time .s {
+  font-size: 26px;
+  color: var(--muted);
+  align-self: flex-end;
+  padding-bottom: 12px;
+}
+.landing-v2 .browser--instrument .mc-clock-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+}
+.landing-v2 .browser--instrument .mc-day {
+  font-family: var(--serif);
+  font-size: 24px;
+  color: var(--display);
+  margin-bottom: 4px;
+}
+.landing-v2 .browser--instrument .mc-clock-push {
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.landing-v2 .browser--instrument .mc-sq {
+  display: inline-block;
+  width: 9px;
+  height: 12px;
+  background: var(--alert);
+  margin-left: 7px;
+  vertical-align: -1px;
+}
+/* bento */
+.landing-v2 .browser--instrument .mc-bento {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: 138px;
+  gap: 12px;
+}
+.landing-v2 .browser--instrument .mc-bento .span2 { grid-column: span 2; }
+.landing-v2 .browser--instrument .mc-bento .row2 { grid-row: span 2; }
+.landing-v2 .browser--instrument .mc-hero {
+  min-height: 288px;
+  justify-content: space-between;
+  background-image: radial-gradient(circle, var(--dot) 1.1px, transparent 1.1px);
+  background-size: 16px 16px;
+  background-position: 8px 8px;
+}
+.landing-v2 .browser--instrument .mc-sigil {
+  flex: 1 1 auto;
+  display: grid;
+  place-items: center;
+  min-height: 0;
+}
+.landing-v2 .browser--instrument .mc-hero-name {
+  font-family: var(--serif);
+  font-size: 25px;
+  color: var(--display);
+}
+.landing-v2 .browser--instrument .mc-hero-tag {
+  margin: 6px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--muted);
+  max-width: 42ch;
+}
+.landing-v2 .browser--instrument .mc-actwrap { margin-top: auto; overflow: hidden; }
+.landing-v2 .browser--instrument .mc-split { gap: 7px; }
+.landing-v2 .browser--instrument .mc-splitlist {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.landing-v2 .browser--instrument .mc-split-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 6px 10px;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+.landing-v2 .browser--instrument .mc-split-row .mc-segwrap { grid-column: 1 / -1; }
+.landing-v2 .browser--instrument .mc-model { color: var(--ink); }
+.landing-v2 .browser--instrument .mc-swatch {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-radius: 2px;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+/* segbar */
+.landing-v2 .browser--instrument .mc-seg { display: flex; gap: 3px; height: 12px; }
+.landing-v2 .browser--instrument .mc-seg i {
+  flex: 1;
+  background: var(--line);
+  transform: scale(0.3);
+  opacity: 0;
+  animation: mcSegIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+.landing-v2 .browser--instrument .mc-seg i.on { background: var(--accent); }
+@keyframes mcSegIn { to { transform: scale(1); opacity: 1; } }
+/* contribution cells */
+.landing-v2 .browser--instrument .mc-cells {
+  display: grid;
+  align-content: center;
+  justify-content: start;
+  gap: 3px;
+}
+.landing-v2 .browser--instrument .mc-cells i {
+  display: block;
+  border-radius: 2px;
+  background: var(--c0);
+  transform: scale(0);
+  animation: mcSlam 0.38s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+.landing-v2 .browser--instrument .mc-cells i.lvl-1 { background: var(--c1); }
+.landing-v2 .browser--instrument .mc-cells i.lvl-2 { background: var(--c2); }
+.landing-v2 .browser--instrument .mc-cells i.lvl-3 { background: var(--c3); }
+.landing-v2 .browser--instrument .mc-cells i.lvl-4 { background: var(--c4); }
+@keyframes mcSlam { 60% { transform: scale(1.25); } to { transform: scale(1); } }
+/* live LED */
+.landing-v2 .browser--instrument .mc-led {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--green);
+  display: inline-block;
+  flex: none;
+  animation: mcLed 2.4s ease infinite;
+}
+.landing-v2 .browser--instrument .mc-led--alert {
+  background: var(--alert);
+  width: 7px;
+  height: 7px;
+  animation-duration: 1.6s;
+}
+@keyframes mcLed { 0%, 100% { opacity: 1; } 50% { opacity: 0.25; } }
+@media (prefers-reduced-motion: reduce) {
+  .landing-v2 .browser--instrument .mc-card,
+  .landing-v2 .browser--instrument .mc-seg i,
+  .landing-v2 .browser--instrument .mc-cells i,
+  .landing-v2 .browser--instrument .mc-led {
+    animation: none !important;
+    opacity: 1;
+    transform: none;
+  }
+}
+@media (max-width: 820px) {
+  .landing-v2 .browser--instrument .mc-shell { grid-template-columns: 1fr; }
+  .landing-v2 .browser--instrument .mc-rail { display: none; }
+  .landing-v2 .browser--instrument .mc-bento { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 520px) {
+  .landing-v2 .browser--instrument .mc-bento { grid-template-columns: 1fr; }
+  .landing-v2 .browser--instrument .mc-bento .span2 { grid-column: auto; }
+  .landing-v2 .browser--instrument .mc-bento .row2 { grid-row: auto; }
+  .landing-v2 .browser--instrument .mc-hero { min-height: 240px; }
+  .landing-v2 .browser--instrument .mc-clock-time .t { font-size: 40px; }
+  .landing-v2 .browser--instrument .mc-clock-time .s { font-size: 18px; }
+  .landing-v2 .browser--instrument .mc-main { padding: 12px; }
+}
+
+/* ---- Wrapped recap deck (scrolls below the bento) + card-viz charts ---- */
+.landing-v2 .browser--instrument .mc-wr-section { margin-top: 4px; }
+.landing-v2 .browser--instrument .mc-wr-kicker { margin-bottom: 12px; }
+.landing-v2 .browser--instrument .mc-wr-deck {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-auto-rows: min-content;
+  align-content: start;
+  gap: 12px;
+}
+.landing-v2 .browser--instrument .mc-wr-card {
+  --card-accent: var(--green);
+  align-self: start;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: 172px;
+}
+.landing-v2 .browser--instrument .mc-wr-card.acc-green { --card-accent: var(--green); }
+.landing-v2 .browser--instrument .mc-wr-card.acc-blue { --card-accent: var(--blue); }
+.landing-v2 .browser--instrument .mc-wr-card.acc-gold { --card-accent: var(--gold); }
+.landing-v2 .browser--instrument .mc-wr-card.acc-violet { --card-accent: var(--violet); }
+.landing-v2 .browser--instrument .mc-wr-card.acc-rose { --card-accent: #e0556f; }
+.landing-v2 .browser--instrument .mc-wr-viz {
+  height: 46px;
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+}
+.landing-v2 .browser--instrument .mc-wr-viz--center { justify-content: center; }
+.landing-v2 .browser--instrument .mc-wr-q {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--card-accent);
+}
+.landing-v2 .browser--instrument .mc-wr-head {
+  font-family: var(--serif);
+  font-weight: 600;
+  font-size: 21px;
+  line-height: 1.08;
+  letter-spacing: -0.01em;
+  color: var(--display);
+  margin: 6px 0 0;
+}
+.landing-v2 .browser--instrument .mc-wr-body {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--muted);
+  margin: 7px 0 0;
+}
+/* bars */
+.landing-v2 .browser--instrument .mc-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  width: 100%;
+  height: 46px;
+}
+.landing-v2 .browser--instrument .mc-bars i {
+  flex: 1;
+  background: color-mix(in srgb, var(--card-accent) 70%, var(--surface));
+  border-radius: 1px 1px 0 0;
+  min-height: 3px;
+}
+.landing-v2 .browser--instrument .mc-bars i.is-now { background: var(--card-accent); }
+/* line / area */
+.landing-v2 .browser--instrument .mc-line { width: 100%; height: 46px; display: block; }
+.landing-v2 .browser--instrument .mc-line-stroke {
+  stroke: var(--card-accent);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+/* radar */
+.landing-v2 .browser--instrument .mc-radar { width: 46px; height: 46px; }
+.landing-v2 .browser--instrument .mc-radar .web {
+  fill: none;
+  stroke: var(--line-hi);
+  stroke-width: 0.5;
+}
+.landing-v2 .browser--instrument .mc-radar-fill {
+  fill: color-mix(in srgb, var(--card-accent) 24%, transparent);
+  stroke: var(--card-accent);
+  stroke-width: 1;
+}
+.landing-v2 .browser--instrument .mc-radar-node { fill: var(--card-accent); }
+/* ring gauge */
+.landing-v2 .browser--instrument .mc-ring { position: relative; width: 46px; height: 46px; }
+.landing-v2 .browser--instrument .mc-ring svg { width: 46px; height: 46px; transform: rotate(135deg); }
+.landing-v2 .browser--instrument .mc-ring .bg { fill: none; stroke: var(--line); stroke-width: 3.2; }
+.landing-v2 .browser--instrument .mc-ring .fg {
+  fill: none;
+  stroke: var(--card-accent);
+  stroke-width: 3.2;
+  stroke-linecap: round;
+}
+.landing-v2 .browser--instrument .mc-ring-val {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-family: "n", var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 16px;
+  color: var(--display);
+}
+
+/* ===========================================================================
+   Wrapped-popup chart kinds - the readouts the floating popups cycle through
+   (bars/line/radar/ring are defined with the recap styles above). Recreated
+   from apps/studio/src/instrument/card-viz.tsx; each keys --card-accent.
+   ========================================================================= */
+/* waffle */
+.landing-v2 .browser--instrument .mc-waffle {
+  display: grid;
+  grid-template-columns: repeat(14, 1fr);
+  grid-auto-rows: 1fr;
+  gap: 2px;
+  width: 100%;
+  max-width: 168px;
+  height: 46px;
+}
+.landing-v2 .browser--instrument .mc-waffle-cell { background: var(--c0); border-radius: 1px; }
+.landing-v2 .browser--instrument .mc-waffle-cell.on { background: var(--card-accent); }
+/* candles */
+.landing-v2 .browser--instrument .mc-candles {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  gap: 3px;
+  width: 100%;
+  height: 46px;
+}
+.landing-v2 .browser--instrument .mc-candle { position: relative; flex: 1; }
+.landing-v2 .browser--instrument .mc-candle.up { color: var(--green); }
+.landing-v2 .browser--instrument .mc-candle.dn { color: var(--red); }
+.landing-v2 .browser--instrument .mc-candle-wick {
+  position: absolute;
+  left: 50%;
+  width: 1.5px;
+  transform: translateX(-50%);
+  background: currentColor;
+}
+.landing-v2 .browser--instrument .mc-candle-body {
+  position: absolute;
+  left: 1px;
+  right: 1px;
+  border-radius: 1px;
+  background: currentColor;
+}
+/* comet */
+.landing-v2 .browser--instrument .mc-comet { width: 46px; height: 46px; }
+.landing-v2 .browser--instrument .mc-comet svg { width: 46px; height: 46px; }
+.landing-v2 .browser--instrument .mc-comet-orbit { fill: none; stroke: var(--line-hi); stroke-width: 1; }
+.landing-v2 .browser--instrument .mc-comet-trail {
+  fill: none;
+  stroke: var(--card-accent);
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+.landing-v2 .browser--instrument .mc-comet-head { fill: var(--card-accent); }
+/* wave (oscilloscope) */
+.landing-v2 .browser--instrument .mc-wave { width: 100%; height: 46px; display: block; }
+.landing-v2 .browser--instrument .mc-wave-grat { stroke: var(--line); stroke-width: 1; vector-effect: non-scaling-stroke; }
+.landing-v2 .browser--instrument .mc-wave-grat.dash { stroke-dasharray: 2 3; }
+.landing-v2 .browser--instrument .mc-wave-trace { stroke: var(--card-accent); stroke-width: 1.5; }
+/* bullet */
+.landing-v2 .browser--instrument .mc-bullet {
+  width: 100%;
+  height: 46px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 9px;
+}
+.landing-v2 .browser--instrument .mc-bullet-track {
+  position: relative;
+  height: 11px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--line) 70%, transparent), var(--surface2));
+}
+.landing-v2 .browser--instrument .mc-bullet-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: 3px;
+  background: var(--card-accent);
+}
+.landing-v2 .browser--instrument .mc-bullet-tick {
+  position: absolute;
+  top: -3px;
+  bottom: -3px;
+  width: 2px;
+  background: var(--display);
+}
+.landing-v2 .browser--instrument .mc-bullet-foot {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+}
+.landing-v2 .browser--instrument .mc-bullet-val {
+  font-family: "n", var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 18px;
+  color: var(--display);
+}
+.landing-v2 .browser--instrument .mc-bullet-goal { font-family: var(--mono); font-size: 10.5px; color: var(--muted); }
+/* signal bars */
+.landing-v2 .browser--instrument .mc-signal { display: flex; align-items: flex-end; gap: 4px; height: 46px; }
+.landing-v2 .browser--instrument .mc-signal-bar {
+  width: 9px;
+  background: var(--surface2);
+  border: 1px solid var(--line);
+  border-radius: 2px;
+}
+.landing-v2 .browser--instrument .mc-signal-bar.on { background: var(--card-accent); border-color: var(--card-accent); }
+/* scatter */
+.landing-v2 .browser--instrument .mc-scatter { position: relative; width: 100%; height: 46px; }
+.landing-v2 .browser--instrument .mc-scatter-svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+.landing-v2 .browser--instrument .mc-scatter-mean { stroke: var(--line-hi); stroke-width: 1; stroke-dasharray: 3 3; }
+.landing-v2 .browser--instrument .mc-scatter-dots { position: absolute; inset: 0; }
+.landing-v2 .browser--instrument .mc-scatter-dot {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--muted);
+  transform: translate(-50%, -50%);
+}
+.landing-v2 .browser--instrument .mc-scatter-dot.hot { background: var(--card-accent); }
+/* delta */
+.landing-v2 .browser--instrument .mc-delta {
+  width: 100%;
+  height: 46px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+}
+.landing-v2 .browser--instrument .mc-delta-num { display: flex; align-items: baseline; gap: 8px; }
+.landing-v2 .browser--instrument .mc-delta-val {
+  font-family: "n", var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 26px;
+  color: var(--display);
+}
+.landing-v2 .browser--instrument .mc-delta-trend {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--card-accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.landing-v2 .browser--instrument .mc-delta.dn .mc-delta-trend { color: var(--red); }
+.landing-v2 .browser--instrument .mc-delta-spark { width: 100%; height: 14px; display: block; }
+
+/* ===========================================================================
+   Mission Control window + floating wrapped-highlight popups. The window is the
+   restored studio mock; 2-3 popup cards float over its edges (sticking out) to
+   spotlight interesting wrapped findings. Popups carry .browser--instrument so
+   they pick up the dark token block + .mc-* chart styles.
+   ========================================================================= */
+/* popups sit in the stage gutter (offsets pinned to 0) so they overlap the
+   window edges without ever exceeding the content column - no clip needed. */
+.landing-v2 .mc-stage { position: relative; max-width: 1080px; margin: 0 auto; }
+.landing-v2 .mc-stage .browser { max-width: 880px; margin: 0 auto; }
+/* desktop: strip is invisible so popups position against the stage; tablet turns
+   it into a real grid (see media query below) */
+.landing-v2 .mc-pop-strip { display: contents; }
+
+.landing-v2 .browser--instrument.mc-pop {
+  position: absolute;
+  width: 222px;
+  min-height: 152px;
+  z-index: 20;
+  background: var(--surface);
+  border: 1px solid var(--line-hi);
+  border-radius: 14px;
+  padding: 13px 15px 14px;
+  display: flex;
+  flex-direction: column;
+  box-shadow:
+    0 28px 54px -20px rgba(0, 0, 0, 0.82),
+    0 8px 20px -8px rgba(0, 0, 0, 0.55);
+  /* parallax drives `translate` (instant, per-scroll-frame); hover animates
+     `scale`/`rotate` only, so the two never fight over `transform`. */
+  translate: 0 var(--py, 0px);
+  rotate: var(--rot, 0deg);
+  transition: scale 0.2s ease, rotate 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+.landing-v2 .browser--instrument.mc-pop.acc-green { --card-accent: var(--green); }
+.landing-v2 .browser--instrument.mc-pop.acc-gold { --card-accent: var(--gold); }
+.landing-v2 .browser--instrument.mc-pop.acc-violet { --card-accent: var(--violet); }
+.landing-v2 .browser--instrument.mc-pop.acc-blue { --card-accent: var(--blue); }
+.landing-v2 .browser--instrument.mc-pop.acc-rose { --card-accent: #e0556f; }
+.landing-v2 .mc-pop--tr { top: 24px; right: 0; --rot: 2.5deg; }
+.landing-v2 .mc-pop--bl { bottom: 38px; left: 0; --rot: -2.5deg; }
+.landing-v2 .mc-pop--br { bottom: 132px; right: 0; --rot: -2deg; }
+/* swap fade when a slot cycles to the next chart */
+.landing-v2 .browser--instrument .mc-pop-swap {
+  display: flex;
+  flex-direction: column;
+  animation: mcPopSwap 0.5s ease;
+}
+@keyframes mcPopSwap {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .landing-v2 .browser--instrument .mc-pop-swap { animation: none; }
+}
+.landing-v2 .browser--instrument.mc-pop:hover {
+  scale: 1.04;
+  rotate: 0deg;
+  z-index: 40;
+  border-color: var(--card-accent);
+  box-shadow: 0 36px 70px -22px rgba(0, 0, 0, 0.88);
+}
+.landing-v2 .browser--instrument .mc-pop-badge {
+  align-self: flex-start;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--card-accent);
+  border: 1px solid color-mix(in srgb, var(--card-accent) 50%, var(--line));
+  border-radius: 4px;
+  padding: 2px 7px;
+  margin-bottom: 11px;
+}
+.landing-v2 .browser--instrument .mc-pop-viz {
+  height: 44px;
+  margin-bottom: 11px;
+  display: flex;
+  align-items: center;
+}
+.landing-v2 .browser--instrument .mc-pop-viz--center { justify-content: center; }
+.landing-v2 .browser--instrument .mc-pop-q {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--card-accent);
+}
+.landing-v2 .browser--instrument .mc-pop-h {
+  font-family: var(--serif);
+  font-weight: 600;
+  font-size: 17px;
+  line-height: 1.06;
+  letter-spacing: -0.01em;
+  color: var(--display);
+  margin: 5px 0 0;
+}
+/* tablet/iPad: popups leave the float and become a 3-up highlight strip below
+   the window (no overlap to clip), window scales down with the container. */
+@media (max-width: 940px) {
+  .landing-v2 .mc-stage { display: flex; flex-direction: column; gap: 16px; }
+  .landing-v2 .mc-stage .browser { max-width: 100%; }
+  .landing-v2 .mc-pop-strip {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+  }
+  .landing-v2 .browser--instrument.mc-pop {
+    position: static;
+    translate: none;
+    rotate: none;
+    scale: none;
+    width: auto;
+    min-height: 0;
+    box-shadow: 0 14px 30px -18px rgba(0, 0, 0, 0.7);
+  }
+  .landing-v2 .browser--instrument.mc-pop:hover { scale: 1; rotate: none; }
+}
+@media (max-width: 560px) {
+  .landing-v2 .mc-pop-strip { grid-template-columns: 1fr; }
+}
+
 /* ---------- lineage (animated) ---------- */
 .landing-v2 section.lineage {
   padding: 88px 0 96px;


### PR DESCRIPTION
## What

The landing's dashboard preview was a light-era hand-coded `/improve` mock that no longer matched the ramped studio (the nullframe dark **instrument** design system). This rebuilds it as the real **Mission Control** window and floats cycling **wrapped highlights** over it.

### Mission Control window
- Dark token bridge + icon rail + live **Doto clock** + bento: archetype sigil, sessions/tokens, activity heatmap, streak segbar, peak hour, model split.
- Ported from `apps/studio/src/instrument/*`, scoped under `.browser--instrument` so the shared `.nx-*`/`.browser` styles **stay light** for `/how-it-works`' PROPOSE act.

### Floating wrapped popups
- 3 popups pop out over the window edges, **cycling through 12 chart kinds** (bars · line · radar · ring · waffle · candles · comet · wave · scatter · bullet · signal · delta) recreated from the `card-viz` registry.
- **Scroll-driven motion**: each popup parallaxes at its own rate (`translate`), the chart index advances with scroll position, and hover straightens + lifts (`scale`/`rotate` — separate properties so parallax and hover never fight).
- **Responsive**: reduced-motion + ≤940px collapse the float into a static 3-up strip; bento → 2-col (≤820) → 1-col with a scaled clock (≤520). No clipping / no horizontal scroll.

## Verify
- `bun run build` (apps/site) passes; dist prerenders.
- Light/dark scoping verified: `/how-it-works` PROPOSE card stays `#fff`.
- Driven entirely from representative demo data; copy points at `ax serve`.

> Note: scroll parallax/cycling run via `requestAnimationFrame` + scroll position, so they animate in a real visible tab (headless/background tabs freeze rAF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)