### PR TITLE
Add guardrail receipts to profiles

### DIFF
--- a/apps/axctl/src/cli/commands/profile.test.ts
+++ b/apps/axctl/src/cli/commands/profile.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+    formatProfile,
     profileProgressLine,
     shouldEmitProfileProgress,
 } from "./profile.ts";
@@ -26,5 +27,50 @@ describe("profile show progress", () => {
         expect(profileProgressLine("done", { windowDays: 14, includeCost: false }, 27040)).toBe(
             "ax profile show: done in 27.0s",
         );
+    });
+});
+
+describe("formatProfile guardrail receipts", () => {
+    test("renders hook receipt lines and honest verdict labels", () => {
+        const out = formatProfile({
+            v: 1,
+            github: "octocat",
+            generated_at: "2026-06-18T00:00:00Z",
+            window_days: 30,
+            stats: {
+                sessions: 1,
+                active_days: 1,
+                streak_days: 1,
+                tokens: { prompt: 1, completion: 1, total: 2 },
+                models: [],
+                harnesses: ["claude"],
+            },
+            rig: {
+                skills: [],
+                hooks: ["enforce-worktree"],
+                routing_table: false,
+            },
+            guardrail_receipts: {
+                hooks: [
+                    { name: "enforce-worktree", fires: 412, blocked: 9, warned: 3 },
+                ],
+                verdicts: {
+                    worked: 4,
+                    did_not_work: 2,
+                    partial: 1,
+                    no_longer_needed: 1,
+                },
+            },
+        });
+
+        expect(out).toContain("guardrails:");
+        expect(out).toContain("enforce-worktree");
+        expect(out).toContain("fired 412x");
+        expect(out).toContain("blocked 9");
+        expect(out).toContain("still earning");
+        expect(out).toContain("4 worked");
+        expect(out).toContain("2 didn't");
+        expect(out).toContain("1 partial");
+        expect(out).toContain("1 no longer needed (resolved or never fired)");
     });
 });

--- a/apps/axctl/src/cli/commands/profile.ts
+++ b/apps/axctl/src/cli/commands/profile.ts
@@ -130,6 +130,33 @@ const money = (n: number): string => {
     return `$${n.toFixed(0)}`;
 };
 
