### PR TITLE
feat(team): per-repo team binding + ax team join/status/leave (Slice 1)

### DIFF
--- a/apps/axctl/src/cli/commands/team.ts
+++ b/apps/axctl/src/cli/commands/team.ts
@@ -38,7 +38,19 @@ import {
 import { sha256Hex } from "../../team/exec-hash.ts";
 import { isOnDefaultBranch } from "../../team/git-branch.ts";
 import { installTeamHook, isSafeHookName, hookSnapshotPath } from "../../team/install-team-hook.ts";
+import {
+    joinTeamBinding,
+    leaveTeamBinding,
+    statusTeamBindings,
+    teamRepositoryContext,
+} from "../../team/team-bindings-commands.ts";
+import {
+    DEFAULT_TEAM_SHARE,
+    TEAM_SHARE_VALUES,
+    defaultTeamBindingsPath,
+} from "../../team/team-bindings-state.ts";
 import { HookProviderRegistryDefault } from "../../hooks/providers/registry.ts";
+import { resolvePwdRepository } from "../../pwd.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 
 // ---------------------------------------------------------------------------
@@ -553,6 +565,104 @@ const experimentCommand = Command.make("experiment").pipe(
 );
 
 // ---------------------------------------------------------------------------
+// ax team join/status/leave
+// ---------------------------------------------------------------------------
+
+const resolveCurrentTeamRepo = (command: "join" | "leave") =>
+    resolvePwdRepository().pipe(
+        Effect.map(teamRepositoryContext),
+        Effect.catchTag("NotAGitRepoError", (error) =>
+            Effect.sync(() => {
+                console.error(
+                    `[ax team ${command}] not inside a git repo (cwd=${error.cwd}).`,
+                );
+                return null;
+            }),
+        ),
+    );
+
+export const joinCommand = Command.make(
+    "join",
+    {
+        org: Argument.string("org"),
+        share: Flag.choice("share", TEAM_SHARE_VALUES).pipe(
+            Flag.withDefault(DEFAULT_TEAM_SHARE),
+        ),
+        yes: Flag.boolean("yes").pipe(Flag.withDefault(false)),
+    },
+    ({ org, share, yes }) =>
+        Effect.gen(function* () {
+            const currentRepo = yield* resolveCurrentTeamRepo("join");
+            if (currentRepo === null) return;
+            const normalizedOrg = org.trim();
+            if (normalizedOrg.length === 0) {
+                console.error("[ax team join] org must not be empty.");
+                return;
+            }
+            yield* Effect.promise(() =>
+                joinTeamBinding({
+                    org: normalizedOrg,
+                    currentRepo,
+                    statePath: defaultTeamBindingsPath(),
+                    share,
+                    ...(yes
+                        ? { confirmed: true }
+                        : {
+                            confirm: () => {
+                                const answer = (
+                                    globalThis.prompt?.("Bind this repo? [y/N]") ?? ""
+                                )
+                                    .trim()
+                                    .toLowerCase();
+                                return answer === "y" || answer === "yes";
+                            },
+                        }),
+                    write: (line) => console.log(line),
+                }),
+            );
+        }),
+).pipe(
+    Command.withDescription(
+        "Bind the current git repo to a team org. Default share is anonymous. " +
+        "--share=anon|full  --yes",
+    ),
+);
+
+export const statusCommand = Command.make("status", {}, () =>
+    Effect.gen(function* () {
+        const currentRepo = yield* resolvePwdRepository().pipe(
+            Effect.map(teamRepositoryContext),
+            Effect.catchTag("NotAGitRepoError", () => Effect.succeed(null)),
+        );
+        yield* Effect.promise(() =>
+            statusTeamBindings({
+                statePath: defaultTeamBindingsPath(),
+                currentRepo,
+                write: (line) => console.log(line),
+            }),
+        );
+    }),
+).pipe(
+    Command.withDescription(
+        "List machine-local repo bindings and mark the current repo.",
+    ),
+);
+
+export const leaveCommand = Command.make("leave", {}, () =>
+    Effect.gen(function* () {
+        const currentRepo = yield* resolveCurrentTeamRepo("leave");
+        if (currentRepo === null) return;
+        yield* Effect.promise(() =>
+            leaveTeamBinding({
+                currentRepo,
+                statePath: defaultTeamBindingsPath(),
+                write: (line) => console.log(line),
+            }),
+        );
+    }),
+).pipe(Command.withDescription("Unbind the current git repo from its team org."));
+
+// ---------------------------------------------------------------------------
 // ax team (group)
 // ---------------------------------------------------------------------------
 
@@ -560,7 +670,14 @@ export const teamCommand = Command.make("team").pipe(
     Command.withDescription(
         "Team rig management: activate the shared .ax/ skills and agents into your local runtime.",
     ),
-    Command.withSubcommands([syncCommand, trustCommand, experimentCommand]),
+    Command.withSubcommands([
+        joinCommand,
+        statusCommand,
+        leaveCommand,
+        syncCommand,
+        trustCommand,
+        experimentCommand,
+    ]),
 );
 
 export const teamRuntime: RuntimeManifest = {
@@ -572,6 +689,9 @@ export const teamRuntime: RuntimeManifest = {
                 sync: "none",
                 trust: "none",
                 experiment: "none",
+                join: "db",
+                status: "db",
+                leave: "db",
             },
         },
         hidden: false,

--- a/apps/axctl/src/team/team-bindings-commands.test.ts
+++ b/apps/axctl/src/team/team-bindings-commands.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chooseIdentity } from "../ingest/repository-identity.ts";
+import { loadTeamBindings } from "./team-bindings-state.ts";
+import {
+    joinTeamBinding,
+    leaveTeamBinding,
+    statusTeamBindings,
+    type TeamRepositoryContext,
+} from "./team-bindings-commands.ts";
+
+const dir = `/tmp/ax-team-bindings-commands-test-${process.pid}`;
+const path = `${dir}/team-bindings.json`;
+
+afterEach(async () => {
+    await Bun.$`rm -rf ${dir}`.quiet().nothrow();
+});
+
+const repo = (remote: string, root: string): TeamRepositoryContext => {
+    const identity = chooseIdentity({
+        remoteUrlNormalized: remote,
+        initialCommit: "initial",
+        checkoutRoot: root,
+    });
+    return {
+        repoKey: identity.repositoryKey,
+        name: remote.split("/").at(-1) ?? remote,
+        repoRoot: root,
+        remoteUrlNormalized: remote,
+    };
+};
+
+describe("team binding command handlers", () => {
+    test("status reports default-deny when nothing is bound", async () => {
+        const lines: string[] = [];
+
+        await statusTeamBindings({
+            statePath: path,
+            currentRepo: null,
+            write: (line) => lines.push(line),
+        });
+
+        expect(lines.join("\n")).toMatch(/no repos bound|default-deny/i);
+        expect(await loadTeamBindings(path)).toEqual({ v: 1, bindings: {} });
+    });
+
+    test("join shows exact consent details and writes the real state file", async () => {
+        const current = repo("github.com/acme/client", "/work/client");
+        const lines: string[] = [];
+
+        const outcome = await joinTeamBinding({
+            org: "acme",
+            currentRepo: current,
+            statePath: path,
+            confirmed: true,
+            now: "2026-07-16T03:00:00.000Z",
+            write: (line) => lines.push(line),
+        });
+
+        expect(outcome).toBe("joined");
+        const output = lines.join("\n");
+        expect(output).toContain(current.repoKey);
+        expect(output).toContain("github.com/acme/client");
+        expect(output).toContain("acme");
+        expect(output).toContain("share: anon");
+        expect(output).toMatch(/aggregate|skills|models/i);
+        expect(output).toMatch(/no transcripts|no code/i);
+        expect((await loadTeamBindings(path)).bindings[current.repoKey]).toEqual({
+            org: "acme",
+            share: "anon",
+            joined_at: "2026-07-16T03:00:00.000Z",
+        });
+    });
+
+    test("join aborts without consent and leaves no binding", async () => {
+        const current = repo("github.com/acme/client", "/work/client");
+
+        expect(
+            await joinTeamBinding({
+                org: "acme",
+                currentRepo: current,
+                statePath: path,
+                confirmed: false,
+                now: "2026-07-16T03:00:00.000Z",
+                write: () => undefined,
+            }),
+        ).toBe("aborted");
+        expect((await loadTeamBindings(path)).bindings).toEqual({});
+    });
+
+    test("status lists independent orgs and marks the current repo", async () => {
+        const one = repo("github.com/acme/one", "/work/one");
+        const two = repo("github.com/other/two", "/work/two");
+        await joinTeamBinding({
+            org: "acme",
+            currentRepo: one,
+            statePath: path,
+            confirmed: true,
+            now: "2026-07-16T01:00:00.000Z",
+            write: () => undefined,
+        });
+        await joinTeamBinding({
+            org: "other",
+            currentRepo: two,
+            statePath: path,
+            confirmed: true,
+            now: "2026-07-16T02:00:00.000Z",
+            write: () => undefined,
+        });
+        const lines: string[] = [];
+
+        await statusTeamBindings({
+            statePath: path,
+            currentRepo: two,
+            write: (line) => lines.push(line),
+        });
+
+        const output = lines.join("\n");
+        expect(output).toContain(`${one.repoKey} → acme`);
+        expect(output).toContain(`${two.repoKey} → other`);
+        expect(output).toMatch(new RegExp(`\\* .*${two.repoKey}`));
+    });
+
+    test("leave removes only the current repo and is a no-op when already unbound", async () => {
+        const one = repo("github.com/acme/one", "/work/one");
+        const two = repo("github.com/other/two", "/work/two");
+        await joinTeamBinding({
+            org: "acme",
+            currentRepo: one,
+            statePath: path,
+            confirmed: true,
+            now: "2026-07-16T01:00:00.000Z",
+            write: () => undefined,
+        });
+        await joinTeamBinding({
+            org: "other",
+            currentRepo: two,
+            statePath: path,
+            confirmed: true,
+            now: "2026-07-16T02:00:00.000Z",
+            write: () => undefined,
+        });
+
+        expect(
+            await leaveTeamBinding({
+                currentRepo: one,
+                statePath: path,
+                write: () => undefined,
+            }),
+        ).toBe("left");
+        const state = await loadTeamBindings(path);
+        expect(state.bindings[one.repoKey]).toBeUndefined();
+        expect(state.bindings[two.repoKey]?.org).toBe("other");
+
+        const lines: string[] = [];
+        expect(
+            await leaveTeamBinding({
+                currentRepo: one,
+                statePath: path,
+                write: (line) => lines.push(line),
+            }),
+        ).toBe("unbound");
+        expect(lines.join("\n")).toMatch(/not bound|nothing to do/i);
+    });
+});

