### PR TITLE
[codex] Context Budget v2 startup footprint

### DIFF
--- a/apps/axctl/src/ingest/claude-config.test.ts
+++ b/apps/axctl/src/ingest/claude-config.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { Effect, FileSystem, Layer, Path } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import {
+    buildClaudeMdGuidanceRevisionStatements,
     buildGuidanceConfigPersistenceStatements,
     buildGuidanceConfigStatements,
     claudeConfigStage,
@@ -392,6 +393,87 @@ describe("buildGuidanceConfigStatements", () => {
         expect(serialized).not.toContain("env-secret");
         expect(serialized).not.toContain("cat ~/.ssh/id_rsa");
         expect(serialized).not.toContain("/Users/alice");
+    });
+});
+
+describe("buildClaudeMdGuidanceRevisionStatements", () => {
+    test("emits baseline and changed CLAUDE.md revisions without raw body text", () => {
+        const globalClaude = parseClaudeConfigArtifact({
+            kind: "memory",
+            scope: "user",
+            path: "/Users/alice/.claude/CLAUDE.md",
+            home: "/Users/alice",
+            text: "# private global memory",
+        });
+        const projectClaude = parseClaudeConfigArtifact({
+            kind: "guidance_doc",
+            scope: "project",
+            path: "/repo/CLAUDE.md",
+            projectRoot: "/repo",
+            text: "# private project rules",
+        });
+        const agentsMd = parseClaudeConfigArtifact({
+            kind: "guidance_doc",
+            scope: "project",
+            path: "/repo/AGENTS.md",
+            projectRoot: "/repo",
+            text: "# project agents",
+        });
+
+        const statements = buildClaudeMdGuidanceRevisionStatements(
+            [globalClaude, projectClaude, agentsMd],
+            new Map([
+                [
+                    projectClaude.pathHash,
+                    {
+                        content_hash: "old-project-hash",
+                        bytes: 12,
+                    },
+                ],
+            ]),
+            new Set(),
+        );
+
+        expect(statements).toHaveLength(2);
+        expect(statements[0]).toContain("UPSERT guidance_revision:");
+        expect(statements[0]).toContain('source_path: "~/.claude/CLAUDE.md"');
+        expect(statements[0]).toContain('change: "added"');
+        expect(statements[1]).toContain('source_path: "$PROJECT/CLAUDE.md"');
+        expect(statements[1]).toContain('change: "changed"');
+        expect(statements[1]).toContain('prev_hash: "old-project-hash"');
+        expect(statements[1]).toContain("prev_bytes: 12");
+
+        const serialized = statements.join("\n");
+        expect(serialized).not.toContain("private global memory");
+        expect(serialized).not.toContain("private project rules");
+        expect(serialized).not.toContain("project agents");
+        expect(serialized).not.toContain("AGENTS.md");
+    });
+
+    test("skips unchanged CLAUDE.md revisions that already have a baseline row", () => {
+        const globalClaude = parseClaudeConfigArtifact({
+            kind: "memory",
+            scope: "user",
+            path: "/Users/alice/.claude/CLAUDE.md",
+            home: "/Users/alice",
+            text: "# private global memory",
+        });
+
+        const statements = buildClaudeMdGuidanceRevisionStatements(
+            [globalClaude],
+            new Map([
+                [
+                    globalClaude.pathHash,
+                    {
+                        content_hash: globalClaude.contentHash,
+                        bytes: globalClaude.bytes,
+                    },
+                ],
+            ]),
+            new Set([`${globalClaude.safePath}\0${globalClaude.contentHash}`]),
+        );
+
+        expect(statements).toEqual([]);
     });
 });
 

--- a/apps/axctl/src/ingest/claude-config.ts
+++ b/apps/axctl/src/ingest/claude-config.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { parse as parseYaml } from "yaml";
 import { Effect, FileSystem, Path, Schema } from "effect";
 import { AxConfig } from "@ax/lib/config";
-import { SurrealClient } from "@ax/lib/db";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
 import { safeKeyPart } from "@ax/lib/shared/derive-keys";
 import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
