### PR TITLE
feat(v2): w0-prunes - drop agent_event.raw, blob GC, otel retention

### DIFF
--- a/apps/axctl/src/cli/commands/ingest-verdicts.test.ts
+++ b/apps/axctl/src/cli/commands/ingest-verdicts.test.ts
@@ -9,6 +9,7 @@ import {
     formatIngestFailedVerdict,
     formatIngestSkipSummary,
     formatIngestTimeoutVerdict,
+    formatMaintenanceSummary,
 } from "./ingest.ts";
 
 describe("ingest verdict lines", () => {
@@ -35,6 +36,46 @@ describe("ingest verdict lines", () => {
     test("skip summary reports per-file isolation count", () => {
         expect(formatIngestSkipSummary(3)).toBe(
             "ingest: ok - 3 file(s) skipped (per-file isolation; retried next run)",
+        );
+    });
+});
+
+describe("formatMaintenanceSummary", () => {
+    test("reports otel + blob gc counts on the happy path", () => {
+        const line = formatMaintenanceSummary({
+            otel: {
+                deletedByTable: { otel_metric_point: 1, otel_span: 2, otel_log_event: 5 },
+                deletedEdges: 3,
+            },
+            blobGc: { scanned: 10, removed: 4, failed: 0, skipped: false },
+        });
+        expect(line).toBe(
+            "ingest: maintenance - otel pruned 8 row(s) + 3 edge(s); blob gc removed 4/10 blob(s)",
+        );
+    });
+
+    test("surfaces a blob gc skip reason instead of counts", () => {
+        const line = formatMaintenanceSummary({
+            blobGc: { scanned: 0, removed: 0, failed: 0, skipped: true, skipReason: "empty reference set" },
+        });
+        expect(line).toBe("ingest: maintenance - blob gc skipped (empty reference set)");
+    });
+
+    test("surfaces per-file remove failures alongside the removed count", () => {
+        const line = formatMaintenanceSummary({
+            blobGc: { scanned: 5, removed: 3, failed: 2, skipped: false },
+        });
+        expect(line).toBe("ingest: maintenance - blob gc removed 3/5 blob(s), 2 failed");
+    });
+
+    test("reports a failure reason instead of counts when a half errors", () => {
+        const line = formatMaintenanceSummary({
+            otelError: "DbError: connection reset",
+            blobGcError: "PlatformError: EACCES",
+        });
+        expect(line).toBe(
+            "ingest: maintenance - otel retention FAILED - DbError: connection reset; " +
+                "blob gc FAILED - PlatformError: EACCES",
         );
     });
 });

--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -3,6 +3,7 @@ import { Effect, Layer, Option, Path, References } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { Command, Flag } from "effect/unstable/cli";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { gcFileBuckets } from "@ax/lib/blob-gc";
 import { AxConfig } from "@ax/lib/config";
 import { ProcessService } from "@ax/lib/process";
 import { prettyPrint } from "@ax/lib/json";
@@ -11,6 +12,7 @@ import { encodeClaudeProjectSlug } from "@ax/lib/transcript-locator";
 import { runIngest, withIngestRunFinish } from "../../ingest/run.ts";
 import { reapStaleIngestRuns } from "../../ingest/reap-runs.ts";
 import { healAdditiveSchemaDrift } from "../../ingest/schema-drift.ts";
+import { retainRecentOtel } from "../../otel/retention.ts";
 import { AX_VERSION } from "../version.ts";
 import { withIngestLock } from "../../ingest/ingest-lock.ts";
 import { StageRegistry, type StageRegistryShape } from "../../ingest/stage/registry.ts";
@@ -327,7 +329,14 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
             // lock's own clock starts a hair after this, so the deadline reads
             // slightly early - the derive reserve absorbs that.
             ...(timeoutSeconds > 0 ? { deadlineMs: Date.now() + timeoutSeconds * 1000 } : {}),
-        });
+        }).pipe(
+            // Keep maintenance inside the ingest lock. Both tasks are
+            // best-effort and only run after a real ingest succeeds.
+            Effect.tap(() => Effect.ignore(retainRecentOtel())),
+            Effect.tap(() => Effect.ignore(
+                gcFileBuckets(path.join(cfg.paths.dataDir, "buckets")),
+            )),
+        );
 
         // Single-flight + hard wall-clock cap, both owned by the lock. While one
         // ingest holds the lock another SKIPS (the watcher re-fires anyway, so a

--- a/apps/axctl/src/cli/commands/ingest.ts
+++ b/apps/axctl/src/cli/commands/ingest.ts
@@ -1,9 +1,9 @@
 // Extracted from cli/index.ts (Phase 2 CLI split)
-import { Effect, Layer, Option, Path, References } from "effect";
+import { Effect, FileSystem, Layer, Option, Path, References } from "effect";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
 import { Command, Flag } from "effect/unstable/cli";
 import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
-import { gcFileBuckets } from "@ax/lib/blob-gc";
+import { gcFileBuckets, type BlobGcResult } from "@ax/lib/blob-gc";
 import { AxConfig } from "@ax/lib/config";
 import { ProcessService } from "@ax/lib/process";
 import { prettyPrint } from "@ax/lib/json";
@@ -12,7 +12,7 @@ import { encodeClaudeProjectSlug } from "@ax/lib/transcript-locator";
 import { runIngest, withIngestRunFinish } from "../../ingest/run.ts";
 import { reapStaleIngestRuns } from "../../ingest/reap-runs.ts";
 import { healAdditiveSchemaDrift } from "../../ingest/schema-drift.ts";
-import { retainRecentOtel } from "../../otel/retention.ts";
+import { retainRecentOtel, type OtelRetentionResult } from "../../otel/retention.ts";
 import { AX_VERSION } from "../version.ts";
 import { withIngestLock } from "../../ingest/ingest-lock.ts";
 import { StageRegistry, type StageRegistryShape } from "../../ingest/stage/registry.ts";
