### PR TITLE
feat(hooks): dispatcher core — multiplex all guards in one process (B, stage 1)

### DIFF
--- a/packages/hooks-sdk/src/dispatch.test.ts
+++ b/packages/hooks-sdk/src/dispatch.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { dispatchEvent, dispatchInstallPlan, ALL_GUARDS, runDispatchMain } from "./dispatch.ts";
+import { defineHook, type HookDefinition } from "./define.ts";
+import { GitEnv, GitEnvTest } from "./git-env.ts";
+import { Verdict } from "./verdict.ts";
+import type { ProcessOutcome } from "./adapters/encode.ts";
+
+const run = (
+  stdin: string,
+  guards: ReadonlyArray<HookDefinition>,
+): Promise<ProcessOutcome> =>
+  Effect.runPromise(
+    dispatchEvent(stdin, {}, guards).pipe(Effect.provide(GitEnvTest({}))),
+  );
+
+const fixed = (
+  name: string,
+  tools: string[],
+  verdict: Verdict,
+): HookDefinition =>
+  defineHook({
+    name,
+    events: ["PreToolUse"],
+    matcher: { tools },
+    run: () => Effect.succeed(verdict),
+  });
+
+const claudeEdit = JSON.stringify({
+  hook_event_name: "PreToolUse",
+  tool_name: "Edit",
+  tool_input: { file_path: "/repo/x.ts" },
+  cwd: "/repo",
+});
+
+describe("dispatchEvent", () => {
+  test("runs only guards whose matcher applies", async () => {
+    const out = await run(claudeEdit, [
+      fixed("for-edit", ["Edit"], Verdict.advise("edit advice")),
+      fixed("for-bash", ["Bash"], Verdict.block("should not fire")),
+    ]);
+    // Bash guard must not have fired -> not a block.
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout).toContain("edit advice");
+  });
+
+  test("a block from any matching guard exits 2 with the reason", async () => {
+    const out = await run(claudeEdit, [
+      fixed("a", ["Edit"], Verdict.advise("a")),
+      fixed("b", ["Edit"], Verdict.block("nope")),
+    ]);
+    expect(out.exitCode).toBe(2);
+    expect(out.stderr).toBe("nope");
+  });
+
+  test("no matching guards -> allow (exit 0, no streams)", async () => {
+    const out = await run(claudeEdit, [fixed("none", ["Bash"], Verdict.block("x"))]);
+    expect(out).toEqual({ exitCode: 0 });
+  });
+
+  test("a guard defect fails open without suppressing the others", async () => {
+    const exploding = defineHook({
+      name: "boom",
+      events: ["PreToolUse"],
+      matcher: { tools: ["Edit"] },
+      run: () =>
+        Effect.sync(() => {
+          throw new Error("kaboom");
+        }),
+    });
+    const out = await run(claudeEdit, [
+      exploding,
+      fixed("survivor", ["Edit"], Verdict.advise("still here")),
+    ]);
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout).toContain("still here");
+  });
+
+  test("encodes per harness: codex advise is a no-op exit 0", async () => {
+    const codexEdit = JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "Edit",
+      tool_input: { file_path: "/repo/x.ts" },
+      cwd: "/repo",
+      turn_id: "t1",
+    });
+    const out = await run(codexEdit, [fixed("a", ["Edit"], Verdict.advise("ctx"))]);
+    // Advise only reaches the model on claude; codex -> bare allow.
+    expect(out).toEqual({ exitCode: 0 });
+  });
+
+  test("guards requiring GitEnv resolve through the provided layer", async () => {
+    const gitGuard = defineHook({
+      name: "git",
+      events: ["PreToolUse"],
+      matcher: { tools: ["Edit"] },
+      run: () =>
+        Effect.gen(function* () {
+          const git = yield* GitEnv;
+          const branch = yield* git.currentBranch("/repo");
+          return branch === "main" ? Verdict.block("on main") : Verdict.allow;
+        }),
+    });
+    const out = await Effect.runPromise(
+      dispatchEvent(claudeEdit, {}, [gitGuard]).pipe(
+        Effect.provide(GitEnvTest({ branches: { "/repo": "main" } })),
+      ),
+    );
+    expect(out.exitCode).toBe(2);
+    expect(out.stderr).toBe("on main");
+  });
+});
+
+describe("ALL_GUARDS registry", () => {
+  test("registers the four shipped guards by name", () => {
+    expect(ALL_GUARDS.map((g) => g.name).sort()).toEqual(
+      ["enforce-worktree", "enforce-worktree-write", "refresh-quota", "route-dispatch"].sort(),
+    );
+  });
+
+  test("runDispatchMain is exported (entry wiring)", () => {
+    expect(typeof runDispatchMain).toBe("function");
+  });
+});
+
+describe("dispatchInstallPlan", () => {
+  test("unions tool matchers per event across guards", () => {
+    const plan = dispatchInstallPlan([
+      defineHook({ name: "a", events: ["PreToolUse"], matcher: { tools: ["Edit"] }, run: () => Effect.succeed(Verdict.allow) }),
+      defineHook({ name: "b", events: ["PreToolUse"], matcher: { tools: ["Write", "Edit"] }, run: () => Effect.succeed(Verdict.allow) }),
+    ]);
+    expect(plan).toHaveLength(1);
+    expect(plan[0]!.event).toBe("PreToolUse");
+    expect([...plan[0]!.tools!].sort()).toEqual(["Edit", "Write"]);
+  });
+
+  test("a matcher-less guard collapses its event to tools:null", () => {
+    const plan = dispatchInstallPlan([
+      defineHook({ name: "tool", events: ["PreToolUse"], matcher: { tools: ["Edit"] }, run: () => Effect.succeed(Verdict.allow) }),
+      defineHook({ name: "session", events: ["SessionStart"], run: () => Effect.succeed(Verdict.allow) }),
+    ]);
+    const session = plan.find((e) => e.event === "SessionStart");
+    expect(session?.tools).toBeNull();
+  });
+
+  test("real guard set: PreToolUse carries tool filters, SessionStart has none", () => {
+    const plan = dispatchInstallPlan();
+    const pre = plan.find((e) => e.event === "PreToolUse");
+    const session = plan.find((e) => e.event === "SessionStart");
+    // PreToolUse guards (enforce-worktree-write, route-dispatch) contribute named tools.
+    expect(pre?.tools).toBeTruthy();
+    expect(pre!.tools!).toContain("Edit");
+    // refresh-quota fires at SessionStart with no tool filter.
+    expect(session?.tools ?? null).toBeNull();
+  });
+});

