### PR TITLE
feat: content-type classification of tool outputs + read-path facets

### DIFF
--- a/apps/axctl/src/cli/commands/recall.test.ts
+++ b/apps/axctl/src/cli/commands/recall.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for recall command helpers.
+ *
+ * parseTypeFlag is not directly testable because fail() calls process.exit(2).
+ * We export validateTypes as a pure function and test that instead, then test
+ * the null-input branch of parseTypeFlag (which is safe - it never calls fail).
+ */
+import { describe, expect, test } from "bun:test";
+import { validateTypes, parseTypeFlag } from "./recall.ts";
+
+describe("validateTypes", () => {
+    test("accepts valid known categories", () => {
+        expect(validateTypes(["code", "json"])).toEqual({ ok: true, types: ["code", "json"] });
+    });
+
+    test("rejects unknown categories", () => {
+        expect(validateTypes(["code", "bogus"])).toEqual({ ok: false, invalid: ["bogus"] });
+    });
+
+    test("rejects multiple unknown categories", () => {
+        const result = validateTypes(["code", "bogus", "nope"]);
+        expect(result).toEqual({ ok: false, invalid: ["bogus", "nope"] });
+    });
+
+    test("accepts empty array", () => {
+        expect(validateTypes([])).toEqual({ ok: true, types: [] });
+    });
+
+    test("accepts all valid categories", () => {
+        const allValid = ["json", "code", "diff", "markdown", "yaml", "config",
+            "log", "filelist", "text", "binary", "empty", "unknown"];
+        const result = validateTypes(allValid);
+        expect(result).toEqual({ ok: true, types: allValid });
+    });
+});
+
+describe("parseTypeFlag", () => {
+    test("returns null for null input", () => {
+        expect(parseTypeFlag(null)).toBeNull();
+    });
+
+    test("returns null for empty string", () => {
+        expect(parseTypeFlag("")).toBeNull();
+    });
+});

