### PR TITLE
fix(ci): wrangler r2 upload needs --remote (v4 defaults to local)

### DIFF
--- a/.github/workflows/studio-desktop-release.yml
+++ b/.github/workflows/studio-desktop-release.yml
@@ -79,5 +79,9 @@ jobs:
           if [ ${#files[@]} -eq 0 ]; then echo "no artifacts to upload" >&2; exit 1; fi
           for f in "${files[@]}"; do
             echo "uploading $(basename "$f") -> $R2_BUCKET/desktop/"
-            bunx wrangler r2 object put "$R2_BUCKET/desktop/$(basename "$f")" --file="$f"
+            # `--remote` is REQUIRED on wrangler v4: `r2 object put` defaults to
+            # LOCAL (miniflare) storage there and silently prints "Upload
+            # complete" without ever touching R2. Pin the version so the flag
+            # set can't drift again.
+            bunx wrangler@4.101.0 r2 object put "$R2_BUCKET/desktop/$(basename "$f")" --file="$f" --remote
           done


### PR DESCRIPTION
The desktop release uploaded 'successfully' but nothing reached R2 — CI's wrangler v4.101.0 `r2 object put` defaults to LOCAL miniflare storage and prints 'Upload complete' without touching R2 (v3 defaulted remote, which is why local testing passed). Add `--remote` + pin wrangler@4.101.0. Verified a real upload round-trips through dl.ax.necmttn.com (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)