### PR TITLE
fix(dashboard): confine GET /api/image to an allowlisted, canonicalized boundary (SECURITY-04)

### DIFF
--- a/apps/axctl/src/dashboard/router/routes/live.test.ts
+++ b/apps/axctl/src/dashboard/router/routes/live.test.ts
@@ -1,15 +1,25 @@
 import { describe, expect, test } from "bun:test";
+import { BunFileSystem } from "@effect/platform-bun";
+import { Effect } from "effect";
+import { mkdir, mkdtemp, realpath, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
     formatSseComment,
     formatSseEvent,
+    handleImageRequest,
     handleEventsRequest,
     imageContentType,
+    isPathWithinRoots,
     liveRoutes,
     recentIngestEventsSql,
+    resolveConfinedImage,
 } from "./live.ts";
 import { matchRoute, type EffectRunner } from "../router.ts";
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+const runFs = <A>(effect: Effect.Effect<A, unknown, import("effect").FileSystem.FileSystem>) =>
+    Effect.runPromise(effect.pipe(Effect.provide(BunFileSystem.layer)));
 
 /** Drain an SSE response body to text until it ends or `cancel` is called. */
 async function drainStream(res: Response, runMs: number): Promise<string> {
@@ -48,6 +58,92 @@ describe("imageContentType", () => {
         expect(imageContentType("/a/notes.txt")).toBeNull();
         expect(imageContentType("/a/script.sh")).toBeNull();
         expect(imageContentType("noext")).toBeNull();
+    });
+});
+
+describe("confined image paths", () => {
+    test("recognizes only exact roots and true descendants", () => {
+        expect(isPathWithinRoots("/safe/images/shot.png", ["/safe/images"])).toBe(true);
+        expect(isPathWithinRoots("/safe/images", ["/safe/images"])).toBe(true);
+        expect(isPathWithinRoots("/safe/images-extra/shot.png", ["/safe/images"])).toBe(false);
+        expect(isPathWithinRoots("/outside/shot.png", ["/safe/images"])).toBe(false);
+    });
+
+    test("rejects an existing image outside the allowed boundary", async () => {
+        const base = await mkdtemp(join(tmpdir(), "ax-image-confine-"));
+        const allowed = join(base, "allowed");
+        const outside = join(base, "outside.png");
+        try {
+            await mkdir(allowed);
+            await Bun.write(outside, "outside");
+            await expect(runFs(resolveConfinedImage(outside, [allowed]))).resolves.toBeNull();
+        } finally {
+            await rm(base, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects .. traversal that resolves outside the allowed boundary", async () => {
+        const base = await mkdtemp(join(tmpdir(), "ax-image-confine-"));
+        const allowed = join(base, "allowed");
+        const nested = join(allowed, "nested");
+        const outside = join(base, "outside.png");
+        try {
+            await mkdir(nested, { recursive: true });
+            await Bun.write(outside, "outside");
+            const traversal = join(nested, "..", "..", "outside.png");
+            await expect(runFs(resolveConfinedImage(traversal, [allowed]))).resolves.toBeNull();
+        } finally {
+            await rm(base, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects a symlink whose target escapes the allowed boundary", async () => {
+        const base = await mkdtemp(join(tmpdir(), "ax-image-confine-"));
+        const allowed = join(base, "allowed");
+        const outside = join(base, "outside.png");
+        const link = join(allowed, "linked.png");
+        try {
+            await mkdir(allowed);
+            await Bun.write(outside, "outside");
+            await symlink(outside, link);
+            await expect(runFs(resolveConfinedImage(link, [allowed]))).resolves.toBeNull();
+        } finally {
+            await rm(base, { recursive: true, force: true });
+        }
+    });
+
+    test("serves a legitimate image inside the allowed boundary", async () => {
+        const base = await mkdtemp(join(tmpdir(), "ax-image-confine-"));
+        const allowed = join(base, "allowed");
+        const image = join(allowed, "shot.png");
+        try {
+            await mkdir(allowed);
+            await Bun.write(image, "image bytes");
+            await expect(runFs(resolveConfinedImage(image, [allowed]))).resolves.toBe(await realpath(image));
+
+            const url = new URL(`http://127.0.0.1:1738/api/image?path=${encodeURIComponent(image)}`);
+            const response = await handleImageRequest(url, [allowed]);
+            expect(response.status).toBe(200);
+            expect(response.headers.get("content-type")).toBe("image/png");
+            await expect(response.text()).resolves.toBe("image bytes");
+        } finally {
+            await rm(base, { recursive: true, force: true });
+        }
+    });
+
+    test("GET /api/image returns an actual 404 for an out-of-boundary image", async () => {
+        const base = await mkdtemp(join(tmpdir(), "ax-image-confine-"));
+        const allowed = join(base, "allowed");
+        const outside = join(base, "outside.png");
+        try {
+            await mkdir(allowed);
+            await Bun.write(outside, "outside");
+            const url = new URL(`http://127.0.0.1:1738/api/image?path=${encodeURIComponent(outside)}`);
+            const response = await handleImageRequest(url, [allowed]);
+            expect(response.status).toBe(404);
+        } finally {
+            await rm(base, { recursive: true, force: true });
+        }
     });
 });
 

--- a/apps/axctl/src/dashboard/router/routes/live.ts
+++ b/apps/axctl/src/dashboard/router/routes/live.ts
@@ -6,8 +6,11 @@
  * POST /api/ingest is served by the contract router (contract/live.ts);
  * the IngestStreamBus/Durable Streams seam is unchanged (ADR-0007/0008).
  */
-import { Effect } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { Effect, FileSystem } from "effect";
 import { SurrealClient } from "@ax/lib/db";
+import { orAbsent } from "@ax/lib/shared/fs-error";
+import { posixPath } from "@ax/lib/shared/path";
 import { addIngestEventSubscriber, removeIngestEventSubscriber } from "../../telemetry.ts";
 import { rawRoute, type AnyRoute, type EffectRunner } from "../router.ts";
 
@@ -33,6 +36,58 @@ export function imageContentType(path: string): string | null {
     const dot = path.lastIndexOf(".");
     if (dot < 0) return null;
     return IMAGE_CONTENT_TYPES[path.slice(dot).toLowerCase()] ?? null;
+}
+
+function defaultImageRoots(): ReadonlyArray<string> {
+    const roots = [process.env.TMPDIR ?? "/tmp"];
+    const home = process.env.HOME;
+    if (home) {
+        roots.push(posixPath.join(home, "Library", "Application Support", "CleanShot", "media"));
+    }
+    return roots;
+}
+
+/**
+ * True when a canonical path is an allowed root or one of its descendants.
+ * Inputs are expected to be absolute, canonical paths.
+ */
+export function isPathWithinRoots(resolvedPath: string, roots: readonly string[]): boolean {
+    return roots.some((root) => {
+        const relative = posixPath.relative(root, resolvedPath);
+        return relative === ""
+            || (!relative.startsWith("..") && !posixPath.isAbsolute(relative));
+    });
+}
+
+/**
+ * Canonicalize a requested image and the allowed roots before checking
+ * containment. Missing paths, non-files, unsupported extensions, and paths
+ * outside every root are all rejected as null.
+ */
+export function resolveConfinedImage(
+    rawPath: string,
+    roots: readonly string[],
+): Effect.Effect<string | null, never, FileSystem.FileSystem> {
+    return Effect.gen(function* () {
+        if (!posixPath.isAbsolute(rawPath) || !imageContentType(rawPath)) return null;
+
+        const fs = yield* FileSystem.FileSystem;
+        const resolvedPath = yield* fs.realPath(rawPath).pipe(orAbsent<string | null>(null));
+        if (resolvedPath === null || !imageContentType(resolvedPath)) return null;
+
+        const resolvedRoots = yield* Effect.forEach(roots, (root) =>
+            fs.realPath(root).pipe(orAbsent<string | null>(null)),
+        );
+        if (!isPathWithinRoots(
+            resolvedPath,
+            resolvedRoots.filter((root): root is string => root !== null),
+        )) {
+            return null;
+        }
+
+        const info = yield* fs.stat(resolvedPath).pipe(orAbsent<FileSystem.File.Info | null>(null));
+        return info?.type === "File" ? resolvedPath : null;
+    });
 }
 
 export function formatSseEvent(event: string, data: unknown): string {
@@ -66,21 +121,25 @@ LIMIT ${safeLimit};`.trim();
  *
  * Serves a local on-disk image so the SPA can render `[Image: source: ...]`
  * transcript refs (a browser can't load `file://` from an http origin). This
- * is a localhost-only personal dev daemon; the safety line is: the path must
- * resolve to an EXISTING regular file with a known image extension. Anything
- * else - missing file, directory, non-image extension, read error - is a flat
- * 404, so we never follow into or leak non-image files.
+ * is a localhost-only personal dev daemon; the safety line is: the canonical
+ * path must stay inside an allowlisted image root and resolve to an existing
+ * regular file with a known image extension. Anything else - missing file,
+ * directory, non-image extension, boundary escape, read error - is a flat 404.
  */
-async function handleImageRequest(url: URL): Promise<Response> {
+export async function handleImageRequest(
+    url: URL,
+    roots: readonly string[] = defaultImageRoots(),
+): Promise<Response> {
     const raw = url.searchParams.get("path");
     if (!raw) return new Response("not found", { status: 404 });
-    const contentType = imageContentType(raw);
-    if (!contentType) return new Response("not found", { status: 404 });
     try {
-        const file = Bun.file(raw);
-        // `exists()` is false for a missing path; a directory yields size 0 and
-        // a failing read below. Bun.file on a dir does not throw on `exists`.
-        if (!(await file.exists())) return new Response("not found", { status: 404 });
+        const resolvedPath = await Effect.runPromise(
+            resolveConfinedImage(raw, roots).pipe(Effect.provide(BunFileSystem.layer)),
+        );
+        if (resolvedPath === null) return new Response("not found", { status: 404 });
+        const contentType = imageContentType(resolvedPath);
+        if (!contentType) return new Response("not found", { status: 404 });
+        const file = Bun.file(resolvedPath);
         const bytes = await file.arrayBuffer();
         return new Response(bytes, {
             headers: {


### PR DESCRIPTION
Completes the SECURITY-04 half that PR #712 couldn't finish. /api/image served any image-extension file at any absolute path (arbitrary read + existence oracle). Now canonicalizes the requested path (realPath — resolves ../symlinks), requires it to stay inside an allowlisted image root AND be a regular file, else 404. Uses the shared posixPath helper (no node:path in app source).

Static-allowlist approach (the audit's acceptable fallback); graph-membership hardening — broader + stronger — is filed as https://github.com/Necmttn/ax/issues/717.

From the /improve audit — finding SECURITY-04. Fleet chunk `sec-image-path`. Part of #702.

Gates: typecheck 0, live.test 18/18, check:no-node-fs 0.

Generated with ax — https://github.com/Necmttn/ax