### PR TITLE
fix(ingest): self-heal agent_event_session_seq ghost-index + codex cwd filter for ingest here (#680)

### DIFF
--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -407,12 +407,13 @@ const cmdIngestHere = (args: string[]) => {
                 `--stages=${registry
                     .all()
                     .map((s) => s.meta.key)
-                    .filter((key) => !["codex", "pi", "opencode", "cursor"].includes(key))
+                    // codex now has a cwd filter (#680); pi/opencode/cursor don't yet.
+                    .filter((key) => !["pi", "opencode", "cursor"].includes(key))
                     .join(",")}`,
             ];
         if (!hasStagesArg) {
             process.stderr.write(
-                "axctl ingest here: codex, pi, opencode, cursor stages skipped - no cwd filter yet\n",
+                "axctl ingest here: pi, opencode, cursor stages skipped - no cwd filter yet\n",
             );
         }
 
@@ -534,8 +535,9 @@ const ingestHereCommand = Command.make(
         ]),
 ).pipe(Command.withDescription(
     "Ingest only the git repository at $PWD. Restricts the claude stage to the matching " +
-        "~/.claude/projects/<slug>/ transcript dir, restricts git history to this repo path. " +
-        "Codex, Pi, OpenCode, and Cursor are skipped by default (no cwd filter yet). " +
+        "~/.claude/projects/<slug>/ transcript dir, scopes codex sessions to those whose cwd is " +
+        "inside this repo, and restricts git history to this repo path. " +
+        "Pi, OpenCode, and Cursor are skipped by default (no cwd filter yet). " +
         "--stages=<a,b,c> overrides the default set.",
 ));
 

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -5,6 +5,7 @@ import { orAbsent } from "@ax/lib/shared/fs-error";
 import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
 import { posixPath } from "@ax/lib/shared/path";
 import { buildOnboardingReport, formatInstallOnboardingGuidance } from "./onboarding.ts";
+import { agentEventIndexDoctorCheck, readIndexUnhealthyMarker } from "../ingest/agent-event-index-heal.ts";
 import { applyClaudeOtelEnv, applyCodexOtelToml } from "../otel/install-config.ts";
 import { fail } from "./commands/shared.ts";
 import {
@@ -1098,6 +1099,12 @@ export function collectDoctorReport(): Effect.Effect<
                         `without finalizing - the next 'ax ingest' auto-sweeps them, or run 'ax ingest reap' now`,
             });
         }
