### PR TITLE
feat(schema): run evidence ledger contract + tables (#578, first slice)

### DIFF
--- a/apps/axctl/src/queries/insights.ts
+++ b/apps/axctl/src/queries/insights.ts
@@ -180,6 +180,8 @@ export const SCHEMA_TABLES: readonly SchemaTableSpec[] = [
     { table: "telemetry_of", stage: "active", note: "Edge: session -> otel telemetry row (drawn at ingest)." },
     { table: "content_type", stage: "active", note: "Closed content-type taxonomy for tool outputs." },
     { table: "has_content", stage: "active", note: "tool_call -> content_type edge; denormalizes session + bytes." },
+    { table: "run_evidence_event", stage: "active", note: "Run evidence ledger (#578): normalized claim/observation/verification/boundary events over the graph; backing distinguishes model claim vs tool-backed." },
+    { table: "run_evidence_ref", stage: "active", note: "Run evidence ledger (#578): structural refs/hashes off an evidence event; privacy_level keeps payloads out by default." },
 ] as const;
 
 export function isInsightView(value: string): value is InsightView {

--- a/packages/lib/src/shared/run-evidence.test.ts
+++ b/packages/lib/src/shared/run-evidence.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { Schema } from "effect";
+import {
+    buildRunEvidenceEventStatement,
+    buildRunEvidenceRefStatement,
+    buildRunEvidenceStatements,
+    RUN_EVIDENCE_BACKINGS,
+    RUN_EVIDENCE_KINDS,
+    RUN_EVIDENCE_PRIVACY_LEVELS,
+    RUN_EVIDENCE_REF_KINDS,
+    RunEvidenceBacking,
+    RunEvidenceKind,
+    runEvidenceEventRecordKey,
+    runEvidenceRefRecordKey,
+    type RunEvidenceEventWrite,
+    type RunEvidenceRefWrite,
+} from "./run-evidence.ts";
+
+const baseEvent: RunEvidenceEventWrite = {
+    sessionId: "sess-1",
+    ts: "2026-06-21T10:00:00.000Z",
+    provider: "claude",
+    kind: "tool_observation",
+    backing: "tool_backed",
+    sourceTable: "tool_call",
+    sourceId: "tc-abc",
+};
+
+describe("run-evidence enums", () => {
+    test("closed sets carry the converged taxonomy", () => {
+        expect(RUN_EVIDENCE_KINDS).toContain("verification");
+        expect(RUN_EVIDENCE_KINDS).toContain("derived_summary");
+        expect(RUN_EVIDENCE_BACKINGS).toEqual([
+            "model_claim",
+            "tool_backed",
+            "verifier_backed",
+            "policy_backed",
+            "derived",
+            "unknown",
+        ]);
+        expect(RUN_EVIDENCE_REF_KINDS).toContain("external_event");
+        expect(RUN_EVIDENCE_PRIVACY_LEVELS[0]).toBe("ref_only");
+    });
+
+    test("Schema unions validate members and reject strangers", () => {
+        expect(Schema.decodeUnknownSync(RunEvidenceKind)("verification")).toBe("verification");
+        expect(Schema.decodeUnknownSync(RunEvidenceBacking)("tool_backed")).toBe("tool_backed");
+        expect(() => Schema.decodeUnknownSync(RunEvidenceBacking)("trusted")).toThrow();
+    });
+});
+
+describe("run-evidence record keys", () => {
+    test("event key is deterministic from (session, source)", () => {
+        const a = runEvidenceEventRecordKey({ sessionId: "sess-1", sourceTable: "tool_call", sourceId: "tc-abc" });
+        const b = runEvidenceEventRecordKey({ sessionId: "sess-1", sourceTable: "tool_call", sourceId: "tc-abc" });
+        expect(a).toBe(b);
+        expect(a).toStartWith("sess_1__");
+    });
+
+    test("different source rows yield different keys", () => {
+        const a = runEvidenceEventRecordKey({ sessionId: "sess-1", sourceTable: "tool_call", sourceId: "tc-abc" });
+        const b = runEvidenceEventRecordKey({ sessionId: "sess-1", sourceTable: "turn", sourceId: "tc-abc" });
+        expect(a).not.toBe(b);
+    });
+
+    test("ref key is deterministic and target-sensitive", () => {
+        const a = runEvidenceRefRecordKey({ eventKey: "ev1", refKind: "file", targetTable: "file", targetId: "f1" });
+        const b = runEvidenceRefRecordKey({ eventKey: "ev1", refKind: "file", targetTable: "file", targetId: "f1" });
+        const c = runEvidenceRefRecordKey({ eventKey: "ev1", refKind: "file", targetTable: "file", targetId: "f2" });
+        expect(a).toBe(b);
+        expect(a).not.toBe(c);
+    });
+});
+
+describe("buildRunEvidenceEventStatement", () => {
+    test("emits an idempotent UPSERT...MERGE with session link + required fields", () => {
+        const sql = buildRunEvidenceEventStatement(baseEvent);
+        expect(sql).toStartWith("UPSERT run_evidence_event:`");
+        expect(sql).toContain("MERGE {");
+        expect(sql).toContain("session: session:`sess-1`");
+        expect(sql).toContain('provider: "claude"');
+        expect(sql).toContain('kind: "tool_observation"');
+        expect(sql).toContain('backing: "tool_backed"');
+        expect(sql).toContain('source_table: "tool_call"');
+        expect(sql).toContain('source_id: "tc-abc"');
+        expect(sql).toEndWith("};");
+    });
+
+    test("same input produces byte-identical SQL (rebuildable)", () => {
+        expect(buildRunEvidenceEventStatement(baseEvent)).toBe(buildRunEvidenceEventStatement(baseEvent));
+    });
+
+    test("absent optionals encode as NONE; present hot refs become record links", () => {
+        const sql = buildRunEvidenceEventStatement(baseEvent);
+        expect(sql).toContain("root_session: NONE");
+        expect(sql).toContain("parent_session: NONE");
+        expect(sql).toContain("summary: NONE");
+        // No hot ref provided -> the field is omitted, not NONE-spammed.
+        expect(sql).not.toContain("tool_call:");
+
+        const withRefs = buildRunEvidenceEventStatement({
+            ...baseEvent,
+            toolCallKey: "tc-abc",
+            fileKey: "repo__src_x_ts",
+            rootSessionId: "root-1",
+        });
+        expect(withRefs).toContain("tool_call: tool_call:`tc-abc`");
+        expect(withRefs).toContain("file: file:`repo__src_x_ts`");
+        expect(withRefs).toContain("root_session: session:`root-1`");
+    });
+
+    test("observed_at is omitted unless provided (default-once semantics)", () => {
+        expect(buildRunEvidenceEventStatement(baseEvent)).not.toContain("observed_at:");
+        const stamped = buildRunEvidenceEventStatement({ ...baseEvent, observedAt: "2026-06-21T11:00:00.000Z" });
+        expect(stamped).toContain('observed_at: d"2026-06-21T11:00:00.000Z"');
+    });
+
+    test("attrs object is JSON-encoded into the attrs string column", () => {
+        const sql = buildRunEvidenceEventStatement({ ...baseEvent, attrs: { exit: 0, cmd: "bun test" } });
+        expect(sql).toContain('attrs: "{\\"exit\\":0,\\"cmd\\":\\"bun test\\"}"');
+        // Empty object collapses to NONE (no noise rows).
+        expect(buildRunEvidenceEventStatement({ ...baseEvent, attrs: {} })).toContain("attrs: NONE");
+    });
+});
+
+describe("buildRunEvidenceRefStatement", () => {
+    const baseRef: RunEvidenceRefWrite = {
+        eventKey: "ev-1",
+        sessionId: "sess-1",
+        ts: "2026-06-21T10:00:00.000Z",
+        refKind: "file",
+        targetTable: "file",
+        targetId: "f1",
+        pathHash: "abc123",
+    };
+
+    test("links to its event + session and defaults privacy to ref_only", () => {
+        const sql = buildRunEvidenceRefStatement(baseRef);
+        expect(sql).toStartWith("UPSERT run_evidence_ref:`");
+        expect(sql).toContain("event: run_evidence_event:`ev-1`");
+        expect(sql).toContain("session: session:`sess-1`");
+        expect(sql).toContain('ref_kind: "file"');
+        expect(sql).toContain('path_hash: "abc123"');
+        expect(sql).toContain('privacy_level: "ref_only"');
+        expect(sql).toContain("uri_hash: NONE");
+    });
+
+    test("explicit privacy level is honored", () => {
+        const sql = buildRunEvidenceRefStatement({ ...baseRef, privacyLevel: "hashed" });
+        expect(sql).toContain('privacy_level: "hashed"');
+    });
+});
+
+describe("buildRunEvidenceStatements", () => {
+    test("emits events before refs", () => {
+        const stmts = buildRunEvidenceStatements({
+            events: [baseEvent],
+            refs: [{ eventKey: "ev-1", sessionId: "sess-1", ts: baseEvent.ts, refKind: "record" }],
+        });
+        expect(stmts).toHaveLength(2);
+        expect(stmts[0]).toContain("run_evidence_event:");
+        expect(stmts[1]).toContain("run_evidence_ref:");
+    });
+});

--- a/packages/lib/src/shared/run-evidence.ts
+++ b/packages/lib/src/shared/run-evidence.ts
@@ -1,0 +1,303 @@
+/**
+ * Run evidence ledger contract (#578).
+ *
+ * A metadata-only overlay on the normalized graph: it normalizes facts already
+ * in `turn` / `tool_call` / `agent_event` / `plan_snapshot` / `compaction` /
+ * `command_outcome` / hook tables into a single reviewer-facing ledger that can
+ * answer, for a run: objective, durable task state, tool-backed observations,
+ * verifier results, policy decisions, and what was lost at compaction/resume
+ * boundaries - and can distinguish a model CLAIM from tool-BACKED evidence.
+ *
+ * This module is the shared CONTRACT + deterministic statement builders. It has
+ * no DB or parser dependency, so both a future ingest stage and read queries can
+ * reuse it. The two tables it targets are `run_evidence_event` and
+ * `run_evidence_ref` (see packages/schema/src/schema.surql).
+ *
+ * Design invariants (from the issue thread):
+ *   - Refs + hashes by default, never raw private payloads (`privacy_level`).
+ *   - `backing` is verifier-DERIVED from joins, not a producer trust label - no
+ *     automatic promotion (repeated claims never become observations; policy
+ *     permission is not proof of execution).
+ *   - Rows are REBUILDABLE: the event key is derived from
+ *     (session, source_table, source_id), so re-deriving overwrites in place.
+ */
+
+import { Schema } from "effect";
+import { stableDigest } from "../ids.ts";
+import {
+    recordRef,
+    safeKeyPart,
+    surrealDate,
+    surrealObject,
+    surrealOptionDate,
+    surrealOptionRecord,
+    surrealOptionString,
+    surrealString,
+} from "./surreal.ts";
+
+// ============================================================================
+// 1. ENUMS / CLOSED SETS
+// ----------------------------------------------------------------------------
+// Each closed set is a const tuple (the single source of truth) + a derived
+// Effect `Schema.Literal` union, so the same values validate at the boundary
+// and type the builder input.
+// ============================================================================
+
+/** What an evidence event asserts about the run. */
+export const RUN_EVIDENCE_KINDS = [
+    "objective",
+    "task_state",
+    "tool_observation",
+    "verification",
+    "policy_decision",
+    "boundary",
+    "artifact_ref",
+    "repo_state",
+    "claim",
+    "derived_summary",
+] as const;
+export const RunEvidenceKind = Schema.Literals(RUN_EVIDENCE_KINDS);
+export type RunEvidenceKind = typeof RunEvidenceKind.Type;
+
+/**
+ * How well-grounded the event is. Verifier-derived from available joins, never a
+ * producer-controlled trust label. No automatic promotion between classes.
+ */
+export const RUN_EVIDENCE_BACKINGS = [
+    "model_claim",
+    "tool_backed",
+    "verifier_backed",
+    "policy_backed",
+    "derived",
+    "unknown",
+] as const;
+export const RunEvidenceBacking = Schema.Literals(RUN_EVIDENCE_BACKINGS);
+export type RunEvidenceBacking = typeof RunEvidenceBacking.Type;
+
+/** What kind of thing a ref points at. */
+export const RUN_EVIDENCE_REF_KINDS = [
+    "record",
+    "file",
+    "sidecar",
+    "url",
+    "command",
+    "commit",
+    "external_event",
+] as const;
+export const RunEvidenceRefKind = Schema.Literals(RUN_EVIDENCE_REF_KINDS);
+export type RunEvidenceRefKind = typeof RunEvidenceRefKind.Type;
+
+/**
+ * How much of the underlying payload a ref retains. Defaults to `ref_only` -
+ * structural pointer + hashes, no payload - so the ledger never re-leaks private
+ * content the producer already holds.
+ */
+export const RUN_EVIDENCE_PRIVACY_LEVELS = [
+    "ref_only",
+    "hashed",
+    "summary",
+    "raw",
+] as const;
+export const RunEvidencePrivacyLevel = Schema.Literals(RUN_EVIDENCE_PRIVACY_LEVELS);
+export type RunEvidencePrivacyLevel = typeof RunEvidencePrivacyLevel.Type;
+
+// ============================================================================
+// 2. WRITE DTOs
+// ----------------------------------------------------------------------------
+// Plain interfaces consumed by the statement builders. Bare record KEYS (no
+// `table:` prefix) are passed for every link; the builder splices them through
+// `recordRef` / `surrealOptionRecord`.
+// ============================================================================
+
+/** Optional hot-ref keys into the normalized graph (bare record keys). */
+export interface RunEvidenceHotRefs {
+    readonly turnKey?: string | null;
+    readonly toolCallKey?: string | null;
+    readonly agentEventKey?: string | null;
+    readonly compactionKey?: string | null;
+    readonly planSnapshotKey?: string | null;
+    readonly commandOutcomeKey?: string | null;
+    readonly hookInvocationKey?: string | null;
+    readonly artifactKey?: string | null;
+    readonly fileKey?: string | null;
+    readonly checkoutKey?: string | null;
+    readonly commitKey?: string | null;
+}
+
+export interface RunEvidenceEventWrite extends RunEvidenceHotRefs {
+    /** Bare session id (no `session:` prefix) the evidence belongs to. */
+    readonly sessionId: string;
+    readonly rootSessionId?: string | null;
+    readonly parentSessionId?: string | null;
+    /** Logical event time (from the source row, not wall-clock). */
+    readonly ts: Date | string;
+    readonly provider: string;
+    readonly kind: RunEvidenceKind;
+    readonly backing: RunEvidenceBacking;
+    /** Table the evidence was normalized from, e.g. `tool_call`. */
+    readonly sourceTable: string;
+    /** Stable id within `sourceTable` (the producer's record/event id). */
+    readonly sourceId: string;
+    readonly summary?: string | null;
+    readonly contentHash?: string | null;
+    readonly inputHash?: string | null;
+    readonly outputHash?: string | null;
+    /** Free-form structured attributes; JSON-encoded into the `attrs` column. */
+    readonly attrs?: unknown;
+    /**
+     * When this derivation first observed the row. Omit to let the column
+     * default once at create time (keeps re-derivation idempotent - a later
+     * rebuild does not re-stamp it).
+     */
+    readonly observedAt?: Date | string | null;
+}
+
+export interface RunEvidenceRefWrite {
+    /** Bare key of the owning `run_evidence_event` row. */
+    readonly eventKey: string;
+    /** Bare session id (no `session:` prefix). */
+    readonly sessionId: string;
+    readonly ts: Date | string;
+    readonly refKind: RunEvidenceRefKind;
+    readonly targetTable?: string | null;
+    readonly targetId?: string | null;
+    readonly pathHash?: string | null;
+    readonly uriHash?: string | null;
+    readonly contentHash?: string | null;
+    readonly privacyLevel?: RunEvidencePrivacyLevel;
+    readonly attrs?: unknown;
+}
+
+// ============================================================================
+// 3. RECORD KEYS
+// ----------------------------------------------------------------------------
+// Deterministic + idempotent: the same logical source always yields the same
+// key, so re-derivation UPSERTs in place rather than duplicating.
+// ============================================================================
+
+/**
+ * `<session>__<digest(source_table|source_id)>` - one event row per
+ * (session, source row). Re-deriving the same source overwrites in place.
+ */
+export const runEvidenceEventRecordKey = (input: {
+    readonly sessionId: string;
+    readonly sourceTable: string;
+    readonly sourceId: string;
+}): string =>
+    `${safeKeyPart(input.sessionId)}__${stableDigest(`${input.sourceTable}|${input.sourceId}`)}`;
+
+/**
+ * `<digest(event|refKind|target|path|uri)>` - one ref row per distinct pointer
+ * off an event. Stable across re-derivation.
+ */
+export const runEvidenceRefRecordKey = (input: {
+    readonly eventKey: string;
+    readonly refKind: RunEvidenceRefKind;
+    readonly targetTable?: string | null;
+    readonly targetId?: string | null;
+    readonly pathHash?: string | null;
+    readonly uriHash?: string | null;
+}): string =>
+    stableDigest(
+        [
+            input.eventKey,
+            input.refKind,
+            input.targetTable ?? "",
+            input.targetId ?? "",
+            input.pathHash ?? "",
+            input.uriHash ?? "",
+        ].join("|"),
+    );
+
+// ============================================================================
+// 4. STATEMENT BUILDERS
+// ----------------------------------------------------------------------------
+// Deterministic SurrealQL strings. UPSERT ... MERGE so a re-derive overwrites
+// the row in place. `attrs` is JSON-encoded; every ref/hash field is an
+// `option` literal (NONE when absent).
+// ============================================================================
+
+const optHotRef = (
+    fields: (readonly [string, string])[],
+    name: string,
+    table: string,
+    key: string | null | undefined,
+): void => {
+    if (key !== null && key !== undefined) fields.push([name, recordRef(table, key)]);
+};
+
+/** Build the `UPSERT run_evidence_event:... MERGE {...}` statement. */
+export const buildRunEvidenceEventStatement = (input: RunEvidenceEventWrite): string => {
+    const key = runEvidenceEventRecordKey(input);
+    const fields: (readonly [string, string])[] = [
+        ["session", recordRef("session", input.sessionId)],
+        ["root_session", surrealOptionRecord("session", input.rootSessionId)],
+        ["parent_session", surrealOptionRecord("session", input.parentSessionId)],
+        ["ts", surrealDate(input.ts)],
+        ["provider", surrealString(input.provider)],
+        ["kind", surrealString(input.kind)],
+        ["backing", surrealString(input.backing)],
+    ];
+    optHotRef(fields, "turn", "turn", input.turnKey);
+    optHotRef(fields, "tool_call", "tool_call", input.toolCallKey);
+    optHotRef(fields, "agent_event", "agent_event", input.agentEventKey);
+    optHotRef(fields, "compaction", "compaction", input.compactionKey);
+    optHotRef(fields, "plan_snapshot", "plan_snapshot", input.planSnapshotKey);
+    optHotRef(fields, "command_outcome", "command_outcome", input.commandOutcomeKey);
+    optHotRef(fields, "hook_invocation", "hook_command_invocation", input.hookInvocationKey);
+    optHotRef(fields, "artifact", "artifact", input.artifactKey);
+    optHotRef(fields, "file", "file", input.fileKey);
+    optHotRef(fields, "checkout", "checkout", input.checkoutKey);
+    optHotRef(fields, "commit", "commit", input.commitKey);
+    fields.push(
+        ["source_table", surrealString(input.sourceTable)],
+        ["source_id", surrealString(input.sourceId)],
+        ["summary", surrealOptionString(input.summary)],
+        ["content_hash", surrealOptionString(input.contentHash)],
+        ["input_hash", surrealOptionString(input.inputHash)],
+        ["output_hash", surrealOptionString(input.outputHash)],
+        ["attrs", surrealOptionString(encodeAttrs(input.attrs))],
+    );
+    // Omit observed_at unless explicitly provided so the column defaults once at
+    // create time and a later rebuild does not re-stamp it (idempotent).
+    if (input.observedAt !== undefined && input.observedAt !== null) {
+        fields.push(["observed_at", surrealOptionDate(input.observedAt)]);
+    }
+    return `UPSERT ${recordRef("run_evidence_event", key)} MERGE ${surrealObject(fields)};`;
+};
+
+/** Build the `UPSERT run_evidence_ref:... MERGE {...}` statement. */
+export const buildRunEvidenceRefStatement = (input: RunEvidenceRefWrite): string => {
+    const key = runEvidenceRefRecordKey(input);
+    const fields: (readonly [string, string])[] = [
+        ["event", recordRef("run_evidence_event", input.eventKey)],
+        ["session", recordRef("session", input.sessionId)],
+        ["ts", surrealDate(input.ts)],
+        ["ref_kind", surrealString(input.refKind)],
+        ["target_table", surrealOptionString(input.targetTable)],
+        ["target_id", surrealOptionString(input.targetId)],
+        ["path_hash", surrealOptionString(input.pathHash)],
+        ["uri_hash", surrealOptionString(input.uriHash)],
+        ["content_hash", surrealOptionString(input.contentHash)],
+        ["privacy_level", surrealString(input.privacyLevel ?? "ref_only")],
+        ["attrs", surrealOptionString(encodeAttrs(input.attrs))],
+    ];
+    return `UPSERT ${recordRef("run_evidence_ref", key)} MERGE ${surrealObject(fields)};`;
+};
+
+/** Build all statements for a batch (events first, then refs). */
+export const buildRunEvidenceStatements = (batch: {
+    readonly events: readonly RunEvidenceEventWrite[];
+    readonly refs: readonly RunEvidenceRefWrite[];
+}): string[] => [
+    ...batch.events.map(buildRunEvidenceEventStatement),
+    ...batch.refs.map(buildRunEvidenceRefStatement),
+];
+
+/** JSON-encode attrs to a string column value (null when absent/empty). */
+const encodeAttrs = (attrs: unknown): string | null => {
+    if (attrs === null || attrs === undefined) return null;
+    if (typeof attrs === "string") return attrs;
+    const json = JSON.stringify(attrs);
+    return json === undefined || json === "{}" ? null : json;
+};

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -2120,3 +2120,73 @@ DEFINE TABLE telemetry_of TYPE RELATION SCHEMAFULL;
 DEFINE FIELD linked_at ON telemetry_of TYPE datetime DEFAULT time::now();
 DEFINE INDEX IF NOT EXISTS telemetry_of_in  ON telemetry_of FIELDS in;
 DEFINE INDEX IF NOT EXISTS telemetry_of_out ON telemetry_of FIELDS out;
+
+-- ---------------------------------------------------------------------------
+-- Run evidence ledger (#578) - a metadata-only overlay on the normalized graph.
+-- It does NOT re-parse harnesses; it normalizes facts already in `turn`,
+-- `tool_call`, `agent_event`, `plan_snapshot`, `compaction`, `command_outcome`,
+-- and hook tables into a single queryable, reviewer-facing ledger that answers,
+-- for a run: objective, durable task state, tool-backed observations, verifier
+-- results, policy decisions, and what was lost at compaction/resume boundaries.
+--
+-- Two invariants:
+--   1. Refs + hashes by default, never raw private payloads (privacy_level).
+--   2. `backing` is verifier-DERIVED from available joins, not a producer trust
+--      label - repeated claims never become observations, policy permission is
+--      not proof of execution. No automatic promotion.
+-- Rows are rebuildable: the key is derived from (session, source_table,
+-- source_id) so re-deriving overwrites in place (idempotent UPSERT).
+-- ---------------------------------------------------------------------------
+DEFINE TABLE IF NOT EXISTS run_evidence_event SCHEMAFULL;
+DEFINE FIELD session         ON run_evidence_event TYPE record<session>;
+DEFINE FIELD root_session    ON run_evidence_event TYPE option<record<session>>;
+DEFINE FIELD parent_session  ON run_evidence_event TYPE option<record<session>>;
+DEFINE FIELD ts              ON run_evidence_event TYPE datetime DEFAULT time::now();
+DEFINE FIELD provider        ON run_evidence_event TYPE string;
+-- objective|task_state|tool_observation|verification|policy_decision|boundary|artifact_ref|repo_state|claim|derived_summary
+DEFINE FIELD kind            ON run_evidence_event TYPE string;
+-- model_claim|tool_backed|verifier_backed|policy_backed|derived|unknown
+DEFINE FIELD backing         ON run_evidence_event TYPE string;
+-- Optional hot refs into the normalized graph (kept as links for traversal).
+DEFINE FIELD turn            ON run_evidence_event TYPE option<record<turn>>;
+DEFINE FIELD tool_call       ON run_evidence_event TYPE option<record<tool_call>>;
+DEFINE FIELD agent_event     ON run_evidence_event TYPE option<record<agent_event>>;
+DEFINE FIELD compaction      ON run_evidence_event TYPE option<record<compaction>>;
+DEFINE FIELD plan_snapshot   ON run_evidence_event TYPE option<record<plan_snapshot>>;
+DEFINE FIELD command_outcome ON run_evidence_event TYPE option<record<command_outcome>>;
+DEFINE FIELD hook_invocation ON run_evidence_event TYPE option<record<hook_command_invocation>>;
+DEFINE FIELD artifact        ON run_evidence_event TYPE option<record<artifact>>;
+DEFINE FIELD file            ON run_evidence_event TYPE option<record<file>>;
+DEFINE FIELD checkout        ON run_evidence_event TYPE option<record<checkout>>;
+DEFINE FIELD commit          ON run_evidence_event TYPE option<record<commit>>;
+-- Provenance back to the source row this evidence was normalized from.
+DEFINE FIELD source_table    ON run_evidence_event TYPE string;
+DEFINE FIELD source_id       ON run_evidence_event TYPE string;
+DEFINE FIELD summary         ON run_evidence_event TYPE option<string>;
+DEFINE FIELD content_hash    ON run_evidence_event TYPE option<string>;
+DEFINE FIELD input_hash      ON run_evidence_event TYPE option<string>;
+DEFINE FIELD output_hash     ON run_evidence_event TYPE option<string>;
+DEFINE FIELD attrs           ON run_evidence_event TYPE option<string>;  -- JSON-encoded
+DEFINE FIELD observed_at     ON run_evidence_event TYPE datetime DEFAULT time::now();
+DEFINE INDEX IF NOT EXISTS run_evidence_event_session  ON run_evidence_event FIELDS session, ts;
+DEFINE INDEX IF NOT EXISTS run_evidence_event_kind     ON run_evidence_event FIELDS session, kind;
+DEFINE INDEX IF NOT EXISTS run_evidence_event_source   ON run_evidence_event FIELDS source_table, source_id;
+DEFINE INDEX IF NOT EXISTS run_evidence_event_observed ON run_evidence_event FIELDS observed_at;
+
+DEFINE TABLE IF NOT EXISTS run_evidence_ref SCHEMAFULL;
+DEFINE FIELD event         ON run_evidence_ref TYPE record<run_evidence_event>;
+DEFINE FIELD session       ON run_evidence_ref TYPE record<session>;
+DEFINE FIELD ts            ON run_evidence_ref TYPE datetime DEFAULT time::now();
+-- record|file|sidecar|url|command|commit|external_event
+DEFINE FIELD ref_kind      ON run_evidence_ref TYPE string;
+DEFINE FIELD target_table  ON run_evidence_ref TYPE option<string>;
+DEFINE FIELD target_id     ON run_evidence_ref TYPE option<string>;
+DEFINE FIELD path_hash     ON run_evidence_ref TYPE option<string>;
+DEFINE FIELD uri_hash      ON run_evidence_ref TYPE option<string>;
+DEFINE FIELD content_hash  ON run_evidence_ref TYPE option<string>;
+-- ref_only|hashed|summary|raw  (default ref_only - structural refs, no payload)
+DEFINE FIELD privacy_level ON run_evidence_ref TYPE string;
+DEFINE FIELD attrs         ON run_evidence_ref TYPE option<string>;  -- JSON-encoded
+DEFINE INDEX IF NOT EXISTS run_evidence_ref_event   ON run_evidence_ref FIELDS event;
+DEFINE INDEX IF NOT EXISTS run_evidence_ref_session ON run_evidence_ref FIELDS session, ts;
+DEFINE INDEX IF NOT EXISTS run_evidence_ref_target  ON run_evidence_ref FIELDS target_table, target_id;

--- a/packages/schema/src/schema.test.ts
+++ b/packages/schema/src/schema.test.ts
@@ -327,3 +327,38 @@ describe("proposal.origin NONE-coerce guard (#472)", () => {
         expect(schema).toContain("UPDATE proposal SET origin = 'mined' WHERE origin = NONE;");
     });
 });
+
+describe("run evidence ledger schema (#578)", () => {
+    test("both tables are defined exactly once", () => {
+        for (const table of ["run_evidence_event", "run_evidence_ref"]) {
+            const matches = schema.match(new RegExp(`DEFINE TABLE IF NOT EXISTS ${table} SCHEMAFULL`, "g"));
+            expect(matches).not.toBeNull();
+            expect(matches!.length).toBe(1);
+        }
+    });
+
+    test("event row anchors to a session and records source provenance", () => {
+        expect(schema).toContain("DEFINE FIELD session         ON run_evidence_event TYPE record<session>");
+        expect(schema).toContain("DEFINE FIELD source_table    ON run_evidence_event TYPE string");
+        expect(schema).toContain("DEFINE FIELD source_id       ON run_evidence_event TYPE string");
+        expect(schema).toContain("DEFINE FIELD backing         ON run_evidence_event TYPE string");
+    });
+
+    test("ref row links to its event + session and carries privacy_level", () => {
+        expect(schema).toContain("DEFINE FIELD event         ON run_evidence_ref TYPE record<run_evidence_event>");
+        expect(schema).toContain("DEFINE FIELD session       ON run_evidence_ref TYPE record<session>");
+        expect(schema).toContain("DEFINE FIELD privacy_level ON run_evidence_ref TYPE string");
+    });
+
+    test("query-prefix indexes are present", () => {
+        expect(schema).toContain(
+            "DEFINE INDEX IF NOT EXISTS run_evidence_event_session  ON run_evidence_event FIELDS session, ts",
+        );
+        expect(schema).toContain(
+            "DEFINE INDEX IF NOT EXISTS run_evidence_event_source   ON run_evidence_event FIELDS source_table, source_id",
+        );
+        expect(schema).toContain(
+            "DEFINE INDEX IF NOT EXISTS run_evidence_ref_event   ON run_evidence_ref FIELDS event",
+        );
+    });
+});


### PR DESCRIPTION
First (lowest-risk) slice of #578 — the cross-harness **run evidence ledger**. Schema + contract + builders + tests only; **no** parser changes, CLI, MCP, or Studio UI (those are follow-ups, per the agreed scope in the issue thread).

## What this is

A metadata-only overlay on the normalized graph (not a re-parse). It will normalize facts already in `turn` / `tool_call` / `agent_event` / `plan_snapshot` / `compaction` / `command_outcome` / hook tables into one reviewer-facing ledger that can answer, for a run: objective, durable task state, tool-backed observations, verifier results, policy decisions, and what was lost at compaction/resume boundaries — and **distinguish a model claim from tool-backed evidence**.

## In this PR

- **Schema** (`packages/schema/src/schema.surql`): two SCHEMAFULL tables
  - `run_evidence_event` — `kind` (objective/task_state/tool_observation/verification/policy_decision/boundary/artifact_ref/repo_state/claim/derived_summary) × `backing` (model_claim/tool_backed/verifier_backed/policy_backed/derived/unknown), optional hot refs into the graph (turn, tool_call, agent_event, compaction, plan_snapshot, command_outcome, hook_invocation, artifact, file, checkout, commit), source provenance (`source_table`/`source_id`), and content/input/output hashes. Indexes on `(session, ts)`, `(session, kind)`, `(source_table, source_id)`, `observed_at`.
  - `run_evidence_ref` — structural ref/hash pointers (`ref_kind`, `target_table`/`target_id`, `path_hash`/`uri_hash`/`content_hash`) with `privacy_level`.
- **Contract** (`packages/lib/src/shared/run-evidence.ts`): closed-set Effect Schema enums, write DTOs, deterministic record keys, and `UPSERT…MERGE` statement builders. DB- and parser-free, so a future ingest stage and the read queries both reuse it.
- **SCHEMA_TABLES** registry entries + schema/contract tests.

## Design invariants (from the thread)

- **Refs + hashes by default, never raw payloads** — `privacy_level` defaults to `ref_only`.
- **`backing` is verifier-derived, not a producer trust label** — no automatic promotion (repeated claims never become observations; policy permission ≠ proof of execution).
- **Rebuildable rows** — the event key is derived from `(session, source_table, source_id)`, so re-deriving overwrites in place (idempotent UPSERT); `observed_at` is default-once so a rebuild doesn't re-stamp it.

## Validation

- 78 unit tests across contract + schema + insights mirror; enums validate/reject, builders emit byte-identical idempotent SQL, hot-refs become record links, absent options encode as `NONE`, attrs JSON-encode.
- **Live-verified**: the full schema imports into SurrealDB 3.1 with *"Import executed with no errors"*, both tables land SCHEMAFULL, and a real builder-shaped event+ref insert validates (record links coerced).
- Full repo `bun test`: +14 tests, only the 3 pre-existing env failures remain (`makeTestConfig` reads this machine's DB port; two `doctor` checks need a live DB) — all on `main` already, none related.

## Not in this PR (follow-ups)

Ingest derive-stage that populates the ledger; honest per-provider capability/coverage states; the `ax runs evidence <session>` read surface + MCP parity; Studio panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)