### PR TITLE
feat(studio): expose session deeplinks in session outputs (#563)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,19 @@ page shows only when no studio is bundled at all. The hosted
 `ax.necmttn.com/studio/` stays a **mock-fixtures demo** (no live daemon); the
 CLI banner points only at the local URL via `serveStudioUrl` (`banner.ts`).
 
+**Session deeplinks (#563)** - the stable Studio session route is
+`http://localhost:<port>/sessions/<bare-session-id>` (`studioSessionUrl` in
+`apps/axctl/src/nav/next-links.ts` is the single source of the shape; agents
+must NOT reconstruct it from frontend route code). Session-oriented outputs
+carry it as a `NavLink` `url` transport (the third transport beside `call`/`cmd`,
+group `navigate`): `ax sessions show` (top-level), `ax sessions here|around|near`
++ `ax recall` (per row/hit), and the matching MCP tools (`session_show`,
+`sessions_around`, `recall`). Port + liveness come from `resolveStudioTarget`
+(`serve-instance.ts`) - it reads the serve pidfile + signal-0s the pid (NO
+network probe, so common queries pay no round-trip); when no daemon is up it
+emits the default-port URL and the link copy nudges `ax serve`. Works for normal
+and subagent sessions (the route renders both).
+
 ### Live ingest in the dashboard
 
 - `ax serve` → `POST /api/ingest` (or the **Live** tab) forks `runIngest` (same pipeline as CLI) onto the server runtime. Progress flows as `IngestStreamEvent`s through the `IngestStreamBus` seam (`apps/axctl/src/dashboard/ingest-stream.ts`) to a per-run Durable Stream `ingest:<runId>`; the browser subscribes from offset `-1`, so refresh/reconnect mid-run rehydrates. Exactly one terminal `run_finished` event guaranteed. The bus seam lets the Bun backing swap for a hosted backend later untouched.

--- a/apps/axctl/src/cli/commands/recall.ts
+++ b/apps/axctl/src/cli/commands/recall.ts
@@ -11,6 +11,7 @@ import {
 } from "../../nav/next-links.ts";
 import { printNextLinks } from "../next-format.ts";
 import { fetchRecall, normalizeRecallParams, resolveRecallSources, type RecallSource, type RecallScope } from "../../dashboard/recall.ts";
+import { resolveStudioTarget } from "../../dashboard/serve-instance.ts";
 import { resolvePwdRepository } from "../../pwd.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, parseCsvFlag } from "./shared.ts";
@@ -259,8 +260,10 @@ const cmdRecall = (opts: RecallCliOpts) =>
             scope,
             ...(types !== null ? { types } : {}),
         }));
