### PR TITLE
feat(dashboard): GET /api/team → aggregated TeamBoards (Slice 4, local)

### DIFF
--- a/apps/axctl/package.json
+++ b/apps/axctl/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@ax-classifier/direction-event": "workspace:*",
     "@ax-classifier/verification-event": "workspace:*",
+    "@ax/community-compile": "workspace:*",
     "@ax/hooks-sdk": "workspace:*",
     "@ax/lib": "workspace:*",
     "@ax/schema": "workspace:*",

--- a/apps/axctl/src/dashboard/contract/team.test.ts
+++ b/apps/axctl/src/dashboard/contract/team.test.ts
@@ -1,0 +1,179 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { TeamProfileV1 } from "@ax/lib/shared/team-community";
+import { GitHubEnvTest } from "../../profile/github-env.ts";
+import {
+    isContractRequest,
+    makeContractWebHandler,
+    type ContractWebHandler,
+} from "./web-handler.ts";
+
+const profile: TeamProfileV1 = {
+    v: 1,
+    login: "alice",
+    org: "acme",
+    repo_key: "acme/widget",
+    window_days: 30,
+    generated_at: "2026-07-17T00:00:00Z",
+    stats: { sessions: 6, active_days: 3, harnesses: ["codex"] },
+    activity: { daily: [] },
+    skills: [{ skill: "tdd", runs: 4, sessions: 3 }],
+    spend: {
+        tokens: { prompt: 800, completion: 200, total: 1_000 },
+        cost_usd: 5,
+        model_mix: [{ model: "gpt-5", share: 1, tokens: 1_000, cost_usd: 5 }],
+    },
+    efficiency: { tool_calls: 40, tool_failures: 2, verification_calls: 10 },
+};
+
+const stubDb = Layer.mock(SurrealClient, {
+    query: <T extends unknown[] = unknown[]>() => Effect.succeed([] as unknown as T),
+    raw: null as never,
+});
+
+const handlers: ContractWebHandler[] = [];
+afterAll(async () => {
+    for (const handler of handlers) await handler.dispose();
+});
+
+describe("GET /api/team", () => {
+    test("is owned by the contract router", () => {
+        expect(isContractRequest("GET", "/api/team")).toBe(true);
+    });
+
+    test("returns compiled team boards for valid GitHub snapshots", async () => {
+        const github = GitHubEnvTest({
+            responses: {
+                "GET /repos/acme/ax-team/contents/.ax-team": [
+                    { name: "alice.json", type: "file" },
+                ],
+                "GET /repos/acme/ax-team/contents/.ax-team/alice.json": {
+                    encoding: "base64",
+                    content: btoa(JSON.stringify(profile)),
+                },
+            },
+        });
+        const handler = makeContractWebHandler({
+            ingestStream: null,
+            services: stubDb,
+            github: github.layer,
+        });
+        handlers.push(handler);
+
+        const response = await handler.handler(
+            new Request("http://127.0.0.1:1738/api/team?org=acme"),
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            coverage: { contributing: 1, identified: 1 },
+            adoption: {
+                contributingDevs: 1,
+                identifiedLogins: ["alice"],
+                sessions: { total: 6, average: 6 },
+                activeDays: { total: 3, average: 3 },
+            },
+            skillMatrix: [
+                { skill: "tdd", devs: 1, runs: 4, sessions: 3, medianRuns: 4 },
+            ],
+            spend: {
+                tokens: { prompt: 800, completion: 200, total: 1_000 },
+                costUsd: 5,
+                costContributors: 1,
+                modelMix: [
+                    {
+                        model: "gpt-5",
+                        tokens: 1_000,
+                        share: 1,
+                        costUsd: 5,
+                        costContributors: 1,
+                    },
+                ],
+            },
+            efficiency: {
+                toolCalls: 40,
+                toolFailures: 2,
+                verificationCalls: 10,
+                toolFailureRate: 0.05,
+                verificationShare: 0.25,
+            },
+        });
+    });
+
+    test("returns an empty valid board when the team repository is missing", async () => {
+        const github = GitHubEnvTest({ responses: {} });
+        const handler = makeContractWebHandler({
+            ingestStream: null,
+            services: stubDb,
+            github: github.layer,
+        });
+        handlers.push(handler);
+
+        const response = await handler.handler(
+            new Request("http://127.0.0.1:1738/api/team?org=missing-org"),
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            coverage: { contributing: 0, identified: 0 },
+            adoption: {
+                contributingDevs: 0,
+                identifiedLogins: [],
+                sessions: { total: 0, average: 0 },
+                activeDays: { total: 0, average: 0 },
+            },
+            skillMatrix: [],
+            spend: {
+                tokens: { prompt: 0, completion: 0, total: 0 },
+                costUsd: 0,
+                costContributors: 0,
+                modelMix: [],
+            },
+            efficiency: {
+                toolCalls: 0,
+                toolFailures: 0,
+                verificationCalls: 0,
+                toolFailureRate: 0,
+                verificationShare: 0,
+            },
+        });
+    });
+
+    test("drops a malformed snapshot and aggregates the valid remainder", async () => {
+        const github = GitHubEnvTest({
+            responses: {
+                "GET /repos/acme/ax-team/contents/.ax-team": [
+                    { name: "alice.json", type: "file" },
+                    { name: "broken.json", type: "file" },
+                ],
+                "GET /repos/acme/ax-team/contents/.ax-team/alice.json": {
+                    encoding: "base64",
+                    content: btoa(JSON.stringify(profile)),
+                },
+                "GET /repos/acme/ax-team/contents/.ax-team/broken.json": {
+                    encoding: "base64",
+                    content: btoa(JSON.stringify({ v: 2, login: "mallory" })),
+                },
+            },
+        });
+        const handler = makeContractWebHandler({
+            ingestStream: null,
+            services: stubDb,
+            github: github.layer,
+        });
+        handlers.push(handler);
+
+        const response = await handler.handler(
+            new Request("http://127.0.0.1:1738/api/team?org=acme"),
+        );
+        const body = await response.json() as {
+            coverage: { contributing: number; identified: number };
+            adoption: { identifiedLogins: string[] };
+        };
+
+        expect(response.status).toBe(200);
+        expect(body.coverage).toEqual({ contributing: 1, identified: 1 });
+        expect(body.adoption.identifiedLogins).toEqual(["alice"]);
+    });
+});

