### PR TITLE
refactor(ingest): shared JSONL provider work-unit + skip-unchanged for codex/pi

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,6 +75,16 @@ unchanged input is skipped (output-equivalent) on the next run. Stored in
 `ingest_file_state` keyed by source kind and path.
 _Avoid_: cache, dedup key
 
+**JSONL Provider Work-Unit**:
+The shared per-file execution loop the three JSONL transcript providers
+(claude / codex / pi) run their candidates through: **Ingest Watermark**
+skip/commit, per-file failure isolation, the dry-run deadline, and the
+file/active-file counters. Each provider supplies only discovery and a
+per-file parse+write; the work-unit owns the mechanics so skip-unchanged is
+uniform across providers (not claude-only). SQLite-store providers
+(opencode / cursor) are a different isolation grain and stay outside it.
+_Avoid_: file loop, ingest helper
+
 **Commit Signal**:
 The quality of commit evidence for reconstructing durable agent work memory.
 _Avoid_: commit lint

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1536,7 +1536,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                     ),
                 );
                 if (vanished) {
-                    return null;
+                    return false;
                 }
 
                 const finalBatch = extractor.drain(true);
@@ -1544,7 +1544,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                 malformedLineCount += extractor.malformedLines();
                 const completedSession = finalBatch.session ?? currentSession;
                 if (!completedSession) {
-                    return null;
+                    return false;
                 }
 
                 // Snapshot the raw codex jsonl into the `codex_artifacts` bucket as
@@ -1626,7 +1626,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                     if (opts.onProgress) yield* opts.onProgress(counts);
                     yield* Effect.logDebug("codex ingest progress", counts);
                 }