--- a/packages/hooks-sdk/src/dispatch.ts
+++ b/packages/hooks-sdk/src/dispatch.ts
@@ -1,0 +1,113 @@
+import { Effect } from "effect";
+import { decodeHookInput } from "./adapters/decode.ts";
+import { encodeVerdict, type ProcessOutcome } from "./adapters/encode.ts";
+import { matches, type HookDefinition } from "./define.ts";
+import { GitEnv, GitEnvLive } from "./git-env.ts";
+import { mergeVerdicts } from "./merge-verdicts.ts";
+import { Verdict } from "./verdict.ts";
+
+import enforceWorktree from "./hooks/enforce-worktree.ts";
+import enforceWorktreeWrite from "./hooks/enforce-worktree-write.ts";
+import routeDispatch from "./hooks/route-dispatch.ts";
+import refreshQuota from "./hooks/refresh-quota.ts";
+
+/**
+ * Every guard the dispatcher multiplexes, in a stable order (mirrors
+ * GUARD_NAMES). Importing a guard module does NOT self-run it: the
+ * `if (import.meta.main)` arm in each file is false when it is imported rather
+ * than spawned directly, so this registry is side-effect-free.
+ */
+export const ALL_GUARDS: ReadonlyArray<HookDefinition> = [
+  enforceWorktree,
+  enforceWorktreeWrite,
+  routeDispatch,
+  refreshQuota,
+];
+
+/**
+ * Decode the event once, run every guard whose matcher applies, and fold the
+ * verdicts into one ProcessOutcome. This is the shared brain for both the
+ * spawned-bundle path (`bun dispatch.js`) and - later - a daemon `/hooks/eval`
+ * endpoint: a single decode + N in-process guard runs, no per-guard process.
+ *
+ * Each guard's defects fail OPEN independently (one buggy guard can't wedge the
+ * agent or suppress the others); `mergeVerdicts` then applies block-wins
+ * precedence across the survivors.
+ */
+export const dispatchEvent = (
+  stdinText: string,
+  env: Record<string, string | undefined>,
+  guards: ReadonlyArray<HookDefinition> = ALL_GUARDS,
+): Effect.Effect<ProcessOutcome, never, GitEnv> =>
+  Effect.gen(function* () {
+    const event = decodeHookInput(stdinText, env);
+    const verdicts: Verdict[] = [];
+    for (const guard of guards) {
+      if (!matches(guard, event)) continue;
+      const verdict = yield* guard
+        .run(event)
+        .pipe(Effect.catchDefect(() => Effect.succeed(Verdict.allow)));
+      verdicts.push(verdict);
+    }
+    return encodeVerdict(mergeVerdicts(verdicts), event.harness);
+  });
+
+/** One provider hook entry the dispatcher must be registered for: an event and
+ *  the tool-name filter (null = no matcher = every tool / non-tool event). */
+export interface DispatchInstallEntry {
+  readonly event: string;
+  readonly tools: ReadonlyArray<string> | null;
+}
+
+/**
+ * Compute the minimal set of provider hook entries that route every guard's
+ * events to the single dispatcher. Guards are grouped by event; within an
+ * event the tool matchers are UNION-ed, and a guard with no matcher (matches
+ * all tools, e.g. a SessionStart guard) collapses that event to `tools: null`
+ * (no filter). This keeps the dispatcher from firing on tools no guard cares
+ * about (vs. installing it matcher-less on every PreToolUse). Order follows the
+ * guard registry, so the plan is deterministic.
+ */
+export const dispatchInstallPlan = (
+  guards: ReadonlyArray<HookDefinition> = ALL_GUARDS,
+): ReadonlyArray<DispatchInstallEntry> => {
+  const byEvent = new Map<string, { tools: Set<string>; all: boolean }>();
+  for (const guard of guards) {
+    for (const event of guard.events) {
+      const slot = byEvent.get(event) ?? { tools: new Set<string>(), all: false };
+      const tools = guard.matcher?.tools;
+      if (!tools || tools.length === 0) slot.all = true;
+      else for (const t of tools) slot.tools.add(t);
+      byEvent.set(event, slot);
+    }
+  }
+  return [...byEvent.entries()].map(([event, slot]) => ({
+    event,
+    tools: slot.all ? null : [...slot.tools],
+  }));
+};
+
+/**
+ * Process entrypoint for `bun dispatch.js`. Mirrors `runMain` but multiplexes
+ * the whole guard set in one spawn. Reads stdin, runs the guards against the
+ * agent's own env + live git, emits the merged outcome, exits.
+ */
+export const runDispatchMain = async (
+  guards: ReadonlyArray<HookDefinition> = ALL_GUARDS,
+): Promise<void> => {
+  if (process.stdin.isTTY) {
+    process.stderr.write("ax hook dispatcher expects JSON on stdin (see @ax/hooks-sdk)\n");
+    process.exit(0);
+  }
+  const stdinText = await Bun.stdin.text();
+  const outcome = await Effect.runPromise(
+    dispatchEvent(stdinText, process.env as Record<string, string | undefined>, guards).pipe(
+      Effect.provide(GitEnvLive),
+    ),
+  );
+  if (outcome.stdout) process.stdout.write(outcome.stdout);
+  if (outcome.stderr) process.stderr.write(outcome.stderr);
+  process.exit(outcome.exitCode);
+};
+
+if (import.meta.main) void runDispatchMain();

