### PR TITLE
fix(ingest): capture cursor + opencode file evidence

### DIFF
--- a/apps/axctl/src/ingest/tool-file-evidence.test.ts
+++ b/apps/axctl/src/ingest/tool-file-evidence.test.ts
@@ -23,6 +23,14 @@ describe("tool file evidence classification", () => {
         expect(classifyToolFileEvidence({ name: "exec_command", commandNorm: "git status" })).toEqual([]);
     });
 
+    // #162: cursor uses _v2-suffixed + cursor-specific tool names that matched no set.
+    test("classifies cursor read/search tool names incl _v2 (#162)", () => {
+        expect(classifyToolFileEvidence({ name: "read_file" })).toEqual(["read_file"]);
+        expect(classifyToolFileEvidence({ name: "read_file_v2" })).toEqual(["read_file"]);
+        expect(classifyToolFileEvidence({ name: "codebase_search" })).toEqual(["searched_file"]);
+        expect(classifyToolFileEvidence({ name: "glob_file_search" })).toEqual(["searched_file"]);
+    });
+
     test("extracts edit/read/search paths from structured tool calls", () => {
         const readKey = toolCallRecordKey({
             sessionId: "session-1",
@@ -109,6 +117,60 @@ describe("tool file evidence classification", () => {
                 path: "/repo/src/edit.ts",
                 pathSeen: "src/edit.ts",
                 evidence: "tool_name:apply_patch",
+            },
+        ]);
+    });
+
+    // #161 (opencode `filePath`) + #162 (cursor `read_file_v2` + `target_file`):
+    // without these tool names / path fields the rows were dropped entirely.
+    test("extracts opencode filePath edits and cursor read_file_v2 paths (#161/#162)", () => {
+        const cursorKey = toolCallRecordKey({ sessionId: "s", seq: 1, callId: "c-read" });
+        const opencodeKey = toolCallRecordKey({ sessionId: "s", seq: 2, callId: "c-edit" });
+
+        expect(extractToolFileEvidence([
+            {
+                provider: "cursor",
+                toolName: "read_file_v2",
+                toolKind: "builtin",
+                sessionId: "s",
+                seq: 1,
+                turnKey: turnRecordKey("s", 1),
+                callId: "c-read",
+                ts: "2026-05-29T06:00:00.000Z",
+                cwd: "/repo",
+                inputJson: { target_file: "src/cursor.ts" },
+                hasError: false,
+            },
+            {
+                provider: "opencode",
+                toolName: "edit",
+                toolKind: "builtin",
+                sessionId: "s",
+                seq: 2,
+                turnKey: turnRecordKey("s", 2),
+                callId: "c-edit",
+                ts: "2026-05-29T06:00:01.000Z",
+                cwd: "/repo",
+                inputJson: { filePath: "src/opencode.ts" },
+                hasError: false,
+            },
+        ]).map((item) => ({
+            kind: item.kind,
+            toolCallKey: item.toolCallKey,
+            path: item.path,
+            pathSeen: item.pathSeen,
+        }))).toEqual([
+            {
+                kind: "read_file",
+                toolCallKey: cursorKey,
+                path: "/repo/src/cursor.ts",
+                pathSeen: "src/cursor.ts",
+            },
+            {
+                kind: "edited",
+                toolCallKey: opencodeKey,
+                path: "/repo/src/opencode.ts",
+                pathSeen: "src/opencode.ts",
             },
         ]);
     });

--- a/apps/axctl/src/ingest/tool-file-evidence.ts
+++ b/apps/axctl/src/ingest/tool-file-evidence.ts
@@ -22,7 +22,9 @@ const SEARCH_TOOLS = FILE_SEARCH_TOOL_NAMES;
 const EDIT_TOOLS = EDIT_TOOL_NAMES;
 const READ_COMMANDS = FILE_READ_COMMANDS;
 const SEARCH_COMMANDS = FILE_SEARCH_COMMANDS;
-const STRUCTURED_PATH_FIELDS = ["file_path", "path", "notebook_path", "file"] as const;
+// `filePath` is opencode's read/write/edit path field (#161); `target_file`/`targetFile`
+// are cursor's read_file/edit_file path fields (#162). Without these the rows are dropped.
+const STRUCTURED_PATH_FIELDS = ["file_path", "path", "notebook_path", "file", "filePath", "target_file", "targetFile"] as const;
 
 export interface ToolFileEvidenceInput {
     readonly name: string;

--- a/packages/lib/src/shared/tool-classes.ts
+++ b/packages/lib/src/shared/tool-classes.ts
@@ -64,9 +64,11 @@ export const EDIT_COMMANDS: ReadonlySet<string> = new Set([
 ]);
 
 /** Lowercased tool names whose calls read a file's contents. */
-export const FILE_READ_TOOL_NAMES: ReadonlySet<string> = new Set(["read"]);
+// `read_file`/`read_file_v2` are cursor's (versioned) read tools (#162).
+export const FILE_READ_TOOL_NAMES: ReadonlySet<string> = new Set(["read", "read_file", "read_file_v2"]);
 /** Lowercased tool names whose calls search across files. */
-export const FILE_SEARCH_TOOL_NAMES: ReadonlySet<string> = new Set(["grep", "glob"]);
+// `codebase_search`/`glob_file_search` are cursor's search tools (#162).
+export const FILE_SEARCH_TOOL_NAMES: ReadonlySet<string> = new Set(["grep", "glob", "codebase_search", "glob_file_search"]);
 /** Read + search tool names merged (metrics treat both as "reads"). */
 export const READ_TOOL_NAMES: ReadonlySet<string> = new Set([
     ...FILE_READ_TOOL_NAMES, ...FILE_SEARCH_TOOL_NAMES,


### PR DESCRIPTION
Two whole harnesses were silently losing **all** file evidence (reads/edits/searches never reached the graph).

## Root cause
A tool-evidence row is only emitted when a path is successfully extracted. Two gaps killed cursor + opencode:

- **#162 (cursor)** — cursor's tool names (`read_file`, `read_file_v2`, `codebase_search`, `glob_file_search`) matched none of the read/search sets, so they weren't even classified.
- **#161 (opencode) + #162 (cursor)** — the path lives in fields absent from `STRUCTURED_PATH_FIELDS`: opencode uses `filePath`, cursor uses `target_file`. With no path extracted, the row was dropped entirely.

## Fix
- `packages/lib/src/shared/tool-classes.ts` — add cursor read names to `FILE_READ_TOOL_NAMES`, cursor search names to `FILE_SEARCH_TOOL_NAMES` (`edit_file`/`apply_diff` were already present).
- `apps/axctl/src/ingest/tool-file-evidence.ts` — add `filePath`, `target_file`, `targetFile` to `STRUCTURED_PATH_FIELDS`.

## Tests (TDD, red→green)
- classify cursor read/search names incl `_v2`
- extract opencode `filePath` edits + cursor `read_file_v2` `target_file` paths

`tool-file-evidence.test.ts` — 6/6 pass.

## Notes
- The path-field additions are additive aliases on a path allowlist (only read when present) — no false-match risk.
- cursor's `target_file` / opencode's `filePath` are from the harnesses' tool schemas; lights up as those sources accumulate (local DB had no cursor/opencode file-tool rows to backfill-verify against).
- Pre-existing/unrelated: the `cursor.test.ts` / `opencode.test.ts` parser suites fail locally on a missing `@effect/platform-bun` dep (fails on `main` too); resolves in CI where deps install.

Closes #161, #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)