### PR TITLE
fix(cost): self-documenting headers + legend for `ax cost sessions`

### DIFF
--- a/apps/axctl/src/cli/commands/ax-cost.test.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { renderCostModelsTable } from "./ax-cost.ts";
-import type { CostModelsResult } from "../../queries/cost-analytics.ts";
+import {
+    COST_SESSIONS_LEGEND,
+    renderCostModelsTable,
+    renderCostSessionsTable,
+} from "./ax-cost.ts";
+import type {
+    CostModelsResult,
+    CostSessionsResult,
+} from "../../queries/cost-analytics.ts";
 
 describe("renderCostModelsTable", () => {
     test("does not clip large token counts or large costs", () => {
@@ -26,5 +33,44 @@ describe("renderCostModelsTable", () => {
         expect(out).toContain("$10999.3970");
         expect(out).not.toContain("14,781,735,4 ");
         expect(out).not.toContain("$10999.397\n");
+    });
+});
+
+describe("renderCostSessionsTable", () => {
+    const result: CostSessionsResult = {
+        rows: [
+            {
+                session_id: "session:`18338926-1b38-4fa2-999b-08aab8f03d64`",
+                project: "-Users-frankjames--super",
+                model: "claude-fable-5",
+                started_at: "2026-07-06T15:25:28",
+                cost_usd: 114.9523,
+                completion_tokens: 823_193,
+                cache_read_tokens: 33_915_145,
+            },
+        ],
+    };
+
+    test("labels token columns as out_tok / cache_tok and strips the session id wrapping", () => {
+        const out = renderCostSessionsTable(result);
+        const [header] = out.split("\n");
+
+        // Self-documenting headers: the two token columns are no longer the
+        // ambiguous "completion" / "cache_read".
+        expect(header).toContain("out_tok");
+        expect(header).toContain("cache_tok");
+        // session: prefix + backtick wrapping stripped to a bare uuid.
+        expect(out).toContain("18338926-1b38-4fa2-999b-08aab8f03d64");
+        expect(out).not.toContain("session:`");
+        // Money + token cells render intact (no clipping).
+        expect(out).toContain("$114.9523");
+        expect(out).toContain("823,193");
+        expect(out).toContain("33,915,145");
+    });
+
+    test("legend spells out every money/token column", () => {
+        expect(COST_SESSIONS_LEGEND).toContain("cost = est. USD");
+        expect(COST_SESSIONS_LEGEND).toContain("out_tok = output");
+        expect(COST_SESSIONS_LEGEND).toContain("cache_tok = cache-hit");
     });
 });

--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -14,6 +14,7 @@ import {
     fetchCostSessions,
     fetchCostSplit,
     type CostModelsResult,
+    type CostSessionsResult,
 } from "../../queries/cost-analytics.ts";
 import { fetchRoutability, type RoutabilityResult } from "../../queries/routability.ts";
 import { fetchImageContext } from "../../queries/image-context.ts";
@@ -110,6 +111,47 @@ const costModelsCommand = Command.make(
 // ax cost sessions [--days=N] [--model=<name>] [--limit=N] [--json]
 // ---------------------------------------------------------------------------
 
+// Legend spelling out the money/token columns so the numbers are never
+// ambiguous when the wide table wraps (or when a row is copy-pasted without
+// the header). Survives wrap because it is its own line.
+export const COST_SESSIONS_LEGEND =
+    "cols: cost = est. USD · out_tok = output (completion) tokens · cache_tok = cache-hit (read input) tokens";
+
+export function renderCostSessionsTable(result: CostSessionsResult): string {
+    type SessionRow = {
+        session: string;
+        project: string;
+        model: string;
+        started: string;
+        cost: string;
+        out_tok: string;
+        cache_tok: string;
+    };
+
+    const rendered: SessionRow[] = result.rows.map((r) => ({
+        // Strip "session:" prefix and optional SurrealDB backtick wrapping (`uuid`)
+        session: r.session_id.replace(/^session:/, "").replace(/^`(.*)`$/, "$1"),
+        project: r.project ?? "",
+        model: r.model ?? "?",
+        started: r.started_at ?? "",
+        cost: usd(r.cost_usd),
+        out_tok: integer(r.completion_tokens),
+        cache_tok: integer(r.cache_read_tokens),
+    }));
+
+    const cols: Column<SessionRow>[] = [
+        { header: "session", get: (r) => r.session, width: 36 },
+        { header: "project", get: (r) => r.project, width: 24, overflow: "clip" },
+        { header: "model", get: (r) => r.model, width: 28, overflow: "clip" },
+        { header: "started", get: (r) => r.started, width: 19, overflow: "clip" },
+        { header: "cost", get: (r) => r.cost, align: "right", width: 10 },
+        { header: "out_tok", get: (r) => r.out_tok, align: "right", width: 12 },
+        { header: "cache_tok", get: (r) => r.cache_tok, align: "right", width: 14 },
+    ];
+
+    return renderTable({ columns: cols, rows: rendered, gap: " " });
+}
+
 const cmdCostSessions = (input: {
     readonly sinceDays: number;
     readonly limit: number;
@@ -133,38 +175,8 @@ const cmdCostSessions = (input: {
             return;
         }
 
-        type SessionRow = {
-            session: string;
-            project: string;
-            model: string;
-            started: string;
-            cost: string;
-            completion: string;
-            cache_read: string;
-        };
-
-        const rendered: SessionRow[] = result.rows.map((r) => ({
-            // Strip "session:" prefix and optional SurrealDB backtick wrapping (`uuid`)
-            session: r.session_id.replace(/^session:/, "").replace(/^`(.*)`$/, "$1"),
-            project: r.project ?? "",
-            model: r.model ?? "?",
-            started: r.started_at ?? "",
-            cost: usd(r.cost_usd),
-            completion: integer(r.completion_tokens),
-            cache_read: integer(r.cache_read_tokens),
-        }));
-
-        const cols: Column<SessionRow>[] = [
-            { header: "session", get: (r) => r.session, width: 36 },
-            { header: "project", get: (r) => r.project, width: 24, overflow: "clip" },
-            { header: "model", get: (r) => r.model, width: 28, overflow: "clip" },
-            { header: "started", get: (r) => r.started, width: 19, overflow: "clip" },
-            { header: "cost", get: (r) => r.cost, align: "right", width: 10 },
-            { header: "completion", get: (r) => r.completion, align: "right", width: 12 },
-            { header: "cache_read", get: (r) => r.cache_read, align: "right", width: 12 },
-        ];
-
-        console.log(renderTable({ columns: cols, rows: rendered, gap: " " }));
+        console.log(renderCostSessionsTable(result));
+        console.log(`\n${COST_SESSIONS_LEGEND}`);
     });
 
 const costSessionsCommand = Command.make(
@@ -188,7 +200,7 @@ const costSessionsCommand = Command.make(
     },
 ).pipe(
     Command.withDescription(
-        "Top sessions by estimated cost: id, project, model, started_at, cost, completion tokens, cache-read tokens. " +
+        "Top sessions by estimated cost: session, project, model, started, cost (USD), out_tok (output tokens), cache_tok (cache-hit tokens). " +
         "--days=N (default 14)  --model=<name>  --limit=N (default 20)  --json",
     ),
 );


### PR DESCRIPTION
## Why

A user shared a pasted `ax cost sessions` sample and asked *what are the two numbers after `$cost`?* — nobody could tell. The columns were headed `completion` / `cache_read` (API jargon), and the table is wide enough that in chat / narrow terminals every row wraps and the header scrolls off, leaving a bare `$114.9523  823,193  33,915,145` with no labels.

## What

- Headers renamed to self-documenting `out_tok` (output/completion tokens) and `cache_tok` (cache-hit / read-input tokens).
- A legend line prints under the table — survives wrap because it's its own line:
  `cols: cost = est. USD · out_tok = output (completion) tokens · cache_tok = cache-hit (read input) tokens`
- Inline render extracted to a pure, exported `renderCostSessionsTable` + unit tests (headers, session-id unwrap, no-clip) and a legend test.

## Verify

`bun test apps/axctl/src/cli/commands/ax-cost.test.ts` → 3 pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)