--- a/packages/hooks-sdk/src/index.ts
+++ b/packages/hooks-sdk/src/index.ts
@@ -1,4 +1,12 @@
 export { defineHook, matches, runHook, runMain, type HookDefinition } from "./define.ts";
+export { mergeVerdicts } from "./merge-verdicts.ts";
+export {
+  ALL_GUARDS,
+  dispatchEvent,
+  dispatchInstallPlan,
+  runDispatchMain,
+  type DispatchInstallEntry,
+} from "./dispatch.ts";
 export { Verdict } from "./verdict.ts";
 export type { Harness, HookEvent, HookEventName } from "./event.ts";
 export { GitEnv, GitEnvLive, GitEnvTest, type GitEnvService } from "./git-env.ts";

--- a/packages/hooks-sdk/src/merge-verdicts.test.ts
+++ b/packages/hooks-sdk/src/merge-verdicts.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { mergeVerdicts } from "./merge-verdicts.ts";
+import { Verdict } from "./verdict.ts";
+
+describe("mergeVerdicts", () => {
+  test("empty -> allow", () => {
+    expect(mergeVerdicts([])).toEqual(Verdict.allow);
+  });
+
+  test("all allow -> allow", () => {
+    expect(mergeVerdicts([Verdict.allow, Verdict.allow])).toEqual(Verdict.allow);
+  });
+
+  test("first block wins and short-circuits", () => {
+    const merged = mergeVerdicts([
+      Verdict.allow,
+      Verdict.block("first reason"),
+      Verdict.block("second reason"),
+      Verdict.advise("ignored"),
+    ]);
+    expect(merged).toEqual(Verdict.block("first reason"));
+  });
+
+  test("block beats any advisory regardless of order", () => {
+    const merged = mergeVerdicts([Verdict.advise("a"), Verdict.warn("w"), Verdict.block("no")]);
+    expect(merged._tag).toBe("Block");
+  });
+
+  test("single advise passes through", () => {
+    expect(mergeVerdicts([Verdict.allow, Verdict.advise("route down")])).toEqual(
+      Verdict.advise("route down"),
+    );
+  });
+
+  test("multiple same-kind advisories join with a blank line", () => {
+    const merged = mergeVerdicts([Verdict.advise("one"), Verdict.advise("two")]);
+    expect(merged).toEqual(Verdict.advise("one\n\ntwo"));
+  });
+
+  test("inject outranks advise and warn", () => {
+    const merged = mergeVerdicts([Verdict.warn("w"), Verdict.advise("a"), Verdict.inject("ctx")]);
+    expect(merged).toEqual(Verdict.inject("ctx"));
+  });
+
+  test("advise outranks warn", () => {
+    const merged = mergeVerdicts([Verdict.warn("w"), Verdict.advise("a")]);
+    expect(merged).toEqual(Verdict.advise("a"));
+  });
+
+  test("warn wins when it is the only advisory", () => {
+    expect(mergeVerdicts([Verdict.allow, Verdict.warn("careful")])).toEqual(
+      Verdict.warn("careful"),
+    );
+  });
+});

