### PR TITLE
fix(community): trend skills by canonical identity, not install source

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -22,6 +22,7 @@
 import alchemy from "alchemy";
 import { KVNamespace, Worker } from "alchemy/cloudflare";
 import { RepositoryWebhook } from "alchemy/github";
+import { FileSystemStateStore } from "alchemy/state";
 
 const OWNER = "Necmttn";
 const REPO = "ax";
@@ -36,14 +37,24 @@ function requireEnv(name: string): string {
 const githubToken = requireEnv("GITHUB_TOKEN");
 const webhookSecret = requireEnv("COMMUNITY_WEBHOOK_SECRET");
 
-const app = await alchemy("ax-community");
+// State lives in a STABLE, machine-global dir - never inside the (often
+// throwaway) git worktree this is deployed from. The default `.alchemy/` under
+// cwd vanished with a removed worktree once, which made redeploys try to
+// recreate the already-live KV/Worker/webhook. `adopt: true` below lets a
+// fresh state reconcile with existing resources rather than colliding.
+const app = await alchemy("ax-community", {
+    stateStore: (scope) =>
+        new FileSystemStateStore(scope, { rootDir: `${requireEnv("HOME")}/.ax/alchemy-state` }),
+});
 
 const board = await KVNamespace("community-board", {
     title: "ax-community-board",
+    adopt: true,
 });
 
 export const worker = await Worker("ax-community-compile", {
     name: "ax-community-compile",
+    adopt: true,
     entrypoint: "./apps/community-worker/src/worker.ts",
     bindings: {
         BOARD: board,

--- a/apps/site/app/components/showcases/profiles-community.tsx
+++ b/apps/site/app/components/showcases/profiles-community.tsx
@@ -59,9 +59,9 @@ export function ProfilesCommunityShowcase() {
             </tbody>
           </table>
           <p className="surface-note">
-            Boards rebuild nightly from registered gists. Trending skills filter out personal{" "}
-            <code className="inline">local:*</code> skills - a skill only trends once 2+ builders
-            publish it. See <Link to="/leaders">the live boards →</Link>
+            Boards rebuild from registered gists. A skill trends once 2+ builders use it -
+            however each installed it (a loose skill dir and a plugin count as the same skill).
+            See <Link to="/leaders">the live boards →</Link>
           </p>
         </article>
 

--- a/apps/site/app/lib/community.test.ts
+++ b/apps/site/app/lib/community.test.ts
@@ -314,20 +314,27 @@ describe("formatUsdCompact", () => {
 });
 
 describe("trendingSkills", () => {
+    // Keys are canonical identities (bare names); the compile already stripped
+    // the install-source prefix and folded local/plugin installs together.
     const stats = {
-        "local:my-personal-skill": { users: 1, runs: 99 },
-        "superpowers:brainstorming": { users: 3, runs: 30 },
-        "superpowers:tdd": { users: 2, runs: 12 },
-        "caveman:caveman": { users: 1, runs: 5 },
+        "my-personal-skill": { users: 1, runs: 99, source: "local" },
+        simplify: { users: 5, runs: 50, source: "local" }, // local-sourced but SHARED
+        brainstorming: { users: 3, runs: 30, source: "superpowers" },
+        tdd: { users: 2, runs: 12, source: "superpowers" },
+        caveman: { users: 1, runs: 5, source: "caveman" },
     };
-    test("drops local:* skills", () => {
+    test("shared skills trend regardless of install source (no local exclusion)", () => {
         const out = trendingSkills(stats).map(([n]) => n);
-        expect(out).not.toContain("local:my-personal-skill");
+        expect(out).toContain("simplify"); // local-sourced, but 5 builders
     });
-    test("requires users >= 2 by default", () => {
+    test("one-off personal skills drop out via the users >= 2 threshold", () => {
         const out = trendingSkills(stats).map(([n]) => n);
-        expect(out).not.toContain("caveman:caveman");
-        expect(out).toEqual(["superpowers:brainstorming", "superpowers:tdd"]);
+        expect(out).not.toContain("my-personal-skill"); // 1 builder
+        expect(out).not.toContain("caveman"); // 1 builder
+    });
+    test("sorts by users desc, then runs desc", () => {
+        const out = trendingSkills(stats).map(([n]) => n);
+        expect(out).toEqual(["simplify", "brainstorming", "tdd"]);
     });
     test("minUsers override + limit", () => {
         expect(trendingSkills(stats, { minUsers: 1, limit: 2 })).toHaveLength(2);

--- a/apps/site/app/lib/community.ts
+++ b/apps/site/app/lib/community.ts
@@ -299,7 +299,10 @@ export function validateLeaderboard(value: unknown): Leaderboard {
     };
 }
 
-export type SkillStats = Record<string, { readonly users: number; readonly runs: number }>;
+// Keyed by canonical skill identity (bare name, source prefix stripped at
+// compile time). `source` is the best-known install source for display (a real
+// plugin beats "local"); optional so older compiled payloads still validate.
+export type SkillStats = Record<string, { readonly users: number; readonly runs: number; readonly source?: string }>;
 
 // --- formatting (shared) --------------------------------------------------------
 
@@ -322,31 +325,33 @@ export const formatUsdCompact = (n: number): string =>
 // --- trending skills (display filter) -------------------------------------------
 
 /**
- * A skill "trends" only when it is a real, shared skill: plugin-namespaced or
- * a known shared source - never a one-off `local:*` skill scoped to a single
- * machine - and adopted by at least `minUsers` people. Without this the board
- * fills with junk (every personal/project skill from a single early adopter).
+ * A skill "trends" once it is shared - adopted by at least `minUsers` distinct
+ * builders. Stats are keyed by canonical identity (the compile strips the
+ * install-source prefix), so the SAME skill installed as a loose `local:` dir
+ * by one builder and a namespaced plugin by another counts together. The
+ * `minUsers >= 2` threshold - not a `local:` exclusion - is what filters
+ * one-off personal skills: a machine-specific skill only ever has 1 builder.
  */
 export function trendingSkills(
     stats: SkillStats,
     opts: { readonly minUsers?: number; readonly limit?: number } = {},
-): ReadonlyArray<readonly [string, { readonly users: number; readonly runs: number }]> {
+): ReadonlyArray<readonly [string, { readonly users: number; readonly runs: number; readonly source?: string }]> {
     const minUsers = opts.minUsers ?? 2;
     const limit = opts.limit ?? 50;
     return Object.entries(stats)
-        .filter(([name, s]) => !name.startsWith("local:") && s.users >= minUsers)
+        .filter(([, s]) => s.users >= minUsers)
         .sort(([, a], [, b]) => b.users - a.users || b.runs - a.runs)
         .slice(0, limit);
 }
 
 export function validateSkillStats(value: unknown): SkillStats {
     if (!isRecord(value)) throw new Error("invalid skill stats");
-    const out: Record<string, { users: number; runs: number }> = {};
+    const out: Record<string, { users: number; runs: number; source?: string }> = {};
     for (const [k, v] of Object.entries(value)) {
         if (!isRecord(v)) continue;
         if (typeof v.users === "number" && Number.isFinite(v.users)
             && typeof v.runs === "number" && Number.isFinite(v.runs)) {
-            out[k] = { users: v.users, runs: v.runs };
+            out[k] = { users: v.users, runs: v.runs, ...(typeof v.source === "string" ? { source: v.source } : {}) };
         }
     }
     return out;

--- a/apps/site/app/routes/leaders.tsx
+++ b/apps/site/app/routes/leaders.tsx
@@ -214,14 +214,15 @@ function TrendingSkills({ skills }: { readonly skills: SkillStats }) {
     return (
         <section className="lb-skills">
             <h2>trending skills</h2>
-            <p className="muted">Adopted by 2+ builders (personal <code>local:*</code> skills don't count).</p>
+            <p className="muted">Skills adopted by 2+ builders, however each installed them.</p>
             <ol className="lb-skill-list">
-                {rows.map(([key, s], i) => {
-                    const idx = key.indexOf(":");
-                    const source = idx > 0 ? key.slice(0, idx) : "";
-                    const name = idx > 0 ? key.slice(idx + 1) : key;
+                {rows.map(([name, s], i) => {
+                    // Keys are canonical skill identities (bare names); the badge
+                    // shows the best-known install source, but only when it's a
+                    // real plugin (a purely-`local` skill gets no badge).
+                    const source = s.source && s.source !== "local" ? s.source : "";
                     return (
-                        <li key={key} className="lb-skill">
+                        <li key={name} className="lb-skill">
                             <span className="lb-skill-rank">{i + 1}</span>
                             <span className="lb-skill-name">
                                 {source && <span className="lb-skill-src">{source}</span>}

--- a/packages/community-compile/src/compile.test.ts
+++ b/packages/community-compile/src/compile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { compileCommunity, skillStatKey, type GistFetcher } from "./compile.ts";
+import { compileCommunity, normalizeSkillName, skillStatKey, type GistFetcher } from "./compile.ts";
 
 const profile = (login: string, over: Record<string, unknown> = {}) => ({
     v: 1,
@@ -40,27 +40,55 @@ describe("compileCommunity", () => {
         expect(out.leaderboard.compiled_at).toBe("2026-06-12T03:00:00Z");
     });
 
-    test("skill/hook stats aggregate by source+name across users", async () => {
+    test("skill/hook stats aggregate by bare name across users", async () => {
         const out = await compileCommunity(users, fetcher({
             g1: profile("alice"),
             g2: profile("bob"),
         }), { now: "2026-06-12T03:00:00Z" });
 
-        expect(out.skillStats["superpowers:tdd"]).toEqual({ users: 2, runs: 20 });
+        // Keyed by canonical identity ("tdd"), not "superpowers:tdd".
+        expect(out.skillStats["tdd"]).toEqual({ users: 2, runs: 20, source: "superpowers" });
         expect(out.hookStats["enforce-worktree"]).toEqual({ users: 2 });
+    });
+
+    test("same skill installed differently per builder (local vs plugin) merges to one row", async () => {
+        // THE fix: a loosely-installed `local:simplify` and a plugin
+        // `superpowers:simplify` are the SAME skill - one row, users=2, and the
+        // real plugin source wins for display.
+        const out = await compileCommunity(users, fetcher({
+            g1: profile("alice", { rig: { skills: [{ name: "simplify", source: "local", runs: 4 }], hooks: [], routing_table: false } }),
+            g2: profile("bob", { rig: { skills: [{ name: "simplify", source: "superpowers", runs: 6 }], hooks: [], routing_table: false } }),
+        }), { now: "2026-06-12T03:00:00Z" });
+
+        expect(out.skillStats["simplify"]).toEqual({ users: 2, runs: 10, source: "superpowers" });
+        expect(out.skillStats["local:simplify"]).toBeUndefined();
+        expect(out.skillStats["superpowers:simplify"]).toBeUndefined();
+    });
+
+    test("a builder counts once per skill even with duplicate sources", async () => {
+        const out = await compileCommunity(
+            [{ github: "alice", gist_id: "g1", joined: "2026-06-01" }],
+            fetcher({
+                g1: profile("alice", { rig: { skills: [
+                    { name: "simplify", source: "local", runs: 2 },
+                    { name: "simplify", source: "superpowers", runs: 3 },
+                ], hooks: [], routing_table: false } }),
+            }),
+            { now: "2026-06-12T03:00:00Z" },
+        );
+        expect(out.skillStats["simplify"]).toEqual({ users: 1, runs: 5, source: "superpowers" });
     });
 
     test("plugin-namespaced skill name does not double its source prefix", async () => {
         // Real shape: source="superpowers", name="superpowers:brainstorming"
-        // (rig.ts keeps the plugin id inside the name). The key must NOT be
-        // "superpowers:superpowers:brainstorming".
+        // (rig.ts keeps the plugin id inside the name). Identity is "brainstorming".
         const out = await compileCommunity(users, fetcher({
             g1: profile("alice", { rig: { skills: [{ name: "superpowers:brainstorming", source: "superpowers", runs: 3 }], hooks: [], routing_table: false } }),
             g2: profile("bob", { rig: { skills: [{ name: "superpowers:brainstorming", source: "superpowers", runs: 7 }], hooks: [], routing_table: false } }),
         }), { now: "2026-06-12T03:00:00Z" });
 
-        expect(out.skillStats["superpowers:brainstorming"]).toEqual({ users: 2, runs: 10 });
-        expect(out.skillStats["superpowers:superpowers:brainstorming"]).toBeUndefined();
+        expect(out.skillStats["brainstorming"]).toEqual({ users: 2, runs: 10, source: "superpowers" });
+        expect(out.skillStats["superpowers:brainstorming"]).toBeUndefined();
     });
 
     test("invalid profile rows are dropped and reported", async () => {
@@ -96,7 +124,7 @@ describe("compileCommunity", () => {
         expect(out.state.year).toBe(2026);
         expect(out.state.users).toBe(2);
         expect(out.state.harness_mix.claude).toBe(2);
-        expect(out.state.skill_adoption["superpowers:tdd"]).toBe(2);
+        expect(out.state.skill_adoption["tdd"]).toBe(2);
     });
 
     test("output is deterministic for identical input", async () => {
@@ -112,6 +140,16 @@ describe("compileCommunity", () => {
         expect(skillStatKey("local", "codex:rescue")).toBe("local:codex:rescue");
         // bare name equal to source (defensive)
         expect(skillStatKey("superpowers", "superpowers")).toBe("superpowers");
+    });
+
+    test("normalizeSkillName strips the install-source prefix to a canonical identity", () => {
+        expect(normalizeSkillName("superpowers", "superpowers:brainstorming")).toBe("brainstorming");
+        expect(normalizeSkillName("superpowers", "tdd")).toBe("tdd");
+        expect(normalizeSkillName("local", "grill-me")).toBe("grill-me");
+        // a loose `local:simplify` and a plugin `superpowers:simplify` share identity
+        expect(normalizeSkillName("local", "simplify")).toBe(normalizeSkillName("superpowers", "simplify"));
+        // plugin-namespaced inner id is preserved
+        expect(normalizeSkillName("local", "codex:rescue")).toBe("codex:rescue");
     });
 
     test("gist impersonation: mallory's gist claiming github=alice is dropped with github-mismatch", async () => {

--- a/packages/community-compile/src/compile.ts
+++ b/packages/community-compile/src/compile.ts
@@ -45,7 +45,7 @@ export interface CompiledOutput {
             readonly cost: BoardRow[];
         };
     };
-    readonly skillStats: Record<string, { users: number; runs: number }>;
+    readonly skillStats: Record<string, { users: number; runs: number; source: string }>;
     readonly hookStats: Record<string, { users: number }>;
     readonly state: {
         readonly year: number;
@@ -71,6 +71,28 @@ const sortBoard = (rows: BoardRow[]): BoardRow[] =>
  */
 export function skillStatKey(source: string, name: string): string {
     return name === source || name.startsWith(`${source}:`) ? name : `${source}:${name}`;
+}
+
+/**
+ * Canonical skill IDENTITY - the bare skill name with the install-source prefix
+ * stripped. The same logical skill ships differently per machine: a namespaced
+ * plugin ("superpowers:brainstorming", source "superpowers") for one builder, a
+ * loose ~/.claude/skills/ dir ("grill-me", source "local") for another. Source
+ * is an install artifact, NOT identity - so trending aggregates on this bare
+ * name, and the `users >= 2` threshold (not a `local:` exclusion) is what
+ * separates shared skills from one-off personal ones. Plugin-namespaced inner
+ * ids are preserved ("codex:rescue" stays "codex:rescue").
+ */
+export function normalizeSkillName(source: string, name: string): string {
+    const key = skillStatKey(source, name);
+    return key.startsWith(`${source}:`) ? key.slice(source.length + 1) : key;
+}
+
+/** Best display source for a skill seen under multiple install sources: a real
+ *  plugin beats "local" (deterministic: lexicographically-first non-local). */
+function representativeSource(sources: ReadonlySet<string>): string {
+    const real = [...sources].filter((s) => s !== "local").sort();
+    return real[0] ?? "local";
 }
 
 const sortedRecord = <V>(entries: Array<[string, V]>): Record<string, V> =>
@@ -118,15 +140,25 @@ export async function compileCommunity(
             }),
         );
 
-    const skillAgg = new Map<string, { users: number; runs: number }>();
+    // Aggregate skills by canonical identity (bare name), NOT by source:name -
+    // see normalizeSkillName. `users` counts distinct builders, deduped within
+    // a profile in case one machine has the same skill under two sources.
+    const skillAgg = new Map<string, { users: number; runs: number; sources: Set<string> }>();
     const hookAgg = new Map<string, { users: number }>();
     const harnessMix = new Map<string, number>();
     const modelUsers = new Map<string, number>();
     for (const { p } of profiles) {
+        const seenSkills = new Set<string>();
         for (const s of p.rig.skills) {
-            const key = skillStatKey(s.source, s.name);
-            const cur = skillAgg.get(key) ?? { users: 0, runs: 0 };
-            skillAgg.set(key, { users: cur.users + 1, runs: cur.runs + s.runs });
+            const id = normalizeSkillName(s.source, s.name);
+            const cur = skillAgg.get(id) ?? { users: 0, runs: 0, sources: new Set<string>() };
+            cur.runs += s.runs;
+            cur.sources.add(s.source);
+            if (!seenSkills.has(id)) {
+                cur.users += 1;
+                seenSkills.add(id);
+            }
+            skillAgg.set(id, cur);
         }
         for (const h of p.rig.hooks) {
             const cur = hookAgg.get(h) ?? { users: 0 };
@@ -151,7 +183,9 @@ export async function compileCommunity(
                 cost: board((p) => p.stats.cost_usd),
             },
         },
-        skillStats: sortedRecord([...skillAgg.entries()]),
+        skillStats: sortedRecord(
+            [...skillAgg.entries()].map(([id, v]) => [id, { users: v.users, runs: v.runs, source: representativeSource(v.sources) }]),
+        ),
         hookStats: sortedRecord([...hookAgg.entries()]),
         state: {
             year: Number(opts.now.slice(0, 4)),


### PR DESCRIPTION
## Problem

The trending-skills board **hid the two most-adopted community skills** — `update-config` and `simplify`, **5 builders each** — and undercounted many others.

A skill's `source` is an *install artifact*, not its identity:
- superpowers as a namespaced plugin → `superpowers:brainstorming`
- the same skill as a loose `~/.claude/skills/<name>/` dir → `local:grill-me`

The compile keyed stats on `source:name` (splitting one skill across two rows) and the site **hard-excluded every `local:*` row** — so genuinely-shared skills installed loosely vanished. 3 of 6 builders had 100% `local:` skills and contributed nothing.

## Fix

Aggregate by **canonical identity** — the bare name with the source prefix stripped (`normalizeSkillName`) — and **drop the `local:` exclusion**. The `users >= 2` threshold alone separates shared skills from one-off personal ones (a machine-specific skill only ever has 1 builder). A loose `local:simplify` and a plugin `superpowers:simplify` now fold into one row; the best-known source (real plugin beats `local`) rides along for the badge.

- **@ax/community-compile**: `normalizeSkillName` + per-builder dedup; `skillStats` gains `source`; `skill_adoption` keyed by bare name. +5 tests (13 pass).
- **site**: `trendingSkills` drops the local exclusion; `SkillStats`/`validateSkillStats` carry `source`; `leaders.tsx` badge + showcase copy updated. (31 pass)
- **alchemy**: durable state store (`~/.ax/alchemy-state`, survives worktree churn) + `adopt: true` on KV/Worker so a fresh state reconciles with live resources instead of colliding.

## Before / after (live)

Before: 8 rows, all `superpowers:*` at exactly 2 builders.
After: led by **simplify (5)**, **update-config (5)**, then composto/ax-repo/grill-me/handoff/schedule (3 each), then the superpowers skills.

## Verification

Deployed + recompiled live; `ax.necmttn.com/leaders` trending now shows simplify/update-config/composto/ax-repo/grill-me. All tests pass, typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)