### PR TITLE
fix(studio-desktop): bundle electron-updater (app crashed on launch)

### DIFF
--- a/apps/studio-desktop/tsdown.config.ts
+++ b/apps/studio-desktop/tsdown.config.ts
@@ -7,10 +7,14 @@ export default defineConfig({
     outExtensions: () => ({ js: ".cjs" }),
     sourcemap: true,
     clean: true,
-    // Electron + native updater are provided by the Electron runtime, never bundled.
-    external: ["electron", "electron-updater"],
-    // Bundle effect + platform-node + @ax/* so the main process is self-contained.
-    noExternal: [/^effect/, /^@effect\//, /^@ax\//],
+    // Only `electron` is provided by the runtime. Everything else is bundled,
+    // because the packaged asar is just dist-electron + package.json (no
+    // node_modules) - a runtime `require` of a non-bundled module crashes the
+    // app (electron-updater did exactly that on first launch).
+    external: ["electron"],
+    // Bundle effect + platform-node + @ax/* + electron-updater so the main
+    // process is fully self-contained.
+    noExternal: [/^effect/, /^@effect\//, /^@ax\//, "electron-updater"],
     // We deliberately bundle those deps (above) into one self-contained main
     // process. tsdown warns about that and, under CI=true, escalates the warning
     // to a fatal error - silence it; the bundling is intended.


### PR DESCRIPTION
The signed/notarized v0.1.0 app crashed on first launch: `Cannot find module 'electron-updater'`. It was tsdown-`external` but the asar is just dist-electron + package.json (no node_modules), so the runtime require found nothing. Bundle it into main.cjs (only `electron` stays external). Verified the packaged .app launches cleanly past startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)