### PR TITLE
fix(#616) packaged ax serve self-spawn + DB watchdog (serve deadline + liveness reaper)

### DIFF
--- a/apps/axctl/src/cli/ingest-trace-progress.ts
+++ b/apps/axctl/src/cli/ingest-trace-progress.ts
@@ -1,7 +1,14 @@
 import { Effect, Layer } from "effect";
 import { TraceTransportTag, type TraceTransport } from "@ax/lib/live-traces/Sink";
 import { createProgressReporter, type ProgressMode, type ProgressReporter, type ProgressSink, type ProgressStage } from "./progress.ts";
-import { initTuiProgress, type TuiProgressHandle } from "./progress-tui.tsx";
+// Type-only import: `progress-tui.tsx` pulls in OpenTUI + React (incl. react's
+// jsx-dev-runtime). A *static* value import here would drag that whole subtree
+// into the module graph of every consumer of this file - notably `ax serve`,
+// which imports this module via `cli/index.ts` but never renders a TUI. The
+// packaged daemon stages react with only the prod jsx-runtime, so the dev
+// runtime isn't resolvable and the serve child crashed (#616). Keep the type
+// erased and load `initTuiProgress` lazily, only when the TUI path actually runs.
+import type { TuiProgressHandle } from "./progress-tui.tsx";
 
 /**
  * Parse a stage-count annotation SpanEvent (emitted by the ingest runner) into a
@@ -190,11 +197,16 @@ export const tuiTraceTransportLayer = (
                                 case "TraceStart": {
                                     if (state.started) break;
                                     state.started = true;
-                                    void initTuiProgress({
-                                        command: "ingest",
-                                        runId: event.traceId.replace(/^ingest:/, ""),
-                                        stages,
-                                    })
+                                    // Lazy import keeps OpenTUI/React (and react's
+                                    // jsx-dev-runtime) out of the serve module graph (#616).
+                                    void import("./progress-tui.tsx")
+                                        .then(({ initTuiProgress }) =>
+                                            initTuiProgress({
+                                                command: "ingest",
+                                                runId: event.traceId.replace(/^ingest:/, ""),
+                                                stages,
+                                            })
+                                        )
                                         .then((handle) => {
                                             // Scope already closed while we were initializing:
                                             // tear the fresh renderer straight back down.

--- a/apps/axctl/src/dashboard/router/router.test.ts
+++ b/apps/axctl/src/dashboard/router/router.test.ts
@@ -196,3 +196,69 @@ describe("dispatch", () => {
         expect(await res?.text()).toBe("bytes");
     });
 });
+
+describe("request deadline (AX_SERVE_QUERY_TIMEOUT_MS)", () => {
+    const slowTable = (ms: number): ReadonlyArray<AnyRoute> => [
+        jsonRoute({
+            method: "GET",
+            path: "/api/slow",
+            decode: () => decodeOk(undefined),
+            // A handler that outlives any tight deadline (mirrors a wedged db.query).
+            handler: () => Effect.sleep(`${ms} millis`).pipe(Effect.as({ ok: true })),
+        }),
+    ];
+
+    test("a handler that outruns the deadline returns 504, not a hang", async () => {
+        const prev = process.env.AX_SERVE_QUERY_TIMEOUT_MS;
+        process.env.AX_SERVE_QUERY_TIMEOUT_MS = "20"; // 20ms deadline
+        try {
+            const res = await dispatch(
+                slowTable(5_000), // handler would take 5s
+                get("/api/slow"),
+                new URL("http://h/api/slow"),
+                testRunner,
+            );
+            expect(res?.status).toBe(504);
+            const body = (await res?.json()) as { error?: string };
+            expect(String(body?.error)).toContain("server query deadline");
+        } finally {
+            if (prev === undefined) delete process.env.AX_SERVE_QUERY_TIMEOUT_MS;
+            else process.env.AX_SERVE_QUERY_TIMEOUT_MS = prev;
+        }
+    });
+
+    test("a fast handler completes normally under the deadline", async () => {
+        const prev = process.env.AX_SERVE_QUERY_TIMEOUT_MS;
+        process.env.AX_SERVE_QUERY_TIMEOUT_MS = "5000";
+        try {
+            const res = await dispatch(
+                slowTable(1), // ~immediate
+                get("/api/slow"),
+                new URL("http://h/api/slow"),
+                testRunner,
+            );
+            expect(res?.status).toBe(200);
+            expect(await res?.json()).toEqual({ ok: true });
+        } finally {
+            if (prev === undefined) delete process.env.AX_SERVE_QUERY_TIMEOUT_MS;
+            else process.env.AX_SERVE_QUERY_TIMEOUT_MS = prev;
+        }
+    });
+
+    test("AX_SERVE_QUERY_TIMEOUT_MS=0 disables the deadline (unbounded)", async () => {
+        const prev = process.env.AX_SERVE_QUERY_TIMEOUT_MS;
+        process.env.AX_SERVE_QUERY_TIMEOUT_MS = "0";
+        try {
+            const res = await dispatch(
+                slowTable(30), // would 504 under a tight deadline; here it must complete
+                get("/api/slow"),
+                new URL("http://h/api/slow"),
+                testRunner,
+            );
+            expect(res?.status).toBe(200);
+        } finally {
+            if (prev === undefined) delete process.env.AX_SERVE_QUERY_TIMEOUT_MS;
+            else process.env.AX_SERVE_QUERY_TIMEOUT_MS = prev;
+        }
+    });
+});

--- a/apps/axctl/src/dashboard/router/router.ts
+++ b/apps/axctl/src/dashboard/router/router.ts
@@ -16,7 +16,8 @@
  * lifetime; router/route unit tests pass a stub so they never build AppLayer
  * (and therefore never touch SurrealDB).
  */
-import type { Effect, Layer } from "effect";
+import { Effect } from "effect";
+import type { Layer } from "effect";
 import type { AppLayer } from "@ax/lib/layers";
 import type { DurableIngestStream } from "../ingest-stream-durable.ts";
 
@@ -153,6 +154,39 @@ export const errorMessage = (err: unknown): string => {
     return String(err);
 };
 
+// ----------------------------------------------------------- request deadline
+//
+// Per-request DB deadline. `acquire` (db.ts) already caps the initial connect at
+// 5s, but once connected a daemon that wedges (alive but not answering - the
+// recurring SurrealDB failure on this box) makes `db.query()` hang FOREVER, so
+// JSON handlers pile up behind a dead websocket and the whole dashboard appears
+// frozen (this is what made /api/wrapped hang). A whole-request timeout bounds
+// each JSON handler's lifetime: the fiber is interrupted, the client gets a fast
+// 504, and handlers stop accumulating. (The orphaned WS promise can't be force-
+// cancelled, but the request no longer blocks - the daemon-side watchdog is what
+// reaps the wedged surreal.)
+//
+// Scope is deliberately JSON routes only: rawRoutes (SSE /api/events, the
+// ingest stream) own their own long-lived lifecycle and must NOT be clamped.
+// Default 45s sits above legit slow reads (recall full-scans 5-15s today) and
+// below Bun's 60s idleTimeout. AX_SERVE_QUERY_TIMEOUT_MS overrides; `0` disables
+// (e.g. tests, or a deployment that wants the old unbounded behavior).
+export const SERVE_REQUEST_TIMEOUT_DEFAULT_MS = 45_000;
+
+/** Read the request deadline per call so serve env / tests can vary it. */
+const serveRequestTimeoutMs = (): number => {
+    const raw = process.env.AX_SERVE_QUERY_TIMEOUT_MS;
+    if (raw === undefined || raw === "") return SERVE_REQUEST_TIMEOUT_DEFAULT_MS;
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? n : SERVE_REQUEST_TIMEOUT_DEFAULT_MS;
+};
+
+/** Sentinel raised when a JSON handler outruns the request deadline -> HTTP 504. */
+export class ServeRequestTimeout {
+    readonly _tag = "ServeRequestTimeout";
+    constructor(readonly ms: number) {}
+}
+
 export const jsonRoute = <P, A>(def: JsonRouteDef<P, A>): AnyRoute => ({
     methods: toMethods(def.method),
     pattern: compilePattern(def.path),
@@ -161,10 +195,31 @@ export const jsonRoute = <P, A>(def: JsonRouteDef<P, A>): AnyRoute => ({
     run: async (input, runner) => {
         const decoded = def.decode(input);
         if (!decoded.ok) return jsonResponse(decoded.body, decoded.status);
+        const timeoutMs = serveRequestTimeoutMs();
+        const handler = def.handler(decoded.value);
+        // Bound the handler so a wedged daemon can't hang the request forever.
+        const effect = timeoutMs > 0
+            ? handler.pipe(
+                Effect.timeoutOrElse({
+                    duration: `${timeoutMs} millis`,
+                    orElse: () => Effect.fail(new ServeRequestTimeout(timeoutMs)),
+                }),
+            )
+            : handler;
         try {
-            const value = await runner(def.handler(decoded.value));
+            const value = await runner(effect);
             return def.respond ? def.respond(value) : jsonResponse(value);
         } catch (err) {
+            if (err instanceof ServeRequestTimeout) {
+                return jsonResponse(
+                    {
+                        error:
+                            `request exceeded the ${err.ms}ms server query deadline; the SurrealDB daemon may be wedged ` +
+                            `(check 'ax serve status' and restart the db)`,
+                    },
+                    504,
+                );
+            }
             return jsonResponse(
                 { error: errorMessage(err) },
                 def.errorStatus?.(err) ?? 500,

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -243,7 +243,10 @@ export async function serveDashboard(args: string[]): Promise<void> {
         }
 
         // 60s idle timeout - recall queries currently full-scan turn excerpts
-        // (no full-text index yet) and can take 5-15s on a year-old graph.
+        // (no full-text index yet) and can take 5-15s on a year-old graph. JSON
+        // handlers also carry a per-request DB deadline (default 45s,
+        // AX_SERVE_QUERY_TIMEOUT_MS, in router.ts) so a wedged daemon returns a
+        // fast 504 instead of hanging the request forever.
         server = Bun.serve({
             port,
             // loopback by default (always-on daemon; browser studio connects locally);

--- a/apps/studio-desktop/electron-builder.config.cjs
+++ b/apps/studio-desktop/electron-builder.config.cjs
@@ -62,7 +62,25 @@ module.exports = {
   files: ["dist-electron/**", "package.json"],
   extraResources: [
     { from: "resources/bin", to: "bin" },
+    // The staged ax source tree. electron-builder's copy filter
+    // (app-builder-lib/out/util/filter.js `createFilter`) HARDCODES
+    // `if (relative === "node_modules") return false` - it drops the top-level
+    // node_modules of any copy root (electron-userland/electron-builder#867).
+    // So this entry copies everything UNDER ax-src EXCEPT its node_modules; the
+    // staged `bun install` tree (effect, surrealdb, durable-streams, lmdb, ...)
+    // would silently vanish and the bundled `ax serve` dies with
+    // `Cannot find package 'effect'` (#616, defect #1). The hardcoded check
+    // fires on the literal relative path "node_modules", and runs BEFORE any
+    // `filter` patterns, so no include glob can rescue it.
     { from: "resources/ax-src", to: "ax-src" },
+    // ...so we copy node_modules via a SEPARATE entry whose copy ROOT is the
+    // node_modules dir itself. Its children have relative paths like "effect" /
+    // "surrealdb" (never the literal "node_modules"), so the exclusion never
+    // fires, and nested package node_modules (relative "effect/node_modules")
+    // are copied too - only the COPY-ROOT node_modules is special-cased.
+    // Reproduces the runtime layout Resources/ax-src/node_modules verbatim.
+    // Verified against app-builder-lib 26.8.1's own FileMatcher/copyFiles.
+    { from: "resources/ax-src/node_modules", to: "ax-src/node_modules" },
     { from: "resources/studio", to: "studio" },
     { from: "build/icons", to: "icons" },
   ],

--- a/apps/studio-desktop/src/backend/SupervisedProcess.test.ts
+++ b/apps/studio-desktop/src/backend/SupervisedProcess.test.ts
@@ -292,3 +292,132 @@ test("stop cancels pending restart, sends SIGTERM, no respawn after stop", async
     expect(out.spawnsLater).toBe(1);
     expect(out.snap.ready).toBe(false);
 });
+
+// ---------------------------------------------------------------------------
+// (d) liveness watchdog: N consecutive failed probes SIGKILL the wedged child
+//     and the exit->restart path respawns it.
+// ---------------------------------------------------------------------------
+
+const LIVENESS = {
+    interval: Duration.seconds(1),
+    timeout: Duration.millis(500),
+    failureThreshold: 3,
+} as const;
+
+test("liveness watchdog SIGKILLs a wedged child after N consecutive failures, then restarts", async () => {
+    const program = Effect.gen(function* () {
+        const stubSpawner = yield* makeStubSpawner;
+        const stubHttp = yield* makeStubHttpClient;
+        const healthy = yield* Ref.make(true);
+        // Caller-supplied probe: ok while healthy, fails (a wedge) otherwise.
+        const probe = Ref.get(healthy).pipe(
+            Effect.flatMap((h) =>
+                h ? Effect.void : Effect.fail(new Error("wedged")),
+            ),
+        );
+        const config: SupervisedProcessConfig = {
+            ...testConfig,
+            liveness: { probe, ...LIVENESS },
+        };
+
+        return yield* Effect.scoped(
+            Effect.gen(function* () {
+                const proc = yield* makeSupervisedProcess(config);
+                yield* proc.start;
+                yield* TestClock.adjust(Duration.millis(200)); // ready, watchdog armed
+                const spawnsReady = yield* stubSpawner.controller.spawnCount;
+
+                // Wedge it: every subsequent probe fails.
+                yield* Ref.set(healthy, false);
+                // 3 intervals -> 3 consecutive failures -> SIGKILL on the 3rd.
+                yield* TestClock.adjust(Duration.seconds(3));
+                yield* TestClock.adjust(Duration.millis(1)); // observe exit
+                const killsAfterWedge =
+                    yield* stubSpawner.controller.killSignals;
+                const snapAfterWedge = yield* proc.snapshot;
+
+                // Recover before the respawn so the new child stays up.
+                yield* Ref.set(healthy, true);
+                yield* TestClock.adjust(INITIAL_RESTART_DELAY); // backoff
+                yield* TestClock.adjust(Duration.millis(200)); // re-ready
+                const spawnsAfterRestart =
+                    yield* stubSpawner.controller.spawnCount;
+
+                yield* proc.stop({ timeout: Duration.seconds(1) });
+                return {
+                    spawnsReady,
+                    killsAfterWedge,
+                    snapAfterWedge,
+                    spawnsAfterRestart,
+                };
+            }),
+        ).pipe(
+            Effect.provide(stubSpawner.layer),
+            Effect.provide(stubHttp.layer),
+            Effect.provide(backendOutputLogNoopLayer),
+        );
+    });
+
+    const out = await Effect.runPromise(
+        program.pipe(Effect.provide(TestClock.layer())),
+    );
+
+    expect(out.spawnsReady).toBe(1);
+    // The wedge must be reaped with SIGKILL (not just the SIGTERM of scope close).
+    expect(out.killsAfterWedge).toContain("SIGKILL");
+    expect(out.snapAfterWedge.restartAttempt).toBeGreaterThanOrEqual(1);
+    // exit->restart respawned the child.
+    expect(out.spawnsAfterRestart).toBe(2);
+});
+
+test("liveness watchdog: a recovered probe resets the counter (no kill)", async () => {
+    const program = Effect.gen(function* () {
+        const stubSpawner = yield* makeStubSpawner;
+        const stubHttp = yield* makeStubHttpClient;
+        const healthy = yield* Ref.make(true);
+        const probe = Ref.get(healthy).pipe(
+            Effect.flatMap((h) =>
+                h ? Effect.void : Effect.fail(new Error("blip")),
+            ),
+        );
+        const config: SupervisedProcessConfig = {
+            ...testConfig,
+            liveness: { probe, ...LIVENESS },
+        };
+
+        return yield* Effect.scoped(
+            Effect.gen(function* () {
+                const proc = yield* makeSupervisedProcess(config);
+                yield* proc.start;
+                yield* TestClock.adjust(Duration.millis(200)); // ready
+
+                // Two failures (below the threshold of 3)...
+                yield* Ref.set(healthy, false);
+                yield* TestClock.adjust(Duration.seconds(2));
+                // ...then recover. The counter resets, so the next failures
+                // start from zero and never reach the threshold here.
+                yield* Ref.set(healthy, true);
+                yield* TestClock.adjust(Duration.seconds(5));
+
+                const kills = yield* stubSpawner.controller.killSignals;
+                const spawns = yield* stubSpawner.controller.spawnCount;
+                const snap = yield* proc.snapshot;
+                yield* proc.stop({ timeout: Duration.seconds(1) });
+                return { kills, spawns, snap };
+            }),
+        ).pipe(
+            Effect.provide(stubSpawner.layer),
+            Effect.provide(stubHttp.layer),
+            Effect.provide(backendOutputLogNoopLayer),
+        );
+    });
+
+    const out = await Effect.runPromise(
+        program.pipe(Effect.provide(TestClock.layer())),
+    );
+
+    // No SIGKILL: failures never hit 3 in a row.
+    expect(out.kills).not.toContain("SIGKILL");
+    expect(out.spawns).toBe(1); // never restarted
+    expect(out.snap.ready).toBe(true);
+});

--- a/apps/studio-desktop/src/backend/SupervisedProcess.ts
+++ b/apps/studio-desktop/src/backend/SupervisedProcess.ts
@@ -58,6 +58,28 @@ export interface SupervisedProcessConfig {
         readonly url: URL;
         readonly timeout: Duration.Duration;
     };
+    /**
+     * Optional liveness watchdog. The startup readiness probe only fires once;
+     * a child that comes up and later WEDGES (process alive, not answering -
+     * the recurring SurrealDB failure) never exits, so the exit->restart path
+     * never triggers and the daemon stays dead-but-running forever.
+     *
+     * When set, the supervisor runs `probe` every `interval` once the child is
+     * ready, each capped at `timeout`. On `failureThreshold` CONSECUTIVE failed
+     * or timed-out probes it classifies the child as wedged and SIGKILLs the
+     * pid, which resolves its exitCode and feeds the existing exit->restart
+     * backoff (LaunchAgent / SupervisedProcess respawn). One success resets the
+     * counter. Keyed on probe timeouts, NOT CPU - a wedged daemon can sit at any
+     * CPU level. The probe is supplied by the caller (so this module stays free
+     * of surreal/ax-serve specifics) and must be fully provided (no env): e.g.
+     * `HEAD /health` AND a tiny `RETURN 1` SQL round-trip, both with deadlines.
+     */
+    readonly liveness?: {
+        readonly probe: Effect.Effect<void, unknown>;
+        readonly interval: Duration.Duration;
+        readonly timeout: Duration.Duration;
+        readonly failureThreshold: number;
+    };
 }
 
 export interface SupervisedProcessSnapshot {
@@ -248,7 +270,59 @@ interface RunChildOptions {
         streamName: SupervisedProcessOutputStream,
         chunk: Uint8Array,
     ) => Effect.Effect<void>;
+    /**
+     * Reports each liveness watchdog outcome: a failed/timed-out probe
+     * (`wedged: false` until the threshold, `wedged: true` on the kill) or a
+     * recovery (`consecutive: 0`). No-op when no liveness config is set.
+     */
+    readonly onLivenessEvent: (info: {
+        readonly consecutive: number;
+        readonly wedged: boolean;
+    }) => Effect.Effect<void>;
 }
+
+/**
+ * Periodic liveness watchdog: probe every `interval` (each capped at
+ * `timeout`); on `failureThreshold` CONSECUTIVE failures, SIGKILL the child so
+ * its exitCode resolves and the supervisor's exit->restart path reaps the
+ * wedged daemon. A single success resets the counter. Returns when it has
+ * killed the child (or is interrupted by the run scope closing on stop/restart).
+ */
+const runLivenessWatchdog = (
+    liveness: NonNullable<SupervisedProcessConfig["liveness"]>,
+    handle: ChildProcessSpawner.ChildProcessHandle,
+    onEvent: RunChildOptions["onLivenessEvent"],
+): Effect.Effect<void> =>
+    Effect.gen(function* () {
+        const failures = yield* Ref.make(0);
+        const loop: Effect.Effect<void> = Effect.suspend(() =>
+            Effect.gen(function* () {
+                yield* Effect.sleep(liveness.interval);
+                // Any probe error OR a per-probe timeout counts as a failure.
+                const failed = yield* liveness.probe.pipe(
+                    Effect.timeout(liveness.timeout),
+                    Effect.as(false),
+                    Effect.catch(() => Effect.succeed(true)),
+                );
+                if (!failed) {
+                    yield* Ref.set(failures, 0);
+                    yield* onEvent({ consecutive: 0, wedged: false });
+                    return yield* loop;
+                }
+                const n = yield* Ref.updateAndGet(failures, (x) => x + 1);
+                const wedged = n >= liveness.failureThreshold;
+                yield* onEvent({ consecutive: n, wedged });
+                if (!wedged) return yield* loop;
+                // Wedged: force-kill so the exit->restart path reaps it. SIGKILL
+                // (not SIGTERM) because a wedged process may ignore graceful
+                // signals - the whole point is that it stopped responding.
+                yield* handle
+                    .kill({ killSignal: "SIGKILL" })
+                    .pipe(Effect.ignore);
+            }),
+        );
+        yield* loop;
+    });
 
 const runChildProcess = Effect.fn("supervisedProcess.runChildProcess")(
     function* (
@@ -291,6 +365,18 @@ const runChildProcess = Effect.fn("supervisedProcess.runChildProcess")(
             config.readiness.timeout,
         ).pipe(
             Effect.tap(() => options.onReady()),
+            // Once ready, keep probing for liveness so a wedged-but-alive child
+            // gets reaped (it would otherwise never exit). Runs in the same run
+            // scope, so stop/restart interrupts it.
+            Effect.flatMap(() =>
+                config.liveness
+                    ? runLivenessWatchdog(
+                          config.liveness,
+                          handle,
+                          options.onLivenessEvent,
+                      )
+                    : Effect.void,
+            ),
             Effect.catch((error) => options.onReadinessFailure(error)),
             Effect.forkScoped,
         );
@@ -502,6 +588,17 @@ export const makeSupervisedProcess = Effect.fn("makeSupervisedProcess")(
                             ),
                         onOutput: (streamName, chunk) =>
                             backendOutputLog.writeOutputChunk(streamName, chunk),
+                        onLivenessEvent: ({ consecutive, wedged }) =>
+                            consecutive === 0
+                                ? Effect.void // healthy probe: stay quiet
+                                : wedged
+                                  ? logError(
+                                        "liveness probe wedged; SIGKILL to force restart",
+                                        { consecutiveFailures: consecutive },
+                                    )
+                                  : logWarning("liveness probe failed", {
+                                        consecutiveFailures: consecutive,
+                                    }),
                     }).pipe(
                         Effect.provideService(
                             ChildProcessSpawner.ChildProcessSpawner,


### PR DESCRIPTION
Follow-up to #614/#615 (the `node:net` arbitration fix). That PR got the desktop app to correctly **decide** `spawn`, but surfaced more bugs in the packaged self-spawn (#616) and the recurring SurrealDB wedge. This PR carries the platform-agnostic, test-verified fixes. Independent of #615 (touches none of `AxDaemonArbitration.ts`).

## #616 — packaged `ax serve` can't self-spawn (both defects)

1. **react `jsx-dev-runtime`** (`fix(axctl)`): `cli/index.ts` → `ingest-trace-progress.ts` statically imported `progress-tui.tsx` (OpenTUI/React), dragging react's dev jsx runtime into the serve module graph; the packaged daemon stages only the prod `jsx-runtime`, so the bundled `ax serve` crashed with `Cannot find module 'react/jsx-dev-runtime'`. Made it a type-only import + lazy `import()` (TUI only loads for `ax ingest` on a TTY). **Verified** via a split bundle: `jsx-dev-runtime` lands in a separate dynamic chunk; the serve entry chunk has **0** references.

2. **`node_modules` dropped from `ax-src`** (`fix(studio-desktop)`): root cause is electron-builder's copy filter (`app-builder-lib/out/util/filter.js`), which **hardcodes** `if (relative === "node_modules") return false` — it drops the top-level `node_modules` of any copy root (electron-userland/electron-builder#867), and runs *before* any `filter` glob, so no include pattern can rescue it. The staged `bun install` tree sat exactly at that excluded root → installed `Resources/ax-src/node_modules` came out empty → `Cannot find package 'effect'`. Fixed with a second `extraResources` entry rooted at the `node_modules` dir itself (its children are package names, never the literal `"node_modules"`). **Verified** end-to-end against app-builder-lib 26.8.1's own `FileMatcher`/`copyFiles`: single-entry config drops it (repro), two-entry restores it in full (real pkgs + internal `@ax` workspace symlink + nested `node_modules`).
   - ⚠️ The file-copy mechanism is platform-independent (verified on Linux), but **final packaging still needs a macOS build** to confirm signing/notarization of the now-included tree.

## DB watchdog (#618) — the two platform-agnostic halves

3. **serve-side request deadline** (`feat(serve)`): `db.ts` caps the initial connect at 5s, but once connected a wedged-but-alive daemon makes `db.query()` hang forever, piling JSON handlers behind a dead websocket (the `/api/wrapped` hang). Every `jsonRoute` handler is now wrapped in a whole-request `Effect.timeoutOrElse` → fast **504** instead of a hang. Scoped to JSON routes only (SSE `/api/events` + the ingest stream keep their long-lived lifecycle). Default 45s (above legit 5–15s recall full-scans, below Bun's 60s idleTimeout); `AX_SERVE_QUERY_TIMEOUT_MS` overrides, `0` disables. **3 new tests.**

4. **supervisor-side liveness watchdog** (`feat(studio-desktop)`): the startup readiness probe fires once; a child that comes up and later **wedges** (process alive, not answering) never exits, so the supervisor's exit→restart path never triggers. Added an injectable periodic liveness watchdog to `SupervisedProcess`: once ready, run `probe` every `interval` (each capped at `timeout`); on `failureThreshold` **consecutive** failures/timeouts, **SIGKILL** the child → exitCode resolves → existing backoff-restart reaps it. Keyed on probe **timeouts**, not CPU. The probe is caller-supplied so the module stays free of surreal/ax-serve specifics. **2 new tests** (wedge→SIGKILL→restart; recovery resets the counter), via TestClock + the stub spawner.

## Deferred — needs live macOS verification (NOT in this PR)

**Part (c): wire the surreal liveness probe into `AxBackendManager` + record surreal ownership state.** The watchdog *mechanism* (#4 above) is done and tested, but the actual surreal probe was intentionally left unwired because it can't be verified on this Linux workbox (no `surreal` binary, no daemon on `:8521`, macOS-only Electron app). To finish on a Mac:

- In `AxBackendManager`, build a liveness probe for the surreal `SupervisedProcessConfig` and pass it via the new `liveness` field on `makeSurrealConfig`. The handoff is explicit that it must be a **real SQL round-trip**, not just `HEAD /health` (the HTTP listener can stay 200 while the query engine wedges). Suggested: POST `RETURN 1;` to surreal's HTTP `/sql` endpoint via the manager's existing `HttpClient` (root/root basic auth + `NS`/`DB` headers) — **verify the exact `/sql` auth + response contract against a live surreal** before trusting it. Recommended knobs: `interval` ~10s, `timeout` ~2s, `failureThreshold` 3.
- **Ownership/takeover state**: record the spawned surreal `pid` + `data-dir` + `port` in runtime state so an orphan (e.g. a studio.app crash leaving a SIGTERM-immune listener on `:8521`) is identifiable and force-killable.
- Add a per-request query deadline note to the LaunchAgent (`com.necmttn.ax-db.plist`) story if relevant; #3 covers the `ax serve` side already.

## Verification on this box
- `axctl` + `studio-desktop` typecheck clean (`tsc --noEmit`, exit 0).
- New tests: 23 pass (5 SupervisedProcess incl. 2 new, 18 router incl. 3 new).
- Pre-existing unrelated flake: `DesktopIngestScheduler.test.ts` fails only in a combined backend run (cross-file TestClock interference); passes in isolation and reproduces **without** any change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
