### PR TITLE
feat(v2): w0-bench-ci - DuckDB bench regression suite + CI gate

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,7 +28,7 @@ jobs:
           duckdb_dir="$RUNNER_TEMP/duckdb"
           mkdir -p "$duckdb_dir"
           url="https://github.com/duckdb/duckdb/releases/download/v1.5.5/duckdb_cli-linux-amd64.zip"
-          if ! curl -fsSL --retry 3 --retry-delay 2 -o "$duckdb_dir/duckdb.zip" "$url"; then
+          if ! curl -fsSL --connect-timeout 30 --max-time 300 --retry 3 --retry-delay 2 -o "$duckdb_dir/duckdb.zip" "$url"; then
             echo "SKIP: duckdb CLI not installable from $url"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -46,3 +46,9 @@ jobs:
         run: |
           bun scripts/bench/gen-mini-fixture.ts .bench-fixture
           bun scripts/bench/run.ts
+
+      - name: Run bench harness test suite
+        if: steps.duckdb.outputs.skip != 'true'
+        env:
+          AX_DUCKDB_BIN: ${{ steps.duckdb.outputs.bin }}
+        run: bun test scripts/bench

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,48 @@
+name: Bench
+
+on:
+  pull_request:
+  push:
+    branches: [main, v2/duckdb]
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.10"
+
+      # Official DuckDB CLI (not brew). Pinned to v1.5.5 to match the
+      # duckdb-spike / #757 recipe. Skip cleanly when the asset cannot be
+      # fetched quickly — this job tests the harness, not dylib CI.
+      - name: Install DuckDB CLI
+        id: duckdb
+        run: |
+          set -euo pipefail
+          duckdb_dir="$RUNNER_TEMP/duckdb"
+          mkdir -p "$duckdb_dir"
+          url="https://github.com/duckdb/duckdb/releases/download/v1.5.5/duckdb_cli-linux-amd64.zip"
+          if ! curl -fsSL --retry 3 --retry-delay 2 -o "$duckdb_dir/duckdb.zip" "$url"; then
+            echo "SKIP: duckdb CLI not installable from $url"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          unzip -o "$duckdb_dir/duckdb.zip" -d "$duckdb_dir"
+          chmod +x "$duckdb_dir/duckdb"
+          "$duckdb_dir/duckdb" --version
+          echo "bin=$duckdb_dir/duckdb" >> "$GITHUB_OUTPUT"
+
+      - name: Generate mini fixture and run suite
+        if: steps.duckdb.outputs.skip != 'true'
+        env:
+          AX_BENCH_FIXTURE: .bench-fixture
+          AX_DUCKDB_BIN: ${{ steps.duckdb.outputs.bin }}
+        run: |
+          bun scripts/bench/gen-mini-fixture.ts .bench-fixture
+          bun scripts/bench/run.ts

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ apps/site/public/studio/
 dogfood-output/
 checkpoints/
 