--- a/packages/hooks-sdk/src/merge-verdicts.ts
+++ b/packages/hooks-sdk/src/merge-verdicts.ts
@@ -1,0 +1,44 @@
+import { Verdict } from "./verdict.ts";
+
+/**
+ * Combine the verdicts of several guards that ran against ONE event into a
+ * single verdict the harness can act on (a hook process emits exactly one
+ * ProcessOutcome).
+ *
+ * Policy:
+ *   1. Any Block wins immediately - the FIRST block's reason is returned, so
+ *      enforcement short-circuits (a deny is terminal; later guards can't
+ *      un-block it).
+ *   2. With no block, the strongest advisory kind present wins, in the fixed
+ *      order Inject > Advise > Warn. Messages of that kind are joined with a
+ *      blank line so multiple same-kind guards all reach the model/user.
+ *   3. Otherwise Allow.
+ *
+ * In practice the installed guards target disjoint tools/events, so at most one
+ * non-Allow verdict appears per event; the same-kind join + priority order make
+ * the rare overlap deterministic rather than order-dependent.
+ */
+export const mergeVerdicts = (verdicts: ReadonlyArray<Verdict>): Verdict => {
+  for (const v of verdicts) {
+    if (v._tag === "Block") return v;
+  }
+
+  const collect = (tag: "Inject" | "Advise" | "Warn"): string[] =>
+    verdicts.flatMap((v) => {
+      if (v._tag === "Inject" && tag === "Inject") return [v.context];
+      if (v._tag === "Advise" && tag === "Advise") return [v.context];
+      if (v._tag === "Warn" && tag === "Warn") return [v.message];
+      return [];
+    });
+
+  const inject = collect("Inject");
+  if (inject.length > 0) return Verdict.inject(inject.join("\n\n"));
+
+  const advise = collect("Advise");
+  if (advise.length > 0) return Verdict.advise(advise.join("\n\n"));
+
+  const warn = collect("Warn");
+  if (warn.length > 0) return Verdict.warn(warn.join("\n\n"));
+
+  return Verdict.allow;
+};


