### PR TITLE
fix(ingest): opencode/cursor --since must fail open on unknown mtime (CORRECTNESS-03)

### DIFF
--- a/apps/axctl/src/ingest/cursor.test.ts
+++ b/apps/axctl/src/ingest/cursor.test.ts
@@ -3,11 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Option } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import {
     __testBuildCursorBatchStatements,
     __testFindCursorStateDbs,
+    __testIncludeCursorByMtime,
     extractCursorStateDb,
     isAllowedCursorHistoryKey,
 } from "./cursor.ts";
@@ -431,6 +432,15 @@ describe("Cursor state.vscdb extraction", () => {
         } finally {
             await rm(dir, { recursive: true, force: true });
         }
+    });
+
+    test("mtime filtering skips old databases but includes unknown mtimes", () => {
+        const cutoffMs = new Date("2026-05-02T00:00:00.000Z").getTime();
+
+        expect(__testIncludeCursorByMtime(Option.some(new Date("2026-05-01T00:00:00.000Z")), cutoffMs)).toBe(
+            false,
+        );
+        expect(__testIncludeCursorByMtime(Option.none(), cutoffMs)).toBe(true);
     });
 
     test("discovery treats fresh SQLite WAL sidecars as fresh database activity", async () => {

--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -948,6 +948,14 @@ const sliceCursorExtractForSession = (
 
 export const __testSliceCursorExtractForSession = sliceCursorExtractForSession;
 
+const includeByMtime = (mtime: Option.Option<Date>, cutoffMs: number): boolean =>
+    Option.match(mtime, {
+        onNone: () => true,
+        onSome: (date) => date.getTime() >= cutoffMs,
+    });
+
+export const __testIncludeCursorByMtime = includeByMtime;
+
 // All fs ops below are discovery PROBES: the OLD code guarded every access with
 // `existsSync`/`readdir`-in-try/catch and treated any miss/fault as "absent,
 // skip". `orAbsent` reproduces that exactly (recovers ANY PlatformError to the
@@ -968,11 +976,11 @@ const includeDbByMtime = (
             // OLD: existsSync guard → skip absent sidecars; stat in try/catch → false.
             const sidecarExists = yield* fs.exists(path).pipe(orAbsent(false));
             if (!sidecarExists) continue;
-            const mtimeMs = yield* fs.stat(path).pipe(
-                Effect.map((st) => Option.getOrElse(st.mtime, () => new Date(0)).getTime()),
-                orAbsent(-1),
+            const included = yield* fs.stat(path).pipe(
+                Effect.map((st) => includeByMtime(st.mtime, cutoffMs)),
+                orAbsent(false),
             );
-            if (mtimeMs >= cutoffMs) return true;
+            if (included) return true;
         }
         return false;
     });

--- a/apps/axctl/src/ingest/opencode.test.ts
+++ b/apps/axctl/src/ingest/opencode.test.ts
@@ -3,11 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Option } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import {
     __testBuildOpenCodeBatchStatements,
     __testFindOpenCodeDbCandidates,
+    __testIncludeOpenCodeByMtime,
     extractOpenCodeDatabase,
 } from "./opencode.ts";
 import { toolCallRecordKey, turnRecordKey } from "./record-keys.ts";
@@ -549,5 +550,14 @@ describe("OpenCode SQLite extraction", () => {
             expect(await findOpenCodeDbCandidates(join(dbPath, ".."), old.getTime() + 1)).toEqual([]);
             expect(await findOpenCodeDbCandidates(join(dbPath, ".."), old.getTime())).toEqual([dbPath]);
         });
+    });
+
+    test("mtime filtering skips old databases but includes unknown mtimes", () => {
+        const cutoffMs = new Date("2026-05-02T00:00:00.000Z").getTime();
+
+        expect(__testIncludeOpenCodeByMtime(Option.some(new Date("2026-05-01T00:00:00.000Z")), cutoffMs)).toBe(
+            false,
+        );
+        expect(__testIncludeOpenCodeByMtime(Option.none(), cutoffMs)).toBe(true);
     });
 });

--- a/apps/axctl/src/ingest/opencode.ts
+++ b/apps/axctl/src/ingest/opencode.ts
@@ -1041,6 +1041,14 @@ function failedExtract(dbPath: string, error: unknown): OpenCodeExtract {
     );
 }
 
+const includeByMtime = (mtime: Option.Option<Date>, cutoffMs: number): boolean =>
+    Option.match(mtime, {
+        onNone: () => true,
+        onSome: (date) => date.getTime() >= cutoffMs,
+    });
+
+export const __testIncludeOpenCodeByMtime = includeByMtime;
+
 // Discovery PROBE: the OLD code guarded with `existsSync` and `stat`-in-try/catch,
 // treating any miss/fault as "no candidate". `orAbsent` reproduces that exactly
 // (recovers ANY PlatformError to the fallback), so this reader never fails; R is
@@ -1058,11 +1066,11 @@ const findOpenCodeDbCandidates = (
         if (!exists) return [];
         if (cutoffMs > 0) {
             // OLD: stat in try/catch → [] on fault or when mtime is below cutoff.
-            const mtimeMs = yield* fs.stat(dbPath).pipe(
-                Effect.map((st) => Option.getOrElse(st.mtime, () => new Date(0)).getTime()),
-                orAbsent(-1),
+            const included = yield* fs.stat(dbPath).pipe(
+                Effect.map((st) => includeByMtime(st.mtime, cutoffMs)),
+                orAbsent(false),
             );
-            if (mtimeMs < cutoffMs) return [];
+            if (!included) return [];
         }
         return [dbPath];
     });


### PR DESCRIPTION
opencode/cursor coerced an unknown file mtime to epoch-0 before the --since cutoff, so any stat path that reports no mtime (Option.none) silently excluded the ENTIRE opencode DB / cursor sidecar from a --since run. Extracts `includeByMtime` that fails OPEN on Option.none (unknown mtime → include) while preserving the old behavior that a stat FAULT still skips. Adds unit tests for both predicates.

From the /improve audit — finding CORRECTNESS-03. Fleet chunk `bug-mtime-since`. Part of #702.

Gates: typecheck 0, opencode+cursor tests 23/23, check:no-node-fs 0.

Generated with ax — https://github.com/Necmttn/ax