### PR TITLE
fix(studio-desktop): silence tsdown inline warning (CI escalates to error)

### DIFF
--- a/apps/studio-desktop/tsdown.config.ts
+++ b/apps/studio-desktop/tsdown.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
     external: ["electron", "electron-updater"],
     // Bundle effect + platform-node + @ax/* so the main process is self-contained.
     noExternal: [/^effect/, /^@effect\//, /^@ax\//],
+    // We deliberately bundle those deps (above) into one self-contained main
+    // process. tsdown warns about that and, under CI=true, escalates the warning
+    // to a fatal error - silence it; the bundling is intended.
+    inlineOnly: false,
     // `@ax/schema/schema.surql` is imported as text (DesktopSchema applies it on
     // boot). Teach rolldown to load `.surql` files as string modules instead of
     // trying to parse them as JS.


### PR DESCRIPTION
Unblocks the v0.1.0 desktop release (2nd build fix). build:main passes locally but fails in CI: tsdown escalates its 'noExternal bundles effect/@effect/*' warning to a fatal error under CI=true. The bundling is intended, so `inlineOnly: false` silences it. Verified `CI=true bun run build` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)