### PR TITLE
fix(ingest): session-health crashes on empty superpowers invocations (time::min sentinel)

### DIFF
--- a/apps/axctl/src/ingest/session-health.test.ts
+++ b/apps/axctl/src/ingest/session-health.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { __testBuildSessionHealthRows, __testTokenUsageStatement } from "./session-health.ts";
+import {
+    __testBuildSessionHealthRows,
+    __testNormalizeFirstSuperpowersAt,
+    __testTokenUsageStatement,
+    __testWorkflowEpochStatements,
+} from "./session-health.ts";
 
 describe("session health derivation", () => {
     test("uses Claude usage metrics when available", () => {
@@ -176,5 +181,34 @@ describe("session health NONE-safety (#680)", () => {
         expect(rows.usages).toHaveLength(1);
         expect(rows.health).toHaveLength(1);
         expect(rows.usages[0].sessionKey).toBe("ok");
+    });
+});
+
+describe("session health empty superpowers invocations", () => {
+    test("rejects SurrealDB's empty-set max datetime sentinel", () => {
+        const firstSuperpowersAt = __testNormalizeFirstSuperpowersAt("+262142-12-31T23:59:59.999999999Z");
+
+        expect(firstSuperpowersAt).toBeNull();
+        expect(__testNormalizeFirstSuperpowersAt(null)).toBeNull();
+        expect(__testNormalizeFirstSuperpowersAt("2026-07-01T00:00:00.000Z"))
+            .toBe("2026-07-01T00:00:00.000Z");
+
+        const rows = __testBuildSessionHealthRows({
+            firstSuperpowersAt,
+            sessions: [{
+                id: "session:`without-superpowers`",
+                source: "codex",
+                started_at: "2026-07-17T00:00:00.000Z",
+            }],
+            turns: [],
+            toolCalls: [],
+            planSnapshots: [],
+            insightMetrics: [],
+        });
+        expect(rows.usages[0]?.workflowEpoch).toBeNull();
+
+        const statements = __testWorkflowEpochStatements(firstSuperpowersAt);
+        expect(statements[0]).toContain("ends_at: NONE");
+        expect(statements.join("\n")).not.toContain("262142");
     });
 });

--- a/apps/axctl/src/ingest/session-health.ts
+++ b/apps/axctl/src/ingest/session-health.ts
@@ -339,6 +339,8 @@ function workflowEpochStatements(firstSuperpowersAt: string | null): string[] {
     ];
 }
 
+export const __testWorkflowEpochStatements = workflowEpochStatements;
+
 function tokenUsageStatement(row: SessionTokenUsage): string {
     const existingActualTokenUsage =
         "prompt_tokens != NONE OR completion_tokens != NONE OR cache_creation_input_tokens != NONE OR cache_read_input_tokens != NONE";
@@ -391,6 +393,20 @@ function sessionHealthStatement(row: SessionHealth): string {
     ])};`;
 }
 
+const FIRST_SUPERPOWERS_MIN_YEAR = 2000;
+const FIRST_SUPERPOWERS_MAX_YEAR = 2100;
+
+function normalizeFirstSuperpowersAt(value: TimestampInput | null | undefined): string | null {
+    if (value === null || value === undefined) return null;
+    const timestamp = isoTimestamp(value);
+    const parsed = Date.parse(timestamp);
+    if (!Number.isFinite(parsed)) return null;
+    const year = new Date(parsed).getUTCFullYear();
+    return year >= FIRST_SUPERPOWERS_MIN_YEAR && year <= FIRST_SUPERPOWERS_MAX_YEAR ? timestamp : null;
+}
+
+export const __testNormalizeFirstSuperpowersAt = normalizeFirstSuperpowersAt;
+
 const fetchFirstSuperpowersAt = (): Effect.Effect<string | null, DbError, SurrealClient> =>
     Effect.gen(function* () {
         const db = yield* SurrealClient;
@@ -399,8 +415,8 @@ SELECT time::min(ts) AS first_superpowers
 FROM invoked
 WHERE out.name CONTAINS "superpowers:"
 GROUP ALL;`);
-        return isoTimestamp(result?.[0]?.[0]?.first_superpowers);
-    }).pipe(Effect.map((value) => value === new Date(0).toISOString() ? null : value));
+        return normalizeFirstSuperpowersAt(result?.[0]?.[0]?.first_superpowers);
+    });
 
 const sinceWhere = (field: string, sinceDays: number | undefined): string =>
     sinceDays && sinceDays > 0 ? `WHERE ${field} > time::now() - ${sinceDays}d` : "";


### PR DESCRIPTION
The session-health derive stage crashed for anyone with NO superpowers: skill invocations. `SELECT time::min(ts) FROM invoked` over an EMPTY set returns SurrealDB's max-datetime sentinel (+262142-…), which the guard (only checking epoch-0) let through into the `workflow_epoch:gsd` UPSERT — and SurrealDB then rejected its own sentinel as "date outside of valid range".

Fix: `normalizeFirstSuperpowersAt` guards `first_superpowers` to a sane year range (rejecting epoch-0 AND the far-future sentinel, robustly — not by string-matching the literal), so an empty invoked set → `firstSuperpowersAt = null` → the gsd epoch writes `ends_at: NONE` and no sentinel ever reaches a datetime column.

User-reported (bug 2 of 3). Gates: typecheck 0, session-health tests green (asserts the sentinel is rejected + never appears in the emitted statements), check:no-node-fs 0.

Generated with ax — https://github.com/Necmttn/ax