### PR TITLE
refactor(studio): consume the contract's generated types end-to-end (#355)

### DIFF
--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -144,14 +144,40 @@ async function jsonFetch<T>(input: RequestInfo, init?: RequestInit): Promise<T> 
 }
 
 /**
- * Route a call through the Insights Surface Contract client (ADR-0013).
+ * Route a call through the Insights Surface Contract client (ADR-0013) and
+ * thread the contract's response type straight through: the `HttpApiClient`
+ * call (`c.insights.recall(...)`) already returns a precisely-typed `Effect`,
+ * so `A` is inferred from it and callers no longer annotate `Promise<T>`.
  * Mock mode without a connected endpoint keeps the legacy mock-fixtures
  * behavior, keyed by the same bare path jsonFetch used; otherwise the
  * generated client runs against the connected endpoint (or same-origin).
- * The `T` cast preserves the dashboard-types interfaces the UI was already
- * trusting under jsonFetch<T> - contract payloads tighten in a later pass.
  */
-async function viaContract<T>(
+async function viaContract<A, E>(
+    mockPath: string,
+    call: (client: AxClient) => Effect.Effect<A, E>,
+    mockInit?: RequestInit,
+): Promise<A> {
+    if (STUDIO_MOCK) {
+        const endpoint = readEndpoint();
+        if (!endpoint) {
+            const { mockFetch } = await import("./mock-fixtures.ts");
+            // mockInit carries the method for fixtures keyed on POST/DELETE.
+            return mockFetch<A>(mockPath, mockInit);
+        }
+        return runContract(endpoint, call);
+    }
+    return runContract(null, call);
+}
+
+/**
+ * Variant for endpoints whose contract response is `Schema.Unknown` on
+ * purpose (raw-row passthroughs, deeply-nested mega-payloads, and `RecordId`
+ * payloads - see the inline rationale in api-contract.ts). The contract can't
+ * type these, so the studio asserts the hand-written dashboard-types shape `T`
+ * at this single, greppable seam instead of scattering casts. Migrate a method
+ * off this helper if/when its contract payload is tightened to a `Schema.Struct`.
+ */
+async function viaContractUnknown<T>(
     mockPath: string,
     call: (client: AxClient) => Effect.Effect<unknown, unknown>,
     mockInit?: RequestInit,
@@ -306,15 +332,15 @@ export interface SessionTimelinePayload {
 }
 
 export const api = {
-    version: (): Promise<DaemonVersion> =>
+    version: () =>
         viaContract("/api/version", (c) => c.system.version()),
-    skills: (): Promise<SkillTriageResponse> =>
+    skills: () =>
         viaContract("/api/skills", (c) => c.skills.skills()),
     decide: (
         name: string,
         decision: TriageDecision,
         reason?: string | null,
-    ): Promise<SkillTriageNote> =>
+    ) =>
         viaContract(
             `/api/skills/${encodeURIComponent(name)}/decide`,
             (c) => c.skills.skillDecide({
@@ -323,7 +349,7 @@ export const api = {
             }),
             { method: "POST" },
         ),
-    clearDecision: (name: string): Promise<{ cleared: boolean; skill_name: string }> =>
+    clearDecision: (name: string) =>
         viaContract(
             `/api/skills/${encodeURIComponent(name)}/decide`,
             (c) => c.skills.skillDecideClear({ params: { name } }),
@@ -333,7 +359,7 @@ export const api = {
         names: ReadonlyArray<string>,
         decision: TriageDecision,
         reason?: string | null,
-    ): Promise<{ notes: ReadonlyArray<SkillTriageNote> }> =>
+    ) =>
         viaContract(
             "/api/skills/decide-bulk",
             (c) => c.skills.skillDecideBulk({
@@ -341,12 +367,12 @@ export const api = {
             }),
             { method: "POST" },
         ),
-    detail: (name: string): Promise<SkillDetailPayload> =>
+    detail: (name: string) =>
         viaContract(
             `/api/skills/${encodeURIComponent(name)}/detail`,
             (c) => c.skills.skillDetail({ params: { name } }),
         ),
-    skillSource: (name: string): Promise<SkillSourcePayload> =>
+    skillSource: (name: string) =>
         viaContract(
             `/api/skills/${encodeURIComponent(name)}/source`,
             (c) => c.skills.skillSource({ params: { name } }),
@@ -354,17 +380,17 @@ export const api = {
     openSkill: (
         name: string,
         target: "finder" | "editor",
-    ): Promise<{ launched: string }> =>
+    ) =>
         viaContract(
             `/api/skills/${encodeURIComponent(name)}/open`,
             (c) => c.skills.skillOpen({ params: { name }, payload: { target } }),
             { method: "POST" },
         ),
-    decisions: (): Promise<{ decisions: ReadonlyArray<SkillTriageNote> }> =>
+    decisions: () =>
         viaContract("/api/decisions", (c) => c.skills.decisions()),
-    workflow: (): Promise<WorkflowResponse> =>
+    workflow: () =>
         viaContract("/api/workflow", (c) => c.insights.workflow()),
-    sessions: (params: { offset?: number; limit?: number; source?: string; project?: string } = {}): Promise<SessionListResponse> =>
+    sessions: (params: { offset?: number; limit?: number; source?: string; project?: string } = {}) =>
         viaContract("/api/sessions", (c) =>
             c.sessions.sessionsList({
                 query: {
@@ -375,17 +401,17 @@ export const api = {
                 },
             })),
     sessionDetail: (sessionId: string): Promise<SessionDetailPayload> =>
-        viaContract(
+        viaContractUnknown(
             `/api/sessions/${encodeURIComponent(sessionId)}`,
             (c) => c.sessions.sessionDetail({ params: { id: sessionId } }),
         ),
-    sessionChildren: (parentId: string): Promise<SessionChildrenResponse> =>
+    sessionChildren: (parentId: string) =>
         viaContract(
             `/api/sessions/${encodeURIComponent(parentId)}/children`,
             (c) => c.sessions.sessionChildren({ params: { id: parentId }, query: {} }),
         ),
     sessionInsights: async (sessionId: string): Promise<SessionInsightsPayload> => {
-        const payload = await viaContract<SessionInsightsPayload>(
+        const payload = await viaContractUnknown<SessionInsightsPayload>(
             `/api/sessions/${encodeURIComponent(sessionId)}/insights`,
             (c) => c.sessions.sessionInsights({ params: { id: sessionId } }),
         );
@@ -398,7 +424,7 @@ export const api = {
         return payload;
     },
     sessionInspect: (sessionId: string, params: { turnOffset?: number; turnLimit?: number } = {}): Promise<SessionInspectPayload> =>
-        viaContract(
+        viaContractUnknown(
             `/api/sessions/${encodeURIComponent(sessionId)}/inspect`,
             (c) => c.sessions.sessionInspect({
                 params: { id: sessionId },
@@ -409,11 +435,11 @@ export const api = {
             }),
         ),
     sessionTimeline: (sessionId: string): Promise<SessionTimelinePayload> =>
-        viaContract(
+        viaContractUnknown(
             `/api/sessions/${encodeURIComponent(sessionId)}/timeline`,
             (c) => c.sessions.sessionTimeline({ params: { id: sessionId } }),
         ),
-    sessionCompare: (ids: ReadonlyArray<string>, params: { turns?: boolean } = {}): Promise<SessionComparePayload> =>
+    sessionCompare: (ids: ReadonlyArray<string>, params: { turns?: boolean } = {}) =>
         viaContract("/api/sessions/compare", (c) =>
             c.sessions.sessionCompare({
                 query: {
@@ -421,13 +447,13 @@ export const api = {
                     ...(params.turns ? { turns: "1" } : {}),
                 },
             })),
-    episodeTimeline: (parentId: string): Promise<EpisodeTimelinePayload> =>
+    episodeTimeline: (parentId: string) =>
         viaContract(
             `/api/episodes/${encodeURIComponent(parentId)}`,
             (c) => c.insights.episodeTimeline({ params: { parentId } }),
         ),
     project: (slug: string): Promise<ProjectPagePayload> =>
-        viaContract(
+        viaContractUnknown(
             `/api/projects/${encodeURIComponent(slug)}`,
             (c) => c.insights.project({ params: { project: slug } }),
         ),
@@ -443,18 +469,18 @@ export const api = {
         const qs = usp.toString();
         return jsonFetch(qs ? `/api/graph-explorer?${qs}` : "/api/graph-explorer");
     },
-    sessionCanvas: (params: { limit?: number } = {}): Promise<SessionCanvasPayload> =>
+    sessionCanvas: (params: { limit?: number } = {}) =>
         viaContract("/api/session-canvas", (c) =>
             c.sessions.sessionCanvas({
                 query: params.limit != null ? { limit: params.limit } : {},
             })),
-    sessionOrchestration: (id: string): Promise<SessionOrchestration> =>
+    sessionOrchestration: (id: string) =>
         viaContract("/api/session-orchestration", (c) =>
             c.sessions.sessionOrchestration({ query: { id } })),
-    sessionSummary: (id: string): Promise<SessionSummary> =>
+    sessionSummary: (id: string) =>
         viaContract("/api/session-summary", (c) =>
             c.sessions.sessionSummary({ query: { id } })),
-    skillGraph: (params: { minCount?: number; limit?: number } = {}): Promise<SkillGraphPayload> =>
+    skillGraph: (params: { minCount?: number; limit?: number } = {}) =>
         viaContract("/api/skill-graph", (c) =>
             c.insights.skillGraph({
                 query: {
@@ -469,7 +495,7 @@ export const api = {
         since?: string | null;
         offset?: number;
         limit?: number;
-    }): Promise<RecallResponse> =>
+    }) =>
         viaContract("/api/recall", (c) =>
             c.insights.recall({
                 query: {
@@ -484,7 +510,7 @@ export const api = {
     /** Trigger a live ingest run. Returns the full Durable Streams sidecar URL
      *  the browser subscribes to directly (the sidecar has permissive CORS and
      *  runs on its own localhost port). */
-    ingest: (params: { since?: number } = {}): Promise<IngestTriggerResponse> =>
+    ingest: (params: { since?: number } = {}) =>
         viaContract(
             "/api/ingest",
             (c) => c.live.ingestTrigger({
@@ -492,61 +518,61 @@ export const api = {
             }),
             { method: "POST" },
         ),
-    toolFailures: (): Promise<ToolFailuresResponse> =>
+    toolFailures: () =>
         viaContract("/api/tool-failures", (c) => c.insights.toolFailures()),
-    toolFailureDetail: (label: string): Promise<ToolFailureDetailPayload> =>
+    toolFailureDetail: (label: string) =>
         viaContract(
             `/api/tool-failures/${encodeURIComponent(label)}/detail`,
             (c) => c.insights.toolFailureDetail({ params: { label } }),
         ),
     wrapped: (): Promise<WrappedProfile> =>
-        viaContract("/api/wrapped", (c) => c.insights.wrapped()),
+        viaContractUnknown("/api/wrapped", (c) => c.insights.wrapped()),
     wrappedPublicPreview: (): Promise<WrappedProfile> =>
-        viaContract("/api/wrapped/public-preview", (c) => c.insights.wrappedPublicPreview()),
+        viaContractUnknown("/api/wrapped/public-preview", (c) => c.insights.wrappedPublicPreview()),
 
     costModels: (): Promise<CostModelsResult> =>
-        viaContract("/api/cost/models", (c) => c.insights.costModels()) as Promise<CostModelsResult>,
+        viaContractUnknown("/api/cost/models", (c) => c.insights.costModels()) as Promise<CostModelsResult>,
     costSplit: (days = 30): Promise<unknown> =>
-        viaContract("/api/cost/split", (c) => c.insights.costSplit({ query: { days } })),
+        viaContractUnknown("/api/cost/split", (c) => c.insights.costSplit({ query: { days } })),
     costDispatches: (days = 30, candidates = false): Promise<unknown> =>
-        viaContract("/api/cost/dispatches", (c) => c.insights.costDispatches({ query: { days, candidates } })),
+        viaContractUnknown("/api/cost/dispatches", (c) => c.insights.costDispatches({ query: { days, candidates } })),
     costRoutability: (days = 30, minRun = 1): Promise<unknown> =>
-        viaContract("/api/cost/routability", (c) => c.insights.costRoutability({ query: { days, minRun } })),
+        viaContractUnknown("/api/cost/routability", (c) => c.insights.costRoutability({ query: { days, minRun } })),
     routingTable: (): Promise<unknown> =>
-        viaContract("/api/routing/table", (c) => c.insights.routingTable()),
+        viaContractUnknown("/api/routing/table", (c) => c.insights.routingTable()),
     routingBacktest: (body: { pattern: string; flags?: string; suggest: string; exclude?: string[]; days?: number }): Promise<unknown> =>
-        viaContract("/api/routing/backtest", (c) => c.insights.routingBacktest({ payload: body }), { method: "POST" }),
+        viaContractUnknown("/api/routing/backtest", (c) => c.insights.routingBacktest({ payload: body }), { method: "POST" }),
     routingUpsertClass: (body: { id: string; pattern: string; flags?: string; suggest: string; reason?: string; exclude?: string[] }): Promise<unknown> =>
-        viaContract("/api/routing/classes", (c) => c.routing.routingUpsertClass({ payload: body }), { method: "POST" }),
+        viaContractUnknown("/api/routing/classes", (c) => c.routing.routingUpsertClass({ payload: body }), { method: "POST" }),
     routingRemoveClass: (id: string): Promise<unknown> =>
-        viaContract(`/api/routing/classes/${encodeURIComponent(id)}`, (c) => c.routing.routingRemoveClass({ params: { id } }), { method: "DELETE" }),
+        viaContractUnknown(`/api/routing/classes/${encodeURIComponent(id)}`, (c) => c.routing.routingRemoveClass({ params: { id } }), { method: "DELETE" }),
     contextBudget: (): Promise<ContextBudgetResult> =>
-        viaContract("/api/context/budget", (c) => c.insights.contextBudget()) as Promise<ContextBudgetResult>,
+        viaContractUnknown("/api/context/budget", (c) => c.insights.contextBudget()) as Promise<ContextBudgetResult>,
     contextDrift: (): Promise<ContextDriftResult> =>
-        viaContract("/api/context/drift", (c) => c.insights.contextDrift()) as Promise<ContextDriftResult>,
+        viaContractUnknown("/api/context/drift", (c) => c.insights.contextDrift()) as Promise<ContextDriftResult>,
 
     nextActions: (): Promise<NextActionsPayload> =>
-        viaContract("/api/next-actions", (c) => c.improve.nextActions()),
+        viaContractUnknown("/api/next-actions", (c) => c.improve.nextActions()),
 
     improveAnalyzeBrief: (): Promise<{ brief: string }> =>
-        viaContract("/api/improve/analyze-brief", (c) => c.improve.analyzeBrief()),
+        viaContractUnknown("/api/improve/analyze-brief", (c) => c.improve.analyzeBrief()),
 
     improveImpact: (sig: string): Promise<{ sig: string; impact: ImpactEstimate }> =>
-        viaContract(`/api/improve/${encodeURIComponent(sig)}/impact`, (c) =>
+        viaContractUnknown(`/api/improve/${encodeURIComponent(sig)}/impact`, (c) =>
             c.improve.improveImpact({ params: { sig } })),
 
     wrappedGenerateBrief: (): Promise<{ brief: string }> =>
-        viaContract("/api/wrapped/generate-brief", (c) => c.insights.wrappedGenerateBrief()),
+        viaContractUnknown("/api/wrapped/generate-brief", (c) => c.insights.wrappedGenerateBrief()),
 
     /** CLI utilization rollup: active days, top commands, unused surface. */
-    usage: (params: { days?: number } = {}): Promise<UsageRollupSchema> =>
+    usage: (params: { days?: number } = {}) =>
         viaContract("/api/usage", (c) =>
             c.usage.usageRollup({
                 query: params.days != null ? { days: params.days } : {},
             })),
 
     /** Read-only SQL console (Lab) - daemon accepts SELECT/RETURN/INFO only. */
-    query: (sql: string): Promise<{ result: unknown; durationMs: number }> =>
+    query: (sql: string) =>
         viaContract(
             "/api/query",
             (c) => c.system.query({ payload: { sql } }),
@@ -556,9 +582,9 @@ export const api = {
     // Experiment loop - see
     // docs/superpowers/plans/2026-05-25-experiment-loop-cleanup-and-rebuild.md
     improve: (): Promise<ImprovePayload> =>
-        viaContract("/api/improve", (c) => c.improve.improveList()),
+        viaContractUnknown("/api/improve", (c) => c.improve.improveList()),
     improveAccept: (sig: string, force = false): Promise<ImproveActionResponse> =>
-        viaContract(
+        viaContractUnknown(
             `/api/improve/${encodeURIComponent(sig)}/accept`,
             (c) => c.improve.improveAction({
                 params: { sig, action: "accept" },
@@ -567,7 +593,7 @@ export const api = {
             { method: "POST" },
         ),
     improveReject: (sig: string, reason?: string | null): Promise<ImproveActionResponse> =>
-        viaContract(
+        viaContractUnknown(
             `/api/improve/${encodeURIComponent(sig)}/reject`,
             (c) => c.improve.improveAction({
                 params: { sig, action: "reject" },
@@ -576,7 +602,7 @@ export const api = {
             { method: "POST" },
         ),
     improveSetVerdict: (sig: string, verdict: string): Promise<ImproveActionResponse> =>
-        viaContract(
+        viaContractUnknown(
             `/api/improve/${encodeURIComponent(sig)}/verdict`,
             (c) => c.improve.improveAction({
                 params: { sig, action: "verdict" },

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -120,6 +120,7 @@ export const RecallHit = Schema.Struct({
     ts: Schema.NullOr(Schema.String),
     snippet: Schema.String,
 });
+export type RecallHit = typeof RecallHit.Type;
 
 export const RecallCommitHit = Schema.Struct({
     commit_id: Schema.String,
@@ -130,6 +131,7 @@ export const RecallCommitHit = Schema.Struct({
     snippet: Schema.String,
     score: Schema.Number,
 });
+export type RecallCommitHit = typeof RecallCommitHit.Type;
 
 export const RecallSkillHit = Schema.Struct({
     skill_id: Schema.String,
@@ -138,6 +140,7 @@ export const RecallSkillHit = Schema.Struct({
     snippet: Schema.String,
     score: Schema.Number,
 });
+export type RecallSkillHit = typeof RecallSkillHit.Type;
 
 export const RecallResponse = Schema.Struct({
     q: Schema.String,
@@ -182,8 +185,9 @@ export const ToolFailuresResponse = Schema.Struct({
     generatedAt: Schema.String,
     failures: Schema.Array(ToolFailureEntry),
 });
+export type ToolFailuresResponse = typeof ToolFailuresResponse.Type;
 
-const ToolFailureSample = Schema.Struct({
+export const ToolFailureSample = Schema.Struct({
     ts: Schema.String,
     exit_code: Schema.NullOr(Schema.Number),
     error_text: Schema.NullOr(Schema.String),
@@ -193,24 +197,29 @@ const ToolFailureSample = Schema.Struct({
     session_id: Schema.NullOr(Schema.String),
     cwd: Schema.NullOr(Schema.String),
 });
+export type ToolFailureSample = typeof ToolFailureSample.Type;
 
 export const ToolFailureDetailPayload = Schema.Struct({
     label: Schema.String,
     samples: Schema.Array(ToolFailureSample),
 });
+export type ToolFailureDetailPayload = typeof ToolFailureDetailPayload.Type;
 
-const SkillGraphNode = Schema.Struct({
+export const SkillGraphNode = Schema.Struct({
     name: Schema.String,
     weight: Schema.Number,
     last_seen: Schema.NullOr(Schema.String),
 });
 
-const SkillGraphEdge = Schema.Struct({
+export type SkillGraphNode = typeof SkillGraphNode.Type;
+
+export const SkillGraphEdge = Schema.Struct({
     source: Schema.String,
     target: Schema.String,
     count: Schema.Number,
     last_seen: Schema.NullOr(Schema.String),
 });
+export type SkillGraphEdge = typeof SkillGraphEdge.Type;
 
 export const SkillGraphPayload = Schema.Struct({
     min_count: Schema.Number,
@@ -221,10 +230,11 @@ export const SkillGraphPayload = Schema.Struct({
     nodes: Schema.Array(SkillGraphNode),
     edges: Schema.Array(SkillGraphEdge),
 });
+export type SkillGraphPayload = typeof SkillGraphPayload.Type;
 
 const PhaseLiteral = Schema.Literals(["plan", "execute", "review", "merge"]);
 
-const EpisodeNode = Schema.Struct({
+export const EpisodeNode = Schema.Struct({
     session_id: Schema.String,
     role: Schema.Literals(["parent", "child"]),
     project: Schema.NullOr(Schema.String),
@@ -236,6 +246,7 @@ const EpisodeNode = Schema.Struct({
     top_skills: Schema.Array(Schema.Struct({ skill: Schema.String, count: Schema.Number })),
     invocation_count: Schema.Number,
 });
+export type EpisodeNode = typeof EpisodeNode.Type;
 
 export const EpisodeTimelinePayload = Schema.Struct({
     parent_session_id: Schema.String,
@@ -247,6 +258,7 @@ export const EpisodeTimelinePayload = Schema.Struct({
     nodes: Schema.Array(EpisodeNode),
     shape: Schema.String,
 });
+export type EpisodeTimelinePayload = typeof EpisodeTimelinePayload.Type;
 
 const WorkflowWeekBucket = Schema.Struct({
     week: Schema.String,
@@ -273,13 +285,14 @@ const SessionShapeAggregate = Schema.Struct({
     example_session_ids: Schema.Array(Schema.String),
 });
 
-const WorkflowEpisode = Schema.Struct({
+export const WorkflowEpisode = Schema.Struct({
     parent_session_id: Schema.String,
     project: Schema.NullOr(Schema.String),
     started_at: Schema.NullOr(Schema.String),
     child_count: Schema.Number,
     distinct_nicknames: Schema.Number,
 });
+export type WorkflowEpisode = typeof WorkflowEpisode.Type;
 
 const EpisodeShapeAggregate = Schema.Struct({
     shape: Schema.String,
@@ -304,6 +317,7 @@ export const WorkflowResponse = Schema.Struct({
     episode_shapes_total: Schema.Number,
     narrative: Schema.String,
 });
+export type WorkflowResponse = typeof WorkflowResponse.Type;
 
 /**
  * The insights family: cross-source recall, project pages, episode
@@ -428,7 +442,7 @@ export const InsightsGroup = HttpApiGroup.make("insights")
 // detail/inspect/insights payloads stay Schema.Unknown below (transcribing
 // the 54k-line inspect handler's output exactly is high-drift, low-value).
 
-const SessionListRow = Schema.Struct({
+export const SessionListRow = Schema.Struct({
     id: Schema.String,
     project: Schema.NullOr(Schema.String),
     source: Schema.String,
@@ -450,6 +464,7 @@ const SessionListRow = Schema.Struct({
     lines_removed: Schema.NullOr(Schema.Number),
     is_live: Schema.Boolean,
 });
+export type SessionListRow = typeof SessionListRow.Type;
 
 export const SessionListResponse = Schema.Struct({
     sessions: Schema.Array(SessionListRow),
@@ -457,11 +472,13 @@ export const SessionListResponse = Schema.Struct({
     burn_p90: Schema.NullOr(Schema.Number),
     window: Schema.Struct({ offset: Schema.Number, limit: Schema.Number }),
 });
+export type SessionListResponse = typeof SessionListResponse.Type;
 
 export const SessionChildrenResponse = Schema.Struct({
     parent_session: Schema.String,
     children: Schema.Array(SessionListRow),
 });
+export type SessionChildrenResponse = typeof SessionChildrenResponse.Type;
 
 export const SessionSummary = Schema.Struct({
     session_id: Schema.String,
@@ -476,6 +493,7 @@ export const SessionSummary = Schema.Struct({
     subagents: Schema.Number,
     tools: Schema.Array(Schema.Struct({ name: Schema.String, count: Schema.Number })),
 });
+export type SessionSummary = typeof SessionSummary.Type;
 
 const SessionOrchestrationSubagent = Schema.Struct({
     id: Schema.String,
@@ -495,6 +513,7 @@ export const SessionOrchestration = Schema.Struct({
     wait_pct: Schema.Number,
     subagents: Schema.Array(SessionOrchestrationSubagent),
 });
+export type SessionOrchestration = typeof SessionOrchestration.Type;
 
 const SessionTokenUsageDetail = Schema.Struct({
     model: Schema.NullOr(Schema.String),
@@ -511,7 +530,7 @@ const SessionTokenUsageDetail = Schema.Struct({
     pricing_source: Schema.NullOr(Schema.String),
 });
 
-const SessionHealthSummary = Schema.Struct({
+export const SessionHealthSummary = Schema.Struct({
     turns: Schema.Number,
     tool_calls: Schema.Number,
     tool_errors: Schema.Number,
@@ -520,8 +539,9 @@ const SessionHealthSummary = Schema.Struct({
     subagent_dispatches: Schema.Number,
     task_label: Schema.NullOr(Schema.String),
 });
+export type SessionHealthSummary = typeof SessionHealthSummary.Type;
 
-const SessionCompareTurn = Schema.Struct({
+export const SessionCompareTurn = Schema.Struct({
     seq: Schema.Number,
     role: Schema.NullOr(Schema.String),
     ts: Schema.NullOr(Schema.String),
@@ -530,8 +550,9 @@ const SessionCompareTurn = Schema.Struct({
     est_cost_usd: Schema.NullOr(Schema.Number),
     has_error: Schema.Boolean,
 });
+export type SessionCompareTurn = typeof SessionCompareTurn.Type;
 
-const SessionCompareEntry = Schema.Struct({
+export const SessionCompareEntry = Schema.Struct({
     session_id: Schema.String,
     source: Schema.String,
     model: Schema.NullOr(Schema.String),
@@ -545,6 +566,7 @@ const SessionCompareEntry = Schema.Struct({
     noise_score: Schema.NullOr(Schema.Number),
     turns: Schema.optionalKey(Schema.Array(SessionCompareTurn)),
 });
+export type SessionCompareEntry = typeof SessionCompareEntry.Type;
 
 export const SessionComparePayload = Schema.Struct({
     task_label: Schema.NullOr(Schema.String),
@@ -557,8 +579,10 @@ export const SessionComparePayload = Schema.Struct({
     }),
     not_found: Schema.Array(Schema.String),
 });
+export type SessionComparePayload = typeof SessionComparePayload.Type;
+export type SessionCompareWinners = typeof SessionComparePayload.Type["winners"];
 
-const SessionCanvasNode = Schema.Struct({
+export const SessionCanvasNode = Schema.Struct({
     id: Schema.String,
     label: Schema.String,
     project: Schema.NullOr(Schema.String),
@@ -576,13 +600,15 @@ const SessionCanvasNode = Schema.Struct({
     subagent_count: Schema.Number,
     wait_segments: Schema.Array(Schema.Struct({ start: Schema.Number, end: Schema.Number })),
 });
+export type SessionCanvasNode = typeof SessionCanvasNode.Type;
 
-const SessionCanvasEdge = Schema.Struct({
+export const SessionCanvasEdge = Schema.Struct({
     source: Schema.String,
     target: Schema.String,
     relation: Schema.String,
     label: Schema.NullOr(Schema.String),
 });
+export type SessionCanvasEdge = typeof SessionCanvasEdge.Type;
 
 export const SessionCanvasPayload = Schema.Struct({
     generatedAt: Schema.String,
@@ -590,6 +616,7 @@ export const SessionCanvasPayload = Schema.Struct({
     edges: Schema.Array(SessionCanvasEdge),
     warnings: Schema.Array(Schema.String),
 });
+export type SessionCanvasPayload = typeof SessionCanvasPayload.Type;
 
 /**
  * The sessions family: list, children, summary, orchestration, compare, and
@@ -700,6 +727,7 @@ export const SkillTriageNote = Schema.Struct({
     reason: Schema.NullOr(Schema.String),
     decided_at: Schema.String,
 });
+export type SkillTriageNote = typeof SkillTriageNote.Type;
 
 const SkillRowFields = {
     name: Schema.String,
@@ -724,11 +752,13 @@ export const SkillTriageEntry = Schema.Struct({
     recommendation_reason: Schema.String,
     decision: Schema.NullOr(SkillTriageNote),
 });
+export type SkillTriageEntry = typeof SkillTriageEntry.Type;
 
 export const SkillTriageResponse = Schema.Struct({
     generatedAt: Schema.String,
     skills: Schema.Array(SkillTriageEntry),
 });
+export type SkillTriageResponse = typeof SkillTriageResponse.Type;
 
 const SkillRecentInvocation = Schema.Struct({
     ts: Schema.String,
@@ -764,6 +794,7 @@ export const SkillDetailPayload = Schema.Struct({
     proposals: Schema.Array(SkillProposalEvidence),
     paired: Schema.Array(SkillPair),
 });
+export type SkillDetailPayload = typeof SkillDetailPayload.Type;
 
 export const SkillSourcePayload = Schema.Struct({
     name: Schema.String,
@@ -776,6 +807,7 @@ export const SkillSourcePayload = Schema.Struct({
     editable: Schema.Boolean,
     error: Schema.NullOr(Schema.String),
 });
+export type SkillSourcePayload = typeof SkillSourcePayload.Type;
 
 export const SkillDecisionsResponse = Schema.Struct({
     decisions: Schema.Array(SkillTriageNote),

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -7,6 +7,46 @@ import type { SessionId } from "./session-id.ts";
 
 export type { SessionId } from "./session-id.ts";
 
+// ---------------------------------------------------------------------------
+// Re-exported from api-contract.ts (single source of truth).
+// These were formerly hand-written interfaces here; they now derive from the
+// Effect Schema structs in api-contract so the two never silently drift.
+// ---------------------------------------------------------------------------
+export type {
+    RecallHit,
+    RecallCommitHit,
+    RecallSkillHit,
+    RecallResponse,
+    ToolFailureSample,
+    ToolFailureDetailPayload,
+    ToolFailuresResponse,
+    SkillGraphNode,
+    SkillGraphEdge,
+    SkillGraphPayload,
+    EpisodeNode,
+    EpisodeTimelinePayload,
+    WorkflowEpisode,
+    WorkflowResponse,
+    SessionListRow,
+    SessionListResponse,
+    SessionChildrenResponse,
+    SessionSummary,
+    SessionOrchestration,
+    SessionHealthSummary,
+    SessionCompareTurn,
+    SessionCompareEntry,
+    SessionComparePayload,
+    SessionCompareWinners,
+    SessionCanvasNode,
+    SessionCanvasEdge,
+    SessionCanvasPayload,
+    SkillTriageNote,
+    SkillTriageEntry,
+    SkillTriageResponse,
+    SkillDetailPayload,
+    SkillSourcePayload,
+} from "./api-contract.ts";
+
 export type TriageDecision = "keep" | "archive" | "review";
 
 export interface SkillRow {
@@ -24,27 +64,6 @@ export interface SkillRow {
     readonly proposals: number;
     readonly commits_after: number;
     readonly taste_score: number;
-}
-
-export interface SkillTriageNote {
-    readonly skill_name: string;
-    readonly decision: TriageDecision;
-    readonly reason: string | null;
-    readonly decided_at: string;
-}
-
-export interface SkillTriageEntry extends SkillRow {
-    /** Suggested action based on the score breakdown. */
-    readonly recommendation: TriageDecision;
-    /** One-line why for the recommendation. */
-    readonly recommendation_reason: string;
-    /** User's saved decision, if any. */
-    readonly decision: SkillTriageNote | null;
-}
-
-export interface SkillTriageResponse {
-    readonly generatedAt: string;
-    readonly skills: ReadonlyArray<SkillTriageEntry>;
 }
 
 export interface SkillRecentInvocation {
@@ -65,23 +84,6 @@ export interface SkillPair {
     readonly last_seen: string | null;
 }
 
-export interface SkillDetailPayload {
-    readonly name: string;
-    readonly scope: string | null;
-    readonly description: string | null;
-    readonly dir_path: string | null;
-    readonly invocations: {
-        readonly total: number;
-        readonly d7: number;
-        readonly d30: number;
-        readonly last: string | null;
-    };
-    readonly recent: ReadonlyArray<SkillRecentInvocation>;
-    readonly corrections: ReadonlyArray<SkillRecentInvocation>;
-    readonly proposals: ReadonlyArray<SkillProposalEvidence>;
-    readonly paired: ReadonlyArray<SkillPair>;
-}
-
 /** On-disk state of a skill's SKILL.md file.
  *  - `active`   - SKILL.md present; the agent harness loads it.
  *  - `disabled` - renamed to SKILL.md.archived; harness skips it (reversible).
@@ -90,23 +92,6 @@ export type SkillSourceState = "active" | "disabled" | "missing";
 
 /** Wire format for `GET /api/skills/:name/source` - the skill's SKILL.md
  *  content plus whether ax may rewrite it on disk. */
-export interface SkillSourcePayload {
-    readonly name: string;
-    readonly scope: string;
-    readonly dir_path: string | null;
-    /** Absolute path to SKILL.md (or the .archived variant when disabled). */
-    readonly file_path: string | null;
-    /** Raw YAML frontmatter text (between the `---` fences), if any. */
-    readonly frontmatter: string | null;
-    /** Markdown body after the frontmatter. */
-    readonly body: string | null;
-    readonly state: SkillSourceState;
-    /** True when ax may disable/restore this skill on disk - user-owned
-     *  scopes only. Plugin/builtin/codex skills are read-only. */
-    readonly editable: boolean;
-    /** Set when the file existed but could not be read. */
-    readonly error: string | null;
-}
 
 // ---------------------------------------------------------------------------
 // Tool failure view
@@ -129,27 +114,6 @@ export interface ToolFailureRow {
 export interface ToolFailureEntry extends ToolFailureRow {
     readonly recommendation: ToolFailureRecommendation;
     readonly recommendation_reason: string;
-}
-
-export interface ToolFailuresResponse {
-    readonly generatedAt: string;
-    readonly failures: ReadonlyArray<ToolFailureEntry>;
-}
-
-export interface ToolFailureSample {
-    readonly ts: string;
-    readonly exit_code: number | null;
-    readonly error_text: string | null;
-    readonly output_excerpt: string | null;
-    readonly command_text: string | null;
-    readonly project: string | null;
-    readonly session_id: SessionId | null;
-    readonly cwd: string | null;
-}
-
-export interface ToolFailureDetailPayload {
-    readonly label: string;
-    readonly samples: ReadonlyArray<ToolFailureSample>;
 }
 
 // ---------------------------------------------------------------------------
@@ -265,68 +229,11 @@ export interface SessionDetailPayload {
 /** Per-session health aggregate read from the `session_health` table. The
  *  noise axis (tool_errors + user_corrections + interruptions) is the
  *  "cleaner" signal the compare view ranks on. */
-export interface SessionHealthSummary {
-    readonly turns: number;
-    readonly tool_calls: number;
-    readonly tool_errors: number;
-    readonly user_corrections: number;
-    readonly interruptions: number;
-    readonly subagent_dispatches: number;
-    readonly task_label: string | null;
-}
 
 /** One turn in a session's timeline, with the per-turn trifecta attached.
  *  Only populated when the compare is requested with per-turn detail (P1). */
-export interface SessionCompareTurn {
-    readonly seq: number;
-    readonly role: string | null;
-    readonly ts: string | null;
-    /** Wall-clock gap to the previous turn, ms. Null for the first turn or when
-     *  a timestamp is missing. NOT model latency - transcripts carry no request
-     *  duration. */
-    readonly gap_ms: number | null;
-    readonly est_tokens: number | null;
-    readonly est_cost_usd: number | null;
-    readonly has_error: boolean;
-}
-
-export interface SessionCompareEntry {
-    readonly session_id: SessionId;
-    readonly source: "claude" | "codex" | string;
-    readonly model: string | null;
-    readonly project: string | null;
-    readonly started_at: string | null;
-    readonly ended_at: string | null;
-    /** ended_at - started_at, ms. Null when either bound is missing. This is
-     *  wall-clock, NOT model latency (transcripts carry no request duration). */
-    readonly duration_ms: number | null;
-    readonly token_usage: SessionTokenUsageDetail | null;
-    readonly health: SessionHealthSummary | null;
-    /** Count of `produced` edges (session → commit). */
-    readonly commit_count: number;
-    /** tool_errors + user_corrections + interruptions. Null if no health row. */
-    readonly noise_score: number | null;
-    /** Per-turn timeline, ordered by seq. Present only when per-turn detail was
-     *  requested; undefined in the summary-only (P0) payload. */
-    readonly turns?: ReadonlyArray<SessionCompareTurn>;
-}
 
 /** Winning session id per axis. Null when undecidable (no data, or a tie). */
-export interface SessionCompareWinners {
-    readonly fastest: SessionId | null;
-    readonly cheapest: SessionId | null;
-    readonly fewest_tokens: SessionId | null;
-    readonly cleanest: SessionId | null;
-}
-
-export interface SessionComparePayload {
-    /** Shared task_label when every compared session agrees; null otherwise. */
-    readonly task_label: string | null;
-    readonly sessions: ReadonlyArray<SessionCompareEntry>;
-    readonly winners: SessionCompareWinners;
-    /** Requested ids that failed to validate or resolve to a session. */
-    readonly not_found: ReadonlyArray<string>;
-}
 
 export interface SessionSkillRoleGroup {
     readonly role: string | null;
@@ -352,60 +259,12 @@ export interface SessionViewPayload {
     readonly compactions: ReadonlyArray<SessionCompaction>;
 }
 
-export interface WorkflowEpisode {
-    readonly parent_session_id: SessionId;
-    readonly project: string | null;
-    readonly started_at: string | null;
-    readonly child_count: number;
-    readonly distinct_nicknames: number;
-}
-
-export interface EpisodeNode {
-    readonly session_id: SessionId;
-    readonly role: "parent" | "child";
-    readonly project: string | null;
-    readonly source: string | null;
-    readonly started_at: string | null;
-    readonly ended_at: string | null;
-    readonly duration_ms: number | null;
-    readonly phase: "plan" | "execute" | "review" | "merge" | "other" | "mixed";
-    readonly top_skills: ReadonlyArray<{ readonly skill: string; readonly count: number }>;
-    readonly invocation_count: number;
-}
-
-export interface EpisodeTimelinePayload {
-    readonly parent_session_id: SessionId;
-    readonly project: string | null;
-    readonly started_at: string | null;
-    readonly ended_at: string | null;
-    readonly duration_ms: number | null;
-    readonly node_count: number;
-    readonly nodes: ReadonlyArray<EpisodeNode>;
-    readonly shape: string;
-}
-
 export interface EpisodeShapeAggregate {
     readonly shape: string;
     readonly phases: ReadonlyArray<"plan" | "execute" | "review" | "merge">;
     readonly episode_count: number;
     readonly example_parent_ids: ReadonlyArray<SessionId>;
     readonly avg_children: number;
-}
-
-export interface WorkflowResponse {
-    readonly generatedAt: string;
-    readonly weeksLookback: number;
-    readonly topK: number;
-    readonly skills: ReadonlyArray<WorkflowWeekBucket>;
-    readonly tools: ReadonlyArray<WorkflowWeekBucket>;
-    readonly sessionShape: ReadonlyArray<WorkflowSessionShape>;
-    readonly convergence: ReadonlyArray<WorkflowConvergencePoint>;
-    readonly shapes: ReadonlyArray<SessionShapeAggregate>;
-    readonly shapesTotal: number;
-    readonly episodes: ReadonlyArray<WorkflowEpisode>;
-    readonly episode_shapes: ReadonlyArray<EpisodeShapeAggregate>;
-    readonly episode_shapes_total: number;
-    readonly narrative: string;
 }
 
 export interface ProjectTopSkill {
@@ -446,29 +305,6 @@ export interface ProjectPagePayload {
     readonly failures: ReadonlyArray<ProjectFailure>;
     readonly recent_sessions: ReadonlyArray<ProjectRecentSession>;
     readonly top_episodes: ReadonlyArray<ProjectEpisode>;
-}
-
-export interface SkillGraphNode {
-    readonly name: string;
-    readonly weight: number;
-    readonly last_seen: string | null;
-}
-
-export interface SkillGraphEdge {
-    readonly source: string;
-    readonly target: string;
-    readonly count: number;
-    readonly last_seen: string | null;
-}
-
-export interface SkillGraphPayload {
-    readonly min_count: number;
-    readonly limit: number;
-    readonly node_count: number;
-    readonly edge_count: number;
-    readonly max_edge_count: number;
-    readonly nodes: ReadonlyArray<SkillGraphNode>;
-    readonly edges: ReadonlyArray<SkillGraphEdge>;
 }
 
 export type GraphExplorerMode =
@@ -565,27 +401,6 @@ export interface GraphExplorerPayload {
 // cross-provider. `turns` (conversational user+assistant turns) is kept as a
 // secondary display number. `epochs` = compaction count (1 = no compaction);
 // `compactions` carries the preTokens at each boundary for epoch notches.
-export interface SessionCanvasNode {
-    readonly id: string;
-    readonly label: string;
-    readonly project: string | null;
-    readonly source: string;            // 'claude' | 'codex' | ...
-    readonly started_at: string | null;
-    readonly ended_at: string | null;
-    readonly size: number;              // context tokens (estimated_tokens)
-    readonly turns: number;             // conversational (user+assistant) turns
-    readonly epochs: number;            // compaction epochs (1 = uncompacted)
-    readonly compactions: ReadonlyArray<{ pre_tokens: number; trigger: string }>;
-    readonly context_pressure: string;  // 'low' | 'medium' | 'high' | 'unknown'
-    readonly corrections: number;
-    readonly tone: string;              // success | warning | neutral
-    readonly is_subagent: boolean;
-    readonly subagent_count: number;    // direct children spawned by this session
-    // Fractions [0..1] of the session's [started_at, ended_at] during which the
-    // main agent was blocked waiting on a subagent (merged child intervals).
-    // Drives the swimlane pill's inline work/wait rail.
-    readonly wait_segments: ReadonlyArray<{ readonly start: number; readonly end: number }>;
-}
 
 // Per-session orchestration drill-in: the main rail + every subagent it spawned,
 // with real timing so the UI can show fan-out / parallel / sequential + wait%.
@@ -603,95 +418,6 @@ export interface SessionOrchestrationSubagent {
 // transcript file read/parse) so it returns in ~ms instead of the 20-60s the
 // full inspect endpoint can take when it has to walk the filesystem to locate
 // a transcript. Same facts the card shows - no data loss.
-export interface SessionSummary {
-    readonly session_id: string;
-    readonly task: string | null;          // first user turn (what it was asked)
-    readonly first_ask: string | null;
-    readonly last_assistant: string | null;
-    readonly correction: string | null;
-    readonly turns: number;                // conversational (user+assistant)
-    readonly tokens: number | null;
-    readonly cost_usd: number | null;
-    readonly model: string | null;
-    readonly subagents: number;
-    readonly tools: ReadonlyArray<{ readonly name: string; readonly count: number }>;
-}
-
-export interface SessionOrchestration {
-    readonly session_id: string;
-    readonly label: string;
-    readonly started_at: string | null;
-    readonly ended_at: string | null;
-    readonly wait_pct: number;          // 0..1 share of session blocked on subagents
-    readonly subagents: ReadonlyArray<SessionOrchestrationSubagent>;
-}
-
-export interface SessionCanvasEdge {
-    readonly source: string;
-    readonly target: string;
-    readonly relation: string;          // 'spawned'
-    readonly label: string | null;      // subagent nickname when present
-}
-
-export interface SessionCanvasPayload {
-    readonly generatedAt: string;
-    readonly nodes: ReadonlyArray<SessionCanvasNode>;
-    readonly edges: ReadonlyArray<SessionCanvasEdge>;
-    readonly warnings: ReadonlyArray<string>;
-}
-
-export interface RecallHit {
-    readonly turn_id: string;
-    readonly session_id: SessionId;
-    readonly project: string | null;
-    readonly source: string | null;
-    /** Session working directory - feeds the resume-command NavLink. */
-    readonly cwd: string | null;
-    readonly role: string | null;
-    readonly ts: string | null;
-    readonly snippet: string;
-}
-
-export interface RecallCommitHit {
-    readonly commit_id: string;     // record id
-    readonly sha: string;
-    readonly repo: string | null;   // stable repo key (repo field on commit)
-    readonly repository: string | null; // record id of repository node, if linked
-    readonly ts: string | null;
-    readonly snippet: string;       // commit message (highlighted)
-    readonly score: number;
-}
-
-export interface RecallSkillHit {
-    readonly skill_id: string;
-    readonly name: string;
-    readonly description: string | null;
-    readonly snippet: string;       // matched portion
-    readonly score: number;
-}
-
-export interface RecallResponse {
-    readonly q: string;
-    readonly hits: ReadonlyArray<RecallHit>;     // turns, unchanged
-    readonly commits: ReadonlyArray<RecallCommitHit>;  // empty when not requested
-    readonly skills: ReadonlyArray<RecallSkillHit>;    // empty when not requested
-    /** Back-compat: true when more results exist beyond what was returned in
-     *  any source - turns have more pages, OR commit/skill results were
-     *  limit-capped. */
-    readonly truncated: boolean;
-    /** Sum of matched records across ALL requested sources (turn + commit +
-     *  skill). When only turns are requested this equals the turn count
-     *  (back-compat). Per-source breakdown is in `total_counts`. */
-    readonly total_count: number;
-    /** Per-source total counts. */
-    readonly total_counts: {
-        readonly turn: number;
-        readonly commit: number;
-        readonly skill: number;
-    };
-    /** The slice that was returned (applies to turns). */
-    readonly window: { readonly offset: number; readonly limit: number };
-}
 
 // ---------------------------------------------------------------------------
 // Agent Wrapped: personality-led usage recap
@@ -806,70 +532,6 @@ export interface IngestEvent {
     readonly counts?: Record<string, number> | null;
     readonly raw?: unknown;
     readonly ts: string;
-}
-
-export interface SessionListRow {
-    readonly id: SessionId;
-    readonly project: string | null;
-    readonly source: string;
-    readonly cwd: string | null;
-    readonly model: string | null;
-    readonly started_at: string | null;
-    readonly ended_at: string | null;
-    /** True when a raw transcript pointer exists (session is inspectable). */
-    readonly has_raw_file: boolean;
-    /** From session_health.turns when a health row exists; 0 is a sentinel for
-     *  "no health data", not a literal zero-turn session. */
-    readonly turn_count: number;
-    /** Parent session id when this row was spawned by another session (e.g. a
-     *  Claude subagent / Codex agent). Null for top-level sessions. Always
-     *  null on rows returned from `/api/sessions` (roots-only). Populated on
-     *  rows returned from `/api/sessions/:id/children`. */
-    readonly parent_session: SessionId | null;
-    /** Count of direct children (subagents) this session spawned. Used by the
-     *  SPA to render an expand toggle without first fetching children. Only
-     *  populated on roots returned from `/api/sessions`. */
-    readonly direct_children_count?: number;
-    /** Enrichment block - every field nullable: aggregate rows may not exist
-     *  for a session (pre-backfill ingests, 8s hook-probes, foreign sources).
-     *  Sourced from session_health / session_token_usage / session_metrics
-     *  batch lookups - NEVER from turn-table scans. */
-    readonly cost_usd: number | null;
-    /** Downsampled per-turn estimated tokens (≤20 buckets) for the BURN
-     *  sparkline. Null when the ingest predates burn_buckets backfill. */
-    readonly burn_buckets: ReadonlyArray<number> | null;
-    /** user_corrections + tool_errors. Null when no session_health row. */
-    readonly friction: number | null;
-    /** 'clean' = health row exists and friction is 0. Null = no health data. */
-    readonly signal: "clean" | "friction" | null;
-    /** Commit/LOC outcome from session_metrics (git-derived at ingest). */
-    readonly produced_commits: number | null;
-    readonly reverted_commits: number | null;
-    readonly lines_added: number | null;
-    readonly lines_removed: number | null;
-    /** ended_at is null AND the latest health derive write is recent - the
-     *  watcher re-ingests live transcripts within ~1 min, so a fresh
-     *  session_health.ts is the cheapest liveness proxy. */
-    readonly is_live: boolean;
-}
-
-export interface SessionListResponse {
-    /** Root sessions only - those with no inbound `spawned` edge. To get a
-     *  root's children, call `/api/sessions/:id/children`. */
-    readonly sessions: ReadonlyArray<SessionListRow>;
-    /** Total root count for the active filter set (independent of window). */
-    readonly total_count: number;
-    /** The user's 30-day p90 per-turn token burn. The SPA colors sparkline
-     *  buckets amber only above this threshold. Null when no usage history. */
-    readonly burn_p90: number | null;
-    /** The slice that was returned. Stays pinned to the first page on the
-     *  SPA side when subsequent pages are appended to the same cache key. */
-    readonly window: { readonly offset: number; readonly limit: number };
-}
-
-export interface SessionChildrenResponse {
-    readonly parent_session: SessionId;
-    readonly children: ReadonlyArray<SessionListRow>;
 }
 
 /** Wire format for `/api/sessions/:id/insights` - the expandable insight


### PR DESCRIPTION
ADR-0013 made every daemon endpoint serve from the Effect `HttpApi` contract, but the studio never actually *received* those types — the transport seam erased them. Closes #355.

## 1. Infer contract types through `viaContract`
`viaContract<T>` cast every response `as T` to the hand-written `dashboard-types` interface, so `useQuery(() => api.recall(...))` got `dashboard-types.RecallResponse`, **not** the contract's validated type.

- `viaContract<A, E>` now **infers** the response type from the `HttpApiClient` call (`runContract` already returns `Promise<A>`); the **24 typed endpoints** drop their `: Promise<T>` annotations and flow the real contract type to consumers.
- `viaContractUnknown<T>` is the single, greppable seam for the **25 endpoints** whose contract response is `Schema.Unknown` on purpose (raw-row passthroughs, mega-payloads, `RecordId` payloads). They keep the explicit dashboard-types assert — migrate one off this helper if/when its payload is tightened.

## 2. Dedupe — api-contract is the single source of truth
The tightened payloads existed **twice** (contract `Schema.Struct` + dashboard-types interface), identical today and free to drift.

- `api-contract.ts`: added derived `export type X = typeof X.Type` for the 25 payloads + nested twins (`SkillTriageEntry`, `SessionCompareTurn/Winners`, `SessionCanvasEdge`, `SkillGraphNode/Edge`, …).
- `dashboard-types.ts`: deleted 32 duplicate interfaces, re-export the names from the contract (**−389 lines**). Hand-written types for the `Schema.Unknown` endpoints stay.

## 3. SessionId brand
Resolved: `SessionId` is `type SessionId = string` — a **no-op alias**, not a real TS brand (no runtime protection; every consumer use is display-only via `shortSessionId(string)`). Deduped types adopt the contract's plain `string`; the alias is kept for the remaining hand-written `Schema.Unknown` payloads. No edge casts needed.

## Why it's a structural no-op for consumers
The only prior diffs between each twin were the `SessionId` alias (= `string`) and readonly modifiers (Schema types are already readonly). `SessionCompareEntry.source` was `"claude"|"codex"|string` which TS collapses to `string`. So consumers compile unchanged.

## Verification
- 13 contract `*-encode.test.ts` guards (the only CI guard — no DB) pass: recall/sessions/skills/insights.
- Whole-repo typecheck: **zero new errors** (pre-existing worktree dep-gaps `@effect/platform-bun` / `@durable-streams` and pre-existing implicit-`any`s are unchanged and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)