-                return completedSession.id;
+                return true;
             }).pipe(Effect.withSpan("codex.file", {
                 // Basename only: keeps exported-trace attributes small (the full
                 // session path is reconstructable locally if ever needed).

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -60,7 +60,8 @@ import { isNotFound, skipNotFound } from "@ax/lib/shared/fs-error";
 import { tokenQualityLabels } from "./token-quality.ts";
 import { estimateCost } from "./model-pricing.ts";
 import { walkJsonlFilesStrict } from "./walk-jsonl.ts";
-import { type FileFailureSnapshot, makeFileFailureCollector } from "./file-isolation.ts";
+import type { FileFailureSnapshot } from "./file-isolation.ts";
+import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 
 const DEFAULT_CODEX_RAW_MAX_BYTES = 5 * 1024 * 1024;
 const DEFAULT_CODEX_PROGRESS_EVERY = 10;
@@ -1381,24 +1382,21 @@ export const ingestCodex = Effect.fn("codex.ingest")(
         let toolCallCount = 0;
         let planSnapshotCount = 0;
         let malformedLineCount = 0;
-        let activeFiles = 0;
         const recordCount = () => turnCount + invCount + toolCallCount + planSnapshotCount;
 
-        const failures = makeFileFailureCollector({
+        // Skip-unchanged watermark + per-file failure isolation + deadline +
+        // active-file counting all live in the shared JSONL work-unit; codex
+        // supplies discovery (above) and the per-file parse/write below. A file
+        // whose (mtime,size) matched a prior run is skipped without re-parsing.
+        const result = yield* runJsonlProviderFiles({
+            candidates: files,
+            sourceKind: "codex_session",
+            forceEnv: "AX_REDERIVE_CODEX",
             source: "codex",
-            ...(opts.onFileFailures ? { onFailure: opts.onFileFailures } : {}),
-        });
-        yield* Effect.forEach(files.map((file, index) => ({ file, index })), ({ file, index }) => Effect.gen(function* () {
-            // Time-box (dry-run calibration): once the deadline passes, start no
-            // new files; in-flight ones finish.
-            if (opts.deadlineMs !== undefined && Date.now() >= opts.deadlineMs) {
-                return;
-            }
-            activeFiles += 1;
-            // Per-file failure isolation: a bad transcript (or a rejected
-            // statement) skips THIS file - it is retried next run - instead of
-            // aborting the whole stage (see file-isolation.ts).
-            yield* failures.isolate(file.path, Effect.gen(function* () {
+            ...(opts.onFileFailures ? { onFileFailures: opts.onFileFailures } : {}),
+            ...(opts.deadlineMs !== undefined ? { deadlineMs: opts.deadlineMs } : {}),
+            concurrency,
+            processFile: (file, index, loop) => Effect.gen(function* () {
                 if (opts.onProgress && (index < 5 || index % 10 === 0)) {
                     yield* opts.onProgress({
                         currentFile: index + 1,
@@ -1409,7 +1407,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                         bytes: byteCount,
                         records: recordCount(),
                         lines: 0,
-                        activeFiles,
+                        activeFiles: loop.activeFiles,
                         phase: 1,
                         sessions: sessionCount,
                         turns: turnCount,
@@ -1454,7 +1452,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                             lines: lineCount,
                             fileTurns,
                             fileToolCalls,
-                            activeFiles,
+                            activeFiles: loop.activeFiles,
                             phase,
                             sessions: sessionCount + (sessionUpserted ? 1 : 0),
                             turns: turnCount,
@@ -1538,7 +1536,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                     ),
                 );
                 if (vanished) {
-                    return;
+                    return null;
                 }
 
                 const finalBatch = extractor.drain(true);
@@ -1546,7 +1544,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                 malformedLineCount += extractor.malformedLines();
                 const completedSession = finalBatch.session ?? currentSession;
                 if (!completedSession) {
-                    return;
+                    return null;
                 }
 
                 // Snapshot the raw codex jsonl into the `codex_artifacts` bucket as
@@ -1617,7 +1615,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                         lines: lineCount,
                         fileTurns,
                         fileToolCalls,
-                        activeFiles,
+                        activeFiles: loop.activeFiles,
                         phase: 2,
                         sessions: sessionCount,
                         turns: turnCount,
@@ -1628,17 +1626,16 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                     if (opts.onProgress) yield* opts.onProgress(counts);
                     yield* Effect.logDebug("codex ingest progress", counts);
                 }
-            }));
-            activeFiles -= 1;
-        }).pipe(Effect.withSpan("codex.file", {
-            // Basename only: keeps exported-trace attributes small (the full
-            // session path is reconstructable locally if ever needed).
-            attributes: {
-                "file.name": file.path.slice(file.path.lastIndexOf("/") + 1),
-                "file.bytes": file.sizeBytes,
-            },
-        })), { concurrency, discard: true });
-        yield* failures.report;
+                return completedSession.id;
+            }).pipe(Effect.withSpan("codex.file", {
+                // Basename only: keeps exported-trace attributes small (the full
+                // session path is reconstructable locally if ever needed).
+                attributes: {
+                    "file.name": file.path.slice(file.path.lastIndexOf("/") + 1),
+                    "file.bytes": file.sizeBytes,
+                },
+            })),
+        });
         yield* Effect.logDebug("codex ingest complete", {
             files: fileCount,
             records: recordCount(),
@@ -1657,7 +1654,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
             toolCalls: toolCallCount,
             planSnapshots: planSnapshotCount,
             malformedLines: malformedLineCount,
-            failedFiles: failures.count(),
+            failedFiles: result.failures.count(),
         } satisfies CodexStats;
     },
 );

--- a/apps/axctl/src/ingest/jsonl-work-unit.test.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.test.ts
@@ -44,7 +44,7 @@ describe("runJsonlProviderFiles - skip-unchanged watermark", () => {
                 source: "codex",
                 processFile: (c) => Effect.sync(() => {
                     processed.push(c.path);
-                    return c.path;
+                    return true;
                 }),
             }).pipe(Effect.provide(layer));
 
@@ -67,7 +67,7 @@ describe("runJsonlProviderFiles - skip-unchanged watermark", () => {
         const processFile = (processed: string[]) => (c: JsonlFileCandidate) =>
             Effect.sync(() => {
                 processed.push(c.path);
-                return c.path;
+                return true;
             });
 
         const base = [candidate("a.jsonl", 10), candidate("b.jsonl", 20)];
@@ -105,7 +105,7 @@ describe("runJsonlProviderFiles - skip-unchanged watermark", () => {
                         ? Effect.fail(new DbError({ operation: "query", message: "boom" }))
                         : Effect.sync(() => {
                             processed.push(c.path);
-                            return c.path;
+                            return true;
                         }),
             }).pipe(Effect.provide(layer));
 
@@ -132,7 +132,7 @@ describe("runJsonlProviderFiles - skip-unchanged watermark", () => {
                 sourceKind: "codex_session",
                 forceEnv: "AX_REDERIVE_TEST",
                 source: "codex",
-                processFile: () => Effect.succeed(null),
+                processFile: () => Effect.succeed(false),
             }).pipe(Effect.provide(layer)),
         );
         expect(r.files).toBe(0);
@@ -149,7 +149,7 @@ describe("runJsonlProviderFiles - skip-unchanged watermark", () => {
             source: "codex",
             processFile: (c: JsonlFileCandidate) => Effect.sync(() => {
                 processed.push(c.path);
-                return c.path;
+                return true;
             }),
         });
         const first: string[] = [];

--- a/apps/axctl/src/ingest/jsonl-work-unit.test.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { DbError } from "@ax/lib/errors";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
+import type { JsonlFileCandidate } from "./walk-jsonl.ts";
+
+/** A stateful fake of the `ingest_file_state` watermark table: the SELECT
+ *  returns whatever prior commits stored, and the UPSERT records them - so a
+ *  second run sees the marks a first run wrote (the whole point of the skip). */
+function statefulWatermarkLayer() {
+    const store = new Map<string, { path: string; mtime_ms: number; size: number }>();
+    const layer = makeTestSurrealClient({
+        fallback: (sql) => {
+            if (sql.includes("__watermark_migration__")) return [[]];
+            if (sql.includes("UPSERT ingest_file_state")) {
+                const path = /path: "([^"]*)"/.exec(sql)?.[1];
+                const mtime = Number(/mtime_ms: (-?\d+)/.exec(sql)?.[1] ?? "0");
+                const size = Number(/size: (-?\d+)/.exec(sql)?.[1] ?? "0");
+                if (path) store.set(path, { path, mtime_ms: mtime, size });
+                return [[]];
+            }
+            if (sql.includes("FROM ingest_file_state")) {
+                return [Array.from(store.values())];
+            }
+            return [[]];
+        },
+    }).layer;
+    return { layer, store };
+}
+
+const candidate = (path: string, mtimeMs: number, sizeBytes = 100): JsonlFileCandidate => ({ path, mtimeMs, sizeBytes });
+
+describe("runJsonlProviderFiles - skip-unchanged watermark", () => {
+    test("first run processes all; identical second run skips all", async () => {
+        const { layer, store } = statefulWatermarkLayer();
+        const candidates = [candidate("a.jsonl", 10), candidate("b.jsonl", 20), candidate("c.jsonl", 30)];
+
+        const run = (processed: string[]) =>
+            runJsonlProviderFiles({
+                candidates,
+                sourceKind: "codex_session",
+                forceEnv: "AX_REDERIVE_TEST",
+                source: "codex",
+                processFile: (c) => Effect.sync(() => {
+                    processed.push(c.path);
+                    return c.path;
+                }),
+            }).pipe(Effect.provide(layer));
+
+        const first: string[] = [];
+        const r1 = await Effect.runPromise(run(first));
+        expect(r1.files).toBe(3);
+        expect(r1.skippedUnchanged).toBe(0);
+        expect(first.sort()).toEqual(["a.jsonl", "b.jsonl", "c.jsonl"]);
+        expect(store.size).toBe(3);
+
+        const second: string[] = [];
+        const r2 = await Effect.runPromise(run(second));
+        expect(r2.files).toBe(0);
+        expect(r2.skippedUnchanged).toBe(3);
+        expect(second).toEqual([]); // nothing re-parsed
+    });
+
+    test("a changed (mtime,size) re-processes only that file", async () => {
+        const { layer } = statefulWatermarkLayer();
+        const processFile = (processed: string[]) => (c: JsonlFileCandidate) =>
+            Effect.sync(() => {
+                processed.push(c.path);
+                return c.path;
+            });
+
+        const base = [candidate("a.jsonl", 10), candidate("b.jsonl", 20)];
+        const first: string[] = [];
+        await Effect.runPromise(
+            runJsonlProviderFiles({ candidates: base, sourceKind: "codex_session", forceEnv: "AX_REDERIVE_TEST", source: "codex", processFile: processFile(first) })
+                .pipe(Effect.provide(layer)),
+        );
+        expect(first.length).toBe(2);
+
+        // b.jsonl grows (new mtime + size); a.jsonl unchanged.
+        const changed = [candidate("a.jsonl", 10), candidate("b.jsonl", 25, 200)];
+        const second: string[] = [];
+        const r = await Effect.runPromise(
+            runJsonlProviderFiles({ candidates: changed, sourceKind: "codex_session", forceEnv: "AX_REDERIVE_TEST", source: "codex", processFile: processFile(second) })
+                .pipe(Effect.provide(layer)),
+        );
+        expect(r.files).toBe(1);
+        expect(r.skippedUnchanged).toBe(1);
+        expect(second).toEqual(["b.jsonl"]);
+    });
+
+    test("an isolated failure does not commit the watermark - file retries next run", async () => {
+        const { layer } = statefulWatermarkLayer();
+        const candidates = [candidate("ok.jsonl", 10), candidate("bad.jsonl", 20)];
+
+        const run = (failBad: boolean, processed: string[]) =>
+            runJsonlProviderFiles({
+                candidates,
+                sourceKind: "codex_session",
+                forceEnv: "AX_REDERIVE_TEST",
+                source: "codex",
+                processFile: (c) =>
+                    failBad && c.path === "bad.jsonl"
+                        ? Effect.fail(new DbError({ operation: "query", message: "boom" }))
+                        : Effect.sync(() => {
+                            processed.push(c.path);
+                            return c.path;
+                        }),
+            }).pipe(Effect.provide(layer));
+
+        const first: string[] = [];
+        const r1 = await Effect.runPromise(run(true, first));
+        expect(r1.files).toBe(1); // only ok.jsonl committed
+        expect(r1.failures.count()).toBe(1);
+        expect(first).toEqual(["ok.jsonl"]);
+
+        // Next run, nothing fails: ok.jsonl is skipped (committed), bad.jsonl retries.
+        const second: string[] = [];
+        const r2 = await Effect.runPromise(run(false, second));
+        expect(r2.skippedUnchanged).toBe(1);
+        expect(r2.files).toBe(1);
+        expect(second).toEqual(["bad.jsonl"]);
+    });
+
+    test("a vanished file (processFile returns null) neither counts nor commits", async () => {
+        const { layer, store } = statefulWatermarkLayer();
+        const candidates = [candidate("gone.jsonl", 10)];
+        const r = await Effect.runPromise(
+            runJsonlProviderFiles({
+                candidates,
+                sourceKind: "codex_session",
+                forceEnv: "AX_REDERIVE_TEST",
+                source: "codex",
+                processFile: () => Effect.succeed(null),
+            }).pipe(Effect.provide(layer)),
+        );
+        expect(r.files).toBe(0);
+        expect(store.size).toBe(0); // never marked done
+    });
+
+    test("AX_REDERIVE_* forces reprocessing even when marks exist", async () => {
+        const { layer } = statefulWatermarkLayer();
+        const candidates = [candidate("a.jsonl", 10)];
+        const opts = (processed: string[]) => ({
+            candidates,
+            sourceKind: "codex_session",
+            forceEnv: "AX_REDERIVE_TEST",
+            source: "codex",
+            processFile: (c: JsonlFileCandidate) => Effect.sync(() => {
+                processed.push(c.path);
+                return c.path;
+            }),
+        });
+        const first: string[] = [];
+        await Effect.runPromise(runJsonlProviderFiles(opts(first)).pipe(Effect.provide(layer)));
+        expect(first).toEqual(["a.jsonl"]);
+
+        process.env.AX_REDERIVE_TEST = "1";
+        try {
+            const second: string[] = [];
+            const r = await Effect.runPromise(runJsonlProviderFiles(opts(second)).pipe(Effect.provide(layer)));
+            expect(r.files).toBe(1); // forced re-derive ignores the mark
+            expect(second).toEqual(["a.jsonl"]);
+        } finally {
+            delete process.env.AX_REDERIVE_TEST;
+        }
+    });
+});

--- a/apps/axctl/src/ingest/jsonl-work-unit.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.ts
@@ -1,0 +1,140 @@
+/**
+ * The shared per-file execution loop for the three JSONL transcript providers
+ * (claude / codex / pi). Each provider discovers its own candidates (claude
+ * keeps its flat walk; codex/pi use `walkJsonlFilesStrict`/`Lenient`) and
+ * supplies a `processFile` that parses + writes ONE file. This work-unit owns
+ * the mechanics every provider previously hand-rolled (only claude did all of
+ * them): the skip-unchanged watermark read/skip/commit, per-file failure
+ * isolation, the deadline time-box, and the file/active-file counters.
+ *
+ * Load-bearing ordering preserved from the claude reference loop:
+ *  - `unchanged()` skip happens BEFORE the failure-isolation wrapper, so a
+ *    skipped file is free (no parse, no write);
+ *  - `commit()` runs INSIDE the isolate, only AFTER `processFile` succeeds, so a
+ *    mid-file failure never advances the watermark and the file retries next run;
+ *  - a `processFile` returning `null` (file vanished between discovery and read)
+ *    neither counts nor commits.
+ *
+ * The work-unit owns ONLY loop mechanics. Per-provider domain counters
+ * (turns / tool calls / edits / ...) and the shape of progress payloads stay in
+ * the provider: it mutates its own counters inside `processFile` and reads the
+ * loop counters (file index, files-done, active-files) back through the live
+ * `loop` accessor passed to `processFile`, so a provider that emits progress at
+ * several points mid-file (codex flushes) reads up-to-date numbers each time.
+ */
+
+import { Effect } from "effect";
+import type { DbError } from "@ax/lib/errors";
+import type { SurrealClient } from "@ax/lib/db";
+import { fileWatermark } from "@ax/lib/shared/watermark";
+import { type FileFailureCollector, type FileFailureSnapshot, makeFileFailureCollector } from "./file-isolation.ts";
+import type { JsonlFileCandidate } from "./walk-jsonl.ts";
+
+/** Live loop counters, readable by `processFile` at any point (getters reflect
+ *  current state, so mid-file progress emits stay accurate). */
+export interface JsonlWorkUnitLoop {
+    /** Total candidate count (includes those skipped as unchanged). */
+    readonly total: number;
+    /** Files fully processed so far this run (excludes skipped/vanished). The
+     *  current file is NOT yet counted while its `processFile` runs. */
+    readonly files: number;
+    /** Files currently in flight (the current file IS counted here). */
+    readonly activeFiles: number;
+}
+
+export interface RunJsonlProviderFilesOptions<A, E, R, C extends JsonlFileCandidate> {
+    readonly candidates: readonly C[];
+    /** Watermark `source_kind` column, e.g. "codex_session". */
+    readonly sourceKind: string;
+    /** Env var forcing a full re-derive when "1", e.g. "AX_REDERIVE_CODEX". */
+    readonly forceEnv: string;
+    /** Failure-collector provider label for log lines, e.g. "codex". */
+    readonly source: string;
+    /** Live-progress publish hook for the skipped-file list (see file-isolation). */
+    readonly onFileFailures?: (snapshot: FileFailureSnapshot) => Effect.Effect<void>;
+    /** Dry-run calibration deadline: once passed, start no new files. */
+    readonly deadlineMs?: number;
+    /** Per-file concurrency. Defaults to 1 (sequential) to match the providers. */
+    readonly concurrency?: number | "unbounded";
+    /**
+     * Parse + write ONE file. Mutate provider-owned counters here, and read the
+     * live `loop` accessor for any progress emits. Return the per-file result,
+     * or `null` if the file vanished and must NOT advance the watermark / file
+     * count.
+     */
+    readonly processFile: (
+        candidate: C,
+        index: number,
+        loop: JsonlWorkUnitLoop,
+    ) => Effect.Effect<A | null, E, R>;
+}
+
+export interface JsonlWorkUnitResult<A> {
+    /** Files fully processed (non-skip, non-vanish). */
+    readonly files: number;
+    /** Candidates skipped because their (mtime,size) matched the watermark. */
+    readonly skippedUnchanged: number;
+    /** Non-null `processFile` results, in completion order. */
+    readonly results: readonly A[];
+    /** The failure collector (count() / failures) for the provider's stats. */
+    readonly failures: FileFailureCollector;
+}
+
+export const runJsonlProviderFiles = <A, E = never, R = never, C extends JsonlFileCandidate = JsonlFileCandidate>(
+    opts: RunJsonlProviderFilesOptions<A, E, R, C>,
+): Effect.Effect<JsonlWorkUnitResult<A>, DbError, SurrealClient | R> =>
+    Effect.gen(function* () {
+        const wm = yield* fileWatermark({ sourceKind: opts.sourceKind, forceEnv: opts.forceEnv });
+        const failures = makeFileFailureCollector({
+            source: opts.source,
+            ...(opts.onFileFailures ? { onFailure: opts.onFileFailures } : {}),
+        });
+
+        let files = 0;
+        let activeFiles = 0;
+        let skippedUnchanged = 0;
+        const results: A[] = [];
+        const total = opts.candidates.length;
+        const loop: JsonlWorkUnitLoop = {
+            total,
+            get files() {
+                return files;
+            },
+            get activeFiles() {
+                return activeFiles;
+            },
+        };
+
+        yield* Effect.forEach(
+            opts.candidates.map((candidate, index) => ({ candidate, index })),
+            ({ candidate, index }) =>
+                Effect.gen(function* () {
+                    if (opts.deadlineMs !== undefined && Date.now() >= opts.deadlineMs) return;
+                    // Skip BEFORE isolation: an unchanged file is output-equivalent
+                    // to a prior run, so it costs nothing.
+                    if (wm.unchanged(candidate.path, candidate.mtimeMs, candidate.sizeBytes)) {
+                        skippedUnchanged += 1;
+                        return;
+                    }
+                    activeFiles += 1;
+                    yield* failures.isolate(
+                        candidate.path,
+                        Effect.gen(function* () {
+                            const result = yield* opts.processFile(candidate, index, loop);
+                            // null ⇒ vanished between discovery and read: never count,
+                            // never commit (so it isn't marked done).
+                            if (result === null) return;
+                            files += 1;
+                            results.push(result);
+                            // Commit ONLY after writes succeed.
+                            yield* wm.commit(candidate.path, candidate.mtimeMs, candidate.sizeBytes);
+                        }),
+                    );
+                    activeFiles -= 1;
+                }),
+            { concurrency: opts.concurrency ?? 1 },
+        );
+
+        yield* failures.report;
+        return { files, skippedUnchanged, results, failures };
+    });

--- a/apps/axctl/src/ingest/jsonl-work-unit.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.ts
@@ -30,19 +30,15 @@ import { fileWatermark } from "@ax/lib/shared/watermark";
 import { type FileFailureCollector, type FileFailureSnapshot, makeFileFailureCollector } from "./file-isolation.ts";
 import type { JsonlFileCandidate } from "./walk-jsonl.ts";
 
-/** Live loop counters, readable by `processFile` at any point (getters reflect
- *  current state, so mid-file progress emits stay accurate). */
+/** Live loop state readable by `processFile` at any point: the one counter a
+ *  provider can't compute itself (the work-unit owns active-file tracking).
+ *  Getter reflects current state, so mid-file progress emits stay accurate. */
 export interface JsonlWorkUnitLoop {
-    /** Total candidate count (includes those skipped as unchanged). */
-    readonly total: number;
-    /** Files fully processed so far this run (excludes skipped/vanished). The
-     *  current file is NOT yet counted while its `processFile` runs. */
-    readonly files: number;
     /** Files currently in flight (the current file IS counted here). */
     readonly activeFiles: number;
 }
 
-export interface RunJsonlProviderFilesOptions<A, E, R, C extends JsonlFileCandidate> {
+export interface RunJsonlProviderFilesOptions<E, R, C extends JsonlFileCandidate> {
     readonly candidates: readonly C[];
     /** Watermark `source_kind` column, e.g. "codex_session". */
     readonly sourceKind: string;
@@ -58,31 +54,29 @@ export interface RunJsonlProviderFilesOptions<A, E, R, C extends JsonlFileCandid
     readonly concurrency?: number | "unbounded";
     /**
      * Parse + write ONE file. Mutate provider-owned counters here, and read the
-     * live `loop` accessor for any progress emits. Return the per-file result,
-     * or `null` if the file vanished and must NOT advance the watermark / file
-     * count.
+     * live `loop` accessor for any progress emits. Return `true` on success
+     * (the work-unit then commits the watermark), or `false` if the file
+     * vanished / had nothing to write and must NOT advance the watermark.
      */
     readonly processFile: (
         candidate: C,
         index: number,
         loop: JsonlWorkUnitLoop,
-    ) => Effect.Effect<A | null, E, R>;
+    ) => Effect.Effect<boolean, E, R>;
 }
 
-export interface JsonlWorkUnitResult<A> {
-    /** Files fully processed (non-skip, non-vanish). */
+export interface JsonlWorkUnitResult {
+    /** Files committed this run (processFile returned true). */
     readonly files: number;
     /** Candidates skipped because their (mtime,size) matched the watermark. */
     readonly skippedUnchanged: number;
-    /** Non-null `processFile` results, in completion order. */
-    readonly results: readonly A[];
     /** The failure collector (count() / failures) for the provider's stats. */
     readonly failures: FileFailureCollector;
 }
 
-export const runJsonlProviderFiles = <A, E = never, R = never, C extends JsonlFileCandidate = JsonlFileCandidate>(
-    opts: RunJsonlProviderFilesOptions<A, E, R, C>,
-): Effect.Effect<JsonlWorkUnitResult<A>, DbError, SurrealClient | R> =>
+export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileCandidate = JsonlFileCandidate>(
+    opts: RunJsonlProviderFilesOptions<E, R, C>,
+): Effect.Effect<JsonlWorkUnitResult, DbError, SurrealClient | R> =>
     Effect.gen(function* () {
         const wm = yield* fileWatermark({ sourceKind: opts.sourceKind, forceEnv: opts.forceEnv });
         const failures = makeFileFailureCollector({
@@ -93,21 +87,15 @@ export const runJsonlProviderFiles = <A, E = never, R = never, C extends JsonlFi
         let files = 0;
         let activeFiles = 0;
         let skippedUnchanged = 0;
-        const results: A[] = [];
-        const total = opts.candidates.length;
         const loop: JsonlWorkUnitLoop = {
-            total,
-            get files() {
-                return files;
-            },
             get activeFiles() {
                 return activeFiles;
             },
         };
 
         yield* Effect.forEach(
-            opts.candidates.map((candidate, index) => ({ candidate, index })),
-            ({ candidate, index }) =>
+            opts.candidates,
+            (candidate, index) =>
                 Effect.gen(function* () {
                     if (opts.deadlineMs !== undefined && Date.now() >= opts.deadlineMs) return;
                     // Skip BEFORE isolation: an unchanged file is output-equivalent
@@ -120,21 +108,20 @@ export const runJsonlProviderFiles = <A, E = never, R = never, C extends JsonlFi
                     yield* failures.isolate(
                         candidate.path,
                         Effect.gen(function* () {
-                            const result = yield* opts.processFile(candidate, index, loop);
-                            // null ⇒ vanished between discovery and read: never count,
-                            // never commit (so it isn't marked done).
-                            if (result === null) return;
+                            const committed = yield* opts.processFile(candidate, index, loop);
+                            // false ⇒ vanished/empty: never count, never commit
+                            // (so it isn't marked done and retries next run).
+                            if (!committed) return;
                             files += 1;
-                            results.push(result);
                             // Commit ONLY after writes succeed.
                             yield* wm.commit(candidate.path, candidate.mtimeMs, candidate.sizeBytes);
                         }),
                     );
                     activeFiles -= 1;
                 }),
-            { concurrency: opts.concurrency ?? 1 },
+            { concurrency: opts.concurrency ?? 1, discard: true },
         );
 
         yield* failures.report;
-        return { files, skippedUnchanged, results, failures };
+        return { files, skippedUnchanged, failures };
     });

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -36,7 +36,7 @@ import {
 } from "./normalized/tool-call-write.ts";
 import { buildSessionTokenUsageStatement } from "./token-usage-writers.ts";
 import { extractToolFileEvidence } from "./tool-file-evidence.ts";
-import { makeFileFailureCollector } from "./file-isolation.ts";
+import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import { decodePiTranscriptLine } from "./line-schemas.ts";
 import { tokenQualityLabels } from "./token-quality.ts";
 import { walkJsonlFilesLenient } from "./walk-jsonl.ts";
@@ -683,14 +683,17 @@ export const ingestPi = Effect.fn("pi.ingest")(
         let skipped = 0;
         let warningCount = 0;
 
-        const failures = makeFileFailureCollector({ source: "pi" });
-        for (const file of files) {
-            // Per-file failure isolation (#261): a bad session file (read
-            // fault or a rejected statement) skips THIS file - it is retried
-            // next run - instead of aborting the whole stage (see
-            // file-isolation.ts). `files` counts only completed files, like
-            // claude/codex.
-            yield* failures.isolate(file.path, Effect.gen(function* () {
+        // Skip-unchanged watermark + per-file failure isolation (#261) live in
+        // the shared JSONL work-unit; pi supplies discovery (above) and the
+        // per-file parse/write below. A file whose (mtime,size) matches a prior
+        // run is skipped without re-reading. `fileCount` (pi's own) counts
+        // completed files, like claude/codex.
+        const result = yield* runJsonlProviderFiles({
+            candidates: files,
+            sourceKind: "pi_session",
+            forceEnv: "AX_REDERIVE_PI",
+            source: "pi",
+            processFile: (file) => Effect.gen(function* () {
                 // OLD: `Bun.file(path).text()` under `Effect.promise` - a read
                 // rejection became an unrecoverable defect. `readFileString`
                 // surfaces a typed PlatformError that the isolation seam
@@ -705,7 +708,9 @@ export const ingestPi = Effect.fn("pi.ingest")(
                     fileCount += 1;
                     skipped += 1;
                     warningCount += 1;
-                    return;
+                    // Empty/unparseable: not committed, so it re-warns next run -
+                    // preserving the pre-watermark behavior (pi re-read every file).
+                    return null;
                 }
 
                 skipped += extracted.skipped;
@@ -725,9 +730,9 @@ export const ingestPi = Effect.fn("pi.ingest")(
                 eventCount += extracted.providerEvents.length;
                 turnCount += extracted.turns.length;
                 toolCallCount += extracted.toolCalls.length;
-            }));
-        }
-        yield* failures.report;
+                return extracted.session.id;
+            }),
+        });
 
         return {
             files: fileCount,
@@ -737,7 +742,7 @@ export const ingestPi = Effect.fn("pi.ingest")(
             toolCalls: toolCallCount,
             skipped,
             warnings: warningCount,
-            failedFiles: failures.count(),
+            failedFiles: result.failures.count(),
         } satisfies PiStats;
     },
 );

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -710,7 +710,7 @@ export const ingestPi = Effect.fn("pi.ingest")(
                     warningCount += 1;
                     // Empty/unparseable: not committed, so it re-warns next run -
                     // preserving the pre-watermark behavior (pi re-read every file).
-                    return null;
+                    return false;
                 }
 
                 skipped += extracted.skipped;
@@ -730,7 +730,7 @@ export const ingestPi = Effect.fn("pi.ingest")(
                 eventCount += extracted.providerEvents.length;
                 turnCount += extracted.turns.length;
                 toolCallCount += extracted.toolCalls.length;
-                return extracted.session.id;
+                return true;
             }),
         });
 

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -66,7 +66,6 @@ import { claudeEffortStamp, loadClaudeEffortLevel } from "./claude-effort.ts";
 
 import { selectByIds } from "@ax/lib/shared/record-select";
 import { executeStatements, executeStatementsWith } from "@ax/lib/shared/statement-exec";
-import { fileWatermark } from "@ax/lib/shared/watermark";
 import { skipNotFound } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
 import {
@@ -79,7 +78,8 @@ import {
 } from "@ax/lib/shared/surql";
 import { safeKeyPart } from "@ax/lib/shared/derive-keys";
 import { estimateCost, normalizeModelName } from "./model-pricing.ts";
-import { type FileFailureSnapshot, makeFileFailureCollector } from "./file-isolation.ts";
+import type { FileFailureSnapshot } from "./file-isolation.ts";
+import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import {
     extractClaudeCompaction,
     type CompactionWrite,
@@ -1653,9 +1653,9 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
 
         const candidates: Array<{
             projectDir: string;
-            filePath: string;
+            path: string;
             mtimeMs: number;
-            size: number;
+            sizeBytes: number;
         }> = [];
         let files = 0;
         let sessions = 0;
@@ -1667,7 +1667,6 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
         let hookEventCount = 0;
         let hookCommandInvocationCount = 0;
         let malformedLineCount = 0;
-        let activeFiles = 0;
         const concurrency = cfg.knobs.claudeConcurrency;
         const recordCount = () =>
             turnCount +
@@ -1712,9 +1711,9 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                 if (cutoff > 0 && mtimeMs < cutoff) continue;
                 candidates.push({
                     projectDir,
-                    filePath,
+                    path: filePath,
                     mtimeMs,
-                    size,
+                    sizeBytes: size,
                 });
             }
         }
@@ -1742,46 +1741,27 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                 .filter((name): name is string => typeof name === "string" && name.length > 0),
         );
 
-        // Skip-unchanged watermark (hypothesis 006), now via the shared
-        // `fileWatermark` seam: ONE indexed read of every per-file (mtime,size)
-        // marker, an in-memory `unchanged()` skip check, and a `commit()` UPSERT
-        // recorded only after a file's writes succeed. A candidate whose stat
-        // still matches its watermark is output-equivalent to a prior run (its
-        // turns/tool calls/events already persist) so we skip parsing+writing it.
-        // `AX_REDERIVE_CLAUDE=1` forces a full re-parse (ignores watermarks).
-        const wm = yield* fileWatermark({
+        // Skip-unchanged watermark + per-file failure isolation + deadline +
+        // active-file counting all live in the shared JSONL work-unit
+        // (jsonl-work-unit.ts); claude supplies its flat-tree discovery (above)
+        // and the per-file parse/write below. A candidate whose (mtime,size)
+        // still matches a prior run is output-equivalent and skipped without
+        // re-parsing. `AX_REDERIVE_CLAUDE=1` forces a full re-parse.
+        const result = yield* runJsonlProviderFiles({
+            candidates,
             sourceKind: "claude_transcript",
             forceEnv: "AX_REDERIVE_CLAUDE",
-        });
-
-        const failures = makeFileFailureCollector({
             source: "claude",
-            ...(opts.onFileFailures ? { onFailure: opts.onFileFailures } : {}),
-        });
-        yield* Effect.forEach(candidates.map((candidate, index) => ({ candidate, index })), ({ candidate, index }) => Effect.gen(function* () {
-            // Time-box (dry-run calibration): once the deadline passes, start no
-            // new files. In-flight ones finish, so the sample is whatever
-            // completed within the budget.
-            if (opts.deadlineMs !== undefined && Date.now() >= opts.deadlineMs) {
-                return;
-            }
-            // Skip-unchanged: a candidate whose on-disk (mtime,size) still
-            // matches its persisted watermark has already been ingested in a
-            // prior run; its rows persist, so skipping is output-equivalent.
-            if (wm.unchanged(candidate.filePath, candidate.mtimeMs, candidate.size)) {
-                return;
-            }
-            activeFiles += 1;
-            // Per-file failure isolation: a bad transcript (or a rejected
-            // statement) skips THIS file - it is retried next run - instead of
-            // aborting the whole stage (see file-isolation.ts).
-            yield* failures.isolate(candidate.filePath, Effect.gen(function* () {
+            ...(opts.onFileFailures ? { onFileFailures: opts.onFileFailures } : {}),
+            ...(opts.deadlineMs !== undefined ? { deadlineMs: opts.deadlineMs } : {}),
+            concurrency,
+            processFile: (candidate, index, loop) => Effect.gen(function* () {
                 if (opts.onProgress && (index < 5 || index % 10 === 0)) {
                     yield* opts.onProgress({
                         currentFile: index + 1,
                         totalFiles: candidates.length,
                         files,
-                        activeFiles,
+                        activeFiles: loop.activeFiles,
                         records: recordCount(),
                         sessions,
                         turns: turnCount,
@@ -1796,22 +1776,23 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                 // A transcript that VANISHED between discovery and here (e.g. a
                 // git worktree cleaned up mid-run) surfaces as a typed
                 // PlatformError; NotFound→null SKIPS it. The skip short-circuits
-                // BEFORE `files += 1` / `wm.commit` below, so a vanished file never
-                // advances the watermark. Non-NotFound failures re-raise.
-                const extracted = yield* extractFile(candidate.filePath, candidate.projectDir).pipe(
+                // BEFORE `files += 1` / the work-unit's commit (returning null),
+                // so a vanished file never advances the watermark. Non-NotFound
+                // failures re-raise.
+                const extracted = yield* extractFile(candidate.path, candidate.projectDir).pipe(
                     skipNotFound(null),
                     Effect.withSpan("transcripts.parse", {
-                        attributes: { "file.size": candidate.size },
+                        attributes: { "file.size": candidate.sizeBytes },
                     }),
                 );
                 if (!extracted) {
-                    return;
+                    return null;
                 }
                 files += 1;
                 malformedLineCount += extracted.malformedLines;
                 const pointer = yield* snapshotTranscript(
                     extracted.session.id,
-                    candidate.filePath,
+                    candidate.path,
                 );
                 extracted.session.raw_file = pointer;
                 yield* upsertSessions([extracted.session]);
@@ -1852,7 +1833,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                         currentFile: index + 1,
                         totalFiles: candidates.length,
                         files,
-                        activeFiles,
+                        activeFiles: loop.activeFiles,
                         records: recordCount(),
                         sessions,
                         turns: turnCount,
@@ -1869,7 +1850,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                         currentFile: index + 1,
                         totalFiles: candidates.length,
                         files,
-                        activeFiles,
+                        activeFiles: loop.activeFiles,
                         records: recordCount(),
                         sessions,
                         turns: turnCount,
@@ -1885,15 +1866,14 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                         ...counts,
                     });
                 }
-                // Record the watermark only after every write for this file
-                // succeeded, so a mid-file failure re-processes next run.
-                yield* wm.commit(candidate.filePath, candidate.mtimeMs, candidate.size);
-            }));
-            activeFiles -= 1;
-        }).pipe(Effect.withSpan("transcripts.file", {
-            attributes: { "file.path": candidate.filePath, "file.size": candidate.size },
-        })), { concurrency, discard: true });
-        yield* failures.report;
+                // Returning the session id signals success: the work-unit
+                // commits the watermark only after this processFile resolves, so
+                // a mid-file failure re-processes next run.
+                return extracted.session.id;
+            }).pipe(Effect.withSpan("transcripts.file", {
+                attributes: { "file.path": candidate.path, "file.size": candidate.sizeBytes },
+            })),
+        });
         yield* Effect.logDebug("transcript ingest complete", {
             files,
             records: recordCount(),
@@ -1918,7 +1898,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
             hookEvents: hookEventCount,
             hookCommandInvocations: hookCommandInvocationCount,
             malformedLines: malformedLineCount,
-            failedFiles: failures.count(),
+            failedFiles: result.failures.count(),
         } satisfies TranscriptStats;
     },
 );

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1786,7 +1786,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                     }),
                 );
                 if (!extracted) {
-                    return null;
+                    return false;
                 }
                 files += 1;
                 malformedLineCount += extracted.malformedLines;
