### PR TITLE
fix(cost): price sonnet-5/gpt-5.6 + UNPRICED marker + query-time recompute (#696)

### DIFF
--- a/apps/axctl/src/cli/commands/ax-cost.test.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.test.ts
@@ -3,10 +3,12 @@ import {
     COST_SESSIONS_LEGEND,
     renderCostModelsTable,
     renderCostSessionsTable,
+    renderCostSplitTable,
 } from "./ax-cost.ts";
 import type {
     CostModelsResult,
     CostSessionsResult,
+    CostSplitResult,
 } from "../../queries/cost-analytics.ts";
 
 describe("renderCostModelsTable", () => {
@@ -22,6 +24,7 @@ describe("renderCostModelsTable", () => {
                     cache_read_tokens: 14_781_735_443,
                     cache_create_tokens: 361_331_748,
                     cost_usd: 10_999.397,
+                    unpriced: false,
                 },
             ],
         };
@@ -33,6 +36,57 @@ describe("renderCostModelsTable", () => {
         expect(out).toContain("$10999.3970");
         expect(out).not.toContain("14,781,735,4 ");
         expect(out).not.toContain("$10999.397\n");
+    });
+
+    test("renders an unknown model as UNPRICED at the rollup seam", () => {
+        const result: CostModelsResult = {
+            total_cost_usd: 0,
+            rows: [{
+                model: "unknown-model",
+                sessions: 1,
+                prompt_tokens: 1_000_000,
+                completion_tokens: 0,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 0,
+                unpriced: true,
+            }],
+        };
+
+        expect(renderCostModelsTable(result)).toContain("UNPRICED");
+    });
+});
+
+describe("renderCostSplitTable", () => {
+    test("renders an unknown model cell as UNPRICED", () => {
+        const result = {
+            rows: [{
+                origin: "main",
+                model: "unknown-model",
+                sessions: 1,
+                prompt_tokens: 1_000_000,
+                completion_tokens: 0,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 0,
+                share_pct: 0,
+                unpriced: true,
+            }],
+            totals: {
+                sessions: 1,
+                prompt_tokens: 1_000_000,
+                completion_tokens: 0,
+                cache_read_tokens: 0,
+                cache_create_tokens: 0,
+                cost_usd: 0,
+            },
+            contentTypes: {
+                rows: [],
+                totals: { calls: 0, bytes: 0, estTokens: 0 },
+            },
+        } satisfies CostSplitResult;
+
+        expect(renderCostSplitTable(result)).toContain("UNPRICED");
     });
 });
 

--- a/apps/axctl/src/cli/commands/ax-cost.ts
+++ b/apps/axctl/src/cli/commands/ax-cost.ts
@@ -15,6 +15,7 @@ import {
     fetchCostSplit,
     type CostModelsResult,
     type CostSessionsResult,
+    type CostSplitResult,
 } from "../../queries/cost-analytics.ts";
 import { fetchRoutability, type RoutabilityResult } from "../../queries/routability.ts";
 import { fetchImageContext } from "../../queries/image-context.ts";
