### PR TITLE
[codex] browse community patterns

### DIFF
--- a/apps/site/app/lib/community-patterns.test.ts
+++ b/apps/site/app/lib/community-patterns.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import {
+    COMMUNITY_PATTERN_TREE_URL,
+    PATTERN_CATEGORIES,
+    communityPatternCommitsUrl,
+    communityPatternRawUrl,
+    fetchCommunityPatterns,
+    groupPatternsByCategory,
+    patternAnchorId,
+    validateCommunityPattern,
+} from "./community-patterns";
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+    new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+
+const fakeFetch = (responses: Record<string, unknown | Response>): typeof fetch =>
+    (async (input: RequestInfo | URL) => {
+        const url = String(input);
+        const response = responses[url];
+        if (response === undefined) return new Response("missing", { status: 404 });
+        return response instanceof Response ? response : jsonResponse(response);
+    }) as typeof fetch;
+
+const failurePath = "community/patterns/failure-mode/edit-loop-thrash.json";
+const workflowPath = "community/patterns/workflow/small-review-loops.json";
+
+const failurePattern = {
+    category: "failure-mode",
+    name: "edit-loop-thrash",
+    summary: "Keeps patching the same file without rereading the surrounding code.",
+    evidence: { sessions: 3, confidence: 0.82, last_reinforced: "2026-06-20", trend: "rising" },
+    links: [
+        { rel: "recovered-by", ref: "workflow/small-review-loops" },
+        { rel: "conflicts-with", ref: "debugging/guess-and-patch" },
+    ],
+};
+
+const workflowPattern = {
+    category: "workflow",
+    name: "small-review-loops",
+    summary: "Review the diff in small increments before expanding scope.",
+    evidence: { sessions: 5, confidence: 0.9, trend: "stable" },
+};
+
+describe("community pattern validation", () => {
+    test("validates a category/name path and linkable evidence", () => {
+        const out = validateCommunityPattern(failurePattern, failurePath);
+
+        expect(out.key).toBe("failure-mode/edit-loop-thrash");
+        expect(out.links?.[0]).toEqual({ rel: "recovered-by", ref: "workflow/small-review-loops" });
+        expect(out.evidence.trend).toBe("rising");
+    });
+
+    test("rejects mismatched paths, bad confidence, and malformed link refs", () => {
+        expect(() => validateCommunityPattern(failurePattern, workflowPath)).toThrow(/category must match/);
+        expect(() => validateCommunityPattern({
+            ...failurePattern,
+            evidence: { sessions: 3, confidence: 2 },
+        }, failurePath)).toThrow(/confidence/);
+        expect(() => validateCommunityPattern({
+            ...failurePattern,
+            links: [{ rel: "caused-by", ref: "workflow/small-review-loops" }],
+        }, failurePath)).toThrow(/pattern.link/);
+        expect(() => validateCommunityPattern({
+            ...failurePattern,
+            links: [{ rel: "recovered-by", ref: "workflow" }],
+        }, failurePath)).toThrow(/pattern.link.ref/);
+    });
+});
+
+describe("fetchCommunityPatterns", () => {
+    test("lists registry JSON files, fetches raw patterns, and attaches commit authors", async () => {
+        const fetcher = fakeFetch({
+            [COMMUNITY_PATTERN_TREE_URL]: {
+                tree: [
+                    { path: "community/patterns/README.md", type: "blob" },
+                    { path: failurePath, type: "blob" },
+                    { path: workflowPath, type: "blob" },
+                ],
+            },
+            [communityPatternRawUrl(failurePath)]: failurePattern,
+            [communityPatternRawUrl(workflowPath)]: workflowPattern,
+            [communityPatternCommitsUrl(failurePath)]: [{ author: { login: "alice" } }],
+            [communityPatternCommitsUrl(workflowPath)]: [{ author: { login: "bob" } }],
+        });
+
+        const out = await fetchCommunityPatterns({ fetch: fetcher });
+
+        expect(out.patterns.map((p) => p.key)).toEqual([
+            "failure-mode/edit-loop-thrash",
+            "workflow/small-review-loops",
+        ]);
+        expect(out.patterns[0]?.author).toEqual({ login: "alice" });
+        expect(out.patterns[1]?.author).toEqual({ login: "bob" });
+        expect(out.dropped).toEqual([]);
+    });
+
+    test("keeps valid rows and reports invalid community files as dropped", async () => {
+        const fetcher = fakeFetch({
+            [COMMUNITY_PATTERN_TREE_URL]: {
+                tree: [
+                    { path: failurePath, type: "blob" },
+                    { path: workflowPath, type: "blob" },
+                ],
+            },
+            [communityPatternRawUrl(failurePath)]: failurePattern,
+            [communityPatternRawUrl(workflowPath)]: { ...workflowPattern, evidence: { sessions: "many", confidence: 0.9 } },
+            [communityPatternCommitsUrl(failurePath)]: [{ author: { login: "alice" } }],
+            [communityPatternCommitsUrl(workflowPath)]: [{ author: { login: "bob" } }],
+        });
+
+        const out = await fetchCommunityPatterns({ fetch: fetcher });
+
+        expect(out.patterns.map((p) => p.key)).toEqual(["failure-mode/edit-loop-thrash"]);
+        expect(out.dropped).toEqual([{ path: workflowPath, reason: "invalid pattern.evidence.sessions" }]);
+    });
+});
+
+describe("pattern grouping and anchors", () => {
+    test("returns every closed category with counts", () => {
+        const groups = groupPatternsByCategory([
+            validateCommunityPattern(failurePattern, failurePath),
+        ]);
+
+        expect(groups).toHaveLength(PATTERN_CATEGORIES.length);
+        expect(groups.find((g) => g.category === "failure-mode")?.count).toBe(1);
+        expect(groups.find((g) => g.category === "workflow")?.count).toBe(0);
+    });
+
+    test("turns category/name refs into stable in-page anchors", () => {
+        expect(patternAnchorId("failure-mode/edit-loop-thrash")).toBe("pattern-failure-mode-edit-loop-thrash");
+    });
+});

