### PR TITLE
fix(studio-desktop): tsdown config satisfies UserConfig (unblocks studio-desktop-v0.2.0)

### DIFF
--- a/apps/studio-desktop/tsdown.config.ts
+++ b/apps/studio-desktop/tsdown.config.ts
@@ -30,7 +30,7 @@ const shared = {
     inputOptions: {
         moduleTypes: { ".surql": "text" },
     },
-} as const;
+} satisfies Partial<import("tsdown").UserConfig>;
 
 export default defineConfig([
     {


### PR DESCRIPTION
The studio-desktop-v0.2.0 release verify gate failed: my as-const in tsdown.config.ts froze `external` as readonly, rejected by tsdown's ExternalOption — caught by the package's own tsc, which the root typecheck doesn't sweep. `satisfies UserConfig` keeps literal checking without readonly widening. Package tsc exit 0; preload build gate green. Will delete + re-push the studio-desktop-v0.2.0 tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)