### PR TITLE
docs(dispatches): #698 pin-mismatch investigation - known model-drop, attribution correct

### DIFF
--- a/docs/investigations/698-pin-mismatch.md
+++ b/docs/investigations/698-pin-mismatch.md
@@ -1,0 +1,130 @@
+# #698 - dispatch `!` pin mismatches: known model-drop, not a pin bug
+
+**Date:** 2026-07-16
+**Verdict:** **Known model-drop - ax attribution is CORRECT.** No CC pin bug, no ax attribution bug.
+**Method:** read-only `ax dispatches --days=14 --json` against the live DB + raw child/parent transcript inspection under `~/.claude/projects/`. No ingest, no DB writes.
+
+## Question
+
+`ax dispatches --days=14` shows rows with `dispatch_model: sonnet` but `child_model: !claude-fable-5`
+($16–29 each). Were these the documented harness drop (first leg honored the pin, continuation legs
+fell back), or something new - a child that NEVER ran sonnet (ax attribution error, or a real Claude
+Code pin bug)?
+
+## Answer
+
+The documented drop, on all six rows. The pin **was** honored: each child starts on
+`claude-sonnet-5` and switches to `claude-fable-5` - the **parent's own model** - on the first
+`SendMessage` continuation. ax's per-leg accounting reproduces the transcript exactly.
+
+## The six mismatch rows (14d window, all `dispatch_model: sonnet` → `child_model: claude-fable-5`)
+
+| ts (UTC) | description | child session | sonnet turns | fable turns | child_cost | dropped_cost |
+|---|---|---|---|---|---|---|
+| 2026-07-12T03:58:41 | Implement Task 5: reconcile lock | `a2c40fe74f3aca4dc` | 85 | 35 | $28.79 | $13.97 |
+| 2026-07-10T10:25:05 | Implement Task 4 pipeline | `a1cebf8bbcbdc4c91` | 91 | 40 | $27.73 | $13.64 |
+| 2026-07-12T03:12:26 | Implement Task 2: executor throwing | `a24a0d20ab9b96bb7` | 97 | 22 | $26.60 | $6.94 |
+| 2026-07-10T10:07:11 | Implement Task 2 SpeechEngine | `aef8229eb86e0f6a5` | 40 | 89 | $22.37 | $16.72 |
+| 2026-07-12T02:56:19 | Implement Task 3: pipeline handler | `afa509dc1c249bdc3` | 88 | 22 | $17.82 | $5.97 |
+| 2026-07-04T09:37:46 | Implement Task 3: v1 bindings | `a09ebf7c88379859e` | 70 | 30 | $15.98 | $6.70 |
+
+**The structural tell:** every one of the six carries **both** a sonnet leg and a fable leg. A genuine
+pin failure would produce a fable-**only** child (no sonnet leg at all). None of the six looks like that.
+
+## Transcript evidence (2 of 6 verified at the raw-message level)
+
+### Row 1 - "Implement Task 5: reconcile lock"
+
+- Parent: `6c68b846-1d0b-4e21-9e99-a3c7339eeff5` (ran `claude-fable-5`, 180 msgs)
+- Parent's dispatch call `toolu_013RnnsNadc4ghMeAmELTt6d`:
+  `{ name: "Agent", model: "sonnet", subagent_type: "general-purpose" }` - **pin was sent**
+- Child: `subagents/agent-a2c40fe74f3aca4dc.jsonl`, 120 assistant messages, one single transition:
+
+```
+msg   1: 2026-07-12T03:58:43.316Z  ->  claude-sonnet-5     # pin HONORED
+msg  86: 2026-07-12T04:12:30.671Z  ->  claude-fable-5      # drop
+```
+
+Trigger, 7s before the switch - no compact boundary anywhere in the child:
+
+```
+2026-07-12T04:12:23.212Z  user       The coordinator sent a message while you were working:\nRevie…
+2026-07-12T04:12:30.671Z  assistant  claude-fable-5
+```
+
+Per-model counts: 85 `claude-sonnet-5`, 35 `claude-fable-5` - **identical** to ax's `child_legs`.
+
+### Row 4 - "Implement Task 2 SpeechEngine" (different project, different day)
+
+- Parent: `470fc362-f81f-4556-9bd9-adbd186daa8b` (ran `claude-fable-5`, 425 msgs)
+- Dispatch call `toolu_017qZbohxzbvDFkd1Tke38wf`: `{ model: "sonnet", description: "Implement Task 2 SpeechEngine" }`
+- Child `agent-aef8229eb86e0f6a5.jsonl`:
+
+```
+msg   1: 2026-07-10T10:07:14.351Z  ->  claude-sonnet-5
+msg  41: 2026-07-10T10:15:29.998Z  ->  claude-fable-5   (coordinator SendMessage at 10:15:22.948Z)
+```
+
+Per-model counts: 40 sonnet / 89 fable - again **identical** to ax's `child_legs`.
+
+## Mechanism
+
+The drop target is not arbitrary: in both cases the child continues on **the parent session's model**
+(`claude-fable-5`), which is what "the harness drops the Agent `model` override on
+SendMessage/compact continuations" predicts. Here the trigger is specifically **SendMessage**
+(`"The coordinator sent a message while you were working:"`); neither child contains a compact
+boundary. A second SendMessage later in row 4 (11:32:42) does not switch anything back - once
+dropped, the child stays on the parent's model for the rest of the run.
+
+Cost consequence is real: $128.18 across 42 dropped dispatches in the window (`dropped_cost_usd`),
+i.e. work that was routed to sonnet and billed at frontier rates after the first continuation.
+
+## Why no code change
+
+- **Attribution is correct.** `child_legs` turn counts match the transcripts exactly on both sampled
+  sessions; `model_dropped` fires on precisely the rows where a leg ran off-pin.
+- **The output does not mislead.** The existing footer in `apps/axctl/src/cli/commands/ax-dispatches.ts:281-287`
+  already states it: *"N routed dispatches continued on a different model ($X on dropped legs, marked
+  "!") - the harness drops the model override on SendMessage/compact continuations."* The `!` marker plus
+  that footer is an accurate account of what the transcripts show. A row-level footnote would restate it.
+- The one arguable gap - `child_model` names only the drop target (fable), not the majority model
+  (sonnet ran 85/120 turns in row 1) - is what `!` + `child_legs` in `--json` exist to express. Not
+  worth a schema/UX change on this evidence.
+
+**Falsifier:** a `!` row whose `child_legs` contain **no** leg matching `dispatch_model` would be a real
+pin failure (child never honored the pin). None of the six is that. Worth re-checking if a fable-only
+child ever appears.
+
+## Separate finding: `claude-sonnet-5` is unpriced → $0 (NOT #698, worth its own issue)
+
+Chasing why every sonnet leg above reports `cost_usd: 0` surfaced an unrelated and larger bug.
+
+`ax cost models --days=14` on this machine:
+
+```
+claude-sonnet-5   572 sessions   1,999,887,365 prompt   7,300,585 completion   1,866,502,376 cache_read   $0.0000
+claude-sonnet-4-6  11 sessions      13,361,274 prompt      58,557 completion      11,725,611 cache_read  $10.4728
+```
+
+**Root cause:** `apps/axctl/src/ingest/model-pricing.ts` - `BUILTIN_MODEL_PRICING_CATALOG` has no
+`claude-sonnet-5` key, and the family fallback (lines 413-416) only covers
+`claude-fable-5` / `claude-haiku-4-5` / `claude-opus-4` / `claude-sonnet-4`:
+
+```ts
+if (modelKey.startsWith("claude-fable-5"))  return catalog.get("claude-fable-5")  ?? null;
+if (modelKey.startsWith("claude-haiku-4-5")) return catalog.get("claude-haiku-4-5") ?? null;
+if (modelKey.startsWith("claude-opus-4"))   return catalog.get("claude-opus-4")   ?? null;
+if (modelKey.startsWith("claude-sonnet-4")) return catalog.get("claude-sonnet-4") ?? null;
+// claude-sonnet-5 matches nothing -> null -> estimated_cost_usd = 0
+```
+
+`claude-sonnet-4-6` prices only because it prefix-matches `claude-sonnet-4`. `claude-sonnet-5` matches
+nothing. Same gap for `gpt-5.6-sol` (168 sessions, 766M prompt tokens, $0), `gpt-5.6-luna`, `gpt-5.6-terra`.
+
+**Blast radius:** every cost surface that reads `estimated_cost_usd` understates sonnet-5 and gpt-5.6
+spend as zero - `ax cost models`, `cost split`, `cost routability`, `dispatches`. It also makes
+route-to-sonnet look free, which flatters exactly the routing decisions ax is meant to measure.
+
+**Not fixed here, deliberately:** the fix is a pricing-catalog change whose effect only lands on
+re-ingest/backfill, and this investigation is scoped read-only (no ingest, no DB writes) - so it could
+not be verified in this worktree. Filed as a follow-up instead.

