### PR TITLE
docs: fix MCP tool count (→17) + manifesto license (MIT→AGPL-3.0)

### DIFF
--- a/apps/site/app/components/features/features-page.tsx
+++ b/apps/site/app/components/features/features-page.tsx
@@ -644,7 +644,7 @@ export function FeaturesPage() {
           <div className="cli-row">
             <span className="cmd">ax mcp</span>
             <span className="desc">
-              Stdio MCP server - exposes ax&apos;s read-only queries as 10 tools so Claude Code or Codex can query the graph in-context.
+              Stdio MCP server - exposes ax&apos;s read-only queries as 17 tools so Claude Code or Codex can query the graph in-context.
             </span>
           </div>
           <div className="cli-row">

--- a/apps/site/app/components/showcases/profiles-community.tsx
+++ b/apps/site/app/components/showcases/profiles-community.tsx
@@ -99,7 +99,7 @@ export function ProfilesCommunityShowcase() {
       {/* ============ MCP ============ */}
       <div className="section-head">
         <h3>Hand the graph to an agent</h3>
-        <div className="meta">ax mcp · stdio · 10 read-only tools</div>
+        <div className="meta">ax mcp · stdio · 17 read-only tools</div>
       </div>
 
       <article className="surface mcp-card" aria-label="MCP server">
@@ -109,7 +109,7 @@ export function ProfilesCommunityShowcase() {
         </header>
         <p className="surface-note">
           <code>ax mcp</code> runs a stdio MCP server exposing ax&apos;s read-only queries as
-          10 tools, so an agent can interrogate your graph in-context - recall a past session,
+          17 tools, so an agent can interrogate your graph in-context - recall a past session,
           pull weighted skills, read a proposal - mid-task. Mutating ops are deliberately not
           exposed.
         </p>

--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -562,10 +562,10 @@ ax daemon: running (pid 48213)
         signature: "ax mcp",
         flags: [],
         receipt: `$ ax mcp
-ax MCP server ready (stdio) - 10 read-only tools
+ax MCP server ready (stdio) - 17 read-only tools
   recall  sessions_around  session_show  skills_weighted  ...`,
         detail: [
-          "Exposes 10 read-only tools (recall, sessions_around, session_show, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list).",
+          "Exposes 17 read-only tools (recall, sessions_around, session_show, session_metrics, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, signal_show, cost_models, cost_split, cost_routability, dispatches, dojo_agenda).",
           "Mutating ops and git-resolved queries (sessions here/near) are intentionally not exposed.",
         ],
       },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -228,7 +228,7 @@ command = "ax"
 args = ["mcp"]
 ```
 
-The 16 tools, each mirroring the matching CLI command:
+The 17 tools, each mirroring the matching CLI command:
 
 - **recall** - full-text recall across turns / commits / skills (`ax recall`).
 - **sessions_around** - sessions in a date window (`ax sessions around`).
@@ -245,6 +245,7 @@ The 16 tools, each mirroring the matching CLI command:
 - **signal_show** - signal catalog list or run a named relation signal (`ax signals`).
 - **cost_models** - per-model token and cost rollup (`ax cost models`).
 - **cost_split** - cost matrix split by origin x model (`ax cost split`).
+- **cost_routability** - main-thread routable-spend lens with est savings (`ax cost routability`).
 - **dispatches** - subagent dispatch analytics and routing candidates (`ax dispatches`).
 - **dojo_agenda** - dojo training agenda: budget envelope + prioritized work items (`ax dojo agenda`).
 

--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -89,7 +89,7 @@ it.
 ## What `ax` is
 
 `ax` is the reference implementation. Local typed graph,
-agent-readable queries, React dashboard, MIT licensed. Runs on your
+agent-readable queries, React dashboard, AGPL-3.0 licensed. Runs on your
 laptop.
 
 The surface is small on purpose:


### PR DESCRIPTION
A **promise→delivery audit** (dogfooding ax's own public claims against the shipped CLI) found the product delivers every advertised command — but two user-facing facts had drifted stale.

## 1. MCP tool count
`ax mcp` registers **17** read-only tools (`apps/axctl/src/mcp/tools.ts`). The docs disagreed:
- site `features-page.tsx`, `profiles-community.tsx` (×2), `-cli-reference.data.ts` → said **10**
- `docs/cli.md` → said **16** (its list was missing `cost_routability`)
- `CLAUDE.md` → already correct at 17

Reconciled every surface to **17** and added `cost_routability` to both tool lists.

## 2. License
`docs/manifesto.md` claimed "**MIT** licensed". The repo is **AGPL-3.0-only** (`LICENSE` + `package.json`), which the site footer + open-source section already state correctly. Fixed the manifesto.

## Audit result (for context)
Ran every promised command against a real graph — `recall`, `skills *`, `cost/costs *`, `sessions *`, `dispatches *`, `routing *`, `quota`, `profile`, `improve *`, `hooks *`, `team *`, `insights` (31 views ✓), `mcp`, `tui`, etc. **All deliver; zero missing.** insights=31 ✓ and 5-harness coverage ✓ matched their claims. The only gaps were these two stale numbers — no vaporware.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)