### PR TITLE
fix(routability): carry judgment from prose turns onto the edits behind them

### DIFF
--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -319,9 +319,10 @@ function renderRoutability(r: RoutabilityResult): string {
         out.push(...renderRoutabilityProvider(p, p.provider));
         out.push("");
     }
-    out.push("estimate: edit/read turns are assumed mechanically routable; reasoning before an");
-    out.push("edit isn't visible in the transcript, so read this as an upper-ish bound, not ground");
-    out.push("truth. judgment-text turns stay on frontier by design. claude + codex main-agent.");
+    out.push("estimate: edit/read turns are assumed mechanically routable; thinking before an");
+    out.push("edit is stripped from the transcript, so read this as an upper-ish bound, not ground");
+    out.push("truth. judgment-text turns stay on frontier, and edits riding behind a judgment");
+    out.push("prose turn in the same message are carried with it. claude + codex main-agent.");
     out.push("codex exec_command is split read/write via command_norm; ambiguous norms stay on main.");
     out.push("next: ax dispatches --candidates   # the subagent-side leak");
     return out.join("\n");

--- a/apps/axctl/src/queries/routability.test.ts
+++ b/apps/axctl/src/queries/routability.test.ts
@@ -97,6 +97,70 @@ describe("buildSpans", () => {
   });
 });
 
