### PR TITLE
feat(studio): run-evidence panel in the session inspector (#578, slice 7)

### DIFF
--- a/apps/axctl/src/dashboard/contract/sessions.ts
+++ b/apps/axctl/src/dashboard/contract/sessions.ts
@@ -16,6 +16,7 @@ import { fetchSessionCanvas, fetchSessionOrchestration } from "../session-canvas
 import { fetchSessionCompare } from "../session-compare.ts";
 import { fetchSessionInsights } from "../session-insights.ts";
 import { fetchSessionInspect } from "../session-inspect.ts";
+import { fetchRunEvidence } from "../../queries/run-evidence.ts";
 import { fetchSessionSummary } from "../session-summary.ts";
 import { fetchSessionChildren, fetchSessionsList } from "../sessions-list.ts";
 import { internal, orInternal } from "./common.ts";
@@ -72,6 +73,8 @@ export const SessionsGroupLive = HttpApiBuilder.group(AxApi, "sessions", (handle
                 Effect.provide(SessionTimelineServiceLayer),
                 Effect.mapError(notFoundOrInternal),
             ))
+        .handle("sessionEvidence", ({ params }) =>
+            orInternal(fetchRunEvidence({ sessionId: params.id })))
         .handle("sessionDetail", ({ params }) =>
             // The Enriched Session facade is the single home for assembling a
             // session read model. This route fetches strictly LESS than the CLI:

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -8,6 +8,7 @@ import type {
     NextActionsPayload,
     ProjectPagePayload,
     RecallResponse,
+    RunEvidencePayload,
     SkillGraphPayload,
     SessionCanvasPayload,
     SessionOrchestration,
@@ -449,6 +450,11 @@ export const api = {
                     ...(params.turnLimit != null ? { turn_limit: params.turnLimit } : {}),
                 },
             }),
+        ),
+    sessionEvidence: (sessionId: string): Promise<RunEvidencePayload> =>
+        viaContractUnknown(
+            `/api/sessions/${encodeURIComponent(sessionId)}/evidence`,
+            (c) => c.sessions.sessionEvidence({ params: { id: sessionId } }),
         ),
     sessionTimeline: (sessionId: string): Promise<SessionTimelinePayload> =>
         viaContractUnknown(

--- a/apps/studio/src/routes/run-evidence-panel.test.tsx
+++ b/apps/studio/src/routes/run-evidence-panel.test.tsx
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { RunEvidencePayload } from "@ax/lib/shared/dashboard-types";
+import { RunEvidencePanel } from "./session-inspect.tsx";
+
+const payload = (over: Partial<RunEvidencePayload>): RunEvidencePayload => ({
+    session_id: "s1",
+    generated_at: "2026-07-01T00:00:00.000Z",
+    objective: null,
+    repo: null,
+    total: 0,
+    by_kind: [],
+    by_backing: [],
+    timeline: [],
+    ref_total: 0,
+    by_ref_kind: [],
+    covered_kinds: [],
+    timeline_limit: 50,
+    ...over,
+});
+
+const render = (sessionId: string, data: RunEvidencePayload): string => {
+    const qc = new QueryClient();
+    qc.setQueryData(["run-evidence", sessionId], data);
+    return renderToStaticMarkup(
+        <QueryClientProvider client={qc}>
+            <RunEvidencePanel sessionId={sessionId} />
+        </QueryClientProvider>,
+    );
+};
+
+test("renders objective + repo headlines + kind/backing counts + ref count", () => {
+    const html = render("s1", payload({
+        total: 5,
+        objective: "Add omp harness support",
+        repo: "Necmttn/ax @ feat/636 · a1b2c3d",
+        by_kind: [{ key: "tool_observation", count: 4 }, { key: "objective", count: 1 }],
+        by_backing: [{ key: "tool_backed", count: 4 }, { key: "model_claim", count: 0 }],
+        ref_total: 2,
+        by_ref_kind: [{ key: "file", count: 2 }],
+    }));
+    expect(html).toContain("run evidence");
+    expect(html).toContain("Add omp harness support");
+    expect(html).toContain("Necmttn/ax @ feat/636 · a1b2c3d");
+    expect(html).toContain("tool_observation 4");
+    expect(html).toContain("tool_backed 4");
+    expect(html).toContain("2 refs");
+    expect(html).toContain("model_claim 0");
+});
+
+test("renders nothing when the session has no run-evidence events", () => {
+    const html = render("s2", payload({ total: 0 }));
+    expect(html).toBe("");
+});

--- a/apps/studio/src/routes/session-inspect.tsx
+++ b/apps/studio/src/routes/session-inspect.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useMemo, useRef, useState, type CSSProperties, type Re
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useParams } from "@tanstack/react-router";
 import { api } from "../api.ts";