@@ -1866,10 +1866,10 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
                         ...counts,
                     });
                 }
-                // Returning the session id signals success: the work-unit
-                // commits the watermark only after this processFile resolves, so
-                // a mid-file failure re-processes next run.
-                return extracted.session.id;
+                // Returning true signals success: the work-unit commits the
+                // watermark only after this processFile resolves, so a mid-file
+                // failure re-processes next run.
+                return true;
             }).pipe(Effect.withSpan("transcripts.file", {
                 attributes: { "file.path": candidate.path, "file.size": candidate.sizeBytes },
             })),

--- a/apps/axctl/src/ingest/transcripts.watermark.test.ts
+++ b/apps/axctl/src/ingest/transcripts.watermark.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer, Path } from "effect";
+import { AxConfigTest } from "@ax/lib/config";
+import { layerTestFileSystem } from "@ax/lib/testing/test-filesystem";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { ingestTranscripts } from "./transcripts.ts";
+
+// Integration regression for the claude fold onto the shared JSONL work-unit:
+// a real `ingestTranscripts` run end-to-end (flat-tree walk -> work-unit ->
+// per-file parse/write -> watermark commit), then an identical second run that
+// must SKIP every file via the watermark. The test FS `stat` returns a stable
+// (mtime=epoch0, size=len), so an unchanged transcript matches its mark.
+//
+// Stateful fake of `ingest_file_state`: SELECT returns prior commits, UPSERT
+// records them. claude_transcript triggers the one-time id-unify migration, so
+// the responder also tracks its sentinel row.
+function statefulClaudeDb() {
+    const marks = new Map<string, { path: string; mtime_ms: number; size: number }>();
+    let migrationDone = false;
+    return makeTestSurrealClient({
+        fallback: (sql) => {
+            if (sql.includes("__watermark_migration__")) {
+                if (sql.includes("UPSERT")) {
+                    migrationDone = true;
+                    return [[]];
+                }
+                return [migrationDone ? [{ id: "sentinel" }] : []];
+            }
+            if (sql.includes("DELETE") && sql.includes("ingest_file_state")) return [[]];
+            if (sql.includes("UPSERT ingest_file_state")) {
+                const path = /path: "([^"]*)"/.exec(sql)?.[1];
+                const mtime = Number(/mtime_ms: (-?\d+)/.exec(sql)?.[1] ?? "0");
+                const size = Number(/size: (-?\d+)/.exec(sql)?.[1] ?? "0");
+                if (path) marks.set(path, { path, mtime_ms: mtime, size });
+                return [[]];
+            }
+            if (sql.includes("FROM ingest_file_state")) {
+                return [Array.from(marks.values())];
+            }
+            // skill catalog + all normalized-batch / token / hook writes -> no-op
+            return [[]];
+        },
+    }).layer;
+}
+
+const fixture = [
+    JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        timestamp: "2026-06-10T09:00:00.000Z",
+        cwd: "/Users/x/proj",
+        message: { role: "user", content: "fix the ingest bug" },
+    }),
+    JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        timestamp: "2026-06-10T09:00:01.000Z",
+        cwd: "/Users/x/proj",
+        message: { model: "claude-sonnet-4-5", content: [{ type: "text", text: "done" }] },
+    }),
+].join("\n");
+
+describe("claude ingest watermark (work-unit fold)", () => {
+    test("first run parses the transcript; identical second run skips it", async () => {
+        const testFs = layerTestFileSystem({
+            "/transcripts/-Users-x-proj/sess.jsonl": fixture,
+        });
+        const TestLayer = Layer.mergeAll(
+            AxConfigTest({ paths: { transcriptsDir: "/transcripts" } }),
+            statefulClaudeDb(),
+            Path.layer,
+        ).pipe(Layer.provideMerge(testFs));
+
+        const run = () => Effect.runPromise(ingestTranscripts().pipe(Effect.provide(TestLayer)));
+
+        const first = await run();
+        expect(first.files).toBe(1);
+        expect(first.sessions).toBe(1);
+
+        // Same bytes, same stat -> watermark matches -> the work-unit skips it.
+        const second = await run();
+        expect(second.files).toBe(0);
+        expect(second.sessions).toBe(0);
+    });
+});