@@ -102,6 +102,11 @@ export interface DiscoverClaudeConfigArtifactsOptions {
 export interface IngestClaudeConfigStats {
     readonly discovered: number;
     readonly written: number;
+}
+
+export interface PreviousGuidanceConfigArtifact {
+    readonly content_hash: string | null;
+    readonly bytes: number | null;
 }
 
 const MAX_ARTIFACT_READ_BYTES = 256 * 1024;
@@ -841,8 +846,99 @@ export const guidanceConfigArtifactKey = (
     record: Pick<GuidanceConfigArtifact, "provider" | "pathHash">,
 ): string => `${safeKeyPart(record.provider)}__${record.pathHash}`;
 
+export const guidanceConfigRevisionKey = (
+    record: Pick<GuidanceConfigArtifact, "safePath" | "contentHash"> & { readonly contentHash: string },
+): string => `${safeKeyPart(record.safePath).slice(0, 72)}__${record.contentHash}`;
+
 const intLiteral = (value: number): string =>
     Number.isFinite(value) ? Math.trunc(value).toString(10) : "0";
+
+const isClaudeMdArtifact = (record: GuidanceConfigArtifact): boolean =>
+    (record.kind === "memory" || record.kind === "guidance_doc") &&
+    record.safePath.endsWith("/CLAUDE.md") &&
+    record.contentHash !== null;
+
+const revisionSetKey = (safePath: string, contentHash: string): string =>
+    `${safePath}\0${contentHash}`;
+
+export const buildClaudeMdGuidanceRevisionStatements = (
+    records: readonly GuidanceConfigArtifact[],
+    previousByPathHash: ReadonlyMap<string, PreviousGuidanceConfigArtifact>,
+    existingRevisionKeys: ReadonlySet<string>,
+): string[] => {
+    const statements: string[] = [];
+    for (const record of records) {
+        if (!isClaudeMdArtifact(record) || record.contentHash === null) continue;
+        const previous = previousByPathHash.get(record.pathHash);
+        const prevHash = previous?.content_hash ?? null;
+        const prevBytes = previous?.bytes ?? null;
+        const isUnchanged = prevHash === record.contentHash;
+        if (isUnchanged && existingRevisionKeys.has(revisionSetKey(record.safePath, record.contentHash))) continue;
+        const change = prevHash !== null && !isUnchanged ? "changed" : "added";
+        statements.push(
+            `UPSERT ${recordRef("guidance_revision", guidanceConfigRevisionKey({ safePath: record.safePath, contentHash: record.contentHash }))} MERGE ${surrealObject([
+                ["source", "NONE"],
+                ["source_path", surrealString(record.safePath)],
+                ["scope", surrealString(record.scope)],
+                ["content_hash", surrealString(record.contentHash)],
+                ["prev_hash", surrealOptionString(prevHash)],
+                ["bytes", intLiteral(record.bytes)],
+                ["prev_bytes", prevBytes === null ? "NONE" : intLiteral(prevBytes)],
+                ["change", surrealString(change)],
+                ["evidence_strength", surrealString("observed")],
+                ["commit_evidence", "NONE"],
+                ["file_evidence", "NONE"],
+                ["observed_at", "time::now()"],
+            ])};`,
+        );
+    }
+    return statements;
+};
+
+const claudeMdRecords = (records: readonly GuidanceConfigArtifact[]): GuidanceConfigArtifact[] =>
+    records.filter(isClaudeMdArtifact);
+
+const fetchPreviousArtifacts = (
+    db: SurrealClientShape,
+    records: readonly GuidanceConfigArtifact[],
+): Effect.Effect<Map<string, PreviousGuidanceConfigArtifact>, DbError> =>
+    Effect.gen(function* () {
+        const hashes = uniqueSorted(claudeMdRecords(records).map((record) => record.pathHash));
+        if (hashes.length === 0) return new Map();
+        const res = yield* db.query<[Array<Record<string, unknown>>]>(
+            `SELECT path_hash, content_hash, bytes FROM ${GUIDANCE_CONFIG_ARTIFACT_TABLE} WHERE provider = "claude" AND path_hash IN ${surrealValue(hashes)};`,
+        );
+        const out = new Map<string, PreviousGuidanceConfigArtifact>();
+        for (const row of res?.[0] ?? []) {
+            const pathHash = typeof row.path_hash === "string" ? row.path_hash : null;
+            if (pathHash === null) continue;
+            out.set(pathHash, {
+                content_hash: typeof row.content_hash === "string" ? row.content_hash : null,
+                bytes: typeof row.bytes === "number" ? row.bytes : null,
+            });
+        }
+        return out;
+    });
+
+const fetchExistingRevisionKeys = (
+    db: SurrealClientShape,
+    records: readonly GuidanceConfigArtifact[],
+): Effect.Effect<Set<string>, DbError> =>
+    Effect.gen(function* () {
+        const current = claudeMdRecords(records).filter((record) => record.contentHash !== null);
+        const sourcePaths = uniqueSorted(current.map((record) => record.safePath));
+        const hashes = uniqueSorted(current.map((record) => record.contentHash).filter((hash): hash is string => hash !== null));
+        if (sourcePaths.length === 0 || hashes.length === 0) return new Set();
+        const res = yield* db.query<[Array<Record<string, unknown>>]>(
+            `SELECT source_path, content_hash FROM guidance_revision WHERE source_path IN ${surrealValue(sourcePaths)} AND content_hash IN ${surrealValue(hashes)};`,
+        );
+        const out = new Set<string>();
+        for (const row of res?.[0] ?? []) {
+            if (typeof row.source_path !== "string" || typeof row.content_hash !== "string") continue;
+            out.add(revisionSetKey(row.source_path, row.content_hash));
+        }
+        return out;
+    });
 
 export const buildGuidanceConfigStatements = (
     records: readonly GuidanceConfigArtifact[],
@@ -913,13 +1009,17 @@ export const ingestClaudeConfigArtifacts = (): Effect.Effect<
             home: cfg.paths.home,
             projectRoot: process.cwd(),
         });