--- a/apps/axctl/src/dashboard/contract/team.ts
+++ b/apps/axctl/src/dashboard/contract/team.ts
@@ -1,0 +1,33 @@
+import { Effect } from "effect";
+import { HttpApiBuilder } from "effect/unstable/httpapi";
+import { compileTeam } from "@ax/community-compile/team";
+import { AxApi } from "@ax/lib/shared/api-contract";
+import { GitHubEnv } from "../../profile/github-env.ts";
+import {
+    defaultTeamBindingsPath,
+    loadTeamBindings,
+} from "../../team/team-bindings-state.ts";
+import { readTeamSnapshots } from "../../team/team-snapshot-reader.ts";
+
+const boundOrg = (): Effect.Effect<string | undefined> =>
+    Effect.promise(async () => {
+        const state = await loadTeamBindings(defaultTeamBindingsPath());
+        const orgs = new Set(Object.values(state.bindings).map((binding) => binding.org));
+        return orgs.size === 1 ? [...orgs][0] : undefined;
+    });
+
+export const TeamGroupLive = HttpApiBuilder.group(AxApi, "team", (handlers) =>
+    handlers.handle("teamBoards", ({ query }) =>
+        Effect.gen(function* () {
+            const github = yield* GitHubEnv;
+            const requested = query.org?.trim();
+            const org = requested === undefined || requested === ""
+                ? yield* boundOrg()
+                : requested;
+            if (org === undefined) return compileTeam([]);
+            const snapshots = yield* readTeamSnapshots(github, org).pipe(
+                Effect.catch(() => Effect.succeed([])),
+            );
+            return compileTeam(snapshots);
+        })),
+);

--- a/apps/axctl/src/dashboard/contract/web-handler.ts
+++ b/apps/axctl/src/dashboard/contract/web-handler.ts
@@ -28,6 +28,7 @@ import { HttpApiBuilder, HttpApiScalar } from "effect/unstable/httpapi";
 import type { SurrealClient } from "@ax/lib/db";
 import { AppLayer } from "@ax/lib/layers";
 import { AxApi } from "@ax/lib/shared/api-contract";
+import { GitHubEnv, GitHubEnvLive } from "../../profile/github-env.ts";
 import type { DurableIngestStream } from "../ingest-stream-durable.ts";
 import { jsonResponse } from "../router/router.ts";
 import { errorText } from "./common.ts";
@@ -39,6 +40,7 @@ import { RoutingGroupLive } from "./routing.ts";
 import { SessionsGroupLive } from "./sessions.ts";
 import { SkillsGroupLive } from "./skills.ts";
 import { ContractServeInfo, SystemGroupLive } from "./system.ts";
+import { TeamGroupLive } from "./team.ts";
 import { UsageGroupLive } from "./usage.ts";
 
 /** Everything the contract handlers reach for; widens as families join. */
