### PR TITLE
chore(studio-desktop): v0.2.0

### DIFF
--- a/apps/studio-desktop/package.json
+++ b/apps/studio-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ax/studio-desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "ax studio desktop app - Electron shell that supervises surreal + ax serve and renders the studio SPA.",


### PR DESCRIPTION
Version bump so `studio-desktop-v0.2.0` can be tagged - first desktop release carrying the #690 fix chain (#615/#619/#691/#693). Tag pushed after merge triggers the signed+notarized DMG/ZIP + latest-mac.yml publish to the R2 updater feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)