### PR TITLE
Compile community pattern stats

### DIFF
--- a/.github/workflows/community-nightly.yml
+++ b/.github/workflows/community-nightly.yml
@@ -30,6 +30,9 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Compile community outputs
+        # Writes leaderboard, skill/hook stats, pattern-stats, state, and the
+        # local ETag cache. The publish step stages community/ but excludes the
+        # cache, so new generated JSON artifacts ride along automatically.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun scripts/compile-community.ts

--- a/apps/community-worker/src/worker.ts
+++ b/apps/community-worker/src/worker.ts
@@ -36,6 +36,7 @@ const KV_KEYS = {
     "/leaders": "leaderboard",
     "/skills": "skill-stats",
     "/hooks": "hook-stats",
+    "/patterns": "pattern-stats",
     "/state": "state",
     "/meta": "meta",
 } as const;
@@ -115,6 +116,7 @@ async function recompile(env: Env): Promise<{ users: number; compiled: number; d
         env.BOARD.put("leaderboard", JSON.stringify(out.leaderboard)),
         env.BOARD.put("skill-stats", JSON.stringify(out.skillStats)),
         env.BOARD.put("hook-stats", JSON.stringify(out.hookStats)),
+        env.BOARD.put("pattern-stats", JSON.stringify(out.patternStats)),
         env.BOARD.put("state", JSON.stringify(out.state)),
         env.BOARD.put("meta", JSON.stringify({ compiled_at: now, users: users.length, dropped: out.dropped })),
     ]);

--- a/apps/site/app/components/landing-sections/site-footer.tsx
+++ b/apps/site/app/components/landing-sections/site-footer.tsx
@@ -19,6 +19,7 @@ export function SiteFooter() {
         <div className="footer-col">
           <div className="footer-col-head">Community</div>
           <Link to="/leaders">Leaders</Link>
+          <Link to="/patterns">Patterns</Link>
           <a href="https://github.com/Necmttn/ax" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a href="https://discord.gg/E4R88Cvr5R" target="_blank" rel="noopener noreferrer">Discord</a>
         </div>

--- a/apps/site/app/components/landing-sections/site-header.tsx
+++ b/apps/site/app/components/landing-sections/site-header.tsx
@@ -55,6 +55,7 @@ export function SiteHeader() {
             <span className="nav-menu-label">Community</span>
             <Link to="/showcases">Showcases</Link>
             <Link to="/leaders">Leaders</Link>
+            <Link to="/patterns">Patterns</Link>
           </div>
         </div>
 

--- a/apps/site/app/lib/community.test.ts
+++ b/apps/site/app/lib/community.test.ts
@@ -5,8 +5,10 @@ import {
     formatUsdCompact,
     profileGistRawUrl,
     registrationRawUrl,
+    trendingPatterns,
     trendingSkills,
     validateLeaderboard,
+    validatePatternStats,
     validateProfileV1,
     validateRegistration,
 } from "./community";
@@ -338,6 +340,56 @@ describe("trendingSkills", () => {
     });
     test("minUsers override + limit", () => {
         expect(trendingSkills(stats, { minUsers: 1, limit: 2 })).toHaveLength(2);
+    });
+});
+
+describe("validatePatternStats + trendingPatterns", () => {
+    const stats = {
+        compiled_at: "2026-06-12T03:00:00Z",
+        patterns: {
+            "failure-mode/edit-loop-thrash": {
+                category: "failure-mode",
+                name: "edit-loop-thrash",
+                users: 2,
+                sessions: 9,
+                recovered_by: {
+                    "problem-solving-strategy/full-file-reread": { users: 1, sessions: 5 },
+                },
+            },
+            "workflow/small-review-loops": {
+                category: "workflow",
+                name: "small-review-loops",
+                users: 3,
+                sessions: 7,
+            },
+        },
+        dropped: [{ login: "alice", index: 2, reason: "invalid-pattern" }],
+    };
+
+    test("validates pattern adoption and recovery joins", () => {
+        const out = validatePatternStats(stats);
+        expect(out.patterns["failure-mode/edit-loop-thrash"]!.users).toBe(2);
+        expect(out.patterns["failure-mode/edit-loop-thrash"]!.recovered_by).toEqual({
+            "problem-solving-strategy/full-file-reread": { users: 1, sessions: 5 },
+        });
+        expect(out.dropped[0]).toEqual({ login: "alice", index: 2, reason: "invalid-pattern" });
+    });
+
+    test("rejects malformed recovery rows", () => {
+        expect(() => validatePatternStats({
+            ...stats,
+            patterns: {
+                "failure-mode/edit-loop-thrash": {
+                    ...stats.patterns["failure-mode/edit-loop-thrash"],
+                    recovered_by: { "workflow/x": { users: "lots", sessions: 1 } },
+                },
+            },
+        })).toThrow();
+    });
+
+    test("sorts by users desc, then sessions desc", () => {
+        const out = trendingPatterns(validatePatternStats(stats)).map(([key]) => key);
+        expect(out).toEqual(["workflow/small-review-loops", "failure-mode/edit-loop-thrash"]);
     });
 });
 