@@ -233,6 +233,44 @@ export const formatIngestSkipSummary = (skippedFiles: number): string =>
     `ingest: ok - ${skippedFiles} file(s) skipped (per-file isolation; retried next run)`;
 
 /**
+ * Best-effort maintenance run after a successful ingest (otel retention +
+ * blob GC). Either side may have failed independently, or blob GC may have
+ * declined to run (see `BlobGcResult.skipped`) - callers pass whichever
+ * halves actually resolved.
+ */
+export interface MaintenanceSummary {
+    readonly otel?: OtelRetentionResult;
+    readonly otelError?: string;
+    readonly blobGc?: BlobGcResult;
+    readonly blobGcError?: string;
+}
+
+/** One-line maintenance summary (F5/F6): reports pruned/deleted counts (or
+ *  the failure reason) for otel retention + blob GC so a slow-but-successful
+ *  ingest's aftermath is legible without grepping the DB. Exported for tests. */
+export const formatMaintenanceSummary = (summary: MaintenanceSummary): string => {
+    const parts: string[] = [];
+
+    if (summary.otelError) {
+        parts.push(`otel retention FAILED - ${summary.otelError}`);
+    } else if (summary.otel) {
+        const rows = Object.values(summary.otel.deletedByTable).reduce((a, b) => a + b, 0);
+        parts.push(`otel pruned ${rows} row(s) + ${summary.otel.deletedEdges} edge(s)`);
+    }
+
+    if (summary.blobGcError) {
+        parts.push(`blob gc FAILED - ${summary.blobGcError}`);
+    } else if (summary.blobGc?.skipped) {
+        parts.push(`blob gc skipped (${summary.blobGc.skipReason})`);
+    } else if (summary.blobGc) {
+        const failedSuffix = summary.blobGc.failed > 0 ? `, ${summary.blobGc.failed} failed` : "";
+        parts.push(`blob gc removed ${summary.blobGc.removed}/${summary.blobGc.scanned} blob(s)${failedSuffix}`);
+    }
+
+    return `ingest: maintenance - ${parts.join("; ")}`;
+};
+
+/**
  * Sessions persisted by this run so far, summed from the per-stage `counts`
  * JSON already written to `ingest_stage` rows. Feeds the FAILED verdict
  * (#265) - the stage stats themselves are lost down the error channel.
@@ -313,6 +351,12 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
             Effect.ignore,
         );
 
+        // GC's reference set is built from the CURRENT `session` table (#F2):
+        // a `--since`-windowed run only touches sessions inside that window,
+        // so the table is a PARTIAL view of what's referenced. Only a full
+        // (unwindowed) ingest run is trustworthy enough to GC against.
+        const fullIngest = !args.some((a) => a.startsWith("--since="));
+
         const work = runIngest({
             command: commandName,
             args,
@@ -329,14 +373,48 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
             // lock's own clock starts a hair after this, so the deadline reads
             // slightly early - the derive reserve absorbs that.
             ...(timeoutSeconds > 0 ? { deadlineMs: Date.now() + timeoutSeconds * 1000 } : {}),
-        }).pipe(
-            // Keep maintenance inside the ingest lock. Both tasks are
-            // best-effort and only run after a real ingest succeeds.
-            Effect.tap(() => Effect.ignore(retainRecentOtel())),
-            Effect.tap(() => Effect.ignore(
-                gcFileBuckets(path.join(cfg.paths.dataDir, "buckets")),
-            )),
-        );
+        });
+
+        // Best-effort maintenance (otel retention + blob GC), still under the
+        // lock, but NOT subject to `timeoutSeconds` (F5/F6) - passed as
+        // `afterWork` so slow-but-harmless maintenance can never retroactively
+        // stamp a genuinely-completed ingest as timeout-failed. Each half is
+        // caught independently (never `Effect.ignore`-d silently) so a fault
+        // logs a warn line instead of vanishing.
+        const afterWork = (): Effect.Effect<void, never, SurrealClient | FileSystem.FileSystem | Path.Path> =>
+            Effect.gen(function* () {
+                const otel = yield* retainRecentOtel().pipe(
+                    Effect.map((result): { result?: OtelRetentionResult; error?: string } => ({ result })),
+                    Effect.catch((error): Effect.Effect<{ result?: OtelRetentionResult; error?: string }> =>
+                        Effect.succeed({ error: errorText(error) })),
+                );
+                if (otel.error) {
+                    process.stderr.write(`axctl ${commandName}: otel retention failed - ${otel.error}\n`);
+                }
+
+                const blobGc = yield* gcFileBuckets(
+                    path.join(cfg.paths.dataDir, "buckets"),
+                    { fullIngest },
+                ).pipe(
+                    Effect.map((result): { result?: BlobGcResult; error?: string } => ({ result })),
+                    Effect.catch((error): Effect.Effect<{ result?: BlobGcResult; error?: string }> =>
+                        Effect.succeed({ error: errorText(error) })),
+                );
+                if (blobGc.error) {
+                    process.stderr.write(`axctl ${commandName}: blob gc failed - ${blobGc.error}\n`);
+                }
+
+                process.stderr.write(
+                    `${
+                        formatMaintenanceSummary({
+                            ...(otel.result ? { otel: otel.result } : {}),
+                            ...(otel.error ? { otelError: otel.error } : {}),
+                            ...(blobGc.result ? { blobGc: blobGc.result } : {}),
+                            ...(blobGc.error ? { blobGcError: blobGc.error } : {}),
+                        })
+                    }\n`,
+                );
+            });
 
         // Single-flight + hard wall-clock cap, both owned by the lock. While one
         // ingest holds the lock another SKIPS (the watcher re-fires anyway, so a
@@ -369,6 +447,7 @@ const cmdIngest = (args: string[], opts: IngestCommandOpts = {}) =>
                         status: "partial",
                         metrics: { error: `timeout after ${timeoutSeconds}s` },
                     })).pipe(Effect.ignore),
+                afterWork,
             },
             work,
         ).pipe(

--- a/apps/axctl/src/dashboard/ingest-workflow.test.ts
+++ b/apps/axctl/src/dashboard/ingest-workflow.test.ts
@@ -1,11 +1,15 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Effect, Layer } from "effect";
-import { BunFileSystem } from "@effect/platform-bun";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { DbError } from "@ax/lib/errors";
 import type { SurrealClient } from "@ax/lib/db";
 import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
-import { AxConfigLive } from "@ax/lib/config";
+import { AxConfigTest } from "@ax/lib/config";
 import { ProcessServiceTest } from "@ax/lib/process";
+import type { IngestLockInfo } from "../ingest/ingest-lock.ts";
 import { StageRegistry, StageRegistryLive, type StageDef } from "../ingest/stage/registry.ts";
 import { BaseStageStats, StageMeta } from "../ingest/stage/types.ts";
 import type { RunIngestOptions } from "../ingest/run.ts";
@@ -43,16 +47,29 @@ const failingStage = (key: string, deps: string[] = []): StageDef => ({
     run: () => Effect.fail(new DbError({ operation: "query", message: `${key} blew up` })),
 });
 
+let dataDir: string;
+beforeEach(() => {
+    // Isolated per-test dataDir: startIngestWorkflow now single-flights
+    // through `<dataDir>/ingest.lock` (#F3) - without this override
+    // AxConfigLive's real default (~/.local/share/ax) would have every test
+    // acquire/release an actual lock file on the machine running the suite.
+    dataDir = mkdtempSync(join(tmpdir(), "ax-ingest-workflow-"));
+});
+afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+});
+
 const baseServices = (dbLayer: Layer.Layer<SurrealClient>, registry: Layer.Layer<StageRegistry>) => {
     const process = ProcessServiceTest({
         route: () => new Error("ProcessService not expected in this test"),
     });
-    // AxConfigLive now reads the persisted runtime endpoint at acquisition, so
-    // it needs FileSystem; provide the real Bun-backed FS beneath it.
+    const platform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+    // `provideMerge` re-exposes FileSystem/Path alongside AxConfig - both the
+    // config build AND the workflow's own lock-file IO need them (IngestBaseServices).
     return Layer.mergeAll(
         dbLayer,
         registry,
-        AxConfigLive.pipe(Layer.provide(BunFileSystem.layer)),
+        AxConfigTest({ paths: { dataDir } }).pipe(Layer.provideMerge(platform)),
         process,
     );
 };
@@ -159,5 +176,36 @@ describe("startIngestWorkflow", () => {
         expect(runFinished && runFinished.kind === "run_finished" && runFinished.status).toBe("failed");
         expect(countTerminal(history)).toBe(1);
         for (const e of history) expect(e.runId).toBe(runId);
+    });
+
+    it("single-flight (#F3): skips the pipeline and publishes a clean run_finished{failed} when the CLI lock is held", async () => {
+        const db = fakeDb();
+        const registry = StageRegistryLive([stage("skills")]);
+        const bus = new InMemoryIngestStreamBus();
+
+        // A fresh lock owned by a live pid (ourselves) - withIngestLock treats
+        // this exactly like a concurrent CLI/watcher ingest already running.
+        writeFileSync(
+            join(dataDir, "ingest.lock"),
+            JSON.stringify(
+                { pid: process.pid, startedAt: Date.now(), command: "cli-ingest" } satisfies IngestLockInfo,
+            ),
+        );
+
+        const { runId } = await Effect.runPromise(
+            startIngestWorkflow(opts(), bus, baseServices(db.layer, registry)),
+        );
+
+        const history = await waitForFinish(bus, runId);
+
+        // The busy skip must never run the pipeline - no run_started/stage events.
+        expect(history.some((e) => e.kind === "run_started")).toBe(false);
+        const runFinished = history.find((e) => e.kind === "run_finished");
+        expect(runFinished && runFinished.kind === "run_finished" && runFinished.status).toBe("failed");
+        expect(countTerminal(history)).toBe(1);
+
+        // The held lock is untouched - a busy skip must not steal/clobber it.
+        const held = JSON.parse(readFileSync(join(dataDir, "ingest.lock"), "utf8")) as IngestLockInfo;
+        expect(held.command).toBe("cli-ingest");
     });
 });

--- a/apps/axctl/src/dashboard/ingest-workflow.ts
+++ b/apps/axctl/src/dashboard/ingest-workflow.ts
@@ -12,8 +12,19 @@
  * `ingest:<runId>`. `ingestStreamEventFromTrace` strips that prefix back to
  * `<runId>`, so the stream name is known before the run starts. The CLI path is
  * unchanged: the CLI does not pass `runId`, so it keeps generating its own.
+ *
+ * **Single-flight (#F3)**: the run is wrapped in the SAME `ingest.lock` file
+ * the CLI uses (`withIngestLock`), so a live-ingest trigger while a CLI/watcher
+ * ingest already holds the lock fails fast instead of piling a second
+ * concurrent ingest onto SurrealDB (the exact contention `withIngestLock` was
+ * built to prevent - see ingest-lock.ts's header). A busy skip never runs
+ * `runIngest` at all; it publishes a synthetic `run_finished{failed}` event
+ * (same shape the early-failure path below already uses) so the stream
+ * terminates cleanly instead of hanging. No `timeoutSeconds` is passed, so
+ * (matching `RunIngestOptions.deadlineMs`'s own doc comment) this path stays
+ * unbounded - only the CLI/`share/recover.ts` callers impose a hard cap.
  */