+        const studio = yield* Effect.promise(() => resolveStudioTarget());
         const { hits, next } = buildRecallNext(result, {
             requestedSources: resolveRecallSources(sources),
+            studio,
         });
         if (opts.json) {
             console.log(prettyPrint({ ...result, hits, next }));

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -38,6 +38,7 @@ import { fetchSessionChurnSummary, formatSessionChurnSummary } from "../../metri
 import { fetchSessionMetrics } from "../../metrics/session-metrics-query.ts";
 import { formatSessionMetrics, SESSION_METRICS_LEGEND } from "../../metrics/util.ts";
 import { buildSessionsNext, buildSessionShowNext } from "../../nav/next-links.ts";
+import { resolveStudioTarget } from "../../dashboard/serve-instance.ts";
 import { resolvePwdRepository, type PwdResolution } from "../../pwd.ts";
 import { printNextLinks } from "../next-format.ts";
 import { catchDbErrorAndExit, stderrExit, wantsJsonFlag } from "../output.ts";
@@ -222,7 +223,8 @@ const cmdSessionsHere = (input: SessionsHereInput) =>
             : allRows.filter((r) => r.source !== "claude-subagent");
         const hiddenSubagents = allRows.length - visible.length;
         const rows = limit === null ? visible : visible.slice(0, limit);
-        const { sessions, next } = buildSessionsNext(rows);
+        const studio = yield* Effect.promise(() => resolveStudioTarget());
+        const { sessions, next } = buildSessionsNext(rows, { studio });
 
         if (json) {
             console.log(prettyPrint({ sessions, next }));
@@ -281,10 +283,12 @@ const cmdSessionsAround = (input: {
         const rows = yield* listSessionsAround(
             normalizeSessionsAroundOpts({ date, days, project }),
         );
+        const studio = yield* Effect.promise(() => resolveStudioTarget());
         const { sessions, next } = buildSessionsNext(rows, {
             date: positional,
             days,
             project,
+            studio,
         });
 
         if (json) {
@@ -345,7 +349,8 @@ const cmdSessionsNear = (input: {
         }
 
         const rows = yield* listSessionsNear({ from, to, repositoryKey });
-        const { sessions, next } = buildSessionsNext(rows);
+        const studio = yield* Effect.promise(() => resolveStudioTarget());
+        const { sessions, next } = buildSessionsNext(rows, { studio });
 
         if (json) {
             console.log(prettyPrint({ sessions, next }));
@@ -455,7 +460,8 @@ const cmdSessionShow = (input: {
             catchDbErrorAndExit("axctl session show"),
         );
 
-        const next = buildSessionShowNext(payload);
+        const studio = yield* Effect.promise(() => resolveStudioTarget());
+        const next = buildSessionShowNext(payload, studio);
 
         if (useJson) {
             console.log(renderSessionJson(payload, { metrics, next }));

--- a/apps/axctl/src/cli/next-format.test.ts
+++ b/apps/axctl/src/cli/next-format.test.ts
@@ -25,6 +25,26 @@ describe("renderNextFooter", () => {
         expect(out).toBe("");
     });
 
+    test("renders url-only links (the Studio deeplink transport)", () => {
+        const out = renderNextFooter([
+            {
+                description: "Open this session in ax Studio",
+                url: "http://localhost:1738/sessions/abc",
+                ui: { group: "navigate" },
+            },
+        ]);
+        expect(out).toContain("http://localhost:1738/sessions/abc");
+        expect(out).toContain("# Open this session in ax Studio");
+    });
+
+    test("cmd wins over url when a link carries both", () => {
+        const out = renderNextFooter([
+            { description: "dual", cmd: "ax sessions show abc", url: "http://x/y" },
+        ]);
+        expect(out).toContain("ax sessions show abc");
+        expect(out).not.toContain("http://x/y");
+    });
+
     test("sorts by priority desc and caps at 4", () => {
         const links = [1, 2, 3, 4, 5].map((p) =>
             link({ cmd: `cmd-${p}`, ui: { priority: p } }),

--- a/apps/axctl/src/cli/next-format.ts
+++ b/apps/axctl/src/cli/next-format.ts
@@ -1,11 +1,12 @@
 /**
  * CLI rendering for NavLinks - the `next:` footer.
  *
- * Text output shows `cmd` links only (a terminal user can't paste an MCP
- * call); priority-sorted, capped at 4, with the description as a dim ANSI
- * comment after the command - matching the inline-ANSI convention used by
- * cmdRecall / formatSessionsTable. `--json` output carries the full NavLink
- * objects instead, so agents driving the CLI get both transports.
+ * Text output shows links with a `cmd` or `url` payload (a terminal user
+ * can't paste an MCP call, but can run a command or open a URL);
+ * priority-sorted, capped at 4, with the description as a dim ANSI comment
+ * after the payload - matching the inline-ANSI convention used by cmdRecall /
+ * formatSessionsTable. `--json` output carries the full NavLink objects
+ * instead, so agents driving the CLI get every transport.
  */
 import type { NavLink } from "@ax/lib/shared/nav-link";
 import { sortNavLinks } from "@ax/lib/shared/nav-link";
@@ -15,20 +16,22 @@ const DIM = "\x1b[2m";
 const RESET = "\x1b[0m";
 
 /**
- * Render the `next:` footer. Returns "" when no link has a `cmd` - callers
- * can append unconditionally.
+ * Render the `next:` footer. Returns "" when no link has a `cmd` or `url`
+ * payload - callers can append unconditionally. A `cmd` wins over `url` when
+ * both are present (a runnable command is the richer terminal affordance).
  */
 export const renderNextFooter = (
     links: ReadonlyArray<NavLink>,
 ): string => {
-    const cmds = sortNavLinks(links)
-        .filter((l): l is NavLink & { cmd: string } => typeof l.cmd === "string")
+    const rows = sortNavLinks(links)
+        .map((l) => ({ link: l, payload: l.cmd ?? l.url }))
+        .filter((r): r is { link: NavLink; payload: string } => typeof r.payload === "string")
         .slice(0, MAX_FOOTER_LINKS);
-    if (cmds.length === 0) return "";
+    if (rows.length === 0) return "";
 
-    const width = Math.max(...cmds.map((l) => l.cmd.length));
-    const lines = cmds.map(
-        (l) => `  ${l.cmd.padEnd(width)}   ${DIM}# ${l.description}${RESET}`,
+    const width = Math.max(...rows.map((r) => r.payload.length));
+    const lines = rows.map(
+        (r) => `  ${r.payload.padEnd(width)}   ${DIM}# ${r.link.description}${RESET}`,
     );
     return `\nnext:\n${lines.join("\n")}`;
 };

--- a/apps/axctl/src/dashboard/serve-instance.test.ts
+++ b/apps/axctl/src/dashboard/serve-instance.test.ts
@@ -7,9 +7,11 @@ import {
     probeServePort,
     readServePidfile,
     removeServePidfile,
+    resolveStudioTarget,
     servePidfilePath,
     writeServePidfile,
 } from "./serve-instance.ts";
+import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
 
 const tmp = mkdtempSync(join(tmpdir(), "ax-serve-instance-"));
 const pidfile = join(tmp, "serve.json");
@@ -106,6 +108,44 @@ describe("probeServePort", () => {
         const port = portOf(server);
         await server.stop(true);
         expect(await probeServePort(port)).toEqual({ kind: "none" });
+    });
+});
+
+describe("resolveStudioTarget", () => {
+    test("no pidfile → default port, not live", async () => {
+        const target = await resolveStudioTarget(join(tmp, "absent.json"));
+        expect(target).toEqual({
+            baseUrl: `http://localhost:${DEFAULT_DASHBOARD_PORT}`,
+            port: DEFAULT_DASHBOARD_PORT,
+            live: false,
+        });
+    });
+
+    test("pidfile with a live pid → recorded port, live", async () => {
+        const path = join(tmp, "studio-live.json");
+        // process.pid is guaranteed alive (it's us) - exercises the live branch.
+        await writeServePidfile(
+            { pid: process.pid, port: 4321, startedAt: "2026-06-22T00:00:00.000Z", axVersion: "0.34.2" },
+            path,
+        );
+        expect(await resolveStudioTarget(path)).toEqual({
+            baseUrl: "http://localhost:4321",
+            port: 4321,
+            live: true,
+        });
+    });
+
+    test("pidfile with a dead pid → default port, not live", async () => {
+        const path = join(tmp, "studio-dead.json");
+        // pid 1 is init; signal-0 to it from a normal user throws EPERM (=alive),
+        // so use an implausibly high pid that is almost certainly not running.
+        await writeServePidfile(
+            { pid: 2_000_000_000, port: 4321, startedAt: "2026-06-22T00:00:00.000Z", axVersion: "0.34.2" },
+            path,
+        );
+        const target = await resolveStudioTarget(path);
+        expect(target.live).toBe(false);
+        expect(target.port).toBe(DEFAULT_DASHBOARD_PORT);
     });
 });
 

--- a/apps/axctl/src/dashboard/serve-instance.ts
+++ b/apps/axctl/src/dashboard/serve-instance.ts
@@ -6,6 +6,7 @@
  * through `withoutDb`.
  */
 import { homedir } from "node:os";
+import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
 import { posixPath } from "@ax/lib/shared/path";
 
 export interface ServePidfile {
@@ -143,4 +144,37 @@ export async function probeServePort(
 /** Narrow an unknown throw to the listen-failure we handle specially. */
 export function isAddrInUse(err: unknown): boolean {
     return isRecord(err) && (err as { code?: string }).code === "EADDRINUSE";
+}
+
+/** Where Studio deeplinks point: the base URL + whether a daemon is up. */
+export interface StudioTarget {
+    /** `http://localhost:<port>` - no trailing slash. */
+    readonly baseUrl: string;
+    readonly port: number;
+    /** A managed ax daemon appears to be running (its pid is alive). */
+    readonly live: boolean;
+}
+
+/**
+ * Resolve the Studio base URL for deeplinks in session-oriented output.
+ *
+ * Reads the serve pidfile (a cheap local file read) and signal-0 checks the
+ * recorded pid - NO network probe, because these deeplinks decorate common,
+ * latency-sensitive commands (`ax recall`, `ax sessions ...`) and must not
+ * pay a port round-trip on every call. When no live managed daemon is
+ * recorded, falls back to the default port: the route is stable, so the URL
+ * is correct either way; `live` only tunes the description (run `ax serve`).
+ */
+export async function resolveStudioTarget(
+    path = servePidfilePath(),
+): Promise<StudioTarget> {
+    const pidfile = await readServePidfile(path);
+    if (pidfile && isPidAlive(pidfile.pid)) {
+        return { baseUrl: `http://localhost:${pidfile.port}`, port: pidfile.port, live: true };
+    }
+    return {
+        baseUrl: `http://localhost:${DEFAULT_DASHBOARD_PORT}`,
+        port: DEFAULT_DASHBOARD_PORT,
+        live: false,
+    };
 }

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -248,10 +248,19 @@ describe("NavLink next[] wiring", () => {
         };
         const rt = { runPromise: () => Promise.resolve(stub) } as never;
         const result = (await byName("recall").run({ q: "timeline" }, rt)) as {
-            hits: ReadonlyArray<{ next?: ReadonlyArray<unknown> }>;
+            hits: ReadonlyArray<{
+                next?: ReadonlyArray<{ call?: { tool?: string }; url?: string }>;
+            }>;
             next: ReadonlyArray<{ cmd?: string }>;
         };
-        expect(result.hits[0]?.next).toHaveLength(1);
+        // per-hit: drill-in (session_show) + open-in-Studio deeplink (#563)
+        expect(result.hits[0]?.next).toHaveLength(2);
+        expect(result.hits[0]?.next?.some((l) => l.call?.tool === "session_show")).toBe(true);
+        expect(
+            result.hits[0]?.next?.some((l) =>
+                l.url?.endsWith("/sessions/019e2531-b552-7b53-a029-c780adbb6560"),
+            ),
+        ).toBe(true);
         expect(
             result.next.some((l) => l.cmd === "codex resume 019e2531-b552-7b53-a029-c780adbb6560"),
         ).toBe(true);

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -40,6 +40,7 @@ import {
     normalizeSessionsAroundOpts,
 } from "../dashboard/sessions-query.ts";
 import { fetchEnrichedSession } from "../queries/enriched-session.ts";
+import { resolveStudioTarget } from "../dashboard/serve-instance.ts";
 import {
     fetchSkillsWeighted,
     normalizeSkillsWeightedParams,
@@ -210,8 +211,10 @@ const recallTool: AxMcpTool = defineMcpTool({
         });
 
         const result = await rt.runPromise(fetchRecall(params));
+        const studio = await resolveStudioTarget();
         const { hits, next } = buildRecallNext(result, {
             requestedSources: resolveRecallSources(params.sources),
+            studio,
         });
         return { ...result, hits, next };
     },
@@ -249,10 +252,12 @@ const sessionsAroundTool: AxMcpTool = defineMcpTool({
             ...(args.project !== undefined ? { project: args.project } : {}),
         });
         const rows = await rt.runPromise(listSessionsAround(opts));
+        const studio = await resolveStudioTarget();
         return buildSessionsNext(rows, {
             date: args.date,
             ...(args.days !== undefined ? { days: args.days } : {}),
             ...(args.project !== undefined ? { project: args.project } : {}),
+            studio,
         });
     },
 });
@@ -297,7 +302,8 @@ const sessionShowTool: AxMcpTool = defineMcpTool({
             }),
         );
         const payload = enriched.view!;
-        return { ...payload, next: buildSessionShowNext(payload) };
+        const studio = await resolveStudioTarget();
+        return { ...payload, next: buildSessionShowNext(payload, studio) };
     },
 });
 

--- a/apps/axctl/src/nav/next-links.test.ts
+++ b/apps/axctl/src/nav/next-links.test.ts
@@ -15,6 +15,9 @@ import {
     buildSkillsRolesNext,
     buildRolesNext,
     buildImproveProposalsNext,
+    studioSessionUrl,
+    studioSessionLink,
+    type StudioDeeplink,
 } from "./next-links.ts";
 
 const UUID_A = "019e2531-b552-7b53-a029-c780adbb6560";
@@ -273,6 +276,71 @@ describe("buildSessionShowNext", () => {
     test("no overview → empty next", () => {
         const next = buildSessionShowNext(view(detail({ overview: null })));
         expect(next).toHaveLength(0);
+    });
+
+    test("studio target → top-level open-in-Studio deeplink", () => {
+        const studio: StudioDeeplink = { baseUrl: "http://localhost:1738", live: true };
+        const next = buildSessionShowNext(view(detail({})), studio);
+        const open = next.find((l) => l.ui?.group === "navigate");
+        expect(open?.url).toBe(`http://localhost:1738/sessions/${UUID_A}`);
+        expect(open?.description).toBe("Open this session in ax Studio");
+    });
+});
+
+describe("studio deeplinks (#563)", () => {
+    test("studioSessionUrl uses the stable /sessions/<id> route, bare id, no double slash", () => {
+        expect(studioSessionUrl("http://localhost:1738", UUID_A)).toBe(
+            `http://localhost:1738/sessions/${UUID_A}`,
+        );
+        // trailing slash on base is tolerated
+        expect(studioSessionUrl("http://localhost:1738/", UUID_A)).toBe(
+            `http://localhost:1738/sessions/${UUID_A}`,
+        );
+        // session:⟨…⟩ wrapper is stripped to the bare uuid
+        expect(studioSessionUrl("http://localhost:1738", `session:⟨${UUID_A}⟩`)).toBe(
+            `http://localhost:1738/sessions/${UUID_A}`,
+        );
+    });
+
+    test("not-live target keeps the default-port URL but nudges `ax serve`", () => {
+        const link = studioSessionLink(UUID_A, { baseUrl: "http://localhost:1738", live: false });
+        expect(link.url).toBe(`http://localhost:1738/sessions/${UUID_A}`);
+        expect(link.description).toContain("ax serve");
+    });
+
+    test("buildSessionsNext attaches a per-row Studio deeplink when studio is set", () => {
+        const studio: StudioDeeplink = { baseUrl: "http://localhost:1738", live: true };
+        const { sessions } = buildSessionsNext([row({})], { studio });
+        const open = sessions[0]?.next?.find((l) => l.ui?.group === "navigate");
+        expect(open?.url).toBe(`http://localhost:1738/sessions/${UUID_A}`);
+        // drill-in is still present alongside it
+        expect(sessions[0]?.next?.some((l) => l.call?.tool === "session_show")).toBe(true);
+    });
+
+    test("buildSessionsNext without studio leaves rows at one drill-in (backward compatible)", () => {
+        const { sessions } = buildSessionsNext([row({})]);
+        expect(sessions[0]?.next).toHaveLength(1);
+        expect(sessions[0]?.next?.some((l) => l.ui?.group === "navigate")).toBe(false);
+    });
+
+    test("buildRecallNext attaches a per-hit Studio deeplink when studio is set", () => {
+        const studio: StudioDeeplink = { baseUrl: "http://localhost:1738", live: true };
+        const { hits } = buildRecallNext(recallResponse([hit({})]), {
+            requestedSources: ["turn"],
+            studio,
+        });
+        const open = hits[0]?.next?.find((l) => l.ui?.group === "navigate");
+        expect(open?.url).toBe(`http://localhost:1738/sessions/${UUID_A}`);
+    });
+
+    test("subagent session still gets a Studio deeplink (route renders both)", () => {
+        const studio: StudioDeeplink = { baseUrl: "http://localhost:1738", live: true };
+        const { sessions } = buildSessionsNext(
+            [row({ source: "claude-subagent", id: "claude-subagent-zzz" })],
+            { studio },
+        );
+        const open = sessions[0]?.next?.find((l) => l.ui?.group === "navigate");
+        expect(open?.url).toBe("http://localhost:1738/sessions/claude-subagent-zzz");
     });
 });
 

--- a/apps/axctl/src/nav/next-links.ts
+++ b/apps/axctl/src/nav/next-links.ts
@@ -48,6 +48,48 @@ export const NEXT_PROTOCOL_HINT =
 // Shared link constructors
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Studio deeplinks
+// ---------------------------------------------------------------------------
+
+/**
+ * Where a Studio deeplink points. Resolved by the caller (CLI handler / MCP
+ * tool) via `resolveStudioTarget` so these builders stay pure - the dashboard
+ * module owns pidfile/port discovery.
+ */
+export interface StudioDeeplink {
+    /** `http://localhost:<port>` - no trailing slash. */
+    readonly baseUrl: string;
+    /** A managed ax daemon appears to be running. Tunes the link copy. */
+    readonly live: boolean;
+}
+
+/**
+ * The Studio session route - single source of the deeplink shape so agents
+ * never have to read frontend route code or guess the URL (issue #563). Bare
+ * session id (the `session:⟨…⟩` wrapper is stripped) keeps the URL clean.
+ */
+export const studioSessionUrl = (baseUrl: string, sessionId: string): string =>
+    `${baseUrl.replace(/\/+$/, "")}/sessions/${toBareSessionId(sessionId)}`;
+
+/**
+ * "Open in Studio" deeplink for a session. Carries the URL as the transport;
+ * when no daemon is up the URL still uses the default port (stable route) and
+ * the description points the user at `ax serve`. Works for normal and
+ * subagent sessions alike - the route renders both.
+ */
+export const studioSessionLink = (
+    sessionId: string,
+    studio: StudioDeeplink,
+    priority = 7,
+): NavLink => ({
+    description: studio.live
+        ? "Open this session in ax Studio"
+        : "Open this session in ax Studio (start the daemon first: ax serve)",
+    url: studioSessionUrl(studio.baseUrl, sessionId),
+    ui: { priority, group: "navigate" },
+});
+
 /** Drill-in link for a session id - dual transport. */
 export const sessionShowLink = (
     sessionId: string,
@@ -124,6 +166,8 @@ const ALL_SOURCES: ReadonlyArray<RecallSource> = ["turn", "commit", "skill"];
 
 export interface RecallNextOptions {
     readonly requestedSources: ReadonlyArray<RecallSource>;
+    /** When set, each turn hit gains an "open in Studio" deeplink. */
+    readonly studio?: StudioDeeplink;
 }
 
 export interface RecallWithNext {
@@ -142,7 +186,10 @@ export const buildRecallNext = (
 ): RecallWithNext => {
     const hits: Array<WithNext<RecallHit>> = r.hits.map((h) => ({
         ...h,
-        next: [sessionShowLink(h.session_id, "Read the session this turn belongs to")],
+        next: [
+            sessionShowLink(h.session_id, "Read the session this turn belongs to"),
+            ...(opts.studio ? [studioSessionLink(h.session_id, opts.studio)] : []),
+        ],
     }));
 
     const top: NavLink[] = [];
@@ -205,6 +252,8 @@ export interface SessionsNextOptions {
     readonly date?: string | undefined;
     readonly days?: number | undefined;
     readonly project?: string | null | undefined;
+    /** When set, each session row gains an "open in Studio" deeplink. */
+    readonly studio?: StudioDeeplink;
 }
 
 export interface SessionsWithNext {
@@ -222,7 +271,10 @@ export const buildSessionsNext = (
 ): SessionsWithNext => {
     const sessions: Array<WithNext<SessionRow>> = rows.map((row) => ({
         ...row,
-        next: [sessionShowLink(row.id)],
+        next: [
+            sessionShowLink(row.id),
+            ...(opts.studio ? [studioSessionLink(row.id, opts.studio)] : []),
+        ],
     }));
 
     const top: NavLink[] = [];
@@ -292,6 +344,7 @@ export const buildSessionsNext = (
  */
 export const buildSessionShowNext = (
     p: SessionViewPayload,
+    studio?: StudioDeeplink,
 ): ReadonlyArray<NavLink> => {
     const top: NavLink[] = [];
     const overview = p.session.overview;
@@ -305,6 +358,11 @@ export const buildSessionShowNext = (
         cwd: overview.cwd,
     });
     if (resume) top.push(resume);
+
+    // ③ Open this focused session in Studio (issue #563) - the user can see
+    //    the timeline/graph in the UI. Below resume so the harness command
+    //    stays the flagship, above the expand-subagents affordance.
+    if (studio) top.push(studioSessionLink(id, studio, 8));
 
     if (p.session.parent) {
         top.push(

--- a/packages/lib/src/shared/nav-link.ts
+++ b/packages/lib/src/shared/nav-link.ts
@@ -4,9 +4,11 @@
  * Instead of teaching the whole tool/CLI grammar upfront in descriptions,
  * responses carry `next` links that describe valid follow-up actions with
  * ready-to-run payloads. An agent copies `call.arguments` verbatim into the
- * named MCP tool, or runs `cmd` as-is in a shell. Two transports because ax
- * is driven both ways: MCP tool calls and CLI/Bash. Some affordances (e.g.
- * the harness resume command) only exist as shell commands.
+ * named MCP tool, runs `cmd` as-is in a shell, or opens `url` in a browser.
+ * Three transports because ax is driven multiple ways: MCP tool calls,
+ * CLI/Bash, and (for Studio deeplinks) a browser. Some affordances (e.g. the
+ * harness resume command) only exist as shell commands; others (an "open this
+ * session in Studio" deeplink) only exist as a URL.
  */
 
 /** An MCP follow-up call. Copy `arguments` verbatim - do not edit. */
@@ -18,14 +20,21 @@ export interface NavLinkCall {
 }
 
 /**
- * A ready-to-run follow-up action. At least one of `call` / `cmd` is set.
- * `call` = MCP follow-up; `cmd` = literal shell command (copy-paste as-is).
+ * A ready-to-run follow-up action. At least one of `call` / `cmd` / `url` is
+ * set. `call` = MCP follow-up; `cmd` = literal shell command (copy-paste
+ * as-is); `url` = a deeplink to open in a browser (e.g. an ax Studio session
+ * route), which an agent can surface to the user verbatim.
  */
 export interface NavLink {
 	/** Human/LLM-readable hint for when to use this link. */
 	readonly description: string;
 	readonly call?: NavLinkCall;
 	readonly cmd?: string;
+	/**
+	 * A deeplink URL to open in a browser - e.g. an ax Studio session route.
+	 * The CLI footer renders it as the actionable payload when no `cmd` is set.
+	 */
+	readonly url?: string;
 	readonly ui?: {
 		/** Higher sorts first. */
 		readonly priority?: number;


### PR DESCRIPTION
Closes #563.

## What

Session-oriented outputs now carry a first-class **"open in ax Studio"** deeplink so agents stop inferring the local Studio route and hand-building `http://localhost:1738/sessions/<id>`.

| Surface | Where the link lands |
|---|---|
| `ax sessions show <id>` | top-level `next` |
| `ax sessions here \| around \| near` | per-row `next` |
| `ax recall` | per-hit `next` |
| MCP `session_show` / `sessions_around` / `recall` | same, in the JSON envelope |

## How

- **`NavLink` gains a third transport, `url`** (beside `call`/`cmd`) — a browser deeplink an agent shows the user verbatim. The CLI footer renders `cmd ?? url` (so url-only links are visible on a TTY); `--json`/MCP carry the full object.
- **`studioSessionUrl` / `studioSessionLink`** (`apps/axctl/src/nav/next-links.ts`) own the stable `/sessions/<bare-id>` shape — single source of truth, agents never read frontend route code.
- **`resolveStudioTarget`** (`serve-instance.ts`) resolves port + liveness from the serve pidfile + a signal-0 pid check — **no network probe**, so the common latency-sensitive queries pay no round-trip. No daemon up → emits the default-port URL and the link copy nudges `ax serve`.
- Works for normal **and** subagent sessions (the route renders both).
- Deeplink format documented in `CLAUDE.md`.

## Acceptance criteria

- [x] Session result `next` links include an "open in Studio" action
- [x] URL uses the active `ax serve` port when available (pidfile), default port otherwise
- [x] Studio-not-running → default-port URL + copy pointing at `ax serve`
- [x] Deeplink format documented somewhere stable (`CLAUDE.md`)
- [x] Works for normal and subagent sessions

## Tests

New coverage in `next-format.test.ts` (url rendering, cmd-wins-over-url), `next-links.test.ts` (URL shape, per-row/per-hit/top-level wiring, backward-compat when no studio target, subagent), `serve-instance.test.ts` (`resolveStudioTarget` live / dead-pid / no-pidfile branches). Backward compatible: builders called without a studio target emit the previous output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)