### PR TITLE
feat(memory): ax memory ops — surface Claude memory writes (#531)

### DIFF
--- a/apps/axctl/src/cli/commands/ax-memory.ts
+++ b/apps/axctl/src/cli/commands/ax-memory.ts
@@ -1,0 +1,140 @@
+/**
+ * `ax memory ops` - Claude memory-file activity (writes/edits to
+ * `~/.claude/.../memory/*.md`), rolled up from existing `edited` edges.
+ *
+ * Read-only, `db` runtime. Sibling of commands/ax-cost.ts. Recall is not
+ * tracked here (it never lands in the transcript - see queries/memory-ops.ts).
+ */
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { prettyPrint } from "@ax/lib/json";
+import { fetchMemoryOps } from "../../queries/memory-ops.ts";
+import { renderTable } from "../table.js";
+import type { Column } from "../table.js";
+import type { RuntimeManifest } from "./manifest.ts";
+import { fail, jsonFlag, positiveLimit } from "./shared.ts";
+
+const MEMORY_DEFAULT_WINDOW_DAYS = 30;
+
+// ---------------------------------------------------------------------------
+// ax memory ops [--days=N] [--events] [--limit=N] [--json]
+// ---------------------------------------------------------------------------
+
+const cmdMemoryOps = (input: {
+    readonly sinceDays: number;
+    readonly events: boolean;
+    readonly limit: number;
+    readonly json: boolean;
+}) =>
+    Effect.gen(function* () {
+        const result = yield* fetchMemoryOps({ sinceDays: input.sinceDays });
+
+        if (input.json) {
+            console.log(prettyPrint(result));
+            return;
+        }
+
+        if (result.totals.ops === 0) {
+            console.log(`(no memory writes in the last ${input.sinceDays} days)`);
+            return;
+        }
+
+        if (input.events) {
+            type EvRow = {
+                ts: string;
+                op: string;
+                kind: string;
+                slug: string;
+                session: string;
+                project: string;
+            };
+            const rendered: EvRow[] = result.events.slice(0, input.limit).map((e) => ({
+                ts: e.ts.replace("T", " ").replace(/\.\d+Z$/, ""),
+                op: e.op,
+                kind: e.kind,
+                slug: e.slug,
+                session: e.session_id.slice(0, 8),
+                project: e.project ?? "",
+            }));
+            const cols: Column<EvRow>[] = [
+                { header: "ts", get: (r) => r.ts, width: 19 },
+                { header: "op", get: (r) => r.op, width: 7 },
+                { header: "kind", get: (r) => r.kind, width: 6 },
+                { header: "slug", get: (r) => r.slug, min: 24, overflow: "ellipsis" },
+                { header: "session", get: (r) => r.session, width: 9 },
+                { header: "project", get: (r) => r.project, width: 24, overflow: "ellipsis" },
+            ];
+            console.log(renderTable({ columns: cols, rows: rendered, gap: " " }));
+            console.log(`\n${result.totals.ops} ops  (${input.sinceDays} days)`);
+            return;
+        }
+
+        // Default: per-file rollup.
+        type FileRow = {
+            slug: string;
+            kind: string;
+            writes: string;
+            edits: string;
+            sessions: string;
+            last_seen: string;
+        };
+        const rendered: FileRow[] = result.files.slice(0, input.limit).map((f) => ({
+            slug: f.slug,
+            kind: f.kind,
+            writes: String(f.writes),
+            edits: String(f.edits),
+            sessions: String(f.sessions),
+            last_seen: f.last_seen.replace("T", " ").replace(/\.\d+Z$/, ""),
+        }));
+        const cols: Column<FileRow>[] = [
+            { header: "slug", get: (r) => r.slug, min: 28, overflow: "ellipsis" },
+            { header: "kind", get: (r) => r.kind, width: 6 },
+            { header: "writes", get: (r) => r.writes, align: "right", width: 7 },
+            { header: "edits", get: (r) => r.edits, align: "right", width: 6 },
+            { header: "sessions", get: (r) => r.sessions, align: "right", width: 9 },
+            { header: "last_seen", get: (r) => r.last_seen, width: 19 },
+        ];
+        console.log(renderTable({ columns: cols, rows: rendered, gap: " " }));
+        console.log(
+            `\n${result.totals.notes} notes  ${result.totals.index_ops} index edits  ` +
+            `${result.totals.ops} ops  ${result.totals.sessions} sessions  (${input.sinceDays} days)`,
+        );
+        console.log("note: memory writes only; recall isn't in the transcript (system-prompt injected).");
+    });
+
+const memoryOpsCommand = Command.make(
+    "ops",
+    {
+        days: Flag.integer("days").pipe(Flag.withDefault(MEMORY_DEFAULT_WINDOW_DAYS)),
+        events: Flag.boolean("events").pipe(Flag.withDefault(false)),
+        limit: positiveLimit(40),
+        json: jsonFlag,
+    },
+    ({ days, events, limit, json }) => {
+        if (!Number.isInteger(days) || days <= 0) {
+            fail(`ax memory ops: --days must be a positive integer (got "${days}")`);
+        }
+        return cmdMemoryOps({ sinceDays: days, events, limit, json });
+    },
+).pipe(
+    Command.withDescription(
+        "Claude memory-file activity (writes/edits to ~/.claude/.../memory/*.md). " +
+        "Default: per-file rollup. --events for the raw stream. " +
+        "--days=N (default 30)  --limit=N (default 40)  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax memory (group command)
+// ---------------------------------------------------------------------------
+
+export const memoryCommand = Command.make("memory").pipe(
+    Command.withDescription(
+        "Claude memory analytics: what memories you've written, per file and session",
+    ),
+    Command.withSubcommands([memoryOpsCommand]),
+);
+
+export const axMemoryRuntime: RuntimeManifest = {
+    memory: "db",
+};

--- a/apps/axctl/src/cli/commands/visible-commands.ts
+++ b/apps/axctl/src/cli/commands/visible-commands.ts
@@ -23,6 +23,7 @@ export const VISIBLE_COMMANDS: readonly string[] = [
     "install",
     "setup",
     "cost",
+    "memory",
     "quota",
     "dojo",
     "profile",

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -16,6 +16,7 @@ import { starCommand, starRuntime } from "./commands/star.ts";
 import { dogfoodCommand, dogfoodRuntime } from "./commands/dogfood.ts";
 import { costsGroupCommand, locCommand, pricingCommand, costsRuntime } from "./commands/costs.ts";
 import { costCommand, axCostRuntime } from "./commands/ax-cost.ts";
+import { memoryCommand, axMemoryRuntime } from "./commands/ax-memory.ts";
 import { quotaCommand, quotaRuntime } from "./commands/quota.ts";
 import { dojoCommand, dojoRuntime } from "./commands/dojo.ts";
 import { profileCommand, axProfileRuntime } from "./commands/profile.ts";
@@ -85,6 +86,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...dogfoodRuntime,
     ...costsRuntime,
     ...axCostRuntime,
+    ...axMemoryRuntime,
     ...quotaRuntime,
     ...dojoRuntime,
     ...axProfileRuntime,
@@ -131,6 +133,7 @@ const registeredCommands: ReadonlyArray<Command.Command.Any> = [
     installCommand,
     setupCommand,
     costCommand,
+    memoryCommand,
     quotaCommand,
     dojoCommand,
     profileCommand,

--- a/apps/axctl/src/queries/memory-ops.test.ts
+++ b/apps/axctl/src/queries/memory-ops.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { makeMockDb, runWithMock } from "@ax/lib/testing/surreal";
+import { fetchMemoryOps } from "./memory-ops.ts";
+
+// Helper: a raw `edited`-edge row as the SQL projection returns it.
+const row = (o: Partial<{
+    ts: string;
+    tool: string;
+    path: string;
+    session_id: string;
+    project: string | null;
+    source: string | null;
+}>) => ({
+    ts: o.ts ?? "2026-06-17T10:00:00.000Z",
+    tool: o.tool ?? "Write",
+    path: o.path ?? "/Users/x/.claude/projects/p/memory/foo.md",
+    session_id: o.session_id ?? "session:`abc`",
+    project: o.project ?? "p",
+    source: o.source ?? "claude",
+});
+
+describe("fetchMemoryOps - events", () => {
+    test("maps tool->op, path->slug+kind, cleans session id", async () => {
+        const db = makeMockDb([[[
+            row({ tool: "Write", path: "/u/.claude/projects/p/memory/recap.md", session_id: "session:`s1`" }),
+            row({ tool: "Edit", path: "/u/.claude/projects/p/memory/MEMORY.md", session_id: "session:`s1`" }),
+        ]]]);
+        const r = await runWithMock(db, fetchMemoryOps({ sinceDays: 30 }));
+
+        expect(r.events).toHaveLength(2);
+        const write = r.events.find((e) => e.slug === "recap")!;
+        expect(write.op).toBe("create");
+        expect(write.kind).toBe("note");
+        expect(write.session_id).toBe("s1"); // session: prefix + backticks stripped
+
+        const idx = r.events.find((e) => e.slug === "MEMORY")!;
+        expect(idx.op).toBe("update"); // Edit -> update
+        expect(idx.kind).toBe("index"); // MEMORY.md -> index
+    });
+
+    test("NotebookEdit counts as update", async () => {
+        const db = makeMockDb([[[row({ tool: "NotebookEdit" })]]]);
+        const r = await runWithMock(db, fetchMemoryOps({ sinceDays: 30 }));
+        expect(r.events[0]!.op).toBe("update");
+    });
+});
+
+describe("fetchMemoryOps - file rollup", () => {
+    test("aggregates writes/edits, distinct sessions, first/last seen", async () => {
+        const db = makeMockDb([[[
+            row({ tool: "Write", path: "/u/.claude/projects/p/memory/a.md", session_id: "session:`s1`", ts: "2026-06-01T00:00:00.000Z" }),
+            row({ tool: "Edit", path: "/u/.claude/projects/p/memory/a.md", session_id: "session:`s1`", ts: "2026-06-03T00:00:00.000Z" }),
+            row({ tool: "Edit", path: "/u/.claude/projects/p/memory/a.md", session_id: "session:`s2`", ts: "2026-06-02T00:00:00.000Z" }),
+        ]]]);
+        const r = await runWithMock(db, fetchMemoryOps({ sinceDays: 30 }));
+
+        expect(r.files).toHaveLength(1);
+        const f = r.files[0]!;
+        expect(f.slug).toBe("a");
+        expect(f.writes).toBe(1);
+        expect(f.edits).toBe(2);
+        expect(f.ops).toBe(3);
+        expect(f.sessions).toBe(2); // s1, s2 distinct
+        expect(f.first_seen).toBe("2026-06-01T00:00:00.000Z");
+        expect(f.last_seen).toBe("2026-06-03T00:00:00.000Z");
+    });
+
+    test("files sorted by last_seen desc", async () => {
+        const db = makeMockDb([[[
+            row({ path: "/u/.claude/projects/p/memory/old.md", ts: "2026-06-01T00:00:00.000Z" }),
+            row({ path: "/u/.claude/projects/p/memory/new.md", ts: "2026-06-10T00:00:00.000Z" }),
+        ]]]);
+        const r = await runWithMock(db, fetchMemoryOps({ sinceDays: 30 }));
+        expect(r.files.map((f) => f.slug)).toEqual(["new", "old"]);
+    });
+});
+
+describe("fetchMemoryOps - totals", () => {
+    test("counts ops, distinct notes, index ops, distinct sessions", async () => {
+        const db = makeMockDb([[[
+            row({ tool: "Write", path: "/u/.claude/projects/p/memory/a.md", session_id: "session:`s1`" }),
+            row({ tool: "Write", path: "/u/.claude/projects/p/memory/b.md", session_id: "session:`s1`" }),
+            row({ tool: "Edit", path: "/u/.claude/projects/p/memory/MEMORY.md", session_id: "session:`s2`" }),
+        ]]]);
+        const r = await runWithMock(db, fetchMemoryOps({ sinceDays: 30 }));
+        expect(r.totals.ops).toBe(3);
+        expect(r.totals.notes).toBe(2); // a, b (MEMORY index excluded)
+        expect(r.totals.index_ops).toBe(1);
+        expect(r.totals.sessions).toBe(2);
+    });
+});
+
+describe("fetchMemoryOps - empty + SQL", () => {
+    test("handles empty result", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchMemoryOps({ sinceDays: 30 }));
+        expect(r.events).toHaveLength(0);
+        expect(r.files).toHaveLength(0);
+        expect(r.totals.ops).toBe(0);
+    });
+
+    test("SQL windows by sinceDays and filters to .claude memory dirs", async () => {
+        const db = makeMockDb([[[]]]);
+        await runWithMock(db, fetchMemoryOps({ sinceDays: 7 }));
+        const sql = db.captured[0]!;
+        expect(sql).toContain("time::now() - 7d");
+        expect(sql).toContain("/.claude/");
+        expect(sql).toContain("/memory/");
+        expect(sql).toContain("FROM edited");
+    });
+});

--- a/apps/axctl/src/queries/memory-ops.ts
+++ b/apps/axctl/src/queries/memory-ops.ts
@@ -1,0 +1,186 @@
+/**
+ * Memory-ops query: surface Claude Code memory-file activity.
+ *
+ * Background: Claude's auto-memory is *model-driven* - the agent saves memories
+ * by calling `Write`/`Edit` on files under `~/.claude/projects/<slug>/memory/`
+ * (and `~/.claude/.../memory/`). Those calls are already in the graph as
+ * `edited` (turn -> file) edges; this query just labels and rolls them up as
+ * "memory operations". Nothing new is ingested.
+ *
+ * Scope note: this covers memory *writes* only. Memory *recall* (the index +
+ * relevant memories the harness injects into the system prompt) is assembled at
+ * request-build time and never written to the transcript JSONL, so it is not
+ * recoverable here - it would need a live capture hook.
+ *
+ * The `edited` edge already carries the path (`absolute_path_seen`), tool, and
+ * ts, so the only deref is `in.session` for session/project attribution - bounded
+ * (a few hundred memory edges), not the 87k-row aggregate that hangs production.
+ * Filter is tightened to `/.claude/` AND `/memory/` so a repo's own `src/memory/`
+ * never counts.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { countField, stringField, stringFieldOr } from "@ax/lib/shared/surreal";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type MemoryOp = "create" | "update";
+export type MemoryKind = "index" | "note";
+
+export interface MemoryOpEvent {
+    readonly ts: string;
+    readonly tool: string;          // Write | Edit | NotebookEdit
+    readonly op: MemoryOp;          // Write -> create, Edit/NotebookEdit -> update
+    readonly slug: string;          // basename without .md ("MEMORY" for the index)
+    readonly kind: MemoryKind;      // MEMORY.md -> index, else note
+    readonly path: string;
+    readonly session_id: string;    // cleaned (no "session:" prefix / backticks)
+    readonly project: string | null;
+    readonly source: string | null;
+}
+
+export interface MemoryFileRollup {
+    readonly slug: string;
+    readonly kind: MemoryKind;
+    readonly writes: number;        // Write ops (new memory)
+    readonly edits: number;         // Edit/NotebookEdit ops (updates)
+    readonly ops: number;           // writes + edits
+    readonly sessions: number;      // distinct sessions that touched it
+    readonly first_seen: string;
+    readonly last_seen: string;
+}
+
+export interface MemoryOpsResult {
+    readonly events: MemoryOpEvent[];      // newest first
+    readonly files: MemoryFileRollup[];    // by last_seen desc
+    readonly totals: {
+        readonly ops: number;
+        readonly notes: number;            // distinct note slugs (index excluded)
+        readonly index_ops: number;        // ops against MEMORY.md
+        readonly sessions: number;         // distinct sessions overall
+    };
+    readonly since_days: number;
+}
+
+export interface MemoryOpsInput {
+    readonly sinceDays: number;
+}
+
+// ---------------------------------------------------------------------------
+// SQL - flat select over `edited`, single bounded deref of in.session
+// ---------------------------------------------------------------------------
+
+const buildSql = (sinceDays: number): string => `
+SELECT
+    ts,
+    tool,
+    absolute_path_seen AS path,
+    type::string(in.session) AS session_id,
+    in.session.project AS project,
+    in.session.source AS source
+FROM edited
+WHERE absolute_path_seen CONTAINS '/.claude/'
+    AND absolute_path_seen CONTAINS '/memory/'
+    AND ts >= time::now() - ${sinceDays}d
+ORDER BY ts DESC;
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const cleanSessionId = (raw: string): string =>
+    raw.replace(/^session:/, "").replace(/^`(.*)`$/, "$1");
+
+const basename = (path: string): string => path.split("/").pop() ?? path;
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+export const fetchMemoryOps = Effect.fn("queries.fetchMemoryOps")(function* (
+    input: MemoryOpsInput,
+) {
+    const db = yield* SurrealClient;
+    const [rows] = yield* db.query<[Array<Record<string, unknown>>]>(
+        buildSql(input.sinceDays),
+    );
+
+    const events: MemoryOpEvent[] = (rows ?? []).map((row) => {
+        const path = stringFieldOr(row, "path", "");
+        const file = basename(path);
+        const tool = stringFieldOr(row, "tool", "");
+        return {
+            ts: stringFieldOr(row, "ts", ""),
+            tool,
+            op: tool === "Write" ? "create" : "update",
+            slug: file.replace(/\.md$/i, ""),
+            kind: file === "MEMORY.md" ? "index" : "note",
+            path,
+            session_id: cleanSessionId(stringFieldOr(row, "session_id", "")),
+            project: stringField(row, "project"),
+            source: stringField(row, "source"),
+        };
+    });
+
+    // Roll up per memory file.
+    const bySlug = new Map<string, {
+        slug: string;
+        kind: MemoryKind;
+        writes: number;
+        edits: number;
+        sessions: Set<string>;
+        first: string;
+        last: string;
+    }>();
+    for (const e of events) {
+        let agg = bySlug.get(e.slug);
+        if (!agg) {
+            agg = { slug: e.slug, kind: e.kind, writes: 0, edits: 0, sessions: new Set(), first: e.ts, last: e.ts };
+            bySlug.set(e.slug, agg);
+        }
+        if (e.op === "create") agg.writes += 1;
+        else agg.edits += 1;
+        if (e.session_id) agg.sessions.add(e.session_id);
+        if (e.ts < agg.first) agg.first = e.ts;
+        if (e.ts > agg.last) agg.last = e.ts;
+    }
+
+    const files: MemoryFileRollup[] = [...bySlug.values()]
+        .map((a) => ({
+            slug: a.slug,
+            kind: a.kind,
+            writes: a.writes,
+            edits: a.edits,
+            ops: a.writes + a.edits,
+            sessions: a.sessions.size,
+            first_seen: a.first,
+            last_seen: a.last,
+        }))
+        .sort((a, b) => (a.last_seen < b.last_seen ? 1 : a.last_seen > b.last_seen ? -1 : 0));
+
+    const allSessions = new Set<string>();
+    for (const e of events) if (e.session_id) allSessions.add(e.session_id);
+
+    const totals = {
+        ops: events.length,
+        notes: files.filter((f) => f.kind === "note").length,
+        index_ops: events.filter((e) => e.kind === "index").length,
+        sessions: allSessions.size,
+    };
+
+    // countField guards against any NaN sneaking into the rendered totals.
+    return {
+        events,
+        files,
+        totals: {
+            ops: countField(totals, "ops"),
+            notes: countField(totals, "notes"),
+            index_ops: countField(totals, "index_ops"),
+            sessions: countField(totals, "sessions"),
+        },
+        since_days: input.sinceDays,
+    } satisfies MemoryOpsResult;
+});

--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -152,6 +152,28 @@ total: $61.22  (14 days)`,
         ],
       },
       {
+        name: "memory",
+        sub: ["ops"],
+        job: "Claude memory-file activity: writes/edits the agent made to its ~/.claude/.../memory/*.md files.",
+        signature: "ax memory ops [--events] [--days=N] [--limit=N] [--json]",
+        flags: [
+          { flag: "--events", desc: "raw op stream instead of the per-file rollup" },
+          { flag: "--days=N", desc: "window (default 30)" },
+          { flag: "--limit=N", desc: "cap rows (default 40)" },
+        ],
+        receipt: `$ ax memory ops --days=30
+slug                       kind    writes  edits  sessions last_seen
+MEMORY                     index        1    130        70 2026-06-17 10:44:33
+recap-deck-unification     note         1      0         1 2026-06-17 10:44:06
+
+116 notes  131 index edits  383 ops  86 sessions  (30 days)`,
+        detail: [
+          "Memory is model-driven: the agent saves memories by calling Write/Edit on files under ~/.claude/.../memory/, already captured as `edited` edges - this view labels and rolls them up.",
+          "Default is a per-file rollup (notes vs the MEMORY index, writes vs edits, distinct sessions); --events gives the raw op stream.",
+          "Recall (the memory context the harness injects into the system prompt) is not tracked - it never lands in the transcript, so it would need a live capture hook.",
+        ],
+      },
+      {
         name: "dispatches",
         sub: ["compile-routing"],
         job: "Subagent dispatch table sorted by child cost, with a candidates view for cheap-model routing.",

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -18,6 +18,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax sessions here | around <date> | near <sha> | show <id>` - windowed session queries; drill into any session turn by turn
 - `ax:extract-workflow` skill - reconstruct the workflow behind a shipped artifact ("what made X work")
 - `ax share <session-id>` - publish a sanitized session share via GitHub Gist, viewable in the hosted studio
+- `ax memory ops [--events] [--days=N]` - Claude memory-file activity: writes/edits the agent made to `~/.claude/.../memory/*.md`, rolled up per memory file (notes vs the MEMORY index) and per session. Recall (the memory context the harness injects into the system prompt) is not tracked - it never lands in the transcript.
 
 ### Skills intelligence
 - `ax skills search | taste | unused | pairs | recovery | stats | weighted` - which installed skills actually get used, and what they pair with

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,7 @@ axctl costs for --terms <a,b,c> [--since=N] # cost for sessions matching any ter
 axctl costs for --commit <sha>              # cost for sessions that produced a commit
 axctl costs for --branch <name>             # cost for sessions linked to a branch
 axctl cost <models|sessions|split>          # model/cost analytics incl. main-vs-subagent split
+axctl memory ops [--events] [--days=N]      # Claude memory-file activity (writes/edits to ~/.claude/.../memory/*.md)
 axctl quota [--statusline|--swiftbar]       # Claude plan usage (5h/7d windows); statusline + menubar output
 axctl dojo agenda [--json|--spar|--budget=N|--until=HH:MM|--force|--days=N]  # training agenda: quota budget envelope + prioritized self-improvement items for the ax:dojo skill loop
 axctl dojo report [--since=<iso>] [--notes-file=<path>] [--json]      # write the morning report for a completed dojo run


### PR DESCRIPTION
Closes #531.

## What
`ax memory ops` — a read-only view of Claude's memory-file activity (writes/edits to `~/.claude/.../memory/*.md`).

## The finding behind it
Investigated "does ax track memory operations?" (Codex fact-checked the assumptions):
- **Writes are already in the graph.** Claude memory is *model-driven* — the agent saves memories by calling `Write`/`Edit`, captured as `edited` (turn→file) edges. 398 genuine `.claude` memory writes today. They just weren't labeled/surfaced as "memory."
- **Recall is not in the transcript.** The injected memory index/context is assembled into the system prompt at request-build time and never persisted to the JSONL ax ingests. Out of scope — needs a live capture hook.

So this is a labeling + rollup over data ax already holds, not new capture.

## Changes
- `queries/memory-ops.ts` — `fetchMemoryOps`: `edited` edges filtered to `/.claude/` AND `/memory/` (tighter filter drops 18 repo `src/memory/` false positives), bounded `in.session` deref for project/session attribution. Per-file rollup (notes vs `MEMORY` index, writes vs edits, distinct sessions, first/last seen) + totals.
- `ax memory ops [--events] [--days=N] [--limit=N] [--json]` — per-file rollup by default; `--events` for the raw op stream.
- Docs: `docs/cli.md`, `llms.txt`, site CLI reference, `visible-commands`.

## Receipt (live)
```
$ ax memory ops --days=30
slug                       kind    writes  edits  sessions last_seen
MEMORY                     index        1    130        70 2026-06-17 10:44:33
recap-deck-unification     note         1      0         1 2026-06-17 10:44:06
...
116 notes  131 index edits  383 ops  86 sessions  (30 days)
note: memory writes only; recall isn't in the transcript (system-prompt injected).
```

## Tests
- 7 new `memory-ops` query tests (op/kind mapping, rollup, totals, SQL window+filter, empty).
- Full `apps/axctl/src/cli` + `queries` sweep: 966 pass, 0 fail. Typecheck clean. Both doc gates + `visible-commands` sync green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)