### PR TITLE
Add State of Agent Engineering report page

### DIFF
--- a/apps/community-worker/src/worker.ts
+++ b/apps/community-worker/src/worker.ts
@@ -60,9 +60,19 @@ export default {
         if (request.method === "OPTIONS") return new Response(null, { status: 204, headers: CORS });
 
         if (request.method === "GET") {
+            const stateYear = stateYearFromPath(url.pathname);
+            if (stateYear !== null) {
+                const body = await env.BOARD.get("state");
+                if (body === null) return json({ error: "not compiled yet" }, 503);
+                if (!stateBodyMatchesYear(body, stateYear)) return json({ error: "not found" }, 404);
+                return new Response(body, {
+                    headers: { "content-type": "application/json", "cache-control": "public, max-age=300", ...CORS },
+                });
+            }
+
             const key = (KV_KEYS as Record<string, string>)[url.pathname];
             if (key === undefined) {
-                return json({ ok: true, endpoints: Object.keys(KV_KEYS) });
+                return json({ ok: true, endpoints: [...Object.keys(KV_KEYS), "/state/{year}"] });
             }
             const body = await env.BOARD.get(key);
             if (body === null) return json({ error: "not compiled yet" }, 503);
@@ -147,6 +157,20 @@ function touchesRegistrations(payload: PushPayload): boolean {
 }
 
 const encoder = new TextEncoder();
+
+function stateYearFromPath(pathname: string): number | null {
+    const match = /^\/state\/(\d{4})$/.exec(pathname);
+    return match ? Number(match[1]) : null;
+}
+
+function stateBodyMatchesYear(body: string, year: number): boolean {
+    try {
+        const parsed = JSON.parse(body) as { year?: unknown };
+        return parsed.year === year;
+    } catch {
+        return false;
+    }
+}
 
 /**
  * Verify GitHub's `x-hub-signature-256` HMAC over the raw body. Constant-time

--- a/apps/site/app/components/state-report.test.tsx
+++ b/apps/site/app/components/state-report.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { STATE_MIN_USERS } from "../lib/state-report";
+import { StateReportDossier } from "./state-report";
+import type { StateReport } from "@ax/lib/shared/community";
+
+const publicReport: StateReport = {
+    year: 2026,
+    users: STATE_MIN_USERS,
+    harness_mix: { claude: 22, codex: 13 },
+    model_share: { "claude-sonnet": 19, "gpt-5": 8 },
+    skill_adoption: {
+        tdd: 18,
+        "agent-browser": 11,
+        "writing-plans": 9,
+    },
+};
+
+function render(report: StateReport): string {
+    return renderToStaticMarkup(<StateReportDossier report={report} />);
+}
+
+describe("StateReportDossier", () => {
+    test("renders measured charts once the minimum-N gate is met", () => {
+        const html = render(publicReport);
+        expect(html).toContain("measured, not asked");
+        expect(html).toContain("Harness mix");
+        expect(html).toContain("Model share");
+        expect(html).toContain("Skill adoption top 20");
+        expect(html).toContain("claude");
+        expect(html).toContain("gpt-5");
+        expect(html).toContain("agent-browser");
+        expect(html).toContain("st-bar");
+        expect(html).not.toContain("Founding sample");
+    });
+
+    test("renders teaser CTA below the minimum-N gate instead of charts", () => {
+        const html = render({ ...publicReport, users: STATE_MIN_USERS - 1 });
+        expect(html).toContain("Founding sample");
+        expect(html).toContain("ax profile publish");
+        expect(html).toContain(`${STATE_MIN_USERS - 1}`);
+        expect(html).toContain(`${STATE_MIN_USERS}`);
+        expect(html).not.toContain("st-bar");
+    });
+});

--- a/apps/site/app/components/state-report.tsx
+++ b/apps/site/app/components/state-report.tsx
@@ -1,0 +1,179 @@
+import { formatCompact, type StateReport } from "@ax/lib/shared/community";
+import {
+    STATE_MIN_USERS,
+    hasEnoughStateUsers,
+    stateRows,
+    topStateRows,
+    type StateRow,
+} from "../lib/state-report";
+
+const pctFmt = new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 0,
+});
+
+function fmtPct(share: number): string {
+    return pctFmt.format(Math.max(0, Math.min(1, share)));
+}
+
+function displaySkill(label: string): { readonly source: string | null; readonly name: string } {
+    const sep = label.indexOf(":");
+    if (sep === -1) return { source: null, name: label };
+    const source = label.slice(0, sep);
+    const rest = label.slice(sep + 1);
+    return { source, name: rest.startsWith(`${source}:`) ? rest.slice(source.length + 1) : rest };
+}
+
+export function StateReportDossier({
+    report,
+    minUsers = STATE_MIN_USERS,
+}: {
+    readonly report: StateReport;
+    readonly minUsers?: number;
+}) {
+    if (!hasEnoughStateUsers(report, minUsers)) {
+        return <StateReportTeaser report={report} minUsers={minUsers} />;
+    }
+
+    const harnessRows = stateRows(report.harness_mix, report.users);
+    const modelRows = stateRows(report.model_share, report.users);
+    const skillRows = topStateRows(report.skill_adoption, 20, report.users);
+    const skillTotal = Object.keys(report.skill_adoption).length;
+
+    return (
+        <article className="state-report-doc">
+            <header className="st-hero">
+                <p className="st-eyebrow">state of agent engineering / {report.year}</p>
+                <h1>State of Agent Engineering {report.year}</h1>
+                <p className="st-lede">
+                    <strong>measured, not asked</strong> - a field report compiled from public opt-in
+                    ax profiles, not survey recall.
+                </p>
+                <div className="st-vitals" aria-label="report vitals">
+                    <Vital value={formatCompact(report.users)} label="registered builders" />
+                    <Vital value={formatCompact(harnessRows.length)} label="harnesses observed" />
+                    <Vital value={formatCompact(modelRows.length)} label="models observed" />
+                    <Vital value={formatCompact(skillTotal)} label="skills observed" />
+                </div>
+            </header>
+
+            <section className="st-method">
+                <p>
+                    Survey reports ask what people remember using. This page counts what their local
+                    coding agents actually emitted into ax: harnesses, models, and skills aggregated
+                    into anonymous distributions.
+                </p>
+            </section>
+
+            <section className="st-chart-grid" aria-label="observed distributions">
+                <StateBarChart title="Harness mix" note="builders with each harness in their published window" rows={harnessRows} accent="green" />
+                <StateBarChart title="Model share" note="builders with each model represented" rows={modelRows} accent="blue" />
+            </section>
+
+            <section className="st-section" aria-labelledby="skill-adoption-heading">
+                <div className="st-section-head">
+                    <p className="st-eyebrow">adoption curve</p>
+                    <h2 id="skill-adoption-heading">Skill adoption top 20</h2>
+                    <p>
+                        Ranked by distinct builders, capped at twenty so early one-off skills do not
+                        overwhelm the shared signal.
+                    </p>
+                </div>
+                <ol className="st-skill-chart">
+                    {skillRows.map((row, index) => {
+                        const skill = displaySkill(row.label);
+                        const max = Math.max(1, skillRows[0]?.count ?? 1);
+                        return (
+                            <li className="st-skill-row" key={row.label}>
+                                <span className="st-rank">{index + 1}</span>
+                                <span className="st-skill-name">
+                                    {skill.source && <span className="st-source">{skill.source}</span>}
+                                    {skill.name}
+                                </span>
+                                <span className="st-bar st-bar--skill" aria-hidden>
+                                    <span style={{ width: `${Math.max(3, (row.count / max) * 100)}%` }} />
+                                </span>
+                                <span className="st-count">{formatCompact(row.count)} builders</span>
+                            </li>
+                        );
+                    })}
+                </ol>
+            </section>
+        </article>
+    );
+}
+
+function StateReportTeaser({
+    report,
+    minUsers,
+}: {
+    readonly report: StateReport;
+    readonly minUsers: number;
+}) {
+    return (
+        <article className="state-report-doc state-report-doc--teaser">
+            <section className="st-teaser">
+                <p className="st-eyebrow">Founding sample</p>
+                <h1>State of Agent Engineering {report.year}</h1>
+                <p className="st-lede">
+                    <strong>measured, not asked</strong> - the report unlocks once at least{" "}
+                    <strong>{formatCompact(minUsers)}</strong> registered builders have published profiles.
+                </p>
+                <p className="st-teaser-copy">
+                    Current sample: <strong>{formatCompact(report.users)}</strong> of{" "}
+                    <strong>{formatCompact(minUsers)}</strong>. Holding the charts back keeps a tiny
+                    founding cohort from pretending to be an industry benchmark.
+                </p>
+                <div className="st-teaser-actions">
+                    <code>ax profile publish</code>
+                    <a href="/leaders">join the public board</a>
+                </div>
+            </section>
+        </article>
+    );
+}
+
+function StateBarChart({
+    title,
+    note,
+    rows,
+    accent,
+}: {
+    readonly title: string;
+    readonly note: string;
+    readonly rows: readonly StateRow[];
+    readonly accent: "green" | "blue";
+}) {
+    const max = Math.max(1, ...rows.map((r) => r.count));
+    return (
+        <section className="st-chart" data-accent={accent}>
+            <div className="st-chart-head">
+                <h2>{title}</h2>
+                <p>{note}</p>
+            </div>
+            <ol className="st-bars">
+                {rows.map((row) => (
+                    <li key={row.label}>
+                        <span className="st-label" title={row.label}>{row.label}</span>
+                        <span className="st-bar" aria-hidden>
+                            <span style={{ width: `${Math.max(3, (row.count / max) * 100)}%` }} />
+                        </span>
+                        <span className="st-count">
+                            {formatCompact(row.count)}
+                            <small>{fmtPct(row.share)}</small>
+                        </span>
+                    </li>
+                ))}
+            </ol>
+        </section>
+    );
+}
+
+function Vital({ value, label }: { readonly value: string; readonly label: string }) {
+    return (
+        <div className="st-vital">
+            <span className="st-vital-value">{value}</span>
+            <span className="st-vital-label">{label}</span>
+        </div>
+    );
+}

--- a/apps/site/app/lib/state-report.test.ts
+++ b/apps/site/app/lib/state-report.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+    STATE_MIN_USERS,
+    hasEnoughStateUsers,
+    parseStateYearParam,
+    stateRows,
+    topStateRows,
+} from "./state-report";
+import type { StateReport } from "@ax/lib/shared/community";
+
+const report: StateReport = {
+    year: 2026,
+    users: STATE_MIN_USERS,
+    harness_mix: { claude: 20, codex: 10 },
+    model_share: { "claude-sonnet": 18, "gpt-5": 7 },
+    skill_adoption: Object.fromEntries(
+        Array.from({ length: 24 }, (_, i) => [`skill-${String(i).padStart(2, "0")}`, 24 - i]),
+    ),
+};
+
+describe("state report route helpers", () => {
+    test("validates route years and rejects future years", () => {
+        expect(parseStateYearParam("2026", { nowYear: 2026 })).toBe(2026);
+        expect(parseStateYearParam("2027", { nowYear: 2026 })).toBeNull();
+        expect(parseStateYearParam("26", { nowYear: 2026 })).toBeNull();
+        expect(parseStateYearParam("2026x", { nowYear: 2026 })).toBeNull();
+    });
+
+    test("minimum-N gate opens only once the report has enough users", () => {
+        expect(hasEnoughStateUsers({ ...report, users: STATE_MIN_USERS - 1 })).toBe(false);
+        expect(hasEnoughStateUsers({ ...report, users: STATE_MIN_USERS })).toBe(true);
+    });
+
+    test("stateRows sorts distributions by count desc, then name", () => {
+        expect(stateRows({ b: 2, c: 3, a: 2 }).map((r) => r.label)).toEqual(["c", "a", "b"]);
+    });
+
+    test("stateRows can use registered users as the percentage denominator", () => {
+        expect(stateRows({ claude: 20, codex: 10 }, 25).map((r) => r.share)).toEqual([0.8, 0.4]);
+    });
+
+    test("topStateRows caps skill adoption to the top 20", () => {
+        const rows = topStateRows(report.skill_adoption, 20);
+        expect(rows).toHaveLength(20);
+        expect(rows[0]).toMatchObject({ label: "skill-00", count: 24 });
+        expect(rows.at(-1)).toMatchObject({ label: "skill-19", count: 5 });
+    });
+});

--- a/apps/site/app/lib/state-report.ts
+++ b/apps/site/app/lib/state-report.ts
@@ -1,0 +1,43 @@
+import type { StateReport } from "@ax/lib/shared/community";
+
+export const STATE_MIN_USERS = 25;
+
+export interface StateRow {
+    readonly label: string;
+    readonly count: number;
+    readonly share: number;
+}
+
+export function parseStateYearParam(
+    raw: string,
+    opts: { readonly nowYear?: number } = {},
+): number | null {
+    if (!/^\d{4}$/.test(raw)) return null;
+    const year = Number(raw);
+    const nowYear = opts.nowYear ?? new Date().getUTCFullYear();
+    if (year > nowYear) return null;
+    if (year < 2020) return null;
+    return year;
+}
+
+export function hasEnoughStateUsers(
+    report: Pick<StateReport, "users">,
+    minUsers = STATE_MIN_USERS,
+): boolean {
+    return report.users >= minUsers;
+}
+
+export function stateRows(values: Record<string, number>, denominator?: number): StateRow[] {
+    const total = denominator ?? Object.values(values).reduce((sum, n) => sum + n, 0);
+    return Object.entries(values)
+        .map(([label, count]) => ({
+            label,
+            count,
+            share: total > 0 ? count / total : 0,
+        }))
+        .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+}
+
+export function topStateRows(values: Record<string, number>, limit: number, denominator?: number): StateRow[] {
+    return stateRows(values, denominator).slice(0, limit);
+}

--- a/apps/site/app/routes/state.$year.tsx
+++ b/apps/site/app/routes/state.$year.tsx
@@ -1,0 +1,88 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { SiteFooter } from "~/components/landing-sections/site-footer";
+import { SiteHeader } from "~/components/landing-sections/site-header";
+import { StateReportDossier } from "~/components/state-report";
+import { parseStateYearParam } from "~/lib/state-report";
+import { fetchStateReport, type StateReport } from "@ax/lib/shared/community";
+
+type LoaderData = { readonly year: number };
+
+function loadStateYear({ params }: { params: { year: string } }): LoaderData {
+    const year = parseStateYearParam(params.year);
+    if (year === null) throw notFound();
+    return { year };
+}
+
+export const Route = createFileRoute("/state/$year")({
+    head: ({ loaderData }) => {
+        const year = (loaderData as LoaderData | undefined)?.year;
+        return {
+            meta: [
+                { title: year ? `State of Agent Engineering ${year} - ax` : "State of Agent Engineering - ax" },
+                {
+                    name: "description",
+                    content: "Measured, not asked: anonymized community distributions from opt-in ax profiles.",
+                },
+            ],
+        };
+    },
+    loader: loadStateYear,
+    component: StatePage,
+});
+
+type State =
+    | { kind: "loading" }
+    | { kind: "not-found" }
+    | { kind: "error"; message: string }
+    | { kind: "ready"; report: StateReport };
+
+function StatePage() {
+    const { year } = Route.useLoaderData() as LoaderData;
+    const [state, setState] = useState<State>({ kind: "loading" });
+
+    useEffect(() => {
+        let alive = true;
+        setState({ kind: "loading" });
+        fetchStateReport(year)
+            .then((report) => {
+                if (alive) setState({ kind: "ready", report });
+            })
+            .catch((e: unknown) => {
+                if (!alive) return;
+                const notFoundState =
+                    typeof e === "object" && e !== null && (e as { notFound?: boolean }).notFound === true;
+                setState(notFoundState
+                    ? { kind: "not-found" }
+                    : { kind: "error", message: e instanceof Error ? e.message : String(e) });
+            });
+        return () => { alive = false; };
+    }, [year]);
+
+    return (
+        <>
+            <SiteHeader />
+            <main className="state-page profile-v2">
+                {state.kind === "loading" && <p className="pf-loading">pulling the state report...</p>}
+                {state.kind === "not-found" && <MissingState year={year} />}
+                {state.kind === "error" && <p className="pf-loading">couldn't load state report: {state.message}</p>}
+                {state.kind === "ready" && <StateReportDossier report={state.report} />}
+            </main>
+            <SiteFooter />
+        </>
+    );
+}
+
+function MissingState({ year }: { readonly year: number }) {
+    return (
+        <section className="sk-empty">
+            <p className="sk-eyebrow">404</p>
+            <h1>state report not found</h1>
+            <p className="muted">
+                No compiled community state report exists for {year}. Published years appear
+                here after the nightly community compile writes <code>community/state/{year}.json</code>.
+            </p>
+            <a className="sk-empty-link" href="/leaders">back to leaders</a>
+        </section>
+    );
+}

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -11918,13 +11918,13 @@ footer.site-footer { padding: 48px 32px 56px; }
      mono numerals, hairline rules, paper/ink. No SaaS chrome.
    ============================================================ */
 
-.profile-page, .leaders-page, .patterns-page, .status-page, .skill-page {
+.profile-page, .leaders-page, .patterns-page, .status-page, .skill-page, .state-page {
     max-width: var(--shell-max);
     margin: 0 auto;
     padding: 32px var(--shell-pad) 96px;
 }
 @media (max-width: 640px) {
-    .profile-page, .leaders-page, .patterns-page, .status-page, .skill-page { padding-left: 20px; padding-right: 20px; }
+    .profile-page, .leaders-page, .patterns-page, .status-page, .skill-page, .state-page { padding-left: 20px; padding-right: 20px; }
 }
 
 /* ----- status: live adoption receipt (unlisted) ----- */
@@ -12067,6 +12067,262 @@ footer.site-footer { padding: 48px 32px 56px; }
 .lf-foot a, .lf-prov a { color: var(--blue); border-bottom: 1px solid transparent; }
 .lf-foot a:hover, .lf-prov a:hover { border-bottom-color: var(--blue); }
 .lf-prov { font-family: var(--mono); font-size: 0.74rem; margin: 0; }
+
+/* ----- state report: measured community distributions ----- */
+.state-report-doc { color: var(--ink); }
+.st-hero {
+    border-bottom: 2px solid var(--ink);
+    padding: 0 0 28px;
+}
+.st-eyebrow {
+    margin: 0 0 8px;
+    font-family: var(--mono);
+    font-size: 0.76rem;
+    text-transform: uppercase;
+    letter-spacing: 0;
+    color: var(--muted);
+}
+.st-hero h1,
+.st-teaser h1 {
+    margin: 0;
+    font-family: var(--serif);
+    font-size: 6.8rem;
+    line-height: 0.92;
+    font-weight: 400;
+    letter-spacing: 0;
+    max-width: 10ch;
+}
+.st-lede {
+    max-width: 62ch;
+    margin: 18px 0 0;
+    font-size: 1.04rem;
+    color: var(--muted);
+}
+.st-lede strong { color: var(--ink); font-weight: 700; }
+.st-vitals {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+    margin-top: 26px;
+}
+.st-vital {
+    min-width: 0;
+    padding: 16px 16px 14px 0;
+}
+.st-vital + .st-vital {
+    border-left: 1px solid var(--line);
+    padding-left: 16px;
+}
+.st-vital-value {
+    display: block;
+    font-family: var(--mono);
+    font-size: 2rem;
+    line-height: 1.05;
+    font-variant-numeric: tabular-nums;
+}
+.st-vital-label {
+    display: block;
+    margin-top: 5px;
+    font-family: var(--mono);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0;
+    color: var(--muted);
+}
+.st-method {
+    max-width: 74ch;
+    margin: 28px 0 0;
+    font-family: var(--mono);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--muted);
+}
+.st-chart-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 34px;
+    margin-top: 48px;
+}
+.st-chart {
+    border: 1px solid var(--ink);
+    background: var(--panel);
+    padding: 20px 20px 18px;
+    box-shadow: 4px 4px 0 color-mix(in srgb, var(--ink) 8%, transparent);
+}
+.st-chart-head {
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 12px;
+    margin-bottom: 12px;
+}
+.st-chart-head h2,
+.st-section-head h2 {
+    margin: 0;
+    font-family: var(--serif);
+    font-size: 1.55rem;
+    line-height: 1.1;
+    font-weight: 400;
+    letter-spacing: 0;
+}
+.st-chart-head p,
+.st-section-head p {
+    margin: 6px 0 0;
+    color: var(--muted);
+    font-size: 0.86rem;
+}
+.st-bars,
+.st-skill-chart {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.st-bars li {
+    display: grid;
+    grid-template-columns: minmax(96px, 0.8fr) minmax(90px, 1fr) auto;
+    align-items: center;
+    gap: 12px;
+    padding: 9px 0;
+    border-bottom: 1px solid var(--line);
+    font-family: var(--mono);
+    font-size: 0.84rem;
+}
+.st-bars li:last-child { border-bottom: 0; }
+.st-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.st-bar {
+    display: block;
+    height: 12px;
+    background: color-mix(in srgb, var(--line) 55%, transparent);
+    overflow: hidden;
+}
+.st-bar span {
+    display: block;
+    height: 100%;
+    background: var(--green);
+}
+.st-chart[data-accent="blue"] .st-bar span { background: var(--blue); }
+.st-count {
+    font-family: var(--mono);
+    color: var(--ink);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+.st-count small {
+    margin-left: 6px;
+    color: var(--muted);
+}
+.st-section { margin-top: 56px; }
+.st-section-head {
+    display: grid;
+    gap: 2px;
+    border-bottom: 1px solid var(--ink);
+    padding-bottom: 14px;
+    margin-bottom: 4px;
+}
+.st-section-head .st-eyebrow { margin-bottom: 0; }
+.st-skill-row {
+    display: grid;
+    grid-template-columns: 1.7rem minmax(0, 1fr) minmax(120px, 0.55fr) auto;
+    align-items: center;
+    gap: 14px;
+    padding: 11px 4px;
+    border-bottom: 1px solid var(--line);
+    font-family: var(--mono);
+    font-size: 0.86rem;
+}
+.st-rank {
+    color: var(--muted);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+.st-skill-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.st-source {
+    display: inline-flex;
+    margin-right: 8px;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    color: var(--muted);
+    padding: 1px 6px;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0;
+}
+.st-bar--skill span { background: var(--green); }
+.st-teaser {
+    max-width: 720px;
+    padding-top: 10px;
+}
+.state-report-doc--teaser .st-lede { color: var(--ink); }
+.st-teaser-copy {
+    max-width: 60ch;
+    margin: 18px 0 0;
+    color: var(--muted);
+}
+.st-teaser-actions {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+    margin-top: 24px;
+}
+.st-teaser-actions code {
+    font-family: var(--mono);
+    font-size: 0.86rem;
+    color: var(--ink);
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 7px 11px;
+}
+.st-teaser-actions code::before { content: "$ "; color: var(--green); }
+.st-teaser-actions a {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0;
+    color: var(--blue);
+    border-bottom: 1px solid transparent;
+}
+.st-teaser-actions a:hover { border-bottom-color: var(--blue); }
+@media (max-width: 820px) {
+    .st-vitals,
+    .st-chart-grid { grid-template-columns: minmax(0, 1fr); }
+    .st-hero h1,
+    .st-teaser h1 { font-size: 5rem; }
+    .st-vital + .st-vital {
+        border-left: 0;
+        border-top: 1px solid var(--line);
+        padding-left: 0;
+    }
+}
+@media (max-width: 640px) {
+    .st-hero h1,
+    .st-teaser h1 { font-size: 3rem; }
+    .st-bars li {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+    .st-bars .st-bar {
+        grid-column: 1 / -1;
+        grid-row: 2;
+    }
+    .st-skill-row {
+        grid-template-columns: 1.4rem minmax(0, 1fr) auto;
+        gap: 10px;
+    }
+    .st-skill-row .st-bar {
+        grid-column: 2 / -1;
+        grid-row: 2;
+    }
+}
 
 /* ----- skill dossier: adoption page for one community skill ----- */
 .sk-head {

--- a/packages/lib/src/shared/community.test.ts
+++ b/packages/lib/src/shared/community.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+    fetchStateReport,
     fetchSkillAdoption,
     fetchMember,
     fetchMembers,
     profileGistRawUrl,
     registrationRawUrl,
     skillRouteKey,
+    stateReportRawUrl,
+    stateReportUrl,
+    validateStateReport,
     validateSkillStats,
     validateSkillRouteKey,
     validateMemberProfile,
@@ -237,5 +241,85 @@ describe("skill adoption fetchers", () => {
         }) as typeof fetch;
 
         await expect(fetchSkillAdoption("superpowers:missing")).rejects.toMatchObject({ notFound: true });
+    });
+});
+
+describe("community state report fetcher", () => {
+    test("validates the compiled state report shape", () => {
+        expect(validateStateReport({
+            year: 2026,
+            users: 25,
+            harness_mix: { claude: 20, codex: 8 },
+            model_share: { "claude-sonnet": 18, "gpt-5": 7 },
+            skill_adoption: { tdd: 17, "agent-browser": 3 },
+        })).toEqual({
+            year: 2026,
+            users: 25,
+            harness_mix: { claude: 20, codex: 8 },
+            model_share: { "claude-sonnet": 18, "gpt-5": 7 },
+            skill_adoption: { tdd: 17, "agent-browser": 3 },
+        });
+    });
+
+    test("rejects malformed state report distributions", () => {
+        expect(() => validateStateReport({
+            year: 2026,
+            users: 25,
+            harness_mix: { claude: "many" },
+            model_share: {},
+            skill_adoption: {},
+        })).toThrow("invalid state report distribution value");
+    });
+
+    test("fetchStateReport reads the validated year endpoint", async () => {
+        const seen: string[] = [];
+        globalThis.fetch = (async (input: string | URL | Request) => {
+            const url = String(input);
+            seen.push(url);
+            if (url === stateReportUrl(2026)) {
+                return new Response(JSON.stringify({
+                    year: 2026,
+                    users: 31,
+                    harness_mix: { claude: 22 },
+                    model_share: { "claude-sonnet": 19 },
+                    skill_adoption: { tdd: 14 },
+                }));
+            }
+            return new Response("missing", { status: 404 });
+        }) as typeof fetch;
+
+        await expect(fetchStateReport(2026)).resolves.toMatchObject({
+            year: 2026,
+            users: 31,
+            skill_adoption: { tdd: 14 },
+        });
+        expect(seen).toEqual([stateReportUrl(2026)]);
+    });
+
+    test("fetchStateReport falls back to the checked-in state file when the worker route is not deployed yet", async () => {
+        const seen: string[] = [];
+        globalThis.fetch = (async (input: string | URL | Request) => {
+            const url = String(input);
+            seen.push(url);
+            if (url === stateReportUrl(2026)) {
+                return new Response(JSON.stringify({ ok: true, endpoints: ["/state"] }));
+            }
+            if (url === stateReportRawUrl(2026)) {
+                return new Response(JSON.stringify({
+                    year: 2026,
+                    users: 1,
+                    harness_mix: { claude: 1 },
+                    model_share: { "claude-sonnet": 1 },
+                    skill_adoption: { tdd: 1 },
+                }));
+            }
+            return new Response("missing", { status: 404 });
+        }) as typeof fetch;
+
+        await expect(fetchStateReport(2026)).resolves.toMatchObject({
+            users: 1,
+            harness_mix: { claude: 1 },
+        });
+        expect(seen).toEqual([stateReportUrl(2026), stateReportRawUrl(2026)]);
     });
 });

--- a/packages/lib/src/shared/community.ts
+++ b/packages/lib/src/shared/community.ts
@@ -512,6 +512,14 @@ export interface PatternStats {
     readonly dropped: readonly PatternStatsDrop[];
 }
 
+export interface StateReport {
+    readonly year: number;
+    readonly users: number;
+    readonly harness_mix: Record<string, number>;
+    readonly skill_adoption: Record<string, number>;
+    readonly model_share: Record<string, number>;
+}
+
 // --- formatting (shared) --------------------------------------------------------
 
 /**
@@ -732,6 +740,32 @@ export function trendingPatterns(
         .slice(0, limit);
 }
 
+function validateDistribution(value: unknown, name: string): Record<string, number> {
+    if (!isRecord(value)) throw new Error(`invalid ${name}`);
+    const out: Record<string, number> = {};
+    for (const [key, raw] of Object.entries(value)) {
+        const count = num(raw, "state report distribution value");
+        if (count < 0) throw new Error("invalid state report distribution value");
+        out[str(key, "state report distribution key")] = count;
+    }
+    return out;
+}
+
+export function validateStateReport(value: unknown): StateReport {
+    if (!isRecord(value)) throw new Error("invalid state report");
+    const year = num(value.year, "state report year");
+    const users = num(value.users, "state report users");
+    if (!Number.isInteger(year) || year < 2000 || year > 9999) throw new Error("invalid state report year");
+    if (!Number.isInteger(users) || users < 0) throw new Error("invalid state report users");
+    return {
+        year,
+        users,
+        harness_mix: validateDistribution(value.harness_mix, "state report harness_mix"),
+        skill_adoption: validateDistribution(value.skill_adoption, "state report skill_adoption"),
+        model_share: validateDistribution(value.model_share, "state report model_share"),
+    };
+}
+
 // --- urls + fetchers --------------------------------------------------------------
 
 export function registrationRawUrl(login: string): string {
@@ -747,6 +781,14 @@ export function profileGistRawUrl(owner: string, gistId: string): string {
 export const leaderboardUrl = `${BOARD_API}/leaders`;
 export const skillStatsUrl = `${BOARD_API}/skills`;
 export const patternStatsUrl = `${BOARD_API}/patterns`;
+export function stateReportUrl(year: number): string {
+    if (!Number.isInteger(year) || year < 2000 || year > 9999) throw new Error("invalid state report year");
+    return `${BOARD_API}/state/${year}`;
+}
+export function stateReportRawUrl(year: number): string {
+    if (!Number.isInteger(year) || year < 2000 || year > 9999) throw new Error("invalid state report year");
+    return `${REPO_RAW}/community/state/${year}.json`;
+}
 
 async function fetchJson(url: string): Promise<unknown> {
     const res = await fetch(url);
@@ -789,6 +831,14 @@ export async function fetchSkillStats(): Promise<SkillStats> {
 
 export async function fetchPatternStats(): Promise<PatternStats> {
     return validatePatternStats(await fetchJson(patternStatsUrl));
+}
+
+export async function fetchStateReport(year: number): Promise<StateReport> {
+    try {
+        return validateStateReport(await fetchJson(stateReportUrl(year)));
+    } catch {
+        return validateStateReport(await fetchJson(stateReportRawUrl(year)));
+    }
 }
 
 export async function fetchSkillAdoption(


### PR DESCRIPTION
## Summary
- Add `/state/$year` State of Agent Engineering dossier page with minimum-N gating, measured-distribution charts, and founding-sample CTA state.
- Add shared `StateReport` validation/fetch helpers with a raw checked-in JSON fallback while the worker route deploys.
- Add `/state/{year}` support to the community worker for compiled state payloads.

## Verification
- `bun test packages/lib/src/shared/community.test.ts packages/community-compile/src/compile.test.ts apps/site/app/lib/state-report.test.ts apps/site/app/components/state-report.test.tsx`
- `bun run typecheck`
- `(cd apps/site && bun run typecheck)`
- `(cd apps/community-worker && bun run typecheck)`
- `(cd apps/site && bun run build)`

Closes #376

---

_Generated with [ax](https://github.com/Necmttn/ax)._
