### PR TITLE
fix(site): routing copy says advise, not auto-route

### DIFF
--- a/apps/site/app/components/routing/routing-page.tsx
+++ b/apps/site/app/components/routing/routing-page.tsx
@@ -175,19 +175,19 @@ export function RoutingPage() {
         <div className="section-head">
           <span className="section-num">03 / The safety rule</span>
           <h2>
-            Judgment work <em>never</em> tiers down.
+            Judgment work <em>never</em> gets nudged down.
           </h2>
           <p className="section-lede">
-            Your obvious objection: won&rsquo;t quality drop? No &mdash; ax refuses to
-            auto-route anything that needs taste. Your reviews, your design calls, your
-            plans stay on the frontier model.
+            Your obvious objection: won&rsquo;t quality drop? No &mdash; ax never even
+            suggests tiering down anything that needs taste. Your reviews, your design
+            calls, your plans stay on the frontier model.
           </p>
         </div>
 
         <div className="rt-lanes">
           <div className="rt-lane is-down">
             <h3>
-              <span className="dot" /> tiers down automatically
+              <span className="dot" /> flagged to tier down
             </h3>
             <ul>
               <li>
@@ -210,7 +210,7 @@ export function RoutingPage() {
             </h3>
             <ul>
               <li>
-                Code review <span className="dim">(quality gate, never auto-routed)</span>
+                Code review <span className="dim">(quality gate, never flagged)</span>
               </li>
               <li>
                 Design &amp; UX <span className="dim">(taste does not tier down)</span>
@@ -226,10 +226,11 @@ export function RoutingPage() {
         </div>
 
         <div className="rt-brief-note">
-          <b>Judgment proposals ship as a brief, not a change.</b> When ax spots
-          judgment-shaped work, it ships the proposal as a written brief your agent
-          stress-tests against your own history before anything applies. Quality stays on
-          the frontier model; only routine work moves.
+          <b>ax advises &mdash; you route.</b> ax flags mechanical dispatches and nudges
+          the cheaper model at dispatch time; your agent still makes the call (a Claude
+          Code hook can&rsquo;t rewrite a dispatch, so it suggests, it doesn&rsquo;t
+          enforce). Judgment-shaped work never gets nudged &mdash; it ships as a written
+          brief your agent stress-tests against your own history before any class is added.
         </div>
       </section>
 

--- a/apps/site/app/components/showcases/dispatch-routing.tsx
+++ b/apps/site/app/components/showcases/dispatch-routing.tsx
@@ -127,12 +127,12 @@ export function DispatchRoutingShowcase() {
         </div>
 
         <div className="stat" data-kind="harness">
-          <div className="label">where the fix fires</div>
+          <div className="label">where the nudge lands</div>
           <div className="big">
-            2<span className="unit">harnesses</span>
+            Claude<span className="unit">code</span>
           </div>
           <div className="delta">route-dispatch hook · at dispatch time</div>
-          <div className="submeta">claude code + codex</div>
+          <div className="submeta">advisory - suggests, can&rsquo;t rewrite the dispatch</div>
         </div>
       </section>
 
@@ -199,12 +199,13 @@ export function DispatchRoutingShowcase() {
         <div className="step">
           <div className="step-head">
             <span className="n">03</span>
-            <span className="verb">fire</span>
+            <span className="verb">advise</span>
           </div>
           <code>route-dispatch hook</code>
           <p>
-            Suggests the cheaper model at dispatch time, in Claude Code <em>and</em> Codex.
-            The next "Fix ingest run lifecycle" rides sonnet, not fable.
+            Nudges the cheaper model at dispatch time in Claude Code &mdash; advisory, so
+            your agent decides. The next "Fix ingest run lifecycle" gets pointed at sonnet,
+            not fable.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Why

A public thread exposed a messaging gap: a user read the site as "ax routes it down for you" and asked *how* it switches models. It doesn't — ax **advises** (an advisory `route-dispatch` hook, Claude Code only) and **measures**; it never changes a model. The `/routing` page and dispatch-routing showcase overclaimed otherwise, and disagreed with our own already-honest blog/README/SKILL copy.

## What changed

`apps/site/app/components/routing/routing-page.tsx` (safety section):
- "tiers down **automatically**" → "flagged to tier down"
- "ax refuses to **auto-route** … taste" / "never **auto-routed**" → nudge / flag language
- brief-note rewritten to **"ax advises — you route"** (notes the CC hook can't rewrite a dispatch)

`apps/site/app/components/showcases/dispatch-routing.tsx`:
- stat "2 harnesses / claude code + codex" → **"where the nudge lands / Claude code / advisory"** — fixes a factual error: `encode.ts` returns a no-op `exit 0` for `Advise` on Codex, so the nudge is Claude-Code-only
- pipeline step 03 "**fire** … rides sonnet, not fable" → "**advise** … gets pointed at sonnet"

## Evidence

- `packages/hooks-sdk/src/adapters/encode.ts:27-38` — `Advise` injects `additionalContext` on Claude, bare `exit 0` (no-op) on Codex
- `packages/hooks-sdk/src/decide-verdict.ts:27-29` — CC bugs #39814/#40580: a hook can't rewrite/block the `Agent` dispatch, so it can only advise
- Already-accurate template copy: `apps/site/content/blog/2026-06-13-routing-tune.md:263-265`, `README.md:197-199`, `skills/efficient-dispatch/SKILL.md:93-100`

Follow-up for closing the gap (proactive routing): #593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)