### PR TITLE
fix(otel): never define codex otel.exporter twice

### DIFF
--- a/apps/axctl/src/otel/install-config.test.ts
+++ b/apps/axctl/src/otel/install-config.test.ts
@@ -108,4 +108,88 @@ describe("install-config", () => {
         expect(next).toContain(`model = "gpt-5"`);
         expect(next).toContain("[otel]");
     });
+
+    // Codex rewrites config.toml itself (project trust, hooks.state, marketplaces)
+    // and when it does it drops comments and normalizes our inline exporter into
+    // an `[otel.exporter.otlp-http]` table. Our marker is gone, so a naive
+    // "marker missing → append" appends a SECOND definition of otel.exporter and
+    // codex dies at boot with `duplicate key`, breaking every codex command.
+    const NORMALIZED = [
+        `model = "gpt-5"`,
+        ``,
+        `[otel.exporter.otlp-http]`,
+        `endpoint = "${ENDPOINT}/v1/logs"`,
+        `protocol = "json"`,
+        ``,
+        `[tui]`,
+        `notifications = true`,
+        ``,
+    ].join("\n");
+
+    // Bun's TOML parser rejects a redefined key the same way codex's loader does
+    // ("Cannot redefine key 'exporter'"), so parsing IS the duplicate-key assertion.
+    const parseToml = (toml: string): Record<string, unknown> =>
+        Bun.TOML.parse(toml) as Record<string, unknown>;
+
+    test("codex toml leaves a codex-normalized exporter table alone (no duplicate key)", () => {
+        const next = applyCodexOtelToml(NORMALIZED, ENDPOINT);
+        expect(next).toBe(NORMALIZED); // already correct - nothing to do
+        parseToml(next); // throws on duplicate key
+    });
+
+    test("codex toml retargets a normalized exporter table in place", () => {
+        const stale = NORMALIZED.replace(`${ENDPOINT}/v1/logs`, "http://127.0.0.1:9999/v1/logs");
+        const next = applyCodexOtelToml(stale, ENDPOINT);
+        const cfg = parseToml(next) as {
+            otel: { exporter: { "otlp-http": { endpoint: string; protocol: string } } };
+            tui: { notifications: boolean };
+        };
+        expect(cfg.otel.exporter["otlp-http"].endpoint).toBe(`${ENDPOINT}/v1/logs`);
+        expect(cfg.otel.exporter["otlp-http"].protocol).toBe("json");
+        expect(cfg.tui.notifications).toBe(true); // later sections survive
+        expect(next).not.toContain("9999");
+        // Exactly one definition of the exporter, however it is spelled.
+        expect(next.match(/\[otel\.exporter|exporter = \{/g)?.length).toBe(1);
+    });
+
+    test("codex toml adds the exporter to an existing [otel] table without clobbering its keys", () => {
+        const existing = `[otel]\nlog_user_prompt = true\nenvironment = "dev"\n`;
+        const next = applyCodexOtelToml(existing, ENDPOINT);
+        const cfg = parseToml(next) as {
+            otel: {
+                log_user_prompt: boolean;
+                environment: string;
+                exporter: { "otlp-http": { endpoint: string } };
+            };
+        };
+        expect(cfg.otel.log_user_prompt).toBe(true); // user's own otel keys kept
+        expect(cfg.otel.environment).toBe("dev");
+        expect(cfg.otel.exporter["otlp-http"].endpoint).toBe(`${ENDPOINT}/v1/logs`);
+    });
+
+    test("codex toml repairs a config already broken by the duplicate", () => {
+        // What a machine hit by the old bug looks like: codex's normalized table
+        // AND an appended ax block. Codex cannot start until one of them goes.
+        const broken = `${NORMALIZED}\n# ax:otel\n[otel]\nexporter = { otlp-http = { endpoint = "${ENDPOINT}/v1/logs", protocol = "json" } }\n`;
+        expect(() => parseToml(broken)).toThrow(); // precondition: genuinely broken
+        const next = applyCodexOtelToml(broken, ENDPOINT);
+        const cfg = parseToml(next) as {
+            otel: { exporter: { "otlp-http": { endpoint: string } } };
+            tui: { notifications: boolean };
+        };
+        expect(cfg.otel.exporter["otlp-http"].endpoint).toBe(`${ENDPOINT}/v1/logs`);
+        expect(cfg.tui.notifications).toBe(true);
+        expect(next).not.toContain("# ax:otel"); // the appended block is what goes
+    });
+
+    test("codex toml applied twice over a codex rewrite stays valid", () => {
+        // Full round trip of the real failure: we write, codex normalizes and
+        // strips the comment, we run install again.
+        const ours = applyCodexOtelToml(`model = "gpt-5"\n`, ENDPOINT);
+        expect(ours).toContain("# ax:otel");
+        const afterCodexRewrite = NORMALIZED; // what codex leaves behind
+        const again = applyCodexOtelToml(afterCodexRewrite, ENDPOINT);
+        parseToml(again);
+        expect(again.match(/\[otel\.exporter|exporter = \{/g)?.length).toBe(1);
+    });
 });

--- a/apps/axctl/src/otel/install-config.ts
+++ b/apps/axctl/src/otel/install-config.ts
@@ -60,10 +60,11 @@ const CODEX_MARKER = "# ax:otel";
  *      full `/v1/logs` path - that is where ax's receiver takes Codex telemetry.
  *   3. `protocol` is Codex's own value `"json"` (not OTEL env's `"http/json"`).
  */
-const codexBlock = (endpoint: string): string => {
-    const logsEndpoint = `${endpoint.replace(/\/+$/, "")}/v1/logs`;
-    return `${CODEX_MARKER}\n[otel]\nexporter = { otlp-http = { endpoint = "${logsEndpoint}", protocol = "json" } }\n`;
-};
+const logsEndpoint = (endpoint: string): string => `${endpoint.replace(/\/+$/, "")}/v1/logs`;
+const exporterKeyLine = (endpoint: string): string =>
+    `exporter = { otlp-http = { endpoint = "${logsEndpoint(endpoint)}", protocol = "json" } }`;
+const codexBlock = (endpoint: string): string =>
+    `${CODEX_MARKER}\n[otel]\n${exporterKeyLine(endpoint)}\n`;
 
 // Matches the ax-owned marker + [otel] block until the next [section] header
 // (that is NOT [otel] itself) or end-of-string. The `?=\n\[(?!otel])` lookahead
@@ -71,17 +72,99 @@ const codexBlock = (endpoint: string): string => {
 const CODEX_BLOCK_RE = (): RegExp =>
     new RegExp(`${CODEX_MARKER}[\\s\\S]*?(?=\\n\\[(?!otel])|$)`, "g");
 
-/** Append/replace the ax-owned [otel] block in codex config.toml. */
+const SECTION_HEADER = /^\s*\[\[?([^\][]+)\]\]?\s*$/;
+
+interface Header { name: string; line: number }
+
+const headersOf = (lines: readonly string[]): Header[] => {
+    const out: Header[] = [];
+    lines.forEach((line, i) => {
+        const name = line.match(SECTION_HEADER)?.[1]?.trim();
+        if (name) out.push({ name, line: i });
+    });
+    return out;
+};
+
+/**
+ * Write ax's OTLP exporter into codex config.toml WITHOUT ever defining
+ * `otel.exporter` twice.
+ *
+ * Why this is not a simple append: codex rewrites config.toml itself (project
+ * trust entries, hooks.state, marketplaces) and when it does it drops comments
+ * - our `# ax:otel` marker included - and re-serializes our inline exporter as
+ * an `[otel.exporter.otlp-http]` table. A marker-only check then sees "no ax
+ * block" and appends a second definition, TOML rejects the duplicate key, and
+ * codex dies at startup before the TUI boots, taking every codex command and
+ * every fleet pane with it. So detect the exporter by SHAPE, not by marker, and
+ * update whatever is already there in place.
+ */
 export const applyCodexOtelToml = (toml: string, endpoint: string): string => {
-    const block = codexBlock(endpoint);
-    if (toml.includes(CODEX_MARKER)) {
-        // Check if the existing block matches what we'd write (idempotency).
-        const existingMatch = toml.match(CODEX_BLOCK_RE());
-        if (existingMatch && block.trimEnd() === existingMatch[0].trimEnd()) return toml;
-        // Strip prior ax-owned block, then append fresh.
-        const stripped = toml.replace(CODEX_BLOCK_RE(), "").trimEnd();
-        return (stripped ? `${stripped}\n\n` : "") + block;
+    const lines = toml.split("\n");
+    const headers = headersOf(lines);
+    const ownerOf = (line: number): string | undefined =>
+        headers.reduce<string | undefined>((own, h) => (h.line < line ? h.name : own), undefined);
+
+    // Shape A: an inline `exporter = { ... }` key - ours, or a root-level
+    // `otel.exporter = { ... }` dotted key. Rewrite the one line, keeping any
+    // sibling keys (and the marker comment, if it survived) untouched.
+    const inline = lines.findIndex((line, i) =>
+        /^\s*otel\s*\.\s*exporter\s*=/.test(line) ||
+        (/^\s*exporter\s*=/.test(line) && ownerOf(i) === "otel"));
+    const normalizedTable = headers.some((h) => h.name.startsWith("otel.exporter"));
+
+    // Both shapes present: a config already broken by the old append-on-missing-
+    // marker bug, which codex refuses to load at all. Drop the ax-owned block and
+    // fall through to updating the table codex itself wrote.
+    if (inline >= 0 && normalizedTable && toml.includes(CODEX_MARKER)) {
+        return applyCodexOtelToml(toml.replace(CODEX_BLOCK_RE(), "").trimEnd() + "\n", endpoint);
     }
-    const stripped = toml.trimEnd();
-    return (stripped ? `${stripped}\n\n` : "") + block;
+
+    if (inline >= 0) {
+        const dotted = /^\s*otel\s*\./.test(lines[inline] ?? "");
+        const next = dotted ? `otel.${exporterKeyLine(endpoint)}` : exporterKeyLine(endpoint);
+        if (lines[inline] === next) return toml;
+        lines[inline] = next;
+        return lines.join("\n");
+    }
+
+    // Shape B: codex's normalized `[otel.exporter.<kind>]` table.
+    const tableIdx = headers.findIndex((h) => h.name === "otel.exporter" || h.name.startsWith("otel.exporter."));
+    const table = headers[tableIdx];
+    if (table) {
+        // A deliberately different exporter kind (otlp-grpc, none). Retargeting
+        // it would be wrong and appending would duplicate - leave it alone.
+        if (table.name !== "otel.exporter.otlp-http") return toml;
+        const end = headers[tableIdx + 1]?.line ?? lines.length;
+        const want = { endpoint: `endpoint = "${logsEndpoint(endpoint)}"`, protocol: `protocol = "json"` };
+        const seen = { endpoint: false, protocol: false };
+        let changed = false;
+        for (let i = table.line + 1; i < end; i++) {
+            const key = (["endpoint", "protocol"] as const).find((k) =>
+                new RegExp(`^\\s*${k}\\s*=`).test(lines[i] ?? ""));
+            if (!key) continue;
+            seen[key] = true;
+            if (lines[i] === want[key]) continue;
+            lines[i] = want[key];
+            changed = true;
+        }
+        const missing = (["endpoint", "protocol"] as const).filter((k) => !seen[k]).map((k) => want[k]);
+        if (missing.length > 0) {
+            lines.splice(table.line + 1, 0, ...missing);
+            changed = true;
+        }
+        return changed ? lines.join("\n") : toml;
+    }
+
+    // An `[otel]` table with other keys (log_user_prompt, environment, ...) but
+    // no exporter: add the key to it rather than opening a second [otel].
+    const otelTable = headers.find((h) => h.name === "otel");
+    if (otelTable) {
+        lines.splice(otelTable.line + 1, 0, exporterKeyLine(endpoint));
+        return lines.join("\n");
+    }
+
+    // No otel config at all - append the ax-owned block (dropping any stale
+    // marker whose body we could not recognise).
+    const stripped = (toml.includes(CODEX_MARKER) ? toml.replace(CODEX_BLOCK_RE(), "") : toml).trimEnd();
+    return (stripped ? `${stripped}\n\n` : "") + codexBlock(endpoint);
 };


### PR DESCRIPTION
## The bug

`ax install` appended its `[otel]` block whenever the `# ax:otel` marker was
missing. But codex rewrites `~/.codex/config.toml` itself (project trust
entries, `hooks.state`, `marketplaces`) and that rewrite **drops comments** and
re-serializes our inline exporter as an `[otel.exporter.otlp-http]` table.

Marker gone -> next install appends a second definition of `otel.exporter` ->
TOML duplicate key -> codex exits before the TUI boots. Every codex command and
every fleet pane dies with no output:

```
Error loading config.toml:
/Users/necmttn/.codex/config.toml:241:1: duplicate key
241 | exporter = { otlp-http = { endpoint = "http://127.0.0.1:1738/v1/logs", protocol = "json" } }
```

This is the second time it has fired on the same machine (first: 2026-07-19,
shaketoship-plat fleet run, where every codex pane vanished at spawn).

## The fix

Detect the exporter by **shape**, not by marker, and update in place:

| existing config | action |
|---|---|
| inline `exporter = {...}` under `[otel]`, or root `otel.exporter` dotted key | rewrite that one line, siblings kept |
| codex's `[otel.exporter.otlp-http]` table | retarget `endpoint`/`protocol` field by field |
| `[otel.exporter.<other kind>]` (grpc, none) | left untouched - never duplicated |
| `[otel]` with only user keys (`log_user_prompt`, ...) | add the exporter key to it |
| both shapes present (already broken) | drop the ax block, keep codex's table - self-heals |
| no otel config | append the marker block, as before |

## Verification

- 15/15 in `install-config.test.ts`, 5 of them new; the 4 regression tests fail
  on the parent commit with the exact production error (`Cannot redefine key
  'exporter'`). Bun's TOML parser rejects the duplicate the same way codex's
  loader does, so parsing IS the assertion.
- Run against the real config that broke today: returns it unchanged, stable on
  a second pass, one exporter definition.
- Run against the broken backup: healed output is **byte-identical** to the hand
  fix, all 17 top-level sections preserved.
- Full `axctl` suite: 4188 pass / 25 fail - the same 25 fail on `main`
  (classifier package, ClassifierPackageService, ingestGit, CLI help drift),
  untouched by this change. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)