### PR TITLE
ci(studio-desktop): R2 feed upload via wrangler (CF token)

### DIFF
--- a/.github/workflows/studio-desktop-release.yml
+++ b/.github/workflows/studio-desktop-release.yml
@@ -14,10 +14,10 @@ name: studio-desktop-release
 #     APPLE_ID                      Apple ID email for notarization
 #     APPLE_APP_SPECIFIC_PASSWORD   app-specific password for that Apple ID
 #     APPLE_TEAM_ID                 Apple Developer Team ID
-#   Cloudflare R2 (upload feed; S3-compatible):
-#     R2_ACCOUNT_ID                 Cloudflare account id (endpoint host)
-#     R2_ACCESS_KEY_ID              R2 API token access key
-#     R2_SECRET_ACCESS_KEY          R2 API token secret
+#   Cloudflare R2 (upload feed; via wrangler):
+#     CLOUDFLARE_API_TOKEN          CF API token with Workers R2 Storage: Edit
+#     R2_ACCOUNT_ID                 Cloudflare account id (also pins wrangler so it
+#                                   skips the /memberships lookup a scoped token can't read)
 #     R2_BUCKET                     R2 bucket name (e.g. ax-desktop-releases)
 
 on:
@@ -63,20 +63,21 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: bunx electron-builder --arm64 --config electron-builder.config.cjs --publish never
 
-      - name: Upload to R2 update feed
-        working-directory: apps/studio-desktop
+      - name: Upload to R2 update feed (wrangler)
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          # R2 rejects the default aws-cli streaming checksums; only send when required.
-          AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
-          AWS_RESPONSE_CHECKSUM_VALIDATION: WHEN_REQUIRED
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Pinning the account makes wrangler skip the /memberships call that a
+          # scoped R2 token can't read.
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
-          aws s3 cp dist-release/ "s3://${{ secrets.R2_BUCKET }}/desktop/" \
-            --recursive \
-            --endpoint-url "https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com" \
-            --exclude "*" \
-            --include "*.dmg" \
-            --include "*.zip" \
-            --include "*.blockmap" \
-            --include "latest-mac.yml"
+          shopt -s nullglob
+          files=(apps/studio-desktop/dist-release/*.dmg \
+                 apps/studio-desktop/dist-release/*.zip \
+                 apps/studio-desktop/dist-release/*.blockmap \
+                 apps/studio-desktop/dist-release/latest-mac.yml)
+          if [ ${#files[@]} -eq 0 ]; then echo "no artifacts to upload" >&2; exit 1; fi
+          for f in "${files[@]}"; do
+            echo "uploading $(basename "$f") -> $R2_BUCKET/desktop/"
+            bunx wrangler r2 object put "$R2_BUCKET/desktop/$(basename "$f")" --file="$f"
+          done

--- a/apps/studio-desktop/electron-builder.config.cjs
+++ b/apps/studio-desktop/electron-builder.config.cjs
@@ -18,23 +18,20 @@
 // (.github/workflows/studio-desktop-release.yml) must:
 //   1. Build SIGNED + NOTARIZED with `--publish never`, producing dist-release/
 //      with the dmg, zip, *.blockmap, and `latest-mac.yml` feed manifest.
-//   2. Upload all of those to the R2 bucket under /desktop/ (S3-compatible).
+//   2. Upload all of those to the R2 bucket under /desktop/ (via wrangler).
 //      `latest-mac.yml` at the feed URL is what the updater polls; without it
 //      `checkForUpdatesAndNotify()` no-ops.
 //   3. Provide credentials:
-//        - R2 (S3) keys to upload: R2_ACCOUNT_ID / R2_ACCESS_KEY_ID /
-//          R2_SECRET_ACCESS_KEY / R2_BUCKET.
+//        - R2 upload: CLOUDFLARE_API_TOKEN (Workers R2 Storage: Edit) +
+//          R2_ACCOUNT_ID + R2_BUCKET.
 //        - Apple signing + notarization (see below): CSC_LINK / CSC_KEY_PASSWORD
 //          + APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID. macOS
 //          electron-updater REQUIRES the update be signed + notarized; an
 //          unsigned/ad-hoc build refuses to apply a downloaded update.
 //
-// ONE-TIME Cloudflare setup (manual, in the CF dashboard):
-//   - Create an R2 bucket (e.g. `ax-desktop-releases`).
-//   - Expose it at a public custom domain matching the `publish.url` host
-//     (default https://dl.ax.necmttn.com → bucket root; files land under
-//     /desktop/). Or set AX_UPDATE_FEED to your r2.dev URL.
-//   - Create an R2 API token (Object Read & Write) → the R2_* secrets above.
+// Cloudflare setup (DONE 2026-06-17): bucket `ax-desktop-releases` (APAC) + the
+// public custom domain `dl.ax.necmttn.com` are provisioned, and the R2/Apple
+// repo secrets are set. To move the feed, set AX_UPDATE_FEED at build time.
 //
 // IMPORTANT - macOS code-signing / SIGKILL failure mode (see memory:
 // dogfood-compiled-binary-codesign):


### PR DESCRIPTION
Follow-up to #500. Switches the desktop release feed upload from `aws s3 cp` (R2 S3 access keys) to `wrangler r2 object put` with a Cloudflare API token — fewer/cleaner secrets.

- Secrets now: `CLOUDFLARE_API_TOKEN` (Workers R2 Storage: Edit) + `R2_ACCOUNT_ID` (also pins wrangler so it skips the `/memberships` call a scoped token can't read) + `R2_BUCKET`. Drops `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`.
- Uploads dmg/zip/blockmap/latest-mac.yml under `/desktop/`.

Infra is live: bucket `ax-desktop-releases` (APAC) + public custom domain `dl.ax.necmttn.com` provisioned; all Apple + CF repo secrets set. Verified an object round-trips through the domain (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)