### PR TITLE
refactor(axctl): deepen improve and dojo seams

### DIFF
--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -139,8 +139,12 @@ const agendaCommand = Command.make(
                 },
                 nowMs,
             );
-            const items = yield* collectAgendaItems({ nowMs, days, spar });
-            const agenda = assembleAgenda(envelope, items, { nowMs, spar });
+            const collected = yield* collectAgendaItems({ nowMs, days, spar });
+            const agenda = assembleAgenda(envelope, collected.items, {
+                nowMs,
+                spar,
+                sourceFailures: collected.source_failures,
+            });
             console.log(json ? prettyPrint(agenda) : renderAgenda(agenda));
         }).pipe(Effect.provide(QuotaEnvLive));
     },

--- a/apps/axctl/src/dashboard/improve-proposals.test.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.test.ts
@@ -7,8 +7,12 @@
 import { describe, expect, it } from "bun:test";
 import { Effect, Layer } from "effect";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import { resetImpactCacheForTest } from "../improve/impact.ts";
-import { fetchImproveProposals, renderHypothesisTemplate, resetHydrateCacheForTest } from "./improve-proposals.ts";
+import { createImpactEstimateCache } from "../improve/impact.ts";
+import {
+    createHypothesisHydrationCache,
+    fetchImproveProposals,
+    renderHypothesisTemplate,
+} from "./improve-proposals.ts";
 import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
 
 // ---------------------------------------------------------------------------
@@ -31,6 +35,12 @@ const run = <A>(
     eff: Effect.Effect<A, unknown, SurrealClient>,
     layer: Layer.Layer<SurrealClient>,
 ) => Effect.runPromise(eff.pipe(Effect.provide(layer)));
