### PR TITLE
fix(ingest): additive schema self-heal at ingest start (#283)

### DIFF
--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -10,6 +10,8 @@ import type { DbError } from "@ax/lib/errors";
 import { encodeClaudeProjectSlug } from "@ax/lib/transcript-locator";
 import { runIngest, withIngestRunFinish } from "../../ingest/run.ts";
 import { reapStaleIngestRuns } from "../../ingest/reap-runs.ts";
+import { healAdditiveSchemaDrift } from "../../ingest/schema-drift.ts";
+import { AX_VERSION } from "../version.ts";
 import { withIngestLock } from "../../ingest/ingest-lock.ts";
 import { StageRegistry, type StageRegistryShape } from "../../ingest/stage/registry.ts";
 import { selectByKeys, selectByTag } from "../../ingest/stage/select.ts";
@@ -262,6 +264,27 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
         // The runId is minted HERE (not inside runIngest) so the timeout and
         // failure paths below can address the `ingest_run` row.
         const runId = runIdFor(commandName);
+
+        // Additive schema self-heal (#283), before any DB write this run. A
+        // binary that adds schema fields breaks ingest against a DB whose
+        // schema predates them - SCHEMAFULL rejects the UPSERT - when the user
+        // swapped the binary without re-running the installer (the #251
+        // checksum incident forced exactly that; dev/bench setups hit it too).
+        // Replays the bundled DEFINE TABLE/FIELD statements as IF NOT EXISTS,
+        // sentinel-gated to once per version, so steady-state ingest pays only
+        // an fs.exists. Additive + idempotent + fail-open: on any failure
+        // ingest proceeds exactly as today (honest missing-field verdict #265).
+        yield* healAdditiveSchemaDrift({ version: AX_VERSION, dataDir: cfg.paths.dataDir }).pipe(
+            Effect.tap((r) =>
+                r.applied && r.statements > 0
+                    ? Effect.sync(() =>
+                        process.stderr.write(
+                            `axctl ${commandName}: applied bundled schema (${r.statements} defs) after version change\n`,
+                        ))
+                    : Effect.void,
+            ),
+            Effect.ignore,
+        );
 
         // Sweep ingest_run rows stranded in "running" by crashes / SIGKILL /
         // pre-0.25 binaries before this run starts (#282). Without this, rows

--- a/apps/axctl/src/ingest/schema-drift.test.ts
+++ b/apps/axctl/src/ingest/schema-drift.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import schemaSurql from "@ax/schema/schema.surql" with { type: "text" };
+import { asIfNotExists, schemaAdditiveHealStatements } from "./schema-drift.ts";
+
+describe("asIfNotExists", () => {
+    it("guards DEFINE TABLE", () => {
+        expect(asIfNotExists("DEFINE TABLE ingest_run SCHEMAFULL;")).toBe(
+            "DEFINE TABLE IF NOT EXISTS ingest_run SCHEMAFULL;",
+        );
+    });
+
+    it("guards DEFINE FIELD", () => {
+        expect(asIfNotExists("DEFINE FIELD last_progress_at ON ingest_run TYPE option<datetime>;")).toBe(
+            "DEFINE FIELD IF NOT EXISTS last_progress_at ON ingest_run TYPE option<datetime>;",
+        );
+    });
+
+    it("is idempotent - already-guarded statements pass through", () => {
+        const guarded = "DEFINE FIELD IF NOT EXISTS x ON t TYPE string;";
+        expect(asIfNotExists(guarded)).toBe(guarded);
+        expect(asIfNotExists("DEFINE TABLE IF NOT EXISTS t SCHEMAFULL;")).toBe(
+            "DEFINE TABLE IF NOT EXISTS t SCHEMAFULL;",
+        );
+    });
+
+    it("preserves a VALUE clause and a trailing comment", () => {
+        expect(asIfNotExists("DEFINE FIELD ingested_at ON skill TYPE datetime VALUE time::now(); -- note")).toBe(
+            "DEFINE FIELD IF NOT EXISTS ingested_at ON skill TYPE datetime VALUE time::now(); -- note",
+        );
+    });
+});
+
+describe("schemaAdditiveHealStatements", () => {
+    const sample = [
+        "DEFINE TABLE foo SCHEMAFULL;",
+        "DEFINE FIELD a ON foo TYPE string;",
+        "DEFINE INDEX foo_a ON foo FIELDS a UNIQUE;", // index: excluded
+        "DEFINE ANALYZER ascii TOKENIZERS class;", // analyzer: excluded
+        "DEFINE FUNCTION fn::x() { RETURN 1; };", // function: excluded
+        "DEFINE BUCKET media BACKEND 'file:/tmp';", // bucket: excluded
+        "-- a comment line",
+        "",
+        "DEFINE FIELD b ON foo TYPE option<int>;",
+    ].join("\n");
+
+    it("keeps only DEFINE TABLE / DEFINE FIELD, all IF NOT EXISTS guarded", () => {
+        expect(schemaAdditiveHealStatements(sample)).toEqual([
+            "DEFINE TABLE IF NOT EXISTS foo SCHEMAFULL;",
+            "DEFINE FIELD IF NOT EXISTS a ON foo TYPE string;",
+            "DEFINE FIELD IF NOT EXISTS b ON foo TYPE option<int>;",
+        ]);
+    });
+
+    it("excludes indexes, analyzers, functions, and buckets", () => {
+        const out = schemaAdditiveHealStatements(sample).join("\n");
+        expect(out).not.toContain("DEFINE INDEX");
+        expect(out).not.toContain("DEFINE ANALYZER");
+        expect(out).not.toContain("DEFINE FUNCTION");
+        expect(out).not.toContain("DEFINE BUCKET");
+    });
+
+    it("preserves source order (table before its fields)", () => {
+        const stmts = schemaAdditiveHealStatements(sample);
+        expect(stmts.indexOf("DEFINE TABLE IF NOT EXISTS foo SCHEMAFULL;")).toBeLessThan(
+            stmts.indexOf("DEFINE FIELD IF NOT EXISTS a ON foo TYPE string;"),
+        );
+    });
+});
+
+describe("against the bundled schema", () => {
+    const stmts = schemaAdditiveHealStatements(schemaSurql);
+
+    it("covers the #283 regression field (ingest_run.last_progress_at)", () => {
+        expect(stmts).toContain("DEFINE FIELD IF NOT EXISTS last_progress_at ON ingest_run TYPE option<datetime>;");
+        expect(stmts).toContain("DEFINE TABLE IF NOT EXISTS ingest_run SCHEMAFULL;");
+    });
+
+    it("every statement is an additive-safe DEFINE TABLE/FIELD IF NOT EXISTS", () => {
+        expect(stmts.length).toBeGreaterThan(100);
+        for (const s of stmts) {
+            expect(s.startsWith("DEFINE TABLE IF NOT EXISTS ") || s.startsWith("DEFINE FIELD IF NOT EXISTS ")).toBe(true);
+        }
+    });
+});

--- a/apps/axctl/src/ingest/schema-drift.ts
+++ b/apps/axctl/src/ingest/schema-drift.ts
@@ -1,0 +1,104 @@
+/**
+ * Additive schema self-heal, gated to once per binary version (#283).
+ *
+ * Releases that add schema fields break ingest for anyone who swaps the
+ * `axctl` binary without re-running `axctl install`. The DB is SCHEMAFULL, so
+ * an UPSERT that writes a field the DB's schema predates is rejected outright:
+ *
+ *   ingest: FAILED after 0 sessions - Found field 'last_progress_at', but no
+ *   such field exists for table 'ingest_run'
+ *
+ * The installer re-applies the full schema, but a manual binary swap is a real
+ * upgrade path (the v0.24.0 checksum incident #251 forced exactly that; dev /
+ * bench setups hit it too). This replays the bundled `DEFINE TABLE` / `DEFINE
+ * FIELD` statements as `IF NOT EXISTS` - a no-op for everything that already
+ * exists, an additive create for whatever the old schema lacks - so the next
+ * ingest after an upgrade heals itself.
+ *
+ * Scope is deliberately the additive subset only. Indexes (a UNIQUE rebuild can
+ * abort on duplicate data), analyzers, functions, and buckets (which need
+ * per-machine bucket-path rendering, #251) stay the installer's job - replaying
+ * them here would risk the exact transaction rollback #251 was about.
+ *
+ * A version-keyed sentinel (`dataDir/.schema-heal-<version>`) gates the replay
+ * to once per binary version: drift can only appear right after an upgrade, so
+ * steady-state ingest pays a single `fs.exists` and nothing more. The whole
+ * thing is best-effort and fail-open - on any error ingest proceeds exactly as
+ * it does today (and surfaces the honest missing-field verdict from #265),
+ * never worse.
+ */
+import { Effect, FileSystem, Path } from "effect";
+import schemaSurql from "@ax/schema/schema.surql" with { type: "text" };
+import { SurrealClient } from "@ax/lib/db";
+
+/** Statement prefixes safe to replay additively (no index/bucket/analyzer). */
+const HEAL_PREFIXES = ["DEFINE TABLE ", "DEFINE FIELD "] as const;
+
+/** Insert `IF NOT EXISTS` after the `DEFINE TABLE` / `DEFINE FIELD` keyword so
+ *  the replay is a no-op on an already-defined table/field and an additive
+ *  create otherwise. Idempotent: a statement that already carries the guard is
+ *  left untouched. */
+export const asIfNotExists = (line: string): string =>
+    line
+        .replace(/^DEFINE TABLE\s+(?!IF NOT EXISTS\b)/, "DEFINE TABLE IF NOT EXISTS ")
+        .replace(/^DEFINE FIELD\s+(?!IF NOT EXISTS\b)/, "DEFINE FIELD IF NOT EXISTS ");
+
+/**
+ * The additive heal statements derived from a schema DDL string, in source
+ * order (so each table is defined before its fields). Pure - exported for tests.
+ */
+export const schemaAdditiveHealStatements = (schema: string): string[] =>
+    schema
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => HEAL_PREFIXES.some((p) => l.startsWith(p)))
+        .map(asIfNotExists);
+
+export interface SchemaHealResult {
+    /** Whether the heal ran (false when the version sentinel already existed). */
+    readonly checked: boolean;
+    /** Whether the replay query succeeded (and the sentinel was written). */
+    readonly applied: boolean;
+    /** Number of DEFINE statements in the replay. */
+    readonly statements: number;
+}
+
+/** Path of the per-version sentinel. Exported for tests. */
+export const schemaHealSentinelPath = (pathSvc: Path.Path, dataDir: string, version: string): string =>
+    pathSvc.join(dataDir, `.schema-heal-${version}`);
+
+/**
+ * Apply the additive schema heal once per binary version. Sentinel-gated,
+ * fail-open: never fails its caller (errors collapse to `applied: false`).
+ */
+export const healAdditiveSchemaDrift = (opts: {
+    readonly version: string;
+    readonly dataDir: string;
+}): Effect.Effect<SchemaHealResult, never, SurrealClient | FileSystem.FileSystem | Path.Path> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const pathSvc = yield* Path.Path;
+        const sentinel = schemaHealSentinelPath(pathSvc, opts.dataDir, opts.version);
+
+        // Steady state: sentinel present => already healed for this version.
+        const already = yield* fs.exists(sentinel).pipe(Effect.orElseSucceed(() => false));
+        if (already) return { checked: false, applied: false, statements: 0 };
+
+        const statements = schemaAdditiveHealStatements(schemaSurql);
+        if (statements.length === 0) return { checked: true, applied: false, statements: 0 };
+
+        const db = yield* SurrealClient;
+        const applied = yield* db.query(statements.join("\n")).pipe(
+            Effect.as(true),
+            Effect.catch(() => Effect.succeed(false)),
+        );
+
+        // Only stamp the sentinel on success, so a transient failure retries on
+        // the next ingest instead of being silently skipped forever.
+        if (applied) {
+            yield* fs
+                .writeFileString(sentinel, `${new Date().toISOString()}\n`)
+                .pipe(Effect.ignore);
+        }
+        return { checked: true, applied, statements: statements.length };
+    });


