### PR TITLE
fix(ingest): cursor stage batches commits + resumes — no longer blows the ingest timeout

### DIFF
--- a/apps/axctl/src/ingest/cursor.batching.test.ts
+++ b/apps/axctl/src/ingest/cursor.batching.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import { mkdtempSync } from "node:fs";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Effect, Exit, Layer, Path } from "effect";
+import { BunFileSystem } from "@effect/platform-bun";
+import { AxConfigTest } from "@ax/lib/config";
+import { DbError } from "@ax/lib/errors";
+import { makeTestSurrealClient, type TestSurrealRoutes } from "@ax/lib/testing/surreal";
 import {
+    __testBuildCursorBatchStatements,
+    __testBuildCursorSessionUpsertStatement,
     __testPartitionCursorExtract,
     __testSliceCursorExtractForSession,
     extractCursorStateDb,
+    ingestCursor,
+    type CursorStats,
 } from "./cursor.ts";
 
 /** Multi-session composerData store: three conversations, one with a tool
@@ -82,5 +92,102 @@ describe("partitionCursorExtract", () => {
         expect(bravo.slice.toolCalls.length).toBe(1);
         expect(bravo.slice.skillRelations.length).toBe(1);
         expect(bravo.slice.invocations.length).toBe(1);
+    });
+});
+
+const layersFor = (cursorUserDir: string, routes: TestSurrealRoutes = []) => {
+    const tc = makeTestSurrealClient({ routes });
+    const layer = Layer.mergeAll(
+        tc.layer,
+        AxConfigTest({ paths: { cursorUserDir } }).pipe(Layer.provide(BunFileSystem.layer)),
+        BunFileSystem.layer,
+        Path.layer,
+    );
+    return { tc, layer };
+};
+
+const runCursor = (layer: Layer.Layer<never>) =>
+    Effect.runPromise(ingestCursor({}).pipe(Effect.provide(layer)) as Effect.Effect<CursorStats>);
+
+describe("cursor batched writes", () => {
+    test("batched run executes the SAME statements as the per-session oracle, in fewer query calls", async () => {
+        const cursorUserDir = await mkdtemp(join(tmpdir(), "ax-cursor-batch-"));
+        try {
+            await mkdir(join(cursorUserDir, "globalStorage"), { recursive: true });
+            const dbPath = seedMultiSessionStore(join(cursorUserDir, "globalStorage"));
+            const { tc, layer } = layersFor(cursorUserDir);
+
+            const stats = await runCursor(layer);
+            expect(stats.sessions).toBe(3);
+            expect(stats.failedFiles).toBe(0);
+
+            const executed = tc.captured.join("");
+            const extract = extractCursorStateDb(dbPath, { cursorUserDir });
+            // Every record-write statement the OLD per-session path would have
+            // issued is present verbatim (same records, same shapes).
+            for (const { session, slice } of __testPartitionCursorExtract(extract)) {
+                expect(executed).toContain(__testBuildCursorSessionUpsertStatement(session));
+                for (const statement of __testBuildCursorBatchStatements(slice, dbPath)) {
+                    expect(executed).toContain(statement);
+                }
+            }
+            // Commit amortization: old path = 2+ round trips per session (SDK
+            // upsert + >=1 statement chunk) = >=6 query calls for 3 sessions.
+            // New path: 1 watermark SELECT + 1 batched chunk.
+            const writeCalls = tc.captured.filter((sql) => !sql.includes("FROM ingest_file_state")).length;
+            expect(writeCalls).toBe(1);
+            expect(tc.upserts.length).toBe(0); // no per-session SDK upserts anymore
+        } finally {
+            await rm(cursorUserDir, { recursive: true, force: true });
+        }
+    });
+
+    test("a bad session inside a batch is isolated (#261): batch falls back per-session", async () => {
+        const cursorUserDir = await mkdtemp(join(tmpdir(), "ax-cursor-batch-iso-"));
+        try {
+            await mkdir(join(cursorUserDir, "globalStorage"), { recursive: true });
+            seedMultiSessionStore(join(cursorUserDir, "globalStorage"));
+            const { tc, layer } = layersFor(cursorUserDir, [
+                { match: "convbravo", rows: Effect.fail(new DbError({ operation: "query", message: "statement rejected" })) },
+            ]);
+
+            const stats = await runCursor(layer);
+            expect(stats.sessions).toBe(2);
+            expect(stats.failedFiles).toBe(1);
+            const executed = tc.captured.join("");
+            expect(executed).toContain("convalpha");
+            expect(executed).toContain("convcharlie");
+            // The bad session committed no watermark: no STANDALONE
+            // ingest_file_state UPSERT (the per-session commit issued by the
+            // #261 fallback) names it. `startsWith` (not `includes`) is
+            // deliberate: the failed whole-group attempt's captured SQL also
+            // contains a watermark statement for convbravo (batched with the
+            // other members' - it never committed, but the mock still
+            // records issued SQL even on failure), and that same blob
+            // legitimately embeds convbravo's own data too. Filtering to
+            // calls that ARE a watermark commit (not merely contain one)
+            // isolates the actual per-session commits the fallback made.
+            const marks = tc.captured.filter((sql) => sql.startsWith("UPSERT ingest_file_state"));
+            expect(marks.join("")).not.toContain("convbravo");
+        } finally {
+            await rm(cursorUserDir, { recursive: true, force: true });
+        }
+    });
+
+    test("a connection-level DbError still aborts the stage through the fallback", async () => {
+        const cursorUserDir = await mkdtemp(join(tmpdir(), "ax-cursor-batch-conn-"));
+        try {
+            await mkdir(join(cursorUserDir, "globalStorage"), { recursive: true });
+            seedMultiSessionStore(join(cursorUserDir, "globalStorage"));
+            const { layer } = layersFor(cursorUserDir, [
+                { match: "UPSERT session:", rows: Effect.fail(new DbError({ operation: "connect", message: "daemon not reachable" })) },
+            ]);
+            const exit = await Effect.runPromiseExit(
+                ingestCursor({}).pipe(Effect.provide(layer)) as Effect.Effect<unknown, DbError>,
+            );
+            expect(Exit.isFailure(exit)).toBe(true);
+        } finally {
+            await rm(cursorUserDir, { recursive: true, force: true });
+        }
     });
 });

--- a/apps/axctl/src/ingest/cursor.batching.test.ts
+++ b/apps/axctl/src/ingest/cursor.batching.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    __testPartitionCursorExtract,
+    __testSliceCursorExtractForSession,
+    extractCursorStateDb,
+} from "./cursor.ts";
+
+/** Multi-session composerData store: three conversations, one with a tool
+ *  call, so the partition covers turns/toolCalls/providerEvents/invocations/
+ *  skillRelations. Conversation ids double as SQL markers for route-matching
+ *  in later tasks. */
+export const seedMultiSessionStore = (dir: string): string => {
+    const dbPath = join(dir, "state.vscdb");
+    const db = new Database(dbPath);
+    try {
+        db.run("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)");
+        const payload = JSON.stringify({
+            conversations: [
+                {
+                    id: "convalpha",
+                    title: "alpha",
+                    messages: [
+                        { id: "a1", role: "user", text: "alpha question", timestamp: "2026-06-01T10:00:00.000Z" },
+                        { id: "a2", role: "assistant", text: "alpha answer", timestamp: "2026-06-01T10:00:05.000Z" },
+                    ],
+                },
+                {
+                    id: "convbravo",
+                    title: "bravo",
+                    messages: [
+                        { id: "b1", role: "user", text: "bravo question", timestamp: "2026-06-01T11:00:00.000Z" },
+                        {
+                            id: "b2",
+                            role: "assistant",
+                            text: "running a command",
+                            timestamp: "2026-06-01T11:00:05.000Z",
+                            toolFormerData: {
+                                toolCallId: "bravo-tool-1",
+                                status: "completed",
+                                name: "run_terminal_command_v2",
+                                rawArgs: "",
+                                params: JSON.stringify({ command: "git status --short" }),
+                                result: JSON.stringify({ output: "clean\n" }),
+                            },
+                        },
+                    ],
+                },
+                {
+                    id: "convcharlie",
+                    title: "charlie",
+                    messages: [
+                        { id: "c1", role: "user", text: "charlie question", timestamp: "2026-06-01T12:00:00.000Z" },
+                    ],
+                },
+            ],
+        });
+        db.query("INSERT INTO ItemTable VALUES ('composer.composerData', ?)").run(payload);
+    } finally {
+        db.close();
+    }
+    return dbPath;
+};
+
+describe("partitionCursorExtract", () => {
+    test("one-pass partition equals the per-session slice oracle for every session", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-cursor-partition-"));
+        const dbPath = seedMultiSessionStore(dir);
+        const extract = extractCursorStateDb(dbPath);
+        expect(extract.sessions.length).toBe(3);
+
+        const partitions = __testPartitionCursorExtract(extract);
+        expect(partitions.map((p) => p.session.id)).toEqual(extract.sessions.map((s) => s.id));
+        for (const { session, slice } of partitions) {
+            expect(slice).toEqual(__testSliceCursorExtractForSession(extract, session.id));
+        }
+        // The tool-call session's slice actually carries the correlated pieces.
+        const bravo = partitions.find((p) => p.session.cursorConversationId === "convbravo")!;
+        expect(bravo.slice.toolCalls.length).toBe(1);
+        expect(bravo.slice.skillRelations.length).toBe(1);
+        expect(bravo.slice.invocations.length).toBe(1);
+    });
+});

