### PR TITLE
docs(experiment): churn-as-gate-grade crux resolved — retrospective path is dead

### DIFF
--- a/docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md
+++ b/docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md
@@ -117,6 +117,36 @@ frontmatter case via `loadAgentScopeMap`, but writes no usage edge.
 
 Until #1 lands, "ax = the open-ended verifier" cannot be tested, let alone claimed.
 
+## Run 2 (2026-06-16): prereq #1 investigated → CRUX RESOLVED (retrospective path is dead)
+
+Probed whether `skill_revision` could be **backfilled from git history** of the skills'
+on-disk dirs (`scripts/prototypes/skillrev-backfill-probe.ts`). Of the top 27 invoked skills:
+
+- 18 sit in a git-tracked dir (0 shallow clones - full history available), BUT
+- only **2** have ≥2 commits touching their dir, and
+- **0** have a commit that straddles the skill's local invocation window (an edit *during* the
+  period it was being used), while **15** have all commits *predating* first local use.
+
+The mechanism is now clear and structural: skills are **installed (committed once) then used** -
+`~/.claude/skills` is an install-snapshot dir, not an evolution log. The edit happens upstream,
+*before* the user ever invokes the skill, so there is no organic before/after signal on a single
+user's machine. (Two probe bugs - `math::min(ts)` returning `"Infinity"` and an early NaN-date
+parse - were caught and fixed before drawing this conclusion; the usage window is now computed
+honestly in JS from the raw `invoked.ts` set.)
+
+**Verdict (resolves the strategy-vs-skeptic fork): the SKEPTIC was right for the passive path.**
+Two independent retrospective sources are both empty - ingest-time `skill_revision` (17 events,
+none testable) and git-history backfill (0 straddling edits). You cannot mine a gate-grade signal
+from passively-observed organic skill edits, because **busy skills don't get edited mid-use and
+edited skills aren't busy.** The confounding question (is churn-delta clean?) never even arises -
+there is no edit→outcome pairing to confound.
+
+**Therefore:** if ax wants to *be* the open-ended verifier, it must use **controlled re-runs**, not
+passive observation - i.e. extend the dojo `spar` loop to carry a *skill edit* as the one delta
+(freeze baseline → apply skill edit → re-run the same task → score). That is the deliberate,
+quota-spending path, and it is the only one that manufactures the counterfactual the gate needs.
+The retrospective `ax verify <skill@version>` design above is shelved.
+
 ## Not in scope
 
 - Building `ax verify` (gated on a positive result here).

