### PR TITLE
feat(v2): w0-otlp-spool - spool-first OTLP receiver + ingest stage

### DIFF
--- a/apps/axctl/src/cli/commands/lifecycle.ts
+++ b/apps/axctl/src/cli/commands/lifecycle.ts
@@ -1,7 +1,7 @@
 // Extracted from cli/index.ts (Phase 2 CLI split)
 import { Effect } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
-import { cmdDaemon, cmdDoctor, cmdInstall, cmdSetup, cmdUninstall } from "../install.ts";
+import { cmdDaemon, cmdDoctor, cmdInstall, cmdSetup, cmdUninstall, resolveTelemetryConsent } from "../install.ts";
 import { liveVersionDeps, printVersion, updateAxctl } from "../version.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 import { boolArg, jsonFlag, parseFileHints } from "./shared.ts";
@@ -37,8 +37,11 @@ export const updateCommand = Command.make(
         ),
 ).pipe(Command.withDescription("Update axctl from the latest GitHub release"));
 
-export const installCommand = Command.make("install", {}, () =>
-    cmdInstall(),
+export const installCommand = Command.make("install", {
+    telemetry: Flag.boolean("telemetry").pipe(Flag.withDefault(false)),
+    noTelemetry: Flag.boolean("no-telemetry").pipe(Flag.withDefault(false)),
+}, ({ telemetry, noTelemetry }) =>
+    cmdInstall({ telemetry: resolveTelemetryConsent(telemetry, noTelemetry) }),
 ).pipe(Command.withDescription("One-shot setup: daemon, watcher, symlink (then runs `ax setup`)"));
 
 export const setupCommand = Command.make(

--- a/apps/axctl/src/cli/commands/lifecycle.ts
+++ b/apps/axctl/src/cli/commands/lifecycle.ts
@@ -1,10 +1,18 @@
 // Extracted from cli/index.ts (Phase 2 CLI split)
 import { Effect } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
-import { cmdDaemon, cmdDoctor, cmdInstall, cmdSetup, cmdUninstall, resolveTelemetryConsent } from "../install.ts";
+import {
+    cmdDaemon,
+    cmdDoctor,
+    cmdInstall,
+    cmdSetup,
+    cmdUninstall,
+    resolveTelemetryConsent,
+    telemetryConsentConflict,
+} from "../install.ts";
 import { liveVersionDeps, printVersion, updateAxctl } from "../version.ts";
 import type { RuntimeManifest } from "./manifest.ts";
-import { boolArg, jsonFlag, parseFileHints } from "./shared.ts";
+import { boolArg, fail, jsonFlag, parseFileHints } from "./shared.ts";
 
 const checkFlag = Flag.boolean("check").pipe(Flag.withDefault(false));
 const bannerFlag = Flag.boolean("banner").pipe(Flag.withDefault(false));
@@ -40,9 +48,14 @@ export const updateCommand = Command.make(
 export const installCommand = Command.make("install", {
     telemetry: Flag.boolean("telemetry").pipe(Flag.withDefault(false)),
     noTelemetry: Flag.boolean("no-telemetry").pipe(Flag.withDefault(false)),
-}, ({ telemetry, noTelemetry }) =>
-    cmdInstall({ telemetry: resolveTelemetryConsent(telemetry, noTelemetry) }),
-).pipe(Command.withDescription("One-shot setup: daemon, watcher, symlink (then runs `ax setup`)"));
+}, ({ telemetry, noTelemetry }) => {
+    // Pure flag validation BEFORE any Effect/install work. fail() calls
+    // process.exit(2) synchronously with a clean one-line message - no
+    // thrown plain Error, no stack trace (matches ingest.ts/quota.ts/dojo.ts).
+    const conflict = telemetryConsentConflict(telemetry, noTelemetry);
+    if (conflict !== null) fail(conflict);
+    return cmdInstall({ telemetry: resolveTelemetryConsent(telemetry, noTelemetry) });
+}).pipe(Command.withDescription("One-shot setup: daemon, watcher, symlink (then runs `ax setup`)"));
 
 export const setupCommand = Command.make(
     "setup",

--- a/apps/axctl/src/cli/commands/otlpd.test.ts
+++ b/apps/axctl/src/cli/commands/otlpd.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { Effect, Layer } from "effect";
+import { formatOtlpdPortBusy, runOtlpd } from "./otlpd.ts";
+
+describe("formatOtlpdPortBusy", () => {
+    it("names the port and hints ax serve may own it - no stack trace", () => {
+        const msg = formatOtlpdPortBusy(1738);
+        expect(msg).toContain("1738");
+        expect(msg).toContain("ax serve");
+        expect(msg).not.toContain("Error:");
+        expect(msg).not.toContain("    at ");
+    });
+});
+
+describe("runOtlpd port collision", () => {
+    const roots: string[] = [];
+    const platformLayer = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
+    afterEach(async () => {
+        for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+    });
+
+    it("exits cleanly (exit code 1, no throw) when the port is already bound by something else", async () => {
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otlpd-cli-"));
+        roots.push(spoolDir);
+        const occupied = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("ok") });
+        const prevExitCode = process.exitCode;
+        const errors: unknown[] = [];
+        const originalError = console.error;
+        console.error = (...args: unknown[]) => {
+            errors.push(args);
+        };
+        try {
+            await Effect.runPromise(
+                runOtlpd({ spoolDir, port: occupied.port ?? 0 }).pipe(Effect.provide(platformLayer)),
+            );
+            expect(process.exitCode).toBe(1);
+            expect(errors).toHaveLength(1);
+            expect(String(errors[0])).toContain(String(occupied.port));
+        } finally {
+            console.error = originalError;
+            process.exitCode = prevExitCode;
+            occupied.stop(true);
+        }
+    });
+});

--- a/apps/axctl/src/cli/commands/otlpd.ts
+++ b/apps/axctl/src/cli/commands/otlpd.ts
@@ -1,17 +1,61 @@
-import { Console, Effect } from "effect";
+import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
+import { Console, Effect, FileSystem, Path, PlatformError } from "effect";
 import { Command } from "effect/unstable/cli";
-import { startOtlpSpoolServer } from "../../otel/spool-server.ts";
+import { isAddrInUse } from "../../dashboard/serve-instance.ts";
+import {
+    OtlpSpoolServerError,
+    startOtlpSpoolServer,
+    type StartOtlpSpoolServerOptions,
+} from "../../otel/spool-server.ts";
 import type { RuntimeManifest } from "./manifest.ts";
 