+
+const hydrationDeps = () => ({
+    hydrationCache: createHypothesisHydrationCache(),
+    impactCache: createImpactEstimateCache(),
+    nowMs: () => 1_000,
+});
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -92,7 +102,6 @@ const makeSequencedDb = (perCall: QueryResult[][]): Layer.Layer<SurrealClient> =
 
 describe("fetchImproveProposals - hypothesis hydration", () => {
     it("hydrates from evidence_query first row", async () => {
-        resetHydrateCacheForTest();
         const dynamicRow = {
             ...openRow,
             dedupe_sig: "sig-dyn",
@@ -101,7 +110,7 @@ describe("fetchImproveProposals - hypothesis hydration", () => {
             evidence_query: "SELECT count() AS n FROM tool_call GROUP ALL;",
         };
         const rows = await run(
-            fetchImproveProposals(),
+            fetchImproveProposals(hydrationDeps()),
             // call 1: proposals list; call 2: the evidence query
             makeSequencedDb([[[dynamicRow]], [[{ n: 42 }]]]),
         ) as ReadonlyArray<ProposalDto>;
@@ -109,8 +118,6 @@ describe("fetchImproveProposals - hypothesis hydration", () => {
     });
 
     it("mined routing proposal: hypothesis rebuilt from the live impact estimate", async () => {
-        resetHydrateCacheForTest();
-        resetImpactCacheForTest();
         const routingRow = {
             ...openRow,
             form: "hook",
@@ -120,7 +127,7 @@ describe("fetchImproveProposals - hypothesis hydration", () => {
                 "39 model-less dispatches on fable/opus matched mechanical routing classes in the last 2d; est $209.59 redirectable. Apply: ax dispatches compile-routing + route-dispatch hook (ax hooks install).",
         };
         const rows = await run(
-            fetchImproveProposals(),
+            fetchImproveProposals(hydrationDeps()),
             // call 1: proposals list; call 2: fetchDispatchCandidates multi-statement
             // (oversized empty tuple satisfies its destructuring with zero rows)
             makeSequencedDb([[[routingRow]], Array.from({ length: 8 }, () => []) as QueryResult[]]),
@@ -136,7 +143,6 @@ describe("fetchImproveProposals - hypothesis hydration", () => {
     });
 
     it("fail-open: non-readonly or failing query keeps the frozen hypothesis", async () => {
-        resetHydrateCacheForTest();
         const badRow = {
             ...openRow,
             dedupe_sig: "sig-bad",
@@ -145,7 +151,7 @@ describe("fetchImproveProposals - hypothesis hydration", () => {
             evidence_query: "DELETE proposal;",
         };
         const rows = await run(
-            fetchImproveProposals(),
+            fetchImproveProposals(hydrationDeps()),
             makeMockDb([[badRow]]),
         ) as ReadonlyArray<ProposalDto>;
         expect(rows[0]?.hypothesis).toBe("frozen stays");
@@ -155,7 +161,7 @@ describe("fetchImproveProposals - hypothesis hydration", () => {
 describe("fetchImproveProposals - brief attachment", () => {
     it("open row: brief contains sig and open-status ask", async () => {
         const rows = await run(
-            fetchImproveProposals(),
+            fetchImproveProposals(hydrationDeps()),
             makeMockDb([[openRow]]),
         ) as ReadonlyArray<ProposalDto>;
 
@@ -168,7 +174,7 @@ describe("fetchImproveProposals - brief attachment", () => {
 
     it("non-open row: brief contains sig and experiment-status ask", async () => {
         const rows = await run(
-            fetchImproveProposals(),
+            fetchImproveProposals(hydrationDeps()),
             makeMockDb([[acceptedRow]]),
         ) as ReadonlyArray<ProposalDto>;
 
@@ -182,7 +188,7 @@ describe("fetchImproveProposals - brief attachment", () => {
 
     it("coalesces missing origin to mined; preserves explicit agent", async () => {
         const rows = await run(
-            fetchImproveProposals(),
+            fetchImproveProposals(hydrationDeps()),
             makeMockDb([[openRow, { ...openRow, dedupe_sig: "sig-agent", origin: "agent" }]]),
         ) as ReadonlyArray<ProposalDto>;
 
@@ -192,7 +198,7 @@ describe("fetchImproveProposals - brief attachment", () => {
 
     it("returns empty array for empty DB result", async () => {
         const rows = await run(
-            fetchImproveProposals(),
+            fetchImproveProposals(hydrationDeps()),
             makeMockDb([[]]),
         );
         expect(rows).toEqual([]);
@@ -200,7 +206,7 @@ describe("fetchImproveProposals - brief attachment", () => {
 
     it("attaches brief to every row in a multi-row result", async () => {
         const rows = await run(
-            fetchImproveProposals(),
+            fetchImproveProposals(hydrationDeps()),
             makeMockDb([[openRow, acceptedRow]]),
         ) as ReadonlyArray<ProposalDto>;
 

--- a/apps/axctl/src/dashboard/improve-proposals.ts
+++ b/apps/axctl/src/dashboard/improve-proposals.ts
@@ -1,7 +1,11 @@
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
-import { estimateImpactCached, ROUTING_PROPOSAL_TITLE } from "../improve/impact.ts";
+import {
+    estimateImpactCached,
+    type ImpactEstimateCache,
+    ROUTING_PROPOSAL_TITLE,
+} from "../improve/impact.ts";
 import { renderAgentBrief } from "./agent-brief.ts";
 
 // Experiment-loop shortlist + verdict state. Reads proposal +
@@ -69,11 +73,38 @@ export const renderHypothesisTemplate = (
  *  expires. Fail-open per proposal - a broken query keeps the frozen
  *  hypothesis. Hydration results cache per sig for 5 minutes. */
 const HYDRATE_TTL_MS = 5 * 60_000;
-const hydrateCache = new Map<string, { hypothesis: string; at: number }>();
 
-export function resetHydrateCacheForTest(): void {
-    hydrateCache.clear();
+export interface HypothesisHydrationCache {
+    readonly get: (dedupeSig: string, nowMs: number) => string | null;
+    readonly set: (dedupeSig: string, hypothesis: string, nowMs: number) => void;
 }
+
+export const createHypothesisHydrationCache = (
+    opts: { readonly ttlMs?: number } = {},
+): HypothesisHydrationCache => {
+    const ttlMs = opts.ttlMs ?? HYDRATE_TTL_MS;
+    const cache = new Map<string, { hypothesis: string; at: number }>();
+    return {
+        get: (dedupeSig, nowMs) => {
+            const hit = cache.get(dedupeSig);
+            return hit && nowMs - hit.at < ttlMs ? hit.hypothesis : null;
+        },
+        set: (dedupeSig, hypothesis, nowMs) => {
+            cache.set(dedupeSig, { hypothesis, at: nowMs });
+        },
+    };
+};
+
+export interface ImproveProposalHydrationDeps {
+    readonly hydrationCache?: HypothesisHydrationCache;
+    readonly impactCache?: ImpactEstimateCache;
+    readonly nowMs?: () => number;
+}
+
+const defaultHydrationCache = createHypothesisHydrationCache();
+
+const currentMs = (deps: ImproveProposalHydrationDeps): number =>
+    deps.nowMs?.() ?? Date.now();
 
 /** The mined routing proposal predates hypothesis_template/evidence_query,
  *  so its dollar figure freezes at mine time while the impact endpoint
@@ -82,8 +113,8 @@ export function resetHydrateCacheForTest(): void {
  *  drawer impact then cannot disagree. Fail-open: any error keeps the
  *  frozen text. */
 const hydrateRoutingHypothesis = Effect.fn("dashboard.hydrateRoutingHypothesis")(
-    function* (p: ProposalDto) {
-        const est = yield* estimateImpactCached(p, Date.now()).pipe(
+    function* (p: ProposalDto, deps: ImproveProposalHydrationDeps) {
+        const est = yield* estimateImpactCached(p, currentMs(deps), deps.impactCache).pipe(
             Effect.catch(() => Effect.succeed(null)),
         );
         if (est === null || est.kind !== "savings_usd") return p;
@@ -97,16 +128,19 @@ const hydrateRoutingHypothesis = Effect.fn("dashboard.hydrateRoutingHypothesis")
 
 const hydrateHypothesis = Effect.fn("dashboard.hydrateHypothesis")(function* (
     p: ProposalDto,
+    deps: ImproveProposalHydrationDeps,
 ) {
     if (p.form === "hook" && p.title === ROUTING_PROPOSAL_TITLE) {
-        return yield* hydrateRoutingHypothesis(p);
+        return yield* hydrateRoutingHypothesis(p, deps);
     }
     const template = p.hypothesis_template;
     const query = p.evidence_query;
     if (!template || !query || !/^(SELECT|RETURN)\b/i.test(query.trim())) return p;
-    const hit = hydrateCache.get(p.dedupe_sig);
-    if (hit && Date.now() - hit.at < HYDRATE_TTL_MS) {
-        return { ...p, hypothesis: hit.hypothesis };
+    const cache = deps.hydrationCache ?? defaultHydrationCache;
+    const nowMs = currentMs(deps);
+    const hit = cache.get(p.dedupe_sig, nowMs);
+    if (hit !== null) {
+        return { ...p, hypothesis: hit };
     }
     const db = yield* SurrealClient;
     const hydrated = yield* db.query<[Array<Record<string, unknown>>]>(query).pipe(
@@ -117,18 +151,18 @@ const hydrateHypothesis = Effect.fn("dashboard.hydrateHypothesis")(function* (
         Effect.catch(() => Effect.succeed(null)),
     );
     if (hydrated === null) return p;
-    hydrateCache.set(p.dedupe_sig, { hypothesis: hydrated, at: Date.now() });
+    cache.set(p.dedupe_sig, hydrated, nowMs);
     return { ...p, hypothesis: hydrated };
 });
 
 /** Raw proposal rows, loosely typed at the edge like the legacy queryApi endpoints. */
 export const fetchImproveProposals = Effect.fn("dashboard.fetchImproveProposals")(
-    function* () {
+    function* (deps: ImproveProposalHydrationDeps = {}) {
         const db = yield* SurrealClient;
         const result = yield* db.query<[Array<Record<string, unknown>>]>(PROPOSALS_SQL);
         // TODO: replace with schema decode when the proposal wire shape stabilizes
         const rows = (result[0] ?? []) as unknown as ReadonlyArray<ProposalDto>;
-        const hydrated = yield* Effect.all(rows.map((p) => hydrateHypothesis(p)), {
+        const hydrated = yield* Effect.all(rows.map((p) => hydrateHypothesis(p, deps)), {
             concurrency: 4,
         });
         return hydrated.map(withBrief);

--- a/apps/axctl/src/dashboard/next-actions.test.ts
+++ b/apps/axctl/src/dashboard/next-actions.test.ts
@@ -268,12 +268,21 @@ describe("impactChip", () => {
         const b = proposalCards([openProposal({ form: "guidance", frequency: 1 })])[0]!;
         expect(b.impact_chip).toBeNull();
     });
+
+    test("forms without chip metadata return null", () => {
+        expect(proposalCards([openProposal({ form: "subagent", frequency: 9 })])[0]!.impact_chip).toBeNull();
+        expect(proposalCards([openProposal({ form: "automation", frequency: 9 })])[0]!.impact_chip).toBeNull();
+        expect(proposalCards([openProposal({ form: "harness_check", frequency: 9 })])[0]!.impact_chip).toBeNull();
+    });
 });
 
 describe("fixKind", () => {
     test("names the mechanism per form, guidance names its file target", () => {
         expect(proposalCards([openProposal({ form: "skill" })])[0]!.fix_kind).toBe("new skill");
         expect(proposalCards([openProposal({ form: "hook" })])[0]!.fix_kind).toBe("new hook");
+        expect(proposalCards([openProposal({ form: "subagent" })])[0]!.fix_kind).toBe("new subagent");
+        expect(proposalCards([openProposal({ form: "automation" })])[0]!.fix_kind).toBe("automation");
+        expect(proposalCards([openProposal({ form: "harness_check" })])[0]!.fix_kind).toBe("harness check");
         expect(
             proposalCards([
                 openProposal({

--- a/apps/axctl/src/dashboard/next-actions.ts
+++ b/apps/axctl/src/dashboard/next-actions.ts
@@ -27,6 +27,7 @@ import type { SkillHygieneRow } from "../queries/skill-hygiene.ts";
 import { fetchSkillHygiene } from "../queries/skill-hygiene.ts";
 import { fetchImproveProposals, proposalReviewBrief } from "./improve-proposals.ts";
 import { findStaleOpenProposals, type StaleProposalRow } from "../improve/housekeep.ts";
+import { interventionFormSpec } from "../improve/intervention-forms.ts";
 import { fetchToolFailures } from "./tool-failures.ts";
 import { renderAgentBrief } from "./agent-brief.ts";
 
@@ -63,14 +64,16 @@ const nn = (v: string | null, fallback = "unknown"): string => v ?? fallback;
  *  (no recompute; the full estimate lives at /api/improve/:sig/impact).
  *  Mined routing proposals carry their savings figure in the hypothesis. */
 export const impactChip = (p: ProposalDto): string | null => {
-    if (p.form === "hook") {
-        const m = /est \$([\d,]+(?:\.\d+)?)/.exec(p.hypothesis);
-        if (m) return `~$${m[1]} redirectable`;
+    switch (interventionFormSpec(String(p.form))?.nextActionImpactChip ?? "none") {
+        case "routing_savings": {
+            const m = /est \$([\d,]+(?:\.\d+)?)/.exec(p.hypothesis);
+            return m ? `~$${m[1]} redirectable` : null;
+        }
+        case "frequency":
+            return p.frequency > 1 ? `${p.frequency}x recurring` : null;
+        case "none":
+            return null;
     }
-    if (p.form === "guidance" || p.form === "skill") {
-        return p.frequency > 1 ? `${p.frequency}x recurring` : null;
-    }
-    return null;
 };
 
 // ---------------------------------------------------------------------------
@@ -83,19 +86,13 @@ export const impactChip = (p: ProposalDto): string | null => {
 /** Name the fix MECHANISM - "checklist" alone doesn't say skill vs
  *  guidance edit vs hook. Guidance names its actual file target. */
 export const fixKind = (p: ProposalDto): string => {
-    switch (p.form) {
-        case "skill":
-            return "new skill";
-        case "guidance":
+    const spec = interventionFormSpec(String(p.form));
+    if (spec === null) return String(p.form);
+    switch (spec.nextActionFixKind) {
+        case "edit_guidance":
             return `edit ${p.guidance_payload?.file_target ?? "guidance"}`;
-        case "hook":
-            return "new hook";
-        case "subagent":
-            return "new subagent";
-        case "automation":
-            return "automation";
         default:
-            return String(p.form);
+            return spec.nextActionFixKind;
     }
 };
 

--- a/apps/axctl/src/dashboard/skills-weighted.ts
+++ b/apps/axctl/src/dashboard/skills-weighted.ts
@@ -11,7 +11,7 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { fetchSparSessionIds } from "../queries/spar-sessions.ts";
-import { sessionTelemetryLatency, bareSession } from "../queries/telemetry-rollup.ts";
+import { enrichRowsWithTelemetryLatency } from "../queries/telemetry-rollup.ts";
 import { fetchSkillHygiene, SKILL_HYGIENE_MIN_INVOCATIONS } from "../queries/skill-hygiene.ts";
 
 // ---------------------------------------------------------------------------
@@ -378,17 +378,23 @@ export const fetchSkillsWeighted = (
             [...skillToSessions.values()].flat(),
         )];
 
-        // One batched call to fetch latency for all recovery sessions
-        const latencyMap = yield* sessionTelemetryLatency(allRecoverySessions);
+        const latencyRows = yield* enrichRowsWithTelemetryLatency(
+            allRecoverySessions,
+            (sid) => sid,
+            (session, latency) => ({ session, duration_ms: latency?.duration_ms ?? null }),
+        );
+        const latencyBySession = new Map(
+            latencyRows.map((row) => [row.session, row.duration_ms] as const),
+        );
 
         // Compute per-skill median recovery duration
         const skillMedianMs = new Map<string, number | null>();
         for (const [skillId, sessionIds] of skillToSessions) {
             const durations: number[] = [];
             for (const sid of sessionIds) {
-                const entry = latencyMap.get(bareSession(sid));
-                if (entry?.duration_ms != null) {
-                    durations.push(entry.duration_ms);
+                const duration = latencyBySession.get(sid);
+                if (duration != null) {
+                    durations.push(duration);
                 }
             }
             if (durations.length === 0) {

--- a/apps/axctl/src/dojo/agenda.test.ts
+++ b/apps/axctl/src/dojo/agenda.test.ts
@@ -29,7 +29,21 @@ describe("assembleAgenda", () => {
         );
         expect(agenda.v).toBe(1);
         expect(agenda.generated_at).toBe("2026-06-13T10:00:00.000Z");
+        expect(agenda.source_failures).toEqual([]);
         expect(agenda.items.map((i) => i.id)).toEqual(["v1", "b1", "e1"]);
+    });
+
+    test("surfaces source failures on the agenda read model", () => {
+        const agenda = assembleAgenda(
+            budget,
+            [],
+            {
+                nowMs: 0,
+                spar: false,
+                sourceFailures: [{ source: "churn", message: "db offline" }],
+            },
+        );
+        expect(agenda.source_failures).toEqual([{ source: "churn", message: "db offline" }]);
     });
 
     test("appends explore when otherwise empty", () => {
@@ -76,7 +90,7 @@ describe("collectAgendaItems", () => {
 
     test("empty graph + missing task dir -> only the proposal-mint nudge", async () => {
         const base = mkdtempSync(join(tmpdir(), "ax-dojo-agenda-"));
-        const items = await Effect.runPromise(
+        const collected = await Effect.runPromise(
             collectAgendaItems({
                 nowMs: Date.parse("2026-06-13T10:00:00.000Z"),
                 days: 30,
@@ -86,6 +100,30 @@ describe("collectAgendaItems", () => {
             }).pipe(Effect.provide(env)),
         );
         // 0 open proposals < MINT_THRESHOLD, so the mint nudge is the lone item.
-        expect(items.map((i) => i.kind)).toEqual(["proposal_mint"]);
+        expect(collected.items.map((i) => i.kind)).toEqual(["proposal_mint"]);
+        expect(collected.source_failures).toEqual([]);
+    });
+
+    test("records which agenda sources failed while preserving degraded items", async () => {
+        const base = mkdtempSync(join(tmpdir(), "ax-dojo-agenda-"));
+        const failingClient: SurrealClientShape = {
+            ...emptyClient,
+            query: <T extends unknown[]>(_sql: string, _bindings?: Record<string, unknown>) =>
+                Effect.fail("db offline") as unknown as Effect.Effect<T>,
+        };
+        const failingEnv = Layer.mergeAll(Layer.succeed(SurrealClient, failingClient), BunFileSystem.layer);
+        const collected = await Effect.runPromise(
+            collectAgendaItems({
+                nowMs: Date.parse("2026-06-13T10:00:00.000Z"),
+                days: 30,
+                spar: false,
+                taskDir: join(base, "does-not-exist"),
+                routingTablePath: join(base, "missing-routing-table.json"),
+            }).pipe(Effect.provide(failingEnv)),
+        );
+        expect(collected.items.map((i) => i.kind)).toEqual(["proposal_mint"]);
+        expect(collected.source_failures.map((f) => f.source)).toEqual(
+            expect.arrayContaining(["verdicts", "churn", "proposals", "routing"]),
+        );
     });
 });

--- a/apps/axctl/src/dojo/agenda.ts
+++ b/apps/axctl/src/dojo/agenda.ts
@@ -4,8 +4,8 @@
  * `assembleAgenda` is the pure, tested core: budget + flat item list -> ordered
  * agenda (priority sort, spar gate, explore fallback). `collectAgendaItems` is
  * the Effect glue that runs every source with per-source failure isolation: a
- * broken source logs to stderr and contributes nothing - it must never kill
- * the whole agenda.
+ * broken source contributes a visible failure record and no items - it must
+ * never kill the whole agenda.
  */
 import { Effect, type FileSystem } from "effect";
 import type { SurrealClient } from "@ax/lib/db";
@@ -23,7 +23,7 @@ import {
     routingBacktestItems,
     sparItem,
 } from "./items.ts";
-import type { BudgetEnvelope, DojoAgenda, DojoItem } from "./schema.ts";
+import type { BudgetEnvelope, DojoAgenda, DojoItem, DojoSourceFailure } from "./schema.ts";
 import { compareByPriority } from "./schema.ts";
 
 export const SPAR_MIN_SPENDABLE_PCT = 30;
@@ -31,6 +31,7 @@ export const SPAR_MIN_SPENDABLE_PCT = 30;
 export interface AssembleOptions {
     readonly nowMs: number;
     readonly spar: boolean;
+    readonly sourceFailures?: readonly DojoSourceFailure[];
 }
 
 /** Pure: budget + flat item list -> ordered agenda. */
@@ -46,6 +47,7 @@ export const assembleAgenda = (
         v: 1,
         generated_at: new Date(opts.nowMs).toISOString(),
         budget,
+        source_failures: opts.sourceFailures ?? [],
         items: sorted,
     };
 };
@@ -66,20 +68,35 @@ const DAY_MS = 86_400_000;
 /** Hot-session rows to consider before churnHotspotItems trims to its top 2. */
 const CHURN_SESSION_LIMIT = 20;
 
-/** Per-source failure isolation: log the failure, contribute the empty value. */
+interface SourceResult<A> {
+    readonly value: A;
+    readonly failure: DojoSourceFailure | null;
+}
+
+const failureMessage = (error: unknown): string =>
+    error instanceof Error ? error.message : String(error);
+
+/** Per-source failure isolation: log the failure and keep it in the read model. */
 const soft = <A, E, R>(
     label: string,
     eff: Effect.Effect<A, E, R>,
     empty: A,
-): Effect.Effect<A, never, R> =>
+): Effect.Effect<SourceResult<A>, never, R> =>
     eff.pipe(
+        Effect.map((value): SourceResult<A> => ({ value, failure: null })),
         Effect.catch((e) =>
             Effect.sync(() => {
-                console.error(`dojo: source ${label} failed: ${String(e)}`);
-                return empty;
+                const message = failureMessage(e);
+                console.error(`dojo: source ${label} failed: ${message}`);
+                return { value: empty, failure: { source: label, message } };
             }),
         ),
     );
+
+export interface CollectAgendaItemsResult {
+    readonly items: readonly DojoItem[];
+    readonly source_failures: readonly DojoSourceFailure[];
+}
 
 /**
  * Run every agenda source and flatten into items. Sources soft-fail
@@ -88,7 +105,7 @@ const soft = <A, E, R>(
  */
 export const collectAgendaItems = (
     opts: CollectOptions,
-): Effect.Effect<readonly DojoItem[], never, SurrealClient | FileSystem.FileSystem> =>
+): Effect.Effect<CollectAgendaItemsResult, never, SurrealClient | FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const verdicts = yield* soft("verdicts", listPendingVerdicts(), []);
         const briefs = yield* soft("briefs", scanTaskDir(opts.taskDir ?? defaultTaskDir()), []);
@@ -111,12 +128,21 @@ export const collectAgendaItems = (
         );
 
         const items: DojoItem[] = [
-            ...pendingVerdictItems(verdicts),
-            ...briefs,
-            ...routingBacktestItems(tune, opts.days),
-            ...churnHotspotItems(churnRows),
+            ...pendingVerdictItems(verdicts.value),
+            ...briefs.value,
+            ...routingBacktestItems(tune.value, opts.days),
+            ...churnHotspotItems(churnRows.value),
         ];
-        const mint = proposalMintItem(open.length);
+        const mint = proposalMintItem(open.value.length);
         if (mint) items.push(mint);
-        return items;
+        return {
+            items,
+            source_failures: [
+                verdicts.failure,
+                briefs.failure,
+                churnRows.failure,
+                open.failure,
+                tune.failure,
+            ].filter((failure): failure is DojoSourceFailure => failure !== null),
+        };
     });

--- a/apps/axctl/src/dojo/format.test.ts
+++ b/apps/axctl/src/dojo/format.test.ts
@@ -11,6 +11,7 @@ const agenda: DojoAgenda = {
         window_remaining_pct: 35, reserve_pct: 15,
         deadline: "2026-06-13T12:00:00.000Z", source: "quota",
     },
+    source_failures: [],
     items: [
         {
             id: "verdict:experiment:aaa", kind: "verdict_pending",
@@ -45,5 +46,13 @@ describe("renderAgenda", () => {
         });
         expect(out).toContain("no surplus");
         expect(out).toContain("--force");
+    });
+
+    test("source failures are visible in human output", () => {
+        const out = renderAgenda({
+            ...agenda,
+            source_failures: [{ source: "churn", message: "db offline" }],
+        });
+        expect(out).toContain("degraded sources: churn");
     });
 });

--- a/apps/axctl/src/dojo/format.ts
+++ b/apps/axctl/src/dojo/format.ts
@@ -20,6 +20,9 @@ export const renderAgenda = (agenda: DojoAgenda): string => {
     if (!b.has_surplus) {
         lines.push("no surplus in the current window - dojo will not start without --force");
     }
+    if (agenda.source_failures.length > 0) {
+        lines.push(`degraded sources: ${agenda.source_failures.map((f) => f.source).join(", ")}`);
+    }
     lines.push("");
     agenda.items.forEach((item, i) => {
         lines.push(`${i + 1}. [${item.kind}/${item.cost_class}] ${item.title}`);

--- a/apps/axctl/src/dojo/schema.ts
+++ b/apps/axctl/src/dojo/schema.ts
@@ -50,10 +50,16 @@ export interface BudgetEnvelope {
     readonly source: "quota" | "override" | "forced" | "unavailable";
 }
 
+export interface DojoSourceFailure {
+    readonly source: string;
+    readonly message: string;
+}
+
 export interface DojoAgenda {
     readonly v: 1;
     readonly generated_at: string;
     readonly budget: BudgetEnvelope;
+    readonly source_failures: readonly DojoSourceFailure[];
     readonly items: readonly DojoItem[];
 }
 

--- a/apps/axctl/src/improve/actions.ts
+++ b/apps/axctl/src/improve/actions.ts
@@ -23,6 +23,7 @@ import {
     planLockVerdict,
     planRejectCandidate,
 } from "./lifecycle.ts";
+import { interventionFormSpec, isInterventionForm, type InterventionForm } from "./intervention-forms.ts";
 import { scaffoldSkill, type ScaffoldResult } from "./skill-scaffold.ts";
 import { renderTaskFile, type TaskInput } from "./task-template.ts";
 
@@ -164,104 +165,33 @@ const fetchFullProposal = (idLiteral: string) =>
 const defaultTaskDir = (): string =>
     process.env.AX_TASK_DIR ?? posixPath.join(process.cwd(), ".ax", "tasks");
 
-/**
- * Map a full proposal row + experimentId to a TaskInput for renderTaskFile.
- */
-const buildTaskInput = (row: FullProposalRow, experimentId: string): TaskInput => {
-    const shortId = row.dedupe_sig;
-    const proposalId = `proposal:${recordKeyPart(row.id, "proposal") ?? row.dedupe_sig}`;
-    if (row.form === "guidance") {
-        return {
-            form: "guidance",
-            experimentId,
-            proposalId,
-            shortId,
-            title: row.title,
-            targetPath: row.guidance_payload?.file_target ?? "~/.claude/CLAUDE.md",
-            section: row.guidance_payload?.section ?? null,
-            suggestedBody: row.guidance_payload?.suggested_text ?? row.hypothesis,
-            proposedBehavior: null,
-            confidence: row.confidence ?? "medium",
-            frequency: row.frequency ?? 0,
-            evidence: row.hypothesis,
-        };
-    }
-    if (row.form === "subagent") {
-        return {
-            form: "subagent",
-            experimentId,
-            proposalId,
-            shortId,
-            title: row.title,
-            targetPath: `~/.claude/agents/${row.dedupe_sig}.md`,
-            section: null,
-            suggestedBody: [
-                row.subagent_payload?.bounded_role ? `Role: ${row.subagent_payload.bounded_role}` : null,
-                row.subagent_payload?.delegation_trigger ? `Delegation trigger: ${row.subagent_payload.delegation_trigger}` : null,
-                row.hypothesis,
-            ].filter((line): line is string => line !== null).join("\n\n"),
-            proposedBehavior: null,
-            confidence: "medium",
-            frequency: 0,
-            evidence: row.hypothesis,
-        };
-    }
-    if (row.form === "hook") {
-        return {
-            form: "hook",
-            experimentId,
-            proposalId,
-            shortId,
-            title: row.title,
-            targetPath: "~/.claude/settings.json",
-            section: row.hook_payload?.event_name ?? "PreToolUse",
-            suggestedBody: row.hook_payload?.hook_command ?? `see proposal: ${row.dedupe_sig}`,
-            proposedBehavior: row.hook_payload?.target_tool ?? null,
-            confidence: "medium",
-            frequency: 0,
-            evidence: row.hypothesis,
-            safety: safetyContractFromPayload(row.hook_payload),
-        };
-    }
-    if (row.form === "automation") {
-        return {
-            form: "automation",
-            experimentId,
-            proposalId,
-            shortId,
-            title: row.title,
-            targetPath: `.ax/interventions/${row.dedupe_sig}/AUTOMATION.md`,
-            section: row.automation_payload?.schedule ?? null,
-            suggestedBody: row.automation_payload?.action ?? `see proposal: ${row.dedupe_sig}`,
-            proposedBehavior: row.automation_payload?.trigger_signal ?? null,
-            confidence: "medium",
-            frequency: 0,
-            evidence: row.hypothesis,
-            safety: safetyContractFromPayload(row.automation_payload),
-        };
-    }
-    if (row.form === "harness_check") {
-        const baselineEvidence = typeof row.baseline === "string" && row.baseline.trim().length > 0
-            ? `\n\nBaseline evidence:\n${row.baseline}`
-            : "";
-        const evidence = `${row.hypothesis}${baselineEvidence}`;
-        return {
-            form: "harness_check",
-            experimentId,
-            proposalId: `proposal:${recordKeyPart(row.id, "proposal") ?? row.dedupe_sig}`,
-            shortId,
-            title: row.title,
-            targetPath: `tests/harness/${row.dedupe_sig}.md`,
-            section: null,
-            suggestedBody: evidence,
-            proposedBehavior: evidence,
-            confidence: row.confidence ?? "medium",
-            frequency: row.frequency ?? 0,
-            evidence,
-        };
-    }
-    // skill form
-    return {
+interface TaskBuildContext {
+    readonly shortId: string;
+    readonly proposalId: string;
+}
+
+type TaskInputBuilder = (
+    row: FullProposalRow,
+    experimentId: string,
+    ctx: TaskBuildContext,
+) => TaskInput;
+
+const taskInputBuilders = {
+    guidance: (row, experimentId, { shortId, proposalId }) => ({
+        form: "guidance",
+        experimentId,
+        proposalId,
+        shortId,
+        title: row.title,
+        targetPath: row.guidance_payload?.file_target ?? "~/.claude/CLAUDE.md",
+        section: row.guidance_payload?.section ?? null,
+        suggestedBody: row.guidance_payload?.suggested_text ?? row.hypothesis,
+        proposedBehavior: null,
+        confidence: row.confidence ?? "medium",
+        frequency: row.frequency ?? 0,
+        evidence: row.hypothesis,
+    }),
+    skill: (row, experimentId, { shortId, proposalId }) => ({
         form: "skill",
         experimentId,
         proposalId,
@@ -274,7 +204,87 @@ const buildTaskInput = (row: FullProposalRow, experimentId: string): TaskInput =
         confidence: row.confidence ?? "medium",
         frequency: row.frequency ?? 0,
         evidence: row.hypothesis,
-    };
+    }),
+    harness_check: (row, experimentId, { shortId, proposalId }) => {
+        const baselineEvidence = typeof row.baseline === "string" && row.baseline.trim().length > 0
+            ? `\n\nBaseline evidence:\n${row.baseline}`
+            : "";
+        const evidence = `${row.hypothesis}${baselineEvidence}`;
+        return {
+            form: "harness_check",
+            experimentId,
+            proposalId,
+            shortId,
+            title: row.title,
+            targetPath: `tests/harness/${row.dedupe_sig}.md`,
+            section: null,
+            suggestedBody: evidence,
+            proposedBehavior: evidence,
+            confidence: row.confidence ?? "medium",
+            frequency: row.frequency ?? 0,
+            evidence,
+        };
+    },
+    subagent: (row, experimentId, { shortId, proposalId }) => ({
+        form: "subagent",
+        experimentId,
+        proposalId,
+        shortId,
+        title: row.title,
+        targetPath: `~/.claude/agents/${row.dedupe_sig}.md`,
+        section: null,
+        suggestedBody: [
+            row.subagent_payload?.bounded_role ? `Role: ${row.subagent_payload.bounded_role}` : null,
+            row.subagent_payload?.delegation_trigger ? `Delegation trigger: ${row.subagent_payload.delegation_trigger}` : null,
+            row.hypothesis,
+        ].filter((line): line is string => line !== null).join("\n\n"),
+        proposedBehavior: null,
+        confidence: "medium",
+        frequency: 0,
+        evidence: row.hypothesis,
+    }),
+    hook: (row, experimentId, { shortId, proposalId }) => ({
+        form: "hook",
+        experimentId,
+        proposalId,
+        shortId,
+        title: row.title,
+        targetPath: "~/.claude/settings.json",
+        section: row.hook_payload?.event_name ?? "PreToolUse",
+        suggestedBody: row.hook_payload?.hook_command ?? `see proposal: ${row.dedupe_sig}`,
+        proposedBehavior: row.hook_payload?.target_tool ?? null,
+        confidence: "medium",
+        frequency: 0,
+        evidence: row.hypothesis,
+        safety: safetyContractFromPayload(row.hook_payload),
+    }),
+    automation: (row, experimentId, { shortId, proposalId }) => ({
+        form: "automation",
+        experimentId,
+        proposalId,
+        shortId,
+        title: row.title,
+        targetPath: `.ax/interventions/${row.dedupe_sig}/AUTOMATION.md`,
+        section: row.automation_payload?.schedule ?? null,
+        suggestedBody: row.automation_payload?.action ?? `see proposal: ${row.dedupe_sig}`,
+        proposedBehavior: row.automation_payload?.trigger_signal ?? null,
+        confidence: "medium",
+        frequency: 0,
+        evidence: row.hypothesis,
+        safety: safetyContractFromPayload(row.automation_payload),
+    }),
+} satisfies Record<InterventionForm, TaskInputBuilder>;
+
+/**
+ * Map a full proposal row + experimentId to a TaskInput for renderTaskFile.
+ */
+const buildTaskInput = (row: FullProposalRow, experimentId: string): TaskInput => {
+    const shortId = row.dedupe_sig;
+    const proposalId = `proposal:${recordKeyPart(row.id, "proposal") ?? row.dedupe_sig}`;
+    if (!isInterventionForm(row.form)) {
+        throw new Error(`unsupported proposal form: ${row.form}`);
+    }
+    return taskInputBuilders[row.form](row, experimentId, { shortId, proposalId });
 };
 
 const safetyContractFromPayload = (
@@ -290,6 +300,13 @@ const safetyContractFromPayload = (
     disableCommand: payload?.disable_command ?? null,
     failureMode: payload?.failure_mode ?? null,
 });
+
+const safetyContractForRow = (row: FullProposalRow): InterventionSafetyContract | null => {
+    const payloadKey = interventionFormSpec(row.form)?.safetyPayloadKey;
+    if (payloadKey === "hook_payload") return safetyContractFromPayload(row.hook_payload);
+    if (payloadKey === "automation_payload") return safetyContractFromPayload(row.automation_payload);
+    return null;
+};
 
 export interface AcceptOptions {
     readonly sigOrId: string;
@@ -335,11 +352,7 @@ export const acceptProposal = (
             form: row.form,
             proposalStatus: row.status,
             autoScaffold: Boolean(opts.autoScaffold),
-            safetyContract: row.form === "hook"
-                ? safetyContractFromPayload(row.hook_payload)
-                : row.form === "automation"
-                    ? safetyContractFromPayload(row.automation_payload)
-                    : null,
+            safetyContract: safetyContractForRow(row),
         });
         if (acceptPlan.status === "wrong_status") {
             const db = yield* SurrealClient;

--- a/apps/axctl/src/improve/impact.test.ts
+++ b/apps/axctl/src/improve/impact.test.ts
@@ -1,12 +1,12 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import type { ProposalDto } from "@ax/lib/shared/dashboard-types";
 import {
+    createImpactEstimateCache,
     estimateImpact,
     estimateImpactCached,
     parseBaseline,
-    resetImpactCacheForTest,
     ROUTING_PROPOSAL_TITLE,
 } from "./impact.ts";
 
@@ -40,8 +40,6 @@ const makeDb = (resultsPerCall: QueryResult[][]) => {
 
 const run = <A>(eff: Effect.Effect<A, unknown, SurrealClient>, layer: Layer.Layer<SurrealClient>) =>
     Effect.runPromise(eff.pipe(Effect.provide(layer)));
-
-afterEach(() => resetImpactCacheForTest());
 
 describe("parseBaseline", () => {
     test("tolerates missing/corrupt baseline", () => {
@@ -127,16 +125,27 @@ describe("estimateImpactCached", () => {
     test("second call within TTL skips recompute", async () => {
         const p = proposal({ form: "guidance", baseline: '{"frequency":3}' });
         const layer = makeDb([[[]]]);
-        const a = await run(estimateImpactCached(p, 1_000), layer);
-        const b = await run(estimateImpactCached(p, 2_000), layer);
+        const cache = createImpactEstimateCache();
+        const a = await run(estimateImpactCached(p, 1_000, cache), layer);
+        const b = await run(estimateImpactCached(p, 2_000, cache), layer);
         expect(b).toBe(a);
     });
 
     test("expired entry recomputes", async () => {
         const p = proposal({ form: "guidance", baseline: '{"frequency":3}' });
         const layer = makeDb([[[]]]);
-        const a = await run(estimateImpactCached(p, 1_000), layer);
-        const b = await run(estimateImpactCached(p, 1_000 + 11 * 60_000), layer);
+        const cache = createImpactEstimateCache();
+        const a = await run(estimateImpactCached(p, 1_000, cache), layer);
+        const b = await run(estimateImpactCached(p, 1_000 + 11 * 60_000, cache), layer);
+        expect(b).not.toBe(a);
+        expect(b).toEqual(a);
+    });
+
+    test("independent cache adapters isolate same-sig estimates", async () => {
+        const p = proposal({ form: "guidance", baseline: '{"frequency":3}' });
+        const layer = makeDb([[[]]]);
+        const a = await run(estimateImpactCached(p, 1_000, createImpactEstimateCache()), layer);
+        const b = await run(estimateImpactCached(p, 2_000, createImpactEstimateCache()), layer);
         expect(b).not.toBe(a);
         expect(b).toEqual(a);
     });

--- a/apps/axctl/src/improve/impact.ts
+++ b/apps/axctl/src/improve/impact.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { ImpactEstimate, ProposalDto } from "@ax/lib/shared/dashboard-types";
 import { fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
+import { interventionFormSpec } from "./intervention-forms.ts";
 
 /**
  * Projected impact per proposal - the "what is this worth" engine
@@ -123,9 +124,14 @@ export const estimateImpact = Effect.fn("improve.estimateImpact")(function* (
         return yield* hookImpact(p.hook_payload.target_tool);
     }
     const baseline = parseBaseline(p);
-    if (p.form === "guidance") return guidanceImpact(p, baseline);
-    if (p.form === "skill") return skillImpact(p, baseline);
-    return fallbackImpact(p);
+    switch (interventionFormSpec(String(p.form))?.impactModel ?? "fallback") {
+        case "guidance":
+            return guidanceImpact(p, baseline);
+        case "skill":
+            return skillImpact(p, baseline);
+        case "fallback":
+            return fallbackImpact(p);
+    }
 });
 
 // ---------------------------------------------------------------------------
@@ -133,18 +139,40 @@ export const estimateImpact = Effect.fn("improve.estimateImpact")(function* (
 // ---------------------------------------------------------------------------
 
 const IMPACT_TTL_MS = 10 * 60_000;
-const cache = new Map<string, { estimate: ImpactEstimate; at: number }>();
+
+export interface ImpactEstimateCache {
+    readonly get: (dedupeSig: string, nowMs: number) => ImpactEstimate | null;
+    readonly set: (dedupeSig: string, estimate: ImpactEstimate, nowMs: number) => void;
+}
+
+export const createImpactEstimateCache = (
+    opts: { readonly ttlMs?: number } = {},
+): ImpactEstimateCache => {
+    const ttlMs = opts.ttlMs ?? IMPACT_TTL_MS;
+    const cache = new Map<string, { estimate: ImpactEstimate; at: number }>();
+    return {
+        get: (dedupeSig, nowMs) => {
+            const hit = cache.get(dedupeSig);
+            return hit && nowMs - hit.at < ttlMs ? hit.estimate : null;
+        },
+        set: (dedupeSig, estimate, nowMs) => {
+            cache.set(dedupeSig, { estimate, at: nowMs });
+        },
+    };
+};
+
+const defaultImpactEstimateCache = createImpactEstimateCache();
 
 export const estimateImpactCached = Effect.fn("improve.estimateImpactCached")(
-    function* (p: ProposalDto, nowMs: number) {
-        const hit = cache.get(p.dedupe_sig);
-        if (hit && nowMs - hit.at < IMPACT_TTL_MS) return hit.estimate;
+    function* (
+        p: ProposalDto,
+        nowMs: number,
+        cache: ImpactEstimateCache = defaultImpactEstimateCache,
+    ) {
+        const hit = cache.get(p.dedupe_sig, nowMs);
+        if (hit !== null) return hit;
         const estimate = yield* estimateImpact(p);
-        cache.set(p.dedupe_sig, { estimate, at: nowMs });
+        cache.set(p.dedupe_sig, estimate, nowMs);
         return estimate;
     },
 );
-
-export function resetImpactCacheForTest(): void {
-    cache.clear();
-}

--- a/apps/axctl/src/improve/intervention-forms.test.ts
+++ b/apps/axctl/src/improve/intervention-forms.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+    INTERVENTION_FORM_REGISTRY,
+    INTERVENTION_FORMS,
+    interventionFormSpec,
+    isInterventionForm,
+} from "./intervention-forms.ts";
+import { TASK_FORM_RENDERERS } from "./task-template.ts";
+
+describe("intervention form registry", () => {
+    test("enumerates every acceptable intervention form exactly once", () => {
+        expect(INTERVENTION_FORMS).toEqual([
+            "guidance",
+            "skill",
+            "harness_check",
+            "subagent",
+            "hook",
+            "automation",
+        ]);
+        expect(Object.keys(INTERVENTION_FORM_REGISTRY)).toEqual([...INTERVENTION_FORMS]);
+    });
+
+    test("carries safety, marker, and impact dispatch metadata", () => {
+        expect(interventionFormSpec("hook")).toMatchObject({
+            requiresSafetyContract: true,
+            markerStrategy: "hook_command",
+            safetyPayloadKey: "hook_payload",
+            nextActionImpactChip: "routing_savings",
+            nextActionFixKind: "new hook",
+        });
+        expect(interventionFormSpec("automation")).toMatchObject({
+            requiresSafetyContract: true,
+            markerStrategy: "automation",
+            safetyPayloadKey: "automation_payload",
+            nextActionImpactChip: "none",
+            nextActionFixKind: "automation",
+        });
+        expect(interventionFormSpec("guidance")).toMatchObject({
+            requiresSafetyContract: false,
+            markerStrategy: "inline",
+            impactModel: "guidance",
+            nextActionImpactChip: "frequency",
+            nextActionFixKind: "edit_guidance",
+        });
+        expect(interventionFormSpec("skill")).toMatchObject({
+            markerStrategy: "frontmatter",
+            impactModel: "skill",
+            nextActionImpactChip: "frequency",
+            nextActionFixKind: "new skill",
+        });
+    });
+
+    test("task rendering is keyed by the registry, not a separate switch list", () => {
+        expect(Object.keys(TASK_FORM_RENDERERS)).toEqual([...INTERVENTION_FORMS]);
+        for (const form of INTERVENTION_FORMS) {
+            expect(TASK_FORM_RENDERERS[form]).toBeTypeOf("function");
+        }
+    });
+
+    test("narrows unknown form strings", () => {
+        expect(isInterventionForm("hook")).toBe(true);
+        expect(isInterventionForm("wish")).toBe(false);
+    });
+});

--- a/apps/axctl/src/improve/intervention-forms.ts
+++ b/apps/axctl/src/improve/intervention-forms.ts
@@ -1,0 +1,114 @@
+/**
+ * Closed set of Acceptable Intervention Forms. The registry carries only
+ * cross-cutting dispatch metadata; each caller still owns its local behavior.
+ */
+
+export const INTERVENTION_FORMS = [
+    "guidance",
+    "skill",
+    "harness_check",
+    "subagent",
+    "hook",
+    "automation",
+] as const;
+
+export type InterventionForm = (typeof INTERVENTION_FORMS)[number];
+
+export type InterventionMarkerStrategy =
+    | "inline"
+    | "frontmatter"
+    | "hook_command"
+    | "automation";
+
+export type InterventionImpactModel = "guidance" | "skill" | "fallback";
+
+export type InterventionSafetyPayloadKey = "hook_payload" | "automation_payload";
+
+export type InterventionNextActionImpactChip = "frequency" | "routing_savings" | "none";
+export type InterventionNextActionFixKind =
+    | "edit_guidance"
+    | "new skill"
+    | "new subagent"
+    | "new hook"
+    | "automation"
+    | "harness check";
+
+export interface InterventionFormSpec {
+    readonly form: InterventionForm;
+    readonly markerStrategy: InterventionMarkerStrategy;
+    readonly requiresSafetyContract: boolean;
+    readonly safetyPayloadKey: InterventionSafetyPayloadKey | null;
+    readonly impactModel: InterventionImpactModel;
+    readonly nextActionImpactChip: InterventionNextActionImpactChip;
+    readonly nextActionFixKind: InterventionNextActionFixKind;
+    readonly acceptsManualTask: true;
+}
+
+export const INTERVENTION_FORM_REGISTRY = {
+    guidance: {
+        form: "guidance",
+        markerStrategy: "inline",
+        requiresSafetyContract: false,
+        safetyPayloadKey: null,
+        impactModel: "guidance",
+        nextActionImpactChip: "frequency",
+        nextActionFixKind: "edit_guidance",
+        acceptsManualTask: true,
+    },
+    skill: {
+        form: "skill",
+        markerStrategy: "frontmatter",
+        requiresSafetyContract: false,
+        safetyPayloadKey: null,
+        impactModel: "skill",
+        nextActionImpactChip: "frequency",
+        nextActionFixKind: "new skill",
+        acceptsManualTask: true,
+    },
+    harness_check: {
+        form: "harness_check",
+        markerStrategy: "frontmatter",
+        requiresSafetyContract: false,
+        safetyPayloadKey: null,
+        impactModel: "fallback",
+        nextActionImpactChip: "none",
+        nextActionFixKind: "harness check",
+        acceptsManualTask: true,
+    },
+    subagent: {
+        form: "subagent",
+        markerStrategy: "frontmatter",
+        requiresSafetyContract: false,
+        safetyPayloadKey: null,
+        impactModel: "fallback",
+        nextActionImpactChip: "none",
+        nextActionFixKind: "new subagent",
+        acceptsManualTask: true,
+    },
+    hook: {
+        form: "hook",
+        markerStrategy: "hook_command",
+        requiresSafetyContract: true,
+        safetyPayloadKey: "hook_payload",
+        impactModel: "fallback",
+        nextActionImpactChip: "routing_savings",
+        nextActionFixKind: "new hook",
+        acceptsManualTask: true,
+    },
+    automation: {
+        form: "automation",
+        markerStrategy: "automation",
+        requiresSafetyContract: true,
+        safetyPayloadKey: "automation_payload",
+        impactModel: "fallback",
+        nextActionImpactChip: "none",
+        nextActionFixKind: "automation",
+        acceptsManualTask: true,
+    },
+} satisfies Record<InterventionForm, InterventionFormSpec>;
+
+export const isInterventionForm = (form: string): form is InterventionForm =>
+    Object.prototype.hasOwnProperty.call(INTERVENTION_FORM_REGISTRY, form);
+
+export const interventionFormSpec = (form: string): InterventionFormSpec | null =>
+    isInterventionForm(form) ? INTERVENTION_FORM_REGISTRY[form] : null;

--- a/apps/axctl/src/improve/lifecycle.ts
+++ b/apps/axctl/src/improve/lifecycle.ts
@@ -3,6 +3,7 @@
  * intervention lifecycle. Keep this module pure: callers own persistence,
  * rendering, and filesystem effects.
  */
+import { INTERVENTION_FORMS, interventionFormSpec } from "./intervention-forms.ts";
 
 export const PROPOSAL_STATUS_OPEN = "open";
 export const PROPOSAL_STATUS_ACCEPTED = "accepted";
@@ -12,7 +13,7 @@ export const GUIDANCE_STATUS_PROPOSED = "proposed";
 
 export const ACCEPTED_PROPOSAL_FORMS = ["guidance", "skill", "harness_check"] as const;
 export type AcceptedProposalForm = (typeof ACCEPTED_PROPOSAL_FORMS)[number];
-export const MANUAL_TASK_PROPOSAL_FORMS = ["guidance", "skill", "harness_check", "subagent", "hook", "automation"] as const;
+export const MANUAL_TASK_PROPOSAL_FORMS = INTERVENTION_FORMS;
 
 export const EXPERIMENT_STATUS_TASK_EMITTED = "task_emitted";
 export const EXPERIMENT_STATUS_SCAFFOLDED = "scaffolded";
@@ -89,7 +90,8 @@ export function isAcceptedProposalForm(form: string): form is AcceptedProposalFo
 }
 
 export function acceptanceFormError(form: string): string {
-    return `accept supports form=guidance, form=skill, form=harness_check, form=subagent, form=hook, and form=automation (got ${form})`;
+    const labels = INTERVENTION_FORMS.map((f) => `form=${f}`);
+    return `accept supports ${labels.slice(0, -1).join(", ")}, and ${labels.at(-1)} (got ${form})`;
 }
 
 export function acceptedExperimentStatus(input: {
@@ -123,13 +125,14 @@ export function planAcceptCandidate(input: {
             message: `proposal already ${input.proposalStatus}`,
         };
     }
-    if (!(MANUAL_TASK_PROPOSAL_FORMS as readonly string[]).includes(input.form)) {
+    const spec = interventionFormSpec(input.form);
+    if (spec === null) {
         return {
             status: "unsupported_form",
             message: acceptanceFormError(input.form),
         };
     }
-    if (input.form === "hook" || input.form === "automation") {
+    if (spec.requiresSafetyContract) {
         const missing = missingInterventionSafetyGates(input.safetyContract);
         if (missing.length > 0) {
             return {

--- a/apps/axctl/src/improve/lint.ts
+++ b/apps/axctl/src/improve/lint.ts
@@ -32,8 +32,9 @@ import {
     EXPERIMENT_STATUS_TASK_EMITTED,
     planTaskScaffolded,
 } from "./lifecycle.ts";
+import { interventionFormSpec, type InterventionForm } from "./intervention-forms.ts";
 
-export type LintForm = "guidance" | "skill" | "subagent" | "hook" | "automation" | "harness_check";
+export type LintForm = InterventionForm;
 
 export interface LintTarget {
     readonly path: string;
@@ -272,77 +273,82 @@ const collectIds = (
         return found;
     }
     const content = contentOpt.value;
-    if (target.form === "guidance") {
-        // Parse fault → a marker_parse_error finding (entries set before the
-        // throw are kept, matching the old try/catch).
-        yield* Effect.try({
-            try: () => {
-                // Inline markers (guidance files) carry no explicit experiment id.
-                for (const m of parseInlineMarkers(content)) found.set(m.id, { path: target.path });
-            },
-            catch: (err) => (err as Error).message,
-        }).pipe(
-            Effect.catch((message) =>
-                Effect.sync(() => {
-                    errors.push({
-                        rule: "marker_parse_error",
-                        severity: "error",
-                        path: target.path,
-                        message,
-                    });
-                }),
-            ),
-        );
-    } else if (target.form === "hook") {
-        yield* Effect.try({
-            try: () => {
-                const parsed = decodeJsonOrNull(content);
-                if (parsed === null) throw new Error("invalid JSON in hook config");
-                const commands: string[] = [];
-                collectJsonCommandStrings(parsed, commands);
-                for (const command of commands) {
-                    for (const marker of parseHookCommandMarkers(command)) {
-                        found.set(
-                            marker.id,
-                            marker.experiment === undefined
-                                ? { path: target.path }
-                                : { path: target.path, experiment: marker.experiment },
-                        );
+    const strategy = interventionFormSpec(target.form)?.markerStrategy ?? "frontmatter";
+    switch (strategy) {
+        case "inline":
+            // Parse fault → a marker_parse_error finding (entries set before the
+            // throw are kept, matching the old try/catch).
+            yield* Effect.try({
+                try: () => {
+                    // Inline markers (guidance files) carry no explicit experiment id.
+                    for (const m of parseInlineMarkers(content)) found.set(m.id, { path: target.path });
+                },
+                catch: (err) => (err as Error).message,
+            }).pipe(
+                Effect.catch((message) =>
+                    Effect.sync(() => {
+                        errors.push({
+                            rule: "marker_parse_error",
+                            severity: "error",
+                            path: target.path,
+                            message,
+                        });
+                    }),
+                ),
+            );
+            break;
+        case "hook_command":
+            yield* Effect.try({
+                try: () => {
+                    const parsed = decodeJsonOrNull(content);
+                    if (parsed === null) throw new Error("invalid JSON in hook config");
+                    const commands: string[] = [];
+                    collectJsonCommandStrings(parsed, commands);
+                    for (const command of commands) {
+                        for (const marker of parseHookCommandMarkers(command)) {
+                            found.set(
+                                marker.id,
+                                marker.experiment === undefined
+                                    ? { path: target.path }
+                                    : { path: target.path, experiment: marker.experiment },
+                            );
+                        }
                     }
-                }
-            },
-            catch: (err) => (err instanceof Error ? err.message : String(err)),
-        }).pipe(
-            Effect.catch((message) =>
-                Effect.sync(() => {
-                    errors.push({
-                        rule: "marker_parse_error",
-                        severity: "error",
-                        path: target.path,
-                        message,
-                    });
-                }),
-            ),
-        );
-    } else if (target.form === "automation") {
-        for (const marker of parseAutomationMarkers(content)) {
-            found.set(
-                marker.id,
-                marker.experiment === undefined
-                    ? { path: target.path }
-                    : { path: target.path, experiment: marker.experiment },
+                },
+                catch: (err) => (err instanceof Error ? err.message : String(err)),
+            }).pipe(
+                Effect.catch((message) =>
+                    Effect.sync(() => {
+                        errors.push({
+                            rule: "marker_parse_error",
+                            severity: "error",
+                            path: target.path,
+                            message,
+                        });
+                    }),
+                ),
             );
-        }
-    } else {
-        // Skill and subagent files use frontmatter; may carry ax_experiment.
-        const fm = parseFrontmatterMarker(content);
-        if (fm) {
-            found.set(
-                fm.id,
-                fm.experiment === undefined
-                    ? { path: target.path }
-                    : { path: target.path, experiment: fm.experiment },
-            );
+            break;
+        case "automation":
+            for (const marker of parseAutomationMarkers(content)) {
+                found.set(
+                    marker.id,
+                    marker.experiment === undefined
+                        ? { path: target.path }
+                        : { path: target.path, experiment: marker.experiment },
+                );
+            }
+            break;
+        case "frontmatter": {
+            const fm = parseFrontmatterMarker(content);
+            if (fm) {
+                found.set(
+                    fm.id,
+                    fm.experiment === undefined
+                        ? { path: target.path }
+                        : { path: target.path, experiment: fm.experiment },
+                );
+            }
         }
     }
     return found;

--- a/apps/axctl/src/improve/show.ts
+++ b/apps/axctl/src/improve/show.ts
@@ -13,6 +13,7 @@ import {
     interventionSafetyMessage,
     missingInterventionSafetyGates,
 } from "./lifecycle.ts";
+import { interventionFormSpec } from "./intervention-forms.ts";
 
 export interface ShowInput { readonly sigOrId: string; }
 
@@ -78,11 +79,12 @@ export const showExperiment = (
             FROM proposal WHERE dedupe_sig = ${idLit} OR id = ${idLit} LIMIT 1;`);
         const prow = (pRows?.[0] ?? [])[0];
         if (!prow) return null;
-        const rawSafety = prow.form === "hook"
+        const safetyPayloadKey = interventionFormSpec(prow.form)?.safetyPayloadKey;
+        const rawSafety = safetyPayloadKey === "hook_payload"
             ? prow.hook_payload
-            : prow.form === "automation"
-                ? prow.automation_payload
-                : null;
+            : safetyPayloadKey === "automation_payload"
+              ? prow.automation_payload
+              : null;
         const proposal: ShowProposal = {
             shortId: prow.dedupe_sig, title: prow.title, form: prow.form,
             hypothesis: prow.hypothesis, status: prow.status,

--- a/apps/axctl/src/improve/task-template.ts
+++ b/apps/axctl/src/improve/task-template.ts
@@ -5,8 +5,9 @@
  */
 
 import type { InterventionSafetyContract } from "./lifecycle.ts";
+import type { InterventionForm } from "./intervention-forms.ts";
 
-export type TaskForm = "guidance" | "skill" | "harness_check" | "subagent" | "hook" | "automation";
+export type TaskForm = InterventionForm;
 
 export interface TaskInput {
     readonly form: TaskForm;
@@ -280,19 +281,14 @@ ${i.suggestedBody}
 - evidence-cmd: \`axctl improve show ${i.shortId}\`
 `;
 
-export const renderTaskFile = (input: TaskInput): string => {
-    switch (input.form) {
-        case "guidance":
-            return guidance(input);
-        case "skill":
-            return skill(input);
-        case "harness_check":
-            return harnessCheck(input);
-        case "subagent":
-            return subagent(input);
-        case "hook":
-            return hook(input);
-        case "automation":
-            return automation(input);
-    }
-};
+export const TASK_FORM_RENDERERS = {
+    guidance,
+    skill,
+    harness_check: harnessCheck,
+    subagent,
+    hook,
+    automation,
+} satisfies Record<TaskForm, (input: TaskInput) => string>;
+
+export const renderTaskFile = (input: TaskInput): string =>
+    TASK_FORM_RENDERERS[input.form](input);

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -698,8 +698,12 @@ const dojoAgendaTool: AxMcpTool = defineMcpTool({
                     { budgetPctOverride: null, untilIso: null, force: false },
                     nowMs,
                 );
-                const items = yield* collectAgendaItems({ nowMs, days, spar });
-                return assembleAgenda(envelope, items, { nowMs, spar });
+                const collected = yield* collectAgendaItems({ nowMs, days, spar });
+                return assembleAgenda(envelope, collected.items, {
+                    nowMs,
+                    spar,
+                    sourceFailures: collected.source_failures,
+                });
             }).pipe(Effect.provide(QuotaEnvLive)),
         );
     },

--- a/apps/axctl/src/metrics/fragility-cascade.ts
+++ b/apps/axctl/src/metrics/fragility-cascade.ts
@@ -1,7 +1,7 @@
 import { Array as Arr, Effect } from "effect";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
-import { bareSession, sessionTelemetryCost } from "../queries/telemetry-rollup.ts";
+import { enrichRowsWithTelemetryCost } from "../queries/telemetry-rollup.ts";
 import { recordKeyPart } from "@ax/lib/shared/derive-keys";
 import { localPathFileRecordKey, recordLiteral, stableDigest } from "@ax/lib/ids";
 import { selectByIds } from "@ax/lib/shared/record-select";
@@ -416,12 +416,9 @@ export const readFragilityCascade = (): Effect.Effect<CascadeEdge[], DbError, Su
                 partialEdges.push({ origin, downstream, weight, downstream_cost_usd: null, downstream_tokens: null });
             }
         }
-        // ONE batched OTLP cost lookup over deduped downstream ids.
-        const ids = [...new Set(partialEdges.map((e) => e.downstream))];
-        const cost = yield* sessionTelemetryCost(ids);
-        return partialEdges.map((e) => ({
+        return yield* enrichRowsWithTelemetryCost(partialEdges, (e) => e.downstream, (e, cost) => ({
             ...e,
-            downstream_cost_usd: cost.get(bareSession(e.downstream))?.cost_usd ?? null,
-            downstream_tokens: cost.get(bareSession(e.downstream))?.tokens ?? null,
+            downstream_cost_usd: cost?.cost_usd ?? null,
+            downstream_tokens: cost?.tokens ?? null,
         }));
     });

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { sessionTelemetryCost } from "../queries/telemetry-rollup.ts";
+import { enrichRowsWithTelemetryCost } from "../queries/telemetry-rollup.ts";
 import { recordLiteral } from "@ax/lib/ids";
 import { recordKeyPart } from "@ax/lib/shared/derive-keys";
 import { SurrealClient } from "@ax/lib/db";
@@ -310,14 +310,15 @@ ${where};`))?.[0] ?? [];
             landedCommits: landed.commits,
         });
 
-        if (summary.hotSessions.length === 0) return summary;
-        const ids = summary.hotSessions.map((r) => r.session);
-        const cost = yield* sessionTelemetryCost(ids);
-        const hotSessions = summary.hotSessions.map((r) => ({
-            ...r,
-            otlp_cost_usd: cost.get(r.session)?.cost_usd ?? null,
-            otlp_tokens: cost.get(r.session)?.tokens ?? null,
-        }));
+        const hotSessions = yield* enrichRowsWithTelemetryCost(
+            summary.hotSessions,
+            (r) => r.session,
+            (r, cost) => ({
+                ...r,
+                otlp_cost_usd: cost?.cost_usd ?? null,
+                otlp_tokens: cost?.tokens ?? null,
+            }),
+        );
         return { ...summary, hotSessions };
     });
 

--- a/apps/axctl/src/queries/insights-enrich.ts
+++ b/apps/axctl/src/queries/insights-enrich.ts
@@ -22,7 +22,7 @@ import type { DbError } from "@ax/lib/errors";
 import { recordIdString } from "@ax/lib/shared/row-fields";
 import { surrealDate } from "@ax/lib/shared/surql";
 import type { InsightView } from "./insights.ts";
-import { bareSession, sessionTelemetryCost } from "./telemetry-rollup.ts";
+import { bareSession, enrichRowsWithTelemetryCost } from "./telemetry-rollup.ts";
 
 /** Per-row fan-out width for the context lookups. */
 const ENRICH_FANOUT = 8;
@@ -174,21 +174,13 @@ const fetchFrictionContentTypes = (
 export const enrichInsightRows = Effect.fn("queries.enrichInsightRows")(
     function* (view: InsightView, rows: ReadonlyArray<Row>) {
         if (view === "friction") {
-            const ids = rows.map(frictionSessionId);
-            const [cost, contentTypes] = yield* Effect.all(
-                [sessionTelemetryCost(ids), fetchFrictionContentTypes(ids)],
-                { concurrency: 2 },
-            );
-            return rows.map((row): Row => {
-                const sid = frictionSessionId(row);
-                const c = cost.get(sid);
-                return {
-                    ...row,
-                    otlp_cost_usd: c?.cost_usd ?? null,
-                    otlp_tokens: c?.tokens ?? null,
-                    contentType: contentTypes.get(sid) ?? null,
-                };
-            });
+            const contentTypes = yield* fetchFrictionContentTypes(rows.map(frictionSessionId));
+            const withCost = yield* enrichRowsWithTelemetryCost(rows, frictionSessionId, (row, cost): Row => ({
+                ...row,
+                otlp_cost_usd: cost?.cost_usd ?? null,
+                otlp_tokens: cost?.tokens ?? null,
+            }));
+            return foldContentTypeOntoFriction(withCost, contentTypes);
         }
         if (!ENRICHED_VIEWS.has(view)) return rows;
         return yield* Effect.forEach(rows, (row) => enrichRow(view, row), { concurrency: ENRICH_FANOUT });

--- a/apps/axctl/src/queries/telemetry-rollup.test.ts
+++ b/apps/axctl/src/queries/telemetry-rollup.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
 import { SurrealClient } from "@ax/lib/db";
-import { sessionTelemetryCost, sessionTelemetryLatency } from "./telemetry-rollup.ts";
+import {
+    enrichRowsWithTelemetryCost,
+    enrichRowsWithTelemetryLatency,
+    sessionTelemetryCost,
+    sessionTelemetryLatency,
+} from "./telemetry-rollup.ts";
 
 const db = (rows: { metric?: unknown[]; log?: unknown[] }) =>
     Layer.succeed(SurrealClient, {
@@ -45,5 +50,49 @@ describe("sessionTelemetryLatency", () => {
         const layer = db({ log: [{ session_id: "c1", d: 693, n: 1 }] });
         const m = await run(sessionTelemetryLatency(["c1"]), layer);
         expect(m.get("c1")?.duration_ms).toBe(693);
+    });
+});
+
+describe("telemetry row enrichment", () => {
+    test("cost enrichment normalizes session record ids and merges absent telemetry as null", async () => {
+        const layer = db({
+            metric: [
+                { session_id: "s1", metric: "claude_code.cost.usage", total: 0.75 },
+                { session_id: "s1", metric: "claude_code.token.usage", total: 300 },
+            ],
+        });
+        const rows = [
+            { id: "a", session: "session:s1" },
+            { id: "b", session: "session:missing" },
+        ] as const;
+        const enriched = await run(
+            enrichRowsWithTelemetryCost(
+                rows,
+                (row) => row.session,
+                (row, cost) => ({
+                    ...row,
+                    otlp_cost_usd: cost?.cost_usd ?? null,
+                    otlp_tokens: cost?.tokens ?? null,
+                }),
+            ),
+            layer,
+        );
+        expect(enriched).toEqual([
+            { id: "a", session: "session:s1", otlp_cost_usd: 0.75, otlp_tokens: 300 },
+            { id: "b", session: "session:missing", otlp_cost_usd: null, otlp_tokens: null },
+        ]);
+    });
+
+    test("latency enrichment hides lookup and normalization details", async () => {
+        const layer = db({ log: [{ session_id: "c1", d: 42, n: 2 }] });
+        const enriched = await run(
+            enrichRowsWithTelemetryLatency(
+                [{ session_id: "session:c1" }],
+                (row) => row.session_id,
+                (row, latency) => ({ ...row, recovery_ms: latency?.duration_ms ?? null }),
+            ),
+            layer,
+        );
+        expect(enriched).toEqual([{ session_id: "session:c1", recovery_ms: 42 }]);
     });
 });

--- a/apps/axctl/src/queries/telemetry-rollup.ts
+++ b/apps/axctl/src/queries/telemetry-rollup.ts
@@ -60,3 +60,31 @@ export const sessionTelemetryLatency = (sessionIds: readonly string[]): Effect.E
         }
         return out;
     });
+
+const uniqueBareSessions = <Row>(
+    rows: ReadonlyArray<Row>,
+    sessionOf: (row: Row) => unknown,
+): readonly string[] =>
+    [...new Set(rows.map((row) => bareSession(sessionOf(row))).filter((id) => id.length > 0))];
+
+export const enrichRowsWithTelemetryCost = <Row, Out>(
+    rows: ReadonlyArray<Row>,
+    sessionOf: (row: Row) => unknown,
+    merge: (row: Row, telemetry: TelemetryCost | null) => Out,
+): Effect.Effect<Out[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        if (rows.length === 0) return [];
+        const telemetry = yield* sessionTelemetryCost(uniqueBareSessions(rows, sessionOf));
+        return rows.map((row) => merge(row, telemetry.get(bareSession(sessionOf(row))) ?? null));
+    });
+
+export const enrichRowsWithTelemetryLatency = <Row, Out>(
+    rows: ReadonlyArray<Row>,
+    sessionOf: (row: Row) => unknown,
+    merge: (row: Row, telemetry: TelemetryLatency | null) => Out,
+): Effect.Effect<Out[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        if (rows.length === 0) return [];
+        const telemetry = yield* sessionTelemetryLatency(uniqueBareSessions(rows, sessionOf));
+        return rows.map((row) => merge(row, telemetry.get(bareSession(sessionOf(row))) ?? null));
+    });


### PR DESCRIPTION
Recovered + rebased work that had been sitting **unmerged on local `main`** (commit `f125da58`, no branch, never PR'd) — preserved so it isn't lost, rebased clean onto current main (one small `skills-weighted.ts` import conflict resolved: codex's `enrichRowsWithTelemetryLatency` refactor + main's `fetchSkillHygiene` addition both kept, the superseded `sessionTelemetryLatency`/`bareSession` imports dropped).

## What it is

A codex (`codex/arch-deepening-rest`) refactor deepening the **improve** and **dojo** seams — 26 files, +754/−303, including a new `apps/axctl/src/improve/intervention-forms.ts` module + tests, plus improve-proposals / next-actions / dojo / telemetry-rollup changes.

⚠️ **I did not author this** — it's recovered work. Review accordingly; the design intent is codex's.

## Gates
`bun test` **4793 pass / 0 fail**; `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)