### PR TITLE
fix(dashboard): echo preflight requested headers - last desktop blocker (#690)

### DIFF
--- a/apps/axctl/src/dashboard/server.test.ts
+++ b/apps/axctl/src/dashboard/server.test.ts
@@ -45,6 +45,17 @@ describe("studio CORS / Private Network Access", () => {
         expect(res.headers.get("access-control-allow-origin")).toBe("ax://studio");
     });
 
+    test("preflight echoes the requested headers (traceparent etc), default content-type", async () => {
+        const withHeaders = await handleDashboardRequestWithCors(preflight({
+            origin: "ax://studio",
+            "access-control-request-headers": "content-type,traceparent",
+        }));
+        expect(withHeaders.headers.get("access-control-allow-headers")).toBe("content-type,traceparent");
+
+        const without = await handleDashboardRequestWithCors(preflight({ origin: "ax://studio" }));
+        expect(without.headers.get("access-control-allow-headers")).toBe("content-type");
+    });
+
     test("other custom-scheme origins stay disallowed", async () => {
         const res = await handleDashboardRequestWithCors(preflight({ origin: "ax://evil" }));
         expect(res.headers.get("access-control-allow-origin")).toBeNull();

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -142,13 +142,21 @@ function isLocalDevOrigin(origin: string): boolean {
     return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
 }
 
-function corsHeadersFor(origin: string | null): Record<string, string> {
+function corsHeadersFor(origin: string | null, requestedHeaders?: string | null): Record<string, string> {
     if (!origin) return {};
     if (!STUDIO_ORIGINS.has(origin) && !isLocalDevOrigin(origin)) return {};
     return {
         "Access-Control-Allow-Origin": origin,
         "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-        "Access-Control-Allow-Headers": "content-type",
+        // Echo whatever the preflight asked for. A browser fails the preflight
+        // when ANY requested header is missing from the allow list, and the
+        // desktop studio's Effect HttpClient adds tracing headers (traceparent)
+        // beyond content-type - a static list silently killed every desktop
+        // request AFTER a passing-looking 204 (#690). No credentials on this
+        // loopback-only API, so echoing is safe.
+        "Access-Control-Allow-Headers": requestedHeaders && requestedHeaders.length > 0
+            ? requestedHeaders
+            : "content-type",
         "Access-Control-Max-Age": "600",
         "Vary": "Origin",
     };
@@ -161,7 +169,7 @@ export async function handleDashboardRequestWithCors(
     contract: ContractWebHandler | null = null,
 ): Promise<Response> {
     const origin = req.headers.get("origin");
-    const cors = corsHeadersFor(origin);
+    const cors = corsHeadersFor(origin, req.headers.get("access-control-request-headers"));
 
     if (req.method === "OPTIONS") {
         // Chrome's Private Network Access: an HTTPS page (the hosted studio at


### PR DESCRIPTION
Follow-up to #691. Preflight 204 looked fine but omitted `traceparent` from Allow-Headers, so the browser failed the preflight and every desktop request died after it. Echo `Access-Control-Request-Headers` (loopback-only, no credentials); default stays `content-type`. Tested: echo + default + disallowed origins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)