-import { Cause, Effect, Layer } from "effect";
+import { Cause, Effect, FileSystem, Layer, Path } from "effect";
 import { AxConfig } from "@ax/lib/config";
 import { SurrealClient } from "@ax/lib/db";
 import { LiveTraceLayer } from "@ax/lib/live-traces/Tracer";
@@ -25,12 +36,26 @@ import {
     type TraceTransport,
 } from "@ax/lib/live-traces/Sink";
 import { runIngest, type RunIngestOptions } from "../ingest/run.ts";
+import { withIngestLock } from "../ingest/ingest-lock.ts";
 import { StageRegistry } from "../ingest/stage/registry.ts";
 import { ingestStreamEventFromTrace } from "../ingest/stream-events.ts";
 import type { IngestStreamBus } from "./ingest-stream.ts";
 
-/** Services `runIngest` needs that the caller must provide via `baseLayer`. */
-export type IngestBaseServices = SurrealClient | AxConfig | ProcessService | StageRegistry;
+/** Services `runIngest` (+ the single-flight lock) need that the caller must
+ *  provide via `baseLayer`. `FileSystem`/`Path` are read/written for the lock
+ *  file; production callers already get them from `AppLayer` (it re-exposes
+ *  its Bun-backed platform layer via `provideMerge` - see packages/lib/src/layers.ts). */
+export type IngestBaseServices =
+    | SurrealClient
+    | AxConfig
+    | ProcessService
+    | StageRegistry
+    | FileSystem.FileSystem
+    | Path.Path;
+
+/** Mirrors `INGEST_LOCK_STALE_GRACE_MS` in `cli/commands/ingest.ts`: extra
+ *  grace beyond the hard ingest timeout before a held lock is deemed stale. */
+const INGEST_LOCK_STALE_GRACE_MS = 60_000;
 
 /**
  * The `baseLayer` accepted by {@link startIngestWorkflow}. It must provide
@@ -122,7 +147,45 @@ export const startIngestWorkflow = (
         // this when it forwards a `run_finished`, so the failure handler below
         // only emits a synthetic terminal event when none was published.
         const state: TerminalState = { finished: false };
-        const program = runIngest({ ...opts, runId: () => runId }).pipe(
+        // Single-flight (#F3): the same `ingest.lock` file the CLI holds. A
+        // busy skip never calls `runIngest` at all - it publishes the
+        // synthetic terminal event itself (mirroring the catchCause guard
+        // below) so the stream terminates cleanly instead of hanging on a
+        // run that never happened.
+        const lockedIngest = Effect.gen(function* () {
+            const cfg = yield* AxConfig;
+            const path = yield* Path.Path;
+            const staleMs = cfg.knobs.ingestTimeoutSeconds * 1000 + INGEST_LOCK_STALE_GRACE_MS;
+            yield* withIngestLock(
+                {
+                    lockPath: path.join(cfg.paths.dataDir, "ingest.lock"),
+                    command: opts.command,
+                    staleMs,
+                    // No `timeoutSeconds` - this path stays unbounded, same as
+                    // before this change (see the module doc comment).
+                    onBusy: (holder) =>
+                        Effect.gen(function* () {
+                            yield* Effect.logWarning(
+                                `live ingest skipped: another ingest (pid ${holder.pid}, ` +
+                                    `${holder.command}) is already running`,
+                            ).pipe(Effect.annotateLogs("runId", runId));
+                            if (!state.finished) {
+                                state.finished = true;
+                                yield* Effect.promise(() =>
+                                    bus.publish(runId, {
+                                        kind: "run_finished",
+                                        runId,
+                                        status: "failed",
+                                        durationMs: 0,
+                                    }),
+                                );
+                            }
+                        }),
+                },
+                runIngest({ ...opts, runId: () => runId }),
+            );
+        });
+        const program = lockedIngest.pipe(
             // Single combined provide; `provideMerge` keeps the original
             // override order (the bus-backed TraceSink wins over any TraceSink
             // a caller's baseLayer happens to carry - see IngestBaseLayer docs).

--- a/apps/axctl/src/ingest/codex-reingest.e2e.test.ts
+++ b/apps/axctl/src/ingest/codex-reingest.e2e.test.ts
@@ -128,6 +128,13 @@ const exists = (db: SurrealClientShape, recordKey: string) =>
         .query<[{ id: unknown }[]]>(`SELECT id FROM agent_event:\`${recordKey}\`;`)
         .pipe(Effect.map((rows) => (rows?.[0]?.length ?? 0) > 0));
 
+const hasRaw = (db: SurrealClientShape, recordKey: string) =>
+    db
+        .query<[{ has_raw: boolean }[]]>(
+            `SELECT raw IS NOT NONE AS has_raw FROM agent_event:\`${recordKey}\`;`,
+        )
+        .pipe(Effect.map((rows) => rows?.[0]?.[0]?.has_raw === true));
+
 const provide = <A>(eff: Effect.Effect<A, unknown, SurrealClient>): Promise<A> =>
     Effect.runPromise(eff.pipe(Effect.provide(AppLayer)) as Effect.Effect<A, unknown, never>);
 
@@ -163,13 +170,22 @@ describe(
                     yield* cleanup(db);
                     yield* ingestOnce(db);
                     const firstCount = yield* countSessionEvents(db);
-                    // Identical second ingest: must not throw, count unchanged.
+                    // Simulate a row from an older writer. CONTENT replacement
+                    // on the second ingest must remove this legacy raw field.
+                    yield* db.query(
+                        `UPDATE agent_event:\`${callEventKey}\` SET raw = "legacy";`,
+                    );
+                    expect(yield* hasRaw(db, callEventKey)).toBe(true);
+                    // Identical second ingest: must not throw, count unchanged,
+                    // and no legacy raw payload remains.
                     yield* ingestOnce(db);
                     const secondCount = yield* countSessionEvents(db);
                     const callPresent = yield* exists(db, callEventKey);
-                    return { firstCount, secondCount, callPresent };
+                    const rawPresent = yield* hasRaw(db, callEventKey);
+                    return { firstCount, secondCount, callPresent, rawPresent };
                 }));
                 expect(result.callPresent).toBe(true);
+                expect(result.rawPresent).toBe(false);
                 expect(result.firstCount).toBeGreaterThan(0);
                 expect(result.secondCount).toBe(result.firstCount);
             },

--- a/apps/axctl/src/ingest/ingest-lock.test.ts
+++ b/apps/axctl/src/ingest/ingest-lock.test.ts
@@ -162,6 +162,80 @@ describe("withIngestLock", () => {
         expect(order).toEqual(["work-finalizer", "onTimeout"]);
     });
 
+    test("afterWork runs after work succeeds, still under the lock, then the lock is released", async () => {
+        const order: string[] = [];
+        const result = await run(
+            withIngestLock(
+                {
+                    lockPath,
+                    command: "ingest",
+                    staleMs: STALE_MS,
+                    now: () => T0,
+                    onBusy: () => Effect.succeed("busy" as const),
+                    afterWork: (value) =>
+                        Effect.sync(() => {
+                            order.push(`afterWork:${value}`);
+                            // still under the lock while afterWork runs
+                            expect(existsSync(lockPath)).toBe(true);
+                        }),
+                },
+                Effect.sync(() => {
+                    order.push("work");
+                    return "ran" as const;
+                }),
+            ),
+        );
+        expect(order).toEqual(["work", "afterWork:ran"]);
+        expect(result).toEqual({ _tag: "completed", value: "ran" });
+        expect(existsSync(lockPath)).toBe(false);
+    });
+
+    test("afterWork does not run when work times out, and the lock stays (cooldown)", async () => {
+        let afterWorkRan = false;
+        const result = await run(
+            withIngestLock(
+                {
+                    lockPath,
+                    command: "ingest",
+                    staleMs: STALE_MS,
+                    timeoutSeconds: 1,
+                    now: () => T0,
+                    onBusy: () => Effect.succeed("busy" as const),
+                    afterWork: () =>
+                        Effect.sync(() => {
+                            afterWorkRan = true;
+                        }),
+                },
+                Effect.never,
+            ),
+        );
+        expect(result).toEqual({ _tag: "timeout" });
+        expect(afterWorkRan).toBe(false);
+        expect(existsSync(lockPath)).toBe(true);
+    });
+
+    test("afterWork is NOT subject to timeoutSeconds - a slow afterWork after fast work still completes", async () => {
+        const result = await run(
+            withIngestLock(
+                {
+                    lockPath,
+                    command: "ingest",
+                    staleMs: STALE_MS,
+                    timeoutSeconds: 1,
+                    now: () => T0,
+                    onBusy: () => Effect.succeed("busy" as const),
+                    // Slower than the 1s `timeoutSeconds`, on its own it would
+                    // never trip the guillotine that only wraps `work`.
+                    afterWork: () =>
+                        Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 1200))),
+                },
+                Effect.succeed("ran" as const),
+            ),
+        );
+        expect(result).toEqual({ _tag: "completed", value: "ran" });
+        expect(existsSync(lockPath)).toBe(false);
+    }, 5000);
+
     test("atomic acquire: a fresh live holder is never overwritten", async () => {
         // pre-existing fresh+live lock; withIngestLock must NOT clobber it.
         writeLock({ pid: process.pid, startedAt: T0, command: "holder" });

--- a/apps/axctl/src/ingest/ingest-lock.ts
+++ b/apps/axctl/src/ingest/ingest-lock.ts
@@ -84,7 +84,7 @@ const readHolder = (
  * `{ _tag: "timeout" }` when `work` timed out (the lock is then left to age
  * out as a cooldown).
  */