+        // agent_event ghost-index health (#680): a cheap fs read of the marker
+        // the codex self-heal writes only when an auto-rebuild couldn't clear a
+        // residual duplicate. No query, so it stays fast on a large agent_event.
+        const indexMarker = yield* readIndexUnhealthyMarker(DATA_DIR);
+        checks.push(agentEventIndexDoctorCheck(indexMarker));
+
         const onboarding = yield* buildOnboardingReport();
         const onboardingChecks: DoctorCheck[] = onboarding.checks.map((c) => ({
             name: `onboarding:${c.id}`,

--- a/apps/axctl/src/ingest/agent-event-index-heal.test.ts
+++ b/apps/axctl/src/ingest/agent-event-index-heal.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import { Effect, FileSystem, Layer, Path } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { DbError } from "@ax/lib/errors";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -10,14 +11,17 @@ import {
     AGENT_EVENT_SEQ_REPAIR_HINT,
     agentEventIndexDoctorCheck,
     agentEventIndexMarkerPath,
-    buildAgentEventSeqRepairStatements,
+    buildAgentEventSeqRebuildStatement,
+    buildSessionDedupSelect,
     clearIndexUnhealthyMarker,
     extractAgentSessionId,
     isAgentEventSeqDuplicateError,
+    makeAgentEventSeqRebuild,
+    planSessionDedup,
     readIndexUnhealthyMarker,
     withAgentEventSeqHeal,
     writeIndexUnhealthyMarker,
-    type AgentEventSeqHealState,
+    type AgentEventSeqHealHooks,
 } from "./agent-event-index-heal.ts";
 
 // Realistic SurrealDB duplicate-index error message (shape observed across
@@ -29,17 +33,29 @@ const DUP_MSG =
 const dupErr = () => new DbError({ operation: "query", message: DUP_MSG });
 const otherDbErr = () => new DbError({ operation: "query", message: "some unrelated failure" });
 
-// Fake client: captures issued SQL, drives success/failure per attempt.
-function makeDb(issued: string[], fail: () => DbError | null) {
-    return {
-        query: (sql: string) =>
-            Effect.suspend(() => {
-                issued.push(sql);
-                const err = fail();
-                return err ? Effect.fail(err) : Effect.succeed([[]]);
-            }),
-    } as unknown as Parameters<typeof withAgentEventSeqHeal>[1]["db"];
+/** Two duplicate rows at seq 1, so a dedupe drops exactly one by primary id. */
+const DEDUP_ROWS = [[[{ id: "agent_event:a", seq: 1 }, { id: "agent_event:b", seq: 1 }]]];
+
+/** A test client whose SELECT returns duplicate rows, REBUILD + INFO succeed. */
+function healClient(opts: { rebuildFails?: boolean } = {}) {
+    return makeTestSurrealClient({
+        denyWrites: false,
+        routes: [
+            { match: "SELECT id, seq FROM agent_event", rows: DEDUP_ROWS[0] },
+            {
+                match: "REBUILD INDEX",
+                rows: opts.rebuildFails
+                    ? Effect.fail(new DbError({ operation: "query", message: "rebuild boom" }))
+                    : [[]],
+            },
+            // INFO FOR INDEX -> no `building` object => ready immediately.
+            { match: "INFO FOR INDEX", rows: [[{}]] },
+        ],
+        fallback: [[]],
+    });
 }
+
+const rebuildCount = (captured: string[]) => captured.filter((s) => s.includes("REBUILD INDEX")).length;
 
 describe("isAgentEventSeqDuplicateError", () => {
     test("matches a DbError naming the index", () => {
@@ -62,90 +78,159 @@ describe("extractAgentSessionId", () => {
     });
 });
 
-describe("buildAgentEventSeqRepairStatements", () => {
-    test("emits the REBUILD for the seq index (ghost-index fix)", () => {
-        const stmts = buildAgentEventSeqRepairStatements();
-        expect(stmts).toHaveLength(1);
-        expect(stmts[0]).toContain("REBUILD INDEX");
-        expect(stmts[0]).toContain(AGENT_EVENT_SEQ_INDEX);
-        expect(stmts[0]).toContain("ON agent_event");
+describe("pure planners", () => {
+    test("planSessionDedup keeps first per seq, drops the rest", () => {
+        const drop = planSessionDedup([
+            { id: "agent_event:a", seq: 1 },
+            { id: "agent_event:b", seq: 1 },
+            { id: "agent_event:c", seq: 2 },
+        ]);
+        expect(drop).toEqual(["agent_event:b"]);
+    });
+
+    test("buildSessionDedupSelect targets the session by full-table predicate", () => {
+        const sql = buildSessionDedupSelect("codex_019abc-def");
+        expect(sql).toContain("SELECT id, seq FROM agent_event");
+        expect(sql).toContain("agent_session = agent_session:`codex_019abc-def`");
+    });
+
+    test("buildAgentEventSeqRebuildStatement is non-blocking CONCURRENTLY", () => {
+        const sql = buildAgentEventSeqRebuildStatement();
+        expect(sql).toContain(`REBUILD INDEX IF EXISTS ${AGENT_EVENT_SEQ_INDEX} ON agent_event`);
+        expect(sql).toContain("CONCURRENTLY");
     });
 });
 
-describe("withAgentEventSeqHeal", () => {
-    test("on duplicate-index failure: rebuilds once, retries, succeeds", async () => {
-        const issued: string[] = [];
-        const db = makeDb(issued, () => null); // db.query (the REBUILD) succeeds
-        const state: AgentEventSeqHealState = { repaired: false };
+// A file-ingest effect that fails with a dup `failTimes` times, then succeeds.
+function makeWork(failTimes: number) {
+    let attempts = 0;
+    const work = Effect.suspend(() => {
+        attempts += 1;
+        return attempts <= failTimes ? Effect.fail(dupErr()) : Effect.succeed("ok" as const);
+    });
+    return { work, attempts: () => attempts };
+}
 
-        let attempts = 0;
+const runHeal = <A>(
+    work: Effect.Effect<A, DbError>,
+    hooks: Omit<AgentEventSeqHealHooks, "db" | "rebuild">,
+    tc = healClient(),
+) =>
+    Effect.gen(function* () {
+        const rebuild = yield* makeAgentEventSeqRebuild(tc.client);
+        return yield* withAgentEventSeqHeal(work, { db: tc.client, rebuild, ...hooks });
+    });
+
+describe("withAgentEventSeqHeal ladder", () => {
+    test("step 1: dedupe by primary id heals without a rebuild", async () => {
+        const tc = healClient();
+        const { work } = makeWork(1); // fails once, then the dedupe+retry succeeds
+        const dedupes: Array<{ id: string; removed: number }> = [];
         const healed: string[] = [];
-        const work = Effect.suspend(() => {
-            attempts += 1;
-            return attempts === 1 ? Effect.fail(dupErr()) : Effect.succeed("ok");
-        });
 
         const out = await Effect.runPromise(
-            withAgentEventSeqHeal(work, {
-                db,
-                state,
-                onHealed: () => Effect.sync(() => healed.push("healed")),
-            }),
+            runHeal(
+                work,
+                {
+                    onDedupe: (id, removed) => Effect.sync(() => dedupes.push({ id, removed })),
+                    onHealed: () => Effect.sync(() => healed.push("healed")),
+                },
+                tc,
+            ),
         );
 
         expect(out).toBe("ok");
-        expect(attempts).toBe(2); // failed once, retried once
-        expect(state.repaired).toBe(true);
-        expect(issued.some((s) => s.includes("REBUILD INDEX"))).toBe(true);
+        // Deduped this session by PRIMARY id (real observable at the seam).
+        expect(tc.captured.some((s) => s.startsWith("DELETE agent_event:b"))).toBe(true);
+        expect(dedupes).toEqual([{ id: "codex_019abc-def", removed: 1 }]);
+        // Cheapest rung only - no rebuild.
+        expect(rebuildCount(tc.captured)).toBe(0);
         expect(healed).toEqual(["healed"]);
     });
 
-    test("rebuilds at most once across files (state guard)", async () => {
-        const issued: string[] = [];
-        const db = makeDb(issued, () => null);
-        const state: AgentEventSeqHealState = { repaired: true }; // already repaired this stage
+    test("step 2: escalates to a CONCURRENTLY rebuild when dedupe is insufficient", async () => {
+        const tc = healClient();
+        const { work } = makeWork(2); // dedupe retry still collides -> rebuild -> retry ok
+        const rebuilt: string[] = [];
+        const healed: string[] = [];
 
-        let attempts = 0;
-        const work = Effect.suspend(() => {
-            attempts += 1;
-            return attempts === 1 ? Effect.fail(dupErr()) : Effect.succeed("ok");
-        });
+        const out = await Effect.runPromise(
+            runHeal(
+                work,
+                {
+                    onRebuild: () => Effect.sync(() => rebuilt.push("rebuilt")),
+                    onHealed: () => Effect.sync(() => healed.push("healed")),
+                },
+                tc,
+            ),
+        );
 
-        const out = await Effect.runPromise(withAgentEventSeqHeal(work, { db, state }));
         expect(out).toBe("ok");
-        expect(issued.some((s) => s.includes("REBUILD INDEX"))).toBe(false); // no second rebuild
+        expect(tc.captured.some((s) => s.includes("REBUILD INDEX") && s.includes("CONCURRENTLY"))).toBe(true);
+        expect(tc.captured.some((s) => s.includes("INFO FOR INDEX"))).toBe(true); // polled readiness
+        expect(rebuilt).toEqual(["rebuilt"]);
+        expect(healed).toEqual(["healed"]);
     });
 
-    test("second failure after repair: calls onExhausted and rethrows", async () => {
-        const issued: string[] = [];
-        const db = makeDb(issued, () => null);
-        const state: AgentEventSeqHealState = { repaired: false };
+    test("step 3: exhausted after rebuild -> onExhausted + rethrow", async () => {
+        const tc = healClient();
         const exhausted: (string | null)[] = [];
 
-        const work = Effect.fail(dupErr()); // always fails
+        const exit = await Effect.runPromiseExit(
+            runHeal(
+                Effect.fail(dupErr()), // always collides
+                { onExhausted: (id) => Effect.sync(() => exhausted.push(id)) },
+                tc,
+            ),
+        );
+
+        expect(exit._tag).toBe("Failure");
+        expect(exhausted).toEqual(["codex_019abc-def"]);
+        expect(rebuildCount(tc.captured)).toBe(1); // rebuild was tried once
+    });
+
+    test("a FAILED rebuild is observable: routes to onExhausted + rethrow", async () => {
+        const tc = healClient({ rebuildFails: true });
+        const exhausted: (string | null)[] = [];
 
         const exit = await Effect.runPromiseExit(
-            withAgentEventSeqHeal(work, {
-                db,
-                state,
-                onExhausted: (id) => Effect.sync(() => exhausted.push(id)),
-            }),
+            runHeal(
+                makeWork(2).work, // survives dedupe, needs the rebuild
+                { onExhausted: (id) => Effect.sync(() => exhausted.push(id)) },
+                tc,
+            ),
         );
+
         expect(exit._tag).toBe("Failure");
         expect(exhausted).toEqual(["codex_019abc-def"]);
     });
 
-    test("non-matching error passes through untouched (no rebuild)", async () => {
-        const issued: string[] = [];
-        const db = makeDb(issued, () => null);
-        const state: AgentEventSeqHealState = { repaired: false };
-
-        const exit = await Effect.runPromiseExit(
-            withAgentEventSeqHeal(Effect.fail(otherDbErr()), { db, state }),
-        );
+    test("non-matching error passes through untouched (no dedupe, no rebuild)", async () => {
+        const tc = healClient();
+        const exit = await Effect.runPromiseExit(runHeal(Effect.fail(otherDbErr()), {}, tc));
         expect(exit._tag).toBe("Failure");
-        expect(issued).toHaveLength(0); // never attempted a rebuild
-        expect(state.repaired).toBe(false);
+        expect(tc.captured).toHaveLength(0);
+    });
+
+    test("shared memoized rebuild fires at most once across concurrent files", async () => {
+        const tc = healClient();
+        const program = Effect.gen(function* () {
+            const rebuild = yield* makeAgentEventSeqRebuild(tc.client);
+            // Two files, each needs the rebuild (fails twice). They share ONE
+            // in-flight rebuild via Effect.cached.
+            return yield* Effect.all(
+                [
+                    withAgentEventSeqHeal(makeWork(2).work, { db: tc.client, rebuild }),
+                    withAgentEventSeqHeal(makeWork(2).work, { db: tc.client, rebuild }),
+                ],
+                { concurrency: 2 },
+            );
+        });
+
+        const outs = await Effect.runPromise(program);
+        expect(outs).toEqual(["ok", "ok"]);
+        // The whole point: NOT one rebuild per file.
+        expect(rebuildCount(tc.captured)).toBe(1);
     });
 });
 
@@ -169,15 +254,22 @@ describe("unhealthy marker + doctor surface", () => {
         expect(gone).toBeNull();
     });
 
+    test("a missing marker reads as absent/healthy (null)", async () => {
+        const marker = await Effect.runPromise(
+            readIndexUnhealthyMarker(join(dir, "does-not-exist-subdir")).pipe(provideFs()),
+        );
+        expect(marker).toBeNull();
+    });
+
     test("doctor check warns when a marker is present, ok when absent", () => {
         const warn = agentEventIndexDoctorCheck({ session_id: "s", message: DUP_MSG, at: "now" });
         expect(warn.ok).toBe(false);
-        expect(warn.detail).toContain("REBUILD INDEX");
+        expect(warn.detail).toContain("repair-agent-event-index.ts");
         expect(agentEventIndexDoctorCheck(null).ok).toBe(true);
     });
 
-    test("repair hint names the manual REBUILD", () => {
-        expect(AGENT_EVENT_SEQ_REPAIR_HINT).toContain("REBUILD INDEX");
+    test("repair hint names the global repair script", () => {
+        expect(AGENT_EVENT_SEQ_REPAIR_HINT).toContain("repair-agent-event-index.ts");
     });
 });
 

--- a/apps/axctl/src/ingest/agent-event-index-heal.test.ts
+++ b/apps/axctl/src/ingest/agent-event-index-heal.test.ts
@@ -1,0 +1,190 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { Effect, FileSystem, Layer, Path } from "effect";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { DbError } from "@ax/lib/errors";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    AGENT_EVENT_SEQ_INDEX,
+    AGENT_EVENT_SEQ_REPAIR_HINT,
+    agentEventIndexDoctorCheck,
+    agentEventIndexMarkerPath,
+    buildAgentEventSeqRepairStatements,
+    clearIndexUnhealthyMarker,
+    extractAgentSessionId,
+    isAgentEventSeqDuplicateError,
+    readIndexUnhealthyMarker,
+    withAgentEventSeqHeal,
+    writeIndexUnhealthyMarker,
+    type AgentEventSeqHealState,
+} from "./agent-event-index-heal.ts";
+
+// Realistic SurrealDB duplicate-index error message (shape observed across
+// versions; the index name is the stable token we key on).
+const DUP_MSG =
+    "Database index `agent_event_session_seq` already contains " +
+    "['agent_session:⟨codex_019abc-def⟩', 4210], with record `agent_event:xyz`";
+
+const dupErr = () => new DbError({ operation: "query", message: DUP_MSG });
+const otherDbErr = () => new DbError({ operation: "query", message: "some unrelated failure" });
+
+// Fake client: captures issued SQL, drives success/failure per attempt.
+function makeDb(issued: string[], fail: () => DbError | null) {
+    return {
+        query: (sql: string) =>
+            Effect.suspend(() => {
+                issued.push(sql);
+                const err = fail();
+                return err ? Effect.fail(err) : Effect.succeed([[]]);
+            }),
+    } as unknown as Parameters<typeof withAgentEventSeqHeal>[1]["db"];
+}
+
+describe("isAgentEventSeqDuplicateError", () => {
+    test("matches a DbError naming the index", () => {
+        expect(isAgentEventSeqDuplicateError(dupErr())).toBe(true);
+    });
+    test("rejects an unrelated DbError", () => {
+        expect(isAgentEventSeqDuplicateError(otherDbErr())).toBe(false);
+    });
+    test("rejects a non-DbError", () => {
+        expect(isAgentEventSeqDuplicateError(new Error(DUP_MSG))).toBe(false);
+    });
+});
+
+describe("extractAgentSessionId", () => {
+    test("pulls the agent_session id from the message", () => {
+        expect(extractAgentSessionId(DUP_MSG)).toBe("codex_019abc-def");
+    });
+    test("null when absent", () => {
+        expect(extractAgentSessionId("no id here")).toBeNull();
+    });
+});
+
+describe("buildAgentEventSeqRepairStatements", () => {
+    test("emits the REBUILD for the seq index (ghost-index fix)", () => {
+        const stmts = buildAgentEventSeqRepairStatements();
+        expect(stmts).toHaveLength(1);
+        expect(stmts[0]).toContain("REBUILD INDEX");
+        expect(stmts[0]).toContain(AGENT_EVENT_SEQ_INDEX);
+        expect(stmts[0]).toContain("ON agent_event");
+    });
+});
+
+describe("withAgentEventSeqHeal", () => {
+    test("on duplicate-index failure: rebuilds once, retries, succeeds", async () => {
+        const issued: string[] = [];
+        const db = makeDb(issued, () => null); // db.query (the REBUILD) succeeds
+        const state: AgentEventSeqHealState = { repaired: false };
+
+        let attempts = 0;
+        const healed: string[] = [];
+        const work = Effect.suspend(() => {
+            attempts += 1;
+            return attempts === 1 ? Effect.fail(dupErr()) : Effect.succeed("ok");
+        });
+
+        const out = await Effect.runPromise(
+            withAgentEventSeqHeal(work, {
+                db,
+                state,
+                onHealed: () => Effect.sync(() => healed.push("healed")),
+            }),
+        );
+
+        expect(out).toBe("ok");
+        expect(attempts).toBe(2); // failed once, retried once
+        expect(state.repaired).toBe(true);
+        expect(issued.some((s) => s.includes("REBUILD INDEX"))).toBe(true);
+        expect(healed).toEqual(["healed"]);
+    });
+
+    test("rebuilds at most once across files (state guard)", async () => {
+        const issued: string[] = [];
+        const db = makeDb(issued, () => null);
+        const state: AgentEventSeqHealState = { repaired: true }; // already repaired this stage
+
+        let attempts = 0;
+        const work = Effect.suspend(() => {
+            attempts += 1;
+            return attempts === 1 ? Effect.fail(dupErr()) : Effect.succeed("ok");
+        });
+
+        const out = await Effect.runPromise(withAgentEventSeqHeal(work, { db, state }));
+        expect(out).toBe("ok");
+        expect(issued.some((s) => s.includes("REBUILD INDEX"))).toBe(false); // no second rebuild
+    });
+
+    test("second failure after repair: calls onExhausted and rethrows", async () => {
+        const issued: string[] = [];
+        const db = makeDb(issued, () => null);
+        const state: AgentEventSeqHealState = { repaired: false };
+        const exhausted: (string | null)[] = [];
+
+        const work = Effect.fail(dupErr()); // always fails
+
+        const exit = await Effect.runPromiseExit(
+            withAgentEventSeqHeal(work, {
+                db,
+                state,
+                onExhausted: (id) => Effect.sync(() => exhausted.push(id)),
+            }),
+        );
+        expect(exit._tag).toBe("Failure");
+        expect(exhausted).toEqual(["codex_019abc-def"]);
+    });
+
+    test("non-matching error passes through untouched (no rebuild)", async () => {
+        const issued: string[] = [];
+        const db = makeDb(issued, () => null);
+        const state: AgentEventSeqHealState = { repaired: false };
+
+        const exit = await Effect.runPromiseExit(
+            withAgentEventSeqHeal(Effect.fail(otherDbErr()), { db, state }),
+        );
+        expect(exit._tag).toBe("Failure");
+        expect(issued).toHaveLength(0); // never attempted a rebuild
+        expect(state.repaired).toBe(false);
+    });
+});
+
+describe("unhealthy marker + doctor surface", () => {
+    const dir = join(tmpdir(), `ax-heal-test-${process.pid}`);
+    mkdirSync(dir, { recursive: true });
+    afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+    test("write / read / clear round-trip", async () => {
+        const path = agentEventIndexMarkerPath(dir);
+        expect(path).toContain("agent-event-index");
+
+        await Effect.runPromise(
+            writeIndexUnhealthyMarker(dir, "codex_019abc-def", DUP_MSG).pipe(provideFs()),
+        );
+        const marker = await Effect.runPromise(readIndexUnhealthyMarker(dir).pipe(provideFs()));
+        expect(marker?.session_id).toBe("codex_019abc-def");
+
+        await Effect.runPromise(clearIndexUnhealthyMarker(dir).pipe(provideFs()));
+        const gone = await Effect.runPromise(readIndexUnhealthyMarker(dir).pipe(provideFs()));
+        expect(gone).toBeNull();
+    });
+
+    test("doctor check warns when a marker is present, ok when absent", () => {
+        const warn = agentEventIndexDoctorCheck({ session_id: "s", message: DUP_MSG, at: "now" });
+        expect(warn.ok).toBe(false);
+        expect(warn.detail).toContain("REBUILD INDEX");
+        expect(agentEventIndexDoctorCheck(null).ok).toBe(true);
+    });
+
+    test("repair hint names the manual REBUILD", () => {
+        expect(AGENT_EVENT_SEQ_REPAIR_HINT).toContain("REBUILD INDEX");
+    });
+});
+
+// The fs helpers need @effect/platform Bun layers. Local helper keeps the
+// tests DB-free (fs leaf only).
+const BunFsLayer = Layer.merge(BunFileSystem.layer, BunPath.layer);
+function provideFs() {
+    return <A, E>(eff: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+        eff.pipe(Effect.provide(BunFsLayer));
+}

--- a/apps/axctl/src/ingest/agent-event-index-heal.ts
+++ b/apps/axctl/src/ingest/agent-event-index-heal.ts
@@ -14,12 +14,21 @@
  * commits (per-file isolation swallows the DbError), so the SAME file fails
  * identically every run until the index is rebuilt.
  *
- * `REBUILD INDEX` rebuilds the index from live table data, discarding ghost
- * entries - the one repair that actually clears the condition. We run it at
- * most ONCE per stage (guarded by a shared `state.repaired`) and retry the
- * failing file once; a second failure falls back to the existing skip-and-retry
- * behavior after recording an unhealthy marker that `ax doctor` surfaces with
- * the manual remediation.
+ * The heal is a small ladder, cheapest rung first (see {@link withAgentEventSeqHeal}):
+ *   1. **Dedupe THIS session by primary id** ({@link planSessionDedup}, the same
+ *      pure planner the global repair script uses). Targeted, lock-free, cheap -
+ *      it clears real duplicate rows. Retry the file once.
+ *   2. **Rebuild the index** if the retry still collides (a true ghost with no
+ *      backing row to dedupe). `REBUILD INDEX ... CONCURRENTLY` returns
+ *      immediately and builds in the background (a plain rebuild locks the whole
+ *      table, which on a millions-row `agent_event` wedges the daemon - the same
+ *      hazard the otel indexes avoid). We poll `INFO FOR INDEX` readiness with a
+ *      bounded budget, fire the rebuild AT MOST ONCE per stage via a shared
+ *      memoized Effect (`Effect.cached`: concurrent files await one in-flight
+ *      rebuild, and a failed rebuild is cached + observable, never re-run).
+ *      Retry the file once more.
+ *   3. **Doctor marker + rethrow** if it STILL collides. `ax doctor` surfaces the
+ *      marker pointing at the global `bun scripts/repair-agent-event-index.ts`.
  *
  * The pure planners + the wrapper are unit-tested with a fake client (no live
  * SurrealDB). Kept small + composable on purpose (#675 is adjacent).
@@ -28,6 +37,7 @@
 import { Effect, FileSystem } from "effect";
 import type { SurrealClientShape } from "@ax/lib/db";
 import { DbError } from "@ax/lib/errors";
+import { skipNotFound } from "@ax/lib/shared/fs-error";
 import { safeJsonParse } from "@ax/lib/shared/safe-json";
 
 export const AGENT_EVENT_SEQ_INDEX = "agent_event_session_seq";
@@ -47,81 +57,220 @@ export const extractAgentSessionId = (message: string): string | null => {
     return m ? m[1] : null;
 };
 
+/** Normalize an `agent_session` id to the bare key (no `agent_session:` prefix,
+ *  no backtick / angle-bracket wrappers) for safe interpolation into a ref. */
+const agentSessionKey = (id: string): string =>
+    id
+        .replace(/^agent_session:/, "")
+        .replace(/^`|`$/g, "")
+        .replace(/^⟨|⟩$/g, "");
+
+// --- Ladder step 1: per-session dedupe by primary id --------------------------
+
 /**
- * One-shot ghost-index repair. `REBUILD INDEX` drops index entries with no
- * backing row (a clear-by-primary-id can't). `IF EXISTS` so a fresh DB without
- * the index no-ops instead of erroring. This is the deliberate choice over
- * `DELETE ... by primary id`: that path is what already runs before insert and
- * still leaves ghosts. Runs on a possibly-large table and briefly locks it, so
- * it fires at most once per stage (see {@link withAgentEventSeqHeal}).
+ * Excess record ids to delete for one session: keep the first row at each seq,
+ * drop the rest. Pure so it can be reasoned about / unit-tested in isolation.
+ * One owner - `scripts/repair-agent-event-index.ts` imports this (the global
+ * repair and the ingest-time heal dedupe by the SAME rule, no copy).
  */
-export const buildAgentEventSeqRepairStatements = (): readonly string[] => [
-    `REBUILD INDEX IF EXISTS ${AGENT_EVENT_SEQ_INDEX} ON agent_event;`,
-];
+export const planSessionDedup = (
+    rows: ReadonlyArray<{ readonly id: string; readonly seq: number }>,
+): string[] => {
+    const seen = new Set<number>();
+    const drop: string[] = [];
+    for (const row of rows) {
+        if (seen.has(row.seq)) drop.push(row.id);
+        else seen.add(row.seq);
+    }
+    return drop;
+};
 
-/** Doctor-actionable manual remediation naming the exact statement. */
-export const AGENT_EVENT_SEQ_REPAIR_HINT =
-    `agent_event ${AGENT_EVENT_SEQ_INDEX} index has residual ghost entries; ` +
-    `run \`REBUILD INDEX ${AGENT_EVENT_SEQ_INDEX} ON agent_event\` against the ax DB to clear them`;
+/** SELECT that enumerates one session's `(id, seq)` rows by the full-table
+ *  predicate (never the corruptible secondary index). */
+export const buildSessionDedupSelect = (sessionId: string): string =>
+    `SELECT id, seq FROM agent_event WHERE agent_session = agent_session:\`${agentSessionKey(sessionId)}\`;`;
 
-/** Shared per-stage guard so the rebuild fires at most once across all files. */
-export interface AgentEventSeqHealState {
-    repaired: boolean;
+/** Dedupe one session's rows by primary id. Returns the count removed. */
+const dedupeSession = (
+    db: SurrealClientShape,
+    sessionId: string,
+): Effect.Effect<number, DbError> =>
+    Effect.gen(function* () {
+        const rows = yield* db
+            .query<[Array<{ id: string; seq: number }>]>(buildSessionDedupSelect(sessionId))
+            .pipe(Effect.map((r) => r?.[0] ?? []));
+        const drop = planSessionDedup(rows.map((row) => ({ id: String(row.id), seq: row.seq })));
+        // Batched to stay under parser limits (mirrors the repair script).
+        for (let i = 0; i < drop.length; i += 200) {
+            const batch = drop.slice(i, i + 200);
+            yield* db.query(batch.map((id) => `DELETE ${id};`).join(""));
+        }
+        return drop.length;
+    });
+
+// --- Ladder step 2: shared, non-blocking index rebuild ------------------------
+
+/**
+ * `REBUILD INDEX ... CONCURRENTLY` (verified supported on SurrealDB 3.2:
+ * https://surrealdb.com/docs/surrealql/statements/rebuild) rebuilds from live
+ * table data - dropping ghost entries - WITHOUT locking the table. `IF EXISTS`
+ * so a fresh DB no-ops. The DEFINE shape stays consistent with
+ * packages/schema/src/schema.surql (UNIQUE, same fields).
+ */
+export const buildAgentEventSeqRebuildStatement = (): string =>
+    `REBUILD INDEX IF EXISTS ${AGENT_EVENT_SEQ_INDEX} ON agent_event CONCURRENTLY;`;
+
+/** ~30s budget (1s interval) to poll a CONCURRENTLY rebuild to readiness. */
+const MAX_INDEX_POLL_ATTEMPTS = 30;
+
+/** `INFO FOR INDEX` reports `{ building: { status } }` while a CONCURRENTLY
+ *  build runs; an empty/absent `building` (or a plain non-concurrent build)
+ *  means ready. An unreadable INFO recovers to "ready" so we never poll
+ *  forever on a probe error. */
+interface IndexBuildInfo {
+    readonly building?: { readonly status?: string } | null;
 }
+
+const isIndexReady = (db: SurrealClientShape): Effect.Effect<boolean> =>
+    db
+        .query<[IndexBuildInfo | null]>(`INFO FOR INDEX ${AGENT_EVENT_SEQ_INDEX} ON agent_event;`)
+        .pipe(
+            Effect.map((r) => {
+                const status = r?.[0]?.building?.status;
+                return !status || status === "ready";
+            }),
+            Effect.orElseSucceed(() => true),
+        );
+
+const waitIndexReady = (
+    db: SurrealClientShape,
+    attempts = MAX_INDEX_POLL_ATTEMPTS,
+): Effect.Effect<void> =>
+    attempts <= 0
+        ? Effect.void
+        : isIndexReady(db).pipe(
+              Effect.flatMap((ready) =>
+                  ready
+                      ? Effect.void
+                      : Effect.sleep("1 second").pipe(
+                            Effect.andThen(waitIndexReady(db, attempts - 1)),
+                        ),
+              ),
+          );
+
+/**
+ * Build the SHARED per-stage rebuild Effect: rebuild CONCURRENTLY then poll to
+ * readiness. Wrapped in {@link Effect.cached} (F2) so ALL files await one
+ * in-flight rebuild - a failed rebuild is cached and observable, and the
+ * rebuild fires at most once even under file concurrency > 1. Yield this once
+ * per stage and hand the inner Effect to every file's {@link withAgentEventSeqHeal}.
+ */
+export const makeAgentEventSeqRebuild = (
+    db: SurrealClientShape,
+): Effect.Effect<Effect.Effect<void, DbError>> =>
+    Effect.cached(
+        Effect.gen(function* () {
+            yield* Effect.logWarning(
+                `rebuilding ${AGENT_EVENT_SEQ_INDEX} CONCURRENTLY (ghost-index heal, once per stage)`,
+            );
+            yield* db.query(buildAgentEventSeqRebuildStatement());
+            yield* waitIndexReady(db);
+        }),
+    );
+
+// --- The heal ladder ----------------------------------------------------------
+
+/** Doctor-actionable manual remediation naming the global repair script. */
+export const AGENT_EVENT_SEQ_REPAIR_HINT =
+    `agent_event ${AGENT_EVENT_SEQ_INDEX} index has residual ghost entries an auto-rebuild couldn't clear; ` +
+    `run \`bun scripts/repair-agent-event-index.ts\` against the ax DB (dedupes by primary id, rebuilds the index)`;
 
 export interface AgentEventSeqHealHooks {
     readonly db: SurrealClientShape;
-    readonly state: AgentEventSeqHealState;
-    /** Called just before the (single) rebuild is issued. */
-    readonly onRepairAttempt?: (sessionId: string | null) => Effect.Effect<void>;
-    /** Called when a retry STILL fails on the same signature (record marker). */
+    /**
+     * SHARED, memoized index rebuild from {@link makeAgentEventSeqRebuild}.
+     * Fires at most once per stage (Effect.cached dedups in-flight + caches a
+     * failure), so file concurrency can't launch overlapping rebuilds.
+     */
+    readonly rebuild: Effect.Effect<void, DbError>;
+    /** Called after step-1 dedupe (removed = rows dropped by primary id). */
+    readonly onDedupe?: (sessionId: string, removed: number) => Effect.Effect<void>;
+    /** Called after the shared rebuild completes (before the second retry). */
+    readonly onRebuild?: () => Effect.Effect<void>;
+    /** Called when the ladder is exhausted (record the doctor marker). */
     readonly onExhausted?: (sessionId: string | null) => Effect.Effect<void>;
-    /** Called when the retry succeeds (clear marker). */
+    /** Called when a retry SUCCEEDS (clear the doctor marker). */
     readonly onHealed?: () => Effect.Effect<void>;
 }
 
 /**
- * Wrap one file's ingest effect. On a duplicate-index {@link DbError}:
- *   1. REBUILD the index once per stage (guarded by `state.repaired`),
- *   2. retry the effect ONCE,
- *   3. on a second matching failure, call `onExhausted` and rethrow so the
- *      caller's per-file isolation skips + retries next run.
- * Non-matching failures pass through untouched (no rebuild, no retry).
+ * Wrap one file's ingest effect. On a duplicate-index {@link DbError}, walk the
+ * dedupe -> rebuild -> marker ladder (see the module doc). Non-matching failures
+ * pass through untouched (no dedupe, no rebuild, no retry).
  */
 export const withAgentEventSeqHeal = <A, E, R>(
     effect: Effect.Effect<A, E, R>,
     hooks: AgentEventSeqHealHooks,
-): Effect.Effect<A, E | DbError, R> =>
-    effect.pipe(
+): Effect.Effect<A, E | DbError, R> => {
+    const withHealClear = (e: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+        e.pipe(Effect.tap(() => (hooks.onHealed ? hooks.onHealed() : Effect.void)));
+
+    const exhausted = (sessionId: string | null, err: DbError): Effect.Effect<never, DbError> =>
+        (hooks.onExhausted ? hooks.onExhausted(sessionId) : Effect.void).pipe(
+            Effect.andThen(
+                Effect.logWarning(
+                    `agent_event index still blocked after heal; ${AGENT_EVENT_SEQ_REPAIR_HINT}`,
+                    { sessionId },
+                ),
+            ),
+            Effect.andThen(Effect.fail(err)),
+        );
+
+    return effect.pipe(
         Effect.catch((err): Effect.Effect<A, E | DbError, R> => {
             if (!isAgentEventSeqDuplicateError(err)) return Effect.fail(err as E);
             const sessionId = extractAgentSessionId((err as DbError).message);
             return Effect.gen(function* () {
-                if (!hooks.state.repaired) {
-                    hooks.state.repaired = true;
-                    if (hooks.onRepairAttempt) yield* hooks.onRepairAttempt(sessionId);
+                // Step 1: dedupe THIS session by primary id (cheap, targeted,
+                // lock-free). A true ghost has no backing row to drop, so it
+                // falls through to the rebuild on the retry below.
+                if (sessionId) {
+                    const removed = yield* dedupeSession(hooks.db, sessionId);
+                    if (hooks.onDedupe) yield* hooks.onDedupe(sessionId, removed);
                     yield* Effect.logWarning(
-                        `agent_event index ${AGENT_EVENT_SEQ_INDEX} duplicate - rebuilding once, then retrying`,
-                        { sessionId },
+                        `agent_event ${AGENT_EVENT_SEQ_INDEX} duplicate - deduped session by primary id, retrying`,
+                        { sessionId, removed },
                     );
-                    yield* hooks.db.query(buildAgentEventSeqRepairStatements().join("\n"));
                 }
-                return yield* effect.pipe(
-                    Effect.tap(() => (hooks.onHealed ? hooks.onHealed() : Effect.void)),
+                // NOTE (accepted tradeoff): a retry re-runs this file's clear +
+                // insert, so stage counters can double-count on the rare heal
+                // path. Stats-only; the DB writes converge (clear is idempotent).
+                return yield* withHealClear(effect).pipe(
                     Effect.catch((err2): Effect.Effect<A, E | DbError, R> => {
                         if (!isAgentEventSeqDuplicateError(err2)) return Effect.fail(err2 as E);
-                        return (hooks.onExhausted ? hooks.onExhausted(sessionId) : Effect.void).pipe(
-                            Effect.andThen(Effect.logWarning(
-                                `agent_event index still blocked after rebuild; ${AGENT_EVENT_SEQ_REPAIR_HINT}`,
-                                { sessionId },
-                            )),
-                            Effect.andThen(Effect.fail(err2 as DbError)),
+                        // Step 2: shared, memoized, non-blocking rebuild (once
+                        // per stage). A failed rebuild is surfaced to doctor.
+                        return hooks.rebuild.pipe(
+                            Effect.catch((rebuildErr: DbError) => exhausted(sessionId, rebuildErr)),
+                            Effect.andThen(hooks.onRebuild ? hooks.onRebuild() : Effect.void),
+                            Effect.andThen(
+                                withHealClear(effect).pipe(
+                                    Effect.catch((err3): Effect.Effect<A, E | DbError, R> => {
+                                        if (!isAgentEventSeqDuplicateError(err3)) {
+                                            return Effect.fail(err3 as E);
+                                        }
+                                        // Step 3: still blocked -> marker + rethrow.
+                                        return exhausted(sessionId, err3 as DbError);
+                                    }),
+                                ),
+                            ),
                         );
                     }),
                 );
             });
         }),
     );
+};
 
 // --- Doctor marker (cheap fs surface, no query) -------------------------------
 
@@ -156,16 +305,35 @@ export const clearIndexUnhealthyMarker = (
         yield* fs.remove(agentEventIndexMarkerPath(dataDir)).pipe(Effect.ignore);
     });
 
+/**
+ * Read the marker. Only a MISSING file reads as "absent/healthy" (null). A
+ * present-but-unreadable file or malformed JSON is NOT silently healthy: it
+ * logs a warning and falls open to null (F3 - fail-open but not blind).
+ */
 export const readIndexUnhealthyMarker = (
     dataDir: string,
 ): Effect.Effect<IndexUnhealthyMarker | null, never, FileSystem.FileSystem> =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        const text = yield* fs.readFileString(agentEventIndexMarkerPath(dataDir)).pipe(
-            Effect.orElseSucceed(() => ""),
+        const path = agentEventIndexMarkerPath(dataDir);
+        const text = yield* fs.readFileString(path).pipe(
+            // Missing file -> healthy (null), silently.
+            skipNotFound(null as string | null),
+            // Any other read error -> logged, fall open to null (not blind).
+            Effect.catchTag("PlatformError", (e) =>
+                Effect.logWarning("agent-event-index marker present but unreadable", {
+                    path,
+                    error: String(e),
+                }).pipe(Effect.as(null as string | null)),
+            ),
         );
-        if (!text) return null;
-        return safeJsonParse<IndexUnhealthyMarker>(text) ?? null;
+        if (text === null) return null;
+        const parsed = safeJsonParse<IndexUnhealthyMarker>(text);
+        if (!parsed) {
+            yield* Effect.logWarning("agent-event-index marker malformed - treating as unknown", { path });
+            return null;
+        }
+        return parsed;
     });
 
 /** Pure doctor verdict from the (already-read) marker. */
@@ -180,5 +348,5 @@ export const agentEventIndexDoctorCheck = (
             detail:
                 `codex ingest hit a residual ghost entry in ${AGENT_EVENT_SEQ_INDEX} ` +
                 `(session ${marker.session_id ?? "?"}, at ${marker.at}) that auto-rebuild couldn't clear; ` +
-                `run \`REBUILD INDEX ${AGENT_EVENT_SEQ_INDEX} ON agent_event\` against the ax DB`,
+                `run \`bun scripts/repair-agent-event-index.ts\` against the ax DB`,
         };

--- a/apps/axctl/src/ingest/agent-event-index-heal.ts
+++ b/apps/axctl/src/ingest/agent-event-index-heal.ts
@@ -1,0 +1,184 @@
+/**
+ * Self-heal for the `agent_event_session_seq` UNIQUE index (#680).
+ *
+ * `agent_event` carries `DEFINE INDEX agent_event_session_seq ON agent_event
+ * FIELDS agent_session, seq UNIQUE`. `seq` is a POSITIONAL counter recomputed
+ * from 0 on every parse, so it drifts across ingests. The per-session clear
+ * (`buildAgentSessionEventClearStatements`) deletes a session's rows by PRIMARY
+ * id before re-insert, which is enough for row-level drift - BUT a long-lived
+ * DB (observed across a SurrealDB version change / older ax) can accumulate
+ * GHOST index entries: `(agent_session, seq)` pairs in the index whose backing
+ * row is already gone. A delete-by-primary-id cannot remove a ghost (there is
+ * no row to enumerate), yet the ghost still blocks the fresh `(session, seq)`
+ * INSERT. The result is a permanent skip loop: the file's watermark never
+ * commits (per-file isolation swallows the DbError), so the SAME file fails
+ * identically every run until the index is rebuilt.
+ *
+ * `REBUILD INDEX` rebuilds the index from live table data, discarding ghost
+ * entries - the one repair that actually clears the condition. We run it at
+ * most ONCE per stage (guarded by a shared `state.repaired`) and retry the
+ * failing file once; a second failure falls back to the existing skip-and-retry
+ * behavior after recording an unhealthy marker that `ax doctor` surfaces with
+ * the manual remediation.
+ *
+ * The pure planners + the wrapper are unit-tested with a fake client (no live
+ * SurrealDB). Kept small + composable on purpose (#675 is adjacent).
+ */
+
+import { Effect, FileSystem } from "effect";
+import type { SurrealClientShape } from "@ax/lib/db";
+import { DbError } from "@ax/lib/errors";
+import { safeJsonParse } from "@ax/lib/shared/safe-json";
+
+export const AGENT_EVENT_SEQ_INDEX = "agent_event_session_seq";
+
+/**
+ * Liberal match: SurrealDB duplicate-index error strings shift across versions
+ * ("already contains", "Database index ... violates ...", etc.), so we key only
+ * on the index NAME appearing in a {@link DbError} message.
+ */
+export const isAgentEventSeqDuplicateError = (err: unknown): boolean =>
+    err instanceof DbError && err.message.includes(AGENT_EVENT_SEQ_INDEX);
+
+/** Best-effort extraction of the offending `agent_session` id for logging /
+ *  the doctor marker. Handles both bare and ⟨angle-bracket⟩ record forms. */
+export const extractAgentSessionId = (message: string): string | null => {
+    const m = message.match(/agent_session:[`⟨]?([A-Za-z0-9_.:-]+?)[`⟩\]',\s]/);
+    return m ? m[1] : null;
+};
+
+/**
+ * One-shot ghost-index repair. `REBUILD INDEX` drops index entries with no
+ * backing row (a clear-by-primary-id can't). `IF EXISTS` so a fresh DB without
+ * the index no-ops instead of erroring. This is the deliberate choice over
+ * `DELETE ... by primary id`: that path is what already runs before insert and
+ * still leaves ghosts. Runs on a possibly-large table and briefly locks it, so
+ * it fires at most once per stage (see {@link withAgentEventSeqHeal}).
+ */
+export const buildAgentEventSeqRepairStatements = (): readonly string[] => [
+    `REBUILD INDEX IF EXISTS ${AGENT_EVENT_SEQ_INDEX} ON agent_event;`,
+];
+
+/** Doctor-actionable manual remediation naming the exact statement. */
+export const AGENT_EVENT_SEQ_REPAIR_HINT =
+    `agent_event ${AGENT_EVENT_SEQ_INDEX} index has residual ghost entries; ` +
+    `run \`REBUILD INDEX ${AGENT_EVENT_SEQ_INDEX} ON agent_event\` against the ax DB to clear them`;
+
+/** Shared per-stage guard so the rebuild fires at most once across all files. */
+export interface AgentEventSeqHealState {
+    repaired: boolean;
+}
+
+export interface AgentEventSeqHealHooks {
+    readonly db: SurrealClientShape;
+    readonly state: AgentEventSeqHealState;
+    /** Called just before the (single) rebuild is issued. */
+    readonly onRepairAttempt?: (sessionId: string | null) => Effect.Effect<void>;
+    /** Called when a retry STILL fails on the same signature (record marker). */
+    readonly onExhausted?: (sessionId: string | null) => Effect.Effect<void>;
+    /** Called when the retry succeeds (clear marker). */
+    readonly onHealed?: () => Effect.Effect<void>;
+}
+
+/**
+ * Wrap one file's ingest effect. On a duplicate-index {@link DbError}:
+ *   1. REBUILD the index once per stage (guarded by `state.repaired`),
+ *   2. retry the effect ONCE,
+ *   3. on a second matching failure, call `onExhausted` and rethrow so the
+ *      caller's per-file isolation skips + retries next run.
+ * Non-matching failures pass through untouched (no rebuild, no retry).
+ */
+export const withAgentEventSeqHeal = <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+    hooks: AgentEventSeqHealHooks,
+): Effect.Effect<A, E | DbError, R> =>
+    effect.pipe(
+        Effect.catch((err): Effect.Effect<A, E | DbError, R> => {
+            if (!isAgentEventSeqDuplicateError(err)) return Effect.fail(err as E);
+            const sessionId = extractAgentSessionId((err as DbError).message);
+            return Effect.gen(function* () {
+                if (!hooks.state.repaired) {
+                    hooks.state.repaired = true;
+                    if (hooks.onRepairAttempt) yield* hooks.onRepairAttempt(sessionId);
+                    yield* Effect.logWarning(
+                        `agent_event index ${AGENT_EVENT_SEQ_INDEX} duplicate - rebuilding once, then retrying`,
+                        { sessionId },
+                    );
+                    yield* hooks.db.query(buildAgentEventSeqRepairStatements().join("\n"));
+                }
+                return yield* effect.pipe(
+                    Effect.tap(() => (hooks.onHealed ? hooks.onHealed() : Effect.void)),
+                    Effect.catch((err2): Effect.Effect<A, E | DbError, R> => {
+                        if (!isAgentEventSeqDuplicateError(err2)) return Effect.fail(err2 as E);
+                        return (hooks.onExhausted ? hooks.onExhausted(sessionId) : Effect.void).pipe(
+                            Effect.andThen(Effect.logWarning(
+                                `agent_event index still blocked after rebuild; ${AGENT_EVENT_SEQ_REPAIR_HINT}`,
+                                { sessionId },
+                            )),
+                            Effect.andThen(Effect.fail(err2 as DbError)),
+                        );
+                    }),
+                );
+            });
+        }),
+    );
+
+// --- Doctor marker (cheap fs surface, no query) -------------------------------
+
+export interface IndexUnhealthyMarker {
+    readonly session_id: string | null;
+    readonly message: string;
+    readonly at: string;
+}
+
+/** Marker path under the ax data dir. Trailing slashes normalized. */
+export const agentEventIndexMarkerPath = (dataDir: string): string =>
+    `${dataDir.replace(/\/+$/, "")}/agent-event-index.unhealthy.json`;
+
+export const writeIndexUnhealthyMarker = (
+    dataDir: string,
+    sessionId: string | null,
+    message: string,
+): Effect.Effect<void, never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const marker: IndexUnhealthyMarker = { session_id: sessionId, message, at: new Date().toISOString() };
+        yield* fs.writeFileString(agentEventIndexMarkerPath(dataDir), JSON.stringify(marker, null, 2)).pipe(
+            Effect.ignore,
+        );
+    });
+
+export const clearIndexUnhealthyMarker = (
+    dataDir: string,
+): Effect.Effect<void, never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.remove(agentEventIndexMarkerPath(dataDir)).pipe(Effect.ignore);
+    });
+
+export const readIndexUnhealthyMarker = (
+    dataDir: string,
+): Effect.Effect<IndexUnhealthyMarker | null, never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const text = yield* fs.readFileString(agentEventIndexMarkerPath(dataDir)).pipe(
+            Effect.orElseSucceed(() => ""),
+        );
+        if (!text) return null;
+        return safeJsonParse<IndexUnhealthyMarker>(text) ?? null;
+    });
+
+/** Pure doctor verdict from the (already-read) marker. */
+export const agentEventIndexDoctorCheck = (
+    marker: IndexUnhealthyMarker | null,
+): { name: string; ok: boolean; detail: string } =>
+    marker === null
+        ? { name: "agent-event-index", ok: true, detail: `${AGENT_EVENT_SEQ_INDEX} healthy` }
+        : {
+            name: "agent-event-index",
+            ok: false,
+            detail:
+                `codex ingest hit a residual ghost entry in ${AGENT_EVENT_SEQ_INDEX} ` +
+                `(session ${marker.session_id ?? "?"}, at ${marker.at}) that auto-rebuild couldn't clear; ` +
+                `run \`REBUILD INDEX ${AGENT_EVENT_SEQ_INDEX} ON agent_event\` against the ax DB`,
+        };

--- a/apps/axctl/src/ingest/codex-scope.test.ts
+++ b/apps/axctl/src/ingest/codex-scope.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { cwdInRepoScope, codexCwdFromMetaLine } from "./codex-scope.ts";
+import { Effect } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { canonicalCwdInRepoScope, cwdInRepoScope, codexCwdFromMetaLine } from "./codex-scope.ts";
 
 describe("cwdInRepoScope", () => {
     const roots = ["/Users/x/Projects/ax"];
@@ -22,6 +27,53 @@ describe("cwdInRepoScope", () => {
     });
     test("tolerates trailing slashes on the root", () => {
         expect(cwdInRepoScope("/Users/x/Projects/ax/apps", ["/Users/x/Projects/ax/"])).toBe(true);
+    });
+});
+
+describe("canonicalCwdInRepoScope (F4: realpath both sides)", () => {
+    const run = (cwd: string | null, roots: readonly string[]) =>
+        Effect.runPromise(
+            canonicalCwdInRepoScope(cwd, roots).pipe(Effect.provide(BunFileSystem.layer)),
+        );
+
+    test("a symlinked in-repo cwd is INCLUDED after realpath", async () => {
+        const base = mkdtempSync(join(tmpdir(), "ax-scope-"));
+        const repo = join(base, "repo");
+        mkdirSync(join(repo, "apps"), { recursive: true });
+        const link = join(base, "repo-link");
+        symlinkSync(repo, link); // link -> repo
+        try {
+            // Lexically, /base/repo-link/apps is NOT under /base/repo ...
+            expect(cwdInRepoScope(join(link, "apps"), [repo])).toBe(false);
+            // ... but canonicalizing resolves the symlink so it IS in scope.
+            expect(await run(join(link, "apps"), [repo])).toBe(true);
+        } finally {
+            rmSync(base, { recursive: true, force: true });
+        }
+    });
+
+    test("a `..` escape is EXCLUDED after canonicalization", async () => {
+        const base = mkdtempSync(join(tmpdir(), "ax-scope-"));
+        const repo = join(base, "repo");
+        const outside = join(base, "outside");
+        mkdirSync(repo, { recursive: true });
+        mkdirSync(outside, { recursive: true });
+        try {
+            // /base/repo/../outside canonicalizes to /base/outside, out of scope.
+            expect(await run(join(repo, "..", "outside"), [repo])).toBe(false);
+        } finally {
+            rmSync(base, { recursive: true, force: true });
+        }
+    });
+
+    test("falls back to the raw path when realpath fails (vanished path)", async () => {
+        // Neither path exists -> realpath fails -> lexical fallback still matches.
+        const root = join(tmpdir(), "ax-scope-missing-root");
+        expect(await run(join(root, "sub"), [root])).toBe(true);
+    });
+
+    test("null cwd is out of scope", async () => {
+        expect(await run(null, ["/whatever"])).toBe(false);
     });
 });
 

--- a/apps/axctl/src/ingest/codex-scope.test.ts
+++ b/apps/axctl/src/ingest/codex-scope.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { cwdInRepoScope, codexCwdFromMetaLine } from "./codex-scope.ts";
+
+describe("cwdInRepoScope", () => {
+    const roots = ["/Users/x/Projects/ax"];
+
+    test("keeps a session whose cwd IS the repo root", () => {
+        expect(cwdInRepoScope("/Users/x/Projects/ax", roots)).toBe(true);
+    });
+    test("keeps a session inside the repo root", () => {
+        expect(cwdInRepoScope("/Users/x/Projects/ax/apps/axctl", roots)).toBe(true);
+    });
+    test("EXCLUDES an out-of-repo rollout", () => {
+        expect(cwdInRepoScope("/Users/x/Projects/other", roots)).toBe(false);
+    });
+    test("does not match a sibling with a shared prefix", () => {
+        // /Users/x/Projects/ax-extra must NOT be considered inside /…/ax
+        expect(cwdInRepoScope("/Users/x/Projects/ax-extra", roots)).toBe(false);
+    });
+    test("null cwd is out of scope", () => {
+        expect(cwdInRepoScope(null, roots)).toBe(false);
+    });
+    test("tolerates trailing slashes on the root", () => {
+        expect(cwdInRepoScope("/Users/x/Projects/ax/apps", ["/Users/x/Projects/ax/"])).toBe(true);
+    });
+});
+
+describe("codexCwdFromMetaLine", () => {
+    test("extracts cwd from a session_meta line", () => {
+        const line = JSON.stringify({
+            type: "session_meta",
+            payload: { id: "abc", cwd: "/Users/x/Projects/ax", cli_version: "1" },
+        });
+        expect(codexCwdFromMetaLine(line)).toBe("/Users/x/Projects/ax");
+    });
+    test("null for a non-session_meta line", () => {
+        expect(codexCwdFromMetaLine(JSON.stringify({ type: "turn_context", payload: {} }))).toBeNull();
+    });
+    test("null for a session_meta line without cwd", () => {
+        expect(codexCwdFromMetaLine(JSON.stringify({ type: "session_meta", payload: { id: "a" } }))).toBeNull();
+    });
+    test("null for malformed json", () => {
+        expect(codexCwdFromMetaLine("{not json")).toBeNull();
+        expect(codexCwdFromMetaLine("")).toBeNull();
+    });
+});

--- a/apps/axctl/src/ingest/codex-scope.ts
+++ b/apps/axctl/src/ingest/codex-scope.ts
@@ -1,0 +1,72 @@
+/**
+ * Repo-scope filter for codex `ingest here` (#680).
+ *
+ * The codex parser already extracts each rollout's cwd from its `session_meta`
+ * head line and lands it on `session.cwd`. To scope `ingest here` to the repo
+ * at $PWD we head-peek that cwd BEFORE the full parse and drop rollouts whose
+ * cwd is outside the repo root - the cheapest viable filter (a few lines read,
+ * not a full parse of every global session).
+ */
+
+import { Effect, FileSystem, Stream } from "effect";
+import type { PlatformError } from "effect";
+import { safeJsonParse } from "@ax/lib/shared/safe-json";
+
+/** How many head lines to scan for the `session_meta` record. It is line 1 in
+ *  practice; the small budget tolerates a stray leading line without reading
+ *  the whole (possibly 30 MB) file. */
+const HEAD_LINE_BUDGET = 8;
+
+const stripTrailingSlash = (p: string): string => p.replace(/\/+$/, "");
+
+/**
+ * Is `cwd` inside one of `repoRoots`? Exact match or a true path-segment
+ * descendant (so `/x/ax` does NOT capture the sibling `/x/ax-extra`).
+ */
+export const cwdInRepoScope = (cwd: string | null | undefined, repoRoots: readonly string[]): boolean => {
+    if (!cwd) return false;
+    const c = stripTrailingSlash(cwd);
+    return repoRoots.some((root) => {
+        const r = stripTrailingSlash(root);
+        return c === r || c.startsWith(`${r}/`);
+    });
+};
+
+/** Extract `cwd` from a codex `session_meta` JSONL line, or null if the line is
+ *  not a session_meta / has no cwd / is malformed. Pure. */
+export const codexCwdFromMetaLine = (line: string): string | null => {
+    if (!line.trim()) return null;
+    const parsed = safeJsonParse<{ type?: unknown; payload?: unknown }>(line);
+    if (!parsed || parsed.type !== "session_meta") return null;
+    const payload = parsed.payload;
+    if (typeof payload !== "object" || payload === null) return null;
+    const cwd = (payload as { cwd?: unknown }).cwd;
+    return typeof cwd === "string" && cwd.length > 0 ? cwd : null;
+};
+
+/**
+ * Head-peek a codex rollout file for its session cwd. Reads at most
+ * {@link HEAD_LINE_BUDGET} lines (the stream is torn down early). Best-effort:
+ * any read error (vanished / unreadable file) recovers to null so the caller
+ * simply treats it as out-of-scope; the genuine fault, if any, surfaces on a
+ * later full ingest.
+ */
+export const readCodexSessionCwd = (
+    filePath: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        let cwd: string | null = null;
+        yield* fs.stream(filePath).pipe(
+            Stream.decodeText(),
+            Stream.splitLines,
+            Stream.take(HEAD_LINE_BUDGET),
+            Stream.runForEach((line) =>
+                Effect.sync(() => {
+                    if (cwd === null) cwd = codexCwdFromMetaLine(line);
+                }),
+            ),
+            Effect.catchTag("PlatformError", (_e: PlatformError.PlatformError) => Effect.void),
+        );
+        return cwd;
+    });

--- a/apps/axctl/src/ingest/codex-scope.ts
+++ b/apps/axctl/src/ingest/codex-scope.ts
@@ -10,6 +10,7 @@
 
 import { Effect, FileSystem, Stream } from "effect";
 import type { PlatformError } from "effect";
+import { orAbsent } from "@ax/lib/shared/fs-error";
 import { safeJsonParse } from "@ax/lib/shared/safe-json";
 
 /** How many head lines to scan for the `session_meta` record. It is line 1 in
@@ -22,6 +23,10 @@ const stripTrailingSlash = (p: string): string => p.replace(/\/+$/, "");
 /**
  * Is `cwd` inside one of `repoRoots`? Exact match or a true path-segment
  * descendant (so `/x/ax` does NOT capture the sibling `/x/ax-extra`).
+ *
+ * PURE + LEXICAL: no symlink resolution, no `..` collapsing - kept pure so it
+ * stays unit-testable without a filesystem. {@link canonicalCwdInRepoScope} is
+ * the thin canonicalizing wrapper the scope filter actually uses.
  */
 export const cwdInRepoScope = (cwd: string | null | undefined, repoRoots: readonly string[]): boolean => {
     if (!cwd) return false;
@@ -31,6 +36,27 @@ export const cwdInRepoScope = (cwd: string | null | undefined, repoRoots: readon
         return c === r || c.startsWith(`${r}/`);
     });
 };
+
+/**
+ * Canonicalizing containment check (F4): realpath both `cwd` and every
+ * `repoRoots` entry before the lexical test, so a symlinked in-repo cwd is
+ * INCLUDED and a `/repo/../outside` cwd is EXCLUDED. realpath failures (a
+ * vanished path, permission) fall back to the raw string (best-effort), so this
+ * never rejects a real in-repo file just because a path couldn't be resolved.
+ */
+export const canonicalCwdInRepoScope = (
+    cwd: string | null | undefined,
+    repoRoots: readonly string[],
+): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
+    Effect.gen(function* () {
+        if (!cwd) return false;
+        const fs = yield* FileSystem.FileSystem;
+        const realCwd = yield* fs.realPath(cwd).pipe(orAbsent(cwd));
+        const realRoots = yield* Effect.forEach(repoRoots, (root) =>
+            fs.realPath(root).pipe(orAbsent(root)),
+        );
+        return cwdInRepoScope(realCwd, realRoots);
+    });
 
 /** Extract `cwd` from a codex `session_meta` JSONL line, or null if the line is
  *  not a session_meta / has no cwd / is malformed. Pure. */

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -65,11 +65,11 @@ import type { FileFailureSnapshot } from "./file-isolation.ts";
 import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import {
     clearIndexUnhealthyMarker,
+    makeAgentEventSeqRebuild,
     withAgentEventSeqHeal,
     writeIndexUnhealthyMarker,
-    type AgentEventSeqHealState,
 } from "./agent-event-index-heal.ts";
-import { cwdInRepoScope, readCodexSessionCwd } from "./codex-scope.ts";
+import { canonicalCwdInRepoScope, readCodexSessionCwd } from "./codex-scope.ts";
 
 const DEFAULT_CODEX_RAW_MAX_BYTES = 5 * 1024 * 1024;
 const DEFAULT_CODEX_PROGRESS_EVERY = 10;
@@ -1383,8 +1383,12 @@ export const ingestCodex = Effect.fn("codex.ingest")(
         const fs = yield* FileSystem.FileSystem;
         const dataDir = cfg.paths.dataDir;
         // Shared across all files this stage run: the agent_event ghost-index
-        // rebuild fires at most once (#680).
-        const healState: AgentEventSeqHealState = { repaired: false };
+        // rebuild fires at most once, memoized so file concurrency awaits one
+        // in-flight rebuild + a failed rebuild is observable (#680).
+        const agentEventSeqRebuild = yield* makeAgentEventSeqRebuild(db);
+        // Set when a file exhausts the heal ladder this run; gates the
+        // clear-on-clean-completion below so we don't wipe a just-written marker.
+        let indexHealExhausted = false;
         const cutoff = opts.sinceDays ? Date.now() - opts.sinceDays * 86400 * 1000 : 0;
         let files = yield* walkJsonlFilesStrict(cfg.paths.codexDir, cutoff);
         // `ingest here` repo scope (#680): head-peek each rollout's session_meta
@@ -1394,15 +1398,25 @@ export const ingestCodex = Effect.fn("codex.ingest")(
         if (opts.repoRoots && opts.repoRoots.length > 0) {
             const roots = opts.repoRoots;
             const scoped: typeof files = [];
+            // NOTE (accepted tradeoff): a head-peek read error maps the cwd to
+            // null -> out-of-scope (best-effort); a later full ingest still
+            // picks the file up. `unreadable` tallies those for a debug log.
+            let unreadable = 0;
             yield* Effect.forEach(
                 files,
                 (file) =>
                     Effect.gen(function* () {
                         const cwd = yield* readCodexSessionCwd(file.path);
-                        if (cwdInRepoScope(cwd, roots)) scoped.push(file);
+                        if (cwd === null) unreadable += 1;
+                        // Canonicalize both sides (realpath) so a symlinked
+                        // in-repo cwd is included and `/repo/../outside` excluded.
+                        if (yield* canonicalCwdInRepoScope(cwd, roots)) scoped.push(file);
                     }),
                 { concurrency: 8, discard: true },
             );
+            if (unreadable > 0) {
+                yield* Effect.logDebug("codex ingest here: unreadable head-peek files", { unreadable });
+            }
             yield* Effect.logDebug("codex ingest here scope", {
                 candidates: files.length,
                 inScope: scoped.length,
@@ -1677,15 +1691,21 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                 return true;
             }).pipe(
                 // Self-heal the agent_event ghost-index collision (#680): on a
-                // duplicate-index DbError, REBUILD once per stage + retry this
-                // file once. A second failure records a doctor marker and rethrows
-                // so per-file isolation skips it (no permanent silent skip loop).
+                // duplicate-index DbError, dedupe this session by primary id +
+                // retry; if still blocked, rebuild the index CONCURRENTLY once
+                // per stage + retry; a second failure records a doctor marker and
+                // rethrows so per-file isolation skips it (no silent skip loop).
                 (eff) =>
                     withAgentEventSeqHeal(eff, {
                         db,
-                        state: healState,
+                        rebuild: agentEventSeqRebuild,
                         onExhausted: (sessionId) =>
-                            writeIndexUnhealthyMarker(dataDir, sessionId, `codex file ${file.path}`).pipe(
+                            Effect.sync(() => {
+                                indexHealExhausted = true;
+                            }).pipe(
+                                Effect.andThen(
+                                    writeIndexUnhealthyMarker(dataDir, sessionId, `codex file ${file.path}`),
+                                ),
                                 Effect.provideService(FileSystem.FileSystem, fs),
                             ),
                         onHealed: () =>
@@ -1703,6 +1723,15 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                 }),
             ),
         });
+        // F3: clear a stale unhealthy marker on ANY clean stage completion (e.g.
+        // a manual `bun scripts/repair-agent-event-index.ts` followed by a clean
+        // ingest that never re-triggers the heal). Skip the clear only when a
+        // file exhausted the ladder THIS run - that just-written marker stays.
+        if (!indexHealExhausted) {
+            yield* clearIndexUnhealthyMarker(dataDir).pipe(
+                Effect.provideService(FileSystem.FileSystem, fs),
+            );
+        }
         yield* Effect.logDebug("codex ingest complete", {
             files: fileCount,
             records: recordCount(),

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -63,6 +63,13 @@ import { codexSourceForThread } from "./source-origin.ts";
 import { walkJsonlFilesStrict } from "./walk-jsonl.ts";
 import type { FileFailureSnapshot } from "./file-isolation.ts";
 import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
+import {
+    clearIndexUnhealthyMarker,
+    withAgentEventSeqHeal,
+    writeIndexUnhealthyMarker,
+    type AgentEventSeqHealState,
+} from "./agent-event-index-heal.ts";
+import { cwdInRepoScope, readCodexSessionCwd } from "./codex-scope.ts";
 
 const DEFAULT_CODEX_RAW_MAX_BYTES = 5 * 1024 * 1024;
 const DEFAULT_CODEX_PROGRESS_EVERY = 10;
@@ -1349,6 +1356,10 @@ interface CodexIngestOpts {
     /** Absolute wall-clock deadline (ms epoch). Once reached, no NEW file is
      *  started; in-flight files finish. Lets `--dry-run` time-box calibration. */
     deadlineMs: number | undefined;
+    /** Repo roots to scope ingest to (`ingest here`). When set, only codex
+     *  rollout files whose session cwd is inside one of these roots are
+     *  ingested (head-peeked before parse). Undefined = ingest all (#680). */
+    repoRoots: readonly string[] | undefined;
 }
 
 export interface CodexStats {
@@ -1370,8 +1381,34 @@ export const ingestCodex = Effect.fn("codex.ingest")(
         const cfg = yield* AxConfig;
         const db = yield* SurrealClient;
         const fs = yield* FileSystem.FileSystem;
+        const dataDir = cfg.paths.dataDir;
+        // Shared across all files this stage run: the agent_event ghost-index
+        // rebuild fires at most once (#680).
+        const healState: AgentEventSeqHealState = { repaired: false };
         const cutoff = opts.sinceDays ? Date.now() - opts.sinceDays * 86400 * 1000 : 0;
-        const files = yield* walkJsonlFilesStrict(cfg.paths.codexDir, cutoff);
+        let files = yield* walkJsonlFilesStrict(cfg.paths.codexDir, cutoff);
+        // `ingest here` repo scope (#680): head-peek each rollout's session_meta
+        // cwd (bounded, cheap) and keep only files inside a repo root. Out-of-repo
+        // files are dropped BEFORE the work-unit so they never watermark - a later
+        // global ingest still picks them up. No repoRoots => ingest everything.
+        if (opts.repoRoots && opts.repoRoots.length > 0) {
+            const roots = opts.repoRoots;
+            const scoped: typeof files = [];
+            yield* Effect.forEach(
+                files,
+                (file) =>
+                    Effect.gen(function* () {
+                        const cwd = yield* readCodexSessionCwd(file.path);
+                        if (cwdInRepoScope(cwd, roots)) scoped.push(file);
+                    }),
+                { concurrency: 8, discard: true },
+            );
+            yield* Effect.logDebug("codex ingest here scope", {
+                candidates: files.length,
+                inScope: scoped.length,
+            });
+            files = scoped;
+        }
         // `--dry-run` calibration: cap to a small representative slice so we can
         // time real parse+write throughput without processing everything.
         if (typeof opts.limit === "number" && files.length > opts.limit) {
@@ -1638,14 +1675,33 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                     yield* Effect.logDebug("codex ingest progress", counts);
                 }
                 return true;
-            }).pipe(Effect.withSpan("codex.file", {
-                // Basename only: keeps exported-trace attributes small (the full
-                // session path is reconstructable locally if ever needed).
-                attributes: {
-                    "file.name": file.path.slice(file.path.lastIndexOf("/") + 1),
-                    "file.bytes": file.sizeBytes,
-                },
-            })),
+            }).pipe(
+                // Self-heal the agent_event ghost-index collision (#680): on a
+                // duplicate-index DbError, REBUILD once per stage + retry this
+                // file once. A second failure records a doctor marker and rethrows
+                // so per-file isolation skips it (no permanent silent skip loop).
+                (eff) =>
+                    withAgentEventSeqHeal(eff, {
+                        db,
+                        state: healState,
+                        onExhausted: (sessionId) =>
+                            writeIndexUnhealthyMarker(dataDir, sessionId, `codex file ${file.path}`).pipe(
+                                Effect.provideService(FileSystem.FileSystem, fs),
+                            ),
+                        onHealed: () =>
+                            clearIndexUnhealthyMarker(dataDir).pipe(
+                                Effect.provideService(FileSystem.FileSystem, fs),
+                            ),
+                    }),
+                Effect.withSpan("codex.file", {
+                    // Basename only: keeps exported-trace attributes small (the full
+                    // session path is reconstructable locally if ever needed).
+                    attributes: {
+                        "file.name": file.path.slice(file.path.lastIndexOf("/") + 1),
+                        "file.bytes": file.sizeBytes,
+                    },
+                }),
+            ),
         });
         yield* Effect.logDebug("codex ingest complete", {
             files: fileCount,
@@ -1722,7 +1778,14 @@ export const codexStage: StageDef<CodexStageStats, SurrealClient | AxConfig | Fi
         // unreadable sessions root or a non-NotFound stat/stream error), so
         // it dies as a defect rather than masquerading as a recoverable
         // DbError - mirroring `claudeStage`.
-        const result = yield* ingestCodex({ sinceDays, onProgress: annotateStageProgress, onFileFailures }).pipe(
+        const result = yield* ingestCodex({
+            sinceDays,
+            onProgress: annotateStageProgress,
+            onFileFailures,
+            // `ingest here` scopes codex to the repo(s) at $PWD (#680); a global
+            // ingest leaves repoRoots undefined => all sessions.
+            ...(ctx.repoPaths ? { repoRoots: ctx.repoPaths } : {}),
+        }).pipe(
             Effect.catchTag("PlatformError", (e) => Effect.die(e)),
         );
         return CodexStageStats.make({

--- a/apps/axctl/src/ingest/session-health.test.ts
+++ b/apps/axctl/src/ingest/session-health.test.ts
@@ -136,3 +136,45 @@ describe("session health derivation", () => {
         expect(statement).toContain("model: IF model != NONE THEN model ELSE NONE END");
     });
 });
+
+describe("session health NONE-safety (#680)", () => {
+    const origWarn = console.warn;
+
+    test("skips a session with no started_at (no epoch warn, no row)", () => {
+        const warnings: unknown[] = [];
+        console.warn = (...args: unknown[]) => warnings.push(args);
+        try {
+            const rows = __testBuildSessionHealthRows({
+                firstSuperpowersAt: null,
+                // Half-ingested codex session: started_at hasn't landed yet.
+                sessions: [{ id: "session:`half`", source: "codex" }],
+                turns: [{ session: "session:`half`", role: "user", text_excerpt: "hi" }],
+                toolCalls: [],
+                planSnapshots: [],
+                insightMetrics: [],
+            });
+            expect(rows.usages).toHaveLength(0);
+            expect(rows.health).toHaveLength(0);
+            expect(warnings).toHaveLength(0);
+        } finally {
+            console.warn = origWarn;
+        }
+    });
+
+    test("still emits rows for a session WITH started_at alongside a half-ingested one", () => {
+        const rows = __testBuildSessionHealthRows({
+            firstSuperpowersAt: null,
+            sessions: [
+                { id: "session:`ok`", source: "codex", started_at: "2026-05-02T00:00:00.000Z" },
+                { id: "session:`half`", source: "codex" },
+            ],
+            turns: [],
+            toolCalls: [],
+            planSnapshots: [],
+            insightMetrics: [],
+        });
+        expect(rows.usages).toHaveLength(1);
+        expect(rows.health).toHaveLength(1);
+        expect(rows.usages[0].sessionKey).toBe("ok");
+    });
+});

--- a/apps/axctl/src/ingest/session-health.ts
+++ b/apps/axctl/src/ingest/session-health.ts
@@ -188,6 +188,11 @@ function buildRows(input: {
     for (const session of input.sessions) {
         const sessionKey = recordKeyPart(session.id, "session");
         if (!sessionKey) continue;
+        // NONE-safe (#680): a half-ingested session (e.g. a codex session whose
+        // started_at hasn't landed yet) has no usable timestamp. Passing it to
+        // isoTimestamp warns and stamps an epoch (1970) row; skip it entirely -
+        // a later ingest recomputes health once the session is complete.
+        if (session.started_at == null) continue;
         const startedAt = isoTimestamp(session.started_at);
         const ts = isoTimestamp(session.ended_at ?? session.started_at);
         const source = session.source ?? "unknown";

--- a/docs/superpowers/plans/2026-07-15-680-ingest-selfheal.md
+++ b/docs/superpowers/plans/2026-07-15-680-ingest-selfheal.md
@@ -1,0 +1,45 @@
+# #680 ingest self-heal + codex `ingest here` filter - Implementation Plan
+
+> **For agentic workers:** strict TDD per task, failing test FIRST. Seam rule: fake only DB client / fs leaf, never the code path under test.
+
+**Goal:** Stop codex files being permanently skipped on `agent_event_session_seq` ghost-index collisions (self-heal + retry + doctor surface), silence the `isoTimestamp undefined` warning on half-ingested sessions, and scope codex ingest to `$PWD` repo under `ingest here`.
+
+**Architecture:** New pure heal module (`agent-event-index-heal.ts`) exposes duplicate-index detection + REBUILD planner + a `withAgentEventSeqHeal` wrapper (retry-once, rebuild-once-per-stage) + an unhealthy-marker (doctor surface). Wired into codex `processFile`. Session-health caller made NONE-safe. Codex stage gains a repo-scope filter via head-peek cwd.
+
+**Tech Stack:** bun:test, Effect v4, SurrealDB.
+
+## Global Constraints
+- SurrealDB 3.x: `REBUILD INDEX [IF EXISTS] <name> ON <table>` is valid; it rebuilds the index from live rows, discarding ghost entries whose backing row is gone (a clear-by-primary-id can't remove those).
+- Tests must NOT require a live SurrealDB; fake the client, use temp dirs for fs.
+- Consult effect-solutions before new Effect.
+- One conventional commit. Never stage BRIEF.md/REPORT.md.
+
+---
+
+### Task A: agent_event ghost-index self-heal
+**Files:**
+- Create `apps/axctl/src/ingest/agent-event-index-heal.ts`
+- Test `apps/axctl/src/ingest/agent-event-index-heal.test.ts`
+- Modify `apps/axctl/src/ingest/codex.ts` (wrap `processFile`, wire marker fs)
+- Modify `apps/axctl/src/cli/install.ts` (doctor check reads marker)
+
+**Exports:** `isAgentEventSeqDuplicateError`, `extractAgentSessionId`, `buildAgentEventSeqRepairStatements`, `AGENT_EVENT_SEQ_REPAIR_HINT`, `withAgentEventSeqHeal(effect, {db,state,onRepairAttempt?,onExhausted?,onHealed?})`, marker helpers `agentEventIndexMarkerPath` / `writeIndexUnhealthyMarker` / `clearIndexUnhealthyMarker` / `readIndexUnhealthyMarker`, `agentEventIndexDoctorCheck`.
+
+- Detect: `DbError` whose message contains `agent_event_session_seq` (liberal - SurrealDB strings shift).
+- Repair: `REBUILD INDEX IF EXISTS agent_event_session_seq ON agent_event;` - once per stage (guard via `state.repaired`).
+- Retry the file effect once; second matching failure → `onExhausted` (write marker) then rethrow (per-file isolation skips w/ hint). Non-matching errors pass through untouched.
+- Success after repair → `onHealed` (clear marker).
+- Doctor: cheap `fs.exists(marker)` → warn with REBUILD remediation.
+
+### Task B: isoTimestamp NONE-safe in session-health
+**Files:** Modify `apps/axctl/src/ingest/session-health.ts` (`buildRows`); test in `apps/axctl/src/ingest/session-health.test.ts`.
+- Skip a session with no `started_at` (half-ingested) → no usage/health row, no epoch warn. Recomputed next ingest.
+
+### Task C: codex cwd filter for `ingest here`
+**Files:**
+- Create `apps/axctl/src/ingest/codex-scope.ts` (`cwdInRepoScope`, `codexCwdFromMetaLine`) + test.
+- Modify `apps/axctl/src/ingest/codex.ts`: `CodexIngestOpts.repoRoots`; head-peek filter of discovered files; `codexStage` reads `ctx.repoPaths`.
+- Modify `apps/axctl/src/cli/commands/ingest.ts`: default-skip set drops `codex` (keep pi/opencode/cursor); update skip message + `here` help copy.
+- C2: verify `sessions.ts` stale copy is honest - no change (recommends `ingest here --since=7`, now genuinely ingests codex).
+
+**Gates:** `bun run typecheck` == 0; `bun test apps/axctl/src/ingest apps/axctl/src/cli` green.

--- a/scripts/repair-agent-event-index.ts
+++ b/scripts/repair-agent-event-index.ts
@@ -35,8 +35,17 @@
 import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { AppLayer } from "@ax/lib/layers";
+// One owner for the dedupe rule: the ingest-time heal and this global repair
+// dedupe a session by the SAME pure planner (no copy). Re-export it so existing
+// importers of `planSessionDedup` from this script keep resolving.
+import {
+    AGENT_EVENT_SEQ_INDEX,
+    planSessionDedup,
+} from "../apps/axctl/src/ingest/agent-event-index-heal.ts";
 
-const INDEX_NAME = "agent_event_session_seq";
+export { planSessionDedup };
+
+const INDEX_NAME = AGENT_EVENT_SEQ_INDEX;
 const DRY_RUN = process.argv.includes("--dry-run");
 
 interface DupGroup {
@@ -44,20 +53,6 @@ interface DupGroup {
     readonly seq: number;
     readonly c: number;
 }
-
-/** Excess record ids to delete for one session: keep the first row at each seq,
- *  drop the rest. Pure so it can be reasoned about / unit-tested in isolation. */
-export const planSessionDedup = (
-    rows: ReadonlyArray<{ readonly id: string; readonly seq: number }>,
-): string[] => {
-    const seen = new Set<number>();
-    const drop: string[] = [];
-    for (const row of rows) {
-        if (seen.has(row.seq)) drop.push(row.id);
-        else seen.add(row.seq);
-    }
-    return drop;
-};
 
 const repair = Effect.gen(function* () {
     const db = yield* SurrealClient;


### PR DESCRIPTION
Fixes #680.

## Root cause
`seq` on `agent_event` is a positional counter recomputed every parse, and a long-lived DB accumulates ghost `(agent_session, seq)` index entries (backing row gone) that the delete-by-primary-id clear can't remove but that still block fresh inserts. Per-file isolation swallowed the DbError without committing the watermark — so the same Codex files failed identically every run ("retried next run" was a permanent skip loop).

## What ships
- **Self-heal ladder** (`agent-event-index-heal.ts`), cheapest rung first, on a duplicate-index DbError:
  1. dedupe THAT session's rows by primary id (reuses `planSessionDedup` — now owned by the heal module, `scripts/repair-agent-event-index.ts` imports it back; one owner) and retry the file once;
  2. if a true ghost survives, `REBUILD INDEX ... CONCURRENTLY` (never locks the millions-row table; the otel lesson) memoized via `Effect.cached` so concurrent files await ONE in-flight rebuild, with a bounded `INFO FOR INDEX` readiness poll before the retry;
  3. doctor marker + rethrow — `ax doctor` surfaces the manual remediation (`bun scripts/repair-agent-event-index.ts`). Marker clears on any clean stage completion.
- **`ingest here` codex scope**: head-peek each rollout's `session_meta` cwd (bounded 8-line read) and drop out-of-repo files BEFORE the work-unit so they never watermark; realpath-canonicalized containment (symlinks in, `..` traversal out). Skip message now names only pi/opencode/cursor.
- **isoTimestamp epoch spam**: session-health skips half-ingested sessions with no `started_at` instead of stamping 1970 rows.

## Known tradeoffs (commented in code)
Stage counters can double-count on the rare retry path (stats-only; DB writes converge). Head-peek read errors map to out-of-scope by design (full ingest picks the file up; debug-logged).

## Gates
`bun run typecheck` exit 0; ingest 1067 / cli 642 / scripts 155 tests, 0 fail. Adversarial cross-review round applied (blocking-REBUILD must-fix, guard race, marker semantics, lexical-containment, reuse of the existing repair script).

⚠️ INFO FOR INDEX shape + `REBUILD ... CONCURRENTLY` verified against SurrealDB 3.2 docs, not a live DB run; the poll is bounded + fail-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)