### PR TITLE
fix: two dogfood findings — wrapped cards fail-visible + ax ingest reap

### DIFF
--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -9,6 +9,7 @@ import { prettyPrint } from "@ax/lib/json";
 import type { DbError } from "@ax/lib/errors";
 import { encodeClaudeProjectSlug } from "@ax/lib/transcript-locator";
 import { runIngest, withIngestRunFinish } from "../../ingest/run.ts";
+import { reapStaleIngestRuns } from "../../ingest/reap-runs.ts";
 import { withIngestLock } from "../../ingest/ingest-lock.ts";
 import { StageRegistry, type StageRegistryShape } from "../../ingest/stage/registry.ts";
 import { selectByKeys, selectByTag } from "../../ingest/stage/select.ts";
@@ -495,6 +496,31 @@ const ingestHereCommand = Command.make(
         "--stages=<a,b,c> overrides the default set.",
 ));
 
+const ingestReapCommand = Command.make(
+    "reap",
+    { dryRun: Flag.boolean("dry-run").pipe(Flag.withDefault(false)), json: jsonFlag },
+    ({ dryRun, json }) =>
+        Effect.gen(function* () {
+            const result = yield* reapStaleIngestRuns({ dryRun });
+            if (json) {
+                console.log(prettyPrint(result));
+                return;
+            }
+            if (result.found === 0) {
+                console.log("no stale ingest_run rows - nothing to reap");
+                return;
+            }
+            console.log(`${dryRun ? "would reap" : "reaped"} ${result.found} stale ingest_run row(s):`);
+            for (const id of result.ids) console.log(`  ingest_run:${id}`);
+            if (dryRun) console.log("(dry-run - no writes)");
+        }),
+).pipe(
+    Command.withDescription(
+        "Settle ingest_run rows stranded in status \"running\" past the ingest timeout " +
+            "(crash/SIGKILL residue that doctor flags). Marks each \"partial\"; idempotent. Use --dry-run to preview.",
+    ),
+);
+
 export const ingestCommand = Command.make(
     "ingest",
     {
@@ -561,7 +587,7 @@ export const ingestCommand = Command.make(
             "(see ADR-0009; canonical list lives in src/ingest/stage/registry.ts). " +
             "Use --reset to wipe the skill graph first and rebuild it clean.",
     ),
-    Command.withSubcommands([ingestHereCommand]),
+    Command.withSubcommands([ingestHereCommand, ingestReapCommand]),
 );
 
 // Shared flag specs + handlers for the derive verbs. They back BOTH the flat

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -949,7 +949,7 @@ export function collectDoctorReport(): Effect.Effect<
                     ? `no ingest_run rows stuck in status "running"`
                     : `${staleIngestRuns.length} ingest_run row(s) stuck in status "running" past the ` +
                         `${ingestTimeoutSeconds}s ingest timeout (${ids}); the run crashed or was killed ` +
-                        `without finalizing - ignore the rows for diagnosis and re-run 'ax ingest'`,
+                        `without finalizing - run 'ax ingest reap' to settle them`,
             });
         }
         const onboarding = yield* buildOnboardingReport();

