### PR TITLE
[codex] fix dogfood discovery surfaces

### DIFF
--- a/apps/axctl/src/cli/commands/ax-cost.test.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { renderCostModelsTable } from "./ax-cost.ts";
+import type { CostModelsResult } from "../../queries/cost-analytics.ts";
+
+describe("renderCostModelsTable", () => {
+    test("does not clip large token counts or large costs", () => {
+        const result: CostModelsResult = {
+            total_cost_usd: 10999.397,
+            rows: [
+                {
+                    model: "claude-opus-4-8",
+                    sessions: 502,
+                    prompt_tokens: 15_171_682_086,
+                    completion_tokens: 48_223_592,
+                    cache_read_tokens: 14_781_735_443,
+                    cache_create_tokens: 361_331_748,
+                    cost_usd: 10_999.397,
+                },
+            ],
+        };
+
+        const out = renderCostModelsTable(result);
+
+        expect(out).toContain("15,171,682,086");
+        expect(out).toContain("14,781,735,443");
+        expect(out).toContain("$10999.3970");
+        expect(out).not.toContain("14,781,735,4 ");
+        expect(out).not.toContain("$10999.397\n");
+    });
+});

--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -13,6 +13,7 @@ import {
     fetchCostModels,
     fetchCostSessions,
     fetchCostSplit,
+    type CostModelsResult,
 } from "../../queries/cost-analytics.ts";
 import { fetchRoutability, type RoutabilityResult } from "../../queries/routability.ts";
 import {
@@ -28,6 +29,40 @@ import { fail, jsonFlag, optionValue, positiveLimit } from "./shared.ts";
 // ---------------------------------------------------------------------------
 // ax cost models [--days=N] [--json]
 // ---------------------------------------------------------------------------
+
+export function renderCostModelsTable(result: CostModelsResult): string {
+    type ModelRow = {
+        model: string;
+        sessions: string;
+        prompt: string;
+        completion: string;
+        cache_read: string;
+        cache_create: string;
+        cost: string;
+    };
+
+    const rendered: ModelRow[] = result.rows.map((r) => ({
+        model: r.model,
+        sessions: integer(r.sessions),
+        prompt: integer(r.prompt_tokens),
+        completion: integer(r.completion_tokens),
+        cache_read: integer(r.cache_read_tokens),
+        cache_create: integer(r.cache_create_tokens),
+        cost: usd(r.cost_usd),
+    }));
+
+    const cols: Column<ModelRow>[] = [
+        { header: "model", get: (r) => r.model, min: 20 },
+        { header: "sessions", get: (r) => r.sessions, align: "right", min: 8 },
+        { header: "prompt", get: (r) => r.prompt, align: "right", min: 14 },
+        { header: "completion", get: (r) => r.completion, align: "right", min: 14 },
+        { header: "cache_read", get: (r) => r.cache_read, align: "right", min: 12 },
+        { header: "cache_create", get: (r) => r.cache_create, align: "right", min: 12 },
+        { header: "cost", get: (r) => r.cost, align: "right", min: 10 },
+    ];
+
+    return renderTable({ columns: cols, rows: rendered, gap: " " });
+}
 
 const cmdCostModels = (input: {
     readonly sinceDays: number;
@@ -47,38 +82,7 @@ const cmdCostModels = (input: {
         }
 
         printNextLinks(buildCostModelsNext(result));
-
-        type ModelRow = {
-            model: string;
-            sessions: string;
-            prompt: string;
-            completion: string;
-            cache_read: string;
-            cache_create: string;
-            cost: string;
-        };
-
-        const rendered: ModelRow[] = result.rows.map((r) => ({
-            model: r.model,
-            sessions: integer(r.sessions),
-            prompt: integer(r.prompt_tokens),
-            completion: integer(r.completion_tokens),
-            cache_read: integer(r.cache_read_tokens),
-            cache_create: integer(r.cache_create_tokens),
-            cost: usd(r.cost_usd),
-        }));
-
-        const cols: Column<ModelRow>[] = [
-            { header: "model", get: (r) => r.model, min: 20 },
-            { header: "sessions", get: (r) => r.sessions, align: "right", width: 8 },
-            { header: "prompt", get: (r) => r.prompt, align: "right", width: 14 },
-            { header: "completion", get: (r) => r.completion, align: "right", width: 14 },
-            { header: "cache_read", get: (r) => r.cache_read, align: "right", width: 12 },
-            { header: "cache_create", get: (r) => r.cache_create, align: "right", width: 12 },
-            { header: "cost", get: (r) => r.cost, align: "right", width: 10 },
-        ];
-
-        console.log(renderTable({ columns: cols, rows: rendered, gap: " " }));
+        console.log(renderCostModelsTable(result));
         console.log(`\ntotal: ${usd(result.total_cost_usd)}  (${input.sinceDays} days)`);
     });
 

--- a/apps/axctl/src/cli/commands/dojo.ts
+++ b/apps/axctl/src/cli/commands/dojo.ts
@@ -52,7 +52,7 @@ import {
     resolveSkillSparTask,
     scoreSkillSpar,
 } from "../../dojo/skill-spar.ts";
-import { resolvePwdRepository } from "../../pwd.ts";
+import { mainRepoRootFromGitCommonDir, resolvePwdRepository } from "../../pwd.ts";
 import { defaultQuotaCachePath } from "../../quota/cache.ts";
 import { QuotaEnvLive } from "../../quota/quota-env.ts";
 import { getQuota } from "../../quota/quota.ts";
@@ -317,15 +317,9 @@ const resolveMainRepoRoot = (repoRoot: string) =>
         const res = yield* proc.exec("git", ["rev-parse", "--git-common-dir"], {
             cwd: repoRoot,
         });
-        const commonDir = res.code === 0 ? res.stdout.trim() : "";
-        if (commonDir.length === 0) return repoRoot;
-        // commonDir is usually absolute (".../<main>/.git") but can be the bare
-        // ".git" relative form when already at the main root.
-        if (commonDir === ".git") return repoRoot;
-        const abs = posixPath.isAbsolute(commonDir)
-            ? commonDir
-            : posixPath.join(repoRoot, commonDir);
-        return posixPath.dirname(abs);
+        // Shared with `resolvePwdRepository` so both call sites agree on how a
+        // linked worktree maps back to its primary checkout.
+        return mainRepoRootFromGitCommonDir(repoRoot, res.code === 0 ? res.stdout.trim() : "");
     });
 
 /**

--- a/apps/axctl/src/cli/commands/profile.test.ts
+++ b/apps/axctl/src/cli/commands/profile.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import {
+    profileProgressLine,
+    shouldEmitProfileProgress,
+} from "./profile.ts";
+
+describe("profile show progress", () => {
+    test("emits by default on TTY stderr and stays silent when AX_PROGRESS=off", () => {
+        expect(shouldEmitProfileProgress({ stderrIsTTY: true, progressEnv: undefined })).toBe(true);
+        expect(shouldEmitProfileProgress({ stderrIsTTY: true, progressEnv: "off" })).toBe(false);
+    });
+
+    test("AX_PROGRESS=on/plain force progress for redirected stderr", () => {
+        expect(shouldEmitProfileProgress({ stderrIsTTY: false, progressEnv: "on" })).toBe(true);
+        expect(shouldEmitProfileProgress({ stderrIsTTY: false, progressEnv: "plain" })).toBe(true);
+        expect(shouldEmitProfileProgress({ stderrIsTTY: false, progressEnv: undefined })).toBe(false);
+    });
+
+    test("progress lines describe the slow graph-building phase", () => {
+        expect(profileProgressLine("env", { windowDays: 14, includeCost: true })).toBe(
+            "ax profile show: gathering local environment",
+        );
+        expect(profileProgressLine("build", { windowDays: 14, includeCost: true })).toBe(
+            "ax profile show: building graph profile (window=14d, cost=on)",
+        );
+        expect(profileProgressLine("done", { windowDays: 14, includeCost: false }, 27040)).toBe(
+            "ax profile show: done in 27.0s",
+        );
+    });
+});

--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -178,6 +178,47 @@ export function formatProfile(p: ProfileV1): string {
 // ax profile show [--window=30] [--no-cost] [--json]
 // ---------------------------------------------------------------------------
 
+type ProfileProgressStep = "env" | "build" | "done";
+
+export function shouldEmitProfileProgress(input: {
+    readonly stderrIsTTY: boolean;
+    readonly progressEnv: string | undefined;
+}): boolean {
+    const mode = (input.progressEnv ?? "").toLowerCase();
+    if (mode === "off") return false;
+    return input.stderrIsTTY || mode === "on" || mode === "plain";
+}
+
+export function profileProgressLine(
+    step: ProfileProgressStep,
+    input: { readonly windowDays: number; readonly includeCost: boolean },
+    elapsedMs?: number,
+): string {
+    if (step === "env") return "ax profile show: gathering local environment";
+    if (step === "build") {
+        return `ax profile show: building graph profile (window=${input.windowDays}d, cost=${input.includeCost ? "on" : "off"})`;
+    }
+    const seconds = ((elapsedMs ?? 0) / 1000).toFixed(1);
+    return `ax profile show: done in ${seconds}s`;
+}
+
+const makeProfileProgress = (input: {
+    readonly windowDays: number;
+    readonly includeCost: boolean;
+}) => {
+    const enabled = shouldEmitProfileProgress({
+        stderrIsTTY: process.stderr.isTTY === true,
+        progressEnv: process.env.AX_PROGRESS,
+    });
+    const startedAt = Date.now();
+    return (step: ProfileProgressStep) =>
+        Effect.sync(() => {
+            if (!enabled) return;
+            const elapsedMs = step === "done" ? Date.now() - startedAt : undefined;
+            process.stderr.write(`${profileProgressLine(step, input, elapsedMs)}\n`);
+        });
+};
+
 const profileShowCommand = Command.make(
     "show",
     {
@@ -190,12 +231,16 @@ const profileShowCommand = Command.make(
             fail(`ax profile show: --window must be a positive integer (got "${window}")`);
         }
         return Effect.gen(function* () {
+            const progress = makeProfileProgress({ windowDays: window, includeCost: !noCost });
+            yield* progress("env");
             const env = yield* gatherEnv;
+            yield* progress("build");
             const profile = yield* buildProfile({
                 windowDays: window,
                 includeCost: !noCost,
                 env,
             });
+            yield* progress("done");
             console.log(json ? prettyPrint(profile) : formatProfile(profile));
         });
     },

--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -186,7 +186,8 @@ export function shouldEmitProfileProgress(input: {
 }): boolean {
     const mode = (input.progressEnv ?? "").toLowerCase();
     if (mode === "off") return false;
-    return input.stderrIsTTY || mode === "on" || mode === "plain";
+    // Force-emit modes mirror the ingest resolver (`withIngest`, cli/index.ts).
+    return input.stderrIsTTY || mode === "on" || mode === "plain" || mode === "pipeline";
 }
 
 export function profileProgressLine(

--- a/apps/axctl/src/cli/commands/sessions.test.ts
+++ b/apps/axctl/src/cli/commands/sessions.test.ts
@@ -15,4 +15,21 @@ describe("sessions command helpers", () => {
             mainRepoRoot: "/repo",
         })).toBe("/repo");
     });
+
+    test("projectRootForHere keeps its own root for an external linked worktree", () => {
+        // Worktree NOT nested under the main checkout: rolling up to mainRepoRoot
+        // would drop this worktree's own sessions (cwd path-prefix filter).
+        expect(projectRootForHere({
+            repoRoot: "/tmp/ax-issue-123",
+            mainRepoRoot: "/repo",
+        })).toBe("/tmp/ax-issue-123");
+    });
+
+    test("projectRootForHere ignores a mis-derived (internal) main root", () => {
+        // e.g. submodule `--git-common-dir` resolving to `.git/modules/<name>`.
+        expect(projectRootForHere({
+            repoRoot: "/repo",
+            mainRepoRoot: "/repo/.git/modules/sub",
+        })).toBe("/repo");
+    });
 });

--- a/apps/axctl/src/cli/commands/sessions.test.ts
+++ b/apps/axctl/src/cli/commands/sessions.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { projectRootForHere } from "./sessions.ts";
+
+describe("sessions command helpers", () => {
+    test("projectRootForHere uses main checkout root for linked worktrees", () => {
+        expect(projectRootForHere({
+            repoRoot: "/repo/.claude/worktrees/issue-123",
+            mainRepoRoot: "/repo",
+        })).toBe("/repo");
+    });
+
+    test("projectRootForHere keeps the active checkout for normal repos", () => {
+        expect(projectRootForHere({
+            repoRoot: "/repo",
+            mainRepoRoot: "/repo",
+        })).toBe("/repo");
+    });
+});

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -38,7 +38,7 @@ import { fetchSessionChurnSummary, formatSessionChurnSummary } from "../../metri
 import { fetchSessionMetrics } from "../../metrics/session-metrics-query.ts";
 import { formatSessionMetrics, SESSION_METRICS_LEGEND } from "../../metrics/util.ts";
 import { buildSessionsNext, buildSessionShowNext } from "../../nav/next-links.ts";
-import { resolvePwdRepository } from "../../pwd.ts";
+import { resolvePwdRepository, type PwdResolution } from "../../pwd.ts";
 import { printNextLinks } from "../next-format.ts";
 import { catchDbErrorAndExit, stderrExit, wantsJsonFlag } from "../output.ts";
 import { renderCompareTable, renderCompareJson } from "../session-compare-format.ts";
@@ -57,6 +57,10 @@ import {
 // ---------------------------------------------------------------------------
 // ax sessions - windowed session queries (F2, F3)
 // ---------------------------------------------------------------------------
+
+export const projectRootForHere = (
+    pwd: Pick<PwdResolution, "repoRoot" | "mainRepoRoot">,
+): string => pwd.mainRepoRoot || pwd.repoRoot;
 
 /**
  * Format a list of SessionRows for TTY output as a compact table.
@@ -648,7 +652,7 @@ const cmdSessionsMetrics = (input: {
                     stderrExit(`axctl sessions metrics: --here requires a git repository (cwd=${err.cwd})\n`, 2),
                 ),
             );
-            project = pwd.repoRoot;
+            project = projectRootForHere(pwd);
         }
         const since = input.sinceDays === null
             ? null
@@ -758,7 +762,7 @@ export const cmdSessionsChurn = (input: {
                     stderrExit(`axctl sessions churn: --here requires a git repository (cwd=${err.cwd})\n`, 2),
                 ),
             );
-            project = pwd.repoRoot;
+            project = projectRootForHere(pwd);
         }
 
         // Default window keeps the all-session fan-out bounded on mature DBs;

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -60,7 +60,18 @@ import {
 
 export const projectRootForHere = (
     pwd: Pick<PwdResolution, "repoRoot" | "mainRepoRoot">,
-): string => pwd.mainRepoRoot || pwd.repoRoot;
+): string => {
+    const { repoRoot, mainRepoRoot } = pwd;
+    if (!mainRepoRoot || mainRepoRoot === repoRoot) return repoRoot;
+    // `sessionProjectClause` filters by cwd path-prefix, so rolling `--here` up
+    // to the primary checkout only works when this worktree physically lives
+    // under it (the common `.claude/worktrees/*` layout). An external/bare
+    // worktree - or a mis-derived `--git-common-dir` (submodule `.git/modules/*`
+    // etc.) - keeps its own root, otherwise its sessions would be silently
+    // filtered out of `sessions metrics/churn --here`.
+    const prefix = mainRepoRoot.endsWith("/") ? mainRepoRoot : `${mainRepoRoot}/`;
+    return repoRoot.startsWith(prefix) ? mainRepoRoot : repoRoot;
+};
 
 /**
  * Format a list of SessionRows for TTY output as a compact table.

--- a/apps/axctl/src/cli/commands/shared.test.ts
+++ b/apps/axctl/src/cli/commands/shared.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { Option } from "effect";
-import { fail, parseCsvFlag, parseFileHints, requirePositiveInt } from "./shared.ts";
+import {
+    fail,
+    parseCsvFlag,
+    parseFileHints,
+    parseOptionalPositiveDayWindow,
+    requirePositiveInt,
+} from "./shared.ts";
 
 // ---------------------------------------------------------------------------
 // fail
@@ -50,6 +56,21 @@ describe("fail", () => {
         expect(requirePositiveInt("sessions around", "days", 14)).toBe(14);
         expect(errorOutput).toEqual([]);
         expect(exitCode).toBeUndefined();
+    });
+
+    it("parseOptionalPositiveDayWindow accepts bare days and d-suffix days", () => {
+        expect(parseOptionalPositiveDayWindow("skills weighted", "window", undefined)).toBeUndefined();
+        expect(parseOptionalPositiveDayWindow("skills weighted", "window", "14")).toBe(14);
+        expect(parseOptionalPositiveDayWindow("skills weighted", "window", "14d")).toBe(14);
+        expect(parseOptionalPositiveDayWindow("skills weighted", "window", "14D")).toBe(14);
+    });
+
+    it("parseOptionalPositiveDayWindow rejects malformed windows with a usage error", () => {
+        expect(() => parseOptionalPositiveDayWindow("skills weighted", "window", "2w")).toThrow("process.exit(2)");
+        expect(errorOutput).toEqual([
+            'axctl skills weighted: --window must be a positive integer day window like 14 or 14d (got "2w")',
+        ]);
+        expect(exitCode).toBe(2);
     });
 });
 

--- a/apps/axctl/src/cli/commands/shared.ts
+++ b/apps/axctl/src/cli/commands/shared.ts
@@ -64,6 +64,24 @@ export function requireOptionalPositiveInt(
     return requirePositiveInt(cmd, flagName, n);
 }
 
+/** Optional day-window flag: accepts `14` and the documented `14d` spelling. */
+export function parseOptionalPositiveDayWindow(
+    cmd: string,
+    flagName: string,
+    value: string | undefined,
+): number | undefined {
+    if (value === undefined) return undefined;
+    const raw = value.trim();
+    const match = raw.match(/^(\d+)(?:d)?$/i);
+    const n = match ? Number(match[1]) : Number.NaN;
+    if (!Number.isSafeInteger(n) || n <= 0) {
+        fail(
+            `axctl ${cmd}: --${flagName} must be a positive integer day window like 14 or 14d (got "${value}")`,
+        );
+    }
+    return n;
+}
+
 /**
  * Format a numeric counter with thousand-separators (issue #46). Thin
  * unknown-typed bridge over `@ax/lib/shared/formatters` fmtCount for the raw

--- a/apps/axctl/src/cli/commands/skills.ts
+++ b/apps/axctl/src/cli/commands/skills.ts
@@ -47,9 +47,9 @@ import {
     fmtCount,
     jsonFlag,
     optionValue,
+    parseOptionalPositiveDayWindow,
     positiveLimit,
     requirePositiveInt,
-    requireOptionalPositiveInt,
 } from "./shared.ts";
 
 interface SearchInput {
@@ -386,7 +386,7 @@ const cmdSkillsLoaded = (input: SkillsLoadedInput) =>
 
 interface SkillsWeightedInput {
     readonly limit: number;
-    readonly windowDays: number | undefined;
+    readonly windowDays: string | undefined;
     readonly doctorThreshold: number;
     readonly includeTools: boolean;
     readonly json: boolean;
@@ -395,7 +395,7 @@ interface SkillsWeightedInput {
 const cmdSkillsWeighted = (input: SkillsWeightedInput) =>
     Effect.gen(function* () {
         const limit = requirePositiveInt("skills weighted", "limit", input.limit);
-        const windowDays = requireOptionalPositiveInt("skills weighted", "window", input.windowDays);
+        const windowDays = parseOptionalPositiveDayWindow("skills weighted", "window", input.windowDays);
         const doctorThreshold = requirePositiveInt("skills weighted", "doctor-threshold", input.doctorThreshold);
         const json = input.json;
         const includeTools = input.includeTools;
@@ -975,7 +975,7 @@ const loadedCommand = Command.make(
 const weightedCommand = Command.make(
     "weighted",
     {
-        window: Flag.integer("window").pipe(Flag.optional),
+        window: Flag.string("window").pipe(Flag.optional),
         limit: positiveLimit(25),
         doctorThreshold: Flag.integer("doctor-threshold").pipe(Flag.withDefault(5)),
         includeTools: Flag.boolean("include-tools").pipe(Flag.withDefault(false)),

--- a/apps/axctl/src/cli/commands/usage.test.ts
+++ b/apps/axctl/src/cli/commands/usage.test.ts
@@ -5,6 +5,10 @@ import type { UsageRollup } from "../../usage/query.ts";
 const roll: UsageRollup = {
   windowDays: 30, total: 5, activeDays: 3,
   topCommands: [{ command: "digest", count: 3, last_used: "2026-06-15T11:00:00.000Z" }],
+  topCommandsByOrigin: {
+    tty: [{ command: "digest", count: 1, last_used: "2026-06-15T11:00:00.000Z" }],
+    agent: [{ command: "quota", count: 4, last_used: "2026-06-15T12:00:00.000Z" }],
+  },
   unusedSurface: ["quota", "thinking"],
   originSplit: { agent: 4, tty: 1 },
   reliability: [],
@@ -17,8 +21,22 @@ describe("renderUsage", () => {
     expect(out).toContain("digest");
     expect(out).toContain("2 never used");
   });
+  it("separates intentional tty usage from background agent usage", () => {
+    const out = renderUsage(roll);
+    expect(out).toContain("top tty commands:");
+    expect(out).toContain("top agent/background commands:");
+    expect(out).toMatch(/digest\s+1/);
+    expect(out).toMatch(/quota\s+4/);
+  });
   it("empty-state line when nothing recorded", () => {
-    const empty: UsageRollup = { ...roll, total: 0, activeDays: 0, topCommands: [], originSplit: { agent: 0, tty: 0 } };
+    const empty: UsageRollup = {
+      ...roll,
+      total: 0,
+      activeDays: 0,
+      topCommands: [],
+      topCommandsByOrigin: { agent: [], tty: [] },
+      originSplit: { agent: 0, tty: 0 },
+    };
     expect(renderUsage(empty)).toContain("no usage recorded yet");
   });
 });

--- a/apps/axctl/src/cli/commands/usage.ts
+++ b/apps/axctl/src/cli/commands/usage.ts
@@ -12,19 +12,27 @@ import type { RuntimeManifest } from "./manifest.ts";
 import { jsonFlag } from "./shared.ts";
 import { VISIBLE_COMMANDS } from "./visible-commands.ts";
 
+const renderCommandCounts = (commands: UsageRollup["topCommands"]): string =>
+    commands
+        .map((c) => `  ${c.command.padEnd(22)} ${String(c.count).padStart(5)}`)
+        .join("\n");
+
 /** Render a UsageRollup as a human-readable board. Pure (tested). */
 export const renderUsage = (r: UsageRollup): string => {
     if (r.total === 0) return "[ax] no usage recorded yet - run some ax commands, then ingest.";
-    const top = r.topCommands
-        .slice(0, 8)
-        .map((c) => `  ${c.command.padEnd(22)} ${String(c.count).padStart(5)}`)
-        .join("\n");
+    const top = renderCommandCounts(r.topCommands.slice(0, 8));
+    const topTty = renderCommandCounts(r.topCommandsByOrigin.tty.slice(0, 5)) || "  (none)";
+    const topAgent = renderCommandCounts(r.topCommandsByOrigin.agent.slice(0, 5)) || "  (none)";
     const unusedCount = r.unusedSurface.length;
     const unusedList = r.unusedSurface.slice(0, 12).join(", ");
     return [
         `[ax] usage (${r.windowDays}d): ${r.total} runs across ${r.activeDays} active days  (agent ${r.originSplit.agent} / tty ${r.originSplit.tty})`,
         "top commands:",
         top,
+        "top tty commands:",
+        topTty,
+        "top agent/background commands:",
+        topAgent,
         `${unusedCount} never used: ${unusedList}`,
     ].join("\n");
 };

