### PR TITLE
feat(hooks): scaffold + embed the single dispatcher (B, stage 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,7 +376,15 @@ warn / inject; defects fail OPEN. `GitEnv` service makes guards layer-testable.
   file fails with `SdkHookFileNotFoundError` (#564); native (non-SDK)
   `ax hooks add` works everywhere.
 - `ax hooks init` - scaffold `~/.ax/hooks` (source: `file:` dep on
-  packages/hooks-sdk, re-run after the SDK moves; binary: writes embedded bundles)
+  packages/hooks-sdk, re-run after the SDK moves; binary: writes embedded bundles).
+  Also scaffolds the **dispatcher** `dispatch.ts`/`.js` (`DISPATCHER_NAME`): one
+  spawn that multiplexes ALL guards (decode once -> run matching guards
+  in-process -> `mergeVerdicts` -> encode once), replacing N fat per-guard
+  bundles. Standalone bundle ~0.9 MB (one, vs ~1.5 MB across four), embedded +
+  scaffolded like the per-guard bundles. Runtime is live (`bun dispatch.ts`);
+  flipping `ax hooks install --all` to register the single dispatcher (per-event
+  matchers via `dispatchInstallPlan`) + migrate off legacy per-guard entries is
+  the next step, then a daemon `/hooks/eval` fast-path (the latency win).
 - `ax hooks install <abs-file> --providers=claude,codex` - idempotent fan-out
   into provider configs via the existing codecs (ax ownership markers)
 - `ax hooks install --all [--providers=claude,codex] [--dir=~/.ax/hooks]` -

--- a/apps/axctl/src/hooks/guard-names.ts
+++ b/apps/axctl/src/hooks/guard-names.ts
@@ -26,3 +26,14 @@ export type GuardName = (typeof GUARD_NAMES)[number];
  */
 export const starterHookContent = (guardName: string): string =>
     `import hook from "@ax/hooks-sdk/hooks/${guardName}";\nimport { runMain } from "@ax/hooks-sdk/define";\n\nexport default hook;\nif (import.meta.main) void runMain(hook);\n`;
+
+/**
+ * The single dispatcher entry. One spawn runs EVERY guard for an event (decode
+ * once -> run matching guards in-process -> merge -> encode once), replacing N
+ * fat per-guard bundles. Scaffolded as `dispatch.ts` (source) / `dispatch.js`
+ * (binary, embedded like the per-guard bundles) and fired as `bun dispatch.*`.
+ */
+export const DISPATCHER_NAME = "dispatch";
+
+export const dispatcherScaffoldContent = (): string =>
+    `import { runDispatchMain } from "@ax/hooks-sdk/dispatch";\n\nif (import.meta.main) void runDispatchMain();\n`;

--- a/apps/axctl/src/hooks/sdk-workspace.test.ts
+++ b/apps/axctl/src/hooks/sdk-workspace.test.ts
@@ -65,6 +65,14 @@ describe("scaffoldWorkspace", () => {
         const rqContent = readFileSync(rqPath, "utf8");
         expect(rqContent).toContain('@ax/hooks-sdk/hooks/refresh-quota');
 
+        // The single dispatcher entry is scaffolded alongside the guards.
+        const dispatchPath = join(dir, "dispatch.ts");
+        expect(existsSync(dispatchPath)).toBe(true);
+        expect(written).toContain(dispatchPath);
+        const dispatchContent = readFileSync(dispatchPath, "utf8");
+        expect(dispatchContent).toContain('@ax/hooks-sdk/dispatch');
+        expect(dispatchContent).toContain('runDispatchMain');
+
         // All hook files should be in the written list
         expect(written).toContain(ewPath);
         expect(written).toContain(ewwPath);
@@ -121,7 +129,9 @@ describe("scaffoldWorkspace", () => {
         expect(written).toContain(join(dir, "enforce-worktree-write.ts"));
         expect(written).toContain(join(dir, "route-dispatch.ts"));
         expect(written).toContain(join(dir, "refresh-quota.ts"));
-        expect(written.length).toBe(5);
+        expect(written).toContain(join(dir, "dispatch.ts"));
+        // package.json + 4 guards + the dispatcher entry.
+        expect(written.length).toBe(6);
     });
 
     test("creates dir if it does not exist", async () => {

--- a/apps/axctl/src/hooks/sdk-workspace.ts
+++ b/apps/axctl/src/hooks/sdk-workspace.ts
@@ -2,7 +2,12 @@ import { Effect, FileSystem, Path } from "effect";
 import type { PlatformError } from "effect/PlatformError";
 import { Schema } from "effect";
 import { writeFileAtomic } from "@ax/lib/atomic-write";
-import { GUARD_NAMES, starterHookContent } from "./guard-names.ts";
+import {
+    GUARD_NAMES,
+    starterHookContent,
+    DISPATCHER_NAME,
+    dispatcherScaffoldContent,
+} from "./guard-names.ts";
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -159,6 +164,13 @@ export const scaffoldWorkspace = (
                 yield* writeFileAtomic(hookPath, starterHookContent(guardName), { backup: false });
                 written.push(hookPath);
             }
+        }
+
+        // 3b. The dispatcher entry (one spawn multiplexes all guards) - only if absent.
+        const dispatchPath = pathSvc.join(opts.dir, `${DISPATCHER_NAME}.ts`);
+        if (!(yield* fs.exists(dispatchPath))) {
+            yield* writeFileAtomic(dispatchPath, dispatcherScaffoldContent(), { backup: false });
+            written.push(dispatchPath);
         }
 
         // 4. bun install

--- a/scripts/gen-hooks-embed.ts
+++ b/scripts/gen-hooks-embed.ts
@@ -20,7 +20,12 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, relative } from "node:path";
-import { GUARD_NAMES, starterHookContent } from "../apps/axctl/src/hooks/guard-names.ts";
+import {
+    GUARD_NAMES,
+    starterHookContent,
+    DISPATCHER_NAME,
+    dispatcherScaffoldContent,
+} from "../apps/axctl/src/hooks/guard-names.ts";
 
 const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const GEN_FILE = join(REPO_ROOT, "apps/axctl/src/hooks/hooks-embed.gen.ts");
@@ -54,20 +59,27 @@ export function writeManifest(): void {
     rmSync(BUILD_DIR, { recursive: true, force: true });
     mkdirSync(BUILD_DIR, { recursive: true });
 
-    const bundles: string[] = [];
-    for (const guard of GUARD_NAMES) {
+    const bundle = (name: string, source: string): void => {
         // Entry wrapper inside apps/axctl so @ax/hooks-sdk resolves.
-        const entry = join(BUILD_DIR, `${guard}.entry.ts`);
-        writeFileSync(entry, starterHookContent(guard));
-        const outfile = join(BUILD_DIR, `${guard}.js`);
+        const entry = join(BUILD_DIR, `${name}.entry.ts`);
+        writeFileSync(entry, source);
+        const outfile = join(BUILD_DIR, `${name}.js`);
         const build = spawnSync(
             "bun",
             ["build", entry, "--target=bun", "--outfile", outfile],
             { cwd: REPO_ROOT, stdio: ["ignore", "ignore", "inherit"] },
         );
-        if (build.status !== 0) throw new Error(`bundling hook '${guard}' failed`);
+        if (build.status !== 0) throw new Error(`bundling hook '${name}' failed`);
+    };
+
+    const bundles: string[] = [];
+    for (const guard of GUARD_NAMES) {
+        bundle(guard, starterHookContent(guard));
         bundles.push(guard);
     }
+    // The single dispatcher (one spawn multiplexes all guards).
+    bundle(DISPATCHER_NAME, dispatcherScaffoldContent());
+    bundles.push(DISPATCHER_NAME);
 
     // Import specifiers are relative to the GEN file's directory.
     const genDir = join(REPO_ROOT, "apps/axctl/src/hooks");


### PR DESCRIPTION
## Context

Stage 2 of the hybrid dispatcher (B), on top of #605 (dispatch core). Makes the dispatcher **installable**: scaffolded + embedded alongside the per-guard bundles, so one spawn multiplexes every guard instead of one fat effect-bundle per guard.

## What

- **`guard-names.ts`** — `DISPATCHER_NAME` + `dispatcherScaffoldContent()` (dep-free, shared by the runtime scaffolder and the binary-embed bundler, mirroring `starterHookContent`).
- **`sdk-workspace.ts`** — `scaffoldWorkspace` writes `dispatch.ts`; `scaffoldFromEmbed` already writes every embed key, so it picks up `dispatch.js` automatically.
- **`gen-hooks-embed.ts`** — factor out `bundle()`; also bundle the dispatcher under key `"dispatch"` so the compiled binary bakes it in via `{ type: "file" }`.

## Verified end-to-end (no DB)

`bun dispatch.ts` decodes once → runs the guard set in-process → merges → encodes once:

| input | result |
|---|---|
| Edit on a `main` checkout | **BLOCK, exit 2** (worktree message) |
| Edit on a branch | allow, exit 0 |
| Read (no guard matches) | allow, exit 0, no output |

The standalone embed bundle (effect inlined) is **~0.9 MB — one bundle for all four guards** vs **~1.5 MB across four** today (`route-dispatch.js` alone is 867 KB), and runs offline identically.

`bun test apps/axctl/src/hooks/sdk-workspace.test.ts` → 17 pass. `bun run typecheck` (axctl) → exit 0.

## Roadmap

1. #605 — dispatch core ✅
2. **This PR** — scaffold + embed the dispatcher; runtime live.
3. **Stage 2b** — flip `ax hooks install --all` to register the single dispatcher (per-event matchers via `dispatchInstallPlan`) + migrate off legacy per-guard entries. Touches provider config CRUD → done with live-DB e2e.
4. **Stage 3** — daemon `POST /hooks/eval` + effect-free shim (daemon-first, lazy-import bundle on fallback). The latency win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)