### PR TITLE
fix(ingest): auto-reap stranded runs + stale-graph warning + derive budgets (#697)

### DIFF
--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -315,6 +315,13 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
             debug: args.includes("--debug"),
             verbose: args.includes("--verbose"),
             runId: () => runId,
+            // This run IS wrapped in withIngestLock's hard timeout below, so it
+            // genuinely owns a deadline - derive stages are budgeted against it
+            // so the pass finalizes itself instead of being guillotined (#697).
+            // Computed from the same `timeoutSeconds` knob the lock uses; the
+            // lock's own clock starts a hair after this, so the deadline reads
+            // slightly early - the derive reserve absorbs that.
+            ...(timeoutSeconds > 0 ? { deadlineMs: Date.now() + timeoutSeconds * 1000 } : {}),
         });
 
         // Single-flight + hard wall-clock cap, both owned by the lock. While one

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -63,7 +63,7 @@ import { appendUsageRecord, defaultUsageLogPath, redactInvocation } from "../usa
 import { stderrExit } from "./output.ts";
 import { agentsCommand, agentsRuntime } from "../agents/cli.ts";
 import { correlateOrphanOtel } from "../otel/correlate.ts";
-import { warnIfIngestStale } from "../queries/ingest-staleness.ts";
+import { withIngestStalenessPreflight } from "../queries/ingest-staleness.ts";
 import { ALL_STAGES } from "../ingest/stage/registry.ts";
 import { IngestRuntimeLayer, ingestRuntimeLayerWith } from "../ingest/stage/runtime.ts";
 import { ConsoleTransportLayer } from "@ax/lib/live-traces/transports/console";
