### PR TITLE
feat(site): rebuild /design-partners — visuals + cohort scarcity + honest claim (#653)

### DIFF
--- a/apps/site/app/routes/design-partners.tsx
+++ b/apps/site/app/routes/design-partners.tsx
@@ -15,7 +15,7 @@ export const Route = createFileRoute("/design-partners")({
       {
         name: "description",
         content:
-          "See how AI is working across your team without shipping your code. Telemetry stays in a private git repo you own; the dashboard runs in your browser.",
+          "See how AI is working across your team without your data leaving your cloud. Telemetry stays in a git repo you own; the dashboard runs in your browser.",
       },
     ],
   }),
@@ -377,7 +377,7 @@ function DesignPartners() {
             across your team.
           </h1>
           <p className="hero-human">
-            Without shipping your code to anyone.
+            Without your data ever leaving your cloud.
           </p>
           <p className="lede">
             Rivals make you choose between visibility and warehousing your code

--- a/apps/site/app/routes/design-partners.tsx
+++ b/apps/site/app/routes/design-partners.tsx
@@ -466,6 +466,12 @@ function DesignPartners() {
             per-seat surface (<code>ax studio</code>) already renders these
             numbers for one dev today.
           </p>
+
+          <div className="cta-row">
+            <a className="cta-secondary" href="/studio/team?demo">
+              Prefer to click around? Open the live demo →
+            </a>
+          </div>
         </section>
 
         {/* ============= sample payload ============= */}

--- a/apps/site/app/routes/design-partners.tsx
+++ b/apps/site/app/routes/design-partners.tsx
@@ -11,16 +11,356 @@ const CONTACT_URL = "https://github.com/Necmttn/ax/discussions";
 export const Route = createFileRoute("/design-partners")({
   head: () => ({
     meta: [
-      { title: "ax for teams - team AI-agent visibility, with zero of your data in our cloud" },
+      { title: "ax for teams - AI visibility, none of your data in our cloud" },
       {
         name: "description",
         content:
-          "See team adoption, skill diffusion and spend for AI coding agents - without ever storing your data. Your telemetry lives in your own private git repo; the dashboard aggregates in the browser. Per-project opt-in, default-deny. $12/seat/mo.",
+          "See how AI is working across your team without shipping your code. Telemetry stays in a private git repo you own; the dashboard runs in your browser.",
       },
     ],
   }),
   component: DesignPartners,
 });
+
+function PitchSwitch() {
+  return (
+    <div className="pitch-switch" role="tablist" aria-label="positioning">
+      <Link to="/teams">for managers</Link>
+      <Link to="/registry">for applied-AI teams</Link>
+      <Link to="/design-partners" className="is-active">
+        the founding cohort
+      </Link>
+    </div>
+  );
+}
+
+/* ---- wide architecture diagram: where your telemetry actually lives ---- */
+function ArchitectureDiagram() {
+  return (
+    <figure className="dp-arch">
+      <svg
+        viewBox="0 0 1120 400"
+        className="dp-arch__svg"
+        role="img"
+        aria-label="Data-flow: your laptops write redacted aggregates to your own private git repo; your browser reads them with your GitHub token; ax runs only a stateless auth broker that stores nothing. Code, prompts and transcripts hit a consent gate and never leave your machine."
+      >
+        <defs>
+          <marker
+            id="dp-ah-green"
+            viewBox="0 0 10 10"
+            refX="8"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+          >
+            <path d="M0 0 L10 5 L0 10 z" fill="var(--green)" />
+          </marker>
+          <marker
+            id="dp-ah-blue"
+            viewBox="0 0 10 10"
+            refX="8"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+          >
+            <path d="M0 0 L10 5 L0 10 z" fill="var(--blue)" />
+          </marker>
+          <marker
+            id="dp-ah-red"
+            viewBox="0 0 10 10"
+            refX="8"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+          >
+            <path d="M0 0 L10 5 L0 10 z" fill="var(--red)" />
+          </marker>
+          <marker
+            id="dp-ah-muted"
+            viewBox="0 0 10 10"
+            refX="8"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M0 0 L10 5 L0 10 z" fill="var(--soft)" />
+          </marker>
+        </defs>
+
+        {/* ---- zone 1: your laptops ---- */}
+        <g className="dp-arch__zone">
+          <rect x="20" y="128" width="248" height="150" rx="10" />
+          <text className="dp-arch__kick" x="40" y="156">
+            YOUR LAPTOPS
+          </text>
+          <text className="dp-arch__title" x="40" y="184">
+            Claude Code · Codex · Cursor
+          </text>
+          <text className="dp-arch__code" x="40" y="212">
+            ~/.claude · local ax
+          </text>
+          <text className="dp-arch__note" x="40" y="238">
+            transcripts parsed on disk,
+          </text>
+          <text className="dp-arch__note" x="40" y="256">
+            collapsed to daily counts
+          </text>
+        </g>
+
+        {/* ---- zone 2: your private git repo (the database) ---- */}
+        <g className="dp-arch__zone dp-arch__zone--db">
+          <rect x="368" y="128" width="248" height="150" rx="10" />
+          <text className="dp-arch__kick dp-arch__kick--db" x="388" y="156">
+            YOUR PRIVATE GIT REPO
+          </text>
+          <text className="dp-arch__title" x="388" y="184">
+            .ax-team/&lt;login&gt;.json
+          </text>
+          <text className="dp-arch__code" x="388" y="212">
+            one file per dev · redacted
+          </text>
+          <text className="dp-arch__note" x="388" y="238">
+            counts, sums, ratios only.
+          </text>
+          <text className="dp-arch__badge" x="388" y="262">
+            THE DATABASE
+          </text>
+        </g>
+
+        {/* ---- zone 3: your browser ---- */}
+        <g className="dp-arch__zone">
+          <rect x="716" y="128" width="248" height="150" rx="10" />
+          <text className="dp-arch__kick" x="736" y="156">
+            YOUR BROWSER
+          </text>
+          <text className="dp-arch__title" x="736" y="184">
+            the dashboard
+          </text>
+          <text className="dp-arch__code" x="736" y="212">
+            aggregates client-side
+          </text>
+          <text className="dp-arch__note" x="736" y="238">
+            renders with the viewer&rsquo;s
+          </text>
+          <text className="dp-arch__note" x="736" y="256">
+            own GitHub token
+          </text>
+        </g>
+
+        {/* ---- zone 4: ax cloud (near-empty, off to the side) ---- */}
+        <g className="dp-arch__cloud">
+          <rect x="1000" y="20" width="112" height="82" rx="9" />
+          <text className="dp-arch__kick dp-arch__kick--cloud" x="1016" y="44">
+            ax CLOUD
+          </text>
+          <text className="dp-arch__cloudline" x="1016" y="64">
+            stateless auth
+          </text>
+          <text className="dp-arch__cloudline" x="1016" y="78">
+            broker
+          </text>
+          <text className="dp-arch__cloudnil" x="1016" y="94">
+            stores nothing
+          </text>
+        </g>
+
+        {/* ---- main flow arrows ---- */}
+        <line
+          className="dp-arch__flow dp-arch__flow--green"
+          x1="268"
+          y1="200"
+          x2="360"
+          y2="200"
+          markerEnd="url(#dp-ah-green)"
+        />
+        <text className="dp-arch__flowlabel dp-arch__flowlabel--green" x="314" y="190">
+          redacted
+        </text>
+        <text className="dp-arch__flowlabel dp-arch__flowlabel--green" x="314" y="222">
+          aggregates
+        </text>
+
+        <line
+          className="dp-arch__flow dp-arch__flow--blue"
+          x1="616"
+          y1="200"
+          x2="708"
+          y2="200"
+          markerEnd="url(#dp-ah-blue)"
+        />
+        <text className="dp-arch__flowlabel dp-arch__flowlabel--blue" x="662" y="190">
+          your token
+        </text>
+        <text className="dp-arch__flowlabel dp-arch__flowlabel--blue" x="662" y="222">
+          reads
+        </text>
+
+        {/* ---- thin auth-only line to the cloud ---- */}
+        <path
+          className="dp-arch__auth"
+          d="M900 128 L900 70 L996 62"
+          markerEnd="url(#dp-ah-muted)"
+        />
+        <text className="dp-arch__authlabel" x="908" y="98">
+          OAuth handshake only
+        </text>
+
+        {/* ---- consent gate + bounce-back dead-end ---- */}
+        <path
+          className="dp-arch__block"
+          d="M120 278 L120 336 L300 336"
+          markerEnd="url(#dp-ah-red)"
+          fill="none"
+        />
+        <path
+          className="dp-arch__block"
+          d="M300 360 L172 360 L172 282"
+          markerEnd="url(#dp-ah-red)"
+          fill="none"
+        />
+        {/* the gate barrier */}
+        <line className="dp-arch__gate" x1="316" y1="322" x2="316" y2="374" />
+        <line className="dp-arch__gate" x1="322" y1="322" x2="322" y2="374" />
+        <text className="dp-arch__blocklabel" x="128" y="326">
+          code · prompts · transcripts
+        </text>
+        <text className="dp-arch__gatelabel" x="336" y="344">
+          consent gate
+        </text>
+        <text className="dp-arch__gatelabel dp-arch__gatelabel--sub" x="336" y="360">
+          default deny · never sent
+        </text>
+      </svg>
+      <figcaption className="dp-arch__cap">
+        Your git repo is the source of truth. ax never holds a copy.
+      </figcaption>
+    </figure>
+  );
+}
+
+/* ---- team-rollup dashboard mock (instrument dark) ---- */
+function RollupMock() {
+  return (
+    <div
+      className="browser browser--instrument dp-rollup"
+      role="img"
+      aria-label="Team rollup dashboard mock: adoption, opt-in status, routable spend, spreading skills and anonymized seats"
+    >
+      <div className="browser-bar">
+        <div className="browser-dots">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+        <div className="browser-url">ax team &middot; acme-web &middot; 30 days</div>
+        <div className="browser-spacer"></div>
+      </div>
+      <div className="dash">
+        <div className="dp-rollup__top">
+          <span className="dp-rollup__title">Team rollup</span>
+          <span className="dp-mock-tag">MOCK</span>
+        </div>
+
+        <div className="dp-rollup__grid">
+          {/* adoption trend */}
+          <div className="dp-card dp-card--wide">
+            <span className="dp-card__label">Adoption, last 30 days</span>
+            <div className="dp-card__row">
+              <span className="dp-card__big">6 / 6</span>
+              <span className="dp-card__unit">seats active</span>
+            </div>
+            <svg className="dp-spark" viewBox="0 0 220 44" preserveAspectRatio="none" aria-hidden="true">
+              <polyline
+                points="0,38 30,34 60,30 90,26 120,20 150,17 180,12 220,9"
+                fill="none"
+              />
+            </svg>
+            <span className="dp-card__sub">82% team active-days, up from 61%</span>
+          </div>
+
+          {/* routable spend */}
+          <div className="dp-card">
+            <span className="dp-card__label">Routable spend</span>
+            <div className="dp-card__row">
+              <span className="dp-card__big">$605</span>
+              <span className="dp-card__unit">of $2,140/mo</span>
+            </div>
+            <div className="dp-bar">
+              <span className="dp-bar__fill" style={{ width: "28%" }}></span>
+            </div>
+            <span className="dp-card__sub">routine sub-tasks on the expensive default</span>
+          </div>
+
+          {/* workflows ready to spread */}
+          <div className="dp-card">
+            <span className="dp-card__label">Workflows ready to spread</span>
+            <div className="dp-card__row">
+              <span className="dp-card__big">3</span>
+              <span className="dp-card__unit">above the cohort floor</span>
+            </div>
+            <span className="dp-card__sub">the workflows your team settles into, seen on 5+ seats</span>
+          </div>
+
+          {/* skills spreading */}
+          <div className="dp-card">
+            <span className="dp-card__label">Skills spreading</span>
+            <ul className="dp-list">
+              <li>
+                <span>effect-kit</span>
+                <span className="dp-list__meta">6 seats</span>
+              </li>
+              <li>
+                <span>ship-checklist</span>
+                <span className="dp-list__meta">5 seats</span>
+              </li>
+              <li>
+                <span>ax-extract-workflow</span>
+                <span className="dp-list__meta">5 seats</span>
+              </li>
+            </ul>
+          </div>
+
+          {/* per-project opt-in */}
+          <div className="dp-card">
+            <span className="dp-card__label">Per-project opt-in</span>
+            <ul className="dp-list">
+              <li>
+                <span>acme-web</span>
+                <span className="dp-tag dp-tag--on">joined</span>
+              </li>
+              <li>
+                <span>acme-billing</span>
+                <span className="dp-tag dp-tag--on">joined</span>
+              </li>
+              <li>
+                <span>acme-infra</span>
+                <span className="dp-tag dp-tag--off">not joined</span>
+              </li>
+            </ul>
+          </div>
+
+          {/* anonymized seats */}
+          <div className="dp-card dp-card--wide">
+            <span className="dp-card__label">Seats (anonymized)</span>
+            <div className="dp-chips">
+              {["eng-01", "eng-02", "eng-03", "eng-04", "eng-05", "eng-06"].map((s) => (
+                <span key={s} className="dp-chip">
+                  <span className="dp-chip__dot"></span>
+                  {s}
+                </span>
+              ))}
+            </div>
+            <span className="dp-card__sub">no per-person ranking, no drilldown</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function DesignPartners() {
   return (
@@ -30,157 +370,148 @@ function DesignPartners() {
         {/* ============= hero ============= */}
         <section className="hero">
           <HeroLogoField />
-          <span className="eyebrow">ax for teams &middot; design partners</span>
+          <span className="eyebrow">ax for teams &middot; founding cohort</span>
+          <span className="reg-badge">Founding cohort &middot; 3 of 5 spots open</span>
           <h1>
-            See how your team ships with <em>AI</em>.<br />
-            We store none of your data.
+            Know if <em>AI</em> is working<br />
+            across your team.
           </h1>
           <p className="hero-human">
-            Your devs are already using agents. You can&rsquo;t see whether
-            it&rsquo;s working.
+            Without shipping your code to anyone.
           </p>
           <p className="lede">
-            Every tool that promises to show you wants to hoover their transcripts
-            into its cloud. ax gives you team-level adoption, skill diffusion and
-            spend visibility &mdash; and your telemetry never leaves your own git.
-            We hold <b>zero company data</b>.
+            Rivals make you choose between visibility and warehousing your code
+            in their cloud. ax reads adoption, spend and effectiveness straight
+            from a private git repo you own.
           </p>
 
           <div className="install-wrap">
-            <span className="install-label">runs on the laptops &amp; git you already have</span>
+            <span className="dp-status">
+              <b>Live today:</b> per-seat receipts + git-native skill mesh
+              <span className="dp-status__sep">&middot;</span>
+              <b>Building with founding partners:</b> the team rollup
+            </span>
             <div className="cta-row">
               <a className="prompt-pill is-solo" href={BOOK_URL}>
-                <span className="prompt-pill__label">Book a walkthrough</span>
+                <span className="prompt-pill__label">Claim a founding spot</span>
               </a>
-              <a className="cta-secondary" href="#guarantees">
-                The three guarantees
+              <a className="cta-secondary" href="#see-it">
+                See it on your own data first
               </a>
             </div>
+            <PitchSwitch />
           </div>
         </section>
 
-        {/* ============= the problem ============= */}
-        <section className="pitch-section">
+        {/* ============= zero-data (promoted to section 2) ============= */}
+        <section className="pitch-section" id="zero-data">
           <div className="pitch-head">
-            <span className="eyebrow">the problem</span>
+            <span className="eyebrow">where your data lives</span>
             <h2>
-              Leadership is <em>flying blind</em> on the AI rollout.
+              The dashboard our servers <em>never see</em>.
             </h2>
             <p>
-              The tools arrived before the operating model. The existing answer is
-              a SaaS that ingests everyone&rsquo;s transcripts &mdash; surveillance
-              for your devs, and a data-liability for you: their code insights,
-              sitting in a third party&rsquo;s database.
+              ax&rsquo;s servers never receive or store your telemetry,
+              transcripts, source, prompts, or derived rows. The frontend reads
+              your data with the viewer&rsquo;s own GitHub token. The only service
+              we run is a stateless auth broker.
             </p>
           </div>
-          <div className="pitch-triad">
-            <div className="pitch-fcard">
-              <h3>Adoption</h3>
+
+          <ArchitectureDiagram />
+
+          <div className="dp-claims">
+            <div className="dp-claim">
+              <span className="dp-claim__k">the database is your repo</span>
               <p>
-                Are devs actually using agents, or is it a few power users? Which
-                skills and workflows are spreading?
+                Aggregates land in a private repo in your own GitHub org, one
+                redacted file per dev. GitHub repo membership is team access.
               </p>
             </div>
-            <div className="pitch-fcard">
-              <h3>Spend</h3>
+            <div className="dp-claim">
+              <span className="dp-claim__k">the browser does the math</span>
               <p>
-                Where is the token and subscription budget going? What&rsquo;s
-                routable to cheaper models?
+                The dashboard aggregates client-side using the viewer&rsquo;s own
+                token. If we get breached, there is nothing of yours to leak.
               </p>
             </div>
-            <div className="pitch-fcard">
-              <h3>Effectiveness</h3>
+            <div className="dp-claim">
+              <span className="dp-claim__k">opt-in, default deny</span>
               <p>
-                Are agents shipping clean, or churning through failure&ndash;repair
-                loops?
+                Nothing pushes until a dev runs <code>ax team join</code> inside a
+                specific repo. Repo identity is pinned, so a fork or rename
+                can&rsquo;t leak the wrong one.
               </p>
             </div>
           </div>
         </section>
 
-        {/* ============= three guarantees ============= */}
-        <section className="pitch-section" id="guarantees">
+        {/* ============= the rollup mock ============= */}
+        <section className="pitch-section dp-alt" id="see-it">
           <div className="pitch-head">
-            <span className="eyebrow">what makes this different</span>
+            <span className="eyebrow">what the team rollup shows</span>
             <h2>
-              Three guarantees, <em>by construction</em>.
+              Adoption, spend and effectiveness, <em>rolled up</em>.
             </h2>
             <p>
-              Not a privacy policy &mdash; a design. Each one is enforced by where
-              the data lives and how it moves, not by our promise to be careful.
+              Every number is a team-level aggregate. There is no per-person
+              leaderboard and no way to drill into one dev.
             </p>
           </div>
-          <div className="pitch-triad">
-            <div className="pitch-fcard">
-              <h3>Zero data in our backend</h3>
-              <p>
-                Snapshots live in <b>your</b> private git repo. The dashboard
-                aggregates client-side using the viewer&rsquo;s own GitHub token.
-                If we get breached, there&rsquo;s nothing of yours to leak &mdash;
-                the only thing we run is a stateless login broker that stores
-                nothing.
-              </p>
-            </div>
-            <div className="pitch-fcard">
-              <h3>Per-project opt-in, default-deny</h3>
-              <p>
-                Nothing is collected until a dev binds a specific repo to the team.
-                Personal projects and other clients&rsquo; code are invisible
-                &mdash; not filtered out, <em>never sent</em>. Repo identity is
-                pinned, so a fork or rename can&rsquo;t leak the wrong one.
-              </p>
-            </div>
-            <div className="pitch-fcard">
-              <h3>Aggregate, not surveillance</h3>
-              <p>
-                Boards are team-level: adoption trend, skill adoption, spend,
-                workflows. Devs can contribute anonymously and withhold cost. This
-                is coaching and ROI, not a keystroke logger &mdash; which is what
-                makes devs actually leave it on.
-              </p>
-            </div>
-          </div>
+
+          <RollupMock />
+
+          <p className="demo-caption">
+            Mock of the rollup we are building with founding partners. The live
+            per-seat surface (<code>ax studio</code>) already renders these
+            numbers for one dev today.
+          </p>
         </section>
 
-        {/* ============= what the team sees ============= */}
-        <section className="pitch-section">
+        {/* ============= sample payload ============= */}
+        <section className="pitch-section" id="payload">
           <div className="pitch-head">
-            <span className="eyebrow">what the team sees</span>
+            <span className="eyebrow">what actually leaves a laptop</span>
             <h2>
-              Adoption and performance, <em>rolled up</em>.
+              The <em>entire file</em> that ships.
             </h2>
+            <p>
+              Names, not contents. No transcripts, no code, no prompts, no paths.
+              Daily-collapsed counts, sums and ratios.
+            </p>
           </div>
-          <div className="pitch-lanes">
-            <div className="pitch-lane is-out">
-              <h3><span className="dot"></span> adoption &amp; diffusion</h3>
-              <ul>
-                <li>Active devs, team active-days + <b>sessions trend</b></li>
-                <li>Which <b>skills &amp; workflows</b> spread, with run counts</li>
-                <li>Cold-start &ldquo;N of M devs contributing&rdquo;</li>
-                <li>The common <b>skill arcs</b> your team converges on</li>
-              </ul>
+
+          <div className="dp-payload">
+            <div className="dp-payload__bar">
+              <span className="dp-payload__path">.ax-team/necmttn.json</span>
+              <span className="dp-payload__tag">redacted &middot; aggregates only</span>
             </div>
-            <div className="pitch-lane is-local">
-              <h3><span className="dot"></span> spend &amp; efficiency</h3>
-              <ul>
-                <li>Total / median <b>tokens + cost</b>, model mix</li>
-                <li><b>Routable spend</b> &mdash; what to move off the default</li>
-                <li>Verification share + <b>tool-failure rate</b></li>
-                <li>Team-wide, never per-person behavior</li>
-              </ul>
-            </div>
+            <pre className="dp-payload__body">{`{
+  "login": "necmttn",
+  "window": "2026-06-01/2026-06-30",
+  "sessions": 214,
+  "active_days": 22,
+  "tokens": { "in": 4120000, "out": 385000 },
+  "routable_usd": 605,
+  "spend_usd": 2140,
+  "top_skills": ["effect-kit", "ship-checklist", "ax-extract-workflow"],
+  "churn_episodes": 7
+}`}</pre>
+            <p className="dp-payload__note">
+              This is the whole file that leaves. Names, not contents.
+            </p>
           </div>
         </section>
 
         {/* ============= how it works ============= */}
-        <section className="pitch-section">
+        <section className="pitch-section dp-alt">
           <div className="pitch-head">
             <span className="eyebrow">how it works</span>
             <h2>
-              Setup is <em>minutes</em>. It&rsquo;s just git.
+              Setup is <em>minutes</em>. It is just git.
             </h2>
             <p>
-              No agents installed on your infra. No transcripts leaving machines.
+              No agents on your infra. No transcripts leaving machines.
             </p>
           </div>
           <div className="pitch-triad">
@@ -188,73 +519,178 @@ function DesignPartners() {
               <h3>1 &middot; A private repo</h3>
               <p>
                 Create a private <code>ax-team</code> repo in your GitHub org and
-                add your devs. Repo membership <em>is</em> team membership.
+                add your devs. Repo membership is team membership.
               </p>
             </div>
             <div className="pitch-fcard">
               <h3>2 &middot; Each dev opts in</h3>
               <p>
-                Inside a client repo: <code>ax team join &lt;org&gt;</code>. A
-                consent screen shows exactly what&rsquo;s shared. Personal repos are
-                never joined.
+                Inside a work repo: <code>ax team join &lt;org&gt;</code>. A consent
+                screen shows exactly what is shared. Personal repos are never
+                joined.
               </p>
             </div>
             <div className="pitch-fcard">
               <h3>3 &middot; Open the dashboard</h3>
               <p>
                 Log in with GitHub. It reads the repo with your own token and
-                renders &mdash; aggregation happens in your browser.
+                renders. Aggregation happens in your browser.
               </p>
             </div>
           </div>
         </section>
 
-        {/* ============= the ask ============= */}
-        <section className="pitch-section">
+        {/* ============= privacy rules (k-anonymity) ============= */}
+        <section className="pitch-section" id="privacy">
           <div className="pitch-head">
-            <span className="eyebrow">the ask</span>
+            <span className="eyebrow">the privacy rules</span>
             <h2>
-              We&rsquo;re onboarding a few <em>design partners</em>.
+              Aggregate, <em>never</em> surveillance.
+            </h2>
+          </div>
+          <div className="dp-kanon">
+            <span className="dp-kanon__mark" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="4.5" y="10.5" width="15" height="9" rx="1.5" />
+                <path d="M8 10.5V8a4 4 0 0 1 8 0v2.5" />
+              </svg>
+            </span>
+            <p className="dp-kanon__text">
+              Team cells with fewer than <b>5</b> contributors are hidden. No
+              individual drilldown. No per-person leaderboard.
+            </p>
+          </div>
+        </section>
+
+        {/* ============= security FAQ ============= */}
+        <section className="pitch-section dp-alt" id="security">
+          <div className="pitch-head">
+            <span className="eyebrow">security, plainly</span>
+            <h2>
+              The questions your <em>security team</em> asks.
+            </h2>
+          </div>
+          <div className="dp-faq">
+            <details className="dp-faq__item">
+              <summary>Where does the data live?</summary>
+              <p>
+                In a private git repo in your own GitHub org. One redacted file
+                per dev. We keep no copy.
+              </p>
+            </details>
+            <details className="dp-faq__item">
+              <summary>Who can read it?</summary>
+              <p>
+                Members of that repo, using their own GitHub token in the browser.
+                Repo membership is the only access control.
+              </p>
+            </details>
+            <details className="dp-faq__item">
+              <summary>What actually leaves a machine?</summary>
+              <p>
+                Only the redacted aggregate file shown above. No transcripts,
+                code, prompts or paths.
+              </p>
+            </details>
+            <details className="dp-faq__item">
+              <summary>What if a dev leaves or a token leaks?</summary>
+              <p>
+                Remove them from the repo and access ends. A leaked token exposes
+                only aggregate counts, never source or transcripts.
+              </p>
+            </details>
+            <details className="dp-faq__item">
+              <summary>GDPR and deletion?</summary>
+              <p>
+                Delete the dev&rsquo;s file from the repo. That removes their data
+                everywhere, because the repo is the only store.
+              </p>
+            </details>
+            <details className="dp-faq__item">
+              <summary>Self-host or exit?</summary>
+              <p>
+                ax is AGPL-3.0. The data is already yours in git, so there is
+                nothing to export and no lock-in.
+              </p>
+            </details>
+          </div>
+        </section>
+
+        {/* ============= founding cohort (scarcity) ============= */}
+        <section className="pitch-section" id="cohort">
+          <div className="pitch-head">
+            <span className="eyebrow">the founding cohort</span>
+            <h2>
+              Five teams, then we <em>close it</em>.
             </h2>
             <p>
-              We&rsquo;ve built the local, git-native foundation. The hosted
-              dashboard is deliberately gated on a real price signal &mdash; we
-              won&rsquo;t build the commercial layer speculatively. We&rsquo;re
-              looking for a small number of teams who will tell us this is worth
-              paying for, and pilot the per-project opt-in with a real team.
+              The rollup is real work built around real repos. We can hand-onboard
+              and hold a weekly founder call for five teams this quarter, no more.
             </p>
+          </div>
+
+          <div className="dp-scarcity">
+            <div className="dp-scarcity__meter" role="img" aria-label="2 of 5 founding seats claimed">
+              <span className="dp-seat is-filled"></span>
+              <span className="dp-seat is-filled"></span>
+              <span className="dp-seat"></span>
+              <span className="dp-seat"></span>
+              <span className="dp-seat"></span>
+            </div>
+            <p className="dp-scarcity__count">2 claimed &middot; 3 open</p>
+            <ul className="dp-scarcity__list">
+              <li>
+                <b>$12/seat locked.</b> Founding price holds as the product grows.
+              </li>
+              <li>
+                <b>Direct founder line.</b> Onboarding by hand, weekly call.
+              </li>
+              <li>
+                <b>Shape the roadmap.</b> We build the rollup around your repos.
+              </li>
+            </ul>
+            <div className="cta-row">
+              <a className="prompt-pill is-solo" href={BOOK_URL}>
+                <span className="prompt-pill__label">Claim a founding spot</span>
+              </a>
+            </div>
           </div>
         </section>
 
         {/* ============= pricing ============= */}
         <section className="pitch-section" id="pricing">
           <div className="pitch-head">
-            <span className="eyebrow">design-partner pricing</span>
+            <span className="eyebrow">founding pricing</span>
             <h2>
               <em>$12</em> per developer, per month.
             </h2>
             <p>
-              Simple per-seat, self-serve, cancel anytime &mdash; a seat is a dev
-              who pushes to the team. It rides as an add-on to the $20&ndash;40 per
-              dev you already spend on agents, and pays for itself the moment it
-              redirects one routine sub-task off the expensive default. Founder
-              pricing is locked for design partners.
+              Per-seat, self-serve, cancel anytime. A seat is a dev who pushes. It
+              rides as an add-on to the $20 to $40 per dev you already spend on
+              agents, and pays for itself the moment it redirects one routine
+              sub-task off the expensive default.
             </p>
           </div>
           <div className="ministats">
             <div className="mini">
               <div className="mini-label">Per seat</div>
-              <div className="mini-value"><span className="unit">$</span>12<span className="unit">/mo</span></div>
+              <div className="mini-value">
+                <span className="unit">$</span>12<span className="unit">/mo</span>
+              </div>
               <div className="mini-sub">a seat = a dev who <b>pushes</b></div>
             </div>
             <div className="mini">
               <div className="mini-label">10-dev team</div>
-              <div className="mini-value"><span className="unit">$</span>120<span className="unit">/mo</span></div>
+              <div className="mini-value">
+                <span className="unit">$</span>120<span className="unit">/mo</span>
+              </div>
               <div className="mini-sub">less than one redirected task</div>
             </div>
             <div className="mini">
               <div className="mini-label">50-dev team</div>
-              <div className="mini-value"><span className="unit">$</span>600<span className="unit">/mo</span></div>
+              <div className="mini-value">
+                <span className="unit">$</span>600<span className="unit">/mo</span>
+              </div>
               <div className="mini-sub">scales per seat, prorated</div>
             </div>
             <div className="mini">
@@ -264,9 +700,8 @@ function DesignPartners() {
             </div>
           </div>
           <p className="demo-caption">
-            You&rsquo;re paying for the dashboard and the enablement &mdash; never
-            for a place to warehouse your code insights. Those stay in <b>your</b>
-            git repo; we store none of it.
+            You pay for the dashboard and the enablement. Your data stays in{" "}
+            <b>your</b> git repo; we store none of it.
           </p>
         </section>
 
@@ -274,12 +709,12 @@ function DesignPartners() {
         <section className="pitch-cta">
           <h2>Visibility without the data-grab.</h2>
           <p>
-            Book a walkthrough on your own local ax data today &mdash; then decide
-            if the team layer is worth piloting.
+            See it on your own local ax data today, then decide if the team layer
+            is worth piloting.
           </p>
           <div className="cta-row">
             <a className="prompt-pill is-solo" href={BOOK_URL}>
-              <span className="prompt-pill__label">Book a walkthrough</span>
+              <span className="prompt-pill__label">Claim a founding spot</span>
             </a>
             <a
               className="cta-secondary"

--- a/apps/site/app/styles/pitch.css
+++ b/apps/site/app/styles/pitch.css
@@ -336,20 +336,554 @@
   color: var(--page);
 }
 
+/* ===========================================================================
+   design-partners page (/design-partners) - namespaced .dp-* extras.
+   Reuses the shared .landing-v2 tokens; the rollup mock rides on the shared
+   .browser--instrument dark-token remap so it reads instrument-dark for free.
+   ========================================================================= */
+
+/* honest above-the-fold status line ---------------------------------------- */
+.landing-v2 .dp-status {
+  max-width: 62ch;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.6;
+  letter-spacing: 0.01em;
+  color: var(--muted);
+  text-align: center;
+}
+.landing-v2 .dp-status b {
+  color: var(--ink);
+  font-weight: 600;
+}
+.landing-v2 .dp-status__sep {
+  margin: 0 8px;
+  color: var(--soft);
+}
+
+/* full-bleed alternating section band (breaks the card-grid rhythm) --------- */
+.landing-v2 .pitch-section.dp-alt {
+  background: var(--panel);
+  margin-left: -32px;
+  margin-right: -32px;
+  padding-left: 32px;
+  padding-right: 32px;
+}
+
+/* wide architecture diagram ------------------------------------------------- */
+.landing-v2 .dp-arch {
+  margin: 8px 0 0;
+  /* break the centered column: run to the full 1120 shell width */
+  margin-left: -32px;
+  margin-right: -32px;
+  padding: 0 32px;
+}
+.landing-v2 .dp-arch__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.landing-v2 .dp-arch__zone rect {
+  fill: var(--panel);
+  stroke: var(--line);
+  stroke-width: 1;
+}
+.landing-v2 .dp-arch__zone--db rect {
+  stroke: var(--ink);
+  stroke-width: 1.4;
+}
+.landing-v2 .dp-arch__cloud rect {
+  fill: var(--page);
+  stroke: var(--line);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+}
+.landing-v2 .dp-arch__kick {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  fill: var(--muted);
+}
+.landing-v2 .dp-arch__kick--db { fill: var(--ink); }
+.landing-v2 .dp-arch__kick--cloud { font-size: 10px; fill: var(--soft); }
+.landing-v2 .dp-arch__title {
+  font-family: var(--serif);
+  font-size: 17px;
+  fill: var(--ink);
+}
+.landing-v2 .dp-arch__code {
+  font-family: var(--mono);
+  font-size: 12px;
+  fill: var(--blue);
+}
+.landing-v2 .dp-arch__note {
+  font-family: var(--mono);
+  font-size: 11px;
+  fill: var(--muted);
+}
+.landing-v2 .dp-arch__badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  fill: var(--amber);
+}
+.landing-v2 .dp-arch__cloudline {
+  font-family: var(--mono);
+  font-size: 10px;
+  fill: var(--muted);
+}
+.landing-v2 .dp-arch__cloudnil {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  fill: var(--soft);
+}
+.landing-v2 .dp-arch__flow {
+  stroke-width: 1.6;
+  fill: none;
+}
+.landing-v2 .dp-arch__flow--green { stroke: var(--green); }
+.landing-v2 .dp-arch__flow--blue { stroke: var(--blue); }
+.landing-v2 .dp-arch__flowlabel {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  text-anchor: middle;
+}
+.landing-v2 .dp-arch__flowlabel--green { fill: var(--green); }
+.landing-v2 .dp-arch__flowlabel--blue { fill: var(--blue); }
+.landing-v2 .dp-arch__auth {
+  stroke: var(--soft);
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+  fill: none;
+}
+.landing-v2 .dp-arch__authlabel {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  fill: var(--soft);
+}
+.landing-v2 .dp-arch__block {
+  stroke: var(--red);
+  stroke-width: 1.4;
+}
+.landing-v2 .dp-arch__gate {
+  stroke: var(--red);
+  stroke-width: 2;
+  stroke-dasharray: 4 3;
+}
+.landing-v2 .dp-arch__blocklabel {
+  font-family: var(--mono);
+  font-size: 10px;
+  fill: var(--red);
+}
+.landing-v2 .dp-arch__gatelabel {
+  font-family: var(--mono);
+  font-size: 10px;
+  fill: var(--red);
+}
+.landing-v2 .dp-arch__gatelabel--sub {
+  font-size: 9px;
+  fill: var(--muted);
+}
+.landing-v2 .dp-arch__cap {
+  margin: 14px auto 0;
+  max-width: 60ch;
+  text-align: center;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 16px;
+  color: var(--ink);
+}
+
+/* three precise zero-data claims ------------------------------------------- */
+.landing-v2 .dp-claims {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  max-width: 1000px;
+  margin: 34px auto 0;
+}
+.landing-v2 .dp-claim {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--panel);
+  padding: 20px 20px 18px;
+}
+.landing-v2 .dp-claim__k {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--green);
+  margin-bottom: 10px;
+}
+.landing-v2 .dp-claim p {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--muted);
+  margin: 0;
+}
+.landing-v2 .dp-claim code {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--page);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: var(--ink);
+}
+
+/* team-rollup dashboard mock ----------------------------------------------- */
+.landing-v2 .dp-rollup .dash {
+  padding: 22px 24px 26px;
+  text-align: left;
+}
+.landing-v2 .dp-rollup__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.landing-v2 .dp-rollup__title {
+  font-family: var(--serif);
+  font-size: 20px;
+  color: #fff;
+}
+.landing-v2 .dp-mock-tag {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  color: var(--amber);
+  border: 1px solid color-mix(in srgb, var(--amber) 55%, var(--line));
+  border-radius: 4px;
+  padding: 2px 7px;
+}
+.landing-v2 .dp-rollup__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+.landing-v2 .dp-card {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface, var(--panel));
+  padding: 14px 15px 13px;
+  min-height: 96px;
+  display: flex;
+  flex-direction: column;
+}
+.landing-v2 .dp-card--wide { grid-column: span 2; }
+.landing-v2 .dp-card__label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+.landing-v2 .dp-card__row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.landing-v2 .dp-card__big {
+  font-family: var(--mono);
+  font-size: 24px;
+  line-height: 1;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+.landing-v2 .dp-card__unit {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+.landing-v2 .dp-card__sub {
+  margin-top: auto;
+  padding-top: 10px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  line-height: 1.45;
+  color: var(--muted);
+}
+.landing-v2 .dp-spark {
+  width: 100%;
+  height: 40px;
+  margin: 10px 0 2px;
+}
+.landing-v2 .dp-spark polyline {
+  stroke: var(--green);
+  stroke-width: 1.6;
+  vector-effect: non-scaling-stroke;
+}
+.landing-v2 .dp-bar {
+  height: 6px;
+  margin: 12px 0 2px;
+  background: var(--line);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.landing-v2 .dp-bar__fill {
+  display: block;
+  height: 100%;
+  background: var(--amber);
+}
+.landing-v2 .dp-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.landing-v2 .dp-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 0;
+  border-top: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink);
+}
+.landing-v2 .dp-list li:first-child { border-top: 0; }
+.landing-v2 .dp-list__meta { color: var(--muted); font-size: 11px; }
+.landing-v2 .dp-tag {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  border-radius: 4px;
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+}
+.landing-v2 .dp-tag--on {
+  color: var(--green);
+  border-color: color-mix(in srgb, var(--green) 45%, var(--line));
+}
+.landing-v2 .dp-tag--off { color: var(--soft); }
+.landing-v2 .dp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-bottom: 4px;
+}
+.landing-v2 .dp-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 4px 10px;
+}
+.landing-v2 .dp-chip__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--green);
+}
+
+/* sample payload card ------------------------------------------------------- */
+.landing-v2 .dp-payload {
+  max-width: 620px;
+  margin: 0 auto;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--panel);
+  overflow: hidden;
+}
+.landing-v2 .dp-payload__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--page);
+}
+.landing-v2 .dp-payload__path {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--blue);
+}
+.landing-v2 .dp-payload__tag {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--green);
+}
+.landing-v2 .dp-payload__body {
+  margin: 0;
+  padding: 16px 18px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--ink);
+  overflow-x: auto;
+  white-space: pre;
+}
+.landing-v2 .dp-payload__note {
+  margin: 0;
+  padding: 11px 14px 13px;
+  border-top: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  text-align: center;
+}
+
+/* k-anonymity callout ------------------------------------------------------- */
+.landing-v2 .dp-kanon {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  max-width: 720px;
+  margin: 0 auto;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--panel);
+  padding: 20px 24px;
+}
+.landing-v2 .dp-kanon__mark {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  display: grid;
+  place-items: center;
+  color: var(--ink);
+}
+.landing-v2 .dp-kanon__mark svg { width: 20px; height: 20px; }
+.landing-v2 .dp-kanon__text {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+.landing-v2 .dp-kanon__text b { color: var(--ink); font-weight: 600; }
+
+/* security FAQ strip -------------------------------------------------------- */
+.landing-v2 .dp-faq {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+.landing-v2 .dp-faq__item {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--page);
+  padding: 4px 16px;
+}
+.landing-v2 .dp-faq__item summary {
+  font-family: var(--serif);
+  font-size: 16px;
+  color: var(--ink);
+  padding: 12px 0;
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.landing-v2 .dp-faq__item summary::-webkit-details-marker { display: none; }
+.landing-v2 .dp-faq__item summary::after {
+  content: "+";
+  font-family: var(--mono);
+  color: var(--muted);
+}
+.landing-v2 .dp-faq__item[open] summary::after { content: "\2212"; }
+.landing-v2 .dp-faq__item p {
+  margin: 0;
+  padding: 0 0 14px;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+
+/* founding-cohort scarcity band -------------------------------------------- */
+.landing-v2 .dp-scarcity {
+  max-width: 620px;
+  margin: 0 auto;
+  border: 1px solid var(--amber);
+  border-radius: 14px;
+  background: var(--panel);
+  padding: 30px 28px 26px;
+  text-align: center;
+}
+.landing-v2 .dp-scarcity__meter {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.landing-v2 .dp-seat {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: transparent;
+}
+.landing-v2 .dp-seat.is-filled {
+  background: var(--ink);
+  border-color: var(--ink);
+}
+.landing-v2 .dp-scarcity__count {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--amber);
+  margin: 0 0 22px;
+}
+.landing-v2 .dp-scarcity__list {
+  list-style: none;
+  margin: 0 auto 24px;
+  padding: 0;
+  max-width: 42ch;
+  text-align: left;
+}
+.landing-v2 .dp-scarcity__list li {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--muted);
+  padding: 8px 0;
+  border-top: 1px solid var(--line);
+}
+.landing-v2 .dp-scarcity__list li:first-child { border-top: 0; }
+.landing-v2 .dp-scarcity__list b { color: var(--ink); font-weight: 600; }
+.landing-v2 .dp-scarcity .cta-row { justify-content: center; }
+
 @media (max-width: 860px) {
   .landing-v2 .pitch-loop {
     grid-template-columns: 1fr 1fr;
   }
   .landing-v2 .pitch-lanes,
   .landing-v2 .pitch-triad,
-  .landing-v2 .metrics-bars {
+  .landing-v2 .metrics-bars,
+  .landing-v2 .dp-claims,
+  .landing-v2 .dp-rollup__grid,
+  .landing-v2 .dp-faq {
     grid-template-columns: 1fr;
   }
+  .landing-v2 .dp-card--wide { grid-column: span 1; }
   .landing-v2 .impact-panel {
     padding: 20px 14px 18px;
   }
   .landing-v2 .pipeline-flow__labels span {
     font-size: 9px;
     letter-spacing: 0.1em;
+  }
+  .landing-v2 .pitch-section.dp-alt,
+  .landing-v2 .dp-arch {
+    margin-left: -20px;
+    margin-right: -20px;
+    padding-left: 20px;
+    padding-right: 20px;
   }
 }

--- a/apps/studio/src/instrument/instrument.css
+++ b/apps/studio/src/instrument/instrument.css
@@ -853,6 +853,16 @@
 
 /* ---- hero scoreboard strip (teaser): 3 outcome tiles + a "so what" line ---- */
 .v-tm-hero { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+/* demo board: 4 dev-adoption tiles */
+.v-tm-hero--demo { grid-template-columns: repeat(4, 1fr); }
+@media (max-width: 1080px) { .v-tm-hero--demo { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 560px) { .v-tm-hero--demo { grid-template-columns: 1fr; } }
+/* honest "sample data" badge on the demo masthead */
+.v-tm-demo-badge {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--accent); border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+    border-radius: 6px; padding: 2px 8px; white-space: nowrap;
+}
 .v-tm-hero-cap { grid-column: 1 / -1; margin: 2px 0 0; line-height: 1.5; color: var(--sec); text-transform: none; letter-spacing: 0; font-size: 12.5px; }
 .v-tm-hero-cap b { color: var(--pri); font-weight: 600; }
 @media (max-width: 720px) { .v-tm-hero { grid-template-columns: 1fr; } }

--- a/apps/studio/src/instrument/team-metrics.tsx
+++ b/apps/studio/src/instrument/team-metrics.tsx
@@ -379,6 +379,146 @@ function mockDays(): WrappedUsageDay[] {
 }
 const MOCK_DAYS: WrappedUsageDay[] = mockDays();
 
+// ===========================================================================
+// DEMO org dataset - the clean, fully-visible `?demo` board. Tells the
+// DEV-ADOPTION story from the /design-partners pitch: a git-native team
+// rollup for AI coding agents. Framing is adoption + routable spend + skill
+// diffusion, NOT the exec business-functions view (which stays on the locked
+// teaser). All numbers echo the pitch's RollupMock so the two never contradict.
+// Fabricated + deterministic; no live queries, renders daemon-up or down.
+// ===========================================================================
+const DEMO_ORG = {
+    label: "acme",
+    seats: 8,
+    activeThisWeek: 8,
+    activePct: 0.82, // team active-days
+    activePctPrev: 0.61, // 8 weeks ago (matches pitch "up from 61%")
+    spendUsd: 2140, // total agent spend / mo
+    routableUsd: 605, // routine sub-tasks on the expensive default
+    workflowsReady: 3, // above the cohort floor (seen on 5+ seats)
+};
+
+/** Model spend for the month - opus is the expensive default; the routable
+ *  slice ($605) is routine work that belongs on cheaper tiers. Sums to $2,140. */
+const DEMO_CHANNELS = [
+    { model: "claude-opus-4-8", cost_usd: 1205 },
+    { model: "claude-sonnet-4-6", cost_usd: 520 },
+    { model: "claude-haiku-4-5", cost_usd: 210 },
+    { model: "gpt-5.4", cost_usd: 205 },
+];
+
+/** A repo in the acme org. `joined` = opted in via `ax team join` (drives the
+ *  status dot); a not-joined repo pushes nothing, so it reads as dashes. */
+function demoProject(
+    name: string, joined: boolean, sessions: number, cost: number,
+    added: number, removed: number, model: string,
+): RosterEntity {
+    return {
+        id: name, label: name, online: joined,
+        spark: joined ? levelize([2, 3, 3, 4, 5, 5, 6]) : [0, 0, 0, 0, 0, 0, 0],
+        model: joined ? model : null, sessions, tokens: 0, cost,
+        metrics: [
+            { label: "opt-in", value: joined ? "joined" : "not joined", n: joined ? 1 : 0 },
+            { label: "sessions", value: joined ? fmtCount(sessions) : "-", n: sessions },
+            { label: "cost / mo", value: joined ? fmtUsd(cost) : "-", n: cost },
+            { label: "top model", value: joined ? shortModel(model) : "-", n: 0 },
+            { label: "lines +", value: joined ? fmtCount(added) : "-", n: added },
+            { label: "lines -", value: joined ? fmtCount(removed) : "-", n: removed },
+        ],
+    };
+}
+
+// joined repos sum to the $2,140/mo org total; acme-infra is opted out.
+const DEMO_PROJECTS: RosterEntity[] = [
+    demoProject("acme-web", true, 312, 940, 41_200, 9_800, "claude-opus-4-8"),
+    demoProject("acme-api", true, 268, 720, 33_100, 7_400, "claude-sonnet-4-6"),
+    demoProject("acme-mobile", true, 141, 310, 18_600, 4_100, "claude-sonnet-4-6"),
+    demoProject("acme-billing", true, 96, 170, 9_200, 2_300, "claude-haiku-4-5"),
+    demoProject("acme-infra", false, 0, 0, 0, 0, "claude-sonnet-4-6"),
+];
+
+/** An anonymized seat (eng-01…eng-08). No names, no per-person spend, no
+ *  ranking metric - just adoption signals. Reinforces k-anonymity. */
+interface DemoSeat { id: string; activeDays: number; sessions: number; harnesses: string[]; model: string; skills: number }
+const DEMO_SEATS: DemoSeat[] = [
+    { id: "eng-01", activeDays: 26, sessions: 41, harnesses: ["claude", "codex"], model: "claude-opus-4-8", skills: 9 },
+    { id: "eng-02", activeDays: 24, sessions: 38, harnesses: ["claude"], model: "claude-sonnet-4-6", skills: 8 },
+    { id: "eng-03", activeDays: 23, sessions: 34, harnesses: ["claude", "cursor"], model: "claude-opus-4-8", skills: 7 },
+    { id: "eng-04", activeDays: 21, sessions: 30, harnesses: ["claude", "codex"], model: "claude-sonnet-4-6", skills: 7 },
+    { id: "eng-05", activeDays: 19, sessions: 27, harnesses: ["claude"], model: "claude-sonnet-4-6", skills: 6 },
+    { id: "eng-06", activeDays: 18, sessions: 24, harnesses: ["claude", "cursor"], model: "claude-haiku-4-5", skills: 5 },
+    { id: "eng-07", activeDays: 15, sessions: 19, harnesses: ["claude"], model: "claude-sonnet-4-6", skills: 5 },
+    { id: "eng-08", activeDays: 12, sessions: 14, harnesses: ["codex"], model: "gpt-5.4", skills: 4 },
+];
+const DEMO_MEMBERS: RosterEntity[] = DEMO_SEATS.map((s) => ({
+    id: s.id, label: s.id, online: s.activeDays >= 7, spark: [],
+    mid: (
+        <span className="v-tm-chips">
+            {s.harnesses.map((h) => <span key={h} className="v-tm-chip">{h}</span>)}
+        </span>
+    ),
+    model: s.model, sessions: s.sessions, tokens: 0, cost: 0,
+    metrics: [
+        { label: "active days", value: `${s.activeDays} / 30`, n: s.activeDays },
+        { label: "sessions", value: fmtCount(s.sessions), n: s.sessions },
+        { label: "harnesses", value: String(s.harnesses.length), n: s.harnesses.length },
+        { label: "skills adopted", value: String(s.skills), n: s.skills },
+        { label: "top model", value: shortModel(s.model), n: 0 },
+    ],
+}));
+
+const DEMO_HARNESSES: RosterEntity[] = [
+    { id: "claude", label: "claude", online: true, spark: levelize([5, 6, 6, 7, 6, 7, 7]), model: "claude-opus-4-8", sessions: 612, tokens: 0, cost: 1610,
+        metrics: [{ label: "sessions", value: "612", n: 612 }, { label: "cost / mo", value: fmtUsd(1610), n: 1610 }, { label: "seats", value: "7", n: 7 }, { label: "active (7d)", value: "yes", n: 1 }] },
+    { id: "codex", label: "codex", online: true, spark: levelize([2, 3, 2, 3, 4, 3, 4]), model: "gpt-5.4", sessions: 138, tokens: 0, cost: 205,
+        metrics: [{ label: "sessions", value: "138", n: 138 }, { label: "cost / mo", value: fmtUsd(205), n: 205 }, { label: "seats", value: "3", n: 3 }, { label: "active (7d)", value: "yes", n: 1 }] },
+    { id: "cursor", label: "cursor", online: true, spark: levelize([1, 2, 1, 2, 2, 1, 2]), model: "claude-sonnet-4-6", sessions: 67, tokens: 0, cost: 325,
+        metrics: [{ label: "sessions", value: "67", n: 67 }, { label: "cost / mo", value: fmtUsd(325), n: 325 }, { label: "seats", value: "2", n: 2 }, { label: "active (7d)", value: "yes", n: 1 }] },
+];
+
+/** Skills spreading across seats - the diffusion story. Seat counts match the
+ *  pitch's "Skills spreading" list (effect-kit 6, ship-checklist 5, ...). */
+const DEMO_SKILLS: { name: string; seats: number; runs: number }[] = [
+    { name: "effect-kit", seats: 6, runs: 214 },
+    { name: "ship-checklist", seats: 5, runs: 168 },
+    { name: "ax-extract-workflow", seats: 5, runs: 132 },
+    { name: "design-taste-frontend", seats: 4, runs: 88 },
+    { name: "cta-design", seats: 3, runs: 54 },
+];
+
+/** Workflows (ordered skill arcs) that recur on 5+ seats - "ready to spread". */
+const DEMO_WORKFLOWS: { arc: string; seats: number }[] = [
+    { arc: "plan → implement → ship-checklist", seats: 6 },
+    { arc: "recall → extract-workflow → improve", seats: 5 },
+    { arc: "gather → design-taste → review", seats: 5 },
+];
+
+/** Deterministic ~9-week daily series with a gently RISING adoption ramp
+ *  (seats coming online) - the "adoption, last N days" trend from the pitch. */
+function demoDays(): WrappedUsageDay[] {
+    const out: WrappedUsageDay[] = [];
+    const today = new Date();
+    const N = 63;
+    for (let i = N - 1; i >= 0; i--) {
+        const d = new Date(today);
+        d.setDate(today.getDate() - i);
+        const dow = d.getDay();
+        const weekday = dow >= 1 && dow <= 5 ? 1 : 0.3; // quiet weekends
+        const t = (N - 1 - i) / (N - 1); // 0 → 1 over the window
+        const ramp = 0.42 + 0.58 * t; // adoption climbs
+        const wobble = 0.92 + 0.08 * Math.sin((N - i) / 3.1);
+        const sessions = Math.round((12 + 30 * ramp) * weekday * wobble);
+        out.push({
+            date: d.toISOString().slice(0, 10),
+            sessions,
+            turns: sessions * (26 + Math.round(12 * ramp)),
+            tokens: sessions * 4_100_000,
+        });
+    }
+    return out;
+}
+const DEMO_DAYS: WrappedUsageDay[] = demoDays();
+
 // ---- range toggle group ---------------------------------------------------
 function Toggle<T extends number>({
     label, values, value, onChange, suffix,
@@ -452,20 +592,104 @@ function HeroStrip() {
     );
 }
 
+// ---- demo hero (dev-adoption tiles) ---------------------------------------
+/** Four adoption tiles for the `?demo` board - active seats, active-days,
+ *  routable spend, workflows ready to spread. Replaces the exec HeroStrip. */
+function DemoHero() {
+    const routablePct = Math.round((DEMO_ORG.routableUsd / DEMO_ORG.spendUsd) * 100);
+    const activeDelta = Math.round((DEMO_ORG.activePct - DEMO_ORG.activePctPrev) * 100);
+    return (
+        <div className="v-tm-hero v-tm-hero--demo">
+            <section className="rdx-card v-tm-herotile">
+                <div className="rdx-label">devs active · this week</div>
+                <div className="rdx-num v-tm-herostat">{DEMO_ORG.activeThisWeek}<small> / {DEMO_ORG.seats}</small></div>
+                <div className="v-tm-trend"><span className="rdx-led accent" /> across 4 joined repos</div>
+            </section>
+            <section className="rdx-card v-tm-herotile">
+                <div className="rdx-label">team active-days</div>
+                <div className="rdx-num v-tm-herostat">{Math.round(DEMO_ORG.activePct * 100)}<small>%</small></div>
+                <div className="v-tm-trend up"><span className="arr">▲</span> +{activeDelta}% from {Math.round(DEMO_ORG.activePctPrev * 100)}% · 8 weeks ago</div>
+            </section>
+            <section className="rdx-card v-tm-herotile">
+                <div className="rdx-label">routable spend · / mo</div>
+                <div className="rdx-num v-tm-herostat">{fmtUsd(DEMO_ORG.routableUsd)}</div>
+                <div className="v-tm-trend"><span className="rdx-led accent" /> {routablePct}% of {fmtUsd(DEMO_ORG.spendUsd)} on the pricey default</div>
+            </section>
+            <section className="rdx-card v-tm-herotile">
+                <div className="rdx-label">workflows ready to spread</div>
+                <div className="rdx-num v-tm-herostat">{DEMO_ORG.workflowsReady}</div>
+                <div className="v-tm-trend"><span className="rdx-led accent" /> settled arcs seen on 5+ seats</div>
+            </section>
+        </div>
+    );
+}
+
+/** Skills-spreading + workflows-ready cards - the diffusion story (demo only).
+ *  Reuses the model-channels list styling (.v-mc-split / .v-mc-split-row). */
+function DemoAdoptionRow() {
+    const maxSeats = Math.max(...DEMO_SKILLS.map((s) => s.seats), 1);
+    return (
+        <div className="v-tm-grid">
+            <section className="rdx-card v-mc-split">
+                <div className="v-mc-meta rdx-label">
+                    <span style={{ color: "var(--pri)" }}>SKILLS SPREADING · seats using</span>
+                    <span>{DEMO_SKILLS.length} skills</span>
+                </div>
+                <div className="nf-list">
+                    {DEMO_SKILLS.map((s) => (
+                        <div className="v-mc-split-row" key={s.name}>
+                            <span style={{ color: "var(--pri)" }}>
+                                <span className="nf-swatch" style={{ background: "var(--accent)" }} />{s.name}
+                            </span>
+                            <span>{s.seats} seats · {fmtCount(s.runs)} runs</span>
+                            <span className="segwrap">
+                                <span className="v-tm-bar"><span style={{ width: `${Math.max(6, (s.seats / maxSeats) * 100)}%`, background: "var(--accent)" }} /></span>
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            </section>
+
+            <section className="rdx-card v-mc-split">
+                <div className="v-mc-meta rdx-label">
+                    <span style={{ color: "var(--pri)" }}>WORKFLOWS READY TO SPREAD</span>
+                    <span>{DEMO_WORKFLOWS.length} above floor</span>
+                </div>
+                <div className="nf-list">
+                    {DEMO_WORKFLOWS.map((w) => (
+                        <div className="v-mc-split-row" key={w.arc}>
+                            <span style={{ color: "var(--pri)" }}>{w.arc}</span>
+                            <span>{w.seats} seats</span>
+                        </div>
+                    ))}
+                    <p className="rdx-label" style={{ margin: "10px 2px 2px", lineHeight: 1.5, textTransform: "none", letterSpacing: 0 }}>
+                        The workflows your team settles into, seen on 5+ seats - ready to package and share.
+                    </p>
+                </div>
+            </section>
+        </div>
+    );
+}
+
 // ---- tabbed, selectable roster --------------------------------------------
 function RosterCard({
-    tab, onTab, entities, loading, selected, onToggle, midHead, orgMode = false,
+    tab, onTab, entities, loading, selected, onToggle, midHead, orgMode = false, demo = false,
 }: {
     tab: RosterTab; onTab: (t: RosterTab) => void;
     entities: RosterEntity[]; loading: boolean;
     selected: ReadonlySet<string>; onToggle: (id: string) => void;
-    midHead: string; orgMode?: boolean;
+    midHead: string; orgMode?: boolean; demo?: boolean;
 }) {
     // orgMode (the paid teaser) frames the members tab as company FUNCTIONS.
     const tabLabel = (t: RosterTab) => (orgMode && t === "members" ? "functions" : TABS.find((x) => x.id === t)?.label ?? t);
-    const noun = tab === "members" ? (orgMode ? "function" : "member") : tab === "projects" ? "project" : "harness";
-    // Members/functions are the org roster - lead with token consumption.
-    const tokenLed = tab === "members";
+    const noun = tab === "members" ? (orgMode ? "function" : demo ? "seat" : "member") : tab === "projects" ? "project" : "harness";
+    // Members/functions are the org roster - lead with token consumption. In the
+    // demo, seats lead with sessions (no per-person spend → no ranking).
+    const tokenLed = tab === "members" && !demo;
+    // Demo seats are anonymized + unranked - say so where a leaderboard is implied.
+    const headNote = demo && tab === "members"
+        ? "aggregate view · no per-person ranking"
+        : selected.size >= 1 ? `${selected.size} selected` : "click rows · compare 2+";
     return (
         <section className="rdx-card v-team-roster">
             <div className="v-tm-roster-head">
@@ -476,7 +700,7 @@ function RosterCard({
                         </button>
                     ))}
                 </div>
-                <span className="rdx-label">{selected.size >= 1 ? `${selected.size} selected` : "click rows · compare 2+"}</span>
+                <span className="rdx-label">{headNote}</span>
             </div>
             <div className="nf-list">
                 {orgMode
@@ -615,11 +839,14 @@ function ComparePanel({ entities, onClear }: { entities: RosterEntity[]; onClear
     );
 }
 
-function Board({ days: liveDays, teaser = false }: { days: ReadonlyArray<WrappedUsageDay>; teaser?: boolean }) {
+function Board({ days: liveDays, teaser = false, demo = false }: { days: ReadonlyArray<WrappedUsageDay>; teaser?: boolean; demo?: boolean }) {
     const [daily, setDaily] = useState<DailyRange>(30);
     const [weeks, setWeeks] = useState<WeeklyRange>(8);
 
-    const days = teaser ? MOCK_DAYS : liveDays;
+    // Both the teaser and the demo run on fabricated, self-contained data (no
+    // live queries) - the difference is framing, not the data source.
+    const mock = teaser || demo;
+    const days = demo ? DEMO_DAYS : teaser ? MOCK_DAYS : liveDays;
     const dWin = useMemo(() => days.slice(-daily), [days, daily]);
     const wAll = useMemo(() => weekly(days), [days]);
     const wWin = useMemo(
@@ -645,11 +872,11 @@ function Board({ days: liveDays, teaser = false }: { days: ReadonlyArray<Wrapped
     // roster + channels. In teaser mode everything is mock (no live queries) so
     // the paywall background never leaks real numbers and never depends on the
     // daemon being up.
-    const sessQ = useQuery({ queryKey: ["sessions", "roster"], queryFn: () => api.sessions({ limit: 500 }), enabled: !teaser });
+    const sessQ = useQuery({ queryKey: ["sessions", "roster"], queryFn: () => api.sessions({ limit: 500 }), enabled: !mock });
     const sessions = sessQ.data?.sessions ?? [];
-    const costQ = useQuery({ queryKey: ["cost", "models"], queryFn: () => api.costModels(), enabled: !teaser });
-    const channels = teaser ? MOCK_CHANNELS : (costQ.data?.rows ?? []).filter((r) => r.cost_usd > 0).slice(0, 8);
-    const costTotal = teaser ? MOCK_COST_TOTAL : (costQ.data?.total_cost_usd || channels.reduce((s, r) => s + r.cost_usd, 0) || 1);
+    const costQ = useQuery({ queryKey: ["cost", "models"], queryFn: () => api.costModels(), enabled: !mock });
+    const channels = demo ? DEMO_CHANNELS : teaser ? MOCK_CHANNELS : (costQ.data?.rows ?? []).filter((r) => r.cost_usd > 0).slice(0, 8);
+    const costTotal = demo ? DEMO_ORG.spendUsd : teaser ? MOCK_COST_TOTAL : (costQ.data?.total_cost_usd || channels.reduce((s, r) => s + r.cost_usd, 0) || 1);
 
     // tabbed roster (projects | members | harnesses) + side-by-side compare.
     // Teaser opens on members (the company org roster, ranked by tokens).
@@ -662,12 +889,12 @@ function Board({ days: liveDays, teaser = false }: { days: ReadonlyArray<Wrapped
         return next;
     });
     // Members are public gists - only fetch when that tab is opened (live only).
-    const memQ = useQuery({ queryKey: ["members"], queryFn: () => fetchMembers(), enabled: !teaser && tab === "members", staleTime: 300_000 });
-    const projects = useMemo(() => teaser ? MOCK_PROJECTS : buildProjects(sessions), [teaser, sessions]);
-    const harnesses = useMemo(() => teaser ? MOCK_HARNESSES : harnessEntities(buildRoster(sessions)), [teaser, sessions]);
-    const members = useMemo(() => teaser ? MOCK_MEMBERS : memberEntities(memQ.data ?? []), [teaser, memQ.data]);
+    const memQ = useQuery({ queryKey: ["members"], queryFn: () => fetchMembers(), enabled: !mock && tab === "members", staleTime: 300_000 });
+    const projects = useMemo(() => demo ? DEMO_PROJECTS : teaser ? MOCK_PROJECTS : buildProjects(sessions), [demo, teaser, sessions]);
+    const harnesses = useMemo(() => demo ? DEMO_HARNESSES : teaser ? MOCK_HARNESSES : harnessEntities(buildRoster(sessions)), [demo, teaser, sessions]);
+    const members = useMemo(() => demo ? DEMO_MEMBERS : teaser ? MOCK_MEMBERS : memberEntities(memQ.data ?? []), [demo, teaser, memQ.data]);
     const entities = tab === "projects" ? projects : tab === "members" ? members : harnesses;
-    const rosterLoading = teaser ? false : tab === "members" ? memQ.isLoading : sessQ.isLoading;
+    const rosterLoading = mock ? false : tab === "members" ? memQ.isLoading : sessQ.isLoading;
     const midHead = tab === "members" ? (teaser ? "headcount" : "harnesses") : "last 7d";
     const selectedEntities = entities.filter((e) => selected.has(e.id));
 
@@ -683,8 +910,11 @@ function Board({ days: liveDays, teaser = false }: { days: ReadonlyArray<Wrapped
         <>
             <header className="v-tm-mast">
                 <div className="v-team-org">
-                    <span className="name"><b>ax</b> team metrics</span>
-                    <span className="ring">local graph</span>
+                    <span className="name">
+                        {demo ? <><b>{DEMO_ORG.label}</b> team adoption</> : <><b>ax</b> team metrics</>}
+                    </span>
+                    <span className="ring">{demo ? "team rollup" : "local graph"}</span>
+                    {demo && <span className="v-tm-demo-badge">demo · sample data</span>}
                 </div>
                 <div className="v-tm-ranges">
                     <Toggle label="daily" values={DAILY} value={daily} onChange={(v) => setDaily(v)} suffix="d" />
@@ -692,12 +922,15 @@ function Board({ days: liveDays, teaser = false }: { days: ReadonlyArray<Wrapped
                 </div>
             </header>
             <p className="rdx-label v-tm-sub">
-                {teaser
-                    ? "Return on every agent dollar - what each team ships, what it costs per task, and who's actually adopting."
-                    : "Where your agent spend goes and which skills & workflows get adopted. Compare projects, harnesses, or community members side-by-side - pick 2+ rows."}
+                {demo
+                    ? "How AI adoption is spreading across the team - active seats, routable spend, and the skills & workflows that land. Every number is a team-level aggregate; no per-person ranking."
+                    : teaser
+                        ? "Return on every agent dollar - what each team ships, what it costs per task, and who's actually adopting."
+                        : "Where your agent spend goes and which skills & workflows get adopted. Compare projects, harnesses, or community members side-by-side - pick 2+ rows."}
             </p>
 
             {teaser && <HeroStrip />}
+            {demo && <DemoHero />}
 
             <div className="v-tm-charts">
                 <ChartCard title="SESSIONS / DAY" range={`last ${daily}d`} total={fmtCount(sum(sessionsD))}
@@ -712,12 +945,12 @@ function Board({ days: liveDays, teaser = false }: { days: ReadonlyArray<Wrapped
 
             <div className="v-tm-grid">
                 <RosterCard tab={tab} onTab={switchTab} entities={entities} loading={rosterLoading}
-                    selected={selected} onToggle={toggleSel} midHead={midHead} orgMode={teaser} />
+                    selected={selected} onToggle={toggleSel} midHead={midHead} orgMode={teaser} demo={demo} />
 
                 <section className="rdx-card v-mc-split">
                     <div className="v-mc-meta rdx-label">
-                        <span style={{ color: "var(--pri)" }}>MODEL CHANNELS · 365d</span>
-                        <span>~{fmtUsd(costTotal)} total</span>
+                        <span style={{ color: "var(--pri)" }}>{demo ? "MODEL SPEND · this month" : "MODEL CHANNELS · 365d"}</span>
+                        <span>{demo ? `${fmtUsd(costTotal)}/mo · ${fmtUsd(DEMO_ORG.routableUsd)} routable` : `~${fmtUsd(costTotal)} total`}</span>
                     </div>
                     <div className="nf-list">
                         {channels.length === 0 ? (
@@ -740,6 +973,8 @@ function Board({ days: liveDays, teaser = false }: { days: ReadonlyArray<Wrapped
                     </div>
                 </section>
             </div>
+
+            {demo && <DemoAdoptionRow />}
 
             <ComparePanel entities={selectedEntities} onClear={() => setSelected(new Set())} />
         </>
@@ -811,8 +1046,23 @@ function isUnlocked(): boolean {
 function isForcedLock(): boolean {
     return typeof window !== "undefined" && new URLSearchParams(window.location.search).has("paywall");
 }
+// `?demo` renders the clean, fully-visible, seeded dev-adoption board - no blur,
+// no paywall, no live queries. It's the public "click around" surface linked
+// from /design-partners, distinct from the locked sales teaser and the live
+// (DEV/`?unlock`) board.
+function isDemo(): boolean {
+    return typeof window !== "undefined" && new URLSearchParams(window.location.search).has("demo");
+}
 
 export function TeamMetricsRoute() {
+    // Demo wins over everything: it's the shareable, self-contained board.
+    if (isDemo()) {
+        return (
+            <div className="v-tm">
+                <Board days={DEMO_DAYS} demo />
+            </div>
+        );
+    }
     const locked = isForcedLock() || !isUnlocked();
     // Locked: the blurred teaser is a self-contained mock org board - no live
     // queries, so it always renders fully (daemon up or down) and never leaks


### PR DESCRIPTION
Closes #653. Rebuild of /design-partners after a 4-way roast (Opus×3 + GPT/Codex).

**What changed**
- **Hero:** kill-the-tradeoff wedge ("Know if AI is working across your team. Without shipping your code to anyone.") + honest live-vs-building status + amber cohort badge.
- **Zero-data (promoted to section 2):** wide inline-SVG **architecture diagram** — your private git repo is the database, code/prompts hit a consent gate and dead-end, ax cloud is a near-empty stateless broker. Precise claim (no telemetry/transcripts/source/prompts/derived rows in ax cloud).
- **Team-rollup dashboard MOCK** (labeled once, no per-person ranking).
- **Sample payload:** redacted `.ax-team/<login>.json`.
- **Scarcity:** founding-cohort band, **capacity-framed (5 teams)**, static seat meter, no countdown; $12/seat locked.
- **k-anonymity rule + security FAQ strip.**
- Copy hygiene (0 em-dashes, jargon translated), metadata within SEO limits, pitch-switch cross-links.

Verified locally: `bun run build` (prerenders /design-partners) + `bun run typecheck` pass. Draft — **review the visuals on the Cloudflare Pages preview** before merge.

Roast sources: 4 subagents on different models. Follow-up to #651/#652.