### PR TITLE
feat(patterns): directive-mining spec (rescoped to v1 MVP after review) + starter pack (#535)

### DIFF
--- a/community/patterns/README.md
+++ b/community/patterns/README.md
@@ -1,8 +1,14 @@
 # Community patterns
 
-Cold-start library of **agent directives** - abstracted "how to work" instructions a
-fresh ax install ships with, so users get value on day 1 before they've accumulated
-their own history.
+> **Status (post-review):** this is a **starter asset / docs checklist**, not a shipping
+> subsystem. The community contribution loop is **deferred + BLOCKED on a security
+> redesign** (spec §0.4); the `detector` refs are **illustrative**, pending the v2
+> detector registry (spec §0.3). v1 reuses existing ax signals directly. See
+> `docs/superpowers/specs/2026-06-17-directive-mining-design.md` §0.
+
+Cold-start list of **agent directives** - generic "how to work" instructions, useful as
+documentation and a setup checklist. (Low-tech by design; the value bet is the local
+miner, not this file.)
 
 ## Files
 

--- a/community/patterns/README.md
+++ b/community/patterns/README.md
@@ -1,0 +1,38 @@
+# Community patterns
+
+Cold-start library of **agent directives** - abstracted "how to work" instructions a
+fresh ax install ships with, so users get value on day 1 before they've accumulated
+their own history.
+
+## Files
+
+- `seed.json` - **curated** pack (hand-authored, versioned). Battle-tested directives
+  across `verification / output / process / git / quality / communication`. Many are
+  abstracted from real ax-user `feedback-*` memories. This is the floor; it has no
+  privacy surface (outbound-curated only).
+- `trending.json` - **compiled** board (generated nightly; do not hand-edit). Ranks
+  community-contributed patterns by adoption. Empty until the contribution loop ships.
+
+## Schema (per pattern)
+
+| field | meaning |
+|-------|---------|
+| `id` | stable kebab identifier |
+| `title` | short human label |
+| `category` | `verification` \| `output` \| `process` \| `git` \| `quality` \| `communication` |
+| `directive` | the instruction, generalized (no project names / paths / opinions) |
+| `phrasings` | example user phrasings that signal this directive |
+| `landing` | `memory` (passive recall) \| `guidance` (applied) \| `hook` (enforced gate) |
+| `rationale` | why it matters |
+| `source` | `curated` \| `community` |
+
+## How it grows
+
+The local **directive miner** (spec: `docs/superpowers/specs/2026-06-17-directive-mining-design.md`)
+mines a user's own directives, abstracts them to pattern shape, and - **consent-gated,
+never automatic** - contributes them. The nightly compile dedups + thresholds + ranks
+contributions into `trending.json`, which feeds back as new seeds. Privacy model and
+the full loop live in §7 of that spec.
+
+`landing` escalates with recurrence: a directive a user keeps restating is not landing
+as a passive note → it gets promoted toward an enforced `hook`.

--- a/community/patterns/seed.json
+++ b/community/patterns/seed.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "generated": "2026-06-17",
-  "note": "Curated cold-start pattern pack: battle-tested agent directives a fresh ax install ships with. Many are abstracted from real ax-user feedback memories (source: curated). Each pattern is tagged `groundable` (detectable from the ax graph via a named detector) or not (pure preference). The contribution loop + grounding layer are specced in docs/superpowers/specs/2026-06-17-directive-mining-design.md (sections 7 + 7.5).",
+  "note": "STARTER ASSET (not a subsystem). A curated cold-start list of generic agent directives - useful as documentation / a setup checklist; intentionally low-tech (any LLM could regenerate it). The `detector` refs are ILLUSTRATIVE: they document how a pattern WOULD ground against the graph, but the detector registry is deferred v2 (see spec §0.3). v1 reuses existing ax signals (check-family, enforce-worktree hook, insights/friction) directly rather than a new detector registry. The community contribution loop is BLOCKED on a security redesign (spec §0.4). Spec: docs/superpowers/specs/2026-06-17-directive-mining-design.md.",
   "categories": ["verification", "output", "process", "git", "quality", "communication"],
   "landings": ["memory", "guidance", "hook"],
   "patterns": [

--- a/community/patterns/seed.json
+++ b/community/patterns/seed.json
@@ -1,7 +1,7 @@
 {
-  "version": 1,
+  "version": 2,
   "generated": "2026-06-17",
-  "note": "Curated cold-start pattern pack: battle-tested agent directives a fresh ax install ships with. Many are abstracted from real ax-user feedback memories (source: curated). The contribution loop (spec 2026-06-17-directive-mining-design.md §7) grows this with community-contributed, consent-gated, abstracted patterns.",
+  "note": "Curated cold-start pattern pack: battle-tested agent directives a fresh ax install ships with. Many are abstracted from real ax-user feedback memories (source: curated). Each pattern is tagged `groundable` (detectable from the ax graph via a named detector) or not (pure preference). The contribution loop + grounding layer are specced in docs/superpowers/specs/2026-06-17-directive-mining-design.md (sections 7 + 7.5).",
   "categories": ["verification", "output", "process", "git", "quality", "communication"],
   "landings": ["memory", "guidance", "hook"],
   "patterns": [
@@ -12,6 +12,8 @@
       "directive": "Run the actual verification command and show its output before claiming something works, is fixed, or passes.",
       "phrasings": ["did you test it", "dogfood before you show", "verify before completion", "show me it works", "is it actually passing"],
       "landing": "hook",
+      "groundable": true,
+      "detector": { "id": "done-without-verification", "params": { "scope": "episode" } },
       "rationale": "Unverified 'done' is the most common agent failure mode; it is enforceable as a gate.",
       "source": "curated"
     },
@@ -22,6 +24,8 @@
       "directive": "Back success claims with the command and its real output, not a summary of what should have happened.",
       "phrasings": ["show the output", "prove it", "paste the result", "don't just tell me it works"],
       "landing": "hook",
+      "groundable": true,
+      "detector": { "id": "assertion-without-evidence", "params": { "scope": "turn" } },
       "rationale": "Assertions without evidence hide failures; the receipt is the proof.",
       "source": "curated"
     },
@@ -32,6 +36,8 @@
       "directive": "Before a deletion or overwrite, verify the target query/scope (right table, filter, DB) with a dry-run and confirm the count is sane.",
       "phrasings": ["double-check the query", "dry run first", "are you sure that's the right table"],
       "landing": "hook",
+      "groundable": true,
+      "detector": { "id": "delete-without-dryrun", "params": { "scope": "episode" } },
       "rationale": "A wrong-scope destructive op is hard to reverse; a dry-run is cheap insurance.",
       "source": "curated"
     },
@@ -42,6 +48,8 @@
       "directive": "Print full absolute paths to files you produce so they are clickable; relative paths can't be opened.",
       "phrasings": ["give me the full path", "absolute path", "i can't click that", "full path so i can open"],
       "landing": "guidance",
+      "groundable": false,
+      "detector": null,
       "rationale": "Clickable paths remove a manual step every time the user wants to open an artifact.",
       "source": "curated"
     },
@@ -52,6 +60,8 @@
       "directive": "Wrap paste-ready copy in ``` fences (not blockquotes or decorated text) so it is easy to copy verbatim.",
       "phrasings": ["wrap it in backticks", "code block so i can copy", "don't add the gutter line"],
       "landing": "guidance",
+      "groundable": false,
+      "detector": null,
       "rationale": "Decorated copy forces the user to hand-clean before pasting.",
       "source": "curated"
     },
@@ -62,6 +72,8 @@
       "directive": "Emit complete code; never leave TODO stubs, '... rest unchanged ...', or truncated blocks when asked for full output.",
       "phrasings": ["give me the full file", "no placeholders", "don't truncate", "complete code"],
       "landing": "guidance",
+      "groundable": true,
+      "detector": { "id": "placeholder-in-edit", "params": { "tools": ["Edit", "Write"] } },
       "rationale": "Placeholders shift the completion work back to the user and hide gaps.",
       "source": "curated"
     },
@@ -72,6 +84,8 @@
       "directive": "Stay terse and under token limits; summarize or paginate long logs/lists rather than dumping everything.",
       "phrasings": ["be brief", "keep it short", "summarize", "don't dump the whole thing"],
       "landing": "guidance",
+      "groundable": false,
+      "detector": null,
       "rationale": "Walls of output bury the signal the user actually needs.",
       "source": "curated"
     },
@@ -82,6 +96,8 @@
       "directive": "In audit/report deliverables, embed key screenshots inline in the document, not just list their file paths.",
       "phrasings": ["show the screenshots", "embed the images", "inline the evidence"],
       "landing": "guidance",
+      "groundable": false,
+      "detector": null,
       "rationale": "A path list makes the reader hunt; inline images make findings legible at a glance.",
       "source": "curated"
     },
@@ -92,6 +108,8 @@
       "directive": "Read the full file before editing it; plan all changes, then make one complete edit instead of many partial passes.",
       "phrasings": ["read it first", "understand before you change", "stop editing the same file"],
       "landing": "guidance",
+      "groundable": true,
+      "detector": { "id": "edit-without-prior-read", "params": { "scope": "session" } },
       "rationale": "Blind partial edits cause repeated rework and broken state.",
       "source": "curated"
     },
@@ -102,6 +120,8 @@
       "directive": "Get a basic understanding from a few files, make the change, then iterate - don't read 10+ files before acting.",
       "phrasings": ["just try it", "stop exploring and act", "you're overthinking this"],
       "landing": "guidance",
+      "groundable": true,
+      "detector": { "id": "read-heavy-prelude", "params": { "threshold": 10 } },
       "rationale": "Excess upfront reading burns time and context without improving the change.",
       "source": "curated"
     },
@@ -112,6 +132,8 @@
       "directive": "When the user corrects you, stop, re-read their message, quote back what they asked for, and confirm before proceeding.",
       "phrasings": ["that's not what i said", "re-read my message", "you missed the point"],
       "landing": "guidance",
+      "groundable": false,
+      "detector": null,
       "rationale": "Plowing ahead after a correction compounds the original miss.",
       "source": "curated"
     },
@@ -122,6 +144,8 @@
       "directive": "After two consecutive failures of the same approach, stop, summarize what you tried, and change strategy or ask for guidance.",
       "phrasings": ["stop retrying the same thing", "try something different", "you're stuck in a loop"],
       "landing": "guidance",
+      "groundable": true,
+      "detector": { "id": "repeated-same-failure", "params": { "min_repeats": 3, "scope": "episode" } },
       "rationale": "Repeating a failing approach wastes turns and tokens.",
       "source": "curated"
     },
