### PR TITLE
feat: support team radar compare

### DIFF
--- a/apps/site/app/components/profile-dossier.tsx
+++ b/apps/site/app/components/profile-dossier.tsx
@@ -1,6 +1,6 @@
 // apps/site/app/components/profile-dossier.tsx
 import { Link, useNavigate } from "@tanstack/react-router";
-import { Fragment, useState, type FormEvent } from "react";
+import { Fragment, useState, type CSSProperties, type FormEvent } from "react";
 import { HeroLogoField } from "~/components/landing-v2/supports-strip";
 import { WrappedDeck, type InsightCard, type VizSpec } from "~/components/wrapped-deck";
 import { RadarChart, type RadarSeries } from "~/components/radar-chart";
@@ -8,8 +8,10 @@ import {
     archetypeFor,
     dominantPair,
     leadTally,
+    parseCompareLogins,
     profileToAxes,
     RADAR_AXES_META,
+    rawValueLeaders,
     type RadarAxes,
 } from "~/lib/radar";
 import { duelPath, duelXIntent } from "~/lib/challenge";
@@ -31,23 +33,30 @@ import {
     type DayColumn,
 } from "~/lib/window-chart";
 
-// mirrors LOGIN_RE in community.ts - GitHub handles only, sanitised before use.
-export const LOGIN_RE = /^[A-Za-z0-9-]{1,39}$/;
 // series colours: primary profile = ax green, comparison = ax blue.
 // Exported so the bespoke duel layout (profile-duel.tsx) tints A green / B blue
 // with the exact same tokens the radar series + overlay use.
 export const SELF_COLOR = "var(--green)";
 export const VS_COLOR = "#2567a8";
+export const COMPARE_COLORS = [
+    SELF_COLOR,
+    VS_COLOR,
+    "#9c4f88",
+    "#a96722",
+    "#577a38",
+] as const;
 
-// comparison-profile load state, kept separate from the primary dossier so a
-// missing/invalid `?vs=` peer degrades to a quiet inline note, never an error
-// page for the profile the visitor actually came to see.
-export type VsState =
-    | { kind: "none" }
+// Comparison-profile load state, kept separate from the primary dossier so a
+// missing/invalid peer degrades to a quiet inline note, never an error page for
+// the profile the visitor actually came to see.
+export type VsPeerState =
     | { kind: "loading"; login: string }
     | { kind: "not-found"; login: string }
     | { kind: "error"; login: string }
     | { kind: "ready"; login: string; profile: ProfileV1 };
+export type VsState =
+    | { kind: "none" }
+    | { kind: "multi"; peers: readonly VsPeerState[] };
 
 /* ---------- formatting (one helper set, everything humanized) ---------- */
 
