### PR TITLE
feat(profile): redefine DEPTH as outcome-density + radar axis legend

### DIFF
--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -134,7 +134,7 @@ export function formatProfile(p: ProfileV1): string {
         lines.push("");
         lines.push("insights:");
         lines.push(
-            `  ${ins.hours_total.toFixed(1)}h total  ·  longest: ${integer(ins.longest_session_minutes)}min  ·  deep (>=90min): ${deepPct}%`,
+            `  ${ins.hours_total.toFixed(1)}h total  ·  longest: ${integer(ins.longest_session_minutes)}min  ·  landed clean: ${deepPct}%`,
         );
         lines.push(
             `  peak hour: ${String(ins.peak_hour_utc).padStart(2, "0")}:00 UTC  ·  max parallel: ${ins.max_parallel_sessions}  ·  spawned: ${integer(ins.subagents_spawned)}  ·  commits: ${integer(ins.commits)}`,

--- a/apps/axctl/src/profile/insights.test.ts
+++ b/apps/axctl/src/profile/insights.test.ts
@@ -15,9 +15,9 @@ describe("deriveInsights", () => {
     ];
 
     const baseDurations: SessionDurationRow[] = [
-        s("2026-06-12T10:00:00Z", "2026-06-12T12:30:00Z"), // 2.5h = deep
-        s("2026-06-12T11:00:00Z", "2026-06-12T11:30:00Z"), // 30min = not deep
-        s("2026-06-12T09:00:00Z", "2026-06-12T10:30:00Z"), // 1.5h = deep
+        s("2026-06-12T10:00:00Z", "2026-06-12T12:30:00Z"), // 2.5h
+        s("2026-06-12T11:00:00Z", "2026-06-12T11:30:00Z"), // 30min
+        s("2026-06-12T09:00:00Z", "2026-06-12T10:30:00Z"), // 1.5h
     ];
 
     test("hours_total sums all durations in hours", () => {
@@ -45,7 +45,21 @@ describe("deriveInsights", () => {
         expect(r!.longest_session_minutes).toBe(150);
     });
 
-    test("deep_session_share = sessions >= 90min / total sessions with duration", () => {
+    test("deep_session_share = deepSessions (clean-ship count) / non-subagent total", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 10,
+            spawned: 5,
+            commits: 20,
+            tools: [],
+            daily: baseDailyFull,
+            deepSessions: 2,
+            deepSessionTotal: 3,
+        });
+        expect(r!.deep_session_share).toBeCloseTo(2 / 3, 3);
+    });
+
+    test("deep_session_share = 0 when outcome inputs omitted", () => {
         const r = deriveInsights({
             durations: baseDurations,
             peakHour: 10,
@@ -54,7 +68,21 @@ describe("deriveInsights", () => {
             tools: [],
             daily: baseDailyFull,
         });
-        expect(r!.deep_session_share).toBeCloseTo(2 / 3, 3);
+        expect(r!.deep_session_share).toBe(0);
+    });
+
+    test("deep_session_share clamps at 1 when deepSessions exceeds total", () => {
+        const r = deriveInsights({
+            durations: baseDurations,
+            peakHour: 10,
+            spawned: 5,
+            commits: 20,
+            tools: [],
+            daily: baseDailyFull,
+            deepSessions: 5,
+            deepSessionTotal: 3,
+        });
+        expect(r!.deep_session_share).toBe(1);
     });
 
     test("busiest_day = max sessions in daily", () => {

--- a/apps/axctl/src/profile/insights.ts
+++ b/apps/axctl/src/profile/insights.ts
@@ -8,7 +8,6 @@
 import type { DailyActivityRow, SessionDurationRow, TopToolRow, WrappedCounts } from "./queries.ts";
 
 const MAX_SESSION_MS = 24 * 60 * 60 * 1000; // 24h cap per session
-const DEEP_THRESHOLD_MIN = 90;
 
 export interface InsightsInput {
     readonly durations: ReadonlyArray<SessionDurationRow>;
@@ -17,6 +16,20 @@ export interface InsightsInput {
     readonly commits: number;
     readonly tools: ReadonlyArray<TopToolRow>;
     readonly daily: ReadonlyArray<DailyActivityRow>;
+    /**
+     * Count of "outcome-deep" sessions in the window: sessions that landed a
+     * real, non-reverted commit (>0 lines touched). DEPTH measures whether your
+     * sessions REACH a clean shipped outcome, not how long they run - wall-clock
+     * and turn-count both reward thrash and penalise handoff-compressed work, so
+     * depth is graded on the result, not the effort. Omitted -> share is 0.
+     */
+    readonly deepSessions?: number;
+    /**
+     * DEPTH denominator: non-subagent sessions in the window. Kept separate from
+     * the duration-based session count because subagent sessions (which the
+     * numerator excludes) roughly double the raw total. Omitted -> share is 0.
+     */
+    readonly deepSessionTotal?: number;
     /** Optional wrapped-style window counts; omitted when not fetched. */
     readonly wrapped?: WrappedCounts;
 }
@@ -49,7 +62,6 @@ export function deriveInsights(input: InsightsInput): InsightsResult | null {
     // --- duration stats (clamped at 24h per session) ------------------------
     let totalMs = 0;
     let longestMs = 0;
-    let deepCount = 0;
     let validCount = 0;
     const events: Array<{ t: number; delta: 1 | -1 }> = [];
 
@@ -61,14 +73,19 @@ export function deriveInsights(input: InsightsInput): InsightsResult | null {
         const clampedMs = Math.min(endMs - startMs, MAX_SESSION_MS);
         totalMs += clampedMs;
         longestMs = Math.max(longestMs, clampedMs);
-        if (clampedMs / 60_000 >= DEEP_THRESHOLD_MIN) deepCount++;
         events.push({ t: startMs, delta: 1 });
         events.push({ t: endMs, delta: -1 });
     }
 
     const hours_total = Math.round((totalMs / 3_600_000) * 10) / 10;
     const longest_session_minutes = Math.round(longestMs / 60_000);
-    const deep_session_share = validCount > 0 ? deepCount / validCount : 0;
+    // DEPTH = share of (non-subagent) sessions that landed clean work. Both
+    // numerator and denominator are subagent-filtered upstream; clamped at 1 for
+    // safety. Falls back to 0 when the outcome inputs are absent (old callers).
+    const deepTotal = input.deepSessionTotal ?? 0;
+    const deep_session_share = deepTotal > 0
+        ? Math.min(1, (input.deepSessions ?? 0) / deepTotal)
+        : 0;
 
     // --- max parallel sessions (classic sweep line) --------------------------
     // Sort by time; on ties process ends before starts so back-to-back

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -9,6 +9,8 @@
  */
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
+import { recordLiteral } from "@ax/lib/ids";
+import { recordKeyPart } from "@ax/lib/shared/derive-keys";
 
 const win = (d: number) => `${Math.max(1, Math.trunc(d))}d`;
 
@@ -243,6 +245,102 @@ export const fetchSessionDurations = Effect.fn("profile.fetchSessionDurations")(
                 started_at: String(r.started_at),
                 ended_at: String(r.ended_at),
             })) satisfies SessionDurationRow[];
+    },
+);
+
+// --- deep sessions (outcome density) ----------------------------------------
+
+/**
+ * Sessions that landed a real, non-reverted commit (>0 lines touched). This is
+ * the numerator for DEPTH. Two cheap deref-light statements joined in JS (house
+ * style): (1) produced edges in window from non-subagent sessions to
+ * non-reverted commits, (2) landed LOC per of those commits. A session is
+ * "deep" when at least one of its produced commits actually touched code. No
+ * LOC floor beyond >0 - a surgical fix that ships clean is a deep outcome; size
+ * lives on the SCALE axis, not here.
+ */
+const DEEP_PRODUCED_SQL = (d: number) => `
+SELECT type::string(in) AS session, type::string(out) AS commit
+FROM produced
+WHERE in.started_at > time::now() - ${win(d)}
+  AND in.source != "claude-subagent"
+  AND out.reverted != true;`;
+
+const COMMIT_LANDED_LOC_SQL = (refs: string) => `
+SELECT type::string(in) AS commit, math::sum((additions ?? 0) + (deletions ?? 0)) AS loc
+FROM touched WHERE in IN [${refs}] GROUP BY commit;`;
+
+// DEPTH denominator: own (non-subagent) session count, so the numerator's
+// subagent filter is mirrored. fetchSessionDurations (which feeds hours/longest)
+// keeps counting every session, so the two denominators differ on purpose -
+// subagent sessions roughly DOUBLE the raw count and would halve this share.
+const DEEP_SESSION_TOTAL_SQL = (d: number) => `
+SELECT count() AS total FROM session
+WHERE started_at > time::now() - ${win(d)}
+  AND started_at IS NOT NONE
+  AND source != "claude-subagent"
+GROUP ALL;`;
+
+const LOC_CHUNK = 500;
+
+export interface DeepSessionCount {
+    /** sessions that landed >=1 real, non-reverted commit (DEPTH numerator) */
+    readonly deep: number;
+    /** non-subagent sessions in window (DEPTH denominator) */
+    readonly total: number;
+}
+
+export const fetchDeepSessionCount = Effect.fn("profile.fetchDeepSessionCount")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const totalRows = yield* db
+            .query<[Array<Record<string, unknown>>]>(DEEP_SESSION_TOTAL_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const total = Number(totalRows[0]?.total ?? 0);
+
+        const produced = yield* db
+            .query<[Array<Record<string, unknown>>]>(DEEP_PRODUCED_SQL(opts.windowDays))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+
+        // (session, commit-key) pairs for landed, non-reverted commits.
+        const pairs = produced
+            .map((r) => ({
+                session: String(r.session ?? ""),
+                commit: recordKeyPart(String(r.commit ?? ""), "commit"),
+            }))
+            .filter((p): p is { session: string; commit: string } =>
+                p.session.length > 0 && p.commit !== null && p.commit.length > 0);
+        if (pairs.length === 0) return { deep: 0, total } satisfies DeepSessionCount;
+
+        const commitKeys = [...new Set(pairs.map((p) => p.commit))];
+        const chunks: string[][] = [];
+        for (let i = 0; i < commitKeys.length; i += LOC_CHUNK) {
+            chunks.push(commitKeys.slice(i, i + LOC_CHUNK));
+        }
+        const locRows = (yield* Effect.all(
+            chunks.map((keys) =>
+                db.query<[Array<Record<string, unknown>>]>(
+                    COMMIT_LANDED_LOC_SQL(keys.map((k) => recordLiteral("commit", k)).join(", ")),
+                ).pipe(Effect.map((r) => r?.[0] ?? [])),
+            ),
+            { concurrency: 4 },
+        )).flat();
+
+        // Commit keys whose landed diff actually touched code.
+        const realCommits = new Set<string>();
+        for (const row of locRows) {
+            if (Number(row.loc ?? 0) > 0) {
+                const key = recordKeyPart(String(row.commit ?? ""), "commit");
+                if (key !== null && key.length > 0) realCommits.add(key);
+            }
+        }
+
+        // Distinct sessions that produced >=1 real commit.
+        const deep = new Set<string>();
+        for (const p of pairs) {
+            if (realCommits.has(p.commit)) deep.add(p.session);
+        }
+        return { deep: deep.size, total } satisfies DeepSessionCount;
     },
 );
 

--- a/apps/axctl/src/profile/render.test.ts
+++ b/apps/axctl/src/profile/render.test.ts
@@ -11,6 +11,7 @@ import { buildProfile } from "./render.ts";
 // 17 wrappedCounts(distinctSkills)  18 wrappedCounts(reposCount)
 // 19 dailyModels  20 dailyToolCalls  21 dailyCommits
 // 22 windowedInvocations  23 windowedSessions
+// 24 deepSessions:total  25 deepSessions:produced  26 deepSessions:landed-loc
 const mockResults = [
     [[{ prompt_tokens: 31_000_000, completion_tokens: 7_000_000, sessions: 142 }]],
     [[{ date: "2026-06-11" }, { date: "2026-06-12" }]],
@@ -71,6 +72,18 @@ const mockResults = [
     [[
         { id: "session:1", s: "2026-06-12T10:00:00Z", e: "2026-06-12T12:30:00Z" },
         { id: "session:2", s: "2026-06-12T09:00:00Z", e: "2026-06-12T10:30:00Z" },
+    ]],
+    // 24: deepSessions total (non-subagent session count = DEPTH denominator)
+    [[{ total: 2 }]],
+    // 25: deepSessions produced edges (session -> non-reverted commit)
+    [[
+        { session: "session:1", commit: "commit:abc" },
+        { session: "session:2", commit: "commit:def" },
+    ]],
+    // 26: deepSessions landed LOC per commit (commit:def landed nothing -> not deep)
+    [[
+        { commit: "commit:abc", loc: 120 },
+        { commit: "commit:def", loc: 0 },
     ]],
 ];
 
@@ -133,7 +146,8 @@ describe("buildProfile", () => {
         expect(p.insights).toBeDefined();
         expect(p.insights!.hours_total).toBeCloseTo(4, 1); // 2.5h + 1.5h
         expect(p.insights!.longest_session_minutes).toBe(150);
-        expect(p.insights!.deep_session_share).toBe(1); // both sessions >= 90min
+        // 1 of 2 non-subagent sessions landed a real commit (session:1 -> commit:abc, loc>0)
+        expect(p.insights!.deep_session_share).toBe(0.5);
         expect(p.insights!.peak_hour_utc).toBe(13);
         expect(p.insights!.busiest_day).toEqual({ date: "2026-06-12", sessions: 12 });
         expect(p.insights!.max_parallel_sessions).toBe(2);

--- a/apps/axctl/src/profile/render.ts
+++ b/apps/axctl/src/profile/render.ts
@@ -15,6 +15,7 @@ import {
     fetchDailyCommits,
     fetchDailyModels,
     fetchDailyToolCalls,
+    fetchDeepSessionCount,
     fetchHarnesses,
     fetchPeakHour,
     fetchSessionDurations,
@@ -82,6 +83,10 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         const dailyCommits = yield* fetchDailyCommits({ windowDays });
         const windowedInvocations = yield* fetchWindowedInvocations({ windowDays });
         const windowedSessions = yield* fetchWindowedSessions({ windowDays });
+        // 24 deepSessions (outcome-density DEPTH numerator + non-subagent
+        // denominator; appended last so existing render.test mock order stays
+        // aligned). Internally fans out: total-count -> produced -> landed-loc.
+        const deep = yield* fetchDeepSessionCount({ windowDays });
 
         const streak = computeStreak(daily, env.today);
 
@@ -109,6 +114,8 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
             commits: commitCount,
             tools: topTools,
             daily: dailyFull,
+            deepSessions: deep.deep,
+            deepSessionTotal: deep.total,
             wrapped: wrappedCounts,
         });
 

--- a/apps/site/app/lib/radar.test.ts
+++ b/apps/site/app/lib/radar.test.ts
@@ -88,10 +88,10 @@ describe("profileToAxes - ENDURANCE log anchors", () => {
 });
 
 describe("profileToAxes - linear axes + caps", () => {
-    it("DEPTH maps 0->0, 60%->100, caps above", () => {
+    it("DEPTH maps 0->0, 30%->100, caps above", () => {
         expect(profileToAxes(profile({ insights: baseInsights({ deep_session_share: 0 }) })).scores.DEPTH).toBe(0);
-        expect(profileToAxes(profile({ insights: baseInsights({ deep_session_share: 0.3 }) })).scores.DEPTH).toBeCloseTo(50, 1);
-        expect(profileToAxes(profile({ insights: baseInsights({ deep_session_share: 0.6 }) })).scores.DEPTH).toBe(100);
+        expect(profileToAxes(profile({ insights: baseInsights({ deep_session_share: 0.15 }) })).scores.DEPTH).toBeCloseTo(50, 1);
+        expect(profileToAxes(profile({ insights: baseInsights({ deep_session_share: 0.3 }) })).scores.DEPTH).toBe(100);
         expect(profileToAxes(profile({ insights: baseInsights({ deep_session_share: 0.9 }) })).scores.DEPTH).toBe(100);
     });
 
@@ -178,7 +178,7 @@ describe("profileToAxes - raws", () => {
                 repos_count: 12,
             }),
         }));
-        expect(a.raws.DEPTH.label).toBe("7.7% deep sessions");
+        expect(a.raws.DEPTH.label).toBe("7.7% landed clean");
         expect(a.raws.SCALE.label).toBe("19.6B tokens");
         expect(a.raws.RIGOR.label).toBe("2.9% verification share");
         expect(a.raws.DELEGATION.label).toBe("0.87 subagents/session");

--- a/apps/site/app/lib/radar.ts
+++ b/apps/site/app/lib/radar.ts
@@ -60,7 +60,7 @@ export interface AxisMeta {
 }
 
 export const RADAR_AXES_META: readonly AxisMeta[] = [
-    { key: "DEPTH", label: "DEPTH", note: "share of sessions that ran long" },
+    { key: "DEPTH", label: "DEPTH", note: "share of sessions that landed clean work" },
     { key: "SCALE", label: "SCALE", note: "total tokens moved" },
     { key: "RIGOR", label: "RIGOR", note: "verification share of tool calls" },
     { key: "DELEGATION", label: "DELEG", note: "subagents per session" },
@@ -121,8 +121,11 @@ function logAnchored(value: number, anchors: ReadonlyArray<readonly [number, num
  * result `partial` so the UI can say "some axes need a newer ax version".
  *
  * Axes:
- *  - DEPTH      deep_session_share, linear: 0% -> 0, 60% -> 100 (capped).
- *               Deep work plateaus; nobody runs 100% 90-min sessions.
+ *  - DEPTH      deep_session_share, linear: 0% -> 0, 30% -> 100 (capped).
+ *               Now an OUTCOME metric: share of sessions that landed a real,
+ *               non-reverted commit. Graded on shipping clean work, not on
+ *               wall-clock or turn count (both reward thrash + punish
+ *               handoff-compressed sessions). ~14% ship at all; 30%+ maxes.
  *  - SCALE      tokens.total, log-anchored:
  *                 1M -> 10, 100M -> 40, 1B -> 60, 10B -> 85, 100B -> 100.
  *               Token totals span 5+ orders of magnitude; log keeps them legible.
@@ -144,9 +147,9 @@ export function profileToAxes(p: ProfileV1): RadarAxes {
     let depth = 0;
     let depthRaw = MISSING_RAW;
     if (ins) {
-        depth = score((ins.deep_session_share / 0.6) * 100);
+        depth = score((ins.deep_session_share / 0.3) * 100);
         depthRaw = {
-            label: `${pct1(ins.deep_session_share * 100)} deep sessions`,
+            label: `${pct1(ins.deep_session_share * 100)} landed clean`,
             value: ins.deep_session_share,
         };
     } else {
@@ -314,7 +317,7 @@ function blurbFor(top: RadarAxisKey, second: RadarAxisKey, p: ProfileV1): string
     const fact = (axis: RadarAxisKey): string => {
         switch (axis) {
             case "DEPTH":
-                return ins ? `${pct1(ins.deep_session_share * 100)} of your sessions run long` : "your deep-session share";
+                return ins ? `${pct1(ins.deep_session_share * 100)} of your sessions land clean work` : "your clean-ship share";
             case "SCALE":
                 return `${fmtCompact.format(p.stats.tokens.total)} tokens moved`;
             case "RIGOR":

--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -424,6 +424,7 @@ function SignSection({ n, profile, vs }: { n: string; profile: ProfileV1; vs: Vs
                             some axes read 0 - they need a newer ax version to populate.
                         </p>
                     )}
+                    <AxisLegend />
                 </div>
 
                 <div className="pf-sign-read">
@@ -483,6 +484,20 @@ function SignSection({ n, profile, vs }: { n: string; profile: ProfileV1; vs: Vs
                 vs={vsReady && vsAxes ? { axes: vsAxes, login: vsReady.login } : undefined}
             />
         </section>
+    );
+}
+
+/** Compact six-axis legend under the radar: what each spoke abbreviation means. */
+function AxisLegend() {
+    return (
+        <dl className="pf-axis-legend" aria-label="axis legend">
+            {RADAR_AXES_META.map((m) => (
+                <div className="pf-axis-legend-row" key={m.key}>
+                    <dt className="pf-axis-legend-key">{m.label}</dt>
+                    <dd className="pf-axis-legend-note">{m.note}</dd>
+                </div>
+            ))}
+        </dl>
     );
 }
 
@@ -550,7 +565,10 @@ function RawTable({
                         const bLeads = vs !== undefined && b !== undefined && b.value !== null && (a.value === null || b.value > a.value);
                         return (
                             <tr key={m.key}>
-                                <th scope="row">{m.label}</th>
+                                <th scope="row">
+                                    <span className="pf-rawvals-metric">{m.label}</span>
+                                    <span className="pf-rawvals-metric-note">{m.note}</span>
+                                </th>
                                 <td className={aLeads ? "pf-rawvals-val pf-rawvals-val--lead" : "pf-rawvals-val"}>
                                     {a.label}
                                     {aLeads && <span className="pf-rawvals-dot" aria-label="leads" />}
@@ -820,7 +838,7 @@ function buildInsightCards(ins: ProfileInsights): InsightCard[] {
         {
             q: "How deep do you go?",
             a: fmtPct(ins.deep_session_share),
-            s: "of sessions ran 90+ minutes - deliberate, not drive-by",
+            s: "of sessions landed a real, non-reverted commit - shipped, not just chatted",
             viz: <VizBar value={ins.deep_session_share} />,
         },
         {

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -13479,14 +13479,64 @@ footer.site-footer { padding: 48px 32px 56px; }
 .pf-rawvals-table thead th span { font-weight: 600; text-transform: none; letter-spacing: 0.03em; }
 .pf-rawvals-table tbody tr { border-bottom: 1px solid var(--line); }
 .pf-rawvals-table tbody th {
-    font-size: 10.5px;
     font-weight: 400;
+    color: var(--muted);
+    text-align: left;
+    width: 190px;
+    vertical-align: top;
+    padding-right: 14px;
+}
+.pf-rawvals-metric {
+    display: block;
+    font-size: 10.5px;
     text-transform: uppercase;
     letter-spacing: 0.12em;
     color: var(--muted);
-    text-align: left;
-    width: 110px;
 }
+.pf-rawvals-metric-note {
+    display: block;
+    margin-top: 2px;
+    font-size: 10px;
+    line-height: 1.35;
+    text-transform: none;
+    letter-spacing: 0.01em;
+    color: var(--faint, var(--muted));
+    opacity: 0.72;
+}
+/* under-chart axis legend: spoke abbreviation -> plain meaning */
+.pf-axis-legend {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 5px 18px;
+    margin: 14px 0 0;
+    padding: 0;
+}
+.pf-axis-legend-row {
+    display: flex;
+    align-items: baseline;
+    gap: 7px;
+    min-width: 0;
+}
+.pf-axis-legend-key {
+    flex: 0 0 auto;
+    font-size: 9.5px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+}
+.pf-axis-legend-note {
+    margin: 0;
+    font-size: 10.5px;
+    line-height: 1.3;
+    color: var(--faint, var(--muted));
+    opacity: 0.78;
+    min-width: 0;
+}
+@media (max-width: 560px) {
+    .pf-axis-legend { grid-template-columns: 1fr; }
+}
+
 .pf-rawvals-val {
     text-align: right;
     color: var(--ink);
@@ -13504,7 +13554,7 @@ footer.site-footer { padding: 48px 32px 56px; }
 }
 @media (max-width: 560px) {
     .pf-sign-name { font-size: 32px; }
-    .pf-rawvals-table tbody th { width: 84px; }
+    .pf-rawvals-table tbody th { width: 130px; }
     .pf-rawvals-val { white-space: normal; }
 }
 


### PR DESCRIPTION
## Why

DEPTH was **% of sessions ≥ 90min wall-clock** — pure elapsed time, idle gaps included. Community feedback (@mitchnick) gave three counterexamples that defeat *every* quantity framing of depth:

1. A long session can be **thrash**, not mastery.
2. Wall-clock counts **AFK idle** (open session, two prompts 2h apart = "deep").
3. Turn-count would **penalise handoff-compressed work** — the disciplined operator who keeps context short scores *worst*.

So depth-as-effort is the wrong axis. Regrade on the **result**.

## What

```
deep_session_share = sessions that landed a non-reverted commit (>0 LOC)
                     ÷ non-subagent sessions in window
```

- Surgical fix that ships clean = deep. 3-hour thrash with no commit = not. Reverted work excluded.
- **No LOC floor** — size lives on the SCALE axis, not here.
- Subagent sessions ~double the raw count (4705 vs 2514), so DEPTH gets its **own non-subagent denominator**; `hours`/`longest`/ENDURANCE keep counting everything.
- New `fetchDeepSessionCount` (count → produced → landed-LOC; deref-light + chunked).

**Real impact (necmttn, 365d):** `7.5%` wall-clock → **`13.3%` landed clean** (335/2514). Verified end-to-end: CLI prints `landed clean: 13%`.

### Radar (site)
- Recalibrate cap `0.6 → 0.3` (14% ship at all; 30%+ maxes).
- Relabel note / raw value / blurb to "landed clean work".
- **Field name kept** (`deep_session_share`, still 0–1) → published gists + sign matrix need no migration; old gists keep rendering.

### Axis legend (also @necmttn feedback)
Six-axis abbreviations weren't self-explanatory. Added both:
- a compact **legend strip under the radar**, and
- **inline notes** under each metric in the raw-values table.

So RIGOR → "verification share of tool calls", DELEG → "subagents per session", etc.

## Verification
- 158 profile/radar + 87 site/CLI tests pass; axctl typecheck clean; `@ax/site` build green.
- End-to-end CLI run against live DB confirms the new value.

## Deferred (noted, not built)
- Repair-ratio cleanliness for DEPTH (needs the churn engine over all sessions; reverted-exclusion already kills the worst thrash).
- BREADTH undercounts MCP-loaded context; taste = self-declared pride — separate threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)