### PR TITLE
feat(attribution): "Generated with ax" watermark on shareable artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,20 @@ Guidance for Claude Code and other AI assistants working in this repo.
 
 `ax` - local taste & telemetry graph for AI coding agents. Ingests transcripts from 5 harnesses - Claude Code (`~/.claude/projects/`), Codex (`~/.codex/sessions/`), Pi (`~/.pi/agent/sessions/`), OpenCode + Cursor (SQLite stores) - plus installed skills (`~/.claude/skills/`, `~/.agents/skills/`, plugin caches) into a dedicated SurrealDB instance. Each harness has a full parser dual-writing provider events (`agent_*` tables) + normalized records (`session`/`turn`/`tool_call`); `AgentProviderName` enumerates them (`apps/axctl/src/ingest/provider-events.ts`). CLI surfaces "what skills/tools you actually use" on demand.
 
+## Attribution on shareable artifacts
+
+When you generate an artifact **for the user to share** (a gist, a posted
+issue/PR body, a report, a public writeup, a social post drafted on their
+behalf), append a `Generated with ax` plug linking https://github.com/Necmttn/ax.
+The marketing reach is the point. The canonical wording lives in
+`@ax/lib/shared/attribution` (`withAxAttribution(md)` /
+`AX_ATTRIBUTION_TEXT`) - reuse it; never hand-roll the line. CLI surfaces that
+emit shareable artifacts already apply it (`ax dojo report`, `ax dojo draft`;
+the JSON share/profile gists carry `ax_version` + the studio "recorded with ax"
+viewer footer). Do NOT plug on internal, agent-only artifacts (`.ax/tasks`
+classify/improve briefs, scaffolds) the user never shares - a plug there is just
+noise.
+
 ## Claiming work (multi-agent)
 
 Many agents (all pushing as the same GitHub user) run this repo in parallel, so