--- a/apps/axctl/src/dashboard/contract/usage.test.ts
+++ b/apps/axctl/src/dashboard/contract/usage.test.ts
@@ -54,6 +54,7 @@ describe("usageRollup handler", () => {
             total: number;
             activeDays: number;
             topCommands: unknown[];
+            topCommandsByOrigin: { agent: unknown[]; tty: unknown[] };
             unusedSurface: string[];
             originSplit: { agent: number; tty: number };
             reliability: unknown[];
@@ -62,6 +63,8 @@ describe("usageRollup handler", () => {
         expect(body).toHaveProperty("total", 0);
         expect(body).toHaveProperty("activeDays", 0);
         expect(Array.isArray(body.topCommands)).toBe(true);
+        expect(Array.isArray(body.topCommandsByOrigin.agent)).toBe(true);
+        expect(Array.isArray(body.topCommandsByOrigin.tty)).toBe(true);
         expect(Array.isArray(body.unusedSurface)).toBe(true);
         expect(typeof body.originSplit).toBe("object");
         expect(body.originSplit).toHaveProperty("agent");
@@ -85,6 +88,10 @@ describe("usageRollup handler", () => {
             total: number;
             activeDays: number;
             topCommands: Array<{ command: string; count: number }>;
+            topCommandsByOrigin: {
+                agent: Array<{ command: string; count: number }>;
+                tty: Array<{ command: string; count: number }>;
+            };
             originSplit: { agent: number; tty: number };
             reliability: Array<{ command: string; failureRate: number }>;
             unusedSurface: string[];
@@ -94,6 +101,8 @@ describe("usageRollup handler", () => {
         expect(body.activeDays).toBe(3);
         // sessions is top command with 2 uses
         expect(body.topCommands[0]).toMatchObject({ command: "sessions", count: 2 });
+        expect(body.topCommandsByOrigin.tty[0]).toMatchObject({ command: "sessions", count: 2 });
+        expect(body.topCommandsByOrigin.agent[0]).toMatchObject({ command: "ingest", count: 1 });
         // origin split: 2 tty, 1 agent
         expect(body.originSplit).toEqual({ tty: 2, agent: 1 });
         // ingest had 1 failure out of 1 run

--- a/apps/axctl/src/dashboard/next-actions.test.ts
+++ b/apps/axctl/src/dashboard/next-actions.test.ts
@@ -13,6 +13,7 @@ import {
     churnCards,
     housekeepingCards,
     fetchNextActions,
+    nextActionSourceTimeoutMs,
     proposalCards,
     routingCards,
     skillHygieneCards,
@@ -613,6 +614,16 @@ describe("housekeepingCards", () => {
 });
 
 describe("fetchNextActions", () => {
+    test("default budgets keep fast tool failures separate from slower discovery sources", () => {
+        expect(nextActionSourceTimeoutMs("tool_failure")).toBe(4_000);
+        expect(nextActionSourceTimeoutMs("proposal")).toBe(12_000);
+        expect(nextActionSourceTimeoutMs("churn")).toBe(30_000);
+        expect(nextActionSourceTimeoutMs("routing")).toBe(12_000);
+        expect(nextActionSourceTimeoutMs("skill_hygiene")).toBe(30_000);
+        expect(nextActionSourceTimeoutMs("housekeeping")).toBe(12_000);
+        expect(nextActionSourceTimeoutMs("routing", 50)).toBe(50);
+    });
+
     test("a failing source degrades to a note, never a defect", async () => {
         const stub: SurrealClientShape = {
             query: (_sql: string) => Effect.fail(new Error("db down") as never),

--- a/apps/axctl/src/dashboard/next-actions.ts
+++ b/apps/axctl/src/dashboard/next-actions.ts
@@ -389,15 +389,28 @@ const ROUTING_WINDOW_DAYS = 14;
 
 /**
  * Per-source timeout: a slow source degrades to a note instead of blocking
- * the panel. The churn leg currently exceeds this (~9s fixed cost - see
- * https://github.com/Necmttn/ax/issues/326); routing and others are typically
- * fast but may spike.
+ * the panel. Tool failures are kept fast because they are a frequent landing
+ * card; the heavier graph rollups get enough room to avoid caching a
+ * timeout-only payload on normal local datasets.
  */
-const SOURCE_TIMEOUT_MS = 4_000;
+const FAST_SOURCE_TIMEOUT_MS = 4_000;
+const DISCOVERY_SOURCE_TIMEOUT_MS = 12_000;
+const HEAVY_DISCOVERY_SOURCE_TIMEOUT_MS = 30_000;
+
+export const nextActionSourceTimeoutMs = (
+    source: NextActionKind,
+    override?: number,
+): number => {
+    if (override != null) return override;
+    if (source === "churn" || source === "skill_hygiene") {
+        return HEAVY_DISCOVERY_SOURCE_TIMEOUT_MS;
+    }
+    return source === "tool_failure" ? FAST_SOURCE_TIMEOUT_MS : DISCOVERY_SOURCE_TIMEOUT_MS;
+};
 
 /**
- * Fan-out to 5 data sources (proposals, tool failures, churn, routing, skill
- * hygiene), merge and sort all cards by impact descending.
+ * Fan-out to 6 data sources (proposals, tool failures, churn, routing, skill
+ * hygiene, housekeeping), merge and sort all cards by impact descending.
  *
  * Each leg is fail-open: a DB error or timeout becomes a NextActionsSourceNote,
  * never a typed failure. The returned Effect has error type `never` for source
@@ -406,8 +419,6 @@ const SOURCE_TIMEOUT_MS = 4_000;
 export const fetchNextActions = Effect.fn("dashboard.fetchNextActions")(function* (
     opts?: { readonly sourceTimeoutMs?: number },
 ) {
-    const timeoutMs = opts?.sourceTimeoutMs ?? SOURCE_TIMEOUT_MS;
-
     // Mutated from concurrent legs; safe because JS fibers interleave only at
     // yield points - the push inside Effect.sync runs atomically.
     const notes: Array<NextActionsSourceNote> = [];
@@ -427,8 +438,9 @@ export const fetchNextActions = Effect.fn("dashboard.fetchNextActions")(function
         source: NextActionKind,
         eff: Effect.Effect<A, unknown, SurrealClient>,
         empty: A,
-    ): Effect.Effect<A, never, SurrealClient> =>
-        eff.pipe(
+    ): Effect.Effect<A, never, SurrealClient> => {
+        const timeoutMs = nextActionSourceTimeoutMs(source, opts?.sourceTimeoutMs);
+        return eff.pipe(
             Effect.timeoutOrElse({
                 duration: `${timeoutMs} millis`,
                 orElse: () =>
@@ -441,6 +453,7 @@ export const fetchNextActions = Effect.fn("dashboard.fetchNextActions")(function
                 }),
             ),
         );
+    };
 
     const [proposals, failures, churn, routing, hygiene, stale] = yield* Effect.all(
         [
@@ -458,7 +471,7 @@ export const fetchNextActions = Effect.fn("dashboard.fetchNextActions")(function
             guarded("skill_hygiene", fetchSkillHygiene({ minInvocations: 3, limit: 10 }), [] as ReadonlyArray<SkillHygieneRow>),
             guarded("housekeeping", findStaleOpenProposals(HOUSEKEEP_DAYS), [] as ReadonlyArray<StaleProposalRow>),
         ] as const,
-        { concurrency: 3 },
+        { concurrency: 6 },
     );
 
     const cards: NextActionCard[] = [

--- a/apps/axctl/src/dashboard/next-actions.ts
+++ b/apps/axctl/src/dashboard/next-actions.ts
@@ -397,16 +397,26 @@ const FAST_SOURCE_TIMEOUT_MS = 4_000;
 const DISCOVERY_SOURCE_TIMEOUT_MS = 12_000;
 const HEAVY_DISCOVERY_SOURCE_TIMEOUT_MS = 30_000;
 
+// Per-source budget lives on the source (exhaustive over NextActionKind) rather
+// than a name-matching branch, so adding a source is a single entry here and the
+// compiler flags any kind left unbudgeted. `tool_failure` stays fast (frequent
+// landing card); `churn`/`skill_hygiene` graph rollups get room to avoid caching
+// a timeout-only payload on normal local datasets. `verdict` is derived from the
+// proposal fetch, never fetched on its own, so its budget is unused.
+const KIND_TIMEOUT_MS: Record<NextActionKind, number> = {
+    verdict: DISCOVERY_SOURCE_TIMEOUT_MS,
+    proposal: DISCOVERY_SOURCE_TIMEOUT_MS,
+    tool_failure: FAST_SOURCE_TIMEOUT_MS,
+    routing: DISCOVERY_SOURCE_TIMEOUT_MS,
+    churn: HEAVY_DISCOVERY_SOURCE_TIMEOUT_MS,
+    skill_hygiene: HEAVY_DISCOVERY_SOURCE_TIMEOUT_MS,
+    housekeeping: DISCOVERY_SOURCE_TIMEOUT_MS,
+};
+
 export const nextActionSourceTimeoutMs = (
     source: NextActionKind,
     override?: number,
-): number => {
-    if (override != null) return override;
-    if (source === "churn" || source === "skill_hygiene") {
-        return HEAVY_DISCOVERY_SOURCE_TIMEOUT_MS;
-    }
-    return source === "tool_failure" ? FAST_SOURCE_TIMEOUT_MS : DISCOVERY_SOURCE_TIMEOUT_MS;
-};
+): number => override ?? KIND_TIMEOUT_MS[source];
 
 /**
  * Fan-out to 6 data sources (proposals, tool failures, churn, routing, skill

--- a/apps/axctl/src/pwd.test.ts
+++ b/apps/axctl/src/pwd.test.ts
@@ -173,6 +173,20 @@ describe("resolvePwdRepository", () => {
         expect(res.repoRoot).toBe(dir);
     });
 
+    test("linked worktree: repoRoot is checkout, mainRepoRoot is primary checkout", async () => {
+        const dir = await makeTempDir();
+        await initRepoWithCommit(dir);
+        const worktree = `${dir}-feature`;
+        tempDirs.push(worktree);
+
+        git(["worktree", "add", "-b", "feature", worktree], dir);
+
+        const res = await resolve(worktree, false);
+
+        expect(res.repoRoot).toBe(worktree);
+        expect(res.mainRepoRoot).toBe(dir);
+    });
+
     test("cwd defaults to process.cwd() when not provided", async () => {
         // This test calls resolvePwdRepository() with no args; it will succeed
         // if we happen to be inside a git repo, or fail with NotAGitRepoError.

--- a/apps/axctl/src/pwd.ts
+++ b/apps/axctl/src/pwd.ts
@@ -6,6 +6,7 @@
  * record does it correspond to?" resolver.
  */
 import { Effect, FileSystem, Schema } from "effect";
+import * as posixPath from "node:path/posix";
 import { RecordId } from "surrealdb";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
@@ -37,6 +38,8 @@ export interface PwdResolution {
     readonly cwd: string;
     /** Result of `git rev-parse --show-toplevel`. */
     readonly repoRoot: string;
+    /** Primary checkout root; differs from repoRoot inside linked worktrees. */
+    readonly mainRepoRoot: string;
     /** Normalized remote URL (e.g. "github.com/foo/bar"), or null. */
     readonly remoteUrlNormalized: string | null;
     /** SHA of the initial (root) commit, or null. */
@@ -52,6 +55,15 @@ export interface PwdResolution {
 // ---------------------------------------------------------------------------
 // Implementation
 // ---------------------------------------------------------------------------
+
+export const mainRepoRootFromGitCommonDir = (repoRoot: string, commonDir: string): string => {
+    const trimmed = commonDir.trim();
+    if (trimmed.length === 0 || trimmed === ".git") return repoRoot;
+    const abs = posixPath.isAbsolute(trimmed)
+        ? trimmed
+        : posixPath.join(repoRoot, trimmed);
+    return posixPath.dirname(abs);
+};
 
 /**
  * Resolve the current working directory (or the provided `cwd`) to a
@@ -89,6 +101,14 @@ export const resolvePwdRepository = (
         }
         const repoRoot = toplevelResult.stdout.trim();
 
+        const commonDirResult = yield* proc.exec("git", ["rev-parse", "--git-common-dir"], {
+            cwd: repoRoot,
+        });
+        const mainRepoRoot = mainRepoRootFromGitCommonDir(
+            repoRoot,
+            commonDirResult.code === 0 ? commonDirResult.stdout.trim() : "",
+        );
+
         // Step 3: git config --get remote.origin.url (null if missing / fails)
         const remoteResult = yield* proc.exec(
             "git",
@@ -115,7 +135,7 @@ export const resolvePwdRepository = (
         const identity = chooseIdentity({
             remoteUrlNormalized,
             initialCommit,
-            checkoutRoot: repoRoot,
+            checkoutRoot: mainRepoRoot,
         });
 
         // Step 6: build RecordId
@@ -132,6 +152,7 @@ export const resolvePwdRepository = (
         return {
             cwd: resolvedCwd,
             repoRoot,
+            mainRepoRoot,
             remoteUrlNormalized,
             initialCommit,
             identity,

--- a/apps/axctl/src/pwd.ts
+++ b/apps/axctl/src/pwd.ts
@@ -6,11 +6,11 @@
  * record does it correspond to?" resolver.
  */
 import { Effect, FileSystem, Schema } from "effect";
-import * as posixPath from "node:path/posix";
 import { RecordId } from "surrealdb";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { orAbsent } from "@ax/lib/shared/fs-error";
+import { posixPath } from "@ax/lib/shared/path";
 import { ProcessService, type ProcessError } from "@ax/lib/process";
 import {
     chooseIdentity,

--- a/apps/axctl/src/usage/query.ts
+++ b/apps/axctl/src/usage/query.ts
@@ -9,11 +9,21 @@ export interface InvocationRow {
   readonly exit_code: number;
 }
 
+export interface TopCommand {
+  readonly command: string;
+  readonly count: number;
+  readonly last_used: string;
+}
+
 export interface UsageRollup {
   readonly windowDays: number;
   readonly total: number;
   readonly activeDays: number;
-  readonly topCommands: ReadonlyArray<{ command: string; count: number; last_used: string }>;
+  readonly topCommands: ReadonlyArray<TopCommand>;
+  readonly topCommandsByOrigin: {
+    readonly agent: ReadonlyArray<TopCommand>;
+    readonly tty: ReadonlyArray<TopCommand>;
+  };
   readonly unusedSurface: string[];
   readonly originSplit: { agent: number; tty: number };
   readonly reliability: ReadonlyArray<{ command: string; runs: number; failures: number; failureRate: number }>;
@@ -21,22 +31,39 @@ export interface UsageRollup {
 
 const utcDay = (iso: string): string => iso.slice(0, 10);
 
+type CommandStats = { count: number; last: string; failures: number };
+
+const bumpCommand = (map: Map<string, CommandStats>, row: InvocationRow): void => {
+  const e = map.get(row.command) ?? { count: 0, last: row.ts, failures: 0 };
+  e.count++;
+  if (row.ts > e.last) e.last = row.ts;
+  if (row.exit_code !== 0) e.failures++;
+  map.set(row.command, e);
+};
+
+const rankCommands = (map: Map<string, CommandStats>): TopCommand[] =>
+  [...map.entries()]
+    .map(([command, e]) => ({ command, count: e.count, last_used: e.last }))
+    .sort((a, b) => b.count - a.count || (a.command < b.command ? -1 : 1));
+
 export const rollup = (rows: ReadonlyArray<InvocationRow>, visibleCommands: ReadonlyArray<string>, windowDays = 30): UsageRollup => {
   const byCommand = new Map<string, { count: number; last: string; failures: number }>();
+  const byAgentCommand = new Map<string, CommandStats>();
+  const byTtyCommand = new Map<string, CommandStats>();
   const days = new Set<string>();
   let agent = 0, tty = 0;
   for (const r of rows) {
     days.add(utcDay(r.ts));
-    if (r.origin === "tty") tty++; else agent++;
-    const e = byCommand.get(r.command) ?? { count: 0, last: r.ts, failures: 0 };
-    e.count++;
-    if (r.ts > e.last) e.last = r.ts;
-    if (r.exit_code !== 0) e.failures++;
-    byCommand.set(r.command, e);
+    if (r.origin === "tty") {
+      tty++;
+      bumpCommand(byTtyCommand, r);
+    } else {
+      agent++;
+      bumpCommand(byAgentCommand, r);
+    }
+    bumpCommand(byCommand, r);
   }
-  const topCommands = [...byCommand.entries()]
-    .map(([command, e]) => ({ command, count: e.count, last_used: e.last }))
-    .sort((a, b) => b.count - a.count || (a.command < b.command ? -1 : 1));
+  const topCommands = rankCommands(byCommand);
   // unusedSurface compares against top-level command tokens (VISIBLE_COMMANDS is
   // top-level), so normalize invoked commands to their first token.
   const invokedTop = new Set([...byCommand.keys()].map((c) => c.split(" ")[0]));
@@ -45,7 +72,19 @@ export const rollup = (rows: ReadonlyArray<InvocationRow>, visibleCommands: Read
     .map(([command, e]) => ({ command, runs: e.count, failures: e.failures, failureRate: e.failures / e.count }))
     .filter((x) => x.failures > 0)
     .sort((a, b) => b.failureRate - a.failureRate);
-  return { windowDays, total: rows.length, activeDays: days.size, topCommands, unusedSurface, originSplit: { agent, tty }, reliability };
+  return {
+    windowDays,
+    total: rows.length,
+    activeDays: days.size,
+    topCommands,
+    topCommandsByOrigin: {
+      agent: rankCommands(byAgentCommand),
+      tty: rankCommands(byTtyCommand),
+    },
+    unusedSurface,
+    originSplit: { agent, tty },
+    reliability,
+  };
 };
 
 export const fetchInvocations = (windowDays: number): Effect.Effect<InvocationRow[], DbError, SurrealClient> =>

--- a/apps/studio/src/instrument/mission-control.test.tsx
+++ b/apps/studio/src/instrument/mission-control.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MissionControlContent } from "./mission-control.tsx";
+
+describe("MissionControlContent", () => {
+    test("loading state explains the cold wrapped-profile build", () => {
+        const html = renderToStaticMarkup(
+            <MissionControlContent data={null} isLoading error={null} />,
+        );
+
+        expect(html).toContain("building profile");
+        expect(html).toContain("Cold graph scans can take about 20s");
+    });
+
+    test("error state is visible instead of a blank instrument", () => {
+        const html = renderToStaticMarkup(
+            <MissionControlContent data={null} isLoading={false} error={new Error("db down")} />,
+        );
+
+        expect(html).toContain("wrapped profile failed");
+        expect(html).toContain("db down");
+    });
+});

--- a/apps/studio/src/instrument/mission-control.tsx
+++ b/apps/studio/src/instrument/mission-control.tsx
@@ -173,15 +173,68 @@ function ModelSplitCard() {
     );
 }
 
+function MissionControlNotice({
+    title,
+    detail,
+}: {
+    readonly title: string;
+    readonly detail: string;
+}) {
+    return (
+        <section className="rdx-card" style={{ padding: 24, maxWidth: 520 }}>
+            <div className="rdx-label" style={{ color: "var(--pri)" }}>{title}</div>
+            <div className="rdx-label" style={{ marginTop: 8, lineHeight: 1.5 }}>{detail}</div>
+        </section>
+    );
+}
+
+const errorDetail = (error: unknown): string => {
+    if (error instanceof Error && error.message.length > 0) return error.message;
+    const text = String(error ?? "");
+    return text.length > 0 ? text : "unknown error";
+};
+
+export function MissionControlContent({
+    data,
+    isLoading,
+    error,
+}: {
+    readonly data: WrappedProfile | null;
+    readonly isLoading: boolean;
+    readonly error: unknown;
+}) {
+    const ready = Boolean(data?.usage && data?.primaryArchetype);
+    if (isLoading && !data) {
+        return (
+            <MissionControlNotice
+                title="building profile"
+                detail="Cold graph scans can take about 20s on large local datasets."
+            />
+        );
+    }
+    if (error && !data) {
+        return (
+            <MissionControlNotice
+                title="wrapped profile failed"
+                detail={errorDetail(error)}
+            />
+        );
+    }
+    if (ready && data) {
+        return <><ClockHero profile={data} /><Bento profile={data} /><RecapDeck cards={data.cards ?? []} /></>;
+    }
+    if (data) {
+        return <MissionControlNotice title="profile not ready" detail="Ingest more sessions to build the mission-control profile." />;
+    }
+    return null;
+}
+
 export function MissionControl() {
     const q = useQuery({ queryKey: ["wrapped"], queryFn: () => api.wrapped() });
     const data = q.data ?? null;
-    const ready = Boolean(data?.usage && data?.primaryArchetype);
     return (
         <InstrumentShell>
-            {q.isLoading && !data ? <div className="rdx-label" style={{ padding: 24 }}>loading…</div> : null}
-            {ready && data ? (<><ClockHero profile={data} /><Bento profile={data} /><RecapDeck cards={data.cards ?? []} /></>) : null}
-            {data && !ready ? <div className="rdx-label" style={{ padding: 24 }}>profile not ready - ingest more sessions.</div> : null}
+            <MissionControlContent data={data} isLoading={q.isLoading} error={q.error} />
         </InstrumentShell>
     );
 }

--- a/apps/studio/src/instrument/mission-control.tsx
+++ b/apps/studio/src/instrument/mission-control.tsx
@@ -203,7 +203,6 @@ export function MissionControlContent({
     readonly isLoading: boolean;
     readonly error: unknown;
 }) {
-    const ready = Boolean(data?.usage && data?.primaryArchetype);
     if (isLoading && !data) {
         return (
             <MissionControlNotice
@@ -220,7 +219,7 @@ export function MissionControlContent({
             />
         );
     }
-    if (ready && data) {
+    if (data?.usage && data?.primaryArchetype) {
         return <><ClockHero profile={data} /><Bento profile={data} /><RecapDeck cards={data.cards ?? []} /></>;
     }
     if (data) {

--- a/apps/studio/src/routes/tools.test.ts
+++ b/apps/studio/src/routes/tools.test.ts
@@ -2,12 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { toolFailuresRefreshUi } from "./tools.tsx";
 
 describe("toolFailuresRefreshUi", () => {
-    test("background query fetching does not lock the manual refresh button", () => {
-        const state = toolFailuresRefreshUi({
-            manualRefreshing: false,
-            queryIsFetching: true,
-            queryIsLoading: false,
-        });
+    test("idle (no manual refresh) leaves the button enabled", () => {
+        // Background React Query fetching is intentionally not an input - the
+        // toolbar must not lock while ingest invalidations refetch in the bg.
+        const state = toolFailuresRefreshUi({ manualRefreshing: false });
 
         expect(state.disabled).toBe(false);
         expect(state.label).toBe("Refresh");
@@ -15,11 +13,7 @@ describe("toolFailuresRefreshUi", () => {
     });
 
     test("manual refresh owns the disabled state", () => {
-        const state = toolFailuresRefreshUi({
-            manualRefreshing: true,
-            queryIsFetching: true,
-            queryIsLoading: false,
-        });
+        const state = toolFailuresRefreshUi({ manualRefreshing: true });
 
         expect(state.disabled).toBe(true);
         expect(state.label).toBe("Refreshing…");

--- a/apps/studio/src/routes/tools.test.ts
+++ b/apps/studio/src/routes/tools.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { toolFailuresRefreshUi } from "./tools.tsx";
+
+describe("toolFailuresRefreshUi", () => {
+    test("background query fetching does not lock the manual refresh button", () => {
+        const state = toolFailuresRefreshUi({
+            manualRefreshing: false,
+            queryIsFetching: true,
+            queryIsLoading: false,
+        });
+
+        expect(state.disabled).toBe(false);
+        expect(state.label).toBe("Refresh");
+        expect(state.tableOpacity).toBe(1);
+    });
+
+    test("manual refresh owns the disabled state", () => {
+        const state = toolFailuresRefreshUi({
+            manualRefreshing: true,
+            queryIsFetching: true,
+            queryIsLoading: false,
+        });
+
+        expect(state.disabled).toBe(true);
+        expect(state.label).toBe("Refreshing…");
+        expect(state.tableOpacity).toBe(0.6);
+    });
+});

--- a/apps/studio/src/routes/tools.tsx
+++ b/apps/studio/src/routes/tools.tsx
@@ -32,6 +32,28 @@ const filterRows = (
     });
 };
 
+export interface ToolFailuresRefreshUiInput {
+    readonly manualRefreshing: boolean;
+    readonly queryIsFetching: boolean;
+    readonly queryIsLoading: boolean;
+}
+
+export const toolFailuresRefreshUi = (input: ToolFailuresRefreshUiInput): {
+    readonly refreshing: boolean;
+    readonly disabled: boolean;
+    readonly label: string;
+    readonly tableOpacity: number;
+} => {
+    // Background ingest invalidations keep React Query fetching; the toolbar
+    // state should reflect only the user's explicit refresh action.
+    const refreshing = input.manualRefreshing;
+    return {
+        refreshing,
+        disabled: refreshing,
+        label: refreshing ? "Refreshing…" : "Refresh",
+        tableOpacity: refreshing ? 0.6 : 1,
+    };
+};
 
 export function ToolFailuresRoute() {
     const queryClient = useQueryClient();
@@ -44,13 +66,25 @@ export function ToolFailuresRoute() {
     const error =
         actionError ?? (failuresQuery.error ? String(failuresQuery.error) : null);
     const loading = failuresQuery.isLoading;
-    const refreshing = failuresQuery.isFetching && !failuresQuery.isLoading;
+    const [manualRefreshing, setManualRefreshing] = useState(false);
+    const refreshUi = toolFailuresRefreshUi({
+        manualRefreshing,
+        queryIsFetching: failuresQuery.isFetching,
+        queryIsLoading: failuresQuery.isLoading,
+    });
     const [filter, setFilter] = useState<Filter>("fix");
     const [search, setSearch] = useState("");
     const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
 
     const load = async (_mode: "initial" | "refresh" = "refresh") => {
-        await failuresQuery.refetch();
+        setError(null);
+        setManualRefreshing(true);
+        try {
+            const result = await failuresQuery.refetch();
+            if (result.error) setError(String(result.error));
+        } finally {
+            setManualRefreshing(false);
+        }
     };
 
     const visible = useMemo(
@@ -125,9 +159,9 @@ export function ToolFailuresRoute() {
                     onClick={() => load("refresh")}
                     type="button"
                     style={{ marginLeft: "auto" }}
-                    disabled={refreshing}
+                    disabled={refreshUi.disabled}
                 >
-                    {refreshing ? "Refreshing…" : "Refresh"}
+                    {refreshUi.label}
                 </button>
             </div>
 
@@ -139,7 +173,7 @@ export function ToolFailuresRoute() {
             ) : null}
 
             {data && visible.length > 0 ? (
-                <table className="skills" style={{ opacity: refreshing ? 0.6 : 1 }}>
+                <table className="skills" style={{ opacity: refreshUi.tableOpacity }}>
                     <thead>
                         <tr>
                             <th>Command</th>

--- a/apps/studio/src/routes/tools.tsx
+++ b/apps/studio/src/routes/tools.tsx
@@ -33,9 +33,9 @@ const filterRows = (
 };
 
 export interface ToolFailuresRefreshUiInput {
+    // Background ingest invalidations keep React Query `isFetching` true, so the
+    // toolbar deliberately reflects ONLY the user's explicit refresh action.
     readonly manualRefreshing: boolean;
-    readonly queryIsFetching: boolean;
-    readonly queryIsLoading: boolean;
 }
 
 export const toolFailuresRefreshUi = (input: ToolFailuresRefreshUiInput): {
@@ -44,8 +44,6 @@ export const toolFailuresRefreshUi = (input: ToolFailuresRefreshUiInput): {
     readonly label: string;
     readonly tableOpacity: number;
 } => {
-    // Background ingest invalidations keep React Query fetching; the toolbar
-    // state should reflect only the user's explicit refresh action.
     const refreshing = input.manualRefreshing;
     return {
         refreshing,
@@ -67,11 +65,7 @@ export function ToolFailuresRoute() {
         actionError ?? (failuresQuery.error ? String(failuresQuery.error) : null);
     const loading = failuresQuery.isLoading;
     const [manualRefreshing, setManualRefreshing] = useState(false);
-    const refreshUi = toolFailuresRefreshUi({
-        manualRefreshing,
-        queryIsFetching: failuresQuery.isFetching,
-        queryIsLoading: failuresQuery.isLoading,
-    });
+    const refreshUi = toolFailuresRefreshUi({ manualRefreshing });
     const [filter, setFilter] = useState<Filter>("fix");
     const [search, setSearch] = useState("");
     const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());

--- a/apps/studio/src/routes/usage.tsx
+++ b/apps/studio/src/routes/usage.tsx
@@ -1,10 +1,35 @@
 /**
  * Utilization panel - minimal view of GET /api/usage.
- * Shows: active days, total invocations, top commands, never-used commands.
+ * Shows: active days, total invocations, top commands, origin split, never-used commands.
  */
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api.ts";
 import type { UsageRollupSchema } from "@ax/lib/shared/api-contract";
+
+type TopCommand = UsageRollupSchema["topCommands"][number];
+
+function CommandTable({ commands }: { readonly commands: readonly TopCommand[] }) {
+    if (commands.length === 0) return <p className="meta">No invocations in this window</p>;
+    return (
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.9em" }}>
+            <tbody>
+                {commands.map((cmd) => (
+                    <tr key={cmd.command}>
+                        <td style={{ padding: "3px 8px 3px 0", fontFamily: "monospace" }}>
+                            ax {cmd.command}
+                        </td>
+                        <td style={{ padding: "3px 8px", color: "var(--muted)" }}>
+                            {cmd.count}×
+                        </td>
+                        <td style={{ padding: "3px 0", color: "var(--muted)", fontSize: "0.85em" }}>
+                            last {new Date(cmd.last_used).toLocaleDateString()}
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+}
 
 export function UsageRoute() {
     const { data, isLoading, error } = useQuery({
@@ -51,23 +76,26 @@ export function UsageRoute() {
                     <h3 style={{ margin: "12px 0 6px", fontSize: "0.85em", textTransform: "uppercase", letterSpacing: "0.05em" }}>
                         Top commands
                     </h3>
-                    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.9em" }}>
-                        <tbody>
-                            {data.topCommands.map((cmd) => (
-                                <tr key={cmd.command}>
-                                    <td style={{ padding: "3px 8px 3px 0", fontFamily: "monospace" }}>
-                                        ax {cmd.command}
-                                    </td>
-                                    <td style={{ padding: "3px 8px", color: "var(--muted)" }}>
-                                        {cmd.count}×
-                                    </td>
-                                    <td style={{ padding: "3px 0", color: "var(--muted)", fontSize: "0.85em" }}>
-                                        last {new Date(cmd.last_used).toLocaleDateString()}
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
+                    <CommandTable commands={data.topCommands} />
+                </>
+            )}
+
+            {(data.topCommandsByOrigin.tty.length > 0 || data.topCommandsByOrigin.agent.length > 0) && (
+                <>
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: "18px", marginTop: "14px" }}>
+                        <section>
+                            <h3 style={{ margin: "0 0 6px", fontSize: "0.85em", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                                Interactive
+                            </h3>
+                            <CommandTable commands={data.topCommandsByOrigin.tty} />
+                        </section>
+                        <section>
+                            <h3 style={{ margin: "0 0 6px", fontSize: "0.85em", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                                Agent/background
+                            </h3>
+                            <CommandTable commands={data.topCommandsByOrigin.agent} />
+                        </section>
+                    </div>
                 </>
             )}
 

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -952,6 +952,10 @@ export const UsageRollupSchema = Schema.Struct({
     total: Schema.Number,
     activeDays: Schema.Number,
     topCommands: Schema.Array(TopCommandEntry),
+    topCommandsByOrigin: Schema.Struct({
+        agent: Schema.Array(TopCommandEntry),
+        tty: Schema.Array(TopCommandEntry),
+    }),
     unusedSurface: Schema.Array(Schema.String),
     originSplit: Schema.Struct({ agent: Schema.Number, tty: Schema.Number }),
     reliability: Schema.Array(ReliabilityEntry),


### PR DESCRIPTION
## What changed

This PR applies the R16 dogfood fixes across the CLI and studio discovery surfaces:

- Shows a clear cold-build/error state for the default Mission Control wrapped-profile route.
- Resolves linked-worktree `--here` analytics to the primary checkout root.
- Prevents `/tools` background refetches from pinning the manual refresh button in `Refreshing...`.
- Keeps large `ax cost models` token and cost values readable instead of clipping digits.
- Accepts documented `--window=14d` spelling for `ax skills weighted`.
- Runs `/api/next-actions` sources concurrently and gives heavier discovery rollups enough timeout budget.
- Adds progress feedback for slow `ax profile show` runs.
- Splits usage rankings by interactive TTY versus agent/background origins in CLI, API, and studio.

## Why

The dogfood pass found that several high-signal ax surfaces either hid useful data, looked stuck, or mixed automation with intentional user behavior. These changes make those discovery paths more trustworthy during normal local use.

## Impact

Users get clearer dashboard states, better worktree-scoped analytics, readable cost tables, source-complete next action cards, and a more honest usage lens that distinguishes background/statusline automation from deliberate CLI use.

## Root cause

Most issues came from discovery surfaces using technically accurate but product-hostile defaults: linked worktree paths instead of canonical repo identity, background query fetching as button state, fixed-width numeric columns, too-short source timeouts, and combined usage rankings over mixed invocation origins.

## Validation

- `bun test` -> 4,797 pass, 5 skip, 0 fail
- `bun run typecheck` -> exit 0 with existing Effect diagnostics
- `bun run --cwd apps/studio build` -> exit 0 with existing Vite large-chunk warning
- `git diff --check` -> exit 0
- Source `/api/next-actions` check returned 23 cards, 0 notes, in 9.665s
