### PR TITLE
fix(pricing): stop over-billing — fast-tier gating, synthetic-model attribution, flat context tier

### DIFF
--- a/apps/axctl/src/dashboard/session-inspect.ts
+++ b/apps/axctl/src/dashboard/session-inspect.ts
@@ -8,7 +8,7 @@
 
 import { Data, Effect, FileSystem, type Path } from "effect";
 import { dissectTurn, type TurnSpan } from "../ingest/turn-dissect.ts";
-import { extractCodexJsonlLines, type CodexTurnTokenUsage } from "../ingest/codex.ts";
+import { extractCodexJsonlLines, isCodexTurnUsageAggregated, type CodexTurnTokenUsage } from "../ingest/codex.ts";
 import { estimateCost } from "../ingest/model-pricing.ts";
 import { turnRecordKey } from "@ax/lib/ids";
 import { SurrealClient } from "@ax/lib/db";
@@ -751,6 +751,9 @@ function codexTurnUsageToDetail(usage: CodexTurnTokenUsage): TurnTokenUsageDetai
         cacheCreationInputTokens: usage.cacheCreationInputTokens,
         cacheReadInputTokens: usage.cacheReadInputTokens,
         estimatedTokens: usage.estimatedTokens,
+        // `first_total` promptTokens is a cumulative sum, not one request's
+        // context - see `isCodexTurnUsageAggregated` (plan 003, fix round 1).
+        ...(isCodexTurnUsageAggregated(usage) ? { aggregated: true } : {}),
     });
     return {
         seq: usage.seq,

--- a/apps/axctl/src/ingest/codex.test.ts
+++ b/apps/axctl/src/ingest/codex.test.ts
@@ -474,6 +474,106 @@ describe("Codex transcript extraction", () => {
         expect(sql).toContain("estimated_cost_usd:");
     });
 
+    // Plan 003 fix round 1: `codexTurnTokenUsageFromPayload`'s `first_total`
+    // outcome (no previous cumulative snapshot to diff against) returns the
+    // FULL cumulative total_token_usage.input_tokens unchanged - a sum by
+    // construction, not one request's context. It must not trigger the
+    // long-context tier even when that cumulative figure exceeds 200k. The
+    // very next turn's `derived_delta` outcome (a real diff against a
+    // previous snapshot) is genuinely request-grain and MUST still trigger
+    // the tier when its own delta exceeds 200k - same freshInputTokens
+    // (250k) on both turns, verifying the flag - not the token count -
+    // drives the tier decision.
+    test("suppresses the long-context tier on the first_total turn but not on the following derived_delta turn", () => {
+        const extracted = __testExtractCodexJsonlLines([
+            JSON.stringify({
+                type: "session_meta",
+                timestamp: "2026-07-01T10:00:00.000Z",
+                payload: {
+                    id: "codex-first-total-tier",
+                    cwd: "/tmp",
+                    model_provider: "openai",
+                    timestamp: "2026-07-01T10:00:00.000Z",
+                },
+            }),
+            JSON.stringify({
+                type: "turn_context",
+                timestamp: "2026-07-01T10:00:00.500Z",
+                payload: { model: "gpt-5.6-terra" },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-07-01T10:00:01.000Z",
+                payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "turn 1" }] },
+            }),
+            // First token_count event this session: no last_token_usage, and
+            // no previous total_token_usage to diff against -> `first_total`.
+            // Its cumulative input_tokens (250k) EXCEEDS the 200k threshold -
+            // exactly the resumed/forked-rollout shape the fix targets.
+            JSON.stringify({
+                type: "event_msg",
+                timestamp: "2026-07-01T10:00:02.000Z",
+                payload: {
+                    type: "token_count",
+                    info: {
+                        total_token_usage: { input_tokens: 250_000, output_tokens: 0, total_tokens: 250_000 },
+                    },
+                },
+            }),
+            JSON.stringify({
+                type: "response_item",
+                timestamp: "2026-07-01T10:00:03.000Z",
+                payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "turn 2" }] },
+            }),
+            // Second token_count event: still no last_token_usage, but NOW a
+            // previous snapshot exists -> `derived_delta`. Delta is
+            // 500k - 250k = 250k, the SAME fresh-input magnitude as turn 1.
+            JSON.stringify({
+                type: "event_msg",
+                timestamp: "2026-07-01T10:00:04.000Z",
+                payload: {
+                    type: "token_count",
+                    info: {
+                        total_token_usage: { input_tokens: 500_000, output_tokens: 0, total_tokens: 500_000 },
+                    },
+                },
+            }),
+        ]);
+
+        expect(extracted).not.toBeNull();
+        if (!extracted) return;
+        expect(extracted.turnTokenUsages).toHaveLength(2);
+        expect(extracted.turnTokenUsages[0]).toMatchObject({
+            seq: 1,
+            usageQuality: "first_total",
+            promptTokens: 250_000,
+            freshInputTokens: 250_000,
+        });
+        expect(extracted.turnTokenUsages[1]).toMatchObject({
+            seq: 2,
+            usageQuality: "derived_delta",
+            promptTokens: 250_000,
+            freshInputTokens: 250_000,
+        });
+
+        const statements = __testBuildCodexBatchStatements(extracted, 1200);
+        const turn1 = statements.find((s) => s.includes("turn_token_usage") && s.includes("seq: 1,"));
+        const turn2 = statements.find((s) => s.includes("turn_token_usage") && s.includes("seq: 2,"));
+        expect(turn1).toBeDefined();
+        expect(turn2).toBeDefined();
+
+        // gpt-5.6-terra: base input $2/M, tier input $4/M above 200k.
+        // first_total (aggregated, suppressed): 250k @ $2/M = $0.5 flat, base
+        // rate - NOT the $1 the tier would have produced.
+        expect(turn1).toContain("estimated_input_cost_usd: 0.5");
+        expect(turn1).toContain("estimated_cost_usd: 0.5");
+        // derived_delta (request-grain, tier applies): 250k @ $4/M = $1 -
+        // same fresh-input token count as turn 1, different (correct)
+        // dollar value because the grain differs.
+        expect(turn2).toContain("estimated_input_cost_usd: 1");
+        expect(turn2).toContain("estimated_cost_usd: 1");
+    });
+
     test("links adjacent provider events with linear parent edges while preserving tool-result parents", () => {
         const extracted = __testExtractCodexJsonlLines([
             JSON.stringify({

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -407,10 +407,32 @@ function codexTurnTokenUsageFromPayload(
         usageSource: previousTotalUsage
             ? "codex_token_count.total_token_usage_delta"
             : "codex_token_count.total_token_usage_first",
-        usageQuality: previousTotalUsage ? "derived_delta" : "first_total",
+        usageQuality: previousTotalUsage ? "derived_delta" : CODEX_TURN_USAGE_QUALITY_FIRST_TOTAL,
         raw: usage.totalTokenUsage,
     };
 }
+
+/**
+ * `codexTurnTokenUsageFromPayload` has THREE outcomes, not two - they differ
+ * in grain:
+ *  - `provider_turn` (real per-request `last_token_usage`) and
+ *    `derived_delta` (diff of two consecutive cumulative snapshots) are each
+ *    tied to exactly ONE turn - request-grain, the tier may apply.
+ *  - `first_total` (no previous snapshot to diff against) is different:
+ *    `positiveDelta(current, null)` returns `current` unchanged, so
+ *    `promptTokens` is the FULL cumulative `total_token_usage.input_tokens`
+ *    up to that point - a sum by construction. For a fresh session that's one
+ *    request and harmless; for a resumed/forked rollout whose first
+ *    `token_count` already carries inherited cumulative totals, it can exceed
+ *    200k and falsely trigger the long-context tier. Consumers must pass
+ *    `aggregated: true` to `estimateCost` for this outcome (plan 003, fix
+ *    round 1).
+ */
+export const CODEX_TURN_USAGE_QUALITY_FIRST_TOTAL = "first_total";
+
+/** True when `usage` came from the `first_total` outcome - see the doc comment above. */
+export const isCodexTurnUsageAggregated = (usage: Pick<CodexTurnTokenUsage, "usageQuality">): boolean =>
+    usage.usageQuality === CODEX_TURN_USAGE_QUALITY_FIRST_TOTAL;
 
 const concreteCodexModel = (session: CodexSession): string | null => {
     if (session.model) return session.model;
@@ -1274,6 +1296,9 @@ const buildCodexTurnTokenUsageStatements = (
                 cacheReadInputTokens: usage.cacheReadInputTokens,
                 estimatedTokens: usage.estimatedTokens,
                 fastTier: fastTierEnabled(),
+                // `first_total` promptTokens is a cumulative sum, not one
+                // request's context - see `isCodexTurnUsageAggregated`.
+                ...(isCodexTurnUsageAggregated(usage) ? { aggregated: true } : {}),
             }),
             usageSource: usage.usageSource,
             usageQuality: usage.usageQuality,

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -58,7 +58,7 @@ import { decodeCodexTranscriptLine } from "./line-schemas.ts";
 import { executeStatements } from "@ax/lib/shared/statement-exec";
 import { isNotFound, skipNotFound } from "@ax/lib/shared/fs-error";
 import { tokenQualityLabels } from "./token-quality.ts";
-import { estimateCost } from "./model-pricing.ts";
+import { estimateCost, fastTierEnabled } from "./model-pricing.ts";
 import { codexSourceForThread } from "./source-origin.ts";
 import { walkJsonlFilesStrict } from "./walk-jsonl.ts";
 import type { FileFailureSnapshot } from "./file-isolation.ts";
@@ -1212,6 +1212,7 @@ const buildCodexTokenUsageStatements = (
         cacheCreationInputTokens: null,
         cacheReadInputTokens: usage.cacheReadInputTokens,
         estimatedTokens: usage.estimatedTokens,
+        fastTier: fastTierEnabled(),
     });
     return [
         // TODO(burn-buckets): codex batching makes per-session series unavailable here; backfill via derive stage
@@ -1269,6 +1270,7 @@ const buildCodexTurnTokenUsageStatements = (
                 cacheCreationInputTokens: usage.cacheCreationInputTokens,
                 cacheReadInputTokens: usage.cacheReadInputTokens,
                 estimatedTokens: usage.estimatedTokens,
+                fastTier: fastTierEnabled(),
             }),
             usageSource: usage.usageSource,
             usageQuality: usage.usageQuality,

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -58,7 +58,7 @@ import { decodeCodexTranscriptLine } from "./line-schemas.ts";
 import { executeStatements } from "@ax/lib/shared/statement-exec";
 import { isNotFound, skipNotFound } from "@ax/lib/shared/fs-error";
 import { tokenQualityLabels } from "./token-quality.ts";
-import { estimateCost, fastTierEnabled } from "./model-pricing.ts";
+import { estimateCost } from "./model-pricing.ts";
 import { codexSourceForThread } from "./source-origin.ts";
 import { walkJsonlFilesStrict } from "./walk-jsonl.ts";
 import type { FileFailureSnapshot } from "./file-isolation.ts";
@@ -1234,7 +1234,6 @@ const buildCodexTokenUsageStatements = (
         cacheCreationInputTokens: null,
         cacheReadInputTokens: usage.cacheReadInputTokens,
         estimatedTokens: usage.estimatedTokens,
-        fastTier: fastTierEnabled(),
         // `usage.promptTokens` is `total_token_usage.input_tokens` - cumulative
         // across the whole session at this point, not one request. See plan 003.
         aggregated: true,
@@ -1295,7 +1294,6 @@ const buildCodexTurnTokenUsageStatements = (
                 cacheCreationInputTokens: usage.cacheCreationInputTokens,
                 cacheReadInputTokens: usage.cacheReadInputTokens,
                 estimatedTokens: usage.estimatedTokens,
-                fastTier: fastTierEnabled(),
                 // `first_total` promptTokens is a cumulative sum, not one
                 // request's context - see `isCodexTurnUsageAggregated`.
                 ...(isCodexTurnUsageAggregated(usage) ? { aggregated: true } : {}),

--- a/apps/axctl/src/ingest/codex.ts
+++ b/apps/axctl/src/ingest/codex.ts
@@ -1213,6 +1213,9 @@ const buildCodexTokenUsageStatements = (
         cacheReadInputTokens: usage.cacheReadInputTokens,
         estimatedTokens: usage.estimatedTokens,
         fastTier: fastTierEnabled(),
+        // `usage.promptTokens` is `total_token_usage.input_tokens` - cumulative
+        // across the whole session at this point, not one request. See plan 003.
+        aggregated: true,
     });
     return [
         // TODO(burn-buckets): codex batching makes per-session series unavailable here; backfill via derive stage

--- a/apps/axctl/src/ingest/model-pricing.test.ts
+++ b/apps/axctl/src/ingest/model-pricing.test.ts
@@ -8,7 +8,6 @@ import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import {
     builtInPricingCatalog,
     estimateCost,
-    fastTierEnabled,
     isSyntheticModel,
     loadPricingCatalog as loadPricingCatalogEffect,
     mergePricingCatalogs,
@@ -167,12 +166,6 @@ describe("model pricing", () => {
         expect(estimateCost(usage).totalUsd).toBeCloseTo(5, 6);
         // Priority tier is 2.5x - opt-in only.
         expect(estimateCost({ ...usage, fastTier: true }).totalUsd).toBeCloseTo(12.5, 6);
-    });
-
-    it("reads the fast-tier opt-in from the environment", () => {
-        expect(fastTierEnabled({})).toBe(false);
-        expect(fastTierEnabled({ AX_OPENAI_FAST_TIER: "0" })).toBe(false);
-        expect(fastTierEnabled({ AX_OPENAI_FAST_TIER: "1" })).toBe(true);
     });
 
     it("prices claude-opus-5 and its dated variants from the built-in catalog", () => {

--- a/apps/axctl/src/ingest/model-pricing.test.ts
+++ b/apps/axctl/src/ingest/model-pricing.test.ts
@@ -8,6 +8,7 @@ import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import {
     builtInPricingCatalog,
     estimateCost,
+    fastTierEnabled,
     loadPricingCatalog as loadPricingCatalogEffect,
     mergePricingCatalogs,
     normalizeModelName,
@@ -146,6 +147,30 @@ describe("model pricing", () => {
             inputAbove200kPerMillionUsd: 0.4,
             outputAbove200kPerMillionUsd: 1.8,
         });
+    });
+
+    it("bills at base rates by default and at the fast tier only when asked", () => {
+        const catalog = builtInPricingCatalog();
+        const usage = {
+            modelKey: "gpt-5.5",
+            promptTokens: 1_000_000,
+            completionTokens: 0,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            estimatedTokens: 1_000_000,
+            pricingCatalog: catalog,
+        };
+
+        // 1M fresh input tokens at $5/M.
+        expect(estimateCost(usage).totalUsd).toBeCloseTo(5, 6);
+        // Priority tier is 2.5x - opt-in only.
+        expect(estimateCost({ ...usage, fastTier: true }).totalUsd).toBeCloseTo(12.5, 6);
+    });
+
+    it("reads the fast-tier opt-in from the environment", () => {
+        expect(fastTierEnabled({})).toBe(false);
+        expect(fastTierEnabled({ AX_OPENAI_FAST_TIER: "0" })).toBe(false);
+        expect(fastTierEnabled({ AX_OPENAI_FAST_TIER: "1" })).toBe(true);
     });
 
     it("prices claude-opus-5 and its dated variants from the built-in catalog", () => {

--- a/apps/axctl/src/ingest/model-pricing.test.ts
+++ b/apps/axctl/src/ingest/model-pricing.test.ts
@@ -9,6 +9,7 @@ import {
     builtInPricingCatalog,
     estimateCost,
     fastTierEnabled,
+    isSyntheticModel,
     loadPricingCatalog as loadPricingCatalogEffect,
     mergePricingCatalogs,
     normalizeModelName,
@@ -17,6 +18,7 @@ import {
     PRICING_CACHE_TTL_MS,
     pricingCacheTtlMs,
     pricingForModel,
+    SYNTHETIC_MODEL_SENTINEL,
 } from "./model-pricing.ts";
 import type { PricingCatalogLoadResult } from "./model-pricing.ts";
 
@@ -210,6 +212,14 @@ describe("model pricing", () => {
         expect(normalizeModelName("openai")).toBeNull();
         expect(normalizeModelName("anthropic")).toBeNull();
         expect(normalizeModelName("gpt-5.5")).toBe("gpt-5.5");
+    });
+
+    it("treats <synthetic> as a non-model everywhere", () => {
+        expect(isSyntheticModel("<synthetic>")).toBe(true);
+        expect(isSyntheticModel(" <synthetic> ")).toBe(true);
+        expect(isSyntheticModel("claude-opus-5")).toBe(false);
+        expect(isSyntheticModel(null)).toBe(false);
+        expect(normalizeModelName(SYNTHETIC_MODEL_SENTINEL)).toBeNull();
     });
 
     it("uses above-200k tier fields when present", () => {

--- a/apps/axctl/src/ingest/model-pricing.test.ts
+++ b/apps/axctl/src/ingest/model-pricing.test.ts
@@ -222,7 +222,7 @@ describe("model pricing", () => {
         expect(normalizeModelName(SYNTHETIC_MODEL_SENTINEL)).toBeNull();
     });
 
-    it("uses above-200k tier fields when present", () => {
+    it("uses above-200k tier fields when present, flat across the whole request", () => {
         const catalog = new Map([
             ["tiered-model", {
                 provider: "test",
@@ -247,9 +247,63 @@ describe("model pricing", () => {
             pricingCatalog: catalog,
         });
 
-        expect(cost.inputUsd).toBe(0.4);
-        expect(cost.outputUsd).toBe(3);
-        expect(cost.totalUsd).toBe(3.4);
+        // promptTokens (300k) exceeds the 200k threshold, so the WHOLE request
+        // - input AND output - bills flat at the tier rate: 300k @ $2/M input,
+        // 250k @ $20/M output. (Old marginal maths gave 0.4/3/3.4 - wrong per
+        // plan 003.)
+        expect(cost.inputUsd).toBe(0.6);
+        expect(cost.outputUsd).toBe(5);
+        expect(cost.totalUsd).toBe(5.6);
+    });
+
+    it("applies the long-context tier flat, per request, and only above the threshold", () => {
+        const catalog = builtInPricingCatalog();
+        const base = {
+            modelKey: "gpt-5.6-terra",
+            completionTokens: 0,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            pricingCatalog: catalog,
+        };
+
+        // Under the threshold: base rate ($2/M).
+        expect(estimateCost({ ...base, promptTokens: 100_000, estimatedTokens: 100_000 }).totalUsd)
+            .toBeCloseTo(0.2, 6);
+        // Over the threshold: the WHOLE request at the tier rate ($4/M) - not
+        // 200k at base plus the remainder at tier.
+        expect(estimateCost({ ...base, promptTokens: 1_000_000, estimatedTokens: 1_000_000 }).totalUsd)
+            .toBeCloseTo(4, 6);
+    });
+
+    it("never applies the long-context tier to aggregated token sums", () => {
+        const catalog = builtInPricingCatalog();
+        const summed = {
+            modelKey: "gpt-5.6-terra",
+            promptTokens: 28_000_000,
+            completionTokens: 0,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            estimatedTokens: 28_000_000,
+            pricingCatalog: catalog,
+        };
+
+        // A session row summing 28M tokens says nothing about any single
+        // request's context - bill at base ($2/M), not the tier rate.
+        expect(estimateCost({ ...summed, aggregated: true }).totalUsd).toBeCloseTo(56, 6);
+    });
+
+    it("reads models.dev context_over_200k tiers", () => {
+        const catalog = parseModelsDevPricingCatalog({
+            openai: { models: { "gpt-test": { id: "gpt-test", cost: {
+                input: 2, output: 12, cache_read: 0.2, cache_write: 2.5,
+                context_over_200k: { input: 4, output: 18, cache_read: 0.4, cache_write: 5 },
+            } } } },
+        });
+        expect(catalog.get("gpt-test")).toMatchObject({
+            inputPerMillionUsd: 2,
+            inputAbove200kPerMillionUsd: 4,
+            outputAbove200kPerMillionUsd: 18,
+        });
     });
 
     it("prices fresh input separately from cache reads", () => {

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -434,12 +434,22 @@ export function parseModelsDevPricingCatalog(input: unknown): Map<string, ModelP
             const inputPerMillionUsd = numberOrNull(cost.input);
             const outputPerMillionUsd = numberOrNull(cost.output);
             if (inputPerMillionUsd === null && outputPerMillionUsd === null) continue;
+            // models.dev's flat `context_over_200k` block mirrors litellm's
+            // `*_above_200k_tokens` fields - the same flat-switch semantics
+            // `estimateCost` now models. Its `tiers[].tier.size` variant (a
+            // different threshold, e.g. 272k) is intentionally NOT read here -
+            // out of scope for this plan.
+            const tier = asRecord(cost.context_over_200k);
             catalog.set(modelKey, withCacheDefaults({
                 provider: providerName,
                 inputPerMillionUsd,
                 outputPerMillionUsd,
                 cacheCreationPerMillionUsd: numberOrNull(cost.cache_write ?? cost.write),
                 cacheReadPerMillionUsd: numberOrNull(cost.cache_read ?? cost.read),
+                inputAbove200kPerMillionUsd: numberOrNull(tier?.input),
+                outputAbove200kPerMillionUsd: numberOrNull(tier?.output),
+                cacheCreationAbove200kPerMillionUsd: numberOrNull(tier?.cache_write),
+                cacheReadAbove200kPerMillionUsd: numberOrNull(tier?.cache_read),
                 fastMultiplier: 1,
                 contextWindow: intOrNull(limit?.context ?? model?.context_window),
                 pricingSource: "models.dev",
@@ -510,11 +520,11 @@ export function pricingForModel(
     return null;
 }
 
-const componentCost = (tokens: number, basePerMillion: number | null, above200kPerMillion?: number | null): number | null => {
-    if (basePerMillion === null) return null;
-    if (!above200kPerMillion || tokens <= 200_000) return tokens * basePerMillion / 1_000_000;
-    return (200_000 * basePerMillion + (tokens - 200_000) * above200kPerMillion) / 1_000_000;
-};
+/** Long-context threshold: above this input context, the whole request bills at the tier rate. */
+export const CONTEXT_TIER_THRESHOLD_TOKENS = 200_000;
+
+const componentCost = (tokens: number, perMillion: number | null): number | null =>
+    perMillion === null ? null : tokens * perMillion / 1_000_000;
 
 export function estimateCost(input: {
     readonly modelKey: string | null;
@@ -531,6 +541,12 @@ export function estimateCost(input: {
      * transcript, so assuming priority overstated every OpenAI cost.
      */
     readonly fastTier?: boolean;
+    /**
+     * These token counts are a SUM over many requests (a session row, a rollup
+     * group), not one request. Suppresses the long-context tier, which is
+     * per-request and cannot be recovered from a sum. Default false.
+     */
+    readonly aggregated?: boolean;
 }): CostEstimate {
     const pricing = pricingForModel(input.modelKey, input.pricingCatalog);
     if (!pricing) {
@@ -547,12 +563,24 @@ export function estimateCost(input: {
     const cacheCreationTokens = input.cacheCreationInputTokens ?? 0;
     const cacheReadTokens = input.cacheReadInputTokens ?? 0;
     const freshInputTokens = Math.max(0, promptTokens - cacheCreationTokens - cacheReadTokens);
-    const inputUsd = componentCost(freshInputTokens, pricing.inputPerMillionUsd, pricing.inputAbove200kPerMillionUsd);
+    // The long-context surcharge is a property of ONE REQUEST's input context,
+    // and it is flat: above the threshold, every token of that request bills at
+    // the tier rate. Callers that pass SUMMED tokens (a whole session, a rollup
+    // group) cannot answer "was any single request long-context?", so they must
+    // NOT trigger the tier - see `aggregated` on the input type above.
+    const tiered = input.aggregated !== true
+        && promptTokens > CONTEXT_TIER_THRESHOLD_TOKENS
+        && pricing.inputAbove200kPerMillionUsd != null;
+    const inputRate = tiered ? pricing.inputAbove200kPerMillionUsd : pricing.inputPerMillionUsd;
+    const outputRate = tiered ? (pricing.outputAbove200kPerMillionUsd ?? pricing.outputPerMillionUsd) : pricing.outputPerMillionUsd;
+    const cacheCreationRate = tiered ? (pricing.cacheCreationAbove200kPerMillionUsd ?? pricing.cacheCreationPerMillionUsd) : pricing.cacheCreationPerMillionUsd;
+    const cacheReadRate = tiered ? (pricing.cacheReadAbove200kPerMillionUsd ?? pricing.cacheReadPerMillionUsd) : pricing.cacheReadPerMillionUsd;
+    const inputUsd = componentCost(freshInputTokens, inputRate);
     const outputUsd = input.completionTokens === null
         ? null
-        : componentCost(input.completionTokens, pricing.outputPerMillionUsd, pricing.outputAbove200kPerMillionUsd);
-    const cacheCreationUsd = componentCost(cacheCreationTokens, pricing.cacheCreationPerMillionUsd, pricing.cacheCreationAbove200kPerMillionUsd);
-    const cacheReadUsd = componentCost(cacheReadTokens, pricing.cacheReadPerMillionUsd, pricing.cacheReadAbove200kPerMillionUsd);
+        : componentCost(input.completionTokens, outputRate);
+    const cacheCreationUsd = componentCost(cacheCreationTokens, cacheCreationRate);
+    const cacheReadUsd = componentCost(cacheReadTokens, cacheReadRate);
     const tierMultiplier = input.fastTier === true ? pricing.fastMultiplier : 1;
     const totalUsd = [inputUsd, outputUsd, cacheCreationUsd, cacheReadUsd]
         .filter((value): value is number => value !== null)

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -514,6 +514,13 @@ export function estimateCost(input: {
     readonly cacheReadInputTokens: number | null;
     readonly estimatedTokens: number;
     readonly pricingCatalog?: ReadonlyMap<string, ModelPricing>;
+    /**
+     * Bill at the provider's priority/fast tier. OFF by default: the harness
+     * default is the standard tier (`service_tier = "default"` in
+     * ~/.codex/config.toml) and no per-session tier signal exists in any
+     * transcript, so assuming priority overstated every OpenAI cost.
+     */
+    readonly fastTier?: boolean;
 }): CostEstimate {
     const pricing = pricingForModel(input.modelKey, input.pricingCatalog);
     if (!pricing) {
@@ -536,9 +543,10 @@ export function estimateCost(input: {
         : componentCost(input.completionTokens, pricing.outputPerMillionUsd, pricing.outputAbove200kPerMillionUsd);
     const cacheCreationUsd = componentCost(cacheCreationTokens, pricing.cacheCreationPerMillionUsd, pricing.cacheCreationAbove200kPerMillionUsd);
     const cacheReadUsd = componentCost(cacheReadTokens, pricing.cacheReadPerMillionUsd, pricing.cacheReadAbove200kPerMillionUsd);
+    const tierMultiplier = input.fastTier === true ? pricing.fastMultiplier : 1;
     const totalUsd = [inputUsd, outputUsd, cacheCreationUsd, cacheReadUsd]
         .filter((value): value is number => value !== null)
-        .reduce((sum, value) => sum + value, 0) * pricing.fastMultiplier;
+        .reduce((sum, value) => sum + value, 0) * tierMultiplier;
     return {
         inputUsd,
         outputUsd,
@@ -548,6 +556,14 @@ export function estimateCost(input: {
         pricingSource: pricing.pricingSource,
     };
 }
+
+/**
+ * Opt into priority/fast-tier billing (`AX_OPENAI_FAST_TIER=1`). Default is the
+ * standard tier - see `estimateCost`'s `fastTier` doc comment.
+ */
+export const fastTierEnabled = (
+    env: Record<string, string | undefined> = process.env,
+): boolean => env.AX_OPENAI_FAST_TIER === "1";
 
 export function agentModelStatement(input: {
     readonly modelKey: string;

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -359,9 +359,19 @@ export const BUILTIN_MODEL_PRICING_CATALOG: Readonly<Record<string, ModelPricing
     },
 };
 
+/**
+ * Claude Code's placeholder `model` on assistant entries it generated WITHOUT an
+ * API call. It is not a model: it must never win a session's model attribution
+ * and must never be priced.
+ */
+export const SYNTHETIC_MODEL_SENTINEL = "<synthetic>";
+
+export const isSyntheticModel = (model: string | null | undefined): boolean =>
+    model?.trim() === SYNTHETIC_MODEL_SENTINEL;
+
 export function normalizeModelName(model: string | null | undefined): string | null {
     const trimmed = model?.trim();
-    if (!trimmed || trimmed === "<synthetic>") return null;
+    if (!trimmed || isSyntheticModel(trimmed)) return null;
     const key = trimmed.toLowerCase();
     if (key === "openai" || key === "anthropic" || key === "google" || key === "deepseek" || key === "qwen") {
         return null;

--- a/apps/axctl/src/ingest/model-pricing.ts
+++ b/apps/axctl/src/ingest/model-pricing.ts
@@ -559,6 +559,13 @@ export function estimateCost(input: {
             pricingSource: null,
         };
     }
+    // This value now GATES the long-context tier below (`tiered` compares it
+    // against `CONTEXT_TIER_THRESHOLD_TOKENS`). Today the only caller that can
+    // pass a null `promptTokens` (the byte-estimate path) also passes
+    // `aggregated: true`, so the fallback never reaches the gate live - but a
+    // future request-grain caller passing null `promptTokens` would gate on a
+    // prompt+completion TOTAL (`estimatedTokens`), not a pure input-context
+    // count. Keep that caller's `promptTokens` non-null, or mark it aggregated.
     const promptTokens = input.promptTokens ?? input.estimatedTokens;
     const cacheCreationTokens = input.cacheCreationInputTokens ?? 0;
     const cacheReadTokens = input.cacheReadInputTokens ?? 0;
@@ -594,14 +601,6 @@ export function estimateCost(input: {
         pricingSource: pricing.pricingSource,
     };
 }
-
-/**
- * Opt into priority/fast-tier billing (`AX_OPENAI_FAST_TIER=1`). Default is the
- * standard tier - see `estimateCost`'s `fastTier` doc comment.
- */
-export const fastTierEnabled = (
-    env: Record<string, string | undefined> = process.env,
-): boolean => env.AX_OPENAI_FAST_TIER === "1";
 
 export function agentModelStatement(input: {
     readonly modelKey: string;

--- a/apps/axctl/src/ingest/transcripts.test.ts
+++ b/apps/axctl/src/ingest/transcripts.test.ts
@@ -1649,6 +1649,48 @@ describe("claude token usage", () => {
         expect(stmt).toContain('source: "claude"');
     });
 
+    test("never triggers the long-context tier on a session's summed tokens above 200k", () => {
+        // `session_token_usage` is priced from the transcript's SUMMED usage
+        // totals, not one request's context - gpt-5.6-terra carries real
+        // `*Above200k*` built-in rates (see model-pricing.ts), so a single
+        // 300k-token message proves the tier stays suppressed (plan 003 fix
+        // round 1: the `aggregated: true` marking in
+        // `buildClaudeTokenUsageStatements`).
+        const lines = [
+            JSON.stringify({
+                type: "user",
+                uuid: "u1",
+                timestamp: "2026-06-01T10:00:00.000Z",
+                sessionId: "cl-tiered",
+                cwd: "/tmp",
+                message: { role: "user", content: "do a thing" },
+            }),
+            JSON.stringify({
+                type: "assistant",
+                uuid: "a1",
+                timestamp: "2026-06-01T10:00:01.000Z",
+                sessionId: "cl-tiered",
+                message: {
+                    role: "assistant",
+                    model: "gpt-5.6-terra",
+                    content: "ok",
+                    usage: {
+                        input_tokens: 300_000,
+                        output_tokens: 0,
+                        cache_creation_input_tokens: 0,
+                        cache_read_input_tokens: 0,
+                    },
+                },
+            }),
+        ];
+        const extracted = __testExtractClaudeJsonlLines(lines, "-tmp", "cl-tiered");
+        const [stmt] = buildClaudeTokenUsageStatements(extracted!);
+        // Base rate only: 300k fresh input @ $2/M = $0.6. The tiered rate
+        // ($4/M) would give $1.2 - if this ever regresses to that, the
+        // `aggregated: true` marking was lost.
+        expect(stmt).toContain("estimated_cost_usd: 0.6");
+    });
+
     test("subagent source override lands on session and turn usage rows", () => {
         const extracted = __testExtractClaudeJsonlLines(
             usageLines("claude-opus-4-8"),

--- a/apps/axctl/src/ingest/transcripts.test.ts
+++ b/apps/axctl/src/ingest/transcripts.test.ts
@@ -1568,12 +1568,20 @@ describe("claude token usage", () => {
         expect(u.model).toBe("claude-opus-4-8");
     });
 
-    test("a trailing <synthetic> entry does not clobber the session's real model", () => {
+    test("a trailing <synthetic> entry does not clobber the session's real model or its own turn row", () => {
         // Claude Code emits assistant entries with model "<synthetic>" for
         // harness-generated messages (no API call). Model attribution is
         // last-write-wins, so a trailing synthetic entry used to overwrite the
         // whole session's model - filing its real spend under a non-model that
         // prices at $0.
+        //
+        // Real synthetic entries carry an all-zero `usage` block (verified
+        // against ~/.claude/projects: 240/240 sampled), so a turn_token_usage
+        // row IS emitted for them - reproduced here rather than omitting
+        // `usage` on the synthetic entry. The guard deliberately relabels that
+        // row's model too (see the comment at the guard site): a phantom
+        // `<synthetic>` leg would otherwise read as a model switch that never
+        // happened to per-model leg detection.
         const lines = [
             JSON.stringify({
                 type: "user",
@@ -1609,11 +1617,21 @@ describe("claude token usage", () => {
                     role: "assistant",
                     model: "<synthetic>",
                     content: "done",
+                    usage: {
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        cache_creation_input_tokens: 0,
+                        cache_read_input_tokens: 0,
+                    },
                 },
             }),
         ];
         const extracted = __testExtractClaudeJsonlLines(lines, "-tmp", "cl-synth");
         expect(extracted?.session.model).toBe("claude-opus-4-8");
+        // The synthetic entry's own turn row - not just the session - carries
+        // the last real model, not "<synthetic>".
+        expect(extracted?.turnTokenUsages).toHaveLength(2);
+        expect(extracted?.turnTokenUsages[1]?.model).toBe("claude-opus-4-8");
     });
 
     test("prices the session via the built-in catalog", () => {

--- a/apps/axctl/src/ingest/transcripts.test.ts
+++ b/apps/axctl/src/ingest/transcripts.test.ts
@@ -1568,6 +1568,54 @@ describe("claude token usage", () => {
         expect(u.model).toBe("claude-opus-4-8");
     });
 
+    test("a trailing <synthetic> entry does not clobber the session's real model", () => {
+        // Claude Code emits assistant entries with model "<synthetic>" for
+        // harness-generated messages (no API call). Model attribution is
+        // last-write-wins, so a trailing synthetic entry used to overwrite the
+        // whole session's model - filing its real spend under a non-model that
+        // prices at $0.
+        const lines = [
+            JSON.stringify({
+                type: "user",
+                uuid: "u1",
+                timestamp: "2026-06-01T10:00:00.000Z",
+                sessionId: "cl-synth",
+                cwd: "/tmp",
+                message: { role: "user", content: "do a thing" },
+            }),
+            JSON.stringify({
+                type: "assistant",
+                uuid: "a1",
+                timestamp: "2026-06-01T10:00:01.000Z",
+                sessionId: "cl-synth",
+                message: {
+                    role: "assistant",
+                    model: "claude-opus-4-8",
+                    content: "ok",
+                    usage: {
+                        input_tokens: 100,
+                        output_tokens: 50,
+                        cache_creation_input_tokens: 0,
+                        cache_read_input_tokens: 0,
+                    },
+                },
+            }),
+            JSON.stringify({
+                type: "assistant",
+                uuid: "a2",
+                timestamp: "2026-06-01T10:00:02.000Z",
+                sessionId: "cl-synth",
+                message: {
+                    role: "assistant",
+                    model: "<synthetic>",
+                    content: "done",
+                },
+            }),
+        ];
+        const extracted = __testExtractClaudeJsonlLines(lines, "-tmp", "cl-synth");
+        expect(extracted?.session.model).toBe("claude-opus-4-8");
+    });
+
     test("prices the session via the built-in catalog", () => {
         const extracted = __testExtractClaudeJsonlLines(
             usageLines("claude-opus-4-8"),

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1016,6 +1016,12 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
             // is not a model, and attribution here is last-write-wins, so one
             // trailing synthetic entry used to relabel the whole session -
             // filing its real spend under a non-model that prices at $0.
+            // This also gates the LOCAL `model`, which flows into each
+            // synthetic entry's own turn_token_usage row (it carries an
+            // all-zero usage block, so a row IS emitted for it) - deliberate:
+            // a zero-token `<synthetic>` leg would otherwise read as a
+            // phantom model switch to per-model leg detection (dispatch
+            // model-drop marking, thinking analytics).
             if (entryModel && !isSyntheticModel(entryModel)) {
                 model = entryModel;
                 if (session) session.model = entryModel;

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -1616,6 +1616,10 @@ export const buildClaudeTokenUsageStatements = (
         cacheCreationInputTokens: usage.cacheCreationInputTokens,
         cacheReadInputTokens: usage.cacheReadInputTokens,
         estimatedTokens: usage.estimatedTokens,
+        // `usage` is summed across the whole session's `message.usage`
+        // blocks (see the `ClaudeTokenUsage` doc comment above), not one
+        // request. See plan 003.
+        aggregated: true,
     });
     const sessionId = extracted.session.id;
     const burnBuckets = computeBurnBuckets(

--- a/apps/axctl/src/ingest/transcripts.ts
+++ b/apps/axctl/src/ingest/transcripts.ts
@@ -78,7 +78,7 @@ import {
     surrealString,
 } from "@ax/lib/shared/surql";
 import { safeKeyPart } from "@ax/lib/shared/derive-keys";
-import { estimateCost, normalizeModelName } from "./model-pricing.ts";
+import { estimateCost, isSyntheticModel, normalizeModelName } from "./model-pricing.ts";
 import type { FileFailureSnapshot } from "./file-isolation.ts";
 import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
 import {
@@ -1012,7 +1012,11 @@ function createClaudeExtractor(path: Path.Path, projectDir: string, sessionId: s
             const role = type ?? "unknown";
             const message = entry.message ?? null;
             const entryModel = message?.model ?? entry.model ?? null;
-            if (entryModel) {
+            // `<synthetic>` marks a harness-generated entry with no API call. It
+            // is not a model, and attribution here is last-write-wins, so one
+            // trailing synthetic entry used to relabel the whole session -
+            // filing its real spend under a non-model that prices at $0.
+            if (entryModel && !isSyntheticModel(entryModel)) {
                 model = entryModel;
                 if (session) session.model = entryModel;
             }

--- a/apps/axctl/src/metrics/cost-estimate.test.ts
+++ b/apps/axctl/src/metrics/cost-estimate.test.ts
@@ -37,6 +37,24 @@ const catalog = new Map<string, ModelPricing>([
     ["claude-haiku-4-5-20251001", haikuPricing],
 ]);
 
+// Carries `*Above200k*` rates so a session-grain call that forgets
+// `aggregated: true` would wrongly trigger the long-context tier (plan 003).
+const tieredPricing: ModelPricing = {
+    provider: "test",
+    inputPerMillionUsd: 1,
+    outputPerMillionUsd: 10,
+    cacheCreationPerMillionUsd: null,
+    cacheReadPerMillionUsd: null,
+    inputAbove200kPerMillionUsd: 2,
+    outputAbove200kPerMillionUsd: 20,
+    fastMultiplier: 1,
+    pricingSource: "test",
+};
+
+const tieredCatalog = new Map<string, ModelPricing>([
+    ["tiered-model", tieredPricing],
+]);
+
 describe("fillEstimatedCost", () => {
     test("keeps a stored cost untouched (estimated=false, source preserved)", () => {
         const out = fillEstimatedCost(
@@ -91,6 +109,27 @@ describe("fillEstimatedCost", () => {
         // built-in claude-opus-4 input = $15/M
         expect(out.estimatedCostUsd).toBeCloseTo(15, 6);
         expect(isEstimatedPricingSource(out.pricingSource)).toBe(true);
+    });
+
+    // `usage` here is a whole `session_token_usage` row - a SUM over many
+    // requests, not one request's context - so the long-context tier must
+    // stay suppressed even when the summed prompt tokens exceed 200k
+    // (plan 003 fix round 1: the `aggregated: true` marking at the
+    // `fillEstimatedCost` call site).
+    test("never triggers the long-context tier on a session's summed tokens above 200k", () => {
+        const out = fillEstimatedCost(
+            usage({
+                model: "tiered-model",
+                prompt_tokens: 300_000,
+                completion_tokens: 0,
+                estimated_tokens: 300_000,
+            }),
+            tieredCatalog,
+        );
+        // Base rate only: 300k fresh input @ $1/M = $0.30. The tiered rate
+        // ($2/M) would give $0.60 - if this ever regresses to $0.60, the
+        // `aggregated: true` marking was lost.
+        expect(out.estimatedCostUsd).toBeCloseTo(0.3, 8);
     });
 });
 

--- a/apps/axctl/src/metrics/cost-estimate.ts
+++ b/apps/axctl/src/metrics/cost-estimate.ts
@@ -82,6 +82,9 @@ export function fillEstimatedCost(
         cacheReadInputTokens: usage.cache_read_input_tokens,
         estimatedTokens: usage.estimated_tokens,
         pricingCatalog: catalog,
+        // `usage` is a `session_token_usage` row - one session's SUMMED
+        // token counts, not one request. See plan 003.
+        aggregated: true,
     });
     if (cost.totalUsd === null) {
         return { estimatedCostUsd: null, pricingSource: usage.pricing_source ?? null, estimated: false };

--- a/apps/axctl/src/queries/cost-analytics.test.ts
+++ b/apps/axctl/src/queries/cost-analytics.test.ts
@@ -139,6 +139,33 @@ describe("fetchCostModels - #696 unpriced/recompute semantics", () => {
 
         expect(result.rows[0]).toMatchObject({ cost_usd: 0, unpriced: false });
     });
+
+    // The recomputed row is a whole rollup GROUP (many sessions summed), never
+    // one request's context. A tiered catalog + >200k prompt tokens proves the
+    // long-context tier stays suppressed at query-time recompute (plan 003 fix
+    // round 1: the `aggregated: true` marking inside `resolveRowCost`).
+    test("never triggers the long-context tier when recomputing a rollup group above 200k tokens", async () => {
+        const dbRows = [
+            { model: "tiered-model", sessions: 1, prompt_tokens: 300_000, completion_tokens: 0,
+              cache_read_tokens: 0, cache_create_tokens: 0, cost_usd: 0 },
+        ];
+        const agentModelRows = [
+            {
+                name: "tiered-model", provider: "test",
+                input_per_million_usd: 1, output_per_million_usd: 10,
+                cache_creation_per_million_usd: null, cache_read_per_million_usd: null,
+                input_above_200k_per_million_usd: 2, output_above_200k_per_million_usd: 20,
+                fast_multiplier: 1, context_window: null, pricing_source: "test",
+            },
+        ];
+        const db = makeMockDb([[dbRows], [agentModelRows]]);
+        const result = await runWithMock(db, fetchCostModels({ sinceDays: 14 }));
+
+        // Base rate only: 300k @ $1/M = $0.30. The tiered rate ($2/M) would
+        // give $0.60 - if this ever regresses to $0.60, the `aggregated:
+        // true` marking was lost.
+        expect(result.rows[0]).toMatchObject({ cost_usd: 0.3, unpriced: false });
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/axctl/src/queries/cost-analytics.ts
+++ b/apps/axctl/src/queries/cost-analytics.ts
@@ -108,6 +108,9 @@ function resolveRowCost(
         cacheReadInputTokens: input.cacheReadTokens,
         estimatedTokens: input.promptTokens,
         pricingCatalog: catalog,
+        // A rollup group (many sessions summed), sometimes even a whole
+        // session row - never one request's context. See plan 003.
+        aggregated: true,
     });
     return estimate.totalUsd === null
         ? { cost_usd: 0, unpriced: true }

--- a/apps/axctl/src/queries/reprice.test.ts
+++ b/apps/axctl/src/queries/reprice.test.ts
@@ -38,4 +38,36 @@ describe("reprice", () => {
         const cost = reprice(usage, "unknown-model", new Map());
         expect(cost).toBe(5);
     });
+
+    // `usage` is a dispatch's SUMMED token buckets, not one request's context.
+    // A tiered catalog + >200k prompt tokens proves the long-context tier
+    // stays suppressed (plan 003 fix round 1: the `aggregated: true` marking
+    // at the `reprice` call site).
+    it("never triggers the long-context tier on a dispatch's summed tokens above 200k", () => {
+        const catalog = new Map([
+            ["tiered-model", {
+                provider: "test",
+                inputPerMillionUsd: 1,
+                outputPerMillionUsd: 10,
+                cacheReadPerMillionUsd: null,
+                cacheCreationPerMillionUsd: null,
+                inputAbove200kPerMillionUsd: 2,
+                outputAbove200kPerMillionUsd: 20,
+                fastMultiplier: 1,
+                pricingSource: "test",
+            }],
+        ]);
+        const tieredUsage: RepriceUsage = {
+            prompt_tokens: 300_000,
+            completion_tokens: 0,
+            cache_read_tokens: 0,
+            cache_create_tokens: 0,
+            cost_usd: 999,
+        };
+        const cost = reprice(tieredUsage, "tiered-model", catalog);
+        // Base rate only: 300k @ $1/M = $0.30. The tiered rate ($2/M) would
+        // give $0.60 - if this ever regresses to $0.60, the `aggregated:
+        // true` marking was lost.
+        expect(cost).toBeCloseTo(0.3, 6);
+    });
 });

--- a/apps/axctl/src/queries/reprice.ts
+++ b/apps/axctl/src/queries/reprice.ts
@@ -46,6 +46,9 @@ export function reprice(
         cacheReadInputTokens: usage.cache_read_tokens,
         estimatedTokens: usage.prompt_tokens + usage.completion_tokens,
         ...(pricingCatalog.size > 0 ? { pricingCatalog } : {}),
+        // `usage` is a dispatch's summed token buckets, not one request's
+        // context - suppress the long-context tier. See plan 003.
+        aggregated: true,
     });
     return cost.totalUsd ?? usage.cost_usd;
 }

--- a/plans/001-fast-multiplier-gating.md
+++ b/plans/001-fast-multiplier-gating.md
@@ -1,0 +1,286 @@
+# 001 - Stop billing every OpenAI session at priority-tier rates
+
+- **Written against commit:** `d70e1b3e` (branch `fix/751-pricing-claude-opus-5-unpriced-the`)
+- **Status:** TODO
+- **Depends on:** nothing
+- **Blocks:** nothing (plan 003 touches the same function; land 001 first)
+
+## Why this matters
+
+`estimateCost` multiplies the whole computed cost by `pricing.fastMultiplier`,
+unconditionally. Four built-in catalog entries carry a multiplier above 1:
+
+| model | fastMultiplier |
+|---|---|
+| `gpt-5.3-codex` | 2 |
+| `gpt-5.3-codex-spark` | 2 |
+| `gpt-5.4` | 2 |
+| `gpt-5.5` | 2.5 |
+
+Those multipliers encode OpenAI's **priority / fast service tier**. models.dev
+confirms the ratio is real for two of them - `gpt-5.5` base is 5/30/0.5 and its
+`experimental.modes.fast.cost` is 12.5/75/1.25, exactly 2.5× - so the *numbers*
+are correct. The bug is that they are applied to **every** session regardless of
+which tier the request actually used.
+
+This machine's Codex config (`~/.codex/config.toml:8`) says:
+
+```toml
+service_tier = "default"
+```
+
+i.e. NOT priority. Yet the live database shows `gpt-5.5` stored at **$17,235.02**
+across 1,736 session rows - the third-largest model by spend - every dollar of
+it inflated 2.5×. Removing the unwarranted multiplier drops it to roughly
+$6,894, i.e. **~$10.3k of the ~$87.5k all-time reported spend is phantom (~12%)**.
+
+`gpt-5.3-codex` is worse: models.dev lists `experimental.modes.fast` as `null`
+for it - there is no documented fast tier at all - yet ax hardcodes ×2.
+
+**There is no per-session tier signal in ingested data.** `service_tier` does not
+appear in Codex rollout transcripts; `turn_context` payloads carry only
+`approval_policy, collaboration_mode, current_date, cwd, model, personality,
+realtime_active, sandbox_policy, summary, timezone, truncation_policy, turn_id,
+user_instructions`. So the fix cannot be "detect the tier per session". It must
+be: **default to base rates, and make the fast tier an explicit opt-in.** Base
+rates are the correct default because the standard tier is the default in the
+harness config.
+
+## Current state
+
+`apps/axctl/src/ingest/model-pricing.ts:539-541`:
+
+```ts
+    const totalUsd = [inputUsd, outputUsd, cacheCreationUsd, cacheReadUsd]
+        .filter((value): value is number => value !== null)
+        .reduce((sum, value) => sum + value, 0) * pricing.fastMultiplier;
+```
+
+`apps/axctl/src/ingest/model-pricing.ts:153-161` (one of the four entries):
+
+```ts
+    "gpt-5.5": {
+        provider: "openai",
+        inputPerMillionUsd: 5,
+        outputPerMillionUsd: 30,
+        cacheCreationPerMillionUsd: 5,
+        cacheReadPerMillionUsd: 0.5,
+        fastMultiplier: 2.5,
+        pricingSource: MODEL_PRICING_SOURCE,
+    },
+```
+
+`fastMultiplier` is also a persisted column: `packages/schema/src/schema.surql:157`
+`DEFINE FIELD fast_multiplier ON agent_model TYPE option<float>;`, written by
+`agentModelStatement` (`model-pricing.ts:572`) and read back by
+`pricingRowsToCatalog` (`model-pricing.ts:469`). Do NOT drop the column - keep
+the rate data, change only when it is applied.
+
+## What to do
+
+### Step 1 - make the multiplier opt-in at the estimate site
+
+In `apps/axctl/src/ingest/model-pricing.ts`, add an optional `fastTier` flag to
+`estimateCost`'s input object (default `false`) and apply the multiplier only
+when it is set:
+
+```ts
+export function estimateCost(input: {
+    readonly modelKey: string | null;
+    readonly promptTokens: number | null;
+    readonly completionTokens: number | null;
+    readonly cacheCreationInputTokens: number | null;
+    readonly cacheReadInputTokens: number | null;
+    readonly estimatedTokens: number;
+    readonly pricingCatalog?: ReadonlyMap<string, ModelPricing>;
+    /**
+     * Bill at the provider's priority/fast tier. OFF by default: the harness
+     * default is the standard tier (`service_tier = "default"` in
+     * ~/.codex/config.toml) and no per-session tier signal exists in any
+     * transcript, so assuming priority overstated every OpenAI cost.
+     */
+    readonly fastTier?: boolean;
+}): CostEstimate {
+```
+
+and at the total:
+
+```ts
+    const tierMultiplier = input.fastTier === true ? pricing.fastMultiplier : 1;
+    const totalUsd = [inputUsd, outputUsd, cacheCreationUsd, cacheReadUsd]
+        .filter((value): value is number => value !== null)
+        .reduce((sum, value) => sum + value, 0) * tierMultiplier;
+```
+
+`exactOptionalPropertyTypes: true` is on in this repo - declare the field as
+`readonly fastTier?: boolean` and compare with `=== true`; do not add
+`| undefined` to the property type, and do not pass `fastTier: undefined`
+explicitly at call sites (omit the key instead). See the existing conditional-
+spread idiom at `apps/axctl/src/queries/reprice.ts:48`:
+`...(pricingCatalog.size > 0 ? { pricingCatalog } : {})`.
+
+**Do not** change any of the four catalog entries' `fastMultiplier` values, and
+do not touch the `fast_multiplier` schema column. The rates stay; only their
+application becomes conditional.
+
+Verify:
+
+```
+bunx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no `error TS` lines. (`bun run typecheck` is NOT sufficient - it can
+exit 0 while CI's plain `tsc` fails; CI gates on the command above.)
+
+### Step 2 - add the env opt-in
+
+Still in `model-pricing.ts`, export a small reader so callers that price at
+ingest can honor an explicit opt-in:
+
+```ts
+/**
+ * Opt into priority/fast-tier billing (`AX_OPENAI_FAST_TIER=1`). Default is the
+ * standard tier - see `estimateCost`'s `fastTier` doc comment.
+ */
+export const fastTierEnabled = (
+    env: Record<string, string | undefined> = process.env,
+): boolean => env.AX_OPENAI_FAST_TIER === "1";
+```
+
+Do NOT wire this into every call site in this plan. Wire it into exactly one:
+the ingest pricing path in `apps/axctl/src/ingest/codex.ts` where `estimateCost`
+is called for Codex usage rows. Find it with:
+
+```
+rg -n "estimateCost\(" apps/axctl/src
+```
+
+Add `fastTier: fastTierEnabled()` to that one call (conditional-spread if the
+flag is false, per the note in step 1). Leave read-time callers
+(`metrics/cost-estimate.ts`, `queries/cost-analytics.ts`, `queries/reprice.ts`)
+on the default - they must agree with what ingest stored, and the default is now
+base rates on both sides.
+
+### Step 3 - tests
+
+Add to `apps/axctl/src/ingest/model-pricing.test.ts`, inside the existing
+`describe("model pricing", ...)` block. Follow the file's existing style: plain
+`it(...)`, `builtInPricingCatalog()` for the catalog, `toMatchObject` /
+`toBeCloseTo` for numbers.
+
+```ts
+    it("bills at base rates by default and at the fast tier only when asked", () => {
+        const catalog = builtInPricingCatalog();
+        const usage = {
+            modelKey: "gpt-5.5",
+            promptTokens: 1_000_000,
+            completionTokens: 0,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            estimatedTokens: 1_000_000,
+            pricingCatalog: catalog,
+        };
+
+        // 1M fresh input tokens at $5/M.
+        expect(estimateCost(usage).totalUsd).toBeCloseTo(5, 6);
+        // Priority tier is 2.5x - opt-in only.
+        expect(estimateCost({ ...usage, fastTier: true }).totalUsd).toBeCloseTo(12.5, 6);
+    });
+
+    it("reads the fast-tier opt-in from the environment", () => {
+        expect(fastTierEnabled({})).toBe(false);
+        expect(fastTierEnabled({ AX_OPENAI_FAST_TIER: "0" })).toBe(false);
+        expect(fastTierEnabled({ AX_OPENAI_FAST_TIER: "1" })).toBe(true);
+    });
+```
+
+Add `fastTierEnabled` to the import list at the top of the test file.
+
+Then check whether any EXISTING test asserts a fast-multiplied total. Run:
+
+```
+rg -n "fastMultiplier|fast_multiplier|gpt-5\.5|gpt-5\.4|gpt-5\.3-codex" apps/axctl/src --glob '*.test.ts'
+```
+
+Any test that asserted a ×2 / ×2.5 total must be updated to the base-rate number
+**and** gain a sibling assertion with `fastTier: true`. A test that only asserts
+the catalog entry's `fastMultiplier` field value (not a computed total) stays
+as-is - the field is unchanged.
+
+Verify:
+
+```
+bun test apps/axctl/src/ingest/model-pricing.test.ts
+bun test
+```
+
+Expected: model-pricing suite fully green. On the full run, exactly 4 failures
+are pre-existing and unrelated - `apps/studio-desktop/src/electron/*.test.ts`
+failing with `Electron failed to install correctly`. Any OTHER failure is yours;
+fix it or STOP and report.
+
+### Step 4 - do NOT reprice history in this plan
+
+Stored costs written under the old multiplier stay wrong until a repricing path
+exists - there is none today (`derive-cost-backfill.ts:79` only selects
+`WHERE estimated_cost_usd IS NONE`, and `ax ingest --reparse=pricing` rewrites
+only the `agent_model` catalog table, not usage rows). Repricing is deliberately
+out of scope here. Note it in the PR body as a known follow-up.
+
+## Boundaries
+
+**In scope:** `apps/axctl/src/ingest/model-pricing.ts`,
+`apps/axctl/src/ingest/model-pricing.test.ts`, the single Codex ingest
+`estimateCost` call site, and any existing test that asserted a fast-multiplied
+total.
+
+**Out of scope - do not touch:**
+- The four `fastMultiplier` values in `BUILTIN_MODEL_PRICING_CATALOG`.
+- `packages/schema/src/schema.surql` (the `fast_multiplier` column stays).
+- `componentCost` and the `*Above200k*` fields - that is plan 003.
+- Any stored-row migration / repricing.
+- `apps/studio*`, `apps/site`, docs beyond a one-line note if you add one.
+
+## Done criteria
+
+1. `bunx tsc --noEmit -p tsconfig.json` prints no `error TS` lines.
+2. `bun test apps/axctl/src/ingest/model-pricing.test.ts` - all pass.
+3. `bun test` - only the 4 pre-existing electron failures.
+4. `rg -n "pricing.fastMultiplier" apps/axctl/src` returns exactly one hit, and
+   that line is guarded by the `fastTier` flag.
+5. Sanity check the headline number:
+   ```
+   bun -e 'import {estimateCost,builtInPricingCatalog} from "./apps/axctl/src/ingest/model-pricing.ts"; const c=builtInPricingCatalog(); const u={modelKey:"gpt-5.5",promptTokens:1e6,completionTokens:0,cacheCreationInputTokens:0,cacheReadInputTokens:0,estimatedTokens:1e6,pricingCatalog:c}; console.log(estimateCost(u).totalUsd, estimateCost({...u,fastTier:true}).totalUsd)'
+   ```
+   Expected output: `5 12.5`.
+
+## Test plan
+
+New tests live in `apps/axctl/src/ingest/model-pricing.test.ts` (pattern: the
+existing `it("prices claude-sonnet-5 and every GPT-5.6 tier from the built-in
+catalog", ...)`). Two cases: default-is-base-rates + opt-in-is-multiplied, and
+the env reader's three states. No DB, no network, no fixtures - `estimateCost`
+and `fastTierEnabled` are pure.
+
+## Maintenance note
+
+Anyone adding a model with a documented priority tier should set
+`fastMultiplier` from the provider's published fast rate ÷ base rate (models.dev
+exposes this as `experimental.modes.fast.cost`) and must NOT assume it will be
+applied - it only applies under `AX_OPENAI_FAST_TIER=1`.
+
+`gpt-5.3-codex` and `gpt-5.3-codex-spark` carry `fastMultiplier: 2` but
+models.dev reports `experimental.modes.fast` as `null` for `gpt-5.3-codex` -
+that multiplier has no upstream basis. After this plan it is inert by default,
+so it is not urgent; flag it in review if someone enables the opt-in.
+
+## Escape hatches
+
+- If `rg -n "estimateCost\(" apps/axctl/src` shows the Codex ingest path does
+  **not** call `estimateCost` directly (e.g. it goes through a wrapper), wire
+  `fastTier` at the wrapper instead - but if that wrapper is shared with a
+  read-time surface, STOP and report: wiring it there would reintroduce the
+  ingest/read disagreement this plan is trying to avoid.
+- If more than ~5 existing tests assert fast-multiplied totals, STOP and report
+  the list before editing them - that many would suggest the multiplier is
+  load-bearing somewhere this plan did not survey.

--- a/plans/002-synthetic-session-model.md
+++ b/plans/002-synthetic-session-model.md
@@ -1,0 +1,240 @@
+# 002 - Stop one `<synthetic>` message from relabelling a whole session's model
+
+- **Written against commit:** `d70e1b3e` (branch `fix/751-pricing-claude-opus-5-unpriced-the`)
+- **Status:** TODO
+- **Depends on:** nothing
+- **Blocks:** nothing
+
+## Why this matters
+
+Claude Code emits assistant entries whose `message.model` is the literal string
+`"<synthetic>"` - messages the harness generated without an API call. ax picks a
+session's model with **last-write-wins** over every entry, so a single trailing
+synthetic entry overwrites the real model for the entire session.
+
+`normalizeModelName` maps `"<synthetic>"` to `null` (correctly - it is not a
+model), so those sessions then price at **$0** and render as **UNPRICED** in the
+cost rollups.
+
+Live database, at the time of writing:
+
+- `SELECT count() FROM session WHERE model = '<synthetic>'` → **148**
+- `SELECT count(), math::sum(prompt_tokens), math::sum(estimated_cost_usd) FROM
+  session_token_usage WHERE model = '<synthetic>'` → **148 rows, 645,067,300
+  prompt tokens, $0.00**
+- The `turn_token_usage` rows for those same 148 sessions total **$384.82** -
+  a lower bound on what is missing at session grain, since turn rows are
+  themselves incomplete.
+
+One concrete session, `0e6ae51b-0865-4804-b89f-b834d30f5afa`:
+
+```
+SELECT model, count() FROM turn_token_usage WHERE session = session:`0e6ae51b-…` GROUP BY model;
+-- [{model: "<synthetic>", n: 1}, {model: "claude-opus-4-8", n: 306}]
+```
+
+306 real `claude-opus-4-8` turns, one synthetic turn - and the session-level row
+is filed under `<synthetic>` with 53,362,299 prompt tokens costed at $0.
+
+The damage is not only cost: `session.model` feeds every model-grouped surface
+(`ax cost models`, `ax cost split`, dispatch analytics, profile model shares), so
+148 sessions are attributed to a non-existent model everywhere.
+
+## Current state
+
+`apps/axctl/src/ingest/transcripts.ts:966-973`:
+
+```ts
+            seq += 1;
+            const role = type ?? "unknown";
+            const message = entry.message ?? null;
+            const entryModel = message?.model ?? entry.model ?? null;
+            if (entryModel) {
+                model = entryModel;
+                if (session) session.model = entryModel;
+            }
+```
+
+`model` (the local) flows into each per-turn usage row
+(`transcripts.ts:992`); `session.model` flows into the session-level usage row
+(`transcripts.ts:1176`, `model: session.model`) and into the `session` record
+itself (`transcripts.ts:1511`, `model: extracted.session.model`).
+
+The sentinel is recognised in exactly one place today -
+`apps/axctl/src/ingest/model-pricing.ts:362-364`:
+
+```ts
+export function normalizeModelName(model: string | null | undefined): string | null {
+    const trimmed = model?.trim();
+    if (!trimmed || trimmed === "<synthetic>") return null;
+```
+
+## What to do
+
+### Step 1 - name the sentinel once, in the pricing module
+
+In `apps/axctl/src/ingest/model-pricing.ts`, just above `normalizeModelName`,
+add and export the constant plus a predicate, and use them in
+`normalizeModelName` so there is a single definition:
+
+```ts
+/**
+ * Claude Code's placeholder `model` on assistant entries it generated WITHOUT an
+ * API call. It is not a model: it must never win a session's model attribution
+ * and must never be priced.
+ */
+export const SYNTHETIC_MODEL_SENTINEL = "<synthetic>";
+
+export const isSyntheticModel = (model: string | null | undefined): boolean =>
+    model?.trim() === SYNTHETIC_MODEL_SENTINEL;
+```
+
+Rewrite the guard inside `normalizeModelName` to use `isSyntheticModel(trimmed)`
+instead of the inline string compare. Behaviour must be identical.
+
+### Step 2 - do not let the sentinel overwrite the session model
+
+In `apps/axctl/src/ingest/transcripts.ts`, import `isSyntheticModel` from
+`./model-pricing.ts` (there are already imports from that module in this file -
+match the existing import grouping) and change the block at lines 969-973 to:
+
+```ts
+            const entryModel = message?.model ?? entry.model ?? null;
+            // `<synthetic>` marks a harness-generated entry with no API call. It
+            // is not a model, and attribution here is last-write-wins, so one
+            // trailing synthetic entry used to relabel the whole session -
+            // filing its real spend under a non-model that prices at $0.
+            if (entryModel && !isSyntheticModel(entryModel)) {
+                model = entryModel;
+                if (session) session.model = entryModel;
+            }
+```
+
+That is the entire behavioural change: a synthetic entry now leaves the
+last real model in place instead of clobbering it.
+
+**Edge case to preserve:** a session whose entries are *all* synthetic keeps
+`session.model === null`, exactly as it does today for a session with no model
+at all. Do not substitute a placeholder.
+
+Verify:
+
+```
+bunx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no `error TS` lines. (`bun run typecheck` can exit 0 while CI's plain
+`tsc` fails - CI gates on the command above.)
+
+### Step 3 - tests
+
+Add a case to `apps/axctl/src/ingest/transcripts.test.ts`. Find an existing test
+that builds a small transcript and asserts on the produced session/usage - use it
+as the structural pattern (search for `usageLines(` in that file; there is
+already a case at roughly line 1539 using `usageLines("some-unpriced-model")`).
+
+The new case must assert: given entries `[assistant model "claude-opus-4-8" with
+usage, assistant model "<synthetic>"]`, the resulting session model is
+`"claude-opus-4-8"` - NOT `"<synthetic>"`.
+
+Add a second, pure case to `apps/axctl/src/ingest/model-pricing.test.ts`:
+
+```ts
+    it("treats <synthetic> as a non-model everywhere", () => {
+        expect(isSyntheticModel("<synthetic>")).toBe(true);
+        expect(isSyntheticModel(" <synthetic> ")).toBe(true);
+        expect(isSyntheticModel("claude-opus-5")).toBe(false);
+        expect(isSyntheticModel(null)).toBe(false);
+        expect(normalizeModelName(SYNTHETIC_MODEL_SENTINEL)).toBeNull();
+    });
+```
+
+Add `isSyntheticModel` and `SYNTHETIC_MODEL_SENTINEL` to that file's import list.
+
+Verify:
+
+```
+bun test apps/axctl/src/ingest/model-pricing.test.ts apps/axctl/src/ingest/transcripts.test.ts
+bun test
+```
+
+Expected: both suites green. On the full run, exactly 4 failures are pre-existing
+and unrelated - `apps/studio-desktop/src/electron/*.test.ts` failing with
+`Electron failed to install correctly`. Any OTHER failure is yours.
+
+### Step 4 - heal the 148 existing sessions
+
+The fix only helps sessions ingested afterwards. To correct history, the affected
+transcripts must be re-read:
+
+```
+ax ingest --reparse=claude,subagents
+```
+
+Do NOT write a SQL migration that rewrites `session.model` in place - the correct
+model per session comes from re-parsing the transcript, and the re-parse path
+already exists (`--reparse` clears the skip-unchanged watermark; see
+`apps/axctl/src/ingest/reparse-targets.ts`).
+
+**Caveat to state in the PR body, not to fix here:** re-parsing rewrites
+`session.model` and the session usage row's `model`, but `derive-cost-backfill`
+only prices rows `WHERE estimated_cost_usd IS NONE`. The 148 rows currently store
+`estimated_cost_usd = 0` (not NONE) for some providers - check before claiming
+the money reappears:
+
+```
+curl -s -u root:root -H "surreal-ns: ax" -H "surreal-db: main" -X POST \
+  http://127.0.0.1:8521/sql --data-binary \
+  "SELECT count() AS n FROM session_token_usage WHERE model = '<synthetic>' AND estimated_cost_usd IS NONE GROUP ALL;"
+```
+
+If `n` is less than 148, the remainder needs the repricing path that does not yet
+exist (finding 5 of the audit) - say so plainly rather than implying the fix
+recovers all of it.
+
+## Boundaries
+
+**In scope:** `apps/axctl/src/ingest/model-pricing.ts` (constant + predicate,
+reuse in `normalizeModelName`), `apps/axctl/src/ingest/transcripts.ts` (the
+model-attribution guard only), and the two test files named above.
+
+**Out of scope - do not touch:**
+- Per-turn model attribution (`transcripts.ts:992`). Turn rows correctly record
+  the synthetic entry as synthetic; only session-level rollup was wrong.
+- `estimateCost`, `componentCost`, `fastMultiplier` - plans 001 and 003.
+- Any SQL migration or in-place rewrite of `session` / `session_token_usage`.
+- The Codex / Pi / OpenCode / Cursor parsers - the sentinel is Claude-specific.
+
+## Done criteria
+
+1. `bunx tsc --noEmit -p tsconfig.json` prints no `error TS` lines.
+2. `bun test apps/axctl/src/ingest/model-pricing.test.ts apps/axctl/src/ingest/transcripts.test.ts` - all pass.
+3. `bun test` - only the 4 pre-existing electron failures.
+4. `rg -n '"<synthetic>"' apps/axctl/src --glob '!*.test.ts'` returns exactly ONE
+   hit: the `SYNTHETIC_MODEL_SENTINEL` definition.
+5. The new transcripts test fails when the guard in step 2 is reverted (confirm
+   by temporarily reverting, running, and restoring - a test that passes either
+   way is not testing the fix).
+
+## Test plan
+
+- Pure predicate coverage in `model-pricing.test.ts` (no DB, no fixtures).
+- Behavioural coverage in `transcripts.test.ts`, following the existing
+  `usageLines(...)` fixture pattern in that file: a two-entry transcript where
+  the synthetic entry is last, asserting the real model survives.
+
+## Maintenance note
+
+`<synthetic>` is a Claude Code harness detail; if another harness introduces its
+own placeholder, extend `isSyntheticModel` rather than adding a second inline
+compare. The reason this went unnoticed is that `normalizeModelName` handled the
+sentinel *correctly* at the pricing boundary - the attribution site upstream had
+no idea the value was special. Any new consumer of `message.model` should route
+through `isSyntheticModel` first.
+
+## Escape hatches
+
+- If the transcripts test fixture helper does not let you set `message.model`
+  per entry, STOP and report rather than restructuring the fixture layer.
+- If `rg -n '"<synthetic>"'` shows the sentinel is also compared in a parser you
+  were told not to touch, report it - do not widen the change silently.

--- a/plans/003-context-tier-semantics.md
+++ b/plans/003-context-tier-semantics.md
@@ -1,0 +1,299 @@
+# 003 - Fix the `>200k` context-tier calculation (and stop feeding it aggregates)
+
+- **Written against commit:** `d70e1b3e` (branch `fix/751-pricing-claude-opus-5-unpriced-the`)
+- **Status:** TODO
+- **Depends on:** plan 001 (same function, `estimateCost`; land 001 first to avoid a conflict)
+- **Blocks:** nothing
+
+## Why this matters
+
+`componentCost` implements long-context pricing as a **marginal, per-component**
+calculation. Real provider pricing is a **flat switch on the request's input
+context size**: if a single request's context exceeds the threshold, that whole
+request bills at the higher rate. Three things are wrong:
+
+1. **Marginal vs flat.** The code bills the first 200k at the base rate and only
+   the remainder at the premium. Providers bill every token of a qualifying
+   request at the premium.
+2. **Per-component vs per-request-context.** The threshold is compared against
+   *each component's own token count* - output tokens against 200k, cache-read
+   tokens against 200k, etc. The tier is a property of the input context, not of
+   each bucket. `outputAbove200kPerMillionUsd` is effectively dead code: output
+   caps at 128k per request, so `tokens <= 200_000` is always true for it.
+3. **Aggregates, not requests.** Every caller passes *summed* token counts.
+   `session_token_usage` holds one row per session - the live DB has
+   `claude-opus-4-8` at 47.86B prompt tokens across 1,669 session rows, i.e.
+   ~28.7M prompt tokens per row. `resolveRowCost` in
+   `apps/axctl/src/queries/cost-analytics.ts` is worse: its input is a whole
+   rollup group summed across many sessions. Against those numbers the "first
+   200k at base rate" is rounding error and **essentially 100% of tokens bill at
+   the premium**, whether or not any individual request was ever long-context.
+
+Today the blast radius is small because none of the top-spend models has tier
+rates loaded - checked in the live DB, `claude-opus-4-8`, `claude-fable-5`,
+`gpt-5.5`, `gpt-5.4`, `claude-opus-4-7`, `claude-sonnet-4-6` and
+`claude-haiku-4-5-20251001` all have `input_above_200k_per_million_usd = NONE`.
+Rows that DO carry tiers (litellm `claude-sonnet-4-5` family, `inp=3 → inp200=6`)
+are not in the user's top spend.
+
+**That changes with PR #752**, which adds `*Above200k*` fields to `gpt-5.6-sol`,
+`gpt-5.6-terra` and `gpt-5.6-luna`. Once merged, any Codex session on those
+models gets ~all of its tokens billed at the premium - for terra that is
+$4/M instead of $2/M input, a ~2× over-count. **This plan must land before, or
+together with, those tier fields becoming active.**
+
+## Current state
+
+`apps/axctl/src/ingest/model-pricing.ts:503-507`:
+
+```ts
+const componentCost = (tokens: number, basePerMillion: number | null, above200kPerMillion?: number | null): number | null => {
+    if (basePerMillion === null) return null;
+    if (!above200kPerMillion || tokens <= 200_000) return tokens * basePerMillion / 1_000_000;
+    return (200_000 * basePerMillion + (tokens - 200_000) * above200kPerMillion) / 1_000_000;
+};
+```
+
+Called four times from `estimateCost` (`model-pricing.ts:533-538`), once per
+component, each with that component's own token count.
+
+Callers, all of which pass aggregated counts:
+- `apps/axctl/src/metrics/cost-estimate.ts:77-85` - one session's summed usage.
+- `apps/axctl/src/ingest/derive-cost-backfill.ts:98-107` - same, at derive time.
+- `apps/axctl/src/queries/cost-analytics.ts` `resolveRowCost` - a rollup group.
+- `apps/axctl/src/queries/reprice.ts:41-49` - a dispatch's summed usage.
+
+## What to do
+
+The honest fix is **not** to make the aggregate calculation cleverer - the input
+simply does not carry the per-request context sizes needed to apply a
+per-request tier. The fix is to make the code do something defensible and say
+which it is doing.
+
+### Step 1 - decide and encode the semantics
+
+Implement **flat-switch, evaluated once per estimate, against the request's
+input context** - and make the "is this one request?" question explicit at the
+call site rather than implied.
+
+In `apps/axctl/src/ingest/model-pricing.ts`, replace `componentCost` with a flat
+rate selection, and choose the tier ONCE in `estimateCost`:
+
+```ts
+/** Long-context threshold: above this input context, the whole request bills at the tier rate. */
+export const CONTEXT_TIER_THRESHOLD_TOKENS = 200_000;
+
+const componentCost = (tokens: number, perMillion: number | null): number | null =>
+    perMillion === null ? null : tokens * perMillion / 1_000_000;
+```
+
+In `estimateCost`, after `promptTokens` / cache buckets are resolved, pick the
+rate set once:
+
+```ts
+    // The long-context surcharge is a property of ONE REQUEST's input context,
+    // and it is flat: above the threshold, every token of that request bills at
+    // the tier rate. Callers that pass SUMMED tokens (a whole session, a rollup
+    // group) cannot answer "was any single request long-context?", so they must
+    // NOT trigger the tier - see `aggregated` below.
+    const tiered = input.aggregated !== true
+        && promptTokens > CONTEXT_TIER_THRESHOLD_TOKENS
+        && pricing.inputAbove200kPerMillionUsd != null;
+
+    const inputRate = tiered ? pricing.inputAbove200kPerMillionUsd : pricing.inputPerMillionUsd;
+    const outputRate = tiered ? (pricing.outputAbove200kPerMillionUsd ?? pricing.outputPerMillionUsd) : pricing.outputPerMillionUsd;
+    const cacheCreationRate = tiered ? (pricing.cacheCreationAbove200kPerMillionUsd ?? pricing.cacheCreationPerMillionUsd) : pricing.cacheCreationPerMillionUsd;
+    const cacheReadRate = tiered ? (pricing.cacheReadAbove200kPerMillionUsd ?? pricing.cacheReadPerMillionUsd) : pricing.cacheReadPerMillionUsd;
+```
+
+and use those four rates in the four `componentCost` calls.
+
+Add the flag to `estimateCost`'s input type (mind `exactOptionalPropertyTypes`:
+declare `readonly aggregated?: boolean`, compare with `=== true`, and omit the
+key rather than passing `undefined`):
+
+```ts
+    /**
+     * These token counts are a SUM over many requests (a session row, a rollup
+     * group), not one request. Suppresses the long-context tier, which is
+     * per-request and cannot be recovered from a sum. Default false.
+     */
+    readonly aggregated?: boolean;
+```
+
+### Step 2 - mark the aggregate call sites
+
+Set `aggregated: true` at every caller that passes summed counts:
+
+- `apps/axctl/src/metrics/cost-estimate.ts` - inside `fillEstimatedCost`.
+- `apps/axctl/src/queries/cost-analytics.ts` - inside `resolveRowCost`.
+- `apps/axctl/src/queries/reprice.ts` - inside `reprice`.
+
+`derive-cost-backfill.ts` goes through `fillEstimatedCost`, so it inherits the
+flag - do not add it there separately.
+
+Leave any genuine per-request call site (a single turn's usage) unflagged. Find
+every call with:
+
+```
+rg -n "estimateCost\(" apps/axctl/src
+```
+
+and classify each one in the PR body: request-grain (tier may apply) vs
+aggregate (tier suppressed). If you cannot tell for a given site, treat it as
+aggregate - under-counting a surcharge is the safer error, and it is the
+behaviour those sites have today for all top-spend models.
+
+### Step 3 - while you are here, read the tiers models.dev already publishes
+
+`parseModelsDevPricingCatalog` (`model-pricing.ts:427-436`) drops the tier data
+entirely, while `parseLiteLlmPricingCatalog` (`:398-401`) reads its
+`*_above_200k_tokens` fields. models.dev exposes the same information as
+`cost.context_over_200k` (and a `cost.tiers` array), e.g. for `gpt-5.6-terra`:
+
+```json
+"cost": { "input": 2, "output": 12, "cache_read": 0.2, "cache_write": 2.5,
+          "context_over_200k": { "input": 4, "output": 18, "cache_read": 0.4, "cache_write": 5 } }
+```
+
+Add the four `*Above200kPerMillionUsd` fields to the object built in
+`parseModelsDevPricingCatalog`, reading from `cost.context_over_200k` via the
+existing `numberOrNull` helper and the existing `asRecord` guard. Ignore
+`cost.tiers` - `context_over_200k` is the flat form this code models.
+
+This is additive: it only populates fields that were `undefined` before. It is in
+scope here (not a separate plan) precisely because step 1 must land first -
+populating tier rates while the marginal/aggregate calculation is still in place
+would activate the over-count on many more models.
+
+### Step 4 - tests
+
+In `apps/axctl/src/ingest/model-pricing.test.ts`:
+
+```ts
+    it("applies the long-context tier flat, per request, and only above the threshold", () => {
+        const catalog = builtInPricingCatalog();
+        const base = {
+            modelKey: "gpt-5.6-terra",
+            completionTokens: 0,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            pricingCatalog: catalog,
+        };
+
+        // Under the threshold: base rate ($2/M).
+        expect(estimateCost({ ...base, promptTokens: 100_000, estimatedTokens: 100_000 }).totalUsd)
+            .toBeCloseTo(0.2, 6);
+        // Over the threshold: the WHOLE request at the tier rate ($4/M) - not
+        // 200k at base plus the remainder at tier.
+        expect(estimateCost({ ...base, promptTokens: 1_000_000, estimatedTokens: 1_000_000 }).totalUsd)
+            .toBeCloseTo(4, 6);
+    });
+
+    it("never applies the long-context tier to aggregated token sums", () => {
+        const catalog = builtInPricingCatalog();
+        const summed = {
+            modelKey: "gpt-5.6-terra",
+            promptTokens: 28_000_000,
+            completionTokens: 0,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            estimatedTokens: 28_000_000,
+            pricingCatalog: catalog,
+        };
+
+        // A session row summing 28M tokens says nothing about any single
+        // request's context - bill at base ($2/M), not the tier rate.
+        expect(estimateCost({ ...summed, aggregated: true }).totalUsd).toBeCloseTo(56, 6);
+    });
+
+    it("reads models.dev context_over_200k tiers", () => {
+        const catalog = parseModelsDevPricingCatalog({
+            openai: { models: { "gpt-test": { id: "gpt-test", cost: {
+                input: 2, output: 12, cache_read: 0.2, cache_write: 2.5,
+                context_over_200k: { input: 4, output: 18, cache_read: 0.4, cache_write: 5 },
+            } } } },
+        });
+        expect(catalog.get("gpt-test")).toMatchObject({
+            inputPerMillionUsd: 2,
+            inputAbove200kPerMillionUsd: 4,
+            outputAbove200kPerMillionUsd: 18,
+        });
+    });
+```
+
+Then find and update every existing test that asserts the OLD marginal maths:
+
+```
+rg -n "200_000|200000|Above200k|above_200k" apps/axctl/src --glob '*.test.ts'
+```
+
+Any test asserting `(200_000 * base + remainder * tier)` must be rewritten to the
+flat expectation. If one of them documents the marginal behaviour as intentional
+(a comment citing a provider doc), **STOP and report** - that would contradict
+this plan's premise and needs a human decision.
+
+Verify:
+
+```
+bun test apps/axctl/src/ingest/model-pricing.test.ts
+bunx tsc --noEmit -p tsconfig.json
+bun test
+```
+
+Expected: green except the 4 pre-existing `apps/studio-desktop` electron
+failures (`Electron failed to install correctly`).
+
+## Boundaries
+
+**In scope:** `apps/axctl/src/ingest/model-pricing.ts` (`componentCost`,
+`estimateCost`, `parseModelsDevPricingCatalog`), the `aggregated: true` flag at
+the three aggregate call sites named in step 2, and the affected tests.
+
+**Out of scope - do not touch:**
+- `fastMultiplier` and its gating - that is plan 001.
+- Session model attribution - that is plan 002.
+- The `*_above_200k_*` schema columns or `agentModelStatement`.
+- Repricing stored history.
+- The 272,000-token `tiers[].tier.size` variant in models.dev. This plan models
+  the flat `context_over_200k` form only; do not implement a second threshold.
+
+## Done criteria
+
+1. `bunx tsc --noEmit -p tsconfig.json` prints no `error TS` lines.
+2. `bun test apps/axctl/src/ingest/model-pricing.test.ts` - all pass, including
+   the three new cases.
+3. `bun test` - only the 4 pre-existing electron failures.
+4. `rg -n "200_000" apps/axctl/src/ingest/model-pricing.ts` shows the threshold
+   defined ONCE (`CONTEXT_TIER_THRESHOLD_TOKENS`) and referenced from
+   `estimateCost` - not inside `componentCost`.
+5. Every `estimateCost(` call site in `apps/axctl/src` is classified in the PR
+   body as request-grain or aggregate.
+
+## Test plan
+
+All three new cases are pure (no DB, no network) and live in
+`apps/axctl/src/ingest/model-pricing.test.ts` alongside the existing pricing
+tests. The models.dev parser case follows the shape of the existing
+`parseLiteLlmPricingCatalog` / `parseModelsDevPricingCatalog` tests at the top of
+that file - inline literal input, `toMatchObject` on the parsed entry.
+
+## Maintenance note
+
+The `aggregated` flag is a **grain assertion**, not a tuning knob: it says "these
+counts are a sum over requests". Any new `estimateCost` caller must answer that
+question. A caller that is unsure should pass `aggregated: true`.
+
+If ax ever records per-request input context (e.g. per-turn prompt tokens at
+request grain rather than turn grain), the tier could be applied accurately at
+that grain and summed upward - that is the only path to a correct long-context
+number, and it is a data-model change, not a pricing-formula change.
+
+## Escape hatches
+
+- If plan 001 has not landed, STOP - both plans edit the tail of `estimateCost`
+  and will conflict.
+- If any existing test documents the marginal calculation as deliberate with a
+  provider-doc citation, STOP and report before changing it.
+- If `rg -n "estimateCost\("` turns up a call site in `apps/studio` or
+  `packages/`, STOP and report - this plan surveyed `apps/axctl` only.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,77 @@
+# Pricing-calculation improvement plans
+
+Written against commit `d70e1b3e` (branch `fix/751-pricing-claude-opus-5-unpriced-the`)
+by an audit scoped to the cost/pricing path only.
+
+All figures below were measured against the live local SurrealDB at the time of
+writing, not estimated.
+
+## Execution order
+
+| # | Plan | Why now | Effort | Risk | Status |
+|---|---|---|---|---|---|
+| 001 | [Stop billing every OpenAI session at priority-tier rates](001-fast-multiplier-gating.md) | ~$10.3k phantom of ~$87.5k all-time reported spend (~12%) | M | M | TODO |
+| 002 | [Stop one `<synthetic>` message relabelling a session's model](002-synthetic-session-model.md) | 148 sessions / 645M prompt tokens priced $0; ≥$385 invisible | S | L | TODO |
+| 003 | [Fix the `>200k` context-tier calculation](003-context-tier-semantics.md) | Latent today, **activated by PR #752** | M | M | TODO |
+
+**Dependencies:** 003 depends on 001 - both edit the tail of `estimateCost` and
+will conflict otherwise. 002 is independent and can land in parallel with either.
+
+**Ordering rationale:** 001 is the largest dollar error and is independent. 002
+is the cheapest real loss with the lowest risk. 003 is latent *today* but PR #752
+adds `*Above200k*` rates to `gpt-5.6-sol/terra/luna`, which activates it - so 003
+must land before, or together with, those tier fields becoming live.
+
+## Interaction with PR #752 (issue #751)
+
+PR #752 is correct about rates and should land. But its three new
+`*Above200k*` field sets are the exact input that turns finding 003 from latent
+into active (~2× over-count on long `gpt-5.6-terra` sessions). Two safe orders:
+
+- Drop the four `*Above200k*` fields from the three `gpt-5.6-*` entries in #752,
+  merge it, then land 003 (which re-adds tiers *and* reads them from models.dev
+  automatically). **Recommended** - smallest window of wrong numbers.
+- Merge #752 as-is and land 003 immediately after, accepting that gpt-5.6 tier
+  usage over-bills in between.
+
+**Known-wrong claim in PR #752's body:** it states that
+`ax ingest --reparse=pricing` reprices old rows. It does not - that target only
+rewrites the `agent_model` catalog table (`model-pricing.ts:764-789`). Stored
+`session_token_usage` costs are never re-priced by anything (see "considered and
+rejected" below). That line needs correcting before merge.
+
+## Considered and not planned
+
+- **Opposite catalog precedence at ingest vs read.** `loadPricingCatalog` merges
+  `(modelsDev, litellm, builtIn)` so the built-in table wins
+  (`model-pricing.ts:707-711`); `loadPricingCatalogForModels` merges
+  `(builtIn, dbRows)` so DB rows win (`metrics/cost-estimate.ts:125`, whose
+  comment asserts the DB-wins policy as intentional). Real inconsistency - the
+  same model can price differently depending on the surface - but it is a
+  policy decision that needs a human call on which source should be canonical,
+  not a mechanical fix. Raise as an issue.
+- **No repricing path for already-costed rows.** `derive-cost-backfill` only
+  selects `WHERE estimated_cost_usd IS NONE` (`derive-cost-backfill.ts:79`) and
+  deliberately never re-prices (documented invariant, `:16-24`). So every rate
+  bug is permanent in history. Fixing this properly wants a `cost_basis` column
+  distinguishing provider-reported / catalog-priced / estimated costs, so a
+  reprice can target only the derived ones - a schema change, worth its own
+  design pass rather than being bolted onto a rate fix.
+- **`reprice()` skips `normalizeModelName`** on its target model
+  (`queries/reprice.ts:41-49`). Real but tiny: its inputs come from
+  `MODEL_ALIASES`, which already holds canonical ids. Fold into whichever plan
+  next touches that file.
+- **`gpt-5.3-codex` / `gpt-5.3-codex-spark` carry `fastMultiplier: 2`** with no
+  upstream basis (models.dev reports `experimental.modes.fast: null` for
+  `gpt-5.3-codex`). Plan 001 makes it inert by default, so it stops mattering;
+  noted in that plan's maintenance section rather than planned separately.
+
+## Verification commands (all plans)
+
+```
+bunx tsc --noEmit -p tsconfig.json     # what CI gates on; `bun run typecheck` can exit 0 while this fails
+bun test                               # 4 pre-existing failures: apps/studio-desktop electron install
+```
+
+These plan files are intentionally **uncommitted** - they are advisory notes on
+the branch, not part of PR #752.


### PR DESCRIPTION
Follow-up to #752. Three fixes to the cost calculation itself, found by auditing the pricing path after #751. Every figure below was measured against a live local database, not estimated.

## 1. Every OpenAI session was billed at priority-tier rates

`estimateCost` multiplied the whole computed cost by `pricing.fastMultiplier`, unconditionally. Four catalog entries carry a multiplier > 1 (`gpt-5.3-codex` ×2, `gpt-5.3-codex-spark` ×2, `gpt-5.4` ×2, `gpt-5.5` ×2.5). Those encode OpenAI's **priority/fast service tier** — models.dev confirms the ratio is real (`gpt-5.5` base 5/30/0.5, `experimental.modes.fast.cost` 12.5/75/1.25 = exactly 2.5×). The numbers were right; applying them to every session was not.

This machine's `~/.codex/config.toml` says `service_tier = "default"`. `gpt-5.5` stored **$17,235.02** across 1,736 session rows — third-largest model by spend — every dollar inflated 2.5×. That is **~$10.3k of ~$87.5k all-time reported spend (~12%)**.

`service_tier` appears nowhere in Codex rollout transcripts (`turn_context` carries `approval_policy, collaboration_mode, model, personality, sandbox_policy, …`), so per-session detection isn't possible. Fix: base rates are the default; `fastTier` remains as an opt-in parameter on `estimateCost`. An env switch was built and then **deliberately removed** before merge — see "Rejected" below.

## 2. One `<synthetic>` message relabelled a whole session

Claude Code emits assistant entries with `message.model === "<synthetic>"` for messages it generated without an API call. Session model attribution was last-write-wins, so one trailing synthetic entry overwrote the real model for the entire session. `normalizeModelName` correctly maps `<synthetic>` → null, so those sessions then priced at **$0**.

- `SELECT count() FROM session WHERE model = '<synthetic>'` → **148**
- Their `session_token_usage`: 148 rows, **645,067,300 prompt tokens, $0.00**
- Session `0e6ae51b-…`: turn-level models are `{<synthetic>: 1, claude-opus-4-8: 306}` — 306 real Opus turns, filed under a non-model.

Fix: a `<synthetic>` entry no longer wins attribution. `SYNTHETIC_MODEL_SENTINEL` / `isSyntheticModel` now name it once.

This deliberately applies to per-turn rows too, and that is now pinned by a test: a zero-token `<synthetic>` leg would otherwise read as a phantom model switch in per-model leg detection (`ax dispatches` model-drop marking, thinking analytics).

## 3. The `>200k` tier was marginal, per-component, and fed aggregates

`componentCost` billed the first 200k at base and the remainder at the premium, comparing the threshold against **each component's own token count**. Real pricing is a flat switch on one request's input context. Three errors compounded:

- **Marginal vs flat** — providers bill every token of a qualifying request at the premium.
- **Per-component** — the tier is a property of input context, not of each bucket. `outputAbove200k…` was dead code (output caps at 128k).
- **Aggregates** — every caller passes summed counts. Session rows hold ~28.7M prompt tokens (`claude-opus-4-8`: 47.86B across 1,669 rows); `resolveRowCost` sums a whole rollup group. Against those numbers essentially 100% of tokens billed at the premium.

Latent before this branch (no top-spend model had tier rates loaded) — but #752 added tier rates to `gpt-5.6-sol/terra/luna`, which activates it (~2× over-count on terra). Fix: flat, evaluated once per estimate off input context, plus an explicit `aggregated: true` **grain assertion** at the five summing call sites. Codex's `first_total` turn outcome is also aggregated — `positiveDelta(current, null)` returns the full cumulative total, which on a resumed rollout can cross 200k and falsely fire the tier.

Also: `parseModelsDevPricingCatalog` now reads `cost.context_over_200k` (the litellm parser already read its equivalent), so tiers stop being hand-copied.

## Rejected before merge

An `AX_OPENAI_FAST_TIER=1` env switch was built for fix 1 and then removed. With it on, ingest stored costs at the multiplier while every read-time recompute stayed at 1× — `dashboard/session-inspect.ts` always recomputes, so the same screen would show a turn cost contradicting its session cost. The switch had no correct consumer; the `fastTier` parameter stays as the seam.

## What this does NOT do

- **No repricing.** Rows ingested before this keep the ×2.5 and the marginal tier; `derive-cost-backfill` only fills `WHERE estimated_cost_usd IS NONE` and documents never re-pricing. `ax cost models` will show a **step change on the merge date that is a formula change, not a spend change**. The ~$10.3k is stopped, not recovered.
- **The 148 sessions need `ax ingest --reparse=claude,subagents`** to heal, and the subset storing `estimated_cost_usd = 0` (not `NONE`) won't reprice even then. A real repricing path — likely a `cost_basis` column separating provider / catalog / estimated costs — is the tracked follow-up.

## Verification

- `bunx tsc --noEmit -p tsconfig.json` → 0 errors (what CI gates on).
- `bun test apps/axctl packages` → **5123 pass, 0 fail**. Full `bun test` adds 4 pre-existing `apps/studio-desktop` electron-install failures, unrelated.
- 6/6 repo checks pass (`check:harness-docs` fails identically on main — upstream OpenAI `llms-full.txt` restructured).

Each change was reviewed independently, and the reviews caught three implementer claims that the code didn't support — including that the four `aggregated: true` markings, the actual dollar fix, were untested: any of them could be deleted with the suite staying green. Each is now pinned by a test verified to fail on removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