--- a/apps/axctl/src/ingest/reap-runs.test.ts
+++ b/apps/axctl/src/ingest/reap-runs.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { selectStrandedRunIds } from "./reap-runs.ts";
+
+describe("selectStrandedRunIds", () => {
+    const now = Date.parse("2026-06-16T12:00:00.000Z");
+    const staleAfterMs = 960_000; // 900s timeout + 60s grace
+
+    test("reaps a run whose heartbeat is older than the budget", () => {
+        const rows = [
+            { id: "ingest_run:dead", started_at: "2026-06-16T11:00:00.000Z", last_progress_at: "2026-06-16T11:30:00.000Z" },
+        ];
+        expect(selectStrandedRunIds(rows, now, staleAfterMs)).toEqual(["dead"]);
+    });
+
+    test("spares a run whose heartbeat is within the budget", () => {
+        const rows = [
+            { id: "ingest_run:live", started_at: "2026-06-16T10:00:00.000Z", last_progress_at: "2026-06-16T11:59:00.000Z" },
+        ];
+        expect(selectStrandedRunIds(rows, now, staleAfterMs)).toEqual([]);
+    });
+
+    test("falls back to started_at when last_progress_at is absent", () => {
+        const rows = [
+            { id: "ingest_run:nohb", started_at: "2026-06-16T11:58:00.000Z" }, // 2min ago -> live
+            { id: "ingest_run:oldhb", started_at: "2026-06-16T11:00:00.000Z" }, // 1h ago -> stranded
+        ];
+        expect(selectStrandedRunIds(rows, now, staleAfterMs)).toEqual(["oldhb"]);
+    });
+
+    test("reaps a row with no parseable timestamp (can't prove it's live)", () => {
+        const rows = [{ id: "ingest_run:mystery" }];
+        expect(selectStrandedRunIds(rows, now, staleAfterMs)).toEqual(["mystery"]);
+    });
+
+    test("strips the ingest_run: prefix and backticks to a bare id", () => {
+        const rows = [{ id: "ingest_run:`weird-id`" }];
+        expect(selectStrandedRunIds(rows, now, staleAfterMs)).toEqual(["weird-id"]);
+    });
+
+    test("strips angle-bracket escaping on uuid-form ids", () => {
+        const rows = [{ id: "ingest_run:⟨070849df-4eba-4545-bd3d-c8e47d3e751a⟩" }];
+        expect(selectStrandedRunIds(rows, now, staleAfterMs)).toEqual(["070849df-4eba-4545-bd3d-c8e47d3e751a"]);
+    });
+});

--- a/apps/axctl/src/ingest/reap-runs.ts
+++ b/apps/axctl/src/ingest/reap-runs.ts
@@ -1,0 +1,91 @@
+/**
+ * Reap ingest_run rows stranded in status "running" past the ingest timeout.
+ *
+ * Every clean exit path (ok / error / interrupt / timeout) settles the row via
+ * `withIngestRunFinish`, so a still-"running" row past the budget is crash/
+ * SIGKILL residue - a lie that misleads diagnosis (doctor flags it, issue #269).
+ * This finalizes each one as "partial" with a reaped marker, matching the
+ * interrupt/timeout finalizer, so doctor stops warning and run history reads
+ * honestly. Idempotent: a row already settled drops out of the WHERE filter.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { AxConfig } from "@ax/lib/config";
+import type { DbError } from "@ax/lib/errors";
+import { buildIngestRunFinishStatement } from "../dashboard/telemetry.ts";
+
+/** Grace beyond the ingest timeout before a still-"running" row is deemed
+ *  stranded - mirrors doctor's stale-run probe (cli/install.ts). */
+export const REAP_GRACE_SECONDS = 60;
+
+interface RunningIngestRunRow {
+    readonly id?: unknown;
+    readonly started_at?: unknown;
+    readonly last_progress_at?: unknown;
+}
+
+/** Newest heartbeat (`last_progress_at`, else `started_at`) older than the
+ *  budget => stranded. No parseable timestamp => can't prove it's live, reap it.
+ *  Same rule as doctor's `staleRunningIngestRuns`. */
+const isStranded = (row: RunningIngestRunRow, nowMs: number, staleAfterMs: number): boolean => {
+    const beat = Date.parse(String(row.last_progress_at ?? row.started_at ?? ""));
+    if (!Number.isFinite(beat)) return true;
+    return nowMs - beat > staleAfterMs;
+};
+
+/** `ingest_run:⟨id⟩` or `ingest_run:\`id\`` (SurrealDB escapes ids with special
+ *  chars - e.g. a uuid's dashes - in angle brackets or backticks) -> the bare id
+ *  that `buildIngestRunFinishStatement` re-wraps in backticks (an equivalent
+ *  escape, so a uuid id still matches). */
+const bareRunId = (id: unknown): string =>
+    String(id)
+        .replace(/^ingest_run:/, "")
+        .replace(/^[`⟨]/, "")
+        .replace(/[`⟩]$/, "");
+
+/** Pure selector: the bare ids of rows that should be reaped. Exported for tests. */
+export function selectStrandedRunIds(
+    rows: readonly RunningIngestRunRow[],
+    nowMs: number,
+    staleAfterMs: number,
+): string[] {
+    return rows.filter((row) => isStranded(row, nowMs, staleAfterMs)).map((row) => bareRunId(row.id));
+}
+
+export interface ReapStaleRunsResult {
+    /** Stranded rows found (regardless of dry-run). */
+    readonly found: number;
+    /** Rows actually finalized (0 on dry-run). */
+    readonly reaped: number;
+    /** Bare run ids that were (or would be) reaped. */
+    readonly ids: ReadonlyArray<string>;
+    readonly dryRun: boolean;
+}
+
+export const reapStaleIngestRuns = (
+    opts: { readonly dryRun?: boolean } = {},
+): Effect.Effect<ReapStaleRunsResult, DbError, SurrealClient | AxConfig> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const config = yield* AxConfig;
+        const staleAfterMs = (config.knobs.ingestTimeoutSeconds + REAP_GRACE_SECONDS) * 1000;
+        const [rows] = yield* db.query<[RunningIngestRunRow[]]>(
+            "SELECT id, started_at, last_progress_at FROM ingest_run WHERE status = 'running';",
+        );
+        const ids = selectStrandedRunIds(rows ?? [], Date.now(), staleAfterMs);
+        if (!opts.dryRun) {
+            for (const runId of ids) {
+                yield* db.query(buildIngestRunFinishStatement({
+                    runId,
+                    status: "partial",
+                    metrics: { error: "reaped: stale running past ingest timeout" },
+                }));
+            }
+        }
+        return {
+            found: ids.length,
+            reaped: opts.dryRun ? 0 : ids.length,
+            ids,
+            dryRun: opts.dryRun ?? false,
+        };
+    });

