### PR TITLE
fix(hooks): clear errors for SDK hooks on compiled binary (#564)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,12 @@ default-exporting `defineHook({ name, events, matcher, run })`; fire path is
 `bun <file>.ts` (no axctl in the hot path; ~70ms). Verdicts: allow / block /
 warn / inject; defects fail OPEN. `GitEnv` service makes guards layer-testable.
 
+- SDK hooks are **source-checkout only** - they run as `bun <file>` against the
+  packages/hooks-sdk workspace, which a compiled binary doesn't bundle. On a
+  compiled binary `ax hooks init`/`install` print a fallback-path message
+  (`isCompiledBinary()` / `COMPILED_BINARY_SDK_HOOK_HELP`) instead of dead-ending
+  on the internal `SdkPathNotFoundError` (#564); native (non-SDK) `ax hooks add`
+  still works there.
 - `ax hooks init` - scaffold `~/.ax/hooks` (file: dep on packages/hooks-sdk;
   re-run after the SDK moves - the dep is an absolute path)
 - `ax hooks install <abs-file> --providers=claude,codex` - idempotent fan-out

--- a/apps/axctl/src/hooks/cli.ts
+++ b/apps/axctl/src/hooks/cli.ts
@@ -4,7 +4,12 @@ import { prettyPrint } from "@ax/lib/json";
 import { HOME } from "@ax/lib/paths";
 import { optionValue } from "../config-core/cli-util.ts";
 import { HookProviderRegistryDefault, ALL_HOOK_PROVIDERS } from "./providers/registry.ts";
-import { resolveSdkPath, scaffoldWorkspace } from "./sdk-workspace.ts";
+import {
+    resolveSdkPath,
+    scaffoldWorkspace,
+    isCompiledBinary,
+    COMPILED_BINARY_SDK_HOOK_HELP,
+} from "./sdk-workspace.ts";
 import {
     readAllHooks,
     addHook,
@@ -175,6 +180,10 @@ const initCommand = Command.make(
     },
     ({ dir, noInstall }) =>
         Effect.gen(function* () {
+            if (isCompiledBinary()) {
+                process.stderr.write(`${COMPILED_BINARY_SDK_HOOK_HELP}\n`);
+                process.exit(1);
+            }
             const workspaceDir = expandTilde(dir);
             const sdkPath = yield* resolveSdkPath();
             const written = yield* scaffoldWorkspace({
@@ -203,8 +212,16 @@ const installCommand = Command.make(
     },
     ({ file, providers, scope }) =>
         Effect.gen(function* () {
+            // A compiled binary can't dynamically import a .ts hook file (no bun
+            // runtime + no @ax/hooks-sdk workspace), so installing one would
+            // dead-end on an opaque import error. Tell the user the supported
+            // path up front. (issue #564)
+            if (isCompiledBinary()) {
+                process.stderr.write(`${COMPILED_BINARY_SDK_HOOK_HELP}\n`);
+                process.exit(1);
+            }
             const path = yield* Path.Path;
-            const absFile = path.resolve(file);
+            const absFile = path.resolve(expandTilde(file));
             const providerList = providers.split(",").map((p) => p.trim()).filter(Boolean);
 
             // Validate provider names against the registry

--- a/apps/axctl/src/hooks/sdk-cli.e2e.test.ts
+++ b/apps/axctl/src/hooks/sdk-cli.e2e.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * End-to-end CLI coverage for issue #564: the two dead-ends a user hit when
+ * setting up SDK hooks. These spawn the REAL CLI process so they exercise the
+ * full path (arg parse -> command body -> exit code -> stderr), which the
+ * in-process installHookFile tests can't.
+ *
+ * The `hooks` command group provisions the SurrealDB layer eagerly at startup
+ * (before the command body, even for --help), so every assertion here needs a
+ * live DB. Gate on AX_E2E_DB=1 like the repo's other CLI e2e tests so CI
+ * without a daemon doesn't fail.
+ */
+
+// apps/axctl (cwd-independent: derive from this file's location)
+const AXCTL_DIR = join(import.meta.dir, "..", "..");
+const CLI_ENTRY = join(AXCTL_DIR, "src", "cli", "index.ts");
+
+const e2eDb = process.env.AX_E2E_DB === "1";
+
+const runCli = (...args: string[]) =>
+    spawnSync("bun", [CLI_ENTRY, ...args], { encoding: "utf-8", cwd: AXCTL_DIR });
+
+describe("ax hooks install (issue #564 - file-not-found)", () => {
+    test.skipIf(!e2eDb)(
+        "missing file exits non-zero with a clear 'file not found' (not the $bunfs import noise)",
+        () => {
+            const missing = join(mkdtempSync(join(tmpdir(), "ax-hook-e2e-")), "missing.ts");
+            const cli = runCli("hooks", "install", missing, "--providers=claude");
+
+            expect(cli.status).not.toBe(0);
+            const out = `${cli.stdout}${cli.stderr}`;
+            expect(out).toContain("file not found");
+            expect(out).toContain("SdkHookFileNotFoundError");
+            // the old misleading failure mode must be gone
+            expect(out).not.toContain("dynamic import failed");
+            expect(out).not.toContain("$bunfs");
+        },
+    );
+});
+
+/**
+ * Compiled-binary guidance (papercut #2). Building a --compile binary in CI is
+ * too heavy to do per-run, so this only runs when a prebuilt binary path is
+ * supplied via AX_E2E_COMPILED_BIN (e.g. `bun run build` then point at
+ * dist/axctl). Verified manually on a real compiled binary; see PR #565.
+ */
+describe("ax hooks init/install (issue #564 - compiled binary)", () => {
+    const compiledBin = process.env.AX_E2E_COMPILED_BIN;
+
+    test.skipIf(!compiledBin)(
+        "init prints the source-checkout fallback and exits non-zero (not SdkPathNotFoundError)",
+        () => {
+            const cli = spawnSync(compiledBin!, ["hooks", "init"], { encoding: "utf-8" });
+            expect(cli.status).not.toBe(0);
+            const out = `${cli.stdout}${cli.stderr}`;
+            expect(out).toContain("SDK (TypeScript) hooks need a source checkout");
+            expect(out).toContain("git clone https://github.com/Necmttn/ax");
+            expect(out).not.toContain("SdkPathNotFoundError");
+        },
+    );
+
+    test.skipIf(!compiledBin)(
+        "install prints the fallback and exits non-zero (not SdkHookImportError)",
+        () => {
+            const cli = spawnSync(
+                compiledBin!,
+                ["hooks", "install", "/tmp/whatever.ts", "--providers=claude"],
+                { encoding: "utf-8" },
+            );
+            expect(cli.status).not.toBe(0);
+            const out = `${cli.stdout}${cli.stderr}`;
+            expect(out).toContain("SDK (TypeScript) hooks need a source checkout");
+            expect(out).not.toContain("SdkHookImportError");
+        },
+    );
+});

--- a/apps/axctl/src/hooks/sdk-install.test.ts
+++ b/apps/axctl/src/hooks/sdk-install.test.ts
@@ -11,6 +11,7 @@ import {
     loadHookMeta,
     filterAlreadyInstalled,
     installHookFile,
+    SdkHookFileNotFoundError,
     SdkHookImportError,
     SdkHookValidationError,
 } from "./sdk-install.ts";
@@ -254,6 +255,18 @@ describe("installHookFile", () => {
         );
         return file;
     };
+
+    test("fails with SdkHookFileNotFoundError (not SdkHookImportError) when the file is missing", async () => {
+        const missing = join(mk(), "does-not-exist.ts");
+        const err = await runFull(
+            installHookFile(missing, ["claude"], "global")
+                .pipe(Effect.flip, Effect.provide(fullLayer)) as Effect.Effect<unknown, never, never>,
+        );
+        expect(err).toBeInstanceOf(SdkHookFileNotFoundError);
+        expect(err).not.toBeInstanceOf(SdkHookImportError);
+        expect((err as SdkHookFileNotFoundError).file).toBe(missing);
+        expect((err as SdkHookFileNotFoundError).reason).toContain("file not found");
+    });
 
     test("fails with SdkHookValidationError when the path is not absolute", async () => {
         const err = await runFull(

--- a/apps/axctl/src/hooks/sdk-install.ts
+++ b/apps/axctl/src/hooks/sdk-install.ts
@@ -17,6 +17,13 @@ import { HookProviderRegistry } from "./providers/registry.ts";
 // Errors
 // ---------------------------------------------------------------------------
 
+export class SdkHookFileNotFoundError extends Schema.TaggedErrorClass<SdkHookFileNotFoundError>(
+    "SdkHookFileNotFoundError",
+)("SdkHookFileNotFoundError", {
+    file: Schema.String,
+    reason: Schema.String,
+}) {}
+
 export class SdkHookImportError extends Schema.TaggedErrorClass<SdkHookImportError>(
     "SdkHookImportError",
 )("SdkHookImportError", {
@@ -221,6 +228,7 @@ export const installHookFile = (
     opts: InstallHookFileOptions = {},
 ): Effect.Effect<
     ReadonlyArray<InstallResult>,
+    | SdkHookFileNotFoundError
     | SdkHookImportError
     | SdkHookValidationError
     | PlatformError
@@ -236,6 +244,20 @@ export const installHookFile = (
             return yield* new SdkHookValidationError({
                 file,
                 reason: "hook file path must be absolute",
+            });
+        }
+
+        // Stat the path BEFORE attempting a dynamic import. A missing file
+        // otherwise surfaces as a confusing `SdkHookImportError: dynamic import
+        // failed` (with `$bunfs/root` resolver noise on a compiled binary),
+        // which reads like an internal packaging bug rather than "you passed a
+        // path that doesn't exist". (issue #564)
+        const fs = yield* FileSystem.FileSystem;
+        const exists = yield* fs.exists(file);
+        if (!exists) {
+            return yield* new SdkHookFileNotFoundError({
+                file,
+                reason: `file not found: ${file}`,
             });
         }
 

--- a/apps/axctl/src/hooks/sdk-workspace.test.ts
+++ b/apps/axctl/src/hooks/sdk-workspace.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Effect, Layer, FileSystem, Path } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
-import { scaffoldWorkspace } from "./sdk-workspace.ts";
+import {
+    scaffoldWorkspace,
+    isCompiledBinary,
+    COMPILED_BINARY_SDK_HOOK_HELP,
+} from "./sdk-workspace.ts";
 
 const fsLayers = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
 
@@ -122,5 +126,20 @@ describe("scaffoldWorkspace", () => {
         const dir = join(base, "nested", "hooks");
         await run(scaffoldWorkspace({ dir, sdkPath: "/sdk", install: false }));
         expect(existsSync(join(dir, "package.json"))).toBe(true);
+    });
+});
+
+describe("isCompiledBinary", () => {
+    test("false when running from source (the test runner)", () => {
+        // The test suite always runs from a source checkout via bun, never from
+        // a `--compile` binary, so detection must report false here.
+        expect(isCompiledBinary()).toBe(false);
+    });
+
+    test("fallback help names the supported path and concrete next steps", () => {
+        expect(COMPILED_BINARY_SDK_HOOK_HELP).toContain("source checkout");
+        expect(COMPILED_BINARY_SDK_HOOK_HELP).toContain("git clone https://github.com/Necmttn/ax");
+        expect(COMPILED_BINARY_SDK_HOOK_HELP).toContain("hooks init");
+        expect(COMPILED_BINARY_SDK_HOOK_HELP).toContain("ax hooks add");
     });
 });

--- a/apps/axctl/src/hooks/sdk-workspace.ts
+++ b/apps/axctl/src/hooks/sdk-workspace.ts
@@ -23,6 +23,40 @@ export class BunInstallError extends Schema.TaggedErrorClass<BunInstallError>(
 }) {}
 
 // ---------------------------------------------------------------------------
+// Compiled-binary detection + fallback guidance
+// ---------------------------------------------------------------------------
+
+/**
+ * True when axctl is running from a `bun build --compile` binary rather than a
+ * source checkout. Compiled binaries live inside bun's virtual filesystem
+ * (`/$bunfs/root/...`), so the packages/hooks-sdk source tree is absent and SDK
+ * (TypeScript) hooks - which run as `bun <file>` against that workspace - can be
+ * neither scaffolded nor installed.
+ */
+export const isCompiledBinary = (): boolean =>
+    import.meta.dir.includes("$bunfs") || import.meta.url.includes("$bunfs");
+
+/**
+ * The next-step guidance to print when an SDK-hook command (init/install) is
+ * invoked on a compiled binary. Tells the user the supported path instead of
+ * dead-ending on an internal SdkPathNotFoundError. (issue #564)
+ */
+export const COMPILED_BINARY_SDK_HOOK_HELP = [
+    "SDK (TypeScript) hooks need a source checkout of ax.",
+    "They run as `bun <file>` against the @ax/hooks-sdk workspace, which the",
+    "compiled binary does not bundle - so `ax hooks init`/`install` can't work here.",
+    "",
+    "To author/install hooks like route-dispatch:",
+    "  git clone https://github.com/Necmttn/ax && cd ax && bun install",
+    "  ./apps/axctl/bin/axctl hooks init   # then `... hooks install <file>`",
+    "",
+    "On a compiled binary you can still:",
+    "  - route models by setting `model:` explicitly per dispatch (efficient-dispatch skill)",
+    "  - measure routing with `ax dispatches` / `ax cost split`",
+    "  - add native (non-SDK) hooks via `ax hooks add --command=\"...\"`",
+].join("\n");
+
+// ---------------------------------------------------------------------------
 // resolveSdkPath
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #564.

On a **compiled-binary** install, `ax hooks init`/`install` dead-ended with internal errors and no next step. Two papercuts fixed:

## 1. `hooks install <missing-file>` → clear "file not found"
`installHookFile` now stats the path **before** the dynamic import. A missing file fails with a new `SdkHookFileNotFoundError` (`file not found: <path>`) instead of the misleading `SdkHookImportError: dynamic import failed` + `$bunfs/root` resolver noise.

```
$ ax hooks install /tmp/missing.ts --providers=claude
axctl error: {
  file: "/tmp/missing.ts",
  reason: "file not found: /tmp/missing.ts",
  _tag: "SdkHookFileNotFoundError",
}
```

## 2. compiled-binary guidance instead of `SdkPathNotFoundError`
New `isCompiledBinary()` + `COMPILED_BINARY_SDK_HOOK_HELP`. `hooks init`/`install` detect a compiled binary up front and print the supported path (clone from source for SDK hooks; `ax hooks add` for native hooks; route via explicit `model:` per dispatch) instead of the raw internal error.

Also: `install` now expands a leading `~` like `backtest` already did.

## Out of scope
Embedding the SDK + starter hooks in the binary (issue's optional fix #3) — larger change, deferred.

## Tests
- `installHookFile` missing-path → `SdkHookFileNotFoundError` (not `SdkHookImportError`)
- `isCompiledBinary()` false from source; help text asserts the supported next steps
- 28 pass in `sdk-install.test.ts` + `sdk-workspace.test.ts`; axctl typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)