-export const otlpdCommand = Command.make("otlpd", {}, () =>
+/**
+ * One-line, no-stack-trace message for an otlpd port collision - mirrors
+ * `ax serve`'s `formatServePortBusy` (dashboard/server.ts), but names
+ * `ax serve` specifically: it runs its own OTLP receiver on the same port
+ * until the spool-first receiver cutover, so it's the likely current owner.
+ */
+export function formatOtlpdPortBusy(port: number): string {
+    return [
+        `[ax] otlpd: port ${port} is already in use.`,
+        "  ax serve may already own it - it runs its own OTLP receiver on this port until the otlpd cutover",
+        `  see who holds it  lsof -nP -iTCP:${port} -sTCP:LISTEN`,
+    ].join("\n");
+}
+
+/**
+ * Run the receiver until interrupted. A port collision (EADDRINUSE) is
+ * reported as a clean one-line message + exit code 1 instead of an
+ * `axctl error:` stack dump - the common cause is `ax serve` already
+ * holding the port, not a genuine crash.
+ */
+export const runOtlpd = (
+    opts: StartOtlpSpoolServerOptions = {},
+): Effect.Effect<
+    void,
+    OtlpSpoolServerError | PlatformError.PlatformError,
+    FileSystem.FileSystem | Path.Path
+> =>
     Effect.acquireUseRelease(
-        startOtlpSpoolServer(),
+        startOtlpSpoolServer(opts),
         (server) => Console.log(`ax otlpd listening on ${server.url}`).pipe(
             Effect.andThen(Effect.never),
         ),
         (server) => Effect.promise(() => server.stop()),
-    ),
-).pipe(Command.withDescription("Receive OTLP JSON and append it to the local spool"));
+    ).pipe(
+        Effect.catchTag("OtlpSpoolServerError", (error) =>
+            isAddrInUse(error.cause)
+                ? Effect.sync(() => {
+                    console.error(formatOtlpdPortBusy(opts.port ?? DEFAULT_DASHBOARD_PORT));
+                    process.exitCode = 1;
+                })
+                : Effect.fail(error),
+        ),
+    );
+
+export const otlpdCommand = Command.make("otlpd", {}, () => runOtlpd()).pipe(
+    Command.withDescription("Receive OTLP JSON and append it to the local spool"),
+);
 
 export const otlpdRuntime: RuntimeManifest = {
     otlpd: "none",

--- a/apps/axctl/src/cli/commands/otlpd.ts
+++ b/apps/axctl/src/cli/commands/otlpd.ts
@@ -1,0 +1,18 @@
+import { Console, Effect } from "effect";
+import { Command } from "effect/unstable/cli";
+import { startOtlpSpoolServer } from "../../otel/spool-server.ts";
+import type { RuntimeManifest } from "./manifest.ts";
+
+export const otlpdCommand = Command.make("otlpd", {}, () =>
+    Effect.acquireUseRelease(
+        startOtlpSpoolServer(),
+        (server) => Console.log(`ax otlpd listening on ${server.url}`).pipe(
+            Effect.andThen(Effect.never),
+        ),
+        (server) => Effect.promise(() => server.stop()),
+    ),
+).pipe(Command.withDescription("Receive OTLP JSON and append it to the local spool"));
+
+export const otlpdRuntime: RuntimeManifest = {
+    otlpd: "none",
+};

--- a/apps/axctl/src/cli/commands/visible-commands.ts
+++ b/apps/axctl/src/cli/commands/visible-commands.ts
@@ -37,4 +37,5 @@ export const VISIBLE_COMMANDS: readonly string[] = [
     "digest",
     "team",
     "usage",
+    "otlpd",
 ];

--- a/apps/axctl/src/cli/effect-cli.test.ts
+++ b/apps/axctl/src/cli/effect-cli.test.ts
@@ -41,6 +41,7 @@ describe("effect cli", () => {
             "costs",
             "pricing",
             "serve",
+            "otlpd",
             "report",
             "recall",
             "skills",

--- a/apps/axctl/src/cli/index.ts
+++ b/apps/axctl/src/cli/index.ts
@@ -11,6 +11,7 @@ import { evidenceCommand, evidenceRuntime } from "./commands/evidence.ts";
 import { contextCommand, contextRuntime } from "./commands/context.ts";
 import { projectCommand, projectRuntime } from "./commands/project.ts";
 import { serveCommand, mcpCommand, tuiCommand, serveRuntime } from "./commands/serve.ts";
+import { otlpdCommand, otlpdRuntime } from "./commands/otlpd.ts";
 import { shareCommand, shareRuntime } from "./commands/share.ts";
 import { starCommand, starRuntime } from "./commands/star.ts";
 import { dogfoodCommand, dogfoodRuntime } from "./commands/dogfood.ts";
@@ -86,6 +87,7 @@ export const RUNTIME_BY_COMMAND: RuntimeManifest = {
     ...contextRuntime,
     ...projectRuntime,
     ...serveRuntime,
+    ...otlpdRuntime,
     ...shareRuntime,
     ...starRuntime,
     ...dogfoodRuntime,
@@ -136,6 +138,7 @@ const registeredCommands: ReadonlyArray<Command.Command.Any> = [
     rolesCommand,
     hooksCommand,
     serveCommand,
+    otlpdCommand,
     mcpCommand,
     tuiCommand,
     shareCommand,

--- a/apps/axctl/src/cli/install-otlpd-plist.test.ts
+++ b/apps/axctl/src/cli/install-otlpd-plist.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { otlpdPlist, resolveTelemetryConsent } from "./install.ts";
+import {
+    otlpdPlist,
+    resolveOtlpdPlistDecision,
+    resolveTelemetryConsent,
+    telemetryConsentConflict,
+} from "./install.ts";
 
 describe("otlpd install wiring", () => {
     it("builds a standalone LaunchAgent for ax otlpd", () => {
@@ -11,13 +16,69 @@ describe("otlpd install wiring", () => {
         expect(plist).toContain("otlpd.out");
         expect(plist).toContain("otlpd.err");
     });
+});
 
-    it("requires explicit telemetry consent", () => {
-        expect(resolveTelemetryConsent(false, false)).toBe(false);
-        expect(resolveTelemetryConsent(true, false)).toBe(true);
-        expect(resolveTelemetryConsent(false, true)).toBe(false);
-        expect(() => resolveTelemetryConsent(true, true)).toThrow(
-            "--telemetry and --no-telemetry cannot be used together",
+describe("telemetryConsentConflict (pure flag validation)", () => {
+    it("flags --telemetry and --no-telemetry together", () => {
+        expect(telemetryConsentConflict(true, true)).toBe(
+            "axctl install: --telemetry and --no-telemetry cannot be used together",
         );
+    });
+    it("no conflict for every other combination", () => {
+        expect(telemetryConsentConflict(false, false)).toBeNull();
+        expect(telemetryConsentConflict(true, false)).toBeNull();
+        expect(telemetryConsentConflict(false, true)).toBeNull();
+    });
+});
+
+describe("resolveTelemetryConsent (tri-state, #findings-1)", () => {
+    it("--telemetry grants consent", () => {
+        expect(resolveTelemetryConsent(true, false)).toBe("grant");
+    });
+    it("--no-telemetry revokes consent", () => {
+        expect(resolveTelemetryConsent(false, true)).toBe("revoke");
+    });
+    it("no flag at all preserves whatever consent state already exists", () => {
+        // This is the load-bearing case: a plain `ax install` re-run must
+        // NOT read as "--no-telemetry" (that used to unload a previously
+        // consented otlpd agent - see resolveOtlpdPlistDecision below).
+        expect(resolveTelemetryConsent(false, false)).toBe("preserve");
+    });
+});
+
+describe("resolveOtlpdPlistDecision (cmdInstall's otlpd plist state machine)", () => {
+    it("default install (no flags) preserves prior consent - never touches the plist", () => {
+        // Whether the plist was previously written+loaded (prior --telemetry
+        // consent) or is absent, "preserve" always no-ops either way - the
+        // decision does not even need to know which case it's in.
+        expect(resolveOtlpdPlistDecision("preserve", { serveAgentManaged: false }))
+            .toEqual({ action: "noop" });
+        expect(resolveOtlpdPlistDecision("preserve", { serveAgentManaged: true }))
+            .toEqual({ action: "noop" });
+    });
+
+    it("default install writes no plist when telemetry was never consented", () => {
+        const decision = resolveOtlpdPlistDecision("preserve", { serveAgentManaged: false });
+        expect(decision.action).toBe("noop");
+    });
+
+    it("explicit --telemetry writes and loads when no serve LaunchAgent owns the port (IDE model)", () => {
+        expect(resolveOtlpdPlistDecision("grant", { serveAgentManaged: false }))
+            .toEqual({ action: "write-and-load" });
+    });
+
+    it("explicit --telemetry writes but defers loading while ax serve owns the OTLP port", () => {
+        const decision = resolveOtlpdPlistDecision("grant", { serveAgentManaged: true });
+        expect(decision.action).toBe("write-only");
+        expect(decision).toMatchObject({
+            note: expect.stringContaining("ax serve currently owns the OTLP receiver"),
+        });
+    });
+
+    it("explicit --no-telemetry always unloads, regardless of serve ownership", () => {
+        expect(resolveOtlpdPlistDecision("revoke", { serveAgentManaged: false }))
+            .toEqual({ action: "unload" });
+        expect(resolveOtlpdPlistDecision("revoke", { serveAgentManaged: true }))
+            .toEqual({ action: "unload" });
     });
 });

--- a/apps/axctl/src/cli/install-otlpd-plist.test.ts
+++ b/apps/axctl/src/cli/install-otlpd-plist.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { otlpdPlist, resolveTelemetryConsent } from "./install.ts";
+
+describe("otlpd install wiring", () => {
+    it("builds a standalone LaunchAgent for ax otlpd", () => {
+        const plist = otlpdPlist("/Users/test/.local/bin/ax");
+
+        expect(plist).toContain("<string>com.necmttn.ax-otlpd</string>");
+        expect(plist).toContain('exec "/Users/test/.local/bin/ax" otlpd');
+        expect(plist).toMatch(/<key>RunAtLoad<\/key>\s*<true\/>/);
+        expect(plist).toContain("otlpd.out");
+        expect(plist).toContain("otlpd.err");
+    });
+
+    it("requires explicit telemetry consent", () => {
+        expect(resolveTelemetryConsent(false, false)).toBe(false);
+        expect(resolveTelemetryConsent(true, false)).toBe(true);
+        expect(resolveTelemetryConsent(false, true)).toBe(false);
+        expect(() => resolveTelemetryConsent(true, true)).toThrow(
+            "--telemetry and --no-telemetry cannot be used together",
+        );
+    });
+});

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -75,6 +75,8 @@ const DERIVE_PLIST = posixPath.join(LAUNCH_AGENTS_DIR, `${DERIVE_LABEL}.plist`);
 const QUOTA_REFRESH_PLIST = posixPath.join(LAUNCH_AGENTS_DIR, `${QUOTA_REFRESH_LABEL}.plist`);
 const SERVE_LABEL = "com.necmttn.ax-serve";
 const SERVE_PLIST = posixPath.join(LAUNCH_AGENTS_DIR, `${SERVE_LABEL}.plist`);
+const OTLPD_LABEL = "com.necmttn.ax-otlpd";
+const OTLPD_PLIST = posixPath.join(LAUNCH_AGENTS_DIR, `${OTLPD_LABEL}.plist`);
 
 /** Candidate install locations for the `ax studio` desktop app bundle (productName "ax studio"). */
 export const DESKTOP_APP_CANDIDATES: readonly string[] = [
@@ -368,6 +370,56 @@ export const servePlist = (binPath: string): string => `<?xml version="1.0" enco
 </dict>
 </plist>
 `;
+
+const otlpdDataDirEnv = (): string => process.env.AX_DATA_DIR
+    ? `
+    <key>AX_DATA_DIR</key>
+    <string>${process.env.AX_DATA_DIR}</string>`
+    : "";
+
+export const otlpdPlist = (binPath: string): string => `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${OTLPD_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>exec "${binPath}" otlpd</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key><false/>
+    <key>Crashed</key><true/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${LOG_DIR}/otlpd.out</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_DIR}/otlpd.err</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>${otlpdDataDirEnv()}
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+</dict>
+</plist>
+`;
+
+export const resolveTelemetryConsent = (
+    telemetry: boolean,
+    noTelemetry: boolean,
+): boolean => {
+    if (telemetry && noTelemetry) {
+        throw new Error("--telemetry and --no-telemetry cannot be used together");
+    }
+    return telemetry;
+};
 
 function which(cmd: string): string | null {
     const r = spawnSync("which", [cmd], { encoding: "utf8" });
@@ -1116,7 +1168,7 @@ export function formatDoctorReport(report: DoctorReport, json = false): string {
     return lines.join("\n");
 }
 
-export function cmdInstall(): Effect.Effect<
+export function cmdInstall(options: { readonly telemetry?: boolean } = {}): Effect.Effect<
     void,
     Error,
     FileSystem.FileSystem | Path.Path
@@ -1281,46 +1333,57 @@ export function cmdInstall(): Effect.Effect<
         yield* fs.remove(schemaPath, { force: true });
         }
 
-        // Write OTLP telemetry env into each installed harness config.
-        // Receiver listens on 127.0.0.1:1738 (the ax OTLP port).
-        const OTLP_ENDPOINT = "http://127.0.0.1:1738";
-        const claudeDir = posixPath.join(HOME, ".claude");
-        const claudeSettings = posixPath.join(claudeDir, "settings.json");
-        // Claude: only touch if ~/.claude exists (harness is installed).
-        const claudeDirExists = yield* fs.exists(claudeDir).pipe(orAbsent(false));
-        if (claudeDirExists) {
-            yield* Effect.promise(async () => {
-                try {
-                    let raw = "{}";
-                    try { raw = await Bun.file(claudeSettings).text(); } catch { /* absent - use default */ }
-                    const parsed = JSON.parse(raw) as Record<string, unknown>;
-                    const next = applyClaudeOtelEnv(parsed, OTLP_ENDPOINT);
-                    await Bun.write(claudeSettings, JSON.stringify(next, null, 2) + "\n");
-                    console.log(`  otel: wrote Claude Code OTLP env → ${claudeSettings}`);
-                } catch (err) {
-                    console.warn(`  otel: could not update ${claudeSettings}: ${(err as Error).message}`);
-                }
-            });
+        if (options.telemetry === true) {
+            yield* fs.writeFileString(OTLPD_PLIST, otlpdPlist(binSource));
+            console.log(`  wrote:  ${OTLPD_PLIST}`);
+            yield* Effect.promise(() => loadAgent(OTLPD_PLIST));
+        } else if (options.telemetry === false) {
+            yield* unloadAgent(OTLPD_PLIST);
         }
 
-        const codexDir = posixPath.join(HOME, ".codex");
-        const codexConfig = posixPath.join(codexDir, "config.toml");
-        // Codex: only touch if ~/.codex exists (harness is installed).
-        const codexDirExists = yield* fs.exists(codexDir).pipe(orAbsent(false));
-        if (codexDirExists) {
-            yield* Effect.promise(async () => {
-                try {
-                    let existing = "";
-                    try { existing = await Bun.file(codexConfig).text(); } catch { /* absent - start empty */ }
-                    const next = applyCodexOtelToml(existing, OTLP_ENDPOINT);
-                    if (next !== existing) {
-                        await Bun.write(codexConfig, next);
-                        console.log(`  otel: wrote Codex OTLP config → ${codexConfig}`);
+        // Write OTLP telemetry env into each installed harness config only
+        // after explicit consent.
+        // Receiver listens on 127.0.0.1:1738 (the ax OTLP port).
+        if (options.telemetry === true) {
+            const OTLP_ENDPOINT = "http://127.0.0.1:1738";
+            const claudeDir = posixPath.join(HOME, ".claude");
+            const claudeSettings = posixPath.join(claudeDir, "settings.json");
+            // Claude: only touch if ~/.claude exists (harness is installed).
+            const claudeDirExists = yield* fs.exists(claudeDir).pipe(orAbsent(false));
+            if (claudeDirExists) {
+                yield* Effect.promise(async () => {
+                    try {
+                        let raw = "{}";
+                        try { raw = await Bun.file(claudeSettings).text(); } catch { /* absent - use default */ }
+                        const parsed = JSON.parse(raw) as Record<string, unknown>;
+                        const next = applyClaudeOtelEnv(parsed, OTLP_ENDPOINT);
+                        await Bun.write(claudeSettings, JSON.stringify(next, null, 2) + "\n");
+                        console.log(`  otel: wrote Claude Code OTLP env → ${claudeSettings}`);
+                    } catch (err) {
+                        console.warn(`  otel: could not update ${claudeSettings}: ${(err as Error).message}`);
                     }
-                } catch (err) {
-                    console.warn(`  otel: could not update ${codexConfig}: ${(err as Error).message}`);
-                }
-            });
+                });
+            }
+
+            const codexDir = posixPath.join(HOME, ".codex");
+            const codexConfig = posixPath.join(codexDir, "config.toml");
+            // Codex: only touch if ~/.codex exists (harness is installed).
+            const codexDirExists = yield* fs.exists(codexDir).pipe(orAbsent(false));
+            if (codexDirExists) {
+                yield* Effect.promise(async () => {
+                    try {
+                        let existing = "";
+                        try { existing = await Bun.file(codexConfig).text(); } catch { /* absent - start empty */ }
+                        const next = applyCodexOtelToml(existing, OTLP_ENDPOINT);
+                        if (next !== existing) {
+                            await Bun.write(codexConfig, next);
+                            console.log(`  otel: wrote Codex OTLP config → ${codexConfig}`);
+                        }
+                    } catch (err) {
+                        console.warn(`  otel: could not update ${codexConfig}: ${(err as Error).message}`);
+                    }
+                });
+            }
         }
 
         const { BANNER } = yield* Effect.promise(() => import("./banner.ts"));
@@ -1578,7 +1641,7 @@ export function cmdUninstall(
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
         console.log("[axctl] uninstall");
-        for (const plist of [SERVE_PLIST, QUOTA_REFRESH_PLIST, DERIVE_PLIST, WATCH_PLIST, DB_PLIST]) {
+        for (const plist of [OTLPD_PLIST, SERVE_PLIST, QUOTA_REFRESH_PLIST, DERIVE_PLIST, WATCH_PLIST, DB_PLIST]) {
             const removed = yield* unloadAgent(plist);
             console.log(`  ${removed ? "removed" : "absent "}: ${plist}`);
         }

--- a/apps/axctl/src/cli/install.ts
+++ b/apps/axctl/src/cli/install.ts
@@ -371,10 +371,13 @@ export const servePlist = (binPath: string): string => `<?xml version="1.0" enco
 </plist>
 `;
 
-const otlpdDataDirEnv = (): string => process.env.AX_DATA_DIR
+// The otlpd spool dir is decoupled from AX_DATA_DIR (see spool-server.ts
+// defaultOtlpSpoolDir) - forward AX_OTLP_SPOOL_DIR into the LaunchAgent's env
+// when the installer's own env carries an override, not AX_DATA_DIR.
+const otlpdSpoolDirEnv = (): string => process.env.AX_OTLP_SPOOL_DIR
     ? `
-    <key>AX_DATA_DIR</key>
-    <string>${process.env.AX_DATA_DIR}</string>`
+    <key>AX_OTLP_SPOOL_DIR</key>
+    <string>${process.env.AX_OTLP_SPOOL_DIR}</string>`
     : "";
 
 export const otlpdPlist = (binPath: string): string => `<?xml version="1.0" encoding="UTF-8"?>
@@ -403,7 +406,7 @@ export const otlpdPlist = (binPath: string): string => `<?xml version="1.0" enco
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>${otlpdDataDirEnv()}
+    <string>${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>${otlpdSpoolDirEnv()}
   </dict>
   <key>ThrottleInterval</key>
   <integer>5</integer>
@@ -411,14 +414,72 @@ export const otlpdPlist = (binPath: string): string => `<?xml version="1.0" enco
 </plist>
 `;
 
+/**
+ * Tri-state telemetry consent, resolved from the `--telemetry`/`--no-telemetry`
+ * flags:
+ *   - "grant"    - explicit `--telemetry`: install + start collecting.
+ *   - "revoke"   - explicit `--no-telemetry`: unload the receiver.
+ *   - "preserve" - neither flag passed (plain `ax install`): touch nothing -
+ *     whatever consent state already exists on disk stays exactly as it is.
+ *     A bare re-run of `ax install` must never silently revoke a prior
+ *     `--telemetry` consent (issue: `resolveTelemetryConsent` used to
+ *     collapse to a boolean, so no flags looked identical to `--no-telemetry`
+ *     and unloaded an already-consented otlpd agent).
+ */
+export type TelemetryConsent = "grant" | "revoke" | "preserve";
+
+/** Pure predicate: a conflict message when both flags are set, else null. */
+export const telemetryConsentConflict = (
+    telemetry: boolean,
+    noTelemetry: boolean,
+): string | null =>
+    telemetry && noTelemetry
+        ? "axctl install: --telemetry and --no-telemetry cannot be used together"
+        : null;
+
+/** Resolves the tri-state consent. Assumes `telemetryConsentConflict` has
+ *  already been checked (returns null) - the caller raises the usage error. */
 export const resolveTelemetryConsent = (
     telemetry: boolean,
     noTelemetry: boolean,
-): boolean => {
-    if (telemetry && noTelemetry) {
-        throw new Error("--telemetry and --no-telemetry cannot be used together");
-    }
-    return telemetry;
+): TelemetryConsent => {
+    if (telemetry) return "grant";
+    if (noTelemetry) return "revoke";
+    return "preserve";
+};
+
+export type OtlpdPlistDecision =
+    | { readonly action: "write-and-load" }
+    | { readonly action: "write-only"; readonly note: string }
+    | { readonly action: "unload" }
+    | { readonly action: "noop" };
+
+/**
+ * Decide what `cmdInstall` should do to the otlpd LaunchAgent plist, given
+ * the resolved tri-state consent:
+ *   - "preserve" ALWAYS no-ops - the plist is neither written nor unloaded,
+ *     regardless of whatever is already on disk (loaded-by-prior-consent, or
+ *     never-consented). That's what "preserve existing state" means.
+ *   - "revoke" always unloads.
+ *   - "grant" writes the plist, but only bootstraps/loads it when no `ax
+ *     serve` LaunchAgent is being installed/present - `ax serve` binds the
+ *     same OTLP port and runs its own receiver until the spool-first
+ *     receiver cutover, so loading otlpd alongside it would collide. The IDE
+ *     desktop-app model has no serve LaunchAgent (`serveAgentManaged: false`
+ *     there), so otlpd loads normally in that model.
+ */
+export const resolveOtlpdPlistDecision = (
+    consent: TelemetryConsent,
+    opts: { readonly serveAgentManaged: boolean },
+): OtlpdPlistDecision => {
+    if (consent === "revoke") return { action: "unload" };
+    if (consent === "preserve") return { action: "noop" };
+    return opts.serveAgentManaged
+        ? {
+            action: "write-only",
+            note: "  otlpd: wrote the LaunchAgent but did not start it - ax serve currently owns the OTLP receiver on this port; otlpd activates at the spool cutover",
+        }
+        : { action: "write-and-load" };
 };
 
 function which(cmd: string): string | null {
@@ -1168,7 +1229,7 @@ export function formatDoctorReport(report: DoctorReport, json = false): string {
     return lines.join("\n");
 }
 
-export function cmdInstall(options: { readonly telemetry?: boolean } = {}): Effect.Effect<
+export function cmdInstall(options: { readonly telemetry?: TelemetryConsent } = {}): Effect.Effect<
     void,
     Error,
     FileSystem.FileSystem | Path.Path
@@ -1333,18 +1394,40 @@ export function cmdInstall(options: { readonly telemetry?: boolean } = {}): Effe
         yield* fs.remove(schemaPath, { force: true });
         }
 
-        if (options.telemetry === true) {
-            yield* fs.writeFileString(OTLPD_PLIST, otlpdPlist(binSource));
-            console.log(`  wrote:  ${OTLPD_PLIST}`);
-            yield* Effect.promise(() => loadAgent(OTLPD_PLIST));
-        } else if (options.telemetry === false) {
-            yield* unloadAgent(OTLPD_PLIST);
+        // Tri-state: "preserve" (no --telemetry/--no-telemetry flag - the
+        // common re-run case) touches neither the plist file nor its loaded
+        // state, so a bare `ax install` never silently revokes a prior
+        // `--telemetry` consent. `serveAgentManaged` mirrors the branch
+        // above: the plain LaunchAgent model installs its own `ax serve`
+        // agent (which owns the OTLP port until the otlpd cutover); the IDE
+        // desktop-app model has no serve LaunchAgent at all.
+        const consent: TelemetryConsent = options.telemetry ?? "preserve";
+        const otlpdDecision = resolveOtlpdPlistDecision(consent, { serveAgentManaged: !desktopApp });
+        switch (otlpdDecision.action) {
+            case "write-and-load": {
+                yield* fs.writeFileString(OTLPD_PLIST, otlpdPlist(binSource));
+                console.log(`  wrote:  ${OTLPD_PLIST}`);
+                yield* Effect.promise(() => loadAgent(OTLPD_PLIST));
+                break;
+            }
+            case "write-only": {
+                yield* fs.writeFileString(OTLPD_PLIST, otlpdPlist(binSource));
+                console.log(`  wrote:  ${OTLPD_PLIST}`);
+                console.log(otlpdDecision.note);
+                break;
+            }
+            case "unload": {
+                yield* unloadAgent(OTLPD_PLIST);
+                break;
+            }
+            case "noop":
+                break;
         }
 
         // Write OTLP telemetry env into each installed harness config only
-        // after explicit consent.
+        // on fresh explicit consent - "preserve" must not rewrite it either.
         // Receiver listens on 127.0.0.1:1738 (the ax OTLP port).
-        if (options.telemetry === true) {
+        if (consent === "grant") {
             const OTLP_ENDPOINT = "http://127.0.0.1:1738";
             const claudeDir = posixPath.join(HOME, ".claude");
             const claudeSettings = posixPath.join(claudeDir, "settings.json");

--- a/apps/axctl/src/ingest/otel-spool.test.ts
+++ b/apps/axctl/src/ingest/otel-spool.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { Effect, Layer } from "effect";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { ingestOtelSpool, otelSpoolStage } from "./otel-spool.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+    for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+const metricPayload = {
+    resourceMetrics: [{
+        resource: { attributes: [{ key: "service.name", value: { stringValue: "claude-code" } }] },
+        scopeMetrics: [{
+            metrics: [{
+                name: "claude_code.cost.usage",
+                unit: "USD",
+                sum: { dataPoints: [{
+                    asDouble: 0.12,
+                    timeUnixNano: "1718409600000000000",
+                    attributes: [{ key: "session.id", value: { stringValue: "session-1" } }],
+                }] },
+            }],
+        }],
+    }],
+};
+
+describe("otel-spool ingest stage", () => {
+    it("decodes a spool file and writes OTLP rows once", async () => {
+        const dataDir = await mkdtemp(join(tmpdir(), "ax-otel-spool-stage-"));
+        roots.push(dataDir);
+        const spoolDir = join(dataDir, "otlp", "spool");
+        await mkdir(spoolDir, { recursive: true });
+        const line = JSON.stringify({
+            received_at: "2026-08-14T12:00:00.000Z",
+            path: "/v1/metrics",
+            body: JSON.stringify(metricPayload),
+        });
+        await writeFile(join(spoolDir, "2026-08-14.jsonl"), `${line}\n`);
+
+        const watermarks = new Map<string, { path: string; mtime_ms: number; size: number }>();
+        const tc = makeTestSurrealClient({
+            fallback: (sql) => {
+                if (sql.includes("FROM ingest_file_state")) return [[...watermarks.values()]];
+                if (sql.includes("UPSERT ingest_file_state")) {
+                    const path = /path: "([^"]+)"/.exec(sql)?.[1];
+                    const mtimeMs = Number(/mtime_ms: (\d+)/.exec(sql)?.[1]);
+                    const size = Number(/size: (\d+)/.exec(sql)?.[1]);
+                    if (path) watermarks.set(path, { path, mtime_ms: mtimeMs, size });
+                }
+                return [[]];
+            },
+        });
+        const layer = Layer.mergeAll(tc.layer, BunFileSystem.layer, BunPath.layer);
+
+        const run = () => Effect.runPromise(
+            ingestOtelSpool({ dataDir }).pipe(Effect.provide(layer)),
+        );
+        const first = await run();
+        const second = await run();
+
+        expect(first).toMatchObject({ files: 1, payloads: 1, rows: 1, malformed: 0 });
+        expect(second).toMatchObject({ files: 0, skippedUnchanged: 1 });
+        const writes = tc.captured.filter((sql) => sql.includes("UPSERT otel_metric_point"));
+        expect(writes).toHaveLength(1);
+        expect(writes[0]).toContain('metric = "claude_code.cost.usage"');
+        expect(writes[0]).toContain('session_id = "session-1"');
+    });
+
+    it("declares the ingest stage contract", () => {
+        expect(otelSpoolStage.meta.key).toBe("otel-spool");
+        expect(otelSpoolStage.meta.tags).toEqual(["ingest"]);
+    });
+});

--- a/apps/axctl/src/ingest/otel-spool.test.ts
+++ b/apps/axctl/src/ingest/otel-spool.test.ts
@@ -32,9 +32,8 @@ const metricPayload = {
 
 describe("otel-spool ingest stage", () => {
     it("decodes a spool file and writes OTLP rows once", async () => {
-        const dataDir = await mkdtemp(join(tmpdir(), "ax-otel-spool-stage-"));
-        roots.push(dataDir);
-        const spoolDir = join(dataDir, "otlp", "spool");
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otel-spool-stage-"));
+        roots.push(spoolDir);
         await mkdir(spoolDir, { recursive: true });
         const line = JSON.stringify({
             received_at: "2026-08-14T12:00:00.000Z",
@@ -59,7 +58,7 @@ describe("otel-spool ingest stage", () => {
         const layer = Layer.mergeAll(tc.layer, BunFileSystem.layer, BunPath.layer);
 
         const run = () => Effect.runPromise(
-            ingestOtelSpool({ dataDir }).pipe(Effect.provide(layer)),
+            ingestOtelSpool({ spoolDir }).pipe(Effect.provide(layer)),
         );
         const first = await run();
         const second = await run();

--- a/apps/axctl/src/ingest/otel-spool.ts
+++ b/apps/axctl/src/ingest/otel-spool.ts
@@ -1,7 +1,7 @@
 import { Effect, FileSystem, Path, PlatformError, Schema } from "effect";
 import { SurrealClient } from "@ax/lib/db";
 import type { DbError } from "@ax/lib/errors";
-import { defaultOtlpDataDir } from "../otel/spool-server.ts";
+import { defaultOtlpSpoolDir } from "../otel/spool-server.ts";
 import { SIGNALS } from "../otel/signals.ts";
 import type { Signal } from "../otel/signal.ts";
 import { OtelWriter, OtelWriterLive } from "../otel/writer.ts";
@@ -43,7 +43,7 @@ const parseBody = (body: string): unknown | undefined => {
 };
 
 export interface IngestOtelSpoolOptions {
-    readonly dataDir?: string;
+    readonly spoolDir?: string;
     readonly runId?: string;
 }
 
@@ -66,8 +66,7 @@ export const ingestOtelSpool = (
 > =>
     Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        const path = yield* Path.Path;
-        const spoolDir = path.join(opts.dataDir ?? defaultOtlpDataDir(), "otlp", "spool");
+        const spoolDir = opts.spoolDir ?? defaultOtlpSpoolDir();
         const candidates = yield* walkJsonlFilesStrict(spoolDir, 0);
         let payloads = 0;
         let rows = 0;

--- a/apps/axctl/src/ingest/otel-spool.ts
+++ b/apps/axctl/src/ingest/otel-spool.ts
@@ -1,0 +1,165 @@
+import { Effect, FileSystem, Path, PlatformError, Schema } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+import type { DbError } from "@ax/lib/errors";
+import { defaultOtlpDataDir } from "../otel/spool-server.ts";
+import { SIGNALS } from "../otel/signals.ts";
+import type { Signal } from "../otel/signal.ts";
+import { OtelWriter, OtelWriterLive } from "../otel/writer.ts";
+import { runJsonlProviderFiles } from "./jsonl-work-unit.ts";
+import { walkJsonlFilesStrict, type JsonlFileCandidate } from "./walk-jsonl.ts";
+import { BaseStageStats, IngestContext, StageMeta } from "./stage/types.ts";
+import type { StageDef } from "./stage/registry.ts";
+
+const PATH_SIGNAL: Readonly<Record<string, Signal>> = {
+    "/v1/metrics": "metrics",
+    "/v1/traces": "traces",
+    "/v1/logs": "logs",
+};
+
+interface SpoolEnvelope {
+    readonly path: string;
+    readonly body: string;
+}
+
+const decodeEnvelope = (line: string): SpoolEnvelope | null => {
+    try {
+        const value: unknown = JSON.parse(line);
+        if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+        const record = value as Record<string, unknown>;
+        return typeof record.path === "string" && typeof record.body === "string"
+            ? { path: record.path, body: record.body }
+            : null;
+    } catch {
+        return null;
+    }
+};
+
+const parseBody = (body: string): unknown | undefined => {
+    try {
+        return JSON.parse(body);
+    } catch {
+        return undefined;
+    }
+};
+
+export interface IngestOtelSpoolOptions {
+    readonly dataDir?: string;
+    readonly runId?: string;
+}
+
+export interface OtelSpoolIngestResult {
+    readonly files: number;
+    readonly skippedUnchanged: number;
+    readonly payloads: number;
+    readonly rows: number;
+    readonly malformed: number;
+    readonly failedFiles: number;
+}
+
+/** Tail changed daily spool files and write decoded payloads with OtelWriter. */
+export const ingestOtelSpool = (
+    opts: IngestOtelSpoolOptions = {},
+): Effect.Effect<
+    OtelSpoolIngestResult,
+    DbError | PlatformError.PlatformError,
+    SurrealClient | FileSystem.FileSystem | Path.Path
+> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const spoolDir = path.join(opts.dataDir ?? defaultOtlpDataDir(), "otlp", "spool");
+        const candidates = yield* walkJsonlFilesStrict(spoolDir, 0);
+        let payloads = 0;
+        let rows = 0;
+        let malformed = 0;
+
+        const result = yield* runJsonlProviderFiles<
+            DbError | PlatformError.PlatformError,
+            OtelWriter,
+            JsonlFileCandidate
+        >({
+            candidates,
+            sourceKind: "otel_spool",
+            forceEnv: "AX_REDERIVE_OTEL_SPOOL",
+            source: "otel-spool",
+            ...(opts.runId === undefined ? {} : { runId: opts.runId }),
+            processFile: (candidate) =>
+                Effect.gen(function* () {
+                    const text = yield* fs.readFileString(candidate.path);
+                    const writer = yield* OtelWriter;
+                    for (const line of text.split("\n")) {
+                        if (line.trim().length === 0) continue;
+                        const envelope = decodeEnvelope(line);
+                        const signal = envelope ? PATH_SIGNAL[envelope.path] : undefined;
+                        if (!envelope || !signal) {
+                            malformed += 1;
+                            continue;
+                        }
+                        const json = parseBody(envelope.body);
+                        if (json === undefined) {
+                            malformed += 1;
+                            continue;
+                        }
+                        const spec = SIGNALS[signal];
+                        const decoded = yield* spec.decode(json).pipe(
+                            Effect.option,
+                        );
+                        if (decoded._tag === "None") {
+                            malformed += 1;
+                            continue;
+                        }
+                        const normalized = spec.normalize(decoded.value);
+                        yield* spec.write(writer)(normalized);
+                        payloads += 1;
+                        rows += normalized.length;
+                    }
+                    return true;
+                }),
+        }).pipe(Effect.provide(OtelWriterLive));
+
+        return {
+            files: result.files,
+            skippedUnchanged: result.skippedUnchanged,
+            payloads,
+            rows,
+            malformed,
+            failedFiles: result.failures.count(),
+        };
+    });
+
+export const OtelSpoolKey = Schema.Literal("otel-spool");
+export type OtelSpoolKey = typeof OtelSpoolKey.Type;
+
+export class OtelSpoolStageStats extends BaseStageStats.extend<OtelSpoolStageStats>(
+    "OtelSpoolStageStats",
+)({
+    filesIngested: Schema.Number,
+    payloadsIngested: Schema.Number,
+    rowsIngested: Schema.Number,
+    malformedPayloads: Schema.Number,
+    failedFiles: Schema.Number,
+}) {}
+
+export const otelSpoolStage: StageDef<
+    OtelSpoolStageStats,
+    SurrealClient | FileSystem.FileSystem | Path.Path
+> = {
+    meta: StageMeta.make({ key: "otel-spool", deps: [], tags: ["ingest"] }),
+    run: Effect.fn(function* (ctx: IngestContext) {
+        const t0 = Date.now();
+        const result = yield* ingestOtelSpool({
+            ...(ctx.runId === undefined ? {} : { runId: ctx.runId }),
+        }).pipe(Effect.catchTag("PlatformError", (error) => Effect.die(error)));
+        return OtelSpoolStageStats.make({
+            durationMs: Date.now() - t0,
+            summary: `ingested ${result.payloads} OTLP payloads, ${result.rows} rows` +
+                (result.malformed > 0 ? `, ${result.malformed} malformed payloads skipped` : "") +
+                (result.failedFiles > 0 ? `, ${result.failedFiles} files failed` : ""),
+            filesIngested: result.files,
+            payloadsIngested: result.payloads,
+            rowsIngested: result.rows,
+            malformedPayloads: result.malformed,
+            failedFiles: result.failedFiles,
+        });
+    }),
+};

--- a/apps/axctl/src/ingest/stage/registry.ts
+++ b/apps/axctl/src/ingest/stage/registry.ts
@@ -11,6 +11,7 @@ import { codexStage } from "../codex.ts";
 import { piStage, ompStage } from "../pi.ts";
 import { opencodeStage } from "../opencode.ts";
 import { cursorStage } from "../cursor.ts";
+import { otelSpoolStage } from "../otel-spool.ts";
 import { subagentsStage } from "../derive-claude-subagents.ts";
 import { claudeSidecarsStage } from "../claude-sidecars.ts";
 import { invokedPositionsStage } from "../backfill-invoked-positions.ts";
@@ -66,7 +67,7 @@ export const StageRegistryLive = (
     });
 
 /** The canonical list of stages provided by `StageRegistryDefault`. */
-export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, claudeConfigStage, pricingStage, claudeStage, codexStage, piStage, ompStage, opencodeStage, cursorStage, subagentsStage, claudeSidecarsStage, invokedPositionsStage, spawnedStage, loadedSkillsStage, gitStage, githubPrStage, signalsStage, outcomesStage, turnContentBlocksStage, turnAnalysisStage, reactionEventsStage, classifierResultsStage, sessionHealthStage, closureStage, deriveMetricsStage, proposalsStage, opportunitiesStage, retroProposalsStage, harnessStage, digestStage, usageStage, contentTypesStage, directiveNgramsStage, adviceStage, runEvidenceStage] as const;
+export const ALL_STAGES = [skillsStage, commandsStage, agentDefStage, claudeConfigStage, pricingStage, claudeStage, codexStage, piStage, ompStage, opencodeStage, cursorStage, otelSpoolStage, subagentsStage, claudeSidecarsStage, invokedPositionsStage, spawnedStage, loadedSkillsStage, gitStage, githubPrStage, signalsStage, outcomesStage, turnContentBlocksStage, turnAnalysisStage, reactionEventsStage, classifierResultsStage, sessionHealthStage, closureStage, deriveMetricsStage, proposalsStage, opportunitiesStage, retroProposalsStage, harnessStage, digestStage, usageStage, contentTypesStage, directiveNgramsStage, adviceStage, runEvidenceStage] as const;
 
 /** Production registry: the canonical list of stages provided by ax. Test code
  *  should prefer `StageRegistryLive([...])` with explicit fixtures. */

--- a/apps/axctl/src/otel/spool-server.test.ts
+++ b/apps/axctl/src/otel/spool-server.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { Effect, Layer } from "effect";
+import {
+    OTLP_ACK,
+    startOtlpSpoolServer,
+    type OtlpSpoolServer,
+} from "./spool-server.ts";
+
+const roots: string[] = [];
+const servers: OtlpSpoolServer[] = [];
+const platformLayer = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
+afterEach(async () => {
+    for (const server of servers.splice(0)) await server.stop();
+    for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+const start = async (now: () => Date) => {
+    const dataDir = await mkdtemp(join(tmpdir(), "ax-otlpd-"));
+    roots.push(dataDir);
+    const server = await Effect.runPromise(
+        startOtlpSpoolServer({ dataDir, port: 0, now }).pipe(Effect.provide(platformLayer)),
+    );
+    servers.push(server);
+    return { dataDir, server };
+};
+
+describe("OTLP spool receiver", () => {
+    it("returns the OTLP acknowledgement and appends the raw JSON body", async () => {
+        const now = new Date("2026-08-14T12:34:56.000Z");
+        const { dataDir, server } = await start(() => now);
+        const raw = '{"resourceMetrics":[]}';
+
+        const response = await fetch(`${server.url}/v1/metrics`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: raw,
+        });
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual(OTLP_ACK);
+        const text = await readFile(join(dataDir, "otlp", "spool", "2026-08-14.jsonl"), "utf8");
+        expect(text.trim().split("\n").map((line) => JSON.parse(line))).toEqual([{
+            received_at: now.toISOString(),
+            path: "/v1/metrics",
+            body: raw,
+        }]);
+    });
+
+    it("returns 2xx and preserves a malformed body", async () => {
+        const now = new Date("2026-08-14T12:34:56.000Z");
+        const { dataDir, server } = await start(() => now);
+
+        const response = await fetch(`${server.url}/v1/logs`, {
+            method: "POST",
+            body: "{broken",
+        });
+
+        expect(response.status).toBe(200);
+        const line = await readFile(join(dataDir, "otlp", "spool", "2026-08-14.jsonl"), "utf8");
+        expect(JSON.parse(line).body).toBe("{broken");
+    });
+
+    it("rotates by day and removes spool files older than 90 days", async () => {
+        let now = new Date("2026-08-14T23:59:59.000Z");
+        const { dataDir, server } = await start(() => now);
+        const spoolDir = join(dataDir, "otlp", "spool");
+        await writeFile(join(spoolDir, "2026-05-15.jsonl"), "old\n");
+        await writeFile(join(spoolDir, "2026-05-17.jsonl"), "keep\n");
+
+        await fetch(`${server.url}/v1/traces`, { method: "POST", body: "{}" });
+        now = new Date("2026-08-15T00:00:01.000Z");
+        await fetch(`${server.url}/v1/traces`, { method: "POST", body: "{}" });
+
+        expect(await Bun.file(join(spoolDir, "2026-08-14.jsonl")).exists()).toBe(true);
+        expect(await Bun.file(join(spoolDir, "2026-08-15.jsonl")).exists()).toBe(true);
+        expect(await Bun.file(join(spoolDir, "2026-05-15.jsonl")).exists()).toBe(false);
+        expect(await Bun.file(join(spoolDir, "2026-05-17.jsonl")).exists()).toBe(true);
+    });
+
+    it("removes expired spool files on startup", async () => {
+        const dataDir = await mkdtemp(join(tmpdir(), "ax-otlpd-startup-"));
+        roots.push(dataDir);
+        const spoolDir = join(dataDir, "otlp", "spool");
+        await Bun.write(join(spoolDir, "2026-05-15.jsonl"), "old\n", { createPath: true });
+
+        const server = await Effect.runPromise(
+            startOtlpSpoolServer({
+                dataDir,
+                port: 0,
+                now: () => new Date("2026-08-15T12:00:00.000Z"),
+            }).pipe(Effect.provide(platformLayer)),
+        );
+        servers.push(server);
+
+        expect(await Bun.file(join(spoolDir, "2026-05-15.jsonl")).exists()).toBe(false);
+    });
+});

--- a/apps/axctl/src/otel/spool-server.test.ts
+++ b/apps/axctl/src/otel/spool-server.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { Effect, Layer } from "effect";
 import {
     OTLP_ACK,
+    defaultOtlpSpoolDir,
     startOtlpSpoolServer,
     type OtlpSpoolServer,
 } from "./spool-server.ts";
@@ -20,19 +21,19 @@ afterEach(async () => {
 });
 
 const start = async (now: () => Date) => {
-    const dataDir = await mkdtemp(join(tmpdir(), "ax-otlpd-"));
-    roots.push(dataDir);
+    const spoolDir = await mkdtemp(join(tmpdir(), "ax-otlpd-"));
+    roots.push(spoolDir);
     const server = await Effect.runPromise(
-        startOtlpSpoolServer({ dataDir, port: 0, now }).pipe(Effect.provide(platformLayer)),
+        startOtlpSpoolServer({ spoolDir, port: 0, now }).pipe(Effect.provide(platformLayer)),
     );
     servers.push(server);
-    return { dataDir, server };
+    return { spoolDir, server };
 };
 
 describe("OTLP spool receiver", () => {
     it("returns the OTLP acknowledgement and appends the raw JSON body", async () => {
         const now = new Date("2026-08-14T12:34:56.000Z");
-        const { dataDir, server } = await start(() => now);
+        const { spoolDir, server } = await start(() => now);
         const raw = '{"resourceMetrics":[]}';
 
         const response = await fetch(`${server.url}/v1/metrics`, {
@@ -43,7 +44,7 @@ describe("OTLP spool receiver", () => {
 
         expect(response.status).toBe(200);
         expect(await response.json()).toEqual(OTLP_ACK);
-        const text = await readFile(join(dataDir, "otlp", "spool", "2026-08-14.jsonl"), "utf8");
+        const text = await readFile(join(spoolDir, "2026-08-14.jsonl"), "utf8");
         expect(text.trim().split("\n").map((line) => JSON.parse(line))).toEqual([{
             received_at: now.toISOString(),
             path: "/v1/metrics",
@@ -53,7 +54,7 @@ describe("OTLP spool receiver", () => {
 
     it("returns 2xx and preserves a malformed body", async () => {
         const now = new Date("2026-08-14T12:34:56.000Z");
-        const { dataDir, server } = await start(() => now);
+        const { spoolDir, server } = await start(() => now);
 
         const response = await fetch(`${server.url}/v1/logs`, {
             method: "POST",
@@ -61,14 +62,13 @@ describe("OTLP spool receiver", () => {
         });
 
         expect(response.status).toBe(200);
-        const line = await readFile(join(dataDir, "otlp", "spool", "2026-08-14.jsonl"), "utf8");
+        const line = await readFile(join(spoolDir, "2026-08-14.jsonl"), "utf8");
         expect(JSON.parse(line).body).toBe("{broken");
     });
 
     it("rotates by day and removes spool files older than 90 days", async () => {
         let now = new Date("2026-08-14T23:59:59.000Z");
-        const { dataDir, server } = await start(() => now);
-        const spoolDir = join(dataDir, "otlp", "spool");
+        const { spoolDir, server } = await start(() => now);
         await writeFile(join(spoolDir, "2026-05-15.jsonl"), "old\n");
         await writeFile(join(spoolDir, "2026-05-17.jsonl"), "keep\n");
 
@@ -83,14 +83,13 @@ describe("OTLP spool receiver", () => {
     });
 
     it("removes expired spool files on startup", async () => {
-        const dataDir = await mkdtemp(join(tmpdir(), "ax-otlpd-startup-"));
-        roots.push(dataDir);
-        const spoolDir = join(dataDir, "otlp", "spool");
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otlpd-startup-"));
+        roots.push(spoolDir);
         await Bun.write(join(spoolDir, "2026-05-15.jsonl"), "old\n", { createPath: true });
 
         const server = await Effect.runPromise(
             startOtlpSpoolServer({
-                dataDir,
+                spoolDir,
                 port: 0,
                 now: () => new Date("2026-08-15T12:00:00.000Z"),
             }).pipe(Effect.provide(platformLayer)),
@@ -98,5 +97,88 @@ describe("OTLP spool receiver", () => {
         servers.push(server);
 
         expect(await Bun.file(join(spoolDir, "2026-05-15.jsonl")).exists()).toBe(false);
+    });
+
+    it("recovers from a crash that left a torn (no trailing newline) line", async () => {
+        const now = new Date("2026-08-14T12:00:00.000Z");
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otlpd-torn-"));
+        roots.push(spoolDir);
+        const dayFile = join(spoolDir, "2026-08-14.jsonl");
+        // Simulates a process kill mid-append: the final line was flushed
+        // partially and never got its trailing "\n".
+        const torn = '{"received_at":"2026-08-14T11:00:00.000Z","path":"/v1/logs","bod';
+        await Bun.write(dayFile, torn, { createPath: true });
+
+        const server = await Effect.runPromise(
+            startOtlpSpoolServer({ spoolDir, port: 0, now: () => now }).pipe(
+                Effect.provide(platformLayer),
+            ),
+        );
+        servers.push(server);
+
+        const response = await fetch(`${server.url}/v1/logs`, {
+            method: "POST",
+            body: '{"resourceLogs":[]}',
+        });
+        expect(response.status).toBe(200);
+
+        const text = await readFile(dayFile, "utf8");
+        const lines = text.split("\n").filter((line) => line.length > 0);
+        expect(lines).toHaveLength(2);
+        // The torn line stays malformed (it was never fixed up) ...
+        expect(() => JSON.parse(lines[0]!)).toThrow();
+        // ... but the new record decodes on its own line.
+        const record = JSON.parse(lines[1]!) as { body: string };
+        expect(record.body).toBe('{"resourceLogs":[]}');
+    });
+
+    it("does not touch an already-clean file's trailing newline", async () => {
+        const now = new Date("2026-08-14T12:00:00.000Z");
+        const spoolDir = await mkdtemp(join(tmpdir(), "ax-otlpd-clean-"));
+        roots.push(spoolDir);
+        const dayFile = join(spoolDir, "2026-08-14.jsonl");
+        const clean = '{"received_at":"2026-08-14T11:00:00.000Z","path":"/v1/logs","body":"{}"}\n';
+        await Bun.write(dayFile, clean, { createPath: true });
+
+        const server = await Effect.runPromise(
+            startOtlpSpoolServer({ spoolDir, port: 0, now: () => now }).pipe(
+                Effect.provide(platformLayer),
+            ),
+        );
+        servers.push(server);
+
+        await fetch(`${server.url}/v1/logs`, { method: "POST", body: '{"resourceLogs":[]}' });
+
+        const text = await readFile(dayFile, "utf8");
+        const lines = text.split("\n").filter((line) => line.length > 0);
+        expect(lines).toHaveLength(2);
+        expect(() => JSON.parse(lines[0]!)).not.toThrow();
+        expect(() => JSON.parse(lines[1]!)).not.toThrow();
+    });
+});
+
+describe("defaultOtlpSpoolDir (decoupled from AX_DATA_DIR)", () => {
+    const prevSpoolDir = process.env.AX_OTLP_SPOOL_DIR;
+    const prevDataDir = process.env.AX_DATA_DIR;
+
+    afterEach(() => {
+        if (prevSpoolDir === undefined) delete process.env.AX_OTLP_SPOOL_DIR;
+        else process.env.AX_OTLP_SPOOL_DIR = prevSpoolDir;
+        if (prevDataDir === undefined) delete process.env.AX_DATA_DIR;
+        else process.env.AX_DATA_DIR = prevDataDir;
+    });
+
+    it("defaults to ~/.ax/otlp/spool, ignoring AX_DATA_DIR entirely", () => {
+        delete process.env.AX_OTLP_SPOOL_DIR;
+        process.env.AX_DATA_DIR = "/some/other/data/dir";
+
+        expect(defaultOtlpSpoolDir()).toBe(`${homedir()}/.ax/otlp/spool`);
+    });
+
+    it("honors an explicit AX_OTLP_SPOOL_DIR override", () => {
+        process.env.AX_OTLP_SPOOL_DIR = "/custom/spool/dir";
+        process.env.AX_DATA_DIR = "/some/other/data/dir";
+
+        expect(defaultOtlpSpoolDir()).toBe("/custom/spool/dir");
     });
 });

--- a/apps/axctl/src/otel/spool-server.ts
+++ b/apps/axctl/src/otel/spool-server.ts
@@ -1,0 +1,171 @@
+import { homedir } from "node:os";
+import { Effect, FileSystem, Path, PlatformError, Schema } from "effect";
+import { skipNotFound } from "@ax/lib/shared/fs-error";
+
+export const OTLP_ACK = { partialSuccess: {} } as const;
+export const OTLP_SPOOL_RETENTION_DAYS = 90;
+
+export class OtlpSpoolServerError extends Schema.TaggedErrorClass<OtlpSpoolServerError>(
+    "OtlpSpoolServerError",
+)("OtlpSpoolServerError", {
+    message: Schema.String,
+    cause: Schema.Defect(),
+}) {}
+
+const OTLP_PATHS = new Set(["/v1/metrics", "/v1/traces", "/v1/logs"]);
+const DAY_MS = 86_400_000;
+const FILE_RE = /^(\d{4}-\d{2}-\d{2})\.jsonl$/;
+
+export const defaultOtlpDataDir = (): string =>
+    process.env.AX_DATA_DIR ?? `${homedir()}/.ax`;
+
+const dayKey = (date: Date): string => date.toISOString().slice(0, 10);
+
+export interface OtlpSpoolRecord {
+    readonly received_at: string;
+    readonly path: string;
+    readonly body: string;
+}
+
+export interface PruneOtlpSpoolOptions {
+    readonly spoolDir: string;
+    readonly now: Date;
+    readonly retentionDays?: number;
+}
+
+/** Remove complete daily spool files whose UTC date is older than retention. */
+export const pruneOtlpSpool = (
+    opts: PruneOtlpSpoolOptions,
+): Effect.Effect<number, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const entries = yield* fs.readDirectory(opts.spoolDir).pipe(skipNotFound([] as string[]));
+        const todayStart = Date.parse(`${dayKey(opts.now)}T00:00:00.000Z`);
+        const cutoff = todayStart - (opts.retentionDays ?? OTLP_SPOOL_RETENTION_DAYS) * DAY_MS;
+        let removed = 0;
+        for (const entry of entries) {
+            const match = FILE_RE.exec(entry);
+            if (!match) continue;
+            const fileTime = Date.parse(`${match[1]}T00:00:00.000Z`);
+            if (!Number.isFinite(fileTime) || fileTime >= cutoff) continue;
+            yield* fs.remove(path.join(opts.spoolDir, entry));
+            removed += 1;
+        }
+        return removed;
+    });
+
+export interface StartOtlpSpoolServerOptions {
+    readonly dataDir?: string;
+    readonly hostname?: string;
+    readonly port?: number;
+    readonly now?: () => Date;
+}
+
+export interface OtlpSpoolServer {
+    readonly hostname: string;
+    readonly port: number;
+    readonly url: string;
+    readonly stop: () => Promise<void>;
+}
+
+/** Start the database-free OTLP receiver and append each accepted request. */
+export const startOtlpSpoolServer = (
+    opts: StartOtlpSpoolServerOptions = {},
+): Effect.Effect<
+    OtlpSpoolServer,
+    PlatformError.PlatformError | OtlpSpoolServerError,
+    FileSystem.FileSystem | Path.Path
+> =>
+    Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const context = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
+        const dataDir = opts.dataDir ?? defaultOtlpDataDir();
+        const spoolDir = path.join(dataDir, "otlp", "spool");
+        const hostname = opts.hostname ?? "127.0.0.1";
+        const now = opts.now ?? (() => new Date());
+        yield* fs.makeDirectory(spoolDir, { recursive: true });
+        yield* pruneOtlpSpool({ spoolDir, now: now() });
+
+        const runFs = Effect.runPromiseWith(context);
+
+        let currentDay = dayKey(now());
+        let writes: Promise<void> = Promise.resolve();
+
+        const append = (pathname: string, body: string): Promise<void> => {
+            writes = writes.catch(() => undefined).then(async () => {
+                const receivedAt = now();
+                const nextDay = dayKey(receivedAt);
+                if (nextDay !== currentDay) {
+                    currentDay = nextDay;
+                    await runFs(pruneOtlpSpool({ spoolDir, now: receivedAt }));
+                }
+                const record: OtlpSpoolRecord = {
+                    received_at: receivedAt.toISOString(),
+                    path: pathname,
+                    body,
+                };
+                await runFs(
+                    fs.writeFileString(
+                        path.join(spoolDir, `${nextDay}.jsonl`),
+                        `${JSON.stringify(record)}\n`,
+                        { flag: "a" },
+                    ),
+                );
+            });
+            return writes;
+        };
+
+        const server = yield* Effect.try({
+            try: () => Bun.serve({
+                hostname,
+                port: opts.port ?? 1738,
+                async fetch(request) {
+                    const pathname = new URL(request.url).pathname;
+                    if (request.method !== "POST" || !OTLP_PATHS.has(pathname)) {
+                        return new Response("Not Found", { status: 404 });
+                    }
+                    const body = await request.text().catch(() => "");
+                    await append(pathname, body).catch(() => undefined);
+                    return Response.json(OTLP_ACK);
+                },
+            }),
+            catch: (error) => new OtlpSpoolServerError({
+                message: error instanceof Error ? error.message : String(error),
+                cause: error,
+            }),
+        });
+
+        let rolloverTimer: ReturnType<typeof setTimeout> | undefined;
+        const scheduleRollover = (): void => {
+            const value = now();
+            const next = Date.UTC(
+                value.getUTCFullYear(),
+                value.getUTCMonth(),
+                value.getUTCDate() + 1,
+            );
+            const delay = Math.max(1, next - value.getTime());
+            rolloverTimer = setTimeout(() => {
+                const valueAtRollover = now();
+                currentDay = dayKey(valueAtRollover);
+                void runFs(pruneOtlpSpool({ spoolDir, now: valueAtRollover }))
+                    .catch(() => undefined)
+                    .finally(scheduleRollover);
+            }, delay);
+            rolloverTimer.unref?.();
+        };
+        scheduleRollover();
+
+        const boundPort = server.port ?? opts.port ?? 1738;
+        return {
+            hostname,
+            port: boundPort,
+            url: `http://${hostname}:${boundPort}`,
+            stop: async () => {
+                if (rolloverTimer !== undefined) clearTimeout(rolloverTimer);
+                await writes.catch(() => undefined);
+                await server.stop(true);
+            },
+        };
+    });

--- a/apps/axctl/src/otel/spool-server.ts
+++ b/apps/axctl/src/otel/spool-server.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import { Effect, FileSystem, Path, PlatformError, Schema } from "effect";
+import { DEFAULT_DASHBOARD_PORT } from "@ax/lib/dashboard-port";
 import { skipNotFound } from "@ax/lib/shared/fs-error";
 
 export const OTLP_ACK = { partialSuccess: {} } as const;
@@ -16,8 +17,14 @@ const OTLP_PATHS = new Set(["/v1/metrics", "/v1/traces", "/v1/logs"]);
 const DAY_MS = 86_400_000;
 const FILE_RE = /^(\d{4}-\d{2}-\d{2})\.jsonl$/;
 
-export const defaultOtlpDataDir = (): string =>
-    process.env.AX_DATA_DIR ?? `${homedir()}/.ax`;
+/**
+ * The spool dir is deliberately decoupled from `AX_DATA_DIR` (every other
+ * `AX_DATA_DIR` consumer defaults to `~/.local/share/ax`, a different tree
+ * entirely - keying the OTLP spool off it made `AX_DATA_DIR` overload two
+ * unrelated roots). `AX_OTLP_SPOOL_DIR` is its own, dedicated override.
+ */
+export const defaultOtlpSpoolDir = (): string =>
+    process.env.AX_OTLP_SPOOL_DIR ?? `${homedir()}/.ax/otlp/spool`;
 
 const dayKey = (date: Date): string => date.toISOString().slice(0, 10);
 
@@ -56,7 +63,7 @@ export const pruneOtlpSpool = (
     });
 
 export interface StartOtlpSpoolServerOptions {
-    readonly dataDir?: string;
+    readonly spoolDir?: string;
     readonly hostname?: string;
     readonly port?: number;
     readonly now?: () => Date;
@@ -81,8 +88,7 @@ export const startOtlpSpoolServer = (
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
         const context = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
-        const dataDir = opts.dataDir ?? defaultOtlpDataDir();
-        const spoolDir = path.join(dataDir, "otlp", "spool");
+        const spoolDir = opts.spoolDir ?? defaultOtlpSpoolDir();
         const hostname = opts.hostname ?? "127.0.0.1";
         const now = opts.now ?? (() => new Date());
         yield* fs.makeDirectory(spoolDir, { recursive: true });
@@ -92,6 +98,25 @@ export const startOtlpSpoolServer = (
 
         let currentDay = dayKey(now());
         let writes: Promise<void> = Promise.resolve();
+
+        // A crash mid-append (SIGKILL, power loss) can leave the LAST line of a
+        // spool file without its trailing "\n" - the next append would then glue
+        // its own record onto the torn tail, producing one undecodable line
+        // instead of two. Every write THIS process makes always ends in "\n", so
+        // once a file's tail has been verified it can only be re-torn by a crash
+        // of THIS process (irrelevant - nothing appends after that) - checked at
+        // most once per file path per process lifetime, not on every write.
+        const newlineChecked = new Set<string>();
+        const closeTornTail = async (filePath: string): Promise<string> => {
+            if (newlineChecked.has(filePath)) return "";
+            newlineChecked.add(filePath);
+            const file = Bun.file(filePath);
+            if (!(await file.exists())) return "";
+            const size = file.size;
+            if (size <= 0) return "";
+            const tail = await file.slice(size - 1, size).text();
+            return tail === "\n" ? "" : "\n";
+        };
 
         const append = (pathname: string, body: string): Promise<void> => {
             writes = writes.catch(() => undefined).then(async () => {
@@ -106,10 +131,12 @@ export const startOtlpSpoolServer = (
                     path: pathname,
                     body,
                 };
+                const filePath = path.join(spoolDir, `${nextDay}.jsonl`);
+                const tornTailFix = await closeTornTail(filePath);
                 await runFs(
                     fs.writeFileString(
-                        path.join(spoolDir, `${nextDay}.jsonl`),
-                        `${JSON.stringify(record)}\n`,
+                        filePath,
+                        `${tornTailFix}${JSON.stringify(record)}\n`,
                         { flag: "a" },
                     ),
                 );
@@ -120,7 +147,7 @@ export const startOtlpSpoolServer = (
         const server = yield* Effect.try({
             try: () => Bun.serve({
                 hostname,
-                port: opts.port ?? 1738,
+                port: opts.port ?? DEFAULT_DASHBOARD_PORT,
                 async fetch(request) {
                     const pathname = new URL(request.url).pathname;
                     if (request.method !== "POST" || !OTLP_PATHS.has(pathname)) {
@@ -157,7 +184,7 @@ export const startOtlpSpoolServer = (
         };
         scheduleRollover();
 
-        const boundPort = server.port ?? opts.port ?? 1738;
+        const boundPort = server.port ?? opts.port ?? DEFAULT_DASHBOARD_PORT;
         return {
             hostname,
             port: boundPort,

--- a/apps/site/app/routes/docs/-cli-reference.data.ts
+++ b/apps/site/app/routes/docs/-cli-reference.data.ts
@@ -683,6 +683,17 @@ ax daemon: running (pid 48213)
         ],
       },
       {
+        name: "otlpd",
+        job: "OTLP spool receiver (telemetry micro-listener): appends inbound OTLP JSON to the local spool.",
+        signature: "ax otlpd",
+        flags: [],
+        receipt: `$ ax otlpd
+ax otlpd listening on http://127.0.0.1:1738`,
+        detail: [
+          "A standalone micro-listener that spools OTLP JSON to disk without booting the full serve daemon; a LaunchAgent (com.necmttn.ax-otlpd) can keep it running.",
+        ],
+      },
+      {
         name: "mcp",
         job: "Run a stdio MCP server exposing ax's read-only queries as tools to an agent.",
         signature: "ax mcp",

--- a/apps/site/public/llms.txt
+++ b/apps/site/public/llms.txt
@@ -78,6 +78,7 @@ Install: `curl -fsSL https://ax.necmttn.com/install | bash`, then `npx skills ad
 - `ax sessions metrics`, `ax evidence weekly` - session health and weekly evidence rollups
 - `ax sessions show <id> --turns[=full] --json` - provider-neutral ordered Turn excerpts or full text for one session
 - `ax serve` - local dashboard with live ingest, session browser, and health views
+- `ax otlpd` - OTLP spool receiver (telemetry micro-listener)
 - `ax tui` - terminal skills browser
 
 ### Setup and ingest

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,7 @@ axctl ingest [--since=N] [--reset] [--stages=<list>]   # backfill the graph
 axctl ingest here [--since=Nd] [--stages=<list>]       # scope ingest to the git repo at $PWD
 axctl derive <signals|intents>              # re-run a derive pass standalone
 axctl serve                                 # live web dashboard
+axctl otlpd                                 # OTLP spool receiver (telemetry micro-listener)
 axctl mcp                                   # MCP server (stdio) - read-only graph queries for agents
 axctl report                                # one-shot static HTML
 axctl tui                                   # interactive terminal dashboard
@@ -90,7 +91,7 @@ axctl version [--check|--banner]
 
 > `axctl --help` lists the everyday commands plus the read-only insight
 > surfaces (`ingest`, `sessions`, `signals`, `improve`, `retro`, `recall`,
-> `skills`, `hooks`, `roles`, `serve`, `mcp`, `tui`, `share`, `contribute`,
+> `skills`, `hooks`, `roles`, `serve`, `otlpd`, `mcp`, `tui`, `share`, `contribute`,
 > `install`, `setup`) to keep it lean. The rest (`derive`, `agents`, `costs`,
 > `report`, `context`, `hook`, `project`, `evidence`, `classifiers`,
 > `insights`, `daemon`, `doctor`, `uninstall`, `update`, `version`) are hidden


### PR DESCRIPTION
Wave-0 chunk of the v2 DuckDB refactor (fleet map #768; backlog in docs/superpowers/plans/2026-08-14-v2-duckdb-backlog.md).

## What

- `ax otlpd` - spool-first OTLP receiver: binds 127.0.0.1:1738, POST /v1/{metrics,traces,logs} append raw body + received_at to `~/.ax/otlp/spool/YYYY-MM-DD.jsonl`, always-2xx, no DB handle, 90-day rotation (decision #760).
- `otel-spool` ingest stage - tails spool files with per-file watermarks (JSONL work-unit pattern), decodes with the existing Effect schemas in `apps/axctl/src/otel/`, writes through the current write path.
- Consent-gated LaunchAgent `com.necmttn.ax-otlpd` wired into install (recommended-on prompt per #759) - installed only on consent.
- CLI surface registration: visible-commands, docs/cli.md, llms.txt, cli-reference data.

## Review

Cross-model consensus gate ran; all 4 must-fix findings fixed in the follow-up commit: consent flags now tri-state (grant/revoke/preserve - bare `ax install` never touches the plist), torn-tail spool recovery (partial line from a crash closed with `\n` before next append), port-collision exits with a one-line hint instead of a stack dump (and install skips loading otlpd while `ax serve` still owns 1738), spool dir decoupled from `AX_DATA_DIR` onto `AX_OTLP_SPOOL_DIR`.

Gates post-rebase on v2/duckdb: `bun run typecheck` 0 · `bunx tsc --noEmit` 0 · `bun test apps/axctl/src/otel` 87 pass / 0 fail (756 pass across otel+cli in the fix run).