@@ -84,6 +86,8 @@ const CONTRACT_ROUTES: ReadonlySet<string> = new Set([
     "GET /api/improve/analyze-brief",
     // usage
     "GET /api/usage",
+    // team
+    "GET /api/team",
     // live (SSE /api/events + binary /api/image stay raw legacy routes)
     "POST /api/ingest",
     // otel receiver
@@ -133,6 +137,8 @@ export interface MakeContractWebHandlerOptions {
     readonly memoMap?: Layer.MemoMap;
     /** Test seam: services the handlers need (default: production AppLayer). */
     readonly services?: Layer.Layer<ContractServices, unknown>;
+    /** Test seam for server-side GitHub calls (default: daemon `gh` auth). */
+    readonly github?: Layer.Layer<GitHubEnv, unknown>;
 }
 
 export function makeContractWebHandler(opts: MakeContractWebHandlerOptions): ContractWebHandler {
@@ -158,13 +164,16 @@ export function makeContractWebHandler(opts: MakeContractWebHandlerOptions): Con
             LiveGroupLive,
             OtelGroupLive,
             RoutingGroupLive,
+            TeamGroupLive,
         ]),
         // FileSystem/Path are provided beneath the route builder for build-time
         // needs. The final app layer merges platformLayer back into the output
         // for request-time handler requirements.
         Layer.provide([BunHttpPlatform.layer, platformLayer, Etag.layer]),
     );
-    const appLayer = Layer.mergeAll(routesLayer, platformLayer);
+    const appLayer = Layer.mergeAll(routesLayer, platformLayer).pipe(
+        Layer.provideMerge(opts.github ?? GitHubEnvLive),
+    );
     const build = (): ContractWebHandler =>
         HttpRouter.toWebHandler(appLayer, {
             memoMap: opts.memoMap,

--- a/apps/axctl/src/team/team-snapshot-reader.ts
+++ b/apps/axctl/src/team/team-snapshot-reader.ts
@@ -1,0 +1,83 @@
+import { Effect } from "effect";
+import { type TeamProfileV1, validateTeamProfile } from "@ax/lib/shared/team-community";
+import {
+    GitHubApiError,
+    type GitHubEnvService,
+} from "../profile/github-env.ts";
+
+interface ContentsEntry {
+    readonly name: string;
+    readonly type: string;
+}
+
+const isContentsEntry = (value: unknown): value is ContentsEntry => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+    const entry = value as Record<string, unknown>;
+    return typeof entry.name === "string" && typeof entry.type === "string";
+};
+
+const isV1Envelope = (value: unknown): boolean =>
+    typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && (value as Record<string, unknown>).v === 1;
+
+const decodeProfile = (value: unknown): TeamProfileV1 => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error("contents response is not an object");
+    }
+    const { content, encoding } = value as Record<string, unknown>;
+    if (encoding !== "base64" || typeof content !== "string") {
+        throw new Error("contents response is not base64");
+    }
+    const binary = atob(content.replace(/\s/g, ""));
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    const decoded: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    const profile = validateTeamProfile(decoded);
+    if (!isV1Envelope(decoded)) throw new Error("invalid team profile version");
+    return profile;
+};
+
+const decodeProfileEffect = (value: unknown) =>
+    Effect.try({
+        try: () => decodeProfile(value),
+        catch: (error) => new GitHubApiError({
+            status: 0,
+            message: error instanceof Error ? error.message : String(error),
+        }),
+    });
+
+export function readTeamSnapshots(
+    github: GitHubEnvService,
+    org: string,
+): Effect.Effect<ReadonlyArray<TeamProfileV1>, GitHubApiError> {
+    return Effect.gen(function* () {
+        const encodedOrg = encodeURIComponent(org);
+        const basePath = `/repos/${encodedOrg}/ax-team/contents/.ax-team`;
+        const listing = yield* github.api("GET", basePath).pipe(
+            Effect.catchIf(
+                (error) => error.status === 404,
+                () => Effect.succeed([]),
+            ),
+        );
+        if (!Array.isArray(listing)) return [];
+
+        const profiles: TeamProfileV1[] = [];
+        const entries = listing.filter(
+            (entry): entry is ContentsEntry =>
+                isContentsEntry(entry)
+                && entry.type === "file"
+                && entry.name.endsWith(".json"),
+        );
+        for (const entry of entries) {
+            const profile = yield* github
+                .api("GET", `${basePath}/${encodeURIComponent(entry.name)}`)
+                .pipe(
+                    Effect.flatMap(decodeProfileEffect),
+                    Effect.catch(() => Effect.succeed(null)),
+                );
+            if (profile !== null) profiles.push(profile);
+        }
+        return profiles;
+    });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -39,13 +39,14 @@
     },
     "apps/axctl": {
       "name": "axctl",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "bin": {
         "axctl": "./bin/axctl",
       },
       "dependencies": {
         "@ax-classifier/direction-event": "workspace:*",
         "@ax-classifier/verification-event": "workspace:*",
+        "@ax/community-compile": "workspace:*",
         "@ax/hooks-sdk": "workspace:*",
         "@ax/lib": "workspace:*",
         "@ax/schema": "workspace:*",
@@ -190,6 +191,7 @@
       "name": "@ax/community-compile",
       "version": "0.0.0",
       "devDependencies": {
+        "@ax/lib": "workspace:*",
         "@types/bun": "catalog:",
         "typescript": "catalog:",
       },

--- a/packages/lib/src/shared/api-contract.ts
+++ b/packages/lib/src/shared/api-contract.ts
@@ -1064,6 +1064,64 @@ export const RoutingGroup = HttpApiGroup.make("routing")
         }),
     );
 
