### PR TITLE
fix(ingest): record blocked hook fires from tool-result text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,6 +493,23 @@ warn / inject; defects fail OPEN. `GitEnv` service makes guards layer-testable.
   duration_ms is absent (provider-reported; run bench for synthetic measure).
 - `ax hooks cases` - deterministic feedback-case backtests (enforce-worktree
   candidate query + structured pass/fail verdict; separate from backtest)
+- **What ax can observe about hook fires (#743).** Claude Code records a fire in
+  only two ways, and ax reads both: a `hook_success` attachment (written ONLY
+  when the hook produced stdout/stderr/content) and, for a BLOCKED call, the
+  tool_result text `PreToolUse:Bash hook error: [<command>]: <msg>` - parsed by
+  `parseHookBlocksFromText` (`apps/axctl/src/ingest/hook-block-text.ts`) into the
+  same `harness_hook_event` + `hook_command_invocation` rows, `source_type =
+  "tool_result_text"`, keyed so an attachment and a text fire collapse into one
+  row. Current CC emits NO `hook_progress` and NO `hook_blocking_error`
+  attachment; the legacy shapes stay parsed for old transcripts. A hook that
+  passes SILENTLY is written nowhere, so an empty `ax hooks summary` is not
+  evidence a hook never ran - both hook tables say so in their empty state
+  (`HOOK_EMPTY_NOTE`). Agent-tool hooks are additionally exempt upstream (CC
+  #39814/#40580); their advice is captured by the advise-tap, not the transcript.
+  Backfilling blocked fires from older transcripts needs
+  `ax ingest --reparse=claude` (watermarked files are skipped otherwise;
+  `apps/axctl/src/ingest/reparse-targets.ts` maps each target to its
+  `AX_REDERIVE_*` switch).
 - Codex: new hook entries written to `~/.codex/hooks.json` when that file
   exists; falls back to `~/.codex/config.toml` otherwise. New/changed entries
   require interactive trust approval in the codex TUI before they fire.

--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -18,6 +18,11 @@ import { selectByKeys, selectByTag } from "../../ingest/stage/select.ts";
 import { type BaseStageStats, type StageDef } from "../../ingest/stage/types.ts";
 import { resolvePwdRepository } from "../../pwd.ts";
 import { estimateIngest, formatDryRun } from "../../ingest/dry-run.ts";
+import {
+    applyReparseSelection,
+    REPARSE_TARGETS,
+    resolveReparseTargets,
+} from "../../ingest/reparse-targets.ts";
 // backfillInvokedPositions - Phase B will register this as invokedPositionsStage.
 import { deriveSignals } from "../../ingest/derive-signals.ts";
 import { deriveTurnIntents } from "../../ingest/derive-intents.ts";
@@ -522,30 +527,57 @@ export const insightsOnlyConflicts = (opts: {
     return conflicts;
 };
 
+/**
+ * `--reparse[=<targets>]` - drop the skip-unchanged watermark for those inputs
+ * so ingest reads them again (#743). Needed after any parser change that
+ * recovers evidence from files ax already marked as done; without it the fix
+ * only ever applies to files written after it shipped.
+ *
+ * Sets the stages' existing `AX_REDERIVE_*` switches, so this is a discoverable
+ * name for a mechanism that already worked - not a second code path.
+ */
+const reparseFlag = Flag.string("reparse").pipe(Flag.optional);
+
+const applyReparseFlag = (raw: string | undefined, label: string): void => {
+    const selection = resolveReparseTargets(raw);
+    if (selection.unknown.length > 0) {
+        fail(
+            `${label}: unknown --reparse target${selection.unknown.length > 1 ? "s" : ""} ` +
+                `${selection.unknown.join(", ")} (known: ${REPARSE_TARGETS.join(", ")}, or all)`,
+        );
+    }
+    applyReparseSelection(selection);
+    console.log(`reparse: ignoring the skip-unchanged watermark for ${selection.targets.join(", ")}`);
+};
+
 
 const ingestHereCommand = Command.make(
     "here",
     {
         since: optionalSince,
         stages: Flag.string("stages").pipe(Flag.optional),
+        reparse: reparseFlag,
         progress: progressFlag,
         verbose: verboseFlag,
         debug: debugFlag,
     },
-    ({ since, stages, progress, verbose, debug }) =>
-        cmdIngestHere([
+    ({ since, stages, reparse, progress, verbose, debug }) => {
+        if (Option.isSome(reparse)) applyReparseFlag(optionValue(reparse), "axctl ingest here");
+        return cmdIngestHere([
             ...intArg("since", optionValue(since)),
             ...stringArg("stages", optionValue(stages)),
             `--progress=${progress}`,
             ...boolArg("verbose", verbose),
             ...boolArg("debug", debug),
-        ]),
+        ]);
+    },
 ).pipe(Command.withDescription(
     "Ingest only the git repository at $PWD. Restricts the claude stage to the matching " +
         "~/.claude/projects/<slug>/ transcript dir, scopes codex sessions to those whose cwd is " +
         "inside this repo, and restricts git history to this repo path. " +
         "Pi, OpenCode, and Cursor are skipped by default (no cwd filter yet). " +
-        "--stages=<a,b,c> overrides the default set.",
+        "--stages=<a,b,c> overrides the default set. " +
+        "--reparse=<targets|all> re-reads inputs the skip-unchanged watermark would skip.",
 ));
 
 const ingestReapCommand = Command.make(
@@ -592,11 +624,14 @@ export const ingestCommand = Command.make(
         dryRun: Flag.boolean("dry-run").pipe(Flag.withDefault(false)),
         json: jsonFlag,
         since: optionalSince,
+        // Re-read inputs whose watermark says "unchanged" (see reparseFlag).
+        reparse: reparseFlag,
         progress: progressFlag,
         verbose: verboseFlag,
         debug: debugFlag,
     },
-    ({ insightsOnly, stages, deriveOnly, reset, dryRun, json, since, progress, verbose, debug }) => {
+    ({ insightsOnly, stages, deriveOnly, reset, dryRun, json, since, reparse, progress, verbose, debug }) => {
+        if (Option.isSome(reparse)) applyReparseFlag(optionValue(reparse), "axctl ingest");
         if (dryRun) {
             // Same runtime layer (IngestRuntimeLayer via withIngest) provides
             // estimateIngest's services (AxConfig/FS/Path/SurrealClient); the cast
@@ -637,7 +672,10 @@ export const ingestCommand = Command.make(
             "Use --dry-run [--json] to estimate how long a full backfill will take (and exit). " +
             "Use --stages=<a,b,c> for a custom subset, or --derive-only to run every stage tagged `derive` " +
             "(see ADR-0009; canonical list lives in src/ingest/stage/registry.ts). " +
-            "Use --reset to wipe the skill graph first and rebuild it clean.",
+            "Use --reset to wipe the skill graph first and rebuild it clean. " +
+            "Use --reparse=<targets|all> (e.g. --reparse=claude) to ignore the skip-unchanged " +
+            "watermark and re-read inputs ax already ingested - needed to backfill evidence a " +
+            "parser fix newly recovers.",
     ),
     Command.withSubcommands([ingestHereCommand, ingestReapCommand]),
 );

--- a/apps/axctl/src/ingest/hook-block-text.test.ts
+++ b/apps/axctl/src/ingest/hook-block-text.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { parseHookBlocksFromText } from "./hook-block-text.ts";
+
+describe("parseHookBlocksFromText", () => {
+    test("recovers a PreToolUse block exactly as Claude Code writes it", () => {
+        // Verbatim shape from ~/.claude/projects/**/*.jsonl (CC 2.1.x).
+        const text =
+            "PreToolUse:Bash hook error: [bun /Users/x/.ax/hooks/enforce-worktree.ts # ax:74da7418]: BLOCKED: history-mutating git op against a DIRTY primary working tree.\n\n  target tree : /Users/x/Projects/apps";
+        const fires = parseHookBlocksFromText(text);
+        expect(fires).toHaveLength(1);
+        expect(fires[0]!.eventName).toBe("PreToolUse");
+        expect(fires[0]!.tool).toBe("Bash");
+        expect(fires[0]!.hookName).toBe("PreToolUse:Bash");
+        expect(fires[0]!.command).toBe("bun /Users/x/.ax/hooks/enforce-worktree.ts # ax:74da7418");
+        expect(fires[0]!.message).toStartWith("BLOCKED: history-mutating git op");
+        expect(fires[0]!.message).toEndWith("/Users/x/Projects/apps");
+    });
+
+    test("handles the ax:hook marker prefix the install path writes", () => {
+        const text =
+            "PreToolUse:Agent hook error: [echo 'ax:hook__17b5aaf6aade53e5' >/dev/null; /Users/x/hooks/dispatch-model-guard.sh]: this Agent dispatch names no model";
+        const fires = parseHookBlocksFromText(text);
+        expect(fires).toHaveLength(1);
+        expect(fires[0]!.command).toContain("dispatch-model-guard.sh");
+        expect(fires[0]!.message).toBe("this Agent dispatch names no model");
+    });
+
+    test("splits several hooks blocking the same call", () => {
+        const text = [
+            "PreToolUse:Write hook error: [bun /h/a.ts]: first said no",
+            "PreToolUse:Write hook error: [bun /h/b.ts]: second said no too",
+        ].join("\n");
+        const fires = parseHookBlocksFromText(text);
+        expect(fires.map((f) => f.command)).toEqual(["bun /h/a.ts", "bun /h/b.ts"]);
+        expect(fires[0]!.message).toBe("first said no");
+        expect(fires[1]!.message).toBe("second said no too");
+    });
+
+    test("accepts session-scoped events with no tool suffix", () => {
+        const fires = parseHookBlocksFromText("Stop hook error: [node /h/gate.mjs]: not done yet");
+        expect(fires).toHaveLength(1);
+        expect(fires[0]!.tool).toBeNull();
+        expect(fires[0]!.hookName).toBe("Stop");
+    });
+
+    test("keeps an empty message when the hook printed nothing after the prefix", () => {
+        const fires = parseHookBlocksFromText("PostToolUse:Edit hook error: [/h/fmt.sh]:");
+        expect(fires).toHaveLength(1);
+        expect(fires[0]!.message).toBe("");
+    });
+
+    test("ignores ordinary tool output, errors included", () => {
+        expect(parseHookBlocksFromText("error: command not found: rtk")).toEqual([]);
+        expect(parseHookBlocksFromText("Error: ENOENT [/tmp/x]: no such file")).toEqual([]);
+        expect(parseHookBlocksFromText(null)).toEqual([]);
+        expect(parseHookBlocksFromText("")).toEqual([]);
+    });
+
+    test("ignores an unknown event name", () => {
+        expect(parseHookBlocksFromText("PreCommitUse:Bash hook error: [x]: nope")).toEqual([]);
+    });
+
+    test("does not let a bracket-less message swallow following text", () => {
+        const text = "PreToolUse:Bash hook error: [x.sh]: nope\nunrelated line";
+        expect(parseHookBlocksFromText(text)[0]!.message).toBe("nope\nunrelated line");
+    });
+});

--- a/apps/axctl/src/ingest/hook-block-text.ts
+++ b/apps/axctl/src/ingest/hook-block-text.ts
@@ -1,0 +1,106 @@
+/**
+ * hook-block-text: recover BLOCKED hook fires from Claude Code tool-result text.
+ *
+ * Why this exists (#743). ax used to learn about hook fires from exactly two
+ * transcript shapes, both written by the harness as structured records:
+ *
+ *   - `data.type === "hook_progress"`   (streamed progress lines)
+ *   - `attachment.type === "hook_success" | "hook_blocking_error"
+ *      | "hook_additional_context"`     (terminal outcome attachments)
+ *
+ * Current Claude Code (2.1.x) emits NEITHER `hook_progress` NOR
+ * `hook_blocking_error`. A hook that BLOCKS a tool call is recorded only as the
+ * text of the tool_result the model receives:
+ *
+ *   PreToolUse:Bash hook error: [bun ~/.ax/hooks/enforce-worktree.ts # ax:74da7418]: BLOCKED: ...
+ *
+ * and (redundantly) on the entry's `toolUseResult` string. `hook_success`
+ * attachments, meanwhile, appear only when the hook actually PRODUCED output.
+ * The combination makes the most consequential guard shape - silent on pass,
+ * blocking on fail - completely invisible in the graph: `ax hooks summary`
+ * showed zero rows for guards the transcripts prove fired dozens of times.
+ *
+ * So this module parses that one line shape back into structured fires. It is
+ * pure and string-in/values-out on purpose: the transcript parser owns keys,
+ * upserts and dedupe (a text-derived fire and an attachment-derived fire for
+ * the same (event, command) collapse onto the same invocation key).
+ *
+ * Scope is deliberately narrow: ONLY the `<Event>[:<Tool>] hook error: [<cmd>]:`
+ * prefix. Non-blocking silent fires remain unobservable - the harness does not
+ * write them anywhere, and inventing them would be fabrication, not recovery.
+ */
+
+/** Hook events Claude Code can name in a `... hook error:` line. */
+const HOOK_EVENT_NAMES = [
+    "PreToolUse",
+    "PostToolUse",
+    "UserPromptSubmit",
+    "Stop",
+    "SubagentStop",
+    "SessionStart",
+    "SessionEnd",
+    "PreCompact",
+    "Notification",
+] as const;
+
+export type HookBlockEventName = (typeof HOOK_EVENT_NAMES)[number];
+
+/**
+ * `PreToolUse:Bash hook error: [<command>]: ` - the whole prefix, with the
+ * command captured. Tool suffix is optional (session-scoped events carry none).
+ * The command is bounded to one line so a runaway `]`-free message can never
+ * swallow the rest of the transcript.
+ */
+const HOOK_ERROR_RE = new RegExp(
+    String.raw`(${HOOK_EVENT_NAMES.join("|")})(?::([A-Za-z_][\w.-]*))? hook error: \[([^\]\n]+)\]:`,
+    "g",
+);
+
+/** One blocked hook fire recovered from tool-result text. */
+export interface HookBlockFire {
+    /** Harness event, e.g. "PreToolUse". */
+    readonly eventName: HookBlockEventName;
+    /** Tool the matcher fired on, e.g. "Bash"; null for session-scoped events. */
+    readonly tool: string | null;
+    /** `<event>:<tool>` when a tool is named, else `<event>` - matches the
+     *  `hook_name` granularity the attachment path already writes. */
+    readonly hookName: string;
+    /** The hook command exactly as the harness printed it. */
+    readonly command: string;
+    /** Everything the hook said after the prefix, trimmed; "" when it said nothing. */
+    readonly message: string;
+}
+
+/**
+ * Extract every blocked-hook fire named in one tool-result text.
+ *
+ * Multiple hooks can block the same call, in which case the harness
+ * concatenates their lines; each match's message runs to the start of the next
+ * match (or to the end of the text).
+ *
+ * Returns `[]` for text that names no hook - the common case, so the cheap
+ * `includes` pre-check keeps this off the hot path for ordinary tool output.
+ */
+export const parseHookBlocksFromText = (
+    text: string | null | undefined,
+): ReadonlyArray<HookBlockFire> => {
+    if (!text || !text.includes(" hook error: [")) return [];
+    const fires: HookBlockFire[] = [];
+    const matches = [...text.matchAll(HOOK_ERROR_RE)];
+    for (const [index, match] of matches.entries()) {
+        const eventName = match[1] as HookBlockEventName | undefined;
+        const command = match[3];
+        if (!eventName || !command) continue;
+        const tool = match[2] ?? null;
+        const start = (match.index ?? 0) + match[0].length;
+        const end = matches[index + 1]?.index ?? text.length;
+        fires.push({
+            eventName,
+            tool,
+            hookName: tool ? `${eventName}:${tool}` : eventName,
+            command,
+            message: text.slice(start, end).trim(),
+        });
+    }
+    return fires;
+};

--- a/apps/axctl/src/ingest/reparse-targets.test.ts
+++ b/apps/axctl/src/ingest/reparse-targets.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+    applyReparseSelection,
+    REPARSE_TARGET_ENV,
+    REPARSE_TARGETS,
+    resolveReparseTargets,
+} from "./reparse-targets.ts";
+
+describe("resolveReparseTargets", () => {
+    test("a bare flag means every target", () => {
+        const bare = resolveReparseTargets(undefined);
+        expect(bare.targets).toEqual(REPARSE_TARGETS);
+        expect(bare.unknown).toEqual([]);
+        expect(resolveReparseTargets("").targets).toEqual(REPARSE_TARGETS);
+        expect(resolveReparseTargets("all").targets).toEqual(REPARSE_TARGETS);
+    });
+
+    test("resolves a named subset to its env vars", () => {
+        const sel = resolveReparseTargets("claude,git");
+        expect(sel.targets).toEqual(["claude", "git"]);
+        expect(sel.envVars).toEqual(["AX_REDERIVE_CLAUDE", "AX_REDERIVE_GIT"]);
+    });
+
+    test("tolerates spacing, case and duplicates", () => {
+        const sel = resolveReparseTargets(" Claude , claude,  GIT ");
+        expect(sel.targets).toEqual(["claude", "git"]);
+    });
+
+    test("reports unknown names instead of silently ignoring them", () => {
+        const sel = resolveReparseTargets("cluade,git");
+        expect(sel.unknown).toEqual(["cluade"]);
+        expect(sel.targets).toEqual(["git"]);
+    });
+
+    test("every target maps to a distinct AX_REDERIVE_* var", () => {
+        const vars = REPARSE_TARGETS.map((t) => REPARSE_TARGET_ENV[t]);
+        expect(new Set(vars).size).toBe(vars.length);
+        for (const v of vars) expect(v).toStartWith("AX_REDERIVE_");
+    });
+});
+
+describe("applyReparseSelection", () => {
+    test("sets each env var to 1 on the given env", () => {
+        const env: Record<string, string | undefined> = {};
+        applyReparseSelection(resolveReparseTargets("claude"), env);
+        expect(env).toEqual({ AX_REDERIVE_CLAUDE: "1" });
+    });
+
+    test("leaves unrelated vars untouched", () => {
+        const env: Record<string, string | undefined> = { PATH: "/bin" };
+        applyReparseSelection(resolveReparseTargets("git"), env);
+        expect(env.PATH).toBe("/bin");
+        expect(env.AX_REDERIVE_GIT).toBe("1");
+        expect(env.AX_REDERIVE_CLAUDE).toBeUndefined();
+    });
+});

--- a/apps/axctl/src/ingest/reparse-targets.ts
+++ b/apps/axctl/src/ingest/reparse-targets.ts
@@ -1,0 +1,96 @@
+/**
+ * reparse-targets: the user-facing name for "ignore the skip-unchanged
+ * watermark and read these inputs again".
+ *
+ * Ingest is incremental - a transcript whose `(mtime,size)` still matches its
+ * `ingest_file_state` mark is skipped entirely. That is right for steady-state
+ * runs and WRONG after a parser change: the new parser never sees the old
+ * files, so a fix that recovers previously-unparsed evidence (#743's blocked
+ * hook fires) appears to do nothing on existing history.
+ *
+ * Each stage already honors an `AX_REDERIVE_*` env var for exactly this, but an
+ * env var nobody can discover from `--help` is not a feature. This module is
+ * the one place that maps a target NAME to its env var, so `ax ingest
+ * --reparse=claude` and the underlying force switch cannot drift apart.
+ */
+
+/** Target name -> the env var whose "1" value forces that input to be re-read. */
+export const REPARSE_TARGET_ENV = {
+    claude: "AX_REDERIVE_CLAUDE",
+    subagents: "AX_REDERIVE_SUBAGENTS",
+    codex: "AX_REDERIVE_CODEX",
+    pi: "AX_REDERIVE_PI",
+    omp: "AX_REDERIVE_OMP",
+    cursor: "AX_REDERIVE_CURSOR",
+    git: "AX_REDERIVE_GIT",
+    closure: "AX_REDERIVE_CLOSURE",
+    pricing: "AX_REDERIVE_PRICING",
+    metrics: "AX_REDERIVE_METRICS",
+    analysis: "AX_REDERIVE_ANALYSIS",
+    content: "AX_REDERIVE_CONTENT",
+} as const satisfies Record<string, string>;
+
+export type ReparseTarget = keyof typeof REPARSE_TARGET_ENV;
+
+/** Every target name, in the order `--help` and error text should list them. */
+export const REPARSE_TARGETS = Object.keys(REPARSE_TARGET_ENV) as ReparseTarget[];
+
+/** The wildcard accepted in place of a target list. */
+export const REPARSE_ALL = "all";
+
+export interface ReparseSelection {
+    /** Env vars to set to "1", deduped, in {@link REPARSE_TARGETS} order. */
+    readonly envVars: ReadonlyArray<string>;
+    /** Target names that matched, for the "re-reading X, Y" progress line. */
+    readonly targets: ReadonlyArray<ReparseTarget>;
+    /** Names that matched nothing - the caller turns these into a usage error. */
+    readonly unknown: ReadonlyArray<string>;
+}
+
+/**
+ * Resolve a `--reparse` value ("claude,git", "all", or "" for the bare flag,
+ * which means all) into env vars.
+ *
+ * Unknown names are REPORTED, never silently dropped: a typo'd `--reparse=cluade`
+ * that quietly ran a normal incremental ingest would look exactly like the bug
+ * the user is trying to clear.
+ */
+export const resolveReparseTargets = (raw: string | undefined): ReparseSelection => {
+    const requested = (raw ?? "")
+        .split(",")
+        .map((part) => part.trim().toLowerCase())
+        .filter((part) => part.length > 0);
+
+    if (requested.length === 0 || requested.includes(REPARSE_ALL)) {
+        return {
+            envVars: REPARSE_TARGETS.map((t) => REPARSE_TARGET_ENV[t]),
+            targets: REPARSE_TARGETS,
+            unknown: [],
+        };
+    }
+
+    const matched = new Set<ReparseTarget>();
+    const unknown: string[] = [];
+    for (const name of requested) {
+        if ((REPARSE_TARGETS as string[]).includes(name)) matched.add(name as ReparseTarget);
+        else unknown.push(name);
+    }
+    const targets = REPARSE_TARGETS.filter((t) => matched.has(t));
+    return {
+        envVars: targets.map((t) => REPARSE_TARGET_ENV[t]),
+        targets,
+        unknown,
+    };
+};
+
+/**
+ * Apply a selection by setting each env var to "1" on the given environment
+ * (defaults to `process.env`). Stages read these when they build their
+ * watermark, so this must run BEFORE the ingest starts.
+ */
+export const applyReparseSelection = (
+    selection: ReparseSelection,
+    env: Record<string, string | undefined> = process.env,
+): void => {
+    for (const name of selection.envVars) env[name] = "1";
+};

--- a/apps/axctl/src/ingest/transcripts.test.ts
+++ b/apps/axctl/src/ingest/transcripts.test.ts
@@ -1362,6 +1362,86 @@ describe("Claude transcript extraction", () => {
             },
         ]);
     });
+
+    // #743: current Claude Code writes NO hook_blocking_error attachment. A
+    // blocked call survives only as the tool_result text, so a guard that is
+    // silent on pass and blocking on fail was invisible in the graph.
+    test("recovers a blocked hook from tool_result text when no attachment exists", () => {
+        const extracted = __testExtractClaudeJsonlLines(
+            [
+                JSON.stringify({
+                    type: "assistant",
+                    timestamp: "2026-08-05T07:38:28.000Z",
+                    cwd: "/Users/necmttn/Projects/ax",
+                    message: {
+                        content: [
+                            {
+                                type: "tool_use",
+                                id: "toolu_blocked",
+                                name: "Bash",
+                                input: { command: "git reset --hard" },
+                            },
+                        ],
+                    },
+                }),
+                JSON.stringify({
+                    type: "user",
+                    uuid: "blocked-result-uuid",
+                    timestamp: "2026-08-05T07:38:28.500Z",
+                    cwd: "/Users/necmttn/Projects/ax",
+                    message: {
+                        role: "user",
+                        content: [
+                            {
+                                type: "tool_result",
+                                tool_use_id: "toolu_blocked",
+                                is_error: true,
+                                content:
+                                    "PreToolUse:Bash hook error: [bun /Users/necmttn/.ax/hooks/enforce-worktree.ts # ax:74da7418]: BLOCKED: history-mutating git op against a DIRTY primary working tree.",
+                            },
+                        ],
+                    },
+                    toolUseResult:
+                        "Error: PreToolUse:Bash hook error: [bun /Users/necmttn/.ax/hooks/enforce-worktree.ts # ax:74da7418]: BLOCKED: history-mutating git op against a DIRTY primary working tree.",
+                }),
+            ],
+            "-Users-necmttn-Projects-ax",
+            "claude-hook-text-session",
+        );
+
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+
+        expect(extracted.hookEvents.map((e) => ({
+            event_name: e.event_name,
+            hook_name: e.hook_name,
+            tool_call_id: e.tool_call_id,
+            source_type: e.source_type,
+        }))).toEqual([
+            {
+                event_name: "PreToolUse",
+                hook_name: "PreToolUse:Bash",
+                tool_call_id: "toolu_blocked",
+                source_type: "tool_result_text",
+            },
+        ]);
+        expect(extracted.hookCommandInvocations).toHaveLength(1);
+        const invocation = extracted.hookCommandInvocations[0]!;
+        expect(invocation.command).toBe(
+            "bun /Users/necmttn/.ax/hooks/enforce-worktree.ts # ax:74da7418",
+        );
+        expect(invocation.provider_status).toBe("blocking_error");
+        expect(invocation.effect).toBe("blocked");
+        expect(invocation.blocking_error_excerpt).toStartWith("BLOCKED: history-mutating git op");
+        // The blocked call is still linked to the tool_call it stopped.
+        expect(invocation.tool_call_key).toBe(
+            toolCallRecordKey({
+                sessionId: "claude-hook-text-session",
+                seq: 1,
+                callId: "toolu_blocked",
+            }),
+        );
+    });
 });
 
 describe("claude compaction", () => {

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -62,6 +62,7 @@ import {
     surrealOptionFloat,
 } from "./token-usage-writers.ts";
 import { decodeClaudeTranscriptLine } from "./line-schemas.ts";
+import { parseHookBlocksFromText } from "./hook-block-text.ts";
 import { claudeEffortStamp, loadClaudeEffortLevel } from "./claude-effort.ts";
 
 import { selectByIds } from "@ax/lib/shared/record-select";
@@ -854,16 +855,60 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
         }
     };
 
