### PR TITLE
fix(retro): let emitted retros file improve proposals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,6 +393,28 @@ The routing-table file is now the source of truth for BOTH the route-dispatch ho
 `ax directives ngrams [--limit=N] [--json]` - the learned per-user lift table (`directive_ngram` rows sorted by lift desc; lift = outcome-rate / base-rate). Populated at ingest; re-run `ax ingest` to refresh. MCP: `directives_list`.
 `ax directives workflows [--emit-brief] [--json]` - mine recurring skill-arc workflows from session history (fixed 12-week window). Finds ordered sequences of skills (length 3–6) that recur across ≥ 3 distinct sessions (gapped, maximal arcs only, top 50 by support). `--emit-brief` writes `.ax/tasks/workflows-<date>.md` for agent review; without it prints a ranked arc table.
 
+### Retro → proposal loop (#742)
+
+A retro's prose is NOT triageable - only rows in `proposal` reach
+`ax improve list`. Two paths write them, and neither reads free text:
+
+1. `derive-retro-proposals` (an `ax ingest` stage, **not** run by
+   `ax derive-signals`) clusters the MACHINE-emitted shapes in `retro.failed`
+   (`<Tool> failed ×<N>`, correction counts, friction kinds) across ≥2 sessions.
+   The `next` field is never mined by anything.
+2. **A reviewer files them explicitly**: `ax retro emit --from-file` accepts
+   `proposals: [<ax improve propose payload>]` (same `ProposeInputSchema`,
+   decoded strictly - a malformed entry fails the emit rather than dropping a
+   finding), writes each through `runPropose`, and RELATEs
+   `proposal->cites_evidence->retro` so triage can trace it back to the review.
+   Emit then runs the derivation inline for that session, and when `failed`/
+   `next` carry findings with nothing filed it says the loop is open.
+
+Careless-reading trap: `derive-signals` reports `proposedSkillEdges` -
+`turn->proposed->skill` edges (a skill a turn NAMED but did not invoke). It was
+called `proposed`, which read as "improve proposals" and made a healthy run look
+like a broken write path.
+
 ## Recommend + apply guidance to your own agent files
 
 `axctl improve recommend / accept / lint / show` ship the v0 grounded-files

--- a/apps/axctl/src/cli/commands/retro-brief.test.ts
+++ b/apps/axctl/src/cli/commands/retro-brief.test.ts
@@ -29,6 +29,32 @@ describe("formatRetroBrief", () => {
         expect(brief).not.toContain("Source of truth is the\ntranscript at");
     });
 
