### PR TITLE
[codex] fix community compile root dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "yaml": "^2.8.4",
       },
       "devDependencies": {
+        "@ax/community-compile": "workspace:*",
         "@effect/language-service": "^0.85.1",
         "@tanstack/react-router": "^1.169",
         "@tanstack/router-plugin": "^1.167",

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "yaml": "^2.8.4"
   },
   "devDependencies": {
+    "@ax/community-compile": "workspace:*",
     "@effect/language-service": "^0.85.1",
     "@tanstack/react-router": "^1.169",
     "@tanstack/router-plugin": "^1.167",


### PR DESCRIPTION
## Summary

- Adds `@ax/community-compile` as a root dev dependency so `bun scripts/compile-community.ts` resolves its workspace import when run from the repo root.
- Updates `bun.lock` with the matching root devDependency entry.

## Root Cause

`.github/workflows/community-nightly.yml` runs `bun scripts/compile-community.ts` from the repository root. That wrapper imports `@ax/community-compile`, but the root package did not declare the workspace package, so Bun could not resolve it in the root execution context.

## Validation

- `bun scripts/compile-community.ts` exits 0 and emits `community/pattern-stats.json` (compiled 7/7 profiles).
- `bun typecheck` exits 0.
- `bun install --frozen-lockfile --ignore-scripts` exits 0 locally for lockfile consistency.

---

_Generated with [ax](https://github.com/Necmttn/ax)._