@@ -50,7 +51,7 @@ export function renderCostModelsTable(result: CostModelsResult): string {
         completion: integer(r.completion_tokens),
         cache_read: integer(r.cache_read_tokens),
         cache_create: integer(r.cache_create_tokens),
-        cost: usd(r.cost_usd),
+        cost: r.unpriced ? "UNPRICED" : usd(r.cost_usd),
     }));
 
     const cols: Column<ModelRow>[] = [
@@ -209,6 +210,57 @@ const costSessionsCommand = Command.make(
 // ax cost split [--days=N] [--json]
 // ---------------------------------------------------------------------------
 
+export function renderCostSplitTable(result: CostSplitResult): string {
+    type SplitRow = {
+        origin: string;
+        model: string;
+        sessions: string;
+        prompt: string;
+        completion: string;
+        cost: string;
+        share: string;
+    };
+
+    const rendered: SplitRow[] = result.rows.map((r) => ({
+        origin: r.origin,
+        model: r.model,
+        sessions: integer(r.sessions),
+        prompt: integer(r.prompt_tokens),
+        completion: integer(r.completion_tokens),
+        cost: r.unpriced ? "UNPRICED" : usd(r.cost_usd),
+        share: pct(r.share_pct),
+    }));
+
+    const t = result.totals;
+    const footer: FooterLine[] = [
+        {
+            cells: [
+                "TOTAL",
+                null,
+                integer(t.sessions),
+                integer(t.prompt_tokens),
+                integer(t.completion_tokens),
+                usd(t.cost_usd),
+                "100.0%",
+            ],
+        },
+    ];
+
+    const modelW = Math.max(20, ...result.rows.map((r) => r.model.length));
+
+    const cols: Column<SplitRow>[] = [
+        { header: "origin", get: (r) => r.origin, width: 8 },
+        { header: "model", get: (r) => r.model, min: modelW },
+        { header: "sessions", get: (r) => r.sessions, align: "right", width: 8 },
+        { header: "prompt", get: (r) => r.prompt, align: "right", width: 14 },
+        { header: "completion", get: (r) => r.completion, align: "right", width: 14 },
+        { header: "cost", get: (r) => r.cost, align: "right", width: 10, footerRule: true },
+        { header: "share", get: (r) => r.share, align: "right", width: 7, footerRule: true },
+    ];
+
+    return renderTable({ columns: cols, rows: rendered, gap: " ", footer });
+}
+
 const cmdCostSplit = (input: {
     readonly sinceDays: number;
     readonly json: boolean;
@@ -221,61 +273,13 @@ const cmdCostSplit = (input: {
             return;
         }
 
-        if (result.totals.cost_usd === 0) {
+        if (result.rows.length === 0) {
             console.log("(no cost data in the requested window)");
             return;
         }
 
         printNextLinks(buildCostSplitNext(result));
-
-        type SplitRow = {
-            origin: string;
-            model: string;
-            sessions: string;
-            prompt: string;
-            completion: string;
-            cost: string;
-            share: string;
-        };
-
-        const rendered: SplitRow[] = result.rows.map((r) => ({
-            origin: r.origin,
-            model: r.model,
-            sessions: integer(r.sessions),
-            prompt: integer(r.prompt_tokens),
-            completion: integer(r.completion_tokens),
-            cost: usd(r.cost_usd),
-            share: pct(r.share_pct),
-        }));
-
-        const t = result.totals;
-        const footer: FooterLine[] = [
-            {
-                cells: [
-                    "TOTAL",
-                    null,
-                    integer(t.sessions),
-                    integer(t.prompt_tokens),
-                    integer(t.completion_tokens),
-                    usd(t.cost_usd),
-                    "100.0%",
-                ],
-            },
-        ];
-
-        const modelW = Math.max(20, ...result.rows.map((r) => r.model.length));
-
-        const cols: Column<SplitRow>[] = [
-            { header: "origin", get: (r) => r.origin, width: 8 },
-            { header: "model", get: (r) => r.model, min: modelW },
-            { header: "sessions", get: (r) => r.sessions, align: "right", width: 8 },
-            { header: "prompt", get: (r) => r.prompt, align: "right", width: 14 },
-            { header: "completion", get: (r) => r.completion, align: "right", width: 14 },
-            { header: "cost", get: (r) => r.cost, align: "right", width: 10, footerRule: true },
-            { header: "share", get: (r) => r.share, align: "right", width: 7, footerRule: true },
-        ];
-
-        console.log(renderTable({ columns: cols, rows: rendered, gap: " ", footer }));
+        console.log(renderCostSplitTable(result));
         console.log(`\n(${input.sinceDays} days)`);
     });
 

--- a/apps/axctl/src/ingest/derive-cost-backfill.test.ts
+++ b/apps/axctl/src/ingest/derive-cost-backfill.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { deriveCostBackfill } from "./derive-cost-backfill.ts";
+import { MODEL_PRICING_SOURCE } from "./model-pricing.ts";
 
 interface UsageRowFixture {
     readonly id: string;
@@ -60,7 +61,7 @@ describe("deriveCostBackfill", () => {
         // 1M estimated tokens × claude-opus-4-5 input $5/M (byte-estimate rows
         // price the whole count at the input rate - honest lower bound).
         expect(stmt).toContain("estimated_cost_usd = 5.00000000");
-        expect(stmt).toContain('pricing_source = "estimated:built_in_catalog_2026-06-10"');
+        expect(stmt).toContain(`pricing_source = "estimated:${MODEL_PRICING_SOURCE}"`);
         // Race guard: a concurrently ingest-priced cost wins at write time.
         expect(stmt).toContain("WHERE estimated_cost_usd IS NONE");
     });

--- a/apps/axctl/src/ingest/model-pricing.test.ts
+++ b/apps/axctl/src/ingest/model-pricing.test.ts
@@ -108,6 +108,29 @@ describe("model pricing", () => {
         });
     });
 
+    it("prices claude-sonnet-5 and GPT-5.6 Sol/Luna from the built-in catalog", () => {
+        const catalog = builtInPricingCatalog();
+
+        expect(pricingForModel("claude-sonnet-5", catalog)).toMatchObject({
+            inputPerMillionUsd: 3,
+            outputPerMillionUsd: 15,
+            cacheCreationPerMillionUsd: 3.75,
+            cacheReadPerMillionUsd: 0.3,
+        });
+        expect(pricingForModel("gpt-5.6-sol", catalog)).toMatchObject({
+            inputPerMillionUsd: 5,
+            outputPerMillionUsd: 30,
+            cacheCreationPerMillionUsd: 6.25,
+            cacheReadPerMillionUsd: 0.5,
+        });
+        expect(pricingForModel("gpt-5.6-luna", catalog)).toMatchObject({
+            inputPerMillionUsd: 1,
+            outputPerMillionUsd: 6,
+            cacheCreationPerMillionUsd: 1.25,
+            cacheReadPerMillionUsd: 0.1,
+        });
+    });
+
     it("does not normalize provider names into model IDs", () => {
         expect(normalizeModelName("openai")).toBeNull();
         expect(normalizeModelName("anthropic")).toBeNull();

--- a/apps/axctl/src/ingest/model-pricing.test.ts
+++ b/apps/axctl/src/ingest/model-pricing.test.ts
@@ -225,16 +225,18 @@ describe("model pricing", () => {
         });
     });
 
-    it("approximates gpt-5.6 variants at the gpt-5.5 tier", () => {
+    it("approximates gpt-5.6 variants WITHOUT an exact row at the gpt-5.5 tier", () => {
         const catalog = builtInPricingCatalog();
 
-        expect(pricingForModel("gpt-5.6-sol", catalog)).toMatchObject({
+        // sol/luna carry exact verified rates (see the catalog test above);
+        // the tier approximation only covers variants with no entry yet.
+        expect(pricingForModel("gpt-5.6-terra", catalog)).toMatchObject({
             inputPerMillionUsd: 5,
             outputPerMillionUsd: 30,
         });
         expect(pricingForModel("gpt-5.6-luna", catalog)).toMatchObject({
-            inputPerMillionUsd: 5,
-            outputPerMillionUsd: 30,
+            inputPerMillionUsd: 1,
+            outputPerMillionUsd: 6,
         });
     });
 

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -436,8 +436,9 @@ export function pricingForModel(
     if (!modelKey) return null;
     const exact = catalog.get(modelKey);
     if (exact) return exact;
-    // gpt-5.6 variants (sol/luna) have no published rates yet - approximate at the gpt-5.5 tier
-    // rather than pricing them $0 (see issue #696). Must precede the generic gpt-5.x rule.
+    // sol/luna carry exact verified rates above (exact match wins); other
+    // gpt-5.6 variants (e.g. terra) approximate at the gpt-5.5 tier rather
+    // than pricing $0 (issue #696). Must precede the generic gpt-5.x rule.
     if (/^gpt-5\.6(?:-|$)/i.test(modelKey)) return catalog.get("gpt-5.5") ?? catalog.get("gpt-5") ?? null;
     if (/^gpt-5(?:\.\d+)?$/i.test(modelKey)) return catalog.get("gpt-5") ?? null;
     if (modelKey.startsWith("claude-fable-5")) return catalog.get("claude-fable-5") ?? null;

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -13,7 +13,7 @@ import type { StageDef } from "./stage/registry.ts";
 const LITELLM_PRICING_URL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 const MODELS_DEV_API_URL = "https://models.dev/api.json";
 
-export const MODEL_PRICING_SOURCE = "built_in_catalog_2026-06-10";
+export const MODEL_PRICING_SOURCE = "built_in_catalog_2026-07-16";
 
 export interface ModelPricing {
     readonly provider: string;
@@ -159,6 +159,24 @@ export const BUILTIN_MODEL_PRICING_CATALOG: Readonly<Record<string, ModelPricing
         fastMultiplier: 2.5,
         pricingSource: MODEL_PRICING_SOURCE,
     },
+    "gpt-5.6-sol": {
+        provider: "openai",
+        inputPerMillionUsd: 5,
+        outputPerMillionUsd: 30,
+        cacheCreationPerMillionUsd: 6.25,
+        cacheReadPerMillionUsd: 0.5,
+        fastMultiplier: 1,
+        pricingSource: MODEL_PRICING_SOURCE,
+    },
+    "gpt-5.6-luna": {
+        provider: "openai",
+        inputPerMillionUsd: 1,
+        outputPerMillionUsd: 6,
+        cacheCreationPerMillionUsd: 1.25,
+        cacheReadPerMillionUsd: 0.1,
+        fastMultiplier: 1,
+        pricingSource: MODEL_PRICING_SOURCE,
+    },
     "gpt-5-mini": {
         provider: "openai",
         inputPerMillionUsd: 0.25,
@@ -259,6 +277,15 @@ export const BUILTIN_MODEL_PRICING_CATALOG: Readonly<Record<string, ModelPricing
         pricingSource: MODEL_PRICING_SOURCE,
     },
     "claude-sonnet-4": {
+        provider: "anthropic",
+        inputPerMillionUsd: 3,
+        outputPerMillionUsd: 15,
+        cacheCreationPerMillionUsd: 3.75,
+        cacheReadPerMillionUsd: 0.3,
+        fastMultiplier: 1,
+        pricingSource: MODEL_PRICING_SOURCE,
+    },
+    "claude-sonnet-5": {
         provider: "anthropic",
         inputPerMillionUsd: 3,
         outputPerMillionUsd: 15,
@@ -414,6 +441,7 @@ export function pricingForModel(
     if (modelKey.startsWith("claude-haiku-4-5")) return catalog.get("claude-haiku-4-5") ?? null;
     if (modelKey.startsWith("claude-opus-4")) return catalog.get("claude-opus-4") ?? null;
     if (modelKey.startsWith("claude-sonnet-4")) return catalog.get("claude-sonnet-4") ?? null;
+    if (modelKey.startsWith("claude-sonnet-5")) return catalog.get("claude-sonnet-5") ?? null;
     return null;
 }
 

--- a/apps/axctl/src/queries/cost-analytics.test.ts
+++ b/apps/axctl/src/queries/cost-analytics.test.ts
@@ -83,6 +83,65 @@ describe("fetchCostModels", () => {
 });
 
 // ---------------------------------------------------------------------------
+// fetchCostModels - #696 follow-up: catalog-vs-stored-cost disagreement
+// (reviewer MUST-FIX) + query-time recompute for pre-existing zero-cost rows
+// (reviewer live-smoke gap) + zero-usage rows never flagged (SHOULD-FIX).
+// ---------------------------------------------------------------------------
+
+describe("fetchCostModels - #696 unpriced/recompute semantics", () => {
+    test("never masks a real nonzero stored cost, even for a model absent from the built-in catalog", async () => {
+        // "db-only-model" is priced ONLY via a DB agent_model refresh (litellm/
+        // models.dev), never in BUILTIN_MODEL_PRICING_CATALOG. The old
+        // isUnpricedModel checked only the built-in catalog and would have
+        // flagged this UNPRICED despite a real stored dollar amount.
+        const dbRows = [
+            { model: "db-only-model", sessions: 1, prompt_tokens: 1_000_000, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 4.25 },
+        ];
+        const db = makeMockDb([[dbRows], [[]]]);
+        const result = await runWithMock(db, fetchCostModels({ sinceDays: 14 }));
+
+        expect(result.rows[0]).toMatchObject({ cost_usd: 4.25, unpriced: false });
+    });
+
+    test("recomputes a stored-zero row from its own token split when the catalog (DB refresh) has a rate", async () => {
+        // Stored cost is 0 (ingested before the model had a rate); the
+        // agent_model DB table now carries a refreshed rate for it. The
+        // query-time resolver must self-heal without waiting for a
+        // derive-cost-backfill re-run.
+        const dbRows = [
+            { model: "custom-model-x", sessions: 1, prompt_tokens: 1_000_000, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0 },
+        ];
+        const agentModelRows = [
+            {
+                name: "custom-model-x", provider: "test",
+                input_per_million_usd: 2, output_per_million_usd: 10,
+                cache_creation_per_million_usd: null, cache_read_per_million_usd: null,
+                fast_multiplier: 1, context_window: null, pricing_source: "litellm",
+            },
+        ];
+        const db = makeMockDb([[dbRows], [agentModelRows]]);
+        const result = await runWithMock(db, fetchCostModels({ sinceDays: 14 }));
+
+        // 1,000,000 prompt tokens * $2/MTok = $2.00
+        expect(result.rows[0]).toMatchObject({ cost_usd: 2, unpriced: false });
+        expect(result.total_cost_usd).toBeCloseTo(2);
+    });
+
+    test("a zero-token row stays $0 and unflagged, even for an unknown model", async () => {
+        const dbRows = [
+            { model: null, sessions: 1, prompt_tokens: 0, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0 },
+        ];
+        const db = makeMockDb([[dbRows], [[]]]);
+        const result = await runWithMock(db, fetchCostModels({ sinceDays: 14 }));
+
+        expect(result.rows[0]).toMatchObject({ cost_usd: 0, unpriced: false });
+    });
+});
+
+// ---------------------------------------------------------------------------
 // fetchCostSessions
 // ---------------------------------------------------------------------------
 
@@ -244,6 +303,65 @@ describe("fetchCostSplit", () => {
 });
 
 // ---------------------------------------------------------------------------
+// fetchCostSplit - #696 follow-up: same catalog-vs-stored-cost + recompute
+// semantics as fetchCostModels, but must also flow into totals/share_pct.
+// ---------------------------------------------------------------------------
+
+describe("fetchCostSplit - #696 unpriced/recompute semantics", () => {
+    test("never masks a real nonzero stored cost cell absent from the built-in catalog", async () => {
+        const dbRows = [
+            { source: "codex", model: "db-only-model", sessions: 1,
+              prompt_tokens: 100, completion_tokens: 10,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 4.25 },
+        ];
+        const db = makeMockDb([[dbRows], [[]], [[]]]);
+        const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+
+        expect(result.rows[0]).toMatchObject({ cost_usd: 4.25, unpriced: false });
+    });
+
+    test("recomputes a stored-zero cell from its own token split and folds it into totals + share_pct", async () => {
+        const dbRows = [
+            { source: "claude", model: "claude-sonnet-4-8", sessions: 1,
+              prompt_tokens: 0, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 1.0 },
+            { source: "codex", model: "custom-model-x", sessions: 1,
+              prompt_tokens: 1_000_000, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0 },
+        ];
+        const agentModelRows = [
+            {
+                name: "custom-model-x", provider: "test",
+                input_per_million_usd: 2, output_per_million_usd: 10,
+                cache_creation_per_million_usd: null, cache_read_per_million_usd: null,
+                fast_multiplier: 1, context_window: null, pricing_source: "litellm",
+            },
+        ];
+        const db = makeMockDb([[dbRows], [agentModelRows], [[]]]);
+        const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+
+        const recomputed = result.rows.find((r) => r.model === "custom-model-x")!;
+        expect(recomputed).toMatchObject({ cost_usd: 2, unpriced: false });
+        // totals + share must reflect the recomputed dollar amount, not the
+        // stale stored 0.
+        expect(result.totals.cost_usd).toBeCloseTo(3.0);
+        expect(recomputed.share_pct).toBeCloseTo((2 / 3) * 100);
+    });
+
+    test("a zero-token cell stays $0 and unflagged, even for an unattributed model", async () => {
+        const dbRows = [
+            { source: "claude-subagent", model: null, sessions: 1,
+              prompt_tokens: 0, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0 },
+        ];
+        const db = makeMockDb([[dbRows], [[]], [[]]]);
+        const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+
+        expect(result.rows[0]).toMatchObject({ cost_usd: 0, unpriced: false });
+    });
+});
+
+// ---------------------------------------------------------------------------
 // NaN-guard regression tests (F-graph-toolkit: finite guard via countField)
 // Decision: FIX - NaN propagation in cost/token aggregation silently
 // corrupts downstream sums, sorts, and pct calculations. countField's finite
@@ -299,7 +417,9 @@ describe("fetchCostSplit - contentTypes dimension", () => {
             { ct: "content_type:code", calls: 5, bytes: 400 },
             { ct: "content_type:docs", calls: 2, bytes: 200 },
         ];
-        const db = makeMockDb([[splitRows], [contentTypeRows]]);
+        // Query order: split rows, THEN the pricing-catalog lookup
+        // (loadPricingCatalogForModels), THEN content-type breakdown.
+        const db = makeMockDb([[splitRows], [[]], [contentTypeRows]]);
         const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
 
         expect(result.contentTypes).toBeDefined();
@@ -318,8 +438,8 @@ describe("fetchCostSplit - contentTypes dimension", () => {
                 cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 1.0,
             },
         ];
-        // Empty content-type response
-        const db = makeMockDb([[splitRows], [[]]]);
+        // Empty content-type response (and empty pricing-catalog lookup)
+        const db = makeMockDb([[splitRows], [[]], [[]]]);
         const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
 
         expect(result.contentTypes.rows).toHaveLength(0);

--- a/apps/axctl/src/queries/cost-analytics.test.ts
+++ b/apps/axctl/src/queries/cost-analytics.test.ts
@@ -417,9 +417,10 @@ describe("fetchCostSplit - contentTypes dimension", () => {
             { ct: "content_type:code", calls: 5, bytes: 400 },
             { ct: "content_type:docs", calls: 2, bytes: 200 },
         ];
-        // Query order: split rows, THEN the pricing-catalog lookup
-        // (loadPricingCatalogForModels), THEN content-type breakdown.
-        const db = makeMockDb([[splitRows], [[]], [contentTypeRows]]);
+        // Query order: split rows, then content-type breakdown. The
+        // pricing-catalog lookup is lazy - this all-priced fixture never
+        // triggers it, so no catalog slot in the mock.
+        const db = makeMockDb([[splitRows], [contentTypeRows]]);
         const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
 
         expect(result.contentTypes).toBeDefined();
@@ -438,8 +439,9 @@ describe("fetchCostSplit - contentTypes dimension", () => {
                 cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 1.0,
             },
         ];
-        // Empty content-type response (and empty pricing-catalog lookup)
-        const db = makeMockDb([[splitRows], [[]], [[]]]);
+        // Empty content-type response; cost_usd > 0 so the lazy
+        // pricing-catalog lookup never fires (extra empty slot unused).
+        const db = makeMockDb([[splitRows], [[]]]);
         const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
 
         expect(result.contentTypes.rows).toHaveLength(0);

--- a/apps/axctl/src/queries/cost-analytics.test.ts
+++ b/apps/axctl/src/queries/cost-analytics.test.ts
@@ -39,6 +39,27 @@ describe("fetchCostModels", () => {
         expect(result.rows[0]!.model).toBe("(unattributed)");
     });
 
+    test("flags unknown model pricing without changing cost_usd's number type", async () => {
+        const dbRows = [
+            { model: "unknown-model", sessions: 1, prompt_tokens: 1_000_000, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0 },
+            { model: "claude-sonnet-5", sessions: 1, prompt_tokens: 1_000_000, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 3 },
+        ];
+        const db = makeMockDb([[dbRows]]);
+        const result = await runWithMock(db, fetchCostModels({ sinceDays: 14 }));
+
+        expect(result.rows.find((row) => row.model === "unknown-model")).toMatchObject({
+            cost_usd: 0,
+            unpriced: true,
+        });
+        expect(result.rows.find((row) => row.model === "claude-sonnet-5")).toMatchObject({
+            cost_usd: 3,
+            unpriced: false,
+        });
+        expect(typeof result.rows[0]!.cost_usd).toBe("number");
+    });
+
     test("handles empty result", async () => {
         const db = makeMockDb([[[]]] );
         const result = await runWithMock(db, fetchCostModels({ sinceDays: 14 }));
@@ -197,6 +218,22 @@ describe("fetchCostSplit", () => {
         const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
 
         expect(result.rows[0]!.share_pct).toBe(0);
+    });
+
+    test("flags an unknown model cell as unpriced", async () => {
+        const dbRows = [
+            { source: "codex", model: "unknown-model", sessions: 1,
+              prompt_tokens: 100, completion_tokens: 10,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0 },
+        ];
+        const db = makeMockDb([[dbRows]]);
+        const result = await runWithMock(db, fetchCostSplit({ sinceDays: 14 }));
+
+        expect(result.rows[0]).toMatchObject({
+            model: "unknown-model",
+            cost_usd: 0,
+            unpriced: true,
+        });
     });
 
     test("SQL groups by source and model", async () => {

--- a/apps/axctl/src/queries/cost-analytics.ts
+++ b/apps/axctl/src/queries/cost-analytics.ts
@@ -62,6 +62,21 @@ const sqlWindowDays = (n: number): number => Math.max(1, Math.trunc(n));
  * 4. Stored cost === 0 with real tokens and NO catalog rate: genuinely
  *    unpriced - render UNPRICED rather than a silent $0.
  */
+const EMPTY_PRICING_CATALOG: ReadonlyMap<string, ModelPricing> = new Map();
+
+/**
+ * True when any row carries a stored zero cost with real tokens - the only
+ * shape `resolveRowCost` needs a catalog for. Keeps the catalog DB round-trip
+ * out of the common all-priced path (and out of every positional-mock caller
+ * that never exercises recompute, e.g. buildProfile).
+ */
+const rowsNeedPricing = (rows: ReadonlyArray<Record<string, unknown>>): boolean =>
+    rows.some((row) =>
+        countField(row, "cost_usd") === 0
+        && countField(row, "prompt_tokens") + countField(row, "completion_tokens")
+            + countField(row, "cache_read_tokens") + countField(row, "cache_create_tokens") > 0,
+    );
+
 function resolveRowCost(
     input: {
         readonly model: string;
@@ -145,9 +160,14 @@ export const fetchCostModels = Effect.fn("queries.fetchCostModels")(
             COST_MODELS_SQL(opts.sinceDays),
         ).pipe(Effect.map((r) => r?.[0] ?? []));
 
-        const catalog = yield* loadPricingCatalogForModels(
-            rows.map((row) => (row.model == null ? null : String(row.model))),
-        );
+        // Lazy: the catalog round-trip only happens when some row actually
+        // needs pricing resolution (stored zero cost with real tokens) - the
+        // common all-priced window skips the extra query entirely.
+        const catalog = rowsNeedPricing(rows)
+            ? yield* loadPricingCatalogForModels(
+                rows.map((row) => (row.model == null ? null : String(row.model))),
+            )
+            : EMPTY_PRICING_CATALOG;
 
         const parsed: CostModelsRow[] = rows.map((row) => {
             const model = row.model == null ? "(unattributed)" : String(row.model);
@@ -311,10 +331,6 @@ export const fetchCostSplit = Effect.fn("queries.fetchCostSplit")(
             COST_SPLIT_SQL(opts.sinceDays),
         ).pipe(Effect.map((r) => r?.[0] ?? []));
 
-        const catalog = yield* loadPricingCatalogForModels(
-            rows.map((row) => (row.model == null ? null : String(row.model))),
-        );
-
         // Aggregate per (origin × model)
         const cellMap = new Map<string, {
             origin: "main" | "subagent";
@@ -361,9 +377,16 @@ export const fetchCostSplit = Effect.fn("queries.fetchCostSplit")(
             }
         }
 
+        // Lazy catalog load - see fetchCostModels; checked on the aggregated
+        // cells since recompute operates at cell grain.
+        const aggregated = [...cellMap.values()];
+        const catalog = rowsNeedPricing(aggregated)
+            ? yield* loadPricingCatalogForModels(aggregated.map((cell) => cell.model))
+            : EMPTY_PRICING_CATALOG;
+
         // Resolve pricing per cell BEFORE totals/share so a recomputed cell's
         // dollars are reflected everywhere downstream (#696 live-smoke gap).
-        const priced = [...cellMap.values()].map((cell) => {
+        const priced = aggregated.map((cell) => {
             const resolved = resolveRowCost({
                 model: cell.model,
                 promptTokens: cell.prompt_tokens,

--- a/apps/axctl/src/queries/cost-analytics.ts
+++ b/apps/axctl/src/queries/cost-analytics.ts
@@ -17,6 +17,7 @@ import { surrealLiteral } from "@ax/lib/json";
 import { countField, stringFieldOr } from "@ax/lib/shared/surreal";
 import { fetchContentTypeBreakdown, type ContentTypeBreakdown } from "./content-types.ts";
 import { originOfSource } from "../ingest/source-origin.ts";
+import { normalizeModelName, pricingForModel } from "../ingest/model-pricing.ts";
 
 // ---------------------------------------------------------------------------
 // Shared constants + SQL-boundary helpers
@@ -35,6 +36,9 @@ export const COST_DEFAULT_WINDOW_DAYS = 14;
  */
 const sqlWindowDays = (n: number): number => Math.max(1, Math.trunc(n));
 
+const isUnpricedModel = (model: string): boolean =>
+    pricingForModel(normalizeModelName(model)) === null;
+
 // ---------------------------------------------------------------------------
 // cost models
 // ---------------------------------------------------------------------------
@@ -47,6 +51,7 @@ export interface CostModelsRow {
     readonly cache_read_tokens: number;
     readonly cache_create_tokens: number;
     readonly cost_usd: number;
+    readonly unpriced: boolean;
 }
 
 export interface CostModelsResult {
@@ -88,6 +93,7 @@ export const fetchCostModels = Effect.fn("queries.fetchCostModels")(
             cache_read_tokens: countField(row, "cache_read_tokens"),
             cache_create_tokens: countField(row, "cache_create_tokens"),
             cost_usd: countField(row, "cost_usd"),
+            unpriced: isUnpricedModel(row.model == null ? "(unattributed)" : String(row.model)),
         }));
 
         // Sort by cost desc
@@ -180,6 +186,7 @@ export interface CostSplitRow {
     readonly cache_create_tokens: number;
     readonly cost_usd: number;
     readonly share_pct: number;
+    readonly unpriced: boolean;
 }
 
 export interface CostSplitTotals {
@@ -293,6 +300,7 @@ export const fetchCostSplit = Effect.fn("queries.fetchCostSplit")(
         const splitRows: CostSplitRow[] = cells.map((cell) => ({
             ...cell,
             share_pct: totalCost > 0 ? (cell.cost_usd / totalCost) * 100 : 0,
+            unpriced: isUnpricedModel(cell.model),
         }));
 
         const totals: CostSplitTotals = {

--- a/apps/axctl/src/queries/cost-analytics.ts
+++ b/apps/axctl/src/queries/cost-analytics.ts
@@ -17,7 +17,8 @@ import { surrealLiteral } from "@ax/lib/json";
 import { countField, stringFieldOr } from "@ax/lib/shared/surreal";
 import { fetchContentTypeBreakdown, type ContentTypeBreakdown } from "./content-types.ts";
 import { originOfSource } from "../ingest/source-origin.ts";
-import { normalizeModelName, pricingForModel } from "../ingest/model-pricing.ts";
+import { estimateCost, normalizeModelName, pricingForModel, type ModelPricing } from "../ingest/model-pricing.ts";
+import { loadPricingCatalogForModels } from "../metrics/cost-estimate.ts";
 
 // ---------------------------------------------------------------------------
 // Shared constants + SQL-boundary helpers
@@ -36,8 +37,67 @@ export const COST_DEFAULT_WINDOW_DAYS = 14;
  */
 const sqlWindowDays = (n: number): number => Math.max(1, Math.trunc(n));
 
-const isUnpricedModel = (model: string): boolean =>
-    pricingForModel(normalizeModelName(model)) === null;
+/**
+ * Resolve a rollup row/cell's displayed cost + `unpriced` flag against a
+ * query-time pricing catalog (issue #696 follow-up).
+ *
+ * `isUnpricedModel` (the prior implementation) checked only the built-in
+ * catalog, but stored `cost_usd` is computed at ingest from the MERGED
+ * catalog (built-in + litellm/models.dev DB refresh, see
+ * `ingest/model-pricing.ts` + `metrics/cost-estimate.ts`). A model priced only
+ * via the DB refresh got real nonzero `cost_usd` yet rendered UNPRICED - the
+ * catalog check and the stored number disagreed. Worse, a model added to the
+ * built-in catalog AFTER older rows were ingested (e.g. claude-sonnet-5,
+ * gpt-5.6-sol/luna - #696) has those older rows stored with a real zero/null
+ * cost forever, since ingest only backfills null-cost rows (never re-prices a
+ * row that already carries a stored cost - `derive-cost-backfill.ts`).
+ *
+ * Resolution order:
+ * 1. A stored cost > 0 is real money - never mask it, never recompute it.
+ * 2. Zero tokens is a genuine zero-usage row (including the "(unattributed)"
+ *    sentinel) - show $0, not UNPRICED.
+ * 3. Stored cost === 0 with real tokens and a catalog rate: recompute from
+ *    the row's own token split at query time (self-healing without an
+ *    ingest re-run).
+ * 4. Stored cost === 0 with real tokens and NO catalog rate: genuinely
+ *    unpriced - render UNPRICED rather than a silent $0.
+ */
+function resolveRowCost(
+    input: {
+        readonly model: string;
+        readonly promptTokens: number;
+        readonly completionTokens: number;
+        readonly cacheReadTokens: number;
+        readonly cacheCreateTokens: number;
+        readonly costUsd: number;
+    },
+    catalog: ReadonlyMap<string, ModelPricing>,
+): { readonly cost_usd: number; readonly unpriced: boolean } {
+    if (input.costUsd > 0) {
+        return { cost_usd: input.costUsd, unpriced: false };
+    }
+    const totalTokens = input.promptTokens + input.completionTokens + input.cacheReadTokens + input.cacheCreateTokens;
+    if (totalTokens === 0) {
+        return { cost_usd: 0, unpriced: false };
+    }
+    const modelKey = normalizeModelName(input.model);
+    const pricing = pricingForModel(modelKey, catalog);
+    if (!pricing) {
+        return { cost_usd: 0, unpriced: true };
+    }
+    const estimate = estimateCost({
+        modelKey,
+        promptTokens: input.promptTokens,
+        completionTokens: input.completionTokens,
+        cacheCreationInputTokens: input.cacheCreateTokens,
+        cacheReadInputTokens: input.cacheReadTokens,
+        estimatedTokens: input.promptTokens,
+        pricingCatalog: catalog,
+    });
+    return estimate.totalUsd === null
+        ? { cost_usd: 0, unpriced: true }
+        : { cost_usd: estimate.totalUsd, unpriced: false };
+}
 
 // ---------------------------------------------------------------------------
 // cost models
@@ -85,16 +145,31 @@ export const fetchCostModels = Effect.fn("queries.fetchCostModels")(
             COST_MODELS_SQL(opts.sinceDays),
         ).pipe(Effect.map((r) => r?.[0] ?? []));
 
-        const parsed: CostModelsRow[] = rows.map((row) => ({
-            model: row.model == null ? "(unattributed)" : String(row.model),
-            sessions: countField(row, "sessions"),
-            prompt_tokens: countField(row, "prompt_tokens"),
-            completion_tokens: countField(row, "completion_tokens"),
-            cache_read_tokens: countField(row, "cache_read_tokens"),
-            cache_create_tokens: countField(row, "cache_create_tokens"),
-            cost_usd: countField(row, "cost_usd"),
-            unpriced: isUnpricedModel(row.model == null ? "(unattributed)" : String(row.model)),
-        }));
+        const catalog = yield* loadPricingCatalogForModels(
+            rows.map((row) => (row.model == null ? null : String(row.model))),
+        );
+
+        const parsed: CostModelsRow[] = rows.map((row) => {
+            const model = row.model == null ? "(unattributed)" : String(row.model);
+            const resolved = resolveRowCost({
+                model,
+                promptTokens: countField(row, "prompt_tokens"),
+                completionTokens: countField(row, "completion_tokens"),
+                cacheReadTokens: countField(row, "cache_read_tokens"),
+                cacheCreateTokens: countField(row, "cache_create_tokens"),
+                costUsd: countField(row, "cost_usd"),
+            }, catalog);
+            return {
+                model,
+                sessions: countField(row, "sessions"),
+                prompt_tokens: countField(row, "prompt_tokens"),
+                completion_tokens: countField(row, "completion_tokens"),
+                cache_read_tokens: countField(row, "cache_read_tokens"),
+                cache_create_tokens: countField(row, "cache_create_tokens"),
+                cost_usd: resolved.cost_usd,
+                unpriced: resolved.unpriced,
+            };
+        });
 
         // Sort by cost desc
         parsed.sort((a, b) => b.cost_usd - a.cost_usd);
@@ -236,6 +311,10 @@ export const fetchCostSplit = Effect.fn("queries.fetchCostSplit")(
             COST_SPLIT_SQL(opts.sinceDays),
         ).pipe(Effect.map((r) => r?.[0] ?? []));
 
+        const catalog = yield* loadPricingCatalogForModels(
+            rows.map((row) => (row.model == null ? null : String(row.model))),
+        );
+
         // Aggregate per (origin × model)
         const cellMap = new Map<string, {
             origin: "main" | "subagent";
@@ -247,13 +326,6 @@ export const fetchCostSplit = Effect.fn("queries.fetchCostSplit")(
             cache_create_tokens: number;
             cost_usd: number;
         }>();
-
-        let totalCost = 0;
-        let totalSessions = 0;
-        let totalPrompt = 0;
-        let totalCompletion = 0;
-        let totalCacheRead = 0;
-        let totalCacheCreate = 0;
 
         for (const row of rows) {
             const origin = originOfSource(stringFieldOr(row, "source"));
@@ -287,30 +359,37 @@ export const fetchCostSplit = Effect.fn("queries.fetchCostSplit")(
                     cost_usd: cost,
                 });
             }
-
-            totalCost += cost;
-            totalSessions += sessions;
-            totalPrompt += prompt;
-            totalCompletion += completion;
-            totalCacheRead += cacheRead;
-            totalCacheCreate += cacheCreate;
         }
 
-        const cells = [...cellMap.values()].sort((a, b) => b.cost_usd - a.cost_usd);
+        // Resolve pricing per cell BEFORE totals/share so a recomputed cell's
+        // dollars are reflected everywhere downstream (#696 live-smoke gap).
+        const priced = [...cellMap.values()].map((cell) => {
+            const resolved = resolveRowCost({
+                model: cell.model,
+                promptTokens: cell.prompt_tokens,
+                completionTokens: cell.completion_tokens,
+                cacheReadTokens: cell.cache_read_tokens,
+                cacheCreateTokens: cell.cache_create_tokens,
+                costUsd: cell.cost_usd,
+            }, catalog);
+            return { ...cell, cost_usd: resolved.cost_usd, unpriced: resolved.unpriced };
+        });
+
+        const totalCost = priced.reduce((sum, c) => sum + c.cost_usd, 0);
+        const totals: CostSplitTotals = {
+            sessions: priced.reduce((sum, c) => sum + c.sessions, 0),
+            prompt_tokens: priced.reduce((sum, c) => sum + c.prompt_tokens, 0),
+            completion_tokens: priced.reduce((sum, c) => sum + c.completion_tokens, 0),
+            cache_read_tokens: priced.reduce((sum, c) => sum + c.cache_read_tokens, 0),
+            cache_create_tokens: priced.reduce((sum, c) => sum + c.cache_create_tokens, 0),
+            cost_usd: totalCost,
+        };
+
+        const cells = priced.sort((a, b) => b.cost_usd - a.cost_usd);
         const splitRows: CostSplitRow[] = cells.map((cell) => ({
             ...cell,
             share_pct: totalCost > 0 ? (cell.cost_usd / totalCost) * 100 : 0,
-            unpriced: isUnpricedModel(cell.model),
         }));
-
-        const totals: CostSplitTotals = {
-            sessions: totalSessions,
-            prompt_tokens: totalPrompt,
-            completion_tokens: totalCompletion,
-            cache_read_tokens: totalCacheRead,
-            cache_create_tokens: totalCacheCreate,
-            cost_usd: totalCost,
-        };
 
         const contentTypes = yield* fetchContentTypeBreakdown();
 


### PR DESCRIPTION
Closes #696.

Three commits:
1. **c2fed221** (codex): built-in catalog rates for `claude-sonnet-5` ($3/$15, cache 3.75/0.30), `gpt-5.6-sol` ($5/$30), `gpt-5.6-luna` ($1/$6) — values verified against published pricing in adversarial review — plus `unpriced` field on cost models/split rows and `UNPRICED` rendering (all-unpriced windows render instead of "no cost data").
2. **0a0559e4** (review must-fix): `unpriced` was built-in-catalog-only while stored `cost_usd` prices from the MERGED catalog → could mask real DB-refresh-priced cost, and rows ingested before a rate existed stayed $0 forever (ingest backfill only heals NULL, never stored-zero). Now `resolveRowCost` per row/cell: stored >0 kept, zero-token rows $0 unflagged (incl. `(unattributed)`), stored-zero+tokens+known-rate recomputes query-time from the row's own token split (before totals/share), stored-zero+tokens+no-rate → UNPRICED.
3. Test fixture: pricing_source assertion now derives from `MODEL_PRICING_SOURCE` (was broken by the catalog-date bump).

Live verification (`ax cost split --days=14`): sonnet-5 subagent now $1,069.57 / 568 sessions (was $0.0000), gpt-5.6-sol main $583.01, `<synthetic>`/`gpt-5.6-terra` render UNPRICED, zero-token rows $0.

## Deferred concerns
- `gpt-5.6-terra` has no rate (2 sessions, ~211K tokens) — surfaces as UNPRICED by design; add a rate when published.

Fleet run: dogfood-0716 (map #699).

🤖 Generated with [Claude Code](https://claude.com/claude-code)