@@ -132,6 +156,8 @@
       "directive": "When stuck, summarize what you've tried and ask the user for guidance instead of retrying the same approach.",
       "phrasings": ["ask me if you're stuck", "don't guess, ask", "check with me first"],
       "landing": "guidance",
+      "groundable": false,
+      "detector": null,
       "rationale": "A timely question beats a confident wrong path.",
       "source": "curated"
     },
@@ -142,6 +168,8 @@
       "directive": "Every few turns, re-read the original request to make sure you haven't drifted from the goal.",
       "phrasings": ["that's not the goal anymore", "you've drifted", "go back to what i asked"],
       "landing": "guidance",
+      "groundable": false,
+      "detector": null,
       "rationale": "Long tasks drift; periodic re-grounding keeps work on target.",
       "source": "curated"
     },
@@ -152,6 +180,8 @@
       "directive": "Before adding new infra (secrets, configs, resources), search the repo for an established pattern and follow it exactly.",
       "phrasings": ["follow the existing pattern", "don't invent a new way", "how do we already do this"],
       "landing": "guidance",
+      "groundable": false,
+      "detector": null,
       "rationale": "Novel one-off patterns fragment the codebase and surprise reviewers.",
       "source": "curated"
     },
@@ -162,6 +192,8 @@
       "directive": "Before proposing a library/protocol/architecture, verify it against the project's established constraints instead of defaulting to a familiar option.",
       "phrasings": ["does that fit our stack", "check our constraints first", "we don't use that here"],
       "landing": "guidance",
+      "groundable": false,
+      "detector": null,
       "rationale": "An off-stack proposal forces a rework round.",
       "source": "curated"
     },
@@ -172,6 +204,8 @@
       "directive": "Confirm before hard-to-reverse or outward-facing actions (publishing, sending, deleting) unless durably authorized.",
       "phrasings": ["ask before you publish", "don't send it yet", "confirm before deleting"],
       "landing": "hook",
+      "groundable": false,
+      "detector": null,
       "rationale": "Outward actions can't be cleanly undone once they leave the machine.",
       "source": "curated"
     },
@@ -182,6 +216,8 @@
       "directive": "Do feature work in an isolated branch/worktree; never edit or commit directly on the main/default branch.",
       "phrasings": ["don't work on main", "make a branch first", "use a worktree"],
       "landing": "hook",
+      "groundable": true,
+      "detector": { "id": "edit-on-main", "params": { "branches": ["main", "master"] } },
       "rationale": "Direct main edits collide with other work and bypass review.",
       "source": "curated"
     },
@@ -192,6 +228,8 @@
       "directive": "Commit your own changes as you finish each part, scoped to only the files you touched for that part.",
       "phrasings": ["commit each part", "commit as you go", "small focused commits"],
       "landing": "guidance",
+      "groundable": true,
+      "detector": { "id": "low-commit-granularity", "params": { "scope": "session" } },
       "rationale": "Granular commits make review and rollback tractable.",
       "source": "curated"
     },
@@ -202,6 +240,8 @@
       "directive": "Stage the specific files for a commit; avoid blanket `git add -A`, which sweeps in unrelated in-flight changes.",
       "phrasings": ["don't add everything", "stage only what you changed", "no git add -A"],
       "landing": "guidance",
+      "groundable": true,
+      "detector": { "id": "git-add-all", "params": { "tool": "Bash" } },
       "rationale": "Blanket staging commits stray work-in-progress files by accident.",
       "source": "curated"
     },
@@ -212,6 +252,8 @@
       "directive": "After merging, verify the staging/production deploy actually succeeded before declaring the task complete.",
       "phrasings": ["did it deploy", "check staging", "verify the deploy went out"],
       "landing": "guidance",
+      "groundable": false,
+      "detector": null,
       "rationale": "A green PR is not a shipped change; the deploy is the real outcome.",
       "source": "curated"
     },
@@ -222,6 +264,8 @@
       "directive": "Default to heavily/end-to-end typed, modular code that can be tested independently; let that shape refactoring decisions.",
       "phrasings": ["keep it typed", "make it modular", "i should be able to test that on its own"],
       "landing": "memory",
+      "groundable": false,
+      "detector": null,
       "rationale": "Typed + modular code is easier to test, change, and reason about.",
       "source": "curated"
     },
@@ -232,6 +276,8 @@
       "directive": "Route review/judgment work to the strongest model and mechanical implementation to cheaper models, not the reverse.",
       "phrasings": ["use the strong model for review", "don't review with the cheap model"],
       "landing": "guidance",
+      "groundable": true,
+      "detector": { "id": "review-on-weak-model", "params": { "agent_classes": ["review", "audit"] } },
       "rationale": "Weak reviewers miss defects; that's the worst place to economize.",
       "source": "curated"
     },
@@ -242,6 +288,8 @@
       "directive": "After a command that may rewrite files (format, codegen, checkout, sed/awk, installs), treat prior reads as stale and re-read before the next edit.",
       "phrasings": ["that file changed", "re-read after formatting", "your view is stale"],
       "landing": "guidance",
+      "groundable": true,
+      "detector": { "id": "stale-edit-after-mutation", "params": { "scope": "session" } },
       "rationale": "Editing against a stale view corrupts files or fails silently.",
       "source": "curated"
     }

