### PR TITLE
perf(otel): window the otel_log_event session-id scan (PERF-01)

### DIFF
--- a/apps/axctl/src/queries/otel-rollup.test.ts
+++ b/apps/axctl/src/queries/otel-rollup.test.ts
@@ -3,6 +3,7 @@ import {
     FLOWING_MS,
     STALE_MS,
     bareUuid,
+    buildOtelSessionIdsQuery,
     coveragePct,
     formatAge,
     healthGlyph,
@@ -80,6 +81,16 @@ describe("bareUuid", () => {
     it("is null for nullish", () => {
         expect(bareUuid(null)).toBeNull();
         expect(bareUuid(undefined)).toBeNull();
+    });
+});
+
+describe("buildOtelSessionIdsQuery", () => {
+    it("windows the session-id scan by observed_at", () => {
+        expect(buildOtelSessionIdsQuery("otel_log_event", 14)).toBe(
+            "SELECT session_id FROM otel_log_event"
+            + " WHERE observed_at > time::now() - 14d"
+            + " AND session_id != NONE GROUP BY session_id;",
+        );
     });
 });
 

--- a/apps/axctl/src/queries/otel-rollup.ts
+++ b/apps/axctl/src/queries/otel-rollup.ts
@@ -141,6 +141,11 @@ const SIGNAL_TABLES: ReadonlyArray<readonly [OtelSignalKind, string]> = [
     ["span", "otel_span"],
 ];
 
+export const buildOtelSessionIdsQuery = (table: string, days: number): string =>
+    `SELECT session_id FROM ${table}`
+    + ` WHERE observed_at > time::now() - ${days}d`
+    + " AND session_id != NONE GROUP BY session_id;";
+
 export const fetchOtelRollup = (
     input: OtelRollupInput,
 ): Effect.Effect<OtelRollupResult, DbError, SurrealClient> =>
@@ -186,7 +191,7 @@ export const fetchOtelRollup = (
         const otelSids = new Set<string>();
         for (const [, table] of SIGNAL_TABLES) {
             const sidRows = (yield* db.query<[Array<Record<string, unknown>>]>(
-                `SELECT session_id FROM ${table} WHERE session_id != NONE GROUP BY session_id;`,
+                buildOtelSessionIdsQuery(table, days),
             ))?.[0] ?? [];
             for (const r of sidRows) {
                 const u = bareUuid(r.session_id);


### PR DESCRIPTION
Windows the coverage session-id enumeration in `fetchOtelRollup` by `observed_at`, matching the cost query's idiom right below it. Removes a full-table GROUP BY over the ~1.5M-row `otel_log_event` on every `ax otel` CLI + MCP call; result is unchanged (windowed sessions only have windowed telemetry). Extracts a testable `buildOtelSessionIdsQuery`; test asserts the real SQL string.

From the /improve audit — finding PERF-01. Fleet chunk `perf-otel-window`. Part of #702.

Gates: typecheck 0, otel-rollup.test.ts 18/18.

Generated with ax — https://github.com/Necmttn/ax