--- a/apps/axctl/src/cli/commands/recall.ts
+++ b/apps/axctl/src/cli/commands/recall.ts
@@ -14,8 +14,10 @@ import { fetchRecall, normalizeRecallParams, resolveRecallSources, type RecallSo
 import { resolvePwdRepository } from "../../pwd.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, parseCsvFlag } from "./shared.ts";
+import { ALL_CONTENT_CATEGORIES } from "../../ingest/content-type-classify.ts";
 
 const VALID_SOURCES: ReadonlySet<string> = new Set(["turn", "commit", "skill"]);
+const VALID_TYPES: ReadonlySet<string> = new Set<string>(ALL_CONTENT_CATEGORIES);
 
 function parseSourcesFlag(raw: string | null): ReadonlyArray<RecallSource> | null {
     if (!raw) return null;
@@ -27,6 +29,35 @@ function parseSourcesFlag(raw: string | null): ReadonlyArray<RecallSource> | nul
     return parts as ReadonlyArray<RecallSource>;
 }
 
+type ValidateTypesResult =
+    | { readonly ok: true; readonly types: ReadonlyArray<string> }
+    | { readonly ok: false; readonly invalid: ReadonlyArray<string> };
+
+/**
+ * Pure validator for content-type category names. Exported for unit tests
+ * because parseTypeFlag calls fail() which exits the process (not throwable).
+ */
+export function validateTypes(parts: ReadonlyArray<string>): ValidateTypesResult {
+    const invalid = parts.filter((p) => !VALID_TYPES.has(p));
+    if (invalid.length > 0) return { ok: false, invalid };
+    return { ok: true, types: parts };
+}
+
+/** Parse --type=csv flag into a validated list of content-type categories. */
+export function parseTypeFlag(raw: string | null): ReadonlyArray<string> | null {
+    if (!raw) return null;
+    const parts = parseCsvFlag(raw);
+    if (parts.length === 0) return null;
+    const result = validateTypes(parts);
+    if (!result.ok) {
+        fail(
+            `axctl recall: unknown content type(s): ${result.invalid.join(", ")}. ` +
+            `Valid: ${ALL_CONTENT_CATEGORIES.join(", ")}`,
+        );
+    }
+    return result.types;
+}
+
 interface RecallCliOpts {
     readonly query: string;
     readonly project: string | null;
@@ -34,6 +65,7 @@ interface RecallCliOpts {
     readonly since: string | null;
     readonly sources: string | null;
     readonly scopeFlag: string | null;
+    readonly type: string | null;
     readonly json: boolean;
 }
 
@@ -217,6 +249,7 @@ const cmdRecall = (opts: RecallCliOpts) =>
         const skill = yield* resolveSkill(opts.skill);
         const sources = parseSourcesFlag(opts.sources);
         const scope = yield* resolveScope(opts.scopeFlag);
+        const types = parseTypeFlag(opts.type);
         const result = yield* fetchRecall(normalizeRecallParams({
             q: opts.query,
             project,
@@ -224,6 +257,7 @@ const cmdRecall = (opts: RecallCliOpts) =>
             since: opts.since,
             ...(sources !== null ? { sources } : {}),
             scope,
+            ...(types !== null ? { types } : {}),
         }));
         const { hits, next } = buildRecallNext(result, {
             requestedSources: resolveRecallSources(sources),
@@ -310,9 +344,10 @@ export const recallCommand = Command.make(
         since: Flag.string("since").pipe(Flag.optional),
         sources: Flag.string("sources").pipe(Flag.optional),
         scope: Flag.string("scope").pipe(Flag.optional),
+        type: Flag.string("type").pipe(Flag.optional),
         json: jsonFlag,
     },
-    ({ query, project, skill, since, sources, scope, json }) =>
+    ({ query, project, skill, since, sources, scope, type, json }) =>
         cmdRecall({
             query: query.join(" "),
             project: Option.getOrNull(project),
@@ -320,12 +355,15 @@ export const recallCommand = Command.make(
             since: Option.getOrNull(since),
             sources: Option.getOrNull(sources),
             scopeFlag: Option.getOrNull(scope),
+            type: Option.getOrNull(type),
             json,
         }),
 ).pipe(
     Command.withDescription(
         "Cross-session text search (BM25). --sources=turn,commit,skill chooses record types (default turn). " +
         "--scope=here filters to the current repo (auto-detected); --scope=all overrides. " +
+        "--type=<csv> restricts turns to sessions whose tool outputs include the given content-type categories " +
+        "(e.g. --type=code,json; valid: json,code,diff,markdown,yaml,config,log,filelist,text,binary,empty,unknown). " +
         "--project=? / --skill=? opens an interactive picker. " +
         "See the ax:extract-workflow skill for narrating workflows behind shipped artifacts. " +
         "Output ends with a `next:` footer of copy-paste follow-up commands (drill into a session, resume it in its harness); --json carries the same links in a `next` field.",

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -203,8 +203,9 @@ describe("effect cli", () => {
         //    + githubPrStage (restored GitHub PR ingest - issue #172)
         //    + digestStage (push-value digest snapshot writer)
         //    + usageStage (usage-log ingest into ax_invocation)
-        //    + loadedSkillsStage (auto-load skill activation edges).
-        expect(resolveIngestStages(testRegistry, [])).toHaveLength(30);
+        //    + loadedSkillsStage (auto-load skill activation edges)
+        //    + contentTypesStage (content-type classification of tool outputs).
+        expect(resolveIngestStages(testRegistry, [])).toHaveLength(31);
     });
 
     test("resolveIngestStages: local agent provider stages can be selected", () => {
@@ -226,6 +227,7 @@ describe("effect cli", () => {
         expect([...keys].sort()).toEqual([
             "classifier-results",
             "closure",
+            "content-types",
             "derive-metrics",
             "digest",
             "harness",

--- a/apps/axctl/src/dashboard/recall.ts
+++ b/apps/axctl/src/dashboard/recall.ts
@@ -48,6 +48,12 @@ export interface RecallParams {
     readonly sources?: ReadonlyArray<RecallSource>;
     /** Repository scope. null / omitted = all. */
     readonly scope?: RecallScope;
+    /**
+     * Restrict turns to sessions whose tool outputs include at least one of
+     * these content-type categories. Prefiltered via the has_content edge
+     * (deref-free: session is denormalized on the edge). null / omitted = all.
+     */
+    readonly types?: ReadonlyArray<string> | null;
 }
 
 /**
@@ -94,6 +100,7 @@ export interface RecallQueryArgs {
     readonly limit?: number | null;
     readonly sources?: ReadonlyArray<RecallSource> | null;
     readonly scope?: RecallScope;
+    readonly types?: ReadonlyArray<string> | null;
 }
 
 /**
@@ -118,6 +125,7 @@ export const normalizeRecallParams = (args: RecallQueryArgs): RecallParams => ({
     limit: args.limit ?? RECALL_DEFAULT_LIMIT,
     ...(args.sources != null ? { sources: args.sources } : {}),
     ...(args.scope !== undefined ? { scope: args.scope } : {}),
+    ...(args.types != null ? { types: args.types } : {}),
 });
 
 export const emptyRecallResponse = (
@@ -181,6 +189,27 @@ export const fetchRecall = (
                         return { hits: [], total_count: 0 };
                     }
                     sessionFilterClause = `AND session IN [${ids.join(", ")}]`;
+                }
+
+                // Content-type filter: prefilter session ids via the has_content edge.
+                // The edge denormalizes `session` so this query is deref-free.
+                // Record ids are inlined as literals (alphanumeric category names
+                // are safe without quoting); bindings cannot carry record id arrays.
+                if (params.types && params.types.length > 0) {
+                    const typeLiterals = params.types.map((t) => `content_type:${t}`).join(", ");
+                    const typeRows = yield* db.query<[Array<{ sid: string }>]>(
+                        `SELECT type::string(session) AS sid FROM has_content WHERE session != NONE AND out IN [${typeLiterals}]`,
+                    );
+                    const typeIds = (typeRows?.[0] ?? [])
+                        .map((r) => r.sid)
+                        .filter((s) => s.length > 0);
+                    if (typeIds.length === 0) {
+                        return { hits: [], total_count: 0 };
+                    }
+                    const typeClause = `AND session IN [${typeIds.join(", ")}]`;
+                    sessionFilterClause = sessionFilterClause
+                        ? `${sessionFilterClause} ${typeClause}`
+                        : typeClause;
                 }
 
                 // Repository scope filter on turns: filter by session.repository.

--- a/apps/axctl/src/ingest/content-type-classify.test.ts
+++ b/apps/axctl/src/ingest/content-type-classify.test.ts
@@ -45,4 +45,16 @@ describe("classifyContentType", () => {
   test(".png -> binary", () => {
     expect(classifyContentType({ filePath: "x.png", output: "..." }).category).toBe("binary");
   });
+
+  test("dotfile path -> config, fineLabel dotfile", () => {
+    const r = classifyContentType({ filePath: "/x/.gitignore", output: "node_modules" });
+    expect(r.category).toBe("config");
+    expect(r.fineLabel).toBe("dotfile");
+  });
+
+  test("shebang sniff, no path -> code by sniff", () => {
+    const r = classifyContentType({ filePath: null, output: "#!/bin/bash\necho hi" });
+    expect(r.category).toBe("code");
+    expect(r.method).toBe("sniff");
+  });
 });

--- a/apps/axctl/src/ingest/content-type-classify.test.ts
+++ b/apps/axctl/src/ingest/content-type-classify.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { classifyContentType } from "./content-type-classify.ts";
+
+describe("classifyContentType", () => {
+  test("extension wins: .ts -> code, conf 0.95", () => {
+    const r = classifyContentType({ filePath: "/a/b.ts", output: "const x = 1;" });
+    expect(r.category).toBe("code");
+    expect(r.method).toBe("extension");
+    expect(r.confidence).toBe(0.95);
+    expect(r.fineLabel).toBe("ts");
+  });
+
+  test(".json -> json", () => {
+    expect(classifyContentType({ filePath: "x.json", output: "{}" }).category).toBe("json");
+  });
+
+  test("empty output -> empty regardless of path", () => {
+    expect(classifyContentType({ filePath: "x.ts", output: "   \n" }).category).toBe("empty");
+  });
+
+  test("no path, JSON-ish body -> json by sniff, conf 0.6", () => {
+    const r = classifyContentType({ filePath: null, output: '  [{"a":1}]' });
+    expect(r.category).toBe("json");
+    expect(r.method).toBe("sniff");
+    expect(r.confidence).toBe(0.6);
+  });
+
+  test("no path, diff markers -> diff", () => {
+    const r = classifyContentType({ filePath: null, output: "diff --git a/x b/x\n@@ -1 +1 @@" });
+    expect(r.category).toBe("diff");
+  });
+
+  test("grep-style hits -> filelist", () => {
+    const out = "src/a.ts:12: foo\nsrc/b.ts:4: bar\nsrc/c.ts:9: baz";
+    expect(classifyContentType({ filePath: null, output: out, toolName: "Grep" }).category).toBe("filelist");
+  });
+
+  test("plain prose -> text fallback, conf 0.4", () => {
+    const r = classifyContentType({ filePath: null, output: "the quick brown fox jumps" });
+    expect(r.category).toBe("text");
+    expect(r.method).toBe("fallback");
+    expect(r.confidence).toBe(0.4);
+  });
+
+  test(".png -> binary", () => {
+    expect(classifyContentType({ filePath: "x.png", output: "..." }).category).toBe("binary");
+  });
+});

--- a/apps/axctl/src/ingest/content-type-classify.ts
+++ b/apps/axctl/src/ingest/content-type-classify.ts
@@ -1,0 +1,109 @@
+/**
+ * Deterministic content-type classifier for tool_call outputs.
+ *
+ * Pure function - no Effect, no DB. The ingest stage calls this per row.
+ * Extension (from the tool input file_path) is the strongest, cheapest signal;
+ * a lightweight content sniff handles Bash/exec output that has no path; a text
+ * fallback closes the set. Magika (the spike probe) is deliberately absent -
+ * group-level categories from ext+sniff were the trustworthy part of the spike.
+ */
+
+export type ContentCategory =
+  | "json" | "code" | "diff" | "markdown" | "yaml" | "config"
+  | "log" | "filelist" | "text" | "binary" | "empty" | "unknown";
+
+export type ClassifyMethod = "extension" | "sniff" | "fallback";
+
+export interface ClassifyInput {
+  /** file_path pulled from the tool input_json (Read/Edit/Write/NotebookEdit); null otherwise */
+  readonly filePath: string | null;
+  /** the output text (output_excerpt is fine - sniff is prefix-tolerant) */
+  readonly output: string;
+  /** tool name, used only to bias Grep/Glob toward filelist */
+  readonly toolName?: string | null;
+}
+
+export interface ClassifyResult {
+  readonly category: ContentCategory;
+  readonly method: ClassifyMethod;
+  readonly confidence: number;
+  readonly fineLabel: string | null;
+}
+
+const CODE_EXT = new Set([
+  "ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "rs", "go", "java", "rb",
+  "c", "h", "cpp", "hpp", "cc", "cs", "swift", "kt", "scala", "clj", "ex",
+  "exs", "php", "sh", "bash", "zsh", "fish", "sql", "surql", "lua", "r",
+  "dart", "vue", "svelte", "css", "scss", "sass", "less", "html", "xml",
+]);
+const BINARY_EXT = new Set([
+  "png", "jpg", "jpeg", "gif", "webp", "ico", "pdf", "zip", "gz", "tar",
+  "wasm", "so", "dylib", "dll", "bin", "exe", "woff", "woff2", "ttf", "mp4", "mov",
+]);
+const EXT_CATEGORY: ReadonlyArray<[ReadonlyArray<string>, ContentCategory]> = [
+  [["json", "jsonl"], "json"],
+  [["md", "mdx"], "markdown"],
+  [["yaml", "yml"], "yaml"],
+  [["toml", "ini", "env", "conf", "cfg"], "config"],
+  [["log"], "log"],
+  [["csv", "tsv", "txt"], "text"],
+];
+const DOTFILES = new Set([".gitignore", ".npmignore", ".dockerignore", ".env", ".editorconfig"]);
+
+const extOf = (p: string): string => {
+  const base = p.split("/").pop() ?? p;
+  if (DOTFILES.has(base)) return "config__dotfile";
+  const i = base.lastIndexOf(".");
+  return i > 0 ? base.slice(i + 1).toLowerCase() : "";
+};
+
+const categoryForExt = (ext: string): ContentCategory | null => {
+  if (ext === "config__dotfile") return "config";
+  if (CODE_EXT.has(ext)) return "code";
+  if (BINARY_EXT.has(ext)) return "binary";
+  for (const [list, cat] of EXT_CATEGORY) {
+    if (list.includes(ext)) return cat;
+  }
+  return null;
+};
+
+const DIFF_RE = /^(diff --git |@@ |Index: |--- )/m;
+const GREP_HIT_RE = /^[^\s:]+:\d+:/;
+
+const sniff = (output: string, toolName: string | null | undefined): ContentCategory | null => {
+  const t = output.trimStart();
+  if (DIFF_RE.test(t)) return "diff";
+  if (t.startsWith("{") || t.startsWith("[")) return "json";
+  if (t.startsWith("#!")) return "code";
+  const lines = output.split("\n").filter((l) => l.length > 0).slice(0, 20);
+  if (lines.length >= 2) {
+    const hits = lines.filter((l) => GREP_HIT_RE.test(l)).length;
+    if (hits / lines.length >= 0.6) return "filelist";
+  }
+  if ((toolName === "Glob" || toolName === "Grep") && lines.length >= 2) return "filelist";
+  return null;
+};
+
+export const classifyContentType = (input: ClassifyInput): ClassifyResult => {
+  if (input.output.trim().length === 0) {
+    return { category: "empty", method: "extension", confidence: 1.0, fineLabel: null };
+  }
+  if (input.filePath) {
+    const ext = extOf(input.filePath);
+    const cat = ext ? categoryForExt(ext) : null;
+    if (cat) {
+      return { category: cat, method: "extension", confidence: 0.95, fineLabel: ext.replace("config__dotfile", "dotfile") };
+    }
+  }
+  const sniffed = sniff(input.output, input.toolName ?? null);
+  if (sniffed) {
+    return { category: sniffed, method: "sniff", confidence: 0.6, fineLabel: null };
+  }
+  return { category: "text", method: "fallback", confidence: 0.4, fineLabel: null };
+};
+
+/** The closed taxonomy - the derive stage upserts exactly these nodes. */
+export const ALL_CONTENT_CATEGORIES: ReadonlyArray<ContentCategory> = [
+  "json", "code", "diff", "markdown", "yaml", "config",
+  "log", "filelist", "text", "binary", "empty", "unknown",
+];

--- a/apps/axctl/src/ingest/content-type-classify.ts
+++ b/apps/axctl/src/ingest/content-type-classify.ts
@@ -12,7 +12,7 @@ export type ContentCategory =
   | "json" | "code" | "diff" | "markdown" | "yaml" | "config"
   | "log" | "filelist" | "text" | "binary" | "empty" | "unknown";
 
-export type ClassifyMethod = "extension" | "sniff" | "fallback";
+export type ClassifyMethod = "extension" | "sniff" | "fallback" | "empty";
 
 export interface ClassifyInput {
   /** file_path pulled from the tool input_json (Read/Edit/Write/NotebookEdit); null otherwise */
@@ -86,7 +86,7 @@ const sniff = (output: string, toolName: string | null | undefined): ContentCate
 
 export const classifyContentType = (input: ClassifyInput): ClassifyResult => {
   if (input.output.trim().length === 0) {
-    return { category: "empty", method: "extension", confidence: 1.0, fineLabel: null };
+    return { category: "empty", method: "empty", confidence: 1.0, fineLabel: null };
   }
   if (input.filePath) {
     const ext = extOf(input.filePath);

--- a/apps/axctl/src/ingest/derive-content-types.test.ts
+++ b/apps/axctl/src/ingest/derive-content-types.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { buildContentEdge, renderContentEdge, renderContentTypeNodes, type ContentEdgeSpec } from "./derive-content-types.ts";
+
+describe("buildContentEdge", () => {
+  test("derives category + denormalized session/bytes from a tool_call row", () => {
+    const e = buildContentEdge({
+      id: "tool_call:abc", session: "session:s1", name: "Read",
+      inputJson: '{"file_path":"/x/y.ts"}', outputExcerpt: "const a = 1;", bytes: 12, ts: "2026-06-17T00:00:00Z",
+    });
+    expect(e).toEqual({
+      toolCallId: "tool_call:abc", category: "code", session: "session:s1",
+      method: "extension", confidence: 0.95, fineLabel: "ts", bytes: 12, ts: "2026-06-17T00:00:00Z",
+    });
+  });
+
+  test("falls back to output sniff when input has no file_path", () => {
+    const e = buildContentEdge({
+      id: "tool_call:b", session: "session:s1", name: "Bash",
+      inputJson: '{"command":"ls"}', outputExcerpt: '[{"a":1}]', bytes: 9, ts: "2026-06-17T00:00:00Z",
+    });
+    expect(e.category).toBe("json");
+    expect(e.method).toBe("sniff");
+  });
+});
+
+describe("renderContentEdge", () => {
+  test("emits a deterministic RELATE keyed by tool_call id (idempotent re-runs)", () => {
+    const sql = renderContentEdge({
+      toolCallId: "tool_call:abc", category: "code", session: "session:s1",
+      method: "extension", confidence: 0.95, fineLabel: "ts", bytes: 12, ts: "2026-06-17T00:00:00Z",
+    });
+    expect(sql).toContain("->has_content:");
+    expect(sql).toContain("->content_type:");
+    expect(sql).toContain("bytes = 12");
+    expect(sql).toContain("confidence = 0.95");
+  });
+
+  test("returns null on an unkeyable id", () => {
+    expect(renderContentEdge({ toolCallId: "", category: "text" } as unknown as ContentEdgeSpec)).toBeNull();
+  });
+});
+
+describe("renderContentTypeNodes", () => {
+  test("upserts all 12 fixed category nodes", () => {
+    const stmts = renderContentTypeNodes();
+    expect(stmts.length).toBe(12);
+    expect(stmts[0]).toContain("UPSERT content_type:");
+  });
+});

--- a/apps/axctl/src/ingest/derive-content-types.test.ts
+++ b/apps/axctl/src/ingest/derive-content-types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildContentEdge, renderContentEdge, renderContentTypeNodes, type ContentEdgeSpec } from "./derive-content-types.ts";
+import { buildContentEdge, renderContentEdge, renderContentTypeNodes, type ContentEdgeSpec, type ToolCallRow } from "./derive-content-types.ts";
 
 describe("buildContentEdge", () => {
   test("derives category + denormalized session/bytes from a tool_call row", () => {
@@ -45,5 +45,42 @@ describe("renderContentTypeNodes", () => {
     const stmts = renderContentTypeNodes();
     expect(stmts.length).toBe(12);
     expect(stmts[0]).toContain("UPSERT content_type:");
+  });
+});
+
+describe("renderContentEdge - collision resistance", () => {
+  // Two tool_call ids that share more than 96 chars of common prefix (the old
+  // safeKeyPart truncation limit) must still produce DIFFERENT edge keys so that
+  // cursor/opencode ids from the same conversation never collide.
+  test("two ids sharing a 100+ char prefix produce different has_content edge keys", () => {
+    const base = "tool_call:" + "x".repeat(100);
+    const spec = (id: string): ContentEdgeSpec => ({
+      toolCallId: id,
+      category: "text",
+      session: "session:s1",
+      method: "fallback",
+      confidence: 0.5,
+      fineLabel: null,
+      bytes: 100,
+      ts: "2026-06-17T00:00:00Z",
+    });
+    const sql1 = renderContentEdge(spec(base + "a"));
+    const sql2 = renderContentEdge(spec(base + "b"));
+    expect(sql1).not.toBeNull();
+    expect(sql2).not.toBeNull();
+    const key1 = sql1!.match(/->has_content:`([^`]+)`/)?.[1];
+    const key2 = sql2!.match(/->has_content:`([^`]+)`/)?.[1];
+    expect(key1).toBeDefined();
+    expect(key2).toBeDefined();
+    expect(key1).not.toBe(key2);
+  });
+
+  test("same id always produces the same edge key (idempotent re-runs)", () => {
+    const row: ToolCallRow = {
+      id: "tool_call:abc123", session: "session:s1", name: "Bash",
+      inputJson: null, outputExcerpt: "hello", bytes: 5, ts: "2026-06-17T00:00:00Z",
+    };
+    const e = buildContentEdge(row);
+    expect(renderContentEdge(e)).toBe(renderContentEdge(e));
   });
 });

--- a/apps/axctl/src/ingest/derive-content-types.ts
+++ b/apps/axctl/src/ingest/derive-content-types.ts
@@ -1,0 +1,125 @@
+/**
+ * @stage derive-content-types
+ * @rationale Build a `has_content` edge from each `tool_call` to the closed
+ *   `content_type` taxonomy node that best describes its output. Extension
+ *   matching on the `file_path` from the tool input is the strongest signal;
+ *   a lightweight content sniff handles Bash/exec output that has no path; a
+ *   text fallback closes the set. Category nodes are a fixed closed taxonomy
+ *   (12 values) upserted once per ingest run. The edge is keyed by tool_call
+ *   id so re-runs are idempotent.
+ * @inputs `tool_call` rows: id, session, name, input_json, output_excerpt, bytes, ts
+ * @outputs `content_type` nodes (upsert, idempotent) + `has_content` edges
+ * @order after tool-calls
+ *
+ * Pure layer - no Effect, no DB calls. Task 4 wires this into the ingest stage.
+ */
+
+import {
+    recordKeyPart,
+    recordRef,
+    safeKeyPart,
+    surrealDate,
+    surrealString,
+} from "@ax/lib/shared/surreal";
+import {
+    ALL_CONTENT_CATEGORIES,
+    classifyContentType,
+    type ContentCategory,
+} from "./content-type-classify.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ToolCallRow {
+    readonly id: string;
+    readonly session: string | null;
+    readonly name: string | null;
+    readonly inputJson: string | null;
+    readonly outputExcerpt: string | null;
+    readonly bytes: number;
+    readonly ts: string;
+}
+
+export interface ContentEdgeSpec {
+    readonly toolCallId: string;
+    readonly category: ContentCategory;
+    readonly session: string | null;
+    readonly method: string;
+    readonly confidence: number;
+    readonly fineLabel: string | null;
+    readonly bytes: number;
+    readonly ts: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure derivation
+// ---------------------------------------------------------------------------
+
+/** Extract a file path from a JSON-encoded tool input (Read/Edit/Write/NotebookEdit). */
+const filePathFromInput = (inputJson: string | null): string | null => {
+    if (!inputJson) return null;
+    try {
+        const obj = JSON.parse(inputJson) as Record<string, unknown>;
+        const fp = obj["file_path"] ?? obj["path"] ?? obj["notebook_path"];
+        return typeof fp === "string" ? fp : null;
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * Derive a content-edge spec from a single tool_call row. Classifies the
+ * output and denormalizes session + bytes onto the edge for fast aggregation
+ * without a join.
+ */
+export const buildContentEdge = (row: ToolCallRow): ContentEdgeSpec => {
+    const r = classifyContentType({
+        filePath: filePathFromInput(row.inputJson),
+        output: row.outputExcerpt ?? "",
+        toolName: row.name,
+    });
+    return {
+        toolCallId: row.id,
+        category: r.category,
+        session: row.session,
+        method: r.method,
+        confidence: r.confidence,
+        fineLabel: r.fineLabel,
+        bytes: row.bytes,
+        ts: row.ts,
+    };
+};
+
+/** Upsert all 12 fixed taxonomy nodes. Idempotent; safe on every ingest run. */
+export const renderContentTypeNodes = (): string[] =>
+    ALL_CONTENT_CATEGORIES.map(
+        (c) =>
+            `UPSERT content_type:${c} SET category = ${surrealString(c)}, label = ${surrealString(c)};`,
+    );
+
+/**
+ * Render one `has_content` RELATE statement. The edge is keyed by the
+ * tool_call id so repeated ingest runs are idempotent (same tool_call ->
+ * same edge key -> RELATE upserts in place).
+ *
+ * Returns `null` when the tool_call id cannot be decomposed into a valid
+ * SurrealDB key (empty string, unrecognised shape).
+ */
+export const renderContentEdge = (e: ContentEdgeSpec): string | null => {
+    const tcKey = recordKeyPart(e.toolCallId, "tool_call");
+    if (!tcKey) return null;
+    const edgeKey = safeKeyPart(e.toolCallId);
+    const sessionKey = e.session ? recordKeyPart(e.session, "session") : null;
+    const sessionClause = sessionKey
+        ? `, session = ${recordRef("session", sessionKey)}`
+        : "";
+    const fineClause = e.fineLabel
+        ? `, fine_label = ${surrealString(e.fineLabel)}`
+        : "";
+    return (
+        `RELATE ${recordRef("tool_call", tcKey)}->${recordRef("has_content", edgeKey)}->content_type:${e.category} ` +
+        `SET method = ${surrealString(e.method)}, confidence = ${e.confidence}, bytes = ${e.bytes}, ` +
+        `ts = ${surrealDate(e.ts)}${sessionClause}${fineClause};`
+    );
+};

--- a/apps/axctl/src/ingest/derive-content-types.ts
+++ b/apps/axctl/src/ingest/derive-content-types.ts
@@ -9,12 +9,13 @@
  *   id so re-runs are idempotent.
  * @inputs `tool_call` rows: id, session, name, input_json, output_excerpt, bytes, ts
  * @outputs `content_type` nodes (upsert, idempotent) + `has_content` edges
- * @order after claude, codex
+ * @order after claude, codex, pi, cursor
  */
 
 import { Effect, Schema } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
+import { stableDigest } from "@ax/lib/ids";
 import {
     executeStatementsWith,
     recordKeyPart,
@@ -22,7 +23,13 @@ import {
     surrealDate,
     surrealString,
 } from "@ax/lib/shared/surreal";
-import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
+import {
+    BaseStageStats,
+    IngestContext,
+    StageMeta,
+    sinceDaysFromCtx,
+    sinceAndClause,
+} from "./stage/types.ts";
 import type { StageDef } from "./stage/registry.ts";
 import {
     ALL_CONTENT_CATEGORIES,
@@ -102,9 +109,9 @@ export const renderContentTypeNodes = (): string[] =>
     );
 
 /**
- * Render one `has_content` RELATE statement. The edge is keyed by the
- * tool_call id so repeated ingest runs are idempotent (same tool_call ->
- * same edge key -> RELATE upserts in place).
+ * Render one `has_content` RELATE statement. The edge is keyed by a stable
+ * digest of the full tool_call id, ensuring collision-free keys even for long
+ * cursor/opencode ids that share a 96+ char common prefix.
  *
  * Returns `null` when the tool_call id cannot be decomposed into a valid
  * SurrealDB key (empty string, unrecognised shape).
@@ -112,10 +119,10 @@ export const renderContentTypeNodes = (): string[] =>
 export const renderContentEdge = (e: ContentEdgeSpec): string | null => {
     const tcKey = recordKeyPart(e.toolCallId, "tool_call");
     if (!tcKey) return null;
-    // Use a hash of the full tool_call id as the edge key so that long cursor /
-    // opencode ids (which share long common prefixes) never collide when
-    // safeKeyPart would truncate them to the same 96-char string.
-    const edgeKey = `h${Bun.hash(e.toolCallId).toString(16)}`;
+    // h-prefix distinguishes these keys from the old safeKeyPart-truncated scheme
+    // used in the first watcher run; existing edges are found via ALREADY_SQL
+    // (reads the `in` field, not the edge key), so no migration is needed.
+    const edgeKey = `h${stableDigest(e.toolCallId)}`;
     const sessionKey = e.session ? recordKeyPart(e.session, "session") : null;
     const sessionClause = sessionKey
         ? `, session = ${recordRef("session", sessionKey)}`
@@ -138,11 +145,14 @@ export const renderContentEdge = (e: ContentEdgeSpec): string | null => {
 // Two flat queries (deref-free): already-classified id set, then the rows.
 // Edge ids are deterministic so re-running is a safe no-op upsert.
 const ALREADY_SQL = `SELECT type::string(in) AS tid FROM has_content;`;
-const ROWS_SQL = `
+
+/** ROWS_SQL scoped by an optional since window (watcher runs pass 1d; full
+ *  re-derives pass undefined to scan everything). */
+const rowsSql = (sinceDays: number | undefined): string => `
 SELECT type::string(id) AS id, type::string(session) AS session, name,
        input_json AS inputJson, output_excerpt AS outputExcerpt,
        string::len(output_json) AS bytes, type::string(ts) AS ts
-FROM tool_call WHERE output_json != NONE;
+FROM tool_call WHERE output_json != NONE${sinceAndClause(sinceDays)};
 `;
 
 export interface DeriveContentTypeStats {
@@ -150,7 +160,7 @@ export interface DeriveContentTypeStats {
     readonly skipped: number;
 }
 
-export const deriveContentTypes = (): Effect.Effect<
+export const deriveContentTypes = (sinceDays?: number): Effect.Effect<
     DeriveContentTypeStats,
     DbError,
     SurrealClient
@@ -159,7 +169,7 @@ export const deriveContentTypes = (): Effect.Effect<
         const db = yield* SurrealClient;
 
         const [already] = yield* db.query<[Array<{ tid: string }>]>(ALREADY_SQL);
-        const [rows] = yield* db.query<[Array<ToolCallRow>]>(ROWS_SQL);
+        const [rows] = yield* db.query<[Array<ToolCallRow>]>(rowsSql(sinceDays));
 
         const done = new Set((already ?? []).map((r) => r.tid));
         const stmts: string[] = renderContentTypeNodes();
@@ -190,18 +200,19 @@ export class ContentTypeStats extends BaseStageStats.extend<ContentTypeStats>(
 /**
  * Content-types stage - classifies tool_call outputs into a closed taxonomy and
  * writes has_content edges (denormalized session + bytes for deref-free reads).
+ * Depends on all four harness stages that produce tool_call rows.
  * Tags: derive.
  */
 export const contentTypesStage: StageDef<ContentTypeStats, SurrealClient> = {
     meta: StageMeta.make({
         key: "content-types",
-        deps: ["claude", "codex"],
+        deps: ["claude", "codex", "pi", "cursor"],
         tags: ["derive"],
     }),
-    run: (_ctx: IngestContext) =>
+    run: (ctx: IngestContext) =>
         Effect.gen(function* () {
             const t0 = Date.now();
-            const result = yield* deriveContentTypes();
+            const result = yield* deriveContentTypes(sinceDaysFromCtx(ctx));
             return ContentTypeStats.make({
                 durationMs: Date.now() - t0,
                 summary: `classified ${result.written} tool outputs (${result.skipped} already done)`,

--- a/apps/axctl/src/ingest/derive-content-types.ts
+++ b/apps/axctl/src/ingest/derive-content-types.ts
@@ -9,18 +9,21 @@
  *   id so re-runs are idempotent.
  * @inputs `tool_call` rows: id, session, name, input_json, output_excerpt, bytes, ts
  * @outputs `content_type` nodes (upsert, idempotent) + `has_content` edges
- * @order after tool-calls
- *
- * Pure layer - no Effect, no DB calls. Task 4 wires this into the ingest stage.
+ * @order after claude, codex
  */
 
+import { Effect, Schema } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
 import {
+    executeStatementsWith,
     recordKeyPart,
     recordRef,
-    safeKeyPart,
     surrealDate,
     surrealString,
 } from "@ax/lib/shared/surreal";
+import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
+import type { StageDef } from "./stage/registry.ts";
 import {
     ALL_CONTENT_CATEGORIES,
     classifyContentType,
@@ -109,7 +112,10 @@ export const renderContentTypeNodes = (): string[] =>
 export const renderContentEdge = (e: ContentEdgeSpec): string | null => {
     const tcKey = recordKeyPart(e.toolCallId, "tool_call");
     if (!tcKey) return null;
-    const edgeKey = safeKeyPart(e.toolCallId);
+    // Use a hash of the full tool_call id as the edge key so that long cursor /
+    // opencode ids (which share long common prefixes) never collide when
+    // safeKeyPart would truncate them to the same 96-char string.
+    const edgeKey = `h${Bun.hash(e.toolCallId).toString(16)}`;
     const sessionKey = e.session ? recordKeyPart(e.session, "session") : null;
     const sessionClause = sessionKey
         ? `, session = ${recordRef("session", sessionKey)}`
@@ -122,4 +128,85 @@ export const renderContentEdge = (e: ContentEdgeSpec): string | null => {
         `SET method = ${surrealString(e.method)}, confidence = ${e.confidence}, bytes = ${e.bytes}, ` +
         `ts = ${surrealDate(e.ts)}${sessionClause}${fineClause};`
     );
+};
+
+// ---------------------------------------------------------------------------
+// Stage
+// ---------------------------------------------------------------------------
+
+// Incremental: classify only tool_calls with no has_content edge yet.
+// Two flat queries (deref-free): already-classified id set, then the rows.
+// Edge ids are deterministic so re-running is a safe no-op upsert.
+const ALREADY_SQL = `SELECT type::string(in) AS tid FROM has_content;`;
+const ROWS_SQL = `
+SELECT type::string(id) AS id, type::string(session) AS session, name,
+       input_json AS inputJson, output_excerpt AS outputExcerpt,
+       string::len(output_json) AS bytes, type::string(ts) AS ts
+FROM tool_call WHERE output_json != NONE;
+`;
+
+export interface DeriveContentTypeStats {
+    readonly written: number;
+    readonly skipped: number;
+}
+
+export const deriveContentTypes = (): Effect.Effect<
+    DeriveContentTypeStats,
+    DbError,
+    SurrealClient
+> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+
+        const [already] = yield* db.query<[Array<{ tid: string }>]>(ALREADY_SQL);
+        const [rows] = yield* db.query<[Array<ToolCallRow>]>(ROWS_SQL);
+
+        const done = new Set((already ?? []).map((r) => r.tid));
+        const stmts: string[] = renderContentTypeNodes();
+        let written = 0;
+        let skipped = 0;
+        for (const row of rows ?? []) {
+            if (done.has(row.id)) {
+                skipped += 1;
+                continue;
+            }
+            const sql = renderContentEdge(buildContentEdge(row));
+            if (sql) {
+                stmts.push(sql);
+                written += 1;
+            }
+        }
+        yield* executeStatementsWith(db, stmts, { chunkSize: 250, label: "contentEdges" });
+        return { written, skipped } satisfies DeriveContentTypeStats;
+    });
+
+export class ContentTypeStats extends BaseStageStats.extend<ContentTypeStats>(
+    "ContentTypeStats",
+)({
+    written: Schema.Number,
+    skipped: Schema.Number,
+}) {}
+
+/**
+ * Content-types stage - classifies tool_call outputs into a closed taxonomy and
+ * writes has_content edges (denormalized session + bytes for deref-free reads).
+ * Tags: derive.
+ */
+export const contentTypesStage: StageDef<ContentTypeStats, SurrealClient> = {
+    meta: StageMeta.make({
+        key: "content-types",
+        deps: ["claude", "codex"],
+        tags: ["derive"],
+    }),
+    run: (_ctx: IngestContext) =>
+        Effect.gen(function* () {
+            const t0 = Date.now();
+            const result = yield* deriveContentTypes();
+            return ContentTypeStats.make({
+                durationMs: Date.now() - t0,
+                summary: `classified ${result.written} tool outputs (${result.skipped} already done)`,
+                written: result.written,
+                skipped: result.skipped,
+            });
+        }),
 };

--- a/apps/axctl/src/ingest/stage/registry.ts
+++ b/apps/axctl/src/ingest/stage/registry.ts
@@ -31,6 +31,7 @@ import { retroProposalsStage } from "../derive-retro-proposals.ts";
 import { harnessStage } from "../harness.ts";
 import { digestStage } from "../../digest/digest-stage.ts";
 import { usageStage } from "../../usage/usage-stage.ts";
+import { contentTypesStage } from "../derive-content-types.ts";
 
 export type { StageDef } from "./types.ts";
 
@@ -60,7 +61,7 @@ export const StageRegistryLive = (
     });
 
 /** The canonical list of stages provided by `StageRegistryDefault`. */
-export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, pricingStage, claudeStage, codexStage, piStage, opencodeStage, cursorStage, subagentsStage, invokedPositionsStage, spawnedStage, loadedSkillsStage, gitStage, githubPrStage, signalsStage, outcomesStage, turnContentBlocksStage, turnAnalysisStage, reactionEventsStage, classifierResultsStage, sessionHealthStage, closureStage, deriveMetricsStage, proposalsStage, opportunitiesStage, retroProposalsStage, harnessStage, digestStage, usageStage] as const;
+export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, pricingStage, claudeStage, codexStage, piStage, opencodeStage, cursorStage, subagentsStage, invokedPositionsStage, spawnedStage, loadedSkillsStage, gitStage, githubPrStage, signalsStage, outcomesStage, turnContentBlocksStage, turnAnalysisStage, reactionEventsStage, classifierResultsStage, sessionHealthStage, closureStage, deriveMetricsStage, proposalsStage, opportunitiesStage, retroProposalsStage, harnessStage, digestStage, usageStage, contentTypesStage] as const;
 
 /** Production registry: the canonical list of stages provided by ax. Test code
  *  should prefer `StageRegistryLive([...])` with explicit fixtures. */

--- a/apps/axctl/src/profile/render.test.ts
+++ b/apps/axctl/src/profile/render.test.ts
@@ -9,9 +9,11 @@ import { buildProfile } from "./render.ts";
 // 10 sessionDurations  11 peakHour  12 spawnedCount  13 commitCount  14 topTools
 // 15 wrappedCounts(toolAgg)  16 wrappedCounts(turnCount)
 // 17 wrappedCounts(distinctSkills)  18 wrappedCounts(reposCount)
+// 18b wrappedCounts(verifyAgg)
 // 19 dailyModels  20 dailyToolCalls  21 dailyCommits
 // 22 windowedInvocations  23 windowedSessions
 // 24 deepSessions:total  25 deepSessions:produced  26 deepSessions:landed-loc
+// 27 contentTypeBreakdown
 const mockResults = [
     [[{ prompt_tokens: 31_000_000, completion_tokens: 7_000_000, sessions: 142 }]],
     [[{ date: "2026-06-11" }, { date: "2026-06-12" }]],
@@ -90,6 +92,11 @@ const mockResults = [
     [[
         { commit: "commit:abc", loc: 120 },
         { commit: "commit:def", loc: 0 },
+    ]],
+    // 27: contentTypeBreakdown
+    [[
+        { ct: "content_type:code", calls: 10, bytes: 800 },
+        { ct: "content_type:text", calls: 5, bytes: 200 },
     ]],
 ];
 
@@ -181,9 +188,17 @@ describe("buildProfile", () => {
         expect(p.stats.models[0]).toEqual({ name: "fable", share: 100 / 142 });
     });
 
-    test("no proposals -> taste omitted", async () => {
+    test("no proposals -> taste has only the mix pattern from content types", async () => {
         const noProposals = mockResults.map((r, i) => (i === 5 ? [[]] : r));
         const db = makeMockDb(noProposals);
+        const p = await runWithMock(db, buildProfile({ windowDays: 30, includeCost: true, env }));
+        expect(p.taste?.patterns).toHaveLength(1);
+        expect(p.taste?.patterns[0]?.category).toBe("tool-output-mix");
+    });
+
+    test("no proposals + no content types -> taste omitted", async () => {
+        const noTaste = mockResults.map((r, i) => (i === 5 || i === 27 ? [[]] : r));
+        const db = makeMockDb(noTaste);
         const p = await runWithMock(db, buildProfile({ windowDays: 30, includeCost: true, env }));
         expect(p.taste).toBeUndefined();
     });

--- a/apps/axctl/src/profile/render.ts
+++ b/apps/axctl/src/profile/render.ts
@@ -6,6 +6,7 @@
  * hook files, rules text) is injected so the Effect needs only SurrealClient.
  */
 import { Effect } from "effect";
+import { fetchContentTypeBreakdown } from "../queries/content-types.ts";
 import { fetchCostModels } from "../queries/cost-analytics.ts";
 import {
     fetchAcceptedProposals,
@@ -31,7 +32,7 @@ import {
 import { deriveInsights } from "./insights.ts";
 import { deriveRig } from "./rig.ts";
 import { computeStreak } from "./streak.ts";
-import { deriveTastePatterns } from "./taste.ts";
+import { buildToolOutputMixPattern, deriveTastePatterns } from "./taste.ts";
 import { decodeProfile, type ProfileV1 } from "./schema.ts";
 import { deriveWorkflowArcs } from "./workflow.ts";
 import { computeDownstreamShares } from "./downstream.ts";
@@ -60,9 +61,11 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         // 5 skillScopes  6 acceptedProposals  7 costModels
         // 8+9 dailyActivityFull (sessions, tokens)  10 sessionDurations
         // 11 peakHour  12 spawnedCount  13 commitCount  14 topTools
-        // 15+16+17+18 wrappedCounts (toolAgg, turnCount, distinctSkills, reposCount)
+        // 15+16+17+18+18b wrappedCounts (toolAgg, turnCount, distinctSkills, reposCount, verifyAgg)
         // 19 dailyModels  20 dailyToolCalls  21 dailyCommits
         // 22 windowedInvocations  23 windowedSessions
+        // 24 deepSessions:total  25 deepSessions:produced  26 deepSessions:landed-loc
+        // 27 contentTypeBreakdown
         const totals = yield* fetchTokenTotals({ windowDays });
         const daily = yield* fetchDailyActivity({ windowDays });
         const harnesses = yield* fetchHarnesses({ windowDays });
@@ -84,9 +87,10 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         const windowedInvocations = yield* fetchWindowedInvocations({ windowDays });
         const windowedSessions = yield* fetchWindowedSessions({ windowDays });
         // 24 deepSessions (outcome-density DEPTH numerator + non-subagent
-        // denominator; appended last so existing render.test mock order stays
-        // aligned). Internally fans out: total-count -> produced -> landed-loc.
+        // denominator). Internally fans out: total-count -> produced -> landed-loc.
         const deep = yield* fetchDeepSessionCount({ windowDays });
+        // 27 content-type breakdown (appended last; keeps mock order in render.test.ts aligned)
+        const contentTypes = yield* fetchContentTypeBreakdown();
 
         const streak = computeStreak(daily, env.today);
 
@@ -105,6 +109,8 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         });
 
         const patterns = deriveTastePatterns(proposals);
+        const mixPattern = buildToolOutputMixPattern(contentTypes, totals.sessions);
+        if (mixPattern !== null) patterns.push(mixPattern);
 
         // null when there is no data at all -> section omitted below.
         const insights = deriveInsights({

--- a/apps/axctl/src/profile/schema.test.ts
+++ b/apps/axctl/src/profile/schema.test.ts
@@ -147,6 +147,7 @@ describe("decodeProfile", () => {
             "failure-mode",
             "problem-solving-strategy",
             "stack-choice",
+            "tool-output-mix",
             "workflow",
         ]);
     });

--- a/apps/axctl/src/profile/schema.ts
+++ b/apps/axctl/src/profile/schema.ts
@@ -13,6 +13,7 @@ export const PATTERN_CATEGORIES = [
     "debugging",
     "failure-mode",
     "workflow",
+    "tool-output-mix",
     "stack-choice",
 ] as const;
 export type PatternCategory = (typeof PATTERN_CATEGORIES)[number];
@@ -39,6 +40,7 @@ const ProsePattern = Schema.Struct({
         "debugging",
         "failure-mode",
         "workflow",
+        "tool-output-mix",
     ]),
     name: Schema.String,
     summary: Schema.String,

--- a/apps/axctl/src/profile/taste.test.ts
+++ b/apps/axctl/src/profile/taste.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { deriveTastePatterns, parseConfidence, slugify } from "./taste.ts";
+import { buildToolOutputMixPattern, deriveTastePatterns, parseConfidence, slugify } from "./taste.ts";
+import type { ContentTypeBreakdown } from "../queries/content-types.ts";
 import type { ProposalRow } from "./queries.ts";
 
 const row = (over: Partial<ProposalRow>): ProposalRow => ({
@@ -66,5 +67,37 @@ describe("deriveTastePatterns", () => {
         ]);
         expect(out).toHaveLength(1);
         expect(out[0]!.evidence.sessions).toBe(9);
+    });
+});
+
+describe("buildToolOutputMixPattern", () => {
+    const breakdown: ContentTypeBreakdown = {
+        rows: [
+            { category: "code", calls: 10, bytes: 800, estTokens: 200, tokenShare: 0.8 },
+            { category: "text", calls: 5, bytes: 200, estTokens: 50, tokenShare: 0.2 },
+        ],
+        totals: { calls: 15, bytes: 1000, estTokens: 250 },
+    };
+
+    test("builds a tool-output-mix pattern from the content breakdown", () => {
+        const p = buildToolOutputMixPattern(breakdown, 42);
+        expect(p?.category).toBe("tool-output-mix");
+        expect(p?.summary).toContain("code");
+    });
+
+    test("encodes lead share in summary", () => {
+        const p = buildToolOutputMixPattern(breakdown, 42);
+        expect(p?.summary).toContain("80%");
+    });
+
+    test("returns null when breakdown has no rows", () => {
+        const empty: ContentTypeBreakdown = { rows: [], totals: { calls: 0, bytes: 0, estTokens: 0 } };
+        expect(buildToolOutputMixPattern(empty, 10)).toBeNull();
+    });
+
+    test("evidence reflects the sessions argument", () => {
+        const p = buildToolOutputMixPattern(breakdown, 7);
+        expect(p?.evidence.sessions).toBe(7);
+        expect(p?.evidence.confidence).toBe(0.9);
     });
 });

--- a/apps/axctl/src/profile/taste.ts
+++ b/apps/axctl/src/profile/taste.ts
@@ -10,6 +10,7 @@
  * the publish path MUST scrub or require per-pattern confirmation before
  * this text leaves the machine.
  */
+import type { ContentTypeBreakdown } from "../queries/content-types.ts";
 import type { ProposalRow } from "./queries.ts";
 import type { TastePattern } from "./schema.ts";
 
@@ -46,6 +47,25 @@ const FORM_TO_CATEGORY: Record<string, ProseCategory> = {
 };
 
 const dayOf = (iso: string): string => iso.slice(0, 10);
+
+/**
+ * Derive a tool-output-mix pattern from the global content-type breakdown.
+ * Returns null when the breakdown is empty (taste section stays omitted).
+ */
+export function buildToolOutputMixPattern(
+    breakdown: ContentTypeBreakdown,
+    sessions: number,
+) {
+    const top = breakdown.rows.slice(0, 3);
+    if (top.length === 0) return null;
+    const lead = top[0]!;
+    return {
+        category: "tool-output-mix" as const,
+        name: `${lead.category}-heavy context`,
+        summary: `Context is ${Math.round(lead.tokenShare * 100)}% ${lead.category} by tokens (${top.map((r) => r.category).join(", ")}).`,
+        evidence: { sessions, confidence: 0.9 },
+    };
+}
 
 export function deriveTastePatterns(rows: ReadonlyArray<ProposalRow>): TastePattern[] {
     const byName = new Map<string, { row: ProposalRow; pattern: TastePattern }>();

--- a/apps/axctl/src/queries/content-types.test.ts
+++ b/apps/axctl/src/queries/content-types.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { rollupContentTypes, BYTES_PER_TOKEN } from "./content-types.ts";
+
+describe("rollupContentTypes", () => {
+  test("aggregates calls + bytes + token share by category", () => {
+    const out = rollupContentTypes([
+      { ct: "content_type:code", calls: 3, bytes: 400 },
+      { ct: "content_type:text", calls: 1, bytes: 400 },
+    ]);
+    expect(out.rows).toEqual([
+      { category: "code", calls: 3, bytes: 400, estTokens: 100, tokenShare: 0.5 },
+      { category: "text", calls: 1, bytes: 400, estTokens: 100, tokenShare: 0.5 },
+    ]);
+    expect(out.totals).toEqual({ calls: 4, bytes: 800, estTokens: 200 });
+  });
+
+  test("sorts by est tokens desc and strips the content_type: prefix", () => {
+    const out = rollupContentTypes([
+      { ct: "content_type:text", calls: 1, bytes: 100 },
+      { ct: "content_type:code", calls: 1, bytes: 900 },
+    ]);
+    expect(out.rows.map((r) => r.category)).toEqual(["code", "text"]);
+  });
+
+  test("BYTES_PER_TOKEN matches the context-budget ratio", () => {
+    expect(BYTES_PER_TOKEN).toBe(4);
+  });
+});

--- a/apps/axctl/src/queries/content-types.ts
+++ b/apps/axctl/src/queries/content-types.ts
@@ -1,0 +1,108 @@
+/**
+ * Content-type rollups over the has_content edge. Deref-free: the edge
+ * denormalizes bytes + session, so every aggregate is a flat GROUP BY (the
+ * house idiom - record derefs inside aggregates over large edge tables hang
+ * production). Shared by context-budget, cost split, and the profile facet.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export const BYTES_PER_TOKEN = 4; // shared with skill-bloat + context-budget
+const estTokens = (bytes: number): number => Math.round(bytes / BYTES_PER_TOKEN);
+
+export interface ContentTypeRow {
+  readonly category: string;
+  readonly calls: number;
+  readonly bytes: number;
+  readonly estTokens: number;
+  readonly tokenShare: number; // 0..1 of total est tokens
+}
+
+export interface ContentTypeBreakdown {
+  readonly rows: ReadonlyArray<ContentTypeRow>;
+  readonly totals: { readonly calls: number; readonly bytes: number; readonly estTokens: number };
+}
+
+interface RawCtRow { readonly ct: string; readonly calls: number; readonly bytes: number }
+
+// ---------------------------------------------------------------------------
+// Pure aggregation - unit tested independently of the DB
+// ---------------------------------------------------------------------------
+
+/** Pure aggregation - unit tested. */
+export const rollupContentTypes = (raw: ReadonlyArray<RawCtRow>): ContentTypeBreakdown => {
+  const totalBytes = raw.reduce((a, r) => a + Number(r.bytes ?? 0), 0);
+  const rows = raw
+    .map((r) => {
+      const bytes = Number(r.bytes ?? 0);
+      const tok = estTokens(bytes);
+      return {
+        category: r.ct.replace(/^content_type:/, ""),
+        calls: Number(r.calls ?? 0),
+        bytes,
+        estTokens: tok,
+        tokenShare: totalBytes > 0 ? bytes / totalBytes : 0,
+      };
+    })
+    .sort((a, b) => b.estTokens - a.estTokens);
+  return {
+    rows,
+    totals: {
+      calls: rows.reduce((a, r) => a + r.calls, 0),
+      bytes: totalBytes,
+      estTokens: estTokens(totalBytes),
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// SQL - deref-free flat GROUP BY (no record derefs inside aggregates)
+// ---------------------------------------------------------------------------
+
+const DISTRIBUTION_SQL = `
+SELECT type::string(out) AS ct, count() AS calls, math::sum(bytes) AS bytes
+FROM has_content GROUP BY ct;
+`;
+
+/** Global content-type distribution. */
+export const fetchContentTypeBreakdown = Effect.fn("queries.fetchContentTypeBreakdown")(
+  function* () {
+    const db = yield* SurrealClient;
+    const [raw] = yield* db.query<[Array<RawCtRow>]>(DISTRIBUTION_SQL);
+    return rollupContentTypes(raw ?? []);
+  },
+);
+
+const PER_SESSION_SQL = `
+SELECT type::string(session) AS sid, type::string(out) AS ct,
+       count() AS calls, math::sum(bytes) AS bytes
+FROM has_content WHERE session != NONE GROUP BY sid, ct;
+`;
+
+export interface SessionContentMix {
+  readonly sessionId: string;
+  readonly mix: ContentTypeBreakdown;
+}
+
+/** Per-session content-type mix (token-weighted). */
+export const fetchSessionContentMix = Effect.fn("queries.fetchSessionContentMix")(
+  function* () {
+    const db = yield* SurrealClient;
+    const [raw] = yield* db.query<[Array<{ sid: string; ct: string; calls: number; bytes: number }>]>(
+      PER_SESSION_SQL,
+    );
+    const bySession = new Map<string, RawCtRow[]>();
+    for (const r of raw ?? []) {
+      const arr = bySession.get(r.sid) ?? [];
+      arr.push({ ct: r.ct, calls: r.calls, bytes: r.bytes });
+      bySession.set(r.sid, arr);
+    }
+    return Array.from(bySession.entries()).map(
+      ([sessionId, rows]) => ({ sessionId, mix: rollupContentTypes(rows) }) satisfies SessionContentMix,
+    );
+  },
+);

--- a/apps/axctl/src/queries/context-budget.test.ts
+++ b/apps/axctl/src/queries/context-budget.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import type { ContextBudgetResult } from "./context-budget.ts";
+
+describe("ContextBudgetResult", () => {
+  test("carries a contentTypes breakdown field", () => {
+    const sample: ContextBudgetResult["contentTypes"] = {
+      rows: [{ category: "code", calls: 1, bytes: 4, estTokens: 1, tokenShare: 1 }],
+      totals: { calls: 1, bytes: 4, estTokens: 1 },
+    };
+    expect(sample.rows[0].category).toBe("code");
+  });
+});

--- a/apps/axctl/src/queries/context-budget.ts
+++ b/apps/axctl/src/queries/context-budget.ts
@@ -20,6 +20,7 @@
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { normalizeLastUsed, UNUSED_RECENT_SQL, UNUSED_SUMMARY_SQL } from "./unused-skills.ts";
+import { fetchContentTypeBreakdown, type ContentTypeBreakdown } from "./content-types.ts";
 
 const WINDOW_DAYS = 30;
 const CHARS_PER_TOKEN = 4;
@@ -84,6 +85,8 @@ export interface ContextBudgetResult {
     readonly skills: ReadonlyArray<SkillBudgetRow>;
     /** Per-source rollup, heaviest index first. */
     readonly sources: ReadonlyArray<SourceBudgetRow>;
+    /** content-type distribution of tool outputs (token-weighted). */
+    readonly contentTypes: ContentTypeBreakdown;
     readonly totals: {
         readonly skills: number;
         readonly index_chars: number;
@@ -120,11 +123,12 @@ export const fetchContextBudget = Effect.fn("queries.fetchContextBudget")(
         const db = yield* SurrealClient;
         // budget rows + bulk usage (per skill id) over the invoked edge table,
         // computed deref-free - see unused-skills.ts for the perf rationale.
-        const [rawRes, summaryRes, recentRes] = yield* Effect.all([
+        const [rawRes, summaryRes, recentRes, contentTypes] = yield* Effect.all([
             db.query<[Array<Record<string, unknown>>]>(BUDGET_SQL),
             db.query<[Array<Record<string, unknown>>]>(UNUSED_SUMMARY_SQL),
             db.query<[Array<Record<string, unknown>>]>(UNUSED_RECENT_SQL(WINDOW_DAYS)),
-        ], { concurrency: 3 });
+            fetchContentTypeBreakdown(),
+        ], { concurrency: 4 });
         const raw = rawRes?.[0] ?? [];
 
         const usageById = new Map<string, { uses: number; last: string | null }>();
@@ -218,7 +222,7 @@ export const fetchContextBudget = Effect.fn("queries.fetchContextBudget")(
             window_days: WINDOW_DAYS,
         };
 
-        return { skills, sources, totals } satisfies ContextBudgetResult;
+        return { skills, sources, totals, contentTypes } satisfies ContextBudgetResult;
     },
 );
 

--- a/apps/axctl/src/queries/cost-analytics.test.ts
+++ b/apps/axctl/src/queries/cost-analytics.test.ts
@@ -241,6 +241,55 @@ describe("fetchCostModels - NaN-guard (countField adoption)", () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// fetchCostSplit - content-type dimension (global breakdown, ADAPT path)
+// CostSplitRow is aggregated by (origin x model) with no per-session id,
+// so a per-row dominant content type is meaningless. Instead, the global
+// ContentTypeBreakdown is attached as `result.contentTypes`.
+// ---------------------------------------------------------------------------
+
+describe("fetchCostSplit - contentTypes dimension", () => {
+    test("includes global content-type breakdown as sibling field on result", async () => {
+        const splitRows = [
+            {
+                source: "claude", model: "claude-sonnet-4-6", sessions: 3,
+                prompt_tokens: 300, completion_tokens: 60,
+                cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 1.5,
+            },
+        ];
+        // Second query: fetchContentTypeBreakdown returns flat rows
+        const contentTypeRows = [
+            { ct: "content_type:code", calls: 5, bytes: 400 },
+            { ct: "content_type:docs", calls: 2, bytes: 200 },
+        ];
+        const db = makeMockDb([[splitRows], [contentTypeRows]]);
+        const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+
+        expect(result.contentTypes).toBeDefined();
+        // rows are sorted by estTokens desc; code (400 bytes) > docs (200 bytes)
+        expect(result.contentTypes.rows).toHaveLength(2);
+        expect(result.contentTypes.rows[0]!.category).toBe("code");
+        expect(result.contentTypes.rows[1]!.category).toBe("docs");
+        expect(result.contentTypes.totals.bytes).toBe(600);
+    });
+
+    test("contentTypes is empty breakdown when no content edges exist", async () => {
+        const splitRows = [
+            {
+                source: "claude", model: "A", sessions: 1,
+                prompt_tokens: 100, completion_tokens: 10,
+                cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 1.0,
+            },
+        ];
+        // Empty content-type response
+        const db = makeMockDb([[splitRows], [[]]]);
+        const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+
+        expect(result.contentTypes.rows).toHaveLength(0);
+        expect(result.contentTypes.totals.bytes).toBe(0);
+    });
+});
+
 describe("fetchCostSessions - stringFieldOr adoption", () => {
     test("session_id from DB string round-trips unchanged", async () => {
         const dbRows = [{

--- a/apps/axctl/src/queries/cost-analytics.ts
+++ b/apps/axctl/src/queries/cost-analytics.ts
@@ -15,6 +15,7 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { surrealLiteral } from "@ax/lib/json";
 import { countField, stringFieldOr } from "@ax/lib/shared/surreal";
+import { fetchContentTypeBreakdown, type ContentTypeBreakdown } from "./content-types.ts";
 
 // ---------------------------------------------------------------------------
 // Shared constants + SQL-boundary helpers
@@ -192,6 +193,11 @@ export interface CostSplitTotals {
 export interface CostSplitResult {
     readonly rows: ReadonlyArray<CostSplitRow>;
     readonly totals: CostSplitTotals;
+    /** Global content-type breakdown across all sessions in the window.
+     * CostSplitRow is aggregated by (origin x model) with no per-session id,
+     * so per-row tagging is not meaningful - the distribution is a sibling
+     * field instead. */
+    readonly contentTypes: ContentTypeBreakdown;
 }
 
 const COST_SPLIT_SQL = (sinceDays: number) => `
@@ -298,6 +304,8 @@ export const fetchCostSplit = Effect.fn("queries.fetchCostSplit")(
             cost_usd: totalCost,
         };
 
-        return { rows: splitRows, totals } satisfies CostSplitResult;
+        const contentTypes = yield* fetchContentTypeBreakdown();
+
+        return { rows: splitRows, totals, contentTypes } satisfies CostSplitResult;
     },
 );

--- a/apps/axctl/src/queries/insights-enrich.test.ts
+++ b/apps/axctl/src/queries/insights-enrich.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, test } from "bun:test";
 import { Effect, type Layer } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
-import { enrichInsightRows } from "./insights-enrich.ts";
+import { enrichInsightRows, foldContentTypeOntoFriction } from "./insights-enrich.ts";
 
 function makeMockDb(): { layer: Layer.Layer<SurrealClient>; captured: string[] } {
     const tc = makeTestSurrealClient({
@@ -125,7 +125,57 @@ describe("enrichInsightRows", () => {
         expect(rows[0]!.otlp_tokens).toBe(800);
         expect(rows[1]!.otlp_cost_usd).toBeNull();
         expect(rows[1]!.otlp_tokens).toBeNull();
-        // Only 2 queries total (otel_metric_point + otel_log_event) - one batch, not per-row
-        expect(tc.captured).toHaveLength(2);
+        // 3 queries total: otel_metric_point + otel_log_event + has_content
+        expect(tc.captured).toHaveLength(3);
+    });
+
+    test("friction: enriches rows with contentType from session-dominant has_content category", async () => {
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            routes: [
+                { match: "FROM otel_metric_point", rows: [[]] },
+                { match: "FROM otel_log_event", rows: [[]] },
+                {
+                    match: "FROM has_content",
+                    rows: [[
+                        { sid: "session:s1", ct: "content_type:unknown", bytes: 500 },
+                        { sid: "session:s1", ct: "content_type:code", bytes: 200 },
+                    ]],
+                },
+            ],
+        });
+        const frictionRows = [
+            { id: "friction_event:f1", session_ref: "session:s1", session: "session:s1", kind: "tool_failure", ts: new Date() },
+            { id: "friction_event:f2", session_ref: "session:s2", session: "session:s2", kind: "tool_failure", ts: new Date() },
+        ];
+        const rows = await Effect.runPromise(
+            enrichInsightRows("friction", frictionRows).pipe(Effect.provide(tc.layer)),
+        );
+        // session s1 has dominant category "unknown" (500 bytes > 200)
+        expect(rows[0]!.contentType).toBe("unknown");
+        // session s2 has no has_content data
+        expect(rows[1]!.contentType).toBeNull();
+    });
+});
+
+describe("foldContentTypeOntoFriction", () => {
+    test("tags each friction row with the dominant content type of its session", () => {
+        const rows = [
+            { id: "friction_event:f1", session_ref: "session:s1", session: "session:s1" },
+            { id: "friction_event:f2", session_ref: "session:s2", session: "session:s2" },
+        ];
+        const bySession = new Map([["s1", "unknown"]]);
+        const out = foldContentTypeOntoFriction(rows as never, bySession);
+        expect(out[0]!.contentType).toBe("unknown");
+        expect(out[1]!.contentType).toBeNull();
+    });
+
+    test("uses session_ref when present, falls back to session field", () => {
+        const rows = [
+            { id: "friction_event:f3", session: "session:abc" },
+        ];
+        const bySession = new Map([["abc", "text"]]);
+        const out = foldContentTypeOntoFriction(rows as never, bySession);
+        expect(out[0]!.contentType).toBe("text");
     });
 });

--- a/apps/axctl/src/queries/insights-enrich.ts
+++ b/apps/axctl/src/queries/insights-enrich.ts
@@ -127,17 +127,67 @@ const frictionSessionId = (row: Row): string =>
             : (recordIdString(row.session) ?? String(row.session ?? "")),
     );
 
+/** Pure fold - exported for unit testing. Tags each friction row with the
+ *  dominant content type of its session. `bySession` is keyed by bare session
+ *  UUID (no `session:` prefix). Returns `null` when no content data exists. */
+export const foldContentTypeOntoFriction = (
+    rows: ReadonlyArray<Row>,
+    bySession: ReadonlyMap<string, string>,
+): Array<Row & { readonly contentType: string | null }> =>
+    rows.map((r) => ({ ...r, contentType: bySession.get(frictionSessionId(r)) ?? null }));
+
+/** Batch lookup: for each session in `ids`, return the dominant content-type
+ *  category (most bytes) from the `has_content` edge. Deref-free - the edge
+ *  already denormalizes `session`. */
+const fetchFrictionContentTypes = (
+    sessionIds: readonly string[],
+): Effect.Effect<Map<string, string>, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        if (sessionIds.length === 0) return new Map<string, string>();
+        const db = yield* SurrealClient;
+        const list = sessionIds
+            .map((id) => `session:\`${bareSession(id).replace(/`/g, "")}\``)
+            .join(", ");
+        const raw = (yield* db.query<[Array<{ sid: string; ct: string; bytes: number }>]>(
+            `SELECT type::string(session) AS sid, type::string(out) AS ct, math::sum(bytes) AS bytes `
+            + `FROM has_content WHERE session IN [${list}] GROUP BY sid, ct;`,
+        ))?.[0] ?? [];
+        // Per session: pick the category with the most bytes
+        const best = new Map<string, { ct: string; bytes: number }>();
+        for (const r of raw) {
+            const sid = bareSession(r.sid);
+            const b = Number(r.bytes ?? 0);
+            const prev = best.get(sid);
+            if (!prev || b > prev.bytes) {
+                best.set(sid, { ct: String(r.ct).replace(/^content_type:/, ""), bytes: b });
+            }
+        }
+        const out = new Map<string, string>();
+        for (const [k, v] of best) out.set(k, v.ct);
+        return out;
+    });
+
 /** Enrich the rows of a classifier insight view with per-row context via
  *  indexed lookups. Views outside ENRICHED_VIEWS pass through untouched.
- *  The "friction" view gets a single batched OTLP cost lookup appended. */
+ *  The "friction" view gets a single batched OTLP cost lookup and a
+ *  session-dominant content-type tag appended. */
 export const enrichInsightRows = Effect.fn("queries.enrichInsightRows")(
     function* (view: InsightView, rows: ReadonlyArray<Row>) {
         if (view === "friction") {
             const ids = rows.map(frictionSessionId);
-            const cost = yield* sessionTelemetryCost(ids);
+            const [cost, contentTypes] = yield* Effect.all(
+                [sessionTelemetryCost(ids), fetchFrictionContentTypes(ids)],
+                { concurrency: 2 },
+            );
             return rows.map((row): Row => {
-                const c = cost.get(frictionSessionId(row));
-                return { ...row, otlp_cost_usd: c?.cost_usd ?? null, otlp_tokens: c?.tokens ?? null };
+                const sid = frictionSessionId(row);
+                const c = cost.get(sid);
+                return {
+                    ...row,
+                    otlp_cost_usd: c?.cost_usd ?? null,
+                    otlp_tokens: c?.tokens ?? null,
+                    contentType: contentTypes.get(sid) ?? null,
+                };
             });
         }
         if (!ENRICHED_VIEWS.has(view)) return rows;

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -175,6 +175,8 @@ export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "otel_span", stage: "active", note: "Harness OTLP trace spans (Codex session_loop + children)." },
     { table: "otel_log_event", stage: "active", note: "Harness OTLP log events (codex events incl. token usage)." },
     { table: "telemetry_of", stage: "active", note: "Edge: session -> otel telemetry row (drawn at ingest)." },
+    { table: "content_type", stage: "active", note: "Closed content-type taxonomy for tool outputs." },
+    { table: "has_content", stage: "active", note: "tool_call -> content_type edge; denormalizes session + bytes." },
 ] as const;
 
 export function isInsightView(value: string): value is InsightView {

--- a/docs/superpowers/plans/2026-06-17-content-type-classification.md
+++ b/docs/superpowers/plans/2026-06-17-content-type-classification.md
@@ -1,0 +1,1113 @@
+# Content-Type Classification for Tool Outputs - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Classify every `tool_call` output by content-type (a small fixed taxonomy) at ingest, write it as a `has_content` graph edge, and thread the content-type facet through existing read paths (context-budget, cost split, recall, insights, profile) - no new CLI command, no new MCP tool.
+
+**Architecture:** A deterministic TS classifier (file-extension from the tool input + lightweight content sniff, `ClassifierKind=heuristic`) runs as a new idempotent ingest derive-stage. It upserts 12 fixed `content_type` nodes and writes one `has_content` edge per tool_call. The edge denormalizes `session` + `bytes` so every downstream rollup is deref-free (the house idiom - stacking record derefs inside aggregates over large edge tables hangs production). Read surfaces gain a content-type dimension via one shared query helper. Magika (the Python probe used in the spike) is intentionally NOT a runtime dependency; it can return later as an optional `local_model` upgrade.
+
+**Tech Stack:** bun >= 1.3, TypeScript (strict), Effect v4 beta, SurrealDB 3.x. Tests: `bun:test`. Internal imports by package name (`@ax/lib/db`, `@ax/lib/shared/surreal`).
+
+**Spike evidence (already run, 4000 recent outputs):** group-level split is trustworthy (text 57.9% / code 41.1%); fine ML labels were noisy (60% < 0.80 confidence, false `clojure` in a TS repo) - hence deterministic categories, not ML. `unknown` outputs errored 42% vs 1-5% baseline; `application`-class blobs were 0.1% of calls but 5.6% of tokens. Those two signals justify the build.
+
+---
+
+## Content-type taxonomy (fixed node set)
+
+Twelve stable categories. Node id = `content_type:<category>`. The set is closed; the classifier always resolves to exactly one.
+
+| category | meaning | primary signal |
+|---|---|---|
+| `json` | JSON / JSONL | ext `.json/.jsonl` or trimmed starts `{`/`[` |
+| `code` | source code | ext in CODE_EXT or shebang |
+| `diff` | unified diff / patch | leading `diff --git` / `@@ ` / `--- `+`+++ ` |
+| `markdown` | markdown / prose docs | ext `.md/.mdx` |
+| `yaml` | YAML | ext `.yaml/.yml` |
+| `config` | config / dotfiles | ext `.toml/.ini/.env/.conf` or known dotfile |
+| `log` | log output | ext `.log` |
+| `filelist` | path lists / search hits | Grep/Glob output shape |
+| `text` | plain text fallback | default for textual content |
+| `binary` | non-text blobs | ext in BINARY_EXT |
+| `empty` | empty / whitespace-only | length 0 after trim |
+| `unknown` | could not resolve | classifier abstained |
+
+`method` (on the edge): `"extension"` (conf 0.95) | `"sniff"` (conf 0.6) | `"fallback"` (conf 0.4). `fine_label` (on the edge, optional) keeps the raw extension or sniff reason for drill-down.
+
+---
+
+## File Structure
+
+**Write path**
+- Create `apps/axctl/src/ingest/content-type-classify.ts` - pure classifier (no Effect, no DB): `classifyContentType(input) -> {category, method, confidence, fineLabel}`. One responsibility: bytes/path -> category.
+- Create `apps/axctl/src/ingest/content-type-classify.test.ts`.
+- Create `apps/axctl/src/ingest/derive-content-types.ts` - the ingest stage: query unclassified tool_calls, classify, write nodes + edges.
+- Create `apps/axctl/src/ingest/derive-content-types.test.ts`.
+- Modify `packages/schema/src/schema.surql` - add `content_type` + `has_content` DDL after the `tool_call` block.
+- Modify `apps/axctl/src/ingest/stage/registry.ts` - register `contentTypesStage`.
+- Modify `apps/axctl/src/queries/insights.ts` - add two `SCHEMA_TABLES` rows.
+
+**Read path (enhance only)**
+- Create `apps/axctl/src/queries/content-types.ts` - shared deref-free rollup helper (global distribution, per-session mix). Used by every surface below.
+- Create `apps/axctl/src/queries/content-types.test.ts`.
+- Modify `apps/axctl/src/queries/context-budget.ts` - attach content-type breakdown to `ContextBudgetResult`.
+- Modify `apps/axctl/src/queries/cost-analytics.ts` - add content-type dimension to cost split.
+- Modify `apps/axctl/src/cli/commands/recall.ts` - add `--type=` filter flag.
+- Modify the profile builder (`apps/axctl/src/profile/`) - add a `tool-output-mix` taste pattern.
+
+---
+
+## Phasing
+
+- **Phase 1 (write path + core read): Tasks 1-6.** Ships the signal end-to-end and the headline read surface (context-budget). Stop-and-ship point.
+- **Phase 2 (remaining read surfaces): Tasks 7-10.** Independent of each other; each rides the Task 5 helper.
+
+---
+
+## Task 1: Pure content-type classifier
+
+**Files:**
+- Create: `apps/axctl/src/ingest/content-type-classify.ts`
+- Test: `apps/axctl/src/ingest/content-type-classify.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// apps/axctl/src/ingest/content-type-classify.test.ts
+import { describe, expect, test } from "bun:test";
+import { classifyContentType } from "./content-type-classify.ts";
+
+describe("classifyContentType", () => {
+  test("extension wins: .ts -> code, conf 0.95", () => {
+    const r = classifyContentType({ filePath: "/a/b.ts", output: "const x = 1;" });
+    expect(r.category).toBe("code");
+    expect(r.method).toBe("extension");
+    expect(r.confidence).toBe(0.95);
+    expect(r.fineLabel).toBe("ts");
+  });
+
+  test(".json -> json", () => {
+    expect(classifyContentType({ filePath: "x.json", output: "{}" }).category).toBe("json");
+  });
+
+  test("empty output -> empty regardless of path", () => {
+    expect(classifyContentType({ filePath: "x.ts", output: "   \n" }).category).toBe("empty");
+  });
+
+  test("no path, JSON-ish body -> json by sniff, conf 0.6", () => {
+    const r = classifyContentType({ filePath: null, output: '  [{"a":1}]' });
+    expect(r.category).toBe("json");
+    expect(r.method).toBe("sniff");
+    expect(r.confidence).toBe(0.6);
+  });
+
+  test("no path, diff markers -> diff", () => {
+    const r = classifyContentType({ filePath: null, output: "diff --git a/x b/x\n@@ -1 +1 @@" });
+    expect(r.category).toBe("diff");
+  });
+
+  test("grep-style hits -> filelist", () => {
+    const out = "src/a.ts:12: foo\nsrc/b.ts:4: bar\nsrc/c.ts:9: baz";
+    expect(classifyContentType({ filePath: null, output: out, toolName: "Grep" }).category).toBe("filelist");
+  });
+
+  test("plain prose -> text fallback, conf 0.4", () => {
+    const r = classifyContentType({ filePath: null, output: "the quick brown fox jumps" });
+    expect(r.category).toBe("text");
+    expect(r.method).toBe("fallback");
+    expect(r.confidence).toBe(0.4);
+  });
+
+  test(".png -> binary", () => {
+    expect(classifyContentType({ filePath: "x.png", output: "..." }).category).toBe("binary");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/ingest/content-type-classify.test.ts`
+Expected: FAIL - "Cannot find module './content-type-classify.ts'".
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// apps/axctl/src/ingest/content-type-classify.ts
+/**
+ * Deterministic content-type classifier for tool_call outputs.
+ *
+ * Pure function - no Effect, no DB. The ingest stage calls this per row.
+ * Extension (from the tool input file_path) is the strongest, cheapest signal;
+ * a lightweight content sniff handles Bash/exec output that has no path; a text
+ * fallback closes the set. Magika (the spike probe) is deliberately absent -
+ * group-level categories from ext+sniff were the trustworthy part of the spike.
+ */
+
+export type ContentCategory =
+  | "json" | "code" | "diff" | "markdown" | "yaml" | "config"
+  | "log" | "filelist" | "text" | "binary" | "empty" | "unknown";
+
+export type ClassifyMethod = "extension" | "sniff" | "fallback";
+
+export interface ClassifyInput {
+  /** file_path pulled from the tool input_json (Read/Edit/Write/NotebookEdit); null otherwise */
+  readonly filePath: string | null;
+  /** the output text (output_excerpt is fine - sniff is prefix-tolerant) */
+  readonly output: string;
+  /** tool name, used only to bias Grep/Glob toward filelist */
+  readonly toolName?: string | null;
+}
+
+export interface ClassifyResult {
+  readonly category: ContentCategory;
+  readonly method: ClassifyMethod;
+  readonly confidence: number;
+  readonly fineLabel: string | null;
+}
+
+const CODE_EXT = new Set([
+  "ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "rs", "go", "java", "rb",
+  "c", "h", "cpp", "hpp", "cc", "cs", "swift", "kt", "scala", "clj", "ex",
+  "exs", "php", "sh", "bash", "zsh", "fish", "sql", "surql", "lua", "r",
+  "dart", "vue", "svelte", "css", "scss", "sass", "less", "html", "xml",
+]);
+const BINARY_EXT = new Set([
+  "png", "jpg", "jpeg", "gif", "webp", "ico", "pdf", "zip", "gz", "tar",
+  "wasm", "so", "dylib", "dll", "bin", "exe", "woff", "woff2", "ttf", "mp4", "mov",
+]);
+const EXT_CATEGORY: ReadonlyArray<[ReadonlyArray<string>, ContentCategory]> = [
+  [["json", "jsonl"], "json"],
+  [["md", "mdx"], "markdown"],
+  [["yaml", "yml"], "yaml"],
+  [["toml", "ini", "env", "conf", "cfg"], "config"],
+  [["log"], "log"],
+  [["csv", "tsv", "txt"], "text"],
+];
+const DOTFILES = new Set([".gitignore", ".npmignore", ".dockerignore", ".env", ".editorconfig"]);
+
+const extOf = (p: string): string => {
+  const base = p.split("/").pop() ?? p;
+  if (DOTFILES.has(base)) return "config__dotfile";
+  const i = base.lastIndexOf(".");
+  return i > 0 ? base.slice(i + 1).toLowerCase() : "";
+};
+
+const categoryForExt = (ext: string): ContentCategory | null => {
+  if (ext === "config__dotfile") return "config";
+  if (CODE_EXT.has(ext)) return "code";
+  if (BINARY_EXT.has(ext)) return "binary";
+  for (const [list, cat] of EXT_CATEGORY) {
+    if (list.includes(ext)) return cat;
+  }
+  return null;
+};
+
+const DIFF_RE = /^(diff --git |@@ |Index: |--- )/m;
+const GREP_HIT_RE = /^[^\s:]+:\d+:/;
+
+const sniff = (output: string, toolName: string | null | undefined): ContentCategory | null => {
+  const t = output.trimStart();
+  if (DIFF_RE.test(t)) return "diff";
+  if (t.startsWith("{") || t.startsWith("[")) return "json";
+  if (t.startsWith("#!")) return "code";
+  // grep/glob style: most non-empty lines are path:line: hits
+  const lines = output.split("\n").filter((l) => l.length > 0).slice(0, 20);
+  if (lines.length >= 2) {
+    const hits = lines.filter((l) => GREP_HIT_RE.test(l)).length;
+    if (hits / lines.length >= 0.6) return "filelist";
+  }
+  if ((toolName === "Glob" || toolName === "Grep") && lines.length >= 2) return "filelist";
+  return null;
+};
+
+export const classifyContentType = (input: ClassifyInput): ClassifyResult => {
+  if (input.output.trim().length === 0) {
+    return { category: "empty", method: "extension", confidence: 1.0, fineLabel: null };
+  }
+  if (input.filePath) {
+    const ext = extOf(input.filePath);
+    const cat = ext ? categoryForExt(ext) : null;
+    if (cat) {
+      return { category: cat, method: "extension", confidence: 0.95, fineLabel: ext.replace("config__dotfile", "dotfile") };
+    }
+  }
+  const sniffed = sniff(input.output, input.toolName ?? null);
+  if (sniffed) {
+    return { category: sniffed, method: "sniff", confidence: 0.6, fineLabel: null };
+  }
+  return { category: "text", method: "fallback", confidence: 0.4, fineLabel: null };
+};
+
+/** The closed taxonomy - the derive stage upserts exactly these nodes. */
+export const ALL_CONTENT_CATEGORIES: ReadonlyArray<ContentCategory> = [
+  "json", "code", "diff", "markdown", "yaml", "config",
+  "log", "filelist", "text", "binary", "empty", "unknown",
+];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/ingest/content-type-classify.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/ingest/content-type-classify.ts apps/axctl/src/ingest/content-type-classify.test.ts
+git commit -m "feat(ingest): deterministic content-type classifier for tool outputs"
+```
+
+---
+
+## Task 2: Schema DDL + SCHEMA_TABLES registration
+
+**Files:**
+- Modify: `packages/schema/src/schema.surql` (after the `tool_call` table block, around line 368)
+- Modify: `apps/axctl/src/queries/insights.ts` (the `SCHEMA_TABLES` array)
+- Test: relies on the existing `insights.test.ts` SCHEMA_TABLES guard
+
+- [ ] **Step 1: Add the DDL**
+
+Insert after the last `tool_call` index (`DEFINE INDEX ... tool_call_command_tool_ts ...`, line 368) in `packages/schema/src/schema.surql`:
+
+```surql
+-- Content-type classification of tool_call outputs (derive-content-types stage).
+-- Closed taxonomy; one node per category. See content-type-classify.ts.
+DEFINE TABLE content_type SCHEMAFULL;
+DEFINE FIELD category    ON content_type TYPE string;  -- json|code|diff|markdown|yaml|config|log|filelist|text|binary|empty|unknown
+DEFINE FIELD label       ON content_type TYPE string;  -- human label (same as category for now)
+
+-- has_content: tool_call -> content_type. Denormalizes session + bytes so every
+-- downstream rollup is deref-free (house idiom; derefs in aggregates hang prod).
+DEFINE TABLE has_content TYPE RELATION FROM tool_call TO content_type SCHEMAFULL;
+DEFINE FIELD method      ON has_content TYPE string;             -- extension|sniff|fallback
+DEFINE FIELD confidence  ON has_content TYPE float DEFAULT 1.0;
+DEFINE FIELD fine_label  ON has_content TYPE option<string>;     -- raw ext / sniff reason
+DEFINE FIELD bytes       ON has_content TYPE int DEFAULT 0;       -- output byte length (token proxy)
+DEFINE FIELD session     ON has_content TYPE option<record<session>>;
+DEFINE FIELD ts          ON has_content TYPE datetime;
+DEFINE INDEX IF NOT EXISTS has_content_in  ON has_content FIELDS in;
+DEFINE INDEX IF NOT EXISTS has_content_out ON has_content FIELDS out;
+DEFINE INDEX IF NOT EXISTS has_content_session ON has_content FIELDS session;
+```
+
+- [ ] **Step 2: Register the tables in SCHEMA_TABLES**
+
+In `apps/axctl/src/queries/insights.ts`, add to the `SCHEMA_TABLES` array (after the `tool_call` entry):
+
+```typescript
+{ table: "content_type", stage: "active", note: "Closed content-type taxonomy for tool outputs." },
+{ table: "has_content", stage: "active", note: "tool_call -> content_type edge; denormalizes session + bytes." },
+```
+
+(Match the exact field names of the existing entries - read one neighbouring entry first; if the property is `name` not `table`, or there is no `stage`, mirror that shape exactly.)
+
+- [ ] **Step 3: Run the schema-mirror guard**
+
+Run: `bun test apps/axctl/src/queries/insights.test.ts`
+Expected: PASS - the SCHEMA_TABLES-mirrors-schema test stays green (it fails if the DDL and registry drift).
+
+- [ ] **Step 4: Reset + reload the local DB schema**
+
+Run: check `package.json` for the schema-apply command (`db:push` / `db:reset` / a `scripts/db-*.ts`) and run it. Then verify:
+
+Run: `curl -s -X POST http://127.0.0.1:8521/sql -H "surreal-ns: ax" -H "surreal-db: main" -u root:root --data "INFO FOR TABLE has_content;" | head -c 200`
+Expected: JSON describing the `has_content` fields (not an error).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/schema/src/schema.surql apps/axctl/src/queries/insights.ts
+git commit -m "feat(schema): content_type node + has_content edge"
+```
+
+---
+
+## Task 3: derive-content-types ingest stage (pure edge builder)
+
+**Files:**
+- Create: `apps/axctl/src/ingest/derive-content-types.ts`
+- Test: `apps/axctl/src/ingest/derive-content-types.test.ts`
+
+This task builds the pure edge-spec layer + render functions. Task 4 wires the DB query + stage registration. Splitting keeps the pure logic unit-testable without a DB.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// apps/axctl/src/ingest/derive-content-types.test.ts
+import { describe, expect, test } from "bun:test";
+import { buildContentEdge, renderContentEdge, renderContentTypeNodes } from "./derive-content-types.ts";
+
+describe("buildContentEdge", () => {
+  test("derives category + denormalized session/bytes from a tool_call row", () => {
+    const e = buildContentEdge({
+      id: "tool_call:abc", session: "session:s1", name: "Read",
+      inputJson: '{"file_path":"/x/y.ts"}', outputExcerpt: "const a = 1;", bytes: 12, ts: "2026-06-17T00:00:00Z",
+    });
+    expect(e).toEqual({
+      toolCallId: "tool_call:abc", category: "code", session: "session:s1",
+      method: "extension", confidence: 0.95, fineLabel: "ts", bytes: 12, ts: "2026-06-17T00:00:00Z",
+    });
+  });
+
+  test("falls back to output sniff when input has no file_path", () => {
+    const e = buildContentEdge({
+      id: "tool_call:b", session: "session:s1", name: "Bash",
+      inputJson: '{"command":"ls"}', outputExcerpt: '[{"a":1}]', bytes: 9, ts: "2026-06-17T00:00:00Z",
+    });
+    expect(e.category).toBe("json");
+    expect(e.method).toBe("sniff");
+  });
+});
+
+describe("renderContentEdge", () => {
+  test("emits a deterministic RELATE keyed by tool_call id (idempotent re-runs)", () => {
+    const sql = renderContentEdge({
+      toolCallId: "tool_call:abc", category: "code", session: "session:s1",
+      method: "extension", confidence: 0.95, fineLabel: "ts", bytes: 12, ts: "2026-06-17T00:00:00Z",
+    });
+    expect(sql).toContain("->has_content:");
+    expect(sql).toContain("->content_type:");
+    expect(sql).toContain("bytes = 12");
+    expect(sql).toContain("confidence = 0.95");
+  });
+
+  test("returns null on an unkeyable id", () => {
+    expect(renderContentEdge({ ...({} as never), toolCallId: "", category: "text" } as never)).toBeNull();
+  });
+});
+
+describe("renderContentTypeNodes", () => {
+  test("upserts all 12 fixed category nodes", () => {
+    const stmts = renderContentTypeNodes();
+    expect(stmts.length).toBe(12);
+    expect(stmts[0]).toContain("UPSERT content_type:");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/ingest/derive-content-types.test.ts`
+Expected: FAIL - module not found.
+
+- [ ] **Step 3: Write the pure layer**
+
+```typescript
+// apps/axctl/src/ingest/derive-content-types.ts (pure section - DB query added in Task 4)
+import {
+  recordKeyPart, recordRef, safeKeyPart, surrealDate, surrealString,
+} from "@ax/lib/shared/surreal";
+import {
+  ALL_CONTENT_CATEGORIES, classifyContentType, type ContentCategory,
+} from "./content-type-classify.ts";
+
+export interface ToolCallRow {
+  readonly id: string;
+  readonly session: string | null;
+  readonly name: string | null;
+  readonly inputJson: string | null;
+  readonly outputExcerpt: string | null;
+  readonly bytes: number;
+  readonly ts: string;
+}
+
+export interface ContentEdgeSpec {
+  readonly toolCallId: string;
+  readonly category: ContentCategory;
+  readonly session: string | null;
+  readonly method: string;
+  readonly confidence: number;
+  readonly fineLabel: string | null;
+  readonly bytes: number;
+  readonly ts: string;
+}
+
+const filePathFromInput = (inputJson: string | null): string | null => {
+  if (!inputJson) return null;
+  try {
+    const obj = JSON.parse(inputJson) as Record<string, unknown>;
+    const fp = obj["file_path"] ?? obj["path"] ?? obj["notebook_path"];
+    return typeof fp === "string" ? fp : null;
+  } catch {
+    return null;
+  }
+};
+
+export const buildContentEdge = (row: ToolCallRow): ContentEdgeSpec => {
+  const r = classifyContentType({
+    filePath: filePathFromInput(row.inputJson),
+    output: row.outputExcerpt ?? "",
+    toolName: row.name,
+  });
+  return {
+    toolCallId: row.id,
+    category: r.category,
+    session: row.session,
+    method: r.method,
+    confidence: r.confidence,
+    fineLabel: r.fineLabel,
+    bytes: row.bytes,
+    ts: row.ts,
+  };
+};
+
+/** UPSERT the closed taxonomy. Idempotent; safe every run. */
+export const renderContentTypeNodes = (): string[] =>
+  ALL_CONTENT_CATEGORIES.map(
+    (c) => `UPSERT content_type:${c} SET category = ${surrealString(c)}, label = ${surrealString(c)};`,
+  );
+
+/** Edge keyed by tool_call id => deterministic => idempotent on re-run. */
+export const renderContentEdge = (e: ContentEdgeSpec): string | null => {
+  const tcKey = recordKeyPart(e.toolCallId, "tool_call");
+  if (!tcKey) return null;
+  const edgeKey = safeKeyPart(e.toolCallId);
+  const sessionClause = e.session ? `, session = ${e.session}` : "";
+  const fineClause = e.fineLabel ? `, fine_label = ${surrealString(e.fineLabel)}` : "";
+  return (
+    `RELATE ${recordRef("tool_call", tcKey)}->${recordRef("has_content", edgeKey)}->content_type:${e.category} ` +
+    `SET method = ${surrealString(e.method)}, confidence = ${e.confidence}, bytes = ${e.bytes}, ` +
+    `ts = ${surrealDate(e.ts)}${sessionClause}${fineClause};`
+  );
+};
+```
+
+Note on `recordRef`/`recordKeyPart`/`safeKeyPart`/`surrealDate`/`surrealString`: import exactly as `derive-loaded-skills.ts` does. If `recordRef`'s signature differs from `(table, key)`, mirror the loaded-skills call site precisely.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/ingest/derive-content-types.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/ingest/derive-content-types.ts apps/axctl/src/ingest/derive-content-types.test.ts
+git commit -m "feat(ingest): content-edge spec builder + renderers"
+```
+
+---
+
+## Task 4: Wire the DB query + register the stage
+
+**Files:**
+- Modify: `apps/axctl/src/ingest/derive-content-types.ts` (append the `deriveContentTypes` Effect + stage def)
+- Modify: `apps/axctl/src/ingest/stage/registry.ts` (import + add to `ALL_STAGES`)
+- Test: `apps/axctl/src/ingest/derive-content-types.test.ts` (add an integration check), `apps/axctl/src/ingest/stage/registry.test.ts` (existing guard)
+
+- [ ] **Step 1: Append the Effect stage to derive-content-types.ts**
+
+```typescript
+// append to apps/axctl/src/ingest/derive-content-types.ts
+import { Effect, Schema } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { executeStatementsWith } from "@ax/lib/shared/surreal";
+import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
+import type { StageDef } from "./stage/registry.ts";
+
+// Incremental: classify only tool_calls that have no has_content edge yet.
+// Two FLAT queries (deref-free): the already-classified id set, and the
+// unclassified rows. Edge ids are deterministic, so re-running is safe even if
+// the "already classified" set races - RELATE on an existing id is a no-op upsert.
+const ALREADY_SQL = `SELECT type::string(in) AS tid FROM has_content;`;
+const ROWS_SQL = `
+SELECT type::string(id) AS id, type::string(session) AS session, name,
+       input_json AS inputJson, output_excerpt AS outputExcerpt,
+       string::len(output_json) AS bytes, type::string(ts) AS ts
+FROM tool_call WHERE output_json != NONE;
+`;
+
+export interface DeriveContentTypeStats {
+  readonly written: number;
+  readonly skipped: number;
+}
+
+export const deriveContentTypes = Effect.fn("ingest.deriveContentTypes")(function* () {
+  const db = yield* SurrealClient;
+  const [already] = yield* db.query<[Array<{ tid: string }>]>(ALREADY_SQL);
+  const [rows] = yield* db.query<[Array<ToolCallRow>]>(ROWS_SQL);
+
+  const done = new Set((already ?? []).map((r) => r.tid));
+  const stmts: string[] = renderContentTypeNodes();
+  let written = 0;
+  let skipped = 0;
+  for (const row of rows ?? []) {
+    if (done.has(row.id)) { skipped += 1; continue; }
+    const sql = renderContentEdge(buildContentEdge(row));
+    if (sql) { stmts.push(sql); written += 1; }
+  }
+  yield* executeStatementsWith(db, stmts, { chunkSize: 250, label: "contentEdges" });
+  return { written, skipped } satisfies DeriveContentTypeStats;
+});
+
+export class ContentTypeStats extends BaseStageStats.extend<ContentTypeStats>(
+  "ContentTypeStats",
+)({
+  written: Schema.Number,
+  skipped: Schema.Number,
+}) {}
+
+/**
+ * Content-types stage - classifies tool_call outputs into a closed taxonomy and
+ * writes has_content edges (denormalized session + bytes for deref-free reads).
+ * Depends on the transcript/codex parsers having written tool_call rows.
+ * Tags: derive.
+ */
+export const contentTypesStage: StageDef<ContentTypeStats, SurrealClient> = {
+  meta: StageMeta.make({
+    key: "content-types",
+    deps: ["claude", "codex"],
+    tags: ["derive"],
+  }),
+  run: (_ctx: IngestContext) =>
+    Effect.gen(function* () {
+      const t0 = Date.now();
+      const result = yield* deriveContentTypes();
+      return ContentTypeStats.make({
+        durationMs: Date.now() - t0,
+        summary: `classified ${result.written} tool outputs (${result.skipped} already done)`,
+        written: result.written,
+        skipped: result.skipped,
+      });
+    }),
+};
+```
+
+Note: confirm the dep keys (`"claude"`, `"codex"`) exist in `ALL_STAGES` meta keys; the registry test validates deps-validity. If the tool_call-producing stages have different keys, use those.
+
+- [ ] **Step 2: Register the stage**
+
+In `apps/axctl/src/ingest/stage/registry.ts`: add the import next to the other derive imports -
+
+```typescript
+import { contentTypesStage } from "../derive-content-types.ts";
+```
+
+and add `contentTypesStage` into the `ALL_STAGES` array, after `cursorStage` (so all tool_call producers have run):
+
+```typescript
+export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, pricingStage, claudeStage, codexStage, piStage, opencodeStage, cursorStage, contentTypesStage, subagentsStage, /* ...unchanged... */] as const;
+```
+
+- [ ] **Step 3: Run the registry guard + a live ingest of the stage**
+
+Run: `bun test apps/axctl/src/ingest/stage/registry.test.ts`
+Expected: PASS (key-uniqueness + deps-validity hold).
+
+Run: `bun run apps/axctl/bin/axctl ingest --stages=content-types`
+Expected: completes; prints a summary like "classified N tool outputs".
+
+- [ ] **Step 4: Verify edges landed + sanity-check the distribution**
+
+Run:
+```bash
+curl -s -X POST http://127.0.0.1:8521/sql -H "surreal-ns: ax" -H "surreal-db: main" -u root:root \
+  --data "SELECT type::string(out) AS ct, count() AS n, math::sum(bytes) AS bytes FROM has_content GROUP BY ct;" | jq '.[0].result'
+```
+Expected: rows for `content_type:code`, `content_type:text`, etc. with plausible counts (code+text dominate, matching the spike). Re-running the ingest should report most rows `skipped` (idempotency holds).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/ingest/derive-content-types.ts apps/axctl/src/ingest/stage/registry.ts
+git commit -m "feat(ingest): register content-types derive stage"
+```
+
+---
+
+## Task 5: Shared deref-free rollup helper
+
+**Files:**
+- Create: `apps/axctl/src/queries/content-types.ts`
+- Test: `apps/axctl/src/queries/content-types.test.ts`
+
+This is the single helper every read surface calls. Pure aggregation logic is unit-tested against fixture rows; the SQL is a thin wrapper.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// apps/axctl/src/queries/content-types.test.ts
+import { describe, expect, test } from "bun:test";
+import { rollupContentTypes, BYTES_PER_TOKEN } from "./content-types.ts";
+
+describe("rollupContentTypes", () => {
+  test("aggregates calls + bytes + token share by category", () => {
+    const out = rollupContentTypes([
+      { ct: "content_type:code", calls: 3, bytes: 400 },
+      { ct: "content_type:text", calls: 1, bytes: 400 },
+    ]);
+    expect(out.rows).toEqual([
+      { category: "code", calls: 3, bytes: 400, estTokens: 100, tokenShare: 0.5 },
+      { category: "text", calls: 1, bytes: 400, estTokens: 100, tokenShare: 0.5 },
+    ]);
+    expect(out.totals).toEqual({ calls: 4, bytes: 800, estTokens: 200 });
+  });
+
+  test("sorts by est tokens desc and strips the content_type: prefix", () => {
+    const out = rollupContentTypes([
+      { ct: "content_type:text", calls: 1, bytes: 100 },
+      { ct: "content_type:code", calls: 1, bytes: 900 },
+    ]);
+    expect(out.rows.map((r) => r.category)).toEqual(["code", "text"]);
+  });
+
+  test("BYTES_PER_TOKEN matches the context-budget ratio", () => {
+    expect(BYTES_PER_TOKEN).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/queries/content-types.test.ts`
+Expected: FAIL - module not found.
+
+- [ ] **Step 3: Write the helper**
+
+```typescript
+// apps/axctl/src/queries/content-types.ts
+/**
+ * Content-type rollups over the has_content edge. Deref-free: the edge
+ * denormalizes bytes + session, so every aggregate is a flat GROUP BY (the
+ * house idiom - record derefs inside aggregates over large edge tables hang
+ * production). Shared by context-budget, cost split, and the profile facet.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+
+export const BYTES_PER_TOKEN = 4; // shared with skill-bloat + context-budget
+const estTokens = (bytes: number): number => Math.round(bytes / BYTES_PER_TOKEN);
+
+export interface ContentTypeRow {
+  readonly category: string;
+  readonly calls: number;
+  readonly bytes: number;
+  readonly estTokens: number;
+  readonly tokenShare: number; // 0..1 of total est tokens
+}
+export interface ContentTypeBreakdown {
+  readonly rows: ReadonlyArray<ContentTypeRow>;
+  readonly totals: { readonly calls: number; readonly bytes: number; readonly estTokens: number };
+}
+
+interface RawCtRow { readonly ct: string; readonly calls: number; readonly bytes: number }
+
+/** Pure aggregation - unit tested. */
+export const rollupContentTypes = (raw: ReadonlyArray<RawCtRow>): ContentTypeBreakdown => {
+  const totalBytes = raw.reduce((a, r) => a + Number(r.bytes ?? 0), 0);
+  const rows = raw
+    .map((r) => {
+      const bytes = Number(r.bytes ?? 0);
+      const tok = estTokens(bytes);
+      return {
+        category: r.ct.replace(/^content_type:/, ""),
+        calls: Number(r.calls ?? 0),
+        bytes,
+        estTokens: tok,
+        tokenShare: totalBytes > 0 ? bytes / totalBytes : 0,
+      };
+    })
+    .sort((a, b) => b.estTokens - a.estTokens);
+  return {
+    rows,
+    totals: {
+      calls: rows.reduce((a, r) => a + r.calls, 0),
+      bytes: totalBytes,
+      estTokens: estTokens(totalBytes),
+    },
+  };
+};
+
+const DISTRIBUTION_SQL = `
+SELECT type::string(out) AS ct, count() AS calls, math::sum(bytes) AS bytes
+FROM has_content GROUP BY ct;
+`;
+
+/** Global content-type distribution. */
+export const fetchContentTypeBreakdown = Effect.fn("queries.fetchContentTypeBreakdown")(
+  function* () {
+    const db = yield* SurrealClient;
+    const [raw] = yield* db.query<[Array<RawCtRow>]>(DISTRIBUTION_SQL);
+    return rollupContentTypes(raw ?? []);
+  },
+);
+
+const PER_SESSION_SQL = `
+SELECT type::string(session) AS sid, type::string(out) AS ct,
+       count() AS calls, math::sum(bytes) AS bytes
+FROM has_content WHERE session != NONE GROUP BY sid, ct;
+`;
+
+export interface SessionContentMix {
+  readonly sessionId: string;
+  readonly mix: ContentTypeBreakdown;
+}
+
+/** Per-session content-type mix (token-weighted). */
+export const fetchSessionContentMix = Effect.fn("queries.fetchSessionContentMix")(
+  function* () {
+    const db = yield* SurrealClient;
+    const [raw] = yield* db.query<[Array<{ sid: string; ct: string; calls: number; bytes: number }>]>(
+      PER_SESSION_SQL,
+    );
+    const bySession = new Map<string, RawCtRow[]>();
+    for (const r of raw ?? []) {
+      const arr = bySession.get(r.sid) ?? [];
+      arr.push({ ct: r.ct, calls: r.calls, bytes: r.bytes });
+      bySession.set(r.sid, arr);
+    }
+    return Array.from(bySession.entries()).map(
+      ([sessionId, rows]) => ({ sessionId, mix: rollupContentTypes(rows) }) satisfies SessionContentMix,
+    );
+  },
+);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/queries/content-types.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/queries/content-types.ts apps/axctl/src/queries/content-types.test.ts
+git commit -m "feat(queries): deref-free content-type rollup helper"
+```
+
+---
+
+## Task 6: Thread content-type into the context-budget read path
+
+**Files:**
+- Modify: `apps/axctl/src/queries/context-budget.ts` (extend `ContextBudgetResult` + `fetchContextBudget`)
+- Test: `apps/axctl/src/queries/context-budget.test.ts` (if present; else add a focused test file)
+
+This is the headline read surface. The `/api/context/budget` handler already maps `fetchContextBudget` to JSON, so attaching a field auto-exposes it; no handler change required.
+
+- [ ] **Step 1: Write/extend the failing test**
+
+```typescript
+// apps/axctl/src/queries/context-budget.test.ts (add this test; create the file if absent)
+import { describe, expect, test } from "bun:test";
+import type { ContextBudgetResult } from "./context-budget.ts";
+
+describe("ContextBudgetResult", () => {
+  test("carries a contentTypes breakdown field", () => {
+    // type-level assertion: the field must exist and be the breakdown shape
+    const sample: ContextBudgetResult["contentTypes"] = {
+      rows: [{ category: "code", calls: 1, bytes: 4, estTokens: 1, tokenShare: 1 }],
+      totals: { calls: 1, bytes: 4, estTokens: 1 },
+    };
+    expect(sample.rows[0].category).toBe("code");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/queries/context-budget.test.ts`
+Expected: FAIL - `Property 'contentTypes' does not exist on type 'ContextBudgetResult'` (a type error at test compile).
+
+- [ ] **Step 3: Extend the result + the query**
+
+In `apps/axctl/src/queries/context-budget.ts`:
+
+a) import the helper at the top:
+```typescript
+import { fetchContentTypeBreakdown, type ContentTypeBreakdown } from "./content-types.ts";
+```
+
+b) add the field to the `ContextBudgetResult` interface:
+```typescript
+  /** content-type distribution of tool outputs (token-weighted). */
+  readonly contentTypes: ContentTypeBreakdown;
+```
+
+c) inside `fetchContextBudget`, add the helper to the existing `Effect.all` batch and attach it. The function already does `Effect.all([...], { concurrency: 3 })`; add a fourth element and bump concurrency:
+```typescript
+    const [rawRes, summaryRes, recentRes, contentTypes] = yield* Effect.all([
+      db.query<[Array<Record<string, unknown>>]>(BUDGET_SQL),
+      db.query<[Array<Record<string, unknown>>]>(UNUSED_SUMMARY_SQL),
+      db.query<[Array<Record<string, unknown>>]>(UNUSED_RECENT_SQL(WINDOW_DAYS)),
+      fetchContentTypeBreakdown(),
+    ], { concurrency: 4 });
+```
+and add `contentTypes` to the returned object:
+```typescript
+    return { skills, sources, totals, contentTypes } satisfies ContextBudgetResult;
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `bun test apps/axctl/src/queries/context-budget.test.ts && bun run typecheck`
+Expected: PASS + clean typecheck.
+
+Run (smoke the live endpoint, daemon must be up):
+```bash
+curl -s http://127.0.0.1:1738/api/context/budget | jq '.contentTypes.rows[:5]'
+```
+Expected: top content-type rows with category/estTokens/tokenShare.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/queries/context-budget.ts apps/axctl/src/queries/context-budget.test.ts
+git commit -m "feat(context-budget): content-type breakdown facet"
+```
+
+**=== Phase 1 ship point. The signal is captured and visible on the headline surface. Tasks 7-10 are independent add-ons. ===**
+
+---
+
+## Task 7: Content-type dimension on cost split
+
+**Files:**
+- Modify: `apps/axctl/src/queries/cost-analytics.ts`
+- Test: `apps/axctl/src/queries/cost-analytics.test.ts` (add a focused test)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to apps/axctl/src/queries/cost-analytics.test.ts
+import { attachContentMix } from "./cost-analytics.ts";
+
+test("attachContentMix folds per-session content mix into cost rows", () => {
+  const rows = [{ session: "session:s1", model: "opus", cost_usd: 1.0 }];
+  const mix = [{ sessionId: "session:s1", mix: { rows: [{ category: "code", calls: 1, bytes: 8, estTokens: 2, tokenShare: 1 }], totals: { calls: 1, bytes: 8, estTokens: 2 } } }];
+  const out = attachContentMix(rows as never, mix as never);
+  expect(out[0].topContentType).toBe("code");
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test apps/axctl/src/queries/cost-analytics.test.ts`
+Expected: FAIL - `attachContentMix` not exported.
+
+- [ ] **Step 3: Implement the pure fold**
+
+In `apps/axctl/src/queries/cost-analytics.ts`, add:
+```typescript
+import type { SessionContentMix } from "./content-types.ts";
+
+export const attachContentMix = <T extends { readonly session: string }>(
+  rows: ReadonlyArray<T>,
+  mixes: ReadonlyArray<SessionContentMix>,
+): Array<T & { topContentType: string | null }> => {
+  const byId = new Map(mixes.map((m) => [m.sessionId, m.mix.rows[0]?.category ?? null]));
+  return rows.map((r) => ({ ...r, topContentType: byId.get(r.session) ?? null }));
+};
+```
+Then in the cost-split query function, call `fetchSessionContentMix()` alongside the existing query and pass both through `attachContentMix` before returning. Add `topContentType` to the row output type.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test apps/axctl/src/queries/cost-analytics.test.ts && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/queries/cost-analytics.ts apps/axctl/src/queries/cost-analytics.test.ts
+git commit -m "feat(cost): content-type dimension on cost split"
+```
+
+---
+
+## Task 8: `--type` filter on recall
+
+**Files:**
+- Modify: `apps/axctl/src/cli/commands/recall.ts`
+- Test: `apps/axctl/src/cli/commands/recall.test.ts` (add a parse test)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to apps/axctl/src/cli/commands/recall.test.ts
+import { parseTypeFlag } from "./recall.ts";
+
+test("parseTypeFlag splits CSV and rejects unknown categories", () => {
+  expect(parseTypeFlag("code,json")).toEqual(["code", "json"]);
+  expect(() => parseTypeFlag("code,bogus")).toThrow(/unknown content type/);
+  expect(parseTypeFlag(null)).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test apps/axctl/src/cli/commands/recall.test.ts`
+Expected: FAIL - `parseTypeFlag` not exported.
+
+- [ ] **Step 3: Implement, mirroring parseSourcesFlag**
+
+In `apps/axctl/src/cli/commands/recall.ts` add, next to `parseSourcesFlag`:
+```typescript
+import { ALL_CONTENT_CATEGORIES } from "../../ingest/content-type-classify.ts";
+const VALID_TYPES = new Set<string>(ALL_CONTENT_CATEGORIES);
+
+export function parseTypeFlag(raw: string | null): ReadonlyArray<string> | null {
+  if (!raw) return null;
+  const parts = parseCsvFlag(raw);
+  const invalid = parts.filter((p) => !VALID_TYPES.has(p));
+  if (invalid.length > 0) fail(`unknown content type(s): ${invalid.join(", ")}.`);
+  return parts;
+}
+```
+Then thread the parsed types into the turn query. Keep it deref-free: pre-query
+`SELECT type::string(session) AS sid FROM has_content WHERE out.category IN [...]`
+into a session-id set and filter turns by that set in JS, matching the recall
+scope-filter idiom. Do NOT add graph derefs to the turn full-text query.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test apps/axctl/src/cli/commands/recall.test.ts && bun run apps/axctl/bin/axctl recall "session" --type=code`
+Expected: parse test PASS; command returns code-typed hits only.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/cli/commands/recall.ts apps/axctl/src/cli/commands/recall.test.ts
+git commit -m "feat(recall): --type content-type filter"
+```
+
+---
+
+## Task 9: Content-type facet on insights (friction / churn)
+
+**Files:**
+- Modify: `apps/axctl/src/queries/insights.ts` (or the friction query module it delegates to)
+- Test: the existing insights test file (add a focused case)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to the insights/friction test file
+import { foldContentTypeOntoFriction } from "./insights.ts";
+
+test("friction rows gain content_type of the failing tool output", () => {
+  const friction = [{ session: "session:s1", toolCallId: "tool_call:a" }];
+  const byTc = new Map([["tool_call:a", "unknown"]]);
+  const out = foldContentTypeOntoFriction(friction as never, byTc);
+  expect(out[0].contentType).toBe("unknown");
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test apps/axctl/src/queries/insights.test.ts`
+Expected: FAIL - export missing.
+
+- [ ] **Step 3: Implement the fold + the lookup query**
+
+Add to `insights.ts`:
+```typescript
+export const foldContentTypeOntoFriction = <T extends { readonly toolCallId: string }>(
+  rows: ReadonlyArray<T>,
+  byToolCall: ReadonlyMap<string, string>,
+): Array<T & { contentType: string | null }> =>
+  rows.map((r) => ({ ...r, contentType: byToolCall.get(r.toolCallId) ?? null }));
+```
+Feed it from a flat lookup:
+```sql
+SELECT type::string(in) AS tid, type::string(out) AS ct FROM has_content;
+```
+mapped into `Map<tid, category>` (strip the `content_type:` prefix). Surfaces the spike's "unknown -> 42% error" signal directly in the friction view.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test apps/axctl/src/queries/insights.test.ts && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/queries/insights.ts apps/axctl/src/queries/insights.test.ts
+git commit -m "feat(insights): content-type facet on friction"
+```
+
+---
+
+## Task 10: `tool-output-mix` profile taste pattern
+
+**Files:**
+- Modify: `apps/axctl/src/profile/schema.ts` (add the category) + the profile builder module that assembles patterns
+- Test: the profile builder test file
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to the profile builder test (use the actual builder path)
+import { buildToolOutputMixPattern } from "./builder.ts";
+
+test("builds a tool-output-mix pattern from the content breakdown", () => {
+  const p = buildToolOutputMixPattern({
+    rows: [
+      { category: "code", calls: 10, bytes: 800, estTokens: 200, tokenShare: 0.8 },
+      { category: "text", calls: 5, bytes: 200, estTokens: 50, tokenShare: 0.2 },
+    ],
+    totals: { calls: 15, bytes: 1000, estTokens: 250 },
+  }, 42);
+  expect(p?.category).toBe("tool-output-mix");
+  expect(p?.summary).toContain("code");
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bun test apps/axctl/src/profile/builder.test.ts`
+Expected: FAIL - export missing.
+
+- [ ] **Step 3: Add the category + builder**
+
+In `apps/axctl/src/profile/schema.ts` add `"tool-output-mix"` to `PATTERN_CATEGORIES` and (if patterns are a discriminated union) add a struct variant carrying `mix: Array<{category, share}>`. Then in the builder:
+```typescript
+import type { ContentTypeBreakdown } from "../queries/content-types.ts";
+
+export const buildToolOutputMixPattern = (
+  breakdown: ContentTypeBreakdown,
+  sessions: number,
+) => {
+  const top = breakdown.rows.slice(0, 3);
+  if (top.length === 0) return null;
+  const lead = top[0];
+  return {
+    category: "tool-output-mix" as const,
+    name: `${lead.category}-heavy context`,
+    summary: `Context is ${Math.round(lead.tokenShare * 100)}% ${lead.category} by tokens (${top.map((r) => r.category).join(", ")}).`,
+    mix: top.map((r) => ({ category: r.category, share: Number(r.tokenShare.toFixed(2)) })),
+    evidence: { sessions, confidence: 0.9 },
+  };
+};
+```
+Wire it into the pattern assembly (call `fetchContentTypeBreakdown()` where the builder gathers its inputs, push the non-null pattern). This is the "org"/community read surface - it flows into the published ProfileV1 + leaderboard automatically.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bun test apps/axctl/src/profile/builder.test.ts && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/axctl/src/profile/schema.ts apps/axctl/src/profile/builder.ts apps/axctl/src/profile/builder.test.ts
+git commit -m "feat(profile): tool-output-mix taste pattern"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `bun test` (repo-wide) - all green.
+- [ ] `bun run typecheck` - clean.
+- [ ] `bun run apps/axctl/bin/axctl ingest --stages=content-types` then re-run - second run reports nearly all `skipped` (idempotency).
+- [ ] `curl -s http://127.0.0.1:1738/api/context/budget | jq '.contentTypes'` - populated.
+- [ ] No em-dash characters introduced (the repo write-hook rejects them); no emoji.
+
+---
+
+## Notes / deferred
+
+- **Real cost (USD) per content-type** is dormant until `telemetry_of` edges exist in the DB (currently 0). The bytes/4 est-token proxy ships now; when telemetry lands, extend the helper with a `session -> telemetry_of -> otel_*` cost join (same dark-then-lit pattern as the telemetry-insight enrichment PR). Do NOT block this plan on it.
+- **Magika upgrade** (optional, later): add a `local_model` ClassifierDefinition that re-scores low-confidence (`fallback`/`sniff`) edges only. Keep it out of the hot ingest path; the deterministic classifier stays the default.
+- **Studio rendering** of the content-type breakdown (a tile on the context-budget view) is a thin follow-up once Task 6 exposes the field; not required for the data to be correct.

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -369,6 +369,25 @@ DEFINE INDEX IF NOT EXISTS tool_call_command_tool_ts ON tool_call FIELDS command
 DEFINE INDEX IF NOT EXISTS tool_call_error_ts ON tool_call FIELDS has_error, ts;
 DEFINE INDEX IF NOT EXISTS tool_call_agent_event ON tool_call FIELDS agent_event;
 
+-- Content-type classification of tool_call outputs (derive-content-types stage).
+-- Closed taxonomy; one node per category. See content-type-classify.ts.
+DEFINE TABLE content_type SCHEMAFULL;
+DEFINE FIELD category    ON content_type TYPE string;
+DEFINE FIELD label       ON content_type TYPE string;
+
+-- has_content: tool_call -> content_type. Denormalizes session + bytes so every
+-- downstream rollup is deref-free (house idiom; derefs in aggregates hang prod).
+DEFINE TABLE has_content TYPE RELATION FROM tool_call TO content_type SCHEMAFULL;
+DEFINE FIELD method      ON has_content TYPE string;
+DEFINE FIELD confidence  ON has_content TYPE float DEFAULT 1.0;
+DEFINE FIELD fine_label  ON has_content TYPE option<string>;
+DEFINE FIELD bytes       ON has_content TYPE int DEFAULT 0;
+DEFINE FIELD session     ON has_content TYPE option<record<session>>;
+DEFINE FIELD ts          ON has_content TYPE datetime;
+DEFINE INDEX IF NOT EXISTS has_content_in  ON has_content FIELDS in;
+DEFINE INDEX IF NOT EXISTS has_content_out ON has_content FIELDS out;
+DEFINE INDEX IF NOT EXISTS has_content_session ON has_content FIELDS session;
+
 DEFINE TABLE plan SCHEMAFULL;
 DEFINE FIELD session        ON plan TYPE option<record<session>>;
 DEFINE FIELD source         ON plan TYPE option<string>;


### PR DESCRIPTION
## Summary

Classifies every `tool_call` output by content-type (a closed 12-category taxonomy) at ingest, writes it as a `has_content` graph edge, and threads the content-type facet through existing read paths. No new CLI command, no new MCP tool - content-type is a dimension, not a destination.

The classifier is a deterministic TS heuristic (file extension from the tool input, else a lightweight content sniff; `ClassifierKind=heuristic`). The spike used Google's Magika to prove the signal was real; the production path deliberately avoids that tfjs dependency - group-level categories from ext+sniff were the trustworthy part of the spike. Magika can return later as an optional `local_model` upgrade.

The `has_content` edge denormalizes `session` + `bytes`, so every downstream rollup is a flat `GROUP BY` (deref-free - the house idiom).

### Write path
- `content-type-classify.ts` - pure deterministic classifier (12 categories).
- `content_type` node + `has_content` edge schema (applied live; ~216k edges, fully idempotent).
- `derive-content-types` ingest stage - incremental, since-aware, batched.

### Read path (enhance-only)
- `queries/content-types.ts` - shared deref-free rollup helper (global distribution + per-session mix).
- `/api/context/budget` - gains a `contentTypes` breakdown (headline surface).
- `ax cost split` - global content-type sibling field.
- `ax recall --type=<csv>` - filter by content type (deref-free session prefilter).
- `ax insights friction` - per-session dominant content type (carries the `unknown` -> high-error signal).
- ProfileV1 - `tool-output-mix` taste pattern (flows to community/leaderboard).

### Signals already visible in live data
- `binary`-class outputs: 0.6% of calls but the 2nd-largest token sink (~131MB) - the giant-blob concentration the spike predicted.
- `unknown`/`empty` outputs error far more than code/text.

### Notable during build
- Edge key switched from `safeKeyPart` (truncates at 96 chars -> long Cursor/OpenCode tool-id collisions) to the repo's canonical `stableDigest`; the since-fix recovered 215 prior collision victims.
- Stage deps widened to all four tool_call producers (claude/codex/pi/cursor) after a write-path review caught a scheduler race.

## Test Plan
- [x] `bun test` repo-wide: 4820 pass, 0 fail, 5 skip (live-DB e2e)
- [x] `bun run typecheck`: clean (exit 0; no feature-file issues)
- [x] Ingest run twice -> second reports written=0 (idempotent)
- [x] `ax recall "..." --type=code` filters; `--type=bogus` errors cleanly
- [ ] Reviewer: confirm the full-history rescan is acceptably windowed via `sinceDaysFromCtx` on the hot watcher path
- [ ] After merge: run ax from source / rebuild binary to display `contentTypes` on the live `/api/context/budget`

Plan: `docs/superpowers/plans/2026-06-17-content-type-classification.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)