--- a/apps/axctl/src/team/team-bindings-commands.ts
+++ b/apps/axctl/src/team/team-bindings-commands.ts
@@ -1,0 +1,136 @@
+import type { PwdResolution } from "../pwd.ts";
+import {
+    DEFAULT_TEAM_SHARE,
+    bindingFor,
+    loadTeamBindings,
+    removeTeamBinding,
+    upsertTeamBinding,
+    type TeamShare,
+} from "./team-bindings-state.ts";
+
+export interface TeamRepositoryContext {
+    readonly repoKey: string;
+    readonly name: string;
+    readonly repoRoot: string;
+    readonly remoteUrlNormalized: string | null;
+}
+
+export const teamRepositoryContext = (
+    resolution: PwdResolution,
+): TeamRepositoryContext => ({
+    repoKey: resolution.identity.repositoryKey,
+    name:
+        resolution.remoteUrlNormalized?.split("/").at(-1) ??
+        resolution.repoRoot.split("/").filter(Boolean).at(-1) ??
+        resolution.repoRoot,
+    repoRoot: resolution.repoRoot,
+    remoteUrlNormalized: resolution.remoteUrlNormalized,
+});
+
+type WriteLine = (line: string) => void;
+
+const repoDisplay = (repo: TeamRepositoryContext): string =>
+    repo.remoteUrlNormalized ?? repo.repoRoot;
+
+const consentLines = (
+    repo: TeamRepositoryContext,
+    org: string,
+    share: TeamShare,
+): ReadonlyArray<string> => [
+    "[ax team join] repo-scoped sharing consent",
+    `repo: ${repoDisplay(repo)}`,
+    `repo_key: ${repo.repoKey}`,
+    `org: ${org}`,
+    `share: ${share}`,
+    "fields shared on a later `ax team push`: aggregate skill/hook usage, model mix, cost, verification, tool-failure, and workflow metrics for this repo only.",
+    "never shared: no transcripts, no prompts/responses, no code or file contents, no paths, flag values, or positional arguments.",
+    share === "anon"
+        ? "identity: anonymous aggregate contribution; GitHub login is stripped."
+        : "identity: named contribution; GitHub login may be included.",
+];
+
+export interface JoinTeamBindingInput {
+    readonly org: string;
+    readonly currentRepo: TeamRepositoryContext;
+    readonly statePath: string;
+    readonly share?: TeamShare;
+    readonly confirmed?: boolean;
+    readonly confirm?: () => boolean | Promise<boolean>;
+    readonly now?: string;
+    readonly write: WriteLine;
+}
+
+export async function joinTeamBinding(
+    input: JoinTeamBindingInput,
+): Promise<"joined" | "aborted"> {
+    const share = input.share ?? DEFAULT_TEAM_SHARE;
+    for (const line of consentLines(input.currentRepo, input.org, share)) input.write(line);
+    const confirmed = input.confirmed ?? (await input.confirm?.()) ?? false;
+    if (!confirmed) {
+        input.write("Aborted. Nothing was bound.");
+        return "aborted";
+    }
+
+    await upsertTeamBinding(input.statePath, input.currentRepo.repoKey, {
+        org: input.org,
+        share,
+        joined_at: input.now ?? new Date().toISOString(),
+    });
+    input.write(
+        `[ax team join] bound ${input.currentRepo.name} (${input.currentRepo.repoKey}) → ${input.org} (${share})`,
+    );
+    return "joined";
+}
+
+export interface StatusTeamBindingsInput {
+    readonly statePath: string;
+    readonly currentRepo: TeamRepositoryContext | null;
+    readonly write: WriteLine;
+}
+
+export async function statusTeamBindings(input: StatusTeamBindingsInput): Promise<void> {
+    const state = await loadTeamBindings(input.statePath);
+    const entries = Object.entries(state.bindings).sort(([left], [right]) =>
+        left.localeCompare(right),
+    );
+    if (entries.length === 0) {
+        input.write("[ax team status] no repos bound (default-deny; nothing will push).");
+        return;
+    }
+
+    input.write(`[ax team status] ${entries.length} bound repo(s):`);
+    for (const [repoKey, binding] of entries) {
+        const current = input.currentRepo?.repoKey === repoKey;
+        const name = current ? `${input.currentRepo.name} / ` : "";
+        input.write(
+            `${current ? "*" : " "} ${name}${repoKey} → ${binding.org}  share=${binding.share}`,
+        );
+    }
+    if (input.currentRepo !== null && bindingFor(state, input.currentRepo.repoKey) === undefined) {
+        input.write(
+            `current repo ${input.currentRepo.name} is unbound (default-deny; nothing will push).`,
+        );
+    }
+}
+
+export interface LeaveTeamBindingInput {
+    readonly currentRepo: TeamRepositoryContext;
+    readonly statePath: string;
+    readonly write: WriteLine;
+}
+
+export async function leaveTeamBinding(
+    input: LeaveTeamBindingInput,
+): Promise<"left" | "unbound"> {
+    const removed = await removeTeamBinding(input.statePath, input.currentRepo.repoKey);
+    if (!removed) {
+        input.write(
+            `[ax team leave] ${input.currentRepo.name} is not bound; nothing to do.`,
+        );
+        return "unbound";
+    }
+    input.write(
+        `[ax team leave] unbound ${input.currentRepo.name} (${input.currentRepo.repoKey}).`,
+    );
+    return "left";
+}