@@ -217,13 +217,13 @@ type CliProgram = Effect.Effect<void, unknown, never>;
  * whose handlers actually touch SurrealDB.
  *
  * Every such command also gets the stale-graph warning (#697): one indexed
- * query, stderr only, after the command's own output so it lands next to the
- * prompt. `ensuring` (not `tap`) so a command that returned empty BECAUSE the
- * graph is stale - the #697 symptom - still explains itself when it fails.
+ * query, stderr only, before the command body. This is deliberately a
+ * pre-flight rather than an `ensuring` finalizer because legacy handlers that
+ * call `process.exit` bypass Effect finalizers; the warning must still cover
+ * those stale-graph symptom paths.
  */
 const withDb = (args: ReadonlyArray<string>): CliProgram =>
-    runCli(args).pipe(
-        Effect.ensuring(warnIfIngestStale),
+    withIngestStalenessPreflight(runCli(args)).pipe(
         Effect.provide(AppLayer),
         Effect.scoped,
     );

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -63,6 +63,7 @@ import { appendUsageRecord, defaultUsageLogPath, redactInvocation } from "../usa
 import { stderrExit } from "./output.ts";
 import { agentsCommand, agentsRuntime } from "../agents/cli.ts";
 import { correlateOrphanOtel } from "../otel/correlate.ts";
+import { warnIfIngestStale } from "../queries/ingest-staleness.ts";
 import { ALL_STAGES } from "../ingest/stage/registry.ts";
 import { IngestRuntimeLayer, ingestRuntimeLayerWith } from "../ingest/stage/runtime.ts";
 import { ConsoleTransportLayer } from "@ax/lib/live-traces/transports/console";
@@ -214,9 +215,18 @@ type CliProgram = Effect.Effect<void, unknown, never>;
  * Provide AppLayer (SurrealClient + AxConfig + ProcessService) and a
  * scope so handlers that allocate scoped resources work. Used by commands
  * whose handlers actually touch SurrealDB.
+ *
+ * Every such command also gets the stale-graph warning (#697): one indexed
+ * query, stderr only, after the command's own output so it lands next to the
+ * prompt. `ensuring` (not `tap`) so a command that returned empty BECAUSE the
+ * graph is stale - the #697 symptom - still explains itself when it fails.
  */
 const withDb = (args: ReadonlyArray<string>): CliProgram =>
-    runCli(args).pipe(Effect.provide(AppLayer), Effect.scoped);
+    runCli(args).pipe(
+        Effect.ensuring(warnIfIngestStale),
+        Effect.provide(AppLayer),
+        Effect.scoped,
+    );
 
 /**
  * Provide IngestRuntimeLayer (AppLayer + StageRegistryDefault) for the

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -32,6 +32,11 @@ import { envConfig as readDbEnvConfig } from "@ax/lib/db";
 import { DEFAULT_INGEST_TIMEOUT_SECONDS } from "@ax/lib/config";
 import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
 import { provisionRetroReviewerAgent } from "./managed-agents.ts";
+import {
+    isStrandedRun,
+    REAP_GRACE_SECONDS,
+    type IngestRunHeartbeatRow,
+} from "@ax/lib/shared/ingest-staleness";
 
 /**
  * Tagged failure for install steps (surreal resolution, symlinking). Extends
@@ -923,14 +928,6 @@ async function probeMissingBuckets(endpoint: { host: string; port: number }): Pr
     }
 }
 
-/** A row from `SELECT ... FROM ingest_run WHERE status = 'running'`. */
-export interface RunningIngestRunRow {
-    readonly id?: unknown;
-    readonly command?: unknown;
-    readonly started_at?: unknown;
-    readonly last_progress_at?: unknown;
-}
-
 /**
  * Ingest wall-clock budget (seconds). Doctor runs on the no-DB code path
  * (no AxConfig layer), so mirror the `AX_INGEST_TIMEOUT_SECONDS` knob with
@@ -942,23 +939,17 @@ function ingestTimeoutSecondsFromEnv(): number {
 }
 
 /**
- * Rows whose newest heartbeat (`last_progress_at`, else `started_at`) is older
- * than `staleAfterMs`. A run still in status "running" past the ingest timeout
- * was crashed/killed without finalizing - every clean exit path (ok, error,
- * interrupt, timeout) settles the row, so a stale "running" row is a lie that
- * misleads diagnosis (issue #269). Exported for tests.
+ * Rows whose newest heartbeat is older than `staleAfterMs` - crash residue that
+ * never finalized (issue #269). Thin filter over the shared
+ * {@link isStrandedRun} rule so doctor and the reapers can't drift. Exported
+ * for tests.
  */
 export function staleRunningIngestRuns(
-    rows: readonly RunningIngestRunRow[],
+    rows: readonly IngestRunHeartbeatRow[],
     nowMs: number,
     staleAfterMs: number,
-): RunningIngestRunRow[] {
-    return rows.filter((row) => {
-        const beat = Date.parse(String(row.last_progress_at ?? row.started_at ?? ""));
-        // No parseable timestamp at all: can't prove it's live, flag it.
-        if (!Number.isFinite(beat)) return true;
-        return nowMs - beat > staleAfterMs;
-    });
+): IngestRunHeartbeatRow[] {
+    return rows.filter((row) => isStrandedRun(row, nowMs, staleAfterMs));
 }
 
 /**
@@ -969,7 +960,7 @@ export function staleRunningIngestRuns(
 async function probeStaleIngestRuns(
     endpoint: { host: string; port: number },
     staleAfterMs: number,
-): Promise<RunningIngestRunRow[] | null> {
+): Promise<IngestRunHeartbeatRow[] | null> {
     try {
         const db = readDbEnvConfig();
         const res = await fetch(`http://${endpoint.host}:${endpoint.port}/sql`, {
@@ -984,7 +975,7 @@ async function probeStaleIngestRuns(
             signal: AbortSignal.timeout(3000),
         });
         if (!res.ok) return null;
-        const out = (await res.json()) as Array<{ result?: RunningIngestRunRow[] }>;
+        const out = (await res.json()) as Array<{ result?: IngestRunHeartbeatRow[] }>;
         const rows = out?.[0]?.result;
         if (!Array.isArray(rows)) return null;
         return staleRunningIngestRuns(rows, Date.now(), staleAfterMs);
@@ -1026,7 +1017,7 @@ export function collectDoctorReport(): Effect.Effect<
         const ingestTimeoutSeconds = ingestTimeoutSecondsFromEnv();
         const staleIngestRuns = dbReachable
             ? yield* Effect.promise(() =>
-                probeStaleIngestRuns(daemon.endpoint, (ingestTimeoutSeconds + 60) * 1000))
+                probeStaleIngestRuns(daemon.endpoint, (ingestTimeoutSeconds + REAP_GRACE_SECONDS) * 1000))
             : null;
         const checks: DoctorCheck[] = [
             {

--- a/apps/axctl/src/dashboard/reap-loop.test.ts
+++ b/apps/axctl/src/dashboard/reap-loop.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test";
+import { Duration, Effect, Fiber, Layer, Path } from "effect";
+import { TestClock } from "effect/testing";
+import { BunFileSystem } from "@effect/platform-bun";
+import { AxConfigTest } from "@ax/lib/config";
+import { DbError } from "@ax/lib/errors";
+import { makeTestSurrealClient, type TestSurrealRoutes } from "@ax/lib/testing/surreal";
+import { reapIntervalSeconds, runReapLoop, superviseReapLoop } from "./reap-loop.ts";
+
+const strandedRow = { id: "ingest_run:dead", started_at: "2020-01-01T00:00:00.000Z" };
+
+const harness = (routes: TestSurrealRoutes) => {
+    const tc = makeTestSurrealClient({ routes });
+    const layer = Layer.mergeAll(
+        tc.layer,
+        AxConfigTest({ knobs: { ingestTimeoutSeconds: 900 } }).pipe(Layer.provide(BunFileSystem.layer)),
+        BunFileSystem.layer,
+        Path.layer,
+    );
+    return { tc, layer };
+};
+
+const reapUpdates = (captured: readonly string[]): string[] =>
+    captured.filter((sql) => sql.startsWith("UPDATE ingest_run:"));
+
+describe("reapIntervalSeconds", () => {
+    test("defaults to 300s", () => {
+        expect(reapIntervalSeconds({} as NodeJS.ProcessEnv)).toBe(300);
+    });
+
+    test("honours AX_REAP_INTERVAL_SECONDS", () => {
+        expect(reapIntervalSeconds({ AX_REAP_INTERVAL_SECONDS: "30" } as NodeJS.ProcessEnv)).toBe(30);
+    });
+
+    test("0 disables the loop; garbage falls back to the default", () => {
+        expect(reapIntervalSeconds({ AX_REAP_INTERVAL_SECONDS: "0" } as NodeJS.ProcessEnv)).toBe(0);
+        expect(reapIntervalSeconds({ AX_REAP_INTERVAL_SECONDS: "nonsense" } as NodeJS.ProcessEnv)).toBe(300);
+    });
+
+    // An exported-but-blank env var (launchd plist entry, shell profile line)
+    // must read as UNSET, not as an explicit "0" disable - `Number("")` and
+    // `Number(" ")` are both `0`, which is finite and `>= 0`.
+    test("empty or whitespace-only value falls back to the default (unset, not disabled)", () => {
+        expect(reapIntervalSeconds({ AX_REAP_INTERVAL_SECONDS: "" } as NodeJS.ProcessEnv)).toBe(300);
+        expect(reapIntervalSeconds({ AX_REAP_INTERVAL_SECONDS: "   " } as NodeJS.ProcessEnv)).toBe(300);
+    });
+});
+
+describe("superviseReapLoop", () => {
+    // Flush the microtask queue so a synchronously-rejected `run()`'s
+    // `.catch` handler (and any onError/scheduleRetry it triggers) has run.
+    const flush = async (): Promise<void> => {
+        await Promise.resolve();
+        await Promise.resolve();
+    };
+
+    test("a rejected run is re-armed after intervalMs, not dropped", async () => {
+        let calls = 0;
+        const scheduled: Array<{ fn: () => void; ms: number }> = [];
+        superviseReapLoop({
+            run: () => {
+                calls += 1;
+                return Promise.reject(new Error("db down"));
+            },
+            intervalMs: 5000,
+            scheduleRetry: (fn, ms) => scheduled.push({ fn, ms }),
+        });
+        await flush();
+
+        expect(calls).toBe(1);
+        expect(scheduled).toHaveLength(1);
+        expect(scheduled[0]?.ms).toBe(5000);
+    });
+
+    test("invoking the scheduled retry genuinely runs the loop again", async () => {
+        let calls = 0;
+        const scheduled: Array<() => void> = [];
+        superviseReapLoop({
+            run: () => {
+                calls += 1;
+                // Reject once (DB not up yet), then succeed (runtime healed).
+                return calls === 1 ? Promise.reject(new Error("db down")) : Promise.resolve(undefined);
+            },
+            intervalMs: 1000,
+            scheduleRetry: (fn) => scheduled.push(fn),
+        });
+        await flush();
+        expect(calls).toBe(1);
+        expect(scheduled).toHaveLength(1);
+
+        scheduled[0]?.();
+        expect(calls).toBe(2);
+    });
+
+    test("repeated failures keep re-arming - it must never give up after one retry", async () => {
+        let calls = 0;
+        const scheduled: Array<() => void> = [];
+        superviseReapLoop({
+            run: () => {
+                calls += 1;
+                return Promise.reject(new Error("still down"));
+            },
+            intervalMs: 1000,
+            scheduleRetry: (fn) => scheduled.push(fn),
+        });
+
+        for (let i = 1; i <= 4; i += 1) {
+            await flush();
+            expect(calls).toBe(i);
+            expect(scheduled).toHaveLength(1);
+            const next = scheduled.pop();
+            next?.();
+        }
+    });
+
+    test("reports the rejection reason via onError", async () => {
+        const errors: unknown[] = [];
+        superviseReapLoop({
+            run: () => Promise.reject(new Error("boom")),
+            intervalMs: 1000,
+            scheduleRetry: () => undefined,
+            onError: (err) => errors.push(err),
+        });
+        await flush();
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toBeInstanceOf(Error);
+        expect((errors[0] as Error).message).toBe("boom");
+    });
+});
+
+describe("runReapLoop", () => {
+    test("reaps a stranded row on the first tick, without waiting for an interval", async () => {
+        const { tc, layer } = harness({ "FROM ingest_run WHERE status = 'running'": [[strandedRow]] });
+
+        await Effect.runPromise(
+            Effect.gen(function* () {
+                const fiber = yield* Effect.forkChild(runReapLoop({ intervalSeconds: 300 }));
+                yield* TestClock.adjust(Duration.zero);
+                // The real observable effect: the stuck row is settled in the DB.
+                expect(reapUpdates(tc.captured)).toHaveLength(1);
+                expect(reapUpdates(tc.captured)[0]).toContain(`status = "partial"`);
+                yield* Fiber.interrupt(fiber);
+            }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer()), Effect.scoped),
+        );
+    });
+
+    test("keeps sweeping on each interval", async () => {
+        const { tc, layer } = harness({ "FROM ingest_run WHERE status = 'running'": [[strandedRow]] });
+
+        await Effect.runPromise(
+            Effect.gen(function* () {
+                const fiber = yield* Effect.forkChild(runReapLoop({ intervalSeconds: 300 }));
+                yield* TestClock.adjust(Duration.zero);
+                expect(reapUpdates(tc.captured)).toHaveLength(1);
+                yield* TestClock.adjust(Duration.minutes(5));
+                expect(reapUpdates(tc.captured)).toHaveLength(2);
+                yield* TestClock.adjust(Duration.minutes(5));
+                expect(reapUpdates(tc.captured)).toHaveLength(3);
+                yield* Fiber.interrupt(fiber);
+            }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer()), Effect.scoped),
+        );
+    });
+
+    test("a failing DB does not kill the loop - the next tick still sweeps", async () => {
+        let call = 0;
+        const { tc, layer } = harness({
+            "FROM ingest_run WHERE status = 'running'": () => {
+                call += 1;
+                return call === 1
+                    ? Effect.fail(new DbError({ operation: "query", message: "connection refused" }))
+                    : [[strandedRow]];
+            },
+        });
+
+        await Effect.runPromise(
+            Effect.gen(function* () {
+                const fiber = yield* Effect.forkChild(runReapLoop({ intervalSeconds: 300 }));
+                yield* TestClock.adjust(Duration.zero);
+                expect(reapUpdates(tc.captured)).toHaveLength(0); // first tick failed
+                yield* TestClock.adjust(Duration.minutes(5));
+                expect(reapUpdates(tc.captured)).toHaveLength(1); // recovered
+                yield* Fiber.interrupt(fiber);
+            }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer()), Effect.scoped),
+        );
+    });
+
+    test("leaves a live run alone", async () => {
+        const live = {
+            id: "ingest_run:live",
+            started_at: new Date().toISOString(),
+            last_progress_at: new Date().toISOString(),
+        };
+        const { tc, layer } = harness({ "FROM ingest_run WHERE status = 'running'": [[live]] });
+
+        await Effect.runPromise(
+            Effect.gen(function* () {
+                const fiber = yield* Effect.forkChild(runReapLoop({ intervalSeconds: 300 }));
+                yield* TestClock.adjust(Duration.zero);
+                expect(reapUpdates(tc.captured)).toHaveLength(0);
+                yield* Fiber.interrupt(fiber);
+            }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer()), Effect.scoped),
+        );
+    });
+});

--- a/apps/axctl/src/dashboard/reap-loop.ts
+++ b/apps/axctl/src/dashboard/reap-loop.ts
@@ -1,0 +1,96 @@
+/**
+ * Periodic ingest_run reaper for the serve daemon (#697).
+ *
+ * `reapStaleIngestRuns` (#282/#597) sweeps crash residue, but only at INGEST
+ * START. That covers the watcher model, where the next transcript write fires
+ * an ingest within minutes. It does NOT cover the IDE daemon model (studio.app
+ * owns surreal + serve, no LaunchAgent watcher): when ingest stops running,
+ * nothing ever calls the reaper again. That is exactly how two rows sat
+ * "running" from Jul 3 to Jul 16 with `ax doctor` the only thing that would
+ * have said so - and doctor only runs when a human runs it.
+ *
+ * So: fork the same reap onto the daemon, which IS always up. The reap itself
+ * is unchanged (stranded = heartbeat past ingest timeout + grace, so a live
+ * concurrent run is never touched) - only the trigger is new.
+ */
+import { Duration, Effect, Schedule } from "effect";
+import { AxConfig } from "@ax/lib/config";
+import { SurrealClient } from "@ax/lib/db";
+import { nonNegativeNumberEnv } from "@ax/lib/shared/env-number";
+import { reapStaleIngestRuns } from "../ingest/reap-runs.ts";
+
+/** Default gap between sweeps. Cheap (one indexed query over
+ *  `status = 'running'`, normally 0-1 rows), so 5min is generous and still
+ *  bounds a crashed row's lifetime to minutes instead of weeks. */
+const DEFAULT_REAP_INTERVAL_SECONDS = 300;
+
+/** `AX_REAP_INTERVAL_SECONDS`; an explicit `0` disables the loop. A blank value
+ *  reads as UNSET, not disabled - see {@link nonNegativeNumberEnv}. Exported
+ *  for tests. */
+export const reapIntervalSeconds = (env: NodeJS.ProcessEnv = process.env): number =>
+    nonNegativeNumberEnv(env.AX_REAP_INTERVAL_SECONDS, DEFAULT_REAP_INTERVAL_SECONDS);
+
+/**
+ * Sweep stranded `ingest_run` rows now, then every `intervalSeconds`. Never
+ * settles - the caller forks it onto the serve runtime, which interrupts it on
+ * dispose.
+ *
+ * Fail-open per tick: a DB blip (daemon started before surreal, connection
+ * dropped) must not kill the loop, or the daemon silently stops reaping and we
+ * are back to #697. Logged at debug - a transient reap failure is not something
+ * a user needs on their terminal.
+ */
+export const runReapLoop = (opts: {
+    readonly intervalSeconds: number;
+}): Effect.Effect<void, never, SurrealClient | AxConfig> =>
+    reapStaleIngestRuns().pipe(
+        Effect.tap((result) =>
+            result.reaped > 0
+                ? Effect.logWarning(
+                    `ax serve: reaped ${result.reaped} stranded ingest_run row(s) ` +
+                        `(${result.ids.join(", ")}) - a previous ingest died without finalizing`,
+                )
+                : Effect.void,
+        ),
+        Effect.catchCause((cause) => Effect.logDebug("ax serve: ingest_run reap tick failed", cause)),
+        Effect.repeat(Schedule.spaced(Duration.seconds(opts.intervalSeconds))),
+        Effect.asVoid,
+    );
+
+/**
+ * Re-arm `run` on rejection instead of dropping it for the daemon's whole
+ * life (#697, take two). `runReapLoop`'s own `Effect.catchCause` only catches
+ * failures INSIDE the effect - it can't catch a LAYER-BUILD failure (e.g.
+ * SurrealDB not listening yet when the daemon boots, a documented and
+ * expected race with the `com.necmttn.ax-db` LaunchAgent). Before this, that
+ * rejection hit a bare `.catch(() => undefined)` at the call site: silently
+ * swallowed, loop never re-forked, reaper gone for the process's entire life
+ * with zero log line - the exact failure mode #697 was filed for, just moved
+ * one layer up.
+ *
+ * `run` heals itself: `handle.runner` (serve-runtime.ts) swaps in a fresh
+ * runtime after any build failure, so the NEXT invocation of `run` retries
+ * the layer build fresh rather than replaying the same dead one.
+ *
+ * Seams are injected so this is testable without a daemon or a live DB:
+ * `run` stands in for `handle.runner(runReapLoop(...))`, `scheduleRetry` for
+ * `setTimeout` (the caller is expected to `.unref()` its timer so a pending
+ * retry can never hold the process open at shutdown), `onError` for logging.
+ */
+export const superviseReapLoop = (opts: {
+    readonly run: () => Promise<unknown>;
+    readonly intervalMs: number;
+    readonly scheduleRetry: (fn: () => void, ms: number) => void;
+    readonly onError?: (err: unknown) => void;
+}): void => {
+    const attempt = (): void => {
+        opts.run().catch((err: unknown) => {
+            opts.onError?.(err);
+            // Re-arm unconditionally - a run() that fails once (DB not up
+            // yet) or repeatedly (DB never comes up) must keep retrying
+            // forever, never give up after a single attempt.
+            opts.scheduleRetry(attempt, opts.intervalMs);
+        });
+    };
+    attempt();
+};

--- a/apps/axctl/src/dashboard/server.ts
+++ b/apps/axctl/src/dashboard/server.ts
@@ -294,6 +294,42 @@ export async function serveDashboard(args: string[]): Promise<void> {
     const { prewarmDashboardCaches } = await import("./prewarm.ts");
     void handle.runner(prewarmDashboardCaches()).catch(() => undefined);
 
+    // Sweep ingest_run rows stranded by a crashed ingest, now and every
+    // interval (#697). The ingest-start reaper (#282) can't help when nothing
+    // re-runs ingest - the IDE daemon model has no watcher - so the daemon,
+    // which is always up, owns the recurring sweep. Fire-and-forget on the
+    // server runtime: `handle.dispose()` interrupts it at shutdown.
+    //
+    // Supervised, not a bare `.catch(() => undefined)`: studio.app routinely
+    // starts `ax serve` before `com.necmttn.ax-db` is listening (serve
+    // self-heals from that once a request hits `handle.runner` - see the
+    // warmup handling above), and that same race can hit the layer build for
+    // THIS fork. `runReapLoop`'s internal `catchCause` can't catch a
+    // layer-build failure (it happens before the effect body runs), so an
+    // unsupervised fork would drop the reaper for the daemon's whole life,
+    // silently, on a documented and expected boot race - #697 again, just
+    // moved up a layer. `superviseReapLoop` re-arms on rejection so a later
+    // attempt (once `handle.runner` has healed the runtime) can succeed.
+    const { reapIntervalSeconds, runReapLoop, superviseReapLoop } = await import("./reap-loop.ts");
+    const reapInterval = reapIntervalSeconds();
+    if (reapInterval > 0) {
+        superviseReapLoop({
+            run: () => handle.runner(runReapLoop({ intervalSeconds: reapInterval })),
+            intervalMs: reapInterval * 1000,
+            // `.unref()` so a pending retry timer can never hold the process
+            // open at shutdown - shutdown() calls process.kill() directly,
+            // it doesn't wait on this loop.
+            scheduleRetry: (fn, ms) => {
+                setTimeout(fn, ms).unref();
+            },
+            onError: (err) => {
+                console.warn(
+                    `[ax] ingest_run reap loop failed to start (${err instanceof Error ? err.message : String(err)}); retrying in ${reapInterval}s.`,
+                );
+            },
+        });
+    }
+
     // Tear down the sidecar + runtime on shutdown. Bun's serve never resolves,
     // so the process exits via a signal; close the open run streams and dispose
     // the runtime (which interrupts any in-flight ingest daemon) first.

--- a/apps/axctl/src/dashboard/telemetry.ts
+++ b/apps/axctl/src/dashboard/telemetry.ts
@@ -46,10 +46,11 @@ export function buildIngestRunFinishStatement(input: {
     return `UPDATE ingest_run:\`${input.runId}\` SET status = ${surrealString(input.status)}, ended_at = time::now(), metrics = ${surrealJson(input.metrics ?? {})} RETURN NONE;`;
 }
 
-/** Heartbeat on the parent run row: stage start/finish bumps
+/** Heartbeat on the parent run row: stage start/finish and long-running
+ *  provider work loops bump
  *  `last_progress_at` so a genuinely-live "running" run is distinguishable
  *  from one stranded by a crash (doctor's stale-run check, issue #269). */
-function ingestRunHeartbeatStatement(runId: string): string {
+export function ingestRunHeartbeatStatement(runId: string): string {
     return `UPDATE ingest_run:\`${runId}\` SET last_progress_at = time::now() RETURN NONE;`;
 }
 

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1345,6 +1345,7 @@ const queryCodexStatements = (statements: readonly string[]) =>
 
 interface CodexIngestOpts {
     sinceDays: number | undefined;
+    runId: string | undefined;
     onProgress: (counts: Record<string, number>) => Effect.Effect<void>;
     /** Cumulative skipped-file snapshots from the failure collector (see
      *  file-isolation.ts). The stage wires `stageFileFailureAnnotator` here so
@@ -1455,6 +1456,7 @@ export const ingestCodex = Effect.fn("codex.ingest")(
             sourceKind: "codex_session",
             forceEnv: "AX_REDERIVE_CODEX",
             source: "codex",
+            ...(opts.runId !== undefined ? { runId: opts.runId } : {}),
             ...(opts.onFileFailures ? { onFileFailures: opts.onFileFailures } : {}),
             ...(opts.deadlineMs !== undefined ? { deadlineMs: opts.deadlineMs } : {}),
             concurrency,
@@ -1809,6 +1811,7 @@ export const codexStage: StageDef<CodexStageStats, SurrealClient | AxConfig | Fi
         // DbError - mirroring `claudeStage`.
         const result = yield* ingestCodex({
             sinceDays,
+            runId: ctx.runId,
             onProgress: annotateStageProgress,
             onFileFailures,
             // `ingest here` scopes codex to the repo(s) at $PWD (#680); a global

--- a/apps/axctl/src/ingest/jsonl-work-unit.test.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
 import { DbError } from "@ax/lib/errors";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
-import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
+import {
+    INGEST_RUN_HEARTBEAT_EVERY_FILES,
+    runJsonlProviderFiles,
+    shouldHeartbeatIngestRun,
+} from "./jsonl-work-unit.ts";
 import type { JsonlFileCandidate } from "./walk-jsonl.ts";
 
 /** A stateful fake of the `ingest_file_state` watermark table: the SELECT
@@ -10,7 +14,7 @@ import type { JsonlFileCandidate } from "./walk-jsonl.ts";
  *  second run sees the marks a first run wrote (the whole point of the skip). */
 function statefulWatermarkLayer() {
     const store = new Map<string, { path: string; mtime_ms: number; size: number }>();
-    const layer = makeTestSurrealClient({
+    const tc = makeTestSurrealClient({
         fallback: (sql) => {
             if (sql.includes("__watermark_migration__")) return [[]];
             if (sql.includes("UPSERT ingest_file_state")) {
@@ -25,8 +29,8 @@ function statefulWatermarkLayer() {
             }
             return [[]];
         },
-    }).layer;
-    return { layer, store };
+    });
+    return { layer: tc.layer, store, tc };
 }
 
 const candidate = (path: string, mtimeMs: number, sizeBytes = 100): JsonlFileCandidate => ({ path, mtimeMs, sizeBytes });
@@ -165,5 +169,44 @@ describe("runJsonlProviderFiles - skip-unchanged watermark", () => {
         } finally {
             delete process.env.AX_REDERIVE_TEST;
         }
+    });
+});
+
+describe("JSONL provider ingest_run heartbeat", () => {
+    test("throttles to every 25 successfully completed files", () => {
+        expect(INGEST_RUN_HEARTBEAT_EVERY_FILES).toBe(25);
+        expect(shouldHeartbeatIngestRun(0)).toBe(false);
+        expect(shouldHeartbeatIngestRun(1)).toBe(false);
+        expect(shouldHeartbeatIngestRun(24)).toBe(false);
+        expect(shouldHeartbeatIngestRun(25)).toBe(true);
+        expect(shouldHeartbeatIngestRun(26)).toBe(false);
+        expect(shouldHeartbeatIngestRun(50)).toBe(true);
+    });
+
+    test("emits one best-effort parent run heartbeat after 25 files", async () => {
+        const { layer, tc } = statefulWatermarkLayer();
+        const candidates = Array.from(
+            { length: INGEST_RUN_HEARTBEAT_EVERY_FILES },
+            (_, index) => candidate(`${index}.jsonl`, index + 1),
+        );
+
+        const result = await Effect.runPromise(
+            runJsonlProviderFiles({
+                candidates,
+                sourceKind: "codex_session",
+                forceEnv: "AX_REDERIVE_TEST",
+                source: "codex",
+                runId: "live-run",
+                processFile: () => Effect.succeed(true),
+            }).pipe(Effect.provide(layer)),
+        );
+
+        expect(result.files).toBe(25);
+        const heartbeats = tc.captured.filter((sql) =>
+            sql.includes("UPDATE ingest_run:`live-run` SET last_progress_at = time::now()")
+        );
+        expect(heartbeats).toEqual([
+            "UPDATE ingest_run:`live-run` SET last_progress_at = time::now() RETURN NONE;",
+        ]);
     });
 });

--- a/apps/axctl/src/ingest/jsonl-work-unit.ts
+++ b/apps/axctl/src/ingest/jsonl-work-unit.ts
@@ -25,10 +25,18 @@
 
 import { Effect } from "effect";
 import type { DbError } from "@ax/lib/errors";
-import type { SurrealClient } from "@ax/lib/db";
+import { SurrealClient } from "@ax/lib/db";
 import { fileWatermark } from "@ax/lib/shared/watermark";
+import { ingestRunHeartbeatStatement } from "../dashboard/telemetry.ts";
 import { type FileFailureCollector, type FileFailureSnapshot, makeFileFailureCollector } from "./file-isolation.ts";
 import type { JsonlFileCandidate } from "./walk-jsonl.ts";
+
+/** One cheap heartbeat per this many successfully committed provider files. */
+export const INGEST_RUN_HEARTBEAT_EVERY_FILES = 25;
+
+/** Pure throttle decision, exported so the cadence cannot regress silently. */
+export const shouldHeartbeatIngestRun = (completedFiles: number): boolean =>
+    completedFiles > 0 && completedFiles % INGEST_RUN_HEARTBEAT_EVERY_FILES === 0;
 
 /** Live loop state readable by `processFile` at any point: the one counter a
  *  provider can't compute itself (the work-unit owns active-file tracking).
@@ -46,6 +54,8 @@ export interface RunJsonlProviderFilesOptions<E, R, C extends JsonlFileCandidate
     readonly forceEnv: string;
     /** Failure-collector provider label for log lines, e.g. "codex". */
     readonly source: string;
+    /** Parent ingest run to heartbeat. Omitted by standalone provider calls. */
+    readonly runId?: string;
     /** Live-progress publish hook for the skipped-file list (see file-isolation). */
     readonly onFileFailures?: (snapshot: FileFailureSnapshot) => Effect.Effect<void>;
     /** Dry-run calibration deadline: once passed, start no new files. */
@@ -78,6 +88,7 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
     opts: RunJsonlProviderFilesOptions<E, R, C>,
 ): Effect.Effect<JsonlWorkUnitResult, DbError, SurrealClient | R> =>
     Effect.gen(function* () {
+        const db = yield* SurrealClient;
         const wm = yield* fileWatermark({ sourceKind: opts.sourceKind, forceEnv: opts.forceEnv });
         const failures = makeFileFailureCollector({
             source: opts.source,
@@ -113,8 +124,14 @@ export const runJsonlProviderFiles = <E = never, R = never, C extends JsonlFileC
                             // (so it isn't marked done and retries next run).
                             if (!committed) return;
                             files += 1;
+                            const completedFiles = files;
                             // Commit ONLY after writes succeed.
                             yield* wm.commit(candidate.path, candidate.mtimeMs, candidate.sizeBytes);
+                            if (opts.runId !== undefined && shouldHeartbeatIngestRun(completedFiles)) {
+                                // Courtesy signal only: a transient heartbeat
+                                // failure must never fail or roll back ingest.
+                                yield* db.query(ingestRunHeartbeatStatement(opts.runId)).pipe(Effect.ignore);
+                            }
                         }),
                     );
                     activeFiles -= 1;

--- a/apps/axctl/src/ingest/pi.ts
+++ b/apps/axctl/src/ingest/pi.ts
@@ -730,6 +730,7 @@ export const __testBuildPiBatchStatements = buildPiBatchStatements;
 
 interface PiIngestOpts {
     sinceDays: number | undefined;
+    runId: string | undefined;
 }
 
 /**
@@ -762,6 +763,7 @@ const makePiLikeIngest = (desc: PiLikeProvider) => Effect.fn(`${desc.provider}.i
             sourceKind: desc.sourceKind,
             forceEnv: desc.forceEnv,
             source: desc.provider,
+            ...(opts.runId !== undefined ? { runId: opts.runId } : {}),
             processFile: (file) => Effect.gen(function* () {
                 // OLD: `Bun.file(path).text()` under `Effect.promise` - a read
                 // rejection became an unrecoverable defect. `readFileString`
@@ -851,7 +853,7 @@ const makePiLikeStage = (
         // per-file isolation seam (#261, see file-isolation.ts), so no
         // PlatformError escapes the ingest. Only connection loss and failure
         // storms abort the stage, as a DbError.
-        const result = yield* ingest({ sinceDays });
+        const result = yield* ingest({ sinceDays, runId: ctx.runId });
         return PiStageStats.make({
             durationMs: Date.now() - t0,
             summary: `ingested ${result.files} files, ${result.sessions} sessions, ${result.events} events, ${result.turns} turns, ${result.toolCalls} tool calls, skipped ${result.skipped}, warnings ${result.warnings}` +

--- a/apps/axctl/src/ingest/reap-runs.test.ts
+++ b/apps/axctl/src/ingest/reap-runs.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { selectStrandedRunIds } from "./reap-runs.ts";
+import { Effect, Layer, Path } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { AxConfigTest } from "@ax/lib/config";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { reapStaleIngestRuns, selectStrandedRunIds } from "./reap-runs.ts";
 
 describe("selectStrandedRunIds", () => {
     const now = Date.parse("2026-06-16T12:00:00.000Z");
@@ -40,5 +44,53 @@ describe("selectStrandedRunIds", () => {
     test("strips angle-bracket escaping on uuid-form ids", () => {
         const rows = [{ id: "ingest_run:⟨070849df-4eba-4545-bd3d-c8e47d3e751a⟩" }];
         expect(selectStrandedRunIds(rows, now, staleAfterMs)).toEqual(["070849df-4eba-4545-bd3d-c8e47d3e751a"]);
+    });
+});
+
+describe("reapStaleIngestRuns (real seam)", () => {
+    // One stranded row (heartbeat in 2020) + one live row (heartbeat now). Only
+    // the DB leaf is faked; the reap logic under test is the real one.
+    const rows = () => [
+        { id: "ingest_run:⟨070849df-4eba-4545-bd3d-c8e47d3e751a⟩", started_at: "2020-01-01T00:00:00.000Z" },
+        { id: "ingest_run:live", started_at: new Date().toISOString(), last_progress_at: new Date().toISOString() },
+    ];
+
+    const harness = () => {
+        const tc = makeTestSurrealClient({
+            routes: { "FROM ingest_run WHERE status = 'running'": [rows()] },
+        });
+        const layer = Layer.mergeAll(
+            tc.layer,
+            AxConfigTest({ knobs: { ingestTimeoutSeconds: 900 } }).pipe(Layer.provide(BunFileSystem.layer)),
+            BunFileSystem.layer,
+            Path.layer,
+        );
+        return { tc, layer };
+    };
+
+    test("finalizes the stranded row as partial and leaves the live one alone", async () => {
+        const { tc, layer } = harness();
+        const result = await Effect.runPromise(reapStaleIngestRuns().pipe(Effect.provide(layer)));
+
+        expect(result.reaped).toBe(1);
+        expect(result.ids).toEqual(["070849df-4eba-4545-bd3d-c8e47d3e751a"]);
+
+        // The observable effect: an UPDATE actually went to the DB for the dead
+        // row, settling it as "partial" with the reaped marker.
+        const updates = tc.captured.filter((sql) => sql.startsWith("UPDATE ingest_run:"));
+        expect(updates).toHaveLength(1);
+        expect(updates[0]).toContain("070849df-4eba-4545-bd3d-c8e47d3e751a");
+        expect(updates[0]).toContain(`status = "partial"`);
+        expect(updates[0]).toContain("reaped");
+        expect(updates.join()).not.toContain("live");
+    });
+
+    test("dry-run reports the row but issues no UPDATE", async () => {
+        const { tc, layer } = harness();
+        const result = await Effect.runPromise(reapStaleIngestRuns({ dryRun: true }).pipe(Effect.provide(layer)));
+
+        expect(result.found).toBe(1);
+        expect(result.reaped).toBe(0);
+        expect(tc.captured.filter((sql) => sql.startsWith("UPDATE ingest_run:"))).toHaveLength(0);
     });
 });

--- a/apps/axctl/src/ingest/reap-runs.test.ts
+++ b/apps/axctl/src/ingest/reap-runs.test.ts
@@ -3,7 +3,11 @@ import { Effect, Layer, Path } from "effect";
 import { BunFileSystem } from "@effect/platform-bun";
 import { AxConfigTest } from "@ax/lib/config";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
-import { reapStaleIngestRuns, selectStrandedRunIds } from "./reap-runs.ts";
+import {
+    buildReapIngestRunStatement,
+    reapStaleIngestRuns,
+    selectStrandedRunIds,
+} from "./reap-runs.ts";
 
 describe("selectStrandedRunIds", () => {
     const now = Date.parse("2026-06-16T12:00:00.000Z");
@@ -82,6 +86,9 @@ describe("reapStaleIngestRuns (real seam)", () => {
         expect(updates[0]).toContain("070849df-4eba-4545-bd3d-c8e47d3e751a");
         expect(updates[0]).toContain(`status = "partial"`);
         expect(updates[0]).toContain("reaped");
+        // A run may settle "ok" after the SELECT but before this write. The
+        // predicate makes that race a no-op instead of flipping it partial.
+        expect(updates[0]).toContain("WHERE status = 'running'");
         expect(updates.join()).not.toContain("live");
     });
 
@@ -92,5 +99,15 @@ describe("reapStaleIngestRuns (real seam)", () => {
         expect(result.found).toBe(1);
         expect(result.reaped).toBe(0);
         expect(tc.captured.filter((sql) => sql.startsWith("UPDATE ingest_run:"))).toHaveLength(0);
+    });
+});
+
+describe("buildReapIngestRunStatement", () => {
+    test("only settles a row that is still running", () => {
+        const sql = buildReapIngestRunStatement("race");
+        expect(sql).toContain("UPDATE ingest_run:`race`");
+        expect(sql).toContain(`SET status = "partial"`);
+        expect(sql).toContain("WHERE status = 'running'");
+        expect(sql).toContain("RETURN NONE");
     });
 });

--- a/apps/axctl/src/ingest/reap-runs.ts
+++ b/apps/axctl/src/ingest/reap-runs.ts
@@ -17,7 +17,7 @@ import {
     REAP_GRACE_SECONDS,
     type IngestRunHeartbeatRow,
 } from "@ax/lib/shared/ingest-staleness";
-import { buildIngestRunFinishStatement } from "../dashboard/telemetry.ts";
+import { surrealJson } from "@ax/lib/shared/surql";
 
 /** `ingest_run:⟨id⟩` or `ingest_run:\`id\`` (SurrealDB escapes ids with special
  *  chars - e.g. a uuid's dashes - in angle brackets or backticks) -> the bare id
@@ -48,6 +48,17 @@ export interface ReapStaleRunsResult {
     readonly dryRun: boolean;
 }
 
+/**
+ * Reap-specific terminal write. The status predicate closes the race between
+ * selecting a stale "running" row and settling it: a live run that finishes
+ * "ok" in that gap must not be overwritten as "partial".
+ */
+export function buildReapIngestRunStatement(runId: string): string {
+    return `UPDATE ingest_run:\`${runId}\` SET status = "partial", ended_at = time::now(), metrics = ${
+        surrealJson({ error: "reaped: stale running past ingest timeout" })
+    } WHERE status = 'running' RETURN NONE;`;
+}
+
 export const reapStaleIngestRuns = (
     opts: { readonly dryRun?: boolean } = {},
 ): Effect.Effect<ReapStaleRunsResult, DbError, SurrealClient | AxConfig> =>
@@ -61,11 +72,7 @@ export const reapStaleIngestRuns = (
         const ids = selectStrandedRunIds(rows ?? [], Date.now(), staleAfterMs);
         if (!opts.dryRun) {
             for (const runId of ids) {
-                yield* db.query(buildIngestRunFinishStatement({
-                    runId,
-                    status: "partial",
-                    metrics: { error: "reaped: stale running past ingest timeout" },
-                }));
+                yield* db.query(buildReapIngestRunStatement(runId));
             }
         }
         return {

--- a/apps/axctl/src/ingest/reap-runs.ts
+++ b/apps/axctl/src/ingest/reap-runs.ts
@@ -12,26 +12,12 @@ import { Effect } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import { AxConfig } from "@ax/lib/config";
 import type { DbError } from "@ax/lib/errors";
+import {
+    isStrandedRun,
+    REAP_GRACE_SECONDS,
+    type IngestRunHeartbeatRow,
+} from "@ax/lib/shared/ingest-staleness";
 import { buildIngestRunFinishStatement } from "../dashboard/telemetry.ts";
-
-/** Grace beyond the ingest timeout before a still-"running" row is deemed
- *  stranded - mirrors doctor's stale-run probe (cli/install.ts). */
-export const REAP_GRACE_SECONDS = 60;
-
-interface RunningIngestRunRow {
-    readonly id?: unknown;
-    readonly started_at?: unknown;
-    readonly last_progress_at?: unknown;
-}
-
-/** Newest heartbeat (`last_progress_at`, else `started_at`) older than the
- *  budget => stranded. No parseable timestamp => can't prove it's live, reap it.
- *  Same rule as doctor's `staleRunningIngestRuns`. */
-const isStranded = (row: RunningIngestRunRow, nowMs: number, staleAfterMs: number): boolean => {
-    const beat = Date.parse(String(row.last_progress_at ?? row.started_at ?? ""));
-    if (!Number.isFinite(beat)) return true;
-    return nowMs - beat > staleAfterMs;
-};
 
 /** `ingest_run:⟨id⟩` or `ingest_run:\`id\`` (SurrealDB escapes ids with special
  *  chars - e.g. a uuid's dashes - in angle brackets or backticks) -> the bare id
@@ -45,11 +31,11 @@ const bareRunId = (id: unknown): string =>
 
 /** Pure selector: the bare ids of rows that should be reaped. Exported for tests. */
 export function selectStrandedRunIds(
-    rows: readonly RunningIngestRunRow[],
+    rows: readonly IngestRunHeartbeatRow[],
     nowMs: number,
     staleAfterMs: number,
 ): string[] {
-    return rows.filter((row) => isStranded(row, nowMs, staleAfterMs)).map((row) => bareRunId(row.id));
+    return rows.filter((row) => isStrandedRun(row, nowMs, staleAfterMs)).map((row) => bareRunId(row.id));
 }
 
 export interface ReapStaleRunsResult {
@@ -69,7 +55,7 @@ export const reapStaleIngestRuns = (
         const db = yield* SurrealClient;
         const config = yield* AxConfig;
         const staleAfterMs = (config.knobs.ingestTimeoutSeconds + REAP_GRACE_SECONDS) * 1000;
-        const [rows] = yield* db.query<[RunningIngestRunRow[]]>(
+        const [rows] = yield* db.query<[IngestRunHeartbeatRow[]]>(
             "SELECT id, started_at, last_progress_at FROM ingest_run WHERE status = 'running';",
         );
         const ids = selectStrandedRunIds(rows ?? [], Date.now(), staleAfterMs);

--- a/apps/axctl/src/ingest/run.test.ts
+++ b/apps/axctl/src/ingest/run.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { Effect, Exit, Fiber, Layer, Schema } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { AxConfigTest } from "@ax/lib/config";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
 import { LiveTraceLayer } from "@ax/lib/live-traces/Tracer";
 import {
@@ -34,6 +36,13 @@ const traceLayer = () => {
     const sink = TraceSinkLive({ flushIntervalMs: 1 }).pipe(Layer.provide(transportLayer));
     return Layer.mergeAll(sink, LiveTraceLayer.pipe(Layer.provide(sink)));
 };
+
+// AxConfig is part of runIngest's declared R (stage defs are asserted to need
+// it in `wrapStage`), even though runIngest itself no longer computes a
+// deadline from it - deadlines are caller-owned via `RunIngestOptions.deadlineMs`
+// (#697, see run.ts). Provided here so real stage types line up.
+const axConfigLayer = () =>
+    AxConfigTest({ knobs: { ingestTimeoutSeconds: 900 } }).pipe(Layer.provide(BunFileSystem.layer));
 
 describe("stageEventName", () => {
     it("uses canonical event labels for registered stages", () => {
@@ -112,7 +121,7 @@ describe("runIngest", () => {
             cwd: "/tmp/ax",
             now: () => new Date("2026-05-29T00:00:00.000Z"),
             runId: () => "test_run",
-        }).pipe(Effect.provide(Layer.mergeAll(db.layer, registry, traceLayer())));
+        }).pipe(Effect.provide(Layer.mergeAll(db.layer, registry, traceLayer(), axConfigLayer())));
 
         const result = await Effect.runPromise(program as Effect.Effect<unknown, never, never>);
 
@@ -149,13 +158,53 @@ describe("runIngest", () => {
             cwd: "/tmp/ax",
             now: () => new Date("2026-05-29T00:00:00.000Z"),
             runId: () => "test_run",
-        }).pipe(Effect.provide(Layer.mergeAll(db.layer, registry, traceLayer())));
+        }).pipe(Effect.provide(Layer.mergeAll(db.layer, registry, traceLayer(), axConfigLayer())));
 
         const result = await Effect.runPromise(
             program as Effect.Effect<unknown, never, never>,
         ) as { totals: Record<string, number> };
 
         expect(result.totals).toEqual({ sessions: 3, failedFiles: 2 });
+    });
+
+    // #697 finding 3: an earlier version computed the derive deadline
+    // unconditionally from `AxConfig.knobs.ingestTimeoutSeconds` inside
+    // runIngest, applying it to every caller - including
+    // dashboard/ingest-workflow.ts, which forks runIngest with NO outer
+    // timeout at all. That silently made the Studio Live tab drop long-running
+    // derive stages against a guillotine that doesn't exist. Ownership now
+    // lives with the caller (RunIngestOptions.deadlineMs); pin that omitting
+    // it means no budget is applied, regardless of what AxConfig says.
+    it("applies no derive deadline when the caller doesn't pass one, even if AxConfig has a short timeout", async () => {
+        const db = fakeDb();
+        // A config an old (buggy) runIngest would have read as "deadline is
+        // ~50ms away, minus a 30s reserve" -> immediately negative -> the
+        // derive stage below would be skipped before it ever ran.
+        const shortTimeoutConfig = AxConfigTest({ knobs: { ingestTimeoutSeconds: 0.05 } }).pipe(
+            Layer.provide(BunFileSystem.layer),
+        );
+        const deriveStage: StageDef = {
+            meta: StageMeta.make({ key: "outcomes", deps: [], tags: ["derive"] }),
+            run: () =>
+                Effect.succeed(BaseStageStats.make({ durationMs: 0, summary: "outcomes ok" })).pipe(
+                    Effect.delay("80 millis"),
+                ),
+        };
+        const registry = StageRegistryLive([deriveStage]);
+        const started = Date.now();
+        const program = runIngest({
+            command: "ingest",
+            args: [],
+            cwd: "/tmp/ax",
+            now: () => new Date("2026-05-29T00:00:00.000Z"),
+            runId: () => "test_run",
+            // deliberately no deadlineMs - mirrors dashboard/ingest-workflow.ts
+        }).pipe(Effect.provide(Layer.mergeAll(db.layer, registry, traceLayer(), shortTimeoutConfig)));
+
+        await Effect.runPromise(program as Effect.Effect<unknown, never, never>);
+        // Ran to completion (the 80ms delay was honored) instead of being
+        // skipped/capped by a deadline runIngest has no business inventing.
+        expect(Date.now() - started).toBeGreaterThanOrEqual(75);
     });
 
     it("rejects reset with stage filters before deleting graph rows", async () => {
@@ -167,7 +216,7 @@ describe("runIngest", () => {
             cwd: "/tmp/ax",
             now: () => new Date("2026-05-29T00:00:00.000Z"),
             runId: () => "test_run",
-        }).pipe(Effect.provide(Layer.mergeAll(db.layer, registry)));
+        }).pipe(Effect.provide(Layer.mergeAll(db.layer, registry, axConfigLayer())));
 
         await expect(Effect.runPromise(program as Effect.Effect<unknown, never, never>))
             .rejects.toThrow(/--reset rebuilds the whole skill graph/);

--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -323,6 +323,7 @@ export const runIngest = (
             cwd: opts.cwd,
             since: sinceDays === undefined ? new Date(0) : new Date(now.getTime() - sinceDays * 86400 * 1000),
             debug: opts.debug ?? opts.args.includes("--debug"),
+            runId,
             ...(opts.repoPaths ? { repoPaths: [...opts.repoPaths] } : {}),
             ...(opts.claudeProject ? { claudeProject: opts.claudeProject } : {}),
         });

--- a/apps/axctl/src/ingest/run.ts
+++ b/apps/axctl/src/ingest/run.ts
@@ -256,6 +256,25 @@ export interface RunIngestOptions {
     readonly verbose?: boolean;
     readonly now?: () => Date;
     readonly runId?: () => string;
+    /**
+     * The run's wall-clock deadline (epoch ms). `derive`-tagged stages are
+     * budgeted against it so the pass ends cleanly instead of being
+     * guillotined by an outer timeout (#697) - see `runner.ts`'s
+     * `runPipeline` for the budgeting itself.
+     *
+     * `runIngest` owns no timeout of its own; it only forwards whatever
+     * deadline the CALLER supplies, because only the caller knows whether one
+     * actually exists. `cli/commands/ingest.ts` and `share/recover.ts` both
+     * wrap this run in `withIngestLock`'s hard timeout and pass a deadline
+     * derived from the same `ingestTimeoutSeconds` knob. `dashboard/
+     * ingest-workflow.ts` (the Studio Live tab) forks this run with NO
+     * timeout at all and passes nothing - a derive budget there would guard
+     * against a guillotine that doesn't exist, silently making the Live tab
+     * drop long-running derives for no reason (this was the bug: an earlier
+     * version computed this deadline unconditionally from `AxConfig`, which
+     * applied it to every caller regardless of whether one wrapped the run).
+     */
+    readonly deadlineMs?: number;
 }
 
 export interface RunIngestResult {
@@ -277,6 +296,9 @@ export const runIngest = (
     Effect.gen(function* () {
         const db = yield* SurrealClient;
         const registry = yield* StageRegistry;
+        // Deadline ownership lives with the CALLER (see RunIngestOptions.deadlineMs)
+        // - forward it as-is, or apply none.
+        const deadlineMs = opts.deadlineMs;
         const hasFilter = opts.args.some((a) => a.startsWith("--stages=")) || opts.args.includes("--derive-only");
         if (opts.args.includes("--reset") && hasFilter) {
             throw new Error(`axctl ${opts.command}: --reset rebuilds the whole skill graph and cannot be combined with stage filters`);
@@ -313,7 +335,11 @@ export const runIngest = (
             )
         );
 
-        const stageStats = yield* runPipeline(wrappedStages, ctx).pipe(
+        const stageStats = yield* runPipeline(
+            wrappedStages,
+            ctx,
+            deadlineMs === undefined ? {} : { deadlineMs },
+        ).pipe(
             LiveTrace.withTrace({
                 traceId: `ingest:${runId}`,
                 label: `ingest ${selectedStages.map((s) => s.meta.key).join(",")}`,

--- a/apps/axctl/src/ingest/stage/derive-budget.test.ts
+++ b/apps/axctl/src/ingest/stage/derive-budget.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { deriveReserveMs, deriveStageBudget, DERIVE_RESERVE_SECONDS } from "./derive-budget.ts";
+
+describe("deriveReserveMs", () => {
+    test("defaults to 30s", () => {
+        expect(deriveReserveMs({} as NodeJS.ProcessEnv)).toBe(DERIVE_RESERVE_SECONDS * 1000);
+        expect(DERIVE_RESERVE_SECONDS).toBe(30);
+    });
+
+    test("honours AX_DERIVE_RESERVE_SECONDS, including 0", () => {
+        expect(deriveReserveMs({ AX_DERIVE_RESERVE_SECONDS: "5" } as NodeJS.ProcessEnv)).toBe(5_000);
+        expect(deriveReserveMs({ AX_DERIVE_RESERVE_SECONDS: "0" } as NodeJS.ProcessEnv)).toBe(0);
+        expect(deriveReserveMs({ AX_DERIVE_RESERVE_SECONDS: "junk" } as NodeJS.ProcessEnv)).toBe(30_000);
+    });
+});
+
+describe("deriveStageBudget", () => {
+    const now = 1_000_000;
+
+    test("uses the static cap when the deadline is far away", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now + 900_000,
+            nowMs: now,
+            reserveMs: 30_000,
+        })).toEqual({ _tag: "capped", capMs: 300_000 });
+    });
+
+    test("shrinks to the remaining budget when the deadline is nearer than the static cap", () => {
+        // 100s left, minus a 30s reserve => 70s for this stage, not the full 300s.
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now + 100_000,
+            nowMs: now,
+            reserveMs: 30_000,
+        })).toEqual({ _tag: "capped", capMs: 70_000 });
+    });
+
+    test("skips once the reserve is all that is left - the run must finalize itself", () => {
+        const budget = deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now + 30_000,
+            nowMs: now,
+            reserveMs: 30_000,
+        });
+        expect(budget._tag).toBe("skip");
+    });
+
+    test("skips when the deadline has already passed", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now - 1,
+            nowMs: now,
+            reserveMs: 30_000,
+        })._tag).toBe("skip");
+    });
+
+    test("no deadline: the static cap still applies (today's behaviour)", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: null,
+            nowMs: now,
+            reserveMs: 30_000,
+        })).toEqual({ _tag: "capped", capMs: 300_000 });
+    });
+
+    test("no deadline and a disabled static cap: uncapped", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 0,
+            deadlineMs: null,
+            nowMs: now,
+            reserveMs: 30_000,
+        })).toEqual({ _tag: "uncapped" });
+    });
+
+    test("disabled static cap still respects the deadline", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 0,
+            deadlineMs: now + 100_000,
+            nowMs: now,
+            reserveMs: 30_000,
+        })).toEqual({ _tag: "capped", capMs: 70_000 });
+    });
+});

