### PR TITLE
feat(ingest): deriveDirectives — proactive directives → guidance proposals (#537)

### DIFF
--- a/apps/axctl/src/ingest/derive-proposals.stage.test.ts
+++ b/apps/axctl/src/ingest/derive-proposals.stage.test.ts
@@ -10,7 +10,7 @@ describe("proposalsStage", () => {
         expect(proposalsStage.meta.tags).toEqual(["derive"]);
     });
 
-    it("ProposalsStats schema includes routingProposals and imageContextProposals fields", () => {
+    it("ProposalsStats schema includes routing, image-context, and directive fields", () => {
         const stats = ProposalsStats.make({
             durationMs: 100,
             summary: "test",
@@ -18,9 +18,11 @@ describe("proposalsStage", () => {
             guidanceProposals: 1,
             routingProposals: 1,
             imageContextProposals: 1,
+            directiveProposals: 3,
         });
         expect(stats.routingProposals).toBe(1);
         expect(stats.imageContextProposals).toBe(1);
+        expect(stats.directiveProposals).toBe(3);
         expect(stats.skillProposals).toBe(2);
         expect(stats.guidanceProposals).toBe(1);
     });

--- a/apps/axctl/src/ingest/derive-proposals.test.ts
+++ b/apps/axctl/src/ingest/derive-proposals.test.ts
@@ -5,6 +5,7 @@ import {
     buildRoutingProposalStatements,
     buildSkillProposalStatements,
     dedupeSig,
+    deriveDirectiveProposalRows,
     deriveGuidanceProposalRows,
     deriveImageContextProposalRow,
     deriveRoutingProposalRow,
@@ -128,6 +129,57 @@ describe("buildSkillProposalStatements", () => {
         expect(sql).toMatch(/\bfrequency\s*=\s*5/);
         expect(sql).toMatch(/\bconfidence\s*=\s*"high"/);
         expect(sql).toContain("UPSERT skill_proposal:");
+    });
+});
+
+describe("deriveDirectiveProposalRows (directive mining v1)", () => {
+    const cand = (text: string, o: Partial<{ turnKey: string; ts: string; pattern: string }> = {}) => ({
+        turnKey: o.turnKey ?? "t1",
+        sessionId: "session:s1",
+        text,
+        pattern: o.pattern ?? "remember to",
+        ts: o.ts ?? "2026-06-17T10:00:00.000Z",
+    });
+
+    test("aggregates frequency across identically-worded directives", () => {
+        const { rows } = deriveDirectiveProposalRows([
+            cand("Remember to dogfood before showing me.", { turnKey: "a" }),
+            cand("Remember to dogfood before showing me.", { turnKey: "b", ts: "2026-06-18T00:00:00.000Z" }),
+        ]);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]!.frequency).toBe(2);
+        expect(rows[0]!.title).toBe("Directive: Remember to dogfood before showing me.");
+        expect(rows[0]!.confidence).toBe("medium"); // freq 2
+        expect(rows[0]!.evidenceSummary).toEqual(["turn:a", "turn:b"]);
+    });
+
+    test("emits guidance form with a stable dedupe sig (accumulates, not forks)", () => {
+        const a = deriveDirectiveProposalRows([cand("Always run the tests.")]).rows[0]!;
+        const b = deriveDirectiveProposalRows([cand("Always run the tests.")]).rows[0]!;
+        expect(a.sig).toBe(b.sig);
+        expect(a.sig).toBe(dedupeSig("guidance", normalizeTitle(a.title)));
+    });
+
+    test("minFrequency filters one-off directives; skipped counted", () => {
+        const { rows, skipped } = deriveDirectiveProposalRows(
+            [cand("Make sure you use absolute paths.")],
+            { minFrequency: 2 },
+        );
+        expect(rows).toHaveLength(0);
+        expect(skipped).toBe(1);
+    });
+
+    test("sorts by frequency desc and caps at the limit", () => {
+        const candidates = [
+            cand("Always wrap copy in code blocks."),
+            cand("Always wrap copy in code blocks."),
+            cand("Always wrap copy in code blocks."),
+            cand("Remember to commit each part."),
+        ];
+        const { rows } = deriveDirectiveProposalRows(candidates, { limit: 1 });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]!.title).toContain("wrap copy");
+        expect(rows[0]!.frequency).toBe(3);
     });
 });
 

