### PR TITLE
Add skill adoption pages

### DIFF
--- a/apps/site/app/routes/-leaders.test.ts
+++ b/apps/site/app/routes/-leaders.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("leaders trending skills", () => {
+    test("links rows to the validated skill adoption route", () => {
+        const src = readFileSync(new URL("./leaders.tsx", import.meta.url), "utf8");
+
+        expect(src).toContain("skillRouteKey");
+        expect(src).toContain('to="/skills/$key"');
+        expect(src).toContain("params={{ key: skillRouteKey(name, s) }}");
+    });
+});

--- a/apps/site/app/routes/leaders.tsx
+++ b/apps/site/app/routes/leaders.tsx
@@ -8,6 +8,7 @@ import {
     fetchSkillStats,
     formatCompact,
     formatUsdCompact,
+    skillRouteKey,
     trendingSkills,
     type Leaderboard,
     type SkillStats,
@@ -224,10 +225,10 @@ function TrendingSkills({ skills }: { readonly skills: SkillStats }) {
                     return (
                         <li key={name} className="lb-skill">
                             <span className="lb-skill-rank">{i + 1}</span>
-                            <span className="lb-skill-name">
+                            <Link className="lb-skill-name" to="/skills/$key" params={{ key: skillRouteKey(name, s) }}>
                                 {source && <span className="lb-skill-src">{source}</span>}
                                 {name}
-                            </span>
+                            </Link>
                             <span className="lb-skill-users">{s.users} builders</span>
                             <span className="lb-skill-runs">
                                 <span className="lb-bar" style={{ width: `${Math.max(4, (s.runs / maxRuns) * 100)}%` }} aria-hidden />

--- a/apps/site/app/routes/skills.$key.tsx
+++ b/apps/site/app/routes/skills.$key.tsx
@@ -1,0 +1,162 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { SiteHeader } from "~/components/landing-sections/site-header";
+import { SiteFooter } from "~/components/landing-sections/site-footer";
+import {
+    fetchSkillAdoption,
+    formatCompact,
+    validateSkillRouteKey,
+    type SkillAdoption,
+} from "@ax/lib/shared/community";
+
+const PROFILE_FANOUT_CAP = 24;
+
+export const Route = createFileRoute("/skills/$key")({
+    head: ({ params }) => {
+        const parsed = safeParseKey(params.key);
+        const title = parsed === null ? "skill not found - ax" : `${parsed.identity} adoption - ax skills`;
+        return {
+            meta: [
+                { title },
+                { name: "description", content: "Community adoption for an ax skill, compiled from public opt-in profile gists." },
+            ],
+        };
+    },
+    component: SkillPage,
+});
+
+type State =
+    | { kind: "loading" }
+    | { kind: "not-found" }
+    | { kind: "error"; message: string }
+    | { kind: "ready"; adoption: SkillAdoption };
+
+function safeParseKey(key: string): ReturnType<typeof validateSkillRouteKey> | null {
+    try {
+        return validateSkillRouteKey(key);
+    } catch {
+        return null;
+    }
+}
+
+function SkillPage() {
+    const { key } = Route.useParams();
+    const [state, setState] = useState<State>({ kind: "loading" });
+
+    useEffect(() => {
+        let alive = true;
+        setState({ kind: "loading" });
+        fetchSkillAdoption(key, { maxProfiles: PROFILE_FANOUT_CAP })
+            .then((adoption) => {
+                if (alive) setState({ kind: "ready", adoption });
+            })
+            .catch((e: unknown) => {
+                if (!alive) return;
+                const notFound =
+                    typeof e === "object" && e !== null && (e as { notFound?: boolean }).notFound === true;
+                const invalid = e instanceof Error && e.message === "invalid skill key";
+                setState(notFound || invalid
+                    ? { kind: "not-found" }
+                    : { kind: "error", message: e instanceof Error ? e.message : String(e) });
+            });
+        return () => { alive = false; };
+    }, [key]);
+
+    return (
+        <>
+            <SiteHeader />
+            <main className="skill-page">
+                {state.kind === "loading" && <p className="pf-loading">pulling the skill dossier...</p>}
+                {state.kind === "not-found" && <SkillNotFound routeKey={key} />}
+                {state.kind === "error" && <p className="pf-loading">couldn't load skill adoption: {state.message}</p>}
+                {state.kind === "ready" && <SkillDossier adoption={state.adoption} />}
+            </main>
+            <SiteFooter />
+        </>
+    );
+}
+
+function SkillDossier({ adoption }: { readonly adoption: SkillAdoption }) {
+    const maxRuns = Math.max(1, ...adoption.users.map((u) => u.runs));
+    return (
+        <>
+            <header className="sk-head">
+                <Link className="sk-back" to="/leaders">leaders</Link>
+                <p className="sk-eyebrow">skill dossier</p>
+                <h1>
+                    {adoption.source !== "local" && (
+                        <>
+                            <span className="sk-source">{adoption.source}</span>{" "}
+                        </>
+                    )}
+                    {adoption.name}
+                </h1>
+                <p className="sk-headline">
+                    used by <strong>{formatCompact(adoption.stats.users)}</strong>{" "}
+                    {adoption.stats.users === 1 ? "dev" : "devs"}{" · "}
+                    <strong>{formatCompact(adoption.stats.runs)}</strong> runs/30d
+                </p>
+                <p className="sk-meta">
+                    aggregate from skill-stats.json - profile roster fetched from public opt-in gists
+                </p>
+            </header>
+
+            <section className="sk-users" aria-labelledby="skill-users-heading">
+                <div className="sk-section-head">
+                    <h2 id="skill-users-heading">who runs it</h2>
+                    <span>
+                        {adoption.users.length} matched
+                        {adoption.truncated && <> - first {adoption.fetchedProfiles} of {adoption.rosterCount} profiles sampled</>}
+                    </span>
+                </div>
+                {adoption.users.length === 0 ? (
+                    <p className="pf-quiet">
+                        No fetched public profile lists this skill yet. The aggregate row can still lead
+                        when the matching registered profiles are outside the capped sample or have not
+                        republished their gist.
+                    </p>
+                ) : (
+                    <ol className="sk-user-list">
+                        {adoption.users.map((user, i) => (
+                            <li className="sk-user" key={user.login}>
+                                <span className="sk-user-rank">{i + 1}</span>
+                                <Link className="sk-user-link" to="/u/$login" params={{ login: user.login }} search={{ vs: undefined }}>
+                                    <img
+                                        className="lb-avatar"
+                                        src={`https://github.com/${user.login}.png?size=64`}
+                                        alt=""
+                                        width={32}
+                                        height={32}
+                                        loading="lazy"
+                                    />
+                                    <span>@{user.login}</span>
+                                </Link>
+                                <span className="sk-user-source">{user.source}</span>
+                                <span className="sk-user-runs">
+                                    <span className="sk-bar" style={{ width: `${Math.max(5, (user.runs / maxRuns) * 100)}%` }} aria-hidden />
+                                    <span>{formatCompact(user.runs)} runs</span>
+                                </span>
+                            </li>
+                        ))}
+                    </ol>
+                )}
+            </section>
+        </>
+    );
+}
+
+function SkillNotFound({ routeKey }: { readonly routeKey: string }) {
+    const parsed = safeParseKey(routeKey);
+    return (
+        <section className="sk-empty">
+            <p className="sk-eyebrow">404</p>
+            <h1>skill not found</h1>
+            <p className="muted">
+                {parsed === null
+                    ? "That skill key is not a valid source:name route."
+                    : `No community skill-stats row exists for ${parsed.key}.`}
+            </p>
+            <Link className="sk-empty-link" to="/leaders">back to leaders</Link>
+        </section>
+    );
+}

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -11918,13 +11918,13 @@ footer.site-footer { padding: 48px 32px 56px; }
      mono numerals, hairline rules, paper/ink. No SaaS chrome.
    ============================================================ */
 
-.profile-page, .leaders-page, .patterns-page, .status-page {
+.profile-page, .leaders-page, .patterns-page, .status-page, .skill-page {
     max-width: var(--shell-max);
     margin: 0 auto;
     padding: 32px var(--shell-pad) 96px;
 }
 @media (max-width: 640px) {
-    .profile-page, .leaders-page, .patterns-page, .status-page { padding-left: 20px; padding-right: 20px; }
+    .profile-page, .leaders-page, .patterns-page, .status-page, .skill-page { padding-left: 20px; padding-right: 20px; }
 }
 
 /* ----- status: live adoption receipt (unlisted) ----- */
@@ -12023,7 +12023,8 @@ footer.site-footer { padding: 48px 32px 56px; }
     border-bottom: 1px solid var(--line); font-family: var(--mono); font-size: 0.86rem;
 }
 .lb-skill-rank { color: var(--muted); font-variant-numeric: tabular-nums; text-align: right; }
-.lb-skill-name { color: var(--ink); display: flex; align-items: center; gap: 8px; min-width: 0; }
+.lb-skill-name { color: var(--ink); display: flex; align-items: center; gap: 8px; min-width: 0; text-decoration: none; }
+.lb-skill-name:hover { text-decoration: underline; text-underline-offset: 3px; }
 .lb-skill-src {
     font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.03em;
     color: var(--muted); background: var(--panel); border: 1px solid var(--line);
@@ -12066,6 +12067,217 @@ footer.site-footer { padding: 48px 32px 56px; }
 .lf-foot a, .lf-prov a { color: var(--blue); border-bottom: 1px solid transparent; }
 .lf-foot a:hover, .lf-prov a:hover { border-bottom-color: var(--blue); }
 .lf-prov { font-family: var(--mono); font-size: 0.74rem; margin: 0; }
+
+/* ----- skill dossier: adoption page for one community skill ----- */
+.sk-head {
+    border-bottom: 2px solid var(--ink);
+    padding: 0 0 24px;
+}
+.sk-back {
+    display: inline-flex;
+    margin-bottom: 18px;
+    font-family: var(--mono);
+    font-size: 0.74rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    text-decoration: none;
+}
+.sk-back::before { content: "<-"; margin-right: 8px; }
+.sk-back:hover { color: var(--ink); }
+.sk-eyebrow {
+    margin: 0 0 8px;
+    font-family: var(--mono);
+    font-size: 0.76rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted);
+}
+.sk-head h1,
+.sk-empty h1 {
+    margin: 0;
+    font-family: var(--serif);
+    font-size: 5.25rem;
+    line-height: 0.95;
+    font-weight: 400;
+    overflow-wrap: anywhere;
+}
+.sk-source {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 12px;
+    transform: translateY(-0.28em);
+    font-family: var(--mono);
+    font-size: 0.9rem;
+    line-height: 1.1;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    border: 1px solid var(--line);
+    background: var(--panel);
+    border-radius: 4px;
+    padding: 3px 7px;
+}
+.sk-headline {
+    margin: 18px 0 0;
+    font-family: var(--mono);
+    font-size: 1rem;
+    color: var(--muted);
+}
+.sk-headline strong {
+    color: var(--ink);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+.sk-meta {
+    margin: 8px 0 0;
+    max-width: 70ch;
+    color: var(--muted);
+    font-size: 0.88rem;
+}
+.sk-users { margin: 36px 0 0; }
+.sk-section-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 18px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--line);
+}
+.sk-section-head h2 {
+    margin: 0;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+}
+.sk-section-head span {
+    font-family: var(--mono);
+    font-size: 0.76rem;
+    color: var(--muted);
+    text-align: right;
+}
+.sk-user-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.sk-user {
+    display: grid;
+    grid-template-columns: 1.6rem minmax(170px, 1fr) minmax(80px, auto) minmax(130px, 0.45fr);
+    align-items: center;
+    gap: 14px;
+    padding: 12px 4px;
+    border-bottom: 1px solid var(--line);
+    font-family: var(--mono);
+    font-size: 0.88rem;
+}
+.sk-user-rank {
+    color: var(--muted);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+.sk-user-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    color: var(--ink);
+    text-decoration: none;
+}
+.sk-user-link span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.sk-user-link:hover span {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+.sk-user-source {
+    color: var(--muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.sk-user-runs {
+    position: relative;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    min-height: 24px;
+    font-variant-numeric: tabular-nums;
+}
+.sk-user-runs span:last-child {
+    position: relative;
+    z-index: 1;
+    color: var(--ink);
+}
+.sk-bar {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 70%;
+    background: color-mix(in srgb, var(--green) 18%, transparent);
+    border-radius: 3px;
+}
+.sk-empty {
+    max-width: 620px;
+    padding: 36px 0 0;
+}
+.sk-empty .muted {
+    margin: 14px 0 22px;
+}
+.sk-empty-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 36px;
+    padding: 6px 12px;
+    border: 1px solid var(--ink);
+    text-decoration: none;
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+.sk-empty-link:hover {
+    background: var(--ink);
+    color: var(--page);
+}
+@media (max-width: 720px) {
+    .sk-head h1,
+    .sk-empty h1 {
+        font-size: 2.65rem;
+        line-height: 1;
+    }
+    .sk-source {
+        margin-right: 8px;
+        transform: translateY(-0.18em);
+        font-size: 0.72rem;
+    }
+    .sk-section-head { display: grid; gap: 4px; }
+    .sk-section-head span { text-align: left; }
+    .sk-user {
+        grid-template-columns: 1.4rem minmax(0, 1fr) auto;
+        gap: 10px;
+    }
+    .sk-user-source { display: none; }
+    .sk-user-runs {
+        grid-column: 2 / -1;
+        justify-content: flex-start;
+    }
+    .sk-bar {
+        left: 0;
+        right: auto;
+    }
+}
+@media (max-width: 400px) {
+    .sk-head h1,
+    .sk-empty h1 {
+        font-size: 2.25rem;
+    }
+}
 
 /* ----- patterns: community taste + recovery mesh ----- */
 .pt-head h1 { margin: 0 0 8px; }

--- a/packages/lib/src/shared/community.test.ts
+++ b/packages/lib/src/shared/community.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+    fetchSkillAdoption,
     fetchMember,
     fetchMembers,
     profileGistRawUrl,
     registrationRawUrl,
+    skillRouteKey,
+    validateSkillStats,
+    validateSkillRouteKey,
     validateMemberProfile,
 } from "./community";
 
@@ -109,5 +113,129 @@ describe("community member fetchers", () => {
         const members = await fetchMembers(["missing", "low", "high"]);
 
         expect(members.map((m) => m.github)).toEqual(["high", "low"]);
+    });
+});
+
+describe("skill adoption fetchers", () => {
+    test("validates a source:name route key and rejects attribute-injection input", () => {
+        expect(validateSkillRouteKey("superpowers:brainstorming")).toEqual({
+            key: "superpowers:brainstorming",
+            source: "superpowers",
+            name: "brainstorming",
+            identity: "brainstorming",
+        });
+        expect(validateSkillRouteKey("local:codex:rescue")).toEqual({
+            key: "local:codex:rescue",
+            source: "local",
+            name: "codex:rescue",
+            identity: "codex:rescue",
+        });
+        expect(validateSkillRouteKey("local:local")).toEqual({
+            key: "local:local",
+            source: "local",
+            name: "local",
+            identity: "local",
+        });
+
+        expect(() => validateSkillRouteKey("nosource")).toThrow("invalid skill key");
+        expect(() => validateSkillRouteKey("local::rescue")).toThrow("invalid skill key");
+        expect(() => validateSkillRouteKey('local:x" onclick="alert(1)')).toThrow("invalid skill key");
+        expect(() => validateSkillRouteKey("local:<script>")).toThrow("invalid skill key");
+        expect(() => validateSkillRouteKey("local:path/segment")).toThrow("invalid skill key");
+    });
+
+    test("builds source:name route keys from old and current skill-stat rows", () => {
+        expect(skillRouteKey("tdd", { users: 2, runs: 12, source: "superpowers" })).toBe("superpowers:tdd");
+        expect(skillRouteKey("local", { users: 1, runs: 1, source: "local" })).toBe("local:local");
+        expect(skillRouteKey("local:agent-browser", { users: 1, runs: 6 })).toBe("local:agent-browser");
+        expect(skillRouteKey("brainstorming", { users: 2, runs: 20, source: "superpowers" })).toBe("superpowers:brainstorming");
+    });
+
+    test("validateSkillStats drops rows whose keys cannot be safely linked", () => {
+        expect(validateSkillStats({
+            tdd: { users: 2, runs: 12, source: "superpowers" },
+            "<img src=x>": { users: 9, runs: 99, source: "local" },
+            "local:path/segment": { users: 3, runs: 3 },
+        })).toEqual({
+            tdd: { users: 2, runs: 12, source: "superpowers" },
+        });
+    });
+
+    test("fetchSkillAdoption resolves stats, caps profile fan-out, and lists matching users", async () => {
+        const seen: string[] = [];
+        const userProfile = (github: string, runs: number) => ({
+            ...profile,
+            github,
+            rig: {
+                ...profile.rig,
+                skills: [
+                    { name: "superpowers:brainstorming", source: "superpowers", runs },
+                    { name: "other", source: "local", runs: 99 },
+                ],
+            },
+        });
+
+        globalThis.fetch = (async (input: string | URL | Request) => {
+            const url = String(input);
+            seen.push(url);
+            if (url === "https://ax-community.necmttn.com/skills") {
+                return new Response(JSON.stringify({
+                    brainstorming: { users: 2, runs: 15, source: "superpowers" },
+                }));
+            }
+            if (url === "https://ax-community.necmttn.com/leaders") {
+                return new Response(JSON.stringify({
+                    compiled_at: "2026-06-19T00:00:00Z",
+                    window_days: 30,
+                    boards: {
+                        tokens: [
+                            { login: "alice", value: 100 },
+                            { login: "bob", value: 50 },
+                            { login: "charlie", value: 25 },
+                        ],
+                        sessions: [],
+                        streak: [],
+                        cost: [],
+                    },
+                }));
+            }
+            if (url === registrationRawUrl("alice")) {
+                return new Response(JSON.stringify({ github: "alice", gist_id: "aaa", joined: "2026-06-19" }));
+            }
+            if (url === registrationRawUrl("bob")) {
+                return new Response(JSON.stringify({ github: "bob", gist_id: "bbb", joined: "2026-06-19" }));
+            }
+            if (url === profileGistRawUrl("alice", "aaa")) return new Response(JSON.stringify(userProfile("alice", 4)));
+            if (url === profileGistRawUrl("bob", "bbb")) return new Response(JSON.stringify(userProfile("bob", 11)));
+            return new Response("missing", { status: 404 });
+        }) as typeof fetch;
+
+        await expect(fetchSkillAdoption("superpowers:brainstorming", { maxProfiles: 2 })).resolves.toMatchObject({
+            key: "superpowers:brainstorming",
+            name: "brainstorming",
+            source: "superpowers",
+            stats: { users: 2, runs: 15, source: "superpowers" },
+            users: [
+                { login: "bob", runs: 11, source: "superpowers", name: "superpowers:brainstorming" },
+                { login: "alice", runs: 4, source: "superpowers", name: "superpowers:brainstorming" },
+            ],
+            rosterCount: 3,
+            fetchedProfiles: 2,
+            truncated: true,
+        });
+
+        expect(seen).not.toContain(registrationRawUrl("charlie"));
+    });
+
+    test("fetchSkillAdoption returns notFound for validated but unknown skills", async () => {
+        globalThis.fetch = (async (input: string | URL | Request) => {
+            const url = String(input);
+            if (url === "https://ax-community.necmttn.com/skills") {
+                return new Response(JSON.stringify({ tdd: { users: 1, runs: 3, source: "superpowers" } }));
+            }
+            return new Response("missing", { status: 404 });
+        }) as typeof fetch;
+
+        await expect(fetchSkillAdoption("superpowers:missing")).rejects.toMatchObject({ notFound: true });
     });
 });

--- a/packages/lib/src/shared/community.ts
+++ b/packages/lib/src/shared/community.ts
@@ -450,7 +450,41 @@ export function validateLeaderboard(value: unknown): Leaderboard {
 // Keyed by canonical skill identity (bare name, source prefix stripped at
 // compile time). `source` is the best-known install source for display (a real
 // plugin beats "local"); optional so older compiled payloads still validate.
-export type SkillStats = Record<string, { readonly users: number; readonly runs: number; readonly source?: string }>;
+export interface SkillStatsEntry {
+    readonly users: number;
+    readonly runs: number;
+    readonly source?: string;
+}
+export type SkillStats = Record<string, SkillStatsEntry>;
+
+export interface SkillRouteKey {
+    readonly key: string;
+    readonly source: string;
+    readonly name: string;
+    readonly identity: string;
+}
+
+export interface SkillAdoptionUser {
+    readonly login: string;
+    readonly runs: number;
+    readonly source: string;
+    readonly name: string;
+}
+
+export interface SkillAdoption {
+    readonly key: string;
+    readonly source: string;
+    readonly name: string;
+    readonly identity: string;
+    readonly stats: SkillStatsEntry;
+    readonly users: readonly SkillAdoptionUser[];
+    readonly rosterCount: number;
+    readonly fetchedProfiles: number;
+    readonly truncated: boolean;
+}
+
+const SKILL_ROUTE_KEY_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}:[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/;
+const SKILL_STAT_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/;
 
 // --- pattern stats --------------------------------------------------------------
 
@@ -509,7 +543,7 @@ export const formatUsdCompact = (n: number): string =>
 export function trendingSkills(
     stats: SkillStats,
     opts: { readonly minUsers?: number; readonly limit?: number } = {},
-): ReadonlyArray<readonly [string, { readonly users: number; readonly runs: number; readonly source?: string }]> {
+): ReadonlyArray<readonly [string, SkillStatsEntry]> {
     const minUsers = opts.minUsers ?? 2;
     const limit = opts.limit ?? 50;
     return Object.entries(stats)
@@ -520,15 +554,122 @@ export function trendingSkills(
 
 export function validateSkillStats(value: unknown): SkillStats {
     if (!isRecord(value)) throw new Error("invalid skill stats");
-    const out: Record<string, { users: number; runs: number; source?: string }> = {};
+    const out: Record<string, SkillStatsEntry> = {};
     for (const [k, v] of Object.entries(value)) {
         if (!isRecord(v)) continue;
+        const source = typeof v.source === "string" && v.source !== "" ? v.source : undefined;
+        if (!isSafeSkillStatKey(k, source)) continue;
         if (typeof v.users === "number" && Number.isFinite(v.users)
             && typeof v.runs === "number" && Number.isFinite(v.runs)) {
-            out[k] = { users: v.users, runs: v.runs, ...(typeof v.source === "string" ? { source: v.source } : {}) };
+            out[k] = { users: v.users, runs: v.runs, ...(source === undefined ? {} : { source }) };
         }
     }
     return out;
+}
+
+function invalidSkillKey(): Error {
+    return new Error("invalid skill key");
+}
+
+function safeDecodeRouteKey(raw: string): string {
+    if (!raw.includes("%")) return raw;
+    try {
+        return decodeURIComponent(raw);
+    } catch {
+        throw invalidSkillKey();
+    }
+}
+
+function skillIdentity(source: string, name: string): string {
+    return name.startsWith(`${source}:`) ? name.slice(source.length + 1) : name;
+}
+
+export function validateSkillRouteKey(raw: string): SkillRouteKey {
+    const key = safeDecodeRouteKey(raw).trim();
+    if (!SKILL_ROUTE_KEY_RE.test(key)) throw invalidSkillKey();
+    const sep = key.indexOf(":");
+    const source = key.slice(0, sep);
+    const name = key.slice(sep + 1);
+    return { key, source, name, identity: skillIdentity(source, name) };
+}
+
+/**
+ * Public route key for a row from skill-stats.json. Current compiled rows are
+ * keyed by canonical identity and carry `source`; older community-data rows
+ * were already keyed as `source:name`. The route stays `source:name` either
+ * way so links are stable and auditable.
+ */
+export function skillRouteKey(name: string, stats: SkillStatsEntry): string {
+    if (stats.source !== undefined && stats.source !== "") {
+        return validateSkillRouteKey(name.startsWith(`${stats.source}:`)
+            ? name
+            : `${stats.source}:${name}`).key;
+    }
+    if (name.includes(":")) return validateSkillRouteKey(name).key;
+    return validateSkillRouteKey(`local:${name}`).key;
+}
+
+function isSafeSkillStatKey(name: string, source: string | undefined): boolean {
+    if (!SKILL_STAT_NAME_RE.test(name)) return false;
+    try {
+        skillRouteKey(name, { users: 0, runs: 0, ...(source === undefined ? {} : { source }) });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function notFoundError(): Error & { notFound: true } {
+    return Object.assign(new Error("not found"), { notFound: true as const });
+}
+
+function skillStatCandidates(key: SkillRouteKey): string[] {
+    return [...new Set([
+        key.key,
+        key.identity,
+        key.name,
+        `${key.source}:${key.source}:${key.identity}`,
+    ])];
+}
+
+function resolveSkillStat(stats: SkillStats, key: SkillRouteKey): SkillStatsEntry | null {
+    for (const candidate of skillStatCandidates(key)) {
+        const row = stats[candidate];
+        if (row !== undefined) return row;
+    }
+    return null;
+}
+
+function leaderboardLogins(lb: Leaderboard): string[] {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    const add = (login: string) => {
+        const k = login.toLowerCase();
+        if (seen.has(k)) return;
+        seen.add(k);
+        out.push(login);
+    };
+    for (const row of lb.boards.tokens) add(row.login);
+    for (const row of lb.boards.sessions) add(row.login);
+    for (const row of lb.boards.streak) add(row.login);
+    for (const row of lb.boards.cost) add(row.login);
+    return out;
+}
+
+function profileSkillIdentity(skill: ProfileSkill): string {
+    return skillIdentity(skill.source, skill.name);
+}
+
+function skillUserFromProfile(login: string, profile: ProfileV1, identity: string): SkillAdoptionUser | null {
+    let runs = 0;
+    let first: ProfileSkill | undefined;
+    for (const skill of profile.rig.skills) {
+        if (profileSkillIdentity(skill) !== identity) continue;
+        runs += skill.runs;
+        first ??= skill;
+    }
+    if (first === undefined || runs <= 0) return null;
+    return { login, runs, source: first.source, name: first.name };
 }
 
 export function validatePatternStats(value: unknown): PatternStats {
@@ -648,4 +789,50 @@ export async function fetchSkillStats(): Promise<SkillStats> {
 
 export async function fetchPatternStats(): Promise<PatternStats> {
     return validatePatternStats(await fetchJson(patternStatsUrl));
+}
+
+export async function fetchSkillAdoption(
+    rawKey: string,
+    opts: { readonly maxProfiles?: number } = {},
+): Promise<SkillAdoption> {
+    const key = validateSkillRouteKey(rawKey);
+    const stats = await fetchSkillStats();
+    const row = resolveSkillStat(stats, key);
+    if (row === null) throw notFoundError();
+
+    let roster: string[];
+    try {
+        roster = leaderboardLogins(await fetchLeaderboard());
+    } catch {
+        roster = [...SEED_LOGINS];
+    }
+    if (roster.length === 0) roster = [...SEED_LOGINS];
+
+    const maxProfiles = Math.max(0, opts.maxProfiles ?? 24);
+    const capped = roster.slice(0, maxProfiles);
+    const settled = await Promise.allSettled(
+        capped.map(async (login) => ({ login, profile: await fetchProfile(login) })),
+    );
+
+    const users: SkillAdoptionUser[] = [];
+    for (const result of settled) {
+        if (result.status !== "fulfilled") continue;
+        const { login, profile } = result.value;
+        if (profile.github.toLowerCase() !== login.toLowerCase()) continue;
+        const user = skillUserFromProfile(login, profile, key.identity);
+        if (user !== null) users.push(user);
+    }
+    users.sort((a, b) => b.runs - a.runs || a.login.localeCompare(b.login));
+
+    return {
+        key: key.key,
+        source: row.source ?? key.source,
+        name: key.identity,
+        identity: key.identity,
+        stats: row,
+        users,
+        rosterCount: roster.length,
+        fetchedProfiles: capped.length,
+        truncated: roster.length > capped.length,
+    };
 }


### PR DESCRIPTION
## Summary

- Add a static-host friendly `/skills/$key` adoption route backed by validated `skill-stats.json` data.
- Link `/leaders` trending skill rows to the new skill dossier pages.
- Add shared route-key validation, capped profile fan-out, and tests for adoption fetching and safe links.

## Validation

- `bun test`
- `bun run typecheck`
- `cd apps/site && bun run build`
- `cd apps/site && bun run typecheck` still fails on pre-existing main-site errors outside changed files; changed files have no diagnostics.
- Browser screenshot pass: `/leaders` click-through, `/skills/claude%3Asimplify` desktop/mobile, and unknown skill 404 state.

Closes #375

---

_Generated with [ax](https://github.com/Necmttn/ax)._
