### PR TITLE
docs: release announcement pages v0.34.0–v0.36.0

### DIFF
--- a/.plan.md
+++ b/.plan.md
@@ -1,0 +1,7 @@
+## rel-batch-b plan
+
+1. Read the release-page process in `docs/releases/README.md` and the newest existing `docs/releases/v*.md` page for style.
+2. Add a temporary bun:test release-page contract outside the worktree that asserts the five rel-batch-b pages exist and no generated scaffold placeholders remain; run it red before implementation.
+3. For each version `v0.34.0`, `v0.34.1`, `v0.34.2`, `v0.35.0`, and `v0.36.0`: run `bun run release:announcement -- <version>`, read the scaffold evidence and relevant tag log, then rewrite the page into concise release markdown grounded in the evidence.
+4. Run the temporary release-page test green, then run the required gates: `bun run typecheck` and `bun run --cwd apps/site build`.
+5. Inspect the diff, ensure only the planned files changed, commit with a conventional commit message ending in the required co-author trailer, and report SHAs/tests/concerns.

--- a/.plan.md
+++ b/.plan.md
@@ -1,7 +1,0 @@
-## rel-batch-b plan
-
-1. Read the release-page process in `docs/releases/README.md` and the newest existing `docs/releases/v*.md` page for style.
-2. Add a temporary bun:test release-page contract outside the worktree that asserts the five rel-batch-b pages exist and no generated scaffold placeholders remain; run it red before implementation.
-3. For each version `v0.34.0`, `v0.34.1`, `v0.34.2`, `v0.35.0`, and `v0.36.0`: run `bun run release:announcement -- <version>`, read the scaffold evidence and relevant tag log, then rewrite the page into concise release markdown grounded in the evidence.
-4. Run the temporary release-page test green, then run the required gates: `bun run typecheck` and `bun run --cwd apps/site build`.
-5. Inspect the diff, ensure only the planned files changed, commit with a conventional commit message ending in the required co-author trailer, and report SHAs/tests/concerns.

