### PR TITLE
feat(team): fetchTeamProfiles — browser contents-API reader for <org>/ax-team (Slice 2)

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -11,6 +11,7 @@
     "./shared/ingest-staleness": "./src/shared/ingest-staleness.ts",
     "./shared/path": "./src/shared/path.ts",
     "./shared/team-community": "./src/shared/team-community.ts",
+    "./shared/team-fetch": "./src/shared/team-fetch.ts",
     "./testing/test-filesystem": "./src/testing/test-filesystem.ts",
     "./testing/surreal": "./src/testing/surreal.ts",
     "./*": {

--- a/packages/lib/src/shared/team-fetch.test.ts
+++ b/packages/lib/src/shared/team-fetch.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import type { TeamProfileV1 } from "./team-community";
+import {
+    fetchTeamProfiles,
+    type GitHubFetch,
+    type GitHubFetchInit,
+} from "./team-fetch";
+
+const profile = (login: string): TeamProfileV1 => ({
+    v: 1,
+    login,
+    org: "acme",
+    repo_key: `remote__github_com_acme_${login}__abc123`,
+    window_days: 30,
+    generated_at: "2026-07-16T00:00:00Z",
+    stats: { sessions: 12, active_days: 5, harnesses: ["claude", "codex"] },
+    activity: { daily: [{ date: "2026-07-15", sessions: 3, tokens: 120_000 }] },
+    skills: [{ skill: "tdd", runs: 8, sessions: 4 }],
+    spend: {
+        tokens: { prompt: 1_000, completion: 200, total: 1_200 },
+        cost_usd: 4.2,
+        model_mix: [{ model: "fable", share: 1, tokens: 1_200, cost_usd: 4.2 }],
+    },
+    efficiency: { tool_calls: 300, tool_failures: 12, verification_calls: 40 },
+});
+
+interface RecordedCall {
+    readonly url: string;
+    readonly init: GitHubFetchInit;
+}
+
+function jsonResponse(value: unknown, status = 200): Response {
+    return new Response(JSON.stringify(value), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+}
+
+function contentsResponse(value: unknown): Response {
+    return jsonResponse({
+        encoding: "base64",
+        content: btoa(JSON.stringify(value)),
+    });
+}
+
+function fakeGitHub(
+    responses: Readonly<Record<string, Response | (() => Response)>>,
+): { readonly fetch: GitHubFetch; readonly calls: RecordedCall[] } {
+    const calls: RecordedCall[] = [];
+    const fetch: GitHubFetch = async (input, init) => {
+        const url = String(input);
+        calls.push({ url, init });
+        const response = responses[url];
+        if (response === undefined) return new Response("not found", { status: 404 });
+        return typeof response === "function" ? response() : response.clone();
+    };
+    return { fetch, calls };
+}
+
+const listUrl = "https://api.github.com/repos/acme/ax-team/contents/.ax-team";
+const fileUrl = (login: string): string =>
+    `https://api.github.com/repos/acme/ax-team/contents/.ax-team/${login}.json`;
+
+describe("fetchTeamProfiles", () => {
+    test("fetches and validates all listed snapshots in parallel", async () => {
+        const snapshots = ["alice", "bob", "carol"].map(profile);
+        const github = fakeGitHub({
+            [listUrl]: jsonResponse([
+                { name: "alice.json", path: ".ax-team/alice.json", type: "file" },
+                { name: "README.md", path: ".ax-team/README.md", type: "file" },
+                { name: "bob.json", path: ".ax-team/bob.json", type: "file" },
+                { name: "carol.json", path: ".ax-team/carol.json", type: "file" },
+            ]),
+            [fileUrl("alice")]: contentsResponse(snapshots[0]),
+            [fileUrl("bob")]: contentsResponse(snapshots[1]),
+            [fileUrl("carol")]: contentsResponse(snapshots[2]),
+        });
+
+        const result = await fetchTeamProfiles({
+            org: "acme",
+            token: "viewer-token",
+            fetch: github.fetch,
+        });
+
+        expect(result).toEqual(snapshots);
+        expect(github.calls.map((call) => call.url)).toEqual([
+            listUrl,
+            fileUrl("alice"),
+            fileUrl("bob"),
+            fileUrl("carol"),
+        ]);
+        for (const call of github.calls) {
+            expect(call.init.headers.authorization).toBe("Bearer viewer-token");
+        }
+    });
+
+    test("drops unreadable, invalid-json, and wrong-version snapshots", async () => {
+        const good = profile("good");
+        const github = fakeGitHub({
+            [listUrl]: jsonResponse([
+                { name: "good.json", path: ".ax-team/good.json", type: "file" },
+                { name: "missing.json", path: ".ax-team/missing.json", type: "file" },
+                { name: "broken.json", path: ".ax-team/broken.json", type: "file" },
+                { name: "invalid.json", path: ".ax-team/invalid.json", type: "file" },
+            ]),
+            [fileUrl("good")]: contentsResponse(good),
+            [fileUrl("missing")]: new Response("not found", { status: 404 }),
+            [fileUrl("broken")]: jsonResponse({
+                encoding: "base64",
+                content: btoa("{not-json"),
+            }),
+            [fileUrl("invalid")]: contentsResponse({ ...profile("invalid"), v: 2 }),
+        });
+
+        await expect(fetchTeamProfiles({
+            org: "acme",
+            token: "viewer-token",
+            fetch: github.fetch,
+        })).resolves.toEqual([good]);
+    });
+
+    test("returns an empty set when the team snapshot directory does not exist", async () => {
+        const github = fakeGitHub({
+            [listUrl]: new Response("not found", { status: 404 }),
+        });
+
+        await expect(fetchTeamProfiles({
+            org: "acme",
+            token: "viewer-token",
+            fetch: github.fetch,
+        })).resolves.toEqual([]);
+        expect(github.calls).toHaveLength(1);
+        expect(github.calls[0]?.init.headers.authorization).toBe("Bearer viewer-token");
+    });
+});

--- a/packages/lib/src/shared/team-fetch.ts
+++ b/packages/lib/src/shared/team-fetch.ts
@@ -1,0 +1,113 @@
+import { type TeamProfileV1, validateTeamProfile } from "./team-community";
+
+export interface GitHubFetchInit {
+    readonly headers: Readonly<Record<string, string>>;
+}
+
+export interface GitHubResponse {
+    readonly ok: boolean;
+    readonly status: number;
+    json(): Promise<unknown>;
+}
+
+export type GitHubFetch = (
+    input: string,
+    init: GitHubFetchInit,
+) => Promise<GitHubResponse>;
+
+export interface FetchTeamProfilesOptions {
+    readonly org: string;
+    readonly token: string;
+    readonly fetch: GitHubFetch;
+}
+
+interface ContentsEntry {
+    readonly name: string;
+    readonly type: string;
+}
+
+const githubHeaders = (token: string): Readonly<Record<string, string>> => ({
+    accept: "application/vnd.github+json",
+    authorization: `Bearer ${token}`,
+    "x-github-api-version": "2022-11-28",
+});
+
+function isContentsEntry(value: unknown): value is ContentsEntry {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+    const entry = value as Record<string, unknown>;
+    return typeof entry.name === "string" && typeof entry.type === "string";
+}
+
+function isV1Envelope(value: unknown): boolean {
+    return typeof value === "object"
+        && value !== null
+        && !Array.isArray(value)
+        && (value as Record<string, unknown>).v === 1;
+}
+
+function decodeBase64Json(content: string): unknown {
+    const binary = atob(content.replace(/\s/g, ""));
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+async function fetchTeamProfile(
+    url: string,
+    token: string,
+    githubFetch: GitHubFetch,
+): Promise<TeamProfileV1> {
+    const response = await githubFetch(url, { headers: githubHeaders(token) });
+    if (!response.ok) throw new Error(`contents fetch failed (${response.status})`);
+
+    const body = await response.json() as { readonly content?: unknown; readonly encoding?: unknown };
+    if (body.encoding !== "base64" || typeof body.content !== "string") {
+        throw new Error("contents response is not base64");
+    }
+
+    const decoded = decodeBase64Json(body.content);
+    const profile = validateTeamProfile(decoded);
+    if (!isV1Envelope(decoded)) throw new Error("invalid team profile version");
+    return profile;
+}
+
+/**
+ * Fetch all browser-readable team snapshots through GitHub's contents API.
+ * A missing snapshot directory is empty; individual unreadable snapshots are
+ * dropped so one developer's bad file cannot reject the team set.
+ */
+export async function fetchTeamProfiles(
+    options: FetchTeamProfilesOptions,
+): Promise<TeamProfileV1[]> {
+    const org = encodeURIComponent(options.org);
+    const baseUrl = `https://api.github.com/repos/${org}/ax-team/contents/.ax-team`;
+    const listResponse = await options.fetch(baseUrl, {
+        headers: githubHeaders(options.token),
+    });
+    if (listResponse.status === 404) return [];
+    if (!listResponse.ok) throw new Error(`contents list failed (${listResponse.status})`);
+
+    const listing = await listResponse.json();
+    if (!Array.isArray(listing)) throw new Error("contents list is not an array");
+
+    const entries = listing.filter(
+        (entry): entry is ContentsEntry =>
+            isContentsEntry(entry)
+            && entry.type === "file"
+            && entry.name.endsWith(".json"),
+    );
+    const settled = await Promise.allSettled(
+        entries.map((entry) =>
+            fetchTeamProfile(
+                `${baseUrl}/${encodeURIComponent(entry.name)}`,
+                options.token,
+                options.fetch,
+            )
+        ),
+    );
+
+    return settled
+        .filter((result): result is PromiseFulfilledResult<TeamProfileV1> =>
+            result.status === "fulfilled"
+        )
+        .map((result) => result.value);
+}


### PR DESCRIPTION
team-dashboard Slice 2 reader. `fetchTeamProfiles({org, token, fetch}): Promise<TeamProfileV1[]>` (new packages/lib/src/shared/team-fetch.ts, Effect-free, injected fetch) lists .ax-team/*.json in the private <org>/ax-team repo via the GitHub contents API with the viewer's token, fetches each in parallel, base64-decodes + validateTeamProfile each, and DROPS failures (unreadable / invalid-json / wrong-version) without rejecting the set. Listing 404 → []. Uses the contents API (not raw URLs — private-repo raw isn't browser-readable). Mirrors the fetchMembers drop-failures pattern.

With team-validate (#734) + team-compile (#735), Slice 2 is complete: fetch → validate → aggregate → boards, all client-side.

Part of #733 (Slice 2, final chunk). Design: goal-package §2/§5.

Gates: typecheck 0, 3 tests green (happy w/ Bearer auth asserted, drop-failures, empty-on-404), Effect-free.

Generated with ax — https://github.com/Necmttn/ax