### PR TITLE
fix(ledger): verification = real checks only + clear stale hot refs (#578)

### DIFF
--- a/apps/axctl/src/ingest/derive-run-evidence.test.ts
+++ b/apps/axctl/src/ingest/derive-run-evidence.test.ts
@@ -49,7 +49,19 @@ describe("buildRunEvidenceEvents - source -> (kind, backing) mapping", () => {
         expect(e.provider).toBe("codex");
         expect(e.commandOutcomeKey).toBe("co1");
         expect(e.toolCallKey).toBe("tc9");
-        expect(e.summary).toBe("success: ok");
+        // summary + attrs are keyed on the check FAMILY (test), not the raw kind.
+        expect(e.summary).toBe("test: ok");
+        expect((e.attrs as { family?: string }).family).toBe("test");
+    });
+
+    test("non-check command_outcome (a plain success) is NOT a verification (#578 review)", () => {
+        // A successful Read/ls produces a command_outcome kind=success; it must
+        // not become verifier_backed evidence.
+        const events = buildRunEvidenceEvents({
+            ...empty,
+            commandOutcomes: [{ id: "co2", session: "sess-claude", ts: "2026-06-21T10:02:00.000Z", kind: "success", status: "ok", commandNorm: "ls -la" }],
+        });
+        expect(events).toHaveLength(0);
     });
 
     test("compaction -> boundary / derived (NOT tool_backed)", () => {
@@ -97,7 +109,7 @@ describe("buildRunEvidenceEvents - invariants", () => {
         const events = buildRunEvidenceEvents({
             ...empty,
             toolCalls: [{ id: "tc1", session: "sess-claude", ts: "2026-06-21T10:00:00.000Z", name: "Bash" }],
-            commandOutcomes: [{ id: "co1", session: "sess-claude", ts: "2026-06-21T10:01:00.000Z", status: "error" }],
+            commandOutcomes: [{ id: "co1", session: "sess-claude", ts: "2026-06-21T10:01:00.000Z", status: "error", commandNorm: "bun test" }],
             compactions: [{ id: "cmp1", session: "sess-claude", ts: "2026-06-21T10:02:00.000Z" }],
             planSnapshots: [{ id: "ps1", session: "sess-claude", ts: "2026-06-21T10:03:00.000Z" }],
         });

--- a/apps/axctl/src/ingest/derive-run-evidence.ts
+++ b/apps/axctl/src/ingest/derive-run-evidence.ts
@@ -31,6 +31,7 @@ import type { DbError } from "@ax/lib/errors";
 import { stableDigest } from "@ax/lib/ids";
 import { EDIT_TOOL_NAMES } from "@ax/lib/shared/tool-classes";
 import { executeStatementsWith } from "@ax/lib/shared/surreal";
+import { checkFamilyFromCommand } from "./check-family.ts";
 import {
     buildRunEvidenceStatements,
     runEvidenceEventRecordKey,
@@ -181,6 +182,13 @@ const toToolObservation = (row: ToolCallRow, provider: string): RunEvidenceEvent
 
 const toVerification = (row: CommandOutcomeRow, provider: string): RunEvidenceEventWrite | null => {
     if (!row.session) return null;
+    // command_outcome is written for EVERY tool_call - `classifyCommandOutcome`
+    // returns "success" for any non-error row - so without this filter a plain
+    // `Read`/`ls` succeeding would become verifier_backed evidence, violating the
+    // no-promotion rule. A `verification` is ONLY a genuine check (test / build /
+    // lint / typecheck), identified by the command's check family (#578 review).
+    const family = checkFamilyFromCommand(row.commandNorm ?? null);
+    if (family === null) return null;
     return {
         sessionId: row.session,
         ts: row.ts,
@@ -191,11 +199,11 @@ const toVerification = (row: CommandOutcomeRow, provider: string): RunEvidenceEv
         sourceId: row.id,
         commandOutcomeKey: row.id,
         toolCallKey: row.toolCall ?? null,
-        summary: `${row.kind ?? "outcome"}: ${row.status ?? "?"}`,
+        summary: `${family}: ${row.status ?? "?"}`,
         attrs: dropUndefined({
+            family,
             kind: row.kind ?? undefined,
             status: row.status ?? undefined,
-            command_norm: row.commandNorm ?? undefined,
         }),
     };
 };

--- a/packages/lib/src/shared/run-evidence.test.ts
+++ b/packages/lib/src/shared/run-evidence.test.ts
@@ -95,8 +95,9 @@ describe("buildRunEvidenceEventStatement", () => {
         expect(sql).toContain("root_session: NONE");
         expect(sql).toContain("parent_session: NONE");
         expect(sql).toContain("summary: NONE");
-        // No hot ref provided -> the field is omitted, not NONE-spammed.
-        expect(sql).not.toContain("tool_call:");
+        // Hot refs are ALWAYS emitted (NONE when absent) so a MERGE re-derive
+        // clears a ref that disappeared between runs - no stale links.
+        expect(sql).toContain("tool_call: NONE");
 
         const withRefs = buildRunEvidenceEventStatement({
             ...baseEvent,

--- a/packages/lib/src/shared/run-evidence.ts
+++ b/packages/lib/src/shared/run-evidence.ts
@@ -223,7 +223,11 @@ const optHotRef = (
     table: string,
     key: string | null | undefined,
 ): void => {
-    if (key !== null && key !== undefined) fields.push([name, recordRef(table, key)]);
+    // Always emit the field (NONE when absent) so a MERGE re-derive CLEARS a hot
+    // ref that disappeared between runs, instead of leaving a stale link. (CONTENT
+    // would also clear, but would re-fire the observed_at DEFAULT every run; MERGE
+    // + explicit NONE keeps observed_at default-once.)
+    fields.push([name, surrealOptionRecord(table, key)]);
 };
 
 /** Build the `UPSERT run_evidence_event:... MERGE {...}` statement. */


### PR DESCRIPTION
Two correctness fixes from the **Codex review** of the merged run-evidence ledger.

## A — verification inflation (the real bug)

`command_outcome` is written for **every** tool_call — `classifyCommandOutcome` returns `"success"` for any non-error row (`outcomes.ts:87`). So slice 2's mapper turned every successful `Read`/`ls` into `verification` / `verifier_backed` evidence, **violating the no-promotion rule** (the strongest backing class applied to non-verifications).

Fix: `toVerification` emits only when the command is a genuine check — `checkFamilyFromCommand(command_norm) != null` (test/build/lint/typecheck). Everything else is skipped. summary + attrs now key on the check **family**, and the raw `command_norm` is dropped from attrs (privacy — it stays on the source row).

## B — stale hot-ref links

Event writes are `UPSERT … MERGE`, but optional hot refs were *omitted* when absent — so a re-derive that no longer has a given ref left the prior run's link dangling. `optHotRef` now always emits the field as `NONE` (MERGE clears it). Chose explicit-NONE over `CONTENT` because CONTENT would re-fire the `observed_at` DEFAULT every run; explicit-NONE keeps `observed_at` default-once.

## On the rest of the review

Codex's clone was **behind `main`** (the same staleness this very ledger is built to expose 🙂), so 3 of its findings were already shipped: refs (#644), the `runs evidence` read surface (#643), the `edited` bridge (#645). The remaining real items — `repo_state` from `session.checkout`, not trusting the always-false `checkout.dirty`, `compaction_summary` keying instead of `#summary`, and `root/parent_session` via the `spawned` edge — land with **slice 6** (the new kinds).

## Validation

+1 test (a plain successful `ls` is **not** a verification); existing summary/NONE assertions updated. Typecheck + full repo `bun test` green but for the 3 pre-existing env failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)