+type HookReceipt = NonNullable<ProfileV1["guardrail_receipts"]>["hooks"][number];
+type GuardrailVerdicts = NonNullable<ProfileV1["guardrail_receipts"]>["verdicts"];
+
+const hookReceiptStatus = (r: HookReceipt): string => {
+    if (r.fires === 0) return "no recent fires";
+    return r.blocked + r.warned > 0 ? "still earning" : "watching";
+};
+
+const formatHookReceipt = (r: HookReceipt): string => {
+    const parts = [`fired ${integer(r.fires)}x`];
+    if (r.blocked > 0) parts.push(`blocked ${integer(r.blocked)}`);
+    if (r.warned > 0) parts.push(`warned ${integer(r.warned)}`);
+    if (r.blocked === 0 && r.warned === 0) parts.push("no blocks/warnings");
+    parts.push(hookReceiptStatus(r));
+    return parts.join(" · ");
+};
+
+const formatGuardrailVerdicts = (v: GuardrailVerdicts): string => {
+    const parts = [
+        `${integer(v.worked)} worked`,
+        `${integer(v.did_not_work)} didn't`,
+    ];
+    if ((v.partial ?? 0) > 0) parts.push(`${integer(v.partial ?? 0)} partial`);
+    parts.push(`${integer(v.no_longer_needed)} no longer needed (resolved or never fired)`);
+    return parts.join(" · ");
+};
+
 export function formatProfile(p: ProfileV1): string {
     const lines: string[] = [];
     lines.push(`ax profile - @${p.github}  (last ${p.window_days}d)`);
@@ -158,6 +185,14 @@ export function formatProfile(p: ProfileV1): string {
     if (p.workflow && p.workflow.arcs.length > 0) {
         const topArc = p.workflow.arcs[0]!;
         lines.push(`workflow: ${topArc.steps.join(" → ")} (${topArc.count}x)`);
+    }
+    if (p.guardrail_receipts) {
+        lines.push("guardrails:");
+        const hookWidth = Math.max(20, ...p.guardrail_receipts.hooks.map((h) => h.name.length));
+        for (const h of p.guardrail_receipts.hooks) {
+            lines.push(`  ${h.name.padEnd(hookWidth)} ${formatHookReceipt(h)}`);
+        }
+        lines.push(`  verdicts: ${formatGuardrailVerdicts(p.guardrail_receipts.verdicts)}`);
     }
     for (const s of topSkills) {
         const downstream = s.downstream_share !== undefined

--- a/apps/axctl/src/profile/guardrails.test.ts
+++ b/apps/axctl/src/profile/guardrails.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { deriveGuardrailReceipts } from "./guardrails.ts";
+
+describe("deriveGuardrailReceipts", () => {
+    test("matches hook evidence by normalized installed hook name", () => {
+        expect(deriveGuardrailReceipts({
+            hookFiles: ["enforce-worktree.ts", "enforce-worktree-write.ts", "guard.test.ts"],
+            hookEvidence: [
+                { hook_name: "/Users/me/.ax/hooks/enforce-worktree.ts", fires: 10, blocked: 2, warned: 1 },
+                { hook_name: "enforce-worktree-write.js", fires: 3, blocked: 0, warned: 3 },
+                { hook_name: "uninstalled.ts", fires: 99, blocked: 99, warned: 99 },
+            ],
+            verdicts: [
+                { verdict: "adopted", count: 4 },
+                { verdict: "ignored", count: 1 },
+                { verdict: "regressed", count: 1 },
+                { verdict: "partial", count: 2 },
+                { verdict: "no_longer_needed", count: 3 },
+            ],
+        })).toEqual({
+            hooks: [
+                { name: "enforce-worktree", fires: 10, blocked: 2, warned: 1 },
+                { name: "enforce-worktree-write", fires: 3, blocked: 0, warned: 3 },
+            ],
+            verdicts: {
+                worked: 4,
+                did_not_work: 2,
+                partial: 2,
+                no_longer_needed: 3,
+            },
+        });
+    });
+
+    test("omits the receipt block when there are no installed hooks or verdicts", () => {
+        expect(deriveGuardrailReceipts({
+            hookFiles: [],
+            hookEvidence: [
+                { hook_name: "uninstalled.ts", fires: 1, blocked: 1, warned: 0 },
+            ],
+            verdicts: [],
+        })).toBeNull();
+    });
+});

--- a/apps/axctl/src/profile/guardrails.ts
+++ b/apps/axctl/src/profile/guardrails.ts
@@ -1,0 +1,83 @@
+import type { GuardrailReceipts } from "./schema.ts";
+
+export interface GuardrailHookEvidenceRow {
+    readonly hook_name: string;
+    readonly fires: number;
+    readonly blocked: number;
+    readonly warned: number;
+}
+
+export interface GuardrailVerdictRow {
+    readonly verdict: string;
+    readonly count: number;
+}
+
+const hookNameFromFile = (file: string): string | null => {
+    if (!file.endsWith(".ts") || file.endsWith(".test.ts")) return null;
+    const name = file.replace(/\.ts$/, "");
+    return name.length > 0 ? name : null;
+};
+
+const hookNameFromEvidence = (hookName: string): string => {
+    const base = hookName.split(/[\\/]/).at(-1) ?? hookName;
+    return base.replace(/\.(?:ts|js)$/, "");
+};
+
+export function deriveGuardrailReceipts(input: {
+    readonly hookFiles: ReadonlyArray<string>;
+    readonly hookEvidence: ReadonlyArray<GuardrailHookEvidenceRow>;
+    readonly verdicts: ReadonlyArray<GuardrailVerdictRow>;
+}): GuardrailReceipts | null {
+    const hookNames = input.hookFiles
+        .map(hookNameFromFile)
+        .filter((name): name is string => name !== null)
+        .sort((a, b) => a.localeCompare(b));
+
+    const totals = new Map<string, { fires: number; blocked: number; warned: number }>();
+    for (const name of hookNames) {
+        totals.set(name, { fires: 0, blocked: 0, warned: 0 });
+    }
+
+    for (const row of input.hookEvidence) {
+        const name = hookNameFromEvidence(row.hook_name);
+        if (!totals.has(name)) continue;
+        const prev = totals.get(name) ?? { fires: 0, blocked: 0, warned: 0 };
+        totals.set(name, {
+            fires: prev.fires + row.fires,
+            blocked: prev.blocked + row.blocked,
+            warned: prev.warned + row.warned,
+        });
+    }
+
+    const verdicts = {
+        worked: 0,
+        did_not_work: 0,
+        no_longer_needed: 0,
+        partial: 0,
+    };
+    for (const row of input.verdicts) {
+        if (row.verdict === "adopted") verdicts.worked += row.count;
+        else if (row.verdict === "ignored" || row.verdict === "regressed") verdicts.did_not_work += row.count;
+        else if (row.verdict === "no_longer_needed") verdicts.no_longer_needed += row.count;
+        else if (row.verdict === "partial") verdicts.partial += row.count;
+    }
+
+    const hooks = [...totals.entries()].map(([name, t]) => ({
+        name,
+        fires: t.fires,
+        blocked: t.blocked,
+        warned: t.warned,
+    }));
+    const anyVerdict = verdicts.worked + verdicts.did_not_work + verdicts.no_longer_needed + verdicts.partial > 0;
+    if (hooks.length === 0 && !anyVerdict) return null;
+
+    return {
+        hooks,
+        verdicts: {
+            worked: verdicts.worked,
+            did_not_work: verdicts.did_not_work,
+            no_longer_needed: verdicts.no_longer_needed,
+            ...(verdicts.partial > 0 ? { partial: verdicts.partial } : {}),
+        },
+    };
+}

--- a/apps/axctl/src/profile/queries.test.ts
+++ b/apps/axctl/src/profile/queries.test.ts
@@ -5,6 +5,8 @@ import {
     fetchCommitCount,
     fetchDailyActivity,
     fetchDailyActivityFull,
+    fetchGuardrailHookEvidence,
+    fetchGuardrailVerdicts,
     fetchHarnesses,
     fetchPeakHour,
     fetchSessionDurations,
@@ -322,5 +324,43 @@ describe("fetchWindowedInvocations", () => {
         const db = makeMockDb([[[]]]);
         const r = await runWithMock(db, fetchWindowedInvocations({ windowDays: 7 }));
         expect(r).toHaveLength(0);
+    });
+});
+
+describe("fetchGuardrailHookEvidence", () => {
+    test("returns per-hook fire/block/warn counts from hook evidence", async () => {
+        const db = makeMockDb([[[
+            { hook_name: "enforce-worktree", fires: 12, blocked: 3, warned: 1 },
+            { hook_name: "route-dispatch", fires: 8, blocked: 0, warned: 6 },
+        ]]]);
+        const rows = await runWithMock(db, fetchGuardrailHookEvidence({ windowDays: 14 }));
+        expect(rows).toEqual([
+            { hook_name: "enforce-worktree", fires: 12, blocked: 3, warned: 1 },
+            { hook_name: "route-dispatch", fires: 8, blocked: 0, warned: 6 },
+        ]);
+        expect(db.captured[0]).toContain("FROM hook_command_invocation");
+        expect(db.captured[0]).toContain("time::now() - 14d");
+        expect(db.captured[0]).toContain("GROUP BY hook_name");
+        expect(db.captured[0]).toContain('effect = "blocked"');
+        expect(db.captured[0]).toContain('"injected_context"');
+    });
+});
+
+describe("fetchGuardrailVerdicts", () => {
+    test("returns locked verdict counts from windowed checkpoint rows", async () => {
+        const db = makeMockDb([[[
+            { verdict: "adopted", count: 4 },
+            { verdict: "ignored", count: 2 },
+            { verdict: "no_longer_needed", count: 1 },
+        ]]]);
+        const rows = await runWithMock(db, fetchGuardrailVerdicts({ windowDays: 30 }));
+        expect(rows).toEqual([
+            { verdict: "adopted", count: 4 },
+            { verdict: "ignored", count: 2 },
+            { verdict: "no_longer_needed", count: 1 },
+        ]);
+        expect(db.captured[0]).toContain("FROM checkpoint");
+        expect(db.captured[0]).toContain("user_verdict IS NOT NONE");
+        expect(db.captured[0]).toContain("time::now() - 30d");
     });
 });

--- a/apps/axctl/src/profile/queries.ts
+++ b/apps/axctl/src/profile/queries.ts
@@ -12,6 +12,7 @@ import { SurrealClient } from "@ax/lib/db";
 import { recordLiteral } from "@ax/lib/ids";
 import { recordKeyPart } from "@ax/lib/shared/derive-keys";
 import { isContextTool, isVerificationTool } from "./tool-taxonomy.ts";
+import type { GuardrailHookEvidenceRow, GuardrailVerdictRow } from "./guardrails.ts";
 
 const win = (d: number) => `${Math.max(1, Math.trunc(d))}d`;
 
@@ -761,5 +762,62 @@ export const fetchWindowedSessions = Effect.fn("profile.fetchWindowedSessions")(
                 s: String(r.s),
                 e: String(r.e),
             })) satisfies WindowedSessionRow[];