--- a/scripts/prototypes/skillrev-backfill-probe.ts
+++ b/scripts/prototypes/skillrev-backfill-probe.ts
@@ -1,0 +1,103 @@
+/**
+ * skillrev-backfill-probe: can skill_revision be backfilled from git history,
+ * and would it overlap invocation data enough to run the churn-as-gate-grade
+ * experiment? Read-only investigation.
+ *
+ * For the top-invoked skills: is the skill's on-disk dir inside a git repo, how
+ * many commits touch its SKILL.md, and (for a multi-commit skill) do invocations
+ * straddle the commit dates? Prints a verdict.
+ *
+ *   bun scripts/prototypes/skillrev-backfill-probe.ts
+ */
+import { spawnSync } from "node:child_process";
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { AppLayer } from "@ax/lib/layers";
+
+const git = (dir: string, args: string[]): string | null => {
+    const r = spawnSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+    return r.status === 0 ? r.stdout.trim() : null;
+};
+
+const p = Effect.gen(function* () {
+    const db = yield* SurrealClient;
+
+    // Top-invoked non-synthetic skills.
+    const [rows] = yield* db.query<[Array<Record<string, unknown>>]>(`
+        SELECT type::string(out) AS sid, count() AS inv
+        FROM invoked GROUP BY sid ORDER BY inv DESC LIMIT 60;
+    `);
+    const [skills] = yield* db.query<[Array<{ id: string; name: string; dir_path: string | null }>]>(
+        `SELECT type::string(id) AS id, name, dir_path FROM skill WHERE dir_path != '(synthetic)';`,
+    );
+    const byId = new Map(skills.map((s) => [s.id, s]));
+
+    // Bulk-pull invocation timestamps; compute the per-skill usage window in JS
+    // (math::min/max(ts) returns "Infinity" on this data - ts aggregation is
+    // unreliable, so do it the honest way).
+    const [invTs] = yield* db.query<[Array<{ sid: string; ts: string }>]>(
+        `SELECT type::string(out) AS sid, type::string(ts) AS ts FROM invoked WHERE ts IS NOT NONE;`,
+    );
+    const windowBySid = new Map<string, { min: number; max: number }>();
+    for (const it of invTs ?? []) {
+        const t = new Date(it.ts).getTime();
+        if (Number.isNaN(t)) continue;
+        const w = windowBySid.get(it.sid);
+        if (!w) windowBySid.set(it.sid, { min: t, max: t });
+        else { if (t < w.min) w.min = t; if (t > w.max) w.max = t; }
+    }
+
+    let gitTracked = 0, multiCommit = 0, straddling = 0, examined = 0;
+    let shallow = 0, editsBeforeUseOnly = 0, editsAfterUseOnly = 0;
+    const hits: string[] = [];
+
+    for (const r of rows ?? []) {
+        const sid = String(r.sid);
+        const skill = byId.get(sid);
+        if (!skill?.dir_path) continue;
+        examined++;
+        const dir = skill.dir_path;
+        const inRepo = git(dir, ["rev-parse", "--is-inside-work-tree"]) === "true";
+        if (!inRepo) continue;
+        gitTracked++;
+        if (git(dir, ["rev-parse", "--is-shallow-repository"]) === "true") shallow++;
+        // commit dates (unix) touching anything in the skill dir
+        const log = git(dir, ["log", "--format=%ct", "--", "."]);
+        const commitTs = (log ?? "").split("\n").filter(Boolean).map((s) => Number(s) * 1000);
+        const inv = Number(r.inv ?? 0);
+        const win = windowBySid.get(sid);
+        if (!win) continue;                       // no usable invocation timestamps
+        const firstInv = win.min;
+        const lastInv = win.max;
+        // timing of ALL commits relative to this skill's local usage window
+        const before = commitTs.filter((c) => c < firstInv).length;
+        const during = commitTs.filter((c) => c > firstInv && c < lastInv).length;
+        const after = commitTs.filter((c) => c > lastInv).length;
+        if (commitTs.length >= 1 && during === 0 && after === 0) editsBeforeUseOnly++;
+        if (commitTs.length >= 1 && during === 0 && before === 0) editsAfterUseOnly++;
+        if (commitTs.length < 2) continue;
+        multiCommit++;
+        if (during > 0) {
+            straddling++;
+            hits.push(`  ${skill.name.padEnd(30)} inv=${inv} commits=${commitTs.length} during=${during}`);
+        }
+    }
+
+    console.log(`examined top ${examined} invoked skills`);
+    console.log(`  git-tracked dir:        ${gitTracked}  (shallow clones: ${shallow})`);
+    console.log(`  >=2 commits on dir:     ${multiCommit}`);
+    console.log(`  ALL edits PREDATE local usage (install-then-use): ${editsBeforeUseOnly}`);
+    console.log(`  ALL edits AFTER local usage:                      ${editsAfterUseOnly}`);
+    console.log(`  edit straddles invocations (TESTABLE): ${straddling}`);
+    if (hits.length) {
+        console.log("\ntestable candidates:");
+        hits.slice(0, 20).forEach((h) => console.log(h));
+    }
+    console.log(
+        straddling >= 5
+            ? `\nVERDICT: ${straddling} testable edits - git-backfill of skill_revision is worth building.`
+            : `\nVERDICT: only ${straddling} testable edits - git-backfill won't unblock the experiment; the crux needs controlled re-runs (expensive path).`,
+    );
+});
+
+await Effect.runPromise(p.pipe(Effect.provide(AppLayer)) as Effect.Effect<void, unknown, never>);


### PR DESCRIPTION
Follow-up to #458. Investigated the **primary** prereq of the churn-as-gate-grade experiment — backfilling `skill_revision` from git history — to decide whether the "ax = open-ended verifier" north-star is testable.

## Finding (decisive)
Probed git history of the top 27 invoked skills' on-disk dirs:
- 18 git-tracked (0 shallow — full history available)
- only **2** have ≥2 commits on their dir
- **0** have an edit straddling the local invocation window; **15** have all commits *predating* first use

**Mechanism:** skills are *installed (committed once) then used* — `~/.claude/skills` is an install-snapshot, not an evolution log. The edit happens upstream, before any local invocation, so there's no organic before/after signal on one machine.

## Resolution of the strategy-vs-skeptic fork
The **skeptic was right for the passive path.** Two independent retrospective sources are empty — ingest-time `skill_revision` (17 events, none testable) and git-history backfill (0 straddling). You can't mine a gate-grade signal from organic skill edits: busy skills aren't edited mid-use and edited skills aren't busy, so there's no edit→outcome pairing to even confound.

**Therefore:** if ax wants to *be* the open-ended verifier, it must use **controlled re-runs** — extend the dojo `spar` loop to carry a *skill edit* as the one delta (freeze baseline → apply edit → re-run same task → score), not passive observation. The retrospective `ax verify <skill@version>` design is shelved.

## Contents
- Resolution section added to `docs/superpowers/plans/2026-06-16-churn-as-gate-grade-experiment.md`
- Evidence probe `scripts/prototypes/skillrev-backfill-probe.ts` (two bugs caught + fixed before concluding: `math::min(ts)`=`"Infinity"`, NaN-date parse; window now computed honestly in JS)

Docs + prototype only — no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)