### PR TITLE
fix(dashboard): harden the loopback daemon — Host check, CORS narrowing, multi-statement query guard (SECURITY-01/02/03)

### DIFF
--- a/apps/axctl/src/dashboard/contract/read-guard.test.ts
+++ b/apps/axctl/src/dashboard/contract/read-guard.test.ts
@@ -37,4 +37,24 @@ describe("isSingleReadStatement", () => {
         expect(isSingleReadStatement("")).toBe(false);
         expect(isSingleReadStatement("   ")).toBe(false);
     });
+
+    test("rejects a stacked write hidden after a line comment terminated by a non-\\n line terminator (SurrealDB lexer parity)", () => {
+        // CR (\r) terminates a SurrealDB single-line comment, same as LF.
+        expect(isSingleReadStatement("SELECT 1 --\r;DELETE FROM session")).toBe(false);
+        // `#` comment + CR terminator.
+        expect(isSingleReadStatement("SELECT 1 #\r;DELETE FROM session")).toBe(false);
+        // Unicode line separator (U+2028) also terminates the comment.
+        expect(isSingleReadStatement("SELECT 1 -- \u2028;DELETE FROM session")).toBe(false);
+        // Unicode paragraph separator (U+2029) and NEL (U+0085) too.
+        expect(isSingleReadStatement("SELECT 1 -- \u2029;DELETE FROM session")).toBe(false);
+        expect(isSingleReadStatement("SELECT 1 -- \u0085;DELETE FROM session")).toBe(false);
+    });
+
+    test("accepts a legitimate single read using a // line comment", () => {
+        expect(isSingleReadStatement("SELECT 1 // note")).toBe(true);
+    });
+
+    test("rejects a stacked write hidden after a // comment terminated by CR", () => {
+        expect(isSingleReadStatement("SELECT 1 //\r;DELETE FROM session")).toBe(false);
+    });
 });

--- a/apps/axctl/src/dashboard/contract/read-guard.test.ts
+++ b/apps/axctl/src/dashboard/contract/read-guard.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { isSingleReadStatement } from "./read-guard.ts";
+
+describe("isSingleReadStatement", () => {
+    test("accepts a single read statement, optional trailing semicolon", () => {
+        expect(isSingleReadStatement("SELECT * FROM session")).toBe(true);
+        expect(isSingleReadStatement("SELECT * FROM session;")).toBe(true);
+        expect(isSingleReadStatement("  select 1  ")).toBe(true);
+        expect(isSingleReadStatement("RETURN 1;")).toBe(true);
+        expect(isSingleReadStatement("INFO FOR DB")).toBe(true);
+    });
+
+    test("rejects a stacked write after a read", () => {
+        expect(isSingleReadStatement("SELECT 1; DELETE FROM session")).toBe(false);
+        expect(isSingleReadStatement("SELECT 1; DELETE FROM session;")).toBe(false);
+        expect(isSingleReadStatement("SELECT 1;\nUPDATE session SET x = 1")).toBe(false);
+    });
+
+    test("rejects a non-read prefix", () => {
+        expect(isSingleReadStatement("DELETE FROM session")).toBe(false);
+        expect(isSingleReadStatement("CREATE session SET x = 1")).toBe(false);
+    });
+
+    test("a semicolon inside a string literal is not a separator", () => {
+        expect(isSingleReadStatement("SELECT * FROM t WHERE name = 'a; b'")).toBe(true);
+        expect(isSingleReadStatement('SELECT * FROM t WHERE name = "a; b";')).toBe(true);
+    });
+
+    test("a semicolon inside a line/block comment is not a separator", () => {
+        expect(isSingleReadStatement("SELECT 1 -- a; b")).toBe(true);
+        expect(isSingleReadStatement("SELECT 1 /* a; b */")).toBe(true);
+        // but a real statement hidden after a comment is still caught
+        expect(isSingleReadStatement("SELECT 1; /* c */ DELETE FROM t")).toBe(false);
+    });
+
+    test("empty / whitespace is not a read statement", () => {
+        expect(isSingleReadStatement("")).toBe(false);
+        expect(isSingleReadStatement("   ")).toBe(false);
+    });
+});