+    },
+);
+
+// --- guardrail receipts -----------------------------------------------------
+
+const GUARDRAIL_HOOK_EVIDENCE_SQL = (d: number) => `
+SELECT
+    hook_name,
+    count() AS fires,
+    math::sum(IF effect = "blocked" OR provider_status = "blocking_error" THEN 1 ELSE 0 END) AS blocked,
+    math::sum(IF effect IN ["notified", "injected_context", "modified_input"] THEN 1 ELSE 0 END) AS warned
+FROM hook_command_invocation
+WHERE ts > time::now() - ${win(d)}
+  AND hook_name IS NOT NONE
+GROUP BY hook_name
+ORDER BY fires DESC
+LIMIT 1000;`;
+
+export const fetchGuardrailHookEvidence = Effect.fn("profile.fetchGuardrailHookEvidence")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* timedQuery(
+            "guardrailHookEvidence",
+            db.query<[Array<Record<string, unknown>>]>(GUARDRAIL_HOOK_EVIDENCE_SQL(opts.windowDays))
+                .pipe(Effect.map((r) => r?.[0] ?? [])),
+        );
+        return rows.map((r) => ({
+            hook_name: String(r.hook_name ?? ""),
+            fires: Number(r.fires ?? 0),
+            blocked: Number(r.blocked ?? 0),
+            warned: Number(r.warned ?? 0),
+        })).filter((r) => r.hook_name.length > 0) satisfies GuardrailHookEvidenceRow[];
+    },
+);
+
+const GUARDRAIL_VERDICTS_SQL = (d: number) => `
+SELECT
+    user_verdict AS verdict,
+    count() AS count
+FROM checkpoint
+WHERE observed_at > time::now() - ${win(d)}
+  AND user_verdict IS NOT NONE
+GROUP BY verdict
+ORDER BY count DESC;`;
+
+export const fetchGuardrailVerdicts = Effect.fn("profile.fetchGuardrailVerdicts")(
+    function* (opts: { readonly windowDays: number }) {
+        const db = yield* SurrealClient;
+        const rows = yield* timedQuery(
+            "guardrailVerdicts",
+            db.query<[Array<Record<string, unknown>>]>(GUARDRAIL_VERDICTS_SQL(opts.windowDays))
+                .pipe(Effect.map((r) => r?.[0] ?? [])),
+        );
+        return rows.map((r) => ({
+            verdict: String(r.verdict ?? ""),
+            count: Number(r.count ?? 0),
+        })).filter((r) => r.verdict.length > 0) satisfies GuardrailVerdictRow[];
     },
 );

