### PR TITLE
fix(ingest): plain progress renders only stage spans (#479)

### DIFF
--- a/apps/axctl/src/cli/ingest-trace-progress.test.ts
+++ b/apps/axctl/src/cli/ingest-trace-progress.test.ts
@@ -65,4 +65,27 @@ describe("pipelineTraceTransportLayer plain mode (issue #479)", () => {
         expect(out).toContain("ingest/skills/upsert done");
         expect(out).toContain("sessions=205");
     });
+
+    test("a count event on a LEAF (grandchild) span is dropped, not attributed", () => {
+        // Counts that ride a nested span (parent = stage, not root) must not leak
+        // into output: the leaf is never tracked, so its SpanEnd is skipped and
+        // its count never reaches a finish line. Only the stage span's own
+        // SpanEnd (no count here) renders.
+        const out = render([
+            traceStart(TRACE, "whole-run", { type: "user", id: "u1" }),
+            spanStart(TRACE, "root", "skills/upsert"),
+            spanStart(TRACE, "stage1", "skills/upsert", {}, "root"),
+            spanStart(TRACE, "leaf1", "db.chunk", {}, "stage1"),
+            // count annotation arrives on the LEAF span, not the stage
+            spanEvent(TRACE, "leaf1", "attribute:ingest.count.sessions", "Info", { value: 999 }),
+            spanEnd(TRACE, "leaf1", "ok", 1),
+            spanEnd(TRACE, "stage1", "ok", 5),
+            traceEnd(TRACE, "completed", 6),
+        ]);
+
+        expect(out).toContain("ingest/skills/upsert done");
+        // The leaf-attributed count must NOT surface (it would, if leaf spans were tracked).
+        expect(out).not.toContain("sessions=999");
+        expect(out).not.toContain("db.chunk");
+    });
 });

--- a/apps/axctl/src/cli/ingest-trace-progress.test.ts
+++ b/apps/axctl/src/cli/ingest-trace-progress.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { TraceTransportTag } from "@ax/lib/live-traces/Sink";
+import { spanEnd, spanEvent, spanStart, traceEnd, traceStart, type TraceEvent } from "@ax/lib/live-traces/types";
+import { pipelineTraceTransportLayer } from "./ingest-trace-progress.ts";
+import { type ProgressSink } from "./progress.ts";
+
+function memorySink(): ProgressSink & { chunks: string[] } {
+    const chunks: string[] = [];
+    return { isTTY: false, columns: 120, chunks, write: (c) => void chunks.push(c) };
+}
+
+// Drive a sequence of trace events through the plain-mode transport and return
+// everything it wrote to the sink.
+function render(events: readonly TraceEvent[]): string {
+    const sink = memorySink();
+    const layer = pipelineTraceTransportLayer("plain", [], sink);
+    Effect.runSync(
+        Effect.gen(function* () {
+            const transport = yield* TraceTransportTag;
+            yield* transport.send(events);
+        }).pipe(Effect.provide(layer)),
+    );
+    return sink.chunks.join("");
+}
+
+const TRACE = "ingest:run1";
+
+describe("pipelineTraceTransportLayer plain mode (issue #479)", () => {
+    test("renders stage spans but suppresses nested leaf spans", () => {
+        const out = render([
+            traceStart(TRACE, "whole-run", { type: "user", id: "u1" }),
+            // root span: no parent -> never rendered, just establishes the root id
+            spanStart(TRACE, "root", "skills/upsert|signals/derive"),
+            // stage span: direct child of root -> rendered
+            spanStart(TRACE, "stage1", "skills/upsert", {}, "root"),
+            // leaf spans: children of the stage -> the #479 flood, must be silent
+            spanStart(TRACE, "leaf1", "process.runCommand", {}, "stage1"),
+            spanEnd(TRACE, "leaf1", "ok", 1),
+            spanStart(TRACE, "leaf2", "db.chunk", {}, "stage1"),
+            spanEnd(TRACE, "leaf2", "ok", 1),
+            spanEnd(TRACE, "stage1", "ok", 5),
+            traceEnd(TRACE, "completed", 6),
+        ]);
+
+        expect(out).toContain("[axctl] ingest/skills/upsert started");
+        expect(out).toContain("[axctl] ingest/skills/upsert done");
+        // The leaf-span chatter that drowned out the real progress is gone.
+        expect(out).not.toContain("process.runCommand");
+        expect(out).not.toContain("db.chunk");
+    });
+
+    test("stage-span count attributes still surface on finish", () => {
+        const out = render([
+            traceStart(TRACE, "whole-run", { type: "user", id: "u1" }),
+            spanStart(TRACE, "root", "skills/upsert"),
+            spanStart(TRACE, "stage1", "skills/upsert", {}, "root"),
+            // count annotation rides the STAGE span, not a leaf (records is the
+            // primary count, hidden from the summary; count.<field> shows up)
+            spanEvent(TRACE, "stage1", "attribute:ingest.count.sessions", "Info", { value: 205 }),
+            spanEnd(TRACE, "stage1", "ok", 5),
+            traceEnd(TRACE, "completed", 6),
+        ]);
+
+        expect(out).toContain("ingest/skills/upsert done");
+        expect(out).toContain("sessions=205");
+    });
+});