--- a/community/patterns/seed.json
+++ b/community/patterns/seed.json
@@ -1,0 +1,249 @@
+{
+  "version": 1,
+  "generated": "2026-06-17",
+  "note": "Curated cold-start pattern pack: battle-tested agent directives a fresh ax install ships with. Many are abstracted from real ax-user feedback memories (source: curated). The contribution loop (spec 2026-06-17-directive-mining-design.md §7) grows this with community-contributed, consent-gated, abstracted patterns.",
+  "categories": ["verification", "output", "process", "git", "quality", "communication"],
+  "landings": ["memory", "guidance", "hook"],
+  "patterns": [
+    {
+      "id": "verify-before-claiming-done",
+      "title": "Verify before claiming done",
+      "category": "verification",
+      "directive": "Run the actual verification command and show its output before claiming something works, is fixed, or passes.",
+      "phrasings": ["did you test it", "dogfood before you show", "verify before completion", "show me it works", "is it actually passing"],
+      "landing": "hook",
+      "rationale": "Unverified 'done' is the most common agent failure mode; it is enforceable as a gate.",
+      "source": "curated"
+    },
+    {
+      "id": "evidence-before-assertion",
+      "title": "Evidence before assertion",
+      "category": "verification",
+      "directive": "Back success claims with the command and its real output, not a summary of what should have happened.",
+      "phrasings": ["show the output", "prove it", "paste the result", "don't just tell me it works"],
+      "landing": "hook",
+      "rationale": "Assertions without evidence hide failures; the receipt is the proof.",
+      "source": "curated"
+    },
+    {
+      "id": "dry-run-before-destructive",
+      "title": "Dry-run before destructive ops",
+      "category": "verification",
+      "directive": "Before a deletion or overwrite, verify the target query/scope (right table, filter, DB) with a dry-run and confirm the count is sane.",
+      "phrasings": ["double-check the query", "dry run first", "are you sure that's the right table"],
+      "landing": "hook",
+      "rationale": "A wrong-scope destructive op is hard to reverse; a dry-run is cheap insurance.",
+      "source": "curated"
+    },
+    {
+      "id": "full-absolute-paths",
+      "title": "Print full absolute paths",
+      "category": "output",
+      "directive": "Print full absolute paths to files you produce so they are clickable; relative paths can't be opened.",
+      "phrasings": ["give me the full path", "absolute path", "i can't click that", "full path so i can open"],
+      "landing": "guidance",
+      "rationale": "Clickable paths remove a manual step every time the user wants to open an artifact.",
+      "source": "curated"
+    },
+    {
+      "id": "copy-in-codeblocks",
+      "title": "Wrap paste-ready copy in code fences",
+      "category": "output",
+      "directive": "Wrap paste-ready copy in ``` fences (not blockquotes or decorated text) so it is easy to copy verbatim.",
+      "phrasings": ["wrap it in backticks", "code block so i can copy", "don't add the gutter line"],
+      "landing": "guidance",
+      "rationale": "Decorated copy forces the user to hand-clean before pasting.",
+      "source": "curated"
+    },
+    {
+      "id": "no-placeholder-output",
+      "title": "No placeholder / truncated output",
+      "category": "output",
+      "directive": "Emit complete code; never leave TODO stubs, '... rest unchanged ...', or truncated blocks when asked for full output.",
+      "phrasings": ["give me the full file", "no placeholders", "don't truncate", "complete code"],
+      "landing": "guidance",
+      "rationale": "Placeholders shift the completion work back to the user and hide gaps.",
+      "source": "curated"
+    },
+    {
+      "id": "concise-output",
+      "title": "Keep output concise",
+      "category": "output",
+      "directive": "Stay terse and under token limits; summarize or paginate long logs/lists rather than dumping everything.",
+      "phrasings": ["be brief", "keep it short", "summarize", "don't dump the whole thing"],
+      "landing": "guidance",
+      "rationale": "Walls of output bury the signal the user actually needs.",
+      "source": "curated"
+    },
+    {
+      "id": "screenshots-inline-in-reports",
+      "title": "Embed key screenshots inline in reports",
+      "category": "output",
+      "directive": "In audit/report deliverables, embed key screenshots inline in the document, not just list their file paths.",
+      "phrasings": ["show the screenshots", "embed the images", "inline the evidence"],
+      "landing": "guidance",
+      "rationale": "A path list makes the reader hunt; inline images make findings legible at a glance.",
+      "source": "curated"
+    },
+    {
+      "id": "read-before-edit",
+      "title": "Read the full file before editing",
+      "category": "process",
+      "directive": "Read the full file before editing it; plan all changes, then make one complete edit instead of many partial passes.",
+      "phrasings": ["read it first", "understand before you change", "stop editing the same file"],
+      "landing": "guidance",
+      "rationale": "Blind partial edits cause repeated rework and broken state.",
+      "source": "curated"
+    },
+    {
+      "id": "act-sooner-fewer-reads",
+      "title": "Act sooner; don't over-read",
+      "category": "process",
+      "directive": "Get a basic understanding from a few files, make the change, then iterate - don't read 10+ files before acting.",
+      "phrasings": ["just try it", "stop exploring and act", "you're overthinking this"],
+      "landing": "guidance",
+      "rationale": "Excess upfront reading burns time and context without improving the change.",
+      "source": "curated"
+    },
+    {
+      "id": "reread-on-correction",
+      "title": "Re-read and confirm when corrected",
+      "category": "process",
+      "directive": "When the user corrects you, stop, re-read their message, quote back what they asked for, and confirm before proceeding.",
+      "phrasings": ["that's not what i said", "re-read my message", "you missed the point"],
+      "landing": "guidance",
+      "rationale": "Plowing ahead after a correction compounds the original miss.",
+      "source": "curated"
+    },
+    {
+      "id": "change-approach-after-2-fails",
+      "title": "Change approach after 2 failures",
+      "category": "process",
+      "directive": "After two consecutive failures of the same approach, stop, summarize what you tried, and change strategy or ask for guidance.",
+      "phrasings": ["stop retrying the same thing", "try something different", "you're stuck in a loop"],
+      "landing": "guidance",
+      "rationale": "Repeating a failing approach wastes turns and tokens.",
+      "source": "curated"
+    },
+    {
+      "id": "ask-when-blocked",
+      "title": "Ask when genuinely blocked",
+      "category": "process",
+      "directive": "When stuck, summarize what you've tried and ask the user for guidance instead of retrying the same approach.",
+      "phrasings": ["ask me if you're stuck", "don't guess, ask", "check with me first"],
+      "landing": "guidance",
+      "rationale": "A timely question beats a confident wrong path.",
+      "source": "curated"
+    },
+    {
+      "id": "reread-request-avoid-drift",
+      "title": "Re-read the original request periodically",
+      "category": "process",
+      "directive": "Every few turns, re-read the original request to make sure you haven't drifted from the goal.",
+      "phrasings": ["that's not the goal anymore", "you've drifted", "go back to what i asked"],
+      "landing": "guidance",
+      "rationale": "Long tasks drift; periodic re-grounding keeps work on target.",
+      "source": "curated"
+    },
+    {
+      "id": "pattern-match-existing-infra",
+      "title": "Follow existing patterns; don't invent",
+      "category": "process",
+      "directive": "Before adding new infra (secrets, configs, resources), search the repo for an established pattern and follow it exactly.",
+      "phrasings": ["follow the existing pattern", "don't invent a new way", "how do we already do this"],
+      "landing": "guidance",
+      "rationale": "Novel one-off patterns fragment the codebase and surprise reviewers.",
+      "source": "curated"
+    },
+    {
+      "id": "tech-stack-verify-before-proposing",
+      "title": "Verify tech choices against constraints",
+      "category": "process",
+      "directive": "Before proposing a library/protocol/architecture, verify it against the project's established constraints instead of defaulting to a familiar option.",
+      "phrasings": ["does that fit our stack", "check our constraints first", "we don't use that here"],
+      "landing": "guidance",
+      "rationale": "An off-stack proposal forces a rework round.",
+      "source": "curated"
+    },
+    {
+      "id": "confirm-before-outward-actions",
+      "title": "Confirm before outward / irreversible actions",
+      "category": "process",
+      "directive": "Confirm before hard-to-reverse or outward-facing actions (publishing, sending, deleting) unless durably authorized.",
+      "phrasings": ["ask before you publish", "don't send it yet", "confirm before deleting"],
+      "landing": "hook",
+      "rationale": "Outward actions can't be cleanly undone once they leave the machine.",
+      "source": "curated"
+    },
+    {
+      "id": "worktree-isolation",
+      "title": "Isolate work in a branch/worktree, never main",
+      "category": "git",
+      "directive": "Do feature work in an isolated branch/worktree; never edit or commit directly on the main/default branch.",
+      "phrasings": ["don't work on main", "make a branch first", "use a worktree"],
+      "landing": "hook",
+      "rationale": "Direct main edits collide with other work and bypass review.",
+      "source": "curated"
+    },
+    {
+      "id": "commit-per-part",
+      "title": "Commit each finished part separately",
+      "category": "git",
+      "directive": "Commit your own changes as you finish each part, scoped to only the files you touched for that part.",
+      "phrasings": ["commit each part", "commit as you go", "small focused commits"],
+      "landing": "guidance",
+      "rationale": "Granular commits make review and rollback tractable.",
+      "source": "curated"
+    },
+    {
+      "id": "no-git-add-all",
+      "title": "Stage explicitly, never blanket add-all",
+      "category": "git",
+      "directive": "Stage the specific files for a commit; avoid blanket `git add -A`, which sweeps in unrelated in-flight changes.",
+      "phrasings": ["don't add everything", "stage only what you changed", "no git add -A"],
+      "landing": "guidance",
+      "rationale": "Blanket staging commits stray work-in-progress files by accident.",
+      "source": "curated"
+    },
+    {
+      "id": "deploy-verify-after-merge",
+      "title": "Verify the deploy after merging",
+      "category": "git",
+      "directive": "After merging, verify the staging/production deploy actually succeeded before declaring the task complete.",
+      "phrasings": ["did it deploy", "check staging", "verify the deploy went out"],
+      "landing": "guidance",
+      "rationale": "A green PR is not a shipped change; the deploy is the real outcome.",
+      "source": "curated"
+    },
+    {
+      "id": "typed-modular-testable",
+      "title": "Prefer typed, modular, independently-testable code",
+      "category": "quality",
+      "directive": "Default to heavily/end-to-end typed, modular code that can be tested independently; let that shape refactoring decisions.",
+      "phrasings": ["keep it typed", "make it modular", "i should be able to test that on its own"],
+      "landing": "memory",
+      "rationale": "Typed + modular code is easier to test, change, and reason about.",
+      "source": "curated"
+    },
+    {
+      "id": "reviewers-get-the-strong-model",
+      "title": "Reviewers get the strong model",
+      "category": "quality",
+      "directive": "Route review/judgment work to the strongest model and mechanical implementation to cheaper models, not the reverse.",
+      "phrasings": ["use the strong model for review", "don't review with the cheap model"],
+      "landing": "guidance",
+      "rationale": "Weak reviewers miss defects; that's the worst place to economize.",
+      "source": "curated"
+    },
+    {
+      "id": "stale-after-mutation",
+      "title": "Re-read files after a mutating command",
+      "category": "quality",
+      "directive": "After a command that may rewrite files (format, codegen, checkout, sed/awk, installs), treat prior reads as stale and re-read before the next edit.",
+      "phrasings": ["that file changed", "re-read after formatting", "your view is stale"],
+      "landing": "guidance",
+      "rationale": "Editing against a stale view corrupts files or fails silently.",
+      "source": "curated"
+    }
+  ]
+}

