### PR TITLE
fix(run-evidence): NONE-safe tool_call + selected ORDER BY idiom (unblocks ingest on SurrealDB 3.2.0)

### DIFF
--- a/apps/axctl/src/ingest/derive-run-evidence.test.ts
+++ b/apps/axctl/src/ingest/derive-run-evidence.test.ts
@@ -3,12 +3,31 @@ import {
     buildLineage,
     buildRunEvidenceEvents,
     buildRunEvidenceRefs,
+    commandOutcomeSql,
     pickEarliestPerSession,
+    policyDecisionSql,
     RUN_EVIDENCE_DERIVED_KINDS,
     runEvidenceStage,
     type RunEvidenceSourceRows,
 } from "./derive-run-evidence.ts";
 import { runEvidenceEventRecordKey } from "@ax/lib/shared/run-evidence";
+
+// Regression for the crash reproduced on SurrealDB 3.2.0 (and any DB with
+// session-level hooks / hook-less outcomes): `record::id(tool_call)` throws
+// "Expected `record` but found `NONE`" when tool_call is NONE. Both SQLs that
+// project tool_call MUST guard the NONE case instead of calling record::id raw.
+describe("run-evidence SQL is NONE-safe on nullable tool_call", () => {
+    for (const [name, sql] of [
+        ["commandOutcomeSql", commandOutcomeSql(undefined)],
+        ["policyDecisionSql", policyDecisionSql(undefined)],
+    ] as const) {
+        test(`${name} guards record::id(tool_call) against NONE`, () => {
+            // The crashing form was a bare projection `record::id(tool_call) AS toolCall`.
+            expect(sql).not.toContain("record::id(tool_call) AS toolCall");
+            expect(sql).toContain("IF tool_call != NONE THEN record::id(tool_call) ELSE NONE END");
+        });
+    }
+});
 
 const sessionProvider = new Map<string, string>([
     ["sess-claude", "claude"],

--- a/apps/axctl/src/ingest/derive-run-evidence.ts
+++ b/apps/axctl/src/ingest/derive-run-evidence.ts
@@ -517,8 +517,8 @@ const toolCallSql = (since: number | undefined): string =>
             name, has_error AS hasError, command_norm AS commandNorm
      FROM tool_call WHERE session != NONE ${sinceAndClause(since)};`;
 
-const commandOutcomeSql = (since: number | undefined): string =>
-    `SELECT record::id(id) AS id, record::id(session) AS session, record::id(tool_call) AS toolCall,
+export const commandOutcomeSql = (since: number | undefined): string =>
+    `SELECT record::id(id) AS id, record::id(session) AS session, (IF tool_call != NONE THEN record::id(tool_call) ELSE NONE END) AS toolCall,
             type::string(ts) AS ts, kind, status, command_norm AS commandNorm
      FROM command_outcome WHERE session != NONE ${sinceAndClause(since)};`;
 
@@ -560,8 +560,8 @@ const objectiveSql = (since: number | undefined): string =>
      FROM turn WHERE session != NONE AND role = "user" AND message_kind = "task" ${sinceAndClause(since)};`;
 
 // Policy decisions: hook invocations whose effect is a real intervention.
-const policyDecisionSql = (since: number | undefined): string =>
-    `SELECT record::id(id) AS id, record::id(session) AS session, record::id(tool_call) AS toolCall,
+export const policyDecisionSql = (since: number | undefined): string =>
+    `SELECT record::id(id) AS id, record::id(session) AS session, (IF tool_call != NONE THEN record::id(tool_call) ELSE NONE END) AS toolCall,
             type::string(ts) AS ts, hook_name AS hookName, effect, provider_status AS providerStatus
      FROM hook_command_invocation
      WHERE session != NONE AND effect IN ["blocked", "injected_context", "modified_input", "notified"] ${sinceAndClause(since)};`;

--- a/apps/axctl/src/queries/run-evidence.ts
+++ b/apps/axctl/src/queries/run-evidence.ts
@@ -124,7 +124,10 @@ export const fetchRunEvidence = (input: RunEvidenceInput): Effect.Effect<
         );
         // Headline kinds: the run's objective + repo identity (latest of each).
         const [heads] = yield* db.query<[Array<{ kind?: string | null; summary?: string | null }>]>(
-            `SELECT kind, summary FROM run_evidence_event
+            // `ts` must appear in the projection: SurrealDB rejects ORDER BY on an
+            // idiom that isn't selected ("Missing order idiom `ts`"). Harmless extra
+            // column - the consumer below reads only kind + summary.
+            `SELECT kind, summary, ts FROM run_evidence_event
              WHERE session = ${sessionRef} AND kind IN ["objective", "repo_state"] ORDER BY ts DESC;`,
         );
         const headOf = (kind: string): string | null =>


### PR DESCRIPTION
Deep-dive root cause of #671; also fixes finding #4 of #675.

## What #671 actually is

I reproduced the reporter's setup on **SurrealDB 3.2.0** (fresh DB, schema applied, small dataset). The ingest **does not hang or loop** — the pipeline is a single-pass DAG (deps are awaited *before* taking a semaphore permit, so no deadlock). It runs **every** stage and then **crashes** on the `run-evidence` derive stage:

```
ingest: FAILED - Incorrect arguments for function record::id().
Argument 1 was the wrong type. Expected `record` but found `NONE`
```

`command_outcome` and `hook_command_invocation` legitimately have `tool_call = NONE` (session-level hooks — UserPromptSubmit/Stop/… — and hook-less outcomes; **3,812** such rows in the repro). `record::id(NONE)` throws, which aborts the entire ingest. Before #673's heartbeat there was no per-stage signal, so a killed/aborting run reads as "never exits" — a strong match for the report.

## Fixes

1. **NONE-safe `tool_call`** in both projecting SQLs (`commandOutcomeSql`, `policyDecisionSql`):
   `IF tool_call != NONE THEN record::id(tool_call) ELSE NONE END`. The JS side already treats `toolCall` as nullable (`row.toolCall ?? null`).
2. **Selected ORDER BY idiom** — a latent second bug found while verifying the read surface: `ax runs evidence` did `SELECT kind, summary … ORDER BY ts`, and SurrealDB rejects ordering by an unselected idiom (`Missing order idiom \`ts\``). Masked on dev boxes where the run_evidence tables never existed. Now selects `ts`.

## Verified live on SurrealDB 3.2.0

- `run-evidence` derive stage now **completes**: `written=55,631 refsWritten=18,882` (previously crashed at 0).
- `ax runs evidence <id>` renders the timeline correctly.
- Regression test asserts both `tool_call` SQLs are NONE-guarded (builders exported). `bun test` on both run-evidence test files → 36 pass; typecheck clean.

## Relationship to #671 / #673

#673 (merged, v0.37.1) makes a genuinely slow/stuck stage visible + non-fatal (heartbeat + watchdog). **This** PR removes the concrete crash that actually aborted ingest in the derive stages. Together they should resolve #671; I've left #671 open pending the reporter confirming on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)