### PR TITLE
feat: n-gram-lift directive miner (#587)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,11 +336,11 @@ task file, then run `axctl improve lint` to reconcile.
 
 ## MCP server
 
-`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 18 tools
+`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 19 tools
 (`recall`, `sessions_around`, `session_show`, `skills_weighted`, `skills_by_role`,
 `skills_roles`, `roles`, `improve_recommend`, `improve_show`, `improve_list`,
 `session_metrics`, `signal_show`, `cost_models`, `cost_split`, `cost_images`,
-`cost_routability`, `dispatches`, `dojo_agenda`) so an agent can query the graph in-context. Run from source (no
+`cost_routability`, `dispatches`, `dojo_agenda`, `directives_list`) so an agent can query the graph in-context. Run from source (no
 native deps, so the compiled binary should work too - untested in v0). Mutating
 ops + `sessions_here`/`near` (need a git-resolved repo key) are intentionally not
 exposed. Server: `apps/axctl/src/mcp/server.ts`; registry: `apps/axctl/src/mcp/tools.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,12 @@ state in `apps/axctl/src/routing-impact/` (DB-free, exhaustively tested); CLI in
 `cli/commands/ax-routing-impact.ts`. `report --share` appends the ax plug.
 The routing-table file is now the source of truth for BOTH the route-dispatch hook and `ax dispatches --candidates` (unify done); `ROUTING_CLASSES` remains the shipped default seed. The committed `/routing-tune` workflow stays the dev-side tool for tuning the defaults themselves.
 
+### Directive mining
+
+`ax directives mine [--days=N] [--emit-brief] [--json]` - rank candidate directive turns by n-gram lift (default 90d). Without `--emit-brief` prints a scored table; with it, writes `.ax/tasks/directives-<date>.md` for agent review. Rides the existing improve pipeline: accepted proposals land via `ax improve accept <id>`.
+`ax directives list [--status=open|all] [--json]` - tracked directive proposals (section="directives"), sorted by recurrence. Discriminated from other guidance proposals by `guidance_proposal.section = 'directives'` (set at ingest, no new schema field).
+`ax directives ngrams [--limit=N] [--json]` - the learned per-user lift table (`directive_ngram` rows sorted by lift desc; lift = outcome-rate / base-rate). Populated at ingest; re-run `ax ingest` to refresh. MCP: `directives_list`.
+
 ## Recommend + apply guidance to your own agent files
 
 `axctl improve recommend / accept / lint / show` ship the v0 grounded-files

--- a/apps/axctl/src/cli/commands/ax-directives.ts
+++ b/apps/axctl/src/cli/commands/ax-directives.ts
@@ -21,7 +21,7 @@ import { SurrealClient } from "@ax/lib/db";
 import { prettyPrint } from "@ax/lib/json";
 import { deriveDirectiveCandidates, scoreDirectiveCandidates, type DirectiveTurnRow } from "../../ingest/directives.ts";
 import { listDirectiveProposals, type ProposalRow } from "../../improve/list.ts";
-import { fetchDirectiveLift } from "../../queries/directive-ngrams.ts";
+import type { LiftRow } from "../../queries/directive-ngrams.ts";
 import { renderDirectivesBrief } from "../directives-brief-template.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { fail, jsonFlag, optionValue, requirePositiveInt } from "./shared.ts";
@@ -181,10 +181,11 @@ const ngramsCommand = Command.make(
     ({ limit, json }) =>
         Effect.gen(function* () {
             const validLimit = requirePositiveInt("directives ngrams", "limit", limit);
-            const liftRows = yield* fetchDirectiveLift({
-                sinceDays: 90,
-                limit: validLimit,
-            });
+            const db = yield* SurrealClient;
+            const [rawRows] = yield* db.query<[LiftRow[]]>(
+                `SELECT ngram, n, occurrences, outcomes, sessions, lift FROM directive_ngram ORDER BY lift DESC LIMIT ${validLimit};`,
+            ).pipe(Effect.orElseSucceed(() => [[] as LiftRow[]]));
+            const liftRows: LiftRow[] = rawRows ?? [];
 
             if (json) {
                 console.log(prettyPrint(liftRows));

--- a/apps/axctl/src/cli/commands/ax-directives.ts
+++ b/apps/axctl/src/cli/commands/ax-directives.ts
@@ -1,0 +1,254 @@
+/**
+ * `ax directives` - on-demand read surface for the directive-mining v2 system.
+ *
+ *   ax directives mine [--days=N] [--emit-brief] [--json]
+ *     Rank candidate directive turns by lift. With --emit-brief writes
+ *     .ax/tasks/directives-<date>.md for agent review, else prints a summary.
+ *
+ *   ax directives list [--status=...] [--json]
+ *     Tracked directive proposals (guidance-form, section='directives'),
+ *     sorted by recurrence (frequency). Discriminator: guidance_proposal.section
+ *     = 'directives' - the field set by deriveDirectiveProposalRows in
+ *     ingest/derive-proposals.ts. Other guidance proposals (harness-derived) use
+ *     a different section value. No schema field added - existing field reused.
+ *
+ *   ax directives ngrams [--json] [--limit=N]
+ *     The learned per-user lift table (directive_ngram rows sorted by lift desc).
+ */
+import { Effect, FileSystem, Path } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import { SurrealClient } from "@ax/lib/db";
+import { prettyPrint } from "@ax/lib/json";
+import { deriveDirectiveCandidates, scoreDirectiveCandidates, type DirectiveTurnRow } from "../../ingest/directives.ts";
+import { fetchDirectiveLift } from "../../queries/directive-ngrams.ts";
+import { renderDirectivesBrief } from "../directives-brief-template.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+import { fail, jsonFlag, optionValue, requirePositiveInt } from "./shared.ts";
+
+// SQL boundary guard - same pattern as directive-ngrams.ts
+const sqlDays = (n: number): number => Math.max(1, Math.trunc(n));
+
+// ---------------------------------------------------------------------------
+// ax directives mine
+// ---------------------------------------------------------------------------
+
+const mineCommand = Command.make(
+    "mine",
+    {
+        days: Flag.integer("days").pipe(Flag.withDefault(90)),
+        emitBrief: Flag.boolean("emit-brief").pipe(Flag.withDefault(false)),
+        json: jsonFlag,
+    },
+    ({ days, emitBrief, json }) =>
+        Effect.gen(function* () {
+            if (!Number.isInteger(days) || days <= 0) {
+                fail(`ax directives mine: --days must be a positive integer (got "${days}")`);
+            }
+
+            const db = yield* SurrealClient;
+
+            // Fetch user turns (same query shape as derive-proposals.ts directive turn fetch,
+            // parameterized by --days instead of hard-coded 90d)
+            const [rawTurns] = yield* db.query<[DirectiveTurnRow[]]>(`
+SELECT type::string(id) AS id, type::string(session) AS session, text_excerpt, type::string(ts) AS ts
+FROM turn
+WHERE role = "user" AND text_excerpt != NONE AND text_excerpt != ""
+  AND ts > time::now() - ${sqlDays(days)}d AND session.source != "claude-subagent";
+`).pipe(Effect.orElseSucceed(() => [[] as DirectiveTurnRow[]]));
+
+            const turns: DirectiveTurnRow[] = rawTurns ?? [];
+
+            // Fetch lift table from directive_ngram
+            const [rawLift] = yield* db.query<[Array<{ ngram: string; lift: number }>]>(
+                `SELECT ngram, lift FROM directive_ngram WHERE lift > 0;`,
+            ).pipe(Effect.orElseSucceed(() => [[] as Array<{ ngram: string; lift: number }>]));
+
+            const liftMap = new Map<string, number>();
+            for (const r of rawLift ?? []) {
+                liftMap.set(r.ngram, r.lift);
+            }
+
+            const candidates = deriveDirectiveCandidates(turns);
+            const scored = scoreDirectiveCandidates(candidates, liftMap as ReadonlyMap<string, number>);
+
+            if (emitBrief) {
+                const date = new Date().toISOString().slice(0, 10);
+                const briefPath = `.ax/tasks/directives-${date}.md`;
+                const fs = yield* FileSystem.FileSystem;
+                const p = yield* Path.Path;
+                yield* fs.makeDirectory(p.dirname(briefPath), { recursive: true }).pipe(Effect.orDie);
+                yield* fs.writeFileString(briefPath, renderDirectivesBrief(scored, { date, days })).pipe(Effect.orDie);
+                if (json) {
+                    console.log(prettyPrint({ brief: briefPath, candidates: scored.length }));
+                    return;
+                }
+                console.log(`brief written: ${briefPath} (${scored.length} candidates)`);
+                console.log(`hand it to your agent; accepted proposals land via: ax improve accept <id>`);
+                return;
+            }
+
+            if (json) {
+                console.log(prettyPrint(scored));
+                return;
+            }
+
+            if (scored.length === 0) {
+                console.log(`(no directive candidates in the last ${days} days)`);
+                return;
+            }
+
+            console.log(`${"#".padEnd(3)}  ${"score".padStart(7)}  ${"src".padEnd(5)}  ${"pattern".padEnd(18)}  ${"ts".padEnd(10)}  ${"session".padEnd(20)}  text`);
+            for (let i = 0; i < scored.length; i++) {
+                const c = scored[i]!;
+                const score = c.source === "lift" ? c.score.toFixed(2).padStart(7) : "   seed";
+                const src = c.source.padEnd(5);
+                const pat = c.pattern.padEnd(18).slice(0, 18);
+                const ts = c.ts.slice(0, 10);
+                const sid = c.sessionId.slice(0, 20).padEnd(20);
+                const text = c.text.length > 60 ? c.text.slice(0, 57) + "..." : c.text;
+                console.log(`${String(i + 1).padEnd(3)}  ${score}  ${src}  ${pat}  ${ts}  ${sid}  ${text}`);
+            }
+            console.log(`\n${scored.length} candidates (${days} days)  emit brief: ax directives mine --emit-brief`);
+        }),
+).pipe(
+    Command.withDescription(
+        "Rank candidate directive turns by lift. --days=N (default 90)  --emit-brief (write agent brief)  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax directives list
+// ---------------------------------------------------------------------------
+//
+// Discriminator: guidance_proposal.section = 'directives'. Both directive
+// and harness-derived guidance proposals share form='guidance' on the proposal
+// table; the section field in the guidance_proposal payload table is the clean
+// discriminator (set by deriveDirectiveProposalRows in derive-proposals.ts).
+// No new schema field needed.
+
+const listCommand = Command.make(
+    "list",
+    {
+        status: Flag.string("status").pipe(Flag.optional),
+        json: jsonFlag,
+    },
+    ({ status, json }) =>
+        Effect.gen(function* () {
+            const db = yield* SurrealClient;
+            const statusFilter = optionValue(status) ?? "open";
+
+            const whereStatus = statusFilter !== "all"
+                ? `AND p.status = "${statusFilter}"`
+                : "";
+
+            const sql = `
+SELECT type::string(p.id) AS id, p.form, p.title, p.hypothesis, p.dedupe_sig,
+       p.frequency, p.confidence, p.status, type::string(p.created_at) AS created_at
+FROM proposal AS p
+WHERE p.form = "guidance"
+  AND p.id IN (SELECT proposal FROM guidance_proposal WHERE section = "directives")
+  ${whereStatus}
+ORDER BY p.frequency DESC, p.created_at DESC
+LIMIT 30;`;
+
+            const [rows] = yield* db.query<[Array<Record<string, unknown>>]>(sql).pipe(
+                Effect.orElseSucceed(() => [[] as Array<Record<string, unknown>>]),
+            );
+            const proposals = rows ?? [];
+
+            if (json) {
+                console.log(prettyPrint(proposals));
+                return;
+            }
+
+            if (proposals.length === 0) {
+                console.log(`(no directive proposals with status="${statusFilter}" - run: ax ingest to mine)`);
+                return;
+            }
+
+            console.log(`${"freq".padStart(6)}  ${"conf".padEnd(6)}  ${"status".padEnd(10)}  ${"dedupe_sig".padEnd(24)}  title`);
+            for (const row of proposals) {
+                const freq = String(row.frequency ?? 0).padStart(6);
+                const conf = String(row.confidence ?? "").padEnd(6);
+                const stat = String(row.status ?? "").padEnd(10);
+                const sig = String(row.dedupe_sig ?? "").slice(0, 24).padEnd(24);
+                console.log(`${freq}  ${conf}  ${stat}  ${sig}  ${row.title}`);
+            }
+            console.log(`\n${proposals.length} directive proposal(s)  accept one: ax improve accept <id>`);
+        }),
+).pipe(
+    Command.withDescription(
+        "List tracked directive proposals (guidance/section=directives), sorted by recurrence. " +
+        "--status=open|all  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax directives ngrams
+// ---------------------------------------------------------------------------
+
+const ngramsCommand = Command.make(
+    "ngrams",
+    {
+        limit: Flag.integer("limit").pipe(Flag.withDefault(50)),
+        json: jsonFlag,
+    },
+    ({ limit, json }) =>
+        Effect.gen(function* () {
+            const validLimit = requirePositiveInt("directives ngrams", "limit", limit);
+            const liftRows = yield* fetchDirectiveLift({
+                sinceDays: 90,
+                limit: validLimit,
+            });
+
+            if (json) {
+                console.log(prettyPrint(liftRows));
+                return;
+            }
+
+            if (liftRows.length === 0) {
+                console.log("(no ngram lift data yet - run: ax ingest to build it)");
+                return;
+            }
+
+            console.log(`${"lift".padStart(6)}  ${"occ".padStart(5)}  ${"out".padStart(5)}  ${"sess".padStart(5)}  ngram`);
+            for (const row of liftRows) {
+                console.log(
+                    `${row.lift.toFixed(2).padStart(6)}  ${String(row.occurrences).padStart(5)}  ` +
+                    `${String(row.outcomes).padStart(5)}  ${String(row.sessions).padStart(5)}  ${row.ngram}`,
+                );
+            }
+            console.log(`\n${liftRows.length} ngrams  (lift = outcome-rate / base-rate; higher = stronger signal)`);
+        }),
+).pipe(
+    Command.withDescription(
+        "Show the learned per-user directive lift table (ngram → outcome lift). " +
+        "--limit=N (default 50)  --json",
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// ax directives (group)
+// ---------------------------------------------------------------------------
+
+export const directivesRootCommand = Command.make("directives").pipe(
+    Command.withDescription(
+        "Directive-mining v2 read surface: mine (rank candidates), list (tracked proposals), ngrams (lift table).",
+    ),
+    Command.withSubcommands([mineCommand, listCommand, ngramsCommand]),
+);
+
+export const axDirectivesRuntime: RuntimeManifest = {
+    directives: {
+        runtime: {
+            kind: "db-conditional",
+            fallback: "db",
+            subcommands: {
+                mine: "db",
+                list: "db",
+                ngrams: "db",
+            },
+        },
+        hidden: false,
+    },
+};

--- a/apps/axctl/src/cli/commands/ax-directives.ts
+++ b/apps/axctl/src/cli/commands/ax-directives.ts
@@ -18,8 +18,9 @@
 import { Effect, FileSystem, Path } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import { SurrealClient } from "@ax/lib/db";
-import { prettyPrint, surrealLiteral } from "@ax/lib/json";
+import { prettyPrint } from "@ax/lib/json";
 import { deriveDirectiveCandidates, scoreDirectiveCandidates, type DirectiveTurnRow } from "../../ingest/directives.ts";
+import { listDirectiveProposals, type ProposalRow } from "../../improve/list.ts";
 import { fetchDirectiveLift } from "../../queries/directive-ngrams.ts";
 import { renderDirectivesBrief } from "../directives-brief-template.ts";
 import type { RuntimeManifest } from "./manifest.ts";
@@ -134,27 +135,11 @@ const listCommand = Command.make(
     },
     ({ status, json }) =>
         Effect.gen(function* () {
-            const db = yield* SurrealClient;
             const statusFilter = optionValue(status) ?? "open";
 
-            const whereStatus = statusFilter !== "all"
-                ? `AND p.status = ${surrealLiteral(statusFilter)}`
-                : "";
-
-            const sql = `
-SELECT type::string(p.id) AS id, p.form, p.title, p.hypothesis, p.dedupe_sig,
-       p.frequency, p.confidence, p.status, type::string(p.created_at) AS created_at
-FROM proposal AS p
-WHERE p.form = "guidance"
-  AND p.id IN (SELECT proposal FROM guidance_proposal WHERE section = "directives")
-  ${whereStatus}
-ORDER BY p.frequency DESC, p.created_at DESC
-LIMIT 30;`;
-
-            const [rows] = yield* db.query<[Array<Record<string, unknown>>]>(sql).pipe(
-                Effect.orElseSucceed(() => [[] as Array<Record<string, unknown>>]),
+            const proposals = yield* listDirectiveProposals(statusFilter).pipe(
+                Effect.orElseSucceed(() => [] as ReadonlyArray<ProposalRow>),
             );
-            const proposals = rows ?? [];
 
             if (json) {
                 console.log(prettyPrint(proposals));

--- a/apps/axctl/src/cli/commands/ax-directives.ts
+++ b/apps/axctl/src/cli/commands/ax-directives.ts
@@ -18,7 +18,7 @@
 import { Effect, FileSystem, Path } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import { SurrealClient } from "@ax/lib/db";
-import { prettyPrint } from "@ax/lib/json";
+import { prettyPrint, surrealLiteral } from "@ax/lib/json";
 import { deriveDirectiveCandidates, scoreDirectiveCandidates, type DirectiveTurnRow } from "../../ingest/directives.ts";
 import { fetchDirectiveLift } from "../../queries/directive-ngrams.ts";
 import { renderDirectivesBrief } from "../directives-brief-template.ts";
@@ -138,7 +138,7 @@ const listCommand = Command.make(
             const statusFilter = optionValue(status) ?? "open";
 
             const whereStatus = statusFilter !== "all"
-                ? `AND p.status = "${statusFilter}"`
+                ? `AND p.status = ${surrealLiteral(statusFilter)}`
                 : "";
 
             const sql = `

--- a/apps/axctl/src/cli/commands/visible-commands.ts
+++ b/apps/axctl/src/cli/commands/visible-commands.ts
@@ -29,6 +29,7 @@ export const VISIBLE_COMMANDS: readonly string[] = [
     "profile",
     "dispatches",
     "routing",
+    "directives",
     "thinking",
     "digest",
     "team",

--- a/apps/axctl/src/cli/directives-brief-template.test.ts
+++ b/apps/axctl/src/cli/directives-brief-template.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { renderDirectivesBrief } from "./directives-brief-template.ts";
+
+test("renderDirectivesBrief lists each candidate with marker, lift, clickable source, and a fill block", () => {
+  const md = renderDirectivesBrief(
+    [
+      { turnKey: "t1", sessionId: "sess-abc", text: "remember to dogfood before showing me", pattern: "remember to", ts: "2026-06-01T00:00:00Z", score: 8.5, source: "lift" },
+      { turnKey: "t2", sessionId: "sess-def", text: "always wrap copy in code blocks", pattern: "always-verb", ts: "2026-06-02T00:00:00Z", score: 0, source: "seed" },
+    ],
+    { date: "2026-06-22", days: 90 },
+  );
+  expect(md).toContain("# "); // a header
+  expect(md.toLowerCase()).toContain("directive"); // names the task
+  expect(md).toContain("remember to dogfood before showing me"); // candidate text
+  expect(md).toContain("sess-abc"); // clickable source session
+  expect(md).toMatch(/lift|score/i); // shows the lift/score signal
+  // a per-candidate fill block with the decision fields
+  expect(md.toLowerCase()).toContain("is_directive");
+  expect(md.toLowerCase()).toMatch(/landing/);
+  expect(md.toLowerCase()).toMatch(/memory|guidance|hook/);
+});
+
+test("renderDirectivesBrief handles empty candidate list without crashing", () => {
+  const md = renderDirectivesBrief([], { date: "2026-06-22", days: 90 });
+  expect(typeof md).toBe("string");
+  expect(md.length).toBeGreaterThan(0);
+});

--- a/apps/axctl/src/cli/directives-brief-template.ts
+++ b/apps/axctl/src/cli/directives-brief-template.ts
@@ -1,0 +1,95 @@
+/**
+ * Pure renderer for `ax directives mine --emit-brief` task files.
+ * No I/O, no Effect - transforms inputs to markdown string only.
+ * Modeled on renderTuneBrief (queries/routing-tune.ts) and
+ * renderClassifyBrief (cli/skills-classify-template.ts).
+ */
+
+import type { ScoredDirectiveCandidate } from "../ingest/directives.ts";
+
+export type { ScoredDirectiveCandidate };
+
+export interface DirectivesBriefOpts {
+    readonly date: string;
+    readonly days: number;
+}
+
+/**
+ * Render a `.ax/tasks/directives-<date>.md` brief for agent review.
+ *
+ * For each candidate the agent must decide:
+ *   - is_directive: true/false  (is this a genuine standing instruction?)
+ *   - canonical_text: the best one-liner wording
+ *   - landing: memory | guidance | hook  (where it should be codified)
+ *   - rationale: why
+ *
+ * Accepted candidates land via `ax improve accept` / `ax improve lint`
+ * (the guidance-form proposal row already exists in the proposal table;
+ * the brief is the agent's vetting gate before that).
+ */
+export const renderDirectivesBrief = (
+    candidates: ReadonlyArray<ScoredDirectiveCandidate>,
+    opts: DirectivesBriefOpts,
+): string => {
+    const { date, days } = opts;
+    const lines: string[] = [
+        `# directives brief - ${date}`,
+        "",
+        `Mined from the last ${days} days of user turns. Each entry is a candidate`,
+        "standing instruction detected by the directive miner.",
+        "",
+        "## Your task (agent)",
+        "",
+        "For each candidate below, judge whether it is a genuine standing directive",
+        "(a 'from now on / always / remember to' rule the user wants applied",
+        "consistently) vs. incidental phrasing in a task description. Then fill in",
+        "the decision block for each one and accept the real directives:",
+        "",
+        "```bash",
+        "ax improve list --form=guidance   # see open guidance proposals",
+        "ax improve accept <id>            # accept a directive proposal",
+        "```",
+        "",
+    ];
+
+    if (candidates.length === 0) {
+        lines.push("(no directive candidates found in the last", `${days} days)`);
+        lines.push("");
+        return lines.join("\n");
+    }
+
+    lines.push("## Candidates", "");
+    lines.push(
+        `| # | pattern | score | source | ts | session |`,
+        `|---|---|---|---|---|---|`,
+    );
+    for (let i = 0; i < candidates.length; i++) {
+        const c = candidates[i]!;
+        const score = c.source === "lift" ? c.score.toFixed(2) : "seed";
+        lines.push(
+            `| ${i + 1} | ${c.pattern} | ${score} | ${c.source} | ${c.ts.slice(0, 10)} | ${c.sessionId} |`,
+        );
+    }
+
+    lines.push("", "### Candidate texts + decision blocks", "");
+    for (let i = 0; i < candidates.length; i++) {
+        const c = candidates[i]!;
+        const score = c.source === "lift" ? c.score.toFixed(2) : "seed";
+        lines.push(
+            `#### ${i + 1}. \`${c.pattern}\` (lift/score: ${score})`,
+            "",
+            `> ${c.text}`,
+            `> session: ${c.sessionId}  ts: ${c.ts}`,
+            "",
+            "```yaml",
+            "is_directive:    # true or false",
+            "canonical_text:  # clean one-liner if true",
+            "landing:         # memory | guidance | hook",
+            "rationale:       # why",
+            "```",
+            "",
+        );
+    }
+
+    return lines.join("\n");
+};

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -223,6 +223,7 @@ describe("effect cli", () => {
             "content-types",
             "derive-metrics",
             "digest",
+            "directive-ngrams",
             "harness",
             "invoked-positions",
             "loaded-skills",

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -22,6 +22,7 @@ import { dojoCommand, dojoRuntime } from "./commands/dojo.ts";
 import { profileCommand, axProfileRuntime } from "./commands/profile.ts";
 import { dispatchesRootCommand, axDispatchesRuntime } from "./commands/ax-dispatches.ts";
 import { routingRootCommand, axRoutingRuntime } from "./commands/ax-routing.ts";
+import { directivesRootCommand, axDirectivesRuntime } from "./commands/ax-directives.ts";
 import { thinkingCommand, axThinkingRuntime } from "./commands/ax-thinking.ts";
 import { digestCommand, digestRuntime } from "./commands/digest.ts";
 import { teamCommand, teamRuntime } from "./commands/team.ts";
@@ -92,6 +93,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...axProfileRuntime,
     ...axDispatchesRuntime,
     ...axRoutingRuntime,
+    ...axDirectivesRuntime,
     ...axThinkingRuntime,
     ...digestRuntime,
     ...teamRuntime,
@@ -139,6 +141,7 @@ const registeredCommands: ReadonlyArray<Command.Command.Any> = [
     profileCommand,
     dispatchesRootCommand,
     routingRootCommand,
+    directivesRootCommand,
     thinkingCommand,
     digestCommand,
     teamCommand,

--- a/apps/axctl/src/dojo/agenda.ts
+++ b/apps/axctl/src/dojo/agenda.ts
@@ -9,7 +9,7 @@
  */
 import { Effect, type FileSystem } from "effect";
 import type { SurrealClient } from "@ax/lib/db";
-import { listProposals } from "../improve/list.ts";
+import { listDirectiveProposals, listProposals } from "../improve/list.ts";
 import { listPendingVerdicts } from "../improve/verdict-pending.ts";
 import { fetchSessionChurnSummary, type SessionChurnRow } from "../metrics/session-churn.ts";
 import { loadEffectiveRoutingTable } from "../queries/routing-table-io.ts";
@@ -17,6 +17,7 @@ import { fetchTuneProposals, type TuneProposal } from "../queries/routing-tune.t
 import { defaultTaskDir, scanTaskDir } from "./briefs.ts";
 import {
     churnHotspotItems,
+    directiveCandidateItems,
     exploreItem,
     pendingVerdictItems,
     proposalMintItem,
@@ -118,6 +119,11 @@ export const collectAgendaItems = (
             [],
         );
         const open = yield* soft("proposals", listProposals({ status: "open" }), []);
+        const directives = yield* soft(
+            "directives",
+            listDirectiveProposals("open"),
+            [],
+        );
         const tune = yield* soft(
             "routing",
             Effect.gen(function* () {
@@ -130,6 +136,7 @@ export const collectAgendaItems = (
         const items: DojoItem[] = [
             ...pendingVerdictItems(verdicts.value),
             ...briefs.value,
+            ...directiveCandidateItems(directives.value),
             ...routingBacktestItems(tune.value, opts.days),
             ...churnHotspotItems(churnRows.value),
         ];
@@ -142,6 +149,7 @@ export const collectAgendaItems = (
                 briefs.failure,
                 churnRows.failure,
                 open.failure,
+                directives.failure,
                 tune.failure,
             ].filter((failure): failure is DojoSourceFailure => failure !== null),
         };

--- a/apps/axctl/src/dojo/items.test.ts
+++ b/apps/axctl/src/dojo/items.test.ts
@@ -4,6 +4,7 @@ import type { SessionChurnRow } from "../metrics/session-churn.ts";
 import type { TuneProposal } from "../queries/routing-tune.ts";
 import {
     churnHotspotItems,
+    directiveCandidateItems,
     exploreItem,
     MINT_THRESHOLD,
     pendingVerdictItems,
@@ -121,5 +122,17 @@ describe("item mappers", () => {
         expect(sparItem().kind).toBe("spar");
         expect(sparItem().cost_class).toBe("xl");
         expect(exploreItem().kind).toBe("explore");
+    });
+
+    test("directiveCandidateItems yields one directives item when unconfirmed candidates exist", () => {
+        const items = directiveCandidateItems([{ title: "stop bare bun test" }, { title: "always use rg" }]);
+        expect(items).toHaveLength(1);
+        expect(items[0]!.kind).toBe("directives");
+        expect(items[0]!.commands).toContain("ax directives mine --emit-brief");
+        expect(items[0]!.success.length).toBeGreaterThan(0);
+    });
+
+    test("directiveCandidateItems yields nothing when there are no candidates", () => {
+        expect(directiveCandidateItems([])).toHaveLength(0);
     });
 });

--- a/apps/axctl/src/dojo/items.ts
+++ b/apps/axctl/src/dojo/items.ts
@@ -102,3 +102,31 @@ export const exploreItem = (): DojoItem => ({
     success: "at least one new outbox draft, proposal, or goal package",
     cost_class: "l",
 });
+
+/** Minimal shape of a directive candidate row consumed by the pure mapper. */
+export interface DirectiveCandidate {
+    readonly title?: string;
+}
+
+/**
+ * Pure mapper: N unconfirmed directive candidates -> one "directives" DojoItem.
+ * Returns [] when there are no candidates (self-clearing: item vanishes once
+ * all open section=directives proposals are accepted/rejected).
+ */
+export const directiveCandidateItems = (
+    candidates: readonly DirectiveCandidate[],
+): DojoItem[] => {
+    if (candidates.length === 0) return [];
+    const n = candidates.length;
+    return [
+        {
+            id: "directives:mine",
+            kind: "directives",
+            title: `Mine ${n} unconfirmed directive candidate${n === 1 ? "" : "s"} into proposals`,
+            commands: ["ax directives mine --emit-brief"],
+            success:
+                "directive proposals accepted (section=directives open proposals cleared)",
+            cost_class: "s",
+        },
+    ];
+};

--- a/apps/axctl/src/dojo/schema.test.ts
+++ b/apps/axctl/src/dojo/schema.test.ts
@@ -7,6 +7,7 @@ describe("KIND_PRIORITY", () => {
         expect(KIND_PRIORITY).toEqual([
             "verdict_pending",
             "brief_unfilled",
+            "directives",
             "routing_backtest",
             "proposal_mint",
             "experiment",

--- a/apps/axctl/src/dojo/schema.ts
+++ b/apps/axctl/src/dojo/schema.ts
@@ -7,6 +7,7 @@ export type DojoCostClass = "s" | "m" | "l" | "xl";
 export type DojoItemKind =
     | "verdict_pending"
     | "brief_unfilled"
+    | "directives"
     | "routing_backtest"
     | "proposal_mint"
     | "experiment"
@@ -17,6 +18,7 @@ export type DojoItemKind =
 export const KIND_PRIORITY: readonly DojoItemKind[] = [
     "verdict_pending",
     "brief_unfilled",
+    "directives",
     "routing_backtest",
     "proposal_mint",
     "experiment",

--- a/apps/axctl/src/improve/list.ts
+++ b/apps/axctl/src/improve/list.ts
@@ -90,16 +90,16 @@ export const listDirectiveProposals = (
     Effect.gen(function* () {
         const db = yield* SurrealClient;
         const whereStatus = status !== "all"
-            ? `AND p.status = ${surrealLiteral(status)}`
+            ? `AND status = ${surrealLiteral(status)}`
             : "";
         const sql = `
-SELECT type::string(p.id) AS id, p.form, p.title, p.hypothesis, p.dedupe_sig,
-       p.frequency, p.confidence, p.status, type::string(p.created_at) AS created_at
-FROM proposal AS p
-WHERE p.form = "guidance"
-  AND p.id IN (SELECT proposal FROM guidance_proposal WHERE section = "directives")
+SELECT type::string(id) AS id, form, title, hypothesis, dedupe_sig,
+       frequency, confidence, status, type::string(created_at) AS created_at
+FROM proposal
+WHERE form = "guidance"
+  AND id IN (SELECT proposal FROM guidance_proposal WHERE section = "directives")
   ${whereStatus}
-ORDER BY p.frequency DESC, p.created_at DESC
+ORDER BY frequency DESC, created_at DESC
 LIMIT ${limit};`;
         const result = yield* db.query<[ProposalRow[]]>(sql);
         return result?.[0] ?? [];

--- a/apps/axctl/src/improve/list.ts
+++ b/apps/axctl/src/improve/list.ts
@@ -76,3 +76,31 @@ export const listProposals = (
         const result = yield* db.query<[ProposalRow[]]>(sql);
         return result?.[0] ?? [];
     });
+
+/**
+ * List directive proposals: guidance_proposal rows with section="directives".
+ * Discriminator: guidance_proposal.section = "directives" (set by
+ * deriveDirectiveProposalRows in ingest/derive-proposals.ts). Shared by the
+ * dojo agenda source and the directives_list MCP tool.
+ */
+export const listDirectiveProposals = (
+    status: string = "open",
+    limit: number = 30,
+): Effect.Effect<ReadonlyArray<ProposalRow>, DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const whereStatus = status !== "all"
+            ? `AND p.status = ${surrealLiteral(status)}`
+            : "";
+        const sql = `
+SELECT type::string(p.id) AS id, p.form, p.title, p.hypothesis, p.dedupe_sig,
+       p.frequency, p.confidence, p.status, type::string(p.created_at) AS created_at
+FROM proposal AS p
+WHERE p.form = "guidance"
+  AND p.id IN (SELECT proposal FROM guidance_proposal WHERE section = "directives")
+  ${whereStatus}
+ORDER BY p.frequency DESC, p.created_at DESC
+LIMIT ${limit};`;
+        const result = yield* db.query<[ProposalRow[]]>(sql);
+        return result?.[0] ?? [];
+    });

--- a/apps/axctl/src/ingest/derive-directive-ngrams.test.ts
+++ b/apps/axctl/src/ingest/derive-directive-ngrams.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { buildNgramUpsertStatements } from "./derive-directive-ngrams.ts";
+import type { LiftRow } from "../queries/directive-ngrams.ts";
+
+test("buildNgramUpsertStatements emits one UPSERT per row with lift + counts", () => {
+    const rows: LiftRow[] = [
+        { ngram: "remember to", n: 2, occurrences: 10, outcomes: 8, sessions: 6, lift: 8 },
+        { ngram: "from now on", n: 3, occurrences: 5, outcomes: 4, sessions: 3, lift: 7.5 },
+    ];
+    const stmts = buildNgramUpsertStatements(rows);
+    expect(stmts).toHaveLength(2);
+    expect(stmts[0]).toContain("UPSERT directive_ngram");
+    expect(stmts[0]).toContain("lift");
+    // values present
+    expect(stmts.join("\n")).toContain("remember to");
+    expect(stmts.join("\n")).toContain("from now on");
+});
+
+test("buildNgramUpsertStatements escapes ngram into a safe record id", () => {
+    const stmts = buildNgramUpsertStatements([
+        { ngram: "git add -A", n: 3, occurrences: 5, outcomes: 5, sessions: 3, lift: 9 },
+    ]);
+    // the record id must not contain raw spaces/special chars that break SurrealQL
+    expect(stmts[0]).toMatch(/UPSERT directive_ngram[:⟨]/);
+});
+
+test("buildNgramUpsertStatements returns empty array for empty input", () => {
+    expect(buildNgramUpsertStatements([])).toEqual([]);
+});
+
+test("buildNgramUpsertStatements includes all required fields", () => {
+    const row: LiftRow = { ngram: "always use", n: 2, occurrences: 7, outcomes: 6, sessions: 4, lift: 3.5 };
+    const stmt = buildNgramUpsertStatements([row])[0]!;
+    expect(stmt).toContain("ngram");
+    expect(stmt).toContain("n");
+    expect(stmt).toContain("occurrences");
+    expect(stmt).toContain("outcomes");
+    expect(stmt).toContain("sessions");
+    expect(stmt).toContain("lift");
+    expect(stmt).toContain("last_seen");
+    expect(stmt).toContain("refit_at");
+});
+
+test("buildNgramUpsertStatements stores the raw ngram text in the ngram field", () => {
+    const row: LiftRow = { ngram: "make sure", n: 2, occurrences: 6, outcomes: 5, sessions: 3, lift: 4.2 };
+    const stmt = buildNgramUpsertStatements([row])[0]!;
+    // The raw ngram value should appear as a quoted string in the SET clause
+    expect(stmt).toContain('"make sure"');
+});

--- a/apps/axctl/src/ingest/derive-directive-ngrams.ts
+++ b/apps/axctl/src/ingest/derive-directive-ngrams.ts
@@ -1,0 +1,98 @@
+/**
+ * derive-directive-ngrams: Lift-refit ingest stage (Milestone A, Task A4 #587).
+ *
+ * Calls fetchDirectiveLift with a FIXED 90d window, then UPSERTs per-ngram
+ * lift rows into the `directive_ngram` table so the table stays fresh across
+ * incremental ingests regardless of `--since`.
+ */
+
+import { Effect, Schema } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { surrealString } from "@ax/lib/shared/surql";
+import { executeStatementsWith } from "@ax/lib/shared/statement-exec";
+import { safeKeyPart } from "@ax/lib/shared/derive-keys";
+import {
+    fetchDirectiveLift,
+    type LiftRow,
+} from "../queries/directive-ngrams.ts";
+import {
+    BaseStageStats,
+    IngestContext,
+    StageMeta,
+} from "./stage/types.ts";
+import type { StageDef } from "./stage/registry.ts";
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+export class DirectiveNgramsStats extends BaseStageStats.extend<DirectiveNgramsStats>(
+    "DirectiveNgramsStats",
+)({
+    refit: Schema.Number,
+}) {}
+
+// ---------------------------------------------------------------------------
+// Pure statement builder (TDD surface)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build one `UPSERT directive_ngram:<safe-id> SET ...` statement per row.
+ *
+ * The record ID is derived from the ngram string via `safeKeyPart` so spaces
+ * and special characters are safe for SurrealQL. The raw ngram text is stored
+ * in the `ngram` field. `first_seen` is left to the schema default (never
+ * overwritten on subsequent refits).
+ */
+export const buildNgramUpsertStatements = (rows: readonly LiftRow[]): string[] =>
+    rows.map((row) => {
+        const id = safeKeyPart(row.ngram);
+        return (
+            `UPSERT directive_ngram:${id} SET ` +
+            `ngram = ${surrealString(row.ngram)}, ` +
+            `n = ${row.n}, ` +
+            `occurrences = ${row.occurrences}, ` +
+            `outcomes = ${row.outcomes}, ` +
+            `sessions = ${row.sessions}, ` +
+            `lift = ${row.lift}, ` +
+            `last_seen = time::now(), ` +
+            `refit_at = time::now();`
+        );
+    });
+
+// ---------------------------------------------------------------------------
+// Stage definition
+// ---------------------------------------------------------------------------
+
+export const DirectiveNgramsKey = Schema.Literal("directive-ngrams");
+export type DirectiveNgramsKey = typeof DirectiveNgramsKey.Type;
+
+/**
+ * Directive-ngrams refit stage.
+ *
+ * Depends on {@link ClosureKey} (turns + outcomes must be written first).
+ * Uses a FIXED 90d window so the lift table is stable across `--since` runs.
+ */
+export const directiveNgramsStage: StageDef<DirectiveNgramsStats, SurrealClient> = {
+    meta: StageMeta.make({
+        key: "directive-ngrams",
+        deps: ["closure"],
+        tags: ["derive"],
+    }),
+    run: (_ctx: IngestContext) =>
+        Effect.gen(function* () {
+            const t0 = Date.now();
+            const rows = yield* fetchDirectiveLift({ sinceDays: 90 });
+            const stmts = buildNgramUpsertStatements(rows);
+            if (stmts.length > 0) {
+                yield* executeStatementsWith(yield* SurrealClient, stmts, {
+                    chunkSize: 500,
+                });
+            }
+            return DirectiveNgramsStats.make({
+                durationMs: Date.now() - t0,
+                summary: `refit ${rows.length} directive ngram lift rows`,
+                refit: rows.length,
+            });
+        }),
+};

--- a/apps/axctl/src/ingest/derive-proposals.ts
+++ b/apps/axctl/src/ingest/derive-proposals.ts
@@ -38,7 +38,7 @@ import { safeKeyPart, recordKeyPart } from "@ax/lib/shared/derive-keys";
 import type { HarnessLearningCandidate } from "../project/types.ts";
 import { fetchDispatchCandidates } from "../queries/dispatch-analytics.ts";
 import { fetchImageContext, type ImageContextResult } from "../queries/image-context.ts";
-import { deriveDirectiveCandidates, type DirectiveCandidate, type DirectiveTurnRow } from "./directives.ts";
+import { deriveDirectiveCandidates, scoreDirectiveCandidates, type DirectiveCandidate, type DirectiveTurnRow } from "./directives.ts";
 
 export interface DeriveProposalsStats {
     readonly skillProposals: number;
@@ -704,8 +704,27 @@ WHERE role = "user" AND text_excerpt != NONE AND text_excerpt != ""
             () => [] as DirectiveTurnRow[],
         );
         const directiveCandidates = deriveDirectiveCandidates(directiveTurns);
+
+        // A5: Load the per-user directive lift table (built by the directive-ngrams
+        // stage) and score candidates so the limit in deriveDirectiveProposalRows
+        // keeps the highest-signal ones. Tolerant: if the table is empty or the
+        // query fails, scoring falls back to seed order (v1 ordering preserved).
+        const directiveLiftMap = yield* Effect.orElseSucceed(
+            db.query<[Array<{ ngram: string; lift: number }>]>(`
+SELECT ngram, lift FROM directive_ngram WHERE lift > 0;`)
+                .pipe(Effect.map((rows) => {
+                    const map = new Map<string, number>();
+                    for (const r of rows?.[0] ?? []) {
+                        map.set(r.ngram, r.lift);
+                    }
+                    return map as ReadonlyMap<string, number>;
+                })),
+            () => new Map<string, number>() as ReadonlyMap<string, number>,
+        );
+        const scoredDirectiveCandidates = scoreDirectiveCandidates(directiveCandidates, directiveLiftMap);
+
         const { rows: directiveRows, skipped: directiveSkipped } =
-            deriveDirectiveProposalRows(directiveCandidates);
+            deriveDirectiveProposalRows(scoredDirectiveCandidates);
         const directiveStmts = buildGuidanceProposalStatements(directiveRows, existingSigs);
 
         yield* executeStatementsWith(db, [...skillStmts, ...guidanceStmts, ...routingStmts, ...imageContextStmts, ...directiveStmts], { chunkSize: 500 });

--- a/apps/axctl/src/ingest/directives.test.ts
+++ b/apps/axctl/src/ingest/directives.test.ts
@@ -87,7 +87,7 @@ describe("scoreDirectiveCandidates", () => {
             { turnKey: "t1", sessionId: "s1", text: "from now on always dogfood before showing", pattern: "from now on", ts: "2026-06-01T00:00:00Z" },
             { turnKey: "t2", sessionId: "s2", text: "never skip the typecheck", pattern: "never-verb", ts: "2026-06-02T00:00:00Z" },
         ];
-        const lift = new Map<string, number>([["from now", 9.0], ["now on", 8.0]]); // t1's ngrams have high lift; t2's not in table
+        const lift = new Map<string, number>([["always", 9.0]]); // t1 contains "always" (survives tokens() filter); t2's ngrams not in table
         const out = scoreDirectiveCandidates(candidates, lift);
         expect(out[0].turnKey).toBe("t1");          // ranked first
         expect(out[0].source).toBe("lift");

--- a/apps/axctl/src/ingest/directives.test.ts
+++ b/apps/axctl/src/ingest/directives.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { matchDirective, deriveDirectiveCandidates } from "./directives.ts";
+import { matchDirective, deriveDirectiveCandidates, scoreDirectiveCandidates } from "./directives.ts";
 
 describe("matchDirective", () => {
     test("matches explicit standing-rule lead-ins", () => {
@@ -78,5 +78,28 @@ describe("deriveDirectiveCandidates", () => {
             turn({ id: "turn:2", text_excerpt: "From now on, always verify before claiming done." }),
         ]);
         expect(out.map((c) => c.turnKey)).toEqual(["2"]);
+    });
+});
+
+describe("scoreDirectiveCandidates", () => {
+    test("ranks high-lift candidates above seed-only ones", () => {
+        const candidates = [
+            { turnKey: "t1", sessionId: "s1", text: "from now on always dogfood before showing", pattern: "from now on", ts: "2026-06-01T00:00:00Z" },
+            { turnKey: "t2", sessionId: "s2", text: "never skip the typecheck", pattern: "never-verb", ts: "2026-06-02T00:00:00Z" },
+        ];
+        const lift = new Map<string, number>([["from now", 9.0], ["now on", 8.0]]); // t1's ngrams have high lift; t2's not in table
+        const out = scoreDirectiveCandidates(candidates, lift);
+        expect(out[0].turnKey).toBe("t1");          // ranked first
+        expect(out[0].source).toBe("lift");
+        expect(out.find((c) => c.turnKey === "t2")!.source).toBe("seed"); // no lift match → seed fallback
+        expect(out[0].score).toBeGreaterThan(out.find((c) => c.turnKey === "t2")!.score);
+    });
+
+    test("cold table → all seed, original order preserved by stable sort", () => {
+        const candidates = [
+            { turnKey: "t1", sessionId: "s1", text: "remember to dogfood", pattern: "remember to", ts: "2026-06-01T00:00:00Z" },
+        ];
+        const out = scoreDirectiveCandidates(candidates, new Map());
+        expect(out[0].source).toBe("seed");
     });
 });

--- a/apps/axctl/src/ingest/directives.ts
+++ b/apps/axctl/src/ingest/directives.ts
@@ -133,40 +133,18 @@ const SEED_SCORE = 0;
 /**
  * Generate 1–4-grams from directive candidate text for lift-table lookup.
  *
- * Returns the union of:
- *   - raw n-grams (no stop-word filter) - needed because directive phrases
- *     like "from now on" / "never commit" embed stop words as their markers
- *   - filtered n-grams via `tokens()` from outcomes.ts (DRY) - mirrors how
- *     the lift table is built in `tallyNgramOutcomes`
- * Using both sets ensures matching regardless of how the table was populated.
+ * Uses the same stop-word-filtered token stream as `tallyNgramOutcomes`
+ * (via `tokens()` from outcomes.ts), so ngram keys exactly match those
+ * stored in the `directive_ngram` lift table. Directive signal markers like
+ * "always", "never", "remember", "dogfood" survive the filter; only
+ * connective particles ("from", "on", "to") are stripped.
  */
 function directiveCandidateNgrams(text: string): string[] {
-    // Raw words: same lowercasing/splitting as tokens() but WITHOUT stop-word
-    // removal, so directive markers like "from now on" stay intact.
-    const rawWords = text
-        .toLowerCase()
-        .replace(/`[^`]+`/g, " ")
-        .replace(/https?:\/\/\S+/g, " ")
-        .split(/[^a-z0-9_'-]+/)
-        .map((t) => t.replace(/^['-]+|['-]+$/g, ""))
-        .filter((t) => t.length >= 2);
-
-    // Filtered words (via DRY import of tokens()): includes n-grams built the
-    // same way as tallyNgramOutcomes so we match those keys too.
-    const filteredWords = tokens(text);
-
-    const seen = new Set<string>();
+    const words = tokens(text);
     const result: string[] = [];
-
-    for (const words of [rawWords, filteredWords]) {
-        for (let n = 1; n <= 4; n++) {
-            for (let i = 0; i <= words.length - n; i++) {
-                const ng = words.slice(i, i + n).join(" ");
-                if (!seen.has(ng)) {
-                    seen.add(ng);
-                    result.push(ng);
-                }
-            }
+    for (let n = 1; n <= 4; n++) {
+        for (let i = 0; i <= words.length - n; i++) {
+            result.push(words.slice(i, i + n).join(" "));
         }
     }
     return result;

--- a/apps/axctl/src/ingest/directives.ts
+++ b/apps/axctl/src/ingest/directives.ts
@@ -14,6 +14,7 @@
  * verdict all come for free from `deriveProposals` + `improve`.
  */
 import { isHarnessInjected } from "./signals/core.ts";
+import { tokens } from "./outcomes.ts";
 
 // Standing-rule lead-ins: each is a strong proactive-directive signal on its
 // own (unlike bare "always"/"never", which need an imperative verb - see below
@@ -116,3 +117,92 @@ export function deriveDirectiveCandidates(
     }
     return out;
 }
+
+// ---------------------------------------------------------------------------
+// A5: Lift-ranked candidate scoring
+// ---------------------------------------------------------------------------
+
+export interface ScoredDirectiveCandidate extends DirectiveCandidate {
+    readonly score: number;   // max lift among the candidate's ngrams; seed-base when cold
+    readonly source: "lift" | "seed";
+}
+
+// Seed score: any real positive lift entry outranks a cold-table candidate.
+const SEED_SCORE = 0;
+
+/**
+ * Generate 1–4-grams from directive candidate text for lift-table lookup.
+ *
+ * Returns the union of:
+ *   - raw n-grams (no stop-word filter) - needed because directive phrases
+ *     like "from now on" / "never commit" embed stop words as their markers
+ *   - filtered n-grams via `tokens()` from outcomes.ts (DRY) - mirrors how
+ *     the lift table is built in `tallyNgramOutcomes`
+ * Using both sets ensures matching regardless of how the table was populated.
+ */
+function directiveCandidateNgrams(text: string): string[] {
+    // Raw words: same lowercasing/splitting as tokens() but WITHOUT stop-word
+    // removal, so directive markers like "from now on" stay intact.
+    const rawWords = text
+        .toLowerCase()
+        .replace(/`[^`]+`/g, " ")
+        .replace(/https?:\/\/\S+/g, " ")
+        .split(/[^a-z0-9_'-]+/)
+        .map((t) => t.replace(/^['-]+|['-]+$/g, ""))
+        .filter((t) => t.length >= 2);
+
+    // Filtered words (via DRY import of tokens()): includes n-grams built the
+    // same way as tallyNgramOutcomes so we match those keys too.
+    const filteredWords = tokens(text);
+
+    const seen = new Set<string>();
+    const result: string[] = [];
+
+    for (const words of [rawWords, filteredWords]) {
+        for (let n = 1; n <= 4; n++) {
+            for (let i = 0; i <= words.length - n; i++) {
+                const ng = words.slice(i, i + n).join(" ");
+                if (!seen.has(ng)) {
+                    seen.add(ng);
+                    result.push(ng);
+                }
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * Rank directive candidates by the learned per-user lift table.
+ *
+ * For each candidate: tokenize text, generate 1–4-grams, look each up in
+ * `liftTable`, take the MAX lift found. `source="lift"` iff at least one
+ * ngram had a positive entry; else `source="seed"` with score=SEED_SCORE so
+ * any real positive lift outranks. Sort by score desc (stable).
+ *
+ * Pure: the DB read of liftTable lives in deriveProposals.
+ */
+export const scoreDirectiveCandidates = (
+    candidates: readonly DirectiveCandidate[],
+    liftTable: ReadonlyMap<string, number>,
+): ScoredDirectiveCandidate[] => {
+    const scored = candidates.map((c): ScoredDirectiveCandidate => {
+        const ngrams = directiveCandidateNgrams(c.text);
+        let maxLift: number | null = null;
+
+        for (const ng of ngrams) {
+            const lift = liftTable.get(ng);
+            if (lift !== undefined && lift > 0) {
+                if (maxLift === null || lift > maxLift) maxLift = lift;
+            }
+        }
+
+        return maxLift !== null
+            ? { ...c, score: maxLift, source: "lift" }
+            : { ...c, score: SEED_SCORE, source: "seed" };
+    });
+
+    // Stable sort (JS Array.sort is stable) by score descending; ties preserve
+    // original order so cold-table runs maintain v1 ordering.
+    return scored.sort((a, b) => b.score - a.score);
+};

--- a/apps/axctl/src/ingest/outcomes.ts
+++ b/apps/axctl/src/ingest/outcomes.ts
@@ -128,13 +128,13 @@ export function deriveCommandOutcomes(rows: readonly ToolCallOutcomeRow[]): Comm
     });
 }
 
-const STOP_WORDS = new Set([
+export const STOP_WORDS = new Set([
     "the", "and", "for", "that", "this", "with", "you", "can", "are", "was", "were", "have", "has", "but", "not", "from", "into",
     "if", "there", "to", "see", "your", "our", "their", "then", "when", "what", "how", "why", "does", "did", "would", "should",
     "could", "let", "lets", "we", "my", "me", "it", "its", "is", "in", "on", "as", "of", "or", "be", "so", "do",
 ]);
 
-function tokens(text: string): string[] {
+export function tokens(text: string): string[] {
     return text
         .toLowerCase()
         .replace(/`[^`]+`/g, " ")

--- a/apps/axctl/src/ingest/stage/registry.ts
+++ b/apps/axctl/src/ingest/stage/registry.ts
@@ -34,6 +34,7 @@ import { harnessStage } from "../harness.ts";
 import { digestStage } from "../../digest/digest-stage.ts";
 import { usageStage } from "../../usage/usage-stage.ts";
 import { contentTypesStage } from "../derive-content-types.ts";
+import { directiveNgramsStage } from "../derive-directive-ngrams.ts";
 
 export type { StageDef } from "./types.ts";
 
@@ -63,7 +64,7 @@ export const StageRegistryLive = (
     });
 
 /** The canonical list of stages provided by `StageRegistryDefault`. */
-export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, claudeConfigStage, pricingStage, claudeStage, codexStage, piStage, opencodeStage, cursorStage, subagentsStage, claudeSidecarsStage, invokedPositionsStage, spawnedStage, loadedSkillsStage, gitStage, githubPrStage, signalsStage, outcomesStage, turnContentBlocksStage, turnAnalysisStage, reactionEventsStage, classifierResultsStage, sessionHealthStage, closureStage, deriveMetricsStage, proposalsStage, opportunitiesStage, retroProposalsStage, harnessStage, digestStage, usageStage, contentTypesStage] as const;
+export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, claudeConfigStage, pricingStage, claudeStage, codexStage, piStage, opencodeStage, cursorStage, subagentsStage, claudeSidecarsStage, invokedPositionsStage, spawnedStage, loadedSkillsStage, gitStage, githubPrStage, signalsStage, outcomesStage, turnContentBlocksStage, turnAnalysisStage, reactionEventsStage, classifierResultsStage, sessionHealthStage, closureStage, deriveMetricsStage, proposalsStage, opportunitiesStage, retroProposalsStage, harnessStage, digestStage, usageStage, contentTypesStage, directiveNgramsStage] as const;
 
 /** Production registry: the canonical list of stages provided by ax. Test code
  *  should prefer `StageRegistryLive([...])` with explicit fixtures. */

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -31,6 +31,7 @@ const EXPECTED_TOOLS = [
     "cost_routability",
     "dispatches",
     "dojo_agenda",
+    "directives_list",
 ] as const;
 
 describe("axMcpTools registry", () => {

--- a/apps/axctl/src/mcp/tools.test.ts
+++ b/apps/axctl/src/mcp/tools.test.ts
@@ -26,6 +26,7 @@ const EXPECTED_INPUT_SHAPES: Record<string, readonly string[]> = {
     cost_routability: ["days", "min_run"],
     dispatches: ["candidates", "days", "limit"],
     dojo_agenda: ["days", "spar"],
+    directives_list: ["limit", "status"],
 };
 
 describe("axMcpTools advertised surface", () => {

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -53,7 +53,7 @@ import {
 } from "../dashboard/role-queries.ts";
 import { recommend, normalizeRecommendInput } from "../improve/recommend.ts";
 import { showExperiment } from "../improve/show.ts";
-import { listProposals, normalizeListProposalsInput } from "../improve/list.ts";
+import { listDirectiveProposals, listProposals, normalizeListProposalsInput } from "../improve/list.ts";
 import { fetchSessionMetrics } from "../metrics/session-metrics-query.ts";
 import { SIGNAL_CATALOG, findSignal, runRelationSignal } from "../metrics/catalog.ts";
 import {
@@ -741,6 +741,30 @@ const dojoAgendaTool: AxMcpTool = defineMcpTool({
     },
 });
 
+const directivesListTool: AxMcpTool = defineMcpTool({
+    name: "directives_list",
+    description:
+        "List tracked directive proposals (guidance form, section=directives), sorted by recurrence (frequency). Returns rows with id, title, status, confidence and dedupe_sig. Use to see what directive candidates have been mined and whether they are still open. Read-only.",
+    inputSchema: {
+        status: z
+            .string()
+            .optional()
+            .describe('Status filter (default "open"; pass "all" to disable).'),
+        limit: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Max proposals to return (default 30)."),
+    },
+    run: async (args, rt) => {
+        const status = args.status ?? "open";
+        const limit = args.limit ?? 30;
+        const rows = await rt.runPromise(listDirectiveProposals(status, limit));
+        return { proposals: rows };
+    },
+});
+
 /**
  * All registered MCP tools. `server.ts` iterates this array to register +
  * wrap each one.
@@ -769,4 +793,5 @@ export const axMcpTools: ReadonlyArray<AxMcpTool> = [
     costRoutabilityTool,
     dispatchesTool,
     dojoAgendaTool,
+    directivesListTool,
 ];

--- a/apps/axctl/src/queries/directive-ngrams.test.ts
+++ b/apps/axctl/src/queries/directive-ngrams.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { computeLift } from "./directive-ngrams.ts";
+
+test("lift ranks outcome-leading ngrams above filler", () => {
+  const rows = [
+    { ngram: "remember to", n: 2, occurrences: 10, outcomes: 8, sessions: 6 },
+    { ngram: "can you",     n: 2, occurrences: 40, outcomes: 4, sessions: 20 },
+  ];
+  const out = computeLift(rows, 0.1, { minOccurrences: 5, minSessions: 3 });
+  expect(out.find((r) => r.ngram === "remember to")!.lift).toBeCloseTo(8.0, 1); // (8/10)/0.1
+  expect(out.find((r) => r.ngram === "can you")!.lift).toBeCloseTo(1.0, 1);     // (4/40)/0.1
+  expect(out[0].ngram).toBe("remember to"); // sorted desc by lift
+});
+
+test("sparsity guard drops ngrams below thresholds", () => {
+  const rows = [{ ngram: "one off", n: 2, occurrences: 2, outcomes: 2, sessions: 1 }];
+  expect(computeLift(rows, 0.1, { minOccurrences: 5, minSessions: 3 })).toHaveLength(0);
+});
+
+test("baseRate of zero yields zero lift, never NaN/Infinity", () => {
+  const rows = [{ ngram: "x y", n: 2, occurrences: 5, outcomes: 0, sessions: 3 }];
+  expect(computeLift(rows, 0, { minOccurrences: 5, minSessions: 3 })[0].lift).toBe(0);
+});

--- a/apps/axctl/src/queries/directive-ngrams.test.ts
+++ b/apps/axctl/src/queries/directive-ngrams.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { computeLift } from "./directive-ngrams.ts";
+import { computeLift, tallyNgramOutcomes } from "./directive-ngrams.ts";
 
 test("lift ranks outcome-leading ngrams above filler", () => {
   const rows = [
@@ -20,4 +20,23 @@ test("sparsity guard drops ngrams below thresholds", () => {
 test("baseRate of zero yields zero lift, never NaN/Infinity", () => {
   const rows = [{ ngram: "x y", n: 2, occurrences: 5, outcomes: 0, sessions: 3 }];
   expect(computeLift(rows, 0, { minOccurrences: 5, minSessions: 3 })[0].lift).toBe(0);
+});
+
+test("tallyNgramOutcomes credits ngrams whose turn precedes an in-window same-session outcome", () => {
+  const turns = [
+    { id: "t1", sid: "sA", seq: 1, ts: "2026-06-01T00:00:00Z", text_excerpt: "remember to dogfood before showing me" },
+    { id: "t2", sid: "sA", seq: 50, ts: "2026-06-01T05:00:00Z", text_excerpt: "remember to dogfood before showing me" }, // outcome ts before this turn - out of window
+    { id: "t3", sid: "sB", seq: 1, ts: "2026-06-02T00:00:00Z", text_excerpt: "can you explain this" },
+  ];
+  const outcomes = [
+    { sid: "sA", ts: "2026-06-01T00:30:00Z" }, // after t1 (in window), before t2 (t2 has no outcome)
+  ];
+  const rows = tallyNgramOutcomes(turns, outcomes, { windowTurns: 20 });
+  const dogfood = rows.find((r) => r.ngram === "remember dogfood" || r.ngram.includes("dogfood"));
+  // ngrams from t1 are credited (t1 is before the outcome); t2 contributes to occurrences but not outcomes
+  expect(dogfood).toBeDefined();
+  expect(dogfood!.outcomes).toBeGreaterThanOrEqual(1);
+  // ngram only from sB (no outcome in sB) gets 0 outcomes
+  const explainRow = rows.find((r) => r.ngram.includes("explain"));
+  expect(explainRow?.outcomes ?? 0).toBe(0);
 });

--- a/apps/axctl/src/queries/directive-ngrams.ts
+++ b/apps/axctl/src/queries/directive-ngrams.ts
@@ -1,3 +1,7 @@
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import { tokens } from "../ingest/outcomes.ts";
+
 export interface NgramOutcomeRow {
   readonly ngram: string;
   readonly n: number;
@@ -9,6 +13,256 @@ export interface NgramOutcomeRow {
 export interface LiftRow extends NgramOutcomeRow {
   readonly lift: number;
 }
+
+// ---------------------------------------------------------------------------
+// Input types for tallyNgramOutcomes
+// ---------------------------------------------------------------------------
+
+export interface UserTurnInput {
+  readonly id: string;
+  readonly sid: string;
+  readonly seq: number;
+  readonly ts: string;
+  readonly text_excerpt: string;
+}
+
+/** A captured outcome that occurred in session `sid` at time `ts`. */
+export interface OutcomeMarker {
+  readonly sid: string;
+  readonly ts: string;
+}
+
+export interface FetchLiftInput {
+  readonly sinceDays: number;
+  readonly windowTurns?: number; // default 20
+  readonly limit?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure: tallyNgramOutcomes
+// ---------------------------------------------------------------------------
+
+/**
+ * For each user turn, generate 1-4 grams (using the shared tokenizer from
+ * outcomes.ts). A turn "has outcome" if an OutcomeMarker exists in the same
+ * session with ts > turn.ts, and the number of user turns in that session
+ * strictly between turn.ts and outcome.ts is < windowTurns.
+ *
+ * Returns per-ngram { occurrences, outcomes, sessions } suitable for computeLift.
+ */
+export const tallyNgramOutcomes = (
+  turns: readonly UserTurnInput[],
+  outcomes: readonly OutcomeMarker[],
+  opts?: { readonly windowTurns?: number },
+): NgramOutcomeRow[] => {
+  const windowTurns = opts?.windowTurns ?? 20;
+
+  // Group user turns by session, sorted by ts asc
+  const turnsBySid = new Map<string, UserTurnInput[]>();
+  for (const t of turns) {
+    const bucket = turnsBySid.get(t.sid);
+    if (bucket) {
+      bucket.push(t);
+    } else {
+      turnsBySid.set(t.sid, [t]);
+    }
+  }
+  for (const bucket of turnsBySid.values()) {
+    bucket.sort((a, b) => a.ts.localeCompare(b.ts));
+  }
+
+  // Group outcome markers by session
+  const outcomesBySid = new Map<string, OutcomeMarker[]>();
+  for (const o of outcomes) {
+    const bucket = outcomesBySid.get(o.sid);
+    if (bucket) {
+      bucket.push(o);
+    } else {
+      outcomesBySid.set(o.sid, [o]);
+    }
+  }
+
+  // Determine which turns "have outcome" within the forward window
+  const turnHasOutcome = new Map<string, boolean>();
+  for (const [sid, sessionTurns] of turnsBySid) {
+    const sessionOutcomes = outcomesBySid.get(sid) ?? [];
+    for (const turn of sessionTurns) {
+      let hasOutcome = false;
+      for (const outcome of sessionOutcomes) {
+        if (outcome.ts <= turn.ts) continue; // outcome not after this turn
+        // Count user turns strictly between turn.ts and outcome.ts (ts-based window proxy)
+        const turnsBetween = sessionTurns.filter(
+          (t) => t.ts > turn.ts && t.ts < outcome.ts,
+        ).length;
+        if (turnsBetween < windowTurns) {
+          hasOutcome = true;
+          break;
+        }
+      }
+      turnHasOutcome.set(turn.id, hasOutcome);
+    }
+  }
+
+  // Aggregate 1-4 grams across all turns
+  interface NgramAcc {
+    n: number;
+    occurrences: number;
+    outcomes: number;
+    sessions: Set<string>;
+  }
+  const ngramMap = new Map<string, NgramAcc>();
+
+  for (const turn of turns) {
+    const tks = tokens(turn.text_excerpt ?? "");
+    if (tks.length === 0) continue;
+    const hasOutcome = turnHasOutcome.get(turn.id) ?? false;
+
+    for (let n = 1; n <= 4; n++) {
+      for (let i = 0; i <= tks.length - n; i++) {
+        const ngram = tks.slice(i, i + n).join(" ");
+        const key = `${n}:${ngram}`;
+        const existing = ngramMap.get(key);
+        if (existing) {
+          existing.occurrences += 1;
+          if (hasOutcome) existing.outcomes += 1;
+          existing.sessions.add(turn.sid);
+        } else {
+          ngramMap.set(key, {
+            n,
+            occurrences: 1,
+            outcomes: hasOutcome ? 1 : 0,
+            sessions: new Set([turn.sid]),
+          });
+        }
+      }
+    }
+  }
+
+  return [...ngramMap.entries()].map(([key, acc]) => ({
+    ngram: key.slice(key.indexOf(":") + 1),
+    n: acc.n,
+    occurrences: acc.occurrences,
+    outcomes: acc.outcomes,
+    sessions: acc.sessions.size,
+  }));
+};
+
+// ---------------------------------------------------------------------------
+// Effect: fetchDirectiveLift
+// ---------------------------------------------------------------------------
+
+// SQL boundary guard
+const sqlDays = (n: number): number => Math.max(1, Math.trunc(n));
+
+/**
+ * Statement 1: User turns in the last `sinceDays` days, excluding subagent
+ * sessions. Mirrors the v1 directive turn-fetch shape from derive-proposals.ts.
+ *
+ * Note: `session.source` is a record-deref in the WHERE clause. This is NOT
+ * inside an aggregate and the turn table is indexed on ts. SurrealDB resolves
+ * this per-row at read time; performance is acceptable on 90d windows (tested
+ * in derive-proposals with identical shape).
+ */
+const userTurnsSql = (sinceDays: number) => `
+SELECT type::string(id) AS id, type::string(session) AS sid, seq, text_excerpt, type::string(ts) AS ts
+FROM turn
+WHERE role = "user" AND text_excerpt != NONE AND text_excerpt != ""
+  AND ts > time::now() - ${sqlDays(sinceDays)}d AND session.source != "claude-subagent";
+`;
+
+/**
+ * Statement 2: Outcome markers from edited edges where the path targets a
+ * memory or hooks directory. Projects `in.session` - a SELECT-projection
+ * deref (NOT inside an aggregate). The matching rows are small in practice
+ * (only writes to /memory/ and /.ax/hooks/ paths), so this does not trigger
+ * the per-edge deref hang seen in the 87k-row aggregate case.
+ *
+ * Proposals with status='accepted' are omitted in v1: the proposal table
+ * carries no session field and cites_evidence → skill_candidate also lacks
+ * one, making a deref-free session mapping impossible without a third query.
+ * Documented as a known limitation (NEEDS_CONTEXT for v2).
+ */
+const outcomeMarkersSql = (sinceDays: number) => `
+SELECT type::string(in.session) AS sid, type::string(ts) AS ts
+FROM edited
+WHERE (absolute_path_seen CONTAINS '/memory/' OR path_seen CONTAINS '/memory/'
+    OR absolute_path_seen CONTAINS '/.ax/hooks/' OR path_seen CONTAINS '/.ax/hooks/')
+    AND ts > time::now() - ${sqlDays(sinceDays)}d AND in != NONE;
+`;
+
+interface RawUserTurn {
+  readonly id: unknown;
+  readonly sid: unknown;
+  readonly seq: unknown;
+  readonly text_excerpt: unknown;
+  readonly ts: unknown;
+}
+
+interface RawOutcomeMarker {
+  readonly sid: unknown;
+  readonly ts: unknown;
+}
+
+export const fetchDirectiveLift = Effect.fn("queries.fetchDirectiveLift")(
+  function* (input: FetchLiftInput) {
+    const db = yield* SurrealClient;
+    const sinceDays = input.sinceDays;
+    const windowTurns = input.windowTurns ?? 20;
+    const limit = input.limit ?? 200;
+
+    // Query 1: user turns
+    const [rawTurns] = yield* db.query<[Array<RawUserTurn>]>(userTurnsSql(sinceDays));
+
+    // Query 2: outcome markers (memory/hooks edited edges)
+    const [rawOutcomes] = yield* db.query<[Array<RawOutcomeMarker>]>(outcomeMarkersSql(sinceDays));
+
+    // Parse user turns
+    const turns: UserTurnInput[] = (rawTurns ?? [])
+      .filter((r) => r.id != null && r.sid != null && r.ts != null && typeof r.text_excerpt === "string" && r.text_excerpt.length > 0)
+      .map((r) => ({
+        id: String(r.id),
+        sid: String(r.sid),
+        seq: typeof r.seq === "number" ? r.seq : 0,
+        ts: String(r.ts),
+        text_excerpt: String(r.text_excerpt),
+      }));
+
+    // Parse outcome markers
+    const outcomes: OutcomeMarker[] = (rawOutcomes ?? [])
+      .filter((r) => r.sid != null && r.ts != null)
+      .map((r) => ({
+        sid: String(r.sid),
+        ts: String(r.ts),
+      }));
+
+    // Pure: tally ngram × outcome co-occurrences
+    const tallyRows = tallyNgramOutcomes(turns, outcomes, { windowTurns });
+
+    // Compute base rate: fraction of user turns that have an outcome in window
+    // Re-compute here using the same logic as tallyNgramOutcomes
+    const turnsWithOutcome = turns.filter((t) => {
+      const sessionOutcomes = outcomes.filter((o) => o.sid === t.sid && o.ts > t.ts);
+      if (sessionOutcomes.length === 0) return false;
+      const sessionTurns = turns.filter((u) => u.sid === t.sid);
+      sessionTurns.sort((a, b) => a.ts.localeCompare(b.ts));
+      for (const outcome of sessionOutcomes) {
+        const between = sessionTurns.filter((u) => u.ts > t.ts && u.ts < outcome.ts).length;
+        if (between < windowTurns) return true;
+      }
+      return false;
+    });
+
+    const baseRate = turns.length > 0 ? turnsWithOutcome.length / turns.length : 0;
+
+    const liftRows = computeLift(tallyRows, baseRate, { minOccurrences: 5, minSessions: 3 });
+
+    return liftRows.slice(0, limit);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// computeLift
+// ---------------------------------------------------------------------------
 
 // baseRate = (total turns with an outcome) / (total turns considered)
 export const computeLift = (

--- a/apps/axctl/src/queries/directive-ngrams.ts
+++ b/apps/axctl/src/queries/directive-ngrams.ts
@@ -1,0 +1,30 @@
+export interface NgramOutcomeRow {
+  readonly ngram: string;
+  readonly n: number;
+  readonly occurrences: number;   // turns containing ngram
+  readonly outcomes: number;      // of those, followed by an outcome within the window
+  readonly sessions: number;      // distinct sessions
+}
+
+export interface LiftRow extends NgramOutcomeRow {
+  readonly lift: number;
+}
+
+// baseRate = (total turns with an outcome) / (total turns considered)
+export const computeLift = (
+  rows: readonly NgramOutcomeRow[],
+  baseRate: number,
+  opts?: { readonly minOccurrences?: number; readonly minSessions?: number },
+): LiftRow[] => {
+  const minOcc = opts?.minOccurrences ?? 5;
+  const minSess = opts?.minSessions ?? 3;
+  const safeBase = baseRate > 0 ? baseRate : 0;
+  return rows
+    .filter((r) => r.occurrences >= minOcc && r.sessions >= minSess)
+    .map((r) => {
+      const pOutcome = r.occurrences > 0 ? r.outcomes / r.occurrences : 0;
+      const lift = safeBase > 0 ? pOutcome / safeBase : 0;
+      return { ...r, lift };
+    })
+    .sort((a, b) => b.lift - a.lift || b.occurrences - a.occurrences || a.ngram.localeCompare(b.ngram));
+};

--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -96,6 +96,7 @@ export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "stack", stage: "active", note: "Lean technology/platform records for applicability matching." },
     { table: "command_outcome", stage: "active", note: "Semantic command result classifications." },
     { table: "user_message_ngram", stage: "active", note: "Derived user-language n-grams for preference and correction mining." },
+    { table: "directive_ngram", stage: "active", note: "Per-user n-gram lift table: which user-turn markers predict captured outcomes (directive mining v2, #587)." },
     { table: "workflow_epoch", stage: "active", note: "Derived workflow eras for before/after comparisons." },
     { table: "session_token_usage", stage: "active", note: "Actual or estimated session token/cache usage." },
     { table: "turn_token_usage", stage: "active", note: "Provider-derived per-turn token/cache usage and priced cost estimates." },

--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -407,6 +407,31 @@ published 6 wrapped cards - the dashboard landing serves them now`,
           "ax wrapped publish replaces the wrapped_card set from { cards: [{question, headline, body, sensitivity?}] } JSON.",
         ],
       },
+      {
+        name: "directives",
+        sub: ["mine", "list", "ngrams"],
+        job: "Mine candidate directive turns by lift, track proposals, and inspect the n-gram lift table.",
+        signature: "ax directives mine [--days=N] [--emit-brief] | list [--status=...] | ngrams [--limit=N]",
+        flags: [
+          { flag: "--emit-brief", desc: "(mine) write .ax/tasks/directives-<date>.md for agent review" },
+          { flag: "--days=N", desc: "(mine) look-back window in days (default 90)" },
+          { flag: "--status=open|all", desc: "(list) filter by proposal status (default open)" },
+          { flag: "--limit=N", desc: "(ngrams) cap rows (default 50)" },
+          { flag: "--json", desc: "machine output on any sub-verb" },
+        ],
+        receipt: `$ ax directives mine --days=90
+#    score  src    pattern             ts          session              text
+1     2.41  lift   always use         2026-06-20  session:7f2a3b4c     always use Effect.gen for...
+2     1.88  lift   prefer typed       2026-06-19  session:9d1e0a2f     prefer typed schemas over...
+
+12 candidates (90 days)  emit brief: ax directives mine --emit-brief`,
+        detail: [
+          "ax directives mine ranks user-turn candidates by n-gram lift (learned from correction events at ingest); --emit-brief writes .ax/tasks/directives-<date>.md for agent review, --json emits raw scored rows.",
+          "ax directives list shows tracked directive proposals (guidance_proposal.section=directives), sorted by recurrence; --status=all includes accepted/rejected.",
+          "ax directives ngrams shows the learned per-user directive lift table (directive_ngram rows sorted by lift desc); lift = outcome-rate / base-rate, higher = stronger directional signal.",
+          "Accepted proposals land via: ax improve accept <id>. Directive mining runs at ingest (derive phase); re-run ax ingest to refresh the lift table. MCP: directives_list.",
+        ],
+      },
     ],
   },
   {

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -57,6 +57,9 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax improve recommend / accept / lint / show` - evidence-backed proposals (guidance, skills, hooks, automations) derived from the graph; accept emits a task brief, lint reconciles applied guidance
 - `ax retro emit / pending / brief` + `ax:retro` skill - guided experiment-loop retrospective: triage proposals, lock verdicts, review hook effectiveness
 - `ax:dojo` skill - surplus-quota overnight training loop: budget-bounded self-improvement (verdicts, briefs, routing, proposals, experiments); install via `npx skills add Necmttn/ax`
+- `ax directives mine [--days=N] [--emit-brief] [--json]` - rank candidate directive turns by n-gram lift; --emit-brief writes .ax/tasks/directives-<date>.md for agent review; accepted proposals land via ax improve accept <id>
+- `ax directives list [--status=open|all] [--json]` - tracked directive proposals (guidance/section=directives), sorted by recurrence
+- `ax directives ngrams [--limit=N] [--json]` - the learned per-user directive lift table (directive_ngram rows, lift = outcome-rate / base-rate). MCP: directives_list
 - `ax hooks init / install / backtest / bench / cases` - author typed TypeScript hooks once, run them on Claude Code + Codex; replay history through a hook before installing it
 - `ax hooks bench <file> [--days=N] [--runs=N] [--budget-ms=N] [--json]` - latency ledger: per-fire p50/p95 from real bun spawns, est fires/day from tool_call history, installed-chain budget vs --budget-ms default 250
 - `ax hooks latency [--days=N] [--baseline=M] [--json]` - regression lens: compare recent (default 7d) vs baseline (default 21d) fire latency per hook event (hook_name is event-granular, e.g. PreToolUse:Bash) from hook_command_invocation telemetry; flags hook events where p95 regressed (factor 1.5, min 15ms delta, min 20 samples)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,10 @@ axctl routing show                          # effective routing table with class
 axctl routing impact begin --arm=off|on     # start an A/B work block (snapshots the 5h plan window)
 axctl routing impact end                     # close the open block
 axctl routing impact report [--share]       # routing off-vs-on receipt, per 5h plan window
+axctl directives mine [--days=N] [--emit-brief] [--json]
+                                            # rank candidate directive turns by n-gram lift; --emit-brief writes .ax/tasks/directives-<date>.md
+axctl directives list [--status=...] [--json]  # tracked directive proposals (section=directives), sorted by recurrence
+axctl directives ngrams [--limit=N] [--json]   # the learned per-user directive lift table (directive_ngram rows, lift = outcome-rate / base-rate)
 axctl profile show [--window=N] [--no-cost] # local profile: stats + rig + taste from the graph
 axctl wrapped <generate|publish>            # agent-authored Wrapped recap cards for the dashboard landing
 axctl profile publish [--if-stale=H] [--yes] [--skip-registration]
@@ -195,6 +199,24 @@ hook fires in the window (unlinked from outcomes - attributing an advisory to th
 resulting dispatch requires a clean PreToolUse→spawn join that isn't available;
 deferred). By-class table sorted by overspend. Use `--candidates` for the
 per-dispatch view of the expensive-tier rows.
+
+## Directive mining
+
+`ax directives mine [--days=N] [--emit-brief] [--json]` - rank candidate directive
+turns by n-gram lift. Reads the last N days of user turns (default 90), scores
+each by the learned per-user lift table (`directive_ngram`), and prints a ranked
+table. `--emit-brief` writes `.ax/tasks/directives-<date>.md` for an agent to
+review; accepted proposals land via `ax improve accept <id>`. `--json` emits raw
+scored rows.
+
+`ax directives list [--status=open|all] [--json]` - list tracked directive proposals
+(`guidance_proposal.section = 'directives'`), sorted by recurrence (frequency).
+Default status filter is `open`; `--status=all` includes accepted and rejected rows.
+
+`ax directives ngrams [--limit=N] [--json]` - show the learned per-user directive
+lift table (`directive_ngram` rows sorted by lift desc). `lift = outcome-rate /
+base-rate`; higher = stronger directional signal. Populated at ingest. Default
+`--limit=50`. MCP: `directives_list`.
 
 ## Grounded agent files (`axctl improve`)
 

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1719,6 +1719,24 @@ DEFINE INDEX IF NOT EXISTS proposal_dedupe_uq    ON proposal FIELDS dedupe_sig U
 DEFINE INDEX IF NOT EXISTS proposal_status_freq  ON proposal FIELDS status, frequency;
 DEFINE INDEX IF NOT EXISTS proposal_form_status  ON proposal FIELDS form, status, created_at;
 
+-- ==== Directive n-gram lift table (#587) ====
+-- Per-user lift table: which n-gram markers in user turns predict a captured
+-- outcome (correction follow-up, friction_event, classifier signal). Keyed by
+-- `ngram` (the whole local DB is per-user, so there is NO user column).
+-- Filled by later tasks in Milestone A; this task only defines the schema.
+DEFINE TABLE directive_ngram SCHEMAFULL;
+DEFINE FIELD ngram        ON directive_ngram TYPE string;
+DEFINE FIELD n            ON directive_ngram TYPE int;            -- token count (1..4)
+DEFINE FIELD occurrences  ON directive_ngram TYPE int DEFAULT 0; -- turns containing the ngram
+DEFINE FIELD outcomes     ON directive_ngram TYPE int DEFAULT 0; -- of those, # followed by a captured outcome
+DEFINE FIELD lift         ON directive_ngram TYPE float DEFAULT 0; -- P(outcome|ngram)/P(outcome)
+DEFINE FIELD sessions     ON directive_ngram TYPE int DEFAULT 0; -- distinct sessions (sparsity guard)
+DEFINE FIELD first_seen   ON directive_ngram TYPE datetime DEFAULT time::now();
+DEFINE FIELD last_seen    ON directive_ngram TYPE option<datetime>;
+DEFINE FIELD refit_at     ON directive_ngram TYPE datetime DEFAULT time::now();
+DEFINE INDEX IF NOT EXISTS directive_ngram_uq   ON directive_ngram FIELDS ngram UNIQUE;
+DEFINE INDEX IF NOT EXISTS directive_ngram_lift ON directive_ngram FIELDS lift;
+
 -- ==== Per-form payload tables ====
 -- One row per proposal of the matching form. Typed fields per form avoid
 -- the JSON-blob trap that killed the prior orphan tables.


### PR DESCRIPTION
Milestone A of the directive-mining v2 goal package (`docs/superpowers/plans/2026-06-22-directive-mining-v2.md`). Closes #587.

## What this ships
The per-user **n-gram lift miner** that ranks which directive markers actually lead to captured outcomes — replacing v1's static regex (PR #538) with a learned, self-refreshing signal, while keeping the regex as a cold-start seed. Rides the existing `improve` proposal pipeline; no parallel subsystem.

**Write angle:** `directive_ngram` table → `directive-ngrams` refit ingest stage (`fetchDirectiveLift` over turns × outcomes, deref-free) → lift-ranked candidate flagging feeding the existing `deriveDirectiveProposalRows`.
**Read angle (on-demand):** `ax directives mine|list|ngrams`. **(agent-facing):** dojo `directives` agenda item + `directives_list` MCP tool (19 tools now). **(distribution):** cli.md + llms.txt + cli-reference + CLAUDE.md gates green.

## Loop
`turns × outcomes → lift table (refit each ingest) → rank candidates → brief → agent judges → existing accept/lint/verdict`. Outcome (locked Q1) = a memory/hook `edited` edge within 20 forward turns, same session.

## Dogfood (live DB)
- `ax directives ngrams` reads 12 real rows from the **persisted** `directive_ngram` table after running the stage live (stage exit 0 — the one path no unit test covers).
- `ax directives mine --emit-brief` → 3 **genuine** standing-directives: *"make sure to pick up the next task and keep iterating"*, *"remember the commit each time you finish"*, *"always keep updating the references — add that memory"*. All `source=seed` (lift is additive; markers haven't accrued lift yet — matches the spec's "lift is shaky at one-user scale" caveat).
- **Bug caught + fixed by dogfood:** `listDirectiveProposals` used `FROM proposal AS p` — SurrealDB v3 rejects table aliasing, failing the whole read path (list/dojo/MCP) at runtime, **invisible to DB-free unit tests** (`list` even swallowed it via `orElseSucceed`). Fixed (`25f78fd7`).

## Verification
`bun test` → 5157 pass / 0 fail / 9 skip. `bun run typecheck` → exit 0 (pre-existing Effect-LSP advisories only, none in new files). Final whole-branch review (opus): **READY — ship it**, no Critical/Important.

## Design decisions (locked)
- Q5 schema: reuse `proposal` (directives = `guidance`/`section="directives"`); one new `directive_ngram` table (transparency surface). Recurrence = `frequency`.
- Q3 landing default `guidance`, escalate to `hook` on recurrence. Q4 recurrence identity = `dedupe_sig`.
- No embeddings; lexical + outcome-grounded; no auto-write (agent judges via brief).

## Follow-ups (non-blocking, from review)
- Stop-word filtering means canonical multi-word markers ("from now on") under-rank vs content words; seed regex is the safety net. Worth a directive-specific tokenizer in a later slice.
- N3: `outcomeMarkers` `CONTAINS` scan over `edited` — perf-watch at volume.
- N4: `directive-ngrams` stage runs after `proposals`, so scoring uses the prior ingest's table (eventually consistent; cold-start seed-handled).
- A3: per-occurrence (not per-turn) n-gram counting (lift ratio preserved); proposal-as-outcome source deferred (no session field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)