### PR TITLE
fix(ingest): space before AND in content-types since clause (#533)

### DIFF
--- a/apps/axctl/src/ingest/derive-content-types.test.ts
+++ b/apps/axctl/src/ingest/derive-content-types.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { buildContentEdge, renderContentEdge, renderContentTypeNodes, type ContentEdgeSpec, type ToolCallRow } from "./derive-content-types.ts";
+import { buildContentEdge, renderContentEdge, renderContentTypeNodes, rowsSql, type ContentEdgeSpec, type ToolCallRow } from "./derive-content-types.ts";
+
+// Regression (#533): the incremental rows query interpolated the
+// `sinceAndClause` continuation directly after `NONE`, producing
+// `output_json != NONEAND ts ...` - a SurrealDB parse error that crashed
+// `ax ingest --since=N` (the watcher path). Guard the token boundary.
+describe("rowsSql since-window boundary", () => {
+  test("incremental window keeps a space before AND (no NONEAND)", () => {
+    const sql = rowsSql(1);
+    expect(sql).not.toContain("NONEAND");
+    expect(sql).toContain("output_json != NONE AND ts > time::now() - 1d");
+  });
+
+  test("full re-derive (no since) emits a bare NONE predicate", () => {
+    const sql = rowsSql(undefined);
+    expect(sql).not.toContain("NONEAND");
+    expect(sql).toContain("output_json != NONE");
+    expect(sql).not.toContain("AND ts >");
+  });
+});
 
 describe("buildContentEdge", () => {
   test("derives category + denormalized session/bytes from a tool_call row", () => {

--- a/apps/axctl/src/ingest/derive-content-types.ts
+++ b/apps/axctl/src/ingest/derive-content-types.ts
@@ -148,11 +148,11 @@ const ALREADY_SQL = `SELECT type::string(in) AS tid FROM has_content;`;
 
 /** ROWS_SQL scoped by an optional since window (watcher runs pass 1d; full
  *  re-derives pass undefined to scan everything). */
-const rowsSql = (sinceDays: number | undefined): string => `
+export const rowsSql = (sinceDays: number | undefined): string => `
 SELECT type::string(id) AS id, type::string(session) AS session, name,
        input_json AS inputJson, output_excerpt AS outputExcerpt,
        string::len(output_json) AS bytes, type::string(ts) AS ts
-FROM tool_call WHERE output_json != NONE${sinceAndClause(sinceDays)};
+FROM tool_call WHERE output_json != NONE ${sinceAndClause(sinceDays)};
 `;
 
 export interface DeriveContentTypeStats {


### PR DESCRIPTION
Closes #533.

## Bug
`ax ingest --since=N` crashed at the content-types derive stage:
```
Parse error: Unexpected token, expected Eof
FROM tool_call WHERE output_json != NONEAND ts > time::now() - 2d
                                           ^^
```
`sinceAndClause()` returns `AND ts > …` with **no leading space**; `derive-content-types.ts` interpolated it directly after `NONE` → `NONEAND ts`. Sibling call sites (`derive-signals`, `outcomes`) already space the clause — this one didn't.

## Impact
Breaks the **incremental** ingest path — the LaunchAgent watcher runs `ingest --since=1` on every new transcript. Full `ax ingest` (no `--since`) worked because the clause is empty. Regression from #524 (merged 2026-06-15).

## Fix
One space at the call site: `NONE ${sinceAndClause(sinceDays)}`. Exported `rowsSql` + added a regression test guarding the `NONE AND` token boundary (both since / no-since branches).

## Verification
- New regression test + full `apps/axctl/src/ingest` suite: **897 pass, 0 fail**.
- Live DB: the fixed `rowsSql(1)` SQL now parses and returns rows (was a hard parse error before).

Found via dogfooding `ax memory ops` (#531) — that command surfaced the crash on `--since=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)