### PR TITLE
fix(otel): correlate telemetry_of by uuid match, session-grain + incremental

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,15 @@ subset, `apps/axctl/src/otel/`), normalize per-harness (`service.name` ->
 harness label), and land in `otel_metric_point` / `otel_span` / `otel_log_event`.
 A correlation pass at ingest finish draws `session -> telemetry_of -> otel_*`
 edges by matching `session.id` (OTLP arrives before the transcript, so the
-ingest run owns linking; idempotent, best-effort via `Effect.ignore`). OTLP cost
+ingest run owns linking; idempotent, best-effort via `Effect.ignore`).
+**Session-grain + incremental** (`correlate.ts`): one edge per top-level session
+that has telemetry (the edge means "this session has telemetry"; no data query
+reads it - enrichment joins `session_id` directly), and the candidate set is just
+the existing-but-unlinked sessions, probed via the `session_id` index in 500-id
+chunks - so it does NOT enumerate the whole (~1.5M-row) `otel_log_event` table
+each ingest. otel `session_id` is a bare uuid, `session.id` is `session:⟨uuid⟩`,
+so matching is uuid-to-uuid in JS (the older `type::record("session:"+id)` form
+mis-parsed hyphenated uuids as arithmetic -> zero edges, #610). OTLP cost
 is stored separately from file-parsed cost (no double-count). The receiver is
 fail-open (always 2xx so exporters never retry-storm) and JSON-only (ax owns the
 harness config, so it forces `http/json` - no protobuf decode, works in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,12 +160,16 @@ edges by matching `session.id` (OTLP arrives before the transcript, so the
 ingest run owns linking; idempotent, best-effort via `Effect.ignore`).
 **Session-grain + incremental** (`correlate.ts`): one edge per top-level session
 that has telemetry (the edge means "this session has telemetry"; no data query
-reads it - enrichment joins `session_id` directly), and the candidate set is just
-the existing-but-unlinked sessions, probed via the `session_id` index in 500-id
-chunks - so it does NOT enumerate the whole (~1.5M-row) `otel_log_event` table
-each ingest. otel `session_id` is a bare uuid, `session.id` is `session:⟨uuid⟩`,
-so matching is uuid-to-uuid in JS (the older `type::record("session:"+id)` form
-mis-parsed hyphenated uuids as arithmetic -> zero edges, #610). OTLP cost
+reads it - enrichment joins `session_id` directly). Only telemetry observed in the
+last 2 days is scanned, via the `observed_at` index (a range scan over recent
+rows, ~30ms - NOT a full GROUP BY over the whole ~1.5M-row `otel_log_event`, which
+cost ~8s every ingest), then filtered to existing+unlinked sessions in JS. otel
+`session_id` is a bare uuid, `session.id` is `session:⟨uuid⟩`, so matching is
+uuid-to-uuid in JS (the older `type::record("session:"+id)` form mis-parsed
+hyphenated uuids as arithmetic -> zero edges, #610). All otel index builds are
+`CONCURRENTLY` (a plain `DEFINE INDEX` locks the table while building, wedging the
+daemon when `ax install` re-applies the schema onto an already-large otel table).
+OTLP cost
 is stored separately from file-parsed cost (no double-count). The receiver is
 fail-open (always 2xx so exporters never retry-storm) and JSON-only (ax owns the
 harness config, so it forces `http/json` - no protobuf decode, works in the

--- a/apps/axctl/src/otel/correlate.test.ts
+++ b/apps/axctl/src/otel/correlate.test.ts
@@ -3,76 +3,110 @@ import { Effect, Layer } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { correlateOrphanOtel } from "./correlate.ts";
 
-const sql: string[] = [];
-const stubDb = Layer.succeed(SurrealClient, {
-    query: <T>(q: string) => {
-        sql.push(q);
-        if (/otel_metric_point/.test(q) && /SELECT/i.test(q)) {
-            return Effect.succeed([[{ id: "otel_metric_point:m1", session_id: "s1" }]] as unknown as T);
-        }
-        if (/otel_span/.test(q) && /SELECT/i.test(q)) return Effect.succeed([[]] as unknown as T);
-        return Effect.succeed([[]] as unknown as T);
-    },
-} as never);
+const UUID = "019fbf3f-9241-40c3-b699-e1f62e7c5341";
+
+/**
+ * Stub the four query shapes the pass issues, in order:
+ *   1. SELECT id FROM session            -> existing sessions (bare-uuid set)
+ *   2. SELECT in FROM telemetry_of       -> already-linked sessions
+ *   3..N SELECT id, session_id FROM <otel table> ... GROUP BY session_id
+ * GROUP BY collapses `id` into an array, which the stub mirrors.
+ */
+const makeDb = (opts: {
+    sessions?: unknown[];
+    linked?: unknown[];
+    metric?: Array<{ id: unknown; session_id: unknown }>;
+    span?: Array<{ id: unknown; session_id: unknown }>;
+    log?: Array<{ id: unknown; session_id: unknown }>;
+}) => {
+    const sql: string[] = [];
+    const layer = Layer.succeed(SurrealClient, {
+        query: <T>(q: string) => {
+            sql.push(q);
+            if (/FROM session;/.test(q)) {
+                return Effect.succeed([(opts.sessions ?? []).map((id) => ({ id }))] as unknown as T);
+            }
+            if (/FROM telemetry_of;/.test(q)) {
+                return Effect.succeed([(opts.linked ?? []).map((i) => ({ in: i }))] as unknown as T);
+            }
+            if (/otel_metric_point/.test(q)) return Effect.succeed([[...(opts.metric ?? [])]] as unknown as T);
+            if (/otel_span/.test(q)) return Effect.succeed([[...(opts.span ?? [])]] as unknown as T);
+            if (/otel_log_event/.test(q)) return Effect.succeed([[...(opts.log ?? [])]] as unknown as T);
+            return Effect.succeed([[]] as unknown as T);
+        },
+    } as never);
+    return { layer, sql };
+};
 
 describe("correlateOrphanOtel", () => {
-    test("RELATEs an orphan metric row to its session", async () => {
-        sql.length = 0;
-        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(stubDb)));
+    test("RELATEs a session to its representative metric row", async () => {
+        const { layer, sql } = makeDb({
+            sessions: [`session:⟨${UUID}⟩`],
+            metric: [{ id: [`otel_metric_point:⟨a|b|${UUID}|||t⟩`], session_id: UUID }],
+        });
+        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(layer)));
         const all = sql.join("\n");
         expect(all).toContain("RELATE session:");
         expect(all).toContain("telemetry_of");
         expect(all).toContain("otel_metric_point:");
     });
 
-    test("handles RecordId object id shape (real-SDK case)", async () => {
-        sql.length = 0;
-        // The SurrealDB SDK returns row `id` as a RecordId object { tb, id },
-        // not a string. Correlation must extract the key from the object form.
-        const objIdDb = Layer.succeed(SurrealClient, {
-            query: <T>(q: string) => {
-                sql.push(q);
-                if (/otel_metric_point/.test(q) && /SELECT/i.test(q)) {
-                    return Effect.succeed([[
-                        { id: { tb: "otel_metric_point", id: "m1" }, session_id: "s1" },
-                    ]] as unknown as T);
-                }
-                return Effect.succeed([[]] as unknown as T);
-            },
-        } as never);
-        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(objIdDb)));
+    test("handles a RecordId object id shape (real-SDK case)", async () => {
+        const { layer, sql } = makeDb({
+            sessions: [{ tb: "session", id: UUID }],
+            metric: [{ id: [{ tb: "otel_metric_point", id: "m1" }], session_id: UUID }],
+        });
+        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(layer)));
         const all = sql.join("\n");
         expect(all).toContain("RELATE session:");
-        expect(all).toContain("telemetry_of");
-        expect(all).toContain("otel_metric_point:");
         expect(all).toContain("m1");
     });
 
-    test("RELATEs an orphan log event row to its session", async () => {
-        sql.length = 0;
-        const logEventDb = Layer.succeed(SurrealClient, {
-            query: <T>(q: string) => {
-                sql.push(q);
-                if (/otel_log_event/.test(q) && /SELECT/i.test(q)) {
-                    return Effect.succeed([[{ id: "otel_log_event:l1", session_id: "s1" }]] as unknown as T);
-                }
-                return Effect.succeed([[]] as unknown as T);
-            },
-        } as never);
-        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(logEventDb)));
-        const all = sql.join("\n");
-        expect(all).toContain("RELATE session:");
-        expect(all).toContain("telemetry_of");
-        expect(all).toContain("otel_log_event:");
+    test("is session-grain: one RELATE even with many rows for the session", async () => {
+        const { layer, sql } = makeDb({
+            sessions: [`session:⟨${UUID}⟩`],
+            // GROUP BY already collapses to one row per session; the id array holds all members.
+            metric: [{ id: [`otel_metric_point:r1`, `otel_metric_point:r2`], session_id: UUID }],
+        });
+        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(layer)));
+        const relates = sql.filter((q) => q.startsWith("RELATE"));
+        expect(relates.length).toBe(1);
     });
 
