### PR TITLE
feat(site): unlisted /status page with live adoption stats

### DIFF
--- a/apps/site/app/lib/adoption.ts
+++ b/apps/site/app/lib/adoption.ts
@@ -1,0 +1,128 @@
+// apps/site/app/lib/adoption.ts
+//
+// Browser-side adoption stats for the unlisted /status page. Mirrors the
+// zero-consent signals from scripts/adoption.ts, but fetched live & client-side
+// (like app/lib/community.ts) so the page is always current with no backend.
+//
+// Sources (all CORS-enabled, unauthenticated):
+//   - api.github.com/repos/<repo>            stars, forks, watchers
+//   - api.github.com/repos/<repo>/releases   asset download_count (install proxy)
+//   - api.github.com/search/issues           open issues, PRs excluded
+//   - api.npmjs.org/downloads                 npm downloads (null until published)
+//
+// Unauthenticated GitHub is 60 req/hr per IP; this page makes ~3 calls and is
+// unlisted, so that's plenty. install.sh `curl|sh` fetches are deliberately NOT
+// shown - a fetch is not an install (bots/retries/mirrors); download_count is
+// the honest proxy.
+
+const REPO = "Necmttn/ax";
+const NPM_PKG = "axctl";
+
+export interface ReleaseStat {
+    readonly tag: string;
+    readonly downloads: number;
+    readonly publishedAt: string;
+}
+
+export interface AdoptionStats {
+    readonly repo: string;
+    readonly stars: number;
+    readonly forks: number;
+    readonly watchers: number;
+    readonly openIssues: number;
+    readonly totalDownloads: number;
+    readonly byPlatform: ReadonlyArray<{ platform: string; downloads: number }>;
+    readonly releases: ReadonlyArray<ReleaseStat>;
+    readonly npm: { lastWeek: number; lastMonth: number } | null;
+}
+
+interface RawAsset {
+    name: string;
+    download_count: number;
+}
+interface RawRelease {
+    tag_name: string;
+    published_at: string;
+    assets: RawAsset[];
+}
+
+async function ghJson<T>(path: string): Promise<T> {
+    const res = await fetch(`https://api.github.com/${path}`, {
+        headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!res.ok) throw new Error(`GitHub ${path} -> ${res.status}`);
+    return res.json() as Promise<T>;
+}
+
+const isTarball = (name: string) => name.endsWith(".tar.gz");
+// Strip both the current (axctl-) and pre-rename (agentctl-) prefixes so old
+// binary downloads fold into the same platform bucket (still counted, just not
+// shown as a separate row).
+const platformOf = (name: string) =>
+    name.replace(/^(axctl|agentctl)-/, "").replace(/\.tar\.gz$/, "") || name;
+
+/** All releases across pages (capped at 5 pages = 500 releases to bound the
+ *  unauthenticated rate-limit cost; ax has ~30 today). */
+async function allReleases(): Promise<RawRelease[]> {
+    const out: RawRelease[] = [];
+    for (let page = 1; page <= 5; page++) {
+        const batch = await ghJson<RawRelease[]>(`repos/${REPO}/releases?per_page=100&page=${page}`);
+        out.push(...batch);
+        if (batch.length < 100) break;
+    }
+    return out;
+}
+
+/** Open issues EXCLUDING pull requests (repo.open_issues_count conflates them). */
+async function openIssues(): Promise<number> {
+    const r = await ghJson<{ total_count: number }>(
+        `search/issues?q=${encodeURIComponent(`repo:${REPO} type:issue state:open`)}&per_page=1`,
+    );
+    return r.total_count;
+}
+
+async function npmPoint(period: "last-week" | "last-month"): Promise<number | null> {
+    const res = await fetch(`https://api.npmjs.org/downloads/point/${period}/${NPM_PKG}`);
+    if (res.status === 404) return null;
+    if (!res.ok) return null;
+    return ((await res.json()) as { downloads: number }).downloads;
+}
+
+export async function fetchAdoption(): Promise<AdoptionStats> {
+    const [repo, releases, issues, npmWeek, npmMonth] = await Promise.all([
+        ghJson<{ stargazers_count: number; forks_count: number; subscribers_count: number }>(`repos/${REPO}`),
+        allReleases(),
+        openIssues(),
+        npmPoint("last-week"),
+        npmPoint("last-month"),
+    ]);
+
+    const assets = releases.flatMap((r) => r.assets).filter((a) => isTarball(a.name));
+    const totalDownloads = assets.reduce((n, a) => n + a.download_count, 0);
+
+    const platMap = new Map<string, number>();
+    for (const a of assets) platMap.set(platformOf(a.name), (platMap.get(platformOf(a.name)) ?? 0) + a.download_count);
+    const byPlatform = [...platMap.entries()]
+        .map(([platform, downloads]) => ({ platform, downloads }))
+        .sort((a, b) => b.downloads - a.downloads);
+
+    const relStats: ReleaseStat[] = releases
+        .map((r) => ({
+            tag: r.tag_name,
+            publishedAt: r.published_at,
+            downloads: r.assets.filter((a) => isTarball(a.name)).reduce((n, a) => n + a.download_count, 0),
+        }))
+        .slice(0, 10);
+
+    return {
+        repo: REPO,
+        stars: repo.stargazers_count,
+        forks: repo.forks_count,
+        watchers: repo.subscribers_count,
+        openIssues: issues,
+        totalDownloads,
+        byPlatform,
+        releases: relStats,
+        npm: npmWeek !== null ? { lastWeek: npmWeek, lastMonth: npmMonth ?? 0 } : null,
+    };
+}

--- a/apps/site/app/routes/status.tsx
+++ b/apps/site/app/routes/status.tsx
@@ -1,0 +1,139 @@
+// apps/site/app/routes/status.tsx
+//
+// Unlisted live-adoption page (not linked from nav). Client-fetches the same
+// zero-consent signals as `bun scripts/adoption.ts`, straight from GitHub/npm,
+// so it's always current with no backend. See app/lib/adoption.ts.
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { SiteHeader } from "~/components/landing-sections/site-header";
+import { SiteFooter } from "~/components/landing-sections/site-footer";
+import { formatCompact } from "~/lib/community";
+import { fetchAdoption, type AdoptionStats } from "~/lib/adoption";
+
+export const Route = createFileRoute("/status")({
+    head: () => ({
+        meta: [
+            { title: "ax status - live adoption" },
+            { name: "description", content: "Live, measured adoption for ax: installs, stars, releases. No surveys, no phone-home." },
+            // Unlisted: keep it out of search results too.
+            { name: "robots", content: "noindex" },
+        ],
+    }),
+    component: StatusPage,
+});
+
+type State =
+    | { kind: "loading" }
+    | { kind: "error"; message: string }
+    | { kind: "ready"; stats: AdoptionStats };
+
+function StatusPage() {
+    const [state, setState] = useState<State>({ kind: "loading" });
+
+    useEffect(() => {
+        let alive = true;
+        fetchAdoption()
+            .then((stats) => alive && setState({ kind: "ready", stats }))
+            .catch((e: unknown) =>
+                alive && setState({ kind: "error", message: e instanceof Error ? e.message : String(e) }),
+            );
+        return () => { alive = false; };
+    }, []);
+
+    return (
+        <>
+            <SiteHeader />
+            <main className="status-page">
+                <header className="status-head">
+                    <h1>status</h1>
+                    <p className="muted">
+                        Live adoption, measured - not surveyed. Installs counted from GitHub release
+                        downloads (an <code>install.sh</code> fetch isn't an install). Pulled straight
+                        from the GitHub &amp; npm APIs on load.
+                    </p>
+                </header>
+
+                {state.kind === "loading" && <p className="muted status-note">measuring…</p>}
+                {state.kind === "error" && (
+                    <p className="muted status-note">
+                        couldn't load stats ({state.message}) - GitHub's anonymous API limit is 60/hr; try again shortly.
+                    </p>
+                )}
+                {state.kind === "ready" && <Receipt stats={state.stats} />}
+            </main>
+            <SiteFooter />
+        </>
+    );
+}
+
+function Receipt({ stats }: { stats: AdoptionStats }) {
+    const maxRelease = Math.max(1, ...stats.releases.map((r) => r.downloads));
+    return (
+        <div className="status-receipt">
+            <dl className="status-cells">
+                <Cell label="installs (all-time)" value={formatCompact(stats.totalDownloads)} hint="release binary downloads" />
+                <Cell label="stars" value={formatCompact(stats.stars)} />
+                <Cell label="forks" value={formatCompact(stats.forks)} />
+                <Cell label="open issues" value={formatCompact(stats.openIssues)} hint="PRs excluded" />
+                <Cell
+                    label="npm / week"
+                    value={stats.npm ? formatCompact(stats.npm.lastWeek) : "-"}
+                    hint={stats.npm ? "axctl" : "not published yet"}
+                />
+            </dl>
+
+            {stats.byPlatform.length > 0 && (
+                <section className="status-block">
+                    <h2>installs by platform</h2>
+                    <ul className="status-bars">
+                        {stats.byPlatform.map((p) => {
+                            const pct = stats.totalDownloads ? Math.round((p.downloads / stats.totalDownloads) * 100) : 0;
+                            return (
+                                <li key={p.platform}>
+                                    <span className="status-bar-label">{p.platform}</span>
+                                    <span className="status-bar-track">
+                                        <span className="status-bar-fill" style={{ width: `${pct}%` }} />
+                                    </span>
+                                    <span className="status-bar-val">{p.downloads} <span className="muted">({pct}%)</span></span>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </section>
+            )}
+
+            <section className="status-block">
+                <h2>recent releases</h2>
+                <ul className="status-bars">
+                    {stats.releases.map((r) => {
+                        const pct = Math.round((r.downloads / maxRelease) * 100);
+                        return (
+                            <li key={r.tag}>
+                                <span className="status-bar-label">{r.tag}</span>
+                                <span className="status-bar-track">
+                                    <span className="status-bar-fill" style={{ width: `${pct}%` }} />
+                                </span>
+                                <span className="status-bar-val">{r.downloads}</span>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </section>
+
+            <p className="muted status-foot">
+                Reproduce locally: <code>bun scripts/adoption.ts</code>. Site traffic is on Cloudflare
+                Web Analytics (browser page views), kept separate from these install numbers.
+            </p>
+        </div>
+    );
+}
+
+function Cell({ label, value, hint }: { label: string; value: string; hint?: string }) {
+    return (
+        <div className="status-cell">
+            <dt>{label}</dt>
+            <dd>{value}</dd>
+            {hint && <span className="status-cell-hint muted">{hint}</span>}
+        </div>
+    );
+}

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -12230,13 +12230,41 @@ footer.site-footer { padding: 48px 32px 56px; }
      mono numerals, hairline rules, paper/ink. No SaaS chrome.
    ============================================================ */
 
-.profile-page, .leaders-page {
+.profile-page, .leaders-page, .status-page {
     max-width: var(--shell-max);
     margin: 0 auto;
     padding: 32px var(--shell-pad) 96px;
 }
 @media (max-width: 640px) {
-    .profile-page, .leaders-page { padding-left: 20px; padding-right: 20px; }
+    .profile-page, .leaders-page, .status-page { padding-left: 20px; padding-right: 20px; }
+}
+
+/* ----- status: live adoption receipt (unlisted) ----- */
+.status-head h1 { margin: 0 0 8px; }
+.status-head .muted { max-width: 70ch; margin: 0 0 4px; }
+.status-note { font-family: var(--mono); font-size: 0.82rem; margin: 24px 0; }
+
+.status-cells {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1px; margin: 26px 0 0; padding: 0;
+    background: var(--line); border: 1px solid var(--line); border-radius: 8px; overflow: hidden;
+}
+.status-cell { background: var(--page); padding: 16px 16px 14px; display: flex; flex-direction: column; gap: 3px; }
+.status-cell dt { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); margin: 0; }
+.status-cell dd { margin: 0; font-family: var(--mono); font-size: 1.7rem; line-height: 1.1; color: var(--ink); font-variant-numeric: tabular-nums; }
+.status-cell-hint { font-size: 0.7rem; }
+
+.status-block { margin: 34px 0 0; }
+.status-block h2 { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); font-weight: 600; margin: 0 0 12px; }
+.status-bars { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 7px; }
+.status-bars li { display: grid; grid-template-columns: 140px 1fr auto; align-items: center; gap: 12px; font-family: var(--mono); font-size: 0.82rem; }
+.status-bar-label { color: var(--ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.status-bar-track { height: 8px; background: color-mix(in srgb, var(--line) 60%, transparent); border-radius: 4px; overflow: hidden; }
+.status-bar-fill { display: block; height: 100%; background: color-mix(in srgb, var(--green) 55%, transparent); border-radius: 4px; }
+.status-bar-val { color: var(--ink); font-variant-numeric: tabular-nums; text-align: right; min-width: 3ch; }
+.status-foot { font-size: 0.78rem; max-width: 70ch; margin: 38px 0 0; }
+@media (max-width: 520px) {
+    .status-bars li { grid-template-columns: 96px 1fr auto; }
 }
 
 /* ----- leaders: live roster (every builder's full receipt, one row) ----- */


### PR DESCRIPTION
## What

Adds **`/status`** — an unlisted (`noindex`, not in nav) page rendering live ax adoption, for quick at-a-glance checks. Follow-up to #514.

Client-fetches the same zero-consent signals as `bun scripts/adoption.ts`, straight from the GitHub + npm APIs on load (no backend — same pattern as `/leaders`):

- installs all-time (release `download_count`), stars, forks, open issues (PRs excluded), npm/week (when published)
- installs-by-platform + recent-releases bars
- pre-rename `agentctl-*` downloads fold into their real platform bucket (still counted)

Receipt-style, measured-not-headlined (ax visual taste). Site page-view traffic stays on Cloudflare Web Analytics, kept separate from these install numbers.

## Verify

Rendered locally against live data — platform bars (darwin-arm64 72, linux-x64 10) and release counts populate from the client-side fetch; nav has no Status link (unlisted). New files typecheck clean.

Files: `app/routes/status.tsx`, `app/lib/adoption.ts`, `app/styles/globals.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)