--- a/apps/axctl/src/ingest/stage/derive-budget.ts
+++ b/apps/axctl/src/ingest/stage/derive-budget.ts
@@ -1,0 +1,65 @@
+/**
+ * How long may a derive stage run, given the pass's own deadline? (#697)
+ *
+ * The static watchdog (`AX_STAGE_TIMEOUT_SECONDS`, #671) caps ONE derive at
+ * 300s but knows nothing about the run's wall-clock budget
+ * (`AX_INGEST_TIMEOUT_SECONDS`, 900s). Under a backlog the provider stages eat
+ * most of the budget, then each derive starts a fresh 300s clock and pushes the
+ * pass past the outer cap. The outer timeout is not a soft landing: it
+ * deliberately LEAVES the ingest lock as a cooldown (see ingest-lock.ts), so
+ * the watcher's next fires skip and a human is left re-running ingest by hand.
+ *
+ * So a derive gets `min(staticCap, timeLeftBeforeDeadline - reserve)`, and is
+ * skipped outright once only the reserve remains. The reserve is what the run
+ * needs to finalize its own `ingest_run` row and exit clean.
+ *
+ * This bounds the pass. It does NOT make a heavy derive finish - that wants
+ * chunked/resumable derive (#689).
+ */
+import { nonNegativeNumberEnv } from "@ax/lib/shared/env-number";
+
+/** What a derive stage is allowed this pass. */
+export type DeriveStageBudget =
+    /** Run it with no timeout (no deadline and the static cap is disabled). */
+    | { readonly _tag: "uncapped" }
+    /** Run it, but time it out after `capMs`. */
+    | { readonly _tag: "capped"; readonly capMs: number }
+    /** Don't start it: there is no budget left. */
+    | { readonly _tag: "skip"; readonly reason: string };
+
+/** Wall-clock held back from derives so the run can finalize its `ingest_run`
+ *  row (and the outer lock release) instead of being guillotined mid-write. */
+export const DERIVE_RESERVE_SECONDS = 30;
+
+/** `AX_DERIVE_RESERVE_SECONDS`; 0 is a legal "no reserve". A blank value
+ *  (unset-but-exported) falls back to the default rather than reading as an
+ *  explicit 0 - see {@link nonNegativeNumberEnv}. Exported for tests. */
+export const deriveReserveMs = (env: NodeJS.ProcessEnv = process.env): number =>
+    nonNegativeNumberEnv(env.AX_DERIVE_RESERVE_SECONDS, DERIVE_RESERVE_SECONDS) * 1000;
+
+/**
+ * Budget for the derive stage about to start. `staticCapMs <= 0` disables the
+ * static cap; `deadlineMs === null` means the caller has no wall-clock budget
+ * (tests, `--derive-only` invocations without a timeout), in which case this
+ * degrades to exactly today's static-cap behaviour.
+ */
+export const deriveStageBudget = (input: {
+    readonly staticCapMs: number;
+    readonly deadlineMs: number | null;
+    readonly nowMs: number;
+    readonly reserveMs: number;
+}): DeriveStageBudget => {
+    const untilDeadline = input.deadlineMs === null
+        ? Number.POSITIVE_INFINITY
+        : input.deadlineMs - input.reserveMs - input.nowMs;
+    if (untilDeadline <= 0) {
+        return {
+            _tag: "skip",
+            reason: "no time left before the ingest deadline (raise AX_INGEST_TIMEOUT_SECONDS, " +
+                "or run 'ax ingest --derive-only' to catch derives up)",
+        };
+    }
+    const staticCap = input.staticCapMs > 0 ? input.staticCapMs : Number.POSITIVE_INFINITY;
+    const capMs = Math.min(staticCap, untilDeadline);
+    return Number.isFinite(capMs) ? { _tag: "capped", capMs } : { _tag: "uncapped" };
+};

--- a/apps/axctl/src/ingest/stage/runner.test.ts
+++ b/apps/axctl/src/ingest/stage/runner.test.ts
@@ -325,6 +325,8 @@ describe("heartbeatSeconds / deriveStageTimeoutSeconds", () => {
         expect(heartbeatSeconds({})).toBe(30);
         expect(heartbeatSeconds({ AX_INGEST_HEARTBEAT_SECONDS: "10" })).toBe(10);
         expect(heartbeatSeconds({ AX_INGEST_HEARTBEAT_SECONDS: "0" })).toBe(0);
+        expect(heartbeatSeconds({ AX_INGEST_HEARTBEAT_SECONDS: "" })).toBe(30);
+        expect(heartbeatSeconds({ AX_INGEST_HEARTBEAT_SECONDS: "   " })).toBe(30);
         expect(heartbeatSeconds({ AX_INGEST_HEARTBEAT_SECONDS: "-5" })).toBe(30);
         expect(heartbeatSeconds({ AX_INGEST_HEARTBEAT_SECONDS: "abc" })).toBe(30);
     });
@@ -333,6 +335,8 @@ describe("heartbeatSeconds / deriveStageTimeoutSeconds", () => {
         expect(deriveStageTimeoutSeconds({})).toBe(300);
         expect(deriveStageTimeoutSeconds({ AX_STAGE_TIMEOUT_SECONDS: "120" })).toBe(120);
         expect(deriveStageTimeoutSeconds({ AX_STAGE_TIMEOUT_SECONDS: "0" })).toBe(0);
+        expect(deriveStageTimeoutSeconds({ AX_STAGE_TIMEOUT_SECONDS: "" })).toBe(300);
+        expect(deriveStageTimeoutSeconds({ AX_STAGE_TIMEOUT_SECONDS: "   " })).toBe(300);
         expect(deriveStageTimeoutSeconds({ AX_STAGE_TIMEOUT_SECONDS: "-1" })).toBe(300);
         expect(deriveStageTimeoutSeconds({ AX_STAGE_TIMEOUT_SECONDS: "nope" })).toBe(300);
     });

--- a/apps/axctl/src/ingest/stage/runner.test.ts
+++ b/apps/axctl/src/ingest/stage/runner.test.ts
@@ -400,3 +400,125 @@ describe("derive-stage watchdog (#671)", () => {
         });
     });
 });
