### PR TITLE
fix(skills): unify weighted doctor count with classify (#481)

### DIFF
--- a/apps/axctl/src/dashboard/skills-weighted.test.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.test.ts
@@ -49,11 +49,21 @@ const mockRoleRows = [
     ],
 ];
 
+// The doctor count now delegates to fetchSkillHygiene (#481), whose ONE db.query
+// returns a 3-statement tuple: [invocation counts, skill rows, classified ids].
+// Build N distinct unclassified skills (≥3 invocations, real dir_path, unique
+// content_hash, none classified) so the hygiene join yields exactly N rows.
+function hygieneResp(n: number): unknown[] {
+    const counts = Array.from({ length: n }, (_, i) => ({ sid: `skill:u${i}`, invocations: 5, sessions: 4 }));
+    const skills = Array.from({ length: n }, (_, i) => ({ id: `skill:u${i}`, name: `u${i}`, dir_path: "/skills", content_hash: `h${i}` }));
+    return [counts, skills, []];
+}
+
 // doctor response - 3 unclassified (below threshold=5)
-const mockDoctorBelow = [[{ n: 3 }]];
+const mockDoctorBelow = hygieneResp(3);
 
 // doctor response - 7 unclassified (above threshold=5)
-const mockDoctorAbove = [[{ n: 7 }]];
+const mockDoctorAbove = hygieneResp(7);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -127,7 +137,7 @@ describe("fetchSkillsWeighted", () => {
         expect(result.rows.some((r) => r.skill_name === "codex:exec_command")).toBe(false);
     });
 