--- a/apps/axctl/src/ingest/walk-jsonl.ts
+++ b/apps/axctl/src/ingest/walk-jsonl.ts
@@ -5,6 +5,10 @@ import { Effect, FileSystem, Option, Path, PlatformError } from "effect";
 export interface JsonlFileCandidate {
     readonly path: string;
     readonly sizeBytes: number;
+    /** File mtime in epoch ms, carried for the skip-unchanged ingest
+     *  watermark (the JSONL provider work-unit feeds `(mtime,size)` to
+     *  `fileWatermark`). Defaulted to 0 when the stat lacks an mtime. */
+    readonly mtimeMs: number;
 }
 
 interface WalkEntryFile {
@@ -26,9 +30,9 @@ type WalkEntry = WalkEntryFile | WalkEntryDirectory;
  *
  * The Claude parser (`ingestTranscripts` in transcripts.ts) intentionally does
  * NOT use this skeleton: its layout is flat (`<project-slug>/<session>.jsonl`,
- * exactly one level, no recursion) and it must keep the full `(mtime, size)`
- * stat per file for the skip-unchanged ingest watermark, whereas this walker
- * only consumes mtime/size for the `--since` cutoff and discards them.
+ * exactly one level, no recursion) so it keeps its own flat walk. Every
+ * candidate carries `(mtimeMs, sizeBytes)` so all three JSONL providers can
+ * feed `fileWatermark` through the shared work-unit (`jsonl-work-unit.ts`).
  */
 const walkJsonlCore = <E, R>(input: {
     readonly root: string;
@@ -53,7 +57,7 @@ const walkJsonlCore = <E, R>(input: {
                         yield* visit(full);
                     } else if (full.endsWith(".jsonl")) {
                         if (input.cutoffMs > 0 && info.mtimeMs < input.cutoffMs) continue;
-                        out.push({ path: full, sizeBytes: info.sizeBytes });
+                        out.push({ path: full, sizeBytes: info.sizeBytes, mtimeMs: info.mtimeMs });
                     }
                 }
             });


