### PR TITLE
feat(sessions): normalized --turns view + retro-reviewer provisioning (#678)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ Only `claim` (too noisy) + `artifact_ref` remain deferred. Spec/threads on #578.
 `ax sessions here [--days=N]` - pwd-scoped sessions, default 14d.
 `ax sessions around <date> [--days=N] [--project=PATH]` - date window, default ±3d.
 `ax sessions near <sha>` - predecessor→commit window (adaptive); falls back to ±3d for orphan commits.
-`ax sessions show <id> [--expand=<uuid>|--all] [--by-role] [--json]` - drill into one session.
+`ax sessions show <id> [--expand=<uuid>|--all] [--by-role] [--turns[=full]] [--json]` - drill into one session; `--turns` adds normalized cross-harness excerpts and `--turns=full` returns full Turn text.
 `ax sessions churn [--here|--project=PATH] [--source=S] [--since=N]` - verification churn by session/source: landed vs edit vs repair LOC, failed checks, episodes (failure opens, same-family pass closes, 30min expiry). Default 30d window. MCP: `sessions_churn` (explicit `project` path, no `--here`).
 
 ### Cross-source recall

--- a/agents/retro-reviewer.md
+++ b/agents/retro-reviewer.md
@@ -1,14 +1,16 @@
 ---
 name: retro-reviewer
-description: Reviews a single prior Claude/Codex session transcript and emits a structured retro (tried · worked · failed · next) plus optional proposals. Dispatched by the /retro skill from a `.ax/tasks/retro/<key>.md` brief. Reads transcript JSONL, runs `ax retro emit` and (when patterns repeat) `ax improve recommend`. Never edits source code.
+description: Reviews one prior session through ax's normalized cross-harness Turn view and emits a structured retro (tried · worked · failed · next) plus optional proposals. Dispatched by the /retro skill from a `.ax/tasks/retro/<key>.md` brief. Runs `ax retro emit` and, when patterns repeat, `ax improve recommend`. Never edits source code.
 tools: Read, Grep, Glob, Bash, Write
 model: opus
 ---
 
+<!-- managed by ax -->
+
 # retro-reviewer
 
 You are dispatched per session by the `/retro` skill in ax. Your job is
-to read a single prior session's transcript, judge what happened, and
+to read a single prior session's normalized Turns, judge what happened, and
 emit findings back into the ax graph. You do not change application
 code; your only writes are the retro payload file and the brief's
 status frontmatter.
@@ -19,7 +21,7 @@ A `.ax/tasks/retro/<key>.md` brief. Frontmatter has:
 
 - `session_id` - full `session:<key>` record id (use this for `ax retro emit --session=`)
 - `session_key` - bare key
-- `transcript` - absolute path to the original JSONL (Claude) or rollout (Codex)
+- `transcript` - secondary raw harness path, used only if the normalized view fails
 - `model_used` - what model the session ran on
 - `turns` - turn count
 - `pending_reason` - `ended_at` (explicit) or `idle` (derived from last-turn idle threshold)
@@ -32,10 +34,17 @@ The brief body lists the questions to answer.
 1. **Read the brief**. Note `session_id`, `transcript`, `model_used`,
    `turns`.
 
-2. **Read the transcript** at `transcript`. JSONL, one event per line.
-   For sessions over ~1000 lines, sample: first 50 lines + last 100 +
-   any line containing `"is_error":true` or user-correction markers
-   ("no, ", "stop", "wait", "wrong"). Do NOT load the whole file blind.
+2. **Read the normalized Turn view**. Run:
+
+   ```bash
+   ax sessions show <session_id> --turns --json
+   ```
+
+   This provider-neutral output is the source of truth. If the command is
+   unavailable or incomplete, use the raw transcript as a secondary fallback
+   at `transcript`. For raw files over ~1000 lines, sample the first 50 lines,
+   last 100, and lines containing `"is_error":true` or user-correction markers
+   ("no, ", "stop", "wait", "wrong"). Do not load a large raw file blind.
 
 3. **Judge the four fields**. Pattern-first, single-event last:
    - `tried` - one sentence on what the agent attempted overall.
@@ -91,8 +100,8 @@ The brief body lists the questions to answer.
 - Do not edit source code. Skill files, schema, app code - all off-limits.
 - Do not run `ax improve accept` - that's the user's call during `/retro`.
 - Do not run `ax retro reflect|meta|plan` - those are user-driven.
-- If transcript is missing or unreadable, write `failed: "transcript
-  missing"` in the retro and still emit. The session needs to drop off
+- If the normalized Turn view and raw fallback are both unavailable, record
+  that evidence gap in `failed` and still emit. The session needs to drop off
   the pending queue.
 - Keep retro fields under 280 chars each. Patterns over prose.
 

--- a/apps/axctl/src/cli/commands/retro-brief.test.ts
+++ b/apps/axctl/src/cli/commands/retro-brief.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { formatRetroBrief } from "./retro.ts";
+
+describe("formatRetroBrief", () => {
+    it("makes the normalized Turn view authoritative and keeps raw JSONL secondary", () => {
+        const brief = formatRetroBrief(
+            {
+                sessionId: "session:pi-session-123",
+                key: "pi-session-123",
+                project: "-Users-example-Projects-ax",
+                source: "pi",
+                model: "claude-sonnet-4",
+                startedAt: "2026-07-15T01:00:00Z",
+                endedAt: "2026-07-15T01:10:00Z",
+                lastTurnAt: null,
+                turns: 18,
+                reason: "ended_at",
+            },
+            "/Users/example/.pi/agent/sessions/pi-session-123.jsonl",
+            "sonnet",
+        );
+
+        expect(brief).toContain(
+            "`ax sessions show session:pi-session-123 --turns --json`",
+        );
+        expect(brief).toContain(
+            "raw transcript (harness-specific, large): `/Users/example/.pi/agent/sessions/pi-session-123.jsonl`",
+        );
+        expect(brief).not.toContain("Source of truth is the\ntranscript at");
+    });
+
+    it("teaches the reviewer to prefer normalized turns over raw harness JSONL", async () => {
+        const template = await Bun.file(
+            new URL("../../../../../agents/retro-reviewer.md", import.meta.url),
+        ).text();
+
+        expect(template).toContain(
+            "ax sessions show <session_id> --turns --json",
+        );
+        expect(template).toContain("raw transcript as a secondary fallback");
+        expect(template).not.toContain('failed: "transcript missing"');
+        expect(template).toContain("normalized Turn view and raw fallback are both unavailable");
+    });
+
+    it("documents an inline fallback when the reviewer subagent is unavailable", async () => {
+        const skill = await Bun.file(
+            new URL("../../../../../skills/retro/SKILL.md", import.meta.url),
+        ).text();
+
+        expect(skill).toContain("doesn't resolve");
+        expect(skill).toContain("review the brief INLINE");
+    });
+});

--- a/apps/axctl/src/cli/commands/retro.ts
+++ b/apps/axctl/src/cli/commands/retro.ts
@@ -150,7 +150,7 @@ interface PendingSessionRow {
     readonly turns: number;
 }
 
-interface PendingSession {
+export interface PendingSession {
     readonly sessionId: string;     // `session:<key>` record id
     readonly key: string;           // bare key (UUID, no prefix)
     readonly project: string | null;
@@ -300,7 +300,7 @@ const cmdRetroPending = (input: {
  * with many turns, corrections, or tool errors → opus. The brief embeds
  * the suggestion as advisory metadata; the dispatcher picks the model.
  */
-const formatRetroBrief = (s: PendingSession, transcriptPath: string | null, suggestedModel: string): string => {
+export const formatRetroBrief = (s: PendingSession, transcriptPath: string | null, suggestedModel: string): string => {
     const fm = [
         "---",
         "kind: retro",
@@ -321,8 +321,10 @@ const formatRetroBrief = (s: PendingSession, transcriptPath: string | null, sugg
 
     const body = `# Retro: ${s.sessionId}
 
-Review the prior session and emit findings. Source of truth is the
-transcript at \`${transcriptPath ?? "(unknown - check raw_file on the session record)"}\`.
+Review the prior session and emit findings. Source of truth is the normalized Turn view:
+\`ax sessions show ${s.sessionId} --turns --json\`.
+
+raw transcript (harness-specific, large): \`${transcriptPath ?? "(unknown - check raw_file on the session record)"}\`
 
 ## What to look for
 

--- a/apps/axctl/src/cli/commands/sessions.test.ts
+++ b/apps/axctl/src/cli/commands/sessions.test.ts
@@ -1,7 +1,41 @@
 import { describe, expect, test } from "bun:test";
-import { projectRootForHere } from "./sessions.ts";
+import { Effect } from "effect";
+import { BunServices } from "@effect/platform-bun";
+import {
+    projectRootForHere,
+    sessionTurnsFlag,
+} from "./sessions.ts";
+import { normalizeSessionViewInput } from "../../dashboard/session-view.ts";
 
 describe("sessions command helpers", () => {
+    test("--turns accepts a bare excerpt mode or =full without enabling by default", async () => {
+        const parse = async (values?: ReadonlyArray<string>) => {
+            const [, parsed] = await Effect.runPromise(
+                sessionTurnsFlag.parse({
+                    arguments: [],
+                    flags: values === undefined ? {} : { turns: values },
+                }).pipe(Effect.provide(BunServices.layer)),
+            );
+            return normalizeSessionViewInput({ turns: parsed }).turns;
+        };
+
+        expect(await Promise.all([
+            parse(),
+            parse(["true"]),
+            parse(["full"]),
+        ])).toEqual([undefined, "excerpt", "full"]);
+    });
+
+    test("sessions show help advertises the optional full-text value", () => {
+        const help = Bun.spawnSync(
+            ["bun", "apps/axctl/src/cli/index.ts", "sessions", "show", "--help"],
+            { stdout: "pipe", stderr: "pipe" },
+        );
+
+        expect(help.exitCode).toBe(0);
+        expect(help.stdout.toString()).toContain("--turns [=full]");
+    });
+
     test("projectRootForHere uses main checkout root for linked worktrees", () => {
         expect(projectRootForHere({
             repoRoot: "/repo/.claude/worktrees/issue-123",

--- a/apps/axctl/src/cli/commands/sessions.test.ts
+++ b/apps/axctl/src/cli/commands/sessions.test.ts
@@ -26,6 +26,8 @@ describe("sessions command helpers", () => {
         ])).toEqual([undefined, "excerpt", "full"]);
     });
 
+    // Cold CLI boot on a CI runner can exceed the default 5s test timeout
+    // (timed out at ~5.9s on GH Actions), so this spawn test gets its own budget.
     test("sessions show help advertises the optional full-text value", () => {
         const help = Bun.spawnSync(
             ["bun", "apps/axctl/src/cli/index.ts", "sessions", "show", "--help"],
@@ -34,7 +36,7 @@ describe("sessions command helpers", () => {
 
         expect(help.exitCode).toBe(0);
         expect(help.stdout.toString()).toContain("--turns [=full]");
-    });
+    }, 30_000);
 
     test("projectRootForHere uses main checkout root for linked worktrees", () => {
         expect(projectRootForHere({

--- a/apps/axctl/src/cli/commands/sessions.test.ts
+++ b/apps/axctl/src/cli/commands/sessions.test.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import { BunServices } from "@effect/platform-bun";
 import {
     projectRootForHere,
+    SESSION_SHOW_DESCRIPTION,
     sessionTurnsFlag,
 } from "./sessions.ts";
 import { normalizeSessionViewInput } from "../../dashboard/session-view.ts";
@@ -26,17 +27,12 @@ describe("sessions command helpers", () => {
         ])).toEqual([undefined, "excerpt", "full"]);
     });
 
-    // Cold CLI boot on a CI runner can exceed the default 5s test timeout
-    // (timed out at ~5.9s on GH Actions), so this spawn test gets its own budget.
+    // Asserted on the exported description rather than a spawned `--help` run:
+    // the full-CLI spawn was CI-flaky (cold boot ~6s, env-dependent exit).
     test("sessions show help advertises the optional full-text value", () => {
-        const help = Bun.spawnSync(
-            ["bun", "apps/axctl/src/cli/index.ts", "sessions", "show", "--help"],
-            { stdout: "pipe", stderr: "pipe" },
-        );
-
-        expect(help.exitCode).toBe(0);
-        expect(help.stdout.toString()).toContain("--turns [=full]");
-    }, 30_000);
+        expect(SESSION_SHOW_DESCRIPTION).toContain("--turns");
+        expect(SESSION_SHOW_DESCRIPTION).toContain("--turns=full");
+    });
 
     test("projectRootForHere uses main checkout root for linked worktrees", () => {
         expect(projectRootForHere({

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -474,6 +474,18 @@ export const sessionTurnsFlag = Flag.choice("turns", ["full"] as const).pipe(
     Flag.orElse(() => Flag.boolean("turns")),
 );
 
+/** Exported for the help-copy test: keeps the advertised flag forms
+ *  (`--turns`, `--turns=full`) asserted without spawning the CLI. */
+export const SESSION_SHOW_DESCRIPTION =
+    "Display a session's timeline (tool calls + subagent spawns) plus a Metrics " +
+    "block showing the commits behind durability_ratio (reverted commits + the " +
+    "commits that fixed them). " +
+    "--expand=<uuid> (repeatable) or --all expands subagent timelines inline. " +
+    "--by-role groups the Top skills section by role. " +
+    "--turns includes normalized cross-harness excerpts; --turns=full includes full text. " +
+    "Auto markdown on TTY, JSON when piped. --json forces JSON. " +
+    "Output ends with a `next:` footer of copy-paste follow-up commands (resume in harness, open parent, expand subagents).";
+
 const sessionShowCommand = Command.make(
     "show",
     {
@@ -487,16 +499,7 @@ const sessionShowCommand = Command.make(
     ({ id, expand, all, byRole, turns, json }) =>
         cmdSessionShow({ id, expand, all, byRole, turns, json }),
 ).pipe(
-    Command.withDescription(
-        "Display a session's timeline (tool calls + subagent spawns) plus a Metrics " +
-        "block showing the commits behind durability_ratio (reverted commits + the " +
-        "commits that fixed them). " +
-        "--expand=<uuid> (repeatable) or --all expands subagent timelines inline. " +
-        "--by-role groups the Top skills section by role. " +
-        "--turns includes normalized cross-harness excerpts; --turns=full includes full text. " +
-        "Auto markdown on TTY, JSON when piped. --json forces JSON. " +
-        "Output ends with a `next:` footer of copy-paste follow-up commands (resume in harness, open parent, expand subagents).",
-    ),
+    Command.withDescription(SESSION_SHOW_DESCRIPTION),
 );
 
 // Effect/CLI Command definitions for sessions subcommands

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -11,6 +11,7 @@ import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
 import { encodeClaudeProjectSlug } from "@ax/lib/transcript-locator";
 import { detectStaleness } from "@ax/lib/transcript-staleness";
 import { fetchSessionCompare } from "../../dashboard/session-compare.ts";
+import { normalizeSessionViewInput } from "../../dashboard/session-view.ts";
 import { fetchEnrichedSession } from "../../queries/enriched-session.ts";
 import {
     listSessionsHere,
@@ -381,20 +382,14 @@ const cmdSessionShow = (input: {
     readonly expand: ReadonlyArray<string>;
     readonly all: boolean;
     readonly byRole: boolean;
+    readonly turns: boolean | "full";
     readonly json: boolean;
 }) =>
     Effect.gen(function* () {
         // Required Argument.string("id") makes the old missing-id guard unreachable.
         const sessionId = input.id;
 
-        const expandAll = input.all;
-        const byRole = input.byRole;
         const useJson = wantsJsonFlag(input.json);
-
-        // Collect --expand=<uuid> values (repeatable)
-        const expandSet = new Set(
-            input.expand.map((v) => v.trim()).filter((v) => v.length > 0),
-        );
 
         // The Enriched Session facade (`fetchEnrichedSession`) is the single
         // home for assembling a session's read model. The CLI base is the full
@@ -407,9 +402,12 @@ const cmdSessionShow = (input: {
         let resolvedId = sessionId;
         const viewBase = {
             kind: "view",
-            expand: expandSet,
-            expandAll,
-            byRole,
+            ...normalizeSessionViewInput({
+                expand: input.expand,
+                expandAll: input.all,
+                byRole: input.byRole,
+                turns: input.turns,
+            }),
         } as const;
         let enriched = yield* fetchEnrichedSession({
             sessionId,
@@ -471,6 +469,11 @@ const cmdSessionShow = (input: {
         }
     });
 
+export const sessionTurnsFlag = Flag.choice("turns", ["full"] as const).pipe(
+    Flag.withMetavar("[=full]"),
+    Flag.orElse(() => Flag.boolean("turns")),
+);
+
 const sessionShowCommand = Command.make(
     "show",
     {
@@ -478,10 +481,11 @@ const sessionShowCommand = Command.make(
         expand: Flag.string("expand").pipe(Flag.atLeast(0)),
         all: Flag.boolean("all").pipe(Flag.withDefault(false)),
         byRole: Flag.boolean("by-role").pipe(Flag.withDefault(false)),
+        turns: sessionTurnsFlag,
         json: jsonFlag,
     },
-    ({ id, expand, all, byRole, json }) =>
-        cmdSessionShow({ id, expand, all, byRole, json }),
+    ({ id, expand, all, byRole, turns, json }) =>
+        cmdSessionShow({ id, expand, all, byRole, turns, json }),
 ).pipe(
     Command.withDescription(
         "Display a session's timeline (tool calls + subagent spawns) plus a Metrics " +
@@ -489,6 +493,7 @@ const sessionShowCommand = Command.make(
         "commits that fixed them). " +
         "--expand=<uuid> (repeatable) or --all expands subagent timelines inline. " +
         "--by-role groups the Top skills section by role. " +
+        "--turns includes normalized cross-harness excerpts; --turns=full includes full text. " +
         "Auto markdown on TTY, JSON when piped. --json forces JSON. " +
         "Output ends with a `next:` footer of copy-paste follow-up commands (resume in harness, open parent, expand subagents).",
     ),

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -30,6 +30,7 @@ import { bucketNames, renderBucketBackends } from "@ax/schema/render";
 import { envConfig as readDbEnvConfig } from "@ax/lib/db";
 import { DEFAULT_INGEST_TIMEOUT_SECONDS } from "@ax/lib/config";
 import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
+import { provisionRetroReviewerAgent } from "./managed-agents.ts";
 
 /**
  * Tagged failure for install steps (surreal resolution, symlinking). Extends
@@ -1436,7 +1437,21 @@ export function cmdSetup(
             else console.log(`  skills: npx exited ${r.status ?? "?"} (re-run 'ax setup' or the npx command above)`);
         }
 
-        // 2. ingest is NOT run here. A full backfill can take minutes; blocking
+        // 2. Claude Code agent templates. The embedded template keeps compiled
+        // binaries self-contained; the provisioner only refreshes ax-owned
+        // files and never clobbers a user's agent of the same name.
+        if (agents.includes("claude-code")) {
+            const provisioned = yield* provisionRetroReviewerAgent(
+                posixPath.join(HOME, ".claude", "agents"),
+            );
+            if (provisioned.status === "skipped_user_owned") {
+                console.log(`  agents: kept user-authored ${provisioned.path}`);
+            } else {
+                console.log(`  agents: ${provisioned.status} ${provisioned.path}`);
+            }
+        }
+
+        // 3. ingest is NOT run here. A full backfill can take minutes; blocking
         // setup on it makes install feel frozen, and re-running it on every
         // `ax update` is pure waste (the watcher + daily ETL keep the graph
         // fresh). The onboarding brief hands ingest to the agent as a narrated
@@ -1447,11 +1462,11 @@ export function cmdSetup(
         console.log("          ax ingest             # full backfill (watch live in ax serve)");
         console.log("          ...or the daily 04:00 sync fills it overnight.");
 
-        // 3. verify.
+        // 4. verify.
         console.log();
         yield* cmdDoctor([]);
 
-        // 4. hand off to the agent for ingest + the labeling loop (classify -> fill -> lint).
+        // 5. hand off to the agent for ingest + the labeling loop (classify -> fill -> lint).
         console.log();
         console.log(renderAgentOnboarding());
     });

--- a/apps/axctl/src/cli/managed-agents.test.ts
+++ b/apps/axctl/src/cli/managed-agents.test.ts
@@ -1,0 +1,61 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import { Effect, Layer } from "effect";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import {
+    AX_AGENT_OWNERSHIP_MARKER,
+    provisionRetroReviewerAgent,
+    RETRO_REVIEWER_AGENT_TEMPLATE,
+} from "./managed-agents.ts";
+
+const BunFsLayer = Layer.merge(BunFileSystem.layer, BunPath.layer);
+
+const provision = (agentsDir: string) =>
+    Effect.runPromise(
+        provisionRetroReviewerAgent(agentsDir).pipe(Effect.provide(BunFsLayer)),
+    );
+
+describe("provisionRetroReviewerAgent", () => {
+    it("creates a missing agents directory and installs the ax-managed template", async () => {
+        const home = await mkdtemp(join(tmpdir(), "ax-managed-agents-"));
+        const agentsDir = join(home, ".claude", "agents");
+
+        const result = await provision(agentsDir);
+        const installed = await readFile(join(agentsDir, "retro-reviewer.md"), "utf8");
+
+        expect(result.status).toBe("installed");
+        expect(installed).toContain(AX_AGENT_OWNERSHIP_MARKER);
+        expect(installed).toContain("name: retro-reviewer");
+    });
+
+    it("never clobbers an existing user-authored reviewer", async () => {
+        const home = await mkdtemp(join(tmpdir(), "ax-managed-agents-"));
+        const agentsDir = join(home, ".claude", "agents");
+        const target = join(agentsDir, "retro-reviewer.md");
+        const userTemplate = "---\nname: retro-reviewer\n---\nmy private reviewer\n";
+        await mkdir(agentsDir, { recursive: true });
+        await writeFile(target, userTemplate);
+
+        const result = await provision(agentsDir);
+
+        expect(result.status).toBe("skipped_user_owned");
+        expect(await readFile(target, "utf8")).toBe(userTemplate);
+    });
+
+    it("updates only an ax-managed reviewer and is idempotent once current", async () => {
+        const home = await mkdtemp(join(tmpdir(), "ax-managed-agents-"));
+        const agentsDir = join(home, ".claude", "agents");
+        const target = join(agentsDir, "retro-reviewer.md");
+        await mkdir(agentsDir, { recursive: true });
+        await writeFile(target, `${AX_AGENT_OWNERSHIP_MARKER}\nstale template\n`);
+
+        const updated = await provision(agentsDir);
+        const unchanged = await provision(agentsDir);
+
+        expect(updated.status).toBe("updated");
+        expect(await readFile(target, "utf8")).toBe(RETRO_REVIEWER_AGENT_TEMPLATE);
+        expect(unchanged.status).toBe("unchanged");
+    });
+});

--- a/apps/axctl/src/cli/managed-agents.ts
+++ b/apps/axctl/src/cli/managed-agents.ts
@@ -1,0 +1,29 @@
+import { Effect, FileSystem } from "effect";
+import { posixPath } from "@ax/lib/shared/path";
+import retroReviewerAgent from "../../../../agents/retro-reviewer.md" with { type: "text" };
+
+export const AX_AGENT_OWNERSHIP_MARKER = "<!-- managed by ax -->";
+export const RETRO_REVIEWER_AGENT_TEMPLATE = retroReviewerAgent;
+
+export const provisionRetroReviewerAgent = Effect.fn(
+    "cli.provisionRetroReviewerAgent",
+)(function* (agentsDir: string) {
+    const fs = yield* FileSystem.FileSystem;
+    const target = posixPath.join(agentsDir, "retro-reviewer.md");
+    yield* fs.makeDirectory(agentsDir, { recursive: true });
+
+    if (yield* fs.exists(target)) {
+        const existing = yield* fs.readFileString(target);
+        if (!existing.includes(AX_AGENT_OWNERSHIP_MARKER)) {
+            return { path: target, status: "skipped_user_owned" } as const;
+        }
+        if (existing !== RETRO_REVIEWER_AGENT_TEMPLATE) {
+            yield* fs.writeFileString(target, RETRO_REVIEWER_AGENT_TEMPLATE);
+            return { path: target, status: "updated" } as const;
+        }
+        return { path: target, status: "unchanged" } as const;
+    }
+
+    yield* fs.writeFileString(target, RETRO_REVIEWER_AGENT_TEMPLATE);
+    return { path: target, status: "installed" } as const;
+});

--- a/apps/axctl/src/cli/session-show-format.test.ts
+++ b/apps/axctl/src/cli/session-show-format.test.ts
@@ -251,6 +251,31 @@ describe("renderSessionMarkdown - compaction", () => {
     });
 });
 
+describe("renderSessionMarkdown - normalized turns", () => {
+    it("appends a compact role and text list capped near 120 characters", () => {
+        const longText = `${"A".repeat(130)}TAIL`;
+        const out = renderSessionMarkdown({
+            ...MINIMAL_PAYLOAD,
+            turns: [
+                {
+                    seq: 7,
+                    ts: "2026-05-28T14:40:00Z",
+                    role: "assistant",
+                    message_kind: "assistant",
+                    intent_kind: "response",
+                    text: longText,
+                    has_error: false,
+                },
+            ],
+        });
+
+        expect(out).toContain("## Turns (1)");
+        expect(out).toContain("assistant");
+        expect(out).toContain(`${"A".repeat(119)}…`);
+        expect(out).not.toContain("TAIL");
+    });
+});
+
 describe("renderSessionMarkdown - not found", () => {
     it("emits not-found message when overview is null", () => {
         const payload: SessionShowPayload = {
@@ -531,6 +556,26 @@ describe("renderSessionJson", () => {
     it("includes expanded_subagents array", () => {
         const parsed = JSON.parse(renderSessionJson(MINIMAL_PAYLOAD));
         expect(Array.isArray(parsed.expanded_subagents)).toBe(true);
+    });
+
+    it("includes the complete normalized turns array when requested", () => {
+        const turns = [
+            {
+                seq: 1,
+                ts: "2026-05-28T14:32:01Z",
+                role: "user",
+                message_kind: "user",
+                intent_kind: "task",
+                text: "Full normalized turn text",
+                has_error: false,
+            },
+        ] as const;
+        const parsed = JSON.parse(renderSessionJson({
+            ...MINIMAL_PAYLOAD,
+            turns,
+        }));
+
+        expect(parsed.turns).toEqual(turns);
     });
 
     it("includes expanded subagent data when provided", () => {

--- a/apps/axctl/src/cli/session-show-format.ts
+++ b/apps/axctl/src/cli/session-show-format.ts
@@ -211,6 +211,22 @@ function renderCompaction(payload: SessionShowPayload): string[] {
     return lines;
 }
 
+function renderTurns(payload: SessionShowPayload): string[] {
+    const turns = payload.turns ?? [];
+    if (turns.length === 0) return [];
+    const lines = [`## Turns (${turns.length})`, ""];
+    for (const turn of turns) {
+        const rawText = "text" in turn ? turn.text : turn.text_excerpt;
+        const compactText = rawText.replace(/\s+/g, " ").trim();
+        const excerpt = compactText.length <= 120
+            ? compactText
+            : `${compactText.slice(0, 119)}…`;
+        const error = turn.has_error ? " !" : "";
+        lines.push(`- ${turn.seq} ${turn.role}${error}  ${excerpt}`);
+    }
+    return lines;
+}
+
 /**
  * Render the session show payload as a markdown-flavoured TTY string.
  * Pure function - no I/O.
@@ -322,6 +338,13 @@ export function renderSessionMarkdown(
 
     lines.push("");
 
+    // ── normalized turns (opt-in) ───────────────────────────────────────────
+    const turnLines = renderTurns(payload);
+    if (turnLines.length > 0) {
+        lines.push(...turnLines);
+        lines.push("");
+    }
+
     // ── compaction section ───────────────────────────────────────────────────
     const compactionLines = renderCompaction(payload);
     if (compactionLines.length > 0) {
@@ -368,6 +391,9 @@ export function renderSessionJson(
             expanded_subagents: payload.expanded_subagents,
             ...(payload.by_role !== null && payload.by_role !== undefined
                 ? { by_role: payload.by_role }
+                : {}),
+            ...(payload.turns !== undefined
+                ? { turns: payload.turns }
                 : {}),
             ...(extras.metrics !== null && extras.metrics !== undefined
                 ? { metrics: extras.metrics }

--- a/apps/axctl/src/dashboard/session-view.test.ts
+++ b/apps/axctl/src/dashboard/session-view.test.ts
@@ -90,14 +90,121 @@ describe("session view role query", () => {
 });
 
 describe("fetchSessionView", () => {
+    it("includes ordered normalized turns in the requested text mode", async () => {
+        const primaryId = "019e0ad4-0000-0000-0000-000000000001";
+        let turnQueries = 0;
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            fallback: (sql) => {
+                if (sql.includes("FROM turn")) {
+                    turnQueries += 1;
+                    return [[
+                        {
+                            id: "turn:one",
+                            seq: 1,
+                            ts: "2026-05-28T10:00:01Z",
+                            role: "user",
+                            message_kind: "user",
+                            intent_kind: "task",
+                            text: "Please inspect the complete normalized turn.",
+                            text_excerpt: "Please inspect the complete…",
+                            has_error: false,
+                        },
+                        {
+                            id: "turn:two",
+                            seq: 2,
+                            ts: "2026-05-28T10:00:02Z",
+                            role: "assistant",
+                            message_kind: "assistant",
+                            intent_kind: "response",
+                            text: "I inspected the complete normalized turn.",
+                            text_excerpt: "I inspected the complete…",
+                            has_error: true,
+                        },
+                    ]];
+                }
+
+                if (sql.includes("FROM session:")) {
+                    return [[{
+                        id: `session:⟨${primaryId}⟩`,
+                        project: "test-project",
+                        cwd: "/tmp/test-project",
+                        source: "pi",
+                        started_at: "2026-05-28T10:00:00Z",
+                        ended_at: "2026-05-28T10:10:00Z",
+                    }]];
+                }
+
+                return [[]];
+            },
+        });
+
+        const result = await Effect.runPromise(
+            fetchSessionView({
+                sessionId: primaryId,
+                expand: new Set(),
+                expandAll: false,
+                turns: "excerpt",
+            }).pipe(Effect.provide(tc.layer)),
+        );
+
+        expect(turnQueries).toBe(1);
+        expect(result.turns).toEqual([
+            {
+                seq: 1,
+                ts: "2026-05-28T10:00:01Z",
+                role: "user",
+                message_kind: "user",
+                intent_kind: "task",
+                text_excerpt: "Please inspect the complete…",
+                has_error: false,
+            },
+            {
+                seq: 2,
+                ts: "2026-05-28T10:00:02Z",
+                role: "assistant",
+                message_kind: "assistant",
+                intent_kind: "response",
+                text_excerpt: "I inspected the complete…",
+                has_error: true,
+            },
+        ]);
+
+        const fullResult = await Effect.runPromise(
+            fetchSessionView({
+                sessionId: primaryId,
+                expand: new Set(),
+                expandAll: false,
+                turns: "full",
+            }).pipe(Effect.provide(tc.layer)),
+        );
+
+        expect(turnQueries).toBe(2);
+        expect(fullResult.turns?.[0]).toEqual({
+            seq: 1,
+            ts: "2026-05-28T10:00:01Z",
+            role: "user",
+            message_kind: "user",
+            intent_kind: "task",
+            text: "Please inspect the complete normalized turn.",
+            has_error: false,
+        });
+    });
+
     it("owns expansion and by-role grouping for the session show read shape", async () => {
         const primaryId = "019e0ad4-0000-0000-0000-000000000001";
         const childId = "claude-subagent-a41ef01d6ca8d521c";
         const seenRoleBindings: unknown[] = [];
+        let turnQueries = 0;
 
         const tc = makeTestSurrealClient({
             denyWrites: true,
             fallback: (sql, bindings) => {
+                if (sql.includes("FROM turn")) {
+                    turnQueries += 1;
+                    return [[]];
+                }
+
                 if (sql.includes("FROM plays_role")) {
                     seenRoleBindings.push(bindings);
                     return [
@@ -181,5 +288,7 @@ describe("fetchSessionView", () => {
         expect(seenRoleBindings).toEqual([
             { skills: ["plan-skill", "debug-skill", "raw-skill"] },
         ]);
+        expect(turnQueries).toBe(0);
+        expect("turns" in result).toBe(false);
     });
 });

--- a/apps/axctl/src/dashboard/session-view.ts
+++ b/apps/axctl/src/dashboard/session-view.ts
@@ -13,13 +13,18 @@ import type {
     SessionSkillRoleGroup,
     SessionTopSkill,
     SessionViewPayload,
+    SessionViewTurn,
 } from "@ax/lib/shared/dashboard-types";
 import { runQuery } from "@ax/lib/shared/graph-query";
 import {
     sessionSkillRolesQuery,
     type SessionSkillRoleEdge,
 } from "../queries/session-view.ts";
-import { sessionCompactionsQuery } from "../queries/session-detail.ts";
+import {
+    sessionCompactionsQuery,
+    sessionShareTurnsQuery,
+} from "../queries/session-detail.ts";
+import type { ShareTurn } from "../share/artifact.ts";
 import { fetchSessionDetail } from "./session-detail.ts";
 
 // Accepts both real UUIDs and our synthetic prefixed ids. Mirrors the
@@ -44,6 +49,38 @@ const fetchSessionCompactions = (
         return rows.filter((c): c is SessionCompaction => c !== null);
     });
 
+export type SessionTurnsMode = "excerpt" | "full";
+
+const toSessionViewTurn = (
+    turn: ShareTurn,
+    mode: SessionTurnsMode,
+): SessionViewTurn => {
+    const common = {
+        seq: turn.seq,
+        ts: turn.ts ?? null,
+        role: turn.role,
+        message_kind: turn.message_kind ?? null,
+        intent_kind: turn.intent_kind ?? null,
+        has_error: turn.has_error ?? false,
+    };
+    return mode === "full"
+        ? { ...common, text: turn.text }
+        : { ...common, text_excerpt: turn.text_excerpt ?? turn.text };
+};
+
+const fetchSessionTurns = (
+    sessionId: string,
+    mode: SessionTurnsMode,
+): Effect.Effect<ReadonlyArray<SessionViewTurn>, never, SurrealClient> =>
+    Effect.gen(function* () {
+        const recordRef = sessionRecordRef(sessionId);
+        if (!recordRef) return [] as ReadonlyArray<SessionViewTurn>;
+        const rows = yield* runQuery(sessionShareTurnsQuery, { recordRef });
+        return rows
+            .filter((turn): turn is ShareTurn => turn !== null)
+            .map((turn) => toSessionViewTurn(turn, mode));
+    });
+
 export type { SessionViewPayload } from "@ax/lib/shared/dashboard-types";
 
 export interface FetchSessionViewOptions {
@@ -62,7 +99,46 @@ export interface FetchSessionViewOptions {
      * "(unclassified)" by CLI callers.
      */
     readonly byRole?: boolean;
+    /** Include normalized turns as excerpts or full text. Omitted means no query. */
+    readonly turns?: SessionTurnsMode;
 }
+
+/**
+ * Transport-agnostic input for the Session View shared by CLI and MCP.
+ * Protocol decoders may use a boolean (`--turns`) or the explicit text mode;
+ * this seam owns presence, trimming, and mode semantics.
+ */
+export interface SessionViewQueryArgs {
+    readonly expand?: ReadonlyArray<string> | undefined;
+    readonly expandAll?: boolean | undefined;
+    readonly byRole?: boolean | undefined;
+    readonly turns?: boolean | SessionTurnsMode | undefined;
+}
+
+export type NormalizedSessionViewInput = Omit<
+    FetchSessionViewOptions,
+    "sessionId"
+>;
+
+export const normalizeSessionViewInput = (
+    args: SessionViewQueryArgs,
+): NormalizedSessionViewInput => {
+    const expand = new Set(
+        (args.expand ?? []).map((value) => value.trim()).filter(Boolean),
+    );
+    const turns = args.turns === true
+        ? "excerpt"
+        : args.turns === "excerpt" || args.turns === "full"
+          ? args.turns
+          : undefined;
+
+    return {
+        expand,
+        expandAll: args.expandAll === true,
+        byRole: args.byRole === true,
+        ...(turns === undefined ? {} : { turns }),
+    };
+};
 
 export const selectSessionChildrenToExpand = (
     children: ReadonlyArray<SessionLink>,
@@ -172,10 +248,13 @@ export const fetchSessionView: (
             : Effect.succeed(null);
 
     const compactionsEffect = fetchSessionCompactions(opts.sessionId);
+    const turnsEffect = opts.turns === undefined
+        ? Effect.succeed(null)
+        : fetchSessionTurns(opts.sessionId, opts.turns);
 
-    const [expanded, byRole, compactions] = yield* Effect.all(
-        [expandedEffect, byRoleEffect, compactionsEffect],
-        { concurrency: 3 },
+    const [expanded, byRole, compactions, turns] = yield* Effect.all(
+        [expandedEffect, byRoleEffect, compactionsEffect, turnsEffect],
+        { concurrency: 4 },
     );
 
     return {
@@ -183,5 +262,6 @@ export const fetchSessionView: (
         expanded_subagents: expanded,
         by_role: byRole,
         compactions,
+        ...(turns === null ? {} : { turns }),
     };
 });

--- a/apps/axctl/src/mcp/server.smoke.test.ts
+++ b/apps/axctl/src/mcp/server.smoke.test.ts
@@ -5,10 +5,11 @@
  * and we assert the registry/envelope shape directly.
  */
 import { describe, expect, it } from "bun:test";
-import { ManagedRuntime } from "effect";
+import { Effect, ManagedRuntime } from "effect";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { AppLayer } from "@ax/lib/layers";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
 import { buildServer, wrapToolError, wrapToolResult } from "./server.ts";
 import { axMcpTools } from "./tools.ts";
 
@@ -303,6 +304,69 @@ describe("NavLink next[] wiring", () => {
             rt,
         )) as { next: ReadonlyArray<{ cmd?: string }> };
         expect(result.next.some((l) => l.cmd?.includes("claude --resume"))).toBe(true);
+    });
+
+    it("session_show returns full normalized turns when requested", async () => {
+        const sessionId = "019e2531-b552-7b53-a029-c780adbb6560";
+        let turnQueries = 0;
+        const tc = makeTestSurrealClient({
+            denyWrites: true,
+            fallback: (sql) => {
+                if (sql.includes("FROM turn")) {
+                    turnQueries += 1;
+                    return [[{
+                        id: "turn:one",
+                        seq: 1,
+                        ts: "2026-05-28T10:00:01Z",
+                        role: "user",
+                        message_kind: "user",
+                        intent_kind: "task",
+                        text: "Full Pi turn text through MCP",
+                        text_excerpt: "Full Pi turn…",
+                        has_error: false,
+                    }]];
+                }
+                if (sql.includes("FROM session:")) {
+                    return [[{
+                        id: `session:⟨${sessionId}⟩`,
+                        project: "test-project",
+                        cwd: "/tmp/test-project",
+                        source: "pi",
+                        started_at: "2026-05-28T10:00:00Z",
+                        ended_at: "2026-05-28T10:10:00Z",
+                    }]];
+                }
+                return [[]];
+            },
+        });
+        const rt = {
+            runPromise: (effect: Effect.Effect<unknown, unknown, never>) =>
+                Effect.runPromise(effect.pipe(Effect.provide(tc.layer))),
+        } as never;
+
+        const withoutTurns = (await byName("session_show").run(
+            { sessionId },
+            rt,
+        )) as Record<string, unknown>;
+
+        expect(turnQueries).toBe(0);
+        expect("turns" in withoutTurns).toBe(false);
+
+        const result = (await byName("session_show").run(
+            { sessionId, turns: "full" },
+            rt,
+        )) as { turns: ReadonlyArray<Record<string, unknown>> | null };
+
+        expect(turnQueries).toBe(1);
+        expect(result.turns?.[0]).toEqual({
+            seq: 1,
+            ts: "2026-05-28T10:00:01Z",
+            role: "user",
+            message_kind: "user",
+            intent_kind: "task",
+            text: "Full Pi turn text through MCP",
+            has_error: false,
+        });
     });
 });
 

--- a/apps/axctl/src/mcp/tools.test.ts
+++ b/apps/axctl/src/mcp/tools.test.ts
@@ -10,7 +10,7 @@ import { axMcpTools, defineMcpTool } from "./tools.ts";
 const EXPECTED_INPUT_SHAPES: Record<string, readonly string[]> = {
     recall: ["limit", "q", "sources"],
     sessions_around: ["date", "days", "project"],
-    session_show: ["byRole", "expand", "expandAll", "sessionId"],
+    session_show: ["byRole", "expand", "expandAll", "sessionId", "turns"],
     skills_weighted: ["limit", "windowDays"],
     skills_by_role: ["limit", "role"],
     skills_roles: ["skill"],

--- a/apps/axctl/src/mcp/tools.ts
+++ b/apps/axctl/src/mcp/tools.ts
@@ -39,6 +39,7 @@ import {
     listSessionsAround,
     normalizeSessionsAroundOpts,
 } from "../dashboard/sessions-query.ts";
+import { normalizeSessionViewInput } from "../dashboard/session-view.ts";
 import { fetchEnrichedSession } from "../queries/enriched-session.ts";
 import { resolveStudioTarget } from "../dashboard/serve-instance.ts";
 import {
@@ -270,7 +271,7 @@ const sessionsAroundTool: AxMcpTool = defineMcpTool({
 const sessionShowTool: AxMcpTool = defineMcpTool({
     name: "session_show",
     description:
-        `Show one session in detail: base facts, optionally expanded subagent children, and optional skill-by-role grouping. Use after sessions_around / recall to drill into a specific session id. ${NEXT_PROTOCOL_HINT}`,
+        `Show one session in detail: base facts, optional normalized cross-harness turns, expanded subagent children, and skill-by-role grouping. Use after sessions_around / recall to drill into a specific session id. ${NEXT_PROTOCOL_HINT}`,
     inputSchema: {
         sessionId: z
             .string()
@@ -287,10 +288,12 @@ const sessionShowTool: AxMcpTool = defineMcpTool({
             .boolean()
             .optional()
             .describe("Group the session's top skills by their role classifications."),
+        turns: z
+            .enum(["excerpt", "full"])
+            .optional()
+            .describe("Include normalized turns as excerpts or full text. Default: omitted."),
     },
     run: async (args, rt) => {
-        const expand = new Set(args.expand ?? []);
-        const expandAll = args.expandAll === true;
         // Read through the Enriched Session facade (the single home for
         // assembling a session read model). The MCP tool needs the Session View
         // base only - no metrics/insights - so the response shape is the bare
@@ -300,9 +303,12 @@ const sessionShowTool: AxMcpTool = defineMcpTool({
                 sessionId: args.sessionId,
                 base: {
                     kind: "view",
-                    expand,
-                    expandAll,
-                    ...(args.byRole !== undefined ? { byRole: args.byRole } : {}),
+                    ...normalizeSessionViewInput({
+                        expand: args.expand,
+                        expandAll: args.expandAll,
+                        byRole: args.byRole,
+                        turns: args.turns,
+                    }),
                 },
             }),
         );

--- a/apps/axctl/src/queries/enriched-session.test.ts
+++ b/apps/axctl/src/queries/enriched-session.test.ts
@@ -33,16 +33,18 @@ const INSIGHTS = { phases: [] } as unknown as SessionInsightsPayload;
 
 interface Calls {
     view: string[];
+    viewTurns: Array<"excerpt" | "full" | undefined>;
     detail: string[];
     metrics: string[];
     insights: string[];
 }
 
 const makeFetchers = (): { fetchers: EnrichedSessionFetchers; calls: Calls } => {
-    const calls: Calls = { view: [], detail: [], metrics: [], insights: [] };
+    const calls: Calls = { view: [], viewTurns: [], detail: [], metrics: [], insights: [] };
     const fetchers: EnrichedSessionFetchers = {
-        fetchView: ((opts: { sessionId: string }) => {
+        fetchView: ((opts: { sessionId: string; turns?: "excerpt" | "full" }) => {
             calls.view.push(opts.sessionId);
+            calls.viewTurns.push(opts.turns);
             return Effect.succeed(VIEW);
         }) as EnrichedSessionFetchers["fetchView"],
         fetchDetail: ((id: string) => {
@@ -86,6 +88,24 @@ describe("fetchEnrichedSession - base selection", () => {
         expect(calls.insights).toEqual([]);
         expect(result.view).toBe(VIEW);
         expect(result.detail).toBeNull();
+    });
+
+    it("forwards full normalized-turn mode to the Session View", async () => {
+        const { fetchers, calls } = makeFetchers();
+        await run(
+            {
+                sessionId: "s1",
+                base: {
+                    kind: "view",
+                    expand: new Set(),
+                    expandAll: false,
+                    turns: "full",
+                },
+            },
+            fetchers,
+        );
+
+        expect(calls.viewTurns).toEqual(["full"]);
     });
 
     it("base=detail runs fetchDetail only, populates .detail", async () => {

--- a/apps/axctl/src/queries/enriched-session.ts
+++ b/apps/axctl/src/queries/enriched-session.ts
@@ -118,6 +118,7 @@ export const fetchEnrichedSession: (
                 expand: opts.base.expand,
                 expandAll: opts.base.expandAll,
                 ...(opts.base.byRole === undefined ? {} : { byRole: opts.base.byRole }),
+                ...(opts.base.turns === undefined ? {} : { turns: opts.base.turns }),
             })
             .pipe(Effect.map((view) => ({ view, detail: null })))
         : fetchers

--- a/apps/axctl/src/queries/query-input-contract.test.ts
+++ b/apps/axctl/src/queries/query-input-contract.test.ts
@@ -37,6 +37,33 @@ import {
     normalizeSkillsByRoleParams,
     SKILLS_BY_ROLE_DEFAULT_LIMIT,
 } from "../dashboard/role-queries.ts";
+import { normalizeSessionViewInput } from "../dashboard/session-view.ts";
+
+// ---------------------------------------------------------------------------
+// session show - shared optional normalized-Turn mode
+// ---------------------------------------------------------------------------
+
+describe("normalizeSessionViewInput", () => {
+    test("normalizes CLI booleans and MCP modes through one shared seam", () => {
+        expect(normalizeSessionViewInput({ turns: true }).turns).toBe("excerpt");
+        expect(normalizeSessionViewInput({ turns: "excerpt" }).turns).toBe("excerpt");
+        expect(normalizeSessionViewInput({ turns: "full" }).turns).toBe("full");
+        expect("turns" in normalizeSessionViewInput({ turns: false })).toBe(false);
+        expect("turns" in normalizeSessionViewInput({})).toBe(false);
+    });
+
+    test("normalizes shared expansion and grouping presence rules", () => {
+        const input = normalizeSessionViewInput({
+            expand: [" child-a ", "", "child-b"],
+            expandAll: true,
+            byRole: true,
+        });
+
+        expect([...input.expand]).toEqual(["child-a", "child-b"]);
+        expect(input.expandAll).toBe(true);
+        expect(input.byRole).toBe(true);
+    });
+});
 
 // ---------------------------------------------------------------------------
 // recommend - DIVERGENT limit default (CLI 5, MCP 10)

--- a/apps/axctl/src/types/text.d.ts
+++ b/apps/axctl/src/types/text.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md" {
+    const content: string;
+    export default content;
+}

--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -83,6 +83,7 @@ ingest: ok`,
         flags: [
           { flag: "--days=N", desc: "window size (here defaults 14, around defaults ±3)" },
           { flag: "--here", desc: "scope metrics/churn to the current git repo" },
+          { flag: "--turns[=full]", desc: "show normalized Turn excerpts or full text for one session" },
           { flag: "--json", desc: "machine output with a copy-paste `next:` follow-up envelope" },
         ],
         receipt: `$ ax sessions here --days=7
@@ -95,7 +96,7 @@ started_at                source            repo            turns  summary
           "ax sessions here lists pwd-repo sessions (default 14d). Subagent sessions are hidden unless --include-subagents.",
           "ax sessions around <date> takes a YYYY-MM-DD or ISO8601 date and a ±N-day window (--days, default 3); --project filters by slug or absolute path.",
           "ax sessions near <sha> lists sessions overlapping a commit window (predecessor commit ts → this commit ts); falls back to ±3d for orphan commits.",
-          "ax sessions show <id> renders one session's tool-call + subagent timeline plus a durability Metrics block; --expand=<uuid> (repeatable) or --all drills into subagents, --by-role groups top skills.",
+          "ax sessions show <id> renders one session's tool-call + subagent timeline plus a durability Metrics block; --turns adds normalized cross-harness excerpts (--turns=full returns full text), --expand=<uuid> or --all drills into subagents, and --by-role groups top skills.",
           "ax sessions compare <a> <b> [...] lines up 2+ runs on duration/tokens/cost/turns/errors and stars the winner per axis; --turns adds a per-turn appendix.",
           "ax sessions metrics lists graph-derived per-session metrics; --group-by=model|repo|source|week folds into rollups, --skill=<name> compares with/without the skill.",
           "ax sessions churn summarizes verification churn (edit/landed/repair LOC, failed checks, episodes); --since defaults 30d.",
@@ -690,6 +691,7 @@ ax daemon: running (pid 48213)
 ax MCP server ready (stdio) - 17 read-only tools
   recall  sessions_around  session_show  skills_weighted  ...`,
         detail: [
+          "The session_show tool accepts turns: excerpt|full to return ordered normalized Turn content without reading harness-specific raw files.",
           "Exposes 17 read-only tools (recall, sessions_around, session_show, session_metrics, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, signal_show, cost_models, cost_split, cost_routability, dispatches, dojo_agenda).",
           "Mutating ops and git-resolved queries (sessions here/near) are intentionally not exposed.",
         ],

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -74,6 +74,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax insights <view>` - 31 read-only graph views
 - `ax signals list | show` - relation-signal catalog (fragility cascades, etc.)
 - `ax sessions metrics`, `ax evidence weekly` - session health and weekly evidence rollups
+- `ax sessions show <id> --turns[=full] --json` - provider-neutral ordered Turn excerpts or full text for one session
 - `ax serve` - local dashboard with live ingest, session browser, and health views
 - `ax tui` - terminal skills browser
 
@@ -87,7 +88,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax doctor` - validate the install (db, watcher, skills)
 
 ### For agents (MCP)
-- `ax mcp` - stdio MCP server exposing read-only graph queries as tools: recall, sessions_around, session_show, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, session_metrics, signal_show, cost_models, cost_split, dispatches, dojo_agenda
+- `ax mcp` - stdio MCP server exposing read-only graph queries as tools: recall, sessions_around, session_show, skills_weighted, skills_by_role, skills_roles, roles, improve_recommend, improve_show, improve_list, session_metrics, signal_show, cost_models, cost_split, dispatches, dojo_agenda; `session_show` accepts `turns: "excerpt" | "full"` for normalized Turn content
 
 ## Q&A - "how do I..." mapped to the ax answer
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,7 +116,7 @@ axctl costs for --terms "live trace,livetrace,live-traces" --since=2 --project /
 axctl costs for --query "checkout bug" --since=7 --here
 axctl costs for --commit 464c80b
 axctl costs for --branch main --limit=20
-axctl sessions show <session-id>
+ax sessions show <session-id> --turns --json
 axctl pricing --query gpt-5.5
 ```
 
@@ -313,8 +313,9 @@ The 17 tools, each mirroring the matching CLI command:
 
 - **recall** - full-text recall across turns / commits / skills (`ax recall`).
 - **sessions_around** - sessions in a date window (`ax sessions around`).
-- **session_show** - one session's detail, with optional subagent expansion
-  and skill-by-role grouping (`ax sessions show`).
+- **session_show** - one session's detail, with optional normalized Turn
+  excerpts/full text, subagent expansion, and skill-by-role grouping
+  (`ax sessions show --turns[=full]`).
 - **skills_weighted** - usage x role-weight skill ranking (`ax skills weighted`).
 - **skills_by_role** - skills tagged with a given role (`ax skills by-role`).
 - **skills_roles** - roles for a given skill (`ax skills roles`).

--- a/docs/insights-cli-reference.md
+++ b/docs/insights-cli-reference.md
@@ -653,10 +653,11 @@ Flags:
 ### `axctl retro brief`
 
 Write a `.ax/tasks/retro/<session-key>.md` task brief for one session.
-The brief is what the `retro-reviewer` subagent consumes. Frontmatter
-includes the transcript pointer, model used, turn count, pending
-reason, and a `suggested_model` heuristic (haiku for ≤5 turns, opus
-for ≥40 turns, sonnet otherwise).
+The brief is what the `retro-reviewer` subagent consumes. Its body names
+`ax sessions show <id> --turns --json` as the provider-neutral source of
+truth; frontmatter retains the raw transcript pointer as a secondary fallback,
+along with model used, turn count, pending reason, and a `suggested_model`
+heuristic (haiku for ≤5 turns, opus for ≥40 turns, sonnet otherwise).
 
 Flags:
 
@@ -777,10 +778,11 @@ axctl sessions near d923fcc
 axctl sessions near HEAD --json
 ```
 
-### `ax sessions show <id> [--expand=<uuid> | --all] [--by-role] [--json]`
+### `ax sessions show <id> [--expand=<uuid> | --all] [--by-role] [--turns[=full]] [--json]`
 
 Display the invoked-skill and tool-call timeline for one session. Subagent
-sessions are collapsed to one-line summaries by default.
+sessions are collapsed to one-line summaries by default. Normalized Turn text
+is opt-in so the default read stays bounded.
 
 Flags:
 
@@ -788,15 +790,18 @@ Flags:
 - `--all` - inline all subagent contents
 - `--by-role` - group the Top Skills section by role instead of a flat list;
   skills without a role appear under "(unclassified)"
+- `--turns` - append ordered cross-harness Turn excerpts; JSON includes
+  `{seq, ts, role, message_kind, intent_kind, text_excerpt, has_error}`
+- `--turns=full` - include full `text` instead of `text_excerpt`
 - `--json` - machine-readable; also the default when stdout is not a TTY
 
 `<id>` accepts a bare UUID, a `claude-subagent-<id>` string, or a full
 `session:⟨...⟩` record id.
 
 ```bash
-axctl sessions show a1b2c3d4-e5f6-...
-axctl sessions show a1b2c3d4 --expand=f9e8d7c6 --by-role
-axctl sessions show a1b2c3d4 --all --json
+ax sessions show a1b2c3d4-e5f6-...
+ax sessions show a1b2c3d4 --expand=f9e8d7c6 --by-role
+ax sessions show a1b2c3d4 --turns=full --json
 ```
 
 ### `ax recall <q> [--sources=turn,commit,skill] [--scope=here|all] [--project=? --skill=? --since=ISO] [--json]`

--- a/packages/lib/src/shared/dashboard-types.ts
+++ b/packages/lib/src/shared/dashboard-types.ts
@@ -253,11 +253,32 @@ export interface SessionCompaction {
     readonly summary: string | null;
 }
 
+export interface SessionTurnBase {
+    readonly seq: number;
+    readonly ts: string | null;
+    readonly role: string;
+    readonly message_kind: string | null;
+    readonly intent_kind: string | null;
+    readonly has_error: boolean;
+}
+
+export interface SessionTurnExcerpt extends SessionTurnBase {
+    readonly text_excerpt: string;
+}
+
+export interface SessionTurnFull extends SessionTurnBase {
+    readonly text: string;
+}
+
+export type SessionViewTurn = SessionTurnExcerpt | SessionTurnFull;
+
 export interface SessionViewPayload {
     readonly session: SessionDetailPayload;
     readonly expanded_subagents: ReadonlyArray<SessionDetailPayload>;
     readonly by_role: ReadonlyArray<SessionSkillRoleGroup> | null;
     readonly compactions: ReadonlyArray<SessionCompaction>;
+    /** Normalized cross-harness turns. Omitted when the caller did not request them. */
+    readonly turns?: ReadonlyArray<SessionViewTurn>;
 }
 
 export interface EpisodeShapeAggregate {

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -73,6 +73,10 @@ through the backlog so the experiment loop has signal next time.
    `model: opus` (override per session if `suggested_model` differs and
    the user asked you to economize).
 
+   If the `retro-reviewer` subagent type doesn't resolve (not installed,
+   or the active harness is not Claude Code), read and review the brief INLINE
+   using its required-output instructions instead of abandoning the backlog.
+
 5. Wait for all subagents. Aggregate results: counts of retros emitted,
    proposals recommended, model-fit suggestions. Render as a short
    summary. The user does not approve retro emissions per row - the


### PR DESCRIPTION
Fixes #678.

## What
- **`ax sessions show <id> --turns[=full]`** — normalized cross-harness message-content view: ordered `turns[]` (seq, ts, role, message_kind, intent_kind, excerpt/full text) promoted from the existing `sessionShareTurnsQuery` (share exporter) into the session-view payload; opt-in so the default view stays fast. Human output renders compact turn lines; `--json` carries the array.
- **MCP `session_show`** mirrors the same turn modes.
- **`ax retro brief`** now names `ax sessions show <id> --turns --json` as source of truth; the raw harness path stays as a secondary reference. `agents/retro-reviewer.md` workflow updated to match.
- **Provisioning**: `ax setup` installs the `retro-reviewer` agent template to `~/.claude/agents/` — embedded via `{ type: "text" }` import so compiled binaries stay self-contained; ax ownership marker (`<!-- managed by ax -->`) means user-authored files of the same name are never clobbered. `skills/retro/SKILL.md` gains an inline-review fallback when the subagent type doesn't resolve (non-Claude harnesses).

## Out of scope
Pi `producedCommits` unreliability (issue comment) — separate follow-up.

## Gates
`bun run typecheck` exit 0; targeted suites 1153 pass / 0 fail; docs gates updated (CLAUDE.md, docs/cli.md, llms.txt, cli-reference.data.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)