### PR TITLE
fix(insights): render `ax insights tools` as a table, not raw JSON

### DIFF
--- a/apps/axctl/src/cli/insights-format.test.ts
+++ b/apps/axctl/src/cli/insights-format.test.ts
@@ -21,6 +21,24 @@ describe("formatInsightRows", () => {
         expect(output).toContain("assistant #10: I recommend building local storage first");
     });
 
+    test("renders failing tools as a compact table, not raw JSON", () => {
+        const output = formatInsightRows("tools", [
+            { name: "Edit", failure_count: 1057, status_error_count: 1057, last_seen: "2026-06-16T08:52:47.916Z" },
+            { name: "write_stdin", exit_code: 1, failure_count: 840, last_seen: "2026-06-11T13:14:03.371Z" },
+            { name: "Bash", command_norm: "bun test", exit_code: 2, failure_count: 12, last_seen: "2026-06-10T09:06:05.000Z" },
+        ]);
+
+        expect(output).toContain("1. Edit  -  1,057 failures  last 2026-06-16 08:52:47");
+        expect(output).toContain("2. write_stdin (exit 1)  -  840 failures");
+        expect(output).toContain("3. Bash: bun test (exit 2)  -  12 failures");
+        expect(output).not.toContain("status_error_count");
+        expect(output).not.toContain("{");
+    });
+
+    test("renders empty failing-tools view with a friendly message", () => {
+        expect(formatInsightRows("tools", [])).toBe("No failing tools found.");
+    });
+
     test("renders signal summaries without dumping nested JSON", () => {
         const output = formatInsightRows("message-signals", [
             {

--- a/apps/axctl/src/cli/insights-format.ts
+++ b/apps/axctl/src/cli/insights-format.ts
@@ -250,11 +250,30 @@ function formatHarnessCandidateRows(rows: readonly InsightRow[]): string {
     }).join("\n\n");
 }
 
+function formatToolRows(rows: readonly InsightRow[]): string {
+    if (rows.length === 0) return "No failing tools found.";
+    const count = (value: unknown): string => {
+        const n = numberOf(value);
+        return n === null ? textOf(value) : n.toLocaleString("en-US");
+    };
+    return rows.map((row, index) => {
+        // Bash-style rows carry the normalized command; prefer it over the bare tool name.
+        const command = textOf(row.command_norm || row.command_tool);
+        const label = command ? `${textOf(row.name)}: ${truncate(command, 80)}` : textOf(row.name);
+        const exit = numberOf(row.exit_code);
+        const exitStr = exit === null ? "" : ` (exit ${exit})`;
+        const last = row.last_seen ? `  last ${compactDate(row.last_seen)}` : "";
+        return `${index + 1}. ${label}${exitStr}  -  ${count(row.failure_count)} failures${last}`;
+    }).join("\n");
+}
+
 export function formatInsightRows(view: InsightView, rows: readonly InsightRow[], opts: { readonly json?: boolean } = {}): string {
     if (opts.json) return prettyPrint(rows);
     switch (view) {
         case "friction":
             return formatFrictionRows(rows);
+        case "tools":
+            return formatToolRows(rows);
         case "feedback-language":
         case "message-signals":
             return formatSignalRows(rows);


### PR DESCRIPTION
## What

`ax insights tools` dumped raw JSON; every sibling view (`friction`, `reactions`, …) prints formatted rows. The `tools` case was missing from the `formatInsightRows` switch, so it hit `default → prettyPrint`.

Adds `formatToolRows` — one compact line per failing tool:

```
1. Edit  -  1,057 failures  last 2026-06-16 08:52:47
2. write_stdin (exit 1)  -  840 failures  last 2026-06-11 13:14:03
3. exec_command: bun test (exit 1)  -  608 failures  last 2026-06-11 14:04:10
12. Bash: rg  -  210 failures  last 2026-06-16 08:46:32
```

Bash/exec_command rows show the normalized command; optional exit code; comma-grouped count; last-seen. Empty state: "No failing tools found." `--json` output unchanged.

## Why

Found dogfooding the new onboarding value-tour (step 7 pairs `insights friction` + `insights tools`) — the JSON dump was an inconsistent UX for a brand-new user.

## Verify

- `bun test apps/axctl/src/cli/insights-format.test.ts` — 9 pass (2 new).
- Dogfooded `insights tools` from source against the live graph (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)