### PR TITLE
feat(community): credit skill authors via a provenance registry

### DIFF
--- a/packages/community-compile/src/compile.test.ts
+++ b/packages/community-compile/src/compile.test.ts
@@ -65,6 +65,34 @@ describe("compileCommunity", () => {
         expect(out.skillStats["superpowers:simplify"]).toBeUndefined();
     });
 
+    test("curated provenance credits a loosely-installed shared skill's author", async () => {
+        // grill-me ships as a loose dir (source "local") for everyone, so no
+        // builder reports a plugin source - the registry credits mattpocock.
+        const out = await compileCommunity(users, fetcher({
+            g1: profile("alice", { rig: { skills: [{ name: "grill-me", source: "local", runs: 4 }], hooks: [], routing_table: false } }),
+            g2: profile("bob", { rig: { skills: [{ name: "grill-me", source: "local", runs: 6 }], hooks: [], routing_table: false } }),
+        }), { now: "2026-06-12T03:00:00Z" });
+        expect(out.skillStats["grill-me"]).toEqual({ users: 2, runs: 10, source: "mattpocock" });
+    });
+
+    test("an observed plugin source overrides the provenance registry", async () => {
+        // If a builder genuinely installed it from a plugin, trust that, not
+        // the curated fallback.
+        const out = await compileCommunity(users, fetcher({
+            g1: profile("alice", { rig: { skills: [{ name: "tdd", source: "someplugin", runs: 1 }], hooks: [], routing_table: false } }),
+            g2: profile("bob", { rig: { skills: [{ name: "tdd", source: "local", runs: 1 }], hooks: [], routing_table: false } }),
+        }), { now: "2026-06-12T03:00:00Z" });
+        expect(out.skillStats["tdd"].source).toBe("someplugin"); // not "mattpocock"
+    });
+
+    test("an unknown loose skill stays source 'local'", async () => {
+        const out = await compileCommunity(users, fetcher({
+            g1: profile("alice", { rig: { skills: [{ name: "my-thing", source: "local", runs: 1 }], hooks: [], routing_table: false } }),
+            g2: profile("bob", { rig: { skills: [{ name: "my-thing", source: "local", runs: 1 }], hooks: [], routing_table: false } }),
+        }), { now: "2026-06-12T03:00:00Z" });
+        expect(out.skillStats["my-thing"].source).toBe("local");
+    });
+
     test("a builder counts once per skill even with duplicate sources", async () => {
         const out = await compileCommunity(
             [{ github: "alice", gist_id: "g1", joined: "2026-06-01" }],

--- a/packages/community-compile/src/compile.ts
+++ b/packages/community-compile/src/compile.ts
@@ -88,11 +88,55 @@ export function normalizeSkillName(source: string, name: string): string {
     return key.startsWith(`${source}:`) ? key.slice(source.length + 1) : key;
 }
 
-/** Best display source for a skill seen under multiple install sources: a real
- *  plugin beats "local" (deterministic: lexicographically-first non-local). */
-function representativeSource(sources: ReadonlySet<string>): string {
+/**
+ * Curated provenance for well-known shared skills that ship as loose
+ * ~/.claude/skills/ dirs (source "local"), so the board can CREDIT their author
+ * instead of showing no badge. Applied ONLY as a fallback - a copy installed
+ * from a real plugin keeps its own observed source. Keyed by canonical skill
+ * identity (bare name). Extend as more shared collections are identified.
+ *
+ * Matt Pocock - github.com/mattpocock/skills (MIT).
+ */
+export const SKILL_PROVENANCE: Record<string, string> = {
+    "design-an-interface": "mattpocock",
+    qa: "mattpocock",
+    "request-refactor-plan": "mattpocock",
+    "ubiquitous-language": "mattpocock",
+    diagnose: "mattpocock",
+    "grill-with-docs": "mattpocock",
+    "improve-codebase-architecture": "mattpocock",
+    prototype: "mattpocock",
+    tdd: "mattpocock",
+    "to-issues": "mattpocock",
+    "to-prd": "mattpocock",
+    triage: "mattpocock",
+    "zoom-out": "mattpocock",
+    review: "mattpocock",
+    "writing-beats": "mattpocock",
+    "writing-fragments": "mattpocock",
+    "writing-shape": "mattpocock",
+    "git-guardrails-claude-code": "mattpocock",
+    "migrate-to-shoehorn": "mattpocock",
+    "scaffold-exercises": "mattpocock",
+    "setup-pre-commit": "mattpocock",
+    "edit-article": "mattpocock",
+    "obsidian-vault": "mattpocock",
+    caveman: "mattpocock",
+    "grill-me": "mattpocock",
+    handoff: "mattpocock",
+    teach: "mattpocock",
+    "write-a-skill": "mattpocock",
+};
+
+/**
+ * Best display source for a skill. A real plugin source observed on any
+ * builder's install wins (deterministic: lexicographically-first non-local);
+ * else the curated provenance registry credits a known author; else "local".
+ */
+function representativeSource(name: string, sources: ReadonlySet<string>): string {
     const real = [...sources].filter((s) => s !== "local").sort();
-    return real[0] ?? "local";
+    if (real[0] !== undefined) return real[0];
+    return SKILL_PROVENANCE[name] ?? "local";
 }
 
 const sortedRecord = <V>(entries: Array<[string, V]>): Record<string, V> =>
@@ -184,7 +228,7 @@ export async function compileCommunity(
             },
         },
         skillStats: sortedRecord(
-            [...skillAgg.entries()].map(([id, v]) => [id, { users: v.users, runs: v.runs, source: representativeSource(v.sources) }]),
+            [...skillAgg.entries()].map(([id, v]) => [id, { users: v.users, runs: v.runs, source: representativeSource(id, v.sources) }]),
         ),
         hookStats: sortedRecord([...hookAgg.entries()]),
         state: {


### PR DESCRIPTION
## What

Skills that ship as loose `~/.claude/skills/<name>/` dirs (source `local`) showed **no badge** on the trending board even when they come from a known public collection — e.g. `grill-me`, `handoff`, `grill-with-docs`.

Adds a curated `SKILL_PROVENANCE` map (bare skill name → author label) in `@ax/community-compile`, applied as a **fallback** in `representativeSource`: a real observed plugin source still wins, but an otherwise-`local` skill now credits its author.

## Seed

Matt Pocock's collection — [github.com/mattpocock/skills](https://github.com/mattpocock/skills) (MIT) → `mattpocock`: grill-me, grill-with-docs, handoff, diagnose, prototype, tdd, to-issues, to-prd, triage, zoom-out, teach, write-a-skill, review, writing-{beats,fragments,shape}, and the rest of his set. Extend as more collections are identified.

## Precedence (so collisions are safe)

1. A genuinely-observed plugin source on any builder's install → use that.
2. Else the curated registry credits the author.
3. Else `local`.

So a plugin-installed copy of a generic name (e.g. `caveman`, `tdd`) keeps its real source; only loosely-installed copies fall through to the registry.

## Verified live

Recompiled on the Worker — `grill-me` and `handoff` now badge **`mattpocock`**; superpowers skills keep their observed source; unknown loose skills stay `local`. 16 compile tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)