+    // #742: the brief used to tell reviewers to run `ax improve recommend ...`
+    // to file a finding. That command only RANKS existing proposals, so a
+    // reviewer following the brief literally produced nothing triageable.
+    it("points the reviewer at the write-path, not the ranking command", () => {
+        const brief = formatRetroBrief(
+            {
+                sessionId: "session:s1",
+                key: "s1",
+                project: null,
+                source: "claude",
+                model: null,
+                startedAt: null,
+                endedAt: null,
+                lastTurnAt: null,
+                turns: 9,
+                reason: "ended_at",
+            },
+            null,
+            "sonnet",
+        );
+
+        expect(brief).toContain('"proposals"');
+        expect(brief).toContain("only RANKS existing proposals");
+        expect(brief).not.toMatch(/```bash\nax improve recommend/);
+    });
+
     it("teaches the reviewer to prefer normalized turns over raw harness JSONL", async () => {
         const template = await Bun.file(
             new URL("../../../../../agents/retro-reviewer.md", import.meta.url),

--- a/apps/axctl/src/cli/commands/retro.ts
+++ b/apps/axctl/src/cli/commands/retro.ts
@@ -6,7 +6,10 @@ import { prettyPrint } from "@ax/lib/json";
 import { safeJsonParse } from "@ax/lib/shared/safe-json";
 import { prettifyProjectSlug } from "@ax/lib/shared/project-slug";
 import { recordRef } from "@ax/lib/shared/surql";
-import { retroFromSession, upsertRetro, type RetroSource } from "../../ingest/retro.ts";
+import { retroFromSession, retroRecordKey, upsertRetro, type RetroSource } from "../../ingest/retro.ts";
+import { decodeRetroEmitPayload, hasUnfiledFindings } from "../../ingest/retro-emit-payload.ts";
+import { proposalKey, runPropose } from "../../improve/propose.ts";
+import { deriveRetroProposals } from "../../ingest/derive-retro-proposals.ts";
 import { cmdRetroReflect } from "../retro-reflect.ts";
 import { cmdRetroMeta } from "../retro-meta.ts";
 import { cmdRetroPlan } from "../retro-plan.ts";
@@ -25,6 +28,26 @@ import { boolArg, fail, jsonFlag, optionValue, positiveLimit, requirePositiveInt
  * --source=<value> overrides. The Stop hook recipe in docs/HOOKS.md
  * uses this path.
  */
+/**
+ * Run the `retro-proposals` derivation for the retro just written (#742).
+ *
+ * That stage is the ONLY path from a retro's clustered failures to a proposal,
+ * and it runs during `ax ingest` - NOT during `ax derive-signals`, which is
+ * where a reporter reasonably looked and found nothing. Emitting a retro and
+ * then seeing an unchanged proposal queue reads as a broken loop, so emit runs
+ * the derivation itself.
+ *
+ * Best-effort: the retro is already committed, and a derivation failure must
+ * not turn a successful emit into a non-zero exit. It returns the number of
+ * proposals derived so the caller can report it.
+ */
+const runInlineRetroDerive = deriveRetroProposals().pipe(
+    Effect.map((stats) =>
+        stats.toolFailureProposals + stats.correctionProposals + stats.frictionProposals
+    ),
+    Effect.orElseSucceed(() => 0),
+);
+
 const cmdRetroEmit = (input: {
     readonly session: string | undefined;
     readonly fromFile: string | undefined;
@@ -57,29 +80,78 @@ const cmdRetroEmit = (input: {
                 fail(`ax retro emit: could not read --from-file=${fromFile}: ${e}`);
                 return "";
             }));
-            const parsed = safeJsonParse<{ tried?: string; worked?: string; failed?: string; next?: string }>(raw);
-            if (!parsed) {
+            const rawJson = safeJsonParse<unknown>(raw);
+            if (!rawJson) {
                 fail(`ax retro emit: --from-file is not valid JSON`);
             }
-            if (!parsed.tried) {
-                fail("ax retro emit: payload missing required `tried` field");
-            }
+            const parsed = yield* decodeRetroEmitPayload(rawJson).pipe(
+                Effect.catch((err: unknown) =>
+                    Effect.sync(() => {
+                        // A payload we cannot read must stop the emit: silently
+                        // dropping a reviewer's proposal is the #742 failure.
+                        fail(
+                            `ax retro emit: --from-file payload is invalid: ${String(err)}\n` +
+                                "expected { tried, worked?, failed?, next?, proposals?: [<ax improve propose payload>] }",
+                        );
+                    })
+                ),
+            );
             const sessionKey = sessionRecordId.split(":").slice(1).join(":").replace(/`/g, "");
             yield* upsertRetro({
                 sessionId: sessionKey,
                 source: sourceFlag,
                 payload: {
-                    tried: String(parsed.tried),
+                    tried: parsed.tried,
                     worked: parsed.worked ?? null,
                     failed: parsed.failed ?? null,
                     next: parsed.next ?? null,
                 },
                 raw,
             });
+
+            // The retro -> proposal loop (#742). Proposals filed in the payload
+            // go through the SAME writer as `ax improve propose`, then cite the
+            // retro they came from, so triage can trace a proposal back to the
+            // session review that produced it.
+            const filed: Array<{ status: string; title: string; sig: string }> = [];
+            for (const proposal of parsed.proposals ?? []) {
+                const result = yield* runPropose(proposal);
+                yield* db.query(
+                    `RELATE ${recordRef("proposal", proposalKey(result.sig))}->cites_evidence->${
+                        recordRef("retro", retroRecordKey(sessionKey))
+                    } SET kind = "retro";`,
+                );
+                filed.push({ status: result.status, title: result.title, sig: result.sig });
+            }
+
+            const derived = yield* runInlineRetroDerive;
+
             if (json) {
-                console.log(prettyPrint({ session: sessionRecordId, source: sourceFlag, payload: parsed }));
-            } else {
-                console.log(`retro ${sourceFlag} for ${sessionRecordId}: ${parsed.tried.slice(0, 80)}…`);
+                console.log(prettyPrint({
+                    session: sessionRecordId,
+                    source: sourceFlag,
+                    payload: parsed,
+                    proposals: filed,
+                    derived,
+                }));
+                return;
+            }
+            console.log(`retro ${sourceFlag} for ${sessionRecordId}: ${parsed.tried.slice(0, 80)}…`);
+            for (const p of filed) {
+                console.log(`  proposal ${p.status}: ${p.title}`);
+            }
+            if (derived > 0) console.log(`  ${derived} proposal(s) derived from clustered retro failures`);
+            if (filed.length > 0 || derived > 0) {
+                console.log(`next: ax improve list --status=open`);
+            } else if (hasUnfiledFindings(parsed)) {
+                // Storing a finding is not filing it. Say so, or the reviewer
+                // walks away believing the loop closed (it is what #742 was).
+                console.log(
+                    "note: this retro records findings but files no proposals, so nothing reaches " +
+                        "`ax improve list`.\n" +
+                        "      add a `proposals` array to the payload (same shape as `ax improve propose`) " +
+                        "to make them triageable.",
+                );
             }
             return;
         }
@@ -89,8 +161,14 @@ const cmdRetroEmit = (input: {
             fail(`ax retro emit: session ${sessionRecordId} not found`);
         }
         yield* upsertRetro(retroInput);
+        const derived = yield* runInlineRetroDerive;
         if (json) {
-            console.log(prettyPrint({ session: sessionRecordId, source: retroInput.source, payload: retroInput.payload }));
+            console.log(prettyPrint({
+                session: sessionRecordId,
+                source: retroInput.source,
+                payload: retroInput.payload,
+                derived,
+            }));
             return;
         }
         console.log(`retro ${retroInput.source} for ${sessionRecordId}`);
@@ -98,6 +176,10 @@ const cmdRetroEmit = (input: {
         if (retroInput.payload.worked) console.log(`  worked  ${retroInput.payload.worked}`);
         if (retroInput.payload.failed) console.log(`  failed  ${retroInput.payload.failed}`);
         if (retroInput.payload.next) console.log(`  next    ${retroInput.payload.next}`);
+        if (derived > 0) {
+            console.log(`  ${derived} proposal(s) derived from clustered retro failures`);
+            console.log(`next: ax improve list --status=open`);
+        }
     });
 
 const cmdRetroList = (input: {
@@ -341,13 +423,39 @@ Run these from the repo whose session this was:
 ax retro emit --session=${s.sessionId} --source=manual --from-file=<path-to-json>
 \`\`\`
 
-…where the JSON file contains \`{tried, worked, failed, next}\`. If you
-spot a repeated pattern (≥2 occurrences in this session, or rhymes with
-prior retros), also call:
+…where the JSON file contains \`{tried, worked, failed, next}\`.
 
-\`\`\`bash
-ax improve recommend ...
+## Filing what you found
+
+A retro's prose is NOT triageable on its own - only proposals reach
+\`ax improve list\`. If you spot a repeated pattern (≥2 occurrences in this
+session, or one that rhymes with prior retros), file it in the SAME payload
+under \`proposals\`, each entry shaped exactly like an \`ax improve propose\`
+input:
+
+\`\`\`json
+{
+  "tried": "…", "worked": "…", "failed": "…", "next": "…",
+  "proposals": [
+    {
+      "form": "skill",
+      "title": "Pre-Bash worktree guard",
+      "hypothesis": "Bash failures cluster on writes against main",
+      "confidence": "medium",
+      "payload": {
+        "trigger_pattern": "git write while on main",
+        "suspected_gap": "nothing checks the branch first",
+        "proposed_behavior": "block and point at a worktree"
+      }
+    }
+  ]
+}
 \`\`\`
+
+Forms: \`skill\` · \`subagent\` · \`hook\` · \`guidance\` · \`automation\` (see
+\`ax improve propose --help\`). Each filed proposal is linked back to this
+retro, so triage can trace it to the review. Note that
+\`ax improve recommend\` only RANKS existing proposals - it cannot create one.
 
 When done, update this file's frontmatter \`status: completed\`. The next
 \`ax retro pending\` call will exclude this session because the

--- a/apps/axctl/src/improve/propose.ts
+++ b/apps/axctl/src/improve/propose.ts
@@ -89,8 +89,13 @@ export interface ProposeResult {
     readonly title: string;
 }
 
-/** Stable record key derived from the sig - same row on re-propose. */
-const proposalKey = (sig: string): string => `agent__${sig}`;
+/**
+ * Stable record key derived from the sig - same row on re-propose. Exported so
+ * callers that must reference the written proposal (e.g. `ax retro emit`
+ * relating a filed proposal back to its retro) address the same record instead
+ * of rebuilding the prefix.
+ */
+export const proposalKey = (sig: string): string => `agent__${sig}`;
 
 const PAYLOAD_TABLE: Record<ProposeInput["form"], string> = {
     skill: "skill_proposal",

--- a/apps/axctl/src/ingest/derive-signals.ts
+++ b/apps/axctl/src/ingest/derive-signals.ts
@@ -112,7 +112,14 @@ export interface DeriveStats {
     sessions: number;
     turns: number;
     corrections: number;
-    proposed: number;
+    /**
+     * `turn -> proposed -> skill` EDGES written - a skill the turn named but did
+     * not invoke. NOT improve-loop proposals (#742): this counter reading 376
+     * while `ax improve list` stayed at 0 looked like a broken write path and
+     * cost a reporter a debugging session. Improve proposals come from the
+     * `proposals` / `retro-proposals` stages, never from here.
+     */
+    proposedSkillEdges: number;
     skillPairs: number;
     recoveries: number;
     frictionEvents: number;
@@ -136,7 +143,7 @@ export const deriveSignals = Effect.fn("derive.signals")(
         if (opts.onProgress) yield* opts.onProgress({ sessions: bundles.length });
 
         let corrections = 0;
-        let proposed = 0;
+        let proposedSkillEdges = 0;
         let turnCount = 0;
         let recoveries = 0;
 
@@ -156,7 +163,7 @@ export const deriveSignals = Effect.fn("derive.signals")(
             const p = deriveProposed(bundle, skillNames);
             const r = deriveRecovered(bundle);
             corrections += c.length;
-            proposed += p.length;
+            proposedSkillEdges += p.length;
             recoveries += r.length;
             correctionBatch.push(...c);
             proposedBatch.push(...p);
@@ -169,7 +176,7 @@ export const deriveSignals = Effect.fn("derive.signals")(
                     sessions: index + 1,
                     turns: turnCount,
                     corrections,
-                    proposed,
+                    proposedSkillEdges,
                     recoveries,
                     skillPairs: shouldWriteSkillPairs ? pairsAccum.size : 0,
                 });
@@ -184,7 +191,7 @@ export const deriveSignals = Effect.fn("derive.signals")(
                 sessions: bundles.length,
                 turns: turnCount,
                 corrections,
-                proposed,
+                proposedSkillEdges,
                 recoveries,
                 skillPairs: pairsList.length,
             });
@@ -202,7 +209,7 @@ export const deriveSignals = Effect.fn("derive.signals")(
                 sessions: bundles.length,
                 turns: turnCount,
                 corrections,
-                proposed,
+                proposedSkillEdges,
                 recoveries,
                 skillPairs: pairsList.length,
                 frictionEvents: frictionBatch.length,
@@ -275,7 +282,7 @@ export const deriveSignals = Effect.fn("derive.signals")(
             sessions: bundles.length,
             turns: turnCount,
             corrections,
-            proposed,
+            proposedSkillEdges,
             skillPairs: pairsList.length,
             recoveries,
             frictionEvents: frictionBatch.length,
@@ -285,7 +292,7 @@ export const deriveSignals = Effect.fn("derive.signals")(
             sessions: bundles.length,
             turns: turnCount,
             corrections,
-            proposed,
+            proposedSkillEdges,
             skillPairs: pairsList.length,
             recoveries,
             frictionEvents: frictionBatch.length,
@@ -322,7 +329,7 @@ export class SignalsStats extends BaseStageStats.extend<SignalsStats>("SignalsSt
     frictionEvents: Schema.Number,
     diagnosticEvents: Schema.Number,
     corrections: Schema.Number,
-    proposed: Schema.Number,
+    proposedSkillEdges: Schema.Number,
 }) {}
 
 export const signalsStage: StageDef<SignalsStats, SurrealClient> = {
@@ -339,7 +346,7 @@ export const signalsStage: StageDef<SignalsStats, SurrealClient> = {
             frictionEvents: result.frictionEvents,
             diagnosticEvents: result.diagnosticEvents,
             corrections: result.corrections,
-            proposed: result.proposed,
+            proposedSkillEdges: result.proposedSkillEdges,
         });
     }),
 };

--- a/apps/axctl/src/ingest/retro-emit-payload.test.ts
+++ b/apps/axctl/src/ingest/retro-emit-payload.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Exit } from "effect";
+import {
+    decodeRetroEmitPayload,
+    hasUnfiledFindings,
+    type RetroEmitPayload,
+} from "./retro-emit-payload.ts";
+
+const decode = (raw: unknown) => Effect.runSyncExit(decodeRetroEmitPayload(raw));
+
+const skillProposal = {
+    form: "skill",
+    title: "Pre-Bash worktree guard",
+    hypothesis: "Bash failures cluster on main-branch writes",
+    confidence: "medium",
+    payload: {
+        trigger_pattern: "git write on main",
+        suspected_gap: "no guard before the write",
+        proposed_behavior: "block and suggest a worktree",
+    },
+};
+
+describe("decodeRetroEmitPayload", () => {
+    test("the pre-existing four-field payload still decodes", () => {
+        const exit = decode({ tried: "reviewed 12 sessions", failed: "flaky", next: "guard" });
+        expect(Exit.isSuccess(exit)).toBe(true);
+    });
+
+    test("accepts proposals in the improve-propose shape", () => {
+        const exit = decode({ tried: "t", proposals: [skillProposal] });
+        expect(Exit.isSuccess(exit)).toBe(true);
+        if (!Exit.isSuccess(exit)) return;
+        expect(exit.value.proposals).toHaveLength(1);
+        expect(exit.value.proposals![0]!.form).toBe("skill");
+    });
+
+    test("rejects a malformed proposal instead of dropping it", () => {
+        // A dropped finding is the bug being fixed - this must be loud.
+        const exit = decode({ tried: "t", proposals: [{ form: "skill", title: "x" }] });
+        expect(Exit.isSuccess(exit)).toBe(false);
+    });
+
+    test("rejects an unknown proposal form", () => {
+        expect(Exit.isSuccess(decode({ tried: "t", proposals: [{ ...skillProposal, form: "essay" }] }))).toBe(false);
+    });
+
+    test("still requires tried", () => {
+        expect(Exit.isSuccess(decode({ failed: "something" }))).toBe(false);
+    });
+});
+
+describe("hasUnfiledFindings", () => {
+    const base = { tried: "t" } as RetroEmitPayload;
+
+    test("substantive failed text with no proposals is an open loop", () => {
+        expect(hasUnfiledFindings({
+            ...base,
+            failed: "the agent re-read the same three files after every Bash call",
+        })).toBe(true);
+    });
+
+    test("substantive next text with no proposals is an open loop", () => {
+        expect(hasUnfiledFindings({
+            ...base,
+            next: "package a pre-Bash guard; this recurred in four separate sessions",
+        })).toBe(true);
+    });
+
+    test("filing a proposal closes it", () => {
+        expect(hasUnfiledFindings({
+            ...base,
+            failed: "the agent re-read the same three files after every Bash call",
+            proposals: [skillProposal as never],
+        })).toBe(false);
+    });
+
+    test("a thin or absent finding does not nag", () => {
+        expect(hasUnfiledFindings(base)).toBe(false);
+        expect(hasUnfiledFindings({ ...base, failed: "flaky" })).toBe(false);
+    });
+});

--- a/apps/axctl/src/ingest/retro-emit-payload.ts
+++ b/apps/axctl/src/ingest/retro-emit-payload.ts
@@ -1,0 +1,66 @@
+/**
+ * retro-emit-payload: the decoded shape of an `ax retro emit --from-file` JSON,
+ * including the proposals a reviewer wants to file from that session (#742).
+ *
+ * The gap this closes. A manual retro used to be a dead end: `ax retro emit`
+ * stored `{tried, worked, failed, next}` and `ax retro list` displayed it, but
+ * nothing consumed it. The only retro -> proposal path is the
+ * `derive-retro-proposals` stage, which parses the MACHINE-emitted shapes out of
+ * `retro.failed` (`<Tool> failed ×<N>`, correction counts, friction kinds) and
+ * needs a cluster across >=2 sessions. A human/agent reviewer writing prose
+ * matches none of that, and `next` - the field that literally holds "what to try
+ * next" - was never read by anything. A reviewer could spend a full session per
+ * retro and produce zero triageable proposals.
+ *
+ * So a reviewer now files proposals DIRECTLY, in the same payload, through the
+ * exact schema `ax improve propose` validates (`ProposeInputSchema`) - no second
+ * format to learn, no mining heuristic to misfire, and a proposal is either
+ * well-formed or a loud decode error.
+ *
+ * Decoding is strict on purpose: an unparseable `proposals` entry must fail the
+ * emit, not silently drop the finding, because a silently-dropped proposal is
+ * exactly the bug being fixed.
+ */
+
+import { Schema } from "effect";
+import { ProposeInputSchema } from "../improve/propose.ts";
+
+/**
+ * `{tried, worked?, failed?, next?, proposals?}` - the file `ax retro emit
+ * --from-file` reads. `tried` stays the one required field (unchanged), and
+ * every proposal entry is a full `ax improve propose` payload.
+ */
+export const RetroEmitPayloadSchema = Schema.Struct({
+    tried: Schema.String,
+    worked: Schema.optional(Schema.String),
+    failed: Schema.optional(Schema.String),
+    next: Schema.optional(Schema.String),
+    proposals: Schema.optional(Schema.Array(ProposeInputSchema)),
+});
+
+export type RetroEmitPayload = typeof RetroEmitPayloadSchema.Type;
+
+export const decodeRetroEmitPayload = (raw: unknown) =>
+    Schema.decodeUnknownEffect(RetroEmitPayloadSchema)(raw);
+
+/**
+ * Does this retro describe a problem but file nothing about it?
+ *
+ * `failed`/`next` are where reviewers put the durable findings, so substantive
+ * text there plus an empty `proposals` is the open-loop shape the reporter hit:
+ * work stored, nothing triageable. The emit still succeeds - a narrative-only
+ * retro is legitimate - but the CLI says the loop is open rather than letting
+ * the reviewer assume it closed.
+ *
+ * The threshold is deliberately crude (any non-trivial text). A precise
+ * "is this a finding" classifier would be a second thing to get wrong; the
+ * point is to prompt the human, not to judge them.
+ */
+export const MIN_SUBSTANTIVE_FINDING_CHARS = 40;
+
+export const hasUnfiledFindings = (payload: RetroEmitPayload): boolean => {
+    if ((payload.proposals?.length ?? 0) > 0) return false;
+    const substantive = (text: string | undefined): boolean =>
+        (text ?? "").trim().length >= MIN_SUBSTANTIVE_FINDING_CHARS;
+    return substantive(payload.failed) || substantive(payload.next);
+};

--- a/apps/axctl/src/ingest/retro.ts
+++ b/apps/axctl/src/ingest/retro.ts
@@ -178,8 +178,17 @@ export const retroFromSession = (
 // Writer
 // ---------------------------------------------------------------------------
 
+/**
+ * The `retro` record key for a session key. One retro per session (the table is
+ * UNIQUE on session), so callers that need to point AT the retro - e.g. a
+ * proposal citing the review it came from - derive the id here rather than
+ * re-implementing the truncation.
+ */
+export const retroRecordKey = (sessionId: string): string =>
+    safeKeyPart(sessionId).slice(0, 96);
+
 export const buildRetroStatement = (input: RetroInput): string => {
-    const key = safeKeyPart(input.sessionId).slice(0, 96);
+    const key = retroRecordKey(input.sessionId);
     const sessionRef = recordRef("session", input.sessionId);
     const retroRef = recordRef("retro", key);
     const upsert = `UPSERT ${retroRef} MERGE ${surrealObject([

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -61,6 +61,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 ### Self-improvement loop
 - `ax improve recommend / accept / lint / show` - evidence-backed proposals (guidance, skills, hooks, automations) derived from the graph; accept emits a task brief, lint reconciles applied guidance
 - `ax retro emit / pending / brief` + `ax:retro` skill - guided experiment-loop retrospective: triage proposals, lock verdicts, review hook effectiveness
+- `ax retro emit --from-file=<json>` - the JSON is `{tried, worked?, failed?, next?, proposals?}`; each `proposals` entry is an `ax improve propose` payload, filed through the same writer and linked back to the retro (`cites_evidence`), so a reviewed session's findings reach `ax improve list`. Prose alone is narrative-only - emit says so when `failed`/`next` carry findings but nothing was filed
 - `ax:dojo` skill - surplus-quota overnight training loop: budget-bounded self-improvement (verdicts, briefs, routing, proposals, experiments); install via `npx skills add Necmttn/ax`
 - `ax directives mine [--days=N] [--emit-brief] [--json]` - rank candidate directive turns by n-gram lift; --emit-brief writes .ax/tasks/directives-<date>.md for agent review; accepted proposals land via ax improve accept <id>
 - `ax directives list [--status=open|all] [--json]` - tracked directive proposals (guidance/section=directives), sorted by recurrence


### PR DESCRIPTION
Fixes #742.

## Root cause — three separate defects

**1. Nothing consumed a manual retro.** The only retro → proposal path is the `derive-retro-proposals` stage, which parses the *machine-emitted* shapes out of `retro.failed` (`<Tool> failed ×<N>`, correction counts, friction kinds) and requires a cluster across ≥2 sessions. Reviewer prose matches none of it. `next` — the field that literally holds "what to try next" — is read by nothing. That's the reported 12 sessions of review → 0 proposals.

**2. The brief pointed at the wrong command.** `ax retro brief` told reviewers to run `ax improve recommend ...`, which only *ranks* existing proposals. Following the brief literally could not create one. The write path (`ax improve propose`) existed but was never named.

**3. A misleading counter.** `derive-signals` reported `proposed: 376` — those are `turn->proposed->skill` **edges** (a skill a turn named but did not invoke), unrelated to the `proposal` table. Read as "376 proposals written", it made a healthy run look like a broken write path.

Also worth stating: `retro-proposals` runs during `ax ingest`, **not** `ax derive-signals` — so the manual `derive-signals --since=1` in the report could never have fired it.

## Fix

- **`proposals[]` in the emit payload** — `ax retro emit --from-file` now takes `{tried, worked?, failed?, next?, proposals?}`, each `proposals` entry being the exact `ax improve propose` payload (`ProposeInputSchema`). Filed through the same `runPropose` writer, then `RELATE proposal->cites_evidence->retro` so triage can trace a proposal to the review that produced it. Decoding is **strict** — a malformed entry fails the emit rather than dropping the finding, since a silently-dropped proposal is the bug being fixed.
- **Open-loop note** — when `failed`/`next` carry substantive text and nothing was filed, emit says so instead of letting the reviewer assume the loop closed. A narrative-only retro stays legitimate.
- **Inline derivation** — emit runs `deriveRetroProposals` itself (best-effort; a derivation failure never fails a committed retro), so the proposal queue reflects the emit without a full `ax ingest`.
- **Brief rewritten** — shows the `proposals` JSON, lists the five forms, and states outright that `ax improve recommend` cannot create a proposal.
- **`proposed` → `proposedSkillEdges`** in `DeriveStats` + the stage stats, with a doc comment saying what it counts and what it is not. Breaking change to `derive-signals --json` output, chosen deliberately over keeping a name that misleads.

## Verification

- `bun test apps/axctl/src packages` — 5074 pass, 0 fail (14 new assertions: payload decode, unfiled-finding detection, brief content)
- `bun run typecheck` clean; `check:cli-reference`, `check:site-cli-reference`, `check:no-node-fs`, `check:record-select`, `check:table-coverage` all OK
- **Live**: emitted a retro carrying one proposal → it appeared in `ax improve list --status=open` and carried its `cites_evidence` edge to the retro (`proposal:agent__guidance__… -> retro:…`); a second, narrative-only payload printed the open-loop note. Both probe rows deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)