### PR TITLE
fix(wrapped): exclude synthetic Codex tools from skill counts (#540)

### DIFF
--- a/apps/axctl/src/queries/wrapped.test.ts
+++ b/apps/axctl/src/queries/wrapped.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
     WRAPPED_DAILY_ACTIVITY_SQL,
+    WRAPPED_SKILLS_SQL,
     WRAPPED_SPAWNED_SQL,
     WRAPPED_TOKEN_USAGE_SQL,
     WRAPPED_USAGE_SQL,
@@ -28,5 +29,11 @@ describe("wrapped queries", () => {
         expect(WRAPPED_TOKEN_USAGE_SQL).toContain("FROM session_token_usage");
         expect(WRAPPED_TOKEN_USAGE_SQL).toContain("math::sum(estimated_tokens)");
         expect(WRAPPED_TOKEN_USAGE_SQL).toContain("GROUP ALL");
+    });
+
+    test("skills query excludes synthetic Codex builtin tools", () => {
+        expect(WRAPPED_SKILLS_SQL).toContain("FROM invoked");
+        expect(WRAPPED_SKILLS_SQL).toContain("out.name IS NOT NONE");
+        expect(WRAPPED_SKILLS_SQL).toContain('out.dir_path != "(synthetic)"');
     });
 });

--- a/apps/axctl/src/queries/wrapped.ts
+++ b/apps/axctl/src/queries/wrapped.ts
@@ -56,6 +56,7 @@ SELECT out.name AS skill, count() AS count
 FROM invoked
 WHERE ts > time::now() - ${DAYS}d
   AND out.name IS NOT NONE
+  AND out.dir_path != "(synthetic)"
 GROUP BY skill
 ORDER BY count DESC
 LIMIT 50;`;


### PR DESCRIPTION
Fixes item 5 of #540.

## Symptom
For Codex-heavy users, `ax wrapped` / `/api/wrapped` reported `distinctSkills: 50` with a top skill of `codex:exec_command`, while `ax skills weighted` correctly reported "(no skill invocations found)".

## Root cause
Codex builtin tools (`exec_command`, `write_stdin`, `apply_patch`, `update_plan`, …) are stored as **synthetic `skill` records** (`dir_path = "(synthetic)"`, `scope = "codex-tool"`) and recorded as `invoked` edges. `WRAPPED_SKILLS_SQL` counted every `invoked` `out.name` as a "skill" with no synthetic filter, so a Codex-only graph filled all 50 slots with tools. `ax skills weighted` already excludes synthetics (`includeTools: false`), which is why the two views disagreed — `skills weighted` was right.

## Fix
Add `AND out.dir_path != "(synthetic)"` to `WRAPPED_SKILLS_SQL` (`apps/axctl/src/queries/wrapped.ts`). This aligns wrapped's `distinctSkills`/`topSkill`/"Skill Stacker" facts with the real-skill definition used elsewhere (same filter already used in `derive-loaded-skills.ts`). Downstream consumers in `dashboard/wrapped.ts` are unchanged — they receive the filtered rows. `ax skills weighted` is untouched.

## Verification
- `bun test apps/axctl/src/queries/wrapped.test.ts apps/axctl/src/dashboard/wrapped.test.ts` → pass; added a test asserting the exclusion clause (fails without the fix).
- `bunx tsc -p apps/axctl/tsconfig.json --noEmit` → exit 0.
- Reviewed: schema declares `dir_path` as non-optional `string`, and the pre-existing `out.name IS NOT NONE` already drops dangling edges, so no real skill is wrongly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)