--- a/apps/axctl/src/ingest/cursor.batching.test.ts
+++ b/apps/axctl/src/ingest/cursor.batching.test.ts
@@ -133,10 +133,31 @@ describe("cursor batched writes", () => {
             }
             // Commit amortization: old path = 2+ round trips per session (SDK
             // upsert + >=1 statement chunk) = >=6 query calls for 3 sessions.
-            // New path: 1 watermark SELECT + 1 batched chunk.
+            // New path: 1 watermark SELECT + 1 batched DATA call + 1 batched
+            // MARKS call. The marks call is deliberately SEPARATE from data
+            // (never combined into the same `executeStatements` call): a
+            // SurrealDB `query()` request runs every statement it's given
+            // independently (per-statement status, no transaction), so if a
+            // mark rode in the SAME request as data, a later mark statement
+            // could still commit server-side even when an earlier data
+            // statement in that request failed - a data-loss hazard where a
+            // failed session's watermark lands anyway and the session is
+            // skipped forever on the next run. Splitting into two calls means
+            // the marks call is only reachable once the data call's Effect
+            // has already succeeded.
             const writeCalls = tc.captured.filter((sql) => !sql.includes("FROM ingest_file_state")).length;
-            expect(writeCalls).toBe(1);
+            expect(writeCalls).toBe(2);
             expect(tc.upserts.length).toBe(0); // no per-session SDK upserts anymore
+
+            // Regression guard for the exact data-loss hazard above: the
+            // batched marks call must carry ONLY watermark commits, never any
+            // data statement, so a failed data call can never let a mark
+            // through in the same request.
+            const marksCalls = tc.captured.filter((sql) => sql.includes("UPSERT ingest_file_state"));
+            for (const sql of marksCalls) {
+                expect(sql).not.toContain("UPSERT session:");
+                expect(sql).not.toContain("UPSERT turn");
+            }
         } finally {
             await rm(cursorUserDir, { recursive: true, force: true });
         }