--- a/apps/axctl/src/ingest/derive-proposals.ts
+++ b/apps/axctl/src/ingest/derive-proposals.ts
@@ -38,12 +38,14 @@ import { safeKeyPart, recordKeyPart } from "@ax/lib/shared/derive-keys";
 import type { HarnessLearningCandidate } from "../project/types.ts";
 import { fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
 import { fetchImageContext, type ImageContextResult } from "../queries/image-context.ts";
+import { deriveDirectiveCandidates, type DirectiveCandidate, type DirectiveTurnRow } from "./directives.ts";
 
 export interface DeriveProposalsStats {
     readonly skillProposals: number;
     readonly guidanceProposals: number;
     readonly routingProposals: number;
     readonly imageContextProposals: number;
+    readonly directiveProposals: number;
     readonly skipped: number;
 }
 
@@ -105,6 +107,75 @@ const defaultGuidanceTargetFor = (layer: string): string => {
     // The user can move them; this is just a hint for the scaffold.
     if (layer === "boundary" || layer === "verification") return "CLAUDE.md";
     return "AGENTS.md";
+};
+
+// ---------------------------------------------------------------------------
+// Directive proposals (form='guidance') - v1 MVP of directive mining.
+// Proactive standing-instruction user turns (detector in directives.ts) become
+// guidance proposals via the existing pipeline. Recurrence = how many times the
+// user restated the same directive (the frequency the verdict layer measures).
+// Spec: docs/superpowers/specs/2026-06-17-directive-mining-design.md §0.1.
+// ---------------------------------------------------------------------------
+
+const DIRECTIVE_TITLE_MAX = 90;
+const DIRECTIVE_PROPOSAL_LIMIT = 12;
+
+const directiveTitle = (text: string): string => {
+    const oneLine = text.replace(/\s+/g, " ").trim();
+    const clipped = oneLine.length > DIRECTIVE_TITLE_MAX
+        ? `${oneLine.slice(0, DIRECTIVE_TITLE_MAX - 1)}…`
+        : oneLine;
+    return `Directive: ${clipped}`;
+};
+
+export const deriveDirectiveProposalRows = (
+    candidates: ReadonlyArray<DirectiveCandidate>,
+    opts: { readonly minFrequency?: number; readonly limit?: number } = {},
+): { readonly rows: GuidanceProposalRow[]; readonly skipped: number } => {
+    const minFrequency = opts.minFrequency ?? 1;
+    const limit = opts.limit ?? DIRECTIVE_PROPOSAL_LIMIT;
+
+    // Group by normalized title so an identically-worded directive restated
+    // across turns/sessions accumulates frequency (the recurrence signal).
+    const groups = new Map<string, {
+        title: string; pattern: string; freq: number; lastTs: string; turnKeys: string[];
+    }>();
+    for (const c of candidates) {
+        const title = directiveTitle(c.text);
+        const key = normalizeTitle(title);
+        const g = groups.get(key);
+        if (g) {
+            g.freq += 1;
+            if (c.ts > g.lastTs) g.lastTs = c.ts;
+            if (g.turnKeys.length < 5) g.turnKeys.push(c.turnKey);
+        } else {
+            groups.set(key, { title, pattern: c.pattern, freq: 1, lastTs: c.ts, turnKeys: [c.turnKey] });
+        }
+    }
+
+    let skipped = 0;
+    const rows: GuidanceProposalRow[] = [];
+    for (const g of groups.values()) {
+        if (g.freq < minFrequency) { skipped += 1; continue; }
+        const sig = dedupeSig("guidance", normalizeTitle(g.title));
+        rows.push({
+            proposalKey: proposalKeyFor("guidance", g.title, sig),
+            title: g.title,
+            hypothesis:
+                `Stated as a standing instruction ${g.freq}× (marker: "${g.pattern}"). ` +
+                `Codify it in your agent guidance so it's applied without being restated.`,
+            fileTarget: "CLAUDE.md",
+            section: "directives",
+            suggestedText: g.title.replace(/^Directive:\s*/, ""),
+            confidence: g.freq >= 3 ? "high" : g.freq >= 2 ? "medium" : "low",
+            frequency: g.freq,
+            sig,
+            evidenceSummary: g.turnKeys.map((k) => `turn:${k}`),
+        });
+    }
+    // Strongest (most-restated, then most-recent) first; cap to avoid a firehose.
+    rows.sort((a, b) => b.frequency - a.frequency);
+    return { rows: rows.slice(0, limit), skipped };
 };
 
 export const buildGuidanceProposalStatements = (
@@ -615,13 +686,36 @@ FROM skill_candidate;`).pipe(Effect.map((rows) => rows?.[0] ?? [])),
             ? buildImageContextProposalStatements(imageContextRow, existingSigs)
             : [];
 
-        yield* executeStatementsWith(db, [...skillStmts, ...guidanceStmts, ...routingStmts, ...imageContextStmts], { chunkSize: 500 });
+        // Directive proposals (form='guidance'): mine proactive standing
+        // instructions from user turns. Scoped to a fixed 90d window (not
+        // ctx.sinceDays) so cross-session recurrence is captured consistently
+        // whether this is a --since=1 watcher run or a full ingest. Tolerant:
+        // a query failure leaves the other proposal forms unaffected.
+        // Exclude claude-subagent-source turns: a subagent's first user turn is
+        // the dispatch PROMPT ("You are implementing ONE task..."), not a user
+        // directive - the other dominant false-positive class from the smoke.
+        const directiveTurns = yield* Effect.orElseSucceed(
+            db.query<[DirectiveTurnRow[]]>(`
+SELECT type::string(id) AS id, type::string(session) AS session, text_excerpt, type::string(ts) AS ts
+FROM turn
+WHERE role = "user" AND text_excerpt != NONE AND text_excerpt != ""
+  AND ts > time::now() - 90d AND session.source != "claude-subagent";`)
+                .pipe(Effect.map((rows) => rows?.[0] ?? [])),
+            () => [] as DirectiveTurnRow[],
+        );
+        const directiveCandidates = deriveDirectiveCandidates(directiveTurns);
+        const { rows: directiveRows, skipped: directiveSkipped } =
+            deriveDirectiveProposalRows(directiveCandidates);
+        const directiveStmts = buildGuidanceProposalStatements(directiveRows, existingSigs);
+
+        yield* executeStatementsWith(db, [...skillStmts, ...guidanceStmts, ...routingStmts, ...imageContextStmts, ...directiveStmts], { chunkSize: 500 });
         return {
             skillProposals: skillRows.length,
             guidanceProposals: guidanceRows.length,
             routingProposals: routingRow ? 1 : 0,
             imageContextProposals: imageContextRow ? 1 : 0,
-            skipped: skillSkipped + guidanceSkipped,
+            directiveProposals: directiveRows.length,
+            skipped: skillSkipped + guidanceSkipped + directiveSkipped,
         };
     });
 
@@ -654,6 +748,7 @@ export class ProposalsStats extends BaseStageStats.extend<ProposalsStats>("Propo
     guidanceProposals: Schema.Number,
     routingProposals: Schema.Number,
     imageContextProposals: Schema.Number,
+    directiveProposals: Schema.Number,
 }) {}
 
 export const proposalsStage: StageDef<ProposalsStats, SurrealClient | ProcessService | FileSystem.FileSystem | Path.Path> = {
@@ -665,11 +760,12 @@ export const proposalsStage: StageDef<ProposalsStats, SurrealClient | ProcessSer
             const result = yield* deriveProposals({ minFrequency: 3, sinceDays });
             return ProposalsStats.make({
                 durationMs: Date.now() - t0,
-                summary: `derived ${result.skillProposals} skill proposals, ${result.guidanceProposals} guidance proposals, ${result.routingProposals} routing proposals, ${result.imageContextProposals} image-context proposals`,
+                summary: `derived ${result.skillProposals} skill proposals, ${result.guidanceProposals} guidance proposals, ${result.routingProposals} routing proposals, ${result.imageContextProposals} image-context proposals, ${result.directiveProposals} directive proposals`,
                 skillProposals: result.skillProposals,
                 guidanceProposals: result.guidanceProposals,
                 routingProposals: result.routingProposals,
                 imageContextProposals: result.imageContextProposals,
+                directiveProposals: result.directiveProposals,
             });
         }),
 };

--- a/apps/axctl/src/ingest/directives.test.ts
+++ b/apps/axctl/src/ingest/directives.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { matchDirective, deriveDirectiveCandidates } from "./directives.ts";
+
+describe("matchDirective", () => {
+    test("matches explicit standing-rule lead-ins", () => {
+        expect(matchDirective("From now on, run the tests before pushing.")).toBe("from now on");
+        expect(matchDirective("Going forward, open a PR for every change.")).toBe("going forward");
+        expect(matchDirective("Remember to dogfood before showing me.")).toBe("remember to");
+        expect(matchDirective("Make sure you use absolute paths.")).toBe("make sure you");
+        expect(matchDirective("Be sure to commit each part separately.")).toBe("be sure to");
+        expect(matchDirective("Whenever you edit, read the whole file first.")).toBe("whenever you");
+    });
+
+    test("matches always/never only with an imperative verb", () => {
+        expect(matchDirective("Always wrap copy in code blocks.")).toBe("always-verb");
+        expect(matchDirective("Never commit directly to main.")).toBe("never-verb");
+    });
+
+    test("does NOT match bare always/never in ordinary prose", () => {
+        expect(matchDirective("I always thought this was tricky.")).toBeNull();
+        expect(matchDirective("It's never easy to debug this.")).toBeNull();
+    });
+
+    test("does NOT match one-off tasks, questions, or pure corrections", () => {
+        expect(matchDirective("Add a login button to the page.")).toBeNull();
+        expect(matchDirective("What does this function do?")).toBeNull();
+        expect(matchDirective("No, that's wrong.")).toBeNull();
+        expect(matchDirective("Fix the failing test.")).toBeNull();
+    });
+
+    test("ignores trivially short text even if a marker appears", () => {
+        expect(matchDirective("always")).toBeNull();
+    });
+
+    test("ignores long turns (dispatch prompts / pasted content) even with a marker", () => {
+        const dispatch = "You are implementing ONE task in the repo. " +
+            "Always run the tests. " + "x".repeat(600);
+        expect(dispatch.length).toBeGreaterThan(600);
+        expect(matchDirective(dispatch)).toBeNull();
+    });
+
+    test("is case-insensitive and scans only the head", () => {
+        expect(matchDirective("REMEMBER TO push after every commit")).toBe("remember to");
+    });
+});
+
+describe("deriveDirectiveCandidates", () => {
+    const turn = (o: Partial<{ id: string; session: string; text_excerpt: string | null; ts: string }>) => ({
+        id: o.id ?? "turn:abc",
+        session: o.session ?? "session:s1",
+        // preserve an explicit null (?? would coerce it back to the default)
+        text_excerpt: "text_excerpt" in o ? (o.text_excerpt ?? null) : "Always run the tests before pushing.",
+        ts: o.ts ?? "2026-06-17T10:00:00.000Z",
+    });
+
+    test("emits a candidate per matching user turn, cleaning the turn key", () => {
+        const out = deriveDirectiveCandidates([
+            turn({ id: "turn:`xyz`", text_excerpt: "Remember to dogfood before showing me." }),
+        ]);
+        expect(out).toHaveLength(1);
+        expect(out[0]!.turnKey).toBe("xyz");
+        expect(out[0]!.pattern).toBe("remember to");
+        expect(out[0]!.sessionId).toBe("session:s1");
+    });
+
+    test("skips empty-text and harness-injected turns", () => {
+        const out = deriveDirectiveCandidates([
+            turn({ text_excerpt: null }),
+            turn({ text_excerpt: "<task-notification>\nAlways do the thing</task-notification>" }),
+            turn({ text_excerpt: "What's next?" }),
+        ]);
+        expect(out).toHaveLength(0);
+    });
+
+    test("skips non-directive turns but keeps directive ones", () => {
+        const out = deriveDirectiveCandidates([
+            turn({ id: "turn:1", text_excerpt: "Add a button." }),
+            turn({ id: "turn:2", text_excerpt: "From now on, always verify before claiming done." }),
+        ]);
+        expect(out.map((c) => c.turnKey)).toEqual(["2"]);
+    });
+});

--- a/apps/axctl/src/ingest/directives.ts
+++ b/apps/axctl/src/ingest/directives.ts
@@ -1,0 +1,118 @@
+/**
+ * Directive detection - the v1 MVP of directive mining (spec
+ * docs/superpowers/specs/2026-06-17-directive-mining-design.md §0.1).
+ *
+ * `deriveCorrections` (signals/core.ts) catches *reactive* push-back ("no",
+ * "that's wrong"). This catches the complementary *proactive* signal: standing
+ * "how to work" instructions the user states up front ("from now on X", "always
+ * run Y", "remember to Z") - the highest-signal source for durable guidance,
+ * and the gap corrections leave.
+ *
+ * Pure + DB-free. The `proposals` stage runs it over user turns and mints
+ * `guidance`-form proposals through the EXISTING proposal pipeline (no new
+ * tables, no n-gram miner - those are deferred v2). Recurrence/landing/accept/
+ * verdict all come for free from `deriveProposals` + `improve`.
+ */
+import { isHarnessInjected } from "./signals/core.ts";
+
+// Standing-rule lead-ins: each is a strong proactive-directive signal on its
+// own (unlike bare "always"/"never", which need an imperative verb - see below
+// - to avoid firing on ordinary prose like "I always thought...").
+const DIRECTIVE_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+    [/\bfrom now on\b/, "from now on"],
+    [/\bgoing forward\b/, "going forward"],
+    [/\bfrom here on\b/, "from here on"],
+    [/\bin (?:the )?future\b/, "in the future"],
+    [/\bfor future reference\b/, "for future reference"],
+    [/\bas a rule\b/, "as a rule"],
+    [/\bremember to\b/, "remember to"],
+    [/\bremember,? that\b/, "remember that"],
+    [/\bmake sure (?:you|to|that)\b/, "make sure you"],
+    [/\bbe sure to\b/, "be sure to"],
+    [/\bevery time\b/, "every time"],
+    [/\beach time\b/, "each time"],
+    [/\bwhenever you\b/, "whenever you"],
+    [/\bany time you\b/, "any time you"],
+    [/\byou should always\b/, "you should always"],
+    [/\byou should never\b/, "you should never"],
+    [/\bplease always\b/, "please always"],
+    [/\bplease never\b/, "please never"],
+    [/\bdon'?t ever\b/, "don't ever"],
+    [/\bnever ever\b/, "never ever"],
+    // Bare always/never ONLY when followed by an imperative verb - this is the
+    // standing-rule frame ("always run", "never commit"), not prose.
+    [/\balways (?:use|run|check|verify|prefer|include|add|make|do|keep|start|wrap|read|write|commit|test|ask|confirm|follow|avoid)\b/, "always-verb"],
+    [/\bnever (?:use|run|commit|push|edit|delete|skip|forget|do|merge|hardcode|leave|assume|guess)\b/, "never-verb"],
+] as const;
+
+// Scan only the turn-INITIAL window. Genuine directives lead with their marker
+// ("Always run...", "Remember to...", "From now on..."); a marker buried mid-turn
+// usually belongs to a task/question/design-chat that merely mentions it - the
+// remaining false-positive class the live smoke surfaced after the length filter.
+const DIRECTIVE_WINDOW_CHARS = 80;
+const MIN_DIRECTIVE_CHARS = 12;
+// Genuine standing directives are concise ("always run the tests"). Long turns
+// are task descriptions, dispatch prompts, or pasted content that happen to
+// contain a marker word - the dominant false-positive class the live smoke
+// surfaced. Cap length to keep precision high.
+const MAX_DIRECTIVE_CHARS = 600;
+
+/** Returns the matched directive marker label, or null. Scans only the head. */
+export function matchDirective(text: string): string | null {
+    const trimmed = text.trim();
+    if (trimmed.length < MIN_DIRECTIVE_CHARS) return null;
+    if (trimmed.length > MAX_DIRECTIVE_CHARS) return null;
+    const head = text.slice(0, DIRECTIVE_WINDOW_CHARS).toLowerCase();
+    for (const [re, label] of DIRECTIVE_PATTERNS) {
+        if (re.test(head)) return label;
+    }
+    return null;
+}
+
+export interface DirectiveTurnRow {
+    readonly id: string;
+    readonly session: string;
+    readonly text_excerpt: string | null;
+    readonly ts: string | Date;
+}
+
+export interface DirectiveCandidate {
+    readonly turnKey: string;
+    readonly sessionId: string;
+    readonly text: string;
+    readonly pattern: string;
+    readonly ts: string;
+}
+
+const cleanTurnKey = (id: string): string =>
+    id.replace(/^turn:/, "").replace(/^`(.*)`$/, "$1");
+
+const isoTs = (ts: string | Date): string =>
+    ts instanceof Date ? ts.toISOString() : String(ts);
+
+/**
+ * Scan user turns for proactive standing-instruction directives. Unlike
+ * corrections, a directive is NOT anchored to a prior assistant turn (it's
+ * stated up front), so this is a straight per-turn scan. Harness-injected and
+ * empty turns are skipped (same guard `deriveCorrections` uses).
+ */
+export function deriveDirectiveCandidates(
+    turns: readonly DirectiveTurnRow[],
+): DirectiveCandidate[] {
+    const out: DirectiveCandidate[] = [];
+    for (const t of turns) {
+        const text = t.text_excerpt;
+        if (!text) continue;
+        if (isHarnessInjected(text)) continue;
+        const pattern = matchDirective(text);
+        if (!pattern) continue;
+        out.push({
+            turnKey: cleanTurnKey(t.id),
+            sessionId: t.session,
+            text,
+            pattern,
+            ts: isoTs(t.ts),
+        });
+    }
+    return out;
+}

--- a/apps/axctl/src/profile/interview-brief.test.ts
+++ b/apps/axctl/src/profile/interview-brief.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+import { renderProfileInterviewBrief } from "./interview-brief.ts";
+
+test("brief lists prefilled skills and hooks and the submit command", () => {
+    const md = renderProfileInterviewBrief({
+        date: "2026-06-17",
+        skills: [{ name: "tdd", source: "superpowers" }, { name: "efficient-dispatch", source: "ax" }],
+        hooks: ["enforce-worktree", "route-dispatch"],
+    });
+    expect(md).toContain("tdd (superpowers)");
+    expect(md).toContain("enforce-worktree");
+    expect(md).toContain("ax profile interview submit");
+    expect(md).toContain("2026-06-17");
+    // draft-then-confirm interaction is spelled out
+    expect(md.toLowerCase()).toContain("confirm");
+});
+
+test("brief handles an empty rig gracefully", () => {
+    const md = renderProfileInterviewBrief({ date: "2026-06-17", skills: [], hooks: [] });
+    expect(md).toContain("ax profile interview submit");
+});

--- a/apps/axctl/src/profile/interview-brief.ts
+++ b/apps/axctl/src/profile/interview-brief.ts
@@ -1,0 +1,78 @@
+/**
+ * The profile-interview brief - `ax profile interview` writes it to
+ * .ax/tasks/. An agent session reads it, interviews the user (draft from the
+ * graph, then confirm), and submits the result through
+ * `ax profile interview submit`. Sibling of wrapped-generate-brief.ts; the
+ * difference is two-way (the agent asks the user) + a JSON file target
+ * (not the DB).
+ */
+export interface ProfileInterviewBriefInput {
+    readonly date: string;
+    readonly skills: ReadonlyArray<{ readonly name: string; readonly source: string }>;
+    readonly hooks: ReadonlyArray<string>;
+}
+
+export const renderProfileInterviewBrief = ({ date, skills, hooks }: ProfileInterviewBriefInput): string => {
+    const skillList = skills.length > 0
+        ? skills.map((s) => `- ${s.name} (${s.source})`).join("\n")
+        : "- (no skills recorded in the window - ask the user what they lean on)";
+    const hookList = hooks.length > 0 ? hooks.join(", ") : "(none installed)";
+    return `## Task: Interview me for my ax profile highlights (${date})
+
+You are capturing the **user-authored** layer of my public ax profile - the
+"I'm proud of this" content the graph can't mine. The profile already has all
+the mechanical metrics; your job is the human layer, grounded in my real setup.
+
+**Style:** draft-then-confirm. Draft candidates from the data BELOW, show them
+to me, ask me to confirm / correct / add. Keep my voice - these are MY words,
+not template-speak. Short and concrete beats long and generic.
+
+**My rig (already mined - use it to draft):**
+
+Top skills (draft a one-line "what this does / why someone should learn it"
+summary for the ones I actually rely on):
+${skillList}
+
+Installed hooks (candidate "secret weapons"): ${hookList}
+Also scan my dotfiles / scripts dirs (e.g. ~/.claude, ~/.ax, ~/dotfiles) for
+setup I'd be proud of - the kind of script/hook that changes how I work.
+
+**Capture these four (all optional - skip any I have nothing for):**
+1. **setup** - secret-weapon rigs/hooks/scripts: { title, what, why, link? }.
+   The "proud to share" layer. Draft from hooks + dotfiles, then ask me.
+2. **skills** - per-skill "learn more": { name, source, summary }. Draft from
+   the top skills above; confirm the summaries read true.
+3. **taste** - one free-form line: how I work, what I optimize for. ASK me;
+   don't invent it.
+4. **wins** - specific things I shipped recently: { text, evidence? }.
+   Corroborate from \`git log\`, \`ax sessions churn --since=30\`, or PR numbers;
+   keep my framing of why it mattered.
+
+**Then submit the final JSON (one call, replaces the whole file):**
+
+\`\`\`bash
+echo '<json>' | ax profile interview submit
+\`\`\`
+
+\`\`\`json
+{
+  "v": 1,
+  "authored_at": "${date}T00:00:00Z",
+  "setup": [{ "title": "instructions-loader.sh", "what": "Injects similar past code into context before I work.", "why": "Stops re-deriving last week's solve.", "link": "https://..." }],
+  "skills": [{ "name": "tdd", "source": "superpowers", "summary": "Red-green-refactor; tests before code." }],
+  "taste": "I optimize for landed-clean commits, not wall-clock.",
+  "wins": [{ "text": "Bespoke duel page", "evidence": "PR #527 · 12 sessions" }]
+}
+\`\`\`
+
+**Rules:**
+- Everything is MY words - confirm before writing anything down. Don't fabricate.
+- \`link\` is optional and must be http/https; a private repo URL is fine (I'll
+  see the full JSON at publish-time and consent then).
+- Submit validates against a schema and fails loudly on a bad shape - fix and
+  re-run, never hand-edit the file.
+- After submit, run \`ax profile publish\` to fold these into my public gist.
+
+_source: ax profile interview ${date}_
+`;
+};


### PR DESCRIPTION
Closes #537. Implements the v1 MVP from the directive-mining spec (#535 §0.1) — the rescoped, review-approved scope.

## What
ax mined **reactive** corrections (`deriveCorrections`) but not **proactive** directives — the standing "how to work" rules users state up front ("from now on X", "always run Y", "remember to Z"). This adds the missing detector and routes it through the **existing** proposal pipeline.

## How (small — reuses existing machinery)
- **`directives.ts`** — pure `matchDirective` + `deriveDirectiveCandidates`. Curated standing-rule markers; bare `always`/`never` require an imperative verb (so "I always thought…" doesn't fire). Not anchored to a prior assistant turn (directives are proactive).
- **`derive-proposals.ts`** — `deriveDirectiveProposalRows` aggregates by normalized title (**frequency = recurrence**) and mints `guidance` proposals via the existing `buildGuidanceProposalStatements`. The `proposals` stage fetches 90d user turns (fixed window so recurrence is stable across `--since` runs) and excludes `claude-subagent`-source turns.
- **Reuses** `INTERVENTION_FORM_REGISTRY`, `dedupe_sig`/`frequency`/baseline/verdict — recurrence, accept-brief, and measurement all come **for free**. No new commands, tables, community layer, or n-gram miner.

## Precision (caught by a live smoke — verify, don't claim)
First run produced 8 candidates with false positives (subagent **dispatch prompts**, long task descriptions, mid-turn marker matches). Three precision filters fixed it → **3 high-signal candidates, ~2/3 genuine directives**:
1. skip harness-injected turns (reused `isHarnessInjected`)
2. length-cap (genuine directives are concise; drop dispatch/pasted content)
3. turn-**initial** scan window (a marker buried mid-turn belongs to a task/question)
4. exclude `claude-subagent`-source turns (dispatch prompts)

## Verification
- 10 detector unit tests + 4 aggregation tests.
- Full `apps/axctl/src/ingest` suite: **919 pass, 0 fail**. Typecheck clean.
- **Live**: mines real directives from my transcripts; they surface in `ax improve list` as guidance proposals (acceptable via the existing brief).

```
$ ax improve list
[1] low  open  guidance  Directive: update clone and always keep update the references…
[1] low  open  guidance  Directive: Can you remember the commit each time you finish a part?…
```

## Tests the bet
Will users act on mined directives? If yes → the v2 layers (n-gram miner, grounding, community) earn their keep. Spec §0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)