--- a/apps/studio/src/instrument/instrument.css
+++ b/apps/studio/src/instrument/instrument.css
@@ -149,7 +149,11 @@
 .rdx-card {
     position: relative; overflow: hidden; background: var(--surface); border: 1px solid var(--border);
     border-radius: 16px; padding: 18px; display: flex; flex-direction: column; gap: 10px;
-    opacity: 0; animation: rdx-card-in 0.5s var(--ease-back) forwards; transition: border-color 0.18s var(--ease);
+    /* fill-mode backwards (not forwards + literal opacity:0) so the entrance
+       animation still plays from the `from` keyframe, but the resting state is
+       the element's own opacity:1 - cards fail VISIBLE if the animation never
+       runs (paused/background tab, missing keyframe). */
+    animation: rdx-card-in 0.5s var(--ease-back) backwards; transition: border-color 0.18s var(--ease);
 }
 .rdx-card:hover { border-color: var(--border-hi); }
 .rdx-card::after {


### PR DESCRIPTION
Two fixes surfaced dogfooding the onboarding value-tour end to end.

## 1. Studio: wrapped cards fail *visible*, not invisible
`apps/studio/src/instrument/instrument.css` — `.rdx-card` rested at `opacity: 0` and only reached `opacity:1` via the `rdx-card-in` keyframe (`fill-mode: forwards`). If that animation never runs (backgrounded/hidden tab pausing CSS animations, or a future bundle split dropping the keyframe), every card sits permanently invisible. Switched to `backwards`: the staggered entrance still plays from the `from` keyframe, but the resting state is the element's own `opacity:1`. Cards are now visible by default. (Found because a published wrapped deck rendered in the DOM with an `opacity:0` ancestor.)

## 2. `ax ingest reap` — settle stranded ingest_run rows
A crash/SIGKILL leaves an `ingest_run` stuck in status `"running"` (every clean exit finalizes it). Doctor flags this (issue #269) but offered no remedy — the stale rows just accumulated (I had **45** on this machine). 

New `ax ingest reap [--dry-run] [--json]`: finds runs past the ingest-timeout budget (+60s grace, mirroring doctor's probe) and finalizes each `"partial"` with a reaped marker. Idempotent. Doctor's warning now points at it. Handles uuid-form record ids (SurrealDB renders dashes in `⟨…⟩` escaping).

## Verify
- `bun test apps/axctl/src/ingest/reap-runs.test.ts` — 6 pass (pure id-selector).
- Dogfooded against the live graph: `ax ingest reap` cleared **45** real stranded rows; `ax doctor` → `ok ingest-runs`.
- `tsc --noEmit` clean on axctl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)