### PR TITLE
fix(ingest): clear-then-derive friction/diagnostic events on full re-derive (#549)

### DIFF
--- a/apps/axctl/src/ingest/derive-signals.ts
+++ b/apps/axctl/src/ingest/derive-signals.ts
@@ -5,6 +5,7 @@ import { AppLayer } from "@ax/lib/layers";
 import type { DbError } from "@ax/lib/errors";
 import { executeStatementsWith } from "@ax/lib/shared/statement-exec";
 import {
+    buildClearDiagnosticEventStatement, buildClearFrictionEventStatement,
     buildCorrectedByStatements, buildDiagnosticEventStatements,
     buildFrictionEventStatements, buildProposedStatements,
     buildRecoveredStatements, buildSkillPairStatements,
@@ -248,6 +249,17 @@ export const deriveSignals = Effect.fn("derive.signals")(
                 attributes: { "signals.count": recoveryBatch.length },
             }),
         );
+        // On a FULL re-derive, clear the standalone derived-event tables before
+        // re-inserting so a row the current logic no longer emits cannot orphan
+        // with a stale ts (#549). `shouldWriteSkillPairs` is exactly the
+        // full-derive gate (sinceDays undefined / <=0); a --since run keeps the
+        // UPSERT-only path so it never drops rows whose source is out of window.
+        if (shouldWriteSkillPairs) {
+            yield* exec([
+                buildClearFrictionEventStatement(),
+                buildClearDiagnosticEventStatement(),
+            ]).pipe(Effect.withSpan("signals.clear.derived-events"));
+        }
         yield* exec(buildFrictionEventStatements(frictionBatch)).pipe(
             Effect.withSpan("signals.write.friction", {
                 attributes: { "signals.count": frictionBatch.length },

--- a/apps/axctl/src/ingest/signals/statements.test.ts
+++ b/apps/axctl/src/ingest/signals/statements.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { CorrectionEdge, DerivedDiagnosticEvent, DerivedFrictionEvent } from "./types.ts";
 import {
+    buildClearDiagnosticEventStatement,
+    buildClearFrictionEventStatement,
     buildCorrectedByStatements,
     buildDiagnosticEventStatements,
     buildFrictionEventStatements,
@@ -155,5 +157,16 @@ describe("buildDiagnosticEventStatements", () => {
         expect(stmt).toContain("UPSERT diagnostic_event:`tool_failure__abc__call_1` MERGE { ");
         expect(stmt).toContain('kind: "tool_failure", status: "error", text: "Expected 1 failure"');
         expect(stmt).toContain('ts: d"2026-05-09T10:00:00.000Z" };');
+    });
+});
+
+describe("clear-table statements (#549 orphan sweep)", () => {
+    test("bare DELETE (no WHERE) so a full re-derive removes orphaned rows", () => {
+        // Bare DELETE avoids the DELETE-WHERE-on-indexed-field ghost-row footgun
+        // (PR #141); only run on a FULL re-derive that re-emits every row.
+        expect(buildClearFrictionEventStatement()).toBe("DELETE friction_event RETURN NONE;");
+        expect(buildClearDiagnosticEventStatement()).toBe("DELETE diagnostic_event RETURN NONE;");
+        expect(buildClearFrictionEventStatement()).not.toContain("WHERE");
+        expect(buildClearDiagnosticEventStatement()).not.toContain("WHERE");
     });
 });

--- a/apps/axctl/src/ingest/signals/statements.ts
+++ b/apps/axctl/src/ingest/signals/statements.ts
@@ -100,6 +100,20 @@ export const buildRecoveredStatements = (edges: readonly RecoveryEdge[]): string
         return `RELATE turn:\`${e.fromTurnKey}\` -> recovered_by:\`${edgeId}\` -> skill:\`${e.skillKey}\` SET ts = d"${e.ts}", error_excerpt = ${excerpt};`;
     });
 
+/**
+ * Truncate the standalone derived event tables before a FULL re-derive (#549).
+ * These rows are written via stable-key UPSERT, so when the current derivation
+ * logic stops emitting a given row (e.g. a classifier change), the old row is
+ * never re-touched and orphans with a stale `ts` (the 1970-epoch residue). On a
+ * full re-derive every row is re-emitted from a complete scan, so clearing
+ * first removes orphans safely. A bare `DELETE` (no WHERE) sidesteps the
+ * DELETE-WHERE-on-indexed-field ghost-row footgun (PR #141). Only safe on a
+ * full derive - a `--since` run must NOT clear (it would drop rows whose source
+ * falls outside the window).
+ */
+export const buildClearFrictionEventStatement = (): string => "DELETE friction_event RETURN NONE;";
+export const buildClearDiagnosticEventStatement = (): string => "DELETE diagnostic_event RETURN NONE;";
+
 export const buildFrictionEventStatements = (
     events: readonly DerivedFrictionEvent[],
 ): string[] =>


### PR DESCRIPTION
Closes #549.

## Root cause
Derived event rows (`friction_event`, `diagnostic_event`) are written via stable-key `UPSERT`. When the current derivation logic stops emitting a given row — e.g. a classifier change like `deriveCorrectionEdges` no longer flagging Codex image-only messages — the old row is never re-touched, so a re-derive can neither overwrite its stale `ts` (the `1970-01-01` epoch residue) nor remove it. There was no delete pass for derived rows whose producing rule stopped matching.

## Fix (the issue's option 1: scoped delete-then-derive)
On a **full** re-derive (no `--since` window) every friction/diagnostic row is re-emitted from a complete scan, so `deriveSignals` now clears those two standalone tables before re-inserting — orphans vanish.

- **Bare `DELETE` (no WHERE)** sidesteps the DELETE-WHERE-on-indexed-field ghost-row footgun (PR #141).
- **Full-derive only.** A `--since` run keeps the UPSERT-only path — clearing there would drop rows whose source falls outside the window. The gate reuses the existing full-derive predicate (`shouldDeriveAllTimeSkillPairs`, the same one guarding all-time skill-pair writes), so full-vs-scoped semantics stay consistent.

Scoped to the two tables named in the issue; the same treatment for other UPSERT-keyed derived edges (corrected_by / proposed / recovered) can follow up.

## Verification
- `bun test apps/axctl/src/ingest/signals` → 53 pass (new clear-builder goldens assert bare `DELETE ... RETURN NONE` with no `WHERE`).
- `bun run typecheck` → exit 0.
- The live clear+re-insert sequence couldn't be exercised against a DB (local SurrealDB wedged this session); the gate reuses a tested predicate and the builders are pure-tested.

Branch rebased onto current main (#283/#282/#311 already landed).