### PR TITLE
fix(pricing): claude-sonnet-5 rates + gpt-5.6 tier approximation

### DIFF
--- a/apps/axctl/src/ingest/model-pricing.test.ts
+++ b/apps/axctl/src/ingest/model-pricing.test.ts
@@ -189,6 +189,32 @@ describe("model pricing", () => {
         });
     });
 
+    it("prices claude-sonnet-5 and its suffixed ids", () => {
+        const catalog = builtInPricingCatalog();
+
+        expect(pricingForModel("claude-sonnet-5", catalog)).toMatchObject({
+            inputPerMillionUsd: 3,
+            outputPerMillionUsd: 15,
+        });
+        expect(pricingForModel("claude-sonnet-5[1m]", catalog)).toMatchObject({
+            inputPerMillionUsd: 3,
+            outputPerMillionUsd: 15,
+        });
+    });
+
+    it("approximates gpt-5.6 variants at the gpt-5.5 tier", () => {
+        const catalog = builtInPricingCatalog();
+
+        expect(pricingForModel("gpt-5.6-sol", catalog)).toMatchObject({
+            inputPerMillionUsd: 5,
+            outputPerMillionUsd: 30,
+        });
+        expect(pricingForModel("gpt-5.6-luna", catalog)).toMatchObject({
+            inputPerMillionUsd: 5,
+            outputPerMillionUsd: 30,
+        });
+    });
+
     it("falls back gpt-5 point releases to gpt-5 pricing when no exact row exists", () => {
         const catalog = new Map([["gpt-5", builtInPricingCatalog().get("gpt-5")!]]);
 

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -267,6 +267,15 @@ export const BUILTIN_MODEL_PRICING_CATALOG: Readonly<Record<string, ModelPricing
         fastMultiplier: 1,
         pricingSource: MODEL_PRICING_SOURCE,
     },
+    "claude-sonnet-5": {
+        provider: "anthropic",
+        inputPerMillionUsd: 3,
+        outputPerMillionUsd: 15,
+        cacheCreationPerMillionUsd: 3.75,
+        cacheReadPerMillionUsd: 0.3,
+        fastMultiplier: 1,
+        pricingSource: MODEL_PRICING_SOURCE,
+    },
     "claude-fable-5": {
         provider: "anthropic",
         inputPerMillionUsd: 10,
@@ -409,10 +418,14 @@ export function pricingForModel(
     if (!modelKey) return null;
     const exact = catalog.get(modelKey);
     if (exact) return exact;
+    // gpt-5.6 variants (sol/luna) have no published rates yet - approximate at the gpt-5.5 tier
+    // rather than pricing them $0 (see issue #696). Must precede the generic gpt-5.x rule.
+    if (/^gpt-5\.6(?:-|$)/i.test(modelKey)) return catalog.get("gpt-5.5") ?? catalog.get("gpt-5") ?? null;
     if (/^gpt-5(?:\.\d+)?$/i.test(modelKey)) return catalog.get("gpt-5") ?? null;
     if (modelKey.startsWith("claude-fable-5")) return catalog.get("claude-fable-5") ?? null;
     if (modelKey.startsWith("claude-haiku-4-5")) return catalog.get("claude-haiku-4-5") ?? null;
     if (modelKey.startsWith("claude-opus-4")) return catalog.get("claude-opus-4") ?? null;
+    if (modelKey.startsWith("claude-sonnet-5")) return catalog.get("claude-sonnet-5") ?? null;
     if (modelKey.startsWith("claude-sonnet-4")) return catalog.get("claude-sonnet-4") ?? null;
     return null;
 }


### PR DESCRIPTION
Fixes the $0.00 pricing rows from #696: adds `claude-sonnet-5` ($3/$15 per MTok, cache write 3.75 / read 0.3, per platform.claude.com model table) with a suffixed-id fallback rule, and prices `gpt-5.6-sol`/`gpt-5.6-luna` at the gpt-5.5 tier as an explicit approximation (no published rates yet; rule precedes the generic gpt-5.x match and falls through to gpt-5 when a fetched catalog lacks 5.5).

Tests: 13/13 pass (`model-pricing.test.ts`), tsc clean.

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)