-    test("no orphans → no RELATE", async () => {
-        sql.length = 0;
-        // override: both selects return empty by re-importing with a fresh stub
-        const emptyDb = Layer.succeed(SurrealClient, {
-            query: <T>(q: string) => { sql.push(q); return Effect.succeed([[]] as unknown as T); },
-        } as never);
-        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(emptyDb)));
+    test("skips a session that already has a telemetry_of edge (idempotent)", async () => {
+        const { layer, sql } = makeDb({
+            sessions: [`session:⟨${UUID}⟩`],
+            linked: [`session:⟨${UUID}⟩`],
+            metric: [{ id: [`otel_metric_point:m1`], session_id: UUID }],
+        });
+        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(layer)));
+        expect(sql.join("\n")).not.toContain("RELATE");
+    });
+
+    test("skips otel rows whose session_id has no matching session", async () => {
+        const { layer, sql } = makeDb({
+            sessions: [], // no sessions exist
+            metric: [{ id: [`otel_metric_point:m1`], session_id: UUID }],
+        });
+        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(layer)));
+        expect(sql.join("\n")).not.toContain("RELATE");
+    });
+
+    test("does not relate the same session twice across tables", async () => {
+        const { layer, sql } = makeDb({
+            sessions: [`session:⟨${UUID}⟩`],
+            metric: [{ id: [`otel_metric_point:m1`], session_id: UUID }],
+            log: [{ id: [`otel_log_event:l1`], session_id: UUID }],
+        });
+        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(layer)));
+        const relates = sql.filter((q) => q.startsWith("RELATE"));
+        expect(relates.length).toBe(1);
+        expect(relates[0]).toContain("otel_metric_point:"); // first table wins
+    });
+
+    test("no telemetry → no RELATE", async () => {
+        const { layer, sql } = makeDb({ sessions: [`session:⟨${UUID}⟩`] });
+        await Effect.runPromise(correlateOrphanOtel().pipe(Effect.provide(layer)));
         expect(sql.join("\n")).not.toContain("RELATE");
     });
 });