### PR DESCRIPTION
Closes #283.

## Bug
Releases that add schema fields broke ingest for anyone who swapped the `axctl` binary without re-running `axctl install`. The DB is SCHEMAFULL, so an UPSERT writing a field the DB's schema predates is rejected:

```
ingest: FAILED after 0 sessions - Found field 'last_progress_at', but no such field exists for table 'ingest_run'
```

The installer re-applies the schema, but manual binary swaps are a real upgrade path (the v0.24.0 checksum incident #251 forced exactly that; dev/bench setups too).

## Fix (the issue's preferred option: auto-heal at next ingest)
`cmdIngest` now self-heals **before any DB write**: it replays the bundled `DEFINE TABLE` / `DEFINE FIELD` statements as `IF NOT EXISTS` — a no-op for what already exists, an additive create for whatever the old schema lacked.

- **Additive subset only.** Indexes (a UNIQUE rebuild can abort on duplicate data), analyzers, functions, and buckets (per-machine path rendering, #251) stay the installer's job — replaying them here would risk the exact transaction rollback #251 was about.
- **Version-keyed sentinel** (`dataDir/.schema-heal-<version>`) gates the replay to once per binary version. Drift only appears right after an upgrade, so steady-state ingest pays a single `fs.exists`.
- **Best-effort + fail-open.** Any failure leaves ingest exactly as it is today (surfacing the honest missing-field verdict from #265) — never worse. Sentinel is only stamped on success, so a transient failure retries next ingest.

New module `apps/axctl/src/ingest/schema-drift.ts`.

## Verification
- `bun test apps/axctl/src/ingest/schema-drift.test.ts` → 9 pass (1334 expects): pure parse/rewrite validated against the **bundled schema**, explicitly covering the `ingest_run.last_progress_at` regression + asserting every emitted statement is an additive-safe `DEFINE TABLE/FIELD IF NOT EXISTS`.
- `bun run typecheck` → exit 0.
- The live replay (`db.query`) path could not be exercised against a DB — the local SurrealDB ws handshake is wedged this session — but it is additive, IF-NOT-EXISTS-guarded, and fail-open.

Branch rebased onto current main (sits on top of #282/#311).