@@ -157,16 +178,16 @@ describe("cursor batched writes", () => {
             const executed = tc.captured.join("");
             expect(executed).toContain("convalpha");
             expect(executed).toContain("convcharlie");
-            // The bad session committed no watermark: no STANDALONE
-            // ingest_file_state UPSERT (the per-session commit issued by the
-            // #261 fallback) names it. `startsWith` (not `includes`) is
-            // deliberate: the failed whole-group attempt's captured SQL also
-            // contains a watermark statement for convbravo (batched with the
-            // other members' - it never committed, but the mock still
-            // records issued SQL even on failure), and that same blob
-            // legitimately embeds convbravo's own data too. Filtering to
-            // calls that ARE a watermark commit (not merely contain one)
-            // isolates the actual per-session commits the fallback made.
+            // The bad session committed no watermark: no ingest_file_state
+            // UPSERT names it. The batch's DATA call fails first (convbravo's
+            // own content matches the route) and the group's marks call -
+            // sequenced strictly after data succeeds - is never reached, so
+            // no mark for ANY group member (bad or good) is attempted in the
+            // failed batch at all; only the #261 per-session fallback's
+            // individual mark commits (for convalpha/convcharlie, which
+            // succeed) show up here. `startsWith` (rather than `includes`)
+            // keeps this precise: it isolates calls that ARE a watermark
+            // commit, not merely ones that mention one.
             const marks = tc.captured.filter((sql) => sql.startsWith("UPSERT ingest_file_state"));
             expect(marks.join("")).not.toContain("convbravo");
         } finally {

--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -948,6 +948,60 @@ const sliceCursorExtractForSession = (
 
 export const __testSliceCursorExtractForSession = sliceCursorExtractForSession;
 
+/** One-pass partition of a whole-store extract into per-session slices.
+ *  Output per session is IDENTICAL to `sliceCursorExtractForSession(extract,
+ *  id)` (the oracle its equivalence test asserts against); this exists because
+ *  filtering the whole extract once per session is O(sessions × extract) and a
+ *  ~1,800-session store made that quadratic cost real. Order follows
+ *  `extract.sessions`. */
+const partitionCursorExtract = (
+    extract: CursorExtract,
+): { session: CursorSession; slice: CursorExtract }[] => {
+    const bySession = new Map<string, { session: CursorSession; slice: CursorExtract }>();
+    const partitions: { session: CursorSession; slice: CursorExtract }[] = [];
+    for (const session of extract.sessions) {
+        const entry = {
+            session,
+            slice: {
+                sessions: [session],
+                turns: [] as CursorTurn[],
+                invocations: [] as CursorInvocation[],
+                toolCalls: [] as ToolCallWrite[],
+                providerEvents: [] as AgentEventWrite[],
+                skillRelations: [] as ToolCallSkillRelationWrite[],
+                compactions: [] as CompactionWrite[],
+                skipped: 0,
+                warnings: [] as string[],
+            },
+        };
+        bySession.set(session.id, entry);
+        partitions.push(entry);
+    }
+    for (const turn of extract.turns) bySession.get(turn.session)?.slice.turns.push(turn);
+    for (const invocation of extract.invocations) bySession.get(invocation.session)?.slice.invocations.push(invocation);
+    // Skill relations carry no session field; correlate through the same
+    // toolCallRecordKey their tool calls were keyed with (mirrors the oracle).
+    const sessionByToolCallKey = new Map<string, string>();
+    for (const call of extract.toolCalls) {
+        bySession.get(call.sessionId)?.slice.toolCalls.push(call);
+        if (bySession.has(call.sessionId)) {
+            sessionByToolCallKey.set(
+                toolCallRecordKey({ sessionId: call.sessionId, seq: call.seq, callId: call.callId ?? null }),
+                call.sessionId,
+            );
+        }
+    }
+    for (const event of extract.providerEvents) bySession.get(event.providerSessionId)?.slice.providerEvents.push(event);
+    for (const relation of extract.skillRelations) {
+        const sessionId = sessionByToolCallKey.get(relation.toolCallKey);
+        if (sessionId !== undefined) bySession.get(sessionId)?.slice.skillRelations.push(relation);
+    }
+    for (const compaction of extract.compactions) bySession.get(compaction.sessionId)?.slice.compactions.push(compaction);
+    return partitions;
+};
+
+export const __testPartitionCursorExtract = partitionCursorExtract;
+
 const includeByMtime = (mtime: Option.Option<Date>, cutoffMs: number): boolean =>
     Option.match(mtime, {
         onNone: () => true,

--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -2,11 +2,14 @@ import { Database } from "bun:sqlite";
 import { Effect, FileSystem, Option, Path, Schema } from "effect";
 import { AxConfig } from "@ax/lib/config";
 import { SkillName } from "@ax/lib/brands";
-import { RecordId, SurrealClient } from "@ax/lib/db";
+import { SurrealClient } from "@ax/lib/db";
+import { stableDigest } from "@ax/lib/ids";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { classifyNoFollow } from "@ax/lib/shared/fs-classify";
 import { posixPath } from "@ax/lib/shared/path";
 import { executeStatements } from "@ax/lib/shared/statement-exec";
+import { fileWatermark, watermarkCommitStatement } from "@ax/lib/shared/watermark";
+import { recordRef, surrealDate, surrealString } from "@ax/lib/shared/surql";
 import {
     type ToolCallSkillRelationWrite,
     type ToolCallWrite,
@@ -33,6 +36,10 @@ export interface CursorStats {
     readonly turns: number;
     readonly toolCalls: number;
     readonly skipped: number;
+    /** Sessions skipped because their content digest matched the stored
+     *  per-session watermark (`ingest_file_state`, source_kind
+     *  "cursor_session") - a killed run resumes instead of restarting. */
+    readonly skippedUnchanged: number;
     readonly warnings: number;
     /** Sessions whose write pipeline failed and was skipped (retried next
      *  run). Named `failedFiles` to match the cross-provider stage-stats key
@@ -1002,6 +1009,41 @@ const partitionCursorExtract = (
 
 export const __testPartitionCursorExtract = partitionCursorExtract;
 
+/** The session-record upsert as a statement. Replaces the per-session SDK
+ *  `db.upsert(new RecordId("session", ...))` round trip so it can ride the
+ *  same batched `executeStatements` call as the session's other statements.
+ *  Field set + CONTENT(replace) semantics are identical to the SDK call it
+ *  supersedes. */
+const buildCursorSessionUpsertStatement = (session: CursorSession): string =>
+    `UPSERT ${recordRef("session", session.id)} CONTENT { source: ${surrealString("cursor")}, started_at: ${surrealDate(session.started_at)}, ended_at: ${surrealDate(session.ended_at)}, raw_file: ${surrealString(session.sourcePath)} };`;
+
+export const __testBuildCursorSessionUpsertStatement = buildCursorSessionUpsertStatement;
+
+/** Statement-count budget per batched `executeStatements` call: aligned with
+ *  the write chunkSize so a batch is ~one round trip. The fixed per-call
+ *  commit cost dominated the old per-session path (~540ms/chat on a 1,838-chat
+ *  store - "28 statements cost the same as 236"), so batches amortize it. */
+export const CURSOR_BATCH_STATEMENT_BUDGET = 500;
+
+const CURSOR_WATERMARK_SOURCE_KIND = "cursor_session";
+
+interface PendingCursorSession {
+    /** `<store path>#<session id>` - the #261 isolation locator AND the
+     *  watermark path key. */
+    readonly locator: string;
+    readonly session: CursorSession;
+    /** Session upsert + the session's full normalized-batch statements. */
+    readonly statements: readonly string[];
+    /** Content fingerprint packed into the (mtime_ms,size) watermark slots:
+     *  first 52 bits of the statement digest + statement count. */
+    readonly digestNum: number;
+    readonly turns: number;
+    readonly toolCalls: number;
+}
+
+const cursorSessionFingerprint = (statements: readonly string[]): number =>
+    Number.parseInt(stableDigest(statements.join("\n")).slice(0, 13), 16);
+
 const includeByMtime = (mtime: Option.Option<Date>, cutoffMs: number): boolean =>
     Option.match(mtime, {
         onNone: () => true,
@@ -1077,18 +1119,27 @@ interface CursorIngestOpts {
 export const ingestCursor = Effect.fn("cursor.ingest")(
     function* (opts: Partial<CursorIngestOpts> = {}) {
         const cfg = yield* AxConfig;
-        const db = yield* SurrealClient;
         const cutoff = opts.sinceDays ? Date.now() - opts.sinceDays * 86400 * 1000 : 0;
         const dbPaths = yield* findCursorStateDbs(cfg.paths.cursorUserDir, cutoff);
         let sessionCount = 0;
         let turnCount = 0;
         let toolCallCount = 0;
         let skipped = 0;
+        let skippedUnchanged = 0;
         let warnings = 0;
 
         // One collector across all state DBs: a failure storm spanning stores
         // is just as systemic as one inside a single store.
         const failures = makeFileFailureCollector({ source: "cursor", unit: "session" });
+
+        // Per-session skip-unchanged watermark (#resumability): one indexed
+        // read up front; a session whose statement digest matches its stored
+        // mark is skipped entirely, so a killed+resumed run does not restart
+        // the store from zero. AX_REDERIVE_CURSOR=1 forces a full re-derive.
+        const watermark = dbPaths.length > 0
+            ? yield* fileWatermark({ sourceKind: CURSOR_WATERMARK_SOURCE_KIND, forceEnv: "AX_REDERIVE_CURSOR" })
+            : null;
+
         for (const dbPath of dbPaths) {
             const extract = yield* Effect.sync(() =>
                 extractCursorStateDb(dbPath, { cursorUserDir: cfg.paths.cursorUserDir })
@@ -1101,25 +1152,95 @@ export const ingestCursor = Effect.fn("cursor.ingest")(
             warnings += extract.warnings.length;
             if (extract.sessions.length === 0) continue;
 
-            for (const session of extract.sessions) {
-                const slice = sliceCursorExtractForSession(extract, session.id);
-                // Per-session failure isolation (#261): one undecodable /
-                // rejected session skips THIS session - the store is re-read
-                // next run - instead of aborting the whole stage (see
-                // file-isolation.ts).
-                yield* failures.isolate(`${dbPath}#${session.id}`, Effect.gen(function* () {
-                    yield* db.upsert(new RecordId("session", session.id), {
-                        source: "cursor",
-                        started_at: new Date(session.started_at),
-                        ended_at: new Date(session.ended_at),
-                        raw_file: session.sourcePath,
-                    });
-                    yield* executeStatements(buildCursorBatchStatements(slice, dbPath), { chunkSize: 500, label: "cursor" });
-                    sessionCount += 1;
-                    turnCount += slice.turns.length;
-                    toolCallCount += slice.toolCalls.length;
-                }));
+            const pending: PendingCursorSession[] = [];
+            for (const { session, slice } of partitionCursorExtract(extract)) {
+                const statements = [
+                    buildCursorSessionUpsertStatement(session),
+                    ...buildCursorBatchStatements(slice, dbPath),
+                ];
+                const locator = `${dbPath}#${session.id}`;
+                const digestNum = cursorSessionFingerprint(statements);
+                if (watermark?.unchanged(locator, digestNum, statements.length)) {
+                    skippedUnchanged += 1;
+                    continue;
+                }
+                pending.push({
+                    locator,
+                    session,
+                    statements,
+                    digestNum,
+                    turns: slice.turns.length,
+                    toolCalls: slice.toolCalls.length,
+                });
             }
+
+            // Greedy statement-budget batches: amortize the per-call commit
+            // cost across sessions. Watermark commits ride the SAME call,
+            // ordered LAST so they only execute after every data chunk of the
+            // batch succeeded (chunks run sequentially; a failure aborts the
+            // rest). On any batch failure, fall back to the per-session
+            // isolate path so one bad session skips only itself (#261).
+            let batch: PendingCursorSession[] = [];
+            let batchStatements = 0;
+
+            const markStatement = (p: PendingCursorSession): string =>
+                watermarkCommitStatement(CURSOR_WATERMARK_SOURCE_KIND, p.locator, p.digestNum, p.statements.length);
+
+            const ingestOne = (p: PendingCursorSession) =>
+                // Per-session failure isolation (#261): one undecodable /
+                // rejected session skips THIS session - retried next run (its
+                // watermark never commits) - instead of aborting the stage.
+                failures.isolate(p.locator, Effect.gen(function* () {
+                    yield* executeStatements(p.statements, { chunkSize: 500, label: "cursor" });
+                    yield* executeStatements([markStatement(p)], { chunkSize: 1, label: "cursor" });
+                    sessionCount += 1;
+                    turnCount += p.turns;
+                    toolCallCount += p.toolCalls;
+                }));
+
+            const flush = () =>
+                Effect.gen(function* () {
+                    if (batch.length === 0) return;
+                    const group = batch;
+                    batch = [];
+                    batchStatements = 0;
+                    const combined = [
+                        ...group.flatMap((p) => [...p.statements]),
+                        ...group.map(markStatement),
+                    ];
+                    const attempt = yield* Effect.result(
+                        executeStatements(combined, { chunkSize: 500, label: "cursor" }),
+                    );
+                    if (attempt._tag === "Success") {
+                        for (const p of group) {
+                            sessionCount += 1;
+                            turnCount += p.turns;
+                            toolCallCount += p.toolCalls;
+                        }
+                        return;
+                    }
+                    // Batch failed: retry each member alone so only the truly
+                    // bad session(s) skip. Statements are idempotent UPSERTs,
+                    // so partially-committed chunks re-apply safely. A
+                    // connection-level DbError rethrows out of isolate and
+                    // aborts the stage, exactly as before.
+                    yield* Effect.logDebug("cursor ingest: batch failed, falling back to per-session isolation", {
+                        sessions: group.length,
+                        message: attempt.failure.message,
+                    });
+                    for (const p of group) {
+                        yield* ingestOne(p);
+                    }
+                });
+
+            for (const p of pending) {
+                if (batch.length > 0 && batchStatements + p.statements.length + batch.length + 1 > CURSOR_BATCH_STATEMENT_BUDGET) {
+                    yield* flush();
+                }
+                batch.push(p);
+                batchStatements += p.statements.length;
+            }
+            yield* flush();
         }
         yield* failures.report;
 
@@ -1128,6 +1249,7 @@ export const ingestCursor = Effect.fn("cursor.ingest")(
             turns: turnCount,
             toolCalls: toolCallCount,
             skipped,
+            skippedUnchanged,
             warnings,
             failedFiles: failures.count(),
         } satisfies CursorStats;
@@ -1139,6 +1261,8 @@ export class CursorStageStats extends BaseStageStats.extend<CursorStageStats>("C
     turnsIngested: Schema.Number,
     toolCallsIngested: Schema.Number,
     skipped: Schema.Number,
+    /** Sessions skipped by the per-session content watermark (unchanged). */
+    skippedUnchanged: Schema.Number,
     warnings: Schema.Number,
     /** Sessions whose write pipeline failed and was skipped (retried next
      *  run). Named `failedFiles` to match the cross-provider stage-stats key
@@ -1157,11 +1281,13 @@ export const cursorStage: StageDef<CursorStageStats, SurrealClient | AxConfig | 
         return CursorStageStats.make({
             durationMs: Date.now() - t0,
             summary: `ingested ${result.sessions} sessions, ${result.turns} turns, ${result.toolCalls} tool calls, skipped ${result.skipped}, warnings ${result.warnings}` +
+                (result.skippedUnchanged > 0 ? `, ${result.skippedUnchanged} unchanged session(s) skipped` : "") +
                 (result.failedFiles > 0 ? `, ${result.failedFiles} session(s) failed (retry next run)` : ""),
             sessionsIngested: result.sessions,
             turnsIngested: result.turns,
             toolCallsIngested: result.toolCalls,
             skipped: result.skipped,
+            skippedUnchanged: result.skippedUnchanged,
             warnings: result.warnings,
             failedFiles: result.failedFiles,
         });

--- a/apps/axctl/src/ingest/cursor.ts
+++ b/apps/axctl/src/ingest/cursor.ts
@@ -1175,11 +1175,23 @@ export const ingestCursor = Effect.fn("cursor.ingest")(
             }
 
             // Greedy statement-budget batches: amortize the per-call commit
-            // cost across sessions. Watermark commits ride the SAME call,
-            // ordered LAST so they only execute after every data chunk of the
-            // batch succeeded (chunks run sequentially; a failure aborts the
-            // rest). On any batch failure, fall back to the per-session
-            // isolate path so one bad session skips only itself (#261).
+            // cost across sessions. Watermark commits ride in a SEPARATE
+            // `executeStatements` call issued AFTER the group's data call -
+            // never combined into the same call. SurrealDB executes every
+            // statement inside one `query()` request independently
+            // (per-statement status, no transaction): if marks rode in the
+            // SAME request as data, a later mark statement could still
+            // commit server-side even though an earlier data statement in
+            // that same request errored, so a failing session's watermark
+            // could land despite its data being lost - and the next run's
+            // `watermark.unchanged()` would then skip it forever with
+            // missing data. Splitting into two sequenced calls means the
+            // marks call is only *reachable* (via `Effect.gen` sequencing)
+            // once the data call's Effect has already succeeded, so a failed
+            // session's mark can never precede - or survive without - its
+            // data. On any batch failure (data OR marks call), fall back to
+            // the per-session isolate path so one bad session skips only
+            // itself (#261).
             let batch: PendingCursorSession[] = [];
             let batchStatements = 0;
 
@@ -1204,12 +1216,18 @@ export const ingestCursor = Effect.fn("cursor.ingest")(
                     const group = batch;
                     batch = [];
                     batchStatements = 0;
-                    const combined = [
-                        ...group.flatMap((p) => [...p.statements]),
-                        ...group.map(markStatement),
-                    ];
+                    const dataStatements = group.flatMap((p) => [...p.statements]);
+                    const markStatements = group.map(markStatement);
+                    // See the batching comment above: marks are a SEPARATE
+                    // call, sequenced strictly after data succeeds, so
+                    // `Effect.result` only observes "Success" once BOTH
+                    // calls landed - a data-only failure never lets a mark
+                    // through.
                     const attempt = yield* Effect.result(
-                        executeStatements(combined, { chunkSize: 500, label: "cursor" }),
+                        Effect.gen(function* () {
+                            yield* executeStatements(dataStatements, { chunkSize: 500, label: "cursor" });
+                            yield* executeStatements(markStatements, { chunkSize: 500, label: "cursor" });
+                        }),
                     );
                     if (attempt._tag === "Success") {
                         for (const p of group) {
@@ -1219,11 +1237,11 @@ export const ingestCursor = Effect.fn("cursor.ingest")(
                         }
                         return;
                     }
-                    // Batch failed: retry each member alone so only the truly
-                    // bad session(s) skip. Statements are idempotent UPSERTs,
-                    // so partially-committed chunks re-apply safely. A
-                    // connection-level DbError rethrows out of isolate and
-                    // aborts the stage, exactly as before.
+                    // Batch failed (data or marks call): retry each member
+                    // alone so only the truly bad session(s) skip. Statements
+                    // are idempotent UPSERTs, so partially-committed chunks
+                    // re-apply safely. A connection-level DbError rethrows
+                    // out of isolate and aborts the stage, exactly as before.
                     yield* Effect.logDebug("cursor ingest: batch failed, falling back to per-session isolation", {
                         sessions: group.length,
                         message: attempt.failure.message,
@@ -1234,7 +1252,7 @@ export const ingestCursor = Effect.fn("cursor.ingest")(
                 });
 
             for (const p of pending) {
-                if (batch.length > 0 && batchStatements + p.statements.length + batch.length + 1 > CURSOR_BATCH_STATEMENT_BUDGET) {
+                if (batch.length > 0 && batchStatements + p.statements.length > CURSOR_BATCH_STATEMENT_BUDGET) {
                     yield* flush();
                 }
                 batch.push(p);

--- a/packages/lib/src/shared/watermark.ts
+++ b/packages/lib/src/shared/watermark.ts
@@ -50,6 +50,19 @@ const MIGRATION_SENTINEL_KEY = "id-unify-v1";
 export const watermarkRecordKey = (sourceKind: string, path: string): string =>
     stableDigest(`${sourceKind}|${path}`);
 
+/** The single watermark-commit UPSERT as a statement string, so stages that
+ *  batch many sessions' writes into one `executeStatements` call can append
+ *  their watermark commits to the SAME batch (cursor #bug-cursor-ingest)
+ *  instead of paying one round trip per mark. `commit()` executes exactly
+ *  this statement. */
+export const watermarkCommitStatement = (
+    sourceKind: string,
+    path: string,
+    mtimeMs: number,
+    size: number,
+): string =>
+    `UPSERT ${recordLiteral(WATERMARK_TABLE, watermarkRecordKey(sourceKind, path))} CONTENT { path: ${surrealString(path)}, source_kind: ${surrealString(sourceKind)}, mtime_ms: ${Math.trunc(mtimeMs)}, size: ${Math.trunc(size)}, ingested_at: time::now() };`;
+
 export interface FileWatermark {
     /** true ⇒ on-disk (mtime,size) matches the stored mark ⇒ caller should skip. */
     unchanged(path: string, mtimeMs: number, size: number): boolean;
@@ -110,9 +123,7 @@ export const fileWatermark = (
             commit: (path, mtimeMs, size) =>
                 executeStatementsWith(
                     db,
-                    [
-                        `UPSERT ${recordLiteral(WATERMARK_TABLE, watermarkRecordKey(cfg.sourceKind, path))} CONTENT { path: ${surrealString(path)}, source_kind: ${surrealString(cfg.sourceKind)}, mtime_ms: ${Math.trunc(mtimeMs)}, size: ${Math.trunc(size)}, ingested_at: time::now() };`,
-                    ],
+                    [watermarkCommitStatement(cfg.sourceKind, path, mtimeMs, size)],
                     { chunkSize: 1 },
                 ),
         } satisfies FileWatermark;


### PR DESCRIPTION
The cursor stage re-extracted and re-upserted every chat on every run at ~540ms/chat (per-transaction commit overhead — 2+ round trips per session), so a large store (~1,838 chats) took ~8.5min, pushed total ingest past AX_INGEST_TIMEOUT_SECONDS (900s), got killed → marked partial → restarted cursor from zero. That was the 'hang' (SurrealDB pinned at 99% CPU).

Fix (correctness-preserving):
- **Batch** many sessions' statements into few executeStatements calls instead of 2+ round-trips per session — amortizes the commit overhead well under the timeout.
- **Resumability:** per-session watermark skip, GATED on batch-data-success, so a killed+resumed run skips already-ingested sessions instead of re-extracting all from zero.
- **#261 per-session failure isolation PRESERVED** — one undecodable session still skips only itself (verified: 'out of isolate and aborts the stage, exactly as before').
- One-pass extract partition proven oracle-equivalent to the original.

User-reported (bug 1 of 3, the highest-impact). Small enabling lib export (`watermarkCommitStatement`, tested).

Gates: typecheck 0, cursor + batching + watermark tests 22/22, check:no-node-fs 0.

Generated with ax — https://github.com/Necmttn/ax