### PR TITLE
copy(site): lean hero on /teams

### DIFF
--- a/apps/site/app/routes/teams.tsx
+++ b/apps/site/app/routes/teams.tsx
@@ -385,49 +385,6 @@ function Teams() {
           </div>
         </section>
 
-        {/* ============= zero-data (the differentiator) ============= */}
-        <section className="pitch-section" id="zero-data">
-          <div className="pitch-head">
-            <span className="eyebrow">where your data lives</span>
-            <h2>
-              The dashboard our servers <em>never see</em>.
-            </h2>
-            <p>
-              ax&rsquo;s servers never receive or store your telemetry,
-              transcripts, source, prompts, or derived rows. The frontend reads
-              your data with the viewer&rsquo;s own GitHub token. The only service
-              we run is a stateless auth broker.
-            </p>
-          </div>
-
-          <ArchitectureDiagram />
-
-          <div className="dp-claims">
-            <div className="dp-claim">
-              <span className="dp-claim__k">the database is your repo</span>
-              <p>
-                Aggregates land in a private repo in your own GitHub org, one
-                redacted file per dev. GitHub repo membership is team access.
-              </p>
-            </div>
-            <div className="dp-claim">
-              <span className="dp-claim__k">the browser does the math</span>
-              <p>
-                The dashboard aggregates client-side using the viewer&rsquo;s own
-                token. If we get breached, there is nothing of yours to leak.
-              </p>
-            </div>
-            <div className="dp-claim">
-              <span className="dp-claim__k">opt-in, default deny</span>
-              <p>
-                Nothing pushes until a dev runs <code>ax team join</code> inside a
-                specific repo. Repo identity is pinned, so a fork or rename
-                can&rsquo;t leak the wrong one.
-              </p>
-            </div>
-          </div>
-        </section>
-
         {/* ============= the rollup mock ============= */}
         <section className="pitch-section dp-alt" id="see-it">
           <div className="pitch-head">
@@ -453,78 +410,6 @@ function Teams() {
             <a className="cta-secondary" href="/studio/team?demo">
               Prefer to click around? Open the live demo &rarr;
             </a>
-          </div>
-        </section>
-
-        {/* ============= sample payload ============= */}
-        <section className="pitch-section" id="payload">
-          <div className="pitch-head">
-            <span className="eyebrow">what actually leaves a laptop</span>
-            <h2>
-              The <em>entire file</em> that ships.
-            </h2>
-            <p>
-              Names, not contents. No transcripts, no code, no prompts, no paths.
-              Daily-collapsed counts, sums and ratios.
-            </p>
-          </div>
-
-          <div className="dp-payload">
-            <div className="dp-payload__bar">
-              <span className="dp-payload__path">.ax-team/necmttn.json</span>
-              <span className="dp-payload__tag">redacted &middot; aggregates only</span>
-            </div>
-            <pre className="dp-payload__body">{`{
-  "login": "necmttn",
-  "window": "2026-06-01/2026-06-30",
-  "sessions": 214,
-  "active_days": 22,
-  "tokens": { "in": 4120000, "out": 385000 },
-  "routable_usd": 605,
-  "spend_usd": 2140,
-  "top_skills": ["effect-kit", "ship-checklist", "ax-extract-workflow"],
-  "churn_episodes": 7
-}`}</pre>
-            <p className="dp-payload__note">
-              This is the whole file that leaves. Names, not contents.
-            </p>
-          </div>
-        </section>
-
-        {/* ============= how it works ============= */}
-        <section className="pitch-section dp-alt">
-          <div className="pitch-head">
-            <span className="eyebrow">how it works</span>
-            <h2>
-              Setup is <em>minutes</em>. It is just git.
-            </h2>
-            <p>
-              No agents on your infra. No transcripts leaving machines.
-            </p>
-          </div>
-          <div className="pitch-triad">
-            <div className="pitch-fcard">
-              <h3>1 &middot; A private repo</h3>
-              <p>
-                Create a private <code>ax-team</code> repo in your GitHub org and
-                add your devs. Repo membership is team membership.
-              </p>
-            </div>
-            <div className="pitch-fcard">
-              <h3>2 &middot; Each dev opts in</h3>
-              <p>
-                Inside a work repo: <code>ax team join &lt;org&gt;</code>. A consent
-                screen shows exactly what is shared. Personal repos are never
-                joined.
-              </p>
-            </div>
-            <div className="pitch-fcard">
-              <h3>3 &middot; Open the dashboard</h3>
-              <p>
-                Log in with GitHub. It reads the repo with your own token and
-                renders. Aggregation happens in your browser.
-              </p>
-            </div>
           </div>
         </section>
 
@@ -635,6 +520,84 @@ function Teams() {
           </p>
         </section>
 
+        {/* ============= zero-data (the differentiator) ============= */}
+        <section className="pitch-section" id="zero-data">
+          <div className="pitch-head">
+            <span className="eyebrow">where your data lives</span>
+            <h2>
+              The dashboard our servers <em>never see</em>.
+            </h2>
+            <p>
+              ax&rsquo;s servers never receive or store your telemetry,
+              transcripts, source, prompts, or derived rows. The frontend reads
+              your data with the viewer&rsquo;s own GitHub token. The only service
+              we run is a stateless auth broker.
+            </p>
+          </div>
+
+          <ArchitectureDiagram />
+
+          <div className="dp-claims">
+            <div className="dp-claim">
+              <span className="dp-claim__k">the database is your repo</span>
+              <p>
+                Aggregates land in a private repo in your own GitHub org, one
+                redacted file per dev. GitHub repo membership is team access.
+              </p>
+            </div>
+            <div className="dp-claim">
+              <span className="dp-claim__k">the browser does the math</span>
+              <p>
+                The dashboard aggregates client-side using the viewer&rsquo;s own
+                token. If we get breached, there is nothing of yours to leak.
+              </p>
+            </div>
+            <div className="dp-claim">
+              <span className="dp-claim__k">opt-in, default deny</span>
+              <p>
+                Nothing pushes until a dev runs <code>ax team join</code> inside a
+                specific repo. Repo identity is pinned, so a fork or rename
+                can&rsquo;t leak the wrong one.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ============= sample payload ============= */}
+        <section className="pitch-section" id="payload">
+          <div className="pitch-head">
+            <span className="eyebrow">what actually leaves a laptop</span>
+            <h2>
+              The <em>entire file</em> that ships.
+            </h2>
+            <p>
+              Names, not contents. No transcripts, no code, no prompts, no paths.
+              Daily-collapsed counts, sums and ratios.
+            </p>
+          </div>
+
+          <div className="dp-payload">
+            <div className="dp-payload__bar">
+              <span className="dp-payload__path">.ax-team/necmttn.json</span>
+              <span className="dp-payload__tag">redacted &middot; aggregates only</span>
+            </div>
+            <pre className="dp-payload__body">{`{
+  "login": "necmttn",
+  "window": "2026-06-01/2026-06-30",
+  "sessions": 214,
+  "active_days": 22,
+  "tokens": { "in": 4120000, "out": 385000 },
+  "routable_usd": 605,
+  "spend_usd": 2140,
+  "top_skills": ["effect-kit", "ship-checklist", "ax-extract-workflow"],
+  "churn_episodes": 7
+}`}</pre>
+            <p className="dp-payload__note">
+              This is the whole file that leaves. Names, not contents.
+            </p>
+          </div>
+        </section>
+
         {/* ============= privacy rules (k-anonymity) ============= */}
         <section className="pitch-section" id="privacy">
           <div className="pitch-head">
@@ -654,6 +617,43 @@ function Teams() {
               Team cells with fewer than <b>5</b> contributors are hidden. No
               individual drilldown. No per-person leaderboard.
             </p>
+          </div>
+        </section>
+
+        {/* ============= how it works ============= */}
+        <section className="pitch-section dp-alt">
+          <div className="pitch-head">
+            <span className="eyebrow">how it works</span>
+            <h2>
+              Setup is <em>minutes</em>. It is just git.
+            </h2>
+            <p>
+              No agents on your infra. No transcripts leaving machines.
+            </p>
+          </div>
+          <div className="pitch-triad">
+            <div className="pitch-fcard">
+              <h3>1 &middot; A private repo</h3>
+              <p>
+                Create a private <code>ax-team</code> repo in your GitHub org and
+                add your devs. Repo membership is team membership.
+              </p>
+            </div>
+            <div className="pitch-fcard">
+              <h3>2 &middot; Each dev opts in</h3>
+              <p>
+                Inside a work repo: <code>ax team join &lt;org&gt;</code>. A consent
+                screen shows exactly what is shared. Personal repos are never
+                joined.
+              </p>
+            </div>
+            <div className="pitch-fcard">
+              <h3>3 &middot; Open the dashboard</h3>
+              <p>
+                Log in with GitHub. It reads the repo with your own token and
+                renders. Aggregation happens in your browser.
+              </p>
+            </div>
           </div>
         </section>
 

--- a/apps/site/app/routes/teams.tsx
+++ b/apps/site/app/routes/teams.tsx
@@ -370,9 +370,12 @@ function Teams() {
 
           <div className="install-wrap">
             <span className="dp-status">
-              <b>Live today:</b> per-seat receipts
-              <span className="dp-status__sep">&middot;</span>
-              <b>With the cohort:</b> the team rollup
+              <span className="dp-status__chip">
+                <b>Live today:</b> per-seat receipts
+              </span>
+              <span className="dp-status__chip">
+                <b>With the cohort:</b> the team rollup
+              </span>
             </span>
             <div className="cta-row">
               <a className="prompt-pill is-solo" href={BOOK_URL}>
@@ -386,7 +389,7 @@ function Teams() {
         </section>
 
         {/* ============= the rollup mock ============= */}
-        <section className="pitch-section dp-alt" id="see-it">
+        <section className="pitch-section" id="see-it">
           <div className="pitch-head">
             <span className="eyebrow">what the team rollup shows</span>
             <h2>
@@ -398,7 +401,16 @@ function Teams() {
             </p>
           </div>
 
-          <RollupMock />
+          <a
+            className="dp-rollup-link"
+            href="/studio/team?demo"
+            aria-label="Open the live team rollup demo"
+          >
+            <RollupMock />
+            <span className="dp-rollup-cta" aria-hidden="true">
+              click to open the live demo &rarr;
+            </span>
+          </a>
 
           <p className="demo-caption">
             Mock of the rollup we are building with founding partners. The live
@@ -564,7 +576,7 @@ function Teams() {
         </section>
 
         {/* ============= sample payload ============= */}
-        <section className="pitch-section" id="payload">
+        <section className="pitch-section dp-alt" id="payload">
           <div className="pitch-head">
             <span className="eyebrow">what actually leaves a laptop</span>
             <h2>
@@ -658,7 +670,7 @@ function Teams() {
         </section>
 
         {/* ============= security FAQ ============= */}
-        <section className="pitch-section dp-alt" id="security">
+        <section className="pitch-section" id="security">
           <div className="pitch-head">
             <span className="eyebrow">security, plainly</span>
             <h2>
@@ -712,7 +724,7 @@ function Teams() {
         </section>
 
         {/* ============= founding cohort (scarcity) ============= */}
-        <section className="pitch-section" id="cohort">
+        <section className="pitch-section dp-alt" id="cohort">
           <div className="pitch-head">
             <span className="eyebrow">the founding cohort</span>
             <h2>

--- a/apps/site/app/routes/teams.tsx
+++ b/apps/site/app/routes/teams.tsx
@@ -442,9 +442,6 @@ function LiveDemoEmbed() {
               loading="lazy"
               tabIndex={-1}
             />
-            <span className="dp-live-tag" aria-hidden="true">
-              live demo &middot; sample data
-            </span>
           </div>
         </div>
       ) : (

--- a/apps/site/app/routes/teams.tsx
+++ b/apps/site/app/routes/teams.tsx
@@ -358,26 +358,21 @@ function Teams() {
         {/* ============= hero ============= */}
         <section className="hero">
           <HeroLogoField />
-          <span className="eyebrow">ax for teams &middot; founding cohort</span>
-          <span className="reg-badge">Founding cohort &middot; 4 of 5 spots open</span>
+          <span className="reg-badge">ax for teams &middot; founding cohort &middot; 4 of 5 spots open</span>
           <h1>
             Know if <em>AI</em> is working<br />
             across your team.
           </h1>
-          <p className="hero-human">
-            Without your data ever leaving your cloud.
-          </p>
           <p className="lede">
-            Rivals make you choose between visibility and warehousing your code
-            in their cloud. ax reads adoption, spend and effectiveness straight
-            from a private git repo you own.
+            Adoption, spend and effectiveness, read straight from a private git
+            repo you own. Your data never touches our cloud.
           </p>
 
           <div className="install-wrap">
             <span className="dp-status">
-              <b>Live today:</b> per-seat receipts + git-native skill mesh
+              <b>Live today:</b> per-seat receipts
               <span className="dp-status__sep">&middot;</span>
-              <b>Building with founding partners:</b> the team rollup
+              <b>With the cohort:</b> the team rollup
             </span>
             <div className="cta-row">
               <a className="prompt-pill is-solo" href={BOOK_URL}>

--- a/apps/site/app/routes/teams.tsx
+++ b/apps/site/app/routes/teams.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
 import { SiteHeader } from "~/components/landing-sections/site-header";
 import { SiteFooter } from "~/components/landing-sections/site-footer";
 import { FooterCards } from "~/components/landing-v2";
@@ -350,6 +351,112 @@ function RollupMock() {
   );
 }
 
+/* ---- live demo embed: lazily swaps the static mock for the real studio ----
+   SSR/prerender renders <RollupMock /> (SEO + no-JS fallback). On the client,
+   once the section approaches the viewport (and we're on a desktop-width
+   screen), it swaps in a non-interactive, scaled iframe of the live demo. The
+   iframe stays pointer-events:none so the wrapping <a> remains the click target
+   and the landing page never scroll-traps. Mobile keeps the static mock. */
+const DEMO_URL = "/studio/team?demo";
+const LIVE_LOGICAL_WIDTH = 1440;
+
+function LiveDemoEmbed() {
+  const embedRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLAnchorElement>(null);
+  const [showIframe, setShowIframe] = useState(false);
+
+  // Mount the iframe lazily when the section nears the viewport (desktop only).
+  useEffect(() => {
+    const isMobile = window.matchMedia?.("(max-width: 719px)").matches ?? false;
+    if (isMobile) return;
+
+    const el = rootRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
+      // No IO support: still upgrade to the live demo on desktop.
+      setShowIframe(true);
+      return;
+    }
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setShowIframe(true);
+          io.disconnect();
+        }
+      },
+      { rootMargin: "400px 0px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  // Keep the desktop-logical iframe scaled to fit the container width.
+  useEffect(() => {
+    if (!showIframe) return;
+    const embed = embedRef.current;
+    if (!embed) return;
+
+    const apply = () => {
+      const w = embed.clientWidth;
+      if (w > 0) {
+        embed.style.setProperty("--dp-scale", String(w / LIVE_LOGICAL_WIDTH));
+      }
+    };
+    apply();
+
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(apply);
+    ro.observe(embed);
+    return () => ro.disconnect();
+  }, [showIframe]);
+
+  return (
+    <a
+      ref={rootRef}
+      className="dp-rollup-link"
+      href={DEMO_URL}
+      target="_blank"
+      rel="noopener"
+      aria-label="Open the ax team rollup live demo in a new tab"
+    >
+      {showIframe ? (
+        <div
+          className="browser browser--instrument dp-rollup dp-rollup--live"
+          role="img"
+          aria-label="ax team rollup live demo, running on sample data"
+        >
+          <div className="browser-bar">
+            <div className="browser-dots">
+              <span></span>
+              <span></span>
+              <span></span>
+            </div>
+            <div className="browser-url">ax studio &middot; live demo</div>
+            <div className="browser-spacer"></div>
+          </div>
+          <div className="dp-embed" ref={embedRef}>
+            <iframe
+              className="dp-embed__frame"
+              src={DEMO_URL}
+              title="ax team rollup live demo"
+              loading="lazy"
+              tabIndex={-1}
+            />
+            <span className="dp-live-tag" aria-hidden="true">
+              live demo &middot; sample data
+            </span>
+          </div>
+        </div>
+      ) : (
+        <RollupMock />
+      )}
+      <span className="dp-rollup-cta" aria-hidden="true">
+        open the live demo &rarr;
+      </span>
+    </a>
+  );
+}
+
 function Teams() {
   return (
     <>
@@ -401,21 +508,13 @@ function Teams() {
             </p>
           </div>
 
-          <a
-            className="dp-rollup-link"
-            href="/studio/team?demo"
-            aria-label="Open the live team rollup demo"
-          >
-            <RollupMock />
-            <span className="dp-rollup-cta" aria-hidden="true">
-              click to open the live demo &rarr;
-            </span>
-          </a>
+          <LiveDemoEmbed />
 
           <p className="demo-caption">
-            Mock of the rollup we are building with founding partners. The live
-            per-seat surface (<code>ax studio</code>) already renders these
-            numbers for one dev today.
+            This is the live <code>ax studio</code> team rollup embedded on
+            sample data &mdash; the same dashboard your cohort gets, not a
+            screenshot. The per-seat surface already renders these numbers for
+            one dev today.
           </p>
 
           <div className="cta-row">

--- a/apps/site/app/styles/pitch.css
+++ b/apps/site/app/styles/pitch.css
@@ -618,6 +618,44 @@
   box-shadow: 0 12px 26px -10px rgba(0, 0, 0, 0.6);
 }
 
+/* live demo iframe embed --------------------------------------------------- */
+/* Renders the studio at a desktop-logical width, scaled to fit via a JS-set
+   --dp-scale, inside a fixed-ratio overflow-hidden frame. The iframe is
+   pointer-events:none so the wrapping link owns clicks (no scroll-trap). */
+.landing-v2 .dp-embed {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1440 / 900;
+  overflow: hidden;
+  background: #0e0e0c;
+}
+.landing-v2 .dp-embed__frame {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1440px;
+  height: 900px;
+  border: 0;
+  transform-origin: top left;
+  transform: scale(var(--dp-scale, 0.5));
+  pointer-events: none;
+}
+.landing-v2 .dp-live-tag {
+  position: absolute;
+  left: 16px;
+  top: 16px;
+  z-index: 2;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  color: var(--green);
+  border: 1px solid color-mix(in srgb, var(--green) 45%, var(--line));
+  border-radius: 4px;
+  padding: 2px 7px;
+  background: rgba(14, 14, 12, 0.6);
+  pointer-events: none;
+}
+
 .landing-v2 .dp-rollup__grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/apps/site/app/styles/pitch.css
+++ b/apps/site/app/styles/pitch.css
@@ -344,21 +344,29 @@
 
 /* honest above-the-fold status line ---------------------------------------- */
 .landing-v2 .dp-status {
-  max-width: 62ch;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   font-family: var(--mono);
-  font-size: 11.5px;
-  line-height: 1.6;
+  font-size: 11px;
   letter-spacing: 0.01em;
   color: var(--muted);
-  text-align: center;
 }
-.landing-v2 .dp-status b {
+.landing-v2 .dp-status__chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  white-space: nowrap;
+  padding: 4px 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+}
+.landing-v2 .dp-status__chip b {
   color: var(--ink);
   font-weight: 600;
-}
-.landing-v2 .dp-status__sep {
-  margin: 0 8px;
-  color: var(--soft);
 }
 
 /* full-bleed alternating section band (breaks the card-grid rhythm) --------- */
@@ -559,6 +567,57 @@
   border-radius: 4px;
   padding: 2px 7px;
 }
+/* the whole mock is the demo affordance ------------------------------------ */
+.landing-v2 .dp-rollup-link {
+  position: relative;
+  display: block;
+  max-width: 920px;
+  margin: 0 auto;
+  border-radius: 12px;
+  text-decoration: none;
+  outline: none;
+  transition:
+    transform 0.16s ease,
+    box-shadow 0.16s ease;
+}
+.landing-v2 .dp-rollup-link:hover {
+  transform: translateY(-3px);
+}
+.landing-v2 .dp-rollup-link:hover .browser,
+.landing-v2 .dp-rollup-link:focus-visible .browser {
+  border-color: color-mix(in srgb, var(--amber) 55%, var(--line));
+}
+.landing-v2 .dp-rollup-link:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 4px;
+}
+.landing-v2 .dp-rollup-cta {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #16150f;
+  background: var(--amber);
+  border-radius: 999px;
+  padding: 6px 13px;
+  box-shadow: 0 8px 22px -10px rgba(0, 0, 0, 0.55);
+  transition:
+    transform 0.16s ease,
+    box-shadow 0.16s ease;
+  pointer-events: none;
+}
+.landing-v2 .dp-rollup-link:hover .dp-rollup-cta {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px -10px rgba(0, 0, 0, 0.6);
+}
+
 .landing-v2 .dp-rollup__grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
Lean pass on the /teams hero after screenshot review:
- **One pill instead of two** ("FOUNDING COHORT" appeared twice side by side): `ax for teams · founding cohort · 4 of 5 spots open`
- **Subline + 3-line lede folded into one 2-line lede** — the zero-data claim was stated 3x before the fold; now once, and section 2 ("The dashboard our servers never see" + diagram) carries the proof
- **Status line compressed** ("Building with founding partners" -> "With the cohort") so it can't wrap mid-phrase

Hero: 6 stacked layers -> 4. Build + prerender + typecheck pass.