### PR TITLE
perf: bound session churn scans to failure candidates

### DIFF
--- a/apps/axctl/src/metrics/session-churn.test.ts
+++ b/apps/axctl/src/metrics/session-churn.test.ts
@@ -395,6 +395,58 @@ describe("fetchSessionChurnSummary", () => {
         expect(seenSql[0]).not.toContain("session_metrics");
     });
 
+    test("secondary scans are bounded to sessions with failed commands or blocking hooks", async () => {
+        const seenSql: string[] = [];
+        const summary = await Effect.runPromise(fetchSessionChurnSummary({
+            since: null,
+            limit: 20,
+            generatedAt: new Date("2026-06-11T00:00:00.000Z"),
+        }).pipe(Effect.provide(db({
+            seenSql,
+            base: [
+                { session: "session:`cmd-hot`", source: "codex" },
+                { session: "session:`hook-hot`", source: "claude" },
+                { session: "session:`quiet`", source: "codex" },
+            ],
+            health: [
+                { session: "session:`cmd-hot`", task_label: "command failure" },
+                { session: "session:`hook-hot`", task_label: "hook failure" },
+                { session: "session:`quiet`", task_label: "quiet work" },
+            ],
+            produced: [
+                { session: "session:`cmd-hot`", commit: "commit:`c1`" },
+                { session: "session:`quiet`", commit: "commit:`c2`" },
+            ],
+            touched: [
+                { commit: "commit:`c1`", file: "file:`f1`", additions: 8, deletions: 1 },
+                { commit: "commit:`c2`", file: "file:`f2`", additions: 99, deletions: 9 },
+            ],
+            edits: [
+                { session: "session:`cmd-hot`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+                { session: "session:`hook-hot`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+                { session: "session:`quiet`", ts: "2026-06-11T00:01:00.000Z", name: "Edit", input_json: JSON.stringify({ old_string: "a", new_string: "a\nb" }) },
+            ],
+            outcomes: [
+                { session: "session:`cmd-hot`", ts: "2026-06-11T00:02:00.000Z", status: "error", command_norm: "tsc" },
+            ],
+            hooks: [
+                { session: "session:`hook-hot`", ts: "2026-06-11T00:02:00.000Z", provider_status: "blocking_error", effect: "blocked", exit_code: 1, command: "bun test" },
+            ],
+        }))));
+
+        expect(summary.hotSessions.map((row) => row.session)).toEqual(["cmd-hot", "hook-hot"]);
+        expect(summary.hotSessions.find((row) => row.session === "quiet")).toBeUndefined();
+
+        const candidateSql = seenSql.find((sql) => sql.includes("FROM command_outcome") && sql.includes('kind = "expected_feedback"'))!;
+        expect(candidateSql).toContain("quiet");
+        const healthSql = seenSql.find((sql) => sql.includes("FROM session_health"))!;
+        const producedSql = seenSql.find((sql) => sql.includes("FROM produced"))!;
+        const editSql = seenSql.find((sql) => sql.includes("FROM tool_call") && sql.includes("input_json"))!;
+        expect(healthSql).not.toContain("quiet");
+        expect(producedSql).not.toContain("quiet");
+        expect(editSql).not.toContain("quiet");
+    });
+
     test("limit only caps hot sessions after ranking, not the base session scan", async () => {
         const seenSql: string[] = [];
         const summary = await Effect.runPromise(fetchSessionChurnSummary({
@@ -568,7 +620,9 @@ describe("fetchSessionChurnSummary", () => {
             ],
         }))));
 
-        const outcomeSql = seenSql.find((s) => s.includes("FROM command_outcome"))!;
+        const outcomeSql = seenSql.find((s) =>
+            s.includes("FROM command_outcome") && !s.includes('kind = "expected_feedback"')
+        )!;
         expect(outcomeSql).not.toContain("tool_call.command_text");
         expect(outcomeSql).not.toContain('kind = "expected_feedback"');
         expect(summary.hotSessions[0]).toMatchObject({

--- a/apps/axctl/src/metrics/session-churn.ts
+++ b/apps/axctl/src/metrics/session-churn.ts
@@ -297,12 +297,22 @@ ${where};`))?.[0] ?? [];
             return computeSessionChurn([], new Map(), new Map(), options);
         }
 
+        const candidateSessionIds = yield* fetchChurnCandidateSessionIds(sessionIds);
+        if (candidateSessionIds.length === 0) {
+            return computeSessionChurn([], new Map(), new Map(), options);
+        }
+
+        const candidateSessions = new Set(candidateSessionIds);
+        const candidateSourceBySession = new Map(
+            [...sourceBySession].filter(([session]) => candidateSessions.has(session)),
+        );
+
         const [health, landed, edits, commandEvents, hookEvents] = yield* Effect.all([
-            fetchSessionHealthMap(sessionIds),
-            fetchLandedLocBySession(sessionIds),
-            fetchEditEvents(sessionIds, sourceBySession),
-            fetchCommandOutcomeEvents(sessionIds, sourceBySession),
-            fetchHookEvents(sessionIds, sourceBySession),
+            fetchSessionHealthMap(candidateSessionIds),
+            fetchLandedLocBySession(candidateSessionIds),
+            fetchEditEvents(candidateSessionIds, candidateSourceBySession),
+            fetchCommandOutcomeEvents(candidateSessionIds, candidateSourceBySession),
+            fetchHookEvents(candidateSessionIds, candidateSourceBySession),
         ], { concurrency: 5 });
 
         const summary = computeSessionChurn([...edits, ...commandEvents, ...hookEvents], landed.bySession, health, {
@@ -320,6 +330,55 @@ ${where};`))?.[0] ?? [];
             }),
         );
         return { ...summary, hotSessions };