--- a/docs/superpowers/plans/2026-07-16-698-pin-mismatch.md
+++ b/docs/superpowers/plans/2026-07-16-698-pin-mismatch.md
@@ -1,0 +1,147 @@
+# 698 Dispatch Pin-Mismatch Investigation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Determine whether `ax dispatches` rows showing `dispatch_model: sonnet` / `child_model: !claude-fable-5` are the known harness model-drop (attribution correct), an ax attribution bug, or a live Claude Code pin bug - and land the evidence.
+
+**Architecture:** Investigation-first. Read the live DB read-only via `bin/axctl`, then corroborate against raw child-session JSONL under `~/.claude/projects/`. Ground truth = per-message `model` ids in the child transcript vs the `model` param on the parent's Agent dispatch call. Code changes ONLY if the transcript contradicts ax's attribution.
+
+**Tech Stack:** bun, TypeScript, SurrealDB (read-only), `bin/axctl` shim, `gh` CLI, bun:test (only if a fix ships).
+
+## Global Constraints
+
+- Read-only on the live DB and transcripts. NEVER run ingest, NEVER write to the DB, NEVER restart the daemon/DB (studio.app owns them on this machine).
+- All work happens in `/Users/necmttn/Projects/ax/.claude/worktrees/698-fix`. `pwd` must match before any git command. Never commit in the primary checkout.
+- Tests are **bun:test**, not vitest.
+- Gate before done: `bun run typecheck` exits 0 (real exit code, unpiped).
+- One conventional commit via `git add -A ':!BRIEF.md' ':!REPORT.md'`. Do NOT push, open a PR, or merge.
+- Final mandatory signal line appended to `/tmp/fleet-dogfood-0716.signals`.
+
+---
+
+### Task 1: Pull the mismatch rows from the live DB
+
+**Files:**
+- Read-only: `apps/axctl/bin/axctl` (invocation), no edits.
+
+**Interfaces:**
+- Produces: the set of mismatch rows - `session_id` (child), parent session id, `agent_type`, `description`, `dispatch_model`, `child_model`, `child_legs[]`, `model_dropped`, `dropped_cost_usd`, `child_cost_usd`, `ts`. Tasks 2-3 consume these ids.
+
+- [ ] **Step 1: Dump the JSON**
+
+```bash
+cd /Users/necmttn/Projects/ax/.claude/worktrees/698-fix
+./apps/axctl/bin/axctl dispatches --days=14 --json > /private/tmp/claude-501/-Users-necmttn-Projects-ax--claude-worktrees-698-fix/ac0e1c8b-4708-46dd-843c-1c58aec82c60/scratchpad/dispatches.json
+```
+
+Expected: valid JSON array, exit 0. If the DB is unreachable, STOP and report BLOCKED (never start the DB).
+
+- [ ] **Step 2: Filter to mismatch rows**
+
+```bash
+jq '[.[] | select(.model_dropped == true or (.dispatch_model != null and .child_model != null and (.child_model | contains(.dispatch_model)) == false))]' dispatches.json
+```
+
+Expected: the ~6 rows named in #698 (e.g. "Implement Task 5: reconcile lock" 2026-07-12, "Implement Task 2 SpeechEngine" 2026-07-10). Record `child_legs` per row - this is ax's claim about which model ran which leg.
+
+- [ ] **Step 3: Read the attribution source**
+
+Read the dispatches query (`apps/axctl/src/queries/`) to learn exactly how `child_model`, `child_legs`, and `model_dropped` are derived (which table, which column, first-leg vs max-cost-leg selection). This is what Task 3 judges against.
+
+---
+
+### Task 2: Corroborate against the raw child transcripts
+
+**Files:**
+- Read-only: `~/.claude/projects/<slug>/<child-session-id>.jsonl` (1-2 mismatch sessions), parent session JSONL.
+
+**Interfaces:**
+- Consumes: child + parent session ids from Task 1.
+- Produces: ordered list of distinct `model` ids across the child transcript (first assistant message vs later ones), and the parent's Agent tool-call `model` param.
+
+- [ ] **Step 1: Locate the child transcript**
+
+```bash
+rg -l "<child-session-id>" ~/.claude/projects/ --glob '*.jsonl'
+```
+
+- [ ] **Step 2: Extract per-message model ids in order**
+
+```bash
+jq -r 'select(.message.model != null) | [.timestamp, .message.model] | @tsv' <child>.jsonl
+```
+
+Expected: either `claude-sonnet-*` first then `claude-fable-5` later (known drop), or `claude-fable-5` from the very first assistant message (live pin bug).
+
+- [ ] **Step 3: Extract the parent's dispatch call**
+
+```bash
+jq -r 'select(.message.content[]?.name? == "Task" or .message.content[]?.name? == "Agent") | .message.content' <parent>.jsonl
+```
+
+Expected: the Agent tool `input` containing `model` (the pin) and `description` matching the mismatch row.
+
+- [ ] **Step 4: Cross-check leg boundaries**
+
+Confirm whether the model switch coincides with a SendMessage/compact continuation (look for compact/summary markers or a resumed leg near the switch timestamp). This distinguishes the documented drop from a fresh pin failure.
+
+---
+
+### Task 3: Verdict + findings doc + issue comment
+
+**Files:**
+- Create: `docs/investigations/698-pin-mismatch.md`
+- Conditional (ONLY if attribution is wrong): the dispatches query under `apps/axctl/src/queries/` + its bun:test suite.
+
+**Interfaces:**
+- Consumes: Task 1 rows, Task 2 transcript evidence.
+
+- [ ] **Step 1: Pick exactly one verdict**
+
+- **Known model-drop** - child's first leg ran the pinned model, continuation legs ran fable → ax attribution CORRECT. Deliverable: doc + issue comment with evidence; propose a footnote clarifying `!` semantics only if the current output genuinely misleads.
+- **ax attribution bug** - child ran the pinned model throughout but ax reports fable → fix the query under TDD (failing bun:test asserting the real observable `ax dispatches` output first - do NOT mock the code path the fix is named after; mock only non-deterministic leaves).
+- **CC harness bug** - parent sent `model: sonnet`, child's FIRST leg already fable → draft an upstream escalation in the issue comment (evidence: dispatch call + transcript model ids) and note "any new `!` row after 2026-07-16 = live bug".
+
+- [ ] **Step 2: Write the findings doc**
+
+`docs/investigations/698-pin-mismatch.md` contains: the question, method, the mismatch rows table (session id, ts, description, dispatch_model, child_model, legs, cost), the per-leg transcript model ids for the sampled sessions, the verdict, and what would falsify it.
+
+- [ ] **Step 3: Gate**
+
+```bash
+cd /Users/necmttn/Projects/ax/.claude/worktrees/698-fix
+bun run typecheck
+echo "typecheck exit: $?"
+```
+
+Expected: exit 0. If code changed, also run the touched bun:test suites (skip live-DB e2e suites, note them).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/necmttn/Projects/ax/.claude/worktrees/698-fix
+git add -A ':!BRIEF.md' ':!REPORT.md'
+git commit -m "docs(dispatches): investigate #698 pin mismatches"
+```
+
+- [ ] **Step 5: Post the issue comment**
+
+```bash
+gh issue comment 698 --repo Necmttn/ax --body-file <verdict.md>
+```
+
+- [ ] **Step 6: Signal (mandatory, last, even on failure)**
+
+```bash
+echo "$(date -Iseconds) 698-pin-mismatch DONE|BLOCKED|ERROR <one-line gist>" >> /tmp/fleet-dogfood-0716.signals
+```
+
+On BLOCKED/ERROR also write detail + what is needed into `REPORT.md` at the worktree root.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Brief steps 1-4 map to Tasks 1, 2, 3 respectively; constraints (read-only, bun:test, worktree, gates, commit, signal) are in Global Constraints + Task 3.
+- **Placeholders:** verdict branches are conditional by design (the investigation decides which fires); no code steps are stubbed - the only code path is gated on the "ax attribution bug" verdict, whose test shape is specified (real observable output, seam rule).
+- **Type consistency:** field names (`dispatch_model`, `child_model`, `child_legs`, `model_dropped`, `dropped_cost_usd`) are taken verbatim from the `--json` contract documented in CLAUDE.md.


### PR DESCRIPTION
Closes #698.

Investigation verdict: all six `dispatch_model: sonnet` / `child_model: !claude-fable-5` rows are the documented harness model-drop — the pin WAS honored (child starts on sonnet-5, falls back to the parent's model on the first SendMessage continuation). ax attribution is correct; no code change. Full evidence (message-level verification on 2/6 children, per-leg turn counts on all 6) in `docs/investigations/698-pin-mismatch.md`; verdict also posted on the issue.

Falsifier for the future: a `!` row with NO leg matching `dispatch_model` = real pin failure.

## Deferred concerns
- sonnet-5 / gpt-5.6 pricing gap the investigation surfaced is #696 (fix in flight this fleet run).
- `gpt-5.6-terra` also unpriced (2 sessions) — covered by #696's UNPRICED marker.

Fleet run: dogfood-0716 (map #699).

🤖 Generated with [Claude Code](https://claude.com/claude-code)