### PR TITLE
fix(v2): revert DDL to FFI-readable types - UTC TIMESTAMP, JSON arrays, banned-type guard

### DIFF
--- a/packages/schema/src/duckdb-load.test.ts
+++ b/packages/schema/src/duckdb-load.test.ts
@@ -71,11 +71,17 @@ describe("schema.duckdb.sql loads into a fresh DuckDB", () => {
     // P2-5: the earlier version of this suite only loaded the DDL and listed
     // tables - it never proved a single row could actually be written and
     // read back. This test inserts one representative row per risky
-    // translation decision from the cross-review (P1-1 polymorphic edges,
-    // P2-1 TIMESTAMPTZ offset preservation, P2-2 DEFAULT-only-on-omit
-    // semantics, P2-3 native list columns) and asserts the values survive a
+    // translation decision from the cross-review (P1-1 polymorphic edges, the
+    // UTC contract for plain TIMESTAMP columns, P2-2 DEFAULT-only-on-omit
+    // semantics, JSON-encoded scalar arrays) and asserts the values survive a
     // round trip through the real DuckDB engine.
-    test("representative inserts round-trip through offset timestamps, lists, JSON text, defaults, and a polymorphic edge", () => {
+    //
+    // TIMESTAMPTZ + native list columns (P2-1/P2-3 as originally reviewed) are
+    // REVERTED: the bun:ffi DuckDB client's row-major `duckdb_value_*`
+    // accessors cannot decode TIMESTAMP_TZ or LIST (probe-confirmed
+    // DuckDbUnsupportedTypeError). This test now exercises the UTC-contract
+    // TIMESTAMP path and JSON-encoded VARCHAR arrays in their place.
+    test("representative inserts round-trip through UTC timestamps, JSON-encoded arrays, defaults, and a polymorphic edge", () => {
         const dir = mkdtempSync(join(tmpdir(), "ax-duckdb-ddl-"));
         try {
             const dbPath = join(dir, "cache.duckdb");
@@ -85,14 +91,15 @@ describe("schema.duckdb.sql loads into a fresh DuckDB", () => {
                 // (session.source has DEFAULT 'claude', omitted here on purpose).
                 `INSERT INTO session (id, labels) VALUES ('s1', '["spar"]');`,
                 `SELECT id, source, labels, json_extract_string(labels, '$[0]') FROM session WHERE id = 's1';`,
-                // TIMESTAMPTZ with a non-UTC offset (+05:30): the UTC instant must
-                // survive the round trip even though DuckDB may display it in a
-                // different session-local zone.
-                `INSERT INTO "commit" (id, sha, repo, ts) VALUES ('c1', 'deadbeef', 'ax', TIMESTAMPTZ '2026-06-15 10:00:00+05:30');`,
+                // UTC contract: the writer normalizes to UTC before insert, so the
+                // literal carries no offset - a plain TIMESTAMP. The instant must
+                // survive the round trip unchanged.
+                `INSERT INTO "commit" (id, sha, repo, ts) VALUES ('c1', 'deadbeef', 'ax', TIMESTAMP '2026-06-15 10:00:00');`,
                 `SELECT epoch(ts) FROM "commit" WHERE id = 'c1';`,
-                // Native list column (P2-3): agent_def.skills is VARCHAR[], not JSON text.
-                `INSERT INTO agent_def (id, name, scope, dir_path, skills, content_hash) VALUES ('a1', 'my-agent', 'user', '/x', ['skill-a', 'skill-b'], 'hash1');`,
-                `SELECT skills FROM agent_def WHERE id = 'a1';`,
+                // JSON-encoded VARCHAR (P2-3 reverted): agent_def.skills is plain
+                // VARCHAR holding a JSON array string, not a native LIST column.
+                `INSERT INTO agent_def (id, name, scope, dir_path, skills, content_hash) VALUES ('a1', 'my-agent', 'user', '/x', '["skill-a","skill-b"]', 'hash1');`,
+                `SELECT skills, json_extract_string(skills, '$[1]') FROM agent_def WHERE id = 'a1';`,
                 // Polymorphic edge row (P1-1): concerns carries an explicit
                 // in_table/out_table pair alongside in_id/out_id.
                 `INSERT INTO concerns (id, in_id, out_id, in_table, out_table, kind) VALUES ('e1', 'tool1', 'skill1', 'tool_call', 'skill', 'test');`,
@@ -123,12 +130,17 @@ describe("schema.duckdb.sql loads into a fresh DuckDB", () => {
             expect(labels).toBe('["spar"]');
             expect(firstLabel).toBe("spar");
 
-            // The instant, not the display offset, is what must be preserved -
-            // 2026-06-15T10:00:00+05:30 is 2026-06-15T04:30:00Z.
-            const expectedEpoch = Date.UTC(2026, 5, 15, 4, 30, 0) / 1000;
+            // The UTC instant inserted (no offset in the literal) must come back
+            // unchanged - 2026-06-15T10:00:00Z.
+            const expectedEpoch = Date.UTC(2026, 5, 15, 10, 0, 0) / 1000;
             expect(Number(commitEpoch)).toBe(expectedEpoch);
 
-            expect(agentDefSkills).toBe("[skill-a, skill-b]");
+            // skills is a plain VARCHAR carrying JSON text, not a native list -
+            // DuckDB's json_extract_string proves it reads as JSON, not as a LIST.
+            const [skillsRaw, secondSkill] = agentDefSkills.split("|");
+            expect(skillsRaw).toBe('["skill-a","skill-b"]');
+            expect(secondSkill).toBe("skill-b");
+
             expect(concernsEdge).toBe("tool_call|skill");
         } finally {
             rmSync(dir, { recursive: true, force: true });

--- a/packages/schema/src/duckdb-parity.test.ts
+++ b/packages/schema/src/duckdb-parity.test.ts
@@ -58,39 +58,20 @@ function surrealTypesByTable(): Map<string, Map<string, SurrealFieldType>> {
     return out;
 }
 
-/** The Surreal `array<T>` element types that become a native DuckDB list
- *  column (P2-3). Anything else - `record<...>`, `object`, nested/flexible
- *  shapes - stays JSON-encoded VARCHAR, unchanged. */
-function scalarArrayElementDuckType(elementType: string): string | null {
-    switch (elementType) {
-        case "string":
-            return "VARCHAR";
-        case "int":
-            return "BIGINT";
-        case "float":
-            return "DOUBLE";
-        case "number":
-            return "DOUBLE";
-        case "bool":
-            return "BOOLEAN";
-        case "datetime":
-            return "TIMESTAMPTZ";
-        default:
-            return null;
-    }
-}
-
-/** Maps a Surreal DEFINE FIELD TYPE to the DuckDB type it must translate to. */
+/** Maps a Surreal DEFINE FIELD TYPE to the DuckDB type it must translate to.
+ *
+ *  P2-3 (native list columns for scalar `array<T>` fields) and P2-1
+ *  (`datetime` -> TIMESTAMPTZ) are both REVERTED (see the UTC CONTRACT / FFI
+ *  CLIENT COMPATIBILITY notes in schema.duckdb.sql's header): the bun:ffi
+ *  DuckDB client's row-major `duckdb_value_*` accessors cannot decode
+ *  TIMESTAMP_TZ or LIST, so every scalar array stays JSON-encoded VARCHAR
+ *  (same as record/object arrays - no distinction by element type anymore)
+ *  and every datetime is plain TIMESTAMP. */
 function expectedDuckType(t: string): string {
     if (t.startsWith("record<")) return "VARCHAR";
-    if (t.startsWith("array<")) {
-        const elementType = t.slice("array<".length, t.lastIndexOf(">"));
-        const listType = scalarArrayElementDuckType(elementType);
-        // A scalar element type (string/int/float/number/bool/datetime) becomes a
-        // native DuckDB list column; anything else (record<>, nested objects) is
-        // still JSON text in a VARCHAR column - unaffected by P2-3.
-        return listType !== null ? `${listType}[]` : "VARCHAR";
-    }
+    // Every array<T> - scalar or not - is JSON-encoded VARCHAR now; DuckDB
+    // native list columns (`T[]`) are banned (FFI client can't decode LIST).
+    if (t.startsWith("array<")) return "VARCHAR";
     if (t === "object") return "VARCHAR";
     switch (t) {
         case "string":
@@ -104,7 +85,10 @@ function expectedDuckType(t: string): string {
         case "bool":
             return "BOOLEAN";
         case "datetime":
-            return "TIMESTAMPTZ";
+            // Plain TIMESTAMP, never TIMESTAMPTZ - the FFI client cannot decode
+            // TIMESTAMP_TZ (DuckDbUnsupportedTypeError, probe-confirmed). Writers
+            // must normalize to UTC before insert; readers append `Z`.
+            return "TIMESTAMP";
         default:
             return `?${t}`;
     }
@@ -241,6 +225,55 @@ describe("type + nullability parity (Surreal DEFINE FIELD TYPE == DuckDB column 
 
         expect(problems).toEqual([]);
         expect(checked).toBe(EXPECTED_COLUMNS_COMPARED);
+    });
+});
+
+// Regression guard for the whole "DDL drifted ahead of the FFI client" conflict
+// class (TIMESTAMPTZ + native LIST columns were both added in a review round
+// that didn't know the reader can't decode either - see the BANNED TYPES note
+// in schema.duckdb.sql's header). The bun:ffi DuckDB client decodes results
+// with the deprecated row-major `duckdb_value_*` accessors (it cannot pass
+// structs by value, so it can't use the columnar/vector API); a probe against
+// the real client + dylib confirmed TIMESTAMP_TZ and LIST both raise
+// DuckDbUnsupportedTypeError. None of these may appear as a column type
+// anywhere in the DDL, and this test scans every column's actual type token -
+// not a fixed set of "known offender" columns - so a future column reintroducing
+// any of them fails here regardless of which table it lands on.
+describe("banned-type guard (FFI client compatibility)", () => {
+    const BANNED_TYPE_TOKENS = [
+        "UUID",
+        "ENUM",
+        "BIT",
+        "TIMESTAMP_S",
+        "TIMESTAMP_MS",
+        "TIMESTAMP_NS",
+        "TIMESTAMP_TZ",
+        "TIMESTAMPTZ", // short-form alias for TIMESTAMP_TZ / TIMESTAMP WITH TIME ZONE
+        "TIME_TZ",
+        "TIMETZ", // short-form alias for TIME_TZ
+    ];
+
+    test("no column in the DDL uses a banned (FFI-unreadable) type", () => {
+        const problems: string[] = [];
+        let checked = 0;
+
+        for (const table of duckTables) {
+            for (const def of parseDuckdbColumnDefs(table)) {
+                checked += 1;
+                if (def.type.endsWith("[]")) {
+                    // Native DuckDB list column - the FFI client cannot decode LIST.
+                    problems.push(`${table}.${def.name}: native LIST column (${def.type}) is banned`);
+                    continue;
+                }
+                if (BANNED_TYPE_TOKENS.includes(def.type.toUpperCase())) {
+                    problems.push(`${table}.${def.name}: banned type ${def.type}`);
+                }
+            }
+        }
+
+        // Sanity floor so this can't silently degrade to scanning zero columns.
+        expect(checked).toBeGreaterThan(1000);
+        expect(problems).toEqual([]);
     });
 });
 

--- a/packages/schema/src/duckdb-schema.test.ts
+++ b/packages/schema/src/duckdb-schema.test.ts
@@ -129,16 +129,19 @@ describe("types and Surreal leftovers", () => {
         }
     });
 
-    test("datetimes are TIMESTAMPTZ, not naive TIMESTAMP (P2-1)", () => {
-        expect(DUCKDB_SCHEMA_SQL).toMatch(/\bTIMESTAMPTZ\b/);
+    // P2-1 (TIMESTAMPTZ for every datetime) is REVERTED: the bun:ffi DuckDB
+    // client cannot decode TIMESTAMP_TZ (probe-confirmed DuckDbUnsupportedTypeError
+    // against the real client + dylib). Every datetime column is plain TIMESTAMP
+    // now, under a UTC contract (writers normalize to UTC before insert; readers
+    // append `Z`). TIMESTAMPTZ is a banned type - see the banned-type guard in
+    // duckdb-parity.test.ts for the exhaustive per-column scan; this test just
+    // pins the header-level contract.
+    test("datetimes are plain TIMESTAMP (UTC contract); TIMESTAMPTZ is banned", () => {
+        expect(DUCKDB_SCHEMA_SQL).toMatch(/\bTIMESTAMP\b/);
         expect(DUCKDB_SCHEMA_SQL).not.toMatch(/\bDATETIME\b/);
-        // No column declaration line may use bare TIMESTAMP - a plain TIMESTAMP
-        // silently drops the UTC offset every Surreal datetime carries. Header
-        // prose is excluded via `statements` (comment lines stripped above).
-        const bareTimestampColumns = statements
-            .split("\n")
-            .filter((line) => /^\s*"?\w+"?\s+TIMESTAMP\b/.test(line) && !line.includes("TIMESTAMPTZ"));
-        expect(bareTimestampColumns).toEqual([]);
+        // No column declaration line (comments stripped via `statements`) may use
+        // TIMESTAMPTZ - the FFI client can't decode it.
+        expect(statements).not.toMatch(/\bTIMESTAMPTZ\b/);
     });
 
     test("index names are unique across the database", () => {
@@ -152,26 +155,34 @@ describe("types and Surreal leftovers", () => {
     });
 });
 
-describe("arrays (P2-3)", () => {
-    // Surreal array<scalar> -> native DuckDB list column; everything else
-    // (record arrays, objects) stays JSON VARCHAR. See the ARRAYS note in the
-    // schema.duckdb.sql header.
-    test("scalar array fields are native list columns, not JSON VARCHAR", () => {
-        const scalarArrayColumns: ReadonlyArray<{ readonly table: string; readonly column: string; readonly type: string }> = [
-            { table: "agent_def", column: "skills", type: "VARCHAR[]" },
-            { table: "hook_fire", column: "injected_titles", type: "VARCHAR[]" },
-            { table: "subagent_proposal", column: "example_task_patterns", type: "VARCHAR[]" },
-            { table: "wrapped_card", column: "series", type: "DOUBLE[]" },
+describe("arrays (P2-3, reverted)", () => {
+    // P2-3 (native DuckDB list columns for scalar array<T> fields) is REVERTED:
+    // the bun:ffi DuckDB client cannot decode LIST columns (probe-confirmed
+    // DuckDbUnsupportedTypeError against the real client + dylib). Every
+    // array<T> field - scalar or record/object - now stays JSON-encoded
+    // VARCHAR, same treatment. See the ARRAYS / BANNED TYPES notes in the
+    // schema.duckdb.sql header; the exhaustive per-column scan lives in the
+    // banned-type guard in duckdb-parity.test.ts.
+    test("formerly-native-list scalar array fields are JSON VARCHAR, not list columns", () => {
+        const scalarArrayColumns: ReadonlyArray<{ readonly table: string; readonly column: string }> = [
+            { table: "agent_def", column: "skills" },
+            { table: "hook_fire", column: "injected_titles" },
+            { table: "subagent_proposal", column: "example_task_patterns" },
+            { table: "wrapped_card", column: "series" },
         ];
-        for (const { column, type } of scalarArrayColumns) {
-            const re = new RegExp(`^\\s*${column}\\s+${type.replace(/\[/g, "\\[").replace(/\]/g, "\\]")}(?![\\w[])`, "m");
-            expect(DUCKDB_SCHEMA_SQL).toMatch(re);
+        for (const { column } of scalarArrayColumns) {
+            expect(DUCKDB_SCHEMA_SQL).toMatch(new RegExp(`^\\s*${column}\\s+VARCHAR\\b`, "m"));
+            expect(DUCKDB_SCHEMA_SQL).not.toMatch(new RegExp(`^\\s*${column}\\s+\\w+\\[\\]`, "m"));
         }
     });
 
-    test("a record<> array (hook_fire.top_prior_sessions) is out of P2-3 scope and stays JSON VARCHAR", () => {
+    test("a record<> array (hook_fire.top_prior_sessions) stays JSON VARCHAR, unaffected by the revert", () => {
         expect(DUCKDB_SCHEMA_SQL).toMatch(/^\s*top_prior_sessions\s+VARCHAR\s+NOT NULL/m);
         expect(DUCKDB_SCHEMA_SQL).not.toMatch(/^\s*top_prior_sessions\s+VARCHAR\[\]/m);
+    });
+
+    test("no native DuckDB list column type (`T[]`) survives anywhere in the DDL", () => {
+        expect(statements).not.toMatch(/^\s*"?\w+"?\s+\w+\[\]/m);
     });
 });
 

--- a/packages/schema/src/schema.duckdb.sql
+++ b/packages/schema/src/schema.duckdb.sql
@@ -50,22 +50,48 @@
 -- rewrites tables independently. Referential integrity is a CHECK, not a
 -- constraint - packages/lib/src/cache-integrity.ts.
 --
--- TYPES. Surreal `datetime` -> TIMESTAMPTZ (== `TIMESTAMP WITH TIME ZONE`; DuckDB
--- accepts the short form as a real alias, not merely display sugar - see the
--- DuckDB timestamp docs). A plain `TIMESTAMP` silently drops the UTC offset Surreal
--- datetimes always carry (P2-1), so every datetime column in this file uses
--- TIMESTAMPTZ, never bare TIMESTAMP. `int` -> BIGINT, `float`/`number` -> DOUBLE,
--- `bool` -> BOOLEAN.
+-- TYPES. Surreal `datetime` -> plain `TIMESTAMP` (NOT `TIMESTAMPTZ`). `int` ->
+-- BIGINT, `float`/`number` -> DOUBLE, `bool` -> BOOLEAN.
 --
--- ARRAYS (P2-3). Surreal `array<T>` where T is a scalar (string/int/float/number/
--- bool/datetime) becomes a native DuckDB list column of the mapped element type
--- (`VARCHAR[]`, `BIGINT[]`, `DOUBLE[]`, `BOOLEAN[]`, `TIMESTAMPTZ[]`) - DuckDB lists
--- are a real first-class type, not a translation compromise, so there is no reason
--- to flatten a scalar array through JSON text. Everything else that is JSON in
--- Surreal - JSON-encoded object fields, arrays of records/objects, and any
--- `flexible`/nested-object shape (v3 has no `flexible<object>`) - stays VARCHAR and
--- is marked `-- JSON` at the column; still JSON text, readable with DuckDB's json
--- functions.
+-- UTC CONTRACT (supersedes P2-1; reverted from TIMESTAMPTZ, see FFI CLIENT
+-- COMPATIBILITY below). All TIMESTAMP columns store UTC instants. Writers MUST
+-- normalize to UTC before insert - DuckDB silently drops offsets on naive
+-- TIMESTAMP inserts, so an offset string reaching the DB is a writer bug.
+-- Readers append `Z` when they need an ISO string back out. TIMESTAMPTZ is
+-- banned in this file: the FFI client cannot decode it (see below).
+--
+-- ARRAYS (P2-3, reverted). Surreal `array<T>` where T is a scalar (string/int/
+-- float/number/bool/datetime) stays JSON-encoded VARCHAR, marked `-- JSON` at
+-- the column, same as every other JSON-in-Surreal shape (object fields, arrays
+-- of records/objects, `flexible`/nested-object shapes - v3 has no
+-- `flexible<object>`). An earlier revision of this file made scalar arrays
+-- native DuckDB list columns (`VARCHAR[]` etc.) since DuckDB lists are a real
+-- first-class type; that native-list form is banned here until the FFI client
+-- gains LIST decoding (see below) - all scalar arrays are JSON text in VARCHAR
+-- for now, readable with DuckDB's json functions.
+--
+-- FFI CLIENT COMPATIBILITY. Every reader of this cache goes through the
+-- bun:ffi DuckDB client, which cannot pass structs by value and therefore
+-- decodes results with the deprecated row-major `duckdb_value_*` accessors
+-- instead of the columnar/vector API. Those accessors do not support every
+-- DuckDB logical type. A probe against the real client + dylib confirmed
+-- `TIMESTAMP_TZ` and `LIST` both raise `DuckDbUnsupportedTypeError`, while
+-- plain `TIMESTAMP` decodes fine - so this DDL bends to the client instead of
+-- the other way round, until a pointer-based (vector API) read path lands
+-- (tracked separately). BANNED TYPES - none of these may appear as a column
+-- type in this file:
+--   UUID, ENUM, BIT, TIMESTAMP_S, TIMESTAMP_MS, TIMESTAMP_NS, TIMESTAMP_TZ,
+--   TIME_TZ, LIST
+-- `duckdb_value_varchar` on an unsupported type either returns NULL with no
+-- failure signal, or the client raises a typed error - neither is a column
+-- type any writer should be allowed to introduce silently, so
+-- duckdb-parity.test.ts scans every column type token in this file against
+-- this exact list.
+--
+-- NUL-BYTE CONTRACT. Text columns must never contain NUL bytes - the FFI
+-- client's CString decode truncates at the first NUL, silently dropping
+-- everything after it. Ingest writers must strip or escape NUL bytes before
+-- insert (enforcement lands with the wave-2 writers, not in this DDL).
 --
 -- SEMANTICS (P2-2): `VALUE time::now()` cannot be expressed in DDL. Surreal's
 -- `VALUE` clause OVERWRITES whatever the caller supplies, on every create AND every
@@ -119,9 +145,9 @@ CREATE TABLE IF NOT EXISTS skill (
     description VARCHAR,  -- parsed from frontmatter; body + raw frontmatter read from dir_path on demand
     content_hash VARCHAR NOT NULL,
     bytes BIGINT,
-    ingested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    last_seen_at TIMESTAMPTZ,  -- reconcile: stamped when present on disk
-    deleted_at TIMESTAMPTZ  -- reconcile: soft tombstone when absent on disk
+    ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at TIMESTAMP,  -- reconcile: stamped when present on disk
+    deleted_at TIMESTAMP  -- reconcile: soft tombstone when absent on disk
 );
 CREATE UNIQUE INDEX IF NOT EXISTS skill_name_uq ON skill(name);
 CREATE INDEX IF NOT EXISTS skill_scope ON skill(scope);
@@ -141,7 +167,7 @@ CREATE TABLE IF NOT EXISTS skill_revision (
     bytes BIGINT,
     prev_bytes BIGINT,
     change VARCHAR NOT NULL,  -- 'added' | 'changed'
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS skill_revision_ts ON skill_revision(ts);
 CREATE INDEX IF NOT EXISTS skill_revision_skill ON skill_revision(skill);
@@ -157,12 +183,12 @@ CREATE TABLE IF NOT EXISTS agent_def (
     dir_path VARCHAR NOT NULL,
     description VARCHAR,
     model VARCHAR,
-    skills VARCHAR[],  -- declared skills: frontmatter list (P2-3: native list, not JSON)
+    skills VARCHAR,  -- JSON-encoded; declared skills: frontmatter list (P2-3 reverted: JSON, not native list)
     content_hash VARCHAR NOT NULL,
     bytes BIGINT,
-    ingested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    last_seen_at TIMESTAMPTZ,
-    deleted_at TIMESTAMPTZ
+    ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at TIMESTAMP,
+    deleted_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS agent_def_name_uq ON agent_def(name);
 CREATE INDEX IF NOT EXISTS agent_def_scope ON agent_def(scope);
@@ -174,8 +200,8 @@ CREATE TABLE IF NOT EXISTS session (
     model VARCHAR,
     reasoning_effort VARCHAR,  -- codex: turn_context effort (minimal|low|medium|high|xhigh, last seen); claude: settings.json effortLevel (high|medium|low), stamped only on sessions active at ingest time
     source VARCHAR NOT NULL DEFAULT 'claude',  -- 'claude' | 'codex'
-    started_at TIMESTAMPTZ,
-    ended_at TIMESTAMPTZ,
+    started_at TIMESTAMP,
+    ended_at TIMESTAMP,
     raw_file VARCHAR,  -- f"transcripts:/<id>.jsonl" pointer; full original jsonl
     labels VARCHAR,  -- JSON string[]; e.g. ["spar"]; spar-score stamps variant sessions
     repository VARCHAR,  -- ref -> repository
@@ -200,12 +226,12 @@ CREATE TABLE IF NOT EXISTS claude_sidecar_artifact (
     safe_relative_path VARCHAR NOT NULL,
     path_hash VARCHAR NOT NULL,
     size BIGINT NOT NULL,
-    mtime TIMESTAMPTZ NOT NULL,
+    mtime TIMESTAMP NOT NULL,
     content_hash VARCHAR,
     session VARCHAR,  -- ref -> session
     relation_ids_json VARCHAR,
     relation_attrs_json VARCHAR,
-    observed_at TIMESTAMPTZ NOT NULL,
+    observed_at TIMESTAMP NOT NULL,
     excerpt VARCHAR,
     attrs_json VARCHAR
 );
@@ -229,7 +255,7 @@ CREATE TABLE IF NOT EXISTS used_sidecar_artifact (
     pattern VARCHAR,
     "offset" BIGINT,
     "limit" BIGINT,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS used_sidecar_artifact_in ON used_sidecar_artifact(in_id);
 CREATE INDEX IF NOT EXISTS used_sidecar_artifact_out ON used_sidecar_artifact(out_id);
@@ -241,8 +267,8 @@ CREATE TABLE IF NOT EXISTS agent_provider (
     display_name VARCHAR NOT NULL,
     version VARCHAR,
     capabilities VARCHAR,  -- JSON-encoded
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS agent_provider_name_uq ON agent_provider(name);
 
@@ -262,8 +288,8 @@ CREATE TABLE IF NOT EXISTS agent_model (
     fast_multiplier DOUBLE,
     context_window BIGINT,
     pricing_source VARCHAR,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS agent_model_name_uq ON agent_model(name);
 CREATE INDEX IF NOT EXISTS agent_model_provider ON agent_model(provider);
@@ -281,10 +307,10 @@ CREATE TABLE IF NOT EXISTS agent_session (
     raw VARCHAR,  -- JSON-encoded
     labels VARCHAR,  -- JSON-encoded
     metrics VARCHAR,  -- JSON-encoded
-    started_at TIMESTAMPTZ,
-    ended_at TIMESTAMPTZ,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    started_at TIMESTAMP,
+    ended_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS agent_session_provider_id ON agent_session(provider, provider_session_id);
 CREATE INDEX IF NOT EXISTS agent_session_ax_session ON agent_session(ax_session);
@@ -297,7 +323,7 @@ CREATE TABLE IF NOT EXISTS agent_event (
     provider_event_id VARCHAR,
     parent_provider_event_id VARCHAR,
     seq BIGINT NOT NULL,
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     type VARCHAR NOT NULL,
     role VARCHAR,
     text VARCHAR,
@@ -315,7 +341,7 @@ CREATE TABLE IF NOT EXISTS turn (
     session VARCHAR NOT NULL,  -- ref -> session; was: REFERENCE ON DELETE CASCADE
     agent_event VARCHAR,  -- ref -> agent_event
     seq BIGINT NOT NULL,
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     role VARCHAR NOT NULL,  -- 'user' | 'assistant' | 'tool_result'
     message_kind VARCHAR,  -- 'task' | 'context' | 'control' | 'tool_result' | 'system_or_developer' | 'assistant' | 'tool_call'
     intent_kind VARCHAR,  -- 'organic_task' | 'correction' | 'preference' | 'wrapper_instruction' | ...
@@ -350,7 +376,7 @@ CREATE TABLE IF NOT EXISTS symbol (
     id VARCHAR PRIMARY KEY,
     name VARCHAR NOT NULL,
     kind VARCHAR,  -- 'camel' | 'snake' | 'function' | ...
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS symbol_name_uq ON symbol(name);
 
@@ -358,7 +384,7 @@ CREATE TABLE IF NOT EXISTS error_signature (
     id VARCHAR PRIMARY KEY,
     text VARCHAR NOT NULL,
     normalized VARCHAR NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS error_signature_norm_uq ON error_signature(normalized);
 
@@ -368,7 +394,7 @@ CREATE TABLE IF NOT EXISTS "commit" (
     repo VARCHAR NOT NULL,
     message VARCHAR,
     author VARCHAR,
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     repository VARCHAR,  -- ref -> repository
     checkout VARCHAR,  -- ref -> checkout
     -- option<bool>, not bool DEFAULT false: the git stage re-UPSERTs commits via
@@ -388,8 +414,8 @@ CREATE TABLE IF NOT EXISTS repository (
     root_path VARCHAR,
     initial_commit VARCHAR,
     default_branch VARCHAR,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS repository_remote ON repository(remote_url);
 CREATE INDEX IF NOT EXISTS repository_initial_commit ON repository(initial_commit);
@@ -402,8 +428,8 @@ CREATE TABLE IF NOT EXISTS checkout (
     head_sha VARCHAR,
     worktree_name VARCHAR,
     dirty BOOLEAN NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS checkout_path_uq ON checkout(repository, path);
 
@@ -413,8 +439,8 @@ CREATE TABLE IF NOT EXISTS workspace (
     checkout VARCHAR,  -- ref -> checkout
     root_path VARCHAR NOT NULL,
     name VARCHAR,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS tool (
@@ -424,8 +450,8 @@ CREATE TABLE IF NOT EXISTS tool (
     identity VARCHAR,
     kind VARCHAR,
     labels VARCHAR,  -- JSON-encoded
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS tool_identity_uq ON tool(provider, name, identity);
 
@@ -436,7 +462,7 @@ CREATE TABLE IF NOT EXISTS tool_call (
     turn VARCHAR,  -- ref -> turn
     tool VARCHAR,  -- ref -> tool
     name VARCHAR NOT NULL,
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     status VARCHAR,
     input_json VARCHAR,  -- JSON-encoded
     output_json VARCHAR,  -- JSON-encoded
@@ -479,7 +505,7 @@ CREATE TABLE IF NOT EXISTS has_content (
     fine_label VARCHAR,
     bytes BIGINT NOT NULL DEFAULT 0,
     session VARCHAR,  -- ref -> session
-    ts TIMESTAMPTZ NOT NULL
+    ts TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS has_content_in ON has_content(in_id);
 CREATE INDEX IF NOT EXISTS has_content_out ON has_content(out_id);
@@ -493,8 +519,8 @@ CREATE TABLE IF NOT EXISTS plan (
     summary VARCHAR,
     status VARCHAR,
     items VARCHAR,  -- JSON-encoded
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS plan_session ON plan(session);
 CREATE INDEX IF NOT EXISTS plan_source_session ON plan(source, session);
@@ -508,10 +534,10 @@ CREATE TABLE IF NOT EXISTS plan_item (
     active_form VARCHAR,
     status VARCHAR,
     raw VARCHAR,  -- JSON-encoded
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ,
-    first_seen_at TIMESTAMPTZ,
-    last_seen_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP,
+    first_seen_at TIMESTAMP,
+    last_seen_at TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS plan_item_plan_seq ON plan_item(plan, seq);
 
@@ -523,8 +549,8 @@ CREATE TABLE IF NOT EXISTS artifact (
     path VARCHAR,
     content_hash VARCHAR,
     raw VARCHAR,  -- JSON-encoded
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS artifact_hash ON artifact(content_hash);
 
@@ -552,7 +578,7 @@ CREATE TABLE IF NOT EXISTS content_document (
     raw VARCHAR,
     labels VARCHAR,
     metrics VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS content_document_source ON content_document(source_kind, source_ref);
 CREATE INDEX IF NOT EXISTS content_document_hash ON content_document(content_hash);
@@ -582,7 +608,7 @@ CREATE TABLE IF NOT EXISTS content_block (
     raw VARCHAR,
     labels VARCHAR,
     metrics VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS content_block_document_seq ON content_block(document, seq);
 CREATE INDEX IF NOT EXISTS content_block_kind ON content_block(kind, ts);
@@ -604,7 +630,7 @@ CREATE TABLE IF NOT EXISTS content_atom (
     end_offset BIGINT,
     confidence DOUBLE NOT NULL DEFAULT 1.0,
     raw VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS content_atom_kind_value ON content_atom(kind, normalized);
 CREATE INDEX IF NOT EXISTS content_atom_block ON content_atom(block);
@@ -622,7 +648,7 @@ CREATE TABLE IF NOT EXISTS mentions_file (
     confidence DOUBLE NOT NULL DEFAULT 1.0,
     source_kind VARCHAR NOT NULL,
     workspace VARCHAR,  -- ref -> workspace
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS mentions_file_in ON mentions_file(in_id);
 CREATE INDEX IF NOT EXISTS mentions_file_out ON mentions_file(out_id);
@@ -637,7 +663,7 @@ CREATE TABLE IF NOT EXISTS mentions_commit (
     confidence DOUBLE NOT NULL DEFAULT 1.0,
     source_kind VARCHAR NOT NULL,
     workspace VARCHAR,  -- ref -> workspace
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS mentions_commit_in ON mentions_commit(in_id);
 CREATE INDEX IF NOT EXISTS mentions_commit_out ON mentions_commit(out_id);
@@ -650,7 +676,7 @@ CREATE TABLE IF NOT EXISTS mentions_artifact (
     block VARCHAR NOT NULL,  -- ref -> content_block
     confidence DOUBLE NOT NULL DEFAULT 1.0,
     source_kind VARCHAR NOT NULL,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS mentions_artifact_in ON mentions_artifact(in_id);
 CREATE INDEX IF NOT EXISTS mentions_artifact_out ON mentions_artifact(out_id);
@@ -665,7 +691,7 @@ CREATE TABLE IF NOT EXISTS plan_snapshot (
     items VARCHAR NOT NULL,  -- JSON-encoded
     summary VARCHAR,
     explanation VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS plan_snapshot_plan_ts ON plan_snapshot(plan, ts);
 CREATE INDEX IF NOT EXISTS plan_snapshot_agent_event ON plan_snapshot(agent_event);
@@ -675,7 +701,7 @@ CREATE TABLE IF NOT EXISTS compaction (
     session VARCHAR NOT NULL,  -- ref -> session
     agent_event VARCHAR,  -- ref -> agent_event
     harness VARCHAR NOT NULL,  -- provider name: claude|codex|pi|cursor|opencode
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     trigger VARCHAR,  -- auto|manual|hook
     strategy VARCHAR NOT NULL,  -- summarize|history_replacement|encrypted
     source_confidence VARCHAR NOT NULL,  -- explicit|derived
@@ -698,7 +724,7 @@ CREATE TABLE IF NOT EXISTS insight (
     text VARCHAR NOT NULL,
     labels VARCHAR,  -- JSON-encoded
     metrics VARCHAR,  -- JSON-encoded
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS insight_subject ON insight(subject_type, subject_id);
 
@@ -711,7 +737,7 @@ CREATE TABLE IF NOT EXISTS friction_event (
     labels VARCHAR,  -- JSON-encoded
     metrics VARCHAR,  -- JSON-encoded
     raw VARCHAR,  -- JSON-encoded
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS friction_session_kind ON friction_event(session, kind);
 
@@ -727,8 +753,8 @@ CREATE TABLE IF NOT EXISTS turn_analysis (
     method VARCHAR NOT NULL,
     signals VARCHAR,  -- JSON-encoded
     text VARCHAR,
-    ts TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS turn_analysis_turn ON turn_analysis(turn);
 CREATE INDEX IF NOT EXISTS turn_analysis_session_act ON turn_analysis(session, act);
@@ -749,8 +775,8 @@ CREATE TABLE IF NOT EXISTS reaction_event (
     user_text VARCHAR,
     assistant_text VARCHAR,
     context_json VARCHAR,  -- JSON-encoded
-    ts TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS reaction_event_user_turn ON reaction_event(user_turn);
 CREATE INDEX IF NOT EXISTS reaction_event_session_ts ON reaction_event(session, ts);
@@ -765,14 +791,14 @@ CREATE TABLE IF NOT EXISTS classifier_definition (
     input VARCHAR NOT NULL,
     labels VARCHAR NOT NULL,  -- JSON-encoded
     targets VARCHAR NOT NULL,  -- JSON-encoded
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS classifier_definition_key_version ON classifier_definition(classifier_key, version);
 
 CREATE TABLE IF NOT EXISTS classifier_run (
     id VARCHAR PRIMARY KEY,
-    started_at TIMESTAMPTZ NOT NULL,
-    finished_at TIMESTAMPTZ,
+    started_at TIMESTAMP NOT NULL,
+    finished_at TIMESTAMP,
     status VARCHAR NOT NULL,
     classifier_keys VARCHAR NOT NULL,  -- JSON-encoded
     since_days BIGINT,
@@ -799,8 +825,8 @@ CREATE TABLE IF NOT EXISTS classifier_result (
     method VARCHAR NOT NULL,
     evidence_json VARCHAR NOT NULL,
     signals VARCHAR,  -- JSON-encoded
-    ts TIMESTAMPTZ NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS classifier_result_classifier ON classifier_result(classifier_key, classifier_version);
 CREATE INDEX IF NOT EXISTS classifier_result_turn ON classifier_result(turn);
@@ -813,7 +839,7 @@ CREATE TABLE IF NOT EXISTS classifier_graph_node (
     label VARCHAR NOT NULL,
     properties_json VARCHAR NOT NULL,
     source_kind VARCHAR NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS classifier_graph_node_graph_id ON classifier_graph_node(graph_id);
 CREATE INDEX IF NOT EXISTS classifier_graph_node_kind ON classifier_graph_node(kind);
@@ -827,7 +853,7 @@ CREATE TABLE IF NOT EXISTS classifier_graph_edge (
     evidence_path VARCHAR NOT NULL,
     properties_json VARCHAR NOT NULL,
     source_kind VARCHAR NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS classifier_graph_edge_graph_id ON classifier_graph_edge(graph_id);
 CREATE INDEX IF NOT EXISTS classifier_graph_edge_kind ON classifier_graph_edge(kind);
@@ -845,7 +871,7 @@ CREATE TABLE IF NOT EXISTS classifier_graph_fact (
     evidence_edges_json VARCHAR NOT NULL,
     properties_json VARCHAR NOT NULL,
     source_kind VARCHAR NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS classifier_graph_fact_graph_id ON classifier_graph_fact(graph_id);
 CREATE INDEX IF NOT EXISTS classifier_graph_fact_kind ON classifier_graph_fact(kind);
@@ -869,7 +895,7 @@ CREATE TABLE IF NOT EXISTS transcript_label_review (
     reviewer VARCHAR NOT NULL,
     rationale VARCHAR NOT NULL,
     evidence_paths_json VARCHAR NOT NULL,  -- JSON-encoded
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS transcript_label_review_candidate ON transcript_label_review(candidate_id);
 CREATE INDEX IF NOT EXISTS transcript_label_review_graph_fact ON transcript_label_review(graph_fact_id);
@@ -885,7 +911,7 @@ CREATE TABLE IF NOT EXISTS transcript_label_vector (
     embedding_ref VARCHAR NOT NULL,
     nearest_reviewed_candidate_ids_json VARCHAR NOT NULL,  -- JSON-encoded
     nearest_scores_json VARCHAR NOT NULL,  -- JSON-encoded
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS transcript_label_vector_candidate ON transcript_label_vector(candidate_id);
 CREATE INDEX IF NOT EXISTS transcript_label_vector_graph_fact ON transcript_label_vector(graph_fact_id);
@@ -899,8 +925,8 @@ CREATE TABLE IF NOT EXISTS semantic_signal (
     description VARCHAR,
     method VARCHAR NOT NULL,
     confidence DOUBLE NOT NULL,
-    first_seen TIMESTAMPTZ,
-    last_seen TIMESTAMPTZ,
+    first_seen TIMESTAMP,
+    last_seen TIMESTAMP,
     metrics VARCHAR  -- JSON-encoded
 );
 CREATE UNIQUE INDEX IF NOT EXISTS semantic_signal_kind_label ON semantic_signal(kind, label);
@@ -915,7 +941,7 @@ CREATE TABLE IF NOT EXISTS diagnostic_event (
     labels VARCHAR,  -- JSON-encoded
     metrics VARCHAR,  -- JSON-encoded
     raw VARCHAR,  -- JSON-encoded
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS diagnostic_session_kind ON diagnostic_event(session, kind);
 
@@ -925,8 +951,8 @@ CREATE TABLE IF NOT EXISTS guidance (
     title VARCHAR,
     status VARCHAR NOT NULL DEFAULT 'active',
     labels VARCHAR,  -- JSON-encoded
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS guidance_slug_uq ON guidance(slug);
 CREATE INDEX IF NOT EXISTS guidance_status ON guidance(status);
@@ -937,7 +963,7 @@ CREATE TABLE IF NOT EXISTS guidance_version (
     version VARCHAR NOT NULL,
     text VARCHAR NOT NULL,
     raw VARCHAR,  -- JSON-encoded
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     status VARCHAR NOT NULL DEFAULT 'proposed',
     scope VARCHAR,
     risk VARCHAR,
@@ -957,7 +983,7 @@ CREATE TABLE IF NOT EXISTS guidance_source (
     evidence_strength VARCHAR NOT NULL,
     git_root VARCHAR,
     tracked BOOLEAN NOT NULL DEFAULT FALSE,
-    observed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    observed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS guidance_source_path_uq ON guidance_source(path);
 CREATE INDEX IF NOT EXISTS guidance_source_scope ON guidance_source(scope, provider);
@@ -975,7 +1001,7 @@ CREATE TABLE IF NOT EXISTS guidance_revision (
     evidence_strength VARCHAR NOT NULL,
     commit_evidence VARCHAR,
     file_evidence VARCHAR,
-    observed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    observed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS guidance_revision_source_hash ON guidance_revision(source_path, content_hash);
 CREATE INDEX IF NOT EXISTS guidance_revision_scope ON guidance_revision(scope, observed_at);
@@ -1010,7 +1036,7 @@ CREATE TABLE IF NOT EXISTS guidance_config_artifact (
     permission_ask_count BIGINT NOT NULL,
     permission_deny_count BIGINT NOT NULL,
     metadata_json VARCHAR,
-    observed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    observed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS guidance_config_artifact_path_hash ON guidance_config_artifact(provider, path_hash);
 CREATE INDEX IF NOT EXISTS guidance_config_artifact_kind_scope ON guidance_config_artifact(provider, kind, scope);
@@ -1022,8 +1048,8 @@ CREATE TABLE IF NOT EXISTS stack (
     name VARCHAR NOT NULL,
     aliases VARCHAR,  -- JSON-encoded
     labels VARCHAR,  -- JSON-encoded
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS stack_name_uq ON stack(name);
 
@@ -1038,7 +1064,7 @@ CREATE TABLE IF NOT EXISTS command_outcome (
     text VARCHAR,
     labels VARCHAR,  -- JSON-encoded
     metrics VARCHAR,  -- JSON-encoded
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS command_outcome_kind_ts ON command_outcome(kind, ts);
 CREATE INDEX IF NOT EXISTS command_outcome_session ON command_outcome(session, ts);
@@ -1053,8 +1079,8 @@ CREATE TABLE IF NOT EXISTS user_message_ngram (
     near_failed_tool_count BIGINT NOT NULL DEFAULT 0,
     near_edit_count BIGINT NOT NULL DEFAULT 0,
     near_verification_count BIGINT NOT NULL DEFAULT 0,
-    first_seen TIMESTAMPTZ,
-    last_seen TIMESTAMPTZ
+    first_seen TIMESTAMP,
+    last_seen TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS user_message_ngram_n_count ON user_message_ngram(n, count);
 CREATE INDEX IF NOT EXISTS user_message_ngram_text ON user_message_ngram(ngram);
@@ -1062,8 +1088,8 @@ CREATE INDEX IF NOT EXISTS user_message_ngram_text ON user_message_ngram(ngram);
 CREATE TABLE IF NOT EXISTS workflow_epoch (
     id VARCHAR PRIMARY KEY,
     name VARCHAR NOT NULL,
-    starts_at TIMESTAMPTZ,
-    ends_at TIMESTAMPTZ,
+    starts_at TIMESTAMP,
+    ends_at TIMESTAMP,
     evidence_kind VARCHAR,
     evidence_ref VARCHAR,
     notes VARCHAR
@@ -1094,7 +1120,7 @@ CREATE TABLE IF NOT EXISTS session_token_usage (
     labels VARCHAR,  -- JSON-encoded
     metrics VARCHAR,  -- JSON-encoded
     burn_buckets VARCHAR,  -- JSON-encoded number[]; sessions-list BURN sparkline
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS session_token_usage_session ON session_token_usage(session);
 CREATE INDEX IF NOT EXISTS session_token_usage_epoch ON session_token_usage(workflow_epoch, source, ts);
@@ -1124,7 +1150,7 @@ CREATE TABLE IF NOT EXISTS turn_token_usage (
     usage_source VARCHAR NOT NULL,
     usage_quality VARCHAR NOT NULL,
     raw VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS turn_token_usage_turn ON turn_token_usage(turn);
 CREATE INDEX IF NOT EXISTS turn_token_usage_session_seq ON turn_token_usage(session, seq);
@@ -1155,7 +1181,7 @@ CREATE TABLE IF NOT EXISTS session_health (
     correction_turns BIGINT NOT NULL DEFAULT 0,
     labels VARCHAR,  -- JSON-encoded
     metrics VARCHAR,  -- JSON-encoded
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS session_health_session ON session_health(session);
 CREATE INDEX IF NOT EXISTS session_health_epoch ON session_health(workflow_epoch, source, ts);
@@ -1172,7 +1198,7 @@ CREATE TABLE IF NOT EXISTS session_metrics (
     time_to_first_edit_ms BIGINT,
     cold_start_reads BIGINT NOT NULL DEFAULT 0,
     delegation_ratio DOUBLE,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS session_metrics_session ON session_metrics(session);
 
@@ -1189,7 +1215,7 @@ CREATE TABLE IF NOT EXISTS fragility_cascade (
     origin VARCHAR NOT NULL,  -- ref -> session
     downstream VARCHAR NOT NULL,  -- ref -> session
     weight BIGINT NOT NULL DEFAULT 0,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS fragility_cascade_pair ON fragility_cascade(origin, downstream);
 
@@ -1202,7 +1228,7 @@ CREATE TABLE IF NOT EXISTS commit_classification (
     message VARCHAR,
     labels VARCHAR,  -- JSON-encoded
     metrics VARCHAR,  -- JSON-encoded
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS commit_classification_commit ON commit_classification(commit);
 CREATE INDEX IF NOT EXISTS commit_classification_kind_ts ON commit_classification(kind, ts);
@@ -1214,8 +1240,8 @@ CREATE TABLE IF NOT EXISTS branch (
     head_sha VARCHAR,
     upstream VARCHAR,
     is_default BOOLEAN NOT NULL DEFAULT FALSE,
-    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    last_seen_at TIMESTAMPTZ
+    first_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS branch_repo_name ON branch(repository, name);
 
@@ -1232,16 +1258,16 @@ CREATE TABLE IF NOT EXISTS pull_request (
     merge_sha VARCHAR,
     author VARCHAR,
     url VARCHAR,
-    opened_at TIMESTAMPTZ,
-    closed_at TIMESTAMPTZ,
-    merged_at TIMESTAMPTZ,
+    opened_at TIMESTAMP,
+    closed_at TIMESTAMP,
+    merged_at TIMESTAMP,
     additions BIGINT NOT NULL DEFAULT 0,
     deletions BIGINT NOT NULL DEFAULT 0,
     changed_files BIGINT NOT NULL DEFAULT 0,
     commit_count BIGINT NOT NULL DEFAULT 0,
     labels VARCHAR,
     raw VARCHAR,
-    updated_at TIMESTAMPTZ
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS pull_request_repo_number ON pull_request(repository, number);
 CREATE INDEX IF NOT EXISTS pull_request_state ON pull_request(repository, state, updated_at);
@@ -1258,7 +1284,7 @@ CREATE TABLE IF NOT EXISTS review_event (
     category VARCHAR NOT NULL DEFAULT 'unknown',
     unresolved BOOLEAN NOT NULL DEFAULT FALSE,
     raw VARCHAR,
-    ts TIMESTAMPTZ NOT NULL
+    ts TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS review_event_pr_ts ON review_event(pull_request, ts);
 CREATE INDEX IF NOT EXISTS review_event_severity ON review_event(repository, severity, ts);
@@ -1274,8 +1300,8 @@ CREATE TABLE IF NOT EXISTS check_run (
     conclusion VARCHAR,
     url VARCHAR,
     raw VARCHAR,
-    started_at TIMESTAMPTZ,
-    completed_at TIMESTAMPTZ
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS check_run_pr ON check_run(pull_request, status, conclusion);
 CREATE INDEX IF NOT EXISTS check_run_commit ON check_run(commit, status, conclusion);
@@ -1296,8 +1322,8 @@ CREATE TABLE IF NOT EXISTS delivery_outcome (
     phase_metrics VARCHAR,
     confidence VARCHAR NOT NULL DEFAULT 'medium',
     evidence VARCHAR,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS delivery_session ON delivery_outcome(session);
 CREATE INDEX IF NOT EXISTS delivery_pr ON delivery_outcome(pull_request);
@@ -1305,7 +1331,7 @@ CREATE INDEX IF NOT EXISTS delivery_status ON delivery_outcome(repository, statu
 
 CREATE TABLE IF NOT EXISTS workflow_snapshot (
     id VARCHAR PRIMARY KEY,
-    generated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    generated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     payload VARCHAR NOT NULL,
     source VARCHAR NOT NULL DEFAULT 'workflow-refresh'
 );
@@ -1317,8 +1343,8 @@ CREATE TABLE IF NOT EXISTS phase_span (
     phase VARCHAR NOT NULL,
     start_turn VARCHAR,  -- ref -> turn
     end_turn VARCHAR,  -- ref -> turn
-    start_ts TIMESTAMPTZ NOT NULL,
-    end_ts TIMESTAMPTZ NOT NULL,
+    start_ts TIMESTAMP NOT NULL,
+    end_ts TIMESTAMP NOT NULL,
     duration_ms BIGINT NOT NULL,
     user_turns BIGINT NOT NULL DEFAULT 0,
     assistant_turns BIGINT NOT NULL DEFAULT 0,
@@ -1344,7 +1370,7 @@ CREATE TABLE IF NOT EXISTS skill_candidate (
     status VARCHAR NOT NULL DEFAULT 'candidate',
     labels VARCHAR,  -- JSON-encoded
     metrics VARCHAR,  -- JSON-encoded
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS skill_candidate_name ON skill_candidate(name);
 CREATE INDEX IF NOT EXISTS skill_candidate_status ON skill_candidate(status, created_at);
@@ -1353,11 +1379,11 @@ CREATE TABLE IF NOT EXISTS ingest_run (
     command VARCHAR NOT NULL,
     status VARCHAR NOT NULL DEFAULT 'running',
     since_days BIGINT,
-    started_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     -- Heartbeat: bumped on every stage start/finish so a genuinely-live "running"
     -- run is distinguishable from one stranded by a crash (doctor stale-run check).
-    last_progress_at TIMESTAMPTZ,
-    ended_at TIMESTAMPTZ,
+    last_progress_at TIMESTAMP,
+    ended_at TIMESTAMP,
     metrics VARCHAR  -- JSON
 );
 CREATE INDEX IF NOT EXISTS ingest_run_status_started ON ingest_run(status, started_at);
@@ -1368,8 +1394,8 @@ CREATE TABLE IF NOT EXISTS ingest_stage (
     source VARCHAR NOT NULL,
     stage VARCHAR NOT NULL,
     status VARCHAR NOT NULL DEFAULT 'running',
-    started_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    ended_at TIMESTAMPTZ,
+    started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ended_at TIMESTAMP,
     counts VARCHAR,  -- JSON
     error_text VARCHAR
 );
@@ -1384,7 +1410,7 @@ CREATE TABLE IF NOT EXISTS ingest_event (
     message VARCHAR NOT NULL,
     counts VARCHAR,  -- JSON
     raw VARCHAR,  -- JSON
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS ingest_event_run_ts ON ingest_event(run, ts);
 CREATE INDEX IF NOT EXISTS ingest_event_source_ts ON ingest_event(source, ts);
@@ -1397,7 +1423,7 @@ CREATE TABLE IF NOT EXISTS query_sample (
     duration_ms BIGINT,
     error_text VARCHAR,
     row_count BIGINT,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS graph_health_check (
@@ -1406,7 +1432,7 @@ CREATE TABLE IF NOT EXISTS graph_health_check (
     status VARCHAR NOT NULL,
     count BIGINT NOT NULL DEFAULT 0,
     rows VARCHAR,  -- JSON
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS graph_health_kind_created ON graph_health_check(kind, created_at);
 
@@ -1432,7 +1458,7 @@ CREATE TABLE IF NOT EXISTS plays_role (
     source VARCHAR NOT NULL,
     weight DOUBLE,
     rationale VARCHAR,
-    since TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    since TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS plays_role_in ON plays_role(in_id);
 CREATE INDEX IF NOT EXISTS plays_role_out ON plays_role(out_id);
@@ -1445,7 +1471,7 @@ CREATE TABLE IF NOT EXISTS invoked (
     in_id VARCHAR NOT NULL,  -- ref -> turn
     out_id VARCHAR NOT NULL,  -- ref -> skill
     args VARCHAR,  -- JSON
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     -- Denormalised source session. Session-detail top-skills must avoid
     -- dereferencing the source turn's session across every invoked edge for
     -- large sessions.
@@ -1477,7 +1503,7 @@ CREATE TABLE IF NOT EXISTS loaded (
     id VARCHAR PRIMARY KEY,
     in_id VARCHAR NOT NULL,  -- ref -> session
     out_id VARCHAR NOT NULL,  -- ref -> skill
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     agent VARCHAR,  -- the scoping agent
     source VARCHAR NOT NULL DEFAULT 'frontmatter'
 );
@@ -1489,7 +1515,7 @@ CREATE TABLE IF NOT EXISTS proposed (
     id VARCHAR PRIMARY KEY,
     in_id VARCHAR NOT NULL,  -- ref -> turn
     out_id VARCHAR NOT NULL,  -- ref -> skill
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     context_excerpt VARCHAR
 );
 -- proposed-but-never-invoked counts traverse the skill side.
@@ -1502,7 +1528,7 @@ CREATE TABLE IF NOT EXISTS edited (
     in_id VARCHAR NOT NULL,  -- ref -> turn
     out_id VARCHAR NOT NULL,  -- ref -> file
     tool VARCHAR NOT NULL,  -- 'Edit'|'Write'|'NotebookEdit'
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     checkout VARCHAR,  -- ref -> checkout
     path_seen VARCHAR,
     absolute_path_seen VARCHAR,
@@ -1523,7 +1549,7 @@ CREATE TABLE IF NOT EXISTS mentioned_file (
     source VARCHAR NOT NULL DEFAULT 'text',  -- 'text' | 'tool_input' | 'tool_output'
     confidence DOUBLE,
     excerpt VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS mentioned_file_in ON mentioned_file(in_id);
 CREATE INDEX IF NOT EXISTS mentioned_file_out ON mentioned_file(out_id);
@@ -1536,7 +1562,7 @@ CREATE TABLE IF NOT EXISTS mentioned_symbol (
     source VARCHAR NOT NULL DEFAULT 'text',
     confidence DOUBLE,
     excerpt VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS mentioned_symbol_in ON mentioned_symbol(in_id);
 CREATE INDEX IF NOT EXISTS mentioned_symbol_out ON mentioned_symbol(out_id);
@@ -1548,7 +1574,7 @@ CREATE TABLE IF NOT EXISTS mentioned_error (
     source VARCHAR NOT NULL DEFAULT 'text',
     confidence DOUBLE,
     excerpt VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS mentioned_error_in ON mentioned_error(in_id);
 CREATE INDEX IF NOT EXISTS mentioned_error_out ON mentioned_error(out_id);
@@ -1561,7 +1587,7 @@ CREATE TABLE IF NOT EXISTS read_file (
     path_seen VARCHAR,
     absolute_path_seen VARCHAR,
     excerpt VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS read_file_in ON read_file(in_id);
 CREATE INDEX IF NOT EXISTS read_file_out ON read_file(out_id);
@@ -1574,7 +1600,7 @@ CREATE TABLE IF NOT EXISTS searched_file (
     path_seen VARCHAR,
     absolute_path_seen VARCHAR,
     excerpt VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS searched_file_in ON searched_file(in_id);
 CREATE INDEX IF NOT EXISTS searched_file_out ON searched_file(out_id);
@@ -1585,7 +1611,7 @@ CREATE TABLE IF NOT EXISTS corrected_by (
     in_id VARCHAR NOT NULL,  -- ref -> turn
     out_id VARCHAR NOT NULL,  -- ref -> turn
     pattern VARCHAR,  -- which negation pattern matched
-    ts TIMESTAMPTZ NOT NULL
+    ts TIMESTAMP NOT NULL
 );
 -- correction-rate lookups walk the assistant turn that was corrected.
 CREATE INDEX IF NOT EXISTS corrected_by_in ON corrected_by(in_id);
@@ -1599,7 +1625,7 @@ CREATE TABLE IF NOT EXISTS expresses (
     session VARCHAR,  -- ref -> session
     confidence DOUBLE NOT NULL,
     method VARCHAR NOT NULL,
-    ts TIMESTAMPTZ NOT NULL
+    ts TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS expresses_in ON expresses(in_id);
 CREATE INDEX IF NOT EXISTS expresses_out ON expresses(out_id);
@@ -1614,7 +1640,7 @@ CREATE TABLE IF NOT EXISTS reacts_to (
     act VARCHAR NOT NULL,
     confidence DOUBLE NOT NULL,
     signal VARCHAR,  -- ref -> semantic_signal
-    ts TIMESTAMPTZ NOT NULL
+    ts TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS reacts_to_in ON reacts_to(in_id);
 CREATE INDEX IF NOT EXISTS reacts_to_out ON reacts_to(out_id);
@@ -1628,7 +1654,7 @@ CREATE TABLE IF NOT EXISTS has_classification (
     label VARCHAR NOT NULL,
     target VARCHAR NOT NULL,
     confidence DOUBLE NOT NULL,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS has_classification_in ON has_classification(in_id);
 CREATE INDEX IF NOT EXISTS has_classification_out ON has_classification(out_id);
@@ -1639,7 +1665,7 @@ CREATE TABLE IF NOT EXISTS produced (
     out_id VARCHAR NOT NULL,  -- ref -> commit
     repository VARCHAR,  -- ref -> repository
     checkout VARCHAR,  -- ref -> checkout
-    ts TIMESTAMPTZ,
+    ts TIMESTAMP,
     source VARCHAR,
     kind VARCHAR
 );
@@ -1660,7 +1686,7 @@ CREATE TABLE IF NOT EXISTS touched (
     new_path VARCHAR,
     repository VARCHAR,  -- ref -> repository
     checkout VARCHAR,  -- ref -> checkout
-    ts TIMESTAMPTZ
+    ts TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS touched_in ON touched(in_id);
 CREATE INDEX IF NOT EXISTS touched_out ON touched(out_id);
@@ -1678,7 +1704,7 @@ CREATE TABLE IF NOT EXISTS later_fixed_by (
     days_between DOUBLE,
     confidence VARCHAR NOT NULL,
     reason VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS later_fixed_by_in ON later_fixed_by(in_id);
 CREATE INDEX IF NOT EXISTS later_fixed_by_out ON later_fixed_by(out_id);
@@ -1690,7 +1716,7 @@ CREATE TABLE IF NOT EXISTS suggests_skill (
     reason VARCHAR,
     evidence VARCHAR,  -- JSON
     confidence VARCHAR NOT NULL,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS suggests_skill_in ON suggests_skill(in_id);
 CREATE INDEX IF NOT EXISTS suggests_skill_out ON suggests_skill(out_id);
@@ -1699,7 +1725,7 @@ CREATE TABLE IF NOT EXISTS has_checkout (
     id VARCHAR PRIMARY KEY,
     in_id VARCHAR NOT NULL,  -- ref -> repository
     out_id VARCHAR NOT NULL,  -- ref -> checkout
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS has_checkout_in ON has_checkout(in_id);
 CREATE INDEX IF NOT EXISTS has_checkout_out ON has_checkout(out_id);
@@ -1720,7 +1746,7 @@ CREATE TABLE IF NOT EXISTS concerns (
     reason VARCHAR,
     labels VARCHAR,  -- JSON
     metrics VARCHAR,  -- JSON
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS concerns_in ON concerns(in_id);
 CREATE INDEX IF NOT EXISTS concerns_out ON concerns(out_id);
@@ -1734,7 +1760,7 @@ CREATE TABLE IF NOT EXISTS resulted_in (
     out_table VARCHAR NOT NULL,
     kind VARCHAR,
     labels VARCHAR,  -- JSON
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS resulted_in_in ON resulted_in(in_id);
 CREATE INDEX IF NOT EXISTS resulted_in_out ON resulted_in(out_id);
@@ -1747,7 +1773,7 @@ CREATE TABLE IF NOT EXISTS produced_artifact (
     out_table VARCHAR NOT NULL,
     kind VARCHAR,
     labels VARCHAR,  -- JSON
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS produced_artifact_in ON produced_artifact(in_id);
 CREATE INDEX IF NOT EXISTS produced_artifact_out ON produced_artifact(out_id);
@@ -1760,7 +1786,7 @@ CREATE TABLE IF NOT EXISTS has_artifact (
     out_table VARCHAR NOT NULL,
     kind VARCHAR,
     labels VARCHAR,  -- JSON
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS has_artifact_in ON has_artifact(in_id);
 CREATE INDEX IF NOT EXISTS has_artifact_out ON has_artifact(out_id);
@@ -1773,7 +1799,7 @@ CREATE TABLE IF NOT EXISTS derived_from (
     out_table VARCHAR NOT NULL,
     kind VARCHAR,
     labels VARCHAR,  -- JSON
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS derived_from_in ON derived_from(in_id);
 CREATE INDEX IF NOT EXISTS derived_from_out ON derived_from(out_id);
@@ -1784,7 +1810,7 @@ CREATE TABLE IF NOT EXISTS skill_paired (
     in_id VARCHAR NOT NULL,  -- ref -> skill
     out_id VARCHAR NOT NULL,  -- ref -> skill
     count BIGINT NOT NULL DEFAULT 1,
-    last_seen TIMESTAMPTZ NOT NULL
+    last_seen TIMESTAMP NOT NULL
 );
 -- Endpoint indexes: the dashboard skill-detail `paired` block filters by
 -- `in_id = $skill OR out_id = $skill` (apps/axctl/src/queries/skill-detail.ts).
@@ -1796,7 +1822,7 @@ CREATE TABLE IF NOT EXISTS recovered_by (
     id VARCHAR PRIMARY KEY,
     in_id VARCHAR NOT NULL,  -- ref -> turn
     out_id VARCHAR NOT NULL,  -- ref -> skill
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     error_excerpt VARCHAR
 );
 CREATE INDEX IF NOT EXISTS recovered_by_in ON recovered_by(in_id);
@@ -1814,7 +1840,7 @@ CREATE TABLE IF NOT EXISTS spawned (
     id VARCHAR PRIMARY KEY,
     in_id VARCHAR NOT NULL,  -- ref -> session
     out_id VARCHAR NOT NULL,  -- ref -> session
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     tool VARCHAR,  -- e.g. "spawn_agent" | "Task"
     tool_call VARCHAR,  -- ref -> tool_call
     nickname VARCHAR,  -- codex assigns "Turing", "Babbage", etc.
@@ -1834,7 +1860,7 @@ CREATE INDEX IF NOT EXISTS spawned_out ON spawned(out_id);
 -- description at query time.
 CREATE TABLE IF NOT EXISTS advice (
     id VARCHAR PRIMARY KEY,
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     session VARCHAR,  -- ref -> session (parent/advised session)
     tool VARCHAR,  -- normally "Agent"
     description VARCHAR,  -- dispatch tool_input.description (join key)
@@ -1851,7 +1877,7 @@ CREATE TABLE IF NOT EXISTS agent_event_child (
     agent_session VARCHAR NOT NULL,  -- ref -> agent_session
     provider VARCHAR NOT NULL,  -- ref -> agent_provider
     kind VARCHAR NOT NULL DEFAULT 'parent',
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS agent_event_child_in ON agent_event_child(in_id);
 CREATE INDEX IF NOT EXISTS agent_event_child_out ON agent_event_child(out_id);
@@ -1865,7 +1891,7 @@ CREATE TABLE IF NOT EXISTS used_model (
     estimated_tokens BIGINT NOT NULL DEFAULT 0,
     estimated_cost_usd DOUBLE,
     pricing_source VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS used_model_in ON used_model(in_id);
 CREATE INDEX IF NOT EXISTS used_model_out ON used_model(out_id);
@@ -1876,7 +1902,7 @@ CREATE TABLE IF NOT EXISTS agent_used_model (
     out_id VARCHAR NOT NULL,  -- ref -> agent_model
     provider VARCHAR NOT NULL,  -- ref -> agent_provider
     source VARCHAR NOT NULL,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS agent_used_model_in ON agent_used_model(in_id);
 CREATE INDEX IF NOT EXISTS agent_used_model_out ON agent_used_model(out_id);
@@ -1891,7 +1917,7 @@ CREATE TABLE IF NOT EXISTS skill_triage_decision (
     skill_name VARCHAR NOT NULL,
     decision VARCHAR NOT NULL,  -- keep | archive | review
     reason VARCHAR,
-    decided_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    decided_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS skill_triage_decision_name ON skill_triage_decision(skill_name);
 
@@ -1903,7 +1929,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS skill_triage_decision_name ON skill_triage_dec
 CREATE TABLE IF NOT EXISTS harness_hook_event (
     id VARCHAR PRIMARY KEY,
     session VARCHAR NOT NULL,  -- ref -> session
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     harness VARCHAR NOT NULL,  -- claude | codex
     event_name VARCHAR NOT NULL,  -- PreToolUse | PostToolUse | SessionStart | ...
     hook_name VARCHAR NOT NULL,  -- e.g. PreToolUse:Bash
@@ -1924,7 +1950,7 @@ CREATE TABLE IF NOT EXISTS hook_command_invocation (
     id VARCHAR PRIMARY KEY,
     hook_event VARCHAR NOT NULL,  -- ref -> harness_hook_event
     session VARCHAR NOT NULL,  -- ref -> session
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     harness VARCHAR NOT NULL,  -- claude | codex
     event_name VARCHAR NOT NULL,
     hook_name VARCHAR NOT NULL,
@@ -1954,7 +1980,7 @@ CREATE INDEX IF NOT EXISTS hook_command_invocation_by_effect ON hook_command_inv
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS ax_invocation (
     id VARCHAR PRIMARY KEY,
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     command VARCHAR NOT NULL,
     flags VARCHAR NOT NULL,
     exit_code BIGINT NOT NULL,
@@ -1980,8 +2006,8 @@ CREATE TABLE IF NOT EXISTS feedback_case_type (
     rule_kind VARCHAR NOT NULL,  -- deterministic | ai_review | hybrid
     rule_json VARCHAR NOT NULL,  -- JSON
     status VARCHAR NOT NULL DEFAULT 'active',  -- active | paused | retired
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS feedback_case_type_name ON feedback_case_type(name);
 CREATE INDEX IF NOT EXISTS feedback_case_type_status ON feedback_case_type(status);
@@ -1992,12 +2018,12 @@ CREATE TABLE IF NOT EXISTS feedback_case_result (
     target_kind VARCHAR NOT NULL,
     target VARCHAR,  -- ref -> hook_command_invocation
     session VARCHAR,  -- ref -> session
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     status VARCHAR NOT NULL,  -- passed | failed | inconclusive
     reason VARCHAR NOT NULL,
     window_json VARCHAR NOT NULL,  -- JSON (inspected window)
     evidence_json VARCHAR NOT NULL,  -- JSON (matched evidence)
-    observed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    observed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS feedback_case_result_by_case ON feedback_case_result(case_type, observed_at);
 CREATE INDEX IF NOT EXISTS feedback_case_result_by_status ON feedback_case_result(status);
@@ -2014,7 +2040,7 @@ CREATE INDEX IF NOT EXISTS feedback_case_result_by_session ON feedback_case_resu
 CREATE TABLE IF NOT EXISTS hook_fire (
     id VARCHAR PRIMARY KEY,
     -- Common telemetry base fields (mirrors packages/lib/src/telemetry-base.ts).
-    ts TIMESTAMPTZ NOT NULL,
+    ts TIMESTAMP NOT NULL,
     kind VARCHAR NOT NULL,  -- always "hook_fire"
     session VARCHAR,  -- ref -> session
     file VARCHAR,  -- ref -> file
@@ -2030,7 +2056,7 @@ CREATE TABLE IF NOT EXISTS hook_fire (
     prior_sessions_considered BIGINT NOT NULL,
     task_excerpt VARCHAR NOT NULL,  -- clipped 240 chars
     top_prior_sessions VARCHAR NOT NULL,  -- JSON session-record-id array; a record[] element type, so out of P2-3 scalar-array scope
-    injected_titles VARCHAR[] NOT NULL DEFAULT []  -- clipped titles of injected sessions (max 3, empty when inject=false); P2-3: native list
+    injected_titles VARCHAR NOT NULL DEFAULT '[]'  -- JSON-encoded; clipped titles of injected sessions (max 3, empty when inject=false); P2-3 reverted: JSON, not native list
 );
 CREATE INDEX IF NOT EXISTS hook_fire_by_ts ON hook_fire(ts);
 CREATE INDEX IF NOT EXISTS hook_fire_by_session ON hook_fire(session);
@@ -2068,8 +2094,8 @@ CREATE TABLE IF NOT EXISTS proposal (
     -- serve) producing the row that fills hypothesis_template
     reject_reason VARCHAR,
     baseline VARCHAR,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS proposal_dedupe_uq ON proposal(dedupe_sig);
 CREATE INDEX IF NOT EXISTS proposal_status_freq ON proposal(status, frequency);
@@ -2088,9 +2114,9 @@ CREATE TABLE IF NOT EXISTS directive_ngram (
     outcomes BIGINT NOT NULL DEFAULT 0, -- of those, # followed by a captured outcome
     lift DOUBLE NOT NULL DEFAULT 0, -- P(outcome|ngram)/P(outcome)
     sessions BIGINT NOT NULL DEFAULT 0, -- distinct sessions (sparsity guard)
-    first_seen TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    last_seen TIMESTAMPTZ,
-    refit_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    first_seen TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen TIMESTAMP,
+    refit_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS directive_ngram_uq ON directive_ngram(ngram);
 CREATE INDEX IF NOT EXISTS directive_ngram_lift ON directive_ngram(lift);
@@ -2115,7 +2141,7 @@ CREATE TABLE IF NOT EXISTS subagent_proposal (
     bounded_role VARCHAR NOT NULL,
     delegation_trigger VARCHAR NOT NULL,
     -- pattern matched against Task tool calls (see opportunity definition below)
-    example_task_patterns VARCHAR[] NOT NULL DEFAULT []  -- P2-3: native list, not JSON
+    example_task_patterns VARCHAR NOT NULL DEFAULT '[]'  -- JSON-encoded; P2-3 reverted: JSON, not native list
 );
 CREATE UNIQUE INDEX IF NOT EXISTS subagent_proposal_uq ON subagent_proposal(proposal);
 
@@ -2178,7 +2204,7 @@ CREATE TABLE IF NOT EXISTS cites_evidence (
     out_table VARCHAR NOT NULL,
     count BIGINT NOT NULL DEFAULT 1,
     kind VARCHAR,
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS cites_evidence_in ON cites_evidence(in_id);
 CREATE INDEX IF NOT EXISTS cites_evidence_out ON cites_evidence(out_id);
@@ -2195,8 +2221,8 @@ CREATE TABLE IF NOT EXISTS experiment (
     proposal VARCHAR NOT NULL,  -- ref -> proposal (was: REFERENCE ON DELETE CASCADE)
     artifact VARCHAR,  -- ref -> skill
     artifact_path VARCHAR,
-    scaffolded_at TIMESTAMPTZ,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    scaffolded_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     locked_verdict VARCHAR,
     status VARCHAR NOT NULL DEFAULT 'task_emitted',
     -- task_emitted | scaffolded | regressed | retired
@@ -2223,7 +2249,7 @@ CREATE TABLE IF NOT EXISTS opportunity (
     in_id VARCHAR NOT NULL,
     out_id VARCHAR NOT NULL,
     out_table VARCHAR NOT NULL,
-    matched_at TIMESTAMPTZ NOT NULL,
+    matched_at TIMESTAMP NOT NULL,
     was_addressed BOOLEAN NOT NULL DEFAULT FALSE
 );
 CREATE INDEX IF NOT EXISTS opportunity_in_ts ON opportunity(in_id, matched_at);
@@ -2256,7 +2282,7 @@ CREATE TABLE IF NOT EXISTS checkpoint (
     suggested VARCHAR,
     -- adopted | ignored | regressed | no_longer_needed | partial
     user_verdict VARCHAR,
-    observed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    observed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS checkpoint_experiment_kind ON checkpoint(experiment, kind, observed_at);
 
@@ -2280,8 +2306,8 @@ CREATE TABLE IF NOT EXISTS dogfood_run (
     timeout_seconds BIGINT,
     transcript_artifact VARCHAR,  -- ref -> artifact
     cwd VARCHAR,
-    started_at TIMESTAMPTZ NOT NULL,
-    ended_at TIMESTAMPTZ NOT NULL
+    started_at TIMESTAMP NOT NULL,
+    ended_at TIMESTAMP NOT NULL
 );
 CREATE UNIQUE INDEX IF NOT EXISTS dogfood_run_id_uq ON dogfood_run(run_id);
 CREATE INDEX IF NOT EXISTS dogfood_run_status_ts ON dogfood_run(status, ended_at);
@@ -2313,7 +2339,7 @@ CREATE TABLE IF NOT EXISTS retro (
     next VARCHAR,
     raw VARCHAR,        -- original JSON payload
     repository VARCHAR,  -- ref -> repository
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS retro_session_uq ON retro(session);
 CREATE INDEX IF NOT EXISTS retro_source_ts ON retro(source, created_at);
@@ -2327,7 +2353,7 @@ CREATE TABLE IF NOT EXISTS reviewed (
     id VARCHAR PRIMARY KEY,
     in_id VARCHAR NOT NULL,
     out_id VARCHAR NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS reviewed_in ON reviewed(in_id);
 CREATE INDEX IF NOT EXISTS reviewed_out ON reviewed(out_id);
@@ -2364,7 +2390,7 @@ CREATE TABLE IF NOT EXISTS ingest_file_state (
     size DOUBLE,
     sha VARCHAR,  -- git HEAD watermark
     since_days DOUBLE,  -- git history window walked
-    ingested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS ingest_file_state_path_uq ON ingest_file_state(path);
 CREATE INDEX IF NOT EXISTS ingest_file_state_source ON ingest_file_state(source_kind);
@@ -2393,7 +2419,7 @@ CREATE TABLE IF NOT EXISTS otel_metric_point (
     skill_name VARCHAR,
     agent_name VARCHAR,
     attrs VARCHAR,   -- JSON-encoded
-    observed_at TIMESTAMPTZ NOT NULL
+    observed_at TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS otel_metric_session ON otel_metric_point(session_id);
 CREATE INDEX IF NOT EXISTS otel_metric_observed ON otel_metric_point(observed_at);
@@ -2406,11 +2432,11 @@ CREATE TABLE IF NOT EXISTS otel_span (
     span_id VARCHAR NOT NULL,
     parent_span_id VARCHAR,
     session_id VARCHAR,
-    started_at TIMESTAMPTZ NOT NULL,
-    ended_at TIMESTAMPTZ NOT NULL,
+    started_at TIMESTAMP NOT NULL,
+    ended_at TIMESTAMP NOT NULL,
     duration_ms DOUBLE NOT NULL,
     attrs VARCHAR,        -- JSON-encoded
-    observed_at TIMESTAMPTZ NOT NULL
+    observed_at TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS otel_span_session ON otel_span(session_id);
 CREATE INDEX IF NOT EXISTS otel_span_observed ON otel_span(observed_at);
@@ -2429,7 +2455,7 @@ CREATE TABLE IF NOT EXISTS otel_log_event (
     duration_ms DOUBLE,
     status_code DOUBLE,
     attrs VARCHAR,
-    observed_at TIMESTAMPTZ NOT NULL
+    observed_at TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS otel_log_event_session ON otel_log_event(session_id);
 CREATE INDEX IF NOT EXISTS otel_log_event_observed ON otel_log_event(observed_at);
@@ -2451,7 +2477,7 @@ CREATE TABLE IF NOT EXISTS harness_tool_event (
     error_type VARCHAR,
     duration_ms DOUBLE,
     attrs VARCHAR,
-    observed_at TIMESTAMPTZ NOT NULL
+    observed_at TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS harness_tool_event_session ON harness_tool_event(session);
 CREATE INDEX IF NOT EXISTS harness_tool_event_kind ON harness_tool_event(event_kind);
@@ -2477,7 +2503,7 @@ CREATE TABLE IF NOT EXISTS harness_run_context (
     terminal_type VARCHAR,
     source_event VARCHAR,  -- ref -> otel_log_event
     attrs VARCHAR,
-    observed_at TIMESTAMPTZ NOT NULL
+    observed_at TIMESTAMP NOT NULL
 );
 CREATE INDEX IF NOT EXISTS harness_run_context_session ON harness_run_context(session);
 CREATE INDEX IF NOT EXISTS harness_run_context_harness ON harness_run_context(harness);
@@ -2495,11 +2521,11 @@ CREATE TABLE IF NOT EXISTS wrapped_card (
     body VARCHAR NOT NULL,   -- <=2 supporting lines
     sensitivity VARCHAR NOT NULL DEFAULT 'public',  -- public | sensitive
     "position" BIGINT NOT NULL DEFAULT 0,
-    series DOUBLE[] NOT NULL DEFAULT [],  -- P2-3: native list, not JSON
+    series VARCHAR NOT NULL DEFAULT '[]',  -- JSON-encoded; P2-3 reverted: JSON, not native list
     -- optional grounding sparkline - REAL data points (e.g. daily sessions
     -- on the card's model), rendered as the card's bar strip
     series_label VARCHAR,
-    generated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    generated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 -- ---------------------------------------------------------------------------
@@ -2521,7 +2547,7 @@ CREATE TABLE IF NOT EXISTS telemetry_of (
     in_id VARCHAR NOT NULL,
     out_id VARCHAR NOT NULL,
     out_table VARCHAR NOT NULL,
-    linked_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    linked_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS telemetry_of_in ON telemetry_of(in_id);
 CREATE INDEX IF NOT EXISTS telemetry_of_out ON telemetry_of(out_id);
@@ -2547,7 +2573,7 @@ CREATE TABLE IF NOT EXISTS run_evidence_event (
     session VARCHAR NOT NULL,  -- ref -> session
     root_session VARCHAR,  -- ref -> session
     parent_session VARCHAR,  -- ref -> session
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     provider VARCHAR NOT NULL,
     -- objective|task_state|tool_observation|verification|policy_decision|boundary|artifact_ref|repo_state|claim|derived_summary
     kind VARCHAR NOT NULL,
@@ -2573,7 +2599,7 @@ CREATE TABLE IF NOT EXISTS run_evidence_event (
     input_hash VARCHAR,
     output_hash VARCHAR,
     attrs VARCHAR,  -- JSON-encoded
-    observed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    observed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS run_evidence_event_session ON run_evidence_event(session, ts);
 CREATE INDEX IF NOT EXISTS run_evidence_event_kind ON run_evidence_event(session, kind);
@@ -2584,7 +2610,7 @@ CREATE TABLE IF NOT EXISTS run_evidence_ref (
     id VARCHAR PRIMARY KEY,
     "event" VARCHAR NOT NULL,  -- ref -> run_evidence_event
     session VARCHAR NOT NULL,  -- ref -> session
-    ts TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     -- record|file|sidecar|url|command|commit|external_event
     ref_kind VARCHAR NOT NULL,
     target_table VARCHAR,


### PR DESCRIPTION
Cross-chunk integration fix for the v2 DuckDB refactor (fleet map #768).

## Why

The schema-ddl gate (PR #787) converted datetimes to TIMESTAMPTZ and four scalar arrays to native lists - correct against DuckDB's documented type system. The ffi-client chunk then established (probe-confirmed against the real client + libduckdb v1.5.5) that the bun:ffi client CANNOT decode TIMESTAMP_TZ or LIST columns: bun:ffi has no by-value structs, forcing the deprecated row-major accessors, and those types raise `DuckDbUnsupportedTypeError` (or worse, return NULL with no failure signal). Two independently-reviewed chunks, each right in its own frame, colliding at the integration surface.

## What

- All 182 datetime columns revert to plain `TIMESTAMP` with an explicit UTC contract in the DDL header (writers normalize to UTC before insert; readers append Z) - this preserves the original offset-loss fix by contract instead of by column type.
- The 4 scalar-array columns revert to `VARCHAR -- JSON-encoded`.
- New DDL header blocks: BANNED TYPES (UUID, ENUM, BIT, TIMESTAMP_S/MS/NS, TIMESTAMP_TZ, TIME_TZ, LIST) with the FFI rationale, and a NUL-byte contract for text columns (#790).
- New regression guard: a parity test scans every column type token in all 138 tables against the banned list (parser-driven, not a fixed offender set) - this conflict class can never merge again.
- Load test updated: UTC-contract round-trip + JSON-array insert via `json_extract_string`.

The proper unlock (pointer-based `duckdb_column_data` read path) is tracked in #788; when it ships, the banned list shrinks.

Gates: `bun test packages/schema packages/lib` with real DuckDB v1.5.5 (load suite running) → 674 pass / 0 fail · `bun run typecheck` 0 · `bunx tsc --noEmit` 0.