--- a/apps/axctl/src/profile/render.test.ts
+++ b/apps/axctl/src/profile/render.test.ts
@@ -13,7 +13,7 @@ import { buildProfile } from "./render.ts";
 // 19 dailyModels  20 dailyToolCalls  21 dailyCommits
 // 22 windowedInvocations  23 windowedSessions
 // 24 deepSessions:total  25 deepSessions:produced  26 deepSessions:landed-loc
-// 27 contentTypeBreakdown
+// 27 contentTypeBreakdown  28 guardrailHookEvidence  29 guardrailVerdicts
 const mockResults = [
     [[{ prompt_tokens: 31_000_000, completion_tokens: 7_000_000, sessions: 142 }]],
     [[{ date: "2026-06-11" }, { date: "2026-06-12" }]],
@@ -98,13 +98,27 @@ const mockResults = [
         { ct: "content_type:code", calls: 10, bytes: 800 },
         { ct: "content_type:text", calls: 5, bytes: 200 },
     ]],
+    // 28: guardrailHookEvidence
+    [[
+        { hook_name: "/Users/me/.ax/hooks/enforce-worktree.ts", fires: 412, blocked: 9, warned: 0 },
+        { hook_name: "route-dispatch", fires: 25, blocked: 0, warned: 12 },
+        { hook_name: "uninstalled.ts", fires: 99, blocked: 99, warned: 0 },
+    ]],
+    // 29: guardrailVerdicts
+    [[
+        { verdict: "adopted", count: 4 },
+        { verdict: "regressed", count: 1 },
+        { verdict: "ignored", count: 1 },
+        { verdict: "no_longer_needed", count: 1 },
+        { verdict: "partial", count: 2 },
+    ]],
 ];
 
 const env = {
     github: "necmttn",
     generatedAt: "2026-06-12T19:00:00Z",
     today: "2026-06-12",
-    hookFiles: ["enforce-worktree.ts"],
+    hookFiles: ["enforce-worktree.ts", "route-dispatch.ts"],
     hasRoutingTable: true,
     rulesMarkdown: "- rule one\n- rule two",
     highlights: null,
@@ -180,6 +194,18 @@ describe("buildProfile", () => {
         expect(p.insights!.repos_count).toBe(12);
         expect(p.insights!.verification_calls).toBe(900); // "bun test" matches
         expect(p.insights!.context_calls).toBe(2000); // "Read" matches
+        expect(p.guardrail_receipts).toEqual({
+            hooks: [
+                { name: "enforce-worktree", fires: 412, blocked: 9, warned: 0 },
+                { name: "route-dispatch", fires: 25, blocked: 0, warned: 12 },
+            ],
+            verdicts: {
+                worked: 4,
+                did_not_work: 2,
+                no_longer_needed: 1,
+                partial: 2,
+            },
+        });
     });
 
     test("includeCost=false strips cost everywhere; share falls back to sessions", async () => {

--- a/apps/axctl/src/profile/render.ts
+++ b/apps/axctl/src/profile/render.ts
@@ -17,6 +17,8 @@ import {
     fetchDailyModels,
     fetchDailyToolCalls,
     fetchDeepSessionCount,
+    fetchGuardrailHookEvidence,
+    fetchGuardrailVerdicts,
     fetchHarnesses,
     fetchPeakHour,
     fetchSessionDurations,
@@ -29,6 +31,7 @@ import {
     fetchWindowedSessions,
     fetchWrappedCounts,
 } from "./queries.ts";
+import { deriveGuardrailReceipts } from "./guardrails.ts";
 import { deriveInsights } from "./insights.ts";
 import { deriveRig } from "./rig.ts";
 import { computeStreak } from "./streak.ts";
@@ -67,6 +70,7 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         // 22 windowedInvocations  23 windowedSessions
         // 24 deepSessions:total  25 deepSessions:produced  26 deepSessions:landed-loc
         // 27 contentTypeBreakdown
+        // 28 guardrailHookEvidence  29 guardrailVerdicts
         const totals = yield* fetchTokenTotals({ windowDays });
         const daily = yield* fetchDailyActivity({ windowDays });
         const harnesses = yield* fetchHarnesses({ windowDays });
@@ -92,6 +96,8 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
         const deep = yield* fetchDeepSessionCount({ windowDays });
         // 27 content-type breakdown (appended last; keeps mock order in render.test.ts aligned)
         const contentTypes = yield* fetchContentTypeBreakdown();
+        const guardrailHookEvidence = yield* fetchGuardrailHookEvidence({ windowDays });
+        const guardrailVerdicts = yield* fetchGuardrailVerdicts({ windowDays });
 
         const streak = computeStreak(daily, env.today);
 
@@ -158,6 +164,11 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
 
         // Derive downstream shares (pure compute over windowed invocations + sessions)
         const shareMap = computeDownstreamShares(windowedInvocations, windowedSessions);
+        const guardrailReceipts = deriveGuardrailReceipts({
+            hookFiles: env.hookFiles,
+            hookEvidence: guardrailHookEvidence,
+            verdicts: guardrailVerdicts,
+        });
 
         // decodeProfile throws on invariant breach -> Effect defect (die),
         // intentionally unrecoverable: a malformed profile is a bug here.
@@ -191,6 +202,7 @@ export const buildProfile = Effect.fn("profile.buildProfile")(
             ...(enrichedDaily.length > 0 ? { activity: { daily: enrichedDaily } } : {}),
             ...(insights !== null ? { insights } : {}),
             ...(workflowArcs.length > 0 ? { workflow: { arcs: workflowArcs } } : {}),
+            ...(guardrailReceipts !== null ? { guardrail_receipts: guardrailReceipts } : {}),
             ...(env.highlights !== null ? { highlights: env.highlights } : {}),
         });
         return profile;

--- a/apps/axctl/src/profile/schema.test.ts
+++ b/apps/axctl/src/profile/schema.test.ts
@@ -392,6 +392,57 @@ describe("new enriched daily fields (optional)", () => {
     });
 });
 
+describe("guardrail receipts schema", () => {
+    const base = {
+        v: 1, github: "x", generated_at: "2026-06-13T00:00:00Z", window_days: 30,
+        stats: {
+            sessions: 1, active_days: 1, streak_days: 1,
+            tokens: { prompt: 0, completion: 0, total: 0 },
+            models: [], harnesses: [],
+        },
+        rig: { skills: [], hooks: ["enforce-worktree"], routing_table: false },
+    };
+
+    test("accepts optional hook receipt counts and verdict tallies", () => {
+        const p = decodeProfile({
+            ...base,
+            guardrail_receipts: {
+                hooks: [
+                    { name: "enforce-worktree", fires: 412, blocked: 9, warned: 3 },
+                    { name: "route-dispatch", fires: 25, blocked: 0, warned: 12 },
+                ],
+                verdicts: {
+                    worked: 4,
+                    did_not_work: 2,
+                    no_longer_needed: 1,
+                },
+            },
+        });
+        expect(p.guardrail_receipts!.hooks[0]).toEqual({
+            name: "enforce-worktree",
+            fires: 412,
+            blocked: 9,
+            warned: 3,
+        });
+        expect(p.guardrail_receipts!.verdicts.no_longer_needed).toBe(1);
+    });
+
+    test("omits guardrail receipts for old gists", () => {
+        const p = decodeProfile(base);
+        expect(p.guardrail_receipts).toBeUndefined();
+    });
+
+    test("rejects non-count receipt fields", () => {
+        expect(() => decodeProfile({
+            ...base,
+            guardrail_receipts: {
+                hooks: [{ name: "enforce-worktree", fires: "lots", blocked: 9, warned: 0 }],
+                verdicts: { worked: 1, did_not_work: 0, no_longer_needed: 0 },
+            },
+        })).toThrow();
+    });
+});
+
 describe("Highlights schema", () => {
     test("Highlights decodes a full block", () => {
         const decode = Schema.decodeUnknownSync(Highlights);

--- a/apps/axctl/src/profile/schema.ts
+++ b/apps/axctl/src/profile/schema.ts
@@ -110,6 +110,26 @@ const Workflow = Schema.Struct({
     arcs: Schema.Array(WorkflowArc),
 });
 
+const GuardrailHookReceipt = Schema.Struct({
+    name: Schema.String,
+    fires: Schema.Number,
+    blocked: Schema.Number,
+    warned: Schema.Number,
+});
+
+const GuardrailVerdicts = Schema.Struct({
+    worked: Schema.Number,
+    did_not_work: Schema.Number,
+    no_longer_needed: Schema.Number,
+    partial: Schema.optional(Schema.Number),
+});
+
+const GuardrailReceipts = Schema.Struct({
+    hooks: Schema.Array(GuardrailHookReceipt),
+    verdicts: GuardrailVerdicts,
+});
+export type GuardrailReceipts = typeof GuardrailReceipts.Type;
+
 export const Highlights = Schema.Struct({
     authored_at: Schema.String,
     setup: Schema.optional(Schema.Array(Schema.Struct({
@@ -191,6 +211,7 @@ export const ProfileV1 = Schema.Struct({
     activity: Schema.optional(Activity),
     insights: Schema.optional(Insights),
     workflow: Schema.optional(Workflow),
+    guardrail_receipts: Schema.optional(GuardrailReceipts),
     highlights: Schema.optional(Highlights),
 });
 export type ProfileV1 = typeof ProfileV1.Type;

--- a/apps/site/app/components/profile-dossier.tsx
+++ b/apps/site/app/components/profile-dossier.tsx
@@ -16,6 +16,8 @@ import { duelPath, duelXIntent } from "~/lib/challenge";
 import {
     type ProfileV1,
     type ProfileDailyRow,
+    type ProfileGuardrailHookReceipt,
+    type ProfileGuardrailVerdicts,
     type ProfileHighlights,
     type ProfileInsights,
     type ProfileSkill,
@@ -84,6 +86,30 @@ const fmtDay = (iso: string): string => {
     return month ? `${month} ${Number(m[3])}` : iso;
 };
 export const clampPct = (x: number): number => (Number.isFinite(x) ? Math.min(100, Math.max(0, x)) : 0);
+
+function hookReceiptStatus(r: ProfileGuardrailHookReceipt): string {
+    if (r.fires === 0) return "no recent fires";
+    return r.blocked + r.warned > 0 ? "still earning" : "watching";
+}
+
+function hookReceiptText(r: ProfileGuardrailHookReceipt): string {
+    const parts = [`fired ${fmtInt(r.fires)}×`];
+    if (r.blocked > 0) parts.push(`blocked ${fmtInt(r.blocked)}`);
+    if (r.warned > 0) parts.push(`warned ${fmtInt(r.warned)}`);
+    if (r.blocked === 0 && r.warned === 0) parts.push("no blocks/warnings");
+    parts.push(hookReceiptStatus(r));
+    return parts.join(" · ");
+}
+
+function verdictSummaryText(v: ProfileGuardrailVerdicts): string {
+    const parts = [
+        `${fmtInt(v.worked)} worked`,
+        `${fmtInt(v.did_not_work)} didn't`,
+    ];
+    if ((v.partial ?? 0) > 0) parts.push(`${fmtInt(v.partial ?? 0)} partial`);
+    parts.push(`${fmtInt(v.no_longer_needed)} no longer needed (resolved or never fired)`);
+    return parts.join(" · ");
+}
 
 /** Only http/https links are rendered as anchors; anything else renders as text. */
 function safeHttpUrl(raw: string): string | null {
@@ -236,6 +262,7 @@ export function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsS
     const { colorOf } = buildModelColors(models);
     const arcs = p.workflow ? buildDisplayArcs(p.workflow.arcs, 5) : [];
     const lede = archetypeFor(profileToAxes(p), p).blurb;
+    const hookReceipts = new Map((p.guardrail_receipts?.hooks ?? []).map((r) => [r.name, r]));
 
     return (
         <article className="profile-v2-doc">
@@ -357,7 +384,9 @@ export function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsS
                         </div>
                         {p.rig.hooks.length > 0 && (
                             <div className="pf-hook-list">
-                                {p.rig.hooks.map((h) => <span className="pf-hook" key={h}>{h}</span>)}
+                                {p.rig.hooks.map((h) => (
+                                    <HookReceiptLine key={h} name={h} receipt={hookReceipts.get(h)} />
+                                ))}
                             </div>
                         )}
                         <div className="pf-guard-row">
@@ -372,6 +401,12 @@ export function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsS
                                 {p.rig.rules ? fmtInt(p.rig.rules.count) : "-"}
                             </span>
                         </div>
+                        {p.guardrail_receipts && (
+                            <div className="pf-guard-verdicts">
+                                <span>verdicts</span>
+                                <span>{verdictSummaryText(p.guardrail_receipts.verdicts)}</span>
+                            </div>
+                        )}
                     </aside>
                 </div>
             </section>
@@ -441,6 +476,17 @@ export function ProfileDossier({ profile: p, vs }: { profile: ProfileV1; vs: VsS
                 <span>publish yours → <code>ax profile publish</code></span>
             </footer>
         </article>
+    );
+}
+
+function HookReceiptLine({ name, receipt }: { name: string; receipt?: ProfileGuardrailHookReceipt }) {
+    return (
+        <div className="pf-hook-receipt">
+            <span className="pf-hook" title={name}>{name}</span>
+            <span className={receipt ? "pf-hook-receipt-text" : "pf-hook-receipt-text pf-hook-receipt-text--empty"}>
+                {receipt ? hookReceiptText(receipt) : "no recent receipt"}
+            </span>
+        </div>
     );
 }
 

--- a/apps/site/app/components/profile-highlights.test.tsx
+++ b/apps/site/app/components/profile-highlights.test.tsx
@@ -31,3 +31,16 @@ describe("dossier renders highlights inside the Taste section", () => {
         expect(src).toContain("pf-toggle");             // disclosure chevron
     });
 });
+
+describe("dossier renders guardrail receipts", () => {
+    test("Guardrails block reads guardrail_receipts and renders per-hook receipts", () => {
+        expect(src).toContain("guardrail_receipts");
+        expect(src).toContain("HookReceiptLine");
+        expect(src).toContain("pf-hook-receipt");
+        expect(src).toContain("still earning");
+    });
+
+    test("no_longer_needed verdicts are labeled without claiming the cause", () => {
+        expect(src).toContain("resolved or never fired");
+    });
+});

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -12555,7 +12555,13 @@ footer.site-footer { padding: 48px 32px 56px; }
 }
 .pf-guard-on { color: var(--green); }
 .pf-guard-off { color: var(--muted); }
-.pf-hook-list { display: flex; flex-wrap: wrap; gap: 6px; padding-bottom: 10px; }
+.pf-hook-list { display: flex; flex-direction: column; gap: 7px; padding-bottom: 10px; }
+.pf-hook-receipt {
+    display: grid;
+    grid-template-columns: minmax(0, 0.42fr) minmax(0, 0.58fr);
+    gap: 8px;
+    align-items: start;
+}
 .pf-hook {
     font-family: var(--mono);
     font-size: 11px;
@@ -12564,6 +12570,25 @@ footer.site-footer { padding: 48px 32px 56px; }
     padding: 2px 8px;
     overflow-wrap: anywhere;
 }
+.pf-hook-receipt-text {
+    font-family: var(--mono);
+    font-size: 11px;
+    line-height: 1.35;
+    color: var(--muted);
+    overflow-wrap: anywhere;
+}
+.pf-hook-receipt-text--empty { color: color-mix(in srgb, var(--muted) 72%, transparent); }
+.pf-guard-verdicts {
+    border-top: 1px solid var(--line);
+    padding-top: 10px;
+    margin-top: 2px;
+    display: grid;
+    gap: 4px;
+    font-family: var(--mono);
+    font-size: 11.5px;
+    line-height: 1.4;
+}
+.pf-guard-verdicts span:first-child { color: var(--muted); }
 
 /* ----- 05 taste patterns ----- */
 .pf-taste {

--- a/packages/lib/src/shared/community-profile.test.ts
+++ b/packages/lib/src/shared/community-profile.test.ts
@@ -426,6 +426,52 @@ describe("validateProfileV1 highlights", () => {
     });
 });
 
+describe("validateProfileV1 guardrail receipts", () => {
+    const base = {
+        v: 1, github: "octocat", generated_at: "2026-06-17T00:00:00Z", window_days: 30,
+        stats: { sessions: 1, active_days: 1, streak_days: 1, tokens: { prompt: 1, completion: 1, total: 2 }, models: [], harnesses: [] },
+        rig: { skills: [], hooks: ["enforce-worktree"], routing_table: false },
+    };
+
+    test("accepts hook receipt counts and verdict tallies", () => {
+        const p = validateProfileV1({
+            ...base,
+            guardrail_receipts: {
+                hooks: [
+                    { name: "enforce-worktree", fires: 412, blocked: 9, warned: 3 },
+                ],
+                verdicts: {
+                    worked: 5,
+                    did_not_work: 2,
+                    no_longer_needed: 1,
+                },
+            },
+        });
+        expect(p.guardrail_receipts?.hooks[0]?.blocked).toBe(9);
+        expect(p.guardrail_receipts?.verdicts.worked).toBe(5);
+    });
+
+    test("profile without guardrail receipts still validates", () => {
+        expect(validateProfileV1(base).guardrail_receipts).toBeUndefined();
+    });
+
+    test("rejects non-number receipt counts", () => {
+        expect(() => validateProfileV1({
+            ...base,
+            guardrail_receipts: {
+                hooks: [
+                    { name: "enforce-worktree", fires: "many", blocked: 9, warned: 3 },
+                ],
+                verdicts: {
+                    worked: 5,
+                    did_not_work: 2,
+                    no_longer_needed: 1,
+                },
+            },
+        })).toThrow();
+    });
+});
+
 describe("urls", () => {
     test("registration + gist raw urls", () => {
         expect(registrationRawUrl("Necmttn")).toBe(

--- a/packages/lib/src/shared/community.ts
+++ b/packages/lib/src/shared/community.ts
@@ -95,6 +95,22 @@ export interface WorkflowArc {
 export interface ProfileWorkflow {
     readonly arcs: readonly WorkflowArc[];
 }
+export interface ProfileGuardrailHookReceipt {
+    readonly name: string;
+    readonly fires: number;
+    readonly blocked: number;
+    readonly warned: number;
+}
+export interface ProfileGuardrailVerdicts {
+    readonly worked: number;
+    readonly did_not_work: number;
+    readonly no_longer_needed: number;
+    readonly partial?: number;
+}
+export interface ProfileGuardrailReceipts {
+    readonly hooks: readonly ProfileGuardrailHookReceipt[];
+    readonly verdicts: ProfileGuardrailVerdicts;
+}
 export interface ProfileToolRun {
     readonly name: string;
     readonly runs: number;
@@ -143,6 +159,7 @@ export interface ProfileV1 {
     readonly activity?: { readonly daily: readonly ProfileDailyRow[] };
     readonly insights?: ProfileInsights;
     readonly workflow?: ProfileWorkflow;
+    readonly guardrail_receipts?: ProfileGuardrailReceipts;
     readonly highlights?: ProfileHighlights;
 }
 
@@ -286,6 +303,22 @@ export function validateProfileV1(value: unknown): ProfileV1 {
             for (const step of arc.steps) str(step, "workflow.arc.step");
             num(arc.count, "workflow.arc.count");
         }
+    }
+    if (value.guardrail_receipts !== undefined) {
+        const gr = value.guardrail_receipts;
+        if (!isRecord(gr)) throw new Error("invalid guardrail_receipts");
+        validateRows(gr.hooks, "guardrail_receipts.hooks", (h) => {
+            str(h.name, "guardrail_receipts.hook.name");
+            num(h.fires, "guardrail_receipts.hook.fires");
+            num(h.blocked, "guardrail_receipts.hook.blocked");
+            num(h.warned, "guardrail_receipts.hook.warned");
+        });
+        if (!Array.isArray(gr.hooks)) throw new Error("invalid guardrail_receipts.hooks");
+        if (!isRecord(gr.verdicts)) throw new Error("invalid guardrail_receipts.verdicts");
+        num(gr.verdicts.worked, "guardrail_receipts.verdicts.worked");
+        num(gr.verdicts.did_not_work, "guardrail_receipts.verdicts.did_not_work");
+        num(gr.verdicts.no_longer_needed, "guardrail_receipts.verdicts.no_longer_needed");
+        optNum(gr.verdicts.partial, "guardrail_receipts.verdicts.partial");
     }
     if (value.highlights !== undefined) {
         const h = value.highlights;


### PR DESCRIPTION
## Summary
- add optional guardrail receipt aggregates to ProfileV1 and the community validator
- derive per-installed-hook fire/block/warn counts from hook evidence plus improve verdict tallies
- render hook receipts and honest verdict summaries in CLI and public profile Guardrails blocks

## Tests
- bun test apps/axctl/src/profile/publish.test.ts apps/axctl/src/profile/guardrails.test.ts apps/axctl/src/profile/schema.test.ts apps/axctl/src/profile/render.test.ts apps/axctl/src/profile/queries.test.ts apps/axctl/src/cli/commands/profile.test.ts packages/lib/src/shared/community-profile.test.ts apps/site/app/components/profile-highlights.test.tsx
- bun run typecheck
- bun run --cwd apps/site typecheck exits 2 on existing route/content-codegen baseline; no changed-file matches

Closes #378

---

_Generated with [ax](https://github.com/Necmttn/ax)._
