### PR TITLE
fix(ingest): detect SurrealDB DateTime by toISOString(), not class name (#670)

### DIFF
--- a/packages/lib/src/shared/surreal.test.ts
+++ b/packages/lib/src/shared/surreal.test.ts
@@ -622,13 +622,29 @@ describe("isoTimestamp", () => {
         expect(isoTimestamp("2024-03-01T00:00:00.000Z")).toBe("2024-03-01T00:00:00.000Z");
     });
 
-    it("handles SurrealDB DateTime objects via constructor name check", () => {
-        const fakeDateTime = {
-            constructor: { name: "DateTime" },
-            toString() { return "2024-06-01T12:00:00.000Z"; },
-        };
-        // Cast to satisfy TS - at runtime this is an object with the right constructor name
-        expect(isoTimestamp(fakeDateTime as unknown as Date)).toBe("2024-06-01T12:00:00.000Z");
+    it("handles a SurrealDB DateTime via its toISOString() method", () => {
+        class DateTime {
+            toISOString() { return "2024-06-01T12:00:00.000Z"; }
+        }
+        expect(isoTimestamp(new DateTime() as unknown as Date)).toBe("2024-06-01T12:00:00.000Z");
+    });
+
+    // #670 regression: `bun build --compile` renames the bundled SDK class
+    // (observed as `DateTime3`), so a `constructor.name === "DateTime"` check
+    // silently fell through to epoch (1970) ONLY in the compiled binary.
+    // Duck-typing on toISOString() is rename-proof.
+    it("handles a DateTime whose class was renamed by the bundler (DateTime3)", () => {
+        class DateTime3 {
+            toISOString() { return "2026-07-08T01:49:50.000Z"; }
+        }
+        const renamed = new DateTime3();
+        expect(renamed.constructor.name).toBe("DateTime3"); // guard the premise
+        expect(isoTimestamp(renamed as unknown as Date)).toBe("2026-07-08T01:49:50.000Z");
+    });
+
+    it("falls through to epoch for an object with no toISOString()", () => {
+        const notADate = { constructor: { name: "DateTime" }, toString() { return "nope"; } };
+        expect(isoTimestamp(notADate as unknown as Date)).toBe(new Date(0).toISOString());
     });
 
     it("returns epoch ISO for null", () => {
@@ -675,8 +691,7 @@ describe("isoTimestamp - warn on epoch fallback", () => {
     it("does NOT warn for a SurrealDB DateTime-like object", () => {
         withWarnSpy((calls) => {
             const fakeDateTime = {
-                constructor: { name: "DateTime" },
-                toString() { return "2024-06-01T12:00:00.000Z"; },
+                toISOString() { return "2024-06-01T12:00:00.000Z"; },
             };
             isoTimestamp(fakeDateTime as unknown as Date);
             expect(calls.length).toBe(0);

--- a/packages/lib/src/shared/surreal.ts
+++ b/packages/lib/src/shared/surreal.ts
@@ -524,13 +524,13 @@ export const executeStatements = (
  * The union of input types accepted by `isoTimestamp`.
  * - `Date`            - JS Date object
  * - `string`          - already-formatted ISO string, passed through as-is
- * - SurrealDB DateTime - detected by `constructor.name === "DateTime"`,
- *                        coerced via `String(value)`
+ * - SurrealDB DateTime - any object exposing `toISOString()`; detected
+ *                        structurally (see `isoTimestamp` for why not by name)
  */
 export type TimestampInput =
     | Date
     | string
-    | { readonly constructor: { readonly name: string }; toString(): string };
+    | { toISOString(): string };
 
 /**
  * Sanitize an arbitrary string into a safe SurrealDB record-key segment.
@@ -587,7 +587,12 @@ export const recordKeyPart = (value: unknown, expectedTable?: string): string | 
  * Branch order:
  * 1. `value instanceof Date`  → `value.toISOString()`
  * 2. Non-empty string         → pass through unchanged
- * 3. SurrealDB DateTime object (`constructor.name === "DateTime"`) → `String(value)`
+ * 3. Any object exposing a `toISOString()` method (the SurrealDB DateTime) →
+ *    `value.toISOString()`. We duck-type on the method rather than checking
+ *    `constructor.name === "DateTime"`, because `bun build --compile` renames
+ *    the bundled SDK class (observed as `DateTime3`), so an exact-name check
+ *    silently falls through to epoch ONLY in the compiled binary - the #670
+ *    "1970-01-01" friction-view timestamps that source builds never showed.
  * 4. Anything else (null / undefined / unknown) → epoch `new Date(0).toISOString()`
  *    and emits a `console.warn` so silent epoch timestamps surface as data bugs
  *    (symptom: `ax insights friction` events timestamped `1970-01-01 00:00:00`)
@@ -595,7 +600,13 @@ export const recordKeyPart = (value: unknown, expectedTable?: string): string | 
 export const isoTimestamp = (value: TimestampInput | null | undefined): string => {
     if (value instanceof Date) return value.toISOString();
     if (typeof value === "string" && value.length > 0) return value;
-    if (value && typeof value === "object" && value.constructor.name === "DateTime") return String(value);
+    if (
+        value &&
+        typeof value === "object" &&
+        typeof (value as { toISOString?: unknown }).toISOString === "function"
+    ) {
+        return (value as { toISOString(): string }).toISOString();
+    }
     const typeDesc = (() => {
         try {
             if (value === null) return "null";


### PR DESCRIPTION
Fixes #670.

## Root cause

`isoTimestamp()` (`packages/lib/src/shared/surreal.ts`) detected the SurrealDB `DateTime` by `value.constructor.name === "DateTime"`. `bun build --compile` **renames the bundled surrealdb SDK class** — at runtime in the compiled binary it's `DateTime3` — so the exact-name check fails and every DateTime falls through to the epoch branch:

```
[ax] isoTimestamp: unrecognized timestamp value, defaulting to epoch: object(DateTime3)
```

Downstream: `ax insights friction` rows timestamped `1970-01-01 00:00:00`, while `ax insights tools` (built off `Date` objects) shows real 2026 times — the internal inconsistency the reporter saw. **Distro-only**: source builds keep the class name, so this never reproduced from `bin/axctl`. Confirmed live on my own v0.37.0 distro ingest (same `object(DateTime3)` warning).

## Fix

Duck-type on `toISOString()` instead of the class name. The SDK's DateTime exposes a real `toISOString()` (proper ISO 8601 incl. nanoseconds), so the detection is rename-proof and returns the exact value rather than a `String()` coercion.

## Tests

- Renamed-class regression: a `DateTime3` class (asserts `constructor.name === "DateTime3"`) still normalizes via `toISOString()`.
- An object with no `toISOString()` still epoch-falls-through (+ warns).
- Existing DateTime/warn tests updated to the method-based contract. `bun test packages/lib/src/shared/surreal.test.ts` → 127 pass; `@ax/lib` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)