-export const withIngestLock = <A, E, R, A2, E2, R2>(
+export const withIngestLock = <A, E, R, A2, E2, R2, R3 = never>(
     opts: {
         readonly lockPath: string;
         readonly command: string;
@@ -98,9 +98,19 @@ export const withIngestLock = <A, E, R, A2, E2, R2>(
          *  finalize the run row + tell the user; runs AFTER the interrupted
          *  work's own finalizers have completed */
         readonly onTimeout?: () => Effect.Effect<void, never, never>;
+        /**
+         * Runs once `work` completes successfully, still holding the lock, but
+         * NOT subject to `timeoutSeconds` - a slow-but-harmless follow-up (e.g.
+         * best-effort maintenance) can never retroactively flip a genuinely
+         * completed `work` into a `"timeout"` outcome. Errors must be handled
+         * by the caller (this signature has no error channel) so a maintenance
+         * fault can't fail the whole lock; an interrupt during `afterWork`
+         * still leaves the lock in place, same as an interrupt during `work`.
+         */
+        readonly afterWork?: (value: A) => Effect.Effect<void, never, R3>;
     },
     work: Effect.Effect<A, E, R>,
-): Effect.Effect<IngestLockOutcome<A, A2>, E | E2, R | R2 | FileSystem.FileSystem | Path.Path> =>
+): Effect.Effect<IngestLockOutcome<A, A2>, E | E2, R | R2 | R3 | FileSystem.FileSystem | Path.Path> =>
     Effect.gen(function* () {
         const busy = (value: A2): IngestLockOutcome<A, A2> => ({ _tag: "busy", value });
         const fs = yield* FileSystem.FileSystem;
@@ -157,7 +167,19 @@ export const withIngestLock = <A, E, R, A2, E2, R2>(
             ? work.pipe(Effect.timeoutOption(`${opts.timeoutSeconds} seconds`))
             : work.pipe(Effect.map(Option.some));
 
-        const result = yield* timed.pipe(
+        // `afterWork` is sequenced AFTER the timeout check resolves, so it is
+        // never raced against `timeoutSeconds` - only genuinely-timed-out work
+        // skips it. It still runs before `deleteLock` below (see the combined
+        // effect's own onExit), so it stays "under the lock".
+        const timedThenAfter = Effect.gen(function* () {
+            const outcome = yield* timed;
+            if (Option.isSome(outcome) && opts.afterWork) {
+                yield* opts.afterWork(outcome.value);
+            }
+            return outcome;
+        });
+
+        const result = yield* timedThenAfter.pipe(
             Effect.onExit((exit) =>
                 Exit.hasInterrupts(exit)
                     ? Effect.void

--- a/apps/axctl/src/ingest/provider-events.test.ts
+++ b/apps/axctl/src/ingest/provider-events.test.ts
@@ -228,6 +228,7 @@ describe("provider event writer statement builders", () => {
         expect(sql).toContain("provider_event_id: \"evt-1/unsafe\"");
         expect(parentEventStatement).toContain("parent_provider_event_id: NONE");
         expect(parentEventStatement).not.toContain("provider_session_id:");
+        expect(parentEventStatement).not.toContain("raw:");
         expect(childEventStatement).toContain("parent_provider_event_id: \"evt-1/unsafe\"");
         expect(childEventStatement).not.toContain("provider_session_id:");
         expect(sql).toContain("seq: 1");

--- a/apps/axctl/src/ingest/provider-events.ts
+++ b/apps/axctl/src/ingest/provider-events.ts
@@ -244,7 +244,6 @@ const buildAgentEventStatement = (event: AgentEventWrite): string => {
         ["role", surrealOptionString(event.role)],
         ["text", surrealOptionString(event.text)],
         ["text_excerpt", surrealOptionString(event.textExcerpt)],
-        ["raw", surrealJsonTextOption(event.raw)],
         ["labels", surrealJsonTextOption(event.labels)],
         ["metrics", surrealJsonTextOption(event.metrics)],
     ])};`;

--- a/apps/axctl/src/otel/retention.e2e.test.ts
+++ b/apps/axctl/src/otel/retention.e2e.test.ts
@@ -32,6 +32,9 @@ const SCHEMA = `
     DEFINE FIELD event_name ON otel_log_event TYPE string;
     DEFINE FIELD observed_at ON otel_log_event TYPE datetime;
     DEFINE INDEX log_observed ON otel_log_event FIELDS observed_at CONCURRENTLY;
+
+    DEFINE TABLE telemetry_of TYPE RELATION SCHEMAFULL;
+    DEFINE FIELD linked_at ON telemetry_of TYPE datetime DEFAULT time::now();
 `;
 
 const seed = (db: SurrealClientShape) => db.query(`
@@ -61,6 +64,8 @@ const seed = (db: SurrealClientShape) => db.query(`
         harness: "test", event_name: "test",
         observed_at: time::now()
     };
+    RELATE otel_span:recent->telemetry_of->otel_metric_point:old;
+    RELATE otel_span:recent->telemetry_of->otel_metric_point:recent;
 `);
 
 const exists = (db: SurrealClientShape, record: string) =>
@@ -102,7 +107,10 @@ describe("OTLP retention (live DB)", () => {
                 yield* Effect.promise(() => db.raw.use({ namespace: "ax", database: TMP_DB }));
                 yield* db.query(SCHEMA);
                 yield* seed(db);
-                yield* retainRecentOtel();
+                const retention = yield* retainRecentOtel();
+                const [edgeRows] = yield* db.query<[Array<{ out: unknown }>]>(
+                    "SELECT out FROM telemetry_of;",
+                );
                 return {
                     metricOld: yield* exists(db, "otel_metric_point:old"),
                     metricRecent: yield* exists(db, "otel_metric_point:recent"),
@@ -110,6 +118,16 @@ describe("OTLP retention (live DB)", () => {
                     spanRecent: yield* exists(db, "otel_span:recent"),
                     logOld: yield* exists(db, "otel_log_event:old"),
                     logRecent: yield* exists(db, "otel_log_event:recent"),
+                    // The edge into the pruned `otel_metric_point:old` row must
+                    // be gone too; the edge into the surviving `recent` row
+                    // must remain. SurrealDB 3.0.x auto-drops a RELATION edge
+                    // as soon as its target record is deleted, so by the time
+                    // the explicit dangling-edge DELETE below runs, it usually
+                    // finds nothing left to do - `deletedEdges` legitimately
+                    // reads 0 while the edge is still gone (asserted via the
+                    // surviving-edge count instead).
+                    telemetryOfEdgeCount: (edgeRows ?? []).length,
+                    retentionDeletedEdges: retention.deletedEdges,
                 };
             });
             const cleanup = Effect.gen(function* () {
@@ -126,6 +144,11 @@ describe("OTLP retention (live DB)", () => {
             spanRecent: true,
             logOld: false,
             logRecent: true,
+            telemetryOfEdgeCount: 1,
+            // SurrealDB already auto-dropped the dangling edge as a side
+            // effect of the `otel_metric_point` delete above, so the
+            // explicit cleanup query legitimately finds 0 left to prune.
+            retentionDeletedEdges: 0,
         });
     }, TEST_TIMEOUT_MS);
 });

--- a/apps/axctl/src/otel/retention.e2e.test.ts
+++ b/apps/axctl/src/otel/retention.e2e.test.ts
@@ -1,0 +1,131 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { AppLayer } from "@ax/lib/layers";
+import { SurrealClient, type SurrealClientShape } from "@ax/lib/db";
+import { retainRecentOtel } from "./retention.ts";
+
+const E2E_ENABLED = process.env.AX_E2E_DB === "1";
+const TEST_TIMEOUT_MS = 30_000;
+const TMP_DB = `retention_${Date.now().toString(36)}`;
+
+const SCHEMA = `
+    DEFINE TABLE otel_metric_point SCHEMAFULL;
+    DEFINE FIELD harness ON otel_metric_point TYPE string;
+    DEFINE FIELD metric ON otel_metric_point TYPE string;
+    DEFINE FIELD value ON otel_metric_point TYPE number;
+    DEFINE FIELD observed_at ON otel_metric_point TYPE datetime;
+    DEFINE INDEX metric_observed ON otel_metric_point FIELDS observed_at CONCURRENTLY;
+
+    DEFINE TABLE otel_span SCHEMAFULL;
+    DEFINE FIELD harness ON otel_span TYPE string;
+    DEFINE FIELD name ON otel_span TYPE string;
+    DEFINE FIELD trace_id ON otel_span TYPE string;
+    DEFINE FIELD span_id ON otel_span TYPE string;
+    DEFINE FIELD started_at ON otel_span TYPE datetime;
+    DEFINE FIELD ended_at ON otel_span TYPE datetime;
+    DEFINE FIELD duration_ms ON otel_span TYPE number;
+    DEFINE FIELD observed_at ON otel_span TYPE datetime;
+    DEFINE INDEX span_observed ON otel_span FIELDS observed_at CONCURRENTLY;
+
+    DEFINE TABLE otel_log_event SCHEMAFULL;
+    DEFINE FIELD harness ON otel_log_event TYPE string;
+    DEFINE FIELD event_name ON otel_log_event TYPE string;
+    DEFINE FIELD observed_at ON otel_log_event TYPE datetime;
+    DEFINE INDEX log_observed ON otel_log_event FIELDS observed_at CONCURRENTLY;
+`;
+
+const seed = (db: SurrealClientShape) => db.query(`
+    UPSERT otel_metric_point:old CONTENT {
+        harness: "test", metric: "test", value: 1,
+        observed_at: time::now() - 31d
+    };
+    UPSERT otel_metric_point:recent CONTENT {
+        harness: "test", metric: "test", value: 1,
+        observed_at: time::now()
+    };
+    UPSERT otel_span:old CONTENT {
+        harness: "test", name: "test", trace_id: "old", span_id: "old",
+        started_at: time::now() - 31d, ended_at: time::now() - 31d,
+        duration_ms: 1, observed_at: time::now() - 31d
+    };
+    UPSERT otel_span:recent CONTENT {
+        harness: "test", name: "test", trace_id: "recent", span_id: "recent",
+        started_at: time::now(), ended_at: time::now(),
+        duration_ms: 1, observed_at: time::now()
+    };
+    UPSERT otel_log_event:old CONTENT {
+        harness: "test", event_name: "test",
+        observed_at: time::now() - 31d
+    };
+    UPSERT otel_log_event:recent CONTENT {
+        harness: "test", event_name: "test",
+        observed_at: time::now()
+    };
+`);
+
+const exists = (db: SurrealClientShape, record: string) =>
+    db.query<[{ id: unknown }[]]>(`SELECT id FROM ${record};`).pipe(
+        Effect.map((rows) => (rows?.[0]?.length ?? 0) > 0),
+    );
+
+const run = <A, E>(effect: Effect.Effect<A, E, SurrealClient>): Promise<A> =>
+    Effect.runPromise(
+        effect.pipe(Effect.provide(AppLayer)) as Effect.Effect<A, E, never>,
+    );
+
+describe("OTLP retention (live DB)", () => {
+    let dbReachable = false;
+
+    beforeAll(async () => {
+        if (!E2E_ENABLED) return;
+        try {
+            await run(Effect.gen(function* () {
+                const db = yield* SurrealClient;
+                yield* db.query("RETURN 1;");
+            }));
+            dbReachable = true;
+        } catch {
+            // The guarded test reports a skip below.
+        }
+    });
+
+    test("removes old rows and keeps recent rows in every OTLP table", async () => {
+        if (!E2E_ENABLED || !dbReachable) {
+            console.log("(skipped - set AX_E2E_DB=1 with a live SurrealDB to run)");
+            expect(true).toBe(true);
+            return;
+        }
+
+        const result = await run(Effect.gen(function* () {
+            const db = yield* SurrealClient;
+            const scenario = Effect.gen(function* () {
+                yield* Effect.promise(() => db.raw.use({ namespace: "ax", database: TMP_DB }));
+                yield* db.query(SCHEMA);
+                yield* seed(db);
+                yield* retainRecentOtel();
+                return {
+                    metricOld: yield* exists(db, "otel_metric_point:old"),
+                    metricRecent: yield* exists(db, "otel_metric_point:recent"),
+                    spanOld: yield* exists(db, "otel_span:old"),
+                    spanRecent: yield* exists(db, "otel_span:recent"),
+                    logOld: yield* exists(db, "otel_log_event:old"),
+                    logRecent: yield* exists(db, "otel_log_event:recent"),
+                };
+            });
+            const cleanup = Effect.gen(function* () {
+                yield* Effect.promise(() => db.raw.use({ namespace: "ax", database: "main" }));
+                yield* db.query(`REMOVE DATABASE ${TMP_DB};`).pipe(Effect.ignore);
+            });
+            return yield* scenario.pipe(Effect.ensuring(cleanup));
+        }));
+
+        expect(result).toEqual({
+            metricOld: false,
+            metricRecent: true,
+            spanOld: false,
+            spanRecent: true,
+            logOld: false,
+            logRecent: true,
+        });
+    }, TEST_TIMEOUT_MS);
+});

--- a/apps/axctl/src/otel/retention.test.ts
+++ b/apps/axctl/src/otel/retention.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
+import { retainRecentOtel } from "./retention.ts";
+
+describe("retainRecentOtel", () => {
+    test("deletes rows older than 30 days through primary ids", async () => {
+        const db = makeTestSurrealClient();
+
+        await Effect.runPromise(retainRecentOtel().pipe(Effect.provide(db.layer)));
+
+        const sql = db.captured.join("\n");
+        for (const table of ["otel_metric_point", "otel_span", "otel_log_event"]) {
+            expect(sql).toContain(
+                `DELETE ${table} WHERE id IN (SELECT VALUE id FROM ${table} WHERE observed_at < time::now() - 30d);`,
+            );
+            expect(sql).not.toContain(`DELETE ${table} WHERE observed_at`);
+        }
+    });
+});

--- a/apps/axctl/src/otel/retention.test.ts
+++ b/apps/axctl/src/otel/retention.test.ts
@@ -4,17 +4,55 @@ import { makeTestSurrealClient } from "@ax/lib/testing/surreal";
 import { retainRecentOtel } from "./retention.ts";
 
 describe("retainRecentOtel", () => {
-    test("deletes rows older than 30 days through primary ids", async () => {
+    test("deletes rows via the non-quadratic result-set DELETE form", async () => {
         const db = makeTestSurrealClient();
 
         await Effect.runPromise(retainRecentOtel().pipe(Effect.provide(db.layer)));
 
         const sql = db.captured.join("\n");
         for (const table of ["otel_metric_point", "otel_span", "otel_log_event"]) {
+            // Correct form: DELETE targets the subquery RESULT by primary id.
             expect(sql).toContain(
-                `DELETE ${table} WHERE id IN (SELECT VALUE id FROM ${table} WHERE observed_at < time::now() - 30d);`,
+                `DELETE (SELECT VALUE id FROM ${table} WHERE observed_at < time::now() - 30d);`,
             );
-            expect(sql).not.toContain(`DELETE ${table} WHERE observed_at`);
+            // Never the quadratic id-IN-subquery form (measured: never
+            // completes at ~460k rows - see provider-events.ts doc comment).
+            expect(sql).not.toContain(
+                `DELETE ${table} WHERE id IN (SELECT VALUE id FROM ${table}`,
+            );
         }
+    });
+
+    test("prunes dangling telemetry_of edges left by the otel delete", async () => {
+        const db = makeTestSurrealClient();
+
+        await Effect.runPromise(retainRecentOtel().pipe(Effect.provide(db.layer)));
+
+        const sql = db.captured.join("\n");
+        expect(sql).toContain(
+            "DELETE (SELECT VALUE id FROM telemetry_of WHERE out.id IS NONE);",
+        );
+        // Same non-quadratic form for the edge cleanup too.
+        expect(sql).not.toContain("DELETE telemetry_of WHERE id IN (SELECT");
+    });
+
+    test("reports pruned counts for observability", async () => {
+        const db = makeTestSurrealClient({
+            routes: {
+                "SELECT count() FROM otel_log_event": [[{ count: 5 }]],
+                "SELECT count() FROM otel_span": [[{ count: 3 }]],
+                "SELECT count() FROM otel_metric_point": [[{ count: 1 }]],
+                "SELECT count() FROM telemetry_of": [[{ count: 2 }]],
+            },
+        });
+
+        const result = await Effect.runPromise(retainRecentOtel().pipe(Effect.provide(db.layer)));
+
+        expect(result.deletedByTable).toEqual({
+            otel_metric_point: 1,
+            otel_span: 3,
+            otel_log_event: 5,
+        });
+        expect(result.deletedEdges).toBe(2);
     });
 });

--- a/apps/axctl/src/otel/retention.ts
+++ b/apps/axctl/src/otel/retention.ts
@@ -3,17 +3,59 @@ import { SurrealClient } from "@ax/lib/db";
 
 const OTEL_TABLES = ["otel_metric_point", "otel_span", "otel_log_event"] as const;
 
-/** Keep only the latest 30 days of stored OTLP rows. */
+export interface OtelRetentionResult {
+    /** Rows pruned per otel table (best-effort count via a pre-delete SELECT count()). */
+    readonly deletedByTable: Record<string, number>;
+    /** Dangling `telemetry_of` edges pruned after their otel target was deleted. */
+    readonly deletedEdges: number;
+}
+
+/**
+ * Keep only the latest 30 days of stored OTLP rows, then prune any
+ * `telemetry_of` edge left dangling by that delete so enrichment joins
+ * (`telemetry-rollup.ts`) never dereference a record that no longer exists.
+ *
+ * DELETE FORM: the subquery RESULT is deleted (`DELETE (SELECT VALUE id ...)`),
+ * never `DELETE ... WHERE id IN (SELECT ...)`. The id-IN-subquery form is
+ * planned as a per-row membership test - the inner full-table scan
+ * re-evaluates for every candidate row, going quadratic in table size. That
+ * exact quadratic form wedged `agent_event`/`agent_event_child` deletes at
+ * ~460k rows (see the doc comment on
+ * `buildAgentSessionEventClearStatements` in
+ * `apps/axctl/src/ingest/provider-events.ts`); `otel_log_event` alone holds
+ * ~1.5M rows, so it would hit the same wall.
+ */
 export const retainRecentOtel = Effect.fn("otel.retention")(function* () {
     const db = yield* SurrealClient;
-    yield* Effect.forEach(
-        OTEL_TABLES,
-        (table) =>
-            db.query(
-                `DELETE ${table} WHERE id IN (`
-                    + `SELECT VALUE id FROM ${table} WHERE observed_at < time::now() - 30d`
-                    + `);`,
-            ),
-        { discard: true },
+    const deletedByTable: Record<string, number> = {};
+
+    for (const table of OTEL_TABLES) {
+        // Best-effort pre-delete count for the run summary (F5/F6
+        // observability) - counted under the same predicate the delete uses,
+        // just before it runs.
+        const [countRows] = yield* db.query<[Array<{ count: number }>]>(
+            `SELECT count() FROM ${table} WHERE observed_at < time::now() - 30d GROUP ALL;`,
+        );
+        deletedByTable[table] = countRows?.[0]?.count ?? 0;
+
+        yield* db.query(
+            `DELETE (SELECT VALUE id FROM ${table} WHERE observed_at < time::now() - 30d);`,
+        );
+    }
+
+    // Belt-and-suspenders: SurrealDB 3.0.x was observed (via a live e2e
+    // check, see retention.e2e.test.ts) to auto-drop a `telemetry_of` edge
+    // as soon as its `out` otel row is deleted above, so this is usually a
+    // no-op. It stays as defense-in-depth for edges that predate that
+    // behavior (e.g. rows written before this fix shipped) or that arrive
+    // via a path that doesn't cascade. `out.id IS NONE` dereferences the
+    // target; it evaluates to NONE once the target record no longer exists.
+    const [edgeCountRows] = yield* db.query<[Array<{ count: number }>]>(
+        "SELECT count() FROM telemetry_of WHERE out.id IS NONE GROUP ALL;",
     );
+    const deletedEdges = edgeCountRows?.[0]?.count ?? 0;
+
+    yield* db.query("DELETE (SELECT VALUE id FROM telemetry_of WHERE out.id IS NONE);");
+
+    return { deletedByTable, deletedEdges } satisfies OtelRetentionResult;
 });

--- a/apps/axctl/src/otel/retention.ts
+++ b/apps/axctl/src/otel/retention.ts
@@ -1,0 +1,19 @@
+import { Effect } from "effect";
+import { SurrealClient } from "@ax/lib/db";
+
+const OTEL_TABLES = ["otel_metric_point", "otel_span", "otel_log_event"] as const;
+
+/** Keep only the latest 30 days of stored OTLP rows. */
+export const retainRecentOtel = Effect.fn("otel.retention")(function* () {
+    const db = yield* SurrealClient;
+    yield* Effect.forEach(
+        OTEL_TABLES,
+        (table) =>
+            db.query(
+                `DELETE ${table} WHERE id IN (`
+                    + `SELECT VALUE id FROM ${table} WHERE observed_at < time::now() - 30d`
+                    + `);`,
+            ),
+        { discard: true },
+    );
+});

--- a/packages/lib/src/blob-gc.test.ts
+++ b/packages/lib/src/blob-gc.test.ts
@@ -1,18 +1,43 @@
 import { describe, expect, test } from "bun:test";
 import { BunFileSystem, BunPath } from "@effect/platform-bun";
-import { Effect, FileSystem, Layer, Path } from "effect";
+import { Effect, FileSystem, Layer, Path, PlatformError } from "effect";
+import { filePointer } from "./db.ts";
 import { gcFileBuckets } from "./blob-gc.ts";
 import { makeTestSurrealClient } from "./testing/surreal.ts";
 
 const PlatformLayer = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
 
+/** Wrap the real BunFileSystem, failing `remove` for exactly one path so F9
+ *  (per-file remove failures continue the loop) can be exercised against a
+ *  genuine `PlatformError` instead of a permission-bit trick that behaves
+ *  differently for root-run CI. Every other operation delegates to the real
+ *  filesystem untouched. */
+const withFailingRemove = (failPath: string): Layer.Layer<FileSystem.FileSystem> =>
+    Layer.effect(
+        FileSystem.FileSystem,
+        Effect.map(FileSystem.FileSystem, (fs) => ({
+            ...fs,
+            remove: (path: string, opts?: Parameters<FileSystem.FileSystem["remove"]>[1]) =>
+                path === failPath
+                    ? Effect.fail(
+                        PlatformError.systemError({
+                            _tag: "PermissionDenied",
+                            module: "FileSystem",
+                            method: "remove",
+                            pathOrDescriptor: path,
+                        }),
+                    )
+                    : fs.remove(path, opts),
+        })),
+    ).pipe(Layer.provide(BunFileSystem.layer));
+
 describe("gcFileBuckets", () => {
-    test("removes unreferenced blobs and keeps referenced blobs", async () => {
+    test("removes unreferenced blobs (age guard disabled) and keeps referenced blobs", async () => {
         const db = makeTestSurrealClient({
             routes: {
                 "SELECT raw_file FROM session": [[
-                    { raw_file: "transcripts:/keep.jsonl" },
-                    { raw_file: "codex_artifacts:/keep.jsonl" },
+                    { raw_file: filePointer("transcripts", "keep.jsonl") },
+                    { raw_file: filePointer("codex_artifacts", "keep.jsonl") },
                     { raw_file: "/source/transcript.jsonl" },
                 ]],
             },
@@ -32,13 +57,167 @@ describe("gcFileBuckets", () => {
             yield* fs.writeFileString(path.join(codex, "keep.jsonl"), "keep");
             yield* fs.writeFileString(path.join(codex, "orphan.jsonl"), "remove");
 
-            const result = yield* gcFileBuckets(root);
+            // Orphans are freshly written (age ~0), so disable the young-blob
+            // guard here - it's covered by its own test below.
+            const result = yield* gcFileBuckets(root, { fullIngest: true, minAgeMs: 0 });
 
-            expect(result).toEqual({ scanned: 4, removed: 2 });
+            expect(result).toEqual({ scanned: 4, removed: 2, failed: 0, skipped: false });
             expect(yield* fs.exists(path.join(transcripts, "keep.jsonl"))).toBe(true);
             expect(yield* fs.exists(path.join(codex, "keep.jsonl"))).toBe(true);
             expect(yield* fs.exists(path.join(transcripts, "orphan.jsonl"))).toBe(false);
             expect(yield* fs.exists(path.join(codex, "orphan.jsonl"))).toBe(false);
         }).pipe(Effect.provide(layer))));
+    });
+
+    test("skips entirely for a since-windowed (partial) ingest run", async () => {
+        const db = makeTestSurrealClient({
+            routes: {
+                "SELECT raw_file FROM session": [[
+                    { raw_file: filePointer("transcripts", "keep.jsonl") },
+                ]],
+            },
+        });
+        const layer = Layer.mergeAll(db.layer, PlatformLayer);
+
+        await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const root = yield* fs.makeTempDirectoryScoped();
+            const transcripts = path.join(root, "transcripts");
+            yield* fs.makeDirectory(transcripts);
+            yield* fs.writeFileString(path.join(transcripts, "orphan.jsonl"), "remove");
+
+            const result = yield* gcFileBuckets(root, { fullIngest: false });
+
+            expect(result.skipped).toBe(true);
+            expect(result.skipReason).toMatch(/since-windowed/);
+            expect(result.scanned).toBe(0);
+            expect(result.removed).toBe(0);
+            // A since-windowed run must never touch disk - the orphan survives.
+            expect(yield* fs.exists(path.join(transcripts, "orphan.jsonl"))).toBe(true);
+        }).pipe(Effect.provide(layer))));
+    });
+
+    test("skips when the session reference set is empty", async () => {
+        // Default fallback for an unmatched query is `[[]]` - no route needed
+        // to simulate "0 session rows with raw_file" (e.g. a fresh/wiped DB).
+        const db = makeTestSurrealClient();
+        const layer = Layer.mergeAll(db.layer, PlatformLayer);
+
+        await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const root = yield* fs.makeTempDirectoryScoped();
+            const transcripts = path.join(root, "transcripts");
+            yield* fs.makeDirectory(transcripts);
+            yield* fs.writeFileString(path.join(transcripts, "orphan.jsonl"), "remove");
+
+            const result = yield* gcFileBuckets(root, { fullIngest: true });
+
+            expect(result.skipped).toBe(true);
+            expect(result.skipReason).toMatch(/empty/);
+            // Refusing an empty reference set must never delete-everything.
+            expect(yield* fs.exists(path.join(transcripts, "orphan.jsonl"))).toBe(true);
+        }).pipe(Effect.provide(layer))));
+    });
+
+    test("spares an unreferenced blob younger than the age guard", async () => {
+        const db = makeTestSurrealClient({
+            routes: {
+                "SELECT raw_file FROM session": [[
+                    { raw_file: filePointer("transcripts", "keep.jsonl") },
+                ]],
+            },
+        });
+        const layer = Layer.mergeAll(db.layer, PlatformLayer);
+
+        await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const root = yield* fs.makeTempDirectoryScoped();
+            const transcripts = path.join(root, "transcripts");
+            yield* fs.makeDirectory(transcripts);
+            yield* fs.writeFileString(path.join(transcripts, "keep.jsonl"), "keep");
+            yield* fs.writeFileString(path.join(transcripts, "young-orphan.jsonl"), "remove");
+
+            // Default 24h age guard, real "now" - the orphan was just written.
+            const result = yield* gcFileBuckets(root, { fullIngest: true });
+
+            expect(result.skipped).toBe(false);
+            expect(result.removed).toBe(0);
+            expect(result.scanned).toBe(2);
+            expect(yield* fs.exists(path.join(transcripts, "young-orphan.jsonl"))).toBe(true);
+        }).pipe(Effect.provide(layer))));
+    });
+
+    test("deletes an old unreferenced blob past the age guard", async () => {
+        const db = makeTestSurrealClient({
+            routes: {
+                "SELECT raw_file FROM session": [[
+                    { raw_file: filePointer("transcripts", "keep.jsonl") },
+                ]],
+            },
+        });
+        const layer = Layer.mergeAll(db.layer, PlatformLayer);
+
+        await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const root = yield* fs.makeTempDirectoryScoped();
+            const transcripts = path.join(root, "transcripts");
+            yield* fs.makeDirectory(transcripts);
+            yield* fs.writeFileString(path.join(transcripts, "keep.jsonl"), "keep");
+            yield* fs.writeFileString(path.join(transcripts, "old-orphan.jsonl"), "remove");
+
+            // Simulate the clock 2 days ahead so the just-written orphan reads
+            // as 2 days old against the 24h default guard.
+            const twoDaysLater = () => Date.now() + 2 * 24 * 60 * 60 * 1000;
+            const result = yield* gcFileBuckets(root, { fullIngest: true, now: twoDaysLater });
+
+            expect(result).toEqual({ scanned: 2, removed: 1, failed: 0, skipped: false });
+            expect(yield* fs.exists(path.join(transcripts, "keep.jsonl"))).toBe(true);
+            expect(yield* fs.exists(path.join(transcripts, "old-orphan.jsonl"))).toBe(false);
+        }).pipe(Effect.provide(layer))));
+    });
+
+    test("a per-file remove failure is counted and does not abort the rest of GC", async () => {
+        const db = makeTestSurrealClient({
+            routes: {
+                "SELECT raw_file FROM session": [[
+                    { raw_file: filePointer("transcripts", "keep.jsonl") },
+                ]],
+            },
+        });
+
+        await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const root = yield* fs.makeTempDirectoryScoped();
+            const transcripts = path.join(root, "transcripts");
+            const codex = path.join(root, "codex_artifacts");
+            yield* fs.makeDirectory(transcripts);
+            yield* fs.makeDirectory(codex);
+            const failingOrphan = path.join(transcripts, "orphan-a.jsonl");
+            const okOrphan = path.join(codex, "orphan-b.jsonl");
+            yield* fs.writeFileString(failingOrphan, "remove");
+            yield* fs.writeFileString(okOrphan, "remove");
+
+            const layer = Layer.mergeAll(
+                db.layer,
+                Layer.mergeAll(withFailingRemove(failingOrphan), BunPath.layer),
+            );
+            const result = yield* gcFileBuckets(root, { fullIngest: true, minAgeMs: 0 }).pipe(
+                Effect.provide(layer),
+            );
+
+            expect(result.scanned).toBe(2);
+            expect(result.failed).toBe(1);
+            expect(result.removed).toBe(1);
+            expect(result.skipped).toBe(false);
+            // The failing remove left its file in place; the other bucket's
+            // orphan was still removed - one bad file never aborts the loop.
+            expect(yield* fs.exists(failingOrphan)).toBe(true);
+            expect(yield* fs.exists(okOrphan)).toBe(false);
+        }).pipe(Effect.provide(PlatformLayer))));
     });
 });