+    /**
+     * Recover blocked-hook fires from a tool_result's text (#743).
+     *
+     * Current Claude Code writes no `hook_blocking_error` attachment - a block
+     * survives only as the `PreToolUse:Bash hook error: [<cmd>]: ...` line the
+     * model reads. Without this, guards that are silent-on-pass and blocking
+     * -on-fail leave NO trace in the graph. Keys match the attachment path, so
+     * a transcript that carries both shapes still yields one invocation row.
+     */
+    const processHookBlocksInText = (
+        text: string | null,
+        ts: string,
+        turnCwd: string | null,
+        toolUseId: string | null,
+        entry: Record<string, unknown>,
+    ): void => {
+        for (const fire of parseHookBlocksFromText(text)) {
+            const eventKey = upsertHookEvent({
+                ts,
+                turnCwd,
+                hookEvent: fire.eventName,
+                hookName: fire.hookName,
+                toolUseId,
+                transcriptUuid: stringField(entry, "uuid"),
+                sourceType: "tool_result_text",
+            });
+            if (!eventKey) continue;
+            upsertHookInvocation({
+                eventKey,
+                ts,
+                hookEvent: fire.eventName,
+                hookName: fire.hookName,
+                toolUseId,
+                command: fire.command,
+                providerStatus: "blocking_error",
+                effect: "blocked",
+                blockingError: fire.message.length > 0 ? fire.message : null,
+            });
+        }
+    };
+
     const processToolResult = (
         block: Record<string, unknown>,
         ts: string,
         role: string,
         parentProviderEventId: string | null,
         topLevelToolUseResult: unknown,
+        turnCwd: string | null,
+        entry: Record<string, unknown>,
     ): boolean => {
         const callId = stringField(block, "tool_use_id");
         const hasError = block.is_error === true;
         const text = outputText(block.content ?? null);
+        processHookBlocksInText(text, ts, turnCwd, callId, entry);
         const eventSeq = nextProviderSeq();
         const result: ToolResultFields = {
             outputJson: block.content ?? null,
@@ -1095,7 +1140,7 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
                 }
                 if (
                     blockType === "tool_result" &&
-                    processToolResult(block, ts, role, providerEventId, rawEntry.toolUseResult)
+                    processToolResult(block, ts, role, providerEventId, rawEntry.toolUseResult, turnCwd, rawEntry)
                 ) {
                     hasError = true;
                 }

--- a/apps/axctl/src/queries/hooks.format.test.ts
+++ b/apps/axctl/src/queries/hooks.format.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+    formatHookInvocationRows,
+    formatHookSummaryRows,
+    HOOK_EMPTY_NOTE,
+    type HookInvocationRow,
+    type HookSummaryRow,
+} from "./hooks.ts";
+
+describe("hook table empty state (#743)", () => {
+    test("summary says what silence means instead of printing a bare header", () => {
+        const out = formatHookSummaryRows([]);
+        expect(out).toBe(HOOK_EMPTY_NOTE);
+        expect(out).not.toStartWith("count\t");
+        expect(out).toContain("not proof");
+        expect(out).toContain("--reparse=claude");
+    });
+
+    test("invocations uses the same note", () => {
+        expect(formatHookInvocationRows([])).toBe(HOOK_EMPTY_NOTE);
+    });
+
+    test("rows still render as TSV with a header", () => {
+        const summary = formatHookSummaryRows([
+            {
+                count: 3,
+                provider_status: "blocking_error",
+                effect: "blocked",
+                avg_duration_ms: null,
+                max_duration_ms: null,
+                last_seen: "2026-08-05T09:00:00.000Z",
+                hook_name: "PreToolUse:Bash",
+                command: "bun /h/enforce-worktree.ts",
+            } as HookSummaryRow,
+        ]);
+        expect(summary.split("\n")[0]).toStartWith("count\t");
+        expect(summary).toContain("PreToolUse:Bash");
+
+        const invocations = formatHookInvocationRows([
+            {
+                ts: "2026-08-05T09:00:00.000Z",
+                session: "session:abc",
+                provider_status: "blocking_error",
+                effect: "blocked",
+                duration_ms: null,
+                hook_name: "PreToolUse:Bash",
+                command: "bun /h/enforce-worktree.ts",
+                blocking_error_excerpt: "BLOCKED: dirty tree",
+                stderr_excerpt: null,
+                stdout_excerpt: null,
+            } as HookInvocationRow,
+        ]);
+        expect(invocations.split("\n")[0]).toStartWith("ts\t");
+        expect(invocations).toContain("BLOCKED: dirty tree");
+    });
+});