--- a/apps/axctl/src/otel/correlate.ts
+++ b/apps/axctl/src/otel/correlate.ts
@@ -4,14 +4,17 @@ import { executeStatements, recordRef } from "@ax/lib/shared/surreal";
 
 const RELATABLE = ["otel_metric_point", "otel_span", "otel_log_event"] as const;
 
-/** session_id IN-list chunk size (mirrors telemetry-rollup.ts). */
-const CHUNK = 500;
-
-const chunk = <T>(xs: readonly T[], n: number): T[][] => {
-    const out: T[][] = [];
-    for (let i = 0; i < xs.length; i += n) out.push(xs.slice(i, i + n));
-    return out;
-};
+/**
+ * Only correlate telemetry observed within this window. The pass runs after
+ * EVERY ingest (incl. the watcher's `--since=1`), so it must be cheap. OTLP
+ * arrives just before / alongside its transcript, so freshly-ingested sessions
+ * always have recent telemetry - a narrow window backed by the `observed_at`
+ * index makes the scan O(recent rows) instead of enumerating the whole (~1.5M
+ * row) otel_log_event table each ingest. Telemetry whose transcript is ingested
+ * more than this many days late stays unlinked, which is fine: nothing reads the
+ * edge for data (enrichment + `ax otel` coverage join `session_id` directly).
+ */
+const SCAN_WINDOW_DAYS = 2;
 
 /**
  * Extract the bare record KEY from a SurrealDB row `id`, which the SDK returns
@@ -55,12 +58,13 @@ const bareUuid = (v: unknown): string | null => {
  * the edge - enrichment joins `session_id` directly), so one representative row
  * per session suffices. Row-grain would write millions of edges no one consumes.
  *
- * INCREMENTAL: the candidate set is exactly the sessions that EXIST but are NOT
- * yet linked, and the otel tables are probed with `session_id IN [candidates]`
- * over the schema's `session_id` index (chunked at 500, like telemetry-rollup.ts).
- * Steady state the candidate set is just the run's new sessions, so the pass is
- * cheap; a full `GROUP BY session_id` over otel_log_event (the old approach) cost
- * ~8s on EVERY ingest by enumerating all 1.5M rows, which this avoids.
+ * INCREMENTAL: only telemetry observed in the last `SCAN_WINDOW_DAYS` is scanned,
+ * via the `observed_at` index (a range scan over recent rows, not a full GROUP BY
+ * over all 1.5M). The earlier full `GROUP BY session_id` cost ~8s on EVERY ingest;
+ * a candidate-set variant re-probed every telemetry-less session forever. Both are
+ * replaced by: window recent telemetry -> filter to existing, unlinked sessions
+ * (in-memory sets) -> relate. Already-linked sessions are skipped, so re-scanning
+ * the same window each run is cheap.
  *
  * Two earlier bugs this replaced:
  *   - `type::record("session:" + session_id)` evaluated the concat as arithmetic
@@ -69,55 +73,50 @@ const bareUuid = (v: unknown): string | null => {
  *     `session.id` is the escaped `session:⟨uuid⟩` record, so we match on bare
  *     uuids in JS instead of trusting `type::record` round-trips.
  *   - the per-row `count(<-telemetry_of)=0` graph traversal idempotency check was
- *     a bottleneck; idempotency is now the in-memory `linked` set (drives the
- *     candidate list, so already-linked sessions are never re-probed).
+ *     a bottleneck; idempotency is now the in-memory `linked` set.
  */
 export const correlateOrphanOtel = () =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
 
