### PR TITLE
fix: omit null skill descriptions during ingest

### DIFF
--- a/apps/axctl/src/ingest/skill-upsert.test.ts
+++ b/apps/axctl/src/ingest/skill-upsert.test.ts
@@ -31,6 +31,39 @@ describe("skill upsert", () => {
 
         expect(tc.upserts.map((u) => String(u.id))).toEqual([`skill:${skillRecordKey(sn("new:skill"))}`]);
     });
+
+    test("omits nullish option fields from the upsert payload", async () => {
+        const tc = makeTestSurrealClient();
+
+        await Effect.runPromise(upsertSkillByName(tc.client, {
+            name: sn("no-description"),
+            scope: "test",
+            dir_path: "/tmp/no-description",
+            description: null,
+            content_hash: "hash",
+            bytes: undefined,
+        }));
+
+        expect(tc.upserts).toHaveLength(1);
+        expect(tc.upserts[0]!.content).toEqual({
+            name: sn("no-description"),
+            scope: "test",
+            dir_path: "/tmp/no-description",
+            content_hash: "hash",
+        });
+
+        const revisionCall = tc.calls.find((call) => call.sql.includes("CREATE skill_revision"));
+        expect(revisionCall?.bindings).toEqual({
+            skill: tc.upserts[0]!.id,
+            name: sn("no-description"),
+            scope: "test",
+            hash: "hash",
+            prev: undefined,
+            bytes: undefined,
+            prevBytes: undefined,
+            change: "added",
+        });
+    });
 });
 
 describe("skillsStage", () => {

--- a/apps/axctl/src/ingest/skill-upsert.ts
+++ b/apps/axctl/src/ingest/skill-upsert.ts
@@ -20,6 +20,18 @@ interface SkillLookupRow {
     readonly bytes?: unknown;
 }
 
+function skillUpsertPayload(content: SkillContent): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+        name: content.name,
+        scope: content.scope,
+        dir_path: content.dir_path,
+        content_hash: content.content_hash,
+    };
+    if (content.description != null) payload.description = content.description;
+    if (content.bytes !== undefined) payload.bytes = content.bytes;
+    return payload;
+}
+
 export function skillRecordIdFromLookup(raw: unknown, fallbackName: SkillName): RecordId {
     if (raw instanceof RecordId) return raw;
     if (typeof raw === "string") {
@@ -57,15 +69,15 @@ export function upsertSkillByName(
                     name: content.name,
                     scope: content.scope,
                     hash: content.content_hash,
-                    prev: prevHash ?? null,
-                    bytes: content.bytes ?? null,
-                    prevBytes: typeof existing?.bytes === "number" ? existing.bytes : null,
+                    prev: prevHash ?? undefined,
+                    bytes: content.bytes ?? undefined,
+                    prevBytes: typeof existing?.bytes === "number" ? existing.bytes : undefined,
                     change: isNew ? "added" : "changed",
                 },
             ));
         }
 
-        yield* db.upsert(id, { ...content });
+        yield* db.upsert(id, skillUpsertPayload(content));
         return id;
     });
 }

--- a/apps/axctl/src/ingest/skills.test.ts
+++ b/apps/axctl/src/ingest/skills.test.ts
@@ -132,6 +132,41 @@ describe("looseLineParse list-format fallback", () => {
             await rm(root, { recursive: true, force: true });
         }
     });
+
+    test("missing, empty, and null descriptions do not upsert SQL null", async () => {
+        const root = await mkdtemp(join(tmpdir(), "ax-skill-test-description-"));
+        const prevSkillDirs = process.env["AX_SKILLS_DIRS"];
+        const skillsDir = join(root, "skills");
+        process.env["AX_SKILLS_DIRS"] = skillsDir;
+        try {
+            const fixtures = [
+                ["no-frontmatter", "# Body only\n"],
+                ["empty-description", "---\nname: empty-description\ndescription:\n---\n# Body\n"],
+                ["null-description", "---\nname: null-description\ndescription: null\n---\n# Body\n"],
+            ] as const;
+
+            for (const [name, content] of fixtures) {
+                const skillDir = join(skillsDir, name);
+                await mkdir(skillDir, { recursive: true });
+                await writeFile(join(skillDir, "SKILL.md"), content, "utf8");
+            }
+
+            const { layer, upserts } = makeMockDb(undefined, { denyWrites: false });
+            const stats = await Effect.runPromise(
+                ingestSkills().pipe(Effect.provide(Layer.mergeAll(layer, PlatformLayer))),
+            );
+
+            expect(stats.count).toBe(3);
+            expect(upserts).toHaveLength(3);
+            for (const upsert of upserts) {
+                expect(upsert.content).not.toHaveProperty("description");
+            }
+        } finally {
+            if (prevSkillDirs === undefined) delete process.env["AX_SKILLS_DIRS"];
+            else process.env["AX_SKILLS_DIRS"] = prevSkillDirs;
+            await rm(root, { recursive: true, force: true });
+        }
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/axctl/src/ingest/skills.ts
+++ b/apps/axctl/src/ingest/skills.ts
@@ -269,7 +269,7 @@ export const ingestSkills = (): Effect.Effect<
                         name: SkillName.make(item.skill.name),
                         scope: item.scope,
                         dir_path: item.dir_path,
-                        description: item.skill.description ?? null,
+                        description: item.skill.description,
                         content_hash: hash,
                         bytes: item.bytes,
                     });


### PR DESCRIPTION
## Summary

- omit nullish optional fields from skill upsert payloads so SurrealDB option columns receive NONE/absence instead of SQL NULL
- stop the skills stage from converting missing descriptions to null before upsert
- add regressions for no-frontmatter, empty-description, and null-description skill files

## Root Cause

`ingestSkills` parsed missing descriptions as undefined, then converted them to null before calling `upsertSkillByName`. The shared upsert helper spread that null into the SDK content payload, which SurrealDB rejected for `skill.description option<string>`.

## Validation

- `bun test apps/axctl/src/ingest/skill-upsert.test.ts apps/axctl/src/ingest/skills.test.ts`
- `bun test`
- `bun run typecheck` (exits 0; existing Effect language-service warnings remain)

Closes #557

---

_Generated with [ax](https://github.com/Necmttn/ax)._