### PR TITLE
feat(team): compileTeam — aggregate TeamProfileV1[] into team boards (Slice 2)

### DIFF
--- a/packages/community-compile/package.json
+++ b/packages/community-compile/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./src/compile.ts",
       "import": "./src/compile.ts"
+    },
+    "./team": {
+      "types": "./src/team-compile.ts",
+      "import": "./src/team-compile.ts"
     }
   },
   "scripts": {
@@ -14,6 +18,7 @@
     "test": "bun test"
   },
   "devDependencies": {
+    "@ax/lib": "workspace:*",
     "@types/bun": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/community-compile/src/team-compile.test.ts
+++ b/packages/community-compile/src/team-compile.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import type { TeamProfileV1 } from "@ax/lib/shared/team-community";
+import { compileTeam } from "./team-compile.ts";
+
+const profile = (
+    login: string | null,
+    overrides: Partial<TeamProfileV1> = {},
+): TeamProfileV1 => ({
+    v: 1,
+    login,
+    org: "acme",
+    repo_key: "acme/widget",
+    window_days: 30,
+    generated_at: "2026-07-17T00:00:00Z",
+    stats: {
+        sessions: 10,
+        active_days: 5,
+        harnesses: ["claude"],
+    },
+    activity: { daily: [] },
+    skills: [],
+    spend: {
+        tokens: { prompt: 800, completion: 200, total: 1_000 },
+        cost_usd: 10,
+        model_mix: [],
+    },
+    efficiency: {
+        tool_calls: 100,
+        tool_failures: 10,
+        verification_calls: 20,
+    },
+    ...overrides,
+});
+
+describe("compileTeam", () => {
+    test("aggregates adoption, skills, spend, model mix, and efficiency", () => {
+        const boards = compileTeam([
+            profile("alice", {
+                stats: { sessions: 12, active_days: 6, harnesses: ["claude"] },
+                skills: [
+                    { skill: "tdd", runs: 8, sessions: 5 },
+                    { skill: "review", runs: 3, sessions: 2 },
+                ],
+                spend: {
+                    tokens: { prompt: 800, completion: 200, total: 1_000 },
+                    cost_usd: 12,
+                    model_mix: [
+                        { model: "opus", share: 0.75, tokens: 750, cost_usd: 9 },
+                        { model: "haiku", share: 0.25, tokens: 250, cost_usd: 3 },
+                    ],
+                },
+                efficiency: { tool_calls: 100, tool_failures: 10, verification_calls: 20 },
+            }),
+            profile(null, {
+                stats: { sessions: 6, active_days: 3, harnesses: ["codex"] },
+                skills: [
+                    { skill: "tdd", runs: 2, sessions: 2 },
+                    { skill: "browser", runs: 5, sessions: 4 },
+                ],
+                spend: {
+                    tokens: { prompt: 400, completion: 100, total: 500 },
+                    cost_usd: 4,
+                    model_mix: [
+                        { model: "opus", share: 0.4, tokens: 200, cost_usd: 3 },
+                        { model: "mini", share: 0.6, tokens: 300, cost_usd: 1 },
+                    ],
+                },
+                efficiency: { tool_calls: 40, tool_failures: 2, verification_calls: 10 },
+            }),
+            profile("carol", {
+                stats: { sessions: 9, active_days: 4, harnesses: ["claude", "codex"] },
+                skills: [
+                    { skill: "tdd", runs: 5, sessions: 4 },
+                    { skill: "review", runs: 7, sessions: 5 },
+                ],
+                spend: {
+                    tokens: { prompt: 1_600, completion: 400, total: 2_000 },
+                    cost_usd: null,
+                    model_mix: [
+                        { model: "opus", share: 0.5, tokens: 1_000 },
+                        { model: "mini", share: 0.5, tokens: 1_000 },
+                    ],
+                },
+                efficiency: { tool_calls: 60, tool_failures: 8, verification_calls: 15 },
+            }),
+        ]);
+
+        expect(boards.coverage).toEqual({
+            contributing: 3,
+            identified: 2,
+        });
+        expect(boards.adoption).toEqual({
+            contributingDevs: 3,
+            identifiedLogins: ["alice", "carol"],
+            sessions: { total: 27, average: 9 },
+            activeDays: { total: 13, average: 13 / 3 },
+        });
+        expect(boards.skillMatrix).toEqual([
+            { skill: "tdd", devs: 3, runs: 15, sessions: 11, medianRuns: 5 },
+            { skill: "review", devs: 2, runs: 10, sessions: 7, medianRuns: 5 },
+            { skill: "browser", devs: 1, runs: 5, sessions: 4, medianRuns: 5 },
+        ]);
+        expect(boards.spend).toEqual({
+            tokens: { prompt: 2_800, completion: 700, total: 3_500 },
+            costUsd: 16,
+            costContributors: 2,
+            modelMix: [
+                { model: "opus", tokens: 1_950, share: 1_950 / 3_500, costUsd: 12, costContributors: 2 },
+                { model: "mini", tokens: 1_300, share: 1_300 / 3_500, costUsd: 1, costContributors: 1 },
+                { model: "haiku", tokens: 250, share: 250 / 3_500, costUsd: 3, costContributors: 1 },
+            ],
+        });
+        expect(boards.efficiency).toEqual({
+            toolCalls: 200,
+            toolFailures: 20,
+            verificationCalls: 45,
+            toolFailureRate: 0.1,
+            verificationShare: 0.225,
+        });
+    });
+
+    test("returns an empty but valid board", () => {
+        expect(compileTeam([])).toEqual({
+            coverage: { contributing: 0, identified: 0 },
+            adoption: {
+                contributingDevs: 0,
+                identifiedLogins: [],
+                sessions: { total: 0, average: 0 },
+                activeDays: { total: 0, average: 0 },
+            },
+            skillMatrix: [],
+            spend: {
+                tokens: { prompt: 0, completion: 0, total: 0 },
+                costUsd: 0,
+                costContributors: 0,
+                modelMix: [],
+            },
+            efficiency: {
+                toolCalls: 0,
+                toolFailures: 0,
+                verificationCalls: 0,
+                toolFailureRate: 0,
+                verificationShare: 0,
+            },
+        });
+    });
+
+    test("anonymous snapshots contribute without creating an identity", () => {
+        const boards = compileTeam([
+            profile(null, {
+                stats: { sessions: 4, active_days: 2, harnesses: ["claude"] },
+                skills: [{ skill: "tdd", runs: 6, sessions: 3 }],
+            }),
+        ]);
+
+        expect(boards.coverage).toEqual({ contributing: 1, identified: 0 });
+        expect(boards.adoption.identifiedLogins).toEqual([]);
+        expect(boards.adoption.sessions).toEqual({ total: 4, average: 4 });
+        expect(boards.skillMatrix).toEqual([
+            { skill: "tdd", devs: 1, runs: 6, sessions: 3, medianRuns: 6 },
+        ]);
+    });
+});

--- a/packages/community-compile/src/team-compile.ts
+++ b/packages/community-compile/src/team-compile.ts
@@ -1,0 +1,209 @@
+/**
+ * Pure TeamProfileV1 aggregation for the team dashboard.
+ *
+ * The caller owns fetching and validation. This module only folds validated
+ * snapshots, so it stays effect-free and safe to run in a browser.
+ */
+import type { TeamProfileV1 } from "@ax/lib/shared/team-community";
+
+export interface TeamBoards {
+    readonly coverage: {
+        readonly contributing: number;
+        readonly identified: number;
+    };
+    readonly adoption: {
+        readonly contributingDevs: number;
+        readonly identifiedLogins: string[];
+        readonly sessions: {
+            readonly total: number;
+            readonly average: number;
+        };
+        readonly activeDays: {
+            readonly total: number;
+            readonly average: number;
+        };
+    };
+    readonly skillMatrix: TeamSkillRow[];
+    readonly spend: {
+        readonly tokens: TeamTokenTotals;
+        readonly costUsd: number;
+        readonly costContributors: number;
+        readonly modelMix: TeamModelRow[];
+    };
+    readonly efficiency: {
+        readonly toolCalls: number;
+        readonly toolFailures: number;
+        readonly verificationCalls: number;
+        readonly toolFailureRate: number;
+        readonly verificationShare: number;
+    };
+}
+
+export interface TeamSkillRow {
+    readonly skill: string;
+    readonly devs: number;
+    readonly runs: number;
+    readonly sessions: number;
+    readonly medianRuns: number;
+}
+
+export interface TeamTokenTotals {
+    readonly prompt: number;
+    readonly completion: number;
+    readonly total: number;
+}
+
+export interface TeamModelRow {
+    readonly model: string;
+    readonly tokens: number;
+    readonly share: number;
+    readonly costUsd: number;
+    readonly costContributors: number;
+}
+
+interface SkillAggregate {
+    devs: number;
+    runs: number;
+    sessions: number;
+    runsByDev: number[];
+}
+
+interface ModelAggregate {
+    tokens: number;
+    costUsd: number;
+    costContributors: number;
+}
+
+const ratio = (numerator: number, denominator: number): number =>
+    denominator === 0 ? 0 : numerator / denominator;
+
+function median(values: ReadonlyArray<number>): number {
+    if (values.length === 0) return 0;
+    const sorted = [...values].sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+    if (sorted.length % 2 === 1) return sorted[middle] ?? 0;
+    return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+}
+
+export function compileTeam(snapshots: ReadonlyArray<TeamProfileV1>): TeamBoards {
+    const identifiedLogins = new Set<string>();
+    const skills = new Map<string, SkillAggregate>();
+    const models = new Map<string, ModelAggregate>();
+
+    let sessions = 0;
+    let activeDays = 0;
+    let promptTokens = 0;
+    let completionTokens = 0;
+    let totalTokens = 0;
+    let costUsd = 0;
+    let costContributors = 0;
+    let toolCalls = 0;
+    let toolFailures = 0;
+    let verificationCalls = 0;
+
+    for (const snapshot of snapshots) {
+        if (snapshot.login !== null) identifiedLogins.add(snapshot.login);
+
+        sessions += snapshot.stats.sessions;
+        activeDays += snapshot.stats.active_days;
+        promptTokens += snapshot.spend.tokens.prompt;
+        completionTokens += snapshot.spend.tokens.completion;
+        totalTokens += snapshot.spend.tokens.total;
+        toolCalls += snapshot.efficiency.tool_calls;
+        toolFailures += snapshot.efficiency.tool_failures;
+        verificationCalls += snapshot.efficiency.verification_calls;
+
+        if (snapshot.spend.cost_usd !== null) {
+            costUsd += snapshot.spend.cost_usd;
+            costContributors += 1;
+        }
+
+        const snapshotSkills = new Map<string, { runs: number; sessions: number }>();
+        for (const row of snapshot.skills) {
+            const current = snapshotSkills.get(row.skill) ?? { runs: 0, sessions: 0 };
+            current.runs += row.runs;
+            current.sessions += row.sessions;
+            snapshotSkills.set(row.skill, current);
+        }
+        for (const [skill, row] of snapshotSkills) {
+            const current = skills.get(skill) ?? { devs: 0, runs: 0, sessions: 0, runsByDev: [] };
+            current.devs += 1;
+            current.runs += row.runs;
+            current.sessions += row.sessions;
+            current.runsByDev.push(row.runs);
+            skills.set(skill, current);
+        }
+
+        const snapshotModels = new Map<string, { tokens: number; costUsd: number; hasCost: boolean }>();
+        for (const row of snapshot.spend.model_mix) {
+            const current = snapshotModels.get(row.model) ?? { tokens: 0, costUsd: 0, hasCost: false };
+            current.tokens += row.tokens;
+            if (row.cost_usd !== undefined) {
+                current.costUsd += row.cost_usd;
+                current.hasCost = true;
+            }
+            snapshotModels.set(row.model, current);
+        }
+        for (const [model, row] of snapshotModels) {
+            const current = models.get(model) ?? { tokens: 0, costUsd: 0, costContributors: 0 };
+            current.tokens += row.tokens;
+            current.costUsd += row.costUsd;
+            if (row.hasCost) current.costContributors += 1;
+            models.set(model, current);
+        }
+    }
+
+    const contributing = snapshots.length;
+    const identified = identifiedLogins.size;
+    const modelTokenTotal = [...models.values()].reduce((total, row) => total + row.tokens, 0);
+
+    return {
+        coverage: { contributing, identified },
+        adoption: {
+            contributingDevs: contributing,
+            identifiedLogins: [...identifiedLogins].sort((a, b) => a.localeCompare(b)),
+            sessions: {
+                total: sessions,
+                average: ratio(sessions, contributing),
+            },
+            activeDays: {
+                total: activeDays,
+                average: ratio(activeDays, contributing),
+            },
+        },
+        skillMatrix: [...skills.entries()]
+            .map(([skill, row]): TeamSkillRow => ({
+                skill,
+                devs: row.devs,
+                runs: row.runs,
+                sessions: row.sessions,
+                medianRuns: median(row.runsByDev),
+            }))
+            .sort((a, b) => b.devs - a.devs || b.runs - a.runs || a.skill.localeCompare(b.skill)),
+        spend: {
+            tokens: {
+                prompt: promptTokens,
+                completion: completionTokens,
+                total: totalTokens,
+            },
+            costUsd,
+            costContributors,
+            modelMix: [...models.entries()]
+                .map(([model, row]): TeamModelRow => ({
+                    model,
+                    tokens: row.tokens,
+                    share: ratio(row.tokens, modelTokenTotal),
+                    costUsd: row.costUsd,
+                    costContributors: row.costContributors,
+                }))
+                .sort((a, b) => b.tokens - a.tokens || a.model.localeCompare(b.model)),
+        },
+        efficiency: {
+            toolCalls,
+            toolFailures,
+            verificationCalls,
+            toolFailureRate: ratio(toolFailures, toolCalls),
+            verificationShare: ratio(verificationCalls, toolCalls),
+        },
+    };
+}


### PR DESCRIPTION
team-dashboard Slice 2 aggregation core. `compileTeam(snapshots): TeamBoards` (new packages/community-compile/src/team-compile.ts, Effect-free) folds validated per-dev TeamProfileV1 snapshots into adoption (contributing devs, sessions/active-days), a skill-adoption matrix (skill → devs/runs/median), and spend (tokens, cost with costContributors counting only non-null costs, model mix). Null-safe for anon (login:null) and no_cost (null cost) snapshots — they still count toward adoption/skills without identity or cost. Models the fold on compileCommunity's runtime-agnostic core.

Part of #733 (Slice 2). Design: goal-package §5 Slice 2/4 panels. Pairs with team-fetch (the reader).

Gates: typecheck 0, 3 aggregation tests green (hand-computed, incl null-cost + anon + empty), Effect-free.

Generated with ax — https://github.com/Necmttn/ax