--- a/apps/axctl/src/dashboard/contract/read-guard.ts
+++ b/apps/axctl/src/dashboard/contract/read-guard.ts
@@ -1,0 +1,63 @@
+/**
+ * Read-only guard for the studio /api/query surface. SurrealDB runs every
+ * `;`-separated statement, so a prefix-only allow (`/^SELECT/`) lets
+ * `SELECT 1; DELETE …` through. We reject any input that is more than ONE
+ * statement, then require a read prefix. String literals and comments are
+ * blanked first so a `;` inside them is not mistaken for a separator.
+ */
+
+/** Replace string-literal and comment spans with spaces, preserving length. */
+function stripLiteralsAndComments(sql: string): string {
+    let out = "";
+    let i = 0;
+    const n = sql.length;
+    while (i < n) {
+        const c = sql[i]!;
+        // single- or double-quoted string
+        if (c === "'" || c === '"') {
+            const quote = c;
+            out += " ";
+            i++;
+            while (i < n) {
+                if (sql[i] === "\\") { out += "  "; i += 2; continue; }
+                if (sql[i] === quote) { out += " "; i++; break; }
+                out += " ";
+                i++;
+            }
+            continue;
+        }
+        // line comment -- ... or # ... to end of line
+        if ((c === "-" && sql[i + 1] === "-") || c === "#") {
+            while (i < n && sql[i] !== "\n") { out += " "; i++; }
+            continue;
+        }
+        // block comment /* ... */
+        if (c === "/" && sql[i + 1] === "*") {
+            out += "  ";
+            i += 2;
+            while (i < n && !(sql[i] === "*" && sql[i + 1] === "/")) { out += " "; i++; }
+            if (i < n) { out += "  "; i += 2; }
+            continue;
+        }
+        out += c;
+        i++;
+    }
+    return out;
+}
+
+const READ_PREFIX_RE = /^(SELECT|RETURN|INFO)\b/i;
+
+/**
+ * True only when `sql` is a single read statement (SELECT/RETURN/INFO), with at
+ * most one optional trailing `;`. Multi-statement input is rejected outright.
+ */
+export function isSingleReadStatement(sql: string): boolean {
+    const trimmed = sql.trim();
+    if (!trimmed) return false;
+    const stripped = stripLiteralsAndComments(trimmed);
+    // Drop a single trailing semicolon (plus trailing ws), then any remaining
+    // `;` means a second statement.
+    const withoutTrailing = stripped.replace(/;\s*$/, "");
+    if (withoutTrailing.includes(";")) return false;
+    return READ_PREFIX_RE.test(trimmed);
+}

--- a/apps/axctl/src/dashboard/contract/read-guard.ts
+++ b/apps/axctl/src/dashboard/contract/read-guard.ts
@@ -26,9 +26,28 @@ function stripLiteralsAndComments(sql: string): string {
             }
             continue;
         }
