### PR TITLE
fix(cli): bare --turns silently no-oped - boolean branch first (#686)

### DIFF
--- a/apps/axctl/src/cli/commands/sessions.test.ts
+++ b/apps/axctl/src/cli/commands/sessions.test.ts
@@ -20,6 +20,14 @@ describe("sessions command helpers", () => {
             return normalizeSessionViewInput({ turns: parsed }).turns;
         };
 
+        // ["true"] is the lexed shape of a BARE `--turns`: the tokenizer's
+        // consumeFlagValue defaults a boolean flag to implicit "true". NOTE
+        // this seam CANNOT catch #686 - that bug lived in consumeFlagValue
+        // consulting the orElse composition's FIRST branch spec (choice =
+        // non-boolean, so bare `--turns` never got the implicit "true"), which
+        // hand-fed flag records bypass entirely. The composition order in
+        // sessionTurnsFlag (boolean first) is the actual fix; verified against
+        // the real CLI in #686.
         expect(await Promise.all([
             parse(),
             parse(["true"]),

--- a/apps/axctl/src/cli/commands/sessions.ts
+++ b/apps/axctl/src/cli/commands/sessions.ts
@@ -469,9 +469,14 @@ const cmdSessionShow = (input: {
         }
     });
 
-export const sessionTurnsFlag = Flag.choice("turns", ["full"] as const).pipe(
+// Boolean branch FIRST. With the choice branch first, a bare `--turns` fails
+// the choice parse (missing value) and the composition resolves to the boolean
+// branch's ABSENT default (false) instead of true - the advertised bare form
+// silently no-oped (#686, found dogfooding). Boolean-first parses bare
+// `--turns` as true; the inline `--turns=full` form still reaches the choice.
+export const sessionTurnsFlag = Flag.boolean("turns").pipe(
+    Flag.orElse(() => Flag.choice("turns", ["full"] as const)),
     Flag.withMetavar("[=full]"),
-    Flag.orElse(() => Flag.boolean("turns")),
 );
 
 /** Exported for the help-copy test: keeps the advertised flag forms


### PR DESCRIPTION
Fixes #686. Dogfood follow-up to #678 before cutting 0.38.0.

`Flag.choice("turns",["full"]).orElse(Flag.boolean("turns"))` presented the choice branch's non-boolean spec to the tokenizer's `consumeFlagValue`, so a bare `--turns` never received the implicit boolean "true" and resolved to the absent-default `false` — the exact form the retro brief tells reviewers to run. Boolean-first fixes it: bare `--turns` → excerpt mode, inline `--turns=full` still reaches the choice branch.

Verified against the real CLI: bare `--turns` → 812 excerpt turns + "## Turns" section renders; `--turns=full` → full text (was: no `turns` key at all). Unit test updated with the real lexed shapes and a comment on why this seam can't catch the composition bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)