--- a/apps/axctl/src/cli/ingest-trace-progress.ts
+++ b/apps/axctl/src/cli/ingest-trace-progress.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer } from "effect";
 import { TraceTransportTag, type TraceTransport } from "@ax/lib/live-traces/Sink";
-import { createProgressReporter, type ProgressMode, type ProgressReporter, type ProgressStage } from "./progress.ts";
+import { createProgressReporter, type ProgressMode, type ProgressReporter, type ProgressSink, type ProgressStage } from "./progress.ts";
 import { initTuiProgress, type TuiProgressHandle } from "./progress-tui.tsx";
 
 /**
@@ -41,10 +41,17 @@ const readCountAttribute = (
 export const pipelineTraceTransportLayer = (
     mode: ProgressMode = "pipeline",
     stages: readonly ProgressStage[] = [],
+    sink?: ProgressSink,
 ): Layer.Layer<TraceTransportTag> => Layer.sync(
     TraceTransportTag,
     () => {
         let progress: ProgressReporter | null = null;
+        // The trace nests root -> stage span (LiveTrace.step) -> leaf spans
+        // (process.runCommand, db.chunk, ...). Only stage spans - the DIRECT
+        // children of the root - are worth a progress line; rendering every leaf
+        // floods plain mode with thousands of started/done lines (issue #479). We
+        // track the root spanId and render only spans whose parent is that root.
+        let rootSpanId: string | null = null;
         const spanNames = new Map<string, string>();
         const spanCounts = new Map<string, Record<string, number>>();
         const stageOf = (name: string): ProgressStage => ({ source: "ingest", stage: name });
@@ -63,15 +70,27 @@ export const pipelineTraceTransportLayer = (
                                     // step indices are stable; PipelineProgress still
                                     // auto-adds rows as spans start.
                                     stages,
+                                    // Only set sink when provided - exactOptionalPropertyTypes
+                                    // forbids an explicit `undefined` on the optional field.
+                                    ...(sink ? { sink } : {}),
                                 });
                                 break;
                             }
                             case "SpanStart": {
-                                // Skip the trace root span (no parent): its name is the
-                                // whole run label (every stage key joined), which wraps
-                                // the terminal and corrupts the in-place animation. Only
-                                // render actual per-stage spans.
-                                if (!event.parentSpanId) break;
+                                // The trace root span has no parent: its name is the whole
+                                // run label (every stage key joined), which wraps the
+                                // terminal and corrupts the in-place animation. Record its
+                                // id so we can tell stage spans (its direct children) from
+                                // deeper leaf spans, then skip rendering it.
+                                if (!event.parentSpanId) {
+                                    rootSpanId = event.spanId;
+                                    break;
+                                }
+                                // Render only stage spans (direct children of the root);
+                                // nested leaf spans (process.runCommand, db.chunk) are
+                                // noise (#479). Their counts ride the stage span, so
+                                // dropping them loses no progress data.
+                                if (event.parentSpanId !== rootSpanId) break;
                                 spanNames.set(event.spanId, event.name);
                                 progress?.start(stageOf(event.name));
                                 break;
@@ -99,6 +118,7 @@ export const pipelineTraceTransportLayer = (
                             case "TraceEnd": {
                                 progress?.stop();
                                 progress = null;
+                                rootSpanId = null;
                                 spanNames.clear();
                                 spanCounts.clear();
                                 break;


### PR DESCRIPTION
Closes #479 — reported by @letItCurl during first-time setup.

## Problem
`AX_PROGRESS=plain ax ingest` emitted **thousands** of `process.runCommand` / `db.chunk` started/done lines (6845 lines in the reporter's repro), burying the per-stage progress and the final summary the onboarding brief tells users to watch for.

## Root cause
The ingest trace nests **root → stage span (`LiveTrace.step`) → leaf spans (`process.runCommand`, `db.chunk`)**. `pipelineTraceTransportLayer` rendered *every* span with a parent, so each leaf became a progress line.

## Fix
Track the root spanId and render only its **direct children** (the stage spans). Count attributes (`ingest.records`, `ingest.count.*`) ride the stage span, so dropping leaf spans loses no progress data. Also applies to the non-TTY `pipeline` fallback, which shared the same transport.

Threaded an injectable `ProgressSink` into the transport so the filter is unit-testable without capturing stderr.

## Tests
`apps/axctl/src/cli/ingest-trace-progress.test.ts` (new): feeds synthetic root/stage/leaf trace events and asserts stage spans render (`ingest/skills/upsert started|done`, `sessions=205`) while `process.runCommand`/`db.chunk` stay silent. Existing `progress.test.ts` (20) still green; touched files typecheck clean.

---
🐕 First fix from the new `bun run wip` claim flow (#493) — claimed, branched, and worktree'd via the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)