### PR TITLE
fix(setup): run npx skills install from HOME, not caller cwd

### DIFF
--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -1313,7 +1313,13 @@ export function cmdSetup(
         } else {
             const args = ["-y", "skills", "add", "Necmttn/ax", "-g", ...agents.flatMap((a) => ["-a", a]), "-y"];
             console.log(`  skills: npx ${args.join(" ")}`);
-            const r = spawnSync("npx", args, { stdio: "inherit" });
+            // Run from HOME, never the caller's cwd. `skills add -g` is a global
+            // op, but npx reads the nearest package.json first - and if the
+            // caller sits inside an npm/bun workspace whose `overrides` npm
+            // dislikes (e.g. dogfooding inside the ax monorepo), npx aborts with
+            // EOVERRIDE before it ever fetches `skills`. A neutral cwd keeps the
+            // surrounding project from poisoning the global install.
+            const r = spawnSync("npx", args, { stdio: "inherit", cwd: HOME });
             if (r.status === 0) console.log(`  skills: installed for ${agents.join(", ")}`);
             else console.log(`  skills: npx exited ${r.status ?? "?"} (re-run 'ax setup' or the npx command above)`);
         }


### PR DESCRIPTION
## Problem

`curl -fsSL https://ax.necmttn.com/install | bash` succeeds at downloading the binary but fails the skills step of `ax setup`:

```
  skills: npx -y skills add Necmttn/ax -g -a claude-code -a codex -a cursor -y
npm error code EOVERRIDE
npm error Override for @tanstack/react-router@^1.169 conflicts with direct dependency
  skills: npx exited 1
```

## Root cause

`ax setup` ran `spawnSync("npx", …, { stdio: "inherit" })` with the caller's cwd inherited. npx reads the nearest `package.json` before doing anything, so running the installer **inside an npm/bun workspace whose `overrides` npm rejects** (e.g. dogfooding inside the ax monorepo, whose root pins `@tanstack/react-router` over a direct dep) makes npx abort with EOVERRIDE before it ever fetches the `skills` package. Agent skills end up uninstalled.

Empirical: `npx skills add … -g` from `/tmp` succeeds; from the repo it EOVERRIDEs. Only difference is cwd.

## Fix

`skills add -g` is a global op, so cwd is irrelevant to its purpose. Pin the spawn to `HOME` so the surrounding project can't poison it.

```ts
const r = spawnSync("npx", args, { stdio: "inherit", cwd: HOME });
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)