+describe("buildSpans judgment carry (Claude prose->edit split)", () => {
+  // Claude splits one assistant message into separate turn rows: a prose turn
+  // (text, no tools) then its tool-use turns (empty text). The judgment guard
+  // only reads ONE turn's text, so edit turns riding behind judgment reasoning
+  // misclassify as mechanical-impl. The carry propagates judgment text from a
+  // prose turn onto the following tool-only turns of the same message.
+  it("demotes edit turns riding behind judgment prose out of routable", () => {
+    const turns = [
+      turn(1, "user", []),
+      turn(2, "assistant", ["Read"]), // interactive (adjacent to user)
+      turn(3, "assistant", [], { text: "Let me review the design before editing" }), // design-decision, sets sticky
+      turn(4, "assistant", ["Edit"]), // empty text, sticky -> demoted (would be mechanical-impl)
+      turn(5, "assistant", ["Edit"]), // demoted
+    ];
+    const spans = buildSpans(turns, 1);
+    expect(spans.find((s) => s.cls === "mechanical-impl")).toBeUndefined();
+    const judgment = spans.find((s) => s.cls === "design-decision");
+    expect(judgment?.turnCount).toBe(3); // prose + 2 edits
+    expect(judgment?.routable).toBe(false);
+  });
+
+  it("leaves edits mechanical when the leading prose carries no judgment", () => {
+    const turns = [
+      turn(1, "user", []),
+      turn(2, "assistant", ["Read"]),
+      turn(3, "assistant", [], { text: "Now let me update the file" }), // no judgment keyword
+      turn(4, "assistant", ["Edit"]), // mechanical-impl (no carry)
+    ];
+    const mech = buildSpans(turns, 1).find((s) => s.cls === "mechanical-impl");
+    expect(mech?.turnCount).toBe(1);
+    expect(mech?.routable).toBe(true);
+  });
+
+  it("resets the carry at the next message's prose turn", () => {
+    const turns = [
+      turn(1, "user", []),
+      turn(2, "assistant", ["Read"]),
+      turn(3, "assistant", [], { text: "review the plan" }), // sticky on
+      turn(4, "assistant", ["Edit"]), // demoted
+      turn(5, "assistant", [], { text: "now apply the rename" }), // non-judgment text -> sticky off
+      turn(6, "assistant", ["Edit"]), // mechanical-impl (carry reset)
+    ];
+    const spans = buildSpans(turns, 1);
+    // exactly one mechanical-impl span (turn 6); turn 4 was demoted
+    expect(spans.filter((s) => s.cls === "mechanical-impl")).toHaveLength(1);
+    expect(spans.some((s) => s.cls === "design-decision")).toBe(true);
+  });
+
+  it("resets the carry at a user boundary", () => {
+    const turns = [
+      turn(1, "user", []),
+      turn(2, "assistant", [], { text: "audit the security model" }), // adjacent->interactive, but sticky on
+      turn(3, "assistant", ["Edit"]), // demoted (sticky survives the forced-interactive turn)
+      turn(4, "user", []), // boundary -> sticky reset
+      turn(5, "assistant", ["Edit"]), // adjacent->interactive
+      turn(6, "assistant", ["Edit"]), // mechanical-impl (carry was reset)
+    ];
+    const spans = buildSpans(turns, 1);
+    // exactly one mechanical-impl span (turn 6); turn 3 was demoted pre-boundary
+    expect(spans.filter((s) => s.cls === "mechanical-impl")).toHaveLength(1);
+    expect(spans.some((s) => s.cls === "design-decision")).toBe(true);
+  });
+});
+
 describe("aggregateRoutability", () => {
   const catalog = new Map<string, ModelPricing>([
     [MODEL_ALIASES.sonnet, { provider: "anthropic", inputPerMillionUsd: 3, outputPerMillionUsd: 15, cacheReadPerMillionUsd: 0.3, cacheCreationPerMillionUsd: 3.75, fastMultiplier: 1, pricingSource: "test" }],

--- a/apps/axctl/src/queries/routability.ts
+++ b/apps/axctl/src/queries/routability.ts
@@ -278,6 +278,15 @@ export function buildSpans(
   const spans: Span[] = [];
   let cur: { cls: WorkClass; turnCount: number; usage: RepriceUsage } | null = null;
   let adjacentToBoundary = false; // next work turn neighbours a user turn
+  // Judgment carry: Claude splits one assistant message into separate turn rows
+  // - a prose turn (text) then its tool-use turns (empty text). classifyTurn
+  // reads only ONE turn's text, so edit turns riding behind judgment reasoning
+  // misclassify as mechanical-impl. A prose turn carrying JUDGMENT_GUARD_RE text
+  // sets this sticky flag; the following tool-only turns of the same message
+  // inherit it and are held off the routable path. A new prose turn (next
+  // message) re-evaluates it; a user boundary clears it. Conservative: it only
+  // demotes (never promotes), so the routability estimate can only tighten.
+  let judgmentSticky = false;
 
   const flush = () => {
     if (!cur) return;
@@ -289,7 +298,7 @@ export function buildSpans(
   for (const t of turns) {
     const kind = roleKind(t.role);
     if (kind === "skip") continue;
-    if (kind === "boundary") { flush(); adjacentToBoundary = true; continue; }
+    if (kind === "boundary") { flush(); adjacentToBoundary = true; judgmentSticky = false; continue; }
     if (kind === "carry") {
       // Tool-output cost belongs to the action that produced it (open span).
       if (cur) cur.usage = addUsage(cur.usage, t.usage);
@@ -297,8 +306,17 @@ export function buildSpans(
       continue;
     }
     // work
-    const cls = classifyTurn(t, adjacentToBoundary);
+    // A turn carrying its own text starts a new assistant message - re-evaluate
+    // the judgment carry from that text. Tool-only turns (empty text) keep the
+    // value set by the prose turn that opened their message.
+    const turnText = t.text?.trim() ?? "";
+    if (turnText.length > 0) judgmentSticky = JUDGMENT_GUARD_RE.test(turnText);
+    let cls = classifyTurn(t, adjacentToBoundary);
     adjacentToBoundary = false;
+    // Hold judgment-adjacent edits off the routable path: fold them into the
+    // design-decision (non-routable) class so they group with the reasoning
+    // that drove them.
+    if (judgmentSticky && ROUTABLE_CLASS_TIER[cls] !== undefined) cls = "design-decision";
     if (cur && cur.cls === cls) {
       cur.turnCount += 1;
       cur.usage = addUsage(cur.usage, t.usage);


### PR DESCRIPTION
## Problem

Claude splits one assistant message into separate `turn` rows — a prose turn (text, no tools) then its tool-use turns (empty text). `classifyTurn` reads only **one** turn's text, so `JUDGMENT_GUARD_RE` (the sole non-tool judgment guard) fires on just **0.13%** of main-thread edit turns (24,336 of 24,368 are empty-text, measured over 14d). Edits riding behind "let me *review* the design …" reasoning therefore misclassified as `mechanical-impl` and **inflated the routable estimate**.

## Fix

`buildSpans` now tracks a `judgmentSticky` flag:
- a prose turn carrying judgment text sets it
- the following tool-only turns of the **same message** inherit it and fold into the (non-routable) `design-decision` class
- a new prose turn re-evaluates it; a user boundary clears it

Conservative — it only ever **demotes**, so the estimate can only tighten. Runs for both Claude and Codex via `buildSpans`.

## Measured (7d, same window, same $5,660.95 main spend — clean A/B)

| | Old | New | Δ |
|---|---|---|---|
| claude mechanical-impl runs | 5,177 | 4,183 | −994 |
| claude mechanical-impl cost | $1,140.57 | $903.84 | −$236.73 |
| total est savings/wk | **$943.21** | **$735.22** | **−$207.99 (−22%)** |

~A fifth of the routability headline was judgment-adjacent work the per-turn guard couldn't see.

## Tests

4 new carry tests (demote / no-carry / reset-at-prose / reset-at-boundary); full `routability.test.ts` green (35/35). Caveat text in `ax cost routability` updated to describe the carry.