+        const [previousArtifacts, existingRevisionKeys] = yield* Effect.all([
+            fetchPreviousArtifacts(db, records),
+            fetchExistingRevisionKeys(db, records),
+        ], { concurrency: 2 });
         const statements = buildGuidanceConfigPersistenceStatements(
             records,
             guidanceConfigAuthorityHashesForScan({
                 home: cfg.paths.home,
                 projectRoot: process.cwd(),
             }),
-        );
+        ).concat(buildClaudeMdGuidanceRevisionStatements(records, previousArtifacts, existingRevisionKeys));
         yield* executeStatementsWith(db, statements, { chunkSize: 500, label: "claudeConfig" });
         return {
             discovered: records.length,

--- a/apps/axctl/src/queries/context-budget.test.ts
+++ b/apps/axctl/src/queries/context-budget.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import type { ContextBudgetResult } from "./context-budget.ts";
+import {
+  buildContextDriftRows,
+  buildStartupBudgetSources,
+  MCP_TOOL_DEFINITION_TOKENS_PER_SERVER,
+  type ContextBudgetResult,
+} from "./context-budget.ts";
 
 describe("ContextBudgetResult", () => {
   test("carries a contentTypes breakdown field", () => {
@@ -8,5 +13,123 @@ describe("ContextBudgetResult", () => {
       totals: { calls: 1, bytes: 4, estTokens: 1 },
     };
     expect(sample.rows[0].category).toBe("code");
+  });
+
+  test("rolls skills, CLAUDE.md, harness prompt, and MCP estimates into startup sources", () => {
+    const budget = buildStartupBudgetSources({
+      skillIndexChars: 400,
+      skillIndexTokens: 100,
+      skillCount: 2,
+      guidanceRows: [
+        {
+          kind: "memory",
+          scope: "user",
+          safe_path: "~/.claude/CLAUDE.md",
+          authority_hash: "user-authority",
+          bytes: 80,
+          token_estimate: 20,
+          mcp_server_names_json: null,
+        },
+        {
+          kind: "guidance_doc",
+          scope: "project",
+          safe_path: "$PROJECT/CLAUDE.md",
+          authority_hash: "project-authority",
+          bytes: 40,
+          token_estimate: 10,
+          mcp_server_names_json: null,
+        },
+        {
+          kind: "guidance_doc",
+          scope: "project",
+          safe_path: "$PROJECT/CLAUDE.md",
+          authority_hash: "stale-project-authority",
+          bytes: 800,
+          token_estimate: 200,
+          mcp_server_names_json: null,
+        },
+        {
+          kind: "settings_config",
+          scope: "user",
+          safe_path: "~/.claude/settings.json",
+          authority_hash: "user-authority",
+          bytes: 200,
+          token_estimate: 50,
+          mcp_server_names_json: JSON.stringify(["github", "linear"]),
+        },
+        {
+          kind: "mcp_server",
+          scope: "project",
+          safe_path: "$PROJECT/.mcp.json",
+          authority_hash: "project-authority",
+          bytes: 60,
+          token_estimate: 15,
+          mcp_server_names_json: JSON.stringify(["github"]),
+        },
+      ],
+      authorityHashes: new Set(["user-authority", "project-authority"]),
+    });
+
+    expect(budget.sources.map((row) => row.category)).toEqual([
+      "skills",
+      "claude_md",
+      "claude_md",
+      "harness_base",
+      "mcp_tools",
+    ]);
+    expect(budget.sources.find((row) => row.source === "CLAUDE.md · global")).toMatchObject({
+      tokens: 20,
+      estimated: false,
+      entries: 1,
+    });
+    expect(budget.sources.find((row) => row.source === "MCP tool definitions")).toMatchObject({
+      tokens: 2 * MCP_TOOL_DEFINITION_TOKENS_PER_SERVER,
+      estimated: true,
+      entries: 2,
+    });
+    expect(budget.totals.startup_tokens).toBe(
+      budget.sources.reduce((sum, row) => sum + row.tokens, 0),
+    );
+    expect(budget.totals.measured_startup_tokens).toBe(130);
+  });
+
+  test("maps skill and CLAUDE.md revisions into one context drift feed", () => {
+    const rows = buildContextDriftRows({
+      skillRows: [
+        {
+          name: "tdd",
+          scope: "user",
+          change: "changed",
+          bytes: 120,
+          prev_bytes: 80,
+          ts: new Date("2026-06-02T00:00:00Z"),
+        },
+      ],
+      guidanceRows: [
+        {
+          source_path: "$PROJECT/CLAUDE.md",
+          scope: "project",
+          change: "changed",
+          bytes: 200,
+          prev_bytes: 100,
+          observed_at: new Date("2026-06-03T00:00:00Z"),
+        },
+      ],
+      limit: 10,
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["claude_md", "skill"]);
+    expect(rows[0]).toMatchObject({
+      name: "CLAUDE.md · project",
+      scope: "project",
+      byte_delta: 100,
+      token_delta: 25,
+    });
+    expect(rows[1]).toMatchObject({
+      name: "tdd",
+      kind: "skill",
+      byte_delta: 40,
+      token_delta: 10,
+    });
   });
 });

--- a/apps/axctl/src/queries/context-budget.ts
+++ b/apps/axctl/src/queries/context-budget.ts
@@ -17,14 +17,24 @@
  * Tables used (read-only): skill { name, scope, bytes, description,
  *   content_hash, dir_path }.
  */
+import { homedir } from "node:os";
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
+import { safeJsonParse } from "@ax/lib/shared/safe-json";
+import { surrealValue } from "@ax/lib/shared/surql";
+import { guidanceConfigAuthorityHashesForScan } from "../ingest/claude-config.ts";
 import { normalizeLastUsed, UNUSED_RECENT_SQL, UNUSED_SUMMARY_SQL } from "./unused-skills.ts";
 import { fetchContentTypeBreakdown, type ContentTypeBreakdown } from "./content-types.ts";
 
 const WINDOW_DAYS = 30;
 const CHARS_PER_TOKEN = 4;
 const toTokens = (chars: number) => Math.round(chars / CHARS_PER_TOKEN);
+
+// Measured startup sources come from disk/DB metadata. These constants cover
+// context that the harness injects but does not expose as text; the API marks
+// their rows `estimated` so the studio does not present them as exact counts.
+export const HARNESS_BASE_PROMPT_TOKENS = 4_200;
+export const MCP_TOOL_DEFINITION_TOKENS_PER_SERVER = 650;
 
 /** Other-harness tool catalogs (codex/cursor/opencode/pi) and similar - not
  *  part of a Claude Code session's context, tracked separately. */
@@ -80,11 +90,36 @@ export interface SourceBudgetRow {
     readonly reclaimable_index_tokens: number;  // always-loaded tokens from this source's dead weight
 }
 
+export type StartupBudgetCategory = "skills" | "claude_md" | "harness_base" | "mcp_tools";
+
+export interface StartupBudgetSourceRow {
+    readonly source: string;
+    readonly category: StartupBudgetCategory;
+    readonly scope: string | null;
+    readonly entries: number;
+    readonly chars: number;
+    readonly tokens: number;
+    readonly estimated: boolean;
+    readonly note: string;
+}
+
+export interface GuidanceConfigBudgetRow {
+    readonly kind: string;
+    readonly scope: string;
+    readonly safe_path: string;
+    readonly authority_hash: string;
+    readonly bytes: number;
+    readonly token_estimate: number;
+    readonly mcp_server_names_json: string | null;
+}
+
 export interface ContextBudgetResult {
     /** Distinct skills (deduped by content_hash), heaviest body first. */
     readonly skills: ReadonlyArray<SkillBudgetRow>;
     /** Per-source rollup, heaviest index first. */
     readonly sources: ReadonlyArray<SourceBudgetRow>;
+    /** Full turn-zero startup footprint slices; skills are one row here. */
+    readonly startupSources: ReadonlyArray<StartupBudgetSourceRow>;
     /** content-type distribution of tool outputs (token-weighted). */
     readonly contentTypes: ContentTypeBreakdown;
     readonly totals: {
@@ -100,6 +135,11 @@ export interface ContextBudgetResult {
         readonly reclaimable_index_tokens: number;
         readonly reclaimable_skills: number;
         readonly verbose_skills: number;
+        /** Full turn-zero startup estimate across skills + config + harness/MCP estimates. */
+        readonly startup_chars: number;
+        readonly startup_tokens: number;
+        readonly measured_startup_tokens: number;
+        readonly estimated_startup_tokens: number;
         /** Recency window (days) used to judge "unused". */
         readonly window_days: number;
     };
@@ -109,6 +149,132 @@ const BUDGET_SQL = `
 SELECT id, name, scope, bytes, string::len(description ?? "") AS desc_len, content_hash, dir_path
 FROM skill;
 `;
+
+const CONFIG_BUDGET_SQL = (authorityHashes: readonly string[]) => `
+SELECT kind, scope, safe_path, authority_hash, bytes, token_estimate, mcp_server_names_json
+FROM guidance_config_artifact
+WHERE provider = "claude"
+AND authority_hash IN ${surrealValue(authorityHashes)};
+`;
+
+const isClaudeMdBudgetRow = (row: GuidanceConfigBudgetRow): boolean =>
+    (row.kind === "memory" || row.kind === "guidance_doc") &&
+    row.safe_path.endsWith("/CLAUDE.md");
+
+const claudeMdSource = (scope: string): string => {
+    if (scope === "user") return "CLAUDE.md · global";
+    if (scope === "project") return "CLAUDE.md · project";
+    return `CLAUDE.md · ${scope}`;
+};
+
+const parseJsonStringArray = (raw: string | null): string[] => {
+    if (raw === null) return [];
+    const parsed = safeJsonParse<unknown>(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+};
+
+export const buildStartupBudgetSources = (
+    input: {
+        readonly skillIndexChars: number;
+        readonly skillIndexTokens: number;
+        readonly skillCount: number;
+        readonly guidanceRows: ReadonlyArray<GuidanceConfigBudgetRow>;
+        readonly authorityHashes?: ReadonlySet<string> | undefined;
+    },
+): {
+    readonly sources: ReadonlyArray<StartupBudgetSourceRow>;
+    readonly totals: Pick<
+        ContextBudgetResult["totals"],
+        "startup_chars" | "startup_tokens" | "measured_startup_tokens" | "estimated_startup_tokens"
+    >;
+} => {
+    const sources: StartupBudgetSourceRow[] = [];
+    const guidanceRows = input.authorityHashes === undefined
+        ? input.guidanceRows
+        : input.guidanceRows.filter((row) => input.authorityHashes?.has(row.authority_hash) ?? false);
+    if (input.skillIndexTokens > 0 || input.skillCount > 0) {
+        sources.push({
+            source: "Skills index",
+            category: "skills",
+            scope: "claude",
+            entries: input.skillCount,
+            chars: input.skillIndexChars,
+            tokens: input.skillIndexTokens,
+            estimated: false,
+            note: "Skill names and descriptions loaded before the first turn.",
+        });
+    }
+
+    const claudeMd = new Map<string, StartupBudgetSourceRow>();
+    for (const row of guidanceRows.filter(isClaudeMdBudgetRow)) {
+        const source = claudeMdSource(row.scope);
+        const prev = claudeMd.get(source);
+        const bytes = Number(row.bytes ?? 0);
+        const tokens = Number(row.token_estimate ?? toTokens(bytes));
+        claudeMd.set(source, {
+            source,
+            category: "claude_md",
+            scope: row.scope,
+            entries: (prev?.entries ?? 0) + 1,
+            chars: (prev?.chars ?? 0) + bytes,
+            tokens: (prev?.tokens ?? 0) + tokens,
+            estimated: false,
+            note: row.scope === "user"
+                ? "Global Claude memory file loaded into Claude Code sessions."
+                : "Project CLAUDE.md loaded into sessions for this checkout.",
+        });
+    }
+    sources.push(...claudeMd.values());
+
+    sources.push({
+        source: "Harness base prompt",
+        category: "harness_base",
+        scope: "claude/codex",
+        entries: 1,
+        chars: HARNESS_BASE_PROMPT_TOKENS * CHARS_PER_TOKEN,
+        tokens: HARNESS_BASE_PROMPT_TOKENS,
+        estimated: true,
+        note: "Best-effort constant for the built-in Claude Code/Codex base instructions.",
+    });
+
+    const mcpServers = new Set<string>();
+    for (const row of guidanceRows) {
+        for (const name of parseJsonStringArray(row.mcp_server_names_json)) mcpServers.add(name);
+    }
+    if (mcpServers.size > 0) {
+        const tokens = mcpServers.size * MCP_TOOL_DEFINITION_TOKENS_PER_SERVER;
+        sources.push({
+            source: "MCP tool definitions",
+            category: "mcp_tools",
+            scope: "claude",
+            entries: mcpServers.size,
+            chars: tokens * CHARS_PER_TOKEN,
+            tokens,
+            estimated: true,
+            note: "Estimated schemas injected for configured MCP servers; raw schemas are not stored.",
+        });
+    }
+
+    const startup_chars = sources.reduce((n, s) => n + s.chars, 0);
+    const startup_tokens = sources.reduce((n, s) => n + s.tokens, 0);
+    const measured_startup_tokens = sources
+        .filter((s) => !s.estimated)
+        .reduce((n, s) => n + s.tokens, 0);
+    const estimated_startup_tokens = sources
+        .filter((s) => s.estimated)
+        .reduce((n, s) => n + s.tokens, 0);
+
+    return {
+        sources,
+        totals: {
+            startup_chars,
+            startup_tokens,
+            measured_startup_tokens,
+            estimated_startup_tokens,
+        },
+    };
+};
 
 /** Prefer a non-namespaced / non-project scope as the canonical home of a
  *  deduped skill (user/plugin/command over the project mirror). */
@@ -121,15 +287,21 @@ const idStr = (v: unknown) => String(v ?? "");
 export const fetchContextBudget = Effect.fn("queries.fetchContextBudget")(
     function* () {
         const db = yield* SurrealClient;
+        const authorityHashes = guidanceConfigAuthorityHashesForScan({
+            home: process.env.HOME ?? homedir(),
+            projectRoot: process.cwd(),
+        });
         // budget rows + bulk usage (per skill id) over the invoked edge table,
         // computed deref-free - see unused-skills.ts for the perf rationale.
-        const [rawRes, summaryRes, recentRes, contentTypes] = yield* Effect.all([
+        const [rawRes, summaryRes, recentRes, configRes, contentTypes] = yield* Effect.all([
             db.query<[Array<Record<string, unknown>>]>(BUDGET_SQL),
             db.query<[Array<Record<string, unknown>>]>(UNUSED_SUMMARY_SQL),
             db.query<[Array<Record<string, unknown>>]>(UNUSED_RECENT_SQL(WINDOW_DAYS)),
+            db.query<[Array<GuidanceConfigBudgetRow>]>(CONFIG_BUDGET_SQL(authorityHashes)),
             fetchContentTypeBreakdown(),
         ], { concurrency: 4 });
         const raw = rawRes?.[0] ?? [];
+        const guidanceRows = configRes?.[0] ?? [];
 
         const usageById = new Map<string, { uses: number; last: string | null }>();
         for (const r of summaryRes?.[0] ?? []) {
@@ -208,6 +380,14 @@ export const fetchContextBudget = Effect.fn("queries.fetchContextBudget")(
         const sources = [...srcMap.values()].sort((a, b) => b.index_chars - a.index_chars);
 
         const cc = skills.filter((s) => !s.is_tool);
+        const startup = buildStartupBudgetSources({
+            skillIndexChars: cc.reduce((n, s) => n + s.index_chars, 0),
+            skillIndexTokens: toTokens(cc.reduce((n, s) => n + s.index_chars, 0)),
+            skillCount: cc.length,
+            guidanceRows,
+            authorityHashes: new Set(authorityHashes),
+        });
+
         const totals = {
             skills: skills.length,
             index_chars: skills.reduce((n, s) => n + s.index_chars, 0),
@@ -219,10 +399,11 @@ export const fetchContextBudget = Effect.fn("queries.fetchContextBudget")(
             reclaimable_index_tokens: cc.filter((s) => s.dead_weight).reduce((n, s) => n + s.index_tokens, 0),
             reclaimable_skills: cc.filter((s) => s.dead_weight).length,
             verbose_skills: cc.filter((s) => s.verbose).length,
+            ...startup.totals,
             window_days: WINDOW_DAYS,
         };
 
-        return { skills, sources, totals, contentTypes } satisfies ContextBudgetResult;
+        return { skills, sources, startupSources: startup.sources, totals, contentTypes } satisfies ContextBudgetResult;
     },
 );
 
@@ -231,6 +412,7 @@ export const fetchContextBudget = Effect.fn("queries.fetchContextBudget")(
 // ---------------------------------------------------------------------------
 
 export interface SkillDriftRow {
+    readonly kind: "skill" | "claude_md";
     readonly name: string;
     readonly scope: string;
     readonly change: string;        // 'added' | 'changed'
@@ -253,28 +435,80 @@ ORDER BY ts DESC
 LIMIT ${Math.max(1, Math.trunc(limit))};
 `;
 
+const GUIDANCE_DRIFT_SQL = (limit: number) => `
+SELECT source_path, scope, change, content_hash, prev_hash, bytes, prev_bytes, observed_at
+FROM guidance_revision
+WHERE string::ends_with(source_path, "CLAUDE.md")
+AND change IS NOT NONE
+ORDER BY observed_at DESC
+LIMIT ${Math.max(1, Math.trunc(limit))};
+`;
+
+const isoTimestamp = (value: unknown): string =>
+    value instanceof Date ? value.toISOString() : String(value ?? "");
+
+const guidanceDriftName = (scope: string): string => {
+    if (scope === "user") return "CLAUDE.md · global";
+    if (scope === "project") return "CLAUDE.md · project";
+    return `CLAUDE.md · ${scope}`;
+};
+
+export const buildContextDriftRows = (
+    input: {
+        readonly skillRows: ReadonlyArray<Record<string, unknown>>;
+        readonly guidanceRows: ReadonlyArray<Record<string, unknown>>;
+        readonly limit: number;
+    },
+): SkillDriftRow[] => {
+    const skillChanges: SkillDriftRow[] = input.skillRows.map((row) => {
+        const bytes = Number(row.bytes ?? 0);
+        const prev_bytes = Number(row.prev_bytes ?? 0);
+        const change = String(row.change ?? "changed");
+        const byte_delta = change === "added" ? 0 : bytes - prev_bytes;
+        return {
+            kind: "skill",
+            name: String(row.name ?? "(unnamed)"),
+            scope: String(row.scope ?? ""),
+            change,
+            ts: isoTimestamp(row.ts),
+            bytes,
+            prev_bytes,
+            byte_delta,
+            token_delta: Math.round(byte_delta / CHARS_PER_TOKEN),
+        };
+    });
+    const guidanceChanges: SkillDriftRow[] = input.guidanceRows.map((row) => {
+        const bytes = Number(row.bytes ?? 0);
+        const prev_bytes = Number(row.prev_bytes ?? 0);
+        const change = String(row.change ?? "changed");
+        const byte_delta = change === "added" ? 0 : bytes - prev_bytes;
+        const scope = String(row.scope ?? "");
+        return {
+            kind: "claude_md",
+            name: guidanceDriftName(scope),
+            scope,
+            change,
+            ts: isoTimestamp(row.observed_at),
+            bytes,
+            prev_bytes,
+            byte_delta,
+            token_delta: Math.round(byte_delta / CHARS_PER_TOKEN),
+        };
+    });
+    return [...skillChanges, ...guidanceChanges]
+        .sort((a, b) => (Date.parse(b.ts) || 0) - (Date.parse(a.ts) || 0))
+        .slice(0, Math.max(1, Math.trunc(input.limit)));
+};
+
 export const fetchSkillDrift = Effect.fn("queries.fetchSkillDrift")(
     function* (opts: { readonly limit: number }) {
         const db = yield* SurrealClient;
-        const rows = yield* db.query<[Array<Record<string, unknown>>]>(DRIFT_SQL(opts.limit))
-            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const [skillRows, guidanceRows] = yield* Effect.all([
+            db.query<[Array<Record<string, unknown>>]>(DRIFT_SQL(opts.limit)).pipe(Effect.map((r) => r?.[0] ?? [])),
+            db.query<[Array<Record<string, unknown>>]>(GUIDANCE_DRIFT_SQL(opts.limit)).pipe(Effect.map((r) => r?.[0] ?? [])),
+        ], { concurrency: 2 });
 
-        const changes: SkillDriftRow[] = rows.map((row) => {
-            const bytes = Number(row.bytes ?? 0);
-            const prev_bytes = Number(row.prev_bytes ?? 0);
-            const byte_delta = row.change === "added" ? 0 : bytes - prev_bytes;
-            const ts = row.ts instanceof Date ? row.ts.toISOString() : String(row.ts ?? "");
-            return {
-                name: String(row.name ?? "(unnamed)"),
-                scope: String(row.scope ?? ""),
-                change: String(row.change ?? "changed"),
-                ts,
-                bytes,
-                prev_bytes,
-                byte_delta,
-                token_delta: Math.round(byte_delta / CHARS_PER_TOKEN),
-            };
-        });
+        const changes = buildContextDriftRows({ skillRows, guidanceRows, limit: opts.limit });
 
         return { changes, total: changes.length } satisfies SkillDriftResult;
     },

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -242,9 +242,20 @@ export interface ContextSourceRow {
     readonly dead_skills: number;
     readonly reclaimable_index_tokens: number;
 }
+export interface ContextStartupSourceRow {
+    readonly source: string;
+    readonly category: "skills" | "claude_md" | "harness_base" | "mcp_tools";
+    readonly scope: string | null;
+    readonly entries: number;
+    readonly chars: number;
+    readonly tokens: number;
+    readonly estimated: boolean;
+    readonly note: string;
+}
 export interface ContextBudgetResult {
     readonly skills: ReadonlyArray<ContextSkillRow>;
     readonly sources: ReadonlyArray<ContextSourceRow>;
+    readonly startupSources: ReadonlyArray<ContextStartupSourceRow>;
     readonly totals: {
         readonly skills: number;
         readonly index_chars: number;
@@ -256,10 +267,15 @@ export interface ContextBudgetResult {
         readonly reclaimable_index_tokens: number;
         readonly reclaimable_skills: number;
         readonly verbose_skills: number;
+        readonly startup_chars: number;
+        readonly startup_tokens: number;
+        readonly measured_startup_tokens: number;
+        readonly estimated_startup_tokens: number;
         readonly window_days: number;
     };
 }
 export interface ContextDriftRow {
+    readonly kind: "skill" | "claude_md";
     readonly name: string;
     readonly scope: string;
     readonly change: string;

--- a/apps/studio/src/routes/skills.tsx
+++ b/apps/studio/src/routes/skills.tsx
@@ -6,6 +6,7 @@ import type {
     ContextDriftRow,
     ContextSkillRow,
     ContextSourceRow,
+    ContextStartupSourceRow,
 } from "../api.ts";
 import { fmtCount } from "@ax/lib/shared/formatters";
 
@@ -61,7 +62,7 @@ const RECLAIM_TRIM = 6;
 
 /** Stable hue per source name (so colour survives sort/filter and matches the
  *  legend even when the row order changes). */
-function buildHueMap(sources: ReadonlyArray<ContextSourceRow>): Map<string, string> {
+function buildHueMap(sources: ReadonlyArray<{ readonly source: string }>): Map<string, string> {
     const map = new Map<string, string>();
     sources.forEach((s, i) => {
         map.set(s.source, SOURCE_HUES[i % SOURCE_HUES.length]);
@@ -104,12 +105,17 @@ export function SkillsRoute() {
         () => (data ? data.sources.filter((s) => s.is_tool) : []),
         [data],
     );
+    const startupSources = data?.startupSources ?? [];
     const hueMap = useMemo(() => buildHueMap(ccSources), [ccSources]);
+    const startupHueMap = useMemo(() => buildHueMap(startupSources), [startupSources]);
 
-    // The always-loaded tax: sum of session-source index tokens. This is the
-    // headline. cc_index_tokens from totals is the authoritative figure.
+    // The full turn-zero footprint is the headline. The skill index remains the
+    // detailed drilldown below because reclaim/trim actions operate on skills.
     const indexTotal = data?.totals.cc_index_tokens ?? 0;
     const bodyTotal = data?.totals.cc_body_tokens ?? 0;
+    const startupTotal = data?.totals.startup_tokens ?? indexTotal;
+    const measuredStartup = data?.totals.measured_startup_tokens ?? indexTotal;
+    const estimatedStartup = data?.totals.estimated_startup_tokens ?? 0;
     const windowDays = data?.totals.window_days ?? 30;
     const reclaimTokens = data?.totals.reclaimable_index_tokens ?? 0;
     const reclaimSkills = data?.totals.reclaimable_skills ?? 0;
@@ -239,10 +245,15 @@ export function SkillsRoute() {
                     </div>
                     {data ? (
                         <div className="inst-hero ctx-hero">
-                            <span className="rdx-doto n">{fmtTokens(indexTotal)}</span>
-                            <span className="l">tokens loaded into every session before you type</span>
+                            <span className="rdx-doto n">{fmtTokens(startupTotal)}</span>
+                            <span className="l">turn-zero tokens before you type</span>
                             <span className="ctx-hero-sub">
-                                + <b>{fmtTokens(bodyTotal)}</b> on demand, only when a skill runs
+                                <b>{fmtTokens(measuredStartup)}</b> measured ·{" "}
+                                <b>{fmtTokens(estimatedStartup)}</b> estimated
+                            </span>
+                            <span className="ctx-hero-sub">
+                                skills add <b>{fmtTokens(indexTotal)}</b> always ·{" "}
+                                <b>{fmtTokens(bodyTotal)}</b> on demand
                             </span>
                         </div>
                     ) : null}
@@ -254,6 +265,13 @@ export function SkillsRoute() {
 
             {data ? (
                 <>
+                    <StartupFootprintPanel
+                        rows={startupSources}
+                        totalTokens={startupTotal}
+                        estimatedTokens={estimatedStartup}
+                        hueMap={startupHueMap}
+                    />
+
                     {/* --- RECLAIM: the CTA. Opportunity-framed, heaviest first --- */}
                     {reclaimTokens > 0 ? (
                         <ReclaimPanel
@@ -271,7 +289,7 @@ export function SkillsRoute() {
                     {/* --- WHERE THE BUDGET GOES: always-loaded index by source --- */}
                     <section className="ctx-breakdown">
                         <div className="ctx-breakdown-head">
-                            <h3>Where the always-loaded budget goes</h3>
+                            <h3>Where the skill index budget goes</h3>
                             <span className="ctx-breakdown-note">
                                 {fmtTokens(indexSum)} index tokens · every session, turn zero
                             </span>
@@ -486,6 +504,71 @@ function CopyAction({
         >
             {copied ? "copied ✓" : label}
         </button>
+    );
+}
+
+function StartupFootprintPanel({
+    rows,
+    totalTokens,
+    estimatedTokens,
+    hueMap,
+}: {
+    readonly rows: ReadonlyArray<ContextStartupSourceRow>;
+    readonly totalTokens: number;
+    readonly estimatedTokens: number;
+    readonly hueMap: Map<string, string>;
+}) {
+    if (rows.length === 0) return null;
+    return (
+        <section className="ctx-breakdown ctx-startup">
+            <div className="ctx-breakdown-head">
+                <h3>Full startup footprint</h3>
+                <span className="ctx-breakdown-note">
+                    {fmtTokens(totalTokens)} turn-zero tokens
+                    {estimatedTokens > 0 ? ` · ${fmtTokens(estimatedTokens)} estimated` : ""}
+                </span>
+            </div>
+            <div className="ctx-stack" aria-hidden="true">
+                {rows
+                    .filter((row) => row.tokens > 0)
+                    .map((row) => (
+                        <span
+                            key={row.source}
+                            className="ctx-stack-seg"
+                            style={{
+                                flexGrow: row.tokens,
+                                background: hueMap.get(row.source),
+                            }}
+                            title={`${row.source} - ${fmtTokens(row.tokens)} tokens`}
+                        />
+                    ))}
+            </div>
+            <ul className="ctx-startup-list">
+                {rows.map((row) => (
+                    <li key={row.source} className="ctx-startup-row">
+                        <span className="ctx-source-name">
+                            <i
+                                className="ctx-swatch"
+                                style={{ background: hueMap.get(row.source) ?? "var(--dim)" }}
+                                aria-hidden="true"
+                            />
+                            {row.source}
+                        </span>
+                        <span className="ctx-startup-note">{row.note}</span>
+                        <span className="ctx-startup-entries">
+                            {fmtCount(row.entries)} {row.entries === 1 ? "entry" : "entries"}
+                        </span>
+                        <span className="ctx-source-index">
+                            {fmtTokens(row.tokens)}
+                            <small>startup</small>
+                        </span>
+                        <span className={`ctx-est-tag${row.estimated ? " is-est" : ""}`}>
+                            {row.estimated ? "est" : "measured"}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </section>
     );
 }
 
@@ -781,11 +864,11 @@ function DriftPanel({ rows }: { rows: ReadonlyArray<ContextDriftRow> }) {
         <section className="ctx-drift">
             <div className="ctx-breakdown-head">
                 <span className="inst-kicker">$ drift</span>
-                <span className="ctx-breakdown-note">skills changed since baseline - tracked from first ingest</span>
+                <span className="ctx-breakdown-note">skills and CLAUDE.md changed since baseline</span>
             </div>
             {items.length === 0 ? (
                 <p className="ctx-foot">
-                    No drift yet. When you - or an agent - edit a skill, the change lands here with its token delta.
+                    No drift yet. When you - or an agent - edit a skill or CLAUDE.md, the change lands here with its token delta.
                 </p>
             ) : (
                 <ul className="ctx-drift-list">

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -3589,6 +3589,49 @@ td.skill-cell .description {
     gap: 9px;
     min-width: 0;
 }
+.rdx .ctx-startup { margin-top: 4px; }
+.rdx .ctx-startup-list { list-style: none; margin: 0; padding: 0; }
+.rdx .ctx-startup-row {
+    display: grid;
+    grid-template-columns: minmax(150px, 1.05fr) minmax(180px, 1.7fr) 82px 92px 74px;
+    align-items: center;
+    gap: 14px;
+    padding: 9px 8px;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+}
+.rdx .ctx-startup-row:last-child { border-bottom: 0; }
+.rdx .ctx-startup-note {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--mono);
+    font-size: 11px;
+    line-height: 1.35;
+    color: var(--sec);
+}
+.rdx .ctx-startup-entries {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--dim);
+    text-align: right;
+    white-space: nowrap;
+}
+.rdx .ctx-est-tag {
+    justify-self: end;
+    font-family: var(--mono);
+    font-size: 9.5px;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    color: var(--green);
+    border: 1px solid color-mix(in srgb, var(--green) 40%, transparent);
+    border-radius: 4px;
+    padding: 2px 6px;
+}
+.rdx .ctx-est-tag.is-est {
+    color: var(--sec);
+    border-color: var(--border-hi);
+}
 .rdx .ctx-swatch {
     width: 9px;
     height: 9px;
@@ -4021,6 +4064,17 @@ td.skill-cell .description {
     .rdx .ctx-source-skills { grid-row: 1; }
     .rdx .ctx-source-index { grid-column: 1; align-items: flex-start; flex-direction: row; gap: 6px; align-items: baseline; }
     .rdx .ctx-source-action { grid-column: 2; }
+    .rdx .ctx-startup-row {
+        grid-template-columns: 1fr auto;
+        gap: 4px 12px;
+    }
+    .rdx .ctx-startup-note {
+        grid-column: 1 / -1;
+        white-space: normal;
+    }
+    .rdx .ctx-startup-entries { grid-column: 1; text-align: left; }
+    .rdx .ctx-startup-row .ctx-source-index { grid-column: 2; grid-row: 1; }
+    .rdx .ctx-est-tag { grid-column: 2; grid-row: 3; }
     .rdx .ctx-reclaim-row {
         grid-template-columns: 1fr auto;
         gap: 3px 12px;

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -818,6 +818,10 @@ DEFINE FIELD source            ON guidance_revision TYPE option<record<guidance_
 DEFINE FIELD source_path       ON guidance_revision TYPE string;
 DEFINE FIELD scope             ON guidance_revision TYPE string;
 DEFINE FIELD content_hash      ON guidance_revision TYPE string;
+DEFINE FIELD prev_hash         ON guidance_revision TYPE option<string>;
+DEFINE FIELD bytes             ON guidance_revision TYPE option<int>;
+DEFINE FIELD prev_bytes        ON guidance_revision TYPE option<int>;
+DEFINE FIELD change            ON guidance_revision TYPE option<string>;
 DEFINE FIELD evidence_strength ON guidance_revision TYPE string;
 DEFINE FIELD commit_evidence   ON guidance_revision TYPE option<string>;
 DEFINE FIELD file_evidence     ON guidance_revision TYPE option<string>;


### PR DESCRIPTION
## Summary
- add startup footprint rows for skills, CLAUDE.md, harness base prompt, and MCP tool definitions to /api/context/budget
- record CLAUDE.md guidance revisions during Claude config ingest and fold them into the context drift feed
- update Studio Context Budget to show turn-zero measured/estimated tokens and the expanded startup-source breakdown

Closes #430

## Validation
- bun run typecheck
- bun run typecheck (apps/studio)
- bun test
- git diff --check

---

_Generated with [ax](https://github.com/Necmttn/ax)._