--- a/packages/lib/src/blob-gc.test.ts
+++ b/packages/lib/src/blob-gc.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { BunFileSystem, BunPath } from "@effect/platform-bun";
+import { Effect, FileSystem, Layer, Path } from "effect";
+import { gcFileBuckets } from "./blob-gc.ts";
+import { makeTestSurrealClient } from "./testing/surreal.ts";
+
+const PlatformLayer = Layer.mergeAll(BunFileSystem.layer, BunPath.layer);
+
+describe("gcFileBuckets", () => {
+    test("removes unreferenced blobs and keeps referenced blobs", async () => {
+        const db = makeTestSurrealClient({
+            routes: {
+                "SELECT raw_file FROM session": [[
+                    { raw_file: "transcripts:/keep.jsonl" },
+                    { raw_file: "codex_artifacts:/keep.jsonl" },
+                    { raw_file: "/source/transcript.jsonl" },
+                ]],
+            },
+        });
+
+        const layer = Layer.mergeAll(db.layer, PlatformLayer);
+        await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const root = yield* fs.makeTempDirectoryScoped();
+            const transcripts = path.join(root, "transcripts");
+            const codex = path.join(root, "codex_artifacts");
+            yield* fs.makeDirectory(transcripts);
+            yield* fs.makeDirectory(codex);
+            yield* fs.writeFileString(path.join(transcripts, "keep.jsonl"), "keep");
+            yield* fs.writeFileString(path.join(transcripts, "orphan.jsonl"), "remove");
+            yield* fs.writeFileString(path.join(codex, "keep.jsonl"), "keep");
+            yield* fs.writeFileString(path.join(codex, "orphan.jsonl"), "remove");
+
+            const result = yield* gcFileBuckets(root);
+
+            expect(result).toEqual({ scanned: 4, removed: 2 });
+            expect(yield* fs.exists(path.join(transcripts, "keep.jsonl"))).toBe(true);
+            expect(yield* fs.exists(path.join(codex, "keep.jsonl"))).toBe(true);
+            expect(yield* fs.exists(path.join(transcripts, "orphan.jsonl"))).toBe(false);
+            expect(yield* fs.exists(path.join(codex, "orphan.jsonl"))).toBe(false);
+        }).pipe(Effect.provide(layer))));
+    });
+});