--- a/apps/axctl/src/queries/hooks.format.test.ts
+++ b/apps/axctl/src/queries/hooks.format.test.ts
@@ -26,12 +26,10 @@ describe("hook table empty state (#743)", () => {
                 count: 3,
                 provider_status: "blocking_error",
                 effect: "blocked",
-                avg_duration_ms: null,
-                max_duration_ms: null,
                 last_seen: "2026-08-05T09:00:00.000Z",
                 hook_name: "PreToolUse:Bash",
                 command: "bun /h/enforce-worktree.ts",
-            } as HookSummaryRow,
+            } satisfies HookSummaryRow,
         ]);
         expect(summary.split("\n")[0]).toStartWith("count\t");
         expect(summary).toContain("PreToolUse:Bash");
@@ -40,15 +38,13 @@ describe("hook table empty state (#743)", () => {
             {
                 ts: "2026-08-05T09:00:00.000Z",
                 session: "session:abc",
+                event_name: "PreToolUse",
                 provider_status: "blocking_error",
                 effect: "blocked",
-                duration_ms: null,
                 hook_name: "PreToolUse:Bash",
                 command: "bun /h/enforce-worktree.ts",
                 blocking_error_excerpt: "BLOCKED: dirty tree",
-                stderr_excerpt: null,
-                stdout_excerpt: null,
-            } as HookInvocationRow,
+            } satisfies HookInvocationRow,
         ]);
         expect(invocations.split("\n")[0]).toStartWith("ts\t");
         expect(invocations).toContain("BLOCKED: dirty tree");

