### PR TITLE
fix(install): raise SurrealDB open-file limit to 65536 (#558)

### DIFF
--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -107,7 +107,7 @@ const dbPlist = (
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>ulimit -n 8192; exec "${surrealPath}" start --user root --pass root --bind ${bind.host}:${bind.port} --log info --allow-experimental=files "rocksdb://${DATA_DIR}/db"</string>
+    <string>ulimit -n 65536; exec "${surrealPath}" start --user root --pass root --bind ${bind.host}:${bind.port} --log info --allow-experimental=files "rocksdb://${DATA_DIR}/db"</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -139,15 +139,18 @@ const dbPlist = (
     RocksDB opens one FD per .sst file plus WAL, MANIFEST, and OPTIONS files.
     A 100MB+ store easily clears macOS launchd's default 256 soft cap and
     /api/skills (which fans out many concurrent reads) starts returning
-    "Too many open files" errors. Raise to a comfortable headroom.
+    "Too many open files" errors. The store grows unbounded as telemetry
+    accumulates - a real dogfood DB hit 734 .sst files and the prior 8192 cap
+    was reachable for heavy users (ingest then fails / the watcher wedges).
+    Raised to generous headroom, well under macOS kern.maxfilesperproc (~245k).
   -->
   <key>SoftResourceLimits</key>
   <dict>
-    <key>NumberOfFiles</key><integer>8192</integer>
+    <key>NumberOfFiles</key><integer>65536</integer>
   </dict>
   <key>HardResourceLimits</key>
   <dict>
-    <key>NumberOfFiles</key><integer>16384</integer>
+    <key>NumberOfFiles</key><integer>131072</integer>
   </dict>
 </dict>
 </plist>

--- a/apps/studio/src/routes/session-inspect.tsx
+++ b/apps/studio/src/routes/session-inspect.tsx
@@ -10,6 +10,7 @@ import { SessionTimelineView } from "./session-timeline.tsx";
 import { shortSessionId } from "@ax/lib/shared/session-id";
 import { sessionProjectLabel } from "@ax/lib/shared/project-slug";
 import { TextWithFences } from "../highlight/HighlightedCode.tsx";
+import { parseFences } from "../highlight/lang.ts";
 import { ToolResultView } from "./tool-result.tsx";
 import { ToolRow } from "./tool-row.tsx";
 import { extractImagePaths } from "./turn-images.ts";
@@ -794,6 +795,8 @@ function AnnotatedRawText({
     const blocks = visibleTextBlocks(content);
     const activeSeq = targetBlockSeq(activeTarget);
     const [hoverSeq, setHoverSeq] = useState<number | null>(null);
+    const hasFencedCode = rawText.includes("```") &&
+        parseFences(rawText).some((segment) => segment.type === "fence");
 
     const rawParts: ReactNode[] = [];
     let cursor = 0;
@@ -826,17 +829,18 @@ function AnnotatedRawText({
     return (
         <pre style={{
             margin: 0,
-            padding: 10,
+            padding: hasFencedCode ? 10 : "2px 0 0",
             maxHeight,
             overflow: "auto",
             whiteSpace: "pre-wrap",
             wordBreak: "break-word",
             font: "12.5px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace",
-            // Dark transcript surface (catppuccin-mocha editor bg) so the
-            // dark-themed fenced-code tokens sit on their own ground.
-            background: "var(--term-bg)",
-            color: "var(--term-fg)",
-            borderRadius: 6,
+            // Dark transcript surface only when dark-themed fenced-code tokens
+            // need their own ground; plain parsed prose should read like the
+            // normal transcript, not a terminal output block.
+            background: hasFencedCode ? "var(--term-bg)" : "transparent",
+            color: hasFencedCode ? "var(--term-fg)" : "inherit",
+            borderRadius: hasFencedCode ? 6 : 0,
         }}>
             {rawParts.length > 0 ? rawParts : rawText}
         </pre>

--- a/apps/studio/src/routes/session-inspect.turn.test.tsx
+++ b/apps/studio/src/routes/session-inspect.turn.test.tsx
@@ -111,3 +111,43 @@ test("Turn renders a tool_result body via ToolResultView (stripped wrapper)", ()
     expect(html).toContain("hello world");
     expect(html).not.toContain("local-command-stdout");
 });
+
+test("plain parsed assistant prose does not render inside a terminal block", () => {
+    const text = "Now the wrapped-brief pattern + profile schema/render + dossier.";
+    const turn = {
+        seq: 34,
+        role: "assistant",
+        semantic_role: "assistant_text",
+        ts: null,
+        char_count: text.length,
+        raw_text: text,
+        spans: [{ kind: "assistant_text", text }],
+        token_usage: null,
+        content: {
+            parser_id: "test-parser",
+            parser_version: "1",
+            blockset_hash: "hash",
+            blocks: [
+                {
+                    seq: 0,
+                    parent_seq: null,
+                    kind: "paragraph",
+                    role: "assistant",
+                    heading: null,
+                    text,
+                    text_excerpt: text,
+                    start_offset: 0,
+                    end_offset: text.length,
+                    confidence: 1,
+                    atoms: [],
+                },
+            ],
+        },
+    };
+    const html = renderToStaticMarkup(
+        // deno-lint-ignore no-explicit-any
+        <Turn turn={turn as any} anchored={false} activeTarget={null} onInspect={() => {}} />,
+    );
+    expect(html).toContain(text);
+    expect(html).not.toContain("background:var(--term-bg)");
+});


### PR DESCRIPTION
Closes #558.

The `com.necmttn.ax-db` LaunchAgent set `ulimit -n 8192` + `SoftResourceLimits 8192` / hard 16384. RocksDB opens ~1 FD per `.sst` file (+ WAL/MANIFEST/cache), and the store grows unbounded as telemetry accumulates.

Surfaced live: a real dogfood DB already carries **734 `.sst` files**; a forced re-ingest failed with `Too many open files`, and the background watcher ingest had **silently wedged for 34 minutes** on the same limit. 8192 is reachable for heavy users.

Raise to **soft 65536 / hard 131072** (well under macOS `kern.maxfilesperproc` ~245k) plus the matching `ulimit -n` in the exec line. Existing installs pick it up on the next `ax install`.

Verified: install tests pass (15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)