### PR TITLE
feat(mcp): expose sessions_churn as a read-only MCP tool (#311)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ docs/superpowers/specs/2026-06-15-otel-receiver-design.md.
 `ax sessions around <date> [--days=N] [--project=PATH]` - date window, default ±3d.
 `ax sessions near <sha>` - predecessor→commit window (adaptive); falls back to ±3d for orphan commits.
 `ax sessions show <id> [--expand=<uuid>|--all] [--by-role] [--json]` - drill into one session.
-`ax sessions churn [--here|--project=PATH] [--source=S] [--since=N]` - verification churn by session/source: landed vs edit vs repair LOC, failed checks, episodes (failure opens, same-family pass closes, 30min expiry). Default 30d window.
+`ax sessions churn [--here|--project=PATH] [--source=S] [--since=N]` - verification churn by session/source: landed vs edit vs repair LOC, failed checks, episodes (failure opens, same-family pass closes, 30min expiry). Default 30d window. MCP: `sessions_churn` (explicit `project` path, no `--here`).
 
 ### Cross-source recall
 
@@ -337,14 +337,15 @@ task file, then run `axctl improve lint` to reconcile.
 
 ## MCP server
 
-`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 20 tools
+`ax mcp` runs a stdio MCP server exposing ax's **read-only** queries as 21 tools
 (`recall`, `sessions_around`, `session_show`, `skills_weighted`, `skills_by_role`,
 `skills_roles`, `roles`, `improve_recommend`, `improve_show`, `improve_list`,
-`session_metrics`, `signal_show`, `cost_models`, `cost_split`, `cost_images`,
+`session_metrics`, `sessions_churn`, `signal_show`, `cost_models`, `cost_split`, `cost_images`,
 `cost_routability`, `dispatches`, `dispatches_advice`, `dojo_agenda`, `directives_list`) so an agent can query the graph in-context. Run from source (no
 native deps, so the compiled binary should work too - untested in v0). Mutating
 ops + `sessions_here`/`near` (need a git-resolved repo key) are intentionally not
-exposed. Server: `apps/axctl/src/mcp/server.ts`; registry: `apps/axctl/src/mcp/tools.ts`.
+exposed; `sessions_churn` takes an explicit `project` path instead of `--here`.
+Server: `apps/axctl/src/mcp/server.ts`; registry: `apps/axctl/src/mcp/tools.ts`.
 
 ## Hooks SDK
 

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -24,6 +24,7 @@ const EXPECTED_TOOLS = [
     "improve_show",
     "improve_list",
     "session_metrics",
+    "sessions_churn",
     "signal_show",
     "cost_models",
     "cost_split",

--- a/apps/axctl/src/mcp/tools.test.ts
+++ b/apps/axctl/src/mcp/tools.test.ts
@@ -19,6 +19,7 @@ const EXPECTED_INPUT_SHAPES: Record<string, readonly string[]> = {
     improve_show: ["sigOrId"],
     improve_list: ["form", "limit", "status"],
     session_metrics: ["limit", "project", "sinceDays"],
+    sessions_churn: ["days", "limit", "project", "source"],
     signal_show: ["id", "limit"],
     cost_models: ["days"],
     cost_split: ["days"],

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -55,11 +55,13 @@ import { recommend, normalizeRecommendInput } from "../improve/recommend.ts";
 import { showExperiment } from "../improve/show.ts";
 import { listDirectiveProposals, listProposals, normalizeListProposalsInput } from "../improve/list.ts";
 import { fetchSessionMetrics } from "../metrics/session-metrics-query.ts";
+import { fetchSessionChurnSummary } from "../metrics/session-churn.ts";
 import { SIGNAL_CATALOG, findSignal, runRelationSignal } from "../metrics/catalog.ts";
 import {
     NEXT_PROTOCOL_HINT,
     buildRecallNext,
     buildSessionsNext,
+    buildSessionsChurnNext,
     buildSessionShowNext,
     buildSkillsWeightedNext,
     buildSkillsByRoleNext,
@@ -523,6 +525,54 @@ const sessionMetricsTool: AxMcpTool = defineMcpTool({
     },
 });
 
+const sessionsChurnTool: AxMcpTool = defineMcpTool({
+    name: "sessions_churn",
+    description:
+        `Verification-churn rollup by session and source: landed vs edit vs repair LOC, failed/passed checks, and episodes (a failure after an edit opens one, a same-family pass closes it, 30min expiry). Returns an envelope { generatedAt, filters, aggregates, hotSessions, next } - aggregates roll up per provider, hotSessions are the highest-churn sessions with per-row drill-in links. Mirrors \`ax sessions churn\`. Pass \`project\` (a repo root / cwd path) to scope - the git-resolved \`--here\` form is CLI-only. ${NEXT_PROTOCOL_HINT}`,
+    inputSchema: {
+        days: z
+            .number()
+            .int()
+            .positive()
+            .max(3650)
+            .optional()
+            .describe("Window in days (default 30, max 3650)."),
+        project: z
+            .string()
+            .optional()
+            .describe("Filter to sessions whose project or cwd equals this path (e.g. a repo root)."),
+        source: z
+            .string()
+            .optional()
+            .describe("Filter to one provider source (e.g. claude, codex, claude-subagent)."),
+        limit: z
+            .number()
+            .int()
+            .positive()
+            .max(500)
+            .optional()
+            .describe("Max hot-session rows to return (default 20, max 500)."),
+    },
+    run: async (args, rt) => {
+        // Mirror the CLI clamp (1..3650 days) so MCP and `ax sessions churn`
+        // agree on window semantics.
+        const sinceDays = args.days ?? 30;
+        const since = new Date(
+            Date.now() - Math.min(Math.max(Math.trunc(sinceDays), 1), 3650) * 86_400_000,
+        );
+        const summary = await rt.runPromise(
+            fetchSessionChurnSummary({
+                since,
+                project: args.project ?? null,
+                source: args.source ?? null,
+                limit: args.limit ?? 20,
+            }),
+        );
+        const studio = await resolveStudioTarget();
+        return buildSessionsChurnNext(summary, { studio });
+    },
+});
+
 const signalShowTool: AxMcpTool = defineMcpTool({
     name: "signal_show",
     description:
@@ -802,6 +852,7 @@ export const axMcpTools: ReadonlyArray<AxMcpTool> = [
     improveShowTool,
     improveListTool,
     sessionMetricsTool,
+    sessionsChurnTool,
     signalShowTool,
     costModelsTool,
     costSplitTool,

--- a/apps/axctl/src/nav/next-links.ts
+++ b/apps/axctl/src/nav/next-links.ts
@@ -27,6 +27,7 @@ import type {
 } from "@ax/lib/shared/dashboard-types";
 import type { WithNext } from "@ax/lib/shared/nav-link";
 import type { SessionRow } from "../dashboard/sessions-query.ts";
+import type { SessionChurnSummary, SessionChurnRow } from "../metrics/session-churn.ts";
 import type { RecallSource } from "../dashboard/recall.ts";
 import type { SkillsWeightedResult } from "../dashboard/skills-weighted.ts";
 import type {
@@ -295,11 +296,12 @@ export const buildSessionsNext = (
         }
     }
 
-    // ③ Churn rollup over the same scope - cmd-only until an MCP
-    //    sessions_churn tool exists.
+    // ③ Churn rollup over the same scope - dual transport (the sessions_churn
+    //    MCP tool now exists, #311).
     if (rows.length > 0) {
         top.push({
             description: "Aggregate verification churn (edit vs repair LOC, failed checks) for this scope",
+            call: { tool: "sessions_churn", arguments: opts.project ? { project: opts.project } : {} },
             cmd: opts.project
                 ? `ax sessions churn --project="${opts.project}"`
                 : "ax sessions churn",
@@ -332,6 +334,66 @@ export const buildSessionsNext = (
     }
 
     return { sessions, next: sortNavLinks(top) };
+};
+
+// ---------------------------------------------------------------------------
+// sessions churn
+// ---------------------------------------------------------------------------
+
+/** A churn hot-session row enriched with its drill-in `next` links. */
+export type ChurnRowWithNext = WithNext<SessionChurnRow>;
+
+export interface SessionsChurnWithNext extends Omit<SessionChurnSummary, "hotSessions"> {
+    readonly hotSessions: ReadonlyArray<ChurnRowWithNext>;
+    readonly next: ReadonlyArray<NavLink>;
+}
+
+/**
+ * Attach drill-in + broaden affordances to a churn summary. Each hot session
+ * gets a per-row `next` (drill into the session, open it in Studio); the
+ * top-level `next` flags the hottest session and, on an empty result, teaches
+ * widening the window / dropping the project filter.
+ */
+export const buildSessionsChurnNext = (
+    summary: SessionChurnSummary,
+    opts: { readonly studio?: StudioDeeplink } = {},
+): SessionsChurnWithNext => {
+    const hotSessions: ChurnRowWithNext[] = summary.hotSessions.map((row) => ({
+        ...row,
+        next: [
+            sessionShowLink(row.session),
+            ...(opts.studio ? [studioSessionLink(row.session, opts.studio)] : []),
+        ],
+    }));
+
+    const top: NavLink[] = [];
+
+    // ① Drill into the hottest session (rows arrive churn-sorted).
+    const hottest = summary.hotSessions[0];
+    if (hottest) {
+        top.push(
+            sessionShowLink(
+                hottest.session,
+                "Drill into the highest-churn session",
+                8,
+            ),
+        );
+    }
+
+    // ② Empty result - teach widening the window / dropping the project filter.
+    if (summary.hotSessions.length === 0) {
+        const project = summary.filters.project;
+        top.push({
+            description: project
+                ? "No churn in this scope - drop the project filter and scan all projects"
+                : "No churn in this window - widen --since to scan deeper history",
+            call: { tool: "sessions_churn", arguments: { days: 90 } },
+            cmd: "ax sessions churn --since=90",
+            ui: { priority: 9, group: "search" },
+        });
+    }
+
+    return { ...summary, hotSessions, next: sortNavLinks(top) };
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #311.

Adds the `sessions_churn` MCP tool — the last session query missing from the MCP surface — wrapping the existing `fetchSessionChurnSummary`.

## Why it's safe in the long-lived server
Unlike the deliberately-deferred `sessions_here`/`sessions_near` (which need a git-resolved `repositoryKey` from a `process.exit`-ing cwd resolver), churn takes an **explicit `project` path** (repo root / cwd), matching the `cost_*` tools. No git resolution in the server.

## Changes
- **`mcp/tools.ts`** — `sessionsChurnTool` (`days` / `project` / `source` / `limit`), CLI-matching clamps (window 1..3650, default 30d; limit default 20). Registered in `axMcpTools`.
- **`nav/next-links.ts`** — new `buildSessionsChurnNext`: per-hot-session drill-in + Studio deeplinks, top-level hottest-session link, empty-result widen/drop-filter affordance. Also upgrades the churn rollup link in `buildSessionsNext` from cmd-only → dual-transport (the TODO it left behind).
- **roster pins** — added to `tools.test.ts` + `server.smoke.test.ts`; CLAUDE.md MCP count 20 → 21.

## Verification
- `bun test apps/axctl/src/mcp apps/axctl/src/nav` → 63 pass
- `bun run typecheck` → exit 0 (remaining `message TS*` lines are pre-existing effect-LSP lints, none in touched files)
- Live DB smoke blocked by a wedged local SurrealDB ws handshake (the installed `ax` CLI times out too) — unrelated to this change; the tool is a thin wrapper over the unchanged query.