-        // line comment -- ... or # ... to end of line
-        if ((c === "-" && sql[i + 1] === "-") || c === "#") {
-            while (i < n && sql[i] !== "\n") { out += " "; i++; }
+        // line comment -- ..., # ..., or // ... to end of line. SurrealDB's
+        // lexer terminates a single-line comment on any of: LF, CR, and the
+        // Unicode line terminators LS (U+2028), PS (U+2029), NEL (U+0085) -
+        // not just "\n". Match that exactly, or a `;` after one of the wider
+        // terminators is blanked-out-hidden from the scanner above but still
+        // executed by SurrealDB as a real statement separator.
+        if (
+            (c === "-" && sql[i + 1] === "-") ||
+            c === "#" ||
+            (c === "/" && sql[i + 1] === "/")
+        ) {
+            while (
+                i < n &&
+                sql[i] !== "\n" &&
+                sql[i] !== "\r" &&
+                sql[i] !== "\u2028" &&
+                sql[i] !== "\u2029" &&
+                sql[i] !== "\u0085"
+            ) {
+                out += " ";
+                i++;
+            }
             continue;
         }
         // block comment /* ... */

--- a/apps/axctl/src/dashboard/contract/system.test.ts
+++ b/apps/axctl/src/dashboard/contract/system.test.ts
@@ -82,8 +82,23 @@ describe("contract system group", () => {
         const res = await handler(req("POST", "/api/query", { sql: "DELETE FROM session" }));
         expect(res.status).toBe(400);
         await expect(res.json()).resolves.toMatchObject({
-            error: "Only SELECT, RETURN, and INFO queries are allowed",
+            error: "Only a single SELECT, RETURN, or INFO statement is allowed",
         });
+    });
+
+    test("POST /api/query rejects a stacked write after a read (multi-statement)", async () => {
+        const { handler } = make();
+        const res = await handler(req("POST", "/api/query", { sql: "SELECT 1; DELETE FROM session" }));
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toMatchObject({
+            error: expect.stringContaining("single"),
+        });
+    });
+
+    test("POST /api/query still accepts a single read with a trailing semicolon", async () => {
+        const { handler } = make();
+        const res = await handler(req("POST", "/api/query", { sql: "SELECT * FROM session;" }));
+        expect(res.status).toBe(200);
     });
 
     test("POST /api/query rejects empty SQL with 400", async () => {

--- a/apps/axctl/src/dashboard/contract/system.ts
+++ b/apps/axctl/src/dashboard/contract/system.ts
@@ -20,6 +20,7 @@ import { graphHealthSql } from "../../queries/graph-health.ts";
 import { API_VERSION, dashboardApiCapabilities } from "../capabilities.ts";
 import { fetchWorktreesOverview } from "../worktrees-overview.ts";
 import { asJsonValue } from "./common.ts";
+import { isSingleReadStatement } from "./read-guard.ts";
 
 /**
  * Boot-time facts the contract handlers need from `serveDashboard`: the
@@ -56,9 +57,9 @@ export const SystemGroupLive = HttpApiBuilder.group(AxApi, "system", (handlers) 
             Effect.gen(function* () {
                 const sql = payload.sql.trim();
                 if (!sql) return yield* new QueryRejected({ error: "SQL is required" });
-                if (!/^(SELECT|RETURN|INFO)\b/i.test(sql)) {
+                if (!isSingleReadStatement(sql)) {
                     return yield* new QueryRejected({
-                        error: "Only SELECT, RETURN, and INFO queries are allowed",
+                        error: "Only a single SELECT, RETURN, or INFO statement is allowed",
                     });
                 }
                 const started = performance.now();

--- a/apps/axctl/src/dashboard/server.test.ts
+++ b/apps/axctl/src/dashboard/server.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import {
     handleDashboardRequest,
     handleDashboardRequestWithCors,
+    isAllowedHost,
     parseDashboardServeArgs,
 } from "./server.ts";
 import { dashboardApiCapabilities, isGraphExplorerEnabled } from "./capabilities.ts";
@@ -176,5 +177,89 @@ describe("dashboard server", () => {
             new Request("http://127.0.0.1:1738/assets/definitely-not-a-real-hash-xyz.js"),
         );
         expect(res.status).toBe(404);
+    });
+});
+
+describe("Host-header validation (DNS-rebinding defense)", () => {
+    test("isAllowedHost accepts loopback hosts with optional port", () => {
+        expect(isAllowedHost("127.0.0.1")).toBe(true);
+        expect(isAllowedHost("127.0.0.1:1738")).toBe(true);
+        expect(isAllowedHost("localhost")).toBe(true);
+        expect(isAllowedHost("localhost:1738")).toBe(true);
+        expect(isAllowedHost("[::1]")).toBe(true);
+        expect(isAllowedHost("[::1]:1738")).toBe(true);
+        expect(isAllowedHost(null)).toBe(true); // non-browser client omits Host
+    });
+
+    test("isAllowedHost rejects foreign hosts", () => {
+        expect(isAllowedHost("attacker.com")).toBe(false);
+        expect(isAllowedHost("attacker.com:1738")).toBe(false);
+        expect(isAllowedHost("ax.necmttn.com")).toBe(false);
+        expect(isAllowedHost("127.0.0.1.attacker.com")).toBe(false);
+        expect(isAllowedHost("0.0.0.0")).toBe(false);
+    });
+
+    test("a foreign Host header is 403ed before dispatch (reads included)", async () => {
+        const res = await handleDashboardRequestWithCors(
+            new Request("http://127.0.0.1:1738/api/version", { headers: { host: "attacker.com" } }),
+        );
+        expect(res.status).toBe(403);
+    });
+
+    test("a foreign Host on a state-changing route is 403ed", async () => {
+        const res = await handleDashboardRequestWithCors(
+            new Request("http://127.0.0.1:1738/api/query", {
+                method: "POST",
+                headers: { host: "attacker.com", "content-type": "application/json" },
+                body: JSON.stringify({ sql: "SELECT 1" }),
+            }),
+        );
+        expect(res.status).toBe(403);
+    });
+
+    test("a foreign Host is 403ed on OPTIONS preflight too", async () => {
+        const res = await handleDashboardRequestWithCors(
+            new Request("http://127.0.0.1:1738/api/version", {
+                method: "OPTIONS",
+                headers: { host: "attacker.com", origin: "https://ax.necmttn.com" },
+            }),
+        );
+        expect(res.status).toBe(403);
+    });
+
+    test("loopback Host on a normal request still works", async () => {
+        const res = await handleDashboardRequestWithCors(
+            new Request("http://127.0.0.1:1738/api/version", { headers: { host: "127.0.0.1:1738" } }),
+        );
+        expect(res.status).toBe(200);
+    });
+});
+
+describe("CORS write-method narrowing (finding #3)", () => {
+    test("studio origin gets the full method set", async () => {
+        const res = await handleDashboardRequestWithCors(preflight({ origin: "https://ax.necmttn.com" }));
+        expect(res.headers.get("access-control-allow-methods")).toBe("GET, POST, DELETE, OPTIONS");
+    });
+
+    test("desktop ax://studio origin gets the full method set", async () => {
+        const res = await handleDashboardRequestWithCors(preflight({ origin: "ax://studio" }));
+        expect(res.headers.get("access-control-allow-methods")).toBe("GET, POST, DELETE, OPTIONS");
+    });
+
+    test("a bare localhost dev origin gets read-only methods (no POST/DELETE)", async () => {
+        const res = await handleDashboardRequestWithCors(preflight({ origin: "http://localhost:3000" }));
+        const methods = res.headers.get("access-control-allow-methods") ?? "";
+        expect(methods).toBe("GET, OPTIONS");
+        expect(methods).not.toContain("POST");
+        expect(methods).not.toContain("DELETE");
+    });
+
+    test("localhost dev origin still gets a CORS grant + PNA (not fully blocked)", async () => {
+        const res = await handleDashboardRequestWithCors(preflight({
+            origin: "http://127.0.0.1:5173",
+            "access-control-request-private-network": "true",
+        }));
+        expect(res.headers.get("access-control-allow-origin")).toBe("http://127.0.0.1:5173");
+        expect(res.headers.get("access-control-allow-private-network")).toBe("true");
     });
 });

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -142,12 +142,35 @@ function isLocalDevOrigin(origin: string): boolean {
     return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
 }
 
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
+
+/**
+ * True when the Host header names the loopback interface (optional :port), or
+ * is absent. A DNS-rebinding page re-points its own domain at 127.0.0.1 and
+ * issues same-origin requests, sailing past CORS; the only value it cannot
+ * forge is the Host header (the browser always sends its own domain). So a
+ * PRESENT, non-loopback Host is rejected; a MISSING Host (curl, unit tests,
+ * non-browser callers) is allowed - a browser can never produce that.
+ */
+export function isAllowedHost(host: string | null): boolean {
+    if (host === null || host === "") return true;
+    const hostname = host.startsWith("[")
+        ? host.slice(0, host.indexOf("]") + 1) // strip :port after ]
+        : host.split(":")[0]!;
+    return LOOPBACK_HOSTS.has(hostname);
+}
+
 function corsHeadersFor(origin: string | null, requestedHeaders?: string | null): Record<string, string> {
     if (!origin) return {};
-    if (!STUDIO_ORIGINS.has(origin) && !isLocalDevOrigin(origin)) return {};
+    const isStudio = STUDIO_ORIGINS.has(origin);
+    if (!isStudio && !isLocalDevOrigin(origin)) return {};
     return {
         "Access-Control-Allow-Origin": origin,
-        "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+        // Studio (hosted + desktop) is the only origin trusted with the
+        // state-changing verbs. A bare localhost dev page gets read-only CORS
+        // so it can't POST/DELETE cross-origin; Host validation (server.ts)
+        // is the primary state-change defense regardless of Origin.
+        "Access-Control-Allow-Methods": isStudio ? "GET, POST, DELETE, OPTIONS" : "GET, OPTIONS",
         // Echo whatever the preflight asked for. A browser fails the preflight
         // when ANY requested header is missing from the allow list, and the
         // desktop studio's Effect HttpClient adds tracing headers (traceparent)
@@ -168,6 +191,10 @@ export async function handleDashboardRequestWithCors(
     serve: ServeContext | null = null,
     contract: ContractWebHandler | null = null,
 ): Promise<Response> {
+    if (!isAllowedHost(req.headers.get("host"))) {
+        return new Response("forbidden", { status: 403 });
+    }
+
     const origin = req.headers.get("origin");
     const cors = corsHeadersFor(origin, req.headers.get("access-control-request-headers"));
 


### PR DESCRIPTION
Hardens the `ax serve` daemon against a malicious webpage reaching 127.0.0.1:1738:
- **SECURITY-01 (DNS-rebinding):** validate the `Host` header (loopback only; a missing Host can't come from a browser, a rebinding attacker can't forge a loopback Host) at the top of the request path — guards ALL routes.
- **SECURITY-03 (CORS):** a bare localhost dev origin now gets read-only methods (GET, OPTIONS); only studio origins keep POST/DELETE.
- **SECURITY-02 (query guard):** `/api/query` read-guard now rejects multi-statement SQL (`SELECT 1; DELETE …`) — strips string literals + all comment forms (incl. SurrealDB's U+2028/2029/0085 line-comment terminators) before checking for a second statement, then requires a SELECT/RETURN/INFO prefix.

From the /improve audit — SECURITY-01/02/03. Fleet chunk `sec-daemon`. Part of #702.

NOTE: SECURITY-04 (`/api/image` path confinement) is NOT in this PR — the pane hit the account spend limit mid-task; it's being finished as a separate chunk.

Gates: typecheck 0, read-guard/system/server tests 51/51, check:no-node-fs 0.

Generated with ax — https://github.com/Necmttn/ax