--- a/apps/axctl/src/queries/hooks.ts
+++ b/apps/axctl/src/queries/hooks.ts
@@ -142,7 +142,27 @@ const sessionText = (value: string): string =>
         .replace(/^`/, "")
         .replace(/`$/, "");
 
+/**
+ * What an empty hook table actually means (#743).
+ *
+ * A bare header row reads as "this hook never fired", which is a claim ax
+ * cannot make: the harness records a fire only when the hook produced output
+ * (an outcome attachment) or blocked a call (named in the tool-result text). A
+ * guard that passes silently writes nothing anywhere. Users read the silence as
+ * evidence and scored hook experiments as unused against transcripts that
+ * proved otherwise - so say it out loud instead.
+ */
+export const HOOK_EMPTY_NOTE = [
+    "(no hook invocations recorded)",
+    "ax observes a fire only when the harness writes one: a hook that printed output,",
+    "or one that BLOCKED a call (recovered from the tool-result text). A hook that",
+    "passes silently leaves no trace in the transcript, so an empty table is not proof",
+    "the hook never ran.",
+    "Blocked fires from before ax 0.33 need a re-read: ax ingest --reparse=claude",
+].join("\n");
+
 export function formatHookSummaryRows(rows: readonly HookSummaryRow[]): string {
+    if (rows.length === 0) return HOOK_EMPTY_NOTE;
     const lines = ["count\tstatus\teffect\tavg_ms\tmax_ms\tlast_seen\thook\tcommand"];
     for (const row of rows) {
         lines.push([
@@ -160,6 +180,7 @@ export function formatHookSummaryRows(rows: readonly HookSummaryRow[]): string {
 }
 
 export function formatHookInvocationRows(rows: readonly HookInvocationRow[]): string {
+    if (rows.length === 0) return HOOK_EMPTY_NOTE;
     const lines = ["ts\tsession\tstatus\teffect\tduration_ms\thook\tcommand\tdetail"];
     for (const row of rows) {
         lines.push([

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -68,6 +68,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax directives workflows [--emit-brief] [--json]` - mine recurring skill-arc workflows (ordered skill sequences recurring ≥ 3 sessions; fixed 12-week window); --emit-brief writes .ax/tasks/workflows-<date>.md for agent review
 - `ax hooks init / install / backtest / bench / cases` - author typed TypeScript hooks once, run them on Claude Code + Codex; replay history through a hook before installing it
 - `ax hooks bench <file> [--days=N] [--runs=N] [--budget-ms=N] [--json]` - latency ledger: per-fire p50/p95 from real bun spawns, est fires/day from tool_call history, installed-chain budget vs --budget-ms default 250
+- `ax hooks summary|invocations [--since=N] [--command=<substr>] [--json]` - recorded harness hook fires. ax sees a fire only when the harness records one: a hook that printed output, or one that BLOCKED a call (recovered from the tool-result text, #743). Silent passing fires are unobservable, so an empty table is not proof a hook never ran
 - `ax hooks latency [--days=N] [--baseline=M] [--json]` - regression lens: compare recent (default 7d) vs baseline (default 21d) fire latency per hook event (hook_name is event-granular, e.g. PreToolUse:Bash) from hook_command_invocation telemetry; flags hook events where p95 regressed (factor 1.5, min 15ms delta, min 20 samples)
 
 ### Graph insights
@@ -84,6 +85,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax team experiment <start|list|promote|drop> <kind> <name>` - isolate→iterate→promote loop: start copies/scaffolds an artifact into a gitignored .ax.local/ overlay, list shows active experiments, promote moves the overlay artifact into committed .ax/ + git adds it (open a PR after), drop discards the overlay; ax team sync activates the overlay version for you only (annotated as "(experiment)")
 - `ax setup` / `ax install` - first-time install: CLI, local SurrealDB, transcript watcher
 - `ax ingest [here] [--since=Nd]` - ingest transcripts, skills, and git history; `here` scopes to the current repo; the watcher does this automatically on new transcripts
+- `ax ingest [here] --reparse=<targets|all>` - ignore the skip-unchanged watermark and re-read inputs ax already ingested (targets: claude, subagents, codex, pi, omp, cursor, git, closure, pricing, metrics, analysis, content); needed to backfill evidence a parser fix newly recovers
 - `ax roles` - list role labels used for skill classification
 - `ax doctor` - validate the install (db, watcher, skills)
 

--- a/packages/schema/src/schema.surql
+++ b/packages/schema/src/schema.surql
@@ -1584,7 +1584,7 @@ DEFINE FIELD tool_call_id    ON harness_hook_event TYPE option<string>;
 DEFINE FIELD tool_call       ON harness_hook_event TYPE option<record<tool_call>>;
 DEFINE FIELD cwd             ON harness_hook_event TYPE option<string>;
 DEFINE FIELD transcript_uuid ON harness_hook_event TYPE option<string>;
-DEFINE FIELD source_type     ON harness_hook_event TYPE string;                 -- hook_progress | hook_success | hook_blocking_error | hook_additional_context
+DEFINE FIELD source_type     ON harness_hook_event TYPE string;                 -- hook_progress | hook_success | hook_blocking_error | hook_additional_context | tool_result_text (blocks recovered from tool-result text, #743)
 DEFINE INDEX IF NOT EXISTS harness_hook_event_by_ts      ON harness_hook_event FIELDS ts;
 DEFINE INDEX IF NOT EXISTS harness_hook_event_by_session ON harness_hook_event FIELDS session;
 DEFINE INDEX IF NOT EXISTS harness_hook_event_by_name    ON harness_hook_event FIELDS hook_name;


### PR DESCRIPTION
Fixes #743.

## Root cause

ax learned about hook fires from two transcript shapes only: `data.type == "hook_progress"` and `attachment.type ∈ {hook_success, hook_blocking_error, hook_additional_context}`.

Swept 200 local transcripts (CC 2.1.x): **4,251 hook records, all `hook_success`** — zero `hook_progress`, zero `hook_blocking_error`. And every `hook_success` sampled had non-empty output, i.e. the harness writes that attachment only when the hook printed something.

So the most consequential guard shape — **silent on pass, blocking on fail** — produced no rows at all. What a block *does* leave behind is the tool_result text the model reads:

```
PreToolUse:Bash hook error: [bun ~/.ax/hooks/enforce-worktree.ts # ax:74da7418]: BLOCKED: ...
```

51 Bash / 29 Write / 21 Edit such blocks sat unparsed in local history.

## Fix

- **`apps/axctl/src/ingest/hook-block-text.ts`** — pure parser for the `<Event>[:<Tool>] hook error: [<cmd>]:` shape. Multi-hook aware (several hooks can block one call), command bounded to one line, unknown event names rejected.
- **`transcripts.ts`** — wired into `processToolResult`; writes the normal `harness_hook_event` + `hook_command_invocation` rows with `source_type = "tool_result_text"`, `provider_status = "blocking_error"`, `effect = "blocked"`, linked to the tool_call it stopped. Keys match the attachment path, so a transcript carrying both shapes yields one row. Legacy shapes stay parsed for older transcripts.
- **`ax ingest [here] --reparse=<targets|all>`** — the `AX_REDERIVE_*` force switches already existed but were undiscoverable, so a parser fix could never reach already-watermarked files. `apps/axctl/src/ingest/reparse-targets.ts` maps each target name to its switch; unknown names fail loudly rather than silently running a normal incremental pass.
- **Honest empty state** (the issue's explicit ask) — `ax hooks summary` / `ax hooks invocations` now say what silence means instead of printing a bare header:

```
(no hook invocations recorded)
ax observes a fire only when the harness writes one: a hook that printed output,
or one that BLOCKED a call (recovered from the tool-result text). A hook that
passes silently leaves no trace in the transcript, so an empty table is not proof
the hook never ran.
Blocked fires from before ax 0.33 need a re-read: ax ingest --reparse=claude
```

## Still not observable

A hook that passes silently is recorded nowhere by the harness — ax cannot invent those, and now says so. Agent-tool hooks remain exempt upstream (CC #39814/#40580); their advice is captured by the advise-tap, not the transcript.

## Verification

- `bun test apps/axctl/src` — 4213 pass, 0 fail (18 new assertions across 3 new test files)
- `bun run typecheck` — clean; `check:cli-reference`, `check:site-cli-reference`, `check:no-node-fs`, `check:record-select`, `check:table-coverage` — all OK
- **Live**: `ax ingest here --reparse=claude --stages=claude` on this repo's transcripts recovered blocked `enforce-worktree` / `enforce-worktree-write` fires back to 2026-07-07, with the block message as the row detail. Empty-state note verified against the built CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)