@@ -521,30 +530,50 @@ function SignSection({ profile, vs }: { profile: ProfileV1; vs: VsState }) {
 
     const selfAxes = profileToAxes(profile);
     const selfArch = archetypeFor(selfAxes, profile);
+    const peers = vs.kind === "multi" ? vs.peers : [];
+    const readyPeers = peers.filter((peer): peer is Extract<VsPeerState, { kind: "ready" }> => peer.kind === "ready");
+    const compareEntries: RawTableProfile[] = [
+        { login: profile.github, profile, axes: selfAxes, color: SELF_COLOR },
+        ...readyPeers.map((peer, index) => {
+            const axes = profileToAxes(peer.profile);
+            return {
+                login: peer.profile.github,
+                profile: peer.profile,
+                axes,
+                color: COMPARE_COLORS[(index + 1) % COMPARE_COLORS.length]!,
+            };
+        }),
+    ];
+    const hasCompare = compareEntries.length > 1;
 
-    const vsReady = vs.kind === "ready" ? vs : null;
-    const vsAxes = vsReady ? profileToAxes(vsReady.profile) : null;
-    const vsArch = vsReady && vsAxes ? archetypeFor(vsAxes, vsReady.profile) : null;
-
-    const tally = vsReady && vsAxes ? leadTally(selfAxes, vsAxes) : null;
+    const singleCompare = hasCompare && peers.length === 1 ? compareEntries[1] : undefined;
+    const tally = singleCompare ? leadTally(selfAxes, singleCompare.axes) : null;
     const origin = typeof window !== "undefined" ? window.location.origin : "https://ax.necmttn.com";
-    const duelUrl = vsReady ? `${origin}${duelPath(profile.github, vsReady.login)}` : "";
-    const copyDuel = () => {
-        if (!duelUrl) return;
-        void navigator.clipboard?.writeText(duelUrl).then(() => {
+    const peerLogins = peers.map((peer) => peer.login);
+    const shareUrl = singleCompare
+        ? `${origin}${duelPath(profile.github, singleCompare.login)}`
+        : peerLogins.length > 0
+            ? `${origin}/u/${profile.github}?vs=${peerLogins.join(",")}`
+            : "";
+    const copyShare = () => {
+        if (!shareUrl) return;
+        void navigator.clipboard?.writeText(shareUrl).then(() => {
             setCopied(true);
             window.setTimeout(() => setCopied(false), 1500);
         }).catch(() => {});
     };
 
-    const series: RadarSeries[] = [{ login: profile.github, axes: selfAxes, color: SELF_COLOR }];
-    if (vsReady && vsAxes) series.push({ login: vsReady.login, axes: vsAxes, color: VS_COLOR });
+    const series: RadarSeries[] = compareEntries.map((entry) => ({
+        login: entry.login,
+        axes: entry.axes,
+        color: entry.color,
+    }));
 
     const submit = (e: FormEvent) => {
         e.preventDefault();
-        const target = draft.trim().replace(/^@/, "");
-        if (!LOGIN_RE.test(target)) return;
-        void navigate({ search: { vs: target } });
+        const targets = parseCompareLogins(draft, { exclude: profile.github });
+        if (targets.length === 0) return;
+        void navigate({ search: { vs: targets.join(",") } });
         setDraft("");
     };
     const clearCompare = () => void navigate({ search: { vs: undefined } });
@@ -554,12 +583,12 @@ function SignSection({ profile, vs }: { profile: ProfileV1; vs: VsState }) {
             <SectionIntro eyebrow="the sign" title="The sign" note="six axes, one archetype" />
             <p className="pf-sign-method">
                 Axes are log-anchored to fixed scales (not min-max), so shapes compare
-                across any two profiles.
+                across profiles.
             </p>
             <div className="pf-sign">
                 <div className="pf-sign-chart">
                     <RadarChart series={series} size={420} />
-                    {selfAxes.partial && (
+                    {compareEntries.some((entry) => entry.axes.partial) && (
                         <p className="pf-sign-partial">
                             some axes read 0 - they need a newer ax version to populate.
                         </p>
@@ -568,39 +597,58 @@ function SignSection({ profile, vs }: { profile: ProfileV1; vs: VsState }) {
                 </div>
 
                 <div className="pf-sign-read">
-                    {vsArch && vsReady ? (
-                        <p className="pf-sign-versus">
-                            <Avatar login={profile.github} size={22} ring={SELF_COLOR} className="pv2-avatar--inline" />
-                            <span style={{ color: SELF_COLOR }}>@{profile.github}</span> is {selfArch.sign}
-                            {" · "}
-                            <Avatar login={vsReady.login} size={22} ring={VS_COLOR} className="pv2-avatar--inline" />
-                            <span style={{ color: VS_COLOR }}>@{vsReady.login}</span> is {vsArch.sign}
-                        </p>
+                    {hasCompare ? (
+                        <>
+                            <span className="pf-sign-kicker">team shape</span>
+                            <div className="pf-sign-head">
+                                <span className="pf-sign-glyph" aria-hidden="true">✦</span>
+                                <h3 className="pf-sign-name">The team's shape</h3>
+                            </div>
+                            <p className="pf-sign-blurb">
+                                Where these polygons stack, the team shares an instinct.
+                                Where they split, the work has a ridge.
+                            </p>
+                            <div className="pf-sign-archetypes" aria-label="member archetypes">
+                                {compareEntries.map((entry) => {
+                                    const arch = archetypeFor(entry.axes, entry.profile);
+                                    return (
+                                        <div className="pf-sign-arch-row" key={entry.login}>
+                                            <Avatar login={entry.login} size={24} ring={entry.color} className="pv2-avatar--inline" linked />
+                                            <span className="pf-sign-arch-handle" style={{ color: entry.color }}>@{entry.login}</span>
+                                            <span className="pf-sign-arch-sign">
+                                                <span aria-hidden="true">{arch.symbol}</span> {arch.sign}
+                                            </span>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </>
                     ) : (
-                        <span className="pf-sign-kicker">your agent sign</span>
+                        <>
+                            <span className="pf-sign-kicker">your agent sign</span>
+                            <div className="pf-sign-head">
+                                <span className="pf-sign-glyph" aria-hidden="true">{selfArch.symbol}</span>
+                                <h3 className="pf-sign-name">{selfArch.sign}</h3>
+                            </div>
+                            <p className="pf-sign-blurb">{selfArch.blurb}</p>
+                        </>
                     )}
-
-                    <div className="pf-sign-head">
-                        <span className="pf-sign-glyph" aria-hidden="true">{selfArch.symbol}</span>
-                        <h3 className="pf-sign-name">{selfArch.sign}</h3>
-                    </div>
-                    <p className="pf-sign-blurb">{selfArch.blurb}</p>
 
                     {/* compare mode: the raw-values table below carries the
                         per-axis comparison - one table, not two summaries */}
-                    {!(vsReady && vsAxes) && <ScoreList axes={selfAxes} />}
+                    {!hasCompare && <ScoreList axes={selfAxes} />}
 
                     {/* compare control */}
                     <div className="pf-sign-compare">
-                        {vsReady ? (
+                        {peers.length > 0 ? (
                             <div className="pf-share-row">
-                                <button type="button" className="pf-share-btn" onClick={copyDuel}>
-                                    {copied ? "copied ✓" : "copy duel link"}
+                                <button type="button" className="pf-share-btn" onClick={copyShare}>
+                                    {copied ? "copied ✓" : singleCompare ? "copy duel link" : "copy compare link"}
                                 </button>
-                                {tally && (
+                                {tally && singleCompare && (
                                     <a
                                         className="pf-share-btn"
-                                        href={duelXIntent({ a: profile.github, b: vsReady.login, aLeads: tally.aLeads, total: tally.total, origin })}
+                                        href={duelXIntent({ a: profile.github, b: singleCompare.login, aLeads: tally.aLeads, total: tally.total, origin })}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                     >
@@ -611,33 +659,27 @@ function SignSection({ profile, vs }: { profile: ProfileV1; vs: VsState }) {
                             </div>
                         ) : (
                             <form className="pf-sign-form" onSubmit={submit}>
-                                <span className="pf-sign-form-label">Think you out-ship @{profile.github}?</span>
+                                <span className="pf-sign-form-label">Build a team shape</span>
                                 <input
                                     className="pf-sign-input"
                                     type="text"
                                     value={draft}
                                     onChange={(e) => setDraft(e.currentTarget.value)}
-                                    placeholder="github handle"
-                                    aria-label="github handle to challenge"
+                                    placeholder="handles, comma-separated"
+                                    aria-label="github handles to compare"
                                     spellCheck={false}
                                     autoCapitalize="off"
                                     autoCorrect="off"
                                 />
-                                <button type="submit" className="pf-sign-go">challenge →</button>
+                                <button type="submit" className="pf-sign-go">compare →</button>
                             </form>
                         )}
-                        {vs.kind === "loading" && <span className="pf-sign-msg">pulling @{vs.login}…</span>}
-                        {vs.kind === "not-found" && <UnclaimedChallenger login={vs.login} />}
-                        {vs.kind === "error" && <span className="pf-sign-msg">couldn't load @{vs.login}.</span>}
+                        {peers.length > 0 && <ComparePeerStatuses peers={peers} />}
                     </div>
                 </div>
             </div>
 
-            <RawTable
-                self={selfAxes}
-                selfLogin={profile.github}
-                vs={vsReady && vsAxes ? { axes: vsAxes, login: vsReady.login } : undefined}
-            />
+            <RawTable profiles={compareEntries} />
         </section>
     );
 }
@@ -680,54 +722,57 @@ function ScoreList({ axes }: { axes: RadarAxes }) {
 
 /**
  * "Raw values" reference table - the un-normalised numbers behind the chart,
- * straight off RadarAxes.raws (never re-derived here). In compare mode each
- * row gets two value columns and the per-metric leader is marked with a small
- * green dot; ties and unmeasurable rows get no dot.
+ * straight off RadarAxes.raws (never re-derived here). In compare mode, each
+ * profile gets its own value column and a strict per-metric leader is marked
+ * with a small dot; ties and unmeasurable rows get no dot.
  */
 export function RawTable({
-    self, selfLogin, vs,
+    profiles,
 }: {
-    self: RadarAxes;
-    selfLogin: string;
-    vs?: { axes: RadarAxes; login: string };
+    profiles: readonly RawTableProfile[];
 }) {
+    const leaderByAxis = rawValueLeaders(profiles.map((entry) => entry.axes));
+    const compareMode = profiles.length > 1;
+
     return (
         <div className="pf-rawvals">
             <div className="pf-rawvals-head">
                 <span className="pf-rawvals-kicker">raw values</span>
                 <span className="pf-rawvals-note">un-normalised numbers behind the chart</span>
             </div>
-            <table className="pf-rawvals-table">
+            <table
+                className={compareMode ? "pf-rawvals-table pf-rawvals-table--compare" : "pf-rawvals-table"}
+                style={compareMode ? ({ "--raw-profile-count": profiles.length } as CSSProperties) : undefined}
+            >
                 <thead>
                     <tr>
                         <th scope="col">metric</th>
-                        <th scope="col" className="pf-rawvals-col">
-                            {vs ? (
-                                <><Avatar login={selfLogin} size={18} ring={SELF_COLOR} className="pv2-avatar--inline" linked /><span style={{ color: SELF_COLOR }}>@{selfLogin}</span></>
-                            ) : "value"}
-                        </th>
-                        {vs && (
-                            <th scope="col" className="pf-rawvals-col">
-                                <Avatar login={vs.login} size={18} ring={VS_COLOR} className="pv2-avatar--inline" linked /><span style={{ color: VS_COLOR }}>@{vs.login}</span>
+                        {profiles.map((entry, index) => (
+                            <th scope="col" className="pf-rawvals-col" key={entry.login}>
+                                {compareMode ? (
+                                    <>
+                                        <Avatar login={entry.login} size={18} ring={entry.color} className="pv2-avatar--inline" linked />
+                                        <span style={{ color: entry.color }}>@{entry.login}</span>
+                                    </>
+                                ) : (
+                                    index === 0 ? "value" : `@${entry.login}`
+                                )}
                             </th>
-                        )}
+                        ))}
                     </tr>
                 </thead>
                 <tbody>
                     {RADAR_AXES_META.map((m) => {
-                        const a = self.raws[m.key];
-                        const b = vs?.axes.raws[m.key];
-                        // leader: strictly greater comparable numeric; null never leads
-                        const aLeads = vs !== undefined && a.value !== null && (b?.value === null || b === undefined || a.value > b.value);
-                        const bLeads = vs !== undefined && b !== undefined && b.value !== null && (a.value === null || b.value > a.value);
+                        const leaderIndexes = leaderByAxis[m.key];
+                        const rawValues = profiles.map((entry) => entry.axes.raws[m.key]);
                         // magnitude split-bar: each side normalised to that row's
                         // pair-max so a blowout reads visually distinct from a near-tie.
-                        const av = a.value;
-                        const bv = b?.value ?? null;
-                        const pairMax = Math.max(av ?? 0, bv ?? 0, 0);
+                        const av = rawValues[0]?.value ?? null;
+                        const bv = rawValues[1]?.value ?? null;
+                        const pairMax = profiles.length === 2 ? Math.max(av ?? 0, bv ?? 0, 0) : 0;
                         const aPct = pairMax > 0 && av !== null ? Math.min(100, (av / pairMax) * 100) : 0;
                         const bPct = pairMax > 0 && bv !== null ? Math.min(100, (bv / pairMax) * 100) : 0;
-                        const ratio = av !== null && bv !== null && av > 0 && bv > 0
+                        const ratio = profiles.length === 2 && av !== null && bv !== null && av > 0 && bv > 0
                             ? Math.max(av, bv) / Math.min(av, bv)
                             : null;
                         const ratioChip = ratio !== null && ratio >= 1.05
@@ -735,29 +780,29 @@ export function RawTable({
                             : null;
                         return (
                             <Fragment key={m.key}>
-                                <tr className={vs ? "pf-rawvals-row pf-rawvals-row--pair" : "pf-rawvals-row"}>
-                                    <th scope="row" rowSpan={vs ? 2 : 1}>{m.label}</th>
-                                    <td className={aLeads ? "pf-rawvals-val pf-rawvals-val--lead" : "pf-rawvals-val"}>
-                                        {a.label}
-                                        {aLeads && <span className="pf-rawvals-dot" aria-label="leads" />}
-                                    </td>
-                                    {vs && b && (
-                                        <td className={bLeads ? "pf-rawvals-val pf-rawvals-val--lead" : "pf-rawvals-val"}>
-                                            {b.label}
-                                            {bLeads && <span className="pf-rawvals-dot" aria-label="leads" />}
-                                        </td>
-                                    )}
+                                <tr className={profiles.length === 2 ? "pf-rawvals-row pf-rawvals-row--pair" : "pf-rawvals-row"}>
+                                    <th scope="row" rowSpan={profiles.length === 2 ? 2 : 1}>{m.label}</th>
+                                    {profiles.map((entry, index) => {
+                                        const raw = rawValues[index]!;
+                                        const leads = leaderIndexes.includes(index);
+                                        return (
+                                            <td className={leads ? "pf-rawvals-val pf-rawvals-val--lead" : "pf-rawvals-val"} key={entry.login}>
+                                                {raw.label}
+                                                {leads && <span className="pf-rawvals-dot" style={{ background: entry.color }} aria-label="leads" />}
+                                            </td>
+                                        );
+                                    })}
                                 </tr>
-                                {vs && (
+                                {profiles.length === 2 && (
                                     <tr className="pf-rawvals-barrow">
-                                        <td colSpan={2}>
+                                        <td colSpan={profiles.length}>
                                             <div className="pf-rawvals-split" aria-hidden="true">
                                                 <span className="pf-rawvals-split-a">
-                                                    <span className="pf-rawvals-split-fill pf-rawvals-split-fill--a" style={{ width: `${aPct}%` }} />
+                                                    <span className="pf-rawvals-split-fill pf-rawvals-split-fill--a" style={{ width: `${aPct}%`, background: profiles[0]!.color }} />
                                                 </span>
                                                 <span className="pf-rawvals-split-mid">{ratioChip}</span>
                                                 <span className="pf-rawvals-split-b">
-                                                    <span className="pf-rawvals-split-fill pf-rawvals-split-fill--b" style={{ width: `${bPct}%` }} />
+                                                    <span className="pf-rawvals-split-fill pf-rawvals-split-fill--b" style={{ width: `${bPct}%`, background: profiles[1]!.color }} />
                                                 </span>
                                             </div>
                                         </td>
@@ -768,6 +813,29 @@ export function RawTable({
                     })}
                 </tbody>
             </table>
+        </div>
+    );
+}
+
+export interface RawTableProfile {
+    readonly login: string;
+    readonly profile: ProfileV1;
+    readonly axes: RadarAxes;
+    readonly color: string;
+}
+
+function ComparePeerStatuses({ peers }: { peers: readonly VsPeerState[] }) {
+    const pending = peers.filter((peer) => peer.kind !== "ready");
+    if (pending.length === 0) return null;
+    return (
+        <div className="pf-sign-peer-status" aria-label="compare profile load status">
+            {pending.map((peer) => (
+                <span className="pf-sign-peer-pill" key={peer.login}>
+                    {peer.kind === "loading" && <>pulling @{peer.login}...</>}
+                    {peer.kind === "not-found" && <>@{peer.login} has not published yet</>}
+                    {peer.kind === "error" && <>couldn't load @{peer.login}</>}
+                </span>
+            ))}
         </div>
     );
 }
@@ -1120,21 +1188,6 @@ export function groupSkills(skills: readonly ProfileSkill[]): SkillGroup[] {
 }
 
 /* ---------- not-found doubles as the join CTA ---------- */
-
-/** Shown inside SignSection when the challenger is unregistered: a compact dare
- *  echoing the dossier's stamp + command motifs. */
-function UnclaimedChallenger({ login }: { login: string }) {
-    return (
-        <div className="pf-challenge-unclaimed">
-            <span className="pf-challenge-stamp" aria-hidden="true">unanswered</span>
-            <p className="pf-challenge-line">
-                challenge issued · <strong>@{login}</strong> hasn't published a dossier yet.
-            </p>
-            <code className="pf-empty-cmd">ax profile publish</code>
-            <span className="pf-challenge-sub">one command answers the challenge - their transcripts never leave their machine.</span>
-        </div>
-    );
-}
 
 export function UnclaimedDossier({ login }: { login: string }) {
     return (

--- a/apps/site/app/components/profile-duel.tsx
+++ b/apps/site/app/components/profile-duel.tsx
@@ -271,9 +271,10 @@ export function DuelDossier({ a, b }: { a: ProfileV1; b: ProfileV1 }) {
                     </p>
                 </div>
                 <RawTable
-                    self={aAxes}
-                    selfLogin={a.github}
-                    vs={{ axes: bAxes, login: b.github }}
+                    profiles={[
+                        { login: a.github, profile: a, axes: aAxes, color: SELF_COLOR },
+                        { login: b.github, profile: b, axes: bAxes, color: VS_COLOR },
+                    ]}
                 />
             </section>
 

--- a/apps/site/app/components/profile-highlights.test.tsx
+++ b/apps/site/app/components/profile-highlights.test.tsx
@@ -44,3 +44,23 @@ describe("dossier renders guardrail receipts", () => {
         expect(src).toContain("resolved or never fired");
     });
 });
+
+describe("dossier supports multi-profile radar compare", () => {
+    test("the sign section builds a profile list and renders every member archetype", () => {
+        expect(src).toContain("compareEntries");
+        expect(src).toContain("pf-sign-archetypes");
+        expect(src).toContain("archetypeFor(entry.axes, entry.profile)");
+    });
+
+    test("the raw-values table accepts N profiles and uses strict raw-value leaders", () => {
+        expect(src).toContain("rawValueLeaders");
+        expect(src).toMatch(/profiles:\s*readonly/);
+        expect(src).toContain("leaderIndexes");
+    });
+
+    test("compare load failures are rendered per peer instead of replacing the whole comparison", () => {
+        expect(src).toContain("vs.peers");
+        expect(src).toContain("pf-sign-peer-status");
+        expect(src).toContain("couldn't load");
+    });
+});

--- a/apps/site/app/components/radar-chart.tsx
+++ b/apps/site/app/components/radar-chart.tsx
@@ -1,11 +1,12 @@
 // apps/site/app/components/radar-chart.tsx
 //
 // Dependency-free SVG spider/radar chart for the agent-sign dossier section.
-// Renders 1 or 2 series over the six fixed RADAR axes. Pure geometry, no JS
+// Renders 1+ series over the six fixed RADAR axes. Pure geometry, no JS
 // interactivity beyond <title> tooltips on the vertices (so SSR == client).
 //
 // Untrusted strings (login) render as text only - never as markup.
 
+import type { CSSProperties } from "react";
 import { RADAR_AXES_META, type RadarAxes } from "~/lib/radar";
 
 export interface RadarSeries {
@@ -31,6 +32,10 @@ function point(cx: number, cy: number, radius: number, i: number, value: number)
 }
 
 const fmt = (n: number): string => (Math.round(n * 10) / 10).toString();
+
+function seriesStyle(color: string, fillOpacity: number): CSSProperties {
+    return { color, "--radar-fill-opacity": fillOpacity } as CSSProperties;
+}
 
 export function RadarChart({
     series,
@@ -102,12 +107,13 @@ export function RadarChart({
 
                 {/* series polygons (drawn back-to-front: first series on top) */}
                 {[...series].reverse().map((serie) => {
+                    const fillOpacity = series.length >= 4 ? 0.08 : series.length === 3 ? 0.11 : 0.16;
                     const pts = RADAR_AXES_META.map((meta, i) =>
                         point(cx, cy, radius, i, serie.axes.scores[meta.key]),
                     );
                     const poly = pts.map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`).join(" ");
                     return (
-                        <g key={serie.login} style={{ color: serie.color }}>
+                        <g key={serie.login} style={seriesStyle(serie.color, fillOpacity)}>
                             <polygon className="pf-radar-area" points={poly} />
                             {pts.map(([x, y], i) => (
                                 <circle key={RADAR_AXES_META[i]!.key} className="pf-radar-dot" cx={x} cy={y} r={3.4}>

--- a/apps/site/app/lib/radar.test.ts
+++ b/apps/site/app/lib/radar.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "bun:test";
 import {
     archetypeFor,
     dominantPair,
+    parseCompareLogins,
     profileToAxes,
     RADAR_AXIS_KEYS,
+    rawValueLeaders,
     type RadarAxes,
     type RadarAxisKey,
 } from "./radar";
@@ -279,6 +281,57 @@ describe("leadTally", () => {
         const t = leadTally(a, b);
         expect(t.aLeads).toBe(1); // axis0: 5 > null
         expect(t.bLeads).toBe(1); // axis1: 7 > null
+    });
+});
+
+/* ---------- multi-profile compare helpers ---------- */
+
+describe("parseCompareLogins", () => {
+    it("accepts comma-separated logins, strips @, dedupes case-insensitively, and caps the list", () => {
+        expect(parseCompareLogins(" @Alpha, beta,alpha,Gamma,delta,epsilon ")).toEqual([
+            "Alpha",
+            "beta",
+            "Gamma",
+            "delta",
+        ]);
+    });
+
+    it("drops invalid entries and the primary login without poisoning valid peers", () => {
+        expect(parseCompareLogins("self,bad handle!,ok,,@Other,-bad,bad-,bad--handle", { exclude: "SELF" })).toEqual(["ok", "Other"]);
+    });
+
+    it("returns an empty list for non-string or empty input", () => {
+        expect(parseCompareLogins(undefined)).toEqual([]);
+        expect(parseCompareLogins(["a"])).toEqual([]);
+        expect(parseCompareLogins(" , , ")).toEqual([]);
+    });
+});
+
+describe("rawValueLeaders", () => {
+    it("picks the single strict leader for each axis across N profiles", () => {
+        const leaders = rawValueLeaders([
+            axesWith([10, 5, 8, 3, 9, 1]),
+            axesWith([2, 7, 12, 4, 1, 0]),
+            axesWith([3, 6, 11, 9, 20, null]),
+        ]);
+
+        expect(leaders.DEPTH).toEqual([0]);
+        expect(leaders.SCALE).toEqual([1]);
+        expect(leaders.RIGOR).toEqual([1]);
+        expect(leaders.DELEGATION).toEqual([2]);
+        expect(leaders.BREADTH).toEqual([2]);
+        expect(leaders.ENDURANCE).toEqual([0]);
+    });
+
+    it("does not mark a leader for ties or all-null values", () => {
+        const leaders = rawValueLeaders([
+            axesWith([10, null, null, null, null, null]),
+            axesWith([10, null, null, null, null, null]),
+            axesWith([2, null, null, null, null, null]),
+        ]);
+
+        expect(leaders.DEPTH).toEqual([]);
+        expect(leaders.SCALE).toEqual([]);
     });
 });
 

--- a/apps/site/app/lib/radar.ts
+++ b/apps/site/app/lib/radar.ts
@@ -25,6 +25,9 @@ export const RADAR_AXIS_KEYS = [
 
 export type RadarAxisKey = (typeof RADAR_AXIS_KEYS)[number];
 
+export const COMPARE_LOGIN_LIMIT = 4;
+const LOGIN_RE = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+
 /**
  * The un-normalised number behind one axis, pre-formatted for the "raw
  * values" reference table so the UI never re-derives. `value` is the
@@ -67,6 +70,33 @@ export const RADAR_AXES_META: readonly AxisMeta[] = [
     { key: "BREADTH", label: "BREADTH", note: "distinct skills × repos" },
     { key: "ENDURANCE", label: "ENDURE", note: "hours in the loop" },
 ];
+
+/* ---------- compare query helpers ---------- */
+
+export function parseCompareLogins(
+    raw: unknown,
+    options: { readonly exclude?: string; readonly limit?: number } = {},
+): readonly string[] {
+    if (typeof raw !== "string") return [];
+
+    const limit = Math.max(0, Math.floor(options.limit ?? COMPARE_LOGIN_LIMIT));
+    const exclude = options.exclude?.toLowerCase();
+    const seen = new Set<string>();
+    const out: string[] = [];
+
+    for (const chunk of raw.split(",")) {
+        const login = chunk.trim().replace(/^@/, "");
+        const key = login.toLowerCase();
+        if (!LOGIN_RE.test(login)) continue;
+        if (exclude && key === exclude) continue;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(login);
+        if (out.length >= limit) break;
+    }
+
+    return out;
+}
 
 /* ---------- scaling helpers ---------- */
 
@@ -379,6 +409,39 @@ export function leadTally(a: RadarAxes, b: RadarAxes): LeadTally {
         else if (bv !== null && (av === null || bv > av)) bLeads++;
     }
     return { aLeads, bLeads, total: RADAR_AXIS_KEYS.length };
+}
+
+export type RawValueLeaders = Readonly<Record<RadarAxisKey, readonly number[]>>;
+
+/**
+ * Single strict raw-value leader per axis across any number of profiles.
+ * Nulls never lead, and ties deliberately produce no leader so the table does
+ * not imply a winner where the comparable values are equal.
+ */
+export function rawValueLeaders(series: readonly RadarAxes[]): RawValueLeaders {
+    const leaders = {} as Record<RadarAxisKey, readonly number[]>;
+
+    for (const key of RADAR_AXIS_KEYS) {
+        let best = Number.NEGATIVE_INFINITY;
+        let bestIndex = -1;
+        let bestCount = 0;
+
+        series.forEach((axes, index) => {
+            const value = axes.raws[key].value;
+            if (value === null) return;
+            if (value > best) {
+                best = value;
+                bestIndex = index;
+                bestCount = 1;
+                return;
+            }
+            if (value === best) bestCount++;
+        });
+
+        leaders[key] = bestIndex >= 0 && bestCount === 1 ? [bestIndex] : [];
+    }
+
+    return leaders;
 }
 
 /** the two axes that defined the sign - handy for the compare delta block */

--- a/apps/site/app/routes/-u-route-compare.test.ts
+++ b/apps/site/app/routes/-u-route-compare.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+const src = await Bun.file(new URL("./u.$login.tsx", import.meta.url)).text();
+
+describe("/u/$login multi-profile compare route", () => {
+    test("normalizes comma-separated vs search with the shared parser", () => {
+        expect(src).toContain("parseCompareLogins");
+        expect(src).toMatch(/parseCompareLogins\(search\.vs\)/);
+    });
+
+    test("filters the primary profile out before fetching peers", () => {
+        expect(src).toContain("exclude: login");
+    });
+
+    test("stores per-peer compare states so one failed profile can degrade alone", () => {
+        expect(src).toContain("kind: \"multi\"");
+        expect(src).toContain("peers:");
+        expect(src).toContain("updatePeer");
+    });
+});

--- a/apps/site/app/routes/u.$login.tsx
+++ b/apps/site/app/routes/u.$login.tsx
@@ -4,11 +4,12 @@ import { useEffect, useState } from "react";
 import { SiteHeader } from "~/components/landing-sections/site-header";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
 import { fetchProfile, type ProfileV1 } from "@ax/lib/shared/community";
-import { ProfileDossier, UnclaimedDossier, LOGIN_RE, type VsState } from "~/components/profile-dossier";
+import { ProfileDossier, UnclaimedDossier, type VsPeerState, type VsState } from "~/components/profile-dossier";
+import { parseCompareLogins } from "~/lib/radar";
 
 export const Route = createFileRoute("/u/$login")({
     validateSearch: (search: Record<string, unknown>) => ({
-        vs: typeof search.vs === "string" && LOGIN_RE.test(search.vs) ? search.vs : undefined,
+        vs: parseCompareLogins(search.vs).join(",") || undefined,
     }),
     head: ({ params }) => ({
         meta: [
@@ -58,26 +59,44 @@ function ProfilePage() {
 
     useEffect(() => {
         let alive = true;
-        if (!vs || vs.toLowerCase() === login.toLowerCase()) {
-            // self-compare is allowed (proves the overlay path); only skip the
-            // empty case so we don't double-render the same series silently.
-            if (!vs) { setVsState({ kind: "none" }); return; }
+        const compareLogins = parseCompareLogins(vs, { exclude: login });
+        if (compareLogins.length === 0) {
+            setVsState({ kind: "none" });
+            return () => { alive = false; };
         }
-        setVsState({ kind: "loading", login: vs });
-        fetchProfile(vs)
-            .then((profile) => {
-                if (!alive) return;
-                if (profile.github.toLowerCase() !== vs.toLowerCase()) {
-                    setVsState({ kind: "error", login: vs });
-                    return;
+
+        const updatePeer = (next: VsPeerState) => {
+            if (!alive) return;
+            setVsState((current) => current.kind === "multi"
+                ? {
+                    kind: "multi",
+                    peers: current.peers.map((peer) =>
+                        peer.login.toLowerCase() === next.login.toLowerCase() ? next : peer,
+                    ),
                 }
-                setVsState({ kind: "ready", login: vs, profile });
-            })
-            .catch((e: unknown) => {
-                if (!alive) return;
-                const notFound = typeof e === "object" && e !== null && (e as { notFound?: boolean }).notFound === true;
-                setVsState(notFound ? { kind: "not-found", login: vs } : { kind: "error", login: vs });
-            });
+                : current);
+        };
+
+        setVsState({
+            kind: "multi",
+            peers: compareLogins.map((peerLogin) => ({ kind: "loading", login: peerLogin })),
+        });
+
+        for (const peerLogin of compareLogins) {
+            fetchProfile(peerLogin)
+                .then((profile) => {
+                    if (profile.github.toLowerCase() !== peerLogin.toLowerCase()) {
+                        updatePeer({ kind: "error", login: peerLogin });
+                        return;
+                    }
+                    updatePeer({ kind: "ready", login: peerLogin, profile });
+                })
+                .catch((e: unknown) => {
+                    const notFound = typeof e === "object" && e !== null && (e as { notFound?: boolean }).notFound === true;
+                    updatePeer(notFound ? { kind: "not-found", login: peerLogin } : { kind: "error", login: peerLogin });
+                });
+        }
+
         return () => { alive = false; };
     }, [vs, login]);
 

--- a/apps/site/app/routes/u.$login_.vs.$other.tsx
+++ b/apps/site/app/routes/u.$login_.vs.$other.tsx
@@ -8,7 +8,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { SiteHeader } from "~/components/landing-sections/site-header";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
-import { ProfileDossier, UnclaimedDossier, type VsState } from "~/components/profile-dossier";
+import { ProfileDossier, UnclaimedDossier, type VsPeerState, type VsState } from "~/components/profile-dossier";
 import { DuelDossier } from "~/components/profile-duel";
 import { fetchProfile, type ProfileV1 } from "@ax/lib/shared/community";
 import { compareDecision, buildDuelOgImageUrl } from "~/lib/challenge";
@@ -40,7 +40,7 @@ type State =
 function DuelPage() {
     const { login, other } = Route.useParams();
     const [state, setState] = useState<State>({ kind: "loading" });
-    const [vsState, setVsState] = useState<VsState>({ kind: "none" });
+    const [vsState, setVsState] = useState<VsPeerState | null>(null);
 
     useEffect(() => {
         let alive = true;
@@ -82,6 +82,8 @@ function DuelPage() {
         return () => { alive = false; };
     }, [other]);
 
+    const fallbackVs: VsState = vsState ? { kind: "multi", peers: [vsState] } : { kind: "none" };
+
     return (
         <>
             <SiteHeader />
@@ -93,10 +95,10 @@ function DuelPage() {
                     // Both profiles resolved -> the bespoke head-to-head layout.
                     // If the peer is still loading / unregistered / errored, fall
                     // back to the single dossier with the overlay (preserves the
-                    // challenge form + UnclaimedChallenger dare - no regression).
-                    vsState.kind === "ready"
+                    // compare controls + per-peer failure state - no regression).
+                    vsState?.kind === "ready"
                         ? <DuelDossier a={state.profile} b={vsState.profile} />
-                        : <ProfileDossier profile={state.profile} vs={vsState} />
+                        : <ProfileDossier profile={state.profile} vs={fallbackVs} />
                 )}
             </main>
             <SiteFooter />

--- a/apps/site/app/styles/globals.css
+++ b/apps/site/app/styles/globals.css
@@ -13260,12 +13260,12 @@ details[open] > summary .pf-toggle { transform: rotate(-135deg); }
 }
 .pf-radar-area {
     fill: currentColor;
-    fill-opacity: 0.16;
+    fill-opacity: var(--radar-fill-opacity, 0.16);
     stroke: currentColor;
-    stroke-width: 2.25;
+    stroke-width: 2.1;
     stroke-linejoin: round;
 }
-.pf-radar-dot { fill: currentColor; stroke: var(--page); stroke-width: 1.5; }
+.pf-radar-dot { fill: currentColor; stroke: var(--page); stroke-width: 1.7; }
 
 .pf-radar-legend {
     display: flex;
@@ -13324,6 +13324,32 @@ details[open] > summary .pf-toggle { transform: rotate(-135deg); }
     margin: 14px 0 22px;
     max-width: 46ch;
 }
+.pf-sign-archetypes {
+    display: grid;
+    gap: 8px;
+    margin: 18px 0 0;
+}
+.pf-sign-arch-row {
+    display: grid;
+    grid-template-columns: auto minmax(86px, max-content) minmax(0, 1fr);
+    align-items: center;
+    gap: 9px;
+    padding: 8px 0;
+    border-top: 1px solid var(--line);
+    font-family: var(--mono);
+    font-size: 12px;
+}
+.pf-sign-arch-row:last-child { border-bottom: 1px solid var(--line); }
+.pf-sign-arch-handle {
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    min-width: 0;
+}
+.pf-sign-arch-sign {
+    color: var(--ink);
+    min-width: 0;
+}
+.pf-sign-arch-sign span { margin-right: 5px; }
 
 /* score list */
 .pf-sign-scores { display: flex; flex-direction: column; gap: 0; margin: 0; }
@@ -13371,7 +13397,7 @@ details[open] > summary .pf-toggle { transform: rotate(-135deg); }
     flex-wrap: wrap;
     gap: 12px;
 }
-.pf-sign-form { display: flex; align-items: center; gap: 8px; }
+.pf-sign-form { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
 .pf-sign-form-label {
     font-family: var(--mono);
     font-size: 10.5px;
@@ -13386,7 +13412,7 @@ details[open] > summary .pf-toggle { transform: rotate(-135deg); }
     border: 1px solid var(--line);
     background: var(--panel);
     color: var(--ink);
-    width: 150px;
+    width: min(240px, 100%);
 }
 .pf-sign-input:focus { outline: none; border-color: var(--green); }
 .pf-sign-go, .pf-sign-clear {
@@ -13408,6 +13434,24 @@ details[open] > summary .pf-toggle { transform: rotate(-135deg); }
     font-size: 11px;
     color: var(--muted);
 }
+.pf-sign-peer-status {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    width: 100%;
+}
+.pf-sign-peer-pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    border: 1px solid var(--line);
+    background: color-mix(in srgb, var(--panel) 84%, var(--page));
+    padding: 4px 8px;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: 0.03em;
+    color: var(--muted);
+}
 /* normalization explainer under the kicker */
 .pf-sign-method {
     font-family: var(--mono);
@@ -13419,7 +13463,11 @@ details[open] > summary .pf-toggle { transform: rotate(-135deg); }
 }
 
 /* raw values reference table */
-.pf-rawvals { margin-top: 40px; }
+.pf-rawvals {
+    margin-top: 40px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+}
 .pf-rawvals-head {
     display: flex;
     align-items: baseline;
@@ -13442,10 +13490,16 @@ details[open] > summary .pf-toggle { transform: rotate(-135deg); }
 .pf-rawvals-table {
     width: 100%;
     border-collapse: collapse;
+    table-layout: fixed;
     font-family: var(--mono);
     font-size: 12.5px;
 }
+.pf-rawvals-table--compare {
+    min-width: calc(118px + (var(--raw-profile-count, 2) * 132px));
+}
 .pf-rawvals-table th, .pf-rawvals-table td { padding: 8px 0; }
+.pf-rawvals-col { min-width: 0; }
+.pf-rawvals-col .pv2-avatar { margin-right: 5px; }
 .pf-rawvals-table thead th {
     font-size: 10.5px;
     font-weight: 400;
@@ -13466,6 +13520,32 @@ details[open] > summary .pf-toggle { transform: rotate(-135deg); }
     color: var(--muted);
     text-align: left;
     width: 110px;
+}
+.pf-rawvals-row--pair { border-bottom: none; }
+.pf-rawvals-row--pair > td,
+.pf-rawvals-row--pair > th { padding-bottom: 3px; }
+.pf-rawvals-barrow > td { padding: 0 0 9px; }
+.pf-rawvals-split {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: center;
+    gap: 0;
+}
+.pf-rawvals-split-a,
+.pf-rawvals-split-b {
+    display: flex;
+    min-width: 0;
+    background: color-mix(in srgb, var(--line) 42%, transparent);
+}
+.pf-rawvals-split-a { justify-content: flex-end; }
+.pf-rawvals-split-b { justify-content: flex-start; }
+.pf-rawvals-split-fill { height: 8px; border-radius: 1px; display: block; }
+.pf-rawvals-split-mid {
+    min-width: 44px;
+    padding: 0 8px;
+    text-align: center;
+    font-size: 9px;
+    color: var(--muted);
 }
 /* under-chart axis legend: spoke abbreviation -> plain meaning */
 .pf-axis-legend {
@@ -13518,7 +13598,11 @@ details[open] > summary .pf-toggle { transform: rotate(-135deg); }
 }
 @media (max-width: 560px) {
     .pf-sign-name { font-size: 32px; }
+    .pf-sign-arch-row { grid-template-columns: auto minmax(0, 1fr); }
+    .pf-sign-arch-sign { grid-column: 2; }
     .pf-rawvals-table tbody th { width: 84px; }
+    .pf-rawvals-table { font-size: 11px; }
+    .pf-rawvals-table thead th { font-size: 9px; letter-spacing: 0.08em; }
     .pf-rawvals-val { white-space: normal; }
 }
 


### PR DESCRIPTION
## Summary

- Extend `/u/<login>?vs=` to parse comma-separated compare handles, dedupe/validate/cap them, and load each peer independently.
- Render team-shape radar overlays with distinct colors, legend chips, member archetype rows, and an N-column raw-values table with strict leader dots.
- Preserve the dedicated duel route while letting per-peer compare failures degrade inline in the dossier.

## Verification

- `bun test apps/site/app/lib/radar.test.ts apps/site/app/components/profile-highlights.test.tsx apps/site/app/components/profile-duel.test.tsx apps/site/app/routes/-u-route-compare.test.ts` - 51 pass, 0 fail
- `bun run typecheck` - exit 0; existing Effect language-service messages remain in unrelated files
- `bun run --cwd apps/site typecheck` - exit 0
- `bun run --cwd apps/site build` - exit 0; existing generated-CSS/chunk/stage warnings remain
- `git diff --check` - exit 0
- Screenshot QA at `/u/Necmttn?vs=janniks,mitchnick,supnim,ak-devmode` on desktop and mobile, including horizontal-scroll raw table on mobile

Closes #377

---

_Generated with [ax](https://github.com/Necmttn/ax)._