### PR DESCRIPTION
## What

The per-file ingest loop — skip-unchanged **watermark**, per-file failure isolation, dry-run deadline, file/active-file counters — was hand-rolled in each of the three JSONL providers, and **only claude wired the watermark**. codex and pi re-parsed + re-UPSERTed *every* JSONL file on *every* run.

Extracted `jsonl-work-unit.ts`: one loop the three providers run their candidates through. Each provider supplies discovery + a per-file `processFile`; the work-unit owns the mechanics (generic over result/error/requirements/candidate type). `walk-jsonl.ts` now carries `mtimeMs` (it already computed it, then discarded it — the only thing that had blocked codex/pi from using the shared watermark).

- **codex + pi** adopt the work-unit → they now skip unchanged files.
- **claude** folded onto it (it was the reference loop); its duplicated watermark/isolation/deadline/active-file code deleted.
- **opencode / cursor** (SQLite stores) stay out — different isolation grain (documented follow-up).

## The win (perf, not corruption — writes were already idempotent)

Live codex re-ingest, `--since=7`, 173 sessions / 19,838 turns:

| run | files parsed | time |
|---|---|---|
| cold (writes watermarks) | 173 | 422,003 ms |
| warm (identical re-run) | **0** | **26 ms** |

A no-op re-ingest drops from ~7 min to 26 ms. The watcher fires `ingest --since=1` constantly, so codex/pi paid this on every transcript before.

## Correctness preserved

Load-bearing ordering kept from claude's reference loop: unchanged-skip happens *before* isolation (free skip); `commit()` runs *only after* `processFile` succeeds (a mid-file failure retries next run); a vanished file (`processFile → null`) never counts or commits. `claude-subagent` exclusion, fail-open isolation, and the dry-run deadline all carry over.

## Tests

`jsonl-work-unit.test.ts` proves skip fires deterministically (identical re-run skips all · changed `(mtime,size)` re-processes only that file · isolated failure doesn't commit → retries · vanished doesn't commit · `AX_REDERIVE_*` forces). `bun test` **4727 pass / 0 fail**; `bun run typecheck` clean.

New CONTEXT.md term: **JSONL Provider Work-Unit**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)