### PR TITLE
feat(site): click-toggle disclosure for profile highlight cards

### DIFF
--- a/apps/site/app/components/profile-dossier.tsx
+++ b/apps/site/app/components/profile-dossier.tsx
@@ -119,16 +119,24 @@ export function HighlightsBlocks({ highlights }: { highlights?: ProfileHighlight
                     <div className="pf-weapons-grid">
                         {highlights.setup.map((s, i) => {
                             const href = s.link ? safeHttpUrl(s.link) : null;
+                            // headline (title) + 2-3 sentence summary (what) stay visible;
+                            // the rationale (why) + source link reveal on click (native <details>).
                             return (
-                                <div className="pf-weapon" key={`${s.title}-${i}`}>
-                                    <div className="pf-weapon-title">
-                                        {href
-                                            ? <a href={href} target="_blank" rel="noopener nofollow">{s.title} ↗</a>
-                                            : s.title}
+                                <details className="pf-weapon" key={`${s.title}-${i}`}>
+                                    <summary className="pf-weapon-summary">
+                                        <span className="pf-weapon-title">{s.title}</span>
+                                        <p className="pf-weapon-what">{s.what}</p>
+                                        <span className="pf-toggle" aria-hidden="true" />
+                                    </summary>
+                                    <div className="pf-weapon-detail">
+                                        <p className="pf-weapon-why">{s.why}</p>
+                                        {href && (
+                                            <a className="pf-weapon-link" href={href} target="_blank" rel="noopener nofollow">
+                                                source ↗
+                                            </a>
+                                        )}
                                     </div>
-                                    <p className="pf-weapon-what">{s.what}</p>
-                                    <p className="pf-weapon-why">{s.why}</p>
-                                </div>
+                                </details>
                             );
                         })}
                     </div>
@@ -138,12 +146,16 @@ export function HighlightsBlocks({ highlights }: { highlights?: ProfileHighlight
             {highlights.skills && highlights.skills.length > 0 && (
                 <div className="pf-learn">
                     <h3>Learn the rig</h3>
+                    {/* headline (name + source) stays visible; the summary reveals on click. */}
                     {highlights.skills.map((s, i) => (
-                        <div className="pf-learn-row" key={`${s.name}-${i}`}>
-                            <span className="pf-learn-name">{s.name}</span>
-                            <span className="pf-learn-src">{s.source}</span>
-                            <span className="pf-learn-sum">{s.summary}</span>
-                        </div>
+                        <details className="pf-learn-row" key={`${s.name}-${i}`}>
+                            <summary className="pf-learn-summary">
+                                <span className="pf-learn-name">{s.name}</span>
+                                <span className="pf-learn-src">{s.source}</span>
+                                <span className="pf-toggle" aria-hidden="true" />
+                            </summary>
+                            <p className="pf-learn-sum">{s.summary}</p>
+                        </details>
                     ))}
                 </div>
             )}

--- a/apps/site/app/components/profile-highlights.test.tsx
+++ b/apps/site/app/components/profile-highlights.test.tsx
@@ -21,4 +21,13 @@ describe("dossier renders highlights inside the Taste section", () => {
         expect(src).toContain("https");        // scheme check present
         expect(src).toContain("noopener");
     });
+    test("weapons + skills use native <details> click-toggle for the detail", () => {
+        // headline + summary in <summary>, detail revealed on toggle.
+        expect(src).toMatch(/<details className="pf-weapon"/);
+        expect(src).toMatch(/<summary className="pf-weapon-summary"/);
+        expect(src).toContain("pf-weapon-detail");      // the revealed area
+        expect(src).toMatch(/<details className="pf-learn-row"/);
+        expect(src).toMatch(/<summary className="pf-learn-summary"/);
+        expect(src).toContain("pf-toggle");             // disclosure chevron
+    });
 });

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -12529,18 +12529,28 @@ footer.site-footer { padding: 48px 32px 56px; }
 .pf-words cite { display: block; opacity: 0.6; font-size: 0.85em; }
 .pf-weapons { margin-bottom: 1.5rem; }
 .pf-weapons h3 { font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.13em; color: var(--muted); margin: 0 0 0.75rem; }
-.pf-weapons-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; }
-.pf-weapon { padding: 1rem; border: 1px solid var(--line, rgba(127,127,127,0.3)); border-radius: 6px; }
+.pf-weapons-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; align-items: start; }
+.pf-weapon { border: 1px solid var(--line, rgba(127,127,127,0.3)); border-radius: 6px; }
+.pf-weapon-summary { list-style: none; cursor: pointer; padding: 1rem 1.9rem 1rem 1rem; position: relative; }
+.pf-weapon-summary::-webkit-details-marker { display: none; }
 .pf-weapon-title { font-weight: 600; margin-bottom: 0.25rem; }
