### PR TITLE
fix(ingest): validate codex transcript timestamps (CORRECTNESS-01)

### DIFF
--- a/apps/axctl/src/ingest/codex.parity.test.ts
+++ b/apps/axctl/src/ingest/codex.parity.test.ts
@@ -173,6 +173,34 @@ const fixtureLines = (): string[] => [
 ];
 
 describe("codex normalized-batch parity", () => {
+    it("warns and falls back for missing or malformed timestamps", () => {
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({
+                type: "session_meta",
+                payload: {
+                    id: "codex-invalid-timestamp",
+                    cwd: "/Users/necmttn/Projects/ax",
+                    timestamp: "2026-06-10T08:00:00.000Z",
+                },
+            }),
+            JSON.stringify({
+                type: "compacted",
+                timestamp: "not-a-timestamp",
+                payload: { message: "", replacement_history: [{ type: "message" }] },
+            }),
+        ]);
+
+        expect(extracted).not.toBeNull();
+        expect(extracted!.warnings).toHaveLength(2);
+        expect(extracted!.warnings[0]).toContain("missing entry timestamp");
+        expect(extracted!.warnings[1]).toContain("invalid entry timestamp");
+        expect(Number.isFinite(new Date(extracted!.session.started_at).getTime())).toBe(true);
+        expect(extracted!.session.started_at).toBe("2026-06-10T08:00:00.000Z");
+        expect(extracted!.session.ended_at).toBe("2026-06-10T08:00:00.000Z");
+        expect(extracted!.compactions).toHaveLength(1);
+        expect(Number.isFinite(extracted!.compactions[0]!.ts.getTime())).toBe(true);
+    });
+
     it("single-shot extract emits golden statement shapes", () => {
         const extracted = __testExtractCodexJsonlLines(fixtureLines());
         expect(extracted).not.toBeNull();

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -77,6 +77,7 @@ export const DEFAULT_CODEX_FLUSH_EVERY = 500;
 const DEFAULT_CODEX_CONCURRENCY = 1;
 const DEFAULT_CODEX_PAYLOAD_MAX_BYTES = 1200;
 const CODEX_PROGRESS_LINE_EVERY = 100;
+const SAFE_FALLBACK_TS = "1970-01-01T00:00:00.000Z";
 
 interface CodexSession {
     id: string;
@@ -92,6 +93,12 @@ interface CodexSession {
     parent_thread_id: string | null;
     started_at: string;
     ended_at: string;
+}
+
+function validIsoTimestamp(input: string | null): string | null {
+    if (input === null || input.trim().length === 0) return null;
+    const date = new Date(input);
+    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
 }
 
 interface CodexTurn {
@@ -424,6 +431,7 @@ function applyToolResult(call: MutableToolCallWrite, result: ToolResultFields): 
 export interface CodexExtract {
     session: CodexSession;
     sourcePath: string | null;
+    warnings: string[];
     turns: CodexTurn[];
     turnTokenUsages: CodexTurnTokenUsage[];
     invocations: CodexInvocation[];
@@ -439,6 +447,7 @@ export interface CodexExtract {
 interface MutableCodexExtract {
     session: CodexSession | null;
     sourcePath: string | null;
+    warnings: string[];
     turns: CodexTurn[];
     turnTokenUsages: CodexTurnTokenUsage[];
     invocations: CodexInvocation[];
@@ -465,6 +474,7 @@ function createCodexExtractor(
     const skillRelations: ToolCallSkillRelationWrite[] = [];
     const planSnapshots: PlanSnapshotWrite[] = [];
     const compactions: CompactionWrite[] = [];
+    const warnings: string[] = [];
     let lastContextTokens: number | null = null;
     let tokenUsage: CodexTokenUsage | null = null;
     let tokenCountEvents = 0;
@@ -759,6 +769,7 @@ function createCodexExtractor(
         return {
             session,
             sourcePath: filePath,
+            warnings: warnings.splice(0, warnings.length),
             turns: drainedTurns,
             turnTokenUsages: drainedTurnTokenUsages,
             invocations: drainedInvocations,
@@ -788,11 +799,27 @@ function createCodexExtractor(
                 return;
             }
             const type = entry.type ?? null;
-            const ts = entry.timestamp ?? null;
-            if (!ts) return;
             const payload = isRecord(rawEntry.payload) ? rawEntry.payload : null;
+            const rawTimestamp = entry.timestamp ?? null;
+            const entryTimestamp = validIsoTimestamp(rawTimestamp);
+            const entryId = type === "session_meta" && payload
+                ? (stringField(payload, "id") ?? filePath)
+                : `${type ?? "unknown"} in ${filePath}`;
+            if (!entryTimestamp) {
+                warnings.push(
+                    `${rawTimestamp ? "invalid" : "missing"} entry timestamp for ${entryId}` +
+                        (rawTimestamp ? `: ${rawTimestamp}` : ""),
+                );
+            }
 
             if (type === "session_meta" && payload) {
+                const rawPayloadTimestamp = stringField(payload, "timestamp");
+                const payloadTimestamp = validIsoTimestamp(rawPayloadTimestamp);
+                if (rawPayloadTimestamp !== null && !payloadTimestamp) {
+                    warnings.push(`invalid session payload timestamp for ${entryId}: ${rawPayloadTimestamp}`);
+                }
+                const startedAt = payloadTimestamp ?? entryTimestamp ?? SAFE_FALLBACK_TS;
+                const endedAt = entryTimestamp ?? payloadTimestamp ?? startedAt;
                 session = {
                     id: stringField(payload, "id") ?? filePath,
                     cwd: stringField(payload, "cwd"),
@@ -802,12 +829,13 @@ function createCodexExtractor(
                     reasoning_effort: null,
                     thread_source: stringField(payload, "thread_source"),
                     parent_thread_id: stringField(payload, "parent_thread_id"),
-                    started_at: stringField(payload, "timestamp") ?? ts,
-                    ended_at: ts,
+                    started_at: startedAt,
+                    ended_at: endedAt,
                 };
                 return;
             }
             if (!session) return;
+            const ts = entryTimestamp ?? session.ended_at;
             session.ended_at = ts;
 
             if (type === "turn_context" && payload) {
@@ -937,6 +965,7 @@ function createCodexExtractor(
             return {
                 session,
                 sourcePath: remaining.sourcePath,
+                warnings: remaining.warnings,
                 turns: remaining.turns,
                 turnTokenUsages: remaining.turnTokenUsages,
                 invocations: remaining.invocations,
@@ -1542,6 +1571,14 @@ export const ingestCodex = Effect.fn("codex.ingest")(
                 let providerEventsCleared = false;
                 const writeBatch = (batch: MutableCodexExtract) =>
                     Effect.gen(function* () {
+                        yield* Effect.forEach(
+                            batch.warnings,
+                            (warning) => Effect.logWarning("codex transcript timestamp fallback", {
+                                file: filePath,
+                                warning,
+                            }),
+                            { discard: true },
+                        );
                         if (!batch.session) return;
                         currentSession = batch.session;
                         if (!sessionUpserted) {


### PR DESCRIPTION
The codex parser was the only one of six harness parsers that trusted an unvalidated timestamp into `new Date()`/the SurrealDB SDK. Adds a `validIsoTimestamp` guard (mirrors pi/cursor/opencode), warns + falls back instead of silently dropping, and builds the session header even when a `session_meta` timestamp is missing/invalid (previously a falsy ts dropped the whole session → zero records, no warning).

From the /improve audit — finding CORRECTNESS-01. Fleet chunk `bug-codex-ts`. Part of #702.

Gates: typecheck 0, codex.parity.test 3/3, check:no-node-fs 0.

Generated with ax — https://github.com/Necmttn/ax