### PR TITLE
fix(lib): warn instead of silently defaulting to epoch in isoTimestamp (#540)

### DIFF
--- a/packages/lib/src/shared/surreal.test.ts
+++ b/packages/lib/src/shared/surreal.test.ts
@@ -645,6 +645,72 @@ describe("isoTimestamp", () => {
     });
 });
 
+describe("isoTimestamp - warn on epoch fallback", () => {
+    // Helper: capture and restore console.warn around a callback.
+    const withWarnSpy = (fn: (calls: unknown[][]) => void): void => {
+        const original = console.warn;
+        const calls: unknown[][] = [];
+        console.warn = (...args: unknown[]) => { calls.push(args); };
+        try {
+            fn(calls);
+        } finally {
+            console.warn = original;
+        }
+    };
+
+    it("does NOT warn for a valid Date", () => {
+        withWarnSpy((calls) => {
+            isoTimestamp(new Date("2024-01-15T10:30:00.000Z"));
+            expect(calls.length).toBe(0);
+        });
+    });
+
+    it("does NOT warn for a non-empty string", () => {
+        withWarnSpy((calls) => {
+            isoTimestamp("2024-03-01T00:00:00.000Z");
+            expect(calls.length).toBe(0);
+        });
+    });
+
+    it("does NOT warn for a SurrealDB DateTime-like object", () => {
+        withWarnSpy((calls) => {
+            const fakeDateTime = {
+                constructor: { name: "DateTime" },
+                toString() { return "2024-06-01T12:00:00.000Z"; },
+            };
+            isoTimestamp(fakeDateTime as unknown as Date);
+            expect(calls.length).toBe(0);
+        });
+    });
+
+    it("warns exactly once and returns epoch for null", () => {
+        withWarnSpy((calls) => {
+            const result = isoTimestamp(null);
+            expect(result).toBe(new Date(0).toISOString());
+            expect(calls.length).toBe(1);
+            expect(String(calls[0]![0])).toContain("[ax] isoTimestamp");
+        });
+    });
+
+    it("warns exactly once and returns epoch for undefined", () => {
+        withWarnSpy((calls) => {
+            const result = isoTimestamp(undefined);
+            expect(result).toBe(new Date(0).toISOString());
+            expect(calls.length).toBe(1);
+            expect(String(calls[0]![0])).toContain("[ax] isoTimestamp");
+        });
+    });
+
+    it("warns exactly once and returns epoch for empty string", () => {
+        withWarnSpy((calls) => {
+            const result = isoTimestamp("" as unknown as Date);
+            expect(result).toBe(new Date(0).toISOString());
+            expect(calls.length).toBe(1);
+            expect(String(calls[0]![0])).toContain("[ax] isoTimestamp");
+        });
+    });
+});
+
 describe("nonEmptyString", () => {
     it("returns the trimmed string when non-empty", () => {
         expect(nonEmptyString("  hello  ")).toBe("hello");

--- a/packages/lib/src/shared/surreal.ts
+++ b/packages/lib/src/shared/surreal.ts
@@ -589,11 +589,28 @@ export const recordKeyPart = (value: unknown, expectedTable?: string): string | 
  * 2. Non-empty string         → pass through unchanged
  * 3. SurrealDB DateTime object (`constructor.name === "DateTime"`) → `String(value)`
  * 4. Anything else (null / undefined / unknown) → epoch `new Date(0).toISOString()`
+ *    and emits a `console.warn` so silent epoch timestamps surface as data bugs
+ *    (symptom: `ax insights friction` events timestamped `1970-01-01 00:00:00`)
  */
 export const isoTimestamp = (value: TimestampInput | null | undefined): string => {
     if (value instanceof Date) return value.toISOString();
     if (typeof value === "string" && value.length > 0) return value;
     if (value && typeof value === "object" && value.constructor.name === "DateTime") return String(value);
+    const typeDesc = (() => {
+        try {
+            if (value === null) return "null";
+            if (value === undefined) return "undefined";
+            const t = typeof value;
+            const ctor =
+                value != null && typeof value === "object"
+                    ? ((value as object).constructor?.name ?? "?")
+                    : undefined;
+            return ctor ? `${t}(${ctor})` : t;
+        } catch {
+            return "unknown";
+        }
+    })();
+    console.warn("[ax] isoTimestamp: unrecognized timestamp value, defaulting to epoch:", typeDesc);
     return new Date(0).toISOString();
 };
 


### PR DESCRIPTION
Addresses item 3 of #540: `ax insights friction` showed events timestamped `1970-01-01 00:00:00`.

## Root cause
The 1175 epoch `friction_event` rows are **stale**: they were derived before a Codex-parser fix that set `ts` on `exec_command` tool_calls. The source `tool_call`/`turn` rows now all carry real timestamps (verified: a sampled epoch friction event's tool_call reads `2026-06-15`), but the friction events were never re-derived because the UPSERT key is stable and incremental ingest only revisits the `--since` window.

The fabrication point is `isoTimestamp` (`packages/lib/src/shared/surreal.ts`): on null/undefined/unrecognized input it **silently** returns `new Date(0).toISOString()`, which made the underlying data bug invisible.

## This PR
Makes the epoch fallback **observable** without changing behavior: `isoTimestamp` still returns the epoch string (no caller breaks), but now emits a single `console.warn` (`[ax] isoTimestamp: unrecognized timestamp value, defaulting to epoch: <safe type descriptor>`) first. Stringification is guarded (typeof + constructor name, try/catch) so it never throws on odd/circular objects and never dumps large payloads. Stays a plain sync utility (not converted to Effect).

## Backfill (operational, not in this PR)
The existing stale rows are fixed by a full re-derive — running `ax ingest` (no `--since`) overwrites the epoch `ts` on all friction_event rows from the now-correct source data. I'm running that on the maintainer's DB separately.

## Verification
- `bun test packages/lib/src/shared/surreal.test.ts` → 125 pass; +6 tests asserting valid Date/string/DateTime inputs do **not** warn and the epoch path warns exactly once (spied).
- `bunx tsc -p packages/lib/tsconfig.json --noEmit` → exit 0.

Reviewed via subagent task review (spec ✅, quality approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)