### PR TITLE
fix(ingest): re-clamp Pi session started_at off the epoch sentinel (CORRECTNESS-02)

### DIFF
--- a/apps/axctl/src/ingest/pi.test.ts
+++ b/apps/axctl/src/ingest/pi.test.ts
@@ -353,6 +353,59 @@ describe("Pi JSONL extraction", () => {
         ]);
     });
 
+    test("bad session timestamp clamps started_at to the earliest valid body timestamp", () => {
+        const extracted = __testExtractPiJsonlLines([
+            JSON.stringify({
+                type: "session",
+                version: 3,
+                id: "pi-bad-header-valid-body",
+                timestamp: "not-a-date",
+                cwd: "/tmp/project",
+            }),
+            JSON.stringify({
+                type: "message",
+                id: "user-later",
+                parentId: null,
+                timestamp: "2026-05-29T06:00:03.000Z",
+                message: {
+                    role: "user",
+                    content: [{ type: "text", text: "Later entry first." }],
+                },
+            }),
+            JSON.stringify({
+                type: "message",
+                id: "assistant-earliest",
+                parentId: "user-later",
+                timestamp: "2026-05-29T06:00:01.000Z",
+                message: {
+                    role: "assistant",
+                    content: [{ type: "text", text: "Earlier entry second." }],
+                },
+            }),
+            JSON.stringify({
+                type: "message",
+                id: "assistant-latest",
+                parentId: "assistant-earliest",
+                timestamp: "2026-05-29T06:00:05.000Z",
+                message: {
+                    role: "assistant",
+                    content: [{ type: "text", text: "Latest entry last." }],
+                },
+            }),
+        ]);
+
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+
+        expect(extracted.session.started_at).toBe("2026-05-29T06:00:01.000Z");
+        expect(extracted.session.started_at).not.toBe("1970-01-01T00:00:00.000Z");
+        expect(extracted.session.ended_at).toBe("2026-05-29T06:00:05.000Z");
+        expect(
+            new Date(extracted.session.ended_at).getTime() -
+                new Date(extracted.session.started_at).getTime(),
+        ).toBe(4_000);
+    });
+
     test("projects assistant toolCall blocks, tool results, synthetic skills, and token usage statements", () => {
         const extracted = __testExtractPiJsonlLines([
             JSON.stringify({

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -473,6 +473,16 @@ function createPiExtractor(filePath: string, desc: PiLikeProvider = PI_PROVIDER)
             const timestamp = sourceTimestamp(entry, session.ended_at);
             if (timestamp.warning) warnings.push(timestamp.warning);
             const ts = timestamp.ts;
+            const tsTime = new Date(ts).getTime();
+            if (
+                Number.isFinite(tsTime) &&
+                (
+                    session.started_at === SAFE_FALLBACK_TS ||
+                    tsTime < new Date(session.started_at).getTime()
+                )
+            ) {
+                session.started_at = ts;
+            }
             session.ended_at = ts;
             const providerEventId = head.id ?? null;
             const parentProviderEventId = head.parentId ?? null;


### PR DESCRIPTION
When a Pi session header has a bad/missing timestamp, started_at was set to the 1970 SAFE_FALLBACK_TS sentinel and never revisited, while ended_at was re-clamped every entry — yielding a ~56-year bogus duration that corrupted duration/latency rollups. Adds the per-entry clamp (mirrors cursor.ts): when started_at is the sentinel or a later entry is earlier, adopt the earliest valid body timestamp.

From the /improve audit — finding CORRECTNESS-02. Fleet chunk `bug-pi-epoch`. Part of #702.

Gates: typecheck 0, pi.test 12/12, check:no-node-fs 0.

Generated with ax — https://github.com/Necmttn/ax