--- a/apps/site/app/lib/community.ts
+++ b/apps/site/app/lib/community.ts
@@ -366,6 +366,32 @@ export function validateLeaderboard(value: unknown): Leaderboard {
 // plugin beats "local"); optional so older compiled payloads still validate.
 export type SkillStats = Record<string, { readonly users: number; readonly runs: number; readonly source?: string }>;
 
+// --- pattern stats --------------------------------------------------------------
+
+export type PatternRecoveryStats = Record<string, { readonly users: number; readonly sessions: number }>;
+
+export interface PatternStatsRow {
+    readonly category: string;
+    readonly name: string;
+    readonly users: number;
+    readonly sessions: number;
+    readonly recovered_by?: PatternRecoveryStats;
+}
+
+export interface PatternStatsDrop {
+    readonly login: string;
+    readonly reason: string;
+    readonly index?: number;
+    readonly key?: string;
+    readonly ref?: string;
+}
+
+export interface PatternStats {
+    readonly compiled_at: string;
+    readonly patterns: Record<string, PatternStatsRow>;
+    readonly dropped: readonly PatternStatsDrop[];
+}
+
 // --- formatting (shared) --------------------------------------------------------
 
 /**
@@ -419,6 +445,66 @@ export function validateSkillStats(value: unknown): SkillStats {
     return out;
 }
 
+export function validatePatternStats(value: unknown): PatternStats {
+    if (!isRecord(value) || !isRecord(value.patterns)) throw new Error("invalid pattern stats");
+    const patterns: Record<string, PatternStatsRow> = {};
+    for (const [key, row] of Object.entries(value.patterns)) {
+        if (!isRecord(row)) throw new Error(`invalid pattern row ${key}`);
+        const recoveredRaw = row.recovered_by;
+        let recovered_by: PatternRecoveryStats | undefined;
+        if (recoveredRaw !== undefined) {
+            if (!isRecord(recoveredRaw)) throw new Error(`invalid pattern recoveries ${key}`);
+            recovered_by = {};
+            for (const [target, recovery] of Object.entries(recoveredRaw)) {
+                if (!isRecord(recovery)) throw new Error(`invalid pattern recovery ${target}`);
+                recovered_by[target] = {
+                    users: num(recovery.users, "pattern.recovery.users"),
+                    sessions: num(recovery.sessions, "pattern.recovery.sessions"),
+                };
+            }
+        }
+        patterns[key] = {
+            category: str(row.category, "pattern.category"),
+            name: str(row.name, "pattern.name"),
+            users: num(row.users, "pattern.users"),
+            sessions: num(row.sessions, "pattern.sessions"),
+            ...(recovered_by === undefined ? {} : { recovered_by }),
+        };
+    }
+
+    const droppedRaw = value.dropped;
+    const dropped: PatternStatsDrop[] = [];
+    if (droppedRaw !== undefined) {
+        if (!Array.isArray(droppedRaw)) throw new Error("invalid pattern dropped");
+        for (const drop of droppedRaw) {
+            if (!isRecord(drop)) throw new Error("invalid pattern dropped row");
+            dropped.push({
+                login: str(drop.login, "pattern.drop.login"),
+                reason: str(drop.reason, "pattern.drop.reason"),
+                ...(drop.index === undefined ? {} : { index: num(drop.index, "pattern.drop.index") }),
+                ...(drop.key === undefined ? {} : { key: str(drop.key, "pattern.drop.key") }),
+                ...(drop.ref === undefined ? {} : { ref: str(drop.ref, "pattern.drop.ref") }),
+            });
+        }
+    }
+
+    return {
+        compiled_at: typeof value.compiled_at === "string" ? value.compiled_at : "",
+        patterns,
+        dropped,
+    };
+}
+
+export function trendingPatterns(
+    stats: PatternStats,
+    opts: { readonly limit?: number } = {},
+): ReadonlyArray<readonly [string, PatternStatsRow]> {
+    const limit = opts.limit ?? 100;
+    return Object.entries(stats.patterns)
+        .sort(([ak, a], [bk, b]) => b.users - a.users || b.sessions - a.sessions || ak.localeCompare(bk))
+        .slice(0, limit);
+}
+
 // --- urls + fetchers --------------------------------------------------------------
 
 export function registrationRawUrl(login: string): string {
@@ -433,6 +519,7 @@ export function profileGistRawUrl(owner: string, gistId: string): string {
 
 export const leaderboardUrl = `${BOARD_API}/leaders`;
 export const skillStatsUrl = `${BOARD_API}/skills`;
+export const patternStatsUrl = `${BOARD_API}/patterns`;
 
 async function fetchJson(url: string): Promise<unknown> {
     const res = await fetch(url);
@@ -456,4 +543,8 @@ export async function fetchLeaderboard(): Promise<Leaderboard> {
 
 export async function fetchSkillStats(): Promise<SkillStats> {
     return validateSkillStats(await fetchJson(skillStatsUrl));
+}
+
+export async function fetchPatternStats(): Promise<PatternStats> {
+    return validatePatternStats(await fetchJson(patternStatsUrl));
 }

--- a/apps/site/app/routes/patterns.tsx
+++ b/apps/site/app/routes/patterns.tsx
@@ -1,0 +1,161 @@
+// apps/site/app/routes/patterns.tsx
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useEffect, useMemo, useState } from "react";
+import { SiteFooter } from "~/components/landing-sections/site-footer";
+import { SiteHeader } from "~/components/landing-sections/site-header";
+import {
+    fetchPatternStats,
+    formatCompact,
+    trendingPatterns,
+    type PatternStats,
+    type PatternStatsRow,
+} from "~/lib/community";
+
+export const Route = createFileRoute("/patterns")({
+    head: () => ({
+        meta: [
+            { title: "ax patterns - community recovery mesh" },
+            { name: "description", content: "Community taste patterns aggregated from published ax profiles, including cross-user failure to recovery joins." },
+        ],
+    }),
+    component: PatternsPage,
+});
+
+type State =
+    | { kind: "loading" }
+    | { kind: "empty" }
+    | { kind: "error"; message: string }
+    | { kind: "ready"; stats: PatternStats };
+
+function PatternsPage() {
+    const [state, setState] = useState<State>({ kind: "loading" });
+
+    useEffect(() => {
+        let alive = true;
+        fetchPatternStats()
+            .then((stats) => {
+                if (!alive) return;
+                setState(Object.keys(stats.patterns).length === 0 ? { kind: "empty" } : { kind: "ready", stats });
+            })
+            .catch((e: unknown) => {
+                if (!alive) return;
+                const notFound = typeof e === "object" && e !== null && (e as { notFound?: boolean }).notFound === true;
+                setState(notFound ? { kind: "empty" } : { kind: "error", message: e instanceof Error ? e.message : String(e) });
+            });
+        return () => { alive = false; };
+    }, []);
+
+    const rows = useMemo(
+        () => (state.kind === "ready" ? trendingPatterns(state.stats) : []),
+        [state],
+    );
+    const totals = useMemo(() => {
+        if (state.kind !== "ready") return { sessions: 0, recoveries: 0 };
+        const sessions = rows.reduce((sum, [, row]) => sum + row.sessions, 0);
+        const recoveries = rows.reduce((sum, [, row]) => sum + recoveryEntries(row).length, 0);
+        return { sessions, recoveries };
+    }, [rows, state]);
+
+    return (
+        <>
+            <SiteHeader />
+            <main className="patterns-page">
+                <header className="pt-head">
+                    <h1>patterns</h1>
+                    <p className="muted">
+                        Taste patterns published by builders, folded into one community mesh. Failure modes link to recovery patterns when another builder has contributed the fix.
+                    </p>
+                    {state.kind === "ready" && (
+                        <p className="pt-meta">
+                            <strong>{rows.length}</strong> patterns
+                            {" · "}<strong>{formatCompact(totals.sessions)}</strong> evidence sessions
+                            {" · "}<strong>{totals.recoveries}</strong> recovery joins
+                            {state.stats.compiled_at !== "" && (
+                                <> · compiled {state.stats.compiled_at.slice(0, 16).replace("T", " ")} UTC</>
+                            )}
+                            {state.stats.dropped.length > 0 && (
+                                <> · {state.stats.dropped.length} dropped rows reported</>
+                            )}
+                        </p>
+                    )}
+                </header>
+
+                {state.kind === "loading" && <p className="muted">loading...</p>}
+                {state.kind === "empty" && <EmptyPatterns />}
+                {state.kind === "error" && <p className="muted">couldn't load patterns: {state.message}</p>}
+
+                {state.kind === "ready" && rows.length > 0 && (
+                    <table className="pt-table">
+                        <thead>
+                            <tr>
+                                <th className="pt-rank">#</th>
+                                <th>pattern</th>
+                                <th className="pt-num">builders</th>
+                                <th className="pt-num">sessions</th>
+                                <th>recovery joins</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {rows.map(([key, row], i) => (
+                                <tr key={key} data-lead={i === 0}>
+                                    <td className="pt-rank">{i + 1}</td>
+                                    <td className="pt-name-cell">
+                                        <span className="pt-cat">{row.category}</span>
+                                        <span className="pt-name">{row.name}</span>
+                                    </td>
+                                    <td className="pt-num">{formatCompact(row.users)}</td>
+                                    <td className="pt-num">{formatCompact(row.sessions)}</td>
+                                    <td className="pt-recoveries">
+                                        <RecoveryList row={row} />
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </main>
+            <SiteFooter />
+        </>
+    );
+}
+
+function recoveryEntries(row: PatternStatsRow): Array<readonly [string, { readonly users: number; readonly sessions: number }]> {
+    return Object.entries(row.recovered_by ?? {})
+        .sort(([ak, a], [bk, b]) => b.users - a.users || b.sessions - a.sessions || ak.localeCompare(bk));
+}
+
+function RecoveryList({ row }: { readonly row: PatternStatsRow }) {
+    const recoveries = recoveryEntries(row);
+    if (recoveries.length === 0) return <span className="pt-none">-</span>;
+    return (
+        <ul className="pt-recovery-list">
+            {recoveries.map(([key, recovery]) => {
+                const slash = key.indexOf("/");
+                const name = slash === -1 ? key : key.slice(slash + 1);
+                return (
+                    <li key={key}>
+                        <span className="pt-recovery-name">{name}</span>
+                        <span className="pt-recovery-count">
+                            {formatCompact(recovery.users)} builders · {formatCompact(recovery.sessions)} sessions
+                        </span>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}
+
+function EmptyPatterns() {
+    return (
+        <section className="leaders-founding">
+            <p className="lf-eyebrow">community mesh</p>
+            <h2 className="lf-headline">No shared patterns have landed yet.</h2>
+            <p className="lf-lede">
+                Patterns appear here as builders publish profiles with taste patterns. The first rows will show adoption counts, then failure-to-recovery joins as the mesh connects.
+            </p>
+            <p className="lf-foot muted">
+                Start from <Link to="/leaders">the community leaders</Link> or publish your own aggregate profile with <code>ax profile publish</code>.
+            </p>
+        </section>
+    );
+}

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -11918,13 +11918,13 @@ footer.site-footer { padding: 48px 32px 56px; }
      mono numerals, hairline rules, paper/ink. No SaaS chrome.
    ============================================================ */
 
-.profile-page, .leaders-page, .status-page {
+.profile-page, .leaders-page, .patterns-page, .status-page {
     max-width: var(--shell-max);
     margin: 0 auto;
     padding: 32px var(--shell-pad) 96px;
 }
 @media (max-width: 640px) {
-    .profile-page, .leaders-page, .status-page { padding-left: 20px; padding-right: 20px; }
+    .profile-page, .leaders-page, .patterns-page, .status-page { padding-left: 20px; padding-right: 20px; }
 }
 
 /* ----- status: live adoption receipt (unlisted) ----- */
@@ -12066,6 +12066,73 @@ footer.site-footer { padding: 48px 32px 56px; }
 .lf-foot a, .lf-prov a { color: var(--blue); border-bottom: 1px solid transparent; }
 .lf-foot a:hover, .lf-prov a:hover { border-bottom-color: var(--blue); }
 .lf-prov { font-family: var(--mono); font-size: 0.74rem; margin: 0; }
+
+/* ----- patterns: community taste + recovery mesh ----- */
+.pt-head h1 { margin: 0 0 8px; }
+.pt-head .muted { max-width: 68ch; margin: 0 0 10px; }
+.pt-meta { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); margin: 0 0 4px; }
+.pt-meta strong { color: var(--ink); }
+
+.pt-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 22px 0 0;
+    font-family: var(--mono);
+    font-size: 0.86rem;
+}
+.pt-table thead th {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+    font-weight: 600;
+    border-bottom: 1px solid var(--line);
+    padding: 0 12px 8px;
+    text-align: left;
+}
+.pt-table tbody td {
+    padding: 13px 12px;
+    border-bottom: 1px solid var(--line);
+    vertical-align: top;
+}
+.pt-table tbody tr:hover { background: color-mix(in srgb, var(--panel) 60%, transparent); }
+.pt-table tbody tr[data-lead="true"] td { background: color-mix(in srgb, var(--green) 9%, transparent); }
+.pt-rank { width: 1%; color: var(--muted); font-variant-numeric: tabular-nums; }
+.pt-table tbody tr[data-lead="true"] .pt-rank { color: var(--green); font-weight: 700; }
+.pt-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.pt-name-cell { min-width: 220px; }
+.pt-cat {
+    display: block;
+    color: var(--green);
+    font-size: 0.68rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+.pt-name {
+    display: block;
+    margin-top: 3px;
+    color: var(--ink);
+    font-size: 0.98rem;
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+.pt-recoveries { min-width: 260px; }
+.pt-none { color: var(--muted); }
+.pt-recovery-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 7px; }
+.pt-recovery-list li {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: baseline;
+    gap: 12px;
+}
+.pt-recovery-name { color: var(--ink); overflow-wrap: anywhere; }
+.pt-recovery-count { color: var(--muted); font-size: 0.76rem; white-space: nowrap; }
+@media (max-width: 760px) {
+    .pt-table { display: block; overflow-x: auto; }
+    .pt-recoveries { min-width: 220px; }
+    .pt-recovery-list li { grid-template-columns: minmax(0, 1fr); gap: 2px; }
+    .pt-recovery-count { white-space: normal; }
+}
 
 /* ----- states ----- */
 .pf-loading {

--- a/community/pattern-stats.json
+++ b/community/pattern-stats.json
@@ -1,0 +1,5 @@
+{
+  "compiled_at": "2026-06-12T08:14:49.510Z",
+  "patterns": {},
+  "dropped": []
+}

--- a/packages/community-compile/src/compile.test.ts
+++ b/packages/community-compile/src/compile.test.ts
@@ -18,6 +18,7 @@ const profile = (login: string, over: Record<string, unknown> = {}) => ({
         routing_table: true,
         ...((over.rig as object) ?? {}),
     },
+    ...(over.taste === undefined ? {} : { taste: over.taste }),
 });
 
 const fetcher = (gists: Record<string, unknown>): GistFetcher => async (gistId) =>
@@ -153,6 +154,93 @@ describe("compileCommunity", () => {
         expect(out.state.users).toBe(2);
         expect(out.state.harness_mix.claude).toBe(2);
         expect(out.state.skill_adoption["tdd"]).toBe(2);
+    });
+
+    test("pattern stats aggregate adoption and cross-user recovered-by joins", async () => {
+        const out = await compileCommunity(users, fetcher({
+            g1: profile("alice", {
+                taste: {
+                    patterns: [{
+                        category: "failure-mode",
+                        name: "edit-loop-thrash",
+                        summary: "keeps patching without rereading",
+                        evidence: { sessions: 3, confidence: 0.8 },
+                        links: [{ rel: "recovered-by", ref: "problem-solving-strategy/full-file-reread" }],
+                    }],
+                },
+            }),
+            g2: profile("bob", {
+                taste: {
+                    patterns: [{
+                        category: "problem-solving-strategy",
+                        name: "full-file-reread",
+                        summary: "rereads the full file before another patch",
+                        evidence: { sessions: 5, confidence: 0.9 },
+                    }],
+                },
+            }),
+        }), { now: "2026-06-12T03:00:00Z" });
+
+        expect(out.patternStats.patterns["failure-mode/edit-loop-thrash"]).toEqual({
+            category: "failure-mode",
+            name: "edit-loop-thrash",
+            users: 1,
+            sessions: 3,
+            recovered_by: {
+                "problem-solving-strategy/full-file-reread": { users: 1, sessions: 5 },
+            },
+        });
+        expect(out.patternStats.patterns["problem-solving-strategy/full-file-reread"]).toEqual({
+            category: "problem-solving-strategy",
+            name: "full-file-reread",
+            users: 1,
+            sessions: 5,
+        });
+        expect(out.patternStats.dropped).toEqual([]);
+    });
+
+    test("invalid and duplicate taste patterns are dropped with reasons", async () => {
+        const out = await compileCommunity(
+            [{ github: "alice", gist_id: "g1", joined: "2026-06-01" }],
+            fetcher({
+                g1: profile("alice", {
+                    taste: {
+                        patterns: [
+                            {
+                                category: "workflow",
+                                name: "small-review-loops",
+                                summary: "reviews in small increments",
+                                evidence: { sessions: 4, confidence: 0.7 },
+                            },
+                            {
+                                category: "workflow",
+                                name: "small-review-loops",
+                                summary: "duplicate row",
+                                evidence: { sessions: 9, confidence: 0.9 },
+                            },
+                            {
+                                category: "workflow",
+                                name: "missing-summary",
+                                evidence: { sessions: 1, confidence: 0.5 },
+                            },
+                        ],
+                    },
+                }),
+            }),
+            { now: "2026-06-12T03:00:00Z" },
+        );
+
+        expect(out.patternStats.patterns["workflow/small-review-loops"]).toEqual({
+            category: "workflow",
+            name: "small-review-loops",
+            users: 1,
+            sessions: 4,
+        });
+        expect(out.patternStats.patterns["workflow/missing-summary"]).toBeUndefined();
+        expect(out.patternStats.dropped).toEqual([
+            { login: "alice", index: 1, key: "workflow/small-review-loops", reason: "duplicate-pattern" },
+            { login: "alice", index: 2, reason: "invalid-pattern" },
+        ]);
     });
 
     test("output is deterministic for identical input", async () => {

--- a/packages/community-compile/src/compile.ts
+++ b/packages/community-compile/src/compile.ts
@@ -9,12 +9,20 @@
  *   leaderboard - boards: tokens, sessions, streak, cost
  *   skillStats  - { "<source>:<name>": { users, runs } }
  *   hookStats   - { "<hook>": { users } }
+ *   patternStats - { patterns: { "<category>/<name>": { users, sessions, recovered_by? } }, dropped }
  *   state       - anonymized distributions
  *
  * The fetcher is injectable so callers choose transport (raw CDN + ETag cache
  * under Bun, plain fetch in the Worker) and tests stay pure.
  */
-import { validateProfile, type CompiledProfile } from "./validate.ts";
+import {
+    patternKey,
+    validateProfile,
+    validateTastePatterns,
+    type CompiledProfile,
+    type CompiledTastePattern,
+    type PatternDropReason,
+} from "./validate.ts";
 
 export type { CompiledProfile } from "./validate.ts";
 
@@ -47,6 +55,7 @@ export interface CompiledOutput {
     };
     readonly skillStats: Record<string, { users: number; runs: number; source: string }>;
     readonly hookStats: Record<string, { users: number }>;
+    readonly patternStats: PatternStats;
     readonly state: {
         readonly year: number;
         readonly users: number;
@@ -55,6 +64,28 @@ export interface CompiledOutput {
         readonly model_share: Record<string, number>;
     };
     readonly dropped: Array<{ login: string; reason: "fetch-failed" | "invalid-profile" | "absurd-values" | "github-mismatch" }>;
+}
+
+export interface PatternStats {
+    readonly compiled_at: string;
+    readonly patterns: Record<string, PatternStatsRow>;
+    readonly dropped: PatternStatsDrop[];
+}
+
+export interface PatternStatsRow {
+    readonly category: string;
+    readonly name: string;
+    readonly users: number;
+    readonly sessions: number;
+    readonly recovered_by?: Record<string, { users: number; sessions: number }>;
+}
+
+export interface PatternStatsDrop {
+    readonly login: string;
+    readonly reason: PatternDropReason | "unresolved-recovery";
+    readonly index?: number;
+    readonly key?: string;
+    readonly ref?: string;
 }
 
 const MAX_TOKENS = 100e9;
@@ -110,6 +141,36 @@ function representativeSource(name: string, sources: ReadonlySet<string>): strin
 const sortedRecord = <V>(entries: Array<[string, V]>): Record<string, V> =>
     Object.fromEntries(entries.sort(([a], [b]) => a.localeCompare(b)));
 
+interface PatternAggregate {
+    readonly category: string;
+    readonly name: string;
+    readonly users: Map<string, number>;
+    readonly recoveryRefs: Array<{ login: string; ref: string }>;
+}
+
+function ensurePatternAggregate(
+    agg: Map<string, PatternAggregate>,
+    key: string,
+    pattern: CompiledTastePattern,
+): PatternAggregate {
+    const cur = agg.get(key);
+    if (cur !== undefined) return cur;
+    const created: PatternAggregate = {
+        category: pattern.category,
+        name: pattern.name,
+        users: new Map(),
+        recoveryRefs: [],
+    };
+    agg.set(key, created);
+    return created;
+}
+
+function sumSessions(users: ReadonlyMap<string, number>): number {
+    let total = 0;
+    for (const sessions of users.values()) total += sessions;
+    return total;
+}
+
 export async function compileCommunity(
     users: ReadonlyArray<RegisteredUser>,
     fetchGist: GistFetcher,
@@ -117,6 +178,8 @@ export async function compileCommunity(
 ): Promise<CompiledOutput> {
     const profiles: Array<{ login: string; p: CompiledProfile }> = [];
     const dropped: CompiledOutput["dropped"] = [];
+    const patternDrops: PatternStatsDrop[] = [];
+    const patternAgg = new Map<string, PatternAggregate>();
 
     for (const user of [...users].sort((a, b) => a.github.localeCompare(b.github))) {
         const fetched = await fetchGist(user.gist_id, user.github);
@@ -142,6 +205,26 @@ export async function compileCommunity(
             continue;
         }
         profiles.push({ login: user.github, p });
+
+        const taste = validateTastePatterns(fetched.profile);
+        for (const d of taste.dropped) {
+            patternDrops.push({
+                login: user.github,
+                reason: d.reason,
+                ...(d.index === undefined ? {} : { index: d.index }),
+                ...(d.key === undefined ? {} : { key: d.key }),
+            });
+        }
+        for (const pattern of taste.patterns) {
+            const key = patternKey(pattern.category, pattern.name);
+            const cur = ensurePatternAggregate(patternAgg, key, pattern);
+            cur.users.set(user.github, (cur.users.get(user.github) ?? 0) + pattern.evidence.sessions);
+            for (const link of pattern.links ?? []) {
+                if (pattern.category === "failure-mode" && link.rel === "recovered-by") {
+                    cur.recoveryRefs.push({ login: user.github, ref: link.ref.trim() });
+                }
+            }
+        }
     }
 
     const board = (value: (p: CompiledProfile) => number | undefined): BoardRow[] =>
@@ -184,6 +267,42 @@ export async function compileCommunity(
         }
     }
 
+    const patternEntries: Array<[string, PatternStatsRow]> = [];
+    for (const [key, pattern] of patternAgg.entries()) {
+        const recoveredBy = new Map<string, Map<string, number>>();
+        for (const link of pattern.recoveryRefs) {
+            const target = patternAgg.get(link.ref);
+            if (target === undefined) {
+                patternDrops.push({ login: link.login, reason: "unresolved-recovery", key, ref: link.ref });
+                continue;
+            }
+            for (const [targetLogin, sessions] of target.users.entries()) {
+                if (targetLogin === link.login) continue;
+                const users = recoveredBy.get(link.ref) ?? new Map<string, number>();
+                users.set(targetLogin, Math.max(users.get(targetLogin) ?? 0, sessions));
+                recoveredBy.set(link.ref, users);
+            }
+        }
+
+        const recoveryEntries = [...recoveredBy.entries()]
+            .filter(([, targetUsers]) => targetUsers.size > 0)
+            .map(([targetKey, targetUsers]) => [
+                targetKey,
+                { users: targetUsers.size, sessions: sumSessions(targetUsers) },
+            ] as [string, { users: number; sessions: number }]);
+
+        patternEntries.push([
+            key,
+            {
+                category: pattern.category,
+                name: pattern.name,
+                users: pattern.users.size,
+                sessions: sumSessions(pattern.users),
+                ...(recoveryEntries.length === 0 ? {} : { recovered_by: sortedRecord(recoveryEntries) }),
+            },
+        ]);
+    }
+
     return {
         leaderboard: {
             compiled_at: opts.now,
@@ -199,6 +318,17 @@ export async function compileCommunity(
             [...skillAgg.entries()].map(([id, v]) => [id, { users: v.users, runs: v.runs, source: representativeSource(id, v.sources) }]),
         ),
         hookStats: sortedRecord([...hookAgg.entries()]),
+        patternStats: {
+            compiled_at: opts.now,
+            patterns: sortedRecord(patternEntries),
+            dropped: patternDrops.sort((a, b) =>
+                a.login.localeCompare(b.login)
+                || (a.index ?? -1) - (b.index ?? -1)
+                || (a.key ?? "").localeCompare(b.key ?? "")
+                || (a.ref ?? "").localeCompare(b.ref ?? "")
+                || a.reason.localeCompare(b.reason),
+            ),
+        },
         state: {
             year: Number(opts.now.slice(0, 4)),
             users: profiles.length,

--- a/packages/community-compile/src/validate.ts
+++ b/packages/community-compile/src/validate.ts
@@ -27,6 +27,53 @@ export interface CompiledProfile {
     };
 }
 
+export const PATTERN_CATEGORIES = [
+    "design-aesthetic",
+    "problem-solving-strategy",
+    "debugging",
+    "failure-mode",
+    "workflow",
+    "tool-output-mix",
+    "stack-choice",
+] as const;
+export type PatternCategory = (typeof PATTERN_CATEGORIES)[number];
+
+const PATTERN_CATEGORY_SET = new Set<string>(PATTERN_CATEGORIES);
+const PATTERN_LINK_RELS = ["recovered-by", "pairs-with", "conflicts-with"] as const;
+const PATTERN_LINK_REL_SET = new Set<string>(PATTERN_LINK_RELS);
+const PATTERN_TRENDS = ["rising", "stable", "falling", "stale"] as const;
+type PatternTrend = (typeof PATTERN_TRENDS)[number];
+const PATTERN_TREND_SET = new Set<string>(PATTERN_TRENDS);
+
+export interface CompiledPatternLink {
+    readonly rel: (typeof PATTERN_LINK_RELS)[number];
+    readonly ref: string;
+}
+
+export interface CompiledTastePattern {
+    readonly category: PatternCategory;
+    readonly name: string;
+    readonly summary?: string;
+    readonly slot?: string;
+    readonly over?: readonly string[];
+    readonly context?: string;
+    readonly evidence: {
+        readonly sessions: number;
+        readonly confidence: number;
+        readonly last_reinforced?: string;
+        readonly trend?: PatternTrend;
+    };
+    readonly links?: readonly CompiledPatternLink[];
+}
+
+export type PatternDropReason = "invalid-pattern" | "duplicate-pattern";
+
+export interface PatternDrop {
+    readonly index?: number;
+    readonly key?: string;
+    readonly reason: PatternDropReason;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -86,4 +133,106 @@ export function validateProfile(value: unknown): CompiledProfile {
         },
         rig: { skills, hooks: rig.hooks as string[] },
     };
+}
+
+export function patternKey(category: string, name: string): string {
+    return `${category.trim()}/${name.trim()}`;
+}
+
+const finitePatternNumber = (v: unknown, what: string): number => {
+    const n = num(v, what);
+    if (n < 0) throw new Error(`invalid ${what}`);
+    return n;
+};
+
+function validatePatternRow(row: unknown): CompiledTastePattern {
+    if (!isRecord(row) || !isRecord(row.evidence)) throw new Error("invalid pattern");
+    const category = str(row.category, "pattern.category").trim();
+    const name = str(row.name, "pattern.name").trim();
+    if (!PATTERN_CATEGORY_SET.has(category) || name === "" || name.includes("/")) throw new Error("invalid pattern key");
+
+    const trend = row.evidence.trend === undefined ? undefined : str(row.evidence.trend, "pattern.evidence.trend");
+    if (trend !== undefined && !PATTERN_TREND_SET.has(trend)) throw new Error("invalid pattern.evidence.trend");
+    const evidence: CompiledTastePattern["evidence"] = {
+        sessions: finitePatternNumber(row.evidence.sessions, "pattern.evidence.sessions"),
+        confidence: finitePatternNumber(row.evidence.confidence, "pattern.evidence.confidence"),
+        ...(row.evidence.last_reinforced === undefined ? {} : { last_reinforced: str(row.evidence.last_reinforced, "pattern.evidence.last_reinforced") }),
+        ...(trend === undefined ? {} : { trend: trend as PatternTrend }),
+    };
+    if (evidence.confidence > 1) throw new Error("invalid pattern.evidence.confidence");
+
+    if (category === "stack-choice") {
+        const slot = str(row.slot, "pattern.slot").trim();
+        if (slot === "") throw new Error("invalid pattern.slot");
+        const over = row.over === undefined ? undefined : row.over;
+        if (over !== undefined && (!Array.isArray(over) || over.some((v) => typeof v !== "string"))) {
+            throw new Error("invalid pattern.over");
+        }
+        const links = validatePatternLinks(row.links);
+        return {
+            category,
+            slot,
+            name,
+            evidence,
+            ...(over === undefined ? {} : { over: over as string[] }),
+            ...(row.context === undefined ? {} : { context: str(row.context, "pattern.context") }),
+            ...(links === undefined ? {} : { links }),
+        };
+    }
+
+    const summary = str(row.summary, "pattern.summary").trim();
+    if (summary === "") throw new Error("invalid pattern.summary");
+    const links = validatePatternLinks(row.links);
+    return {
+        category: category as Exclude<PatternCategory, "stack-choice">,
+        name,
+        summary,
+        evidence,
+        ...(links === undefined ? {} : { links }),
+    };
+}
+
+function validatePatternLinks(value: unknown): CompiledPatternLink[] | undefined {
+    if (value === undefined) return undefined;
+    if (!Array.isArray(value)) throw new Error("invalid pattern.links");
+    return value.map((link) => {
+        if (!isRecord(link)) throw new Error("invalid pattern.link");
+        const rel = str(link.rel, "pattern.link.rel");
+        const ref = str(link.ref, "pattern.link.ref").trim();
+        if (!PATTERN_LINK_REL_SET.has(rel) || ref === "") throw new Error("invalid pattern.link");
+        return { rel: rel as CompiledPatternLink["rel"], ref };
+    });
+}
+
+/**
+ * Validate optional taste patterns without invalidating the whole profile. The
+ * profile gist is user-controlled community input; one bad taste row should be
+ * reported and skipped, not erase the user's leaderboard row.
+ */
+export function validateTastePatterns(value: unknown): { patterns: CompiledTastePattern[]; dropped: PatternDrop[] } {
+    if (!isRecord(value) || value.taste === undefined) return { patterns: [], dropped: [] };
+    if (!isRecord(value.taste) || !Array.isArray(value.taste.patterns)) {
+        return { patterns: [], dropped: [{ reason: "invalid-pattern" }] };
+    }
+
+    const patterns: CompiledTastePattern[] = [];
+    const dropped: PatternDrop[] = [];
+    const seen = new Set<string>();
+    for (const [index, row] of value.taste.patterns.entries()) {
+        let p: CompiledTastePattern;
+        try {
+            p = validatePatternRow(row);
+        } catch {
+            dropped.push({ index, reason: "invalid-pattern" });
+            continue;
+        }
+        const key = patternKey(p.category, p.name);
+        if (seen.has(key)) {
+            dropped.push({ index, key, reason: "duplicate-pattern" });
+            continue;
+        }
+        seen.add(key);
+        patterns.push(p);
+    }
+    return { patterns, dropped };
 }

--- a/scripts/compile-community.ts
+++ b/scripts/compile-community.ts
@@ -7,6 +7,7 @@
  *   community/leaderboard.json   - boards: tokens, sessions, streak, cost
  *   community/skill-stats.json   - { "<source>:<name>": { users, runs } }
  *   community/hook-stats.json    - { "<hook>": { users } }
+ *   community/pattern-stats.json - profile taste pattern adoption + recovery joins
  *   community/state/<year>.json  - anonymized distributions
  *
  * NOTE: the live community compile now runs on the alchemy-provisioned
@@ -85,6 +86,7 @@ if (import.meta.main) {
     await Bun.write("community/leaderboard.json", `${JSON.stringify(out.leaderboard, null, 2)}\n`);
     await Bun.write("community/skill-stats.json", `${JSON.stringify(out.skillStats, null, 2)}\n`);
     await Bun.write("community/hook-stats.json", `${JSON.stringify(out.hookStats, null, 2)}\n`);
+    await Bun.write("community/pattern-stats.json", `${JSON.stringify(out.patternStats, null, 2)}\n`);
     await Bun.write(`community/state/${year}.json`, `${JSON.stringify(out.state, null, 2)}\n`);
     await Bun.write(cachePath, `${JSON.stringify(cache, null, 2)}\n`);
 


### PR DESCRIPTION
## Summary
- compile profile taste patterns into community/pattern-stats.json with dropped-row reporting
- expose pattern stats from the community worker and render a new /patterns community page
- add compiler/site validation tests for recovery joins and dropped pattern rows

## Test plan
- bun test
- bun typecheck
- bun --filter @ax/community-compile typecheck
- bun --filter @ax/community-worker typecheck
- bun --filter @ax/site build
- bun run lint (not available: root package has no lint script)

Closes #374

---

_Generated with [ax](https://github.com/Necmttn/ax)._
