### PR TITLE
fix(sessions): SurrealDB 3.1.2 ORDER BY idiom parse error (#540)

### DIFF
--- a/apps/axctl/src/dashboard/sessions-query.test.ts
+++ b/apps/axctl/src/dashboard/sessions-query.test.ts
@@ -111,6 +111,12 @@ describe("listSessionsHere", () => {
         expect(enrich).toContain("AND role = 'user'");
         expect(enrich).toContain("LIMIT 1");
         expect(enrich).not.toContain("session IN");
+        // Regression #540: SurrealDB >=3.1.2 rejects `SELECT VALUE x ... ORDER BY seq`
+        // ("Missing order idiom `seq` in statement selection") because the order
+        // idiom is absent from the projection. The first-user-message subquery must
+        // therefore select `seq` and pluck the field rather than use SELECT VALUE.
+        expect(enrich).not.toMatch(/SELECT\s+VALUE\b[^)]*ORDER BY seq/);
+        expect(enrich).toMatch(/SELECT text_excerpt, seq FROM turn[^)]*ORDER BY seq/);
     });
 
     test("orders by started_at DESC", async () => {

--- a/apps/axctl/src/dashboard/sessions-query.ts
+++ b/apps/axctl/src/dashboard/sessions-query.ts
@@ -103,7 +103,7 @@ const enrichSessions = (
                     >(
                         `SELECT
                             (SELECT count() FROM turn WHERE session = ${lit} GROUP ALL)[0].count AS turn_count,
-                            (SELECT VALUE text_excerpt FROM turn WHERE session = ${lit} AND role = 'user' ORDER BY seq ASC LIMIT 1)[0] AS first_user_message
+                            (SELECT text_excerpt, seq FROM turn WHERE session = ${lit} AND role = 'user' ORDER BY seq ASC LIMIT 1)[0].text_excerpt AS first_user_message
                          FROM ONLY ${lit};`,
                     );
                     const enriched = result?.[0] ?? null;

--- a/apps/axctl/src/dojo/skill-spar.test.ts
+++ b/apps/axctl/src/dojo/skill-spar.test.ts
@@ -485,7 +485,7 @@ describe("resolveSkillSparTask", () => {
                     [{ id: "session:s1", source: "claude" }],
                 ],
                 // turn text_excerpt for the picked session
-                "text_excerpt FROM turn WHERE session": [["Fix the bug"]],
+                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Fix the bug" }]],
             },
         });
 
@@ -517,7 +517,7 @@ describe("resolveSkillSparTask", () => {
                 "source FROM": [
                     [{ id: "session:s2", source: "claude" }],
                 ],
-                "text_excerpt FROM turn WHERE session": [["Do the loaded task"]],
+                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Do the loaded task" }]],
             },
         });
 
@@ -547,7 +547,7 @@ describe("resolveSkillSparTask", () => {
                         { id: "session:s2", source: "claude" },
                     ],
                 ],
-                "text_excerpt FROM turn WHERE session": [["Newer task"]],
+                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Newer task" }]],
             },
         });
 
@@ -618,7 +618,7 @@ describe("resolveSkillSparTask", () => {
                     [{ id: "session:s42" }],
                 ],
                 // Turn text_excerpt for the explicit session
-                "text_excerpt FROM turn WHERE session": [["Custom task"]],
+                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Custom task" }]],
             },
         });
 
@@ -647,7 +647,7 @@ describe("resolveSkillSparTask", () => {
                 "source FROM": [
                     [{ id: "session:s1", source: "claude" }],
                 ],
-                "text_excerpt FROM turn WHERE session": [["Task text"]],
+                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Task text" }]],
             },
         });
 
@@ -685,7 +685,7 @@ describe("resolveSkillSparTask", () => {
                 "source FROM": [
                     [{ id: "session:s1", source: "claude" }],
                 ],
-                "text_excerpt FROM turn WHERE session": [["HEAD task"]],
+                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "HEAD task" }]],
             },
         });
 
@@ -751,7 +751,7 @@ describe("resolveSkillSparTask", () => {
                         { id: "session:s2", source: "claude" },
                     ],
                 ],
-                "text_excerpt FROM turn WHERE session": [["Winner via loaded ts"]],
+                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Winner via loaded ts" }]],
             },
         });
 
@@ -777,7 +777,7 @@ describe("resolveSkillSparTask", () => {
                 "source FROM": [
                     [{ id: "session:s1", source: "claude" }],
                 ],
-                "text_excerpt FROM turn WHERE session": [["Repo task"]],
+                "text_excerpt, seq FROM turn WHERE session": [[{ text_excerpt: "Repo task" }]],
             },
         });
 
@@ -834,7 +834,7 @@ describe("resolveSkillSparTask", () => {
                     [{ id: "session:s1", source: "claude" }],
                 ],
                 // turn query returns empty: no user turns in this session
-                "text_excerpt FROM turn WHERE session": [[]],
+                "text_excerpt, seq FROM turn WHERE session": [[]],
             },
         });
 
