### PR TITLE
chore(wip): auto-clear status:in-progress on issue close

### DIFF
--- a/.github/workflows/wip-clear-label.yml
+++ b/.github/workflows/wip-clear-label.yml
@@ -1,0 +1,30 @@
+name: wip-clear-label
+
+# When an issue closes (typically a "Closes #N" PR merging), drop the
+# `status:in-progress` label the wip-tracker convention adds when an agent claims
+# it (scripts/wip claim). Merging an issue's PR closes the issue but never touches
+# its labels, so the claim marker lingered on closed issues. Clearing it
+# server-side keeps `bun run wip list` and the issue view honest without a manual
+# `bun run wip release`. See CONTRIBUTING.md "Claiming work".
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  clear-label:
+    runs-on: ubuntu-24.04
+    # Only act when the label is actually present - avoids a no-op API call (and
+    # its 422) on the vast majority of issues that were never claimed.
+    if: contains(github.event.issue.labels.*.name, 'status:in-progress')
+    steps:
+      - name: Remove status:in-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label "status:in-progress"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ name is the claim**. Before starting an issue:
 bun run wip list          # see open issues + which branch (if any) claimed each
 bun run wip claim 481 fix # worktree + branch fix/481-<slug>, label, claim comment
 cd .claude/worktrees/481-fix   # the path claim prints - do the work here, open a PR
-bun run wip release 481   # only if you abandon it; merging the PR closes it
+bun run wip release 481   # only if you ABANDON it; merging the PR auto-clears the label
 ```
 
 `claim` creates an **isolated worktree** at `.claude/worktrees/<issue#>-<type>` on


### PR DESCRIPTION
Follow-up to #493 (the wip-tracker).

## Problem
Merging a `Closes #N` PR closes the issue but doesn't touch labels, so the `status:in-progress` claim marker lingered on closed issues (seen on #478/#479/#481 today — cleared by hand).

## Fix
A minimal workflow that fires on `issues: closed` and removes `status:in-progress`. Gated with `if: contains(github.event.issue.labels.*.name, 'status:in-progress')` so it no-ops (no API call, no 422) on the ~all issues that were never claimed. `permissions: issues: write`, `GITHUB_TOKEN` only.

Keeps `bun run wip list` and the GitHub issue view honest without a manual `bun run wip release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)