-.pf-weapon-title a { color: inherit; }
-.pf-weapon-what { margin: 0 0 0.25rem; font-size: 0.9em; }
+.pf-weapon-what { margin: 0; font-size: 0.9em; }
+.pf-weapon-detail { padding: 0 1rem 1rem; }
 .pf-weapon-why { margin: 0; opacity: 0.7; font-size: 0.9em; }
+.pf-weapon-link { display: inline-block; margin-top: 0.45rem; font-family: var(--mono); font-size: 0.76em; opacity: 0.7; color: inherit; }
 .pf-learn { margin-bottom: 1.5rem; }
 .pf-learn h3 { font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.13em; color: var(--muted); margin: 0 0 0.5rem; }
-.pf-learn-row { display: flex; gap: 0.75rem; align-items: baseline; padding: 0.25rem 0; border-bottom: 1px solid var(--line, rgba(127,127,127,0.15)); }
+.pf-learn-row { border-bottom: 1px solid var(--line, rgba(127,127,127,0.15)); }
+.pf-learn-summary { list-style: none; cursor: pointer; display: flex; gap: 0.75rem; align-items: baseline; padding: 0.4rem 1.5rem 0.4rem 0; position: relative; }
+.pf-learn-summary::-webkit-details-marker { display: none; }
 .pf-learn-name { font-family: var(--mono); font-size: 13px; }
 .pf-learn-src { opacity: 0.5; font-size: 0.8em; }
-.pf-learn-sum { font-size: 0.88em; }
+.pf-learn-sum { font-size: 0.88em; margin: 0 0 0.5rem; opacity: 0.82; }
+/* shared disclosure chevron: points down, flips up when the <details> is open */
+.pf-toggle { position: absolute; top: 1.05rem; right: 0.9rem; width: 7px; height: 7px; border-right: 1.5px solid var(--muted); border-bottom: 1.5px solid var(--muted); transform: rotate(45deg); transition: transform 0.15s ease; opacity: 0.55; }
+.pf-learn-summary .pf-toggle { top: 0.55rem; right: 0.2rem; }
+summary:hover .pf-toggle { opacity: 0.95; }
+details[open] > summary .pf-toggle { transform: rotate(-135deg); }
 .pf-wins { margin-bottom: 1.5rem; }
 .pf-wins h3 { font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.13em; color: var(--muted); margin: 0 0 0.5rem; }
 .pf-win { display: flex; justify-content: space-between; gap: 1rem; padding: 0.2rem 0; }


### PR DESCRIPTION
## What
The user-authored highlight cards (Secret weapons + Learn the rig) were a wall of text. This collapses each into a native `<details>` disclosure:

- **Secret weapon**: title (headline) + `what` (2-3 sentence summary) stay visible; `why` rationale + source link reveal on click.
- **Skill**: name + source stay visible; the summary reveals on click.

Native `<details>/<summary>` → accessible, keyboard + touch friendly, no JS state, chevron flips on open. `HighlightsBlocks` is shared, so `/u/<login>` and the `/u/<a>/vs/<b>` duel page both get it.

Dark-shell CSS tokens only (`--line`/`--muted`), no hardcoded colors.

Follow-up to #539.

## Verify
- Source-grep test updated to assert the `<details>` structure (4/0 pass).
- apps/site typecheck clean on touched files.
- Full local suite blocked by a worktree node_modules resolution gap (`@effect/platform-bun` unresolved across 116 unrelated files) — CI runs a clean install; relying on CI verify + Cloudflare Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)