+    });
+
+const fetchChurnCandidateSessionIds = (
+    sessionIds: readonly string[],
+): Effect.Effect<string[], DbError, SurrealClient> =>
+    Effect.gen(function* () {
+        if (sessionIds.length === 0) return [];
+        const db = yield* SurrealClient;
+        const chunks = chunked(sessionIds, IN_CHUNK);
+
+        const [commandResults, hookResults] = yield* Effect.all([
+            Effect.all(
+                chunks.map((ids) =>
+                    db.query<[Array<Record<string, unknown>>]>(
+                        // De-dupe in JS instead of GROUP BY session; grouping
+                        // non-key fields is the slow path on large SurrealDB tables.
+                        `SELECT type::string(session) AS session`
+                        + ` FROM command_outcome`
+                        + ` WHERE session IN [${sessionRefList(ids)}]`
+                        + ` AND (kind = "expected_feedback" OR status = "error");`,
+                    ),
+                ),
+                { concurrency: 4 },
+            ),
+            Effect.all(
+                chunks.map((ids) =>
+                    db.query<[Array<Record<string, unknown>>]>(
+                        `SELECT type::string(session) AS session`
+                        + ` FROM hook_command_invocation`
+                        + ` WHERE session IN [${sessionRefList(ids)}]`
+                        + ` AND (provider_status = "blocking_error"`
+                        + ` OR effect = "blocked"`
+                        + ` OR (exit_code IS NOT NONE AND exit_code != 0));`,
+                    ),
+                ),
+                { concurrency: 4 },
+            ),
+        ], { concurrency: 2 });
+
+        const candidates = new Set<string>();
+        const addRows = (rows: readonly Record<string, unknown>[]) => {
+            for (const row of rows) {
+                const session = cleanSessionId(String(row.session ?? ""));
+                if (session.length > 0) candidates.add(session);
+            }
+        };
+        for (const batch of commandResults) addRows(batch?.[0] ?? []);
+        for (const batch of hookResults) addRows(batch?.[0] ?? []);
+        return sessionIds.filter((session) => candidates.has(session));
     });
 
 export const fetchLandedLocBySession = (
@@ -426,7 +485,7 @@ const fetchEditEvents = (
             if (!isEditTool(call)) continue;
             const session = cleanSessionId(String(row.session ?? ""));
             const tsMs = msOrNull(row.ts);
-            if (session.length === 0 || tsMs === null) continue;
+            if (session.length === 0 || !sourceBySession.has(session) || tsMs === null) continue;
             const inputJson = strOrNull(row.input_json);
             const delta = isApplyPatchCall(call)
                 ? applyPatchDelta(inputJson)
@@ -473,6 +532,7 @@ const fetchCommandOutcomeEvents = (
         const events: ChurnEvent[] = [];
         const pending: PendingOutcome[] = [];
         const pushEvent = (session: string, tsMs: number, eventKind: PendingOutcome["eventKind"], check: string) => {
+            if (!sourceBySession.has(session)) return;
             events.push({
                 session,
                 source: sourceBySession.get(session) ?? null,
@@ -494,7 +554,7 @@ const fetchCommandOutcomeEvents = (
                 : status === "ok"
                     ? "verification_pass" as const
                     : null;
-            if (eventKind === null || session.length === 0 || tsMs === null) continue;
+            if (eventKind === null || session.length === 0 || !sourceBySession.has(session) || tsMs === null) continue;
 
             const norm = strOrNull(row.command_norm);
             const check = checkFamilyFromCommand(norm);
@@ -557,7 +617,7 @@ const fetchHookEvents = (
             // Classify by the hook's command only - hook_name keywords (e.g.
             // "bun-test-blocking") must not register as verification events.
             const check = normalizedCheckFrom(row.command);
-            if (session.length === 0 || tsMs === null || check === null) continue;
+            if (session.length === 0 || !sourceBySession.has(session) || tsMs === null || check === null) continue;
             const providerStatus = strOrNull(row.provider_status);
             const effect = strOrNull(row.effect);
             const exitCode = exitCodeOf(row.exit_code);


### PR DESCRIPTION
## What

- Bound session churn's expensive health, landed LOC, edit, command, and hook scans to sessions that first show a failed command outcome or blocking hook.
- Preserved the existing churn computation path and telemetry enrichment.
- Added a regression test proving quiet sessions in the base window do not enter the secondary scans.

## Validation

- `bun run typecheck`
- `bun test apps/axctl/src/metrics/session-churn.test.ts`
- `bun test apps/axctl/src/dashboard/next-actions.test.ts`
- `bun run lint` (fails: repo has no `lint` script)
- `bun test` (fails in this container after 5274 pass / 9 skip: Electron postinstall remains unavailable because `node-pty` rebuild needs missing `make`; an existing failure-source test logs `db down`)

Closes #326

---

_Generated with [ax](https://github.com/Necmttn/ax)._