--- a/apps/site/app/lib/community-patterns.ts
+++ b/apps/site/app/lib/community-patterns.ts
@@ -1,0 +1,322 @@
+const REPO_RAW = "https://raw.githubusercontent.com/Necmttn/ax/main";
+const REPO_API = "https://api.github.com/repos/Necmttn/ax";
+
+export const COMMUNITY_PATTERN_TREE_URL = `${REPO_API}/git/trees/main?recursive=1`;
+
+export const PATTERN_CATEGORIES = [
+    "design-aesthetic",
+    "problem-solving-strategy",
+    "debugging",
+    "failure-mode",
+    "workflow",
+    "tool-output-mix",
+    "stack-choice",
+] as const;
+
+export type PatternCategory = (typeof PATTERN_CATEGORIES)[number];
+
+export const PATTERN_CATEGORY_LABELS = {
+    "design-aesthetic": "Design aesthetic",
+    "problem-solving-strategy": "Problem-solving strategy",
+    debugging: "Debugging",
+    "failure-mode": "Failure mode",
+    workflow: "Workflow",
+    "tool-output-mix": "Tool/output mix",
+    "stack-choice": "Stack choice",
+} satisfies Record<PatternCategory, string>;
+
+export type PatternLinkRel = "recovered-by" | "pairs-with" | "conflicts-with";
+export type PatternTrend = "rising" | "stable" | "falling" | "stale";
+
+export interface CommunityPatternEvidence {
+    readonly sessions: number;
+    readonly confidence: number;
+    readonly last_reinforced?: string;
+    readonly trend?: PatternTrend;
+}
+
+export interface CommunityPatternLink {
+    readonly rel: PatternLinkRel;
+    readonly ref: string;
+}
+
+export interface CommunityPatternAuthor {
+    readonly login: string;
+}
+
+interface CommunityPatternBase {
+    readonly key: string;
+    readonly category: PatternCategory;
+    readonly name: string;
+    readonly evidence: CommunityPatternEvidence;
+    readonly links?: readonly CommunityPatternLink[];
+    readonly author?: CommunityPatternAuthor;
+}
+
+export type ProsePatternCategory = Exclude<PatternCategory, "stack-choice">;
+
+export type CommunityPattern =
+    | (CommunityPatternBase & {
+        readonly category: ProsePatternCategory;
+        readonly summary: string;
+    })
+    | (CommunityPatternBase & {
+        readonly category: "stack-choice";
+        readonly slot: string;
+        readonly over?: readonly string[];
+        readonly context?: string;
+    });
+
+export interface CommunityPatternDrop {
+    readonly path: string;
+    readonly reason: string;
+}
+
+export interface CommunityPatternsResult {
+    readonly patterns: readonly CommunityPattern[];
+    readonly dropped: readonly CommunityPatternDrop[];
+}
+
+export interface PatternCategoryGroup {
+    readonly category: PatternCategory;
+    readonly label: string;
+    readonly count: number;
+    readonly patterns: readonly CommunityPattern[];
+}
+
+const CATEGORY_SET = new Set<string>(PATTERN_CATEGORIES);
+const PROSE_CATEGORY_SET = new Set<string>(PATTERN_CATEGORIES.filter((c) => c !== "stack-choice"));
+const LINK_REL_SET = new Set<string>(["recovered-by", "pairs-with", "conflicts-with"]);
+const TREND_SET = new Set<string>(["rising", "stable", "falling", "stale"]);
+
+const PATTERN_FILE_RE = /^community\/patterns\/([a-z0-9-]+)\/([a-z0-9-]+)\.json$/;
+const PATTERN_REF_RE = /^([a-z0-9-]+)\/([a-z0-9-]+)$/;
+const LOGIN_RE = /^[A-Za-z0-9-]{1,39}$/;
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const str = (value: unknown, what: string): string => {
+    if (typeof value !== "string") throw new Error(`invalid ${what}`);
+    return value;
+};
+
+const optionalStr = (value: unknown, what: string): string | undefined => {
+    if (value === undefined) return undefined;
+    return str(value, what);
+};
+
+const finiteNumber = (value: unknown, what: string): number => {
+    if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`invalid ${what}`);
+    if (value < 0) throw new Error(`invalid ${what}`);
+    return value;
+};
+
+const maybeStringArray = (value: unknown, what: string): readonly string[] | undefined => {
+    if (value === undefined) return undefined;
+    if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) throw new Error(`invalid ${what}`);
+    return value;
+};
+
+function parsePatternPath(path: string): { category: PatternCategory; name: string } | null {
+    const match = PATTERN_FILE_RE.exec(path);
+    if (match === null) return null;
+    const category = match[1];
+    const name = match[2];
+    if (category === undefined || name === undefined || !CATEGORY_SET.has(category)) return null;
+    return { category: category as PatternCategory, name };
+}
+
+function patternCategoryOrder(category: PatternCategory): number {
+    return PATTERN_CATEGORIES.indexOf(category);
+}
+
+function sortPatterns(patterns: readonly CommunityPattern[]): CommunityPattern[] {
+    return [...patterns].sort((a, b) =>
+        patternCategoryOrder(a.category) - patternCategoryOrder(b.category)
+        || a.name.localeCompare(b.name)
+    );
+}
+
+function validatePatternRef(ref: string): string {
+    const match = PATTERN_REF_RE.exec(ref);
+    if (match === null) throw new Error("invalid pattern.link.ref");
+    const category = match[1];
+    if (category === undefined || !CATEGORY_SET.has(category)) throw new Error("invalid pattern.link.ref");
+    return ref;
+}
+
+function validateLinks(value: unknown): readonly CommunityPatternLink[] | undefined {
+    if (value === undefined) return undefined;
+    if (!Array.isArray(value)) throw new Error("invalid pattern.links");
+    return value.map((link) => {
+        if (!isRecord(link)) throw new Error("invalid pattern.link");
+        const rel = str(link.rel, "pattern.link.rel");
+        if (!LINK_REL_SET.has(rel)) throw new Error("invalid pattern.link");
+        const ref = validatePatternRef(str(link.ref, "pattern.link.ref").trim());
+        return { rel: rel as PatternLinkRel, ref };
+    });
+}
+
+function validateEvidence(value: unknown): CommunityPatternEvidence {
+    if (!isRecord(value)) throw new Error("invalid pattern.evidence");
+    const sessions = finiteNumber(value.sessions, "pattern.evidence.sessions");
+    const confidence = finiteNumber(value.confidence, "pattern.evidence.confidence");
+    if (confidence > 1) throw new Error("invalid pattern.evidence.confidence");
+    const trend = optionalStr(value.trend, "pattern.evidence.trend");
+    if (trend !== undefined && !TREND_SET.has(trend)) throw new Error("invalid pattern.evidence.trend");
+    return {
+        sessions,
+        confidence,
+        ...(value.last_reinforced === undefined ? {} : { last_reinforced: str(value.last_reinforced, "pattern.evidence.last_reinforced") }),
+        ...(trend === undefined ? {} : { trend: trend as PatternTrend }),
+    };
+}
+
+export function validateCommunityPattern(value: unknown, path: string): CommunityPattern {
+    const pathParts = parsePatternPath(path);
+    if (pathParts === null) throw new Error("invalid community pattern path");
+    if (!isRecord(value)) throw new Error("invalid pattern");
+
+    const category = str(value.category, "pattern.category").trim();
+    const name = str(value.name, "pattern.name").trim();
+    if (!CATEGORY_SET.has(category)) throw new Error("invalid pattern.category");
+    if (category !== pathParts.category) throw new Error(`category must match path (${pathParts.category})`);
+    if (name !== pathParts.name) throw new Error(`name must match path (${pathParts.name})`);
+
+    const evidence = validateEvidence(value.evidence);
+    const links = validateLinks(value.links);
+    const base = {
+        key: `${pathParts.category}/${pathParts.name}`,
+        category: pathParts.category,
+        name: pathParts.name,
+        evidence,
+        ...(links === undefined ? {} : { links }),
+    };
+
+    if (category === "stack-choice") {
+        const slot = str(value.slot, "pattern.slot").trim();
+        if (slot === "") throw new Error("invalid pattern.slot");
+        const over = maybeStringArray(value.over, "pattern.over");
+        const context = optionalStr(value.context, "pattern.context");
+        return {
+            ...base,
+            category: "stack-choice",
+            slot,
+            ...(over === undefined ? {} : { over }),
+            ...(context === undefined ? {} : { context }),
+        };
+    }
+
+    if (!PROSE_CATEGORY_SET.has(category)) throw new Error("invalid pattern.category");
+    const summary = str(value.summary, "pattern.summary").trim();
+    if (summary === "") throw new Error("invalid pattern.summary");
+    return {
+        ...base,
+        category: category as ProsePatternCategory,
+        summary,
+    };
+}
+
+export function communityPatternRawUrl(path: string): string {
+    if (parsePatternPath(path) === null) throw new Error("invalid community pattern path");
+    return `${REPO_RAW}/${path}`;
+}
+
+export function communityPatternCommitsUrl(path: string): string {
+    if (parsePatternPath(path) === null) throw new Error("invalid community pattern path");
+    return `${REPO_API}/commits?sha=main&path=${encodeURIComponent(path)}&per_page=1`;
+}
+
+async function fetchJson(url: string, fetchImpl: FetchLike): Promise<unknown> {
+    const response = await fetchImpl(url);
+    if (response.status === 404) throw Object.assign(new Error("not found"), { notFound: true });
+    if (!response.ok) throw new Error(`fetch failed (${response.status})`);
+    return response.json();
+}
+
+function validateTreePaths(value: unknown): string[] {
+    if (!isRecord(value) || !Array.isArray(value.tree)) throw new Error("invalid pattern tree");
+    if (value.truncated === true) throw new Error("pattern tree truncated");
+    const paths: string[] = [];
+    for (const row of value.tree) {
+        if (!isRecord(row) || row.type !== "blob" || typeof row.path !== "string") continue;
+        if (parsePatternPath(row.path) !== null) paths.push(row.path);
+    }
+    return paths.sort((a, b) => {
+        const ap = parsePatternPath(a);
+        const bp = parsePatternPath(b);
+        if (ap === null || bp === null) return a.localeCompare(b);
+        return patternCategoryOrder(ap.category) - patternCategoryOrder(bp.category)
+            || ap.name.localeCompare(bp.name);
+    });
+}
+
+async function fetchPatternAuthor(path: string, fetchImpl: FetchLike): Promise<CommunityPatternAuthor | undefined> {
+    try {
+        const raw = await fetchJson(communityPatternCommitsUrl(path), fetchImpl);
+        if (!Array.isArray(raw)) return undefined;
+        const first = raw[0];
+        if (!isRecord(first) || !isRecord(first.author)) return undefined;
+        const login = first.author.login;
+        return typeof login === "string" && LOGIN_RE.test(login) ? { login } : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function withAuthor(pattern: CommunityPattern, author: CommunityPatternAuthor | undefined): CommunityPattern {
+    return author === undefined ? pattern : { ...pattern, author };
+}
+
+export async function fetchCommunityPatterns(
+    opts: { readonly fetch?: FetchLike } = {},
+): Promise<CommunityPatternsResult> {
+    const fetchImpl = opts.fetch ?? globalThis.fetch.bind(globalThis);
+    const paths = validateTreePaths(await fetchJson(COMMUNITY_PATTERN_TREE_URL, fetchImpl));
+    const settled = await Promise.all(paths.map(async (path): Promise<
+        | { readonly kind: "pattern"; readonly pattern: CommunityPattern }
+        | { readonly kind: "drop"; readonly drop: CommunityPatternDrop }
+    > => {
+        try {
+            const raw = await fetchJson(communityPatternRawUrl(path), fetchImpl);
+            const pattern = validateCommunityPattern(raw, path);
+            const author = await fetchPatternAuthor(path, fetchImpl);
+            return { kind: "pattern", pattern: withAuthor(pattern, author) };
+        } catch (error) {
+            return {
+                kind: "drop",
+                drop: { path, reason: error instanceof Error ? error.message : String(error) },
+            };
+        }
+    }));
+
+    const patterns: CommunityPattern[] = [];
+    const dropped: CommunityPatternDrop[] = [];
+    for (const row of settled) {
+        if (row.kind === "pattern") patterns.push(row.pattern);
+        else dropped.push(row.drop);
+    }
+    return { patterns: sortPatterns(patterns), dropped };
+}
+
+export function groupPatternsByCategory(patterns: readonly CommunityPattern[]): PatternCategoryGroup[] {
+    const sorted = sortPatterns(patterns);
+    return PATTERN_CATEGORIES.map((category) => {
+        const rows = sorted.filter((pattern) => pattern.category === category);
+        return {
+            category,
+            label: PATTERN_CATEGORY_LABELS[category],
+            count: rows.length,
+            patterns: rows,
+        };
+    });
+}
+
+export function patternAnchorId(ref: string): string {
+    const slug = ref.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+    return `pattern-${slug}`;
+}

--- a/apps/site/app/routes/-patterns.test.ts
+++ b/apps/site/app/routes/-patterns.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+const src = await Bun.file(new URL("./patterns.tsx", import.meta.url)).text();
+const headerSrc = await Bun.file(new URL("../components/landing-sections/site-header.tsx", import.meta.url)).text();
+
+describe("patterns route", () => {
+    test("uses the validated app/lib fetch layer", () => {
+        expect(src).toContain("fetchCommunityPatterns");
+        expect(src).toContain("groupPatternsByCategory");
+    });
+
+    test("renders category counts, relationship anchors, and author profile links", () => {
+        expect(src).toContain("PatternCategorySection");
+        expect(src).toContain("patternAnchorId");
+        expect(src).toContain("relLabel");
+        expect(src).toContain('to="/u/$login"');
+    });
+
+    test("empty state is a contribution CTA", () => {
+        expect(src).toContain("ax contribute pattern");
+    });
+
+    test("top navigation exposes the existing patterns route", () => {
+        expect(headerSrc).toContain('to="/patterns"');
+        expect(headerSrc).toContain("Patterns");
+    });
+});

--- a/apps/site/app/routes/patterns.tsx
+++ b/apps/site/app/routes/patterns.tsx
@@ -4,18 +4,22 @@ import { useEffect, useMemo, useState } from "react";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
 import { SiteHeader } from "~/components/landing-sections/site-header";
 import {
-    fetchPatternStats,
-    formatCompact,
-    trendingPatterns,
-    type PatternStats,
-    type PatternStatsRow,
-} from "@ax/lib/shared/community";
+    fetchCommunityPatterns,
+    groupPatternsByCategory,
+    patternAnchorId,
+    PATTERN_CATEGORY_LABELS,
+    type CommunityPattern,
+    type CommunityPatternsResult,
+    type PatternCategoryGroup,
+    type PatternLinkRel,
+} from "~/lib/community-patterns";
+import { formatCompact } from "@ax/lib/shared/community";
 
 export const Route = createFileRoute("/patterns")({
     head: () => ({
         meta: [
             { title: "ax patterns - community recovery mesh" },
-            { name: "description", content: "Community taste patterns aggregated from published ax profiles, including cross-user failure to recovery joins." },
+            { name: "description", content: "Community taste patterns from the ax registry, grouped by category with linked recoveries and conflicts." },
         ],
     }),
     component: PatternsPage,
@@ -25,17 +29,17 @@ type State =
     | { kind: "loading" }
     | { kind: "empty" }
     | { kind: "error"; message: string }
-    | { kind: "ready"; stats: PatternStats };
+    | { kind: "ready"; result: CommunityPatternsResult };
 
 function PatternsPage() {
     const [state, setState] = useState<State>({ kind: "loading" });
 
     useEffect(() => {
         let alive = true;
-        fetchPatternStats()
-            .then((stats) => {
+        fetchCommunityPatterns()
+            .then((result) => {
                 if (!alive) return;
-                setState(Object.keys(stats.patterns).length === 0 ? { kind: "empty" } : { kind: "ready", stats });
+                setState({ kind: "ready", result });
             })
             .catch((e: unknown) => {
                 if (!alive) return;
@@ -45,73 +49,54 @@ function PatternsPage() {
         return () => { alive = false; };
     }, []);
 
-    const rows = useMemo(
-        () => (state.kind === "ready" ? trendingPatterns(state.stats) : []),
+    const groups = useMemo(
+        () => state.kind === "ready" ? groupPatternsByCategory(state.result.patterns) : [],
         [state],
     );
     const totals = useMemo(() => {
-        if (state.kind !== "ready") return { sessions: 0, recoveries: 0 };
-        const sessions = rows.reduce((sum, [, row]) => sum + row.sessions, 0);
-        const recoveries = rows.reduce((sum, [, row]) => sum + recoveryEntries(row).length, 0);
-        return { sessions, recoveries };
-    }, [rows, state]);
+        if (state.kind !== "ready") return { patterns: 0, sessions: 0, links: 0, dropped: 0 };
+        return {
+            patterns: state.result.patterns.length,
+            sessions: state.result.patterns.reduce((sum, p) => sum + p.evidence.sessions, 0),
+            links: state.result.patterns.reduce((sum, p) => sum + (p.links?.length ?? 0), 0),
+            dropped: state.result.dropped.length,
+        };
+    }, [state]);
 
     return (
         <>
             <SiteHeader />
             <main className="patterns-page">
                 <header className="pt-head">
+                    <p className="lf-eyebrow">community registry</p>
                     <h1>patterns</h1>
                     <p className="muted">
-                        Taste patterns published by builders, folded into one community mesh. Failure modes link to recovery patterns when another builder has contributed the fix.
+                        Shared taste patterns from <code>community/patterns/</code>, grouped by the closed category enum. Relationship links stay inside this page so recovery paths are inspectable without trusting user HTML.
                     </p>
                     {state.kind === "ready" && (
                         <p className="pt-meta">
-                            <strong>{rows.length}</strong> patterns
-                            {" · "}<strong>{formatCompact(totals.sessions)}</strong> evidence sessions
-                            {" · "}<strong>{totals.recoveries}</strong> recovery joins
-                            {state.stats.compiled_at !== "" && (
-                                <> · compiled {state.stats.compiled_at.slice(0, 16).replace("T", " ")} UTC</>
-                            )}
-                            {state.stats.dropped.length > 0 && (
-                                <> · {state.stats.dropped.length} dropped rows reported</>
-                            )}
+                            <strong>{totals.patterns}</strong> patterns
+                            {" / "}<strong>{formatCompact(totals.sessions)}</strong> evidence sessions
+                            {" / "}<strong>{totals.links}</strong> registry links
+                            {totals.dropped > 0 && <> / {totals.dropped} dropped files</>}
                         </p>
                     )}
                 </header>
 
-                {state.kind === "loading" && <p className="muted">loading...</p>}
+                {state.kind === "loading" && <p className="pf-loading">loading patterns...</p>}
                 {state.kind === "empty" && <EmptyPatterns />}
-                {state.kind === "error" && <p className="muted">couldn't load patterns: {state.message}</p>}
+                {state.kind === "error" && <p className="pf-loading">couldn't load patterns: {state.message}</p>}
 
-                {state.kind === "ready" && rows.length > 0 && (
-                    <table className="pt-table">
-                        <thead>
-                            <tr>
-                                <th className="pt-rank">#</th>
-                                <th>pattern</th>
-                                <th className="pt-num">builders</th>
-                                <th className="pt-num">sessions</th>
-                                <th>recovery joins</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {rows.map(([key, row], i) => (
-                                <tr key={key} data-lead={i === 0}>
-                                    <td className="pt-rank">{i + 1}</td>
-                                    <td className="pt-name-cell">
-                                        <span className="pt-cat">{row.category}</span>
-                                        <span className="pt-name">{row.name}</span>
-                                    </td>
-                                    <td className="pt-num">{formatCompact(row.users)}</td>
-                                    <td className="pt-num">{formatCompact(row.sessions)}</td>
-                                    <td className="pt-recoveries">
-                                        <RecoveryList row={row} />
-                                    </td>
-                                </tr>
+                {state.kind === "ready" && totals.patterns === 0 && <EmptyPatterns dropped={state.result.dropped.length} />}
+                {state.kind === "ready" && totals.patterns > 0 && (
+                    <>
+                        <CategoryNav groups={groups} />
+                        <div className="pt-category-stack">
+                            {groups.map((group) => (
+                                <PatternCategorySection key={group.category} group={group} />
                             ))}
-                        </tbody>
-                    </table>
+                        </div>
+                    </>
                 )}
             </main>
             <SiteFooter />
@@ -119,42 +104,155 @@ function PatternsPage() {
     );
 }
 
-function recoveryEntries(row: PatternStatsRow): Array<readonly [string, { readonly users: number; readonly sessions: number }]> {
-    return Object.entries(row.recovered_by ?? {})
-        .sort(([ak, a], [bk, b]) => b.users - a.users || b.sessions - a.sessions || ak.localeCompare(bk));
+function CategoryNav({ groups }: { readonly groups: readonly PatternCategoryGroup[] }) {
+    return (
+        <nav className="pt-category-nav" aria-label="pattern categories">
+            {groups.map((group) => (
+                <a href={`#patterns-${group.category}`} key={group.category}>
+                    <span>{group.label}</span>
+                    <strong>{group.count}</strong>
+                </a>
+            ))}
+        </nav>
+    );
 }
 
-function RecoveryList({ row }: { readonly row: PatternStatsRow }) {
-    const recoveries = recoveryEntries(row);
-    if (recoveries.length === 0) return <span className="pt-none">-</span>;
+function PatternCategorySection({ group }: { readonly group: PatternCategoryGroup }) {
     return (
-        <ul className="pt-recovery-list">
-            {recoveries.map(([key, recovery]) => {
-                const slash = key.indexOf("/");
-                const name = slash === -1 ? key : key.slice(slash + 1);
-                return (
-                    <li key={key}>
-                        <span className="pt-recovery-name">{name}</span>
-                        <span className="pt-recovery-count">
-                            {formatCompact(recovery.users)} builders · {formatCompact(recovery.sessions)} sessions
-                        </span>
-                    </li>
-                );
-            })}
+        <section className="pt-category-section" id={`patterns-${group.category}`} data-empty={group.count === 0}>
+            <div className="pt-category-head">
+                <div>
+                    <p className="pt-cat">{group.category}</p>
+                    <h2>{group.label}</h2>
+                </div>
+                <span className="pt-category-count">{group.count}</span>
+            </div>
+
+            {group.count === 0 ? (
+                <p className="pt-category-empty">
+                    No {group.label.toLowerCase()} patterns have landed in the registry yet.
+                </p>
+            ) : (
+                <div className="pt-pattern-grid">
+                    {group.patterns.map((pattern) => (
+                        <PatternCard pattern={pattern} key={pattern.key} />
+                    ))}
+                </div>
+            )}
+        </section>
+    );
+}
+
+function PatternCard({ pattern }: { readonly pattern: CommunityPattern }) {
+    return (
+        <article className="pt-pattern-card" id={patternAnchorId(pattern.key)}>
+            <div className="pt-pattern-top">
+                <span className="pt-cat">{PATTERN_CATEGORY_LABELS[pattern.category]}</span>
+                <h3>{pattern.name}</h3>
+            </div>
+
+            <PatternBody pattern={pattern} />
+            <PatternEvidence pattern={pattern} />
+            <PatternRelations pattern={pattern} />
+
+            <footer className="pt-pattern-foot">
+                {pattern.author !== undefined ? (
+                    <Link to="/u/$login" params={{ login: pattern.author.login }} search={{ vs: undefined }}>
+                        @{pattern.author.login}
+                    </Link>
+                ) : (
+                    <span>author pending</span>
+                )}
+                <a href={`#${patternAnchorId(pattern.key)}`} aria-label={`Link to ${pattern.key}`}>#{pattern.key}</a>
+            </footer>
+        </article>
+    );
+}
+
+function PatternBody({ pattern }: { readonly pattern: CommunityPattern }) {
+    if (pattern.category === "stack-choice") {
+        return (
+            <p className="pt-summary">
+                <span className="pt-slot">{pattern.slot}</span>
+                {" preference for "}<strong>{pattern.name}</strong>
+                {pattern.over !== undefined && pattern.over.length > 0 && <> over {pattern.over.join(", ")}</>}
+                {pattern.context !== undefined && <> in {pattern.context}</>}.
+            </p>
+        );
+    }
+    return <p className="pt-summary">{pattern.summary}</p>;
+}
+
+function PatternEvidence({ pattern }: { readonly pattern: CommunityPattern }) {
+    return (
+        <dl className="pt-evidence">
+            <div>
+                <dt>sessions</dt>
+                <dd>{formatCompact(pattern.evidence.sessions)}</dd>
+            </div>
+            <div>
+                <dt>confidence</dt>
+                <dd>{formatPct(pattern.evidence.confidence)}</dd>
+            </div>
+            <div>
+                <dt>trend</dt>
+                <dd>{pattern.evidence.trend ?? "untracked"}</dd>
+            </div>
+            {pattern.evidence.last_reinforced !== undefined && (
+                <div>
+                    <dt>reinforced</dt>
+                    <dd>{pattern.evidence.last_reinforced}</dd>
+                </div>
+            )}
+        </dl>
+    );
+}
+
+function PatternRelations({ pattern }: { readonly pattern: CommunityPattern }) {
+    const links = pattern.links ?? [];
+    if (links.length === 0) {
+        return <p className="pt-no-links">No registry links yet.</p>;
+    }
+    return (
+        <ul className="pt-link-list">
+            {links.map((link, i) => (
+                <li key={`${link.rel}-${link.ref}-${i}`} data-rel={link.rel}>
+                    <span>{relLabel(link.rel)}</span>
+                    <a href={`#${patternAnchorId(link.ref)}`}>{displayRef(link.ref)}</a>
+                </li>
+            ))}
         </ul>
     );
 }
 
-function EmptyPatterns() {
+function relLabel(rel: PatternLinkRel): string {
+    switch (rel) {
+        case "recovered-by": return "recovered by";
+        case "pairs-with": return "pairs with";
+        case "conflicts-with": return "conflicts with";
+    }
+}
+
+function displayRef(ref: string): string {
+    const slash = ref.indexOf("/");
+    return slash === -1 ? ref : ref.slice(slash + 1);
+}
+
+function formatPct(value: number): string {
+    return `${Math.round(value * 100)}%`;
+}
+
+function EmptyPatterns({ dropped = 0 }: { readonly dropped?: number }) {
     return (
-        <section className="leaders-founding">
+        <section className="leaders-founding pt-empty">
             <p className="lf-eyebrow">community mesh</p>
             <h2 className="lf-headline">No shared patterns have landed yet.</h2>
             <p className="lf-lede">
-                Patterns appear here as builders publish profiles with taste patterns. The first rows will show adoption counts, then failure-to-recovery joins as the mesh connects.
+                Patterns appear here after builders contribute reviewed taste-pattern JSON to the registry. The page will show category counts, evidence, authors, and recovery links as soon as the first files merge.
             </p>
             <p className="lf-foot muted">
-                Start from <Link to="/leaders">the community leaders</Link> or publish your own aggregate profile with <code>ax profile publish</code>.
+                Start from <Link to="/leaders">the community leaders</Link> or run <code>ax contribute pattern</code> to open a reviewed registry PR.
+                {dropped > 0 && <> {dropped} registry file(s) were skipped because they did not validate.</>}
             </p>
         </section>
     );

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -12280,70 +12280,226 @@ footer.site-footer { padding: 48px 32px 56px; }
 }
 
 /* ----- patterns: community taste + recovery mesh ----- */
+.pt-head { margin-bottom: 24px; }
 .pt-head h1 { margin: 0 0 8px; }
-.pt-head .muted { max-width: 68ch; margin: 0 0 10px; }
+.pt-head .muted { max-width: 74ch; margin: 0 0 10px; }
+.pt-head code,
+.pt-empty code {
+    font-family: var(--mono);
+    font-size: 0.88em;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+.pt-empty code { white-space: nowrap; }
 .pt-meta { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); margin: 0 0 4px; }
 .pt-meta strong { color: var(--ink); }
 
-.pt-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 22px 0 0;
+.pt-category-nav {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(165px, 1fr));
+    gap: 8px;
+    margin: 26px 0 42px;
+}
+.pt-category-nav a {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    border-radius: 6px;
+    padding: 10px 12px;
+    text-decoration: none;
+    color: var(--ink);
+}
+.pt-category-nav a:hover { border-color: color-mix(in srgb, var(--ink) 40%, var(--line)); }
+.pt-category-nav span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.84rem;
+}
+.pt-category-nav strong {
     font-family: var(--mono);
-    font-size: 0.86rem;
+    font-size: 0.78rem;
+    color: var(--green);
+    font-weight: 700;
 }
-.pt-table thead th {
-    font-size: 0.72rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--muted);
-    font-weight: 600;
+
+.pt-category-stack { display: grid; gap: 48px; padding-bottom: 28px; }
+.pt-category-section { scroll-margin-top: 96px; }
+.pt-category-section[data-empty="true"] { opacity: 0.72; }
+.pt-category-head {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 18px;
     border-bottom: 1px solid var(--line);
-    padding: 0 12px 8px;
-    text-align: left;
+    padding-bottom: 12px;
+    margin-bottom: 14px;
 }
-.pt-table tbody td {
-    padding: 13px 12px;
-    border-bottom: 1px solid var(--line);
-    vertical-align: top;
+.pt-category-head h2 {
+    margin: 3px 0 0;
+    font-family: var(--serif);
+    font-size: clamp(1.65rem, 4vw, 2.55rem);
+    line-height: 1;
+    font-weight: 500;
 }
-.pt-table tbody tr:hover { background: color-mix(in srgb, var(--panel) 60%, transparent); }
-.pt-table tbody tr[data-lead="true"] td { background: color-mix(in srgb, var(--green) 9%, transparent); }
-.pt-rank { width: 1%; color: var(--muted); font-variant-numeric: tabular-nums; }
-.pt-table tbody tr[data-lead="true"] .pt-rank { color: var(--green); font-weight: 700; }
-.pt-num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
-.pt-name-cell { min-width: 220px; }
+.pt-category-count {
+    min-width: 44px;
+    text-align: right;
+    font-family: var(--mono);
+    font-size: 1.45rem;
+    color: var(--green);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
 .pt-cat {
     display: block;
     color: var(--green);
     font-size: 0.68rem;
     letter-spacing: 0.05em;
     text-transform: uppercase;
+    font-family: var(--mono);
 }
-.pt-name {
-    display: block;
-    margin-top: 3px;
-    color: var(--ink);
-    font-size: 0.98rem;
-    white-space: normal;
+.pt-category-empty {
+    margin: 0;
+    padding: 10px 0 2px;
+    color: var(--muted);
+    font-size: 0.92rem;
+}
+
+.pt-pattern-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
+    gap: 14px;
+}
+.pt-pattern-card {
+    min-width: 0;
+    scroll-margin-top: 96px;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    border-radius: 6px;
+    padding: 17px 18px 15px;
+}
+.pt-pattern-top {
+    display: grid;
+    gap: 4px;
+    margin-bottom: 10px;
+}
+.pt-pattern-top h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    line-height: 1.15;
     overflow-wrap: anywhere;
 }
-.pt-recoveries { min-width: 260px; }
-.pt-none { color: var(--muted); }
-.pt-recovery-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 7px; }
-.pt-recovery-list li {
+.pt-summary {
+    margin: 0;
+    min-height: 3.4em;
+    font-size: 0.92rem;
+    line-height: 1.48;
+    color: color-mix(in srgb, var(--ink) 86%, var(--muted));
+}
+.pt-slot {
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    color: var(--muted);
+}
+.pt-evidence {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 7px;
+    margin: 16px 0 14px;
+}
+.pt-evidence div {
+    min-width: 0;
+    border-top: 1px solid var(--line);
+    padding-top: 8px;
+}
+.pt-evidence dt {
+    font-family: var(--mono);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+}
+.pt-evidence dd {
+    margin: 2px 0 0;
+    font-family: var(--mono);
+    font-size: 0.88rem;
+    color: var(--ink);
+    overflow-wrap: anywhere;
+}
+.pt-no-links {
+    margin: 0;
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    color: var(--muted);
+}
+.pt-link-list {
+    list-style: none;
+    display: grid;
+    gap: 7px;
+    margin: 0;
+    padding: 0;
+}
+.pt-link-list li {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: baseline;
-    gap: 12px;
+    gap: 10px;
+    border-left: 2px solid var(--line);
+    padding-left: 9px;
 }
-.pt-recovery-name { color: var(--ink); overflow-wrap: anywhere; }
-.pt-recovery-count { color: var(--muted); font-size: 0.76rem; white-space: nowrap; }
+.pt-link-list li[data-rel="recovered-by"] { border-left-color: var(--green); }
+.pt-link-list li[data-rel="pairs-with"] { border-left-color: var(--blue); }
+.pt-link-list li[data-rel="conflicts-with"] { border-left-color: var(--red); }
+.pt-link-list span {
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.pt-link-list a {
+    min-width: 0;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    color: var(--ink);
+    text-align: right;
+    overflow-wrap: anywhere;
+}
+.pt-pattern-foot {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 16px;
+    padding-top: 12px;
+    border-top: 1px solid var(--line);
+    font-family: var(--mono);
+    font-size: 0.77rem;
+    color: var(--muted);
+}
+.pt-pattern-foot a {
+    color: var(--ink);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+    overflow-wrap: anywhere;
+}
 @media (max-width: 760px) {
-    .pt-table { display: block; overflow-x: auto; }
-    .pt-recoveries { min-width: 220px; }
-    .pt-recovery-list li { grid-template-columns: minmax(0, 1fr); gap: 2px; }
-    .pt-recovery-count { white-space: normal; }
+    .pt-category-nav { grid-template-columns: minmax(0, 1fr); margin-bottom: 34px; }
+    .pt-category-head { align-items: start; }
+    .pt-pattern-grid { grid-template-columns: minmax(0, 1fr); }
+    .pt-summary { min-height: 0; }
+    .pt-evidence { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .pt-link-list li { grid-template-columns: minmax(0, 1fr); gap: 2px; }
+    .pt-link-list a { text-align: left; }
+    .pt-pattern-foot { flex-direction: column; gap: 5px; }
 }
 
 /* ----- states ----- */


### PR DESCRIPTION
## Summary

- Extends the existing `/patterns` route to browse validated `community/patterns/` registry files instead of creating a duplicate page.
- Adds an app-local manual validation/fetch layer for pattern JSON, GitHub tree discovery, author lookup, closed-category grouping, and stable in-page anchors.
- Renders pattern evidence, author profile links, relationship anchors, and an `ax contribute pattern` empty-state CTA in the dossier-style site UI.

## Validation

- `bun test apps/site/app/lib/community-patterns.test.ts apps/site/app/routes/-patterns.test.ts`
- `bun run typecheck` (exit 0; existing Effect-plugin diagnostics are outside this change)
- `cd apps/site && bun run typecheck`
- `cd apps/site && bun run build` (exit 0; existing CSS/chunk warnings)
- Screenshot review via `bunx agent-browser`: `/tmp/ax-patterns-mobile.png`, `/tmp/ax-patterns-desktop.png`

Closes #373

---

_Generated with [ax](https://github.com/Necmttn/ax)._