-    it("includeTools=true keeps tools and drops the synthetic doctor clause", async () => {
+    it("includeTools=true keeps tools in the ranking", async () => {
         const db = makeMockDb([
             noSparSessions, invWithTool, mockRoleRows, mockDoctorBelow, [[]], synthIds, nameRows,
         ]);
@@ -136,16 +146,23 @@ describe("fetchSkillsWeighted", () => {
 
         // Tool is ranked (and named) when opted in.
         expect(result.rows[0]!.skill_name).toBe("codex:exec_command");
-        // Doctor SQL (index 3) must NOT exclude synthetics when includeTools.
-        expect(db.captured[3]).not.toContain('dir_path = "(synthetic)"');
     });
 
-    it("doctor SQL excludes synthetics by default", async () => {
-        const db = makeMockDb();
-
-        await runWithMock(db, fetchSkillsWeighted());
-        // Doctor query is at index 3 (after spar query at 0, inv at 1, role at 2)
-        expect(db.captured[3]).toContain('dir_path = "(synthetic)"');
+    it("doctor count excludes synthetic provider tools by default (#481)", async () => {
+        // Doctor delegates to fetchSkillHygiene, which drops synthetic skills
+        // (dir_path == "(synthetic)") in JS rather than via a doctor-SQL clause.
+        const counts = [
+            { sid: "skill:real", invocations: 5, sessions: 4 },
+            { sid: "skill:synthtool", invocations: 9, sessions: 6 },
+        ];
+        const skills = [
+            { id: "skill:real", name: "real", dir_path: "/skills", content_hash: "h1" },
+            { id: "skill:synthtool", name: "tool", dir_path: "(synthetic)", content_hash: "h2" },
+        ];
+        const db = makeMockDb([noSparSessions, mockInvRows, mockRoleRows, [counts, skills, []]]);
+        const result = await runWithMock(db, fetchSkillsWeighted());
+        // Only the real unclassified skill counts; the synthetic tool is excluded.
+        expect(result.doctor.unclassified_count).toBe(1);
     });
 
     it("includes window clause when windowDays is set", async () => {
@@ -180,7 +197,7 @@ describe("fetchSkillsWeighted", () => {
     });
 
     it("handles empty invocation result gracefully", async () => {
-        const db = makeMockDb([noSparSessions, [[]], [[]], [[{ n: 0 }]]]);
+        const db = makeMockDb([noSparSessions, [[]], [[]], hygieneResp(0)]);
         const result = await runWithMock(db, fetchSkillsWeighted());
         expect(result.rows).toHaveLength(0);
         expect(result.doctor.unclassified_count).toBe(0);

--- a/apps/axctl/src/dashboard/skills-weighted.test.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.test.ts
@@ -165,6 +165,22 @@ describe("fetchSkillsWeighted", () => {
         expect(result.doctor.unclassified_count).toBe(1);
     });
 
+    it("includeTools=true counts synthetic tools in the doctor count (#481)", async () => {
+        // Mirrors the exclusion test, but opts in: includeTools must thread to
+        // hygiene's includeSynthetic so the synthetic tool is now counted too.
+        const counts = [
+            { sid: "skill:real", invocations: 5, sessions: 4 },
+            { sid: "skill:synthtool", invocations: 9, sessions: 6 },
+        ];
+        const skills = [
+            { id: "skill:real", name: "real", dir_path: "/skills", content_hash: "h1" },
+            { id: "skill:synthtool", name: "tool", dir_path: "(synthetic)", content_hash: "h2" },
+        ];
+        const db = makeMockDb([noSparSessions, mockInvRows, mockRoleRows, [counts, skills, []]]);
+        const result = await runWithMock(db, fetchSkillsWeighted({ includeTools: true }));
+        expect(result.doctor.unclassified_count).toBe(2);
+    });
+
     it("includes window clause when windowDays is set", async () => {
         const db = makeMockDb();
 

--- a/apps/axctl/src/dashboard/skills-weighted.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.ts
@@ -12,6 +12,7 @@ import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { fetchSparSessionIds } from "../queries/spar-sessions.ts";
 import { sessionTelemetryLatency, bareSession } from "../queries/telemetry-rollup.ts";
+import { fetchSkillHygiene, SKILL_HYGIENE_MIN_INVOCATIONS } from "../queries/skill-hygiene.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -189,21 +190,14 @@ const SKILL_NAMES_SQL = `SELECT id, name FROM skill`;
  */
 const SYNTHETIC_SKILLS_SQL = `SELECT VALUE id FROM skill WHERE dir_path = "(synthetic)"`;
 
-function buildUnclassifiedSql(includeTools: boolean): string {
-    // Exclude synthetic provider tools from the doctor count too, unless the
-    // caller asked for them - otherwise "N unclassified skills" is dominated by
-    // codex/pi tool calls that can never carry a role.
-    const toolClause = includeTools
-        ? ""
-        : `\n    AND sid NOT IN (${SYNTHETIC_SKILLS_SQL})`;
-    return `
-SELECT count() AS n FROM (
-    SELECT out AS sid, count() AS c FROM invoked GROUP BY sid
-)
-WHERE c >= 3
-    AND sid NOT IN (SELECT VALUE in FROM plays_role WHERE source IN ["frontmatter", "brief", "user"])${toolClause}
-GROUP ALL;`.trim();
-}
+// NOTE: the doctor count no longer has its own SurrealQL. An earlier inline
+// `buildUnclassifiedSql` drifted from queries/skill-hygiene.ts - it lacked the
+// content-hash dedup that collapses plugin-namespace twins (same SKILL.md
+// ingested under a bare AND a namespaced name) and counted orphan `invoked`
+// targets with no skill row, so the doctor over-reported (e.g. 37) while
+// `ax skills classify` briefed fewer (e.g. 30): the dead-end nudge from #481.
+// The count now delegates to fetchSkillHygiene - the SAME function classify uses
+// - so the nudge can never point at a command that finds something different.
 
 // ---------------------------------------------------------------------------
 // Main export
@@ -232,9 +226,12 @@ export const fetchSkillsWeighted = (
                     { sparSessions: [...sparSessions] },
                 ),
                 db.query<[Array<Record<string, unknown>>]>(ROLE_WEIGHT_SQL),
-                db.query<[Array<Record<string, unknown>>]>(
-                    buildUnclassifiedSql(includeTools),
-                ),
+                // Doctor count: the SAME source of truth `ax skills classify` uses,
+                // so the nudge count exactly matches what classify will brief (#481).
+                fetchSkillHygiene({
+                    minInvocations: SKILL_HYGIENE_MIN_INVOCATIONS,
+                    includeSynthetic: includeTools,
+                }),
                 db.query<[Array<unknown>]>(DELETED_SKILLS_SQL),
                 db.query<[Array<unknown>]>(SYNTHETIC_SKILLS_SQL),
                 db.query<[Array<Record<string, unknown>>]>(SKILL_NAMES_SQL),
@@ -420,9 +417,9 @@ export const fetchSkillsWeighted = (
         // Doctor
         // ---------------------------------------------------------------------------
 
-        const unclassifiedCount = Number(
-            (doctorRes?.[0] as Array<Record<string, unknown>> | undefined)?.[0]?.n ?? 0,
-        );
+        // doctorRes is now the fetchSkillHygiene row set (same as classify); its
+        // length IS the unclassified-with-≥3-invocations count.
+        const unclassifiedCount = doctorRes.length;
 
         const advice =
             unclassifiedCount >= doctorThreshold

--- a/apps/axctl/src/dashboard/skills-weighted.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.ts
@@ -185,19 +185,16 @@ const SKILL_NAMES_SQL = `SELECT id, name FROM skill`;
  * Synthetic provider built-in tool skill ids. These rows are written by the
  * codex/pi/opencode/cursor ingest with `dir_path = '(synthetic)'` so tool usage
  * is trackable, but they are tool calls, not skills. The skill table is small,
- * so this direct field-filter scan is cheap - no graph derefs. Used both as a
- * subquery (doctor) and to drop tools from the ranking in JS.
+ * so this direct field-filter scan is cheap - no graph derefs. Used to drop
+ * tools from the ranking in JS (the doctor count excludes them via hygiene's
+ * includeSynthetic flag instead).
  */
 const SYNTHETIC_SKILLS_SQL = `SELECT VALUE id FROM skill WHERE dir_path = "(synthetic)"`;
 
-// NOTE: the doctor count no longer has its own SurrealQL. An earlier inline
-// `buildUnclassifiedSql` drifted from queries/skill-hygiene.ts - it lacked the
-// content-hash dedup that collapses plugin-namespace twins (same SKILL.md
-// ingested under a bare AND a namespaced name) and counted orphan `invoked`
-// targets with no skill row, so the doctor over-reported (e.g. 37) while
-// `ax skills classify` briefed fewer (e.g. 30): the dead-end nudge from #481.
-// The count now delegates to fetchSkillHygiene - the SAME function classify uses
-// - so the nudge can never point at a command that finds something different.
+// The doctor count delegates to fetchSkillHygiene (see the Effect.all below).
+// An earlier inline `buildUnclassifiedSql` drifted from it - missing the
+// content-hash dedup and counting orphan invoked-targets - so the nudge
+// over-reported vs what classify briefs (#481).
 
 // ---------------------------------------------------------------------------
 // Main export


### PR DESCRIPTION
Closes #481 — reported by @letItCurl during onboarding.

## Problem
`ax skills classify` and `ax skills weighted` disagreed on how many skills are unclassified, so the weighted "run ax skills classify" nudge could point at a command that briefs a different count — a confusing dead-end.

`classify` already uses `fetchSkillHygiene` as the single source of truth, but the weighted **doctor count** kept its own inline `buildUnclassifiedSql`. That query:
- lacked hygiene's **content-hash dedup** → plugin-namespace twins (same `SKILL.md` under a bare AND a namespaced name) counted twice;
- counted **orphan `invoked` targets** with no skill row.

Live: doctor reported **37** while classify briefed **30**.

## Fix
Delegate the doctor count to `fetchSkillHygiene` (same threshold), so the nudge count is exactly what classify will brief. **Verified live: both now 30.** `buildUnclassifiedSql` removed; synthetic-tool exclusion now rides hygiene's `includeSynthetic` flag in JS, so two obsolete doctor-SQL-string tests became behavioral count assertions. 62 tests across the 4 affected suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)