### PR TITLE
docs(team): git-native zero-data team dashboard goal package (#649)

### DIFF
--- a/apps/site/app/routes/registry.tsx
+++ b/apps/site/app/routes/registry.tsx
@@ -304,6 +304,61 @@ function Registry() {
               </ul>
             </div>
           </div>
+          <p className="demo-caption">
+            <b>The registry is your git repo.</b> Blessed skills live in a folder
+            you own and version &mdash; ax adds governed sync and trust-gating on
+            top, and stores <b>zero company data</b> of its own. A breach of ours
+            has nothing of yours to leak.
+          </p>
+          <p className="demo-caption">
+            <b>Per-repo, opt-in, default-deny.</b> A skill lands on a laptop only
+            after <code>ax team sync</code> &mdash; and anything executable only
+            after an explicit <code>ax team trust</code> review. Never silently,
+            never machine-wide; personal projects are untouched.
+          </p>
+        </section>
+
+        {/* ============= pricing ============= */}
+        <section className="pitch-section" id="pricing">
+          <div className="pitch-head">
+            <span className="eyebrow">design-partner pricing</span>
+            <h2>
+              <em>$12</em> per developer, per month.
+            </h2>
+            <p>
+              Simple per-seat, self-serve, cancel anytime &mdash; a seat is a dev
+              on the team. Governed skill sync, trust-gating and the upstream-fix
+              loop, priced as an add-on to the agent stack you already run. Founder
+              pricing is locked for design partners.
+            </p>
+          </div>
+          <div className="ministats">
+            <div className="mini">
+              <div className="mini-label">Per seat</div>
+              <div className="mini-value"><span className="unit">$</span>12<span className="unit">/mo</span></div>
+              <div className="mini-sub">a seat = a dev on the team</div>
+            </div>
+            <div className="mini">
+              <div className="mini-label">10-dev team</div>
+              <div className="mini-value"><span className="unit">$</span>120<span className="unit">/mo</span></div>
+              <div className="mini-sub">one blessed skill pays for it</div>
+            </div>
+            <div className="mini">
+              <div className="mini-label">50-dev team</div>
+              <div className="mini-value"><span className="unit">$</span>600<span className="unit">/mo</span></div>
+              <div className="mini-sub">scales per seat, prorated</div>
+            </div>
+            <div className="mini">
+              <div className="mini-label">Cancel</div>
+              <div className="mini-value">anytime</div>
+              <div className="mini-sub">self-serve, via Stripe</div>
+            </div>
+          </div>
+          <p className="demo-caption">
+            You&rsquo;re paying for governed distribution and the fix loop &mdash;
+            never for a place to warehouse your code. Your skills and telemetry
+            stay in <b>your</b> git repo; we store none of it.
+          </p>
         </section>
 
         {/* ============= closing CTA ============= */}

--- a/apps/site/app/routes/teams.tsx
+++ b/apps/site/app/routes/teams.tsx
@@ -317,9 +317,12 @@ function Teams() {
               ax is AGPL-3.0 and runs entirely on each laptop. There is one real
               export today &mdash; <code>ax profile publish</code> &mdash; and it
               shows you the precise JSON in a consent prompt before the first byte
-              moves. The team aggregation layer is built to the same contract: a
-              local consent gate, ax-shaped aggregates only. Below is the design
-              contract we&rsquo;re building to.
+              moves. The team layer keeps that contract and goes further: your
+              team&rsquo;s aggregates live in <b>your own private git repo</b>, not
+              our database. The dashboard reads them in the browser with each
+              viewer&rsquo;s own GitHub login &mdash; repo access is the only key.
+              We store <b>zero company data</b>: a breach of ours has nothing of
+              yours to leak.
             </p>
           </div>
           <div className="pitch-lanes">
@@ -343,9 +346,60 @@ function Teams() {
             </div>
           </div>
           <p className="demo-caption">
+            <b>Per-project, opt-in, default-deny.</b> Nothing is collected until a
+            dev runs <code>ax team join</code> inside a specific repo. Personal
+            projects and other clients&rsquo; code are <em>never sent</em> &mdash;
+            not filtered out, never uploaded. Each dev&rsquo;s choice is private and
+            per-repo; a fork or rename can&rsquo;t leak the wrong one.
+          </p>
+          <p className="demo-caption">
             Verifiable today: <code>ax profile publish</code> prints the full
             payload and waits for your yes. Source is AGPL-3.0 &mdash; read the
             line, don&rsquo;t trust it.
+          </p>
+        </section>
+
+        {/* ============= pricing ============= */}
+        <section className="pitch-section" id="pricing">
+          <div className="pitch-head">
+            <span className="eyebrow">design-partner pricing</span>
+            <h2>
+              <em>$12</em> per developer, per month.
+            </h2>
+            <p>
+              Simple per-seat, self-serve, cancel anytime &mdash; a seat is a dev
+              who pushes to the team. It rides as an add-on to the $20&ndash;40 per
+              dev you already spend on agents, and pays for itself the moment it
+              redirects one routine sub-task off the expensive default. Founder
+              pricing is locked for design partners.
+            </p>
+          </div>
+          <div className="ministats">
+            <div className="mini">
+              <div className="mini-label">Per seat</div>
+              <div className="mini-value"><span className="unit">$</span>12<span className="unit">/mo</span></div>
+              <div className="mini-sub">a seat = a dev who <b>pushes</b></div>
+            </div>
+            <div className="mini">
+              <div className="mini-label">10-dev team</div>
+              <div className="mini-value"><span className="unit">$</span>120<span className="unit">/mo</span></div>
+              <div className="mini-sub">less than one redirected task</div>
+            </div>
+            <div className="mini">
+              <div className="mini-label">50-dev team</div>
+              <div className="mini-value"><span className="unit">$</span>600<span className="unit">/mo</span></div>
+              <div className="mini-sub">scales per seat, prorated</div>
+            </div>
+            <div className="mini">
+              <div className="mini-label">Cancel</div>
+              <div className="mini-value">anytime</div>
+              <div className="mini-sub">self-serve, via Stripe</div>
+            </div>
+          </div>
+          <p className="demo-caption">
+            You&rsquo;re paying for the dashboard and the enablement &mdash; never
+            for a place to warehouse your code insights. Those stay in <b>your</b>
+            git repo; we store none of it.
           </p>
         </section>
 

--- a/docs/superpowers/plans/2026-07-01-team-dashboard-git-native-goal-package.md
+++ b/docs/superpowers/plans/2026-07-01-team-dashboard-git-native-goal-package.md
@@ -86,16 +86,39 @@ URLs - the one deviation from the public community-rails fetch path.
 - **Tenancy = GitHub ACL.** A viewer only ever reads repos they already have access to; ax
   grants nothing.
 
+### Per-project opt-in (dev control) - first-class
+A dev typically has client repos AND personal projects on one machine. Personal work must
+never reach a team dashboard. The control:
+
+- **Default-deny.** A fresh machine pushes nothing. There is no whole-machine enroll.
+- **Per-repo binding.** `ax team join <org>` is run *inside* a repo and binds only that
+  repo → that org. A personal repo is simply never joined, so it never pushes.
+- **Binding is machine-local + private:** `~/.ax/team-bindings.json`
+  (`repo_key → { org, share }`), NOT committed to the repo - it is the dev's private choice,
+  invisible to teammates and absent from git history.
+- **Identity pinned fail-closed** (`chooseIdentity`): a fork/rename of a personal repo
+  cannot collide with a bound client repo's `repo_key`.
+- **Multi-client isolation:** many repos → many orgs; each repo pushes only to its bound
+  org; unbound repos push to nothing.
+- **Watcher honors bindings:** post-ingest auto-push fires only for bound repos.
+- **Per-field control:** `share=anon` and the sticky `no_cost` flag let a dev contribute
+  adoption while withholding identity/spend. First push shows a consent screen with the
+  exact repo + fields.
+- `ax team status` lists what is bound and pushing; `ax team leave` unbinds and stops.
+
 ## 5. Slices (each ships independently)
 
-### Slice 1 - repo-scoped push
+### Slice 1 - repo-scoped push + per-repo binding
+- `ax team join <org>` / `status` / `leave`: bind the current repo -> org in machine-local
+  `~/.ax/team-bindings.json` (`repo_key -> { org, share }`). Default-deny; unbound repos never
+  push. Consent screen shows the exact repo + fields at join.
 - `TeamProfileV1` query: repo-scoped, redacted, daily-collapsed aggregate.
-- `ax team push`: builds the snapshot, upserts `.ax-team/<login>.json` to the company repo
-  through the re-pointed `GitHubEnv` seam.
-- Consent screen: exact repo + fields shown; `~/.ax/team-push.json` records consent + repo
-  + `no_cost` stickiness (mirror `profile publish`).
-- Tests: repo-scope isolation (fork/rename/worktree), redaction/scrub, anon login strip,
-  idempotent upsert (contents-API sha handling).
+- `ax team push`: for each bound repo, builds the snapshot and upserts `.ax-team/<login>.json`
+  to that org's repo through the re-pointed `GitHubEnv` seam. Refuses to push an unbound repo.
+- State mirrors `profile publish` (`no_cost` sticky, `share=anon` strips login).
+- Tests: default-deny (nothing pushes unbound), repo-scope isolation (fork/rename/worktree
+  cannot cross bindings), multi-org isolation, redaction/scrub, anon login strip, idempotent
+  upsert (contents-API sha handling).
 
 ### Slice 2 - client aggregation
 - Fork `community-compile` + `shared/community` validation for `TeamProfileV1`.

--- a/docs/superpowers/plans/2026-07-01-team-dashboard-git-native-goal-package.md
+++ b/docs/superpowers/plans/2026-07-01-team-dashboard-git-native-goal-package.md
@@ -214,3 +214,66 @@ seam** (`GitBackend` v1, `R2Backend` stub) so R2 drops in without reworking Slic
 ## 9. Not building v1 (deferred behind price signal)
 Named per-dev breakdowns, Top Shippers / effectiveness scoring, action-card worklist,
 Team Retro, the encrypted-R2 backend.
+
+## 10. Appendix A - Stripe setup (per-seat)
+
+### Objects to create (Stripe dashboard or API, test mode first)
+- **1 Product:** "ax for teams".
+- **1 Price:** recurring `month`, `usage_type=licensed`, `billing_scheme=per_unit`,
+  currency USD, unit = one seat. (Licensed-quantity, not metered - we set the quantity from
+  the seat count; Stripe bills quantity x unit price. Simpler + prorates cleanly on
+  quantity change.)
+- **Customer Portal config:** allow cancel + payment-method update; optionally allow plan
+  quantity self-edit off (we drive quantity from seat count).
+
+### Data model (billing-only KV, keyed by GitHub org id)
+```
+entitlement[github_org_id] = {
+  stripe_customer_id, stripe_subscription_id,
+  status,            // active | trialing | past_due | canceled
+  plan,              // price id / tier label
+  seats,             // last-synced licensed quantity
+  current_period_end // unix; grace logic
+}
+```
+No telemetry. If we later want invoice/audit history, promote this to D1 (open Q8) - still
+billing-only.
+
+### Flows
+- **Signup:** admin hits `/billing/checkout` → server creates a Checkout Session
+  (`mode=subscription`, the Price, `client_reference_id=github_org_id`) → redirect to
+  Stripe. On success, webhook writes the entitlement.
+- **Manage:** `/billing/portal` → Billing Portal Session for the org's customer.
+- **Webhooks** (`/billing/webhook`, verify signature): handle
+  `checkout.session.completed` (map `client_reference_id` → org, store customer/sub),
+  `customer.subscription.updated` + `customer.subscription.deleted` (sync status / seats /
+  period_end). Idempotent by Stripe event id.
+
+### Seat sync (no seat DB)
+- Seats = count of distinct `.ax-team/*.json` in the org's team repo, read ephemerally via
+  the App/viewer token. A periodic reconcile (cron Worker or on-push) calls
+  `subscriptions.update(sub, { items: [{ id, quantity }] }, { proration_behavior })` when
+  the count changes.
+- v1 enforcement = **soft**: never block; surface over-cap ("paying for N, using M") in the
+  dashboard + a Stripe usage note. Hard cap (deny token/push above quantity) is a fast
+  follow (open Q6).
+
+### Enforcement point (the paywall)
+The auth broker (Slice 3), before minting a dashboard token:
+```
+org = resolveViewerOrg(githubToken)
+ent = entitlement[org.id]
+if !ent || ent.status not in {active, trialing}      -> 402, redirect /billing/checkout
+if ent.current_period_end < now - GRACE              -> 402 (past_due grace elapsed)
+else                                                  -> mint short-lived dashboard token
+```
+GitHub OAuth + Stripe Customer cover identity; **no Better Auth** (open Q5).
+
+### Secrets (Worker env, never in the browser)
+`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID`, GitHub OAuth
+`client_id`/`client_secret`. The broker holds these and persists no company data.
+
+### Rollout
+Test-mode keys + Stripe CLI (`stripe listen --forward-to`) for local webhook dev → verify
+the checkout→webhook→entitlement→token loop end-to-end → swap to live keys behind the
+locked CF origin (Slice 3).

--- a/docs/superpowers/plans/2026-07-01-team-dashboard-git-native-goal-package.md
+++ b/docs/superpowers/plans/2026-07-01-team-dashboard-git-native-goal-package.md
@@ -1,0 +1,145 @@
+# Goal package - Team dashboard v1: git-native, zero company data in backend
+
+- **Issue:** https://github.com/Necmttn/ax/issues/649
+- **Branch:** `plan/649-team-dashboard-v1-git-native-zero`
+- **Decided:** 2026-07-01
+- **Supersedes:** the deferred hosted-backend slices (4-7) of `docs/superpowers/specs/2026-06-15-team-backend-design.md`
+
+## 1. Problem & re-scope
+
+The commercial team dashboard was gated behind a design-partner price signal because
+the spec's hosted backend (slices 4-7) stores per-dev telemetry in **Cloudflare D1**
+via **Better Auth** (org + device-authorization plugins). Holding company data in ax's
+DB drags in the entire heavy surface: multi-tenant isolation guards
+(`requireOrgMember` on every endpoint), org-bound device tokens with rotation/revoke
+lifecycle, k-anonymity suppression, pseudonymity framing, right-to-delete, and breach
+liability. That is a real product, and it is what made the build scary.
+
+**New hard constraint: ax never stores readable company data.** Telemetry lives in the
+**company's own private git repo**; the dashboard aggregates **client-side** in the
+viewer's browser using the viewer's own GitHub token. GitHub repo membership becomes the
+tenancy boundary - we delete the tenancy/token/anonymity surface almost entirely and can
+pilot the moment an inquiry converts.
+
+Storage model locked (2026-07-01, user): **git-native SPA**. Encrypted-R2 is a
+documented fallback seam, not built in v1.
+
+## 2. Target architecture
+
+```
+dev's local ax
+   │  ax team push  (repo-scoped, redacted, daily-collapsed)
+   ▼
+company PRIVATE git repo
+   .ax-team/<login>.json        ← per-dev TeamProfileV1 snapshot
+   │  repo membership == team membership  (git owns distribution + auth + tenancy, free)
+   ▼
+team dashboard SPA (studio /team, hosted or local)
+   │  reads via the VIEWER's own GitHub OAuth token → api.github.com/repos/{org}/{repo}/contents/.ax-team/*
+   │  aggregates in-browser (reuse community-compile core)
+   ▼
+adoption + performance boards
+```
+
+**Data at rest in ax-owned infra: none.**
+Only stateful component: a **stateless OAuth-exchange Worker** that holds the GitHub
+OAuth *client secret* and swaps an auth code for a user token. It persists nothing.
+
+Removed vs the old spec: D1, Better Auth org/device plugins, `dev_snapshot` /
+`dev_snapshot_history` / `team_device_token` / `team_scope` tables, `requireOrgMember`
+tenancy guards, k-anonymity engine. GitHub repo ACL replaces all of it.
+
+### Why client-side private-repo read works
+`api.github.com` returns CORS headers for authenticated requests, so a browser holding
+the viewer's OAuth token can `GET /repos/{org}/{repo}/contents/{path}` (base64 body) for
+any repo the viewer can already read. Private-repo `raw.githubusercontent.com` is *not*
+usable from the browser (no auth header on the CDN), so we use the contents API, not raw
+URLs - the one deviation from the public community-rails fetch path.
+
+## 3. Reuse map (grounded, from repo scout 2026-07-01)
+
+| Layer | Reuse (file) | Change |
+|---|---|---|
+| Profile build | `apps/axctl/src/profile/render.ts` `buildProfile` | parameterize by repo set → `TeamProfileV1` |
+| Publish seam | `apps/axctl/src/profile/github-env.ts` `GitHubEnv` (Live/Test, `api(method,path,body)`) | re-point from `POST /gists` to `PUT /repos/{org}/{repo}/contents/.ax-team/{login}.json` |
+| Publish flow | `apps/axctl/src/profile/publish.ts` (`createProfileGist`/`patchProfileGist`, `isStale`) | contents-API upsert (get sha → PUT) instead of gist create/PATCH |
+| Consent/state | `apps/axctl/src/profile/publish-state.ts` `PublishState` (`~/.ax/profile-publish.json`) | clone → `~/.ax/team-push.json` (+ team repo, repo-scope) |
+| Repo-scope | `apps/axctl/src/pwd.ts` `resolvePwdRepository`; `apps/axctl/src/dashboard/sessions-query.ts` `listSessionsHere`; `apps/axctl/src/ingest/repository-identity.ts` `chooseIdentity`/`normalizeGitRemoteUrl` (pinned, fail-closed) | new repo-scoped profile query (ProfileV1 is machine-wide today) |
+| Aggregate core | `packages/community-compile/src/compile.ts` (runtime-agnostic `compileCommunity`) | swap fetcher to authed contents-API reads |
+| Validation | `packages/lib/src/shared/community.ts` (manual, no-Effect; render-safe) | fork strict schema for the team profile |
+| Dashboard UI | `apps/studio/src/instrument/team-metrics.tsx` (**already built**: projects/members/harnesses tabs, compare mode, teaser); `/team` route in `apps/studio/src/router.tsx` | swap `fetchMembers()` public-gist source → authed private-repo source; drop mock teaser paywall |
+| CF hosting | `apps/site` TanStack Start SPA → Pages (`vite.config.ts`); `apps/community-worker` KV+webhook+cron pattern | KV holds only compiled *aggregates* (or pure client-side); **no D1** |
+
+## 4. Security invariants (carried from spec S1, S4)
+
+- **Repo-scoped push (S1).** Snapshot built only from the bound repo via
+  `resolvePwdRepository` + repo-scoped query. Repo identity pinned fail-closed
+  (normalized remote → initial commit → local path hash); forks/renames/basename
+  collisions disambiguated. Whole-machine push is rejected.
+- **Redaction.** No transcript content, paths, or project names - aggregates only. Scrub
+  `taste.patterns[].summary` (can leak repo names / dollar amounts) in the shared
+  serializer *before* redirecting the publish target. Strip `ProfileV1.github` login when
+  the dev pushes anonymously.
+- **No executable payloads in the telemetry repo.** `.ax-team/*.json` is data only; it is
+  never activated. (The executable-mesh trust flow is a separate, already-shipped concern:
+  `ax team trust`.)
+- **Tenancy = GitHub ACL.** A viewer only ever reads repos they already have access to; ax
+  grants nothing.
+
+## 5. Slices (each ships independently)
+
+### Slice 1 - repo-scoped push
+- `TeamProfileV1` query: repo-scoped, redacted, daily-collapsed aggregate.
+- `ax team push`: builds the snapshot, upserts `.ax-team/<login>.json` to the company repo
+  through the re-pointed `GitHubEnv` seam.
+- Consent screen: exact repo + fields shown; `~/.ax/team-push.json` records consent + repo
+  + `no_cost` stickiness (mirror `profile publish`).
+- Tests: repo-scope isolation (fork/rename/worktree), redaction/scrub, anon login strip,
+  idempotent upsert (contents-API sha handling).
+
+### Slice 2 - client aggregation
+- Fork `community-compile` + `shared/community` validation for `TeamProfileV1`.
+- Browser fetcher over `api.github.com/.../contents` with the viewer's token; parallel
+  per-dev fetch, drop failures (mirror `fetchMembers`).
+- Render-safe validation guarantee preserved (hostile value renders as text, never crashes).
+
+### Slice 3 - auth broker
+- Stateless OAuth-exchange Worker (GitHub OAuth app, PKCE web flow) - **stores nothing**.
+- Lock one CF origin for the SPA (first-party session; no split-origin design).
+- (Alt under evaluation: GitHub App user-to-server token - see open Q1.)
+
+### Slice 4 - dashboard
+- Wire `team-metrics.tsx` to the authed private-repo source; remove mock teaser.
+- Panels: adoption (active devs, team active-days/sessions trend); skill-adoption matrix
+  (skill → #devs → runs → median); spend/efficiency (tokens, cost, model mix, verification
+  share, tool-failure rate); workflow arcs + origin split.
+- Cold-start UX: "N of M devs contributing" activation panel.
+
+## 6. Encrypted-R2 fallback (documented, not built)
+For teams without a git-centric flow: dev envelope-encrypts the snapshot with a team key,
+uploads ciphertext to R2; the dashboard fetches + decrypts in-browser. ax stores only
+unreadable blobs. Key distribution is the hard part (wrapped-key-per-member) and a
+lost-key = lost-data footgun. **Design the push + dashboard-read behind a `StorageEnv`
+seam** (`GitBackend` v1, `R2Backend` stub) so R2 drops in without reworking Slices 1/4.
+
+## 7. Decisions (locked)
+- Storage v1 = git-native SPA; encrypted-R2 = seam only.
+- Backend stores zero company data; GitHub repo membership = tenancy.
+- Push is repo-scoped, never whole-machine.
+
+## 8. Open questions
+1. **OAuth mechanism** - plain GitHub OAuth app (PKCE + tiny exchange Worker) vs GitHub App
+   user-to-server token? App gives finer repo-scoped install but more setup.
+2. **Snapshot location** - `.ax-team/` dir inside the company *code* repo vs a dedicated
+   `<org>/ax-team` repo? A separate repo isolates telemetry churn from code history and
+   scopes access independently.
+3. **Push cadence** - watcher-driven (post-ingest `--if-stale`) vs explicit `ax team push`?
+   Watcher is zero-effort but noisier git history.
+4. **Aggregate caching** - pure client-side (truly zero backend) vs optional KV-cached
+   *anonymized aggregates* for large teams (still zero raw data)?
+5. **Better Auth** - fully removed, or keep the org plugin only as a human-friendly org
+   roster UI that stores no telemetry?
+
+## 9. Not building v1 (deferred behind price signal)
+Named per-dev breakdowns, Top Shippers / effectiveness scoring, action-card worklist,
+Team Retro, the encrypted-R2 backend.

--- a/docs/superpowers/plans/2026-07-01-team-dashboard-git-native-goal-package.md
+++ b/docs/superpowers/plans/2026-07-01-team-dashboard-git-native-goal-package.md
@@ -115,6 +115,44 @@ URLs - the one deviation from the public community-rails fetch path.
   share, tool-failure rate); workflow arcs + origin split.
 - Cold-start UX: "N of M devs contributing" activation panel.
 
+### Slice 5 - billing & paywall (per-seat, Stripe)
+Pricing decided 2026-07-01: **per-seat / dev per month**.
+
+**Billing state is NOT company telemetry** - an org→subscription record is standard SaaS
+metadata, not customer IP. The zero-data guarantee (no *telemetry* at rest) holds; a
+billing store leak only exposes who-pays-what, a far lower stake than the multi-tenant
+telemetry DB that gated the old slices 4-7. Better Auth is still not needed - Stripe
+Customer + GitHub OAuth cover identity.
+
+**Chokepoint = the auth broker (Slice 3).** It is the one component only ax runs, and
+every dashboard viewer must pass through it. Gate token issuance on entitlement:
+
+```
+viewer → GitHub OAuth → auth Worker
+                          1. resolve viewer's GitHub org id
+                          2. lookup entitlement[org_id]  (KV, billing-only)
+                          3. active sub → mint dashboard token
+                             none       → 402 → Stripe Checkout
+```
+
+**Stripe pieces (self-serve, minimal surface):**
+- **Checkout** (hosted) - signup → subscription. No PCI, no card handling.
+- **Customer Portal** (hosted) - upgrade/cancel/card update; zero UI to build.
+- **Webhooks** - `checkout.session.completed`, `customer.subscription.updated|deleted`
+  → upsert entitlement.
+- **Entitlement store** - tiny KV (or D1): `github_org_id → { status, plan, seats,
+  current_period_end }`. Billing metadata only; **never telemetry**.
+- **Enforcement** - auth Worker reads entitlement before minting a dashboard token.
+
+**Seat counting without a seat DB:** seats = count of distinct `.ax-team/*.json` files in
+the customer repo, read **ephemerally** via the viewer/App token (never stored). Sync that
+count to Stripe as the licensed subscription **quantity** (periodic reconcile job or on
+push). v1 enforcement = soft (report + surface over-cap in dashboard); hard cap (deny push
+/ deny token above quantity) is a fast follow.
+
+- Tests: entitlement lookup gating (active/none/past_due), webhook idempotency, seat-count
+  from repo file set, no-telemetry-in-billing-store invariant.
+
 ## 6. Encrypted-R2 fallback (documented, not built)
 For teams without a git-centric flow: dev envelope-encrypts the snapshot with a team key,
 uploads ciphertext to R2; the dashboard fetches + decrypts in-browser. ax stores only
@@ -124,8 +162,12 @@ seam** (`GitBackend` v1, `R2Backend` stub) so R2 drops in without reworking Slic
 
 ## 7. Decisions (locked)
 - Storage v1 = git-native SPA; encrypted-R2 = seam only.
-- Backend stores zero company data; GitHub repo membership = tenancy.
+- Backend stores zero company *telemetry*; GitHub repo membership = tenancy.
 - Push is repo-scoped, never whole-machine.
+- Pricing = **per-seat / dev per month** (Stripe); billing metadata (org→subscription) is
+  the only ax-held state and is explicitly not telemetry.
+- Paywall enforced at the auth broker (only ax-run component); Stripe Checkout + Portal +
+  webhooks; entitlement keyed by GitHub org id.
 
 ## 8. Open questions
 1. **OAuth mechanism** - plain GitHub OAuth app (PKCE + tiny exchange Worker) vs GitHub App
@@ -139,6 +181,12 @@ seam** (`GitBackend` v1, `R2Backend` stub) so R2 drops in without reworking Slic
    *anonymized aggregates* for large teams (still zero raw data)?
 5. **Better Auth** - fully removed, or keep the org plugin only as a human-friendly org
    roster UI that stores no telemetry?
+6. **Seat enforcement** - soft (report over-cap) vs hard cap (deny token/push above paid
+   quantity) for v1? Recommend soft first.
+7. **Seat definition** - pushing devs (`.ax-team/*.json` count) vs dashboard viewers?
+   Pushers is cleaner to count and is the value-generating population.
+8. **Entitlement store** - KV (simplest, billing-only) vs D1 (if we want invoicing/audit
+   history)?
 
 ## 9. Not building v1 (deferred behind price signal)
 Named per-dev breakdowns, Top Shippers / effectiveness scoring, action-card worklist,

--- a/docs/team-dashboard-design-partner-pitch.md
+++ b/docs/team-dashboard-design-partner-pitch.md
@@ -1,0 +1,79 @@
+# ax for teams - design-partner pitch
+
+**Your devs are already using AI agents. You can't see whether it's working - and every
+tool that promises to show you wants to hoover their transcripts into its own cloud.**
+
+ax for teams gives you team-level adoption, skill diffusion, and spend visibility for AI
+coding agents **without ever storing your data**. Your telemetry lives in your own private
+git repo; the dashboard reads it in the browser. We hold zero company data.
+
+## The problem
+
+Teams are adopting Claude Code, Codex, Cursor, and friends fast, but leadership is flying
+blind:
+
+- **Adoption:** are devs actually using agents, or is it a few power users? Which skills
+  and workflows are spreading?
+- **Spend:** where is the token/subscription budget going? What's routable to cheaper
+  models?
+- **Effectiveness:** are agents shipping clean, or churning?
+
+The existing answer is a SaaS that ingests everyone's transcripts into its cloud. That's a
+surveillance vibe for your devs *and* a data-liability for you (their code insights,
+sitting in a third party's DB).
+
+## What makes this different - three guarantees
+
+1. **Zero company data in our backend.** Snapshots live in *your* private git repo
+   (`.ax-team/<dev>.json`). The dashboard aggregates client-side using the viewer's own
+   GitHub token. Repo membership is the access boundary. If we get breached, there's
+   nothing of yours to leak. (Only thing we run is a stateless login broker - it stores
+   nothing.)
+
+2. **Per-project opt-in, default-deny.** Nothing is collected until a dev explicitly binds
+   a repo to the team. A dev's personal projects and other clients' repos are invisible -
+   not filtered out, *never sent*. Binding is the dev's private choice; it isn't committed
+   or visible to teammates. Repo identity is pinned so a fork or rename can't leak the
+   wrong repo.
+
+3. **Aggregate-first, not surveillance.** Boards are team-level (adoption trend, skill
+   adoption, spend, workflows). Devs can contribute anonymously and withhold cost. This is
+   coaching and ROI, not a keystroke logger - and framing it that way is what makes devs
+   actually leave it on.
+
+## What the team sees
+
+- **Adoption:** active devs, team active-days + sessions trend, cold-start "N of M devs
+  contributing."
+- **Skill diffusion:** which skills/workflows spread across the team, run counts, medians.
+- **Spend & efficiency:** total/median tokens + cost, model mix, verification share, tool-
+  failure rate - the routable-spend lens ax already computes for individuals, team-wide.
+- **Workflows:** the common skill arcs your team converges on.
+
+## How it works (setup is minutes)
+
+1. Create a private `ax-team` repo in your GitHub org (or a `.ax-team/` dir in an existing
+   repo). Add your devs - repo membership *is* team membership.
+2. Each dev, inside a client repo: `ax team join <org>`. A consent screen shows exactly
+   what's shared. Personal repos are never joined.
+3. Open the dashboard, log in with GitHub. It reads the repo and renders.
+
+No agents installed on your infra. No transcripts leaving machines. Just git.
+
+## What we're asking of design partners
+
+We've built the local, git-native foundation. The hosted dashboard is deliberately
+**gated on a real price signal** - we won't build the commercial layer speculatively. We're
+looking for a small number of design partners who will:
+
+- Tell us this is worth paying for (and roughly what) - the signal that unlocks the build.
+- Pilot the per-project opt-in flow with a real team and tell us where it chafes.
+
+## Pricing (design-partner)
+
+Per-seat / dev per month, self-serve via Stripe, cancel anytime. Design partners get
+founder pricing locked for the pilot and direct input on the roadmap.
+
+---
+
+_Generated with [ax](https://github.com/Necmttn/ax)._


### PR DESCRIPTION
Goal package for #649. Re-scopes the deferred hosted-backend slices (4-7) of the team-backend spec away from Better Auth + D1 (which stores per-dev `dev_snapshot` rows) toward a **git-native SPA that holds zero company data**.

- Telemetry lives in the **company's private repo** (`.ax-team/<login>.json`, repo-scoped, redacted, daily-collapsed).
- Dashboard aggregates **client-side** via the viewer's own GitHub token; **repo membership = tenancy**.
- Only stateful ax component = a **stateless OAuth-exchange Worker** (client secret only, stores nothing). D1 + Better Auth org/device tenancy surface removed.
- Encrypted-R2 = documented `StorageEnv` fallback seam, not built v1.

Grounded reuse map + 4 build slices in the doc. Draft — awaiting review of the re-scope + open questions (OAuth mechanism, snapshot location, push cadence, aggregate caching, Better Auth removal).

Doc: `docs/superpowers/plans/2026-07-01-team-dashboard-git-native-goal-package.md`