### PR TITLE
chore(wip): multi-agent/multi-device issue-claim tracker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ Guidance for Claude Code and other AI assistants working in this repo.
 
 `ax` - local taste & telemetry graph for AI coding agents. Ingests transcripts from 5 harnesses - Claude Code (`~/.claude/projects/`), Codex (`~/.codex/sessions/`), Pi (`~/.pi/agent/sessions/`), OpenCode + Cursor (SQLite stores) - plus installed skills (`~/.claude/skills/`, `~/.agents/skills/`, plugin caches) into a dedicated SurrealDB instance. Each harness has a full parser dual-writing provider events (`agent_*` tables) + normalized records (`session`/`turn`/`tool_call`); `AgentProviderName` enumerates them (`apps/axctl/src/ingest/provider-events.ts`). CLI surfaces "what skills/tools you actually use" on demand.
 
+## Claiming work (multi-agent)
+
+Many agents (all pushing as the same GitHub user) run this repo in parallel, so
+issue *assignee* is useless - the **branch name is the claim**. Before starting an
+issue: `bun run wip list` (🟢 claimed shows branch, ⚪ free), then
+`bun run wip claim <issue#> [type]` (branch `<type>/<issue#>-<slug>` + label +
+claim comment). One branch per issue; work in a worktree off it. See CONTRIBUTING.md.
+
 ## Stack
 
 - **Runtime**: bun ≥ 1.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,10 @@ Guidance for Claude Code and other AI assistants working in this repo.
 Many agents (all pushing as the same GitHub user) run this repo in parallel, so
 issue *assignee* is useless - the **branch name is the claim**. Before starting an
 issue: `bun run wip list` (🟢 claimed shows branch, ⚪ free), then
-`bun run wip claim <issue#> [type]` (branch `<type>/<issue#>-<slug>` + label +
-claim comment). One branch per issue; work in a worktree off it. See CONTRIBUTING.md.
+`bun run wip claim <issue#> [type]` - creates an isolated worktree at
+`.claude/worktrees/<issue#>-<type>` on branch `<type>/<issue#>-<slug>`, pushes it,
+labels + comments the issue. `cd` to the printed worktree path to work. One branch
+per issue. See CONTRIBUTING.md.
 
 ## Stack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,23 +22,27 @@ name is the claim**. Before starting an issue:
 
 ```bash
 bun run wip list          # see open issues + which branch (if any) claimed each
-bun run wip claim 481 fix # branch fix/481-<slug>, label it, post a claim comment
-# ...do the work on that branch, open a PR...
+bun run wip claim 481 fix # worktree + branch fix/481-<slug>, label, claim comment
+cd .claude/worktrees/481-fix   # the path claim prints - do the work here, open a PR
 bun run wip release 481   # only if you abandon it; merging the PR closes it
 ```
 