--- a/apps/axctl/src/team/team-bindings-state.test.ts
+++ b/apps/axctl/src/team/team-bindings-state.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chooseIdentity } from "../ingest/repository-identity.ts";
+import {
+    bindingFor,
+    loadTeamBindings,
+    removeTeamBinding,
+    upsertTeamBinding,
+} from "./team-bindings-state.ts";
+
+const dir = `/tmp/ax-team-bindings-state-test-${process.pid}`;
+const path = `${dir}/team-bindings.json`;
+
+afterEach(async () => {
+    await Bun.$`rm -rf ${dir}`.quiet().nothrow();
+});
+
+describe("team bindings state", () => {
+    test("missing file is default-deny", async () => {
+        const state = await loadTeamBindings(path);
+
+        expect(state).toEqual({ v: 1, bindings: {} });
+        expect(bindingFor(state, "repository-key")).toBeUndefined();
+    });
+
+    test("join upserts, re-join updates, and leave removes", async () => {
+        await upsertTeamBinding(path, "repo-client", {
+            org: "acme",
+            share: "anon",
+            joined_at: "2026-07-16T01:00:00.000Z",
+        });
+        expect(bindingFor(await loadTeamBindings(path), "repo-client")).toEqual({
+            org: "acme",
+            share: "anon",
+            joined_at: "2026-07-16T01:00:00.000Z",
+        });
+
+        await upsertTeamBinding(path, "repo-client", {
+            org: "acme-labs",
+            share: "full",
+            joined_at: "2026-07-16T02:00:00.000Z",
+        });
+        expect(bindingFor(await loadTeamBindings(path), "repo-client")).toEqual({
+            org: "acme-labs",
+            share: "full",
+            joined_at: "2026-07-16T02:00:00.000Z",
+        });
+
+        expect(await removeTeamBinding(path, "repo-client")).toBe(true);
+        expect(bindingFor(await loadTeamBindings(path), "repo-client")).toBeUndefined();
+    });
+
+    test("fork and rename identities remain separate bindings", async () => {
+        const client = chooseIdentity({
+            remoteUrlNormalized: "github.com/acme/client",
+            initialCommit: "same-root",
+            checkoutRoot: "/work/client",
+        });
+        const personalFork = chooseIdentity({
+            remoteUrlNormalized: "github.com/alice/client-fork",
+            initialCommit: "same-root",
+            checkoutRoot: "/work/client-fork",
+        });
+
+        expect(client.repositoryKey).not.toBe(personalFork.repositoryKey);
+
+        await upsertTeamBinding(path, client.repositoryKey, {
+            org: "acme",
+            share: "anon",
+            joined_at: "2026-07-16T01:00:00.000Z",
+        });
+        await upsertTeamBinding(path, personalFork.repositoryKey, {
+            org: "alice",
+            share: "full",
+            joined_at: "2026-07-16T02:00:00.000Z",
+        });
+
+        const state = await loadTeamBindings(path);
+        expect(bindingFor(state, client.repositoryKey)?.org).toBe("acme");
+        expect(bindingFor(state, personalFork.repositoryKey)?.org).toBe("alice");
+    });
+
+    test("multiple repos can bind to different orgs", async () => {
+        await upsertTeamBinding(path, "repo-one", {
+            org: "org-one",
+            share: "anon",
+            joined_at: "2026-07-16T01:00:00.000Z",
+        });
+        await upsertTeamBinding(path, "repo-two", {
+            org: "org-two",
+            share: "anon",
+            joined_at: "2026-07-16T02:00:00.000Z",
+        });
+
+        const state = await loadTeamBindings(path);
+        expect(bindingFor(state, "repo-one")?.org).toBe("org-one");
+        expect(bindingFor(state, "repo-two")?.org).toBe("org-two");
+    });
+});

