### PR TITLE
fix(install): profile publish watcher gate 6h -> 2h

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ profile (ProfileV1: stats + rig + taste patterns) from the graph.
 publish to a public gist (create once, PATCH in place). First run: consent
 prompt showing the exact JSON, then fork + community/users/<login>.json
 registration PR into Necmttn/ax (git-data API, no local clone). The watcher
-runs `--if-stale=6` after ingest - silent no-op until first consent.
+runs `--if-stale=2` after ingest - silent no-op until first consent.
 `--no-cost` is sticky across republishes; `ax profile unpublish` (delete
 gist + local state) resets it. State: `~/.ax/profile-publish.json`. Spec:
 docs/superpowers/specs/2026-06-12-ax-profiles-design.md; site routes land

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -154,7 +154,7 @@ const watchPlist = (binPath: string): string => `<?xml version="1.0" encoding="U
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>${binPath} ingest --since=1 >>${LOG_DIR}/watcher.log 2>&amp;1 &amp;&amp; ${binPath} derive-signals --since=1 >>${LOG_DIR}/watcher.log 2>&amp;1; ${binPath} profile publish --if-stale=6 >>${LOG_DIR}/watcher.log 2>&amp;1 || true</string>
+    <string>${binPath} ingest --since=1 >>${LOG_DIR}/watcher.log 2>&amp;1 &amp;&amp; ${binPath} derive-signals --since=1 >>${LOG_DIR}/watcher.log 2>&amp;1; ${binPath} profile publish --if-stale=2 >>${LOG_DIR}/watcher.log 2>&amp;1 || true</string>
   </array>
   <key>WatchPaths</key>
   <array>


### PR DESCRIPTION
## What

The `ax-watch` LaunchAgent republishes the public profile gist after each ingest, gated on `ax profile publish --if-stale=H`. Lower the installed gate from **6h → 2h** so the gist tracks live data more closely.

## Why

At 6h the gist sat visibly behind the local graph for most of the day. 2h keeps it fresh without spamming: the watcher only fires on new transcripts and is throttled to 60s.

## Changes
- `apps/axctl/src/cli/install.ts:157` — generated plist now stamps `--if-stale=2`
- `CLAUDE.md` — Profile section doc updated to match

Already applied the same change to my live `~/Library/LaunchAgents/com.necmttn.ax-watch.plist` and reloaded the agent; this just makes reinstalls stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)