### PR TITLE
fix(ingest): see OpenCode's own skills, and what its skill tool loads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code and other AI assistants working in this repo.
 
 ## What this is
 
-`ax` - local taste & telemetry graph for AI coding agents. Ingests transcripts from 6 harnesses - Claude Code (`~/.claude/projects/`), Codex (`~/.codex/sessions/`), Pi (`~/.pi/agent/sessions/`), oh-my-pi/omp (`~/.omp/agent/sessions/`, a Pi fork sharing Pi's JSONL format - one parameterized parser, distinct `omp` identity; `AX_OMP_DIR` override), OpenCode + Cursor (SQLite stores) - plus installed skills (`~/.claude/skills/`, `~/.agents/skills/`, plugin caches) into a dedicated SurrealDB instance. Each harness has a full parser dual-writing provider events (`agent_*` tables) + normalized records (`session`/`turn`/`tool_call`); `AgentProviderName` enumerates them (`apps/axctl/src/ingest/provider-events.ts`). CLI surfaces "what skills/tools you actually use" on demand.
+`ax` - local taste & telemetry graph for AI coding agents. Ingests transcripts from 6 harnesses - Claude Code (`~/.claude/projects/`), Codex (`~/.codex/sessions/`), Pi (`~/.pi/agent/sessions/`), oh-my-pi/omp (`~/.omp/agent/sessions/`, a Pi fork sharing Pi's JSONL format - one parameterized parser, distinct `omp` identity; `AX_OMP_DIR` override), OpenCode + Cursor (SQLite stores) - plus installed skills (`~/.claude/skills/`, `~/.agents/skills/`, `$XDG_CONFIG_HOME/opencode/{skill,skills}/`, project `.claude/skills` + `.opencode/{skill,skills}`, plugin caches) into a dedicated SurrealDB instance. Each harness has a full parser dual-writing provider events (`agent_*` tables) + normalized records (`session`/`turn`/`tool_call`); `AgentProviderName` enumerates them (`apps/axctl/src/ingest/provider-events.ts`). CLI surfaces "what skills/tools you actually use" on demand.
 
 ## Attribution on shareable artifacts
 
@@ -252,6 +252,22 @@ Only `claim` (too noisy) + `artifact_ref` remain deferred. Spec/threads on #578.
 `ax skills weighted [--window=Nd] [--limit=N]` - usage × role-weight ranking; enters doctor mode when many skills are unclassified.
 `ax skills by-role <role>` - list skills tagged with a given role.
 `ax skills roles <skill>` - list roles for a skill.
+
+**OpenCode skills (#746).** OpenCode discovers skills from the shared
+`~/.claude/skills` + `~/.agents/skills` dirs AND its own config dir
+(`$XDG_CONFIG_HOME/opencode/{skill,skills}/**/SKILL.md`, plus project
+`.opencode/`), so an OpenCode-only user's catalog lived somewhere ax never
+looked - `defaultSkillDirs()` (`packages/lib/src/paths.ts`) now covers it.
+Activation is a tool call: OpenCode's `skill` tool takes `{name}` and loading IS
+the invocation. The parser writes TWO rows for it - the synthetic
+`opencode:skill` tool row (as for every tool) and a real invocation against the
+CATALOG skill, name-resolved via `resolveSkillName` against the on-disk catalog.
+That second row is the one usage views can see: `ax skills weighted` excludes
+skills with `dir_path = "(synthetic)"`, which is why an OpenCode-only user read
+"(no skill invocations found)" despite steady skill use. Catalog rows are
+written create-if-missing (`skillUpsert: "if_missing"` ->
+`INSERT ... ON DUPLICATE KEY UPDATE name = name`); a plain MERGE would stamp a
+real skill with `dir_path = "(opencode)"` and hide it from those same views.
 
 ### Role registry
 

--- a/apps/axctl/src/ingest/normalized/transcripts.ts
+++ b/apps/axctl/src/ingest/normalized/transcripts.ts
@@ -91,6 +91,20 @@ export interface NormalizedSyntheticSkillInvocationWrite {
     readonly skillScope?: string;
     readonly skillDirPath?: string;
     readonly skillContentHash?: string;
+    /**
+     * How to write the `skill` row this invocation points at.
+     *
+     * `"merge"` (default, and the only pre-#746 behavior) overwrites
+     * scope/dir_path/content_hash - correct for SYNTHETIC provider-tool skills,
+     * which this batch is the sole author of.
+     *
+     * `"if_missing"` creates the row only when absent and leaves an existing
+     * one untouched. Required when the invocation names a REAL catalog skill
+     * (OpenCode's `skill` tool loads one by name): merging would stamp the
+     * on-disk skill with `dir_path = "(opencode)"`, and every view that
+     * excludes synthetic rows would then drop a genuine skill.
+     */
+    readonly skillUpsert?: "merge" | "if_missing";
 }
 
 /**
@@ -190,14 +204,22 @@ export const buildNormalizedSyntheticSkillInvocationStatements = (
         if (!skills.has(invocation.skillName)) skills.set(invocation.skillName, invocation);
     }
 
-    const skillStatements = [...skills.values()].map((invocation) =>
-        `UPSERT ${recordRef("skill", skillRecordKey(invocation.skillName))} MERGE ${surrealObject([
+    const skillStatements = [...skills.values()].map((invocation) => {
+        const ref = recordRef("skill", skillRecordKey(invocation.skillName));
+        const fields: ReadonlyArray<readonly [string, string]> = [
             ["name", surrealString(invocation.skillName)],
             ["scope", surrealString(invocation.skillScope ?? "unknown")],
             ["dir_path", surrealString(invocation.skillDirPath ?? "(synthetic)")],
             ["content_hash", surrealString(invocation.skillContentHash ?? "synthetic")],
-        ])};`
-    );
+        ];
+        if (invocation.skillUpsert === "if_missing") {
+            // Create-if-absent, never clobber: `ON DUPLICATE KEY UPDATE name =
+            // name` is a no-op on an existing row, so a catalog skill keeps its
+            // real scope/dir_path/content_hash (#746).
+            return `INSERT INTO skill ${surrealObject([["id", ref], ...fields])} ON DUPLICATE KEY UPDATE name = name;`;
+        }
+        return `UPSERT ${ref} MERGE ${surrealObject(fields)};`;
+    });
 
     const invocationStatements = invocations.map((invocation) => {
         const turnKey = turnRecordKey(invocation.sessionId, invocation.seq);

--- a/apps/axctl/src/ingest/opencode-skills.test.ts
+++ b/apps/axctl/src/ingest/opencode-skills.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import { SkillName } from "@ax/lib/brands";
+import {
+    OPENCODE_SKILL_LOAD_REASON,
+    openCodeLoadedSkillName,
+    resolveOpenCodeCatalogSkills,
+    type OpenCodeExtract,
+} from "./opencode.ts";
+import { buildNormalizedSyntheticSkillInvocationStatements } from "./normalized/transcripts.ts";
+
+describe("openCodeLoadedSkillName (#746)", () => {
+    test("reads the skill the `skill` tool loaded", () => {
+        expect(openCodeLoadedSkillName("skill", { name: "kubuntu" })).toBe("kubuntu");
+        expect(openCodeLoadedSkillName("skill", { name: "  podman  " })).toBe("podman");
+    });
+
+    test("ignores every other tool", () => {
+        expect(openCodeLoadedSkillName("bash", { name: "kubuntu" })).toBeNull();
+        expect(openCodeLoadedSkillName("task", { name: "kubuntu" })).toBeNull();
+    });
+
+    test("ignores a skill call with no usable name", () => {
+        expect(openCodeLoadedSkillName("skill", {})).toBeNull();
+        expect(openCodeLoadedSkillName("skill", { name: "" })).toBeNull();
+        expect(openCodeLoadedSkillName("skill", { name: 3 })).toBeNull();
+        expect(openCodeLoadedSkillName("skill", null)).toBeNull();
+        expect(openCodeLoadedSkillName("skill", "kubuntu")).toBeNull();
+    });
+});
+
+const extractWith = (
+    invocations: OpenCodeExtract["invocations"],
+    skillRelations: OpenCodeExtract["skillRelations"],
+): OpenCodeExtract => ({
+    sessions: [],
+    turns: [],
+    providerEvents: [],
+    toolCalls: [],
+    invocations,
+    skillRelations,
+    compactions: [],
+    skipped: 0,
+    warnings: [],
+});
+
+describe("resolveOpenCodeCatalogSkills", () => {
+    const relation = (skillName: string, reason: string) => ({
+        toolCallKey: "tc1",
+        skillName: SkillName.make(skillName),
+        ts: "2026-08-05T00:00:00.000Z",
+        reason,
+        labels: {},
+        metrics: {},
+    });
+    const invocation = (skill: string, catalogSkill?: boolean) => ({
+        session: "s1",
+        seq: 1,
+        ts: "2026-08-05T00:00:00.000Z",
+        skill: SkillName.make(skill),
+        args: {},
+        ...(catalogSkill ? { catalogSkill: true } : {}),
+    });
+
+    test("maps a bare skill-tool load onto its namespaced catalog name", () => {
+        const out = resolveOpenCodeCatalogSkills(
+            extractWith(
+                [invocation("systematic-debugging", true)],
+                [relation("systematic-debugging", OPENCODE_SKILL_LOAD_REASON)],
+            ),
+            new Set(["superpowers:systematic-debugging"]),
+        );
+        expect(String(out.invocations[0]!.skill)).toBe("superpowers:systematic-debugging");
+        expect(String(out.skillRelations[0]!.skillName)).toBe("superpowers:systematic-debugging");
+    });
+
+    test("leaves synthetic provider-tool skills alone", () => {
+        // The bare-name rule would otherwise fold `opencode:bash` into a real
+        // skill named `bash`, merging tool telemetry into skill usage.
+        const out = resolveOpenCodeCatalogSkills(
+            extractWith(
+                [invocation("opencode:bash")],
+                [relation("opencode:bash", "OpenCode tool part")],
+            ),
+            new Set(["bash"]),
+        );
+        expect(String(out.invocations[0]!.skill)).toBe("opencode:bash");
+        expect(String(out.skillRelations[0]!.skillName)).toBe("opencode:bash");
+    });
+
+    test("keeps the recorded name when the catalog has no match", () => {
+        const out = resolveOpenCodeCatalogSkills(
+            extractWith([invocation("kubuntu", true)], []),
+            new Set(["podman"]),
+        );
+        expect(String(out.invocations[0]!.skill)).toBe("kubuntu");
+    });
+
+    test("is a no-op against an empty catalog", () => {
+        const input = extractWith([invocation("kubuntu", true)], []);
+        expect(resolveOpenCodeCatalogSkills(input, new Set())).toBe(input);
+    });
+});
+
+describe("skill row write mode", () => {
+    const base = {
+        sessionId: "s1",
+        seq: 1,
+        ts: "2026-08-05T00:00:00.000Z",
+        args: {},
+    };
+
+    test("if_missing creates without clobbering an existing catalog row", () => {
+        const [skillStmt] = buildNormalizedSyntheticSkillInvocationStatements([
+            {
+                ...base,
+                skillName: SkillName.make("kubuntu"),
+                skillScope: "opencode-skill",
+                skillDirPath: "(opencode)",
+                skillContentHash: "opencode",
+                skillUpsert: "if_missing",
+            },
+        ]);
+        expect(skillStmt).toStartWith("INSERT INTO skill ");
+        expect(skillStmt).toContain("ON DUPLICATE KEY UPDATE name = name");
+    });
+
+    test("synthetic provider-tool skills keep the merge write", () => {
+        const [skillStmt] = buildNormalizedSyntheticSkillInvocationStatements([
+            {
+                ...base,
+                skillName: SkillName.make("opencode:bash"),
+                skillScope: "opencode-tool",
+                skillContentHash: "opencode",
+            },
+        ]);
+        expect(skillStmt).toStartWith("UPSERT ");
+        expect(skillStmt).toContain("MERGE");
+        expect(skillStmt).toContain('"(synthetic)"');
+    });
+});

--- a/apps/axctl/src/ingest/opencode.ts
+++ b/apps/axctl/src/ingest/opencode.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { Effect, FileSystem, Option, Path, Schema } from "effect";
 import { AxConfig } from "@ax/lib/config";
 import { SkillName } from "@ax/lib/brands";
+import { resolveSkillName } from "@ax/lib/skill-id";
 import { RecordId, SurrealClient } from "@ax/lib/db";
 import { orAbsent } from "@ax/lib/shared/fs-error";
 import { executeStatements } from "@ax/lib/shared/statement-exec";
@@ -84,7 +85,38 @@ interface OpenCodeInvocation {
     ts: string;
     skill: SkillName;
     args: unknown;
+    /**
+     * True when `skill` names a REAL installed skill (the `skill` tool loading
+     * one by name) rather than the synthetic `opencode:<tool>` stand-in. These
+     * must not overwrite the catalog row - see `skillUpsert` on the normalized
+     * write (#746).
+     */
+    catalogSkill?: boolean;
 }
+
+/**
+ * OpenCode's skill-loading tool. Its parameters are `{ name: string }` ("The
+ * name of the skill from available_skills"), and loading a skill IS the
+ * invocation - there is no separate Skill-tool-like event. Verified against
+ * opencode 1.3.17 (`src/tool/skill.ts`).
+ */
+export const OPENCODE_SKILL_TOOL = "skill";
+
+/**
+ * The skill an OpenCode tool call loaded, or null when this call is not a
+ * skill load. Pure so the mapping is testable without a store.
+ */
+export const openCodeLoadedSkillName = (
+    toolName: string,
+    inputJson: unknown,
+): string | null => {
+    if (toolName !== OPENCODE_SKILL_TOOL) return null;
+    if (typeof inputJson !== "object" || inputJson === null) return null;
+    const name = (inputJson as Record<string, unknown>).name;
+    if (typeof name !== "string") return null;
+    const trimmed = name.trim();
+    return trimmed.length > 0 ? trimmed : null;
+};
 
 export interface OpenCodeStats {
     readonly sessions: number;
@@ -664,6 +696,38 @@ function processToolPart(input: {
             partOrdinal: input.ordinal,
         },
     });
+
+    // A `skill` tool call loads a REAL skill by name (#746). The synthetic
+    // `opencode:skill` row above records that the tool fired; this records
+    // WHICH skill it loaded, against the catalog row - the only form that
+    // reaches usage views, which exclude synthetic skills by `dir_path`.
+    const loadedSkill = openCodeLoadedSkillName(toolName, inputJson);
+    if (loadedSkill) {
+        const loadedSkillName = SkillName.make(loadedSkill);
+        input.invocations.push({
+            session: input.session.id,
+            seq: input.turnSeq,
+            ts,
+            skill: loadedSkillName,
+            args: inputJson ?? {},
+            catalogSkill: true,
+        });
+        input.skillRelations.push({
+            toolCallKey,
+            skillName: loadedSkillName,
+            ts,
+            reason: OPENCODE_SKILL_LOAD_REASON,
+            labels: {
+                provider: "opencode",
+                toolName,
+                source: "opencode_sqlite",
+            },
+            metrics: {
+                turnSeq: input.turnSeq,
+                partOrdinal: input.ordinal,
+            },
+        });
+    }
 }
 
 export function extractOpenCodeDatabase(dbPath: string): OpenCodeExtract {
@@ -954,6 +1018,37 @@ const sliceOpenCodeExtractForSession = (
 
 export const __testSliceOpenCodeExtractForSession = sliceOpenCodeExtractForSession;
 
+/** Marks the relation written for a `skill` tool load (see below). */
+export const OPENCODE_SKILL_LOAD_REASON = "OpenCode skill tool load";
+
+/**
+ * Map skill-tool loads onto their catalog names (#746).
+ *
+ * Applied ONLY to skill-tool rows. Running `resolveSkillName` over the
+ * synthetic `opencode:<tool>` names would be actively wrong: its bare-name rule
+ * would let `opencode:bash` resolve onto a real skill named `bash`, silently
+ * merging tool telemetry into a skill's usage.
+ */
+export const resolveOpenCodeCatalogSkills = (
+    extract: OpenCodeExtract,
+    catalog: ReadonlySet<string>,
+): OpenCodeExtract => {
+    if (catalog.size === 0) return extract;
+    return {
+        ...extract,
+        invocations: extract.invocations.map((invocation) =>
+            invocation.catalogSkill
+                ? { ...invocation, skill: resolveSkillName(invocation.skill, catalog) ?? invocation.skill }
+                : invocation
+        ),
+        skillRelations: extract.skillRelations.map((relation) =>
+            relation.reason === OPENCODE_SKILL_LOAD_REASON
+                ? { ...relation, skillName: resolveSkillName(relation.skillName, catalog) ?? relation.skillName }
+                : relation
+        ),
+    };
+};
+
 const buildOpenCodeBatchStatements = (
     extract: OpenCodeExtract,
     sourcePath: string,
@@ -1018,15 +1113,32 @@ const buildOpenCodeBatchStatements = (
         // OpenCode emits no tool-file evidence today (pre-toolkit behavior preserved).
         toolFileEvidence: [],
         agentEventParentEdges: [],
-        syntheticSkillInvocations: extract.invocations.map((invocation) => ({
-            sessionId: invocation.session,
-            seq: invocation.seq,
-            ts: invocation.ts,
-            skillName: invocation.skill,
-            args: invocation.args,
-            skillScope: "opencode-tool",
-            skillContentHash: "opencode",
-        })),
+        syntheticSkillInvocations: extract.invocations.map((invocation) =>
+            invocation.catalogSkill
+                ? {
+                    sessionId: invocation.session,
+                    seq: invocation.seq,
+                    ts: invocation.ts,
+                    skillName: invocation.skill,
+                    args: invocation.args,
+                    // Placeholders used ONLY if the skill is not in the catalog
+                    // (e.g. a skill installed after this session ran); an
+                    // existing row keeps its real values.
+                    skillScope: "opencode-skill",
+                    skillDirPath: "(opencode)",
+                    skillContentHash: "opencode",
+                    skillUpsert: "if_missing" as const,
+                }
+                : {
+                    sessionId: invocation.session,
+                    seq: invocation.seq,
+                    ts: invocation.ts,
+                    skillName: invocation.skill,
+                    args: invocation.args,
+                    skillScope: "opencode-tool",
+                    skillContentHash: "opencode",
+                }
+        ),
         toolCallSkillRelations: extract.skillRelations,
         planSnapshots: [],
         compactions: extract.compactions,
@@ -1121,12 +1233,30 @@ export const ingestOpenCode = Effect.fn("opencode.ingest")(
             };
         }
 
+        // Snapshot the real skill catalog once (the skills stage is a declared
+        // dep, so it is complete). A `skill` tool call records the name the
+        // model typed - bare - while a project- or plugin-scoped skill is
+        // catalogued namespaced; `resolveSkillName` maps the former onto the
+        // latter so the invocation attaches to the real row instead of minting
+        // a ghost (#746). Same treatment the Claude parser gives Skill calls.
+        const catalogRows = (yield* db.query<[Array<{ name?: string }>]>(
+            `SELECT name FROM skill WHERE dir_path != "(unknown)";`,
+        ))?.[0] ?? [];
+        const skillCatalog: ReadonlySet<string> = new Set(
+            catalogRows
+                .map((row) => row.name)
+                .filter((name): name is string => typeof name === "string" && name.length > 0),
+        );
+
         const failures = makeFileFailureCollector({ source: "opencode", unit: "session" });
         let sessionCount = 0;
         let turnCount = 0;
         let toolCallCount = 0;
         for (const session of extract.sessions) {
-            const slice = sliceOpenCodeExtractForSession(extract, session.id);
+            const slice = resolveOpenCodeCatalogSkills(
+                sliceOpenCodeExtractForSession(extract, session.id),
+                skillCatalog,
+            );
             // Per-session failure isolation (#261): one undecodable / rejected
             // session skips THIS session - the store is re-read next run -
             // instead of aborting the whole stage (see file-isolation.ts).

--- a/apps/axctl/src/ingest/skills.ts
+++ b/apps/axctl/src/ingest/skills.ts
@@ -194,17 +194,27 @@ const readProjectSkills = (): FsReader =>
         const roots = yield* discoverProjectRoots();
         const out: SkillItem[] = [];
         for (const root of roots) {
-            const skillsDir = path.join(root.path, ".claude", "skills");
-            const items = yield* readSkillDir(skillsDir, `project:${root.name}`);
-            // Re-namespace under the project so two repos with the same bare
-            // skill name (`expo-deployment`) don't collide in the catalog and
-            // the resolver's `:bare` suffix rule attaches invocations correctly.
-            items.forEach((it) => {
-                if (!it.skill.name.includes(":")) {
-                    it.skill.name = `${root.name}:${it.skill.name}`;
-                }
-            });
-            out.push(...items);
+            // `.claude/skills` plus OpenCode's project-local `.opencode/{skill,
+            // skills}` (#746) - same harness-agnostic catalog, so a repo that
+            // ships skills for OpenCode is as visible as one shipping them for
+            // Claude Code.
+            const skillsDirs = [
+                path.join(root.path, ".claude", "skills"),
+                path.join(root.path, ".opencode", "skills"),
+                path.join(root.path, ".opencode", "skill"),
+            ];
+            for (const skillsDir of skillsDirs) {
+                const items = yield* readSkillDir(skillsDir, `project:${root.name}`);
+                // Re-namespace under the project so two repos with the same bare
+                // skill name (`expo-deployment`) don't collide in the catalog and
+                // the resolver's `:bare` suffix rule attaches invocations correctly.
+                items.forEach((it) => {
+                    if (!it.skill.name.includes(":")) {
+                        it.skill.name = `${root.name}:${it.skill.name}`;
+                    }
+                });
+                out.push(...items);
+            }
         }
         return out;
     });

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -21,7 +21,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax memory ops [--events] [--days=N]` - Claude memory-file activity: writes/edits the agent made to `~/.claude/.../memory/*.md`, rolled up per memory file (notes vs the MEMORY index) and per session. Recall (the memory context the harness injects into the system prompt) is not tracked - it never lands in the transcript.
 
 ### Skills intelligence
-- `ax skills search | taste | unused | pairs | recovery | stats | weighted` - which installed skills actually get used, and what they pair with
+- `ax skills search | taste | unused | pairs | recovery | stats | weighted` - which installed skills actually get used, and what they pair with. The catalog is scanned from `~/.claude/skills`, `~/.agents/skills`, `$XDG_CONFIG_HOME/opencode/{skill,skills}` (OpenCode's own dir), project `.claude/skills` + `.opencode/{skill,skills}`, and plugin caches; OpenCode `skill` tool calls count as invocations of the skill they load
 - `ax skills classify / tag / lint / by-role / roles` - role-tag skills via review briefs; usage x role-weight ranking
 - `ax skills config` - skill lifecycle (live / orphan / out-of-scope / parked)
 

--- a/packages/lib/src/paths.test.ts
+++ b/packages/lib/src/paths.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { defaultSkillDirs, opencodeSkillDirs } from "./paths.ts";
+
+const savedXdg = process.env.XDG_CONFIG_HOME;
+const savedSkillDirs = process.env.AX_SKILLS_DIRS;
+
+afterEach(() => {
+    if (savedXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = savedXdg;
+    if (savedSkillDirs === undefined) delete process.env.AX_SKILLS_DIRS;
+    else process.env.AX_SKILLS_DIRS = savedSkillDirs;
+});
+
+describe("opencodeSkillDirs (#746)", () => {
+    test("defaults to ~/.config/opencode and covers both spellings", () => {
+        delete process.env.XDG_CONFIG_HOME;
+        expect(opencodeSkillDirs().map((d) => d.dir)).toEqual([
+            `${homedir()}/.config/opencode/skills`,
+            `${homedir()}/.config/opencode/skill`,
+        ]);
+    });
+
+    test("honors XDG_CONFIG_HOME, as OpenCode itself does", () => {
+        process.env.XDG_CONFIG_HOME = "/custom/cfg";
+        expect(opencodeSkillDirs().map((d) => d.dir)).toEqual([
+            "/custom/cfg/opencode/skills",
+            "/custom/cfg/opencode/skill",
+        ]);
+    });
+
+    test("ignores a blank XDG_CONFIG_HOME rather than rooting at /opencode", () => {
+        process.env.XDG_CONFIG_HOME = "   ";
+        expect(opencodeSkillDirs()[0]!.dir).toBe(`${homedir()}/.config/opencode/skills`);
+    });
+
+    test("scopes rows as opencode", () => {
+        expect(new Set(opencodeSkillDirs().map((d) => d.scope))).toEqual(new Set(["opencode"]));
+    });
+});
+
+describe("defaultSkillDirs", () => {
+    test("includes the OpenCode dirs alongside the Claude/agents ones", () => {
+        delete process.env.AX_SKILLS_DIRS;
+        delete process.env.XDG_CONFIG_HOME;
+        const dirs = defaultSkillDirs().map((d) => d.dir);
+        expect(dirs).toContain(`${homedir()}/.claude/skills`);
+        expect(dirs).toContain(`${homedir()}/.agents/skills`);
+        expect(dirs).toContain(`${homedir()}/.config/opencode/skills`);
+    });
+
+    test("AX_SKILLS_DIRS stays a full override", () => {
+        process.env.AX_SKILLS_DIRS = "/tmp/only";
+        expect(defaultSkillDirs()).toEqual([{ dir: "/tmp/only", scope: "user" }]);
+    });
+});

--- a/packages/lib/src/paths.ts
+++ b/packages/lib/src/paths.ts
@@ -28,6 +28,29 @@ function liveSkillDirList(): string[] {
  */
 export const skillDirsOverridden = (): boolean => liveSkillDirList().length > 0;
 
+/**
+ * OpenCode's own skill folders (#746).
+ *
+ * OpenCode discovers skills from two places: the shared `~/.claude/skills` +
+ * `~/.agents/skills` dirs (already covered above) AND its own config dir, where
+ * it globs `{skill,skills}/**` + `/SKILL.md`. An OpenCode-only user keeps every
+ * skill in the latter, so ax saw an empty catalog - `ax skills weighted` said
+ * "no skill invocations found" and `ax skills stats <name>` said "missing".
+ *
+ * The config dir follows XDG (`$XDG_CONFIG_HOME`, else `~/.config`), matching
+ * how OpenCode itself resolves it, so a non-default XDG home is honored rather
+ * than silently missed.
+ */
+export function opencodeSkillDirs(): { dir: string; scope: string }[] {
+    const configHome = process.env.XDG_CONFIG_HOME?.trim() || posixPath.join(HOME, ".config");
+    const base = posixPath.join(configHome, "opencode");
+    // Both spellings: OpenCode accepts `skill/` and `skills/`.
+    return [
+        { dir: posixPath.join(base, "skills"), scope: "opencode" },
+        { dir: posixPath.join(base, "skill"), scope: "opencode" },
+    ];
+}
+
 export function defaultSkillDirs(): { dir: string; scope: string }[] {
     // Re-read at call time so tests can override AX_SKILLS_DIRS after module load.
     const fromEnv = liveSkillDirList().map((dir) => ({ dir, scope: "user" }));
@@ -35,5 +58,6 @@ export function defaultSkillDirs(): { dir: string; scope: string }[] {
     return [
         { dir: posixPath.join(HOME, ".claude", "skills"), scope: "user" },
         { dir: posixPath.join(HOME, ".agents", "skills"), scope: "agents-shared" },
+        ...opencodeSkillDirs(),
     ];
 }


### PR DESCRIPTION
Fixes #746.

## Root cause — two, and either alone keeps the graph empty

**1. Discovery.** OpenCode (verified against 1.3.17, `src/skill/index.ts`) scans skills from `EXTERNAL_DIRS = [".claude", ".agents"]` under `$HOME` **and** from its own config dirs with the pattern `{skill,skills}/**/SKILL.md` — i.e. `$XDG_CONFIG_HOME/opencode/skills/…` (default `~/.config/opencode`), plus project-local `.opencode/`. ax only scanned the two shared dirs, so a catalog kept where OpenCode actually puts it never existed in the graph. That's the reporter's `~/.config/opencode/skills/` observation, and it explains `ax skills stats <name>` → "missing".

**2. Attribution.** This is why invocations were zero even though 479 tool calls ingested. Every OpenCode tool call already becomes a synthetic `opencode:<tool>` skill — and `ax skills weighted` deliberately excludes synthetic rows (`SELECT VALUE id FROM skill WHERE dir_path = "(synthetic)"`). So an OpenCode-only user's entire skill usage was filtered out by design. Meanwhile OpenCode's `skill` tool (`{ name: string }`, "Load a skill by name") *is* the activation event, and nothing mapped it to the skill it loaded.

## Fix

- **`packages/lib/src/paths.ts`** — `opencodeSkillDirs()` adds `$XDG_CONFIG_HOME/opencode/{skills,skill}` (XDG-aware exactly as OpenCode resolves it), folded into `defaultSkillDirs()`. `AX_SKILLS_DIRS` stays a full override.
- **`skills.ts`** — project discovery scans `.opencode/{skills,skill}` alongside `.claude/skills`.
- **`opencode.ts`** — a `skill` tool call now also writes an invocation + tool-call relation against the **real** catalog skill, name-resolved via `resolveSkillName` (bare `x` → catalogued `plugin:x`). Resolution is scoped strictly to skill-tool rows: applied to `opencode:bash`, the bare-name rule would fold tool telemetry into a real skill named `bash`. The synthetic tool row is kept, so tool-level analytics are unchanged.
- **`normalized/transcripts.ts`** — new `skillUpsert: "if_missing"` write mode emitting `INSERT INTO skill {…} ON DUPLICATE KEY UPDATE name = name`. Needed because the existing MERGE would stamp a real catalog skill with `dir_path = "(opencode)"` — hiding it from the very views this PR fixes. Default behavior for synthetic rows is untouched.

## Verification

- `bun test apps/axctl/src packages` — 5079 pass, 0 fail (15 new assertions across 2 new test files); `bun run typecheck` clean; all five repo checks OK
- **Live**: a skill placed under `$XDG_CONFIG_HOME/opencode/skills/` ingested as `scope: "opencode"` with its real `dir_path`; replaying the generated invocation write against that row left `scope`/`dir_path`/`content_hash` untouched (a MERGE would have overwritten all three). Both probe rows deleted afterwards.

## Honest limits

- Skill dirs are read one level deep (`<dir>/<name>/SKILL.md`), the standard layout. OpenCode's glob is recursive, so a deeply nested skill is still missed — say the word and I'll make the reader recursive.
- OpenCode config keys `skills.paths` / `skills.urls` (extra folders, remote skills cached under OpenCode's cache dir) are not read. Worth a follow-up if anyone uses them.
- If a build of OpenCode injects skills **without** a `skill` tool call, that activation leaves no trace ax can observe — the same blind spot Claude Code has for frontmatter-loaded skills, which ax models separately as the `loaded` edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)