-import type { HookFireDto, InspectSpanDto, InspectSpanKind, InspectTurnDto, SessionInspectPayload, SessionTokenUsageDetail, TurnTokenUsageDetail } from "@ax/lib/shared/dashboard-types";
+import type { HookFireDto, InspectSpanDto, InspectSpanKind, InspectTurnDto, RunEvidenceCount, RunEvidencePayload, SessionInspectPayload, SessionTokenUsageDetail, TurnTokenUsageDetail } from "@ax/lib/shared/dashboard-types";
 import { childrenByAnchorTurn, spawnAnchorSet, turnText } from "./inspector-filters.ts";
 import { spliceHookFires } from "@ax/lib/shared/hook-fire-splice";
 import { FilterBar } from "./inspector-filter-bar.tsx";
@@ -1683,6 +1683,55 @@ function TurnImpl({
  *  own props change (not on every parent hover/scroll/hash update). */
 export const Turn = memo(TurnImpl);
 
+const nonZeroCounts = (cs: ReadonlyArray<RunEvidenceCount>): string =>
+    cs.filter((c) => c.count > 0).map((c) => `${c.key} ${c.count}`).join(" · ");
+
+/**
+ * Run-evidence ledger header (#578): the run's objective + repo identity, then
+ * the kind/backing breakdown. Renders nothing until the ledger has events for
+ * this session (it derives at ingest). Fail-soft: a query error just hides it.
+ */
+export function RunEvidencePanel({ sessionId }: { readonly sessionId: string }) {
+    const q = useQuery({
+        queryKey: ["run-evidence", sessionId],
+        queryFn: () => api.sessionEvidence(sessionId),
+    });
+    const ev: RunEvidencePayload | undefined = q.data;
+    if (!ev || ev.total === 0) return null;
+    const claim = ev.by_backing.find((b) => b.key === "model_claim")?.count ?? 0;
+    return (
+        <div
+            style={{
+                padding: "10px var(--strip-x) 12px",
+                borderBottom: "1px solid var(--line)",
+                display: "grid",
+                gap: 5,
+                fontFamily: "ui-monospace, monospace",
+                fontSize: 12,
+            }}
+        >
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                <strong style={{ color: "var(--ink)", fontSize: 13 }}>run evidence</strong>
+                <span style={{ color: "var(--muted)" }}>
+                    {ev.total} event{ev.total === 1 ? "" : "s"}
+                    {ev.ref_total > 0 ? ` · ${ev.ref_total} ref${ev.ref_total === 1 ? "" : "s"}` : ""}
+                </span>
+            </div>
+            {ev.objective ? (
+                <div><span style={{ color: "var(--muted)" }}>objective </span><span style={{ color: "var(--ink)" }}>{ev.objective}</span></div>
+            ) : null}
+            {ev.repo ? (
+                <div><span style={{ color: "var(--muted)" }}>repo </span><span style={{ color: "var(--ink)" }}>{ev.repo}</span></div>
+            ) : null}
+            <div style={{ color: "var(--muted)" }}>kind: {nonZeroCounts(ev.by_kind)}</div>
+            <div style={{ color: "var(--muted)" }}>
+                backing: {nonZeroCounts(ev.by_backing)}
+                {claim === 0 ? <span style={{ opacity: 0.7 }}>  (model_claim 0)</span> : null}
+            </div>
+        </div>
+    );
+}
+
 export function SessionInspectRoute() {
     const { sessionId } = useParams({ from: "/sessions/$sessionId/inspect" });
     return <SessionInspectView sessionId={sessionId} />;
@@ -1848,6 +1897,7 @@ export function SessionInspectView({ sessionId }: { readonly sessionId: string }
                     <code>{shortSessionId(decoded)}…</code>
                 </span>
             </header>
+            <RunEvidencePanel sessionId={decoded} />
             {view === "timeline" ? <SessionTimelineView sessionId={decoded} /> : null}
             {view === "transcript" && query.error ? <div className="error">Error: {String(query.error)}</div> : null}
             {view === "transcript" && query.isLoading && !data ? <div className="loading">Loading…</div> : null}

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -698,6 +698,11 @@ export const SessionsGroup = HttpApiGroup.make("sessions")
             success: Schema.Unknown,
             error: [NotFoundError, InternalError],
         }),
+        HttpApiEndpoint.get("sessionEvidence", "/api/sessions/:id/evidence", {
+            params: { id: Schema.String },
+            success: Schema.Unknown,
+            error: InternalError,
+        }),
         HttpApiEndpoint.get("sessionDetail", "/api/sessions/:id", {
             params: { id: Schema.String },
             success: Schema.Unknown,

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -973,3 +973,40 @@ export interface ImproveActionResponse {
     readonly task_path?: string;
     readonly message?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Run evidence ledger (#578) - the `ax runs evidence` / Studio panel payload.
+// Mirrors `RunEvidenceResult` in apps/axctl/src/queries/run-evidence.ts (the
+// endpoint's contract success is `Schema.Unknown`, so this is the asserted shape
+// at the studio seam). Snake_case matches the query's JSON output.
+// ---------------------------------------------------------------------------
+
+export interface RunEvidenceCount {
+    readonly key: string;
+    readonly count: number;
+}
+
+export interface RunEvidenceTimelineRow {
+    readonly ts: string;
+    readonly kind: string;
+    readonly backing: string;
+    readonly source_table: string;
+    readonly summary: string | null;
+}
+
+export interface RunEvidencePayload {
+    readonly session_id: string;
+    readonly generated_at: string;
+    /** the run's stated goal (latest `objective` event), or null */
+    readonly objective: string | null;
+    /** the run's repo identity (latest `repo_state` event), or null */
+    readonly repo: string | null;
+    readonly total: number;
+    readonly by_kind: ReadonlyArray<RunEvidenceCount>;
+    readonly by_backing: ReadonlyArray<RunEvidenceCount>;
+    readonly timeline: ReadonlyArray<RunEvidenceTimelineRow>;
+    readonly ref_total: number;
+    readonly by_ref_kind: ReadonlyArray<RunEvidenceCount>;
+    readonly covered_kinds: ReadonlyArray<string>;
+    readonly timeline_limit: number;
+}


### PR DESCRIPTION
Surfaces the run-evidence ledger **in Studio**, same-origin. The data was already reachable via `ax runs evidence` + the `runs_evidence` MCP tool — this is the visual reviewer surface (the last non-`claim` piece of #578).

## Chain

- **Endpoint** `GET /api/sessions/:id/evidence` on the typed HttpApi contract (SessionsGroup); handler is a thin delegation to the existing `fetchRunEvidence` query (`success: Schema.Unknown`, like the sibling `sessionInspect`/`sessionTimeline` reads).
- **Shared type** `RunEvidencePayload` in `@ax/lib/shared/dashboard-types` (mirrors the query's `RunEvidenceResult`; asserted at the studio `viaContractUnknown` seam). Studio api client gains `sessionEvidence`.
- **`RunEvidencePanel`** in the session-inspect header: `objective` + `repo` headline lines, then kind/backing counts + ref count (`model_claim` shown even at 0). **Fail-soft** — renders nothing until the ledger has events for the session. Dark-shell tokens only.

```
run evidence                          61 events · 17 refs
objective  Add omp harness support
repo       Necmttn/ax @ feat/636 · a1b2c3d
kind: tool_observation 42 · policy_decision 3 · verification 8 · …
backing: tool_backed 44 · verifier_backed 8 · policy_backed 3   (model_claim 0)
```

## Validation

Typecheck clean across **lib + axctl + studio** (strict-null). 2 SSR panel tests (populated render asserts objective/repo/counts/refs; empty→`null`). Full repo `bun test` green but for the 3 pre-existing env failures.

**Caveat:** the actual HTTP round-trip needs a live `ax serve` daemon (not verifiable in this env). The contract is typed end-to-end and the handler mirrors `sessionInspect` exactly, so risk is low; CI's studio build + the contract types gate the wiring.

## #578 status

This closes the **read/visual** surface. Remaining: `claim` (model-assertion NLP, deferred as too noisy) + `artifact_ref`. Every other acceptance criterion — objective, durable task state, touched files, pending checks, claim-vs-tool-backed, run→child→tool→evidence traversal — is now answered across CLI, MCP, and Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)