--- a/packages/lib/src/blob-gc.ts
+++ b/packages/lib/src/blob-gc.ts
@@ -1,18 +1,62 @@
-import { Effect, FileSystem, Path } from "effect";
-import { SurrealClient } from "./db.ts";
-import { skipNotFound } from "./shared/fs-error.ts";
+import { Effect, FileSystem, Option, Path } from "effect";
+import { filePointer, SurrealClient } from "./db.ts";
+import { orAbsent, skipNotFound } from "./shared/fs-error.ts";
 
 const FILE_BUCKETS = ["transcripts", "codex_artifacts"] as const;
+
+/** Never delete a blob written more recently than this - guards the window
+ *  where a blob has just landed on disk (e.g. serve's live ingest, still
+ *  mid-write) but its `session` row referencing it hasn't been upserted yet. */
+const DEFAULT_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 
 export interface BlobGcResult {
     readonly scanned: number;
     readonly removed: number;
+    /** `fs.remove` failures - counted, not fatal (F9): one bad file must not
+     *  abort GC for every other candidate. */
+    readonly failed: number;
+    /** True when GC declined to run/delete anything this call - see
+     *  `skipReason` for why. `scanned`/`removed`/`failed` are all 0 then. */
+    readonly skipped: boolean;
+    readonly skipReason?: string;
 }