+
+describe("runPipeline derive budget (#697)", () => {
+    const ctx = IngestContext.make({ cwd: "/tmp", since: new Date(0), debug: false });
+
+    const stage = (
+        key: string,
+        tags: ReadonlyArray<"ingest" | "derive">,
+        run: Effect.Effect<BaseStageStats, never, never>,
+    ): StageDef<BaseStageStats, never> => ({
+        meta: StageMeta.make({ key, deps: [], tags }),
+        run: () => run,
+    });
+
+    const instant = (key: string, tags: ReadonlyArray<"ingest" | "derive">) =>
+        stage(key, tags, Effect.succeed(BaseStageStats.make({ durationMs: 0, summary: `${key} ok` })));
+
+    /** A stage that would run far past any test's patience. */
+    const hangs = (key: string, tags: ReadonlyArray<"ingest" | "derive">) =>
+        stage(key, tags, Effect.never as Effect.Effect<BaseStageStats, never, never>);
+
+    it("a derive stage past the deadline is skipped and the pass still completes", async () => {
+        const stats = await Effect.runPromise(
+            runPipeline([instant("claude", ["ingest"]), hangs("derive-metrics", ["derive"])], ctx, {
+                deadlineMs: Date.now() - 1, // budget already blown, as after a backlog
+                reserveMs: 0,
+            }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+        );
+
+        // The real observable effect: the pipeline RETURNS instead of hanging
+        // until the outer 900s timeout guillotines it (and leaves a cooldown lock).
+        expect(stats).toHaveLength(2);
+        const derive = stats.find((s) => s.summary.includes("skipped"));
+        expect(derive).toBeDefined();
+        expect(stats.some((s) => s.summary === "claude ok")).toBe(true);
+    });
+
+    it("a derive stage is capped by the time left, not its static 300s cap", async () => {
+        const started = Date.now();
+        const stats = await Effect.runPromise(
+            runPipeline([hangs("outcomes", ["derive"])], ctx, {
+                deadlineMs: Date.now() + 150,
+                reserveMs: 0,
+            }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+        );
+
+        // Bounded by the deadline (150ms), NOT by AX_STAGE_TIMEOUT_SECONDS (300s).
+        // Either summary proves the DEADLINE (not the 300s static cap) bounded
+        // the stage: "timed out" if the budget read still saw time left when
+        // the stage started, "skipped" if CI scheduling slop pushed pipeline
+        // startup past the 150ms deadline before the stage got its permit.
+        expect(Date.now() - started).toBeLessThan(5_000);
+        expect(stats[0]?.summary).toMatch(/timed out|skipped/);
+    });
+
+    it("an ingest-tagged stage is exempt - a real backfill legitimately runs long", async () => {
+        const stats = await Effect.runPromise(
+            runPipeline([instant("skills", ["ingest"])], ctx, {
+                deadlineMs: Date.now() - 1,
+                reserveMs: 0,
+            }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+        );
+
+        // Provider stages must not be skipped by the derive budget: if the
+        // `!tags.includes("derive")` exemption in runner.ts were dropped, this
+        // stage would be budgeted like any derive, the deadline is already
+        // blown, and it would read the sentinel "skipped (out of budget)"
+        // summary instead of actually running.
+        expect(stats[0]?.summary).toBe("skills ok");
+    });
+
+    it("suspends the budget read until the derive stage actually starts, not when it's built (#697 finding 1)", async () => {
+        // Saturate every pipeline permit with slow no-dep `ingest` stages so
+        // the derive stage below is forced to WAIT for one. If the budget
+        // were read eagerly (at stage-build time, which happens near t=0 for
+        // every dep-free stage regardless of permit availability), the
+        // 150ms-out deadline still looks open and the derive gets a live cap
+        // - it then runs (once a permit frees up ~200ms later) and times out
+        // at the watchdog. If the budget is correctly suspended until the
+        // derive stage actually starts (post-permit, ~200ms in), the deadline
+        // has already passed and it's skipped instead - never even starting
+        // the timed body. The two behaviors are distinguishable both by
+        // summary and by wall-clock (~200ms vs ~350ms).
+        const started = Date.now();
+        const saturators = Array.from({ length: PIPELINE_CONCURRENCY }, (_, i) =>
+            stage(
+                `hold-${i}`,
+                ["ingest"],
+                Effect.succeed(BaseStageStats.make({ durationMs: 0, summary: `hold-${i} ok` })).pipe(
+                    Effect.delay("200 millis"),
+                ),
+            ),
+        );
+        const derive = hangs("derive-metrics", ["derive"]);
+
+        const stats = await Effect.runPromise(
+            runPipeline([...saturators, derive], ctx, {
+                deadlineMs: started + 150,
+                reserveMs: 0,
+            }) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+        );
+
+        const deriveResult = stats.find(
+            (s) => s.summary.includes("skipped") || s.summary.includes("timed out"),
+        );
+        // THE load-bearing assertion. Suspended (correct): the budget is read
+        // once the permit frees, by which time the deadline has passed -> skip.
+        // Eager (broken): the budget is read at build time, when 150ms still
+        // remained -> the body runs and the watchdog times it out instead.
+        expect(deriveResult?.summary).toBe("skipped (out of budget)");
+        // Generous: the summary above is what pins the suspend. This only
+        // guards against the pipeline hanging - a tight bound here just makes
+        // the test flaky on a loaded box.
+        expect(Date.now() - started).toBeLessThan(5_000);
+    });
+
+    it("no deadline: unchanged behaviour (stages run to completion)", async () => {
+        const stats = await Effect.runPromise(
+            runPipeline([instant("claude", ["ingest"]), instant("outcomes", ["derive"])], ctx) as Effect.Effect<ReadonlyArray<BaseStageStats>, never, never>,
+        );
+        expect(stats.map((s) => s.summary).sort()).toEqual(["claude ok", "outcomes ok"]);
+    });
+});

--- a/apps/axctl/src/ingest/stage/runner.ts
+++ b/apps/axctl/src/ingest/stage/runner.ts
@@ -1,6 +1,7 @@
 import { Deferred, Effect, Fiber, Option, Semaphore } from "effect";
 import type { DbError } from "@ax/lib/errors";
 import { LiveTrace } from "@ax/lib/live-traces/index";
+import { nonNegativeNumberEnv } from "@ax/lib/shared/env-number";
 import type { FileFailureSnapshot } from "../file-isolation.ts";
 import { INGEST_FILE_FAILURES_KEY } from "../stream-events.ts";
 import { deriveReserveMs, deriveStageBudget } from "./derive-budget.ts";
@@ -15,8 +16,7 @@ export const PIPELINE_CONCURRENCY = 4;
  *  slow stage is attributable instead of looking like a silent stall (#671).
  *  Env override `AX_INGEST_HEARTBEAT_SECONDS`; 0 disables. Exported for tests. */
 export const heartbeatSeconds = (env: NodeJS.ProcessEnv = process.env): number => {
-    const raw = Number(env.AX_INGEST_HEARTBEAT_SECONDS);
-    return Number.isFinite(raw) && raw >= 0 ? raw : 30;
+    return nonNegativeNumberEnv(env.AX_INGEST_HEARTBEAT_SECONDS, 30);
 };
 
 /** Hard per-stage cap applied to `derive`-tagged stages ONLY. Derives reshape
@@ -27,8 +27,7 @@ export const heartbeatSeconds = (env: NodeJS.ProcessEnv = process.env): number =
  *  are deliberately exempt: a full backfill legitimately runs for many minutes.
  *  Env override `AX_STAGE_TIMEOUT_SECONDS`; 0 disables. Exported for tests. */
 export const deriveStageTimeoutSeconds = (env: NodeJS.ProcessEnv = process.env): number => {
-    const raw = Number(env.AX_STAGE_TIMEOUT_SECONDS);
-    return Number.isFinite(raw) && raw >= 0 ? raw : 300;
+    return nonNegativeNumberEnv(env.AX_STAGE_TIMEOUT_SECONDS, 300);
 };
 
 /** Annotate the active stage span with the numeric fields of its result stats

--- a/apps/axctl/src/ingest/stage/runner.ts
+++ b/apps/axctl/src/ingest/stage/runner.ts
@@ -3,6 +3,7 @@ import type { DbError } from "@ax/lib/errors";
 import { LiveTrace } from "@ax/lib/live-traces/index";
 import type { FileFailureSnapshot } from "../file-isolation.ts";
 import { INGEST_FILE_FAILURES_KEY } from "../stream-events.ts";
+import { deriveReserveMs, deriveStageBudget } from "./derive-budget.ts";
 import type { BaseStageStats, IngestContext, StageDef } from "./types.ts";
 
 /** Max stages running their `run` Effect concurrently. Each stage has its own
@@ -134,10 +135,17 @@ export const topoLayers = <S extends BaseStageStats, R>(
 /** Run the given stages with DAG scheduling. Each stage waits for its in-graph
  *  deps via Deferreds; only `PIPELINE_CONCURRENCY` are inside the semaphore at
  *  once. Each stage is wrapped in `LiveTrace.step` so progress flows through
- *  the configured `TraceTransport` (ADR-0007). */
+ *  the configured `TraceTransport` (ADR-0007).
+ *
+ *  `opts.deadlineMs` is the run's wall-clock deadline (epoch ms). Derive stages
+ *  are budgeted against it so the pass ends cleanly instead of being killed by
+ *  the outer ingest timeout (#697); omit it and derives keep only their static
+ *  `AX_STAGE_TIMEOUT_SECONDS` cap. `opts.reserveMs` overrides the finalization
+ *  reserve (env default) - tests pass 0. */
 export const runPipeline = <S extends BaseStageStats, R>(
     stages: ReadonlyArray<StageDef<S, R>>,
     ctx: IngestContext,
+    opts: { readonly deadlineMs?: number; readonly reserveMs?: number } = {},
 ): Effect.Effect<ReadonlyArray<S>, DbError, R> =>
     Effect.gen(function* () {
         topoLayers(stages); // cycle check
@@ -152,6 +160,8 @@ export const runPipeline = <S extends BaseStageStats, R>(
         // heartbeat reads this so a hang is attributable to a specific stage (#671).
         const inFlight = new Set<string>();
         const stageTimeoutMs = deriveStageTimeoutSeconds() * 1000;
+        const deadlineMs = opts.deadlineMs ?? null;
+        const reserveMs = opts.reserveMs ?? deriveReserveMs();
 
         const runStage = (s: StageDef<S, R>) =>
             Effect.gen(function* () {
@@ -170,30 +180,54 @@ export const runPipeline = <S extends BaseStageStats, R>(
                         "ingest.stage.tags": s.meta.tags.join(","),
                     }),
                 );
-                // Watchdog: cap `derive` stages so one stuck derive can't wedge the
-                // whole run. On timeout, warn + fail OPEN with empty stats - downstream
-                // deps only await this Deferred (they never read its value; they re-query
-                // the DB), and the totals roll-up skips `durationMs` + non-numeric fields,
-                // so an empty BaseStageStats is a safe sentinel. Provider stages are exempt.
-                const guarded =
-                    stageTimeoutMs > 0 && s.meta.tags.includes("derive")
-                        ? body.pipe(
-                              Effect.timeoutOrElse({
-                                  duration: stageTimeoutMs,
-                                  orElse: () =>
-                                      Effect.logWarning(
-                                          `ingest: derive stage '${s.meta.key}' exceeded ${stageTimeoutMs / 1000}s - ` +
-                                              `skipping it (failed open) so the run can finish. ` +
-                                              `Raise/disable with AX_STAGE_TIMEOUT_SECONDS.`,
-                                      ).pipe(
-                                          Effect.as({
-                                              durationMs: stageTimeoutMs,
-                                              summary: "timed out (watchdog)",
-                                          } as unknown as S),
-                                      ),
-                              }),
-                          )
-                        : body;
+                // Watchdog: cap `derive` stages so one stuck or backlogged derive
+                // can't wedge the run OR push the pass past its deadline (#671,
+                // #697). Fails OPEN - a warning plus sentinel stats - because
+                // downstream deps only await this Deferred (they never read its
+                // value; they re-query the DB), and the totals roll-up skips
+                // `durationMs` + non-numeric fields, so an empty BaseStageStats is
+                // safe. Heavy provider stages (claude, codex, git) are exempt: a
+                // full backfill legitimately runs for many minutes.
+                // Suspended so `Date.now()` is read at stage START (post-deps,
+                // post-permit) - reading it at build time would hand every stage
+                // the budget the FIRST one had.
+                const guarded = !s.meta.tags.includes("derive")
+                    ? body
+                    : Effect.suspend(() => {
+                        const budget = deriveStageBudget({
+                            staticCapMs: stageTimeoutMs,
+                            deadlineMs,
+                            nowMs: Date.now(),
+                            reserveMs,
+                        });
+                        if (budget._tag === "uncapped") return body;
+                        if (budget._tag === "skip") {
+                            return Effect.logWarning(
+                                `ingest: skipping derive stage '${s.meta.key}' - ${budget.reason}.`,
+                            ).pipe(
+                                Effect.as({
+                                    durationMs: 0,
+                                    summary: "skipped (out of budget)",
+                                } as unknown as S),
+                            );
+                        }
+                        return body.pipe(
+                            Effect.timeoutOrElse({
+                                duration: budget.capMs,
+                                orElse: () =>
+                                    Effect.logWarning(
+                                        `ingest: derive stage '${s.meta.key}' exceeded ${Math.round(budget.capMs / 1000)}s - ` +
+                                            `skipping it (failed open) so the run can finish. ` +
+                                            `Raise/disable with AX_STAGE_TIMEOUT_SECONDS.`,
+                                    ).pipe(
+                                        Effect.as({
+                                            durationMs: budget.capMs,
+                                            summary: "timed out (watchdog)",
+                                        } as unknown as S),
+                                    ),
+                            }),
+                        );
+                    });
                 const tracked = Effect.sync(() => {
                     inFlight.add(s.meta.key);
                 }).pipe(

--- a/apps/axctl/src/ingest/stage/types.ts
+++ b/apps/axctl/src/ingest/stage/types.ts
@@ -16,6 +16,8 @@ export class IngestContext extends Schema.Class<IngestContext>("IngestContext")(
     cwd: Schema.String,
     since: Schema.Date,
     debug: Schema.Boolean,
+    /** Present for orchestrated runs; standalone provider calls omit it. */
+    runId: Schema.optional(Schema.String),
     repoPaths: Schema.optional(Schema.Array(Schema.String)),
     claudeProject: Schema.optional(Schema.String),
 }) {}

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1667,6 +1667,7 @@ export const writeTokenUsageForSubagents = (extracted: FileExtract) => {
 interface IngestOpts {
     sinceDays: number | undefined;
     project: string | undefined;
+    runId: string | undefined;
     onProgress: (counts: Record<string, number>) => Effect.Effect<void>;
     /** Cumulative skipped-file snapshots from the failure collector (see
      *  file-isolation.ts). The stage wires `stageFileFailureAnnotator` here so
@@ -1826,6 +1827,7 @@ export const ingestTranscripts = Effect.fn("transcripts.ingest")(
             sourceKind: "claude_transcript",
             forceEnv: "AX_REDERIVE_CLAUDE",
             source: "claude",
+            ...(opts.runId !== undefined ? { runId: opts.runId } : {}),
             ...(opts.onFileFailures ? { onFileFailures: opts.onFileFailures } : {}),
             ...(opts.deadlineMs !== undefined ? { deadlineMs: opts.deadlineMs } : {}),
             concurrency,
@@ -2028,7 +2030,13 @@ export const claudeStage: StageDef<ClaudeStats, SurrealClient | AxConfig | FileS
         // genuine FS failure (e.g. an unreadable transcripts root or a
         // non-NotFound stat/stream error) so it dies as a defect rather
         // than masquerading as a recoverable DbError.
-        const result = yield* ingestTranscripts({ sinceDays, project: ctx.claudeProject, onProgress: annotateStageProgress, onFileFailures }).pipe(
+        const result = yield* ingestTranscripts({
+            sinceDays,
+            project: ctx.claudeProject,
+            runId: ctx.runId,
+            onProgress: annotateStageProgress,
+            onFileFailures,
+        }).pipe(
             Effect.catchTag("PlatformError", (e) => Effect.die(e)),
         );
         return ClaudeStats.make({

--- a/apps/axctl/src/queries/ingest-staleness.test.ts
+++ b/apps/axctl/src/queries/ingest-staleness.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { DbError } from "@ax/lib/errors";
+import { makeMockDb, makeTestSurrealClient, runWithMock } from "@ax/lib/testing/surreal";
+import {
+    fetchLastSuccessfulIngestAt,
+    staleIngestThresholdMs,
+    warnIfIngestStale,
+} from "./ingest-staleness.ts";
+
+describe("staleIngestThresholdMs", () => {
+    test("defaults to 48h", () => {
+        expect(staleIngestThresholdMs({} as NodeJS.ProcessEnv)).toBe(48 * 3_600_000);
+    });
+
+    test("honours AX_STALE_INGEST_HOURS; 0 disables", () => {
+        expect(staleIngestThresholdMs({ AX_STALE_INGEST_HOURS: "6" } as NodeJS.ProcessEnv)).toBe(6 * 3_600_000);
+        expect(staleIngestThresholdMs({ AX_STALE_INGEST_HOURS: "0" } as NodeJS.ProcessEnv)).toBe(0);
+    });
+
+    // #697 finding 1: an exported-but-blank env var (launchd plist entry, a
+    // bare `export AX_STALE_INGEST_HOURS=` shell profile line) must read as
+    // UNSET, not as an explicit "0" disable - `Number("")` and `Number(" ")`
+    // are both `0`, which is finite and `>= 0`. Without the guard this
+    // silently turns the #697 stale-graph warning off.
+    test("empty or whitespace-only value falls back to the 48h default (unset, not disabled)", () => {
+        expect(staleIngestThresholdMs({ AX_STALE_INGEST_HOURS: "" } as NodeJS.ProcessEnv)).toBe(48 * 3_600_000);
+        expect(staleIngestThresholdMs({ AX_STALE_INGEST_HOURS: "   " } as NodeJS.ProcessEnv)).toBe(48 * 3_600_000);
+    });
+});
+
+describe("fetchLastSuccessfulIngestAt", () => {
+    test("reads the newest ok run via one status-filtered indexed query", async () => {
+        const db = makeMockDb([[[{ ended_at: "2026-07-03T12:00:00.000Z", started_at: "2026-07-03T11:50:00.000Z" }]]]);
+        const at = await runWithMock(db, fetchLastSuccessfulIngestAt);
+
+        expect(at).toBe(Date.parse("2026-07-03T12:00:00.000Z"));
+        expect(db.captured).toHaveLength(1);
+        // Must hit the ingest_run_status_started index: filter on status, order
+        // by started_at. A full scan here would tax every read command.
+        expect(db.captured[0]).toContain("FROM ingest_run");
+        expect(db.captured[0]).toContain("status = 'ok'");
+        expect(db.captured[0]).toContain("ORDER BY started_at DESC");
+        expect(db.captured[0]).toContain("LIMIT 1");
+    });
+
+    test("falls back to started_at when ended_at is absent", async () => {
+        const db = makeMockDb([[[{ started_at: "2026-07-03T11:50:00.000Z" }]]]);
+        expect(await runWithMock(db, fetchLastSuccessfulIngestAt)).toBe(Date.parse("2026-07-03T11:50:00.000Z"));
+    });
+
+    test("null when no ok run exists", async () => {
+        const db = makeMockDb([[[]]]);
+        expect(await runWithMock(db, fetchLastSuccessfulIngestAt)).toBeNull();
+    });
+
+    test("null when the timestamps are unparseable", async () => {
+        const db = makeMockDb([[[{ ended_at: "not-a-date" }]]]);
+        expect(await runWithMock(db, fetchLastSuccessfulIngestAt)).toBeNull();
+    });
+});
+
+describe("warnIfIngestStale (real seam)", () => {
+    // Capture BOTH streams around the run: stdout must stay clean (`--json |
+    // jq` breaks on a stray line there) and the warning IS the printed stderr
+    // line. Patching stderr alone would catch a MOVE to stdout (the stale
+    // case's captured stderr would just go empty) but not an ADDITION - e.g. a
+    // stray `console.log(warning)` beside the stderr write. Also patch
+    // `console.log` itself, not just `process.stdout.write`: verified live
+    // that under Bun, `console.log` does NOT route through
+    // `process.stdout.write` (it holds its own handle to the stream), so a
+    // patch of `process.stdout.write` alone silently fails to observe it and
+    // this test would pass even with the stray console.log left in.
+    const captureOutput = async (
+        effect: Effect.Effect<void, never, never>,
+    ): Promise<{ stdout: string; stderr: string }> => {
+        const originalStderr = process.stderr.write.bind(process.stderr);
+        const originalStdout = process.stdout.write.bind(process.stdout);
+        const originalConsoleLog = console.log;
+        let stderr = "";
+        let stdout = "";
+        process.stderr.write = (chunk: string) => {
+            stderr += String(chunk);
+            return true;
+        };
+        process.stdout.write = (chunk: string) => {
+            stdout += String(chunk);
+            return true;
+        };
+        console.log = (...args: unknown[]) => {
+            stdout += `${args.map(String).join(" ")}\n`;
+        };
+        try {
+            await Effect.runPromise(effect);
+        } finally {
+            process.stderr.write = originalStderr;
+            process.stdout.write = originalStdout;
+            console.log = originalConsoleLog;
+        }
+        return { stdout, stderr };
+    };
+
+    const okRunFrom = (iso: string) =>
+        makeTestSurrealClient({ routes: { "FROM ingest_run": [[{ ended_at: iso, started_at: iso }]] } });
+
+    test("prints one warning line to stderr, and nothing to stdout, when the last ok ingest is older than 48h", async () => {
+        const db = okRunFrom(new Date(Date.now() - 13 * 86_400_000).toISOString());
+        const { stdout, stderr } = await captureOutput(warnIfIngestStale.pipe(Effect.provide(db.layer)));
+
+        expect(stderr).toContain("graph is stale");
+        expect(stderr).toContain("13d ago");
+        expect(stderr.trimEnd().split("\n")).toHaveLength(1);
+        // Load-bearing: `ax cost --json | jq` must never see this line.
+        expect(stdout).toBe("");
+    });
+
+    test("stays silent when the graph is fresh", async () => {
+        const db = okRunFrom(new Date(Date.now() - 3_600_000).toISOString());
+        const { stdout, stderr } = await captureOutput(warnIfIngestStale.pipe(Effect.provide(db.layer)));
+        expect(stderr).toBe("");
+        expect(stdout).toBe("");
+    });
+
+    test("degrades silently when the DB is unreachable", async () => {
+        const db = makeTestSurrealClient({
+            routes: {
+                "FROM ingest_run": Effect.fail(
+                    new DbError({ operation: "query", message: "connection refused" }),
+                ),
+            },
+        });
+        const { stdout, stderr } = await captureOutput(warnIfIngestStale.pipe(Effect.provide(db.layer)));
+        expect(stderr).toBe("");
+        expect(stdout).toBe("");
+    });
+});

--- a/apps/axctl/src/queries/ingest-staleness.test.ts
+++ b/apps/axctl/src/queries/ingest-staleness.test.ts
@@ -6,6 +6,7 @@ import {
     fetchLastSuccessfulIngestAt,
     staleIngestThresholdMs,
     warnIfIngestStale,
+    withIngestStalenessPreflight,
 } from "./ingest-staleness.ts";
 
 describe("staleIngestThresholdMs", () => {
@@ -132,5 +133,28 @@ describe("warnIfIngestStale (real seam)", () => {
         const { stdout, stderr } = await captureOutput(warnIfIngestStale.pipe(Effect.provide(db.layer)));
         expect(stderr).toBe("");
         expect(stdout).toBe("");
+    });
+
+    test("runs as a preflight before the command body", async () => {
+        const db = okRunFrom(new Date(Date.now() - 13 * 86_400_000).toISOString());
+        const originalStderr = process.stderr.write.bind(process.stderr);
+        const events: string[] = [];
+        process.stderr.write = () => {
+            events.push("warning");
+            return true;
+        };
+        try {
+            await Effect.runPromise(
+                withIngestStalenessPreflight(
+                    Effect.sync(() => {
+                        events.push("command");
+                    }),
+                ).pipe(Effect.provide(db.layer)),
+            );
+        } finally {
+            process.stderr.write = originalStderr;
+        }
+
+        expect(events).toEqual(["warning", "command"]);
     });
 });

--- a/apps/axctl/src/queries/ingest-staleness.ts
+++ b/apps/axctl/src/queries/ingest-staleness.ts
@@ -79,3 +79,13 @@ export const warnIfIngestStale: Effect.Effect<void, never, SurrealClient> = Effe
     // interruptions are swallowed too - the only way to honor "never fails."
     Effect.ignoreCause,
 );
+
+/**
+ * Run the stale-graph probe before a DB-backed command. This must be a
+ * preflight rather than a finalizer: some legacy handlers call `process.exit`
+ * directly, so no finalizer gets a chance to run on their failure paths.
+ */
+export const withIngestStalenessPreflight = <A, E, R>(
+    command: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R | SurrealClient> =>
+    warnIfIngestStale.pipe(Effect.andThen(command));

--- a/apps/axctl/src/queries/ingest-staleness.ts
+++ b/apps/axctl/src/queries/ingest-staleness.ts
@@ -1,0 +1,81 @@
+/**
+ * Stale-graph warning for read commands (#697).
+ *
+ * `ax dispatches` / `ax cost` returned empty for two weeks while ingest was
+ * dead, and nothing said so - an empty table reads as "you have no data", not
+ * "your data stopped 13 days ago". Doctor knew, but only when run by hand.
+ *
+ * So every DB-backed command pays one indexed query (`status = 'ok'` ORDER BY
+ * the indexed `started_at`, LIMIT 1) and prints at most one stderr line. It is
+ * wired into `withDb` (cli/index.ts) rather than per-command, so a new read
+ * command inherits it without knowing this exists.
+ *
+ * Fail-open: an unreachable DB prints nothing (the command's own error already
+ * says that) and a warning never touches stdout, so `--json` stays machine-clean.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { nonNegativeNumberEnv } from "@ax/lib/shared/env-number";
+import {
+    formatStaleIngestWarning,
+    STALE_INGEST_AFTER_HOURS,
+} from "@ax/lib/shared/ingest-staleness";
+
+/** Age past which the graph is called stale. `AX_STALE_INGEST_HOURS`; 0
+ *  disables the warning. A blank value (unset-but-exported) falls back to
+ *  the default rather than reading as an explicit 0 - see
+ *  {@link nonNegativeNumberEnv}. Exported for tests. */
+export const staleIngestThresholdMs = (env: NodeJS.ProcessEnv = process.env): number =>
+    nonNegativeNumberEnv(env.AX_STALE_INGEST_HOURS, STALE_INGEST_AFTER_HOURS) * 3_600_000;
+
+/** Hard cap on the probe. A wedged DB must not add latency to a command that
+ *  is already failing - the warning is a courtesy, not a feature. */
+const PROBE_TIMEOUT_MS = 2_000;
+
+interface LastOkRunRow {
+    readonly ended_at?: unknown;
+    readonly started_at?: unknown;
+}
+
+/**
+ * Epoch ms of the newest ingest that finished with status "ok", or null when
+ * there is none (or its timestamps are unreadable). Hits the
+ * `ingest_run_status_started` index: equality on `status`, ordered by the
+ * indexed `started_at`. Reads `ended_at` as the completion instant, falling
+ * back to `started_at` for rows written before `ended_at` existed.
+ */
+export const fetchLastSuccessfulIngestAt: Effect.Effect<number | null, DbError, SurrealClient> =
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const [rows] = yield* db.query<[LastOkRunRow[]]>(
+            "SELECT ended_at, started_at FROM ingest_run WHERE status = 'ok' ORDER BY started_at DESC LIMIT 1;",
+        );
+        const row = rows?.[0];
+        if (row === undefined) return null;
+        const at = Date.parse(String(row.ended_at ?? row.started_at ?? ""));
+        return Number.isFinite(at) ? at : null;
+    });
+
+/**
+ * Print the stale-graph warning to stderr if the graph is out of date. Never
+ * fails, never throws, never writes to stdout.
+ */
+export const warnIfIngestStale: Effect.Effect<void, never, SurrealClient> = Effect.gen(
+    function* () {
+        const thresholdMs = staleIngestThresholdMs();
+        if (thresholdMs <= 0) return;
+        const lastOkMs = yield* fetchLastSuccessfulIngestAt;
+        const warning = formatStaleIngestWarning({ lastOkMs, nowMs: Date.now(), thresholdMs });
+        if (warning === null) return;
+        yield* Effect.sync(() => process.stderr.write(`${warning}\n`));
+    },
+).pipe(
+    Effect.timeoutOption(PROBE_TIMEOUT_MS),
+    // `ignore` only matches the error channel (E) - a defect (e.g. EPIPE from
+    // process.stderr.write when a piped reader closes early, `ax cost 2>&1 |
+    // head -1`) rides the Cause untouched and would fail a successful command
+    // via `ensuring`. `ignoreCause` matches on the whole Cause, so defects and
+    // interruptions are swallowed too - the only way to honor "never fails."
+    Effect.ignoreCause,
+);

--- a/apps/axctl/src/share/recover.ts
+++ b/apps/axctl/src/share/recover.ts
@@ -108,6 +108,14 @@ export const ingestShareTranscript = (
             args: [`--stages=${hit.harness}`, `--since=${sinceDays}`],
             cwd: process.cwd(),
             ...(claudeProject ? { claudeProject } : {}),
+            // This run is wrapped in the same `withIngestLock` hard timeout
+            // below, so - like cli/commands/ingest.ts - it genuinely owns a
+            // deadline (#697). The `--stages=<harness>` filter above never
+            // selects a `derive`-tagged stage today, so this is currently a
+            // no-op; passing it anyway keeps the invariant honest ("a caller
+            // wrapped in a real timeout passes one") instead of silently
+            // relying on today's stage selection never changing.
+            ...(timeoutSeconds > 0 ? { deadlineMs: Date.now() + timeoutSeconds * 1000 } : {}),
         }).pipe(Effect.as<ShareIngestOutcome>({ kind: "ingested" }));
 
         const outcome = yield* withIngestLock(

--- a/docs/superpowers/plans/2026-07-16-ingest-reaper-staleness-derive-budget.md
+++ b/docs/superpowers/plans/2026-07-16-ingest-reaper-staleness-derive-budget.md
@@ -1,0 +1,1312 @@
+# Ingest reaper + staleness warning + derive budget Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close issue #697 - the serve daemon auto-reaps stranded `ingest_run` rows, every DB-backed read command warns when the graph is stale, and derive stages can't push a pass past its wall-clock deadline.
+
+**Architecture:** Three seams, no new tables. (a) A periodic `Effect.repeat(Schedule.spaced(...))` loop forked onto the existing serve runtime calls the already-shipped `reapStaleIngestRuns` - the #597 reap is correct but only fires at ingest start, and on the IDE-daemon model (no watcher) ingest never re-ran, so nothing swept it. (b) `withDb` in the CLI gains an `Effect.ensuring` staleness probe - one indexed query, stderr-only, fail-open. (c) The existing derive watchdog (`AX_STAGE_TIMEOUT_SECONDS`, 300s, #671) gains deadline-awareness: a derive stage's cap becomes `min(staticCap, timeUntilRunDeadline - reserve)`, so derives end before the outer `AX_INGEST_TIMEOUT_SECONDS` guillotine fires and the run finalizes cleanly instead of leaving a cooldown lock.
+
+**Tech Stack:** TypeScript strict, Effect v4 beta (`effect@beta`), SurrealDB 3.x, bun:test.
+
+## Global Constraints
+
+- Tests are **bun:test** (`import { describe, expect, test } from "bun:test"`), NOT vitest. `TestClock` comes from `effect/testing` (pattern: `apps/studio-desktop/src/backend/DesktopIngestScheduler.test.ts`).
+- NEVER touch the live daemon/DB at `127.0.0.1:8521` / `1738`. All tests use `makeTestSurrealClient` / `AxConfigTest` layers. No live-DB e2e.
+- Work ONLY in `/Users/necmttn/Projects/ax/.claude/worktrees/697-fix`. `pwd` must match before any git command.
+- Every write is fail-open: a reap/staleness/budget defect must never break ingest or a read command.
+- Do NOT expand into #689 (usage derive exceeds watchdog, cascades). File a follow-up instead.
+- Gates: `bun run typecheck` exits 0 (check the REAL exit code) + `bun test` green on touched suites.
+
+---
+
+### Task 1: Shared stranded-run predicate (`@ax/lib/shared/ingest-staleness`)
+
+The stale-"running" rule is currently written TWICE - `staleRunningIngestRuns` (`apps/axctl/src/cli/install.ts:951`, doctor's HTTP probe) and `isStranded` (`apps/axctl/src/ingest/reap-runs.ts:30`, the reaper). Same logic, two copies; the daemon reaper (Task 2) and the staleness warning (Task 3) would make it four. Extract the predicate + the graph-staleness formatter into one dep-free module both sides import.
+
+**Files:**
+- Create: `packages/lib/src/shared/ingest-staleness.ts`
+- Create: `packages/lib/src/shared/ingest-staleness.test.ts`
+- Modify: `packages/lib/package.json` (add the `./shared/ingest-staleness` export)
+- Modify: `apps/axctl/src/ingest/reap-runs.ts:17-34` (import the predicate, re-export `REAP_GRACE_SECONDS`)
+- Modify: `apps/axctl/src/cli/install.ts:951-962,1029` (import the predicate + grace constant)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface IngestRunHeartbeatRow { readonly id?: unknown; readonly started_at?: unknown; readonly last_progress_at?: unknown }`
+  - `const REAP_GRACE_SECONDS: number` (= 60)
+  - `const isStrandedRun: (row: IngestRunHeartbeatRow, nowMs: number, staleAfterMs: number) => boolean`
+  - `const STALE_INGEST_AFTER_HOURS: number` (= 48)
+  - `const formatStaleIngestWarning: (input: { readonly lastOkMs: number | null; readonly nowMs: number; readonly thresholdMs: number }) => string | null`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/lib/src/shared/ingest-staleness.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+    formatStaleIngestWarning,
+    isStrandedRun,
+    REAP_GRACE_SECONDS,
+    STALE_INGEST_AFTER_HOURS,
+} from "./ingest-staleness.ts";
+
+describe("isStrandedRun", () => {
+    const now = Date.parse("2026-07-16T12:00:00.000Z");
+    const staleAfterMs = 960_000; // 900s ingest timeout + 60s grace
+
+    test("strands a run whose heartbeat is older than the budget", () => {
+        expect(isStrandedRun(
+            { id: "ingest_run:dead", started_at: "2026-07-16T11:00:00.000Z", last_progress_at: "2026-07-16T11:30:00.000Z" },
+            now,
+            staleAfterMs,
+        )).toBe(true);
+    });
+
+    test("spares a run whose heartbeat is within the budget", () => {
+        expect(isStrandedRun(
+            { id: "ingest_run:live", started_at: "2026-07-16T10:00:00.000Z", last_progress_at: "2026-07-16T11:59:00.000Z" },
+            now,
+            staleAfterMs,
+        )).toBe(false);
+    });
+
+    test("falls back to started_at when last_progress_at is absent", () => {
+        expect(isStrandedRun({ id: "a", started_at: "2026-07-16T11:58:00.000Z" }, now, staleAfterMs)).toBe(false);
+        expect(isStrandedRun({ id: "b", started_at: "2026-07-16T11:00:00.000Z" }, now, staleAfterMs)).toBe(true);
+    });
+
+    test("strands a row with no parseable timestamp (can't prove it's live)", () => {
+        expect(isStrandedRun({ id: "ingest_run:mystery" }, now, staleAfterMs)).toBe(true);
+    });
+
+    test("REAP_GRACE_SECONDS is the shared 60s margin doctor and the reaper both use", () => {
+        expect(REAP_GRACE_SECONDS).toBe(60);
+    });
+});
+
+describe("formatStaleIngestWarning", () => {
+    const now = Date.parse("2026-07-16T12:00:00.000Z");
+    const thresholdMs = STALE_INGEST_AFTER_HOURS * 3_600_000;
+
+    test("no warning when the last successful ingest is inside the threshold", () => {
+        expect(formatStaleIngestWarning({
+            lastOkMs: now - 3_600_000,
+            nowMs: now,
+            thresholdMs,
+        })).toBeNull();
+    });
+
+    test("warns in days once the graph is older than the threshold", () => {
+        const warning = formatStaleIngestWarning({
+            lastOkMs: Date.parse("2026-07-03T12:00:00.000Z"),
+            nowMs: now,
+            thresholdMs,
+        });
+        expect(warning).toContain("graph is stale");
+        expect(warning).toContain("13d ago");
+        expect(warning).toContain("ax ingest");
+    });
+
+    test("warns in hours just past the threshold", () => {
+        const warning = formatStaleIngestWarning({
+            lastOkMs: now - 50 * 3_600_000,
+            nowMs: now,
+            thresholdMs,
+        });
+        expect(warning).toContain("50h ago");
+    });
+
+    test("warns with tailored copy when no successful ingest was ever recorded", () => {
+        const warning = formatStaleIngestWarning({ lastOkMs: null, nowMs: now, thresholdMs });
+        expect(warning).toContain("no successful ingest");
+        expect(warning).toContain("ax ingest");
+    });
+
+    test("a non-positive threshold disables the warning entirely", () => {
+        expect(formatStaleIngestWarning({ lastOkMs: null, nowMs: now, thresholdMs: 0 })).toBeNull();
+        expect(formatStaleIngestWarning({ lastOkMs: 0, nowMs: now, thresholdMs: 0 })).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/lib/src/shared/ingest-staleness.test.ts`
+Expected: FAIL - `Cannot find module './ingest-staleness.ts'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/lib/src/shared/ingest-staleness.ts`:
+
+```ts
+/**
+ * Ingest staleness rules, shared by every surface that judges "is the graph
+ * current?" - `ax doctor`'s HTTP probe (cli/install.ts), the ingest-start +
+ * daemon reapers (ingest/reap-runs.ts, dashboard/reap-loop.ts), and the
+ * read-command warning (queries/ingest-staleness.ts).
+ *
+ * Two distinct questions live here on purpose - they are the same subject
+ * (#697) and drifted apart once already:
+ *  - {@link isStrandedRun}: is THIS "running" row a crash leftover?
+ *  - {@link formatStaleIngestWarning}: is the graph as a whole out of date?
+ *
+ * Dep-free (no Effect, no DB) so doctor's no-layer code path and the site can
+ * both import it.
+ */
+
+/** The `ingest_run` columns the stranded check reads. Shape is shared by
+ *  doctor's raw HTTP probe and the reaper's SurrealClient query. */
+export interface IngestRunHeartbeatRow {
+    readonly id?: unknown;
+    readonly started_at?: unknown;
+    readonly last_progress_at?: unknown;
+}
+
+/** Grace beyond the ingest timeout before a still-"running" row is deemed
+ *  stranded. Doctor, the ingest-start reaper and the daemon reaper share it so
+ *  they can never disagree about what "stuck" means. */
+export const REAP_GRACE_SECONDS = 60;
+
+/**
+ * Is this "running" row crash residue? Every clean exit path (ok / error /
+ * interrupt / timeout) settles the row, so a row whose newest heartbeat
+ * (`last_progress_at`, else `started_at`) is past the budget was killed
+ * without finalizing. No parseable timestamp => can't prove it's live => treat
+ * as stranded.
+ */
+export const isStrandedRun = (
+    row: IngestRunHeartbeatRow,
+    nowMs: number,
+    staleAfterMs: number,
+): boolean => {
+    const beat = Date.parse(String(row.last_progress_at ?? row.started_at ?? ""));
+    if (!Number.isFinite(beat)) return true;
+    return nowMs - beat > staleAfterMs;
+};
+
+/** Age past which the graph is called stale on read commands (#697: two weeks
+ *  of empty `ax cost` / `ax dispatches` went unflagged). */
+export const STALE_INGEST_AFTER_HOURS = 48;
+
+/** `50h` / `13d` - days once we're past two days, where "13d" reads better. */
+const formatAge = (ageMs: number): string => {
+    const hours = Math.floor(ageMs / 3_600_000);
+    return hours >= 48 ? `${Math.floor(hours / 24)}d` : `${hours}h`;
+};
+
+/**
+ * One-line warning for a stale graph, or null when it's current (or the check
+ * is disabled with a non-positive threshold).
+ *
+ * `lastOkMs` is the newest run that finished with status "ok". Deliberately
+ * NOT "ok or partial": the reaper settles crash residue as "partial", so
+ * counting partials would let the ghost rows from #697 suppress the very
+ * warning that exists to surface them.
+ */
+export const formatStaleIngestWarning = (input: {
+    readonly lastOkMs: number | null;
+    readonly nowMs: number;
+    readonly thresholdMs: number;
+}): string | null => {
+    if (input.thresholdMs <= 0) return null;
+    if (input.lastOkMs === null) {
+        return "ax: no successful ingest recorded - results are empty until you run 'ax ingest'.";
+    }
+    const ageMs = input.nowMs - input.lastOkMs;
+    if (ageMs <= input.thresholdMs) return null;
+    return `ax: graph is stale - last successful ingest ${formatAge(ageMs)} ago; ` +
+        `results may be incomplete. Run 'ax ingest' ('ax doctor' to diagnose).`;
+};
+```
+
+Add the export to `packages/lib/package.json`, directly after the `"./shared/fs-classify"` line:
+
+```json
+    "./shared/ingest-staleness": "./src/shared/ingest-staleness.ts",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/lib/src/shared/ingest-staleness.test.ts`
+Expected: PASS (11 tests)
+
+- [ ] **Step 5: Point the two existing copies at the shared predicate**
+
+In `apps/axctl/src/ingest/reap-runs.ts`, delete the local `RunningIngestRunRow` interface, the local `REAP_GRACE_SECONDS`, and the local `isStranded`, then import the shared ones. The exported `REAP_GRACE_SECONDS` is re-exported so existing importers keep working:
+
+```ts
+import {
+    isStrandedRun,
+    REAP_GRACE_SECONDS,
+    type IngestRunHeartbeatRow,
+} from "@ax/lib/shared/ingest-staleness";
+
+export { REAP_GRACE_SECONDS };
+```
+
+Then update `selectStrandedRunIds` to use it (keep `bareRunId` exactly as-is):
+
+```ts
+/** Pure selector: the bare ids of rows that should be reaped. Exported for tests. */
+export function selectStrandedRunIds(
+    rows: readonly IngestRunHeartbeatRow[],
+    nowMs: number,
+    staleAfterMs: number,
+): string[] {
+    return rows.filter((row) => isStrandedRun(row, nowMs, staleAfterMs)).map((row) => bareRunId(row.id));
+}
+```
+
+In `apps/axctl/src/cli/install.ts`, delete the local `RunningIngestRunRow` interface and rewrite `staleRunningIngestRuns` over the shared predicate (keep the exported name - `install.test.ts` uses it):
+
+```ts
+import {
+    isStrandedRun,
+    REAP_GRACE_SECONDS,
+    type IngestRunHeartbeatRow,
+} from "@ax/lib/shared/ingest-staleness";
+
+/**
+ * Rows whose newest heartbeat is older than `staleAfterMs` - crash residue that
+ * never finalized (issue #269). Thin filter over the shared
+ * {@link isStrandedRun} rule so doctor and the reapers can't drift. Exported
+ * for tests.
+ */
+export function staleRunningIngestRuns(
+    rows: readonly IngestRunHeartbeatRow[],
+    nowMs: number,
+    staleAfterMs: number,
+): IngestRunHeartbeatRow[] {
+    return rows.filter((row) => isStrandedRun(row, nowMs, staleAfterMs));
+}
+```
+
+Replace the hardcoded `60` at `install.ts:1029` with the shared constant:
+
+```ts
+        const staleIngestRuns = dbReachable
+            ? yield* Effect.promise(() =>
+                probeStaleIngestRuns(daemon.endpoint, (ingestTimeoutSeconds + REAP_GRACE_SECONDS) * 1000))
+            : null;
+```
+
+Also swap the `RunningIngestRunRow` annotations inside `probeStaleIngestRuns` for `IngestRunHeartbeatRow`.
+
+- [ ] **Step 6: Run the affected suites**
+
+Run: `bun test packages/lib/src/shared/ingest-staleness.test.ts apps/axctl/src/ingest/reap-runs.test.ts apps/axctl/src/cli/install.test.ts`
+Expected: PASS - the pre-existing reap + install tests still pass against the shared predicate (proof the extraction is behavior-preserving).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `bun run typecheck`
+Expected: exit 0.
+
+---
+
+### Task 2: Daemon auto-reap loop (issue #697 part 1a)
+
+`reapStaleIngestRuns` (#597) is correct but only fires at ingest START. On the IDE-daemon model there is no watcher, so when ingest stopped running the two crashed rows from Jul 3 sat "running" for two weeks with nothing to sweep them. Fix the trigger, not the reap: fork a periodic reap onto the serve runtime, which IS always up.
+
+**Files:**
+- Create: `apps/axctl/src/dashboard/reap-loop.ts`
+- Create: `apps/axctl/src/dashboard/reap-loop.test.ts`
+- Modify: `apps/axctl/src/ingest/reap-runs.test.ts` (add the real-seam test)
+- Modify: `apps/axctl/src/dashboard/server.ts:290-296` (fork the loop after listen)
+
+**Interfaces:**
+- Consumes: `reapStaleIngestRuns` from `../ingest/reap-runs.ts` (Task 1 leaves its signature unchanged: `(opts?: { dryRun?: boolean }) => Effect.Effect<ReapStaleRunsResult, DbError, SurrealClient | AxConfig>`).
+- Produces:
+  - `const reapIntervalSeconds: (env?: NodeJS.ProcessEnv) => number` (default 300, `AX_REAP_INTERVAL_SECONDS`, 0 disables)
+  - `const runReapLoop: (opts: { readonly intervalSeconds: number }) => Effect.Effect<void, never, SurrealClient | AxConfig>`
+
+- [ ] **Step 1: Write the failing real-seam test for the reap itself**
+
+The existing `reap-runs.test.ts` only covers the pure selector - nothing asserts a stuck row actually gets finalized. Append to `apps/axctl/src/ingest/reap-runs.test.ts` (add the imports at the top of the file):
+
+```ts
+import { Effect, Layer, Path } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { AxConfigTest } from "@ax/lib/config";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { reapStaleIngestRuns, selectStrandedRunIds } from "./reap-runs.ts";
+
+describe("reapStaleIngestRuns (real seam)", () => {
+    // One stranded row (heartbeat in 2020) + one live row (heartbeat now). Only
+    // the DB leaf is faked; the reap logic under test is the real one.
+    const rows = () => [
+        { id: "ingest_run:⟨070849df-4eba-4545-bd3d-c8e47d3e751a⟩", started_at: "2020-01-01T00:00:00.000Z" },
+        { id: "ingest_run:live", started_at: new Date().toISOString(), last_progress_at: new Date().toISOString() },
+    ];
+
+    const harness = () => {
+        const tc = makeTestSurrealClient({
+            routes: { "FROM ingest_run WHERE status = 'running'": [rows()] },
+        });
+        const layer = Layer.mergeAll(
+            tc.layer,
+            AxConfigTest({ knobs: { ingestTimeoutSeconds: 900 } }).pipe(Layer.provide(BunFileSystem.layer)),
+            BunFileSystem.layer,
+            Path.layer,
+        );
+        return { tc, layer };
+    };
+
+    test("finalizes the stranded row as partial and leaves the live one alone", async () => {
+        const { tc, layer } = harness();
+        const result = await Effect.runPromise(reapStaleIngestRuns().pipe(Effect.provide(layer)));
+
+        expect(result.reaped).toBe(1);
+        expect(result.ids).toEqual(["070849df-4eba-4545-bd3d-c8e47d3e751a"]);
+
+        // The observable effect: an UPDATE actually went to the DB for the dead
+        // row, settling it as "partial" with the reaped marker.
+        const updates = tc.captured.filter((sql) => sql.startsWith("UPDATE ingest_run:"));
+        expect(updates).toHaveLength(1);
+        expect(updates[0]).toContain("070849df-4eba-4545-bd3d-c8e47d3e751a");
+        expect(updates[0]).toContain(`status = "partial"`);
+        expect(updates[0]).toContain("reaped");
+        expect(updates.join()).not.toContain("live");
+    });
+
+    test("dry-run reports the row but issues no UPDATE", async () => {
+        const { tc, layer } = harness();
+        const result = await Effect.runPromise(reapStaleIngestRuns({ dryRun: true }).pipe(Effect.provide(layer)));
+
+        expect(result.found).toBe(1);
+        expect(result.reaped).toBe(0);
+        expect(tc.captured.filter((sql) => sql.startsWith("UPDATE ingest_run:"))).toHaveLength(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it passes (the reap is already correct)**
+
+Run: `bun test apps/axctl/src/ingest/reap-runs.test.ts`
+Expected: PASS. This test is a characterization pin, not a red - #697's bug is the missing TRIGGER, and Step 3's test is the red. If this FAILS, stop: the reap itself is broken and the plan's premise is wrong.
+
+- [ ] **Step 3: Write the failing test for the loop**
+
+Create `apps/axctl/src/dashboard/reap-loop.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { Duration, Effect, Fiber, Layer, Path } from "effect";
+import { TestClock } from "effect/testing";
+import { BunFileSystem } from "@effect/platform-bun";
+import { AxConfigTest } from "@ax/lib/config";
+import { DbError } from "@ax/lib/errors";
+import { makeTestSurrealClient, type TestSurrealRoutes } from "@ax/lib/testing/surreal";
+import { reapIntervalSeconds, runReapLoop } from "./reap-loop.ts";
+
+const strandedRow = { id: "ingest_run:dead", started_at: "2020-01-01T00:00:00.000Z" };
+
+const harness = (routes: TestSurrealRoutes) => {
+    const tc = makeTestSurrealClient({ routes });
+    const layer = Layer.mergeAll(
+        tc.layer,
+        AxConfigTest({ knobs: { ingestTimeoutSeconds: 900 } }).pipe(Layer.provide(BunFileSystem.layer)),
+        BunFileSystem.layer,
+        Path.layer,
+    );
+    return { tc, layer };
+};
+
+const reapUpdates = (captured: readonly string[]): string[] =>
+    captured.filter((sql) => sql.startsWith("UPDATE ingest_run:"));
+
+describe("reapIntervalSeconds", () => {
+    test("defaults to 300s", () => {
+        expect(reapIntervalSeconds({} as NodeJS.ProcessEnv)).toBe(300);
+    });
+
+    test("honours AX_REAP_INTERVAL_SECONDS", () => {
+        expect(reapIntervalSeconds({ AX_REAP_INTERVAL_SECONDS: "30" } as NodeJS.ProcessEnv)).toBe(30);
+    });
+
+    test("0 disables the loop; garbage falls back to the default", () => {
+        expect(reapIntervalSeconds({ AX_REAP_INTERVAL_SECONDS: "0" } as NodeJS.ProcessEnv)).toBe(0);
+        expect(reapIntervalSeconds({ AX_REAP_INTERVAL_SECONDS: "nonsense" } as NodeJS.ProcessEnv)).toBe(300);
+    });
+});
+
+describe("runReapLoop", () => {
+    test("reaps a stranded row on the first tick, without waiting for an interval", async () => {
+        const { tc, layer } = harness({ "FROM ingest_run WHERE status = 'running'": [[strandedRow]] });
+
+        await Effect.runPromise(
+            Effect.gen(function* () {
+                const fiber = yield* Effect.forkChild(runReapLoop({ intervalSeconds: 300 }));
+                yield* TestClock.adjust(Duration.zero);
+                // The real observable effect: the stuck row is settled in the DB.
+                expect(reapUpdates(tc.captured)).toHaveLength(1);
+                expect(reapUpdates(tc.captured)[0]).toContain(`status = "partial"`);
+                yield* Fiber.interrupt(fiber);
+            }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer()), Effect.scoped),
+        );
+    });
+
+    test("keeps sweeping on each interval", async () => {
+        const { tc, layer } = harness({ "FROM ingest_run WHERE status = 'running'": [[strandedRow]] });
+
+        await Effect.runPromise(
+            Effect.gen(function* () {
+                const fiber = yield* Effect.forkChild(runReapLoop({ intervalSeconds: 300 }));
+                yield* TestClock.adjust(Duration.zero);
+                expect(reapUpdates(tc.captured)).toHaveLength(1);
+                yield* TestClock.adjust(Duration.minutes(5));
+                expect(reapUpdates(tc.captured)).toHaveLength(2);
+                yield* TestClock.adjust(Duration.minutes(5));
+                expect(reapUpdates(tc.captured)).toHaveLength(3);
+                yield* Fiber.interrupt(fiber);
+            }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer()), Effect.scoped),
+        );
+    });
+
+    test("a failing DB does not kill the loop - the next tick still sweeps", async () => {
+        let call = 0;
+        const { tc, layer } = harness({
+            "FROM ingest_run WHERE status = 'running'": () => {
+                call += 1;
+                return call === 1
+                    ? Effect.fail(new DbError({ message: "connection refused" }))
+                    : [[strandedRow]];
+            },
+        });
+
+        await Effect.runPromise(
+            Effect.gen(function* () {
+                const fiber = yield* Effect.forkChild(runReapLoop({ intervalSeconds: 300 }));
+                yield* TestClock.adjust(Duration.zero);
+                expect(reapUpdates(tc.captured)).toHaveLength(0); // first tick failed
+                yield* TestClock.adjust(Duration.minutes(5));
+                expect(reapUpdates(tc.captured)).toHaveLength(1); // recovered
+                yield* Fiber.interrupt(fiber);
+            }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer()), Effect.scoped),
+        );
+    });
+
+    test("leaves a live run alone", async () => {
+        const live = {
+            id: "ingest_run:live",
+            started_at: new Date().toISOString(),
+            last_progress_at: new Date().toISOString(),
+        };
+        const { tc, layer } = harness({ "FROM ingest_run WHERE status = 'running'": [[live]] });
+
+        await Effect.runPromise(
+            Effect.gen(function* () {
+                const fiber = yield* Effect.forkChild(runReapLoop({ intervalSeconds: 300 }));
+                yield* TestClock.adjust(Duration.zero);
+                expect(reapUpdates(tc.captured)).toHaveLength(0);
+                yield* Fiber.interrupt(fiber);
+            }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer()), Effect.scoped),
+        );
+    });
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/dashboard/reap-loop.test.ts`
+Expected: FAIL - `Cannot find module './reap-loop.ts'`
+
+- [ ] **Step 5: Write minimal implementation**
+
+Create `apps/axctl/src/dashboard/reap-loop.ts`:
+
+```ts
+/**
+ * Periodic ingest_run reaper for the serve daemon (#697).
+ *
+ * `reapStaleIngestRuns` (#282/#597) sweeps crash residue, but only at INGEST
+ * START. That covers the watcher model, where the next transcript write fires
+ * an ingest within minutes. It does NOT cover the IDE daemon model (studio.app
+ * owns surreal + serve, no LaunchAgent watcher): when ingest stops running,
+ * nothing ever calls the reaper again. That is exactly how two rows sat
+ * "running" from Jul 3 to Jul 16 with `ax doctor` the only thing that would
+ * have said so - and doctor only runs when a human runs it.
+ *
+ * So: fork the same reap onto the daemon, which IS always up. The reap itself
+ * is unchanged (stranded = heartbeat past ingest timeout + grace, so a live
+ * concurrent run is never touched) - only the trigger is new.
+ */
+import { Duration, Effect, Schedule } from "effect";
+import { AxConfig } from "@ax/lib/config";
+import { SurrealClient } from "@ax/lib/db";
+import { reapStaleIngestRuns } from "../ingest/reap-runs.ts";
+
+/** Gap between sweeps. Cheap (one indexed query over `status = 'running'`,
+ *  normally 0-1 rows), so 5min is generous and still bounds a crashed row's
+ *  lifetime to minutes instead of weeks. `AX_REAP_INTERVAL_SECONDS`; 0
+ *  disables. Exported for tests. */
+export const reapIntervalSeconds = (env: NodeJS.ProcessEnv = process.env): number => {
+    const raw = Number(env.AX_REAP_INTERVAL_SECONDS);
+    return Number.isFinite(raw) && raw >= 0 ? raw : 300;
+};
+
+/**
+ * Sweep stranded `ingest_run` rows now, then every `intervalSeconds`. Never
+ * settles - the caller forks it onto the serve runtime, which interrupts it on
+ * dispose.
+ *
+ * Fail-open per tick: a DB blip (daemon started before surreal, connection
+ * dropped) must not kill the loop, or the daemon silently stops reaping and we
+ * are back to #697. Logged at debug - a transient reap failure is not something
+ * a user needs on their terminal.
+ */
+export const runReapLoop = (opts: {
+    readonly intervalSeconds: number;
+}): Effect.Effect<void, never, SurrealClient | AxConfig> =>
+    reapStaleIngestRuns().pipe(
+        Effect.tap((result) =>
+            result.reaped > 0
+                ? Effect.logWarning(
+                    `ax serve: reaped ${result.reaped} stranded ingest_run row(s) ` +
+                        `(${result.ids.join(", ")}) - a previous ingest died without finalizing`,
+                )
+                : Effect.void,
+        ),
+        Effect.catchCause((cause) => Effect.logDebug("ax serve: ingest_run reap tick failed", cause)),
+        Effect.repeat(Schedule.spaced(Duration.seconds(opts.intervalSeconds))),
+        Effect.asVoid,
+    );
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/dashboard/reap-loop.test.ts`
+Expected: PASS (7 tests)
+
+- [ ] **Step 7: Fork the loop from the serve daemon**
+
+In `apps/axctl/src/dashboard/server.ts`, directly after the `prewarmDashboardCaches` block (~line 295) and before the shutdown handlers, add:
+
+```ts
+    // Sweep ingest_run rows stranded by a crashed ingest, now and every
+    // interval (#697). The ingest-start reaper (#282) can't help when nothing
+    // re-runs ingest - the IDE daemon model has no watcher - so the daemon,
+    // which is always up, owns the recurring sweep. Fire-and-forget on the
+    // server runtime: `handle.dispose()` interrupts it at shutdown.
+    const { reapIntervalSeconds, runReapLoop } = await import("./reap-loop.ts");
+    const reapInterval = reapIntervalSeconds();
+    if (reapInterval > 0) {
+        void handle.runner(runReapLoop({ intervalSeconds: reapInterval })).catch(() => undefined);
+    }
+```
+
+- [ ] **Step 8: Typecheck + full affected suites**
+
+Run: `bun run typecheck && bun test apps/axctl/src/dashboard/reap-loop.test.ts apps/axctl/src/ingest/reap-runs.test.ts`
+Expected: exit 0, all green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/lib apps/axctl/src/dashboard/reap-loop.ts apps/axctl/src/dashboard/reap-loop.test.ts apps/axctl/src/dashboard/server.ts apps/axctl/src/ingest/reap-runs.ts apps/axctl/src/ingest/reap-runs.test.ts apps/axctl/src/cli/install.ts
+git commit -m "fix(ingest): auto-reap stranded ingest_run rows from the serve daemon (#697)"
+```
+
+---
+
+### Task 3: Stale-graph warning on read commands (issue #697 part 1b)
+
+Two weeks of `ax cost` / `ax dispatches` returned empty and nothing said why. Every DB-backed command routes through `withDb`, so one `Effect.ensuring` there covers sessions/cost/dispatches/recall and everything else, forever.
+
+**Files:**
+- Create: `apps/axctl/src/queries/ingest-staleness.ts`
+- Create: `apps/axctl/src/queries/ingest-staleness.test.ts`
+- Modify: `apps/axctl/src/cli/index.ts:218-219` (`withDb`)
+
+**Interfaces:**
+- Consumes: `formatStaleIngestWarning`, `STALE_INGEST_AFTER_HOURS` from `@ax/lib/shared/ingest-staleness` (Task 1).
+- Produces:
+  - `const staleIngestThresholdMs: (env?: NodeJS.ProcessEnv) => number`
+  - `const fetchLastSuccessfulIngestAt: Effect.Effect<number | null, DbError, SurrealClient>`
+  - `const warnIfIngestStale: Effect.Effect<void, never, SurrealClient>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/axctl/src/queries/ingest-staleness.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { DbError } from "@ax/lib/errors";
+import { makeMockDb, makeTestSurrealClient, runWithMock } from "@ax/lib/testing/surreal";
+import {
+    fetchLastSuccessfulIngestAt,
+    staleIngestThresholdMs,
+    warnIfIngestStale,
+} from "./ingest-staleness.ts";
+
+describe("staleIngestThresholdMs", () => {
+    test("defaults to 48h", () => {
+        expect(staleIngestThresholdMs({} as NodeJS.ProcessEnv)).toBe(48 * 3_600_000);
+    });
+
+    test("honours AX_STALE_INGEST_HOURS; 0 disables", () => {
+        expect(staleIngestThresholdMs({ AX_STALE_INGEST_HOURS: "6" } as NodeJS.ProcessEnv)).toBe(6 * 3_600_000);
+        expect(staleIngestThresholdMs({ AX_STALE_INGEST_HOURS: "0" } as NodeJS.ProcessEnv)).toBe(0);
+    });
+});
+
+describe("fetchLastSuccessfulIngestAt", () => {
+    test("reads the newest ok run via one status-filtered indexed query", async () => {
+        const db = makeMockDb([[[{ ended_at: "2026-07-03T12:00:00.000Z", started_at: "2026-07-03T11:50:00.000Z" }]]]);
+        const at = await runWithMock(db, fetchLastSuccessfulIngestAt);
+
+        expect(at).toBe(Date.parse("2026-07-03T12:00:00.000Z"));
+        expect(db.captured).toHaveLength(1);
+        // Must hit the ingest_run_status_started index: filter on status, order
+        // by started_at. A full scan here would tax every read command.
+        expect(db.captured[0]).toContain("FROM ingest_run");
+        expect(db.captured[0]).toContain("status = 'ok'");
+        expect(db.captured[0]).toContain("ORDER BY started_at DESC");
+        expect(db.captured[0]).toContain("LIMIT 1");
+    });
+
+    test("falls back to started_at when ended_at is absent", async () => {
+        const db = makeMockDb([[[{ started_at: "2026-07-03T11:50:00.000Z" }]]]);
+        expect(await runWithMock(db, fetchLastSuccessfulIngestAt)).toBe(Date.parse("2026-07-03T11:50:00.000Z"));
+    });
+
+    test("null when no ok run exists", async () => {
+        const db = makeMockDb([[[]]]);
+        expect(await runWithMock(db, fetchLastSuccessfulIngestAt)).toBeNull();
+    });
+
+    test("null when the timestamps are unparseable", async () => {
+        const db = makeMockDb([[[{ ended_at: "not-a-date" }]]]);
+        expect(await runWithMock(db, fetchLastSuccessfulIngestAt)).toBeNull();
+    });
+});
+
+describe("warnIfIngestStale (real seam)", () => {
+    // Capture stderr around the run: the observable effect IS the printed line.
+    const captureStderr = async (effect: Effect.Effect<void, never, never>): Promise<string> => {
+        const original = process.stderr.write.bind(process.stderr);
+        let out = "";
+        // @ts-expect-error - narrow test double for the write overloads
+        process.stderr.write = (chunk: string) => {
+            out += String(chunk);
+            return true;
+        };
+        try {
+            await Effect.runPromise(effect);
+        } finally {
+            process.stderr.write = original;
+        }
+        return out;
+    };
+
+    const okRunFrom = (iso: string) =>
+        makeTestSurrealClient({ routes: { "FROM ingest_run": [[{ ended_at: iso, started_at: iso }]] } });
+
+    test("prints one warning line when the last ok ingest is older than 48h", async () => {
+        const db = okRunFrom(new Date(Date.now() - 13 * 86_400_000).toISOString());
+        const out = await captureStderr(warnIfIngestStale.pipe(Effect.provide(db.layer)));
+
+        expect(out).toContain("graph is stale");
+        expect(out).toContain("13d ago");
+        expect(out.trimEnd().split("\n")).toHaveLength(1);
+    });
+
+    test("stays silent when the graph is fresh", async () => {
+        const db = okRunFrom(new Date(Date.now() - 3_600_000).toISOString());
+        expect(await captureStderr(warnIfIngestStale.pipe(Effect.provide(db.layer)))).toBe("");
+    });
+
+    test("degrades silently when the DB is unreachable", async () => {
+        const db = makeTestSurrealClient({
+            routes: { "FROM ingest_run": Effect.fail(new DbError({ message: "connection refused" })) },
+        });
+        expect(await captureStderr(warnIfIngestStale.pipe(Effect.provide(db.layer)))).toBe("");
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/queries/ingest-staleness.test.ts`
+Expected: FAIL - `Cannot find module './ingest-staleness.ts'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/axctl/src/queries/ingest-staleness.ts`:
+
+```ts
+/**
+ * Stale-graph warning for read commands (#697).
+ *
+ * `ax dispatches` / `ax cost` returned empty for two weeks while ingest was
+ * dead, and nothing said so - an empty table reads as "you have no data", not
+ * "your data stopped 13 days ago". Doctor knew, but only when run by hand.
+ *
+ * So every DB-backed command pays one indexed query (`status = 'ok'` ORDER BY
+ * the indexed `started_at`, LIMIT 1) and prints at most one stderr line. It is
+ * wired into `withDb` (cli/index.ts) rather than per-command, so a new read
+ * command inherits it without knowing this exists.
+ *
+ * Fail-open: an unreachable DB prints nothing (the command's own error already
+ * says that) and a warning never touches stdout, so `--json` stays machine-clean.
+ */
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import {
+    formatStaleIngestWarning,
+    STALE_INGEST_AFTER_HOURS,
+} from "@ax/lib/shared/ingest-staleness";
+
+/** Age past which the graph is called stale. `AX_STALE_INGEST_HOURS`; 0
+ *  disables the warning. Exported for tests. */
+export const staleIngestThresholdMs = (env: NodeJS.ProcessEnv = process.env): number => {
+    const raw = Number(env.AX_STALE_INGEST_HOURS);
+    const hours = Number.isFinite(raw) && raw >= 0 ? raw : STALE_INGEST_AFTER_HOURS;
+    return hours * 3_600_000;
+};
+
+/** Hard cap on the probe. A wedged DB must not add latency to a command that
+ *  is already failing - the warning is a courtesy, not a feature. */
+const PROBE_TIMEOUT_MS = 2_000;
+
+interface LastOkRunRow {
+    readonly ended_at?: unknown;
+    readonly started_at?: unknown;
+}
+
+/**
+ * Epoch ms of the newest ingest that finished with status "ok", or null when
+ * there is none (or its timestamps are unreadable). Hits the
+ * `ingest_run_status_started` index: equality on `status`, ordered by the
+ * indexed `started_at`. Reads `ended_at` as the completion instant, falling
+ * back to `started_at` for rows written before `ended_at` existed.
+ */
+export const fetchLastSuccessfulIngestAt: Effect.Effect<number | null, DbError, SurrealClient> =
+    Effect.gen(function* () {
+        const db = yield* SurrealClient;
+        const [rows] = yield* db.query<[LastOkRunRow[]]>(
+            "SELECT ended_at, started_at FROM ingest_run WHERE status = 'ok' ORDER BY started_at DESC LIMIT 1;",
+        );
+        const row = rows?.[0];
+        if (row === undefined) return null;
+        const at = Date.parse(String(row.ended_at ?? row.started_at ?? ""));
+        return Number.isFinite(at) ? at : null;
+    });
+
+/**
+ * Print the stale-graph warning to stderr if the graph is out of date. Never
+ * fails, never throws, never writes to stdout.
+ */
+export const warnIfIngestStale: Effect.Effect<void, never, SurrealClient> = Effect.gen(
+    function* () {
+        const thresholdMs = staleIngestThresholdMs();
+        if (thresholdMs <= 0) return;
+        const lastOkMs = yield* fetchLastSuccessfulIngestAt;
+        const warning = formatStaleIngestWarning({ lastOkMs, nowMs: Date.now(), thresholdMs });
+        if (warning === null) return;
+        yield* Effect.sync(() => process.stderr.write(`${warning}\n`));
+    },
+).pipe(
+    Effect.timeoutOption(PROBE_TIMEOUT_MS),
+    Effect.asVoid,
+    Effect.ignore,
+);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/queries/ingest-staleness.test.ts`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Wire it into `withDb`**
+
+In `apps/axctl/src/cli/index.ts`, add the import alongside the other query imports:
+
+```ts
+import { warnIfIngestStale } from "../queries/ingest-staleness.ts";
+```
+
+and replace `withDb` (lines 213-219) with:
+
+```ts
+/**
+ * Provide AppLayer (SurrealClient + AxConfig + ProcessService) and a
+ * scope so handlers that allocate scoped resources work. Used by commands
+ * whose handlers actually touch SurrealDB.
+ *
+ * Every such command also gets the stale-graph warning (#697): one indexed
+ * query, stderr only, after the command's own output so it lands next to the
+ * prompt. `ensuring` (not `tap`) so a command that returned empty BECAUSE the
+ * graph is stale - the #697 symptom - still explains itself when it fails.
+ */
+const withDb = (args: ReadonlyArray<string>): CliProgram =>
+    runCli(args).pipe(
+        Effect.ensuring(warnIfIngestStale),
+        Effect.provide(AppLayer),
+        Effect.scoped,
+    );
+```
+
+- [ ] **Step 6: Verify the warning does not leak into stdout**
+
+Run: `bun test apps/axctl/src/queries/ingest-staleness.test.ts apps/axctl/src/cli/index.test.ts`
+Expected: PASS. (If `apps/axctl/src/cli/index.test.ts` does not exist, run only the first suite and note it.)
+
+- [ ] **Step 7: Typecheck**
+
+Run: `bun run typecheck`
+Expected: exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/axctl/src/queries/ingest-staleness.ts apps/axctl/src/queries/ingest-staleness.test.ts apps/axctl/src/cli/index.ts
+git commit -m "feat(cli): warn on read commands when the graph is >48h stale (#697)"
+```
+
+---
+
+### Task 4: Deadline-aware derive budget (issue #697 part 2)
+
+**Premise correction, read before starting:** a per-stage derive watchdog ALREADY exists - `deriveStageTimeoutSeconds` (`apps/axctl/src/ingest/stage/runner.ts:28`, default 300s, `AX_STAGE_TIMEOUT_SECONDS`, #671), applied to `derive`-tagged stages only, failing open with empty stats. `derive-metrics` and `outcomes` are both `derive`-tagged, so they are already capped at 300s each. Do NOT re-add it.
+
+The remaining gap is that the cap is a fixed 300s with no idea of the run's own deadline. Under a backlog, provider stages eat most of the 900s `AX_INGEST_TIMEOUT_SECONDS`, then derives start their own 300s clocks and blow through the outer cap. The outer timeout then guillotines the pass, which by design LEAVES the ingest lock in place as a cooldown - so the watcher's next fires SKIP, and the user is left re-running ingest by hand ("completion needs many manual re-runs"). Fix: cap each derive by whatever is actually left before the deadline, keeping a reserve so the run finalizes itself cleanly rather than being killed.
+
+Scope discipline: this makes passes END CLEANLY. It does NOT make a heavy derive COMPLETE - that needs chunked/resumable derive, which is #689's territory. File the follow-up (Step 8); do not build it here.
+
+**Files:**
+- Create: `apps/axctl/src/ingest/stage/derive-budget.ts`
+- Create: `apps/axctl/src/ingest/stage/derive-budget.test.ts`
+- Modify: `apps/axctl/src/ingest/stage/runner.ts:138-237` (`runPipeline`)
+- Modify: `apps/axctl/src/ingest/stage/runner.test.ts` (real-seam pipeline tests)
+- Modify: `apps/axctl/src/ingest/run.ts:316` (pass the deadline)
+
+**Interfaces:**
+- Consumes: `deriveStageTimeoutSeconds` from `./runner.ts` (unchanged); `BaseStageStats`, `StageDef`, `IngestContext` from `./types.ts`.
+- Produces:
+  - `type DeriveStageBudget = { readonly _tag: "uncapped" } | { readonly _tag: "capped"; readonly capMs: number } | { readonly _tag: "skip"; readonly reason: string }`
+  - `const DERIVE_RESERVE_SECONDS: number` (= 30)
+  - `const deriveReserveMs: (env?: NodeJS.ProcessEnv) => number`
+  - `const deriveStageBudget: (input: { readonly staticCapMs: number; readonly deadlineMs: number | null; readonly nowMs: number; readonly reserveMs: number }) => DeriveStageBudget`
+  - `runPipeline` gains a third parameter: `opts: { readonly deadlineMs?: number; readonly reserveMs?: number } = {}`
+
+- [ ] **Step 1: Write the failing test for the pure allocator**
+
+Create `apps/axctl/src/ingest/stage/derive-budget.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { deriveReserveMs, deriveStageBudget, DERIVE_RESERVE_SECONDS } from "./derive-budget.ts";
+
+describe("deriveReserveMs", () => {
+    test("defaults to 30s", () => {
+        expect(deriveReserveMs({} as NodeJS.ProcessEnv)).toBe(DERIVE_RESERVE_SECONDS * 1000);
+        expect(DERIVE_RESERVE_SECONDS).toBe(30);
+    });
+
+    test("honours AX_DERIVE_RESERVE_SECONDS, including 0", () => {
+        expect(deriveReserveMs({ AX_DERIVE_RESERVE_SECONDS: "5" } as NodeJS.ProcessEnv)).toBe(5_000);
+        expect(deriveReserveMs({ AX_DERIVE_RESERVE_SECONDS: "0" } as NodeJS.ProcessEnv)).toBe(0);
+        expect(deriveReserveMs({ AX_DERIVE_RESERVE_SECONDS: "junk" } as NodeJS.ProcessEnv)).toBe(30_000);
+    });
+});
+
+describe("deriveStageBudget", () => {
+    const now = 1_000_000;
+
+    test("uses the static cap when the deadline is far away", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now + 900_000,
+            nowMs: now,
+            reserveMs: 30_000,
+        })).toEqual({ _tag: "capped", capMs: 300_000 });
+    });
+
+    test("shrinks to the remaining budget when the deadline is nearer than the static cap", () => {
+        // 100s left, minus a 30s reserve => 70s for this stage, not the full 300s.
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now + 100_000,
+            nowMs: now,
+            reserveMs: 30_000,
+        })).toEqual({ _tag: "capped", capMs: 70_000 });
+    });
+
+    test("skips once the reserve is all that is left - the run must finalize itself", () => {
+        const budget = deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now + 30_000,
+            nowMs: now,
+            reserveMs: 30_000,
+        });
+        expect(budget._tag).toBe("skip");
+    });
+
+    test("skips when the deadline has already passed", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: now - 1,
+            nowMs: now,
+            reserveMs: 30_000,
+        })._tag).toBe("skip");
+    });
+
+    test("no deadline: the static cap still applies (today's behaviour)", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 300_000,
+            deadlineMs: null,
+            nowMs: now,
+            reserveMs: 30_000,
+        })).toEqual({ _tag: "capped", capMs: 300_000 });
+    });
+
+    test("no deadline and a disabled static cap: uncapped", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 0,
+            deadlineMs: null,
+            nowMs: now,
+            reserveMs: 30_000,
+        })).toEqual({ _tag: "uncapped" });
+    });
+
+    test("disabled static cap still respects the deadline", () => {
+        expect(deriveStageBudget({
+            staticCapMs: 0,
+            deadlineMs: now + 100_000,
+            nowMs: now,
+            reserveMs: 30_000,
+        })).toEqual({ _tag: "capped", capMs: 70_000 });
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/ingest/stage/derive-budget.test.ts`
+Expected: FAIL - `Cannot find module './derive-budget.ts'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/axctl/src/ingest/stage/derive-budget.ts`:
+
+```ts
+/**
+ * How long may a derive stage run, given the pass's own deadline? (#697)
+ *
+ * The static watchdog (`AX_STAGE_TIMEOUT_SECONDS`, #671) caps ONE derive at
+ * 300s but knows nothing about the run's wall-clock budget
+ * (`AX_INGEST_TIMEOUT_SECONDS`, 900s). Under a backlog the provider stages eat
+ * most of the budget, then each derive starts a fresh 300s clock and pushes the
+ * pass past the outer cap. The outer timeout is not a soft landing: it
+ * deliberately LEAVES the ingest lock as a cooldown (see ingest-lock.ts), so
+ * the watcher's next fires skip and a human is left re-running ingest by hand.
+ *
+ * So a derive gets `min(staticCap, timeLeftBeforeDeadline - reserve)`, and is
+ * skipped outright once only the reserve remains. The reserve is what the run
+ * needs to finalize its own `ingest_run` row and exit clean.
+ *
+ * This bounds the pass. It does NOT make a heavy derive finish - that wants
+ * chunked/resumable derive (#689).
+ */
+
+/** What a derive stage is allowed this pass. */
+export type DeriveStageBudget =
+    /** Run it with no timeout (no deadline and the static cap is disabled). */
+    | { readonly _tag: "uncapped" }
+    /** Run it, but time it out after `capMs`. */
+    | { readonly _tag: "capped"; readonly capMs: number }
+    /** Don't start it: there is no budget left. */
+    | { readonly _tag: "skip"; readonly reason: string };
+
+/** Wall-clock held back from derives so the run can finalize its `ingest_run`
+ *  row (and the outer lock release) instead of being guillotined mid-write. */
+export const DERIVE_RESERVE_SECONDS = 30;
+
+/** `AX_DERIVE_RESERVE_SECONDS`; 0 is a legal "no reserve". Exported for tests. */
+export const deriveReserveMs = (env: NodeJS.ProcessEnv = process.env): number => {
+    const raw = Number(env.AX_DERIVE_RESERVE_SECONDS);
+    return (Number.isFinite(raw) && raw >= 0 ? raw : DERIVE_RESERVE_SECONDS) * 1000;
+};
+
+/**
+ * Budget for the derive stage about to start. `staticCapMs <= 0` disables the
+ * static cap; `deadlineMs === null` means the caller has no wall-clock budget
+ * (tests, `--derive-only` invocations without a timeout), in which case this
+ * degrades to exactly today's static-cap behaviour.
+ */
+export const deriveStageBudget = (input: {
+    readonly staticCapMs: number;
+    readonly deadlineMs: number | null;
+    readonly nowMs: number;
+    readonly reserveMs: number;
+}): DeriveStageBudget => {
+    const untilDeadline = input.deadlineMs === null
+        ? Number.POSITIVE_INFINITY
+        : input.deadlineMs - input.reserveMs - input.nowMs;
+    if (untilDeadline <= 0) {
+        return {
+            _tag: "skip",
+            reason: "no time left before the ingest deadline (raise AX_INGEST_TIMEOUT_SECONDS, " +
+                "or run 'ax ingest --derive-only' to catch derives up)",
+        };
+    }
+    const staticCap = input.staticCapMs > 0 ? input.staticCapMs : Number.POSITIVE_INFINITY;
+    const capMs = Math.min(staticCap, untilDeadline);
+    return Number.isFinite(capMs) ? { _tag: "capped", capMs } : { _tag: "uncapped" };
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/ingest/stage/derive-budget.test.ts`
+Expected: PASS (10 tests)
+
+- [ ] **Step 5: Write the failing real-seam pipeline test**
+
+Append to `apps/axctl/src/ingest/stage/runner.test.ts` (reuse whatever stage-fixture helpers the file already has; if it has none, use these verbatim):
+
+```ts
+import { Effect } from "effect";
+import { runPipeline } from "./runner.ts";
+import { BaseStageStats, IngestContext, StageMeta } from "./types.ts";
+import type { StageDef } from "./types.ts";
+
+describe("runPipeline derive budget (#697)", () => {
+    const ctx = IngestContext.make({ cwd: "/tmp", since: new Date(0), debug: false });
+
+    const stage = (
+        key: string,
+        tags: ReadonlyArray<"ingest" | "derive">,
+        run: Effect.Effect<BaseStageStats, never, never>,
+    ): StageDef<BaseStageStats, never> => ({
+        meta: StageMeta.make({ key, deps: [], tags }),
+        run: () => run,
+    });
+
+    const instant = (key: string, tags: ReadonlyArray<"ingest" | "derive">) =>
+        stage(key, tags, Effect.succeed(BaseStageStats.make({ durationMs: 0, summary: `${key} ok` })));
+
+    /** A stage that would run far past any test's patience. */
+    const hangs = (key: string, tags: ReadonlyArray<"ingest" | "derive">) =>
+        stage(key, tags, Effect.never as Effect.Effect<BaseStageStats, never, never>);
+
+    test("a derive stage past the deadline is skipped and the pass still completes", async () => {
+        const stats = await Effect.runPromise(
+            runPipeline([instant("claude", ["ingest"]), hangs("derive-metrics", ["derive"])], ctx, {
+                deadlineMs: Date.now() - 1, // budget already blown, as after a backlog
+                reserveMs: 0,
+            }),
+        );
+
+        // The real observable effect: the pipeline RETURNS instead of hanging
+        // until the outer 900s timeout guillotines it (and leaves a cooldown lock).
+        expect(stats).toHaveLength(2);
+        const derive = stats.find((s) => s.summary.includes("skipped"));
+        expect(derive).toBeDefined();
+        expect(stats.some((s) => s.summary === "claude ok")).toBe(true);
+    });
+
+    test("a derive stage is capped by the time left, not its static 300s cap", async () => {
+        const started = Date.now();
+        const stats = await Effect.runPromise(
+            runPipeline([hangs("outcomes", ["derive"])], ctx, {
+                deadlineMs: Date.now() + 150,
+                reserveMs: 0,
+            }),
+        );
+
+        // Bounded by the deadline (150ms), NOT by AX_STAGE_TIMEOUT_SECONDS (300s).
+        expect(Date.now() - started).toBeLessThan(5_000);
+        expect(stats[0]?.summary).toContain("timed out");
+    });
+
+    test("an ingest-tagged stage is exempt - a real backfill legitimately runs long", async () => {
+        const exit = await Effect.runPromiseExit(
+            runPipeline([instant("skills", ["ingest"])], ctx, {
+                deadlineMs: Date.now() - 1,
+                reserveMs: 0,
+            }),
+        );
+
+        // Provider stages must not be skipped by the derive budget.
+        expect(exit._tag).toBe("Success");
+    });
+
+    test("no deadline: unchanged behaviour (stages run to completion)", async () => {
+        const stats = await Effect.runPromise(
+            runPipeline([instant("claude", ["ingest"]), instant("outcomes", ["derive"])], ctx),
+        );
+        expect(stats.map((s) => s.summary).sort()).toEqual(["claude ok", "outcomes ok"]);
+    });
+});
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `bun test apps/axctl/src/ingest/stage/runner.test.ts`
+Expected: FAIL - `runPipeline` takes 2 args, so the `opts` are ignored: the skip test hangs (or the `stats.find(...skipped)` assertion fails) and the cap test blows the 5s bound.
+
+- [ ] **Step 7: Wire the budget into `runPipeline`**
+
+In `apps/axctl/src/ingest/stage/runner.ts`, add the import:
+
+```ts
+import { deriveReserveMs, deriveStageBudget } from "./derive-budget.ts";
+```
+
+Change the signature (line 138) to take opts:
+
+```ts
+/** Run the given stages with DAG scheduling. Each stage waits for its in-graph
+ *  deps via Deferreds; only `PIPELINE_CONCURRENCY` are inside the semaphore at
+ *  once. Each stage is wrapped in `LiveTrace.step` so progress flows through
+ *  the configured `TraceTransport` (ADR-0007).
+ *
+ *  `opts.deadlineMs` is the run's wall-clock deadline (epoch ms). Derive stages
+ *  are budgeted against it so the pass ends cleanly instead of being killed by
+ *  the outer ingest timeout (#697); omit it and derives keep only their static
+ *  `AX_STAGE_TIMEOUT_SECONDS` cap. `opts.reserveMs` overrides the finalization
+ *  reserve (env default) - tests pass 0. */
+export const runPipeline = <S extends BaseStageStats, R>(
+    stages: ReadonlyArray<StageDef<S, R>>,
+    ctx: IngestContext,
+    opts: { readonly deadlineMs?: number; readonly reserveMs?: number } = {},
+): Effect.Effect<ReadonlyArray<S>, DbError, R> =>
+```
+
+Inside, after `const stageTimeoutMs = deriveStageTimeoutSeconds() * 1000;` (line 154) add:
+
+```ts
+        const deadlineMs = opts.deadlineMs ?? null;
+        const reserveMs = opts.reserveMs ?? deriveReserveMs();
+```
+
+Then replace the whole `const guarded = ...` block (lines 178-196) with a suspended, budget-aware version. It MUST be `Effect.suspend` so `Date.now()` is read when the stage actually starts - i.e. after it has waited on its deps AND acquired a semaphore permit - not when the pipeline was built:
+
+```ts
+                // Watchdog: cap `derive` stages so one stuck or backlogged derive
+                // can't wedge the run OR push the pass past its deadline (#671,
+                // #697). Fails OPEN - a warning plus sentinel stats - because
+                // downstream deps only await this Deferred (they never read its
+                // value; they re-query the DB) and the totals roll-up skips
+                // `durationMs` + non-numeric fields, so an empty BaseStageStats is
+                // safe. Heavy provider stages (claude, codex, git) are exempt: a
+                // full backfill legitimately runs for many minutes.
+                // Suspended so `Date.now()` is read at stage START (post-deps,
+                // post-permit) - reading it at build time would hand every stage
+                // the budget the FIRST one had.
+                const guarded = !s.meta.tags.includes("derive")
+                    ? body
+                    : Effect.suspend(() => {
+                        const budget = deriveStageBudget({
+                            staticCapMs: stageTimeoutMs,
+                            deadlineMs,
+                            nowMs: Date.now(),
+                            reserveMs,
+                        });
+                        if (budget._tag === "uncapped") return body;
+                        if (budget._tag === "skip") {
+                            return Effect.logWarning(
+                                `ingest: skipping derive stage '${s.meta.key}' - ${budget.reason}.`,
+                            ).pipe(
+                                Effect.as({
+                                    durationMs: 0,
+                                    summary: "skipped (out of budget)",
+                                } as unknown as S),
+                            );
+                        }
+                        return body.pipe(
+                            Effect.timeoutOrElse({
+                                duration: budget.capMs,
+                                orElse: () =>
+                                    Effect.logWarning(
+                                        `ingest: derive stage '${s.meta.key}' exceeded ${Math.round(budget.capMs / 1000)}s - ` +
+                                            `skipping it (failed open) so the run can finish. ` +
+                                            `Raise/disable with AX_STAGE_TIMEOUT_SECONDS.`,
+                                    ).pipe(
+                                        Effect.as({
+                                            durationMs: budget.capMs,
+                                            summary: "timed out (watchdog)",
+                                        } as unknown as S),
+                                    ),
+                            }),
+                        );
+                    });
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `bun test apps/axctl/src/ingest/stage/runner.test.ts apps/axctl/src/ingest/stage/derive-budget.test.ts`
+Expected: PASS - including the pre-existing runner tests (the no-deadline path must be unchanged).
+
+- [ ] **Step 9: Pass the deadline from `runIngest`**
+
+In `apps/axctl/src/ingest/run.ts`, `runIngest` already has `AxConfig` in its requirements. Add after `const registry = yield* StageRegistry;` (line 279):
+
+```ts
+        const config = yield* AxConfig;
+        // The pass's wall-clock deadline, mirroring the `withIngestLock` timeout
+        // that wraps this run (cli/commands/ingest.ts). Derives are budgeted
+        // against it so the pass finalizes itself instead of being guillotined -
+        // the outer timeout deliberately leaves the lock as a cooldown, which is
+        // what turned #697's backlog into "re-run ingest by hand, repeatedly".
+        // The lock starts fractionally earlier than this, so our deadline is a
+        // hair late; the derive reserve absorbs that.
+        const deadlineMs = config.knobs.ingestTimeoutSeconds > 0
+            ? Date.now() + config.knobs.ingestTimeoutSeconds * 1000
+            : undefined;
+```
+
+and change the `runPipeline` call (line 316) to:
+
+```ts
+        const stageStats = yield* runPipeline(
+            wrappedStages,
+            ctx,
+            deadlineMs === undefined ? {} : { deadlineMs },
+        ).pipe(
+```
+
+(the rest of the `.pipe(...)` chain is unchanged).
+
+- [ ] **Step 10: Typecheck + the ingest suites**
+
+Run: `bun run typecheck && bun test apps/axctl/src/ingest/stage/ apps/axctl/src/ingest/run.test.ts`
+Expected: exit 0, green.
+
+- [ ] **Step 11: File the chunked-derive follow-up (do NOT implement)**
+
+```bash
+gh issue comment 697 --body "$(cat <<'EOF'
+Deadline-aware derive budgets landed: a derive stage now gets `min(AX_STAGE_TIMEOUT_SECONDS, timeLeftBeforeDeadline - reserve)`, so a pass finalizes cleanly instead of being guillotined by the outer `AX_INGEST_TIMEOUT_SECONDS` (which leaves the ingest lock as a cooldown and forces the manual re-runs reported here).
+
+Not addressed, and deliberately out of scope: a heavy derive still does not COMPLETE under a large backlog - it fails open each pass. That needs chunked/resumable derive, which overlaps #689 (usage derive exceeds watchdog, cascades). Tracking it there.
+EOF
+)"
+```
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add apps/axctl/src/ingest/stage/derive-budget.ts apps/axctl/src/ingest/stage/derive-budget.test.ts apps/axctl/src/ingest/stage/runner.ts apps/axctl/src/ingest/stage/runner.test.ts apps/axctl/src/ingest/run.ts
+git commit -m "fix(ingest): budget derive stages against the run deadline (#697)"
+```
+
+---
+
+## Verification (all tasks)
+
+- [ ] `bun run typecheck` exits 0 (capture the REAL exit code - do not pipe through `tail`/`grep` before checking `$?`).
+- [ ] `bun test packages/lib/src/shared/ingest-staleness.test.ts apps/axctl/src/ingest/reap-runs.test.ts apps/axctl/src/dashboard/reap-loop.test.ts apps/axctl/src/queries/ingest-staleness.test.ts apps/axctl/src/ingest/stage/derive-budget.test.ts apps/axctl/src/ingest/stage/runner.test.ts apps/axctl/src/cli/install.test.ts` - all green.
+- [ ] No live-DB e2e suites run. The daemon at `127.0.0.1:8521`/`1738` is untouched.
+- [ ] `git status` clean (apart from `BRIEF.md` / `REPORT.md`).
+
+## Open questions
+
+1. **Warning placement** - `withDb` covers `ax tui` too. `ensuring` fires after the TUI tears down, so the line lands on the shell prompt, not into the OpenTUI canvas. Acceptable; revisit if it looks wrong in practice.
+2. **`status = 'ok'` strictness** - a run that ends `partial` (outer timeout) does not clear the stale warning even though it landed data. Deliberate: the reaper writes `partial`, so counting partials would let #697's ghost rows silence the warning. Task 4 makes clean `ok` endings the norm, so the two changes reinforce each other.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "exports": {
     "./shared/community": "./src/shared/community.ts",
+    "./shared/env-number": "./src/shared/env-number.ts",
     "./shared/fs-error": "./src/shared/fs-error.ts",
     "./shared/fs-classify": "./src/shared/fs-classify.ts",
+    "./shared/ingest-staleness": "./src/shared/ingest-staleness.ts",
     "./shared/path": "./src/shared/path.ts",
     "./testing/test-filesystem": "./src/testing/test-filesystem.ts",
     "./testing/surreal": "./src/testing/surreal.ts",

--- a/packages/lib/src/shared/env-number.test.ts
+++ b/packages/lib/src/shared/env-number.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { nonNegativeNumberEnv } from "./env-number.ts";
+
+describe("nonNegativeNumberEnv", () => {
+    test("unset -> fallback", () => {
+        expect(nonNegativeNumberEnv(undefined, 300)).toBe(300);
+    });
+
+    // #697 finding 1: a blank value must read as UNSET, not as an explicit
+    // "0" - `Number("")` and `Number("   ")` are both `0`, which is finite
+    // and `>= 0`, so without the trim+empty-check this silently disables
+    // whatever the caller's "0" means (stale-warning off, no derive reserve).
+    test("empty string -> fallback", () => {
+        expect(nonNegativeNumberEnv("", 300)).toBe(300);
+    });
+
+    test("whitespace-only -> fallback", () => {
+        expect(nonNegativeNumberEnv("   ", 300)).toBe(300);
+    });
+
+    test("explicit \"0\" is honored, not treated as unset", () => {
+        expect(nonNegativeNumberEnv("0", 300)).toBe(0);
+    });
+
+    test("a valid value overrides the fallback", () => {
+        expect(nonNegativeNumberEnv("42", 300)).toBe(42);
+    });
+
+    test("unparseable garbage -> fallback", () => {
+        expect(nonNegativeNumberEnv("nonsense", 300)).toBe(300);
+    });
+
+    test("negative -> fallback (this parser is non-negative only)", () => {
+        expect(nonNegativeNumberEnv("-5", 300)).toBe(300);
+    });
+});

--- a/packages/lib/src/shared/env-number.ts
+++ b/packages/lib/src/shared/env-number.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared "non-negative number env var" parser (#697 follow-up).
+ *
+ * `Number("")` and `Number("  ")` are both `0` - finite and `>= 0` - so a
+ * naive `Number.isFinite(raw) && raw >= 0` guard reads a BLANK env var as an
+ * explicit "0" rather than "unset". An exported-but-blank var is a real
+ * trigger, not a hypothetical: an empty string in a launchd plist, or a bare
+ * `export AX_FOO=` line in a shell profile. `reapIntervalSeconds`
+ * (dashboard/reap-loop.ts) already guarded against this; `staleIngestThresholdMs`
+ * (queries/ingest-staleness.ts) and `deriveReserveMs` (ingest/stage/derive-budget.ts)
+ * did not - three parsers hand-rolled the same shape and two got it wrong, so
+ * it lives here once.
+ *
+ * Semantics: undefined / blank / whitespace-only / unparseable -> `fallback`.
+ * A valid non-negative number (including the literal `"0"`) -> that number;
+ * each call site treats an explicit `0` as its own meaningful "disabled" /
+ * "no reserve" value, so `0` must never be confused with "unset".
+ *
+ * Dep-free (no Effect, no DB) - `ax doctor`'s no-layer probe imports from
+ * this directory.
+ */
+export const nonNegativeNumberEnv = (raw: string | undefined, fallback: number): number => {
+    const trimmed = raw?.trim();
+    if (!trimmed) return fallback;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};

--- a/packages/lib/src/shared/ingest-staleness.test.ts
+++ b/packages/lib/src/shared/ingest-staleness.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+    formatStaleIngestWarning,
+    isStrandedRun,
+    REAP_GRACE_SECONDS,
+    STALE_INGEST_AFTER_HOURS,
+} from "./ingest-staleness.ts";
+
+describe("isStrandedRun", () => {
+    const now = Date.parse("2026-07-16T12:00:00.000Z");
+    const staleAfterMs = 960_000; // 900s ingest timeout + 60s grace
+
+    test("strands a run whose heartbeat is older than the budget", () => {
+        expect(isStrandedRun(
+            { id: "ingest_run:dead", started_at: "2026-07-16T11:00:00.000Z", last_progress_at: "2026-07-16T11:30:00.000Z" },
+            now,
+            staleAfterMs,
+        )).toBe(true);
+    });
+
+    test("spares a run whose heartbeat is within the budget", () => {
+        expect(isStrandedRun(
+            { id: "ingest_run:live", started_at: "2026-07-16T10:00:00.000Z", last_progress_at: "2026-07-16T11:59:00.000Z" },
+            now,
+            staleAfterMs,
+        )).toBe(false);
+    });
+
+    test("falls back to started_at when last_progress_at is absent", () => {
+        expect(isStrandedRun({ id: "a", started_at: "2026-07-16T11:58:00.000Z" }, now, staleAfterMs)).toBe(false);
+        expect(isStrandedRun({ id: "b", started_at: "2026-07-16T11:00:00.000Z" }, now, staleAfterMs)).toBe(true);
+    });
+
+    test("strands a row with no parseable timestamp (can't prove it's live)", () => {
+        expect(isStrandedRun({ id: "ingest_run:mystery" }, now, staleAfterMs)).toBe(true);
+    });
+
+    test("REAP_GRACE_SECONDS is the shared 60s margin doctor and the reaper both use", () => {
+        expect(REAP_GRACE_SECONDS).toBe(60);
+    });
+});
+
+describe("formatStaleIngestWarning", () => {
+    const now = Date.parse("2026-07-16T12:00:00.000Z");
+    const thresholdMs = STALE_INGEST_AFTER_HOURS * 3_600_000;
+
+    test("no warning when the last successful ingest is inside the threshold", () => {
+        expect(formatStaleIngestWarning({
+            lastOkMs: now - 3_600_000,
+            nowMs: now,
+            thresholdMs,
+        })).toBeNull();
+    });
+
+    test("warns in days once the graph is older than the threshold", () => {
+        const warning = formatStaleIngestWarning({
+            lastOkMs: Date.parse("2026-07-03T12:00:00.000Z"),
+            nowMs: now,
+            thresholdMs,
+        });
+        expect(warning).toContain("graph is stale");
+        expect(warning).toContain("13d ago");
+        expect(warning).toContain("ax ingest");
+    });
+
+    test("warns in hours just past the threshold", () => {
+        const warning = formatStaleIngestWarning({
+            lastOkMs: now - 50 * 3_600_000,
+            nowMs: now,
+            thresholdMs,
+        });
+        expect(warning).toContain("50h ago");
+    });
+
+    test("warns with tailored copy when no successful ingest was ever recorded", () => {
+        const warning = formatStaleIngestWarning({ lastOkMs: null, nowMs: now, thresholdMs });
+        expect(warning).toContain("no successful ingest");
+        expect(warning).toContain("ax ingest");
+    });
+
+    test("a non-positive threshold disables the warning entirely", () => {
+        expect(formatStaleIngestWarning({ lastOkMs: null, nowMs: now, thresholdMs: 0 })).toBeNull();
+        expect(formatStaleIngestWarning({ lastOkMs: 0, nowMs: now, thresholdMs: 0 })).toBeNull();
+    });
+});

--- a/packages/lib/src/shared/ingest-staleness.ts
+++ b/packages/lib/src/shared/ingest-staleness.ts
@@ -1,0 +1,82 @@
+/**
+ * Ingest staleness rules, shared by every surface that judges "is the graph
+ * current?" - `ax doctor`'s HTTP probe (cli/install.ts), the ingest-start +
+ * daemon reapers (ingest/reap-runs.ts, dashboard/reap-loop.ts), and the
+ * read-command warning (queries/ingest-staleness.ts).
+ *
+ * Two distinct questions live here on purpose - they are the same subject
+ * (#697) and drifted apart once already:
+ *  - {@link isStrandedRun}: is THIS "running" row a crash leftover?
+ *  - {@link formatStaleIngestWarning}: is the graph as a whole out of date?
+ *
+ * Dep-free (no Effect, no DB) so doctor's no-layer code path and the site can
+ * both import it.
+ */
+
+/** The `ingest_run` columns the stranded check reads. Shape is shared by
+ *  doctor's raw HTTP probe and the reaper's SurrealClient query. */
+export interface IngestRunHeartbeatRow {
+    readonly id?: unknown;
+    readonly started_at?: unknown;
+    readonly last_progress_at?: unknown;
+}
+
+/** Grace beyond the ingest timeout before a still-"running" row is deemed
+ *  stranded. Doctor, the ingest-start reaper and the daemon reaper share it so
+ *  they can never disagree about what "stuck" means. */
+export const REAP_GRACE_SECONDS = 60;
+
+/**
+ * Is this "running" row crash residue? Every clean exit path (ok / error /
+ * interrupt / timeout) settles the row, so a row whose newest heartbeat
+ * (`last_progress_at`, else `started_at`) is past the budget was killed
+ * without finalizing. No parseable timestamp => can't prove it's live => treat
+ * as stranded.
+ */
+export const isStrandedRun = (
+    row: IngestRunHeartbeatRow,
+    nowMs: number,
+    staleAfterMs: number,
+): boolean => {
+    const beat = Date.parse(String(row.last_progress_at ?? row.started_at ?? ""));
+    if (!Number.isFinite(beat)) return true;
+    return nowMs - beat > staleAfterMs;
+};
+
+/** Age past which the graph is called stale on read commands (#697: two weeks
+ *  of empty `ax cost` / `ax dispatches` went unflagged). */
+export const STALE_INGEST_AFTER_HOURS = 48;
+
+/** `50h` / `13d` - days once we're past three days, where "13d" reads better
+ *  than three-digit hour counts. (Not the same 48h as {@link STALE_INGEST_AFTER_HOURS}:
+ *  that's when the warning starts firing at all; this is purely about when the
+ *  *display* switches units, a day later so hours right after the threshold
+ *  still read precisely.) */
+const formatAge = (ageMs: number): string => {
+    const hours = Math.floor(ageMs / 3_600_000);
+    return hours >= 72 ? `${Math.floor(hours / 24)}d` : `${hours}h`;
+};
+
+/**
+ * One-line warning for a stale graph, or null when it's current (or the check
+ * is disabled with a non-positive threshold).
+ *
+ * `lastOkMs` is the newest run that finished with status "ok". Deliberately
+ * NOT "ok or partial": the reaper settles crash residue as "partial", so
+ * counting partials would let the ghost rows from #697 suppress the very
+ * warning that exists to surface them.
+ */
+export const formatStaleIngestWarning = (input: {
+    readonly lastOkMs: number | null;
+    readonly nowMs: number;
+    readonly thresholdMs: number;
+}): string | null => {
+    if (input.thresholdMs <= 0) return null;
+    if (input.lastOkMs === null) {
+        return "ax: no successful ingest recorded - results are empty until you run 'ax ingest'.";
+    }
+    const ageMs = input.nowMs - input.lastOkMs;
+    if (ageMs <= input.thresholdMs) return null;
+    return `ax: graph is stale - last successful ingest ${formatAge(ageMs)} ago; ` +
+        `results may be incomplete. Run 'ax ingest' ('ax doctor' to diagnose).`;
+};


### PR DESCRIPTION
Closes #697.

Three fixes from today's dogfood, plus the root cause #597's reap-on-start missed (on the IDE daemon model nothing re-runs ingest, so a start-time reaper never fires):

1. **Daemon auto-reap**: `runReapLoop` sweeps stranded `ingest_run` rows from `ax serve` (always up); `superviseReapLoop` re-arms when serve boots before SurrealDB. Reap write is guarded `WHERE status = 'running'` so a run finishing `ok` mid-sweep is never flipped to partial; the shared per-file provider loop now bumps `last_progress_at` (throttled) so a long single-stage backfill is never falsely reaped.
2. **Staleness surfacing**: every DB-backed command warns on stderr when the last `status='ok'` ingest is >48h old (`AX_STALE_INGEST_HOURS` override, blank-safe via shared env parser). Wired as a pre-flight in `withDb` — not `ensuring` — because legacy handlers `process.exit(1)` past finalizers on exactly the stale-symptom paths. `--json` stdout stays clean; fail-open with a 2s cap.
3. **Derive budgets**: derive stages are capped against the run deadline (`deriveStageBudget`: static per-stage cap ∧ remaining deadline − reserve), skip-with-warning when out of budget; heavy provider stages stay exempt.

Gate: codex adversarial review (FAIL → 4 items fixed: conditional reap, provider heartbeat, pre-flight warning, env-number reuse) + orchestrator verification. typecheck 0; 91 tests green across 9 touched suites.

## Deferred concerns (filed as follow-ups)
- staleness probe orders by `started_at` (index) but reports `ended_at` — overlapping-run edge can misdate the warning
- derive budget hands each stage the full remaining window — no fair-share split across a serial chain
- `superviseReapLoop` timer is uncancellable on runtime disposal
- reap-loop/staleness/deadline wiring lacks production-path integration tests

Fleet run: dogfood-0716 (map #699).

🤖 Generated with [Claude Code](https://claude.com/claude-code)