--- a/docs/superpowers/specs/2026-06-17-directive-mining-deck.html
+++ b/docs/superpowers/specs/2026-06-17-directive-mining-deck.html
@@ -1,0 +1,292 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Directive Mining · ax</title>
+<style>
+  :root{
+    --bg:#0b0b0c; --panel:#141416; --panel2:#1a1a1d; --line:#2a2a2f;
+    --ink:#ece9e2; --muted:#8d8d85; --faint:#5a5a54;
+    --green:#46c46e; --amber:#e0a21a; --blue:#5aa0e6; --violet:#9685f0; --rose:#e07aa6; --red:#e06a5a;
+    --serif:Georgia,"Times New Roman",serif;
+    --mono:ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{
+    background:var(--bg);color:var(--ink);font-family:var(--sans);
+    -webkit-font-smoothing:antialiased;line-height:1.5;
+    background-image:radial-gradient(circle at 50% -10%, rgba(70,196,110,.05), transparent 60%);
+  }
+  .deck{height:100vh;overflow-y:scroll;scroll-snap-type:y mandatory}
+  section{
+    min-height:100vh;scroll-snap-align:start;display:flex;flex-direction:column;
+    justify-content:center;padding:72px 40px;position:relative;
+    border-bottom:1px solid var(--line);
+  }
+  .wrap{width:100%;max-width:980px;margin:0 auto}
+  .kicker{font-family:var(--mono);font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--amber);margin-bottom:20px;display:flex;gap:12px;align-items:center}
+  .kicker .num{color:var(--faint)}
+  .kicker .bar{height:1px;flex:1;background:var(--line)}
+  h1{font-family:var(--serif);font-weight:400;font-size:clamp(38px,6vw,72px);line-height:1.02;letter-spacing:-.02em}
+  h2{font-family:var(--serif);font-weight:400;font-size:clamp(28px,4vw,46px);line-height:1.06;letter-spacing:-.01em;margin-bottom:8px}
+  .lede{font-size:clamp(17px,2vw,21px);color:var(--muted);max-width:62ch;margin-top:18px}
+  p{max-width:64ch;color:#cfcdc6}
+  .mono{font-family:var(--mono)}
+  .accent{color:var(--green)} .am{color:var(--amber)} .bl{color:var(--blue)} .vi{color:var(--violet)} .ro{color:var(--rose)} .rd{color:var(--red)} .mu{color:var(--muted)}
+  .grid{display:grid;gap:18px;margin-top:34px}
+  .g2{grid-template-columns:1fr 1fr} .g3{grid-template-columns:repeat(3,1fr)}
+  @media(max-width:780px){.g2,.g3{grid-template-columns:1fr}}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:22px 22px}
+  .card h3{font-family:var(--mono);font-size:12.5px;letter-spacing:.04em;text-transform:uppercase;color:var(--muted);margin-bottom:12px;font-weight:600}
+  .card .big{font-size:18px;color:var(--ink);margin-bottom:6px}
+  .card p{font-size:14.5px;color:#bdbbb4;max-width:none}
+  .tag{display:inline-block;font-family:var(--mono);font-size:11px;padding:3px 8px;border-radius:999px;border:1px solid var(--line);color:var(--muted);margin:3px 4px 3px 0}
+  .tag.on{border-color:rgba(70,196,110,.4);color:var(--green)}
+  .tag.off{border-color:rgba(141,141,133,.3);color:var(--faint)}
+  pre{font-family:var(--mono);font-size:13px;line-height:1.6;background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--amber);border-radius:8px;padding:18px 20px;overflow-x:auto;color:#d6d4cd;margin-top:24px}
+  pre .c{color:var(--faint)} pre .k{color:var(--green)} pre .a{color:var(--amber)} pre .b{color:var(--blue)} pre .v{color:var(--violet)} pre .r{color:var(--rose)}
+  .flow{display:flex;flex-wrap:wrap;gap:10px;align-items:stretch;margin-top:30px;font-family:var(--mono);font-size:13px}
+  .step{background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:12px 14px;flex:1;min-width:120px}
+  .step .l{color:var(--green);font-weight:600;display:block;margin-bottom:4px}
+  .step .d{color:var(--muted);font-size:12px}
+  .arrow{display:flex;align-items:center;color:var(--faint);font-size:18px}
+  table{width:100%;border-collapse:collapse;margin-top:28px;font-size:14.5px}
+  th,td{text-align:left;padding:12px 14px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);font-weight:600}
+  td .mono{font-size:13px}
+  .lead-num{font-family:var(--mono);color:var(--amber)}
+  .foot{position:fixed;bottom:16px;right:20px;font-family:var(--mono);font-size:12px;color:var(--faint);z-index:20}
+  .brandmark{position:fixed;top:16px;left:20px;font-family:var(--mono);font-size:13px;letter-spacing:.1em;color:var(--muted);z-index:20}
+  .brandmark b{color:var(--green)}
+  .progress{position:fixed;top:0;left:0;height:2px;background:var(--green);width:0;z-index:30;transition:width .2s ease}
+  .dots{position:fixed;left:18px;top:50%;transform:translateY(-50%);display:flex;flex-direction:column;gap:10px;z-index:20}
+  .dots a{width:7px;height:7px;border-radius:50%;background:var(--line);transition:.2s;display:block}
+  .dots a.active{background:var(--green);transform:scale(1.35)}
+  .hint{position:fixed;bottom:16px;left:20px;font-family:var(--mono);font-size:11px;color:var(--faint);z-index:20}
+  .pillrow{margin-top:26px;max-width:none}
+  .stat{font-family:var(--mono);color:var(--amber)}
+  .rule{height:1px;background:var(--line);margin:26px 0}
+  .lineage{font-family:var(--mono);font-size:12.5px;color:var(--muted);margin-top:40px;line-height:1.9}
+  .lineage .x{color:var(--faint)}
+  ul.clean{list-style:none;margin-top:18px;display:flex;flex-direction:column;gap:10px}
+  ul.clean li{padding-left:20px;position:relative;color:#cfcdc6;font-size:15.5px;max-width:66ch}
+  ul.clean li:before{content:"→";position:absolute;left:0;color:var(--green)}
+</style>
+</head>
+<body>
+<div class="brandmark"><b>ax</b> · directive mining</div>
+<div class="progress" id="bar"></div>
+<div class="dots" id="dots"></div>
+<div class="foot" id="foot">01 / 09</div>
+<div class="hint">↓ / → / space</div>
+
+<div class="deck" id="deck">
+
+  <!-- 01 COVER -->
+  <section>
+    <div class="wrap">
+      <div class="kicker"><span class="num">01</span><span>feature · spec #535</span><span class="bar"></span></div>
+      <h1>ax learns <span class="accent">how you work</span>-<br>then shares it.</h1>
+      <p class="lede">You already tell agents how to behave: <span class="mono am">"dogfood before showing me"</span>, <span class="mono am">"give me full paths"</span>, <span class="mono am">"commit each part"</span>. ax mines those <b>directives</b> from your own transcripts, grounds them against the graph, and grows a conflict-free community pattern library on top.</p>
+      <div class="lineage">
+        dogfood question <span class="x">→</span> <span class="accent">ax memory ops</span> (#532) <span class="x">→</span> caught the watcher-ingest crash <span class="accent">(#534)</span> <span class="x">→</span> searched "remember" turns <span class="x">→</span> <b>this</b>
+      </div>
+    </div>
+  </section>
+
+  <!-- 02 THE GAP -->
+  <section>
+    <div class="wrap">
+      <div class="kicker"><span class="num">02</span><span>the gap</span><span class="bar"></span></div>
+      <h2>ax mines corrections. It misses <span class="am">directives</span>.</h2>
+      <div class="grid g2">
+        <div class="card">
+          <h3 class="rd">Corrections · reactive</h3>
+          <p class="big">"No, that's wrong. I said X."</p>
+          <p>Agent did something → user pushes back. ax already captures these (<span class="mono">deriveCorrections</span>).</p>
+        </div>
+        <div class="card">
+          <h3 class="accent">Directives · proactive</h3>
+          <p class="big">"Remember to verify before you show me."</p>
+          <p>A standing rule, stated before any failure. The highest-signal source for durable memory + guidance - and <b>unharvested</b>.</p>
+        </div>
+      </div>
+      <p style="margin-top:26px"><span class="stat">~half</span> of this user's turns containing <span class="mono am">"remember"</span> already became saved <span class="mono">feedback-*</span> memories. The pattern works - it was just being done <b>by hand</b>.</p>
+    </div>
+  </section>
+
+  <!-- 03 THE LOCAL LOOP -->
+  <section>
+    <div class="wrap">
+      <div class="kicker"><span class="num">03</span><span>the local loop</span><span class="bar"></span></div>
+      <h2>Mine → brief → track → <span class="am">escalate</span></h2>
+      <div class="flow">
+        <div class="step"><span class="l">mine</span><span class="d">n-grams by lift over your turns</span></div>
+        <div class="arrow">→</div>
+        <div class="step"><span class="l">flag</span><span class="d">candidate directive turns</span></div>
+        <div class="arrow">→</div>
+        <div class="step"><span class="l">brief</span><span class="d">.ax/tasks/ → agent judges</span></div>
+        <div class="arrow">→</div>
+        <div class="step"><span class="l">track</span><span class="d">directive record + recurrence</span></div>
+        <div class="arrow">→</div>
+        <div class="step"><span class="l">grow</span><span class="d">recurrence → escalate</span></div>
+      </div>
+      <p style="margin-top:30px">CLI scaffolds deterministically, the agent fills judgment - the same shape as <span class="mono">routing tune --emit-brief</span>, <span class="mono">skills classify</span>, <span class="mono">improve accept</span>. Nothing exotic.</p>
+    </div>
+  </section>
+
+  <!-- 04 WHY IT IMPROVES -->
+  <section>
+    <div class="wrap">
+      <div class="kicker"><span class="num">04</span><span>why it keeps improving</span><span class="bar"></span></div>
+      <h2>Two moves make it self-tuning</h2>
+      <div class="grid g2">
+        <div class="card">
+          <h3 class="bl">Lift, not frequency</h3>
+          <p class="mono" style="color:var(--blue);font-size:15px;margin-bottom:8px">P(outcome | ngram) / P(outcome)</p>
+          <p>Rank n-grams by how much more they lead to a <span class="accent">memory write</span> / accepted proposal - not raw count. Markers are <b>learned per user</b>, re-fit each ingest. "Different users, different words" dissolves: the table is yours.</p>
+        </div>
+        <div class="card">
+          <h3 class="am">Recurrence = escalation</h3>
+          <p class="mono" style="font-size:13.5px;color:#bdbbb4;line-height:1.8">said once&nbsp;&nbsp;&nbsp;&nbsp;<span class="mu">→</span> memory note<br>keeps coming back <span class="mu">→</span> <span class="am">escalate to hook</span><br>stops after&nbsp;&nbsp;&nbsp;<span class="mu">→</span> retire</p>
+          <p style="margin-top:10px">"It keeps coming back" is the <b>feature</b>: if you restate a rule, the note didn't land → promote it to an enforced gate. The system grades its own directives.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 05 THREE LAYERS -->
+  <section>
+    <div class="wrap">
+      <div class="kicker"><span class="num">05</span><span>architecture</span><span class="bar"></span></div>
+      <h2>Detectors · Patterns · Cases</h2>
+      <p class="lede">The separation that makes it safe, conflict-free, and grounded.</p>
+      <table>
+        <tr><th>Layer</th><th>Is</th><th>Grows via</th><th>Conflict</th></tr>
+        <tr><td class="mono accent">Detectors</td><td>code - named, tested graph queries</td><td>reviewed code PRs</td><td class="mu">n/a (curated)</td></tr>
+        <tr><td class="mono am">Patterns</td><td>data - id + text + landing + detector ref</td><td>per-user files</td><td class="accent">zero</td></tr>
+        <tr><td class="mono vi">Cases</td><td>data - instance + matched evidence rows</td><td>per-user files</td><td class="accent">zero</td></tr>
+      </table>
+      <p style="margin-top:24px">A <span class="am">pattern</span> binds to a <span class="accent">detector</span> (a graph query) which produces <span class="vi">cases</span> (evidence) + metrics from <i>your</i> graph.</p>
+    </div>
+  </section>
+
+  <!-- 06 GROUNDING -->
+  <section>
+    <div class="wrap">
+      <div class="kicker"><span class="num">06</span><span>grounding</span><span class="bar"></span></div>
+      <h2>Patterns are <span class="accent">executable</span> against the graph</h2>
+      <p>A directive isn't prose to eyeball - the behavioral ones run as queries that find where you broke them and measure whether adopting them helped.</p>
+      <pre><span class="c">// behavioral → graph-grounded</span>
+verify-before-claiming-done <span class="c">→</span> <span class="k">"done-without-verification"</span>
+   <span class="c">assistant turn says "fixed/passing" AND no check-family tool_call in the episode</span>
+worktree-isolation          <span class="c">→</span> <span class="k">"edit-on-main"</span>      <span class="c">edited edge where branch = main</span>
+no-git-add-all              <span class="c">→</span> <span class="k">"git-add-all"</span>      <span class="c">Bash command_text ~ git add -A</span>
+
+<span class="c">// preference → not groundable, marked honestly</span>
+copy-in-codeblocks          <span class="c">→</span> <span class="r">groundable:false</span>   <span class="c">adopted as guidance, never auto-measured</span></pre>
+      <div class="grid g3" style="margin-top:24px">
+        <div class="card"><h3 class="accent">12 / 24</h3><p>seed patterns are graph-grounded today</p></div>
+        <div class="card"><h3 class="am">no raw SQL</h3><p>contributors reference a <b>curated</b> detector by id - never submit queries</p></div>
+        <div class="card"><h3 class="bl">reuses</h3><p><span class="mono">ax hooks cases</span>, check-family, churn episodes</p></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 07 CONFLICT-FREE CONTRIBUTION -->
+  <section>
+    <div class="wrap">
+      <div class="kicker"><span class="num">07</span><span>contribution</span><span class="bar"></span></div>
+      <h2>Conflict-free <span class="am">by construction</span></h2>
+      <p>One shared growing file = constant merge conflicts. ax already has the fix: <span class="mono">community/users/&lt;login&gt;.json</span> - each user owns their file, so two PRs <b>physically can't</b> collide. Mirror it.</p>
+      <pre>community/patterns/
+  seed.json            <span class="c"># maintainer-curated, low churn</span>
+  contributed/
+    <span class="a">&lt;login&gt;.json</span>       <span class="c"># per-user, append-only → ZERO conflict</span>
+  trending.json        <span class="c"># COMPILED nightly (never hand-edit)</span>
+  index.json           <span class="c"># COMPILED: seed + contributed, served to installs</span></pre>
+      <div class="flow" style="margin-top:22px">
+        <div class="step"><span class="l">auto-mine</span><span class="d">local, no network</span></div><div class="arrow">→</div>
+        <div class="step"><span class="l">auto-abstract</span><span class="d">strip specifics</span></div><div class="arrow">→</div>
+        <div class="step" style="border-color:rgba(224,162,26,.5)"><span class="l am">consent-publish</span><span class="d">one yes · never auto</span></div><div class="arrow">→</div>
+        <div class="step"><span class="l">auto-compile</span><span class="d">dedup · ≥N threshold</span></div><div class="arrow">→</div>
+        <div class="step"><span class="l">auto-seed</span><span class="d">day-1 value</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 08 SEED PACK -->
+  <section>
+    <div class="wrap">
+      <div class="kicker"><span class="num">08</span><span>shipped now</span><span class="bar"></span></div>
+      <h2><span class="stat">24</span> battle-tested directives - day one</h2>
+      <p class="lede">The cold-start pack a fresh install ships with. No history needed; no privacy surface. <span class="accent on tag" style="margin-left:6px">grounded</span> <span class="off tag">preference</span></p>
+      <div class="pillrow">
+        <span class="tag on">verify-before-claiming-done</span>
+        <span class="tag on">worktree-isolation</span>
+        <span class="tag on">dry-run-before-destructive</span>
+        <span class="tag on">read-before-edit</span>
+        <span class="tag on">no-git-add-all</span>
+        <span class="tag on">change-approach-after-2-fails</span>
+        <span class="tag on">stale-after-mutation</span>
+        <span class="tag on">reviewers-get-the-strong-model</span>
+        <span class="tag off">full-absolute-paths</span>
+        <span class="tag off">copy-in-codeblocks</span>
+        <span class="tag off">typed-modular-testable</span>
+        <span class="tag off">confirm-before-outward-actions</span>
+      </div>
+      <p style="margin-top:26px">Consume it today: <span class="mono am">ax patterns list</span> · <span class="mono am">ax patterns adopt &lt;id&gt;</span> · <span class="mono am">ax patterns suggest</span> (the gap vs what you already follow).</p>
+    </div>
+  </section>
+
+  <!-- 09 FLYWHEEL / CLOSE -->
+  <section>
+    <div class="wrap">
+      <div class="kicker"><span class="num">09</span><span>the flywheel</span><span class="bar"></span></div>
+      <h2>A system that <span class="accent">improves itself</span></h2>
+      <ul class="clean">
+        <li>Your transcripts reveal how you tell agents to work.</li>
+        <li>ax mines it, grounds it against the graph, measures whether it lands.</li>
+        <li>What recurs gets enforced; what works gets shared; what's shared seeds the next person.</li>
+      </ul>
+      <div class="rule"></div>
+      <p class="mono" style="font-size:13px;color:var(--muted);line-height:1.9">
+        <span class="accent">#532</span> ax memory ops &nbsp;<span class="x mu">·</span>&nbsp;
+        <span class="accent">#534</span> ingest crash fix &nbsp;<span class="x mu">·</span>&nbsp;
+        <span class="accent">#536</span> seed pack + contribution design &nbsp;<span class="x mu">·</span>&nbsp;
+        <span class="am">#535</span> spec
+      </p>
+      <p style="margin-top:14px;color:var(--faint);font-family:var(--mono);font-size:12px">ax - local taste &amp; telemetry graph for AI coding agents</p>
+    </div>
+  </section>
+
+</div>
+
+<script>
+  const deck=document.getElementById('deck');
+  const secs=[...deck.querySelectorAll('section')];
+  const foot=document.getElementById('foot');
+  const bar=document.getElementById('bar');
+  const dotsWrap=document.getElementById('dots');
+  const pad=n=>String(n).padStart(2,'0');
+  secs.forEach((s,i)=>{const a=document.createElement('a');a.href='#';a.dataset.i=i;a.onclick=e=>{e.preventDefault();s.scrollIntoView();};dotsWrap.appendChild(a);});
+  const dots=[...dotsWrap.children];
+  let cur=0;
+  const io=new IntersectionObserver(es=>{
+    es.forEach(e=>{if(e.isIntersecting){cur=secs.indexOf(e.target);
+      foot.textContent=pad(cur+1)+' / '+pad(secs.length);
+      bar.style.width=((cur+1)/secs.length*100)+'%';
+      dots.forEach((d,i)=>d.classList.toggle('active',i===cur));
+    }});
+  },{root:deck,threshold:.55});
+  secs.forEach(s=>io.observe(s));
+  addEventListener('keydown',e=>{
+    if(['ArrowDown','ArrowRight',' ','PageDown'].includes(e.key)){e.preventDefault();secs[Math.min(cur+1,secs.length-1)].scrollIntoView();}
+    if(['ArrowUp','ArrowLeft','PageUp'].includes(e.key)){e.preventDefault();secs[Math.max(cur-1,0)].scrollIntoView();}
+  });
+</script>
+</body>
+</html>

--- a/docs/superpowers/specs/2026-06-17-directive-mining-deck.html
+++ b/docs/superpowers/specs/2026-06-17-directive-mining-deck.html
@@ -77,7 +77,7 @@
 </style>
 </head>
 <body>
-<div class="brandmark"><b>ax</b> · directive mining</div>
+<div class="brandmark"><b>ax</b> · directive mining · <span style="color:var(--amber)">v2 vision</span></div>
 <div class="progress" id="bar"></div>
 <div class="dots" id="dots"></div>
 <div class="foot" id="foot">01 / 09</div>
@@ -88,7 +88,7 @@
   <!-- 01 COVER -->
   <section>
     <div class="wrap">
-      <div class="kicker"><span class="num">01</span><span>feature · spec #535</span><span class="bar"></span></div>
+      <div class="kicker"><span class="num">01</span><span>v2 vision · spec #535 · v1 = one detector on the improve pipeline</span><span class="bar"></span></div>
       <h1>ax learns <span class="accent">how you work</span>-<br>then shares it.</h1>
       <p class="lede">You already tell agents how to behave: <span class="mono am">"dogfood before showing me"</span>, <span class="mono am">"give me full paths"</span>, <span class="mono am">"commit each part"</span>. ax mines those <b>directives</b> from your own transcripts, grounds them against the graph, and grows a conflict-free community pattern library on top.</p>
       <div class="lineage">

--- a/docs/superpowers/specs/2026-06-17-directive-mining-design.md
+++ b/docs/superpowers/specs/2026-06-17-directive-mining-design.md
@@ -185,8 +185,90 @@ A candidate vanishes once it becomes a directive or is dismissed.
 
 ---
 
-## 7. Implementation slices (post-spec)
+## 7. Community layer - seed pack + contribution loop
 
+The local miner only pays off once a user has history; a **community pattern library
+gives day-1 value** and turns ax into a two-sided system (your patterns + everyone's).
+This is the parked registry/mesh design (`ax-registry-mesh-design`) with a *safer
+wedge*: abstracted **patterns** instead of raw recovery verdicts. It rides existing
+community rails - `ax profile publish` (consent gate), `community-nightly` (compile
+worker), trending boards - so it's incremental, not greenfield. Strategically it's also
+the adoption wedge (`team-adoption-roadmap`: push-value first, then contribution, then moat).
+
+### 7.1 Three layers (ship 1 now, design 2-3)
+
+1. **Curated seed pack** - `community/patterns/seed.json`: ~24 battle-tested directives
+   across verification / output / process / git / quality / communication. Decoupled
+   from the miner, **no privacy surface** (outbound-curated). Delivers immediate value:
+   a fresh install ships with adoptable patterns. Many seeds are abstracted from real
+   ax-user `feedback-*` memories - living proof the contribution concept works.
+   **Shipped in this PR.**
+2. **Contribution loop** - local mined directives, abstracted, consent-gated publish,
+   compiled into pattern-stats, fed back as new seeds. See 7.3.
+3. **Trending patterns board** - `community/patterns/trending.json` beside
+   trending-skills; the moat + contributor recognition (same dynamic that already works
+   for skills).
+
+### 7.2 Pattern schema
+
+```jsonc
+{
+  "id": "verify-before-claiming-done",        // stable kebab id
+  "title": "Verify before claiming done",
+  "category": "verification",                  // verification|output|process|git|quality|communication
+  "directive": "Run the actual verification command and show its output before claiming something works/passes.",
+  "phrasings": ["did you test it", "dogfood before showing", "show me it works"],
+  "landing": "hook",                            // memory|guidance|hook (passive -> enforced)
+  "rationale": "Unverified 'done' is the most common agent failure; enforceable as a gate.",
+  "source": "curated"                           // curated|community
+}
+```
+
+### 7.3 Contribution loop - where "auto" applies (and where it must not)
+
+```
+auto-MINE        local n-grams + candidates                      (no network)
+auto-ABSTRACT    directive -> pattern SHAPE, specifics stripped    ("verify-before-claiming-done", not the raw turn)
+consent PUBLISH  one yes, exact JSON shown                        (the ax profile publish model - NEVER auto)
+auto-COMPILE     nightly: dedup + threshold + rank across users   (pattern-stats)
+auto-SEED        installs pull top community patterns             (day-1 value, grows over time)
+```
+
+**Privacy is the whole game** (locked decision, v1): contribute the *generalized
+pattern*, never the raw turn text (which leaks project names, paths, opinions).
+Guarantees:
+- abstraction strips specifics (paths, names, repos) **before anything leaves the machine**;
+- publish is **consent-gated** - profile-publish precedent: show the exact JSON, one
+  explicit yes, PATCH-in-place - **never automatic**;
+- only patterns seen across **>= N independent contributors** compile into the public
+  board (the threshold kills one-off / identifying patterns);
+- validation reuses `community-users.yml` (schema-validated, data-only PR head, never executed).
+
+### 7.4 Consume the seed (immediate-value surface)
+
+- `ax patterns list [--category=C] [--json]` - browse the seed / community library.
+- `ax patterns adopt <id>` - write the pattern into your setup via the existing
+  `improve accept` brief path (memory / guidance / hook per its `landing`).
+- `ax patterns suggest` - patterns you're not yet following (gap vs your `feedback-*`
+  memories + installed hooks). The cold-start companion to the local miner.
+
+---
+
+## 8. Open questions (community layer)
+
+6. **Abstraction mechanism** - generalize a raw directive to a shareable pattern via
+   deterministic templating off the matched n-gram, or an agent abstraction step in the
+   brief (judgment, slower)? Determines how reliably specifics are stripped.
+7. **Contribution threshold N** - how many independent contributors must surface a
+   pattern before it compiles into the public board? (Higher = safer/less identifying,
+   slower to grow.)
+8. **Seed-on-install** - does `ax install` auto-offer the seed pack (opt-in prompt), or
+   is adoption purely pull (`ax patterns adopt`)? Auto-offer = more day-1 value, but must
+   not auto-write the user's config without consent.
+
+## 9. Implementation slices (post-spec)
+
+**Local miner**
 1. `queries/directive-ngrams.ts` - lift table over `turn` × outcomes (deref-free,
    per-user). Tests on synthetic turn/outcome fixtures.
 2. `ingest/derive-directive-candidates.ts` - flag + store candidates (harness-noise
@@ -195,6 +277,17 @@ A candidate vanishes once it becomes a directive or is dismissed.
    template.
 4. Directive record + `improve` proposal-kind wiring (or `directive` table per Q5);
    accept/lint reuse.
-5. Dojo agenda item + escalation rule (memory→hook on recurrence threshold).
-6. Docs gates (cli.md, llms.txt, cli-reference.data.ts, VISIBLE_COMMANDS) +
-   `ax directives` in MCP if read-only views warrant it.
+5. Dojo agenda item + escalation rule (memory->hook on recurrence threshold).
+
+**Community layer**
+6. Seed pack (`community/patterns/seed.json` + README) - **shipped in this PR**.
+7. `cli/commands/ax-patterns.ts` - `list` / `adopt` / `suggest` over the seed pack;
+   `adopt` reuses the `improve accept` brief path. *(Immediate-value slice - build next.)*
+8. Abstraction + consent-gated contribution (`ax patterns contribute`, profile-publish
+   rails), producing a `community/users` data PR.
+9. `community-nightly` compile extension producing `community/patterns/trending.json`
+   (dedup + threshold + rank); site trending-patterns board beside trending-skills.
+
+**Cross-cutting**
+10. Docs gates (cli.md, llms.txt, cli-reference.data.ts, VISIBLE_COMMANDS) for
+    `ax directives` + `ax patterns`; MCP read-only views if warranted.

--- a/docs/superpowers/specs/2026-06-17-directive-mining-design.md
+++ b/docs/superpowers/specs/2026-06-17-directive-mining-design.md
@@ -252,6 +252,84 @@ Guarantees:
 - `ax patterns suggest` - patterns you're not yet following (gap vs your `feedback-*`
   memories + installed hooks). The cold-start companion to the local miner.
 
+### 7.5 Grounding layer - patterns are executable against the graph
+
+A pattern is not just prose to eyeball; the behavioral ones are **executable against
+the ax graph**. Grounding is what makes "are you following this?" and "did adopting it
+help?" answerable, and what separates a *measurable* directive from a vibe. Three layers,
+cleanly separated:
+
+| Layer | Is | Grows via | Conflict |
+|-------|-----|-----------|----------|
+| **Detectors** | code - named, tested graph queries returning evidence rows | reviewed code PRs | n/a (curated) |
+| **Patterns** | data - id + text + landing + `detector` ref + `groundable` | per-user files | zero |
+| **Cases** | data - a pattern instance + the evidence rows a detector matched | per-user files | zero |
+
+A **pattern binds to a detector** (a named graph query), which produces **cases**
+(evidence rows) and **metrics** (violation counts) from the user's own graph.
+
+**Security boundary:** contributors NEVER submit raw SurrealQL (running arbitrary
+contributed queries against a local graph is a footgun). A pattern references a
+**curated detector by id + params**; the detector registry is *code* - tested,
+reviewed, named - so the data layer stays conflict-free AND the query layer stays safe.
+
+Detector registry: `apps/axctl/src/patterns/detectors/*.ts`, each a named, deref-free
+graph query (reusing the insights query toolkit, `check-family.ts`, churn-episode
+logic, the `edited`/branch and `dispatches` model signals). Seed examples:
+
+```
+verify-before-claiming-done → "done-without-verification": assistant turn with done-language
+   ("fixed/passing/works") AND no check-family tool_call in the same episode → violation rows
+worktree-isolation          → "edit-on-main":   `edited` edge where checkout branch = main/master
+dry-run-before-destructive  → "delete-without-dryrun": destructive tool_call (DELETE/DROP/rm) with
+   no preceding count/dry-run in the episode
+no-git-add-all              → "git-add-all":     Bash command_text matching `git add -A|.`
+read-before-edit            → "edit-without-prior-read": Edit on a file with no preceding Read in session
+```
+
+**Not everything is groundable, and that's marked honestly.** Output-format / preference
+patterns (`copy-in-codeblocks`, `full-absolute-paths`, `concise-output`, `typed-modular-testable`)
+can't be detected from the graph; they carry `groundable: false`, `detector: null`, and
+are adopted as guidance/memory, never auto-measured. In the v2 seed pack, **12 of 24
+patterns are graph-grounded**, 12 are preference-only.
+
+What grounding unlocks (the loop becomes real, not prose):
+- **`ax patterns suggest`** runs groundable detectors over your graph → patterns you
+  *actually violate*, ranked by violation count (behavioral, not keyword-matching).
+- **Adoption is measurable**: install a pattern as a hook → detector violation count over
+  time → did it drop? That confirms/escalates the verdict (§2.5 recurrence), grounded in
+  evidence instead of guessed.
+- **Contributed cases are verifiable**: a case ships `detector_id` + evidence shape, so
+  the compile step can re-validate it's a real instance, not a claim. Dedup + the >=N
+  threshold also handle privacy (one-off identifying cases never graduate).
+- **Reuses the existing primitive**: `ax hooks cases` is already "candidate query +
+  structured pass/fail verdict" - this extends that proven shape to community patterns.
+
+### 7.6 Contribution format - conflict-free by construction (locked)
+
+A single shared growing file (a JSON array) is the worst case for contribution: every
+PR edits the same array → structural merge conflicts. Eval frameworks avoid this by
+never sharing one growing file (promptfoo globs a *directory* of per-case files; eval
+datasets append JSONL). ax already has the strongest version of this: **`community/users/<login>.json`** -
+each user owns their own file, validated + auto-merged + nightly-compiled, so two
+contributors *physically cannot* conflict. Mirror it exactly:
+
+```
+community/patterns/
+  seed.json                  # maintainer-curated, single file, low churn - keep as-is
+  contributed/
+    <login>.json             # per-user, append-only, OWNER writes only -> zero conflict
+  trending.json              # COMPILED nightly (generated, never hand-edit)
+  index.json                 # COMPILED: merged seed + contributed, served to installs
+```
+
+A contributor only ever appends to `contributed/<login>.json` (patterns + cases). The
+nightly compile (extends `community-nightly.yml`) merges curated + everyone's
+contributed into `index.json` + `trending.json`, dedups by content hash, graduates a
+pattern to public at >=N independent contributors. "Ever-growing list" = the union of
+per-user files, grown by *adding files*, never editing a shared one. Validation reuses
+`community-users.yml` (schema-checked, data-only PR head, never executed).
+
 ---
 
 ## 8. Open questions (community layer)

--- a/docs/superpowers/specs/2026-06-17-directive-mining-design.md
+++ b/docs/superpowers/specs/2026-06-17-directive-mining-design.md
@@ -120,6 +120,78 @@ miner counts recurrence automatically (same directive re-surfaced by the same/re
 n-grams across sessions), so directives **self-prioritise and self-escalate** with no
 manual tuning. This is the engine that "keeps improving."
 
+### 2.6 Two entry points - antecedent (bottom-up) + directive (top-down)
+
+A directive is the *reaction* to a problem; **what comes before it** - the recurring
+friction that provoked it - is the **antecedent pattern**, and that's where autonomous
+pattern-recognition + automation start. You say "dogfood before showing me" *because* an
+agent kept claiming done without verifying. The directive is your hand-authored fix; the
+antecedent is the **machine-recognisable pattern the fix addresses**. So there are two
+entry points that meet at a shared spine:
+
+```
+BOTTOM-UP (behaviour)                            TOP-DOWN (words)
+recurring friction pattern in the graph           user states a directive
+   "agent keeps claiming done w/o verifying"         "dogfood before showing me"
+            \                                        /
+             \______________  DETECTOR  ____________/      <- the shared spine
+                  (a named graph query that recognises the pattern)
+                              |  recurs past threshold
+                    candidate directive + proposed enforcement (consent-gated)
+                              |  install hook
+                    measure: did the antecedent drop?  -> verdict / escalate
+```
+
+A directive's detector *is* an antecedent recogniser. The **bottom-up path needs no
+words** - so the "different users, different words" problem disappears entirely for the
+autonomous lane. In ML terms: the directive (words) is the *supervised label*; the
+antecedent (behaviour) is the *unsupervised pattern*. Mining antecedents proposes; the
+directive confirms which ones matter. Semi-supervised, and it works even for users who
+never articulate anything.
+
+**ax already recognises most antecedents - reuse, don't rebuild.** The same queries are
+the antecedent recognisers AND the directive detectors:
+
+| Existing ax signal | Antecedent for directive |
+|--------------------|--------------------------|
+| `sessions churn` episodes (fail -> repair -> close) | verify-before-done, change-approach-after-2-fails |
+| `insights friction` | general friction hotspots |
+| `fragility_cascade` | risky-edit / stale-after-mutation |
+| repair loops / verification taxonomy (failed checks) | verify-before-done |
+| edit-without-read sequences | read-before-edit |
+
+ax also already turns graph signals into proposals (`deriveProposals` / `improve
+recommend`), so antecedent -> candidate is partly built. Bottom-up directive discovery is
+mostly *wiring existing insight signals into the pattern/proposal loop*, not new
+detection. This reframes the whole feature: not "mine what users say" but **"recognise
+friction patterns, propose fixes, let user words confirm and sharpen."**
+
+### 2.7 Granularity ladder - directives (atomic) -> workflows (sequence)
+
+The same mine -> ground -> propose -> automate -> measure loop applies at two scales:
+
+```
+atomic antecedent   ->  directive  ->  HOOK              (enforce a single rule)
+sequence antecedent ->  workflow   ->  CODIFIED WORKFLOW  (automate an ordered arc: skill / checklist / command)
+```
+
+A **directive** is one "how to work" rule (verify-before-done). A **workflow** is a
+recurring *ordered sequence* of actions/skills/episodes that accomplishes a kind of task -
+e.g. the `claim -> worktree -> TDD -> verify -> PR` arc repeated three times in the
+session that produced this spec. Both are patterns mined from the graph; they differ only
+in granularity (single-turn antecedent vs. an ordered chain), and they share the same
+detector/proposal/verdict spine - a workflow detector matches a *sequence* of tool/skill/
+episode events rather than a single-turn shape.
+
+ax already has the **sequence-scale machinery**: the `ax-extract-workflow` skill
+("reconstruct the workflow behind a shipped artifact") and the `workflow_epoch` table.
+So directive mining is the *atomic* rung of a ladder whose *sequence* rung already
+exists - identifying directives is also the on-ramp to identifying workflows. Mining the
+recurring action arcs (and the order directives fire within them) turns "how you work"
+from scattered rules into reusable, suggestable, eventually-automatable workflows.
+*(Workflow-scale detection is a follow-on; this spec ships the atomic rung and the shared
+spine that the sequence rung plugs into.)*
+
 ---
 
 ## 3. The loop

--- a/docs/superpowers/specs/2026-06-17-directive-mining-design.md
+++ b/docs/superpowers/specs/2026-06-17-directive-mining-design.md
@@ -1,9 +1,87 @@
 # Directive Mining - learn per-user "how to work" instructions
 
 **Issue:** #535
-**Status:** Draft
+**Status:** Rescoped v1 after adversarial review (see §0). Sections 1–6 describe the
+v1 MVP; sections 7+ and §2.1/§2.6/§2.7 are the **deferred v2 vision** (preserved, not built).
 **Date:** 2026-06-17
 **Found via:** dogfooding `ax memory ops` (#531) → searching the user's "remember" turns → realising ax mines *corrections* but not *directives*.
+
+---
+
+## 0. Status - rescoped after adversarial review
+
+A 4-reviewer panel (2 Codex + 2 Claude, distinct lenses) roasted the original design.
+Unanimous across both models: the original v1 was over-built - a research program
+stapled to an unproven hypothesis, with ~80% either duplicating the existing `improve`
+pipeline or (for the community layer) unsafe as designed. This section records the
+verdict and the rescope; the rest of the doc keeps the full design, tagged.
+
+### 0.1 The v1 MVP (the only thing built first)
+
+**One new signal - `deriveDirectives` - feeding the existing proposal pipeline.** It
+flags *proactive standing-instruction* user turns (imperative-mood, not anchored to a
+prior agent action - the gap `deriveCorrections` leaves, which only catches *reactive*
+push-back) and emits them as `guidance`-form rows into `deriveProposals`. They then
+surface in `ax improve recommend`, accept via the existing `.ax/tasks` brief, and accrue
+`frequency` / verdict **for free**.
+
+> **Zero new commands, zero new tables, zero community layer, zero n-gram miner.**
+> This alone tests the core bet: *will users act on mined directives?* Everything else
+> is gated on that answer.
+
+### 0.2 Reuse map - what already ships (do NOT rebuild)
+
+| Spec concept | Already exists | File |
+|--------------|----------------|------|
+| mine → propose → accept-brief → reconcile → measure | the whole loop | `ingest/derive-proposals.ts` + `improve/` |
+| recurrence → escalate → measure (§2.5) | `frequency` on stable `dedupe_sig` + frozen `baseline` → verdict friction-delta | `derive-proposals.ts` |
+| landing `memory\|guidance\|hook` (§2.3) | `INTERVENTION_FORM_REGISTRY` (`guidance\|skill\|harness_check\|subagent\|hook\|automation`) - a superset | `improve/intervention-forms.ts` |
+| harness-noise filter (§2.2) | drops `<task-notification>` + `claude-subagent` | `ingest/signals/core.ts` (`deriveCorrections`) |
+| grounding detectors (§7.5): `done-without-verification` | verification taxonomy (PR #474) | `check-family.ts` |
+| grounding detectors (§7.5): `edit-on-main` | the enforce-worktree hook | hooks-sdk |
+| "candidate query + pass/fail verdict" | `ax hooks cases` | `queries/feedback-cases.ts` |
+
+So a "directive" is **a new `kind`/detector on the existing proposal pipeline**, not a
+parallel subsystem. (Resolves §6 Q5: reuse, don't add a table.)
+
+### 0.3 Deferred to v2 (built only if the MVP proves the bet)
+
+- **§2.1 n-gram-lift miner** - gold-plating. §2.6 concedes ax already computes the
+  antecedents; v1 wires those existing signals, no new mining. (Also: lift is
+  statistically shaky at one-user scale - sparse N, and the same turn often both states
+  the directive *and* triggers the outcome → circular labels.)
+- **§2.7 workflow ladder** - pure speculation; defers its own payload.
+- **§7 community layer (all of it)** - see §0.4. Premature *and* unsafe.
+- **§7.5 grounding-detector registry as new code** - mostly reskins `insights.ts` /
+  `check-family.ts` / `feedback-cases.ts`. v1 reuses those directly.
+- **24-pattern `seed.json`** - demoted from "subsystem deliverable" to a starter/docs
+  asset (it's generic agent hygiene any LLM regenerates; 12/24 detector refs are
+  illustrative, pending the v2 registry).
+
+### 0.4 Community layer - BLOCKED on security redesign (do not build)
+
+The privacy reviewer found the contribution loop unsafe as designed. Hard blockers
+before any community code:
+
+1. `pull_request_target` auto-merge feeds data into **3 code-execution sinks**: detector
+   `params` → SurrealQL **on every install** (injection unless params are a closed typed
+   schema, bound never interpolated); free-text `directive`/`phrasings` → **stored XSS**
+   on the site; validator pwn-request.
+2. **">= N contributors" does not stop sybils** - content-hash dedup *is* the sybil
+   counter (N free accounts, same hash → graduate → auto-seed a malicious `landing:hook`
+   to every install). Define "independent"; require account history; invert (identical
+   content from many fresh accounts = sybil signal, not diversity); **human gate before
+   graduation**.
+3. **Abstraction leaks** - `phrasings` are raw user turns; per-user `contributed/<login>.json`
+   is world-readable on merge *before* the threshold applies. The "specifics stripped
+   before anything leaves the machine" claim (§7.3) is false as written. Drop `phrasings`
+   from published artifacts; compile from user gists (profile-publish model), not repo forks.
+4. **One-time consent + auto-PATCH** of later-mined content (the watcher re-publishes
+   `--if-stale`) → user consents to X, publishes X+Δ; git history is permanent. Require
+   per-change consent showing the diff.
+5. **Case evidence rows** are raw graph rows (`command_text`, paths) - scrubbing undefined.
+
+→ Community layer is **too risky for v1**; redesign required before it ships.
 
 ---
 
@@ -50,6 +128,11 @@ judgment where it belongs (is this turn a real standing directive, what does it 
 where should it land - the agent).
 
 ### 2.1 Mine n-grams by **lift**, not frequency
+
+> **⚠ v2 - DEFERRED (§0.3).** v1 does NOT build the n-gram miner; it wires ax's
+> existing antecedent signals (churn/friction/fragility/repair, per §2.6) into the
+> proposal pipeline. Lift is also statistically shaky at one-user scale (sparse N,
+> circular labels). Kept here as the v2 vision.
 
 Frequency alone surfaces "the", "can you". The signal is **lift**:
 
@@ -168,6 +251,8 @@ friction patterns, propose fixes, let user words confirm and sharpen."**
 
 ### 2.7 Granularity ladder - directives (atomic) -> workflows (sequence)
 
+> **⚠ v2 - DEFERRED (§0.3).** Speculative; defers its own payload. Not built in v1.
+
 The same mine -> ground -> propose -> automate -> measure loop applies at two scales:
 
 ```
@@ -258,6 +343,12 @@ A candidate vanishes once it becomes a directive or is dismissed.
 ---
 
 ## 7. Community layer - seed pack + contribution loop
+
+> **🚫 v2 - BLOCKED + DEFERRED. Not built in v1.** Premature (§0.3) AND unsafe as
+> designed (§0.4: auto-merge → 3 code-exec sinks, sybil threshold defeated by its own
+> dedup, abstraction leaks raw turns, one-time consent + auto-PATCH). The 5 security
+> blockers in §0.4 must be resolved by redesign before any community code. The curated
+> `seed.json` (layer 1, §7.1) is the only safe-to-ship piece, demoted to a starter asset.
 
 The local miner only pays off once a user has history; a **community pattern library
 gives day-1 value** and turns ax into a two-sided system (your patterns + everyone's).
@@ -417,6 +508,20 @@ per-user files, grown by *adding files*, never editing a shared one. Validation 
    not auto-write the user's config without consent.
 
 ## 9. Implementation slices (post-spec)
+
+> **v1 = slice 0 ONLY.** Everything below slice 0 is **v2**, gated on the MVP proving the
+> bet (and the community slices additionally gated on the §0.4 security redesign).
+
+**v1 MVP**
+0. `ingest/derive-directives.ts` - one signal that flags *proactive standing-instruction*
+   user turns (imperative-mood, not anchored to a prior agent action) and emits a
+   `guidance`-form row into the existing `deriveProposals` pipeline. Reuses
+   `deriveCorrections`' harness-noise filter, `INTERVENTION_FORM_REGISTRY`, and the
+   `frequency`/`baseline`/verdict machinery. Surfaces via `ax improve recommend`; accepts
+   via the existing brief. **No new commands, tables, or community layer.** Tests on
+   synthetic turn fixtures (directive vs task vs correction vs question).
+
+**v2 (deferred - see §0.3 / §0.4)**
 
 **Local miner**
 1. `queries/directive-ngrams.ts` - lift table over `turn` × outcomes (deref-free,

--- a/docs/superpowers/specs/2026-06-17-directive-mining-design.md
+++ b/docs/superpowers/specs/2026-06-17-directive-mining-design.md
@@ -1,0 +1,200 @@
+# Directive Mining - learn per-user "how to work" instructions
+
+**Issue:** #535
+**Status:** Draft
+**Date:** 2026-06-17
+**Found via:** dogfooding `ax memory ops` (#531) → searching the user's "remember" turns → realising ax mines *corrections* but not *directives*.
+
+---
+
+## 1. Problem
+
+ax already mines **corrections** (`deriveCorrections`): reactive signals where the
+agent did something and the user pushed back. It does **not** capture **directives**:
+*proactive* standing instructions where the user states how the agent should work -
+independent of any failure.
+
+> "remember to dogfood before you show anything to me"
+> "you should remember this as a project memory and decide based on it when refactoring"
+> "always wrap copy in ``` blocks"
+> "give me full paths so I can click them"
+
+These are the **highest-signal source for durable memory + guidance** - the user
+literally telling the agent how to behave. Evidence they matter: in this user's own
+graph, ~half of all turns containing "remember" already became `feedback-*` memories.
+**The harvesting is happening - by hand.** This spec automates it.
+
+### Why a naive detector fails
+- A hand-tuned marker regex (`remember to|always|from now on`) is brittle and needs
+  endless babysitting.
+- **Different users use different words.** One says "remember to", another "make sure
+  you", a third just uses bare imperatives. A shipped global list can't fit all.
+- The word alone is noisy: of 12 "remember" turns in this user's history, only ~half
+  were directives; the rest were filler ("I don't remember", "as I remember").
+
+So the design must be **per-user, self-improving, and grounded in outcomes** - not a
+static classifier.
+
+---
+
+## 2. Approach - CLI scaffolds deterministically, agent fills judgment
+
+This is ax's established **brief** pattern. Direct siblings:
+- `routing tune --emit-brief` (mine clusters deterministically; agent backtests judgment)
+- `skills classify` (emit briefs for unclassified skills; agent tags)
+- `improve accept` (proposal → `.ax/tasks/<id>.md` brief → agent acts → `lint` reconciles)
+- `dojo spar-plan` (CLI freezes baseline; agent runs the variant)
+
+Determinism where it belongs (counting, lift, recurrence - reproducible math),
+judgment where it belongs (is this turn a real standing directive, what does it mean,
+where should it land - the agent).
+
+### 2.1 Mine n-grams by **lift**, not frequency
+
+Frequency alone surfaces "the", "can you". The signal is **lift**:
+
+```
+lift(ngram) = P(outcome | turn contains ngram) / P(outcome)
+```
+
+where **outcome** = the user turn was followed (same session, within a bounded window)
+by:
+- a **memory write** - an `edited` edge to a `~/.claude/.../memory/` path (the signal
+  `ax memory ops` exposes, #531/#532), **or**
+- an **accepted `improve` proposal**, **or**
+- a **hook/rule** added to `~/.ax/hooks/`.
+
+High-lift n-grams (1–4 tokens, lowercased, over `role=user` turns) are **this user's
+directive markers**. The table is:
+- **data-derived per user** - no shipped regex,
+- **re-fit every ingest** - grows as the user's vocabulary surfaces,
+- **self-correcting** - an n-gram that stops leading to captured outcomes loses rank.
+
+Cold start: until enough outcomes exist to compute stable lift, fall back to a small
+**seed** marker set (imperative-mood heuristic + a handful of universal markers) at
+**lower confidence**, clearly labelled as unconfirmed. The seed only bootstraps; lift
+takes over as labels accumulate.
+
+### 2.2 Flag candidates
+
+User turns matching high-lift n-grams (or seed markers) that are **not yet captured**
+as a memory / guidance / hook. Hard filters (the `deriveCorrections` pollution lesson):
+- drop `<task-notification>` / harness-injected bodies,
+- drop `source = claude-subagent` (dispatch prompts, not the human),
+- drop turns already linked to an existing directive/memory/proposal.
+
+### 2.3 Emit a brief
+
+```
+ax directives mine --emit-brief  →  .ax/tasks/directives-<date>.md
+```
+
+The brief lists each candidate turn with: the matched n-gram(s) + lift, the source
+session/ts (clickable), recurrence count (§2.5), and a fill-in block per candidate:
+`is_directive? · canonical_text · landing(memory|guidance|hook) · rationale`.
+
+### 2.4 Agent fills → tracked directive records
+
+The agent judges each candidate and writes a **directive** record. A directive is
+modelled as a **new `improve` proposal kind** so it inherits the existing
+accept / verdict / lint machinery for free - no parallel review surface.
+
+Fields (on the proposal, or a sibling `directive` table if cleaner):
+`text · evidence_turns[] · surfaced_ngrams[] · landing · status · recurrence · verdict`.
+
+### 2.5 Track + grow via **recurrence** - "it keeps coming back" is the feature
+
+A directive's *strength* = how often the user restates it across sessions. Recurrence
+is the escalation signal, and it's exactly what answers "this will keep coming back":
+
+```
+said once               → memory note            (passive recall)
+keeps recurring         → the note isn't landing  → ESCALATE to guidance / hook (enforcement)
+stops after enforcement → it's working            → retire to background
+```
+
+The system **measures whether its own directives are being followed**. If the user
+keeps telling the agent "dogfood before showing me" every week, that's proof the
+memory note failed to change behaviour → escalate it to a `verify`-style gate. The
+miner counts recurrence automatically (same directive re-surfaced by the same/related
+n-grams across sessions), so directives **self-prioritise and self-escalate** with no
+manual tuning. This is the engine that "keeps improving."
+
+---
+
+## 3. The loop
+
+```
+mine    directive-ngrams query: rank n-grams by lift vs outcomes (per user, re-fit each ingest)
+flag    user turns matching high-lift n-grams, not yet captured → candidates (harness noise filtered)
+brief   ax directives mine --emit-brief → .ax/tasks/directives-<date>.md
+fill    agent judges each: real directive? meaning? landing? → writes directive record
+track   directive: text, evidence, recurrence, status, landing, verdict
+grow    recurrence ↑ → escalate memory→hook; lift table sharpens as outcomes accumulate; self-clearing
+```
+
+Runs as: a recurring **ingest derive stage** (flag candidates each ingest) + a
+self-clearing **dojo/retro agenda item** (surface unconfirmed directives for a yes/no).
+A candidate vanishes once it becomes a directive or is dismissed.
+
+---
+
+## 4. Surface
+
+- `ax directives mine [--emit-brief] [--days=N]` - rank candidate directive turns by
+  n-gram lift; emit the agent brief.
+- `ax directives list [--status=active|candidate|escalated] [--json]` - tracked
+  directives, sorted by recurrence.
+- `ax directives ngrams [--json]` - the learned per-user lift table (transparency /
+  debugging; this is what makes "different users, different words" visible).
+- Dojo: a `directives` agenda item when unconfirmed candidates exist.
+- Reuse `ax improve accept` / `lint` for the accept→apply→reconcile path.
+
+---
+
+## 5. Explicitly NOT
+
+- **No embeddings.** The clustering spike (`embedding-clustering-spike`) rejected them:
+  noise-dominated, only 1/8 clusters real. Stay lexical (n-gram + lift) and
+  outcome-grounded - cheaper, explainable, and the grounding does the work embeddings
+  couldn't.
+- **No hand-maintained global marker list.** Markers are *learned per user* from
+  outcomes; the only shipped lexicon is the tiny cold-start seed.
+- **No auto-write of directives.** The agent (judgment) writes them via the brief;
+  the CLI only scaffolds candidates. Mirrors every other ax brief loop.
+
+---
+
+## 6. Open questions
+
+1. **Confirmation window** - what counts as a turn "leading to" an outcome: same
+   session only? same session within ±N turns? Topical match (shared file/skill/keyword)
+   in addition to temporal? (Tighter = higher precision lift, fewer labels.)
+2. **Directive vs task** - v1 binary (directive-or-not), or full 4-way
+   (directive / task / question / correction) so it also de-noises the `turn` table for
+   other consumers (e.g. "what the user actually asked", which came up this session)?
+3. **Landing default** - when the agent is unsure, does a new directive default to
+   `memory` (safe, passive) and only escalate on recurrence, or can the agent open it
+   straight as a `hook` when the text is clearly an enforceable gate?
+4. **Recurrence identity** - how is "the same directive restated" detected across
+   sessions: shared canonical_text similarity, shared surfaced n-gram, or shared
+   landing target? (Determines how reliably escalation fires.)
+5. **Schema** - reuse `proposal` with a new `kind`, or a dedicated `directive` table?
+   Reuse is less surface but may strain the proposal shape (recurrence, landing,
+   escalation state have no `proposal` home today).
+
+---
+
+## 7. Implementation slices (post-spec)
+
+1. `queries/directive-ngrams.ts` - lift table over `turn` × outcomes (deref-free,
+   per-user). Tests on synthetic turn/outcome fixtures.
+2. `ingest/derive-directive-candidates.ts` - flag + store candidates (harness-noise
+   filtered); recurrence counter.
+3. `cli/commands/ax-directives.ts` - `mine --emit-brief` / `list` / `ngrams`; brief
+   template.
+4. Directive record + `improve` proposal-kind wiring (or `directive` table per Q5);
+   accept/lint reuse.
+5. Dojo agenda item + escalation rule (memory→hook on recurrence threshold).
+6. Docs gates (cli.md, llms.txt, cli-reference.data.ts, VISIBLE_COMMANDS) +
+   `ax directives` in MCP if read-only views warrant it.


### PR DESCRIPTION
Issue #535. Design spec for directive mining + a starter pattern pack. **Rescoped to a v1 MVP after a 4-reviewer adversarial roast** (2 Codex + 2 Claude); the full design is preserved as the deferred v2 vision.

## v1 MVP (spec §0.1) — the only thing built first
**One new signal — `deriveDirectives` — feeding the EXISTING proposal pipeline.** Flags *proactive standing-instruction* user turns (the gap `deriveCorrections` leaves — it only catches reactive push-back) → `guidance`-form rows into `deriveProposals` → surfaces in `ax improve recommend`, accepts via the existing brief, accrues `frequency`/verdict **for free**. Zero new commands/tables/community/miner. Tests the core bet: *will users act on mined directives?*

## What the roast changed (spec §0)
Unanimous across both models: the original v1 was over-built (~80% duplicated `improve` or, for the community layer, unsafe).
- **Reuse map (§0.2)** — recurrence=`frequency` on `dedupe_sig`, landing=`INTERVENTION_FORM_REGISTRY`, harness-noise filter, and several "grounding detectors" (`done-without-verification`=check-family/PR#474, `edit-on-main`=enforce-worktree hook) **already ship**. A directive is a new `kind` on the existing pipeline, not a subsystem.
- **Deferred to v2 (§0.3)** — n-gram-lift miner (§2.1; also statistically shaky at one-user scale), workflow ladder (§2.7), grounding-detector registry as new code (§7.5).
- **Community layer BLOCKED on security redesign (§0.4)** — `pull_request_target` auto-merge → 3 code-exec sinks (detector params→SurrealQL on every install, stored XSS, pwn-request); ">=N contributors" sybil gate defeated by its own content-hash dedup; `phrasings` leak raw turns + per-user files public before the threshold; one-time consent + auto-PATCH of later-mined content.

## Files
- `docs/superpowers/specs/2026-06-17-directive-mining-design.md` — spec, rescoped (§0 leads; v2 sections tagged inline).
- `community/patterns/seed.json` + README — **demoted to a starter/docs asset**; detector refs illustrative (registry is v2); contribution loop blocked.
- `...-deck.html` — flagged "v2 vision" (v1 = one detector).

## Origin
dogfood `ax memory ops` (#532) → caught & fixed the watcher-ingest crash (#534) → searched "remember" turns → directive insight → spec → adversarial review → this rescope.

## Next (no decisions needed)
Build slice 0: `ingest/derive-directives.ts` → existing `deriveProposals`. That's the whole v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)