### PR TITLE
Fix site typecheck codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
 
       - run: bun run typecheck
 
+      - run: bun run --cwd apps/site typecheck
+
       - run: bun run check:cli-reference
 
       - run: bun run check:no-node-fs

--- a/apps/site/app/client.tsx
+++ b/apps/site/app/client.tsx
@@ -1,13 +1,12 @@
 import { StrictMode, startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { StartClient } from "@tanstack/react-start/client";
-import { getRouter } from "./router";
 
 startTransition(() => {
   hydrateRoot(
     document,
     <StrictMode>
-      <StartClient router={getRouter()} />
+      <StartClient />
     </StrictMode>,
   );
 });

--- a/apps/site/app/components/origin-sections/chapter-exhibit-a.tsx
+++ b/apps/site/app/components/origin-sections/chapter-exhibit-a.tsx
@@ -11,9 +11,9 @@ export function ChapterExhibitA() {
     const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 
     // ── Rail drag (vertical re-injection dial) ──────────────────────────────
-    const LEVELS: Record<string, number> = { off: 400, light: 290, full: 118 };
     const LEVEL_ORDER = ["off", "light", "full"] as const;
     type Level = typeof LEVEL_ORDER[number];
+    const LEVELS: Record<Level, number> = { off: 400, light: 290, full: 118 };
 
     const fig          = root;
     const handleEl     = root.querySelector<SVGRectElement>("[data-cs-handle]");
@@ -235,8 +235,14 @@ export function ChapterExhibitA() {
       if (reduce) return;
       takeover();
       const idx = LEVEL_ORDER.indexOf(currentLevel);
-      if (ev.key === "ArrowUp"   && idx < 2) setLevel(LEVEL_ORDER[idx + 1]);
-      if (ev.key === "ArrowDown" && idx > 0) setLevel(LEVEL_ORDER[idx - 1]);
+      if (ev.key === "ArrowUp" && idx < 2) {
+        const next = LEVEL_ORDER[idx + 1];
+        if (next) setLevel(next);
+      }
+      if (ev.key === "ArrowDown" && idx > 0) {
+        const previous = LEVEL_ORDER[idx - 1];
+        if (previous) setLevel(previous);
+      }
       ev.preventDefault();
     });
 

--- a/apps/site/app/components/origin-sections/chapter-exhibit-e.tsx
+++ b/apps/site/app/components/origin-sections/chapter-exhibit-e.tsx
@@ -11,6 +11,7 @@ export function ChapterExhibitE() {
   useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
+    const rootEl = root;
 
     const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 
@@ -204,11 +205,11 @@ export function ChapterExhibitE() {
 
       const evEl = document.createElement("div");
       evEl.className = "exp-evidence";
-      [7, 30, 90].forEach((cp) => {
+      ([7, 30, 90] as const).forEach((cp) => {
         const tick = document.createElement("div");
         tick.className = "ev-tick";
         tick.setAttribute("data-cp", String(cp));
-        tick.innerHTML = (item.ticks as Record<number, string>)[cp];
+        tick.innerHTML = item.ticks[cp];
         evEl.appendChild(tick);
       });
       lane.appendChild(evEl);
@@ -279,14 +280,14 @@ export function ChapterExhibitE() {
     function refreshEmpties() {
       let pending = 0;
       SEED.forEach((s) => { if (state[s.id] === "pending") pending++; });
-      const countEl = root.querySelector("[data-count-retros]");
+      const countEl = rootEl.querySelector("[data-count-retros]");
       if (countEl) countEl.textContent = `${pending} / week`;
 
-      const emptyProp = root.querySelector('[data-empty="proposals"]');
+      const emptyProp = rootEl.querySelector<HTMLElement>('[data-empty="proposals"]');
       if (emptyProp) emptyProp.style.display = propBody!.querySelector(".proposal-card") ? "none" : "";
-      const emptyExp = root.querySelector('[data-empty="experiments"]');
+      const emptyExp = rootEl.querySelector<HTMLElement>('[data-empty="experiments"]');
       if (emptyExp) emptyExp.style.display = expBody!.querySelector(".exp-lane") ? "none" : "";
-      const emptyVerd = root.querySelector('[data-empty="verdicts"]');
+      const emptyVerd = rootEl.querySelector<HTMLElement>('[data-empty="verdicts"]');
       if (emptyVerd) emptyVerd.style.display = verdBody!.querySelector(".verdict-slot") ? "none" : "";
     }
 
@@ -398,8 +399,13 @@ export function ChapterExhibitE() {
       clearEl(expBody!);
       clearEl(verdBody!);
 
-      [["proposals", "drag a retro here"], ["experiments", "start an experiment"], ["verdicts", "resolve at +30 sessions"]].forEach(([col, text]) => {
-        const bodyEl = root.querySelector<HTMLElement>(`[data-drop="${col}"]`);
+      const emptyStates = [
+        ["proposals", "drag a retro here"],
+        ["experiments", "start an experiment"],
+        ["verdicts", "resolve at +30 sessions"],
+      ] as const;
+      emptyStates.forEach(([col, text]) => {
+        const bodyEl = rootEl.querySelector<HTMLElement>(`[data-drop="${col}"]`);
         const em = document.createElement("div");
         em.className = "col-empty";
         em.setAttribute("data-empty", col);
@@ -418,7 +424,7 @@ export function ChapterExhibitE() {
     }
 
     function staticEnd() {
-      root.setAttribute("data-static", "1");
+      rootEl.setAttribute("data-static", "1");
       clearEl(retroBody!);
       clearEl(propBody!);
       clearEl(expBody!);
@@ -533,7 +539,8 @@ export function ChapterExhibitE() {
 
       for (let i = 0; i < SEED.length; i++) {
         if (userTookOver) return;
-        await playItem(SEED[i], i === SEED.length - 1);
+        const item = SEED[i];
+        if (item) await playItem(item, i === SEED.length - 1);
       }
 
       if (userTookOver) return;

--- a/apps/site/app/components/origin-sections/chapter-exhibit-f.tsx
+++ b/apps/site/app/components/origin-sections/chapter-exhibit-f.tsx
@@ -7,6 +7,7 @@ export function ChapterExhibitF() {
   useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
+    const rootEl = root;
 
     const svg          = root.querySelector<SVGSVGElement>("[data-enforce-svg]");
     const dotLayer     = root.querySelector<SVGGElement>("[data-dot-layer]");
@@ -34,12 +35,12 @@ export function ChapterExhibitF() {
       "Edit{src/foo.ts}", "Read{schema.surql}", "Bash{npm i}", "Bash{git status}",
       "Edit{README.md}", "Bash{bun test}", "Read{package.json}", "Glob{**/*.ts}",
       "Bash{tsc --noEmit}", "Edit{src/lib/db.ts}",
-    ];
+    ] as const;
     const DANGER_CALLS = [
       "Bash{git checkout main}", "Bash{git push --force main}", "Edit{flake.nix}",
       "Bash{git reset --hard origin/main}", "Bash{rm -rf .references}",
       "Bash{git commit --amend} on main",
-    ];
+    ] as const;
 
     type DotKind = "safe" | "danger";
     type DotState = "idle" | "flying" | "blocked" | "fading";
@@ -109,6 +110,9 @@ export function ChapterExhibitF() {
 
     function rand(min: number, max: number) { return min + Math.random() * (max - min); }
     function liveCount() { return dots.filter((d) => d.live).length; }
+    function pickCall(calls: readonly string[], index = (Math.random() * calls.length) | 0) {
+      return calls[index % calls.length] ?? calls[0] ?? "";
+    }
 
     function spawn() {
       const d = dots.find((d) => !d.live);
@@ -116,8 +120,8 @@ export function ChapterExhibitF() {
       const isDanger = Math.random() < 0.18;
       d.kind  = isDanger ? "danger" : "safe";
       d.label = isDanger
-        ? DANGER_CALLS[(Math.random() * DANGER_CALLS.length) | 0]
-        : SAFE_CALLS[(Math.random() * SAFE_CALLS.length) | 0];
+        ? pickCall(DANGER_CALLS)
+        : pickCall(SAFE_CALLS);
       d.x = -10;
       d.y = rand(LANE_TOP + 8, LANE_BOT - 8);
       d.vx = rand(0.55, 0.95);
@@ -140,7 +144,7 @@ export function ChapterExhibitF() {
     function setMode(next: "prose" | "hook") {
       if (mode === next) return;
       mode = next;
-      root.setAttribute("data-mode", mode);
+      rootEl.setAttribute("data-mode", mode);
       pills.forEach((p) => {
         const isActive = p.dataset.mode === mode;
         p.setAttribute("aria-pressed", isActive ? "true" : "false");
@@ -168,7 +172,7 @@ export function ChapterExhibitF() {
       if (!tip) return;
       tip.innerHTML = html;
       tip.hidden = false;
-      const hostRect = root.getBoundingClientRect();
+      const hostRect = rootEl.getBoundingClientRect();
       let x = clientX - hostRect.left + 14;
       let y = clientY - hostRect.top + 14;
       if (x + 220 > hostRect.width)  x = clientX - hostRect.left - 240;
@@ -282,9 +286,10 @@ export function ChapterExhibitF() {
       setMode("hook");
       samples.forEach((s, i) => {
         const d = dots[i];
+        if (!d) return;
         d.live = true;
         d.kind  = (s.k === "danger" || s.k === "blocked") ? "danger" : "safe";
-        d.label = d.kind === "danger" ? DANGER_CALLS[i % DANGER_CALLS.length] : SAFE_CALLS[i % SAFE_CALLS.length];
+        d.label = d.kind === "danger" ? pickCall(DANGER_CALLS, i) : pickCall(SAFE_CALLS, i);
         d.r     = d.kind === "danger" ? 7 : 4.5;
         d.x = s.x; d.y = s.y;
         d.core.setAttribute("r", String(d.r));

--- a/apps/site/app/components/origin-sections/chapter-exhibit-g.tsx
+++ b/apps/site/app/components/origin-sections/chapter-exhibit-g.tsx
@@ -7,6 +7,7 @@ export function ChapterExhibitG() {
   useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
+    const rootEl = root;
 
     const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 
@@ -57,7 +58,7 @@ export function ChapterExhibitG() {
 
     function countSurvived(k: number) {
       let n = 0;
-      root.querySelectorAll<HTMLElement>("[data-drop]").forEach((rule) => {
+      rootEl.querySelectorAll<HTMLElement>("[data-drop]").forEach((rule) => {
         const drop = parseInt(rule.getAttribute("data-drop") ?? "999", 10);
         if (k < drop) n++;
       });
@@ -76,7 +77,7 @@ export function ChapterExhibitG() {
       track!.setAttribute("aria-valuenow", String(Math.round(k)));
 
       // update each rule
-      root.querySelectorAll<HTMLElement>("[data-pressure-rule]").forEach((ruleEl) => {
+      rootEl.querySelectorAll<HTMLElement>("[data-pressure-rule]").forEach((ruleEl) => {
         const drop     = parseInt(ruleEl.getAttribute("data-drop") ?? "999", 10);
         const kind     = ruleEl.getAttribute("data-kind") ?? "prose";
         const statusEl = ruleEl.querySelector<HTMLElement>("[data-pressure-status]");
@@ -106,7 +107,7 @@ export function ChapterExhibitG() {
       });
 
       const survived  = countSurvived(k);
-      const total     = root.querySelectorAll("[data-drop]").length;
+      const total     = rootEl.querySelectorAll("[data-drop]").length;
       if (survivedEl) {
         survivedEl.textContent = String(survived);
         survivedEl.classList.toggle("is-max", survived === total);
@@ -235,13 +236,13 @@ export function ChapterExhibitG() {
 
     // Boot
     if (reduce) {
-      root.setAttribute("data-static", "1");
+      rootEl.setAttribute("data-static", "1");
       setPillState("reduce", "motion paused");
       setPosition(MAX);
       const cap = document.createElement("div");
       cap.className = "static-caption";
       cap.textContent = "motion paused - full context window shown";
-      root.querySelector("[data-pressure-wrap]")?.appendChild(cap);
+      rootEl.querySelector("[data-pressure-wrap]")?.appendChild(cap);
     } else {
       setPosition(MIN);
       setPillState("idle", "auto · idle");

--- a/apps/site/app/components/origin-sections/chapter-exhibit-h.tsx
+++ b/apps/site/app/components/origin-sections/chapter-exhibit-h.tsx
@@ -7,6 +7,7 @@ export function ChapterExhibitH() {
   useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
+    const rootEl = root;
 
     const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 
@@ -94,11 +95,12 @@ export function ChapterExhibitH() {
       vibesBody!.appendChild(el);
       requestAnimationFrame(() => { el.classList.add("is-shown"); });
       if (vibesCount) vibesCount.textContent = String(vKept);
-      if (vKept >= 15) root.setAttribute("data-lane-vibes-overflow", "1");
+      if (vKept >= 15) rootEl.setAttribute("data-lane-vibes-overflow", "1");
     }
 
     function addAxRow(i: number) {
       const row = AX_ROWS[i % AX_ROWS.length];
+      if (!row) return;
       const accepted = row.verdict === "kept" || row.verdict === "self-resolved";
       if (accepted) aKept++; else aDropped++;
 
@@ -139,8 +141,8 @@ export function ChapterExhibitH() {
       if (vibesCount) vibesCount.textContent = "0";
       if (axKept)     axKept.textContent = "0";
       if (axDropped)  axDropped.textContent = "0";
-      root.removeAttribute("data-lane-vibes-overflow");
-      root.removeAttribute("data-playing");
+      rootEl.removeAttribute("data-lane-vibes-overflow");
+      rootEl.removeAttribute("data-playing");
       setPillState("idle", "auto · idle");
     }
 
@@ -152,7 +154,7 @@ export function ChapterExhibitH() {
     async function runAutoplay() {
       if (userTookOver || reduce) return;
       autoPlaying = true;
-      root.setAttribute("data-playing", "1");
+      rootEl.setAttribute("data-playing", "1");
       setPillState("playing", "auto · playing");
 
       const wait = (ms: number) => new Promise<void>((resolve) => {
@@ -170,7 +172,7 @@ export function ChapterExhibitH() {
       }
 
       autoPlaying = false;
-      root.removeAttribute("data-playing");
+      rootEl.removeAttribute("data-playing");
       setPillState("done", "auto · done");
     }
 
@@ -179,7 +181,7 @@ export function ChapterExhibitH() {
       userTookOver = true;
       autoPlaying  = false;
       clearPending();
-      root.removeAttribute("data-playing");
+      rootEl.removeAttribute("data-playing");
       setPillState("manual", "manual");
     }
 
@@ -208,13 +210,13 @@ export function ChapterExhibitH() {
     }, true);
 
     if (reduce) {
-      root.setAttribute("data-static", "1");
+      rootEl.setAttribute("data-static", "1");
       setPillState("reduce", "motion paused");
       run20();
       const cap = document.createElement("div");
       cap.className = "static-caption";
       cap.textContent = "motion paused - end state of 20 iterations";
-      root.querySelector("[data-race-counter]")?.appendChild(cap);
+      rootEl.querySelector("[data-race-counter]")?.appendChild(cap);
     } else {
       setPillState("idle", "auto · idle");
       // Pre-seed a few iterations so both lanes show content on first paint

--- a/apps/site/app/components/pitch/MetricsBars.tsx
+++ b/apps/site/app/components/pitch/MetricsBars.tsx
@@ -50,7 +50,9 @@ function MetricBar({
       const fill = Math.max(0, Math.min(1, (p - lo) / (hi - lo)));
       if (barRef.current) barRef.current.style.transform = `scaleX(${fill})`;
       if (numRef.current && parsed) {
-        const [, sign, digits, suffix] = parsed;
+        const sign = parsed[1] ?? "";
+        const digits = parsed[2] ?? "0";
+        const suffix = parsed[3] ?? "";
         const value = Math.round(Number.parseInt(digits, 10) * fill);
         numRef.current.textContent = `${sign}${value}${suffix}`;
       }

--- a/apps/site/app/components/pitch/PipelineFlow.tsx
+++ b/apps/site/app/components/pitch/PipelineFlow.tsx
@@ -6,6 +6,7 @@ const MAX_DOTS = 120;
 const OPEN_MS = 320;
 const CLOSE_MS = 520;
 const GREENS = ["#39d353", "#26a641", "#006d32", "#0e4429", "#39d353", "#26a641", "#006d32", "#0e4429"];
+const FALLBACK_GREEN = "#39d353";
 
 interface Dot {
   x: number;
@@ -80,7 +81,8 @@ export function PipelineFlow({
       for (let i = 0; i < STAGES.length; i++) {
         const center = (i + 0.5) / STAGES.length;
         const bell = Math.exp(-0.5 * ((x - center) / sigma) ** 2);
-        const min = minH + (maxH - minH) * s.transitions[i];
+        const transition = s.transitions[i] ?? 0;
+        const min = minH + (maxH - minH) * transition;
         result -= (maxH - min) * bell;
       }
       return Math.max(minH, result);
@@ -109,9 +111,10 @@ export function PipelineFlow({
         const target = progress >= threshold ? 1 : 0;
         const duration = target === 1 ? OPEN_MS : CLOSE_MS;
         const maxStep = dt / duration;
-        const delta = target - s.transitions[i];
+        const current = s.transitions[i] ?? 0;
+        const delta = target - current;
         s.transitions[i] =
-          Math.abs(delta) <= maxStep ? target : s.transitions[i] + Math.sign(delta) * maxStep;
+          Math.abs(delta) <= maxStep ? target : current + Math.sign(delta) * maxStep;
 
         const label = labelsRef.current[i];
         if (label) {
@@ -135,12 +138,13 @@ export function PipelineFlow({
 
       const bottlenecks: { center: number; closedness: number }[] = [];
       for (let i = 0; i < STAGES.length; i++) {
-        const closedness = 1 - s.transitions[i];
+        const closedness = 1 - (s.transitions[i] ?? 0);
         if (closedness > 0.1) bottlenecks.push({ center: (i + 0.5) / STAGES.length, closedness });
       }
 
       for (let dotIndex = 0; dotIndex < dots.length; dotIndex++) {
         const dot = dots[dotIndex];
+        if (!dot) continue;
         let dotSpeed = speed(dot.x);
         for (const bottleneck of bottlenecks) {
           const zone = 0.18;
@@ -199,12 +203,13 @@ export function PipelineFlow({
       ctx.setLineDash([]);
 
       for (let i = 0; i < STAGES.length; i++) {
-        if (s.transitions[i] < 0.9) {
+        const transition = s.transitions[i] ?? 0;
+        if (transition < 0.9) {
           const bx = ((i + 0.5) / STAGES.length) * w;
           ctx.setLineDash([2, 4]);
           ctx.strokeStyle = isDark
-            ? `rgba(255,120,80,${0.3 * (1 - s.transitions[i])})`
-            : `rgba(191,74,48,${0.3 * (1 - s.transitions[i])})`;
+            ? `rgba(255,120,80,${0.3 * (1 - transition)})`
+            : `rgba(191,74,48,${0.3 * (1 - transition)})`;
           ctx.beginPath();
           ctx.moveTo(bx, cy - 0.44 * ps);
           ctx.lineTo(bx, cy + 0.44 * ps);
@@ -217,7 +222,7 @@ export function PipelineFlow({
       ctx.shadowColor = "#39d35380";
       ctx.shadowBlur = 5;
       for (const dot of s.dots) {
-        ctx.fillStyle = GREENS[dot.colorIdx] ?? GREENS[0];
+        ctx.fillStyle = GREENS[dot.colorIdx] ?? FALLBACK_GREEN;
         ctx.fillRect(dot.x * w - SQ / 2, cy + (dot.y - 0.5) * ps * 0.6 - SQ / 2, SQ, SQ);
       }
       ctx.restore();

--- a/apps/site/app/routes/blog_.$slug.tsx
+++ b/apps/site/app/routes/blog_.$slug.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { MDXContent } from "@content-collections/mdx/react";
-import { allBlogs } from "content-collections";
+import { allBlogs, type Blog } from "content-collections";
 import { mdxComponents } from "~/components/mdx-components";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
 import { SiteHeader } from "~/components/landing-sections/site-header";
@@ -28,14 +28,19 @@ function fmtDate(iso: string): string {
   return `${months[Number(m[2]) - 1]} ${Number(m[3])}, ${m[1]}`;
 }
 
+type BlogLoaderData = { post: Blog };
+
+function loadBlogPost({ params }: { params: { slug: string } }): BlogLoaderData {
+  const post = allBlogs.find((p) => p.slug === params.slug);
+  if (!post) throw notFound();
+  return { post };
+}
+
 export const Route = createFileRoute("/blog_/$slug")({
-  // NOTE: like every dynamic content-collections route in this app
-  // (docs/adr.$slug, changelog_.$version), the strict site typecheck does not
-  // thread loaderData's type into `head` - it reads as `never`. Accepted,
-  // pre-existing repo-wide pattern; the build/runtime are correct. Matching the
-  // adr-style optional-chain shape here for consistency.
+  // This TanStack version does not thread loaderData's type into `head`, so
+  // keep the cast at this boundary and share the named loader type elsewhere.
   head: ({ loaderData }) => {
-    const post = loaderData?.post;
+    const post = (loaderData as BlogLoaderData | undefined)?.post;
     if (!post) return { meta: [{ title: "Blog - ax" }] };
     const og = ogImageUrl(post.slug, post.title, post.date);
     return {
@@ -55,16 +60,12 @@ export const Route = createFileRoute("/blog_/$slug")({
       ],
     };
   },
-  loader: ({ params }) => {
-    const post = allBlogs.find((p) => p.slug === params.slug);
-    if (!post) throw notFound();
-    return { post };
-  },
+  loader: loadBlogPost,
   component: BlogPost,
 });
 
 function BlogPost() {
-  const { post } = Route.useLoaderData();
+  const { post } = Route.useLoaderData() as BlogLoaderData;
   // The markdown body carries its own H1, so we render only a date eyebrow
   // above it - no second, competing headline.
   return (

--- a/apps/site/app/routes/changelog_.$version.tsx
+++ b/apps/site/app/routes/changelog_.$version.tsx
@@ -1,35 +1,52 @@
 import { createFileRoute, notFound, Link } from "@tanstack/react-router";
-import { allChangelogs, allReleaseAnnouncements } from "content-collections";
+import {
+  allChangelogs,
+  allReleaseAnnouncements,
+  type ReleaseAnnouncement,
+} from "content-collections";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
 import { SiteHeader } from "~/components/landing-sections/site-header";
 import { MarkdownInline, MarkdownLite } from "~/components/release-markdown";
 
+type ReleaseLoaderData = {
+  release: ReleaseAnnouncement;
+  generatedEntry: string | null;
+  generatedSections: GeneratedSection[];
+};
+
+function loadRelease({ params }: { params: { version: string } }): ReleaseLoaderData {
+  const normalized = params.version.replace(/^v/, "");
+  const release = allReleaseAnnouncements.find((item) => item.version === normalized);
+  if (!release) throw notFound();
+  const changelog = allChangelogs[0]?.content ?? "";
+  const generatedEntry = extractGeneratedEntry(changelog, normalized);
+  return {
+    release,
+    generatedEntry,
+    generatedSections: parseGeneratedSections(generatedEntry),
+  };
+}
+
 export const Route = createFileRoute("/changelog_/$version")({
-  head: ({ loaderData }) => ({
-    meta: loaderData ? [
-      { title: `${loaderData.release.title} - ax v${loaderData.release.version}` },
-      { name: "description", content: loaderData.release.summary },
-    ] : [
-      { title: "Release not found - ax" },
-    ],
-  }),
-  loader: ({ params }) => {
-    const normalized = params.version.replace(/^v/, "");
-    const release = allReleaseAnnouncements.find((item) => item.version === normalized);
-    if (!release) throw notFound();
-    const changelog = allChangelogs[0]?.content ?? "";
-    const generatedEntry = extractGeneratedEntry(changelog, normalized);
+  head: ({ loaderData }) => {
+    const data = loaderData as ReleaseLoaderData | undefined;
     return {
-      release,
-      generatedEntry,
-      generatedSections: parseGeneratedSections(generatedEntry),
+      meta: data
+        ? [
+            { title: `${data.release.title} - ax v${data.release.version}` },
+            { name: "description", content: data.release.summary },
+          ]
+        : [
+            { title: "Release not found - ax" },
+          ],
     };
   },
+  loader: loadRelease,
   component: ReleasePage,
 });
 
 function ReleasePage() {
-  const { release, generatedEntry, generatedSections } = Route.useLoaderData();
+  const { release, generatedEntry, generatedSections } = Route.useLoaderData() as ReleaseLoaderData;
   const itemCount = generatedSections.reduce((sum, section) => sum + section.items.length, 0);
 
   return (

--- a/apps/site/app/routes/docs/adr.$slug.tsx
+++ b/apps/site/app/routes/docs/adr.$slug.tsx
@@ -1,27 +1,33 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { MDXContent } from "@content-collections/mdx/react";
-import { allAdrs } from "content-collections";
+import { allAdrs, type Adr } from "content-collections";
 import { mdxComponents } from "~/components/mdx-components";
 import { DocShell } from "~/components/doc-shell";
+
+type AdrLoaderData = { adr: Adr };
+
+function loadAdr({ params }: { params: { slug: string } }): AdrLoaderData {
+  const adr = allAdrs.find((a) => a.slug === params.slug);
+  if (!adr) throw notFound();
+  return { adr };
+}
 
 export const Route = createFileRoute("/docs/adr/$slug")({
   head: ({ loaderData }) => ({
     meta: [
-      { title: `${loaderData?.adr.title ?? "ADR"} - ax` },
+      {
+        title: `${(loaderData as AdrLoaderData | undefined)?.adr.title ?? "ADR"} - ax`,
+      },
       // ADRs are internal engineering records, not visitor-facing docs.
       { name: "robots", content: "noindex, nofollow" },
     ],
   }),
-  loader: ({ params }) => {
-    const adr = allAdrs.find((a) => a.slug === params.slug);
-    if (!adr) throw notFound();
-    return { adr };
-  },
+  loader: loadAdr,
   component: AdrPage,
 });
 
 function AdrPage() {
-  const { adr } = Route.useLoaderData();
+  const { adr } = Route.useLoaderData() as AdrLoaderData;
   // The markdown body carries its own H1, so DocShell renders no title here -
   // that avoids a second, slug-mangled headline competing with the real one.
   return (

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -10,7 +10,8 @@
     "dev": "vite dev",
     "build": "bun ../../scripts/extract-stage-rationale.ts && cp ../../install.sh public/install && bun ../../scripts/stage-studio.ts && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit",
+    "codegen": "bun scripts/sync-generated.ts",
+    "typecheck": "bun run codegen && tsc --noEmit",
     "deploy": "bun run build && wrangler pages deploy dist/client --project-name=ax --branch=main && bun run verify:functions",
     "deploy:check": "bun run build && echo 'dist/client/ ready for: wrangler pages deploy dist/client --project-name=ax'",
     "verify:functions": "sleep 3 && curl -s -o /dev/null -w '%{content_type}' 'https://ax.necmttn.com/og/Necmttn/a6d4c2215bbe0998c93b38ad11db2ccb' | grep -q image/png && echo 'functions OK on production' || (echo 'PRODUCTION IS MISSING THE PAGES FUNCTIONS (/og, /s meta)' && exit 1)"
@@ -41,6 +42,7 @@
     "@cloudflare/vite-plugin": "^1.29.0",
     "@tailwindcss/vite": "^4.2.0",
     "@tanstack/router-devtools": "^1.166.0",
+    "@tanstack/router-generator": "1.167.10",
     "@types/node": "^25.0.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",

--- a/apps/site/scripts/sync-generated.ts
+++ b/apps/site/scripts/sync-generated.ts
@@ -1,0 +1,25 @@
+import { createBuilder } from "@content-collections/core";
+import { Generator, getConfig } from "@tanstack/router-generator";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Content transforms currently resolve repo-relative assets from apps/site.
+process.chdir(siteRoot);
+
+const contentBuilder = await createBuilder("content-collections.ts");
+await contentBuilder.build();
+
+const routerConfig = getConfig(
+  {
+    routesDirectory: "./app/routes",
+    generatedRouteTree: "./app/routeTree.gen.ts",
+    quoteStyle: "double",
+    semicolons: true,
+  },
+  siteRoot,
+);
+
+const routerGenerator = new Generator({ config: routerConfig, root: siteRoot });
+await routerGenerator.run();

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -11,5 +11,5 @@
       "content-collections": ["./.content-collections/generated"]
     }
   },
-  "include": ["app", "vite.config.ts", "content-collections.ts"]
+  "include": ["app", "scripts", "vite.config.ts", "content-collections.ts"]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
     },
     "apps/axctl": {
       "name": "axctl",
-      "version": "0.32.0",
+      "version": "0.35.0",
       "bin": {
         "axctl": "./bin/axctl",
       },
@@ -117,6 +117,7 @@
         "@cloudflare/vite-plugin": "^1.29.0",
         "@tailwindcss/vite": "^4.2.0",
         "@tanstack/router-devtools": "^1.166.0",
+        "@tanstack/router-generator": "1.167.10",
         "@types/node": "^25.0.0",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
@@ -843,7 +844,7 @@
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.168.0", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.170.0", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-wQoQhlBK7nlZgqzaqdYXKWNTpdHdsaREdaPhFZVH0/Ador+F+eM3/NF2i3f2LPeS0GgKraZUQXe1Q/1+KHyEYg=="],
 
-    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.42", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.169.2", "@tanstack/router-utils": "1.161.8", "@tanstack/virtual-file-routes": "1.161.7", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^3.24.2" } }, "sha512-2qBWC0t78r6b3vI+AbnvCZcFAvbYBDlLuWZrTjQbcjUmwG3qyeQp983tJyDuj9wb5//adG1tgAGXZkJ3aDwdBg=="],
+    "@tanstack/router-generator": ["@tanstack/router-generator@1.167.10", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.6", "@tanstack/router-utils": "1.162.1", "@tanstack/virtual-file-routes": "1.162.0", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^4.4.3" } }, "sha512-CjbjWRSo6djLU/C7ncb9IbKUcf4IwpdqhLGngkwKkXaVFXGxEAafA/uhvOCv/UEUVR7NI3tJqqQmxYXGcJPbjw=="],
 
     "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.35", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.169.2", "@tanstack/router-generator": "1.166.42", "@tanstack/router-utils": "1.161.8", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^3.0.0", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.169.2", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-UAScU5VAzLYVY4FML/Cbc5S5TucT4I8Ata05yozGOe4ZfepTKRffA5xWLtD2N+ov5svdv0KTX/kqlZnYPe28mA=="],
 
@@ -2451,7 +2452,11 @@
 
     "@tanstack/react-start-rsc/@tanstack/router-utils": ["@tanstack/router-utils@1.162.1", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-62layyTGmclHDQS/eidwKRfN1hhCKwViG7iEBcVmL0MXgcAB3OOucWCEcDDGd9Cu11H6b4QQ5oOo47MWIqwz0A=="],
 
-    "@tanstack/router-generator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "@tanstack/router-generator/@tanstack/router-utils": ["@tanstack/router-utils@1.162.1", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-62layyTGmclHDQS/eidwKRfN1hhCKwViG7iEBcVmL0MXgcAB3OOucWCEcDDGd9Cu11H6b4QQ5oOo47MWIqwz0A=="],
+
+    "@tanstack/router-generator/@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
+
+    "@tanstack/router-plugin/@tanstack/router-generator": ["@tanstack/router-generator@1.166.42", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.169.2", "@tanstack/router-utils": "1.161.8", "@tanstack/virtual-file-routes": "1.161.7", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^3.24.2" } }, "sha512-2qBWC0t78r6b3vI+AbnvCZcFAvbYBDlLuWZrTjQbcjUmwG3qyeQp983tJyDuj9wb5//adG1tgAGXZkJ3aDwdBg=="],
 
     "@tanstack/router-plugin/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -2460,8 +2465,6 @@
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@tanstack/start-plugin-core/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
-
-    "@tanstack/start-plugin-core/@tanstack/router-generator": ["@tanstack/router-generator@1.167.10", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.6", "@tanstack/router-utils": "1.162.1", "@tanstack/virtual-file-routes": "1.162.0", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^4.4.3" } }, "sha512-CjbjWRSo6djLU/C7ncb9IbKUcf4IwpdqhLGngkwKkXaVFXGxEAafA/uhvOCv/UEUVR7NI3tJqqQmxYXGcJPbjw=="],
 
     "@tanstack/start-plugin-core/@tanstack/router-plugin": ["@tanstack/router-plugin@1.168.11", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.6", "@tanstack/router-generator": "1.167.10", "@tanstack/router-utils": "1.162.1", "@tanstack/virtual-file-routes": "1.162.0", "chokidar": "^5.0.0", "unplugin": "^3.0.0", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.170.8", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-b2eom/8xCWL/OiWxKub8kYsr8p+kvmB/eXwYGqCWG8vilcJo+eQCSyp54nKt0AZ5k/ET1+eINc+4mwL3bVeAgg=="],
 
@@ -2723,7 +2726,7 @@
 
     "@tanstack/react-start/@tanstack/router-utils/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
-    "@tanstack/start-plugin-core/@tanstack/router-generator/@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
+    "@tanstack/router-generator/@tanstack/router-utils/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "@tanstack/start-plugin-core/@tanstack/router-plugin/@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -121,6 +121,7 @@
   "@ax/hooks-sdk" = copyPathToStore ./packages/hooks-sdk;
   "@ax/lib" = copyPathToStore ./packages/lib;
   "@ax/onboarding-prompt" = copyPathToStore ./packages/onboarding-prompt;
+  "@ax/recap-deck" = copyPathToStore ./packages/recap-deck;
   "@ax/schema" = copyPathToStore ./packages/schema;
   "@ax/site" = copyPathToStore ./apps/site;
   "@ax/studio" = copyPathToStore ./apps/studio;


### PR DESCRIPTION
## Summary
- add an explicit `apps/site` codegen step that runs content-collections sync and TanStack route-tree generation before `tsc`
- wire `bun run --cwd apps/site typecheck` into CI so the missing-codegen failure is caught on PRs
- fix the genuine strict-null/noUncheckedIndexedAccess fallout surfaced once generated content types existed

## Root cause
`apps/site` typecheck was plain `tsc --noEmit`. That bypassed the Vite plugins that normally create `.content-collections/generated` and `app/routeTree.gen.ts`, so content routes degraded to `never`/missing-module types. Running the same generated inputs before `tsc` restores the route/content types; the remaining failures were real strict TS issues in route loaders and animated UI components.

## Verification
- `bun run --cwd apps/site typecheck`
- `bun run typecheck`
- `bun run --cwd apps/site build`
- `bun test`

---

_Generated with [ax](https://github.com/Necmttn/ax)._