### PR TITLE
ci: cache bun+turbo, wire orphaned drift-guards (DX-01/DX-02)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,24 @@ jobs:
         with:
           bun-version: "1.3.10"
 
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Cache Turbo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('bun.lock', '.github/workflows/ci.yml') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ hashFiles('bun.lock', '.github/workflows/ci.yml') }}-
+            ${{ runner.os }}-turbo-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-turbo-
+
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep
 
@@ -33,7 +51,11 @@ jobs:
 
       - run: bun run check:cli-reference
 
+      - run: bun run check:site-cli-reference
+
       - run: bun run check:no-node-fs
+
+      - run: bun run check:record-select
 
       - run: bun run check:table-coverage
 


### PR DESCRIPTION
Adds actions/cache for `~/.bun/install/cache` (keyed on bun.lock) and `.turbo` so pushes stop paying a cold install + full build. Wires two previously-unautomated drift-guards into the verify job: `check:site-cli-reference`, `check:record-select` (both green). `check:harness-docs` is deferred — pre-existing drift, filed as #708 — rather than wiring a red gate.

From the /improve audit — findings DX-01, DX-02. Fleet chunk `ci-cache-checks`. Part of #702.

Generated with ax — https://github.com/Necmttn/ax