--- a/docs/releases/v0.34.0.md
+++ b/docs/releases/v0.34.0.md
@@ -1,0 +1,72 @@
+---
+version: "0.34.0"
+date: "2026-06-18"
+title: "Make Codex spend visible, make shared artifacts accountable"
+summary: "Codex sessions now feed the same routability and dispatch views as Claude, while shared reports and published profiles gained clearer authorship and attribution."
+---
+
+### How we got here
+
+The v0.33 community and profile work made ax more shareable, but the telemetry
+model still had a Claude-shaped blind spot. Codex sessions could run expensive
+main-thread work and spawn agents, yet the cost and dispatch views could not
+separate that work cleanly from top-level Codex usage. The release range shows a
+focused pass over `apps/axctl/src/queries/routability.ts`, Codex ingest,
+dispatch derivation, and cost analytics to put Codex on the same accounting
+surface.
+
+The same range tightened the public artifacts ax emits. If dojo reports,
+outbox issues, and profile pages are meant to leave the local graph, they need
+consistent attribution and room for the user to add their own context. v0.34.0
+therefore pairs provider accounting with the `Generated with ax` shared helper
+and the first user-authored profile interview flow.
+
+### What changed
+
+**Codex joins the routability lens** ([#552](https://github.com/Necmttn/ax/issues/552)):
+`ax cost routability` now classifies Codex/gpt-5.x sessions separately from
+Claude, folds Codex tool-output cost onto the action that produced it, and
+reprices Codex work within the Codex model family. The key point is that routing
+recommendations no longer pretend Claude and Codex have interchangeable model
+tiers.
+
+```bash
+ax cost routability --days=14
+ax cost split --days=14
+```
+
+**Codex subagents are their own origin** ([#554](https://github.com/Necmttn/ax/issues/554)):
+the Codex parser now marks child-agent work as `codex-subagent`, so cost,
+thinking, workflow, and insight queries can stop mixing subagent spend into
+Codex main-thread totals. A sibling ingest change surfaces Codex `spawn_agent`
+events in `ax dispatches`, so dispatch analytics are not limited to Claude's
+Agent tool shape.
+
+**Shareable outputs use one attribution helper** ([#541](https://github.com/Necmttn/ax/issues/541)):
+`@ax/lib/shared/attribution` became the single place for the ax plug. Dojo
+reports and issue/outbox writers use the helper instead of copying text by
+hand, which keeps public artifacts consistent without adding noise to internal
+agent-only files.
+
+**Profiles can include the user's own highlights** ([#539](https://github.com/Necmttn/ax/issues/539)):
+`ax profile interview` emits an interview brief, `ax profile interview submit`
+validates the resulting JSON, and the profile renderer/site can show setup,
+skill summaries, taste lines, and wins as a distinct "in their words" layer.
+The site also collapsed highlight weapons and skills into click-toggle
+disclosures so dense profiles stay readable.
+
+**The graph got sturdier**: the release fixed a SurrealDB 3.1.2 `ORDER BY`
+idiom parse error, stopped profile reads from scanning the full turn table
+without diagnostics, warned on invalid ISO timestamps instead of silently
+falling back to epoch, excluded synthetic Codex tools from wrapped skill counts,
+restored shared transcript contrast, and raised the installed SurrealDB
+open-file limit to `65536`.
+
+### Why it matters
+
+This is the release where Codex becomes a first-class cost source instead of an
+edge case in Claude-shaped reports. If a run spends money in Codex, spawns Codex
+subagents, or could have been routed down, ax can now show that without smearing
+the numbers across providers. The profile and attribution work closes the loop
+on the other side: when ax output leaves the machine, it carries clearer context
+about who wrote the human layer and which tool produced the artifact.

--- a/docs/releases/v0.34.1.md
+++ b/docs/releases/v0.34.1.md
@@ -1,6 +1,6 @@
 ---
 version: "0.34.1"
-date: "2026-06-18"
+date: "2026-06-19"
 title: "Patch the setup and shared-viewer edges"
 summary: "A small patch release fixed skill installation from arbitrary directories, made skill ingest tolerate null descriptions, and sped up shared transcript pages."
 ---

--- a/docs/releases/v0.34.1.md
+++ b/docs/releases/v0.34.1.md
@@ -1,0 +1,51 @@
+---
+version: "0.34.1"
+date: "2026-06-18"
+title: "Patch the setup and shared-viewer edges"
+summary: "A small patch release fixed skill installation from arbitrary directories, made skill ingest tolerate null descriptions, and sped up shared transcript pages."
+---
+
+### How we got here
+
+v0.34.0 expanded the surfaces that ingest skills, share transcripts, and publish
+profile artifacts. The follow-up range is much narrower: it fixes the places
+where those surfaces met real filesystem and data-shape edge cases. The commit
+list is a patch set, not a new feature wave: setup path handling, nullable skill
+metadata, and the shared transcript viewer.
+
+The practical problem was that polish work only matters if the first install
+and the shared pages survive ordinary user environments. Running the installer
+from a project directory should not confuse `npx skills install`, a missing
+skill description should not poison ingest, and opening a shared transcript
+should not feel heavy.
+
+### What changed
+
+**Skill setup runs from the right directory** ([#562](https://github.com/Necmttn/ax/issues/562)):
+the install path now runs `npx skills install` from `$HOME` instead of the
+caller's current working directory. That keeps global skill installation from
+accidentally inheriting project-local package state.
+
+```bash
+ax install
+```
+
+**Skill ingest tolerates missing descriptions** ([#560](https://github.com/Necmttn/ax/issues/560)):
+skill upsert now omits null descriptions rather than trying to write them into
+the stored skill row. The release added coverage around both the low-level
+upsert path and the skills ingest stage so future skill metadata changes keep
+the same behavior.
+
+**Shared transcript pages got lighter**: the Studio shared-viewer work split
+visible-turn rendering, transcript rendering, and files-touched panels into
+tested pieces, then added a benchmark script for the share viewer. The page
+still renders the same evidence, but the implementation does less work to get
+there and treats shared prose as prose rather than an unstructured blob.
+
+### Why it matters
+
+This patch does not change the main workflow, and that is the point. It removes
+the kind of friction that makes a new local tool feel brittle: install commands
+depending on the caller's directory, ingest falling over on incomplete metadata,
+and shared links feeling slow just when someone else is trying to inspect your
+run.

--- a/docs/releases/v0.34.2.md
+++ b/docs/releases/v0.34.2.md
@@ -1,0 +1,46 @@
+---
+version: "0.34.2"
+date: "2026-06-19"
+title: "Clear SDK hook errors in the compiled binary"
+summary: "The compiled ax binary can now install and run SDK hooks without leaving stale hook errors behind."
+---
+
+### How we got here
+
+The hooks SDK was moving from source-tree development into installed binary
+usage. That exposed a packaging edge: the compiled binary needed the same
+workspace and install behavior as the source checkout, but the error-clearing
+path for SDK hooks was not surviving that environment. The release range is one
+focused fix across `apps/axctl/src/hooks/cli.ts`, `sdk-install.ts`, and
+`sdk-workspace.ts`, backed by a new end-to-end SDK CLI test.
+
+This was not a feature expansion. It was the release that made the previous
+hook work safe for people using the actual distributed binary instead of a
+development checkout.
+
+### What changed
+
+**SDK hook install resolves the compiled workspace** ([#565](https://github.com/Necmttn/ax/issues/565)):
+the workspace helper now understands the compiled binary case and can locate the
+embedded or installed hook assets it needs. The install path gained explicit
+coverage for that mode.
+
+**Hook errors are cleared correctly**: the CLI path now clears SDK hook errors
+when the compiled binary repairs or reinstalls hooks, instead of preserving an
+old error after the underlying problem has been fixed.
+
+**The regression is covered end to end**: `sdk-cli.e2e.test.ts` exercises the
+CLI shape that previously only showed up after compilation, while the
+workspace/install tests cover the lower-level resolution branches.
+
+```bash
+ax hooks status
+ax hooks install --all
+```
+
+### Why it matters
+
+Hooks are trust and workflow infrastructure. If the installed binary reports a
+stale hook error after the repair path has done its job, users cannot tell
+whether the guardrail is broken or the diagnostic is wrong. v0.34.2 keeps that
+status surface honest for binary installs.

--- a/docs/releases/v0.35.0.md
+++ b/docs/releases/v0.35.0.md
@@ -1,6 +1,6 @@
 ---
 version: "0.35.0"
-date: "2026-06-19"
+date: "2026-06-20"
 title: "Measure routing impact, bundle hooks, preview team metrics"
 summary: "Routing now has an off-vs-on receipt, SDK hooks are embedded into compiled ax builds, and Studio gained the first team metrics board."
 ---

--- a/docs/releases/v0.35.0.md
+++ b/docs/releases/v0.35.0.md
@@ -1,0 +1,64 @@
+---
+version: "0.35.0"
+date: "2026-06-19"
+title: "Measure routing impact, bundle hooks, preview team metrics"
+summary: "Routing now has an off-vs-on receipt, SDK hooks are embedded into compiled ax builds, and Studio gained the first team metrics board."
+---
+
+### How we got here
+
+The previous releases made routing advice and hook installation more visible,
+but they still left two operational questions open. First: does routing actually
+help inside a fixed 5h plan window, or does it only look cheaper in token
+equivalent dollars? Second: can a compiled ax binary install its hook SDK
+without depending on source files sitting beside it?
+
+v0.35.0 answers both. The range adds a new `routing-impact` module and command
+family, then changes the build to generate and embed bundled hook assets. In
+parallel, Studio picked up a team metrics board and the installer became more
+graceful around IDE daemon state.
+
+### What changed
+
+**Routing gets an A/B receipt** ([#576](https://github.com/Necmttn/ax/issues/576)):
+`ax routing impact` records paired work blocks with routing off and on,
+snapshots the Claude 5h quota window at each edge, and reports the result. The
+report keeps token-equivalent dollars as context, but the headline is plan-window
+utilization because that is the scarce resource on a fixed plan.
+
+```bash
+ax routing impact begin --arm=off --label=baseline
+# work a comparable block
+ax routing impact end
+
+ax routing impact begin --arm=on --label=routed
+# work the matched block
+ax routing impact end
+
+ax routing impact report
+```
+
+**Compiled builds carry the SDK hooks** ([#574](https://github.com/Necmttn/ax/issues/574)):
+the build now runs `scripts/gen-hooks-embed.ts` and includes a generated hook
+manifest, so `ax hooks` can install the bundled SDK hooks from the compiled
+binary. The hook guard names moved into a shared module, and the workspace tests
+cover both source and compiled layouts.
+
+**Studio gained a team metrics board** ([#567](https://github.com/Necmttn/ax/issues/567)):
+the instrument shell now has a team metrics route and visualization layer,
+including the first `ax-for-teams` paywall shape. This is the early product
+surface for comparing team-level usage and outcomes rather than only local
+single-user runs.
+
+**Install and inspect paths were hardened**: the IDE daemon model became
+doctor-aware and degrades more cleanly during install, while session inspect
+pagination stays anchored to the server window instead of drifting while a user
+pages through a large transcript.
+
+### Why it matters
+
+Routing only earns a place in the workflow if it can prove it preserves scarce
+plan capacity without making the work worse. v0.35.0 gives that experiment a
+local receipt. At the same time, embedding hooks in the binary moves ax closer
+to a tool that can be installed and repaired from one artifact, which matters
+more as the hook layer becomes the front door for routing and guardrails.

--- a/docs/releases/v0.36.0.md
+++ b/docs/releases/v0.36.0.md
@@ -1,0 +1,83 @@
+---
+version: "0.36.0"
+date: "2026-06-29"
+title: "Close the routing loop, expose OTLP health, grow the community graph"
+summary: "v0.36.0 links routing advice to outcomes, adds an OTLP health command, moves hooks toward a dispatcher, and expands the public community/profile surfaces."
+---
+
+### How we got here
+
+By v0.35.0 ax could advise on routing and measure paired work blocks, but the
+feedback loop was still incomplete. Advice fired before a child session existed,
+OTLP telemetry flowed into tables without a direct health command, and hook
+installation was still a collection of individual guards rather than one
+coordinated path. The v0.36.0 range is the consolidation pass: record what the
+advice said, join it back to the dispatch that followed, expose whether telemetry
+is flowing, and make hook installation simpler.
+
+The same release also pushes the community side forward. Profiles gained a
+widget, the site gained pattern and state-report pages, and the graph learned to
+mine repeated directive and workflow shapes from real sessions.
+
+### What changed
+
+**Advice now has an outcome ledger** ([#595](https://github.com/Necmttn/ax/issues/595)):
+the route-dispatch advice tap writes each PreToolUse[Agent] recommendation to
+`~/.ax/hooks/advise-log.jsonl`; ingest loads that ledger into the graph; and
+`ax dispatches --advice` joins advice rows to nearby spawned dispatches. The
+report can now say whether a suggested cheaper model was followed, ignored, or
+unmatched.
+
+```bash
+ax dispatches --advice --days=14
+ax dispatches --economy --days=14
+```
+
+**OTLP got its own read surface** ([#609](https://github.com/Necmttn/ax/issues/609)):
+`ax otel` reports receiver freshness, top-level session coverage, and OTLP cost
+cross-checks. The release also fixed telemetry correlation by matching bare
+UUIDs to `session:<uuid>` records in JS and scanning only recent telemetry, so a
+large `otel_log_event` table no longer turns every ingest into a full historical
+grouping job.
+
+```bash
+ax otel --days=14
+```
+
+**Hooks moved toward one dispatcher** ([#603](https://github.com/Necmttn/ax/issues/603),
+[#605](https://github.com/Necmttn/ax/issues/605), [#606](https://github.com/Necmttn/ax/issues/606),
+[#607](https://github.com/Necmttn/ax/issues/607), [#612](https://github.com/Necmttn/ax/issues/612),
+[#613](https://github.com/Necmttn/ax/issues/613)):
+`ax hooks install --all` became the one-shot install path, the hooks SDK gained
+a dispatcher that multiplexes guard verdicts in one process, and the daemon
+path added a `/hooks/eval` fast path plus opt-in daemon install mode. The site
+copy was corrected to describe route-dispatch as advice rather than automatic
+routing.
+
+**Directive and workflow mining became inspectable** ([#592](https://github.com/Necmttn/ax/issues/592),
+[#598](https://github.com/Necmttn/ax/issues/598)):
+the graph now derives n-gram lift for directive candidates and mines recurring
+skill-arc workflows. `ax directives mine`, `ax directives ngrams`, and
+`ax directives workflows` turn those derived rows into reviewable tables and
+agent briefs instead of leaving them as hidden ingest artifacts.
+
+**Community surfaces expanded**: community pattern contributions landed, the
+nightly compiler produces pattern stats, `/patterns` lets visitors browse those
+patterns, `/state/<year>` renders a compiled state report, team radar compare
+arrived, and `ax profile widget` can write a marker-delimited block into a
+GitHub profile README.
+
+**The core graph got less fragile**: ingest now sweeps stranded `ingest_run`
+rows, reapplies additive schema self-heal before ingest, clears derived
+friction/diagnostic rows on full re-derive, bounds session churn scans to
+failure candidates, exposes `sessions_churn` through MCP, shows full context
+startup budget, and derives OpenCode compactions.
+
+### Why it matters
+
+v0.36.0 turns several "trust me" systems into inspectable systems. Routing
+advice can be checked against what actually ran. OTLP can be checked for
+freshness and coverage. Hook installation has a single path instead of a pile
+of separate guard commands. And the community/profile additions make the local
+graph useful outside one machine without losing the evidence trail that made ax
+useful in the first place.


### PR DESCRIPTION
Adds the 5 missing changelog pages: v0.34.0, v0.34.1, v0.34.2, v0.35.0, v0.36.0 (pre-push hook has been warning on these).

Reviewed for factual grounding against tag ranges — every headline claim traces to a real commit/issue; frontmatter matches the releaseAnnouncements schema in apps/site/content-collections.ts; dates corrected to tag dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)