### PR TITLE
feat(site): revamp /leaders into a unified builder roster

### DIFF
--- a/apps/site/app/routes/leaders.tsx
+++ b/apps/site/app/routes/leaders.tsx
@@ -1,13 +1,13 @@
 // apps/site/app/routes/leaders.tsx
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SiteHeader } from "~/components/landing-sections/site-header";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
 import {
     fetchLeaderboard,
     fetchSkillStats,
     formatCompact,
-    formatUsd,
+    formatUsdCompact,
     trendingSkills,
     type Leaderboard,
     type SkillStats,
@@ -23,19 +23,17 @@ export const Route = createFileRoute("/leaders")({
     component: LeadersPage,
 });
 
-const BOARDS = ["tokens", "sessions", "streak", "cost", "skills"] as const;
-type Board = (typeof BOARDS)[number];
-
-// Below this many entrants the boards are technically valid but socially empty -
-// render the founding state instead of a one-row "leaderboard".
-const FOUNDING_THRESHOLD = 5;
-
-const valueLabel: Record<Exclude<Board, "skills">, (v: number) => string> = {
-    tokens: formatCompact,
-    sessions: formatCompact,
-    streak: (v) => `${v}d`,
-    cost: formatUsd,
-};
+// The four ranked metrics, joined into one roster row per builder. `key`
+// indexes both the leaderboard board and the RosterRow; clicking a column
+// header re-sorts the whole roster by that metric (the old tab-flip showed
+// one number at a time - this shows every builder's full receipt at once).
+type MetricKey = "tokens" | "sessions" | "cost" | "streak";
+const METRICS: ReadonlyArray<{ key: MetricKey; label: string; fmt: (v: number) => string }> = [
+    { key: "tokens", label: "tokens", fmt: formatCompact },
+    { key: "sessions", label: "sessions", fmt: formatCompact },
+    { key: "cost", label: "spend", fmt: formatUsdCompact },
+    { key: "streak", label: "streak", fmt: (v) => `${v}d` },
+];
 
 // Privacy boundary doc (the gist carries counts/dates/trend only - no transcripts).
 const WHAT_GETS_PUBLISHED =
@@ -47,17 +45,34 @@ type State =
     | { kind: "error"; message: string }
     | { kind: "ready"; lb: Leaderboard; skills: SkillStats };
 
-function entrantCount(lb: Leaderboard): number {
-    const logins = new Set<string>();
-    for (const board of [lb.boards.tokens, lb.boards.sessions, lb.boards.streak, lb.boards.cost]) {
-        for (const row of board) logins.add(row.login);
-    }
-    return logins.size;
+interface RosterRow {
+    readonly login: string;
+    tokens?: number;
+    sessions?: number;
+    cost?: number;
+    streak?: number;
+}
+
+// Fold the four independently-sorted boards into one row per builder.
+function buildRoster(lb: Leaderboard): RosterRow[] {
+    const byLogin = new Map<string, RosterRow>();
+    const merge = (key: MetricKey, rows: Leaderboard["boards"][MetricKey]) => {
+        for (const r of rows) {
+            const row = byLogin.get(r.login) ?? { login: r.login };
+            row[key] = r.value;
+            byLogin.set(r.login, row);
+        }
+    };
+    merge("tokens", lb.boards.tokens);
+    merge("sessions", lb.boards.sessions);
+    merge("cost", lb.boards.cost);
+    merge("streak", lb.boards.streak);
+    return [...byLogin.values()];
 }
 
 function LeadersPage() {
     const [state, setState] = useState<State>({ kind: "loading" });
-    const [board, setBoard] = useState<Board>("tokens");
+    const [sort, setSort] = useState<MetricKey>("tokens");
 
     useEffect(() => {
         let alive = true;
@@ -71,55 +86,105 @@ function LeadersPage() {
         return () => { alive = false; };
     }, []);
 
-    const founding = state.kind === "ready" && entrantCount(state.lb) < FOUNDING_THRESHOLD;
+    const roster = useMemo(
+        () => (state.kind === "ready" ? buildRoster(state.lb) : []),
+        [state],
+    );
+    const sorted = useMemo(() => {
+        const v = (r: RosterRow) => r[sort] ?? Number.NEGATIVE_INFINITY;
+        return [...roster].sort((a, b) => v(b) - v(a) || a.login.localeCompare(b.login));
+    }, [roster, sort]);
+    const max = useMemo(
+        () => Math.max(1, ...sorted.map((r) => r[sort] ?? 0)),
+        [sorted, sort],
+    );
+
+    const empty = state.kind === "empty" || (state.kind === "ready" && roster.length === 0);
 
     return (
         <>
             <SiteHeader />
             <main className="leaders-page">
-                <h1>leaders</h1>
-                <p className="muted">
-                    Measured from real agent telemetry (last{" "}
-                    {state.kind === "ready" ? state.lb.window_days : 30} days), self-reported
-                    by each user's local ax graph. Join: <code>ax profile publish</code>
-                </p>
+                <header className="lb-head">
+                    <h1>leaders</h1>
+                    <p className="muted">
+                        Ranked from real agent telemetry, self-reported by each builder's local ax
+                        graph and recompiled nightly. Join in one command: <code>ax profile publish</code>
+                    </p>
+                    {state.kind === "ready" && !empty && (
+                        <p className="lb-meta">
+                            <strong>{roster.length}</strong> {roster.length === 1 ? "builder" : "builders"}
+                            {" · "}last {state.lb.window_days}d
+                            {state.lb.compiled_at !== "" && (
+                                <> · compiled {state.lb.compiled_at.slice(0, 16).replace("T", " ")} UTC</>
+                            )}
+                        </p>
+                    )}
+                </header>
 
                 {state.kind === "loading" && <p className="muted">loading…</p>}
-                {(state.kind === "empty" || founding) && (
-                    <FoundingState entrants={state.kind === "ready" ? entrantCount(state.lb) : 0} />
-                )}
+                {empty && <FoundingState />}
                 {state.kind === "error" && <p className="muted">couldn't load leaderboard: {state.message}</p>}
 
-                {state.kind === "ready" && !founding && (
+                {state.kind === "ready" && !empty && (
                     <>
-                        <div className="leaders-tabs" role="tablist">
-                            {BOARDS.map((b) => (
-                                <button key={b} role="tab" aria-selected={board === b} onClick={() => setBoard(b)}>
-                                    {b === "skills" ? "trending skills" : b}
-                                </button>
-                            ))}
-                        </div>
-
-                        {board !== "skills" ? (
-                            <table className="leaders-table">
-                                <thead><tr><th>#</th><th>user</th><th>{board}</th></tr></thead>
-                                <tbody>
-                                    {state.lb.boards[board].map((row, i) => (
-                                        <tr key={row.login}>
-                                            <td>{i + 1}</td>
-                                            <td><Link to="/u/$login" params={{ login: row.login }} search={{ vs: undefined }}>@{row.login}</Link></td>
-                                            <td>{valueLabel[board](row.value)}</td>
-                                        </tr>
+                        <table className="lb-roster">
+                            <thead>
+                                <tr>
+                                    <th className="lb-rank">#</th>
+                                    <th className="lb-who">builder</th>
+                                    {METRICS.map((m) => (
+                                        <th
+                                            key={m.key}
+                                            className="lb-num"
+                                            data-active={sort === m.key}
+                                            aria-sort={sort === m.key ? "descending" : "none"}
+                                        >
+                                            <button type="button" onClick={() => setSort(m.key)}>
+                                                {m.label}
+                                                <span className="lb-caret" aria-hidden>{sort === m.key ? "▾" : ""}</span>
+                                            </button>
+                                        </th>
                                     ))}
-                                </tbody>
-                            </table>
-                        ) : (
-                            <TrendingSkillsTable skills={state.skills} />
-                        )}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {sorted.map((row, i) => (
+                                    <tr key={row.login} data-lead={i === 0}>
+                                        <td className="lb-rank">{i + 1}</td>
+                                        <td className="lb-who">
+                                            <Link to="/u/$login" params={{ login: row.login }} search={{ vs: undefined }}>
+                                                <img
+                                                    className="lb-avatar"
+                                                    src={`https://github.com/${row.login}.png?size=48`}
+                                                    alt=""
+                                                    width={24}
+                                                    height={24}
+                                                    loading="lazy"
+                                                />
+                                                <span>@{row.login}</span>
+                                            </Link>
+                                        </td>
+                                        {METRICS.map((m) => {
+                                            const v = row[m.key];
+                                            const active = sort === m.key;
+                                            return (
+                                                <td key={m.key} className="lb-num" data-active={active}>
+                                                    {active && v != null && (
+                                                        <span className="lb-bar" style={{ width: `${Math.max(2, (v / max) * 100)}%` }} aria-hidden />
+                                                    )}
+                                                    <span className="lb-val">{v == null ? "-" : m.fmt(v)}</span>
+                                                </td>
+                                            );
+                                        })}
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
 
-                        {state.lb.compiled_at !== "" && (
-                            <p className="muted">compiled {state.lb.compiled_at.slice(0, 16).replace("T", " ")} UTC · refreshes nightly</p>
-                        )}
+                        <JoinBand />
+
+                        <TrendingSkills skills={state.skills} />
                     </>
                 )}
             </main>
@@ -128,55 +193,67 @@ function LeadersPage() {
     );
 }
 
-function TrendingSkillsTable({ skills }: { readonly skills: SkillStats }) {
-    const rows = trendingSkills(skills);
-    if (rows.length === 0) {
-        return (
-            <p className="muted">
-                No skill trends yet - a skill trends once <strong>2+ builders</strong> publish
-                it (personal <code>local:*</code> skills don't count). Check back after the
-                next nightly compile.
-            </p>
-        );
-    }
+// Slim "you're next" band - woven below the live board, never a takeover. The
+// board already proves the boards are real; this just hands you the command.
+function JoinBand() {
     return (
-        <table className="leaders-table">
-            <thead><tr><th>#</th><th>skill</th><th>users</th><th>runs/30d</th></tr></thead>
-            <tbody>
-                {rows.map(([name, s], i) => (
-                    <tr key={name}>
-                        <td>{i + 1}</td>
-                        <td>{name}</td>
-                        <td>{s.users}</td>
-                        <td>{formatCompact(s.runs)}</td>
-                    </tr>
-                ))}
-            </tbody>
-        </table>
+        <aside className="lb-join">
+            <code className="lb-join-cmd">$ ax profile publish</code>
+            <span className="lb-join-copy">
+                ranks what your local ax graph measured - counts, dates, and trends only.{" "}
+                <a href={WHAT_GETS_PUBLISHED} target="_blank" rel="noreferrer">what gets published →</a>
+            </span>
+        </aside>
+    );
+}
+
+function TrendingSkills({ skills }: { readonly skills: SkillStats }) {
+    const rows = trendingSkills(skills);
+    if (rows.length === 0) return null;
+    const maxRuns = Math.max(1, ...rows.map(([, s]) => s.runs));
+    return (
+        <section className="lb-skills">
+            <h2>trending skills</h2>
+            <p className="muted">Adopted by 2+ builders (personal <code>local:*</code> skills don't count).</p>
+            <ol className="lb-skill-list">
+                {rows.map(([key, s], i) => {
+                    const idx = key.indexOf(":");
+                    const source = idx > 0 ? key.slice(0, idx) : "";
+                    const name = idx > 0 ? key.slice(idx + 1) : key;
+                    return (
+                        <li key={key} className="lb-skill">
+                            <span className="lb-skill-rank">{i + 1}</span>
+                            <span className="lb-skill-name">
+                                {source && <span className="lb-skill-src">{source}</span>}
+                                {name}
+                            </span>
+                            <span className="lb-skill-users">{s.users} builders</span>
+                            <span className="lb-skill-runs">
+                                <span className="lb-bar" style={{ width: `${Math.max(4, (s.runs / maxRuns) * 100)}%` }} aria-hidden />
+                                <span className="lb-val">{formatCompact(s.runs)}<small>/30d</small></span>
+                            </span>
+                        </li>
+                    );
+                })}
+            </ol>
+        </section>
     );
 }
 
 /**
- * Founding / empty state. The boards are legitimately empty until the nightly
- * compile picks up enough entrants - so make it earn its place: a real CTA, a
- * paper-stub render of the exact JSON shape that gets published, and an honest
- * "what gets published" privacy link. Never look broken.
+ * Founding / empty state - shown ONLY when the board has zero builders. Make it
+ * earn its place: a real CTA, a paper-stub render of the exact JSON shape that
+ * gets published, and an honest "what gets published" privacy link.
  */
-function FoundingState({ entrants }: { readonly entrants: number }) {
-    const headline =
-        entrants <= 0
-            ? "No one is on the board yet - be #1."
-            : entrants === 1
-                ? "1 builder is publishing receipts - be #2."
-                : `${entrants} builders are publishing receipts - join them.`;
+function FoundingState() {
     return (
         <section className="leaders-founding">
             <p className="lf-eyebrow">$ ax profile publish</p>
-            <h2 className="lf-headline">{headline}</h2>
+            <h2 className="lf-headline">No one is on the board yet - be #1.</h2>
             <p className="lf-lede">
-                The boards rank what your local ax graph actually measured - tokens,
-                sessions, streak, spend - and rebuild nightly. They fill in as builders
-                opt in. One command publishes yours.
+                The boards rank what your local ax graph actually measured - tokens, sessions,
+                streak, spend - and rebuild nightly. They fill in as builders opt in. One command
+                publishes yours.
             </p>
 
             <figure className="lf-stub" aria-label="example published profile">

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -12151,13 +12151,92 @@ footer.site-footer { padding: 48px 32px 56px; }
     .profile-page, .leaders-page { padding-left: 20px; padding-right: 20px; }
 }
 
-/* ----- leaders (unchanged behavior, /leaders depends on these) ----- */
-.leaders-tabs { display: flex; gap: 8px; margin: 16px 0; flex-wrap: wrap; }
-.leaders-tabs button { font: inherit; padding: 6px 14px; border: 1px solid var(--line); background: var(--panel); cursor: pointer; border-radius: 6px; }
-.leaders-tabs button[aria-selected="true"] { background: var(--ink); color: var(--page); }
-.leaders-table { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 0.9rem; }
-.leaders-table td, .leaders-table th { padding: 8px 10px; border-bottom: 1px solid var(--line); text-align: left; }
-.leaders-table td:last-child, .leaders-table th:last-child { text-align: right; }
+/* ----- leaders: live roster (every builder's full receipt, one row) ----- */
+.lb-head h1 { margin: 0 0 8px; }
+.lb-head .muted { max-width: 64ch; margin: 0 0 10px; }
+.lb-meta { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); margin: 0 0 4px; }
+.lb-meta strong { color: var(--ink); }
+
+.lb-roster { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 0.9rem; margin: 18px 0 0; }
+.lb-roster thead th {
+    font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--muted); font-weight: 600; border-bottom: 1px solid var(--line);
+    padding: 0 12px 8px; text-align: left;
+}
+.lb-roster thead th.lb-num { text-align: right; }
+.lb-roster thead th button {
+    font: inherit; color: inherit; text-transform: inherit; letter-spacing: inherit;
+    background: none; border: 0; padding: 0; cursor: pointer; display: inline-flex;
+    align-items: baseline; gap: 4px;
+}
+.lb-roster thead th button:hover { color: var(--ink); }
+.lb-roster thead th[data-active="true"] button { color: var(--ink); }
+.lb-caret { font-size: 0.6rem; }
+
+.lb-roster tbody td { padding: 11px 12px; border-bottom: 1px solid var(--line); vertical-align: middle; }
+.lb-roster tbody tr:hover { background: color-mix(in srgb, var(--panel) 60%, transparent); }
+.lb-roster tbody tr[data-lead="true"] td { background: color-mix(in srgb, var(--green) 9%, transparent); }
+.lb-rank { width: 1%; color: var(--muted); font-variant-numeric: tabular-nums; }
+.lb-roster tbody tr[data-lead="true"] .lb-rank { color: var(--green); font-weight: 700; }
+
+.lb-who a { display: inline-flex; align-items: center; gap: 9px; color: var(--ink); text-decoration: none; }
+.lb-who a:hover span { border-bottom: 1px solid var(--ink); }
+.lb-avatar { border-radius: 50%; background: var(--panel); border: 1px solid var(--line); flex: none; }
+
+.lb-num { text-align: right; font-variant-numeric: tabular-nums; }
+.lb-num .lb-val { color: var(--muted); }
+.lb-num[data-active="true"] { position: relative; }
+.lb-num[data-active="true"] .lb-val { color: var(--ink); font-weight: 600; position: relative; z-index: 1; }
+.lb-num[data-active="true"] .lb-bar {
+    position: absolute; right: 0; top: 50%; transform: translateY(-50%); height: 60%;
+    background: color-mix(in srgb, var(--green) 22%, transparent);
+    border-radius: 3px; pointer-events: none;
+}
+
+/* ----- join band (slim CTA woven below the live board, never a takeover) ----- */
+.lb-join {
+    display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    margin: 22px 0 0; padding: 12px 14px; border: 1px solid var(--line);
+    border-radius: 8px; background: var(--panel);
+}
+.lb-join-cmd {
+    font-family: var(--mono); font-size: 0.82rem; color: var(--ink);
+    background: var(--page); border: 1px solid var(--line); border-radius: 6px;
+    padding: 4px 10px; white-space: nowrap;
+}
+.lb-join-copy { font-size: 0.84rem; color: var(--muted); }
+.lb-join-copy a { color: var(--blue); border-bottom: 1px solid transparent; }
+.lb-join-copy a:hover { border-bottom-color: var(--blue); }
+
+/* ----- trending skills (real community signal, always shown when populated) ----- */
+.lb-skills { margin: 40px 0 0; }
+.lb-skills h2 { margin: 0 0 4px; }
+.lb-skills .muted { margin: 0 0 16px; }
+.lb-skill-list { list-style: none; margin: 0; padding: 0; }
+.lb-skill {
+    display: grid; grid-template-columns: 1.6rem 1fr auto minmax(110px, 0.5fr);
+    align-items: center; gap: 14px; padding: 10px 4px;
+    border-bottom: 1px solid var(--line); font-family: var(--mono); font-size: 0.86rem;
+}
+.lb-skill-rank { color: var(--muted); font-variant-numeric: tabular-nums; text-align: right; }
+.lb-skill-name { color: var(--ink); display: flex; align-items: center; gap: 8px; min-width: 0; }
+.lb-skill-src {
+    font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.03em;
+    color: var(--muted); background: var(--panel); border: 1px solid var(--line);
+    border-radius: 4px; padding: 1px 6px; flex: none;
+}
+.lb-skill-users { color: var(--muted); font-size: 0.78rem; white-space: nowrap; }
+.lb-skill-runs { position: relative; display: flex; justify-content: flex-end; align-items: center; }
+.lb-skill-runs .lb-bar {
+    position: absolute; right: 0; top: 50%; transform: translateY(-50%); height: 70%;
+    background: color-mix(in srgb, var(--blue) 18%, transparent); border-radius: 3px;
+}
+.lb-skill-runs .lb-val { position: relative; z-index: 1; color: var(--ink); font-variant-numeric: tabular-nums; }
+.lb-skill-runs .lb-val small { color: var(--muted); margin-left: 2px; }
+@media (max-width: 640px) {
+    .lb-skill { grid-template-columns: 1.4rem 1fr auto; }
+    .lb-skill-runs { grid-column: 2 / -1; justify-content: flex-start; }
+}
 
 /* ----- founding / empty state (earns its place; never looks broken) ----- */
 .leaders-founding { max-width: 640px; margin: 28px 0 12px; }


### PR DESCRIPTION
## What

Revamps `/leaders` from a tab board (one metric at a time) into a single **builder roster** — one row per builder showing all four metrics at once, with github avatars, click-to-sort columns, and an inline proportional bar on the active metric.

## Why

We now have 6 registered profiles but the page showed an empty founding state — `FOUNDING_THRESHOLD=5` was **hiding real data** behind the "be #1" stub even when builders had published.

## Changes

- **Unified roster**: tokens · sessions · spend · streak in one row; sortable headers re-rank the whole board; active column gets a proportional bar; leader row tinted; avatars from github.
- **Founding state only at 0 builders** — real boards (2–6 entrants) now render.
- **Trending skills always shown** when populated (source badges + runs/30d bars).
- **Slim join CTA** woven below the board, not a full-page takeover.

## Verification

- Typecheck clean for `leaders.tsx` (remaining site errors are pre-existing strict-null, need a prior build).
- Rendered in-browser against live data: 6 builders, sortable (streak click floats the 24d builder to #1), avatars load, 8 trending skills.

Note: this reads via the existing `community.ts` fetch path. The separate `feat/community-compile-worker` PR repoints that fetch at the live compile Worker (instant updates on registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)