--- a/apps/axctl/src/dojo/outbox.test.ts
+++ b/apps/axctl/src/dojo/outbox.test.ts
@@ -1,5 +1,5 @@
 // apps/axctl/src/dojo/outbox.test.ts
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
@@ -34,6 +34,8 @@ describe("writeDraft + listDrafts", () => {
         expect(drafts).toHaveLength(1);
         expect(drafts[0]).toMatchObject({ title: "Fix the scanner!", kind: "bug", session: "s1" });
         expect(drafts[0]?.path).toBe(written.path);
+        // The body carries the ax attribution so it travels into the posted upstream issue.
+        expect(readFileSync(written.path, "utf8")).toContain("Generated with [ax]");
     });
     test("newline in title can't inject extra frontmatter keys", async () => {
         const base = mkdtempSync(`${tmpdir()}/dojo-outbox-`);

--- a/apps/axctl/src/dojo/outbox.ts
+++ b/apps/axctl/src/dojo/outbox.ts
@@ -1,4 +1,5 @@
 import { Effect, FileSystem, type PlatformError } from "effect";
+import { withAxAttribution } from "@ax/lib/shared/attribution";
 import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
 import { skipNotFound } from "@ax/lib/shared/fs-error";
 import { posixPath } from "@ax/lib/shared/path";
@@ -59,7 +60,8 @@ const render = (i: WriteDraftInput): string => {
         "---",
         "",
     ].join("\n");
-    return `${fm}${i.body}\n`;
+    // Attribution travels into the posted upstream issue/PR body (marketing reach).
+    return `${fm}${withAxAttribution(i.body)}`;
 };
 
 export const writeDraft = (

--- a/apps/axctl/src/dojo/report.test.ts
+++ b/apps/axctl/src/dojo/report.test.ts
@@ -30,6 +30,8 @@ describe("renderReport", () => {
         expect(md).toContain("## Proposals created (1)");
         expect(md).toContain("## Outbox drafts pending review (1)");
         expect(md).toContain("## Notes\nran 4 laps");
+        expect(md).toContain("Generated with [ax]");
+        expect(md.trimEnd().endsWith("._")).toBe(true);
     });
     test("empty sections render '- (none)' and no Notes header when notes empty", () => {
         const md = renderReport({ ...data, verdicts: [], proposals: [], drafts: [], notes: "" });

--- a/apps/axctl/src/dojo/report.ts
+++ b/apps/axctl/src/dojo/report.ts
@@ -10,6 +10,7 @@
  */
 import { Effect, FileSystem } from "effect";
 import { SurrealClient } from "@ax/lib/db";
+import { withAxAttribution } from "@ax/lib/shared/attribution";
 import {
     listProposalsCreatedSince,
     listVerdictsLockedSince,
@@ -62,7 +63,7 @@ export const renderReport = (data: ReportData): string => {
     if (data.notes.trim().length > 0) {
         blocks.push(`## Notes\n${data.notes}`);
     }
-    return `${blocks.join("\n\n")}\n`;
+    return withAxAttribution(blocks.join("\n\n"));
 };
 
 export interface GatherReportInput {

--- a/packages/lib/src/shared/attribution.test.ts
+++ b/packages/lib/src/shared/attribution.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { AX_ATTRIBUTION_MD, AX_ATTRIBUTION_TEXT, AX_URL, withAxAttribution } from "./attribution.ts";
+
+describe("attribution constants", () => {
+    test("text + markdown forms both carry the canonical url", () => {
+        expect(AX_ATTRIBUTION_TEXT).toContain(AX_URL);
+        expect(AX_ATTRIBUTION_MD).toContain(AX_URL);
+        expect(AX_ATTRIBUTION_MD).toBe(`_Generated with [ax](${AX_URL})._`);
+    });
+});
+
+describe("withAxAttribution", () => {
+    test("appends a horizontal rule + attribution line", () => {
+        const out = withAxAttribution("# Report\n\nbody");
+        expect(out).toBe(`# Report\n\nbody\n\n---\n\n${AX_ATTRIBUTION_MD}\n`);
+    });
+
+    test("normalizes trailing whitespace before the footer", () => {
+        const out = withAxAttribution("body\n\n\n");
+        expect(out).toBe(`body\n\n---\n\n${AX_ATTRIBUTION_MD}\n`);
+    });
+
+    test("is idempotent - re-applying does not stack footers", () => {
+        const once = withAxAttribution("body");
+        const twice = withAxAttribution(once);
+        expect(twice).toBe(once);
+    });
+});

--- a/packages/lib/src/shared/attribution.ts
+++ b/packages/lib/src/shared/attribution.ts
@@ -1,0 +1,41 @@
+/**
+ * attribution: the shared "Generated with ax" marketing watermark appended to
+ * SHAREABLE artifacts ax produces on the user's behalf - artifacts meant to
+ * leave the machine (dojo morning reports, staged upstream issue/PR drafts).
+ *
+ * This is the human-visible counterpart to the structured attribution already
+ * carried by the JSON share/profile surfaces (`ax_version` in the share
+ * manifest, the studio "recorded with ax" viewer footer). Internal, agent-only
+ * artifacts (`.ax/tasks` classify/improve briefs) deliberately do NOT get this
+ * footer - a plug on a file the agent consumes and the user never shares is
+ * just noise.
+ *
+ * One source of truth so the wording, URL, and spacing never drift across
+ * surfaces. Always on by design (no opt-out) - the marketing reach is the point.
+ *
+ * NOTE: distinct from `watermark.ts`, which is the ingest file-state
+ * idempotency fingerprint - same English word, unrelated concept.
+ */
+
+/** The canonical project URL the attribution links to. */
+export const AX_URL = "https://github.com/Necmttn/ax";
+
+/** One-line plain-text attribution (for contexts where markdown links render literally). */
+export const AX_ATTRIBUTION_TEXT = `Generated with ax - ${AX_URL}`;
+
+/** Markdown attribution line: "_Generated with [ax](url)._" */
+export const AX_ATTRIBUTION_MD = `_Generated with [ax](${AX_URL})._`;
+
+/**
+ * Append the markdown attribution footer to a generated document.
+ *
+ * Idempotent: a body that already ends with the attribution is returned
+ * unchanged, so re-rendering / double-application never stacks footers. The
+ * footer is a `---` rule then the attribution line, with the body's trailing
+ * whitespace normalized to a single newline before it.
+ */
+export const withAxAttribution = (body: string): string => {
+    const trimmed = body.replace(/\s+$/, "");
+    if (trimmed.endsWith(AX_ATTRIBUTION_MD)) return `${trimmed}\n`;
+    return `${trimmed}\n\n---\n\n${AX_ATTRIBUTION_MD}\n`;
+};


### PR DESCRIPTION
## What

Adds a shared marketing attribution seam (`@ax/lib/shared/attribution`) and applies the **Generated with ax** plug to the markdown artifacts ax generates for the user to share onward.

## Why

Shareable artifacts that leave the machine should carry a plug back to the project - marketing reach. There was no single source for the wording, and the directly-posted markdown surfaces (dojo report, staged upstream issue drafts) had no attribution at all.

## Changes

- **`@ax/lib/shared/attribution`** - one source of truth: `withAxAttribution(md)` (idempotent footer), `AX_ATTRIBUTION_TEXT`, `AX_ATTRIBUTION_MD`, `AX_URL`. Always on by design (no opt-out). Named distinctly from `watermark.ts` (the ingest idempotency fingerprint - same English word, unrelated concept).
- **`ax dojo report`** - footer appended to the morning report.
- **`ax dojo draft`** - footer appended to the body so it travels into the posted upstream issue/PR.
- **`CLAUDE.md`** - agent rule: plug shareable artifacts (gists, posts, reports) reusing the shared seam; never plug internal `.ax/tasks` briefs.

## Scope

Shareable-only, decided with the maintainer. The JSON share/profile gists already carry `ax_version` + the studio "recorded with ax" viewer footer, so internal agent-only artifacts (classify/improve briefs, scaffolds) deliberately stay clean.

## Tests

- New `attribution.test.ts` (constants, footer shape, whitespace normalization, idempotency).
- `report.test.ts` / `outbox.test.ts` assert the footer is present + travels into the written draft file.
- `bun test` on the three files: 13 pass / 0 fail. `tsc --noEmit` on `@ax/lib` + `axctl`: zero `error TS`.

## Follow-up

The `/u/<login>` profile **site** page could surface a visible "generated with ax" line (the gist JSON carries attribution but the rendered page doesn't yet) - separate site change, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)