### PR TITLE
fix(db): keep AX_DB_QUERY_LOG bare values out of the repo root (SECURITY-06/DEBT-03)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 data/
 *.log
+# SurrealQL diagnostic logs (AX_DB_QUERY_LOG)
+db-query-*.querylog
+/[0-9]
 .env
 .env.local
 bun.lockb

--- a/packages/lib/src/db-query-log.test.ts
+++ b/packages/lib/src/db-query-log.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { resolveQueryLogPath } from "./db.ts";
+
+describe("resolveQueryLogPath", () => {
+    test("routes a bare numeric value outside the current working directory", () => {
+        const cwd = "/workspace/ax";
+        const path = resolveQueryLogPath("1", "/home/user/.local/share/ax", cwd);
+
+        expect(path).toBe("/home/user/.local/share/ax/db-query-1.querylog");
+        expect(path).not.toBe(`${cwd}/1`);
+    });
+
+    test("preserves an absolute path", () => {
+        expect(resolveQueryLogPath("/tmp/x.log", "/data/ax", "/workspace/ax"))
+            .toBe("/tmp/x.log");
+    });
+
+    test("preserves an explicit dotted relative path", () => {
+        expect(resolveQueryLogPath("./logs/x.log", "/data/ax", "/workspace/ax"))
+            .toBe("./logs/x.log");
+    });
+});

--- a/packages/lib/src/db.ts
+++ b/packages/lib/src/db.ts
@@ -7,6 +7,7 @@ import {
     type Table,
 } from "surrealdb";
 import { Config, ConfigProvider, Context, Effect, Layer, Option, Redacted, Schedule } from "effect";
+import { posixPath } from "@ax/lib/shared/path";
 import { AxConfig, type AxConfigShape } from "./config.ts";
 import { DbError } from "./errors.ts";
 
@@ -260,8 +261,27 @@ interface QueryLogState {
     readonly full: boolean;
 }
 
-const queryLogConfig: Effect.Effect<QueryLogState | undefined> = Effect.gen(
-    function* () {
+/**
+ * Keep shorthand/flag-like values out of the caller's cwd. Explicit paths
+ * retain their existing meaning; bare names are made recognizable and routed
+ * under ax's data directory.
+ */
+export const resolveQueryLogPath = (
+    value: string,
+    dataDir: string,
+    cwd: string,
+): string => {
+    if (value.includes("/")) return value;
+    const resolvedDataDir = posixPath.resolve(cwd, dataDir);
+    return posixPath.join(
+        resolvedDataDir,
+        `db-query-${encodeURIComponent(value)}.querylog`,
+    );
+};
+
+const queryLogConfig = (
+    dataDir: string,
+): Effect.Effect<QueryLogState | undefined> => Effect.gen(function* () {
         const path = Option.getOrUndefined(
             yield* Config.string("AX_DB_QUERY_LOG").pipe(Config.option),
         );
@@ -269,9 +289,11 @@ const queryLogConfig: Effect.Effect<QueryLogState | undefined> = Effect.gen(
         const full = Option.getOrUndefined(
             yield* Config.string("AX_DB_QUERY_LOG_FULL").pipe(Config.option),
         );
-        return { path, full: full === "1" };
-    },
-).pipe(Effect.orDie);
+        return {
+            path: resolveQueryLogPath(path, dataDir, process.cwd()),
+            full: full === "1",
+        };
+    }).pipe(Effect.orDie);
 
 let queryLogSeq = 0;
 let queryLogSink: ReturnType<ReturnType<typeof Bun.file>["writer"]> | null = null;
@@ -394,7 +416,7 @@ export const SurrealClientLive: Layer.Layer<SurrealClient, DbError, AxConfig> =
     Layer.effect(SurrealClient)(
         Effect.gen(function* () {
             const cfg = yield* AxConfig;
-            const queryLog = yield* queryLogConfig;
+            const queryLog = yield* queryLogConfig(cfg.paths.dataDir);
             const db = yield* Effect.acquireRelease(acquire(cfg.db), release);
             return wrap(db, queryLog);
         }),


### PR DESCRIPTION
Running with a bare `AX_DB_QUERY_LOG=1` wrote the SurrealQL query log to a file literally named `1` in the cwd (repo root) — 136 KB of query text, untracked, un-gitignored, one `git add -A` from committing inlined query values. `resolveQueryLogPath` now routes a bare (no-slash) value under ax's data dir as `db-query-<value>.querylog`; explicit/dotted paths keep working. Adds .gitignore rules for the log shape + a defensive single-digit-root guard.

From the /improve audit — findings SECURITY-06 / DEBT-03. Fleet chunk `hygiene-stray-file`. Part of #702.

Gates: typecheck 0, db-query-log.test 3/3.

Generated with ax — https://github.com/Necmttn/ax