+
+export interface BlobGcOptions {
+    /**
+     * Only actually delete when the triggering ingest run was NOT
+     * since-windowed (i.e. it scanned every session). The reference set below
+     * is built from the CURRENT `session` table; after a DB wipe + a
+     * `--since`-windowed re-ingest, that table only holds the sessions the
+     * windowed run touched - every session outside the window looks
+     * unreferenced even though its blob is still live. Running GC against
+     * that partial view would permanently delete cold-but-referenced blobs.
+     */
+    readonly fullIngest: boolean;
+    /** Override the young-blob guard window (ms). Defaults to 24h. */
+    readonly minAgeMs?: number;
+    readonly now?: () => number;
+}
+
+const skip = (reason: string): BlobGcResult => ({
+    scanned: 0,
+    removed: 0,
+    failed: 0,
+    skipped: true,
+    skipReason: reason,
+});
 
 /** Remove local file-bucket blobs that no session row references. */
 export const gcFileBuckets = Effect.fn("blobGc.gcFileBuckets")(function* (
     bucketsDir: string,
+    opts: BlobGcOptions,
 ) {
+    if (!opts.fullIngest) {
+        return skip(
+            "ingest run was --since-windowed (partial); the session table is not a complete " +
+                "reference set, so blob GC was skipped to avoid deleting live blobs",
+        );
+    }
+
     const db = yield* SurrealClient;
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -25,8 +69,19 @@ export const gcFileBuckets = Effect.fn("blobGc.gcFileBuckets")(function* (
             .filter((value): value is string => typeof value === "string"),
     );
 
+    if (referenced.size === 0) {
+        return skip(
+            "the session reference set is empty (0 rows with raw_file); refusing to run blob GC " +
+                "against an empty reference set, which would delete every blob",
+        );
+    }
+
+    const now = opts.now ?? (() => Date.now());
+    const minAgeMs = opts.minAgeMs ?? DEFAULT_MIN_AGE_MS;
+
     let scanned = 0;
     let removed = 0;
+    let failed = 0;
     for (const bucket of FILE_BUCKETS) {
         const bucketDir = path.join(bucketsDir, bucket);
         const entries = yield* fs.readDirectory(bucketDir).pipe(
@@ -37,11 +92,22 @@ export const gcFileBuckets = Effect.fn("blobGc.gcFileBuckets")(function* (
             const info = yield* fs.stat(filePath).pipe(skipNotFound(null));
             if (info === null || info.type !== "File") continue;
             scanned += 1;
-            if (referenced.has(`${bucket}:/${entry}`)) continue;
-            yield* fs.remove(filePath);
-            removed += 1;
+            if (referenced.has(filePointer(bucket, entry))) continue;
+
+            const ageMs = Option.match(info.mtime, {
+                onNone: () => Number.POSITIVE_INFINITY,
+                onSome: (mtime) => now() - mtime.getTime(),
+            });
+            if (ageMs < minAgeMs) continue; // young blob spared
+
+            const ok = yield* fs.remove(filePath).pipe(
+                Effect.as(true),
+                orAbsent(false),
+            );
+            if (ok) removed += 1;
+            else failed += 1;
         }
     }
 
-    return { scanned, removed } satisfies BlobGcResult;
+    return { scanned, removed, failed, skipped: false } satisfies BlobGcResult;
 });

--- a/packages/lib/src/blob-gc.ts
+++ b/packages/lib/src/blob-gc.ts
@@ -1,0 +1,47 @@
+import { Effect, FileSystem, Path } from "effect";
+import { SurrealClient } from "./db.ts";
+import { skipNotFound } from "./shared/fs-error.ts";
+
+const FILE_BUCKETS = ["transcripts", "codex_artifacts"] as const;
+
+export interface BlobGcResult {
+    readonly scanned: number;
+    readonly removed: number;
+}
+
+/** Remove local file-bucket blobs that no session row references. */
+export const gcFileBuckets = Effect.fn("blobGc.gcFileBuckets")(function* (
+    bucketsDir: string,
+) {
+    const db = yield* SurrealClient;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const [rows] = yield* db.query<[Array<{ raw_file: unknown }>]>(
+        "SELECT raw_file FROM session WHERE raw_file IS NOT NONE;",
+    );
+    const referenced = new Set(
+        (rows ?? [])
+            .map((row) => row.raw_file)
+            .filter((value): value is string => typeof value === "string"),
+    );
+
+    let scanned = 0;
+    let removed = 0;
+    for (const bucket of FILE_BUCKETS) {
+        const bucketDir = path.join(bucketsDir, bucket);
+        const entries = yield* fs.readDirectory(bucketDir).pipe(
+            skipNotFound<ReadonlyArray<string>>([]),
+        );
+        for (const entry of entries) {
+            const filePath = path.join(bucketDir, entry);
+            const info = yield* fs.stat(filePath).pipe(skipNotFound(null));
+            if (info === null || info.type !== "File") continue;
+            scanned += 1;
+            if (referenced.has(`${bucket}:/${entry}`)) continue;
+            yield* fs.remove(filePath);
+            removed += 1;
+        }
+    }
+
+    return { scanned, removed } satisfies BlobGcResult;
+});


### PR DESCRIPTION
Wave-0 chunk of the v2 DuckDB refactor (fleet map #768; backlog in docs/superpowers/plans/2026-08-14-v2-duckdb-backlog.md).

## What

Three independent prunes that shrink the data plane before the engine swap:

- Stop writing `agent_event.raw` at ingest (the DuckDB cache re-derives from transcripts; raw blobs were dead weight).
- Blob-bucket GC for orphaned file-content buckets.
- 30-day retention pass for `otel_*` rows, run as post-ingest maintenance.

## Review

Adversarial review found 2 CRITICAL + 4 secondary findings; all fixed in the follow-up commit:

- F1: retention used the quadratic `id IN (subquery)` delete form (wedges SurrealDB at ~460k rows; the brief itself propagated this from a stale memory) → rewritten to `DELETE (SELECT VALUE id ...)`, with a test that rejects the quadratic form. Live e2e also corrected an assumption: SurrealDB 3.0.x auto-drops `telemetry_of` edges when their `out` record dies, so edge cleanup is defense-in-depth.
- F2: blob GC could permanently delete cold transcript storage after a DB reset or on a `--since`-windowed run → GC now runs only on full ingests, skips empty reference sets, and spares blobs younger than 24h.
- F3: serve live-ingest bypassed the ingest lockfile → `ingest-workflow` now wraps `runIngest` in the same `withIngestLock` as the CLI; busy → synthetic `run_finished{failed}`.
- F5/F6: maintenance runs via a new `afterWork` hook (after timeout check, before lock release) with an independent per-pass catch + summary line. F9: single-bucket remove failures counted, never abort the loop.

Gates post-rebase on v2/duckdb: `bun run typecheck` 0 · `bunx tsc --noEmit` 0 · `bun test apps/axctl/src/otel packages/lib apps/axctl/src/ingest` 1796 pass / 0 fail (fix run also did full-repo bun test: 5771 pass, only pre-existing studio-desktop electron failures).