+// ---------------------------------------------------------------- team
+
+const TeamModelRow = Schema.Struct({
+    model: Schema.String,
+    tokens: Schema.Number,
+    share: Schema.Number,
+    costUsd: Schema.Number,
+    costContributors: Schema.Number,
+});
+
+const TeamSkillRow = Schema.Struct({
+    skill: Schema.String,
+    devs: Schema.Number,
+    runs: Schema.Number,
+    sessions: Schema.Number,
+    medianRuns: Schema.Number,
+});
+
+/** Aggregated, render-safe boards returned by the local team endpoint. */
+export const TeamBoardsResponse = Schema.Struct({
+    coverage: Schema.Struct({
+        contributing: Schema.Number,
+        identified: Schema.Number,
+    }),
+    adoption: Schema.Struct({
+        contributingDevs: Schema.Number,
+        identifiedLogins: Schema.Array(Schema.String),
+        sessions: Schema.Struct({ total: Schema.Number, average: Schema.Number }),
+        activeDays: Schema.Struct({ total: Schema.Number, average: Schema.Number }),
+    }),
+    skillMatrix: Schema.Array(TeamSkillRow),
+    spend: Schema.Struct({
+        tokens: Schema.Struct({
+            prompt: Schema.Number,
+            completion: Schema.Number,
+            total: Schema.Number,
+        }),
+        costUsd: Schema.Number,
+        costContributors: Schema.Number,
+        modelMix: Schema.Array(TeamModelRow),
+    }),
+    efficiency: Schema.Struct({
+        toolCalls: Schema.Number,
+        toolFailures: Schema.Number,
+        verificationCalls: Schema.Number,
+        toolFailureRate: Schema.Number,
+        verificationShare: Schema.Number,
+    }),
+});
+export type TeamBoardsResponse = typeof TeamBoardsResponse.Type;
+
+export const TeamGroup = HttpApiGroup.make("team").add(
+    HttpApiEndpoint.get("teamBoards", "/api/team", {
+        query: { org: Schema.optionalKey(Schema.String) },
+        success: TeamBoardsResponse,
+    }),
+);
+
 /** The Insights Surface Contract. Families join as they migrate (ADR-0013). */
 export const AxApi = HttpApi.make("ax")
     .add(SystemGroup)
@@ -1075,5 +1133,6 @@ export const AxApi = HttpApi.make("ax")
     .add(LiveGroup)
     .add(OtelGroup)
     .add(RoutingGroup)
+    .add(TeamGroup)
     .annotate(OpenApi.Title, "ax daemon API")
     .annotate(OpenApi.Version, "1");


### PR DESCRIPTION
team-dashboard Slice 4 backend (LOCAL, no OAuth). Adds a contract-typed `GET /api/team?org=` daemon route: a server-side snapshot reader pulls .ax-team/*.json from <org>/ax-team using the daemon's own gh auth, validateTeamProfile-drops failures, and compileTeam aggregates into TeamBoards — returned as JSON. Empty-safe (no org / no team repo / no snapshots → compileTeam([]), never a 500). Loopback-only, so no auth needed for the local dashboard.

Pairs with team-dashboard-ui (#738) — together the /team page renders real pushed snapshots with zero infra.

Part of Slice 4. Design: goal-package §5 Slice 4.

Gates: typecheck 0, team.test green, frozen-lockfile clean, check:no-node-fs 0.

Generated with ax — https://github.com/Necmttn/ax