### PR TITLE
feat(routing): ax routing impact — off-vs-on receipt per 5h plan window (#575)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,20 @@ not depend on effect).
 `ax routing compile [--out=PATH]` - merge-preserving regenerate of `~/.ax/hooks/routing-table.json` (defaults refresh, `origin: user` classes survive; refuses to overwrite a corrupt file). `ax dispatches compile-routing` is an alias.
 `ax routing tune [--days=N] [--dry-run] [--emit-brief] [--apply=id,...] [--out=PATH]` - mine unmatched expensive inherit dispatches for new routing classes (two-token prefix clustering, ≥3 members, suggests sonnet). Auto-applies non-judgment proposals to `~/.ax/hooks/routing-table.json` as `origin: user`; judgment-flagged ones (review/design/plan/audit/...) only ship via `--emit-brief` → `.ax/tasks/routing-tune-<date>.md` → agent backtest → `--apply=ids` (carry the brief's `--days` window).
 `ax routing show` - effective table with class origins.
+`ax routing impact begin --arm=off|on [--label]` / `end` / `report [--share] [--json]` -
+forward A/B receipt for the routing loop (#575). Captures an `ax quota` snapshot at
+the start/end of a routing-off work block and a routing-on block (state:
+`~/.ax/routing-impact.json`), then `report` diffs **5h plan-window utilization
+consumed per unit work** off vs on - the "1.Nx more work per $200 window" proof a
+fixed-plan user actually feels (you don't pay per token; the window is the budget).
+Token-equiv $ + assistant-turns (work proxy) ride along; inherit-rate-in-window is a
+deferred enrichment. Honest constraints: quota is live-only (no historical timeline,
+hence forward capture); window RESETS mid-block are detected (`resets_at` change or
+utilization drop) and the delta omitted; matched work across blocks is the operator's
+responsibility. route-dispatch is advisory, so the real A/B variable is routing
+PRACTICE (hook nudge + explicit `model:`), not "hook on/off". Pure compute +
+state in `apps/axctl/src/routing-impact/` (DB-free, exhaustively tested); CLI in
+`cli/commands/ax-routing-impact.ts`. `report --share` appends the ax plug.
 The routing-table file is now the source of truth for BOTH the route-dispatch hook and `ax dispatches --candidates` (unify done); `ROUTING_CLASSES` remains the shipped default seed. The committed `/routing-tune` workflow stays the dev-side tool for tuning the defaults themselves.
 
 ## Recommend + apply guidance to your own agent files

--- a/apps/axctl/src/cli/commands/ax-routing-impact.ts
+++ b/apps/axctl/src/cli/commands/ax-routing-impact.ts
@@ -1,0 +1,151 @@
+/**
+ * `ax routing impact` - the routing-off vs routing-on receipt, measured per 5h
+ * plan window (issue #575). Forward A/B capture:
+ *
+ *   ax routing impact begin --arm=off|on [--label=...]   # snapshot quota, mark t0
+ *   (work a ~5h block)
+ *   ax routing impact end                                 # snapshot quota, close block
+ *   ...repeat with the other arm, matched work...
+ *   ax routing impact report [--share] [--json]           # before/after card
+ *
+ * Headline: 5h-window utilization consumed per unit work (off vs on). On a fixed
+ * plan you don't pay per token - the window is the budget. Token-equiv $ rides
+ * along. Quota snapshots come from the same source as `ax quota`.
+ */
+import { Effect } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { prettyPrint } from "@ax/lib/json";
+import { defaultQuotaCachePath } from "../../quota/cache.ts";
+import { QuotaEnvLive } from "../../quota/quota-env.ts";
+import { getQuota } from "../../quota/quota.ts";
+import type { QuotaSnapshot } from "../../quota/schema.ts";
+import {
+    buildImpactReport,
+    type BlockInput,
+    type WindowEdge,
+} from "../../routing-impact/compute.ts";
+import {
+    beginBlock,
+    endBlock,
+    completedBlocks,
+    RoutingImpactStateError,
+} from "../../routing-impact/state.ts";
+import {
+    defaultStatePath,
+    fetchWindowMetrics,
+    loadState,
+    saveState,
+} from "../../routing-impact/io.ts";
+import { renderImpact } from "../../routing-impact/format.ts";
+import { fail, jsonFlag, optionValue } from "./shared.ts";
+
+const fiveHourEdge = (snap: QuotaSnapshot): WindowEdge | null =>
+    snap.five_hour
+        ? { utilization: snap.five_hour.utilization, resets_at: snap.five_hour.resets_at }
+        : null;
+
+/** Best-effort live quota snapshot (forces a fresh read; falls back to cache). */
+const snapshotQuota = Effect.gen(function* () {
+    const result = yield* getQuota({
+        cachePath: defaultQuotaCachePath(),
+        maxAgeSeconds: 0,
+        nowMs: Date.now(),
+    }).pipe(
+        Effect.catch(() => Effect.succeed(null)),
+    );
+    return result?.snapshot ?? null;
+}).pipe(Effect.provide(QuotaEnvLive));
+
+const beginImpactCommand = Command.make(
+    "begin",
+    {
+        arm: Flag.string("arm"),
+        label: Flag.string("label").pipe(Flag.optional),
+    },
+    ({ arm, label }) =>
+        Effect.gen(function* () {
+            if (arm !== "off" && arm !== "on") {
+                fail('ax routing impact begin: --arm must be "off" or "on"');
+            }
+            const path = defaultStatePath();
+            const state = yield* Effect.promise(() => loadState(path));
+            const snap = yield* snapshotQuota;
+            const next = beginBlock(state, {
+                arm: arm as "off" | "on",
+                label: optionValue(label),
+                startedAt: new Date().toISOString(),
+                fiveHour: snap ? fiveHourEdge(snap) : null,
+            });
+            if (next instanceof RoutingImpactStateError) fail(next.reason);
+            yield* Effect.promise(() => saveState(path, next));
+            const winPct = snap?.five_hour ? `${Math.round(snap.five_hour.utilization)}%` : "n/a";
+            console.log(`routing impact: started "${arm}" block (5h window now at ${winPct}).`);
+            console.log("work your block, then: ax routing impact end");
+        }),
+).pipe(Command.withDescription("Start a work block (snapshots the 5h plan window). --arm=off|on [--label]"));
+
+const endImpactCommand = Command.make(
+    "end",
+    {},
+    () =>
+        Effect.gen(function* () {
+            const path = defaultStatePath();
+            const state = yield* Effect.promise(() => loadState(path));
+            const snap = yield* snapshotQuota;
+            const next = endBlock(state, {
+                endedAt: new Date().toISOString(),
+                fiveHour: snap ? fiveHourEdge(snap) : null,
+            });
+            if (next instanceof RoutingImpactStateError) fail(next.reason);
+            yield* Effect.promise(() => saveState(path, next));
+            const winPct = snap?.five_hour ? `${Math.round(snap.five_hour.utilization)}%` : "n/a";
+            console.log(`routing impact: closed block (5h window now at ${winPct}).`);
+            console.log("run the other arm, then: ax routing impact report");
+        }),
+).pipe(Command.withDescription("Close the open work block (snapshots the 5h plan window)."));
+
+const reportImpactCommand = Command.make(
+    "report",
+    { share: Flag.boolean("share").pipe(Flag.withDefault(false)), json: jsonFlag },
+    ({ share, json }) =>
+        Effect.gen(function* () {
+            const path = defaultStatePath();
+            const state = yield* Effect.promise(() => loadState(path));
+            const done = completedBlocks(state);
+
+            // Best-effort DB enrichment: a query failure degrades to zeros rather
+            // than killing the receipt (the quota-window core is DB-free).
+            const inputs: BlockInput[] = [];
+            for (const b of done) {
+                const metrics = yield* fetchWindowMetrics(b.started_at, b.ended_at!).pipe(
+                    Effect.catch(() => Effect.succeed({ tokenCostUsd: 0, turns: 0 })),
+                );
+                inputs.push({
+                    arm: b.arm,
+                    label: b.label,
+                    started_at: b.started_at,
+                    ended_at: b.ended_at!,
+                    fiveHourStart: b.five_hour_start,
+                    fiveHourEnd: b.five_hour_end,
+                    tokenCostUsd: metrics.tokenCostUsd,
+                    dispatchCount: 0,
+                    inheritCount: 0,
+                    turns: metrics.turns,
+                });
+            }
+
+            const report = buildImpactReport(inputs);
+            if (json) {
+                console.log(prettyPrint(report));
+                return;
+            }
+            console.log(renderImpact(report, { share }));
+        }),
+).pipe(Command.withDescription("Render the off-vs-on receipt. [--share appends the ax plug] [--json]"));
+
+export const routingImpactCommand = Command.make("impact").pipe(
+    Command.withDescription(
+        "Routing A/B receipt: capture work blocks (begin/end) and compare routing off vs on per 5h plan window (report).",
+    ),
+    Command.withSubcommands([beginImpactCommand, endImpactCommand, reportImpactCommand]),
+);

--- a/apps/axctl/src/cli/commands/ax-routing.ts
+++ b/apps/axctl/src/cli/commands/ax-routing.ts
@@ -34,6 +34,7 @@ import {
 import { usd } from "../render.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionValue, parseCsvFlag } from "./shared.ts";
+import { routingImpactCommand } from "./ax-routing-impact.ts";
 
 const printProposals = (proposals: ReadonlyArray<TuneProposal>) => {
     console.log(
@@ -254,7 +255,7 @@ export const routingRootCommand = Command.make("routing").pipe(
     Command.withDescription(
         "Routing-table operations: tune (mine your dispatch history), compile (regenerate defaults), show.",
     ),
-    Command.withSubcommands([tuneCommand, compileCommand, showCommand]),
+    Command.withSubcommands([tuneCommand, compileCommand, showCommand, routingImpactCommand]),
 );
 
 export const axRoutingRuntime: RuntimeManifest = {
@@ -266,6 +267,10 @@ export const axRoutingRuntime: RuntimeManifest = {
                 tune: "db",
                 compile: "none",
                 show: "none",
+                // begin/end only need quota (they provide QuotaEnvLive themselves);
+                // report queries the graph. Keyed on argv[1]="impact", so the whole
+                // group shares one runtime - "db", consistent with ax analytics.
+                impact: "db",
             },
         },
         hidden: false,

--- a/apps/axctl/src/routing-impact/compute.test.ts
+++ b/apps/axctl/src/routing-impact/compute.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { buildImpactReport, type BlockInput } from "./compute.ts";
+
+// utilization is 0-100 (matches the quota endpoint), so a delta is points directly.
+const edge = (utilization: number, resets_at = "2026-06-19T20:00:00Z") => ({ utilization, resets_at });
+
+const block = (over: Partial<BlockInput> & { arm: BlockInput["arm"] }): BlockInput => ({
+    label: undefined,
+    started_at: "2026-06-19T10:00:00Z",
+    ended_at: "2026-06-19T15:00:00Z",
+    fiveHourStart: edge(10),
+    fiveHourEnd: edge(40),
+    tokenCostUsd: 100,
+    dispatchCount: 10,
+    inheritCount: 5,
+    turns: 300,
+    ...over,
+});
+
+describe("buildImpactReport - single block", () => {
+    test("computes window pp consumed, inherit %, and work-per-window", () => {
+        const { blocks } = buildImpactReport([block({ arm: "off" })]);
+        const b = blocks[0]!;
+        expect(b.fiveHourPpConsumed).toBe(30); // 40 - 10
+        expect(b.inheritPct).toBe(50); // 5/10
+        expect(b.workPerWindowPp).toBe(10); // 300 turns / 30 pp
+        expect(b.windowReset).toBe(false);
+        expect(b.durationMin).toBe(300);
+    });
+
+    test("flags a window reset (resets_at changed) and omits the delta", () => {
+        const { blocks, notes } = buildImpactReport([
+            block({
+                arm: "off",
+                fiveHourStart: edge(80, "2026-06-19T20:00:00Z"),
+                fiveHourEnd: edge(10, "2026-06-20T01:00:00Z"),
+            }),
+        ]);
+        expect(blocks[0]!.windowReset).toBe(true);
+        expect(blocks[0]!.fiveHourPpConsumed).toBeNull();
+        expect(blocks[0]!.workPerWindowPp).toBeNull();
+        expect(notes.some((n) => n.includes("reset"))).toBe(true);
+    });
+
+    test("flags a reset when utilization drops without a resets_at change", () => {
+        const { blocks } = buildImpactReport([
+            block({ arm: "off", fiveHourStart: edge(50), fiveHourEnd: edge(20) }),
+        ]);
+        expect(blocks[0]!.windowReset).toBe(true);
+        expect(blocks[0]!.fiveHourPpConsumed).toBeNull();
+    });
+
+    test("null quota edges → no window delta, note emitted", () => {
+        const { blocks, notes } = buildImpactReport([
+            block({ arm: "off", fiveHourStart: null, fiveHourEnd: null }),
+        ]);
+        expect(blocks[0]!.fiveHourPpConsumed).toBeNull();
+        expect(blocks[0]!.windowReset).toBe(false);
+        expect(notes.some((n) => n.includes("unavailable"))).toBe(true);
+    });
+
+    test("zero dispatches → inheritPct null (no divide-by-zero)", () => {
+        const { blocks } = buildImpactReport([block({ arm: "off", dispatchCount: 0, inheritCount: 0 })]);
+        expect(blocks[0]!.inheritPct).toBeNull();
+    });
+
+    test("zero window consumed → workPerWindowPp null (no divide-by-zero)", () => {
+        const { blocks } = buildImpactReport([
+            block({ arm: "off", fiveHourStart: edge(30), fiveHourEnd: edge(30) }),
+        ]);
+        expect(blocks[0]!.fiveHourPpConsumed).toBe(0);
+        expect(blocks[0]!.workPerWindowPp).toBeNull();
+    });
+});
+
+describe("buildImpactReport - off vs on comparison", () => {
+    test("computes the work-per-window ratio, cost ratio, inherit drop", () => {
+        // off: 300 turns over 30pp → 10 work/pp, $100, 50% inherit
+        // on:  300 turns over 15pp → 20 work/pp, $40,  10% inherit
+        const { comparison } = buildImpactReport([
+            block({ arm: "off" }),
+            block({
+                arm: "on",
+                fiveHourStart: edge(10),
+                fiveHourEnd: edge(25), // 15pp
+                tokenCostUsd: 40,
+                dispatchCount: 10,
+                inheritCount: 1,
+                turns: 300,
+            }),
+        ]);
+        expect(comparison).not.toBeNull();
+        expect(comparison!.workPerWindowRatio).toBe(2); // 20/10 → 2x more work per window
+        expect(comparison!.costRatio).toBe(2.5); // 100/40
+        expect(comparison!.inheritPctDrop).toBe(40); // 50 - 10
+    });
+
+    test("no comparison with only one arm", () => {
+        const { comparison } = buildImpactReport([block({ arm: "off" })]);
+        expect(comparison).toBeNull();
+    });
+
+    test("comparison ratio null when one side had a window reset", () => {
+        const { comparison } = buildImpactReport([
+            block({ arm: "off", fiveHourStart: edge(90), fiveHourEnd: edge(10) }), // reset
+            block({ arm: "on" }),
+        ]);
+        expect(comparison!.workPerWindowRatio).toBeNull();
+        // cost ratio still computable
+        expect(comparison!.costRatio).not.toBeNull();
+    });
+
+    test("multiple blocks per arm → no comparison, note emitted", () => {
+        const { comparison, notes } = buildImpactReport([
+            block({ arm: "off" }),
+            block({ arm: "off" }),
+            block({ arm: "on" }),
+        ]);
+        expect(comparison).toBeNull();
+        expect(notes.some((n) => n.includes("multiple blocks"))).toBe(true);
+    });
+});

--- a/apps/axctl/src/routing-impact/compute.ts
+++ b/apps/axctl/src/routing-impact/compute.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure compute for `ax routing impact` - the routing-off vs routing-on receipt,
+ * measured per 5-hour plan window (issue #575).
+ *
+ * On a fixed plan the unit that matters is the 5h rate-limit window, not dollars
+ * (you don't pay per token). We capture an `ax quota` snapshot at the start and
+ * end of each work block and diff the 5h-window utilization. Token-equiv $ and
+ * the dispatch inherit rate ride along as secondary evidence.
+ *
+ * Correctness trap: the 5h window RESETS every 5h. If a block straddles a reset,
+ * `end.utilization < start.utilization` (or `resets_at` changed) and the delta is
+ * not a clean single-window consumption - we flag it `windowReset` and fall back
+ * to token-$ rather than printing a bogus/negative number.
+ *
+ * No DB, no Effect here - just data in, card out, so it's exhaustively testable.
+ */
+
+export type Arm = "off" | "on";
+
+/** A captured window edge: utilization (0-100, matching the quota endpoint) +
+ *  the reset boundary it belongs to. */
+export interface WindowEdge {
+    readonly utilization: number;
+    readonly resets_at: string;
+}
+
+/** One completed work block (filled in by begin/end against the state file). */
+export interface BlockInput {
+    readonly arm: Arm;
+    readonly label?: string | undefined;
+    readonly started_at: string;
+    readonly ended_at: string;
+    /** 5h-window edge at block start / end (null if quota was unavailable). */
+    readonly fiveHourStart: WindowEdge | null;
+    readonly fiveHourEnd: WindowEdge | null;
+    /** Token-equivalent cost summed over the block window (USD). */
+    readonly tokenCostUsd: number;
+    /** Subagent dispatches that started in the block window. */
+    readonly dispatchCount: number;
+    /** Of those, how many ran on an inherited (unrouted) model. */
+    readonly inheritCount: number;
+    /** Work-volume proxy: assistant turns in the block window. */
+    readonly turns: number;
+}
+
+export interface BlockResult {
+    readonly arm: Arm;
+    readonly label?: string | undefined;
+    readonly durationMin: number;
+    /** Percentage POINTS of the 5h window consumed (end-start, ×100). Null when
+     *  quota was missing or the window reset mid-block (see windowReset). */
+    readonly fiveHourPpConsumed: number | null;
+    readonly windowReset: boolean;
+    readonly tokenCostUsd: number;
+    readonly inheritPct: number | null;
+    readonly dispatchCount: number;
+    readonly turns: number;
+    /** Work per percentage-point of 5h window (turns / pp). Null when pp is
+     *  unavailable or zero. The normalizer for "more work per window". */
+    readonly workPerWindowPp: number | null;
+}
+
+export interface ImpactReport {
+    readonly blocks: ReadonlyArray<BlockResult>;
+    /** Present only when exactly one off and one on block are complete. */
+    readonly comparison: {
+        /** on.workPerWindowPp / off.workPerWindowPp - the "1.Nx more work per
+         *  window" headline. Null when either side lacks a clean window delta. */
+        readonly workPerWindowRatio: number | null;
+        /** off.tokenCostUsd / on.tokenCostUsd (token-equiv $ saved factor). */
+        readonly costRatio: number | null;
+        /** inherit-rate change in points (off - on); positive = routing helped. */
+        readonly inheritPctDrop: number | null;
+    } | null;
+    readonly notes: ReadonlyArray<string>;
+}
+
+const minutesBetween = (a: string, b: string): number =>
+    Math.max(0, (new Date(b).getTime() - new Date(a).getTime()) / 60_000);
+
+const round = (n: number, dp = 2): number => {
+    const f = 10 ** dp;
+    return Math.round(n * f) / f;
+};
+
+/** Did the 5h window roll over between the two edges? */
+const didReset = (start: WindowEdge, end: WindowEdge): boolean =>
+    end.resets_at !== start.resets_at || end.utilization < start.utilization;
+
+const resolveBlock = (b: BlockInput): BlockResult => {
+    const durationMin = round(minutesBetween(b.started_at, b.ended_at), 1);
+
+    let fiveHourPpConsumed: number | null = null;
+    let windowReset = false;
+    if (b.fiveHourStart && b.fiveHourEnd) {
+        if (didReset(b.fiveHourStart, b.fiveHourEnd)) {
+            windowReset = true;
+        } else {
+            // utilization is already 0-100, so the delta is already in points.
+            fiveHourPpConsumed = round(b.fiveHourEnd.utilization - b.fiveHourStart.utilization, 2);
+        }
+    }
+
+    const inheritPct = b.dispatchCount > 0 ? round((b.inheritCount / b.dispatchCount) * 100, 1) : null;
+
+    const workPerWindowPp =
+        fiveHourPpConsumed !== null && fiveHourPpConsumed > 0
+            ? round(b.turns / fiveHourPpConsumed, 2)
+            : null;
+
+    return {
+        arm: b.arm,
+        label: b.label,
+        durationMin,
+        fiveHourPpConsumed,
+        windowReset,
+        tokenCostUsd: round(b.tokenCostUsd, 2),
+        inheritPct,
+        dispatchCount: b.dispatchCount,
+        turns: b.turns,
+        workPerWindowPp,
+    };
+};
+
+/** Build the off-vs-on impact report from completed blocks. Pure. */
+export const buildImpactReport = (blocks: ReadonlyArray<BlockInput>): ImpactReport => {
+    const results = blocks.map(resolveBlock);
+    const notes: string[] = [];
+
+    if (results.some((r) => r.windowReset)) {
+        notes.push(
+            "a block straddled a 5h-window reset - its window delta is omitted; compare token-$ instead.",
+        );
+    }
+    if (results.some((r) => r.fiveHourPpConsumed === null && !r.windowReset)) {
+        notes.push("quota was unavailable for a block - window delta omitted for it.");
+    }
+
+    // Comparison only when we have exactly one clean off and one clean on block.
+    const off = results.filter((r) => r.arm === "off");
+    const on = results.filter((r) => r.arm === "on");
+    let comparison: ImpactReport["comparison"] = null;
+    if (off.length === 1 && on.length === 1) {
+        const o = off[0]!;
+        const n = on[0]!;
+        comparison = {
+            workPerWindowRatio:
+                o.workPerWindowPp !== null && n.workPerWindowPp !== null && o.workPerWindowPp > 0
+                    ? round(n.workPerWindowPp / o.workPerWindowPp, 2)
+                    : null,
+            costRatio: n.tokenCostUsd > 0 ? round(o.tokenCostUsd / n.tokenCostUsd, 2) : null,
+            inheritPctDrop:
+                o.inheritPct !== null && n.inheritPct !== null
+                    ? round(o.inheritPct - n.inheritPct, 1)
+                    : null,
+        };
+        notes.push("matched work across the two blocks is your responsibility - the ratio assumes it.");
+    } else if (off.length > 1 || on.length > 1) {
+        notes.push("multiple blocks per arm - showing each; comparison needs exactly one off + one on.");
+    }
+
+    return { blocks: results, comparison, notes };
+};

--- a/apps/axctl/src/routing-impact/format.ts
+++ b/apps/axctl/src/routing-impact/format.ts
@@ -1,0 +1,64 @@
+/**
+ * Render the `ax routing impact` receipt - the routing-off vs routing-on card,
+ * headlined on 5h plan-window utilization. Pure string-building, so it's tested
+ * without IO. The shareable text card carries the ax attribution plug.
+ */
+import { withAxAttribution } from "@ax/lib/shared/attribution";
+import type { ImpactReport, BlockResult } from "./compute.ts";
+
+const armLabel = (b: BlockResult): string =>
+    `${b.arm === "off" ? "routing OFF" : "routing ON "}${b.label ? ` (${b.label})` : ""}`;
+
+const pp = (n: number | null): string => (n === null ? "  -  " : `${n.toFixed(1)}pp`);
+const pct = (n: number | null): string => (n === null ? " - " : `${n.toFixed(0)}%`);
+const usd = (n: number): string => `$${n.toFixed(2)}`;
+
+const blockLine = (b: BlockResult): string => {
+    const win = b.windowReset ? "window reset" : pp(b.fiveHourPpConsumed);
+    return [
+        `  ${armLabel(b).padEnd(22)}`,
+        `5h window: ${win.padStart(11)}`,
+        `tokens: ${usd(b.tokenCostUsd).padStart(9)}`,
+        `inherit: ${pct(b.inheritPct).padStart(4)}`,
+        `turns: ${String(b.turns).padStart(4)}`,
+    ].join("  ");
+};
+
+/** Human card. `share: true` appends the ax attribution plug (for posting). */
+export const renderImpact = (report: ImpactReport, opts: { share?: boolean } = {}): string => {
+    const lines: string[] = [];
+    lines.push("routing impact - same work, routing off vs on (per 5h plan window)");
+    lines.push("");
+    if (report.blocks.length === 0) {
+        lines.push("  no completed blocks yet.");
+        lines.push("  run: ax routing impact begin --arm=off   (work a block)   ax routing impact end");
+        lines.push("  then the same with --arm=on, then: ax routing impact report");
+        return lines.join("\n");
+    }
+
+    for (const b of report.blocks) lines.push(blockLine(b));
+
+    const c = report.comparison;
+    if (c) {
+        lines.push("");
+        if (c.workPerWindowRatio !== null) {
+            lines.push(
+                `  ▸ ${c.workPerWindowRatio.toFixed(2)}× more work per 5h window with routing on`,
+            );
+        }
+        if (c.costRatio !== null) {
+            lines.push(`  ▸ ${c.costRatio.toFixed(2)}× cheaper in token-equiv $ (same work)`);
+        }
+        if (c.inheritPctDrop !== null) {
+            lines.push(`  ▸ inherit (frontier) rate down ${c.inheritPctDrop.toFixed(0)} points`);
+        }
+    }
+
+    if (report.notes.length > 0) {
+        lines.push("");
+        for (const n of report.notes) lines.push(`  note: ${n}`);
+    }
+
+    const out = lines.join("\n");
+    return opts.share ? withAxAttribution(out) : out;
+};

--- a/apps/axctl/src/routing-impact/io.ts
+++ b/apps/axctl/src/routing-impact/io.ts
@@ -1,0 +1,69 @@
+/**
+ * State + DB IO for `ax routing impact`. State lives at
+ * `~/.ax/routing-impact.json` and is read/written with Bun.file/Bun.write (no
+ * node:fs, no Effect FS layer) so begin/end stay light. The windowed metrics
+ * come from the same SurrealDB the rest of ax analytics use.
+ */
+import { Effect, Option } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { prettyPrint } from "@ax/lib/json";
+import { decodeState, EMPTY_STATE, type RoutingImpactState } from "./state.ts";
+
+export const defaultStatePath = (): string =>
+    `${process.env.HOME ?? "."}/.ax/routing-impact.json`;
+
+/** Load state; a missing/corrupt file resets to EMPTY_STATE (fail-open). */
+export const loadState = async (path: string): Promise<RoutingImpactState> => {
+    const file = Bun.file(path);
+    if (!(await file.exists())) return EMPTY_STATE;
+    try {
+        const raw: unknown = JSON.parse(await file.text());
+        const decoded = decodeState(raw);
+        return Option.isSome(decoded) ? decoded.value : EMPTY_STATE;
+    } catch {
+        return EMPTY_STATE;
+    }
+};
+
+export const saveState = async (path: string, state: RoutingImpactState): Promise<void> => {
+    await Bun.write(path, `${prettyPrint(state)}\n`, { createPath: true });
+};
+
+// ---------------------------------------------------------------------------
+// Windowed metrics (token-equiv cost + work-volume proxy)
+// ---------------------------------------------------------------------------
+
+export interface WindowMetrics {
+    readonly tokenCostUsd: number;
+    /** assistant turns in the window - the work-volume proxy. */
+    readonly turns: number;
+}
+
+/**
+ * Sum token-equivalent cost and count assistant turns in [startIso, endIso].
+ * Datetime bindings are JS Date objects (SurrealDB SDK requirement). GROUP ALL
+ * makes the aggregates return a single row.
+ */
+export const fetchWindowMetrics = (
+    startIso: string,
+    endIso: string,
+): Effect.Effect<WindowMetrics, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const bindings = { start: new Date(startIso), end: new Date(endIso) };
+
+        const [costRows] = yield* db.query<[ReadonlyArray<{ c: number | null }>]>(
+            "SELECT math::sum(estimated_cost_usd) AS c FROM session_token_usage WHERE ts > $start AND ts <= $end GROUP ALL;",
+            bindings,
+        );
+        const [turnRows] = yield* db.query<[ReadonlyArray<{ n: number | null }>]>(
+            "SELECT count() AS n FROM turn WHERE role = 'assistant' AND ts > $start AND ts <= $end GROUP ALL;",
+            bindings,
+        );
+
+        return {
+            tokenCostUsd: Number(costRows?.[0]?.c ?? 0),
+            turns: Number(turnRows?.[0]?.n ?? 0),
+        };
+    });

--- a/apps/axctl/src/routing-impact/state.test.ts
+++ b/apps/axctl/src/routing-impact/state.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+    EMPTY_STATE,
+    beginBlock,
+    endBlock,
+    openBlock,
+    completedBlocks,
+    RoutingImpactStateError,
+    type RoutingImpactState,
+} from "./state.ts";
+
+const edge = { utilization: 0.2, resets_at: "2026-06-19T20:00:00Z" };
+
+describe("routing-impact state transitions", () => {
+    test("begin appends an open block", () => {
+        const s = beginBlock(EMPTY_STATE, { arm: "off", startedAt: "t0", fiveHour: edge });
+        expect(s).not.toBeInstanceOf(RoutingImpactStateError);
+        const state = s as RoutingImpactState;
+        expect(state.blocks).toHaveLength(1);
+        expect(openBlock(state)?.arm).toBe("off");
+        expect(openBlock(state)?.ended_at).toBeNull();
+    });
+
+    test("begin twice without end fails", () => {
+        const s1 = beginBlock(EMPTY_STATE, { arm: "off", startedAt: "t0", fiveHour: edge }) as RoutingImpactState;
+        const s2 = beginBlock(s1, { arm: "on", startedAt: "t1", fiveHour: edge });
+        expect(s2).toBeInstanceOf(RoutingImpactStateError);
+        expect((s2 as RoutingImpactStateError).reason).toContain("still running");
+    });
+
+    test("end closes the open block with the end edge", () => {
+        const s1 = beginBlock(EMPTY_STATE, { arm: "off", startedAt: "t0", fiveHour: edge }) as RoutingImpactState;
+        const endEdge = { utilization: 0.5, resets_at: "2026-06-19T20:00:00Z" };
+        const s2 = endBlock(s1, { endedAt: "t1", fiveHour: endEdge }) as RoutingImpactState;
+        expect(openBlock(s2)).toBeNull();
+        expect(completedBlocks(s2)).toHaveLength(1);
+        expect(completedBlocks(s2)[0]!.five_hour_end).toEqual(endEdge);
+        expect(completedBlocks(s2)[0]!.ended_at).toBe("t1");
+    });
+
+    test("end with no open block fails", () => {
+        const s = endBlock(EMPTY_STATE, { endedAt: "t1", fiveHour: edge });
+        expect(s).toBeInstanceOf(RoutingImpactStateError);
+        expect((s as RoutingImpactStateError).reason).toContain("no open block");
+    });
+
+    test("full off→on cycle yields two completed blocks", () => {
+        let s = beginBlock(EMPTY_STATE, { arm: "off", startedAt: "a", fiveHour: edge }) as RoutingImpactState;
+        s = endBlock(s, { endedAt: "b", fiveHour: edge }) as RoutingImpactState;
+        s = beginBlock(s, { arm: "on", startedAt: "c", fiveHour: edge }) as RoutingImpactState;
+        s = endBlock(s, { endedAt: "d", fiveHour: edge }) as RoutingImpactState;
+        expect(completedBlocks(s)).toHaveLength(2);
+        expect(completedBlocks(s).map((b) => b.arm)).toEqual(["off", "on"]);
+    });
+
+    test("label is carried when provided", () => {
+        const s = beginBlock(EMPTY_STATE, { arm: "on", label: "tuesday", startedAt: "t0", fiveHour: edge }) as RoutingImpactState;
+        expect(openBlock(s)?.label).toBe("tuesday");
+    });
+
+    test("null quota edge is allowed (quota unavailable at capture)", () => {
+        const s = beginBlock(EMPTY_STATE, { arm: "off", startedAt: "t0", fiveHour: null }) as RoutingImpactState;
+        expect(openBlock(s)?.five_hour_start).toBeNull();
+    });
+});

--- a/apps/axctl/src/routing-impact/state.ts
+++ b/apps/axctl/src/routing-impact/state.ts
@@ -1,0 +1,90 @@
+/**
+ * Persisted state for `ax routing impact` (issue #575): the captured work blocks
+ * the off-vs-on receipt is built from. Lives at `~/.ax/routing-impact.json`
+ * (sibling of routing-table.json / quota-cache.json). Pure transitions here;
+ * the CLT does the IO.
+ */
+import { Schema } from "effect";
+import type { Arm, WindowEdge } from "./compute.ts";
+
+export const WindowEdgeSchema = Schema.Struct({
+    utilization: Schema.Number,
+    resets_at: Schema.String,
+});
+
+/** One captured block. Open while `ended_at` is null (between begin and end). */
+export const BlockSchema = Schema.Struct({
+    arm: Schema.Literals(["off", "on"]),
+    label: Schema.optional(Schema.String),
+    started_at: Schema.String,
+    ended_at: Schema.NullOr(Schema.String),
+    five_hour_start: Schema.NullOr(WindowEdgeSchema),
+    five_hour_end: Schema.NullOr(WindowEdgeSchema),
+});
+export type Block = typeof BlockSchema.Type;
+
+export const RoutingImpactStateSchema = Schema.Struct({
+    v: Schema.Literal(1),
+    blocks: Schema.Array(BlockSchema),
+});
+export type RoutingImpactState = typeof RoutingImpactStateSchema.Type;
+
+export const EMPTY_STATE: RoutingImpactState = { v: 1, blocks: [] };
+
+export const decodeState = Schema.decodeUnknownOption(RoutingImpactStateSchema);
+
+/** The currently-open block (begin without a matching end), or null. */
+export const openBlock = (state: RoutingImpactState): Block | null =>
+    state.blocks.find((b) => b.ended_at === null) ?? null;
+
+export class RoutingImpactStateError extends Schema.TaggedErrorClass<RoutingImpactStateError>(
+    "RoutingImpactStateError",
+)("RoutingImpactStateError", {
+    reason: Schema.String,
+}) {}
+
+/**
+ * Pure: append a new open block. Fails if one is already open (you must `end`
+ * the current block before starting another).
+ */
+export const beginBlock = (
+    state: RoutingImpactState,
+    args: { arm: Arm; label?: string | undefined; startedAt: string; fiveHour: WindowEdge | null },
+): RoutingImpactState | RoutingImpactStateError => {
+    const open = openBlock(state);
+    if (open) {
+        return new RoutingImpactStateError({
+            reason: `a "${open.arm}" block opened at ${open.started_at} is still running - run \`ax routing impact end\` first`,
+        });
+    }
+    const block: Block = {
+        arm: args.arm,
+        ...(args.label !== undefined ? { label: args.label } : {}),
+        started_at: args.startedAt,
+        ended_at: null,
+        five_hour_start: args.fiveHour,
+        five_hour_end: null,
+    };
+    return { v: 1, blocks: [...state.blocks, block] };
+};
+
+/** Pure: close the open block. Fails if none is open. */
+export const endBlock = (
+    state: RoutingImpactState,
+    args: { endedAt: string; fiveHour: WindowEdge | null },
+): RoutingImpactState | RoutingImpactStateError => {
+    const open = openBlock(state);
+    if (!open) {
+        return new RoutingImpactStateError({
+            reason: "no open block - run `ax routing impact begin --arm=off|on` first",
+        });
+    }
+    const blocks = state.blocks.map((b) =>
+        b === open ? { ...b, ended_at: args.endedAt, five_hour_end: args.fiveHour } : b,
+    );
+    return { v: 1, blocks };
+};
+
+/** Completed blocks only (both edges of the timestamp pair present). */
+export const completedBlocks = (state: RoutingImpactState): ReadonlyArray<Block> =>
+    state.blocks.filter((b): b is Block & { ended_at: string } => b.ended_at !== null);

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -33,6 +33,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax routing tune` - mine the user's own dispatch history for new routing classes; judgment work is never auto-routed (vetted via --emit-brief agent backtest)
 - `ax routing compile` - regenerate the routing table that drives the route-dispatch hook and the efficient-dispatch skill, preserving user-mined classes (`ax dispatches compile-routing` is an alias)
 - `ax routing show` - effective routing table with class origins
+- `ax routing impact begin|end|report` - forward A/B receipt: snapshot the 5h plan window at the start/end of a routing-off block and a routing-on block, then `report` shows work-per-window off vs on (the "1.Nx more work per $200 window" proof). `report --share` appends the ax plug
 - `efficient-dispatch` skill - orchestration pattern: the main model keeps judgment and review, mechanical dispatches carry an explicit cheaper model
 - `route-dispatch` hook - deterministic dispatch-time nudge when a mechanical dispatch forgets an explicit model
 - `ax costs summary | for --session/--query/--commit/--branch` - what any session, feature, or branch cost in tokens and USD

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,6 +45,9 @@ axctl dispatches [--candidates] [--economy] # subagent dispatch routing analytic
 axctl routing tune [--dry-run|--emit-brief] # mine YOUR dispatch history for new routing classes
 axctl routing compile                       # regenerate ~/.ax/hooks/routing-table.json (user classes preserved)
 axctl routing show                          # effective routing table with class origins
+axctl routing impact begin --arm=off|on     # start an A/B work block (snapshots the 5h plan window)
+axctl routing impact end                     # close the open block
+axctl routing impact report [--share]       # routing off-vs-on receipt, per 5h plan window
 axctl profile show [--window=N] [--no-cost] # local profile: stats + rig + taste from the graph
 axctl wrapped <generate|publish>            # agent-authored Wrapped recap cards for the dashboard landing
 axctl profile publish [--if-stale=H] [--yes] [--skip-registration]


### PR DESCRIPTION
Closes #575. The receipt the feedback asked for: **"a normal 5h block cost me X; the same work with routing cost me Y."**

On a fixed $200 plan you don't pay per token — the unit that matters is the **5-hour rate-limit window**, and ax is one of the few tools with the plan meter (`ax quota`). This makes that the headline.

## Flow (forward A/B capture)
Quota is live-only (no historical timeline), so we capture forward:
```
ax routing impact begin --arm=off    # snapshots the 5h window, marks t0
# ...work a ~5h block...
ax routing impact end                # snapshots again, closes the block
# ...repeat with --arm=on, matched work...
ax routing impact report [--share]   # off-vs-on card
```
Report headline: **work per 5h-window-point, off vs on** ("1.N× more work per window"). Token-equiv $ + inherit drop are secondary.

## Honest by construction
- **Window resets mid-block** (every 5h) are detected (`resets_at` change or utilization drop) and the delta omitted — never a bogus negative; falls back to token-$.
- **utilization is 0–100** (matches the quota endpoint) — I had it as a 0–1 fraction; dogfood caught it ("300%"), fixed across compute + print + tests.
- **Matched work** across blocks is the operator's responsibility (stated in the card).
- **route-dispatch is advisory**, so the real A/B variable is routing *practice* (hook nudge + explicit `model:`), not "hook on/off" — framed truthfully.

## Design
- Pure compute + state in `apps/axctl/src/routing-impact/` — DB-free, **17 tests** (window math, reset detection, divide-by-zero guards, off-vs-on ratio, state transitions).
- DB enrichment (token-equiv cost + assistant-turns-in-window as the work proxy) is **best-effort** — a query failure degrades to zeros, the quota-window core still renders.
- Nested under `ax routing` (runtime `db`); `begin`/`end` provide `QuotaEnvLive` themselves.
- `report --share` appends the ax attribution plug (shareable artifact).

## Verified
- Dogfooded begin→end→begin→end→report live (real quota capture, error path, `--json`); state at `~/.ax/routing-impact.json`.
- 643 tests pass, typecheck clean, `check:no-node-fs` clean.

## Follow-ups (tracked)
- inherit-rate-in-window enrichment (the complex `tool_call` input_json join) — deferred
- a rendered before/after card for the studio/marketing receipt

Pairs with the interim "leak" receipt (existing-data numbers) for the Twitter lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)