-`claim` creates branch `<type>/<issue#>-<slug>`, **pushes it to origin**, adds the
-`status:in-progress` label, and posts a claim comment carrying the branch + host
-so every other agent (and machine) sees the claim - not just your local worktree.
-`wip list` reads those comments back: 🟢 = claimed (shows `branch [host, age]`),
-⚪ = free to grab.
+`claim` creates an **isolated worktree** at `.claude/worktrees/<issue#>-<type>` on
+branch `<type>/<issue#>-<slug>` (this repo's enforce-worktree guard blocks edits on
+the primary tree, so a claim never switches your current tree's branch), **pushes
+the branch to origin**, adds the `status:in-progress` label, and posts a claim
+comment carrying the branch + host so every other agent (and machine) sees the
+claim - not just your local worktree. `wip list` reads those comments back:
+🟢 = claimed (shows `branch [host, age]`), ⚪ = free to grab.
 
 **Multiple devices (same user, many laptops):** claims live on GitHub, so `wip
 list` shows the same truth everywhere - no local sync. Because `claim` pushes the
-branch, you can continue or take over work started on another machine:
+branch, you can continue or take over work started on another machine - re-running
+`claim` for the same issue on a second device checks the existing remote branch out
+into a fresh local worktree instead of forking a new branch:
 
 ```bash
-git fetch && git switch fix/481-classify-unclassified
+bun run wip claim 481 fix   # on device B: "continuing existing branch fix/481-..."
 ```
 
 The 🟢 line's `host` tells you which device owns it; the `age` flags a stale claim

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,43 @@ fast.
 - **Conventional commits.** `feat:`, `fix:`, `chore:`, `refactor:`,
   `docs:`, `test:` - scope optional. Release-please reads these.
 
+## Claiming work (multi-agent)
+
+Several agents (often all pushing as the **same** GitHub user) work this repo in
+parallel, so the issue *assignee* can't tell you who owns what. The **branch
+name is the claim**. Before starting an issue:
+
+```bash
+bun run wip list          # see open issues + which branch (if any) claimed each
+bun run wip claim 481 fix # branch fix/481-<slug>, label it, post a claim comment
+# ...do the work on that branch, open a PR...
+bun run wip release 481   # only if you abandon it; merging the PR closes it
+```
+
+`claim` creates branch `<type>/<issue#>-<slug>`, **pushes it to origin**, adds the
+`status:in-progress` label, and posts a claim comment carrying the branch + host
+so every other agent (and machine) sees the claim - not just your local worktree.
+`wip list` reads those comments back: 🟢 = claimed (shows `branch [host, age]`),
+⚪ = free to grab.
+
+**Multiple devices (same user, many laptops):** claims live on GitHub, so `wip
+list` shows the same truth everywhere - no local sync. Because `claim` pushes the
+branch, you can continue or take over work started on another machine:
+
+```bash
+git fetch && git switch fix/481-classify-unclassified
+```
+
+The 🟢 line's `host` tells you which device owns it; the `age` flags a stale claim
+(dead laptop) - clear it from any device with `bun run wip release <N>`.
+
+**Conventions this relies on:**
+- Branch = `<type>/<issue#>-<slug>` (e.g. `fix/481-classify-unclassified`). The
+  leading `<issue#>` is what links work ↔ issue everywhere.
+- One branch per issue; one agent per branch.
+- Always work in a git worktree off that branch (the worktree guard blocks edits
+  on `main`).
+
 ## Local setup
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "prepare": "effect-language-service patch && lefthook install --force",
     "postinstall": "[ -f bun.lock ] && bun2nix -o bun.nix || true",
     "typecheck": "tsc --noEmit",
+    "wip": "scripts/wip",
     "ingest": "bun apps/axctl/src/cli/index.ts ingest",
     "search": "bun apps/axctl/src/cli/index.ts search",
     "db:start": "scripts/db-start.sh",

--- a/scripts/wip
+++ b/scripts/wip
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# wip - claim / release / list in-progress issues across many agents (one GitHub user).
+#
+# Why: every agent pushes as the same GitHub user, so issue *assignee* can't tell
+# which of N concurrent agents owns an issue. The BRANCH NAME is the agent identity.
+# Claiming posts a machine-parseable claim comment carrying that branch + host, and
+# flips the `status:in-progress` label so the claim is visible to every other agent
+# (and machine) - not just the local worktree.
+#
+# Usage:
+#   scripts/wip list                 # open issues + who(which branch) claimed them
+#   scripts/wip claim <N> [type]     # branch type/N-slug, label + claim comment
+#   scripts/wip release <N>          # drop label + post release comment
+#
+# type defaults to feat (feat|fix|chore|refactor|docs|test).
+set -euo pipefail
+
+REPO="Necmttn/ax"
+LABEL="status:in-progress"
+MARK="<!-- wip-claim"   # marker prefix on claim/release comments
+
+die() { echo "wip: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null || die "missing '$1'"; }
+need gh; need jq; need git
+
+slug() { echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40; }
+
+cmd_claim() {
+  local n="${1:?issue number}" type="${2:-feat}"
+  local title; title=$(gh issue view "$n" --repo "$REPO" --json title --jq .title) \
+    || die "issue #$n not found"
+  local branch="$type/$n-$(slug "$title")"
+  local host; host=$(hostname -s)
+
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    git switch "$branch"
+  else
+    git switch -c "$branch"
+  fi
+
+  # Push the branch so it's fetchable from any device (continue/take-over across
+  # machines). Best-effort: the claim is still recorded on the issue if push fails.
+  git push -u origin "$branch" 2>/dev/null \
+    && echo "wip: pushed $branch to origin" \
+    || echo "wip: WARNING could not push $branch - claim still recorded on the issue" >&2
+
+  gh issue edit "$n" --repo "$REPO" --add-label "$LABEL" >/dev/null
+  gh issue comment "$n" --repo "$REPO" --body \
+"$MARK branch=$branch host=$host -->
+🤖 Claimed on branch \`$branch\` (host \`$host\`). Working on it - see this branch for progress."
+  echo "wip: claimed #$n on $branch"
+}
+
+cmd_release() {
+  local n="${1:?issue number}"
+  local branch; branch=$(git branch --show-current 2>/dev/null || echo "?")
+  gh issue edit "$n" --repo "$REPO" --remove-label "$LABEL" >/dev/null 2>&1 || true
+  gh issue comment "$n" --repo "$REPO" --body \
+"$MARK released branch=$branch -->
+↩️ Released by branch \`$branch\`."
+  echo "wip: released #$n"
+}
+
+cmd_list() {
+  # For each open issue, derive its live claim from the latest claim/release comment.
+  # 🟢 lines carry the claiming branch, host, and claim age so a dead-laptop claim
+  # (old age) is distinguishable from a fresh one.
+  local now; now=$(date +%s)
+  gh issue list --repo "$REPO" --state open --limit 100 \
+    --json number,title,labels,comments \
+  | jq -r --arg label "$LABEL" --arg mark "$MARK" --argjson now "$now" '
+      def ago($s):
+        ($now - $s) as $d
+        | if   $d < 3600  then "\(($d/60)    | floor)m"
+          elif $d < 86400 then "\(($d/3600)  | floor)h"
+          else                 "\(($d/86400) | floor)d" end;
+      .[]
+      | (.labels | map(.name) | index($label)) as $inprog
+      | (.comments | map(select(.body | startswith($mark))) | last) as $c
+      | (($c.body // "") | [scan("branch=([^ ]+)")] | (.[0][0] // null)) as $branch
+      | (($c.body // "") | [scan("host=([^ ]+)")]   | (.[0][0] // null)) as $host
+      | (($c.body // "") | startswith($mark + " released")) as $released
+      | (if $c then ($c.createdAt | fromdateiso8601) else null end) as $ct
+      | (if $inprog and ($released | not)
+           then "🟢 \($branch // "?")  [\($host // "?"), \(if $ct then ago($ct) else "?" end)]"
+           else "⚪ free" end) as $state
+      | "\($state)\t#\(.number)\t\(.title)"
+    ' | sort
+}
+
+case "${1:-list}" in
+  claim)   shift; cmd_claim "$@";;
+  release) shift; cmd_release "$@";;
+  list|"") cmd_list;;
+  *) die "unknown command '$1' (claim|release|list)";;
+esac

--- a/scripts/wip
+++ b/scripts/wip
@@ -23,7 +23,14 @@ die() { echo "wip: $*" >&2; exit 1; }
 need() { command -v "$1" >/dev/null || die "missing '$1'"; }
 need gh; need jq; need git
 
-slug() { echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40; }
+# kebab-case the title, capped ~40 chars but cut on a word (hyphen) boundary so
+# branch names don't end mid-word (`...unreadably-n`).
+slug() {
+  local s; s=$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
+  if [ "${#s}" -le 40 ]; then echo "$s"; return; fi
+  local cut="${s:0:40}"; cut="${cut%-*}"          # drop the trailing partial word
+  echo "$cut" | sed -E 's/-+$//'
+}
 
 cmd_claim() {
   local n="${1:?issue number}" type="${2:-feat}"
@@ -31,24 +38,38 @@ cmd_claim() {
     || die "issue #$n not found"
   local branch="$type/$n-$(slug "$title")"
   local host; host=$(hostname -s)
+  local root; root=$(git rev-parse --show-toplevel)
+  local wt="$root/.claude/worktrees/$n-$type"
 
-  if git show-ref --verify --quiet "refs/heads/$branch"; then
-    git switch "$branch"
+  [ -e "$wt" ] && die "worktree $wt already exists - cd there, or remove it first"
+
+  # This repo mandates worktrees (the enforce-worktree guard blocks edits on the
+  # primary tree), so a claim creates an ISOLATED worktree rather than switching
+  # the current tree's branch. If the branch already exists locally or on origin
+  # (a claim from another device), check it out instead of forking a new one -
+  # that's how you take over / continue cross-machine work.
+  git fetch --quiet origin "$branch" 2>/dev/null || true
+  if git show-ref --verify --quiet "refs/heads/$branch" \
+     || git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    git worktree add "$wt" "$branch" >/dev/null \
+      || die "couldn't add worktree for existing branch $branch"
+    echo "wip: continuing existing branch $branch"
   else
-    git switch -c "$branch"
+    git worktree add "$wt" -b "$branch" >/dev/null \
+      || die "couldn't create worktree/branch $branch"
+    # Push so the branch is fetchable from any device. Best-effort: the claim is
+    # still recorded on the issue even if push fails (offline).
+    git -C "$wt" push -u origin "$branch" 2>/dev/null \
+      && echo "wip: pushed $branch to origin" \
+      || echo "wip: WARNING could not push $branch - claim still recorded on the issue" >&2
   fi
-
-  # Push the branch so it's fetchable from any device (continue/take-over across
-  # machines). Best-effort: the claim is still recorded on the issue if push fails.
-  git push -u origin "$branch" 2>/dev/null \
-    && echo "wip: pushed $branch to origin" \
-    || echo "wip: WARNING could not push $branch - claim still recorded on the issue" >&2
 
   gh issue edit "$n" --repo "$REPO" --add-label "$LABEL" >/dev/null
   gh issue comment "$n" --repo "$REPO" --body \
 "$MARK branch=$branch host=$host -->
 🤖 Claimed on branch \`$branch\` (host \`$host\`). Working on it - see this branch for progress."
   echo "wip: claimed #$n on $branch"
+  echo "wip: worktree ready -> cd $wt"
 }
 
 cmd_release() {


### PR DESCRIPTION
## What

Adds `scripts/wip` (`bun run wip`) to track in-progress work across many parallel agents — and across devices.

**Problem:** every agent pushes as the same GitHub user, so issue *assignee* can't say who owns what. **The branch name is the claim.** Claims route through GitHub (label + comment), not local worktrees, so they're visible to every agent and machine.

## Commands

- `wip list` — open issues as `🟢 branch [host, age]` / `⚪ free`
- `wip claim <N> [type]` — branch `<type>/<N>-<slug>`, **push to origin**, add `status:in-progress` label, post claim comment (branch + host)
- `wip release <N>` — drop label, post release comment

## Multi-device

- Claims live on GitHub → `wip list` is identical on every laptop, no local sync
- `claim` pushes the branch → continue/take-over elsewhere with `git fetch && git switch <branch>`
- 🟢 line shows `host` (which device) + `age` (spot a dead-laptop stale claim); `release` clears from anywhere

## Also

- `status:in-progress` label created on the repo
- Convention documented in CONTRIBUTING.md + CLAUDE.md
- Render paths verified: ⚪ on live data, 🟢 on synthetic fixture (uses jq `scan`, not `capture`, which throws on no-match)

## Notes

- jq quirk: `gh issue list --json comments` returns the full comment array (incl. `body`/`createdAt`) — relied on for claim parsing
- `host` = `hostname -s`; if two machines share a hostname they're indistinguishable, but the branch name still disambiguates the work

🤖 Generated with [Claude Code](https://claude.com/claude-code)