### PR TITLE
fix(ingest): auto-sweep stranded ingest_run rows at ingest start (#282)

### DIFF
--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -263,6 +263,26 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
         // failure paths below can address the `ingest_run` row.
         const runId = runIdFor(commandName);
 
+        // Sweep ingest_run rows stranded in "running" by crashes / SIGKILL /
+        // pre-0.25 binaries before this run starts (#282). Without this, rows
+        // left by an old binary warn in `ax doctor` forever - "re-run ax ingest"
+        // never cleared them, training users to ignore doctor. The stranded
+        // filter only matches rows whose newest heartbeat is past the ingest
+        // timeout + grace, so a live concurrent run is never reaped; this run's
+        // own row does not exist yet (runIngest creates it). Best-effort: a reap
+        // failure must never block the actual ingest.
+        yield* reapStaleIngestRuns().pipe(
+            Effect.tap((r) =>
+                r.reaped > 0
+                    ? Effect.sync(() =>
+                        process.stderr.write(
+                            `axctl ${commandName}: reaped ${r.reaped} stranded ingest_run row(s)\n`,
+                        ))
+                    : Effect.void,
+            ),
+            Effect.ignore,
+        );
+
         const work = runIngest({
             command: commandName,
             args,

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -1066,7 +1066,7 @@ export function collectDoctorReport(): Effect.Effect<
                     ? `no ingest_run rows stuck in status "running"`
                     : `${staleIngestRuns.length} ingest_run row(s) stuck in status "running" past the ` +
                         `${ingestTimeoutSeconds}s ingest timeout (${ids}); the run crashed or was killed ` +
-                        `without finalizing - run 'ax ingest reap' to settle them`,
+                        `without finalizing - the next 'ax ingest' auto-sweeps them, or run 'ax ingest reap' now`,
             });
         }
         const onboarding = yield* buildOnboardingReport();


### PR DESCRIPTION
Closes #282.

## Gap
`ingest_run` rows stranded in status `"running"` by a crash / SIGKILL / **pre-0.25 binary** warned in `ax doctor` forever — nothing settled them, so a permanent warn trained users to ignore doctor. `reapStaleIngestRuns` already existed (PR #269) but was only reachable via the manual `ax ingest reap` subcommand.

## Fix (the issue's preferred option: auto at next ingest, zero user action)
Every `ax ingest` / `ax ingest here` now runs a **best-effort reap before the run starts**:
- The stranded filter (newest heartbeat past `ingestTimeout + 60s grace`) can't match a live concurrent run, and this run's own `ingest_run` row doesn't exist yet (`runIngest` creates it) — so it's safe to do outside the ingest lock and never self-reaps.
- Wrapped in `Effect.ignore` so a reap failure can never block the actual ingest; prints a one-line stderr note only when it actually reaps something.
- Doctor's `ingest-runs` hint updated: "the next 'ax ingest' auto-sweeps them, or run 'ax ingest reap' now".

The manual `ax ingest reap` subcommand stays for on-demand use.

## Verification
- `bun test apps/axctl/src/cli/install.test.ts apps/axctl/src/ingest/reap-runs.test.ts` → 30 pass
- `bun run typecheck` → exit 0
- No test pins the old doctor message string.