@@ -855,7 +855,7 @@ describe("resolveSkillSparTask", () => {
                     [{ id: "session:s42" }],
                 ],
                 // turn query returns empty
-                "text_excerpt FROM turn WHERE session": [[]],
+                "text_excerpt, seq FROM turn WHERE session": [[]],
             },
         });
 

--- a/apps/axctl/src/dojo/skill-spar.ts
+++ b/apps/axctl/src/dojo/skill-spar.ts
@@ -392,10 +392,10 @@ export const resolveSkillSparTask = (
             baselineSession = sess.id;
 
             // Derive first user turn text_excerpt (the canonical first-message field).
-            const promptRows = yield* db.query<[Array<string | null>]>(
-                `SELECT VALUE text_excerpt FROM turn WHERE session = ${recordLiteral("session", key)} AND role = 'user' ORDER BY seq ASC LIMIT 1;`,
+            const promptRows = yield* db.query<[Array<{ text_excerpt: string | null }>]>(
+                `SELECT text_excerpt, seq FROM turn WHERE session = ${recordLiteral("session", key)} AND role = 'user' ORDER BY seq ASC LIMIT 1;`,
             );
-            const promptText = promptRows?.[0]?.[0] ?? null;
+            const promptText = promptRows?.[0]?.[0]?.text_excerpt ?? null;
             if (!promptText) {
                 return yield* Effect.fail(
                     new SparCaptureError(
@@ -476,10 +476,10 @@ export const resolveSkillSparTask = (
 
             // Derive the task text from the first user turn in the chosen session.
             const bestKey = recordKeyPart(best!.id, "session") ?? best!.id;
-            const promptRows = yield* db.query<[Array<string | null>]>(
-                `SELECT VALUE text_excerpt FROM turn WHERE session = ${recordLiteral("session", bestKey)} AND role = 'user' ORDER BY seq ASC LIMIT 1;`,
+            const promptRows = yield* db.query<[Array<{ text_excerpt: string | null }>]>(
+                `SELECT text_excerpt, seq FROM turn WHERE session = ${recordLiteral("session", bestKey)} AND role = 'user' ORDER BY seq ASC LIMIT 1;`,
             );
-            const promptText = promptRows?.[0]?.[0] ?? null;
+            const promptText = promptRows?.[0]?.[0]?.text_excerpt ?? null;
             if (!promptText) {
                 return yield* Effect.fail(
                     new SparCaptureError(


### PR DESCRIPTION
Fixes the SQL parse error from #540 (item 2).

## Root cause

SurrealDB **>=3.1.2** tightened `ORDER BY` validation: a subquery of the form

```sql
(SELECT VALUE text_excerpt FROM turn WHERE ... ORDER BY seq ASC LIMIT 1)
```

is now rejected with:

```
Parse error: Missing order idiom `seq` in statement selection
```

because the order idiom (`seq`) is absent from the projection. On <=3.1.0 this parses fine, which is why it slipped through. The reporter hit it on SurrealDB 3.1.2 — it breaks **`ax sessions here`** and **`ax sessions around`** (and the same shape in the two dojo skill-spar first-user-turn lookups).

## Fix

Select `seq` into the projection and pluck the field instead of `SELECT VALUE`:

```sql
(SELECT text_excerpt, seq FROM turn WHERE ... ORDER BY seq ASC LIMIT 1)[0].text_excerpt
```

Same value, version-robust shape. Applied to:
- `apps/axctl/src/dashboard/sessions-query.ts` (the `sessions here`/`around` enrichment)
- `apps/axctl/src/dojo/skill-spar.ts` (×2 first-user-turn lookups)

Guard test in `sessions-query.test.ts` asserts the enrichment SQL no longer emits the rejected `SELECT VALUE ... ORDER BY seq` shape.

## Verification

- `bun test sessions-query.test.ts skill-spar.test.ts` → 103 pass
- `bunx tsc -p apps/axctl/tsconfig.json --noEmit` → exit 0
- Confirmed the new subquery shape returns the correct value against a live SurrealDB.

## Not in this PR

Issue #540 bundles 4 other observations; this PR only closes the SQL-parse regression. Triage of the rest (recommend splitting):
- **friction 1970 timestamps** — stale derivation: the `friction_event` rows predate a Codex-parser fix that added `ts` to `exec_command` tool_calls; the underlying `tool_call` rows now carry real `ts` but the friction events were never re-derived (stable UPSERT key). Needs a re-derivation/backfill, not a query fix.
- **profile show hang** — not reproduced locally (profile queries return <0.5s on a 140k-edge graph); needs the reporter's data to pin which query stalls.
- **cost routability \$0 on Codex** — currently Claude-main-agent-only by design; a scope note would help.
- **skills weighted empty vs wrapped distinctSkills:50** — scope/filter mismatch to clarify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)