### PR DESCRIPTION
## Context

Stage 1 of the **hybrid dispatcher** (B), the follow-up to #603. Spun out of comparing ax's hook setup to [FailproofAI](https://github.com/FailproofAI/failproofai): their guardrails run through *one* persistent local process; ax spawns a separate **effect-inlined fat bundle per guard** (`route-dispatch.js` is 867 KB), so each fire pays a cold bun start + a megabyte parse.

This PR lands the **shared dispatch brain** — the piece both halves of the hybrid reuse — with **no install or runtime change yet** (zero prod risk).

## What

- **`mergeVerdicts(Verdict[])`** — fold N guard verdicts into one: block-wins precedence (first block short-circuits), else strongest advisory (`Inject > Advise > Warn`) with same-kind messages joined. Pure, 9 tests.
- **`dispatchEvent(stdin, env, guards)`** — decode the event once → run every guard whose `matches()` passes (each guard's **defects fail OPEN independently**) → `mergeVerdicts` → `encodeVerdict` once per harness. Reuses the existing decode/match/encode seams; generalises `runHook` from 1→N guards.
- **`ALL_GUARDS`** registry + **`runDispatchMain`** entry — mirrors `runMain` but multiplexes the whole guard set in one spawn.
- **`dispatchInstallPlan(guards)`** — computes the minimal provider hook entries that route each guard's events to the single dispatcher: tool matchers **UNION-ed per event**, a matcher-less guard (e.g. SessionStart) collapses its event to no-filter (so the dispatcher won't fire on tools no guard cares about). Deterministic. This is the install fan-out's brain — wired up in stage 2.

## Correctness

Verified the make-or-break: `GitEnvLive` is fully `dir`-parameterised (`git -C dir …`) and guards derive `dir` from `event.cwd` + payload paths — so in-process multiplexing judges the **right repo**, not the dispatcher's cwd. The one ambient coupling (`process.env.ALLOW_MAIN_WRITE`/`HOME`) is correct here because the bundle runs in the agent's own process; closing it for the daemon path (stage 3) needs a `HookEnv` service + env forwarding.

## Roadmap

1. **This PR** — dispatch core (pure, fully unit-tested).
2. **Stage 2** — embed the dispatcher bundle + flip `ax hooks install --all` to install the single dispatcher (using `dispatchInstallPlan`) and migrate off legacy per-guard entries. Needs live-DB e2e (config CRUD), hence split out.
3. **Stage 3** — daemon fast-path: `POST /hooks/eval` on `ax serve` (warm, ~1ms) + an effect-free shim that tries the daemon and lazy-imports the bundle on fallback. This is where the latency win lands.

## Test

`bun test packages/hooks-sdk/` → **193 pass, 0 fail**. `bun run typecheck` (hooks-sdk + axctl) → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)