-        // Already-linked sessions (telemetry_of stays small - one edge per session).
+        // Existing top-level sessions (uuid id) and sessions already linked.
+        const sessRows = (yield* db.query<[Array<{ id: unknown }>]>(
+            `SELECT id FROM session;`,
+        ))?.[0] ?? [];
+        const sessions = new Set<string>();
+        for (const r of sessRows) { const u = bareUuid(r.id); if (u) sessions.add(u); }
+
         const edgeRows = (yield* db.query<[Array<{ in: unknown }>]>(
             `SELECT in FROM telemetry_of;`,
         ))?.[0] ?? [];
         const linked = new Set<string>();
         for (const r of edgeRows) { const u = bareUuid(r.in); if (u) linked.add(u); }
 
-        // Candidates = existing top-level sessions (uuid id) not yet linked.
-        const sessRows = (yield* db.query<[Array<{ id: unknown }>]>(
-            `SELECT id FROM session;`,
-        ))?.[0] ?? [];
-        const candidates = [...new Set(
-            sessRows.map((r) => bareUuid(r.id)).filter((u): u is string => u !== null),
-        )].filter((u) => !linked.has(u));
-        if (candidates.length === 0) return;
-
-        // For each candidate, find one representative otel row via the indexed
-        // `session_id IN [...]` probe (chunked). First table that has it wins.
+        // One representative recent otel row per session, first table wins.
         const seen = new Set<string>();
         const stmts: string[] = [];
         for (const table of RELATABLE) {
-            const remaining = candidates.filter((u) => !seen.has(u));
-            if (remaining.length === 0) break;
-            for (const part of chunk(remaining, CHUNK)) {
-                const list = part.map((u) => `"${u}"`).join(", ");
-                const rows = (yield* db.query<[Array<{ id: unknown; session_id: unknown }>]>(
-                    `SELECT id, session_id FROM ${table} WHERE session_id IN [${list}] GROUP BY session_id;`,
-                ))?.[0] ?? [];
-                for (const o of rows) {
-                    const u = bareUuid(o.session_id);
-                    if (u === null || seen.has(u)) continue;
-                    // GROUP BY collapses `id` into an array of the group's row ids;
-                    // take the first as the representative. recordKey handles the
-                    // SDK's string|RecordId shape; recordRef escapes it canonically.
-                    const repId = Array.isArray(o.id) ? o.id[0] : o.id;
-                    const recId = recordKey(repId);
-                    if (recId === null) continue;
-                    seen.add(u);
-                    stmts.push(
-                        `RELATE ${recordRef("session", u)}->telemetry_of->${recordRef(table, recId)};`,
-                    );
-                }
+            // WHERE is observed_at-only so the range scan uses the `observed_at`
+            // index; a leading `session_id != NONE` defeated the index (full scan).
+            // NONE / non-uuid session_ids fall out via bareUuid below.
+            const rows = (yield* db.query<[Array<{ id: unknown; session_id: unknown }>]>(
+                `SELECT id, session_id FROM ${table}`
+                + ` WHERE observed_at > time::now() - ${SCAN_WINDOW_DAYS}d`
+                + ` GROUP BY session_id;`,
+            ))?.[0] ?? [];
+            for (const o of rows) {
+                const u = bareUuid(o.session_id);
+                if (u === null || seen.has(u) || linked.has(u) || !sessions.has(u)) continue;
+                // GROUP BY collapses `id` into an array of the group's row ids; take
+                // the first as the representative. recordKey handles the SDK's
+                // string|RecordId shape; recordRef escapes it canonically.
+                const repId = Array.isArray(o.id) ? o.id[0] : o.id;
+                const recId = recordKey(repId);
+                if (recId === null) continue;
+                seen.add(u);
+                stmts.push(
+                    `RELATE ${recordRef("session", u)}->telemetry_of->${recordRef(table, recId)};`,
+                );
             }
         }
         if (stmts.length > 0) yield* executeStatements(stmts);

--- a/apps/axctl/src/otel/correlate.ts
+++ b/apps/axctl/src/otel/correlate.ts
@@ -2,9 +2,16 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { executeStatements, recordRef } from "@ax/lib/shared/surreal";
 
-interface Orphan { readonly id: unknown; readonly session_id: string }
-
 const RELATABLE = ["otel_metric_point", "otel_span", "otel_log_event"] as const;
+
+/** session_id IN-list chunk size (mirrors telemetry-rollup.ts). */
+const CHUNK = 500;
+
+const chunk = <T>(xs: readonly T[], n: number): T[][] => {
+    const out: T[][] = [];
+    for (let i = 0; i < xs.length; i += n) out.push(xs.slice(i, i + n));
+    return out;
+};
 
 /**
  * Extract the bare record KEY from a SurrealDB row `id`, which the SDK returns
@@ -30,38 +37,87 @@ const recordKey = (id: unknown): string | null => {
     return null;
 };
 
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+/** Bare uuid from an otel `session_id` (already bare) or a `session:⟨uuid⟩` record. */
+const bareUuid = (v: unknown): string | null => {
+    if (v == null) return null;
+    const s = typeof v === "string" ? v : String((v as { id?: unknown }).id ?? v);
+    const m = UUID_RE.exec(s);
+    return m ? m[0].toLowerCase() : null;
+};
+
 /**
- * Link every otel row whose session_id matches a session and that has no
- * telemetry_of edge yet. Runs at ingest finish; idempotent.
+ * Draw `session -> telemetry_of -> otel_*` edges, one per top-level session that
+ * has matching telemetry. Runs at ingest finish; idempotent + INCREMENTAL.
  *
- * The SELECT dialect is validated against SurrealDB 3.x:
- *   - `type::record("session:" + session_id)` casts the session_id string to a
- *     record reference for the IN check (`type::thing` does NOT exist in v3 -
- *     the parser suggests `type::record`).
- *   - `count(<-telemetry_of) = 0` counts incoming telemetry_of edges (orphans
- *     only); confirmed valid in v3.
+ * SESSION-GRAIN, not row-grain: otel can hold ~1.5M log rows for a few hundred
+ * sessions, and the edge means "this session has telemetry" (no data query reads
+ * the edge - enrichment joins `session_id` directly), so one representative row
+ * per session suffices. Row-grain would write millions of edges no one consumes.
+ *
+ * INCREMENTAL: the candidate set is exactly the sessions that EXIST but are NOT
+ * yet linked, and the otel tables are probed with `session_id IN [candidates]`
+ * over the schema's `session_id` index (chunked at 500, like telemetry-rollup.ts).
+ * Steady state the candidate set is just the run's new sessions, so the pass is
+ * cheap; a full `GROUP BY session_id` over otel_log_event (the old approach) cost
+ * ~8s on EVERY ingest by enumerating all 1.5M rows, which this avoids.
+ *
+ * Two earlier bugs this replaced:
+ *   - `type::record("session:" + session_id)` evaluated the concat as arithmetic
+ *     for hyphenated uuids -> `session:019fbf3f` (everything after the first
+ *     hyphen dropped) -> ZERO matches. otel `session_id` is a bare uuid while
+ *     `session.id` is the escaped `session:⟨uuid⟩` record, so we match on bare
+ *     uuids in JS instead of trusting `type::record` round-trips.
+ *   - the per-row `count(<-telemetry_of)=0` graph traversal idempotency check was
+ *     a bottleneck; idempotency is now the in-memory `linked` set (drives the
+ *     candidate list, so already-linked sessions are never re-probed).
  */
 export const correlateOrphanOtel = () =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
+
+        // Already-linked sessions (telemetry_of stays small - one edge per session).
+        const edgeRows = (yield* db.query<[Array<{ in: unknown }>]>(
+            `SELECT in FROM telemetry_of;`,
+        ))?.[0] ?? [];
+        const linked = new Set<string>();
+        for (const r of edgeRows) { const u = bareUuid(r.in); if (u) linked.add(u); }
+
+        // Candidates = existing top-level sessions (uuid id) not yet linked.
+        const sessRows = (yield* db.query<[Array<{ id: unknown }>]>(
+            `SELECT id FROM session;`,
+        ))?.[0] ?? [];
+        const candidates = [...new Set(
+            sessRows.map((r) => bareUuid(r.id)).filter((u): u is string => u !== null),
+        )].filter((u) => !linked.has(u));
+        if (candidates.length === 0) return;
+
+        // For each candidate, find one representative otel row via the indexed
+        // `session_id IN [...]` probe (chunked). First table that has it wins.
+        const seen = new Set<string>();
         const stmts: string[] = [];
         for (const table of RELATABLE) {
-            const q =
-                `SELECT id, session_id FROM ${table} ` +
-                `WHERE session_id != NONE ` +
-                `AND type::record("session:" + session_id) IN (SELECT VALUE id FROM session) ` +
-                `AND count(<-telemetry_of) = 0;`;
-            const res = yield* db.query<Orphan[][]>(q);
-            const orphans = res[0] ?? [];
-            for (const o of orphans) {
-                // The SDK returns `id` as a string or a RecordId object; extract
-                // the bare key robustly, then use recordRef for canonical escaped
-                // record references.
-                const recId = recordKey(o.id);
-                if (recId === null) continue;
-                stmts.push(
-                    `RELATE ${recordRef("session", o.session_id)}->telemetry_of->${recordRef(table, recId)};`,
-                );
+            const remaining = candidates.filter((u) => !seen.has(u));
+            if (remaining.length === 0) break;
+            for (const part of chunk(remaining, CHUNK)) {
+                const list = part.map((u) => `"${u}"`).join(", ");
+                const rows = (yield* db.query<[Array<{ id: unknown; session_id: unknown }>]>(
+                    `SELECT id, session_id FROM ${table} WHERE session_id IN [${list}] GROUP BY session_id;`,
+                ))?.[0] ?? [];
+                for (const o of rows) {
+                    const u = bareUuid(o.session_id);
+                    if (u === null || seen.has(u)) continue;
+                    // GROUP BY collapses `id` into an array of the group's row ids;
+                    // take the first as the representative. recordKey handles the
+                    // SDK's string|RecordId shape; recordRef escapes it canonically.
+                    const repId = Array.isArray(o.id) ? o.id[0] : o.id;
+                    const recId = recordKey(repId);
+                    if (recId === null) continue;
+                    seen.add(u);
+                    stmts.push(
+                        `RELATE ${recordRef("session", u)}->telemetry_of->${recordRef(table, recId)};`,
+                    );
+                }
             }
         }
         if (stmts.length > 0) yield* executeStatements(stmts);

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1991,8 +1991,12 @@ DEFINE INDEX IF NOT EXISTS ingest_file_state_source  ON ingest_file_state FIELDS
 -- Stores harness-push metric data points and trace spans received via the
 -- /v1/metrics and /v1/traces OTLP/JSON receiver endpoints. Linked to the
 -- session graph via the telemetry_of relation. `attrs` is JSON-encoded
--- key-value attributes from the OTLP payload. Both tables index session_id
--- for the correlation pass that emits telemetry_of edges at ingest time.
+-- key-value attributes from the OTLP payload. Tables index session_id (for the
+-- telemetry-enriched rollups) and observed_at (for the incremental correlation
+-- pass that windows recent telemetry). Index builds are CONCURRENTLY: a plain
+-- DEFINE INDEX takes a table lock while it builds, which wedges the daemon when
+-- re-applied to an already-large otel_log_event (codex emits ~1.5M log rows);
+-- CONCURRENTLY builds in the background without locking.
 -- ---------------------------------------------------------------------------
 DEFINE TABLE otel_metric_point SCHEMAFULL;
 DEFINE FIELD harness     ON otel_metric_point TYPE string;
@@ -2005,7 +2009,8 @@ DEFINE FIELD skill_name  ON otel_metric_point TYPE option<string>;
 DEFINE FIELD agent_name  ON otel_metric_point TYPE option<string>;
 DEFINE FIELD attrs       ON otel_metric_point TYPE option<string>;   -- JSON-encoded
 DEFINE FIELD observed_at ON otel_metric_point TYPE datetime;
-DEFINE INDEX IF NOT EXISTS otel_metric_session ON otel_metric_point FIELDS session_id;
+DEFINE INDEX IF NOT EXISTS otel_metric_session ON otel_metric_point FIELDS session_id CONCURRENTLY;
+DEFINE INDEX IF NOT EXISTS otel_metric_observed ON otel_metric_point FIELDS observed_at CONCURRENTLY;
 
 DEFINE TABLE otel_span SCHEMAFULL;
 DEFINE FIELD harness        ON otel_span TYPE string;
@@ -2019,7 +2024,8 @@ DEFINE FIELD ended_at       ON otel_span TYPE datetime;
 DEFINE FIELD duration_ms    ON otel_span TYPE number;
 DEFINE FIELD attrs          ON otel_span TYPE option<string>;        -- JSON-encoded
 DEFINE FIELD observed_at    ON otel_span TYPE datetime;
-DEFINE INDEX IF NOT EXISTS otel_span_session ON otel_span FIELDS session_id;
+DEFINE INDEX IF NOT EXISTS otel_span_session ON otel_span FIELDS session_id CONCURRENTLY;
+DEFINE INDEX IF NOT EXISTS otel_span_observed ON otel_span FIELDS observed_at CONCURRENTLY;
 
 DEFINE TABLE otel_log_event SCHEMAFULL;
 DEFINE FIELD harness          ON otel_log_event TYPE string;
@@ -2035,7 +2041,8 @@ DEFINE FIELD duration_ms      ON otel_log_event TYPE option<number>;
 DEFINE FIELD status_code      ON otel_log_event TYPE option<number>;
 DEFINE FIELD attrs            ON otel_log_event TYPE option<string>;
 DEFINE FIELD observed_at      ON otel_log_event TYPE datetime;
-DEFINE INDEX IF NOT EXISTS otel_log_event_session ON otel_log_event FIELDS session_id;
+DEFINE INDEX IF NOT EXISTS otel_log_event_session ON otel_log_event FIELDS session_id CONCURRENTLY;
+DEFINE INDEX IF NOT EXISTS otel_log_event_observed ON otel_log_event FIELDS observed_at CONCURRENTLY;
 
 DEFINE TABLE harness_tool_event SCHEMAFULL;
 DEFINE FIELD session         ON harness_tool_event TYPE record<session>;


### PR DESCRIPTION
Fixes #610. Pairs with #609 (`ax otel`), which surfaced the bug.

## Root cause
`correlate.ts` drew **zero** `telemetry_of` edges. `type::record("session:" + session_id)` evaluated the concat as **arithmetic** for hyphenated uuids:
```
RETURN type::record("session:" + "019fbf3f-9241-...")  -->  session:019fbf3f
```
Everything after the first hyphen was dropped, so the `IN (SELECT VALUE id FROM session)` check never matched. otel `session_id` is a bare uuid; `session.id` is the escaped `session:⟨uuid⟩` record — so we now match **uuid-to-uuid in JS**.

## Made cheap on the ingest hot path
This pass runs after **every** ingest (incl. the watcher's `--since=1`).

- **Session-grain**, not row-grain. The edge means "this session has telemetry" — and *nothing reads it for data* (enrichment + `ax otel` coverage both join `session_id` directly). Codex emits ~1.5M log rows for a few hundred sessions; one edge per otel row would write millions nobody consumes. Now: one representative edge per session.
- **Windowed + incremental.** Only telemetry observed in the last **2 days** is scanned, over a new `observed_at` index (range scan ~30ms), then filtered to existing+unlinked sessions in JS. OTLP arrives with its transcript, so recent telemetry is what a fresh ingest needs to link. (An earlier "candidates = existing − linked" cut was actually *worse* — 32s — because transcript-only sessions never get telemetry and stayed permanent candidates, re-probed every run. The full `GROUP BY` it replaced cost ~8s/ingest enumerating all 1.5M rows.)

## Root-caused the DB wedge (bonus, affects all users)
Every DB stall in this work traced to a plain `DEFINE INDEX` taking a **table lock** while building — so re-applying the schema (`ax install`) onto an already-large `otel_log_event` wedges the daemon. **All otel index builds are now `CONCURRENTLY`** (background, no lock), plus the new `observed_at` indexes.

## Verification (live)
- 2-day window scan = **~30ms** (observed_at index used; a leading `session_id != NONE` was defeating the index → 8s, fixed).
- 5-day replay over real data created **33 correct edges** (proper `session:⟨uuid⟩` ↔ `otel_*:⟨…⟩` escaping), confirming the relate path.
- 7 unit tests (candidate filtering, session-grain, cross-table dedup, idempotency, skip-unmatched, RecordId shape) + 83 otel/schema tests pass. `tsc` clean.

Coverage in `ax otel` (#609) reads `session_id` directly and never depended on this edge — so this is correctness + perf hygiene for the documented edge, not something the coverage number needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)