--- a/apps/axctl/src/team/team-bindings-state.ts
+++ b/apps/axctl/src/team/team-bindings-state.ts
@@ -1,0 +1,117 @@
+/**
+ * Private, machine-local opt-in state for team dashboard sharing.
+ *
+ * Missing or invalid state is always treated as empty (default-deny). The file
+ * contains no repo data itself, only the fail-closed repository key and the
+ * user's sharing choice.
+ */
+import { atomicWriteJson } from "../profile/fs.ts";
+
+export const TEAM_SHARE_VALUES = ["anon", "full"] as const;
+export type TeamShare = (typeof TEAM_SHARE_VALUES)[number];
+export const DEFAULT_TEAM_SHARE: TeamShare = "anon";
+
+export interface TeamBinding {
+    readonly org: string;
+    readonly share: TeamShare;
+    readonly joined_at: string;
+}
+
+export interface TeamBindings {
+    readonly v: 1;
+    readonly bindings: Readonly<Record<string, TeamBinding>>;
+}
+
+export const emptyTeamBindings = (): TeamBindings => ({ v: 1, bindings: {} });
+
+export const defaultTeamBindingsPath = (): string =>
+    `${process.env.HOME}/.ax/team-bindings.json`;
+
+const isTeamShare = (value: unknown): value is TeamShare =>
+    value === "anon" || value === "full";
+
+const decodeBinding = (value: unknown): TeamBinding | null => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+    const record = value as Record<string, unknown>;
+    if (
+        typeof record.org !== "string" ||
+        record.org.trim().length === 0 ||
+        !isTeamShare(record.share) ||
+        typeof record.joined_at !== "string" ||
+        record.joined_at.length === 0
+    ) {
+        return null;
+    }
+    return {
+        org: record.org,
+        share: record.share,
+        joined_at: record.joined_at,
+    };
+};
+
+const decodeTeamBindings = (value: unknown): TeamBindings | null => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+    const record = value as Record<string, unknown>;
+    if (
+        record.v !== 1 ||
+        typeof record.bindings !== "object" ||
+        record.bindings === null ||
+        Array.isArray(record.bindings)
+    ) {
+        return null;
+    }
+
+    const bindings: Record<string, TeamBinding> = {};
+    for (const [repoKey, rawBinding] of Object.entries(record.bindings)) {
+        if (repoKey.length === 0) return null;
+        const binding = decodeBinding(rawBinding);
+        if (binding === null) return null;
+        bindings[repoKey] = binding;
+    }
+    return { v: 1, bindings };
+};
+
+export async function loadTeamBindings(path: string): Promise<TeamBindings> {
+    try {
+        const file = Bun.file(path);
+        if (!(await file.exists())) return emptyTeamBindings();
+        return decodeTeamBindings(JSON.parse(await file.text())) ?? emptyTeamBindings();
+    } catch {
+        return emptyTeamBindings();
+    }
+}
+
+export async function saveTeamBindings(path: string, state: TeamBindings): Promise<void> {
+    await atomicWriteJson(path, state);
+}
+
+export const bindingFor = (
+    state: TeamBindings,
+    repoKey: string,
+): TeamBinding | undefined => state.bindings[repoKey];
+
+export async function upsertTeamBinding(
+    path: string,
+    repoKey: string,
+    binding: TeamBinding,
+): Promise<TeamBindings> {
+    const current = await loadTeamBindings(path);
+    const next: TeamBindings = {
+        v: 1,
+        bindings: {
+            ...current.bindings,
+            [repoKey]: binding,
+        },
+    };
+    await saveTeamBindings(path, next);
+    return next;
+}
+
+export async function removeTeamBinding(path: string, repoKey: string): Promise<boolean> {
+    const current = await loadTeamBindings(path);
+    if (bindingFor(current, repoKey) === undefined) return false;
+    const bindings = { ...current.bindings };
+    delete bindings[repoKey];
+    await saveTeamBindings(path, { v: 1, bindings });
+    return true;
+}


### PR DESCRIPTION
team-dashboard Slice 1 foundation: per-repo opt-in for team telemetry. Adds a machine-local `~/.ax/team-bindings.json` store (repo_key → {org, share}, cloned from the profile publish-state pattern) and `ax team join <org>` / `status` / `leave`, nested as subcommands in the EXISTING `teamCommand` group (alongside the shipped sync/trust/experiment). Default-deny: a fresh machine binds nothing; unbound repos never push. Repo identity is fail-closed via chooseIdentity so a fork/rename can't collide.

Part of #728 (Slice 1). Design: docs/superpowers/plans/2026-07-01-team-dashboard-git-native-goal-package.md §4/§5. Decision: dedicated <org>/ax-team repo, explicit push.

Gates: typecheck 0, bindings + commands + existing team.test 16/16, check:no-node-fs 0.

Generated with ax — https://github.com/Necmttn/ax