### PR TITLE
feat(team): ax team push — idempotent snapshot upsert into <org>/ax-team (Slice 1)

### DIFF
--- a/apps/axctl/src/cli/commands/team.test.ts
+++ b/apps/axctl/src/cli/commands/team.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { renderSyncReport, renderTrustReport, renderExperimentList } from "./team.ts";
+import {
+  renderSyncReport,
+  renderTrustReport,
+  renderExperimentList,
+  teamRuntime,
+} from "./team.ts";
+import { resolveRuntime } from "./manifest.ts";
 
 describe("renderSyncReport", () => {
   it("summarizes activated, unchanged, and gated", () => {
@@ -36,4 +42,10 @@ describe("renderExperimentList", () => {
     expect(out).toMatch(/shadow|overrides|committed/i);
   });
   it("empty-state", () => { expect(renderExperimentList([])).toContain("no experiments"); });
+});
+
+describe("team command routing", () => {
+  it("routes team push through the database runtime", () => {
+    expect(resolveRuntime(teamRuntime.team!, ["team", "push"])).toBe("db");
+  });
 });

--- a/apps/axctl/src/cli/commands/team.ts
+++ b/apps/axctl/src/cli/commands/team.ts
@@ -11,6 +11,10 @@
  *     Review + install the team's executable `.ax/hooks/*` (sha256 trust-on-change,
  *     default-branch-only). `--yes` approves installation. `--allow-branch`
  *     bypasses the default-branch guard.
+ *
+ *   ax team push
+ *     Push the current bound Repository's redacted 30-day TeamProfileV1 to
+ *     its organization's private `<org>/ax-team` repository.
  */
 import { Effect } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
@@ -49,6 +53,13 @@ import {
     TEAM_SHARE_VALUES,
     defaultTeamBindingsPath,
 } from "../../team/team-bindings-state.ts";
+import {
+    pushCurrentTeamProfile,
+    type TeamRepoUnboundError,
+    type TeamPushIdentityError,
+} from "../../team/team-push.ts";
+import { defaultPublishStatePath } from "../../profile/publish-state.ts";
+import type { GitHubApiError } from "../../profile/github-env.ts";
 import { HookProviderRegistryDefault } from "../../hooks/providers/registry.ts";
 import { resolvePwdRepository } from "../../pwd.ts";
 import type { RuntimeManifest } from "./manifest.ts";
@@ -565,10 +576,10 @@ const experimentCommand = Command.make("experiment").pipe(
 );
 
 // ---------------------------------------------------------------------------
-// ax team join/status/leave
+// ax team join/status/leave/push
 // ---------------------------------------------------------------------------
 
-const resolveCurrentTeamRepo = (command: "join" | "leave") =>
+const resolveCurrentTeamRepo = (command: "join" | "leave" | "push") =>
     resolvePwdRepository().pipe(
         Effect.map(teamRepositoryContext),
         Effect.catchTag("NotAGitRepoError", (error) =>
@@ -662,6 +673,51 @@ export const leaveCommand = Command.make("leave", {}, () =>
     }),
 ).pipe(Command.withDescription("Unbind the current git repo from its team org."));
 
+export const pushCommand = Command.make("push", {}, () =>
+    Effect.gen(function* () {
+        const currentRepo = yield* resolveCurrentTeamRepo("push");
+        if (currentRepo === null) return;
+        const result = yield* pushCurrentTeamProfile({
+            repoKey: currentRepo.repoKey,
+            bindingsPath: defaultTeamBindingsPath(),
+            publishStatePath: defaultPublishStatePath(),
+            windowDays: 30,
+            generatedAt: new Date().toISOString(),
+        }).pipe(
+            Effect.catchTags({
+                TeamRepoUnboundError: (error: TeamRepoUnboundError) =>
+                    Effect.sync(() => {
+                        console.error(`[ax team push] ${error.message}`);
+                        return null;
+                    }),
+                TeamPushIdentityError: (error: TeamPushIdentityError) =>
+                    Effect.sync(() => {
+                        console.error(`[ax team push] ${error.message}`);
+                        return null;
+                    }),
+                GitHubApiError: (error: GitHubApiError) =>
+                    Effect.sync(() => {
+                        console.error(`[ax team push] GitHub API failed: ${error.message}`);
+                        return null;
+                    }),
+            }),
+        );
+        if (result === null) return;
+        console.log(
+            `[ax team push] pushed ${result.repoKey} → ${result.org}/ax-team/${result.file}`,
+        );
+        if (result.anonymous) {
+            console.log(
+                "[ax team push] anonymous sharing confirmed: no GitHub login was sent in the filename or snapshot.",
+            );
+        }
+    }),
+).pipe(
+    Command.withDescription(
+        "Push the current bound repository's redacted 30-day snapshot to <org>/ax-team.",
+    ),
+);
+
 // ---------------------------------------------------------------------------
 // ax team (group)
 // ---------------------------------------------------------------------------
@@ -674,6 +730,7 @@ export const teamCommand = Command.make("team").pipe(
         joinCommand,
         statusCommand,
         leaveCommand,
+        pushCommand,
         syncCommand,
         trustCommand,
         experimentCommand,
@@ -692,6 +749,7 @@ export const teamRuntime: RuntimeManifest = {
                 join: "db",
                 status: "db",
                 leave: "db",
+                push: "db",
             },
         },
         hidden: false,

--- a/apps/axctl/src/team/team-push.test.ts
+++ b/apps/axctl/src/team/team-push.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { makeMockDb } from "@ax/lib/testing/surreal";
+import { Effect, Layer } from "effect";
+import { GitHubEnvTest } from "../profile/github-env.ts";
+import { savePublishState } from "../profile/publish-state.ts";
+import { upsertTeamBinding } from "./team-bindings-state.ts";
+import { pushCurrentTeamProfile } from "./team-push.ts";
+
+const dir = `/tmp/ax-team-push-test-${process.pid}`;
+const bindingsPath = `${dir}/team-bindings.json`;
+const publishStatePath = `${dir}/profile-publish.json`;
+
+afterEach(async () => {
+    await Bun.$`rm -rf ${dir}`.quiet().nothrow();
+});
+
+describe("pushCurrentTeamProfile", () => {
+    test("refuses an unbound repository without sending anything to GitHub", async () => {
+        const github = GitHubEnvTest({ responses: {}, login: "alice" });
+        const db = makeMockDb(new Map());
+
+        const outcome = await Effect.runPromise(
+            pushCurrentTeamProfile({
+                repoKey: "repo-unbound",
+                bindingsPath,
+                publishStatePath,
+                windowDays: 30,
+                generatedAt: "2026-07-16T00:00:00Z",
+            }).pipe(
+                Effect.match({
+                    onSuccess: (value) => ({ ok: true as const, value }),
+                    onFailure: (error) => ({ ok: false as const, error }),
+                }),
+                Effect.provide(Layer.merge(github.layer, db.layer)),
+            ),
+        );
+
+        expect(outcome.ok).toBe(false);
+        if (!outcome.ok) {
+            expect(outcome.error._tag).toBe("TeamRepoUnboundError");
+            expect(outcome.error.message).toMatch(/unbound|not bound|refus/i);
+        }
+        expect(github.calls).toEqual([]);
+        expect(db.captured).toEqual([]);
+    });
+
+    test("creates without a sha, then updates with the current contents sha", async () => {
+        const repoKey = "repo-acme";
+        await upsertTeamBinding(bindingsPath, repoKey, {
+            org: "acme",
+            share: "full",
+            joined_at: "2026-07-16T00:00:00Z",
+        });
+        const path = "/repos/acme/ax-team/contents/.ax-team/alice.json";
+        const db = makeMockDb(new Map());
+        const first = GitHubEnvTest({
+            responses: {
+                [`PUT ${path}`]: { content: { sha: "created-sha" } },
+            },
+            login: "Alice",
+        });
+
+        const firstResult = await Effect.runPromise(
+            pushCurrentTeamProfile({
+                repoKey,
+                bindingsPath,
+                publishStatePath,
+                windowDays: 30,
+                generatedAt: "2026-07-16T00:00:00Z",
+            }).pipe(Effect.provide(Layer.merge(first.layer, db.layer))),
+        );
+
+        expect(firstResult.file).toBe(".ax-team/alice.json");
+        expect(first.calls.map(({ method, path: callPath }) => `${method} ${callPath}`)).toEqual([
+            `GET ${path}`,
+            `PUT ${path}`,
+        ]);
+        const firstBody = first.calls[1]?.body as Record<string, unknown>;
+        expect(firstBody).not.toHaveProperty("sha");
+        const firstProfile = JSON.parse(
+            Buffer.from(String(firstBody.content), "base64").toString("utf8"),
+        ) as Record<string, unknown>;
+        expect(firstProfile.login).toBe("Alice");
+        expect(firstProfile.repo_key).toBe(repoKey);
+
+        const second = GitHubEnvTest({
+            responses: {
+                [`GET ${path}`]: { sha: "current-sha" },
+                [`PUT ${path}`]: { content: { sha: "updated-sha" } },
+            },
+            login: "Alice",
+        });
+        await Effect.runPromise(
+            pushCurrentTeamProfile({
+                repoKey,
+                bindingsPath,
+                publishStatePath,
+                windowDays: 30,
+                generatedAt: "2026-07-16T00:00:00Z",
+            }).pipe(Effect.provide(Layer.merge(second.layer, db.layer))),
+        );
+
+        expect(second.calls.map(({ method, path: callPath }) => `${method} ${callPath}`)).toEqual([
+            `GET ${path}`,
+            `PUT ${path}`,
+        ]);
+        expect(second.calls[1]?.body).toMatchObject({ sha: "current-sha" });
+    });
+
+    test("anonymous sharing uses a pseudonymous filename and strips identity and cost", async () => {
+        const repoKey = "repo-private";
+        await upsertTeamBinding(bindingsPath, repoKey, {
+            org: "secret-org",
+            share: "anon",
+            joined_at: "2026-07-16T00:00:00Z",
+        });
+        await savePublishState(publishStatePath, {
+            v: 1,
+            gist_id: "profile-gist",
+            owner: "Alice",
+            consented_at: "2026-07-16T00:00:00Z",
+            published_at: "2026-07-16T00:00:00Z",
+            no_cost: true,
+        });
+        const anonymousPath =
+            "/repos/secret-org/ax-team/contents/.ax-team/anon-a82d4c1d6bcd84fd0bfc8cbf.json";
+        const github = GitHubEnvTest({
+            responses: {
+                [`PUT ${anonymousPath}`]: { content: { sha: "created-sha" } },
+            },
+            login: "Alice",
+        });
+        const db = makeMockDb(new Map());
+
+        const result = await Effect.runPromise(
+            pushCurrentTeamProfile({
+                repoKey,
+                bindingsPath,
+                publishStatePath,
+                windowDays: 30,
+                generatedAt: "2026-07-16T00:00:00Z",
+            }).pipe(Effect.provide(Layer.merge(github.layer, db.layer))),
+        );
+
+        expect(result.anonymous).toBe(true);
+        expect(result.file).toMatch(/^\.ax-team\/anon-[a-f0-9]{24}\.json$/);
+        expect(result.file.toLowerCase()).not.toContain("alice");
+        const put = github.calls.find((call) => call.method === "PUT");
+        const body = put?.body as Record<string, unknown>;
+        const profile = JSON.parse(
+            Buffer.from(String(body.content), "base64").toString("utf8"),
+        ) as {
+            login: string | null;
+            spend: { cost_usd: number | null; model_mix: Array<Record<string, unknown>> };
+        };
+        expect(profile.login).toBeNull();
+        expect(profile.spend.cost_usd).toBeNull();
+        expect(profile.spend.model_mix.every((model) => !("cost_usd" in model))).toBe(true);
+        expect(JSON.stringify({ calls: github.calls, profile }).toLowerCase()).not.toContain("alice");
+    });
+
+    test("each bound repository pushes only to its own organization", async () => {
+        await upsertTeamBinding(bindingsPath, "repo-one", {
+            org: "org-one",
+            share: "full",
+            joined_at: "2026-07-16T00:00:00Z",
+        });
+        await upsertTeamBinding(bindingsPath, "repo-two", {
+            org: "org-two",
+            share: "full",
+            joined_at: "2026-07-16T00:00:00Z",
+        });
+        const onePath = "/repos/org-one/ax-team/contents/.ax-team/alice.json";
+        const twoPath = "/repos/org-two/ax-team/contents/.ax-team/alice.json";
+        const github = GitHubEnvTest({
+            responses: {
+                [`PUT ${onePath}`]: {},
+                [`PUT ${twoPath}`]: {},
+            },
+            login: "alice",
+        });
+        const db = makeMockDb(new Map());
+        const layer = Layer.merge(github.layer, db.layer);
+
+        await Effect.runPromise(
+            pushCurrentTeamProfile({
+                repoKey: "repo-one",
+                bindingsPath,
+                publishStatePath,
+                windowDays: 30,
+                generatedAt: "2026-07-16T00:00:00Z",
+            }).pipe(Effect.provide(layer)),
+        );
+        await Effect.runPromise(
+            pushCurrentTeamProfile({
+                repoKey: "repo-two",
+                bindingsPath,
+                publishStatePath,
+                windowDays: 30,
+                generatedAt: "2026-07-16T00:00:00Z",
+            }).pipe(Effect.provide(layer)),
+        );
+
+        expect(github.calls.map(({ method, path }) => `${method} ${path}`)).toEqual([
+            `GET ${onePath}`,
+            `PUT ${onePath}`,
+            `GET ${twoPath}`,
+            `PUT ${twoPath}`,
+        ]);
+        const profiles = github.calls
+            .filter((call) => call.method === "PUT")
+            .map((call) => JSON.parse(
+                Buffer.from(
+                    String((call.body as Record<string, unknown>).content),
+                    "base64",
+                ).toString("utf8"),
+            ) as { org: string; repo_key: string });
+        expect(profiles.map(({ org, repo_key }) => ({ org, repo_key }))).toEqual([
+            { org: "org-one", repo_key: "repo-one" },
+            { org: "org-two", repo_key: "repo-two" },
+        ]);
+    });
+});

--- a/apps/axctl/src/team/team-push.ts
+++ b/apps/axctl/src/team/team-push.ts
@@ -1,0 +1,115 @@
+/**
+ * Push one explicitly bound Repository's redacted TeamProfileV1 through the
+ * GitHub contents API. Anonymous filenames are org-scoped pseudonyms so the
+ * real login is absent from both the path and snapshot.
+ */
+import { Effect, Schema } from "effect";
+import { GitHubApiError, GitHubEnv } from "../profile/github-env.ts";
+import { loadPublishState } from "../profile/publish-state.ts";
+import { sha256Hex } from "./exec-hash.ts";
+import { bindingFor, loadTeamBindings } from "./team-bindings-state.ts";
+import { buildTeamProfile } from "./team-profile.ts";
+
+export class TeamRepoUnboundError extends Schema.TaggedErrorClass<TeamRepoUnboundError>(
+    "TeamRepoUnboundError",
+)("TeamRepoUnboundError", {
+    repoKey: Schema.String,
+    message: Schema.String,
+}) {}
+
+export class TeamPushIdentityError extends Schema.TaggedErrorClass<TeamPushIdentityError>(
+    "TeamPushIdentityError",
+)("TeamPushIdentityError", {
+    message: Schema.String,
+}) {}
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+    typeof value === "object" && value !== null
+        ? value as Record<string, unknown>
+        : {};
+
+const snapshotFilename = (input: {
+    readonly login: string;
+    readonly org: string;
+    readonly anonymous: boolean;
+}): string =>
+    input.anonymous
+        ? `anon-${sha256Hex(`${input.org.toLowerCase()}\0${input.login.toLowerCase()}`).slice(0, 24)}.json`
+        : `${input.login.toLowerCase()}.json`;
+
+export const pushCurrentTeamProfile = Effect.fn("team.pushCurrentTeamProfile")(
+    function* (input: {
+        readonly repoKey: string;
+        readonly bindingsPath: string;
+        readonly publishStatePath: string;
+        readonly windowDays: number;
+        readonly generatedAt: string;
+    }) {
+        const bindings = yield* Effect.promise(() => loadTeamBindings(input.bindingsPath));
+        const binding = bindingFor(bindings, input.repoKey);
+        if (binding === undefined) {
+            return yield* new TeamRepoUnboundError({
+                repoKey: input.repoKey,
+                message: `Repository ${input.repoKey} is unbound; refusing to push.`,
+            });
+        }
+
+        const github = yield* GitHubEnv;
+        const login = yield* github.login();
+        if (login === null || login.trim().length === 0) {
+            return yield* new TeamPushIdentityError({
+                message: "GitHub identity is unavailable; run `gh auth login` before `ax team push`.",
+            });
+        }
+
+        const anonymous = binding.share === "anon";
+        const filename = snapshotFilename({
+            login,
+            org: binding.org,
+            anonymous,
+        });
+        const file = `.ax-team/${filename}`;
+        const apiPath = `/repos/${binding.org}/ax-team/contents/${file}`;
+        const publishState = yield* Effect.promise(() =>
+            loadPublishState(input.publishStatePath),
+        );
+        const profile = yield* buildTeamProfile({
+            org: binding.org,
+            repoKey: input.repoKey,
+            windowDays: input.windowDays,
+            // Bindings call named sharing "full"; TeamProfileV1 calls it "public".
+            share: anonymous ? "anon" : "public",
+            includeCost: !(publishState?.no_cost ?? false),
+            env: {
+                login,
+                generatedAt: input.generatedAt,
+            },
+        });
+        const currentSha = yield* github.api("GET", apiPath).pipe(
+            Effect.map((response) => {
+                const sha = asRecord(response).sha;
+                return typeof sha === "string" && sha.length > 0 ? sha : undefined;
+            }),
+            Effect.catchTag("GitHubApiError", (error: GitHubApiError) =>
+                error.status === 404
+                    ? Effect.succeed(undefined)
+                    : Effect.fail(error),
+            ),
+        );
+        yield* github.api("PUT", apiPath, {
+            message: `team: update ${filename}`,
+            content: Buffer.from(
+                `${JSON.stringify(profile, null, 2)}\n`,
+                "utf8",
+            ).toString("base64"),
+            ...(currentSha === undefined ? {} : { sha: currentSha }),
+        });
+
+        return {
+            org: binding.org,
+            repoKey: input.repoKey,
+            file,
+            anonymous,
+        };
+    },
+);


### PR DESCRIPTION
Completes team-dashboard Slice 1. `ax team push` (nested in the existing teamCommand) builds each BOUND repo's redacted TeamProfileV1 snapshot and upserts it to that org's private <org>/ax-team repo as .ax-team/<login>.json via the re-pointed GitHubEnv contents API: GET the current sha (404 = new) → PUT with base64 content + sha. Idempotent, default-deny (refuses unbound repos with TeamRepoUnboundError, sending nothing).

With #729 (bindings + join/status/leave) and #731 (TeamProfileV1 builder), Slice 1 works end-to-end: `ax team join <org>` → `ax team push`.

Part of #728 (Slice 1, final chunk). Decision: dedicated <org>/ax-team repo, explicit push.

Gates: typecheck 0, team-push + team.test 12/12 (idempotent GET-sha→PUT-with-sha asserted via GitHubEnvTest call recording; unbound refused), check:no-node-fs 0.

Generated with ax — https://github.com/Necmttn/ax