### PR TITLE
[codex] Add live ingest event contract schema

### DIFF
--- a/apps/axctl/src/dashboard/ingest-stream-durable.test.ts
+++ b/apps/axctl/src/dashboard/ingest-stream-durable.test.ts
@@ -14,11 +14,26 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { stream } from "@durable-streams/client";
 import {
     createDurableIngestStream,
+    encodeIngestStreamEventJson,
     type DurableIngestStream,
 } from "./ingest-stream-durable.ts";
 import type { IngestStreamEvent } from "../ingest/stream-events.ts";
 
 const E2E_ENABLED = process.env.AX_STREAM_E2E === "1";
+
+describe("encodeIngestStreamEventJson", () => {
+    test("serializes valid events with the existing JSON shape", () => {
+        expect(encodeIngestStreamEventJson({ kind: "stage_started", runId: "r", stage: "discover" })).toBe(
+            JSON.stringify({ kind: "stage_started", runId: "r", stage: "discover" }),
+        );
+    });
+
+    test("rejects invalid events before Durable Stream append", () => {
+        // Simulates a malformed runtime value crossing the TypeScript boundary.
+        const malformed = { kind: "stage_finished", runId: "r", stage: "s", status: "completed", durationMs: 1 } as unknown as IngestStreamEvent;
+        expect(() => encodeIngestStreamEventJson(malformed)).toThrow();
+    });
+});
 
 describe(
     E2E_ENABLED

--- a/apps/axctl/src/dashboard/ingest-stream-durable.ts
+++ b/apps/axctl/src/dashboard/ingest-stream-durable.ts
@@ -1,6 +1,8 @@
 import { DurableStream, DurableStreamError } from "@durable-streams/client";
-import type { IngestStreamEvent } from "../ingest/stream-events.ts";
+import { encodeIngestStreamEventJson, type IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
 import { ingestStreamName, type IngestStreamBus } from "./ingest-stream.ts";
+
+export { encodeIngestStreamEventJson };
 
 export interface DurableIngestStream extends IngestStreamBus {
     /** Base URL of the running sidecar, e.g. "http://127.0.0.1:58200". */
@@ -77,8 +79,9 @@ export async function createDurableIngestStream(
     };
 
     const publish = async (runId: string, event: IngestStreamEvent): Promise<void> => {
+        const encoded = encodeIngestStreamEventJson(event);
         const handle = await openHandle(runId);
-        await handle.append(JSON.stringify(event));
+        await handle.append(encoded);
         if (event.kind === "run_finished") {
             // EOF so dashboards stop tailing; evict so a future run with the
             // same id (shouldn't happen with uuids) re-creates cleanly.

--- a/apps/axctl/src/ingest/stream-events.test.ts
+++ b/apps/axctl/src/ingest/stream-events.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, test } from "bun:test";
+import {
+    spanEnd,
+    spanEvent,
+    spanStart,
+    traceEnd,
+    type SpanEvent,
+    type SpanStart,
+} from "@ax/lib/live-traces/types";
 import { ingestStreamEventFromTrace, type IngestStreamEvent } from "./stream-events.ts";
 
 describe("ingest stream events", () => {
     test("maps a SpanStart to a stage-started event", () => {
         const ev = ingestStreamEventFromTrace(
-            { _tag: "SpanStart", traceId: "ingest:run123", spanId: "s1", name: "skills" } as never,
+            spanStart("ingest:run123", "s1", "skills"),
             { spanNames: new Map() },
         );
         expect(ev).toEqual({ kind: "stage_started", runId: "run123", stage: "skills" } as IngestStreamEvent);
@@ -13,7 +21,7 @@ describe("ingest stream events", () => {
     test("maps a SpanEnd (ok) to a stage-finished event with status", () => {
         const names = new Map([["s1", "skills"]]);
         const ev = ingestStreamEventFromTrace(
-            { _tag: "SpanEnd", traceId: "ingest:run123", spanId: "s1", status: "ok", durationMs: 12 } as never,
+            spanEnd("ingest:run123", "s1", "ok", 12),
             { spanNames: names },
         );
         expect(ev).toEqual({ kind: "stage_finished", runId: "run123", stage: "skills", status: "ok", durationMs: 12 });
@@ -21,14 +29,14 @@ describe("ingest stream events", () => {
 
     test("maps TraceEnd to run_finished", () => {
         const ev = ingestStreamEventFromTrace(
-            { _tag: "TraceEnd", traceId: "ingest:run123", status: "completed", durationMs: 99 } as never,
+            traceEnd("ingest:run123", "completed", 99),
             { spanNames: new Map() },
         );
         expect(ev).toEqual({ kind: "run_finished", runId: "run123", status: "completed", durationMs: 99 });
     });
 
     test("returns null for unrelated events", () => {
-        expect(ingestStreamEventFromTrace({ _tag: "SpanEvent", traceId: "ingest:x", spanId: "s", name: "n" } as never, { spanNames: new Map() })).toBeNull();
+        expect(ingestStreamEventFromTrace(spanEvent("ingest:x", "s", "n"), { spanNames: new Map() })).toBeNull();
     });
 
     test("maps an attribute:ingest.fileFailures SpanEvent to stage_file_failures, keyed to the stage span", () => {
@@ -38,13 +46,7 @@ describe("ingest stream events", () => {
             failures: [{ filePath: "/p/a.jsonl", tag: "DbError", message: "boom" }],
         };
         const ev = ingestStreamEventFromTrace(
-            {
-                _tag: "SpanEvent",
-                traceId: "ingest:run123",
-                spanId: "s1",
-                name: "attribute:ingest.fileFailures",
-                attributes: { value: JSON.stringify(snapshot) },
-            } as never,
+            spanEvent("ingest:run123", "s1", "attribute:ingest.fileFailures", undefined, { value: JSON.stringify(snapshot) }),
             { spanNames: names },
         );
         expect(ev).toEqual({
@@ -67,17 +69,24 @@ describe("ingest stream events", () => {
         ];
         for (const value of cases) {
             const ev = ingestStreamEventFromTrace(
-                {
-                    _tag: "SpanEvent",
-                    traceId: "ingest:run123",
-                    spanId: "s1",
-                    name: "attribute:ingest.fileFailures",
-                    attributes: { value },
-                } as never,
+                spanEvent("ingest:run123", "s1", "attribute:ingest.fileFailures", undefined, { value }),
                 { spanNames: new Map([["s1", "claude"]]) },
             );
             expect(ev).toBeNull();
         }
+    });
+
+    test("drops fileFailures payloads whose failure entries do not match the shared schema", () => {
+        const ev = ingestStreamEventFromTrace(
+            spanEvent("ingest:run123", "s1", "attribute:ingest.fileFailures", undefined, {
+                value: JSON.stringify({
+                    total: 2,
+                    failures: [{ filePath: "/p/a.jsonl", tag: "DbError", message: 42 }],
+                }),
+            }),
+            { spanNames: new Map([["s1", "claude"]]) },
+        );
+        expect(ev).toBeNull();
     });
 
     test("emits stage_progress once current + total are both known, with rate + eta", () => {
@@ -87,19 +96,43 @@ describe("ingest stream events", () => {
             spanCounts: new Map<string, Record<string, number>>(),
             index: { started: 0 },
         };
+        const start: SpanStart = {
+            _tag: "SpanStart",
+            traceId: "ingest:r",
+            spanId: "s1",
+            name: "claude/transcripts",
+            attributes: {},
+            timestamp: 1000,
+        };
         ingestStreamEventFromTrace(
-            { _tag: "SpanStart", traceId: "ingest:r", spanId: "s1", name: "claude/transcripts", timestamp: 1000 } as never,
+            start,
             ctx,
         );
         // Total only -> not yet determinate -> null.
+        const total: SpanEvent = {
+            _tag: "SpanEvent",
+            traceId: "ingest:r",
+            spanId: "s1",
+            name: "attribute:ingest.count.totalFiles",
+            attributes: { value: 200 },
+            timestamp: 1000,
+        };
         const partial = ingestStreamEventFromTrace(
-            { _tag: "SpanEvent", traceId: "ingest:r", spanId: "s1", name: "attribute:ingest.count.totalFiles", attributes: { value: 200 }, timestamp: 1000 } as never,
+            total,
             ctx,
         );
         expect(partial).toBeNull();
         // Now current arrives 5s in -> 50/200 @ 10/s, 150 left -> 15s.
+        const current: SpanEvent = {
+            _tag: "SpanEvent",
+            traceId: "ingest:r",
+            spanId: "s1",
+            name: "attribute:ingest.count.currentFile",
+            attributes: { value: 50 },
+            timestamp: 6000,
+        };
         const ev = ingestStreamEventFromTrace(
-            { _tag: "SpanEvent", traceId: "ingest:r", spanId: "s1", name: "attribute:ingest.count.currentFile", attributes: { value: 50 }, timestamp: 6000 } as never,
+            current,
             ctx,
         );
         expect(ev).toMatchObject({ kind: "stage_progress", stage: "claude/transcripts", current: 50, total: 200, stageIndex: 1 });

--- a/apps/axctl/src/ingest/stream-events.ts
+++ b/apps/axctl/src/ingest/stream-events.ts
@@ -1,5 +1,10 @@
 import type { TraceEvent } from "@ax/lib/live-traces/types";
-import type { IngestFileFailure, IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
+import { Option } from "effect";
+import {
+    decodeIngestFileFailureSnapshotOption,
+    type IngestFileFailure,
+    type IngestStreamEvent,
+} from "@ax/lib/shared/ingest-stream-events";
 
 // Re-export so existing axctl importers (`from ".../ingest/stream-events.ts"`)
 // keep resolving the type unchanged after the contract moved to @ax/lib/shared.
@@ -51,18 +56,11 @@ const readFileFailures = (
     if (typeof raw !== "string") return null;
     try {
         const parsed: unknown = JSON.parse(raw);
-        if (typeof parsed !== "object" || parsed === null) return null;
-        const { total, failures } = parsed as { total?: unknown; failures?: unknown };
-        if (typeof total !== "number" || !Number.isFinite(total) || total <= 0) return null;
-        if (!Array.isArray(failures)) return null;
-        const details: IngestFileFailure[] = [];
-        for (const f of failures) {
-            if (typeof f !== "object" || f === null) return null;
-            const { filePath, tag, message } = f as Record<string, unknown>;
-            if (typeof filePath !== "string" || typeof tag !== "string" || typeof message !== "string") return null;
-            details.push({ filePath, tag, message });
-        }
-        return { total, failures: details };
+        const decoded = decodeIngestFileFailureSnapshotOption(parsed);
+        if (Option.isNone(decoded)) return null;
+        const snapshot = decoded.value;
+        if (!Number.isFinite(snapshot.total) || snapshot.total <= 0) return null;
+        return { total: snapshot.total, failures: [...snapshot.failures] };
     } catch {
         return null;
     }

--- a/apps/studio/src/use-ingest-stream.test.ts
+++ b/apps/studio/src/use-ingest-stream.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
-import { applyEvent, type IngestStreamState } from "./use-ingest-stream.ts";
+import { applyEvent, decodeStreamItems, type IngestStreamState } from "./use-ingest-stream.ts";
 
 const IDLE: IngestStreamState = {
     stages: {},
@@ -18,6 +18,22 @@ const failure = (filePath: string): { filePath: string; tag: string; message: st
     filePath,
     tag: "DbError",
     message: "boom",
+});
+
+describe("decodeStreamItems", () => {
+    test("returns valid ingest events and counts malformed items", () => {
+        const batch = decodeStreamItems([
+            { kind: "stage_started", runId: "r", stage: "claude" },
+            { kind: "stage_finished", runId: "r", stage: "claude", status: "completed", durationMs: 1 },
+            { kind: "run_finished", runId: "r", status: "completed", durationMs: 2 },
+        ]);
+
+        expect(batch.events).toEqual([
+            { kind: "stage_started", runId: "r", stage: "claude" },
+            { kind: "run_finished", runId: "r", status: "completed", durationMs: 2 },
+        ]);
+        expect(batch.invalidCount).toBe(1);
+    });
 });
 
 describe("applyEvent: stage_file_failures", () => {

--- a/apps/studio/src/use-ingest-stream.ts
+++ b/apps/studio/src/use-ingest-stream.ts
@@ -1,6 +1,11 @@
 import { useEffect, useReducer } from "react";
 import { stream, type StreamResponse } from "@durable-streams/client";
-import type { IngestFileFailure, IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
+import { Option } from "effect";
+import {
+    decodeIngestStreamEventOption,
+    type IngestFileFailure,
+    type IngestStreamEvent,
+} from "@ax/lib/shared/ingest-stream-events";
 
 /**
  * Live ingest view over Durable Streams.
@@ -67,6 +72,27 @@ type Action =
     | { readonly type: "reset" }
     | { readonly type: "event"; readonly event: IngestStreamEvent; readonly offset?: string }
     | { readonly type: "error"; readonly message: string };
+
+export interface DecodedStreamItems {
+    readonly events: ReadonlyArray<IngestStreamEvent>;
+    readonly invalidCount: number;
+}
+
+export function decodeStreamItems(items: ReadonlyArray<unknown>): DecodedStreamItems {
+    const events: IngestStreamEvent[] = [];
+    let invalidCount = 0;
+    for (const item of items) {
+        Option.match(decodeIngestStreamEventOption(item), {
+            onSome: (event) => {
+                events.push(event);
+            },
+            onNone: () => {
+                invalidCount += 1;
+            },
+        });
+    }
+    return { events, invalidCount };
+}
 
 /** Fold one ingest event into state. Idempotent: re-applying a finished stage
  *  (or a duplicate run_started) leaves state unchanged. Exported for tests. */
@@ -167,12 +193,12 @@ export function useIngestStream(streamUrl: string | null): IngestStreamState {
         let receivedAny = false;
         const controller = new AbortController();
         let unsubscribe: (() => void) | null = null;
-        let session: StreamResponse<IngestStreamEvent> | null = null;
+        let session: StreamResponse<unknown> | null = null;
 
         (async () => {
             try {
                 // Default offset ("-1") => replay from start, then live deltas.
-                const res = await stream<IngestStreamEvent>({
+                const res = await stream<unknown>({
                     url: streamUrl,
                     live: true,
                     signal: controller.signal,
@@ -200,7 +226,14 @@ export function useIngestStream(streamUrl: string | null): IngestStreamState {
                 unsubscribe = res.subscribeJson((batch) => {
                     if (cancelled) return;
                     if (batch.items.length > 0) receivedAny = true;
-                    for (const event of batch.items) {
+                    const decoded = decodeStreamItems(batch.items);
+                    if (decoded.invalidCount > 0) {
+                        dispatch({
+                            type: "error",
+                            message: `received ${decoded.invalidCount} invalid ingest stream event${decoded.invalidCount === 1 ? "" : "s"}`,
+                        });
+                    }
+                    for (const event of decoded.events) {
                         dispatch({ type: "event", event, offset: batch.offset });
                     }
                 });

--- a/goals/live-ingest-event-contract/facts.md
+++ b/goals/live-ingest-event-contract/facts.md
@@ -1,0 +1,21 @@
+# Live Ingest Event Contract Facts
+
+These facts are the shared understanding for the overnight goal.
+
+1. Live ingest stream payloads are runtime-validated with Effect Schema in `packages/lib/src/shared/ingest-stream-events.ts`, not only described by TypeScript interfaces.
+2. The public TypeScript names `IngestFileFailure` and `IngestStreamEvent` remain available from `@ax/lib/shared/ingest-stream-events`, and existing import sites keep working.
+3. The event discriminator stays `kind`. Do not rename the stream event union to Effect's default `_tag` shape.
+4. `stage_file_failures.failures` is validated as an array of `{ filePath: string, tag: string, message: string }`.
+5. `stage_finished.status` accepts only `"ok"` or `"error"`.
+6. `run_finished.status` accepts only `"completed"` or `"failed"`.
+7. `stage_progress.etaLeftMs` accepts a finite number or `null`.
+8. The daemon encodes or validates every `IngestStreamEvent` before appending it to Durable Streams.
+9. The studio treats Durable Stream JSON items as `unknown` until each item passes the shared decoder.
+10. A malformed stream item does not crash the studio reducer. It surfaces an error state and continues folding valid items.
+11. The trace-to-ingest translator in `apps/axctl/src/ingest/stream-events.ts` keeps the current behavior and uses the shared schema where it removes manual shape checks.
+12. The `/api/ingest` trigger response stays in `packages/lib/src/shared/api-contract.ts`; the stream transport itself stays outside `HttpApi`.
+13. The comments in `api-contract.ts` are updated to say streaming routes are outside `HttpApi`, while the live-ingest event payload is still schema-typed in `ingest-stream-events.ts`.
+14. No `@effect/rpc`, Electron, MessagePort, effect-atom, or new transport dependency is introduced.
+15. Generated or embedded artifacts under `apps/studio/dist*` and `apps/studio-desktop/resources/ax-src` are not edited.
+16. The work is verified with focused unit tests for the shared schema, the producer-side Durable Stream append path, the trace translator, and the studio stream fold path.
+17. The final gate is `bun run typecheck` plus the focused `bun test` files listed in `plan.md`. Run the full `bun test` suite if time remains.

--- a/goals/live-ingest-event-contract/goal.md
+++ b/goals/live-ingest-event-contract/goal.md
@@ -1,0 +1,19 @@
+# Live Ingest Event Contract Goal
+
+Make live ingest progress events a real shared runtime contract. Today `packages/lib/src/shared/ingest-stream-events.ts` calls itself a shared contract, but it exports TypeScript interfaces only. Promote those event shapes to Effect `Schema` definitions, validate/encode events before the daemon appends them to Durable Streams, and decode stream items in the studio before reducing them into UI state.
+
+Read `facts.md` first. Execute `plan.md` task by task. Keep the scope focused on the live-ingest event contract and tests. Do not introduce `@effect/rpc`, Electron, effect-atom, or a new transport layer.
+
+Done means:
+
+- `IngestStreamEvent` is schema-backed and still importable from `@ax/lib/shared/ingest-stream-events`.
+- The daemon validates/encodes events before Durable Stream append.
+- The studio decodes unknown stream items and handles malformed items without crashing.
+- Contract comments no longer imply live-ingest payloads are untyped.
+- Focused tests pass, and `bun run typecheck` passes.
+
+Recommended launch from this worktree:
+
+```bash
+/goal goals/live-ingest-event-contract/goal.md
+```

--- a/goals/live-ingest-event-contract/plan.md
+++ b/goals/live-ingest-event-contract/plan.md
@@ -1,0 +1,935 @@
+# Live Ingest Event Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote live ingest Durable Stream events from TypeScript-only shapes to a runtime-validated shared Effect Schema contract.
+
+**Architecture:** Keep the existing HTTP trigger and Durable Streams transport. Add a schema-backed event contract in `@ax/lib/shared`, validate on the daemon append path, and decode in the studio before reducing events. This borrows the useful idea from the Effect/Electron example, namely a single schema-defined wire payload, without adopting its Electron or `@effect/rpc` transport.
+
+**Tech Stack:** Bun, TypeScript strict mode, Effect 4 beta `Schema`, Durable Streams, React reducer state in `apps/studio`, existing `bun:test` test style.
+
+---
+
+## Current Context
+
+The current shared event file is only structural TypeScript:
+
+- `packages/lib/src/shared/ingest-stream-events.ts`
+- Imported by producer code through `apps/axctl/src/ingest/stream-events.ts`
+- Published by `apps/axctl/src/dashboard/ingest-stream-durable.ts`
+- Consumed by `apps/studio/src/use-ingest-stream.ts`
+
+The repo already has a nearby schema-union pattern:
+
+- `packages/lib/src/live-traces/Schema.ts`
+
+Do not copy that file blindly. It uses `_tag` via `Schema.TaggedStruct`; live ingest events currently use `kind`, and the UI reducer switches on `event.kind`. The live ingest contract must keep `kind`.
+
+The main doc mismatch to clean up is in:
+
+- `packages/lib/src/shared/api-contract.ts`
+
+The module comment says SSE and binary stay outside the contract because streaming/binary shapes do not fit `HttpApi`. After this work, the accurate statement is: streaming and binary routes stay outside `HttpApi`, but live-ingest stream payloads are schema-typed in `@ax/lib/shared/ingest-stream-events`.
+
+## Non-Goals
+
+- Do not add `@effect/rpc`.
+- Do not add Electron, MessagePort, or any desktop transport.
+- Do not migrate studio state to effect-atom.
+- Do not alter the Durable Streams sidecar protocol.
+- Do not touch generated build artifacts under `apps/studio/dist*`.
+- Do not touch copied app sources under `apps/studio-desktop/resources/ax-src`.
+- Do not broaden this into unrelated query input contracts, pagination, OTLP, MCP, or table rendering work.
+
+## Worktree Protocol
+
+- If the overnight runner starts in a dedicated non-main worktree, use the current worktree and branch. Do not create a nested worktree.
+- If the runner starts on `main` and an issue number exists, use the repo's normal claim flow:
+
+```bash
+bun run wip list
+bun run wip claim <issue#> arch
+cd <printed-worktree-path>
+```
+
+- If the runner starts on `main` and there is no issue number, create a dedicated branch/worktree before editing:
+
+```bash
+git worktree add .claude/worktrees/live-ingest-event-contract -b arch/live-ingest-event-contract
+cd .claude/worktrees/live-ingest-event-contract
+```
+
+- Do not edit code on `main`.
+- Before editing, run:
+
+```bash
+git status --short
+git branch --show-current
+```
+
+If unrelated dirty files are present, leave them alone.
+
+## File Map
+
+Modify:
+
+- `packages/lib/src/shared/ingest-stream-events.ts`
+  - Owns schema definitions, derived public types, decoder/encoder helpers, and the failure-snapshot schema.
+
+- `apps/axctl/src/ingest/stream-events.ts`
+  - Keeps translating trace events into ingest stream events.
+  - Replaces manual `stage_file_failures` shape checks with the shared schema where possible.
+
+- `apps/axctl/src/dashboard/ingest-stream-durable.ts`
+  - Encodes or validates each event before `handle.append(JSON.stringify(...))`.
+
+- `apps/studio/src/use-ingest-stream.ts`
+  - Treats Durable Stream items as `unknown`.
+  - Decodes each item using the shared contract before calling `applyEvent`.
+  - Dispatches an error for malformed items without breaking valid-item folding.
+
+- `packages/lib/src/shared/api-contract.ts`
+  - Updates comments only. The `HttpApi` route itself should stay unchanged.
+
+Test:
+
+- Create `packages/lib/src/shared/ingest-stream-events.test.ts`
+- Update `apps/axctl/src/ingest/stream-events.test.ts`
+- Update `apps/axctl/src/dashboard/ingest-stream-durable.test.ts`
+- Update `apps/studio/src/use-ingest-stream.test.ts`
+
+Do not modify:
+
+- `apps/studio/dist*`
+- `apps/studio-desktop/resources/ax-src`
+- `package.json` dependency lists
+- `packages/lib/package.json` exports, unless TypeScript resolution fails. It should not fail because `@ax/lib` has a wildcard export.
+
+---
+
+## Task 1: Shared Schema Contract
+
+**Files:**
+
+- Modify: `packages/lib/src/shared/ingest-stream-events.ts`
+- Create: `packages/lib/src/shared/ingest-stream-events.test.ts`
+
+### Task 1 Goal
+
+Replace the interface-only event shapes with Effect Schema definitions and derive the public types from the schemas.
+
+### Step 1: Write the failing schema tests
+
+- [ ] Add `packages/lib/src/shared/ingest-stream-events.test.ts` with tests covering every valid variant and representative invalid shapes.
+
+Use this test file content as the starting point:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { Option, Schema } from "effect";
+import {
+    decodeIngestStreamEventOption,
+    encodeIngestStreamEvent,
+    IngestStreamEventSchema,
+    isIngestStreamEvent,
+    type IngestStreamEvent,
+} from "./ingest-stream-events.ts";
+
+const validEvents: ReadonlyArray<IngestStreamEvent> = [
+    { kind: "run_started", runId: "r1", label: "ingest" },
+    { kind: "stage_started", runId: "r1", stage: "claude" },
+    {
+        kind: "stage_progress",
+        runId: "r1",
+        stage: "claude",
+        current: 10,
+        total: 25,
+        ratePerSec: 5,
+        etaLeftMs: 3000,
+        stageIndex: 1,
+    },
+    {
+        kind: "stage_progress",
+        runId: "r1",
+        stage: "claude",
+        current: 25,
+        total: 25,
+        ratePerSec: 10,
+        etaLeftMs: null,
+        stageIndex: 1,
+    },
+    {
+        kind: "stage_file_failures",
+        runId: "r1",
+        stage: "claude",
+        total: 2,
+        failures: [
+            { filePath: "/tmp/a.jsonl", tag: "DbError", message: "boom" },
+            { filePath: "/tmp/b.jsonl", tag: "ParseError", message: "bad json" },
+        ],
+    },
+    { kind: "stage_finished", runId: "r1", stage: "claude", status: "ok", durationMs: 42 },
+    { kind: "stage_finished", runId: "r1", stage: "codex", status: "error", durationMs: 99 },
+    { kind: "run_finished", runId: "r1", status: "completed", durationMs: 120 },
+    { kind: "run_finished", runId: "r2", status: "failed", durationMs: 121 },
+];
+
+describe("IngestStreamEventSchema", () => {
+    test("decodes every valid live-ingest event variant", () => {
+        for (const event of validEvents) {
+            expect(Schema.decodeUnknownSync(IngestStreamEventSchema)(event)).toEqual(event);
+            expect(Option.isSome(decodeIngestStreamEventOption(event))).toBe(true);
+            expect(isIngestStreamEvent(event)).toBe(true);
+        }
+    });
+
+    test("encodes valid events without changing their JSON shape", () => {
+        for (const event of validEvents) {
+            expect(encodeIngestStreamEvent(event)).toEqual(event);
+        }
+    });
+
+    test("rejects unknown event kinds and invalid status literals", () => {
+        const invalid: ReadonlyArray<unknown> = [
+            { kind: "wat", runId: "r1" },
+            { kind: "stage_finished", runId: "r1", stage: "s", status: "completed", durationMs: 1 },
+            { kind: "run_finished", runId: "r1", status: "ok", durationMs: 1 },
+        ];
+
+        for (const value of invalid) {
+            expect(Option.isNone(decodeIngestStreamEventOption(value))).toBe(true);
+            expect(isIngestStreamEvent(value)).toBe(false);
+        }
+    });
+
+    test("rejects malformed stage_file_failures details", () => {
+        const invalid: ReadonlyArray<unknown> = [
+            { kind: "stage_file_failures", runId: "r", stage: "s", total: 1, failures: [{ filePath: 1, tag: "x", message: "y" }] },
+            { kind: "stage_file_failures", runId: "r", stage: "s", total: 1, failures: [{ filePath: "/x", tag: 2, message: "y" }] },
+            { kind: "stage_file_failures", runId: "r", stage: "s", total: 1, failures: [{ filePath: "/x", tag: "x", message: null }] },
+        ];
+
+        for (const value of invalid) {
+            expect(Option.isNone(decodeIngestStreamEventOption(value))).toBe(true);
+        }
+    });
+});
+```
+
+Run:
+
+```bash
+bun test packages/lib/src/shared/ingest-stream-events.test.ts
+```
+
+Expected before implementation: fail because the schema/helper exports do not exist.
+
+### Step 2: Implement the schemas and helpers
+
+- [ ] Edit `packages/lib/src/shared/ingest-stream-events.ts`.
+
+Use `Schema.Struct` with explicit `kind` literals. Do not use `Schema.TaggedStruct`, because that would introduce `_tag`.
+
+Implementation shape:
+
+```ts
+import { Option, Schema } from "effect";
+
+export const IngestFileFailureSchema = Schema.Struct({
+    filePath: Schema.String,
+    tag: Schema.String,
+    message: Schema.String,
+});
+export type IngestFileFailure = typeof IngestFileFailureSchema.Type;
+
+export const IngestFileFailureSnapshotSchema = Schema.Struct({
+    total: Schema.Number,
+    failures: Schema.Array(IngestFileFailureSchema),
+});
+export type IngestFileFailureSnapshot = typeof IngestFileFailureSnapshotSchema.Type;
+
+export const RunStartedEventSchema = Schema.Struct({
+    kind: Schema.Literal("run_started"),
+    runId: Schema.String,
+    label: Schema.String,
+});
+
+export const StageStartedEventSchema = Schema.Struct({
+    kind: Schema.Literal("stage_started"),
+    runId: Schema.String,
+    stage: Schema.String,
+});
+
+export const StageProgressEventSchema = Schema.Struct({
+    kind: Schema.Literal("stage_progress"),
+    runId: Schema.String,
+    stage: Schema.String,
+    current: Schema.Number,
+    total: Schema.Number,
+    ratePerSec: Schema.Number,
+    etaLeftMs: Schema.NullOr(Schema.Number),
+    stageIndex: Schema.Number,
+});
+
+export const StageFileFailuresEventSchema = Schema.Struct({
+    kind: Schema.Literal("stage_file_failures"),
+    runId: Schema.String,
+    stage: Schema.String,
+    total: Schema.Number,
+    failures: Schema.Array(IngestFileFailureSchema),
+});
+
+export const StageFinishedEventSchema = Schema.Struct({
+    kind: Schema.Literal("stage_finished"),
+    runId: Schema.String,
+    stage: Schema.String,
+    status: Schema.Literals(["ok", "error"]),
+    durationMs: Schema.Number,
+});
+
+export const RunFinishedEventSchema = Schema.Struct({
+    kind: Schema.Literal("run_finished"),
+    runId: Schema.String,
+    status: Schema.Literals(["completed", "failed"]),
+    durationMs: Schema.Number,
+});
+
+export const IngestStreamEventSchema = Schema.Union([
+    RunStartedEventSchema,
+    StageStartedEventSchema,
+    StageProgressEventSchema,
+    StageFileFailuresEventSchema,
+    StageFinishedEventSchema,
+    RunFinishedEventSchema,
+]);
+export type IngestStreamEvent = typeof IngestStreamEventSchema.Type;
+
+const decodeEventOption = Schema.decodeUnknownOption(IngestStreamEventSchema);
+const decodeFailureSnapshotOption = Schema.decodeUnknownOption(IngestFileFailureSnapshotSchema);
+const encodeEventSync = Schema.encodeSync(IngestStreamEventSchema);
+
+export const decodeIngestStreamEventOption = (value: unknown) =>
+    decodeEventOption(value);
+
+export const decodeIngestFileFailureSnapshotOption = (value: unknown) =>
+    decodeFailureSnapshotOption(value);
+
+export const isIngestStreamEvent = (value: unknown): value is IngestStreamEvent =>
+    Option.isSome(decodeEventOption(value));
+
+export const encodeIngestStreamEvent = (event: IngestStreamEvent): unknown =>
+    encodeEventSync(event);
+```
+
+If `Option.isSome` is not exported in this Effect beta, inspect existing Option usage with:
+
+```bash
+rg "Option\\.isSome|Option\\." apps packages -n
+```
+
+Then use the local idiom. Do not add a dependency for this.
+
+### Step 3: Run the shared schema tests
+
+- [ ] Run:
+
+```bash
+bun test packages/lib/src/shared/ingest-stream-events.test.ts
+```
+
+Expected after implementation: pass.
+
+### Step 4: Typecheck the shared package
+
+- [ ] Run:
+
+```bash
+bun --cwd packages/lib run typecheck
+```
+
+Expected: pass.
+
+Commit:
+
+```bash
+git add packages/lib/src/shared/ingest-stream-events.ts packages/lib/src/shared/ingest-stream-events.test.ts
+git commit -m "feat: schema live ingest stream events"
+```
+
+---
+
+## Task 2: Producer-Side Validation Before Durable Stream Append
+
+**Files:**
+
+- Modify: `apps/axctl/src/dashboard/ingest-stream-durable.ts`
+- Modify: `apps/axctl/src/dashboard/ingest-stream-durable.test.ts`
+
+### Task 2 Goal
+
+The daemon must not append an event that fails the shared stream contract. This catches producer drift close to the source.
+
+### Step 1: Add a failing test for invalid producer events
+
+- [ ] In `apps/axctl/src/dashboard/ingest-stream-durable.test.ts`, add a non-E2E test outside the `AX_STREAM_E2E` gated describe block if the file structure makes that practical.
+
+Because the current implementation opens a real sidecar before it can append, do not overfit the test to internals. Export a pure helper from the producer module in the next step:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { encodeIngestStreamEventJson } from "./ingest-stream-durable.ts";
+import type { IngestStreamEvent } from "../ingest/stream-events.ts";
+
+describe("encodeIngestStreamEventJson", () => {
+    test("serializes valid events with the existing JSON shape", () => {
+        expect(encodeIngestStreamEventJson({ kind: "stage_started", runId: "r", stage: "discover" })).toBe(
+            JSON.stringify({ kind: "stage_started", runId: "r", stage: "discover" }),
+        );
+    });
+
+    test("rejects invalid events before Durable Stream append", () => {
+        // Simulates a malformed runtime value crossing the TypeScript boundary.
+        const malformed = { kind: "stage_finished", runId: "r", stage: "s", status: "completed", durationMs: 1 } as unknown as IngestStreamEvent;
+        expect(() =>
+            encodeIngestStreamEventJson(malformed),
+        ).toThrow();
+    });
+});
+```
+
+Run:
+
+```bash
+bun test apps/axctl/src/dashboard/ingest-stream-durable.test.ts
+```
+
+Expected before implementation: fail because `encodeIngestStreamEventJson` does not exist.
+
+### Step 2: Add the producer encoder helper
+
+- [ ] Edit `apps/axctl/src/dashboard/ingest-stream-durable.ts`.
+
+Import the shared JSON-string encoder:
+
+```ts
+import { encodeIngestStreamEventJson } from "@ax/lib/shared/ingest-stream-events";
+```
+
+Re-export the pure helper near the top-level exports for the producer tests:
+
+```ts
+export { encodeIngestStreamEventJson };
+```
+
+Then change:
+
+```ts
+await handle.append(JSON.stringify(event));
+```
+
+to:
+
+```ts
+await handle.append(encodeIngestStreamEventJson(event));
+```
+
+Do not catch schema failures here. An invalid producer event is a programmer error in ax, not a malformed remote client. Let the append path fail so tests and live ingest reveal the bug.
+
+### Step 3: Run producer tests
+
+- [ ] Run:
+
+```bash
+bun test apps/axctl/src/dashboard/ingest-stream-durable.test.ts
+```
+
+Expected: pure helper tests pass. The E2E sidecar test remains skipped unless `AX_STREAM_E2E=1`.
+
+### Step 4: Optional E2E if time and local native sidecar works
+
+- [ ] Run:
+
+```bash
+AX_STREAM_E2E=1 bun test apps/axctl/src/dashboard/ingest-stream-durable.test.ts
+```
+
+Expected: sidecar publish/read still passes. If native `lmdb` or Durable Streams setup blocks this, document the blocker in the final report and continue with typecheck plus focused unit tests.
+
+Commit:
+
+```bash
+git add apps/axctl/src/dashboard/ingest-stream-durable.ts apps/axctl/src/dashboard/ingest-stream-durable.test.ts
+git commit -m "test: validate live ingest stream appends"
+```
+
+---
+
+## Task 3: Trace Translator Uses the Shared Failure Snapshot Schema
+
+**Files:**
+
+- Modify: `apps/axctl/src/ingest/stream-events.ts`
+- Modify: `apps/axctl/src/ingest/stream-events.test.ts`
+
+### Task 3 Goal
+
+Keep the existing trace-to-stream behavior, but stop hand-validating the `ingest.fileFailures` snapshot shape when the shared schema can do it.
+
+### Step 1: Strengthen existing translator tests
+
+- [ ] Add a test that proves malformed failure snapshots are dropped because of schema validation:
+
+```ts
+test("drops fileFailures payloads whose failure entries do not match the shared schema", () => {
+    const malformedEvent: SpanEvent = {
+        _tag: "SpanEvent",
+        traceId: "ingest:run123",
+        spanId: "s1",
+        name: "attribute:ingest.fileFailures",
+        attributes: {
+            value: JSON.stringify({
+                total: 2,
+                failures: [{ filePath: "/p/a.jsonl", tag: "DbError", message: 42 }],
+            }),
+        },
+    };
+
+    const ev = ingestStreamEventFromTrace(
+        malformedEvent,
+        { spanNames: new Map([["s1", "claude"]]) },
+    );
+    expect(ev).toBeNull();
+});
+```
+
+Run:
+
+```bash
+bun test apps/axctl/src/ingest/stream-events.test.ts
+```
+
+Expected before implementation: this may already pass because manual checks exist. That is acceptable for a characterization test.
+
+### Step 2: Replace manual shape checks for the snapshot
+
+- [ ] Edit `apps/axctl/src/ingest/stream-events.ts`.
+
+Change the import from shared event types:
+
+```ts
+import type { IngestFileFailure, IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
+```
+
+to:
+
+```ts
+import {
+    decodeIngestFileFailureSnapshotOption,
+    type IngestFileFailure,
+    type IngestStreamEvent,
+} from "@ax/lib/shared/ingest-stream-events";
+```
+
+Then replace the object-entry loop inside `readFileFailures` with:
+
+```ts
+const decoded = decodeIngestFileFailureSnapshotOption(parsed);
+if (Option.isNone(decoded)) return null;
+const snapshot = decoded.value;
+if (snapshot.total <= 0) return null;
+return { total: snapshot.total, failures: [...snapshot.failures] };
+```
+
+Use public `Option` APIs instead of inspecting the `Option` discriminator directly.
+
+Keep the JSON parse try/catch. The shared schema validates the parsed object; it does not replace JSON parsing.
+
+### Step 3: Run translator tests
+
+- [ ] Run:
+
+```bash
+bun test apps/axctl/src/ingest/stream-events.test.ts
+```
+
+Expected: pass.
+
+Commit:
+
+```bash
+git add packages/lib/src/shared/ingest-stream-events.ts apps/axctl/src/ingest/stream-events.ts apps/axctl/src/ingest/stream-events.test.ts
+git commit -m "refactor: validate ingest failure snapshots with schema"
+```
+
+---
+
+## Task 4: Studio Decodes Unknown Stream Items Before Reducing
+
+**Files:**
+
+- Modify: `apps/studio/src/use-ingest-stream.ts`
+- Modify: `apps/studio/src/use-ingest-stream.test.ts`
+
+### Task 4 Goal
+
+The studio should not trust generic type parameters from `@durable-streams/client`. Stream items are external JSON at runtime. Decode them before `applyEvent`.
+
+### Step 1: Add pure decode/fold tests
+
+- [ ] Extend `apps/studio/src/use-ingest-stream.test.ts`.
+
+Add an exported pure helper in the implementation during Step 2, then test it here:
+
+```ts
+import { decodeStreamItems } from "./use-ingest-stream.ts";
+```
+
+Add tests:
+
+```ts
+describe("decodeStreamItems", () => {
+    test("returns valid ingest events and counts malformed items", () => {
+        const batch = decodeStreamItems([
+            { kind: "stage_started", runId: "r", stage: "claude" },
+            { kind: "stage_finished", runId: "r", stage: "claude", status: "completed", durationMs: 1 },
+            { kind: "run_finished", runId: "r", status: "completed", durationMs: 2 },
+        ]);
+
+        expect(batch.events).toEqual([
+            { kind: "stage_started", runId: "r", stage: "claude" },
+            { kind: "run_finished", runId: "r", status: "completed", durationMs: 2 },
+        ]);
+        expect(batch.invalidCount).toBe(1);
+    });
+});
+```
+
+Run:
+
+```bash
+bun test apps/studio/src/use-ingest-stream.test.ts
+```
+
+Expected before implementation: fail because `decodeStreamItems` does not exist.
+
+### Step 2: Implement `decodeStreamItems`
+
+- [ ] Edit `apps/studio/src/use-ingest-stream.ts`.
+
+Change:
+
+```ts
+import type { IngestFileFailure, IngestStreamEvent } from "@ax/lib/shared/ingest-stream-events";
+```
+
+to:
+
+```ts
+import {
+    decodeIngestStreamEventOption,
+    type IngestFileFailure,
+    type IngestStreamEvent,
+} from "@ax/lib/shared/ingest-stream-events";
+```
+
+Add a pure helper near the reducer helpers:
+
+```ts
+export interface DecodedStreamItems {
+    readonly events: ReadonlyArray<IngestStreamEvent>;
+    readonly invalidCount: number;
+}
+
+export function decodeStreamItems(items: ReadonlyArray<unknown>): DecodedStreamItems {
+    const events: IngestStreamEvent[] = [];
+    let invalidCount = 0;
+    for (const item of items) {
+        Option.match(decodeIngestStreamEventOption(item), {
+            onSome: (event) => {
+                events.push(event);
+            },
+            onNone: () => {
+                invalidCount += 1;
+            },
+        });
+    }
+    return { events, invalidCount };
+}
+```
+
+Use public `Option` helpers such as `Option.match`, `Option.isSome`, or `Option.isNone`; do not inspect `Option` internals.
+
+### Step 3: Decode in the hook
+
+- [ ] In `useIngestStream`, make the Durable Stream session unknown-typed:
+
+```ts
+let session: StreamResponse<unknown> | null = null;
+```
+
+Change:
+
+```ts
+const res = await stream<IngestStreamEvent>({
+```
+
+to:
+
+```ts
+const res = await stream<unknown>({
+```
+
+Then change the subscribe block from:
+
+```ts
+unsubscribe = res.subscribeJson((batch) => {
+    if (cancelled) return;
+    if (batch.items.length > 0) receivedAny = true;
+    for (const event of batch.items) {
+        dispatch({ type: "event", event, offset: batch.offset });
+    }
+});
+```
+
+to:
+
+```ts
+unsubscribe = res.subscribeJson((batch) => {
+    if (cancelled) return;
+    if (batch.items.length > 0) receivedAny = true;
+    const decoded = decodeStreamItems(batch.items);
+    if (decoded.invalidCount > 0) {
+        dispatch({
+            type: "error",
+            message: `received ${decoded.invalidCount} invalid ingest stream event${decoded.invalidCount === 1 ? "" : "s"}`,
+        });
+    }
+    for (const event of decoded.events) {
+        dispatch({ type: "event", event, offset: batch.offset });
+    }
+});
+```
+
+Rationale:
+
+- A malformed item should not crash rendering.
+- Valid items in the same batch should still fold.
+- The error is visible in state, so the UI can surface it.
+
+### Step 4: Run studio stream tests
+
+- [ ] Run:
+
+```bash
+bun test apps/studio/src/use-ingest-stream.test.ts
+```
+
+Expected: pass.
+
+Commit:
+
+```bash
+git add apps/studio/src/use-ingest-stream.ts apps/studio/src/use-ingest-stream.test.ts
+git commit -m "fix: decode live ingest stream items in studio"
+```
+
+---
+
+## Task 5: Update Contract Comments
+
+**Files:**
+
+- Modify: `packages/lib/src/shared/api-contract.ts`
+
+### Task 5 Goal
+
+Keep the architecture comments accurate. The stream route is outside `HttpApi`, but its JSON event payload is now schema-typed.
+
+### Step 1: Update the module comment
+
+- [ ] In the top comment, replace:
+
+```ts
+SSE /api/events and binary /api/image stay OUTSIDE the contract permanently
+(streaming/binary shapes that don't fit HttpApi).
+```
+
+with:
+
+```ts
+SSE /api/events, Durable Stream tails returned by /api/ingest, and binary
+/api/image stay outside HttpApi routing. Live-ingest stream event payloads
+are still schema-typed separately in @ax/lib/shared/ingest-stream-events.
+```
+
+Keep line lengths consistent with the file.
+
+### Step 2: Update the live group comment
+
+- [ ] Near `LiveGroup`, replace:
+
+```ts
+The live family's JSON endpoint. SSE /api/events and binary /api/image
+stay OUTSIDE the contract permanently (module doc above).
+```
+
+with:
+
+```ts
+The live family's JSON trigger endpoint. The returned Durable Stream URL is
+not an HttpApi route, but its event payload is schema-typed in
+@ax/lib/shared/ingest-stream-events.
+```
+
+### Step 3: Run a narrow typecheck
+
+- [ ] Run:
+
+```bash
+bun --cwd packages/lib run typecheck
+```
+
+Expected: pass.
+
+Commit:
+
+```bash
+git add packages/lib/src/shared/api-contract.ts
+git commit -m "docs: clarify live ingest stream contract"
+```
+
+---
+
+## Task 6: Verification Pass
+
+### Step 1: Run focused tests
+
+- [ ] Run:
+
+```bash
+bun test \
+  packages/lib/src/shared/ingest-stream-events.test.ts \
+  apps/axctl/src/ingest/stream-events.test.ts \
+  apps/axctl/src/dashboard/ingest-stream-durable.test.ts \
+  apps/studio/src/use-ingest-stream.test.ts
+```
+
+Expected: pass. The Durable Streams E2E section may remain skipped unless `AX_STREAM_E2E=1`.
+
+### Step 2: Run package typechecks
+
+- [ ] Run:
+
+```bash
+bun --cwd packages/lib run typecheck
+bun --cwd apps/axctl run typecheck
+bun --cwd apps/studio run typecheck
+```
+
+Expected: pass.
+
+Note: the site/studio typecheck sometimes depends on generated route/content output. If it fails for missing generated artifacts, run the repo's established build step first:
+
+```bash
+bun run build
+```
+
+Then rerun the failing typecheck.
+
+### Step 3: Run full gates if time remains
+
+- [ ] Run:
+
+```bash
+bun test
+bun run typecheck
+```
+
+Expected: pass.
+
+If `bun test` is blocked by a local hook that requires the project test wrapper, follow the repo's current test-wrapper convention and record the exact command used in the final report.
+
+### Step 4: Inspect changed files
+
+- [ ] Run:
+
+```bash
+git status --short
+git diff --stat
+git diff -- packages/lib/src/shared/ingest-stream-events.ts
+git diff -- apps/axctl/src/dashboard/ingest-stream-durable.ts
+git diff -- apps/studio/src/use-ingest-stream.ts
+```
+
+Confirm:
+
+- No generated `dist` files changed.
+- No `apps/studio-desktop/resources/ax-src` files changed.
+- No dependencies changed.
+- The public type names still exist.
+- The UI reducer still switches on `event.kind`.
+
+### Step 5: Final commit if previous tasks were not committed
+
+- [ ] If the task commits were skipped, make one commit:
+
+```bash
+git add \
+  packages/lib/src/shared/ingest-stream-events.ts \
+  packages/lib/src/shared/ingest-stream-events.test.ts \
+  packages/lib/src/shared/api-contract.ts \
+  apps/axctl/src/ingest/stream-events.ts \
+  apps/axctl/src/ingest/stream-events.test.ts \
+  apps/axctl/src/dashboard/ingest-stream-durable.ts \
+  apps/axctl/src/dashboard/ingest-stream-durable.test.ts \
+  apps/studio/src/use-ingest-stream.ts \
+  apps/studio/src/use-ingest-stream.test.ts
+
+git commit -m "feat: validate live ingest stream contract"
+```
+
+---
+
+## Edge Cases and Traps
+
+### Keep `kind`, not `_tag`
+
+The Effect/Electron example uses `Schema.TaggedStruct`, and ax's live traces schema also uses `_tag`. Live ingest events do not. The studio reducer is keyed on `kind`. Preserve that.
+
+### Do not use `Schema.Unknown` for the event union
+
+The whole point is to catch drift. A union of exact structs is needed.
+
+### Do not silently drop malformed producer events
+
+Producer-side invalid events indicate an ax code bug. The daemon append helper should throw/reject. Consumer-side malformed events are external stream data and should be handled gracefully.
+
+### Avoid over-validating counts in the first pass
+
+The current TypeScript type allows any number for `current`, `total`, `ratePerSec`, `durationMs`, and `stageIndex`. It is fine to restrict obvious literals like statuses and kind. Do not add positivity or integer constraints unless tests prove all producers already satisfy them. This goal is a contract promotion, not a semantic behavior change.
+
+### `Schema.Array` may return readonly arrays
+
+If TypeScript complains when returning `snapshot.failures`, use `[...snapshot.failures]` at the boundary. Do not loosen the schema.
+
+### Use public `Option` APIs
+
+Use `Option.match`, `Option.isSome`, or `Option.isNone` for Effect `Option` values. Reserve direct discriminator checks for this project's own public wire unions.
+
+### `apps/studio/src/use-ingest-stream.ts` still owns UI state
+
+Do not move `applyEvent` into shared lib in this goal. The shared contract should know event shapes; the studio hook should own render state.
+
+### Comments matter here
+
+The old comment in `api-contract.ts` says streaming payloads do not fit the contract. After this change, leaving that comment untouched will mislead the next agent into thinking the stream is intentionally untyped.
+
+## Suggested Final Report
+
+The final response should include:
+
+- Files changed.
+- Focused tests run and pass/fail status.
+- Typecheck commands run and pass/fail status.
+- Whether `AX_STREAM_E2E=1` was run or skipped.
+- Any deviations from this plan, especially around Effect `Option` APIs or schema helper naming.

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -8,8 +8,9 @@
  *
  * Migration is strangler-style, one route family at a time; endpoints not
  * yet listed here are still served by the legacy route table. SSE
- * /api/events and binary /api/image stay OUTSIDE the contract permanently
- * (streaming/binary shapes that don't fit HttpApi).
+ * /api/events, Durable Stream tails returned by /api/ingest, and binary
+ * /api/image stay outside HttpApi routing. Live-ingest stream event payloads
+ * are still schema-typed separately in @ax/lib/shared/ingest-stream-events.
  *
  * This module must stay daemon-agnostic: no imports from apps/* (the studio
  * bundles it for the browser).
@@ -1021,8 +1022,9 @@ export class IngestTriggerResult extends Schema.Class<IngestTriggerResult>("ax/I
 }) {}
 
 /**
- * The live family's JSON endpoint. SSE /api/events and binary /api/image
- * stay OUTSIDE the contract permanently (module doc above).
+ * The live family's JSON trigger endpoint. The returned Durable Stream URL is
+ * not an HttpApi route, but its event payload is schema-typed in
+ * @ax/lib/shared/ingest-stream-events.
  */
 export const LiveGroup = HttpApiGroup.make("live")
     .add(

--- a/packages/lib/src/shared/ingest-stream-events.test.ts
+++ b/packages/lib/src/shared/ingest-stream-events.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { Option, Schema } from "effect";
+import {
+    decodeIngestStreamEventOption,
+    encodeIngestStreamEvent,
+    encodeIngestStreamEventJson,
+    IngestStreamEventJsonSchema,
+    IngestStreamEventSchema,
+    isIngestStreamEvent,
+    type IngestStreamEvent,
+} from "./ingest-stream-events.ts";
+
+const validEvents: ReadonlyArray<IngestStreamEvent> = [
+    { kind: "run_started", runId: "r1", label: "ingest" },
+    { kind: "stage_started", runId: "r1", stage: "claude" },
+    {
+        kind: "stage_progress",
+        runId: "r1",
+        stage: "claude",
+        current: 10,
+        total: 25,
+        ratePerSec: 5,
+        etaLeftMs: 3000,
+        stageIndex: 1,
+    },
+    {
+        kind: "stage_progress",
+        runId: "r1",
+        stage: "claude",
+        current: 25,
+        total: 25,
+        ratePerSec: 10,
+        etaLeftMs: null,
+        stageIndex: 1,
+    },
+    {
+        kind: "stage_file_failures",
+        runId: "r1",
+        stage: "claude",
+        total: 2,
+        failures: [
+            { filePath: "/tmp/a.jsonl", tag: "DbError", message: "boom" },
+            { filePath: "/tmp/b.jsonl", tag: "ParseError", message: "bad json" },
+        ],
+    },
+    { kind: "stage_finished", runId: "r1", stage: "claude", status: "ok", durationMs: 42 },
+    { kind: "stage_finished", runId: "r1", stage: "codex", status: "error", durationMs: 99 },
+    { kind: "run_finished", runId: "r1", status: "completed", durationMs: 120 },
+    { kind: "run_finished", runId: "r2", status: "failed", durationMs: 121 },
+];
+
+describe("IngestStreamEventSchema", () => {
+    test("decodes every valid live-ingest event variant", () => {
+        for (const event of validEvents) {
+            expect(Schema.decodeUnknownSync(IngestStreamEventSchema)(event)).toEqual(event);
+            expect(Option.isSome(decodeIngestStreamEventOption(event))).toBe(true);
+            expect(isIngestStreamEvent(event)).toBe(true);
+        }
+    });
+
+    test("encodes valid events without changing their JSON shape", () => {
+        for (const event of validEvents) {
+            expect(encodeIngestStreamEvent(event)).toEqual(event);
+        }
+    });
+
+    test("encodes and decodes valid events at the JSON-string boundary", () => {
+        for (const event of validEvents) {
+            const json = encodeIngestStreamEventJson(event);
+
+            expect(json).toBe(JSON.stringify(event));
+            expect(Schema.decodeUnknownSync(IngestStreamEventJsonSchema)(json)).toEqual(event);
+        }
+    });
+
+    test("rejects malformed JSON-string events", () => {
+        const invalid = JSON.stringify({
+            kind: "stage_finished",
+            runId: "r1",
+            stage: "claude",
+            status: "completed",
+            durationMs: 1,
+        });
+
+        expect(() => Schema.decodeUnknownSync(IngestStreamEventJsonSchema)(invalid)).toThrow();
+    });
+
+    test("rejects unknown event kinds and invalid status literals", () => {
+        const invalid: ReadonlyArray<unknown> = [
+            { kind: "wat", runId: "r1" },
+            { kind: "stage_finished", runId: "r1", stage: "s", status: "completed", durationMs: 1 },
+            { kind: "run_finished", runId: "r1", status: "ok", durationMs: 1 },
+        ];
+
+        for (const value of invalid) {
+            expect(Option.isNone(decodeIngestStreamEventOption(value))).toBe(true);
+            expect(isIngestStreamEvent(value)).toBe(false);
+        }
+    });
+
+    test("rejects non-finite JSON numbers", () => {
+        const invalid: ReadonlyArray<unknown> = [
+            {
+                kind: "stage_progress",
+                runId: "r1",
+                stage: "claude",
+                current: 1,
+                total: 2,
+                ratePerSec: Infinity,
+                etaLeftMs: null,
+                stageIndex: 1,
+            },
+            {
+                kind: "stage_progress",
+                runId: "r1",
+                stage: "claude",
+                current: 1,
+                total: 2,
+                ratePerSec: 1,
+                etaLeftMs: Number.NaN,
+                stageIndex: 1,
+            },
+            { kind: "run_finished", runId: "r1", status: "completed", durationMs: -Infinity },
+        ];
+
+        for (const value of invalid) {
+            expect(Option.isNone(decodeIngestStreamEventOption(value))).toBe(true);
+        }
+    });
+
+    test("rejects malformed stage_file_failures details", () => {
+        const invalid: ReadonlyArray<unknown> = [
+            { kind: "stage_file_failures", runId: "r", stage: "s", total: 1, failures: [{ filePath: 1, tag: "x", message: "y" }] },
+            { kind: "stage_file_failures", runId: "r", stage: "s", total: 1, failures: [{ filePath: "/x", tag: 2, message: "y" }] },
+            { kind: "stage_file_failures", runId: "r", stage: "s", total: 1, failures: [{ filePath: "/x", tag: "x", message: null }] },
+        ];
+
+        for (const value of invalid) {
+            expect(Option.isNone(decodeIngestStreamEventOption(value))).toBe(true);
+        }
+    });
+});

--- a/packages/lib/src/shared/ingest-stream-events.ts
+++ b/packages/lib/src/shared/ingest-stream-events.ts
@@ -1,46 +1,112 @@
 /**
- * Shared contract for live ingest progress events streamed to the studio SPA
- * over Durable Streams. Lives in @ax/lib/shared so both the axctl daemon
- * (producer, apps/axctl/src/ingest/stream-events.ts) and the studio SPA
- * (consumer, apps/studio/src/use-ingest-stream.ts) can import it without
- * reaching across workspace boundaries.
+ * Shared runtime contract for live ingest progress events streamed to the
+ * studio SPA over Durable Streams. Lives in @ax/lib/shared so both the axctl
+ * daemon (producer, apps/axctl/src/ingest/stream-events.ts) and the studio SPA
+ * (consumer, apps/studio/src/use-ingest-stream.ts) validate the same wire
+ * payload without reaching across workspace boundaries.
  */
+import { Option, Schema } from "effect";
+
+const JsonNumber = Schema.Finite;
+
 /** One skipped file's failure detail, as recorded by the ingest stage's
  *  per-file failure collector (apps/axctl/src/ingest/file-isolation.ts). */
-export interface IngestFileFailure {
-    readonly filePath: string;
+export const IngestFileFailureSchema = Schema.Struct({
+    filePath: Schema.String,
     /** Error tag (`DbError`, `SkillParseError`, ...) or constructor name. */
-    readonly tag: string;
-    readonly message: string;
-}
+    tag: Schema.String,
+    message: Schema.String,
+});
+export type IngestFileFailure = typeof IngestFileFailureSchema.Type;
 
-export type IngestStreamEvent =
-    | { readonly kind: "run_started"; readonly runId: string; readonly label: string }
-    | { readonly kind: "stage_started"; readonly runId: string; readonly stage: string }
-    | {
-        readonly kind: "stage_progress";
-        readonly runId: string;
-        readonly stage: string;
-        readonly current: number;
-        readonly total: number;
-        readonly ratePerSec: number;
-        readonly etaLeftMs: number | null;
-        /** 1-based index of this stage among those started so far. */
-        readonly stageIndex: number;
-    }
-    | {
-        /**
-         * Cumulative skipped-file snapshot for one stage. Re-published on each
-         * new failure (each snapshot supersedes the previous one for the same
-         * stage), so the Live tab shows the count climb while the stage runs
-         * AND a Durable Stream replay reconverges on the final list. `failures`
-         * is capped by the collector (25 details); `total` is not.
-         */
-        readonly kind: "stage_file_failures";
-        readonly runId: string;
-        readonly stage: string;
-        readonly total: number;
-        readonly failures: ReadonlyArray<IngestFileFailure>;
-    }
-    | { readonly kind: "stage_finished"; readonly runId: string; readonly stage: string; readonly status: "ok" | "error"; readonly durationMs: number }
-    | { readonly kind: "run_finished"; readonly runId: string; readonly status: "completed" | "failed"; readonly durationMs: number };
+export const IngestFileFailureSnapshotSchema = Schema.Struct({
+    total: JsonNumber,
+    failures: Schema.Array(IngestFileFailureSchema),
+});
+export type IngestFileFailureSnapshot = typeof IngestFileFailureSnapshotSchema.Type;
+
+export const RunStartedEventSchema = Schema.Struct({
+    kind: Schema.Literal("run_started"),
+    runId: Schema.String,
+    label: Schema.String,
+});
+
+export const StageStartedEventSchema = Schema.Struct({
+    kind: Schema.Literal("stage_started"),
+    runId: Schema.String,
+    stage: Schema.String,
+});
+
+export const StageProgressEventSchema = Schema.Struct({
+    kind: Schema.Literal("stage_progress"),
+    runId: Schema.String,
+    stage: Schema.String,
+    current: JsonNumber,
+    total: JsonNumber,
+    ratePerSec: JsonNumber,
+    etaLeftMs: Schema.NullOr(JsonNumber),
+    /** 1-based index of this stage among those started so far. */
+    stageIndex: JsonNumber,
+});
+
+export const StageFileFailuresEventSchema = Schema.Struct({
+    /**
+     * Cumulative skipped-file snapshot for one stage. Re-published on each
+     * new failure (each snapshot supersedes the previous one for the same
+     * stage), so the Live tab shows the count climb while the stage runs
+     * AND a Durable Stream replay reconverges on the final list. `failures`
+     * is capped by the collector (25 details); `total` is not.
+     */
+    kind: Schema.Literal("stage_file_failures"),
+    runId: Schema.String,
+    stage: Schema.String,
+    total: JsonNumber,
+    failures: Schema.Array(IngestFileFailureSchema),
+});
+
+export const StageFinishedEventSchema = Schema.Struct({
+    kind: Schema.Literal("stage_finished"),
+    runId: Schema.String,
+    stage: Schema.String,
+    status: Schema.Literals(["ok", "error"]),
+    durationMs: JsonNumber,
+});
+
+export const RunFinishedEventSchema = Schema.Struct({
+    kind: Schema.Literal("run_finished"),
+    runId: Schema.String,
+    status: Schema.Literals(["completed", "failed"]),
+    durationMs: JsonNumber,
+});
+
+export const IngestStreamEventSchema = Schema.Union([
+    RunStartedEventSchema,
+    StageStartedEventSchema,
+    StageProgressEventSchema,
+    StageFileFailuresEventSchema,
+    StageFinishedEventSchema,
+    RunFinishedEventSchema,
+]);
+export type IngestStreamEvent = typeof IngestStreamEventSchema.Type;
+
+export const IngestStreamEventJsonSchema = Schema.fromJsonString(IngestStreamEventSchema);
+
+const decodeEventOption = Schema.decodeUnknownOption(IngestStreamEventSchema);
+const decodeFailureSnapshotOption = Schema.decodeUnknownOption(IngestFileFailureSnapshotSchema);
+const encodeEventSync = Schema.encodeSync(IngestStreamEventSchema);
+const encodeEventJsonSync = Schema.encodeSync(IngestStreamEventJsonSchema);
+
+export const decodeIngestStreamEventOption = (value: unknown) =>
+    decodeEventOption(value);
+
+export const decodeIngestFileFailureSnapshotOption = (value: unknown) =>
+    decodeFailureSnapshotOption(value);
+
+export const isIngestStreamEvent = (value: unknown): value is IngestStreamEvent =>
+    Option.isSome(decodeEventOption(value));
+
+export const encodeIngestStreamEvent = (event: IngestStreamEvent): unknown =>
+    encodeEventSync(event);
+
+export const encodeIngestStreamEventJson = (event: IngestStreamEvent): string =>
+    encodeEventJsonSync(event);


### PR DESCRIPTION
## Summary

Promotes live ingest stream events from TypeScript-only interfaces to a shared Effect Schema runtime contract in `@ax/lib/shared/ingest-stream-events`.

## What changed

- Added schema-backed live ingest event variants while preserving `IngestFileFailure` and `IngestStreamEvent` exports and the `kind` discriminator.
- Adds a shared `Schema.fromJsonString(IngestStreamEventSchema)` JSON-string boundary helper for Durable Streams encoding.
- Validates and encodes daemon events before appending to Durable Streams.
- Decodes Durable Stream JSON items as `unknown` in the studio, surfaces malformed stream items as an error state, and continues folding valid events.
- Reuses the shared schema for ingest file-failure snapshots in the trace translator.
- Updates HttpApi comments to clarify `/api/ingest` is the trigger endpoint while stream event payloads are schema-typed separately.
- Adds the overnight goal brief under `goals/live-ingest-event-contract/`.

## Validation

- `bun run typecheck`
- `bun test packages/lib/src/shared/ingest-stream-events.test.ts apps/axctl/src/ingest/stream-events.test.ts apps/axctl/src/dashboard/ingest-stream-durable.test.ts apps/studio/src/use-ingest-stream.test.ts`
- `AX_STREAM_E2E=1 bun test apps/axctl/src/dashboard/ingest-stream-durable.test.ts`
- `bun test`
- `git diff --check`

Full suite result: `4952 pass, 5 skip, 0 fail`.
