### PR TITLE
feat(team): render-safe TeamProfileV1 validator in @ax/lib/shared (Slice 2)

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -10,6 +10,7 @@
     "./shared/fs-classify": "./src/shared/fs-classify.ts",
     "./shared/ingest-staleness": "./src/shared/ingest-staleness.ts",
     "./shared/path": "./src/shared/path.ts",
+    "./shared/team-community": "./src/shared/team-community.ts",
     "./testing/test-filesystem": "./src/testing/test-filesystem.ts",
     "./testing/surreal": "./src/testing/surreal.ts",
     "./*": {

--- a/packages/lib/src/shared/team-community.test.ts
+++ b/packages/lib/src/shared/team-community.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { type TeamProfileV1, validateTeamProfile } from "./team-community";
+
+const valid = {
+    v: 1,
+    login: "necmttn",
+    org: "acme",
+    repo_key: "remote__github_com_acme_widgets__abc123",
+    window_days: 30,
+    generated_at: "2026-07-16T00:00:00Z",
+    stats: { sessions: 12, active_days: 5, harnesses: ["claude", "codex"] },
+    activity: { daily: [{ date: "2026-07-15", sessions: 3, tokens: 120_000 }] },
+    skills: [{ skill: "tdd", runs: 8, sessions: 4 }],
+    spend: {
+        tokens: { prompt: 1_000, completion: 200, total: 1_200 },
+        cost_usd: 4.2,
+        model_mix: [{ model: "fable", share: 1, tokens: 1_200, cost_usd: 4.2 }],
+    },
+    efficiency: { tool_calls: 300, tool_failures: 12, verification_calls: 40 },
+} satisfies TeamProfileV1;
+
+describe("validateTeamProfile", () => {
+    test("round-trips a well-formed TeamProfileV1 snapshot", () => {
+        expect(validateTeamProfile(valid)).toEqual(valid);
+    });
+
+    test("accepts an anonymous no-cost snapshot", () => {
+        const anon = {
+            ...valid,
+            login: null,
+            spend: {
+                ...valid.spend,
+                cost_usd: null,
+                model_mix: [{ model: "fable", share: 1, tokens: 1_200 }],
+            },
+        };
+
+        expect(validateTeamProfile(anon)).toEqual(anon);
+    });
+
+    test("coerces malformed and injection-looking fields to inert render-safe values", () => {
+        expect(validateTeamProfile({
+            v: 99,
+            login: { toString: () => "<img src=x onerror=alert(1)>" },
+            org: "<script>alert(1)</script>",
+            repo_key: null,
+            window_days: -30,
+            generated_at: 42,
+            stats: {
+                sessions: Number.POSITIVE_INFINITY,
+                active_days: -2,
+                harnesses: ["<b>claude</b>", 7],
+            },
+            activity: { daily: "not-an-array" },
+            skills: "not-an-array",
+            spend: {
+                tokens: { prompt: -10, completion: "200" },
+                cost_usd: "secret",
+                model_mix: [{
+                    model: "<svg/onload=alert(1)>",
+                    share: 4,
+                    tokens: -1,
+                    cost_usd: -3,
+                }],
+            },
+            efficiency: {
+                tool_calls: -1,
+                tool_failures: null,
+                verification_calls: Number.NaN,
+            },
+        })).toEqual({
+            v: 1,
+            login: "<img src=x onerror=alert(1)>",
+            org: "<script>alert(1)</script>",
+            repo_key: "",
+            window_days: 0,
+            generated_at: "42",
+            stats: {
+                sessions: 0,
+                active_days: 0,
+                harnesses: ["<b>claude</b>", "7"],
+            },
+            activity: { daily: [] },
+            skills: [],
+            spend: {
+                tokens: { prompt: 0, completion: 0, total: 0 },
+                cost_usd: 0,
+                model_mix: [{
+                    model: "<svg/onload=alert(1)>",
+                    share: 1,
+                    tokens: 0,
+                    cost_usd: 0,
+                }],
+            },
+            efficiency: {
+                tool_calls: 0,
+                tool_failures: 0,
+                verification_calls: 0,
+            },
+        });
+    });
+
+    test("falls back to an empty snapshot when hostile property access throws", () => {
+        const hostile = new Proxy({}, {
+            get() {
+                throw new Error("hostile getter");
+            },
+        });
+
+        expect(validateTeamProfile(hostile)).toEqual({
+            v: 1,
+            login: "",
+            org: "",
+            repo_key: "",
+            window_days: 0,
+            generated_at: "",
+            stats: { sessions: 0, active_days: 0, harnesses: [] },
+            activity: { daily: [] },
+            skills: [],
+            spend: {
+                tokens: { prompt: 0, completion: 0, total: 0 },
+                cost_usd: 0,
+                model_mix: [],
+            },
+            efficiency: {
+                tool_calls: 0,
+                tool_failures: 0,
+                verification_calls: 0,
+            },
+        });
+    });
+});

--- a/packages/lib/src/shared/team-community.ts
+++ b/packages/lib/src/shared/team-community.ts
@@ -1,0 +1,141 @@
+/**
+ * Browser-safe TeamProfileV1 contract.
+ *
+ * Validation is intentionally manual so consumers do not pull Effect into
+ * their bundle. Snapshots are untrusted git data, so malformed fields collapse
+ * to inert render-safe defaults instead of escaping into the render path.
+ */
+
+export interface TeamProfileV1 {
+    readonly v: 1;
+    readonly login: string | null;
+    readonly org: string;
+    readonly repo_key: string;
+    readonly window_days: number;
+    readonly generated_at: string;
+    readonly stats: {
+        readonly sessions: number;
+        readonly active_days: number;
+        readonly harnesses: ReadonlyArray<string>;
+    };
+    readonly activity: {
+        readonly daily: ReadonlyArray<{
+            readonly date: string;
+            readonly sessions: number;
+            readonly tokens: number;
+        }>;
+    };
+    readonly skills: ReadonlyArray<{
+        readonly skill: string;
+        readonly runs: number;
+        readonly sessions: number;
+    }>;
+    readonly spend: {
+        readonly tokens: {
+            readonly prompt: number;
+            readonly completion: number;
+            readonly total: number;
+        };
+        readonly cost_usd: number | null;
+        readonly model_mix: ReadonlyArray<{
+            readonly model: string;
+            readonly share: number;
+            readonly tokens: number;
+            readonly cost_usd?: number;
+        }>;
+    };
+    readonly efficiency: {
+        readonly tool_calls: number;
+        readonly tool_failures: number;
+        readonly verification_calls: number;
+    };
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+const record = (value: unknown): UnknownRecord =>
+    typeof value === "object" && value !== null && !Array.isArray(value)
+        ? value as UnknownRecord
+        : {};
+
+const text = (value: unknown): string => {
+    if (typeof value === "string") return value;
+    if (value === null || value === undefined) return "";
+    try {
+        return String(value);
+    } catch {
+        return "";
+    }
+};
+
+const nonNegative = (value: unknown): number =>
+    typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : 0;
+
+const ratio = (value: unknown): number => Math.min(1, nonNegative(value));
+
+const rows = <T>(value: unknown, map: (row: UnknownRecord) => T): T[] =>
+    Array.isArray(value) ? value.map((item) => map(record(item))) : [];
+
+function normalizeTeamProfile(value: unknown): TeamProfileV1 {
+    const profile = record(value);
+    const stats = record(profile.stats);
+    const activity = record(profile.activity);
+    const spend = record(profile.spend);
+    const tokens = record(spend.tokens);
+    const efficiency = record(profile.efficiency);
+
+    return {
+        v: 1,
+        login: profile.login === null ? null : text(profile.login),
+        org: text(profile.org),
+        repo_key: text(profile.repo_key),
+        window_days: nonNegative(profile.window_days),
+        generated_at: text(profile.generated_at),
+        stats: {
+            sessions: nonNegative(stats.sessions),
+            active_days: nonNegative(stats.active_days),
+            harnesses: Array.isArray(stats.harnesses) ? stats.harnesses.map(text) : [],
+        },
+        activity: {
+            daily: rows(activity.daily, (row) => ({
+                date: text(row.date),
+                sessions: nonNegative(row.sessions),
+                tokens: nonNegative(row.tokens),
+            })),
+        },
+        skills: rows(profile.skills, (row) => ({
+            skill: text(row.skill),
+            runs: nonNegative(row.runs),
+            sessions: nonNegative(row.sessions),
+        })),
+        spend: {
+            tokens: {
+                prompt: nonNegative(tokens.prompt),
+                completion: nonNegative(tokens.completion),
+                total: nonNegative(tokens.total),
+            },
+            cost_usd: spend.cost_usd === null ? null : nonNegative(spend.cost_usd),
+            model_mix: rows(spend.model_mix, (row) => ({
+                model: text(row.model),
+                share: ratio(row.share),
+                tokens: nonNegative(row.tokens),
+                ...(typeof row.cost_usd === "number" && Number.isFinite(row.cost_usd)
+                    ? { cost_usd: nonNegative(row.cost_usd) }
+                    : {}),
+            })),
+        },
+        efficiency: {
+            tool_calls: nonNegative(efficiency.tool_calls),
+            tool_failures: nonNegative(efficiency.tool_failures),
+            verification_calls: nonNegative(efficiency.verification_calls),
+        },
+    };
+}
+
+export function validateTeamProfile(value: unknown): TeamProfileV1 {
+    try {
+        return normalizeTeamProfile(value);
+    } catch {
+        return normalizeTeamProfile({});
+    }
+}


### PR DESCRIPTION
team-dashboard Slice 2 foundation: a browser-consumable, **Effect-free**, render-safe validator for the TeamProfileV1 snapshots that ax team push writes. New `packages/lib/src/shared/team-community.ts` (`validateTeamProfile` + the `TeamProfileV1` interface, wired into package exports), mirroring `validateMemberProfile`'s defensiveness — hostile/malformed/injection-looking inputs coerce to inert render-safe values, anon (login:null) is handled, hostile property access falls back to an empty snapshot. No Effect import (verified) so the site can bundle it.

Part of #733 (Slice 2). Design: goal-package §5 Slice 2. Feeds the wave-2 aggregation + fetcher.

Gates: typecheck 0, 4 render-safety tests green, Effect-free confirmed.

Generated with ax — https://github.com/Necmttn/ax