### PR TITLE
fix(profile): replace turn-table scans + timeout/diagnostics in profile show (#540)

### DIFF
--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -271,7 +271,17 @@ const profileShowCommand = Command.make(
                 windowDays: window,
                 includeCost: !noCost,
                 env,
-            });
+            }).pipe(
+                Effect.timeout("40 seconds"),
+                Effect.catchTag("TimeoutError", () =>
+                    Effect.sync(() =>
+                        fail(
+                            `ax profile show timed out (>40s) - your graph may be very large (Codex-heavy). ` +
+                            `Try a smaller window: ax profile show --window=7`,
+                        ),
+                    ),
+                ),
+            );
             yield* progress("done");
             console.log(json ? prettyPrint(profile) : formatProfile(profile));
         });

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -13,6 +13,7 @@ import {
     fetchSpawnedCount,
     fetchTokenTotals,
     fetchTopTools,
+    fetchWindowedInvocations,
     fetchWrappedCounts,
 } from "./queries.ts";
 
@@ -33,11 +34,14 @@ describe("fetchTokenTotals", () => {
 });
 
 describe("fetchDailyActivity", () => {
-    test("returns day keys", async () => {
+    test("returns day keys from session table (not turn)", async () => {
         const db = makeMockDb([[[{ date: "2026-06-11" }, { date: "2026-06-12" }]]]);
         const r = await runWithMock(db, fetchDailyActivity({ windowDays: 30 }));
         expect(r).toEqual(["2026-06-11", "2026-06-12"]);
-        expect(db.captured[0]).toContain('time::format(ts, "%Y-%m-%d")');
+        // Fix 1a: must use session.started_at (fast) not turn.ts (full-scan)
+        expect(db.captured[0]).toContain('time::format(started_at, "%Y-%m-%d")');
+        expect(db.captured[0]).toContain("FROM session");
+        expect(db.captured[0]).not.toContain("FROM turn");
     });
 });
 
@@ -102,7 +106,10 @@ describe("fetchDailyActivityFull", () => {
         expect(r[0]).toEqual({ date: "2026-06-11", sessions: 5, tokens: 100_000 });
         expect(r[1]).toEqual({ date: "2026-06-12", sessions: 3, tokens: 80_000 });
         expect(db.captured[0]).toContain("time::now() - 30d");
-        expect(db.captured[0]).toContain("array::len(array::distinct(session))");
+        // Fix 1b: must use session table (fast) not turn table full-scan
+        expect(db.captured[0]).toContain("FROM session");
+        expect(db.captured[0]).toContain("count() AS sessions");
+        expect(db.captured[0]).not.toContain("array::len(array::distinct(session))");
     });
 
     test("day with no tokens entry gets tokens=0", async () => {
@@ -290,5 +297,30 @@ describe("fetchWrappedCounts", () => {
         expect(r.verification_calls).toBe(500);
         expect(r.context_calls).toBe(300);
         expect(r.tool_calls).toBe(1000);
+    });
+});
+
+describe("fetchWindowedInvocations", () => {
+    test("uses denormalized session field (not in.session deref) and filters NONE rows", async () => {
+        const db = makeMockDb([[[
+            { session: "session:1", skill: "tdd", ts: "2026-06-12T10:00:00Z" },
+            // pre-denormalization edge: session = NONE (stringified to "NONE")
+            { session: "NONE", skill: "tdd", ts: "2026-06-12T11:00:00Z" },
+            // null session (js null)
+            { session: null, skill: "ship", ts: "2026-06-12T12:00:00Z" },
+        ]]]);
+        const r = await runWithMock(db, fetchWindowedInvocations({ windowDays: 30 }));
+        // Fix 2: SQL must read the denormalized `session` field, not `in.session`
+        expect(db.captured[0]).toContain("type::string(session) AS session");
+        expect(db.captured[0]).not.toContain("in.session");
+        // Fix 2: NONE and null rows are filtered out in JS
+        expect(r).toHaveLength(1);
+        expect(r[0]).toEqual({ session: "session:1", skill: "tdd", ts: "2026-06-12T10:00:00Z" });
+    });
+
+    test("empty invocations -> empty array", async () => {
+        const db = makeMockDb([[[]]]);
+        const r = await runWithMock(db, fetchWindowedInvocations({ windowDays: 7 }));
+        expect(r).toHaveLength(0);
     });
 });

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -15,6 +15,32 @@ import { isContextTool, isVerificationTool } from "./tool-taxonomy.ts";
 
 const win = (d: number) => `${Math.max(1, Math.trunc(d))}d`;
 
+// ---------------------------------------------------------------------------
+// Per-query slow-query diagnostics
+// ---------------------------------------------------------------------------
+// Wraps a DB query effect to log a warning when the query exceeds SLOW_QUERY_MS.
+// Non-invasive: the warning is best-effort (logWarning is fire-and-forget) and
+// the result is unchanged.
+
+const SLOW_QUERY_MS = 500;
+
+function timedQuery<A, E, R>(
+    label: string,
+    queryEffect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+    return Effect.gen(function* () {
+        const start = Date.now();
+        const result = yield* queryEffect;
+        const elapsed = Date.now() - start;
+        if (elapsed > SLOW_QUERY_MS) {
+            yield* Effect.logWarning(
+                `[profile] slow query "${label}" took ${elapsed}ms (>${SLOW_QUERY_MS}ms threshold)`,
+            );
+        }
+        return result;
+    });
+}
+
 // --- token totals -----------------------------------------------------------
 
 export interface TokenTotals {
@@ -35,9 +61,11 @@ GROUP ALL;`;
 export const fetchTokenTotals = Effect.fn("profile.fetchTokenTotals")(
     function* (opts: { readonly windowDays: number }) {
         const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(TOKEN_TOTALS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const rows = yield* timedQuery(
+            "tokenTotals",
+            db.query<[Array<Record<string, unknown>>]>(TOKEN_TOTALS_SQL(opts.windowDays))
+                .pipe(Effect.map((r) => r?.[0] ?? [])),
+        );
         const row = rows[0] ?? {};
         return {
             prompt_tokens: Number(row.prompt_tokens ?? 0),
@@ -48,20 +76,24 @@ export const fetchTokenTotals = Effect.fn("profile.fetchTokenTotals")(
 );
 
 // --- daily activity (streak input) -----------------------------------------
+// Session-based scan: ~18ms vs ~3s on the turn table (150× faster for Codex
+// users who accumulate millions of turn rows). The streak only needs distinct
+// active days, and session.started_at is indexed.
 
 const DAILY_ACTIVITY_SQL = (d: number) => `
-SELECT time::format(ts, "%Y-%m-%d") AS date
-FROM turn
-WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
-GROUP BY date
-ORDER BY date ASC;`;
+SELECT time::format(started_at, "%Y-%m-%d") AS date
+FROM session
+WHERE started_at > time::now() - ${win(d)} AND started_at IS NOT NONE
+GROUP BY date ORDER BY date ASC;`;
 
 export const fetchDailyActivity = Effect.fn("profile.fetchDailyActivity")(
     function* (opts: { readonly windowDays: number }) {
         const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(DAILY_ACTIVITY_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const rows = yield* timedQuery(
+            "dailyActivity",
+            db.query<[Array<Record<string, unknown>>]>(DAILY_ACTIVITY_SQL(opts.windowDays))
+                .pipe(Effect.map((r) => r?.[0] ?? [])),
+        );
         return rows
             .map((r) => String(r.date))
             .filter((d) => d !== "undefined" && d !== "null");
@@ -175,14 +207,15 @@ export interface DailyActivityRow {
     readonly tokens: number;
 }
 
+// Session-based: count() per day from the session table - avoids the full
+// turn-table scan (array::distinct(session) over millions of Codex turns = 3s+).
 const DAILY_SESSIONS_SQL = (d: number) => `
 SELECT
-    time::format(ts, "%Y-%m-%d") AS date,
-    array::len(array::distinct(session)) AS sessions
-FROM turn
-WHERE ts > time::now() - ${win(d)} AND ts IS NOT NONE
-GROUP BY date
-ORDER BY date ASC;`;
+    time::format(started_at, "%Y-%m-%d") AS date,
+    count() AS sessions
+FROM session
+WHERE started_at > time::now() - ${win(d)} AND started_at IS NOT NONE
+GROUP BY date ORDER BY date ASC;`;
 
 const DAILY_TOKENS_SQL = (d: number) => `
 SELECT
@@ -196,12 +229,16 @@ ORDER BY date ASC;`;
 export const fetchDailyActivityFull = Effect.fn("profile.fetchDailyActivityFull")(
     function* (opts: { readonly windowDays: number }) {
         const db = yield* SurrealClient;
-        const sessionRows = yield* db
-            .query<[Array<Record<string, unknown>>]>(DAILY_SESSIONS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
-        const tokenRows = yield* db
-            .query<[Array<Record<string, unknown>>]>(DAILY_TOKENS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const sessionRows = yield* timedQuery(
+            "dailySessions",
+            db.query<[Array<Record<string, unknown>>]>(DAILY_SESSIONS_SQL(opts.windowDays))
+                .pipe(Effect.map((r) => r?.[0] ?? [])),
+        );
+        const tokenRows = yield* timedQuery(
+            "dailyTokens",
+            db.query<[Array<Record<string, unknown>>]>(DAILY_TOKENS_SQL(opts.windowDays))
+                .pipe(Effect.map((r) => r?.[0] ?? [])),
+        );
         // Join tokens onto session rows in JS (two grouped queries; SurrealDB
         // 3.x grouped aggregates stay deref-free per the hang rule).
         const tokenMap = new Map(
@@ -661,9 +698,13 @@ export interface WindowedInvocationRow {
     readonly ts: string;
 }
 
+// Reads the denormalized `session` field on the invoked edge rather than the
+// deref `in.session` - avoids a per-row SurrealDB record lookup (~3–4× faster
+// on the maintainer's 64k-invocation graph). Pre-denormalization edges stored
+// session = NONE; the JS filter below excludes them ("NONE" guard).
 const WINDOWED_INVOCATIONS_SQL = (d: number) => `
 SELECT
-    type::string(in.session) AS session,
+    type::string(session) AS session,
     out.name AS skill,
     type::string(ts) AS ts
 FROM invoked
@@ -672,11 +713,17 @@ WHERE ts > time::now() - ${win(d)};`;
 export const fetchWindowedInvocations = Effect.fn("profile.fetchWindowedInvocations")(
     function* (opts: { readonly windowDays: number }) {
         const db = yield* SurrealClient;
-        const rows = yield* db
-            .query<[Array<Record<string, unknown>>]>(WINDOWED_INVOCATIONS_SQL(opts.windowDays))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const rows = yield* timedQuery(
+            "windowedInvocations",
+            db.query<[Array<Record<string, unknown>>]>(WINDOWED_INVOCATIONS_SQL(opts.windowDays))
+                .pipe(Effect.map((r) => r?.[0] ?? [])),
+        );
         return rows
-            .filter((r) => r.session != null && r.skill != null && r.session !== "null" && r.skill !== "null")
+            .filter((r) =>
+                r.session != null && r.skill != null
+                && r.session !== "null" && r.skill !== "null"
+                && r.session !== "NONE" // pre-denormalization edges stored session = NONE
+            )
             .map((r) => ({
                 session: String(r.session),
                 skill: String(r.skill),


### PR DESCRIPTION
Fixes item 1 of #540: `ax profile show` hung >45s with no output for Codex-heavy users.

## Root cause
`buildProfile` runs ~27 DB queries **sequentially**. Three are full-`turn`-table scans (`DAILY_ACTIVITY_SQL`, `DAILY_SESSIONS_SQL`, plus the turn-count). On the maintainer's 695k-turn DB each takes ~3s; on a Codex-heavy multi-million-turn graph (~10× turn inflation) each takes ~30s, so the *first* query alone blows the 45s budget. Progress is silent on non-TTY, so the user saw nothing.

## Fixes (this PR)
- **Fix 1 — kill the turn-table scans.** `DAILY_ACTIVITY_SQL` (feeds the streak — a list of unique active dates) and `DAILY_SESSIONS_SQL` (daily session counts) now query the small, indexed `session` table grouped by `started_at` instead of scanning `turn`. Live-DB: **2.98s → 18ms** and **2.71s → 16ms** (~165×).
- **Fix 2 — drop a redundant deref.** `WINDOWED_INVOCATIONS_SQL` used `type::string(in.session)` (walk invoked→turn→session) when the `invoked` edge already stores a denormalized `session` field. Switched to `type::string(session)` (**1.23s → 358ms**) and added a `"NONE"` guard for legacy pre-denormalization edges.
- **Fix 4 — make slowness observable** (the reporter's expected behavior). A 40s overall timeout around `buildProfile` now fails with a clear message (`…try a smaller window: ax profile show --window=7`) instead of hanging silently, and a per-query timing wrapper warns when any single query exceeds ~500ms.

`buildProfile` remains **sequential** by design — running its independent queries concurrently fights the order-dependent test mock and is deferred as a follow-up.

## Known semantic change (accepted)
`DAILY_SESSIONS_SQL` previously counted *distinct sessions with a turn on a given day*; it now counts *sessions whose `started_at` falls on that day*. For days containing sessions that started the previous night, per-day counts read ~3–10% lower. This is acceptable for an indicative activity bar (trend, not ledger); the **streak is unaffected** (verified: the new `DAILY_ACTIVITY_SQL` date set matches the old one on real data).

## Verification
- Live-DB before/after timings above (each rewritten query re-run and compared for equivalent buckets).
- `bun test apps/axctl/src/profile/ apps/axctl/src/cli/commands/profile.test.ts` → 174 pass; test SQL-shape assertions updated to the new queries (+2 new `fetchWindowedInvocations` tests).
- `bunx tsc -p apps/axctl/tsconfig.json --noEmit` → exit 0. One advisory TS70 at `profile.ts:277` (Effect-LSP) is a false positive — the timeout handler's `Effect.sync` thunk returns `never` via `process.exit`, not a Promise.
- Effect tag confirmed: the timeout is caught as `TimeoutError` (correct for effect@beta 4.x; `TimeoutException` was the old-API name).

Reviewed via subagent task review (spec ✅, quality approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)