### PR TITLE
feat(studio): render real team boards in /team from /api/team (Slice 4)

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -13,6 +13,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@ax/community-compile": "workspace:*",
     "@ax/foresight": "workspace:*",
     "@ax/lib": "workspace:*",
     "@ax/recap-deck": "workspace:*",

--- a/apps/studio/src/api.ts
+++ b/apps/studio/src/api.ts
@@ -30,6 +30,7 @@ import type {
     WrappedProfile,
 } from "@ax/lib/shared/dashboard-types";
 import type { UsageRollupSchema } from "@ax/lib/shared/api-contract";
+import type { TeamBoards } from "@ax/community-compile/team";
 
 // Studio mock-mode build flag. When true (set at build time for the public
 // studio bundle), every fetch is either:
@@ -560,6 +561,11 @@ export const api = {
         viaContractUnknown("/api/wrapped", (c) => c.insights.wrapped()),
     wrappedPublicPreview: (): Promise<WrappedProfile> =>
         viaContractUnknown("/api/wrapped/public-preview", (c) => c.insights.wrappedPublicPreview()),
+
+    /** Team boards - aggregate of pushed team snapshots (local daemon rollup).
+     *  Contract owned by the `team-serve` route: GET /api/team?org=<org>. */
+    team: (org?: string): Promise<TeamBoards> =>
+        jsonFetch(org ? `/api/team?org=${encodeURIComponent(org)}` : "/api/team"),
 
     costModels: (): Promise<CostModelsResult> =>
         viaContractUnknown("/api/cost/models", (c) => c.insights.costModels()) as Promise<CostModelsResult>,

--- a/apps/studio/src/instrument/team-boards-model.test.ts
+++ b/apps/studio/src/instrument/team-boards-model.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, test } from "bun:test";
+import type { TeamBoards } from "@ax/community-compile/team";
+import { buildTeamView, fmtBig, fmtUsd } from "./team-boards-model.ts";
+
+function boards(overrides: Partial<TeamBoards> = {}): TeamBoards {
+    return {
+        coverage: { contributing: 3, identified: 2 },
+        adoption: {
+            contributingDevs: 3,
+            identifiedLogins: ["alice", "bob"],
+            sessions: { total: 30, average: 10 },
+            activeDays: { total: 15, average: 5 },
+        },
+        skillMatrix: [
+            { skill: "tdd", devs: 3, runs: 30, sessions: 10, medianRuns: 10 },
+            { skill: "debug", devs: 1, runs: 5, sessions: 2, medianRuns: 5 },
+        ],
+        spend: {
+            tokens: { prompt: 800, completion: 200, total: 1_000 },
+            costUsd: 25,
+            costContributors: 2,
+            modelMix: [
+                { model: "claude-sonnet", tokens: 700, share: 0.7, costUsd: 20, costContributors: 2 },
+                { model: "claude-haiku", tokens: 300, share: 0.3, costUsd: 0, costContributors: 0 },
+            ],
+        },
+        efficiency: {
+            toolCalls: 100,
+            toolFailures: 10,
+            verificationCalls: 20,
+            toolFailureRate: 0.1,
+            verificationShare: 0.2,
+        },
+        ...overrides,
+    };
+}
+
+describe("fmtUsd", () => {
+    test("formats thousands with K suffix", () => {
+        expect(fmtUsd(2_500)).toBe("$2.5K");
+    });
+    test("strips trailing .0", () => {
+        expect(fmtUsd(3_000)).toBe("$3K");
+    });
+    test("rounds sub-thousand amounts", () => {
+        expect(fmtUsd(42.6)).toBe("$43");
+    });
+    test("keeps two decimals under $1", () => {
+        expect(fmtUsd(0.5)).toBe("$0.50");
+    });
+});
+
+describe("fmtBig", () => {
+    test("returns 0 for null/undefined", () => {
+        expect(fmtBig(null)).toBe("0");
+        expect(fmtBig(undefined)).toBe("0");
+    });
+    test("formats billions", () => {
+        expect(fmtBig(2_500_000_000)).toBe("2.5B");
+    });
+    test("formats millions", () => {
+        expect(fmtBig(3_000_000)).toBe("3M");
+    });
+    test("formats ten-thousands as K", () => {
+        expect(fmtBig(12_345)).toBe("12.3K");
+    });
+    test("uses locale string below 10K", () => {
+        expect(fmtBig(1_234)).toBe("1,234");
+    });
+});
+
+describe("buildTeamView - empty", () => {
+    test("empty is true iff coverage.contributing === 0", () => {
+        expect(buildTeamView(boards()).empty).toBe(false);
+        expect(
+            buildTeamView(boards({ coverage: { contributing: 0, identified: 0 } })).empty,
+        ).toBe(true);
+    });
+});
+
+describe("buildTeamView - activation", () => {
+    test("contributing 3, identified 2 -> anon segment", () => {
+        expect(buildTeamView(boards()).activation).toBe(
+            "3 devs contributing · 2 identified · 1 anon",
+        );
+    });
+    test("identified === contributing -> no anon segment", () => {
+        const v = buildTeamView(
+            boards({ coverage: { contributing: 3, identified: 3 } }),
+        );
+        expect(v.activation).toBe("3 devs contributing · 3 identified");
+    });
+    test("contributing 1 -> singular dev", () => {
+        const v = buildTeamView(
+            boards({ coverage: { contributing: 1, identified: 1 } }),
+        );
+        expect(v.activation).toBe("1 dev contributing · 1 identified");
+    });
+});
+
+describe("buildTeamView - hero", () => {
+    test("has exactly 4 tiles in order", () => {
+        const v = buildTeamView(boards());
+        expect(v.hero).toHaveLength(4);
+        expect(v.hero.map((t) => t.label)).toEqual([
+            "devs contributing",
+            "sessions",
+            "active days",
+            "spend",
+        ]);
+    });
+
+    test("tile 0: devs contributing", () => {
+        const v = buildTeamView(boards());
+        expect(v.hero[0]).toMatchObject({
+            label: "devs contributing",
+            value: "3",
+            sub: "2 identified · 1 anon",
+        });
+    });
+
+    test("tile 1: sessions", () => {
+        const v = buildTeamView(boards());
+        expect(v.hero[1]).toMatchObject({
+            label: "sessions",
+            value: fmtBig(30),
+            sub: "avg 10/dev",
+        });
+    });
+
+    test("tile 1: sessions avg strips trailing decimal precisely", () => {
+        const v = buildTeamView(
+            boards({
+                adoption: {
+                    contributingDevs: 3,
+                    identifiedLogins: ["alice", "bob"],
+                    sessions: { total: 12, average: 3.47 },
+                    activeDays: { total: 15, average: 5 },
+                },
+            }),
+        );
+        expect(v.hero[1].sub).toBe("avg 3.5/dev");
+    });
+
+    test("tile 2: active days", () => {
+        const v = buildTeamView(boards());
+        expect(v.hero[2]).toMatchObject({
+            label: "active days",
+            value: fmtBig(15),
+            sub: "avg 5/dev",
+        });
+    });
+
+    test("tile 3: spend with contributors", () => {
+        const v = buildTeamView(boards());
+        expect(v.hero[3]).toMatchObject({
+            label: "spend",
+            value: fmtUsd(25),
+            sub: "2 of 3 devs report cost",
+        });
+    });
+
+    test("tile 3: spend when all devs report cost -> 'all devs report cost'", () => {
+        const v = buildTeamView(
+            boards({
+                spend: {
+                    tokens: { prompt: 800, completion: 200, total: 1_000 },
+                    costUsd: 25,
+                    costContributors: 3,
+                    modelMix: [],
+                },
+            }),
+        );
+        expect(v.hero[3]).toMatchObject({
+            label: "spend",
+            value: fmtUsd(25),
+            sub: "all devs report cost",
+        });
+    });
+
+    test("tile 3: spend with zero contributors -> dash + no cost data", () => {
+        const v = buildTeamView(
+            boards({
+                spend: {
+                    tokens: { prompt: 800, completion: 200, total: 1_000 },
+                    costUsd: 0,
+                    costContributors: 0,
+                    modelMix: [],
+                },
+            }),
+        );
+        expect(v.hero[3]).toMatchObject({
+            label: "spend",
+            value: "-",
+            sub: "no cost data pushed",
+        });
+    });
+});
+
+describe("buildTeamView - costNote", () => {
+    test("null when costContributors === contributing && contributing > 0", () => {
+        const v = buildTeamView(
+            boards({
+                spend: {
+                    tokens: { prompt: 800, completion: 200, total: 1_000 },
+                    costUsd: 25,
+                    costContributors: 3,
+                    modelMix: [],
+                },
+            }),
+        );
+        expect(v.costNote).toBeNull();
+    });
+
+    test("'no cost data pushed' when costContributors === 0", () => {
+        const v = buildTeamView(
+            boards({
+                spend: {
+                    tokens: { prompt: 800, completion: 200, total: 1_000 },
+                    costUsd: 0,
+                    costContributors: 0,
+                    modelMix: [],
+                },
+            }),
+        );
+        expect(v.costNote).toBe("no cost data pushed");
+    });
+
+    test("'N of M devs report cost' otherwise", () => {
+        const v = buildTeamView(boards());
+        expect(v.costNote).toBe("2 of 3 devs report cost");
+    });
+});
+
+describe("buildTeamView - skills", () => {
+    test("preserves input order and computes devShare relative to max devs row", () => {
+        const v = buildTeamView(boards());
+        expect(v.skills.map((s) => s.skill)).toEqual(["tdd", "debug"]);
+        expect(v.skills[0]).toMatchObject({
+            skill: "tdd",
+            devs: 3,
+            runs: 30,
+            sessions: 10,
+            medianRuns: 10,
+            devShare: 1,
+        });
+        expect(v.skills[1]).toMatchObject({
+            skill: "debug",
+            devs: 1,
+            devShare: 1 / 3,
+        });
+    });
+
+    test("empty skillMatrix -> empty array, no NaN", () => {
+        const v = buildTeamView(boards({ skillMatrix: [] }));
+        expect(v.skills).toEqual([]);
+    });
+});
+
+describe("buildTeamView - models", () => {
+    test("share passed through, cost formatted, tokens formatted", () => {
+        const v = buildTeamView(boards());
+        expect(v.models).toEqual([
+            { model: "claude-sonnet", tokens: fmtBig(700), share: 0.7, cost: fmtUsd(20) },
+            { model: "claude-haiku", tokens: fmtBig(300), share: 0.3, cost: "-" },
+        ]);
+    });
+});
+
+describe("buildTeamView - efficiency", () => {
+    test("toolCalls fmtBig, rates rounded to whole percent", () => {
+        const v = buildTeamView(boards());
+        expect(v.efficiency).toEqual({
+            toolCalls: fmtBig(100),
+            failureRate: "10%",
+            verificationShare: "20%",
+        });
+    });
+});
+
+describe("buildTeamView - tokens", () => {
+    test("fmtBig of prompt/completion/total", () => {
+        const v = buildTeamView(boards());
+        expect(v.tokens).toEqual({
+            prompt: fmtBig(800),
+            completion: fmtBig(200),
+            total: fmtBig(1_000),
+        });
+    });
+});