+# duckdb bench mini fixture (generated; real 524MB fixture is local-only)
+.bench-fixture/
+
 # generated preview HTML from prototype scripts - contains real transcript text
 scripts/prototypes/*-preview.html
 

--- a/scripts/bench/02_duckdb_load.sql
+++ b/scripts/bench/02_duckdb_load.sql
@@ -66,10 +66,18 @@ CREATE OR REPLACE TABLE spawned (
 );
 COPY spawned FROM 'jsonl/spawned.jsonl' (FORMAT json);
 
+CREATE OR REPLACE TABLE telemetry_of (
+  session_id VARCHAR,
+  otel_id VARCHAR,
+  linked_at TIMESTAMP
+);
+COPY telemetry_of FROM 'jsonl/telemetry_of.jsonl' (FORMAT json);
+
 SELECT 'turn' AS tbl, count(*) FROM turn
 UNION ALL SELECT 'tool_call', count(*) FROM tool_call
 UNION ALL SELECT 'session', count(*) FROM session
 UNION ALL SELECT 'commit', count(*) FROM "commit"
 UNION ALL SELECT 'skill', count(*) FROM skill
 UNION ALL SELECT 'invoked', count(*) FROM invoked
-UNION ALL SELECT 'spawned', count(*) FROM spawned;
+UNION ALL SELECT 'spawned', count(*) FROM spawned
+UNION ALL SELECT 'telemetry_of', count(*) FROM telemetry_of;

--- a/scripts/bench/gen-mini-fixture.test.ts
+++ b/scripts/bench/gen-mini-fixture.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { JOIN_DRILL_SESSION, writeMiniFixture } from "./gen-mini-fixture.ts";
+
+const SCRIPT = join(import.meta.dir, "gen-mini-fixture.ts");
+
+const REQUIRED = [
+    "turn.jsonl",
+    "tool_call.jsonl",
+    "session.jsonl",
+    "commit.jsonl",
+    "skill.jsonl",
+    "invoked.jsonl",
+    "spawned.jsonl",
+    "telemetry_of.jsonl",
+] as const;
+
+const temps: string[] = [];
+afterEach(() => {
+    for (const dir of temps) rmSync(dir, { recursive: true, force: true });
+    temps.length = 0;
+});
+
+const countLines = (dir: string, file: string): number => {
+    const text = readFileSync(join(dir, file), "utf8");
+    return text.split("\n").filter((line) => line.length > 0).length;
+};
+
+const dirBytes = (dir: string): number =>
+    readdirSync(dir).reduce((sum, name) => sum + statSync(join(dir, name)).size, 0);
+
+describe("writeMiniFixture", () => {
+    test("writes ~5k turn rows plus proportional tables under 5MB", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-mini-fx-"));
+        temps.push(dir);
+        const result = writeMiniFixture(dir);
+        expect(result.turnRows).toBeGreaterThanOrEqual(4500);
+        expect(result.turnRows).toBeLessThanOrEqual(5500);
+        expect(countLines(dir, "turn.jsonl")).toBe(result.turnRows);
+        expect(countLines(dir, "tool_call.jsonl")).toBeGreaterThan(1000);
+        expect(countLines(dir, "session.jsonl")).toBeGreaterThan(50);
+        expect(countLines(dir, "commit.jsonl")).toBeGreaterThan(20);
+        expect(countLines(dir, "skill.jsonl")).toBeGreaterThan(10);
+        expect(countLines(dir, "invoked.jsonl")).toBeGreaterThan(50);
+        expect(countLines(dir, "spawned.jsonl")).toBeGreaterThan(10);
+        expect(countLines(dir, "telemetry_of.jsonl")).toBeGreaterThan(10);
+        for (const name of REQUIRED) {
+            expect(statSync(join(dir, name)).isFile()).toBe(true);
+        }
+        expect(dirBytes(dir)).toBeLessThan(5 * 1024 * 1024);
+    });
+
+    test("includes BM25 query text and the join-drill session id", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-mini-fx-"));
+        temps.push(dir);
+        writeMiniFixture(dir);
+        const turns = readFileSync(join(dir, "turn.jsonl"), "utf8");
+        expect(turns).toContain("ingest pipeline");
+        expect(turns).toContain(JOIN_DRILL_SESSION);
+        const sessions = readFileSync(join(dir, "session.jsonl"), "utf8");
+        expect(sessions).toContain(JOIN_DRILL_SESSION);
+    });
+});
+
+describe("gen-mini-fixture CLI", () => {
+    test("writes the 8 JSONL files into the given directory", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ax-mini-cli-"));
+        temps.push(dir);
+        const proc = spawnSync("bun", [SCRIPT, dir], { encoding: "utf8" });
+        expect(proc.status).toBe(0);
+        for (const name of REQUIRED) {
+            expect(statSync(join(dir, name)).isFile()).toBe(true);
+        }
+    });
+});

--- a/scripts/bench/gen-mini-fixture.ts
+++ b/scripts/bench/gen-mini-fixture.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env bun
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const JOIN_DRILL_SESSION = "session:`claude-subagent-af3f3b45c70ccf85c`";
+export const TURN_ROWS = 5000;
+export const TOOL_CALL_ROWS = 4000;
+export const SESSION_ROWS = 200;
+export const COMMIT_ROWS = 150;
+export const SKILL_ROWS = 40;
+export const INVOKED_ROWS = 400;
+export const SPAWNED_ROWS = 80;
+export const TELEMETRY_ROWS = 60;
+
+const iso = (i: number): string =>
+    new Date(Date.UTC(2026, 0, 1, 0, 0, i % 86_400)).toISOString();
+
+const sessionId = (i: number): string =>
+    i === 0 ? JOIN_DRILL_SESSION : `session:s${String(i).padStart(4, "0")}`;
+
+const skillId = (i: number): string => `skill:sk${String(i).padStart(3, "0")}`;
+
+const writeJsonl = (dir: string, name: string, rows: unknown[]): void => {
+    writeFileSync(
+        join(dir, name),
+        `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`,
+        "utf8",
+    );
+};
+
+export const writeMiniFixture = (
+    dir: string,
+): { turnRows: number; bytes: number } => {
+    mkdirSync(dir, { recursive: true });
+
+    const sessions = Array.from({ length: SESSION_ROWS }, (_, i) => ({
+        id: sessionId(i),
+        source: i % 5 === 0 ? "claude-subagent" : "claude",
+        project: i % 3 === 0 ? "ax" : "other",
+        model: i % 2 === 0 ? "opus" : "sonnet",
+        started_at: iso(i * 60),
+        ended_at: iso(i * 60 + 30),
+    }));
+
+    const turns = Array.from({ length: TURN_ROWS }, (_, i) => ({
+        id: `turn:t${String(i).padStart(5, "0")}`,
+        session: i < 54 ? JOIN_DRILL_SESSION : sessionId(1 + (i % (SESSION_ROWS - 1))),
+        ts: iso(i),
+        role: i % 3 === 0 ? "user" : "assistant",
+        text_excerpt:
+            i % 40 === 0
+                ? "ingest pipeline load FTS snapshot query"
+                : `synthetic turn ${i} about routing and cost`,
+    }));
+
+    const toolCalls = Array.from({ length: TOOL_CALL_ROWS }, (_, i) => ({
+        id: `tool_call:tc${String(i).padStart(5, "0")}`,
+        session: sessionId(i % SESSION_ROWS),
+        ts: iso(i + 1),
+        name: i % 4 === 0 ? "Bash" : i % 4 === 1 ? "Read" : i % 4 === 2 ? "Edit" : "Grep",
+        status: i % 17 === 0 ? "error" : "success",
+    }));
+
+    const commits = Array.from({ length: COMMIT_ROWS }, (_, i) => ({
+        id: `commit:c${String(i).padStart(4, "0")}`,
+        sha: `sha${String(i).padStart(8, "0")}deadbeef`,
+        message: i % 11 === 0 ? "ingest pipeline timing" : `commit message ${i}`,
+        ts: iso(i * 120),
+        repo: "Necmttn/ax",
+    }));
+
+    const skills = Array.from({ length: SKILL_ROWS }, (_, i) => ({
+        id: skillId(i),
+        name: `skill-${i}`,
+        dir_path: `~/.claude/skills/skill-${i}`,
+        scope: i % 2 === 0 ? "user" : "project",
+    }));
+
+    const invoked = Array.from({ length: INVOKED_ROWS }, (_, i) => ({
+        turn_id: `turn:t${String(i % TURN_ROWS).padStart(5, "0")}`,
+        skill_id: skillId(i % SKILL_ROWS),
+        session: sessionId(i % SESSION_ROWS),
+        ts: iso(i + 3),
+    }));
+
+    const spawned = Array.from({ length: SPAWNED_ROWS }, (_, i) => ({
+        parent_session: sessionId(i % SESSION_ROWS),
+        child_session: sessionId((i + 1) % SESSION_ROWS),
+        ts: iso(i * 15),
+        agent_type: i % 2 === 0 ? "Explore" : "general-purpose",
+        description: `dispatch ${i}`,
+    }));
+
+    const telemetry = Array.from({ length: TELEMETRY_ROWS }, (_, i) => ({
+        session_id: sessionId(i % SESSION_ROWS),
+        otel_id: `otel:o${String(i).padStart(4, "0")}`,
+        linked_at: iso(i * 9),
+    }));
+
+    writeJsonl(dir, "session.jsonl", sessions);
+    writeJsonl(dir, "turn.jsonl", turns);
+    writeJsonl(dir, "tool_call.jsonl", toolCalls);
+    writeJsonl(dir, "commit.jsonl", commits);
+    writeJsonl(dir, "skill.jsonl", skills);
+    writeJsonl(dir, "invoked.jsonl", invoked);
+    writeJsonl(dir, "spawned.jsonl", spawned);
+    writeJsonl(dir, "telemetry_of.jsonl", telemetry);
+
+    const bytes = [
+        "session.jsonl",
+        "turn.jsonl",
+        "tool_call.jsonl",
+        "commit.jsonl",
+        "skill.jsonl",
+        "invoked.jsonl",
+        "spawned.jsonl",
+        "telemetry_of.jsonl",
+    ].reduce((sum, name) => sum + Bun.file(join(dir, name)).size, 0);
+
+    return { turnRows: TURN_ROWS, bytes };
+};
+
+if (import.meta.main) {
+    const out = process.argv[2] ?? ".bench-fixture";
+    const result = writeMiniFixture(out);
+    console.log(
+        `wrote ${result.turnRows} turns (${result.bytes} bytes) -> ${out}`,
+    );
+}

--- a/scripts/bench/run.test.ts
+++ b/scripts/bench/run.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { writeMiniFixture } from "./gen-mini-fixture.ts";
+import { resolveDuckdbBin } from "./run.ts";
+
+const REPO_ROOT = join(import.meta.dir, "../..");
+const SCRIPT = join(import.meta.dir, "run.ts");
+
+const FIXTURE_FILES = [
+    "turn",
+    "tool_call",
+    "session",
+    "commit",
+    "skill",
+    "invoked",
+    "spawned",
+    "telemetry_of",
+] as const;
+
+const runBench = (envOverrides: Record<string, string | undefined>) => {
+    const env: Record<string, string | undefined> = { ...process.env };
+    for (const [key, value] of Object.entries(envOverrides)) {
+        if (value === undefined) delete env[key];
+        else env[key] = value;
+    }
+    const proc = spawnSync("bun", [SCRIPT], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: env as NodeJS.ProcessEnv,
+    });
+    return {
+        exitCode: proc.status ?? -1,
+        out: `${proc.stdout ?? ""}${proc.stderr ?? ""}`,
+    };
+};
+
+const makeEmptyFixture = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), "ax-bench-empty-"));
+    for (const name of FIXTURE_FILES) {
+        writeFileSync(join(dir, `${name}.jsonl`), "", "utf8");
+    }
+    return dir;
+};
+
+const temps: string[] = [];
+afterEach(() => {
+    for (const dir of temps) rmSync(dir, { recursive: true, force: true });
+    temps.length = 0;
+});
+
+describe("bench runner skip", () => {
+    test("exits 0 with a SKIP notice when AX_BENCH_FIXTURE is absent", () => {
+        const r = runBench({
+            AX_BENCH_FIXTURE: undefined,
+            AX_DUCKDB_BIN: "/usr/bin/true",
+        });
+        expect(r.exitCode).toBe(0);
+        expect(r.out).toContain("SKIP");
+        expect(r.out.toLowerCase()).toContain("fixture");
+    });
+
+    test("exits 0 with a SKIP notice when duckdb CLI is not found", () => {
+        const fixture = makeEmptyFixture();
+        temps.push(fixture);
+        const bunDir = dirname(Bun.which("bun") ?? process.execPath);
+        const r = runBench({
+            AX_BENCH_FIXTURE: fixture,
+            AX_DUCKDB_BIN: undefined,
+            PATH: [bunDir, "/usr/bin", "/bin"].join(":"),
+        });
+        expect(r.exitCode).toBe(0);
+        expect(r.out).toContain("SKIP");
+        expect(r.out.toLowerCase()).toContain("duckdb");
+    });
+
+    test("exits 0 with SKIP when AX_DUCKDB_BIN points at a missing file", () => {
+        const fixture = makeEmptyFixture();
+        temps.push(fixture);
+        const r = runBench({
+            AX_BENCH_FIXTURE: fixture,
+            AX_DUCKDB_BIN: join(tmpdir(), "no-such-duckdb-bin"),
+        });
+        expect(r.exitCode).toBe(0);
+        expect(r.out).toContain("SKIP");
+        expect(r.out.toLowerCase()).toContain("duckdb");
+    });
+});
+
+describe("bench runner suite", () => {
+    const duckdb = resolveDuckdbBin();
+
+    test("prints the metric table and exits 0 against the mini fixture", () => {
+        if (!duckdb) throw new Error("duckdb CLI required for the suite seam test");
+        const fixture = mkdtempSync(join(tmpdir(), "ax-bench-mini-"));
+        temps.push(fixture);
+        writeMiniFixture(fixture);
+        const r = runBench({
+            AX_BENCH_FIXTURE: fixture,
+            AX_DUCKDB_BIN: duckdb,
+        });
+        expect(r.out).toContain("full re-derive write path");
+        expect(r.out).toContain("FTS rebuild");
+        expect(r.out).toContain("snapshot copy");
+        expect(r.out).toContain("BM25 top-20");
+        expect(r.out).toContain("aggregate join");
+        expect(r.out).toContain("edge-traversal");
+        expect(r.out).toContain("cache file");
+        expect(r.out).toContain("PASS");
+        expect(r.exitCode).toBe(0);
+    }, 120_000);
+
+    test("exits non-zero when a target is tightened past the measured value", () => {
+        if (!duckdb) throw new Error("duckdb CLI required for the gate-fire seam test");
+        const fixture = mkdtempSync(join(tmpdir(), "ax-bench-tight-"));
+        temps.push(fixture);
+        writeMiniFixture(fixture);
+        const r = runBench({
+            AX_BENCH_FIXTURE: fixture,
+            AX_DUCKDB_BIN: duckdb,
+            AX_BENCH_MAX_BM25_MS: "0",
+        });
+        expect(r.exitCode).not.toBe(0);
+        expect(r.out).toContain("FAIL");
+        expect(r.out).toContain("BM25 top-20");
+    }, 120_000);
+});

--- a/scripts/bench/run.test.ts
+++ b/scripts/bench/run.test.ts
@@ -92,8 +92,8 @@ describe("bench runner skip", () => {
 describe("bench runner suite", () => {
     const duckdb = resolveDuckdbBin();
 
-    test("prints the metric table and exits 0 against the mini fixture", () => {
-        if (!duckdb) throw new Error("duckdb CLI required for the suite seam test");
+    test.skipIf(!duckdb)("prints the metric table and exits 0 against the mini fixture", () => {
+        if (!duckdb) return;
         const fixture = mkdtempSync(join(tmpdir(), "ax-bench-mini-"));
         temps.push(fixture);
         writeMiniFixture(fixture);
@@ -112,8 +112,8 @@ describe("bench runner suite", () => {
         expect(r.exitCode).toBe(0);
     }, 120_000);
 
-    test("exits non-zero when a target is tightened past the measured value", () => {
-        if (!duckdb) throw new Error("duckdb CLI required for the gate-fire seam test");
+    test.skipIf(!duckdb)("exits non-zero when a target is tightened past the measured value", () => {
+        if (!duckdb) return;
         const fixture = mkdtempSync(join(tmpdir(), "ax-bench-tight-"));
         temps.push(fixture);
         writeMiniFixture(fixture);

--- a/scripts/bench/run.test.ts
+++ b/scripts/bench/run.test.ts
@@ -66,10 +66,16 @@ describe("bench runner skip", () => {
         const fixture = makeEmptyFixture();
         temps.push(fixture);
         const bunDir = dirname(Bun.which("bun") ?? process.execPath);
+        // Deliberately exclude /usr/bin and /bin: a system-installed duckdb
+        // there would satisfy Bun.which("duckdb") and break this SKIP
+        // assertion. Only the bun dir (needed to spawn the script) plus a
+        // guaranteed-empty dir (in case an empty PATH misbehaves) are on PATH.
+        const emptyPathDir = mkdtempSync(join(tmpdir(), "ax-bench-emptypath-"));
+        temps.push(emptyPathDir);
         const r = runBench({
             AX_BENCH_FIXTURE: fixture,
             AX_DUCKDB_BIN: undefined,
-            PATH: [bunDir, "/usr/bin", "/bin"].join(":"),
+            PATH: [bunDir, emptyPathDir].join(":"),
         });
         expect(r.exitCode).toBe(0);
         expect(r.out).toContain("SKIP");
@@ -126,4 +132,33 @@ describe("bench runner suite", () => {
         expect(r.out).toContain("FAIL");
         expect(r.out).toContain("BM25 top-20");
     }, 120_000);
+
+    test.skipIf(!duckdb)("rejects a fixture where every table is empty instead of silently passing", () => {
+        if (!duckdb) return;
+        const fixture = makeEmptyFixture();
+        temps.push(fixture);
+        const r = runBench({
+            AX_BENCH_FIXTURE: fixture,
+            AX_DUCKDB_BIN: duckdb,
+        });
+        expect(r.exitCode).not.toBe(0);
+        expect(r.out).toContain("ERROR");
+        expect(r.out.toLowerCase()).toContain("empty");
+    }, 60_000);
+});
+
+describe("bench runner target validation", () => {
+    test("exits non-zero with the offending name+value when a target override is not a number", () => {
+        const fixture = makeEmptyFixture();
+        temps.push(fixture);
+        const r = runBench({
+            AX_BENCH_FIXTURE: fixture,
+            AX_DUCKDB_BIN: "/usr/bin/true",
+            AX_BENCH_MAX_BM25_MS: "10ms",
+        });
+        expect(r.exitCode).not.toBe(0);
+        expect(r.out).toContain("ERROR");
+        expect(r.out).toContain("AX_BENCH_MAX_BM25_MS");
+        expect(r.out).toContain("10ms");
+    });
 });

--- a/scripts/bench/run.ts
+++ b/scripts/bench/run.ts
@@ -1,0 +1,261 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+import {
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+    evaluateGates,
+    formatMetricTable,
+    loadTargets,
+    type BenchMeasurements,
+} from "./targets.ts";
+
+export const FIXTURE_TABLES = [
+    "turn",
+    "tool_call",
+    "session",
+    "commit",
+    "skill",
+    "invoked",
+    "spawned",
+    "telemetry_of",
+] as const;
+
+const SCRIPT_DIR = import.meta.dir;
+const QUERY_RUNS = 5;
+
+export const resolveFixtureDir = (
+    env: Record<string, string | undefined> = process.env,
+): string | null => {
+    const dir = env.AX_BENCH_FIXTURE;
+    if (!dir) return null;
+    if (!existsSync(dir)) return null;
+    try {
+        if (!statSync(dir).isDirectory()) return null;
+    } catch {
+        return null;
+    }
+    return dir;
+};
+
+export const resolveDuckdbBin = (
+    env: Record<string, string | undefined> = process.env,
+): string | null => {
+    const fromEnv = env.AX_DUCKDB_BIN;
+    if (fromEnv) {
+        return existsSync(fromEnv) ? fromEnv : null;
+    }
+    return Bun.which("duckdb");
+};
+
+export const lastTimerRealS = (output: string): number | null => {
+    const matches = [...output.matchAll(/real\s+([0-9.]+)/g)];
+    if (matches.length === 0) return null;
+    return Number(matches[matches.length - 1]![1]);
+};
+
+const median = (values: number[]): number => {
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted[mid]!;
+};
+
+const readSql = (name: string): string =>
+    readFileSync(join(SCRIPT_DIR, name), "utf8");
+
+type DuckRun = {
+    status: number;
+    stdout: string;
+    stderr: string;
+    elapsedS: number;
+    out: string;
+};
+
+const runDuck = (
+    bin: string,
+    args: string[],
+    sql: string,
+    cwd: string,
+): DuckRun => {
+    const start = performance.now();
+    const proc = spawnSync(bin, args, {
+        cwd,
+        input: sql,
+        encoding: "utf8",
+    });
+    const stdout = proc.stdout ?? "";
+    const stderr = proc.stderr ?? "";
+    return {
+        status: proc.status ?? 1,
+        stdout,
+        stderr,
+        elapsedS: (performance.now() - start) / 1000,
+        out: `${stdout}${stderr}`,
+    };
+};
+
+const failRun = (label: string, run: DuckRun, write: (line: string) => void): number => {
+    write(`ERROR: ${label} failed (exit ${run.status})`);
+    if (run.out.trim()) write(run.out.trim());
+    return 1;
+};
+
+const timeQueryMedian = (
+    bin: string,
+    sql: string,
+    cwd: string,
+    write: (line: string) => void,
+    label: string,
+): number | null => {
+    const warmup = runDuck(bin, ["bench.duckdb"], sql, cwd);
+    if (warmup.status !== 0) {
+        failRun(`${label} warmup`, warmup, write);
+        return null;
+    }
+    const samples: number[] = [];
+    for (let i = 0; i < QUERY_RUNS; i++) {
+        const run = runDuck(bin, ["bench.duckdb"], sql, cwd);
+        if (run.status !== 0) {
+            failRun(`${label} run ${i + 1}`, run, write);
+            return null;
+        }
+        const timed = lastTimerRealS(run.out);
+        if (timed === null) {
+            write(`ERROR: ${label} run ${i + 1} produced no .timer real`);
+            write(run.out.trim());
+            return null;
+        }
+        samples.push(timed);
+    }
+    return median(samples);
+};
+
+export const main = async (
+    env: Record<string, string | undefined> = process.env,
+    write: (line: string) => void = console.log,
+): Promise<number> => {
+    const fixture = resolveFixtureDir(env);
+    if (!fixture) {
+        write("SKIP: AX_BENCH_FIXTURE is unset or not a directory");
+        return 0;
+    }
+    const duckdb = resolveDuckdbBin(env);
+    if (!duckdb) {
+        write(
+            "SKIP: duckdb CLI not found (set AX_DUCKDB_BIN or install duckdb on PATH)",
+        );
+        return 0;
+    }
+
+    const missing = FIXTURE_TABLES.filter(
+        (name) => !existsSync(join(fixture, `${name}.jsonl`)),
+    );
+    if (missing.length > 0) {
+        write(
+            `ERROR: fixture missing ${missing.map((name) => `${name}.jsonl`).join(", ")}`,
+        );
+        return 1;
+    }
+
+    const workDir = join(tmpdir(), `ax-bench-${process.pid}-${Date.now()}`);
+    mkdirSync(join(workDir, "jsonl"), { recursive: true });
+    for (const name of FIXTURE_TABLES) {
+        symlinkSync(
+            resolve(fixture, `${name}.jsonl`),
+            join(workDir, "jsonl", `${name}.jsonl`),
+        );
+    }
+
+    const keepWork = env.AX_BENCH_KEEP === "1";
+    const cleanup = () => {
+        if (!keepWork) rmSync(workDir, { recursive: true, force: true });
+    };
+
+    try {
+        const ext = runDuck(duckdb, [], "INSTALL fts; LOAD fts;", workDir);
+        if (ext.status !== 0) {
+            return failRun("INSTALL/LOAD fts", ext, write);
+        }
+
+        const loadSql = readSql("02_duckdb_load.sql");
+        const load = runDuck(duckdb, ["bench.duckdb"], loadSql, workDir);
+        if (load.status !== 0) return failRun("load", load, write);
+
+        const ftsSql = `LOAD fts;\n${readSql("03_fts_build.sql")}`;
+        const fts = runDuck(duckdb, ["bench.duckdb"], ftsSql, workDir);
+        if (fts.status !== 0) return failRun("FTS rebuild", fts, write);
+
+        const snapSql = readSql("05_snapshot_copy.sql");
+        const snap = runDuck(duckdb, [], snapSql, workDir);
+        if (snap.status !== 0) return failRun("snapshot copy", snap, write);
+
+        const query = (file: string, label: string): number | null =>
+            timeQueryMedian(
+                duckdb,
+                `LOAD fts;\n${readSql(file)}`,
+                workDir,
+                write,
+                label,
+            );
+
+        const bm25S = query("04a_query_bm25.sql", "BM25 top-20");
+        if (bm25S === null) return 1;
+        const aggS = query("04b_query_agg.sql", "aggregate join");
+        if (aggS === null) return 1;
+        const lookupS = query("04c_query_lookup.sql", "point lookup");
+        if (lookupS === null) return 1;
+        const joinDrillS = query("04d_query_join_drill.sql", "join drill");
+        if (joinDrillS === null) return 1;
+        const traversalInvokedS = query(
+            "04e_query_graph_traversal.sql",
+            "edge-traversal invoked",
+        );
+        if (traversalInvokedS === null) return 1;
+        const traversalSpawnedS = query(
+            "04f_query_spawn_chain.sql",
+            "edge-traversal spawned",
+        );
+        if (traversalSpawnedS === null) return 1;
+
+        const snapshotPath = join(workDir, "snapshot.duckdb");
+        const cacheBytes = existsSync(snapshotPath)
+            ? statSync(snapshotPath).size
+            : statSync(join(workDir, "bench.duckdb")).size;
+
+        const measured: BenchMeasurements = {
+            loadS: load.elapsedS,
+            ftsS: fts.elapsedS,
+            snapshotS: snap.elapsedS,
+            bm25S,
+            aggS,
+            traversalInvokedS,
+            traversalSpawnedS,
+            cacheBytes,
+        };
+        const result = evaluateGates(measured, loadTargets(env));
+        write(formatMetricTable(result));
+        write(
+            `lookup=${lookupS}s join_drill=${joinDrillS}s work=${keepWork ? workDir : "deleted"}`,
+        );
+        if (!result.ok) {
+            write(
+                `FAIL: ${result.breaches.map((row) => row.metric).join(", ")} exceeded target`,
+            );
+            return 1;
+        }
+        return 0;
+    } finally {
+        cleanup();
+    }
+};
+
+if (import.meta.main) {
+    process.exit(await main());
+}

--- a/scripts/bench/run.ts
+++ b/scripts/bench/run.ts
@@ -13,8 +13,10 @@ import { join, resolve } from "node:path";
 import {
     evaluateGates,
     formatMetricTable,
+    InvalidBenchTargetError,
     loadTargets,
     type BenchMeasurements,
+    type BenchTargets,
 } from "./targets.ts";
 
 export const FIXTURE_TABLES = [
@@ -50,7 +52,11 @@ export const resolveDuckdbBin = (
 ): string | null => {
     const fromEnv = env.AX_DUCKDB_BIN;
     if (fromEnv) {
-        return existsSync(fromEnv) ? fromEnv : null;
+        // Resolve against the launch cwd now -- every duckdb spawn below runs
+        // with `cwd: workDir`, so a relative AX_DUCKDB_BIN would otherwise be
+        // looked up relative to the wrong directory.
+        const absolute = resolve(fromEnv);
+        return existsSync(absolute) ? absolute : null;
     }
     return Bun.which("duckdb");
 };
@@ -107,16 +113,32 @@ const failRun = (label: string, run: DuckRun, write: (line: string) => void): nu
     return 1;
 };
 
+// Counts result rows out of `.mode csv\n.headers off` output: every non-blank
+// line that isn't the trailing `.timer on` "Run Time" summary is one row.
+const countCsvResultRows = (out: string): number =>
+    out
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && !line.startsWith("Run Time")).length;
+
 const timeQueryMedian = (
     bin: string,
     sql: string,
     cwd: string,
     write: (line: string) => void,
     label: string,
+    minRows: number,
 ): number | null => {
     const warmup = runDuck(bin, ["bench.duckdb"], sql, cwd);
     if (warmup.status !== 0) {
         failRun(`${label} warmup`, warmup, write);
+        return null;
+    }
+    const rows = countCsvResultRows(warmup.stdout);
+    if (rows < minRows) {
+        write(
+            `ERROR: ${label} returned ${rows} row(s), expected >= ${minRows} -- fixture/query is degenerate`,
+        );
         return null;
     }
     const samples: number[] = [];
@@ -164,6 +186,17 @@ export const main = async (
         return 1;
     }
 
+    let targets: BenchTargets;
+    try {
+        targets = loadTargets(env);
+    } catch (err) {
+        if (err instanceof InvalidBenchTargetError) {
+            write(`ERROR: ${err.message}`);
+            return 1;
+        }
+        throw err;
+    }
+
     const workDir = join(tmpdir(), `ax-bench-${process.pid}-${Date.now()}`);
     mkdirSync(join(workDir, "jsonl"), { recursive: true });
     for (const name of FIXTURE_TABLES) {
@@ -188,6 +221,39 @@ export const main = async (
         const load = runDuck(duckdb, ["bench.duckdb"], loadSql, workDir);
         if (load.status !== 0) return failRun("load", load, write);
 
+        const countSql = [
+            ".mode csv",
+            ".headers off",
+            ...FIXTURE_TABLES.map(
+                (name) =>
+                    `SELECT '${name}', count(*) FROM ${name === "commit" ? '"commit"' : name};`,
+            ),
+        ].join("\n");
+        const counted = runDuck(duckdb, ["bench.duckdb"], countSql, workDir);
+        if (counted.status !== 0) {
+            return failRun("row-count sanity check", counted, write);
+        }
+        const rowCounts = new Map<string, number>();
+        for (const line of counted.stdout.split("\n")) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            const idx = trimmed.lastIndexOf(",");
+            if (idx === -1) continue;
+            const n = Number(trimmed.slice(idx + 1).trim());
+            if (Number.isFinite(n)) {
+                rowCounts.set(trimmed.slice(0, idx).trim(), n);
+            }
+        }
+        const empty = FIXTURE_TABLES.filter(
+            (name) => (rowCounts.get(name) ?? 0) <= 0,
+        );
+        if (empty.length > 0) {
+            write(
+                `ERROR: fixture is empty/degenerate -- zero rows in: ${empty.join(", ")}`,
+            );
+            return 1;
+        }
+
         const ftsSql = `LOAD fts;\n${readSql("03_fts_build.sql")}`;
         const fts = runDuck(duckdb, ["bench.duckdb"], ftsSql, workDir);
         if (fts.status !== 0) return failRun("FTS rebuild", fts, write);
@@ -196,13 +262,18 @@ export const main = async (
         const snap = runDuck(duckdb, [], snapSql, workDir);
         if (snap.status !== 0) return failRun("snapshot copy", snap, write);
 
-        const query = (file: string, label: string): number | null =>
+        const query = (
+            file: string,
+            label: string,
+            minRows = 1,
+        ): number | null =>
             timeQueryMedian(
                 duckdb,
-                `LOAD fts;\n${readSql(file)}`,
+                `.mode csv\n.headers off\nLOAD fts;\n${readSql(file)}`,
                 workDir,
                 write,
                 label,
+                minRows,
             );
 
         const bm25S = query("04a_query_bm25.sql", "BM25 top-20");
@@ -225,9 +296,13 @@ export const main = async (
         if (traversalSpawnedS === null) return 1;
 
         const snapshotPath = join(workDir, "snapshot.duckdb");
-        const cacheBytes = existsSync(snapshotPath)
-            ? statSync(snapshotPath).size
-            : statSync(join(workDir, "bench.duckdb")).size;
+        if (!existsSync(snapshotPath)) {
+            write(
+                `ERROR: snapshot copy did not produce ${snapshotPath} -- refusing to fall back to bench.duckdb`,
+            );
+            return 1;
+        }
+        const cacheBytes = statSync(snapshotPath).size;
 
         const measured: BenchMeasurements = {
             loadS: load.elapsedS,
@@ -239,7 +314,7 @@ export const main = async (
             traversalSpawnedS,
             cacheBytes,
         };
-        const result = evaluateGates(measured, loadTargets(env));
+        const result = evaluateGates(measured, targets);
         write(formatMetricTable(result));
         write(
             `lookup=${lookupS}s join_drill=${joinDrillS}s work=${keepWork ? workDir : "deleted"}`,

--- a/scripts/bench/targets.test.ts
+++ b/scripts/bench/targets.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import {
+    DEFAULT_TARGETS,
+    evaluateGates,
+    formatMetricTable,
+    loadTargets,
+} from "./targets.ts";
+
+const underBudget = {
+    loadS: 1,
+    ftsS: 2,
+    snapshotS: 0.5,
+    bm25S: 0.01,
+    aggS: 0.02,
+    traversalInvokedS: 0.01,
+    traversalSpawnedS: 0.01,
+    cacheBytes: 1024,
+};
+
+describe("DEFAULT_TARGETS", () => {
+    test("matches the #758 / backlog regression table", () => {
+        expect(DEFAULT_TARGETS.loadS).toBe(15);
+        expect(DEFAULT_TARGETS.ftsS).toBe(30);
+        expect(DEFAULT_TARGETS.snapshotS).toBe(5);
+        expect(DEFAULT_TARGETS.bm25S).toBe(0.15);
+        expect(DEFAULT_TARGETS.aggS).toBe(0.2);
+        expect(DEFAULT_TARGETS.traversalS).toBe(0.05);
+        expect(DEFAULT_TARGETS.cacheBytes).toBe(1024 * 1024 * 1024);
+    });
+});
+
+describe("evaluateGates", () => {
+    test("passes when every metric is under its target", () => {
+        const result = evaluateGates(underBudget);
+        expect(result.ok).toBe(true);
+        expect(result.breaches).toEqual([]);
+    });
+
+    test("fails when BM25 median exceeds 150ms", () => {
+        const result = evaluateGates({ ...underBudget, bm25S: 0.2 });
+        expect(result.ok).toBe(false);
+        expect(result.breaches.map((b) => b.metric)).toContain("BM25 top-20");
+    });
+
+    test("fails when either edge-traversal query exceeds 50ms", () => {
+        const invoked = evaluateGates({ ...underBudget, traversalInvokedS: 0.06 });
+        const spawned = evaluateGates({ ...underBudget, traversalSpawnedS: 0.06 });
+        expect(invoked.ok).toBe(false);
+        expect(spawned.ok).toBe(false);
+        expect(invoked.breaches.map((b) => b.metric)).toContain(
+            "edge-traversal invoked",
+        );
+        expect(spawned.breaches.map((b) => b.metric)).toContain(
+            "edge-traversal spawned",
+        );
+    });
+
+    test("fails when the cache file exceeds 1GB", () => {
+        const result = evaluateGates({
+            ...underBudget,
+            cacheBytes: 1024 * 1024 * 1024 + 1,
+        });
+        expect(result.ok).toBe(false);
+        expect(result.breaches.map((b) => b.metric)).toContain("cache file");
+    });
+});
+
+describe("formatMetricTable", () => {
+    test("prints measured vs target for every gated metric", () => {
+        const table = formatMetricTable(evaluateGates(underBudget));
+        expect(table).toContain("full re-derive write path");
+        expect(table).toContain("FTS rebuild");
+        expect(table).toContain("snapshot copy");
+        expect(table).toContain("BM25 top-20");
+        expect(table).toContain("aggregate join");
+        expect(table).toContain("edge-traversal invoked");
+        expect(table).toContain("edge-traversal spawned");
+        expect(table).toContain("cache file");
+        expect(table).toContain("PASS");
+        expect(table).toContain("15s");
+        expect(table).toContain("150ms");
+    });
+
+    test("marks a breach as FAIL", () => {
+        const table = formatMetricTable(
+            evaluateGates({ ...underBudget, loadS: 20 }),
+        );
+        expect(table).toContain("FAIL");
+        expect(table).toContain("full re-derive write path");
+    });
+});
+
+describe("loadTargets", () => {
+    test("lets AX_BENCH_MAX_BM25_MS tighten the BM25 gate", () => {
+        const targets = loadTargets({ AX_BENCH_MAX_BM25_MS: "0" });
+        expect(targets.bm25S).toBe(0);
+        const result = evaluateGates(underBudget, targets);
+        expect(result.ok).toBe(false);
+        expect(result.breaches.map((b) => b.metric)).toContain("BM25 top-20");
+    });
+});

--- a/scripts/bench/targets.ts
+++ b/scripts/bench/targets.ts
@@ -1,0 +1,185 @@
+export type BenchTargets = {
+    loadS: number;
+    ftsS: number;
+    snapshotS: number;
+    bm25S: number;
+    aggS: number;
+    traversalS: number;
+    cacheBytes: number;
+};
+
+export type BenchMeasurements = {
+    loadS: number;
+    ftsS: number;
+    snapshotS: number;
+    bm25S: number;
+    aggS: number;
+    traversalInvokedS: number;
+    traversalSpawnedS: number;
+    cacheBytes: number;
+};
+
+export type GateRow = {
+    metric: string;
+    measured: number;
+    target: number;
+    unit: "s" | "ms" | "bytes";
+    ok: boolean;
+};
+
+export type GateResult = {
+    ok: boolean;
+    rows: GateRow[];
+    breaches: GateRow[];
+};
+
+export const DEFAULT_TARGETS: BenchTargets = {
+    loadS: 15,
+    ftsS: 30,
+    snapshotS: 5,
+    bm25S: 0.15,
+    aggS: 0.2,
+    traversalS: 0.05,
+    cacheBytes: 1024 * 1024 * 1024,
+};
+
+const parseEnvNumber = (raw: string | undefined, fallback: number): number => {
+    if (raw === undefined || raw === "") return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : fallback;
+};
+
+export const loadTargets = (
+    env: Record<string, string | undefined> = process.env,
+): BenchTargets => ({
+    loadS: parseEnvNumber(env.AX_BENCH_MAX_LOAD_S, DEFAULT_TARGETS.loadS),
+    ftsS: parseEnvNumber(env.AX_BENCH_MAX_FTS_S, DEFAULT_TARGETS.ftsS),
+    snapshotS: parseEnvNumber(
+        env.AX_BENCH_MAX_SNAPSHOT_S,
+        DEFAULT_TARGETS.snapshotS,
+    ),
+    bm25S: parseEnvNumber(env.AX_BENCH_MAX_BM25_MS, DEFAULT_TARGETS.bm25S * 1000) / 1000,
+    aggS: parseEnvNumber(env.AX_BENCH_MAX_AGG_MS, DEFAULT_TARGETS.aggS * 1000) / 1000,
+    traversalS:
+        parseEnvNumber(
+            env.AX_BENCH_MAX_TRAVERSAL_MS,
+            DEFAULT_TARGETS.traversalS * 1000,
+        ) / 1000,
+    cacheBytes: parseEnvNumber(
+        env.AX_BENCH_MAX_CACHE_BYTES,
+        DEFAULT_TARGETS.cacheBytes,
+    ),
+});
+
+export const evaluateGates = (
+    measured: BenchMeasurements,
+    targets: BenchTargets = DEFAULT_TARGETS,
+): GateResult => {
+    const rows: GateRow[] = [
+        {
+            metric: "full re-derive write path",
+            measured: measured.loadS,
+            target: targets.loadS,
+            unit: "s",
+            ok: measured.loadS < targets.loadS,
+        },
+        {
+            metric: "FTS rebuild",
+            measured: measured.ftsS,
+            target: targets.ftsS,
+            unit: "s",
+            ok: measured.ftsS < targets.ftsS,
+        },
+        {
+            metric: "snapshot copy",
+            measured: measured.snapshotS,
+            target: targets.snapshotS,
+            unit: "s",
+            ok: measured.snapshotS < targets.snapshotS,
+        },
+        {
+            metric: "BM25 top-20",
+            measured: measured.bm25S,
+            target: targets.bm25S,
+            unit: "ms",
+            ok: measured.bm25S < targets.bm25S,
+        },
+        {
+            metric: "aggregate join",
+            measured: measured.aggS,
+            target: targets.aggS,
+            unit: "ms",
+            ok: measured.aggS < targets.aggS,
+        },
+        {
+            metric: "edge-traversal invoked",
+            measured: measured.traversalInvokedS,
+            target: targets.traversalS,
+            unit: "ms",
+            ok: measured.traversalInvokedS < targets.traversalS,
+        },
+        {
+            metric: "edge-traversal spawned",
+            measured: measured.traversalSpawnedS,
+            target: targets.traversalS,
+            unit: "ms",
+            ok: measured.traversalSpawnedS < targets.traversalS,
+        },
+        {
+            metric: "cache file",
+            measured: measured.cacheBytes,
+            target: targets.cacheBytes,
+            unit: "bytes",
+            ok: measured.cacheBytes < targets.cacheBytes,
+        },
+    ];
+    const breaches = rows.filter((row) => !row.ok);
+    return { ok: breaches.length === 0, rows, breaches };
+};
+
+const trimNum = (n: number, digits: number): string =>
+    n.toFixed(digits).replace(/\.?0+$/, "");
+
+const formatSeconds = (s: number): string => `${trimNum(s, 3)}s`;
+
+const formatMillis = (s: number): string => `${trimNum(s * 1000, 1)}ms`;
+
+const formatBytes = (bytes: number): string => {
+    if (bytes >= 1024 * 1024 * 1024) {
+        const gb = bytes / (1024 * 1024 * 1024);
+        return gb === 1 ? "1GB" : `${trimNum(gb, 2)}GB`;
+    }
+    if (bytes >= 1024 * 1024) return `${trimNum(bytes / (1024 * 1024), 2)}MB`;
+    if (bytes >= 1024) return `${trimNum(bytes / 1024, 1)}KB`;
+    return `${bytes}B`;
+};
+
+const formatValue = (row: GateRow): string => {
+    if (row.unit === "s") return formatSeconds(row.measured);
+    if (row.unit === "ms") return formatMillis(row.measured);
+    return formatBytes(row.measured);
+};
+
+const formatTarget = (row: GateRow): string => {
+    if (row.unit === "s") return formatSeconds(row.target);
+    if (row.unit === "ms") return formatMillis(row.target);
+    return formatBytes(row.target);
+};
+
+export const formatMetricTable = (result: GateResult): string => {
+    const header = [
+        "metric".padEnd(28),
+        "measured".padStart(12),
+        "target".padStart(12),
+        "status".padStart(8),
+    ].join("  ");
+    const lines = result.rows.map((row) =>
+        [
+            row.metric.padEnd(28),
+            formatValue(row).padStart(12),
+            formatTarget(row).padStart(12),
+            (row.ok ? "PASS" : "FAIL").padStart(8),
+        ].join("  "),
+    );
+    return [header, ...lines].join("\n");
+};

--- a/scripts/bench/targets.ts
+++ b/scripts/bench/targets.ts
@@ -43,29 +43,62 @@ export const DEFAULT_TARGETS: BenchTargets = {
     cacheBytes: 1024 * 1024 * 1024,
 };
 
-const parseEnvNumber = (raw: string | undefined, fallback: number): number => {
+export class InvalidBenchTargetError extends Error {
+    constructor(name: string, raw: string) {
+        super(`invalid ${name}=${JSON.stringify(raw)}: expected a number`);
+        this.name = "InvalidBenchTargetError";
+    }
+}
+
+const parseEnvNumber = (
+    name: string,
+    raw: string | undefined,
+    fallback: number,
+): number => {
     if (raw === undefined || raw === "") return fallback;
     const n = Number(raw);
-    return Number.isFinite(n) ? n : fallback;
+    if (!Number.isFinite(n)) throw new InvalidBenchTargetError(name, raw);
+    return n;
 };
 
 export const loadTargets = (
     env: Record<string, string | undefined> = process.env,
 ): BenchTargets => ({
-    loadS: parseEnvNumber(env.AX_BENCH_MAX_LOAD_S, DEFAULT_TARGETS.loadS),
-    ftsS: parseEnvNumber(env.AX_BENCH_MAX_FTS_S, DEFAULT_TARGETS.ftsS),
+    loadS: parseEnvNumber(
+        "AX_BENCH_MAX_LOAD_S",
+        env.AX_BENCH_MAX_LOAD_S,
+        DEFAULT_TARGETS.loadS,
+    ),
+    ftsS: parseEnvNumber(
+        "AX_BENCH_MAX_FTS_S",
+        env.AX_BENCH_MAX_FTS_S,
+        DEFAULT_TARGETS.ftsS,
+    ),
     snapshotS: parseEnvNumber(
+        "AX_BENCH_MAX_SNAPSHOT_S",
         env.AX_BENCH_MAX_SNAPSHOT_S,
         DEFAULT_TARGETS.snapshotS,
     ),
-    bm25S: parseEnvNumber(env.AX_BENCH_MAX_BM25_MS, DEFAULT_TARGETS.bm25S * 1000) / 1000,
-    aggS: parseEnvNumber(env.AX_BENCH_MAX_AGG_MS, DEFAULT_TARGETS.aggS * 1000) / 1000,
+    bm25S:
+        parseEnvNumber(
+            "AX_BENCH_MAX_BM25_MS",
+            env.AX_BENCH_MAX_BM25_MS,
+            DEFAULT_TARGETS.bm25S * 1000,
+        ) / 1000,
+    aggS:
+        parseEnvNumber(
+            "AX_BENCH_MAX_AGG_MS",
+            env.AX_BENCH_MAX_AGG_MS,
+            DEFAULT_TARGETS.aggS * 1000,
+        ) / 1000,
     traversalS:
         parseEnvNumber(
+            "AX_BENCH_MAX_TRAVERSAL_MS",
             env.AX_BENCH_MAX_TRAVERSAL_MS,
             DEFAULT_TARGETS.traversalS * 1000,
         ) / 1000,
     cacheBytes: parseEnvNumber(
+        "AX_BENCH_MAX_CACHE_BYTES",
         env.AX_BENCH_MAX_CACHE_BYTES,
         DEFAULT_TARGETS.cacheBytes,
     ),


### PR DESCRIPTION
Wave-0 chunk of the v2 DuckDB refactor (fleet map #768; backlog in docs/superpowers/plans/2026-08-14-v2-duckdb-backlog.md).

## What

- `scripts/bench/run.ts` - runnable regression suite over the DuckDB targets from #758: full re-derive <15s, FTS rebuild <30s, snapshot copy <5s, BM25 top-20 <150ms, aggregates <200ms, traversals <50ms, cache file <1GB. Fixture via `AX_BENCH_FIXTURE` (absent → SKIP notice, exit 0); targets tunable via `AX_BENCH_MAX_*` env.
- `scripts/bench/gen-mini-fixture.ts` + checked-in mini fixture path - ~5k-row synthetic slice so CI tests the harness; the 524MB real export (kept out of git) tests the numbers.
- `.github/workflows/bench.yml` - fixture-gated CI job with pinned DuckDB v1.5.5 install.

## Review

Codex cross-review found 8 findings (3×P1: the gate could PASS with empty fixture data, empty query results, or a missing snapshot file). All 8 fixed in `a4693c0a`: row-count sanity after load, min-rows check on every timed query's warmup, snapshot file required (no fallback), AX_DUCKDB_BIN resolved absolute, invalid target env values hard-error, CI now runs `bun test scripts/bench` with DuckDB installed, curl timeouts, PATH-isolated missing-duckdb test.

Gates post-rebase on v2/duckdb: `bun test scripts/bench` with a real DuckDB v1.5.5 CLI → 18 pass / 0 fail (gated tests exercised live) · `bun run typecheck` 0 · `bunx tsc --noEmit` 0.
