### PR TITLE
fix(dashboard): route session evidence through contract handler (#679)

### DIFF
--- a/apps/axctl/src/dashboard/contract/sessions.test.ts
+++ b/apps/axctl/src/dashboard/contract/sessions.test.ts
@@ -48,6 +48,7 @@ describe("isContractRequest - sessions routing", () => {
     test("single-segment session param paths route to the contract", () => {
         expect(isContractRequest("GET", "/api/sessions/abc")).toBe(true);
         expect(isContractRequest("GET", "/api/sessions/abc/inspect")).toBe(true);
+        expect(isContractRequest("GET", "/api/sessions/abc/evidence")).toBe(true);
         expect(isContractRequest("GET", "/api/sessions/abc/children")).toBe(true);
         expect(isContractRequest("GET", "/api/sessions/abc/insights")).toBe(true);
         expect(isContractRequest("GET", "/api/sessions/abc/timeline")).toBe(true);

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -105,7 +105,7 @@ const CONTRACT_PATTERNS: ReadonlyArray<{ readonly method: string; readonly patte
     // That is intentional: both route into the contract and FindMyWay gives
     // static paths precedence over :param paths, so compare wins correctly.
     { method: "GET", pattern: /^\/api\/sessions\/[^/]+$/ },
-    { method: "GET", pattern: /^\/api\/sessions\/[^/]+\/(children|insights|inspect|timeline)$/ },
+    { method: "GET", pattern: /^\/api\/sessions\/[^/]+\/(children|evidence|insights|inspect|timeline)$/ },
     { method: "GET", pattern: /^\/api\/skills\/[^/]+\/(detail|source)$/ },
     { method: "POST", pattern: /^\/api\/skills\/[^/]+\/(decide|open)$/ },
     { method: "DELETE", pattern: /^\/api\/skills\/[^/]+\/decide$/ },

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -451,11 +451,20 @@ export const api = {
                 },
             }),
         ),
-    sessionEvidence: (sessionId: string): Promise<RunEvidencePayload> =>
-        viaContractUnknown(
+    sessionEvidence: async (sessionId: string): Promise<RunEvidencePayload> => {
+        const payload = await viaContractUnknown<RunEvidencePayload>(
             `/api/sessions/${encodeURIComponent(sessionId)}/evidence`,
             (c) => c.sessions.sessionEvidence({ params: { id: sessionId } }),
-        ),
+        );
+        // Daemons older than the /evidence route answer via the legacy
+        // /api/sessions/:id+ catch-all with a 200 + session-detail shape.
+        // Reject it here so callers hit their query error path instead of
+        // crashing on `payload.by_backing`.
+        if (!Array.isArray((payload as { by_backing?: unknown }).by_backing)) {
+            throw new ApiError("daemon too old for run evidence - update axctl", 404);
+        }
+        return payload;
+    },
     sessionTimeline: (sessionId: string): Promise<SessionTimelinePayload> =>
         viaContractUnknown(
             `/api/sessions/${encodeURIComponent(sessionId)}/timeline`,

--- a/apps/studio/src/routes/run-evidence-panel.test.tsx
+++ b/apps/studio/src/routes/run-evidence-panel.test.tsx
@@ -53,3 +53,9 @@ test("renders nothing when the session has no run-evidence events", () => {
     const html = render("s2", payload({ total: 0 }));
     expect(html).toBe("");
 });
+
+test("renders nothing when backing breakdown is missing", () => {
+    const malformed = { ...payload({ total: 5 }), by_backing: 3 as unknown as never[] };
+    const html = render("s3", malformed as RunEvidencePayload);
+    expect(html).toBe("");
+});

--- a/apps/studio/src/routes/session-inspect.tsx
+++ b/apps/studio/src/routes/session-inspect.tsx
@@ -1694,7 +1694,7 @@ export function RunEvidencePanel({ sessionId }: { readonly sessionId: string }) 
         queryFn: () => api.sessionEvidence(sessionId),
     });
     const ev: RunEvidencePayload | undefined = q.data;
-    if (!ev || ev.total === 0) return null;
+    if (!ev || !Array.isArray(ev.by_backing) || ev.total === 0) return null;
     const claim = ev.by_backing.find((b) => b.key === "model_claim")?.count ?? 0;
     return (
         <div


### PR DESCRIPTION
Fixes #679.

## Root cause
`/api/sessions/:id/evidence` was missing from the contract-route alternation in `web-handler.ts`, so requests fell through to the legacy `/api/*` catch-all which answers `200 {"error":"not_found"}`. The studio session page then crashed on `ev.by_backing.find(...)` since its guard (`!ev || ev.total === 0`) doesn't catch that shape.

## Fix
- Add `evidence` to the contract pattern so the request reaches the already-correct contract handler (`fetchRunEvidence` always returns a well-formed payload, `total: 0` when a session has no evidence).
- Defense-in-depth for daemons older than the route: `api.sessionEvidence` throws `ApiError(404)` when `by_backing` is not an array (mirrors the `sessionInsights` old-daemon guard), and the panel guard also checks `Array.isArray(ev.by_backing)`.
- The generic `/api/*` 200 quirk in `server.ts` is intentionally untouched (asserted in `server.test.ts`).

## Tests
- `isContractRequest("GET", "/api/sessions/abc/evidence")` regression test.
- Run-evidence panel renders nothing on malformed `by_backing`.
- `bun run typecheck` exit 0; targeted suites 14/14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)