--- a/apps/studio/src/instrument/team-boards-model.ts
+++ b/apps/studio/src/instrument/team-boards-model.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure view-model for the studio team boards. No react imports - keeps the
+ * formatting/derivation logic testable without a DOM.
+ */
+import type { TeamBoards } from "@ax/community-compile/team";
+
+export const fmtUsd = (n: number): string =>
+    n >= 1000 ? `$${(n / 1000).toFixed(1).replace(/\.0$/, "")}K` : n >= 1 ? `$${Math.round(n)}` : `$${n.toFixed(2)}`;
+
+export const fmtBig = (n: number | null | undefined): string => {
+    if (n == null) return "0";
+    const a = Math.abs(n);
+    if (a >= 1e9) return (n / 1e9).toFixed(1).replace(/\.0$/, "") + "B";
+    if (a >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+    if (a >= 1e4) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "K";
+    return n.toLocaleString("en-US");
+};
+
+const fmtAvg = (n: number): string => n.toFixed(1).replace(/\.0$/, "");
+
+export interface TeamHeroTile {
+    label: string;
+    value: string;
+    small?: string;
+    sub: string;
+}
+
+export interface TeamSkillView {
+    skill: string;
+    devs: number;
+    runs: number;
+    sessions: number;
+    medianRuns: number;
+    devShare: number;
+}
+
+export interface TeamModelView {
+    model: string;
+    tokens: string;
+    share: number;
+    cost: string;
+}
+
+export interface TeamBoardsViewModel {
+    empty: boolean;
+    activation: string;
+    hero: TeamHeroTile[];
+    skills: TeamSkillView[];
+    models: TeamModelView[];
+    tokens: { prompt: string; completion: string; total: string };
+    efficiency: { toolCalls: string; failureRate: string; verificationShare: string };
+    costNote: string | null;
+}
+
+function identifiedSegment(contributing: number, identified: number): string {
+    if (identified === contributing) return `${identified} identified`;
+    return `${identified} identified · ${contributing - identified} anon`;
+}
+
+function activationLine(contributing: number, identified: number): string {
+    const devWord = contributing === 1 ? "dev" : "devs";
+    return `${contributing} ${devWord} contributing · ${identifiedSegment(contributing, identified)}`;
+}
+
+export function buildTeamView(b: TeamBoards): TeamBoardsViewModel {
+    const { contributing, identified } = b.coverage;
+    const empty = contributing === 0;
+
+    const costNote =
+        b.spend.costContributors === contributing && contributing > 0
+            ? null
+            : b.spend.costContributors === 0
+              ? "no cost data pushed"
+              : `${b.spend.costContributors} of ${contributing} devs report cost`;
+
+    const spendTile: TeamHeroTile =
+        b.spend.costContributors > 0
+            ? {
+                  label: "spend",
+                  value: fmtUsd(b.spend.costUsd),
+                  sub: costNote ?? "all devs report cost",
+              }
+            : {
+                  label: "spend",
+                  value: "-",
+                  sub: "no cost data pushed",
+              };
+
+    const hero: TeamHeroTile[] = [
+        {
+            label: "devs contributing",
+            value: String(contributing),
+            sub: identifiedSegment(contributing, identified),
+        },
+        {
+            label: "sessions",
+            value: fmtBig(b.adoption.sessions.total),
+            sub: `avg ${fmtAvg(b.adoption.sessions.average)}/dev`,
+        },
+        {
+            label: "active days",
+            value: fmtBig(b.adoption.activeDays.total),
+            sub: `avg ${fmtAvg(b.adoption.activeDays.average)}/dev`,
+        },
+        spendTile,
+    ];
+
+    const maxDevs = b.skillMatrix.reduce((max, row) => Math.max(max, row.devs), 0);
+    const skills: TeamSkillView[] = b.skillMatrix.map((row) => ({
+        skill: row.skill,
+        devs: row.devs,
+        runs: row.runs,
+        sessions: row.sessions,
+        medianRuns: row.medianRuns,
+        devShare: maxDevs === 0 ? 0 : row.devs / maxDevs,
+    }));
+
+    const models: TeamModelView[] = b.spend.modelMix.map((row) => ({
+        model: row.model,
+        tokens: fmtBig(row.tokens),
+        share: row.share,
+        cost: row.costContributors === 0 ? "-" : fmtUsd(row.costUsd),
+    }));
+
+    return {
+        empty,
+        activation: activationLine(contributing, identified),
+        hero,
+        skills,
+        models,
+        tokens: {
+            prompt: fmtBig(b.spend.tokens.prompt),
+            completion: fmtBig(b.spend.tokens.completion),
+            total: fmtBig(b.spend.tokens.total),
+        },
+        efficiency: {
+            toolCalls: fmtBig(b.efficiency.toolCalls),
+            failureRate: `${Math.round(b.efficiency.toolFailureRate * 100)}%`,
+            verificationShare: `${Math.round(b.efficiency.verificationShare * 100)}%`,
+        },
+        costNote,
+    };
+}

--- a/apps/studio/src/instrument/team-metrics.tsx
+++ b/apps/studio/src/instrument/team-metrics.tsx
@@ -1,23 +1,20 @@
 /**
- * Team Metrics - a dense, nullframe-styled metrics board modelled on the
- * HumanLayer "Team Metrics" page, mapped onto ax's LOCAL graph. ax is
- * single-user, so the "team" is the set of agents on your graph: the 5
- * harnesses (the roster), the models they run (the channels), and the daily /
- * weekly telemetry series they produce.
+ * Team Boards - the studio /team page, backed by the daemon's team rollup.
  *
- * Phase 1 (this file): wires the real daemon data we already have - wrapped
- * usage.days (per-day sessions/turns/tokens) + cost models + the sessions list
- * (aggregated client-side into a per-harness roster). Range toggles slice the
- * window. Design system: ./instrument.css (.v-tm-*, .v-team-*) + ./viz BarChart.
+ * The real path fetches `GET /api/team` (aggregate of `ax team push` snapshots
+ * compiled by @ax/community-compile `compileTeam`) and renders adoption /
+ * skill-matrix / spend panels. `?demo` keeps the seeded, self-contained
+ * dev-adoption board - the public "click around" surface iframed by the
+ * marketing site (/design-partners) - which never touches live queries.
+ * Design system: ./instrument.css (.v-tm-*, .v-team-*) + ./viz BarChart.
  */
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api.ts";
 import type { WrappedUsageDay } from "@ax/lib/shared/dashboard-types";
-import type { SessionListRow } from "@ax/lib/shared/api-contract";
 import { fmtCount } from "@ax/lib/shared/formatters";
-import { fetchMembers, type MemberProfile } from "@ax/lib/shared/community";
 import { BarChart } from "./viz.tsx";
+import { buildTeamView, fmtBig, fmtUsd } from "./team-boards-model.ts";
 
 // ---- range model ----------------------------------------------------------
 type DailyRange = 7 | 30 | 90;
@@ -26,16 +23,6 @@ const DAILY: ReadonlyArray<DailyRange> = [7, 30, 90];
 const WEEKLY: ReadonlyArray<WeeklyRange> = [4, 8, 12];
 
 // ---- formatting -----------------------------------------------------------
-const fmtUsd = (n: number): string =>
-    n >= 1000 ? `$${(n / 1000).toFixed(1).replace(/\.0$/, "")}K` : n >= 1 ? `$${Math.round(n)}` : `$${n.toFixed(2)}`;
-const fmtBig = (n: number | null | undefined): string => {
-    if (n == null) return "0";
-    const a = Math.abs(n);
-    if (a >= 1e9) return (n / 1e9).toFixed(1).replace(/\.0$/, "") + "B";
-    if (a >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
-    if (a >= 1e4) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "K";
-    return n.toLocaleString("en-US");
-};
 const shortModel = (m: string): string => m.replace(/-\d{6,}$/, "");
 const mdLabel = (iso: string): string => {
     const d = new Date(iso + (iso.length <= 10 ? "T00:00:00" : ""));
@@ -52,16 +39,6 @@ const toneFor = (m: string): string => {
     if (s.includes("gpt") || s.includes("o3") || s.includes("o4") || s.includes("codex")) return "var(--gold)";
     return "var(--accent)";
 };
-
-// ---- harness roster (the "active users" table) ----------------------------
-interface HarnessRow {
-    source: string;
-    sessions: number;
-    cost: number;
-    model: string | null;
-    spark: number[]; // 0-4 levels, last 7 buckets
-    online: boolean;
-}
 
 /** ISO-ish week key (year-week) from a yyyy-mm-dd date string. */
 const weekKey = (iso: string): string => {
@@ -90,37 +67,7 @@ function weekly(days: ReadonlyArray<WrappedUsageDay>): { labels: string[]; sessi
     };
 }
 
-/** Build the per-harness roster from the recent sessions list. */
-function buildRoster(rows: ReadonlyArray<SessionListRow>): HarnessRow[] {
-    const now = Date.now();
-    const dayMs = 86400000;
-    const by = new Map<string, HarnessRow & { lastTs: number }>();
-    for (const r of rows) {
-        const src = r.source || "unknown";
-        const cur = by.get(src) ?? {
-            source: src, sessions: 0, cost: 0, model: null, spark: [0, 0, 0, 0, 0, 0, 0], online: false, lastTs: 0,
-        };
-        cur.sessions += 1;
-        cur.cost += r.cost_usd ?? 0;
-        const ts = r.started_at ? Date.parse(r.started_at) : NaN;
-        if (!Number.isNaN(ts)) {
-            if (ts > cur.lastTs) { cur.lastTs = ts; cur.model = r.model ?? cur.model; }
-            const ageDays = Math.floor((now - ts) / dayMs);
-            if (ageDays >= 0 && ageDays < 7) cur.spark[6 - ageDays] += 1;
-        }
-        by.set(src, cur);
-    }
-    const list = [...by.values()];
-    // normalize spark counts → 0-4 levels per row
-    for (const h of list) {
-        const peak = Math.max(1, ...h.spark);
-        h.spark = h.spark.map((c) => (c <= 0 ? 0 : c / peak > 0.66 ? 4 : c / peak > 0.4 ? 3 : c / peak > 0.15 ? 2 : 1));
-        h.online = now - h.lastTs < dayMs;
-    }
-    return list.sort((a, b) => b.sessions - a.sessions);
-}
-
-// ---- unified roster + compare model ---------------------------------------
+// ---- unified roster + compare model (demo board) ---------------------------
 type RosterTab = "projects" | "members" | "harnesses";
 const TABS: ReadonlyArray<{ id: RosterTab; label: string }> = [
     { id: "projects", label: "projects" },
@@ -137,255 +84,23 @@ interface RosterEntity {
     mid?: ReactNode; // override for the middle cell (e.g. member team chips)
     model: string | null;
     sessions: number;
-    tokens: number; // token consumption (the headline org metric for members)
+    tokens: number;
     cost: number;
     metrics: CompareMetric[]; // compare-panel rows (consistent within a tab)
-    // Outcome fields - the org scoreboard (teaser only). Sell value, not spend.
-    // Unit is "tasks" (AI-assisted work items completed) so it generalizes
-    // across functions - PRs for eng, tickets for support, accounts for sales -
-    // unlike $/PR, which only makes sense for teams that ship code.
-    outcome?: {
-        taskShare: number; // 0-1, share of company's AI-assisted work items
-        tasks: number; // work items completed / mo
-        perTask: number; // $ per completed task
-        firstPass: number; // 0-1, % completed without a redo
-    };
 }
 
-const basename = (p: string | null): string => {
-    if (!p) return "unknown";
-    const parts = p.replace(/\/+$/, "").split("/");
-    return parts[parts.length - 1] || p;
-};
-const topModel = (counts: Map<string, number>): string | null => {
-    let best: string | null = null, max = 0;
-    for (const [m, c] of counts) if (c > max) { max = c; best = m; }
-    return best;
-};
 const levelize = (spark: number[]): number[] => {
     const peak = Math.max(1, ...spark);
     return spark.map((c) => (c <= 0 ? 0 : c / peak > 0.66 ? 4 : c / peak > 0.4 ? 3 : c / peak > 0.15 ? 2 : 1));
 };
 
-/** Aggregate the sessions list into a per-project (repo) roster. */
-function buildProjects(rows: ReadonlyArray<SessionListRow>): RosterEntity[] {
-    const now = Date.now(), dayMs = 86400000;
-    interface Acc {
-        sessions: number; cost: number; added: number; removed: number; friction: number;
-        models: Map<string, number>; spark: number[]; lastTs: number;
-    }
-    const by = new Map<string, Acc>();
-    for (const r of rows) {
-        const key = basename(r.cwd);
-        const a = by.get(key) ?? { sessions: 0, cost: 0, added: 0, removed: 0, friction: 0, models: new Map(), spark: [0, 0, 0, 0, 0, 0, 0], lastTs: 0 };
-        a.sessions += 1;
-        a.cost += r.cost_usd ?? 0;
-        a.added += r.lines_added ?? 0;
-        a.removed += r.lines_removed ?? 0;
-        if (r.signal === "friction") a.friction += 1;
-        if (r.model) a.models.set(r.model, (a.models.get(r.model) ?? 0) + 1);
-        const ts = r.started_at ? Date.parse(r.started_at) : NaN;
-        if (!Number.isNaN(ts)) {
-            if (ts > a.lastTs) a.lastTs = ts;
-            const age = Math.floor((now - ts) / dayMs);
-            if (age >= 0 && age < 7) a.spark[6 - age] += 1;
-        }
-        by.set(key, a);
-    }
-    return [...by.entries()].map(([id, a]) => {
-        const model = topModel(a.models);
-        return {
-        id, label: id, online: now - a.lastTs < dayMs, spark: levelize(a.spark),
-        model, sessions: a.sessions, tokens: 0, cost: a.cost,
-        metrics: [
-            { label: "sessions", value: fmtCount(a.sessions), n: a.sessions },
-            { label: "cost", value: a.cost > 0 ? fmtUsd(a.cost) : "-", n: a.cost },
-            { label: "top model", value: model ? shortModel(model) : "-", n: 0 },
-            { label: "lines +", value: fmtCount(a.added), n: a.added },
-            { label: "lines -", value: fmtCount(a.removed), n: a.removed },
-            { label: "friction sessions", value: fmtCount(a.friction), n: a.friction },
-        ],
-        };
-    }).sort((x, y) => y.sessions - x.sessions);
-}
-
-/** Adapt the per-harness roster into the unified shape. */
-function harnessEntities(rows: HarnessRow[]): RosterEntity[] {
-    return rows.map((h) => ({
-        id: h.source, label: h.source, online: h.online, spark: h.spark,
-        model: h.model, sessions: h.sessions, tokens: 0, cost: h.cost,
-        metrics: [
-            { label: "sessions", value: fmtCount(h.sessions), n: h.sessions },
-            { label: "cost", value: h.cost > 0 ? fmtUsd(h.cost) : "-", n: h.cost },
-            { label: "top model", value: h.model ? shortModel(h.model) : "-", n: 0 },
-            { label: "active (7d)", value: h.online ? "yes" : "no", n: h.online ? 1 : 0 },
-        ],
-    }));
-}
-
-/** Adapt fetched community profiles into the unified shape. */
-function memberEntities(profiles: ReadonlyArray<MemberProfile>): RosterEntity[] {
-    return profiles.map((p) => {
-        const top = [...p.models].sort((a, b) => b.share - a.share)[0]?.name ?? null;
-        return {
-            id: p.github, label: p.github, online: false, spark: [],
-            mid: (
-                <span className="v-tm-chips">
-                    {p.harnesses.slice(0, 4).map((h) => <span key={h} className="v-tm-chip">{h}</span>)}
-                    {p.harnesses.length === 0 ? <span className="rdx-dim">-</span> : null}
-                </span>
-            ),
-            model: top, sessions: p.sessions, tokens: p.tokens_total, cost: p.cost_usd ?? 0,
-            metrics: [
-                { label: "sessions", value: fmtCount(p.sessions), n: p.sessions },
-                { label: "cost", value: p.cost_usd ? fmtUsd(p.cost_usd) : "-", n: p.cost_usd ?? 0 },
-                { label: "tokens", value: fmtBig(p.tokens_total), n: p.tokens_total },
-                { label: "streak", value: `${p.streak_days}d`, n: p.streak_days },
-                { label: "active days", value: fmtCount(p.active_days), n: p.active_days },
-                { label: "harnesses", value: String(p.harnesses.length), n: p.harnesses.length },
-                { label: "top model", value: top ? shortModel(top) : "-", n: 0 },
-            ],
-        };
-    });
-}
-
-// ===========================================================================
-// MOCK org dataset - the blurred paywall teaser. Models a company's agent spend
-// broken down BY FUNCTION (Engineering, Support, Sales…) - the exact view eng
-// leadership pays for: who consumes the tokens, $/person, $/mo, spend share.
-// All fabricated + deterministic: never leaks the operator's real numbers and
-// renders fully even when the daemon is down.
-// ===========================================================================
-// Each function carries spend AND outcome. Output is counted in "tasks" -
-// AI-assisted work items completed (PRs for eng, tickets for support, accounts
-// for sales) - a unit that's comparable across every function. The story: by
-// volume, Support is the standout (more AI-assisted work than engineering);
-// Engineering is a fifth of the tasks but the majority of the spend.
-interface MockFn {
-    name: string; head: number; monthly: number; tokens: number; model: string;
-    skills: number; workflows: number; tasks: number; firstPass: number; adopt: number;
-}
-const MOCK_FN_RAW: MockFn[] = [
-    { name: "Engineering", head: 24, monthly: 74_556, tokens: 8_320_000_000, model: "claude-opus-4-8", skills: 31, workflows: 12, tasks: 793, firstPass: 0.86, adopt: 7 },
-    { name: "Support", head: 11, monthly: 16_940, tokens: 1_880_000_000, model: "claude-sonnet-4-6", skills: 18, workflows: 7, tasks: 1_420, firstPass: 0.83, adopt: 1 },
-    { name: "Sales", head: 44, monthly: 10_120, tokens: 1_120_000_000, model: "claude-haiku-4-5", skills: 9, workflows: 3, tasks: 880, firstPass: 0.71, adopt: 0 },
-    { name: "Customer Success", head: 12, monthly: 8_280, tokens: 920_000_000, model: "claude-sonnet-4-6", skills: 11, workflows: 4, tasks: 612, firstPass: 0.85, adopt: 3 },
-    { name: "Marketing", head: 8, monthly: 9_120, tokens: 1_010_000_000, model: "claude-sonnet-4-6", skills: 13, workflows: 5, tasks: 240, firstPass: 0.74, adopt: 2 },
-    { name: "Founders", head: 4, monthly: 6_400, tokens: 710_000_000, model: "claude-opus-4-8", skills: 16, workflows: 6, tasks: 64, firstPass: 0.78, adopt: 6 },
-];
-const MOCK_FN_TOTAL = MOCK_FN_RAW.reduce((s, f) => s + f.monthly, 0);
-const MOCK_FN_TASKS = MOCK_FN_RAW.reduce((s, f) => s + f.tasks, 0);
-
-/** Org-level hero numbers (the scoreboard headline). */
-const MOCK_ORG = {
-    tasksPerMo: MOCK_FN_TASKS,
-    perTask: Math.round(MOCK_FN_TOTAL / MOCK_FN_TASKS),
-    perTaskPrev: 52, // 90d ago - the "it gets cheaper" trend
-    monthly: MOCK_FN_TOTAL,
-    activePct: 0.88,
-    activePctPrev: 0.41,
-    firstPass: MOCK_FN_RAW.reduce((s, f) => s + f.tasks * f.firstPass, 0) / MOCK_FN_TASKS,
-};
-
-const MOCK_MEMBERS: RosterEntity[] = MOCK_FN_RAW.map((f) => {
-    const share = f.monthly / MOCK_FN_TOTAL;
-    const taskShare = f.tasks / MOCK_FN_TASKS;
-    const perTask = Math.round(f.monthly / f.tasks);
-    const perPerson = Math.round(f.monthly / f.head);
-    return {
-        id: f.name, label: f.name, online: true, spark: [],
-        mid: <span className="v-tm-chips"><span className="v-tm-chip team">{f.head} ppl</span></span>,
-        model: f.model, sessions: f.head, tokens: f.tokens, cost: f.monthly,
-        outcome: { taskShare, tasks: f.tasks, perTask, firstPass: f.firstPass },
-        // Compare panel: OUTCOME first, spend demoted to the bottom rows.
-        metrics: [
-            { label: "task share", value: `${Math.round(taskShare * 100)}%`, n: taskShare },
-            { label: "tasks / mo", value: fmtCount(f.tasks), n: f.tasks },
-            { label: "$ / task", value: fmtUsd(perTask), n: -perTask },
-            { label: "first-pass", value: `${Math.round(f.firstPass * 100)}%`, n: f.firstPass },
-            { label: "skills adopted", value: String(f.skills), n: f.skills },
-            { label: "adoption Δ 30d", value: `${f.adopt >= 0 ? "+" : ""}${f.adopt}`, n: f.adopt },
-            { label: "spend $ / mo", value: fmtUsd(f.monthly), n: -f.monthly },
-            { label: "spend share", value: `${Math.round(share * 100)}%`, n: -share },
-            { label: "$ / person", value: fmtUsd(perPerson), n: -perPerson },
-        ],
-    };
-});
-
-function mockProject(
-    name: string, sessions: number, cost: number, added: number, removed: number,
-    friction: number, model: string,
-): RosterEntity {
-    return {
-        id: name, label: name, online: true, spark: levelize([3, 5, 2, 6, 4, 7, 5]),
-        model, sessions, tokens: 0, cost,
-        metrics: [
-            { label: "sessions", value: fmtCount(sessions), n: sessions },
-            { label: "cost", value: fmtUsd(cost), n: cost },
-            { label: "top model", value: shortModel(model), n: 0 },
-            { label: "lines +", value: fmtCount(added), n: added },
-            { label: "lines -", value: fmtCount(removed), n: removed },
-            { label: "friction sessions", value: fmtCount(friction), n: friction },
-        ],
-    };
-}
-
-const MOCK_PROJECTS: RosterEntity[] = [
-    mockProject("checkout-service", 842, 9120, 184_300, 41_200, 173, "claude-opus-4-8"),
-    mockProject("web-app", 731, 6240, 142_800, 38_900, 142, "claude-sonnet-4-6"),
-    mockProject("data-pipeline", 519, 5380, 98_400, 22_100, 121, "gpt-5.4"),
-    mockProject("mobile", 388, 3110, 67_200, 19_400, 88, "claude-sonnet-4-6"),
-    mockProject("infra", 247, 2740, 31_900, 12_800, 54, "claude-haiku-4-5"),
-];
-
-const MOCK_HARNESSES: RosterEntity[] = [
-    { id: "claude", label: "claude", online: true, spark: levelize([6, 5, 7, 6, 7, 6, 7]), model: "claude-opus-4-8", sessions: 1840, tokens: 0, cost: 21300,
-        metrics: [{ label: "sessions", value: "1,840", n: 1840 }, { label: "cost", value: fmtUsd(21300), n: 21300 }, { label: "top model", value: "claude-opus-4-8", n: 0 }, { label: "active (7d)", value: "yes", n: 1 }] },
-    { id: "codex", label: "codex", online: true, spark: levelize([3, 4, 2, 5, 3, 4, 3]), model: "gpt-5.4", sessions: 612, tokens: 0, cost: 7200,
-        metrics: [{ label: "sessions", value: "612", n: 612 }, { label: "cost", value: fmtUsd(7200), n: 7200 }, { label: "top model", value: "gpt-5.4", n: 0 }, { label: "active (7d)", value: "yes", n: 1 }] },
-    { id: "cursor", label: "cursor", online: false, spark: levelize([1, 0, 2, 1, 0, 1, 0]), model: "claude-sonnet-4-6", sessions: 203, tokens: 0, cost: 1810,
-        metrics: [{ label: "sessions", value: "203", n: 203 }, { label: "cost", value: fmtUsd(1810), n: 1810 }, { label: "top model", value: "claude-sonnet-4-6", n: 0 }, { label: "active (7d)", value: "no", n: 0 }] },
-];
-
-const MOCK_CHANNELS = [
-    { model: "claude-opus-4-8", cost_usd: 14200 },
-    { model: "claude-fable-5", cost_usd: 8600 },
-    { model: "gpt-5.4", cost_usd: 6300 },
-    { model: "claude-sonnet-4-6", cost_usd: 4100 },
-    { model: "claude-haiku-4-5", cost_usd: 1200 },
-];
-const MOCK_COST_TOTAL = MOCK_CHANNELS.reduce((s, r) => s + r.cost_usd, 0);
-
-/** Deterministic ~9-week org-wide daily series (sessions/turns/tokens). */
-function mockDays(): WrappedUsageDay[] {
-    const out: WrappedUsageDay[] = [];
-    const today = new Date();
-    const N = 63;
-    for (let i = N - 1; i >= 0; i--) {
-        const d = new Date(today);
-        d.setDate(today.getDate() - i);
-        const dow = d.getDay();
-        const weekday = dow >= 1 && dow <= 5 ? 1 : 0.35; // quiet weekends
-        const wave = 0.62 + 0.38 * Math.sin((N - i) / 6.2);
-        const sessions = Math.round((120 + 90 * wave) * weekday);
-        out.push({
-            date: d.toISOString().slice(0, 10),
-            sessions,
-            turns: sessions * (38 + Math.round(14 * wave)),
-            tokens: sessions * 9_400_000,
-        });
-    }
-    return out;
-}
-const MOCK_DAYS: WrappedUsageDay[] = mockDays();
-
 // ===========================================================================
 // DEMO org dataset - the clean, fully-visible `?demo` board. Tells the
 // DEV-ADOPTION story from the /design-partners pitch: a git-native team
 // rollup for AI coding agents. Framing is adoption + routable spend + skill
-// diffusion, NOT the exec business-functions view (which stays on the locked
-// teaser). All numbers echo the pitch's RollupMock so the two never contradict.
-// Fabricated + deterministic; no live queries, renders daemon-up or down.
+// diffusion. All numbers echo the pitch's RollupMock so the two never
+// contradict. Fabricated + deterministic; no live queries, renders daemon-up
+// or down - the marketing site iframes this route.
 // ===========================================================================
 const DEMO_ORG = {
     label: "acme",
@@ -554,47 +269,9 @@ function ChartCard({
     );
 }
 
-// ---- hero scoreboard strip (teaser) ---------------------------------------
-/** Three outcome tiles - the band that reads above the paywall card. Sells
- *  return-on-agent (output + leverage + momentum), not the bill. */
-function HeroStrip() {
-    // The surprising cross-function insight: by AI-assisted work volume, Support
-    // leads - while Engineering is the spend leader. (mirrors the LinkedIn post)
-    const byTasks = [...MOCK_FN_RAW].sort((a, b) => b.tasks - a.tasks)[0];
-    const bySpend = [...MOCK_FN_RAW].sort((a, b) => b.monthly - a.monthly)[0];
-    const topTaskShare = Math.round((byTasks.tasks / MOCK_FN_TASKS) * 100);
-    const topPerTask = Math.round(byTasks.monthly / byTasks.tasks);
-    const spendTaskShare = Math.round((bySpend.tasks / MOCK_FN_TASKS) * 100);
-    const spendShare = Math.round((bySpend.monthly / MOCK_FN_TOTAL) * 100);
-    const drop = Math.round((1 - MOCK_ORG.perTask / MOCK_ORG.perTaskPrev) * 100);
-    return (
-        <div className="v-tm-hero">
-            <section className="rdx-card v-tm-herotile">
-                <div className="rdx-label">$ / task · org-wide</div>
-                <div className="rdx-num v-tm-herostat">{fmtUsd(MOCK_ORG.perTask)}</div>
-                <div className="v-tm-trend down"><span className="arr">▼</span> {drop}% vs 90d ago · was {fmtUsd(MOCK_ORG.perTaskPrev)}</div>
-            </section>
-            <section className="rdx-card v-tm-herotile">
-                <div className="rdx-label">tasks shipped · / mo</div>
-                <div className="rdx-num v-tm-herostat">{fmtCount(MOCK_ORG.tasksPerMo)}</div>
-                <div className="v-tm-trend"><span className="rdx-led accent" /> {Math.round(MOCK_ORG.firstPass * 100)}% done first-pass</div>
-            </section>
-            <section className="rdx-card v-tm-herotile">
-                <div className="rdx-label">people active · this week</div>
-                <div className="rdx-num v-tm-herostat">{Math.round(MOCK_ORG.activePct * 100)}<small>%</small></div>
-                <div className="v-tm-trend up"><span className="arr">▲</span> from {Math.round(MOCK_ORG.activePctPrev * 100)}% · 8 weeks ago</div>
-            </section>
-            <p className="v-tm-hero-cap rdx-label">
-                <b>{byTasks.name}</b> does <b>{topTaskShare}%</b> of the company's AI-assisted work at {fmtUsd(topPerTask)}/task &mdash; more than engineering.
-                <b> {bySpend.name}</b> is {spendTaskShare}% of the tasks but {spendShare}% of the spend. A cost report wouldn't tell you that.
-            </p>
-        </div>
-    );
-}
-
 // ---- demo hero (dev-adoption tiles) ---------------------------------------
 /** Four adoption tiles for the `?demo` board - active seats, active-days,
- *  routable spend, workflows ready to spread. Replaces the exec HeroStrip. */
+ *  routable spend, workflows ready to spread. */
 function DemoHero() {
     const routablePct = Math.round((DEMO_ORG.routableUsd / DEMO_ORG.spendUsd) * 100);
     const activeDelta = Math.round((DEMO_ORG.activePct - DEMO_ORG.activePctPrev) * 100);
@@ -671,23 +348,18 @@ function DemoAdoptionRow() {
     );
 }
 
-// ---- tabbed, selectable roster --------------------------------------------
+// ---- tabbed, selectable roster (demo board) --------------------------------
 function RosterCard({
-    tab, onTab, entities, loading, selected, onToggle, midHead, orgMode = false, demo = false,
+    tab, onTab, entities, selected, onToggle, midHead,
 }: {
     tab: RosterTab; onTab: (t: RosterTab) => void;
-    entities: RosterEntity[]; loading: boolean;
+    entities: RosterEntity[];
     selected: ReadonlySet<string>; onToggle: (id: string) => void;
-    midHead: string; orgMode?: boolean; demo?: boolean;
+    midHead: string;
 }) {
-    // orgMode (the paid teaser) frames the members tab as company FUNCTIONS.
-    const tabLabel = (t: RosterTab) => (orgMode && t === "members" ? "functions" : TABS.find((x) => x.id === t)?.label ?? t);
-    const noun = tab === "members" ? (orgMode ? "function" : demo ? "seat" : "member") : tab === "projects" ? "project" : "harness";
-    // Members/functions are the org roster - lead with token consumption. In the
-    // demo, seats lead with sessions (no per-person spend → no ranking).
-    const tokenLed = tab === "members" && !demo;
+    const noun = tab === "members" ? "seat" : tab === "projects" ? "project" : "harness";
     // Demo seats are anonymized + unranked - say so where a leaderboard is implied.
-    const headNote = demo && tab === "members"
+    const headNote = tab === "members"
         ? "aggregate view · no per-person ranking"
         : selected.size >= 1 ? `${selected.size} selected` : "click rows · compare 2+";
     return (
@@ -696,104 +368,51 @@ function RosterCard({
                 <div className="v-tm-tabs">
                     {TABS.map((t) => (
                         <button key={t.id} type="button" className={t.id === tab ? "on" : ""} onClick={() => onTab(t.id)}>
-                            {tabLabel(t.id)}
+                            {t.label}
                         </button>
                     ))}
                 </div>
                 <span className="rdx-label">{headNote}</span>
             </div>
             <div className="nf-list">
-                {orgMode
-                    ? <OutcomeTable entities={entities} loading={loading} selected={selected} onToggle={onToggle} />
-                    : (
-                        <table className="v-team-rt">
-                            <thead>
-                                <tr>
-                                    <th>{noun}</th>
-                                    <th>{midHead}</th>
-                                    <th className="r">model</th>
-                                    <th className="r">{tokenLed ? "tokens" : "sessions"}</th>
-                                    <th className="r">cost</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {entities.length === 0 ? (
-                                    <tr><td colSpan={5} className="rdx-label">{loading ? "loading…" : `no ${noun}s yet`}</td></tr>
-                                ) : entities.map((e) => (
-                                    <tr key={e.id} className={`v-tm-row${selected.has(e.id) ? " sel" : ""}`} onClick={() => onToggle(e.id)}>
-                                        <td>
-                                            <span className="v-team-who">
-                                                <span className={`v-tm-check${selected.has(e.id) ? " on" : ""}`} />
-                                                <span className={`dot${e.online ? " on" : ""}`} />
-                                                <span className="h">{e.label}</span>
-                                            </span>
-                                        </td>
-                                        <td>
-                                            {e.spark.length > 0 ? (
-                                                <span className="v-team-spark">
-                                                    {e.spark.map((lvl, i) => <i key={i} className={lvl ? `lvl-${lvl}` : ""} />)}
-                                                </span>
-                                            ) : (e.mid ?? <span className="rdx-dim">-</span>)}
-                                        </td>
-                                        <td className="r"><span className="v-team-model">{e.model ? shortModel(e.model) : "-"}</span></td>
-                                        <td className="r v-team-num">{tokenLed ? fmtBig(e.tokens) : fmtCount(e.sessions)}</td>
-                                        <td className="r v-team-num">{e.cost > 0 ? fmtUsd(e.cost) : "-"}</td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    )}
+                <table className="v-team-rt">
+                    <thead>
+                        <tr>
+                            <th>{noun}</th>
+                            <th>{midHead}</th>
+                            <th className="r">model</th>
+                            <th className="r">sessions</th>
+                            <th className="r">cost</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {entities.length === 0 ? (
+                            <tr><td colSpan={5} className="rdx-label">{`no ${noun}s yet`}</td></tr>
+                        ) : entities.map((e) => (
+                            <tr key={e.id} className={`v-tm-row${selected.has(e.id) ? " sel" : ""}`} onClick={() => onToggle(e.id)}>
+                                <td>
+                                    <span className="v-team-who">
+                                        <span className={`v-tm-check${selected.has(e.id) ? " on" : ""}`} />
+                                        <span className={`dot${e.online ? " on" : ""}`} />
+                                        <span className="h">{e.label}</span>
+                                    </span>
+                                </td>
+                                <td>
+                                    {e.spark.length > 0 ? (
+                                        <span className="v-team-spark">
+                                            {e.spark.map((lvl, i) => <i key={i} className={lvl ? `lvl-${lvl}` : ""} />)}
+                                        </span>
+                                    ) : (e.mid ?? <span className="rdx-dim">-</span>)}
+                                </td>
+                                <td className="r"><span className="v-team-model">{e.model ? shortModel(e.model) : "-"}</span></td>
+                                <td className="r v-team-num">{fmtCount(e.sessions)}</td>
+                                <td className="r v-team-num">{e.cost > 0 ? fmtUsd(e.cost) : "-"}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
             </div>
         </section>
-    );
-}
-
-/** The org scoreboard table - output-led (tasks), spend demoted to the last
- *  column. "Tasks" = AI-assisted work items, comparable across all functions. */
-function OutcomeTable({
-    entities, loading, selected, onToggle,
-}: { entities: RosterEntity[]; loading: boolean; selected: ReadonlySet<string>; onToggle: (id: string) => void }) {
-    const ranked = [...entities].sort((a, b) => (b.outcome?.taskShare ?? 0) - (a.outcome?.taskShare ?? 0));
-    return (
-        <table className="v-team-rt v-tm-out">
-            <thead>
-                <tr>
-                    <th>function</th>
-                    <th>share of AI work</th>
-                    <th className="r">tasks/mo</th>
-                    <th className="r">$/task</th>
-                    <th className="r">first-pass</th>
-                    <th className="r dim">$/mo</th>
-                </tr>
-            </thead>
-            <tbody>
-                {ranked.length === 0 ? (
-                    <tr><td colSpan={6} className="rdx-label">{loading ? "loading…" : "no functions yet"}</td></tr>
-                ) : ranked.map((e) => {
-                    const o = e.outcome;
-                    return (
-                        <tr key={e.id} className={`v-tm-row${selected.has(e.id) ? " sel" : ""}`} onClick={() => onToggle(e.id)}>
-                            <td>
-                                <span className="v-team-who">
-                                    <span className={`v-tm-check${selected.has(e.id) ? " on" : ""}`} />
-                                    <span className="h">{e.label}</span>
-                                </span>
-                            </td>
-                            <td>
-                                <span className="v-tm-share">
-                                    <span className="v-tm-bar"><span style={{ width: `${Math.max(3, (o?.taskShare ?? 0) * 100)}%`, background: "var(--accent)" }} /></span>
-                                    <b>{Math.round((o?.taskShare ?? 0) * 100)}%</b>
-                                </span>
-                            </td>
-                            <td className="r v-team-num">{fmtCount(o?.tasks ?? 0)}</td>
-                            <td className="r v-team-num">{fmtUsd(o?.perTask ?? 0)}</td>
-                            <td className="r v-team-num">{Math.round((o?.firstPass ?? 0) * 100)}%</td>
-                            <td className="r v-team-num dim">{fmtUsd(e.cost)}</td>
-                        </tr>
-                    );
-                })}
-            </tbody>
-        </table>
     );
 }
 
@@ -839,14 +458,12 @@ function ComparePanel({ entities, onClear }: { entities: RosterEntity[]; onClear
     );
 }
 
-function Board({ days: liveDays, teaser = false, demo = false }: { days: ReadonlyArray<WrappedUsageDay>; teaser?: boolean; demo?: boolean }) {
+/** The seeded `?demo` board - fabricated data only, no live queries. */
+function DemoBoard() {
     const [daily, setDaily] = useState<DailyRange>(30);
     const [weeks, setWeeks] = useState<WeeklyRange>(8);
 
-    // Both the teaser and the demo run on fabricated, self-contained data (no
-    // live queries) - the difference is framing, not the data source.
-    const mock = teaser || demo;
-    const days = demo ? DEMO_DAYS : teaser ? MOCK_DAYS : liveDays;
+    const days = DEMO_DAYS;
     const dWin = useMemo(() => days.slice(-daily), [days, daily]);
     const wAll = useMemo(() => weekly(days), [days]);
     const wWin = useMemo(
@@ -869,18 +486,11 @@ function Board({ days: liveDays, teaser = false, demo = false }: { days: Readonl
     const turnsD = dWin.map((d) => d.turns);
     const sum = (a: ReadonlyArray<number>) => a.reduce((s, n) => s + n, 0);
 
-    // roster + channels. In teaser mode everything is mock (no live queries) so
-    // the paywall background never leaks real numbers and never depends on the
-    // daemon being up.
-    const sessQ = useQuery({ queryKey: ["sessions", "roster"], queryFn: () => api.sessions({ limit: 500 }), enabled: !mock });
-    const sessions = sessQ.data?.sessions ?? [];
-    const costQ = useQuery({ queryKey: ["cost", "models"], queryFn: () => api.costModels(), enabled: !mock });
-    const channels = demo ? DEMO_CHANNELS : teaser ? MOCK_CHANNELS : (costQ.data?.rows ?? []).filter((r) => r.cost_usd > 0).slice(0, 8);
-    const costTotal = demo ? DEMO_ORG.spendUsd : teaser ? MOCK_COST_TOTAL : (costQ.data?.total_cost_usd || channels.reduce((s, r) => s + r.cost_usd, 0) || 1);
+    const channels = DEMO_CHANNELS;
+    const costTotal = DEMO_ORG.spendUsd;
 
     // tabbed roster (projects | members | harnesses) + side-by-side compare.
-    // Teaser opens on members (the company org roster, ranked by tokens).
-    const [tab, setTab] = useState<RosterTab>(teaser ? "members" : "projects");
+    const [tab, setTab] = useState<RosterTab>("projects");
     const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
     const switchTab = (t: RosterTab) => { setTab(t); setSelected(new Set()); };
     const toggleSel = (id: string) => setSelected((prev) => {
@@ -888,33 +498,17 @@ function Board({ days: liveDays, teaser = false, demo = false }: { days: Readonl
         next.has(id) ? next.delete(id) : next.add(id);
         return next;
     });
-    // Members are public gists - only fetch when that tab is opened (live only).
-    const memQ = useQuery({ queryKey: ["members"], queryFn: () => fetchMembers(), enabled: !mock && tab === "members", staleTime: 300_000 });
-    const projects = useMemo(() => demo ? DEMO_PROJECTS : teaser ? MOCK_PROJECTS : buildProjects(sessions), [demo, teaser, sessions]);
-    const harnesses = useMemo(() => demo ? DEMO_HARNESSES : teaser ? MOCK_HARNESSES : harnessEntities(buildRoster(sessions)), [demo, teaser, sessions]);
-    const members = useMemo(() => demo ? DEMO_MEMBERS : teaser ? MOCK_MEMBERS : memberEntities(memQ.data ?? []), [demo, teaser, memQ.data]);
-    const entities = tab === "projects" ? projects : tab === "members" ? members : harnesses;
-    const rosterLoading = mock ? false : tab === "members" ? memQ.isLoading : sessQ.isLoading;
-    const midHead = tab === "members" ? (teaser ? "headcount" : "harnesses") : "last 7d";
+    const entities = tab === "projects" ? DEMO_PROJECTS : tab === "members" ? DEMO_MEMBERS : DEMO_HARNESSES;
+    const midHead = tab === "members" ? "harnesses" : "last 7d";
     const selectedEntities = entities.filter((e) => selected.has(e.id));
-
-    // Teaser: auto-select the top 2 of the current tab so the blurred compare
-    // panel behind the paywall shows a head-to-head (two engineers by default).
-    useEffect(() => {
-        if (teaser && selected.size === 0 && entities.length >= 2) {
-            setSelected(new Set([entities[0].id, entities[1].id]));
-        }
-    }, [teaser, selected.size, entities]);
 
     return (
         <>
             <header className="v-tm-mast">
                 <div className="v-team-org">
-                    <span className="name">
-                        {demo ? <><b>{DEMO_ORG.label}</b> team adoption</> : <><b>ax</b> team metrics</>}
-                    </span>
-                    <span className="ring">{demo ? "team rollup" : "local graph"}</span>
-                    {demo && <span className="v-tm-demo-badge">demo · sample data</span>}
+                    <span className="name"><b>{DEMO_ORG.label}</b> team adoption</span>
+                    <span className="ring">team rollup</span>
+                    <span className="v-tm-demo-badge">demo · sample data</span>
                 </div>
                 <div className="v-tm-ranges">
                     <Toggle label="daily" values={DAILY} value={daily} onChange={(v) => setDaily(v)} suffix="d" />
@@ -922,15 +516,10 @@ function Board({ days: liveDays, teaser = false, demo = false }: { days: Readonl
                 </div>
             </header>
             <p className="rdx-label v-tm-sub">
-                {demo
-                    ? "How AI adoption is spreading across the team - active seats, routable spend, and the skills & workflows that land. Every number is a team-level aggregate; no per-person ranking."
-                    : teaser
-                        ? "Return on every agent dollar - what each team ships, what it costs per task, and who's actually adopting."
-                        : "Where your agent spend goes and which skills & workflows get adopted. Compare projects, harnesses, or community members side-by-side - pick 2+ rows."}
+                How AI adoption is spreading across the team - active seats, routable spend, and the skills & workflows that land. Every number is a team-level aggregate; no per-person ranking.
             </p>
 
-            {teaser && <HeroStrip />}
-            {demo && <DemoHero />}
+            <DemoHero />
 
             <div className="v-tm-charts">
                 <ChartCard title="SESSIONS / DAY" range={`last ${daily}d`} total={fmtCount(sum(sessionsD))}
@@ -944,18 +533,16 @@ function Board({ days: liveDays, teaser = false, demo = false }: { days: Readonl
             </div>
 
             <div className="v-tm-grid">
-                <RosterCard tab={tab} onTab={switchTab} entities={entities} loading={rosterLoading}
-                    selected={selected} onToggle={toggleSel} midHead={midHead} orgMode={teaser} demo={demo} />
+                <RosterCard tab={tab} onTab={switchTab} entities={entities}
+                    selected={selected} onToggle={toggleSel} midHead={midHead} />
 
                 <section className="rdx-card v-mc-split">
                     <div className="v-mc-meta rdx-label">
-                        <span style={{ color: "var(--pri)" }}>{demo ? "MODEL SPEND · this month" : "MODEL CHANNELS · 365d"}</span>
-                        <span>{demo ? `${fmtUsd(costTotal)}/mo · ${fmtUsd(DEMO_ORG.routableUsd)} routable` : `~${fmtUsd(costTotal)} total`}</span>
+                        <span style={{ color: "var(--pri)" }}>MODEL SPEND · this month</span>
+                        <span>{fmtUsd(costTotal)}/mo · {fmtUsd(DEMO_ORG.routableUsd)} routable</span>
                     </div>
                     <div className="nf-list">
-                        {channels.length === 0 ? (
-                            <span className="rdx-label" style={{ marginTop: 8 }}>{costQ.isLoading ? "loading…" : "no cost data"}</span>
-                        ) : channels.map((r) => {
+                        {channels.map((r) => {
                             const share = r.cost_usd / costTotal;
                             const c = toneFor(r.model);
                             return (
@@ -974,7 +561,7 @@ function Board({ days: liveDays, teaser = false, demo = false }: { days: Readonl
                 </section>
             </div>
 
-            {demo && <DemoAdoptionRow />}
+            <DemoAdoptionRow />
 
             <ComparePanel entities={selectedEntities} onClear={() => setSelected(new Set())} />
         </>
@@ -990,113 +577,152 @@ function Notice({ title, detail }: { title: string; detail: string }) {
     );
 }
 
-// cal.com booking - the single source of truth for the sales CTA.
-const BOOK_A_CALL_URL = "https://cal.com/necmttn/30min";
+// ---- the real team boards (GET /api/team) ----------------------------------
 
-const Check = () => (
-    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" style={{ flex: "none" }}>
-        <path d="M3 8.5l3 3 7-8" fill="none" stroke="var(--accent)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-);
+/** Renders the daemon's TeamBoards rollup: adoption hero tiles, the skill
+ *  matrix, and spend/model-mix - or clean loading / empty / error states. */
+function TeamBoardsPanel() {
+    const q = useQuery({ queryKey: ["team", "boards"], queryFn: () => api.team() });
 
-/** The fake paywall: a glass card over the blurred team board. The paid pitch
- *  is "ax for teams" for engineering leadership - cost reduction (CTO/CEO) and
- *  skill/workflow adoption (EM) - gated behind a sales call. */
-function TeamPaywall() {
+    if (q.isLoading && !q.data) {
+        return <Notice title="loading team boards" detail="Fetching the org rollup from your local daemon." />;
+    }
+    if (q.error && !q.data) {
+        const msg = String((q.error as Error)?.message ?? q.error);
+        return (
+            <Notice title="team boards unavailable"
+                detail={`${msg} - the /api/team endpoint needs a current ax daemon. Start it with \`ax serve\`, and push snapshots with \`ax team push\`.`} />
+        );
+    }
+    if (!q.data) {
+        return <Notice title="no team data yet" detail="No snapshots pushed. Run `ax team push` from a repo bound to your team." />;
+    }
+
+    const boards = q.data;
+    const view = buildTeamView(boards);
+    if (view.empty) {
+        return (
+            <Notice title="no team data yet"
+                detail="No dev snapshots in the rollup. Each teammate runs `ax team push` from a bound repo; the boards fill in as snapshots land." />
+        );
+    }
+
+    const maxSkillDevs = Math.max(...view.skills.map((s) => s.devs), 1);
     return (
-        <div className="v-tm-paywall" role="dialog" aria-label="ax for teams">
-            <div className="v-tm-paywall-card rdx-card">
-                <div className="v-tm-paywall-kicker rdx-label">
-                    <span className="rdx-led accent" /> ax for teams · private beta
+        <>
+            <header className="v-tm-mast">
+                <div className="v-team-org">
+                    <span className="name"><b>ax</b> team boards</span>
+                    <span className="ring">org rollup</span>
                 </div>
-                <h2 className="v-tm-paywall-h">Who's shipping<br />with the&nbsp;agents</h2>
-                <p className="v-tm-paywall-lede">
-                    Not what AI costs &mdash; what it <i>returns</i>. Work shipped, $/task and
-                    adoption per team, from real sessions.
-                </p>
-                <ul className="v-tm-paywall-feats">
-                    <li><Check /> Output per team &mdash; share of AI work, $/task <span className="v-tm-persona">CTO · CEO</span></li>
-                    <li><Check /> Adoption &mdash; the skills &amp; workflows that land <span className="v-tm-persona">EM</span></li>
-                    <li><Check /> Your daemon &mdash; org rollup, nothing leaves</li>
-                </ul>
-                <div className="v-tm-paywall-cta">
-                    <a className="v-tm-paywall-btn" href={BOOK_A_CALL_URL} target="_blank" rel="noopener noreferrer">
-                        Book a 30-min walkthrough →
-                    </a>
-                </div>
-                <div className="v-tm-paywall-foot rdx-label">live sample · your own daemon · no card</div>
+            </header>
+            <p className="rdx-label v-tm-sub">
+                {view.activation} - aggregated from pushed snapshots. Anonymous pushes count toward every board; cost only where a dev shares it.
+            </p>
+
+            <div className="v-tm-hero v-tm-hero--demo">
+                {view.hero.map((t) => (
+                    <section className="rdx-card v-tm-herotile" key={t.label}>
+                        <div className="rdx-label">{t.label}</div>
+                        <div className="rdx-num v-tm-herostat">{t.value}{t.small ? <small> {t.small}</small> : null}</div>
+                        <div className="v-tm-trend"><span className="rdx-led accent" /> {t.sub}</div>
+                    </section>
+                ))}
             </div>
-        </div>
+
+            <div className="v-tm-grid">
+                <section className="rdx-card v-team-roster">
+                    <div className="v-tm-roster-head">
+                        <div className="rdx-label" style={{ color: "var(--pri)" }}>SKILL MATRIX · devs using</div>
+                        <span className="rdx-label">{view.skills.length} skills</span>
+                    </div>
+                    <div className="nf-list">
+                        <table className="v-team-rt">
+                            <thead>
+                                <tr>
+                                    <th>skill</th>
+                                    <th>devs</th>
+                                    <th className="r">runs</th>
+                                    <th className="r">sessions</th>
+                                    <th className="r">median runs</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {view.skills.length === 0 ? (
+                                    <tr><td colSpan={5} className="rdx-label">no skill invocations pushed yet</td></tr>
+                                ) : view.skills.map((s) => (
+                                    <tr key={s.skill}>
+                                        <td><span className="v-team-who"><span className="h">{s.skill}</span></span></td>
+                                        <td>
+                                            <span className="v-tm-share">
+                                                <span className="v-tm-bar"><span style={{ width: `${Math.max(6, (s.devs / maxSkillDevs) * 100)}%`, background: "var(--accent)" }} /></span>
+                                                <b>{s.devs}</b>
+                                            </span>
+                                        </td>
+                                        <td className="r v-team-num">{fmtCount(s.runs)}</td>
+                                        <td className="r v-team-num">{fmtCount(s.sessions)}</td>
+                                        <td className="r v-team-num">{fmtBig(s.medianRuns)}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <section className="rdx-card v-mc-split">
+                    <div className="v-mc-meta rdx-label">
+                        <span style={{ color: "var(--pri)" }}>MODEL MIX · by tokens</span>
+                        <span>{boards.spend.costContributors > 0 ? `${fmtUsd(boards.spend.costUsd)} total` : "no cost data"}</span>
+                    </div>
+                    <div className="nf-list">
+                        {view.models.length === 0 ? (
+                            <span className="rdx-label" style={{ marginTop: 8 }}>no model usage pushed yet</span>
+                        ) : view.models.map((r) => {
+                            const c = toneFor(r.model);
+                            return (
+                                <div className="v-mc-split-row" key={r.model}>
+                                    <span style={{ color: "var(--pri)" }}>
+                                        <span className="nf-swatch" style={{ background: c }} />{shortModel(r.model)}
+                                    </span>
+                                    <span>{Math.round(r.share * 100)}% · {r.tokens} tok{r.cost !== "-" ? ` · ${r.cost}` : ""}</span>
+                                    <span className="segwrap">
+                                        <span className="v-tm-bar"><span style={{ width: `${Math.max(2, r.share * 100)}%`, background: c }} /></span>
+                                    </span>
+                                </div>
+                            );
+                        })}
+                        <p className="rdx-label" style={{ margin: "10px 2px 2px", lineHeight: 1.5, textTransform: "none", letterSpacing: 0 }}>
+                            tokens · {view.tokens.prompt} prompt · {view.tokens.completion} completion · {view.tokens.total} total
+                            <br />
+                            tools · {view.efficiency.toolCalls} calls · {view.efficiency.failureRate} fail · {view.efficiency.verificationShare} verification
+                            {view.costNote ? <><br />cost · {view.costNote}</> : null}
+                        </p>
+                    </div>
+                </section>
+            </div>
+        </>
     );
 }
 
-/**
- * Team Metrics is a fake-paywalled feature in PRODUCTION builds: the real
- * community-compare board renders blurred behind a sales CTA. Dev keeps full
- * access (so the feature is buildable); a `?unlock` query or the
- * `ax:team-unlock` localStorage flag also bypasses for demos.
- */
-function isUnlocked(): boolean {
-    if (import.meta.env.DEV) return true;
-    if (typeof window === "undefined") return false;
-    if (new URLSearchParams(window.location.search).has("unlock")) return true;
-    try { return window.localStorage.getItem("ax:team-unlock") === "1"; } catch { return false; }
-}
-// `?paywall` forces the locked state even in dev, to preview the paywall.
-function isForcedLock(): boolean {
-    return typeof window !== "undefined" && new URLSearchParams(window.location.search).has("paywall");
-}
-// `?demo` renders the clean, fully-visible, seeded dev-adoption board - no blur,
-// no paywall, no live queries. It's the public "click around" surface linked
-// from /design-partners, distinct from the locked sales teaser and the live
-// (DEV/`?unlock`) board.
+// `?demo` renders the clean, fully-visible, seeded dev-adoption board - no
+// live queries. It's the public "click around" surface linked (and iframed)
+// from /design-partners, distinct from the live daemon-backed board.
 function isDemo(): boolean {
     return typeof window !== "undefined" && new URLSearchParams(window.location.search).has("demo");
 }
 
 export function TeamMetricsRoute() {
-    // Demo wins over everything: it's the shareable, self-contained board.
+    // Demo wins: it's the shareable, self-contained board.
     if (isDemo()) {
         return (
             <div className="v-tm">
-                <Board days={DEMO_DAYS} demo />
+                <DemoBoard />
             </div>
         );
     }
-    const locked = isForcedLock() || !isUnlocked();
-    // Locked: the blurred teaser is a self-contained mock org board - no live
-    // queries, so it always renders fully (daemon up or down) and never leaks
-    // the operator's real numbers behind the glass.
-    if (locked) {
-        return (
-            <div className="v-tm v-tm-locked">
-                <div className="v-tm-blur" aria-hidden="true" inert>
-                    <div className="v-tm"><Board days={MOCK_DAYS} teaser /></div>
-                </div>
-                <TeamPaywall />
-            </div>
-        );
-    }
-    return <UnlockedBoard />;
-}
-
-/** The real, unlocked feature - live local + community data. */
-function UnlockedBoard() {
-    const q = useQuery({ queryKey: ["wrapped"], queryFn: () => api.wrapped() });
-    const data = q.data ?? null;
-    // Render bare: the studio root Shell already wraps non-instrument routes in
-    // the InstrumentShell rail + live/offline chrome (see Shell.tsx).
     return (
         <div className="v-tm">
-            {q.isLoading && !data ? (
-                <Notice title="building profile" detail="Cold graph scans can take about 20s on large local datasets." />
-            ) : q.error && !data ? (
-                <Notice title="team metrics failed" detail={String((q.error as Error)?.message ?? q.error)} />
-            ) : data?.usage ? (
-                <Board days={data.usage.days ?? []} />
-            ) : (
-                <Notice title="profile not ready" detail="Ingest more sessions to build the team metrics board." />
-            )}
+            <TeamBoardsPanel />
         </div>
     );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
     },
     "apps/axctl": {
       "name": "axctl",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "bin": {
         "axctl": "./bin/axctl",
       },
@@ -133,6 +133,7 @@
       "name": "@ax/studio",
       "version": "0.15.0",
       "dependencies": {
+        "@ax/community-compile": "workspace:*",
         "@ax/foresight": "workspace:*",
         "@ax/lib": "workspace:*",
         "@ax/recap-deck": "workspace:*",
@@ -190,6 +191,7 @@
       "name": "@ax/community-compile",
       "version": "0.0.0",
       "devDependencies": {
+        "@ax/lib": "workspace:*",
         "@types/bun": "catalog:",
         "typescript": "catalog:",
       },

--- a/docs/superpowers/plans/2026-07-17-team-dashboard-ui.md
+++ b/docs/superpowers/plans/2026-07-17-team-dashboard-ui.md
@@ -1,0 +1,120 @@
+# Team Dashboard UI (studio /team real boards) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the studio `/team` page to the daemon `GET /api/team?org=<org>` → `TeamBoards` endpoint and render real adoption / skill-matrix / spend / cold-start panels, removing the paywall teaser + harnesses-as-team placeholder (keep `?demo` - the marketing site iframes it).
+
+**Architecture:** A pure view-model module (`team-boards-model.ts`, bun:test-covered) maps `TeamBoards` → display rows; `team-metrics.tsx` gains a `TeamBoardsView` that `useQuery`s `api.team()` and renders with the file's existing `.v-tm-*` / `.v-team-*` / `.v-mc-*` / `.rdx-*` design system. Mock teaser (MOCK_*, HeroStrip, TeamPaywall, OutcomeTable, unlock/paywall gating) and the live harnesses-as-team board (UnlockedBoard + live builders) are deleted; the demo (`?demo`) board stays byte-identical visually.
+
+**Tech Stack:** React 19 + @tanstack/react-query, bun:test, TypeScript strict, vite (daemon target proxies `/api` → `AX_DAEMON_PORT`).
+
+## Global Constraints
+
+- Scope IN: `apps/studio/src/instrument/team-metrics.tsx`, `apps/studio/src/api.ts`, `apps/studio/package.json` (new workspace dep), new `apps/studio/src/instrument/team-boards-model.ts` + test.
+- Scope OUT: no backend/route changes, no `compileTeam`/`TeamBoards` changes, no CSS/design-system additions, no site changes.
+- `?demo` path MUST keep working (iframed by `apps/site/app/routes/teams.tsx`).
+- Import `TeamBoards` type-only from `@ax/community-compile/team` (exports map: `./team` → `src/team-compile.ts`).
+- Respect null cost: `spend.costUsd` meaningful only when `spend.costContributors > 0`; per-model cost only when `row.costContributors > 0`.
+- No hardcoded colors - reuse `var(--accent)`, `var(--pri)`, `var(--gold)`, `var(--violet)`, `var(--blue)`, existing `toneFor`.
+- Gates: `bun run typecheck` exit 0 (real `$?`), `bun test apps/studio` green, described render verification.
+- One conventional commit at the end; `git add -A ':!BRIEF.md' ':!REPORT.md'`.
+
+---
+
+### Task 1: Dep + api client `team()` call
+
+**Files:**
+- Modify: `apps/studio/package.json` (add `"@ax/community-compile": "workspace:*"` to dependencies)
+- Modify: `apps/studio/src/api.ts`
+
+**Interfaces:**
+- Produces: `api.team(org?: string): Promise<TeamBoards>` - GET `/api/team` (append `?org=<encoded>` when org given), via existing `jsonFetch` (same pattern as `graphExplorer`).
+
+- [ ] **Step 1:** Add dep to `apps/studio/package.json` dependencies:
+```json
+"@ax/community-compile": "workspace:*",
+```
+- [ ] **Step 2:** Run `bun install` from worktree root. Expected: lockfile updates, exit 0.
+- [ ] **Step 3:** In `api.ts` add near other type imports:
+```ts
+import type { TeamBoards } from "@ax/community-compile/team";
+```
+and inside the `api` object (near `costModels`):
+```ts
+/** Team boards - aggregate of pushed team snapshots (LOCAL daemon rollup). */
+team: (org?: string): Promise<TeamBoards> =>
+    jsonFetch(org ? `/api/team?org=${encodeURIComponent(org)}` : "/api/team"),
+```
+- [ ] **Step 4:** `bun run typecheck` at repo root. Expected exit 0.
+
+### Task 2: Pure view-model + tests (TDD, dispatchable)
+
+**Files:**
+- Create: `apps/studio/src/instrument/team-boards-model.ts`
+- Test: `apps/studio/src/instrument/team-boards-model.test.ts`
+
+**Interfaces:**
+- Consumes: `TeamBoards` from `@ax/community-compile/team`.
+- Produces:
+```ts
+export interface TeamHeroTile { label: string; value: string; small?: string; sub: string; tone: "up" | "flat" }
+export interface TeamSkillView { skill: string; devs: number; runs: number; sessions: number; medianRuns: number; devShare: number /* 0-1 of max devs */ }
+export interface TeamModelView { model: string; tokens: string; share: number /* 0-1 */; cost: string /* "-" when no contributors */ }
+export interface TeamBoardsView {
+    empty: boolean;                 // contributing === 0
+    activation: string;             // "3 devs contributing · 2 identified · 1 anon"
+    hero: TeamHeroTile[];           // devs / sessions / active days / spend
+    skills: TeamSkillView[];
+    models: TeamModelView[];
+    tokens: { prompt: string; completion: string; total: string };
+    efficiency: { toolCalls: string; failureRate: string; verificationShare: string };
+    costNote: string | null;        // "2 of 3 devs report cost" | "no cost data pushed" (when contributors < contributing)
+}
+export function buildTeamView(b: TeamBoards): TeamBoardsView
+```
+Formatting: reuse local copies of fmt helpers (fmtUsd/fmtBig semantics identical to team-metrics.tsx; export them from the model module and have team-metrics.tsx import them to stay DRY - move `fmtUsd`/`fmtBig` here).
+
+Behavior specs (each a test):
+1. `empty` true iff `coverage.contributing === 0`.
+2. Activation line: contributing 3, identified 2 → `"3 devs contributing · 2 identified · 1 anon"`; identified === contributing → no anon segment (`"3 devs contributing · 3 identified"`); contributing 1 → `"1 dev contributing …"` singular.
+3. Hero tiles: devs tile value `String(contributing)`; sessions tile value fmtBig(total) sub `avg N/dev` (average rounded to 1 decimal, trailing `.0` stripped); active-days same; spend tile value fmtUsd(costUsd) when `costContributors > 0`, else value `"-"` sub `"no cost data pushed"`.
+4. `costNote`: null when `costContributors === contributing && contributing > 0`; `"no cost data pushed"` when 0 contributors; `"2 of 3 devs report cost"` otherwise.
+5. Skills: `devShare = devs / max(devs across rows)` (1 for the top row; rows already sorted by compileTeam - preserve order).
+6. Models: `share` passthrough; `cost` = `"-"` when `row.costContributors === 0` else fmtUsd; `tokens` = fmtBig.
+7. Efficiency: percentages rendered `Math.round(rate*100) + "%"`.
+
+- [ ] **Step 1:** Write `team-boards-model.test.ts` with a `boards()` fixture factory (plain object literal implementing `TeamBoards`) and the 7 specs above as failing tests.
+- [ ] **Step 2:** Run `bun test apps/studio/src/instrument/team-boards-model.test.ts` → FAIL (module missing).
+- [ ] **Step 3:** Implement `team-boards-model.ts` (pure, no react import).
+- [ ] **Step 4:** Run same test → PASS.
+
+### Task 3: Rewrite team-metrics.tsx
+
+**Files:**
+- Modify: `apps/studio/src/instrument/team-metrics.tsx`
+
+**Interfaces:**
+- Consumes: `api.team()` (Task 1), `buildTeamView`, `fmtUsd`, `fmtBig` (Task 2).
+- Produces: `TeamMetricsRoute` (router import unchanged).
+
+- [ ] **Step 1:** Delete: `MOCK_*` datasets + `mockDays`, `HeroStrip`, `TeamPaywall`, `OutcomeTable`, `BOOK_A_CALL_URL`, `Check`, `isUnlocked`, `isForcedLock`, `UnlockedBoard`, live builders (`buildRoster`, `buildProjects`, `harnessEntities`, `memberEntities`, `HarnessRow`), `fetchMembers` import, `orgMode`/`teaser` branches in `Board`/`RosterCard`, live `useQuery`s (`sessQ`, `costQ`, `memQ`), `outcome` field on `RosterEntity`, teaser auto-select `useEffect`. Move `fmtUsd`/`fmtBig` imports to the model module. `Board` becomes demo-only (`demo` prop dropped, always demo data).
+- [ ] **Step 2:** Add `TeamBoardsView` component: `useQuery({ queryKey: ["team", "boards"], queryFn: () => api.team() })`; states:
+  - loading → existing `Notice` card ("loading team boards");
+  - error → `Notice` ("team boards unavailable", message + hint: needs `ax serve` with the team endpoint);
+  - `view.empty` → `Notice` ("no team data yet", "No snapshots pushed. Run `ax team push` from a bound repo …");
+  - data → mast (`.v-tm-mast`/`.v-team-org`, ring "org rollup") + activation line (`.rdx-label .v-tm-sub`) + hero tiles (`.v-tm-hero`/`.v-tm-herotile`) + grid (`.v-tm-grid`): skill-matrix table (`.rdx-card .v-team-roster`, `table.v-team-rt` cols: skill / devs(+bar `.v-tm-bar` width devShare) / runs / sessions / median) and model-mix card (`.rdx-card .v-mc-split` rows like MODEL CHANNELS: swatch `toneFor(model)`, share % · tokens · cost, bar) + tokens/efficiency footer rows inside the spend card (`.v-mc-meta` labels: prompt/completion/total; tool calls / failure rate / verification share).
+- [ ] **Step 3:** `TeamMetricsRoute`: `isDemo()` → demo Board (unchanged markup); else `<div className="v-tm"><TeamBoardsView /></div>`.
+- [ ] **Step 4:** `bun run typecheck` exit 0; `bun test apps/studio` green.
+- [ ] **Step 5:** Commit `feat(studio): render real team boards on /team` (single commit at END after Task 4 verification - do not commit mid-way; brief demands one commit).
+
+### Task 4: Render verification
+
+- [ ] **Step 1:** Stub daemon: write scratchpad `team-stub.ts` - `Bun.serve` on 17399 answering `GET /api/team` with a realistic `TeamBoards` JSON (3 devs, 2 identified, mixed skills, one null-cost dev semantics via costContributors 2, 3 models), `/api/version` minimal `{ ok: true }`-ish, everything else 404.
+- [ ] **Step 2:** `AX_DAEMON_PORT=17399 bun x vite dev` in `apps/studio` (background), open `http://localhost:5173/team` via cmux/agent-browser, screenshot boards; also `/team?demo` (demo intact) and stop stub → reload `/team` (error state).
+- [ ] **Step 3:** Kill background processes. Record findings in report.
+
+## Self-Review
+
+- Spec coverage: data hook (T1), panels adoption/skills/spend/cold-start (T2+T3), mock-teaser removal (T3 step 1), loading/empty/error (T3 step 2), theme tokens reused, demo preserved (site iframe). ✓
+- No placeholders: concrete signatures + class names given; JSX detail lives in T3 step 2 spec with exact class hooks. ✓
+- Types consistent: `TeamBoardsView` name used in both T2 (model) and T3 (component) - RENAME: model interface stays `TeamBoardsView`, the React component is `TeamBoardsPanel` to avoid collision. T3 references adjusted accordingly.


### PR DESCRIPTION
team-dashboard Slice 4 UI. Wires the studio /team page (team-metrics.tsx) to the local `GET /api/team?org=` endpoint (from the team-serve chunk) and renders the real `TeamBoards` — adoption, skill matrix, spend/efficiency, cold-start 'N of M contributing'. Removes the mock/harnesses-as-team teaser entirely. Adds a testable `team-boards-model` transform layer, an `api.team(org?)` client call, and `@ax/community-compile` as a dep for the TeamBoards type. Empty/loading/error states handled (no team bound / no snapshots → clean empty-state).

Part of the Slice 4 local dashboard (pairs with team-serve). Design: goal-package §5 Slice 4.

Gates: typecheck 0, team-boards-model tests green, frozen-lockfile install clean.

Generated with ax — https://github.com/Necmttn/ax